### PR TITLE
Fixed incorrect usage of 'Borrowing'.

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1142,7 +1142,7 @@ For a more in-depth explanation of borrowed pointers, read the
 
 ## Freezing
 
-Borrowing an immutable pointer to an object freezes it and prevents mutation.
+Lending an immutable pointer to an object freezes it and prevents mutation.
 `Owned` objects have freezing enforced statically at compile-time.
 
 ~~~~


### PR DESCRIPTION
To keep consistency with the word "borrowing" I suppose an alternate way to write this could be "Having an object borrow an immutable pointer freezes it and prevents mutation".
