### PR TITLE
Ready to enable android bot to make check 2

### DIFF
--- a/src/etc/adb_run_wrapper.sh
+++ b/src/etc/adb_run_wrapper.sh
@@ -5,8 +5,9 @@
 # Sometimes android shell produce exitcode "1 : Text File Busy"
 # Retry after $WAIT seconds, expecting resource cleaned-up
 WAIT=10
-PATH=$1
-if [ -d "$PATH" ]
+TEST_PATH=$1
+BIN_PATH=/system/bin
+if [ -d "$TEST_PATH" ]
 then
     shift
     RUN=$1
@@ -17,10 +18,10 @@ then
 
         L_RET=1
         L_COUNT=0
-        cd $PATH
+        cd $TEST_PATH
         while [ $L_RET -eq 1 ]
         do
-            TEST_EXEC_ENV=22 LD_LIBRARY_PATH=$PATH $PATH/$RUN $@ 1>$PATH/$RUN.stdout 2>$PATH/$RUN.stderr
+            TEST_EXEC_ENV=22 LD_LIBRARY_PATH=$TEST_PATH PATH=$BIN_PATH:$TEST_PATH $TEST_PATH/$RUN $@ 1>$TEST_PATH/$RUN.stdout 2>$TEST_PATH/$RUN.stderr
             L_RET=$?
             if [ $L_COUNT -gt 0 ]
             then
@@ -30,7 +31,7 @@ then
             L_COUNT=$((L_COUNT+1))
         done
 
-        echo $L_RET > $PATH/$RUN.exitcode
+        echo $L_RET > $TEST_PATH/$RUN.exitcode
 
     fi
 fi

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -477,6 +477,7 @@ impl<'self, T:Send +
 
 
 #[test]
+#[cfg(not(target_os="android"))] // FIXME(#10455)
 fn test() {
     use std::{os, run};
     use std::io::fs;

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -22,13 +22,23 @@ use std::io;
 
 #[test]
 fn test_destroy_once() {
-    let mut p = run::Process::new("echo", [], run::ProcessOptions::new());
+    #[cfg(not(target_os="android"))]
+    static PROG: &'static str = "echo";
+    #[cfg(target_os="android")]
+    static PROG: &'static str = "ls"; // android don't have echo binary
+
+    let mut p = run::Process::new(PROG, [], run::ProcessOptions::new());
     p.destroy(); // this shouldn't crash (and nor should the destructor)
 }
 
 #[test]
 fn test_destroy_twice() {
-    let mut p = run::Process::new("echo", [], run::ProcessOptions::new());
+    #[cfg(not(target_os="android"))]
+    static PROG: &'static str = "echo";
+    #[cfg(target_os="android")]
+    static PROG: &'static str = "ls"; // android don't have echo binary
+
+    let mut p = run::Process::new(PROG, [], run::ProcessOptions::new());
     p.destroy(); // this shouldnt crash...
     do io::io_error::cond.trap(|_| {}).inside {
         p.destroy(); // ...and nor should this (and nor should the destructor)

--- a/src/test/run-pass/x86stdcall.rs
+++ b/src/test/run-pass/x86stdcall.rs
@@ -33,4 +33,5 @@ pub fn main() {
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "android")]
 pub fn main() { }


### PR DESCRIPTION
To enable test on android bot #9120

 workcache::test disabled and run-pass/core-run-destroy.rs fixed on android
