### PR TITLE
Option::and is not as polymorphic as it can be

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -132,7 +132,7 @@ impl<T> Option<T> {
 
     /// Returns `None` if the option is `None`, otherwise returns `optb`.
     #[inline]
-    pub fn and(self, optb: Option<U>) -> Option<U> {
+    pub fn and<U>(self, optb: Option<U>) -> Option<U> {
         match self {
             Some(_) => optb,
             None => None,

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -132,7 +132,7 @@ impl<T> Option<T> {
 
     /// Returns `None` if the option is `None`, otherwise returns `optb`.
     #[inline]
-    pub fn and(self, optb: Option<T>) -> Option<T> {
+    pub fn and(self, optb: Option<U>) -> Option<U> {
         match self {
             Some(_) => optb,
             None => None,


### PR DESCRIPTION
Option::and currently requires optb to contain the same type as self. Option::and_then demonstrates that this is unnecessary, since the function will either return None or optb.
