### PR TITLE
Add macros to check if logging at a given label is enabled

### DIFF
--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -20,14 +20,20 @@ There are five macros that the logging subsystem uses:
 
 * `log!(level, ...)` - the generic logging macro, takes a level as a u32 and any
                        related `format!` arguments
-* `debug!(...)` - a macro hard-wired to the log level of 4
-* `info!(...)` - a macro hard-wired to the log level of 3
-* `warn!(...)` - a macro hard-wired to the log level of 2
-* `error!(...)` - a macro hard-wired to the log level of 1
+* `debug!(...)` - a macro hard-wired to the log level of `DEBUG`
+* `info!(...)` - a macro hard-wired to the log level of `INFO`
+* `warn!(...)` - a macro hard-wired to the log level of `WARN`
+* `error!(...)` - a macro hard-wired to the log level of `ERROR`
 
 All of these macros use the same style of syntax as the `format!` syntax
 extension. Details about the syntax can be found in the documentation of
-`std::fmt` along with the Rust tutorial/manual
+`std::fmt` along with the Rust tutorial/manual.
+
+If you want to check at runtime if a given logging level is enabled (e.g. if the
+information you would want to log is expensive to produce), you can use the
+following macro:
+
+* `log_enabled!(level)` - returns true if logging of the given level is enabled
 
 ## Enabling logging
 
@@ -94,6 +100,15 @@ use option::*;
 use rt::local::Local;
 use rt::logging::{Logger, StdErrLogger};
 use rt::task::Task;
+
+/// Debug log level
+pub static DEBUG: u32 = 4;
+/// Info log level
+pub static INFO: u32 = 3;
+/// Warn log level
+pub static WARN: u32 = 2;
+/// Error log level
+pub static ERROR: u32 = 1;
 
 /// This function is called directly by the compiler when using the logging
 /// macros. This function does not take into account whether the log level

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -754,6 +754,13 @@ pub fn std_macros() -> @str {
         if cfg!(not(ndebug)) { log!(4u32, $($arg)*) }
     ))
 
+    macro_rules! log_enabled(
+        ($lvl:expr) => ( {
+            let lvl = $lvl;
+            lvl <= __log_level() && (lvl != 4 || cfg!(not(ndebug)))
+        } )
+    )
+
     macro_rules! fail(
         () => (
             fail!("explicit failure")

--- a/src/test/run-pass/logging-enabled-debug.rs
+++ b/src/test/run-pass/logging-enabled-debug.rs
@@ -1,0 +1,21 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// compile-flags:--cfg ndebug
+// exec-env:RUST_LOG=logging-enabled-debug=debug
+
+use std::logging;
+
+fn main() {
+    if log_enabled!(logging::DEBUG) {
+        fail!("what?! debugging?");
+    }
+}

--- a/src/test/run-pass/logging-enabled.rs
+++ b/src/test/run-pass/logging-enabled.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// exec-env:RUST_LOG=logging-enabled=info
+
+use std::logging;
+
+fn main() {
+    if log_enabled!(logging::DEBUG) {
+        fail!("what?! debugging?");
+    }
+    if !log_enabled!(logging::INFO) {
+        fail!("what?! no info?");
+    }
+}


### PR DESCRIPTION
This is useful when the information that is needed to do useful logging
is expensive to produce.
