### PR TITLE
Fix JS errors in the docs page when searching for some specific terms.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -307,7 +307,8 @@
                                             item.path.replace(/::/g, '/') +
                                             '/index.html" class="' + type +
                                             '">' + name + '</a>';
-                    } else if (item.parent !== undefined) {
+                    } else if (item.parent !== undefined &&
+                               allPaths[item.parent] !== undefined) {
                         var myparent = allPaths[item.parent];
                         var anchor = '#' + type + '.' + name;
                         output += item.path + '::' + myparent.name +


### PR DESCRIPTION
Search for "ru" here: http://static.rust-lang.org/doc/master/std/index.html and you'll get the following error in Firebug:

![screen shot 2013-10-30 at 11 42 56 pm](https://f.cloud.github.com/assets/217126/1439737/110e9b3a-418f-11e3-9da4-b7099e3892d7.png)
