### PR TITLE
Use consistent capitalization in makefile errors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -249,12 +249,12 @@ endef
 # by $(2) with a space character prefix, which invalidates the
 # construction $(1)$(2).
 define CHECK_FOR_OLD_GLOB_MATCHES_EXCEPT
-  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "Warning: there are previous" \'$(2)\' "libraries:" $$MATCHES; fi
+  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "warning: there are previous" \'$(2)\' "libraries:" $$MATCHES; fi
 endef
 
 # Same interface as above, but deletes rather than just listing the files.
 define REMOVE_ALL_OLD_GLOB_MATCHES_EXCEPT
-  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "Warning: removing previous" \'$(2)\' "libraries:" $$MATCHES; rm $$MATCHES ; fi
+  $(Q)MATCHES="$(filter-out %$(3),$(wildcard $(1)/$(2)))"; if [ -n "$$MATCHES" ] ; then echo "warning: removing previous" \'$(2)\' "libraries:" $$MATCHES; rm $$MATCHES ; fi
 endef
 
 # We use a different strategy for LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
@@ -265,7 +265,7 @@ endef
 # be run at the outset of a command list in a rule.)
 ifdef VERBOSE
 define LIST_ALL_OLD_GLOB_MATCHES_EXCEPT
-  @echo "Info: now are following matches for" '$(2)' "libraries:"
+  @echo "info: now are following matches for" '$(2)' "libraries:"
   @( cd $(1) && ( ls $(2) 2>/dev/null || true ) | grep -v $(3) || true )
 endef
 else

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -50,7 +50,7 @@ define INSTALL_LIB
   MATCHES="$(filter-out %$(notdir $(lastword $(wildcard $(LIB_SOURCE_DIR)/$(1)))),\
                         $(wildcard $(LIB_DESTIN_DIR)/$(1)))";              \
   if [ -n "$$MATCHES" ]; then                                              \
-    echo "Warning, one or libraries matching Rust library '$(1)'" &&       \
+    echo "warning: one or libraries matching Rust library '$(1)'" &&       \
     echo "  (other than '$$LIB_NAME' itself) already present"     &&       \
     echo "  at destination $(LIB_DESTIN_DIR):"                    &&       \
     echo $$MATCHES ;                                                       \


### PR DESCRIPTION
In Rust we don't like capital letters.
