### PR TITLE
std: Make atomic types non-copyable. Closes #8380

### DIFF
--- a/src/libstd/unstable/atomics.rs
+++ b/src/libstd/unstable/atomics.rs
@@ -23,40 +23,46 @@ use cast;
 use option::{Option,Some,None};
 use libc::c_void;
 use ops::Drop;
+use util::NonCopyable;
 
 /**
  * A simple atomic flag, that can be set and cleared. The most basic atomic type.
  */
 pub struct AtomicFlag {
-    priv v: int
+    priv v: int,
+    priv nocopy: NonCopyable
 }
 
 /**
  * An atomic boolean type.
  */
 pub struct AtomicBool {
-    priv v: uint
+    priv v: uint,
+    priv nocopy: NonCopyable
 }
 
 /**
  * A signed atomic integer type, supporting basic atomic arithmetic operations
  */
 pub struct AtomicInt {
-    priv v: int
+    priv v: int,
+    priv nocopy: NonCopyable
 }
 
 /**
  * An unsigned atomic integer type, supporting basic atomic arithmetic operations
  */
 pub struct AtomicUint {
-    priv v: uint
+    priv v: uint,
+    priv nocopy: NonCopyable
 }
 
 /**
  * An unsafe atomic pointer. Only supports basic atomic operations
  */
 pub struct AtomicPtr<T> {
-    priv p: *mut T
+    priv p: *mut T,
+    priv nocopy: NonCopyable
 }
 
 /**
@@ -75,15 +81,15 @@ pub enum Ordering {
     SeqCst
 }
 
-pub static INIT_ATOMIC_FLAG : AtomicFlag = AtomicFlag { v: 0 };
-pub static INIT_ATOMIC_BOOL : AtomicBool = AtomicBool { v: 0 };
-pub static INIT_ATOMIC_INT  : AtomicInt  = AtomicInt  { v: 0 };
-pub static INIT_ATOMIC_UINT : AtomicUint = AtomicUint { v: 0 };
+pub static INIT_ATOMIC_FLAG : AtomicFlag = AtomicFlag { v: 0, nocopy: NonCopyable };
+pub static INIT_ATOMIC_BOOL : AtomicBool = AtomicBool { v: 0, nocopy: NonCopyable };
+pub static INIT_ATOMIC_INT  : AtomicInt  = AtomicInt  { v: 0, nocopy: NonCopyable };
+pub static INIT_ATOMIC_UINT : AtomicUint = AtomicUint { v: 0, nocopy: NonCopyable };
 
 impl AtomicFlag {
 
     pub fn new() -> AtomicFlag {
-        AtomicFlag { v: 0 }
+        AtomicFlag { v: 0, nocopy: NonCopyable }
     }
 
     /**
@@ -106,7 +112,7 @@ impl AtomicFlag {
 
 impl AtomicBool {
     pub fn new(v: bool) -> AtomicBool {
-        AtomicBool { v: if v { 1 } else { 0 } }
+        AtomicBool { v: if v { 1 } else { 0 }, nocopy: NonCopyable }
     }
 
     #[inline]
@@ -171,7 +177,7 @@ impl AtomicBool {
 
 impl AtomicInt {
     pub fn new(v: int) -> AtomicInt {
-        AtomicInt { v:v }
+        AtomicInt { v:v, nocopy: NonCopyable }
     }
 
     #[inline]
@@ -209,7 +215,7 @@ impl AtomicInt {
 
 impl AtomicUint {
     pub fn new(v: uint) -> AtomicUint {
-        AtomicUint { v:v }
+        AtomicUint { v:v, nocopy: NonCopyable }
     }
 
     #[inline]
@@ -247,7 +253,7 @@ impl AtomicUint {
 
 impl<T> AtomicPtr<T> {
     pub fn new(p: *mut T) -> AtomicPtr<T> {
-        AtomicPtr { p:p }
+        AtomicPtr { p:p, nocopy: NonCopyable }
     }
 
     #[inline]

--- a/src/test/compile-fail/std-uncopyable-atomics.rs
+++ b/src/test/compile-fail/std-uncopyable-atomics.rs
@@ -1,0 +1,31 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #8380
+
+#[feature(globs)];
+
+use std::unstable::atomics::*;
+use std::ptr;
+
+fn main() {
+    let x = INIT_ATOMIC_FLAG;
+    let x = *&x; //~ ERROR: cannot move out of dereference
+    let x = INIT_ATOMIC_BOOL;
+    let x = *&x; //~ ERROR: cannot move out of dereference
+    let x = INIT_ATOMIC_INT;
+    let x = *&x; //~ ERROR: cannot move out of dereference
+    let x = INIT_ATOMIC_UINT;
+    let x = *&x; //~ ERROR: cannot move out of dereference
+    let x: AtomicPtr<uint> = AtomicPtr::new(ptr::mut_null());
+    let x = *&x; //~ ERROR: cannot move out of dereference
+    let x: AtomicOption<uint> = AtomicOption::empty();
+    let x = *&x; //~ ERROR: cannot move out of dereference
+}


### PR DESCRIPTION
I didn't try to add clone methods since it's not clear to me which types are appropriate to clone or what the memory ordering should be.
