### PR TITLE
Give test and main tasks better names

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -869,6 +869,10 @@ pub fn run_test(force_ignore: bool,
         do task::spawn {
             let mut task = task::task();
             task.unlinked();
+            task.name(match desc.name {
+                DynTestName(ref name) => SendStrOwned(name.clone()),
+                StaticTestName(name) => SendStrStatic(name),
+            });
             let result_future = task.future_result();
             task.spawn(testfn_cell.take());
 

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -68,6 +68,7 @@ use rt::sched::{Scheduler, Shutdown};
 use rt::sleeper_list::SleeperList;
 use rt::task::UnwindResult;
 use rt::task::{Task, SchedTask, GreenTask, Sched};
+use send_str::SendStrStatic;
 use unstable::atomics::{AtomicInt, AtomicBool, SeqCst};
 use unstable::sync::UnsafeArc;
 use vec::{OwnedVector, MutableVector, ImmutableVector};
@@ -373,6 +374,7 @@ fn run_(main: ~fn(), use_main_sched: bool) -> int {
         // run the main task in one of our threads.
 
         let mut main_task = ~Task::new_root(&mut scheds[0].stack_pool, None, main.take());
+        main_task.name = Some(SendStrStatic("<main>"));
         main_task.death.on_exit = Some(on_exit.take());
         let main_task_cell = Cell::new(main_task);
 
@@ -410,6 +412,7 @@ fn run_(main: ~fn(), use_main_sched: bool) -> int {
         let home = Sched(main_sched.make_handle());
         let mut main_task = ~Task::new_root_homed(&mut main_sched.stack_pool, None,
                                                   home, main.take());
+        main_task.name = Some(SendStrStatic("<main>"));
         main_task.death.on_exit = Some(on_exit.take());
         rtdebug!("bootstrapping main_task");
 

--- a/src/test/run-fail/main-fail.rs
+++ b/src/test/run-fail/main-fail.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task '<main>' failed at
+
+fn main() {
+    fail!()
+}

--- a/src/test/run-fail/test-fail.rs
+++ b/src/test/run-fail/test-fail.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:task 'test_foo' failed at
+// compile-flags: --test
+
+#[test]
+fn test_foo() {
+    fail!()
+}
+


### PR DESCRIPTION
Tests now have the same name as the test that they're running (to allow for
easier diagnosing of failure sources), and the main task is now specially named
`<main>` instead of `<unnamed>`.

Closes #10195
Closes #10073
