### PR TITLE
Cache a task's stderr logger

### DIFF
--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -110,7 +110,11 @@ pub fn log(_level: u32, args: &fmt::Arguments) {
                 match (*local).logger {
                     // Use the available logger if we have one
                     Some(ref mut logger) => return logger.log(args),
-                    None => {}
+                    None => {
+                        let mut logger = StdErrLogger::new();
+                        logger.log(args);
+                        (*local).logger = Some(logger);
+                    }
                 }
             }
             None => {}

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -1,0 +1,40 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+
+// Make sure that if a process doesn't have its stdio/stderr descriptors set up
+// that we don't die in a large ball of fire
+
+use std::os;
+use std::io::process;
+
+fn main () {
+    let args = os::args();
+    if args.len() > 1 && args[1] == ~"child" {
+        for _ in range(0, 1000) {
+            error!("hello?");
+        }
+        for _ in range(0, 1000) {
+            println!("hello?");
+        }
+    }
+
+    let config = process::ProcessConfig {
+        program : args[0].as_slice(),
+        args : [~"child"],
+        env : None,
+        cwd : None,
+        io : []
+    };
+
+    let mut p = process::Process::new(config).unwrap();
+    println!("{}", p.wait());
+}


### PR DESCRIPTION
This is both useful for performance (otherwise logging is unbuffered), but also
useful for correctness. Because when a task is destroyed we can't block the task
waiting for the logger to close, loggers are opened with a 'CloseAsynchronously'
specification. This causes libuv do defer the call to close() until the next
turn of the event loop.

If you spin in a tight loop around printing, you never yield control back to the
libuv event loop, meaning that you simply enqueue a large number of close
requests but nothing is actually closed. This queue ends up never getting
closed, meaning that if you keep trying to create handles one will eventually
fail, which the runtime will attempt to print the failure, causing mass
destruction.

Caching will provide better performance as well as prevent creation of too many
handles.

Closes #10626
