### PR TITLE
Removed unneccessary `_iter` suffixes from the various APIs

### DIFF
--- a/doc/tutorial-conditions.md
+++ b/doc/tutorial-conditions.md
@@ -82,7 +82,7 @@ fn read_int_pairs() -> ~[(int,int)] {
         let line = fi.read_line();
 
         // 2. Split the line into fields ("words").
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
 
         // 3. Match the vector of fields against a vector pattern.
         match fields {
@@ -295,7 +295,7 @@ fn read_int_pairs() -> ~[(int,int)] {
     let fi = FileInput::from_args();
     while ! fi.eof() {
         let line = fi.read_line();
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
         match fields {
             [a, b] => pairs.push((from_str::<int>(a).unwrap(),
                                   from_str::<int>(b).unwrap())),
@@ -396,7 +396,7 @@ fn read_int_pairs() -> ~[(int,int)] {
     let fi = FileInput::from_args();
     while ! fi.eof() {
         let line = fi.read_line();
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
         match fields {
             [a, b] => pairs.push((from_str::<int>(a).unwrap(),
                                   from_str::<int>(b).unwrap())),
@@ -473,7 +473,7 @@ fn read_int_pairs() -> ~[(int,int)] {
     let fi = FileInput::from_args();
     while ! fi.eof() {
         let line = fi.read_line();
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
         match fields {
             [a, b] => pairs.push((from_str::<int>(a).unwrap(),
                                   from_str::<int>(b).unwrap())),
@@ -551,7 +551,7 @@ fn read_int_pairs() -> ~[(int,int)] {
     let fi = FileInput::from_args();
     while ! fi.eof() {
         let line = fi.read_line();
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
         match fields {
             [a, b] => pairs.push((from_str::<int>(a).unwrap(),
                                   from_str::<int>(b).unwrap())),
@@ -647,7 +647,7 @@ fn read_int_pairs() -> ~[(int,int)] {
     let fi = FileInput::from_args();
     while ! fi.eof() {
         let line = fi.read_line();
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
         match fields {
             [a, b] => pairs.push((from_str::<int>(a).unwrap(),
                                   from_str::<int>(b).unwrap())),
@@ -787,7 +787,7 @@ fn read_int_pairs() -> ~[(int,int)] {
     let fi = FileInput::from_args();
     while ! fi.eof() {
         let line = fi.read_line();
-        let fields = line.word_iter().to_owned_vec();
+        let fields = line.words().to_owned_vec();
         match fields {
 
             // Delegate parsing ints to helper function that will

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -145,7 +145,7 @@ fn parse_check_line(line: &str) -> Option<~str> {
 fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {
     do parse_name_value_directive(line, ~"exec-env").map |nv| {
         // nv is either FOO or FOO=BAR
-        let mut strs: ~[~str] = nv.splitn_iter('=', 1).map(|s| s.to_owned()).collect();
+        let mut strs: ~[~str] = nv.splitn('=', 1).map(|s| s.to_owned()).collect();
 
         match strs.len() {
           1u => (strs.pop(), ~""),

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -383,11 +383,11 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
     if num_check_lines > 0 {
         // Allow check lines to leave parts unspecified (e.g., uninitialized
         // bits in the wrong case of an enum) with the notation "[...]".
-        let check_fragments: ~[~[&str]] = check_lines.map(|s| s.split_str_iter("[...]").collect());
+        let check_fragments: ~[~[&str]] = check_lines.map(|s| s.split_str("[...]").collect());
         // check if each line in props.check_lines appears in the
         // output (in order)
         let mut i = 0u;
-        for line in ProcRes.stdout.line_iter() {
+        for line in ProcRes.stdout.lines() {
             let mut rest = line.trim();
             let mut first = true;
             let mut failed = false;
@@ -439,7 +439,7 @@ fn check_error_patterns(props: &TestProps,
     let mut next_err_idx = 0u;
     let mut next_err_pat = &props.error_patterns[next_err_idx];
     let mut done = false;
-    for line in ProcRes.stderr.line_iter() {
+    for line in ProcRes.stderr.lines() {
         if line.contains(*next_err_pat) {
             debug!("found error pattern {}", *next_err_pat);
             next_err_idx += 1u;
@@ -483,7 +483,7 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
     }).collect::<~[~str]>();
 
     fn to_lower( s : &str ) -> ~str {
-        let i = s.iter();
+        let i = s.chars();
         let c : ~[char] = i.map( |c| {
             if c.is_ascii() {
                 c.to_ascii().to_lower().to_char()
@@ -512,7 +512,7 @@ fn check_expected_errors(expected_errors: ~[errors::ExpectedError],
     //    filename:line1:col1: line2:col2: *warning:* msg
     // where line1:col1: is the starting point, line2:col2:
     // is the ending point, and * represents ANSI color codes.
-    for line in ProcRes.stderr.line_iter() {
+    for line in ProcRes.stderr.lines() {
         let mut was_expected = false;
         for (i, ee) in expected_errors.iter().enumerate() {
             if !found_flags[i] {
@@ -777,7 +777,7 @@ fn make_run_args(config: &config, _props: &TestProps, testfile: &Path) ->
 fn split_maybe_args(argstr: &Option<~str>) -> ~[~str] {
     match *argstr {
         Some(ref s) => {
-            s.split_iter(' ')
+            s.split(' ')
                 .filter_map(|s| if s.is_whitespace() {None} else {Some(s.to_owned())})
                 .collect()
         }
@@ -896,7 +896,7 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
     let cmdline = make_cmdline("", args.prog, args.args);
 
     // get bare program string
-    let mut tvec: ~[~str] = args.prog.split_iter('/').map(|ts| ts.to_owned()).collect();
+    let mut tvec: ~[~str] = args.prog.split('/').map(|ts| ts.to_owned()).collect();
     let prog_short = tvec.pop();
 
     // copy to target
@@ -939,7 +939,7 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
                      Some(~""));
 
     let mut exitcode : int = 0;
-    for c in exitcode_out.iter() {
+    for c in exitcode_out.chars() {
         if !c.is_digit() { break; }
         exitcode = exitcode * 10 + match c {
             '0' .. '9' => c as int - ('0' as int),
@@ -1089,7 +1089,7 @@ fn disassemble_extract(config: &config, _props: &TestProps,
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end();
     let x = str::from_utf8_owned(x);
-    x.line_iter().len()
+    x.lines().len()
 }
 
 

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -193,7 +193,7 @@ impl<'self> FromBase64 for &'self str {
         let mut buf: u32 = 0;
         let mut modulus = 0;
 
-        let mut it = self.byte_iter().enumerate();
+        let mut it = self.bytes().enumerate();
         for (idx, byte) in it {
             let val = byte as u32;
 

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -413,7 +413,7 @@ pub fn getopts(args: &[~str], opts: &[Opt]) -> Result {
             let mut i_arg = None;
             if cur[1] == '-' as u8 {
                 let tail = cur.slice(2, curlen);
-                let tail_eq: ~[&str] = tail.split_iter('=').collect();
+                let tail_eq: ~[&str] = tail.split('=').collect();
                 if tail_eq.len() <= 1 {
                     names = ~[Long(tail.to_owned())];
                 } else {
@@ -735,7 +735,7 @@ pub mod groups {
 
             // Normalize desc to contain words separated by one space character
             let mut desc_normalized_whitespace = ~"";
-            for word in desc.word_iter() {
+            for word in desc.words() {
                 desc_normalized_whitespace.push_str(word);
                 desc_normalized_whitespace.push_char(' ');
             }
@@ -826,7 +826,7 @@ pub mod groups {
             cont
         };
 
-        ss.char_offset_iter().advance(|x| machine(x));
+        ss.char_indices().advance(|x| machine(x));
 
         // Let the automaton 'run out' by supplying trailing whitespace
         while cont && match state { B | C => true, A => false } {

--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -102,7 +102,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> GlobIterator {
 
     let root_len = pat_root.map_default(0u, |p| p.as_vec().len());
     let dir_patterns = pattern.slice_from(root_len.min(&pattern.len()))
-                       .split_terminator_iter(is_sep).map(|s| Pattern::new(s)).to_owned_vec();
+                       .split_terminator(is_sep).map(|s| Pattern::new(s)).to_owned_vec();
 
     let todo = list_dir_sorted(&root).move_iter().map(|x|(x,0u)).to_owned_vec();
 
@@ -209,7 +209,7 @@ impl Pattern {
      */
     pub fn new(pattern: &str) -> Pattern {
 
-        let chars = pattern.iter().to_owned_vec();
+        let chars = pattern.chars().to_owned_vec();
         let mut tokens = ~[];
         let mut i = 0;
 
@@ -272,7 +272,7 @@ impl Pattern {
      */
     pub fn escape(s: &str) -> ~str {
         let mut escaped = ~"";
-        for c in s.iter() {
+        for c in s.chars() {
             match c {
                 // note that ! does not need escaping because it is only special inside brackets
                 '?' | '*' | '[' | ']' => {
@@ -586,10 +586,10 @@ mod test {
         let pats = ["[a-z123]", "[1a-z23]", "[123a-z]"];
         for &p in pats.iter() {
             let pat = Pattern::new(p);
-            for c in "abcdefghijklmnopqrstuvwxyz".iter() {
+            for c in "abcdefghijklmnopqrstuvwxyz".chars() {
                 assert!(pat.matches(c.to_str()));
             }
-            for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".iter() {
+            for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ".chars() {
                 let options = MatchOptions {case_sensitive: false, .. MatchOptions::new()};
                 assert!(pat.matches_with(c.to_str(), options));
             }

--- a/src/libextra/hex.rs
+++ b/src/libextra/hex.rs
@@ -91,7 +91,7 @@ impl<'self> FromHex for &'self str {
         let mut modulus = 0;
         let mut buf = 0u8;
 
-        for (idx, byte) in self.byte_iter().enumerate() {
+        for (idx, byte) in self.bytes().enumerate() {
             buf <<= 4;
 
             match byte as char {

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -59,7 +59,7 @@ pub struct Error {
 
 fn escape_str(s: &str) -> ~str {
     let mut escaped = ~"\"";
-    for c in s.iter() {
+    for c in s.chars() {
         match c {
           '"' => escaped.push_str("\\\""),
           '\\' => escaped.push_str("\\\\"),
@@ -559,7 +559,7 @@ impl<T : Iterator<char>> Parser<T> {
     }
 
     fn parse_ident(&mut self, ident: &str, value: Json) -> Result<Json, Error> {
-        if ident.iter().all(|c| c == self.next_char()) {
+        if ident.chars().all(|c| c == self.next_char()) {
             self.bump();
             Ok(value)
         } else {
@@ -844,13 +844,13 @@ impl<T : Iterator<char>> Parser<T> {
 /// Decodes a json value from an `&mut io::Reader`
 pub fn from_reader(rdr: &mut io::Reader) -> Result<Json, Error> {
     let s = str::from_utf8(rdr.read_to_end());
-    let mut parser = Parser(~s.iter());
+    let mut parser = Parser(~s.chars());
     parser.parse()
 }
 
 /// Decodes a json value from a string
 pub fn from_str(s: &str) -> Result<Json, Error> {
-    let mut parser = Parser(~s.iter());
+    let mut parser = Parser(~s.chars());
     parser.parse()
 }
 
@@ -930,7 +930,7 @@ impl serialize::Decoder for Decoder {
     fn read_char(&mut self) -> char {
         let s = self.read_str();
         {
-            let mut it = s.iter();
+            let mut it = s.chars();
             match (it.next(), it.next()) {
                 // exactly one character
                 (Some(c), None) => return c,

--- a/src/libextra/num/rational.rs
+++ b/src/libextra/num/rational.rs
@@ -292,7 +292,7 @@ impl<T: FromStr + Clone + Integer + Ord>
     FromStr for Ratio<T> {
     /// Parses `numer/denom`.
     fn from_str(s: &str) -> Option<Ratio<T>> {
-        let split: ~[&str] = s.splitn_iter('/', 1).collect();
+        let split: ~[&str] = s.splitn('/', 1).collect();
         if split.len() < 2 {
             return None
         }
@@ -309,7 +309,7 @@ impl<T: FromStrRadix + Clone + Integer + Ord>
     FromStrRadix for Ratio<T> {
     /// Parses `numer/denom` where the numbers are in base `radix`.
     fn from_str_radix(s: &str, radix: uint) -> Option<Ratio<T>> {
-        let split: ~[&str] = s.splitn_iter('/', 1).collect();
+        let split: ~[&str] = s.splitn('/', 1).collect();
         if split.len() < 2 {
             None
         } else {

--- a/src/libextra/semver.rs
+++ b/src/libextra/semver.rs
@@ -176,7 +176,7 @@ fn take_num<T: Iterator<char>>(rdr: &mut T) -> (uint, Option<char>) {
 
 fn take_ident<T: Iterator<char>>(rdr: &mut T) -> (Identifier, Option<char>) {
     let (s,ch) = take_nonempty_prefix(rdr, char::is_alphanumeric);
-    if s.iter().all(char::is_digit) {
+    if s.chars().all(char::is_digit) {
         match from_str::<uint>(s) {
             None => { bad_parse::cond.raise(()); (Numeric(0), ch) },
             Some(i) => (Numeric(i), ch)
@@ -239,7 +239,7 @@ pub fn parse(s: &str) -> Option<Version> {
     let s = s.trim();
     let mut bad = false;
     do bad_parse::cond.trap(|_| { debug!("bad"); bad = true }).inside {
-        let v = parse_iter(&mut s.iter());
+        let v = parse_iter(&mut s.chars());
         if bad || v.to_str() != s.to_owned() {
             None
         } else {

--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -216,7 +216,7 @@ pub fn parse(file: &mut io::Reader,
     }
 
     let names_str = str::from_utf8(file.read_bytes(names_bytes as uint - 1)); // don't read NUL
-    let term_names: ~[~str] = names_str.split_iter('|').map(|s| s.to_owned()).collect();
+    let term_names: ~[~str] = names_str.split('|').map(|s| s.to_owned()).collect();
 
     file.read_byte(); // consume NUL
 

--- a/src/libextra/terminfo/searcher.rs
+++ b/src/libextra/terminfo/searcher.rs
@@ -36,7 +36,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<~Path> {
                 dirs_to_search.push(homedir.unwrap().join(".terminfo"))
             }
             match getenv("TERMINFO_DIRS") {
-                Some(dirs) => for i in dirs.split_iter(':') {
+                Some(dirs) => for i in dirs.split(':') {
                     if i == "" {
                         dirs_to_search.push(Path::new("/usr/share/terminfo"));
                     } else {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -313,7 +313,7 @@ pub fn opt_shard(maybestr: Option<~str>) -> Option<(uint,uint)> {
     match maybestr {
         None => None,
         Some(s) => {
-            match s.split_iter('.').to_owned_vec() {
+            match s.split('.').to_owned_vec() {
                 [a, b] => match (from_str::<uint>(a), from_str::<uint>(b)) {
                     (Some(a), Some(b)) => Some((a,b)),
                     _ => None

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -248,7 +248,7 @@ impl Tm {
 pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
     fn match_str(s: &str, pos: uint, needle: &str) -> bool {
         let mut i = pos;
-        for ch in needle.byte_iter() {
+        for ch in needle.bytes() {
             if s[i] != ch {
                 return false;
             }

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -170,7 +170,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
 
     /// Return a lazy iterator to the first key-value pair whose key is not less than `k`
     /// If all keys in map are less than `k` an empty iterator is returned.
-    pub fn lower_bound_iter<'a>(&'a self, k: &K) -> TreeMapIterator<'a, K, V> {
+    pub fn lower_bound<'a>(&'a self, k: &K) -> TreeMapIterator<'a, K, V> {
         let mut iter: TreeMapIterator<'a, K, V> = self.iter_for_traversal();
         loop {
             match iter.node {
@@ -194,7 +194,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
 
     /// Return a lazy iterator to the first key-value pair whose key is greater than `k`
     /// If all keys in map are not greater than `k` an empty iterator is returned.
-    pub fn upper_bound_iter<'a>(&'a self, k: &K) -> TreeMapIterator<'a, K, V> {
+    pub fn upper_bound<'a>(&'a self, k: &K) -> TreeMapIterator<'a, K, V> {
         let mut iter: TreeMapIterator<'a, K, V> = self.iter_for_traversal();
         loop {
             match iter.node {
@@ -526,15 +526,15 @@ impl<T: TotalOrd> TreeSet<T> {
     /// Get a lazy iterator pointing to the first value not less than `v` (greater or equal).
     /// If all elements in the set are less than `v` empty iterator is returned.
     #[inline]
-    pub fn lower_bound_iter<'a>(&'a self, v: &T) -> TreeSetIterator<'a, T> {
-        TreeSetIterator{iter: self.map.lower_bound_iter(v)}
+    pub fn lower_bound<'a>(&'a self, v: &T) -> TreeSetIterator<'a, T> {
+        TreeSetIterator{iter: self.map.lower_bound(v)}
     }
 
     /// Get a lazy iterator pointing to the first value greater than `v`.
     /// If all elements in the set are not greater than `v` empty iterator is returned.
     #[inline]
-    pub fn upper_bound_iter<'a>(&'a self, v: &T) -> TreeSetIterator<'a, T> {
-        TreeSetIterator{iter: self.map.upper_bound_iter(v)}
+    pub fn upper_bound<'a>(&'a self, v: &T) -> TreeSetIterator<'a, T> {
+        TreeSetIterator{iter: self.map.upper_bound(v)}
     }
 
     /// Visit the values (in-order) representing the difference
@@ -1095,19 +1095,19 @@ mod test_treemap {
         }
 
         for i in range(1, 198) {
-            let mut lb_it = m.lower_bound_iter(&i);
+            let mut lb_it = m.lower_bound(&i);
             let (&k, &v) = lb_it.next().unwrap();
             let lb = i + i % 2;
             assert_eq!(lb, k);
             assert_eq!(lb * 2, v);
 
-            let mut ub_it = m.upper_bound_iter(&i);
+            let mut ub_it = m.upper_bound(&i);
             let (&k, &v) = ub_it.next().unwrap();
             let ub = i + 2 - i % 2;
             assert_eq!(ub, k);
             assert_eq!(ub * 2, v);
         }
-        let mut end_it = m.lower_bound_iter(&199);
+        let mut end_it = m.lower_bound(&199);
         assert_eq!(end_it.next(), None);
     }
 

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -356,7 +356,7 @@ fn userinfo_to_str(userinfo: &UserInfo) -> ~str {
 fn query_from_str(rawquery: &str) -> Query {
     let mut query: Query = ~[];
     if !rawquery.is_empty() {
-        for p in rawquery.split_iter('&') {
+        for p in rawquery.split('&') {
             let (k, v) = split_char_first(p, '=');
             query.push((decode_component(k), decode_component(v)));
         };
@@ -391,7 +391,7 @@ pub fn query_to_str(query: &Query) -> ~str {
 
 // returns the scheme and the rest of the url, or a parsing error
 pub fn get_scheme(rawurl: &str) -> Result<(~str, ~str), ~str> {
-    for (i,c) in rawurl.iter().enumerate() {
+    for (i,c) in rawurl.chars().enumerate() {
         match c {
           'A' .. 'Z' | 'a' .. 'z' => continue,
           '0' .. '9' | '+' | '-' | '.' => {
@@ -453,7 +453,7 @@ fn get_authority(rawurl: &str) ->
     let mut begin = 2;
     let mut end = len;
 
-    for (i,c) in rawurl.iter().enumerate() {
+    for (i,c) in rawurl.chars().enumerate() {
         if i < 2 { continue; } // ignore the leading //
 
         // deal with input class first
@@ -587,7 +587,7 @@ fn get_path(rawurl: &str, authority: bool) ->
     Result<(~str, ~str), ~str> {
     let len = rawurl.len();
     let mut end = len;
-    for (i,c) in rawurl.iter().enumerate() {
+    for (i,c) in rawurl.chars().enumerate() {
         match c {
           'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '&' |'\'' | '(' | ')' | '.'
           | '@' | ':' | '%' | '/' | '+' | '!' | '*' | ',' | ';' | '='

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -366,7 +366,7 @@ impl Uuid {
         }
 
         // Make sure all chars are either hex digits or hyphen
-        for (i, c) in us.iter().enumerate() {
+        for (i, c) in us.chars().enumerate() {
             match c {
                 '0'..'9' | 'A'..'F' | 'a'..'f' | '-' => {},
                 _ => return Err(ErrorInvalidCharacter(c, i)),
@@ -374,7 +374,7 @@ impl Uuid {
         }
 
         // Split string up by hyphens into groups
-        let hex_groups: ~[&str] = us.split_str_iter("-").collect();
+        let hex_groups: ~[&str] = us.split_str("-").collect();
 
         // Get the length of each group
         let group_lens: ~[uint] = hex_groups.iter().map(|&v| v.len()).collect();
@@ -407,7 +407,7 @@ impl Uuid {
 
         // At this point, we know we have a valid hex string, without hyphens
         assert!(vs.len() == 32);
-        assert!(vs.iter().all(|c| c.is_digit_radix(16)));
+        assert!(vs.chars().all(|c| c.is_digit_radix(16)));
 
         // Allocate output UUID buffer
         let mut ub = [0u8, ..16];
@@ -650,7 +650,7 @@ mod test {
         let s = uuid1.to_simple_str();
 
         assert!(s.len() == 32);
-        assert!(s.iter().all(|c| c.is_digit_radix(16)));
+        assert!(s.chars().all(|c| c.is_digit_radix(16)));
     }
 
     #[test]
@@ -659,7 +659,7 @@ mod test {
         let s = uuid1.to_str();
 
         assert!(s.len() == 32);
-        assert!(s.iter().all(|c| c.is_digit_radix(16)));
+        assert!(s.chars().all(|c| c.is_digit_radix(16)));
     }
 
     #[test]
@@ -668,7 +668,7 @@ mod test {
         let s = uuid1.to_hyphenated_str();
 
         assert!(s.len() == 36);
-        assert!(s.iter().all(|c| c.is_digit_radix(16) || c == '-'));
+        assert!(s.chars().all(|c| c.is_digit_radix(16) || c == '-'));
     }
 
     #[test]
@@ -679,7 +679,7 @@ mod test {
 
         assert!(ss.starts_with("urn:uuid:"));
         assert!(s.len() == 36);
-        assert!(s.iter().all(|c| c.is_digit_radix(16) || c == '-'));
+        assert!(s.chars().all(|c| c.is_digit_radix(16) || c == '-'));
     }
 
     #[test]
@@ -689,7 +689,7 @@ mod test {
         let hs = uuid1.to_hyphenated_str();
         let ss = uuid1.to_str();
 
-        let hsn = str::from_chars(hs.iter().filter(|&c| c != '-').collect::<~[char]>());
+        let hsn = str::from_chars(hs.chars().filter(|&c| c != '-').collect::<~[char]>());
 
         assert!(hsn == ss);
     }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -711,7 +711,7 @@ pub fn get_symbol_hash(ccx: &mut CrateContext, t: ty::t) -> @str {
 // gas accepts the following characters in symbols: a-z, A-Z, 0-9, ., _, $
 pub fn sanitize(s: &str) -> ~str {
     let mut result = ~"";
-    for c in s.iter() {
+    for c in s.chars() {
         match c {
             // Escape these with $ sequences
             '@' => result.push_str("$SP$"),

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -172,7 +172,6 @@ mod test {
 
     use back::rpath::{get_absolute_rpath, get_install_prefix_rpath};
     use back::rpath::{minimize_rpaths, rpaths_to_flags, get_rpath_relative_to_output};
-    use driver::session;
     use syntax::abi;
 
     #[test]

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -757,7 +757,7 @@ pub fn build_session_options(binary: @str,
     }).move_iter().collect();
     let linker = matches.opt_str("linker");
     let linker_args = matches.opt_strs("link-args").flat_map( |a| {
-        a.split_iter(' ').map(|arg| arg.to_owned()).collect()
+        a.split(' ').map(|arg| arg.to_owned()).collect()
     });
 
     let cfg = parse_cfgspecs(matches.opt_strs("cfg"), demitter);
@@ -767,7 +767,7 @@ pub fn build_session_options(binary: @str,
     let custom_passes = match matches.opt_str("passes") {
         None => ~[],
         Some(s) => {
-            s.split_iter(|c: char| c == ' ' || c == ',').map(|s| {
+            s.split(|c: char| c == ' ' || c == ',').map(|s| {
                 s.trim().to_owned()
             }).collect()
         }
@@ -775,7 +775,7 @@ pub fn build_session_options(binary: @str,
     let llvm_args = match matches.opt_str("llvm-args") {
         None => ~[],
         Some(s) => {
-            s.split_iter(|c: char| c == ' ' || c == ',').map(|s| {
+            s.split(|c: char| c == ' ' || c == ',').map(|s| {
                 s.trim().to_owned()
             }).collect()
         }

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -113,7 +113,7 @@ pub fn get_used_libraries<'a>(cstore: &'a CStore) -> &'a [@str] {
 }
 
 pub fn add_used_link_args(cstore: &mut CStore, args: &str) {
-    for s in args.split_iter(' ') {
+    for s in args.split(' ') {
         cstore.used_link_args.push(s.to_managed());
     }
 }

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -198,7 +198,7 @@ pub fn rust_path() -> ~[Path] {
     let mut env_rust_path: ~[Path] = match get_rust_path() {
         Some(env_path) => {
             let env_path_components: ~[&str] =
-                env_path.split_str_iter(PATH_ENTRY_SEPARATOR).collect();
+                env_path.split_str(PATH_ENTRY_SEPARATOR).collect();
             env_path_components.map(|&s| Path::new(s))
         }
         None => ~[]

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -936,7 +936,7 @@ fn check_item_non_uppercase_statics(cx: &Context, it: &ast::item) {
             // check for lowercase letters rather than non-uppercase
             // ones (some scripts don't have a concept of
             // upper/lowercase)
-            if s.iter().any(|c| c.is_lowercase()) {
+            if s.chars().any(|c| c.is_lowercase()) {
                 cx.span_lint(non_uppercase_statics, it.span,
                              "static constant should have an uppercase identifier");
             }
@@ -952,7 +952,7 @@ fn check_pat_non_uppercase_statics(cx: &Context, p: &ast::Pat) {
             // last identifier alone is right choice for this lint.
             let ident = path.segments.last().identifier;
             let s = cx.tcx.sess.str_of(ident);
-            if s.iter().any(|c| c.is_lowercase()) {
+            if s.chars().any(|c| c.is_lowercase()) {
                 cx.span_lint(non_uppercase_pattern_statics, path.span,
                              "static constant in pattern should be all caps");
             }

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -157,7 +157,7 @@ pub fn trans_intrinsic(ccx: @mut CrateContext,
     // This requires that atomic intrinsics follow a specific naming pattern:
     // "atomic_<operation>[_<ordering>], and no ordering means SeqCst
     if name.starts_with("atomic_") {
-        let split : ~[&str] = name.split_iter('_').collect();
+        let split : ~[&str] = name.split('_').collect();
         assert!(split.len() >= 2, "Atomic intrinsic not correct format");
         let order = if split.len() == 2 {
             lib::llvm::SequentiallyConsistent

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3926,7 +3926,7 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
     let nm = ccx.tcx.sess.str_of(it.ident);
     let name = nm.as_slice();
     let (n_tps, inputs, output) = if name.starts_with("atomic_") {
-        let split : ~[&str] = name.split_iter('_').collect();
+        let split : ~[&str] = name.split('_').collect();
         assert!(split.len() >= 2, "Atomic intrinsic not correct format");
 
         //We only care about the operation here

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -25,7 +25,7 @@ impl<'self> fmt::Default for Escape<'self> {
         // characters to escape: http://stackoverflow.com/questions/7381974
         let pile_o_bits = s.as_slice();
         let mut last = 0;
-        for (i, ch) in s.byte_iter().enumerate() {
+        for (i, ch) in s.bytes().enumerate() {
             match ch as char {
                 '<' | '>' | '&' | '\'' | '"' => {
                     fmt.buf.write(pile_o_bits.slice(last, i).as_bytes());

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -338,7 +338,7 @@ fn mkdir(path: &Path) {
 fn clean_srcpath(src: &[u8], f: &fn(&str)) {
     let p = Path::new(src);
     if p.as_vec() != bytes!(".") {
-        for c in p.str_component_iter().map(|x|x.unwrap()) {
+        for c in p.str_components().map(|x|x.unwrap()) {
             if ".." == c {
                 f("up");
             } else {
@@ -1621,7 +1621,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<~str, ~[~str]> {
 
 impl<'self> fmt::Default for Source<'self> {
     fn fmt(s: &Source<'self>, fmt: &mut fmt::Formatter) {
-        let lines = s.line_iter().len();
+        let lines = s.lines().len();
         let mut cols = 0;
         let mut tmp = lines;
         while tmp > 0 {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -215,12 +215,12 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
                         default_passes = false;
                     }
                     clean::NameValue(~"passes", ref value) => {
-                        for pass in value.word_iter() {
+                        for pass in value.words() {
                             passes.push(pass.to_owned());
                         }
                     }
                     clean::NameValue(~"plugins", ref value) => {
-                        for p in value.word_iter() {
+                        for p in value.words() {
                             plugins.push(p.to_owned());
                         }
                     }

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -228,7 +228,7 @@ pub fn collapse_docs(crate: clean::Crate) -> plugins::PluginResult {
 }
 
 pub fn unindent(s: &str) -> ~str {
-    let lines = s.any_line_iter().collect::<~[&str]>();
+    let lines = s.lines_any().collect::<~[&str]>();
     let mut saw_first_line = false;
     let mut saw_second_line = false;
     let min_indent = do lines.iter().fold(uint::max_value) |min_indent, line| {
@@ -257,7 +257,7 @@ pub fn unindent(s: &str) -> ~str {
         } else {
             saw_first_line = true;
             let mut spaces = 0;
-            do line.iter().all |char| {
+            do line.chars().all |char| {
                 // Only comparing against space because I wouldn't
                 // know what to do with mixed whitespace chars
                 if char == ' ' {

--- a/src/librustpkg/installed_packages.rs
+++ b/src/librustpkg/installed_packages.rs
@@ -59,7 +59,7 @@ pub fn has_library(p: &Path) -> Option<~str> {
     for path in files.iter() {
         if path.extension_str() == Some(os::consts::DLL_EXTENSION) {
             let stuff : &str = path.filestem_str().expect("has_library: weird path");
-            let mut stuff2 = stuff.split_str_iter(&"-");
+            let mut stuff2 = stuff.split_str("-");
             let stuff3: ~[&str] = stuff2.collect();
             // argh
             let chars_to_drop = os::consts::DLL_PREFIX.len();

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -184,7 +184,7 @@ impl<'self> PkgScript<'self> {
                                              [sysroot.as_str().unwrap().to_owned(), ~"configs"]);
             debug!("run_custom: second pkg command did {:?}", output.status);
             // Run the configs() function to get the configs
-            let cfgs = str::from_utf8_slice(output.output).word_iter()
+            let cfgs = str::from_utf8_slice(output.output).words()
                 .map(|w| w.to_owned()).collect();
             (cfgs, output.status)
         }

--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -102,8 +102,8 @@ impl PkgId {
         self.short_name.as_bytes() != self.path.as_vec()
     }
 
-    pub fn prefixes_iter(&self) -> Prefixes {
-        prefixes_iter(&self.path)
+    pub fn prefixes(&self) -> Prefixes {
+        prefixes(&self.path)
     }
 
     // This is the workcache function name for the *installed*
@@ -114,9 +114,9 @@ impl PkgId {
     }
 }
 
-pub fn prefixes_iter(p: &Path) -> Prefixes {
+pub fn prefixes(p: &Path) -> Prefixes {
     Prefixes {
-        components: p.str_component_iter().map(|x|x.unwrap().to_owned()).to_owned_vec(),
+        components: p.str_components().map(|x|x.unwrap().to_owned()).to_owned_vec(),
         remaining: ~[]
     }
 }

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -132,7 +132,7 @@ impl PkgSrc {
             None => {
                 // See if any of the prefixes of this package ID form a valid package ID
                 // That is, is this a package ID that points into the middle of a workspace?
-                for (prefix, suffix) in id.prefixes_iter() {
+                for (prefix, suffix) in id.prefixes() {
                     let package_id = PkgId::new(prefix.as_str().unwrap());
                     let path = build_dir.join(&package_id.path);
                     debug!("in loop: checking if {} is a directory", path.display());
@@ -183,7 +183,7 @@ impl PkgSrc {
                                 || d.is_ancestor_of(&versionize(&id.path, &id.version)) {
                                 // Strip off the package ID
                                 source_workspace = d.clone();
-                                for _ in id.path.component_iter() {
+                                for _ in id.path.components() {
                                     source_workspace.pop();
                                 }
                                 // Strip off the src/ part
@@ -279,7 +279,7 @@ impl PkgSrc {
                 Some(local.clone())
             }
             DirToUse(clone_target) => {
-                if pkgid.path.component_iter().nth(1).is_none() {
+                if pkgid.path.components().nth(1).is_none() {
                     // If a non-URL, don't bother trying to fetch
                     return None;
                 }
@@ -329,7 +329,7 @@ impl PkgSrc {
     }
 
     pub fn push_crate(cs: &mut ~[Crate], prefix: uint, p: &Path) {
-        let mut it = p.component_iter().peekable();
+        let mut it = p.components().peekable();
         if prefix > 0 {
             it.nth(prefix-1); // skip elements
         }
@@ -351,7 +351,7 @@ impl PkgSrc {
     pub fn find_crates_with_filter(&mut self, filter: &fn(&str) -> bool) {
         use conditions::missing_pkg_files::cond;
 
-        let prefix = self.start_dir.component_iter().len();
+        let prefix = self.start_dir.components().len();
         debug!("Matching against {}", self.id.short_name);
         for pth in fs::walk_dir(&self.start_dir) {
             let maybe_known_crate_set = match pth.filename_str() {

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -457,7 +457,7 @@ fn command_line_test_output(args: &[~str]) -> ~[~str] {
     let mut result = ~[];
     let p_output = command_line_test(args, &os::getcwd());
     let test_output = str::from_utf8(p_output.output);
-    for s in test_output.split_iter('\n') {
+    for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
     result
@@ -471,7 +471,7 @@ fn command_line_test_output_with_env(args: &[~str], env: ~[(~str, ~str)]) -> ~[~
         Success(r) => r
     };
     let test_output = str::from_utf8(p_output.output);
-    for s in test_output.split_iter('\n') {
+    for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
     result

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -177,7 +177,7 @@ pub fn compile_input(context: &BuildContext,
                      cfgs: &[~str],
                      opt: session::OptLevel,
                      what: OutputType) -> Option<Path> {
-    assert!(in_file.component_iter().nth(1).is_some());
+    assert!(in_file.components().nth(1).is_some());
     let input = driver::file_input(in_file.clone());
     debug!("compile_input: {} / {:?}", in_file.display(), what);
     // tjc: by default, use the package ID name as the link name

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -115,7 +115,7 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
 
     let mut output = None;
     let output_text = str::from_utf8(outp.output);
-    for l in output_text.line_iter() {
+    for l in output_text.lines() {
         if !l.is_whitespace() {
             output = Some(l);
         }
@@ -157,7 +157,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
                                             ~"tag", ~"-l"]);
             let output_text = str::from_utf8(outp.output);
             debug!("Full output: ( {} ) [{:?}]", output_text, outp.status);
-            for l in output_text.line_iter() {
+            for l in output_text.lines() {
                 debug!("A line of output: {}", l);
                 if !l.is_whitespace() {
                     output = Some(l);
@@ -187,7 +187,7 @@ pub fn try_parsing_version(s: &str) -> Option<Version> {
     let s = s.trim();
     debug!("Attempting to parse: {}", s);
     let mut parse_state = Start;
-    for c in s.iter() {
+    for c in s.chars() {
         if char::is_digit(c) {
             parse_state = SawDigit;
         }
@@ -207,7 +207,7 @@ pub fn try_parsing_version(s: &str) -> Option<Version> {
 /// Just an approximation
 fn is_url_like(p: &Path) -> bool {
     // check if there are more than 2 /-separated components
-    p.as_vec().split_iter(|b| *b == '/' as u8).nth(2).is_some()
+    p.as_vec().split(|b| *b == '/' as u8).nth(2).is_some()
 }
 
 /// If s is of the form foo#bar, where bar is a valid version
@@ -215,7 +215,7 @@ fn is_url_like(p: &Path) -> bool {
 /// Otherwise, return None.
 pub fn split_version<'a>(s: &'a str) -> Option<(&'a str, Version)> {
     // Check for extra '#' characters separately
-    if s.split_iter('#').len() > 2 {
+    if s.split('#').len() > 2 {
         return None;
     }
     split_version_general(s, '#')

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -180,7 +180,7 @@ impl<'self> AsciiCast<&'self [Ascii]> for &'self str {
 
     #[inline]
     fn is_ascii(&self) -> bool {
-        self.byte_iter().all(|b| b.is_ascii())
+        self.bytes().all(|b| b.is_ascii())
     }
 }
 
@@ -394,7 +394,7 @@ unsafe fn str_map_bytes(string: ~str, map: &'static [u8]) -> ~str {
 
 #[inline]
 unsafe fn str_copy_map_bytes(string: &str, map: &'static [u8]) -> ~str {
-    let bytes = string.byte_iter().map(|b| map[b]).to_owned_vec();
+    let bytes = string.bytes().map(|b| map[b]).to_owned_vec();
 
     str::raw::from_utf8_owned(bytes)
 }
@@ -498,8 +498,8 @@ mod tests {
         assert_eq!('`'.to_ascii().to_upper().to_char(), '`');
         assert_eq!('{'.to_ascii().to_upper().to_char(), '{');
 
-        assert!("banana".iter().all(|c| c.is_ascii()));
-        assert!(!"ประเทศไทย中华Việt Nam".iter().all(|c| c.is_ascii()));
+        assert!("banana".chars().all(|c| c.is_ascii()));
+        assert!(!"ประเทศไทย中华Việt Nam".chars().all(|c| c.is_ascii()));
     }
 
     #[test]

--- a/src/libstd/fmt/parse.rs
+++ b/src/libstd/fmt/parse.rs
@@ -196,7 +196,7 @@ impl<'self> Parser<'self> {
     pub fn new<'a>(s: &'a str) -> Parser<'a> {
         Parser {
             input: s,
-            cur: s.char_offset_iter(),
+            cur: s.char_indices(),
             depth: 0,
         }
     }

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -736,7 +736,7 @@ impl<T:Hash + Eq> HashSet<T> {
     }
 
     /// Visit the values representing the difference
-    pub fn difference_iter<'a>(&'a self, other: &'a HashSet<T>) -> SetAlgebraIter<'a, T> {
+    pub fn difference<'a>(&'a self, other: &'a HashSet<T>) -> SetAlgebraIter<'a, T> {
         Repeat::new(other)
             .zip(self.iter())
             .filter_map(|(other, elt)| {
@@ -745,13 +745,13 @@ impl<T:Hash + Eq> HashSet<T> {
     }
 
     /// Visit the values representing the symmetric difference
-    pub fn symmetric_difference_iter<'a>(&'a self, other: &'a HashSet<T>)
+    pub fn symmetric_difference<'a>(&'a self, other: &'a HashSet<T>)
         -> Chain<SetAlgebraIter<'a, T>, SetAlgebraIter<'a, T>> {
-        self.difference_iter(other).chain(other.difference_iter(self))
+        self.difference(other).chain(other.difference(self))
     }
 
     /// Visit the values representing the intersection
-    pub fn intersection_iter<'a>(&'a self, other: &'a HashSet<T>)
+    pub fn intersection<'a>(&'a self, other: &'a HashSet<T>)
         -> SetAlgebraIter<'a, T> {
         Repeat::new(other)
             .zip(self.iter())
@@ -761,9 +761,9 @@ impl<T:Hash + Eq> HashSet<T> {
     }
 
     /// Visit the values representing the union
-    pub fn union_iter<'a>(&'a self, other: &'a HashSet<T>)
+    pub fn union<'a>(&'a self, other: &'a HashSet<T>)
         -> Chain<HashSetIterator<'a, T>, SetAlgebraIter<'a, T>> {
-        self.iter().chain(other.difference_iter(self))
+        self.iter().chain(other.difference(self))
     }
 
 }
@@ -1114,7 +1114,7 @@ mod test_set {
 
         let mut i = 0;
         let expected = [3, 5, 11, 77];
-        for x in a.intersection_iter(&b) {
+        for x in a.intersection(&b) {
             assert!(expected.contains(x));
             i += 1
         }
@@ -1137,7 +1137,7 @@ mod test_set {
 
         let mut i = 0;
         let expected = [1, 5, 11];
-        for x in a.difference_iter(&b) {
+        for x in a.difference(&b) {
             assert!(expected.contains(x));
             i += 1
         }
@@ -1163,7 +1163,7 @@ mod test_set {
 
         let mut i = 0;
         let expected = [-2, 1, 5, 11, 14, 22];
-        for x in a.symmetric_difference_iter(&b) {
+        for x in a.symmetric_difference(&b) {
             assert!(expected.contains(x));
             i += 1
         }
@@ -1193,7 +1193,7 @@ mod test_set {
 
         let mut i = 0;
         let expected = [-2, 1, 3, 5, 9, 11, 13, 16, 19, 24];
-        for x in a.union_iter(&b) {
+        for x in a.union(&b) {
             assert!(expected.contains(x));
             i += 1
         }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -46,7 +46,7 @@ Some examples of obvious things you might want to do
 
 * Pull the lines of a file into a vector of strings
 
-    let lines = File::open("message.txt").line_iter().to_vec();
+    let lines = File::open("message.txt").lines().to_vec();
 
 * Make an simple HTTP request
 

--- a/src/libstd/io/native/process.rs
+++ b/src/libstd/io/native/process.rs
@@ -315,7 +315,7 @@ pub fn make_command_line(prog: &str, args: &[~str]) -> ~str {
     return cmd;
 
     fn append_arg(cmd: &mut ~str, arg: &str) {
-        let quote = arg.iter().any(|c| c == ' ' || c == '\t');
+        let quote = arg.chars().any(|c| c == ' ' || c == '\t');
         if quote {
             cmd.push_char('"');
         }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -200,7 +200,7 @@ pub fn env() -> ~[(~str,~str)] {
         fn env_convert(input: ~[~str]) -> ~[(~str, ~str)] {
             let mut pairs = ~[];
             for p in input.iter() {
-                let vs: ~[&str] = p.splitn_iter('=', 1).collect();
+                let vs: ~[&str] = p.splitn('=', 1).collect();
                 debug!("splitting: len: {}", vs.len());
                 assert_eq!(vs.len(), 2);
                 pairs.push((vs[0].to_owned(), vs[1].to_owned()));

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -20,7 +20,7 @@ appropriate platform-specific path variant.
 Both `PosixPath` and `WindowsPath` implement a trait `GenericPath`, which
 contains the set of methods that behave the same for both paths. They each also
 implement some methods that could not be expressed in `GenericPath`, yet behave
-identically for both path flavors, such as `.component_iter()`.
+identically for both path flavors, such as `.components()`.
 
 The three main design goals of this module are 1) to avoid unnecessary
 allocation, 2) to behave the same regardless of which flavor of path is being

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -170,7 +170,7 @@ impl<'self> ReprVisitor<'self> {
 
     pub fn write_escaped_slice(&mut self, slice: &str) {
         self.writer.write(['"' as u8]);
-        for ch in slice.iter() {
+        for ch in slice.chars() {
             self.write_escaped_char(ch, true);
         }
         self.writer.write(['"' as u8]);

--- a/src/libstd/rt/borrowck.rs
+++ b/src/libstd/rt/borrowck.rs
@@ -17,7 +17,7 @@ use rt::env;
 use rt::local::Local;
 use rt::task;
 use rt::task::Task;
-use str::{OwnedStr, StrSlice};
+use str::OwnedStr;
 use str;
 use uint;
 use unstable::raw;

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -63,8 +63,8 @@ fn parse_log_level(level: &str) -> Option<u32> {
 /// Also supports string log levels of error, warn, info, and debug
 fn parse_logging_spec(spec: ~str) -> ~[LogDirective]{
     let mut dirs = ~[];
-    for s in spec.split_iter(',') {
-        let parts: ~[&str] = s.split_iter('=').collect();
+    for s in spec.split(',') {
+        let parts: ~[&str] = s.split('=').collect();
         let mut log_level;
         let mut name = Some(parts[0].to_owned());
         match parts.len() {

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -77,7 +77,7 @@ pub fn dumb_println(args: &fmt::Arguments) {
 
 pub fn abort(msg: &str) -> ! {
     let msg = if !msg.is_empty() { msg } else { "aborted" };
-    let hash = msg.iter().fold(0, |accum, val| accum + (val as uint) );
+    let hash = msg.chars().fold(0, |accum, val| accum + (val as uint) );
     let quote = match hash % 10 {
         0 => "
 It was from the artists and poets that the pertinent answers came, and I

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -508,14 +508,14 @@ impl<'self, Sep: CharEq> Iterator<&'self str> for CharSplitIterator<'self, Sep> 
 
         let mut next_split = None;
         if self.only_ascii {
-            for (idx, byte) in self.string.byte_iter().enumerate() {
+            for (idx, byte) in self.string.bytes().enumerate() {
                 if self.sep.matches(byte as char) && byte < 128u8 {
                     next_split = Some((idx, idx + 1));
                     break;
                 }
             }
         } else {
-            for (idx, ch) in self.string.char_offset_iter() {
+            for (idx, ch) in self.string.char_indices() {
                 if self.sep.matches(ch) {
                     next_split = Some((idx, self.string.char_range_at(idx).next));
                     break;
@@ -550,14 +550,14 @@ for CharSplitIterator<'self, Sep> {
         let mut next_split = None;
 
         if self.only_ascii {
-            for (idx, byte) in self.string.byte_iter().enumerate().invert() {
+            for (idx, byte) in self.string.bytes().enumerate().invert() {
                 if self.sep.matches(byte as char) && byte < 128u8 {
                     next_split = Some((idx, idx + 1));
                     break;
                 }
             }
         } else {
-            for (idx, ch) in self.string.char_offset_rev_iter() {
+            for (idx, ch) in self.string.char_indices_rev() {
                 if self.sep.matches(ch) {
                     next_split = Some((idx, self.string.char_range_at(idx).next));
                     break;
@@ -763,7 +763,7 @@ impl<'self> Iterator<char> for NormalizationIterator<'self> {
 pub fn replace(s: &str, from: &str, to: &str) -> ~str {
     let mut result = ~"";
     let mut last_end = 0;
-    for (start, end) in s.matches_index_iter(from) {
+    for (start, end) in s.match_indices(from) {
         result.push_str(unsafe{raw::slice_bytes(s, last_end, start)});
         result.push_str(to);
         last_end = end;
@@ -1211,7 +1211,7 @@ pub mod traits {
     impl<'self> TotalOrd for &'self str {
         #[inline]
         fn cmp(&self, other: & &'self str) -> Ordering {
-            for (s_b, o_b) in self.byte_iter().zip(other.byte_iter()) {
+            for (s_b, o_b) in self.bytes().zip(other.bytes()) {
                 match s_b.cmp(&o_b) {
                     Greater => return Greater,
                     Less => return Less,
@@ -1397,26 +1397,26 @@ pub trait StrSlice<'self> {
     /// # Example
     ///
     /// ```rust
-    /// let v: ~[char] = "abc åäö".iter().collect();
+    /// let v: ~[char] = "abc åäö".chars().collect();
     /// assert_eq!(v, ~['a', 'b', 'c', ' ', 'å', 'ä', 'ö']);
     /// ```
-    fn iter(&self) -> CharIterator<'self>;
+    fn chars(&self) -> CharIterator<'self>;
 
     /// An iterator over the characters of `self`, in reverse order.
-    fn rev_iter(&self) -> CharRevIterator<'self>;
+    fn chars_rev(&self) -> CharRevIterator<'self>;
 
     /// An iterator over the bytes of `self`
-    fn byte_iter(&self) -> ByteIterator<'self>;
+    fn bytes(&self) -> ByteIterator<'self>;
 
     /// An iterator over the bytes of `self`, in reverse order
-    fn byte_rev_iter(&self) -> ByteRevIterator<'self>;
+    fn bytes_rev(&self) -> ByteRevIterator<'self>;
 
     /// An iterator over the characters of `self` and their byte offsets.
-    fn char_offset_iter(&self) -> CharOffsetIterator<'self>;
+    fn char_indices(&self) -> CharOffsetIterator<'self>;
 
     /// An iterator over the characters of `self` and their byte offsets,
     /// in reverse order.
-    fn char_offset_rev_iter(&self) -> CharOffsetRevIterator<'self>;
+    fn char_indices_rev(&self) -> CharOffsetRevIterator<'self>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`.
@@ -1424,32 +1424,32 @@ pub trait StrSlice<'self> {
     /// # Example
     ///
     /// ```rust
-    /// let v: ~[&str] = "Mary had a little lamb".split_iter(' ').collect();
+    /// let v: ~[&str] = "Mary had a little lamb".split(' ').collect();
     /// assert_eq!(v, ~["Mary", "had", "a", "little", "lamb"]);
     ///
-    /// let v: ~[&str] = "abc1def2ghi".split_iter(|c: char| c.is_digit()).collect();
+    /// let v: ~[&str] = "abc1def2ghi".split(|c: char| c.is_digit()).collect();
     /// assert_eq!(v, ~["abc", "def", "ghi"]);
     /// ```
-    fn split_iter<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'self, Sep>;
+    fn split<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'self, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, restricted to splitting at most `count`
     /// times.
-    fn splitn_iter<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitNIterator<'self, Sep>;
+    fn splitn<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitNIterator<'self, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`.
     ///
-    /// Equivalent to `split_iter`, except that the trailing substring
+    /// Equivalent to `split`, except that the trailing substring
     /// is skipped if empty (terminator semantics).
     ///
     /// # Example
     ///
     /// ```rust
-    /// let v: ~[&str] = "A.B.".split_terminator_iter('.').collect();
+    /// let v: ~[&str] = "A.B.".split_terminator('.').collect();
     /// assert_eq!(v, ~["A", "B"]);
     /// ```
-    fn split_terminator_iter<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'self, Sep>;
+    fn split_terminator<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'self, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, in reverse order
@@ -1457,47 +1457,47 @@ pub trait StrSlice<'self> {
     /// # Example
     ///
     /// ```rust
-    /// let v: ~[&str] = "Mary had a little lamb".rsplit_iter(' ').collect();
+    /// let v: ~[&str] = "Mary had a little lamb".rsplit(' ').collect();
     /// assert_eq!(v, ~["lamb", "little", "a", "had", "Mary"]);
     /// ```
-    fn rsplit_iter<Sep: CharEq>(&self, sep: Sep) -> CharRSplitIterator<'self, Sep>;
+    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> CharRSplitIterator<'self, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, starting from the end of the string.
     /// Restricted to splitting at most `count` times.
-    fn rsplitn_iter<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitNIterator<'self, Sep>;
+    fn rsplitn<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitNIterator<'self, Sep>;
 
     /// An iterator over the start and end indices of each match of
     /// `sep` within `self`.
-    fn matches_index_iter(&self, sep: &'self str) -> MatchesIndexIterator<'self>;
+    fn match_indices(&self, sep: &'self str) -> MatchesIndexIterator<'self>;
 
     /// An iterator over the substrings of `self` separated by `sep`.
     ///
     /// # Example
     ///
     /// ```rust
-    /// let v: ~[&str] = "abcXXXabcYYYabc".split_str_iter("abc").collect()
+    /// let v: ~[&str] = "abcXXXabcYYYabc".split_str("abc").collect()
     /// assert_eq!(v, ["", "XXX", "YYY", ""]);
     /// ```
-    fn split_str_iter(&self, &'self str) -> StrSplitIterator<'self>;
+    fn split_str(&self, &'self str) -> StrSplitIterator<'self>;
 
     /// An iterator over the lines of a string (subsequences separated
     /// by `\n`).
-    fn line_iter(&self) -> CharSplitIterator<'self, char>;
+    fn lines(&self) -> CharSplitIterator<'self, char>;
 
     /// An iterator over the lines of a string, separated by either
     /// `\n` or (`\r\n`).
-    fn any_line_iter(&self) -> AnyLineIterator<'self>;
+    fn lines_any(&self) -> AnyLineIterator<'self>;
 
     /// An iterator over the words of a string (subsequences separated
     /// by any sequence of whitespace).
-    fn word_iter(&self) -> WordIterator<'self>;
+    fn words(&self) -> WordIterator<'self>;
 
     /// An Iterator over the string in Unicode Normalization Form D (canonical decomposition)
-    fn nfd_iter(&self) -> NormalizationIterator<'self>;
+    fn nfd_chars(&self) -> NormalizationIterator<'self>;
 
     /// An Iterator over the string in Unicode Normalization Form KD (compatibility decomposition)
-    fn nfkd_iter(&self) -> NormalizationIterator<'self>;
+    fn nfkd_chars(&self) -> NormalizationIterator<'self>;
 
     /// Returns true if the string contains only whitespace
     ///
@@ -1751,7 +1751,7 @@ pub trait StrSlice<'self> {
     /// ```rust
     /// let string = "a\nb\nc";
     /// let mut lines = ~[];
-    /// for line in string.line_iter() { lines.push(line) }
+    /// for line in string.lines() { lines.push(line) }
     ///
     /// assert!(string.subslice_offset(lines[0]) == 0); // &"a"
     /// assert!(string.subslice_offset(lines[1]) == 2); // &"b"
@@ -1777,37 +1777,37 @@ impl<'self> StrSlice<'self> for &'self str {
     }
 
     #[inline]
-    fn iter(&self) -> CharIterator<'self> {
+    fn chars(&self) -> CharIterator<'self> {
         CharIterator{string: *self}
     }
 
     #[inline]
-    fn rev_iter(&self) -> CharRevIterator<'self> {
-        self.iter().invert()
+    fn chars_rev(&self) -> CharRevIterator<'self> {
+        self.chars().invert()
     }
 
     #[inline]
-    fn byte_iter(&self) -> ByteIterator<'self> {
+    fn bytes(&self) -> ByteIterator<'self> {
         self.as_bytes().iter().map(|&b| b)
     }
 
     #[inline]
-    fn byte_rev_iter(&self) -> ByteRevIterator<'self> {
-        self.byte_iter().invert()
+    fn bytes_rev(&self) -> ByteRevIterator<'self> {
+        self.bytes().invert()
     }
 
     #[inline]
-    fn char_offset_iter(&self) -> CharOffsetIterator<'self> {
-        CharOffsetIterator{string: *self, iter: self.iter()}
+    fn char_indices(&self) -> CharOffsetIterator<'self> {
+        CharOffsetIterator{string: *self, iter: self.chars()}
     }
 
     #[inline]
-    fn char_offset_rev_iter(&self) -> CharOffsetRevIterator<'self> {
-        self.char_offset_iter().invert()
+    fn char_indices_rev(&self) -> CharOffsetRevIterator<'self> {
+        self.char_indices().invert()
     }
 
     #[inline]
-    fn split_iter<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'self, Sep> {
+    fn split<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'self, Sep> {
         CharSplitIterator {
             string: *self,
             only_ascii: sep.only_ascii(),
@@ -1818,41 +1818,41 @@ impl<'self> StrSlice<'self> for &'self str {
     }
 
     #[inline]
-    fn splitn_iter<Sep: CharEq>(&self, sep: Sep, count: uint)
+    fn splitn<Sep: CharEq>(&self, sep: Sep, count: uint)
         -> CharSplitNIterator<'self, Sep> {
         CharSplitNIterator {
-            iter: self.split_iter(sep),
+            iter: self.split(sep),
             count: count,
             invert: false,
         }
     }
 
     #[inline]
-    fn split_terminator_iter<Sep: CharEq>(&self, sep: Sep)
+    fn split_terminator<Sep: CharEq>(&self, sep: Sep)
         -> CharSplitIterator<'self, Sep> {
         CharSplitIterator {
             allow_trailing_empty: false,
-            ..self.split_iter(sep)
+            ..self.split(sep)
         }
     }
 
     #[inline]
-    fn rsplit_iter<Sep: CharEq>(&self, sep: Sep) -> CharRSplitIterator<'self, Sep> {
-        self.split_iter(sep).invert()
+    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> CharRSplitIterator<'self, Sep> {
+        self.split(sep).invert()
     }
 
     #[inline]
-    fn rsplitn_iter<Sep: CharEq>(&self, sep: Sep, count: uint)
+    fn rsplitn<Sep: CharEq>(&self, sep: Sep, count: uint)
         -> CharSplitNIterator<'self, Sep> {
         CharSplitNIterator {
-            iter: self.split_iter(sep),
+            iter: self.split(sep),
             count: count,
             invert: true,
         }
     }
 
     #[inline]
-    fn matches_index_iter(&self, sep: &'self str) -> MatchesIndexIterator<'self> {
+    fn match_indices(&self, sep: &'self str) -> MatchesIndexIterator<'self> {
         assert!(!sep.is_empty())
         MatchesIndexIterator {
             haystack: *self,
@@ -1862,21 +1862,21 @@ impl<'self> StrSlice<'self> for &'self str {
     }
 
     #[inline]
-    fn split_str_iter(&self, sep: &'self str) -> StrSplitIterator<'self> {
+    fn split_str(&self, sep: &'self str) -> StrSplitIterator<'self> {
         StrSplitIterator {
-            it: self.matches_index_iter(sep),
+            it: self.match_indices(sep),
             last_end: 0,
             finished: false
         }
     }
 
     #[inline]
-    fn line_iter(&self) -> CharSplitIterator<'self, char> {
-        self.split_terminator_iter('\n')
+    fn lines(&self) -> CharSplitIterator<'self, char> {
+        self.split_terminator('\n')
     }
 
-    fn any_line_iter(&self) -> AnyLineIterator<'self> {
-        do self.line_iter().map |line| {
+    fn lines_any(&self) -> AnyLineIterator<'self> {
+        do self.lines().map |line| {
             let l = line.len();
             if l > 0 && line[l - 1] == '\r' as u8 { line.slice(0, l - 1) }
             else { line }
@@ -1884,14 +1884,14 @@ impl<'self> StrSlice<'self> for &'self str {
     }
 
     #[inline]
-    fn word_iter(&self) -> WordIterator<'self> {
-        self.split_iter(char::is_whitespace).filter(|s| !s.is_empty())
+    fn words(&self) -> WordIterator<'self> {
+        self.split(char::is_whitespace).filter(|s| !s.is_empty())
     }
 
     #[inline]
-    fn nfd_iter(&self) -> NormalizationIterator<'self> {
+    fn nfd_chars(&self) -> NormalizationIterator<'self> {
         NormalizationIterator {
-            iter: self.iter(),
+            iter: self.chars(),
             buffer: ~[],
             sorted: false,
             kind: NFD
@@ -1899,9 +1899,9 @@ impl<'self> StrSlice<'self> for &'self str {
     }
 
     #[inline]
-    fn nfkd_iter(&self) -> NormalizationIterator<'self> {
+    fn nfkd_chars(&self) -> NormalizationIterator<'self> {
         NormalizationIterator {
-            iter: self.iter(),
+            iter: self.chars(),
             buffer: ~[],
             sorted: false,
             kind: NFKD
@@ -1909,13 +1909,13 @@ impl<'self> StrSlice<'self> for &'self str {
     }
 
     #[inline]
-    fn is_whitespace(&self) -> bool { self.iter().all(char::is_whitespace) }
+    fn is_whitespace(&self) -> bool { self.chars().all(char::is_whitespace) }
 
     #[inline]
-    fn is_alphanumeric(&self) -> bool { self.iter().all(char::is_alphanumeric) }
+    fn is_alphanumeric(&self) -> bool { self.chars().all(char::is_alphanumeric) }
 
     #[inline]
-    fn char_len(&self) -> uint { self.iter().len() }
+    fn char_len(&self) -> uint { self.chars().len() }
 
     #[inline]
     fn slice(&self, begin: uint, end: uint) -> &'self str {
@@ -1942,7 +1942,7 @@ impl<'self> StrSlice<'self> for &'self str {
 
         // This could be even more efficient by not decoding,
         // only finding the char boundaries
-        for (idx, _) in self.char_offset_iter() {
+        for (idx, _) in self.char_indices() {
             if count == begin { begin_byte = Some(idx); }
             if count == end { end_byte = Some(idx); break; }
             count += 1;
@@ -1972,7 +1972,7 @@ impl<'self> StrSlice<'self> for &'self str {
     fn escape_default(&self) -> ~str {
         let mut out: ~str = ~"";
         out.reserve_at_least(self.len());
-        for c in self.iter() {
+        for c in self.chars() {
             do c.escape_default |c| {
                 out.push_char(c);
             }
@@ -1983,7 +1983,7 @@ impl<'self> StrSlice<'self> for &'self str {
     fn escape_unicode(&self) -> ~str {
         let mut out: ~str = ~"";
         out.reserve_at_least(self.len());
-        for c in self.iter() {
+        for c in self.chars() {
             do c.escape_unicode |c| {
                 out.push_char(c);
             }
@@ -2033,7 +2033,7 @@ impl<'self> StrSlice<'self> for &'self str {
     fn replace(&self, from: &str, to: &str) -> ~str {
         let mut result = ~"";
         let mut last_end = 0;
-        for (start, end) in self.matches_index_iter(from) {
+        for (start, end) in self.match_indices(from) {
             result.push_str(unsafe{raw::slice_bytes(*self, last_end, start)});
             result.push_str(to);
             last_end = end;
@@ -2067,7 +2067,7 @@ impl<'self> StrSlice<'self> for &'self str {
 
     fn to_utf16(&self) -> ~[u16] {
         let mut u = ~[];
-        for ch in self.iter() {
+        for ch in self.chars() {
             // Arithmetic with u32 literals is easier on the eyes than chars.
             let mut ch = ch as u32;
 
@@ -2172,9 +2172,9 @@ impl<'self> StrSlice<'self> for &'self str {
 
     fn find<C: CharEq>(&self, search: C) -> Option<uint> {
         if search.only_ascii() {
-            self.byte_iter().position(|b| search.matches(b as char))
+            self.bytes().position(|b| search.matches(b as char))
         } else {
-            for (index, c) in self.char_offset_iter() {
+            for (index, c) in self.char_indices() {
                 if search.matches(c) { return Some(index); }
             }
             None
@@ -2183,9 +2183,9 @@ impl<'self> StrSlice<'self> for &'self str {
 
     fn rfind<C: CharEq>(&self, search: C) -> Option<uint> {
         if search.only_ascii() {
-            self.byte_iter().rposition(|b| search.matches(b as char))
+            self.bytes().rposition(|b| search.matches(b as char))
         } else {
-            for (index, c) in self.char_offset_rev_iter() {
+            for (index, c) in self.char_indices_rev() {
                 if search.matches(c) { return Some(index); }
             }
             None
@@ -2196,7 +2196,7 @@ impl<'self> StrSlice<'self> for &'self str {
         if needle.is_empty() {
             Some(0)
         } else {
-            self.matches_index_iter(needle)
+            self.match_indices(needle)
                 .next()
                 .map(|(start, _end)| start)
         }
@@ -2226,12 +2226,12 @@ impl<'self> StrSlice<'self> for &'self str {
 
         let mut dcol = vec::from_fn(tlen + 1, |x| x);
 
-        for (i, sc) in self.iter().enumerate() {
+        for (i, sc) in self.chars().enumerate() {
 
             let mut current = i;
             dcol[0] = current + 1;
 
-            for (j, tc) in t.iter().enumerate() {
+            for (j, tc) in t.chars().enumerate() {
 
                 let next = dcol[j + 1];
 
@@ -2674,10 +2674,10 @@ mod tests {
     #[test]
     fn test_collect() {
         let empty = ~"";
-        let s: ~str = empty.iter().collect();
+        let s: ~str = empty.chars().collect();
         assert_eq!(empty, s);
         let data = ~"ประเทศไทย中";
-        let s: ~str = data.iter().collect();
+        let s: ~str = data.chars().collect();
         assert_eq!(data, s);
     }
 
@@ -2686,7 +2686,7 @@ mod tests {
         let data = ~"ประเทศไทย中";
         let mut cpy = data.clone();
         let other = "abc";
-        let mut it = other.iter();
+        let mut it = other.chars();
         cpy.extend(&mut it);
         assert_eq!(cpy, data + other);
     }
@@ -3227,7 +3227,7 @@ mod tests {
 
         let string = "a\nb\nc";
         let mut lines = ~[];
-        for line in string.line_iter() { lines.push(line) }
+        for line in string.lines() { lines.push(line) }
         assert_eq!(string.subslice_offset(lines[0]), 0);
         assert_eq!(string.subslice_offset(lines[1]), 2);
         assert_eq!(string.subslice_offset(lines[2]), 4);
@@ -3443,7 +3443,7 @@ mod tests {
         let v = ~['ศ','ไ','ท','ย','中','华','V','i','ệ','t',' ','N','a','m'];
 
         let mut pos = 0;
-        let mut it = s.iter();
+        let mut it = s.chars();
 
         for c in it {
             assert_eq!(c, v[pos]);
@@ -3459,7 +3459,7 @@ mod tests {
         let v = ~['m', 'a', 'N', ' ', 't', 'ệ','i','V','华','中','ย','ท','ไ','ศ'];
 
         let mut pos = 0;
-        let mut it = s.rev_iter();
+        let mut it = s.chars_rev();
 
         for c in it {
             assert_eq!(c, v[pos]);
@@ -3471,13 +3471,13 @@ mod tests {
     #[test]
     fn test_iterator_clone() {
         let s = "ศไทย中华Việt Nam";
-        let mut it = s.iter();
+        let mut it = s.chars();
         it.next();
         assert!(it.zip(it.clone()).all(|(x,y)| x == y));
     }
 
     #[test]
-    fn test_byte_iterator() {
+    fn test_bytesator() {
         let s = ~"ศไทย中华Việt Nam";
         let v = [
             224, 184, 168, 224, 185, 132, 224, 184, 151, 224, 184, 162, 228,
@@ -3486,14 +3486,14 @@ mod tests {
         ];
         let mut pos = 0;
 
-        for b in s.byte_iter() {
+        for b in s.bytes() {
             assert_eq!(b, v[pos]);
             pos += 1;
         }
     }
 
     #[test]
-    fn test_byte_rev_iterator() {
+    fn test_bytes_revator() {
         let s = ~"ศไทย中华Việt Nam";
         let v = [
             224, 184, 168, 224, 185, 132, 224, 184, 151, 224, 184, 162, 228,
@@ -3502,21 +3502,21 @@ mod tests {
         ];
         let mut pos = v.len();
 
-        for b in s.byte_rev_iter() {
+        for b in s.bytes_rev() {
             pos -= 1;
             assert_eq!(b, v[pos]);
         }
     }
 
     #[test]
-    fn test_char_offset_iterator() {
+    fn test_char_indicesator() {
         use iter::*;
         let s = "ศไทย中华Việt Nam";
         let p = [0, 3, 6, 9, 12, 15, 18, 19, 20, 23, 24, 25, 26, 27];
         let v = ['ศ','ไ','ท','ย','中','华','V','i','ệ','t',' ','N','a','m'];
 
         let mut pos = 0;
-        let mut it = s.char_offset_iter();
+        let mut it = s.char_indices();
 
         for c in it {
             assert_eq!(c, (p[pos], v[pos]));
@@ -3527,14 +3527,14 @@ mod tests {
     }
 
     #[test]
-    fn test_char_offset_rev_iterator() {
+    fn test_char_indices_revator() {
         use iter::*;
         let s = "ศไทย中华Việt Nam";
         let p = [27, 26, 25, 24, 23, 20, 19, 18, 15, 12, 9, 6, 3, 0];
         let v = ['m', 'a', 'N', ' ', 't', 'ệ','i','V','华','中','ย','ท','ไ','ศ'];
 
         let mut pos = 0;
-        let mut it = s.char_offset_rev_iter();
+        let mut it = s.char_indices_rev();
 
         for c in it {
             assert_eq!(c, (p[pos], v[pos]));
@@ -3548,32 +3548,32 @@ mod tests {
     fn test_split_char_iterator() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let split: ~[&str] = data.split_iter(' ').collect();
+        let split: ~[&str] = data.split(' ').collect();
         assert_eq!( split, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit_iter(' ').collect();
+        let mut rsplit: ~[&str] = data.rsplit(' ').collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
-        let split: ~[&str] = data.split_iter(|c: char| c == ' ').collect();
+        let split: ~[&str] = data.split(|c: char| c == ' ').collect();
         assert_eq!( split, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit_iter(|c: char| c == ' ').collect();
+        let mut rsplit: ~[&str] = data.rsplit(|c: char| c == ' ').collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
         // Unicode
-        let split: ~[&str] = data.split_iter('ä').collect();
+        let split: ~[&str] = data.split('ä').collect();
         assert_eq!( split, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit_iter('ä').collect();
+        let mut rsplit: ~[&str] = data.rsplit('ä').collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
 
-        let split: ~[&str] = data.split_iter(|c: char| c == 'ä').collect();
+        let split: ~[&str] = data.split(|c: char| c == 'ä').collect();
         assert_eq!( split, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit_iter(|c: char| c == 'ä').collect();
+        let mut rsplit: ~[&str] = data.rsplit(|c: char| c == 'ä').collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
     }
@@ -3582,17 +3582,17 @@ mod tests {
     fn test_splitn_char_iterator() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let split: ~[&str] = data.splitn_iter(' ', 3).collect();
+        let split: ~[&str] = data.splitn(' ', 3).collect();
         assert_eq!(split, ~["\nMäry", "häd", "ä", "little lämb\nLittle lämb\n"]);
 
-        let split: ~[&str] = data.splitn_iter(|c: char| c == ' ', 3).collect();
+        let split: ~[&str] = data.splitn(|c: char| c == ' ', 3).collect();
         assert_eq!(split, ~["\nMäry", "häd", "ä", "little lämb\nLittle lämb\n"]);
 
         // Unicode
-        let split: ~[&str] = data.splitn_iter('ä', 3).collect();
+        let split: ~[&str] = data.splitn('ä', 3).collect();
         assert_eq!(split, ~["\nM", "ry h", "d ", " little lämb\nLittle lämb\n"]);
 
-        let split: ~[&str] = data.splitn_iter(|c: char| c == 'ä', 3).collect();
+        let split: ~[&str] = data.splitn(|c: char| c == 'ä', 3).collect();
         assert_eq!(split, ~["\nM", "ry h", "d ", " little lämb\nLittle lämb\n"]);
     }
 
@@ -3600,20 +3600,20 @@ mod tests {
     fn test_rsplitn_char_iterator() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let mut split: ~[&str] = data.rsplitn_iter(' ', 3).collect();
+        let mut split: ~[&str] = data.rsplitn(' ', 3).collect();
         split.reverse();
         assert_eq!(split, ~["\nMäry häd ä", "little", "lämb\nLittle", "lämb\n"]);
 
-        let mut split: ~[&str] = data.rsplitn_iter(|c: char| c == ' ', 3).collect();
+        let mut split: ~[&str] = data.rsplitn(|c: char| c == ' ', 3).collect();
         split.reverse();
         assert_eq!(split, ~["\nMäry häd ä", "little", "lämb\nLittle", "lämb\n"]);
 
         // Unicode
-        let mut split: ~[&str] = data.rsplitn_iter('ä', 3).collect();
+        let mut split: ~[&str] = data.rsplitn('ä', 3).collect();
         split.reverse();
         assert_eq!(split, ~["\nMäry häd ", " little l", "mb\nLittle l", "mb\n"]);
 
-        let mut split: ~[&str] = data.rsplitn_iter(|c: char| c == 'ä', 3).collect();
+        let mut split: ~[&str] = data.rsplitn(|c: char| c == 'ä', 3).collect();
         split.reverse();
         assert_eq!(split, ~["\nMäry häd ", " little l", "mb\nLittle l", "mb\n"]);
     }
@@ -3622,10 +3622,10 @@ mod tests {
     fn test_split_char_iterator_no_trailing() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let split: ~[&str] = data.split_iter('\n').collect();
+        let split: ~[&str] = data.split('\n').collect();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb", ""]);
 
-        let split: ~[&str] = data.split_terminator_iter('\n').collect();
+        let split: ~[&str] = data.split_terminator('\n').collect();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb"]);
     }
 
@@ -3633,65 +3633,65 @@ mod tests {
     fn test_rev_split_char_iterator_no_trailing() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let mut split: ~[&str] = data.split_iter('\n').invert().collect();
+        let mut split: ~[&str] = data.split('\n').invert().collect();
         split.reverse();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb", ""]);
 
-        let mut split: ~[&str] = data.split_terminator_iter('\n').invert().collect();
+        let mut split: ~[&str] = data.split_terminator('\n').invert().collect();
         split.reverse();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb"]);
     }
 
     #[test]
-    fn test_word_iter() {
+    fn test_words() {
         let data = "\n \tMäry   häd\tä  little lämb\nLittle lämb\n";
-        let words: ~[&str] = data.word_iter().collect();
+        let words: ~[&str] = data.words().collect();
         assert_eq!(words, ~["Märy", "häd", "ä", "little", "lämb", "Little", "lämb"])
     }
 
     #[test]
-    fn test_nfd_iter() {
-        assert_eq!("abc".nfd_iter().collect::<~str>(), ~"abc");
-        assert_eq!("\u1e0b\u01c4".nfd_iter().collect::<~str>(), ~"d\u0307\u01c4");
-        assert_eq!("\u2026".nfd_iter().collect::<~str>(), ~"\u2026");
-        assert_eq!("\u2126".nfd_iter().collect::<~str>(), ~"\u03a9");
-        assert_eq!("\u1e0b\u0323".nfd_iter().collect::<~str>(), ~"d\u0323\u0307");
-        assert_eq!("\u1e0d\u0307".nfd_iter().collect::<~str>(), ~"d\u0323\u0307");
-        assert_eq!("a\u0301".nfd_iter().collect::<~str>(), ~"a\u0301");
-        assert_eq!("\u0301a".nfd_iter().collect::<~str>(), ~"\u0301a");
-        assert_eq!("\ud4db".nfd_iter().collect::<~str>(), ~"\u1111\u1171\u11b6");
-        assert_eq!("\uac1c".nfd_iter().collect::<~str>(), ~"\u1100\u1162");
+    fn test_nfd_chars() {
+        assert_eq!("abc".nfd_chars().collect::<~str>(), ~"abc");
+        assert_eq!("\u1e0b\u01c4".nfd_chars().collect::<~str>(), ~"d\u0307\u01c4");
+        assert_eq!("\u2026".nfd_chars().collect::<~str>(), ~"\u2026");
+        assert_eq!("\u2126".nfd_chars().collect::<~str>(), ~"\u03a9");
+        assert_eq!("\u1e0b\u0323".nfd_chars().collect::<~str>(), ~"d\u0323\u0307");
+        assert_eq!("\u1e0d\u0307".nfd_chars().collect::<~str>(), ~"d\u0323\u0307");
+        assert_eq!("a\u0301".nfd_chars().collect::<~str>(), ~"a\u0301");
+        assert_eq!("\u0301a".nfd_chars().collect::<~str>(), ~"\u0301a");
+        assert_eq!("\ud4db".nfd_chars().collect::<~str>(), ~"\u1111\u1171\u11b6");
+        assert_eq!("\uac1c".nfd_chars().collect::<~str>(), ~"\u1100\u1162");
     }
 
     #[test]
-    fn test_nfkd_iter() {
-        assert_eq!("abc".nfkd_iter().collect::<~str>(), ~"abc");
-        assert_eq!("\u1e0b\u01c4".nfkd_iter().collect::<~str>(), ~"d\u0307DZ\u030c");
-        assert_eq!("\u2026".nfkd_iter().collect::<~str>(), ~"...");
-        assert_eq!("\u2126".nfkd_iter().collect::<~str>(), ~"\u03a9");
-        assert_eq!("\u1e0b\u0323".nfkd_iter().collect::<~str>(), ~"d\u0323\u0307");
-        assert_eq!("\u1e0d\u0307".nfkd_iter().collect::<~str>(), ~"d\u0323\u0307");
-        assert_eq!("a\u0301".nfkd_iter().collect::<~str>(), ~"a\u0301");
-        assert_eq!("\u0301a".nfkd_iter().collect::<~str>(), ~"\u0301a");
-        assert_eq!("\ud4db".nfkd_iter().collect::<~str>(), ~"\u1111\u1171\u11b6");
-        assert_eq!("\uac1c".nfkd_iter().collect::<~str>(), ~"\u1100\u1162");
+    fn test_nfkd_chars() {
+        assert_eq!("abc".nfkd_chars().collect::<~str>(), ~"abc");
+        assert_eq!("\u1e0b\u01c4".nfkd_chars().collect::<~str>(), ~"d\u0307DZ\u030c");
+        assert_eq!("\u2026".nfkd_chars().collect::<~str>(), ~"...");
+        assert_eq!("\u2126".nfkd_chars().collect::<~str>(), ~"\u03a9");
+        assert_eq!("\u1e0b\u0323".nfkd_chars().collect::<~str>(), ~"d\u0323\u0307");
+        assert_eq!("\u1e0d\u0307".nfkd_chars().collect::<~str>(), ~"d\u0323\u0307");
+        assert_eq!("a\u0301".nfkd_chars().collect::<~str>(), ~"a\u0301");
+        assert_eq!("\u0301a".nfkd_chars().collect::<~str>(), ~"\u0301a");
+        assert_eq!("\ud4db".nfkd_chars().collect::<~str>(), ~"\u1111\u1171\u11b6");
+        assert_eq!("\uac1c".nfkd_chars().collect::<~str>(), ~"\u1100\u1162");
     }
 
     #[test]
-    fn test_line_iter() {
+    fn test_lines() {
         let data = "\nMäry häd ä little lämb\n\nLittle lämb\n";
-        let lines: ~[&str] = data.line_iter().collect();
+        let lines: ~[&str] = data.lines().collect();
         assert_eq!(lines, ~["", "Märy häd ä little lämb", "", "Little lämb"]);
 
         let data = "\nMäry häd ä little lämb\n\nLittle lämb"; // no trailing \n
-        let lines: ~[&str] = data.line_iter().collect();
+        let lines: ~[&str] = data.lines().collect();
         assert_eq!(lines, ~["", "Märy häd ä little lämb", "", "Little lämb"]);
     }
 
     #[test]
-    fn test_split_str_iterator() {
+    fn test_split_strator() {
         fn t<'a>(s: &str, sep: &'a str, u: ~[&str]) {
-            let v: ~[&str] = s.split_str_iter(sep).collect();
+            let v: ~[&str] = s.split_str(sep).collect();
             assert_eq!(v, u);
         }
         t("--1233345--", "12345", ~["--1233345--"]);
@@ -3865,7 +3865,7 @@ mod bench {
         let len = s.char_len();
 
         do bh.iter {
-            assert_eq!(s.iter().len(), len);
+            assert_eq!(s.chars().len(), len);
         }
     }
 
@@ -3880,7 +3880,7 @@ mod bench {
         let len = s.char_len();
 
         do bh.iter {
-            assert_eq!(s.iter().len(), len);
+            assert_eq!(s.chars().len(), len);
         }
     }
 
@@ -3890,41 +3890,41 @@ mod bench {
         let len = s.char_len();
 
         do bh.iter {
-            assert_eq!(s.rev_iter().len(), len);
+            assert_eq!(s.chars_rev().len(), len);
         }
     }
 
     #[bench]
-    fn char_offset_iterator(bh: &mut BenchHarness) {
+    fn char_indicesator(bh: &mut BenchHarness) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
         do bh.iter {
-            assert_eq!(s.char_offset_iter().len(), len);
+            assert_eq!(s.char_indices().len(), len);
         }
     }
 
     #[bench]
-    fn char_offset_iterator_rev(bh: &mut BenchHarness) {
+    fn char_indicesator_rev(bh: &mut BenchHarness) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
         do bh.iter {
-            assert_eq!(s.char_offset_rev_iter().len(), len);
+            assert_eq!(s.char_indices_rev().len(), len);
         }
     }
 
     #[bench]
-    fn split_iter_unicode_ascii(bh: &mut BenchHarness) {
+    fn split_unicode_ascii(bh: &mut BenchHarness) {
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
         do bh.iter {
-            assert_eq!(s.split_iter('V').len(), 3);
+            assert_eq!(s.split('V').len(), 3);
         }
     }
 
     #[bench]
-    fn split_iter_unicode_not_ascii(bh: &mut BenchHarness) {
+    fn split_unicode_not_ascii(bh: &mut BenchHarness) {
         struct NotAscii(char);
         impl CharEq for NotAscii {
             fn matches(&self, c: char) -> bool {
@@ -3935,23 +3935,23 @@ mod bench {
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
         do bh.iter {
-            assert_eq!(s.split_iter(NotAscii('V')).len(), 3);
+            assert_eq!(s.split(NotAscii('V')).len(), 3);
         }
     }
 
 
     #[bench]
-    fn split_iter_ascii(bh: &mut BenchHarness) {
+    fn split_ascii(bh: &mut BenchHarness) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split_iter(' ').len();
+        let len = s.split(' ').len();
 
         do bh.iter {
-            assert_eq!(s.split_iter(' ').len(), len);
+            assert_eq!(s.split(' ').len(), len);
         }
     }
 
     #[bench]
-    fn split_iter_not_ascii(bh: &mut BenchHarness) {
+    fn split_not_ascii(bh: &mut BenchHarness) {
         struct NotAscii(char);
         impl CharEq for NotAscii {
             #[inline]
@@ -3959,41 +3959,41 @@ mod bench {
             fn only_ascii(&self) -> bool { false }
         }
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split_iter(' ').len();
+        let len = s.split(' ').len();
 
         do bh.iter {
-            assert_eq!(s.split_iter(NotAscii(' ')).len(), len);
+            assert_eq!(s.split(NotAscii(' ')).len(), len);
         }
     }
 
     #[bench]
-    fn split_iter_extern_fn(bh: &mut BenchHarness) {
+    fn split_extern_fn(bh: &mut BenchHarness) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split_iter(' ').len();
+        let len = s.split(' ').len();
         fn pred(c: char) -> bool { c == ' ' }
 
         do bh.iter {
-            assert_eq!(s.split_iter(pred).len(), len);
+            assert_eq!(s.split(pred).len(), len);
         }
     }
 
     #[bench]
-    fn split_iter_closure(bh: &mut BenchHarness) {
+    fn split_closure(bh: &mut BenchHarness) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split_iter(' ').len();
+        let len = s.split(' ').len();
 
         do bh.iter {
-            assert_eq!(s.split_iter(|c: char| c == ' ').len(), len);
+            assert_eq!(s.split(|c: char| c == ' ').len(), len);
         }
     }
 
     #[bench]
-    fn split_iter_slice(bh: &mut BenchHarness) {
+    fn split_slice(bh: &mut BenchHarness) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split_iter(' ').len();
+        let len = s.split(' ').len();
 
         do bh.iter {
-            assert_eq!(s.split_iter(&[' ']).len(), len);
+            assert_eq!(s.split(&[' ']).len(), len);
         }
     }
 

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -158,7 +158,7 @@ impl<T> TrieMap<T> {
 
     // If `upper` is true then returns upper_bound else returns lower_bound.
     #[inline]
-    fn bound_iter<'a>(&'a self, key: uint, upper: bool) -> TrieMapIterator<'a, T> {
+    fn bound<'a>(&'a self, key: uint, upper: bool) -> TrieMapIterator<'a, T> {
         let mut node: &'a TrieNode<T> = &self.root;
         let mut idx = 0;
         let mut it = TrieMapIterator {
@@ -193,14 +193,14 @@ impl<T> TrieMap<T> {
 
     /// Get an iterator pointing to the first key-value pair whose key is not less than `key`.
     /// If all keys in the map are less than `key` an empty iterator is returned.
-    pub fn lower_bound_iter<'a>(&'a self, key: uint) -> TrieMapIterator<'a, T> {
-        self.bound_iter(key, false)
+    pub fn lower_bound<'a>(&'a self, key: uint) -> TrieMapIterator<'a, T> {
+        self.bound(key, false)
     }
 
     /// Get an iterator pointing to the first key-value pair whose key is greater than `key`.
     /// If all keys in the map are not greater than `key` an empty iterator is returned.
-    pub fn upper_bound_iter<'a>(&'a self, key: uint) -> TrieMapIterator<'a, T> {
-        self.bound_iter(key, true)
+    pub fn upper_bound<'a>(&'a self, key: uint) -> TrieMapIterator<'a, T> {
+        self.bound(key, true)
     }
 }
 
@@ -282,14 +282,14 @@ impl TrieSet {
 
     /// Get an iterator pointing to the first value that is not less than `val`.
     /// If all values in the set are less than `val` an empty iterator is returned.
-    pub fn lower_bound_iter<'a>(&'a self, val: uint) -> TrieSetIterator<'a> {
-        TrieSetIterator{iter: self.map.lower_bound_iter(val)}
+    pub fn lower_bound<'a>(&'a self, val: uint) -> TrieSetIterator<'a> {
+        TrieSetIterator{iter: self.map.lower_bound(val)}
     }
 
     /// Get an iterator pointing to the first value that key is greater than `val`.
     /// If all values in the set are not greater than `val` an empty iterator is returned.
-    pub fn upper_bound_iter<'a>(&'a self, val: uint) -> TrieSetIterator<'a> {
-        TrieSetIterator{iter: self.map.upper_bound_iter(val)}
+    pub fn upper_bound<'a>(&'a self, val: uint) -> TrieSetIterator<'a> {
+        TrieSetIterator{iter: self.map.upper_bound(val)}
     }
 }
 
@@ -713,10 +713,10 @@ mod test_map {
     }
 
     #[test]
-    fn test_bound_iter() {
+    fn test_bound() {
         let empty_map : TrieMap<uint> = TrieMap::new();
-        assert_eq!(empty_map.lower_bound_iter(0).next(), None);
-        assert_eq!(empty_map.upper_bound_iter(0).next(), None);
+        assert_eq!(empty_map.lower_bound(0).next(), None);
+        assert_eq!(empty_map.upper_bound(0).next(), None);
 
         let last = 999u;
         let step = 3u;
@@ -729,8 +729,8 @@ mod test_map {
         }
 
         for i in range(0u, last - step) {
-            let mut lb = map.lower_bound_iter(i);
-            let mut ub = map.upper_bound_iter(i);
+            let mut lb = map.lower_bound(i);
+            let mut ub = map.upper_bound(i);
             let next_key = i - i % step + step;
             let next_pair = (next_key, &value);
             if (i % step == 0) {
@@ -741,15 +741,15 @@ mod test_map {
             assert_eq!(ub.next(), Some(next_pair));
         }
 
-        let mut lb = map.lower_bound_iter(last - step);
+        let mut lb = map.lower_bound(last - step);
         assert_eq!(lb.next(), Some((last - step, &value)));
-        let mut ub = map.upper_bound_iter(last - step);
+        let mut ub = map.upper_bound(last - step);
         assert_eq!(ub.next(), None);
 
         for i in range(last - step + 1, last) {
-            let mut lb = map.lower_bound_iter(i);
+            let mut lb = map.lower_bound(i);
             assert_eq!(lb.next(), None);
-            let mut ub = map.upper_bound_iter(i);
+            let mut ub = map.upper_bound(i);
             assert_eq!(ub.next(), None);
         }
     }

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -29,7 +29,7 @@ pub fn expand_syntax_ext(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> bas
             ast::ExprLit(lit) => match lit.node {
                 // string literal, push each byte to vector expression
                 ast::lit_str(s, _) => {
-                    for byte in s.byte_iter() {
+                    for byte in s.bytes() {
                         bytes.push(cx.expr_u8(expr.span, byte));
                     }
                 }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -60,14 +60,14 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         let mut i = 0u;
         let mut j = lines.len();
         // first line of all-stars should be omitted
-        if lines.len() > 0 && lines[0].iter().all(|c| c == '*') {
+        if lines.len() > 0 && lines[0].chars().all(|c| c == '*') {
             i += 1;
         }
         while i < j && lines[i].trim().is_empty() {
             i += 1;
         }
         // like the first, a last line of all stars should be omitted
-        if j > i && lines[j - 1].iter().skip(1).all(|c| c == '*') {
+        if j > i && lines[j - 1].chars().skip(1).all(|c| c == '*') {
             j -= 1;
         }
         while j > i && lines[j - 1].trim().is_empty() {
@@ -82,7 +82,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         let mut can_trim = true;
         let mut first = true;
         for line in lines.iter() {
-            for (j, c) in line.iter().enumerate() {
+            for (j, c) in line.chars().enumerate() {
                 if j > i || !"* \t".contains_char(c) {
                     can_trim = false;
                     break;
@@ -124,7 +124,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
 
     if comment.starts_with("/*") {
         let lines = comment.slice(3u, comment.len() - 2u)
-            .any_line_iter()
+            .lines_any()
             .map(|s| s.to_owned())
             .collect::<~[~str]>();
 

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -318,7 +318,7 @@ fn consume_whitespace_and_comments(rdr: @mut StringReader)
 
 pub fn is_line_non_doc_comment(s: &str) -> bool {
     let s = s.trim_right();
-    s.len() > 3 && s.iter().all(|ch| ch == '/')
+    s.len() > 3 && s.chars().all(|ch| ch == '/')
 }
 
 // PRECONDITION: rdr.curr is not whitespace
@@ -379,7 +379,7 @@ fn consume_any_line_comment(rdr: @mut StringReader)
 
 pub fn is_block_non_doc_comment(s: &str) -> bool {
     assert!(s.len() >= 1u);
-    s.slice(1u, s.len() - 1u).iter().all(|ch| ch == '*')
+    s.slice(1u, s.len() - 1u).chars().all(|ch| ch == '*')
 }
 
 // might return a sugared-doc-attr

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4586,7 +4586,7 @@ impl Parser {
                 self.bump();
                 let the_string = ident_to_str(&s);
                 let mut abis = AbiSet::empty();
-                for word in the_string.word_iter() {
+                for word in the_string.words() {
                     match abi::lookup(word) {
                         Some(abi) => {
                             if abis.contains(abi) {

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -128,7 +128,7 @@ fn make_masks() -> ~[~[~[u64]]] {
         let mut cur_piece = ~[];
         for dy in range(0, 10) {
             for dx in range(0, 5) {
-                let masks = 
+                let masks =
                     trans.iter()
                     .filter_map(|t| mask(dy, dx, id, *t))
                     .collect();
@@ -192,7 +192,7 @@ fn to_utf8(raw_sol: &List<u64>) -> ~str {
 
 // Prints a solution in ~str form.
 fn print_sol(sol: &str) {
-    for (i, c) in sol.iter().enumerate() {
+    for (i, c) in sol.chars().enumerate() {
         if (i) % 5 == 0 {println("");}
         if (i + 5) % 10 == 0 {print(" ");}
         print!("{} ", c);
@@ -220,7 +220,7 @@ fn handle_sol(raw_sol: &List<u64>, data: &mut Data) -> bool {
     // reverse order, i.e. the board rotated by half a turn.
     data.nb += 2;
     let sol1 = to_utf8(raw_sol);
-    let sol2: ~str = sol1.iter().invert().collect();
+    let sol2: ~str = sol1.chars().invert().collect();
 
     if data.nb == 2 {
         data.min = sol1.clone();

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -76,7 +76,7 @@ impl Sudoku {
             let line = match reader.read_line() {
                 Some(ln) => ln, None => break
             };
-            let comps: ~[&str] = line.trim().split_iter(',').collect();
+            let comps: ~[&str] = line.trim().split(',').collect();
 
             if comps.len() == 3u {
                 let row     = from_str::<uint>(comps[0]).unwrap() as u8;

--- a/src/test/run-pass/linear-for-loop.rs
+++ b/src/test/run-pass/linear-for-loop.rs
@@ -16,7 +16,7 @@ pub fn main() {
     assert_eq!(y, 6);
     let s = ~"hello there";
     let mut i: int = 0;
-    for c in s.byte_iter() {
+    for c in s.bytes() {
         if i == 0 { assert!((c == 'h' as u8)); }
         if i == 1 { assert!((c == 'e' as u8)); }
         if i == 2 { assert!((c == 'l' as u8)); }

--- a/src/test/run-pass/nul-characters.rs
+++ b/src/test/run-pass/nul-characters.rs
@@ -16,23 +16,23 @@ pub fn main()
     let all_nuls4 = "\x00\u0000\0\U00000000";
 
     // sizes for two should suffice
-    assert_eq!(all_nuls1.len(), 4); 
+    assert_eq!(all_nuls1.len(), 4);
     assert_eq!(all_nuls2.len(), 4);
 
     // string equality should pass between the strings
     assert_eq!(all_nuls1, all_nuls2);
     assert_eq!(all_nuls2, all_nuls3);
     assert_eq!(all_nuls3, all_nuls4);
-    
+
     // all extracted characters in all_nuls are equivalent to each other
-    for c1 in all_nuls1.iter()
+    for c1 in all_nuls1.chars()
     {
-        for c2 in all_nuls1.iter()
+        for c2 in all_nuls1.chars()
         {
             assert_eq!(c1,c2);
         }
     }
-    
+
     // testing equality between explicit character literals
     assert_eq!('\0', '\x00');
     assert_eq!('\u0000', '\x00');

--- a/src/test/run-pass/utf8.rs
+++ b/src/test/run-pass/utf8.rs
@@ -41,7 +41,7 @@ pub fn main() {
 
     fn check_str_eq(a: ~str, b: ~str) {
         let mut i: int = 0;
-        for ab in a.byte_iter() {
+        for ab in a.bytes() {
             info!("{}", i);
             info!("{}", ab);
             let bb: u8 = b[i];

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -16,7 +16,7 @@ pub fn main() {
     // Chars of 1, 2, 3, and 4 bytes
     let chs: ~[char] = ~['e', 'é', '€', '\U00010000'];
     let s: ~str = str::from_chars(chs);
-    let schs: ~[char] = s.iter().collect();
+    let schs: ~[char] = s.chars().collect();
 
     assert!(s.len() == 10u);
     assert!(s.char_len() == 4u);


### PR DESCRIPTION
This PR removes almost all `_iter` suffixes in various APIs of the codebase that return Iterators, as discussed in #9440.

As a summarize for the intend behind this PR:
- Iterators are the recommended way to provide a potentially lazy list of values, no need to name them painfully verbose. If anything, functions that return a specific container type should have more verbose names.
- We have a static type system, so no need to encode the return value of a constructor function into its name.

Following is a possibly incomplete list of all renamings I performed in the codebase. For a few of them I'm a bit unsure whether the new name still properly expresses their functionality, so feedback would be welcome:

```
&str : word_iter()             -> words()
       line_iter()             -> lines()
       any_line_iter()         -> lines_any()
       iter()                  -> chars()
       char_offset_iter()      -> char_indices()
       byte_iter()             -> bytes()
       split_iter()            -> split()
       splitn_iter()           -> splitn()
       split_str_iter()        -> split_str()
       split_terminator_iter() -> split_terminator()
       matches_index_iter()    -> match_indices()
       nfd_iter()              -> nfd_chars()
       nfkd_iter()             -> nfkd_chars()

&[T] : split_iter()        -> split()
       splitn_iter()       -> splitn()
       window_iter()       -> windows()
       chunk_iter()        -> chunks()
       permutations_iter() -> permutations()

extra:bitv::Bitv :  rev_liter()    -> rev_iter()
                    common_iter()  -> commons()
                    outlier_iter() -> outliers()

extra::treemap::{...} : lower_bound_iter() -> lower_bound()
                        upper_bound_iter() -> upper_bound()

std::trie::{...} : bound_iter()       -> bound()
                   lower_bound_iter() -> lower_bound()
                   upper_bound_iter() -> upper_bound()

rustpkg::package_id::{...} : prefixes_iter() -> prefixes()

std::hashmap::{...} : difference_iter()           -> difference()
                      symmetric_difference_iter() -> symmetric_difference()
                      intersection_iter()         -> intersection()
                      union_iter()                -> union()

std::path::{posix, windows} : component_iter()     -> components()
                              str_component_iter() -> str_components()

... not showing all identical renamings for reverse versions
```

---

I'm also planning a few more changes, like removing all unnecessary `_rev` constructors (#9391), or reducing the `split` variants on `&str` to a more versatile and concise system.
