### PR TITLE
Make the ccache-free case look like the ccache case. 

### DIFF
--- a/configure
+++ b/configure
@@ -893,11 +893,11 @@ do
             LLVM_CC_64="ccache clang -Qunused-arguments"
             ;;
             ("clang")
-            LLVM_CXX_32="clang++ -m32"
-            LLVM_CC_32="clang -m32"
+            LLVM_CXX_32="clang++ -m32 -Qunused-arguments"
+            LLVM_CC_32="clang -m32 -Qunused-arguments"
 
-            LLVM_CXX_64="clang++"
-            LLVM_CC_64="clang"
+            LLVM_CXX_64="clang++ -Qunused-arguments"
+            LLVM_CC_64="clang -Qunused-arguments"
             ;;
             ("ccache gcc")
             LLVM_CXX_32="ccache g++ -m32"

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -88,14 +88,15 @@ AR := ar
 
 CFG_INFO := $(info cfg: using $(CFG_C_COMPILER))
 ifeq ($(CFG_C_COMPILER),clang)
+  # The -Qunused-arguments sidesteps spurious warnings from clang
   ifeq ($(origin CC),default)
-    CC=clang
+    CC=clang -Qunused-arguments
   endif
   ifeq ($(origin CXX),default)
-    CXX=clang++
+    CXX=clang++ -Qunused-arguments
   endif
   ifeq ($(origin CPP),default)
-    CPP=clang
+    CPP=clang -Qunused-arguments
   endif
 else
 ifeq ($(CFG_C_COMPILER),gcc)


### PR DESCRIPTION
 This fixes a problem with `make check` clang -Werror failing due to an unused -Llib arg.
