### PR TITLE
extra / rustpkg: Make getopts::opt_val private again

### DIFF
--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -185,18 +185,14 @@ impl Name {
 }
 
 impl Matches {
-    /// FIXME: #9311 This used to be private, but rustpkg somehow managed to depend on it.
-    /// No idea what this does.
-    pub fn opt_vals(&self, nm: &str) -> ~[Optval] {
+    fn opt_vals(&self, nm: &str) -> ~[Optval] {
         match find_opt(self.opts, Name::from_str(nm)) {
             Some(id) => self.vals[id].clone(),
             None => fail!("No option '{}' defined", nm)
         }
     }
 
-    /// FIXME: #9311 This used to be private, but rustpkg somehow managed to depend on it.
-    /// No idea what this does.
-    pub fn opt_val(&self, nm: &str) -> Option<Optval> {
+    fn opt_val(&self, nm: &str) -> Option<Optval> {
         let vals = self.opt_vals(nm);
         if (vals.is_empty()) {
             None

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -762,7 +762,7 @@ pub fn main_args(args: &[~str]) -> int {
                    matches.opt_present("help");
     let no_link = matches.opt_present("no-link");
     let no_trans = matches.opt_present("no-trans");
-    let supplied_sysroot = matches.opt_val("sysroot");
+    let supplied_sysroot = matches.opt_str("sysroot");
     let generate_asm = matches.opt_present("S") ||
         matches.opt_present("assembly");
     let parse_only = matches.opt_present("parse-only");
@@ -894,7 +894,7 @@ pub fn main_args(args: &[~str]) -> int {
     let mut remaining_args: ~[~str] = remaining_args.map(|s| (*s).clone()).collect();
     remaining_args.shift();
     let sroot = match supplied_sysroot {
-        Some(getopts::Val(s)) => Path::new(s),
+        Some(s) => Path::new(s),
         _ => filesearch::get_or_default_sysroot()
     };
 


### PR DESCRIPTION
and use opt_str instead of opt_val in rustpkg

Closes #9311
