### PR TITLE
remove RetVoid from abort intrinsic

### DIFF
--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -221,7 +221,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
         "abort" => {
             let llfn = bcx.ccx().intrinsics.get_copy(&("llvm.trap"));
             Call(bcx, llfn, [], []);
-            RetVoid(bcx);
+            Unreachable(bcx);
         }
         "size_of" => {
             let tp_ty = substs.tys[0];


### PR DESCRIPTION
The function is marked `noreturn`, so it shouldn't have this.
