### PR TITLE
debuginfo: Improved stepping for if-expressions

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -509,6 +509,17 @@ pub fn set_source_location(fcx: &FunctionContext,
     }
 }
 
+/// Clears the current debug location.
+///
+/// Instructions generated hereafter won't be assigned a source location.
+pub fn clear_source_location(fcx: &FunctionContext) {
+    if fn_should_be_ignored(fcx) {
+        return;
+    }
+
+    set_debug_location(fcx.ccx, UnknownLocation);
+}
+
 /// Enables emitting source locations for the given functions.
 ///
 /// Since we don't want source locations to be emitted for the function prelude, they are disabled


### PR DESCRIPTION
This PR improves the single-stepping experience for if-expression (no more jumping into the _else_ branch before entering the _then_ branch, no more jumping to the end of the _else_ branch after finishing the _then_ branch). Unfortunately I don't know of a straight-forward way of writing automated tests for this. Suggestions welcome!
