### PR TITLE
Implement an O(1) stack treemap move iterator

### DIFF
--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -792,7 +792,6 @@ mod test {
 
     #[test]
     fn test_serialize_round_trip() {
-        use std;
         use ebml;
         use serialize::{Encodable, Decodable};
 


### PR DESCRIPTION
Because the move iterator contains ownership of the tree, we can destructure it
as we go (and modify the internal structure). This also allows us to make the
move iterator for a treemap invertable and exactly sized (for an enumerable
variant). Sadly, I know of no way to extend this to a normal iterator, so iter()
will still require a stack allocation for now.

Additionally, this implements the clear() method in terms of move_iter() to
force O(1) stack usage when clearing a tree. I tried to implement this in a Drop
implementation for `TreeMap` as well, but I ran into ICE problems about some
missing vtables, so I'll leave that implementation for a later date. The idea
would be that dropping a `TreeMap` requires O(1) stack space instead of O(depth)
stack space.
