### PR TITLE
Edited comment for docs to show std::io is deleted and replaced by std::...

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -21,7 +21,7 @@
 //! boxes (`owned`), and unsafe and borrowed pointers (`ptr`, `borrowed`).
 //! Additionally, `std` provides pervasive types (`option` and `result`),
 //! task creation and communication primitives (`task`, `comm`), platform
-//! abstractions (`os` and `path`), basic I/O abstractions (`io`), common
+//! abstractions (`os` and `path`), basic I/O abstractions (`rt::io`), common
 //! traits (`kinds`, `ops`, `cmp`, `num`, `to_str`), and complete bindings
 //! to the C standard library (`libc`).
 //!


### PR DESCRIPTION
...rt::io
