### PR TITLE
std::run: Use Result instead of condition

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -55,7 +55,7 @@ pub fn run(lib_path: &str,
         in_fd: None,
         out_fd: None,
         err_fd: None
-    });
+    }).unwrap();
 
     for input in input.iter() {
         process.input().write(input.as_bytes());
@@ -82,7 +82,7 @@ pub fn run_background(lib_path: &str,
         in_fd: None,
         out_fd: None,
         err_fd: None
-    });
+    }).unwrap();
 
     for input in input.iter() {
         process.input().write(input.as_bytes());

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -376,14 +376,20 @@ pub mod write {
             ~"-o", object.as_str().unwrap().to_owned(),
             assembly.as_str().unwrap().to_owned()];
 
-        let prog = run::process_output(cc_prog, cc_args);
-
-        if !prog.status.success() {
-            sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
-            sess.note(format!("{} arguments: {}",
-                        cc_prog, cc_args.connect(" ")));
-            sess.note(str::from_utf8(prog.error + prog.output));
-            sess.abort_if_errors();
+        match run::process_output(cc_prog, cc_args) {
+            Ok(prog) => {
+                if !prog.status.success() {
+                    sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
+                    sess.note(format!("{} arguments: {}",
+                                cc_prog, cc_args.connect(" ")));
+                    sess.note(str::from_utf8(prog.error + prog.output));
+                    sess.abort_if_errors();
+                }
+            }
+            Err(err) => {
+                sess.err(format!("linking with `{}` failed: {}", cc_prog, err.desc));
+                sess.abort_if_errors();
+            }
         }
     }
 
@@ -945,14 +951,20 @@ pub fn link_binary(sess: Session,
     }
 
     // We run 'cc' here
-    let prog = run::process_output(cc_prog, cc_args);
-
-    if !prog.status.success() {
-        sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
-        sess.note(format!("{} arguments: {}",
-                    cc_prog, cc_args.connect(" ")));
-        sess.note(str::from_utf8(prog.error + prog.output));
-        sess.abort_if_errors();
+    match run::process_output(cc_prog, cc_args) {
+        Ok(prog) => {
+            if !prog.status.success() {
+                sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
+                sess.note(format!("{} arguments: {}",
+                            cc_prog, cc_args.connect(" ")));
+                sess.note(str::from_utf8(prog.error + prog.output));
+                sess.abort_if_errors();
+            }
+        }
+        Err(err) => {
+            sess.err(format!("linking with `{}` failed: {}", cc_prog, err.desc));
+            sess.abort_if_errors();
+        }
     }
 
     // On OSX, debuggers needs this utility to get run to do some munging of the

--- a/src/librustpkg/api.rs
+++ b/src/librustpkg/api.rs
@@ -169,7 +169,7 @@ pub fn build_library_in_workspace(exec: &mut workcache::Exec,
 
     let all_args = flags + absolute_paths + cc_args +
          ~[~"-o", out_name.as_str().unwrap().to_owned()];
-    let exit_process = run::process_status(tool, all_args);
+    let exit_process = run::process_status(tool, all_args).unwrap();
     if exit_process.success() {
         let out_name_str = out_name.as_str().unwrap().to_owned();
         exec.discover_output("binary",

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -171,7 +171,8 @@ impl<'self> PkgScript<'self> {
         // FIXME #7401 should support commands besides `install`
         // FIXME (#9639): This needs to handle non-utf8 paths
         let status = run::process_status(exe.as_str().unwrap(),
-                                         [sysroot.as_str().unwrap().to_owned(), ~"install"]);
+                                         [sysroot.as_str().unwrap().to_owned(),
+                                          ~"install"]).unwrap();
         if !status.success() {
             debug!("run_custom: first pkg command failed with {:?}", status);
             (~[], status)
@@ -181,7 +182,8 @@ impl<'self> PkgScript<'self> {
                    exe.display(), sysroot.display(), "configs");
             // FIXME (#9639): This needs to handle non-utf8 paths
             let output = run::process_output(exe.as_str().unwrap(),
-                                             [sysroot.as_str().unwrap().to_owned(), ~"configs"]);
+                                             [sysroot.as_str().unwrap().to_owned(),
+                                              ~"configs"]).unwrap();
             debug!("run_custom: second pkg command did {:?}", output.status);
             // Run the configs() function to get the configs
             let cfgs = str::from_utf8_slice(output.output).word_iter()
@@ -697,7 +699,8 @@ impl CtxMethods for BuildContext {
             Some(test_exec) => {
                 debug!("test: test_exec = {}", test_exec.display());
                 // FIXME (#9639): This needs to handle non-utf8 paths
-                let status = run::process_status(test_exec.as_str().unwrap(), [~"--test"]);
+                let status = run::process_status(test_exec.as_str().unwrap(),
+                                                 [~"--test"]).unwrap();
                 if !status.success() {
                     fail!("Some tests failed");
                 }

--- a/src/librustpkg/source_control.rs
+++ b/src/librustpkg/source_control.rs
@@ -35,7 +35,7 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
             // FIXME (#9639): This needs to handle non-utf8 paths
             let outp = run::process_output("git", [~"clone",
                                                    source.as_str().unwrap().to_owned(),
-                                                   target.as_str().unwrap().to_owned()]);
+                                                   target.as_str().unwrap().to_owned()]).unwrap();
             if !outp.status.success() {
                 println(str::from_utf8_owned(outp.output.clone()));
                 println(str::from_utf8_owned(outp.error));
@@ -51,7 +51,7 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                         let outp = run::process_output("git",
                             [format!("--work-tree={}", target.as_str().unwrap().to_owned()),
                              format!("--git-dir={}", git_dir.as_str().unwrap().to_owned()),
-                             ~"checkout", format!("{}", *s)]);
+                             ~"checkout", format!("{}", *s)]).unwrap();
                         if !outp.status.success() {
                             println(str::from_utf8_owned(outp.output.clone()));
                             println(str::from_utf8_owned(outp.error));
@@ -72,7 +72,7 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
             let args = [format!("--work-tree={}", target.as_str().unwrap().to_owned()),
                         format!("--git-dir={}", git_dir.as_str().unwrap().to_owned()),
                         ~"pull", ~"--no-edit", source.as_str().unwrap().to_owned()];
-            let outp = run::process_output("git", args);
+            let outp = run::process_output("git", args).unwrap();
             assert!(outp.status.success());
         }
         CheckedOutSources
@@ -109,7 +109,7 @@ pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
 
     // FIXME (#9639): This needs to handle non-utf8 paths
     let outp = run::process_output("git", [~"clone", source.to_owned(),
-                                           target.as_str().unwrap().to_owned()]);
+                                           target.as_str().unwrap().to_owned()]).unwrap();
     if !outp.status.success() {
          debug!("{}", str::from_utf8_owned(outp.output.clone()));
          debug!("{}", str::from_utf8_owned(outp.error));
@@ -133,7 +133,7 @@ pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
 
 fn process_output_in_cwd(prog: &str, args: &[~str], cwd: &Path) -> ProcessOutput {
     let mut prog = Process::new(prog, args, ProcessOptions{ dir: Some(cwd)
-                                ,..ProcessOptions::new()});
+                                ,..ProcessOptions::new()}).unwrap();
     prog.finish_with_output()
 }
 

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -149,7 +149,7 @@ fn run_git(args: &[~str], env: Option<~[(~str, ~str)]>, cwd: &Path, err_msg: &st
         in_fd: None,
         out_fd: None,
         err_fd: None
-    });
+    }).unwrap();
     let rslt = prog.finish_with_output();
     if !rslt.status.success() {
         fail!("{} [git returned {:?}, output = {}, error = {}]", err_msg,
@@ -286,7 +286,7 @@ fn command_line_test_with_env(args: &[~str], cwd: &Path, env: Option<~[(~str, ~s
         in_fd: None,
         out_fd: None,
         err_fd: None
-    });
+    }).unwrap();
     let output = prog.finish_with_output();
     debug!("Output from command {} with args {:?} was {} \\{{}\\}[{:?}]",
                     cmd, args, str::from_utf8(output.output),
@@ -504,9 +504,10 @@ fn touch_source_file(workspace: &Path, pkgid: &PkgId) {
             // should be able to do this w/o a process
             // FIXME (#9639): This needs to handle non-utf8 paths
             // n.b. Bumps time up by 2 seconds to get around granularity issues
-            if !run::process_output("touch", [~"--date",
+            let output = run::process_output("touch", [~"--date",
                                              ~"+2 seconds",
-                                             p.as_str().unwrap().to_owned()]).status.success() {
+                                             p.as_str().unwrap().to_owned()]).unwrap();
+            if !output.status.success() {
                 let _ = cond.raise((pkg_src_dir.clone(), ~"Bad path"));
             }
         }
@@ -523,8 +524,9 @@ fn touch_source_file(workspace: &Path, pkgid: &PkgId) {
             // should be able to do this w/o a process
             // FIXME (#9639): This needs to handle non-utf8 paths
             // n.b. Bumps time up by 2 seconds to get around granularity issues
-            if !run::process_output("touch", [~"-A02",
-                                             p.as_str().unwrap().to_owned()]).status.success() {
+            let output = run::process_output("touch", [~"-A02",
+                                             p.as_str().unwrap().to_owned()]).unwrap();
+            if !output.status.success() {
                 let _ = cond.raise((pkg_src_dir.clone(), ~"Bad path"));
             }
         }
@@ -1278,7 +1280,7 @@ fn test_extern_mod() {
         in_fd: None,
         out_fd: None,
         err_fd: None
-    });
+    }).unwrap();
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
@@ -1333,7 +1335,7 @@ fn test_extern_mod_simpler() {
         in_fd: None,
         out_fd: None,
         err_fd: None
-    });
+    }).unwrap();
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -105,7 +105,7 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
         }
         // FIXME (#9639): This needs to handle non-utf8 paths
         let outp = run::process_output("git",
-                                   ["--git-dir=" + git_dir.as_str().unwrap(), ~"tag", ~"-l"]);
+                           ["--git-dir=" + git_dir.as_str().unwrap(), ~"tag", ~"-l"]).unwrap();
 
         debug!("git --git-dir={} tag -l ~~~> {:?}", git_dir.display(), outp.status);
 
@@ -142,7 +142,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
         // FIXME (#9639): This needs to handle non-utf8 paths
         let outp  = run::process_output("git", [~"clone", format!("https://{}",
                                                                   remote_path.as_str().unwrap()),
-                                                tmp_dir.as_str().unwrap().to_owned()]);
+                                                tmp_dir.as_str().unwrap().to_owned()]).unwrap();
         if outp.status.success() {
             debug!("Cloned it... ( {}, {} )",
                    str::from_utf8(outp.output),
@@ -154,7 +154,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
             // FIXME (#9639): This needs to handle non-utf8 paths
             let outp = run::process_output("git",
                                            ["--git-dir=" + git_dir.as_str().unwrap(),
-                                            ~"tag", ~"-l"]);
+                                            ~"tag", ~"-l"]).unwrap();
             let output_text = str::from_utf8(outp.output);
             debug!("Full output: ( {} ) [{:?}]", output_text, outp.status);
             for l in output_text.line_iter() {

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -27,7 +27,7 @@ fn test_destroy_once() {
     #[cfg(target_os="android")]
     static PROG: &'static str = "ls"; // android don't have echo binary
 
-    let mut p = run::Process::new(PROG, [], run::ProcessOptions::new());
+    let mut p = run::Process::new(PROG, [], run::ProcessOptions::new()).unwrap();
     p.destroy(); // this shouldn't crash (and nor should the destructor)
 }
 
@@ -38,7 +38,7 @@ fn test_destroy_twice() {
     #[cfg(target_os="android")]
     static PROG: &'static str = "ls"; // android don't have echo binary
 
-    let mut p = run::Process::new(PROG, [], run::ProcessOptions::new());
+    let mut p = run::Process::new(PROG, [], run::ProcessOptions::new()).unwrap();
     p.destroy(); // this shouldnt crash...
     do io::io_error::cond.trap(|_| {}).inside {
         p.destroy(); // ...and nor should this (and nor should the destructor)
@@ -58,13 +58,15 @@ fn test_destroy_actually_kills(force: bool) {
 
     #[cfg(unix,not(target_os="android"))]
     fn process_exists(pid: libc::pid_t) -> bool {
-        let run::ProcessOutput {output, _} = run::process_output("ps", [~"-p", pid.to_str()]);
+        let run::ProcessOutput {output, _} = run::process_output("ps",
+                                                                 [~"-p", pid.to_str()]).unwrap();
         str::from_utf8(output).contains(pid.to_str())
     }
 
     #[cfg(unix,target_os="android")]
     fn process_exists(pid: libc::pid_t) -> bool {
-        let run::ProcessOutput {output, _} = run::process_output("/system/bin/ps", [pid.to_str()]);
+        let run::ProcessOutput {output, _} = run::process_output("/system/bin/ps",
+                                                                 [pid.to_str()]).unwrap();
         str::from_utf8(output).contains(~"root")
     }
 
@@ -88,7 +90,7 @@ fn test_destroy_actually_kills(force: bool) {
     }
 
     // this process will stay alive indefinitely trying to read from stdin
-    let mut p = run::Process::new(BLOCK_COMMAND, [], run::ProcessOptions::new());
+    let mut p = run::Process::new(BLOCK_COMMAND, [], run::ProcessOptions::new()).unwrap();
 
     assert!(process_exists(p.get_id()));
 

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -19,7 +19,7 @@ fn main() {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }
     } else {
-        let status = run::process_status(args[0], [~"signal"]);
+        let status = run::process_status(args[0], [~"signal"]).unwrap();
         // Windows does not have signal, so we get exit status 0xC0000028 (STATUS_BAD_STACK).
         match status {
             process::ExitSignal(_) if cfg!(unix) => {},


### PR DESCRIPTION
Previously `std::run::Process::new()` raised a io_error condition then
tried to unwrap `None`, so it caused assertion failure.

This fixes the problem by returning Result instead of raising
condition.

This also fixes rustc ICE on nonexistent `--linker`.
