### PR TITLE
mark bounds check failures as the cold path

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2844,6 +2844,8 @@ pub fn declare_intrinsics(llmod: ModuleRef) -> HashMap<&'static str, ValueRef> {
     ifn!(intrinsics, "llvm.umul.with.overflow.i64",
         [Type::i64(), Type::i64()], Type::struct_([Type::i64(), Type::i1()], false));
 
+    ifn!(intrinsics, "llvm.expect.i1", [Type::i1(), Type::i1()], Type::i1());
+
     return intrinsics;
 }
 

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -981,7 +981,9 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
         debug!("trans_index: len {}", bcx.val_to_str(len));
 
         let bounds_check = ICmp(bcx, lib::llvm::IntUGE, ix_val, len);
-        let bcx = do with_cond(bcx, bounds_check) |bcx| {
+        let expect = ccx.intrinsics.get_copy(&("llvm.expect.i1"));
+        let expected = Call(bcx, expect, [bounds_check, C_i1(false)], []);
+        let bcx = do with_cond(bcx, expected) |bcx| {
             controlflow::trans_fail_bounds_check(bcx, index_expr.span, ix_val, len)
         };
         let elt = InBoundsGEP(bcx, base, [ix_val]);


### PR DESCRIPTION
LLVM is unable to determine this for most cases.

http://llvm-reviews.chandlerc.com/D2034 needs to land upstream before
this is going to have an effect. It's harmless to start generating the
expect hint now.
