### PR TITLE
Made `std::option`and `std::result` more similar

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4560,14 +4560,14 @@ pub fn count_traits_and_supertraits(tcx: ctxt,
 }
 
 pub fn get_tydesc_ty(tcx: ctxt) -> Result<t, ~str> {
-    do tcx.lang_items.require(TyDescStructLangItem).map_move |tydesc_lang_item| {
+    do tcx.lang_items.require(TyDescStructLangItem).map |tydesc_lang_item| {
         tcx.intrinsic_defs.find_copy(&tydesc_lang_item)
             .expect("Failed to resolve TyDesc")
     }
 }
 
 pub fn get_opaque_ty(tcx: ctxt) -> Result<t, ~str> {
-    do tcx.lang_items.require(OpaqueStructLangItem).map_move |opaque_lang_item| {
+    do tcx.lang_items.require(OpaqueStructLangItem).map |opaque_lang_item| {
         tcx.intrinsic_defs.find_copy(&opaque_lang_item)
             .expect("Failed to resolve Opaque")
     }

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -2464,7 +2464,7 @@ fn test_timer_sleep_simple() {
         unsafe {
             let io = local_io();
             let timer = io.timer_init();
-            do timer.map_move |mut t| { t.sleep(1) };
+            do timer.map |mut t| { t.sleep(1) };
         }
     }
 }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -494,7 +494,7 @@ mod tests {
     use super::*;
 
     use result::{IntoResult, ToResult};
-    use result::{Result, Ok, Err};
+    use result::{Ok, Err};
     use str::StrSlice;
     use util;
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -42,11 +42,9 @@ use clone::Clone;
 use clone::DeepClone;
 use cmp::{Eq, TotalEq, TotalOrd};
 use default::Default;
-use either;
 use fmt;
 use iter::{Iterator, DoubleEndedIterator, ExactSize};
 use kinds::Send;
-use num::Zero;
 use result::{IntoResult, ToResult, AsResult};
 use result::{Result, Ok, Err};
 use str::OwnedStr;
@@ -361,17 +359,6 @@ impl<T: Default> Option<T> {
     }
 }
 
-impl<T: Zero> Option<T> {
-    /// Returns the contained value or zero (for this type)
-    #[inline]
-    pub fn unwrap_or_zero(self) -> T {
-        match self {
-            Some(x) => x,
-            None => Zero::zero()
-        }
-    }
-}
-
 /////////////////////////////////////////////////////////////////////////////
 // Constructor extension trait
 /////////////////////////////////////////////////////////////////////////////
@@ -449,26 +436,6 @@ impl<T> AsResult<T, ()> for Option<T> {
     }
 }
 
-impl<T: Clone> either::ToEither<(), T> for Option<T> {
-    #[inline]
-    fn to_either(&self) -> either::Either<(), T> {
-        match *self {
-            Some(ref x) => either::Right(x.clone()),
-            None => either::Left(()),
-        }
-    }
-}
-
-impl<T> either::IntoEither<(), T> for Option<T> {
-    #[inline]
-    fn into_either(self) -> either::Either<(), T> {
-        match self {
-            Some(x) => either::Right(x),
-            None => either::Left(()),
-        }
-    }
-}
-
 impl<T: fmt::Default> fmt::Default for Option<T> {
     #[inline]
     fn fmt(s: &Option<T>, f: &mut fmt::Formatter) {
@@ -526,8 +493,6 @@ impl<A> ExactSize<A> for OptionIterator<A> {}
 mod tests {
     use super::*;
 
-    use either::{IntoEither, ToEither};
-    use either;
     use result::{IntoResult, ToResult};
     use result::{Result, Ok, Err};
     use str::StrSlice;
@@ -697,14 +662,6 @@ mod tests {
     }
 
     #[test]
-    fn test_unwrap_or_zero() {
-        let some_stuff = Some(42);
-        assert_eq!(some_stuff.unwrap_or_zero(), 42);
-        let no_stuff: Option<int> = None;
-        assert_eq!(no_stuff.unwrap_or_zero(), 0);
-    }
-
-    #[test]
     fn test_filtered() {
         let some_stuff = Some(42);
         let modified_stuff = some_stuff.filtered(|&x| {x < 10});
@@ -819,23 +776,5 @@ mod tests {
 
         assert_eq!(some.into_result(), Ok(100));
         assert_eq!(none.into_result(), Err(()));
-    }
-
-    #[test]
-    pub fn test_to_either() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.to_either(), either::Right(100));
-        assert_eq!(none.to_either(), either::Left(()));
-    }
-
-    #[test]
-    pub fn test_into_either() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.into_either(), either::Right(100));
-        assert_eq!(none.into_either(), either::Left(()));
     }
 }

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -415,7 +415,7 @@ mod tests {
 
     use iter::range;
     use option::{IntoOption, ToOption, AsOption};
-    use option::{Option, Some, None};
+    use option::{Some, None};
     use vec::ImmutableVector;
     use to_str::ToStr;
 

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,19 +10,18 @@
 
 //! A type representing either success or failure
 
-#[allow(missing_doc)];
-
+use any::Any;
 use clone::Clone;
 use cmp::Eq;
 use either;
+use fmt;
 use iter::Iterator;
+use kinds::Send;
 use option::{None, Option, Some, OptionIterator};
 use option;
-use vec;
-use vec::OwnedVector;
 use to_str::ToStr;
-use str::StrSlice;
-use fmt;
+use vec::OwnedVector;
+use vec;
 
 /// `Result` is a type that represents either success (`Ok`) or failure (`Err`).
 ///
@@ -37,20 +36,14 @@ pub enum Result<T, E> {
     Err(E)
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// Type implementation
+/////////////////////////////////////////////////////////////////////////////
+
 impl<T, E: ToStr> Result<T, E> {
-    /// Get a reference to the value out of a successful result
-    ///
-    /// # Failure
-    ///
-    /// If the result is an error
-    #[inline]
-    pub fn get_ref<'a>(&'a self) -> &'a T {
-        match *self {
-            Ok(ref t) => t,
-            Err(ref e) => fail!("called `Result::get_ref()` on `Err` value: {}",
-                                 e.to_str()),
-        }
-    }
+    /////////////////////////////////////////////////////////////////////////
+    // Querying the contained values
+    /////////////////////////////////////////////////////////////////////////
 
     /// Returns true if the result is `Ok`
     #[inline]
@@ -67,12 +60,114 @@ impl<T, E: ToStr> Result<T, E> {
         !self.is_ok()
     }
 
-    /// Call a method based on a previous result
+    /////////////////////////////////////////////////////////////////////////
+    // Adapter for working with references
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Convert from `Result<T, E>` to `Result<&T, &E>`
+    #[inline]
+    pub fn as_ref<'r>(&'r self) -> Result<&'r T, &'r E> {
+        match *self {
+            Ok(ref x) => Ok(x),
+            Err(ref x) => Err(x),
+        }
+    }
+
+    /// Convert from `Result<T, E>` to `Result<&mut T, &mut E>`
+    #[inline]
+    pub fn as_mut<'r>(&'r mut self) -> Result<&'r mut T, &'r mut E> {
+        match *self {
+            Ok(ref mut x) => Ok(x),
+            Err(ref mut x) => Err(x),
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    // Getting to contained values
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Unwraps a result, yielding the content of an `Ok`.
+    /// Fails if the value is a `Err` with a custom failure message provided by `msg`.
+    #[inline]
+    pub fn expect<M: Any + Send>(self, msg: M) -> T {
+        match self {
+            Ok(t) => t,
+            Err(_) => fail!(msg),
+        }
+    }
+
+    /// Unwraps a result, yielding the content of an `Err`.
+    /// Fails if the value is a `Ok` with a custom failure message provided by `msg`.
+    #[inline]
+    pub fn expect_err<M: Any + Send>(self, msg: M) -> E {
+        match self {
+            Err(e) => e,
+            Ok(_) => fail!(msg),
+        }
+    }
+
+    /// Unwraps a result, yielding the content of an `Ok`.
+    /// Fails if the value is a `Err` with an error message derived
+    /// from `E`'s `ToStr` implementation.
+    #[inline]
+    pub fn unwrap(self) -> T {
+        match self {
+            Ok(t) => t,
+            Err(e) => fail!("called `Result::unwrap()` on `Err` value '{}'",
+                             e.to_str()),
+        }
+    }
+
+    /// Unwraps a result, yielding the content of an `Err`.
+    /// Fails if the value is a `Ok`.
+    #[inline]
+    pub fn unwrap_err(self) -> E {
+        match self {
+            Ok(_) => fail!("called `Result::unwrap_err()` on an `Ok` value"),
+            Err(e) => e
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    // Transforming contained values
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Maps an `Result<T, E>` to `Result<U, E>` by applying a function to an
+    /// contained `Ok` value, leaving an `Err` value untouched.
     ///
-    /// If `self` is `Ok` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is returned. if `self` is `Err` then it is
-    /// immediately returned. This function can be used to compose the results
-    /// of two functions.
+    /// This function can be used to compose the results of two functions.
+    ///
+    /// Example:
+    ///
+    ///     let res = do read_file(file).map |buf| {
+    ///         parse_bytes(buf)
+    ///     }
+    #[inline]
+    pub fn map<U>(self, op: &fn(T) -> U) -> Result<U,E> {
+        match self {
+          Ok(t) => Ok(op(t)),
+          Err(e) => Err(e)
+        }
+    }
+
+    /// Maps an `Result<T, E>` to `Result<T, F>` by applying a function to an
+    /// contained `Err` value, leaving an `Ok` value untouched.
+    ///
+    /// This function can be used to pass through a successful result while handling
+    /// an error.
+    #[inline]
+    pub fn map_err<F>(self, op: &fn(E) -> F) -> Result<T,F> {
+        match self {
+          Ok(t) => Ok(t),
+          Err(e) => Err(op(e))
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    // Iterator constructors
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Returns an `Iterator` over one or zero references to the value of an `Ok`
     ///
     /// Example:
     ///
@@ -87,12 +182,7 @@ impl<T, E: ToStr> Result<T, E> {
         }.move_iter()
     }
 
-    /// Call a method based on a previous result
-    ///
-    /// If `self` is `Err` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is returned. if `self` is `Ok` then it is
-    /// immediately returned.  This function can be used to pass through a
-    /// successful result while handling an error.
+    /// Returns an `Iterator` over one or zero references to the value of an `Err`
     #[inline]
     pub fn iter_err<'r>(&'r self) -> OptionIterator<&'r E> {
         match *self {
@@ -101,103 +191,22 @@ impl<T, E: ToStr> Result<T, E> {
         }.move_iter()
     }
 
-    /// Unwraps a result, yielding the content of an `Ok`.
-    /// Fails if the value is a `Err` with an error message derived
-    /// from `E`'s `ToStr` implementation.
-    #[inline]
-    pub fn unwrap(self) -> T {
-        match self {
-            Ok(t) => t,
-            Err(e) => fail!("called `Result::unwrap()` on `Err` value: {}",
-                             e.to_str()),
-        }
-    }
+    ////////////////////////////////////////////////////////////////////////
+    // Boolean operations on the values, eager and lazy
+    /////////////////////////////////////////////////////////////////////////
 
-    /// Unwraps a result, yielding the content of an `Err`.
-    /// Fails if the value is a `Ok`.
+    /// Returns `res` if the result is `Ok`, otherwise returns the `Err` value of `self`.
     #[inline]
-    pub fn unwrap_err(self) -> E {
-        self.expect_err("called `Result::unwrap_err()` on `Ok` value")
-    }
-
-    /// Unwraps a result, yielding the content of an `Ok`.
-    /// Fails if the value is a `Err` with a custom failure message.
-    #[inline]
-    pub fn expect(self, reason: &str) -> T {
-        match self {
-            Ok(t) => t,
-            Err(_) => fail!("{}", reason.to_owned()),
-        }
-    }
-
-    /// Unwraps a result, yielding the content of an `Err`
-    /// Fails if the value is a `Ok` with a custom failure message.
-    #[inline]
-    pub fn expect_err(self, reason: &str) -> E {
-        match self {
-            Err(e) => e,
-            Ok(_) => fail!("{}", reason.to_owned()),
-        }
-    }
-
-    /// Call a method based on a previous result
-    ///
-    /// If `self` is `Ok` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is wrapped in `Ok` and returned. if `self` is
-    /// `Err` then it is immediately returned.  This function can be used to
-    /// compose the results of two functions.
-    ///
-    /// Example:
-    ///
-    ///     let res = do read_file(file).map_move |buf| {
-    ///         parse_bytes(buf)
-    ///     }
-    #[inline]
-    pub fn map_move<U>(self, op: &fn(T) -> U) -> Result<U,E> {
-        match self {
-          Ok(t) => Ok(op(t)),
-          Err(e) => Err(e)
-        }
-    }
-
-    /// Call a method based on a previous result
-    ///
-    /// If `self` is `Err` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is wrapped in an `Err` and returned. if `self` is
-    /// `Ok` then it is immediately returned.  This function can be used to pass
-    /// through a successful result while handling an error.
-    #[inline]
-    pub fn map_err_move<F>(self, op: &fn(E) -> F) -> Result<T,F> {
-        match self {
-          Ok(t) => Ok(t),
-          Err(e) => Err(op(e))
-        }
-    }
-
-    /// Call a method based on a previous result
-    ///
-    /// If `self` is `Ok`, then `res` it is returned. If `self` is `Err`,
-    /// then `self` is returned.
-    #[inline]
-    pub fn and(self, res: Result<T, E>) -> Result<T, E> {
+    pub fn and<U>(self, res: Result<U, E>) -> Result<U, E> {
         match self {
             Ok(_) => res,
-            Err(_) => self,
+            Err(e) => Err(e),
         }
     }
 
-    /// Call a method based on a previous result
+    /// Calls `op` if the result is `Ok`, otherwise returns the `Err` value of `self`.
     ///
-    /// If `self` is `Ok` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is returned. If `self` is `Err` then it is
-    /// immediately returned. This function can be used to compose the results
-    /// of two functions.
-    ///
-    /// Example:
-    ///
-    ///     let res = do read_file(file) |buf| {
-    ///         Ok(parse_bytes(buf))
-    ///     };
+    /// This function can be used for control flow based on result values
     #[inline]
     pub fn and_then<U>(self, op: &fn(T) -> Result<U, E>) -> Result<U, E> {
         match self {
@@ -206,10 +215,7 @@ impl<T, E: ToStr> Result<T, E> {
         }
     }
 
-    /// Call a method based on a previous result
-    ///
-    /// If `self` is `Ok`, then `self` is returned. If `self` is `Err`
-    /// then `res` is returned.
+    /// Returns `res` if the result is `Err`, otherwise returns the `Ok` value of `self`.
     #[inline]
     pub fn or(self, res: Result<T, E>) -> Result<T, E> {
         match self {
@@ -218,12 +224,9 @@ impl<T, E: ToStr> Result<T, E> {
         }
     }
 
-    /// Call a function based on a previous result
+    /// Calls `op` if the result is `Err`, otherwise returns the `Ok` value of `self`.
     ///
-    /// If `self` is `Err` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is returned. if `self` is `Ok` then it is
-    /// immediately returned.  This function can be used to pass through a
-    /// successful result while handling an error.
+    /// This function can be used for control flow based on result values
     #[inline]
     pub fn or_else<F>(self, op: &fn(E) -> Result<T, F>) -> Result<T, F> {
         match self {
@@ -231,45 +234,29 @@ impl<T, E: ToStr> Result<T, E> {
             Err(e) => op(e),
         }
     }
-}
 
-impl<T: Clone, E: ToStr> Result<T, E> {
-    /// Call a method based on a previous result
+    /////////////////////////////////////////////////////////////////////////
+    // Common special cases
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Get a reference to the value out of a successful result
     ///
-    /// If `self` is `Err` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is wrapped in an `Err` and returned. if `self` is
-    /// `Ok` then it is immediately returned.  This function can be used to pass
-    /// through a successful result while handling an error.
+    /// # Failure
+    ///
+    /// If the result is an error
     #[inline]
-    pub fn map_err<F: Clone>(&self, op: &fn(&E) -> F) -> Result<T,F> {
+    pub fn get_ref<'a>(&'a self) -> &'a T {
         match *self {
-            Ok(ref t) => Ok(t.clone()),
-            Err(ref e) => Err(op(e))
+            Ok(ref t) => t,
+            Err(ref e) => fail!("called `Result::get_ref()` on `Err` value '{}'",
+                                 e.to_str()),
         }
     }
 }
 
-impl<T, E: Clone + ToStr> Result<T, E> {
-    /// Call a method based on a previous result
-    ///
-    /// If `self` is `Ok` then the value is extracted and passed to `op`
-    /// whereupon `op`s result is wrapped in `Ok` and returned. if `self` is
-    /// `Err` then it is immediately returned.  This function can be used to
-    /// compose the results of two functions.
-    ///
-    /// Example:
-    ///
-    ///     let res = do read_file(file).map |buf| {
-    ///         parse_bytes(buf)
-    ///     };
-    #[inline]
-    pub fn map<U>(&self, op: &fn(&T) -> U) -> Result<U,E> {
-        match *self {
-            Ok(ref t) => Ok(op(t)),
-            Err(ref e) => Err(e.clone())
-        }
-    }
-}
+/////////////////////////////////////////////////////////////////////////////
+// Constructor extension trait
+/////////////////////////////////////////////////////////////////////////////
 
 /// A generic trait for converting a value to a `Result`
 pub trait ToResult<T, E> {
@@ -288,6 +275,30 @@ pub trait AsResult<T, E> {
     /// Convert to the `result` type
     fn as_result<'a>(&'a self) -> Result<&'a T, &'a E>;
 }
+
+impl<T: Clone, E: Clone> ToResult<T, E> for Result<T, E> {
+    #[inline]
+    fn to_result(&self) -> Result<T, E> { self.clone() }
+}
+
+impl<T, E> IntoResult<T, E> for Result<T, E> {
+    #[inline]
+    fn into_result(self) -> Result<T, E> { self }
+}
+
+impl<T, E> AsResult<T, E> for Result<T, E> {
+    #[inline]
+    fn as_result<'a>(&'a self) -> Result<&'a T, &'a E> {
+        match *self {
+            Ok(ref t) => Ok(t),
+            Err(ref e) => Err(e),
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Trait implementations
+/////////////////////////////////////////////////////////////////////////////
 
 impl<T: Clone, E> option::ToOption<T> for Result<T, E> {
     #[inline]
@@ -315,26 +326,6 @@ impl<T, E> option::AsOption<T> for Result<T, E> {
         match *self {
             Ok(ref t) => Some(t),
             Err(_) => None,
-        }
-    }
-}
-
-impl<T: Clone, E: Clone> ToResult<T, E> for Result<T, E> {
-    #[inline]
-    fn to_result(&self) -> Result<T, E> { self.clone() }
-}
-
-impl<T, E> IntoResult<T, E> for Result<T, E> {
-    #[inline]
-    fn into_result(self) -> Result<T, E> { self }
-}
-
-impl<T, E> AsResult<T, E> for Result<T, E> {
-    #[inline]
-    fn as_result<'a>(&'a self) -> Result<&'a T, &'a E> {
-        match *self {
-            Ok(ref t) => Ok(t),
-            Err(ref e) => Err(e),
         }
     }
 }
@@ -388,6 +379,10 @@ impl<T: fmt::Default, E: fmt::Default> fmt::Default for Result<T, E> {
         }
     }
 }
+
+/////////////////////////////////////////////////////////////////////////////
+// Free functions
+/////////////////////////////////////////////////////////////////////////////
 
 /// Takes each element in the iterator: if it is an error, no further
 /// elements are taken, and the error is returned.
@@ -450,6 +445,9 @@ pub fn fold_<T, E, Iter: Iterator<Result<T, E>>>(
     fold(iterator, (), |_, _| ())
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// Tests
+/////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
 mod tests {
@@ -460,7 +458,6 @@ mod tests {
     use iter::range;
     use option::{IntoOption, ToOption, AsOption};
     use option;
-    use str::OwnedStr;
     use vec::ImmutableVector;
     use to_str::ToStr;
 
@@ -470,10 +467,10 @@ mod tests {
     #[test]
     pub fn test_and() {
         assert_eq!(op1().and(Ok(667)).unwrap(), 667);
-        assert_eq!(op1().and(Err(~"bad")).unwrap_err(), ~"bad");
+        assert_eq!(op1().and(Err::<(), ~str>(~"bad")).unwrap_err(), ~"bad");
 
         assert_eq!(op2().and(Ok(667)).unwrap_err(), ~"sadface");
-        assert_eq!(op2().and(Err(~"bad")).unwrap_err(), ~"sadface");
+        assert_eq!(op2().and(Err::<(), ~str>(~"bad")).unwrap_err(), ~"sadface");
     }
 
     #[test]
@@ -530,26 +527,14 @@ mod tests {
 
     #[test]
     pub fn test_impl_map() {
-        assert_eq!(Ok::<~str, ~str>(~"a").map(|x| (~"b").append(*x)), Ok(~"ba"));
-        assert_eq!(Err::<~str, ~str>(~"a").map(|x| (~"b").append(*x)), Err(~"a"));
+        assert_eq!(Ok::<~str, ~str>(~"a").map(|x| x + "b"), Ok(~"ab"));
+        assert_eq!(Err::<~str, ~str>(~"a").map(|x| x + "b"), Err(~"a"));
     }
 
     #[test]
     pub fn test_impl_map_err() {
-        assert_eq!(Ok::<~str, ~str>(~"a").map_err(|x| (~"b").append(*x)), Ok(~"a"));
-        assert_eq!(Err::<~str, ~str>(~"a").map_err(|x| (~"b").append(*x)), Err(~"ba"));
-    }
-
-    #[test]
-    pub fn test_impl_map_move() {
-        assert_eq!(Ok::<~str, ~str>(~"a").map_move(|x| x + "b"), Ok(~"ab"));
-        assert_eq!(Err::<~str, ~str>(~"a").map_move(|x| x + "b"), Err(~"a"));
-    }
-
-    #[test]
-    pub fn test_impl_map_err_move() {
-        assert_eq!(Ok::<~str, ~str>(~"a").map_err_move(|x| x + "b"), Ok(~"a"));
-        assert_eq!(Err::<~str, ~str>(~"a").map_err_move(|x| x + "b"), Err(~"ab"));
+        assert_eq!(Ok::<~str, ~str>(~"a").map_err(|x| x + "b"), Ok(~"a"));
+        assert_eq!(Err::<~str, ~str>(~"a").map_err(|x| x + "b"), Err(~"ab"));
     }
 
     #[test]

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -13,7 +13,6 @@
 use any::Any;
 use clone::Clone;
 use cmp::Eq;
-use either;
 use fmt;
 use iter::Iterator;
 use kinds::Send;
@@ -331,36 +330,6 @@ impl<T, E> AsOption<T> for Result<T, E> {
     }
 }
 
-impl<T: Clone, E: Clone> either::ToEither<E, T> for Result<T, E> {
-    #[inline]
-    fn to_either(&self) -> either::Either<E, T> {
-        match *self {
-            Ok(ref t) => either::Right(t.clone()),
-            Err(ref e) => either::Left(e.clone()),
-        }
-    }
-}
-
-impl<T, E> either::IntoEither<E, T> for Result<T, E> {
-    #[inline]
-    fn into_either(self) -> either::Either<E, T> {
-        match self {
-            Ok(t) => either::Right(t),
-            Err(e) => either::Left(e),
-        }
-    }
-}
-
-impl<T, E> either::AsEither<E, T> for Result<T, E> {
-    #[inline]
-    fn as_either<'a>(&'a self) -> either::Either<&'a E, &'a T> {
-        match *self {
-            Ok(ref t) => either::Right(t),
-            Err(ref e) => either::Left(e),
-        }
-    }
-}
-
 impl<T: fmt::Default, E: fmt::Default> fmt::Default for Result<T, E> {
     #[inline]
     fn fmt(s: &Result<T, E>, f: &mut fmt::Formatter) {
@@ -444,8 +413,6 @@ pub fn fold_<T, E, Iter: Iterator<Result<T, E>>>(
 mod tests {
     use super::*;
 
-    use either::{IntoEither, ToEither, AsEither};
-    use either;
     use iter::range;
     use option::{IntoOption, ToOption, AsOption};
     use option::{Option, Some, None};
@@ -629,33 +596,6 @@ mod tests {
 
         let x = 404;
         assert_eq!(err.as_result(), Err(&x));
-    }
-
-    #[test]
-    pub fn test_to_either() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.to_either(), either::Right(100));
-        assert_eq!(err.to_either(), either::Left(404));
-    }
-
-    #[test]
-    pub fn test_into_either() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.into_either(), either::Right(100));
-        assert_eq!(err.into_either(), either::Left(404));
-    }
-
-    #[test]
-    pub fn test_as_either() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.as_either().unwrap_right(), &100);
-        assert_eq!(err.as_either().unwrap_left(), &404);
     }
 
     #[test]

--- a/src/libstd/rt/io/stdio.rs
+++ b/src/libstd/rt/io/stdio.rs
@@ -195,7 +195,7 @@ impl Reader for StdReader {
     fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
         let ret = match self.inner {
             TTY(ref mut tty) => tty.read(buf),
-            File(ref mut file) => file.read(buf).map_move(|i| i as uint),
+            File(ref mut file) => file.read(buf).map(|i| i as uint),
         };
         match ret {
             Ok(amt) => Some(amt as uint),

--- a/src/libstd/std.rs
+++ b/src/libstd/std.rs
@@ -8,45 +8,40 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*!
-
-# The Rust standard library
-
-The Rust standard library is a group of interrelated modules defining
-the core language traits, operations on built-in data types, collections,
-platform abstractions, the task scheduler, runtime support for language
-features and other common functionality.
-
-`std` includes modules corresponding to each of the integer types,
-each of the floating point types, the `bool` type, tuples, characters,
-strings (`str`), vectors (`vec`), managed boxes (`managed`), owned
-boxes (`owned`), and unsafe and borrowed pointers (`ptr`, `borrowed`).
-Additionally, `std` provides pervasive types (`option` and `result`),
-task creation and communication primitives (`task`, `comm`), platform
-abstractions (`os` and `path`), basic I/O abstractions (`io`), common
-traits (`kinds`, `ops`, `cmp`, `num`, `to_str`), and complete bindings
-to the C standard library (`libc`).
-
-# Standard library injection and the Rust prelude
-
-`std` is imported at the topmost level of every crate by default, as
-if the first line of each crate was
-
-    extern mod std;
-
-This means that the contents of std can be accessed from any context
-with the `std::` path prefix, as in `use std::vec`, `use std::task::spawn`,
-etc.
-
-Additionally, `std` contains a `prelude` module that reexports many of the
-most common types, traits and functions. The contents of the prelude are
-imported into every *module* by default.  Implicitly, all modules behave as if
-they contained the following prologue:
-
-    use std::prelude::*;
-
-*/
-
+//! # The Rust standard library
+//!
+//! The Rust standard library is a group of interrelated modules defining
+//! the core language traits, operations on built-in data types, collections,
+//! platform abstractions, the task scheduler, runtime support for language
+//! features and other common functionality.
+//!
+//! `std` includes modules corresponding to each of the integer types,
+//! each of the floating point types, the `bool` type, tuples, characters,
+//! strings (`str`), vectors (`vec`), managed boxes (`managed`), owned
+//! boxes (`owned`), and unsafe and borrowed pointers (`ptr`, `borrowed`).
+//! Additionally, `std` provides pervasive types (`option` and `result`),
+//! task creation and communication primitives (`task`, `comm`), platform
+//! abstractions (`os` and `path`), basic I/O abstractions (`io`), common
+//! traits (`kinds`, `ops`, `cmp`, `num`, `to_str`), and complete bindings
+//! to the C standard library (`libc`).
+//!
+//! # Standard library injection and the Rust prelude
+//!
+//! `std` is imported at the topmost level of every crate by default, as
+//! if the first line of each crate was
+//!
+//!     extern mod std;
+//!
+//! This means that the contents of std can be accessed from any context
+//! with the `std::` path prefix, as in `use std::vec`, `use std::task::spawn`,
+//! etc.
+//!
+//! Additionally, `std` contains a `prelude` module that reexports many of the
+//! most common types, traits and functions. The contents of the prelude are
+//! imported into every *module* by default.  Implicitly, all modules behave as if
+//! they contained the following prologue:
+//!
+//!     use std::prelude::*;
 
 #[link(name = "std",
        vers = "0.9-pre",
@@ -96,6 +91,7 @@ pub mod linkhack {
 /* The Prelude. */
 
 pub mod prelude;
+
 
 /* Primitive types */
 
@@ -158,6 +154,7 @@ pub mod container;
 pub mod default;
 pub mod any;
 
+
 /* Common data structures */
 
 pub mod option;
@@ -198,10 +195,12 @@ pub mod util;
 pub mod routine;
 pub mod mem;
 
+
 /* Unsupported interfaces */
 
 // Private APIs
 pub mod unstable;
+
 
 /* For internal use, not exported */
 

--- a/src/libstd/unit.rs
+++ b/src/libstd/unit.rs
@@ -8,11 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*!
-
-Functions for the unit type.
-
-*/
+//! Functions for the unit type.
 
 #[cfg(not(test))]
 use prelude::*;

--- a/src/test/run-fail/result-get-fail.rs
+++ b/src/test/run-fail/result-get-fail.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:called `Result::unwrap()` on `Err` value: kitty
+// error-pattern:called `Result::unwrap()` on `Err` value 'kitty'
 
 use std::result;
 


### PR DESCRIPTION
This takes the last reforms on the `Option` type and applies them to `Result` too. For that, I reordered and grouped the functions in both modules, and also did some refactorings:
- Added `as_ref` and `as_mut` adapters to `Result`.
- Renamed `Result::map_move` to `Result::map` (same for `_err` variant), deleted other map functions. 
- Made the `.expect()` methods be generic over anything you can
  fail with.
- Updated some doc comments to the line doc comment style
- Cleaned up and extended standard trait implementations on `Option` and `Result`
- Removed legacy implementations in the `option` and `result` module
