### PR TITLE
Ignore a deque test on windows

### DIFF
--- a/src/libstd/rt/deque.rs
+++ b/src/libstd/rt/deque.rs
@@ -590,6 +590,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore(cfg(windows))] // apparently windows scheduling is weird?
     fn no_starvation() {
         static AMT: int = 10000;
         static NTHREADS: int = 4;


### PR DESCRIPTION
I've seen this fail on windows twice now, and it's not clear to me why it's
failing. For now, ignore it on that platform while investigation enuses.
