### PR TITLE
fix immediate rvalues

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1917,7 +1917,7 @@ fn trans_match_inner(scope_cx: @mut Block,
             Infallible
         }
     };
-    let lldiscr = discr_datum.to_zeroable_ref_llval(bcx);
+    let lldiscr = discr_datum.to_ref_llval(bcx);
     compile_submatch(bcx, matches, [lldiscr], chk);
 
     let mut arm_cxs = ~[];
@@ -1996,7 +1996,7 @@ pub fn store_local(bcx: @mut Block,
                 if bcx.sess().asm_comments() {
                     add_comment(bcx, "creating zeroable ref llval");
                 }
-                let llptr = init_datum.to_zeroable_ref_llval(bcx);
+                let llptr = init_datum.to_ref_llval(bcx);
                 return bind_irrefutable_pat(bcx, pat, llptr, BindLocal);
             }
         }

--- a/src/test/run-pass/cancel-clean-via-immediate-rvalue-ref.rs
+++ b/src/test/run-pass/cancel-clean-via-immediate-rvalue-ref.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo(x: &mut ~u8) {
+    *x = ~5;
+}
+
+pub fn main() {
+    foo(&mut ~4);
+}


### PR DESCRIPTION
The code generation previously assumed a reference could not alter the
value in a way the destructor would notice. This is an incorrect
assumption for `&mut`, and is also incorrect for an `&` pointer to a
non-`Freeze` type.

Closes #7972
