### PR TITLE
std: Move the SendDeferred trait to std::comm

### DIFF
--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -17,7 +17,6 @@ Message passing
 use clone::Clone;
 use kinds::Send;
 use option::Option;
-pub use rt::comm::SendDeferred;
 use rtcomm = rt::comm;
 
 /// A trait for things that can send multiple messages.
@@ -31,6 +30,12 @@ pub trait GenericChan<T> {
 pub trait GenericSmartChan<T> {
     /// Sends a message, or report if the receiver has closed the connection.
     fn try_send(&self, x: T) -> bool;
+}
+
+/// Trait for non-rescheduling send operations, similar to `send_deferred` on ChanOne.
+pub trait SendDeferred<T> {
+    fn send_deferred(&self, val: T);
+    fn try_send_deferred(&self, val: T) -> bool;
 }
 
 /// A trait for things that can receive multiple messages.

--- a/src/libstd/rt/comm.rs
+++ b/src/libstd/rt/comm.rs
@@ -23,7 +23,7 @@ use select::{Select, SelectPort};
 use unstable::atomics::{AtomicUint, AtomicOption, Acquire, Relaxed, SeqCst};
 use unstable::sync::UnsafeArc;
 use util::Void;
-use comm::{GenericChan, GenericSmartChan, GenericPort, Peekable};
+use comm::{GenericChan, GenericSmartChan, GenericPort, Peekable, SendDeferred};
 use cell::Cell;
 use clone::Clone;
 use tuple::ImmutableTuple;
@@ -425,12 +425,6 @@ impl<T> Drop for PortOne<T> {
             }
         }
     }
-}
-
-/// Trait for non-rescheduling send operations, similar to `send_deferred` on ChanOne.
-pub trait SendDeferred<T> {
-    fn send_deferred(&self, val: T);
-    fn try_send_deferred(&self, val: T) -> bool;
 }
 
 struct StreamPayload<T> {


### PR DESCRIPTION
Just putting this public trait into the correct module.
