### PR TITLE
Fix for Rustpkg Opt Settings

### DIFF
--- a/src/librustpkg/context.rs
+++ b/src/librustpkg/context.rs
@@ -11,7 +11,7 @@
 // Context data structure used by rustpkg
 
 use extra::workcache;
-use rustc::driver::session::{OptLevel, No};
+use rustc::driver::session;
 
 use std::hashmap::HashSet;
 
@@ -88,7 +88,7 @@ pub struct RustcFlags {
     // Extra arguments to pass to rustc with the --link-args flag
     link_args: Option<~str>,
     // Optimization level. 0 = default. -O = 2.
-    optimization_level: OptLevel,
+    optimization_level: session::OptLevel,
     // True if the user passed in --save-temps
     save_temps: bool,
     // Target (defaults to rustc's default target)
@@ -224,7 +224,7 @@ impl RustcFlags {
             linker: None,
             link_args: None,
             compile_upto: Nothing,
-            optimization_level: No,
+            optimization_level: session::Default,
             save_temps: false,
             target: None,
             target_cpu: None,

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -28,6 +28,8 @@ use workcache_support::{digest_only_date, digest_file_with_date, crate_tag};
 use extra::workcache;
 use extra::treemap::TreeMap;
 
+use rustc::driver::session;
+
 // An enumeration of the unpacked source of a package workspace.
 // This contains a list of files found in the source workspace.
 #[deriving(Clone)]
@@ -425,6 +427,7 @@ impl PkgSrc {
                     }
                     debug!("Compiling crate {}; its output will be in {}",
                            subpath.display(), sub_dir.display());
+                    let opt: session::OptLevel = subcx.context.rustc_flags.optimization_level;
                     let result = compile_crate(&subcx,
                                                exec,
                                                &id,
@@ -433,7 +436,7 @@ impl PkgSrc {
                                                &mut (sub_deps.clone()),
                                                sub_flags,
                                                subcfgs,
-                                               false,
+                                               opt,
                                                what);
                     // XXX: result is an Option<Path>. The following code did not take that
                     // into account. I'm not sure if the workcache really likes seeing the

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -175,7 +175,7 @@ pub fn compile_input(context: &BuildContext,
                      deps: &mut DepMap,
                      flags: &[~str],
                      cfgs: &[~str],
-                     opt: bool,
+                     opt: session::OptLevel,
                      what: OutputType) -> Option<Path> {
     assert!(in_file.component_iter().nth(1).is_some());
     let input = driver::file_input(in_file.clone());
@@ -241,7 +241,7 @@ pub fn compile_input(context: &BuildContext,
 
     let options = @session::options {
         crate_type: crate_type,
-        optimize: if opt { session::Aggressive } else { session::No },
+        optimize: opt,
         test: what == Test || what == Bench,
         maybe_sysroot: Some(sysroot_to_use),
         addl_lib_search_paths: @mut context.additional_library_paths(),
@@ -408,7 +408,7 @@ pub fn compile_crate(ctxt: &BuildContext,
                      deps: &mut DepMap,
                      flags: &[~str],
                      cfgs: &[~str],
-                     opt: bool,
+                     opt: session::OptLevel,
                      what: OutputType) -> Option<Path> {
     debug!("compile_crate: crate={}, workspace={}", crate.display(), workspace.display());
     debug!("compile_crate: short_name = {}, flags =...", pkg_id.to_str());


### PR DESCRIPTION
This commit fixes issue #10468.

It propagate optimization level from PkgSrc to compile_crate as a rustc::driver::session::OptLevel enum.

The 'opt' argument to compile_crate was previously hardcoded as boolean false, such that calls to session::options would always result in the session::No flag being used.
