### PR TITLE
Change default lint output format

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -372,12 +372,16 @@ impl Context {
 
         let mut note = None;
         let msg = match src {
-            Default | CommandLine => {
-                format!("{} [-{} {}{}]", msg, match level {
+            Default => {
+                format!("{}, \\#[{}({})] on by default", msg,
+                    level_to_str(level), self.lint_to_str(lint))
+            },
+            CommandLine => {
+                format!("{} [-{} {}]", msg,
+                    match level {
                         warn => 'W', deny => 'D', forbid => 'F',
                         allow => fail2!()
-                    }, self.lint_to_str(lint).replace("_", "-"),
-                    if src == Default { " (default)" } else { "" })
+                    }, self.lint_to_str(lint).replace("_", "-"))
             },
             Node(src) => {
                 note = Some(src);

--- a/src/test/compile-fail/lint-output-format.rs
+++ b/src/test/compile-fail/lint-output-format.rs
@@ -1,0 +1,32 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-F experimental -D unstable
+
+#[deprecated]
+fn foo() -> uint {
+    20
+}
+
+#[experimental]
+fn bar() -> uint {
+    40
+}
+
+#[unstable]
+fn baz() -> uint {
+    30
+}
+
+fn main() {
+    let _x = foo(); //~ WARNING #[warn(deprecated)] on by default
+    let _y = bar(); //~ ERROR [-F experimental]
+    let _z = baz(); //~ ERROR [-D unstable]
+}


### PR DESCRIPTION
Since lint check attributes are the preferred way of selectively
enabling/disabling lint checks, the output format of a failed
default check has been changed to reflect that.

When lint checks are being explicitly set by a command-line flag
or an attribute, the behavior is unchanged, so that the user can
quickly pinpoint the source.

Supersedes the patch suggested in #9778
Closes #6580
