### PR TITLE
track language changes, improve attr handling in GtkSourceView language-spec

### DIFF
--- a/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
+++ b/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
@@ -85,7 +85,6 @@
 		<keyword>u64</keyword>
 		<keyword>f32</keyword>
 		<keyword>f64</keyword>
-		<keyword>float</keyword>
 		<keyword>char</keyword>
 		<keyword>str</keyword>
 		<keyword>Either</keyword>
@@ -205,16 +204,36 @@
       </include>
     </context>
 
+    <define-regex id="int_suffix" extended="true">
+      (i8|i16|i32|i64|i|u8|u16|u32|u64|u)
+    </define-regex>
+
+    <define-regex id="exponent" extended="true">
+      ([eE][+-]?[0-9_]+)
+    </define-regex>
+
+    <define-regex id="float_suffix" extended="true">
+      (\%{exponent}?(f32|f64)?)|(\.[0-9][0-9_]*\%{exponent}?)?(f32|f64)?|\.
+    </define-regex>
+
+    <define-regex id="num_suffix" extended="true">
+      \%{int_suffix}|\%{float_suffix}
+    </define-regex>
+
+    <define-regex id="hex_digit" extended="true">
+      [0-9a-fA-F]
+    </define-regex>
+
     <context id="number" style-ref="number">
       <match extended="true">
-        (?&lt;![\w\.])
+        ((?&lt;=\.\.)|(?&lt;![\w\.]))
         (
-        0x[0-9a-fA-F_]+(u8|u16|u32|u64|i8|i16|i32|i64|u|i)?|
-        0b[0-1_]+(u8|u16|u32|u64|i8|i16|i32|i64|u|i)?|
-        [0-9][0-9_]*\.[0-9_]*([eE][+-]?[0-9_]+)?(f32|f64|f)?|
-        [0-9][0-9_]*(u8|u16|u32|u64|i8|i16|i32|i64|u|i)?
+        [1-9][0-9_]*\%{num_suffix}?|
+        0[0-9_]*\%{num_suffix}?|
+        0b[01_]+\%{int_suffix}?|
+        0x(\%{hex_digit}|_)+\%{int_suffix}?
         )
-        (?![\w\.])
+        ((?![\w\.].)|(?=\.\.))
       </match>
     </context>
 
@@ -234,32 +253,37 @@
       </match>
     </context>
 
-    <context id="string" style-ref="string" class="string" class-disabled="no-spell-check">
-      <start>"</start>
-      <end>"</end>
-      <include>
-        <context ref="def:escape"/>
-        <context ref="def:line-continue"/>
-      </include>
-    </context>
-
-    <define-regex id="hex_digit" extended="true">
-      [0-9a-fA-F]
-    </define-regex>
-
     <define-regex id="common_escape" extended="true">
-      (n|r|t)|
+      '|"|
+      \\|n|r|t|
       x\%{hex_digit}{2}|
       u\%{hex_digit}{4}|
       U\%{hex_digit}{8}
     </define-regex>
 
-    <context id="char" style-ref="char" class="char">
-      <match extended="true">'([^\\]|\\\%{common_escape})'</match>
+    <context id="string_escape" style-ref="def:special-char">
+      <match>\\\%{common_escape}</match>
+    </context>
+
+    <context id="string" style-ref="string" class="string" class-disabled="no-spell-check">
+      <start>"</start>
+      <end>"</end>
+      <include>
+        <context ref="string_escape"/>
+        <context ref="def:line-continue"/>
+      </include>
+    </context>
+
+    <context id="char" style-ref="char">
+      <match extended="true">'([^\\']|\\\%{common_escape})'</match>
     </context>
 
     <context id="attribute" style-ref="attribute" class="attribute">
-      <match extended="true">\#\[[^\]]+\]</match>
+      <start extended="true">\#\[</start>
+      <end>\]</end>
+      <include>
+        <context ref="def:in-comment"/>
+      </include>
     </context>
 
     <context id="rust" class="no-spell-check">


### PR DESCRIPTION
Refactors parsing of numerical literals to make it more readable.
Removes 'float'/the 'f' literal suffix and invalid character literals ''' and '\'.
Also makes attribute highlighting more robust and allows urls in attributes to be recognized.
