### PR TITLE
syntax: allow macros to expand to items with attributes.

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -20,6 +20,7 @@ use ext::tt::macro_parser::{named_match, matched_seq, matched_nonterminal};
 use ext::tt::macro_parser::{parse, parse_or_else, success, failure};
 use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
+use parse::attr::parser_attr;
 use parse::token::{get_ident_interner, special_idents, gensym_ident, ident_to_str};
 use parse::token::{FAT_ARROW, SEMI, nt_matchers, nt_tt, EOF};
 use print;
@@ -54,12 +55,14 @@ impl AnyMacro for ParserAnyMacro {
         ret
     }
     fn make_item(&self) -> Option<@ast::item> {
-        let ret = self.parser.parse_item(~[]);     // no attrs
+        let attrs = self.parser.parse_outer_attributes();
+        let ret = self.parser.parse_item(attrs);
         self.ensure_complete_parse(false);
         ret
     }
     fn make_stmt(&self) -> @ast::Stmt {
-        let ret = self.parser.parse_stmt(~[]);     // no attrs
+        let attrs = self.parser.parse_outer_attributes();
+        let ret = self.parser.parse_stmt(attrs);
         self.ensure_complete_parse(true);
         ret
     }

--- a/src/test/run-pass/macro-attributes.rs
+++ b/src/test/run-pass/macro-attributes.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-pretty - token trees can't pretty print
+
+#[feature(macro_rules)];
+
+macro_rules! compiles_fine {
+    ($at:attr) => {
+        // test that the different types of attributes work
+        #[attribute]
+        /// Documentation!
+        $at
+
+        // check that the attributes are recognised by requiring this
+        // to be removed to avoid a compile error
+        #[cfg(always_remove)]
+        static MISTYPED: () = "foo";
+    }
+}
+
+// item
+compiles_fine!(#[foo])
+
+pub fn main() {
+    // statement
+    compiles_fine!(#[bar]);
+}


### PR DESCRIPTION
Fixes #4471.
