### PR TITLE
Forbid keywords as lifetime parameters names.

### DIFF
--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -774,7 +774,17 @@ fn next_token_inner(rdr: @mut StringReader) -> token::Token {
                 bump(rdr);
             }
             return with_str_from(rdr, start, |lifetime_name| {
-                token::LIFETIME(str_to_ident(lifetime_name))
+                let ident = str_to_ident(lifetime_name);
+                let tok = &token::IDENT(ident, false);
+
+                if token::is_any_keyword(tok)
+                    && !token::is_keyword(token::keywords::Static, tok)
+                    && !token::is_keyword(token::keywords::Self, tok) {
+                    fatal_span(rdr, start, rdr.last_pos,
+                        ~"invalid lifetime name");
+                }
+
+                token::LIFETIME(ident)
             })
         }
 

--- a/src/test/compile-fail/lifetime-no-keyword.rs
+++ b/src/test/compile-fail/lifetime-no-keyword.rs
@@ -1,0 +1,16 @@
+
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo(a: &'let int) { } //~ ERROR invalid lifetime name
+fn bar(a: &'static int) { }
+fn baz<'self>(a: &'self int) { }
+
+fn main() { }


### PR DESCRIPTION
Fixes #10565.

`'self` is still allowed for the moment, as it is used everywhere in the codebase. And I'm not sure if it still has a special meaning currently or not.
