### PR TITLE
Fix initial debug statements printing twice

### DIFF
--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -107,9 +107,10 @@ pub fn log(_level: u32, args: &fmt::Arguments) {
         let optional_task: Option<*mut Task> = Local::try_unsafe_borrow();
         match optional_task {
             Some(local) => {
+                // Lazily initialize the local task's logger
                 match (*local).logger {
                     // Use the available logger if we have one
-                    Some(ref mut logger) => return logger.log(args),
+                    Some(ref mut logger) => { logger.log(args); }
                     None => {
                         let mut logger = StdErrLogger::new();
                         logger.log(args);
@@ -117,10 +118,11 @@ pub fn log(_level: u32, args: &fmt::Arguments) {
                     }
                 }
             }
-            None => {}
+            // If there's no local task, then always log to stderr
+            None => {
+                let mut logger = StdErrLogger::new();
+                logger.log(args);
+            }
         }
-        // There is no logger anywhere, just write to stderr
-        let mut logger = StdErrLogger::new();
-        logger.log(args);
     }
 }

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -1,0 +1,36 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// exec-env:RUST_LOG=debug
+
+#[feature(managed_boxes)];
+
+use std::fmt;
+
+struct Foo(@mut int);
+
+impl fmt::Default for Foo {
+    fn fmt(f: &Foo, _fmt: &mut fmt::Formatter) {
+        assert!(***f == 0);
+        ***f = 1;
+    }
+}
+
+pub fn main() {
+    let (p,c) = stream();
+    do spawn {
+        let f = Foo(@mut 0);
+        debug!("{}", f);
+        assert!(**f == 1);
+        c.send(());
+    }
+    p.recv();
+}


### PR DESCRIPTION
It may mislead you into thinking tasks are spawning twice, when in fact they are
not.
