### PR TITLE
configure: Fix passing multiple target and host triples.

### DIFF
--- a/configure
+++ b/configure
@@ -401,9 +401,9 @@ valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 valopt libdir "${CFG_PREFIX}/lib" "install libraries" 
 
 #Deprecated opts to keep compatibility
-valopt build-triple "${CFG_BUILD}" "LLVM build triple"
-valopt host-triples "${CFG_HOST}" "LLVM host triples"
-valopt target-triples "${CFG_TARGET}" "LLVM target triples"
+valopt build-triple "" "LLVM build triple"
+valopt host-triples "" "LLVM host triples"
+valopt target-triples "" "LLVM target triples"
 
 # Validate Options
 step_msg "validating $CFG_SELF args"
@@ -602,6 +602,18 @@ fi
 
 # a little post-processing of various config values
 
+# XXX: Support for deprecated syntax, should be dropped.
+if [ ! -z "$CFG_BUILD_TRIPLE" ]; then
+    CFG_BUILD=${CFG_BUILD_TRIPLE}
+fi
+if [ ! -z "$CFG_HOST_TRIPLES" ]; then
+    CFG_HOST=${CFG_HOST_TRIPLES}
+fi
+if [ ! -z "$CFG_TARGET_TRIPLES" ]; then
+    CFG_TARGET=${CFG_TARGET_TRIPLES}
+fi
+
+
 CFG_PREFIX=${CFG_PREFIX%/}
 CFG_MANDIR=${CFG_MANDIR%/}
 CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"
@@ -615,26 +627,6 @@ do
    echo "$V_TEMP" | grep -qF $i || V_TEMP="$V_TEMP${V_TEMP:+ }$i"
 done
 CFG_TARGET=$V_TEMP
-
-# copy host-triples to target-triples so that hosts are a subset of targets
-# XXX: remove deprecated variables here
-V_TEMP=""
-for i in $CFG_HOST_TRIPLES $CFG_TARGET_TRIPLES;
-do
-   echo "$V_TEMP" | grep -qF $i || V_TEMP="$V_TEMP${V_TEMP:+ }$i"
-done
-CFG_TARGET_TRIPLES=$V_TEMP
-
-# XXX: Support for deprecated syntax, should be dropped.
-if [ ! -z "$CFG_BUILD_TRIPLE" ]; then
-    CFG_BUILD=${CFG_BUILD_TRIPLE}
-fi
-if [ ! -z "$CFG_HOST_TRIPLES" ]; then
-    CFG_HOST=${CFG_HOST_TRIPLES}
-fi
-if [ ! -z "$CFG_TARGET_TRIPLES" ]; then
-    CFG_TARGET=${CFG_TARGET_TRIPLES}
-fi
 
 # check target-specific tool-chains
 for i in $CFG_TARGET

--- a/configure
+++ b/configure
@@ -400,11 +400,6 @@ valopt infodir "${CFG_PREFIX}/share/info" "install additional info"
 valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 valopt libdir "${CFG_PREFIX}/lib" "install libraries" 
 
-#Deprecated opts to keep compatibility
-valopt build-triple "" "LLVM build triple"
-valopt host-triples "" "LLVM host triples"
-valopt target-triples "" "LLVM target triples"
-
 # Validate Options
 step_msg "validating $CFG_SELF args"
 validate_opt
@@ -601,19 +596,6 @@ then
 fi
 
 # a little post-processing of various config values
-
-# XXX: Support for deprecated syntax, should be dropped.
-if [ ! -z "$CFG_BUILD_TRIPLE" ]; then
-    CFG_BUILD=${CFG_BUILD_TRIPLE}
-fi
-if [ ! -z "$CFG_HOST_TRIPLES" ]; then
-    CFG_HOST=${CFG_HOST_TRIPLES}
-fi
-if [ ! -z "$CFG_TARGET_TRIPLES" ]; then
-    CFG_TARGET=${CFG_TARGET_TRIPLES}
-fi
-
-
 CFG_PREFIX=${CFG_PREFIX%/}
 CFG_MANDIR=${CFG_MANDIR%/}
 CFG_HOST="$(echo $CFG_HOST | tr ',' ' ')"

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -42,14 +42,14 @@ $(HLIB0_H_$(CFG_BUILD))/$(CFG_EXTRALIB_$(CFG_BUILD)): \
 		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_LIBRUSTUV_$(CFG_BUILD)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_LIBRUSTUV_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
-$(HLIB0_H_$(CFG_BUILD_TRIPLE))/$(CFG_LIBRUSTC_$(CFG_BUILD)): \
-		$(HBIN0_H_$(CFG_BUILD_TRIPLE))/rustc$(X_$(CFG_BUILD)) \
-		| $(HLIB0_H_$(CFG_BUILD_TRIPLE))/
+$(HLIB0_H_$(CFG_BUILD))/$(CFG_LIBRUSTC_$(CFG_BUILD)): \
+		$(HBIN0_H_$(CFG_BUILD))/rustc$(X_$(CFG_BUILD)) \
+		| $(HLIB0_H_$(CFG_BUILD))/
 	$(Q)touch $@
 
 $(HLIB0_H_$(CFG_BUILD))/$(CFG_RUSTLLVM_$(CFG_BUILD)): \
@@ -124,5 +124,5 @@ endef
 
 # Use stage1 to build other architectures: then you don't have to wait
 # for stage2, but you get the latest updates to the compiler source.
-$(foreach t,$(NON_BUILD_HOSTS),								\
+$(foreach t,$(NON_BUILD_HOST),								\
  $(eval $(call BOOTSTRAP_STAGE0,$(t),1,$(CFG_BUILD))))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -164,7 +164,7 @@ $(info check: android device test dir $(CFG_ADB_TEST_DIR) ready \
                   $(CFG_ADB_TEST_DIR)) \
  $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD))/$(EXTRALIB_GLOB_arm-linux-androideabi) \
                   $(CFG_ADB_TEST_DIR)) \
- $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD_TRIPLE))/$(LIBRUSTUV_GLOB_arm-linux-androideabi) \
+ $(shell adb push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD))/$(LIBRUSTUV_GLOB_arm-linux-androideabi) \
                   $(CFG_ADB_TEST_DIR)) \
  )
 else
@@ -471,8 +471,8 @@ define DEF_RUSTPKG_STACK_FIX
 $$(call TEST_OK_FILE,$(1),$(2),$(3),rustpkg): export RUST_MIN_STACK=8000000
 endef
 
-$(foreach host,$(CFG_HOST_TRIPLES), \
- $(foreach target,$(CFG_TARGET_TRIPLES), \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
   $(foreach stage,$(STAGES), \
    $(eval $(call DEF_RUSTPKG_STACK_FIX,$(stage),$(target),$(host))))))
 


### PR DESCRIPTION
Previously we were actually overwriting `CFG_{HOST,TARGET,BUILD}` with `CFG_{HOST,TARGET,BUILD}_TRIPLE(S)` since configure tested for the legacy one by checking if it was empty which would never be the case. That meant it wouldn't split up multiple triples and just treat it as one long triple.

This pull also fixes the rules that were changed when librustuv was added to use the right CFG_ vars and removes the legacy flags.
