### PR TITLE
std::rt: Fix the set up of the main thread so that it doesn't try to ste...

### DIFF
--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -310,8 +310,14 @@ fn run_(main: ~fn(), use_main_sched: bool) -> int {
                                                      sleepers.clone(),
                                                      false,
                                                      Some(friend_handle));
-        let main_handle = main_sched.make_handle();
-        handles.push(main_handle);
+        let mut main_handle = main_sched.make_handle();
+        // Allow the scheduler to exit when the main task exits.
+        // Note: sending the shutdown message also prevents the scheduler
+        // from pushing itself to the sleeper list, which is used for
+        // waking up schedulers for work stealing; since this is a
+        // non-work-stealing scheduler it should not be adding itself
+        // to the list.
+        main_handle.send_shutdown();
         Some(main_sched)
     } else {
         None


### PR DESCRIPTION
...al work

This is causing really awful scheduler behavior where the main thread scheduler is
continually waking up, stealing work, discovering it can't actually run the work,
and sending it off to another scheduler.

No test cases because we don't have suitable instrumentation for it.
