### PR TITLE
Avoid forcing int and float type variables in early vtable resolution

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -691,6 +691,9 @@ pub fn encode_vtable_origin(ecx: &e::EncodeContext,
                 })
             })
           }
+          typeck::vtable_none => {
+            fail!("unexpected vtable_none in astencode")
+          }
         }
     })
 }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1227,6 +1227,9 @@ pub fn resolve_vtable_under_param_substs(tcx: ty::ctxt,
                 }
             }
         }
+        typeck::vtable_none => {
+            tcx.sess.bug("unexpected vtable_none in trans");
+        }
     }
 }
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -364,6 +364,9 @@ pub fn trans_monomorphized_callee(bcx: @mut Block,
       typeck::vtable_param(..) => {
           fail!("vtable_param left in monomorphized function's vtable substs");
       }
+      typeck::vtable_none => {
+          fail!("unexpected vtable_none in trans");
+      }
     };
 
 }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -20,7 +20,7 @@ use middle::typeck::infer::{force_all, resolve_all, resolve_region};
 use middle::typeck::infer::resolve_type;
 use middle::typeck::infer;
 use middle::typeck::{vtable_res, vtable_origin};
-use middle::typeck::{vtable_static, vtable_param};
+use middle::typeck::{vtable_static, vtable_param, vtable_none};
 use middle::typeck::method_map_entry;
 use middle::typeck::write_substs_to_tcx;
 use middle::typeck::write_ty_to_tcx;
@@ -109,6 +109,9 @@ fn resolve_vtable_map_entry(fcx: @mut FnCtxt, sp: Span, id: ast::NodeId) {
             }
             &vtable_param(n, b) => {
                 vtable_param(n, b)
+            }
+            &vtable_none => {
+                vtable_none
             }
         }
     }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -183,6 +183,9 @@ pub enum vtable_origin {
       and the second is the bound number (identifying baz)
      */
     vtable_param(param_index, uint),
+
+    // For early vtable resolution
+    vtable_none,
 }
 
 impl Repr for vtable_origin {
@@ -198,6 +201,9 @@ impl Repr for vtable_origin {
 
             vtable_param(x, y) => {
                 format!("vtable_param({:?}, {:?})", x, y)
+            }
+            vtable_none => {
+                ~"vtable_none"
             }
         }
     }

--- a/src/test/run-pass/issue-10436.rs
+++ b/src/test/run-pass/issue-10436.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn f<T: Clone>(x: T) -> T {
+    x
+}
+
+fn main() {
+    let x: uint = f(0);
+    assert_eq!(x, 0);
+}


### PR DESCRIPTION
This is a request for feedback. This addresses #10436, but I am not sure whether this is the right direction.
