### PR TITLE
Allow piped stdout/stderr use uv_tty_t

### DIFF
--- a/src/librustuv/tty.rs
+++ b/src/librustuv/tty.rs
@@ -39,7 +39,8 @@ impl TtyWatcher {
         // Related:
         // - https://github.com/joyent/libuv/issues/982
         // - https://github.com/joyent/libuv/issues/988
-        if unsafe { uvll::guess_handle(fd) != uvll::UV_TTY as libc::c_int } {
+        let guess = unsafe { uvll::guess_handle(fd) };
+        if readable && guess != uvll::UV_TTY as libc::c_int {
             return Err(UvError(uvll::EBADF));
         }
 
@@ -99,6 +100,10 @@ impl RtioTTY for TtyWatcher {
             0 => Ok((width as int, height as int)),
             n => Err(uv_error_to_io_error(UvError(n)))
         }
+    }
+
+    fn isatty(&self) -> bool {
+        unsafe { uvll::guess_handle(self.fd) == uvll::UV_TTY as libc::c_int }
     }
 }
 

--- a/src/libstd/io/native/file.rs
+++ b/src/libstd/io/native/file.rs
@@ -167,6 +167,7 @@ impl rtio::RtioTTY for FileDesc {
     fn get_winsize(&mut self) -> Result<(int, int), IoError> {
         Err(super::unimpl())
     }
+    fn isatty(&self) -> bool { false }
 }
 
 impl Drop for FileDesc {

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -230,6 +230,7 @@ pub trait RtioTTY {
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError>;
     fn set_raw(&mut self, raw: bool) -> Result<(), IoError>;
     fn get_winsize(&mut self) -> Result<(int, int), IoError>;
+    fn isatty(&self) -> bool;
 }
 
 pub trait PausibleIdleCallback {


### PR DESCRIPTION
There are issues with reading stdin when it is actually attached to a pipe, but
I have run into no problems in writing to stdout/stderr when they are attached
to pipes.
