### PR TITLE
libstd: Change all `~fn()`s to `proc`s in the standard library.

### DIFF
--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -157,7 +157,7 @@ mod tests {
     use io::*;
     use rt::comm::oneshot;
 
-    fn smalltest(server: ~fn(UnixStream), client: ~fn(UnixStream)) {
+    fn smalltest(server: proc(UnixStream), client: proc(UnixStream)) {
         let server = Cell::new(server);
         let client = Cell::new(client);
         do run_in_mt_newsched_task {

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -478,11 +478,11 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
     }
 
     fn visit_closure_ptr(&mut self, ck: uint) -> bool {
-        self.align_to::<~fn()>();
+        self.align_to::<proc()>();
         if ! self.inner.visit_closure_ptr(ck) {
             return false
         }
-        self.bump_past::<~fn()>();
+        self.bump_past::<proc()>();
         true
     }
 }

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -207,7 +207,7 @@ pub mod borrowck;
 /// # Return value
 ///
 /// The return value is used as the process return code. 0 on success, 101 on error.
-pub fn start(argc: int, argv: **u8, main: ~fn()) -> int {
+pub fn start(argc: int, argv: **u8, main: proc()) -> int {
 
     init(argc, argv);
     let exit_code = run(main);
@@ -221,7 +221,7 @@ pub fn start(argc: int, argv: **u8, main: ~fn()) -> int {
 ///
 /// This is appropriate for running code that must execute on the main thread,
 /// such as the platform event loop and GUI.
-pub fn start_on_main_thread(argc: int, argv: **u8, main: ~fn()) -> int {
+pub fn start_on_main_thread(argc: int, argv: **u8, main: proc()) -> int {
     init(argc, argv);
     let exit_code = run_on_main_thread(main);
     cleanup();
@@ -254,15 +254,15 @@ pub fn cleanup() {
 /// Configures the runtime according to the environment, by default
 /// using a task scheduler with the same number of threads as cores.
 /// Returns a process exit code.
-pub fn run(main: ~fn()) -> int {
+pub fn run(main: proc()) -> int {
     run_(main, false)
 }
 
-pub fn run_on_main_thread(main: ~fn()) -> int {
+pub fn run_on_main_thread(main: proc()) -> int {
     run_(main, true)
 }
 
-fn run_(main: ~fn(), use_main_sched: bool) -> int {
+fn run_(main: proc(), use_main_sched: bool) -> int {
     static DEFAULT_ERROR_CODE: int = 101;
 
     let nscheds = util::default_sched_threads();
@@ -341,7 +341,7 @@ fn run_(main: ~fn(), use_main_sched: bool) -> int {
     // When the main task exits, after all the tasks in the main
     // task tree, shut down the schedulers and set the exit code.
     let handles = Cell::new(handles);
-    let on_exit: ~fn(UnwindResult) = |exit_success| {
+    let on_exit: proc(UnwindResult) = |exit_success| {
         unsafe {
             assert!(!(*exited_already.get()).swap(true, SeqCst),
                     "the runtime already exited");

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -990,7 +990,9 @@ mod test {
                 assert!(Task::on_appropriate_sched());
             };
 
-            let on_exit: ~fn(UnwindResult) = |exit_status| rtassert!(exit_status.is_success());
+            let on_exit: proc(UnwindResult) = |exit_status| {
+                rtassert!(exit_status.is_success())
+            };
             task.death.on_exit = Some(on_exit);
 
             sched.bootstrap(task);

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -139,7 +139,10 @@ impl Task {
 
     // A helper to build a new task using the dynamically found
     // scheduler and task. Only works in GreenTask context.
-    pub fn build_homed_child(stack_size: Option<uint>, f: ~fn(), home: SchedHome) -> ~Task {
+    pub fn build_homed_child(stack_size: Option<uint>,
+                             f: proc(),
+                             home: SchedHome)
+                             -> ~Task {
         let f = Cell::new(f);
         let home = Cell::new(home);
         do Local::borrow |running_task: &mut Task| {
@@ -153,11 +156,14 @@ impl Task {
         }
     }
 
-    pub fn build_child(stack_size: Option<uint>, f: ~fn()) -> ~Task {
+    pub fn build_child(stack_size: Option<uint>, f: proc()) -> ~Task {
         Task::build_homed_child(stack_size, f, AnySched)
     }
 
-    pub fn build_homed_root(stack_size: Option<uint>, f: ~fn(), home: SchedHome) -> ~Task {
+    pub fn build_homed_root(stack_size: Option<uint>,
+                            f: proc(),
+                            home: SchedHome)
+                            -> ~Task {
         let f = Cell::new(f);
         let home = Cell::new(home);
         do Local::borrow |running_task: &mut Task| {
@@ -171,7 +177,7 @@ impl Task {
         }
     }
 
-    pub fn build_root(stack_size: Option<uint>, f: ~fn()) -> ~Task {
+    pub fn build_root(stack_size: Option<uint>, f: proc()) -> ~Task {
         Task::build_homed_root(stack_size, f, AnySched)
     }
 
@@ -196,21 +202,21 @@ impl Task {
 
     pub fn new_root(stack_pool: &mut StackPool,
                     stack_size: Option<uint>,
-                    start: ~fn()) -> Task {
+                    start: proc()) -> Task {
         Task::new_root_homed(stack_pool, stack_size, AnySched, start)
     }
 
     pub fn new_child(&mut self,
                      stack_pool: &mut StackPool,
                      stack_size: Option<uint>,
-                     start: ~fn()) -> Task {
+                     start: proc()) -> Task {
         self.new_child_homed(stack_pool, stack_size, AnySched, start)
     }
 
     pub fn new_root_homed(stack_pool: &mut StackPool,
                           stack_size: Option<uint>,
                           home: SchedHome,
-                          start: ~fn()) -> Task {
+                          start: proc()) -> Task {
         Task {
             heap: LocalHeap::new(),
             gc: GarbageCollector,
@@ -233,7 +239,7 @@ impl Task {
                            stack_pool: &mut StackPool,
                            stack_size: Option<uint>,
                            home: SchedHome,
-                           start: ~fn()) -> Task {
+                           start: proc()) -> Task {
         Task {
             heap: LocalHeap::new(),
             gc: GarbageCollector,
@@ -404,7 +410,10 @@ impl Drop for Task {
 
 impl Coroutine {
 
-    pub fn new(stack_pool: &mut StackPool, stack_size: Option<uint>, start: ~fn()) -> Coroutine {
+    pub fn new(stack_pool: &mut StackPool,
+               stack_size: Option<uint>,
+               start: proc())
+               -> Coroutine {
         let stack_size = match stack_size {
             Some(size) => size,
             None => env::min_stack()
@@ -425,9 +434,9 @@ impl Coroutine {
         }
     }
 
-    fn build_start_wrapper(start: ~fn()) -> ~fn() {
+    fn build_start_wrapper(start: proc()) -> proc() {
         let start_cell = Cell::new(start);
-        let wrapper: ~fn() = || {
+        let wrapper: proc() = || {
             // First code after swap to this new context. Run our
             // cleanup job.
             unsafe {

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -65,28 +65,28 @@ pub fn new_test_sched() -> Scheduler {
     return sched;
 }
 
-pub fn run_in_uv_task(f: ~fn()) {
+pub fn run_in_uv_task(f: proc()) {
     let f = Cell::new(f);
     do run_in_bare_thread {
         run_in_uv_task_core(f.take());
     }
 }
 
-pub fn run_in_newsched_task(f: ~fn()) {
+pub fn run_in_newsched_task(f: proc()) {
     let f = Cell::new(f);
     do run_in_bare_thread {
         run_in_newsched_task_core(f.take());
     }
 }
 
-pub fn run_in_uv_task_core(f: ~fn()) {
+pub fn run_in_uv_task_core(f: proc()) {
 
     use rt::sched::Shutdown;
 
     let mut sched = ~new_test_uv_sched();
     let exit_handle = Cell::new(sched.make_handle());
 
-    let on_exit: ~fn(UnwindResult) = |exit_status| {
+    let on_exit: proc(UnwindResult) = |exit_status| {
         exit_handle.take().send(Shutdown);
         rtassert!(exit_status.is_success());
     };
@@ -96,13 +96,13 @@ pub fn run_in_uv_task_core(f: ~fn()) {
     sched.bootstrap(task);
 }
 
-pub fn run_in_newsched_task_core(f: ~fn()) {
+pub fn run_in_newsched_task_core(f: proc()) {
     use rt::sched::Shutdown;
 
     let mut sched = ~new_test_sched();
     let exit_handle = Cell::new(sched.make_handle());
 
-    let on_exit: ~fn(UnwindResult) = |exit_status| {
+    let on_exit: proc(UnwindResult) = |exit_status| {
         exit_handle.take().send(Shutdown);
         rtassert!(exit_status.is_success());
     };
@@ -196,7 +196,7 @@ pub fn prepare_for_lots_of_tests() {
 /// Create more than one scheduler and run a function in a task
 /// in one of the schedulers. The schedulers will stay alive
 /// until the function `f` returns.
-pub fn run_in_mt_newsched_task(f: ~fn()) {
+pub fn run_in_mt_newsched_task(f: proc()) {
     use os;
     use from_str::FromStr;
     use rt::sched::Shutdown;
@@ -246,7 +246,7 @@ pub fn run_in_mt_newsched_task(f: ~fn()) {
         }
 
         let handles = Cell::new(handles);
-        let on_exit: ~fn(UnwindResult) = |exit_status| {
+        let on_exit: proc(UnwindResult) = |exit_status| {
             let mut handles = handles.take();
             // Tell schedulers to exit
             for handle in handles.mut_iter() {
@@ -295,16 +295,16 @@ pub fn run_in_mt_newsched_task(f: ~fn()) {
 }
 
 /// Test tasks will abort on failure instead of unwinding
-pub fn spawntask(f: ~fn()) {
+pub fn spawntask(f: proc()) {
     Scheduler::run_task(Task::build_child(None, f));
 }
 
 /// Create a new task and run it right now. Aborts on failure
-pub fn spawntask_later(f: ~fn()) {
+pub fn spawntask_later(f: proc()) {
     Scheduler::run_task_later(Task::build_child(None, f));
 }
 
-pub fn spawntask_random(f: ~fn()) {
+pub fn spawntask_random(f: proc()) {
     use rand::{Rand, rng};
 
     let mut rng = rng();
@@ -317,11 +317,11 @@ pub fn spawntask_random(f: ~fn()) {
     }
 }
 
-pub fn spawntask_try(f: ~fn()) -> Result<(),()> {
+pub fn spawntask_try(f: proc()) -> Result<(),()> {
 
     let (port, chan) = oneshot();
     let chan = Cell::new(chan);
-    let on_exit: ~fn(UnwindResult) = |exit_status| chan.take().send(exit_status);
+    let on_exit: proc(UnwindResult) = |exit_status| chan.take().send(exit_status);
 
     let mut new_task = Task::build_root(None, f);
     new_task.death.on_exit = Some(on_exit);
@@ -334,7 +334,7 @@ pub fn spawntask_try(f: ~fn()) -> Result<(),()> {
 }
 
 /// Spawn a new task in a new scheduler and return a thread handle.
-pub fn spawntask_thread(f: ~fn()) -> Thread {
+pub fn spawntask_thread(f: proc()) -> Thread {
 
     let f = Cell::new(f);
 
@@ -346,7 +346,7 @@ pub fn spawntask_thread(f: ~fn()) -> Thread {
 }
 
 /// Get a ~Task for testing purposes other than actually scheduling it.
-pub fn with_test_task(blk: ~fn(~Task) -> ~Task) {
+pub fn with_test_task(blk: proc(~Task) -> ~Task) {
     do run_in_bare_thread {
         let mut sched = ~new_test_sched();
         let task = blk(~Task::new_root(&mut sched.stack_pool, None, ||{}));

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -35,7 +35,7 @@ static DEFAULT_STACK_SIZE: libc::size_t = 1024*1024;
 
 impl Thread {
 
-    pub fn start(main: ~fn()) -> Thread {
+    pub fn start(main: proc()) -> Thread {
         // This is the starting point of rust os threads. The first thing we do
         // is make sure that we don't trigger __morestack (also why this has a
         // no_split_stack annotation), and then we extract the main function
@@ -45,7 +45,7 @@ impl Thread {
             use rt::context;
             unsafe {
                 context::record_stack_bounds(0, uint::max_value);
-                let f: ~~fn() = cast::transmute(trampoline);
+                let f: ~proc() = cast::transmute(trampoline);
                 (*f)();
             }
             unsafe { cast::transmute(0) }
@@ -67,7 +67,7 @@ impl Thread {
 
 #[cfg(windows)]
 fn native_thread_create(thread_start: extern "C" fn(*libc::c_void) -> rust_thread_return,
-                        tramp: ~~fn()) -> rust_thread {
+                        tramp: ~proc()) -> rust_thread {
     unsafe {
         let ptr: *mut libc::c_void = cast::transmute(tramp);
         CreateThread(ptr::mut_null(), DEFAULT_STACK_SIZE, thread_start, ptr, 0, ptr::mut_null())
@@ -82,7 +82,7 @@ fn native_thread_join(native: rust_thread) {
 
 #[cfg(unix)]
 fn native_thread_create(thread_start: extern "C" fn(*libc::c_void) -> rust_thread_return,
-                        tramp: ~~fn()) -> rust_thread {
+                        tramp: ~proc()) -> rust_thread {
     use unstable::intrinsics;
     let mut native: libc::pthread_t = unsafe { intrinsics::uninit() };
 

--- a/src/libstd/task/mod.rs
+++ b/src/libstd/task/mod.rs
@@ -195,7 +195,7 @@ pub struct TaskOpts {
 // FIXME (#3724): Replace the 'consumed' bit with move mode on self
 pub struct TaskBuilder {
     opts: TaskOpts,
-    priv gen_body: Option<~fn(v: ~fn()) -> ~fn()>,
+    priv gen_body: Option<proc(v: proc()) -> proc()>,
     priv can_not_copy: Option<util::NonCopyable>,
     priv consumed: bool,
 }
@@ -340,18 +340,18 @@ impl TaskBuilder {
      * generator by applying the task body which results from the
      * existing body generator to the new body generator.
      */
-    pub fn add_wrapper(&mut self, wrapper: ~fn(v: ~fn()) -> ~fn()) {
+    pub fn add_wrapper(&mut self, wrapper: proc(v: proc()) -> proc()) {
         let prev_gen_body = self.gen_body.take();
         let prev_gen_body = match prev_gen_body {
             Some(gen) => gen,
             None => {
-                let f: ~fn(~fn()) -> ~fn() = |body| body;
+                let f: proc(proc()) -> proc() = |body| body;
                 f
             }
         };
         let prev_gen_body = Cell::new(prev_gen_body);
         let next_gen_body = {
-            let f: ~fn(~fn()) -> ~fn() = |body| {
+            let f: proc(proc()) -> proc() = |body| {
                 let prev_gen_body = prev_gen_body.take();
                 wrapper(prev_gen_body(body))
             };
@@ -372,7 +372,7 @@ impl TaskBuilder {
      * When spawning into a new scheduler, the number of threads requested
      * must be greater than zero.
      */
-    pub fn spawn(&mut self, f: ~fn()) {
+    pub fn spawn(&mut self, f: proc()) {
         let gen_body = self.gen_body.take();
         let notify_chan = self.opts.notify_chan.take();
         let name = self.opts.name.take();
@@ -399,7 +399,7 @@ impl TaskBuilder {
     }
 
     /// Runs a task, while transferring ownership of one argument to the child.
-    pub fn spawn_with<A:Send>(&mut self, arg: A, f: ~fn(v: A)) {
+    pub fn spawn_with<A:Send>(&mut self, arg: A, f: proc(v: A)) {
         let arg = Cell::new(arg);
         do self.spawn {
             f(arg.take());
@@ -419,7 +419,7 @@ impl TaskBuilder {
      * # Failure
      * Fails if a future_result was already set for this task.
      */
-    pub fn try<T:Send>(&mut self, f: ~fn() -> T) -> Result<T, ~Any> {
+    pub fn try<T:Send>(&mut self, f: proc() -> T) -> Result<T, ~Any> {
         let (po, ch) = stream::<T>();
 
         let result = self.future_result();
@@ -468,20 +468,20 @@ pub fn default_task_opts() -> TaskOpts {
 /// the provided unique closure.
 ///
 /// This function is equivalent to `task().spawn(f)`.
-pub fn spawn(f: ~fn()) {
+pub fn spawn(f: proc()) {
     let mut task = task();
     task.spawn(f)
 }
 
 /// Creates a child task unlinked from the current one. If either this
 /// task or the child task fails, the other will not be killed.
-pub fn spawn_unlinked(f: ~fn()) {
+pub fn spawn_unlinked(f: proc()) {
     let mut task = task();
     task.unlinked();
     task.spawn(f)
 }
 
-pub fn spawn_supervised(f: ~fn()) {
+pub fn spawn_supervised(f: proc()) {
     /*!
      * Creates a child task supervised by the current one. If the child
      * task fails, the parent will not be killed, but if the parent fails,
@@ -498,13 +498,13 @@ pub fn spawn_supervised(f: ~fn()) {
 /// (Note that this convenience wrapper still uses linked-failure, so the
 /// child's children will still be killable by the parent. For the fastest
 /// possible spawn mode, use task::task().unlinked().indestructible().spawn.)
-pub fn spawn_indestructible(f: ~fn()) {
+pub fn spawn_indestructible(f: proc()) {
     let mut task = task();
     task.indestructible();
     task.spawn(f)
 }
 
-pub fn spawn_with<A:Send>(arg: A, f: ~fn(v: A)) {
+pub fn spawn_with<A:Send>(arg: A, f: proc(v: A)) {
     /*!
      * Runs a task, while transferring ownership of one argument to the
      * child.
@@ -519,7 +519,7 @@ pub fn spawn_with<A:Send>(arg: A, f: ~fn(v: A)) {
     task.spawn_with(arg, f)
 }
 
-pub fn spawn_sched(mode: SchedMode, f: ~fn()) {
+pub fn spawn_sched(mode: SchedMode, f: proc()) {
     /*!
      * Creates a new task on a new or existing scheduler.
      *
@@ -537,7 +537,7 @@ pub fn spawn_sched(mode: SchedMode, f: ~fn()) {
     task.spawn(f)
 }
 
-pub fn try<T:Send>(f: ~fn() -> T) -> Result<T, ~Any> {
+pub fn try<T:Send>(f: proc() -> T) -> Result<T, ~Any> {
     /*!
      * Execute a function in another task and return either the return value
      * of the function or result::err.
@@ -1033,7 +1033,7 @@ fn test_add_wrapper() {
     let ch = Cell::new(ch);
     do b0.add_wrapper |body| {
         let ch = Cell::new(ch.take());
-        let result: ~fn() = || {
+        let result: proc() = || {
             let ch = ch.take();
             body();
             ch.send(());
@@ -1211,7 +1211,7 @@ fn test_spawn_sched_blocking() {
 }
 
 #[cfg(test)]
-fn avoid_copying_the_body(spawnfn: &fn(v: ~fn())) {
+fn avoid_copying_the_body(spawnfn: &fn(v: proc())) {
     let (p, ch) = stream::<uint>();
 
     let x = ~1;
@@ -1337,7 +1337,7 @@ fn test_child_doesnt_ref_parent() {
     // (well, it would if the constant were 8000+ - I lowered it to be more
     // valgrind-friendly. try this at home, instead..!)
     static generations: uint = 16;
-    fn child_no(x: uint) -> ~fn() {
+    fn child_no(x: uint) -> proc() {
         return || {
             if x < generations {
                 let mut t = task();

--- a/src/libstd/unstable/finally.rs
+++ b/src/libstd/unstable/finally.rs
@@ -54,7 +54,6 @@ impl<'self,T> Finally<T> for &'self fn() -> T {
     }
 }
 
-finally_fn!(~fn() -> T)
 finally_fn!(extern "Rust" fn() -> T)
 
 struct Finallyalizer<'self> {
@@ -107,14 +106,5 @@ fn test_compact() {
     fn but_always_run_this_function() { }
     do_some_fallible_work.finally(
         but_always_run_this_function);
-}
-
-#[test]
-fn test_owned() {
-    fn spawn_with_finalizer(f: ~fn()) {
-        do spawn { do f.finally { } }
-    }
-    let owned: ~fn() = || { };
-    spawn_with_finalizer(owned);
 }
 

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -35,7 +35,7 @@ for it to terminate.
 The executing thread has no access to a task pointer and will be using
 a normal large stack.
 */
-pub fn run_in_bare_thread(f: ~fn()) {
+pub fn run_in_bare_thread(f: proc()) {
     use cell::Cell;
     use rt::thread::Thread;
 


### PR DESCRIPTION
This makes `Cell`s no longer necessary in most cases.

r? @alexcrichton
