### PR TITLE
Documentation updates - Remove reference to 'rust' tool in Tutorial

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -3168,7 +3168,7 @@ Raw pointers (`*`)
   : Raw pointers are pointers without safety or liveness guarantees.
     Raw pointers are written `*content`,
     for example `*int` means a raw pointer to an integer.
-    Copying or dropping a raw pointer is has no effect on the lifecycle of any other value.
+    Copying or dropping a raw pointer has no effect on the lifecycle of any other value.
     Dereferencing a raw pointer or converting it to any other pointer type is an [`unsafe` operation](#unsafe-functions).
     Raw pointers are generally discouraged in Rust code;
     they exist to support interoperability with foreign code,

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -151,22 +151,6 @@ declaration to appear at the top level of the file: all statements must
 live inside a function.  Rust programs can also be compiled as
 libraries, and included in other programs.
 
-## Using the rust tool
-
-While using `rustc` directly to generate your executables, and then
-running them manually is a perfectly valid way to test your code,
-for smaller projects, prototypes, or if you're a beginner, it might be
-more convenient to use the `rust` tool.
-
-The `rust` tool provides central access to the other rust tools,
-as well as handy shortcuts for directly running source files.
-For example, if you have a file `foo.rs` in your current directory,
-`rust run foo.rs` would attempt to compile it and, if successful,
-directly run the resulting binary.
-
-To get a list of all available commands, simply call `rust` without any
-argument.
-
 ## Editing Rust code
 
 There are vim highlighting and indentation scripts in the Rust source

--- a/src/libstd/rt/io/mod.rs
+++ b/src/libstd/rt/io/mod.rs
@@ -12,8 +12,8 @@
 
 This module defines the Rust interface for synchronous I/O.
 It models byte-oriented input and output with the Reader and Writer traits.
-Types that implement both `Reader` and `Writer` and called 'streams',
-and automatically implement trait `Stream`.
+Types that implement both `Reader` and `Writer` are called 'streams',
+and automatically implement the `Stream` trait.
 Implementations are provided for common I/O streams like
 file, TCP, UDP, Unix domain sockets.
 Readers and Writers may be composed to add capabilities like string


### PR DESCRIPTION
I'm planning on doing more updates, but the section in the tutorial stood out at me since the 'rust' tool no longer exists, this should probably be removed to lessen confusion.
