### PR TITLE
Concatenating adjacent string literals

### DIFF
--- a/src/test/run-pass/adjacent-string-0.rs
+++ b/src/test/run-pass/adjacent-string-0.rs
@@ -1,0 +1,15 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    assert_eq!("f" "o" "o", "foo");
+    assert_eq!(~"f" "o" "o", ~"foo");
+    assert_eq!(@"f" "o" "o", @"foo");
+}

--- a/src/test/run-pass/adjacent-string-1.rs
+++ b/src/test/run-pass/adjacent-string-1.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let x = "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog"
+            "string";
+    println(x);
+}

--- a/src/test/run-pass/adjacent-string-2.rs
+++ b/src/test/run-pass/adjacent-string-2.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let x = "foo " // foo
+            "and " /* and */
+            "bar"; // bar
+    let y = "foo \
+             and \
+             bar";
+    assert_eq!(x, y);
+    assert_eq!(x, "foo and bar");
+}


### PR DESCRIPTION
This makes string literals placed next to each other be concatenated.
Thus "Foo" "Bar" would be "FooBar".
