### PR TITLE
Make std::rt::io::extensions public

### DIFF
--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -297,7 +297,7 @@ pub mod flate;
 pub mod comm_adapters;
 
 /// Extension traits
-mod extensions;
+pub mod extensions;
 
 /// Non-I/O things needed by the I/O module
 // XXX: shouldn this really be pub?


### PR DESCRIPTION
This works around #9779, but is probably the right thing to do anyways
since that's the module where all of the documentation for those traits
lives.
