### PR TITLE
`std::ptr::read_ptr` now takes `*T` instead of `*mut T`

### DIFF
--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -155,7 +155,7 @@ pub unsafe fn replace_ptr<T>(dest: *mut T, mut src: T) -> T {
  * Reads the value from `*src` and returns it. Does not copy `*src`.
  */
 #[inline(always)]
-pub unsafe fn read_ptr<T>(src: *mut T) -> T {
+pub unsafe fn read_ptr<T>(src: *T) -> T {
     let mut tmp: T = intrinsics::uninit();
     copy_nonoverlapping_memory(&mut tmp, src, 1);
     tmp
@@ -168,7 +168,7 @@ pub unsafe fn read_ptr<T>(src: *mut T) -> T {
 #[inline(always)]
 pub unsafe fn read_and_zero_ptr<T>(dest: *mut T) -> T {
     // Copy the data out from `dest`:
-    let tmp = read_ptr(dest);
+    let tmp = read_ptr(&*dest);
 
     // Now zero out `dest`:
     zero_memory(dest, 1);

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1527,7 +1527,7 @@ impl<T> OwnedVector<T> for ~[T] {
                 let valptr = ptr::to_mut_unsafe_ptr(&mut self[ln - 1u]);
                 unsafe {
                     raw::set_len(self, ln - 1u);
-                    Some(ptr::read_ptr(valptr))
+                    Some(ptr::read_ptr(&*valptr))
                 }
             }
         }


### PR DESCRIPTION
Closes #10579
