### PR TITLE
Make -Z gen-crate-map usable for I/O

### DIFF
--- a/src/test/run-pass-fulldeps/bootstrap-from-c.rs
+++ b/src/test/run-pass-fulldeps/bootstrap-from-c.rs
@@ -1,0 +1,88 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This test exercises bootstrapping the runtime from C to make sure that this
+// continues to work. The runtime is expected to have all local I/O services
+// that one would normally expect.
+
+#[feature(managed_boxes)];
+
+extern mod extra;
+extern mod rustc;
+extern mod syntax;
+
+use extra::glob;
+use extra::tempfile::TempDir;
+use rustc::back::link;
+use rustc::driver::driver;
+use rustc::driver::session;
+use std::os;
+use std::rt::io::fs;
+use std::run;
+use std::str;
+use syntax::diagnostic;
+
+fn main() {
+    // Sketchily figure out where our sysroot is
+    let mut sysroot = Path::new(os::self_exe_path().unwrap());
+    sysroot.pop();
+    sysroot.pop();
+    sysroot.push("stage2");
+
+    // Give ourselves a little workspace
+    let d = TempDir::new("mytest").unwrap();
+    let d = d.path();
+
+    // Figure out where we are
+    let mut me = Path::new(file!());
+    me.pop();
+    let srcfile = me.join("bootstrap-from-c/lib.rs");
+    let cfile = me.join("bootstrap-from-c/main.c");
+
+    // Compile the rust crate
+    let options = @session::options {
+        maybe_sysroot: Some(@sysroot),
+        debugging_opts: session::gen_crate_map,
+        ..(*session::basic_options()).clone()
+    };
+    let diagnostic = @diagnostic::DefaultEmitter as @diagnostic::Emitter;
+    let session = driver::build_session(options, diagnostic);
+    driver::compile_input(session, ~[], &driver::file_input(srcfile),
+                          &Some(d.clone()), &None);
+
+    // Copy the C source into place
+    let cdst = d.join("main.c");
+    let exe = d.join("out" + os::consts::EXE_SUFFIX);
+    fs::copy(&cfile, &cdst);
+
+    // Figure out where we put the dynamic library
+    let dll = os::dll_filename("boot-*");
+    let dll = glob::glob(d.as_str().unwrap() + "/" + dll).next().unwrap();
+
+    // Compile the c program with all the appropriate arguments. We're compiling
+    // the cfile and the library together, and may have to do some linker rpath
+    // magic to make sure that the dll can get found when the executable is
+    // running.
+    let cc = link::get_cc_prog(session);
+    let mut cc_args = session.targ_cfg.target_strs.cc_args.clone();
+    cc_args.push_all([~"-o", exe.as_str().unwrap().to_owned()]);
+    cc_args.push(cdst.as_str().unwrap().to_owned());
+    cc_args.push(dll.as_str().unwrap().to_owned());
+    if cfg!(target_os = "macos") {
+        cc_args.push("-Wl,-rpath," + d.as_str().unwrap().to_owned());
+    }
+    let status = run::process_status(cc, cc_args);
+    assert!(status.success());
+
+    // Finally, run the program and make sure that it tells us hello.
+    let res = run::process_output(exe.as_str().unwrap().to_owned(), []);
+    assert!(res.status.success());
+    assert_eq!(str::from_utf8(res.output), ~"hello\n");
+}

--- a/src/test/run-pass-fulldeps/bootstrap-from-c/lib.rs
+++ b/src/test/run-pass-fulldeps/bootstrap-from-c/lib.rs
@@ -1,0 +1,25 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[link(package_id = "boot", name = "boot", vers = "0.1")];
+
+extern mod rustuv; // pull in uvio
+
+use std::rt;
+use std::ptr;
+
+#[no_mangle] // this needs to get called from C
+pub extern "C" fn foo(argc: int, argv: **u8) -> int {
+    do rt::start(argc, argv) {
+        do spawn {
+            println!("hello");
+        }
+    }
+}

--- a/src/test/run-pass-fulldeps/bootstrap-from-c/main.c
+++ b/src/test/run-pass-fulldeps/bootstrap-from-c/main.c
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// this is the rust entry point that we're going to call.
+int foo(int argc, char *argv[]);
+
+int main(int argc, char *argv[]) {
+  return foo(argc, argv);
+}


### PR DESCRIPTION
In #10422, I didn't actually test to make sure that the '-Z gen-crate-map'
option was usable before I implemented it. The crate map was indeed generated
when '-Z gen-crate-map' was specified, but the I/O factory slot was empty
because of an extra check in trans about filling in that location.

This commit both fixes that location, and checks in a "fancy test" which does
lots of fun stuff. The test will use the rustc library to compile a rust crate,
and then compile a C program to link against that crate and run the C program.
To my knowledge this is the first test of its kind, so it's a little ad-hoc, but
it seems to get the job done. We could perhaps generalize running tests like
this, but for now I think it's fine to have this sort of functionality tucked
away in a test.
