### PR TITLE
Add a default value for the 'package_id' meta attribute for library crates

### DIFF
--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -21,6 +21,7 @@ Rust extras are part of the standard Rust distribution.
 */
 
 #[link(name = "extra",
+       package_id = "extra",
        vers = "0.9-pre",
        uuid = "122bed0b-c19b-4b82-b0b7-7ae8aead7297",
        url = "https://github.com/mozilla/rust/tree/master/src/libextra")];

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -634,20 +634,12 @@ pub fn build_link_meta(sess: Session,
         }
     }
 
-    fn crate_meta_pkgid(sess: Session, output: &Path, opt_pkg_id: Option<@str>)
+    fn crate_meta_pkgid(sess: Session, name: @str, opt_pkg_id: Option<@str>)
         -> @str {
         match opt_pkg_id {
             Some(v) if !v.is_empty() => v,
             _ => {
-                let pkg_id = session::expect(sess,
-                                             output.filestem_str(),
-                                             || format!("output file name `{}` doesn't\
-                                                      appear to have a stem",
-                                                     output.display())).to_managed();
-                if pkg_id.is_empty() {
-                    sess.fatal("missing crate link meta `package_id`, and the \
-                                inferred name is blank");
-                }
+                let pkg_id = name.clone();
                 warn_missing(sess, "package_id", pkg_id);
                 pkg_id
             }
@@ -662,7 +654,7 @@ pub fn build_link_meta(sess: Session,
     } = provided_link_metas(sess, c);
     let name = crate_meta_name(sess, output, opt_name);
     let vers = crate_meta_vers(sess, opt_vers);
-    let pkg_id = crate_meta_pkgid(sess, output, opt_pkg_id);
+    let pkg_id = crate_meta_pkgid(sess, name, opt_pkg_id);
     let dep_hashes = cstore::get_dep_hashes(sess.cstore);
     let extras_hash =
         crate_meta_extras_hash(symbol_hasher, cmh_items,

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[link(name = "rustc",
+       package_id = "rustc",
        vers = "0.9-pre",
        uuid = "0ce89b41-2f92-459e-bbc1-8f5fe32f16cf",
        url = "https://github.com/mozilla/rust/tree/master/src/rustc")];

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1510,7 +1510,7 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
                                                               pkg_id),
                 // uses package_id equal to name;
                 // this should never happen here but package_id is an Option
-                // FIX: change package_id in LinkMeta to @str instead of Option<@str>
+                // FIXME (#10370): change package_id in LinkMeta to @str instead of Option<@str>
                 _ => attr::mk_name_value_item_str(@"package_id",
                                                   ecx.link_meta.name)
         };

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1487,8 +1487,8 @@ fn encode_attributes(ebml_w: &mut writer::Encoder, attrs: &[Attribute]) {
 
 // So there's a special crate attribute called 'link' which defines the
 // metadata that Rust cares about for linking crates. This attribute requires
-// 'name' and 'vers' items, so if the user didn't provide them we will throw
-// them in anyway with default values.
+// 'name', 'vers' and 'package_id' items, so if the user didn't provide them we
+// will throw them in anyway with default values.
 fn synthesize_crate_attrs(ecx: &EncodeContext,
                           crate: &Crate) -> ~[Attribute] {
 
@@ -1505,9 +1505,20 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
             attr::mk_name_value_item_str(@"vers",
                                          ecx.link_meta.vers);
 
-        let mut meta_items = ~[name_item, vers_item];
+        let pkgid_item = match ecx.link_meta.package_id {
+                Some(pkg_id) =>  attr::mk_name_value_item_str(@"package_id",
+                                                              pkg_id),
+                // uses package_id equal to name;
+                // this should never happen here but package_id is an Option
+                // FIX: change package_id in LinkMeta to @str instead of Option<@str>
+                _ => attr::mk_name_value_item_str(@"package_id",
+                                                  ecx.link_meta.name)
+        };
 
-        for &mi in items.iter().filter(|mi| "name" != mi.name() && "vers" != mi.name()) {
+        let mut meta_items = ~[name_item, vers_item, pkgid_item];
+
+        for &mi in items.iter().filter(|mi| "name" != mi.name() && "vers" != mi.name() &&
+                                            "package_id" != mi.name()) {
             meta_items.push(mi);
         }
         let link_item = attr::mk_list_item(@"link", meta_items);

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[link(name = "rustdoc",
+       package_id = "rustdoc",
        vers = "0.9-pre",
        uuid = "8c6e4598-1596-4aa5-a24c-b811914bbbc6",
        url = "https://github.com/mozilla/rust/tree/master/src/librustdoc")];

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -11,6 +11,7 @@
 // rustpkg - a package manager and build system for Rust
 
 #[link(name = "rustpkg",
+       package_id = "rustpkg",
        vers = "0.9-pre",
        uuid = "25de5e6e-279e-4a20-845c-4cabae92daaf",
        url = "https://github.com/mozilla/rust/tree/master/src/librustpkg")];

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -35,6 +35,7 @@ via `close` and `delete` methods.
 */
 
 #[link(name = "rustuv",
+       package_id = "rustuv",
        vers = "0.9-pre",
        uuid = "f3719011-0459-9b86-b11c-29265c0d0864",
        url = "https://github.com/mozilla/rust/tree/master/src/librustuv")];

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -44,6 +44,7 @@
 //!     use std::prelude::*;
 
 #[link(name = "std",
+       package_id = "std",
        vers = "0.9-pre",
        uuid = "c70c24a7-5551-4f73-8e37-380b11d80be8",
        url = "https://github.com/mozilla/rust/tree/master/src/libstd")];

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -14,6 +14,7 @@
  */
 
 #[link(name = "syntax",
+       package_id = "syntax",
        vers = "0.9-pre",
        uuid = "9311401b-d6ea-4cd9-a1d9-61f89499c645")];
 

--- a/src/test/auxiliary/crateresolve8-1.rs
+++ b/src/test/auxiliary/crateresolve8-1.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// default link meta for 'package_id' will be equal to filestem
+#[link(name = "crateresolve8",
+       vers = "0.1")];
+
+#[crate_type = "lib"];
+
+pub fn f() -> int { 20 }

--- a/src/test/run-pass/crateresolve8.rs
+++ b/src/test/run-pass/crateresolve8.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:crateresolve8-1.rs
+
+extern mod crateresolve8(vers = "0.1", package_id="crateresolve8");
+//extern mod crateresolve8(vers = "0.1");
+
+pub fn main() {
+    assert_eq!(crateresolve8::f(), 20);
+}


### PR DESCRIPTION
This Fixes #10265 and paves the way for fixing #9543. It works by adding a 'package_id' attribute by default for library crates that don't specify it. This is necessary to use the 'extern mod foo = "bar"' form instead of 'extern mod foo(name="bar") (as per #9543), because the former adds a required package_id when trying to link with the bar crate. I added a simple test to ensure that the default package_id value is being generated, and also added an explicit package_id in the link attribute in all rust libs to avoid getting warnings about default package_id values when building rust. 
