### PR TITLE
Relax the constraints on a debuginfo test

### DIFF
--- a/src/test/debug-info/basic-types-metadata.rs
+++ b/src/test/debug-info/basic-types-metadata.rs
@@ -44,7 +44,7 @@
 // check:type = f64
 // debugger:info functions _yyy
 // check:[...]
-// check:! basic-types-metadata::_yyy()();
+// check:![...]_yyy()();
 // debugger:detach
 // debugger:quit
 


### PR DESCRIPTION
The snapshot just failed due to a debuginfo test failing, and according to its
output at
http://buildbot.rust-lang.org/builders/snap3-linux/builds/564/steps/test/logs/stdio
it appears to be because the printed lines has a little less information than
the original lines were checking for. I would suspect that this is just because
of a slightly different version of gdb, but it's not that serious regardless.
