### PR TITLE
Clarify which errors are format string errors

### DIFF
--- a/src/libstd/fmt/parse.rs
+++ b/src/libstd/fmt/parse.rs
@@ -180,7 +180,7 @@ impl<'self> Iterator<Piece<'self>> for Parser<'self> {
             }
             Some((_, '}')) if self.depth == 0 => {
                 self.cur.next();
-                self.err(~"unmatched `}` found");
+                self.err("unmatched `}` found");
                 None
             }
             Some((_, '}')) | None => { None }
@@ -204,8 +204,8 @@ impl<'self> Parser<'self> {
     /// Notifies of an error. The message doesn't actually need to be of type
     /// ~str, but I think it does when this eventually uses conditions so it
     /// might as well start using it now.
-    fn err(&self, msg: ~str) {
-        parse_error::cond.raise(msg);
+    fn err(&self, msg: &str) {
+        parse_error::cond.raise("invalid format string: " + msg);
     }
 
     /// Optionally consumes the specified character. If the character is not at
@@ -230,11 +230,11 @@ impl<'self> Parser<'self> {
                 self.cur.next();
             }
             Some((_, other)) => {
-                parse_error::cond.raise(
+                self.err(
                     format!("expected `{}` but found `{}`", c, other));
             }
             None => {
-                parse_error::cond.raise(
+                self.err(
                     format!("expected `{}` but string was terminated", c));
             }
         }
@@ -267,7 +267,7 @@ impl<'self> Parser<'self> {
                 c
             }
             None => {
-                self.err(~"expected an escape sequence, but format string was \
+                self.err("expected an escape sequence, but format string was \
                            terminated");
                 ' '
             }
@@ -411,7 +411,7 @@ impl<'self> Parser<'self> {
                 Some(self.plural())
             }
             "" => {
-                self.err(~"expected method after comma");
+                self.err("expected method after comma");
                 return None;
             }
             method => {
@@ -430,7 +430,7 @@ impl<'self> Parser<'self> {
             self.ws();
             let selector = self.word();
             if selector == "" {
-                self.err(~"cannot have an empty selector");
+                self.err("cannot have an empty selector");
                 break
             }
             self.must_consume('{');
@@ -440,7 +440,7 @@ impl<'self> Parser<'self> {
             self.must_consume('}');
             if selector == "other" {
                 if !other.is_none() {
-                    self.err(~"multiple `other` statements in `select");
+                    self.err("multiple `other` statements in `select");
                 }
                 other = Some(pieces);
             } else {
@@ -456,7 +456,7 @@ impl<'self> Parser<'self> {
         let other = match other {
             Some(arm) => { arm }
             None => {
-                self.err(~"`select` statement must provide an `other` case");
+                self.err("`select` statement must provide an `other` case");
                 ~[]
             }
         };
@@ -488,7 +488,7 @@ impl<'self> Parser<'self> {
                             match self.integer() {
                                 Some(i) => { offset = Some(i); }
                                 None => {
-                                    self.err(~"offset must be an integer");
+                                    self.err("offset must be an integer");
                                 }
                             }
                         }
@@ -506,8 +506,8 @@ impl<'self> Parser<'self> {
                 match self.integer() {
                     Some(i) => Right(i),
                     None => {
-                        self.err(~"plural `=` selectors must be followed by an \
-                                   integer");
+                        self.err("plural `=` selectors must be followed by an \
+                                  integer");
                         Right(0)
                     }
                 }
@@ -538,7 +538,7 @@ impl<'self> Parser<'self> {
             self.must_consume('}');
             if isother {
                 if !other.is_none() {
-                    self.err(~"multiple `other` statements in `select");
+                    self.err("multiple `other` statements in `select");
                 }
                 other = Some(pieces);
             } else {
@@ -554,7 +554,7 @@ impl<'self> Parser<'self> {
         let other = match other {
             Some(arm) => { arm }
             None => {
-                self.err(~"`plural` statement must provide an `other` case");
+                self.err("`plural` statement must provide an `other` case");
                 ~[]
             }
         };


### PR DESCRIPTION
There were a few ambiguous error messages which look like they could have
cropped up from either the rust compiler for the format string parser. To
differentiate, the prefix 'invalid format string' is now added in front of all
format string errors.

cc #9970
