### PR TITLE
Implement a concat!() format extension

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -568,6 +568,7 @@ This requirement most often affects name-designator pairs when they occur at the
 * `log_syntax!` : print out the arguments at compile time
 * `trace_macros!` : supply `true` or `false` to enable or disable macro expansion logging
 * `stringify!` : turn the identifier argument into a string literal
+* `concat!` : concatenates a comma-separated list of literals
 * `concat_idents!` : create a new identifier by concatenating the arguments
 
 # Crates and source files

--- a/src/libsyntax/ext/concat.rs
+++ b/src/libsyntax/ext/concat.rs
@@ -1,0 +1,58 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::char;
+
+use ast;
+use codemap;
+use ext::base;
+use ext::build::AstBuilder;
+
+pub fn expand_syntax_ext(cx: @base::ExtCtxt,
+                         sp: codemap::Span,
+                         tts: &[ast::token_tree]) -> base::MacResult {
+    let es = base::get_exprs_from_tts(cx, sp, tts);
+    let mut accumulator = ~"";
+    for e in es.move_iter() {
+        let e = cx.expand_expr(e);
+        match e.node {
+            ast::ExprLit(lit) => {
+                match lit.node {
+                    ast::lit_str(s, _) |
+                    ast::lit_float(s, _) |
+                    ast::lit_float_unsuffixed(s) => {
+                        accumulator.push_str(s);
+                    }
+                    ast::lit_char(c) => {
+                        accumulator.push_char(char::from_u32(c).unwrap());
+                    }
+                    ast::lit_int(i, _) |
+                    ast::lit_int_unsuffixed(i) => {
+                        accumulator.push_str(format!("{}", i));
+                    }
+                    ast::lit_uint(u, _) => {
+                        accumulator.push_str(format!("{}", u));
+                    }
+                    ast::lit_nil => {}
+                    ast::lit_bool(b) => {
+                        accumulator.push_str(format!("{}", b));
+                    }
+                    ast::lit_binary(*) => {
+                        cx.span_err(e.span, "cannot concatenate a binary literal");
+                    }
+                }
+            }
+            _ => {
+                cx.span_err(e.span, "expected a literal");
+            }
+        }
+    }
+    return base::MRExpr(cx.expr_str(sp, accumulator.to_managed()));
+}

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1083,7 +1083,7 @@ struct NoOpFolder {
 
 impl ast_fold for NoOpFolder {}
 
-struct MacroExpander {
+pub struct MacroExpander {
     extsbox: @mut SyntaxEnv,
     cx: @ExtCtxt,
 }

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -735,8 +735,10 @@ pub fn expand_args(ecx: @ExtCtxt, sp: Span,
         (_, None) => { return MRExpr(ecx.expr_uint(sp, 2)); }
     };
     cx.fmtsp = efmt.span;
-    let (fmt, _fmt_str_style) = expr_to_str(ecx, efmt,
-                                            "format argument must be a string literal.");
+    // Be sure to recursively expand macros just in case the format string uses
+    // a macro to build the format expression.
+    let (fmt, _) = expr_to_str(ecx, ecx.expand_expr(efmt),
+                               "format argument must be a string literal.");
 
     let mut err = false;
     do parse::parse_error::cond.trap(|m| {

--- a/src/libsyntax/syntax.rs
+++ b/src/libsyntax/syntax.rs
@@ -77,6 +77,7 @@ pub mod ext {
     pub mod format;
     pub mod env;
     pub mod bytes;
+    pub mod concat;
     pub mod concat_idents;
     pub mod log_syntax;
     pub mod auto_encode;

--- a/src/test/compile-fail/concat.rs
+++ b/src/test/compile-fail/concat.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    concat!(foo);   //~ ERROR: expected a literal
+    concat!(foo()); //~ ERROR: expected a literal
+}

--- a/src/test/run-pass/concat.rs
+++ b/src/test/run-pass/concat.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    assert_eq!(format!(concat!("foo", "bar", "{}"), "baz"), ~"foobarbaz");
+    assert_eq!(format!(concat!()), ~"");
+
+    assert_eq!(
+        concat!(1, 2i, 3u, 4f32, 4.0, 'a', true, ()),
+        "12344.0atrue"
+    );
+}


### PR DESCRIPTION
This extension can be used to concatenate string literals at compile time. C has
this useful ability when placing string literals lexically next to one another,
but this needs to be handled at the syntax extension level to recursively expand
macros.

The major use case for this is something like:

```
macro_rules! mylog( ($fmt:expr $($arg:tt)*) => {
    error2!(concat!(file!(), ":", line!(), " - ", $fmt) $($arg)*);
})
```

Where the mylog macro will automatically prepend the filename/line number to the
beginning of every log message.
