### PR TITLE
Fix usage of <float> in docs

### DIFF
--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -732,7 +732,7 @@ impl<R: Rng> Rng for @mut R {
 ///         let x = random();
 ///         println!("{}", 2u * x);
 ///     } else {
-///         println!("{}", random::<float>());
+///         println!("{}", random::<f64>());
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
The example for std::rand::random was still
using <float>, which got removed from Rust.
