### PR TITLE
Handle another possible error in a unix pipe test

### DIFF
--- a/src/libstd/rt/io/net/unix.rs
+++ b/src/libstd/rt/io/net/unix.rs
@@ -243,7 +243,8 @@ mod tests {
             let mut stop = false;
             while !stop{
                 do io_error::cond.trap(|e| {
-                    assert_eq!(e.kind, BrokenPipe);
+                    assert!(e.kind == BrokenPipe || e.kind == NotConnected,
+                            "unknown error {:?}", e);
                     stop = true;
                 }).inside {
                     server.write(buf);


### PR DESCRIPTION
This cropped up on the bsd bot, and if it's an error that gets thrown then it's
fine to just whitelist another type of error in the test.
