### PR TITLE
Add a type_id intrinsic

### DIFF
--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -274,6 +274,11 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             let td = PointerCast(bcx, static_ti.tydesc, userland_tydesc_ty);
             Ret(bcx, td);
         }
+        "type_id" => {
+            let hash = ty::hash_crate_independent(ccx.tcx, substs.tys[0],
+                                                  ccx.link_meta.extras_hash);
+            Ret(bcx, C_i64(hash as i64))
+        }
         "init" => {
             let tp_ty = substs.tys[0];
             let lltp_ty = type_of::type_of(ccx, tp_ty);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3700,6 +3700,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
               });
               (1u, ~[], td_ptr)
             }
+            "type_id" => (1u, ~[], ty::mk_u64()),
             "visit_tydesc" => {
               let tydesc_ty = match ty::get_tydesc_ty(ccx.tcx) {
                   Ok(t) => t,

--- a/src/libstd/any.rs
+++ b/src/libstd/any.rs
@@ -20,7 +20,6 @@ use util::Void;
 
 ///////////////////////////////////////////////////////////////////////////////
 // TypeId
-// FIXME: #9913 - Needs proper intrinsic support to work reliably cross crate
 ///////////////////////////////////////////////////////////////////////////////
 
 /// `TypeId` represents a globally unique identifier for a type
@@ -199,8 +198,10 @@ mod tests {
 
     #[test]
     fn type_id() {
-        let (a, b, c) = (TypeId::of::<uint>(), TypeId::of::<&str>(), TypeId::of::<Test>());
-        let (d, e, f) = (TypeId::of::<uint>(), TypeId::of::<&str>(), TypeId::of::<Test>());
+        let (a, b, c) = (TypeId::of::<uint>(), TypeId::of::<&'static str>(),
+                         TypeId::of::<Test>());
+        let (d, e, f) = (TypeId::of::<uint>(), TypeId::of::<&'static str>(),
+                         TypeId::of::<Test>());
 
         assert!(a != b);
         assert!(a != c);

--- a/src/libstd/any.rs
+++ b/src/libstd/any.rs
@@ -15,7 +15,7 @@ use cast::transmute;
 use cmp::Eq;
 use option::{Option, Some, None};
 use to_str::ToStr;
-use unstable::intrinsics::{TyDesc, get_tydesc, forget};
+use unstable::intrinsics;
 use util::Void;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -24,15 +24,30 @@ use util::Void;
 ///////////////////////////////////////////////////////////////////////////////
 
 /// `TypeId` represents a globally unique identifier for a type
+#[cfg(stage0)]
 pub struct TypeId {
-    priv t: *TyDesc
+    priv t: *intrinsics::TyDesc,
+}
+
+/// `TypeId` represents a globally unique identifier for a type
+#[cfg(not(stage0))]
+pub struct TypeId {
+    priv t: u64,
 }
 
 impl TypeId {
     /// Returns the `TypeId` of the type this generic function has been instantiated with
     #[inline]
-    pub fn of<T>() -> TypeId {
-        TypeId{ t: unsafe { get_tydesc::<T>() } }
+    #[cfg(stage0)]
+    pub fn of<T: 'static>() -> TypeId {
+        TypeId{ t: unsafe { intrinsics::get_tydesc::<T>() } }
+    }
+
+    /// Returns the `TypeId` of the type this generic function has been instantiated with
+    #[inline]
+    #[cfg(not(stage0))]
+    pub fn of<T: 'static>() -> TypeId {
+        TypeId{ t: unsafe { intrinsics::type_id::<T>() } }
     }
 }
 
@@ -51,21 +66,31 @@ impl Eq for TypeId {
 /// for dynamic typing
 pub trait Any {
     /// Get the `TypeId` of `self`
+    fn get_type_id(&self) -> TypeId;
+
+    /// Get a void pointer to `self`
+    fn as_void_ptr(&self) -> *Void;
+
+    /// Get a mutable void pointer to `self`
+    fn as_mut_void_ptr(&mut self) -> *mut Void;
+}
+
+impl<T: 'static> Any for T {
+    /// Get the `TypeId` of `self`
     fn get_type_id(&self) -> TypeId {
-        TypeId::of::<Self>()
+        TypeId::of::<T>()
     }
 
     /// Get a void pointer to `self`
     fn as_void_ptr(&self) -> *Void {
-        self as *Self as *Void
+        self as *T as *Void
     }
 
     /// Get a mutable void pointer to `self`
     fn as_mut_void_ptr(&mut self) -> *mut Void {
-        self as *mut Self as *mut Void
+        self as *mut T as *mut Void
     }
 }
-impl<T> Any for T {}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Extension methods for Any trait objects.
@@ -75,16 +100,16 @@ impl<T> Any for T {}
 /// Extension methods for a referenced `Any` trait object
 pub trait AnyRefExt<'self> {
     /// Returns true if the boxed type is the same as `T`
-    fn is<T>(self) -> bool;
+    fn is<T: 'static>(self) -> bool;
 
     /// Returns some reference to the boxed value if it is of type `T`, or
     /// `None` if it isn't.
-    fn as_ref<T>(self) -> Option<&'self T>;
+    fn as_ref<T: 'static>(self) -> Option<&'self T>;
 }
 
 impl<'self> AnyRefExt<'self> for &'self Any {
     #[inline]
-    fn is<T>(self) -> bool {
+    fn is<T: 'static>(self) -> bool {
         // Get TypeId of the type this function is instantiated with
         let t = TypeId::of::<T>();
 
@@ -96,7 +121,7 @@ impl<'self> AnyRefExt<'self> for &'self Any {
     }
 
     #[inline]
-    fn as_ref<T>(self) -> Option<&'self T> {
+    fn as_ref<T: 'static>(self) -> Option<&'self T> {
         if self.is::<T>() {
             Some(unsafe { transmute(self.as_void_ptr()) })
         } else {
@@ -109,12 +134,12 @@ impl<'self> AnyRefExt<'self> for &'self Any {
 pub trait AnyMutRefExt<'self> {
     /// Returns some mutable reference to the boxed value if it is of type `T`, or
     /// `None` if it isn't.
-    fn as_mut<T>(self) -> Option<&'self mut T>;
+    fn as_mut<T: 'static>(self) -> Option<&'self mut T>;
 }
 
 impl<'self> AnyMutRefExt<'self> for &'self mut Any {
     #[inline]
-    fn as_mut<T>(self) -> Option<&'self mut T> {
+    fn as_mut<T: 'static>(self) -> Option<&'self mut T> {
         if self.is::<T>() {
             Some(unsafe { transmute(self.as_mut_void_ptr()) })
         } else {
@@ -127,19 +152,19 @@ impl<'self> AnyMutRefExt<'self> for &'self mut Any {
 pub trait AnyOwnExt {
     /// Returns the boxed value if it is of type `T`, or
     /// `None` if it isn't.
-    fn move<T>(self) -> Option<~T>;
+    fn move<T: 'static>(self) -> Option<~T>;
 }
 
 impl AnyOwnExt for ~Any {
     #[inline]
-    fn move<T>(self) -> Option<~T> {
+    fn move<T: 'static>(self) -> Option<~T> {
         if self.is::<T>() {
             unsafe {
                 // Extract the pointer to the boxed value, temporary alias with self
                 let ptr: ~T = transmute(self.as_void_ptr());
 
                 // Prevent destructor on self being run
-                forget(self);
+                intrinsics::forget(self);
 
                 Some(ptr)
             }

--- a/src/libstd/rt/kill.rs
+++ b/src/libstd/rt/kill.rs
@@ -155,9 +155,9 @@ use cell::Cell;
 use option::{Option, Some, None};
 use prelude::*;
 use rt::task::Task;
-use rt::task::UnwindMessageLinked;
 use rt::task::{UnwindResult, Failure};
 use task::spawn::Taskgroup;
+use task::LinkedFailure;
 use to_bytes::IterBytes;
 use unstable::atomics::{AtomicUint, Relaxed};
 use unstable::sync::{UnsafeArc, UnsafeArcSelf, UnsafeArcT, LittleLock};
@@ -597,7 +597,7 @@ impl Death {
                 }
 
                 if !success {
-                    result = Cell::new(Failure(UnwindMessageLinked));
+                    result = Cell::new(Failure(~LinkedFailure as ~Any));
                 }
             }
             on_exit(result.take());

--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -83,11 +83,11 @@ use local_data;
 use rt::local::Local;
 use rt::sched::{Scheduler, Shutdown, TaskFromFriend};
 use rt::task::{Task, Sched};
-use rt::task::{UnwindMessageLinked, UnwindMessageStrStatic};
 use rt::task::{UnwindResult, Success, Failure};
 use rt::thread::Thread;
 use rt::work_queue::WorkQueue;
 use rt::{in_green_task_context, new_event_loop, KillHandle};
+use task::LinkedFailure;
 use task::SingleThreaded;
 use task::TaskOpts;
 use task::unkillable;
@@ -324,7 +324,7 @@ impl Drop for Taskgroup {
         do RuntimeGlue::with_task_handle_and_failing |me, failing| {
             if failing {
                 for x in self.notifier.mut_iter() {
-                    x.task_result = Some(Failure(UnwindMessageLinked));
+                    x.task_result = Some(Failure(~LinkedFailure as ~Any));
                 }
                 // Take everybody down with us. After this point, every
                 // other task in the group will see 'tg' as none, which
@@ -379,7 +379,7 @@ impl AutoNotify {
             notify_chan: chan,
 
             // Un-set above when taskgroup successfully made.
-            task_result: Some(Failure(UnwindMessageStrStatic("AutoNotify::new()")))
+            task_result: Some(Failure(~("AutoNotify::new()") as ~Any))
         }
     }
 }

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -49,23 +49,23 @@ pub struct TyDesc {
     align: uint,
 
     // Called on a copy of a value of type `T` *after* memcpy
-    priv take_glue: GlueFn,
+    take_glue: GlueFn,
 
     // Called when a value of type `T` is no longer needed
     drop_glue: GlueFn,
 
     // Called by drop glue when a value of type `T` can be freed
-    priv free_glue: GlueFn,
+    free_glue: GlueFn,
 
     // Called by reflection visitor to visit a value of type `T`
-    priv visit_glue: GlueFn,
+    visit_glue: GlueFn,
 
     // If T represents a box pointer (`@U` or `~U`), then
     // `borrow_offset` is the amount that the pointer must be adjusted
     // to find the payload.  This is always derivable from the type
     // `U`, but in the case of `@Trait` or `~Trait` objects, the type
     // `U` is unknown.
-    priv borrow_offset: uint,
+    borrow_offset: uint,
 
     // Name corresponding to the type
     name: &'static str
@@ -309,6 +309,12 @@ extern "rust-intrinsic" {
 
     /// Get a static pointer to a type descriptor.
     pub fn get_tydesc<T>() -> *TyDesc;
+
+    /// Gets an identifier which is globally unique to the specified type. This
+    /// function will return the same value for a type regardless of whichever
+    /// crate it is invoked in.
+    #[cfg(not(stage0))]
+    pub fn type_id<T: 'static>() -> u64;
 
     /// Create a value initialized to zero.
     ///

--- a/src/test/auxiliary/typeid-intrinsic.rs
+++ b/src/test/auxiliary/typeid-intrinsic.rs
@@ -1,0 +1,32 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::unstable::intrinsics;
+
+pub struct A;
+pub struct B(Option<A>);
+pub struct C(Option<int>);
+pub struct D(Option<&'static str>);
+pub struct E(Result<&'static str, int>);
+
+pub type F = Option<int>;
+pub type G = uint;
+pub type H = &'static str;
+
+pub unsafe fn id_A() -> u64 { intrinsics::type_id::<A>() }
+pub unsafe fn id_B() -> u64 { intrinsics::type_id::<B>() }
+pub unsafe fn id_C() -> u64 { intrinsics::type_id::<C>() }
+pub unsafe fn id_D() -> u64 { intrinsics::type_id::<D>() }
+pub unsafe fn id_E() -> u64 { intrinsics::type_id::<E>() }
+pub unsafe fn id_F() -> u64 { intrinsics::type_id::<F>() }
+pub unsafe fn id_G() -> u64 { intrinsics::type_id::<G>() }
+pub unsafe fn id_H() -> u64 { intrinsics::type_id::<H>() }
+
+pub unsafe fn foo<T: 'static>() -> u64 { intrinsics::type_id::<T>() }

--- a/src/test/auxiliary/typeid-intrinsic2.rs
+++ b/src/test/auxiliary/typeid-intrinsic2.rs
@@ -1,0 +1,32 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::unstable::intrinsics;
+
+pub struct A;
+pub struct B(Option<A>);
+pub struct C(Option<int>);
+pub struct D(Option<&'static str>);
+pub struct E(Result<&'static str, int>);
+
+pub type F = Option<int>;
+pub type G = uint;
+pub type H = &'static str;
+
+pub unsafe fn id_A() -> u64 { intrinsics::type_id::<A>() }
+pub unsafe fn id_B() -> u64 { intrinsics::type_id::<B>() }
+pub unsafe fn id_C() -> u64 { intrinsics::type_id::<C>() }
+pub unsafe fn id_D() -> u64 { intrinsics::type_id::<D>() }
+pub unsafe fn id_E() -> u64 { intrinsics::type_id::<E>() }
+pub unsafe fn id_F() -> u64 { intrinsics::type_id::<F>() }
+pub unsafe fn id_G() -> u64 { intrinsics::type_id::<G>() }
+pub unsafe fn id_H() -> u64 { intrinsics::type_id::<H>() }
+
+pub unsafe fn foo<T: 'static>() -> u64 { intrinsics::type_id::<T>() }

--- a/src/test/run-pass/typeid-intrinsic.rs
+++ b/src/test/run-pass/typeid-intrinsic.rs
@@ -1,0 +1,53 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast windows doesn't like aux-build
+// aux-build:typeid-intrinsic.rs
+// aux-build:typeid-intrinsic2.rs
+
+extern mod other1(name = "typeid-intrinsic");
+extern mod other2(name = "typeid-intrinsic2");
+
+use std::unstable::intrinsics;
+
+struct A;
+
+fn main() {
+    unsafe {
+        assert_eq!(intrinsics::type_id::<other1::A>(), other1::id_A());
+        assert_eq!(intrinsics::type_id::<other1::B>(), other1::id_B());
+        assert_eq!(intrinsics::type_id::<other1::C>(), other1::id_C());
+        assert_eq!(intrinsics::type_id::<other1::D>(), other1::id_D());
+        assert_eq!(intrinsics::type_id::<other1::E>(), other1::id_E());
+        assert_eq!(intrinsics::type_id::<other1::F>(), other1::id_F());
+        assert_eq!(intrinsics::type_id::<other1::G>(), other1::id_G());
+        assert_eq!(intrinsics::type_id::<other1::H>(), other1::id_H());
+
+        assert_eq!(intrinsics::type_id::<other2::A>(), other2::id_A());
+        assert_eq!(intrinsics::type_id::<other2::B>(), other2::id_B());
+        assert_eq!(intrinsics::type_id::<other2::C>(), other2::id_C());
+        assert_eq!(intrinsics::type_id::<other2::D>(), other2::id_D());
+        assert_eq!(intrinsics::type_id::<other2::E>(), other2::id_E());
+        assert_eq!(intrinsics::type_id::<other2::F>(), other2::id_F());
+        assert_eq!(intrinsics::type_id::<other2::G>(), other2::id_G());
+        assert_eq!(intrinsics::type_id::<other2::H>(), other2::id_H());
+
+        assert_eq!(other1::id_F(), other2::id_F());
+        assert_eq!(other1::id_G(), other2::id_G());
+        assert_eq!(other1::id_H(), other2::id_H());
+
+        assert_eq!(intrinsics::type_id::<int>(), other2::foo::<int>());
+        assert_eq!(intrinsics::type_id::<int>(), other1::foo::<int>());
+        assert_eq!(other2::foo::<int>(), other1::foo::<int>());
+        assert_eq!(intrinsics::type_id::<A>(), other2::foo::<A>());
+        assert_eq!(intrinsics::type_id::<A>(), other1::foo::<A>());
+        assert_eq!(other2::foo::<A>(), other1::foo::<A>());
+    }
+}


### PR DESCRIPTION
This isn't quite as fancy as the struct in #9913, but I'm not sure we should be exposing crate names/hashes of the types. That being said, it'd be pretty easy to extend this (the deterministic hashing regardless of what crate you're in was the hard part).
