### PR TITLE
Use updated local declaration syntax for xfail'd test

### DIFF
--- a/src/test/run-pass/deriving-self-lifetime-totalord-totaleq.rs
+++ b/src/test/run-pass/deriving-self-lifetime-totalord-totaleq.rs
@@ -1,5 +1,3 @@
-// xfail-test FIXME #6257
-
 // Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -16,9 +14,8 @@ use std::cmp::{Less,Equal,Greater};
 struct A<'self> {
     x: &'self int
 }
-
 fn main() {
-    let a = A { x: &1 }, b = A { x: &2 };
+    let (a, b) = (A { x: &1 }, A { x: &2 });
 
     assert!(a.equals(&a));
     assert!(b.equals(&b));

--- a/src/test/run-pass/deriving-self-lifetime-totalord-totaleq.rs
+++ b/src/test/run-pass/deriving-self-lifetime-totalord-totaleq.rs
@@ -14,7 +14,7 @@ use std::cmp::{Less,Equal,Greater};
 struct A<'self> {
     x: &'self int
 }
-fn main() {
+pub fn main() {
     let (a, b) = (A { x: &1 }, A { x: &2 });
 
     assert!(a.equals(&a));


### PR DESCRIPTION
This patch is trivial, but it comes with a question. Does Mozilla need to own the copyright on code submitted to Rust?

The reason I ask is that, since the last time I submitted anything to a Mozilla project, I started working at Google, and they (by default) own the copyright on code that I write (even in my spare time). There's a process to assign copyright to another entity, and it should be a formality for something like this, but I'd still have to go through it if that's a requirement for Rust.

Anyway, I'm submitting this incredibly trivial thing because, if I have to go through that process for the first time, I'd like it to be for something that's trivial, so I can see how much of a hassle it is (if any) without having invested much time up front.

I didn't see anything about copyright in the Mozilla contributor's agreement, but I could have easily missed something somewhere else.
