### PR TITLE
Shink NodeId, CrateNum, Name and Mrk down to 32 bits on x64.

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -28,7 +28,6 @@ use syntax::abi;
 use syntax::parse::token;
 use syntax;
 
-use std::int;
 use std::hashmap::{HashMap,HashSet};
 
 #[deriving(Clone)]
@@ -209,7 +208,7 @@ pub struct Session_ {
     building_library: @mut bool,
     working_dir: Path,
     lints: @mut HashMap<ast::NodeId, ~[(lint::lint, codemap::Span, ~str)]>,
-    node_id: @mut uint,
+    node_id: @mut ast::NodeId,
 }
 
 pub type Session = @Session_;
@@ -274,13 +273,15 @@ impl Session_ {
     pub fn next_node_id(&self) -> ast::NodeId {
         self.reserve_node_ids(1)
     }
-    pub fn reserve_node_ids(&self, count: uint) -> ast::NodeId {
+    pub fn reserve_node_ids(&self, count: ast::NodeId) -> ast::NodeId {
         let v = *self.node_id;
-        *self.node_id += count;
-        if v > (int::max_value as uint) {
-            self.bug("Input too large, ran out of node ids!");
+
+        match v.checked_add(&count) {
+            Some(next) => { *self.node_id = next; }
+            None => self.bug("Input too large, ran out of node ids!")
         }
-        v as int
+
+        v
     }
     pub fn diagnostic(&self) -> @mut diagnostic::span_handler {
         self.span_diagnostic

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -67,7 +67,7 @@ impl visit::Visitor<()> for ReadCrateVisitor {
 
 #[deriving(Clone)]
 struct cache_entry {
-    cnum: int,
+    cnum: ast::CrateNum,
     span: Span,
     hash: @str,
     metas: @~[@ast::MetaItem]
@@ -242,7 +242,7 @@ fn metas_with_ident(ident: @str, metas: ~[@ast::MetaItem])
 }
 
 fn existing_match(e: &Env, metas: &[@ast::MetaItem], hash: &str)
-               -> Option<int> {
+               -> Option<ast::CrateNum> {
     for c in e.crate_cache.iter() {
         if loader::metadata_matches(*c.metas, metas)
             && (hash.is_empty() || c.hash.as_slice() == hash) {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -76,10 +76,10 @@ fn lookup_hash(d: ebml::Doc, eq_fn: |&[u8]| -> bool, hash: u64) ->
 
 pub type GetCrateDataCb<'self> = &'self fn(ast::CrateNum) -> Cmd;
 
-pub fn maybe_find_item(item_id: int, items: ebml::Doc) -> Option<ebml::Doc> {
-    fn eq_item(bytes: &[u8], item_id: int) -> bool {
+pub fn maybe_find_item(item_id: ast::NodeId, items: ebml::Doc) -> Option<ebml::Doc> {
+    fn eq_item(bytes: &[u8], item_id: ast::NodeId) -> bool {
         return u64_from_be_bytes(
-            bytes.slice(0u, 4u), 0u, 4u) as int
+            bytes.slice(0u, 4u), 0u, 4u) as ast::NodeId
             == item_id;
     }
     lookup_hash(items,
@@ -87,7 +87,7 @@ pub fn maybe_find_item(item_id: int, items: ebml::Doc) -> Option<ebml::Doc> {
                 (item_id as i64).hash())
 }
 
-fn find_item(item_id: int, items: ebml::Doc) -> ebml::Doc {
+fn find_item(item_id: ast::NodeId, items: ebml::Doc) -> ebml::Doc {
     match maybe_find_item(item_id, items) {
        None => fail!("lookup_item: id not found: {}", item_id),
        Some(d) => d
@@ -96,7 +96,7 @@ fn find_item(item_id: int, items: ebml::Doc) -> ebml::Doc {
 
 // Looks up an item in the given metadata and returns an ebml doc pointing
 // to the item data.
-pub fn lookup_item(item_id: int, data: @~[u8]) -> ebml::Doc {
+pub fn lookup_item(item_id: ast::NodeId, data: @~[u8]) -> ebml::Doc {
     let items = reader::get_doc(reader::Doc(data), tag_items);
     find_item(item_id, items)
 }
@@ -343,7 +343,7 @@ fn item_name(intr: @ident_interner, item: ebml::Doc) -> ast::Ident {
     let string = name.as_str_slice();
     match intr.find_equiv(&string) {
         None => token::str_to_ident(string),
-        Some(val) => ast::Ident::new(val),
+        Some(val) => ast::Ident::new(val as ast::Name),
     }
 }
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -161,8 +161,7 @@ fn reserve_id_range(sess: Session,
     // Handle the case of an empty range:
     if from_id_range.empty() { return from_id_range; }
     let cnt = from_id_range.max - from_id_range.min;
-    assert!(cnt >= 0);
-    let to_id_min = sess.reserve_node_ids(cnt as uint);
+    let to_id_min = sess.reserve_node_ids(cnt);
     let to_id_max = to_id_min + cnt;
     ast_util::id_range { min: to_id_min, max: to_id_max }
 }
@@ -1210,7 +1209,7 @@ fn decode_side_tables(xcx: @ExtendedDecodeContext,
     let tbl_doc = ast_doc.get(c::tag_table as uint);
     do reader::docs(tbl_doc) |tag, entry_doc| {
         let id0 = entry_doc.get(c::tag_table_id as uint).as_int();
-        let id = xcx.tr_id(id0);
+        let id = xcx.tr_id(id0 as ast::NodeId);
 
         debug!(">> Side table document with tag 0x{:x} \
                 found for id {} (orig {})",

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -169,7 +169,7 @@ pub struct field_ty {
 // the types of AST nodes.
 #[deriving(Eq,IterBytes)]
 pub struct creader_cache_key {
-    cnum: int,
+    cnum: CrateNum,
     pos: uint,
     len: uint
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -69,7 +69,7 @@ impl Eq for Ident {
 
 // this uint is a reference to a table stored in thread-local
 // storage.
-pub type SyntaxContext = uint;
+pub type SyntaxContext = u32;
 
 // the SCTable contains a table of SyntaxContext_'s. It
 // represents a flattened tree structure, to avoid having
@@ -87,8 +87,8 @@ pub struct SCTable {
 }
 
 // NB: these must be placed in any SCTable...
-pub static EMPTY_CTXT : uint = 0;
-pub static ILLEGAL_CTXT : uint = 1;
+pub static EMPTY_CTXT : SyntaxContext = 0;
+pub static ILLEGAL_CTXT : SyntaxContext = 1;
 
 #[deriving(Eq, Encodable, Decodable,IterBytes)]
 pub enum SyntaxContext_ {
@@ -109,10 +109,10 @@ pub enum SyntaxContext_ {
 
 /// A name is a part of an identifier, representing a string or gensym. It's
 /// the result of interning.
-pub type Name = uint;
+pub type Name = u32;
 
 /// A mark represents a unique id associated with a macro expansion
-pub type Mrk = uint;
+pub type Mrk = u32;
 
 impl<S:Encoder> Encodable<S> for Ident {
     fn encode(&self, s: &mut S) {
@@ -163,9 +163,9 @@ pub struct PathSegment {
     types: OptVec<Ty>,
 }
 
-pub type CrateNum = int;
+pub type CrateNum = u32;
 
-pub type NodeId = int;
+pub type NodeId = u32;
 
 #[deriving(Clone, TotalEq, TotalOrd, Eq, Encodable, Decodable, IterBytes, ToStr)]
 pub struct DefId {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -18,7 +18,7 @@ use visit::Visitor;
 use visit;
 
 use std::hashmap::HashMap;
-use std::int;
+use std::u32;
 use std::local_data;
 use std::num;
 use std::option;
@@ -382,8 +382,8 @@ pub struct id_range {
 impl id_range {
     pub fn max() -> id_range {
         id_range {
-            min: int::max_value,
-            max: int::min_value,
+            min: u32::max_value,
+            max: u32::min_value,
         }
     }
 
@@ -803,9 +803,9 @@ pub fn display_sctable(table : &SCTable) {
 
 
 /// Add a value to the end of a vec, return its index
-fn idx_push<T>(vec: &mut ~[T], val: T) -> uint {
+fn idx_push<T>(vec: &mut ~[T], val: T) -> u32 {
     vec.push(val);
-    vec.len() - 1
+    (vec.len() - 1) as u32
 }
 
 /// Resolve a syntax object to a name, per MTWT.
@@ -917,7 +917,7 @@ pub fn mtwt_outer_mark(ctxt: SyntaxContext) -> Mrk {
 
 /// Push a name... unless it matches the one on top, in which
 /// case pop and discard (so two of the same marks cancel)
-pub fn xorPush(marks: &mut ~[uint], mark: uint) {
+pub fn xorPush(marks: &mut ~[Mrk], mark: Mrk) {
     if ((marks.len() > 0) && (getLast(marks) == mark)) {
         marks.pop();
     } else {
@@ -927,7 +927,7 @@ pub fn xorPush(marks: &mut ~[uint], mark: uint) {
 
 // get the last element of a mutable array.
 // FIXME #4903: , must be a separate procedure for now.
-pub fn getLast(arr: &~[Mrk]) -> uint {
+pub fn getLast(arr: &~[Mrk]) -> Mrk {
     *arr.last()
 }
 
@@ -1000,14 +1000,8 @@ mod test {
         assert_eq!(s.clone(),~[14]);
     }
 
-    // convert a list of uints to an @[ident]
-    // (ignores the interner completely)
-    fn uints_to_idents (uints: &~[uint]) -> @~[Ident] {
-        @uints.map(|u| Ident {name:*u, ctxt: EMPTY_CTXT})
-    }
-
-    fn id (u : uint, s: SyntaxContext) -> Ident {
-        Ident{name:u, ctxt: s}
+    fn id(n: Name, s: SyntaxContext) -> Ident {
+        Ident {name: n, ctxt: s}
     }
 
     // because of the SCTable, I now need a tidy way of

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -502,12 +502,12 @@ fn mk_fresh_ident_interner() -> @ident_interner {
     @interner::StrInterner::prefill(init_vec)
 }
 
-static SELF_KEYWORD_NAME: uint = 8;
-static STATIC_KEYWORD_NAME: uint = 27;
-static STRICT_KEYWORD_START: uint = 32;
-static STRICT_KEYWORD_FINAL: uint = 65;
-static RESERVED_KEYWORD_START: uint = 66;
-static RESERVED_KEYWORD_FINAL: uint = 72;
+static SELF_KEYWORD_NAME: Name = 8;
+static STATIC_KEYWORD_NAME: Name = 27;
+static STRICT_KEYWORD_START: Name = 32;
+static STRICT_KEYWORD_FINAL: Name = 65;
+static RESERVED_KEYWORD_START: Name = 66;
+static RESERVED_KEYWORD_FINAL: Name = 72;
 
 // if an interner exists in TLS, return it. Otherwise, prepare a
 // fresh one.


### PR DESCRIPTION
### Rationale

There is no reason to support more than 2³² nodes or names at this moment, as compiling something that big (even without considering the quadratic space usage of some analysis passes) would take at least **64GB**.
Meanwhile, some can't (or barely can) compile rustc because it requires almost **1.5GB**.
### Potential problems

Can someone confirm this doesn't affect metadata (de)serialization? I can't tell myself, I know nothing about it.
### Results

Some structures have a size reduction of 25% to 50%: [before](https://gist.github.com/luqmana/3a82a51fa9c86d9191fa) - [after](https://gist.github.com/eddyb/5a75f8973d3d8018afd3).
Sadly, there isn't a massive change in the memory used for compiling stage2 librustc (it doesn't go over **1.4GB** as [before](http://huonw.github.io/isrustfastyet/mem/), but I can barely see the difference).
However, my own testcase (previously peaking at **1.6GB** in typeck) shows a reduction of **200**-**400MB**.
