### PR TITLE
support for GNU configure syntax

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -70,22 +70,22 @@ include config.mk
 ALL_OBJ_FILES :=
 
 MKFILE_DEPS := config.stamp $(call rwildcard,$(CFG_SRC_DIR)mk/,*)
-NON_BUILD_HOST_TRIPLES = $(filter-out $(CFG_BUILD_TRIPLE),$(CFG_HOST_TRIPLES))
-NON_BUILD_TARGET_TRIPLES = $(filter-out $(CFG_BUILD_TRIPLE),$(CFG_TARGET_TRIPLES))
+NON_BUILD_HOST = $(filter-out $(CFG_BUILD),$(CFG_HOST))
+NON_BUILD_TARGET = $(filter-out $(CFG_BUILD),$(CFG_TARGET))
 
 ifneq ($(MAKE_RESTARTS),)
 CFG_INFO := $(info cfg: make restarts: $(MAKE_RESTARTS))
 endif
 
-CFG_INFO := $(info cfg: build triple $(CFG_BUILD_TRIPLE))
-CFG_INFO := $(info cfg: host triples $(CFG_HOST_TRIPLES))
-CFG_INFO := $(info cfg: target triples $(CFG_TARGET_TRIPLES))
+CFG_INFO := $(info cfg: build triple $(CFG_BUILD))
+CFG_INFO := $(info cfg: host triples $(CFG_HOST))
+CFG_INFO := $(info cfg: target triples $(CFG_TARGET))
 
-ifneq ($(wildcard $(NON_BUILD_HOST_TRIPLES)),)
-CFG_INFO := $(info cfg: non-build host triples $(NON_BUILD_HOST_TRIPLES))
+ifneq ($(wildcard $(NON_BUILD_HOST)),)
+CFG_INFO := $(info cfg: non-build host triples $(NON_BUILD_HOST))
 endif
-ifneq ($(wildcard $(NON_BUILD_TARGET_TRIPLES)),)
-CFG_INFO := $(info cfg: non-build target triples $(NON_BUILD_TARGET_TRIPLES))
+ifneq ($(wildcard $(NON_BUILD_TARGET)),)
+CFG_INFO := $(info cfg: non-build target triples $(NON_BUILD_TARGET))
 endif
 
 CFG_RUSTC_FLAGS := $(RUSTFLAGS)
@@ -189,7 +189,7 @@ S := $(CFG_SRC_DIR)
 define DEF_X
 X_$(1) := $(CFG_EXE_SUFFIX_$(1))
 endef
-$(foreach target,$(CFG_TARGET_TRIPLES),\
+$(foreach target,$(CFG_TARGET),\
   $(eval $(call DEF_X,$(target))))
 
 # Look in doc and src dirs.
@@ -270,7 +270,7 @@ define LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
 endef
 endif
 
-$(foreach target,$(CFG_TARGET_TRIPLES),\
+$(foreach target,$(CFG_TARGET),\
   $(eval $(call DEF_LIBS,$(target))))
 
 ######################################################################
@@ -336,7 +336,7 @@ LLC_$(1)=$$(CFG_LLVM_INST_DIR_$(1))/bin/llc$$(X_$(1))
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
  $(eval $(call DEF_LLVM_VARS,$(host))))
 
 ######################################################################
@@ -350,7 +350,7 @@ export CFG_SRC_DIR
 export CFG_BUILD_DIR
 export CFG_VERSION
 export CFG_VERSION_WIN
-export CFG_BUILD_TRIPLE
+export CFG_BUILD
 export CFG_LLVM_ROOT
 export CFG_ENABLE_MINGW_CROSS
 export CFG_PREFIX
@@ -465,7 +465,7 @@ CFGFLAG$(1)_T_$(2)_H_$(3) = stage$(1)
 # if you're building a cross config, the host->* parts are
 # effectively stage1, since it uses the just-built stage0.
 ifeq ($(1),0)
-ifneq ($(strip $(CFG_BUILD_TRIPLE)),$(strip $(3)))
+ifneq ($(strip $(CFG_BUILD)),$(strip $(3)))
 CFGFLAG$(1)_T_$(2)_H_$(3) = stage1
 endif
 endif
@@ -488,8 +488,8 @@ PERF_STAGE$(1)_T_$(2)_H_$(3) := 				\
 
 endef
 
-$(foreach build,$(CFG_HOST_TRIPLES), \
- $(eval $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach build,$(CFG_HOST), \
+ $(eval $(foreach target,$(CFG_TARGET), \
   $(eval $(foreach stage,$(STAGES), \
    $(eval $(call SREQ,$(stage),$(target),$(build))))))))
 
@@ -504,18 +504,18 @@ define DEF_RUSTC_STAGE_TARGET
 # $(2) == stage
 
 rustc-stage$(2)-H-$(1):							\
-	$$(foreach target,$$(CFG_TARGET_TRIPLES),	\
+	$$(foreach target,$$(CFG_TARGET),	\
 		$$(SREQ$(2)_T_$$(target)_H_$(1)))
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES),							\
+$(foreach host,$(CFG_HOST),							\
  $(eval $(foreach stage,1 2 3,									\
   $(eval $(call DEF_RUSTC_STAGE_TARGET,$(host),$(stage))))))
 
-rustc-stage1: rustc-stage1-H-$(CFG_BUILD_TRIPLE)
-rustc-stage2: rustc-stage2-H-$(CFG_BUILD_TRIPLE)
-rustc-stage3: rustc-stage3-H-$(CFG_BUILD_TRIPLE)
+rustc-stage1: rustc-stage1-H-$(CFG_BUILD)
+rustc-stage2: rustc-stage2-H-$(CFG_BUILD)
+rustc-stage3: rustc-stage3-H-$(CFG_BUILD)
 
 define DEF_RUSTC_TARGET
 # $(1) == architecture
@@ -523,15 +523,15 @@ define DEF_RUSTC_TARGET
 rustc-H-$(1): rustc-stage2-H-$(1)
 endef
 
-$(foreach host,$(CFG_TARGET_TRIPLES),			\
+$(foreach host,$(CFG_TARGET),			\
  $(eval $(call DEF_RUSTC_TARGET,$(host))))
 
-rustc-stage1: rustc-stage1-H-$(CFG_BUILD_TRIPLE)
-rustc-stage2: rustc-stage2-H-$(CFG_BUILD_TRIPLE)
-rustc-stage3: rustc-stage3-H-$(CFG_BUILD_TRIPLE)
-rustc: rustc-H-$(CFG_BUILD_TRIPLE)
+rustc-stage1: rustc-stage1-H-$(CFG_BUILD)
+rustc-stage2: rustc-stage2-H-$(CFG_BUILD)
+rustc-stage3: rustc-stage3-H-$(CFG_BUILD)
+rustc: rustc-H-$(CFG_BUILD)
 
-rustc-H-all: $(foreach host,$(CFG_HOST_TRIPLES),rustc-H-$(host))
+rustc-H-all: $(foreach host,$(CFG_HOST),rustc-H-$(host))
 
 ######################################################################
 # Entrypoint rule
@@ -547,12 +547,12 @@ CFG_INFO := $(info cfg: *** stage2 and later will not be built ***)
 CFG_INFO := $(info cfg:)
 
 #XXX This is surely busted
-all: $(SREQ1$(CFG_BUILD_TRIPLE)) $(GENERATED) docs
+all: $(SREQ1$(CFG_BUILD)) $(GENERATED) docs
 
 else
 
 define ALL_TARGET_N
-ifneq ($$(findstring $(1),$$(CFG_HOST_TRIPLES)),)
+ifneq ($$(findstring $(1),$$(CFG_HOST)),)
 # This is a host
 all-target-$(1)-host-$(2): $$(CSREQ2_T_$(1)_H_$(2))
 else
@@ -561,12 +561,12 @@ all-target-$(1)-host-$(2): $$(SREQ2_T_$(1)_H_$(2))
 endif
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES), \
- $(foreach host,$(CFG_HOST_TRIPLES), \
+$(foreach target,$(CFG_TARGET), \
+ $(foreach host,$(CFG_HOST), \
  $(eval $(call ALL_TARGET_N,$(target),$(host)))))
 
-ALL_TARGET_RULES = $(foreach target,$(CFG_TARGET_TRIPLES), \
-	$(foreach host,$(CFG_HOST_TRIPLES), \
+ALL_TARGET_RULES = $(foreach target,$(CFG_TARGET), \
+	$(foreach host,$(CFG_HOST), \
  all-target-$(target)-host-$(host)))
 
 all: $(ALL_TARGET_RULES) $(GENERATED) docs

--- a/configure
+++ b/configure
@@ -336,7 +336,7 @@ then
 fi
 
 
-DEFAULT_BUILD_TRIPLE="${CFG_CPUTYPE}-${CFG_OSTYPE}"
+DEFAULT_BUILD="${CFG_CPUTYPE}-${CFG_OSTYPE}"
 
 CFG_SRC_DIR="$(cd $(dirname $0) && pwd)/"
 CFG_BUILD_DIR="$(pwd)/"
@@ -385,11 +385,24 @@ opt pax-flags 0 "apply PaX flags to rustc binaries (required for GRSecurity/PaX-
 valopt prefix "/usr/local" "set installation prefix"
 valopt local-rust-root "/usr/local" "set prefix for local rust binary"
 valopt llvm-root "" "set LLVM root"
-valopt build-triple "${DEFAULT_BUILD_TRIPLE}" "LLVM build triple"
-valopt host-triples "${CFG_BUILD_TRIPLE}" "LLVM host triples"
-valopt target-triples "${CFG_HOST_TRIPLES}" "LLVM target triples"
 valopt android-cross-path "/opt/ndk_standalone" "Android NDK standalone path"
 valopt mingw32-cross-path "" "MinGW32 cross compiler path"
+
+valopt build "${DEFAULT_BUILD}" "GNUs ./configure syntax LLVM build triple"
+valopt host "${CFG_BUILD}" "GNUs ./configure syntax LLVM host triples"
+valopt target "${CFG_HOST}" "GNUs ./configure syntax LLVM target triples"
+
+valopt localstatedir "/var/lib" "local state directory"
+valopt sysconfdir "/etc" "install system configuration files"
+valopt datadir "/usr/share" "install data"
+valopt infodir "/usr/share/info" "install additional info"
+valopt mandir "/usr/share/man" "install man pages in PATH"
+valopt libdir "/usr/lib" "install libraries"
+
+#Deprecated opts to keep compatibility
+valopt build-triple "${DEFAULT_BUILD}" "LLVM build triple"
+valopt host-triples "${CFG_BUILD}" "LLVM host triples"
+valopt target-triples "${CFG_HOST}" "LLVM target triples"
 
 # Validate Options
 step_msg "validating $CFG_SELF args"
@@ -589,23 +602,24 @@ fi
 # a little post-processing of various config values
 
 CFG_PREFIX=${CFG_PREFIX%/}
-CFG_HOST_TRIPLES="$(echo $CFG_HOST_TRIPLES | tr ',' ' ')"
-CFG_TARGET_TRIPLES="$(echo $CFG_TARGET_TRIPLES | tr ',' ' ')"
-CFG_SUPPORTED_TARGET_TRIPLES="$(grep ^CC_*=* $CFG_SRC_DIR/mk/platform.mk | sed -e 's/^CC_//' -e 's/\([^=]*\).*/\1/' | xargs)"
+CFG_MANDIR=${CFG_MANDIR%/}
+CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"
+CFG_TARGET="$(echo $CFG_TARGET | tr ',' ' ')"
+CFG_SUPPORTED_TARGET="$(grep ^CC_*=* $CFG_SRC_DIR/mk/platform.mk | sed -e 's/^CC_//' -e 's/\([^=]*\).*/\1/' | xargs)"
 
 # copy host-triples to target-triples so that hosts are a subset of targets
 V_TEMP=""
-for i in $CFG_HOST_TRIPLES $CFG_TARGET_TRIPLES;
+for i in $CFG_HOST $CFG_TARGET;
 do
    echo "$V_TEMP" | grep -qF $i || V_TEMP="$V_TEMP${V_TEMP:+ }$i"
 done
-CFG_TARGET_TRIPLES=$V_TEMP
+CFG_TARGET=$V_TEMP
 
 # check target-specific tool-chains
-for i in $CFG_TARGET_TRIPLES
+for i in $CFG_TARGET
 do
     L_CHECK=false
-    for j in $CFG_SUPPORTED_TARGET_TRIPLES
+    for j in $CFG_SUPPORTED_TARGET
     do
         if [ $i = $j ]
         then
@@ -664,17 +678,17 @@ do
     make_dir $i
 done
 
-for t in $CFG_HOST_TRIPLES
+for t in $CFG_HOST
 do
     make_dir $t/llvm
 done
 
-for t in $CFG_HOST_TRIPLES
+for t in $CFG_HOST
 do
     make_dir $t/rustllvm
 done
 
-for t in $CFG_TARGET_TRIPLES
+for t in $CFG_TARGET
 do
   make_dir $t/rt
   for s in 0 1 2 3
@@ -703,9 +717,9 @@ then
     CFG_LIBDIR=bin
 fi
 
-for h in $CFG_HOST_TRIPLES
+for h in $CFG_HOST_
 do
-    for t in $CFG_TARGET_TRIPLES
+    for t in $CFG_TARGET
     do
         for i in 0 1 2 3
         do
@@ -785,7 +799,7 @@ fi
 # Configure llvm, only if necessary
 step_msg "looking at LLVM"
 CFG_LLVM_SRC_DIR=${CFG_SRC_DIR}src/llvm/
-for t in $CFG_HOST_TRIPLES
+for t in $CFG_HOST
 do
     do_reconfigure=1
 
@@ -961,14 +975,29 @@ putvar CFG_OSTYPE
 putvar CFG_CPUTYPE
 putvar CFG_CONFIGURE_ARGS
 putvar CFG_PREFIX
-putvar CFG_BUILD_TRIPLE
-putvar CFG_HOST_TRIPLES
-putvar CFG_TARGET_TRIPLES
+putvar CFG_BUILD
+putvar CFG_HOST
+putvar CFG_TARGET
 putvar CFG_C_COMPILER
 putvar CFG_LIBDIR
 putvar CFG_DISABLE_MANAGE_SUBMODULES
 putvar CFG_ANDROID_CROSS_PATH
 putvar CFG_MINGW32_CROSS_PATH
+putvar CFG_MANDIR
+
+# Support for deprecated syntax, should be dropped.
+putvar CFG_BUILD_TRIPLE
+putvar CFG_HOST_TRIPLES
+putvar CFG_TARGET_TRIPLES
+if [ ! -z "$CFG_BUILD_TRIPLE" ]; then
+    CFG_BUILD=${CFG_BUILD_TRIPLE}
+fi
+if [ ! -z "$CFG_HOST_TRIPLES" ]; then
+    CFG_HOST=${CFG_HOST_TRIPLES}
+fi
+if [ ! -z "$CFG_TARGET_TRIPLES" ]; then
+    CFG_TARGET=${CFG_TARGET_TRIPLES}
+fi
 
 if [ ! -z "$CFG_ENABLE_PAX_FLAGS" ]
 then
@@ -1015,7 +1044,7 @@ fi
 putvar CFG_LLVM_ROOT
 putvar CFG_LLVM_SRC_DIR
 
-for t in $CFG_HOST_TRIPLES
+for t in $CFG_HOST
 do
     CFG_LLVM_BUILD_DIR=$(echo CFG_LLVM_BUILD_DIR_${t} | tr - _)
     CFG_LLVM_INST_DIR=$(echo CFG_LLVM_INST_DIR_${t} | tr - _)

--- a/configure
+++ b/configure
@@ -394,10 +394,11 @@ valopt target "${CFG_HOST}" "GNUs ./configure syntax LLVM target triples"
 
 valopt localstatedir "/var/lib" "local state directory"
 valopt sysconfdir "/etc" "install system configuration files"
-valopt datadir "/usr/share" "install data"
-valopt infodir "/usr/share/info" "install additional info"
-valopt mandir "/usr/share/man" "install man pages in PATH"
-valopt libdir "/usr/lib" "install libraries"
+
+valopt datadir "${CFG_PREFIX}/share" "install data"
+valopt infodir "${CFG_PREFIX}/share/info" "install additional info"
+valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
+valopt libdir "${CFG_PREFIX}/lib" "install libraries" 
 
 #Deprecated opts to keep compatibility
 valopt build-triple "${DEFAULT_BUILD}" "LLVM build triple"

--- a/configure
+++ b/configure
@@ -616,6 +616,26 @@ do
 done
 CFG_TARGET=$V_TEMP
 
+# copy host-triples to target-triples so that hosts are a subset of targets
+# XXX: remove deprecated variables here
+V_TEMP=""
+for i in $CFG_HOST_TRIPLES $CFG_TARGET_TRIPLES;
+do
+   echo "$V_TEMP" | grep -qF $i || V_TEMP="$V_TEMP${V_TEMP:+ }$i"
+done
+CFG_TARGET_TRIPLES=$V_TEMP
+
+# XXX: Support for deprecated syntax, should be dropped.
+if [ ! -z "$CFG_BUILD_TRIPLE" ]; then
+    CFG_BUILD=${CFG_BUILD_TRIPLE}
+fi
+if [ ! -z "$CFG_HOST_TRIPLES" ]; then
+    CFG_HOST=${CFG_HOST_TRIPLES}
+fi
+if [ ! -z "$CFG_TARGET_TRIPLES" ]; then
+    CFG_TARGET=${CFG_TARGET_TRIPLES}
+fi
+
 # check target-specific tool-chains
 for i in $CFG_TARGET
 do
@@ -718,7 +738,7 @@ then
     CFG_LIBDIR=bin
 fi
 
-for h in $CFG_HOST_
+for h in $CFG_HOST
 do
     for t in $CFG_TARGET
     do
@@ -985,26 +1005,6 @@ putvar CFG_DISABLE_MANAGE_SUBMODULES
 putvar CFG_ANDROID_CROSS_PATH
 putvar CFG_MINGW32_CROSS_PATH
 putvar CFG_MANDIR
-
-# Support for deprecated syntax, should be dropped.
-putvar CFG_BUILD_TRIPLE
-putvar CFG_HOST_TRIPLES
-putvar CFG_TARGET_TRIPLES
-if [ ! -z "$CFG_BUILD_TRIPLE" ]; then
-    CFG_BUILD=${CFG_BUILD_TRIPLE}
-fi
-if [ ! -z "$CFG_HOST_TRIPLES" ]; then
-    CFG_HOST=${CFG_HOST_TRIPLES}
-fi
-if [ ! -z "$CFG_TARGET_TRIPLES" ]; then
-    CFG_TARGET=${CFG_TARGET_TRIPLES}
-fi
-
-if [ ! -z "$CFG_ENABLE_PAX_FLAGS" ]
-then
-    putvar CFG_ENABLE_PAX_FLAGS
-    putvar CFG_PAXCTL
-fi
 
 # Avoid spurious warnings from clang by feeding it original source on
 # ccache-miss rather than preprocessed input.

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -14,13 +14,13 @@
 
 CLEAN_STAGE_RULES =								\
  $(foreach stage, $(STAGES),					\
-  $(foreach host, $(CFG_HOST_TRIPLES),		\
+  $(foreach host, $(CFG_HOST),		\
    clean$(stage)_H_$(host)						\
-   $(foreach target, $(CFG_TARGET_TRIPLES),		\
+   $(foreach target, $(CFG_TARGET),		\
     clean$(stage)_T_$(target)_H_$(host))))
 
 CLEAN_LLVM_RULES = 								\
- $(foreach target, $(CFG_HOST_TRIPLES),		\
+ $(foreach target, $(CFG_HOST),		\
   clean-llvm$(target))
 
 .PHONY: clean clean-all clean-misc clean-llvm
@@ -33,9 +33,9 @@ clean: clean-misc $(CLEAN_STAGE_RULES)
 
 clean-misc:
 	@$(call E, cleaning)
-	$(Q)find $(CFG_BUILD_TRIPLE)/rustllvm \
-	         $(CFG_BUILD_TRIPLE)/rt \
-		 $(CFG_BUILD_TRIPLE)/test \
+	$(Q)find $(CFG_BUILD)/rustllvm \
+	         $(CFG_BUILD)/rt \
+		 $(CFG_BUILD)/test \
          -name '*.[odasS]' -o \
          -name '*.so' -o      \
          -name '*.dylib' -o   \
@@ -43,7 +43,7 @@ clean-misc:
          -name '*.def' -o     \
          -name '*.bc'         \
          | xargs rm -f
-	$(Q)find $(CFG_BUILD_TRIPLE)\
+	$(Q)find $(CFG_BUILD)\
          -name '*.dSYM'       \
          | xargs rm -Rf
 	$(Q)rm -f $(RUNTIME_OBJS) $(RUNTIME_DEF)
@@ -86,7 +86,7 @@ clean$(1)_H_$(2):
 
 endef
 
-$(foreach host, $(CFG_HOST_TRIPLES), \
+$(foreach host, $(CFG_HOST), \
  $(eval $(foreach stage, $(STAGES), \
   $(eval $(call CLEAN_HOST_STAGE_N,$(stage),$(host))))))
 
@@ -118,8 +118,8 @@ clean$(1)_T_$(2)_H_$(3):
 	$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/run_pass_stage* # For windows
 endef
 
-$(foreach host, $(CFG_HOST_TRIPLES), \
- $(eval $(foreach target, $(CFG_TARGET_TRIPLES), \
+$(foreach host, $(CFG_HOST), \
+ $(eval $(foreach target, $(CFG_TARGET), \
   $(eval $(foreach stage, 0 1 2 3, \
    $(eval $(call CLEAN_TARGET_STAGE_N,$(stage),$(target),$(host))))))))
 
@@ -133,5 +133,5 @@ clean-llvm$(1): ;
 endif
 endef
 
-$(foreach host, $(CFG_HOST_TRIPLES), \
+$(foreach host, $(CFG_HOST), \
  $(eval $(call DEF_CLEAN_LLVM_HOST,$(host))))

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -57,7 +57,7 @@ LICENSE.txt: $(S)COPYRIGHT $(S)LICENSE-APACHE $(S)LICENSE-MIT
 	cp $< $@
 
 $(PKG_EXE): rust.iss modpath.iss LICENSE.txt rust-logo.ico \
-            $(PKG_FILES) $(CSREQ3_T_$(CFG_BUILD_TRIPLE)_H_$(CFG_BUILD_TRIPLE))
+            $(PKG_FILES) $(CSREQ3_T_$(CFG_BUILD)_H_$(CFG_BUILD))
 	$(CFG_PYTHON) $(S)src/etc/copy-runtime-deps.py i686-pc-mingw32/stage3/bin
 	@$(call E, ISCC: $@)
 	$(Q)"$(CFG_ISCC)" $<
@@ -84,7 +84,7 @@ $(PKG_TAR): $(PKG_FILES)
 
 .PHONY: dist distcheck
 
-ifdef CFG_WINDOWSY_$(CFG_BUILD_TRIPLE)
+ifdef CFG_WINDOWSY_$(CFG_BUILD)
 
 dist: $(PKG_EXE)
 

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -235,7 +235,7 @@ endif
 ######################################################################
 
 # The rustdoc executable
-RUSTDOC = $(HBIN2_H_$(CFG_BUILD_TRIPLE))/rustdoc$(X_$(CFG_BUILD_TRIPLE))
+RUSTDOC = $(HBIN2_H_$(CFG_BUILD))/rustdoc$(X_$(CFG_BUILD))
 
 # The library documenting macro
 # $(1) - The crate name (std/extra)
@@ -249,8 +249,8 @@ doc/$(1)/index.html: $$(RUSTDOC) $$(TLIB2_T_$(3)_H_$(3))/$(CFG_STDLIB_$(3))
 DOCS += doc/$(1)/index.html
 endef
 
-$(eval $(call libdoc,std,$(STDLIB_CRATE),$(CFG_BUILD_TRIPLE)))
-$(eval $(call libdoc,extra,$(EXTRALIB_CRATE),$(CFG_BUILD_TRIPLE)))
+$(eval $(call libdoc,std,$(STDLIB_CRATE),$(CFG_BUILD)))
+$(eval $(call libdoc,extra,$(EXTRALIB_CRATE),$(CFG_BUILD)))
 
 
 ifdef CFG_DISABLE_DOCS

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -145,7 +145,7 @@ endif
 
 endef
 
-$(foreach t,$(CFG_HOST_TRIPLES),					\
+$(foreach t,$(CFG_HOST),					\
 	$(eval $(call CP_HOST_STAGE_N,0,1,$(t),$(t)))	\
 	$(eval $(call CP_HOST_STAGE_N,1,2,$(t),$(t)))	\
 	$(eval $(call CP_HOST_STAGE_N,2,3,$(t),$(t))))

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -80,8 +80,8 @@ PTL$(1)$(2) = $$(PTR$(1)$(2))/$(CFG_LIBDIR)
 
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES), \
- $(eval $(call INSTALL_PREPARE_N,$(target),$(CFG_BUILD_TRIPLE))))
+$(foreach target,$(CFG_TARGET), \
+ $(eval $(call INSTALL_PREPARE_N,$(target),$(CFG_BUILD))))
 
 define INSTALL_TARGET_N
 install-target-$(1)-host-$(2): LIB_SOURCE_DIR=$$(TL$(1)$(2))
@@ -112,21 +112,21 @@ install-target-$(1)-host-$(2): $$(CSREQ$$(ISTAGE)_T_$(1)_H_$(2))
 
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES), \
- $(if $(findstring $(target), $(CFG_BUILD_TRIPLE)), \
-  $(eval $(call INSTALL_HOST_N,$(target),$(CFG_BUILD_TRIPLE))), \
-  $(eval $(call INSTALL_TARGET_N,$(target),$(CFG_BUILD_TRIPLE)))))
+$(foreach target,$(CFG_TARGET), \
+ $(if $(findstring $(target), $(CFG_BUILD)), \
+  $(eval $(call INSTALL_HOST_N,$(target),$(CFG_BUILD))), \
+  $(eval $(call INSTALL_TARGET_N,$(target),$(CFG_BUILD)))))
 
-INSTALL_TARGET_RULES = $(foreach target,$(CFG_TARGET_TRIPLES), \
- install-target-$(target)-host-$(CFG_BUILD_TRIPLE))
+INSTALL_TARGET_RULES = $(foreach target,$(CFG_TARGET), \
+ install-target-$(target)-host-$(CFG_BUILD))
 
 install: all install-host install-targets
 
 # Shorthand for build/stageN/bin
-HB = $(HBIN$(ISTAGE)_H_$(CFG_BUILD_TRIPLE))
-HB2 = $(HBIN2_H_$(CFG_BUILD_TRIPLE))
+HB = $(HBIN$(ISTAGE)_H_$(CFG_BUILD))
+HB2 = $(HBIN2_H_$(CFG_BUILD))
 # Shorthand for build/stageN/lib
-HL = $(HLIB$(ISTAGE)_H_$(CFG_BUILD_TRIPLE))
+HL = $(HLIB$(ISTAGE)_H_$(CFG_BUILD))
 # Shorthand for the prefix bin directory
 PHB = $(PREFIX_BIN)
 # Shorthand for the prefix bin directory
@@ -134,24 +134,24 @@ PHL = $(PREFIX_LIB)
 
 install-host: LIB_SOURCE_DIR=$(HL)
 install-host: LIB_DESTIN_DIR=$(PHL)
-install-host: $(CSREQ$(ISTAGE)_T_$(CFG_BUILD_TRIPLE)_H_$(CFG_BUILD_TRIPLE))
+install-host: $(CSREQ$(ISTAGE)_T_$(CFG_BUILD_)_H_$(CFG_BUILD_))
 	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_BIN))
 	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_LIB))
-	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_ROOT)/share/man/man1)
-	$(Q)$(call INSTALL,$(HB2),$(PHB),rustc$(X_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL,$(HB2),$(PHB),rustpkg$(X_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL,$(HB2),$(PHB),rustdoc$(X_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(STDLIB_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(EXTRALIB_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(LIBRUSTC_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(LIBSYNTAX_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(LIBRUSTPKG_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL_LIB,$(LIBRUSTDOC_GLOB_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUNTIME_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUSTLLVM_$(CFG_BUILD_TRIPLE)))
-	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/share/man/man1,rustc.1)
-	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/share/man/man1,rustdoc.1)
-	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/share/man/man1,rustpkg.1)
+	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_ROOT)/$(CFG_MANDIR)/man1)
+	$(Q)$(call INSTALL,$(HB2),$(PHB),rustc$(X_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL,$(HB2),$(PHB),rustpkg$(X_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL,$(HB2),$(PHB),rustdoc$(X_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL_LIB,$(STDLIB_GLOB_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL_LIB,$(EXTRALIB_GLOB_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTC_GLOB_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL_LIB,$(LIBSYNTAX_GLOB_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTPKG_GLOB_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL_LIB,$(LIBRUSTDOC_GLOB_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUNTIME_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUSTLLVM_$(CFG_BUILD_)))
+	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/$(CFG_MANDIR)/man1,rustc.1)
+	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/$(CFG_MANDIR)/man1,rustdoc.1)
+	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/$(CFG_MANDIR)/man1,rustpkg.1)
 
 install-targets: $(INSTALL_TARGET_RULES)
 
@@ -160,25 +160,27 @@ HOST_LIB_FROM_HL_GLOB = \
   $(patsubst $(HL)/%,$(PHL)/%,$(wildcard $(HL)/$(1)))
 
 uninstall:
-	$(Q)rm -f $(PHB)/rustc$(X_$(CFG_BUILD_TRIPLE))
-	$(Q)rm -f $(PHB)/rustpkg$(X_$(CFG_BUILD_TRIPLE))
-	$(Q)rm -f $(PHB)/rustdoc$(X_$(CFG_BUILD_TRIPLE))
-	$(Q)rm -f $(PHL)/$(CFG_RUSTLLVM_$(CFG_BUILD_TRIPLE))
-	$(Q)rm -f $(PHL)/$(CFG_RUNTIME_$(CFG_BUILD_TRIPLE))
+	$(Q)rm -f $(PHB)/rustc$(X_$(CFG_BUILD))
+	$(Q)rm -f $(PHB)/rustpkg$(X_$(CFG_BUILD))
+	$(Q)rm -f $(PHB)/rustdoc$(X_$(CFG_BUILD))
+	$(Q)rm -f $(PHL)/$(CFG_RUSTLLVM_$(CFG_BUILD))
+	$(Q)rm -f $(PHL)/$(CFG_RUNTIME_$(CFG_BUILD))
 	$(Q)for i in \
-          $(call HOST_LIB_FROM_HL_GLOB,$(STDLIB_GLOB_$(CFG_BUILD_TRIPLE))) \
-          $(call HOST_LIB_FROM_HL_GLOB,$(EXTRALIB_GLOB_$(CFG_BUILD_TRIPLE))) \
-          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTC_GLOB_$(CFG_BUILD_TRIPLE))) \
-          $(call HOST_LIB_FROM_HL_GLOB,$(LIBSYNTAX_GLOB_$(CFG_BUILD_TRIPLE))) \
-          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTPKG_GLOB_$(CFG_BUILD_TRIPLE))) \
-          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTDOC_GLOB_$(CFG_BUILD_TRIPLE))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(STDLIB_GLOB_$(CFG_BUILD))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(EXTRALIB_GLOB_$(CFG_BUILD))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTC_GLOB_$(CFG_BUILD))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(LIBSYNTAX_GLOB_$(CFG_BUILD))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTPKG_GLOB_$(CFG_BUILD))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTDOC_GLOB_$(CFG_BUILD))) \
+          $(call HOST_LIB_FROM_HL_GLOB,$(LIBRUSTI_GLOB_$(CFG_BUILD))) \
         ; \
         do rm -f $$i ; \
         done
 	$(Q)rm -Rf $(PHL)/rustc
-	$(Q)rm -f $(PREFIX_ROOT)/share/man/man1/rustc.1
-	$(Q)rm -f $(PREFIX_ROOT)/share/man/man1/rustdoc.1
-	$(Q)rm -f $(PREFIX_ROOT)/share/man/man1/rustpkg.1
+	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rustc.1
+	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rustdoc.1
+	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rusti.1
+	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rustpkg.1
 
 # target platform specific variables
 # for arm-linux-androidabi
@@ -186,7 +188,7 @@ define DEF_ADB_DEVICE_STATUS
 CFG_ADB_DEVICE_STATUS=$(1)
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach target,$(CFG_TARGET), \
   $(if $(findstring $(target),"arm-linux-androideabi"), \
     $(if $(findstring adb,$(CFG_ADB)), \
       $(if $(findstring device,$(shell $(CFG_ADB) devices 2>/dev/null | grep -E '^[_A-Za-z0-9-]+[[:blank:]]+device')), \
@@ -240,12 +242,12 @@ install-runtime-target-$(1)-cleanup:
 	$(Q)$(call ADB_SHELL,rm,$(CFG_RUNTIME_PUSH_DIR)/$(EXTRALIB_GLOB_$(1)))
 endef
 
-$(eval $(call INSTALL_RUNTIME_TARGET_N,arm-linux-androideabi,$(CFG_BUILD_TRIPLE)))
+$(eval $(call INSTALL_RUNTIME_TARGET_N,arm-linux-androideabi,$(CFG_BUILD)))
 $(eval $(call INSTALL_RUNTIME_TARGET_CLEANUP_N,arm-linux-androideabi))
 
 install-runtime-target: \
 	install-runtime-target-arm-linux-androideabi-cleanup \
-	install-runtime-target-arm-linux-androideabi-host-$(CFG_BUILD_TRIPLE)
+	install-runtime-target-arm-linux-androideabi-host-$(CFG_BUILD)
 else
 install-runtime-target:
 	@echo "No device to install runtime library"

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -137,7 +137,7 @@ install-host: LIB_DESTIN_DIR=$(PHL)
 install-host: $(CSREQ$(ISTAGE)_T_$(CFG_BUILD_)_H_$(CFG_BUILD_))
 	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_BIN))
 	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_LIB))
-	$(Q)$(call MK_INSTALL_DIR,$(PREFIX_ROOT)/$(CFG_MANDIR)/man1)
+	$(Q)$(call MK_INSTALL_DIR,$(CFG_MANDIR)/man1)
 	$(Q)$(call INSTALL,$(HB2),$(PHB),rustc$(X_$(CFG_BUILD_)))
 	$(Q)$(call INSTALL,$(HB2),$(PHB),rustpkg$(X_$(CFG_BUILD_)))
 	$(Q)$(call INSTALL,$(HB2),$(PHB),rustdoc$(X_$(CFG_BUILD_)))
@@ -149,9 +149,9 @@ install-host: $(CSREQ$(ISTAGE)_T_$(CFG_BUILD_)_H_$(CFG_BUILD_))
 	$(Q)$(call INSTALL_LIB,$(LIBRUSTDOC_GLOB_$(CFG_BUILD_)))
 	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUNTIME_$(CFG_BUILD_)))
 	$(Q)$(call INSTALL,$(HL),$(PHL),$(CFG_RUSTLLVM_$(CFG_BUILD_)))
-	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/$(CFG_MANDIR)/man1,rustc.1)
-	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/$(CFG_MANDIR)/man1,rustdoc.1)
-	$(Q)$(call INSTALL,$(S)/man, $(PREFIX_ROOT)/$(CFG_MANDIR)/man1,rustpkg.1)
+	$(Q)$(call INSTALL,$(S)/man, $(CFG_MANDIR)/man1,rustc.1)
+	$(Q)$(call INSTALL,$(S)/man, $(CFG_MANDIR)/man1,rustdoc.1)
+	$(Q)$(call INSTALL,$(S)/man, $(CFG_MANDIR)/man1,rustpkg.1)
 
 install-targets: $(INSTALL_TARGET_RULES)
 
@@ -177,10 +177,10 @@ uninstall:
         do rm -f $$i ; \
         done
 	$(Q)rm -Rf $(PHL)/rustc
-	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rustc.1
-	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rustdoc.1
-	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rusti.1
-	$(Q)rm -f $(PREFIX_ROOT)/$(CFG_MANDIR)/man1/rustpkg.1
+	$(Q)rm -f $(CFG_MANDIR)/man1/rustc.1
+	$(Q)rm -f $(CFG_MANDIR)/man1/rustdoc.1
+	$(Q)rm -f $(CFG_MANDIR)/man1/rusti.1
+	$(Q)rm -f $(CFG_MANDIR)/man1/rustpkg.1
 
 # target platform specific variables
 # for arm-linux-androidabi

--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -42,5 +42,5 @@ $$(LLVM_STAMP_$(1)): $(S)src/rustllvm/llvm-auto-clean-trigger
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
  $(eval $(call DEF_LLVM_RULES,$(host))))

--- a/mk/perf.mk
+++ b/mk/perf.mk
@@ -10,16 +10,16 @@
 
 
 ifdef CFG_PERF_TOOL
-rustc-perf$(X): $(CFG_BUILD_TRIPLE)/stage2/bin/rustc$(X_$(CFG_BUILD_TRIPLE))
+rustc-perf$(X): $(CFG_BUILD)/stage2/bin/rustc$(X_$(CFG_BUILD))
 	@$(call E, perf compile: $@)
-	$(PERF_STAGE2_T_$(CFG_BUILD_TRIPLE)_H_$(CFG_BUILD_TRIPLE)) \
+	$(PERF_STAGE2_T_$(CFG_BUILD)_H_$(CFG_BUILD)) \
 		 -o $@ $(COMPILER_CRATE) >rustc-perf.err 2>&1
 	$(Q)rm -f $(LIBRUSTC_GLOB)
 else
-rustc-perf$(X): $(CFG_BUILD_TRIPLE)/stage2/bin/rustc$(X_$(CFG_BUILD_TRIPLE))
+rustc-perf$(X): $(CFG_BUILD)/stage2/bin/rustc$(X_$(CFG_BUILD))
 	$(Q)touch $@
 endif
 
-perf: check-stage2-perf rustc-perf$(X_$(CFG_BUILD_TRIPLE))
-	$(Q)find $(CFG_BUILD_TRIPLE)/test/perf -name \*.err | xargs cat
+perf: check-stage2-perf rustc-perf$(X_$(CFG_BUILD))
+	$(Q)find $(CFG_BUILD)/test/perf -name \*.err | xargs cat
 	$(Q)cat rustc-perf.err

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -16,15 +16,15 @@
 define DEF_HOST_VAR
   HOST_$(1) = $(subst i686,i386,$(word 1,$(subst -, ,$(1))))
 endef
-$(foreach t,$(CFG_TARGET_TRIPLES),$(eval $(call DEF_HOST_VAR,$(t))))
-$(foreach t,$(CFG_TARGET_TRIPLES),$(info cfg: host for $(t) is $(HOST_$(t))))
+$(foreach t,$(CFG_TARGET),$(eval $(call DEF_HOST_VAR,$(t))))
+$(foreach t,$(CFG_TARGET),$(info cfg: host for $(t) is $(HOST_$(t))))
 
 # Ditto for OSTYPE
 define DEF_OSTYPE_VAR
   OSTYPE_$(1) = $(subst $(firstword $(subst -, ,$(1)))-,,$(1))
 endef
-$(foreach t,$(CFG_TARGET_TRIPLES),$(eval $(call DEF_OSTYPE_VAR,$(t))))
-$(foreach t,$(CFG_TARGET_TRIPLES),$(info cfg: os for $(t) is $(OSTYPE_$(t))))
+$(foreach t,$(CFG_TARGET),$(eval $(call DEF_OSTYPE_VAR,$(t))))
+$(foreach t,$(CFG_TARGET),$(info cfg: os for $(t) is $(OSTYPE_$(t))))
 
 # FIXME: no-omit-frame-pointer is just so that task_start_wrapper
 # has a frame pointer and the stack walker can understand it. Turning off
@@ -378,7 +378,7 @@ CFG_UNIXY_i686-pc-mingw32 :=
 CFG_PATH_MUNGE_i686-pc-mingw32 :=
 CFG_LDPATH_i686-pc-mingw32 :=$(CFG_LDPATH_i686-pc-mingw32):$(PATH)
 CFG_RUN_i686-pc-mingw32=PATH="$(CFG_LDPATH_i686-pc-mingw32):$(1)" $(2)
-CFG_RUN_TARG_i686-pc-mingw32=$(call CFG_RUN_i686-pc-mingw32,$(HLIB$(1)_H_$(CFG_BUILD_TRIPLE)),$(2))
+CFG_RUN_TARG_i686-pc-mingw32=$(call CFG_RUN_i686-pc-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
 
 # i586-mingw32msvc configuration
 CC_i586-mingw32msvc=$(CFG_MINGW32_CROSS_PATH)/bin/i586-mingw32msvc-gcc
@@ -432,7 +432,7 @@ CFG_UNIXY_x86_64-w64-mingw32 :=
 CFG_PATH_MUNGE_x86_64-w64-mingw32 :=
 CFG_LDPATH_x86_64-w64-mingw32 :=$(CFG_LDPATH_x86_64-w64-mingw32):$(PATH)
 CFG_RUN_x86_64-w64-mingw32=PATH="$(CFG_LDPATH_x86_64-w64-mingw32):$(1)" $(2)
-CFG_RUN_TARG_x86_64-w64-mingw32=$(call CFG_RUN_x86_64-w64-mingw32,$(HLIB$(1)_H_$(CFG_BUILD_TRIPLE)),$(2))
+CFG_RUN_TARG_x86_64-w64-mingw32=$(call CFG_RUN_x86_64-w64-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
 
 # x86_64-unknown-freebsd configuration
 CC_x86_64-unknown-freebsd=$(CC)
@@ -498,7 +498,7 @@ define CFG_MAKE_TOOLCHAIN
   # We're using llvm-mc as our assembler because it supports
   # .cfi pseudo-ops on mac
   CFG_ASSEMBLE_$(1)=$$(CPP_$(1)) -E $$(CFG_DEPEND_FLAGS) $$(2) | \
-                    $$(LLVM_MC_$$(CFG_BUILD_TRIPLE)) \
+                    $$(LLVM_MC_$$(CFG_BUILD)) \
                     -assemble \
                     -filetype=obj \
                     -triple=$(1) \
@@ -514,5 +514,5 @@ define CFG_MAKE_TOOLCHAIN
 
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES),\
+$(foreach target,$(CFG_TARGET),\
   $(eval $(call CFG_MAKE_TOOLCHAIN,$(target))))

--- a/mk/pp.mk
+++ b/mk/pp.mk
@@ -24,10 +24,10 @@ else
                        "no-reformat\|xfail-pretty\|xfail-test")
 endif
 
-reformat: $(SREQ1$(CFG_BUILD_TRIPLE))
+reformat: $(SREQ1$(CFG_BUILD))
 	@$(call E, reformat [stage1]: $@)
 	for i in $(PP_INPUTS_FILTERED);  \
-    do $(call CFG_RUN_TARG_$(CFG_BUILD_TRIPLE),1,$(CFG_BUILD_TRIPLE)/stage1/rustc$(X_$(CFG_BUILD_TRIPLE))) \
+    do $(call CFG_RUN_TARG_$(CFG_BUILD),1,$(CFG_BUILD)/stage1/rustc$(X_$(CFG_BUILD))) \
        --pretty normal $$i >$$i.tmp; \
     if [ $$? -ne 0 ]; \
         then echo failed to print $$i; rm $$i.tmp; \

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -44,7 +44,7 @@ endif
 define DEF_LIBUV_ARCH_VAR
   LIBUV_ARCH_$(1) = $$(subst i386,ia32,$$(subst x86_64,x64,$$(HOST_$(1))))
 endef
-$(foreach t,$(CFG_TARGET_TRIPLES),$(eval $(call DEF_LIBUV_ARCH_VAR,$(t))))
+$(foreach t,$(CFG_TARGET),$(eval $(call DEF_LIBUV_ARCH_VAR,$(t))))
 
 ifdef CFG_ENABLE_FAST_MAKE
 LIBUV_DEPS := $(S)/.gitmodules
@@ -76,7 +76,7 @@ RUNTIME_CXXFLAGS_$(1)_$(2) = -D_RUST_STAGE$(2)
 # XXX: Like with --cfg stage0, pass the defines for stage1 to the stage0
 # build of non-build-triple host compilers
 ifeq ($(2),0)
-ifneq ($(strip $(CFG_BUILD_TRIPLE)),$(strip $(1)))
+ifneq ($(strip $(CFG_BUILD)),$(strip $(1)))
 RUNTIME_CFLAGS_$(1)_$(2) = -D_RUST_STAGE1
 RUNTIME_CXXFLAGS_$(1)_$(2) = -D_RUST_STAGE1
 endif
@@ -131,7 +131,7 @@ $$(RT_BUILD_DIR_$(1)_$(2))/%.o: rt/%.c $$(MKFILE_DEPS)
                  $$(SNAP_DEFINES) $$(RUNTIME_CFLAGS_$(1)_$(2))) $$<
 
 $$(RT_BUILD_DIR_$(1)_$(2))/%.o: rt/%.S  $$(MKFILE_DEPS) \
-                     $$(LLVM_CONFIG_$$(CFG_BUILD_TRIPLE))
+                     $$(LLVM_CONFIG_$$(CFG_BUILD))
 	@$$(call E, compile: $$@)
 	$$(Q)$$(call CFG_ASSEMBLE_$(1),$$@,$$<)
 
@@ -242,12 +242,11 @@ $$(LIBUV_LIB_$(1)): $$(LIBUV_DEPS) $$(LIBUV_MAKEFILE_$(1))
 		NO_LOAD="$$(LIBUV_NO_LOAD)" \
 		V=$$(VERBOSE)
 endif
-
 endef
 
 # Instantiate template for all stages/targets
-$(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach target,$(CFG_TARGET), \
      $(eval $(call DEF_THIRD_PARTY_TARGETS,$(target))))
 $(foreach stage,$(STAGES), \
-    $(foreach target,$(CFG_TARGET_TRIPLES), \
+    $(foreach target,$(CFG_TARGET), \
 	 $(eval $(call DEF_RUNTIME_TARGETS,$(target),$(stage)))))

--- a/mk/rustllvm.mk
+++ b/mk/rustllvm.mk
@@ -46,5 +46,5 @@ $(1)/rustllvm/%.o: rustllvm/%.cpp $$(MKFILE_DEPS) $$(LLVM_CONFIG_$(1))
 endef
 
 # Instantiate template for all stages
-$(foreach host,$(CFG_HOST_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
  $(eval $(call DEF_RUSTLLVM_TARGETS,$(host))))

--- a/mk/snap.mk
+++ b/mk/snap.mk
@@ -17,12 +17,12 @@ snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES),						\
+$(foreach host,$(CFG_HOST),						\
  $(eval $(foreach stage,1 2 3,								\
   $(eval $(call DEF_SNAP_FOR_STAGE_H,$(stage),$(host))))))
 
-snap-stage1: snap-stage1-H-$(CFG_BUILD_TRIPLE)
+snap-stage1: snap-stage1-H-$(CFG_BUILD)
 
-snap-stage2: snap-stage2-H-$(CFG_BUILD_TRIPLE)
+snap-stage2: snap-stage2-H-$(CFG_BUILD)
 
-snap-stage3: snap-stage3-H-$(CFG_BUILD_TRIPLE)
+snap-stage3: snap-stage3-H-$(CFG_BUILD)

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -1,23 +1,23 @@
 # Extract the snapshot host compiler
 
-$(HBIN0_H_$(CFG_BUILD_TRIPLE))/:
+$(HBIN0_H_$(CFG_BUILD))/:
 	mkdir -p $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/:
+$(HLIB0_H_$(CFG_BUILD))/:
 	mkdir -p $@
 
 $(SNAPSHOT_RUSTC_POST_CLEANUP):						\
 		$(S)src/snapshots.txt					\
 		$(S)src/etc/get-snapshot.py $(MKFILE_DEPS)		\
-		| $(HBIN0_H_$(CFG_BUILD_TRIPLE))/
+		| $(HBIN0_H_$(CFG_BUILD))/
 
 	@$(call E, fetch: $@)
 #   Note: the variable "SNAPSHOT_FILE" is generally not set, and so
 #   we generally only pass one argument to this script.
 ifdef CFG_ENABLE_LOCAL_RUST
-	$(Q)$(S)src/etc/local_stage0.sh $(CFG_BUILD_TRIPLE) $(CFG_LOCAL_RUST_ROOT)
+	$(Q)$(S)src/etc/local_stage0.sh $(CFG_BUILD) $(CFG_LOCAL_RUST_ROOT)
 else
-	$(Q)$(CFG_PYTHON) $(S)src/etc/get-snapshot.py $(CFG_BUILD_TRIPLE) $(SNAPSHOT_FILE)
+	$(Q)$(CFG_PYTHON) $(S)src/etc/get-snapshot.py $(CFG_BUILD) $(SNAPSHOT_FILE)
 ifdef CFG_ENABLE_PAX_FLAGS
 	@$(call E, apply PaX flags: $@)
 	@"$(CFG_PAXCTL)" -cm "$@"
@@ -27,29 +27,29 @@ endif
 
 # Host libs will be extracted by the above rule
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_RUNTIME_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_RUNTIME_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_STDLIB_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_STDLIB_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_EXTRALIB_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_EXTRALIB_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_LIBRUSTC_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_LIBRUSTC_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_RUSTLLVM_$(CFG_BUILD_TRIPLE)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_RUSTLLVM_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
 # For other targets, let the host build the target:
@@ -111,5 +111,5 @@ endef
 
 # Use stage1 to build other architectures: then you don't have to wait
 # for stage2, but you get the latest updates to the compiler source.
-$(foreach t,$(NON_BUILD_HOST_TRIPLES),								\
- $(eval $(call BOOTSTRAP_STAGE0,$(t),1,$(CFG_BUILD_TRIPLE))))
+$(foreach t,$(NON_BUILD_HOSTS),								\
+ $(eval $(call BOOTSTRAP_STAGE0,$(t),1,$(CFG_BUILD))))

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -11,7 +11,7 @@
 # This is the compile-time target-triple for the compiler. For the compiler at
 # runtime, this should be considered the host-triple. More explanation for why
 # this exists can be found on issue #2400
-export CFG_COMPILER_TRIPLE
+export CFG_COMPILER
 
 # The standard libraries should be held up to a higher standard than any old
 # code, make sure that these common warnings are denied by default. These can
@@ -36,7 +36,7 @@ WFLAGS_ST2 = -D warnings
 # had its chance to clean it out; otherwise the other products will be
 # inadvertantly included in the clean out.
 
-SNAPSHOT_RUSTC_POST_CLEANUP=$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD_TRIPLE))
+SNAPSHOT_RUSTC_POST_CLEANUP=$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD))
 
 define TARGET_STAGE_N
 
@@ -85,7 +85,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBSYNTAX_$(3)): \
 	$$(call LIST_ALL_OLD_GLOB_MATCHES_EXCEPT,$$(dir $$@),$(LIBSYNTAX_GLOB_$(2)),$$(notdir $$@))
 
 # Only build the compiler for host triples
-ifneq ($$(findstring $(2),$$(CFG_HOST_TRIPLES)),)
+ifneq ($$(findstring $(2),$$(CFG_HOST)),)
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUSTLLVM_$(3)): \
 		$(2)/rustllvm/$(CFG_RUSTLLVM_$(3)) \
@@ -94,7 +94,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUSTLLVM_$(3)): \
 	@$$(call E, cp: $$@)
 	$$(Q)cp $$< $$@
 
-$$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)): CFG_COMPILER_TRIPLE = $(2)
+$$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)): CFG_COMPILER = $(2)
 $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_LIBRUSTC_$(3)):		\
 		$$(COMPILER_CRATE) $$(COMPILER_INPUTS)		\
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
@@ -131,8 +131,8 @@ endif
 endef
 
 # In principle, each host can build each target:
-$(foreach source,$(CFG_HOST_TRIPLES),				\
- $(foreach target,$(CFG_TARGET_TRIPLES),			\
+$(foreach source,$(CFG_HOST),				\
+ $(foreach target,$(CFG_TARGET),			\
   $(eval $(call TARGET_STAGE_N,0,$(target),$(source)))		\
   $(eval $(call TARGET_STAGE_N,1,$(target),$(source)))		\
   $(eval $(call TARGET_STAGE_N,2,$(target),$(source)))		\

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -107,20 +107,20 @@ ifdef CFG_WINDOWSY_$(1)
                stage2/$$(CFG_LIBDIR), \
                $$(if $$(findstring stage3,$$(1)), \
                     stage3/$$(CFG_LIBDIR), \
-               )))))/rustc/$$(CFG_BUILD_TRIPLE)/$$(CFG_LIBDIR)
+               )))))/rustc/$$(CFG_BUILD)/$$(CFG_LIBDIR)
   CFG_RUN_TEST_$(1)=$$(call CFG_RUN_$(1),$$(call CFG_TESTLIB_$(1),$$(1),$$(3)),$$(1))
 endif
 
 # Run the compiletest runner itself under valgrind
 ifdef CTEST_VALGRIND
-CFG_RUN_CTEST_$(1)=$$(call CFG_RUN_TEST_$$(CFG_BUILD_TRIPLE),$$(2),$$(3))
+CFG_RUN_CTEST_$(1)=$$(call CFG_RUN_TEST_$$(CFG_BUILD),$$(2),$$(3))
 else
-CFG_RUN_CTEST_$(1)=$$(call CFG_RUN_$$(CFG_BUILD_TRIPLE),$$(TLIB$$(1)_T_$$(3)_H_$$(3)),$$(2))
+CFG_RUN_CTEST_$(1)=$$(call CFG_RUN_$$(CFG_BUILD),$$(TLIB$$(1)_T_$$(3)_H_$$(3)),$$(2))
 endif
 
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach target,$(CFG_TARGET), \
   $(eval $(call DEF_TARGET_COMMANDS,$(target))))
 
 # Target platform specific variables
@@ -129,7 +129,7 @@ define DEF_ADB_DEVICE_STATUS
 CFG_ADB_DEVICE_STATUS=$(1)
 endef
 
-$(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach target,$(CFG_TARGET), \
   $(if $(findstring $(target),"arm-linux-androideabi"), \
     $(if $(findstring adb,$(CFG_ADB)), \
       $(if $(findstring device,$(shell $(CFG_ADB) devices 2>/dev/null | grep -E '^[_A-Za-z0-9-]+[[:blank:]]+device')), \
@@ -158,11 +158,11 @@ $(info check: android device test dir $(CFG_ADB_TEST_DIR) ready \
  $(shell adb push $(S)src/etc/adb_run_wrapper.sh $(CFG_ADB_TEST_DIR) 1>/dev/null) \
  $(shell adb push $(CFG_ANDROID_CROSS_PATH)/arm-linux-androideabi/lib/armv7-a/libgnustl_shared.so \
                   $(CFG_ADB_TEST_DIR) 1>/dev/null) \
- $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD_TRIPLE))/$(CFG_RUNTIME_arm-linux-androideabi) \
+ $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD))/$(CFG_RUNTIME_arm-linux-androideabi) \
                   $(CFG_ADB_TEST_DIR)) \
- $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD_TRIPLE))/$(STDLIB_GLOB_arm-linux-androideabi) \
+ $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD))/$(STDLIB_GLOB_arm-linux-androideabi) \
                   $(CFG_ADB_TEST_DIR)) \
- $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD_TRIPLE))/$(EXTRALIB_GLOB_arm-linux-androideabi) \
+ $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD))/$(EXTRALIB_GLOB_arm-linux-androideabi) \
                   $(CFG_ADB_TEST_DIR)) \
  )
 else
@@ -199,7 +199,7 @@ cleantmptestlogs:
 	$(Q)rm -f tmp/*.log
 
 cleantestlibs:
-	$(Q)find $(CFG_BUILD_TRIPLE)/test \
+	$(Q)find $(CFG_BUILD)/test \
          -name '*.[odasS]' -o \
          -name '*.so' -o      \
          -name '*.dylib' -o   \
@@ -290,7 +290,7 @@ check-stage$(1)-T-$(2)-H-$(3)-exec:     				\
 
 # Only test the compiler-dependent crates when the target is
 # able to build a compiler (when the target triple is in the set of host triples)
-ifneq ($$(findstring $(2),$$(CFG_HOST_TRIPLES)),)
+ifneq ($$(findstring $(2),$$(CFG_HOST)),)
 
 check-stage$(1)-T-$(2)-H-$(3)-crates-exec: \
 	$$(foreach crate,$$(TEST_CRATES), \
@@ -317,8 +317,8 @@ check-stage$(1)-T-$(2)-H-$(3)-pretty-exec: \
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
   $(foreach stage,$(STAGES), \
     $(eval $(call DEF_TEST_SETS,$(stage),$(target),$(host))))))
 
@@ -356,7 +356,7 @@ $(3)/stage$(1)/test/syntaxtest-$(2)$$(X_$(2)):			\
 	@$$(call E, compile_and_link: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test
 
-$(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)): CFG_COMPILER_TRIPLE = $(2)
+$(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)): CFG_COMPILER = $(2)
 $(3)/stage$(1)/test/rustctest-$(2)$$(X_$(2)):					\
 		$$(COMPILER_CRATE) $$(COMPILER_INPUTS) \
 		$$(SREQ$(1)_T_$(2)_H_$(3)) \
@@ -386,8 +386,8 @@ $(3)/stage$(1)/test/rustdoctest-$(2)$$(X_$(2)):					\
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(eval $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(eval $(foreach target,$(CFG_TARGET), \
   $(eval $(foreach stage,$(STAGES), \
    $(eval $(call TEST_RUNNER,$(stage),$(target),$(host))))))))
 
@@ -441,11 +441,11 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 	@touch $$@
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
   $(foreach stage,$(STAGES), \
    $(foreach crate, $(TEST_CRATES), \
-    $(if $(findstring $(target),$(CFG_BUILD_TRIPLE)), \
+    $(if $(findstring $(target),$(CFG_BUILD)), \
      $(eval $(call DEF_TEST_CRATE_RULES,$(stage),$(target),$(host),$(crate))), \
      $(if $(findstring $(target),"arm-linux-androideabi"), \
       $(if $(findstring $(CFG_ADB_DEVICE_STATUS),"true"), \
@@ -573,7 +573,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3))			\
         --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
         --clang-path $(if $(CFG_CLANG),$(CFG_CLANG),clang) \
-        --llvm-bin-path $(CFG_LLVM_INST_DIR_$(CFG_BUILD_TRIPLE))/bin \
+        --llvm-bin-path $(CFG_LLVM_INST_DIR_$(CFG_BUILD))/bin \
         --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
         --target $(2)                                       \
@@ -593,8 +593,8 @@ CTEST_DEPS_codegen_$(1)-T-$(2)-H-$(3) = $$(CODEGEN_TESTS)
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(eval $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(eval $(foreach target,$(CFG_TARGET), \
   $(eval $(foreach stage,$(STAGES), \
    $(eval $(call DEF_CTEST_VARS,$(stage),$(target),$(host))))))))
 
@@ -636,8 +636,8 @@ endef
 
 CTEST_NAMES = rpass rpass-full rfail cfail bench perf debuginfo codegen
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(eval $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(eval $(foreach target,$(CFG_TARGET), \
   $(eval $(foreach stage,$(STAGES), \
    $(eval $(foreach name,$(CTEST_NAMES), \
    $(eval $(call DEF_RUN_COMPILETEST,$(stage),$(target),$(host),$(name))))))))))
@@ -675,8 +675,8 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
   $(foreach stage,$(STAGES), \
    $(foreach pretty-name,$(PRETTY_NAMES), \
     $(eval $(call DEF_RUN_PRETTY_TEST,$(stage),$(target),$(host),$(pretty-name)))))))
@@ -702,8 +702,8 @@ $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-$(4)): \
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
   $(foreach stage,$(STAGES), \
    $(foreach docname,$(DOC_TEST_NAMES), \
     $(eval $(call DEF_RUN_DOC_TEST,$(stage),$(target),$(host),$(docname)))))))
@@ -724,7 +724,7 @@ doc-$(2)-extract$(1):
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
  $(foreach docname,$(DOC_TEST_NAMES), \
   $(eval $(call DEF_DOC_TEST_HOST,$(host),$(docname)))))
 
@@ -759,8 +759,8 @@ check-stage$(1)-T-$(2)-H-$(3): check-stage$(1)-T-$(2)-H-$(3)-exec
 endef
 
 $(foreach stage,$(STAGES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
-  $(foreach host,$(CFG_HOST_TRIPLES), \
+ $(foreach target,$(CFG_TARGET), \
+  $(foreach host,$(CFG_HOST), \
    $(eval $(call DEF_CHECK_FOR_STAGE_AND_TARGET_AND_HOST,$(stage),$(target),$(host))))))
 
 define DEF_CHECK_FOR_STAGE_AND_TARGET_AND_HOST_AND_GROUP
@@ -768,14 +768,14 @@ check-stage$(1)-T-$(2)-H-$(3)-$(4): check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec
 endef
 
 $(foreach stage,$(STAGES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
-  $(foreach host,$(CFG_HOST_TRIPLES), \
+ $(foreach target,$(CFG_TARGET), \
+  $(foreach host,$(CFG_HOST), \
    $(foreach group,$(TEST_GROUPS), \
     $(eval $(call DEF_CHECK_FOR_STAGE_AND_TARGET_AND_HOST_AND_GROUP,$(stage),$(target),$(host),$(group)))))))
 
 define DEF_CHECK_FOR_STAGE
-check-stage$(1): check-stage$(1)-H-$$(CFG_BUILD_TRIPLE)
-check-stage$(1)-H-all: $$(foreach target,$$(CFG_TARGET_TRIPLES), \
+check-stage$(1): check-stage$(1)-H-$$(CFG_BUILD)
+check-stage$(1)-H-all: $$(foreach target,$$(CFG_TARGET), \
                            check-stage$(1)-H-$$(target))
 endef
 
@@ -783,8 +783,8 @@ $(foreach stage,$(STAGES), \
  $(eval $(call DEF_CHECK_FOR_STAGE,$(stage))))
 
 define DEF_CHECK_FOR_STAGE_AND_GROUP
-check-stage$(1)-$(2): check-stage$(1)-H-$$(CFG_BUILD_TRIPLE)-$(2)
-check-stage$(1)-H-all-$(2): $$(foreach target,$$(CFG_TARGET_TRIPLES), \
+check-stage$(1)-$(2): check-stage$(1)-H-$$(CFG_BUILD)-$(2)
+check-stage$(1)-H-all-$(2): $$(foreach target,$$(CFG_TARGET), \
                                check-stage$(1)-H-$$(target)-$(2))
 endef
 
@@ -794,21 +794,21 @@ $(foreach stage,$(STAGES), \
 
 
 define DEF_CHECK_FOR_STAGE_AND_HOSTS
-check-stage$(1)-H-$(2): $$(foreach target,$$(CFG_TARGET_TRIPLES), \
+check-stage$(1)-H-$(2): $$(foreach target,$$(CFG_TARGET), \
                            check-stage$(1)-T-$$(target)-H-$(2))
 endef
 
 $(foreach stage,$(STAGES), \
- $(foreach host,$(CFG_HOST_TRIPLES), \
+ $(foreach host,$(CFG_HOST), \
   $(eval $(call DEF_CHECK_FOR_STAGE_AND_HOSTS,$(stage),$(host)))))
 
 define DEF_CHECK_FOR_STAGE_AND_HOSTS_AND_GROUP
-check-stage$(1)-H-$(2)-$(3): $$(foreach target,$$(CFG_TARGET_TRIPLES), \
+check-stage$(1)-H-$(2)-$(3): $$(foreach target,$$(CFG_TARGET), \
                                 check-stage$(1)-T-$$(target)-H-$(2)-$(3))
 endef
 
 $(foreach stage,$(STAGES), \
- $(foreach host,$(CFG_HOST_TRIPLES), \
+ $(foreach host,$(CFG_HOST), \
   $(foreach group,$(TEST_GROUPS), \
    $(eval $(call DEF_CHECK_FOR_STAGE_AND_HOSTS_AND_GROUP,$(stage),$(host),$(group))))))
 
@@ -817,7 +817,7 @@ $(foreach stage,$(STAGES), \
 ######################################################################
 
 FT := run_pass_stage2
-FT_LIB := $(call CFG_LIB_NAME_$(CFG_BUILD_TRIPLE),$(FT))
+FT_LIB := $(call CFG_LIB_NAME_$(CFG_BUILD),$(FT))
 FT_DRIVER := $(FT)_driver
 
 GENERATED += tmp/$(FT).rc tmp/$(FT_DRIVER).rs
@@ -857,11 +857,11 @@ check-fast-T-$(2)-H-$(3):     			\
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(eval $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(eval $(foreach target,$(CFG_TARGET), \
    $(eval $(call DEF_CHECK_FAST_FOR_T_H,,$(target),$(host))))))
 
-check-fast: tidy check-fast-H-$(CFG_BUILD_TRIPLE) check-stage2-std check-stage2-extra
+check-fast: tidy check-fast-H-$(CFG_BUILD) check-stage2-std check-stage2-extra
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
 define DEF_CHECK_FAST_FOR_H
@@ -870,5 +870,5 @@ check-fast-H-$(1): 		check-fast-T-$(1)-H-$(1)
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES),			\
+$(foreach host,$(CFG_HOST),			\
  $(eval $(call DEF_CHECK_FAST_FOR_H,$(host))))

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -127,14 +127,14 @@ $$(HBIN$(2)_H_$(4))/rustdoc$$(X_$(4)):				\
 
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES),				\
-$(foreach target,$(CFG_TARGET_TRIPLES),				\
+$(foreach host,$(CFG_HOST),				\
+$(foreach target,$(CFG_TARGET),				\
  $(eval $(call TOOLS_STAGE_N_TARGET,0,1,$(host),$(target)))	\
  $(eval $(call TOOLS_STAGE_N_TARGET,1,2,$(host),$(target)))	\
  $(eval $(call TOOLS_STAGE_N_TARGET,2,3,$(host),$(target)))	\
  $(eval $(call TOOLS_STAGE_N_TARGET,3,bogus,$(host),$(target)))))
 
-$(foreach host,$(CFG_HOST_TRIPLES),				\
+$(foreach host,$(CFG_HOST),				\
  $(eval $(call TOOLS_STAGE_N_HOST,0,1,$(host),$(host)))	\
  $(eval $(call TOOLS_STAGE_N_HOST,1,2,$(host),$(host)))	\
  $(eval $(call TOOLS_STAGE_N_HOST,2,3,$(host),$(host))))

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -643,7 +643,7 @@ pub fn host_triple() -> ~str {
     // Instead of grabbing the host triple (for the current host), we grab (at
     // compile time) the target triple that this rustc is built with and
     // calling that (at runtime) the host triple.
-    (env!("CFG_COMPILER_TRIPLE")).to_owned()
+    (env!("CFG_COMPILER")).to_owned()
 }
 
 pub fn build_session_options(binary: @str,


### PR DESCRIPTION
Re-created: https://github.com/mozilla/rust/pull/9760

Now, without adding `pc-linux-gnu` platform

Re-created: #9565

t will be useful for unix systems, some package managers and external tools that is passing / maybe looking for GNU configure syntax options.

One of related bugs: #5138

Also that could be useful in future if project will really install man pages / other stuff using those variables.
