### PR TITLE
simplify memcpy/memmove/memset intrinsics

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3734,7 +3734,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                    mutbl: ast::MutImmutable
                }))
             }
-            "memcpy32" => {
+            "copy_nonoverlapping_memory" => {
               (1,
                ~[
                   ty::mk_ptr(tcx, ty::mt {
@@ -3745,11 +3745,11 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                       ty: param(ccx, 0),
                       mutbl: ast::MutImmutable
                   }),
-                  ty::mk_u32()
+                  ty::mk_uint()
                ],
                ty::mk_nil())
             }
-            "memcpy64" => {
+            "copy_memory" => {
               (1,
                ~[
                   ty::mk_ptr(tcx, ty::mt {
@@ -3760,41 +3760,11 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                       ty: param(ccx, 0),
                       mutbl: ast::MutImmutable
                   }),
-                  ty::mk_u64()
+                  ty::mk_uint()
                ],
                ty::mk_nil())
             }
-            "memmove32" => {
-              (1,
-               ~[
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutMutable
-                  }),
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutImmutable
-                  }),
-                  ty::mk_u32()
-               ],
-               ty::mk_nil())
-            }
-            "memmove64" => {
-              (1,
-               ~[
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutMutable
-                  }),
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutImmutable
-                  }),
-                  ty::mk_u64()
-               ],
-               ty::mk_nil())
-            }
-            "memset32" => {
+            "set_memory" => {
               (1,
                ~[
                   ty::mk_ptr(tcx, ty::mt {
@@ -3802,19 +3772,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                       mutbl: ast::MutMutable
                   }),
                   ty::mk_u8(),
-                  ty::mk_u32()
-               ],
-               ty::mk_nil())
-            }
-            "memset64" => {
-              (1,
-               ~[
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutMutable
-                  }),
-                  ty::mk_u8(),
-                  ty::mk_u64()
+                  ty::mk_uint()
                ],
                ty::mk_nil())
             }

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -13,26 +13,15 @@
 use ptr::RawPtr;
 use mem;
 use unstable::intrinsics;
+use ptr::copy_nonoverlapping_memory;
 
 /// Casts the value at `src` to U. The two types must have the same length.
-#[cfg(target_word_size = "32")]
 #[inline]
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
     let mut dest: U = intrinsics::uninit();
     let dest_ptr: *mut u8 = transmute(&mut dest);
     let src_ptr: *u8 = transmute(src);
-    intrinsics::memcpy32(dest_ptr, src_ptr, mem::size_of::<U>() as u32);
-    dest
-}
-
-/// Casts the value at `src` to U. The two types must have the same length.
-#[cfg(target_word_size = "64")]
-#[inline]
-pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    let mut dest: U = intrinsics::uninit();
-    let dest_ptr: *mut u8 = transmute(&mut dest);
-    let src_ptr: *u8 = transmute(src);
-    intrinsics::memcpy64(dest_ptr, src_ptr, mem::size_of::<U>() as u64);
+    copy_nonoverlapping_memory(dest_ptr, src_ptr, mem::size_of::<U>());
     dest
 }
 

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -87,7 +87,7 @@ pub fn is_not_null<T,P:RawPtr<T>>(ptr: P) -> bool { ptr.is_not_null() }
  * and destination may overlap.
  */
 #[inline]
-#[cfg(target_word_size = "32")]
+#[cfg(target_word_size = "32", stage0)]
 pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
     intrinsics::memmove32(dst,
                           cast::transmute_immut_unsafe(src),
@@ -101,7 +101,7 @@ pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
  * and destination may overlap.
  */
 #[inline]
-#[cfg(target_word_size = "64")]
+#[cfg(target_word_size = "64", stage0)]
 pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
     intrinsics::memmove64(dst,
                           cast::transmute_immut_unsafe(src),
@@ -112,10 +112,22 @@ pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
  * Copies data from one location to another.
  *
  * Copies `count` elements (not bytes) from `src` to `dst`. The source
+ * and destination may overlap.
+ */
+#[inline]
+#[cfg(not(stage0))]
+pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
+    intrinsics::copy_memory(dst, cast::transmute_immut_unsafe(src), count)
+}
+
+/**
+ * Copies data from one location to another.
+ *
+ * Copies `count` elements (not bytes) from `src` to `dst`. The source
  * and destination may *not* overlap.
  */
 #[inline]
-#[cfg(target_word_size = "32")]
+#[cfg(target_word_size = "32", stage0)]
 pub unsafe fn copy_nonoverlapping_memory<T,P:RawPtr<T>>(dst: *mut T,
                                                         src: P,
                                                         count: uint) {
@@ -131,7 +143,7 @@ pub unsafe fn copy_nonoverlapping_memory<T,P:RawPtr<T>>(dst: *mut T,
  * and destination may *not* overlap.
  */
 #[inline]
-#[cfg(target_word_size = "64")]
+#[cfg(target_word_size = "64", stage0)]
 pub unsafe fn copy_nonoverlapping_memory<T,P:RawPtr<T>>(dst: *mut T,
                                                         src: P,
                                                         count: uint) {
@@ -141,11 +153,25 @@ pub unsafe fn copy_nonoverlapping_memory<T,P:RawPtr<T>>(dst: *mut T,
 }
 
 /**
+ * Copies data from one location to another.
+ *
+ * Copies `count` elements (not bytes) from `src` to `dst`. The source
+ * and destination may *not* overlap.
+ */
+#[inline]
+#[cfg(not(stage0))]
+pub unsafe fn copy_nonoverlapping_memory<T,P:RawPtr<T>>(dst: *mut T,
+                                                        src: P,
+                                                        count: uint) {
+    intrinsics::copy_nonoverlapping_memory(dst, cast::transmute_immut_unsafe(src), count)
+}
+
+/**
  * Invokes memset on the specified pointer, setting `count * size_of::<T>()`
  * bytes of memory starting at `dst` to `c`.
  */
 #[inline]
-#[cfg(target_word_size = "32")]
+#[cfg(target_word_size = "32", stage0)]
 pub unsafe fn set_memory<T>(dst: *mut T, c: u8, count: uint) {
     intrinsics::memset32(dst, c, count as u32);
 }
@@ -155,9 +181,19 @@ pub unsafe fn set_memory<T>(dst: *mut T, c: u8, count: uint) {
  * bytes of memory starting at `dst` to `c`.
  */
 #[inline]
-#[cfg(target_word_size = "64")]
+#[cfg(target_word_size = "64", stage0)]
 pub unsafe fn set_memory<T>(dst: *mut T, c: u8, count: uint) {
     intrinsics::memset64(dst, c, count as u64);
+}
+
+/**
+ * Invokes memset on the specified pointer, setting `count * size_of::<T>()`
+ * bytes of memory starting at `dst` to `c`.
+ */
+#[inline]
+#[cfg(not(stage0))]
+pub unsafe fn set_memory<T>(dst: *mut T, c: u8, count: uint) {
+    intrinsics::set_memory(dst, c, count)
 }
 
 /**

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -345,24 +345,39 @@ extern "rust-intrinsic" {
 
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
+    #[cfg(stage0)]
     pub fn memcpy32<T>(dst: *mut T, src: *T, count: u32);
     /// Equivalent to the `llvm.memcpy.p0i8.0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
+    #[cfg(stage0)]
     pub fn memcpy64<T>(dst: *mut T, src: *T, count: u64);
 
     /// Equivalent to the `llvm.memmove.p0i8.0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
+    #[cfg(stage0)]
     pub fn memmove32<T>(dst: *mut T, src: *T, count: u32);
     /// Equivalent to the `llvm.memmove.p0i8.0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
+    #[cfg(stage0)]
     pub fn memmove64<T>(dst: *mut T, src: *T, count: u64);
 
     /// Equivalent to the `llvm.memset.p0i8.i32` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
+    #[cfg(stage0)]
     pub fn memset32<T>(dst: *mut T, val: u8, count: u32);
     /// Equivalent to the `llvm.memset.p0i8.i64` intrinsic, with a size of
     /// `count` * `size_of::<T>()` and an alignment of `min_align_of::<T>()`
+    #[cfg(stage0)]
     pub fn memset64<T>(dst: *mut T, val: u8, count: u64);
+
+    #[cfg(not(stage0))]
+    pub fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *T, count: uint);
+
+    #[cfg(not(stage0))]
+    pub fn copy_memory<T>(dst: *mut T, src: *T, count: uint);
+
+    #[cfg(not(stage0))]
+    pub fn set_memory<T>(dst: *mut T, val: u8, count: uint);
 
     pub fn sqrtf32(x: f32) -> f32;
     pub fn sqrtf64(x: f64) -> f64;


### PR DESCRIPTION
This moves the per-architecture difference into the compiler.
