### PR TITLE
std::ascii: Provide a copyless [Ascii] -> str method.

### DIFF
--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -52,10 +52,8 @@ fn parse_expected(line_num: uint, line: ~str) -> ~[ExpectedError] {
     let start_kind = idx;
     while idx < len && line[idx] != (' ' as u8) { idx += 1u; }
 
-    // FIXME: #4318 Instead of to_ascii and to_str_ascii, could use
-    // to_ascii_consume and to_str_consume to not do a unnecessary copy.
     let kind = line.slice(start_kind, idx);
-    let kind = kind.to_ascii().to_lower().to_str_ascii();
+    let kind = kind.to_ascii().to_lower().into_str();
 
     // Extract msg:
     while idx < len && line[idx] == (' ' as u8) { idx += 1u; }

--- a/src/libextra/sort.rs
+++ b/src/libextra/sort.rs
@@ -887,12 +887,8 @@ mod tests {
         // tjc: funny that we have to use parens
         fn ile(x: &(&'static str), y: &(&'static str)) -> bool
         {
-            // FIXME: #4318 Instead of to_ascii and to_str_ascii, could use
-            // to_ascii_move and to_str_move to not do a unnecessary clone.
-            // (Actually, could just remove the to_str_* call, but needs an deriving(Ord) on
-            // Ascii)
-            let x = x.to_ascii().to_lower().to_str_ascii();
-            let y = y.to_ascii().to_lower().to_str_ascii();
+            let x = x.to_ascii().to_lower().into_str();
+            let y = y.to_ascii().to_lower().into_str();
             x <= y
         }
 

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -669,10 +669,8 @@ pub fn build_session_options(binary: @str,
     for level in lint_levels.iter() {
         let level_name = lint::level_to_str(*level);
 
-        // FIXME: #4318 Instead of to_ascii and to_str_ascii, could use
-        // to_ascii_move and to_str_move to not do a unnecessary copy.
         let level_short = level_name.slice_chars(0, 1);
-        let level_short = level_short.to_ascii().to_upper().to_str_ascii();
+        let level_short = level_short.to_ascii().to_upper().into_str();
         let flags = vec::append(matches.opt_strs(level_short),
                                 matches.opt_strs(level_name));
         for lint_name in flags.iter() {

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -72,10 +72,8 @@ fn sort_and_fmt(mm: &HashMap<~[u8], uint>, total: uint) -> ~str {
        let (k,v) = (*kv).clone();
        unsafe {
            let b = str::raw::from_utf8(k);
-           // FIXME: #4318 Instead of to_ascii and to_str_ascii, could use
-           // to_ascii_move and to_str_move to not do a unnecessary copy.
            buffer.push_str(format!("{} {:0.3f}\n",
-                                   b.to_ascii().to_upper().to_str_ascii(), v));
+                                   b.into_ascii().to_upper().into_str(), v));
        }
    }
 
@@ -84,9 +82,7 @@ fn sort_and_fmt(mm: &HashMap<~[u8], uint>, total: uint) -> ~str {
 
 // given a map, search for the frequency of a pattern
 fn find(mm: &HashMap<~[u8], uint>, key: ~str) -> uint {
-   // FIXME: #4318 Instead of to_ascii and to_str_ascii, could use
-   // to_ascii_move and to_str_move to not do a unnecessary copy.
-   let key = key.to_ascii().to_lower().to_str_ascii();
+   let key = key.into_ascii().to_lower().into_str();
    match mm.find_equiv(&key.as_bytes()) {
       option::None      => { return 0u; }
       option::Some(&num) => { return num; }


### PR DESCRIPTION
This renames to_str_ascii to as_str_ascii and makes it non-copying,
which is possible now that strings no longer have a hidden extra
byte/null terminator.

Fixes #6120.
