### PR TITLE
more useful rustpkg init

### DIFF
--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -24,6 +24,7 @@ use std::{os, result, run, str, task};
 use std::io::process;
 use std::hashmap::HashSet;
 use std::io;
+use std::io::File;
 use std::io::fs;
 pub use std::path::Path;
 
@@ -72,6 +73,11 @@ pub mod workcache_support;
 mod workspace;
 
 pub mod usage;
+
+enum PkgType {
+    Bin,
+    Lib,
+}
 
 /// A PkgScript represents user-supplied custom logic for
 /// special build hooks. This only exists for packages with
@@ -226,7 +232,7 @@ pub trait CtxMethods {
     fn test(&self, id: &CrateId, workspace: &Path);
     fn uninstall(&self, _id: &str, _vers: Option<~str>);
     fn unprefer(&self, _id: &str, _vers: Option<~str>);
-    fn init(&self);
+    fn init(&self, name: &str, pkg_type: PkgType);
 }
 
 impl CtxMethods for BuildContext {
@@ -389,10 +395,19 @@ impl CtxMethods for BuildContext {
                 }
             }
             "init" => {
-                if args.len() != 0 {
-                    return usage::init();
+                if args.len() != 2 {
+                    usage::init();
                 } else {
-                    self.init();
+                    let pkg_type = match args[0] {
+                        ~"bin" => Some(Bin),
+                        ~"lib" => Some(Lib),
+                        _ => None,
+                    };
+                    if pkg_type.is_none() {
+                        usage::init();
+                    } else {
+                        self.init(args[1].as_slice(), pkg_type.unwrap());
+                    }
                 }
             }
             "uninstall" => {
@@ -728,11 +743,36 @@ impl CtxMethods for BuildContext {
         }
     }
 
-    fn init(&self) {
-        fs::mkdir_recursive(&Path::new("src"), io::UserRWX);
-        fs::mkdir_recursive(&Path::new("bin"), io::UserRWX);
-        fs::mkdir_recursive(&Path::new("lib"), io::UserRWX);
-        fs::mkdir_recursive(&Path::new("build"), io::UserRWX);
+    fn init(&self, name: &str, pkg_type: PkgType) {
+        let path = Path::new(name);
+        let path_exists = path.exists();
+        if path_exists && path.is_file() {
+            error(format!("rustpkg fails to initialize {0:s}: {0:s} appears to be a file.", name));
+        } else if path_exists && fs::walk_dir(&path).len() != 0 {
+            error(format!("rustpkg fails to initialize {0:s}: {0:s} is non-empty.", name));
+        } else {
+            let src_dir = format!("{0:s}/src/{0:s}", name);
+            fs::mkdir_recursive(&Path::new(src_dir.as_slice()), io::UserRWX);
+            fs::mkdir_recursive(&Path::new(format!("{:s}/bin", name)), io::UserRWX);
+            fs::mkdir_recursive(&Path::new(format!("{:s}/lib", name)), io::UserRWX);
+            fs::mkdir_recursive(&Path::new(format!("{:s}/build", name)), io::UserRWX);
+            match pkg_type {
+                Bin => match File::create(&Path::new(format!("{:s}/main.rs", src_dir.as_slice()))) {
+                    Some(mut file) => file.write(bytes!("fn main() {
+println(\"I don't do much. Yet.\");
+}
+")),
+                    None => warn("rustpkg fails to create main.rs"),
+                },
+                Lib => match File::create(&Path::new(format!("{:s}/lib.rs", src_dir.as_slice()))) {
+                    Some(mut file) => file.write(bytes!("pub fn get_answer() -> int {
+    42
+}
+")),
+                    None => warn("rustpkg fails to create lib.rs"),
+                },
+            }
+        }
     }
 
     fn uninstall(&self, _id: &str, _vers: Option<~str>)  {

--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -148,9 +148,9 @@ Options:
 }
 
 pub fn init() {
-    println("rustpkg init
+    println("rustpkg init <bin|lib> package-name
 
-This will turn the current working directory into a workspace. The first
-command you run when starting off a new project.
+This initializes a workspace with the same name as package-name in the current
+directory. The first command you run when starting off a new project.
 ");
 }


### PR DESCRIPTION
This PR modifies the behavior of `rustpkg init`.

`rustpkg init` now accepts two more arguments, the first is the type of package to initialize (`bin` or `lib`), and the second is the package name. Instead of initializing a workspace in the current directory, `rustpkg init` now initializes a workspace under the directory with the same name as the supplied package name. In addition, it also creates some default crates (i.e. `lib.rs` or `main.rs`) under `src/<package-name>/`.

E.g. `rustpkg init lib awesome_lib` will create the following directory tree in the current directory.

```
awesome_lib/ 
 - bin/
 - build/
 - lib/
 - src/
    - awesome_lib/
       - lib.rs
```

The content of `lib.rs` is the following.

``` rust
pub fn get_answer() -> int {
    42
}
```

EDIT: `test.rs` is no longer generated.
PS: re-opening of #10651, as per request @alexcrichton
