### PR TITLE
Enable uv pipe tests on windows

### DIFF
--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -251,7 +251,6 @@ mod tests {
     use super::super::local_loop;
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#10386): how windows pipes work
     fn connect_err() {
         match PipeWatcher::connect(local_loop(), &"path/to/nowhere".to_c_str()) {
             Ok(*) => fail!(),
@@ -260,7 +259,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#10386): how windows pipes work
     fn bind_err() {
         match PipeListener::bind(local_loop(), &"path/to/nowhere".to_c_str()) {
             Ok(*) => fail!(),
@@ -269,7 +267,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#10386): how windows pipes work
     fn bind() {
         let p = next_test_unix().to_c_str();
         match PipeListener::bind(local_loop(), &p) {
@@ -279,7 +276,6 @@ mod tests {
     }
 
     #[test] #[should_fail]
-    #[ignore(cfg(windows))] // FIXME(#10386): how windows pipes work
     fn bind_fail() {
         let p = next_test_unix().to_c_str();
         let _w = PipeListener::bind(local_loop(), &p).unwrap();
@@ -287,7 +283,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#10386): how windows pipes work
     fn connect() {
         let path = next_test_unix();
         let path2 = path.clone();
@@ -313,7 +308,6 @@ mod tests {
     }
 
     #[test] #[should_fail]
-    #[ignore(cfg(windows))] // FIXME(#10386): how windows pipes work
     fn connect_fail() {
         let path = next_test_unix();
         let path2 = path.clone();

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -375,7 +375,11 @@ pub fn next_test_port() -> u16 {
 /// Get a temporary path which could be the location of a unix socket
 #[fixed_stack_segment] #[inline(never)]
 pub fn next_test_unix() -> Path {
-    os::tmpdir().join(rand::task_rng().gen_ascii_str(20))
+    if cfg!(unix) {
+        os::tmpdir().join(rand::task_rng().gen_ascii_str(20))
+    } else {
+        Path::new(r"\\.\pipe\" + rand::task_rng().gen_ascii_str(20))
+    }
 }
 
 /// Get a unique IPv4 localhost:port pair starting at 9600


### PR DESCRIPTION
Turns out the pipe names must have special names on windows. Once we have
special names, all the tests pass just fine.

Closes #10386
