### PR TITLE
rustdoc: Strip methods correctly based on privacy

### DIFF
--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -337,7 +337,7 @@ impl Clean<Item> for ast::method {
             name: Some(self.ident.clean()),
             attrs: self.attrs.clean(),
             source: self.span.clean(),
-            id: self.self_id.clone(),
+            id: self.id.clone(),
             visibility: self.vis.clean(),
             inner: MethodItem(Method {
                 generics: self.generics.clean(),


### PR DESCRIPTION
Beforehand the id of a method was the id of the 'self' argument, but this is not
the id which privacy was using (the id of the ast::method) struct, so by moving
the ids over to the privacy-target ones the methods are now stripped correctly.
