### PR TITLE
Refine privacy error messages to be more accurate

### DIFF
--- a/src/test/compile-fail/export-tag-variant.rs
+++ b/src/test/compile-fail/export-tag-variant.rs
@@ -14,4 +14,4 @@ mod foo {
     enum y { y1, }
 }
 
-fn main() { let z = foo::y1; } //~ ERROR: is private
+fn main() { let z = foo::y1; } //~ ERROR: is inaccessible

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -100,11 +100,14 @@ mod foo {
         ::bar::A::bar();        //~ ERROR: method `bar` is private
         ::bar::A.foo2();
         ::bar::A.bar2();        //~ ERROR: method `bar2` is private
-        ::bar::baz::A::foo();   //~ ERROR: method `foo` is private
+        ::bar::baz::A::foo();   //~ ERROR: method `foo` is inaccessible
+                                //~^ NOTE: module `baz` is private
         ::bar::baz::A::bar();   //~ ERROR: method `bar` is private
-        ::bar::baz::A.foo2();   //~ ERROR: struct `A` is private
-        ::bar::baz::A.bar2();   //~ ERROR: struct `A` is private
+        ::bar::baz::A.foo2();   //~ ERROR: struct `A` is inaccessible
+                                //~^ NOTE: module `baz` is private
+        ::bar::baz::A.bar2();   //~ ERROR: struct `A` is inaccessible
                                 //~^ ERROR: method `bar2` is private
+                                //~^^ NOTE: module `baz` is private
         ::lol();
 
         ::bar::Priv; //~ ERROR: variant `Priv` is private
@@ -120,13 +123,14 @@ mod foo {
 
         ::bar::gpub();
 
-        ::bar::baz::foo(); //~ ERROR: function `foo` is private
+        ::bar::baz::foo(); //~ ERROR: function `foo` is inaccessible
+                           //~^ NOTE: module `baz` is private
         ::bar::baz::bar(); //~ ERROR: function `bar` is private
     }
 
     fn test2() {
         use bar::baz::{foo, bar};
-        //~^ ERROR: function `foo` is private
+        //~^ ERROR: function `foo` is inaccessible
         //~^^ ERROR: function `bar` is private
         foo();
         bar();
@@ -155,7 +159,8 @@ pub mod mytest {
     // external crates through `foo::foo`, it should not be accessible through
     // its definition path (which has the private `i` module).
     use self::foo::foo;
-    use self::foo::i::A; //~ ERROR: type `A` is private
+    use self::foo::i::A; //~ ERROR: type `A` is inaccessible
+                         //~^ NOTE: module `i` is private
 
     pub mod foo {
         pub use foo = self::i::A;


### PR DESCRIPTION
This stops labeling everything as "is private" when in fact the destination may
be public. Instead, the clause "is inaccessible" is used and the private part of
the flag is called out with a "is private" message.

Closes #9793
