### PR TITLE
Remove even more of std::io

### DIFF
--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -10,7 +10,6 @@
 
 use common::config;
 
-use std::io;
 use std::os::getenv;
 
 /// Conversion table from triple OS name to Rust SYSNAME
@@ -64,5 +63,5 @@ pub fn path_div() -> ~str { ~";" }
 
 pub fn logv(config: &config, s: ~str) {
     debug2!("{}", s);
-    if config.verbose { io::println(s); }
+    if config.verbose { println(s); }
 }

--- a/src/etc/combine-tests.py
+++ b/src/etc/combine-tests.py
@@ -56,15 +56,15 @@ d.write("#[feature(globs)];\n")
 d.write("extern mod extra;\n")
 d.write("extern mod run_pass_stage2;\n")
 d.write("use run_pass_stage2::*;\n")
-d.write("use std::io::WriterUtil;\n");
-d.write("use std::io;\n");
+d.write("use std::rt::io;\n");
+d.write("use std::rt::io::Writer;\n");
 d.write("fn main() {\n");
-d.write("    let out = io::stdout();\n");
+d.write("    let mut out = io::stdout();\n");
 i = 0
 for t in stage2_tests:
     p = os.path.join("test", "run-pass", t)
     p = p.replace("\\", "\\\\")
-    d.write("    out.write_str(\"run-pass [stage2]: %s\\n\");\n" % p)
+    d.write("    out.write(\"run-pass [stage2]: %s\\n\".as_bytes());\n" % p)
     d.write("    t_%d::main();\n" % i)
     i += 1
 d.write("}\n")

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -30,8 +30,6 @@
 
 use std::char;
 use std::cmp;
-use std::io::{ReaderUtil};
-use std::io;
 use std::option::{Option, Some, None};
 use std::to_str::ToStr;
 
@@ -147,14 +145,19 @@ condition! {
     bad_parse: () -> ();
 }
 
-fn take_nonempty_prefix(rdr: @io::Reader,
-                        ch: char,
-                        pred: &fn(char) -> bool) -> (~str, char) {
+fn take_nonempty_prefix<T: Iterator<char>>(rdr: &mut T,
+                        pred: &fn(char) -> bool) -> (~str, Option<char>) {
     let mut buf = ~"";
-    let mut ch = ch;
-    while pred(ch) {
-        buf.push_char(ch);
-        ch = rdr.read_char();
+    let mut ch = rdr.next();
+    loop {
+        match ch {
+            None => break,
+            Some(c) if !pred(c) => break,
+            Some(c) => {
+                buf.push_char(c);
+                ch = rdr.next();
+            }
+        }
     }
     if buf.is_empty() {
         bad_parse::cond.raise(())
@@ -163,16 +166,16 @@ fn take_nonempty_prefix(rdr: @io::Reader,
     (buf, ch)
 }
 
-fn take_num(rdr: @io::Reader, ch: char) -> (uint, char) {
-    let (s, ch) = take_nonempty_prefix(rdr, ch, char::is_digit);
+fn take_num<T: Iterator<char>>(rdr: &mut T) -> (uint, Option<char>) {
+    let (s, ch) = take_nonempty_prefix(rdr, char::is_digit);
     match from_str::<uint>(s) {
         None => { bad_parse::cond.raise(()); (0, ch) },
         Some(i) => (i, ch)
     }
 }
 
-fn take_ident(rdr: @io::Reader, ch: char) -> (Identifier, char) {
-    let (s,ch) = take_nonempty_prefix(rdr, ch, char::is_alphanumeric);
+fn take_ident<T: Iterator<char>>(rdr: &mut T) -> (Identifier, Option<char>) {
+    let (s,ch) = take_nonempty_prefix(rdr, char::is_alphanumeric);
     if s.iter().all(char::is_digit) {
         match from_str::<uint>(s) {
             None => { bad_parse::cond.raise(()); (Numeric(0), ch) },
@@ -183,38 +186,38 @@ fn take_ident(rdr: @io::Reader, ch: char) -> (Identifier, char) {
     }
 }
 
-fn expect(ch: char, c: char) {
-    if ch != c {
+fn expect(ch: Option<char>, c: char) {
+    if ch != Some(c) {
         bad_parse::cond.raise(())
     }
 }
 
-fn parse_reader(rdr: @io::Reader) -> Version {
-    let (major, ch) = take_num(rdr, rdr.read_char());
+fn parse_iter<T: Iterator<char>>(rdr: &mut T) -> Version {
+    let (major, ch) = take_num(rdr);
     expect(ch, '.');
-    let (minor, ch) = take_num(rdr, rdr.read_char());
+    let (minor, ch) = take_num(rdr);
     expect(ch, '.');
-    let (patch, ch) = take_num(rdr, rdr.read_char());
+    let (patch, ch) = take_num(rdr);
 
     let mut pre = ~[];
     let mut build = ~[];
 
     let mut ch = ch;
-    if ch == '-' {
+    if ch == Some('-') {
         loop {
-            let (id, c) = take_ident(rdr, rdr.read_char());
+            let (id, c) = take_ident(rdr);
             pre.push(id);
             ch = c;
-            if ch != '.' { break; }
+            if ch != Some('.') { break; }
         }
     }
 
-    if ch == '+' {
+    if ch == Some('+') {
         loop {
-            let (id, c) = take_ident(rdr, rdr.read_char());
+            let (id, c) = take_ident(rdr);
             build.push(id);
             ch = c;
-            if ch != '.' { break; }
+            if ch != Some('.') { break; }
         }
     }
 
@@ -236,13 +239,11 @@ pub fn parse(s: &str) -> Option<Version> {
     let s = s.trim();
     let mut bad = false;
     do bad_parse::cond.trap(|_| { debug2!("bad"); bad = true }).inside {
-        do io::with_str_reader(s) |rdr| {
-            let v = parse_reader(rdr);
-            if bad || v.to_str() != s.to_owned() {
-                None
-            } else {
-                Some(v)
-            }
+        let v = parse_iter(&mut s.iter());
+        if bad || v.to_str() != s.to_owned() {
+            None
+        } else {
+            Some(v)
         }
     }
 }

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -11,7 +11,7 @@
 use sort;
 use std::cmp;
 use std::hashmap;
-use std::io;
+use std::rt::io;
 use std::num;
 
 // NB: this can probably be rewritten in terms of num::Num
@@ -266,14 +266,14 @@ pub fn winsorize(samples: &mut [f64], pct: f64) {
 }
 
 /// Render writes the min, max and quartiles of the provided `Summary` to the provided `Writer`.
-pub fn write_5_number_summary(w: @io::Writer, s: &Summary) {
+pub fn write_5_number_summary(w: &mut io::Writer, s: &Summary) {
     let (q1,q2,q3) = s.quartiles;
-    w.write_str(format!("(min={}, q1={}, med={}, q3={}, max={})",
+    write!(w, "(min={}, q1={}, med={}, q3={}, max={})",
                      s.min,
                      q1,
                      q2,
                      q3,
-                     s.max));
+                     s.max);
 }
 
 /// Render a boxplot to the provided writer. The boxplot shows the min, max and quartiles of the
@@ -288,7 +288,7 @@ pub fn write_5_number_summary(w: @io::Writer, s: &Summary) {
 ///   10 |        [--****#******----------]          | 40
 /// ~~~~
 
-pub fn write_boxplot(w: @io::Writer, s: &Summary, width_hint: uint) {
+pub fn write_boxplot(w: &mut io::Writer, s: &Summary, width_hint: uint) {
 
     let (q1,q2,q3) = s.quartiles;
 
@@ -318,52 +318,48 @@ pub fn write_boxplot(w: @io::Writer, s: &Summary, width_hint: uint) {
     let range_width = width_hint - overhead_width;;
     let char_step = range / (range_width as f64);
 
-    w.write_str(lostr);
-    w.write_char(' ');
-    w.write_char('|');
+    write!(w, "{} |", lostr);
 
     let mut c = 0;
     let mut v = lo;
 
     while c < range_width && v < s.min {
-        w.write_char(' ');
+        write!(w, " ");
         v += char_step;
         c += 1;
     }
-    w.write_char('[');
+    write!(w, "[");
     c += 1;
     while c < range_width && v < q1 {
-        w.write_char('-');
+        write!(w, "-");
         v += char_step;
         c += 1;
     }
     while c < range_width && v < q2 {
-        w.write_char('*');
+        write!(w, "*");
         v += char_step;
         c += 1;
     }
-    w.write_char('#');
+    write!(w, r"\#");
     c += 1;
     while c < range_width && v < q3 {
-        w.write_char('*');
+        write!(w, "*");
         v += char_step;
         c += 1;
     }
     while c < range_width && v < s.max {
-        w.write_char('-');
+        write!(w, "-");
         v += char_step;
         c += 1;
     }
-    w.write_char(']');
+    write!(w, "]");
     while c < range_width {
-        w.write_char(' ');
+        write!(w, " ");
         v += char_step;
         c += 1;
     }
 
-    w.write_char('|');
-    w.write_char(' ');
-    w.write_str(histr);
+    write!(w, "| {}", histr);
 }
 
 /// Returns a HashMap with the number of occurrences of every element in the
@@ -385,18 +381,20 @@ mod tests {
     use stats::Summary;
     use stats::write_5_number_summary;
     use stats::write_boxplot;
-    use std::io;
+    use std::rt::io;
+    use std::str;
 
     fn check(samples: &[f64], summ: &Summary) {
 
         let summ2 = Summary::new(samples);
 
-        let w = io::stdout();
-        w.write_char('\n');
+        let mut w = io::stdout();
+        let w = &mut w as &mut io::Writer;
+        write!(w, "\n");
         write_5_number_summary(w, &summ2);
-        w.write_char('\n');
+        write!(w, "\n");
         write_boxplot(w, &summ2, 50);
-        w.write_char('\n');
+        write!(w, "\n");
 
         assert_eq!(summ.sum, summ2.sum);
         assert_eq!(summ.min, summ2.min);
@@ -937,10 +935,11 @@ mod tests {
     #[test]
     fn test_boxplot_nonpositive() {
         fn t(s: &Summary, expected: ~str) {
-            let out = do io::with_str_writer |w|  {
-                write_boxplot(w, s, 30)
-            };
-
+            use std::rt::io::mem::MemWriter;
+            use std::rt::io::Decorator;
+            let mut m = MemWriter::new();
+            write_boxplot(&mut m as &mut io::Writer, s, 30);
+            let out = str::from_utf8_owned(m.inner());
             assert_eq!(out, expected);
         }
 

--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -13,7 +13,7 @@
 #[allow(missing_doc)];
 
 
-use std::io;
+use std::rt::io;
 
 #[cfg(not(target_os = "win32"))] use std::os;
 #[cfg(not(target_os = "win32"))] use terminfo::*;
@@ -96,19 +96,19 @@ fn cap_for_attr(attr: attr::Attr) -> &'static str {
 #[cfg(not(target_os = "win32"))]
 pub struct Terminal {
     num_colors: u16,
-    priv out: @io::Writer,
+    priv out: @mut io::Writer,
     priv ti: ~TermInfo
 }
 
 #[cfg(target_os = "win32")]
 pub struct Terminal {
     num_colors: u16,
-    priv out: @io::Writer,
+    priv out: @mut io::Writer,
 }
 
 #[cfg(not(target_os = "win32"))]
 impl Terminal {
-    pub fn new(out: @io::Writer) -> Result<Terminal, ~str> {
+    pub fn new(out: @mut io::Writer) -> Result<Terminal, ~str> {
         let term = os::getenv("TERM");
         if term.is_none() {
             return Err(~"TERM environment variable undefined");
@@ -243,7 +243,7 @@ impl Terminal {
 
 #[cfg(target_os = "win32")]
 impl Terminal {
-    pub fn new(out: @io::Writer) -> Result<Terminal, ~str> {
+    pub fn new(out: @mut io::Writer) -> Result<Terminal, ~str> {
         return Ok(Terminal {out: out, num_colors: 0});
     }
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -30,8 +30,8 @@ use treemap::TreeMap;
 
 use std::clone::Clone;
 use std::comm::{stream, SharedChan, GenericPort, GenericChan};
-use std::io;
-use std::result;
+use std::rt::io;
+use std::rt::io::file::FileInfo;
 use std::task;
 use std::to_str::ToStr;
 use std::f64;
@@ -336,8 +336,8 @@ pub enum TestResult {
 }
 
 struct ConsoleTestState {
-    out: @io::Writer,
-    log_out: Option<@io::Writer>,
+    out: @mut io::Writer,
+    log_out: Option<@mut io::Writer>,
     term: Option<term::Terminal>,
     use_color: bool,
     total: uint,
@@ -353,17 +353,13 @@ struct ConsoleTestState {
 impl ConsoleTestState {
     pub fn new(opts: &TestOpts) -> ConsoleTestState {
         let log_out = match opts.logfile {
-            Some(ref path) => match io::file_writer(path,
-                                                    [io::Create,
-                                                     io::Truncate]) {
-                result::Ok(w) => Some(w),
-                result::Err(ref s) => {
-                    fail2!("can't open output file: {}", *s)
-                }
+            Some(ref path) => {
+                let out = path.open_writer(io::CreateOrTruncate);
+                Some(@mut out as @mut io::Writer)
             },
             None => None
         };
-        let out = io::stdout();
+        let out = @mut io::stdio::stdout() as @mut io::Writer;
         let term = match term::Terminal::new(out) {
             Err(_) => None,
             Ok(t) => Some(t)
@@ -424,12 +420,12 @@ impl ConsoleTestState {
                         word: &str,
                         color: term::color::Color) {
         match self.term {
-            None => self.out.write_str(word),
+            None => self.out.write(word.as_bytes()),
             Some(ref t) => {
                 if self.use_color {
                     t.fg(color);
                 }
-                self.out.write_str(word);
+                self.out.write(word.as_bytes());
                 if self.use_color {
                     t.reset();
                 }
@@ -440,12 +436,12 @@ impl ConsoleTestState {
     pub fn write_run_start(&mut self, len: uint) {
         self.total = len;
         let noun = if len != 1 { &"tests" } else { &"test" };
-        self.out.write_line(format!("\nrunning {} {}", len, noun));
+        write!(self.out, "\nrunning {} {}\n", len, noun);
     }
 
     pub fn write_test_start(&self, test: &TestDesc, align: NamePadding) {
         let name = test.padded_name(self.max_name_len, align);
-        self.out.write_str(format!("test {} ... ", name));
+        write!(self.out, "test {} ... ", name);
     }
 
     pub fn write_result(&self, result: &TestResult) {
@@ -455,41 +451,40 @@ impl ConsoleTestState {
             TrIgnored => self.write_ignored(),
             TrMetrics(ref mm) => {
                 self.write_metric();
-                self.out.write_str(": " + fmt_metrics(mm));
+                write!(self.out, ": {}", fmt_metrics(mm));
             }
             TrBench(ref bs) => {
                 self.write_bench();
-                self.out.write_str(": " + fmt_bench_samples(bs))
+                write!(self.out, ": {}", fmt_bench_samples(bs));
             }
         }
-        self.out.write_str(&"\n");
+        write!(self.out, "\n");
     }
 
     pub fn write_log(&self, test: &TestDesc, result: &TestResult) {
         match self.log_out {
             None => (),
             Some(out) => {
-                out.write_line(format!("{} {}",
-                                    match *result {
+                write!(out, "{} {}",match *result {
                                         TrOk => ~"ok",
                                         TrFailed => ~"failed",
                                         TrIgnored => ~"ignored",
                                         TrMetrics(ref mm) => fmt_metrics(mm),
                                         TrBench(ref bs) => fmt_bench_samples(bs)
-                                    }, test.name.to_str()));
+                                    }, test.name.to_str());
             }
         }
     }
 
     pub fn write_failures(&self) {
-        self.out.write_line("\nfailures:");
+        write!(self.out, "\nfailures:\n");
         let mut failures = ~[];
         for f in self.failures.iter() {
             failures.push(f.name.to_str());
         }
         sort::tim_sort(failures);
         for name in failures.iter() {
-            self.out.write_line(format!("    {}", name.to_str()));
+            writeln!(self.out, "    {}", name.to_str());
         }
     }
 
@@ -506,36 +501,34 @@ impl ConsoleTestState {
                 MetricAdded => {
                     added += 1;
                     self.write_added();
-                    self.out.write_line(format!(": {}", *k));
+                    writeln!(self.out, ": {}", *k);
                 }
                 MetricRemoved => {
                     removed += 1;
                     self.write_removed();
-                    self.out.write_line(format!(": {}", *k));
+                    writeln!(self.out, ": {}", *k);
                 }
                 Improvement(pct) => {
                     improved += 1;
-                    self.out.write_str(*k);
-                    self.out.write_str(": ");
+                    write!(self.out, "{}: ", *k);
                     self.write_improved();
-                    self.out.write_line(format!(" by {:.2f}%", pct as f64))
+                    writeln!(self.out, " by {:.2f}%", pct as f64);
                 }
                 Regression(pct) => {
                     regressed += 1;
-                    self.out.write_str(*k);
-                    self.out.write_str(": ");
+                    write!(self.out, "{}: ", *k);
                     self.write_regressed();
-                    self.out.write_line(format!(" by {:.2f}%", pct as f64))
+                    writeln!(self.out, " by {:.2f}%", pct as f64);
                 }
             }
         }
-        self.out.write_line(format!("result of ratchet: {} matrics added, {} removed, \
-                                  {} improved, {} regressed, {} noise",
-                                 added, removed, improved, regressed, noise));
+        writeln!(self.out, "result of ratchet: {} matrics added, {} removed, \
+                            {} improved, {} regressed, {} noise",
+                            added, removed, improved, regressed, noise);
         if regressed == 0 {
-            self.out.write_line("updated ratchet file")
+            writeln!(self.out, "updated ratchet file");
         } else {
-            self.out.write_line("left ratchet file untouched")
+            writeln!(self.out, "left ratchet file untouched");
         }
     }
 
@@ -547,12 +540,12 @@ impl ConsoleTestState {
         let ratchet_success = match *ratchet_metrics {
             None => true,
             Some(ref pth) => {
-                self.out.write_str(format!("\nusing metrics ratchet: {}\n", pth.to_str()));
+                write!(self.out, "\nusing metrics ratcher: {}\n", pth.to_str());
                 match ratchet_pct {
                     None => (),
                     Some(pct) =>
-                    self.out.write_str(format!("with noise-tolerance forced to: {}%%\n",
-                                            pct as f64))
+                        writeln!(self.out, "with noise-tolerance forced to: {}%",
+                                 pct)
                 }
                 let (diff, ok) = self.metrics.ratchet(pth, ratchet_pct);
                 self.write_metric_diff(&diff);
@@ -567,15 +560,15 @@ impl ConsoleTestState {
 
         let success = ratchet_success && test_success;
 
-        self.out.write_str("\ntest result: ");
+        write!(self.out, "\ntest result: ");
         if success {
             // There's no parallelism at this point so it's safe to use color
             self.write_ok();
         } else {
             self.write_failed();
         }
-        self.out.write_str(format!(". {} passed; {} failed; {} ignored; {} measured\n\n",
-                                self.passed, self.failed, self.ignored, self.measured));
+        write!(self.out, ". {} passed; {} failed; {} ignored; {} measured\n\n",
+               self.passed, self.failed, self.ignored, self.measured);
         return success;
     }
 }
@@ -659,7 +652,7 @@ pub fn run_tests_console(opts: &TestOpts,
         None => (),
         Some(ref pth) => {
             st.metrics.save(pth);
-            st.out.write_str(format!("\nmetrics saved to: {}", pth.to_str()));
+            write!(st.out, "\nmetrics saved to: {}", pth.to_str());
         }
     }
     return st.write_run_finish(&opts.ratchet_metrics, opts.ratchet_noise_percent);
@@ -667,38 +660,41 @@ pub fn run_tests_console(opts: &TestOpts,
 
 #[test]
 fn should_sort_failures_before_printing_them() {
+    use std::rt::io;
+    use std::rt::io::Decorator;
+    use std::rt::io::mem::MemWriter;
+    use std::str;
     fn dummy() {}
 
-    let s = do io::with_str_writer |wr| {
-        let test_a = TestDesc {
-            name: StaticTestName("a"),
-            ignore: false,
-            should_fail: false
-        };
-
-        let test_b = TestDesc {
-            name: StaticTestName("b"),
-            ignore: false,
-            should_fail: false
-        };
-
-        let st = @ConsoleTestState {
-            out: wr,
-            log_out: None,
-            term: None,
-            use_color: false,
-            total: 0u,
-            passed: 0u,
-            failed: 0u,
-            ignored: 0u,
-            measured: 0u,
-            metrics: MetricMap::new(),
-            failures: ~[test_b, test_a],
-            max_name_len: 0u,
-        };
-
-        st.write_failures();
+    let m = @mut MemWriter::new();
+    let test_a = TestDesc {
+        name: StaticTestName("a"),
+        ignore: false,
+        should_fail: false
     };
+
+    let test_b = TestDesc {
+        name: StaticTestName("b"),
+        ignore: false,
+        should_fail: false
+    };
+
+    let st = @ConsoleTestState {
+        out: m as @mut io::Writer,
+        log_out: None,
+        term: None,
+        use_color: false,
+        total: 0u,
+        passed: 0u,
+        failed: 0u,
+        ignored: 0u,
+        measured: 0u,
+        metrics: MetricMap::new(),
+        failures: ~[test_b, test_a]
+    };
+
+    st.write_failures();
+    let s = str::from_utf8(*m.inner_ref());
 
     let apos = s.find_str("a").unwrap();
     let bpos = s.find_str("b").unwrap();
@@ -941,15 +937,15 @@ impl MetricMap {
     /// Load MetricDiff from a file.
     pub fn load(p: &Path) -> MetricMap {
         assert!(os::path_exists(p));
-        let f = io::file_reader(p).unwrap();
+        let f = @mut p.open_reader(io::Open) as @mut io::Reader;
         let mut decoder = json::Decoder(json::from_reader(f).unwrap());
         MetricMap(Decodable::decode(&mut decoder))
     }
 
     /// Write MetricDiff to a file.
     pub fn save(&self, p: &Path) {
-        let f = io::file_writer(p, [io::Create, io::Truncate]).unwrap();
-        self.to_json().to_pretty_writer(f);
+        let f = @mut p.open_writer(io::CreateOrTruncate);
+        self.to_json().to_pretty_writer(f as @mut io::Writer);
     }
 
     /// Compare against another MetricMap. Optionally compare all

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -10,7 +10,8 @@
 
 #[allow(missing_doc)];
 
-use std::io;
+use std::rt::io::Reader;
+use std::rt::io::mem::BufReader;
 use std::num;
 use std::str;
 
@@ -665,61 +666,69 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
         }
     }
 
-    do io::with_str_reader(format) |rdr| {
-        let mut tm = Tm {
-            tm_sec: 0_i32,
-            tm_min: 0_i32,
-            tm_hour: 0_i32,
-            tm_mday: 0_i32,
-            tm_mon: 0_i32,
-            tm_year: 0_i32,
-            tm_wday: 0_i32,
-            tm_yday: 0_i32,
-            tm_isdst: 0_i32,
-            tm_gmtoff: 0_i32,
-            tm_zone: ~"",
-            tm_nsec: 0_i32,
+    let mut rdr = BufReader::new(format.as_bytes());
+    let mut tm = Tm {
+        tm_sec: 0_i32,
+        tm_min: 0_i32,
+        tm_hour: 0_i32,
+        tm_mday: 0_i32,
+        tm_mon: 0_i32,
+        tm_year: 0_i32,
+        tm_wday: 0_i32,
+        tm_yday: 0_i32,
+        tm_isdst: 0_i32,
+        tm_gmtoff: 0_i32,
+        tm_zone: ~"",
+        tm_nsec: 0_i32,
+    };
+    let mut pos = 0u;
+    let len = s.len();
+    let mut result = Err(~"Invalid time");
+
+    while pos < len {
+        let range = s.char_range_at(pos);
+        let ch = range.ch;
+        let next = range.next;
+
+        let mut buf = [0];
+        let c = match rdr.read(buf) {
+            Some(*) => buf[0] as u8 as char,
+            None => break
         };
-        let mut pos = 0u;
-        let len = s.len();
-        let mut result = Err(~"Invalid time");
-
-        while !rdr.eof() && pos < len {
-            let range = s.char_range_at(pos);
-            let ch = range.ch;
-            let next = range.next;
-
-            match rdr.read_char() {
-                '%' => {
-                    match parse_type(s, pos, rdr.read_char(), &mut tm) {
-                        Ok(next) => pos = next,
-                        Err(e) => { result = Err(e); break; }
-                    }
-                },
-                c => {
-                    if c != ch { break }
-                    pos = next;
+        match c {
+            '%' => {
+                let ch = match rdr.read(buf) {
+                    Some(*) => buf[0] as u8 as char,
+                    None => break
+                };
+                match parse_type(s, pos, ch, &mut tm) {
+                    Ok(next) => pos = next,
+                    Err(e) => { result = Err(e); break; }
                 }
+            },
+            c => {
+                if c != ch { break }
+                pos = next;
             }
         }
-
-        if pos == len && rdr.eof() {
-            Ok(Tm {
-                tm_sec: tm.tm_sec,
-                tm_min: tm.tm_min,
-                tm_hour: tm.tm_hour,
-                tm_mday: tm.tm_mday,
-                tm_mon: tm.tm_mon,
-                tm_year: tm.tm_year,
-                tm_wday: tm.tm_wday,
-                tm_yday: tm.tm_yday,
-                tm_isdst: tm.tm_isdst,
-                tm_gmtoff: tm.tm_gmtoff,
-                tm_zone: tm.tm_zone.clone(),
-                tm_nsec: tm.tm_nsec,
-            })
-        } else { result }
     }
+
+    if pos == len && rdr.eof() {
+        Ok(Tm {
+            tm_sec: tm.tm_sec,
+            tm_min: tm.tm_min,
+            tm_hour: tm.tm_hour,
+            tm_mday: tm.tm_mday,
+            tm_mon: tm.tm_mon,
+            tm_year: tm.tm_year,
+            tm_wday: tm.tm_wday,
+            tm_yday: tm.tm_yday,
+            tm_isdst: tm.tm_isdst,
+            tm_gmtoff: tm.tm_gmtoff,
+            tm_zone: tm.tm_zone.clone(),
+            tm_nsec: tm.tm_nsec,
+        })
+    } else { result }
 }
 
 /// Formats the time according to the format string.
@@ -928,18 +937,26 @@ pub fn strftime(format: &str, tm: &Tm) -> ~str {
         }
     }
 
-    let mut buf = ~"";
+    let mut buf = ~[];
 
-    do io::with_str_reader(format) |rdr| {
-        while !rdr.eof() {
-            match rdr.read_char() {
-                '%' => buf.push_str(parse_type(rdr.read_char(), tm)),
-                ch => buf.push_char(ch)
+    let mut rdr = BufReader::new(format.as_bytes());
+    loop {
+        let mut b = [0];
+        let ch = match rdr.read(b) {
+            Some(*) => b[0],
+            None => break,
+        };
+        match ch as char {
+            '%' => {
+                rdr.read(b);
+                let s = parse_type(b[0] as char, tm);
+                buf.push_all(s.as_bytes());
             }
+            ch => buf.push(ch as u8)
         }
     }
 
-    buf
+    str::from_utf8_owned(buf)
 }
 
 #[cfg(test)]

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -12,10 +12,9 @@
 
 #[allow(missing_doc)];
 
-
+use std::rt::io::{Reader, Seek};
+use std::rt::io::mem::BufReader;
 use std::cmp::Eq;
-use std::io::{Reader, ReaderUtil};
-use std::io;
 use std::hashmap::HashMap;
 use std::to_bytes;
 use std::uint;
@@ -68,42 +67,46 @@ impl UserInfo {
 }
 
 fn encode_inner(s: &str, full_url: bool) -> ~str {
-    do io::with_str_reader(s) |rdr| {
-        let mut out = ~"";
+    let mut rdr = BufReader::new(s.as_bytes());
+    let mut out = ~"";
 
-        while !rdr.eof() {
-            let ch = rdr.read_byte() as u8 as char;
-            match ch {
-              // unreserved:
-              'A' .. 'Z' |
-              'a' .. 'z' |
-              '0' .. '9' |
-              '-' | '.' | '_' | '~' => {
-                out.push_char(ch);
-              }
-              _ => {
-                  if full_url {
-                    match ch {
-                      // gen-delims:
-                      ':' | '/' | '?' | '#' | '[' | ']' | '@' |
+    loop {
+        let mut buf = [0];
+        let ch = match rdr.read(buf) {
+            None => break,
+            Some(*) => buf[0] as char,
+        };
 
-                      // sub-delims:
-                      '!' | '$' | '&' | '"' | '(' | ')' | '*' |
-                      '+' | ',' | ';' | '=' => {
-                        out.push_char(ch);
-                      }
+        match ch {
+          // unreserved:
+          'A' .. 'Z' |
+          'a' .. 'z' |
+          '0' .. '9' |
+          '-' | '.' | '_' | '~' => {
+            out.push_char(ch);
+          }
+          _ => {
+              if full_url {
+                match ch {
+                  // gen-delims:
+                  ':' | '/' | '?' | '#' | '[' | ']' | '@' |
 
-                      _ => out.push_str(format!("%{:X}", ch as uint))
-                    }
-                } else {
-                    out.push_str(format!("%{:X}", ch as uint));
+                  // sub-delims:
+                  '!' | '$' | '&' | '"' | '(' | ')' | '*' |
+                  '+' | ',' | ';' | '=' => {
+                    out.push_char(ch);
+                  }
+
+                  _ => out.push_str(format!("%{:X}", ch as uint))
                 }
-              }
+            } else {
+                out.push_str(format!("%{:X}", ch as uint));
             }
+          }
         }
-
-        out
     }
+
+    out
 }
 
 /**
@@ -128,41 +131,49 @@ pub fn encode_component(s: &str) -> ~str {
 }
 
 fn decode_inner(s: &str, full_url: bool) -> ~str {
-    do io::with_str_reader(s) |rdr| {
-        let mut out = ~"";
+    let mut rdr = BufReader::new(s.as_bytes());
+    let mut out = ~"";
 
-        while !rdr.eof() {
-            match rdr.read_char() {
-              '%' => {
-                let bytes = rdr.read_bytes(2u);
-                let ch = uint::parse_bytes(bytes, 16u).unwrap() as u8 as char;
-
-                if full_url {
-                    // Only decode some characters:
-                    match ch {
-                      // gen-delims:
-                      ':' | '/' | '?' | '#' | '[' | ']' | '@' |
-
-                      // sub-delims:
-                      '!' | '$' | '&' | '"' | '(' | ')' | '*' |
-                      '+' | ',' | ';' | '=' => {
-                        out.push_char('%');
-                        out.push_char(bytes[0u] as char);
-                        out.push_char(bytes[1u] as char);
-                      }
-
-                      ch => out.push_char(ch)
-                    }
-                } else {
-                      out.push_char(ch);
-                }
-              }
-              ch => out.push_char(ch)
+    loop {
+        let mut buf = [0];
+        let ch = match rdr.read(buf) {
+            None => break,
+            Some(*) => buf[0] as char
+        };
+        match ch {
+          '%' => {
+            let mut bytes = [0, 0];
+            match rdr.read(bytes) {
+                Some(2) => {}
+                _ => fail2!() // XXX: malformed url?
             }
-        }
+            let ch = uint::parse_bytes(bytes, 16u).unwrap() as u8 as char;
 
-        out
+            if full_url {
+                // Only decode some characters:
+                match ch {
+                  // gen-delims:
+                  ':' | '/' | '?' | '#' | '[' | ']' | '@' |
+
+                  // sub-delims:
+                  '!' | '$' | '&' | '"' | '(' | ')' | '*' |
+                  '+' | ',' | ';' | '=' => {
+                    out.push_char('%');
+                    out.push_char(bytes[0u] as char);
+                    out.push_char(bytes[1u] as char);
+                  }
+
+                  ch => out.push_char(ch)
+                }
+            } else {
+                  out.push_char(ch);
+            }
+          }
+          ch => out.push_char(ch)
+        }
     }
+
+    out
 }
 
 /**
@@ -182,22 +193,25 @@ pub fn decode_component(s: &str) -> ~str {
 }
 
 fn encode_plus(s: &str) -> ~str {
-    do io::with_str_reader(s) |rdr| {
-        let mut out = ~"";
+    let mut rdr = BufReader::new(s.as_bytes());
+    let mut out = ~"";
 
-        while !rdr.eof() {
-            let ch = rdr.read_byte() as u8 as char;
-            match ch {
-              'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '.' | '-' => {
-                out.push_char(ch);
-              }
-              ' ' => out.push_char('+'),
-              _ => out.push_str(format!("%{:X}", ch as uint))
-            }
+    loop {
+        let mut buf = [0];
+        let ch = match rdr.read(buf) {
+            Some(*) => buf[0] as char,
+            None => break,
+        };
+        match ch {
+          'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '.' | '-' => {
+            out.push_char(ch);
+          }
+          ' ' => out.push_char('+'),
+          _ => out.push_str(format!("%{:X}", ch as uint))
         }
-
-        out
     }
+
+    out
 }
 
 /**
@@ -230,61 +244,69 @@ pub fn encode_form_urlencoded(m: &HashMap<~str, ~[~str]>) -> ~str {
  * type into a hashmap.
  */
 pub fn decode_form_urlencoded(s: &[u8]) -> HashMap<~str, ~[~str]> {
-    do io::with_bytes_reader(s) |rdr| {
-        let mut m = HashMap::new();
-        let mut key = ~"";
-        let mut value = ~"";
-        let mut parsing_key = true;
+    let mut rdr = BufReader::new(s);
+    let mut m = HashMap::new();
+    let mut key = ~"";
+    let mut value = ~"";
+    let mut parsing_key = true;
 
-        while !rdr.eof() {
-            match rdr.read_char() {
-                '&' | ';' => {
-                    if key != ~"" && value != ~"" {
-                        let mut values = match m.pop(&key) {
-                            Some(values) => values,
-                            None => ~[],
-                        };
-
-                        values.push(value);
-                        m.insert(key, values);
-                    }
-
-                    parsing_key = true;
-                    key = ~"";
-                    value = ~"";
-                }
-                '=' => parsing_key = false,
-                ch => {
-                    let ch = match ch {
-                        '%' => {
-                            let bytes = rdr.read_bytes(2u);
-                            uint::parse_bytes(bytes, 16u).unwrap() as u8 as char
-                        }
-                        '+' => ' ',
-                        ch => ch
+    loop {
+        let mut buf = [0];
+        let ch = match rdr.read(buf) {
+            Some(*) => buf[0] as char,
+            None => break,
+        };
+        match ch {
+            '&' | ';' => {
+                if key != ~"" && value != ~"" {
+                    let mut values = match m.pop(&key) {
+                        Some(values) => values,
+                        None => ~[],
                     };
 
-                    if parsing_key {
-                        key.push_char(ch)
-                    } else {
-                        value.push_char(ch)
+                    values.push(value);
+                    m.insert(key, values);
+                }
+
+                parsing_key = true;
+                key = ~"";
+                value = ~"";
+            }
+            '=' => parsing_key = false,
+            ch => {
+                let ch = match ch {
+                    '%' => {
+                        let mut bytes = [0, 0];
+                        match rdr.read(bytes) {
+                            Some(2) => {}
+                            _ => fail2!() // XXX: malformed?
+                        }
+                        uint::parse_bytes(bytes, 16u).unwrap() as u8 as char
                     }
+                    '+' => ' ',
+                    ch => ch
+                };
+
+                if parsing_key {
+                    key.push_char(ch)
+                } else {
+                    value.push_char(ch)
                 }
             }
         }
-
-        if key != ~"" && value != ~"" {
-            let mut values = match m.pop(&key) {
-                Some(values) => values,
-                None => ~[],
-            };
-
-            values.push(value);
-            m.insert(key, values);
-        }
-
-        m
     }
+
+    if key != ~"" && value != ~"" {
+        let mut values = match m.pop(&key) {
+            Some(values) => values,
+            None => ~[],
+        };
+
+        values.push(value);
+        m.insert(key, values);
+    }
+
+    m
 }
 
 
@@ -292,16 +314,18 @@ fn split_char_first(s: &str, c: char) -> (~str, ~str) {
     let len = s.len();
     let mut index = len;
     let mut mat = 0;
-    do io::with_str_reader(s) |rdr| {
-        let mut ch;
-        while !rdr.eof() {
-            ch = rdr.read_byte() as u8 as char;
-            if ch == c {
-                // found a match, adjust markers
-                index = rdr.tell()-1;
-                mat = 1;
-                break;
-            }
+    let mut rdr = BufReader::new(s.as_bytes());
+    loop {
+        let mut buf = [0];
+        let ch = match rdr.read(buf) {
+            Some(*) => buf[0] as char,
+            None => break,
+        };
+        if ch == c {
+            // found a match, adjust markers
+            index = (rdr.tell() as uint) - 1;
+            mat = 1;
+            break;
         }
     }
     if index+mat == len {

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -19,7 +19,13 @@ use arc::{Arc,RWArc};
 use treemap::TreeMap;
 use std::cell::Cell;
 use std::comm::{PortOne, oneshot};
-use std::{io, os, task};
+use std::{os, str, task};
+use std::rt::io;
+use std::rt::io::Writer;
+use std::rt::io::Decorator;
+use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::mem::MemWriter;
+use std::rt::io::file::FileInfo;
 
 /**
 *
@@ -174,19 +180,19 @@ impl Database {
 
     // FIXME #4330: This should have &mut self and should set self.db_dirty to false.
     fn save(&self) {
-        let f = io::file_writer(&self.db_filename, [io::Create, io::Truncate]).unwrap();
-        self.db_cache.to_json().to_pretty_writer(f);
+        let f = @mut self.db_filename.open_writer(io::CreateOrTruncate);
+        self.db_cache.to_json().to_pretty_writer(f as @mut io::Writer);
     }
 
     fn load(&mut self) {
         assert!(!self.db_dirty);
         assert!(os::path_exists(&self.db_filename));
-        let f = io::file_reader(&self.db_filename);
+        let f = self.db_filename.open_reader(io::Open);
         match f {
-            Err(e) => fail2!("Couldn't load workcache database {}: {}",
-                            self.db_filename.to_str(), e.to_str()),
-            Ok(r) =>
-                match json::from_reader(r) {
+            None => fail2!("Couldn't load workcache database {}",
+                           self.db_filename.to_str()),
+            Some(r) =>
+                match json::from_reader(@mut r as @mut io::Reader) {
                     Err(e) => fail2!("Couldn't parse workcache database (from file {}): {}",
                                     self.db_filename.to_str(), e.to_str()),
                     Ok(r) => {
@@ -219,7 +225,7 @@ impl Logger {
     }
 
     pub fn info(&self, i: &str) {
-        io::println(~"workcache: " + i);
+        println(~"workcache: " + i);
     }
 }
 
@@ -256,20 +262,18 @@ enum Work<'self, T> {
 }
 
 fn json_encode<T:Encodable<json::Encoder>>(t: &T) -> ~str {
-    do io::with_str_writer |wr| {
-        let mut encoder = json::Encoder(wr);
-        t.encode(&mut encoder);
-    }
+    let writer = @mut MemWriter::new();
+    let mut encoder = json::Encoder(writer as @mut io::Writer);
+    t.encode(&mut encoder);
+    str::from_utf8(writer.inner_ref().as_slice())
 }
 
 // FIXME(#5121)
 fn json_decode<T:Decodable<json::Decoder>>(s: &str) -> T {
     debug2!("json decoding: {}", s);
-    do io::with_str_reader(s) |rdr| {
-        let j = json::from_reader(rdr).unwrap();
-        let mut decoder = json::Decoder(j);
-        Decodable::decode(&mut decoder)
-    }
+    let j = json::from_str(s).unwrap();
+    let mut decoder = json::Decoder(j);
+    Decodable::decode(&mut decoder)
 }
 
 fn digest<T:Encodable<json::Encoder>>(t: &T) -> ~str {
@@ -280,8 +284,8 @@ fn digest<T:Encodable<json::Encoder>>(t: &T) -> ~str {
 
 fn digest_file(path: &Path) -> ~str {
     let mut sha = ~Sha1::new();
-    let s = io::read_whole_file_str(path);
-    (*sha).input_str(s.unwrap());
+    let s = path.open_reader(io::Open).read_to_end();
+    (*sha).input(s);
     (*sha).result_str()
 }
 
@@ -492,7 +496,6 @@ impl<'self, T:Send +
 
 #[test]
 fn test() {
-    use std::io::WriterUtil;
     use std::{os, run};
 
     // Create a path to a new file 'filename' in the directory in which
@@ -507,8 +510,7 @@ fn test() {
 
     let pth = make_path(~"foo.c");
     {
-        let r = io::file_writer(&pth, [io::Create]);
-        r.unwrap().write_str("int main() { return 0; }");
+        pth.open_writer(io::Create).write(bytes!("int main() { return 0; }"));
     }
 
     let db_path = make_path(~"db.json");
@@ -534,5 +536,5 @@ fn test() {
         }
     };
 
-    io::println(s);
+    println(s);
 }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -26,7 +26,6 @@ use std::c_str::ToCStr;
 use std::char;
 use std::hash::Streaming;
 use std::hash;
-use std::io;
 use std::os::consts::{macos, freebsd, linux, android, win32};
 use std::os;
 use std::ptr;
@@ -931,7 +930,7 @@ pub fn link_binary(sess: Session,
     let cc_args = link_args(sess, obj_filename, out_filename, lm);
     debug2!("{} link args: {}", cc_prog, cc_args.connect(" "));
     if (sess.opts.debugging_opts & session::print_link_args) != 0 {
-        io::println(format!("{} link args: {}", cc_prog, cc_args.connect(" ")));
+        println!("{} link args: {}", cc_prog, cc_args.connect(" "));
     }
 
     // We run 'cc' here

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -26,7 +26,8 @@ use util::common::time;
 use util::ppaux;
 
 use std::hashmap::{HashMap,HashSet};
-use std::io;
+use std::rt::io;
+use std::rt::io::mem::MemReader;
 use std::os;
 use std::vec;
 use extra::getopts::groups::{optopt, optmulti, optflag, optflagopt};
@@ -549,17 +550,16 @@ pub fn pretty_print_input(sess: Session,
     };
 
     let src = sess.codemap.get_filemap(source_name(input)).src;
-    do io::with_str_reader(src) |rdr| {
-        pprust::print_crate(sess.codemap,
-                            token::get_ident_interner(),
-                            sess.span_diagnostic,
-                            &crate,
-                            source_name(input),
-                            rdr,
-                            io::stdout(),
-                            annotation,
-                            is_expanded);
-    }
+    let rdr = @mut MemReader::new(src.as_bytes().to_owned());
+    pprust::print_crate(sess.codemap,
+                        token::get_ident_interner(),
+                        sess.span_diagnostic,
+                        &crate,
+                        source_name(input),
+                        rdr as @mut io::Reader,
+                        @mut io::stdout() as @mut io::Writer,
+                        annotation,
+                        is_expanded);
 }
 
 pub fn get_os(triple: &str) -> Option<session::Os> {
@@ -1040,7 +1040,7 @@ pub fn early_error(emitter: @diagnostic::Emitter, msg: &str) -> ! {
     fail2!();
 }
 
-pub fn list_metadata(sess: Session, path: &Path, out: @io::Writer) {
+pub fn list_metadata(sess: Session, path: &Path, out: @mut io::Writer) {
     metadata::loader::list_file_metadata(
         token::get_ident_interner(),
         session::sess_os_to_meta_os(sess.targ_cfg.os), path, out);

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -27,8 +27,7 @@ use middle::astencode::vtable_decoder_helpers;
 
 
 use std::u64;
-use std::io::WriterUtil;
-use std::io;
+use std::rt::io;
 use std::option;
 use std::str;
 use std::vec;
@@ -56,14 +55,14 @@ fn lookup_hash(d: ebml::Doc, eq_fn: &fn(x:&[u8]) -> bool, hash: u64) ->
     let index = reader::get_doc(d, tag_index);
     let table = reader::get_doc(index, tag_index_table);
     let hash_pos = table.start + (hash % 256 * 4) as uint;
-    let pos = io::u64_from_be_bytes(*d.data, hash_pos, 4) as uint;
+    let pos = ::std::io::u64_from_be_bytes(*d.data, hash_pos, 4) as uint;
     let tagged_doc = reader::doc_at(d.data, pos);
 
     let belt = tag_index_buckets_bucket_elt;
 
     let mut ret = None;
     do reader::tagged_docs(tagged_doc.doc, belt) |elt| {
-        let pos = io::u64_from_be_bytes(*elt.data, elt.start, 4) as uint;
+        let pos = ::std::io::u64_from_be_bytes(*elt.data, elt.start, 4) as uint;
         if eq_fn(elt.data.slice(elt.start + 4, elt.end)) {
             ret = Some(reader::doc_at(d.data, pos).doc);
             false
@@ -78,7 +77,7 @@ pub type GetCrateDataCb<'self> = &'self fn(ast::CrateNum) -> Cmd;
 
 pub fn maybe_find_item(item_id: int, items: ebml::Doc) -> Option<ebml::Doc> {
     fn eq_item(bytes: &[u8], item_id: int) -> bool {
-        return io::u64_from_be_bytes(
+        return ::std::io::u64_from_be_bytes(
             bytes.slice(0u, 4u), 0u, 4u) as int
             == item_id;
     }
@@ -1254,7 +1253,7 @@ fn family_names_type(fam: Family) -> bool {
 
 fn read_path(d: ebml::Doc) -> (~str, uint) {
     do reader::with_doc_data(d) |desc| {
-        let pos = io::u64_from_be_bytes(desc, 0u, 4u) as uint;
+        let pos = ::std::io::u64_from_be_bytes(desc, 0u, 4u) as uint;
         let pathbytes = desc.slice(4u, desc.len());
         let path = str::from_utf8(pathbytes);
 
@@ -1353,23 +1352,23 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
 
 fn list_meta_items(intr: @ident_interner,
                    meta_items: ebml::Doc,
-                   out: @io::Writer) {
+                   out: @mut io::Writer) {
     let r = get_meta_items(meta_items);
     for mi in r.iter() {
-        out.write_str(format!("{}\n", pprust::meta_item_to_str(*mi, intr)));
+        write!(out, "{}\n", pprust::meta_item_to_str(*mi, intr));
     }
 }
 
 fn list_crate_attributes(intr: @ident_interner, md: ebml::Doc, hash: &str,
-                         out: @io::Writer) {
-    out.write_str(format!("=Crate Attributes ({})=\n", hash));
+                         out: @mut io::Writer) {
+    write!(out, "=Crate Attributes ({})=\n", hash);
 
     let r = get_attributes(md);
     for attr in r.iter() {
-        out.write_str(format!("{}\n", pprust::attribute_to_str(attr, intr)));
+        write!(out, "{}\n", pprust::attribute_to_str(attr, intr));
     }
 
-    out.write_str("\n\n");
+    write!(out, "\n\n");
 }
 
 pub fn get_crate_attributes(data: @~[u8]) -> ~[ast::Attribute] {
@@ -1404,17 +1403,16 @@ pub fn get_crate_deps(data: @~[u8]) -> ~[CrateDep] {
     return deps;
 }
 
-fn list_crate_deps(data: @~[u8], out: @io::Writer) {
-    out.write_str("=External Dependencies=\n");
+fn list_crate_deps(data: @~[u8], out: @mut io::Writer) {
+    write!(out, "=External Dependencies=\n");
 
     let r = get_crate_deps(data);
     for dep in r.iter() {
-        out.write_str(
-            format!("{} {}-{}-{}\n",
-                 dep.cnum, token::ident_to_str(&dep.name), dep.hash, dep.vers));
+        write!(out, "{} {}-{}-{}\n",
+                 dep.cnum, token::ident_to_str(&dep.name), dep.hash, dep.vers);
     }
 
-    out.write_str("\n");
+    write!(out, "\n");
 }
 
 pub fn get_crate_hash(data: @~[u8]) -> @str {
@@ -1434,7 +1432,7 @@ pub fn get_crate_vers(data: @~[u8]) -> @str {
 }
 
 pub fn list_crate_metadata(intr: @ident_interner, bytes: @~[u8],
-                           out: @io::Writer) {
+                           out: @mut io::Writer) {
     let hash = get_crate_hash(bytes);
     let md = reader::Doc(bytes);
     list_crate_attributes(intr, md, hash, out);

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -25,7 +25,7 @@ use syntax::attr::AttrMetaMethods;
 
 use std::c_str::ToCStr;
 use std::cast;
-use std::io;
+use std::rt::io;
 use std::num;
 use std::option;
 use std::os::consts::{macos, freebsd, linux, android, win32};
@@ -269,11 +269,11 @@ pub fn read_meta_section_name(os: Os) -> &'static str {
 pub fn list_file_metadata(intr: @ident_interner,
                           os: Os,
                           path: &Path,
-                          out: @io::Writer) {
+                          out: @mut io::Writer) {
     match get_metadata_section(os, path) {
       option::Some(bytes) => decoder::list_crate_metadata(intr, bytes, out),
       option::None => {
-        out.write_str(format!("could not find metadata in {}.\n", path.to_str()))
+        write!(out, "could not find metadata in {}.\n", path.to_str())
       }
     }
 }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -21,7 +21,6 @@ use util::common::stmt_set;
 use util::ppaux::{note_and_explain_region, Repr, UserString};
 
 use std::hashmap::{HashSet, HashMap};
-use std::io;
 use std::ops::{BitOr, BitAnd};
 use std::result::{Result};
 use syntax::ast;
@@ -99,7 +98,7 @@ pub fn check_crate(
     visit::walk_crate(bccx, crate, ());
 
     if tcx.sess.borrowck_stats() {
-        io::println("--- borrowck stats ---");
+        println("--- borrowck stats ---");
         println!("paths requiring guarantees: {}",
                  bccx.stats.guaranteed_paths);
         println!("paths requiring loans     : {}",

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -18,7 +18,7 @@
 
 
 use std::cast;
-use std::io;
+use std::rt::io;
 use std::uint;
 use std::vec;
 use std::hashmap::HashMap;
@@ -349,12 +349,12 @@ impl<O:DataFlowOperator+Clone+'static> DataFlowContext<O> {
         debug2!("Dataflow result:");
         debug2!("{}", {
             let this = @(*self).clone();
-            this.pretty_print_to(io::stderr(), blk);
+            this.pretty_print_to(@mut io::stderr() as @mut io::Writer, blk);
             ""
         });
     }
 
-    fn pretty_print_to(@self, wr: @io::Writer, blk: &ast::Block) {
+    fn pretty_print_to(@self, wr: @mut io::Writer, blk: &ast::Block) {
         let ps = pprust::rust_printer_annotated(wr,
                                                 self.tcx.sess.intr(),
                                                 self as @pprust::pp_ann);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -70,7 +70,6 @@ use middle::trans::type_::Type;
 use std::c_str::ToCStr;
 use std::hash;
 use std::hashmap::HashMap;
-use std::io;
 use std::libc::c_uint;
 use std::vec;
 use std::local_data;
@@ -3154,7 +3153,7 @@ pub fn trans_crate(sess: session::Session,
     // Translate the metadata.
     write_metadata(ccx, &crate);
     if ccx.sess.trans_stats() {
-        io::println("--- trans stats ---");
+        println("--- trans stats ---");
         println!("n_static_tydescs: {}", ccx.stats.n_static_tydescs);
         println!("n_glues_created: {}", ccx.stats.n_glues_created);
         println!("n_null_glues: {}", ccx.stats.n_null_glues);
@@ -3164,7 +3163,7 @@ pub fn trans_crate(sess: session::Session,
         println!("n_monos: {}", ccx.stats.n_monos);
         println!("n_inlines: {}", ccx.stats.n_inlines);
         println!("n_closures: {}", ccx.stats.n_closures);
-        io::println("fn stats:");
+        println("fn stats:");
         do sort::quick_sort(ccx.stats.fn_stats) |&(_, _, insns_a), &(_, _, insns_b)| {
             insns_a > insns_b
         }

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -36,7 +36,8 @@ use driver::session;
 use middle::lint;
 
 use std::comm;
-use std::io;
+use std::rt::io;
+use std::rt::io::extensions::ReaderUtil;
 use std::num;
 use std::os;
 use std::result;
@@ -181,7 +182,7 @@ Available lint options:
                  lint::level_to_str(spec.default),
                  spec.desc);
     }
-    io::println("");
+    println("");
 }
 
 pub fn describe_debug_flags() {
@@ -247,7 +248,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
       1u => {
         let ifile = matches.free[0].as_slice();
         if "-" == ifile {
-            let src = str::from_utf8(io::stdin().read_whole_stream());
+            let src = str::from_utf8(io::stdin().read_to_end());
             str_input(src.to_managed())
         } else {
             file_input(Path(ifile))
@@ -275,7 +276,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
     if ls {
         match input {
           file_input(ref ifile) => {
-            list_metadata(sess, &(*ifile), io::stdout());
+            list_metadata(sess, &(*ifile), @mut io::stdout() as @mut io::Writer);
           }
           str_input(_) => {
             early_error(demitter, "can not list metadata for stdin");

--- a/src/librustdoc/rustdoc.rs
+++ b/src/librustdoc/rustdoc.rs
@@ -27,6 +27,9 @@ use std::cell::Cell;
 use std::rt::io::Writer;
 use std::rt::io::file::FileInfo;
 use std::rt::io;
+use std::rt::io::mem::MemWriter;
+use std::rt::io::Decorator;
+use std::str;
 use extra::getopts;
 use extra::getopts::groups;
 use extra::json;
@@ -254,11 +257,11 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
 /// This input format purely deserializes the json output file. No passes are
 /// run over the deserialized output.
 fn json_input(input: &str) -> Result<Output, ~str> {
-    let input = match ::std::io::file_reader(&Path(input)) {
-        Ok(i) => i,
-        Err(s) => return Err(s),
+    let input = match Path(input).open_reader(io::Open) {
+        Some(f) => f,
+        None => return Err(format!("couldn't open {} for reading", input)),
     };
-    match json::from_reader(input) {
+    match json::from_reader(@mut input as @mut io::Reader) {
         Err(s) => Err(s.to_str()),
         Ok(json::Object(obj)) => {
             let mut obj = obj;
@@ -303,8 +306,10 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
 
     // FIXME #8335: yuck, Rust -> str -> JSON round trip! No way to .encode
     // straight to the Rust JSON representation.
-    let crate_json_str = do std::io::with_str_writer |w| {
-        crate.encode(&mut json::Encoder(w));
+    let crate_json_str = {
+        let w = @mut MemWriter::new();
+        crate.encode(&mut json::Encoder(w as @mut io::Writer));
+        str::from_utf8(*w.inner_ref())
     };
     let crate_json = match json::from_str(crate_json_str) {
         Ok(j) => j,

--- a/src/librusti/utils.rs
+++ b/src/librusti/utils.rs
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
+use std::rt::io;
+use std::rt::io::Decorator;
+use std::str;
+
 use syntax::ast;
 use syntax::print::pp;
 use syntax::print::pprust;
@@ -42,11 +45,11 @@ pub fn each_binding(l: @ast::Local, f: &fn(&ast::Path, ast::NodeId)) {
 
 /// A utility function that hands off a pretty printer to a callback.
 pub fn with_pp(intr: @token::ident_interner,
-               cb: &fn(@pprust::ps, @io::Writer)) -> ~str {
-    do io::with_str_writer |writer| {
-        let pp = pprust::rust_printer(writer, intr);
+               cb: &fn(@pprust::ps, @mut io::Writer)) -> ~str {
+    let writer = @mut io::mem::MemWriter::new();
+    let pp = pprust::rust_printer(writer as @mut io::Writer, intr);
 
-        cb(pp, writer);
-        pp::eof(pp.s);
-    }
+    cb(pp, writer as @mut io::Writer);
+    pp::eof(pp.s);
+    str::from_utf8(*writer.inner_ref())
 }

--- a/src/librustpkg/messages.rs
+++ b/src/librustpkg/messages.rs
@@ -9,31 +9,38 @@
 // except according to those terms.
 
 use extra::term;
-use std::io;
+use std::rt::io;
 
 pub fn note(msg: &str) {
-    pretty_message(msg, "note: ", term::color::GREEN, io::stdout())
+    pretty_message(msg, "note: ", term::color::GREEN,
+                   @mut io::stdout() as @mut io::Writer)
 }
 
 pub fn warn(msg: &str) {
-    pretty_message(msg, "warning: ", term::color::YELLOW, io::stdout())
+    pretty_message(msg, "warning: ", term::color::YELLOW,
+                   @mut io::stdout() as @mut io::Writer)
 }
 
 pub fn error(msg: &str) {
-    pretty_message(msg, "error: ", term::color::RED, io::stdout())
+    pretty_message(msg, "error: ", term::color::RED,
+                   @mut io::stdout() as @mut io::Writer)
 }
 
-fn pretty_message<'a>(msg: &'a str, prefix: &'a str, color: term::color::Color, out: @io::Writer) {
+fn pretty_message<'a>(msg: &'a str,
+                      prefix: &'a str,
+                      color: term::color::Color,
+                      out: @mut io::Writer) {
     let term = term::Terminal::new(out);
     match term {
         Ok(ref t) => {
             t.fg(color);
-            out.write_str(prefix);
+            out.write(prefix.as_bytes());
             t.reset();
         },
         _ => {
-            out.write_str(prefix);
+            out.write(prefix.as_bytes());
         }
     }
-    out.write_line(msg);
+    out.write(msg.as_bytes());
+    out.write(['\n' as u8]);
 }

--- a/src/librustpkg/testsuite/fail/src/no-inferred-crates/src/zzyzx.rs
+++ b/src/librustpkg/testsuite/fail/src/no-inferred-crates/src/zzyzx.rs
@@ -15,8 +15,6 @@ The test runner should check that, after `rustpkg build hello-world`:
   * testsuite/hello-world/build/ does not contain a library
 */
 
-use std::io;
-
 fn main() {
-    io::println(~"Hello world!");
+    println(~"Hello world!");
 }

--- a/src/librustpkg/testsuite/pass/src/hello-world/main.rs
+++ b/src/librustpkg/testsuite/pass/src/hello-world/main.rs
@@ -18,8 +18,6 @@ The test runner should check that, after `rustpkg build hello-world`:
   * testsuite/pass/hello-world/build is empty
 */
 
-use std::io;
-
 fn main() {
-    io::println(~"Hello world!");
+    println(~"Hello world!");
 }

--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -8,10 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
-
 pub fn general() {
-    io::println("Usage: rustpkg [options] <cmd> [args..]
+    println("Usage: rustpkg [options] <cmd> [args..]
 
 Where <cmd> is one of:
     build, clean, do, info, install, list, prefer, test, uninstall, unprefer
@@ -24,7 +22,7 @@ Options:
 }
 
 pub fn build() {
-    io::println("rustpkg build [options..] [package-ID]
+    println("rustpkg build [options..] [package-ID]
 
 Build the given package ID if specified. With no package ID argument,
 build the package in the current directory. In that case, the current
@@ -50,21 +48,21 @@ Options:
 }
 
 pub fn clean() {
-    io::println("rustpkg clean
+    println("rustpkg clean
 
 Remove all build files in the work cache for the package in the current
 directory.");
 }
 
 pub fn do_cmd() {
-    io::println("rustpkg do <cmd>
+    println("rustpkg do <cmd>
 
 Runs a command in the package script. You can listen to a command
 by tagging a function with the attribute `#[pkg_do(cmd)]`.");
 }
 
 pub fn info() {
-    io::println("rustpkg [options..] info
+    println("rustpkg [options..] info
 
 Probe the package script in the current directory for information.
 
@@ -73,13 +71,13 @@ Options:
 }
 
 pub fn list() {
-    io::println("rustpkg list
+    println("rustpkg list
 
 List all installed packages.");
 }
 
 pub fn install() {
-    io::println("rustpkg install [options..] [package-ID]
+    println("rustpkg install [options..] [package-ID]
 
 Install the given package ID if specified. With no package ID
 argument, install the package in the current directory.
@@ -105,14 +103,14 @@ Options:
 }
 
 pub fn uninstall() {
-    io::println("rustpkg uninstall <id|name>[@version]
+    println("rustpkg uninstall <id|name>[@version]
 
 Remove a package by id or name and optionally version. If the package(s)
 is/are depended on by another package then they cannot be removed.");
 }
 
 pub fn prefer() {
-    io::println("rustpkg [options..] prefer <id|name>[@version]
+    println("rustpkg [options..] prefer <id|name>[@version]
 
 By default all binaries are given a unique name so that multiple versions can
 coexist. The prefer command will symlink the uniquely named binary to
@@ -130,7 +128,7 @@ Example:
 }
 
 pub fn unprefer() {
-    io::println("rustpkg [options..] unprefer <id|name>[@version]
+    println("rustpkg [options..] unprefer <id|name>[@version]
 
 Remove all symlinks from the store to the binary directory for a package
 name and optionally version. If version is not supplied, the latest version
@@ -139,7 +137,7 @@ information.");
 }
 
 pub fn test() {
-    io::println("rustpkg [options..] test
+    println("rustpkg [options..] test
 
 Build all test crates in the current directory with the test flag.
 Then, run all the resulting test executables, redirecting the output
@@ -150,7 +148,7 @@ Options:
 }
 
 pub fn init() {
-    io::println("rustpkg init
+    println("rustpkg init
 
 This will turn the current working directory into a workspace. The first
 command you run when starting off a new project.

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -962,7 +962,6 @@ pub fn segments_name_eq(a : &[ast::PathSegment], b : &[ast::PathSegment]) -> boo
 mod test {
     use ast::*;
     use super::*;
-    use std::io;
     use opt_vec;
     use std::hashmap::HashMap;
 
@@ -1137,7 +1136,7 @@ mod test {
         // - two renames of the same var.. can only happen if you use
         // local-expand to prevent the inner binding from being renamed
         // during the rename-pass caused by the first:
-        io::println("about to run bad test");
+        println("about to run bad test");
         { let sc = unfold_test_sc(~[R(id(a,EMPTY_CTXT),50),
                                     R(id(a,EMPTY_CTXT),51)],
                                   EMPTY_CTXT,&mut t);

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -11,7 +11,7 @@
 use codemap::{Pos, Span};
 use codemap;
 
-use std::io;
+use std::rt::io;
 use std::local_data;
 use extra::term;
 
@@ -195,9 +195,14 @@ fn diagnosticcolor(lvl: level) -> term::color::Color {
 fn print_maybe_styled(msg: &str, color: term::attr::Attr) {
     local_data_key!(tls_terminal: @Option<term::Terminal>)
 
-    let stderr = io::stderr();
+    let stderr = @mut io::stderr() as @mut io::Writer;
+    fn is_stderr_screen() -> bool {
+        #[fixed_stack_segment];
+        use std::libc;
+        unsafe { libc::isatty(libc::STDERR_FILENO) != 0 }
+    }
 
-    if stderr.get_type() == io::Screen {
+    if is_stderr_screen() {
         let t = match local_data::get(tls_terminal, |v| v.map(|k| *k)) {
             None => {
                 let t = term::Terminal::new(stderr);
@@ -214,21 +219,21 @@ fn print_maybe_styled(msg: &str, color: term::attr::Attr) {
         match t {
             &Some(ref term) => {
                 term.attr(color);
-                stderr.write_str(msg);
+                write!(stderr, "{}", msg);
                 term.reset();
             },
-            _ => stderr.write_str(msg)
+            _ => write!(stderr, "{}", msg)
         }
     } else {
-        stderr.write_str(msg);
+        write!(stderr, "{}", msg);
     }
 }
 
 fn print_diagnostic(topic: &str, lvl: level, msg: &str) {
-    let stderr = io::stderr();
+    let mut stderr = io::stderr();
 
     if !topic.is_empty() {
-        stderr.write_str(format!("{} ", topic));
+        write!(&mut stderr as &mut io::Writer, "{} ", topic);
     }
 
     print_maybe_styled(format!("{}: ", diagnosticstr(lvl)),
@@ -262,6 +267,8 @@ fn highlight_lines(cm: @codemap::CodeMap,
                    lvl: level,
                    lines: @codemap::FileLines) {
     let fm = lines.file;
+    let mut err = io::stderr();
+    let err = &mut err as &mut io::Writer;
 
     // arbitrarily only print up to six lines of the error
     let max_lines = 6u;
@@ -273,21 +280,12 @@ fn highlight_lines(cm: @codemap::CodeMap,
     }
     // Print the offending lines
     for line in display_lines.iter() {
-        io::stderr().write_str(format!("{}:{} ", fm.name, *line + 1u));
-        let s = fm.get_line(*line as int) + "\n";
-        io::stderr().write_str(s);
+        write!(err, "{}:{} {}\n", fm.name, *line + 1, fm.get_line(*line as int));
     }
     if elided {
         let last_line = display_lines[display_lines.len() - 1u];
         let s = format!("{}:{} ", fm.name, last_line + 1u);
-        let mut indent = s.len();
-        let mut out = ~"";
-        while indent > 0u {
-            out.push_char(' ');
-            indent -= 1u;
-        }
-        out.push_str("...\n");
-        io::stderr().write_str(out);
+        write!(err, "{0:1$}...\n", "", s.len());
     }
 
     // FIXME (#3260)
@@ -321,7 +319,7 @@ fn highlight_lines(cm: @codemap::CodeMap,
                 _ => s.push_char(' '),
             };
         }
-        io::stderr().write_str(s);
+        write!(err, "{}", s);
         let mut s = ~"^";
         let hi = cm.lookup_char_pos(sp.hi);
         if hi.col != lo.col {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1038,12 +1038,12 @@ pub fn std_macros() -> @str {
     //              allocation but should rather delegate to an invocation of
     //              write! instead of format!
     macro_rules! print (
-        ($($arg:tt)*) => (::std::io::print(format!($($arg)*)))
+        ($($arg:tt)*) => (::std::rt::io::stdio::print(format!($($arg)*)))
     )
     // FIXME(#6846) once stdio is redesigned, this shouldn't perform an
     //              allocation but should rather delegate to an io::Writer
     macro_rules! println (
-        ($($arg:tt)*) => (::std::io::println(format!($($arg)*)))
+        ($($arg:tt)*) => (::std::rt::io::stdio::println(format!($($arg)*)))
     )
 
     macro_rules! local_data_key (
@@ -1572,7 +1572,8 @@ mod test {
     }
 
     fn fake_print_crate(crate: &ast::Crate) {
-        let s = pprust::rust_printer(std::io::stderr(),get_ident_interner());
+        let out = @mut std::rt::io::stderr() as @mut std::rt::io::Writer;
+        let s = pprust::rust_printer(out, get_ident_interner());
         pprust::print_crate_(s, crate);
     }
 
@@ -1584,7 +1585,7 @@ mod test {
 
     //fn expand_and_resolve(crate_str: @str) -> ast::crate {
         //let expanded_ast = expand_crate_str(crate_str);
-        // std::io::println(format!("expanded: {:?}\n",expanded_ast));
+        // println(format!("expanded: {:?}\n",expanded_ast));
         //mtwt_resolve_crate(expanded_ast)
     //}
     //fn expand_and_resolve_and_pretty_print (crate_str : @str) -> ~str {
@@ -1693,9 +1694,9 @@ mod test {
                     let varref_marks = mtwt_marksof(varref.segments[0].identifier.ctxt,
                                                     invalid_name);
                     if (!(varref_name==binding_name)){
-                        std::io::println("uh oh, should match but doesn't:");
-                        std::io::println(format!("varref: {:?}",varref));
-                        std::io::println(format!("binding: {:?}", bindings[binding_idx]));
+                        println("uh oh, should match but doesn't:");
+                        println!("varref: {:?}",varref);
+                        println!("binding: {:?}", bindings[binding_idx]);
                         ast_util::display_sctable(get_sctable());
                     }
                     assert_eq!(varref_name,binding_name);
@@ -1713,12 +1714,12 @@ mod test {
                         println!("text of test case: \"{}\"", teststr);
                         println!("");
                         println!("uh oh, matches but shouldn't:");
-                        std::io::println(format!("varref: {:?}",varref));
+                        println!("varref: {:?}",varref);
                         // good lord, you can't make a path with 0 segments, can you?
                         println!("varref's first segment's uint: {}, and string: \"{}\"",
                                  varref.segments[0].identifier.name,
                                  ident_to_str(&varref.segments[0].identifier));
-                        std::io::println(format!("binding: {:?}", bindings[binding_idx]));
+                        println!("binding: {:?}", bindings[binding_idx]);
                         ast_util::display_sctable(get_sctable());
                     }
                     assert!(!fail);
@@ -1751,17 +1752,17 @@ foo_module!()
                                           && (@"xx" == (ident_to_str(&p.segments[0].identifier)))
                                      }).enumerate() {
             if (mtwt_resolve(v.segments[0].identifier) != resolved_binding) {
-                std::io::println("uh oh, xx binding didn't match xx varref:");
-                std::io::println(format!("this is xx varref \\# {:?}",idx));
-                std::io::println(format!("binding: {:?}",cxbind));
-                std::io::println(format!("resolves to: {:?}",resolved_binding));
-                std::io::println(format!("varref: {:?}",v.segments[0].identifier));
-                std::io::println(format!("resolves to: {:?}",
-                                         mtwt_resolve(v.segments[0].identifier)));
+                println("uh oh, xx binding didn't match xx varref:");
+                println!("this is xx varref \\# {:?}",idx);
+                println!("binding: {:?}",cxbind);
+                println!("resolves to: {:?}",resolved_binding);
+                println!("varref: {:?}",v.segments[0].identifier);
+                println!("resolves to: {:?}",
+                         mtwt_resolve(v.segments[0].identifier));
                 let table = get_sctable();
-                std::io::println("SC table:");
+                println("SC table:");
                 for (idx,val) in table.table.iter().enumerate() {
-                    std::io::println(format!("{:4u} : {:?}",idx,val));
+                    println!("{:4u} : {:?}",idx,val);
                 }
             }
             assert_eq!(mtwt_resolve(v.segments[0].identifier),resolved_binding);

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -15,15 +15,13 @@ use ext::base;
 use print;
 use parse::token::{get_ident_interner};
 
-use std::io;
-
 pub fn expand_syntax_ext(cx: @ExtCtxt,
                          sp: codemap::Span,
                          tt: &[ast::token_tree])
                       -> base::MacResult {
 
     cx.print_backtrace();
-    io::stdout().write_line(
+    println(
         print::pprust::tt_to_str(
             &ast::tt_delim(@mut tt.to_owned()),
             get_ident_interner()));

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -18,7 +18,8 @@ use parse::lexer;
 use parse::token;
 use parse::token::{get_ident_interner};
 
-use std::io;
+use std::rt::io;
+use std::rt::io::extensions::ReaderUtil;
 use std::str;
 use std::uint;
 
@@ -346,9 +347,9 @@ pub struct lit {
 pub fn gather_comments_and_literals(span_diagnostic:
                                     @mut diagnostic::span_handler,
                                     path: @str,
-                                    srdr: @io::Reader)
+                                    mut srdr: &mut io::Reader)
                                  -> (~[cmnt], ~[lit]) {
-    let src = str::from_utf8(srdr.read_whole_stream()).to_managed();
+    let src = str::from_utf8(srdr.read_to_end()).to_managed();
     let cm = CodeMap::new();
     let filemap = cm.new_filemap(path, src);
     let rdr = lexer::new_low_level_string_reader(span_diagnostic, filemap);

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -19,8 +19,11 @@ use parse::attr::parser_attr;
 use parse::lexer::reader;
 use parse::parser::Parser;
 
-use std::io;
 use std::path::Path;
+use std::rt::io;
+use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::file::FileInfo;
+use std::str;
 
 pub mod lexer;
 pub mod parser;
@@ -260,15 +263,34 @@ pub fn new_parser_from_tts(sess: @mut ParseSess,
 /// add the path to the session's codemap and return the new filemap.
 pub fn file_to_filemap(sess: @mut ParseSess, path: &Path, spanopt: Option<Span>)
     -> @FileMap {
-    match io::read_whole_file_str(path) {
-        Ok(src) => string_to_filemap(sess, src.to_managed(), path.to_str().to_managed()),
-        Err(e) => {
-            match spanopt {
-                Some(span) => sess.span_diagnostic.span_fatal(span, e),
-                None => sess.span_diagnostic.handler().fatal(e)
-            }
+    let err = |msg: &str| {
+        match spanopt {
+            Some(sp) => sess.span_diagnostic.span_fatal(sp, msg),
+            None => sess.span_diagnostic.handler().fatal(msg),
+        }
+    };
+    let mut error = None;
+    let bytes = do io::io_error::cond.trap(|e| error = Some(e)).inside {
+        do io::read_error::cond.trap(|e| error = Some(e)).inside {
+            path.open_reader(io::Open).read_to_end()
+        }
+    };
+    match error {
+        Some(e) => {
+            err(format!("couldn't read {}: {}", path.to_str(), e.desc));
+        }
+        None => {}
+    }
+    match str::from_utf8_owned_opt(bytes) {
+        Some(s) => {
+            return string_to_filemap(sess, s.to_managed(),
+                                     path.to_str().to_managed());
+        }
+        None => {
+            err(format!("{} is not UTF-8 encoded", path.to_str()))
         }
     }
+    unreachable!()
 }
 
 // given a session and a string, add the string to
@@ -317,7 +339,10 @@ mod test {
     use super::*;
     use extra::serialize::Encodable;
     use extra;
-    use std::io;
+    use std::rt::io;
+    use std::rt::io::Decorator;
+    use std::rt::io::mem::MemWriter;
+    use std::str;
     use codemap::{Span, BytePos, Spanned};
     use opt_vec;
     use ast;
@@ -329,10 +354,10 @@ mod test {
     use util::parser_testing::string_to_stmt;
 
     #[cfg(test)] fn to_json_str<E : Encodable<extra::json::Encoder>>(val: @E) -> ~str {
-        do io::with_str_writer |writer| {
-            let mut encoder = extra::json::Encoder(writer);
-            val.encode(&mut encoder);
-        }
+        let writer = @mut MemWriter::new();
+        let mut encoder = extra::json::Encoder(writer as @mut io::Writer);
+        val.encode(&mut encoder);
+        str::from_utf8(*writer.inner_ref())
     }
 
     // produce a codemap::span

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -61,7 +61,7 @@
  * avoid combining it with other lines and making matters even worse.
  */
 
-use std::io;
+use std::rt::io;
 use std::vec;
 
 #[deriving(Clone, Eq)]
@@ -148,7 +148,7 @@ pub struct print_stack_elt {
 
 pub static size_infinity: int = 0xffff;
 
-pub fn mk_printer(out: @io::Writer, linewidth: uint) -> @mut Printer {
+pub fn mk_printer(out: @mut io::Writer, linewidth: uint) -> @mut Printer {
     // Yes 3, it makes the ring buffers big enough to never
     // fall behind.
     let n: uint = 3 * linewidth;
@@ -157,7 +157,7 @@ pub fn mk_printer(out: @io::Writer, linewidth: uint) -> @mut Printer {
     let size: ~[int] = vec::from_elem(n, 0);
     let scan_stack: ~[uint] = vec::from_elem(n, 0u);
     @mut Printer {
-        out: @out,
+        out: out,
         buf_len: n,
         margin: linewidth as int,
         space: linewidth as int,
@@ -255,7 +255,7 @@ pub fn mk_printer(out: @io::Writer, linewidth: uint) -> @mut Printer {
  * called 'print'.
  */
 pub struct Printer {
-    out: @@io::Writer,
+    out: @mut io::Writer,
     buf_len: uint,
     margin: int, // width of lines we're constrained to
     space: int, // number of spaces left on line
@@ -452,7 +452,7 @@ impl Printer {
     }
     pub fn print_newline(&mut self, amount: int) {
         debug2!("NEWLINE {}", amount);
-        (*self.out).write_str("\n");
+        write!(self.out, "\n");
         self.pending_indentation = 0;
         self.indent(amount);
     }
@@ -474,10 +474,10 @@ impl Printer {
     }
     pub fn print_str(&mut self, s: &str) {
         while self.pending_indentation > 0 {
-            (*self.out).write_str(" ");
+            write!(self.out, " ");
             self.pending_indentation -= 1;
         }
-        (*self.out).write_str(s);
+        write!(self.out, "{}", s);
     }
     pub fn print(&mut self, x: token, L: int) {
         debug2!("print {} {} (remaining line space={})", tok_str(x), L,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -28,7 +28,10 @@ use print::pp;
 use print::pprust;
 
 use std::char;
-use std::io;
+use std::str;
+use std::rt::io;
+use std::rt::io::Decorator;
+use std::rt::io::mem::MemWriter;
 
 // The @ps is stored here to prevent recursive type.
 pub enum ann_node<'self> {
@@ -83,11 +86,11 @@ pub fn end(s: @ps) {
     pp::end(s.s);
 }
 
-pub fn rust_printer(writer: @io::Writer, intr: @ident_interner) -> @ps {
+pub fn rust_printer(writer: @mut io::Writer, intr: @ident_interner) -> @ps {
     return rust_printer_annotated(writer, intr, @no_ann::new() as @pp_ann);
 }
 
-pub fn rust_printer_annotated(writer: @io::Writer,
+pub fn rust_printer_annotated(writer: @mut io::Writer,
                               intr: @ident_interner,
                               ann: @pp_ann)
                               -> @ps {
@@ -118,8 +121,8 @@ pub fn print_crate(cm: @CodeMap,
                    span_diagnostic: @mut diagnostic::span_handler,
                    crate: &ast::Crate,
                    filename: @str,
-                   input: @io::Reader,
-                   out: @io::Writer,
+                   input: @mut io::Reader,
+                   out: @mut io::Writer,
                    ann: @pp_ann,
                    is_expanded: bool) {
     let (cmnts, lits) = comments::gather_comments_and_literals(
@@ -200,26 +203,26 @@ pub fn path_to_str(p: &ast::Path, intr: @ident_interner) -> ~str {
 pub fn fun_to_str(decl: &ast::fn_decl, purity: ast::purity, name: ast::Ident,
                   opt_explicit_self: Option<ast::explicit_self_>,
                   generics: &ast::Generics, intr: @ident_interner) -> ~str {
-    do io::with_str_writer |wr| {
-        let s = rust_printer(wr, intr);
-        print_fn(s, decl, Some(purity), AbiSet::Rust(),
-                 name, generics, opt_explicit_self, ast::inherited);
-        end(s); // Close the head box
-        end(s); // Close the outer box
-        eof(s.s);
-    }
+    let wr = @mut MemWriter::new();
+    let s = rust_printer(wr as @mut io::Writer, intr);
+    print_fn(s, decl, Some(purity), AbiSet::Rust(),
+             name, generics, opt_explicit_self, ast::inherited);
+    end(s); // Close the head box
+    end(s); // Close the outer box
+    eof(s.s);
+    str::from_utf8(*wr.inner_ref())
 }
 
 pub fn block_to_str(blk: &ast::Block, intr: @ident_interner) -> ~str {
-    do io::with_str_writer |wr| {
-        let s = rust_printer(wr, intr);
-        // containing cbox, will be closed by print-block at }
-        cbox(s, indent_unit);
-        // head-ibox, will be closed by print-block after {
-        ibox(s, 0u);
-        print_block(s, blk);
-        eof(s.s);
-    }
+    let wr = @mut MemWriter::new();
+    let s = rust_printer(wr as @mut io::Writer, intr);
+    // containing cbox, will be closed by print-block at }
+    cbox(s, indent_unit);
+    // head-ibox, will be closed by print-block after {
+    ibox(s, 0u);
+    print_block(s, blk);
+    eof(s.s);
+    str::from_utf8(*wr.inner_ref())
 }
 
 pub fn meta_item_to_str(mi: &ast::MetaItem, intr: @ident_interner) -> ~str {
@@ -2182,11 +2185,11 @@ pub fn print_string(s: @ps, st: &str, style: ast::StrStyle) {
 }
 
 pub fn to_str<T>(t: &T, f: &fn(@ps, &T), intr: @ident_interner) -> ~str {
-    do io::with_str_writer |wr| {
-        let s = rust_printer(wr, intr);
-        f(s, t);
-        eof(s.s);
-    }
+    let wr = @mut MemWriter::new();
+    let s = rust_printer(wr as @mut io::Writer, intr);
+    f(s, t);
+    eof(s.s);
+    str::from_utf8(*wr.inner_ref())
 }
 
 pub fn next_comment(s: @ps) -> Option<comments::cmnt> {

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -13,7 +13,6 @@ extern mod extra;
 use extra::time;
 use extra::treemap::TreeMap;
 use std::hashmap::{HashMap, HashSet};
-use std::io;
 use std::os;
 use std::rand::{Rng, IsaacRng, SeedableRng};
 use std::trie::TrieMap;
@@ -28,7 +27,7 @@ fn timed(label: &str, f: &fn()) {
 }
 
 fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
-    io::println(" Ascending integers:");
+    println(" Ascending integers:");
 
     do timed("insert") {
         for i in range(0u, n_keys) {
@@ -50,7 +49,7 @@ fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
 }
 
 fn descending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
-    io::println(" Descending integers:");
+    println(" Descending integers:");
 
     do timed("insert") {
         for i in range(0, n_keys).invert() {
@@ -118,7 +117,7 @@ fn main() {
 
     println!("{} keys", n_keys);
 
-    io::println("\nTreeMap:");
+    println("\nTreeMap:");
 
     {
         let mut map: TreeMap<uint,uint> = TreeMap::new();
@@ -131,12 +130,12 @@ fn main() {
     }
 
     {
-        io::println(" Random integers:");
+        println(" Random integers:");
         let mut map: TreeMap<uint,uint> = TreeMap::new();
         vector(&mut map, n_keys, rand);
     }
 
-    io::println("\nHashMap:");
+    println("\nHashMap:");
 
     {
         let mut map: HashMap<uint,uint> = HashMap::new();
@@ -149,12 +148,12 @@ fn main() {
     }
 
     {
-        io::println(" Random integers:");
+        println(" Random integers:");
         let mut map: HashMap<uint,uint> = HashMap::new();
         vector(&mut map, n_keys, rand);
     }
 
-    io::println("\nTrieMap:");
+    println("\nTrieMap:");
 
     {
         let mut map: TrieMap<uint> = TrieMap::new();
@@ -167,7 +166,7 @@ fn main() {
     }
 
     {
-        io::println(" Random integers:");
+        println(" Random integers:");
         let mut map: TrieMap<uint> = TrieMap::new();
         vector(&mut map, n_keys, rand);
     }

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -13,7 +13,6 @@ extern mod extra;
 use extra::bitv::BitvSet;
 use extra::treemap::TreeSet;
 use std::hashmap::HashSet;
-use std::io;
 use std::os;
 use std::rand;
 use std::uint;
@@ -123,12 +122,11 @@ impl Results {
 }
 
 fn write_header(header: &str) {
-    io::stdout().write_str(header);
-    io::stdout().write_str("\n");
+    println(header);
 }
 
 fn write_row(label: &str, value: f64) {
-    io::stdout().write_str(format!("{:30s} {} s\n", label, value));
+    println!("{:30s} {} s\n", label, value);
 }
 
 fn write_results(label: &str, results: &Results) {

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -22,7 +22,6 @@ extern mod extra;
 
 use std::comm::{Port, Chan, SharedChan};
 use std::comm;
-use std::io;
 use std::os;
 use std::task;
 use std::uint;
@@ -90,10 +89,10 @@ fn run(args: &[~str]) {
     let result = from_child.recv();
     let end = extra::time::precise_time_s();
     let elapsed = end - start;
-    io::stdout().write_str(format!("Count is {:?}\n", result));
-    io::stdout().write_str(format!("Test took {:?} seconds\n", elapsed));
+    print!("Count is {:?}\n", result);
+    print!("Test took {:?} seconds\n", elapsed);
     let thruput = ((size / workers * workers) as f64) / (elapsed as f64);
-    io::stdout().write_str(format!("Throughput={} per sec\n", thruput));
+    print!("Throughput={} per sec\n", thruput);
     assert_eq!(result, num_bytes * size);
 }
 

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -17,7 +17,6 @@
 extern mod extra;
 
 use std::comm::{SharedChan, Chan, stream};
-use std::io;
 use std::os;
 use std::task;
 use std::uint;
@@ -84,10 +83,10 @@ fn run(args: &[~str]) {
     let result = from_child.recv();
     let end = extra::time::precise_time_s();
     let elapsed = end - start;
-    io::stdout().write_str(format!("Count is {:?}\n", result));
-    io::stdout().write_str(format!("Test took {:?} seconds\n", elapsed));
+    print!("Count is {:?}\n", result);
+    print!("Test took {:?} seconds\n", elapsed);
     let thruput = ((size / workers * workers) as f64) / (elapsed as f64);
-    io::stdout().write_str(format!("Throughput={} per sec\n", thruput));
+    print!("Throughput={} per sec\n", thruput);
     assert_eq!(result, num_bytes * size);
 }
 

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -14,7 +14,6 @@ extern mod extra;
 
 use std::cell::Cell;
 use std::comm::{stream, SharedChan};
-use std::io;
 use std::option;
 use std::os;
 use std::task;
@@ -191,15 +190,15 @@ fn rendezvous(nn: uint, set: ~[color]) {
     }
 
     // print each color in the set
-    io::println(show_color_list(set));
+    println(show_color_list(set));
 
     // print each creature's stats
     for rep in report.iter() {
-        io::println(*rep);
+        println(*rep);
     }
 
     // print the total number of creatures met
-    io::println(show_number(creatures_met));
+    println(show_number(creatures_met));
 }
 
 fn main() {
@@ -215,10 +214,10 @@ fn main() {
     let nn = from_str::<uint>(args[1]).unwrap();
 
     print_complements();
-    io::println("");
+    println("");
 
     rendezvous(nn, ~[Blue, Red, Yellow]);
-    io::println("");
+    println("");
 
     rendezvous(nn,
         ~[Blue, Red, Yellow, Red, Yellow, Blue, Red, Yellow, Red, Blue]);

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -18,7 +18,7 @@
 extern mod extra;
 
 use std::int;
-use std::io;
+use std::rt::io;
 use std::os;
 use std::rand::Rng;
 use std::rand;
@@ -68,12 +68,12 @@ fn select_random(r: u32, genelist: ~[AminoAcids]) -> char {
     bisect(genelist.clone(), 0, genelist.len() - 1, r)
 }
 
-fn make_random_fasta(wr: @io::Writer,
+fn make_random_fasta(wr: @mut io::Writer,
                      id: ~str,
                      desc: ~str,
                      genelist: ~[AminoAcids],
                      n: int) {
-    wr.write_line(~">" + id + " " + desc);
+    writeln!(wr, ">{} {}", id, desc);
     let mut rng = rand::rng();
     let rng = @mut MyRandom {
         last: rng.gen()
@@ -83,26 +83,26 @@ fn make_random_fasta(wr: @io::Writer,
         op.push_char(select_random(myrandom_next(rng, 100u32),
                                    genelist.clone()));
         if op.len() >= LINE_LENGTH {
-            wr.write_line(op);
+            writeln!(wr, "{}", op);
             op = ~"";
         }
     }
-    if op.len() > 0u { wr.write_line(op); }
+    if op.len() > 0u { writeln!(wr, "{}", op); }
 }
 
-fn make_repeat_fasta(wr: @io::Writer, id: ~str, desc: ~str, s: ~str, n: int) {
-    wr.write_line(~">" + id + " " + desc);
+fn make_repeat_fasta(wr: @mut io::Writer, id: ~str, desc: ~str, s: ~str, n: int) {
+    writeln!(wr, ">{} {}", id, desc);
     let mut op = str::with_capacity( LINE_LENGTH );
     let sl = s.len();
     for i in range(0u, n as uint) {
         if (op.len() >= LINE_LENGTH) {
-            wr.write_line( op );
+            writeln!(wr, "{}", op);
             op = str::with_capacity( LINE_LENGTH );
         }
         op.push_char( s[i % sl] as char );
     }
     if op.len() > 0 {
-        wr.write_line(op)
+        writeln!(wr, "{}", op);
     }
 }
 
@@ -122,10 +122,10 @@ fn main() {
     };
 
     let writer = if os::getenv("RUST_BENCH").is_some() {
-        io::file_writer(&Path("./shootout-fasta.data"),
-                        [io::Truncate, io::Create]).unwrap()
+        let file = Path("./shootout-fasta.data").open_writer(io::CreateOrTruncate);
+        @mut file as @mut io::Writer
     } else {
-        io::stdout()
+        @mut io::stdout() as @mut io::Writer
     };
 
     let n = from_str::<int>(args[1]).unwrap();

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -18,8 +18,6 @@ use std::cmp::Ord;
 use std::comm::{stream, Port, Chan};
 use std::comm;
 use std::hashmap::HashMap;
-use std::io::ReaderUtil;
-use std::io;
 use std::option;
 use std::os;
 use std::str;
@@ -240,6 +238,6 @@ fn main() {
 
    // now fetch and print result messages
     for (ii, _sz) in sizes.iter().enumerate() {
-      io::println(from_child[ii].recv());
+      println(from_child[ii].recv());
    }
 }

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -23,8 +23,6 @@ extern mod extra;
 
 use extra::{time, getopts};
 use std::comm::{stream, SharedChan};
-use std::io::WriterUtil;
-use std::io;
 use std::os;
 use std::result::{Ok, Err};
 use std::task;
@@ -113,8 +111,6 @@ fn main() {
 
         let num_trials = 10;
 
-        let out = io::stdout();
-
         for n in range(1, max + 1) {
             for _ in range(0, num_trials) {
                 let start = time::precise_time_ns();
@@ -123,8 +119,7 @@ fn main() {
 
                 let elapsed = stop - start;
 
-                out.write_line(format!("{}\t{}\t{}", n, fibn,
-                                       elapsed.to_str()));
+                println!("{}\t{}\t{}", n, fibn, elapsed.to_str());
             }
         }
     }

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -13,8 +13,6 @@
 extern mod extra;
 
 use extra::smallintmap::SmallIntMap;
-use std::io::WriterUtil;
-use std::io;
 use std::os;
 use std::uint;
 
@@ -59,8 +57,8 @@ fn main() {
 
     let maxf = max as f64;
 
-    io::stdout().write_str(format!("insert(): {:?} seconds\n", checkf));
-    io::stdout().write_str(format!("        : {} op/sec\n", maxf/checkf));
-    io::stdout().write_str(format!("get()   : {:?} seconds\n", appendf));
-    io::stdout().write_str(format!("        : {} op/sec\n", maxf/appendf));
+    println!("insert(): {:?} seconds\n", checkf);
+    println!("        : {} op/sec\n", maxf/checkf);
+    println!("get()   : {:?} seconds\n", appendf);
+    println!("        : {} op/sec\n", maxf/appendf);
 }

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -12,8 +12,7 @@
 
 extern mod extra;
 
-use std::io::{ReaderUtil, WriterUtil};
-use std::io;
+use std::rt::io;
 use std::os;
 use std::uint;
 use std::unstable::intrinsics::cttz16;
@@ -65,7 +64,7 @@ impl Sudoku {
         return true;
     }
 
-    pub fn read(reader: @io::Reader) -> Sudoku {
+    pub fn read(reader: @mut io::Reader) -> Sudoku {
         assert!(reader.read_line() == ~"9,9"); /* assert first line is exactly "9,9" */
 
         let mut g = vec::from_fn(10u, { |_i| ~[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8] });
@@ -85,7 +84,7 @@ impl Sudoku {
         return Sudoku::new(g)
     }
 
-    pub fn write(&self, writer: @io::Writer) {
+    pub fn write(&self, writer: @mut io::Writer) {
         for row in range(0u8, 9u8) {
             writer.write_str(format!("{}", self.grid[row][0] as uint));
             for col in range(1u8, 9u8) {
@@ -276,8 +275,8 @@ fn main() {
     let mut sudoku = if use_default {
         Sudoku::from_vec(&DEFAULT_SUDOKU)
     } else {
-        Sudoku::read(io::stdin())
+        Sudoku::read(@mut io::stdin() as @mut io::Reader)
     };
     sudoku.solve();
-    sudoku.write(io::stdout());
+    sudoku.write(@mut io::stdout() as @mut io::Writer);
 }

--- a/src/test/compile-fail/issue-5060-fail.rs
+++ b/src/test/compile-fail/issue-5060-fail.rs
@@ -10,17 +10,15 @@
 
 #[feature(macro_rules)];
 
-use std::io;
-
 macro_rules! print_hd_tl (
     ($field_hd:ident, $($field_tl:ident),+) => ({
-        io::print(stringify!($field)); //~ ERROR unknown macro variable
-        io::print("::[");
+        print(stringify!($field)); //~ ERROR unknown macro variable
+        print("::[");
         $(
-            io::print(stringify!($field_tl));
-            io::print(", ");
+            print(stringify!($field_tl));
+            print(", ");
         )+
-        io::print("]\n");
+        print("]\n");
     })
 )
 

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
+trait A {}
 
 struct Struct {
-    r: io::Reader //~ ERROR reference to trait `io::Reader` where a type is expected
+    r: A //~ ERROR reference to trait `A` where a type is expected
 }
 
-fn new_struct(r: io::Reader) -> Struct { //~ ERROR reference to trait `io::Reader` where a type is expected
+fn new_struct(r: A) -> Struct { //~ ERROR reference to trait `A` where a type is expected
     Struct { r: r }
 }
 

--- a/src/test/compile-fail/issue-7573.rs
+++ b/src/test/compile-fail/issue-7573.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
-
 pub struct PkgId {
     local_path: ~str,
     junk: ~str
@@ -32,7 +30,7 @@ pub fn remove_package_from_database() {
     list_database(push_id);
 
     for l in lines_to_use.iter() {
-        io::stdout().write_line(l.local_path);
+        println!("{}", l.local_path);
     }
 
 }

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -13,8 +13,6 @@
 
 use cal = bar::c::cc;
 
-use std::io;
-
 use std::either::Right;        //~ ERROR unused import
 
 use std::util::*;              // shouldn't get errors for not using
@@ -24,14 +22,22 @@ use std::util::*;              // shouldn't get errors for not using
 use std::option::{Some, None}; //~ ERROR unused import
                                 //~^ ERROR unused import
 
-use std::io::ReaderUtil;       //~ ERROR unused import
+use test::A;       //~ ERROR unused import
 // Be sure that if we just bring some methods into scope that they're also
 // counted as being used.
-use std::io::WriterUtil;
+use test::B;
 
 // Make sure this import is warned about when at least one of its imported names
 // is unused
 use std::vec::{from_fn, from_elem};   //~ ERROR unused import
+
+mod test {
+    pub trait A { fn a(&self) {} }
+    pub trait B { fn b(&self) {} }
+    pub struct C;
+    impl A for C {}
+    impl B for C {}
+}
 
 mod foo {
     pub struct Point{x: int, y: int}
@@ -58,6 +64,6 @@ fn main() {
     cal(foo::Point{x:3, y:9});
     let a = 3;
     ignore(a);
-    io::stdout().write_str("a");
+    test::C.b();
     let _a = from_elem(0, 0);
 }

--- a/src/test/run-pass/auto-ref-bounded-ty-param.rs
+++ b/src/test/run-pass/auto-ref-bounded-ty-param.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
-
 trait Foo {
     fn f(&self);
 }
@@ -30,7 +28,7 @@ impl<T:Baz> Foo for T {
 
 impl Baz for Bar {
     fn g(&self) {
-        io::println(self.x.to_str());
+        println(self.x.to_str());
     }
 }
 

--- a/src/test/run-pass/expr-repeat-vstore.rs
+++ b/src/test/run-pass/expr-repeat-vstore.rs
@@ -1,5 +1,3 @@
-use std::io::println;
-
 pub fn main() {
     let v: ~[int] = ~[ 1, ..5 ];
     println(v[0].to_str());

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -14,8 +14,7 @@
 
 extern mod extra;
 
-use std::io::ReaderUtil;
-use std::io;
+use std::rt::io;
 use std::to_str;
 
 enum square {
@@ -62,16 +61,15 @@ fn square_from_char(c: char) -> square {
 }
 
 fn read_board_grid<rdr:'static + io::Reader>(input: rdr) -> ~[~[square]] {
-    let input = @input as @io::Reader;
+    let input = @mut input as @mut io::Reader;
     let mut grid = ~[];
-    do input.each_line |line| {
-        let mut row = ~[];
-        for c in line.iter() {
-            row.push(square_from_char(c))
-        }
-        grid.push(row);
-        true
-    };
+    let mut line = [0, ..10];
+    input.read(line);
+    let mut row = ~[];
+    for c in line.iter() {
+        row.push(square_from_char(*c as char))
+    }
+    grid.push(row);
     let width = grid[0].len();
     for row in grid.iter() { assert!(row.len() == width) }
     grid

--- a/src/test/run-pass/issue-3556.rs
+++ b/src/test/run-pass/issue-3556.rs
@@ -10,9 +10,6 @@
 
 extern mod extra;
 
-use std::io::WriterUtil;
-use std::io;
-
 enum Token {
         Text(@~str),
         ETag(@~[~str], @~str),
@@ -26,8 +23,7 @@ fn check_strs(actual: &str, expected: &str) -> bool
 {
         if actual != expected
         {
-            io::stderr().write_line(format!("Found {}, but expected {}", actual,
-                                            expected));
+            println!("Found {}, but expected {}", actual, expected);
             return false;
         }
         return true;

--- a/src/test/run-pass/issue-3559.rs
+++ b/src/test/run-pass/issue-3559.rs
@@ -13,13 +13,11 @@
 // rustc --test map_to_str.rs && ./map_to_str
 extern mod extra;
 
-use std::io::{WriterUtil};
-
 fn check_strs(actual: &str, expected: &str) -> bool
 {
     if actual != expected
     {
-        io::stderr().write_line(fmt!("Found %s, but expected %s", actual, expected));
+        println!("Found %s, but expected %s", actual, expected);
         return false;
     }
     return true;

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -20,8 +20,6 @@ extern mod extra;
 
 // Extern mod controls linkage. Use controls the visibility of names to modules that are
 // already linked in. Using WriterUtil allows us to use the write_line method.
-use std::io::WriterUtil;
-use std::io;
 use std::str;
 use std::vec;
 
@@ -150,7 +148,7 @@ impl Canvas for AsciiArt {
 // this little helper.
 pub fn check_strs(actual: &str, expected: &str) -> bool {
     if actual != expected {
-        io::stderr().write_line(format!("Found:\n{}\nbut expected\n{}", actual, expected));
+        println!("Found:\n{}\nbut expected\n{}", actual, expected);
         return false;
     }
     return true;

--- a/src/test/run-pass/issue-4333.rs
+++ b/src/test/run-pass/issue-4333.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
+use std::rt::io;
 
 pub fn main() {
-    let stdout = &io::stdout() as &io::WriterUtil;
-    stdout.write_line("Hello!");
+    let stdout = &mut io::stdout() as &mut io::Writer;
+    stdout.write(bytes!("Hello!"));
 }

--- a/src/test/run-pass/issue-4541.rs
+++ b/src/test/run-pass/issue-4541.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io;
-
 fn parse_args() -> ~str {
     let args = ::std::os::args();
     let mut n = 0;
@@ -28,5 +26,5 @@ fn parse_args() -> ~str {
 }
 
 pub fn main() {
-    io::println(parse_args());
+    println(parse_args());
 }

--- a/src/test/run-pass/issue-5060.rs
+++ b/src/test/run-pass/issue-5060.rs
@@ -10,17 +10,15 @@
 
 #[feature(macro_rules)];
 
-use std::io;
-
 macro_rules! print_hd_tl (
     ($field_hd:ident, $($field_tl:ident),+) => ({
-        io::print(stringify!($field_hd));
-        io::print("::[");
+        print(stringify!($field_hd));
+        print("::[");
         $(
-            io::print(stringify!($field_tl));
-            io::print(", ");
+            print(stringify!($field_tl));
+            print(", ");
         )+
-        io::print("]\n");
+        print("]\n");
     })
 )
 

--- a/src/test/run-pass/issue-5741.rs
+++ b/src/test/run-pass/issue-5741.rs
@@ -10,9 +10,7 @@
 
 #[allow(unreachable_code)];
 
-use std::io;
-
 pub fn main() {
     return;
-    while io::stdin().read_line() != ~"quit" { };
+    while true {};
 }

--- a/src/test/run-pass/issue-8498.rs
+++ b/src/test/run-pass/issue-8498.rs
@@ -9,14 +9,13 @@
 // except according to those terms.
 
 // xfail-test
-use std::io;
 
 fn main() {
 // This is ok
     match &[(~5,~7)] {
         ps => {
            let (ref y, _) = ps[0];
-           io::println(fmt!("1. y = %d", **y));
+           println(fmt!("1. y = %d", **y));
            assert!(**y == 5);
         }
     }
@@ -25,8 +24,8 @@ fn main() {
     match Some(&[(~5,)]) {
         Some(ps) => {
            let (ref y,) = ps[0];
-           io::println(fmt!("2. y = %d", **y));
-           if **y != 5 { io::println("sadness"); }
+           println(fmt!("2. y = %d", **y));
+           if **y != 5 { println("sadness"); }
         }
         None => ()
     }
@@ -35,7 +34,7 @@ fn main() {
     match Some(&[(~5,~7)]) {
         Some(ps) => {
            let (ref y, ref z) = ps[0];
-           io::println(fmt!("3. y = %d z = %d", **y, **z));
+           println(fmt!("3. y = %d z = %d", **y, **z));
            assert!(**y == 5);
         }
         None => ()

--- a/src/test/run-pass/match-drop-strs-issue-4541.rs
+++ b/src/test/run-pass/match-drop-strs-issue-4541.rs
@@ -2,7 +2,6 @@
 // copying, and moving to ensure that we don't segfault
 // or double-free, as we were wont to do in the past.
 
-use std::io;
 use std::os;
 
 fn parse_args() -> ~str {
@@ -23,5 +22,5 @@ fn parse_args() -> ~str {
 }
 
 pub fn main() {
-    io::println(parse_args());
+    println(parse_args());
 }

--- a/src/test/run-pass/monomorphized-callees-with-ty-params-3314.rs
+++ b/src/test/run-pass/monomorphized-callees-with-ty-params-3314.rs
@@ -10,8 +10,6 @@
 
 extern mod extra;
 
-use std::io;
-
 trait Serializer {
 }
 
@@ -31,15 +29,13 @@ impl<A:Serializable> Serializable for F<A> {
     }
 }
 
-impl Serializer for @io::Writer {
+impl Serializer for int {
 }
 
 pub fn main() {
-    do io::with_str_writer |wr| {
-        let foo = F { a: 1 };
-        foo.serialize(wr);
+    let foo = F { a: 1 };
+    foo.serialize(1i);
 
-        let bar = F { a: F {a: 1 } };
-        bar.serialize(wr);
-    };
+    let bar = F { a: F {a: 1 } };
+    bar.serialize(2i);
 }

--- a/src/test/run-pass/new-import-syntax.rs
+++ b/src/test/run-pass/new-import-syntax.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::println;
-
 pub fn main() {
     println("Hello world!");
 }

--- a/src/test/run-pass/new-style-constants.rs
+++ b/src/test/run-pass/new-style-constants.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::println;
-
 static FOO: int = 3;
 
 pub fn main() {

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -13,8 +13,9 @@
 extern mod extra;
 
 use extra::tempfile;
-use std::io::WriterUtil;
-use std::io;
+use std::rt::io;
+use std::rt::io::Writer;
+use std::rt::io::file::FileInfo;
 use std::os;
 
 pub fn main() {
@@ -22,11 +23,12 @@ pub fn main() {
     let path = dir.path().push("file");
 
     {
-        match io::file_writer(&path, [io::Create, io::Truncate]) {
-            Err(ref e) => fail2!("{}", e.clone()),
-            Ok(f) => {
+        match path.open_writer(io::CreateOrTruncate) {
+            None => unreachable!(),
+            Some(f) => {
+                let mut f = f;
                 for _ in range(0u, 1000) {
-                    f.write_u8(0);
+                    f.write([0]);
                 }
             }
         }

--- a/src/test/run-pass/trait-static-method-overwriting.rs
+++ b/src/test/run-pass/trait-static-method-overwriting.rs
@@ -11,8 +11,6 @@
 // except according to those terms.
 
 mod base {
-    use std::io;
-
     pub trait HasNew<T> {
         fn new() -> Self;
     }
@@ -34,7 +32,7 @@ mod base {
 
     impl ::base::HasNew<Bar> for Bar {
         fn new() -> Bar {
-            io::println("Bar");
+            println("Bar");
             Bar { dummy: () }
         }
     }


### PR DESCRIPTION
This will be ready for merging soon, but I wanted to solicit for some opinions about the changes here. I'm unhappy about the diff stat being positive, although it's not too largely so in this case. Currently most of the increase in verbosity is from being forced to use `@mut io::{Writer, Reader}` instead of using `&mut io::Writer` which is more well-supported (especially when writing to an array of bytes). This I don't think can be helped much (without other refactorings).

I was curious what others thought about the usage of the file I/O right now, though. Things I noticed:
- Every argument to `open_reader` was `io::Open`, and every argument to `open_writer` was `io::CreateOrTruncate` except maybe one or two.
- Using `open_reader` and `open_writer` requires at least two imports: `std::rt::io` and `std::rt::io::file::FileInfo`.
- Using `MemReader` usefully also requires two imports: `std::rt::io::mem::{MemReader, MemWriter}`, and `std::rt::io::Decorator`
- Having `Reader` and `Writer` defined on `Option<T>` is awesome. Once I realized that was true, I started making code a lot smaller.
- There's one location where I have to catch on both the `io_error` and `read_error` conditions. This seems wrong?

I'm not sure if these intend to be added to the prelude, but it is a bit unfortunate if they had to be in the prelude to make these nicer to use. I'm personally in favor of `File::open` and `File::create` with default arguments to `open_reader` and `open_writer` respectively because that's what you want 90% of the time.
