### PR TITLE
Add a feature flag for ASM

### DIFF
--- a/src/test/compile-fail/asm-gated.rs
+++ b/src/test/compile-fail/asm-gated.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-test
+
+fn main() {
+    unsafe {
+        asm!(""); //~ ERROR inline assembly is not stable enough
+    }
+}


### PR DESCRIPTION
Fixes #9882
Note that the actual checking code is inside a if false in order to compile libstd properly.
libstd uses asm! in rt. If we put `#[feature(asm)]` in libstd, it fails to build at stage0 beacause the
asm feature is not known yet by the snapshot compiler.
We must wait that this PR arrives into the snapshot in order to actually activate the checking code.
