### PR TITLE
Rewrite the issue-10734 rpass file

### DIFF
--- a/src/test/run-pass/issue-10734.rs
+++ b/src/test/run-pass/issue-10734.rs
@@ -8,13 +8,37 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+static mut drop_count: uint = 0;
+
+#[unsafe_no_drop_flag]
+struct Foo {
+    dropped: bool
+}
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        // Test to make sure we haven't dropped already
+        assert!(!self.dropped);
+        self.dropped = true;
+        // And record the fact that we dropped for verification later
+        unsafe { drop_count += 1; }
+    }
+}
+
 pub fn main() {
+    // An `if true { expr }` statement should compile the same as `{ expr }`.
     if true {
-        let _a = ~3;
+        let _a = Foo{ dropped: false };
     }
+    // Check that we dropped already (as expected from a `{ expr }`).
+    unsafe { assert!(drop_count == 1); }
+
+    // An `if false {} else { expr }` statement should compile the same as `{ expr }`.
     if false {
-        fail!()
+        fail!();
     } else {
-        let _a = ~3;
+        let _a = Foo{ dropped: false };
     }
+    // Check that we dropped already (as expected from a `{ expr }`).
+    unsafe { assert!(drop_count == 2); }
 }


### PR DESCRIPTION
Stop relying on a malloc error to indicate failure and instead use an
explicit check. Also ensure that the value is dropped at the correct
time (e.g. that the if statement is translated into `{ expr }` instead
of `expr`).
