### PR TITLE
Use loader_path instead of executable_path for osx

### DIFF
--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -118,7 +118,7 @@ pub fn get_rpath_relative_to_output(os: session::Os,
     let prefix = match os {
         session::OsAndroid | session::OsLinux | session::OsFreebsd
                           => "$ORIGIN",
-        session::OsMacos => "@executable_path",
+        session::OsMacos => "@loader_path",
         session::OsWin32 => unreachable!()
     };
 
@@ -241,7 +241,7 @@ mod test {
         let res = get_rpath_relative_to_output(o,
                                                &Path::new("bin/rustc"),
                                                &Path::new("lib/libstd.so"));
-        assert_eq!(res.as_slice(), "@executable_path/../lib");
+        assert_eq!(res.as_slice(), "@loader_path/../lib");
     }
 
     #[test]


### PR DESCRIPTION
According to apple's documentation of rpath semantics, `@executable_path` means
that the path is relative the the _process executable_, not necessarily the
library in question. On the other hand, `@loader_path` is the path that points to
the library which contains the `@loader_path` reference. All of our rpath usage is
based off the library or executable, not just the executable. This means that on
OSX we should be using `@loader_path` instead of `@executable_path` to achieve the
same semantics as linux's $ORIGIN.

The purpose of this is to unblock the current snapshot from landing. It appears that because we were propagating linker arguments we never saw this before. Now that we're no longer printing linker arguments, we're depending on the libraries to resolve their own references. In using `@executable_path` on OSX, libraries in different locations than the executable were not able to resolve their references (because their rpaths listed were all relative to the location of the library, not the executable).

I'm still a little unclear on how this ever passed locally on my own machine, but it's clear why this is failing on the bots at least.
