### PR TITLE
std::rand: move TaskRng off @mut.

### DIFF
--- a/src/libstd/rand/distributions/mod.rs
+++ b/src/libstd/rand/distributions/mod.rs
@@ -444,17 +444,17 @@ mod tests {
     fn test_rand_sample() {
         let mut rand_sample = RandSample::<ConstRand>;
 
-        assert_eq!(*rand_sample.sample(task_rng()), 0);
-        assert_eq!(*rand_sample.ind_sample(task_rng()), 0);
+        assert_eq!(*rand_sample.sample(&mut task_rng()), 0);
+        assert_eq!(*rand_sample.ind_sample(&mut task_rng()), 0);
     }
 
     #[test]
     fn test_normal() {
         let mut norm = Normal::new(10.0, 10.0);
-        let rng = task_rng();
+        let mut rng = task_rng();
         for _ in range(0, 1000) {
-            norm.sample(rng);
-            norm.ind_sample(rng);
+            norm.sample(&mut rng);
+            norm.ind_sample(&mut rng);
         }
     }
     #[test]
@@ -466,10 +466,10 @@ mod tests {
     #[test]
     fn test_exp() {
         let mut exp = Exp::new(10.0);
-        let rng = task_rng();
+        let mut rng = task_rng();
         for _ in range(0, 1000) {
-            assert!(exp.sample(rng) >= 0.0);
-            assert!(exp.ind_sample(rng) >= 0.0);
+            assert!(exp.sample(&mut rng) >= 0.0);
+            assert!(exp.ind_sample(&mut rng) >= 0.0);
         }
     }
     #[test]

--- a/src/libstd/rand/distributions/range.rs
+++ b/src/libstd/rand/distributions/range.rs
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_integers() {
-        let rng = task_rng();
+        let mut rng = task_rng();
         macro_rules! t (
             ($($ty:ty),*) => {{
                 $(
@@ -193,9 +193,9 @@ mod tests {
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
                         for _ in range(0, 1000) {
-                            let v = sampler.sample(rng);
+                            let v = sampler.sample(&mut rng);
                             assert!(low <= v && v < high);
-                            let v = sampler.ind_sample(rng);
+                            let v = sampler.ind_sample(&mut rng);
                             assert!(low <= v && v < high);
                         }
                     }
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_floats() {
-        let rng = task_rng();
+        let mut rng = task_rng();
         macro_rules! t (
             ($($ty:ty),*) => {{
                 $(
@@ -219,9 +219,9 @@ mod tests {
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
                         for _ in range(0, 1000) {
-                            let v = sampler.sample(rng);
+                            let v = sampler.sample(&mut rng);
                             assert!(low <= v && v < high);
-                            let v = sampler.ind_sample(rng);
+                            let v = sampler.ind_sample(&mut rng);
                             assert!(low <= v && v < high);
                         }
                     }

--- a/src/test/compile-fail/task-rng-isnt-sendable.rs
+++ b/src/test/compile-fail/task-rng-isnt-sendable.rs
@@ -1,0 +1,18 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ensure that the TaskRng isn't/doesn't become accidentally sendable.
+
+fn test_send<S: Send>() {}
+
+pub fn main() {
+    test_send::<::std::rand::TaskRng>();
+    //~^ ERROR: incompatible type `std::rand::TaskRng`, which does not fulfill `Send`
+}


### PR DESCRIPTION
Replace with some unsafe code by storing a pointer into TLS-owned heap
data.
