### PR TITLE
Add float to Ratio conversion

### DIFF
--- a/src/libextra/num/rational.rs
+++ b/src/libextra/num/rational.rs
@@ -121,8 +121,8 @@ impl Ratio<BigInt> {
         if mantissa == 0 || exponent >= 0 {
             let mut numer: BigUint = FromPrimitive::from_u64(mantissa).unwrap();
             numer = numer << (exponent as uint);
-            let bigintSign: Sign = if sign == 1 { Plus } else { Minus };
-            return Some(Ratio::from_integer(BigInt::from_biguint(bigintSign, numer)));
+            let bigint_sign: Sign = if sign == 1 { Plus } else { Minus };
+            return Some(Ratio::from_integer(BigInt::from_biguint(bigint_sign, numer)));
         }
 
         let one: BigInt = One::one();
@@ -152,7 +152,7 @@ impl Ratio<BigInt> {
                 q1 = q2;
 
                 let tmp = (b - Ratio::from_integer(k.clone())).recip();
-                b = (a - Ratio::from_integer(k.clone())).recip();
+                b = (a - Ratio::from_integer(k)).recip();
                 a = tmp;
             } else {
                 break;
@@ -161,12 +161,8 @@ impl Ratio<BigInt> {
 
         let p_last: BigInt = c.to_integer() * p1 + p0;
         let q_last: BigInt = c.to_integer() * q1 + q0;
-
-        if sign == 1 {
-            Some(Ratio::new(p_last, q_last))
-        } else {
-            Some(Ratio::new(-p_last, q_last))
-        }
+        let p = if sign == 1 { p_last } else { -p_last };
+        Some(Ratio::new(p, q_last))
     }
 }
 


### PR DESCRIPTION
Add a function to create a Ratio<BigInt> out of a float
(f32 or f64).

I'm a newbie, hence this commit is meant as a first step to get something similar committed. I originally tried to port the `as_integer_ratio()` function from CPython, but then found out that the [IronPython's implementation](https://ironpython.codeplex.com/SourceControl/latest#IronPython_2_6/Src/IronPython/Runtime/Operations/FloatOps.cs) is even simpler.

So please let me know what needs to be done to make that a committable change.
