### PR TITLE
std::ascii:  Fix is_digit() and is_control()

### DIFF
--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -67,7 +67,7 @@ impl Ascii {
     /// Check if the character is a number (0-9)
     #[inline]
     pub fn is_digit(&self) -> bool {
-        self.chr >= 0x31 && self.chr <= 0x39
+        self.chr >= 0x30 && self.chr <= 0x39
     }
 
     /// Check if the character is a letter or number
@@ -85,7 +85,7 @@ impl Ascii {
     /// Check if the character is a control character
     #[inline]
     pub fn is_control(&self) -> bool {
-        self.chr <= 0x20 || self.chr == 0x7F
+        self.chr < 0x20 || self.chr == 0x7F
     }
 
     /// Checks if the character is printable (except space)

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -498,6 +498,15 @@ mod tests {
         assert_eq!('`'.to_ascii().to_upper().to_char(), '`');
         assert_eq!('{'.to_ascii().to_upper().to_char(), '{');
 
+        assert!('0'.to_ascii().is_digit());
+        assert!('9'.to_ascii().is_digit());
+        assert!(!'/'.to_ascii().is_digit());
+        assert!(!':'.to_ascii().is_digit());
+
+        assert!((0x1fu8).to_ascii().is_control());
+        assert!(!' '.to_ascii().is_control());
+        assert!((0x7fu8).to_ascii().is_control());
+
         assert!("banana".chars().all(|c| c.is_ascii()));
         assert!(!"ประเทศไทย中华Việt Nam".chars().all(|c| c.is_ascii()));
     }


### PR DESCRIPTION
is_digit() incorrectly returned false for '0'.
is_control() incorrectly returned true for ' ' (space).
