### PR TITLE
Remove `extern mod foo (name="bar")` syntax, closes #9543

### DIFF
--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -21,6 +21,8 @@ use syntax::fold;
 use syntax::opt_vec;
 use syntax::util::small_vector::SmallVector;
 
+pub static VERSION: &'static str = "0.9-pre";
+
 pub fn maybe_inject_libstd_ref(sess: Session, crate: ast::Crate)
                                -> ast::Crate {
     if use_std(&crate) {
@@ -57,7 +59,8 @@ impl fold::ast_fold for StandardLibraryInjector {
     fn fold_crate(&mut self, crate: ast::Crate) -> ast::Crate {
         let mut vis = ~[ast::view_item {
             node: ast::view_item_extern_mod(self.sess.ident_of("std"),
-                                            None,
+                                            Some((format!("std\\#{}", VERSION).to_managed(),
+                                                  ast::CookedStr)),
                                             ast::DUMMY_NODE_ID),
             attrs: ~[],
             vis: ast::private,
@@ -67,7 +70,8 @@ impl fold::ast_fold for StandardLibraryInjector {
         if use_uv(&crate) && !self.sess.building_library.get() {
             vis.push(ast::view_item {
                 node: ast::view_item_extern_mod(self.sess.ident_of("green"),
-                                                None,
+                                                Some((format!("green\\#{}", VERSION).to_managed(),
+                                                      ast::CookedStr)),
                                                 ast::DUMMY_NODE_ID),
                 attrs: ~[],
                 vis: ast::private,
@@ -75,7 +79,8 @@ impl fold::ast_fold for StandardLibraryInjector {
             });
             vis.push(ast::view_item {
                 node: ast::view_item_extern_mod(self.sess.ident_of("rustuv"),
-                                                None,
+                                                Some((format!("rustuv\\#{}", VERSION).to_managed(),
+                                                      ast::CookedStr)),
                                                 ast::DUMMY_NODE_ID),
                 attrs: ~[],
                 vis: ast::private,

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -21,8 +21,6 @@ use syntax::fold;
 use syntax::opt_vec;
 use syntax::util::small_vector::SmallVector;
 
-static STD_VERSION: &'static str = "0.9-pre";
-
 pub fn maybe_inject_libstd_ref(sess: Session, crate: ast::Crate)
                                -> ast::Crate {
     if use_std(&crate) {
@@ -57,12 +55,9 @@ struct StandardLibraryInjector {
 
 impl fold::ast_fold for StandardLibraryInjector {
     fn fold_crate(&mut self, crate: ast::Crate) -> ast::Crate {
-        let version = STD_VERSION.to_managed();
-        let vers_item = attr::mk_name_value_item_str(@"vers", version);
         let mut vis = ~[ast::view_item {
             node: ast::view_item_extern_mod(self.sess.ident_of("std"),
                                             None,
-                                            ~[vers_item.clone()],
                                             ast::DUMMY_NODE_ID),
             attrs: ~[],
             vis: ast::private,
@@ -73,7 +68,6 @@ impl fold::ast_fold for StandardLibraryInjector {
             vis.push(ast::view_item {
                 node: ast::view_item_extern_mod(self.sess.ident_of("green"),
                                                 None,
-                                                ~[vers_item],
                                                 ast::DUMMY_NODE_ID),
                 attrs: ~[],
                 vis: ast::private,
@@ -82,7 +76,6 @@ impl fold::ast_fold for StandardLibraryInjector {
             vis.push(ast::view_item {
                 node: ast::view_item_extern_mod(self.sess.ident_of("rustuv"),
                                                 None,
-                                                ~[vers_item],
                                                 ast::DUMMY_NODE_ID),
                 attrs: ~[],
                 vis: ast::private,

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -291,8 +291,7 @@ fn mk_std(cx: &TestCtxt) -> ast::view_item {
                                             path_node(~[id_extra]),
                                             ast::DUMMY_NODE_ID))])
     } else {
-        let mi = attr::mk_name_value_item_str(@"vers", @"0.9-pre");
-        ast::view_item_extern_mod(id_extra, None, ~[mi], ast::DUMMY_NODE_ID)
+        ast::view_item_extern_mod(id_extra, None, ast::DUMMY_NODE_ID)
     };
     ast::view_item {
         node: vi,

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -13,6 +13,7 @@
 
 use driver::session;
 use front::config;
+use front::std_inject::VERSION;
 
 use std::cell::RefCell;
 use std::vec;
@@ -291,7 +292,10 @@ fn mk_std(cx: &TestCtxt) -> ast::view_item {
                                             path_node(~[id_extra]),
                                             ast::DUMMY_NODE_ID))])
     } else {
-        ast::view_item_extern_mod(id_extra, None, ast::DUMMY_NODE_ID)
+        ast::view_item_extern_mod(id_extra,
+                                  Some((format!("extra\\#{}", VERSION).to_managed(),
+                                        ast::CookedStr)),
+                                  ast::DUMMY_NODE_ID)
     };
     ast::view_item {
         node: vi,

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -132,7 +132,7 @@ fn visit_crate(e: &Env, c: &ast::Crate) {
 
 fn visit_view_item(e: &mut Env, i: &ast::view_item) {
     match i.node {
-      ast::view_item_extern_mod(ident, path_opt, _, id) => {
+      ast::view_item_extern_mod(ident, path_opt, id) => {
           let ident = token::ident_to_str(&ident);
           debug!("resolving extern mod stmt. ident: {:?} path_opt: {:?}",
                  ident, path_opt);

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1507,7 +1507,7 @@ impl Resolver {
                 }
             }
 
-            view_item_extern_mod(name, _, _, node_id) => {
+            view_item_extern_mod(name, _, node_id) => {
                 // n.b. we don't need to look at the path option here, because cstore already did
                 match self.session.cstore.find_extern_mod_stmt_cnum(node_id) {
                     Some(crate_id) => {

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -994,15 +994,15 @@ impl Clean<Item> for ast::view_item {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub enum ViewItemInner {
-    ExternMod(~str, Option<~str>, ~[Attribute], ast::NodeId),
+    ExternMod(~str, Option<~str>, ast::NodeId),
     Import(~[ViewPath])
 }
 
 impl Clean<ViewItemInner> for ast::view_item_ {
     fn clean(&self) -> ViewItemInner {
         match self {
-            &ast::view_item_extern_mod(ref i, ref p, ref mi, ref id) =>
-                ExternMod(i.clean(), p.map(|(ref x, _)| x.to_owned()),  mi.clean(), *id),
+            &ast::view_item_extern_mod(ref i, ref p, ref id) =>
+                ExternMod(i.clean(), p.map(|(ref x, _)| x.to_owned()), *id),
             &ast::view_item_use(ref vp) => Import(vp.clean())
         }
     }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -995,7 +995,7 @@ fn item_module(w: &mut Writer, cx: &Context,
 
             clean::ViewItemItem(ref item) => {
                 match item.inner {
-                    clean::ExternMod(ref name, ref src, _, _) => {
+                    clean::ExternMod(ref name, ref src, _) => {
                         write!(w, "<tr><td><code>extern mod {}",
                                name.as_slice());
                         match *src {

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -14,7 +14,8 @@
 
 pub use crate_id::CrateId;
 pub use target::{OutputType, Main, Lib, Test, Bench, Target, Build, Install};
-pub use version::{Version, NoVersion, split_version_general, try_parsing_version};
+pub use version::{Version, ExactRevision, NoVersion, split_version, split_version_general,
+    try_parsing_version};
 pub use rustc::metadata::filesearch::rust_path;
 use rustc::metadata::filesearch::libdir;
 use rustc::driver::driver::host_triple;
@@ -213,8 +214,9 @@ pub fn library_in_workspace(path: &Path, short_name: &str, where: Target,
 }
 
 // rustc doesn't use target-specific subdirectories
-pub fn system_library(sysroot: &Path, lib_name: &str) -> Option<Path> {
-    library_in(lib_name, &NoVersion, &sysroot.join(libdir()))
+pub fn system_library(sysroot: &Path, crate_id: &str) -> Option<Path> {
+    let (lib_name, version) = split_crate_id(crate_id);
+    library_in(lib_name, &version, &sysroot.join(libdir()))
 }
 
 fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Option<Path> {
@@ -268,6 +270,7 @@ fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Opti
                                }
                                None => break
                            }
+
                        }
                        _ => { f_name = f_name.slice(0, i); }
                  }
@@ -292,6 +295,22 @@ fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Opti
 
     abs_path
 }
+
+fn split_crate_id<'a>(crate_id: &'a str) -> (&'a str, Version) {
+    match split_version(crate_id) {
+        Some((name, vers)) =>
+            match vers {
+                ExactRevision(ref v) => match v.find('-') {
+                    Some(pos) => (name, ExactRevision(v.slice(0, pos).to_owned())),
+                    None => (name, ExactRevision(v.to_owned()))
+                },
+                _ => (name, vers)
+            },
+        None => (crate_id, NoVersion)
+    }
+}
+
+
 
 /// Returns the executable that would be installed for <crateid>
 /// in <workspace>

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -461,7 +461,7 @@ impl<'a> Visitor<()> for ViewItemVisitor<'a> {
 
         match vi.node {
             // ignore metadata, I guess
-            ast::view_item_extern_mod(lib_ident, path_opt, _, _) => {
+            ast::view_item_extern_mod(lib_ident, path_opt, _) => {
                 let lib_name = match path_opt {
                     Some((p, _)) => p,
                     None => self.sess.str_of(lib_ident)

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1057,7 +1057,7 @@ pub enum view_item_ {
     // optional @str: if present, this is a location (containing
     // arbitrary characters) from which to fetch the crate sources
     // For example, extern mod whatever = "github.com/mozilla/rust"
-    view_item_extern_mod(Ident, Option<(@str, StrStyle)>, ~[@MetaItem], NodeId),
+    view_item_extern_mod(Ident, Option<(@str, StrStyle)>, NodeId),
     view_item_use(~[@view_path]),
 }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -419,7 +419,7 @@ impl<'a, O: IdVisitingOperation> Visitor<()> for IdVisitor<'a, O> {
 
     fn visit_view_item(&mut self, view_item: &view_item, env: ()) {
         match view_item.node {
-            view_item_extern_mod(_, _, _, node_id) => {
+            view_item_extern_mod(_, _, node_id) => {
                 self.operation.visit_id(node_id)
             }
             view_item_use(ref view_paths) => {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -66,11 +66,9 @@ pub trait ast_fold {
         let inner_view_item = match vi.node {
             view_item_extern_mod(ref ident,
                                  string,
-                                 ref meta_items,
                                  node_id) => {
                 view_item_extern_mod(ident.clone(),
                                      string,
-                                     self.fold_meta_items(*meta_items),
                                      self.new_id(node_id))
             }
             view_item_use(ref view_paths) => {

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -45,6 +45,7 @@ pub enum ObsoleteSyntax {
     ObsoleteBoxedClosure,
     ObsoleteClosureType,
     ObsoleteMultipleImport,
+    ObsoleteExternModAttributesInParens
 }
 
 impl to_bytes::IterBytes for ObsoleteSyntax {
@@ -145,6 +146,11 @@ impl ParserObsoleteMethods for Parser {
                 "multiple imports",
                 "only one import is allowed per `use` statement"
             ),
+            ObsoleteExternModAttributesInParens => (
+                "`extern mod` with linkage attribute list",
+                "use `extern mod foo = \"bar\";` instead of \
+                `extern mod foo (name = \"bar\")`"
+            )
         };
 
         self.report(sp, kind, kind_str, desc);

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4446,11 +4446,18 @@ impl Parser {
             self.span_err(*self.span, "an ABI may not be specified here");
         }
 
+
+        if *self.token == token::LPAREN {
+            // `extern mod foo (name = "bar"[,vers = "version"]) is obsolete,
+            // `extern mod foo = "bar#[version]";` should be used.
+            // Parse obsolete options to avoid wired parser errors
+            self.parse_optional_meta();
+            self.obsolete(*self.span, ObsoleteExternModAttributesInParens);
+        }
         // extern mod foo;
-        let metadata = self.parse_optional_meta();
         self.expect(&token::SEMI);
         iovi_view_item(ast::view_item {
-            node: view_item_extern_mod(ident, maybe_path, metadata, ast::DUMMY_NODE_ID),
+            node: view_item_extern_mod(ident, maybe_path, ast::DUMMY_NODE_ID),
             attrs: attrs,
             vis: visibility,
             span: mk_sp(lo, self.last_span.hi)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1952,7 +1952,7 @@ pub fn print_view_item(s: @ps, item: &ast::view_item) {
     print_outer_attributes(s, item.attrs);
     print_visibility(s, item.vis);
     match item.node {
-        ast::view_item_extern_mod(id, ref optional_path, ref mta, _) => {
+        ast::view_item_extern_mod(id, ref optional_path, _) => {
             head(s, "extern mod");
             print_ident(s, id);
             for &(ref p, style) in optional_path.iter() {
@@ -1960,11 +1960,6 @@ pub fn print_view_item(s: @ps, item: &ast::view_item) {
                 word(s.s, "=");
                 space(s.s);
                 print_string(s, *p, style);
-            }
-            if !mta.is_empty() {
-                popen(s);
-                commasep(s, consistent, *mta, |p, &i| print_meta_item(p, i));
-                pclose(s);
             }
         }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -139,7 +139,7 @@ pub fn walk_mod<E:Clone, V:Visitor<E>>(visitor: &mut V, module: &_mod, env: E) {
 
 pub fn walk_view_item<E:Clone, V:Visitor<E>>(visitor: &mut V, vi: &view_item, env: E) {
     match vi.node {
-        view_item_extern_mod(name, _, _, _) => {
+        view_item_extern_mod(name, _, _) => {
             visitor.visit_ident(vi.span, name, env)
         }
         view_item_use(ref paths) => {

--- a/src/test/run-pass/crateresolve8.rs
+++ b/src/test/run-pass/crateresolve8.rs
@@ -13,7 +13,7 @@
 
 #[crate_id="crateresolve8#0.1"];
 
-extern mod crateresolve8(vers = "0.1", package_id="crateresolve8#0.1");
+extern mod crateresolve8 = "crateresolve8#0.1";
 //extern mod crateresolve8(vers = "0.1");
 
 pub fn main() {

--- a/src/test/run-pass/extern-crosscrate.rs
+++ b/src/test/run-pass/extern-crosscrate.rs
@@ -11,7 +11,7 @@
 // xfail-fast
 //aux-build:extern-crosscrate-source.rs
 
-extern mod externcallback(vers = "0.1");
+extern mod externcallback = "externcallback#0.1";
 
 fn fact(n: uint) -> uint {
     unsafe {

--- a/src/test/run-pass/issue-6919.rs
+++ b/src/test/run-pass/issue-6919.rs
@@ -12,7 +12,6 @@
 // xfail-fast
 
 #[crate_id="issue-6919"];
-
 extern mod issue6919_3;
 
 pub fn main() {


### PR DESCRIPTION
This patch for  #9543 throws an `obsolete syntax` error for `extern mod foo (name="bar")` . 
I was wondering if [this](https://github.com/fhahn/rust/compare/mozilla:master...fhahn:issue9543-remove-extern-mod-foo?expand=1#diff-da9d34ca1d0f6beee2838cf02e07345cR4444) is the correct place to do this?

I think the wording of the error message could probably be improved as well.

If this approach is OK, I'm going to run the whole test suite tomorrow and update the old syntax to the new one.
