### PR TITLE
Point gyp submodule to github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 	branch = master
 [submodule "src/gyp"]
 	path = src/gyp
-	url = https://git.chromium.org/external/gyp.git
+	url = https://github.com/brson/gyp.git


### PR DESCRIPTION
The upstream repo has been offline for hours. A single point of failure is plenty.
