### PR TITLE
don't create intermediate string while creating json (rustdoc)

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -324,7 +324,6 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
     json.insert(~"crate", crate_json);
     json.insert(~"plugins", json::Object(plugins_json));
 
-    let mut file = File::create(&dst).unwrap();
-    let output = json::Object(json).to_str();
-    file.write(output.as_bytes());
+    let file = @mut File::create(&dst).unwrap();
+    json::Object(json).to_writer(file as @mut io::Writer);
 }


### PR DESCRIPTION
as recommended by @huonw on this PR https://github.com/mozilla/rust/pull/10711 , I removed intermediate step that generates a string instead of directly writing to Writer without generating intermediate string.
