### PR TITLE
Drop struct fields if the user destructor fails

### DIFF
--- a/src/test/run-pass/fail-in-dtor-drops-fields.rs
+++ b/src/test/run-pass/fail-in-dtor-drops-fields.rs
@@ -1,0 +1,42 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::task;
+
+static mut dropped: bool = false;
+
+struct A {
+    b: B,
+}
+
+struct B {
+    foo: int,
+}
+
+impl Drop for A {
+    fn drop(&mut self) {
+        fail!()
+    }
+}
+
+impl Drop for B {
+    fn drop(&mut self) {
+        unsafe { dropped = true; }
+    }
+}
+
+pub fn main() {
+    let ret = do task::try {
+        let _a = A { b: B { foo: 3 } };
+    };
+    assert!(ret.is_err());
+    unsafe { assert!(dropped); }
+}
+


### PR DESCRIPTION
This commit changes drop glue generated for structs to use the invoke LLVM
instruction instead of call. What this means is that if the user destructor
triggers an unwinding, then the fields of the struct will still ge dropped.

This is not an attempt to support failing while failing, as that's mostly a
problem of runtime support. This is more of an issue of soundness in making sure
that destructors are appropriately run. The test included fails before this
commit, and only has one call to fail!(), yet it doesn't destroy its struct
fields.
