### PR TITLE
Freeze the AST by removing a couple of unused @mut ~[T] from token_tree.

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -612,14 +612,14 @@ pub enum token_tree {
     tt_tok(Span, ::parse::token::Token),
     // a delimited sequence (the delimiters appear as the first
     // and last elements of the vector)
-    tt_delim(@mut ~[token_tree]),
+    tt_delim(@~[token_tree]),
 
     // These only make sense for right-hand-sides of MBE macros:
 
     // a kleene-style repetition sequence with a span, a tt_forest,
     // an optional separator, and a boolean where true indicates
     // zero or more (*), and false indicates one or more (+).
-    tt_seq(Span, @mut ~[token_tree], Option<::parse::token::Token>, bool),
+    tt_seq(Span, @~[token_tree], Option<::parse::token::Token>, bool),
 
     // a syntactic variable that will be filled in by macro expansion.
     tt_nonterminal(Span, Ident)
@@ -1178,6 +1178,18 @@ pub enum inlined_item {
     ii_item(@item),
     ii_method(DefId /* impl id */, bool /* is provided */, @method),
     ii_foreign(@foreign_item),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn is_freeze<T: Freeze>() {}
+
+    // Assert that the AST remains Freeze (#10693).
+    #[test] fn ast_is_freeze() {
+        is_freeze::<item>();
+    }
 }
 
 /* hold off on tests ... they appear in a later merge.

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -23,7 +23,7 @@ pub fn expand_syntax_ext(cx: @ExtCtxt,
     cx.print_backtrace();
     println(
         print::pprust::tt_to_str(
-            &ast::tt_delim(@mut tt.to_owned()),
+            &ast::tt_delim(@tt.to_owned()),
             get_ident_interner()));
 
     //trivial expression

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -104,7 +104,7 @@ fn generic_extension(cx: @ExtCtxt,
         println!("{}! \\{ {} \\}",
                   cx.str_of(name),
                   print::pprust::tt_to_str(
-                      &ast::tt_delim(@mut arg.to_owned()),
+                      &ast::tt_delim(@arg.to_owned()),
                       get_ident_interner()));
     }
 

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -22,7 +22,7 @@ use std::option;
 
 ///an unzipping of `token_tree`s
 struct TtFrame {
-    forest: @mut ~[ast::token_tree],
+    forest: @~[ast::token_tree],
     idx: uint,
     dotdotdoted: bool,
     sep: Option<Token>,
@@ -52,7 +52,7 @@ pub fn new_tt_reader(sp_diag: @mut span_handler,
     let r = @mut TtReader {
         sp_diag: sp_diag,
         stack: @mut TtFrame {
-            forest: @mut src,
+            forest: @src,
             idx: 0u,
             dotdotdoted: false,
             sep: None,
@@ -74,7 +74,7 @@ pub fn new_tt_reader(sp_diag: @mut span_handler,
 
 fn dup_tt_frame(f: @mut TtFrame) -> @mut TtFrame {
     @mut TtFrame {
-        forest: @mut (*f.forest).clone(),
+        forest: @(*f.forest).clone(),
         idx: f.idx,
         dotdotdoted: f.dotdotdoted,
         sep: f.sep.clone(),
@@ -175,8 +175,7 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
     loop {
         {
             let stack = &mut *r.stack;
-            let forest = &mut *stack.forest;
-            if stack.idx < forest.len() {
+            if stack.idx < stack.forest.len() {
                 break;
             }
         }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -457,10 +457,10 @@ pub fn fold_tts<T:ast_fold>(tts: &[token_tree], fld: &T) -> ~[token_tree] {
         match *tt {
             tt_tok(span, ref tok) =>
             tt_tok(span,maybe_fold_ident(tok,fld)),
-            tt_delim(ref tts) => tt_delim(@mut fold_tts(**tts, fld)),
-            tt_seq(span, ref pattern, ref sep, is_optional) =>
+            tt_delim(tts) => tt_delim(@fold_tts(*tts, fld)),
+            tt_seq(span, pattern, ref sep, is_optional) =>
             tt_seq(span,
-                   @mut fold_tts(**pattern, fld),
+                   @fold_tts(*pattern, fld),
                    sep.as_ref().map(|tok|maybe_fold_ident(tok,fld)),
                    is_optional),
             tt_nonterminal(sp,ref ident) =>

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2112,7 +2112,7 @@ impl Parser {
                     };
                     tt_seq(
                         mk_sp(sp.lo, p.span.hi),
-                        @mut seq,
+                        @seq,
                         s,
                         z
                     )
@@ -2157,7 +2157,7 @@ impl Parser {
                 result.push(parse_any_tt_tok(self));
                 self.open_braces.pop();
 
-                tt_delim(@mut result)
+                tt_delim(@result)
             }
             _ => parse_non_delim_tt_tok(self)
         }


### PR DESCRIPTION
It's truly immutable now, which will allow us to remove some cloning in the parser and box parts of the AST in `Rc<T>` (if desired).
