### PR TITLE
Remove named extern blocks from the AST

### DIFF
--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -102,7 +102,6 @@ fn fold_foreign_mod(cx: &Context, nm: &ast::foreign_mod) -> ast::foreign_mod {
         }
     }.collect();
     ast::foreign_mod {
-        sort: nm.sort,
         abis: nm.abis,
         view_items: filtered_view_items,
         items: filtered_items

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -175,40 +175,43 @@ fn visit_item(e: &Env, i: @ast::item) {
         }
 
         let cstore = e.cstore;
-        let mut already_added = false;
         let link_args = i.attrs.iter()
             .filter_map(|at| if "link_args" == at.name() {Some(at)} else {None})
             .collect::<~[&ast::Attribute]>();
 
-        match fm.sort {
-            ast::named => {
-                let link_name = i.attrs.iter()
-                    .find(|at| "link_name" == at.name())
-                    .and_then(|at| at.value_str());
+        // XXX: two whom it may concern, this was the old logic applied to the
+        //      ast's extern mod blocks which had names (we used to allow
+        //      "extern mod foo"). This code was never run for anonymous blocks,
+        //      and we now only have anonymous blocks. We're still in the midst
+        //      of figuring out what the exact operations we'd like to support
+        //      when linking external modules, but I wanted to leave this logic
+        //      here for the time beging to refer back to it
 
-                let foreign_name = match link_name {
-                        Some(nn) => {
-                            if nn.is_empty() {
-                                e.diag.span_fatal(
-                                    i.span,
-                                    "empty #[link_name] not allowed; use \
-                                     #[nolink].");
-                            }
-                            nn
-                        }
-                        None => token::ident_to_str(&i.ident)
-                    };
-                if !attr::contains_name(i.attrs, "nolink") {
-                    already_added =
-                        !cstore::add_used_library(cstore, foreign_name);
-                }
-                if !link_args.is_empty() && already_added {
-                    e.diag.span_fatal(i.span, ~"library '" + foreign_name +
-                               "' already added: can't specify link_args.");
-                }
-            }
-            ast::anonymous => { /* do nothing */ }
-        }
+        //let mut already_added = false;
+        //let link_name = i.attrs.iter()
+        //    .find(|at| "link_name" == at.name())
+        //    .and_then(|at| at.value_str());
+
+        //let foreign_name = match link_name {
+        //        Some(nn) => {
+        //            if nn.is_empty() {
+        //                e.diag.span_fatal(
+        //                    i.span,
+        //                    "empty #[link_name] not allowed; use \
+        //                     #[nolink].");
+        //            }
+        //            nn
+        //        }
+        //        None => token::ident_to_str(&i.ident)
+        //    };
+        //if !attr::contains_name(i.attrs, "nolink") {
+        //    already_added =
+        //        !cstore::add_used_library(cstore, foreign_name);
+        //}
+        //if !link_args.is_empty() && already_added {
+        //    e.diag.span_fatal(i.span, ~"library '" + foreign_name +
+        //               "' already added: can't specify link_args.");
+        //}
 
         for m in link_args.iter() {
             match m.value_str() {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1183,31 +1183,7 @@ impl Resolver {
                 ModuleReducedGraphParent(name_bindings.get_module())
             }
 
-            item_foreign_mod(ref fm) => {
-                match fm.sort {
-                    named => {
-                        let (name_bindings, new_parent) =
-                            self.add_child(ident, parent,
-                                           ForbidDuplicateModules, sp);
-
-                        let parent_link = self.get_parent_link(new_parent,
-                                                               ident);
-                        let def_id = DefId { crate: 0, node: item.id };
-                        name_bindings.define_module(parent_link,
-                                                    Some(def_id),
-                                                    ExternModuleKind,
-                                                    false,
-                                                    true,
-                                                    sp);
-
-                        ModuleReducedGraphParent(name_bindings.get_module())
-                    }
-
-                    // For anon foreign mods, the contents just go in the
-                    // current scope
-                    anonymous => parent
-                }
-            }
+            item_foreign_mod(*) => parent,
 
             // These items live in the value namespace.
             item_static(_, m, _) => {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -949,16 +949,8 @@ pub struct _mod {
     items: ~[@item],
 }
 
-// Foreign mods can be named or anonymous
-#[deriving(Clone, Eq, Encodable, Decodable,IterBytes)]
-pub enum foreign_mod_sort {
-    named,
-    anonymous,
-}
-
 #[deriving(Clone, Eq, Encodable, Decodable,IterBytes)]
 pub struct foreign_mod {
-    sort: foreign_mod_sort,
     abis: AbiSet,
     view_items: ~[view_item],
     items: ~[@foreign_item],

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -294,17 +294,11 @@ impl Visitor<()> for Ctx {
                                                       nm.abis,
                                                       visibility,
                                                       // FIXME (#2543)
-                                                      if nm.sort ==
-                                                            ast::named {
-                                                          let e = path_name(
-                                                              i.ident);
-                                                          self.extend(e)
-                                                      } else {
                                                         // Anonymous extern
                                                         // mods go in the
                                                         // parent scope.
                                                         @self.path.clone()
-                                                      }));
+                                                      ));
                 }
             }
             item_struct(struct_def, _) => {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -289,7 +289,6 @@ pub trait ast_fold {
 
     fn fold_foreign_mod(&self, nm: &foreign_mod) -> foreign_mod {
         ast::foreign_mod {
-            sort: nm.sort,
             abis: nm.abis,
             view_items: nm.view_items
                           .iter()

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -539,14 +539,6 @@ pub fn print_item(s: @ps, item: &ast::item) {
       ast::item_foreign_mod(ref nmod) => {
         head(s, "extern");
         word_nbsp(s, nmod.abis.to_str());
-        match nmod.sort {
-            ast::named => {
-                word_nbsp(s, "mod");
-                print_ident(s, item.ident);
-                nbsp(s);
-            }
-            ast::anonymous => {}
-        }
         bopen(s);
         print_foreign_mod(s, nmod, item.attrs);
         bclose(s, item.span);


### PR DESCRIPTION
There's currently a fair amount of code which is being ignored on unnamed blocks
(which are the default now), and I opted to leave it commented out for now. I
intend on very soon revisiting on how we perform linking with extern crates in
an effort to support static linking.
