### PR TITLE
remove `cast::unsafe_copy`

### DIFF
--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -26,14 +26,6 @@ pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
 }
 
 /**
- * Forces a copy of a value, even if that value is considered noncopyable.
- */
-#[inline]
-pub unsafe fn unsafe_copy<T>(thing: &T) -> T {
-    transmute_copy(thing)
-}
-
-/**
  * Move a thing into the void
  *
  * The forget function will take ownership of the provided value but neglect


### PR DESCRIPTION
This is the same functionality as `ptr::read_ptr`.
