### PR TITLE
implement emit-ast option ( see issue #10485 )

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -26,7 +26,7 @@ extern mod syntax;
 use driver::driver::{host_triple, optgroups, early_error};
 use driver::driver::{str_input, file_input, build_session_options};
 use driver::driver::{build_session, build_configuration, parse_pretty};
-use driver::driver::{PpMode, pretty_print_input, list_metadata};
+use driver::driver::{PpMode, pretty_print_input, emit_ast, list_metadata};
 use driver::driver::{compile_input};
 use driver::session;
 use middle::lint;
@@ -268,6 +268,10 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
         return;
       }
       None::<PpMode> => {/* continue */ }
+    }
+    if matches.opt_present("emit-ast") {
+        emit_ast(sess, cfg, &input, &ofile);
+        return;
     }
     let ls = matches.opt_present("ls");
     if ls {


### PR DESCRIPTION
First try for #10485. Unit/regression tests are missing for now.

Any comments would be appreciated.

JSON generation part is mostly copied from `librustdoc::lib::json_output`.
