### PR TITLE
Reduce the aggressiveness of reachability

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2469,7 +2469,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
     match val {
         Some(v) => v,
         None => {
-            let mut exprt = false;
+            let mut foreign = false;
             let item = ccx.tcx.items.get_copy(&id);
             let val = match item {
                 ast_map::node_item(i, pth) => {
@@ -2582,7 +2582,6 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
                                          get_item_val()");
                         }
                         ast::provided(m) => {
-                            exprt = true;
                             register_method(ccx, id, pth, m)
                         }
                     }
@@ -2594,7 +2593,7 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
 
                 ast_map::node_foreign_item(ni, abis, _, pth) => {
                     let ty = ty::node_id_to_type(ccx.tcx, ni.id);
-                    exprt = true;
+                    foreign = true;
 
                     match ni.node {
                         ast::foreign_item_fn(*) => {
@@ -2688,7 +2687,10 @@ pub fn get_item_val(ccx: @mut CrateContext, id: ast::NodeId) -> ValueRef {
                 }
             };
 
-            if !exprt && !ccx.reachable.contains(&id) {
+            // foreign items (extern fns and extern statics) don't have internal
+            // linkage b/c that doesn't quite make sense. Otherwise items can
+            // have internal linkage if they're not reachable.
+            if !foreign && !ccx.reachable.contains(&id) {
                 lib::llvm::SetLinkage(val, lib::llvm::InternalLinkage);
             }
 

--- a/src/test/auxiliary/linkage-visibility.rs
+++ b/src/test/auxiliary/linkage-visibility.rs
@@ -1,0 +1,36 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::unstable::dynamic_lib::DynamicLibrary;
+
+#[no_mangle]
+pub fn foo() { bar(); }
+
+pub fn foo2<T>() {
+    fn bar2() {
+        bar();
+    }
+    bar2();
+}
+
+#[no_mangle]
+fn bar() { }
+
+#[no_mangle]
+fn baz() { }
+
+pub fn test() {
+    let lib = DynamicLibrary::open(None).unwrap();
+    unsafe {
+        assert!(lib.symbol::<int>("foo").is_ok());
+        assert!(lib.symbol::<int>("baz").is_err());
+        assert!(lib.symbol::<int>("bar").is_err());
+    }
+}

--- a/src/test/run-pass/linkage-visibility.rs
+++ b/src/test/run-pass/linkage-visibility.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:linkage-visibility.rs
+// xfail-fast windows doesn't like aux-build
+
+extern mod foo(name = "linkage-visibility");
+
+fn main() {
+    foo::test();
+    foo::foo2::<int>();
+    foo::foo();
+}


### PR DESCRIPTION
Previously, all functions called by a reachable function were considered
reachable, but this is only the case if the original function was possibly
inlineable (if it's type generic or #[inline]-flagged).
