### PR TITLE
Declare librustrt a static dependency of libextra

### DIFF
--- a/src/libextra/flate.rs
+++ b/src/libextra/flate.rs
@@ -23,7 +23,7 @@ use std::vec;
 pub mod rustrt {
     use std::libc::{c_int, c_void, size_t};
 
-    #[link(name = "rustrt")]
+    #[link(name = "rustrt", kind = "static")]
     extern {
         pub fn tdefl_compress_mem_to_heap(psrc_buf: *c_void,
                                           src_buf_len: size_t,


### PR DESCRIPTION
This wasn't uncovered during testing because the librustrt is available locally
in the build directory (and it needs to be for all the tests to link against it
as well).

Closes #10765
