### PR TITLE
Issue #6580: Change default lint output format.

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -372,12 +372,16 @@ impl Context {
 
         let mut note = None;
         let msg = match src {
-            Default | CommandLine => {
-                format!("{} [-{} {}{}]", msg, match level {
+            Default => {
+                format!("{}, \\#[{}({})] on by default", msg,
+                    level_to_str(level), self.lint_to_str(lint))
+            },
+            CommandLine => {
+                format!("{} [-{} {}]", msg,
+                    match level {
                         warn => 'W', deny => 'D', forbid => 'F',
                         allow => fail2!()
-                    }, self.lint_to_str(lint).replace("_", "-"),
-                    if src == Default { " (default)" } else { "" })
+                    }, self.lint_to_str(lint).replace("_", "-"))
             },
             Node(src) => {
                 note = Some(src);


### PR DESCRIPTION
Since lint check attributes are the preferred way of selectively
enabling/disabling lint checks, the output format of a failed
default check has been changed to reflect that.

When lint checks are being explicitly set by a command-line flag
or an attribute, the behavior is unchanged, so that the user can
quickly pinpoint the source.
