### PR TITLE
test: test that the `unsafe_block` lint picks up `unsafe` blocks in macros.

### DIFF
--- a/src/test/compile-fail/lint-unsafe-block.rs
+++ b/src/test/compile-fail/lint-unsafe-block.rs
@@ -10,11 +10,20 @@
 
 #[allow(unused_unsafe)];
 #[deny(unsafe_block)];
+#[feature(macro_rules)];
 
 unsafe fn allowed() {}
 
 #[allow(unsafe_block)] fn also_allowed() { unsafe {} }
 
+macro_rules! unsafe_in_macro {
+    () => {
+        unsafe {} //~ ERROR: usage of an `unsafe` block
+    }
+}
+
 fn main() {
     unsafe {} //~ ERROR: usage of an `unsafe` block
+
+    unsafe_in_macro!()
 }


### PR DESCRIPTION
Add a test for the case I mentioned on #10599.
