### PR TITLE
Allow attributes on macros

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4548,9 +4548,6 @@ impl Parser {
                     || self.look_ahead(2, |t| *t == token::LPAREN)
                     || self.look_ahead(2, |t| *t == token::LBRACE)) {
             // MACRO INVOCATION ITEM
-            if attrs.len() > 0 {
-                self.fatal("attrs on macros are not yet supported");
-            }
 
             // item macro.
             let pth = self.parse_path(NoTypesAllowed).path;

--- a/src/test/run-pass/macro-with-attrs1.rs
+++ b/src/test/run-pass/macro-with-attrs1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:attrs on macros are not yet supported
+// xfail-fast windows doesn't like compile-flags
+// compile-flags: --cfg foo
 
-// Don't know how to deal with a syntax extension appearing after an
-// item attribute. Probably could use a better error message.
-#[foo = "bar"]
-fmt!("baz")
-fn main() { }
+#[feature(macro_rules)];
+
+#[cfg(foo)]
+macro_rules! foo( () => (1) )
+
+#[cfg(not(foo))]
+macro_rules! foo( () => (2) )
+
+fn main() {
+    assert_eq!(foo!(), 1);
+}

--- a/src/test/run-pass/macro-with-attrs2.rs
+++ b/src/test/run-pass/macro-with-attrs2.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(macro_rules)];
+
+#[cfg(foo)]
+macro_rules! foo( () => (1) )
+
+#[cfg(not(foo))]
+macro_rules! foo( () => (2) )
+
+pub fn main() {
+    assert_eq!(foo!(), 2);
+}
+


### PR DESCRIPTION
It's unclear to me why these currently aren't allowed, and my best guess is that
a long time ago we didn't strip the ast of cfg nodes before syntax expansion.
Now that this is done, I'm not certain that we should continue to prohibit this
functionality.

This is a step in the right direction towards #5605, because now we can add an
empty `std::macros` module to the documentation with a bunch of empty macros
explaining how they're supposed to be used.
