### PR TITLE
Add a flag to force generating toplevel crate map

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -76,6 +76,7 @@ pub static no_vectorize_loops:      uint = 1 << 26;
 pub static no_vectorize_slp:        uint = 1 << 27;
 pub static no_prepopulate_passes:   uint = 1 << 28;
 pub static use_softfp:              uint = 1 << 29;
+pub static gen_crate_map:           uint = 1 << 30;
 
 pub fn debugging_opts_map() -> ~[(&'static str, &'static str, uint)] {
     ~[("verbose", "in general, enable more debug printouts", verbose),
@@ -128,6 +129,7 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, uint)] {
       "Don't run LLVM's SLP vectorization passes",
       no_vectorize_slp),
      ("soft-float", "Generate software floating point library calls", use_softfp),
+     ("gen-crate-map", "Force generation of a toplevel crate map", gen_crate_map),
     ]
 }
 
@@ -330,6 +332,9 @@ impl Session_ {
     }
     pub fn no_vectorize_slp(&self) -> bool {
         self.debugging_opt(no_vectorize_slp)
+    }
+    pub fn gen_crate_map(&self) -> bool {
+        self.debugging_opt(gen_crate_map)
     }
 
     // pointless function, now...

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2961,7 +2961,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     let mut n_subcrates = 1;
     let cstore = sess.cstore;
     while cstore::have_crate_data(cstore, n_subcrates) { n_subcrates += 1; }
-    let mapname = if *sess.building_library {
+    let mapname = if *sess.building_library && !sess.gen_crate_map() {
         format!("{}_{}_{}", mapmeta.name, mapmeta.vers, mapmeta.extras_hash)
     } else {
         ~"toplevel"


### PR DESCRIPTION
As we start to move runtime components into the crate map, it's becoming harder
and harder to start the runtime from a C function as rust is embedded in another
application. Right now if you compile a rust crate as a dynamic library which is
then linked to another application, when using std::rt::start there are no I/O
local services, even though rustuv was linked against and requested. The reason
for this is that there is no top level crate map available specifying where to
find libuv I/O.

This option is not meant to be used regularly, but rather whenever compiling a
final library crate and linking it into another application. This lifts the
requirement that to get a crate map you must have the final destination be an
executable.
