### PR TITLE
Fix struct field visibility and add enum field doc

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1344,6 +1344,26 @@ fn item_enum(w: &mut io::Writer, it: &clean::Item, e: &clean::Enum) {
             write!(w, "<tr><td id='variant.{name}'><code>{name}</code></td><td>",
                    name = variant.name.get_ref().as_slice());
             document(w, variant);
+            match variant.inner {
+                clean::VariantItem(ref var) => {
+                    match var.kind {
+                        clean::StructVariant(ref s) => {
+                            write!(w, "<h3 class='fields'>Fields</h3>\n<table>");
+                            for field in s.fields.iter() {
+                                write!(w, "<tr><td id='variant.{v}.field.{f}'>\
+                                           <code>{f}</code></td><td>",
+                                       v = variant.name.get_ref().as_slice(),
+                                       f = field.name.get_ref().as_slice());
+                                document(w, field);
+                                write!(w, "</td></tr>");
+                            }
+                            write!(w, "</table>");
+                        }
+                        _ => ()
+                    }
+                }
+                _ => ()
+            }
             write!(w, "</td></tr>");
         }
         write!(w, "</table>");

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -135,8 +135,14 @@ impl<'self> fold::DocFolder for Stripper<'self> {
                 }
             }
 
-            clean::ViewItemItem(*) | clean::StructFieldItem(*) => {
+            clean::ViewItemItem(*) => {
                 if i.visibility != Some(ast::public) {
+                    return None
+                }
+            }
+
+            clean::StructFieldItem(*) => {
+                if i.visibility == Some(ast::private) {
                     return None;
                 }
             }


### PR DESCRIPTION
Struct fields with inherited visibility were previously stripped.

Closes #9899
