### PR TITLE
Make UvTImer selectable and implement recv_timeout

### DIFF
--- a/src/libstd/rt/io/timer.rs
+++ b/src/libstd/rt/io/timer.rs
@@ -51,6 +51,21 @@ impl Timer {
 }
 
 trait TimedPort<T: Send> {
+
+ /**
+  * This implementation adds the required
+  * API for recv_timeout with an approximate
+  * but not safe behavior.
+  *
+  * Current implementations of this Trait for
+  * both PortOne and Port poll on the port every
+  * second to check for new messages. A correct
+  * implementation for recv_timeout should implement
+  * `SelectInner` and Select for UvTimer and re-write
+  * the sleep method around that.
+  *
+  * FIXME: (flaper87) #9195
+  */
   fn recv_timeout(self, msecs: u64) -> Option<T>;
 }
 

--- a/src/libstd/rt/io/timer.rs
+++ b/src/libstd/rt/io/timer.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use comm;
+use kinds::Send;
 use option::{Option, Some, None};
 use result::{Ok, Err};
 use rt::io::{io_error};
@@ -48,10 +50,50 @@ impl Timer {
     }
 }
 
+trait TimedPort<T: Send> {
+  fn recv_timeout(self, msecs: u64) -> Option<T>;
+}
+
+impl<T: Send> TimedPort<T> for comm::PortOne<T> {
+
+    fn recv_timeout(self, msecs: u64) -> Option<T> {
+        let mut tout = msecs;
+        let mut timer = Timer::new().unwrap();
+
+        while tout > 0 {
+            if self.peek() { return Some(self.recv()); }
+            timer.sleep(1000);
+            tout -= 1000;
+        }
+
+        None
+    }
+}
+
+
+impl<T: Send> TimedPort<T> for comm::Port<T> {
+
+    fn recv_timeout(self, msecs: u64) -> Option<T> {
+        let mut tout = msecs;
+        let mut timer = Timer::new().unwrap();
+
+        while tout > 0 {
+            if self.peek() { return Some(self.recv()); }
+            timer.sleep(1000);
+            tout -= 1000;
+        }
+
+        None
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use rt::test::*;
+    use task;
+    use comm;
+
     #[test]
     fn test_io_timer_sleep_simple() {
         do run_in_mt_newsched_task {
@@ -64,6 +106,34 @@ mod test {
     fn test_io_timer_sleep_standalone() {
         do run_in_mt_newsched_task {
             sleep(1)
+        }
+    }
+
+    #[test]
+    fn test_recv_timeout() {
+        do run_in_newsched_task {
+            let (p, c) = comm::stream::<int>();
+            do task::spawn {
+                let mut t = Timer::new().unwrap();
+                t.sleep(1000);
+                c.send(1);
+            }
+
+            assert!(p.recv_timeout(2000).unwrap() == 1);
+        }
+    }
+
+    #[test]
+    fn test_recv_timeout_expire() {
+        do run_in_newsched_task {
+            let (p, c) = comm::stream::<int>();
+            do task::spawn {
+                let mut t = Timer::new().unwrap();
+                t.sleep(3000);
+                c.send(1);
+            }
+
+            assert!(p.recv_timeout(1000).is_none());
         }
     }
 }

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -132,6 +132,8 @@ pub trait RtioUdpSocket : RtioSocket {
 
 pub trait RtioTimer {
     fn sleep(&mut self, msecs: u64);
+    fn sleep_uv(&mut self, msecs: u64, deschedule: bool);
+    fn sleep_then(&mut self, msecs: u64, cb: &fn(&mut Self));
 }
 
 pub trait RtioFileStream {


### PR DESCRIPTION
**NOTE** This is not ready to be merged, it's a work in progress idea.

I'm looking for feedback on the `SelectInner` implementation for UvTimer. The idea I came up with is to have a `select_then` method that takes a callback and calls it right after starting the watcher. The reason why this is needed is that libuv IO has to happen within it's own scheduler and before switching back to the main scheduler the timer has to have completed or stopped.

In `sleep_then` callback, users will be able to either deschedule the task themselves or sleep on multiple 'selectable' objects and wake up the task at the first event.

Thoughts?

This is part of #3015 
