### PR TITLE
Remove the extension traits for Readers/Writers

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -23,7 +23,7 @@ use util::logv;
 use std::cell::Cell;
 use std::rt::io;
 use std::rt::io::Writer;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::rt::io::file::FileInfo;
 use std::os;
 use std::str;

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -22,7 +22,6 @@ use std::f64;
 use std::hashmap::HashMap;
 use std::rt::io;
 use std::rt::io::Decorator;
-use std::rt::io::extensions::ReaderUtil;
 use std::rt::io::mem::MemWriter;
 use std::num;
 use std::str;
@@ -843,7 +842,7 @@ impl<T : Iterator<char>> Parser<T> {
 }
 
 /// Decodes a json value from an `&mut io::Reader`
-pub fn from_reader(mut rdr: &mut io::Reader) -> Result<Json, Error> {
+pub fn from_reader(rdr: &mut io::Reader) -> Result<Json, Error> {
     let s = str::from_utf8(rdr.read_to_end());
     let mut parser = Parser(~s.iter());
     parser.parse()

--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -16,7 +16,6 @@
 use std::{vec, str};
 use std::hashmap::HashMap;
 use std::rt::io;
-use std::rt::io::extensions::{ReaderByteConversions, ReaderUtil};
 use super::super::TermInfo;
 
 // These are the orders ncurses uses in its compiled format (as of 5.9). Not sure if portable.
@@ -161,7 +160,7 @@ pub static stringnames: &'static[&'static str] = &'static[ "cbt", "_", "cr", "cs
     "box1"];
 
 /// Parse a compiled terminfo entry, using long capability names if `longnames` is true
-pub fn parse(mut file: &mut io::Reader,
+pub fn parse(file: &mut io::Reader,
              longnames: bool) -> Result<~TermInfo, ~str> {
     let bnames;
     let snames;
@@ -178,17 +177,17 @@ pub fn parse(mut file: &mut io::Reader,
     }
 
     // Check magic number
-    let magic = file.read_le_u16_();
+    let magic = file.read_le_u16();
     if (magic != 0x011A) {
         return Err(format!("invalid magic number: expected {:x} but found {:x}",
                            0x011A, magic as uint));
     }
 
-    let names_bytes          = file.read_le_i16_() as int;
-    let bools_bytes          = file.read_le_i16_() as int;
-    let numbers_count        = file.read_le_i16_() as int;
-    let string_offsets_count = file.read_le_i16_() as int;
-    let string_table_bytes   = file.read_le_i16_() as int;
+    let names_bytes          = file.read_le_i16() as int;
+    let bools_bytes          = file.read_le_i16() as int;
+    let numbers_count        = file.read_le_i16() as int;
+    let string_offsets_count = file.read_le_i16() as int;
+    let string_table_bytes   = file.read_le_i16() as int;
 
     assert!(names_bytes          > 0);
 
@@ -247,7 +246,7 @@ pub fn parse(mut file: &mut io::Reader,
     let mut numbers_map = HashMap::new();
     if numbers_count != 0 {
         for i in range(0, numbers_count) {
-            let n = file.read_le_u16_();
+            let n = file.read_le_u16();
             if n != 0xFFFF {
                 debug!("{}\\#{}", nnames[i], n);
                 numbers_map.insert(nnames[i].to_owned(), n);
@@ -262,7 +261,7 @@ pub fn parse(mut file: &mut io::Reader,
     if string_offsets_count != 0 {
         let mut string_offsets = vec::with_capacity(10);
         for _ in range(0, string_offsets_count) {
-            string_offsets.push(file.read_le_u16_());
+            string_offsets.push(file.read_le_u16());
         }
 
         debug!("offsets: {:?}", string_offsets);

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -20,6 +20,7 @@ use std::comm::{PortOne, oneshot};
 use std::{os, str, task};
 use std::rt::io;
 use std::rt::io::Writer;
+use std::rt::io::Reader;
 use std::rt::io::Decorator;
 use std::rt::io::mem::MemWriter;
 use std::rt::io::file::FileInfo;
@@ -481,7 +482,7 @@ impl<'self, T:Send +
 #[test]
 fn test() {
     use std::{os, run};
-    use std::rt::io::ReaderUtil;
+    use std::rt::io::Reader;
     use std::str::from_utf8_owned;
 
     // Create a path to a new file 'filename' in the directory in which

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -22,7 +22,6 @@ use middle::typeck;
 use middle;
 
 use std::hashmap::{HashMap, HashSet};
-use std::rt::io::extensions::WriterByteConversions;
 use std::rt::io::{Writer, Seek, Decorator};
 use std::rt::io::mem::MemWriter;
 use std::str;
@@ -894,11 +893,11 @@ fn encode_info_for_item(ecx: &EncodeContext,
                         vis: ast::visibility) {
     let tcx = ecx.tcx;
 
-    fn add_to_index_(item: @item, ebml_w: &writer::Encoder,
+    fn add_to_index(item: @item, ebml_w: &writer::Encoder,
                      index: @mut ~[entry<i64>]) {
         index.push(entry { val: item.id as i64, pos: ebml_w.writer.tell() });
     }
-    let add_to_index: &fn() = || add_to_index_(item, ebml_w, index);
+    let add_to_index: &fn() = || add_to_index(item, ebml_w, index);
 
     debug!("encoding info for item at {}",
            ecx.tcx.sess.codemap.span_to_str(item.span));
@@ -1411,7 +1410,7 @@ fn encode_index<T:'static>(
             assert!(elt.pos < 0xffff_ffff);
             {
                 let wr: &mut MemWriter = ebml_w.writer;
-                wr.write_be_u32_(elt.pos as u32);
+                wr.write_be_u32(elt.pos as u32);
             }
             write_fn(ebml_w.writer, &elt.val);
             ebml_w.end_tag();
@@ -1423,7 +1422,7 @@ fn encode_index<T:'static>(
     for pos in bucket_locs.iter() {
         assert!(*pos < 0xffff_ffff);
         let wr: &mut MemWriter = ebml_w.writer;
-        wr.write_be_u32_(*pos as u32);
+        wr.write_be_u32(*pos as u32);
     }
     ebml_w.end_tag();
     ebml_w.end_tag();
@@ -1436,7 +1435,7 @@ fn write_str(writer: @mut MemWriter, s: ~str) {
 fn write_i64(writer: @mut MemWriter, &n: &i64) {
     let wr: &mut MemWriter = writer;
     assert!(n < 0x7fff_ffff);
-    wr.write_be_u32_(n as u32);
+    wr.write_be_u32(n as u32);
 }
 
 fn encode_meta_item(ebml_w: &mut writer::Encoder, mi: @MetaItem) {
@@ -1591,14 +1590,14 @@ fn encode_lang_items(ecx: &EncodeContext, ebml_w: &mut writer::Encoder) {
                 ebml_w.start_tag(tag_lang_items_item_id);
                 {
                     let wr: &mut MemWriter = ebml_w.writer;
-                    wr.write_be_u32_(i as u32);
+                    wr.write_be_u32(i as u32);
                 }
                 ebml_w.end_tag();   // tag_lang_items_item_id
 
                 ebml_w.start_tag(tag_lang_items_item_node_id);
                 {
                     let wr: &mut MemWriter = ebml_w.writer;
-                    wr.write_be_u32_(id.node as u32);
+                    wr.write_be_u32(id.node as u32);
                 }
                 ebml_w.end_tag();   // tag_lang_items_item_node_id
 

--- a/src/librustc/rustc.rs
+++ b/src/librustc/rustc.rs
@@ -37,7 +37,7 @@ use middle::lint;
 
 use std::comm;
 use std::rt::io;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::num;
 use std::os;
 use std::result;

--- a/src/librustpkg/workcache_support.rs
+++ b/src/librustpkg/workcache_support.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::rt::io;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::rt::io::file::FileInfo;
 use extra::workcache;
 use sha1::{Digest, Sha1};

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -12,7 +12,6 @@
 
 use option::{Some, None};
 use rt::io::Reader;
-use rt::io::ReaderByteConversions;
 
 use rand::Rng;
 
@@ -51,17 +50,17 @@ impl<R: Reader> Rng for ReaderRng<R> {
         // platform just involves blitting the bytes into the memory
         // of the u32, similarly for BE on BE; avoiding byteswapping.
         if cfg!(target_endian="little") {
-            self.reader.read_le_u32_()
+            self.reader.read_le_u32()
         } else {
-            self.reader.read_be_u32_()
+            self.reader.read_be_u32()
         }
     }
     fn next_u64(&mut self) -> u64 {
         // see above for explanation.
         if cfg!(target_endian="little") {
-            self.reader.read_le_u64_()
+            self.reader.read_le_u64()
         } else {
-            self.reader.read_be_u64_()
+            self.reader.read_be_u64()
         }
     }
     fn fill_bytes(&mut self, v: &mut [u8]) {

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -19,7 +19,7 @@ use libc;
 use prelude::*;
 use rt::io::process;
 use rt::io;
-use rt::io::extensions::ReaderUtil;
+use rt::io::Reader;
 use task;
 
 /**

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -20,7 +20,7 @@ use parse::token::{get_ident_interner};
 use print::pprust;
 
 use std::rt::io;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::rt::io::file::FileInfo;
 use std::str;
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -19,7 +19,6 @@ use parse::token;
 use parse::token::{get_ident_interner};
 
 use std::rt::io;
-use std::rt::io::extensions::ReaderUtil;
 use std::str;
 use std::uint;
 
@@ -347,7 +346,7 @@ pub struct lit {
 pub fn gather_comments_and_literals(span_diagnostic:
                                     @mut diagnostic::span_handler,
                                     path: @str,
-                                    mut srdr: &mut io::Reader)
+                                    srdr: &mut io::Reader)
                                  -> (~[cmnt], ~[lit]) {
     let src = str::from_utf8(srdr.read_to_end()).to_managed();
     let cm = CodeMap::new();

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -21,7 +21,7 @@ use parse::parser::Parser;
 
 use std::path::Path;
 use std::rt::io;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::rt::io::file::FileInfo;
 use std::str;
 


### PR DESCRIPTION
These methods are all excellent candidates for default methods, so there's no need to require extra imports of various traits. Additionally, this was able to remove all the weird underscores after the method names. Yay!
