### PR TITLE
Made Results API more composable

### DIFF
--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -1822,7 +1822,7 @@ fn test_linker_build() {
     let workspace = workspace.path();
     let matches = getopts([], optgroups());
     let options = build_session_options(@"rustpkg",
-                                        matches.get_ref(),
+                                        matches.as_ref().unwrap(),
                                         @diagnostic::DefaultEmitter as
                                             @diagnostic::Emitter);
     let sess = build_session(options,

--- a/src/libstd/any.rs
+++ b/src/libstd/any.rs
@@ -151,7 +151,6 @@ mod tests {
     use super::*;
     use super::AnyRefExt;
     use option::{Some, None};
-    use hash::Hash;
 
     #[deriving(Eq)]
     struct Test;

--- a/src/libstd/rt/local_ptr.rs
+++ b/src/libstd/rt/local_ptr.rs
@@ -48,6 +48,7 @@ pub unsafe fn borrow<T>(f: |&mut T|) {
 /// it wherever possible.
 #[cfg(not(windows), not(target_os = "android"))]
 pub mod compiled {
+    #[cfg(not(test))]
     use libc::c_void;
     use cast;
     use option::{Option, Some, None};

--- a/src/test/run-fail/result-get-fail.rs
+++ b/src/test/run-fail/result-get-fail.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:called `Result::unwrap()` on `Err` value 'kitty'
+// error-pattern:called `Result::unwrap()` on an `Err` value
 
 use std::result;
 

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -64,7 +64,7 @@ fn test_rm_tempdir() {
         let f: proc() -> TempDir = proc() {
             TempDir::new("test_rm_tempdir").unwrap()
         };
-        let tmp = task::try(f).expect("test_rm_tmdir");
+        let tmp = task::try(f).ok().expect("test_rm_tmdir");
         path = tmp.path().clone();
         assert!(path.exists());
     }


### PR DESCRIPTION
This implements parts of the changes to `Result` and `Option` I proposed and discussed in this thread: https://mail.mozilla.org/pipermail/rust-dev/2013-November/006254.html

This PR includes:
- Adding `ok()` and `err()` option adapters for both `Result` variants.
- Removing `get_ref`, `expect` and iterator constructors for `Result`, as they are reachable with the variant adapters.
- Removing `Result`s `ToStr` bound on the error type because of composability issues. (See https://mail.mozilla.org/pipermail/rust-dev/2013-November/006283.html)
- Some warning cleanups
