### PR TITLE
Make the documentation for std::task::spawn_sched render correctly.

### DIFF
--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -488,8 +488,8 @@ pub fn spawn_with<A:Send>(arg: A, f: ~fn(v: A)) {
 
 pub fn spawn_sched(mode: SchedMode, f: ~fn()) {
     /*!
-     * Creates a new task on a new or existing scheduler
-
+     * Creates a new task on a new or existing scheduler.
+     *
      * When there are no more tasks to execute the
      * scheduler terminates.
      *


### PR DESCRIPTION
Currently each line is a separate bullet point in a list: http://static.rust-lang.org/doc/master/std/task/fn.spawn_sched.html
