### PR TITLE
std::str: stop from_utf8 allocating. 

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -60,12 +60,12 @@ pub fn run(lib_path: &str,
     for input in input.iter() {
         process.input().write(input.as_bytes());
     }
-    let output = process.finish_with_output();
+    let run::ProcessOutput { status, output, error } = process.finish_with_output();
 
     Result {
-        status: output.status,
-        out: str::from_utf8(output.output),
-        err: str::from_utf8(output.error)
+        status: status,
+        out: str::from_utf8_owned(output),
+        err: str::from_utf8_owned(error)
     }
 }
 
@@ -90,4 +90,3 @@ pub fn run_background(lib_path: &str,
 
     return process;
 }
-

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -298,7 +298,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
 
                 let adb_arg = format!("export LD_LIBRARY_PATH={}; gdbserver :5039 {}/{}",
                          config.adb_test_dir.clone(), config.adb_test_dir.clone(),
-                         str::from_utf8(exe_file.filename().unwrap())).clone();
+                         str::from_utf8_slice(exe_file.filename().unwrap()));
 
                 let mut process = procsrv::run_background("", config.adb_path.clone(),
                         [~"shell",adb_arg.clone()],~[(~"",~"")], Some(~""));
@@ -1151,4 +1151,3 @@ fn run_codegen_test(config: &config, props: &TestProps,
                      (base_lines as f64) / (clang_lines as f64),
                      0.001);
 }
-

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -298,7 +298,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
 
                 let adb_arg = format!("export LD_LIBRARY_PATH={}; gdbserver :5039 {}/{}",
                          config.adb_test_dir.clone(), config.adb_test_dir.clone(),
-                         str::from_utf8_slice(exe_file.filename().unwrap()));
+                         str::from_utf8(exe_file.filename().unwrap()));
 
                 let mut process = procsrv::run_background("", config.adb_path.clone(),
                         [~"shell",adb_arg.clone()],~[(~"",~"")], Some(~""));

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -162,7 +162,7 @@ impl<'self> FromBase64 for &'self str {
      * Convert any base64 encoded string (literal, `@`, `&`, or `~`)
      * to the byte values it encodes.
      *
-     * You can use the `from_utf8` function in `std::str`
+     * You can use the `from_utf8_owned` function in `std::str`
      * to turn a `[u8]` into a string with characters corresponding to those
      * values.
      *
@@ -180,7 +180,7 @@ impl<'self> FromBase64 for &'self str {
      *     println!("base64 output: {}", hello_str);
      *     let res = hello_str.from_base64();
      *     if res.is_ok() {
-     *       let optBytes = str::from_utf8_opt(res.unwrap());
+     *       let optBytes = str::from_utf8_owned_opt(res.unwrap());
      *       if optBytes.is_some() {
      *         println!("decoded from base64: {}", optBytes.unwrap());
      *       }

--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -41,7 +41,7 @@ impl Doc {
     }
 
     pub fn as_str_slice<'a>(&'a self) -> &'a str {
-        str::from_utf8_slice(self.data.slice(self.start, self.end))
+        str::from_utf8(self.data.slice(self.start, self.end))
     }
 
     pub fn as_str(&self) -> ~str {

--- a/src/libextra/hex.rs
+++ b/src/libextra/hex.rs
@@ -62,7 +62,7 @@ impl<'self> FromHex for &'self str {
      * Convert any hexadecimal encoded string (literal, `@`, `&`, or `~`)
      * to the byte values it encodes.
      *
-     * You can use the `from_utf8` function in `std::str`
+     * You can use the `from_utf8_owned` function in `std::str`
      * to turn a `[u8]` into a string with characters corresponding to those
      * values.
      *
@@ -80,7 +80,7 @@ impl<'self> FromHex for &'self str {
      *     println!("{}", hello_str);
      *     let bytes = hello_str.from_hex().unwrap();
      *     println!("{:?}", bytes);
-     *     let result_str = str::from_utf8(bytes);
+     *     let result_str = str::from_utf8_owned(bytes);
      *     println!("{}", result_str);
      * }
      * ```

--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -215,7 +215,9 @@ pub fn parse(file: &mut io::Reader,
         return Err(~"incompatible file: more string offsets than expected");
     }
 
-    let names_str = str::from_utf8(file.read_bytes(names_bytes as uint - 1)); // don't read NUL
+    // don't read NUL
+    let names_str = str::from_utf8_owned(file.read_bytes(names_bytes as uint - 1));
+
     let term_names: ~[~str] = names_str.split('|').map(|s| s.to_owned()).collect();
 
     file.read_byte(); // consume NUL

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -701,7 +701,7 @@ fn should_sort_failures_before_printing_them() {
 
     st.write_failures();
     let s = match st.out {
-        Right(ref m) => str::from_utf8(*m.inner_ref()),
+        Right(ref m) => str::from_utf8_slice(*m.inner_ref()),
         Left(_) => unreachable!()
     };
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -701,7 +701,7 @@ fn should_sort_failures_before_printing_them() {
 
     st.write_failures();
     let s = match st.out {
-        Right(ref m) => str::from_utf8_slice(*m.inner_ref()),
+        Right(ref m) => str::from_utf8(*m.inner_ref()),
         Left(_) => unreachable!()
     };
 

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -310,7 +310,7 @@ impl Uuid {
             s[i*2+0] = digit[0];
             s[i*2+1] = digit[1];
         }
-        str::from_utf8(s)
+        str::from_utf8_owned(s)
     }
 
     /// Returns a string of hexadecimal digits, separated into groups with a hypen

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -260,7 +260,7 @@ fn json_encode<'self, T:Encodable<json::Encoder<'self>>>(t: &T) -> ~str {
     let mut writer = MemWriter::new();
     let mut encoder = json::Encoder::init(&mut writer as &mut io::Writer);
     t.encode(&mut encoder);
-    str::from_utf8(writer.inner_ref().as_slice())
+    str::from_utf8_owned(writer.inner())
 }
 
 // FIXME(#5121)

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -41,8 +41,8 @@ fn run_ar(sess: Session, args: &str, cwd: Option<&Path>,
     let o = Process::new(ar, args.as_slice(), opts).finish_with_output();
     if !o.status.success() {
         sess.err(format!("{} failed with: {}", ar, o.status));
-        sess.note(format!("stdout ---\n{}", str::from_utf8(o.output)));
-        sess.note(format!("stderr ---\n{}", str::from_utf8(o.error)));
+        sess.note(format!("stdout ---\n{}", str::from_utf8_slice(o.output)));
+        sess.note(format!("stderr ---\n{}", str::from_utf8_slice(o.error)));
         sess.abort_if_errors();
     }
     o

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -41,8 +41,8 @@ fn run_ar(sess: Session, args: &str, cwd: Option<&Path>,
     let o = Process::new(ar, args.as_slice(), opts).finish_with_output();
     if !o.status.success() {
         sess.err(format!("{} failed with: {}", ar, o.status));
-        sess.note(format!("stdout ---\n{}", str::from_utf8_slice(o.output)));
-        sess.note(format!("stderr ---\n{}", str::from_utf8_slice(o.error)));
+        sess.note(format!("stdout ---\n{}", str::from_utf8(o.output)));
+        sess.note(format!("stderr ---\n{}", str::from_utf8(o.error)));
         sess.abort_if_errors();
     }
     o

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -368,7 +368,7 @@ pub mod write {
         if !prog.status.success() {
             sess.err(format!("linking with `{}` failed: {}", cc, prog.status));
             sess.note(format!("{} arguments: '{}'", cc, args.connect("' '")));
-            sess.note(str::from_utf8(prog.error + prog.output));
+            sess.note(str::from_utf8_owned(prog.error + prog.output));
             sess.abort_if_errors();
         }
     }
@@ -1079,7 +1079,7 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
     if !prog.status.success() {
         sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
         sess.note(format!("{} arguments: '{}'", cc_prog, cc_args.connect("' '")));
-        sess.note(str::from_utf8(prog.error + prog.output));
+        sess.note(str::from_utf8_owned(prog.error + prog.output));
         sess.abort_if_errors();
     }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -166,7 +166,7 @@ Available lint options:
         max_key = num::max(name.len(), max_key);
     }
     fn padded(max: uint, s: &str) -> ~str {
-        str::from_utf8(vec::from_elem(max - s.len(), ' ' as u8)) + s
+        " ".repeat(max - s.len()) + s
     }
     println("\nAvailable lint checks:\n");
     println!("    {}  {:7.7s}  {}",
@@ -246,7 +246,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
       1u => {
         let ifile = matches.free[0].as_slice();
         if "-" == ifile {
-            let src = str::from_utf8(io::stdin().read_to_end());
+            let src = str::from_utf8_owned(io::stdin().read_to_end());
             str_input(src.to_managed())
         } else {
             file_input(Path::init(ifile))

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1274,8 +1274,8 @@ fn family_names_type(fam: Family) -> bool {
 fn read_path(d: ebml::Doc) -> (~str, uint) {
     reader::with_doc_data(d, |desc| {
         let pos = u64_from_be_bytes(desc, 0u, 4u) as uint;
-        let pathbytes = desc.slice(4u, desc.len());
-        let path = str::from_utf8(pathbytes);
+        let pathbytes = desc.slice_from(4u).to_owned();
+        let path = str::from_utf8_owned(pathbytes);
 
         (path, pos)
     })

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1902,5 +1902,5 @@ pub fn encoded_ty(tcx: ty::ctxt, t: ty::t) -> ~str {
         abbrevs: tyencode::ac_no_abbrevs};
     let wr = @mut MemWriter::new();
     tyencode::enc_ty(wr, cx, t);
-    str::from_utf8(*wr.inner_ref())
+    str::from_utf8_owned(wr.inner_ref().to_owned())
 }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -97,8 +97,9 @@ pub fn parse_ident(st: &mut PState, last: char) -> ast::Ident {
 }
 
 fn parse_ident_(st: &mut PState, is_last: |char| -> bool) -> ast::Ident {
-    let rslt = scan(st, is_last, str::from_utf8);
-    return st.tcx.sess.ident_of(rslt);
+    scan(st, is_last, |bytes| {
+            st.tcx.sess.ident_of(str::from_utf8_slice(bytes))
+        })
 }
 
 pub fn parse_state_from_data<'a>(data: &'a [u8], crate_num: ast::CrateNum,
@@ -492,10 +493,11 @@ fn parse_abi_set(st: &mut PState) -> AbiSet {
     assert_eq!(next(st), '[');
     let mut abis = AbiSet::empty();
     while peek(st) != ']' {
-        // FIXME(#5422) str API should not force this copy
-        let abi_str = scan(st, |c| c == ',', str::from_utf8);
-        let abi = abi::lookup(abi_str).expect(abi_str);
-        abis.add(abi);
+         scan(st, |c| c == ',', |bytes| {
+                 let abi_str = str::from_utf8_slice(bytes).to_owned();
+                 let abi = abi::lookup(abi_str).expect(abi_str);
+                 abis.add(abi);
+              });
     }
     assert_eq!(next(st), ']');
     return abis;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -98,7 +98,7 @@ pub fn parse_ident(st: &mut PState, last: char) -> ast::Ident {
 
 fn parse_ident_(st: &mut PState, is_last: |char| -> bool) -> ast::Ident {
     scan(st, is_last, |bytes| {
-            st.tcx.sess.ident_of(str::from_utf8_slice(bytes))
+            st.tcx.sess.ident_of(str::from_utf8(bytes))
         })
 }
 
@@ -494,7 +494,7 @@ fn parse_abi_set(st: &mut PState) -> AbiSet {
     let mut abis = AbiSet::empty();
     while peek(st) != ']' {
          scan(st, |c| c == ',', |bytes| {
-                 let abi_str = str::from_utf8_slice(bytes).to_owned();
+                 let abi_str = str::from_utf8(bytes).to_owned();
                  let abi = abi::lookup(abi_str).expect(abi_str);
                  abis.add(abi);
               });

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -72,7 +72,7 @@ pub fn enc_ty(w: @mut MemWriter, cx: @ctxt, t: ty::t) {
             None => {
                 let wr = @mut MemWriter::new();
                 enc_sty(wr, cx, &ty::get(t).sty);
-                let s = str::from_utf8(*wr.inner_ref()).to_managed();
+                let s = str::from_utf8_slice(*wr.inner_ref()).to_managed();
                 cx.tcx.short_names_cache.insert(t, s);
                 s
           }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -72,7 +72,7 @@ pub fn enc_ty(w: @mut MemWriter, cx: @ctxt, t: ty::t) {
             None => {
                 let wr = @mut MemWriter::new();
                 enc_sty(wr, cx, &ty::get(t).sty);
-                let s = str::from_utf8_slice(*wr.inner_ref()).to_managed();
+                let s = str::from_utf8(*wr.inner_ref()).to_managed();
                 cx.tcx.short_names_cache.insert(t, s);
                 s
           }

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -184,7 +184,7 @@ impl<'self> PkgScript<'self> {
                                              [sysroot.as_str().unwrap().to_owned(), ~"configs"]);
             debug!("run_custom: second pkg command did {:?}", output.status);
             // Run the configs() function to get the configs
-            let cfgs = str::from_utf8_slice(output.output).words()
+            let cfgs = str::from_utf8(output.output).words()
                 .map(|w| w.to_owned()).collect();
             (cfgs, output.status)
         }

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -154,7 +154,7 @@ fn run_git(args: &[~str], env: Option<~[(~str, ~str)]>, cwd: &Path, err_msg: &st
     let rslt = prog.finish_with_output();
     if !rslt.status.success() {
         fail!("{} [git returned {:?}, output = {}, error = {}]", err_msg,
-           rslt.status, str::from_utf8(rslt.output), str::from_utf8(rslt.error));
+           rslt.status, str::from_utf8_slice(rslt.output), str::from_utf8_slice(rslt.error));
     }
 }
 
@@ -290,13 +290,13 @@ fn command_line_test_with_env(args: &[~str], cwd: &Path, env: Option<~[(~str, ~s
     });
     let output = prog.finish_with_output();
     debug!("Output from command {} with args {:?} was {} \\{{}\\}[{:?}]",
-                    cmd, args, str::from_utf8(output.output),
-                   str::from_utf8(output.error),
-                   output.status);
+           cmd, args, str::from_utf8_slice(output.output),
+           str::from_utf8_slice(output.error),
+           output.status);
     if !output.status.success() {
         debug!("Command {} {:?} failed with exit code {:?}; its output was --- {} ---",
               cmd, args, output.status,
-              str::from_utf8(output.output) + str::from_utf8(output.error));
+              str::from_utf8_slice(output.output) + str::from_utf8_slice(output.error));
         Fail(output)
     }
     else {
@@ -455,7 +455,7 @@ fn built_library_exists(repo: &Path, short_name: &str) -> bool {
 fn command_line_test_output(args: &[~str]) -> ~[~str] {
     let mut result = ~[];
     let p_output = command_line_test(args, &os::getcwd());
-    let test_output = str::from_utf8(p_output.output);
+    let test_output = str::from_utf8_slice(p_output.output);
     for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
@@ -469,7 +469,7 @@ fn command_line_test_output_with_env(args: &[~str], env: ~[(~str, ~str)]) -> ~[~
         Fail(_) => fail!("Command-line test failed"),
         Success(r) => r
     };
-    let test_output = str::from_utf8(p_output.output);
+    let test_output = str::from_utf8_slice(p_output.output);
     for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
@@ -1204,7 +1204,7 @@ fn test_info() {
     let expected_info = ~"package foo"; // fill in
     let workspace = create_local_package(&PkgId::new("foo"));
     let output = command_line_test([~"info", ~"foo"], workspace.path());
-    assert_eq!(str::from_utf8(output.output), expected_info);
+    assert_eq!(str::from_utf8_owned(output.output), expected_info);
 }
 
 #[test]
@@ -1212,7 +1212,7 @@ fn test_uninstall() {
     let workspace = create_local_package(&PkgId::new("foo"));
     command_line_test([~"uninstall", ~"foo"], workspace.path());
     let output = command_line_test([~"list"], workspace.path());
-    assert!(!str::from_utf8(output.output).contains("foo"));
+    assert!(!str::from_utf8_slice(output.output).contains("foo"));
 }
 
 #[test]
@@ -1282,8 +1282,8 @@ fn test_extern_mod() {
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
-              str::from_utf8(outp.output),
-              str::from_utf8(outp.error));
+              str::from_utf8_slice(outp.output),
+              str::from_utf8_slice(outp.error));
     }
     assert!(exec_file.exists() && is_executable(&exec_file));
 }
@@ -1337,8 +1337,8 @@ fn test_extern_mod_simpler() {
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
-              str::from_utf8(outp.output),
-              str::from_utf8(outp.error));
+              str::from_utf8_slice(outp.output),
+              str::from_utf8_slice(outp.error));
     }
     assert!(exec_file.exists() && is_executable(&exec_file));
 }
@@ -2101,7 +2101,7 @@ fn test_rustpkg_test_creates_exec() {
 fn test_rustpkg_test_output() {
     let workspace = create_local_package_with_test(&PkgId::new("foo"));
     let output = command_line_test([~"test", ~"foo"], workspace.path());
-    let output_str = str::from_utf8(output.output);
+    let output_str = str::from_utf8_slice(output.output);
     // The first two assertions are separate because test output may
     // contain color codes, which could appear between "test f" and "ok".
     assert!(output_str.contains("test f"));
@@ -2132,7 +2132,7 @@ fn test_rustpkg_test_cfg() {
               "#[test] #[cfg(not(foobar))] fn f() { assert!('a' != 'a'); }");
     let output = command_line_test([~"test", ~"--cfg", ~"foobar", ~"foo"],
                                    foo_workspace);
-    let output_str = str::from_utf8(output.output);
+    let output_str = str::from_utf8_slice(output.output);
     assert!(output_str.contains("0 passed; 0 failed; 0 ignored; 0 measured"));
 }
 
@@ -2430,8 +2430,8 @@ fn correct_error_dependency() {
         Fail(ProcessOutput{ error: error, output: output, .. }) => {
             assert!(str::is_utf8(error));
             assert!(str::is_utf8(output));
-            let error_str = str::from_utf8(error);
-            let out_str   = str::from_utf8(output);
+            let error_str = str::from_utf8_slice(error);
+            let out_str   = str::from_utf8_slice(output);
             debug!("ss = {}", error_str);
             debug!("out_str = {}", out_str);
             if out_str.contains("Package badpkg depends on some_package_that_doesnt_exist") &&

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -154,7 +154,7 @@ fn run_git(args: &[~str], env: Option<~[(~str, ~str)]>, cwd: &Path, err_msg: &st
     let rslt = prog.finish_with_output();
     if !rslt.status.success() {
         fail!("{} [git returned {:?}, output = {}, error = {}]", err_msg,
-           rslt.status, str::from_utf8_slice(rslt.output), str::from_utf8_slice(rslt.error));
+           rslt.status, str::from_utf8(rslt.output), str::from_utf8(rslt.error));
     }
 }
 
@@ -290,13 +290,13 @@ fn command_line_test_with_env(args: &[~str], cwd: &Path, env: Option<~[(~str, ~s
     });
     let output = prog.finish_with_output();
     debug!("Output from command {} with args {:?} was {} \\{{}\\}[{:?}]",
-           cmd, args, str::from_utf8_slice(output.output),
-           str::from_utf8_slice(output.error),
+           cmd, args, str::from_utf8(output.output),
+           str::from_utf8(output.error),
            output.status);
     if !output.status.success() {
-        debug!("Command {} {:?} failed with exit code {:?}; its output was --- {} ---",
+        debug!("Command {} {:?} failed with exit code {:?}; its output was --- {} {} ---",
               cmd, args, output.status,
-              str::from_utf8_slice(output.output) + str::from_utf8_slice(output.error));
+              str::from_utf8(output.output), str::from_utf8(output.error));
         Fail(output)
     }
     else {
@@ -455,7 +455,7 @@ fn built_library_exists(repo: &Path, short_name: &str) -> bool {
 fn command_line_test_output(args: &[~str]) -> ~[~str] {
     let mut result = ~[];
     let p_output = command_line_test(args, &os::getcwd());
-    let test_output = str::from_utf8_slice(p_output.output);
+    let test_output = str::from_utf8(p_output.output);
     for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
@@ -469,7 +469,7 @@ fn command_line_test_output_with_env(args: &[~str], env: ~[(~str, ~str)]) -> ~[~
         Fail(_) => fail!("Command-line test failed"),
         Success(r) => r
     };
-    let test_output = str::from_utf8_slice(p_output.output);
+    let test_output = str::from_utf8(p_output.output);
     for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
@@ -1212,7 +1212,7 @@ fn test_uninstall() {
     let workspace = create_local_package(&PkgId::new("foo"));
     command_line_test([~"uninstall", ~"foo"], workspace.path());
     let output = command_line_test([~"list"], workspace.path());
-    assert!(!str::from_utf8_slice(output.output).contains("foo"));
+    assert!(!str::from_utf8(output.output).contains("foo"));
 }
 
 #[test]
@@ -1282,8 +1282,8 @@ fn test_extern_mod() {
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
-              str::from_utf8_slice(outp.output),
-              str::from_utf8_slice(outp.error));
+              str::from_utf8(outp.output),
+              str::from_utf8(outp.error));
     }
     assert!(exec_file.exists() && is_executable(&exec_file));
 }
@@ -1337,8 +1337,8 @@ fn test_extern_mod_simpler() {
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
-              str::from_utf8_slice(outp.output),
-              str::from_utf8_slice(outp.error));
+              str::from_utf8(outp.output),
+              str::from_utf8(outp.error));
     }
     assert!(exec_file.exists() && is_executable(&exec_file));
 }
@@ -2101,7 +2101,7 @@ fn test_rustpkg_test_creates_exec() {
 fn test_rustpkg_test_output() {
     let workspace = create_local_package_with_test(&PkgId::new("foo"));
     let output = command_line_test([~"test", ~"foo"], workspace.path());
-    let output_str = str::from_utf8_slice(output.output);
+    let output_str = str::from_utf8(output.output);
     // The first two assertions are separate because test output may
     // contain color codes, which could appear between "test f" and "ok".
     assert!(output_str.contains("test f"));
@@ -2132,7 +2132,7 @@ fn test_rustpkg_test_cfg() {
               "#[test] #[cfg(not(foobar))] fn f() { assert!('a' != 'a'); }");
     let output = command_line_test([~"test", ~"--cfg", ~"foobar", ~"foo"],
                                    foo_workspace);
-    let output_str = str::from_utf8_slice(output.output);
+    let output_str = str::from_utf8(output.output);
     assert!(output_str.contains("0 passed; 0 failed; 0 ignored; 0 measured"));
 }
 
@@ -2430,8 +2430,8 @@ fn correct_error_dependency() {
         Fail(ProcessOutput{ error: error, output: output, .. }) => {
             assert!(str::is_utf8(error));
             assert!(str::is_utf8(output));
-            let error_str = str::from_utf8_slice(error);
-            let out_str   = str::from_utf8_slice(output);
+            let error_str = str::from_utf8(error);
+            let out_str   = str::from_utf8(output);
             debug!("ss = {}", error_str);
             debug!("out_str = {}", out_str);
             if out_str.contains("Package badpkg depends on some_package_that_doesnt_exist") &&

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -113,19 +113,19 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
             continue;
         }
 
-    let mut output = None;
-    let output_text = str::from_utf8(outp.output);
-    for l in output_text.lines() {
-        if !l.is_whitespace() {
-            output = Some(l);
-        }
-        match output.and_then(try_parsing_version) {
-            Some(v) => return Some(v),
-            None    => ()
+        let mut output = None;
+        let output_text = str::from_utf8_slice(outp.output);
+        for l in output_text.lines() {
+            if !l.is_whitespace() {
+                output = Some(l);
+            }
+            match output.and_then(try_parsing_version) {
+                Some(v) => return Some(v),
+                None    => ()
+            }
         }
     }
-  }
-  None
+    None
 }
 
 /// If `remote_path` refers to a git repo that can be downloaded,
@@ -145,8 +145,8 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
                                                 tmp_dir.as_str().unwrap().to_owned()]);
         if outp.status.success() {
             debug!("Cloned it... ( {}, {} )",
-                   str::from_utf8(outp.output),
-                   str::from_utf8(outp.error));
+                   str::from_utf8_slice(outp.output),
+                   str::from_utf8_slice(outp.error));
             let mut output = None;
             let git_dir = tmp_dir.join(".git");
             debug!("(getting version, now getting tags) executing \\{git --git-dir={} tag -l\\}",
@@ -155,7 +155,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
             let outp = run::process_output("git",
                                            ["--git-dir=" + git_dir.as_str().unwrap(),
                                             ~"tag", ~"-l"]);
-            let output_text = str::from_utf8(outp.output);
+            let output_text = str::from_utf8_slice(outp.output);
             debug!("Full output: ( {} ) [{:?}]", output_text, outp.status);
             for l in output_text.lines() {
                 debug!("A line of output: {}", l);

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -114,7 +114,7 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
         }
 
         let mut output = None;
-        let output_text = str::from_utf8_slice(outp.output);
+        let output_text = str::from_utf8(outp.output);
         for l in output_text.lines() {
             if !l.is_whitespace() {
                 output = Some(l);
@@ -145,8 +145,8 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
                                                 tmp_dir.as_str().unwrap().to_owned()]);
         if outp.status.success() {
             debug!("Cloned it... ( {}, {} )",
-                   str::from_utf8_slice(outp.output),
-                   str::from_utf8_slice(outp.error));
+                   str::from_utf8(outp.output),
+                   str::from_utf8(outp.error));
             let mut output = None;
             let git_dir = tmp_dir.join(".git");
             debug!("(getting version, now getting tags) executing \\{git --git-dir={} tag -l\\}",
@@ -155,7 +155,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
             let outp = run::process_output("git",
                                            ["--git-dir=" + git_dir.as_str().unwrap(),
                                             ~"tag", ~"-l"]);
-            let output_text = str::from_utf8_slice(outp.output);
+            let output_text = str::from_utf8(outp.output);
             debug!("Full output: ( {} ) [{:?}]", output_text, outp.status);
             for l in output_text.lines() {
                 debug!("A line of output: {}", l);

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -487,7 +487,7 @@ mod test {
 
             let nread = result.unwrap();
             assert!(nread > 0);
-            let read_str = str::from_utf8_slice(read_mem.slice_to(nread as uint));
+            let read_str = str::from_utf8(read_mem.slice_to(nread as uint));
             assert_eq!(read_str, "hello");
         }
         // unlink

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -487,8 +487,8 @@ mod test {
 
             let nread = result.unwrap();
             assert!(nread > 0);
-            let read_str = str::from_utf8(read_mem.slice(0, nread as uint));
-            assert_eq!(read_str, ~"hello");
+            let read_str = str::from_utf8_slice(read_mem.slice_to(nread as uint));
+            assert_eq!(read_str, "hello");
         }
         // unlink
         let result = FsRequest::unlink(l(), &path_str.to_c_str());

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -81,7 +81,7 @@ pub fn sockaddr_to_socket_addr(addr: *sockaddr) -> SocketAddr {
             };
             port as u16
         };
-        let ip_str = str::from_utf8_slice(ip_name).trim_right_chars(&'\x00');
+        let ip_str = str::from_utf8(ip_name).trim_right_chars(&'\x00');
         let ip_addr = FromStr::from_str(ip_str).unwrap();
 
         SocketAddr { ip: ip_addr, port: ip_port }

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -167,7 +167,7 @@ impl CString {
         if self.buf.is_null() { return None; }
         let buf = self.as_bytes();
         let buf = buf.slice_to(buf.len()-1); // chop off the trailing NUL
-        str::from_utf8_slice_opt(buf)
+        str::from_utf8_opt(buf)
     }
 
     /// Return a CString iterator.

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -802,7 +802,7 @@ impl<'self> Formatter<'self> {
 
     fn runplural(&mut self, value: uint, pieces: &[rt::Piece]) {
         ::uint::to_str_bytes(value, 10, |buf| {
-            let valuestr = str::from_utf8_slice(buf);
+            let valuestr = str::from_utf8(buf);
             for piece in pieces.iter() {
                 self.run(piece, Some(valuestr));
             }

--- a/src/libstd/io/flate.rs
+++ b/src/libstd/io/flate.rs
@@ -117,7 +117,7 @@ mod test {
         let mut out_bytes = [0, .. 100];
         let bytes_read = inflate_reader.read(out_bytes).unwrap();
         assert_eq!(bytes_read, in_bytes.len());
-        let out_msg = str::from_utf8_slice(out_bytes);
+        let out_msg = str::from_utf8(out_bytes);
         assert_eq!(in_msg, out_msg);
     }
 }

--- a/src/libstd/io/flate.rs
+++ b/src/libstd/io/flate.rs
@@ -107,7 +107,7 @@ mod test {
     fn smoke_test() {
         let mem_writer = MemWriter::new();
         let mut deflate_writer = DeflateWriter::new(mem_writer);
-        let in_msg = "test";
+        let in_msg: &str = "test";
         let in_bytes = in_msg.as_bytes();
         deflate_writer.write(in_bytes);
         deflate_writer.flush();
@@ -117,7 +117,7 @@ mod test {
         let mut out_bytes = [0, .. 100];
         let bytes_read = inflate_reader.read(out_bytes).unwrap();
         assert_eq!(bytes_read, in_bytes.len());
-        let out_msg = str::from_utf8(out_bytes);
-        assert!(in_msg == out_msg);
+        let out_msg = str::from_utf8_slice(out_bytes);
+        assert_eq!(in_msg, out_msg);
     }
 }

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -770,9 +770,9 @@ mod test {
             let mut read_buf = [0, .. 1028];
             let read_str = match read_stream.read(read_buf).unwrap() {
                 -1|0 => fail!("shouldn't happen"),
-                n => str::from_utf8(read_buf.slice_to(n))
+                n => str::from_utf8_owned(read_buf.slice_to(n).to_owned())
             };
-            assert!(read_str == message.to_owned());
+            assert_eq!(read_str, message.to_owned());
         }
         unlink(filename);
     })
@@ -801,7 +801,7 @@ mod test {
     })
 
     test!(fn file_test_io_non_positional_read() {
-        let message = "ten-four";
+        let message: &str = "ten-four";
         let mut read_mem = [0, .. 8];
         let tmpdir = tmpdir();
         let filename = &tmpdir.join("file_rt_io_file_test_positional.txt");
@@ -821,8 +821,8 @@ mod test {
             }
         }
         unlink(filename);
-        let read_str = str::from_utf8(read_mem);
-        assert!(read_str == message.to_owned());
+        let read_str = str::from_utf8_slice(read_mem);
+        assert_eq!(read_str, message);
     })
 
     test!(fn file_test_io_seek_and_tell_smoke_test() {
@@ -845,10 +845,10 @@ mod test {
             tell_pos_post_read = read_stream.tell();
         }
         unlink(filename);
-        let read_str = str::from_utf8(read_mem);
-        assert!(read_str == message.slice(4, 8).to_owned());
-        assert!(tell_pos_pre_read == set_cursor);
-        assert!(tell_pos_post_read == message.len() as u64);
+        let read_str = str::from_utf8_slice(read_mem);
+        assert_eq!(read_str, message.slice(4, 8));
+        assert_eq!(tell_pos_pre_read, set_cursor);
+        assert_eq!(tell_pos_post_read, message.len() as u64);
     })
 
     test!(fn file_test_io_seek_and_write() {
@@ -870,16 +870,16 @@ mod test {
             read_stream.read(read_mem);
         }
         unlink(filename);
-        let read_str = str::from_utf8(read_mem);
+        let read_str = str::from_utf8_slice(read_mem);
         assert!(read_str == final_msg.to_owned());
     })
 
     test!(fn file_test_io_seek_shakedown() {
         use std::str;          // 01234567890123
         let initial_msg =   "qwer-asdf-zxcv";
-        let chunk_one = "qwer";
-        let chunk_two = "asdf";
-        let chunk_three = "zxcv";
+        let chunk_one: &str = "qwer";
+        let chunk_two: &str = "asdf";
+        let chunk_three: &str = "zxcv";
         let mut read_mem = [0, .. 4];
         let tmpdir = tmpdir();
         let filename = &tmpdir.join("file_rt_io_file_test_seek_shakedown.txt");
@@ -892,18 +892,15 @@ mod test {
 
             read_stream.seek(-4, SeekEnd);
             read_stream.read(read_mem);
-            let read_str = str::from_utf8(read_mem);
-            assert!(read_str == chunk_three.to_owned());
+            assert_eq!(str::from_utf8_slice(read_mem), chunk_three);
 
             read_stream.seek(-9, SeekCur);
             read_stream.read(read_mem);
-            let read_str = str::from_utf8(read_mem);
-            assert!(read_str == chunk_two.to_owned());
+            assert_eq!(str::from_utf8_slice(read_mem), chunk_two);
 
             read_stream.seek(0, SeekSet);
             read_stream.read(read_mem);
-            let read_str = str::from_utf8(read_mem);
-            assert!(read_str == chunk_one.to_owned());
+            assert_eq!(str::from_utf8_slice(read_mem), chunk_one);
         }
         unlink(filename);
     })
@@ -977,12 +974,12 @@ mod test {
             {
                 let n = f.filestem_str();
                 File::open(f).read(mem);
-                let read_str = str::from_utf8(mem);
+                let read_str = str::from_utf8_slice(mem);
                 let expected = match n {
                     None|Some("") => fail!("really shouldn't happen.."),
                     Some(n) => prefix+n
                 };
-                assert!(expected == read_str);
+                assert_eq!(expected.as_slice(), read_str);
             }
             unlink(f);
         }

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -821,7 +821,7 @@ mod test {
             }
         }
         unlink(filename);
-        let read_str = str::from_utf8_slice(read_mem);
+        let read_str = str::from_utf8(read_mem);
         assert_eq!(read_str, message);
     })
 
@@ -845,7 +845,7 @@ mod test {
             tell_pos_post_read = read_stream.tell();
         }
         unlink(filename);
-        let read_str = str::from_utf8_slice(read_mem);
+        let read_str = str::from_utf8(read_mem);
         assert_eq!(read_str, message.slice(4, 8));
         assert_eq!(tell_pos_pre_read, set_cursor);
         assert_eq!(tell_pos_post_read, message.len() as u64);
@@ -870,7 +870,7 @@ mod test {
             read_stream.read(read_mem);
         }
         unlink(filename);
-        let read_str = str::from_utf8_slice(read_mem);
+        let read_str = str::from_utf8(read_mem);
         assert!(read_str == final_msg.to_owned());
     })
 
@@ -892,15 +892,15 @@ mod test {
 
             read_stream.seek(-4, SeekEnd);
             read_stream.read(read_mem);
-            assert_eq!(str::from_utf8_slice(read_mem), chunk_three);
+            assert_eq!(str::from_utf8(read_mem), chunk_three);
 
             read_stream.seek(-9, SeekCur);
             read_stream.read(read_mem);
-            assert_eq!(str::from_utf8_slice(read_mem), chunk_two);
+            assert_eq!(str::from_utf8(read_mem), chunk_two);
 
             read_stream.seek(0, SeekSet);
             read_stream.read(read_mem);
-            assert_eq!(str::from_utf8_slice(read_mem), chunk_one);
+            assert_eq!(str::from_utf8(read_mem), chunk_one);
         }
         unlink(filename);
     })
@@ -974,7 +974,7 @@ mod test {
             {
                 let n = f.filestem_str();
                 File::open(f).read(mem);
-                let read_str = str::from_utf8_slice(mem);
+                let read_str = str::from_utf8(mem);
                 let expected = match n {
                     None|Some("") => fail!("really shouldn't happen.."),
                     Some(n) => prefix+n

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1049,7 +1049,7 @@ pub trait Buffer: Reader {
             Some(n) if n == width => {}
             Some(..) | None => return None // read error
         }
-        match str::from_utf8_slice_opt(buf.slice_to(width)) {
+        match str::from_utf8_opt(buf.slice_to(width)) {
             Some(s) => Some(s.char_at(0)),
             None => None
         }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -426,7 +426,7 @@ pub fn float_to_str_common<T:NumCast+Zero+One+Eq+Ord+NumStrConv+Float+Round+
         sign: SignFormat, digits: SignificantDigits) -> (~str, bool) {
     let (bytes, special) = float_to_str_bytes_common(num, radix,
                                negative_zero, sign, digits);
-    (str::from_utf8(bytes), special)
+    (str::from_utf8_owned(bytes), special)
 }
 
 // Some constants for from_str_bytes_common's input validation,

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -176,7 +176,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// If the path is not representable in utf-8, this returns None.
     #[inline]
     fn as_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8_slice_opt(self.as_vec())
+        str::from_utf8_opt(self.as_vec())
     }
 
     /// Returns the path as a byte vector
@@ -207,7 +207,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `dirname` for details.
     #[inline]
     fn dirname_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8_slice_opt(self.dirname())
+        str::from_utf8_opt(self.dirname())
     }
     /// Returns the file component of `self`, as a byte vector.
     /// If `self` represents the root of the file hierarchy, returns None.
@@ -217,7 +217,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `filename` for details.
     #[inline]
     fn filename_str<'a>(&'a self) -> Option<&'a str> {
-        self.filename().and_then(str::from_utf8_slice_opt)
+        self.filename().and_then(str::from_utf8_opt)
     }
     /// Returns the stem of the filename of `self`, as a byte vector.
     /// The stem is the portion of the filename just before the last '.'.
@@ -239,7 +239,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `filestem` for details.
     #[inline]
     fn filestem_str<'a>(&'a self) -> Option<&'a str> {
-        self.filestem().and_then(str::from_utf8_slice_opt)
+        self.filestem().and_then(str::from_utf8_opt)
     }
     /// Returns the extension of the filename of `self`, as an optional byte vector.
     /// The extension is the portion of the filename just after the last '.'.
@@ -262,7 +262,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `extension` for details.
     #[inline]
     fn extension_str<'a>(&'a self) -> Option<&'a str> {
-        self.extension().and_then(str::from_utf8_slice_opt)
+        self.extension().and_then(str::from_utf8_opt)
     }
 
     /// Replaces the filename portion of the path with the given byte vector or string.
@@ -493,12 +493,12 @@ pub trait BytesContainer {
     /// Raises `str::null_byte` if not utf-8
     #[inline]
     fn container_as_str<'a>(&'a self) -> &'a str {
-        str::from_utf8_slice(self.container_as_bytes())
+        str::from_utf8(self.container_as_bytes())
     }
     /// Returns the receiver interpreted as a utf-8 string, if possible
     #[inline]
     fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8_slice_opt(self.container_as_bytes())
+        str::from_utf8_opt(self.container_as_bytes())
     }
     /// Returns whether .container_as_str() is guaranteed to not fail
     // FIXME (#8888): Remove unused arg once ::<for T> works

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -396,13 +396,13 @@ impl Path {
     /// Returns an iterator that yields each component of the path as Option<&str>.
     /// See components() for details.
     pub fn str_components<'a>(&'a self) -> StrComponentIter<'a> {
-        self.components().map(str::from_utf8_slice_opt)
+        self.components().map(str::from_utf8_opt)
     }
 
     /// Returns an iterator that yields each component of the path in reverse as Option<&str>.
     /// See components() for details.
     pub fn rev_str_components<'a>(&'a self) -> RevStrComponentIter<'a> {
-        self.rev_components().map(str::from_utf8_slice_opt)
+        self.rev_components().map(str::from_utf8_opt)
     }
 }
 
@@ -684,7 +684,7 @@ mod tests {
             (s: $path:expr, $op:ident, $exp:expr, opt) => (
                 {
                     let path = Path::init($path);
-                    let left = path.$op().map(|x| str::from_utf8_slice(x));
+                    let left = path.$op().map(|x| str::from_utf8(x));
                     assert_eq!(left, $exp);
                 }
             );

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -347,7 +347,7 @@ mod tests {
 
         let run::ProcessOutput {status, output, error}
              = run::process_output("echo", [~"hello"]);
-        let output_str = str::from_utf8(output);
+        let output_str = str::from_utf8_owned(output);
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_owned(), ~"hello");
@@ -439,7 +439,7 @@ mod tests {
         let mut prog = run::Process::new("echo", [~"hello"], run::ProcessOptions::new());
         let run::ProcessOutput {status, output, error}
             = prog.finish_with_output();
-        let output_str = str::from_utf8(output);
+        let output_str = str::from_utf8_owned(output);
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_owned(), ~"hello");
@@ -457,7 +457,7 @@ mod tests {
         let run::ProcessOutput {status, output, error}
             = prog.finish_with_output();
 
-        let output_str = str::from_utf8(output);
+        let output_str = str::from_utf8_owned(output);
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_owned(), ~"hello");
@@ -504,7 +504,7 @@ mod tests {
     fn test_keep_current_working_dir() {
         let mut prog = run_pwd(None);
 
-        let output = str::from_utf8(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output);
         let parent_dir = os::getcwd();
         let child_dir = Path::init(output.trim());
 
@@ -522,7 +522,7 @@ mod tests {
         let parent_dir = os::getcwd().dir_path();
         let mut prog = run_pwd(Some(&parent_dir));
 
-        let output = str::from_utf8(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output);
         let child_dir = Path::init(output.trim());
 
         let parent_stat = parent_dir.stat();
@@ -561,7 +561,7 @@ mod tests {
         if running_on_valgrind() { return; }
 
         let mut prog = run_env(None);
-        let output = str::from_utf8(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output);
 
         let r = os::env();
         for &(ref k, ref v) in r.iter() {
@@ -575,7 +575,7 @@ mod tests {
         if running_on_valgrind() { return; }
 
         let mut prog = run_env(None);
-        let output = str::from_utf8(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output);
 
         let r = os::env();
         for &(ref k, ref v) in r.iter() {
@@ -594,7 +594,7 @@ mod tests {
         new_env.push((~"RUN_TEST_NEW_ENV", ~"123"));
 
         let mut prog = run_env(Some(new_env));
-        let output = str::from_utf8(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output);
 
         assert!(output.contains("RUN_TEST_NEW_ENV=123"));
     }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -159,16 +159,16 @@ pub fn from_utf8_owned_opt(vv: ~[u8]) -> Option<~str> {
 /// # Failure
 ///
 /// Fails if invalid UTF-8
-pub fn from_utf8_slice<'a>(v: &'a [u8]) -> &'a str {
-    from_utf8_slice_opt(v).expect("from_utf8_slice: not utf-8")
+pub fn from_utf8<'a>(v: &'a [u8]) -> &'a str {
+    from_utf8_opt(v).expect("from_utf8: not utf-8")
 }
 
 /// Converts a vector to a string slice without performing any allocations.
 ///
 /// Returns None if the slice is not utf-8.
-pub fn from_utf8_slice_opt<'a>(v: &'a [u8]) -> Option<&'a str> {
+pub fn from_utf8_opt<'a>(v: &'a [u8]) -> Option<&'a str> {
     if is_utf8(v) {
-        Some(unsafe { raw::from_utf8_slice(v) })
+        Some(unsafe { raw::from_utf8(v) })
     } else { None }
 }
 
@@ -1029,7 +1029,7 @@ pub mod raw {
 
     /// Converts a slice of bytes to a string slice without checking
     /// that the string contains valid UTF-8.
-    pub unsafe fn from_utf8_slice<'a>(v: &'a [u8]) -> &'a str {
+    pub unsafe fn from_utf8<'a>(v: &'a [u8]) -> &'a str {
         cast::transmute(v)
     }
 
@@ -3153,7 +3153,7 @@ mod tests {
         let s1: ~str = ~"All mimsy were the borogoves";
 
         let v: ~[u8] = s1.as_bytes().to_owned();
-        let s2: ~str = from_utf8_slice(v).to_owned();
+        let s2: ~str = from_utf8(v).to_owned();
         let mut i: uint = 0u;
         let n1: uint = s1.len();
         let n2: uint = v.len();
@@ -3676,31 +3676,31 @@ mod tests {
     }
 
     #[test]
-    fn test_str_from_utf8_slice() {
+    fn test_str_from_utf8() {
         let xs = bytes!("hello");
-        assert_eq!(from_utf8_slice(xs), "hello");
+        assert_eq!(from_utf8(xs), "hello");
 
         let xs = bytes!("ศไทย中华Việt Nam");
-        assert_eq!(from_utf8_slice(xs), "ศไทย中华Việt Nam");
+        assert_eq!(from_utf8(xs), "ศไทย中华Việt Nam");
     }
 
     #[test]
     #[should_fail]
-    fn test_str_from_utf8_slice_invalid() {
+    fn test_str_from_utf8_invalid() {
         let xs = bytes!("hello", 0xff);
-        let _ = from_utf8_slice(xs);
+        let _ = from_utf8(xs);
     }
 
     #[test]
-    fn test_str_from_utf8_slice_opt() {
+    fn test_str_from_utf8_opt() {
         let xs = bytes!("hello");
-        assert_eq!(from_utf8_slice_opt(xs), Some("hello"));
+        assert_eq!(from_utf8_opt(xs), Some("hello"));
 
         let xs = bytes!("ศไทย中华Việt Nam");
-        assert_eq!(from_utf8_slice_opt(xs), Some("ศไทย中华Việt Nam"));
+        assert_eq!(from_utf8_opt(xs), Some("ศไทย中华Việt Nam"));
 
         let xs = bytes!("hello", 0xff);
-        assert_eq!(from_utf8_slice_opt(xs), None);
+        assert_eq!(from_utf8_opt(xs), None);
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -124,34 +124,6 @@ condition! {
 Section: Creating a string
 */
 
-/// Convert a vector of bytes to a new UTF-8 string
-///
-/// # Failure
-///
-/// Raises the `not_utf8` condition if invalid UTF-8
-pub fn from_utf8(vv: &[u8]) -> ~str {
-    use str::not_utf8::cond;
-
-    match from_utf8_opt(vv) {
-        None => {
-            let first_bad_byte = *vv.iter().find(|&b| !is_utf8([*b])).unwrap();
-            cond.raise(format!("from_utf8: input is not UTF-8; first bad \
-                                byte is {}", first_bad_byte))
-        }
-        Some(s) => s
-    }
-}
-
-/// Convert a vector of bytes to a new UTF-8 string, if possible.
-/// Returns None if the vector contains invalid UTF-8.
-pub fn from_utf8_opt(vv: &[u8]) -> Option<~str> {
-    if is_utf8(vv) {
-        Some(unsafe { raw::from_utf8(vv) })
-    } else {
-        None
-    }
-}
-
 /// Consumes a vector of bytes to create a new utf-8 string
 ///
 /// # Failure
@@ -196,7 +168,7 @@ pub fn from_utf8_slice<'a>(v: &'a [u8]) -> &'a str {
 /// Returns None if the slice is not utf-8.
 pub fn from_utf8_slice_opt<'a>(v: &'a [u8]) -> Option<&'a str> {
     if is_utf8(v) {
-        Some(unsafe { cast::transmute(v) })
+        Some(unsafe { raw::from_utf8_slice(v) })
     } else { None }
 }
 
@@ -1055,9 +1027,10 @@ pub mod raw {
         from_buf_len(buf as *u8, i as uint)
     }
 
-    /// Converts a vector of bytes to a new owned string.
-    pub unsafe fn from_utf8(v: &[u8]) -> ~str {
-        v.as_imm_buf(|buf, len| from_buf_len(buf, len))
+    /// Converts a slice of bytes to a string slice without checking
+    /// that the string contains valid UTF-8.
+    pub unsafe fn from_utf8_slice<'a>(v: &'a [u8]) -> &'a str {
+        cast::transmute(v)
     }
 
     /// Converts an owned vector of bytes to a new owned string. This assumes
@@ -1068,7 +1041,7 @@ pub mod raw {
     }
 
     /// Converts a byte to a string.
-    pub unsafe fn from_byte(u: u8) -> ~str { from_utf8([u]) }
+    pub unsafe fn from_byte(u: u8) -> ~str { from_utf8_owned(~[u]) }
 
     /// Form a slice from a C string. Unsafe because the caller must ensure the
     /// C string has the static lifetime, or else the return value may be
@@ -3078,33 +3051,6 @@ mod tests {
     }
 
     #[test]
-    fn test_unsafe_from_utf8() {
-        let a = ~[65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8];
-        let b = unsafe { raw::from_utf8(a) };
-        assert_eq!(b, ~"AAAAAAA");
-    }
-
-    #[test]
-    fn test_from_utf8() {
-        let ss = ~"ศไทย中华Việt Nam";
-        let bb = ~[0xe0_u8, 0xb8_u8, 0xa8_u8,
-                  0xe0_u8, 0xb9_u8, 0x84_u8,
-                  0xe0_u8, 0xb8_u8, 0x97_u8,
-                  0xe0_u8, 0xb8_u8, 0xa2_u8,
-                  0xe4_u8, 0xb8_u8, 0xad_u8,
-                  0xe5_u8, 0x8d_u8, 0x8e_u8,
-                  0x56_u8, 0x69_u8, 0xe1_u8,
-                  0xbb_u8, 0x87_u8, 0x74_u8,
-                  0x20_u8, 0x4e_u8, 0x61_u8,
-                  0x6d_u8];
-
-
-        assert_eq!(ss, from_utf8(bb));
-        assert_eq!(~"𐌀𐌖𐌋𐌄𐌑𐌉ปรدولة الكويتทศไทย中华𐍅𐌿𐌻𐍆𐌹𐌻𐌰",
-                   from_utf8(bytes!("𐌀𐌖𐌋𐌄𐌑𐌉ปรدولة الكويتทศไทย中华𐍅𐌿𐌻𐍆𐌹𐌻𐌰")));
-    }
-
-    #[test]
     fn test_is_utf8() {
         // deny overlong encodings
         assert!(!is_utf8([0xc0, 0x80]));
@@ -3127,31 +3073,6 @@ mod tests {
         assert!(is_utf8([0xEF, 0xBF, 0xBF]));
         assert!(is_utf8([0xF0, 0x90, 0x80, 0x80]));
         assert!(is_utf8([0xF4, 0x8F, 0xBF, 0xBF]));
-    }
-
-
-    #[test]
-    fn test_from_utf8_fail() {
-        use str::not_utf8::cond;
-
-        let bb = ~[0xff_u8, 0xb8_u8, 0xa8_u8,
-                  0xe0_u8, 0xb9_u8, 0x84_u8,
-                  0xe0_u8, 0xb8_u8, 0x97_u8,
-                  0xe0_u8, 0xb8_u8, 0xa2_u8,
-                  0xe4_u8, 0xb8_u8, 0xad_u8,
-                  0xe5_u8, 0x8d_u8, 0x8e_u8,
-                  0x56_u8, 0x69_u8, 0xe1_u8,
-                  0xbb_u8, 0x87_u8, 0x74_u8,
-                  0x20_u8, 0x4e_u8, 0x61_u8,
-                  0x6d_u8];
-
-        let mut error_happened = false;
-        let _x = cond.trap(|err| {
-            assert_eq!(err, ~"from_utf8: input is not UTF-8; first bad byte is 255");
-            error_happened = true;
-            ~""
-        }).inside(|| from_utf8(bb));
-        assert!(error_happened);
     }
 
     #[test]
@@ -3232,7 +3153,7 @@ mod tests {
         let s1: ~str = ~"All mimsy were the borogoves";
 
         let v: ~[u8] = s1.as_bytes().to_owned();
-        let s2: ~str = from_utf8(v);
+        let s2: ~str = from_utf8_slice(v).to_owned();
         let mut i: uint = 0u;
         let n1: uint = s1.len();
         let n2: uint = v.len();
@@ -3780,27 +3701,6 @@ mod tests {
 
         let xs = bytes!("hello", 0xff);
         assert_eq!(from_utf8_slice_opt(xs), None);
-    }
-
-    #[test]
-    fn test_str_from_utf8() {
-        let xs = bytes!("hello");
-        assert_eq!(from_utf8(xs), ~"hello");
-
-        let xs = bytes!("ศไทย中华Việt Nam");
-        assert_eq!(from_utf8(xs), ~"ศไทย中华Việt Nam");
-    }
-
-    #[test]
-    fn test_str_from_utf8_opt() {
-        let xs = bytes!("hello").to_owned();
-        assert_eq!(from_utf8_opt(xs), Some(~"hello"));
-
-        let xs = bytes!("ศไทย中华Việt Nam");
-        assert_eq!(from_utf8_opt(xs), Some(~"ศไทย中华Việt Nam"));
-
-        let xs = bytes!("hello", 0xff);
-        assert_eq!(from_utf8_opt(xs), None);
     }
 
     #[test]

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -346,7 +346,7 @@ pub fn gather_comments_and_literals(span_diagnostic:
                                     path: @str,
                                     srdr: &mut io::Reader)
                                  -> (~[cmnt], ~[lit]) {
-    let src = str::from_utf8(srdr.read_to_end()).to_managed();
+    let src = str::from_utf8_owned(srdr.read_to_end()).to_managed();
     let cm = CodeMap::new();
     let filemap = cm.new_filemap(path, src);
     let rdr = lexer::new_low_level_string_reader(span_diagnostic, filemap);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -210,7 +210,7 @@ pub fn fun_to_str(decl: &ast::fn_decl, purity: ast::purity, name: ast::Ident,
     end(s); // Close the head box
     end(s); // Close the outer box
     eof(s.s);
-    str::from_utf8(*wr.inner_ref())
+    str::from_utf8_owned(wr.inner_ref().to_owned())
 }
 
 pub fn block_to_str(blk: &ast::Block, intr: @ident_interner) -> ~str {
@@ -222,7 +222,7 @@ pub fn block_to_str(blk: &ast::Block, intr: @ident_interner) -> ~str {
     ibox(s, 0u);
     print_block(s, blk);
     eof(s.s);
-    str::from_utf8(*wr.inner_ref())
+    str::from_utf8_owned(wr.inner_ref().to_owned())
 }
 
 pub fn meta_item_to_str(mi: &ast::MetaItem, intr: @ident_interner) -> ~str {
@@ -2292,7 +2292,7 @@ pub fn to_str<T>(t: &T, f: |@ps, &T|, intr: @ident_interner) -> ~str {
     let s = rust_printer(wr as @mut io::Writer, intr);
     f(s, t);
     eof(s.s);
-    str::from_utf8(*wr.inner_ref())
+    str::from_utf8_owned(wr.inner_ref().to_owned())
 }
 
 pub fn next_comment(s: @ps) -> Option<comments::cmnt> {

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -70,12 +70,10 @@ fn sort_and_fmt(mm: &HashMap<~[u8], uint>, total: uint) -> ~str {
 
    let mut buffer = ~"";
 
-   for kv in pairs_sorted.iter() {
-       let (k,v) = (*kv).clone();
+   for &(ref k, v) in pairs_sorted.iter() {
        unsafe {
-           let b = str::raw::from_utf8(k);
            buffer.push_str(format!("{} {:0.3f}\n",
-                                   b.into_ascii().to_upper().into_str(), v));
+                                   k.to_ascii().to_upper().into_str(), v));
        }
    }
 

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -60,7 +60,7 @@ impl Code {
         }
 
         reverse(result);
-        str::from_utf8(result)
+        str::from_utf8_owned(result)
     }
 }
 

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -17,13 +17,13 @@ static C: *u8 = B as *u8;
 pub fn main() {
     unsafe {
         let foo = &A as *u8;
-        assert_eq!(str::raw::from_utf8_slice(A), "hi");
+        assert_eq!(str::raw::from_utf8(A), "hi");
         assert_eq!(str::raw::from_buf_len(foo, A.len()), ~"hi");
         assert_eq!(str::raw::from_buf_len(C, B.len()), ~"hi");
         assert!(*C == A[0]);
         assert!(*(&B[0] as *u8) == A[0]);
 
-        let bar = str::raw::from_utf8_slice(A).to_c_str();
+        let bar = str::raw::from_utf8(A).to_c_str();
         assert_eq!(bar.with_ref(|buf| str::raw::from_c_str(buf)), ~"hi");
     }
 }

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -17,13 +17,13 @@ static C: *u8 = B as *u8;
 pub fn main() {
     unsafe {
         let foo = &A as *u8;
-        assert_eq!(str::raw::from_utf8(A), ~"hi");
+        assert_eq!(str::raw::from_utf8_slice(A), "hi");
         assert_eq!(str::raw::from_buf_len(foo, A.len()), ~"hi");
         assert_eq!(str::raw::from_buf_len(C, B.len()), ~"hi");
         assert!(*C == A[0]);
         assert!(*(&B[0] as *u8) == A[0]);
 
-        let bar = str::raw::from_utf8(A).to_c_str();
+        let bar = str::raw::from_utf8_slice(A).to_c_str();
         assert_eq!(bar.with_ref(|buf| str::raw::from_c_str(buf)), ~"hi");
     }
 }

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -59,13 +59,13 @@ fn test_destroy_actually_kills(force: bool) {
     #[cfg(unix,not(target_os="android"))]
     fn process_exists(pid: libc::pid_t) -> bool {
         let run::ProcessOutput {output, ..} = run::process_output("ps", [~"-p", pid.to_str()]);
-        str::from_utf8(output).contains(pid.to_str())
+        str::from_utf8_owned(output).contains(pid.to_str())
     }
 
     #[cfg(unix,target_os="android")]
     fn process_exists(pid: libc::pid_t) -> bool {
         let run::ProcessOutput {output, ..} = run::process_output("/system/bin/ps", [pid.to_str()]);
-        str::from_utf8(output).contains(~"root")
+        str::from_utf8_owned(output).contains(~"root")
     }
 
     #[cfg(windows)]

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -79,11 +79,10 @@ mod map_reduce {
             match ctrl_port.recv() {
               mapper_done => { num_mappers -= 1; }
               find_reducer(k, cc) => {
-                let mut c;
-                match reducers.find(&str::from_utf8(k)) {
-                  Some(&_c) => { c = _c; }
-                  None => { c = 0; }
-                }
+                let c = match reducers.find(&str::from_utf8_owned(k)) {
+                  Some(&_c) => _c,
+                  None => 0
+                };
                 cc.send(c);
               }
             }

--- a/src/test/run-pass/rtio-processes.rs
+++ b/src/test/run-pass/rtio-processes.rs
@@ -108,7 +108,7 @@ fn read_all(input: &mut Reader) -> ~str {
     loop {
         match input.read(buf) {
             None => { break }
-            Some(n) => { ret.push_str(str::from_utf8_slice(buf.slice_to(n))); }
+            Some(n) => { ret.push_str(str::from_utf8(buf.slice_to(n))); }
         }
     }
     return ret;

--- a/src/test/run-pass/rtio-processes.rs
+++ b/src/test/run-pass/rtio-processes.rs
@@ -108,7 +108,7 @@ fn read_all(input: &mut Reader) -> ~str {
     loop {
         match input.read(buf) {
             None => { break }
-            Some(n) => { ret = ret + str::from_utf8(buf.slice_to(n)); }
+            Some(n) => { ret.push_str(str::from_utf8_slice(buf.slice_to(n))); }
         }
     }
     return ret;


### PR DESCRIPTION
This function had type &[u8] -> ~str, i.e. it allocates a string
internally, even though the non-allocating version that take &[u8] ->
&str and ~[u8] -> ~str are all that is necessary in most circumstances.
