### PR TITLE
Add placeholder text to the search bar in the documentation.

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -59,7 +59,8 @@ pub fn render<T: fmt::Default, S: fmt::Default>(
     <nav class=\"sub\">
         <form class=\"search-form js-only\">
             <input class=\"search-input\" name=\"search\"
-                   autocomplete=\"off\" />
+                   autocomplete=\"off\"
+                   placeholder=\"Search documentation...\" />
             <button class=\"do-search\">Search</button>
         </form>
     </nav>

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -60,7 +60,8 @@ pub fn render<T: fmt::Default, S: fmt::Default>(
         <form class=\"search-form js-only\">
             <input class=\"search-input\" name=\"search\"
                    autocomplete=\"off\"
-                   placeholder=\"Search documentation...\" />
+                   placeholder=\"Search documentation...\"
+                   type=\"search\" />
             <button class=\"do-search\">Search</button>
         </form>
     </nav>


### PR DESCRIPTION
This makes the search bar more visible.
