### PR TITLE
Remove the `@` boxes from extra::json

### DIFF
--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -464,7 +464,7 @@ impl Json{
     pub fn to_pretty_str(&self) -> ~str {
         let mut s = MemWriter::new();
         self.to_pretty_writer(&mut s as &mut io::Writer);
-        str::from_utf8(s.inner_ref().as_slice())
+        str::from_utf8_owned(s.inner())
     }
 }
 
@@ -847,7 +847,7 @@ impl<T : Iterator<char>> Parser<T> {
 
 /// Decodes a json value from an `&mut io::Reader`
 pub fn from_reader(rdr: &mut io::Reader) -> Result<Json, Error> {
-    let s = str::from_utf8(rdr.read_to_end());
+    let s = str::from_utf8_owned(rdr.read_to_end());
     let mut parser = Parser::init(s.chars());
     parser.parse()
 }
@@ -1319,9 +1319,9 @@ impl<A:ToJson> ToJson for Option<A> {
 impl to_str::ToStr for Json {
     /// Encodes a json value into a string
     fn to_str(&self) -> ~str {
-        let s = @mut MemWriter::new();
-        self.to_writer(s as @mut io::Writer);
-        str::from_utf8(s.inner_ref().as_slice())
+        let mut s = MemWriter::new();
+        self.to_writer(&mut s as &mut io::Writer);
+        str::from_utf8_owned(s.inner())
     }
 }
 
@@ -1507,14 +1507,14 @@ mod tests {
         assert_eq!(a.clone(), from_str(a.to_pretty_str()).unwrap());
     }
 
-    fn with_str_writer(f: |@mut io::Writer|) -> ~str {
+    fn with_str_writer(f: |&mut io::Writer|) -> ~str {
         use std::io::mem::MemWriter;
         use std::io::Decorator;
         use std::str;
 
-        let m = @mut MemWriter::new();
-        f(m as @mut io::Writer);
-        str::from_utf8(*m.inner_ref())
+        let mut m = MemWriter::new();
+        f(&mut m as &mut io::Writer);
+        str::from_utf8_owned(m.inner())
     }
 
     #[test]

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -1195,10 +1195,6 @@ impl ToJson for Json {
     fn to_json(&self) -> Json { (*self).clone() }
 }
 
-impl ToJson for @Json {
-    fn to_json(&self) -> Json { (**self).to_json() }
-}
-
 impl ToJson for int {
     fn to_json(&self) -> Json { Number(*self as f64) }
 }
@@ -1257,10 +1253,6 @@ impl ToJson for bool {
 
 impl ToJson for ~str {
     fn to_json(&self) -> Json { String((*self).clone()) }
-}
-
-impl ToJson for @~str {
-    fn to_json(&self) -> Json { String((**self).clone()) }
 }
 
 impl<A:ToJson,B:ToJson> ToJson for (A, B) {

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -54,7 +54,7 @@ pub struct Error {
     /// The column number at which the error occurred
     priv col: uint,
     /// A message describing the type of the error
-    priv msg: @~str,
+    priv msg: ~str,
 }
 
 fn escape_str(s: &str) -> ~str {
@@ -525,7 +525,7 @@ impl<T : Iterator<char>> Parser<T> {
     }
 
     fn error<T>(&self, msg: ~str) -> Result<T, Error> {
-        Err(Error { line: self.line, col: self.col, msg: @msg })
+        Err(Error { line: self.line, col: self.col, msg: msg })
     }
 
     fn parse_value(&mut self) -> Result<Json, Error> {
@@ -1327,7 +1327,7 @@ impl to_str::ToStr for Json {
 
 impl to_str::ToStr for Error {
     fn to_str(&self) -> ~str {
-        format!("{}:{}: {}", self.line, self.col, *self.msg)
+        format!("{}:{}: {}", self.line, self.col, self.msg)
     }
 }
 
@@ -1593,35 +1593,35 @@ mod tests {
     #[test]
     fn test_trailing_characters() {
         assert_eq!(from_str("nulla"),
-            Err(Error {line: 1u, col: 5u, msg: @~"trailing characters"}));
+            Err(Error {line: 1u, col: 5u, msg: ~"trailing characters"}));
         assert_eq!(from_str("truea"),
-            Err(Error {line: 1u, col: 5u, msg: @~"trailing characters"}));
+            Err(Error {line: 1u, col: 5u, msg: ~"trailing characters"}));
         assert_eq!(from_str("falsea"),
-            Err(Error {line: 1u, col: 6u, msg: @~"trailing characters"}));
+            Err(Error {line: 1u, col: 6u, msg: ~"trailing characters"}));
         assert_eq!(from_str("1a"),
-            Err(Error {line: 1u, col: 2u, msg: @~"trailing characters"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"trailing characters"}));
         assert_eq!(from_str("[]a"),
-            Err(Error {line: 1u, col: 3u, msg: @~"trailing characters"}));
+            Err(Error {line: 1u, col: 3u, msg: ~"trailing characters"}));
         assert_eq!(from_str("{}a"),
-            Err(Error {line: 1u, col: 3u, msg: @~"trailing characters"}));
+            Err(Error {line: 1u, col: 3u, msg: ~"trailing characters"}));
     }
 
     #[test]
     fn test_read_identifiers() {
         assert_eq!(from_str("n"),
-            Err(Error {line: 1u, col: 2u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"invalid syntax"}));
         assert_eq!(from_str("nul"),
-            Err(Error {line: 1u, col: 4u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 4u, msg: ~"invalid syntax"}));
 
         assert_eq!(from_str("t"),
-            Err(Error {line: 1u, col: 2u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"invalid syntax"}));
         assert_eq!(from_str("truz"),
-            Err(Error {line: 1u, col: 4u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 4u, msg: ~"invalid syntax"}));
 
         assert_eq!(from_str("f"),
-            Err(Error {line: 1u, col: 2u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"invalid syntax"}));
         assert_eq!(from_str("faz"),
-            Err(Error {line: 1u, col: 3u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 3u, msg: ~"invalid syntax"}));
 
         assert_eq!(from_str("null"), Ok(Null));
         assert_eq!(from_str("true"), Ok(Boolean(true)));
@@ -1649,20 +1649,20 @@ mod tests {
     #[test]
     fn test_read_number() {
         assert_eq!(from_str("+"),
-            Err(Error {line: 1u, col: 1u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 1u, msg: ~"invalid syntax"}));
         assert_eq!(from_str("."),
-            Err(Error {line: 1u, col: 1u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 1u, msg: ~"invalid syntax"}));
 
         assert_eq!(from_str("-"),
-            Err(Error {line: 1u, col: 2u, msg: @~"invalid number"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"invalid number"}));
         assert_eq!(from_str("00"),
-            Err(Error {line: 1u, col: 2u, msg: @~"invalid number"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"invalid number"}));
         assert_eq!(from_str("1."),
-            Err(Error {line: 1u, col: 3u, msg: @~"invalid number"}));
+            Err(Error {line: 1u, col: 3u, msg: ~"invalid number"}));
         assert_eq!(from_str("1e"),
-            Err(Error {line: 1u, col: 3u, msg: @~"invalid number"}));
+            Err(Error {line: 1u, col: 3u, msg: ~"invalid number"}));
         assert_eq!(from_str("1e+"),
-            Err(Error {line: 1u, col: 4u, msg: @~"invalid number"}));
+            Err(Error {line: 1u, col: 4u, msg: ~"invalid number"}));
 
         assert_eq!(from_str("3"), Ok(Number(3.0)));
         assert_eq!(from_str("3.1"), Ok(Number(3.1)));
@@ -1708,10 +1708,10 @@ mod tests {
     #[test]
     fn test_read_str() {
         assert_eq!(from_str("\""),
-            Err(Error {line: 1u, col: 2u, msg: @~"EOF while parsing string"
+            Err(Error {line: 1u, col: 2u, msg: ~"EOF while parsing string"
         }));
         assert_eq!(from_str("\"lol"),
-            Err(Error {line: 1u, col: 5u, msg: @~"EOF while parsing string"
+            Err(Error {line: 1u, col: 5u, msg: ~"EOF while parsing string"
         }));
 
         assert_eq!(from_str("\"\""), Ok(String(~"")));
@@ -1768,15 +1768,15 @@ mod tests {
     #[test]
     fn test_read_list() {
         assert_eq!(from_str("["),
-            Err(Error {line: 1u, col: 2u, msg: @~"EOF while parsing value"}));
+            Err(Error {line: 1u, col: 2u, msg: ~"EOF while parsing value"}));
         assert_eq!(from_str("[1"),
-            Err(Error {line: 1u, col: 3u, msg: @~"EOF while parsing list"}));
+            Err(Error {line: 1u, col: 3u, msg: ~"EOF while parsing list"}));
         assert_eq!(from_str("[1,"),
-            Err(Error {line: 1u, col: 4u, msg: @~"EOF while parsing value"}));
+            Err(Error {line: 1u, col: 4u, msg: ~"EOF while parsing value"}));
         assert_eq!(from_str("[1,]"),
-            Err(Error {line: 1u, col: 4u, msg: @~"invalid syntax"}));
+            Err(Error {line: 1u, col: 4u, msg: ~"invalid syntax"}));
         assert_eq!(from_str("[6 7]"),
-            Err(Error {line: 1u, col: 4u, msg: @~"expected `,` or `]`"}));
+            Err(Error {line: 1u, col: 4u, msg: ~"expected `,` or `]`"}));
 
         assert_eq!(from_str("[]"), Ok(List(~[])));
         assert_eq!(from_str("[ ]"), Ok(List(~[])));
@@ -1824,49 +1824,49 @@ mod tests {
             Err(Error {
                 line: 1u,
                 col: 2u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
         assert_eq!(from_str("{ "),
             Err(Error {
                 line: 1u,
                 col: 3u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
         assert_eq!(from_str("{1"),
             Err(Error {
                 line: 1u,
                 col: 2u,
-                msg: @~"key must be a string"}));
+                msg: ~"key must be a string"}));
         assert_eq!(from_str("{ \"a\""),
             Err(Error {
                 line: 1u,
                 col: 6u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
         assert_eq!(from_str("{\"a\""),
             Err(Error {
                 line: 1u,
                 col: 5u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
         assert_eq!(from_str("{\"a\" "),
             Err(Error {
                 line: 1u,
                 col: 6u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
 
         assert_eq!(from_str("{\"a\" 1"),
-            Err(Error {line: 1u, col: 6u, msg: @~"expected `:`"}));
+            Err(Error {line: 1u, col: 6u, msg: ~"expected `:`"}));
         assert_eq!(from_str("{\"a\":"),
-            Err(Error {line: 1u, col: 6u, msg: @~"EOF while parsing value"}));
+            Err(Error {line: 1u, col: 6u, msg: ~"EOF while parsing value"}));
         assert_eq!(from_str("{\"a\":1"),
             Err(Error {
                 line: 1u,
                 col: 7u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
         assert_eq!(from_str("{\"a\":1 1"),
-            Err(Error {line: 1u, col: 8u, msg: @~"expected `,` or `}`"}));
+            Err(Error {line: 1u, col: 8u, msg: ~"expected `,` or `}`"}));
         assert_eq!(from_str("{\"a\":1,"),
             Err(Error {
                 line: 1u,
                 col: 8u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
 
         assert_eq!(from_str("{}").unwrap(), mk_object([]));
         assert_eq!(from_str("{\"a\": 3}").unwrap(),
@@ -1966,7 +1966,7 @@ mod tests {
             Err(Error {
                 line: 3u,
                 col: 8u,
-                msg: @~"EOF while parsing object"}));
+                msg: ~"EOF while parsing object"}));
     }
 
     #[deriving(Decodable)]

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -945,8 +945,9 @@ impl MetricMap {
     /// Load MetricDiff from a file.
     pub fn load(p: &Path) -> MetricMap {
         assert!(p.exists());
-        let f = @mut File::open(p) as @mut io::Reader;
-        let mut decoder = json::Decoder::init(json::from_reader(f).unwrap());
+        let mut f = File::open(p);
+        let value = json::from_reader(&mut f as &mut io::Reader).unwrap();
+        let mut decoder = json::Decoder::init(value);
         MetricMap(Decodable::decode(&mut decoder))
     }
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -946,7 +946,7 @@ impl MetricMap {
     pub fn load(p: &Path) -> MetricMap {
         assert!(p.exists());
         let f = @mut File::open(p) as @mut io::Reader;
-        let mut decoder = json::Decoder(json::from_reader(f).unwrap());
+        let mut decoder = json::Decoder::init(json::from_reader(f).unwrap());
         MetricMap(Decodable::decode(&mut decoder))
     }
 

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -191,7 +191,7 @@ impl Database {
                     Err(e) => fail!("Couldn't parse workcache database (from file {}): {}",
                                     self.db_filename.display(), e.to_str()),
                     Ok(r) => {
-                        let mut decoder = json::Decoder(r);
+                        let mut decoder = json::Decoder::init(r);
                         self.db_cache = Decodable::decode(&mut decoder);
                     }
             }
@@ -258,7 +258,7 @@ enum Work<'self, T> {
 
 fn json_encode<T:Encodable<json::Encoder>>(t: &T) -> ~str {
     let writer = @mut MemWriter::new();
-    let mut encoder = json::Encoder(writer as @mut io::Writer);
+    let mut encoder = json::Encoder::init(writer as @mut io::Writer);
     t.encode(&mut encoder);
     str::from_utf8(writer.inner_ref().as_slice())
 }
@@ -267,7 +267,7 @@ fn json_encode<T:Encodable<json::Encoder>>(t: &T) -> ~str {
 fn json_decode<T:Decodable<json::Decoder>>(s: &str) -> T {
     debug!("json decoding: {}", s);
     let j = json::from_str(s).unwrap();
-    let mut decoder = json::Decoder(j);
+    let mut decoder = json::Decoder::init(j);
     Decodable::decode(&mut decoder)
 }
 

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -256,9 +256,9 @@ enum Work<'self, T> {
     WorkFromTask(&'self Prep<'self>, PortOne<(Exec, T)>),
 }
 
-fn json_encode<T:Encodable<json::Encoder>>(t: &T) -> ~str {
-    let writer = @mut MemWriter::new();
-    let mut encoder = json::Encoder::init(writer as @mut io::Writer);
+fn json_encode<'self, T:Encodable<json::Encoder<'self>>>(t: &T) -> ~str {
+    let mut writer = MemWriter::new();
+    let mut encoder = json::Encoder::init(&mut writer as &mut io::Writer);
     t.encode(&mut encoder);
     str::from_utf8(writer.inner_ref().as_slice())
 }
@@ -396,15 +396,15 @@ impl<'self> Prep<'self> {
         return true;
     }
 
-    pub fn exec<T:Send +
-        Encodable<json::Encoder> +
+    pub fn exec<'self, T:Send +
+        Encodable<json::Encoder<'self>> +
         Decodable<json::Decoder>>(
             &'self self, blk: proc(&mut Exec) -> T) -> T {
         self.exec_work(blk).unwrap()
     }
 
-    fn exec_work<T:Send +
-        Encodable<json::Encoder> +
+    fn exec_work<'self, T:Send +
+        Encodable<json::Encoder<'self>> +
         Decodable<json::Decoder>>( // FIXME(#5121)
             &'self self, blk: proc(&mut Exec) -> T) -> Work<'self, T> {
         let mut bo = Some(blk);
@@ -449,7 +449,7 @@ impl<'self> Prep<'self> {
 }
 
 impl<'self, T:Send +
-       Encodable<json::Encoder> +
+       Encodable<json::Encoder<'self>> +
        Decodable<json::Decoder>>
     Work<'self, T> { // FIXME(#5121)
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -283,7 +283,7 @@ fn json_input(input: &str) -> Result<Output, ~str> {
             }
             let crate = match obj.pop(&~"crate") {
                 Some(json) => {
-                    let mut d = json::Decoder(json);
+                    let mut d = json::Decoder::init(json);
                     Decodable::decode(&mut d)
                 }
                 None => return Err(~"malformed json"),
@@ -313,7 +313,7 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
     // straight to the Rust JSON representation.
     let crate_json_str = {
         let w = @mut MemWriter::new();
-        crate.encode(&mut json::Encoder(w as @mut io::Writer));
+        crate.encode(&mut json::Encoder::init(w as @mut io::Writer));
         str::from_utf8(*w.inner_ref())
     };
     let crate_json = match json::from_str(crate_json_str) {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -312,9 +312,12 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
     // FIXME #8335: yuck, Rust -> str -> JSON round trip! No way to .encode
     // straight to the Rust JSON representation.
     let crate_json_str = {
-        let w = @mut MemWriter::new();
-        crate.encode(&mut json::Encoder::init(w as @mut io::Writer));
-        str::from_utf8(*w.inner_ref())
+        let mut w = MemWriter::new();
+        {
+            let mut encoder = json::Encoder::init(&mut w as &mut io::Writer);
+            crate.encode(&mut encoder);
+        }
+        str::from_utf8_owned(w.inner())
     };
     let crate_json = match json::from_str(crate_json_str) {
         Ok(j) => j,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -343,7 +343,7 @@ mod test {
 
     #[cfg(test)] fn to_json_str<E : Encodable<extra::json::Encoder>>(val: @E) -> ~str {
         let writer = @mut MemWriter::new();
-        let mut encoder = extra::json::Encoder(writer as @mut io::Writer);
+        let mut encoder = extra::json::Encoder::init(writer as @mut io::Writer);
         val.encode(&mut encoder);
         str::from_utf8(*writer.inner_ref())
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -341,9 +341,10 @@ mod test {
     use util::parser_testing::{string_to_expr, string_to_item};
     use util::parser_testing::string_to_stmt;
 
-    #[cfg(test)] fn to_json_str<E : Encodable<extra::json::Encoder>>(val: @E) -> ~str {
-        let writer = @mut MemWriter::new();
-        let mut encoder = extra::json::Encoder::init(writer as @mut io::Writer);
+    #[cfg(test)]
+    fn to_json_str<'a, E: Encodable<extra::json::Encoder<'a>>>(val: &E) -> ~str {
+        let mut writer = MemWriter::new();
+        let mut encoder = extra::json::Encoder::init(&mut writer as &mut io::Writer);
         val.encode(&mut encoder);
         str::from_utf8(*writer.inner_ref())
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -346,7 +346,7 @@ mod test {
         let mut writer = MemWriter::new();
         let mut encoder = extra::json::Encoder::init(&mut writer as &mut io::Writer);
         val.encode(&mut encoder);
-        str::from_utf8(*writer.inner_ref())
+        str::from_utf8_owned(writer.inner())
     }
 
     // produce a codemap::span

--- a/src/test/run-pass/issue-4016.rs
+++ b/src/test/run-pass/issue-4016.rs
@@ -18,7 +18,7 @@ trait JD : Decodable<json::Decoder> { }
 
 fn exec<T: JD>() {
     let doc = json::from_str("").unwrap();
-    let mut decoder = json::Decoder(doc);
+    let mut decoder = json::Decoder::init(doc);
     let _v: T = Decodable::decode(&mut decoder);
     fail!()
 }

--- a/src/test/run-pass/issue-4036.rs
+++ b/src/test/run-pass/issue-4036.rs
@@ -17,6 +17,6 @@ use self::extra::serialize;
 
 pub fn main() {
     let json = json::from_str("[1]").unwrap();
-    let mut decoder = json::Decoder(json);
+    let mut decoder = json::Decoder::init(json);
     let _x: ~[int] = serialize::Decodable::decode(&mut decoder);
 }


### PR DESCRIPTION
This PR does some small modernizations to the json library. First is to remove the `@` boxes, second is to rename the constructors to `new`.
