### PR TITLE
Reduce a large amount of uv boilerplate

### DIFF
--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -235,7 +235,7 @@ pub fn accum_addrinfo(addr: &net::UvAddrInfo) -> ~[ai::Info] {
     }
 }
 
-impl NativeHandle<*uvll::uv_getaddrinfo_t> for GetAddrInfoRequest {
+impl NativeHandle<uvll::uv_getaddrinfo_t> for GetAddrInfoRequest {
     fn from_native_handle(handle: *uvll::uv_getaddrinfo_t) -> GetAddrInfoRequest {
         GetAddrInfoRequest(handle)
     }

--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -110,12 +110,12 @@ impl GetAddrInfoRequest {
         self.get_req_data().getaddrinfo_cb = Some(wrapper_cb);
 
         unsafe {
-            assert!(0 == uvll::getaddrinfo(loop_.native_handle(),
-                                           self.native_handle(),
-                                           getaddrinfo_cb,
-                                           c_node_ptr,
-                                           c_service_ptr,
-                                           hint_ptr));
+            assert!(0 == uvll::uv_getaddrinfo(loop_.native_handle(),
+                                              self.native_handle(),
+                                              getaddrinfo_cb,
+                                              c_node_ptr,
+                                              c_service_ptr,
+                                              hint_ptr));
         }
 
         extern "C" fn getaddrinfo_cb(req: *uvll::uv_getaddrinfo_t,
@@ -127,7 +127,7 @@ impl GetAddrInfoRequest {
             let data = req.get_req_data();
             (*data.getaddrinfo_cb.get_ref())(req, &addrinfo, err);
             unsafe {
-                uvll::freeaddrinfo(res);
+                uvll::uv_freeaddrinfo(res);
             }
         }
     }

--- a/src/librustuv/async.rs
+++ b/src/librustuv/async.rs
@@ -26,7 +26,7 @@ impl AsyncWatcher {
             watcher.install_watcher_data();
             let data = watcher.get_watcher_data();
             data.async_cb = Some(cb);
-            assert_eq!(0, uvll::async_init(loop_.native_handle(), handle, async_cb));
+            assert_eq!(0, uvll::uv_async_init(loop_.native_handle(), handle, async_cb));
             return watcher;
         }
 
@@ -42,7 +42,7 @@ impl AsyncWatcher {
     pub fn send(&mut self) {
         unsafe {
             let handle = self.native_handle();
-            uvll::async_send(handle);
+            uvll::uv_async_send(handle);
         }
     }
 }

--- a/src/librustuv/async.rs
+++ b/src/librustuv/async.rs
@@ -19,16 +19,13 @@ impl Watcher for AsyncWatcher { }
 
 impl AsyncWatcher {
     pub fn new(loop_: &mut Loop, cb: AsyncCallback) -> AsyncWatcher {
-        unsafe {
-            let handle = uvll::malloc_handle(uvll::UV_ASYNC);
-            assert!(handle.is_not_null());
-            let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
-            watcher.install_watcher_data();
-            let data = watcher.get_watcher_data();
-            data.async_cb = Some(cb);
-            assert_eq!(0, uvll::uv_async_init(loop_.native_handle(), handle, async_cb));
-            return watcher;
-        }
+        let mut watcher: AsyncWatcher = NativeHandle::alloc(uvll::UV_ASYNC);
+        assert_eq!(unsafe {
+            uvll::uv_async_init(loop_.native_handle(), *watcher, async_cb)
+        }, 0);
+        watcher.install_watcher_data();
+        watcher.get_watcher_data().async_cb = Some(cb);
+        return watcher;
 
         extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {
             let mut watcher: AsyncWatcher = NativeHandle::from_native_handle(handle);
@@ -40,14 +37,11 @@ impl AsyncWatcher {
     }
 
     pub fn send(&mut self) {
-        unsafe {
-            let handle = self.native_handle();
-            uvll::uv_async_send(handle);
-        }
+        unsafe { uvll::uv_async_send(self.native_handle()) }
     }
 }
 
-impl NativeHandle<*uvll::uv_async_t> for AsyncWatcher {
+impl NativeHandle<uvll::uv_async_t> for AsyncWatcher {
     fn from_native_handle(handle: *uvll::uv_async_t) -> AsyncWatcher {
         AsyncWatcher(handle)
     }

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -11,10 +11,9 @@
 use std::ptr::null;
 use std::c_str;
 use std::c_str::CString;
-use std::libc::c_void;
-use std::cast::transmute;
 use std::libc;
-use std::libc::{c_int};
+use std::libc::{c_void, c_int, c_uint};
+use std::cast::transmute;
 
 use super::{Request, NativeHandle, Loop, FsCallback, Buf,
             status_to_maybe_uv_error, UvError};
@@ -43,8 +42,9 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = path.with_ref(|p| unsafe {
-            uvll::fs_open(loop_.native_handle(),
-                          self.native_handle(), p, flags, mode, complete_cb_ptr)
+            uvll::uv_fs_open(loop_.native_handle(),
+                             self.native_handle(), p, flags as c_int,
+                             mode as c_int, complete_cb_ptr)
         });
         assert_eq!(ret, 0);
     }
@@ -56,8 +56,9 @@ impl FsRequest {
             me.req_boilerplate(None)
         };
         let result = path.with_ref(|p| unsafe {
-            uvll::fs_open(loop_.native_handle(),
-                    self.native_handle(), p, flags, mode, complete_cb_ptr)
+            uvll::uv_fs_open(loop_.native_handle(),
+                             self.native_handle(), p, flags as c_int,
+                             mode as c_int, complete_cb_ptr)
         });
         self.sync_cleanup(result)
     }
@@ -68,8 +69,8 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = path.with_ref(|p| unsafe {
-            uvll::fs_unlink(loop_.native_handle(),
-                          self.native_handle(), p, complete_cb_ptr)
+            uvll::uv_fs_unlink(loop_.native_handle(),
+                               self.native_handle(), p, complete_cb_ptr)
         });
         assert_eq!(ret, 0);
     }
@@ -81,8 +82,8 @@ impl FsRequest {
             me.req_boilerplate(None)
         };
         let result = path.with_ref(|p| unsafe {
-            uvll::fs_unlink(loop_.native_handle(),
-                          self.native_handle(), p, complete_cb_ptr)
+            uvll::uv_fs_unlink(loop_.native_handle(),
+                               self.native_handle(), p, complete_cb_ptr)
         });
         self.sync_cleanup(result)
     }
@@ -93,8 +94,8 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = path.with_ref(|p| unsafe {
-            uvll::fs_stat(loop_.native_handle(),
-                          self.native_handle(), p, complete_cb_ptr)
+            uvll::uv_fs_stat(loop_.native_handle(),
+                             self.native_handle(), p, complete_cb_ptr)
         });
         assert_eq!(ret, 0);
     }
@@ -107,9 +108,9 @@ impl FsRequest {
         let base_ptr = buf.base as *c_void;
         let len = buf.len as uint;
         let ret = unsafe {
-            uvll::fs_write(loop_.native_handle(), self.native_handle(),
-                           fd, base_ptr,
-                           len, offset, complete_cb_ptr)
+            uvll::uv_fs_write(loop_.native_handle(), self.native_handle(),
+                              fd, base_ptr,
+                              len as c_uint, offset, complete_cb_ptr)
         };
         assert_eq!(ret, 0);
     }
@@ -122,9 +123,9 @@ impl FsRequest {
         let base_ptr = buf.base as *c_void;
         let len = buf.len as uint;
         let result = unsafe {
-            uvll::fs_write(loop_.native_handle(), self.native_handle(),
-                           fd, base_ptr,
-                           len, offset, complete_cb_ptr)
+            uvll::uv_fs_write(loop_.native_handle(), self.native_handle(),
+                              fd, base_ptr,
+                              len as c_uint, offset, complete_cb_ptr)
         };
         self.sync_cleanup(result)
     }
@@ -137,9 +138,9 @@ impl FsRequest {
         let buf_ptr = buf.base as *c_void;
         let len = buf.len as uint;
         let ret = unsafe {
-            uvll::fs_read(loop_.native_handle(), self.native_handle(),
-                           fd, buf_ptr,
-                           len, offset, complete_cb_ptr)
+            uvll::uv_fs_read(loop_.native_handle(), self.native_handle(),
+                             fd, buf_ptr,
+                             len as c_uint, offset, complete_cb_ptr)
         };
         assert_eq!(ret, 0);
     }
@@ -152,9 +153,9 @@ impl FsRequest {
         let buf_ptr = buf.base as *c_void;
         let len = buf.len as uint;
         let result = unsafe {
-            uvll::fs_read(loop_.native_handle(), self.native_handle(),
-                           fd, buf_ptr,
-                           len, offset, complete_cb_ptr)
+            uvll::uv_fs_read(loop_.native_handle(), self.native_handle(),
+                             fd, buf_ptr,
+                             len as c_uint, offset, complete_cb_ptr)
         };
         self.sync_cleanup(result)
     }
@@ -165,8 +166,8 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = unsafe {
-            uvll::fs_close(loop_.native_handle(), self.native_handle(),
-                           fd, complete_cb_ptr)
+            uvll::uv_fs_close(loop_.native_handle(), self.native_handle(),
+                              fd, complete_cb_ptr)
         };
         assert_eq!(ret, 0);
     }
@@ -176,8 +177,8 @@ impl FsRequest {
             me.req_boilerplate(None)
         };
         let result = unsafe {
-            uvll::fs_close(loop_.native_handle(), self.native_handle(),
-                           fd, complete_cb_ptr)
+            uvll::uv_fs_close(loop_.native_handle(), self.native_handle(),
+                              fd, complete_cb_ptr)
         };
         self.sync_cleanup(result)
     }
@@ -188,8 +189,9 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = path.with_ref(|p| unsafe {
-            uvll::fs_mkdir(loop_.native_handle(),
-                           self.native_handle(), p, mode, complete_cb_ptr)
+            uvll::uv_fs_mkdir(loop_.native_handle(),
+                              self.native_handle(), p,
+                              mode as c_int, complete_cb_ptr)
         });
         assert_eq!(ret, 0);
     }
@@ -200,8 +202,8 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = path.with_ref(|p| unsafe {
-            uvll::fs_rmdir(loop_.native_handle(),
-                           self.native_handle(), p, complete_cb_ptr)
+            uvll::uv_fs_rmdir(loop_.native_handle(),
+                              self.native_handle(), p, complete_cb_ptr)
         });
         assert_eq!(ret, 0);
     }
@@ -213,8 +215,8 @@ impl FsRequest {
             me.req_boilerplate(Some(cb))
         };
         let ret = path.with_ref(|p| unsafe {
-            uvll::fs_readdir(loop_.native_handle(),
-                             self.native_handle(), p, flags, complete_cb_ptr)
+            uvll::uv_fs_readdir(loop_.native_handle(),
+                                self.native_handle(), p, flags, complete_cb_ptr)
         });
         assert_eq!(ret, 0);
     }
@@ -228,12 +230,10 @@ impl FsRequest {
             None => Ok(result)
         }
     }
-    fn req_boilerplate(&mut self, cb: Option<FsCallback>) -> *u8 {
+    fn req_boilerplate(&mut self, cb: Option<FsCallback>) -> uvll::uv_fs_cb {
         let result = match cb {
-            Some(_) => {
-                compl_cb as *u8
-            },
-            None => 0 as *u8
+            Some(_) => compl_cb,
+            None => 0 as uvll::uv_fs_cb
         };
         self.install_req_data(cb);
         result
@@ -304,7 +304,7 @@ impl FsRequest {
             let data = uvll::get_data_for_req(self.native_handle());
             let _data = transmute::<*c_void, ~RequestData>(data);
             uvll::set_data_for_req(self.native_handle(), null::<()>());
-            uvll::fs_req_cleanup(self.native_handle());
+            uvll::uv_fs_req_cleanup(self.native_handle());
             free_req(self.native_handle() as *c_void)
         }
     }

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -310,7 +310,7 @@ impl FsRequest {
     }
 }
 
-impl NativeHandle<*uvll::uv_fs_t> for FsRequest {
+impl NativeHandle<uvll::uv_fs_t> for FsRequest {
     fn from_native_handle(handle: *uvll:: uv_fs_t) -> FsRequest {
         FsRequest(handle)
     }

--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -21,7 +21,7 @@ impl IdleWatcher {
         unsafe {
             let handle = uvll::malloc_handle(uvll::UV_IDLE);
             assert!(handle.is_not_null());
-            assert_eq!(uvll::idle_init(loop_.native_handle(), handle), 0);
+            assert_eq!(uvll::uv_idle_init(loop_.native_handle(), handle), 0);
             let mut watcher: IdleWatcher = NativeHandle::from_native_handle(handle);
             watcher.install_watcher_data();
             return watcher
@@ -35,14 +35,14 @@ impl IdleWatcher {
         }
 
         unsafe {
-            assert_eq!(uvll::idle_start(self.native_handle(), idle_cb), 0)
+            assert_eq!(uvll::uv_idle_start(self.native_handle(), idle_cb), 0)
         }
     }
 
     pub fn restart(&mut self) {
         unsafe {
             assert!(self.get_watcher_data().idle_cb.is_some());
-            assert_eq!(uvll::idle_start(self.native_handle(), idle_cb), 0)
+            assert_eq!(uvll::uv_idle_start(self.native_handle(), idle_cb), 0)
         }
     }
 
@@ -52,7 +52,7 @@ impl IdleWatcher {
         // free
 
         unsafe {
-            assert_eq!(uvll::idle_stop(self.native_handle()), 0);
+            assert_eq!(uvll::uv_idle_stop(self.native_handle()), 0);
         }
     }
 }

--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -18,14 +18,12 @@ impl Watcher for IdleWatcher { }
 
 impl IdleWatcher {
     pub fn new(loop_: &mut Loop) -> IdleWatcher {
-        unsafe {
-            let handle = uvll::malloc_handle(uvll::UV_IDLE);
-            assert!(handle.is_not_null());
-            assert_eq!(uvll::uv_idle_init(loop_.native_handle(), handle), 0);
-            let mut watcher: IdleWatcher = NativeHandle::from_native_handle(handle);
-            watcher.install_watcher_data();
-            return watcher
-        }
+        let mut watcher: IdleWatcher = NativeHandle::alloc(uvll::UV_IDLE);
+        assert_eq!(unsafe {
+            uvll::uv_idle_init(loop_.native_handle(), *watcher)
+        }, 0);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     pub fn start(&mut self, cb: IdleCallback) {
@@ -57,7 +55,7 @@ impl IdleWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_idle_t> for IdleWatcher {
+impl NativeHandle<uvll::uv_idle_t> for IdleWatcher {
     fn from_native_handle(handle: *uvll::uv_idle_t) -> IdleWatcher {
         IdleWatcher(handle)
     }

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -48,7 +48,7 @@ use std::str::raw::from_c_str;
 use std::vec;
 use std::ptr;
 use std::str;
-use std::libc::{c_void, c_int, size_t, malloc, free};
+use std::libc::{c_void, c_int, size_t, malloc, free, c_char, c_uint};
 use std::cast::transmute;
 use std::ptr::null;
 use std::unstable::finally::Finally;
@@ -126,11 +126,11 @@ impl Loop {
     }
 
     pub fn run(&mut self) {
-        unsafe { uvll::run(self.native_handle()) };
+        unsafe { uvll::uv_run(self.native_handle(), uvll::RUN_DEFAULT) };
     }
 
     pub fn close(&mut self) {
-        unsafe { uvll::loop_delete(self.native_handle()) };
+        unsafe { uvll::uv_loop_delete(self.native_handle()) };
     }
 }
 
@@ -239,7 +239,9 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
             data.close_cb = Some(cb);
         }
 
-        unsafe { uvll::close(self.native_handle(), close_cb); }
+        unsafe {
+            uvll::uv_close(self.native_handle() as *uvll::uv_handle_t, close_cb);
+        }
 
         extern fn close_cb(handle: *uvll::uv_handle_t) {
             let mut h: Handle = NativeHandle::from_native_handle(handle);
@@ -250,7 +252,9 @@ impl<H, W: Watcher + NativeHandle<*H>> WatcherInterop for W {
     }
 
     fn close_async(self) {
-        unsafe { uvll::close(self.native_handle(), close_cb); }
+        unsafe {
+            uvll::uv_close(self.native_handle() as *uvll::uv_handle_t, close_cb);
+        }
 
         extern fn close_cb(handle: *uvll::uv_handle_t) {
             let mut h: Handle = NativeHandle::from_native_handle(handle);
@@ -269,7 +273,7 @@ impl UvError {
     pub fn name(&self) -> ~str {
         unsafe {
             let inner = match self { &UvError(a) => a };
-            let name_str = uvll::err_name(inner);
+            let name_str = uvll::uv_err_name(inner);
             assert!(name_str.is_not_null());
             from_c_str(name_str)
         }
@@ -278,7 +282,7 @@ impl UvError {
     pub fn desc(&self) -> ~str {
         unsafe {
             let inner = match self { &UvError(a) => a };
-            let desc_str = uvll::strerror(inner);
+            let desc_str = uvll::uv_strerror(inner);
             assert!(desc_str.is_not_null());
             from_c_str(desc_str)
         }
@@ -308,7 +312,7 @@ pub fn uv_error_to_io_error(uverr: UvError) -> IoError {
         use std::rt::io::*;
 
         // uv error descriptions are static
-        let c_desc = uvll::strerror(*uverr);
+        let c_desc = uvll::uv_strerror(*uverr);
         let desc = str::raw::c_str_to_static_slice(c_desc);
 
         let kind = match *uverr {
@@ -359,7 +363,7 @@ pub fn empty_buf() -> Buf {
 /// Borrow a slice to a Buf
 pub fn slice_to_uv_buf(v: &[u8]) -> Buf {
     let data = vec::raw::to_ptr(v);
-    unsafe { uvll::buf_init(data, v.len()) }
+    unsafe { uvll::uv_buf_init(data as *c_char, v.len() as c_uint) }
 }
 
 // XXX: Do these conversions without copying
@@ -375,7 +379,7 @@ pub fn vec_to_uv_buf(v: ~[u8]) -> Buf {
             let data = data as *mut u8;
             ptr::copy_memory(data, b, l)
         }
-        uvll::buf_init(data, v.len())
+        uvll::uv_buf_init(data as *c_char, v.len() as c_uint)
     }
 }
 

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -347,14 +347,17 @@ pub fn uv_error_to_io_error(uverr: UvError) -> IoError {
     }
 }
 
-/// Given a uv handle, convert a callback status to a UvError
-pub fn status_to_maybe_uv_error(status: c_int) -> Option<UvError>
-{
+/// Given a uv error code, convert a callback status to a UvError
+pub fn status_to_maybe_uv_error(status: c_int) -> Option<UvError> {
     if status >= 0 {
         None
     } else {
         Some(UvError(status))
     }
+}
+
+pub fn status_to_io_result(status: c_int) -> Result<(), IoError> {
+    if status >= 0 {Ok(())} else {Err(uv_error_to_io_error(UvError(status)))}
 }
 
 /// The uv buffer type

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -117,7 +117,6 @@ pub trait NativeHandle<T> {
     fn from_native_handle(h: *T) -> Self;
     fn native_handle(&self) -> *T;
 
-    // FIXME(#8888) dummy self
     fn alloc(ty: uvll::uv_handle_type) -> Self {
         unsafe {
             NativeHandle::from_native_handle(uvll::malloc_handle(ty) as *T)

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -216,7 +216,7 @@ impl StreamWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_stream_t> for StreamWatcher {
+impl NativeHandle<uvll::uv_stream_t> for StreamWatcher {
     fn from_native_handle(handle: *uvll::uv_stream_t) -> StreamWatcher {
         StreamWatcher(handle)
     }
@@ -230,14 +230,12 @@ impl Watcher for TcpWatcher { }
 
 impl TcpWatcher {
     pub fn new(loop_: &Loop) -> TcpWatcher {
-        unsafe {
-            let handle = malloc_handle(UV_TCP);
-            assert!(handle.is_not_null());
-            assert_eq!(0, uvll::uv_tcp_init(loop_.native_handle(), handle));
-            let mut watcher: TcpWatcher = NativeHandle::from_native_handle(handle);
-            watcher.install_watcher_data();
-            return watcher;
-        }
+        let mut watcher: TcpWatcher = NativeHandle::alloc(uvll::UV_TCP);
+        assert_eq!(unsafe {
+            uvll::uv_tcp_init(loop_.native_handle(), *watcher)
+        }, 0);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     pub fn bind(&mut self, address: SocketAddr) -> Result<(), UvError> {
@@ -289,7 +287,7 @@ impl TcpWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_tcp_t> for TcpWatcher {
+impl NativeHandle<uvll::uv_tcp_t> for TcpWatcher {
     fn from_native_handle(handle: *uvll::uv_tcp_t) -> TcpWatcher {
         TcpWatcher(handle)
     }
@@ -303,14 +301,12 @@ impl Watcher for UdpWatcher { }
 
 impl UdpWatcher {
     pub fn new(loop_: &Loop) -> UdpWatcher {
-        unsafe {
-            let handle = malloc_handle(UV_UDP);
-            assert!(handle.is_not_null());
-            assert_eq!(0, uvll::uv_udp_init(loop_.native_handle(), handle));
-            let mut watcher: UdpWatcher = NativeHandle::from_native_handle(handle);
-            watcher.install_watcher_data();
-            return watcher;
-        }
+        let mut watcher: UdpWatcher = NativeHandle::alloc(uvll::UV_UDP);
+        assert_eq!(unsafe {
+            uvll::uv_udp_init(loop_.native_handle(), *watcher)
+        }, 0);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     pub fn bind(&mut self, address: SocketAddr) -> Result<(), UvError> {
@@ -397,7 +393,7 @@ impl UdpWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_udp_t> for UdpWatcher {
+impl NativeHandle<uvll::uv_udp_t> for UdpWatcher {
     fn from_native_handle(handle: *uvll::uv_udp_t) -> UdpWatcher {
         UdpWatcher(handle)
     }
@@ -430,7 +426,7 @@ impl ConnectRequest {
     }
 }
 
-impl NativeHandle<*uvll::uv_connect_t> for ConnectRequest {
+impl NativeHandle<uvll::uv_connect_t> for ConnectRequest {
     fn from_native_handle(handle: *uvll:: uv_connect_t) -> ConnectRequest {
         ConnectRequest(handle)
     }
@@ -462,7 +458,7 @@ impl WriteRequest {
     }
 }
 
-impl NativeHandle<*uvll::uv_write_t> for WriteRequest {
+impl NativeHandle<uvll::uv_write_t> for WriteRequest {
     fn from_native_handle(handle: *uvll:: uv_write_t) -> WriteRequest {
         WriteRequest(handle)
     }
@@ -493,7 +489,7 @@ impl UdpSendRequest {
     }
 }
 
-impl NativeHandle<*uvll::uv_udp_send_t> for UdpSendRequest {
+impl NativeHandle<uvll::uv_udp_send_t> for UdpSendRequest {
     fn from_native_handle(handle: *uvll::uv_udp_send_t) -> UdpSendRequest {
         UdpSendRequest(handle)
     }

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -26,7 +26,7 @@ impl Pipe {
             let handle = uvll::malloc_handle(uvll::UV_NAMED_PIPE);
             assert!(handle.is_not_null());
             let ipc = ipc as libc::c_int;
-            assert_eq!(uvll::pipe_init(loop_.native_handle(), handle, ipc), 0);
+            assert_eq!(uvll::uv_pipe_init(loop_.native_handle(), handle, ipc), 0);
             let mut ret: Pipe =
                     NativeHandle::from_native_handle(handle);
             ret.install_watcher_data();
@@ -40,7 +40,7 @@ impl Pipe {
 
     #[fixed_stack_segment] #[inline(never)]
     pub fn open(&mut self, file: libc::c_int) -> Result<(), UvError> {
-        match unsafe { uvll::pipe_open(self.native_handle(), file) } {
+        match unsafe { uvll::uv_pipe_open(self.native_handle(), file) } {
             0 => Ok(()),
             n => Err(UvError(n))
         }
@@ -49,7 +49,7 @@ impl Pipe {
     #[fixed_stack_segment] #[inline(never)]
     pub fn bind(&mut self, name: &CString) -> Result<(), UvError> {
         do name.with_ref |name| {
-            match unsafe { uvll::pipe_bind(self.native_handle(), name) } {
+            match unsafe { uvll::uv_pipe_bind(self.native_handle(), name) } {
                 0 => Ok(()),
                 n => Err(UvError(n))
             }
@@ -68,7 +68,7 @@ impl Pipe {
         let name = do name.with_ref |p| { p };
 
         unsafe {
-            uvll::pipe_connect(connect.native_handle(),
+            uvll::uv_pipe_connect(connect.native_handle(),
                                self.native_handle(),
                                name,
                                connect_cb)

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::libc;
+use std::libc::c_int;
 use std::c_str::CString;
 
 use super::{Loop, UvError, Watcher, NativeHandle, status_to_maybe_uv_error};
@@ -22,16 +23,12 @@ impl Watcher for Pipe {}
 
 impl Pipe {
     pub fn new(loop_: &Loop, ipc: bool) -> Pipe {
-        unsafe {
-            let handle = uvll::malloc_handle(uvll::UV_NAMED_PIPE);
-            assert!(handle.is_not_null());
-            let ipc = ipc as libc::c_int;
-            assert_eq!(uvll::uv_pipe_init(loop_.native_handle(), handle, ipc), 0);
-            let mut ret: Pipe =
-                    NativeHandle::from_native_handle(handle);
-            ret.install_watcher_data();
-            ret
-        }
+        let mut watcher: Pipe = NativeHandle::alloc(uvll::UV_NAMED_PIPE);
+        assert_eq!(unsafe {
+            uvll::uv_pipe_init(loop_.native_handle(), *watcher, ipc as c_int)
+        }, 0);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     pub fn as_stream(&self) -> net::StreamWatcher {
@@ -88,7 +85,7 @@ impl Pipe {
 
 }
 
-impl NativeHandle<*uvll::uv_pipe_t> for Pipe {
+impl NativeHandle<uvll::uv_pipe_t> for Pipe {
     fn from_native_handle(handle: *uvll::uv_pipe_t) -> Pipe {
         Pipe(handle)
     }

--- a/src/librustuv/process.rs
+++ b/src/librustuv/process.rs
@@ -27,11 +27,9 @@ impl Watcher for Process {}
 impl Process {
     /// Creates a new process, ready to spawn inside an event loop
     pub fn new() -> Process {
-        let handle = unsafe { uvll::malloc_handle(uvll::UV_PROCESS) };
-        assert!(handle.is_not_null());
-        let mut ret: Process = NativeHandle::from_native_handle(handle);
-        ret.install_watcher_data();
-        return ret;
+        let mut watcher: Process = NativeHandle::alloc(uvll::UV_PROCESS);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     /// Spawn a new process inside the specified event loop.
@@ -192,7 +190,7 @@ fn with_env<T>(env: Option<&[(~str, ~str)]>, f: &fn(**libc::c_char) -> T) -> T {
     c_envp.as_imm_buf(|buf, _| f(buf))
 }
 
-impl NativeHandle<*uvll::uv_process_t> for Process {
+impl NativeHandle<uvll::uv_process_t> for Process {
     fn from_native_handle(handle: *uvll::uv_process_t) -> Process {
         Process(handle)
     }

--- a/src/librustuv/process.rs
+++ b/src/librustuv/process.rs
@@ -94,7 +94,7 @@ impl Process {
                 };
 
                 match unsafe {
-                    uvll::spawn(loop_.native_handle(), **self, options)
+                    uvll::uv_spawn(loop_.native_handle(), **self, options)
                 } {
                     0 => {
                         (*self).get_watcher_data().exit_cb = Some(exit_cb.take());
@@ -111,7 +111,7 @@ impl Process {
     /// This is a wrapper around `uv_process_kill`
     pub fn kill(&self, signum: int) -> Result<(), UvError> {
         match unsafe {
-            uvll::process_kill(self.native_handle(), signum as libc::c_int)
+            uvll::uv_process_kill(self.native_handle(), signum as libc::c_int)
         } {
             0 => Ok(()),
             err => Err(UvError(err))

--- a/src/librustuv/signal.rs
+++ b/src/librustuv/signal.rs
@@ -21,14 +21,12 @@ impl Watcher for SignalWatcher { }
 
 impl SignalWatcher {
     pub fn new(loop_: &mut Loop) -> SignalWatcher {
-        unsafe {
-            let handle = uvll::malloc_handle(uvll::UV_SIGNAL);
-            assert!(handle.is_not_null());
-            assert!(0 == uvll::uv_signal_init(loop_.native_handle(), handle));
-            let mut watcher: SignalWatcher = NativeHandle::from_native_handle(handle);
-            watcher.install_watcher_data();
-            return watcher;
-        }
+        let mut watcher: SignalWatcher = NativeHandle::alloc(uvll::UV_SIGNAL);
+        assert_eq!(unsafe {
+            uvll::uv_signal_init(loop_.native_handle(), *watcher)
+        }, 0);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     pub fn start(&mut self, signum: Signum, callback: SignalCallback)
@@ -61,7 +59,7 @@ impl SignalWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_signal_t> for SignalWatcher {
+impl NativeHandle<uvll::uv_signal_t> for SignalWatcher {
     fn from_native_handle(handle: *uvll::uv_signal_t) -> SignalWatcher {
         SignalWatcher(handle)
     }

--- a/src/librustuv/signal.rs
+++ b/src/librustuv/signal.rs
@@ -24,7 +24,7 @@ impl SignalWatcher {
         unsafe {
             let handle = uvll::malloc_handle(uvll::UV_SIGNAL);
             assert!(handle.is_not_null());
-            assert!(0 == uvll::signal_init(loop_.native_handle(), handle));
+            assert!(0 == uvll::uv_signal_init(loop_.native_handle(), handle));
             let mut watcher: SignalWatcher = NativeHandle::from_native_handle(handle);
             watcher.install_watcher_data();
             return watcher;
@@ -35,8 +35,8 @@ impl SignalWatcher {
             -> Result<(), UvError>
     {
         return unsafe {
-            match uvll::signal_start(self.native_handle(), signal_cb,
-                                     signum as c_int) {
+            match uvll::uv_signal_start(self.native_handle(), signal_cb,
+                                        signum as c_int) {
                 0 => {
                     let data = self.get_watcher_data();
                     data.signal_cb = Some(callback);
@@ -56,7 +56,7 @@ impl SignalWatcher {
 
     pub fn stop(&mut self) {
         unsafe {
-            uvll::signal_stop(self.native_handle());
+            uvll::uv_signal_stop(self.native_handle());
         }
     }
 }

--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -18,14 +18,12 @@ impl Watcher for TimerWatcher { }
 
 impl TimerWatcher {
     pub fn new(loop_: &mut Loop) -> TimerWatcher {
-        unsafe {
-            let handle = uvll::malloc_handle(uvll::UV_TIMER);
-            assert!(handle.is_not_null());
-            assert!(0 == uvll::uv_timer_init(loop_.native_handle(), handle));
-            let mut watcher: TimerWatcher = NativeHandle::from_native_handle(handle);
-            watcher.install_watcher_data();
-            return watcher;
-        }
+        let mut watcher: TimerWatcher = NativeHandle::alloc(uvll::UV_TIMER);
+        assert_eq!(unsafe {
+            uvll::uv_timer_init(loop_.native_handle(), *watcher)
+        }, 0);
+        watcher.install_watcher_data();
+        return watcher;
     }
 
     pub fn start(&mut self, timeout: u64, repeat: u64, cb: TimerCallback) {
@@ -54,7 +52,7 @@ impl TimerWatcher {
     }
 }
 
-impl NativeHandle<*uvll::uv_timer_t> for TimerWatcher {
+impl NativeHandle<uvll::uv_timer_t> for TimerWatcher {
     fn from_native_handle(handle: *uvll::uv_timer_t) -> TimerWatcher {
         TimerWatcher(handle)
     }

--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -21,7 +21,7 @@ impl TimerWatcher {
         unsafe {
             let handle = uvll::malloc_handle(uvll::UV_TIMER);
             assert!(handle.is_not_null());
-            assert!(0 == uvll::timer_init(loop_.native_handle(), handle));
+            assert!(0 == uvll::uv_timer_init(loop_.native_handle(), handle));
             let mut watcher: TimerWatcher = NativeHandle::from_native_handle(handle);
             watcher.install_watcher_data();
             return watcher;
@@ -35,7 +35,7 @@ impl TimerWatcher {
         }
 
         unsafe {
-            uvll::timer_start(self.native_handle(), timer_cb, timeout, repeat);
+            uvll::uv_timer_start(self.native_handle(), timer_cb, timeout, repeat);
         }
 
         extern fn timer_cb(handle: *uvll::uv_timer_t, status: c_int) {
@@ -49,7 +49,7 @@ impl TimerWatcher {
 
     pub fn stop(&mut self) {
         unsafe {
-            uvll::timer_stop(self.native_handle());
+            uvll::uv_timer_stop(self.native_handle());
         }
     }
 }

--- a/src/librustuv/tty.rs
+++ b/src/librustuv/tty.rs
@@ -24,21 +24,18 @@ impl TTY {
     pub fn new(loop_: &Loop, fd: libc::c_int, readable: bool) ->
             Result<TTY, UvError>
     {
-        let handle = unsafe { uvll::malloc_handle(uvll::UV_TTY) };
-        assert!(handle.is_not_null());
-
+        let mut watcher: TTY = NativeHandle::alloc(uvll::UV_TTY);
         let ret = unsafe {
-            uvll::uv_tty_init(loop_.native_handle(), handle, fd as libc::c_int,
+            uvll::uv_tty_init(loop_.native_handle(), *watcher, fd as libc::c_int,
                               readable as libc::c_int)
         };
         match ret {
             0 => {
-                let mut ret: TTY = NativeHandle::from_native_handle(handle);
-                ret.install_watcher_data();
-                Ok(ret)
+                watcher.install_watcher_data();
+                Ok(watcher)
             }
             n => {
-                unsafe { uvll::free_handle(handle); }
+                unsafe { uvll::free_handle(*watcher); }
                 Err(UvError(n))
             }
         }
@@ -72,7 +69,7 @@ impl TTY {
     }
 }
 
-impl NativeHandle<*uvll::uv_tty_t> for TTY {
+impl NativeHandle<uvll::uv_tty_t> for TTY {
     fn from_native_handle(handle: *uvll::uv_tty_t) -> TTY {
         TTY(handle)
     }

--- a/src/librustuv/tty.rs
+++ b/src/librustuv/tty.rs
@@ -28,8 +28,8 @@ impl TTY {
         assert!(handle.is_not_null());
 
         let ret = unsafe {
-            uvll::tty_init(loop_.native_handle(), handle, fd as libc::c_int,
-                           readable as libc::c_int)
+            uvll::uv_tty_init(loop_.native_handle(), handle, fd as libc::c_int,
+                              readable as libc::c_int)
         };
         match ret {
             0 => {
@@ -51,7 +51,7 @@ impl TTY {
     #[fixed_stack_segment] #[inline(never)]
     pub fn set_mode(&self, raw: bool) -> Result<(), UvError> {
         let raw = raw as libc::c_int;
-        match unsafe { uvll::tty_set_mode(self.native_handle(), raw) } {
+        match unsafe { uvll::uv_tty_set_mode(self.native_handle(), raw) } {
             0 => Ok(()),
             n => Err(UvError(n))
         }
@@ -64,8 +64,8 @@ impl TTY {
         let widthptr: *libc::c_int = &width;
         let heightptr: *libc::c_int = &width;
 
-        match unsafe { uvll::tty_get_winsize(self.native_handle(),
-                                             widthptr, heightptr) } {
+        match unsafe { uvll::uv_tty_get_winsize(self.native_handle(),
+                                                widthptr, heightptr) } {
             0 => Ok((width as int, height as int)),
             n => Err(UvError(n))
         }

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -94,12 +94,33 @@ trait HomingIO {
         self.home().sched_id
     }
 
-    // XXX: dummy self parameter
-    fn restore_original_home(_: Option<Self>, io_home: uint) {
+    /// Fires a single homing missile, returning another missile targeted back
+    /// at the original home of this task. In other words, this function will
+    /// move the local task to its I/O scheduler and then return an RAII wrapper
+    /// which will return the task home.
+    fn fire_missiles(&mut self) -> HomingMissile {
+        HomingMissile { io_home: self.go_to_IO_home() }
+    }
+
+    /// Same as `fire_missiles`, but returns the local scheduler as well
+    fn fire_missiles_sched(&mut self) -> (HomingMissile, ~Scheduler) {
+        (self.fire_missiles(), Local::take())
+    }
+}
+
+/// After a homing operation has been completed, this will return the current
+/// task back to its appropriate home (if applicable). The field is used to
+/// assert that we are where we think we are.
+struct HomingMissile {
+    priv io_home: uint,
+}
+
+impl Drop for HomingMissile {
+    fn drop(&mut self) {
         // It would truly be a sad day if we had moved off the home I/O
         // scheduler while we were doing I/O.
         assert_eq!(Local::borrow(|sched: &mut Scheduler| sched.sched_id()),
-                   io_home);
+                   self.io_home);
 
         // If we were a homed task, then we must send ourselves back to the
         // original scheduler. Otherwise, we can just return and keep running
@@ -113,30 +134,6 @@ trait HomingIO {
                 }
             }
         }
-    }
-
-    fn home_for_io<A>(&mut self, io: &fn(&mut Self) -> A) -> A {
-        let home = self.go_to_IO_home();
-        let a = io(self); // do IO
-        HomingIO::restore_original_home(None::<Self>, home);
-        a // return the result of the IO
-    }
-
-    fn home_for_io_consume<A>(mut self, io: &fn(Self) -> A) -> A {
-        let home = self.go_to_IO_home();
-        let a = io(self); // do IO
-        HomingIO::restore_original_home(None::<Self>, home);
-        a // return the result of the IO
-    }
-
-    fn home_for_io_with_sched<A>(&mut self, io_sched: &fn(&mut Self, ~Scheduler) -> A) -> A {
-        let home = self.go_to_IO_home();
-        let a = do task::unkillable { // FIXME(#8674)
-            let scheduler: ~Scheduler = Local::take();
-            io_sched(self, scheduler) // do IO and scheduling action
-        };
-        HomingIO::restore_original_home(None::<Self>, home);
-        a // return result of IO
     }
 }
 
@@ -897,13 +894,12 @@ impl UvTcpListener {
 
 impl Drop for UvTcpListener {
     fn drop(&mut self) {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task = Cell::new(task);
-                do self_.watcher.as_stream().close {
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task.take());
-                }
+        let (_m, sched) = self.fire_missiles_sched();
+        do sched.deschedule_running_task_and_then |_, task| {
+            let task = Cell::new(task);
+            do self.watcher.as_stream().close {
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task.take());
             }
         }
     }
@@ -911,38 +907,36 @@ impl Drop for UvTcpListener {
 
 impl RtioSocket for UvTcpListener {
     fn socket_name(&mut self) -> Result<SocketAddr, IoError> {
-        do self.home_for_io |self_| {
-            socket_name(Tcp, self_.watcher)
-        }
+        let _m = self.fire_missiles();
+        socket_name(Tcp, self.watcher)
     }
 }
 
 impl RtioTcpListener for UvTcpListener {
-    fn listen(~self) -> Result<~RtioTcpAcceptor, IoError> {
-        do self.home_for_io_consume |self_| {
-            let acceptor = ~UvTcpAcceptor::new(self_);
-            let incoming = Cell::new(acceptor.incoming.clone());
-            let mut stream = acceptor.listener.watcher.as_stream();
-            let res = do stream.listen |mut server, status| {
-                do incoming.with_mut_ref |incoming| {
-                    let inc = match status {
-                        Some(_) => Err(standard_error(OtherIoError)),
-                        None => {
-                            let inc = TcpWatcher::new(&server.event_loop());
-                            // first accept call in the callback guarenteed to succeed
-                            server.accept(inc.as_stream());
-                            let home = get_handle_to_current_scheduler!();
-                            Ok(~UvTcpStream { watcher: inc, home: home }
-                                    as ~RtioTcpStream)
-                        }
-                    };
-                    incoming.send(inc);
-                }
-            };
-            match res {
-                Ok(()) => Ok(acceptor as ~RtioTcpAcceptor),
-                Err(e) => Err(uv_error_to_io_error(e)),
+    fn listen(mut ~self) -> Result<~RtioTcpAcceptor, IoError> {
+        let _m = self.fire_missiles();
+        let acceptor = ~UvTcpAcceptor::new(*self);
+        let incoming = Cell::new(acceptor.incoming.clone());
+        let mut stream = acceptor.listener.watcher.as_stream();
+        let res = do stream.listen |mut server, status| {
+            do incoming.with_mut_ref |incoming| {
+                let inc = match status {
+                    Some(_) => Err(standard_error(OtherIoError)),
+                    None => {
+                        let inc = TcpWatcher::new(&server.event_loop());
+                        // first accept call in the callback guarenteed to succeed
+                        server.accept(inc.as_stream());
+                        let home = get_handle_to_current_scheduler!();
+                        Ok(~UvTcpStream { watcher: inc, home: home }
+                                as ~RtioTcpStream)
+                    }
+                };
+                incoming.send(inc);
             }
+        };
+        match res {
+            Ok(()) => Ok(acceptor as ~RtioTcpAcceptor),
+            Err(e) => Err(uv_error_to_io_error(e)),
         }
     }
 }
@@ -964,9 +958,8 @@ impl UvTcpAcceptor {
 
 impl RtioSocket for UvTcpAcceptor {
     fn socket_name(&mut self) -> Result<SocketAddr, IoError> {
-        do self.home_for_io |self_| {
-            socket_name(Tcp, self_.listener.watcher)
-        }
+        let _m = self.fire_missiles();
+        socket_name(Tcp, self.listener.watcher)
     }
 }
 
@@ -979,21 +972,18 @@ fn accept_simultaneously(stream: StreamWatcher, a: int) -> Result<(), IoError> {
 
 impl RtioTcpAcceptor for UvTcpAcceptor {
     fn accept(&mut self) -> Result<~RtioTcpStream, IoError> {
-        do self.home_for_io |self_| {
-            self_.incoming.recv()
-        }
+        let _m = self.fire_missiles();
+        self.incoming.recv()
     }
 
     fn accept_simultaneously(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            accept_simultaneously(self_.listener.watcher.as_stream(), 1)
-        }
+        let _m = self.fire_missiles();
+        accept_simultaneously(self.listener.watcher.as_stream(), 1)
     }
 
     fn dont_accept_simultaneously(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            accept_simultaneously(self_.listener.watcher.as_stream(), 0)
-        }
+        let _m = self.fire_missiles();
+        accept_simultaneously(self.listener.watcher.as_stream(), 0)
     }
 }
 
@@ -1086,14 +1076,12 @@ impl HomingIO for UvUnboundPipe {
 
 impl Drop for UvUnboundPipe {
     fn drop(&mut self) {
-        do self.home_for_io |self_| {
-            let scheduler: ~Scheduler = Local::take();
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                do self_.pipe.close {
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, sched) = self.fire_missiles_sched();
+        do sched.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            do self.pipe.close {
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
     }
@@ -1111,14 +1099,12 @@ impl UvPipeStream {
 
 impl RtioPipe for UvPipeStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<uint, IoError> {
-        do self.inner.home_for_io_with_sched |self_, scheduler| {
-            read_stream(self_.pipe.as_stream(), scheduler, buf)
-        }
+        let (_m, scheduler) = self.inner.fire_missiles_sched();
+        read_stream(self.inner.pipe.as_stream(), scheduler, buf)
     }
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
-        do self.inner.home_for_io_with_sched |self_, scheduler| {
-            write_stream(self_.pipe.as_stream(), scheduler, buf)
-        }
+        let (_m, scheduler) = self.inner.fire_missiles_sched();
+        write_stream(self.inner.pipe.as_stream(), scheduler, buf)
     }
 }
 
@@ -1133,13 +1119,12 @@ impl HomingIO for UvTcpStream {
 
 impl Drop for UvTcpStream {
     fn drop(&mut self) {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                do self_.watcher.as_stream().close {
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, sched) = self.fire_missiles_sched();
+        do sched.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            do self.watcher.as_stream().close {
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
     }
@@ -1147,67 +1132,55 @@ impl Drop for UvTcpStream {
 
 impl RtioSocket for UvTcpStream {
     fn socket_name(&mut self) -> Result<SocketAddr, IoError> {
-        do self.home_for_io |self_| {
-            socket_name(Tcp, self_.watcher)
-        }
+        let _m = self.fire_missiles();
+        socket_name(Tcp, self.watcher)
     }
 }
 
 impl RtioTcpStream for UvTcpStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<uint, IoError> {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            read_stream(self_.watcher.as_stream(), scheduler, buf)
-        }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        read_stream(self.watcher.as_stream(), scheduler, buf)
     }
 
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            write_stream(self_.watcher.as_stream(), scheduler, buf)
-        }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        write_stream(self.watcher.as_stream(), scheduler, buf)
     }
 
     fn peer_name(&mut self) -> Result<SocketAddr, IoError> {
-        do self.home_for_io |self_| {
-            socket_name(TcpPeer, self_.watcher)
-        }
+        let _m = self.fire_missiles();
+        socket_name(TcpPeer, self.watcher)
     }
 
     fn control_congestion(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_tcp_nodelay(self_.watcher.native_handle(), 0 as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_tcp_nodelay(self.watcher.native_handle(), 0 as c_int)
+        })
     }
 
     fn nodelay(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_tcp_nodelay(self_.watcher.native_handle(), 1 as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_tcp_nodelay(self.watcher.native_handle(), 1 as c_int)
+        })
     }
 
     fn keepalive(&mut self, delay_in_seconds: uint) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_tcp_keepalive(self_.watcher.native_handle(), 1 as c_int,
-                                       delay_in_seconds as c_uint)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_tcp_keepalive(self.watcher.native_handle(), 1 as c_int,
+                                   delay_in_seconds as c_uint)
+        })
     }
 
     fn letdie(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_tcp_keepalive(self_.watcher.native_handle(),
-                                       0 as c_int, 0 as c_uint)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_tcp_keepalive(self.watcher.native_handle(),
+                                   0 as c_int, 0 as c_uint)
+        })
     }
 }
 
@@ -1222,13 +1195,12 @@ impl HomingIO for UvUdpSocket {
 
 impl Drop for UvUdpSocket {
     fn drop(&mut self) {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                do self_.watcher.close {
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            do self.watcher.close {
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
     }
@@ -1236,157 +1208,138 @@ impl Drop for UvUdpSocket {
 
 impl RtioSocket for UvUdpSocket {
     fn socket_name(&mut self) -> Result<SocketAddr, IoError> {
-        do self.home_for_io |self_| {
-            socket_name(Udp, self_.watcher)
-        }
+        let _m = self.fire_missiles();
+        socket_name(Udp, self.watcher)
     }
 }
 
 impl RtioUdpSocket for UvUdpSocket {
     fn recvfrom(&mut self, buf: &mut [u8]) -> Result<(uint, SocketAddr), IoError> {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            let result_cell = Cell::new_empty();
-            let result_cell_ptr: *Cell<Result<(uint, SocketAddr), IoError>> = &result_cell;
+        let (_m, scheduler) = self.fire_missiles_sched();
+        let result_cell = Cell::new_empty();
+        let result_cell_ptr: *Cell<Result<(uint, SocketAddr), IoError>> = &result_cell;
 
-            let buf_ptr: *&mut [u8] = &buf;
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                let alloc: AllocCallback = |_| unsafe { slice_to_uv_buf(*buf_ptr) };
-                do self_.watcher.recv_start(alloc) |mut watcher, nread, _buf, addr, flags, status| {
-                    let _ = flags; // /XXX add handling for partials?
+        let buf_ptr: *&mut [u8] = &buf;
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            let alloc: AllocCallback = |_| unsafe { slice_to_uv_buf(*buf_ptr) };
+            do self.watcher.recv_start(alloc) |mut watcher, nread, _buf, addr, flags, status| {
+                let _ = flags; // /XXX add handling for partials?
 
-                    watcher.recv_stop();
+                watcher.recv_stop();
 
-                    let result = match status {
-                        None => {
-                            assert!(nread >= 0);
-                            Ok((nread as uint, addr))
-                        }
-                        Some(err) => Err(uv_error_to_io_error(err)),
-                    };
+                let result = match status {
+                    None => {
+                        assert!(nread >= 0);
+                        Ok((nread as uint, addr))
+                    }
+                    Some(err) => Err(uv_error_to_io_error(err)),
+                };
 
-                    unsafe { (*result_cell_ptr).put_back(result); }
+                unsafe { (*result_cell_ptr).put_back(result); }
 
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
-
-            assert!(!result_cell.is_empty());
-            result_cell.take()
         }
+
+        assert!(!result_cell.is_empty());
+        result_cell.take()
     }
 
     fn sendto(&mut self, buf: &[u8], dst: SocketAddr) -> Result<(), IoError> {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            let result_cell = Cell::new_empty();
-            let result_cell_ptr: *Cell<Result<(), IoError>> = &result_cell;
-            let buf_ptr: *&[u8] = &buf;
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                let buf = unsafe { slice_to_uv_buf(*buf_ptr) };
-                do self_.watcher.send(buf, dst) |_watcher, status| {
+        let (_m, scheduler) = self.fire_missiles_sched();
+        let result_cell = Cell::new_empty();
+        let result_cell_ptr: *Cell<Result<(), IoError>> = &result_cell;
+        let buf_ptr: *&[u8] = &buf;
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            let buf = unsafe { slice_to_uv_buf(*buf_ptr) };
+            do self.watcher.send(buf, dst) |_watcher, status| {
 
-                    let result = match status {
-                        None => Ok(()),
-                        Some(err) => Err(uv_error_to_io_error(err)),
-                    };
+                let result = match status {
+                    None => Ok(()),
+                    Some(err) => Err(uv_error_to_io_error(err)),
+                };
 
-                    unsafe { (*result_cell_ptr).put_back(result); }
+                unsafe { (*result_cell_ptr).put_back(result); }
 
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
-
-            assert!(!result_cell.is_empty());
-            result_cell.take()
         }
+
+        assert!(!result_cell.is_empty());
+        result_cell.take()
     }
 
     fn join_multicast(&mut self, multi: IpAddr) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                do multi.to_str().with_c_str |m_addr| {
-                    uvll::uv_udp_set_membership(self_.watcher.native_handle(),
-                                                m_addr, ptr::null(),
-                                                uvll::UV_JOIN_GROUP)
-                }
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            do multi.to_str().with_c_str |m_addr| {
+                uvll::uv_udp_set_membership(self.watcher.native_handle(),
+                                            m_addr, ptr::null(),
+                                            uvll::UV_JOIN_GROUP)
+            }
+        })
     }
 
     fn leave_multicast(&mut self, multi: IpAddr) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                do multi.to_str().with_c_str |m_addr| {
-                    uvll::uv_udp_set_membership(self_.watcher.native_handle(),
-                                                m_addr, ptr::null(),
-                                                uvll::UV_LEAVE_GROUP)
-                }
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            do multi.to_str().with_c_str |m_addr| {
+                uvll::uv_udp_set_membership(self.watcher.native_handle(),
+                                            m_addr, ptr::null(),
+                                            uvll::UV_LEAVE_GROUP)
+            }
+        })
     }
 
     fn loop_multicast_locally(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_udp_set_multicast_loop(self_.watcher.native_handle(),
-                                                1 as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_udp_set_multicast_loop(self.watcher.native_handle(),
+                                            1 as c_int)
+        })
     }
 
     fn dont_loop_multicast_locally(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_udp_set_multicast_loop(self_.watcher.native_handle(),
-                                                0 as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_udp_set_multicast_loop(self.watcher.native_handle(),
+                                            0 as c_int)
+        })
     }
 
     fn multicast_time_to_live(&mut self, ttl: int) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_udp_set_multicast_ttl(self_.watcher.native_handle(),
-                                               ttl as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_udp_set_multicast_ttl(self.watcher.native_handle(),
+                                           ttl as c_int)
+        })
     }
 
     fn time_to_live(&mut self, ttl: int) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_udp_set_ttl(self_.watcher.native_handle(), ttl as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_udp_set_ttl(self.watcher.native_handle(), ttl as c_int)
+        })
     }
 
     fn hear_broadcasts(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_udp_set_broadcast(self_.watcher.native_handle(),
-                                           1 as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_udp_set_broadcast(self.watcher.native_handle(),
+                                       1 as c_int)
+        })
     }
 
     fn ignore_broadcasts(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            let r = unsafe {
-                uvll::uv_udp_set_broadcast(self_.watcher.native_handle(),
-                                           0 as c_int)
-            };
-            status_to_io_result(r)
-        }
+        let _m = self.fire_missiles();
+        status_to_io_result(unsafe {
+            uvll::uv_udp_set_broadcast(self.watcher.native_handle(),
+                                       0 as c_int)
+        })
     }
 }
 
@@ -1407,14 +1360,13 @@ impl UvTimer {
 
 impl Drop for UvTimer {
     fn drop(&mut self) {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            uvdebug!("closing UvTimer");
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                do self_.watcher.close {
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        uvdebug!("closing UvTimer");
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            do self.watcher.close {
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
     }
@@ -1422,18 +1374,17 @@ impl Drop for UvTimer {
 
 impl RtioTimer for UvTimer {
     fn sleep(&mut self, msecs: u64) {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            do scheduler.deschedule_running_task_and_then |_sched, task| {
-                uvdebug!("sleep: entered scheduler context");
-                let task_cell = Cell::new(task);
-                do self_.watcher.start(msecs, 0) |_, status| {
-                    assert!(status.is_none());
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        do scheduler.deschedule_running_task_and_then |_sched, task| {
+            uvdebug!("sleep: entered scheduler context");
+            let task_cell = Cell::new(task);
+            do self.watcher.start(msecs, 0) |_, status| {
+                assert!(status.is_none());
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
-            self_.watcher.stop();
         }
+        self.watcher.stop();
     }
 
     fn oneshot(&mut self, msecs: u64) -> PortOne<()> {
@@ -1441,13 +1392,11 @@ impl RtioTimer for UvTimer {
 
         let (port, chan) = oneshot();
         let chan = Cell::new(chan);
-        do self.home_for_io |self_| {
-            let chan = Cell::new(chan.take());
-            do self_.watcher.start(msecs, 0) |_, status| {
-                assert!(status.is_none());
-                assert!(!chan.is_empty());
-                chan.take().send_deferred(());
-            }
+        let _m = self.fire_missiles();
+        do self.watcher.start(msecs, 0) |_, status| {
+            assert!(status.is_none());
+            assert!(!chan.is_empty());
+            chan.take().send_deferred(());
         }
 
         return port;
@@ -1458,13 +1407,11 @@ impl RtioTimer for UvTimer {
 
         let (port, chan) = stream();
         let chan = Cell::new(chan);
-        do self.home_for_io |self_| {
-            let chan = Cell::new(chan.take());
-            do self_.watcher.start(msecs, msecs) |_, status| {
-                assert!(status.is_none());
-                do chan.with_ref |chan| {
-                    chan.send_deferred(());
-                }
+        let _m = self.fire_missiles();
+        do self.watcher.start(msecs, msecs) |_, status| {
+            assert!(status.is_none());
+            do chan.with_ref |chan| {
+                chan.send_deferred(());
             }
         }
 
@@ -1497,20 +1444,19 @@ impl UvFileStream {
         let result_cell = Cell::new_empty();
         let result_cell_ptr: *Cell<Result<int, IoError>> = &result_cell;
         let buf_ptr: *&mut [u8] = &buf;
-        do self.home_for_io_with_sched |self_, scheduler| {
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let buf = unsafe { slice_to_uv_buf(*buf_ptr) };
-                let task_cell = Cell::new(task);
-                let read_req = file::FsRequest::new();
-                do read_req.read(&self_.loop_, self_.fd, buf, offset) |req, uverr| {
-                    let res = match uverr  {
-                        None => Ok(req.get_result() as int),
-                        Some(err) => Err(uv_error_to_io_error(err))
-                    };
-                    unsafe { (*result_cell_ptr).put_back(res); }
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let buf = unsafe { slice_to_uv_buf(*buf_ptr) };
+            let task_cell = Cell::new(task);
+            let read_req = file::FsRequest::new();
+            do read_req.read(&self.loop_, self.fd, buf, offset) |req, uverr| {
+                let res = match uverr  {
+                    None => Ok(req.get_result() as int),
+                    Some(err) => Err(uv_error_to_io_error(err))
+                };
+                unsafe { (*result_cell_ptr).put_back(res); }
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
         result_cell.take()
@@ -1519,20 +1465,19 @@ impl UvFileStream {
         let result_cell = Cell::new_empty();
         let result_cell_ptr: *Cell<Result<(), IoError>> = &result_cell;
         let buf_ptr: *&[u8] = &buf;
-        do self.home_for_io_with_sched |self_, scheduler| {
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let buf = unsafe { slice_to_uv_buf(*buf_ptr) };
-                let task_cell = Cell::new(task);
-                let write_req = file::FsRequest::new();
-                do write_req.write(&self_.loop_, self_.fd, buf, offset) |_, uverr| {
-                    let res = match uverr  {
-                        None => Ok(()),
-                        Some(err) => Err(uv_error_to_io_error(err))
-                    };
-                    unsafe { (*result_cell_ptr).put_back(res); }
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let buf = unsafe { slice_to_uv_buf(*buf_ptr) };
+            let task_cell = Cell::new(task);
+            let write_req = file::FsRequest::new();
+            do write_req.write(&self.loop_, self.fd, buf, offset) |_, uverr| {
+                let res = match uverr  {
+                    None => Ok(()),
+                    Some(err) => Err(uv_error_to_io_error(err))
+                };
+                unsafe { (*result_cell_ptr).put_back(res); }
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
         result_cell.take()
@@ -1564,14 +1509,13 @@ impl Drop for UvFileStream {
                 do close_req.close(&self.loop_, self.fd) |_,_| {}
             }
             CloseSynchronously => {
-                do self.home_for_io_with_sched |self_, scheduler| {
-                    do scheduler.deschedule_running_task_and_then |_, task| {
-                        let task_cell = Cell::new(task);
-                        let close_req = file::FsRequest::new();
-                        do close_req.close(&self_.loop_, self_.fd) |_,_| {
-                            let scheduler: ~Scheduler = Local::take();
-                            scheduler.resume_blocked_task_immediately(task_cell.take());
-                        }
+                let (_m, scheduler) = self.fire_missiles_sched();
+                do scheduler.deschedule_running_task_and_then |_, task| {
+                    let task_cell = Cell::new(task);
+                    let close_req = file::FsRequest::new();
+                    do close_req.close(&self.loop_, self.fd) |_,_| {
+                        let scheduler: ~Scheduler = Local::take();
+                        scheduler.resume_blocked_task_immediately(task_cell.take());
                     }
                 }
             }
@@ -1604,7 +1548,7 @@ impl RtioFileStream for UvFileStream {
     fn tell(&self) -> Result<u64, IoError> {
         use std::libc::SEEK_CUR;
         // this is temporary
-        let self_ = unsafe { cast::transmute::<&UvFileStream, &mut UvFileStream>(self) };
+        let self_ = unsafe { cast::transmute_mut(self) };
         self_.seek_common(0, SEEK_CUR)
     }
 }
@@ -1647,7 +1591,8 @@ impl Drop for UvProcess {
         if self.home.is_none() {
             close(self)
         } else {
-            self.home_for_io(close)
+            let _m = self.fire_missiles();
+            close(self)
         }
     }
 }
@@ -1658,30 +1603,28 @@ impl RtioProcess for UvProcess {
     }
 
     fn kill(&mut self, signal: int) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            match self_.process.kill(signal) {
-                Ok(()) => Ok(()),
-                Err(uverr) => Err(uv_error_to_io_error(uverr))
-            }
+        let _m = self.fire_missiles();
+        match self.process.kill(signal) {
+            Ok(()) => Ok(()),
+            Err(uverr) => Err(uv_error_to_io_error(uverr))
         }
     }
 
     fn wait(&mut self) -> int {
         // Make sure (on the home scheduler) that we have an exit status listed
-        do self.home_for_io |self_| {
-            match self_.exit_status {
-                Some(*) => {}
-                None => {
-                    // If there's no exit code previously listed, then the
-                    // process's exit callback has yet to be invoked. We just
-                    // need to deschedule ourselves and wait to be reawoken.
-                    let scheduler: ~Scheduler = Local::take();
-                    do scheduler.deschedule_running_task_and_then |_, task| {
-                        assert!(self_.descheduled.is_none());
-                        self_.descheduled = Some(task);
-                    }
-                    assert!(self_.exit_status.is_some());
+        let _m = self.fire_missiles();
+        match self.exit_status {
+            Some(*) => {}
+            None => {
+                // If there's no exit code previously listed, then the
+                // process's exit callback has yet to be invoked. We just
+                // need to deschedule ourselves and wait to be reawoken.
+                let scheduler: ~Scheduler = Local::take();
+                do scheduler.deschedule_running_task_and_then |_, task| {
+                    assert!(self.descheduled.is_none());
+                    self.descheduled = Some(task);
                 }
+                assert!(self.exit_status.is_some());
             }
         }
 
@@ -1704,28 +1647,27 @@ impl UvUnixListener {
 }
 
 impl RtioUnixListener for UvUnixListener {
-    fn listen(~self) -> Result<~RtioUnixAcceptor, IoError> {
-        do self.home_for_io_consume |self_| {
-            let acceptor = ~UvUnixAcceptor::new(self_);
-            let incoming = Cell::new(acceptor.incoming.clone());
-            let mut stream = acceptor.listener.inner.pipe.as_stream();
-            let res = do stream.listen |mut server, status| {
-                do incoming.with_mut_ref |incoming| {
-                    let inc = match status {
-                        Some(e) => Err(uv_error_to_io_error(e)),
-                        None => {
-                            let pipe = UvUnboundPipe::new(&server.event_loop());
-                            server.accept(pipe.pipe.as_stream());
-                            Ok(~UvPipeStream::new(pipe) as ~RtioPipe)
-                        }
-                    };
-                    incoming.send(inc);
-                }
-            };
-            match res {
-                Ok(()) => Ok(acceptor as ~RtioUnixAcceptor),
-                Err(e) => Err(uv_error_to_io_error(e)),
+    fn listen(mut ~self) -> Result<~RtioUnixAcceptor, IoError> {
+        let _m = self.fire_missiles();
+        let acceptor = ~UvUnixAcceptor::new(*self);
+        let incoming = Cell::new(acceptor.incoming.clone());
+        let mut stream = acceptor.listener.inner.pipe.as_stream();
+        let res = do stream.listen |mut server, status| {
+            do incoming.with_mut_ref |incoming| {
+                let inc = match status {
+                    Some(e) => Err(uv_error_to_io_error(e)),
+                    None => {
+                        let pipe = UvUnboundPipe::new(&server.event_loop());
+                        server.accept(pipe.pipe.as_stream());
+                        Ok(~UvPipeStream::new(pipe) as ~RtioPipe)
+                    }
+                };
+                incoming.send(inc);
             }
+        };
+        match res {
+            Ok(()) => Ok(acceptor as ~RtioUnixAcceptor),
+            Err(e) => Err(uv_error_to_io_error(e)),
         }
     }
 }
@@ -1753,30 +1695,26 @@ impl Drop for UvTTY {
 
 impl RtioTTY for UvTTY {
     fn read(&mut self, buf: &mut [u8]) -> Result<uint, IoError> {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            read_stream(self_.tty.as_stream(), scheduler, buf)
-        }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        read_stream(self.tty.as_stream(), scheduler, buf)
     }
 
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError> {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            write_stream(self_.tty.as_stream(), scheduler, buf)
-        }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        write_stream(self.tty.as_stream(), scheduler, buf)
     }
 
     fn set_raw(&mut self, raw: bool) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            match self_.tty.set_mode(raw) {
-                Ok(p) => Ok(p), Err(e) => Err(uv_error_to_io_error(e))
-            }
+        let _m = self.fire_missiles();
+        match self.tty.set_mode(raw) {
+            Ok(p) => Ok(p), Err(e) => Err(uv_error_to_io_error(e))
         }
     }
 
     fn get_winsize(&mut self) -> Result<(int, int), IoError> {
-        do self.home_for_io |self_| {
-            match self_.tty.get_winsize() {
-                Ok(p) => Ok(p), Err(e) => Err(uv_error_to_io_error(e))
-            }
+        let _m = self.fire_missiles();
+        match self.tty.get_winsize() {
+            Ok(p) => Ok(p), Err(e) => Err(uv_error_to_io_error(e))
         }
     }
 
@@ -1802,21 +1740,18 @@ impl UvUnixAcceptor {
 
 impl RtioUnixAcceptor for UvUnixAcceptor {
     fn accept(&mut self) -> Result<~RtioPipe, IoError> {
-        do self.home_for_io |self_| {
-            self_.incoming.recv()
-        }
+        let _m = self.fire_missiles();
+        self.incoming.recv()
     }
 
     fn accept_simultaneously(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            accept_simultaneously(self_.listener.inner.pipe.as_stream(), 1)
-        }
+        let _m = self.fire_missiles();
+        accept_simultaneously(self.listener.inner.pipe.as_stream(), 1)
     }
 
     fn dont_accept_simultaneously(&mut self) -> Result<(), IoError> {
-        do self.home_for_io |self_| {
-            accept_simultaneously(self_.listener.inner.pipe.as_stream(), 0)
-        }
+        let _m = self.fire_missiles();
+        accept_simultaneously(self.listener.inner.pipe.as_stream(), 0)
     }
 }
 
@@ -1839,14 +1774,13 @@ impl RtioSignal for UvSignal {}
 
 impl Drop for UvSignal {
     fn drop(&mut self) {
-        do self.home_for_io_with_sched |self_, scheduler| {
-            uvdebug!("closing UvSignal");
-            do scheduler.deschedule_running_task_and_then |_, task| {
-                let task_cell = Cell::new(task);
-                do self_.watcher.close {
-                    let scheduler: ~Scheduler = Local::take();
-                    scheduler.resume_blocked_task_immediately(task_cell.take());
-                }
+        let (_m, scheduler) = self.fire_missiles_sched();
+        uvdebug!("closing UvSignal");
+        do scheduler.deschedule_running_task_and_then |_, task| {
+            let task_cell = Cell::new(task);
+            do self.watcher.close {
+                let scheduler: ~Scheduler = Local::take();
+                scheduler.resume_blocked_task_immediately(task_cell.take());
             }
         }
     }

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -972,7 +972,7 @@ impl RtioSocket for UvTcpAcceptor {
 
 fn accept_simultaneously(stream: StreamWatcher, a: int) -> Result<(), IoError> {
     let r = unsafe {
-        uvll::tcp_simultaneous_accepts(stream.native_handle(), a as c_int)
+        uvll::uv_tcp_simultaneous_accepts(stream.native_handle(), a as c_int)
     };
 
     match status_to_maybe_uv_error(r) {
@@ -1178,7 +1178,9 @@ impl RtioTcpStream for UvTcpStream {
 
     fn control_congestion(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-            let r = unsafe { uvll::tcp_nodelay(self_.watcher.native_handle(), 0 as c_int) };
+            let r = unsafe {
+                uvll::uv_tcp_nodelay(self_.watcher.native_handle(), 0 as c_int)
+            };
 
             match status_to_maybe_uv_error(r) {
                 Some(err) => Err(uv_error_to_io_error(err)),
@@ -1189,7 +1191,9 @@ impl RtioTcpStream for UvTcpStream {
 
     fn nodelay(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-            let r = unsafe { uvll::tcp_nodelay(self_.watcher.native_handle(), 1 as c_int) };
+            let r = unsafe {
+                uvll::uv_tcp_nodelay(self_.watcher.native_handle(), 1 as c_int)
+            };
 
             match status_to_maybe_uv_error(r) {
                 Some(err) => Err(uv_error_to_io_error(err)),
@@ -1201,8 +1205,8 @@ impl RtioTcpStream for UvTcpStream {
     fn keepalive(&mut self, delay_in_seconds: uint) -> Result<(), IoError> {
         do self.home_for_io |self_| {
             let r = unsafe {
-                uvll::tcp_keepalive(self_.watcher.native_handle(), 1 as c_int,
-                                    delay_in_seconds as c_uint)
+                uvll::uv_tcp_keepalive(self_.watcher.native_handle(), 1 as c_int,
+                                       delay_in_seconds as c_uint)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1215,7 +1219,8 @@ impl RtioTcpStream for UvTcpStream {
     fn letdie(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
             let r = unsafe {
-                uvll::tcp_keepalive(self_.watcher.native_handle(), 0 as c_int, 0 as c_uint)
+                uvll::uv_tcp_keepalive(self_.watcher.native_handle(),
+                                       0 as c_int, 0 as c_uint)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1323,8 +1328,9 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
             let r = unsafe {
                 do multi.to_str().with_c_str |m_addr| {
-                    uvll::udp_set_membership(self_.watcher.native_handle(), m_addr,
-                                             ptr::null(), uvll::UV_JOIN_GROUP)
+                    uvll::uv_udp_set_membership(self_.watcher.native_handle(),
+                                                m_addr, ptr::null(),
+                                                uvll::UV_JOIN_GROUP)
                 }
             };
 
@@ -1339,8 +1345,9 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
             let r = unsafe {
                 do multi.to_str().with_c_str |m_addr| {
-                    uvll::udp_set_membership(self_.watcher.native_handle(), m_addr,
-                                             ptr::null(), uvll::UV_LEAVE_GROUP)
+                    uvll::uv_udp_set_membership(self_.watcher.native_handle(),
+                                                m_addr, ptr::null(),
+                                                uvll::UV_LEAVE_GROUP)
                 }
             };
 
@@ -1355,7 +1362,8 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
 
             let r = unsafe {
-                uvll::udp_set_multicast_loop(self_.watcher.native_handle(), 1 as c_int)
+                uvll::uv_udp_set_multicast_loop(self_.watcher.native_handle(),
+                                                1 as c_int)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1369,7 +1377,8 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
 
             let r = unsafe {
-                uvll::udp_set_multicast_loop(self_.watcher.native_handle(), 0 as c_int)
+                uvll::uv_udp_set_multicast_loop(self_.watcher.native_handle(),
+                                                0 as c_int)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1383,7 +1392,8 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
 
             let r = unsafe {
-                uvll::udp_set_multicast_ttl(self_.watcher.native_handle(), ttl as c_int)
+                uvll::uv_udp_set_multicast_ttl(self_.watcher.native_handle(),
+                                               ttl as c_int)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1397,7 +1407,7 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
 
             let r = unsafe {
-                uvll::udp_set_ttl(self_.watcher.native_handle(), ttl as c_int)
+                uvll::uv_udp_set_ttl(self_.watcher.native_handle(), ttl as c_int)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1411,7 +1421,8 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
 
             let r = unsafe {
-                uvll::udp_set_broadcast(self_.watcher.native_handle(), 1 as c_int)
+                uvll::uv_udp_set_broadcast(self_.watcher.native_handle(),
+                                           1 as c_int)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1425,7 +1436,8 @@ impl RtioUdpSocket for UvUdpSocket {
         do self.home_for_io |self_| {
 
             let r = unsafe {
-                uvll::udp_set_broadcast(self_.watcher.native_handle(), 0 as c_int)
+                uvll::uv_udp_set_broadcast(self_.watcher.native_handle(),
+                                           0 as c_int)
             };
 
             match status_to_maybe_uv_error(r) {
@@ -1827,7 +1839,7 @@ impl RtioTTY for UvTTY {
     }
 
     fn isatty(&self) -> bool {
-        unsafe { uvll::guess_handle(self.fd) == uvll::UV_TTY as c_int }
+        unsafe { uvll::uv_guess_handle(self.fd) == uvll::UV_TTY }
     }
 }
 

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -151,8 +151,8 @@ enum SocketNameKind {
     Udp
 }
 
-fn socket_name<T, U: Watcher + NativeHandle<*T>>(sk: SocketNameKind,
-                                                 handle: U) -> Result<SocketAddr, IoError> {
+fn socket_name<T, U: Watcher + NativeHandle<T>>(sk: SocketNameKind,
+                                                handle: U) -> Result<SocketAddr, IoError> {
     let getsockname = match sk {
         TcpPeer => uvll::tcp_getpeername,
         Tcp     => uvll::tcp_getsockname,

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -974,11 +974,7 @@ fn accept_simultaneously(stream: StreamWatcher, a: int) -> Result<(), IoError> {
     let r = unsafe {
         uvll::uv_tcp_simultaneous_accepts(stream.native_handle(), a as c_int)
     };
-
-    match status_to_maybe_uv_error(r) {
-        Some(err) => Err(uv_error_to_io_error(err)),
-        None => Ok(())
-    }
+    status_to_io_result(r)
 }
 
 impl RtioTcpAcceptor for UvTcpAcceptor {
@@ -1181,11 +1177,7 @@ impl RtioTcpStream for UvTcpStream {
             let r = unsafe {
                 uvll::uv_tcp_nodelay(self_.watcher.native_handle(), 0 as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
@@ -1194,11 +1186,7 @@ impl RtioTcpStream for UvTcpStream {
             let r = unsafe {
                 uvll::uv_tcp_nodelay(self_.watcher.native_handle(), 1 as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
@@ -1208,11 +1196,7 @@ impl RtioTcpStream for UvTcpStream {
                 uvll::uv_tcp_keepalive(self_.watcher.native_handle(), 1 as c_int,
                                        delay_in_seconds as c_uint)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
@@ -1222,11 +1206,7 @@ impl RtioTcpStream for UvTcpStream {
                 uvll::uv_tcp_keepalive(self_.watcher.native_handle(),
                                        0 as c_int, 0 as c_uint)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 }
@@ -1333,11 +1313,7 @@ impl RtioUdpSocket for UvUdpSocket {
                                                 uvll::UV_JOIN_GROUP)
                 }
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
@@ -1350,100 +1326,66 @@ impl RtioUdpSocket for UvUdpSocket {
                                                 uvll::UV_LEAVE_GROUP)
                 }
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
     fn loop_multicast_locally(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-
             let r = unsafe {
                 uvll::uv_udp_set_multicast_loop(self_.watcher.native_handle(),
                                                 1 as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
     fn dont_loop_multicast_locally(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-
             let r = unsafe {
                 uvll::uv_udp_set_multicast_loop(self_.watcher.native_handle(),
                                                 0 as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
     fn multicast_time_to_live(&mut self, ttl: int) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-
             let r = unsafe {
                 uvll::uv_udp_set_multicast_ttl(self_.watcher.native_handle(),
                                                ttl as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
     fn time_to_live(&mut self, ttl: int) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-
             let r = unsafe {
                 uvll::uv_udp_set_ttl(self_.watcher.native_handle(), ttl as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
     fn hear_broadcasts(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-
             let r = unsafe {
                 uvll::uv_udp_set_broadcast(self_.watcher.native_handle(),
                                            1 as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 
     fn ignore_broadcasts(&mut self) -> Result<(), IoError> {
         do self.home_for_io |self_| {
-
             let r = unsafe {
                 uvll::uv_udp_set_broadcast(self_.watcher.native_handle(),
                                            0 as c_int)
             };
-
-            match status_to_maybe_uv_error(r) {
-                Some(err) => Err(uv_error_to_io_error(err)),
-                None => Ok(())
-            }
+            status_to_io_result(r)
         }
     }
 }

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -33,7 +33,6 @@ use std::libc::{size_t, c_int, c_uint, c_void, c_char, uintptr_t};
 use std::libc::ssize_t;
 use std::libc::{malloc, free};
 use std::libc;
-use std::ptr;
 use std::vec;
 
 pub use self::errors::*;
@@ -93,6 +92,13 @@ pub struct uv_buf_t {
 pub struct uv_buf_t {
     len: u32,
     base: *u8,
+}
+
+#[repr(C)]
+pub enum uv_run_mode {
+    RUN_DEFAULT = 0,
+    RUN_ONCE,
+    RUN_NOWAIT,
 }
 
 pub struct uv_process_options_t {
@@ -222,6 +228,7 @@ pub type uv_exit_cb = extern "C" fn(handle: *uv_process_t,
                                     term_signal: c_int);
 pub type uv_signal_cb = extern "C" fn(handle: *uv_signal_t,
                                       signum: c_int);
+pub type uv_fs_cb = extern "C" fn(req: *uv_fs_t);
 
 pub type sockaddr = c_void;
 pub type sockaddr_in = c_void;
@@ -275,6 +282,7 @@ pub struct addrinfo {
 #[cfg(windows)] pub type uv_uid_t = libc::c_uchar;
 #[cfg(windows)] pub type uv_gid_t = libc::c_uchar;
 
+#[repr(C)]
 #[deriving(Eq)]
 pub enum uv_handle_type {
     UV_UNKNOWN_HANDLE,
@@ -298,6 +306,7 @@ pub enum uv_handle_type {
     UV_HANDLE_TYPE_MAX
 }
 
+#[repr(C)]
 #[cfg(unix)]
 #[deriving(Eq)]
 pub enum uv_req_type {
@@ -315,6 +324,7 @@ pub enum uv_req_type {
 
 // uv_req_type may have additional fields defined by UV_REQ_TYPE_PRIVATE.
 // See UV_REQ_TYPE_PRIVATE at libuv/include/uv-win.h
+#[repr(C)]
 #[cfg(windows)]
 #[deriving(Eq)]
 pub enum uv_req_type {
@@ -338,6 +348,7 @@ pub enum uv_req_type {
     UV_REQ_TYPE_MAX
 }
 
+#[repr(C)]
 #[deriving(Eq)]
 pub enum uv_membership {
     UV_LEAVE_GROUP,
@@ -348,7 +359,7 @@ pub unsafe fn malloc_handle(handle: uv_handle_type) -> *c_void {
     #[fixed_stack_segment]; #[inline(never)];
 
     assert!(handle != UV_UNKNOWN_HANDLE && handle != UV_HANDLE_TYPE_MAX);
-    let size = rust_uv_handle_size(handle as uint);
+    let size = uv_handle_size(handle);
     let p = malloc(size);
     assert!(p.is_not_null());
     return p;
@@ -364,7 +375,7 @@ pub unsafe fn malloc_req(req: uv_req_type) -> *c_void {
     #[fixed_stack_segment]; #[inline(never)];
 
     assert!(req != UV_UNKNOWN_REQ && req != UV_REQ_TYPE_MAX);
-    let size = rust_uv_req_size(req as uint);
+    let size = uv_req_size(req);
     let p = malloc(size);
     assert!(p.is_not_null());
     return p;
@@ -399,54 +410,6 @@ pub unsafe fn loop_new() -> *c_void {
     return rust_uv_loop_new();
 }
 
-pub unsafe fn loop_delete(loop_handle: *c_void) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_loop_delete(loop_handle);
-}
-
-pub unsafe fn run(loop_handle: *c_void) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_run(loop_handle);
-}
-
-pub unsafe fn close<T>(handle: *T, cb: uv_close_cb) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_close(handle as *c_void, cb);
-}
-
-pub unsafe fn walk(loop_handle: *c_void, cb: uv_walk_cb, arg: *c_void) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_walk(loop_handle, cb, arg);
-}
-
-pub unsafe fn idle_init(loop_handle: *uv_loop_t, handle: *uv_idle_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_idle_init(loop_handle, handle)
-}
-
-pub unsafe fn idle_start(handle: *uv_idle_t, cb: uv_idle_cb) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_idle_start(handle, cb)
-}
-
-pub unsafe fn idle_stop(handle: *uv_idle_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_idle_stop(handle)
-}
-
-pub unsafe fn udp_init(loop_handle: *uv_loop_t, handle: *uv_udp_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_init(loop_handle, handle);
-}
-
 pub unsafe fn udp_bind(server: *uv_udp_t, addr: *sockaddr_in, flags: c_uint) -> c_int {
     #[fixed_stack_segment]; #[inline(never)];
 
@@ -477,19 +440,6 @@ pub unsafe fn udp_send6<T>(req: *uv_udp_send_t, handle: *T, buf_in: &[uv_buf_t],
     return rust_uv_udp_send6(req, handle as *c_void, buf_ptr, buf_cnt, addr, cb);
 }
 
-pub unsafe fn udp_recv_start(server: *uv_udp_t, on_alloc: uv_alloc_cb,
-                             on_recv: uv_udp_recv_cb) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_recv_start(server, on_alloc, on_recv);
-}
-
-pub unsafe fn udp_recv_stop(server: *uv_udp_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_recv_stop(server);
-}
-
 pub unsafe fn get_udp_handle_from_send_req(send_req: *uv_udp_send_t) -> *uv_udp_t {
     #[fixed_stack_segment]; #[inline(never)];
 
@@ -500,43 +450,6 @@ pub unsafe fn udp_getsockname(handle: *uv_udp_t, name: *sockaddr_storage) -> c_i
     #[fixed_stack_segment]; #[inline(never)];
 
     return rust_uv_udp_getsockname(handle, name);
-}
-
-pub unsafe fn udp_set_membership(handle: *uv_udp_t, multicast_addr: *c_char,
-                                 interface_addr: *c_char, membership: uv_membership) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_set_membership(handle, multicast_addr, interface_addr, membership as c_int);
-}
-
-pub unsafe fn udp_set_multicast_loop(handle: *uv_udp_t, on: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_set_multicast_loop(handle, on);
-}
-
-pub unsafe fn udp_set_multicast_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_set_multicast_ttl(handle, ttl);
-}
-
-pub unsafe fn udp_set_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_set_ttl(handle, ttl);
-}
-
-pub unsafe fn udp_set_broadcast(handle: *uv_udp_t, on: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_udp_set_broadcast(handle, on);
-}
-
-pub unsafe fn tcp_init(loop_handle: *c_void, handle: *uv_tcp_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_tcp_init(loop_handle, handle);
 }
 
 pub unsafe fn tcp_connect(connect_ptr: *uv_connect_t, tcp_handle_ptr: *uv_tcp_t,
@@ -577,108 +490,17 @@ pub unsafe fn tcp_getsockname(handle: *uv_tcp_t, name: *sockaddr_storage) -> c_i
     return rust_uv_tcp_getsockname(handle, name);
 }
 
-pub unsafe fn tcp_nodelay(handle: *uv_tcp_t, enable: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_tcp_nodelay(handle, enable);
-}
-
-pub unsafe fn tcp_keepalive(handle: *uv_tcp_t, enable: c_int, delay: c_uint) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_tcp_keepalive(handle, enable, delay);
-}
-
-pub unsafe fn tcp_simultaneous_accepts(handle: *uv_tcp_t, enable: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_tcp_simultaneous_accepts(handle, enable);
-}
-
-pub unsafe fn listen<T>(stream: *T, backlog: c_int,
-                        cb: uv_connection_cb) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_listen(stream as *c_void, backlog, cb);
-}
-
-pub unsafe fn accept(server: *c_void, client: *c_void) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_accept(server as *c_void, client as *c_void);
-}
-
-pub unsafe fn write<T>(req: *uv_write_t,
-                       stream: *T,
+pub unsafe fn uv_write(req: *uv_write_t,
+                       stream: *uv_stream_t,
                        buf_in: &[uv_buf_t],
                        cb: uv_write_cb) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
+    externfn!(fn uv_write(req: *uv_write_t, stream: *uv_stream_t,
+                          buf_in: *uv_buf_t, buf_cnt: c_int,
+                          cb: uv_write_cb) -> c_int)
 
     let buf_ptr = vec::raw::to_ptr(buf_in);
     let buf_cnt = buf_in.len() as i32;
-    return rust_uv_write(req as *c_void, stream as *c_void, buf_ptr, buf_cnt, cb);
-}
-pub unsafe fn read_start(stream: *uv_stream_t,
-                         on_alloc: uv_alloc_cb,
-                         on_read: uv_read_cb) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_read_start(stream as *c_void, on_alloc, on_read);
-}
-
-pub unsafe fn read_stop(stream: *uv_stream_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_read_stop(stream as *c_void);
-}
-
-pub unsafe fn strerror(err: c_int) -> *c_char {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_strerror(err);
-}
-pub unsafe fn err_name(err: c_int) -> *c_char {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_err_name(err);
-}
-
-pub unsafe fn async_init(loop_handle: *c_void,
-                         async_handle: *uv_async_t,
-                         cb: uv_async_cb) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_async_init(loop_handle, async_handle, cb);
-}
-
-pub unsafe fn async_send(async_handle: *uv_async_t) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_async_send(async_handle);
-}
-pub unsafe fn buf_init(input: *u8, len: uint) -> uv_buf_t {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    let out_buf = uv_buf_t { base: ptr::null(), len: 0 as size_t };
-    let out_buf_ptr = ptr::to_unsafe_ptr(&out_buf);
-    rust_uv_buf_init(out_buf_ptr, input, len as size_t);
-    return out_buf;
-}
-
-pub unsafe fn timer_init(loop_ptr: *c_void, timer_ptr: *uv_timer_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_timer_init(loop_ptr, timer_ptr);
-}
-pub unsafe fn timer_start(timer_ptr: *uv_timer_t,
-                          cb: uv_timer_cb, timeout: u64,
-                          repeat: u64) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_timer_start(timer_ptr, cb, timeout, repeat);
-}
-pub unsafe fn timer_stop(timer_ptr: *uv_timer_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_timer_stop(timer_ptr);
+    return uv_write(req, stream, buf_ptr, buf_cnt, cb);
 }
 
 pub unsafe fn is_ip4_addr(addr: *sockaddr) -> bool {
@@ -730,18 +552,6 @@ pub unsafe fn free_ip6_addr(addr: *sockaddr_in6) {
     rust_uv_free_ip6_addr(addr);
 }
 
-pub unsafe fn ip4_name(addr: *sockaddr_in, dst: *u8, size: size_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_ip4_name(addr, dst, size);
-}
-
-pub unsafe fn ip6_name(addr: *sockaddr_in6, dst: *u8, size: size_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_ip6_name(addr, dst, size);
-}
-
 pub unsafe fn ip4_port(addr: *sockaddr_in) -> c_uint {
     #[fixed_stack_segment]; #[inline(never)];
 
@@ -752,87 +562,6 @@ pub unsafe fn ip6_port(addr: *sockaddr_in6) -> c_uint {
     #[fixed_stack_segment]; #[inline(never)];
 
     return rust_uv_ip6_port(addr);
-}
-
-pub unsafe fn fs_open(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, flags: int, mode: int,
-                cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_open(loop_ptr, req, path, flags as c_int, mode as c_int, cb)
-}
-
-pub unsafe fn fs_unlink(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
-                cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_unlink(loop_ptr, req, path, cb)
-}
-pub unsafe fn fs_write(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
-                       len: uint, offset: i64, cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_write(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
-}
-pub unsafe fn fs_read(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
-                       len: uint, offset: i64, cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_read(loop_ptr, req, fd, buf, len as c_uint, offset, cb)
-}
-pub unsafe fn fs_close(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int,
-                cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_close(loop_ptr, req, fd, cb)
-}
-pub unsafe fn fs_stat(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_stat(loop_ptr, req, path, cb)
-}
-pub unsafe fn fs_fstat(loop_ptr: *uv_loop_t, req: *uv_fs_t, fd: c_int, cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_fstat(loop_ptr, req, fd, cb)
-}
-pub unsafe fn fs_mkdir(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char, mode: int,
-                cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_mkdir(loop_ptr, req, path, mode as c_int, cb)
-}
-pub unsafe fn fs_rmdir(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
-                cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_rmdir(loop_ptr, req, path, cb)
-}
-pub unsafe fn fs_readdir(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
-                flags: c_int, cb: *u8) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_readdir(loop_ptr, req, path, flags, cb)
-}
-pub unsafe fn populate_stat(req_in: *uv_fs_t, stat_out: *uv_stat_t) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_populate_uv_stat(req_in, stat_out)
-}
-pub unsafe fn fs_req_cleanup(req: *uv_fs_t) {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    rust_uv_fs_req_cleanup(req);
-}
-
-pub unsafe fn spawn(loop_ptr: *c_void, result: *uv_process_t,
-                    options: uv_process_options_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_spawn(loop_ptr, result, options);
-}
-
-pub unsafe fn process_kill(p: *uv_process_t, signum: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_process_kill(p, signum);
 }
 
 pub unsafe fn process_pid(p: *uv_process_t) -> c_int {
@@ -856,11 +585,6 @@ pub unsafe fn set_stdio_container_stream(c: *uv_stdio_container_t,
                                          stream: *uv_stream_t) {
     #[fixed_stack_segment]; #[inline(never)];
     rust_set_stdio_container_stream(c, stream);
-}
-
-pub unsafe fn pipe_init(loop_ptr: *c_void, p: *uv_pipe_t, ipc: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_pipe_init(loop_ptr, p, ipc)
 }
 
 // data access helpers
@@ -929,114 +653,24 @@ pub unsafe fn set_data_for_req<T, U>(req: *T, data: *U) {
 
     rust_uv_set_data_for_req(req as *c_void, data as *c_void);
 }
-pub unsafe fn get_base_from_buf(buf: uv_buf_t) -> *u8 {
+pub unsafe fn populate_stat(req_in: *uv_fs_t, stat_out: *uv_stat_t) {
     #[fixed_stack_segment]; #[inline(never)];
 
-    return rust_uv_get_base_from_buf(buf);
-}
-pub unsafe fn get_len_from_buf(buf: uv_buf_t) -> size_t {
-    #[fixed_stack_segment]; #[inline(never)];
-
-    return rust_uv_get_len_from_buf(buf);
-}
-pub unsafe fn getaddrinfo(loop_: *uv_loop_t, req: *uv_getaddrinfo_t,
-               getaddrinfo_cb: uv_getaddrinfo_cb,
-               node: *c_char, service: *c_char,
-               hints: *addrinfo) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_getaddrinfo(loop_, req, getaddrinfo_cb, node, service, hints);
-}
-pub unsafe fn freeaddrinfo(ai: *addrinfo) {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_freeaddrinfo(ai);
-}
-pub unsafe fn pipe_open(pipe: *uv_pipe_t, file: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_pipe_open(pipe, file)
-}
-pub unsafe fn pipe_bind(pipe: *uv_pipe_t, name: *c_char) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_pipe_bind(pipe, name)
-}
-pub unsafe fn pipe_connect(req: *uv_connect_t, handle: *uv_pipe_t,
-                           name: *c_char, cb: uv_connect_cb) {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_pipe_connect(req, handle, name, cb)
-}
-pub unsafe fn tty_init(loop_ptr: *uv_loop_t, tty: *uv_tty_t, fd: c_int,
-                       readable: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_tty_init(loop_ptr, tty, fd, readable)
-}
-pub unsafe fn tty_set_mode(tty: *uv_tty_t, mode: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_tty_set_mode(tty, mode)
-}
-pub unsafe fn tty_get_winsize(tty: *uv_tty_t, width: *c_int,
-                              height: *c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_tty_get_winsize(tty, width, height)
-}
-// FIXME(#9613) this should return uv_handle_type, not a c_int
-pub unsafe fn guess_handle(fd: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    rust_uv_guess_handle(fd)
+    rust_uv_populate_uv_stat(req_in, stat_out)
 }
 
-pub unsafe fn signal_init(loop_: *uv_loop_t, handle: *uv_signal_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_signal_init(loop_, handle);
-}
-pub unsafe fn signal_start(handle: *uv_signal_t,
-                           signal_cb: uv_signal_cb,
-                           signum: c_int) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_signal_start(handle, signal_cb, signum);
-}
-pub unsafe fn signal_stop(handle: *uv_signal_t) -> c_int {
-    #[fixed_stack_segment]; #[inline(never)];
-    return rust_uv_signal_stop(handle);
-}
-
-pub struct uv_err_data {
-    err_name: ~str,
-    err_msg: ~str,
-}
 
 // uv_support is the result of compiling rust_uv.cpp
 #[link_args = "-luv_support -luv"]
 extern {
+    fn rust_uv_loop_new() -> *c_void;
 
-    fn rust_uv_handle_size(type_: uintptr_t) -> size_t;
-    fn rust_uv_req_size(type_: uintptr_t) -> size_t;
     fn rust_uv_handle_type_max() -> uintptr_t;
     fn rust_uv_req_type_max() -> uintptr_t;
-
-    // libuv public API
-    fn rust_uv_loop_new() -> *c_void;
-    fn rust_uv_loop_delete(lp: *c_void);
-    fn rust_uv_run(loop_handle: *c_void);
-    fn rust_uv_close(handle: *c_void, cb: uv_close_cb);
-    fn rust_uv_walk(loop_handle: *c_void, cb: uv_walk_cb, arg: *c_void);
-
-    fn rust_uv_idle_init(loop_handle: *uv_loop_t, handle: *uv_idle_t) -> c_int;
-    fn rust_uv_idle_start(handle: *uv_idle_t, cb: uv_idle_cb) -> c_int;
-    fn rust_uv_idle_stop(handle: *uv_idle_t) -> c_int;
-
-    fn rust_uv_async_send(handle: *uv_async_t);
-    fn rust_uv_async_init(loop_handle: *c_void,
-                          async_handle: *uv_async_t,
-                          cb: uv_async_cb) -> c_int;
-    fn rust_uv_tcp_init(loop_handle: *c_void, handle_ptr: *uv_tcp_t) -> c_int;
-    fn rust_uv_buf_init(out_buf: *uv_buf_t, base: *u8, len: size_t);
-    fn rust_uv_strerror(err: c_int) -> *c_char;
-    fn rust_uv_err_name(err: c_int) -> *c_char;
     fn rust_uv_ip4_addrp(ip: *u8, port: c_int) -> *sockaddr_in;
     fn rust_uv_ip6_addrp(ip: *u8, port: c_int) -> *sockaddr_in6;
     fn rust_uv_free_ip4_addr(addr: *sockaddr_in);
     fn rust_uv_free_ip6_addr(addr: *sockaddr_in6);
-    fn rust_uv_ip4_name(src: *sockaddr_in, dst: *u8, size: size_t) -> c_int;
-    fn rust_uv_ip6_name(src: *sockaddr_in6, dst: *u8, size: size_t) -> c_int;
     fn rust_uv_ip4_port(src: *sockaddr_in) -> c_uint;
     fn rust_uv_ip6_port(src: *sockaddr_in6) -> c_uint;
     fn rust_uv_tcp_connect(req: *uv_connect_t, handle: *uv_tcp_t,
@@ -1049,75 +683,25 @@ extern {
     fn rust_uv_tcp_bind6(tcp_server: *uv_tcp_t, addr: *sockaddr_in6) -> c_int;
     fn rust_uv_tcp_getpeername(tcp_handle_ptr: *uv_tcp_t, name: *sockaddr_storage) -> c_int;
     fn rust_uv_tcp_getsockname(handle: *uv_tcp_t, name: *sockaddr_storage) -> c_int;
-    fn rust_uv_tcp_nodelay(handle: *uv_tcp_t, enable: c_int) -> c_int;
-    fn rust_uv_tcp_keepalive(handle: *uv_tcp_t, enable: c_int, delay: c_uint) -> c_int;
-    fn rust_uv_tcp_simultaneous_accepts(handle: *uv_tcp_t, enable: c_int) -> c_int;
-
-    fn rust_uv_udp_init(loop_handle: *uv_loop_t, handle_ptr: *uv_udp_t) -> c_int;
     fn rust_uv_udp_bind(server: *uv_udp_t, addr: *sockaddr_in, flags: c_uint) -> c_int;
     fn rust_uv_udp_bind6(server: *uv_udp_t, addr: *sockaddr_in6, flags: c_uint) -> c_int;
     fn rust_uv_udp_send(req: *uv_udp_send_t, handle: *uv_udp_t, buf_in: *uv_buf_t,
                         buf_cnt: c_int, addr: *sockaddr_in, cb: uv_udp_send_cb) -> c_int;
     fn rust_uv_udp_send6(req: *uv_udp_send_t, handle: *uv_udp_t, buf_in: *uv_buf_t,
                          buf_cnt: c_int, addr: *sockaddr_in6, cb: uv_udp_send_cb) -> c_int;
-    fn rust_uv_udp_recv_start(server: *uv_udp_t,
-                              on_alloc: uv_alloc_cb,
-                              on_recv: uv_udp_recv_cb) -> c_int;
-    fn rust_uv_udp_recv_stop(server: *uv_udp_t) -> c_int;
     fn rust_uv_get_udp_handle_from_send_req(req: *uv_udp_send_t) -> *uv_udp_t;
     fn rust_uv_udp_getsockname(handle: *uv_udp_t, name: *sockaddr_storage) -> c_int;
-    fn rust_uv_udp_set_membership(handle: *uv_udp_t, multicast_addr: *c_char,
-                                  interface_addr: *c_char, membership: c_int) -> c_int;
-    fn rust_uv_udp_set_multicast_loop(handle: *uv_udp_t, on: c_int) -> c_int;
-    fn rust_uv_udp_set_multicast_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int;
-    fn rust_uv_udp_set_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int;
-    fn rust_uv_udp_set_broadcast(handle: *uv_udp_t, on: c_int) -> c_int;
-
     fn rust_uv_is_ipv4_sockaddr(addr: *sockaddr) -> c_int;
     fn rust_uv_is_ipv6_sockaddr(addr: *sockaddr) -> c_int;
     fn rust_uv_malloc_sockaddr_storage() -> *sockaddr_storage;
     fn rust_uv_free_sockaddr_storage(ss: *sockaddr_storage);
-
-    fn rust_uv_listen(stream: *c_void, backlog: c_int,
-                      cb: uv_connection_cb) -> c_int;
-    fn rust_uv_accept(server: *c_void, client: *c_void) -> c_int;
-    fn rust_uv_write(req: *c_void, stream: *c_void, buf_in: *uv_buf_t, buf_cnt: c_int,
-                     cb: uv_write_cb) -> c_int;
-    fn rust_uv_read_start(stream: *c_void,
-                          on_alloc: uv_alloc_cb,
-                          on_read: uv_read_cb) -> c_int;
-    fn rust_uv_read_stop(stream: *c_void) -> c_int;
-    fn rust_uv_timer_init(loop_handle: *c_void, timer_handle: *uv_timer_t) -> c_int;
-    fn rust_uv_timer_start(timer_handle: *uv_timer_t, cb: uv_timer_cb, timeout: libc::uint64_t,
-                           repeat: libc::uint64_t) -> c_int;
-    fn rust_uv_timer_stop(handle: *uv_timer_t) -> c_int;
-    fn rust_uv_fs_open(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
-                       flags: c_int, mode: c_int, cb: *u8) -> c_int;
-    fn rust_uv_fs_unlink(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
-                       cb: *u8) -> c_int;
-    fn rust_uv_fs_write(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
-                       buf: *c_void, len: c_uint, offset: i64, cb: *u8) -> c_int;
-    fn rust_uv_fs_read(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
-                       buf: *c_void, len: c_uint, offset: i64, cb: *u8) -> c_int;
-    fn rust_uv_fs_close(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int,
-                        cb: *u8) -> c_int;
-    fn rust_uv_fs_stat(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char, cb: *u8) -> c_int;
-    fn rust_uv_fs_fstat(loop_ptr: *c_void, req: *uv_fs_t, fd: c_int, cb: *u8) -> c_int;
-    fn rust_uv_fs_mkdir(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
-                        mode: c_int, cb: *u8) -> c_int;
-    fn rust_uv_fs_rmdir(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
-                        cb: *u8) -> c_int;
-    fn rust_uv_fs_readdir(loop_ptr: *c_void, req: *uv_fs_t, path: *c_char,
-                        flags: c_int, cb: *u8) -> c_int;
-    fn rust_uv_fs_req_cleanup(req: *uv_fs_t);
     fn rust_uv_populate_uv_stat(req_in: *uv_fs_t, stat_out: *uv_stat_t);
     fn rust_uv_get_result_from_fs_req(req: *uv_fs_t) -> c_int;
     fn rust_uv_get_ptr_from_fs_req(req: *uv_fs_t) -> *libc::c_void;
     fn rust_uv_get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t;
     fn rust_uv_get_loop_from_getaddrinfo_req(req: *uv_fs_t) -> *uv_loop_t;
-
-    fn rust_uv_get_stream_handle_from_connect_req(connect_req: *uv_connect_t) -> *uv_stream_t;
-    fn rust_uv_get_stream_handle_from_write_req(write_req: *uv_write_t) -> *uv_stream_t;
+    fn rust_uv_get_stream_handle_from_connect_req(req: *uv_connect_t) -> *uv_stream_t;
+    fn rust_uv_get_stream_handle_from_write_req(req: *uv_write_t) -> *uv_stream_t;
     fn rust_uv_get_loop_for_uv_handle(handle: *c_void) -> *c_void;
     fn rust_uv_get_data_for_uv_loop(loop_ptr: *c_void) -> *c_void;
     fn rust_uv_set_data_for_uv_loop(loop_ptr: *c_void, data: *c_void);
@@ -1125,55 +709,128 @@ extern {
     fn rust_uv_set_data_for_uv_handle(handle: *c_void, data: *c_void);
     fn rust_uv_get_data_for_req(req: *c_void) -> *c_void;
     fn rust_uv_set_data_for_req(req: *c_void, data: *c_void);
-    fn rust_uv_get_base_from_buf(buf: uv_buf_t) -> *u8;
-    fn rust_uv_get_len_from_buf(buf: uv_buf_t) -> size_t;
-    fn rust_uv_getaddrinfo(loop_: *uv_loop_t, req: *uv_getaddrinfo_t,
-                           getaddrinfo_cb: uv_getaddrinfo_cb,
-                           node: *c_char, service: *c_char,
-                           hints: *addrinfo) -> c_int;
-    fn rust_uv_freeaddrinfo(ai: *addrinfo);
-    fn rust_uv_spawn(loop_ptr: *c_void, outptr: *uv_process_t,
-                     options: uv_process_options_t) -> c_int;
-    fn rust_uv_process_kill(p: *uv_process_t, signum: c_int) -> c_int;
-    fn rust_uv_process_pid(p: *uv_process_t) -> c_int;
     fn rust_set_stdio_container_flags(c: *uv_stdio_container_t, flags: c_int);
     fn rust_set_stdio_container_fd(c: *uv_stdio_container_t, fd: c_int);
     fn rust_set_stdio_container_stream(c: *uv_stdio_container_t,
                                        stream: *uv_stream_t);
-    fn rust_uv_pipe_init(loop_ptr: *c_void, p: *uv_pipe_t, ipc: c_int) -> c_int;
-
-    fn rust_uv_pipe_open(pipe: *uv_pipe_t, file: c_int) -> c_int;
-    fn rust_uv_pipe_bind(pipe: *uv_pipe_t, name: *c_char) -> c_int;
-    fn rust_uv_pipe_connect(req: *uv_connect_t, handle: *uv_pipe_t,
-                            name: *c_char, cb: uv_connect_cb);
-    fn rust_uv_tty_init(loop_ptr: *uv_loop_t, tty: *uv_tty_t, fd: c_int,
-                        readable: c_int) -> c_int;
-    fn rust_uv_tty_set_mode(tty: *uv_tty_t, mode: c_int) -> c_int;
-    fn rust_uv_tty_get_winsize(tty: *uv_tty_t, width: *c_int,
-                               height: *c_int) -> c_int;
-    fn rust_uv_guess_handle(fd: c_int) -> c_int;
-
-    // XXX: see comments in addrinfo.rs
-    // These should all really be constants...
-    //#[rust_stack] pub fn rust_SOCK_STREAM() -> c_int;
-    //#[rust_stack] pub fn rust_SOCK_DGRAM() -> c_int;
-    //#[rust_stack] pub fn rust_SOCK_RAW() -> c_int;
-    //#[rust_stack] pub fn rust_IPPROTO_UDP() -> c_int;
-    //#[rust_stack] pub fn rust_IPPROTO_TCP() -> c_int;
-    //#[rust_stack] pub fn rust_AI_ADDRCONFIG() -> c_int;
-    //#[rust_stack] pub fn rust_AI_ALL() -> c_int;
-    //#[rust_stack] pub fn rust_AI_CANONNAME() -> c_int;
-    //#[rust_stack] pub fn rust_AI_NUMERICHOST() -> c_int;
-    //#[rust_stack] pub fn rust_AI_NUMERICSERV() -> c_int;
-    //#[rust_stack] pub fn rust_AI_PASSIVE() -> c_int;
-    //#[rust_stack] pub fn rust_AI_V4MAPPED() -> c_int;
-
-    fn rust_uv_signal_init(loop_: *uv_loop_t, handle: *uv_signal_t) -> c_int;
-    fn rust_uv_signal_start(handle: *uv_signal_t,
-                            signal_cb: uv_signal_cb,
-                            signum: c_int) -> c_int;
-    fn rust_uv_signal_stop(handle: *uv_signal_t) -> c_int;
+    fn rust_uv_process_pid(p: *uv_process_t) -> c_int;
 }
+
+// generic uv functions
+externfn!(fn uv_loop_delete(l: *uv_loop_t))
+externfn!(fn uv_handle_size(ty: uv_handle_type) -> size_t)
+externfn!(fn uv_req_size(ty: uv_req_type) -> size_t)
+externfn!(fn uv_run(l: *uv_loop_t, mode: uv_run_mode) -> c_int)
+externfn!(fn uv_close(h: *uv_handle_t, cb: uv_close_cb))
+externfn!(fn uv_walk(l: *uv_loop_t, cb: uv_walk_cb, arg: *c_void))
+externfn!(fn uv_buf_init(base: *c_char, len: c_uint) -> uv_buf_t)
+externfn!(fn uv_strerror(err: c_int) -> *c_char)
+externfn!(fn uv_err_name(err: c_int) -> *c_char)
+externfn!(fn uv_listen(s: *uv_stream_t, backlog: c_int,
+                       cb: uv_connection_cb) -> c_int)
+externfn!(fn uv_accept(server: *uv_stream_t, client: *uv_stream_t) -> c_int)
+externfn!(fn uv_read_start(stream: *uv_stream_t,
+                           on_alloc: uv_alloc_cb,
+                           on_read: uv_read_cb) -> c_int)
+externfn!(fn uv_read_stop(stream: *uv_stream_t) -> c_int)
+
+// idle bindings
+externfn!(fn uv_idle_init(l: *uv_loop_t, i: *uv_idle_t) -> c_int)
+externfn!(fn uv_idle_start(i: *uv_idle_t, cb: uv_idle_cb) -> c_int)
+externfn!(fn uv_idle_stop(i: *uv_idle_t) -> c_int)
+
+// async bindings
+externfn!(fn uv_async_init(l: *uv_loop_t, a: *uv_async_t,
+                           cb: uv_async_cb) -> c_int)
+externfn!(fn uv_async_send(a: *uv_async_t))
+
+// tcp bindings
+externfn!(fn uv_tcp_init(l: *uv_loop_t, h: *uv_tcp_t) -> c_int)
+externfn!(fn uv_ip4_name(src: *sockaddr_in, dst: *c_char,
+                         size: size_t) -> c_int)
+externfn!(fn uv_ip6_name(src: *sockaddr_in6, dst: *c_char,
+                         size: size_t) -> c_int)
+externfn!(fn uv_tcp_nodelay(h: *uv_tcp_t, enable: c_int) -> c_int)
+externfn!(fn uv_tcp_keepalive(h: *uv_tcp_t, enable: c_int,
+                              delay: c_uint) -> c_int)
+externfn!(fn uv_tcp_simultaneous_accepts(h: *uv_tcp_t, enable: c_int) -> c_int)
+
+// udp bindings
+externfn!(fn uv_udp_init(l: *uv_loop_t, h: *uv_udp_t) -> c_int)
+externfn!(fn uv_udp_recv_start(server: *uv_udp_t,
+                               on_alloc: uv_alloc_cb,
+                               on_recv: uv_udp_recv_cb) -> c_int)
+externfn!(fn uv_udp_set_membership(handle: *uv_udp_t, multicast_addr: *c_char,
+                                   interface_addr: *c_char,
+                                   membership: uv_membership) -> c_int)
+externfn!(fn uv_udp_recv_stop(server: *uv_udp_t) -> c_int)
+externfn!(fn uv_udp_set_multicast_loop(handle: *uv_udp_t, on: c_int) -> c_int)
+externfn!(fn uv_udp_set_multicast_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int)
+externfn!(fn uv_udp_set_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int)
+externfn!(fn uv_udp_set_broadcast(handle: *uv_udp_t, on: c_int) -> c_int)
+
+// timer bindings
+externfn!(fn uv_timer_init(l: *uv_loop_t, t: *uv_timer_t) -> c_int)
+externfn!(fn uv_timer_start(t: *uv_timer_t, cb: uv_timer_cb,
+                            timeout: libc::uint64_t,
+                            repeat: libc::uint64_t) -> c_int)
+externfn!(fn uv_timer_stop(handle: *uv_timer_t) -> c_int)
+
+// fs operations
+externfn!(fn uv_fs_open(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                        flags: c_int, mode: c_int, cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_unlink(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                          cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_write(l: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
+                         len: c_uint, offset: i64, cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_read(l: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
+                        len: c_uint, offset: i64, cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_close(l: *uv_loop_t, req: *uv_fs_t, fd: c_int,
+                         cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_stat(l: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                        cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_fstat(l: *uv_loop_t, req: *uv_fs_t, fd: c_int,
+                         cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_mkdir(l: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                         mode: c_int, cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_rmdir(l: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                         cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_readdir(l: *uv_loop_t, req: *uv_fs_t, path: *c_char,
+                           flags: c_int, cb: uv_fs_cb) -> c_int)
+externfn!(fn uv_fs_req_cleanup(req: *uv_fs_t))
+
+// getaddrinfo
+externfn!(fn uv_getaddrinfo(loop_: *uv_loop_t, req: *uv_getaddrinfo_t,
+                            getaddrinfo_cb: uv_getaddrinfo_cb,
+                            node: *c_char, service: *c_char,
+                            hints: *addrinfo) -> c_int)
+externfn!(fn uv_freeaddrinfo(ai: *addrinfo))
+
+// process spawning
+externfn!(fn uv_spawn(loop_ptr: *uv_loop_t, outptr: *uv_process_t,
+                      options: uv_process_options_t) -> c_int)
+externfn!(fn uv_process_kill(p: *uv_process_t, signum: c_int) -> c_int)
+
+// pipes
+externfn!(fn uv_pipe_init(l: *uv_loop_t, p: *uv_pipe_t, ipc: c_int) -> c_int)
+externfn!(fn uv_pipe_open(pipe: *uv_pipe_t, file: c_int) -> c_int)
+externfn!(fn uv_pipe_bind(pipe: *uv_pipe_t, name: *c_char) -> c_int)
+externfn!(fn uv_pipe_connect(req: *uv_connect_t, handle: *uv_pipe_t,
+                             name: *c_char, cb: uv_connect_cb))
+
+// tty
+externfn!(fn uv_tty_init(l: *uv_loop_t, tty: *uv_tty_t, fd: c_int,
+                         readable: c_int) -> c_int)
+externfn!(fn uv_tty_set_mode(tty: *uv_tty_t, mode: c_int) -> c_int)
+externfn!(fn uv_tty_get_winsize(tty: *uv_tty_t, width: *c_int,
+                                height: *c_int) -> c_int)
+externfn!(fn uv_guess_handle(fd: c_int) -> uv_handle_type)
+
+// signals
+externfn!(fn uv_signal_init(loop_: *uv_loop_t, handle: *uv_signal_t) -> c_int)
+externfn!(fn uv_signal_start(h: *uv_signal_t, cb: uv_signal_cb,
+                             signum: c_int) -> c_int)
+externfn!(fn uv_signal_stop(handle: *uv_signal_t) -> c_int)
 
 // libuv requires various system libraries to successfully link on some
 // platforms

--- a/src/rt/rust_uv.cpp
+++ b/src/rt/rust_uv.cpp
@@ -32,77 +32,8 @@ rust_uv_loop_new() {
 }
 
 extern "C" void
-rust_uv_loop_delete(uv_loop_t* loop) {
-    // FIXME: This is a workaround for #1815. libev uses realloc(0) to
-    // free the loop, which valgrind doesn't like. We have suppressions
-    // to make valgrind ignore them.
-    //
-    // Valgrind also has a sanity check when collecting allocation backtraces
-    // that the stack pointer must be at least 512 bytes into the stack (at
-    // least 512 bytes of frames must have come before). When this is not
-    // the case it doesn't collect the backtrace.
-    //
-    // Unfortunately, with our spaghetti stacks that valgrind check triggers
-    // sometimes and we don't get the backtrace for the realloc(0), it
-    // fails to be suppressed, and it gets reported as 0 bytes lost
-    // from a malloc with no backtrace.
-    //
-    // This pads our stack with some extra space before deleting the loop
-    alloca(512);
-    uv_loop_delete(loop);
-}
-
-extern "C" void
 rust_uv_loop_set_data(uv_loop_t* loop, void* data) {
     loop->data = data;
-}
-
-extern "C" void
-rust_uv_run(uv_loop_t* loop) {
-    uv_run(loop, UV_RUN_DEFAULT);
-}
-
-extern "C" void
-rust_uv_close(uv_handle_t* handle, uv_close_cb cb) {
-    uv_close(handle, cb);
-}
-
-extern "C" void
-rust_uv_walk(uv_loop_t* loop, uv_walk_cb cb, void* arg) {
-    uv_walk(loop, cb, arg);
-}
-
-extern "C" void
-rust_uv_async_send(uv_async_t* handle) {
-    uv_async_send(handle);
-}
-
-extern "C" int
-rust_uv_async_init(uv_loop_t* loop_handle,
-        uv_async_t* async_handle,
-        uv_async_cb cb) {
-    return uv_async_init(loop_handle, async_handle, cb);
-}
-
-extern "C" int
-rust_uv_timer_init(uv_loop_t* loop, uv_timer_t* timer) {
-    return uv_timer_init(loop, timer);
-}
-
-extern "C" int
-rust_uv_timer_start(uv_timer_t* the_timer, uv_timer_cb cb,
-                    int64_t timeout, int64_t repeat) {
-    return uv_timer_start(the_timer, cb, timeout, repeat);
-}
-
-extern "C" int
-rust_uv_timer_stop(uv_timer_t* the_timer) {
-    return uv_timer_stop(the_timer);
-}
-
-extern "C" int
-rust_uv_tcp_init(uv_loop_t* loop, uv_tcp_t* handle) {
-    return uv_tcp_init(loop, handle);
 }
 
 extern "C" int
@@ -160,29 +91,6 @@ rust_uv_tcp_getsockname
 }
 
 extern "C" int
-rust_uv_tcp_nodelay
-(uv_tcp_t* handle, int enable) {
-    return uv_tcp_nodelay(handle, enable);
-}
-
-extern "C" int
-rust_uv_tcp_keepalive
-(uv_tcp_t* handle, int enable, unsigned int delay) {
-    return uv_tcp_keepalive(handle, enable, delay);
-}
-
-extern "C" int
-rust_uv_tcp_simultaneous_accepts
-(uv_tcp_t* handle, int enable) {
-    return uv_tcp_simultaneous_accepts(handle, enable);
-}
-
-extern "C" int
-rust_uv_udp_init(uv_loop_t* loop, uv_udp_t* handle) {
-    return uv_udp_init(loop, handle);
-}
-
-extern "C" int
 rust_uv_udp_bind(uv_udp_t* server, sockaddr_in* addr_ptr, unsigned flags) {
     return uv_udp_bind(server, *addr_ptr, flags);
 }
@@ -204,16 +112,6 @@ rust_uv_udp_send6(uv_udp_send_t* req, uv_udp_t* handle, uv_buf_t* buf_in,
     return uv_udp_send6(req, handle, buf_in, buf_cnt, *addr_ptr, cb);
 }
 
-extern "C" int
-rust_uv_udp_recv_start(uv_udp_t* server, uv_alloc_cb on_alloc, uv_udp_recv_cb on_read) {
-    return uv_udp_recv_start(server, on_alloc, on_read);
-}
-
-extern "C" int
-rust_uv_udp_recv_stop(uv_udp_t* server) {
-    return uv_udp_recv_stop(server);
-}
-
 extern "C" uv_udp_t*
 rust_uv_get_udp_handle_from_send_req(uv_udp_send_t* send_req) {
     return send_req->handle;
@@ -226,47 +124,6 @@ rust_uv_udp_getsockname
     // sockaddr_in or sockaddr_in6
     int namelen = sizeof(sockaddr_storage);
     return uv_udp_getsockname(handle, (sockaddr*)name, &namelen);
-}
-
-extern "C" int
-rust_uv_udp_set_membership
-(uv_udp_t* handle, const char* m_addr, const char* i_addr, uv_membership membership) {
-    return uv_udp_set_membership(handle, m_addr, i_addr, membership);
-}
-
-extern "C" int
-rust_uv_udp_set_multicast_loop
-(uv_udp_t* handle, int on) {
-    return uv_udp_set_multicast_loop(handle, on);
-}
-
-extern "C" int
-rust_uv_udp_set_multicast_ttl
-(uv_udp_t* handle, int ttl) {
-    return uv_udp_set_multicast_ttl(handle, ttl);
-}
-
-extern "C" int
-rust_uv_udp_set_ttl
-(uv_udp_t* handle, int ttl) {
-    return uv_udp_set_ttl(handle, ttl);
-}
-
-extern "C" int
-rust_uv_udp_set_broadcast
-(uv_udp_t* handle, int on) {
-    return uv_udp_set_broadcast(handle, on);
-}
-
-extern "C" int
-rust_uv_listen(uv_stream_t* stream, int backlog,
-        uv_connection_cb cb) {
-    return uv_listen(stream, backlog, cb);
-}
-
-extern "C" int
-rust_uv_accept(uv_stream_t* server, uv_stream_t* client) {
-    return uv_accept(server, client);
 }
 
 extern "C" uv_stream_t*
@@ -319,43 +176,6 @@ rust_uv_set_data_for_req(uv_req_t* req, void* data) {
     req->data = data;
 }
 
-extern "C" char*
-rust_uv_get_base_from_buf(uv_buf_t buf) {
-    return buf.base;
-}
-
-extern "C" size_t
-rust_uv_get_len_from_buf(uv_buf_t buf) {
-    return buf.len;
-}
-
-extern "C" const char*
-rust_uv_strerror(int err) {
-    return uv_strerror(err);
-}
-
-extern "C" const char*
-rust_uv_err_name(int err) {
-    return uv_err_name(err);
-}
-
-extern "C" int
-rust_uv_write(uv_write_t* req, uv_stream_t* handle,
-        uv_buf_t* bufs, int buf_cnt,
-        uv_write_cb cb) {
-    return uv_write(req, handle, bufs, buf_cnt, cb);
-}
-extern "C" int
-rust_uv_read_start(uv_stream_t* stream, uv_alloc_cb on_alloc,
-        uv_read_cb on_read) {
-    return uv_read_start(stream, on_alloc, on_read);
-}
-
-extern "C" int
-rust_uv_read_stop(uv_stream_t* stream) {
-    return uv_read_stop(stream);
-}
-
 extern "C" struct sockaddr_in
 rust_uv_ip4_addr(const char* ip, int port) {
     struct sockaddr_in addr = uv_ip4_addr(ip, port);
@@ -403,16 +223,6 @@ extern "C" void
 rust_uv_free_ip6_addr(sockaddr_in6 *addrp) {
   free(addrp);
 }
-
-extern "C" int
-rust_uv_ip4_name(struct sockaddr_in* src, char* dst, size_t size) {
-    return uv_ip4_name(src, dst, size);
-}
-extern "C" int
-rust_uv_ip6_name(struct sockaddr_in6* src, char* dst, size_t size) {
-    int result = uv_ip6_name(src, dst, size);
-    return result;
-}
 extern "C" unsigned int
 rust_uv_ip4_port(struct sockaddr_in* src) {
     return ntohs(src->sin_port);
@@ -420,18 +230,6 @@ rust_uv_ip4_port(struct sockaddr_in* src) {
 extern "C" unsigned int
 rust_uv_ip6_port(struct sockaddr_in6* src) {
     return ntohs(src->sin6_port);
-}
-
-extern  "C" int
-rust_uv_getaddrinfo(uv_loop_t* loop, uv_getaddrinfo_t* handle,
-                    uv_getaddrinfo_cb cb,
-                    char* node, char* service,
-                    addrinfo* hints) {
-    return uv_getaddrinfo(loop, handle, cb, node, service, hints);
-}
-extern "C" void
-rust_uv_freeaddrinfo(addrinfo* res) {
-    uv_freeaddrinfo(res);
 }
 
 extern "C" int
@@ -466,31 +264,6 @@ rust_uv_addrinfo_as_sockaddr_in6(addrinfo* input) {
     return (sockaddr_in6*)input->ai_addr;
 }
 
-extern "C" int
-rust_uv_idle_init(uv_loop_t* loop, uv_idle_t* idle) {
-  return uv_idle_init(loop, idle);
-}
-
-extern "C" int
-rust_uv_idle_start(uv_idle_t* idle, uv_idle_cb cb) {
-  return uv_idle_start(idle, cb);
-}
-
-extern "C" int
-rust_uv_idle_stop(uv_idle_t* idle) {
-  return uv_idle_stop(idle);
-}
-
-extern "C" size_t
-rust_uv_handle_size(uintptr_t type) {
-  return uv_handle_size((uv_handle_type)type);
-}
-
-extern "C" size_t
-rust_uv_req_size(uintptr_t type) {
-  return uv_req_size((uv_req_type)type);
-}
-
 extern "C" uintptr_t
 rust_uv_handle_type_max() {
   return UV_HANDLE_TYPE_MAX;
@@ -501,33 +274,6 @@ rust_uv_req_type_max() {
   return UV_REQ_TYPE_MAX;
 }
 
-extern "C" int
-rust_uv_fs_open(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags,
-                int mode, uv_fs_cb cb) {
-  return uv_fs_open(loop, req, path, flags, mode, cb);
-}
-extern "C" int
-rust_uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
-  return uv_fs_unlink(loop, req, path, cb);
-}
-extern "C" int
-rust_uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file fd, void* buf,
-                 size_t len, int64_t offset, uv_fs_cb cb) {
-  return uv_fs_write(loop, req, fd, buf, len, offset, cb);
-}
-extern "C" int
-rust_uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file fd, void* buf,
-                 size_t len, int64_t offset, uv_fs_cb cb) {
-  return uv_fs_read(loop, req, fd, buf, len, offset, cb);
-}
-extern "C" int
-rust_uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file fd, uv_fs_cb cb) {
-  return uv_fs_close(loop, req, fd, cb);
-}
-extern "C" void
-rust_uv_fs_req_cleanup(uv_fs_t* req) {
-  uv_fs_req_cleanup(req);
-}
 extern "C" int
 rust_uv_get_result_from_fs_req(uv_fs_t* req) {
   return req->result;
@@ -544,15 +290,6 @@ rust_uv_get_loop_from_fs_req(uv_fs_t* req) {
 extern "C" uv_loop_t*
 rust_uv_get_loop_from_getaddrinfo_req(uv_getaddrinfo_t* req) {
   return req->loop;
-}
-
-extern "C" int
-rust_uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
-  return uv_fs_stat(loop, req, path, cb);
-}
-extern "C" int
-rust_uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb) {
-  return uv_fs_fstat(loop, req, file, cb);
 }
 
 extern "C" void
@@ -579,30 +316,6 @@ rust_uv_populate_uv_stat(uv_fs_t* req_in, uv_stat_t* stat_out) {
   stat_out->st_birthtim.tv_nsec = req_in->statbuf.st_birthtim.tv_nsec;
 }
 
-extern "C" int
-rust_uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int mode, uv_fs_cb cb) {
-  return uv_fs_mkdir(loop, req, path, mode, cb);
-}
-extern "C" int
-rust_uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, const char* path, uv_fs_cb cb) {
-  return uv_fs_rmdir(loop, req, path, cb);
-}
-
-extern "C" int
-rust_uv_fs_readdir(uv_loop_t* loop, uv_fs_t* req, const char* path, int flags, uv_fs_cb cb) {
-  return uv_fs_readdir(loop, req, path, flags, cb);
-}
-
-extern "C" int
-rust_uv_spawn(uv_loop_t *loop, uv_process_t *p, uv_process_options_t options) {
-  return uv_spawn(loop, p, options);
-}
-
-extern "C" int
-rust_uv_process_kill(uv_process_t *p, int signum) {
-  return uv_process_kill(p, signum);
-}
-
 extern "C" void
 rust_set_stdio_container_flags(uv_stdio_container_t *c, int flags) {
   c->flags = (uv_stdio_flags) flags;
@@ -621,60 +334,4 @@ rust_set_stdio_container_stream(uv_stdio_container_t *c, uv_stream_t *stream) {
 extern "C" int
 rust_uv_process_pid(uv_process_t* p) {
   return p->pid;
-}
-
-extern "C" int
-rust_uv_pipe_init(uv_loop_t *loop, uv_pipe_t* p, int ipc) {
-  return uv_pipe_init(loop, p, ipc);
-}
-
-extern "C" int
-rust_uv_pipe_open(uv_pipe_t *pipe, int file) {
-    return uv_pipe_open(pipe, file);
-}
-
-extern "C" int
-rust_uv_pipe_bind(uv_pipe_t *pipe, char *name) {
-    return uv_pipe_bind(pipe, name);
-}
-
-extern "C" void
-rust_uv_pipe_connect(uv_connect_t *req, uv_pipe_t *handle,
-                     char *name, uv_connect_cb cb) {
-    uv_pipe_connect(req, handle, name, cb);
-}
-
-extern "C" int
-rust_uv_tty_init(uv_loop_t *loop, uv_tty_t *tty, int fd, int readable) {
-    return uv_tty_init(loop, tty, fd, readable);
-}
-
-extern "C" int
-rust_uv_tty_set_mode(uv_tty_t *tty, int mode) {
-    return uv_tty_set_mode(tty, mode);
-}
-
-extern "C" int
-rust_uv_tty_get_winsize(uv_tty_t *tty, int *width, int *height) {
-    return uv_tty_get_winsize(tty, width, height);
-}
-
-extern "C" int
-rust_uv_guess_handle(int fd) {
-    return uv_guess_handle(fd);
-}
-
-extern "C" int
-rust_uv_signal_init(uv_loop_t* loop, uv_signal_t* handle) {
-  return uv_signal_init(loop, handle);
-}
-
-extern "C" int
-rust_uv_signal_start(uv_signal_t* handle, uv_signal_cb signal_cb, int signum) {
-  return uv_signal_start(handle, signal_cb, signum);
-}
-
-extern "C" int
-rust_uv_signal_stop(uv_signal_t* handle) {
-  return uv_signal_stop(handle);
 }


### PR DESCRIPTION
This removes a large number of the wrapper functions from libuv. Most of these only existed for weird linker purposes, but now that we're statically linking libuv to librustuv, we can use them all directly (as they were intended to be!

This also refactors a bit of uv handle initialization/management, purely to reduce the amount of code that's needed to look at.

Finally, this removes the `home_for_io` closure-based function, replacing it with an RAII-oriented function (fire_missiles!)
