### PR TITLE
testsuite: test for fixed issue. Closes #7580.

### DIFF
--- a/src/test/run-fail/glob-use-std.rs
+++ b/src/test/run-fail/glob-use-std.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #7580
+
+// error-pattern:fail works
+#[feature(globs)];
+
+use std::*;
+
+fn main() {
+    str::with_capacity(10); // avoid an unused import message
+
+    fail!("fail works")
+}


### PR DESCRIPTION
Fixed by the privacy changes that allowed the `mod std {}` at the top
level of `std` to be non-`pub`.
