### PR TITLE
Disable priv in std::comm::Port, etc

### DIFF
--- a/src/libstd/comm.rs
+++ b/src/libstd/comm.rs
@@ -55,16 +55,17 @@ pub trait Peekable<T> {
     fn peek(&self) -> bool;
 }
 
-pub struct PortOne<T> { priv x: rtcomm::PortOne<T> }
-pub struct ChanOne<T> { priv x: rtcomm::ChanOne<T> }
+/* priv is disabled to allow users to get at traits like Select. */
+pub struct PortOne<T> { /* priv */ x: rtcomm::PortOne<T> }
+pub struct ChanOne<T> { /* priv */ x: rtcomm::ChanOne<T> }
 
 pub fn oneshot<T: Send>() -> (PortOne<T>, ChanOne<T>) {
     let (p, c) = rtcomm::oneshot();
     (PortOne { x: p }, ChanOne { x: c })
 }
 
-pub struct Port<T> { priv x: rtcomm::Port<T> }
-pub struct Chan<T> { priv x: rtcomm::Chan<T> }
+pub struct Port<T> { /* priv */ x: rtcomm::Port<T> }
+pub struct Chan<T> { /* priv */ x: rtcomm::Chan<T> }
 
 pub fn stream<T: Send>() -> (Port<T>, Chan<T>) {
     let (p, c) = rtcomm::stream();
@@ -158,7 +159,7 @@ impl<T: Send> Peekable<T> for Port<T> {
 }
 
 
-pub struct SharedChan<T> { priv x: rtcomm::SharedChan<T> }
+pub struct SharedChan<T> { /* priv */ x: rtcomm::SharedChan<T> }
 
 impl<T: Send> SharedChan<T> {
     pub fn new(c: Chan<T>) -> SharedChan<T> {
@@ -200,7 +201,7 @@ impl<T: Send> Clone for SharedChan<T> {
     }
 }
 
-pub struct SharedPort<T> { priv x: rtcomm::SharedPort<T> }
+pub struct SharedPort<T> { /* priv */ x: rtcomm::SharedPort<T> }
 
 impl<T: Send> SharedPort<T> {
     pub fn new(p: Port<T>) -> SharedPort<T> {


### PR DESCRIPTION
It's useful to allow users to get at the internal std::rc::comm::Port,
and other such fields, since they implement important traits like
Select.

See [rust-dev] "select on std::comm::Port and different types" at https://mail.mozilla.org/pipermail/rust-dev/2013-November/006735.html for background.
