### PR TITLE
add lint for `unsafe` blocks

### DIFF
--- a/src/test/compile-fail/lint-unsafe-block.rs
+++ b/src/test/compile-fail/lint-unsafe-block.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[allow(unused_unsafe)];
+#[deny(unsafe_block)];
+
+unsafe fn allowed() {}
+
+#[allow(unsafe_block)] fn also_allowed() { unsafe {} }
+
+fn main() {
+    unsafe {} //~ ERROR: usage of an `unsafe` block
+}


### PR DESCRIPTION
This is just meant to be for containing usage of `unsafe`, much like `heap_memory`.
