### PR TITLE
Allow cross-compiling with mingw64.

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -231,7 +231,7 @@ CFG_LIB_NAME_x86_64-apple-darwin=lib$(1).dylib
 CFG_STATIC_LIB_NAME_x86_64-apple-darwin=lib$(1).a
 CFG_LIB_GLOB_x86_64-apple-darwin=lib$(1)-*.dylib
 CFG_LIB_DSYM_GLOB_x86_64-apple-darwin=lib$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_x86_64-apple-darwin := -Wall -g -fPIC -m64 -arch x86_64
+CFG_GCCISH_CFLAGS_x86_64-apple-darwin := -Wall -Werror -g -fPIC -m64 -arch x86_64
 CFG_GCCISH_CXXFLAGS_x86_64-apple-darwin := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_x86_64-apple-darwin := -dynamiclib -pthread  -framework CoreServices -m64
 CFG_GCCISH_DEF_FLAG_x86_64-apple-darwin := -Wl,-exported_symbols_list,
@@ -257,7 +257,7 @@ CFG_LIB_NAME_i686-apple-darwin=lib$(1).dylib
 CFG_STATIC_LIB_NAME_i686-apple-darwin=lib$(1).a
 CFG_LIB_GLOB_i686-apple-darwin=lib$(1)-*.dylib
 CFG_LIB_DSYM_GLOB_i686-apple-darwin=lib$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_i686-apple-darwin := -Wall -g -fPIC -m32 -arch i386
+CFG_GCCISH_CFLAGS_i686-apple-darwin := -Wall -Werror -g -fPIC -m32 -arch i386
 CFG_GCCISH_CXXFLAGS_i686-apple-darwin := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_i686-apple-darwin := -dynamiclib -pthread  -framework CoreServices -m32
 CFG_GCCISH_DEF_FLAG_i686-apple-darwin := -Wl,-exported_symbols_list,
@@ -396,7 +396,7 @@ CFG_LIB_NAME_i686-pc-mingw32=$(1).dll
 CFG_STATIC_LIB_NAME_i686-pc-mingw32=$(1).lib
 CFG_LIB_GLOB_i686-pc-mingw32=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_i686-pc-mingw32=$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_i686-pc-mingw32 := -Wall -g -m32 -march=i686 -D_WIN32_WINNT=0x0600 -I$(CFG_SRC_DIR)src/etc/mingw-fix-include
+CFG_GCCISH_CFLAGS_i686-pc-mingw32 := -Wall -Werror -g -m32 -march=i686 -D_WIN32_WINNT=0x0600 -I$(CFG_SRC_DIR)src/etc/mingw-fix-include
 CFG_GCCISH_CXXFLAGS_i686-pc-mingw32 := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_i686-pc-mingw32 := -shared -fPIC -g -m32
 CFG_GCCISH_DEF_FLAG_i686-pc-mingw32 :=
@@ -452,7 +452,7 @@ CFG_LIB_NAME_i686-w64-mingw32=$(1).dll
 CFG_STATIC_LIB_NAME_i686-w64-mingw32=$(1).lib
 CFG_LIB_GLOB_i686-w64-mingw32=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_i686-w64-mingw32=$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_i686-w64-mingw32 := -Wall -g -m32 -D_WIN32_WINNT=0x0600
+CFG_GCCISH_CFLAGS_i686-w64-mingw32 := -Wall -Werror -g -m32 -D_WIN32_WINNT=0x0600
 CFG_GCCISH_CXXFLAGS_i686-w64-mingw32 := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_i686-w64-mingw32 := -shared -g -m32
 CFG_GCCISH_DEF_FLAG_i686-w64-mingw32 :=
@@ -480,7 +480,7 @@ CFG_LIB_NAME_x86_64-w64-mingw32=$(1).dll
 CFG_STATIC_LIB_NAME_x86_64-w64-mingw32=$(1).lib
 CFG_LIB_GLOB_x86_64-w64-mingw32=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_x86_64-w64-mingw32=$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_x86_64-w64-mingw32 := -Wall -g -m64 -D_WIN32_WINNT=0x0600
+CFG_GCCISH_CFLAGS_x86_64-w64-mingw32 := -Wall -Werror -g -m64 -D_WIN32_WINNT=0x0600
 CFG_GCCISH_CXXFLAGS_x86_64-w64-mingw32 := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_x86_64-w64-mingw32 := -shared -g -m64
 CFG_GCCISH_DEF_FLAG_x86_64-w64-mingw32 :=

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -257,7 +257,7 @@ CFG_LIB_NAME_i686-apple-darwin=lib$(1).dylib
 CFG_STATIC_LIB_NAME_i686-apple-darwin=lib$(1).a
 CFG_LIB_GLOB_i686-apple-darwin=lib$(1)-*.dylib
 CFG_LIB_DSYM_GLOB_i686-apple-darwin=lib$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_i686-apple-darwin := -Wall -Werror -g -fPIC -m32 -arch i386
+CFG_GCCISH_CFLAGS_i686-apple-darwin := -Wall -g -fPIC -m32 -arch i386
 CFG_GCCISH_CXXFLAGS_i686-apple-darwin := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_i686-apple-darwin := -dynamiclib -pthread  -framework CoreServices -m32
 CFG_GCCISH_DEF_FLAG_i686-apple-darwin := -Wl,-exported_symbols_list,
@@ -302,10 +302,11 @@ CFG_RUN_TARG_arm-linux-androideabi=
 RUSTC_FLAGS_arm-linux-androideabi :=--android-cross-path=$(CFG_ANDROID_CROSS_PATH)
 
 # arm-unknown-linux-gnueabihf configuration
-CC_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-gcc
-CXX_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-g++
-CPP_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-gcc -E
-AR_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-ar
+CROSS_PREFIX_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-
+CC_arm-unknown-linux-gnueabihf=gcc
+CXX_arm-unknown-linux-gnueabihf=g++
+CPP_arm-unknown-linux-gnueabihf=gcc -E
+AR_arm-unknown-linux-gnueabihf=ar
 CFG_LIB_NAME_arm-unknown-linux-gnueabihf=lib$(1).so
 CFG_STATIC_LIB_NAME_arm-unknown-linux-gnueabihf=lib$(1).a
 CFG_LIB_GLOB_arm-unknown-linux-gnueabihf=lib$(1)-*.so
@@ -324,15 +325,17 @@ CFG_WINDOWSY_arm-unknown-linux-gnueabihf :=
 CFG_UNIXY_arm-unknown-linux-gnueabihf := 1
 CFG_PATH_MUNGE_arm-unknown-linux-gnueabihf := true
 CFG_LDPATH_arm-unknown-linux-gnueabihf :=
-CFG_RUN_arm-unknown-linux-gnueabihf=
-CFG_RUN_TARG_arm-unknown-linux-gnueabihf=
-RUSTC_FLAGS_arm-unknown-linux-gnueabihf := --linker=$(CC_arm-unknown-linux-gnueabihf)
+CFG_RUN_arm-unknown-linux-gnueabihf=$(2)
+CFG_RUN_TARG_arm-unknown-linux-gnueabihf=$(call CFG_RUN_arm-unknown-linux-gnueabihf,,$(2))
+RUSTC_FLAGS_arm-unknown-linux-gnueabihf :=
+RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabihf := --linker=$(CROSS_PREFIX_arm-unknown-linux-gnueabihf)$(CC_arm-unknown-linux-gnueabihf)
 
 # arm-unknown-linux-gnueabi configuration
-CC_arm-unknown-linux-gnueabi=arm-linux-gnueabi-gcc
-CXX_arm-unknown-linux-gnueabi=arm-linux-gnueabi-g++
-CPP_arm-unknown-linux-gnueabi=arm-linux-gnueabi-gcc -E
-AR_arm-unknown-linux-gnueabi=arm-linux-gnueabi-ar
+CROSS_PREFIX_arm-unknown-linux-gnueabi=arm-linux-gnueabi-
+CC_arm-unknown-linux-gnueabi=gcc
+CXX_arm-unknown-linux-gnueabi=g++
+CPP_arm-unknown-linux-gnueabi=gcc -E
+AR_arm-unknown-linux-gnueabi=ar
 CFG_LIB_NAME_arm-unknown-linux-gnueabi=lib$(1).so
 CFG_STATIC_LIB_NAME_arm-unknown-linux-gnueabi=lib$(1).a
 CFG_LIB_GLOB_arm-unknown-linux-gnueabi=lib$(1)-*.so
@@ -351,9 +354,10 @@ CFG_WINDOWSY_arm-unknown-linux-gnueabi :=
 CFG_UNIXY_arm-unknown-linux-gnueabi := 1
 CFG_PATH_MUNGE_arm-unknown-linux-gnueabi := true
 CFG_LDPATH_arm-unknown-linux-gnueabi :=
-CFG_RUN_arm-unknown-linux-gnueabi=
-CFG_RUN_TARG_arm-unknown-linux-gnueabi=
-RUSTC_FLAGS_arm-unknown-linux-gnueabi := --linker=$(CC_arm-unknown-linux-gnueabi)
+CFG_RUN_arm-unknown-linux-gnueabi=$(2)
+CFG_RUN_TARG_arm-unknown-linux-gnueabi=$(call CFG_RUN_arm-unknown-linux-gnueabi,,$(2))
+RUSTC_FLAGS_arm-unknown-linux-gnueabi :=
+RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabi := --linker=$(CROSS_PREFIX_arm-unknown-linux-gnueabi)$(CC_arm-unknown-linux-gnueabi)
 
 # mips-unknown-linux-gnu configuration
 CC_mips-unknown-linux-gnu=mips-linux-gnu-gcc
@@ -399,7 +403,7 @@ CFG_GCCISH_PRE_LIB_FLAGS_i686-pc-mingw32 :=
 CFG_GCCISH_POST_LIB_FLAGS_i686-pc-mingw32 :=
 CFG_DEF_SUFFIX_i686-pc-mingw32 := .mingw32.def
 CFG_INSTALL_NAME_i686-pc-mingw32 =
-CFG_LIBUV_LINK_FLAGS_i686-pc-mingw32 := -lWs2_32 -lpsapi -liphlpapi
+CFG_LIBUV_LINK_FLAGS_i686-pc-mingw32 := -lws2_32 -lpsapi -liphlpapi
 CFG_LLVM_BUILD_ENV_i686-pc-mingw32 := CPATH=$(CFG_SRC_DIR)src/etc/mingw-fix-include
 CFG_EXE_SUFFIX_i686-pc-mingw32 := .exe
 CFG_WINDOWSY_i686-pc-mingw32 := 1
@@ -437,24 +441,53 @@ CFG_LDPATH_i586-mingw32msvc :=
 CFG_RUN_i586-mingw32msvc=
 CFG_RUN_TARG_i586-mingw32msvc=
 
+# i686-w64-mingw32 configuration
+CROSS_PREFIX_i686-w64-mingw32=i686-w64-mingw32-
+CC_i686-w64-mingw32=gcc
+CXX_i686-w64-mingw32=g++
+CPP_i686-w64-mingw32=gcc -E
+AR_i686-w64-mingw32=ar
+CFG_LIB_NAME_i686-w64-mingw32=$(1).dll
+CFG_STATIC_LIB_NAME_i686-w64-mingw32=$(1).lib
+CFG_LIB_GLOB_i686-w64-mingw32=$(1)-*.dll
+CFG_LIB_DSYM_GLOB_i686-w64-mingw32=$(1)-*.dylib.dSYM
+CFG_GCCISH_CFLAGS_i686-w64-mingw32 := -Wall -g -m32 -D_WIN32_WINNT=0x0600
+CFG_GCCISH_CXXFLAGS_i686-w64-mingw32 := -fno-rtti
+CFG_GCCISH_LINK_FLAGS_i686-w64-mingw32 := -shared -g -m32
+CFG_GCCISH_DEF_FLAG_i686-w64-mingw32 :=
+CFG_GCCISH_PRE_LIB_FLAGS_i686-w64-mingw32 :=
+CFG_GCCISH_POST_LIB_FLAGS_i686-w64-mingw32 :=
+CFG_DEF_SUFFIX_i686-w64-mingw32 := .mingw32.def
+CFG_INSTALL_NAME_i686-w64-mingw32 =
+CFG_LIBUV_LINK_FLAGS_i686-w64-mingw32 := -lws2_32 -lpsapi -liphlpapi
+CFG_EXE_SUFFIX_i686-w64-mingw32 := .exe
+CFG_WINDOWSY_i686-w64-mingw32 := 1
+CFG_UNIXY_i686-w64-mingw32 :=
+CFG_PATH_MUNGE_i686-w64-mingw32 :=
+CFG_LDPATH_i686-w64-mingw32 :=$(CFG_LDPATH_i686-w64-mingw32):$(PATH)
+CFG_RUN_i686-w64-mingw32=PATH="$(CFG_LDPATH_i686-w64-mingw32):$(1)" $(2)
+CFG_RUN_TARG_i686-w64-mingw32=$(call CFG_RUN_i686-w64-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
+RUSTC_CROSS_FLAGS_i686-w64-mingw32 := --linker=$(CROSS_PREFIX_i686-w64-mingw32)$(CC_i686-w64-mingw32)
+
 # x86_64-w64-mingw32 configuration
-CC_x86_64-w64-mingw32=$(CC)
-CXX_x86_64-w64-mingw32=$(CXX)
-CPP_x86_64-w64-mingw32=$(CPP)
-AR_x86_64-w64-mingw32=$(AR)
+CROSS_PREFIX_x86_64-w64-mingw32=x86_64-w64-mingw32-
+CC_x86_64-w64-mingw32=gcc
+CXX_x86_64-w64-mingw32=g++
+CPP_x86_64-w64-mingw32=gcc -E
+AR_x86_64-w64-mingw32=ar
 CFG_LIB_NAME_x86_64-w64-mingw32=$(1).dll
 CFG_STATIC_LIB_NAME_x86_64-w64-mingw32=$(1).lib
 CFG_LIB_GLOB_x86_64-w64-mingw32=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_x86_64-w64-mingw32=$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_x86_64-w64-mingw32 := -Wall -Werror -g -m64 -D_WIN32_WINNT=0x0600
+CFG_GCCISH_CFLAGS_x86_64-w64-mingw32 := -Wall -g -m64 -D_WIN32_WINNT=0x0600
 CFG_GCCISH_CXXFLAGS_x86_64-w64-mingw32 := -fno-rtti
-CFG_GCCISH_LINK_FLAGS_x86_64-w64-mingw32 := -shared -fPIC -g -m64
+CFG_GCCISH_LINK_FLAGS_x86_64-w64-mingw32 := -shared -g -m64
 CFG_GCCISH_DEF_FLAG_x86_64-w64-mingw32 :=
 CFG_GCCISH_PRE_LIB_FLAGS_x86_64-w64-mingw32 :=
 CFG_GCCISH_POST_LIB_FLAGS_x86_64-w64-mingw32 :=
 CFG_DEF_SUFFIX_x86_64-w64-mingw32 := .mingw32.def
 CFG_INSTALL_NAME_x86_64-w64-mingw32 =
-CFG_LIBUV_LINK_FLAGS_x86_64-w64-mingw32 := -lWs2_32 -lpsapi -liphlpapi
+CFG_LIBUV_LINK_FLAGS_x86_64-w64-mingw32 := -lws2_32 -lpsapi -liphlpapi
 CFG_EXE_SUFFIX_x86_64-w64-mingw32 := .exe
 CFG_WINDOWSY_x86_64-w64-mingw32 := 1
 CFG_UNIXY_x86_64-w64-mingw32 :=
@@ -462,6 +495,7 @@ CFG_PATH_MUNGE_x86_64-w64-mingw32 :=
 CFG_LDPATH_x86_64-w64-mingw32 :=$(CFG_LDPATH_x86_64-w64-mingw32):$(PATH)
 CFG_RUN_x86_64-w64-mingw32=PATH="$(CFG_LDPATH_x86_64-w64-mingw32):$(1)" $(2)
 CFG_RUN_TARG_x86_64-w64-mingw32=$(call CFG_RUN_x86_64-w64-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
+RUSTC_CROSS_FLAGS_x86_64-w64-mingw32 := --linker=$(CROSS_PREFIX_x86_64-w64-mingw32)$(CC_x86_64-w64-mingw32)
 
 # x86_64-unknown-freebsd configuration
 CC_x86_64-unknown-freebsd=$(CC)
@@ -499,6 +533,16 @@ ifdef CFG_CCACHE_BASEDIR
 endif
 
 define CFG_MAKE_TOOLCHAIN
+  # Prepend the tools with their prefix if cross compiling
+  ifneq ($(CFG_BUILD),$(1))
+	CC_$(1)=$(CROSS_PREFIX_$(1))$(CC_$(1))
+	CXX_$(1)=$(CROSS_PREFIX_$(1))$(CXX_$(1))
+	CPP_$(1)=$(CROSS_PREFIX_$(1))$(CPP_$(1))
+	AR_$(1)=$(CROSS_PREFIX_$(1))$(AR_$(1))
+
+	RUSTC_FLAGS_$(1)=$(RUSTC_CROSS_FLAGS_$(1))
+  endif
+
   CFG_COMPILE_C_$(1) = $$(CC_$(1))  \
         $$(CFG_GCCISH_CFLAGS)      \
         $$(CFG_GCCISH_CFLAGS_$(1)) \

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -231,7 +231,7 @@ CFG_LIB_NAME_x86_64-apple-darwin=lib$(1).dylib
 CFG_STATIC_LIB_NAME_x86_64-apple-darwin=lib$(1).a
 CFG_LIB_GLOB_x86_64-apple-darwin=lib$(1)-*.dylib
 CFG_LIB_DSYM_GLOB_x86_64-apple-darwin=lib$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_x86_64-apple-darwin := -Wall -Werror -g -fPIC -m64 -arch x86_64
+CFG_GCCISH_CFLAGS_x86_64-apple-darwin := -Wall -g -fPIC -m64 -arch x86_64
 CFG_GCCISH_CXXFLAGS_x86_64-apple-darwin := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_x86_64-apple-darwin := -dynamiclib -pthread  -framework CoreServices -m64
 CFG_GCCISH_DEF_FLAG_x86_64-apple-darwin := -Wl,-exported_symbols_list,
@@ -300,6 +300,7 @@ CFG_LDPATH_arm-linux-androideabi :=
 CFG_RUN_arm-linux-androideabi=
 CFG_RUN_TARG_arm-linux-androideabi=
 RUSTC_FLAGS_arm-linux-androideabi :=--android-cross-path=$(CFG_ANDROID_CROSS_PATH)
+RUSTC_CROSS_FLAGS_arm-linux-androideabi :=--android-cross-path=$(CFG_ANDROID_CROSS_PATH)
 
 # arm-unknown-linux-gnueabihf configuration
 CROSS_PREFIX_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-
@@ -395,7 +396,7 @@ CFG_LIB_NAME_i686-pc-mingw32=$(1).dll
 CFG_STATIC_LIB_NAME_i686-pc-mingw32=$(1).lib
 CFG_LIB_GLOB_i686-pc-mingw32=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_i686-pc-mingw32=$(1)-*.dylib.dSYM
-CFG_GCCISH_CFLAGS_i686-pc-mingw32 := -Wall -Werror -g -m32 -march=i686 -D_WIN32_WINNT=0x0600 -I$(CFG_SRC_DIR)src/etc/mingw-fix-include
+CFG_GCCISH_CFLAGS_i686-pc-mingw32 := -Wall -g -m32 -march=i686 -D_WIN32_WINNT=0x0600 -I$(CFG_SRC_DIR)src/etc/mingw-fix-include
 CFG_GCCISH_CXXFLAGS_i686-pc-mingw32 := -fno-rtti
 CFG_GCCISH_LINK_FLAGS_i686-pc-mingw32 := -shared -fPIC -g -m32
 CFG_GCCISH_DEF_FLAG_i686-pc-mingw32 :=

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -329,7 +329,7 @@ CFG_LDPATH_arm-unknown-linux-gnueabihf :=
 CFG_RUN_arm-unknown-linux-gnueabihf=$(2)
 CFG_RUN_TARG_arm-unknown-linux-gnueabihf=$(call CFG_RUN_arm-unknown-linux-gnueabihf,,$(2))
 RUSTC_FLAGS_arm-unknown-linux-gnueabihf :=
-RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabihf := --linker=$(CROSS_PREFIX_arm-unknown-linux-gnueabihf)$(CC_arm-unknown-linux-gnueabihf)
+RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabihf := --linker=$(CROSS_PREFIX_arm-unknown-linux-gnueabihf)$(CXX_arm-unknown-linux-gnueabihf)
 
 # arm-unknown-linux-gnueabi configuration
 CROSS_PREFIX_arm-unknown-linux-gnueabi=arm-linux-gnueabi-
@@ -358,7 +358,7 @@ CFG_LDPATH_arm-unknown-linux-gnueabi :=
 CFG_RUN_arm-unknown-linux-gnueabi=$(2)
 CFG_RUN_TARG_arm-unknown-linux-gnueabi=$(call CFG_RUN_arm-unknown-linux-gnueabi,,$(2))
 RUSTC_FLAGS_arm-unknown-linux-gnueabi :=
-RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabi := --linker=$(CROSS_PREFIX_arm-unknown-linux-gnueabi)$(CC_arm-unknown-linux-gnueabi)
+RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabi := --linker=$(CROSS_PREFIX_arm-unknown-linux-gnueabi)$(CXX_arm-unknown-linux-gnueabi)
 
 # mips-unknown-linux-gnu configuration
 CC_mips-unknown-linux-gnu=mips-linux-gnu-gcc
@@ -468,7 +468,7 @@ CFG_PATH_MUNGE_i686-w64-mingw32 :=
 CFG_LDPATH_i686-w64-mingw32 :=$(CFG_LDPATH_i686-w64-mingw32):$(PATH)
 CFG_RUN_i686-w64-mingw32=PATH="$(CFG_LDPATH_i686-w64-mingw32):$(1)" $(2)
 CFG_RUN_TARG_i686-w64-mingw32=$(call CFG_RUN_i686-w64-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
-RUSTC_CROSS_FLAGS_i686-w64-mingw32 := --linker=$(CROSS_PREFIX_i686-w64-mingw32)$(CC_i686-w64-mingw32)
+RUSTC_CROSS_FLAGS_i686-w64-mingw32 := --linker=$(CROSS_PREFIX_i686-w64-mingw32)$(CXX_i686-w64-mingw32)
 
 # x86_64-w64-mingw32 configuration
 CROSS_PREFIX_x86_64-w64-mingw32=x86_64-w64-mingw32-
@@ -496,7 +496,7 @@ CFG_PATH_MUNGE_x86_64-w64-mingw32 :=
 CFG_LDPATH_x86_64-w64-mingw32 :=$(CFG_LDPATH_x86_64-w64-mingw32):$(PATH)
 CFG_RUN_x86_64-w64-mingw32=PATH="$(CFG_LDPATH_x86_64-w64-mingw32):$(1)" $(2)
 CFG_RUN_TARG_x86_64-w64-mingw32=$(call CFG_RUN_x86_64-w64-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
-RUSTC_CROSS_FLAGS_x86_64-w64-mingw32 := --linker=$(CROSS_PREFIX_x86_64-w64-mingw32)$(CC_x86_64-w64-mingw32)
+RUSTC_CROSS_FLAGS_x86_64-w64-mingw32 := --linker=$(CROSS_PREFIX_x86_64-w64-mingw32)$(CXX_x86_64-w64-mingw32)
 
 # x86_64-unknown-freebsd configuration
 CC_x86_64-unknown-freebsd=$(CC)

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -23,39 +23,6 @@
 # fit the experimental data (i.e., I was able to get the system
 # working under these assumptions).
 
-# Hack for passing flags into LIBUV, see below.
-define DEF_LIBUV_FLAGS
-ifeq ($(HOST_$(1)), i386)
-	ifneq (,$(findstring mingw32,$(OSTYPE_$(1))))
-		# Don't add -fPIC since it's ignored for this target
-		# and it will just cause the build to fail due to -Werror
-		LIBUV_FLAGS_$(1) = -m32 -I$(S)src/etc/mingw-fix-include
-	else
-		LIBUV_FLAGS_$(1) = -m32 -fPIC -I$(S)src/etc/mingw-fix-include
-	endif
-else ifeq ($(HOST_$(1)), x86_64)
-	ifneq (,$(findstring mingw32,$(OSTYPE_$(1))))
-		# Don't add -fPIC since it's ignored for this target
-		# and it will just cause the build to fail due to -Werror
-		LIBUV_FLAGS_$(1) = -m64
-	else
-		LIBUV_FLAGS_$(1) = -m64 -fPIC
-	endif
-else ifeq ($(HOST_$(1)), arm)
-	ifeq ($(OSTYPE_$(1)), apple-darwin)
-		IOS_SDK := $(shell xcrun --show-sdk-path -sdk iphoneos 2>/dev/null)
-		LIBUV_FLAGS_$(1) = -fPIC -std=gnu99 -I$(IOS_SDK)/usr/include -I$(IOS_SDK)/usr/include/c++/4.2.1
-	else
-		LIBUV_FLAGS_$(1) = -fPIC -std=gnu99
-	endif
-else ifeq ($(HOST_$(1)), mips)
-	LIBUV_FLAGS_$(1) = -fPIC -mips32r2 -msoft-float -mabi=32
-else
-	LIBUV_FLAGS_$(1) = -fPIC -std=gnu99
-endif
-endef
-$(foreach t,$(CFG_TARGET),$(eval $(call DEF_LIBUV_FLAGS,$(t))))
-
 # when we're doing a snapshot build, we intentionally degrade as many
 # features in libuv and the runtime as possible, to ease portability.
 
@@ -238,15 +205,15 @@ $$(LIBUV_MAKEFILE_$(1)): $$(LIBUV_DEPS)
 ifdef CFG_WINDOWSY_$(1)
 $$(LIBUV_LIB_$(1)): $$(LIBUV_DEPS)
 	$$(Q)$$(MAKE) -C $$(S)src/libuv -f Makefile.mingw \
-		CC="$$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) $$(LIBUV_FLAGS_$(1)) $$(SNAP_DEFINES)" \
+		CC="$$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) $$(SNAP_DEFINES)" \
 		AR="$$(AR_$(1))" \
 		V=$$(VERBOSE)
 	$$(Q)cp $$(S)src/libuv/libuv.a $$@
 else
 $$(LIBUV_LIB_$(1)): $$(LIBUV_DEPS) $$(LIBUV_MAKEFILE_$(1))
 	$$(Q)$$(MAKE) -C $$(@D) \
-		CFLAGS="$$(CFG_GCCISH_CFLAGS_$(1)) $$(LIBUV_FLAGS_$(1)) $$(SNAP_DEFINES)" \
-		LDFLAGS="$$(CFG_GCCISH_LINK_FLAGS_$(1)) $$(LIBUV_FLAGS_$(1))" \
+		CFLAGS="$$(CFG_GCCISH_CFLAGS_$(1)) $$(SNAP_DEFINES)" \
+		LDFLAGS="$$(CFG_GCCISH_LINK_FLAGS_$(1))" \
 		CC="$$(CC_$(1))" \
 		CXX="$$(CXX_$(1))" \
 		AR="$$(AR_$(1))" \

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -192,6 +192,9 @@ LIBUV_LIB_$(1) := $$(RT_OUTPUT_DIR_$(1))/libuv/$$(LIBUV_NAME_$(1))
 
 LIBUV_MAKEFILE_$(1) := $$(CFG_BUILD_DIR)$$(RT_OUTPUT_DIR_$(1))/libuv/Makefile
 
+# libuv triggers a few warnings on some platforms
+LIBUV_CFLAGS_$(1) := $(subst -Werror,,$(CFG_GCCISH_CFLAGS_$(1)))
+
 $$(LIBUV_MAKEFILE_$(1)): $$(LIBUV_DEPS)
 	(cd $(S)src/libuv/ && \
 	 $$(CFG_PYTHON) ./gyp_uv.py -f make -Dtarget_arch=$$(LIBUV_ARCH_$(1)) \
@@ -205,14 +208,16 @@ $$(LIBUV_MAKEFILE_$(1)): $$(LIBUV_DEPS)
 ifdef CFG_WINDOWSY_$(1)
 $$(LIBUV_LIB_$(1)): $$(LIBUV_DEPS)
 	$$(Q)$$(MAKE) -C $$(S)src/libuv -f Makefile.mingw \
-		CC="$$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) $$(SNAP_DEFINES)" \
+		LDFLAGS="$$(CFG_GCCISH_LINK_FLAGS_$(1))" \
+		CC="$$(CC_$(1)) $$(LIBUV_CFLAGS_$(1)) $$(SNAP_DEFINES)" \
+		CXX="$$(CXX_$(1))" \
 		AR="$$(AR_$(1))" \
 		V=$$(VERBOSE)
 	$$(Q)cp $$(S)src/libuv/libuv.a $$@
 else
 $$(LIBUV_LIB_$(1)): $$(LIBUV_DEPS) $$(LIBUV_MAKEFILE_$(1))
 	$$(Q)$$(MAKE) -C $$(@D) \
-		CFLAGS="$$(CFG_GCCISH_CFLAGS_$(1)) $$(SNAP_DEFINES)" \
+		CFLAGS="$$(LIBUV_CFLAGS_$(1)) $$(SNAP_DEFINES)" \
 		LDFLAGS="$$(CFG_GCCISH_LINK_FLAGS_$(1))" \
 		CC="$$(CC_$(1))" \
 		CXX="$$(CXX_$(1))" \

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -85,11 +85,16 @@ pub fn default_configuration(sess: Session) ->
         abi::Mips =>   (@"big",    @"mips",   @"32")
     };
 
+    let fam = match sess.targ_cfg.os {
+        abi::OsWin32 => @"windows",
+        _ => @"unix"
+    };
+
     let mk = attr::mk_name_value_item_str;
     return ~[ // Target bindings.
-         attr::mk_word_item(os::FAMILY.to_managed()),
+         attr::mk_word_item(fam),
          mk(@"target_os", tos),
-         mk(@"target_family", os::FAMILY.to_managed()),
+         mk(@"target_family", fam),
          mk(@"target_arch", arch),
          mk(@"target_endian", end),
          mk(@"target_word_size", wordsz),

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -724,5 +724,5 @@ extern {
 extern {}
 
 #[cfg(target_os = "win32")]
-#[link_args = "-lWs2_32 -lpsapi -liphlpapi"]
+#[link_args = "-lws2_32 -lpsapi -liphlpapi"]
 extern {}

--- a/src/rt/rust_upcall.c
+++ b/src/rt/rust_upcall.c
@@ -25,14 +25,24 @@ typedef int _Unwind_Action;
 struct _Unwind_Context;
 struct _Unwind_Exception;
 
-#ifdef __SEH__
-#  define PERSONALITY_FUNC __gxx_personality_seh0
+#if __USING_SJLJ_EXCEPTIONS__
+#   define PERSONALITY_FUNC __gxx_personality_sj0
 #else
-#  ifdef __USING_SJLJ_EXCEPTIONS__
-#    define PERSONALITY_FUNC __gxx_personality_sjlj
-#  else
-#    define PERSONALITY_FUNC __gxx_personality_v0
-#  endif
+#   ifdef __SEH__
+#       define PERSONALITY_FUNC __gxx_personality_seh0
+#   else
+#       define PERSONALITY_FUNC __gxx_personality_v0
+#   endif
+#endif
+
+#if __USING_SJLJ_EXCEPTIONS__
+void _Unwind_SjLj_Resume(struct _Unwind_Exception* exception_object);
+
+void _Unwind_Resume(struct _Unwind_Exception* exception_object) {
+    _Unwind_SjLj_Resume(exception_object);
+}
+#else
+extern void _Unnwind_Resume(struct _Unwind_Exception* exception_object);
 #endif
 
 _Unwind_Reason_Code

--- a/src/rt/rust_upcall.c
+++ b/src/rt/rust_upcall.c
@@ -35,16 +35,6 @@ struct _Unwind_Exception;
 #   endif
 #endif
 
-#if __USING_SJLJ_EXCEPTIONS__
-void _Unwind_SjLj_Resume(struct _Unwind_Exception* exception_object);
-
-void _Unwind_Resume(struct _Unwind_Exception* exception_object) {
-    _Unwind_SjLj_Resume(exception_object);
-}
-#else
-extern void _Unnwind_Resume(struct _Unwind_Exception* exception_object);
-#endif
-
 _Unwind_Reason_Code
 PERSONALITY_FUNC(int version,
                      _Unwind_Action actions,

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -49,3 +49,4 @@ rust_get_test_int
 rust_pthread_mutex_t_size
 rust_pthread_cond_t_size
 rust_crit_section_size
+_Unwind_Resume

--- a/src/rt/rustrt.def.in
+++ b/src/rt/rustrt.def.in
@@ -49,4 +49,3 @@ rust_get_test_int
 rust_pthread_mutex_t_size
 rust_pthread_cond_t_size
 rust_crit_section_size
-_Unwind_Resume


### PR DESCRIPTION
With these changes I was able to cross compile for windows from a linux box. (Using the mingw-w64 package on Debian Testing).

Fixed a bug where the `target_family` cfg would be wrong when targeting something with a different value than the host. (i.e windows -> unix or unix -> windows).

Also, removed `LIBUV_FLAGS` in `mk/rt.mk` because of the redundancy between it and `CFG_GCCISH_CFLAGS_(target)`.

After this we can create a snapshot and migrate to mingw64 instead of mingw32.
