### PR TITLE
more useful rustpkg init

### DIFF
--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -148,9 +148,9 @@ Options:
 }
 
 pub fn init() {
-    println("rustpkg init
+    println("rustpkg init <bin|lib> package-name
 
-This will turn the current working directory into a workspace. The first
-command you run when starting off a new project.
+This initializes a workspace with the same name as package-name in the current
+directory. The first command you run when starting off a new project.
 ");
 }


### PR DESCRIPTION
This PR modifies the behavior of `rustpkg init`.

`rustpkg init` now accepts two more arguments, the first is the type of package to initialize (`bin` or `lib`), and the second is the package name. Instead of initializing a workspace in the current directory, `rustpkg init` now initializes a workspace under the directory with the same name as the supplied package name. In addition, it also creates some default crates (i.e. `lib.rs` or `main.rs`) under `src/<package-name>/`.

E.g. `rustpkg init lib awesome_lib` will create the following directory tree in the current directory.

```
awesome_lib/ 
 - bin/
 - build/
 - lib/
 - src/
    - awesome_lib/
       - lib.rs
```

The content of `lib.rs` is the following.

``` rust
pub fn get_answer() -> int {
    42
}
```

EDIT: `test.rs` is no longer generated.
