### PR TITLE
Add section on closure types to manual

### DIFF
--- a/doc/rust.md
+++ b/doc/rust.md
@@ -3193,6 +3193,32 @@ let bo: Binop = add;
 x = bo(5,7);
 ~~~~
 
+### Closure types
+
+The type of a closure mapping an input of type `A` to an output of type `B` is `|A| -> B`. A closure with no arguments or return values has type `||`.
+
+
+An example of creating and calling a closure:
+
+```rust
+let captured_var = 10; 
+
+let closure_no_args = || println!("captured_var={}", captured_var); 
+
+let closure_args = |arg: int| -> int {
+  println!("captured_var={}, arg={}", captured_var, arg); 
+  arg // Note lack of semicolon after 'arg'
+};
+
+fn call_closure(c1: ||, c2: |int| -> int) {
+  c1();
+  c2(2);
+}
+
+call_closure(closure_no_args, closure_args);
+
+```
+
 ### Object types
 
 Every trait item (see [traits](#traits)) defines a type with the same name as the trait.


### PR DESCRIPTION
The section on closure types was missing, so I added one. I'm new to Rust, so there are probably important things to say about closure types that I'm missing here.

I tested the example with the latest Rust nightly.
