### PR TITLE
Add build_lib_with_cfgs, build_bin_with_cfgs to rustpkg API

### DIFF
--- a/src/librustpkg/api.rs
+++ b/src/librustpkg/api.rs
@@ -81,6 +81,11 @@ pub fn new_workcache_context(p: &Path) -> workcache::Context {
 
 pub fn build_lib(sysroot: Path, root: Path, name: ~str, version: Version,
                  lib: Path) {
+    build_lib_with_cfgs(sysroot, root, name, version, lib, ~[])
+}
+
+pub fn build_lib_with_cfgs(sysroot: Path, root: Path, name: ~str,
+                           version: Version, lib: Path, cfgs: ~[~str]) {
     let cx = default_context(sysroot, root.clone());
     let pkg_src = PkgSrc {
         source_workspace: root.clone(),
@@ -94,11 +99,16 @@ pub fn build_lib(sysroot: Path, root: Path, name: ~str, version: Version,
         tests: ~[],
         benchs: ~[]
     };
-    pkg_src.build(&cx, ~[], []);
+    pkg_src.build(&cx, cfgs, []);
 }
 
 pub fn build_exe(sysroot: Path, root: Path, name: ~str, version: Version,
                  main: Path) {
+    build_exe_with_cfgs(sysroot, root, name, version, main, ~[])
+}
+
+pub fn build_exe_with_cfgs(sysroot: Path, root: Path, name: ~str,
+                           version: Version, main: Path, cfgs: ~[~str]) {
     let cx = default_context(sysroot, root.clone());
     let pkg_src = PkgSrc {
         source_workspace: root.clone(),
@@ -113,7 +123,7 @@ pub fn build_exe(sysroot: Path, root: Path, name: ~str, version: Version,
         benchs: ~[]
     };
 
-    pkg_src.build(&cx, ~[], []);
+    pkg_src.build(&cx, cfgs, []);
 }
 
 pub fn install_pkg(cx: &BuildContext,


### PR DESCRIPTION
Allows you to provide explicit `--cfg` flags when building certain packages through the rustpkg API.
