### PR TITLE
Allow expanding a tuple type `T` in a list of types with `..T`.

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1080,8 +1080,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_name(ecx, ebml_w, item.ident);
         encode_attributes(ebml_w, item.attrs);
         match ty.node {
-            ast::ty_path(ref path, ref bounds, _) if path.segments
-                                                         .len() == 1 => {
+            ast::ty_path(_, ref path, ref bounds, _) if path.segments
+                                                            .len() == 1 => {
                 assert!(bounds.is_none());
                 encode_impl_type_basename(ecx, ebml_w,
                                           ast_util::path_to_ident(path));

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -304,7 +304,10 @@ fn enc_sty(w: @mut MemWriter, cx: @ctxt, st: &ty::sty) {
         ty::ty_infer(_) => {
             cx.diag.handler().bug("Cannot encode inference variable types");
         }
-        ty::ty_param(param_ty {idx: id, def_id: did}) => {
+        ty::ty_param(expand, param_ty {idx: id, def_id: did}) => {
+            if expand {
+                cx.tcx.sess.bug("found unexpanded ty_param in tyencode::enc_sty");
+            }
             mywrite!(w, "p{}|{}", (cx.ds)(did), id);
         }
         ty::ty_self(did) => {

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -159,7 +159,7 @@ impl Visitor<()> for MarkSymbolVisitor {
 
     fn visit_ty(&mut self, typ: &ast::Ty, _: ()) {
         match typ.node {
-            ast::ty_path(_, _, ref id) => {
+            ast::ty_path(_, _, _, ref id) => {
                 self.lookup_and_handle_definition(id, typ.span);
             }
             _ => visit::walk_ty(self, typ, ()),

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -137,7 +137,7 @@ fn check_impl_of_trait(cx: &mut Context, it: @item, trait_ref: &trait_ref, self_
     // If this is a destructor, check kinds.
     if cx.tcx.lang_items.drop_trait() == Some(trait_def_id) {
         match self_type.node {
-            ty_path(_, ref bounds, path_node_id) => {
+            ty_path(_, _, ref bounds, path_node_id) => {
                 assert!(bounds.is_none());
                 let struct_def = cx.tcx.def_map.get_copy(&path_node_id);
                 let struct_did = ast_util::def_id_of_def(struct_def);
@@ -325,7 +325,7 @@ pub fn check_expr(cx: &mut Context, e: @Expr) {
 
 fn check_ty(cx: &mut Context, aty: &Ty) {
     match aty.node {
-      ty_path(_, _, id) => {
+      ty_path(_, _, _, id) => {
           let r = cx.tcx.node_type_substs.find(&id);
           for ts in r.iter() {
               let did = ast_util::def_id_of_def(cx.tcx.def_map.get_copy(&id));
@@ -554,7 +554,7 @@ pub fn check_cast_for_escaping_regions(
 
         |ty| {
             match ty::get(ty).sty {
-                ty::ty_param(source_param) => {
+                ty::ty_param(_, source_param) => {
                     if target_params.iter().any(|x| x == &source_param) {
                         /* case (2) */
                     } else {

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -711,7 +711,7 @@ fn check_type_limits(cx: &Context, e: &ast::Expr) {
 fn check_item_ctypes(cx: &Context, it: &ast::item) {
     fn check_ty(cx: &Context, ty: &ast::Ty) {
         match ty.node {
-            ast::ty_path(_, _, id) => {
+            ast::ty_path(_, _, _, id) => {
                 match cx.tcx.def_map.get_copy(&id) {
                     ast::DefPrimTy(ast::ty_int(ast::ty_i)) => {
                         cx.span_lint(ctypes, ty.span,

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -219,7 +219,7 @@ impl<'self> Visitor<()> for EmbargoVisitor<'self> {
             // * Private trait impls for private types can be completely ignored
             ast::item_impl(_, _, ref ty, ref methods) => {
                 let public_ty = match ty.node {
-                    ast::ty_path(_, _, id) => {
+                    ast::ty_path(_, _, _, id) => {
                         match self.tcx.def_map.get_copy(&id) {
                             ast::DefPrimTy(..) => true,
                             def => {
@@ -699,7 +699,7 @@ impl<'self> Visitor<()> for PrivacyVisitor<'self> {
 
     fn visit_ty(&mut self, t: &ast::Ty, _: ()) {
         match t.node {
-            ast::ty_path(ref path, _, id) => self.check_path(t.span, id, path),
+            ast::ty_path(_, ref path, _, id) => self.check_path(t.span, id, path),
             _ => {}
         }
         visit::walk_ty(self, t, ());

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1236,7 +1236,7 @@ impl Resolver {
 
                 // Create the module and add all methods.
                 match ty.node {
-                    ty_path(ref path, _, _) if path.segments.len() == 1 => {
+                    ty_path(_, ref path, _, _) if path.segments.len() == 1 => {
                         let name = path_to_ident(path);
 
                         let new_parent = match parent.children.find(&name.name) {
@@ -4129,7 +4129,7 @@ impl Resolver {
             // Like path expressions, the interpretation of path types depends
             // on whether the path has multiple elements in it or not.
 
-            ty_path(ref path, ref bounds, path_id) => {
+            ty_path(_, ref path, ref bounds, path_id) => {
                 // This is a path in the type namespace. Walk through scopes
                 // scopes looking for it.
                 let mut result_def = None;

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -63,7 +63,7 @@ impl<'self> TypeFolder for SubstFolder<'self> {
         }
 
         match ty::get(t).sty {
-            ty::ty_param(p) => {
+            ty::ty_param(_, p) => {
                 self.substs.tps[p.idx]
             }
             ty::ty_self(_) => {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -351,7 +351,12 @@ impl Reflector {
           // Miscellaneous extra types
           ty::ty_infer(_) => self.leaf("infer"),
           ty::ty_err => self.leaf("err"),
-          ty::ty_param(ref p) => {
+          ty::ty_param(expand, ref p) => {
+              if expand {
+                  tcx.sess.bug(format!(
+                      "found unexpanded ty_param `{}` in reflect::visit_ty",
+                      ty_to_str(tcx, t)));
+              }
               let extra = ~[self.c_uint(p.idx)];
               self.visit("param", extra)
           }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -321,7 +321,7 @@ impl<'self> LookupContext<'self> {
         let mut self_ty = self_ty;
         loop {
             match get(self_ty).sty {
-                ty_param(p) => {
+                ty_param(_, p) => {
                     self.push_inherent_candidates_from_param(self_ty, p);
                 }
                 ty_self(..) => {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3917,7 +3917,7 @@ pub fn check_bounds_are_used(ccx: @mut CrateCtxt,
 
     ty::walk_ty(ty, |t| {
             match ty::get(t).sty {
-                ty::ty_param(param_ty {idx, ..}) => {
+                ty::ty_param(_, param_ty {idx, ..}) => {
                     debug!("Found use of ty param \\#{}", idx);
                     tps_used[idx] = true;
                 }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -247,7 +247,7 @@ fn lookup_vtable(vcx: &VtableContext,
     // If the type is self or a param, we look at the trait/supertrait
     // bounds to see if they include the trait we are looking for.
     let vtable_opt = match ty::get(ty).sty {
-        ty::ty_param(param_ty {idx: n, ..}) => {
+        ty::ty_param(_, param_ty {idx: n, ..}) => {
             let type_param_bounds: &[@ty::TraitRef] =
                 vcx.param_env.type_param_bounds[n].trait_bounds;
             lookup_vtable_from_bounds(vcx,

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -542,7 +542,7 @@ impl CoherenceChecker {
     pub fn ast_type_is_defined_in_local_crate(&self, original_type: &ast::Ty)
                                               -> bool {
         match original_type.node {
-            ty_path(_, _, path_id) => {
+            ty_path(_, _, _, path_id) => {
                 match self.crate_context.tcx.def_map.get_copy(&path_id) {
                     DefTy(def_id) | DefStruct(def_id) => {
                         if def_id.crate != LOCAL_CRATE {

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -482,7 +482,7 @@ pub fn super_tys<C:Combine>(this: &C, a: ty::t, b: ty::t) -> cres<ty::t> {
         }
       }
 
-      (&ty::ty_param(ref a_p), &ty::ty_param(ref b_p)) if a_p.idx == b_p.idx => {
+      (&ty::ty_param(false, ref a_p), &ty::ty_param(false, ref b_p)) if a_p.idx == b_p.idx => {
         Ok(a)
       }
 

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -659,7 +659,7 @@ impl<'self> ConstraintContext<'self> {
                                                  substs, variance);
             }
 
-            ty::ty_param(ty::param_ty { def_id: ref def_id, .. }) => {
+            ty::ty_param(_, ty::param_ty { def_id: ref def_id, .. }) => {
                 assert_eq!(def_id.crate, ast::LOCAL_CRATE);
                 match self.terms_cx.inferred_map.find(&def_id.node) {
                     Some(&index) => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -471,7 +471,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       }
       ty_infer(infer_ty) => infer_ty.to_str(),
       ty_err => ~"[type error]",
-      ty_param(param_ty {idx: id, def_id: did}) => {
+      ty_param(expand, param_ty {idx: id, def_id: did}) => {
           let param_def = cx.ty_param_defs.find(&did.node);
           let ident = match param_def {
               Some(def) => {
@@ -482,7 +482,8 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
                   format!("BUG[{:?}]", id)
               }
           };
-          if !cx.sess.verbose() { ident } else { format!("{}:{:?}", ident, did) }
+          let s = if !cx.sess.verbose() { ident } else { format!("{}:{:?}", ident, did) };
+          if expand { ".." + s } else { s }
       }
       ty_self(..) => ~"Self",
       ty_enum(did, ref substs) | ty_struct(did, ref substs) => {

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -628,8 +628,8 @@ impl Clean<Type> for ast::Ty {
             ty_vec(ref m) => Vector(~m.ty.clean()),
             ty_fixed_length_vec(ref m, ref e) => FixedVector(~m.ty.clean(),
                                                              e.span.to_src()),
-            ty_tup(ref tys) => Tuple(tys.iter().map(|x| x.clean()).collect()),
-            ty_path(ref p, ref tpbs, id) =>
+            ty_tup(false, ref tys) => Tuple(tys.iter().map(|x| x.clean()).collect()),
+            ty_path(false, ref p, ref tpbs, id) =>
                 resolve_type(p.clean(), tpbs.clean(), id),
             ty_closure(ref c) => Closure(~c.clean()),
             ty_bare_fn(ref barefn) => BareFunction(~barefn.clean()),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -882,8 +882,8 @@ pub enum ty_ {
     ty_rptr(Option<Lifetime>, mt),
     ty_closure(@TyClosure),
     ty_bare_fn(@TyBareFn),
-    ty_tup(~[P<Ty>]),
-    ty_path(Path, Option<OptVec<TyParamBound>>, NodeId), // for #7264; see above
+    ty_tup(bool /* expand */, ~[P<Ty>]),
+    ty_path(bool /* expand */, Path, Option<OptVec<TyParamBound>>, NodeId), // for #7264; see above
     ty_typeof(@Expr),
     // ty_infer means the type should be inferred instead of it having been
     // specified. This should only appear at the "top level" of a type and not

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -86,7 +86,7 @@ pub fn impl_pretty_name(trait_ref: &Option<trait_ref>,
                         ty: &Ty, default: Ident) -> path_elt {
     let itr = get_ident_interner();
     let ty_ident = match ty.node {
-        ty_path(ref path, _, _) => path.segments.last().identifier,
+        ty_path(_, ref path, _, _) => path.segments.last().identifier,
         _ => default
     };
     let hash = (trait_ref, ty).hash();

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -506,7 +506,7 @@ impl<'self, O: IdVisitingOperation> Visitor<()> for IdVisitor<'self, O> {
     fn visit_ty(&mut self, typ: &Ty, env: ()) {
         self.operation.visit_id(typ.id);
         match typ.node {
-            ty_path(_, _, id) => self.operation.visit_id(id),
+            ty_path(_, _, _, id) => self.operation.visit_id(id),
             _ => {}
         }
         visit::walk_ty(self, typ, env)

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -292,7 +292,7 @@ impl AstBuilder for @ExtCtxt {
     fn ty_path(&self, path: ast::Path, bounds: Option<OptVec<ast::TyParamBound>>)
               -> P<ast::Ty> {
         self.ty(path.span,
-                ast::ty_path(path, bounds, ast::DUMMY_NODE_ID))
+                ast::ty_path(false, path, bounds, ast::DUMMY_NODE_ID))
     }
 
     // Might need to take bounds as an argument in the future, if you ever want

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -155,7 +155,7 @@ impl<'self> Ty<'self> {
                 let ty = if fields.is_empty() {
                     ast::ty_nil
                 } else {
-                    ast::ty_tup(fields.map(|f| f.to_ty(cx, span, self_ty, self_generics)))
+                    ast::ty_tup(false, fields.map(|f| f.to_ty(cx, span, self_ty, self_generics)))
                 };
 
                 cx.ty(span, ty)

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -266,9 +266,9 @@ pub trait ast_fold {
                     decl: fold_fn_decl(f.decl, self)
                 })
             }
-            ty_tup(ref tys) => ty_tup(tys.map(|&ty| self.fold_ty(ty))),
-            ty_path(ref path, ref bounds, id) => {
-                ty_path(self.fold_path(path),
+            ty_tup(expand, ref tys) => ty_tup(expand, tys.map(|&ty| self.fold_ty(ty))),
+            ty_path(expand, ref path, ref bounds, id) => {
+                ty_path(expand, self.fold_path(path),
                         fold_opt_bounds(bounds, self),
                         self.new_id(id))
             }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -658,7 +658,7 @@ mod test {
                             node: ast::item_fn(ast::P(ast::fn_decl{
                                 inputs: ~[ast::arg{
                                     ty: ast::P(ast::Ty{id: ast::DUMMY_NODE_ID,
-                                                       node: ast::ty_path(ast::Path{
+                                                       node: ast::ty_path(false, ast::Path{
                                         span:sp(10,13),
                                         global:false,
                                         segments: ~[

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -416,7 +416,10 @@ pub fn print_type(s: @ps, ty: &ast::Ty) {
           print_opt_lifetime(s, lifetime);
           print_mt(s, mt);
       }
-      ast::ty_tup(ref elts) => {
+      ast::ty_tup(expand, ref elts) => {
+        if expand {
+            word(s.s, "..");
+        }
         popen(s);
         commasep(s, inconsistent, *elts, print_type_ref);
         if elts.len() == 1 {
@@ -442,7 +445,12 @@ pub fn print_type(s: @ps, ty: &ast::Ty) {
                       f.purity, f.onceness, f.decl, None, &f.bounds,
                       Some(&generics), None);
       }
-      ast::ty_path(ref path, ref bounds, _) => print_bounded_path(s, path, bounds),
+      ast::ty_path(expand, ref path, ref bounds, _) => {
+        if expand {
+            word(s.s, "..");
+        }
+        print_bounded_path(s, path, bounds);
+      }
       ast::ty_fixed_length_vec(ref mt, v) => {
         word(s.s, "[");
         match mt.mutbl {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -303,7 +303,8 @@ pub fn walk_ty<E:Clone, V:Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
             visitor.visit_opt_lifetime_ref(typ.span, lifetime, env.clone());
             visitor.visit_ty(mutable_type.ty, env)
         }
-        ty_tup(ref tuple_element_types) => {
+        ty_tup(_expand, ref tuple_element_types) => {
+            // FIXME(eddyb) #10769 what to do with expand?
             for &tuple_element_type in tuple_element_types.iter() {
                 visitor.visit_ty(tuple_element_type, env.clone())
             }
@@ -331,7 +332,8 @@ pub fn walk_ty<E:Clone, V:Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
             walk_lifetime_decls(visitor, &function_declaration.lifetimes,
                                 env.clone());
         }
-        ty_path(ref path, ref bounds, _) => {
+        ty_path(_expand, ref path, ref bounds, _) => {
+            // FIXME(eddyb) #10769 what to do with expand?
             walk_path(visitor, path, env.clone());
             for bounds in bounds.iter() {
                 walk_ty_param_bounds(visitor, bounds, env.clone())

--- a/src/test/compile-fail/tuple-expansion-enum.rs
+++ b/src/test/compile-fail/tuple-expansion-enum.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum MaybeTup<T> {
+    SomeTup(..T), //~ ERROR cannot expand non-tuple type `T`
+    NoTup
+}
+
+fn main() {}

--- a/src/test/compile-fail/tuple-expansion-fn.rs
+++ b/src/test/compile-fail/tuple-expansion-fn.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot expand non-tuple type `..U`
+
+// FIXME(eddyb) #10769 these generic substitution errors don't have spans.
+fn foo<T, U>(_: (T, ..U, T)) {}
+
+fn main() {}

--- a/src/test/compile-fail/tuple-expansion-generic.rs
+++ b/src/test/compile-fail/tuple-expansion-generic.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+type Pair<T, U> = (T, U);
+type MaybePair<T> = Pair<..T>; //~ ERROR wrong number of type arguments: expected 2 but found 1
+
+fn main() {}

--- a/src/test/compile-fail/tuple-expansion-impl.rs
+++ b/src/test/compile-fail/tuple-expansion-impl.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot expand non-tuple type `..T`
+
+trait Tuple {}
+
+// FIXME(eddyb) #10769 these generic substitution errors don't have spans.
+impl<T> Tuple for (..T) {}
+//^ ERROR cannot determine a type for this bounded type parameter: unconstrained type
+
+fn main() {}

--- a/src/test/compile-fail/tuple-expansion-parse-type.rs
+++ b/src/test/compile-fail/tuple-expansion-parse-type.rs
@@ -1,0 +1,23 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+type A = (
+    ..(u8, i8),
+    ..~(u8, i8), //~ ERROR expected tuple or path after `..`
+    ..*(u8, i8), //~ ERROR expected tuple or path after `..`
+    ..&(u8, i8), //~ ERROR expected tuple or path after `..`
+    ..[int], //~ ERROR expected tuple or path after `..`
+    ..[int, ..5], //~ ERROR expected tuple or path after `..`
+    ..fn(u8, i8) -> int, //~ ERROR expected tuple or path after `..`
+    ..|u8, i8| -> int, //~ ERROR expected tuple or path after `..`
+    ..proc(u8, i8) -> int //~ ERROR expected tuple or path after `..`
+);
+
+type B<T> = ..T; //~ ERROR expected type, found token DOTDOT

--- a/src/test/compile-fail/tuple-expansion-struct.rs
+++ b/src/test/compile-fail/tuple-expansion-struct.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Tuple<T>(..T); //~ ERROR cannot expand non-tuple type `T`
+
+fn main() {}

--- a/src/test/run-pass/tuple-expansion-type.rs
+++ b/src/test/run-pass/tuple-expansion-type.rs
@@ -1,0 +1,49 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(macro_rules)];
+
+fn same_type<T>(_: Option<T>, _: Option<T>) {}
+
+macro_rules! ty_eq(
+    ($T:ty, $U:ty) => (same_type(None::<$T>, None::<$U>))
+)
+
+fn main() {
+    type A = (..(u8, i8));
+    ty_eq!(A, (u8, i8));
+
+    type B = (..((u8, i8)));
+    ty_eq!(B, (u8, i8));
+
+    type C = fn(..(u8, i8)) -> int;
+    ty_eq!(C, fn(u8, i8) -> int);
+
+    type D = 'static|..(u8, i8)| -> int;
+    ty_eq!(D, 'static|u8, i8| -> int);
+
+    type E = proc(..(u8, i8)) -> int;
+    ty_eq!(E, proc(u8, i8) -> int);
+
+    type F<T, U> = (T, U, T);
+    ty_eq!(F<char, int>, (char, int, char));
+
+    type G = (..F<..(u8, i8)>);
+    ty_eq!(G, (u8, i8, u8));
+
+    type TupleWrap<T, U> = (T, ..U, T);
+    ty_eq!(TupleWrap<char, (u8, i8)>, (char, u8, i8, char));
+
+    type I<T, U> = (T, ..F<T, U>, T);
+    ty_eq!(I<char, (u8, i8)>, (char, char, (u8, i8), char, char));
+
+    type TupleConcat<T, U> = (..T, ..U);
+    ty_eq!(TupleConcat<(char, int), (u8, i8)>, (char, int, u8, i8));
+}


### PR DESCRIPTION
First part in implementing #10124, `..T` with `T` a tuple type, with only one structural change to `middle::ty`.

cc @nikomatsakis @pnkfelix @pcwalton
