### PR TITLE
Remove unused upcalls

### DIFF
--- a/src/librustc/back/upcall.rs
+++ b/src/librustc/back/upcall.rs
@@ -15,22 +15,10 @@ use middle::trans::type_::Type;
 use lib::llvm::{ModuleRef, ValueRef};
 
 pub struct Upcalls {
-    trace: ValueRef,
     rust_personality: ValueRef,
-    reset_stack_limit: ValueRef
 }
 
 macro_rules! upcall (
-    (fn $name:ident($($arg:expr),+) -> $ret:expr) => ({
-        let fn_ty = Type::func([ $($arg),* ], &$ret);
-        base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty)
-    });
-    (nothrow fn $name:ident($($arg:expr),+) -> $ret:expr) => ({
-        let fn_ty = Type::func([ $($arg),* ], &$ret);
-        let decl = base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty);
-        base::set_no_unwind(decl);
-        decl
-    });
     (nothrow fn $name:ident -> $ret:expr) => ({
         let fn_ty = Type::func([], &$ret);
         let decl = base::decl_cdecl_fn(llmod, ~"upcall_" + stringify!($name), fn_ty);
@@ -39,13 +27,9 @@ macro_rules! upcall (
     })
 )
 
-pub fn declare_upcalls(targ_cfg: @session::config, llmod: ModuleRef) -> @Upcalls {
-    let opaque_ptr = Type::i8().ptr_to();
-    let int_ty = Type::int(targ_cfg.arch);
-
+pub fn declare_upcalls(_targ_cfg: @session::config,
+                       llmod: ModuleRef) -> @Upcalls {
     @Upcalls {
-        trace: upcall!(fn trace(opaque_ptr, opaque_ptr, int_ty) -> Type::void()),
         rust_personality: upcall!(nothrow fn rust_personality -> Type::i32()),
-        reset_stack_limit: upcall!(nothrow fn reset_stack_limit -> Type::void())
     }
 }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -52,30 +52,29 @@ pub static time_llvm_passes:        uint = 1 <<  3;
 pub static trans_stats:             uint = 1 <<  4;
 pub static asm_comments:            uint = 1 <<  5;
 pub static no_verify:               uint = 1 <<  6;
-pub static trace:                   uint = 1 <<  7;
-pub static coherence:               uint = 1 <<  8;
-pub static borrowck_stats:          uint = 1 <<  9;
-pub static borrowck_note_pure:      uint = 1 << 10;
-pub static borrowck_note_loan:      uint = 1 << 11;
-pub static no_landing_pads:         uint = 1 << 12;
-pub static debug_llvm:              uint = 1 << 13;
-pub static count_type_sizes:        uint = 1 << 14;
-pub static meta_stats:              uint = 1 << 15;
-pub static no_opt:                  uint = 1 << 16;
-pub static gc:                      uint = 1 << 17;
-pub static jit:                     uint = 1 << 18;
-pub static debug_info:              uint = 1 << 19;
-pub static extra_debug_info:        uint = 1 << 20;
-pub static statik:                  uint = 1 << 21;
-pub static print_link_args:         uint = 1 << 22;
-pub static no_debug_borrows:        uint = 1 << 23;
-pub static lint_llvm:               uint = 1 << 24;
-pub static print_llvm_passes:       uint = 1 << 25;
-pub static no_vectorize_loops:      uint = 1 << 26;
-pub static no_vectorize_slp:        uint = 1 << 27;
-pub static no_prepopulate_passes:   uint = 1 << 28;
-pub static use_softfp:              uint = 1 << 29;
-pub static gen_crate_map:           uint = 1 << 30;
+pub static coherence:               uint = 1 <<  7;
+pub static borrowck_stats:          uint = 1 <<  8;
+pub static borrowck_note_pure:      uint = 1 <<  9;
+pub static borrowck_note_loan:      uint = 1 << 10;
+pub static no_landing_pads:         uint = 1 << 11;
+pub static debug_llvm:              uint = 1 << 12;
+pub static count_type_sizes:        uint = 1 << 13;
+pub static meta_stats:              uint = 1 << 14;
+pub static no_opt:                  uint = 1 << 15;
+pub static gc:                      uint = 1 << 16;
+pub static jit:                     uint = 1 << 17;
+pub static debug_info:              uint = 1 << 18;
+pub static extra_debug_info:        uint = 1 << 19;
+pub static statik:                  uint = 1 << 20;
+pub static print_link_args:         uint = 1 << 21;
+pub static no_debug_borrows:        uint = 1 << 22;
+pub static lint_llvm:               uint = 1 << 23;
+pub static print_llvm_passes:       uint = 1 << 24;
+pub static no_vectorize_loops:      uint = 1 << 25;
+pub static no_vectorize_slp:        uint = 1 << 26;
+pub static no_prepopulate_passes:   uint = 1 << 27;
+pub static use_softfp:              uint = 1 << 28;
+pub static gen_crate_map:           uint = 1 << 29;
 
 pub fn debugging_opts_map() -> ~[(&'static str, &'static str, uint)] {
     ~[("verbose", "in general, enable more debug printouts", verbose),
@@ -87,7 +86,6 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, uint)] {
      ("trans-stats", "gather trans statistics", trans_stats),
      ("asm-comments", "generate comments into the assembly (may change behavior)", asm_comments),
      ("no-verify", "skip LLVM verification", no_verify),
-     ("trace", "emit trace logs", trace),
      ("coherence", "perform coherence checking", coherence),
      ("borrowck-stats", "gather borrowck statistics",  borrowck_stats),
      ("borrowck-note-pure", "note where purity is req'd",
@@ -310,7 +308,6 @@ impl Session_ {
     pub fn asm_comments(&self) -> bool { self.debugging_opt(asm_comments) }
     pub fn no_verify(&self) -> bool { self.debugging_opt(no_verify) }
     pub fn lint_llvm(&self) -> bool { self.debugging_opt(lint_llvm) }
-    pub fn trace(&self) -> bool { self.debugging_opt(trace) }
     pub fn coherence(&self) -> bool { self.debugging_opt(coherence) }
     pub fn borrowck_stats(&self) -> bool { self.debugging_opt(borrowck_stats) }
     pub fn borrowck_note_pure(&self) -> bool {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -567,8 +567,6 @@ fn trans_to_datum_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
 fn trans_rvalue_datum_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
     let _icx = push_ctxt("trans_rvalue_datum_unadjusted");
 
-    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
-
     match expr.node {
         ast::ExprPath(_) | ast::ExprSelf => {
             return trans_def_datum_unadjusted(bcx, expr, bcx.def(expr.id));
@@ -625,8 +623,6 @@ fn trans_rvalue_stmt_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> @mut Block
         return bcx;
     }
 
-    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
-
     match expr.node {
         ast::ExprBreak(label_opt) => {
             return controlflow::trans_break(bcx, label_opt);
@@ -675,8 +671,6 @@ fn trans_rvalue_dps_unadjusted(bcx: @mut Block, expr: &ast::Expr,
                                dest: Dest) -> @mut Block {
     let _icx = push_ctxt("trans_rvalue_dps_unadjusted");
     let tcx = bcx.tcx();
-
-    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
 
     match expr.node {
         ast::ExprParen(e) => {
@@ -894,8 +888,6 @@ fn trans_lvalue_unadjusted(bcx: @mut Block, expr: &ast::Expr) -> DatumBlock {
 
     debug!("trans_lvalue(expr={})", bcx.expr_to_str(expr));
     let _indenter = indenter();
-
-    trace_span!(bcx, expr.span, shorten(bcx.expr_to_str(expr)));
 
     return match expr.node {
         ast::ExprParen(e) => {

--- a/src/librustc/middle/trans/macros.rs
+++ b/src/librustc/middle/trans/macros.rs
@@ -29,25 +29,3 @@ macro_rules! unpack_result(
         }
     )
 )
-
-macro_rules! trace_span(
-    ($bcx: ident, $sp: expr, $str: expr) => (
-        {
-            let bcx = $bcx;
-            if bcx.sess().trace() {
-                trans_trace(bcx, Some($sp), $str);
-            }
-        }
-    )
-)
-
-macro_rules! trace(
-    ($bcx: ident, $str: expr) => (
-        {
-            let bcx = $bcx;
-            if bcx.sess().trace() {
-                trans_trace(bcx, None, $str);
-            }
-        }
-    )
-)

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -114,13 +114,6 @@ fn root(datum: &Datum,
     debug!("write_guard::root(root_key={:?}, root_info={:?}, datum={:?})",
            root_key, root_info, datum.to_str(bcx.ccx()));
 
-    if bcx.sess().trace() {
-        trans_trace(
-            bcx, None,
-            (format!("preserving until end of scope {}",
-                  root_info.scope)).to_managed());
-    }
-
     // First, root the datum. Note that we must zero this value,
     // because sometimes we root on one path but not another.
     // See e.g. #4904.

--- a/src/rt/rust_upcall.c
+++ b/src/rt/rust_upcall.c
@@ -51,7 +51,7 @@ struct s_rust_personality_args {
     struct _Unwind_Context *context;
 };
 
-void
+static void
 upcall_s_rust_personality(struct s_rust_personality_args *args) {
     args->retval = PERSONALITY_FUNC(args->version,
                                     args->actions,
@@ -78,6 +78,7 @@ upcall_rust_personality(int version,
     return args.retval;
 }
 
+// NOTE: remove after stage0
 // Landing pads need to call this to insert the
 // correct limit into TLS.
 // NB: This must run on the Rust stack because it


### PR DESCRIPTION
The main one removed is rust_upcall_reset_stack_limit (continuation of #10156),
and this also removes the upcall_trace function. The was hidden behind a
`-Z trace` flag, but if you attempt to use this now you'll get a linker error
because there is no implementation of the 'upcall_trace' function. Due to this
no longer working, I decided to remove it entirely from the compiler (I'm also a
little unsure on what it did in the first place).

Closes #10156
