### PR TITLE
rt::task: Make current_stack_segment public again

### DIFF
--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -73,7 +73,10 @@ pub struct Coroutine {
     /// The segment of stack on which the task is currently running or
     /// if the task is blocked, on which the task will resume
     /// execution.
-    priv current_stack_segment: StackSegment,
+    ///
+    /// Servo needs this to be public in order to tell SpiderMonkey
+    /// about the stack bounds.
+    current_stack_segment: StackSegment,
     /// Always valid if the task is alive and not running.
     saved_context: Context
 }


### PR DESCRIPTION
This was done in 2145de8c and reverted in 0ada7c7f, but Servo needs it.

Closes #10065.

r? @brson
