### PR TITLE
Add a note for unclosed delimiters

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2086,15 +2086,13 @@ impl Parser {
         fn parse_non_delim_tt_tok(p: &Parser) -> token_tree {
             maybe_whole!(deref p, nt_tt);
             match *p.token {
-              token::RPAREN | token::RBRACE | token::RBRACKET
-              => {
-                p.fatal(
-                    format!(
-                        "incorrect close delimiter: `{}`",
-                        p.this_token_to_str()
-                    )
-                );
-              }
+              token::RPAREN | token::RBRACE | token::RBRACKET => {
+                  // This is a conservative error: only report the last unclosed delimiter. The
+                  // previous unclosed delimiters could actually be closed! The parser just hasn't
+                  // gotten to them yet.
+                  p.open_braces.last_opt().map(|sp| p.span_note(*sp, "unclosed delimiter"));
+                  p.fatal(format!("incorrect close delimiter: `{}`", p.this_token_to_str()));
+              },
               /* we ought to allow different depths of unquotation */
               token::DOLLAR if *p.quote_depth > 0u => {
                 p.bump();

--- a/src/test/compile-fail/issue-10636-1.rs
+++ b/src/test/compile-fail/issue-10636-1.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Obj { //~ NOTE: unclosed delimiter
+    member: uint
+) //~ ERROR: incorrect close delimiter

--- a/src/test/compile-fail/issue-10636-2.rs
+++ b/src/test/compile-fail/issue-10636-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn trace_option(option: Option<int>) {
+    option.map(|some| 42; //~ NOTE: unclosed delimiter
+} //~ ERROR: incorrect close delimiter


### PR DESCRIPTION
Currently, the parser doesn't give any context when it finds an unclosed
delimiter and it's not EOF. Report the most recent unclosed delimiter, to help
the user along.

Closes #10636
