### PR TITLE
fix android timegm

### DIFF
--- a/src/rt/rust_builtin.cpp
+++ b/src/rt/rust_builtin.cpp
@@ -43,12 +43,15 @@ timegm(struct tm *tm)
     char *tz;
 
     tz = getenv("TZ");
+    if (tz)
+        tz = strdup(tz);
     setenv("TZ", "", 1);
     tzset();
     ret = mktime(tm);
-    if (tz)
+    if (tz) {
         setenv("TZ", tz, 1);
-    else
+        free(tz);
+    } else
         unsetenv("TZ");
     tzset();
     return ret;


### PR DESCRIPTION
fix timegm bug on android
TZ restore not correctly before.
and it cause test case fail (time::tests::run_tests::test_convertions)

with @sammykim
