### PR TITLE
Make a time test less flaky

### DIFF
--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -1005,18 +1005,17 @@ mod tests {
 
     fn test_precise_time() {
         let s0 = precise_time_s();
-        let ns1 = precise_time_ns();
-
         debug!("s0={} sec", f64::to_str_digits(s0, 9u));
         assert!(s0 > 0.);
-        let ns0 = (s0 * 1000000000.) as u64;
-        debug!("ns0={:?} ns", ns0);
 
-        debug!("ns1={:?} ns", ns0);
+        let ns0 = precise_time_ns();
+        let ns1 = precise_time_ns();
+        debug!("ns0={:?} ns", ns0);
+        debug!("ns1={:?} ns", ns1);
         assert!(ns1 >= ns0);
 
         let ns2 = precise_time_ns();
-        debug!("ns2={:?} ns", ns0);
+        debug!("ns2={:?} ns", ns2);
         assert!(ns2 >= ns1);
     }
 


### PR DESCRIPTION
This test was failing periodically on windows and other platforms, and in
debugging the issue locally I've found that the previous test was failing
at the assertion `ns0 <= ns1`. Upon inspecting the values, the two numbers were
very close to one another, but off by a little bit.

I believe that this is because `precise_time_s` goes from `u64` -> `f64` and
then we go again back to `u64` for the assertion. This conversion is a lossy one
that's not always guaranteed to succeed, so instead I've changed the test to
only compare against u64 instances.
