### PR TITLE
syntax: Forbid non-string literals in meta items. #623

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -161,6 +161,16 @@ impl parser_attr for Parser {
             token::EQ => {
                 self.bump();
                 let lit = self.parse_lit();
+                // FIXME #623 Non-string meta items are not serialized correctly;
+                // just forbid them for now
+                match lit.node {
+                    ast::lit_str(*) => (),
+                    _ => {
+                        self.span_err(
+                            lit.span,
+                            "non-string literals are not allowed in meta-items");
+                    }
+                }
                 let hi = self.span.hi;
                 @spanned(lo, hi, ast::MetaNameValue(name, lit))
             }

--- a/src/test/compile-fail/non-str-meta.rs
+++ b/src/test/compile-fail/non-str-meta.rs
@@ -1,0 +1,15 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #623 - non-string meta items are not serialized correctly;
+// for now just forbid them
+
+#[foo = 1] //~ ERROR: non-string literals are not allowed in meta-items
+fn main() { }

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -174,7 +174,9 @@ mod test_foreign_items {
     }
 }
 
-mod test_literals {
+
+// FIXME #623 - these aren't supported yet
+/*mod test_literals {
     #[str = "s"];
     #[char = 'c'];
     #[int = 100];
@@ -185,7 +187,7 @@ mod test_literals {
     #[nil = ()];
     #[bool = true];
     mod m {}
-}
+}*/
 
 fn test_fn_inner() {
     #[inner_fn_attr];


### PR DESCRIPTION
This doesn't fix #623 but works around it by limiting the grammar.
