### PR TITLE
rm special case for ty_struct from take glue

### DIFF
--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -423,7 +423,6 @@ pub fn trans_struct_drop_flag(bcx: @mut Block, t: ty::t, v0: ValueRef, dtor_did:
             bcx = drop_ty(bcx, llfld_a, fld.mt.ty);
         }
 
-        Store(bcx, C_u8(0), drop_flag);
         bcx
     }
 }

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -595,23 +595,6 @@ pub fn make_take_glue(bcx: @mut Block, v: ValueRef, t: ty::t) -> @mut Block {
           bcx
       }
       ty::ty_opaque_closure_ptr(_) => bcx,
-      ty::ty_struct(did, _) => {
-        let tcx = bcx.tcx();
-        let bcx = iter_structural_ty(bcx, v, t, take_ty);
-
-        match ty::ty_dtor(tcx, did) {
-          ty::TraitDtor(_, false) => {
-            // Zero out the struct
-            unsafe {
-                let ty = Type::from_ref(llvm::LLVMTypeOf(v));
-                memzero(&B(bcx), v, ty);
-            }
-
-          }
-          _ => { }
-        }
-        bcx
-      }
       _ if ty::type_is_structural(t) => {
         iter_structural_ty(bcx, v, t, take_ty)
       }


### PR DESCRIPTION
This is incorrect, as take glue isn't used for moves.
