### PR TITLE
Fire fewer homing missiles

### DIFF
--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -330,6 +330,12 @@ impl Scheduler {
                 this.process_task(task, Scheduler::resume_task_immediately_cl);
                 return None;
             }
+            Some(RunOnce(task)) => {
+                // bypass the process_task logic to force running this task once
+                // on this home scheduler. This is often used for I/O (homing).
+                Scheduler::resume_task_immediately_cl(this, task);
+                return None;
+            }
             Some(Wake) => {
                 this.sleepy = false;
                 Local::put(this);
@@ -789,7 +795,8 @@ pub enum SchedMessage {
     Wake,
     Shutdown,
     PinnedTask(~Task),
-    TaskFromFriend(~Task)
+    TaskFromFriend(~Task),
+    RunOnce(~Task),
 }
 
 pub struct SchedHandle {


### PR DESCRIPTION
This optimizes the `home_for_io` code path by requiring fewer scheduler
operations in some situtations.

When moving to your home scheduler, this no longer forces a context switch if
you're already on the home scheduler. Instead, the homing code now simply pins
you to your current scheduler (making it so you can't be stolen away). If you're
not on your home scheduler, then we context switch away, sending you to your
home scheduler.

When the I/O operation is done, then we also no longer forcibly trigger a
context switch. Instead, the action is cased on whether the task is homed or
not. If a task does not have a home, then the task is re-flagged as not having a
home and no context switch is performed. If a task is homed to the current
scheduler, then we don't do anything, and if the task is homed to a foreign
scheduler, then it's sent along its merry way.

I verified that there are about a third as many `write` syscalls done in print
operations now. Libuv uses write to implement async handles, and the homing
before and after each I/O operation was triggering a write on these async
handles. Additionally, using the terrible benchmark of printing 10k times in a
loop, this drives the runtime from 0.6s down to 0.3s (yay!).
