### PR TITLE
add an `abort` intrinsic

### DIFF
--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -222,6 +222,11 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
     }
 
     match name {
+        "abort" => {
+            let llfn = bcx.ccx().intrinsics.get_copy(&("llvm.trap"));
+            Call(bcx, llfn, [], []);
+            RetVoid(bcx);
+        }
         "size_of" => {
             let tp_ty = substs.tys[0];
             let lltp_ty = type_of::type_of(ccx, tp_ty);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3585,6 +3585,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
 
     } else {
         match name {
+            "abort"  => (0, ~[], ty::mk_bot()),
             "size_of" |
             "pref_align_of" | "min_align_of" => (1u, ~[], ty::mk_uint()),
             "init" => (1u, ~[], param(ccx, 0u)),

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -171,6 +171,9 @@ pub trait TyVisitor {
 }
 
 extern "rust-intrinsic" {
+    /// Abort the execution of the process.
+    #[cfg(not(stage0))]
+    pub fn abort() -> !;
 
     /// Atomic compare and exchange, sequentially consistent.
     pub fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;


### PR DESCRIPTION
This should be preferred to calling the libc `abort` function.
