### PR TITLE
Remove a debug! statement before I/O is ready

### DIFF
--- a/src/libstd/task/spawn.rs
+++ b/src/libstd/task/spawn.rs
@@ -661,7 +661,6 @@ pub fn spawn_raw(mut opts: TaskOpts, f: ~fn()) {
                 };
                 new_sched.bootstrap(bootstrap_task);
 
-                debug!("enqueing join_task");
                 // Now tell the original scheduler to join with this thread
                 // by scheduling a thread-joining task on the original scheduler
                 orig_sched_handle.send(TaskFromFriend(join_task));

--- a/src/test/run-pass/spawning-with-debug.rs
+++ b/src/test/run-pass/spawning-with-debug.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// exec-env:RUST_LOG=debug
+// xfail-fast
+
+// regression test for issue #10405, make sure we don't call debug! too soon.
+
+use std::task;
+
+fn main() {
+    let mut t = task::task();
+    t.sched_mode(task::SingleThreaded);
+    t.spawn(|| ());
+}


### PR DESCRIPTION
The logging macros all use libuv-based I/O, and there was one stray debug
statement in task::spawn which was executing before the I/O context was ready.
Remove it and add a test to make sure that we can continue to debug this sort of
code.

Closes #10405
