### PR TITLE
Fix issue #8763

### DIFF
--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -60,10 +60,11 @@ use middle::typeck::lookup_def_tcx;
 
 use std::vec;
 use syntax::abi::AbiSet;
-use syntax::{ast, ast_util};
+use syntax::{ast, ast_map, ast_util};
 use syntax::codemap::Span;
 use syntax::opt_vec::OptVec;
 use syntax::opt_vec;
+use syntax::parse::token;
 use syntax::print::pprust::{lifetime_to_str, path_to_str};
 
 pub trait AstConv {
@@ -517,6 +518,12 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
             check_path_args(tcx, path, NO_TPS | NO_REGIONS);
             let did = ast_util::local_def(id);
             ty::mk_self(tcx, did)
+          }
+          ast::DefMod(id) => {
+            tcx.sess.span_fatal(ast_ty.span,
+                                format!("found module name used as a type: {}",
+                                        ast_map::node_id_to_str(tcx.items, id.node,
+                                        token::get_ident_interner())));
           }
           _ => {
             tcx.sess.span_fatal(ast_ty.span,

--- a/src/test/compile-fail/trait-impl-for-module.rs
+++ b/src/test/compile-fail/trait-impl-for-module.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#8767) bad error message; Option is not a module
-impl<T> Option<T> { //~ERROR found module name used as a type
-    pub fn foo(&self) { }
+mod a {
 }
 
-fn main() { }
+trait A {
+}
+
+impl A for a { //~ERROR found module name used as a type
+}
+
+fn main() {
+}


### PR DESCRIPTION
Issue #8763 is about improving a particular error message.
- added case & better error message for "impl trait for module"
- added compile-fail test trait-impl-for-module.rs
- updated copyright dates
- revised compile-fail test trait-or-new-type-instead
  (the error message for the modified test is still unclear, but that's a different bug https://github.com/mozilla/rust/issues/8767)
