### PR TITLE
remove the `simple_llvm_intrinsic` wrappers

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3973,8 +3973,6 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
 
     } else {
         match name {
-            "abort" => (0, ~[], ty::mk_bot()),
-            "breakpoint" => (0, ~[], ty::mk_nil()),
             "size_of" |
             "pref_align_of" | "min_align_of" => (1u, ~[], ty::mk_uint()),
             "init" => (1u, ~[], param(ccx, 0u)),
@@ -4090,72 +4088,6 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
                ],
                ty::mk_nil())
             }
-            "sqrtf32" => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "sqrtf64" => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "powif32" => {
-               (0,
-                ~[ ty::mk_f32(), ty::mk_i32() ],
-                ty::mk_f32())
-            }
-            "powif64" => {
-               (0,
-                ~[ ty::mk_f64(), ty::mk_i32() ],
-                ty::mk_f64())
-            }
-            "sinf32" => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "sinf64" => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "cosf32" => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "cosf64" => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "powf32" => {
-               (0,
-                ~[ ty::mk_f32(), ty::mk_f32() ],
-                ty::mk_f32())
-            }
-            "powf64" => {
-               (0,
-                ~[ ty::mk_f64(), ty::mk_f64() ],
-                ty::mk_f64())
-            }
-            "expf32"   => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "expf64"   => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "exp2f32"  => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "exp2f64"  => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "logf32"   => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "logf64"   => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "log10f32" => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "log10f64" => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "log2f32"  => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "log2f64"  => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "fmaf32" => {
-                (0,
-                 ~[ ty::mk_f32(), ty::mk_f32(), ty::mk_f32() ],
-                 ty::mk_f32())
-            }
-            "fmaf64" => {
-                (0,
-                 ~[ ty::mk_f64(), ty::mk_f64(), ty::mk_f64() ],
-                 ty::mk_f64())
-            }
-            "fabsf32"      => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "fabsf64"      => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "copysignf32"  => (0, ~[ ty::mk_f32(), ty::mk_f32() ], ty::mk_f32()),
-            "copysignf64"  => (0, ~[ ty::mk_f64(), ty::mk_f64() ], ty::mk_f64()),
-            "floorf32"     => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "floorf64"     => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "ceilf32"      => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "ceilf64"      => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "truncf32"     => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "truncf64"     => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "rintf32"      => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "rintf64"      => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "nearbyintf32" => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "nearbyintf64" => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "roundf32"     => (0, ~[ ty::mk_f32() ], ty::mk_f32()),
-            "roundf64"     => (0, ~[ ty::mk_f64() ], ty::mk_f64()),
-            "ctpop8"       => (0, ~[ ty::mk_i8()  ], ty::mk_i8()),
-            "ctpop16"      => (0, ~[ ty::mk_i16() ], ty::mk_i16()),
-            "ctpop32"      => (0, ~[ ty::mk_i32() ], ty::mk_i32()),
-            "ctpop64"      => (0, ~[ ty::mk_i64() ], ty::mk_i64()),
             "ctlz8"        => (0, ~[ ty::mk_i8()  ], ty::mk_i8()),
             "ctlz16"       => (0, ~[ ty::mk_i16() ], ty::mk_i16()),
             "ctlz32"       => (0, ~[ ty::mk_i32() ], ty::mk_i32()),
@@ -4164,9 +4096,6 @@ pub fn check_intrinsic_type(ccx: @mut CrateCtxt, it: @ast::foreign_item) {
             "cttz16"       => (0, ~[ ty::mk_i16() ], ty::mk_i16()),
             "cttz32"       => (0, ~[ ty::mk_i32() ], ty::mk_i32()),
             "cttz64"       => (0, ~[ ty::mk_i64() ], ty::mk_i64()),
-            "bswap16"      => (0, ~[ ty::mk_i16() ], ty::mk_i16()),
-            "bswap32"      => (0, ~[ ty::mk_i32() ], ty::mk_i32()),
-            "bswap64"      => (0, ~[ ty::mk_i64() ], ty::mk_i64()),
 
             "i8_add_with_overflow" | "i8_sub_with_overflow" | "i8_mul_with_overflow" =>
                 (0, ~[ty::mk_i8(), ty::mk_i8()],

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -172,13 +172,128 @@ pub trait TyVisitor {
     fn visit_closure_ptr(&mut self, ck: uint) -> bool;
 }
 
-extern "rust-intrinsic" {
+extern {
     /// Abort the execution of the process.
+    #[link_name = "llvm.trap"]
     pub fn abort() -> !;
 
     /// Execute a breakpoint trap, for inspection by a debugger.
+    #[link_name = "llvm.debugtrap"]
     pub fn breakpoint();
 
+    #[link_name = "llvm.sqrt.f32"]
+    pub fn sqrtf32(x: f32) -> f32;
+    #[link_name = "llvm.sqrt.f64"]
+    pub fn sqrtf64(x: f64) -> f64;
+
+    #[link_name = "llvm.powi.f32"]
+    pub fn powif32(a: f32, x: i32) -> f32;
+    #[link_name = "llvm.powi.f64"]
+    pub fn powif64(a: f64, x: i32) -> f64;
+
+    #[link_name = "llvm.sin.f32"]
+    pub fn sinf32(x: f32) -> f32;
+    #[link_name = "llvm.sin.f64"]
+    pub fn sinf64(x: f64) -> f64;
+
+    #[link_name = "llvm.cos.f32"]
+    pub fn cosf32(x: f32) -> f32;
+    #[link_name = "llvm.cos.f64"]
+    pub fn cosf64(x: f64) -> f64;
+
+    #[link_name = "llvm.pow.f32"]
+    pub fn powf32(a: f32, x: f32) -> f32;
+    #[link_name = "llvm.pow.f64"]
+    pub fn powf64(a: f64, x: f64) -> f64;
+
+    #[link_name = "llvm.exp.f32"]
+    pub fn expf32(x: f32) -> f32;
+    #[link_name = "llvm.exp.f64"]
+    pub fn expf64(x: f64) -> f64;
+
+    #[link_name = "llvm.exp2.f32"]
+    pub fn exp2f32(x: f32) -> f32;
+    #[link_name = "llvm.exp2.f64"]
+    pub fn exp2f64(x: f64) -> f64;
+
+    #[link_name = "llvm.log.f32"]
+    pub fn logf32(x: f32) -> f32;
+    #[link_name = "llvm.log.f64"]
+    pub fn logf64(x: f64) -> f64;
+
+    #[link_name = "llvm.log10.f32"]
+    pub fn log10f32(x: f32) -> f32;
+    #[link_name = "llvm.log10.f64"]
+    pub fn log10f64(x: f64) -> f64;
+
+    #[link_name = "llvm.log2.f32"]
+    pub fn log2f32(x: f32) -> f32;
+    #[link_name = "llvm.log2.f64"]
+    pub fn log2f64(x: f64) -> f64;
+
+    #[link_name = "llvm.fma.f32"]
+    pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
+    #[link_name = "llvm.fma.f64"]
+    pub fn fmaf64(a: f64, b: f64, c: f64) -> f64;
+
+    #[link_name = "llvm.fabs.f32"]
+    pub fn fabsf32(x: f32) -> f32;
+    #[link_name = "llvm.fabs.f64"]
+    pub fn fabsf64(x: f64) -> f64;
+
+    #[link_name = "llvm.copysign.f32"]
+    pub fn copysignf32(x: f32, y: f32) -> f32;
+    #[link_name = "llvm.copysign.f64"]
+    pub fn copysignf64(x: f64, y: f64) -> f64;
+
+    #[link_name = "llvm.floor.f32"]
+    pub fn floorf32(x: f32) -> f32;
+    #[link_name = "llvm.floor.f64"]
+    pub fn floorf64(x: f64) -> f64;
+
+    #[link_name = "llvm.ceil.f32"]
+    pub fn ceilf32(x: f32) -> f32;
+    #[link_name = "llvm.ceil.f64"]
+    pub fn ceilf64(x: f64) -> f64;
+
+    #[link_name = "llvm.trunc.f32"]
+    pub fn truncf32(x: f32) -> f32;
+    #[link_name = "llvm.trunc.f64"]
+    pub fn truncf64(x: f64) -> f64;
+
+    #[link_name = "llvm.rint.f32"]
+    pub fn rintf32(x: f32) -> f32;
+    #[link_name = "llvm.rint.f64"]
+    pub fn rintf64(x: f64) -> f64;
+
+    #[link_name = "llvm.nearbyint.f32"]
+    pub fn nearbyintf32(x: f32) -> f32;
+    #[link_name = "llvm.nearbyint.f64"]
+    pub fn nearbyintf64(x: f64) -> f64;
+
+    #[link_name = "llvm.round.f32"]
+    pub fn roundf32(x: f32) -> f32;
+    #[link_name = "llvm.round.f64"]
+    pub fn roundf64(x: f64) -> f64;
+
+    #[link_name = "llvm.ctpop.i8"]
+    pub fn ctpop8(x: i8) -> i8;
+    #[link_name = "llvm.ctpop.i16"]
+    pub fn ctpop16(x: i16) -> i16;
+    #[link_name = "llvm.ctpop.i32"]
+    pub fn ctpop32(x: i32) -> i32;
+    #[link_name = "llvm.ctpop.i64"]
+    pub fn ctpop64(x: i64) -> i64;
+
+    #[link_name = "llvm.bswap.i16"]
+    pub fn bswap16(x: i16) -> i16;
+    #[link_name = "llvm.bswap.i32"]
+    pub fn bswap32(x: i32) -> i32;
+    #[link_name = "llvm.bswap.i64"]
+    pub fn bswap64(x: i64) -> i64;
+}
+
+extern "rust-intrinsic" {
     /// Atomic compare and exchange, sequentially consistent.
     pub fn atomic_cxchg(dst: &mut int, old: int, src: int) -> int;
     /// Atomic compare and exchange, acquire ordering.
@@ -366,68 +481,6 @@ extern "rust-intrinsic" {
     /// `min_align_of::<T>()`
     pub fn set_memory<T>(dst: *mut T, val: u8, count: uint);
 
-    pub fn sqrtf32(x: f32) -> f32;
-    pub fn sqrtf64(x: f64) -> f64;
-
-    pub fn powif32(a: f32, x: i32) -> f32;
-    pub fn powif64(a: f64, x: i32) -> f64;
-
-    pub fn sinf32(x: f32) -> f32;
-    pub fn sinf64(x: f64) -> f64;
-
-    pub fn cosf32(x: f32) -> f32;
-    pub fn cosf64(x: f64) -> f64;
-
-    pub fn powf32(a: f32, x: f32) -> f32;
-    pub fn powf64(a: f64, x: f64) -> f64;
-
-    pub fn expf32(x: f32) -> f32;
-    pub fn expf64(x: f64) -> f64;
-
-    pub fn exp2f32(x: f32) -> f32;
-    pub fn exp2f64(x: f64) -> f64;
-
-    pub fn logf32(x: f32) -> f32;
-    pub fn logf64(x: f64) -> f64;
-
-    pub fn log10f32(x: f32) -> f32;
-    pub fn log10f64(x: f64) -> f64;
-
-    pub fn log2f32(x: f32) -> f32;
-    pub fn log2f64(x: f64) -> f64;
-
-    pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
-    pub fn fmaf64(a: f64, b: f64, c: f64) -> f64;
-
-    pub fn fabsf32(x: f32) -> f32;
-    pub fn fabsf64(x: f64) -> f64;
-
-    pub fn copysignf32(x: f32, y: f32) -> f32;
-    pub fn copysignf64(x: f64, y: f64) -> f64;
-
-    pub fn floorf32(x: f32) -> f32;
-    pub fn floorf64(x: f64) -> f64;
-
-    pub fn ceilf32(x: f32) -> f32;
-    pub fn ceilf64(x: f64) -> f64;
-
-    pub fn truncf32(x: f32) -> f32;
-    pub fn truncf64(x: f64) -> f64;
-
-    pub fn rintf32(x: f32) -> f32;
-    pub fn rintf64(x: f64) -> f64;
-
-    pub fn nearbyintf32(x: f32) -> f32;
-    pub fn nearbyintf64(x: f64) -> f64;
-
-    pub fn roundf32(x: f32) -> f32;
-    pub fn roundf64(x: f64) -> f64;
-
-    pub fn ctpop8(x: i8) -> i8;
-    pub fn ctpop16(x: i16) -> i16;
-    pub fn ctpop32(x: i32) -> i32;
-    pub fn ctpop64(x: i64) -> i64;
-
     pub fn ctlz8(x: i8) -> i8;
     pub fn ctlz16(x: i16) -> i16;
     pub fn ctlz32(x: i32) -> i32;
@@ -437,10 +490,6 @@ extern "rust-intrinsic" {
     pub fn cttz16(x: i16) -> i16;
     pub fn cttz32(x: i32) -> i32;
     pub fn cttz64(x: i64) -> i64;
-
-    pub fn bswap16(x: i16) -> i16;
-    pub fn bswap32(x: i32) -> i32;
-    pub fn bswap64(x: i64) -> i64;
 
     pub fn i8_add_with_overflow(x: i8, y: i8) -> (i8, bool);
     pub fn i16_add_with_overflow(x: i16, y: i16) -> (i16, bool);

--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -15,12 +15,25 @@
 extern mod extra;
 
 mod rusti {
-    extern "rust-intrinsic" {
+    extern {
+        #[link_name = "llvm.ctpop.i8"]
         pub fn ctpop8(x: i8) -> i8;
+        #[link_name = "llvm.ctpop.i16"]
         pub fn ctpop16(x: i16) -> i16;
+        #[link_name = "llvm.ctpop.i32"]
         pub fn ctpop32(x: i32) -> i32;
+        #[link_name = "llvm.ctpop.i64"]
         pub fn ctpop64(x: i64) -> i64;
 
+        #[link_name = "llvm.bswap.i16"]
+        pub fn bswap16(x: i16) -> i16;
+        #[link_name = "llvm.bswap.i32"]
+        pub fn bswap32(x: i32) -> i32;
+        #[link_name = "llvm.bswap.i64"]
+        pub fn bswap64(x: i64) -> i64;
+    }
+
+    extern "rust-intrinsic" {
         pub fn ctlz8(x: i8) -> i8;
         pub fn ctlz16(x: i16) -> i16;
         pub fn ctlz32(x: i32) -> i32;
@@ -30,10 +43,6 @@ mod rusti {
         pub fn cttz16(x: i16) -> i16;
         pub fn cttz32(x: i32) -> i32;
         pub fn cttz64(x: i64) -> i64;
-
-        pub fn bswap16(x: i16) -> i16;
-        pub fn bswap32(x: i32) -> i32;
-        pub fn bswap64(x: i64) -> i64;
     }
 }
 

--- a/src/test/run-pass/intrinsics-math.rs
+++ b/src/test/run-pass/intrinsics-math.rs
@@ -13,36 +13,66 @@
 #[feature(globs)];
 
 mod rusti {
-    extern "rust-intrinsic" {
+    extern {
+        #[link_name = "llvm.sqrt.f32"]
         pub fn sqrtf32(x: f32) -> f32;
+        #[link_name = "llvm.sqrt.f64"]
         pub fn sqrtf64(x: f64) -> f64;
+        #[link_name = "llvm.powi.f32"]
         pub fn powif32(a: f32, x: i32) -> f32;
+        #[link_name = "llvm.powi.f64"]
         pub fn powif64(a: f64, x: i32) -> f64;
+        #[link_name = "llvm.sin.f32"]
         pub fn sinf32(x: f32) -> f32;
+        #[link_name = "llvm.sin.f64"]
         pub fn sinf64(x: f64) -> f64;
+        #[link_name = "llvm.cos.f32"]
         pub fn cosf32(x: f32) -> f32;
+        #[link_name = "llvm.cos.f64"]
         pub fn cosf64(x: f64) -> f64;
+        #[link_name = "llvm.pow.f32"]
         pub fn powf32(a: f32, x: f32) -> f32;
+        #[link_name = "llvm.pow.f64"]
         pub fn powf64(a: f64, x: f64) -> f64;
+        #[link_name = "llvm.exp.f32"]
         pub fn expf32(x: f32) -> f32;
+        #[link_name = "llvm.exp.f64"]
         pub fn expf64(x: f64) -> f64;
+        #[link_name = "llvm.exp2.f32"]
         pub fn exp2f32(x: f32) -> f32;
+        #[link_name = "llvm.exp2.f64"]
         pub fn exp2f64(x: f64) -> f64;
+        #[link_name = "llvm.log.f32"]
         pub fn logf32(x: f32) -> f32;
+        #[link_name = "llvm.log.f64"]
         pub fn logf64(x: f64) -> f64;
+        #[link_name = "llvm.log10.f32"]
         pub fn log10f32(x: f32) -> f32;
+        #[link_name = "llvm.log10.f64"]
         pub fn log10f64(x: f64) -> f64;
+        #[link_name = "llvm.log2.f32"]
         pub fn log2f32(x: f32) -> f32;
+        #[link_name = "llvm.log2.f64"]
         pub fn log2f64(x: f64) -> f64;
+        #[link_name = "llvm.fma.f32"]
         pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
+        #[link_name = "llvm.fma.f64"]
         pub fn fmaf64(a: f64, b: f64, c: f64) -> f64;
+        #[link_name = "llvm.fabs.f32"]
         pub fn fabsf32(x: f32) -> f32;
+        #[link_name = "llvm.fabs.f64"]
         pub fn fabsf64(x: f64) -> f64;
+        #[link_name = "llvm.floor.f32"]
         pub fn floorf32(x: f32) -> f32;
+        #[link_name = "llvm.floor.f64"]
         pub fn floorf64(x: f64) -> f64;
+        #[link_name = "llvm.ceil.f32"]
         pub fn ceilf32(x: f32) -> f32;
+        #[link_name = "llvm.ceil.f64"]
         pub fn ceilf64(x: f64) -> f64;
+        #[link_name = "llvm.trunc.f32"]
         pub fn truncf32(x: f32) -> f32;
+        #[link_name = "llvm.trunc.f64"]
         pub fn truncf64(x: f64) -> f64;
     }
 }


### PR DESCRIPTION
This removes a layer of generated wrappers from native LLVM intrinsics
we can represent directly in the type system. There are a lot with `i1`
parameters so there's still a need for those to be in the compiler.

These are an implementation detail of the compiler, so the inconsistency
is worth the simplification and faster compiles.
