### PR TITLE
Don't infinitely recurse in a process test

### DIFF
--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -25,6 +25,7 @@ fn main () {
         for _ in range(0, 1000) {
             println!("hello?");
         }
+        return;
     }
 
     let config = process::ProcessConfig {


### PR DESCRIPTION
Note entirely sure how this is passing at all today, but regardless this fixes
the problems seen in #10790 

Closes #10790
