### PR TITLE
Fix an off-by-one in managed::refcount

### DIFF
--- a/src/libstd/managed.rs
+++ b/src/libstd/managed.rs
@@ -21,7 +21,7 @@ pub static RC_IMMORTAL : uint = 0x77777777;
 #[inline]
 pub fn refcount<T>(t: @T) -> uint {
     use unstable::raw::Repr;
-    unsafe { (*t.repr()).ref_count }
+    unsafe { (*t.repr()).ref_count - 1 }
 }
 
 /// Determine if two shared boxes point to the same object
@@ -109,4 +109,15 @@ fn test() {
     assert!((ptr_eq::<int>(y, y)));
     assert!((!ptr_eq::<int>(x, y)));
     assert!((!ptr_eq::<int>(y, x)));
+}
+
+#[test]
+fn refcount_test() {
+    use clone::Clone;
+
+    let x = @3;
+    assert_eq!(refcount(x), 1);
+    let y = x.clone();
+    assert_eq!(refcount(x), 2);
+    assert_eq!(refcount(y), 2);
 }


### PR DESCRIPTION
This fixes a bug I accidentally introduced in #9922
