### PR TITLE
Check crate root for docs in missing_doc lint.

### DIFF
--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -130,6 +130,7 @@ pub fn walk_mod<E:Clone, V:Visitor<E>>(visitor: &mut V, module: &_mod, env: E) {
     for view_item in module.view_items.iter() {
         visitor.visit_view_item(view_item, env.clone())
     }
+
     for item in module.items.iter() {
         visitor.visit_item(*item, env.clone())
     }

--- a/src/test/compile-fail/issue-10656.rs
+++ b/src/test/compile-fail/issue-10656.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: missing documentation for crate
+
+#[deny(missing_doc)];
+#[crate_type="lib"];

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -14,6 +14,9 @@
 #[feature(globs)];
 #[deny(missing_doc)];
 
+//! Some garbage docs for the crate here
+#[doc="More garbage"];
+
 struct Foo {
     a: int,
     priv b: int,


### PR DESCRIPTION
Because the root module isn't actually an item, we need to do some hackish
handling of it.

Closes #10656.
