### PR TITLE
Support macros expanding to multiple items

### DIFF
--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -19,6 +19,7 @@ use syntax::codemap;
 use syntax::fold::ast_fold;
 use syntax::fold;
 use syntax::opt_vec;
+use syntax::util::small_vector::SmallVector;
 
 static STD_VERSION: &'static str = "0.9-pre";
 
@@ -98,14 +99,14 @@ impl fold::ast_fold for StandardLibraryInjector {
         }
     }
 
-    fn fold_item(&self, item: @ast::item) -> Option<@ast::item> {
+    fn fold_item(&self, item: @ast::item) -> SmallVector<@ast::item> {
         if !no_prelude(item.attrs) {
             // only recur if there wasn't `#[no_implicit_prelude];`
             // on this item, i.e. this means that the prelude is not
             // implicitly imported though the whole subtree
             fold::noop_fold_item(item, self)
         } else {
-            Some(item)
+            SmallVector::one(item)
         }
     }
 

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -26,6 +26,7 @@ use syntax::fold;
 use syntax::opt_vec;
 use syntax::print::pprust;
 use syntax::{ast, ast_util};
+use syntax::util::small_vector::SmallVector;
 
 struct Test {
     span: Span,
@@ -76,7 +77,7 @@ impl fold::ast_fold for TestHarnessGenerator {
         }
     }
 
-    fn fold_item(&self, i: @ast::item) -> Option<@ast::item> {
+    fn fold_item(&self, i: @ast::item) -> SmallVector<@ast::item> {
         self.cx.path.push(i.ident);
         debug!("current path: {}",
                ast_util::path_name_i(self.cx.path.clone()));
@@ -108,7 +109,7 @@ impl fold::ast_fold for TestHarnessGenerator {
 
         let res = fold::noop_fold_item(i, self);
         self.cx.path.pop();
-        return res;
+        res
     }
 
     fn fold_mod(&self, m: &ast::_mod) -> ast::_mod {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -33,6 +33,7 @@ use syntax::codemap;
 use syntax::fold::*;
 use syntax::fold;
 use syntax::parse::token;
+use syntax::util::small_vector::SmallVector;
 use syntax;
 
 use std::at_vec;
@@ -347,11 +348,18 @@ fn simplify_ast(ii: &ast::inlined_item) -> ast::inlined_item {
 
     match *ii {
         //hack: we're not dropping items
-        ast::ii_item(i) => ast::ii_item(fld.fold_item(i).unwrap()),
+        ast::ii_item(i) => ast::ii_item(get_only_one(fld.fold_item(i))),
         ast::ii_method(d, is_provided, m) =>
           ast::ii_method(d, is_provided, fld.fold_method(m)),
         ast::ii_foreign(i) => ast::ii_foreign(fld.fold_foreign_item(i))
     }
+}
+
+fn get_only_one<T>(mut v: SmallVector<T>) -> T {
+    if v.len() != 1 {
+        fail!("Attempting to extract unique member but there isn't one");
+    }
+    v.pop()
 }
 
 fn decode_ast(par_doc: ebml::Doc) -> ast::inlined_item {
@@ -379,7 +387,7 @@ fn renumber_ast(xcx: @ExtendedDecodeContext, ii: ast::inlined_item)
         xcx: xcx,
     };
     match ii {
-        ast::ii_item(i) => ast::ii_item(fld.fold_item(i).unwrap()),
+        ast::ii_item(i) => ast::ii_item(get_only_one(fld.fold_item(i))),
         ast::ii_method(d, is_provided, m) =>
           ast::ii_method(xcx.tr_def_id(d), is_provided, fld.fold_method(m)),
         ast::ii_foreign(i) => ast::ii_foreign(fld.fold_foreign_item(i)),

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -33,7 +33,6 @@ use syntax::codemap;
 use syntax::fold::*;
 use syntax::fold;
 use syntax::parse::token;
-use syntax::util::small_vector::SmallVector;
 use syntax;
 
 use std::at_vec;
@@ -348,18 +347,12 @@ fn simplify_ast(ii: &ast::inlined_item) -> ast::inlined_item {
 
     match *ii {
         //hack: we're not dropping items
-        ast::ii_item(i) => ast::ii_item(get_only_one(fld.fold_item(i))),
+        ast::ii_item(i) => ast::ii_item(fld.fold_item(i)
+                                        .expect_one("expected one item")),
         ast::ii_method(d, is_provided, m) =>
           ast::ii_method(d, is_provided, fld.fold_method(m)),
         ast::ii_foreign(i) => ast::ii_foreign(fld.fold_foreign_item(i))
     }
-}
-
-fn get_only_one<T>(mut v: SmallVector<T>) -> T {
-    if v.len() != 1 {
-        fail!("Attempting to extract unique member but there isn't one");
-    }
-    v.pop()
 }
 
 fn decode_ast(par_doc: ebml::Doc) -> ast::inlined_item {
@@ -387,7 +380,8 @@ fn renumber_ast(xcx: @ExtendedDecodeContext, ii: ast::inlined_item)
         xcx: xcx,
     };
     match ii {
-        ast::ii_item(i) => ast::ii_item(get_only_one(fld.fold_item(i))),
+        ast::ii_item(i) => ast::ii_item(fld.fold_item(i)
+                                        .expect_one("expected one item")),
         ast::ii_method(d, is_provided, m) =>
           ast::ii_method(xcx.tr_def_id(d), is_provided, fld.fold_method(m)),
         ast::ii_foreign(i) => ast::ii_foreign(fld.fold_foreign_item(i)),

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -22,6 +22,7 @@ use syntax::{ast, attr, codemap, diagnostic, fold, visit};
 use syntax::attr::AttrMetaMethods;
 use syntax::fold::ast_fold;
 use syntax::visit::Visitor;
+use syntax::util::small_vector::SmallVector;
 use rustc::back::link::output_type_exe;
 use rustc::back::link;
 use rustc::driver::session::{lib_crate, bin_crate};
@@ -99,7 +100,7 @@ fn fold_mod(_ctx: @mut ReadyCtx, m: &ast::_mod, fold: &CrateSetup)
 }
 
 fn fold_item(ctx: @mut ReadyCtx, item: @ast::item, fold: &CrateSetup)
-             -> Option<@ast::item> {
+             -> SmallVector<@ast::item> {
     ctx.path.push(item.ident);
 
     let mut cmds = ~[];
@@ -142,7 +143,7 @@ struct CrateSetup {
 }
 
 impl fold::ast_fold for CrateSetup {
-    fn fold_item(&self, item: @ast::item) -> Option<@ast::item> {
+    fn fold_item(&self, item: @ast::item) -> SmallVector<@ast::item> {
         fold_item(self.ctx, item, self)
     }
     fn fold_mod(&self, module: &ast::_mod) -> ast::_mod {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -18,6 +18,7 @@ use ext::expand;
 use parse;
 use parse::token;
 use parse::token::{ident_to_str, intern, str_to_ident};
+use util::small_vector::SmallVector;
 
 use std::hashmap::HashMap;
 
@@ -131,7 +132,7 @@ pub type SyntaxExpanderTTItemFunNoCtxt =
 
 pub trait AnyMacro {
     fn make_expr(&self) -> @ast::Expr;
-    fn make_item(&self) -> Option<@ast::item>;
+    fn make_items(&self) -> SmallVector<@ast::item>;
     fn make_stmt(&self) -> @ast::Stmt;
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -28,6 +28,7 @@ use parse::token;
 use parse::token::{fresh_mark, fresh_name, ident_to_str, intern};
 use visit;
 use visit::Visitor;
+use util::small_vector::SmallVector;
 
 use std::vec;
 
@@ -310,7 +311,7 @@ pub fn expand_item(extsbox: @mut SyntaxEnv,
                    cx: @ExtCtxt,
                    it: @ast::item,
                    fld: &MacroExpander)
-                   -> Option<@ast::item> {
+                   -> SmallVector<@ast::item> {
     match it.node {
         ast::item_mac(*) => expand_item_mac(extsbox, cx, it, fld),
         ast::item_mod(_) | ast::item_foreign_mod(_) => {
@@ -337,7 +338,7 @@ pub fn expand_item_mac(extsbox: @mut SyntaxEnv,
                        cx: @ExtCtxt,
                        it: @ast::item,
                        fld: &MacroExpander)
-                       -> Option<@ast::item> {
+                       -> SmallVector<@ast::item> {
     let (pth, tts, ctxt) = match it.node {
         item_mac(codemap::Spanned {
             node: mac_invoc_tt(ref pth, ref tts, ctxt),
@@ -396,28 +397,30 @@ pub fn expand_item_mac(extsbox: @mut SyntaxEnv,
             it.span, format!("{}! is not legal in item position", extnamestr))
     };
 
-    let maybe_it = match expanded {
+    let items = match expanded {
         MRItem(it) => {
-            mark_item(it,fm)
-                .and_then(|i| fld.fold_item(i))
+            mark_item(it,fm).move_iter()
+                .flat_map(|i| fld.fold_item(i).move_iter())
+                .collect()
         }
         MRExpr(_) => {
             cx.span_fatal(pth.span, format!("expr macro in item position: {}", extnamestr))
         }
         MRAny(any_macro) => {
-            any_macro.make_item()
-                     .and_then(|i| mark_item(i,fm))
-                     .and_then(|i| fld.fold_item(i))
+            any_macro.make_items().move_iter()
+                    .flat_map(|i| mark_item(i, fm).move_iter())
+                    .flat_map(|i| fld.fold_item(i).move_iter())
+                    .collect()
         }
         MRDef(ref mdef) => {
             // yikes... no idea how to apply the mark to this. I'm afraid
             // we're going to have to wait-and-see on this one.
             insert_macro(*extsbox,intern(mdef.name), @SE((*mdef).ext));
-            None
+            SmallVector::zero()
         }
     };
     cx.bt_pop();
-    return maybe_it;
+    return items;
 }
 
 
@@ -442,7 +445,7 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
                    cx: @ExtCtxt,
                    s: &Stmt,
                    fld: &MacroExpander)
-                   -> Option<@Stmt> {
+                   -> SmallVector<@Stmt> {
     // why the copying here and not in expand_expr?
     // looks like classic changed-in-only-one-place
     let (pth, tts, semi, ctxt) = match s.node {
@@ -461,7 +464,7 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
     }
     let extname = &pth.segments[0].identifier;
     let extnamestr = ident_to_str(extname);
-    let fully_expanded: @ast::Stmt = match (*extsbox).find(&extname.name) {
+    let fully_expanded: SmallVector<@Stmt> = match (*extsbox).find(&extname.name) {
         None => {
             cx.span_fatal(pth.span, format!("macro undefined: '{}'", extnamestr))
         }
@@ -501,22 +504,15 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
             let marked_after = mark_stmt(expanded,fm);
 
             // Keep going, outside-in.
-            let fully_expanded = match fld.fold_stmt(marked_after) {
-                Some(stmt) => {
-                    let fully_expanded = &stmt.node;
-                    cx.bt_pop();
-                    @Spanned {
-                        span: stmt.span,
-                        node: (*fully_expanded).clone(),
-                    }
-                }
-                None => {
-                    cx.span_fatal(pth.span,
-                                  "macro didn't expand to a statement")
-                }
-            };
-
-            fully_expanded
+            let fully_expanded = fld.fold_stmt(marked_after);
+            if fully_expanded.is_empty() {
+                cx.span_fatal(pth.span,
+                              "macro didn't expand to a statement");
+            }
+            cx.bt_pop();
+            fully_expanded.move_iter()
+                    .map(|s| @Spanned { span: s.span, node: s.node.clone() })
+                    .collect()
         }
 
         _ => {
@@ -525,21 +521,23 @@ pub fn expand_stmt(extsbox: @mut SyntaxEnv,
         }
     };
 
-    match fully_expanded.node {
-        StmtExpr(e, stmt_id) if semi => {
-            Some(@Spanned {
-                span: fully_expanded.span,
-                node: StmtSemi(e, stmt_id),
-            })
+    fully_expanded.move_iter().map(|s| {
+        match s.node {
+            StmtExpr(e, stmt_id) if semi => {
+                @Spanned {
+                    span: s.span,
+                    node: StmtSemi(e, stmt_id)
+                }
+            }
+            _ => s /* might already have a semi */
         }
-        _ => Some(fully_expanded), /* might already have a semi */
-    }
+    }).collect()
 }
 
 // expand a non-macro stmt. this is essentially the fallthrough for
 // expand_stmt, above.
 fn expand_non_macro_stmt(exts: SyntaxEnv, s: &Stmt, fld: &MacroExpander)
-                         -> Option<@Stmt> {
+                         -> SmallVector<@Stmt> {
     // is it a let?
     match s.node {
         StmtDecl(@Spanned {
@@ -590,7 +588,7 @@ fn expand_non_macro_stmt(exts: SyntaxEnv, s: &Stmt, fld: &MacroExpander)
                     id: id,
                     span: span,
                 };
-            Some(@Spanned {
+            SmallVector::one(@Spanned {
                 node: StmtDecl(@Spanned {
                         node: DeclLocal(rewritten_local),
                         span: stmt_span
@@ -679,13 +677,9 @@ pub fn expand_block_elts(exts: SyntaxEnv, b: &Block, fld: &MacroExpander)
     let pending_renames = block_info.pending_renames;
     let rename_fld = renames_to_fold(pending_renames);
     let new_view_items = b.view_items.map(|x| fld.fold_view_item(x));
-    let mut new_stmts = ~[];
-    for x in b.stmts.iter() {
-        match fld.fold_stmt(mustbesome(rename_fld.fold_stmt(*x))) {
-            Some(s) => new_stmts.push(s),
-            None => ()
-        }
-    }
+    let new_stmts = b.stmts.iter()
+            .flat_map(|x| fld.fold_stmt(mustbeone(rename_fld.fold_stmt(*x))).move_iter())
+            .collect();
     let new_expr = b.expr.map(|x| fld.fold_expr(rename_fld.fold_expr(x)));
     Block{
         view_items: new_view_items,
@@ -697,13 +691,12 @@ pub fn expand_block_elts(exts: SyntaxEnv, b: &Block, fld: &MacroExpander)
     }
 }
 
-// rename_fold should never return "None".
-// (basically, just .get() with a better message...)
-fn mustbesome<T>(val : Option<T>) -> T {
-    match val {
-        Some(v) => v,
-        None => fail!("rename_fold returned None")
+// rename_fold should never return anything other than one thing
+fn mustbeone<T>(mut val : SmallVector<T>) -> T {
+    if val.len() != 1 {
+        fail!("rename_fold didn't return one value");
     }
+    val.pop()
 }
 
 // get the (innermost) BlockInfo from an exts stack
@@ -741,10 +734,11 @@ pub fn renames_to_fold(renames: @mut ~[(ast::Ident,ast::Name)]) -> @ast_fold {
 
 // perform a bunch of renames
 fn apply_pending_renames(folder : @ast_fold, stmt : ast::Stmt) -> @ast::Stmt {
-    match folder.fold_stmt(&stmt) {
-        Some(s) => s,
-        None => fail!("renaming of stmt produced None")
+    let mut stmts = folder.fold_stmt(&stmt);
+    if stmts.len() != 1 {
+        fail!("renaming of stmt did not produce one stmt");
     }
+    stmts.pop()
 }
 
 
@@ -1025,14 +1019,14 @@ impl ast_fold for MacroExpander {
                          self)
     }
 
-    fn fold_item(&self, item: @ast::item) -> Option<@ast::item> {
+    fn fold_item(&self, item: @ast::item) -> SmallVector<@ast::item> {
         expand_item(self.extsbox,
                     self.cx,
                     item,
                     self)
     }
 
-    fn fold_stmt(&self, stmt: &ast::Stmt) -> Option<@ast::Stmt> {
+    fn fold_stmt(&self, stmt: &ast::Stmt) -> SmallVector<@ast::Stmt> {
         expand_stmt(self.extsbox,
                     self.cx,
                     stmt,
@@ -1191,11 +1185,15 @@ fn mark_expr(expr : @ast::Expr, m : Mrk) -> @ast::Expr {
 
 // apply a given mark to the given stmt. Used following the expansion of a macro.
 fn mark_stmt(expr : &ast::Stmt, m : Mrk) -> @ast::Stmt {
-    new_mark_folder(m).fold_stmt(expr).unwrap()
+    let mut stmts = new_mark_folder(m).fold_stmt(expr);
+    if stmts.len() != 1 {
+        fail!("marking a stmt didn't return a stmt");
+    }
+    stmts.pop()
 }
 
 // apply a given mark to the given item. Used following the expansion of a macro.
-fn mark_item(expr : @ast::item, m : Mrk) -> Option<@ast::item> {
+fn mark_item(expr : @ast::item, m : Mrk) -> SmallVector<@ast::item> {
     new_mark_folder(m).fold_item(expr)
 }
 

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -24,6 +24,7 @@ use parse::attr::parser_attr;
 use parse::token::{get_ident_interner, special_idents, gensym_ident, ident_to_str};
 use parse::token::{FAT_ARROW, SEMI, nt_matchers, nt_tt, EOF};
 use print;
+use util::small_vector::SmallVector;
 
 struct ParserAnyMacro {
     parser: @Parser,
@@ -54,9 +55,15 @@ impl AnyMacro for ParserAnyMacro {
         self.ensure_complete_parse(true);
         ret
     }
-    fn make_item(&self) -> Option<@ast::item> {
-        let attrs = self.parser.parse_outer_attributes();
-        let ret = self.parser.parse_item(attrs);
+    fn make_items(&self) -> SmallVector<@ast::item> {
+        let mut ret = SmallVector::zero();
+        loop {
+            let attrs = self.parser.parse_outer_attributes();
+            match self.parser.parse_item(attrs) {
+                Some(item) => ret.push(item),
+                None => break
+            }
+        }
         self.ensure_complete_parse(false);
         ret
     }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -31,6 +31,7 @@ pub mod util {
     pub mod interner;
     #[cfg(test)]
     pub mod parser_testing;
+    pub mod small_vector;
 }
 
 pub mod syntax {

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -1,0 +1,213 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use std::vec::MoveIterator;
+use std::util;
+
+/// A vector type optimized for cases where the size is almost always 0 or 1
+pub enum SmallVector<T> {
+    priv Zero,
+    priv One(T),
+    priv Many(~[T]),
+}
+
+impl<T> Container for SmallVector<T> {
+    fn len(&self) -> uint {
+        match *self {
+            Zero => 0,
+            One(*) => 1,
+            Many(ref vals) => vals.len()
+        }
+    }
+}
+
+impl<T> FromIterator<T> for SmallVector<T> {
+    fn from_iterator<I: Iterator<T>>(iter: &mut I) -> SmallVector<T> {
+        let mut v = Zero;
+        for val in *iter {
+            v.push(val);
+        }
+        v
+    }
+}
+
+impl<T> SmallVector<T> {
+    pub fn zero() -> SmallVector<T> {
+        Zero
+    }
+
+    pub fn one(v: T) -> SmallVector<T> {
+        One(v)
+    }
+
+    pub fn many(vs: ~[T]) -> SmallVector<T> {
+        Many(vs)
+    }
+
+    pub fn push(&mut self, v: T) {
+        match *self {
+            Zero => *self = One(v),
+            One(*) => {
+                let mut tmp = Many(~[]);
+                util::swap(self, &mut tmp);
+                match *self {
+                    Many(ref mut vs) => {
+                        match tmp {
+                            One(v1) => {
+                                vs.push(v1);
+                                vs.push(v);
+                            }
+                            _ => unreachable!()
+                        }
+                    }
+                    _ => unreachable!()
+                }
+            }
+            Many(ref mut vs) => vs.push(v)
+        }
+    }
+
+    pub fn get<'a>(&'a self, idx: uint) -> &'a T {
+        match *self {
+            One(ref v) if idx == 0 => v,
+            Many(ref vs) => &vs[idx],
+            _ => fail!("Out of bounds access")
+        }
+    }
+
+    pub fn iter<'a>(&'a self) -> SmallVectorIterator<'a, T> {
+        SmallVectorIterator {
+            vec: self,
+            idx: 0
+        }
+    }
+
+    pub fn move_iter(self) -> SmallVectorMoveIterator<T> {
+        match self {
+            Zero => ZeroIterator,
+            One(v) => OneIterator(v),
+            Many(vs) => ManyIterator(vs.move_iter())
+        }
+    }
+}
+
+pub struct SmallVectorIterator<'vec, T> {
+    priv vec: &'vec SmallVector<T>,
+    priv idx: uint
+}
+
+impl<'vec, T> Iterator<&'vec T> for SmallVectorIterator<'vec, T> {
+    fn next(&mut self) -> Option<&'vec T> {
+        if self.idx == self.vec.len() {
+            return None;
+        }
+
+        self.idx += 1;
+        Some(self.vec.get(self.idx - 1))
+    }
+
+    fn size_hint(&self) -> (uint, Option<uint>) {
+        let rem = self.vec.len() - self.idx;
+        (rem, Some(rem))
+    }
+}
+
+pub enum SmallVectorMoveIterator<T> {
+    priv ZeroIterator,
+    priv OneIterator(T),
+    priv ManyIterator(MoveIterator<T>),
+}
+
+impl<T> Iterator<T> for SmallVectorMoveIterator<T> {
+    fn next(&mut self) -> Option<T> {
+        match *self {
+            ZeroIterator => None,
+            OneIterator(*) => {
+                let mut replacement = ZeroIterator;
+                util::swap(self, &mut replacement);
+                match replacement {
+                    OneIterator(v) => Some(v),
+                    _ => unreachable!()
+                }
+            }
+            ManyIterator(ref mut inner) => inner.next()
+        }
+    }
+
+    fn size_hint(&self) -> (uint, Option<uint>) {
+        match *self {
+            ZeroIterator => (0, Some(0)),
+            OneIterator(*) => (1, Some(1)),
+            ManyIterator(ref inner) => inner.size_hint()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_len() {
+        let v: SmallVector<int> = SmallVector::zero();
+        assert_eq!(0, v.len());
+
+        assert_eq!(1, SmallVector::one(1).len());
+        assert_eq!(5, SmallVector::many(~[1, 2, 3, 4, 5]).len());
+    }
+
+    #[test]
+    fn test_push_get() {
+        let mut v = SmallVector::zero();
+        v.push(1);
+        assert_eq!(1, v.len());
+        assert_eq!(&1, v.get(0));
+        v.push(2);
+        assert_eq!(2, v.len());
+        assert_eq!(&2, v.get(1));
+        v.push(3);
+        assert_eq!(3, v.len());
+        assert_eq!(&3, v.get(2));
+    }
+
+    #[test]
+    fn test_from_iterator() {
+        let v: SmallVector<int> = (~[1, 2, 3]).move_iter().collect();
+        assert_eq!(3, v.len());
+        assert_eq!(&1, v.get(0));
+        assert_eq!(&2, v.get(1));
+        assert_eq!(&3, v.get(2));
+    }
+
+    #[test]
+    fn test_iter() {
+        let v = SmallVector::zero();
+        let v: ~[&int] = v.iter().collect();
+        assert_eq!(~[], v);
+
+        let v = SmallVector::one(1);
+        assert_eq!(~[&1], v.iter().collect());
+
+        let v = SmallVector::many(~[1, 2, 3]);
+        assert_eq!(~[&1, &2, &3], v.iter().collect());
+    }
+
+    #[test]
+    fn test_move_iter() {
+        let v = SmallVector::zero();
+        let v: ~[int] = v.move_iter().collect();
+        assert_eq!(~[], v);
+
+        let v = SmallVector::one(1);
+        assert_eq!(~[1], v.move_iter().collect());
+
+        let v = SmallVector::many(~[1, 2, 3]);
+        assert_eq!(~[1, 2, 3], v.move_iter().collect());
+    }
+}

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -73,6 +73,22 @@ impl<T> SmallVector<T> {
         }
     }
 
+    pub fn pop(&mut self) -> T {
+        match *self {
+            Zero => fail!("attempted to pop from an empty SmallVector"),
+            One(*) => {
+                let mut tmp = Zero;
+                util::swap(self, &mut tmp);
+                match tmp {
+                    One(v) => v,
+                    _ => unreachable!()
+                }
+            }
+            // Should this reduce to a One if possible?
+            Many(ref mut vs) => vs.pop()
+        }
+    }
+
     pub fn get<'a>(&'a self, idx: uint) -> &'a T {
         match *self {
             One(ref v) if idx == 0 => v,
@@ -174,6 +190,18 @@ mod test {
         v.push(3);
         assert_eq!(3, v.len());
         assert_eq!(&3, v.get(2));
+    }
+
+    #[test]
+    fn test_pop() {
+        let mut v = SmallVector::one(1);
+        assert_eq!(1, v.pop());
+        assert_eq!(0, v.len());
+
+        let mut v= SmallVector::many(~[1, 2]);
+        assert_eq!(2, v.pop());
+        assert_eq!(1, v.pop());
+        assert_eq!(0, v.len());
     }
 
     #[test]

--- a/src/test/run-pass/macro-multiple-items.rs
+++ b/src/test/run-pass/macro-multiple-items.rs
@@ -8,22 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-pretty - token trees can't pretty print
+
 #[feature(macro_rules)];
 
-macro_rules! ignored_item {
-    () => {
-        fn foo() {}
-        fn bar() {}
-        , //~ ERROR macro expansion ignores token `,`
-    }
-}
+macro_rules! make_foo(
+    () => (
+        struct Foo;
 
-macro_rules! ignored_expr {
-    () => ( 1, 2 ) //~ ERROR macro expansion ignores token `,`
-}
+        impl Foo {
+            fn bar(&self) {}
+        }
+    )
+)
 
-ignored_item!()
+make_foo!()
 
-fn main() {
-    ignored_expr!()
+pub fn main() {
+    Foo.bar()
 }


### PR DESCRIPTION
The majority of this change is modifying some of the `ast_visit` methods to return multiple values.

It's prohibitively expensive to allocate a `~[Foo]` every time a statement, declaration, item, etc is visited, especially since the vast majority will have 0 or 1 elements. I've added a `SmallVector` class that avoids allocation in the 0 and 1 element cases to take care of that.
