### PR TITLE
fix some cfail test cases for arm

### DIFF
--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -15,6 +15,8 @@ fn foo(x: int) { info!("{}", x); }
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "arm")]
+
 pub fn main() {
     let x: int;
     let y: int;
@@ -26,5 +28,5 @@ pub fn main() {
     foo(y);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-assign-imm.rs
+++ b/src/test/compile-fail/asm-out-assign-imm.rs
@@ -15,6 +15,7 @@ fn foo(x: int) { info!("{}", x); }
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "arm")]
 pub fn main() {
     let x: int;
     x = 1; //~ NOTE prior assignment occurs here
@@ -25,5 +26,5 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -15,6 +15,7 @@ fn foo(x: int) { info!("{}", x); }
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "arm")]
 pub fn main() {
     let x: int;
     unsafe {
@@ -23,5 +24,5 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -15,6 +15,7 @@ fn foo(x: int) { info!("{}", x); }
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "arm")]
 pub fn main() {
     let x: int;
     unsafe {
@@ -23,5 +24,5 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
 pub fn main() {}


### PR DESCRIPTION
adding #[cfg(target_arch = "arm")] for asm of cfail test cases
