### PR TITLE
Fix the temporary name of the object file created

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -441,7 +441,8 @@ pub fn compile_input(sess: Session, cfg: ast::CrateConfig, input: &input,
         };
         let analysis = phase_3_run_analysis_passes(sess, &expanded_crate);
         if stop_after_phase_3(sess) { return; }
-        let outputs = build_output_filenames(input, outdir, output, [], sess);
+        let outputs = build_output_filenames(input, outdir, output,
+                                             expanded_crate.attrs, sess);
         let trans = phase_4_translate_to_llvm(sess, expanded_crate,
                                               &analysis, outputs);
         (outputs, trans)


### PR DESCRIPTION
This file did not respect the #[link(name = "...")] attribute when it was
clearly intended to do so. The problem is that the crate attributes just weren't
passed in. This causes lots of problems in rust today because the object file
for all our libraries is inferred to be 'lib.o' because all of the files are
called 'lib.rs'.

I tried to figure out a good way to test for this, but I wasn't able to come up
with a good way that fit into our current testing framework. Nonetheless, I have
tested this locally and object files get named as they should. This should fix
compiling with `make -jN` again (because the object files are all different
again).
