### PR TITLE
Various cleanups of macro-expanding-to-module workarounds

### DIFF
--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -10,32 +10,31 @@
 
 
 use back::{link};
-use std::libc::c_uint;
-use lib::llvm::{ValueRef, CallConv, StructRetAttribute};
 use lib::llvm::llvm;
+use lib::llvm::{ValueRef, CallConv, StructRetAttribute};
 use lib;
-use middle::trans::machine;
-use middle::trans::base;
 use middle::trans::base::push_ctxt;
-use middle::trans::cabi;
+use middle::trans::base;
 use middle::trans::build::*;
 use middle::trans::builder::noname;
+use middle::trans::cabi;
 use middle::trans::common::*;
+use middle::trans::machine;
+use middle::trans::type_::Type;
 use middle::trans::type_of::*;
 use middle::trans::type_of;
-use middle::ty;
 use middle::ty::FnSig;
-
-use std::uint;
+use middle::ty;
+use std::cmp;
+use std::libc::c_uint;
 use std::vec;
+use syntax::abi::{Cdecl, Aapcs, C, AbiSet, Win64};
+use syntax::abi::{RustIntrinsic, Rust, Stdcall, Fastcall, System};
 use syntax::codemap::Span;
+use syntax::parse::token::special_idents;
 use syntax::{ast};
 use syntax::{attr, ast_map};
-use syntax::parse::token::special_idents;
-use syntax::abi::{RustIntrinsic, Rust, Stdcall, Fastcall, System,
-                  Cdecl, Aapcs, C, AbiSet, Win64};
 use util::ppaux::{Repr, UserString};
-use middle::trans::type_::Type;
 
 ///////////////////////////////////////////////////////////////////////////
 // Type definitions
@@ -332,7 +331,7 @@ pub fn trans_native_call(bcx: @mut Block,
             let llrust_size = machine::llsize_of_store(ccx, llrust_ret_ty);
             let llforeign_align = machine::llalign_of_min(ccx, llforeign_ret_ty);
             let llrust_align = machine::llalign_of_min(ccx, llrust_ret_ty);
-            let llalign = uint::min(llforeign_align, llrust_align);
+            let llalign = cmp::min(llforeign_align, llrust_align);
             debug!("llrust_size={:?}", llrust_size);
             base::call_memcpy(bcx, llretptr_i8, llscratch_i8,
                               C_uint(ccx, llrust_size), llalign as u32);

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -1036,31 +1036,26 @@ pub fn upperhex(buf: &[u8], f: &mut Formatter) {
     f.pad_integral(local.slice_to(buf.len()), "0x", true);
 }
 
-// FIXME(#4375) shouldn't need an inner module
 macro_rules! integer(($signed:ident, $unsigned:ident) => {
-    mod $signed {
-        use super::*;
-
-        // Signed is special because it actuall emits the negative sign,
-        // nothing else should do that, however.
-        impl Signed for $signed {
-            fn fmt(c: &$signed, f: &mut Formatter) {
-                ::$unsigned::to_str_bytes(c.abs() as $unsigned, 10, |buf| {
-                    f.pad_integral(buf, "", *c >= 0);
-                })
-            }
+    // Signed is special because it actuall emits the negative sign,
+    // nothing else should do that, however.
+    impl Signed for $signed {
+        fn fmt(c: &$signed, f: &mut Formatter) {
+            ::$unsigned::to_str_bytes(c.abs() as $unsigned, 10, |buf| {
+                f.pad_integral(buf, "", *c >= 0);
+            })
         }
-        int_base!($signed, $unsigned, 2, Binary, "0b")
-        int_base!($signed, $unsigned, 8, Octal, "0o")
-        int_base!($signed, $unsigned, 16, LowerHex, "0x")
-        upper_hex!($signed, $unsigned)
-
-        int_base!($unsigned, $unsigned, 2, Binary, "0b")
-        int_base!($unsigned, $unsigned, 8, Octal, "0o")
-        int_base!($unsigned, $unsigned, 10, Unsigned, "")
-        int_base!($unsigned, $unsigned, 16, LowerHex, "0x")
-        upper_hex!($unsigned, $unsigned)
     }
+    int_base!($signed, $unsigned, 2, Binary, "0b")
+    int_base!($signed, $unsigned, 8, Octal, "0o")
+    int_base!($signed, $unsigned, 16, LowerHex, "0x")
+    upper_hex!($signed, $unsigned)
+
+    int_base!($unsigned, $unsigned, 2, Binary, "0b")
+    int_base!($unsigned, $unsigned, 8, Octal, "0o")
+    int_base!($unsigned, $unsigned, 10, Unsigned, "")
+    int_base!($unsigned, $unsigned, 16, LowerHex, "0x")
+    upper_hex!($unsigned, $unsigned)
 })
 
 integer!(int, uint)

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -901,7 +901,7 @@ impl<'self> Formatter<'self> {
                 // case where the maximum length will matter.
                 let char_len = s.char_len();
                 if char_len >= max {
-                    let nchars = ::uint::min(max, char_len);
+                    let nchars = ::cmp::min(max, char_len);
                     self.buf.write(s.slice_chars(0, nchars).as_bytes());
                     return
                 }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -11,17 +11,18 @@
 //! Operations and constants for `f32`
 #[allow(missing_doc)];
 
-use default::Default;
-use libc::c_int;
-use num::{Zero, One, strconv};
-use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
-use num;
 use prelude::*;
+
+use cmath::c_float_utils;
+use default::Default;
+use libc::{c_float, c_int};
+use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
+use num::{Zero, One, strconv};
+use num;
 use to_str;
+use unstable::intrinsics;
 
 pub use cmath::c_float_targ_consts::*;
-
-use self::delegated::*;
 
 macro_rules! delegate(
     (
@@ -33,22 +34,14 @@ macro_rules! delegate(
             ) -> $rv:ty = $bound_name:path
         ),*
     ) => (
-        // An inner module is required to get the #[inline] attribute on the
-        // functions.
-        mod delegated {
-            use cmath::c_float_utils;
-            use libc::{c_float, c_int};
-            use unstable::intrinsics;
-
-            $(
-                #[inline]
-                pub fn $name($( $arg : $arg_ty ),*) -> $rv {
-                    unsafe {
-                        $bound_name($( $arg ),*)
-                    }
+        $(
+            #[inline]
+            pub fn $name($( $arg : $arg_ty ),*) -> $rv {
+                unsafe {
+                    $bound_name($( $arg ),*)
                 }
-            )*
-        }
+            }
+        )*
     )
 )
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -12,18 +12,19 @@
 
 #[allow(missing_doc)];
 
-use default::Default;
-use libc::c_int;
-use num::{Zero, One, strconv};
-use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
-use num;
 use prelude::*;
+
+use cmath::c_double_utils;
+use default::Default;
+use libc::{c_double, c_int};
+use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
+use num::{Zero, One, strconv};
+use num;
 use to_str;
+use unstable::intrinsics;
 
 pub use cmath::c_double_targ_consts::*;
 pub use cmp::{min, max};
-
-use self::delegated::*;
 
 macro_rules! delegate(
     (
@@ -35,22 +36,14 @@ macro_rules! delegate(
             ) -> $rv:ty = $bound_name:path
         ),*
     ) => (
-        // An inner module is required to get the #[inline] attribute on the
-        // functions.
-        mod delegated {
-            use cmath::c_double_utils;
-            use libc::{c_double, c_int};
-            use unstable::intrinsics;
-
-            $(
-                #[inline]
-                pub fn $name($( $arg : $arg_ty ),*) -> $rv {
-                    unsafe {
-                        $bound_name($( $arg ),*)
-                    }
+        $(
+            #[inline]
+            pub fn $name($( $arg : $arg_ty ),*) -> $rv {
+                unsafe {
+                    $bound_name($( $arg ),*)
                 }
-            )*
-        }
+            }
+        )*
     )
 )
 

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -10,11 +10,17 @@
 
 //! Operations and constants for `i16`
 
-use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 int_module!(i16, 16)
 

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -10,11 +10,17 @@
 
 //! Operations and constants for `i32`
 
-use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 int_module!(i32, 32)
 

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -10,13 +10,19 @@
 
 //! Operations and constants for `i64`
 
-use num::{BitCount, CheckedAdd, CheckedSub};
+#[allow(non_uppercase_statics)];
+
+use prelude::*;
+
+use default::Default;
 #[cfg(target_word_size = "64")]
 use num::CheckedMul;
+use num::{BitCount, CheckedAdd, CheckedSub};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
 use option::{Option, Some, None};
+use str;
 use unstable::intrinsics;
-
-pub use self::generated::*;
 
 int_module!(i64, 64)
 

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -10,11 +10,17 @@
 
 //! Operations and constants for `i8`
 
-use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 int_module!(i8, 8)
 

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -12,16 +12,18 @@
 
 #[allow(non_uppercase_statics)];
 
+use prelude::*;
+
+use default::Default;
 use num::{BitCount, CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
 use option::{Option, Some, None};
+use str;
 use unstable::intrinsics;
 
-pub use self::generated::*;
-
-#[cfg(target_word_size = "32")] pub static bits: uint = 32;
-#[cfg(target_word_size = "64")] pub static bits: uint = 64;
-
-int_module!(int, super::bits)
+#[cfg(target_word_size = "32")] int_module!(int, 32)
+#[cfg(target_word_size = "64")] int_module!(int, 64)
 
 #[cfg(target_word_size = "32")]
 impl BitCount for int {

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#4375): this shouldn't have to be a nested module named 'generated'
+// FIXME(#4375):  This shouldn't have to be a nested module named 'generated'...
+// FIXME(#10716): ... but now that we could solve that, the import lines and
+//                attributes still prevent a removal of that module.
 
 #[macro_escape];
 #[doc(hidden)];

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#4375):  This shouldn't have to be a nested module named 'generated'...
-// FIXME(#10716): ... but now that we could solve that, the import lines and
-//                attributes still prevent a removal of that module.
-
 #[macro_escape];
 #[doc(hidden)];
 
-macro_rules! int_module (($T:ty, $bits:expr) => (mod generated {
-
-#[allow(non_uppercase_statics)];
-
-use default::Default;
-use num::{ToStrRadix, FromStrRadix};
-use num::{CheckedDiv, Zero, One, strconv};
-use prelude::*;
-use str;
+macro_rules! int_module (($T:ty, $bits:expr) => (
 
 pub static bits : uint = $bits;
 pub static bytes : uint = ($bits / 8);
@@ -781,4 +769,4 @@ mod tests {
     }
 }
 
-}))
+))

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -25,8 +25,6 @@ use num::{CheckedDiv, Zero, One, strconv};
 use prelude::*;
 use str;
 
-pub use cmp::{min, max};
-
 pub static bits : uint = $bits;
 pub static bytes : uint = ($bits / 8);
 

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -10,11 +10,18 @@
 
 //! Operations and constants for `u16`
 
-use num::{CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use num::BitCount;
+use num::{CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 uint_module!(u16, i16, 16)
 

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -10,11 +10,18 @@
 
 //! Operations and constants for `u32`
 
-use num::{CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use num::BitCount;
+use num::{CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 uint_module!(u32, i32, 32)
 

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -10,13 +10,20 @@
 
 //! Operations and constants for `u64`
 
-use num::{CheckedAdd, CheckedSub};
+#[allow(non_uppercase_statics)];
+
+use prelude::*;
+
+use default::Default;
+use num::BitCount;
 #[cfg(target_word_size = "64")]
 use num::CheckedMul;
+use num::{CheckedAdd, CheckedSub};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
 use option::{Option, Some, None};
+use str;
 use unstable::intrinsics;
-
-pub use self::generated::*;
 
 uint_module!(u64, i64, 64)
 

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -10,11 +10,18 @@
 
 //! Operations and constants for `u8`
 
-use num::{CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use num::BitCount;
+use num::{CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 uint_module!(u8, i8, 8)
 

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -10,13 +10,20 @@
 
 //! Operations and constants for `uint`
 
-use num;
-use num::{CheckedAdd, CheckedSub, CheckedMul};
-use option::{Option, Some, None};
-use unstable::intrinsics;
-use mem;
+#[allow(non_uppercase_statics)];
 
-pub use self::generated::*;
+use prelude::*;
+
+use default::Default;
+use mem;
+use num::BitCount;
+use num::{CheckedAdd, CheckedSub, CheckedMul};
+use num::{CheckedDiv, Zero, One, strconv};
+use num::{ToStrRadix, FromStrRadix};
+use num;
+use option::{Option, Some, None};
+use str;
+use unstable::intrinsics;
 
 uint_module!(uint, int, ::int::bits)
 

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -8,23 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#4375):  This shouldn't have to be a nested module named 'generated'...
-// FIXME(#10716): ... but now that we could solve that, the import lines and
-//                attributes still prevent a removal of that module.
-
 #[macro_escape];
 #[doc(hidden)];
 
-macro_rules! uint_module (($T:ty, $T_SIGNED:ty, $bits:expr) => (mod generated {
-
-#[allow(non_uppercase_statics)];
-
-use default::Default;
-use num::BitCount;
-use num::{ToStrRadix, FromStrRadix};
-use num::{CheckedDiv, Zero, One, strconv};
-use prelude::*;
-use str;
+macro_rules! uint_module (($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
 pub static bits : uint = $bits;
 pub static bytes : uint = ($bits / 8);
@@ -554,4 +541,4 @@ mod tests {
     }
 }
 
-}))
+))

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#4375): this shouldn't have to be a nested module named 'generated'
+// FIXME(#4375):  This shouldn't have to be a nested module named 'generated'...
+// FIXME(#10716): ... but now that we could solve that, the import lines and
+//                attributes still prevent a removal of that module.
 
 #[macro_escape];
 #[doc(hidden)];

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -26,8 +26,6 @@ use num::{CheckedDiv, Zero, One, strconv};
 use prelude::*;
 use str;
 
-pub use cmp::{min, max};
-
 pub static bits : uint = $bits;
 pub static bytes : uint = ($bits / 8);
 

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -17,7 +17,6 @@ use io::stdio::StdWriter;
 use io::buffered::LineBufferedWriter;
 use rt::crate_map::{ModEntry, CrateMap, iter_crate_map, get_crate_map};
 use str::StrSlice;
-use u32;
 use vec::ImmutableVector;
 #[cfg(test)] use cast::transmute;
 
@@ -46,7 +45,7 @@ fn parse_log_level(level: &str) -> Option<u32> {
             let position = log_level_names.iter().position(|&name| name == level);
             match position {
                 Some(position) => {
-                    log_level = Some(u32::min(MAX_LOG_LEVEL, (position + 1) as u32))
+                    log_level = Some(::cmp::min(MAX_LOG_LEVEL, (position + 1) as u32))
                 },
                 _ => {
                     log_level = None;

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2463,15 +2463,14 @@ impl<A> Default for @[A] {
 }
 
 macro_rules! iterator {
-    /* FIXME: #4375 Cannot attach documentation/attributes to a macro generated struct.
     (struct $name:ident -> $ptr:ty, $elem:ty) => {
+        /// An iterator for iterating over a vector.
         pub struct $name<'self, T> {
             priv ptr: $ptr,
             priv end: $ptr,
-            priv lifetime: $elem // FIXME: #5922
+            priv lifetime: Option<$elem> // FIXME: #5922
         }
-    };*/
-    (impl $name:ident -> $elem:ty) => {
+
         impl<'self, T> Iterator<$elem> for $name<'self, T> {
             #[inline]
             fn next(&mut self) -> Option<$elem> {
@@ -2502,11 +2501,7 @@ macro_rules! iterator {
                 (exact, Some(exact))
             }
         }
-    }
-}
 
-macro_rules! double_ended_iterator {
-    (impl $name:ident -> $elem:ty) => {
         impl<'self, T> DoubleEndedIterator<$elem> for $name<'self, T> {
             #[inline]
             fn next_back(&mut self) -> Option<$elem> {
@@ -2548,15 +2543,7 @@ impl<'self, T> RandomAccessIterator<&'self T> for VecIterator<'self, T> {
     }
 }
 
-//iterator!{struct VecIterator -> *T, &'self T}
-/// An iterator for iterating over a vector.
-pub struct VecIterator<'self, T> {
-    priv ptr: *T,
-    priv end: *T,
-    priv lifetime: Option<&'self ()> // FIXME: #5922
-}
-iterator!{impl VecIterator -> &'self T}
-double_ended_iterator!{impl VecIterator -> &'self T}
+iterator!{struct VecIterator -> *T, &'self T}
 pub type RevIterator<'self, T> = Invert<VecIterator<'self, T>>;
 
 impl<'self, T> ExactSize<&'self T> for VecIterator<'self, T> {}
@@ -2566,15 +2553,7 @@ impl<'self, T> Clone for VecIterator<'self, T> {
     fn clone(&self) -> VecIterator<'self, T> { *self }
 }
 
-//iterator!{struct VecMutIterator -> *mut T, &'self mut T}
-/// An iterator for mutating the elements of a vector.
-pub struct VecMutIterator<'self, T> {
-    priv ptr: *mut T,
-    priv end: *mut T,
-    priv lifetime: Option<&'self mut ()> // FIXME: #5922
-}
-iterator!{impl VecMutIterator -> &'self mut T}
-double_ended_iterator!{impl VecMutIterator -> &'self mut T}
+iterator!{struct VecMutIterator -> *mut T, &'self mut T}
 pub type MutRevIterator<'self, T> = Invert<VecMutIterator<'self, T>>;
 
 /// An iterator that moves out of a vector.


### PR DESCRIPTION
- Removed module reexport workaround for the integer module macros
- Removed legacy reexports of `cmp::{min, max}` in the integer module macros
- Combined a few macros in `vec` into one
- Documented a few issues
