### PR TITLE
Put non-ascii identifiers behind a feature gate.

### DIFF
--- a/src/test/compile-fail/gated-non-ascii-idents.rs
+++ b/src/test/compile-fail/gated-non-ascii-idents.rs
@@ -1,0 +1,47 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast feature doesn't work.
+
+#[feature(struct_variant)];
+
+extern mod bäz; //~ ERROR non-ascii idents
+
+use föö::bar; //~ ERROR non-ascii idents
+
+mod föö { //~ ERROR non-ascii idents
+    pub fn bar() {}
+}
+
+fn bär( //~ ERROR non-ascii idents
+    bäz: int //~ ERROR non-ascii idents
+    ) {
+    let _ö: int; //~ ERROR non-ascii idents
+
+    match (1, 2) {
+        (_ä, _) => {} //~ ERROR non-ascii idents
+    }
+}
+
+struct Föö { //~ ERROR non-ascii idents
+    föö: int //~ ERROR non-ascii idents
+}
+
+enum Bär { //~ ERROR non-ascii idents
+    Bäz { //~ ERROR non-ascii idents
+        qüx: int //~ ERROR non-ascii idents
+    }
+}
+
+extern {
+    fn qüx();  //~ ERROR non-ascii idents
+}
+
+fn main() {}

--- a/src/test/run-pass/lint-non-camel-case-types-non-uppercase-statics-unicode.rs
+++ b/src/test/run-pass/lint-non-camel-case-types-non-uppercase-statics-unicode.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast feature doesn't work.
+
 #[forbid(non_camel_case_types)];
 #[forbid(non_uppercase_statics)];
+#[feature(non_ascii_idents)];
 
 // Some scripts (e.g. hiragana) don't have a concept of
 // upper/lowercase

--- a/src/test/run-pass/utf8_idents.rs
+++ b/src/test/run-pass/utf8_idents.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast feature doesn't work.
+
+#[feature(non_ascii_idents)];
+
 use std::num;
 
 pub fn main() {


### PR DESCRIPTION
cf. https://mail.mozilla.org/pipermail/rust-dev/2013-November/006920.html
