### PR TITLE
update for ndk r9b

### DIFF
--- a/src/rt/rust_android_dummy.cpp
+++ b/src/rt/rust_android_dummy.cpp
@@ -60,10 +60,6 @@ extern "C" void atof()
 {
 }
 
-extern "C" void tgammaf()
-{
-}
-
 extern "C" int glob(const char *pattern,
                     int flags,
                     int (*errfunc) (const char *epath, int eerrno),


### PR DESCRIPTION
update for ndk r9b (#10323)

```
Android NDK, Revision 9b (October 2013)
Important changes:
Updated include/android/*h and math.h for all Android API levels up to 18, 
including the addition of levels 13, 15, 16 and 17. 
For information on added APIs, 
see commit messages for Changes 68012 and 68014. (Issues 47150, 58528, and 38423)
```

https://android-review.googlesource.com/#/c/68014/
