### PR TITLE
Rustdoc: Properly strip private modules

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -622,6 +622,11 @@ impl DocFolder for Cache {
                         }
                         None
                     }
+                    // Private modules may survive the strip-private pass if
+                    // they contain impls for public types, but those will get
+                    // stripped here
+                    clean::Item { inner: clean::ModuleItem(ref m), _ }
+                            if m.items.len() == 0 => None,
                     i => Some(i),
                 }
             }


### PR DESCRIPTION
A private module will survive the strip-private pass if it contains
trait implementations, which aren't stripped until a separate pass in
render.
