### PR TITLE
Make Rustdoc strip private fields

### DIFF
--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -685,6 +685,7 @@ pub struct Struct {
     struct_type: doctree::StructType,
     generics: Generics,
     fields: ~[Item],
+    fields_stripped: bool,
 }
 
 impl Clean<Item> for doctree::Struct {
@@ -699,6 +700,7 @@ impl Clean<Item> for doctree::Struct {
                 struct_type: self.struct_type,
                 generics: self.generics.clean(),
                 fields: self.fields.clean(),
+                fields_stripped: false,
             }),
         }
     }
@@ -711,6 +713,7 @@ impl Clean<Item> for doctree::Struct {
 pub struct VariantStruct {
     struct_type: doctree::StructType,
     fields: ~[Item],
+    fields_stripped: bool,
 }
 
 impl Clean<VariantStruct> for syntax::ast::struct_def {
@@ -718,6 +721,7 @@ impl Clean<VariantStruct> for syntax::ast::struct_def {
         VariantStruct {
             struct_type: doctree::struct_type_from_def(self),
             fields: self.fields.clean(),
+            fields_stripped: false,
         }
     }
 }
@@ -726,6 +730,7 @@ impl Clean<VariantStruct> for syntax::ast::struct_def {
 pub struct Enum {
     variants: ~[Item],
     generics: Generics,
+    variants_stripped: bool,
 }
 
 impl Clean<Item> for doctree::Enum {
@@ -739,6 +744,7 @@ impl Clean<Item> for doctree::Enum {
             inner: EnumItem(Enum {
                 variants: self.variants.clean(),
                 generics: self.generics.clean(),
+                variants_stripped: false,
             }),
         }
     }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -27,7 +27,9 @@ pub trait DocFolder {
             StructItem(i) => {
                 let mut i = i;
                 let mut foo = ~[]; swap(&mut foo, &mut i.fields);
+                let num_fields = foo.len();
                 i.fields.extend(&mut foo.move_iter().filter_map(|x| self.fold_item(x)));
+                i.fields_stripped |= num_fields != i.fields.len();
                 StructItem(i)
             },
             ModuleItem(i) => {
@@ -36,7 +38,9 @@ pub trait DocFolder {
             EnumItem(i) => {
                 let mut i = i;
                 let mut foo = ~[]; swap(&mut foo, &mut i.variants);
+                let num_variants = foo.len();
                 i.variants.extend(&mut foo.move_iter().filter_map(|x| self.fold_item(x)));
+                i.variants_stripped |= num_variants != i.variants.len();
                 EnumItem(i)
             },
             TraitItem(i) => {
@@ -73,7 +77,9 @@ pub trait DocFolder {
                     StructVariant(j) => {
                         let mut j = j;
                         let mut foo = ~[]; swap(&mut foo, &mut j.fields);
+                        let num_fields = foo.len();
                         j.fields.extend(&mut foo.move_iter().filter_map(c));
+                        j.fields_stripped |= num_fields != j.fields.len();
                         VariantItem(Variant {kind: StructVariant(j), ..i2})
                     },
                     _ => VariantItem(i2)

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1265,7 +1265,8 @@ fn render_method(w: &mut io::Writer, meth: &clean::Item, withlink: bool) {
 
 fn item_struct(w: &mut io::Writer, it: &clean::Item, s: &clean::Struct) {
     write!(w, "<pre class='struct'>");
-    render_struct(w, it, Some(&s.generics), s.struct_type, s.fields, "", true);
+    render_struct(w, it, Some(&s.generics), s.struct_type, s.fields,
+                  s.fields_stripped, "", true);
     write!(w, "</pre>");
 
     document(w, it);
@@ -1312,13 +1313,17 @@ fn item_enum(w: &mut io::Writer, it: &clean::Item, e: &clean::Enum) {
                         }
                         clean::StructVariant(ref s) => {
                             render_struct(w, v, None, s.struct_type, s.fields,
-                                          "    ", false);
+                                          s.fields_stripped, "    ", false);
                         }
                     }
                 }
                 _ => unreachable!()
             }
             write!(w, ",\n");
+        }
+
+        if e.variants_stripped {
+            write!(w, "    // some variants omitted\n");
         }
         write!(w, "\\}");
     }
@@ -1343,6 +1348,7 @@ fn render_struct(w: &mut io::Writer, it: &clean::Item,
                  g: Option<&clean::Generics>,
                  ty: doctree::StructType,
                  fields: &[clean::Item],
+                 fields_stripped: bool,
                  tab: &str,
                  structhead: bool) {
     write!(w, "{}{}{}",
@@ -1367,6 +1373,10 @@ fn render_struct(w: &mut io::Writer, it: &clean::Item,
                     }
                     _ => unreachable!()
                 }
+            }
+
+            if fields_stripped {
+                write!(w, "    // some fields omitted\n{}", tab);
             }
             write!(w, "\\}");
         }

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -70,16 +70,12 @@ pub fn strip_private(mut crate: clean::Crate) -> plugins::PluginResult {
                     }
                 }
 
-                // These are public-by-default (if the enum was public)
-                clean::VariantItem(*) => {
+                // These are public-by-default (if the enum/struct was public)
+                clean::VariantItem(*) | clean::StructFieldItem(*) => {
                     if i.visibility == Some(ast::private) {
                         return None;
                     }
                 }
-
-                // We show these regardless of whether they're public/private
-                // because it's useful to see sometimes
-                clean::StructFieldItem(*) => {}
 
                 // handled below
                 clean::ModuleItem(*) => {}

--- a/src/librustdoc/rustdoc.rs
+++ b/src/librustdoc/rustdoc.rs
@@ -48,7 +48,7 @@ pub mod passes;
 pub mod plugins;
 pub mod visit_ast;
 
-pub static SCHEMA_VERSION: &'static str = "0.8.0";
+pub static SCHEMA_VERSION: &'static str = "0.8.1";
 
 type Pass = (&'static str,                                      // name
              extern fn(clean::Crate) -> plugins::PluginResult,  // fn


### PR DESCRIPTION
In addition, the renderer will add comments to structs and enums saying
that fields or variants have been stripped.

The comments are currently

``` rust
// some fields stripped
// some variants stripped
```

I was thinking of changing that to "some private..." but passes other than
strip-private may strip fields or variants as well.

cc @alexcrichton
