### PR TITLE
Map trait improvements

### DIFF
--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -208,7 +208,7 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
     fn compute_id_range(&mut self, id: ast::NodeId) -> (uint, uint) {
         let mut expanded = false;
         let len = self.nodeid_to_bitset.len();
-        let n = do self.nodeid_to_bitset.find_or_insert_with(id) |_| {
+        let (_, n) = do self.nodeid_to_bitset.find_or_insert_with(id) |_| {
             expanded = true;
             len
         };

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -36,7 +36,8 @@ pub fn replace_bound_regions_in_fn_sig(
                 debug!("region r={}", r.to_str());
                 match r {
                 ty::ReLateBound(s, br) if s == fn_sig.binder_id => {
-                    *map.find_or_insert_with(br, |_| mapf(br))
+                    let (_, v) = map.find_or_insert_with(br, |_| mapf(br));
+                    *v
                 }
                 _ => r
             }});

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -491,7 +491,7 @@ impl DocFolder for Cache {
             clean::ImplItem(ref i) => {
                 match i.trait_ {
                     Some(clean::ResolvedPath{ id, _ }) => {
-                        let v = do self.implementors.find_or_insert_with(id) |_|{
+                        let (_, v) = do self.implementors.find_or_insert_with(id) |_|{
                             ~[]
                         };
                         match i.for_ {
@@ -594,7 +594,7 @@ impl DocFolder for Cache {
                     clean::Item{ attrs, inner: clean::ImplItem(i), _ } => {
                         match i.for_ {
                             clean::ResolvedPath { id, _ } => {
-                                let v = do self.impls.find_or_insert_with(id) |_| {
+                                let (_, v) = do self.impls.find_or_insert_with(id) |_| {
                                     ~[]
                                 };
                                 // extract relevant documentation for this impl
@@ -1607,7 +1607,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<~str, ~[~str]> {
             None => continue,
             Some(ref s) => s.to_owned(),
         };
-        let v = map.find_or_insert_with(short.to_owned(), |_| ~[]);
+        let (_, v) = map.find_or_insert_with(short.to_owned(), |_| ~[]);
         v.push(myname);
     }
 

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -70,9 +70,11 @@ impl<T> Map<int, T> for cat<T> {
 }
 
 impl<T> MutableMap<int, T> for cat<T> {
-    fn insert(&mut self, k: int, _: T) -> bool {
+    fn find_or_insert_with<'a>(&'a mut self, k: int, f: &fn(&int) -> T)
+                               -> (&'a int, &'a mut T) {
+        self.name = f(&k);
         self.meows += k;
-        true
+        (&self.meows, &mut self.name)
     }
 
     fn find_mut<'a>(&'a mut self, _k: &int) -> Option<&'a mut T> { fail!() }
@@ -88,6 +90,9 @@ impl<T> MutableMap<int, T> for cat<T> {
     fn pop(&mut self, _k: &int) -> Option<T> { fail!() }
 
     fn swap(&mut self, _k: int, _v: T) -> Option<T> { fail!() }
+
+    fn reserve_at_least(&mut self, n: uint) {
+    }
 }
 
 impl<T> cat<T> {


### PR DESCRIPTION
Add methods `find_or_insert`, `find_or_insert_with`, `insert_or_update_with` and `reserve_at_least` to the `MutableMap` trait.

Closes #5568.

The unsafe way of implementing `find_or_insert_with` on `TreeMap` mentioned in the issue discussion doesn't work after all.  The way done here isn't great but it works at least.  Someone can come up with a better implementation in the future but I don't think that should hold the rest of this up.
