### PR TITLE
Check LHS expression of assignment

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2366,6 +2366,11 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
         let result_t = fcx.expr_ty(expr);
         demand::suptype(fcx, expr.span, result_t, lhs_t);
 
+        let tcx = fcx.tcx();
+        if !ty::expr_is_lval(tcx, fcx.ccx.method_map, lhs) {
+            tcx.sess.span_err(lhs.span, "illegal left-hand side expression");
+        }
+
         // Overwrite result of check_binop...this preserves existing behavior
         // but seems quite dubious with regard to user-defined methods
         // and so forth. - Niko
@@ -2538,6 +2543,12 @@ pub fn check_expr_with_unifier(fcx: @mut FnCtxt,
       }
       ast::ExprAssign(lhs, rhs) => {
         check_assignment(fcx, lhs, rhs, id);
+
+        let tcx = fcx.tcx();
+        if !ty::expr_is_lval(tcx, fcx.ccx.method_map, lhs) {
+            tcx.sess.span_err(lhs.span, "illegal left-hand side expression");
+        }
+
         let lhs_ty = fcx.expr_ty(lhs);
         let rhs_ty = fcx.expr_ty(rhs);
         if ty::type_is_error(lhs_ty) || ty::type_is_error(rhs_ty) {

--- a/src/test/compile-fail/bad-expr-lhs.rs
+++ b/src/test/compile-fail/bad-expr-lhs.rs
@@ -1,0 +1,20 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    1 = 2; //~ ERROR illegal left-hand side expression
+    1 += 2; //~ ERROR illegal left-hand side expression
+    (1, 2) = (3, 4); //~ ERROR illegal left-hand side expression
+
+    let (a, b) = (1, 2);
+    (a, b) = (3, 4); //~ ERROR illegal left-hand side expression
+
+    None = Some(3); //~ ERROR illegal left-hand side expression
+}

--- a/src/test/compile-fail/borrowck-assign-to-constants.rs
+++ b/src/test/compile-fail/borrowck-assign-to-constants.rs
@@ -12,6 +12,5 @@ static foo: int = 5;
 
 fn main() {
     // assigning to various global constants
-    None = Some(3); //~ ERROR cannot assign to immutable static item
     foo = 6; //~ ERROR cannot assign to immutable static item
 }


### PR DESCRIPTION
This patch fixes rustc to emit explicit error if LHS of assignment is
not allowed.

Fixes #7507
Fixes #7508
