### PR TITLE
lint: _-prefixed variables don't get an unused-mut warning.

### DIFF
--- a/src/test/compile-fail/lint-unused-mut-variables.rs
+++ b/src/test/compile-fail/lint-unused-mut-variables.rs
@@ -49,6 +49,10 @@ fn main() {
 
     let x = |mut y: int| y = 32;
     fn nothing(mut foo: int) { foo = 37; }
+
+    // leading underscore should avoid the warning, just like the
+    // unused variable lint.
+    let mut _allowed = 1;
 }
 
 fn callback(f: &fn()) {}


### PR DESCRIPTION
Bringing it into line with the unused-variable one,

```
fn main() {
    let mut _a = 1;
}
```

will not warn that `_a` is never used mutably.

Fixes #6911.
