### PR TITLE
syntax: Display spans for open delimiters when a file ends prematurely

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -308,6 +308,7 @@ pub fn Parser(sess: @mut ParseSess,
         quote_depth: @mut 0,
         obsolete_set: @mut HashSet::new(),
         mod_path_stack: @mut ~[],
+        open_braces: @mut ~[]
     }
 }
 
@@ -336,6 +337,8 @@ pub struct Parser {
     obsolete_set: @mut HashSet<ObsoleteSyntax>,
     /// Used to determine the path to externally loaded source files
     mod_path_stack: @mut ~[@str],
+    /// Stack of spans of open delimiters. Used for error message.
+    open_braces: @mut ~[@Span]
 }
 
 #[unsafe_destructor]
@@ -2022,12 +2025,18 @@ impl Parser {
 
         match *self.token {
             token::EOF => {
-                self.fatal("file ended with unbalanced delimiters");
+                for sp in self.open_braces.iter() {
+                    self.span_note(**sp, "Did you mean to close this delimiter?");
+                }
+                // There shouldn't really be a span, but it's easier for the test runner
+                // if we give it one
+                self.fatal("This file contains an un-closed delimiter ");
             }
             token::LPAREN | token::LBRACE | token::LBRACKET => {
                 let close_delim = token::flip_delimiter(&*self.token);
 
                 // Parse the open delimiter.
+                (*self.open_braces).push(@*self.span);
                 let mut result = ~[parse_any_tt_tok(self)];
 
                 let trees =
@@ -2038,6 +2047,7 @@ impl Parser {
 
                 // Parse the close delimiter.
                 result.push(parse_any_tt_tok(self));
+                self.open_braces.pop();
 
                 tt_delim(@mut result)
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -338,7 +338,7 @@ pub struct Parser {
     /// Used to determine the path to externally loaded source files
     mod_path_stack: @mut ~[@str],
     /// Stack of spans of open delimiters. Used for error message.
-    open_braces: @mut ~[@Span]
+    open_braces: @mut ~[Span]
 }
 
 #[unsafe_destructor]
@@ -2026,7 +2026,7 @@ impl Parser {
         match *self.token {
             token::EOF => {
                 for sp in self.open_braces.iter() {
-                    self.span_note(**sp, "Did you mean to close this delimiter?");
+                    self.span_note(*sp, "Did you mean to close this delimiter?");
                 }
                 // There shouldn't really be a span, but it's easier for the test runner
                 // if we give it one
@@ -2036,7 +2036,7 @@ impl Parser {
                 let close_delim = token::flip_delimiter(&*self.token);
 
                 // Parse the open delimiter.
-                (*self.open_braces).push(@*self.span);
+                (*self.open_braces).push(*self.span);
                 let mut result = ~[parse_any_tt_tok(self)];
 
                 let trees =

--- a/src/test/compile-fail/issue-2354-1.rs
+++ b/src/test/compile-fail/issue-2354-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo() { //~ NOTE Did you mean to close this delimiter?
-  match Some(x) {
-      Some(y) { fail!(); }
-      None    { fail!(); }
-}
+static foo: int = 2; } //~ ERROR incorrect close delimiter:
 
-fn bar() {
-    let mut i = 0;
-    while (i < 1000) {}
-}
-
-fn main() {} //~ ERROR This file contains an un-closed delimiter


### PR DESCRIPTION
r? anybody It's more helpful to list the span of each open delimiter seen so far
than to print out an error with the span of the last position in the file.

Closes #2354
