### PR TITLE
Don't run cleanups twice in "if true" blocks

### DIFF
--- a/src/test/run-pass/issue-10734.rs
+++ b/src/test/run-pass/issue-10734.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    if true {
+        let _a = ~3;
+    }
+    if false {
+        fail!()
+    } else {
+        let _a = ~3;
+    }
+}


### PR DESCRIPTION
Turns out `with_scope` already translates destructors, so by manually
translating destructors we end up running them all twice (bad).

Closes #10734
