### PR TITLE
Fix a bug in exporting trait implementations

### DIFF
--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -243,7 +243,7 @@ impl<'self> Visitor<()> for EmbargoVisitor<'self> {
                             ast::sty_static => public_ty,
                             _ => true,
                         } && method.vis == ast::public;
-                        if meth_public || public_trait {
+                        if meth_public || tr.is_some() {
                             self.exported_items.insert(method.id);
                         }
                     }

--- a/src/test/auxiliary/priv-impl-prim-ty.rs
+++ b/src/test/auxiliary/priv-impl-prim-ty.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait A {
+    fn frob(&self);
+}
+
+impl A for int { fn frob(&self) {} }
+
+pub fn frob<T:A>(t: T) {
+    t.frob();
+}

--- a/src/test/run-pass/priv-impl-prim-ty.rs
+++ b/src/test/run-pass/priv-impl-prim-ty.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:priv-impl-prim-ty.rs
+
+extern mod bar(name = "priv-impl-prim-ty");
+
+fn main() {
+    bar::frob(1i);
+
+}


### PR DESCRIPTION
I used the wrong condition where I was looking for "is this method public or is
this implementation a trait" rather than what was being checked.
