### PR TITLE
Use the result of privacy for reachability

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -263,9 +263,10 @@ pub fn phase_3_run_analysis_passes(sess: Session,
                                           method_map, ty_cx));
 
     let maps = (external_exports, last_private_map);
-    time(time_passes, "privacy checking", maps, |(a, b)|
-         middle::privacy::check_crate(ty_cx, &method_map, &exp_map2,
-                                      a, b, crate));
+    let exported_items =
+        time(time_passes, "privacy checking", maps, |(a, b)|
+             middle::privacy::check_crate(ty_cx, &method_map, &exp_map2,
+                                          a, b, crate));
 
     time(time_passes, "effect checking", (), |_|
          middle::effect::check_crate(ty_cx, method_map, crate));
@@ -300,7 +301,8 @@ pub fn phase_3_run_analysis_passes(sess: Session,
 
     let reachable_map =
         time(time_passes, "reachability checking", (), |_|
-             reachable::find_reachable(ty_cx, method_map, crate));
+             reachable::find_reachable(ty_cx, method_map, exp_map2,
+                                       &exported_items));
 
     time(time_passes, "lint checking", (), |_|
          lint::check_crate(ty_cx, crate));

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2535,7 +2535,6 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
                             let (v, inlineable) = consts::const_expr(ccx, expr);
                             ccx.const_values.insert(id, v);
                             let mut inlineable = inlineable;
-                            exprt = true;
 
                             unsafe {
                                 let llty = llvm::LLVMTypeOf(v);

--- a/src/test/auxiliary/reexport-should-still-link.rs
+++ b/src/test/auxiliary/reexport-should-still-link.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use foo::bar;
+
+mod foo {
+    pub fn bar() {}
+}

--- a/src/test/codegen/iterate-over-array.rs
+++ b/src/test/codegen/iterate-over-array.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[no_mangle]
-fn test(x: &[int]) -> int {
+pub fn test(x: &[int]) -> int {
     let mut y = 0;
     let mut i = 0;
     while (i < x.len()) {

--- a/src/test/codegen/scalar-function-call.rs
+++ b/src/test/codegen/scalar-function-call.rs
@@ -13,6 +13,6 @@ fn foo(x: int) -> int {
 }
 
 #[no_mangle]
-fn test() {
+pub fn test() {
     let _x = foo(10);
 }

--- a/src/test/codegen/single-return-value.rs
+++ b/src/test/codegen/single-return-value.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 #[no_mangle]
-fn test() -> int {
+pub fn test() -> int {
     5
 }

--- a/src/test/codegen/small-dense-int-switch.rs
+++ b/src/test/codegen/small-dense-int-switch.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[no_mangle]
-fn test(x: int, y: int) -> int {
+pub fn test(x: int, y: int) -> int {
     match x {
         1 => y,
         2 => y*2,

--- a/src/test/codegen/stack-alloc-string-slice.rs
+++ b/src/test/codegen/stack-alloc-string-slice.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 #[no_mangle]
-fn test() {
+pub fn test() {
     let _x = "hello";
 }

--- a/src/test/codegen/static-method-call-multi.rs
+++ b/src/test/codegen/static-method-call-multi.rs
@@ -19,10 +19,10 @@ impl Struct {
 }
 
 #[no_mangle]
-fn test(a: &Struct,
-        b: &Struct,
-        c: &Struct,
-        d: &Struct,
-        e: &Struct) -> int {
+pub fn test(a: &Struct,
+            b: &Struct,
+            c: &Struct,
+            d: &Struct,
+            e: &Struct) -> int {
     a.method(b.method(c.method(d.method(e.method(1)))))
 }

--- a/src/test/codegen/static-method-call.rs
+++ b/src/test/codegen/static-method-call.rs
@@ -19,6 +19,6 @@ impl Struct {
 }
 
 #[no_mangle]
-fn test(s: &Struct) -> int {
+pub fn test(s: &Struct) -> int {
     s.method()
 }

--- a/src/test/codegen/virtual-method-call-struct-return.rs
+++ b/src/test/codegen/virtual-method-call-struct-return.rs
@@ -18,6 +18,6 @@ trait Trait {
 }
 
 #[no_mangle]
-fn test(t: &Trait) -> int {
+pub fn test(t: &Trait) -> int {
     t.method().a
 }

--- a/src/test/codegen/virtual-method-call.rs
+++ b/src/test/codegen/virtual-method-call.rs
@@ -13,6 +13,6 @@ trait Trait {
 }
 
 #[no_mangle]
-fn test(t: &Trait) -> int {
+pub fn test(t: &Trait) -> int {
     t.method()
 }

--- a/src/test/run-pass/reexport-should-still-link.rs
+++ b/src/test/run-pass/reexport-should-still-link.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:reexport-should-still-link.rs
+// xfail-fast windows doesn't like extern mod
+
+extern mod foo(name = "reexport-should-still-link");
+
+fn main() {
+    foo::bar();
+}


### PR DESCRIPTION
This fixes a bug in which the visibility rules were approximated by
reachability, but forgot to cover the case where a 'pub use' reexports a private
item. This fixes the commit by instead using the results of the privacy pass of
the compiler to create the initial working set of the reachability pass.

This may have the side effect of increasing the size of metadata, but it's
difficult to avoid for correctness purposes sadly.

Closes #9790
