### PR TITLE
Move more of the exportation burden into privacy

### DIFF
--- a/src/test/auxiliary/privacy_reexport.rs
+++ b/src/test/auxiliary/privacy_reexport.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use bar = foo;
+
+mod foo {
+    pub fn frob() {}
+}

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -57,6 +57,11 @@ pub trait C { //~ ERROR: missing documentation
 #[allow(missing_doc)] pub trait D {}
 
 impl Foo {
+    pub fn foo() {}
+    fn bar() {}
+}
+
+impl PubFoo {
     pub fn foo() {} //~ ERROR: missing documentation
     /// dox
     pub fn foo1() {}

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -31,6 +31,12 @@ mod bar {
         fn bar2(&self) {}
     }
 
+    trait B {
+        fn foo() -> Self;
+    }
+
+    impl B for int { fn foo() -> int { 3 } }
+
     pub enum Enum {
         priv Priv,
         Pub
@@ -108,6 +114,10 @@ mod foo {
         ::bar::baz::A.bar2();   //~ ERROR: struct `A` is inaccessible
                                 //~^ ERROR: method `bar2` is private
                                 //~^^ NOTE: module `baz` is private
+
+        let _: int =
+        ::bar::B::foo();        //~ ERROR: method `foo` is inaccessible
+                                //~^ NOTE: trait `B` is private
         ::lol();
 
         ::bar::Priv; //~ ERROR: variant `Priv` is private

--- a/src/test/run-pass/privacy-reexport.rs
+++ b/src/test/run-pass/privacy-reexport.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:privacy_reexport.rs
+
+extern mod privacy_reexport;
+
+fn main() {
+    privacy_reexport::bar::frob();
+}


### PR DESCRIPTION
I added a test case which does not compile today, and required changes on
privacy's side of things to get right. Additionally, this moves a good bit of
logic which did not belong in reachability into privacy.

All of reachability should solely be responsible for determining what the
reachable surface area of a crate is given the exported surface area (where the
exported surface area is that which is usable by external crates).

Privacy will now correctly figure out what's exported by deeply looking
through reexports. Previously if a module were reexported under another name,
nothing in the module would actually get exported in the executable. I also
consolidated the phases of privacy to be clearer about what's an input to what.
The privacy checking pass no longer uses the notion of an "all public" path, and
the embargo visitor is no longer an input to the checking pass.

Currently the embargo visitor is built as a saturating analysis because it's
unknown what portions of the AST are going to get re-exported.

This also cracks down on exported methods from impl blocks and trait blocks. If you implement a private trait, none of the symbols are exported, and if you have an impl for a private type none of the symbols are exported either. On the other hand, if you implement a public trait for a private type, the symbols are still exported. I'm unclear on whether this last part is correct, but librustc will fail to link unless it's in place.
