### PR TITLE
add feature gate for managed boxes

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -35,6 +35,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("struct_variant", Active),
     ("once_fns", Active),
     ("asm", Active),
+    ("managed_boxes", Active),
 
     // These are used to test this portion of the compiler, they don't actually
     // mean anything
@@ -137,6 +138,15 @@ impl Visitor<()> for Context {
                                    experimental and likely to be removed");
 
             },
+            // NOTE: enable after snapshot
+            ast::ty_box(_) if false => {
+                self.gate_feature("managed_boxes", t.span, "The managed box syntax may be replaced \
+                                                            by a library type, and a garbage \
+                                                            collector is not yet implemented. \
+                                                            Consider using the `std::rc` module \
+                                                            as it performs much better as a \
+                                                            reference counting implementation.");
+            }
             _ => {}
         }
 


### PR DESCRIPTION
I'll flip this on after doing a snapshot. This syntax may or may not
stay around, and managed boxes are currently not very useful. They have
the same overall performance characteristics as `std::rc::Rc`, but are
significantly slower, allocate larger boxes and hold onto the memory
beyond when it is needed due to lacking move semantics.

There are currently two useful aspects of the type:
- the dereference sugar, which we should implement for `Rc`
- the annihilator freeing cycles at the end of the task
