### PR TITLE
Bump required pandoc version to 1.9.

### DIFF
--- a/configure
+++ b/configure
@@ -468,12 +468,14 @@ then
         # extract the first 2 version fields, ignore everything else
         sed 's/pandoc \([0-9]*\)\.\([0-9]*\).*/\1 \2/')
 
+    MIN_PV_MAJOR="1"
+    MIN_PV_MINOR="9"
     # these patterns are shell globs, *not* regexps
     PV_MAJOR=${PV_MAJOR_MINOR% *}
     PV_MINOR=${PV_MAJOR_MINOR#* }
-    if [ "$PV_MAJOR" -lt "1" ] || [ "$PV_MINOR" -lt "8" ]
+    if [ "$PV_MAJOR" -lt "$MIN_PV_MAJOR" ] || [ "$PV_MINOR" -lt "$MIN_PV_MINOR" ]
     then
-		step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. disabling"
+		step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. Need at least $MIN_PV_MAJOR.$MIN_PV_MINOR. Disabling"
 		BAD_PANDOC=1
     fi
 fi


### PR DESCRIPTION
Earlier versions of pandoc don't have the `default.html5` template file. When `make docs` is run, the build process fails with this message.

```
pandoc: doc/rust.html
pandoc: /usr/share/pandoc-1.8.2.1/templates/default.html5: openFile: does not exist (No such file or directory)

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
Error: write EPIPE
    at errnoException (net.js:670:11)
    at Object.afterWrite [as oncomplete] (net.js:503:19)
make: *** [doc/rust.html] Error 1
```
