### PR TITLE
Don't make tags for our dependencies and tests.

### DIFF
--- a/mk/ctags.mk
+++ b/mk/ctags.mk
@@ -15,7 +15,27 @@
 
 .PHONY: TAGS.emacs TAGS.vi
 
-CTAGS_OPTS=--options=${CFG_SRC_DIR}/src/etc/ctags.rust -R ${CFG_SRC_DIR}/src
+# This is using a blacklist approach, probably more durable than a whitelist.
+# We exclude: external dependencies (llvm, libuv, gyp, rt/{msvc,sundown,vg}),
+# tests (compiletest, test) and a couple of other things (rt/arch, etc)
+CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/llvm,,\
+				$(patsubst ${CFG_SRC_DIR}src/libuv,,\
+				$(patsubst ${CFG_SRC_DIR}src/compiletest,,\
+				$(patsubst ${CFG_SRC_DIR}src/test,,\
+				$(patsubst ${CFG_SRC_DIR}src/gyp,,\
+				$(patsubst ${CFG_SRC_DIR}src/etc,,\
+				$(patsubst ${CFG_SRC_DIR}src/rt,,\
+				$(patsubst ${CFG_SRC_DIR}src/rt/arch,,\
+				$(patsubst ${CFG_SRC_DIR}src/rt/msvc,,\
+				$(patsubst ${CFG_SRC_DIR}src/rt/sundown,,\
+				$(patsubst ${CFG_SRC_DIR}src/rt/vg,,\
+				$(wildcard ${CFG_SRC_DIR}src/*) $(wildcard ${CFG_SRC_DIR}src/rt/*)\
+				)))))))))))
+CTAGS_OPTS=--options="${CFG_SRC_DIR}src/etc/ctags.rust" --languages=-javascript --recurse ${CTAGS_LOCATIONS}
+# We could use `--languages=Rust`, but there is value in producing tags for the
+# C++ parts of the code base too (at the time of writing, those are .h and .cpp
+# files in src/rt, src/rt/sync and src/rustllvm); we mainly just want to
+# exclude the external dependencies.
 
 TAGS.emacs:
 	ctags -e -f $@ ${CTAGS_OPTS}


### PR DESCRIPTION
Largely, this is just being more specific about where tags get searched
for to remove external dependencies like src/llvm, which reduces the
number of tags _enormously_ and significantly increases the usefulness
of the tags file as it is then focusing on 240K lines of Rust code
and 4.5K of C++ rather than just shy of 1M lines of C++ code (mostly
from LLVM) and another 100K lines of Rust tests and a diverse collection
of other languages.

src/rustllvm/RustWrapper.cpp and src/rustllvm/PassWrapper.cpp are
getting tags made, but I'm not sure if that's desirable or not. At
worst, it's not a significant wrong.

A future, desirable step is producing tags for just libstd and libextra
for the use of people using Rust-the-language rather than working on
Rust itself.
