### PR TITLE
Add --dep-info flag to write Makefile compatible dependency files

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -720,7 +720,7 @@ pub fn link_binary(sess: Session,
                    trans: &CrateTranslation,
                    obj_filename: &Path,
                    out_filename: &Path,
-                   lm: &LinkMeta) {
+                   lm: &LinkMeta) -> ~[Path] {
     // If we're generating a test executable, then ignore all other output
     // styles at all other locations
     let outputs = if sess.opts.test {
@@ -729,8 +729,10 @@ pub fn link_binary(sess: Session,
         (*sess.outputs).clone()
     };
 
+    let mut out_filenames = ~[];
     for output in outputs.move_iter() {
-        link_binary_output(sess, trans, output, obj_filename, out_filename, lm);
+        let out_file = link_binary_output(sess, trans, output, obj_filename, out_filename, lm);
+        out_filenames.push(out_file);
     }
 
     // Remove the temporary object file and metadata if we aren't saving temps
@@ -738,6 +740,8 @@ pub fn link_binary(sess: Session,
         fs::unlink(obj_filename);
         fs::unlink(&obj_filename.with_extension("metadata.o"));
     }
+
+    out_filenames
 }
 
 fn is_writeable(p: &Path) -> bool {
@@ -754,7 +758,7 @@ fn link_binary_output(sess: Session,
                       output: session::OutputStyle,
                       obj_filename: &Path,
                       out_filename: &Path,
-                      lm: &LinkMeta) {
+                      lm: &LinkMeta) -> Path {
     let libname = output_lib_filename(lm);
     let out_filename = match output {
         session::OutputRlib => {
@@ -805,6 +809,8 @@ fn link_binary_output(sess: Session,
             link_natively(sess, true, obj_filename, &out_filename);
         }
     }
+
+    out_filename
 }
 
 // Create an 'rlib'

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -170,6 +170,8 @@ pub struct options {
     no_trans: bool,
     debugging_opts: uint,
     android_cross_path: Option<~str>,
+    // Whether to write .d dependency files
+    write_dependency_info: bool,
 }
 
 pub struct crate_metadata {
@@ -393,6 +395,7 @@ pub fn basic_options() -> @options {
         no_trans: false,
         debugging_opts: 0u,
         android_cross_path: None,
+        write_dependency_info: false,
     }
 }
 

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -353,7 +353,8 @@ pub fn compile_crate_from_input(input: &Path,
 
     // bad copy
     debug!("out_dir = {}", out_dir.display());
-    let mut outputs = driver::build_output_filenames(&driver::file_input(input.clone()),
+    let file_input = driver::file_input(input.clone());
+    let mut outputs = driver::build_output_filenames(&file_input,
                                                      &Some(out_dir.clone()), &None,
                                                      crate.attrs, sess);
     match what {
@@ -388,7 +389,7 @@ pub fn compile_crate_from_input(input: &Path,
     // -c
     if driver::stop_after_phase_5(sess)
         || stop_before == Link || stop_before == Assemble { return Some(outputs.out_filename); }
-    driver::phase_6_link_output(sess, &translation, outputs);
+    driver::phase_6_link_output(sess, &translation, &file_input, outputs);
 
     // Register dependency on the source file
     // FIXME (#9639): This needs to handle non-utf8 paths

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -260,6 +260,10 @@ impl FileMap {
         };
         self.multibyte_chars.push(mbc);
     }
+
+    pub fn is_real_file(&self) -> bool {
+        !(self.name.starts_with("<") && self.name.ends_with(">"))
+    }
 }
 
 pub struct CodeMap {

--- a/src/test/run-make/dep-info/Makefile
+++ b/src/test/run-make/dep-info/Makefile
@@ -1,0 +1,11 @@
+-include ../tools.mk
+all:
+	$(RUSTC) --dep-info --lib lib.rs
+	sleep 1
+	touch foo.rs
+	-rm -f $(TMPDIR)/done
+	$(MAKE) -f Makefile.foo
+	rm $(TMPDIR)/done
+	pwd
+	$(MAKE) -df Makefile.foo
+	rm $(TMPDIR)/done && exit 1 || exit 0

--- a/src/test/run-make/dep-info/Makefile.foo
+++ b/src/test/run-make/dep-info/Makefile.foo
@@ -1,0 +1,11 @@
+ifeq ($(shell uname),Darwin)
+LIBEXT=dylib
+else
+LIBEXT=so
+endif
+
+$(TMPDIR)/libfoo-b517899a-0.1.$(LIBEXT):
+	$(RUSTC) --dep-info --lib lib.rs
+	touch $(TMPDIR)/done
+
+-include $(TMPDIR)/lib.d

--- a/src/test/run-make/dep-info/bar.rs
+++ b/src/test/run-make/dep-info/bar.rs
@@ -1,0 +1,1 @@
+pub fn bar() {}

--- a/src/test/run-make/dep-info/foo.rs
+++ b/src/test/run-make/dep-info/foo.rs
@@ -1,0 +1,1 @@
+pub fn foo() {}

--- a/src/test/run-make/dep-info/lib.rs
+++ b/src/test/run-make/dep-info/lib.rs
@@ -1,0 +1,4 @@
+#[pkgid="foo#0.1"];
+
+pub mod foo;
+pub mod bar;


### PR DESCRIPTION
This isn't super useful for libraries yet without #10593.

Fixes #7633.
