### PR TITLE
Add support for nested comments

### DIFF
--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -39,32 +39,32 @@ pub struct GlobIterator {
     priv todo: ~[(Path,uint)]
 }
 
-/**
- * Return an iterator that produces all the Paths that match the given pattern,
- * which may be absolute or relative to the current working directory.
- *
- * This method uses the default match options and is equivalent to calling
- * `glob_with(pattern, MatchOptions::new())`. Use `glob_with` directly if you
- * want to use non-default match options.
- *
- * # Example
- *
- * Consider a directory `/media/pictures` containing only the files `kittens.jpg`,
- * `puppies.jpg` and `hamsters.gif`:
- *
- * ```rust
- * for path in glob("/media/pictures/*.jpg") {
- *     println(path.to_str());
- * }
- * ```
- *
- * The above code will print:
- *
- * ```
- * /media/pictures/kittens.jpg
- * /media/pictures/puppies.jpg
- * ```
- */
+///
+/// Return an iterator that produces all the Paths that match the given pattern,
+/// which may be absolute or relative to the current working directory.
+///
+/// is method uses the default match options and is equivalent to calling
+/// `glob_with(pattern, MatchOptions::new())`. Use `glob_with` directly if you
+/// want to use non-default match options.
+///
+/// # Example
+///
+/// Consider a directory `/media/pictures` containing only the files `kittens.jpg`,
+/// `puppies.jpg` and `hamsters.gif`:
+///
+/// ```rust
+/// for path in glob("/media/pictures/*.jpg") {
+///     println(path.to_str());
+/// }
+/// ```
+///
+/// The above code will print:
+///
+/// ```
+/// /media/pictures/kittens.jpg
+/// /media/pictures/puppies.jpg
+/// ```
+///
 pub fn glob(pattern: &str) -> GlobIterator {
     glob_with(pattern, MatchOptions::new())
 }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -516,12 +516,6 @@ pub fn self_exe_path() -> Option<Path> {
     load_self().and_then(|path| Path::new_opt(path).map(|mut p| { p.pop(); p }))
 }
 
-
-/**
- * Returns the path to the user's home directory, if known.
-}
-
-
 /**
  * Returns the path to the user's home directory, if known.
  *

--- a/src/test/run-pass/nested-block-comment.rs
+++ b/src/test/run-pass/nested-block-comment.rs
@@ -8,19 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:
-
-/* This is a test to ensure that we do _not_ support nested/balanced comments. I know you might be
-   thinking "but nested comments are cool", and that would be a valid point, but they are also a
-   thing that would make our lexical syntax non-regular, and we do not want that to be true.
-
-   omitting-things at a higher level (tokens) should be done via token-trees / macros,
-   not comments.
+/* This test checks that nested comments are supported
 
    /*
-     fail here
+     This should not fail
    */
 */
 
-fn main() {
+pub fn main() {
 }


### PR DESCRIPTION
This should close #9468.

I removed the test stating that nested comments should not be implemented.

I had a little chicken-and-egg problem because a comment of the std contains "/*", and adding support for nested comment creates a backward incompatibility in that case, so I had to use a dirty hack to get stage1 and stage2 to compile. This part should be revert when this commit lands in a snapshot.

This is my first non-typo contribution, so I'm open to any comment.
