### PR TITLE
Fix ICE when casting on constant expressions

### DIFF
--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -477,6 +477,22 @@ fn const_expr_unadjusted(cx: @mut CrateContext,
               (expr::cast_integral, expr::cast_pointer) => {
                 llvm::LLVMConstIntToPtr(v, llty.to_ref())
               }
+              (expr::cast_pointer, expr::cast_integral) => {
+                // it's impossible to relocate a link-time constant if the
+                // destination is not exactly of the same size than the pointer
+                // if this is the case, emit an error rather than letting
+                // LLVM report the error
+                let bty = type_of::type_of(cx, basety);
+                let csize = machine::llsize_of_alloc(cx, bty);
+                let tsize = machine::llsize_of_alloc(cx, llty);
+                if csize != tsize {
+                    cx.sess.span_fatal(e.span,
+                        "Cannot cast relocated expression to \
+                        a different size because its value is not known at \
+                        compile time");
+                }
+                llvm::LLVMConstPtrToInt(v, llty.to_ref())
+              }
               _ => {
                 cx.sess.impossible_case(e.span,
                                         "bad combination of types for cast")

--- a/src/test/compile-fail/const-ptr-cast-relocation.rs
+++ b/src/test/compile-fail/const-ptr-cast-relocation.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo() {
+}
+
+// should fail on both 32 and 64 bits archs
+static a: u16 = foo as u16; 
+//~^ ERROR cannot cast relocated expression to a different size
+
+fn main() {
+}

--- a/src/test/run-pass/const-ptr-cast.rs
+++ b/src/test/run-pass/const-ptr-cast.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo() {
+}
+
+static a: uint = foo as uint;
+
+fn main() {
+    println!("{:u}", a);
+}


### PR DESCRIPTION
This pull request fixes the bug I opened ( #9867 )
It also fixes a small issue that was causing Rustc build to fail on my setup, by removing a rusti target in the Makefile.
