### PR TITLE
Create epub versions of tutorial and ref manual.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 *.cps
 *.log
 *.pdf
+*.epub
 *.html
 *.pg
 *.toc

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -53,7 +53,7 @@ clean-misc:
 	$(Q)rm -Rf tmp/*
 	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz dist
 	$(Q)rm -Rf $(foreach ext, \
-                 html aux cp fn ky log pdf pg toc tp vr cps, \
+                 html aux cp fn ky log pdf pg toc tp vr cps epub, \
                  $(wildcard doc/*.$(ext)))
 	$(Q)find doc/std doc/extra -mindepth 1 | xargs rm -Rf
 	$(Q)rm -Rf doc/version.md

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -64,6 +64,20 @@ doc/rust.tex: rust.md doc/version.md
          --from=markdown --to=latex \
          --output=$@
 
+DOCS += doc/rust.epub
+doc/rust.epub: rust.md doc/version_info.html doc/rust.css doc/manual.inc
+	@$(call E, pandoc: $@)
+	$(Q)$(CFG_NODE) $(S)doc/prep.js --highlight $< | \
+	"$(CFG_PANDOC)" \
+         --standalone --toc \
+         --section-divs \
+         --number-sections \
+         --from=markdown --to=epub \
+         --css=rust.css --include-in-header=doc/manual.inc \
+         --include-before-body=doc/version_info.html \
+         --output=$@
+
+
 DOCS += doc/tutorial.tex
 doc/tutorial.tex: tutorial.md doc/version.md
 	@$(call E, pandoc: $@)
@@ -97,6 +111,17 @@ doc/tutorial.html: tutorial.md doc/version_info.html doc/rust.css
            --from=markdown --to=html5 --css=rust.css \
            --include-before-body=doc/version_info.html \
            --output=$@
+
+DOCS += doc/tutorial.epub
+doc/tutorial.epub: tutorial.md doc/version_info.html doc/rust.css
+	@$(call E, pandoc: $@)
+	$(Q)$(CFG_NODE) $(S)doc/prep.js --highlight $< | \
+          $(CFG_PANDOC) --standalone --toc \
+           --section-divs --number-sections \
+           --from=markdown --to=epub --css=rust.css \
+           --include-before-body=doc/version_info.html \
+           --output=$@
+
 
 DOCS_L10N += doc/l10n/ja/tutorial.html
 doc/l10n/ja/tutorial.html: doc/l10n/ja/tutorial.md doc/version_info.html doc/rust.css


### PR DESCRIPTION
Added two new rules to create epubs out of the tutorial and reference manual source files. This is useful and doesn't add any new dependencies to the build process. 
