### PR TITLE
Issue 7331

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -115,6 +115,7 @@ use std::result;
 use std::util::replace;
 use std::vec;
 use extra::list::Nil;
+use extra::list;
 use syntax::abi::AbiSet;
 use syntax::ast::{provided, required};
 use syntax::ast;
@@ -3342,19 +3343,30 @@ pub fn instantiate_path(fcx: @mut FnCtxt,
         }
     };
 
-    // Special case: If there is a self parameter, omit it from the list of
-    // type parameters.
-    //
-    // Here we calculate the "user type parameter count", which is the number
-    // of type parameters actually manifest in the AST. This will differ from
-    // the internal type parameter count when there are self types involved.
-    let (user_type_parameter_count, self_parameter_index) = match def {
+    // Special case for static trait methods: omit the self parameter
+    // from the list of type parameters and constrain the 'self
+    // lifetime to be equal to the enclosing 'self lifetime.
+    let (user_type_parameter_count, self_parameter_index, regions) = match def {
         ast::DefStaticMethod(_, provenance @ ast::FromTrait(_), _) => {
             let generics = generics_of_static_method_container(fcx.ccx.tcx,
                                                                provenance);
-            (ty_param_count - 1, Some(generics.type_param_defs.len()))
+
+            // If 'self is in scope, then use the free region it is already
+            // associated with. If 'self is not in scope then
+            // `regions` won't be used anyway.
+            let constrained_regions =
+                match list::find(fcx.in_scope_regions,
+                                 |&(br, _)| br == ty::br_self) {
+                    Some((_, r)) => opt_vec::with(r),
+                    None => regions
+            };
+
+            (ty_param_count - 1,
+             Some(generics.type_param_defs.len()),
+             constrained_regions)
         }
-        _ => (ty_param_count, None),
+        _ => {
+            (ty_param_count, None, regions)}
     };
 
     // determine values for type parameters, using the values given by

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -268,7 +268,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
         //        fn foo<D,E,F>(...) -> Self;
         //     }
         //
-        // and we will create a function like
+        // then we will create a function like
         //
         //     fn foo<A',B',C',D',E',F',G'>(...) -> D' {}
         //
@@ -357,7 +357,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
                           ty_param_bounds_and_ty {
                               generics: ty::Generics {
                                   type_param_defs: @new_type_param_defs,
-                                  region_param: trait_ty_generics.region_param
+                                  region_param: None
                               },
                               ty: ty
                           });

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -312,7 +312,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt,
         //     Self => D'
         //     D,E,F => E',F',G'
         let substs = substs {
-            regions: ty::NonerasedRegions(opt_vec::Empty),
+            regions: ty::NonerasedRegions(opt_vec::with(ty::re_bound(ty::br_self))),
             self_ty: Some(self_param),
             tps: non_shifted_trait_tps + shifted_method_tps
         };

--- a/src/test/run-pass/issue-7331.rs
+++ b/src/test/run-pass/issue-7331.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Interner<'self, T> {
+    fn new() -> Self;
+    fn get(&'self self, tag: uint) -> Option<&'self T>;
+}
+
+pub trait FromVec<'self> {
+    fn fromVec(&'self [u8]) -> Self;
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-7331.rs
+++ b/src/test/run-pass/issue-7331.rs
@@ -17,4 +17,15 @@ pub trait FromVec<'self> {
     fn fromVec(&'self [u8]) -> Self;
 }
 
+struct Reader<'self> {
+    v : &'self [u8]
+}
+
+impl <'self, T : FromVec<'self>> Reader<'self> {
+    fn get(&self) -> T {
+        FromVec::fromVec(self.v)
+    }
+}
+
+
 fn main() {}


### PR DESCRIPTION
Closes #7331.

Motivating example:

```
trait FromVec<'self> {
    fn fromVec(&'self [u8]) -> Self;
}

struct Reader<'self> {
    v : &'self [u8]
}

impl <'self> FromVec<'self> for Reader<'self> {
    fn fromVec(v : &'self [u8]) -> Reader<'self> {
        Reader::<'self> { v : v }
    }
}

impl <'self, T : FromVec<'self>> Reader<'self> {
    fn get(self) -> T {
        FromVec::fromVec(self.v);
    }
}
```

When we typecheck `FromVec::fromVec`, we get `fn(&'self [u8]) -> T` where `T` is bounded by `FromVec<'self>`. Usually we would replace the argument's `'self` with a new region variable which could match anything. However, if we allow that here then we lose an important constraint between the argument and the return type `T`, namely that the `'self` in `FromVec<'self>` needs to be the same as the argument's `'self`. 

In this patch, I handle this case by replacing the argument's `'self` with the free region that has already been constructed for `'self` in the enclosing scope.

Note that I remove the region param from static trait methods (line 360 of collect.rs). The main motivation for that change is to provide a more sensible error message on something like `FromVec::fromVec::<'self>(self.v)`, which would otherwise confusingly yield the error message "this trait has a lifetime parameter but no lifetime was specified". Moreover, although it could be argued that these methods technically still are region-parameterized, the actual plugged-in region is always the same thing---a free region associated with `'self`; I think it's prudent to syntactically prevent anyone from trying to plug anything else in.
