### PR TITLE
Rename std::util::ignore to std::util::drop

### DIFF
--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -77,8 +77,8 @@ impl RtioTimer for TimerWatcher {
         let _missile = match util::replace(&mut self.action, None) {
             None => missile, // no need to do a homing dance
             Some(action) => {
-                util::ignore(missile);      // un-home ourself
-                util::ignore(action);       // destroy the previous action
+                drop(missile);      // un-home ourself
+                drop(action);       // destroy the previous action
                 self.fire_homing_missile()  // re-home ourself
             }
         };

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -26,7 +26,6 @@ use std::libc::{O_CREAT, O_APPEND, O_TRUNC, O_RDWR, O_RDONLY, O_WRONLY,
 use std::io::{FileMode, FileAccess, Open, Append, Truncate, Read, Write,
                   ReadWrite, FileStat};
 use std::io::signal::Signum;
-use std::util;
 use ai = std::io::net::addrinfo;
 
 #[cfg(test)] use std::unstable::run_in_bare_thread;
@@ -104,7 +103,7 @@ impl HomingMissile {
 
 impl Drop for HomingMissile {
     fn drop(&mut self) {
-        let f = ForbidUnwind::new("leaving home");
+        let _f = ForbidUnwind::new("leaving home");
 
         // It would truly be a sad day if we had moved off the home I/O
         // scheduler while we were doing I/O.
@@ -120,8 +119,6 @@ impl Drop for HomingMissile {
                 });
             })
         }
-
-        util::ignore(f);
     }
 }
 

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1179,7 +1179,7 @@ mod test {
         file.write(bytes!("foo"));
         file.fsync();
         file.datasync();
-        util::ignore(file);
+        drop(file);
     })
 
     test!(fn truncate_works() {
@@ -1210,7 +1210,7 @@ mod test {
         assert_eq!(stat(&path).size, 9);
         assert_eq!(File::open(&path).read_to_end(),
                    (bytes!("fo", 0, 0, 0, 0, "wut")).to_owned());
-        util::ignore(file);
+        drop(file);
     })
 
     test!(fn open_flavors() {

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -86,3 +86,7 @@ pub use vec::{Vector, VectorVector, CopyableVector, ImmutableVector};
 // Reexported runtime types
 pub use comm::{stream, Port, Chan, GenericChan, GenericSmartChan, GenericPort, Peekable};
 pub use task::spawn;
+
+/// Disposes of a value.
+#[inline]
+pub fn drop<T>(_x: T) { }

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -1173,7 +1173,6 @@ mod test {
         use rt::sleeper_list::SleeperList;
         use rt::stack::StackPool;
         use rt::sched::{Shutdown, TaskFromFriend};
-        use util;
 
         do run_in_bare_thread {
             stress_factor().times(|| {
@@ -1205,7 +1204,7 @@ mod test {
                 handle.send(TaskFromFriend(task));
 
                 handle.send(Shutdown);
-                util::ignore(handle);
+                drop(handle);
 
                 thread.join();
             })

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -467,7 +467,6 @@ mod tests {
     use prelude::*;
     use super::{Exclusive, UnsafeArc, atomically};
     use task;
-    use util;
     use mem::size_of;
 
     //#[unsafe_no_drop_flag] FIXME: #9758
@@ -571,7 +570,7 @@ mod tests {
         let x2 = x.clone();
         let left_x = x.try_unwrap();
         assert!(left_x.is_self());
-        util::ignore(left_x);
+        drop(left_x);
         assert!(x2.try_unwrap().expect_t("try_unwrap none") == ~~"hello");
     }
 
@@ -590,7 +589,7 @@ mod tests {
         task::deschedule(); // Try to make the unwrapper get blocked first.
         let left_x = x.try_unwrap();
         assert!(left_x.is_self());
-        util::ignore(left_x);
+        drop(left_x);
         p.recv();
     }
 
@@ -620,7 +619,7 @@ mod tests {
             assert!(x2.unwrap() == ~~"hello");
         }
         // Have to get rid of our reference before blocking.
-        util::ignore(x);
+        drop(x);
         res.recv();
     }
 

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -19,10 +19,6 @@ use unstable::intrinsics;
 #[inline]
 pub fn id<T>(x: T) -> T { x }
 
-/// Ignores a value.
-#[inline]
-pub fn ignore<T>(_x: T) { }
-
 /**
  * Swap the values at two mutable locations of the same type, without
  * deinitialising or copying either one.

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -63,7 +63,7 @@ mod bar {
 fn main() {
     cal(foo::Point{x:3, y:9});
     let a = 3;
-    ignore(a);
+    id(a);
     test::C.b();
     let _a = from_elem(0, 0);
 }

--- a/src/test/compile-fail/once-cant-call-twice-on-heap.rs
+++ b/src/test/compile-fail/once-cant-call-twice-on-heap.rs
@@ -14,7 +14,6 @@
 #[feature(once_fns)];
 extern mod extra;
 use extra::arc;
-use std::util;
 
 fn foo(blk: proc()) {
     blk();
@@ -25,6 +24,6 @@ fn main() {
     let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
-        util::ignore(x);
+        drop(x);
     }
 }

--- a/src/test/compile-fail/once-cant-call-twice-on-stack.rs
+++ b/src/test/compile-fail/once-cant-call-twice-on-stack.rs
@@ -14,7 +14,6 @@
 #[feature(once_fns)];
 extern mod extra;
 use extra::arc;
-use std::util;
 
 fn foo(blk: once ||) {
     blk();
@@ -25,6 +24,6 @@ fn main() {
     let x = arc::Arc::new(true);
     foo(|| {
         assert!(*x.get());
-        util::ignore(x);
+        drop(x);
     })
 }

--- a/src/test/compile-fail/once-cant-move-out-of-non-once-on-stack.rs
+++ b/src/test/compile-fail/once-cant-move-out-of-non-once-on-stack.rs
@@ -13,7 +13,6 @@
 
 extern mod extra;
 use extra::arc;
-use std::util;
 
 fn foo(blk: ||) {
     blk();
@@ -24,6 +23,6 @@ fn main() {
     let x = arc::Arc::new(true);
     foo(|| {
         assert!(*x.get());
-        util::ignore(x); //~ ERROR cannot move out of captured outer variable
+        drop(x); //~ ERROR cannot move out of captured outer variable
     })
 }

--- a/src/test/run-pass/once-move-out-on-heap.rs
+++ b/src/test/run-pass/once-move-out-on-heap.rs
@@ -15,7 +15,6 @@
 #[feature(once_fns)];
 extern mod extra;
 use extra::arc;
-use std::util;
 
 fn foo(blk: proc()) {
     blk();
@@ -25,6 +24,6 @@ fn main() {
     let x = arc::Arc::new(true);
     do foo {
         assert!(*x.get());
-        util::ignore(x);
+        drop(x);
     }
 }

--- a/src/test/run-pass/once-move-out-on-stack.rs
+++ b/src/test/run-pass/once-move-out-on-stack.rs
@@ -15,7 +15,6 @@
 #[feature(once_fns)];
 extern mod extra;
 use extra::arc;
-use std::util;
 
 fn foo(blk: once ||) {
     blk();
@@ -25,6 +24,6 @@ fn main() {
     let x = arc::Arc::new(true);
     foo(|| {
         assert!(*x.get());
-        util::ignore(x);
+        drop(x);
     })
 }


### PR DESCRIPTION
It's a more fitting name for the most common use case of this function.
