### PR TITLE
add support for the `cold` function attribute

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -693,6 +693,8 @@ pub mod llvm {
         pub fn LLVMAddReturnAttribute(Fn: ValueRef, PA: c_uint);
         pub fn LLVMRemoveReturnAttribute(Fn: ValueRef, PA: c_uint);
 
+        pub fn LLVMAddColdAttribute(Fn: ValueRef);
+
         pub fn LLVMRemoveFunctionAttr(Fn: ValueRef,
                                       PA: c_ulonglong,
                                       HighPA: c_ulonglong);

--- a/src/libstd/rt/borrowck.rs
+++ b/src/libstd/rt/borrowck.rs
@@ -57,6 +57,7 @@ pub fn clear_task_borrow_list() {
     let _ = try_take_task_borrow_list();
 }
 
+#[cold]
 unsafe fn fail_borrowed(box: *mut raw::Box<()>, file: *c_char, line: size_t) -> ! {
     debug_borrow("fail_borrowed: ", box, 0, 0, file, line);
 

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -16,11 +16,13 @@ use libc::{c_char, size_t, uintptr_t};
 use rt::task;
 use rt::borrowck;
 
+#[cold]
 #[lang="fail_"]
 pub fn fail_(expr: *c_char, file: *c_char, line: size_t) -> ! {
     task::begin_unwind(expr, file, line);
 }
 
+#[cold]
 #[lang="fail_bounds_check"]
 pub fn fail_bounds_check(file: *c_char, line: size_t, index: size_t, len: size_t) -> ! {
     let msg = format!("index out of bounds: the len is {} but the index is {}",

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -365,6 +365,11 @@ extern "C" void LLVMRemoveReturnAttribute(LLVMValueRef Fn, LLVMAttribute PA) {
                       AttributeSet::get(A->getContext(), AttributeSet::ReturnIndex,  B));
 }
 
+extern "C" void LLVMAddColdAttribute(LLVMValueRef Fn) {
+  Function *A = unwrap<Function>(Fn);
+  A->addAttribute(AttributeSet::FunctionIndex, Attribute::Cold);
+}
+
 extern "C" LLVMValueRef LLVMBuildAtomicLoad(LLVMBuilderRef B,
                                             LLVMValueRef source,
                                             const char* Name,

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -629,3 +629,4 @@ LLVMRustAddAlwaysInlinePass
 LLVMAddReturnAttribute
 LLVMRemoveReturnAttribute
 LLVMTypeToString
+LLVMAddColdAttribute


### PR DESCRIPTION
This allows a function to marked as infrequently called, resulting in
any branch calling it to be considered colder.
