### PR TITLE
Working code examples for std::rt::io::net

### DIFF
--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -52,10 +52,18 @@ Some examples of obvious things you might want to do
 
 * Make an simple HTTP request
 
-    let socket = TcpStream::open("localhost:8080");
-    socket.write_line("GET / HTTP/1.0");
-    socket.write_line("");
-    let response = socket.read_to_end();
+    let s = TcpStream::connect(SocketAddr{ip:Ipv4Addr(127,0,0,1), port:8080});
+    let mut socket = s.unwrap();
+    socket.write(bytes!("GET / HTTP/1.0\n"));
+    socket.write(bytes!("\n"));
+    let mut buf = [0u8, ..2000];
+    let response = socket.read(buf);
+    if response.is_some() {
+      let optBytes = str::from_utf8_opt(buf);
+      if optBytes.is_some() {
+        println!("answer: {}", optBytes.unwrap());
+      }
+    }
 
 * Connect based on URL? Requires thinking about where the URL type lives
   and how to make protocol handlers extensible, e.g. the "tcp" protocol


### PR DESCRIPTION
Hi!

I was trying to play with networking code today, and noticed the code example in std::rt::io was not really corresponding to TcpStream.

If that code is ok, I'll add more examples in this pull request for TcpStream and UdpStream, client and server and squash it in one commit.

BTW, it seems that std::io::{Reader,Writer} and std::rt::io::{Reader,Writer} are not consistent. These code examples would be nicer if I could use std::io::{ReaderUtil,WriterUtil}. Should I continue the work that began in #9749 to make them available in std::rt::io?
