### PR TITLE
resurect shootout-mandelbrot.rs

### DIFF
--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -21,14 +21,15 @@ static LIMIT: f64 = 2.0;
 fn main() {
     let args = std::os::args();
     let (w, mut out) = if args.len() < 2 {
-        println("Test mode: do not dump the image.");
+        println("Test mode: do not dump the image because it's not utf8,"
+                + " which interferes with the test runner.");
         (1000, ~DummyWriter as ~Writer)
     } else {
         (from_str(args[1]).unwrap(),
          ~BufferedWriter::new(std::io::stdout()) as ~Writer)
     };
     let h = w;
-    let mut byte_acc = 0i8;
+    let mut byte_acc = 0u8;
     let mut bit_num = 0;
 
     writeln!(out, "P4\n{} {}", w, h);
@@ -62,12 +63,12 @@ fn main() {
             bit_num += 1;
 
             if bit_num == 8 {
-                out.write_i8(byte_acc);
+                out.write_u8(byte_acc);
                 byte_acc = 0;
                 bit_num = 0;
             } else if x == w - 1 {
                 byte_acc <<= 8 - w % 8;
-                out.write_i8(byte_acc);
+                out.write_u8(byte_acc);
                 byte_acc = 0;
                 bit_num = 0;
             }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -1,64 +1,78 @@
-// xfail-test reading from os::args()[1] - bogus!
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
-use std::cast::transmute;
-use std::from_str::FromStr;
-use std::libc::{STDOUT_FILENO, c_int, fdopen, fputc};
-use std::os;
+use std::io::buffered::BufferedWriter;
 
-static ITER: uint = 50;
+struct DummyWriter;
+impl Writer for DummyWriter {
+    fn write(&mut self, _: &[u8]) {}
+}
+
+static ITER: int = 50;
 static LIMIT: f64 = 2.0;
 
 fn main() {
-    unsafe {
-        let w: i32 = FromStr::from_str(os::args()[1]).unwrap();
-        let h = w;
-        let mut byte_acc: i8 = 0;
-        let mut bit_num: i32 = 0;
+    let args = std::os::args();
+    let (w, mut out) = if args.len() < 2 {
+        println("Test mode: do not dump the image.");
+        (1000, ~DummyWriter as ~Writer)
+    } else {
+        (from_str(args[1]).unwrap(),
+         ~BufferedWriter::new(std::io::stdout()) as ~Writer)
+    };
+    let h = w;
+    let mut byte_acc = 0i8;
+    let mut bit_num = 0;
 
-        println!("P4\n{} {}", w, h);
+    writeln!(out, "P4\n{} {}", w, h);
 
-        let mode = "w";
-        let stdout = fdopen(STDOUT_FILENO as c_int, transmute(&mode[0]));
+    for y in range(0, h) {
+        let y = y as f64;
+        for x in range(0, w) {
+            let mut z_r = 0f64;
+            let mut z_i = 0f64;
+            let mut t_r = 0f64;
+            let mut t_i = 0f64;
+            let c_r = 2.0 * (x as f64) / (w as f64) - 1.5;
+            let c_i = 2.0 * (y as f64) / (h as f64) - 1.0;
 
-        for y in range(0i32, h) {
-            let y = y as f64;
-            for x in range(0i32, w) {
-                let mut Zr = 0f64;
-                let mut Zi = 0f64;
-                let mut Tr = 0f64;
-                let mut Ti = 0f64;
-                let Cr = 2.0 * (x as f64) / (w as f64) - 1.5;
-                let Ci = 2.0 * (y as f64) / (h as f64) - 1.0;
-
-                for _ in range(0i32, ITER as i32) {
-                    if Tr + Ti > LIMIT * LIMIT {
-                        break;
-                    }
-
-                    Zi = 2.0*Zr*Zi + Ci;
-                    Zr = Tr - Ti + Cr;
-                    Tr = Zr * Zr;
-                    Ti = Zi * Zi;
+            for _ in range(0, ITER) {
+                if t_r + t_i > LIMIT * LIMIT {
+                    break;
                 }
 
-                byte_acc <<= 1;
-                if Tr + Ti <= LIMIT * LIMIT {
-                    byte_acc |= 1;
-                }
+                z_i = 2.0 * z_r * z_i + c_i;
+                z_r = t_r - t_i + c_r;
+                t_r = z_r * z_r;
+                t_i = z_i * z_i;
+            }
 
-                bit_num += 1;
+            byte_acc <<= 1;
+            if t_r + t_i <= LIMIT * LIMIT {
+                byte_acc |= 1;
+            }
 
-                if bit_num == 8 {
-                    fputc(byte_acc as c_int, stdout);
-                    byte_acc = 0;
-                    bit_num = 0;
-                } else if x == w - 1 {
-                    byte_acc <<= 8 - w%8;
-                    fputc(byte_acc as c_int, stdout);
-                    byte_acc = 0;
-                    bit_num = 0;
-                }
+            bit_num += 1;
+
+            if bit_num == 8 {
+                out.write_i8(byte_acc);
+                byte_acc = 0;
+                bit_num = 0;
+            } else if x == w - 1 {
+                byte_acc <<= 8 - w % 8;
+                out.write_i8(byte_acc);
+                byte_acc = 0;
+                bit_num = 0;
             }
         }
     }
+
+    out.flush();
 }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -21,8 +21,8 @@ static LIMIT: f64 = 2.0;
 fn main() {
     let args = std::os::args();
     let (w, mut out) = if args.len() < 2 {
-        println("Test mode: do not dump the image because it's not utf8,"
-                + " which interferes with the test runner.");
+        println("Test mode: do not dump the image because it's not utf8, \
+                which interferes with the test runner.");
         (1000, ~DummyWriter as ~Writer)
     } else {
         (from_str(args[1]).unwrap(),


### PR DESCRIPTION
Changes:
- add licence;
- remove usage of libc and unsafe;
- use BufferedWriter to improve performance;
- use a DummyWriter to cancel binary output in test.
