### PR TITLE
Remove rusti reference from pp.mk

### DIFF
--- a/mk/pp.mk
+++ b/mk/pp.mk
@@ -1,4 +1,4 @@
-# Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+# Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.
 #
@@ -18,7 +18,6 @@ else
               $(wildcard $(S)src/test/*/*.rs    \
                          $(S)src/test/*/*/*.rs) \
               $(wildcard $(S)src/rustpkg/*.rs) \
-              $(wildcard $(S)src/rusti/*.rs) \
               $(wildcard $(S)src/rust/*.rs)
 
   PP_INPUTS_FILTERED = $(shell echo $(PP_INPUTS) | xargs grep -L \


### PR DESCRIPTION
It seems like rusti has been removed, except for one reference in one Makefile. This reference breaks building rust on my computer because the "all-target" rule has rusti as a target.

```
make: *** No rule to make target `x86_64-unknown-linux-gnu/stage2/bin/rusti', needed by `all-target-x86_64-unknown-linux-gnu-host-x86_64-unknown-linux-gnu'.  Stop.
```

Removing this line fixes things for me.
