### PR TITLE
rustdoc: Tell rustc we're building a library

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -51,6 +51,7 @@ fn get_ast_and_resolve(cpath: &Path,
         binary: @"rustdoc",
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: @mut libs,
+        outputs: ~[driver::session::OutputDylib],
         .. (*rustc::driver::session::basic_options()).clone()
     };
 


### PR DESCRIPTION
This makes sure that when generating documentation we don't waste time doing
things like looking for a main function.
