### PR TITLE
Don't allocate a string when calling println

### DIFF
--- a/src/libstd/rt/io/stdio.rs
+++ b/src/libstd/rt/io/stdio.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use fmt;
 use libc;
 use option::{Option, Some, None};
 use result::{Ok, Err};
@@ -56,7 +57,9 @@ pub fn stderr() -> StdWriter {
 pub fn print(s: &str) {
     // XXX: need to see if not caching stdin() is the cause of performance
     //      issues, it should be possible to cache a stdout handle in each Task
-    //      and then re-use that across calls to print/println
+    //      and then re-use that across calls to print/println. Note that the
+    //      resolution of this comment will affect all of the prints below as
+    //      well.
     stdout().write(s.as_bytes());
 }
 
@@ -66,6 +69,20 @@ pub fn println(s: &str) {
     let mut out = stdout();
     out.write(s.as_bytes());
     out.write(['\n' as u8]);
+}
+
+/// Similar to `print`, but takes a `fmt::Arguments` structure to be compatible
+/// with the `format_args!` macro.
+pub fn print_args(fmt: &fmt::Arguments) {
+    let mut out = stdout();
+    fmt::write(&mut out as &mut Writer, fmt);
+}
+
+/// Similar to `println`, but takes a `fmt::Arguments` structure to be
+/// compatible with the `format_args!` macro.
+pub fn println_args(fmt: &fmt::Arguments) {
+    let mut out = stdout();
+    fmt::writeln(&mut out as &mut Writer, fmt);
 }
 
 /// Representation of a reader of a standard input stream

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -999,16 +999,11 @@ pub fn std_macros() -> @str {
     macro_rules! writeln(($dst:expr, $($arg:tt)*) => (
         format_args!(|args| { ::std::fmt::writeln($dst, args) }, $($arg)*)
     ))
-    // FIXME(#6846) once stdio is redesigned, this shouldn't perform an
-    //              allocation but should rather delegate to an invocation of
-    //              write! instead of format!
     macro_rules! print (
-        ($($arg:tt)*) => (::std::io::print(format!($($arg)*)))
+        ($($arg:tt)*) => (format_args!(::std::rt::io::stdio::print_args, $($arg)*))
     )
-    // FIXME(#6846) once stdio is redesigned, this shouldn't perform an
-    //              allocation but should rather delegate to an io::Writer
     macro_rules! println (
-        ($($arg:tt)*) => (::std::io::println(format!($($arg)*)))
+        ($($arg:tt)*) => (format_args!(::std::rt::io::stdio::println_args, $($arg)*))
     )
 
     macro_rules! local_data_key (


### PR DESCRIPTION
Instead use format_args! to pass around a struct to pass along into std::fmt
