### PR TITLE
Add type hint struct

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -16,8 +16,9 @@ use libc::c_int;
 use num::{Zero, One, strconv};
 use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
 use num;
-use prelude::*;
 use to_str;
+use util::ForType;
+use prelude::*;
 
 pub use cmath::c_float_targ_consts::*;
 
@@ -584,13 +585,13 @@ impl Bounded for f32 {
 
 impl Primitive for f32 {
     #[inline]
-    fn bits(_: Option<f32>) -> uint { 32 }
+    fn bits(_: ForType<f32>) -> uint { 32 }
 
     #[inline]
-    fn bytes(_: Option<f32>) -> uint { Primitive::bits(Some(0f32)) / 8 }
+    fn bytes(_: ForType<f32>) -> uint { Primitive::bits(ForType::<f32>) / 8 }
 
     #[inline]
-    fn is_signed(_: Option<f32>) -> bool { true }
+    fn is_signed(_: ForType<f32>) -> bool { true }
 }
 
 impl Float for f32 {
@@ -647,25 +648,25 @@ impl Float for f32 {
     }
 
     #[inline]
-    fn mantissa_digits(_: Option<f32>) -> uint { 24 }
+    fn mantissa_digits(_: ForType<f32>) -> uint { 24 }
 
     #[inline]
-    fn digits(_: Option<f32>) -> uint { 6 }
+    fn digits(_: ForType<f32>) -> uint { 6 }
 
     #[inline]
     fn epsilon() -> f32 { 1.19209290e-07 }
 
     #[inline]
-    fn min_exp(_: Option<f32>) -> int { -125 }
+    fn min_exp(_: ForType<f32>) -> int { -125 }
 
     #[inline]
-    fn max_exp(_: Option<f32>) -> int { 128 }
+    fn max_exp(_: ForType<f32>) -> int { 128 }
 
     #[inline]
-    fn min_10_exp(_: Option<f32>) -> int { -37 }
+    fn min_10_exp(_: ForType<f32>) -> int { -37 }
 
     #[inline]
-    fn max_10_exp(_: Option<f32>) -> int { 38 }
+    fn max_10_exp(_: ForType<f32>) -> int { 38 }
 
     /// Constructs a floating point number by multiplying `x` by 2 raised to the power of `exp`
     #[inline]
@@ -927,6 +928,7 @@ mod tests {
     use num::*;
     use num;
     use mem;
+    use util::ForType;
 
     #[test]
     fn test_num() {
@@ -1195,9 +1197,8 @@ mod tests {
 
     #[test]
     fn test_primitive() {
-        let none: Option<f32> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<f32>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<f32>());
+        assert_eq!(Primitive::bits(ForType::<f32>), mem::size_of::<f32>() * 8);
+        assert_eq!(Primitive::bytes(ForType::<f32>), mem::size_of::<f32>());
     }
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -17,8 +17,9 @@ use libc::c_int;
 use num::{Zero, One, strconv};
 use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
 use num;
-use prelude::*;
 use to_str;
+use util::ForType;
+use prelude::*;
 
 pub use cmath::c_double_targ_consts::*;
 pub use cmp::{min, max};
@@ -632,13 +633,13 @@ impl Bounded for f64 {
 
 impl Primitive for f64 {
     #[inline]
-    fn bits(_: Option<f64>) -> uint { 64 }
+    fn bits(_: ForType<f64>) -> uint { 64 }
 
     #[inline]
-    fn bytes(_: Option<f64>) -> uint { Primitive::bits(Some(0f64)) / 8 }
+    fn bytes(_: ForType<f64>) -> uint { Primitive::bits(ForType::<f64>) / 8 }
 
     #[inline]
-    fn is_signed(_: Option<f64>) -> bool { true }
+    fn is_signed(_: ForType<f64>) -> bool { true }
 }
 
 impl Float for f64 {
@@ -695,25 +696,25 @@ impl Float for f64 {
     }
 
     #[inline]
-    fn mantissa_digits(_: Option<f64>) -> uint { 53 }
+    fn mantissa_digits(_: ForType<f64>) -> uint { 53 }
 
     #[inline]
-    fn digits(_: Option<f64>) -> uint { 15 }
+    fn digits(_: ForType<f64>) -> uint { 15 }
 
     #[inline]
     fn epsilon() -> f64 { 2.2204460492503131e-16 }
 
     #[inline]
-    fn min_exp(_: Option<f64>) -> int { -1021 }
+    fn min_exp(_: ForType<f64>) -> int { -1021 }
 
     #[inline]
-    fn max_exp(_: Option<f64>) -> int { 1024 }
+    fn max_exp(_: ForType<f64>) -> int { 1024 }
 
     #[inline]
-    fn min_10_exp(_: Option<f64>) -> int { -307 }
+    fn min_10_exp(_: ForType<f64>) -> int { -307 }
 
     #[inline]
-    fn max_10_exp(_: Option<f64>) -> int { 308 }
+    fn max_10_exp(_: ForType<f64>) -> int { 308 }
 
     /// Constructs a floating point number by multiplying `x` by 2 raised to the power of `exp`
     #[inline]
@@ -975,6 +976,7 @@ mod tests {
     use num::*;
     use num;
     use mem;
+    use util::ForType;
 
     #[test]
     fn test_num() {
@@ -1246,9 +1248,8 @@ mod tests {
 
     #[test]
     fn test_primitive() {
-        let none: Option<f64> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<f64>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<f64>());
+        assert_eq!(Primitive::bits(ForType::<f64>), mem::size_of::<f64>() * 8);
+        assert_eq!(Primitive::bytes(ForType::<f64>), mem::size_of::<f64>());
     }
 
     #[test]

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -20,8 +20,9 @@ macro_rules! int_module (($T:ty, $bits:expr) => (mod generated {
 use default::Default;
 use num::{ToStrRadix, FromStrRadix};
 use num::{CheckedDiv, Zero, One, strconv};
-use prelude::*;
 use str;
+use util::ForType;
+use prelude::*;
 
 pub use cmp::{min, max};
 
@@ -377,13 +378,13 @@ impl Int for $T {}
 
 impl Primitive for $T {
     #[inline]
-    fn bits(_: Option<$T>) -> uint { bits }
+    fn bits(_: ForType<$T>) -> uint { bits }
 
     #[inline]
-    fn bytes(_: Option<$T>) -> uint { bits / 8 }
+    fn bytes(_: ForType<$T>) -> uint { bits / 8 }
 
     #[inline]
-    fn is_signed(_: Option<$T>) -> bool { true }
+    fn is_signed(_: ForType<$T>) -> bool { true }
 }
 
 // String conversion functions and impl str -> num
@@ -458,6 +459,7 @@ mod tests {
     use i32;
     use num;
     use mem;
+    use util::ForType;
 
     #[test]
     fn test_num() {
@@ -653,9 +655,8 @@ mod tests {
 
     #[test]
     fn test_primitive() {
-        let none: Option<$T> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<$T>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<$T>());
+        assert_eq!(Primitive::bits(ForType::<$T>), mem::size_of::<$T>() * 8);
+        assert_eq!(Primitive::bytes(ForType::<$T>), mem::size_of::<$T>());
     }
 
     #[test]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -20,6 +20,7 @@ use cmp::{Eq, ApproxEq, Ord};
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 use ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 use option::{Option, Some, None};
+use util::ForType;
 
 pub mod strconv;
 
@@ -344,9 +345,9 @@ pub trait Primitive: Clone
                    + Rem<Self,Self> {
     // FIXME (#5527): These should be associated constants
     // FIXME (#8888): Removing `unused_self` requires #8888 to be fixed.
-    fn bits(unused_self: Option<Self>) -> uint;
-    fn bytes(unused_self: Option<Self>) -> uint;
-    fn is_signed(unused_self: Option<Self>) -> bool;
+    fn bits(_: ForType<Self>) -> uint;
+    fn bytes(_: ForType<Self>) -> uint;
+    fn is_signed(_: ForType<Self>) -> bool;
 }
 
 /// A collection of traits relevant to primitive signed and unsigned integers
@@ -388,13 +389,13 @@ pub trait Float: Real
     fn classify(&self) -> FPCategory;
 
     // FIXME (#8888): Removing `unused_self` requires #8888 to be fixed.
-    fn mantissa_digits(unused_self: Option<Self>) -> uint;
-    fn digits(unused_self: Option<Self>) -> uint;
+    fn mantissa_digits(_: ForType<Self>) -> uint;
+    fn digits(_: ForType<Self>) -> uint;
     fn epsilon() -> Self;
-    fn min_exp(unused_self: Option<Self>) -> int;
-    fn max_exp(unused_self: Option<Self>) -> int;
-    fn min_10_exp(unused_self: Option<Self>) -> int;
-    fn max_10_exp(unused_self: Option<Self>) -> int;
+    fn min_exp(_: ForType<Self>) -> int;
+    fn max_exp(_: ForType<Self>) -> int;
+    fn min_10_exp(_: ForType<Self>) -> int;
+    fn max_10_exp(_: ForType<Self>) -> int;
 
     fn ldexp(x: Self, exp: int) -> Self;
     fn frexp(&self) -> (Self, int);
@@ -490,7 +491,7 @@ pub trait ToPrimitive {
 macro_rules! impl_to_primitive_int_to_int(
     ($SrcT:ty, $DstT:ty) => (
         {
-            if Primitive::bits(None::<$SrcT>) <= Primitive::bits(None::<$DstT>) {
+            if Primitive::bits(ForType::<$SrcT>) <= Primitive::bits(ForType::<$DstT>) {
                 Some(*self as $DstT)
             } else {
                 let n = *self as i64;
@@ -575,7 +576,7 @@ macro_rules! impl_to_primitive_uint_to_int(
 macro_rules! impl_to_primitive_uint_to_uint(
     ($SrcT:ty, $DstT:ty) => (
         {
-            if Primitive::bits(None::<$SrcT>) <= Primitive::bits(None::<$DstT>) {
+            if Primitive::bits(ForType::<$SrcT>) <= Primitive::bits(ForType::<$DstT>) {
                 Some(*self as $DstT)
             } else {
                 let zero: $SrcT = Zero::zero();
@@ -631,7 +632,7 @@ impl_to_primitive_uint!(u64)
 
 macro_rules! impl_to_primitive_float_to_float(
     ($SrcT:ty, $DstT:ty) => (
-        if Primitive::bits(None::<$SrcT>) <= Primitive::bits(None::<$DstT>) {
+        if Primitive::bits(ForType::<$SrcT>) <= Primitive::bits(ForType::<$DstT>) {
             Some(*self as $DstT)
         } else {
             let n = *self as f64;

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -344,7 +344,7 @@ pub trait Primitive: Clone
                    + Div<Self,Self>
                    + Rem<Self,Self> {
     // FIXME (#5527): These should be associated constants
-    // FIXME (#8888): Removing `unused_self` requires #8888 to be fixed.
+    // FIXME (#8888): `ForType` should be a language feature. See also: #6894
     fn bits(_: ForType<Self>) -> uint;
     fn bytes(_: ForType<Self>) -> uint;
     fn is_signed(_: ForType<Self>) -> bool;
@@ -388,7 +388,7 @@ pub trait Float: Real
     fn is_normal(&self) -> bool;
     fn classify(&self) -> FPCategory;
 
-    // FIXME (#8888): Removing `unused_self` requires #8888 to be fixed.
+    // FIXME (#8888): `ForType` should be a language feature. See also: #6894
     fn mantissa_digits(_: ForType<Self>) -> uint;
     fn digits(_: ForType<Self>) -> uint;
     fn epsilon() -> Self;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -21,8 +21,9 @@ use default::Default;
 use num::BitCount;
 use num::{ToStrRadix, FromStrRadix};
 use num::{CheckedDiv, Zero, One, strconv};
-use prelude::*;
 use str;
+use util::ForType;
+use prelude::*;
 
 pub use cmp::{min, max};
 
@@ -302,13 +303,13 @@ impl ToStrRadix for $T {
 
 impl Primitive for $T {
     #[inline]
-    fn bits(_: Option<$T>) -> uint { bits }
+    fn bits(_: ForType<$T>) -> uint { bits }
 
     #[inline]
-    fn bytes(_: Option<$T>) -> uint { bits / 8 }
+    fn bytes(_: ForType<$T>) -> uint { bits / 8 }
 
     #[inline]
-    fn is_signed(_: Option<$T>) -> bool { false }
+    fn is_signed(_: ForType<$T>) -> bool { false }
 }
 
 impl BitCount for $T {
@@ -339,6 +340,7 @@ mod tests {
     use num;
     use mem;
     use u16;
+    use util::ForType;
 
     #[test]
     fn test_num() {
@@ -430,9 +432,8 @@ mod tests {
 
     #[test]
     fn test_primitive() {
-        let none: Option<$T> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<$T>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<$T>());
+        assert_eq!(Primitive::bits(ForType::<$T>), mem::size_of::<$T>() * 8);
+        assert_eq!(Primitive::bytes(ForType::<$T>), mem::size_of::<$T>());
     }
 
     #[test]

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -80,6 +80,23 @@ impl Void {
     }
 }
 
+/// A zero-sized type hint useful for accessing static methods that don't
+/// mention `Self`.
+///
+/// # Example
+///
+/// ~~~rust
+/// trait A {
+///     fn a(_: ForType<Self>) -> uint;
+/// }
+///
+/// impl A for int {
+///     fn a(_: ForType<Self>) -> uint { 6 }
+/// }
+///
+/// assert_eq!(A::a(ForType::<int>), 6);
+/// ~~~
+pub struct ForType<T>;
 
 #[cfg(test)]
 mod tests {
@@ -150,6 +167,19 @@ mod tests {
         }
 
         unsafe { assert_eq!(did_run, true); }
+    }
+
+    #[test]
+    fn type_hint() {
+        trait A {
+            fn a(_: ForType<Self>) -> uint;
+        }
+
+        impl A for int {
+            fn a(_: ForType<Self>) -> uint { 6 }
+        }
+
+        assert_eq!(A::a(ForType::<int>), 6);
     }
 }
 

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -96,6 +96,7 @@ impl Void {
 ///
 /// assert_eq!(A::a(ForType::<int>), 6);
 /// ~~~
+// FIXME (#8888): This should really be part of the language. See also: #6894
 pub struct ForType<T>;
 
 #[cfg(test)]
@@ -176,7 +177,7 @@ mod tests {
         }
 
         impl A for int {
-            fn a(_: ForType<int>) -> uint { 6 }
+            fn a(_: ForType<int33>) -> uint { 6 }
         }
 
         assert_eq!(A::a(ForType::<int>), 6);

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -91,7 +91,7 @@ impl Void {
 /// }
 ///
 /// impl A for int {
-///     fn a(_: ForType<Self>) -> uint { 6 }
+///     fn a(_: ForType<int>) -> uint { 6 }
 /// }
 ///
 /// assert_eq!(A::a(ForType::<int>), 6);
@@ -176,7 +176,7 @@ mod tests {
         }
 
         impl A for int {
-            fn a(_: ForType<Self>) -> uint { 6 }
+            fn a(_: ForType<int>) -> uint { 6 }
         }
 
         assert_eq!(A::a(ForType::<int>), 6);

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -23,10 +23,8 @@ pub fn id<T>(x: T) -> T { x }
 #[inline]
 pub fn ignore<T>(_x: T) { }
 
-/**
- * Swap the values at two mutable locations of the same type, without
- * deinitialising or copying either one.
- */
+/// Swap the values at two mutable locations of the same type, without
+/// deinitialising or copying either one.
 #[inline]
 pub fn swap<T>(x: &mut T, y: &mut T) {
     unsafe {
@@ -47,10 +45,8 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
     }
 }
 
-/**
- * Replace the value at a mutable location with a new one, returning the old
- * value, without deinitialising or copying either one.
- */
+/// Replace the value at a mutable location with a new one, returning the old
+/// value, without deinitialising or copying either one.
 #[inline]
 pub fn replace<T>(dest: &mut T, mut src: T) -> T {
     swap(dest, &mut src);


### PR DESCRIPTION
Adds a zero-sized type hint that can be used to access static methods that don't mention `Self`. For example:

``` rust
trait A {
    fn a(_: ForType<Self>) -> uint;
}

impl A for int {
    fn a(_: ForType<int>) -> uint { 6 }
}

assert_eq!(A::a(ForType::<int>), 6);
```

Previously `Option<Self>` was usually used, but this makes the intent clearer.
