### PR TITLE
Relax restrictions on unknown feature directives

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -18,6 +18,8 @@
 //! Features are enabled in programs via the crate-level attributes of
 //! #[feature(...)] with a comma-separated list of features.
 
+use middle::lint;
+
 use syntax::ast;
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
@@ -197,7 +199,10 @@ pub fn check_crate(sess: Session, crate: &ast::Crate) {
                                                      directive not necessary");
                         }
                         None => {
-                            sess.span_err(mi.span, "unknown feature");
+                            sess.add_lint(lint::unknown_features,
+                                          ast::CRATE_NODE_ID,
+                                          mi.span,
+                                          ~"unknown feature");
                         }
                     }
                 }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -59,6 +59,7 @@ use syntax::codemap::Span;
 use syntax::codemap;
 use syntax::parse::token;
 use syntax::{ast, ast_util, visit};
+use syntax::ast_util::IdVisitingOperation;
 use syntax::visit::Visitor;
 
 #[deriving(Clone, Eq)]
@@ -77,6 +78,7 @@ pub enum lint {
     unused_unsafe,
     unsafe_block,
     attribute_usage,
+    unknown_features,
 
     managed_heap_memory,
     owned_heap_memory,
@@ -320,6 +322,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
         lint: warnings,
         desc: "mass-change the level for lints which produce warnings",
         default: warn
+    }),
+
+    ("unknown_features",
+     LintSpec {
+        lint: unknown_features,
+        desc: "unknown features found in create-level #[feature] directives",
+        default: deny,
     }),
 ];
 
@@ -1319,7 +1328,7 @@ impl<'self> Visitor<()> for Context<'self> {
     }
 }
 
-impl<'self> ast_util::IdVisitingOperation for Context<'self> {
+impl<'self> IdVisitingOperation for Context<'self> {
     fn visit_id(&self, id: ast::NodeId) {
         match self.tcx.sess.lints.pop(&id) {
             None => {}
@@ -1355,6 +1364,7 @@ pub fn check_crate(tcx: ty::ctxt,
         cx.set_level(lint, level, CommandLine);
     }
     cx.with_lint_attrs(crate.attrs, |cx| {
+        cx.visit_id(ast::CRATE_NODE_ID);
         cx.visit_ids(|v| {
             v.visited_outermost = true;
             visit::walk_crate(v, crate, ());

--- a/src/test/compile-fail/lint-unknown-feature.rs
+++ b/src/test/compile-fail/lint-unknown-feature.rs
@@ -8,16 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(
-    foo_bar_baz,
-    foo(bar),
-    foo = "baz"
-)];
-//~^^^ ERROR: malformed feature
-//~^^^ ERROR: malformed feature
+#[deny(unknown_features)];
 
-#[feature]; //~ ERROR: malformed feature
-#[feature = "foo"]; //~ ERROR: malformed feature
+#[feature(this_is_not_a_feature)]; //~ ERROR: unknown feature
 
-#[feature(test_removed_feature)]; //~ ERROR: feature has been removed
-#[feature(test_accepted_feature)]; //~ WARNING: feature has added
+fn main() {}


### PR DESCRIPTION
Instead of forcibly always aborting compilation, allow usage of
 #[warn(unknown_features)] and related lint attributes to selectively abort
 compilation. By default, this lint is deny.
