### PR TITLE
add a breakpoint intrinsic for debugging

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2759,6 +2759,7 @@ pub fn declare_intrinsics(llmod: ModuleRef) -> HashMap<&'static str, ValueRef> {
          [i8p, Type::i8(), Type::i64(), Type::i32(), Type::i1()], Type::void());
 
     ifn!(intrinsics, "llvm.trap", [], Type::void());
+    ifn!(intrinsics, "llvm.debugtrap", [], Type::void());
     ifn!(intrinsics, "llvm.frameaddress", [Type::i32()], i8p);
 
     ifn!(intrinsics, "llvm.powi.f32", [Type::f32(), Type::i32()], Type::f32());

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -228,6 +228,11 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
             Call(bcx, llfn, [], []);
             Unreachable(bcx);
         }
+        "breakpoint" => {
+            let llfn = bcx.ccx().intrinsics.get_copy(&("llvm.debugtrap"));
+            Call(bcx, llfn, [], []);
+            RetVoid(bcx);
+        }
         "size_of" => {
             let tp_ty = substs.tys[0];
             let lltp_ty = type_of::type_of(ccx, tp_ty);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3968,7 +3968,8 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
 
     } else {
         match name {
-            "abort"  => (0, ~[], ty::mk_bot()),
+            "abort" => (0, ~[], ty::mk_bot()),
+            "breakpoint" => (0, ~[], ty::mk_nil()),
             "size_of" |
             "pref_align_of" | "min_align_of" => (1u, ~[], ty::mk_uint()),
             "init" => (1u, ~[], param(ccx, 0u)),

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -176,6 +176,10 @@ extern "rust-intrinsic" {
     /// Abort the execution of the process.
     pub fn abort() -> !;
 
+    /// Execute a breakpoint trap, for inspection by a debugger.
+    #[cfg(not(stage0))]
+    pub fn breakpoint();
+
     /// Atomic compare and exchange, sequentially consistent.
     pub fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;
     /// Atomic compare and exchange, acquire ordering.


### PR DESCRIPTION
This can be used to grab the attention of a debugger, and unlike
`abort` execution can be resumed.
