### PR TITLE
std::rand: wrappers for floats from [0,1] and (0,1).

### DIFF
--- a/src/libstd/rand/distributions/gamma.rs
+++ b/src/libstd/rand/distributions/gamma.rs
@@ -10,7 +10,7 @@
 
 //! The Gamma distribution.
 
-use rand::Rng;
+use rand::{Rng, Open01};
 use super::{IndependentSample, Sample, StandardNormal, Exp};
 use num;
 
@@ -142,11 +142,7 @@ impl IndependentSample<f64> for Gamma {
 }
 impl IndependentSample<f64> for GammaSmallShape {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
-        // Need (0, 1) here.
-        let mut u = rng.gen::<f64>();
-        while u == 0. {
-            u = rng.gen();
-        }
+        let u = *rng.gen::<Open01<f64>>();
 
         self.large_shape.ind_sample(rng) * num::pow(u, self.inv_shape)
     }
@@ -161,12 +157,7 @@ impl IndependentSample<f64> for GammaLargeShape {
             }
 
             let v = v_cbrt * v_cbrt * v_cbrt;
-            // Need (0, 1) here, not [0, 1). This would be faster if
-            // we were generating an f64 in (0, 1) directly.
-            let mut u = rng.gen::<f64>();
-            while u == 0.0 {
-                u = rng.gen();
-            }
+            let u = *rng.gen::<Open01<f64>>();
 
             let x_sqr = x * x;
             if u < 1.0 - 0.0331 * x_sqr * x_sqr ||

--- a/src/libstd/rand/distributions/mod.rs
+++ b/src/libstd/rand/distributions/mod.rs
@@ -23,7 +23,7 @@ that do not need to record state.
 use iter::range;
 use option::{Some, None};
 use num;
-use rand::{Rng,Rand};
+use rand::{Rng, Rand, Open01};
 use clone::Clone;
 
 pub use self::range::Range;
@@ -276,10 +276,12 @@ impl Rand for StandardNormal {
             let mut x = 1.0f64;
             let mut y = 0.0f64;
 
-            // FIXME #7755: infinities?
             while -2.0 * y < x * x {
-                x = rng.gen::<f64>().ln() / ziggurat_tables::ZIG_NORM_R;
-                y = rng.gen::<f64>().ln();
+                let x_ = *rng.gen::<Open01<f64>>();
+                let y_ = *rng.gen::<Open01<f64>>();
+
+                x = x_.ln() / ziggurat_tables::ZIG_NORM_R;
+                y = y_.ln();
             }
 
             if u < 0.0 { x - ziggurat_tables::ZIG_NORM_R } else { ziggurat_tables::ZIG_NORM_R - x }

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -647,6 +647,46 @@ pub fn random<T: Rand>() -> T {
     task_rng().gen()
 }
 
+/// A wrapper for generating floating point numbers uniformly in the
+/// open interval `(0,1)` (not including either endpoint).
+///
+/// Use `Closed01` for the closed interval `[0,1]`, and the default
+/// `Rand` implementation for `f32` and `f64` for the half-open
+/// `[0,1)`.
+///
+/// # Example
+/// ```rust
+/// use std::rand::{random, Open01};
+///
+/// fn main() {
+///     println!("f32 from (0,1): {}", *random::<Open01<f32>>());
+///
+///     let x: Open01<f64> = random();
+///     println!("f64 from (0,1): {}", *x);
+/// }
+/// ```
+pub struct Open01<F>(F);
+
+/// A wrapper for generating floating point numbers uniformly in the
+/// closed interval `[0,1]` (including both endpoints).
+///
+/// Use `Open01` for the closed interval `(0,1)`, and the default
+/// `Rand` implementation of `f32` and `f64` for the half-open
+/// `[0,1)`.
+///
+/// # Example
+/// ```rust
+/// use std::rand::{random, Closed01};
+///
+/// fn main() {
+///     println!("f32 from [0,1]: {}", *random::<Closed01<f32>>());
+///
+///     let x: Closed01<f64> = random();
+///     println!("f64 from [0,1]: {}", *x);
+/// }
+/// ```
+pub struct Closed01<F>(F);
+
 #[cfg(test)]
 mod test {
     use iter::{Iterator, range};


### PR DESCRIPTION
Provide `Closed01` and `Open01` that generate directly from the
closed/open intervals from 0 to 1, in contrast to the plain impls for
f32 and f64 which generate the half-open [0,1).

Fixes #7755.
