### PR TITLE
librustc: Implement `|A| -> B` syntax for closures

### DIFF
--- a/src/librustc/back/upcall.rs
+++ b/src/librustc/back/upcall.rs
@@ -17,19 +17,12 @@ use lib::llvm::{ModuleRef, ValueRef};
 pub struct Upcalls {
     trace: ValueRef,
     rust_personality: ValueRef,
-    reset_stack_limit: ValueRef
 }
 
 macro_rules! upcall (
     (fn $name:ident($($arg:expr),+) -> $ret:expr) => ({
         let fn_ty = Type::func([ $($arg),* ], &$ret);
         base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty)
-    });
-    (nothrow fn $name:ident($($arg:expr),+) -> $ret:expr) => ({
-        let fn_ty = Type::func([ $($arg),* ], &$ret);
-        let decl = base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty);
-        base::set_no_unwind(decl);
-        decl
     });
     (nothrow fn $name:ident -> $ret:expr) => ({
         let fn_ty = Type::func([], &$ret);
@@ -46,6 +39,5 @@ pub fn declare_upcalls(targ_cfg: @session::config, llmod: ModuleRef) -> @Upcalls
     @Upcalls {
         trace: upcall!(fn trace(opaque_ptr, opaque_ptr, int_ty) -> Type::void()),
         rust_personality: upcall!(nothrow fn rust_personality -> Type::i32()),
-        reset_stack_limit: upcall!(nothrow fn reset_stack_limit -> Type::void())
     }
 }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1012,11 +1012,6 @@ pub fn get_landing_pad(bcx: @mut Block) -> BasicBlockRef {
     // The landing pad block is a cleanup
     SetCleanup(pad_bcx, llretval);
 
-    // Because we may have unwound across a stack boundary, we must call into
-    // the runtime to figure out which stack segment we are on and place the
-    // stack limit back into the TLS.
-    Call(pad_bcx, bcx.ccx().upcalls.reset_stack_limit, [], []);
-
     // We store the retval in a function-central alloca, so that calls to
     // Resume can find it.
     match bcx.fcx.personality {

--- a/src/test/compile-fail/block-coerce-no-2.rs
+++ b/src/test/compile-fail/block-coerce-no-2.rs
@@ -19,5 +19,5 @@ fn main() {
     }
 
     f(g);
-    //~^ ERROR mismatched types: expected `extern "Rust" fn(extern "Rust" fn(extern "Rust" fn()))`
+    //~^ ERROR mismatched types: expected `fn(fn(fn()))`
 }

--- a/src/test/compile-fail/closure-reform-bad.rs
+++ b/src/test/compile-fail/closure-reform-bad.rs
@@ -1,0 +1,13 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+fn call_bare(f: fn(&str)) {
+    f("Hello ");
+}
+
+fn main() {
+    let string = "world!";
+    let f: |&str| = |s| println(s + string);
+    call_bare(f)    //~ ERROR mismatched types
+}
+

--- a/src/test/pretty/closure-reform-pretty.rs
+++ b/src/test/pretty/closure-reform-pretty.rs
@@ -1,0 +1,17 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// pp-exact
+
+fn call_it(f: proc(~str) -> ~str) { }
+
+fn call_this(f: |&str|: Send) { }
+
+fn call_that(f: <'a>|&'a int, &'a int|: -> int) { }
+
+fn call_extern(f: fn() -> int) { }
+
+fn call_abid_extern(f: extern "C" fn() -> int) { }
+
+pub fn main() { }
+

--- a/src/test/pretty/disamb-stmt-expr.rs
+++ b/src/test/pretty/disamb-stmt-expr.rs
@@ -14,7 +14,7 @@
 // preserved.  They are needed to disambiguate `{return n+1}; - 0` from
 // `({return n+1}-0)`.
 
-fn id(f: &fn() -> int) -> int { f() }
+fn id(f: || -> int) -> int { f() }
 
 fn wsucc(_n: int) -> int { (do id || { 1 }) - 0 }
 fn main() { }

--- a/src/test/pretty/do1.rs
+++ b/src/test/pretty/do1.rs
@@ -10,6 +10,6 @@
 
 // pp-exact
 
-fn f(f: &fn(int)) { f(10) }
+fn f(f: |int|) { f(10) }
 
 fn main() { do f |i| { assert!(i == 10) } }

--- a/src/test/pretty/fn-types.rs
+++ b/src/test/pretty/fn-types.rs
@@ -10,7 +10,7 @@
 
 // pp-exact
 
-fn from_foreign_fn(_x: extern "Rust" fn()) { }
-fn from_stack_closure(_x: &fn()) { }
+fn from_foreign_fn(_x: fn()) { }
+fn from_stack_closure(_x: ||) { }
 fn from_unique_closure(_x: ~fn()) { }
 fn main() { }

--- a/src/test/run-pass/closure-reform.rs
+++ b/src/test/run-pass/closure-reform.rs
@@ -1,11 +1,42 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+use std::cast;
+
 fn call_it(f: proc(~str) -> ~str) {
     println(f(~"Fred"))
 }
 
+fn call_a_thunk(f: ||) {
+    f();
+}
+
+fn call_this(f: |&str|:Send) {
+    f("Hello!");
+}
+
+fn call_that(f: <'a>|&'a int, &'a int|: -> int) {
+    let (ten, forty_two) = (10, 42);
+    println!("Your lucky number is {}", f(&ten, &forty_two));
+}
+
+fn call_cramped(f:||->uint,g:<'a>||->&'a uint) {
+    let number = f();
+    let other_number = *g();
+    println!("Ticket {} wins an all-expenses-paid trip to Mountain View", number + other_number);
+}
+
+fn call_bare(f: fn(&str)) {
+    f("Hello world!")
+}
+
+fn call_bare_again(f: extern "Rust" fn(&str)) {
+    f("Goodbye world!")
+}
+
 pub fn main() {
+    // Procs
+
     let greeting = ~"Hi ";
     do call_it |s| {
         greeting + s
@@ -23,5 +54,26 @@ pub fn main() {
     call_it(proc(s: ~str) -> ~str {
         greeting + s
     });
+
+    // Closures
+
+    call_a_thunk(|| println("Hello world!"));
+
+    call_this(|s| println(s));
+
+    call_that(|x, y| *x + *y);
+
+    let z = 100;
+    call_that(|x, y| *x + *y - z);
+
+    call_cramped(|| 1, || unsafe {
+        cast::transmute(&100)
+    });
+
+    // External functions
+
+    call_bare(println);
+
+    call_bare_again(println);
 }
 


### PR DESCRIPTION
r? @nikomatsakis 
