### PR TITLE
extra::tempfile: replace mkdtemp with an RAII wrapper (Closes #9763)

### DIFF
--- a/src/libextra/tempfile.rs
+++ b/src/libextra/tempfile.rs
@@ -15,17 +15,63 @@ use std::os;
 use std::rand::Rng;
 use std::rand;
 
-/// Attempts to make a temporary directory inside of `tmpdir` whose name will
-/// have the suffix `suffix`. If no directory can be created, None is returned.
-pub fn mkdtemp(tmpdir: &Path, suffix: &str) -> Option<Path> {
-    let mut r = rand::rng();
-    for _ in range(0u, 1000) {
-        let p = tmpdir.push(r.gen_ascii_str(16) + suffix);
-        if os::make_dir(&p, 0x1c0) { // 700
-            return Some(p);
+/// A wrapper for a path to temporary directory implementing automatic
+/// scope-pased deletion.
+pub struct TempDir {
+    priv path: Option<Path>
+}
+
+impl TempDir {
+    /// Attempts to make a temporary directory inside of `tmpdir` whose name
+    /// will have the suffix `suffix`. The directory will be automatically
+    /// deleted once the returned wrapper is destroyed.
+    ///
+    /// If no directory can be created, None is returned.
+    pub fn new_in(tmpdir: &Path, suffix: &str) -> Option<TempDir> {
+        if !tmpdir.is_absolute() {
+            let abs_tmpdir = os::make_absolute(tmpdir);
+            return TempDir::new_in(&abs_tmpdir, suffix);
+        }
+
+        let mut r = rand::rng();
+        for _ in range(0u, 1000) {
+            let p = tmpdir.push(r.gen_ascii_str(16) + suffix);
+            if os::make_dir(&p, 0x1c0) { // 700
+                return Some(TempDir { path: Some(p) });
+            }
+        }
+        None
+    }
+
+    /// Attempts to make a temporary directory inside of `os::tmpdir()` whose
+    /// name will have the suffix `suffix`. The directory will be automatically
+    /// deleted once the returned wrapper is destroyed.
+    ///
+    /// If no directory can be created, None is returned.
+    pub fn new(suffix: &str) -> Option<TempDir> {
+        TempDir::new_in(&os::tmpdir(), suffix)
+    }
+
+    /// Unwrap the wrapped `std::path::Path` from the `TempDir` wrapper.
+    /// This discards the wrapper so that the automatic deletion of the
+    /// temporary directory is prevented.
+    pub fn unwrap(self) -> Path {
+        let mut tmpdir = self;
+        tmpdir.path.take_unwrap()
+    }
+
+    /// Access the wrapped `std::path::Path` to the temporary directory.
+    pub fn path<'a>(&'a self) -> &'a Path {
+        self.path.get_ref()
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        for path in self.path.iter() {
+            os::remove_dir_recursive(path);
         }
     }
-    None
 }
 
 // the tests for this module need to change the path using change_dir,

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -1148,8 +1148,7 @@ mod tests {
     use test::{TestOpts, run_test};
 
     use std::comm::{stream, SharedChan};
-    use tempfile;
-    use std::os;
+    use tempfile::TempDir;
 
     #[test]
     pub fn do_not_run_ignored_tests() {
@@ -1392,9 +1391,8 @@ mod tests {
 
     pub fn ratchet_test() {
 
-        let dpth = tempfile::mkdtemp(&os::tmpdir(),
-                                     "test-ratchet").expect("missing test for ratchet");
-        let pth = dpth.push("ratchet.json");
+        let dpth = TempDir::new("test-ratchet").expect("missing test for ratchet");
+        let pth = dpth.path().push("ratchet.json");
 
         let mut m1 = MetricMap::new();
         m1.insert_metric("runtime", 1000.0, 2.0);
@@ -1432,7 +1430,5 @@ mod tests {
         assert_eq!(m4.len(), 2);
         assert_eq!(*(m4.find(&~"runtime").unwrap()), Metric { value: 1100.0, noise: 2.0 });
         assert_eq!(*(m4.find(&~"throughput").unwrap()), Metric { value: 50.0, noise: 2.0 });
-
-        os::remove_dir_recursive(&dpth);
     }
 }

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -239,9 +239,6 @@ impl PkgSrc {
     pub fn fetch_git(local: &Path, pkgid: &PkgId) -> Option<Path> {
         use conditions::git_checkout_failed::cond;
 
-        // We use a temporary directory because if the git clone fails,
-        // it creates the target directory anyway and doesn't delete it
-
         debug2!("Checking whether {} (path = {}) exists locally. Cwd = {}, does it? {:?}",
                 pkgid.to_str(), pkgid.path.to_str(),
                 os::getcwd().to_str(),

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -15,7 +15,7 @@ extern mod std;
 
 use extra::semver;
 use std::{char, os, result, run, str};
-use extra::tempfile::mkdtemp;
+use extra::tempfile::TempDir;
 use path_util::rust_path;
 
 #[deriving(Clone)]
@@ -132,8 +132,9 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
 /// otherwise, `None`
 pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
     if is_url_like(remote_path) {
-        let tmp_dir = mkdtemp(&os::tmpdir(),
-                              "test").expect("try_getting_version: couldn't create temp dir");
+        let tmp_dir = TempDir::new("test");
+        let tmp_dir = tmp_dir.expect("try_getting_version: couldn't create temp dir");
+        let tmp_dir = tmp_dir.path();
         debug2!("(to get version) executing \\{git clone https://{} {}\\}",
                remote_path.to_str(),
                tmp_dir.to_str());

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 // This test can't be a unit test in std,
-// because it needs mkdtemp, which is in extra
+// because it needs TempDir, which is in extra
 
 // xfail-fast
 extern mod extra;
 
-use extra::tempfile::mkdtemp;
+use extra::tempfile::TempDir;
 use std::os;
 use std::libc;
 
@@ -23,7 +23,8 @@ fn rename_directory() {
     unsafe {
         static U_RWX: i32 = (libc::S_IRUSR | libc::S_IWUSR | libc::S_IXUSR) as i32;
 
-        let tmpdir = mkdtemp(&os::tmpdir(), "rename_directory").expect("rename_directory failed");
+        let tmpdir = TempDir::new("rename_directory").expect("rename_directory failed");
+        let tmpdir = tmpdir.path();
         let old_path = tmpdir.push_many(["foo", "bar", "baz"]);
         assert!(os::mkdir_recursive(&old_path, U_RWX));
         let test_file = &old_path.push("temp.txt");

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -18,8 +18,8 @@ use std::io;
 use std::os;
 
 pub fn main() {
-    let dir = tempfile::mkdtemp(&Path("."), "").unwrap();
-    let path = dir.push("file");
+    let dir = tempfile::TempDir::new_in(&Path("."), "").unwrap();
+    let path = dir.path().push("file");
 
     {
         match io::file_writer(&path, [io::Create, io::Truncate]) {
@@ -34,7 +34,4 @@ pub fn main() {
 
     assert!(path.exists());
     assert_eq!(path.get_size(), Some(1000));
-
-    os::remove_file(&path);
-    os::remove_dir(&dir);
 }


### PR DESCRIPTION
this incidentally stops `make check` from leaving directories in `/tmp` (Closes #9764)
