### PR TITLE
add copy-on-write mutable borrowing to Rc and Arc

### DIFF
--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -140,6 +140,27 @@ impl<T:Freeze+Send> Arc<T> {
     }
 }
 
+impl<T: Freeze+Send+Clone> Arc<T> {
+    /// Clones the content if there is more than one reference, and returns a
+    /// mutable reference to the data once this is the only refence
+    #[inline]
+    pub fn cow<'r>(&'r mut self) -> &'r mut T {
+        unsafe {
+            if !self.x.is_owned() {
+                self.cow_clone()
+            } else {
+                &mut *self.x.get()
+            }
+        }
+    }
+
+    #[inline(never)]
+    unsafe fn cow_clone<'r>(&'r mut self) -> &'r mut T {
+        self.x = UnsafeArc::new((*self.x.get_immut()).clone());
+        &mut *self.x.get()
+    }
+}
+
 impl<T:Freeze + Send> Clone for Arc<T> {
     /**
     * Duplicate an atomically reference counted wrapper.
@@ -620,6 +641,15 @@ mod tests {
         assert_eq!(arc_v.get()[4], 5);
 
         info2!("{:?}", arc_v);
+    }
+
+    #[test]
+    fn test_arc_mut() {
+        let mut x = Arc::new(5);
+        let y = x.clone();
+        *x.cow() = 9;
+        assert_eq!(*x.get(), 9);
+        assert_eq!(*y.get(), 5);
     }
 
     #[test]

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -120,7 +120,9 @@ impl<T:Freeze+Send> Arc<T> {
     pub fn new(data: T) -> Arc<T> {
         Arc { x: UnsafeArc::new(data) }
     }
+}
 
+impl<T> Arc<T> {
     pub fn get<'a>(&'a self) -> &'a T {
         unsafe { &*self.x.get_immut() }
     }
@@ -157,7 +159,7 @@ impl<T:Freeze+Send> Arc<T> {
     }
 }
 
-impl<T: Freeze+Send+Clone> Arc<T> {
+impl<T: Clone> Arc<T> {
     /// Clones the content if there is more than one reference, and returns a
     /// mutable reference to the data once this is the only refence
     #[inline]
@@ -173,7 +175,7 @@ impl<T: Freeze+Send+Clone> Arc<T> {
 
     #[inline(never)]
     unsafe fn cow_clone<'r>(&'r mut self) -> &'r mut T {
-        self.x = UnsafeArc::new((*self.x.get_immut()).clone());
+        self.x = UnsafeArc::new_unsafe((*self.x.get_immut()).clone());
         &mut *self.x.get()
     }
 
@@ -187,7 +189,7 @@ impl<T: Freeze+Send+Clone> Arc<T> {
     }
 }
 
-impl<T:Freeze + Send> Clone for Arc<T> {
+impl<T> Clone for Arc<T> {
     /**
     * Duplicate an atomically reference counted wrapper.
     *


### PR DESCRIPTION
This patch adds a copy-on-write mechanism to Rc and Arc of Clonable types that allows to mutably borrow the contents.

In the simplest case, if the reference count is 1, we can just give out a mutable reference since we are obviously the only user.

If the reference count is more than 1, we clone the contents, and we are back to the previous case.

With this change, Rc and Arc can be used as a variant of unique pointers with the advantage of O(1) time and space copy (as long as the contents are not mutated) but the disadvantage of requiring an extra machine branch and a bunch of machine code on every mutation.

This can be used for things like persistent functional data structures and in general data that starts being the same as parent data, but sometimes gets changed.
