### PR TITLE
Make process exit status more flexible to allow for handling when a child is terminated by signal

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -11,6 +11,7 @@
 use std::os;
 use std::run;
 use std::str;
+use std::rt::io::process::ProcessExit;
 
 #[cfg(target_os = "win32")]
 fn target_env(lib_path: &str, prog: &str) -> ~[(~str,~str)] {
@@ -39,7 +40,7 @@ fn target_env(_lib_path: &str, _prog: &str) -> ~[(~str,~str)] {
     os::env()
 }
 
-pub struct Result {status: int, out: ~str, err: ~str}
+pub struct Result {status: ProcessExit, out: ~str, err: ~str}
 
 pub fn run(lib_path: &str,
            prog: &str,

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -378,9 +378,8 @@ pub mod write {
 
         let prog = run::process_output(cc_prog, cc_args);
 
-        if prog.status != 0 {
-            sess.err(format!("building with `{}` failed with code {}",
-                        cc_prog, prog.status));
+        if !prog.status.success() {
+            sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
             sess.note(format!("{} arguments: {}",
                         cc_prog, cc_args.connect(" ")));
             sess.note(str::from_utf8(prog.error + prog.output));
@@ -947,11 +946,11 @@ pub fn link_binary(sess: Session,
 
     // We run 'cc' here
     let prog = run::process_output(cc_prog, cc_args);
-    if 0 != prog.status {
-        sess.err(format!("linking with `{}` failed with code {}",
-                      cc_prog, prog.status));
+
+    if !prog.status.success() {
+        sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
         sess.note(format!("{} arguments: {}",
-                       cc_prog, cc_args.connect(" ")));
+                    cc_prog, cc_args.connect(" ")));
         sess.note(str::from_utf8(prog.error + prog.output));
         sess.abort_if_errors();
     }

--- a/src/librustpkg/api.rs
+++ b/src/librustpkg/api.rs
@@ -159,17 +159,16 @@ pub fn build_library_in_workspace(exec: &mut workcache::Exec,
 
     let all_args = flags + absolute_paths + cc_args +
          ~[~"-o", out_name.as_str().unwrap().to_owned()];
-    let exit_code = run::process_status(tool, all_args);
-    if exit_code != 0 {
-        command_failed.raise((tool.to_owned(), all_args, exit_code))
-    }
-    else {
+    let exit_process = run::process_status(tool, all_args);
+    if exit_process.success() {
         let out_name_str = out_name.as_str().unwrap().to_owned();
         exec.discover_output("binary",
                              out_name_str,
                              digest_only_date(&out_name));
         context.add_library_path(out_name.dir_path());
         out_name_str
+    } else {
+        command_failed.raise((tool.to_owned(), all_args, exit_process))
     }
 }
 

--- a/src/librustpkg/conditions.rs
+++ b/src/librustpkg/conditions.rs
@@ -13,6 +13,7 @@
 pub use std::path::Path;
 pub use package_id::PkgId;
 pub use std::rt::io::FileStat;
+pub use std::rt::io::process::ProcessExit;
 
 condition! {
     pub bad_path: (Path, ~str) -> Path;
@@ -57,5 +58,5 @@ condition! {
 condition! {
     // str is output of applying the command (first component)
     // to the args (second component)
-    pub command_failed: (~str, ~[~str], int) -> ~str;
+    pub command_failed: (~str, ~[~str], ProcessExit) -> ~str;
 }

--- a/src/librustpkg/source_control.rs
+++ b/src/librustpkg/source_control.rs
@@ -36,7 +36,7 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
             let outp = run::process_output("git", [~"clone",
                                                    source.as_str().unwrap().to_owned(),
                                                    target.as_str().unwrap().to_owned()]);
-            if outp.status != 0 {
+            if !outp.status.success() {
                 println(str::from_utf8_owned(outp.output.clone()));
                 println(str::from_utf8_owned(outp.error));
                 return DirToUse(target.clone());
@@ -52,7 +52,7 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                             [format!("--work-tree={}", target.as_str().unwrap().to_owned()),
                              format!("--git-dir={}", git_dir.as_str().unwrap().to_owned()),
                              ~"checkout", format!("{}", *s)]);
-                        if outp.status != 0 {
+                        if !outp.status.success() {
                             println(str::from_utf8_owned(outp.output.clone()));
                             println(str::from_utf8_owned(outp.error));
                             return DirToUse(target.clone());
@@ -73,7 +73,7 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                         format!("--git-dir={}", git_dir.as_str().unwrap().to_owned()),
                         ~"pull", ~"--no-edit", source.as_str().unwrap().to_owned()];
             let outp = run::process_output("git", args);
-            assert!(outp.status == 0);
+            assert!(outp.status.success());
         }
         CheckedOutSources
     } else {
@@ -110,7 +110,7 @@ pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
     // FIXME (#9639): This needs to handle non-utf8 paths
     let outp = run::process_output("git", [~"clone", source.to_owned(),
                                            target.as_str().unwrap().to_owned()]);
-    if outp.status != 0 {
+    if !outp.status.success() {
          debug!("{}", str::from_utf8_owned(outp.output.clone()));
          debug!("{}", str::from_utf8_owned(outp.error));
          cond.raise((source.to_owned(), target.clone()))
@@ -120,7 +120,7 @@ pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
             &ExactRevision(ref s) | &Tagged(ref s) => {
                     let outp = process_output_in_cwd("git", [~"checkout", s.to_owned()],
                                                          target);
-                    if outp.status != 0 {
+                    if !outp.status.success() {
                         debug!("{}", str::from_utf8_owned(outp.output.clone()));
                         debug!("{}", str::from_utf8_owned(outp.error));
                         cond.raise((source.to_owned(), target.clone()))

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -109,7 +109,7 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
 
         debug!("git --git-dir={} tag -l ~~~> {:?}", git_dir.display(), outp.status);
 
-        if outp.status != 0 {
+        if !outp.status.success() {
             continue;
         }
 
@@ -143,7 +143,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
         let outp  = run::process_output("git", [~"clone", format!("https://{}",
                                                                   remote_path.as_str().unwrap()),
                                                 tmp_dir.as_str().unwrap().to_owned()]);
-        if outp.status == 0 {
+        if outp.status.success() {
             debug!("Cloned it... ( {}, {} )",
                    str::from_utf8(outp.output),
                    str::from_utf8(outp.error));

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -18,7 +18,7 @@ use c_str::CString;
 use ai = rt::io::net::addrinfo;
 use rt::io::IoError;
 use rt::io::signal::Signum;
-use super::io::process::ProcessConfig;
+use super::io::process::{ProcessConfig, ProcessExit};
 use super::io::net::ip::{IpAddr, SocketAddr};
 use path::Path;
 use super::io::{SeekStyle};
@@ -201,7 +201,7 @@ pub trait RtioFileStream {
 pub trait RtioProcess {
     fn id(&self) -> libc::pid_t;
     fn kill(&mut self, signal: int) -> Result<(), IoError>;
-    fn wait(&mut self) -> int;
+    fn wait(&mut self) -> ProcessExit;
 }
 
 pub trait RtioPipe {

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -1,0 +1,29 @@
+// copyright 2013 the rust project developers. see the copyright
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/copyright.
+//
+// licensed under the apache license, version 2.0 <license-apache or
+// http://www.apache.org/licenses/license-2.0> or the mit license
+// <license-mit or http://opensource.org/licenses/mit>, at your
+// option. this file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+
+use std::{os, run};
+use std::rt::io::process;
+
+fn main() {
+    let args = os::args();
+    if args.len() >= 2 && args[1] == ~"signal" {
+        // Raise a segfault.
+        unsafe { *(0 as *mut int) = 0; }
+    } else {
+        let status = run::process_status(args[0], [~"signal"]);
+        match status {
+            process::ExitSignal(_) => {},
+            _ => fail!("invalid termination (was not signalled): {:?}", status)
+        }
+    }
+}
+


### PR DESCRIPTION
The UvProcess exit callback is called with a zero exit status and non-zero termination signal when a child is terminated by a signal.

If a parent checks only the exit status (for example, only checks the return value from `wait()`), it may believe the process completed successfully when it actually failed.

Helpers for common use-cases are in `std::rt::io::process`.

Should resolve https://github.com/mozilla/rust/issues/10062.
