### PR TITLE
Revert new naming

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -103,15 +103,15 @@ pub fn parse_config(args: ~[~str]) -> config {
     }
 
     fn opt_path(m: &getopts::Matches, nm: &str) -> Path {
-        Path::init(m.opt_str(nm).unwrap())
+        Path::new(m.opt_str(nm).unwrap())
     }
 
     config {
         compile_lib_path: matches.opt_str("compile-lib-path").unwrap(),
         run_lib_path: matches.opt_str("run-lib-path").unwrap(),
         rustc_path: opt_path(matches, "rustc-path"),
-        clang_path: matches.opt_str("clang-path").map(|s| Path::init(s)),
-        llvm_bin_path: matches.opt_str("llvm-bin-path").map(|s| Path::init(s)),
+        clang_path: matches.opt_str("clang-path").map(|s| Path::new(s)),
+        llvm_bin_path: matches.opt_str("llvm-bin-path").map(|s| Path::new(s)),
         src_base: opt_path(matches, "src-base"),
         build_base: opt_path(matches, "build-base"),
         aux_base: opt_path(matches, "aux-base"),
@@ -124,10 +124,10 @@ pub fn parse_config(args: ~[~str]) -> config {
             } else {
                 None
             },
-        logfile: matches.opt_str("logfile").map(|s| Path::init(s)),
-        save_metrics: matches.opt_str("save-metrics").map(|s| Path::init(s)),
+        logfile: matches.opt_str("logfile").map(|s| Path::new(s)),
+        save_metrics: matches.opt_str("save-metrics").map(|s| Path::new(s)),
         ratchet_metrics:
-            matches.opt_str("ratchet-metrics").map(|s| Path::init(s)),
+            matches.opt_str("ratchet-metrics").map(|s| Path::new(s)),
         ratchet_noise_percent:
             matches.opt_str("ratchet-noise-percent").and_then(|s| from_str::<f64>(s)),
         runtool: matches.opt_str("runtool"),

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -160,10 +160,10 @@ fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {
 
 fn parse_pp_exact(line: &str, testfile: &Path) -> Option<Path> {
     match parse_name_value_directive(line, ~"pp-exact") {
-      Some(s) => Some(Path::init(s)),
+      Some(s) => Some(Path::new(s)),
       None => {
         if parse_name_directive(line, "pp-exact") {
-            testfile.filename().map(|s| Path::init(s))
+            testfile.filename().map(|s| Path::new(s))
         } else {
             None
         }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -45,7 +45,7 @@ pub fn run_metrics(config: config, testfile: ~str, mm: &mut MetricMap) {
         // We're going to be dumping a lot of info. Start on a new line.
         print!("\n\n");
     }
-    let testfile = Path::init(testfile);
+    let testfile = Path::new(testfile);
     debug!("running {}", testfile.display());
     let props = load_props(&testfile);
     debug!("loaded props");
@@ -852,7 +852,7 @@ fn aux_output_dir_name(config: &config, testfile: &Path) -> Path {
 }
 
 fn output_testname(testfile: &Path) -> Path {
-    Path::init(testfile.filestem().unwrap())
+    Path::new(testfile.filestem().unwrap())
 }
 
 fn output_base_name(config: &config, testfile: &Path) -> Path {

--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -90,7 +90,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> GlobIterator {
 
     // calculate root this way to handle volume-relative Windows paths correctly
     let mut root = os::getcwd();
-    let pat_root = Path::init(pattern).root_path();
+    let pat_root = Path::new(pattern).root_path();
     if pat_root.is_some() {
         if check_windows_verbatim(pat_root.get_ref()) {
             // XXX: How do we want to handle verbatim paths? I'm inclined to return nothing,
@@ -766,9 +766,9 @@ mod test {
 
     #[test]
     fn test_matches_path() {
-        // on windows, (Path::init("a/b").as_str().unwrap() == "a\\b"), so this
+        // on windows, (Path::new("a/b").as_str().unwrap() == "a\\b"), so this
         // tests that / and \ are considered equivalent on windows
-        assert!(Pattern::new("a/b").matches_path(&Path::init("a/b")));
+        assert!(Pattern::new("a/b").matches_path(&Path::new("a/b")));
     }
 }
 

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -91,7 +91,7 @@ pub struct Encoder<'self> {
 impl<'self> Encoder<'self> {
     /// Creates a new JSON encoder whose output will be written to the writer
     /// specified.
-    pub fn init<'a>(wr: &'a mut io::Writer) -> Encoder<'a> {
+    pub fn new<'a>(wr: &'a mut io::Writer) -> Encoder<'a> {
         Encoder { wr: wr }
     }
 }
@@ -247,7 +247,7 @@ pub struct PrettyEncoder<'self> {
 
 impl<'self> PrettyEncoder<'self> {
     /// Creates a new encoder whose output will be written to the specified writer
-    pub fn init<'a>(wr: &'a mut io::Writer) -> PrettyEncoder<'a> {
+    pub fn new<'a>(wr: &'a mut io::Writer) -> PrettyEncoder<'a> {
         PrettyEncoder {
             wr: wr,
             indent: 0,
@@ -449,14 +449,14 @@ impl<E: serialize::Encoder> serialize::Encodable<E> for Json {
 impl Json{
     /// Encodes a json value into a io::writer.  Uses a single line.
     pub fn to_writer(&self, wr: &mut io::Writer) {
-        let mut encoder = Encoder::init(wr);
+        let mut encoder = Encoder::new(wr);
         self.encode(&mut encoder)
     }
 
     /// Encodes a json value into a io::writer.
     /// Pretty-prints in a more readable format.
     pub fn to_pretty_writer(&self, wr: &mut io::Writer) {
-        let mut encoder = PrettyEncoder::init(wr);
+        let mut encoder = PrettyEncoder::new(wr);
         self.encode(&mut encoder)
     }
 
@@ -477,7 +477,7 @@ pub struct Parser<T> {
 
 impl<T: Iterator<char>> Parser<T> {
     /// Decode a json value from an Iterator<char>
-    pub fn init(rdr: T) -> Parser<T> {
+    pub fn new(rdr: T) -> Parser<T> {
         let mut p = Parser {
             rdr: rdr,
             ch: '\x00',
@@ -848,13 +848,13 @@ impl<T : Iterator<char>> Parser<T> {
 /// Decodes a json value from an `&mut io::Reader`
 pub fn from_reader(rdr: &mut io::Reader) -> Result<Json, Error> {
     let s = str::from_utf8_owned(rdr.read_to_end());
-    let mut parser = Parser::init(s.chars());
+    let mut parser = Parser::new(s.chars());
     parser.parse()
 }
 
 /// Decodes a json value from a string
 pub fn from_str(s: &str) -> Result<Json, Error> {
-    let mut parser = Parser::init(s.chars());
+    let mut parser = Parser::new(s.chars());
     parser.parse()
 }
 
@@ -865,7 +865,7 @@ pub struct Decoder {
 
 impl Decoder {
     /// Creates a new decoder instance for decoding the specified JSON value.
-    pub fn init(json: Json) -> Decoder {
+    pub fn new(json: Json) -> Decoder {
         Decoder {
             stack: ~[json]
         }
@@ -1522,14 +1522,14 @@ mod tests {
         let animal = Dog;
         assert_eq!(
             with_str_writer(|wr| {
-                let mut encoder = Encoder::init(wr);
+                let mut encoder = Encoder::new(wr);
                 animal.encode(&mut encoder);
             }),
             ~"\"Dog\""
         );
         assert_eq!(
             with_str_writer(|wr| {
-                let mut encoder = PrettyEncoder::init(wr);
+                let mut encoder = PrettyEncoder::new(wr);
                 animal.encode(&mut encoder);
             }),
             ~"\"Dog\""
@@ -1538,14 +1538,14 @@ mod tests {
         let animal = Frog(~"Henry", 349);
         assert_eq!(
             with_str_writer(|wr| {
-                let mut encoder = Encoder::init(wr);
+                let mut encoder = Encoder::new(wr);
                 animal.encode(&mut encoder);
             }),
             ~"{\"variant\":\"Frog\",\"fields\":[\"Henry\",349]}"
         );
         assert_eq!(
             with_str_writer(|wr| {
-                let mut encoder = PrettyEncoder::init(wr);
+                let mut encoder = PrettyEncoder::new(wr);
                 animal.encode(&mut encoder);
             }),
             ~"\
@@ -1561,14 +1561,14 @@ mod tests {
     fn test_write_some() {
         let value = Some(~"jodhpurs");
         let s = with_str_writer(|wr| {
-            let mut encoder = Encoder::init(wr);
+            let mut encoder = Encoder::new(wr);
             value.encode(&mut encoder);
         });
         assert_eq!(s, ~"\"jodhpurs\"");
 
         let value = Some(~"jodhpurs");
         let s = with_str_writer(|wr| {
-            let mut encoder = PrettyEncoder::init(wr);
+            let mut encoder = PrettyEncoder::new(wr);
             value.encode(&mut encoder);
         });
         assert_eq!(s, ~"\"jodhpurs\"");
@@ -1578,13 +1578,13 @@ mod tests {
     fn test_write_none() {
         let value: Option<~str> = None;
         let s = with_str_writer(|wr| {
-            let mut encoder = Encoder::init(wr);
+            let mut encoder = Encoder::new(wr);
             value.encode(&mut encoder);
         });
         assert_eq!(s, ~"null");
 
         let s = with_str_writer(|wr| {
-            let mut encoder = Encoder::init(wr);
+            let mut encoder = Encoder::new(wr);
             value.encode(&mut encoder);
         });
         assert_eq!(s, ~"null");
@@ -1633,15 +1633,15 @@ mod tests {
 
     #[test]
     fn test_decode_identifiers() {
-        let mut decoder = Decoder::init(from_str("null").unwrap());
+        let mut decoder = Decoder::new(from_str("null").unwrap());
         let v: () = Decodable::decode(&mut decoder);
         assert_eq!(v, ());
 
-        let mut decoder = Decoder::init(from_str("true").unwrap());
+        let mut decoder = Decoder::new(from_str("true").unwrap());
         let v: bool = Decodable::decode(&mut decoder);
         assert_eq!(v, true);
 
-        let mut decoder = Decoder::init(from_str("false").unwrap());
+        let mut decoder = Decoder::new(from_str("false").unwrap());
         let v: bool = Decodable::decode(&mut decoder);
         assert_eq!(v, false);
     }
@@ -1676,31 +1676,31 @@ mod tests {
 
     #[test]
     fn test_decode_numbers() {
-        let mut decoder = Decoder::init(from_str("3").unwrap());
+        let mut decoder = Decoder::new(from_str("3").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, 3.0);
 
-        let mut decoder = Decoder::init(from_str("3.1").unwrap());
+        let mut decoder = Decoder::new(from_str("3.1").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, 3.1);
 
-        let mut decoder = Decoder::init(from_str("-1.2").unwrap());
+        let mut decoder = Decoder::new(from_str("-1.2").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, -1.2);
 
-        let mut decoder = Decoder::init(from_str("0.4").unwrap());
+        let mut decoder = Decoder::new(from_str("0.4").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4);
 
-        let mut decoder = Decoder::init(from_str("0.4e5").unwrap());
+        let mut decoder = Decoder::new(from_str("0.4e5").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4e5);
 
-        let mut decoder = Decoder::init(from_str("0.4e15").unwrap());
+        let mut decoder = Decoder::new(from_str("0.4e15").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4e15);
 
-        let mut decoder = Decoder::init(from_str("0.4e-01").unwrap());
+        let mut decoder = Decoder::new(from_str("0.4e-01").unwrap());
         let v: f64 = Decodable::decode(&mut decoder);
         assert_eq!(v, 0.4e-01);
     }
@@ -1728,39 +1728,39 @@ mod tests {
 
     #[test]
     fn test_decode_str() {
-        let mut decoder = Decoder::init(from_str("\"\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"");
 
-        let mut decoder = Decoder::init(from_str("\"foo\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"foo\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"foo");
 
-        let mut decoder = Decoder::init(from_str("\"\\\"\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\\"\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\"");
 
-        let mut decoder = Decoder::init(from_str("\"\\b\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\b\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\x08");
 
-        let mut decoder = Decoder::init(from_str("\"\\n\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\n\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\n");
 
-        let mut decoder = Decoder::init(from_str("\"\\r\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\r\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\r");
 
-        let mut decoder = Decoder::init(from_str("\"\\t\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\t\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\t");
 
-        let mut decoder = Decoder::init(from_str("\"\\u12ab\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\u12ab\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\u12ab");
 
-        let mut decoder = Decoder::init(from_str("\"\\uAB12\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"\\uAB12\"").unwrap());
         let v: ~str = Decodable::decode(&mut decoder);
         assert_eq!(v, ~"\uAB12");
     }
@@ -1793,27 +1793,27 @@ mod tests {
 
     #[test]
     fn test_decode_list() {
-        let mut decoder = Decoder::init(from_str("[]").unwrap());
+        let mut decoder = Decoder::new(from_str("[]").unwrap());
         let v: ~[()] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[]);
 
-        let mut decoder = Decoder::init(from_str("[null]").unwrap());
+        let mut decoder = Decoder::new(from_str("[null]").unwrap());
         let v: ~[()] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[()]);
 
-        let mut decoder = Decoder::init(from_str("[true]").unwrap());
+        let mut decoder = Decoder::new(from_str("[true]").unwrap());
         let v: ~[bool] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[true]);
 
-        let mut decoder = Decoder::init(from_str("[true]").unwrap());
+        let mut decoder = Decoder::new(from_str("[true]").unwrap());
         let v: ~[bool] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[true]);
 
-        let mut decoder = Decoder::init(from_str("[3, 1]").unwrap());
+        let mut decoder = Decoder::new(from_str("[3, 1]").unwrap());
         let v: ~[int] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[3, 1]);
 
-        let mut decoder = Decoder::init(from_str("[[3], [1, 2]]").unwrap());
+        let mut decoder = Decoder::new(from_str("[[3], [1, 2]]").unwrap());
         let v: ~[~[uint]] = Decodable::decode(&mut decoder);
         assert_eq!(v, ~[~[3], ~[1, 2]]);
     }
@@ -1915,7 +1915,7 @@ mod tests {
                 { \"a\": null, \"b\": 2, \"c\": [\"abc\", \"xyz\"] }
             ]
         }";
-        let mut decoder = Decoder::init(from_str(s).unwrap());
+        let mut decoder = Decoder::new(from_str(s).unwrap());
         let v: Outer = Decodable::decode(&mut decoder);
         assert_eq!(
             v,
@@ -1929,23 +1929,23 @@ mod tests {
 
     #[test]
     fn test_decode_option() {
-        let mut decoder = Decoder::init(from_str("null").unwrap());
+        let mut decoder = Decoder::new(from_str("null").unwrap());
         let value: Option<~str> = Decodable::decode(&mut decoder);
         assert_eq!(value, None);
 
-        let mut decoder = Decoder::init(from_str("\"jodhpurs\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"jodhpurs\"").unwrap());
         let value: Option<~str> = Decodable::decode(&mut decoder);
         assert_eq!(value, Some(~"jodhpurs"));
     }
 
     #[test]
     fn test_decode_enum() {
-        let mut decoder = Decoder::init(from_str("\"Dog\"").unwrap());
+        let mut decoder = Decoder::new(from_str("\"Dog\"").unwrap());
         let value: Animal = Decodable::decode(&mut decoder);
         assert_eq!(value, Dog);
 
         let s = "{\"variant\":\"Frog\",\"fields\":[\"Henry\",349]}";
-        let mut decoder = Decoder::init(from_str(s).unwrap());
+        let mut decoder = Decoder::new(from_str(s).unwrap());
         let value: Animal = Decodable::decode(&mut decoder);
         assert_eq!(value, Frog(~"Henry", 349));
     }
@@ -1953,7 +1953,7 @@ mod tests {
     #[test]
     fn test_decode_map() {
         let s = ~"{\"a\": \"Dog\", \"b\": {\"variant\":\"Frog\",\"fields\":[\"Henry\", 349]}}";
-        let mut decoder = Decoder::init(from_str(s).unwrap());
+        let mut decoder = Decoder::new(from_str(s).unwrap());
         let mut map: TreeMap<~str, Animal> = Decodable::decode(&mut decoder);
 
         assert_eq!(map.pop(&~"a"), Some(Dog));
@@ -1990,7 +1990,7 @@ mod tests {
             match from_str(to_parse) {
                 Err(e) => Some(e.to_str()),
                 Ok(json) => {
-                    let _: T = Decodable::decode(&mut Decoder::init(json));
+                    let _: T = Decodable::decode(&mut Decoder::new(json));
                     None
                 }
             }

--- a/src/libextra/terminfo/searcher.rs
+++ b/src/libextra/terminfo/searcher.rs
@@ -29,7 +29,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<~Path> {
 
     // Find search directory
     match getenv("TERMINFO") {
-        Some(dir) => dirs_to_search.push(Path::init(dir)),
+        Some(dir) => dirs_to_search.push(Path::new(dir)),
         None => {
             if homedir.is_some() {
                 // ncurses compatability;
@@ -38,17 +38,17 @@ pub fn get_dbpath_for_term(term: &str) -> Option<~Path> {
             match getenv("TERMINFO_DIRS") {
                 Some(dirs) => for i in dirs.split(':') {
                     if i == "" {
-                        dirs_to_search.push(Path::init("/usr/share/terminfo"));
+                        dirs_to_search.push(Path::new("/usr/share/terminfo"));
                     } else {
-                        dirs_to_search.push(Path::init(i.to_owned()));
+                        dirs_to_search.push(Path::new(i.to_owned()));
                     }
                 },
                 // Found nothing, use the default paths
                 // /usr/share/terminfo is the de facto location, but it seems
                 // Ubuntu puts it in /lib/terminfo
                 None => {
-                    dirs_to_search.push(Path::init("/usr/share/terminfo"));
-                    dirs_to_search.push(Path::init("/lib/terminfo"));
+                    dirs_to_search.push(Path::new("/usr/share/terminfo"));
+                    dirs_to_search.push(Path::new("/lib/terminfo"));
                 }
             }
         }

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -947,7 +947,7 @@ impl MetricMap {
         assert!(p.exists());
         let mut f = File::open(p);
         let value = json::from_reader(&mut f as &mut io::Reader).unwrap();
-        let mut decoder = json::Decoder::init(value);
+        let mut decoder = json::Decoder::new(value);
         MetricMap(Decodable::decode(&mut decoder))
     }
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -276,20 +276,20 @@ pub fn parse_opts(args: &[~str]) -> Option<OptRes> {
     let run_ignored = matches.opt_present("ignored");
 
     let logfile = matches.opt_str("logfile");
-    let logfile = logfile.map(|s| Path::init(s));
+    let logfile = logfile.map(|s| Path::new(s));
 
     let run_benchmarks = matches.opt_present("bench");
     let run_tests = ! run_benchmarks ||
         matches.opt_present("test");
 
     let ratchet_metrics = matches.opt_str("ratchet-metrics");
-    let ratchet_metrics = ratchet_metrics.map(|s| Path::init(s));
+    let ratchet_metrics = ratchet_metrics.map(|s| Path::new(s));
 
     let ratchet_noise_percent = matches.opt_str("ratchet-noise-percent");
     let ratchet_noise_percent = ratchet_noise_percent.map(|s| from_str::<f64>(s).unwrap());
 
     let save_metrics = matches.opt_str("save-metrics");
-    let save_metrics = save_metrics.map(|s| Path::init(s));
+    let save_metrics = save_metrics.map(|s| Path::new(s));
 
     let test_shard = matches.opt_str("test-shard");
     let test_shard = opt_shard(test_shard);

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -191,7 +191,7 @@ impl Database {
                     Err(e) => fail!("Couldn't parse workcache database (from file {}): {}",
                                     self.db_filename.display(), e.to_str()),
                     Ok(r) => {
-                        let mut decoder = json::Decoder::init(r);
+                        let mut decoder = json::Decoder::new(r);
                         self.db_cache = Decodable::decode(&mut decoder);
                     }
             }
@@ -258,7 +258,7 @@ enum Work<'self, T> {
 
 fn json_encode<'self, T:Encodable<json::Encoder<'self>>>(t: &T) -> ~str {
     let mut writer = MemWriter::new();
-    let mut encoder = json::Encoder::init(&mut writer as &mut io::Writer);
+    let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
     t.encode(&mut encoder);
     str::from_utf8_owned(writer.inner())
 }
@@ -267,7 +267,7 @@ fn json_encode<'self, T:Encodable<json::Encoder<'self>>>(t: &T) -> ~str {
 fn json_decode<T:Decodable<json::Decoder>>(s: &str) -> T {
     debug!("json decoding: {}", s);
     let j = json::from_str(s).unwrap();
-    let mut decoder = json::Decoder::init(j);
+    let mut decoder = json::Decoder::new(j);
     Decodable::decode(&mut decoder)
 }
 

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -70,10 +70,10 @@ impl Archive {
             let loc = TempDir::new("rsar").unwrap();
             let archive = os::make_absolute(&self.dst);
             run_ar(self.sess, "x", Some(loc.path()), [&archive,
-                                                      &Path::init(file)]);
+                                                      &Path::new(file)]);
             fs::File::open(&loc.path().join(file)).read_to_end()
         } else {
-            run_ar(self.sess, "p", None, [&self.dst, &Path::init(file)]).output
+            run_ar(self.sess, "p", None, [&self.dst, &Path::new(file)]).output
         }
     }
 

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -160,7 +160,7 @@ pub fn get_install_prefix_rpath(target_triple: &str) -> ~str {
     let install_prefix = env!("CFG_PREFIX");
 
     let tlib = filesearch::relative_target_lib_path(target_triple);
-    let mut path = Path::init(install_prefix);
+    let mut path = Path::new(install_prefix);
     path.push(&tlib);
     let path = os::make_absolute(&path);
     // FIXME (#9639): This needs to handle non-utf8 paths
@@ -195,7 +195,7 @@ mod test {
     #[test]
     fn test_prefix_rpath() {
         let res = get_install_prefix_rpath("triple");
-        let mut d = Path::init(env!("CFG_PREFIX"));
+        let mut d = Path::new(env!("CFG_PREFIX"));
         d.push("lib/rustc/triple/lib");
         debug!("test_prefix_path: {} vs. {}",
                res,
@@ -206,7 +206,7 @@ mod test {
     #[test]
     fn test_prefix_rpath_abs() {
         let res = get_install_prefix_rpath("triple");
-        assert!(Path::init(res).is_absolute());
+        assert!(Path::new(res).is_absolute());
     }
 
     #[test]
@@ -230,7 +230,7 @@ mod test {
     fn test_rpath_relative() {
       let o = abi::OsLinux;
       let res = get_rpath_relative_to_output(o,
-            &Path::init("bin/rustc"), &Path::init("lib/libstd.so"));
+            &Path::new("bin/rustc"), &Path::new("lib/libstd.so"));
       assert_eq!(res.as_slice(), "$ORIGIN/../lib");
     }
 
@@ -239,7 +239,7 @@ mod test {
     fn test_rpath_relative() {
         let o = abi::OsFreebsd;
         let res = get_rpath_relative_to_output(o,
-            &Path::init("bin/rustc"), &Path::init("lib/libstd.so"));
+            &Path::new("bin/rustc"), &Path::new("lib/libstd.so"));
         assert_eq!(res.as_slice(), "$ORIGIN/../lib");
     }
 
@@ -248,15 +248,15 @@ mod test {
     fn test_rpath_relative() {
         let o = abi::OsMacos;
         let res = get_rpath_relative_to_output(o,
-                                               &Path::init("bin/rustc"),
-                                               &Path::init("lib/libstd.so"));
+                                               &Path::new("bin/rustc"),
+                                               &Path::new("lib/libstd.so"));
         assert_eq!(res.as_slice(), "@loader_path/../lib");
     }
 
     #[test]
     fn test_get_absolute_rpath() {
-        let res = get_absolute_rpath(&Path::init("lib/libstd.so"));
-        let lib = os::make_absolute(&Path::init("lib"));
+        let res = get_absolute_rpath(&Path::new("lib/libstd.so"));
+        let lib = os::make_absolute(&Path::new("lib"));
         debug!("test_get_absolute_rpath: {} vs. {}",
                res.to_str(), lib.display());
 

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -725,7 +725,7 @@ pub fn build_session_options(binary: @str,
         } else if matches.opt_present("emit-llvm") {
             link::output_type_bitcode
         } else { link::output_type_exe };
-    let sysroot_opt = matches.opt_str("sysroot").map(|m| @Path::init(m));
+    let sysroot_opt = matches.opt_str("sysroot").map(|m| @Path::new(m));
     let target = matches.opt_str("target").unwrap_or(host_triple());
     let target_cpu = matches.opt_str("target-cpu").unwrap_or(~"generic");
     let target_feature = matches.opt_str("target-feature").unwrap_or(~"");
@@ -757,7 +757,7 @@ pub fn build_session_options(binary: @str,
         extra_debuginfo;
 
     let addl_lib_search_paths = matches.opt_strs("L").map(|s| {
-        Path::init(s.as_slice())
+        Path::new(s.as_slice())
     }).move_iter().collect();
     let ar = matches.opt_str("ar");
     let linker = matches.opt_str("linker");

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -249,7 +249,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
             let src = str::from_utf8_owned(io::stdin().read_to_end());
             str_input(src.to_managed())
         } else {
-            file_input(Path::init(ifile))
+            file_input(Path::new(ifile))
         }
       }
       _ => early_error(demitter, "multiple input filenames provided")
@@ -257,8 +257,8 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
 
     let sopts = build_session_options(binary, matches, demitter);
     let sess = build_session(sopts, demitter);
-    let odir = matches.opt_str("out-dir").map(|o| Path::init(o));
-    let ofile = matches.opt_str("o").map(|o| Path::init(o));
+    let odir = matches.opt_str("out-dir").map(|o| Path::new(o));
+    let ofile = matches.opt_str("o").map(|o| Path::new(o));
     let cfg = build_configuration(sess);
     let pretty = matches.opt_default("pretty", "normal").map(|a| {
         parse_pretty(sess, a)

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -134,7 +134,7 @@ fn visit_view_item(e: @mut Env, i: &ast::view_item) {
           let meta_items = match path_opt {
               None => meta_items.clone(),
               Some((p, _path_str_style)) => {
-                  let p_path = Path::init(p);
+                  let p_path = Path::new(p);
                   match p_path.filestem_str() {
                       None|Some("") =>
                           e.sess.span_bug(i.span, "Bad package path in `extern mod` item"),

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -145,7 +145,7 @@ pub fn search(filesearch: @FileSearch, pick: pick) {
 
 pub fn relative_target_lib_path(target_triple: &str) -> Path {
     let dir = libdir();
-    let mut p = Path::init(dir.as_slice());
+    let mut p = Path::new(dir.as_slice());
     assert!(p.is_relative());
     p.push("rustc");
     p.push(target_triple);
@@ -199,7 +199,7 @@ pub fn rust_path() -> ~[Path] {
         Some(env_path) => {
             let env_path_components: ~[&str] =
                 env_path.split_str(PATH_ENTRY_SEPARATOR).collect();
-            env_path_components.map(|&s| Path::init(s))
+            env_path_components.map(|&s| Path::new(s))
         }
         None => ~[]
     };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -336,7 +336,7 @@ fn mkdir(path: &Path) {
 /// static HTML tree.
 // FIXME (#9639): The closure should deal with &[u8] instead of &str
 fn clean_srcpath(src: &[u8], f: |&str|) {
-    let p = Path::init(src);
+    let p = Path::new(src);
     if p.as_vec() != bytes!(".") {
         for c in p.str_components().map(|x|x.unwrap()) {
             if ".." == c {
@@ -411,7 +411,7 @@ impl<'self> DocFolder for SourceCollector<'self> {
 impl<'self> SourceCollector<'self> {
     /// Renders the given filename into its corresponding HTML source file.
     fn emit_source(&mut self, filename: &str) -> bool {
-        let p = Path::init(filename);
+        let p = Path::new(filename);
 
         // Read the contents of the file
         let mut contents = ~[];

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -283,7 +283,7 @@ fn json_input(input: &str) -> Result<Output, ~str> {
             }
             let crate = match obj.pop(&~"crate") {
                 Some(json) => {
-                    let mut d = json::Decoder::init(json);
+                    let mut d = json::Decoder::new(json);
                     Decodable::decode(&mut d)
                 }
                 None => return Err(~"malformed json"),
@@ -314,7 +314,7 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
     let crate_json_str = {
         let mut w = MemWriter::new();
         {
-            let mut encoder = json::Encoder::init(&mut w as &mut io::Writer);
+            let mut encoder = json::Encoder::new(&mut w as &mut io::Writer);
             crate.encode(&mut encoder);
         }
         str::from_utf8_owned(w.inner())

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -140,13 +140,13 @@ pub fn main_args(args: &[~str]) -> int {
 
     info!("going to format");
     let started = time::precise_time_ns();
-    let output = matches.opt_str("o").map(|s| Path::init(s));
+    let output = matches.opt_str("o").map(|s| Path::new(s));
     match matches.opt_str("w") {
         Some(~"html") | None => {
-            html::render::run(crate, output.unwrap_or(Path::init("doc")))
+            html::render::run(crate, output.unwrap_or(Path::new("doc")))
         }
         Some(~"json") => {
-            json_output(crate, res, output.unwrap_or(Path::init("doc.json")))
+            json_output(crate, res, output.unwrap_or(Path::new("doc.json")))
         }
         Some(s) => {
             println!("unknown output format: {}", s);
@@ -194,9 +194,9 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
     let mut plugins = matches.opt_strs("plugins");
 
     // First, parse the crate and extract all relevant information.
-    let libs = Cell::new(matches.opt_strs("L").map(|s| Path::init(s.as_slice())));
+    let libs = Cell::new(matches.opt_strs("L").map(|s| Path::new(s.as_slice())));
     let cfgs = Cell::new(matches.opt_strs("cfg"));
-    let cr = Cell::new(Path::init(cratefile));
+    let cr = Cell::new(Path::new(cratefile));
     info!("starting to run rustc");
     let (crate, analysis) = do std::task::try {
         let cr = cr.take();
@@ -238,7 +238,7 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
 
     // Load all plugins/passes into a PluginManager
     let path = matches.opt_str("plugin-path").unwrap_or(~"/tmp/rustdoc_ng/plugins");
-    let mut pm = plugins::PluginManager::new(Path::init(path));
+    let mut pm = plugins::PluginManager::new(Path::new(path));
     for pass in passes.iter() {
         let plugin = match PASSES.iter().position(|&(p, _, _)| p == *pass) {
             Some(i) => PASSES[i].n1(),
@@ -262,7 +262,7 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
 /// This input format purely deserializes the json output file. No passes are
 /// run over the deserialized output.
 fn json_input(input: &str) -> Result<Output, ~str> {
-    let input = match File::open(&Path::init(input)) {
+    let input = match File::open(&Path::new(input)) {
         Some(f) => f,
         None => return Err(format!("couldn't open {} for reading", input)),
     };

--- a/src/librustpkg/api.rs
+++ b/src/librustpkg/api.rs
@@ -56,12 +56,12 @@ pub fn new_default_context(c: workcache::Context, p: Path) -> BuildContext {
 }
 
 fn file_is_fresh(path: &str, in_hash: &str) -> bool {
-    let path = Path::init(path);
+    let path = Path::new(path);
     path.exists() && in_hash == digest_file_with_date(&path)
 }
 
 fn binary_is_fresh(path: &str, in_hash: &str) -> bool {
-    let path = Path::init(path);
+    let path = Path::new(path);
     path.exists() && in_hash == digest_only_date(&path)
 }
 
@@ -189,7 +189,7 @@ pub fn my_workspace(context: &Context, package_name: &str) -> Path {
     let pkgid = PkgId::new(package_name);
     let workspaces = pkg_parent_workspaces(context, &pkgid);
     if workspaces.is_empty() {
-        bad_pkg_id.raise((Path::init(package_name), package_name.to_owned()));
+        bad_pkg_id.raise((Path::new(package_name), package_name.to_owned()));
     }
     workspaces[0]
 }

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -483,7 +483,7 @@ impl CtxMethods for BuildContext {
                     })
                 });
                 // We always *run* the package script
-                let (cfgs, hook_result) = PkgScript::run_custom(&Path::init(pkg_exe), &sysroot);
+                let (cfgs, hook_result) = PkgScript::run_custom(&Path::new(pkg_exe), &sysroot);
                 debug!("Command return code = {:?}", hook_result);
                 if !hook_result.success() {
                     fail!("Error running custom build command")
@@ -509,7 +509,7 @@ impl CtxMethods for BuildContext {
                 // Find crates inside the workspace
                 Everything => pkg_src.find_crates(),
                 // Find only tests
-                Tests => pkg_src.find_crates_with_filter(|s| { is_test(&Path::init(s)) }),
+                Tests => pkg_src.find_crates_with_filter(|s| { is_test(&Path::new(s)) }),
                 // Don't infer any crates -- just build the one that was requested
                 JustOne(ref p) => {
                     // We expect that p is relative to the package source's start directory,
@@ -588,7 +588,7 @@ impl CtxMethods for BuildContext {
         let result = self.install_no_build(pkg_src.build_workspace(),
                                            build_inputs,
                                            &pkg_src.destination_workspace,
-                                           &id).map(|s| Path::init(s.as_slice()));
+                                           &id).map(|s| Path::new(s.as_slice()));
         installed_files = installed_files + result;
         note(format!("Installed package {} to {}",
                      id.to_str(),
@@ -709,10 +709,10 @@ impl CtxMethods for BuildContext {
     }
 
     fn init(&self) {
-        fs::mkdir_recursive(&Path::init("src"), io::UserRWX);
-        fs::mkdir_recursive(&Path::init("bin"), io::UserRWX);
-        fs::mkdir_recursive(&Path::init("lib"), io::UserRWX);
-        fs::mkdir_recursive(&Path::init("build"), io::UserRWX);
+        fs::mkdir_recursive(&Path::new("src"), io::UserRWX);
+        fs::mkdir_recursive(&Path::new("bin"), io::UserRWX);
+        fs::mkdir_recursive(&Path::new("lib"), io::UserRWX);
+        fs::mkdir_recursive(&Path::new("build"), io::UserRWX);
     }
 
     fn uninstall(&self, _id: &str, _vers: Option<~str>)  {
@@ -894,7 +894,7 @@ pub fn main_args(args: &[~str]) -> int {
     let mut remaining_args: ~[~str] = remaining_args.map(|s| (*s).clone()).collect();
     remaining_args.shift();
     let sroot = match supplied_sysroot {
-        Some(s) => Path::init(s),
+        Some(s) => Path::new(s),
         _ => filesearch::get_or_default_sysroot()
     };
 

--- a/src/librustpkg/package_id.rs
+++ b/src/librustpkg/package_id.rs
@@ -58,7 +58,7 @@ impl PkgId {
             }
         };
 
-        let path = Path::init(s);
+        let path = Path::new(s);
         if !path.is_relative() {
             return cond.raise((path, ~"absolute pkgid"));
         }
@@ -136,8 +136,8 @@ impl Iterator<(Path, Path)> for Prefixes {
             let last = self.components.pop();
             self.remaining.unshift(last);
             // converting to str and then back is a little unfortunate
-            Some((Path::init(self.components.connect("/")),
-                  Path::init(self.remaining.connect("/"))))
+            Some((Path::new(self.components.connect("/")),
+                  Path::new(self.remaining.connect("/"))))
         }
     }
 }

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -332,7 +332,7 @@ impl PkgSrc {
             it.nth(prefix-1); // skip elements
         }
         assert!(it.peek().is_some());
-        let mut sub = Path::init(".");
+        let mut sub = Path::new(".");
         for c in it {
             sub.push(c);
         }
@@ -414,11 +414,11 @@ impl PkgSrc {
                                                     (k.clone(), p.as_str().unwrap().to_owned()));
                 prep.exec(proc(exec) {
                     for &(ref kind, ref p) in inputs.iter() {
-                        let pth = Path::init(p.clone());
+                        let pth = Path::new(p.clone());
                         exec.discover_input(*kind, *p, if *kind == ~"file" {
                                 digest_file_with_date(&pth)
                             } else if *kind == ~"binary" {
-                                digest_only_date(&Path::init(p.clone()))
+                                digest_only_date(&Path::new(p.clone()))
                             } else {
                                 fail!("Bad kind in build_crates")
                             });

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -64,7 +64,7 @@ fn fake_ctxt(sysroot: Path, workspace: &Path) -> BuildContext {
 fn fake_pkg() -> PkgId {
     let sn = ~"bogus";
     PkgId {
-        path: Path::init(sn.as_slice()),
+        path: Path::new(sn.as_slice()),
         short_name: sn,
         version: NoVersion
     }
@@ -72,7 +72,7 @@ fn fake_pkg() -> PkgId {
 
 fn git_repo_pkg() -> PkgId {
     PkgId {
-        path: Path::init("mockgithub.com/catamorphism/test-pkg"),
+        path: Path::new("mockgithub.com/catamorphism/test-pkg"),
         short_name: ~"test-pkg",
         version: NoVersion
     }
@@ -80,7 +80,7 @@ fn git_repo_pkg() -> PkgId {
 
 fn git_repo_pkg_with_tag(a_tag: ~str) -> PkgId {
     PkgId {
-        path: Path::init("mockgithub.com/catamorphism/test-pkg"),
+        path: Path::new("mockgithub.com/catamorphism/test-pkg"),
         short_name: ~"test-pkg",
         version: Tagged(a_tag)
     }
@@ -480,7 +480,7 @@ fn command_line_test_output_with_env(args: &[~str], env: ~[(~str, ~str)]) -> ~[~
 fn lib_output_file_name(workspace: &Path, short_name: &str) -> Path {
     debug!("lib_output_file_name: given {} and short name {}",
            workspace.display(), short_name);
-    library_in_workspace(&Path::init(short_name),
+    library_in_workspace(&Path::new(short_name),
                          short_name,
                          Build,
                          workspace,
@@ -753,12 +753,12 @@ fn test_package_ids_must_be_relative_path_like() {
     });
 
     cond.trap(|(p, e)| {
-        let abs = os::make_absolute(&Path::init("foo/bar/quux"));
+        let abs = os::make_absolute(&Path::new("foo/bar/quux"));
         assert_eq!(p, abs);
         assert!("absolute pkgid" == e);
         whatever.clone()
     }).inside(|| {
-        let zp = os::make_absolute(&Path::init("foo/bar/quux"));
+        let zp = os::make_absolute(&Path::new("foo/bar/quux"));
         // FIXME (#9639): This needs to handle non-utf8 paths
         let z = PkgId::new(zp.as_str().unwrap());
         assert_eq!(~"foo-0.1", z.to_str());
@@ -769,7 +769,7 @@ fn test_package_ids_must_be_relative_path_like() {
 #[test]
 fn test_package_version() {
     let local_path = "mockgithub.com/catamorphism/test_pkg_version";
-    let repo = init_git_repo(&Path::init(local_path));
+    let repo = init_git_repo(&Path::new(local_path));
     let repo = repo.path();
     let repo_subdir = repo.join_many(["mockgithub.com", "catamorphism", "test_pkg_version"]);
     debug!("Writing files in: {}", repo_subdir.display());
@@ -809,7 +809,7 @@ fn test_package_version() {
 #[test]
 fn test_package_request_version() {
     let local_path = "mockgithub.com/catamorphism/test_pkg_version";
-    let repo = init_git_repo(&Path::init(local_path));
+    let repo = init_git_repo(&Path::new(local_path));
     let repo = repo.path();
     let repo_subdir = repo.join_many(["mockgithub.com", "catamorphism", "test_pkg_version"]);
     debug!("Writing files in: {}", repo_subdir.display());
@@ -828,7 +828,7 @@ fn test_package_request_version() {
 
     command_line_test([~"install", format!("{}\\#0.3", local_path)], repo);
 
-    assert!(match installed_library_in_workspace(&Path::init("test_pkg_version"),
+    assert!(match installed_library_in_workspace(&Path::new("test_pkg_version"),
                                                  &repo.join(".rust")) {
         Some(p) => {
             debug!("installed: {}", p.display());
@@ -842,7 +842,7 @@ fn test_package_request_version() {
             == repo.join_many([".rust", "bin", "test_pkg_version"]));
 
     let mut dir = target_build_dir(&repo.join(".rust"));
-    dir.push(&Path::init("src/mockgithub.com/catamorphism/test_pkg_version-0.3"));
+    dir.push(&Path::new("src/mockgithub.com/catamorphism/test_pkg_version-0.3"));
     debug!("dir = {}", dir.display());
     assert!(dir.is_dir());
     assert!(dir.join("version-0.3-file.txt").exists());
@@ -859,7 +859,7 @@ fn rustpkg_install_url_2() {
 
 #[test]
 fn rustpkg_library_target() {
-    let foo_repo = init_git_repo(&Path::init("foo"));
+    let foo_repo = init_git_repo(&Path::new("foo"));
     let foo_repo = foo_repo.path();
     let package_dir = foo_repo.join("foo");
 
@@ -875,7 +875,7 @@ fn rustpkg_library_target() {
 
     add_git_tag(&package_dir, ~"1.0");
     command_line_test([~"install", ~"foo"], foo_repo);
-    assert_lib_exists(&foo_repo.join(".rust"), &Path::init("foo"), ExactRevision(~"1.0"));
+    assert_lib_exists(&foo_repo.join(".rust"), &Path::new("foo"), ExactRevision(~"1.0"));
 }
 
 #[test]
@@ -893,12 +893,12 @@ fn package_script_with_default_build() {
     debug!("dir = {}", dir.display());
     let mut source = test_sysroot().dir_path();
     source.pop(); source.pop();
-    let source = Path::init(file!()).dir_path().join_many(
+    let source = Path::new(file!()).dir_path().join_many(
         [~"testsuite", ~"pass", ~"src", ~"fancy-lib", ~"pkg.rs"]);
     debug!("package_script_with_default_build: {}", source.display());
     fs::copy(&source, &dir.join_many(["src", "fancy-lib-0.1", "pkg.rs"]));
     command_line_test([~"install", ~"fancy-lib"], dir);
-    assert_lib_exists(dir, &Path::init("fancy-lib"), NoVersion);
+    assert_lib_exists(dir, &Path::new("fancy-lib"), NoVersion);
     assert!(target_build_dir(dir).join_many([~"fancy-lib", ~"generated.rs"]).exists());
     let generated_path = target_build_dir(dir).join_many([~"fancy-lib", ~"generated.rs"]);
     debug!("generated path = {}", generated_path.display());
@@ -929,7 +929,7 @@ fn rustpkg_install_no_arg() {
               "fn main() { let _x = (); }");
     debug!("install_no_arg: dir = {}", package_dir.display());
     command_line_test([~"install"], &package_dir);
-    assert_lib_exists(&tmp, &Path::init("foo"), NoVersion);
+    assert_lib_exists(&tmp, &Path::new("foo"), NoVersion);
 }
 
 #[test]
@@ -952,7 +952,7 @@ fn rustpkg_clean_no_arg() {
 #[test]
 fn rust_path_test() {
     let dir_for_path = TempDir::new("more_rust").expect("rust_path_test failed");
-    let dir = mk_workspace(dir_for_path.path(), &Path::init("foo"), &NoVersion);
+    let dir = mk_workspace(dir_for_path.path(), &Path::new("foo"), &NoVersion);
     debug!("dir = {}", dir.display());
     writeFile(&dir.join("main.rs"), "fn main() { let _x = (); }");
 
@@ -993,9 +993,9 @@ fn rust_path_contents() {
 fn rust_path_parse() {
     os::setenv("RUST_PATH", "/a/b/c:/d/e/f:/g/h/i");
     let paths = rust_path();
-    assert!(paths.contains(&Path::init("/g/h/i")));
-    assert!(paths.contains(&Path::init("/d/e/f")));
-    assert!(paths.contains(&Path::init("/a/b/c")));
+    assert!(paths.contains(&Path::new("/g/h/i")));
+    assert!(paths.contains(&Path::new("/d/e/f")));
+    assert!(paths.contains(&Path::new("/a/b/c")));
     os::unsetenv("RUST_PATH");
 }
 
@@ -1375,8 +1375,8 @@ fn multiple_workspaces() {
 // Copy the exact same package into directory B and install it
 // Set the RUST_PATH to A:B
 // Make a third package that uses foo, make sure we can build/install it
-    let (a_loc, _pkg_dir) = mk_temp_workspace(&Path::init("foo"), &NoVersion);
-    let (b_loc, _pkg_dir) = mk_temp_workspace(&Path::init("foo"), &NoVersion);
+    let (a_loc, _pkg_dir) = mk_temp_workspace(&Path::new("foo"), &NoVersion);
+    let (b_loc, _pkg_dir) = mk_temp_workspace(&Path::new("foo"), &NoVersion);
     let (a_loc, b_loc) = (a_loc.path(), b_loc.path());
     debug!("Trying to install foo in {}", a_loc.display());
     command_line_test([~"install", ~"foo"], a_loc);
@@ -1401,7 +1401,7 @@ fn rust_path_hack_test(hack_flag: bool) {
    let p_id = PkgId::new("foo");
    let workspace = create_local_package(&p_id);
    let workspace = workspace.path();
-   let dest_workspace = mk_empty_workspace(&Path::init("bar"), &NoVersion, "dest_workspace");
+   let dest_workspace = mk_empty_workspace(&Path::new("bar"), &NoVersion, "dest_workspace");
    let dest_workspace = dest_workspace.path();
    let foo_path = workspace.join_many(["src", "foo-0.1"]);
    let rust_path = Some(~[(~"RUST_PATH",
@@ -1410,11 +1410,11 @@ fn rust_path_hack_test(hack_flag: bool) {
                foo_path.as_str().unwrap()))]);
    command_line_test_with_env(~[~"install"] + if hack_flag { ~[~"--rust-path-hack"] } else { ~[] } +
                                ~[~"foo"], dest_workspace, rust_path);
-   assert_lib_exists(dest_workspace, &Path::init("foo"), NoVersion);
+   assert_lib_exists(dest_workspace, &Path::new("foo"), NoVersion);
    assert_executable_exists(dest_workspace, "foo");
    assert_built_library_exists(dest_workspace, "foo");
    assert_built_executable_exists(dest_workspace, "foo");
-   assert!(!lib_exists(workspace, &Path::init("foo"), NoVersion));
+   assert!(!lib_exists(workspace, &Path::new("foo"), NoVersion));
    assert!(!executable_exists(workspace, "foo"));
    assert!(!built_library_exists(workspace, "foo"));
    assert!(!built_executable_exists(workspace, "foo"));
@@ -1449,15 +1449,15 @@ fn rust_path_hack_cwd() {
    fs::mkdir_recursive(&cwd, io::UserRWX);
    writeFile(&cwd.join("lib.rs"), "pub fn f() { }");
 
-   let dest_workspace = mk_empty_workspace(&Path::init("bar"), &NoVersion, "dest_workspace");
+   let dest_workspace = mk_empty_workspace(&Path::new("bar"), &NoVersion, "dest_workspace");
    let dest_workspace = dest_workspace.path();
    // FIXME (#9639): This needs to handle non-utf8 paths
    let rust_path = Some(~[(~"RUST_PATH", dest_workspace.as_str().unwrap().to_owned())]);
    command_line_test_with_env([~"install", ~"--rust-path-hack", ~"foo"], &cwd, rust_path);
    debug!("Checking that foo exists in {}", dest_workspace.display());
-   assert_lib_exists(dest_workspace, &Path::init("foo"), NoVersion);
+   assert_lib_exists(dest_workspace, &Path::new("foo"), NoVersion);
    assert_built_library_exists(dest_workspace, "foo");
-   assert!(!lib_exists(&cwd, &Path::init("foo"), NoVersion));
+   assert!(!lib_exists(&cwd, &Path::new("foo"), NoVersion));
    assert!(!built_library_exists(&cwd, "foo"));
 }
 
@@ -1470,15 +1470,15 @@ fn rust_path_hack_multi_path() {
    writeFile(&subdir.join("lib.rs"), "pub fn f() { }");
    let name = ~"foo/bar/quux";
 
-   let dest_workspace = mk_empty_workspace(&Path::init("bar"), &NoVersion, "dest_workspace");
+   let dest_workspace = mk_empty_workspace(&Path::new("bar"), &NoVersion, "dest_workspace");
    let dest_workspace = dest_workspace.path();
    // FIXME (#9639): This needs to handle non-utf8 paths
    let rust_path = Some(~[(~"RUST_PATH", dest_workspace.as_str().unwrap().to_owned())]);
    command_line_test_with_env([~"install", ~"--rust-path-hack", name.clone()], &subdir, rust_path);
    debug!("Checking that {} exists in {}", name, dest_workspace.display());
-   assert_lib_exists(dest_workspace, &Path::init("quux"), NoVersion);
+   assert_lib_exists(dest_workspace, &Path::new("quux"), NoVersion);
    assert_built_library_exists(dest_workspace, name);
-   assert!(!lib_exists(&subdir, &Path::init("quux"), NoVersion));
+   assert!(!lib_exists(&subdir, &Path::new("quux"), NoVersion));
    assert!(!built_library_exists(&subdir, name));
 }
 
@@ -1491,15 +1491,15 @@ fn rust_path_hack_install_no_arg() {
    assert!(make_dir_rwx(&source_dir));
    writeFile(&source_dir.join("lib.rs"), "pub fn f() { }");
 
-   let dest_workspace = mk_empty_workspace(&Path::init("bar"), &NoVersion, "dest_workspace");
+   let dest_workspace = mk_empty_workspace(&Path::new("bar"), &NoVersion, "dest_workspace");
    let dest_workspace = dest_workspace.path();
    // FIXME (#9639): This needs to handle non-utf8 paths
    let rust_path = Some(~[(~"RUST_PATH", dest_workspace.as_str().unwrap().to_owned())]);
    command_line_test_with_env([~"install", ~"--rust-path-hack"], &source_dir, rust_path);
    debug!("Checking that foo exists in {}", dest_workspace.display());
-   assert_lib_exists(dest_workspace, &Path::init("foo"), NoVersion);
+   assert_lib_exists(dest_workspace, &Path::new("foo"), NoVersion);
    assert_built_library_exists(dest_workspace, "foo");
-   assert!(!lib_exists(&source_dir, &Path::init("foo"), NoVersion));
+   assert!(!lib_exists(&source_dir, &Path::new("foo"), NoVersion));
    assert!(!built_library_exists(cwd, "foo"));
 }
 
@@ -1511,7 +1511,7 @@ fn rust_path_hack_build_no_arg() {
    assert!(make_dir_rwx(&source_dir));
    writeFile(&source_dir.join("lib.rs"), "pub fn f() { }");
 
-   let dest_workspace = mk_empty_workspace(&Path::init("bar"), &NoVersion, "dest_workspace");
+   let dest_workspace = mk_empty_workspace(&Path::new("bar"), &NoVersion, "dest_workspace");
    let dest_workspace = dest_workspace.path();
    // FIXME (#9639): This needs to handle non-utf8 paths
    let rust_path = Some(~[(~"RUST_PATH", dest_workspace.as_str().unwrap().to_owned())]);
@@ -1549,7 +1549,7 @@ fn rust_path_hack_build_with_dependency() {
 fn rust_path_install_target() {
     let dir_for_path = TempDir::new(
         "source_workspace").expect("rust_path_install_target failed");
-    let mut dir = mk_workspace(dir_for_path.path(), &Path::init("foo"), &NoVersion);
+    let mut dir = mk_workspace(dir_for_path.path(), &Path::new("foo"), &NoVersion);
     debug!("dir = {}", dir.display());
     writeFile(&dir.join("main.rs"), "fn main() { let _x = (); }");
     let dir_to_install_to = TempDir::new(
@@ -1661,7 +1661,7 @@ fn notrans_flag_fail() {
                           workspace, None, BAD_FLAG_CODE);
         assert!(!built_executable_exists(workspace, "foo"));
         assert!(!object_file_exists(workspace, "foo"));
-        assert!(!lib_exists(workspace, &Path::init("foo"), NoVersion));
+        assert!(!lib_exists(workspace, &Path::new("foo"), NoVersion));
     }
 }
 
@@ -1929,9 +1929,9 @@ fn test_recursive_deps() {
     command_line_test_with_env([~"install", ~"a"],
                                a_workspace,
                                environment);
-    assert_lib_exists(a_workspace, &Path::init("a"), NoVersion);
-    assert_lib_exists(b_workspace, &Path::init("b"), NoVersion);
-    assert_lib_exists(b_workspace, &Path::init("c"), NoVersion);
+    assert_lib_exists(a_workspace, &Path::new("a"), NoVersion);
+    assert_lib_exists(b_workspace, &Path::new("b"), NoVersion);
+    assert_lib_exists(b_workspace, &Path::new("c"), NoVersion);
 }
 
 #[test]
@@ -1939,7 +1939,7 @@ fn test_install_to_rust_path() {
     let p_id = PkgId::new("foo");
     let second_workspace = create_local_package(&p_id);
     let second_workspace = second_workspace.path();
-    let first_workspace = mk_empty_workspace(&Path::init("p"), &NoVersion, "dest");
+    let first_workspace = mk_empty_workspace(&Path::new("p"), &NoVersion, "dest");
     let first_workspace = first_workspace.path();
     // FIXME (#9639): This needs to handle non-utf8 paths
     let rust_path = Some(~[(~"RUST_PATH",
@@ -1986,7 +1986,7 @@ fn test_target_specific_install_dir() {
                        ~"foo"],
                       workspace);
     assert!(workspace.join_many([~"lib", host_triple()]).is_dir());
-    assert_lib_exists(workspace, &Path::init("foo"), NoVersion);
+    assert_lib_exists(workspace, &Path::new("foo"), NoVersion);
     assert!(fs::readdir(&workspace.join("lib")).len() == 1);
     assert!(workspace.join("bin").is_dir());
     assert_executable_exists(workspace, "foo");
@@ -2062,7 +2062,7 @@ fn correct_package_name_with_rust_path_hack() {
     let bar_id = PkgId::new("bar");
     let foo_workspace = create_local_package(&foo_id);
     let foo_workspace = foo_workspace.path();
-    let dest_workspace = mk_empty_workspace(&Path::init("bar"), &NoVersion, "dest_workspace");
+    let dest_workspace = mk_empty_workspace(&Path::new("bar"), &NoVersion, "dest_workspace");
     let dest_workspace = dest_workspace.path();
 
     writeFile(&dest_workspace.join_many(["src", "bar-0.1", "main.rs"]),
@@ -2332,7 +2332,7 @@ fn test_c_dependency_ok() {
     writeFile(&dir.join_many(["src", "cdep-0.1", "foo.c"]), "void f() {}");
 
     debug!("dir = {}", dir.display());
-    let source = Path::init(file!()).dir_path().join_many(
+    let source = Path::new(file!()).dir_path().join_many(
         [~"testsuite", ~"pass", ~"src", ~"c-dependencies", ~"pkg.rs"]);
     fs::copy(&source, &dir.join_many([~"src", ~"cdep-0.1", ~"pkg.rs"]));
     command_line_test([~"build", ~"cdep"], dir);
@@ -2354,7 +2354,7 @@ fn test_c_dependency_no_rebuilding() {
     writeFile(&dir.join_many(["src", "cdep-0.1", "foo.c"]), "void f() {}");
 
     debug!("dir = {}", dir.display());
-    let source = Path::init(file!()).dir_path().join_many(
+    let source = Path::new(file!()).dir_path().join_many(
         [~"testsuite", ~"pass", ~"src", ~"c-dependencies", ~"pkg.rs"]);
     fs::copy(&source, &dir.join_many([~"src", ~"cdep-0.1", ~"pkg.rs"]));
     command_line_test([~"build", ~"cdep"], dir);
@@ -2388,7 +2388,7 @@ fn test_c_dependency_yes_rebuilding() {
     let c_file_name = dir.join_many(["src", "cdep-0.1", "foo.c"]);
     writeFile(&c_file_name, "void f() {}");
 
-    let source = Path::init(file!()).dir_path().join_many(
+    let source = Path::new(file!()).dir_path().join_many(
         [~"testsuite", ~"pass", ~"src", ~"c-dependencies", ~"pkg.rs"]);
     let target = dir.join_many([~"src", ~"cdep-0.1", ~"pkg.rs"]);
     debug!("Copying {} -> {}", source.display(), target.display());

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -510,7 +510,7 @@ impl<'self> Visitor<()> for ViewItemVisitor<'self> {
                             self.context.install(
                                 pkg_src,
                                 &WhatToBuild::new(Inferred,
-                                                  JustOne(Path::init(lib_crate_filename))));
+                                                  JustOne(Path::new(lib_crate_filename))));
                         debug!("Installed {}, returned {:?} dependencies and \
                                {:?} transitive dependencies",
                                lib_name, outputs_disc.len(), inputs_disc.len());
@@ -548,7 +548,7 @@ impl<'self> Visitor<()> for ViewItemVisitor<'self> {
                                 self.exec.discover_input(*what,
                                                          *dep,
                                                          digest_file_with_date(
-                                                             &Path::init(dep.as_slice())));
+                                                             &Path::new(dep.as_slice())));
                             } else if *what == ~"binary" {
                                 add_dep(self.deps,
                                         self.parent_crate.as_str().unwrap().to_owned(),
@@ -556,7 +556,7 @@ impl<'self> Visitor<()> for ViewItemVisitor<'self> {
                                 self.exec.discover_input(*what,
                                                          *dep,
                                                          digest_only_date(
-                                                             &Path::init(dep.as_slice())));
+                                                             &Path::new(dep.as_slice())));
                             } else {
                                 fail!("Bad kind: {}", *what);
                             }

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -141,7 +141,7 @@ impl FsRequest {
         }).map(|req| unsafe {
             let mut paths = ~[];
             let path = CString::new(path.with_ref(|p| p), false);
-            let parent = Path::init(path);
+            let parent = Path::new(path);
             c_str::from_c_multistring(req.get_ptr() as *libc::c_char,
                                       Some(req.get_result() as uint),
                                       |rel| {
@@ -157,7 +157,7 @@ impl FsRequest {
             uvll::uv_fs_readlink(loop_.handle, req,
                                  path.with_ref(|p| p), cb)
         }).map(|req| {
-            Path::init(unsafe {
+            Path::new(unsafe {
                 CString::new(req.get_ptr() as *libc::c_char, false)
             })
         })
@@ -245,7 +245,7 @@ impl FsRequest {
 
     pub fn mkstat(&self) -> FileStat {
         let path = unsafe { uvll::get_path_from_fs_req(self.req) };
-        let path = unsafe { Path::init(CString::new(path, false)) };
+        let path = unsafe { Path::new(CString::new(path, false)) };
         let stat = self.get_stat();
         fn to_msec(stat: uvll::uv_timespec_t) -> u64 {
             // Be sure to cast to u64 first to prevent overflowing if the tv_sec

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -1082,7 +1082,7 @@ mod test {
 
         do run_in_bare_thread {
             let sleepers = SleeperList::new();
-            let mut pool = BufferPool::init();
+            let mut pool = BufferPool::new();
             let (worker1, stealer1) = pool.deque();
             let (worker2, stealer2) = pool.deque();
             let queues = ~[stealer1, stealer2];

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -29,7 +29,7 @@ particular bits of it, etc.
 
     use std::io::{File, fs};
 
-    let path = Path::init("foo.txt");
+    let path = Path::new("foo.txt");
 
     // create the file, whether it exists or not
     let mut file = File::create(&path);
@@ -40,7 +40,7 @@ particular bits of it, etc.
     file.read_to_end();
 
     println!("{}", path.stat().size);
-    fs::symlink(&path, &Path::init("bar.txt"));
+    fs::symlink(&path, &Path::new("bar.txt"));
     fs::unlink(&path);
 
 */
@@ -95,7 +95,7 @@ impl File {
     ///
     ///     use std::io::{File, io_error, Open, ReadWrite};
     ///
-    ///     let p = Path::init("/some/file/path.txt");
+    ///     let p = Path::new("/some/file/path.txt");
     ///
     ///     io_error::cond.trap(|_| {
     ///         // hoo-boy...
@@ -157,7 +157,7 @@ impl File {
     ///
     ///     use std::io::File;
     ///
-    ///     let contents = File::open(&Path::init("foo.txt")).read_to_end();
+    ///     let contents = File::open(&Path::new("foo.txt")).read_to_end();
     pub fn open(path: &Path) -> Option<File> {
         File::open_mode(path, Open, Read)
     }
@@ -172,7 +172,7 @@ impl File {
     ///
     ///     use std::io::File;
     ///
-    ///     let mut f = File::create(&Path::init("foo.txt"));
+    ///     let mut f = File::create(&Path::new("foo.txt"));
     ///     f.write(bytes!("This is a sample file"));
     pub fn create(path: &Path) -> Option<File> {
         File::open_mode(path, Truncate, Write)
@@ -229,7 +229,7 @@ impl File {
 ///
 ///     use std::io::fs;
 ///
-///     let p = Path::init("/some/file/path.txt");
+///     let p = Path::new("/some/file/path.txt");
 ///     fs::unlink(&p);
 ///     // if we made it here without failing, then the
 ///     // unlink operation was successful
@@ -260,7 +260,7 @@ pub fn unlink(path: &Path) {
 ///     use std::io;
 ///     use std::io::fs;
 ///
-///     let p = Path::init("/some/file/path.txt");
+///     let p = Path::new("/some/file/path.txt");
 ///     match io::result(|| fs::stat(&p)) {
 ///         Ok(stat) => { /* ... */ }
 ///         Err(e) => { /* handle error */ }
@@ -277,7 +277,7 @@ pub fn stat(path: &Path) -> FileStat {
 
 fn dummystat() -> FileStat {
     FileStat {
-        path: Path::init(""),
+        path: Path::new(""),
         size: 0,
         kind: io::TypeFile,
         perm: 0,
@@ -317,7 +317,7 @@ pub fn lstat(path: &Path) -> FileStat {
 ///
 ///     use std::io::fs;
 ///
-///     fs::rename(&Path::init("foo"), &Path::init("bar"));
+///     fs::rename(&Path::new("foo"), &Path::new("bar"));
 ///     // Oh boy, nothing was raised!
 ///
 /// # Errors
@@ -339,7 +339,7 @@ pub fn rename(from: &Path, to: &Path) {
 ///
 ///     use std::io::fs;
 ///
-///     fs::copy(&Path::init("foo.txt"), &Path::init("bar.txt"));
+///     fs::copy(&Path::new("foo.txt"), &Path::new("bar.txt"));
 ///     // Oh boy, nothing was raised!
 ///
 /// # Errors
@@ -386,10 +386,10 @@ pub fn copy(from: &Path, to: &Path) {
 ///     use std::io;
 ///     use std::io::fs;
 ///
-///     fs::chmod(&Path::init("file.txt"), io::UserFile);
-///     fs::chmod(&Path::init("file.txt"), io::UserRead | io::UserWrite);
-///     fs::chmod(&Path::init("dir"),      io::UserDir);
-///     fs::chmod(&Path::init("file.exe"), io::UserExec);
+///     fs::chmod(&Path::new("file.txt"), io::UserFile);
+///     fs::chmod(&Path::new("file.txt"), io::UserRead | io::UserWrite);
+///     fs::chmod(&Path::new("dir"),      io::UserDir);
+///     fs::chmod(&Path::new("file.exe"), io::UserExec);
 ///
 /// # Errors
 ///
@@ -448,7 +448,7 @@ pub fn readlink(path: &Path) -> Option<Path> {
 ///     use std::libc::S_IRWXU;
 ///     use std::io::fs;
 ///
-///     let p = Path::init("/some/dir");
+///     let p = Path::new("/some/dir");
 ///     fs::mkdir(&p, S_IRWXU as int);
 ///     // If we got here, our directory exists! Horray!
 ///
@@ -467,7 +467,7 @@ pub fn mkdir(path: &Path, mode: FilePermission) {
 ///
 ///     use std::io::fs;
 ///
-///     let p = Path::init("/some/dir");
+///     let p = Path::new("/some/dir");
 ///     fs::rmdir(&p);
 ///     // good riddance, you mean ol' directory
 ///
@@ -987,12 +987,12 @@ mod test {
     })
 
     test!(fn recursive_mkdir_slash() {
-        mkdir_recursive(&Path::init("/"), io::UserRWX);
+        mkdir_recursive(&Path::new("/"), io::UserRWX);
     })
 
     test!(fn unicode_path_is_dir() {
-        assert!(Path::init(".").is_dir());
-        assert!(!Path::init("test/stdtest/fs.rs").is_dir());
+        assert!(Path::new(".").is_dir());
+        assert!(!Path::new("test/stdtest/fs.rs").is_dir());
 
         let tmpdir = tmpdir();
 
@@ -1009,20 +1009,20 @@ mod test {
     })
 
     test!(fn unicode_path_exists() {
-        assert!(Path::init(".").exists());
-        assert!(!Path::init("test/nonexistent-bogus-path").exists());
+        assert!(Path::new(".").exists());
+        assert!(!Path::new("test/nonexistent-bogus-path").exists());
 
         let tmpdir = tmpdir();
         let unicode = tmpdir.clone();
         let unicode = unicode.join(format!("test-각丁ー再见"));
         mkdir(&unicode, io::UserRWX);
         assert!(unicode.exists());
-        assert!(!Path::init("test/unicode-bogus-path-각丁ー再见").exists());
+        assert!(!Path::new("test/unicode-bogus-path-각丁ー再见").exists());
     })
 
     test!(fn copy_file_does_not_exist() {
-        let from = Path::init("test/nonexistent-bogus-path");
-        let to = Path::init("test/other-bogus-path");
+        let from = Path::new("test/nonexistent-bogus-path");
+        let to = Path::new("test/other-bogus-path");
         match io::result(|| copy(&from, &to)) {
             Ok(..) => fail!(),
             Err(..) => {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -450,7 +450,7 @@ pub trait Reader {
     ///
     /// # Example
     ///
-    ///     let reader = File::open(&Path::init("foo.txt"))
+    ///     let reader = File::open(&Path::new("foo.txt"))
     ///     while !reader.eof() {
     ///         println(reader.read_line());
     ///     }

--- a/src/libstd/io/native/file.rs
+++ b/src/libstd/io/native/file.rs
@@ -278,7 +278,6 @@ impl rtio::RtioFileStream for FileDesc {
         self.seek(orig_pos as i64, io::SeekSet);
         return ret;
     }
-
     #[cfg(unix)]
     fn truncate(&mut self, offset: i64) -> Result<(), IoError> {
         super::mkerr_libc(unsafe {
@@ -481,7 +480,7 @@ pub fn mkdir(p: &CString, mode: io::FilePermission) -> IoResult<()> {
 pub fn readdir(p: &CString) -> IoResult<~[Path]> {
     fn prune(root: &CString, dirs: ~[Path]) -> ~[Path] {
         let root = unsafe { CString::new(root.with_ref(|p| p), false) };
-        let root = Path::init(root);
+        let root = Path::new(root);
 
         dirs.move_iter().filter(|path| {
             path.as_vec() != bytes!(".") && path.as_vec() != bytes!("..")
@@ -506,7 +505,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
                 let mut entry_ptr = readdir(dir_ptr);
                 while (entry_ptr as uint != 0) {
                     let cstr = CString::new(rust_list_dir_val(entry_ptr), false);
-                    paths.push(Path::init(cstr));
+                    paths.push(Path::new(cstr));
                     entry_ptr = readdir(dir_ptr);
                 }
                 closedir(dir_ptr);
@@ -537,7 +536,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
                 fn rust_list_dir_wfd_fp_buf(wfd: *libc::c_void) -> *u16;
             }
             let p = CString::new(p.with_ref(|p| p), false);
-            let p = Path::init(p);
+            let p = Path::new(p);
             let star = p.join("*");
             as_utf16_p(star.as_str().unwrap(), |path_ptr| {
                 let wfd_ptr = malloc_raw(rust_list_dir_wfd_size() as uint);
@@ -554,7 +553,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
                             let fp_vec = vec::from_buf(
                                 fp_buf, wcslen(fp_buf) as uint);
                             let fp_str = str::from_utf16(fp_vec);
-                            paths.push(Path::init(fp_str));
+                            paths.push(Path::new(fp_str));
                         }
                         more_files = FindNextFileW(find_handle, wfd_ptr as HANDLE);
                     }
@@ -684,7 +683,7 @@ pub fn readlink(p: &CString) -> IoResult<Path> {
             }
         });
         let ret = match ret {
-            Some(s) => Ok(Path::init(s)),
+            Some(s) => Ok(Path::new(s)),
             None => Err(super::last_error()),
         };
         unsafe { libc::CloseHandle(handle) };
@@ -708,7 +707,7 @@ pub fn readlink(p: &CString) -> IoResult<Path> {
             n => {
                 assert!(n > 0);
                 unsafe { vec::raw::set_len(&mut buf, n as uint); }
-                Ok(Path::init(buf))
+                Ok(Path::new(buf))
             }
         }
     }
@@ -771,7 +770,7 @@ fn mkstat(stat: &libc::stat, path: &CString) -> io::FileStat {
     };
 
     io::FileStat {
-        path: Path::init(path),
+        path: Path::new(path),
         size: stat.st_size as u64,
         kind: kind,
         perm: (stat.st_mode) as io::FilePermission & io::AllPermissions,
@@ -820,7 +819,7 @@ fn mkstat(stat: &libc::stat, path: &CString) -> io::FileStat {
     fn gen(_stat: &libc::stat) -> u64 { 0 }
 
     io::FileStat {
-        path: Path::init(path),
+        path: Path::new(path),
         size: stat.st_size as u64,
         kind: kind,
         perm: (stat.st_mode) as io::FilePermission & io::AllPermissions,

--- a/src/libstd/io/native/process.rs
+++ b/src/libstd/io/native/process.rs
@@ -95,7 +95,7 @@ impl Process {
         let (err_pipe, err_fd) = get_io(config.io, &mut ret_io, 2);
 
         let env = config.env.map(|a| a.to_owned());
-        let cwd = config.cwd.map(|a| Path::init(a));
+        let cwd = config.cwd.map(|a| Path::new(a));
         let res = spawn_process_os(config.program, config.args, env,
                                    cwd.as_ref(), in_fd, out_fd, err_fd);
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -64,7 +64,7 @@ pub fn getcwd() -> Path {
                 fail!()
             }
 
-            Path::init(CString::new(buf as *c_char, false))
+            Path::new(CString::new(buf as *c_char, false))
         }
     })
 }
@@ -81,7 +81,7 @@ pub fn getcwd() -> Path {
             }
         }
     });
-    Path::init(str::from_utf16(buf))
+    Path::new(str::from_utf16(buf))
 }
 
 #[cfg(windows)]
@@ -384,7 +384,7 @@ pub fn self_exe_path() -> Option<Path> {
     fn load_self() -> Option<~[u8]> {
         use std::io;
 
-        match io::result(|| io::fs::readlink(&Path::init("/proc/self/exe"))) {
+        match io::result(|| io::fs::readlink(&Path::new("/proc/self/exe"))) {
             Ok(Some(path)) => Some(path.as_vec().to_owned()),
             Ok(None) | Err(..) => None
         }
@@ -418,7 +418,7 @@ pub fn self_exe_path() -> Option<Path> {
         }
     }
 
-    load_self().and_then(|path| Path::init_opt(path).map(|mut p| { p.pop(); p }))
+    load_self().and_then(|path| Path::new_opt(path).map(|mut p| { p.pop(); p }))
 }
 
 /**
@@ -437,7 +437,7 @@ pub fn self_exe_path() -> Option<Path> {
 pub fn homedir() -> Option<Path> {
     // FIXME (#7188): getenv needs a ~[u8] variant
     return match getenv("HOME") {
-        Some(ref p) if !p.is_empty() => Path::init_opt(p.as_slice()),
+        Some(ref p) if !p.is_empty() => Path::new_opt(p.as_slice()),
         _ => secondary()
     };
 
@@ -450,7 +450,7 @@ pub fn homedir() -> Option<Path> {
     fn secondary() -> Option<Path> {
         getenv("USERPROFILE").and_then(|p| {
             if !p.is_empty() {
-                Path::init_opt(p)
+                Path::new_opt(p)
             } else {
                 None
             }
@@ -479,7 +479,7 @@ pub fn tmpdir() -> Path {
                 if x.is_empty() {
                     None
                 } else {
-                    Path::init_opt(x)
+                    Path::new_opt(x)
                 },
             _ => None
         }
@@ -488,9 +488,9 @@ pub fn tmpdir() -> Path {
     #[cfg(unix)]
     fn lookup() -> Path {
         if cfg!(target_os = "android") {
-            Path::init("/data/tmp")
+            Path::new("/data/tmp")
         } else {
-            getenv_nonempty("TMPDIR").unwrap_or(Path::init("/tmp"))
+            getenv_nonempty("TMPDIR").unwrap_or(Path::new("/tmp"))
         }
     }
 
@@ -499,7 +499,7 @@ pub fn tmpdir() -> Path {
         getenv_nonempty("TMP").or(
             getenv_nonempty("TEMP").or(
                 getenv_nonempty("USERPROFILE").or(
-                   getenv_nonempty("WINDIR")))).unwrap_or(Path::init("C:\\Windows"))
+                   getenv_nonempty("WINDIR")))).unwrap_or(Path::new("C:\\Windows"))
     }
 }
 
@@ -1366,13 +1366,13 @@ mod tests {
 
     #[test]
     fn test() {
-        assert!((!Path::init("test-path").is_absolute()));
+        assert!((!Path::new("test-path").is_absolute()));
 
         let cwd = getcwd();
         debug!("Current working directory: {}", cwd.display());
 
-        debug!("{:?}", make_absolute(&Path::init("test-path")));
-        debug!("{:?}", make_absolute(&Path::init("/usr/bin")));
+        debug!("{:?}", make_absolute(&Path::new("test-path")));
+        debug!("{:?}", make_absolute(&Path::new("/usr/bin")));
     }
 
     #[test]
@@ -1381,7 +1381,7 @@ mod tests {
         let oldhome = getenv("HOME");
 
         setenv("HOME", "/home/MountainView");
-        assert_eq!(os::homedir(), Some(Path::init("/home/MountainView")));
+        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
 
         setenv("HOME", "");
         assert!(os::homedir().is_none());
@@ -1402,16 +1402,16 @@ mod tests {
         assert!(os::homedir().is_none());
 
         setenv("HOME", "/home/MountainView");
-        assert_eq!(os::homedir(), Some(Path::init("/home/MountainView")));
+        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
 
         setenv("HOME", "");
 
         setenv("USERPROFILE", "/home/MountainView");
-        assert_eq!(os::homedir(), Some(Path::init("/home/MountainView")));
+        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
 
         setenv("HOME", "/home/MountainView");
         setenv("USERPROFILE", "/home/PaloAlto");
-        assert_eq!(os::homedir(), Some(Path::init("/home/MountainView")));
+        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
 
         for s in oldhome.iter() { setenv("HOME", *s) }
         for s in olduserprofile.iter() { setenv("USERPROFILE", *s) }

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -32,8 +32,8 @@ no restriction on paths beyond disallowing NUL).
 Usage of this module is fairly straightforward. Unless writing platform-specific
 code, `Path` should be used to refer to the platform-native path.
 
-Creation of a path is typically done with either `Path::init(some_str)` or
-`Path::init(some_vec)`. This path can be modified with `.push()` and
+Creation of a path is typically done with either `Path::new(some_str)` or
+`Path::new(some_vec)`. This path can be modified with `.push()` and
 `.pop()` (and other setters). The resulting Path can either be passed to another
 API that expects a path, or can be turned into a &[u8] with `.as_vec()` or a
 Option<&str> with `.as_str()`. Similarly, attributes of the path can be queried
@@ -41,7 +41,7 @@ with methods such as `.filename()`. There are also methods that return a new
 path instead of modifying the receiver, such as `.join()` or `.dir_path()`.
 
 Paths are always kept in normalized form. This means that creating the path
-`Path::init("a/b/../c")` will return the path `a/c`. Similarly any attempt
+`Path::new("a/b/../c")` will return the path `a/c`. Similarly any attempt
 to mutate the path will always leave it in normalized form.
 
 When rendering a path to some form of output, there is a method `.display()`
@@ -53,7 +53,7 @@ actually operates on the path; it is only intended for display.
 ## Example
 
 ```rust
-let mut path = Path::from_str("/tmp/path");
+let mut path = Path::new("/tmp/path");
 debug!("path: {}", path.display());
 path.set_filename("foo");
 path.push("bar");
@@ -151,24 +151,24 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     ///
     /// See individual Path impls for additional restrictions.
     #[inline]
-    fn init<T: BytesContainer>(path: T) -> Self {
+    fn new<T: BytesContainer>(path: T) -> Self {
         if contains_nul(path.container_as_bytes()) {
             let path = self::null_byte::cond.raise(path.container_into_owned_bytes());
             assert!(!contains_nul(path));
-            unsafe { GenericPathUnsafe::init_unchecked(path) }
+            unsafe { GenericPathUnsafe::new_unchecked(path) }
         } else {
-            unsafe { GenericPathUnsafe::init_unchecked(path) }
+            unsafe { GenericPathUnsafe::new_unchecked(path) }
         }
     }
 
     /// Creates a new Path from a byte vector or string, if possible.
     /// The resulting Path will always be normalized.
     #[inline]
-    fn init_opt<T: BytesContainer>(path: T) -> Option<Self> {
+    fn new_opt<T: BytesContainer>(path: T) -> Option<Self> {
         if contains_nul(path.container_as_bytes()) {
             None
         } else {
-            Some(unsafe { GenericPathUnsafe::init_unchecked(path) })
+            Some(unsafe { GenericPathUnsafe::new_unchecked(path) })
         }
     }
 
@@ -382,7 +382,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// If `self` represents the root of the filesystem hierarchy, returns `self`.
     fn dir_path(&self) -> Self {
         // self.dirname() returns a NUL-free vector
-        unsafe { GenericPathUnsafe::init_unchecked(self.dirname()) }
+        unsafe { GenericPathUnsafe::new_unchecked(self.dirname()) }
     }
 
     /// Returns a Path that represents the filesystem root that `self` is rooted in.
@@ -510,7 +510,7 @@ pub trait BytesContainer {
 pub trait GenericPathUnsafe {
     /// Creates a new Path without checking for null bytes.
     /// The resulting Path will always be normalized.
-    unsafe fn init_unchecked<T: BytesContainer>(path: T) -> Self;
+    unsafe fn new_unchecked<T: BytesContainer>(path: T) -> Self;
 
     /// Replaces the filename portion of the path without checking for null
     /// bytes.
@@ -694,11 +694,11 @@ mod tests {
     #[test]
     fn test_cstring() {
         let input = "/foo/bar/baz";
-        let path: PosixPath = PosixPath::init(input.to_c_str());
+        let path: PosixPath = PosixPath::new(input.to_c_str());
         assert_eq!(path.as_vec(), input.as_bytes());
 
         let input = r"\foo\bar\baz";
-        let path: WindowsPath = WindowsPath::init(input.to_c_str());
+        let path: WindowsPath = WindowsPath::new(input.to_c_str());
         assert_eq!(path.as_str().unwrap(), input.as_slice());
     }
 }

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -68,7 +68,7 @@ impl Eq for Path {
 
 impl FromStr for Path {
     fn from_str(s: &str) -> Option<Path> {
-        Path::init_opt(s)
+        Path::new_opt(s)
     }
 }
 
@@ -111,7 +111,7 @@ impl<'self> BytesContainer for &'self Path {
 }
 
 impl GenericPathUnsafe for Path {
-    unsafe fn init_unchecked<T: BytesContainer>(path: T) -> Path {
+    unsafe fn new_unchecked<T: BytesContainer>(path: T) -> Path {
         let path = Path::normalize(path.container_as_bytes());
         assert!(!path.is_empty());
         let idx = path.rposition_elem(&sep_byte);
@@ -218,7 +218,7 @@ impl GenericPath for Path {
 
     fn root_path(&self) -> Option<Path> {
         if self.is_absolute() {
-            Some(Path::init("/"))
+            Some(Path::new("/"))
         } else {
             None
         }
@@ -287,7 +287,7 @@ impl GenericPath for Path {
                     }
                 }
             }
-            Some(Path::init(comps.connect_vec(&sep_byte)))
+            Some(Path::new(comps.connect_vec(&sep_byte)))
         }
     }
 
@@ -314,14 +314,14 @@ impl Path {
     ///
     /// Raises the `null_byte` condition if the vector contains a NUL.
     #[inline]
-    pub fn init<T: BytesContainer>(path: T) -> Path {
-        GenericPath::init(path)
+    pub fn new<T: BytesContainer>(path: T) -> Path {
+        GenericPath::new(path)
     }
 
     /// Returns a new Path from a byte vector or string, if possible
     #[inline]
-    pub fn init_opt<T: BytesContainer>(path: T) -> Option<Path> {
-        GenericPath::init_opt(path)
+    pub fn new_opt<T: BytesContainer>(path: T) -> Option<Path> {
+        GenericPath::new_opt(path)
     }
 
     /// Returns a normalized byte vector representation of a path, by removing all empty
@@ -471,51 +471,51 @@ mod tests {
     #[test]
     fn test_paths() {
         let empty: &[u8] = [];
-        t!(v: Path::init(empty), b!("."));
-        t!(v: Path::init(b!("/")), b!("/"));
-        t!(v: Path::init(b!("a/b/c")), b!("a/b/c"));
-        t!(v: Path::init(b!("a/b/c", 0xff)), b!("a/b/c", 0xff));
-        t!(v: Path::init(b!(0xff, "/../foo", 0x80)), b!("foo", 0x80));
-        let p = Path::init(b!("a/b/c", 0xff));
+        t!(v: Path::new(empty), b!("."));
+        t!(v: Path::new(b!("/")), b!("/"));
+        t!(v: Path::new(b!("a/b/c")), b!("a/b/c"));
+        t!(v: Path::new(b!("a/b/c", 0xff)), b!("a/b/c", 0xff));
+        t!(v: Path::new(b!(0xff, "/../foo", 0x80)), b!("foo", 0x80));
+        let p = Path::new(b!("a/b/c", 0xff));
         assert_eq!(p.as_str(), None);
 
-        t!(s: Path::init(""), ".");
-        t!(s: Path::init("/"), "/");
-        t!(s: Path::init("hi"), "hi");
-        t!(s: Path::init("hi/"), "hi");
-        t!(s: Path::init("/lib"), "/lib");
-        t!(s: Path::init("/lib/"), "/lib");
-        t!(s: Path::init("hi/there"), "hi/there");
-        t!(s: Path::init("hi/there.txt"), "hi/there.txt");
+        t!(s: Path::new(""), ".");
+        t!(s: Path::new("/"), "/");
+        t!(s: Path::new("hi"), "hi");
+        t!(s: Path::new("hi/"), "hi");
+        t!(s: Path::new("/lib"), "/lib");
+        t!(s: Path::new("/lib/"), "/lib");
+        t!(s: Path::new("hi/there"), "hi/there");
+        t!(s: Path::new("hi/there.txt"), "hi/there.txt");
 
-        t!(s: Path::init("hi/there/"), "hi/there");
-        t!(s: Path::init("hi/../there"), "there");
-        t!(s: Path::init("../hi/there"), "../hi/there");
-        t!(s: Path::init("/../hi/there"), "/hi/there");
-        t!(s: Path::init("foo/.."), ".");
-        t!(s: Path::init("/foo/.."), "/");
-        t!(s: Path::init("/foo/../.."), "/");
-        t!(s: Path::init("/foo/../../bar"), "/bar");
-        t!(s: Path::init("/./hi/./there/."), "/hi/there");
-        t!(s: Path::init("/./hi/./there/./.."), "/hi");
-        t!(s: Path::init("foo/../.."), "..");
-        t!(s: Path::init("foo/../../.."), "../..");
-        t!(s: Path::init("foo/../../bar"), "../bar");
+        t!(s: Path::new("hi/there/"), "hi/there");
+        t!(s: Path::new("hi/../there"), "there");
+        t!(s: Path::new("../hi/there"), "../hi/there");
+        t!(s: Path::new("/../hi/there"), "/hi/there");
+        t!(s: Path::new("foo/.."), ".");
+        t!(s: Path::new("/foo/.."), "/");
+        t!(s: Path::new("/foo/../.."), "/");
+        t!(s: Path::new("/foo/../../bar"), "/bar");
+        t!(s: Path::new("/./hi/./there/."), "/hi/there");
+        t!(s: Path::new("/./hi/./there/./.."), "/hi");
+        t!(s: Path::new("foo/../.."), "..");
+        t!(s: Path::new("foo/../../.."), "../..");
+        t!(s: Path::new("foo/../../bar"), "../bar");
 
-        assert_eq!(Path::init(b!("foo/bar")).into_vec(), b!("foo/bar").to_owned());
-        assert_eq!(Path::init(b!("/foo/../../bar")).into_vec(),
+        assert_eq!(Path::new(b!("foo/bar")).into_vec(), b!("foo/bar").to_owned());
+        assert_eq!(Path::new(b!("/foo/../../bar")).into_vec(),
                    b!("/bar").to_owned());
 
-        let p = Path::init(b!("foo/bar", 0x80));
+        let p = Path::new(b!("foo/bar", 0x80));
         assert_eq!(p.as_str(), None);
     }
 
     #[test]
     fn test_opt_paths() {
-        assert_eq!(Path::init_opt(b!("foo/bar", 0)), None);
-        t!(v: Path::init_opt(b!("foo/bar")).unwrap(), b!("foo/bar"));
-        assert_eq!(Path::init_opt("foo/bar\0"), None);
-        t!(s: Path::init_opt("foo/bar").unwrap(), "foo/bar");
+        assert_eq!(Path::new_opt(b!("foo/bar", 0)), None);
+        t!(v: Path::new_opt(b!("foo/bar")).unwrap(), b!("foo/bar"));
+        assert_eq!(Path::new_opt("foo/bar\0"), None);
+        t!(s: Path::new_opt("foo/bar").unwrap(), "foo/bar");
     }
 
     #[test]
@@ -528,7 +528,7 @@ mod tests {
             assert_eq!(v.as_slice(), b!("foo/bar", 0));
             (b!("/bar").to_owned())
         }).inside(|| {
-            Path::init(b!("foo/bar", 0))
+            Path::new(b!("foo/bar", 0))
         });
         assert!(handled);
         assert_eq!(p.as_vec(), b!("/bar"));
@@ -576,12 +576,12 @@ mod tests {
             cond.trap(|_| {
                 (b!("null", 0).to_owned())
             }).inside(|| {
-                Path::init(b!("foo/bar", 0))
+                Path::new(b!("foo/bar", 0))
             });
         })
 
         t!(~"set_filename w/nul" => {
-            let mut p = Path::init(b!("foo/bar"));
+            let mut p = Path::new(b!("foo/bar"));
             cond.trap(|_| {
                 (b!("null", 0).to_owned())
             }).inside(|| {
@@ -590,7 +590,7 @@ mod tests {
         })
 
         t!(~"push w/nul" => {
-            let mut p = Path::init(b!("foo/bar"));
+            let mut p = Path::new(b!("foo/bar"));
             cond.trap(|_| {
                 (b!("null", 0).to_owned())
             }).inside(|| {
@@ -604,7 +604,7 @@ mod tests {
         macro_rules! t(
             ($path:expr, $disp:ident, $exp:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     assert_eq!(path.$disp().to_str(), ~$exp);
                 }
             )
@@ -620,7 +620,7 @@ mod tests {
             ($path:expr, $exp:expr) => (
                 {
                     let mut called = false;
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     path.display().with_str(|s| {
                         assert_eq!(s, $exp);
                         called = true;
@@ -631,7 +631,7 @@ mod tests {
             ($path:expr, $exp:expr, filename) => (
                 {
                     let mut called = false;
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     path.filename_display().with_str(|s| {
                         assert_eq!(s, $exp);
                         called = true;
@@ -654,7 +654,7 @@ mod tests {
         macro_rules! t(
             ($path:expr, $exp:expr, $expf:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     let f = format!("{}", path.display());
                     assert_eq!(f.as_slice(), $exp);
                     let f = format!("{}", path.filename_display());
@@ -677,20 +677,20 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $op:ident, $exp:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     assert_eq!(path.$op(), ($exp).as_bytes());
                 }
             );
             (s: $path:expr, $op:ident, $exp:expr, opt) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     let left = path.$op().map(|x| str::from_utf8(x));
                     assert_eq!(left, $exp);
                 }
             );
             (v: $path:expr, $op:ident, $exp:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     assert_eq!(path.$op(), $exp);
                 }
             );
@@ -762,7 +762,7 @@ mod tests {
                 {
                     let path = ($path);
                     let join = ($join);
-                    let mut p1 = Path::init(path);
+                    let mut p1 = Path::new(path);
                     let p2 = p1.clone();
                     p1.push(join);
                     assert_eq!(p1, p2.join(join));
@@ -781,8 +781,8 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $push:expr, $exp:expr) => (
                 {
-                    let mut p = Path::init($path);
-                    let push = Path::init($push);
+                    let mut p = Path::new($path);
+                    let push = Path::new($push);
                     p.push(&push);
                     assert_eq!(p.as_str(), Some($exp));
                 }
@@ -804,14 +804,14 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $push:expr, $exp:expr) => (
                 {
-                    let mut p = Path::init($path);
+                    let mut p = Path::new($path);
                     p.push_many($push);
                     assert_eq!(p.as_str(), Some($exp));
                 }
             );
             (v: $path:expr, $push:expr, $exp:expr) => (
                 {
-                    let mut p = Path::init($path);
+                    let mut p = Path::new($path);
                     p.push_many($push);
                     assert_eq!(p.as_vec(), $exp);
                 }
@@ -835,7 +835,7 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $left:expr, $right:expr) => (
                 {
-                    let mut p = Path::init($path);
+                    let mut p = Path::new($path);
                     let result = p.pop();
                     assert_eq!(p.as_str(), Some($left));
                     assert_eq!(result, $right);
@@ -843,7 +843,7 @@ mod tests {
             );
             (v: [$($path:expr),+], [$($left:expr),+], $right:expr) => (
                 {
-                    let mut p = Path::init(b!($($path),+));
+                    let mut p = Path::new(b!($($path),+));
                     let result = p.pop();
                     assert_eq!(p.as_vec(), b!($($left),+));
                     assert_eq!(result, $right);
@@ -869,21 +869,21 @@ mod tests {
 
     #[test]
     fn test_root_path() {
-        assert_eq!(Path::init(b!("a/b/c")).root_path(), None);
-        assert_eq!(Path::init(b!("/a/b/c")).root_path(), Some(Path::init("/")));
+        assert_eq!(Path::new(b!("a/b/c")).root_path(), None);
+        assert_eq!(Path::new(b!("/a/b/c")).root_path(), Some(Path::new("/")));
     }
 
     #[test]
     fn test_join() {
-        t!(v: Path::init(b!("a/b/c")).join(b!("..")), b!("a/b"));
-        t!(v: Path::init(b!("/a/b/c")).join(b!("d")), b!("/a/b/c/d"));
-        t!(v: Path::init(b!("a/", 0x80, "/c")).join(b!(0xff)), b!("a/", 0x80, "/c/", 0xff));
-        t!(s: Path::init("a/b/c").join(".."), "a/b");
-        t!(s: Path::init("/a/b/c").join("d"), "/a/b/c/d");
-        t!(s: Path::init("a/b").join("c/d"), "a/b/c/d");
-        t!(s: Path::init("a/b").join("/c/d"), "/c/d");
-        t!(s: Path::init(".").join("a/b"), "a/b");
-        t!(s: Path::init("/").join("a/b"), "/a/b");
+        t!(v: Path::new(b!("a/b/c")).join(b!("..")), b!("a/b"));
+        t!(v: Path::new(b!("/a/b/c")).join(b!("d")), b!("/a/b/c/d"));
+        t!(v: Path::new(b!("a/", 0x80, "/c")).join(b!(0xff)), b!("a/", 0x80, "/c/", 0xff));
+        t!(s: Path::new("a/b/c").join(".."), "a/b");
+        t!(s: Path::new("/a/b/c").join("d"), "/a/b/c/d");
+        t!(s: Path::new("a/b").join("c/d"), "a/b/c/d");
+        t!(s: Path::new("a/b").join("/c/d"), "/c/d");
+        t!(s: Path::new(".").join("a/b"), "a/b");
+        t!(s: Path::new("/").join("a/b"), "/a/b");
     }
 
     #[test]
@@ -891,8 +891,8 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $join:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
-                    let join = Path::init($join);
+                    let path = Path::new($path);
+                    let join = Path::new($join);
                     let res = path.join(&join);
                     assert_eq!(res.as_str(), Some($exp));
                 }
@@ -914,14 +914,14 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $join:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     let res = path.join_many($join);
                     assert_eq!(res.as_str(), Some($exp));
                 }
             );
             (v: $path:expr, $join:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     let res = path.join_many($join);
                     assert_eq!(res.as_vec(), $exp);
                 }
@@ -943,51 +943,51 @@ mod tests {
     fn test_with_helpers() {
         let empty: &[u8] = [];
 
-        t!(v: Path::init(b!("a/b/c")).with_filename(b!("d")), b!("a/b/d"));
-        t!(v: Path::init(b!("a/b/c", 0xff)).with_filename(b!(0x80)), b!("a/b/", 0x80));
-        t!(v: Path::init(b!("/", 0xff, "/foo")).with_filename(b!(0xcd)),
+        t!(v: Path::new(b!("a/b/c")).with_filename(b!("d")), b!("a/b/d"));
+        t!(v: Path::new(b!("a/b/c", 0xff)).with_filename(b!(0x80)), b!("a/b/", 0x80));
+        t!(v: Path::new(b!("/", 0xff, "/foo")).with_filename(b!(0xcd)),
               b!("/", 0xff, "/", 0xcd));
-        t!(s: Path::init("a/b/c").with_filename("d"), "a/b/d");
-        t!(s: Path::init(".").with_filename("foo"), "foo");
-        t!(s: Path::init("/a/b/c").with_filename("d"), "/a/b/d");
-        t!(s: Path::init("/").with_filename("foo"), "/foo");
-        t!(s: Path::init("/a").with_filename("foo"), "/foo");
-        t!(s: Path::init("foo").with_filename("bar"), "bar");
-        t!(s: Path::init("/").with_filename("foo/"), "/foo");
-        t!(s: Path::init("/a").with_filename("foo/"), "/foo");
-        t!(s: Path::init("a/b/c").with_filename(""), "a/b");
-        t!(s: Path::init("a/b/c").with_filename("."), "a/b");
-        t!(s: Path::init("a/b/c").with_filename(".."), "a");
-        t!(s: Path::init("/a").with_filename(""), "/");
-        t!(s: Path::init("foo").with_filename(""), ".");
-        t!(s: Path::init("a/b/c").with_filename("d/e"), "a/b/d/e");
-        t!(s: Path::init("a/b/c").with_filename("/d"), "a/b/d");
-        t!(s: Path::init("..").with_filename("foo"), "../foo");
-        t!(s: Path::init("../..").with_filename("foo"), "../../foo");
-        t!(s: Path::init("..").with_filename(""), "..");
-        t!(s: Path::init("../..").with_filename(""), "../..");
+        t!(s: Path::new("a/b/c").with_filename("d"), "a/b/d");
+        t!(s: Path::new(".").with_filename("foo"), "foo");
+        t!(s: Path::new("/a/b/c").with_filename("d"), "/a/b/d");
+        t!(s: Path::new("/").with_filename("foo"), "/foo");
+        t!(s: Path::new("/a").with_filename("foo"), "/foo");
+        t!(s: Path::new("foo").with_filename("bar"), "bar");
+        t!(s: Path::new("/").with_filename("foo/"), "/foo");
+        t!(s: Path::new("/a").with_filename("foo/"), "/foo");
+        t!(s: Path::new("a/b/c").with_filename(""), "a/b");
+        t!(s: Path::new("a/b/c").with_filename("."), "a/b");
+        t!(s: Path::new("a/b/c").with_filename(".."), "a");
+        t!(s: Path::new("/a").with_filename(""), "/");
+        t!(s: Path::new("foo").with_filename(""), ".");
+        t!(s: Path::new("a/b/c").with_filename("d/e"), "a/b/d/e");
+        t!(s: Path::new("a/b/c").with_filename("/d"), "a/b/d");
+        t!(s: Path::new("..").with_filename("foo"), "../foo");
+        t!(s: Path::new("../..").with_filename("foo"), "../../foo");
+        t!(s: Path::new("..").with_filename(""), "..");
+        t!(s: Path::new("../..").with_filename(""), "../..");
 
-        t!(v: Path::init(b!("hi/there", 0x80, ".txt")).with_extension(b!("exe")),
+        t!(v: Path::new(b!("hi/there", 0x80, ".txt")).with_extension(b!("exe")),
               b!("hi/there", 0x80, ".exe"));
-        t!(v: Path::init(b!("hi/there.txt", 0x80)).with_extension(b!(0xff)),
+        t!(v: Path::new(b!("hi/there.txt", 0x80)).with_extension(b!(0xff)),
               b!("hi/there.", 0xff));
-        t!(v: Path::init(b!("hi/there", 0x80)).with_extension(b!(0xff)),
+        t!(v: Path::new(b!("hi/there", 0x80)).with_extension(b!(0xff)),
               b!("hi/there", 0x80, ".", 0xff));
-        t!(v: Path::init(b!("hi/there.", 0xff)).with_extension(empty), b!("hi/there"));
-        t!(s: Path::init("hi/there.txt").with_extension("exe"), "hi/there.exe");
-        t!(s: Path::init("hi/there.txt").with_extension(""), "hi/there");
-        t!(s: Path::init("hi/there.txt").with_extension("."), "hi/there..");
-        t!(s: Path::init("hi/there.txt").with_extension(".."), "hi/there...");
-        t!(s: Path::init("hi/there").with_extension("txt"), "hi/there.txt");
-        t!(s: Path::init("hi/there").with_extension("."), "hi/there..");
-        t!(s: Path::init("hi/there").with_extension(".."), "hi/there...");
-        t!(s: Path::init("hi/there.").with_extension("txt"), "hi/there.txt");
-        t!(s: Path::init("hi/.foo").with_extension("txt"), "hi/.foo.txt");
-        t!(s: Path::init("hi/there.txt").with_extension(".foo"), "hi/there..foo");
-        t!(s: Path::init("/").with_extension("txt"), "/");
-        t!(s: Path::init("/").with_extension("."), "/");
-        t!(s: Path::init("/").with_extension(".."), "/");
-        t!(s: Path::init(".").with_extension("txt"), ".");
+        t!(v: Path::new(b!("hi/there.", 0xff)).with_extension(empty), b!("hi/there"));
+        t!(s: Path::new("hi/there.txt").with_extension("exe"), "hi/there.exe");
+        t!(s: Path::new("hi/there.txt").with_extension(""), "hi/there");
+        t!(s: Path::new("hi/there.txt").with_extension("."), "hi/there..");
+        t!(s: Path::new("hi/there.txt").with_extension(".."), "hi/there...");
+        t!(s: Path::new("hi/there").with_extension("txt"), "hi/there.txt");
+        t!(s: Path::new("hi/there").with_extension("."), "hi/there..");
+        t!(s: Path::new("hi/there").with_extension(".."), "hi/there...");
+        t!(s: Path::new("hi/there.").with_extension("txt"), "hi/there.txt");
+        t!(s: Path::new("hi/.foo").with_extension("txt"), "hi/.foo.txt");
+        t!(s: Path::new("hi/there.txt").with_extension(".foo"), "hi/there..foo");
+        t!(s: Path::new("/").with_extension("txt"), "/");
+        t!(s: Path::new("/").with_extension("."), "/");
+        t!(s: Path::new("/").with_extension(".."), "/");
+        t!(s: Path::new(".").with_extension("txt"), ".");
     }
 
     #[test]
@@ -997,9 +997,9 @@ mod tests {
                 {
                     let path = $path;
                     let arg = $arg;
-                    let mut p1 = Path::init(path);
+                    let mut p1 = Path::new(path);
                     p1.$set(arg);
-                    let p2 = Path::init(path);
+                    let p2 = Path::new(path);
                     assert_eq!(p1, p2.$with(arg));
                 }
             );
@@ -1007,9 +1007,9 @@ mod tests {
                 {
                     let path = $path;
                     let arg = $arg;
-                    let mut p1 = Path::init(path);
+                    let mut p1 = Path::new(path);
                     p1.$set(arg);
-                    let p2 = Path::init(path);
+                    let p2 = Path::new(path);
                     assert_eq!(p1, p2.$with(arg));
                 }
             )
@@ -1069,39 +1069,39 @@ mod tests {
             )
         )
 
-        t!(v: Path::init(b!("a/b/c")), Some(b!("c")), b!("a/b"), Some(b!("c")), None);
-        t!(v: Path::init(b!("a/b/", 0xff)), Some(b!(0xff)), b!("a/b"), Some(b!(0xff)), None);
-        t!(v: Path::init(b!("hi/there.", 0xff)), Some(b!("there.", 0xff)), b!("hi"),
+        t!(v: Path::new(b!("a/b/c")), Some(b!("c")), b!("a/b"), Some(b!("c")), None);
+        t!(v: Path::new(b!("a/b/", 0xff)), Some(b!(0xff)), b!("a/b"), Some(b!(0xff)), None);
+        t!(v: Path::new(b!("hi/there.", 0xff)), Some(b!("there.", 0xff)), b!("hi"),
               Some(b!("there")), Some(b!(0xff)));
-        t!(s: Path::init("a/b/c"), Some("c"), Some("a/b"), Some("c"), None);
-        t!(s: Path::init("."), None, Some("."), None, None);
-        t!(s: Path::init("/"), None, Some("/"), None, None);
-        t!(s: Path::init(".."), None, Some(".."), None, None);
-        t!(s: Path::init("../.."), None, Some("../.."), None, None);
-        t!(s: Path::init("hi/there.txt"), Some("there.txt"), Some("hi"),
+        t!(s: Path::new("a/b/c"), Some("c"), Some("a/b"), Some("c"), None);
+        t!(s: Path::new("."), None, Some("."), None, None);
+        t!(s: Path::new("/"), None, Some("/"), None, None);
+        t!(s: Path::new(".."), None, Some(".."), None, None);
+        t!(s: Path::new("../.."), None, Some("../.."), None, None);
+        t!(s: Path::new("hi/there.txt"), Some("there.txt"), Some("hi"),
               Some("there"), Some("txt"));
-        t!(s: Path::init("hi/there"), Some("there"), Some("hi"), Some("there"), None);
-        t!(s: Path::init("hi/there."), Some("there."), Some("hi"),
+        t!(s: Path::new("hi/there"), Some("there"), Some("hi"), Some("there"), None);
+        t!(s: Path::new("hi/there."), Some("there."), Some("hi"),
               Some("there"), Some(""));
-        t!(s: Path::init("hi/.there"), Some(".there"), Some("hi"), Some(".there"), None);
-        t!(s: Path::init("hi/..there"), Some("..there"), Some("hi"),
+        t!(s: Path::new("hi/.there"), Some(".there"), Some("hi"), Some(".there"), None);
+        t!(s: Path::new("hi/..there"), Some("..there"), Some("hi"),
               Some("."), Some("there"));
-        t!(s: Path::init(b!("a/b/", 0xff)), None, Some("a/b"), None, None);
-        t!(s: Path::init(b!("a/b/", 0xff, ".txt")), None, Some("a/b"), None, Some("txt"));
-        t!(s: Path::init(b!("a/b/c.", 0x80)), None, Some("a/b"), Some("c"), None);
-        t!(s: Path::init(b!(0xff, "/b")), Some("b"), None, Some("b"), None);
+        t!(s: Path::new(b!("a/b/", 0xff)), None, Some("a/b"), None, None);
+        t!(s: Path::new(b!("a/b/", 0xff, ".txt")), None, Some("a/b"), None, Some("txt"));
+        t!(s: Path::new(b!("a/b/c.", 0x80)), None, Some("a/b"), Some("c"), None);
+        t!(s: Path::new(b!(0xff, "/b")), Some("b"), None, Some("b"), None);
     }
 
     #[test]
     fn test_dir_path() {
-        t!(v: Path::init(b!("hi/there", 0x80)).dir_path(), b!("hi"));
-        t!(v: Path::init(b!("hi", 0xff, "/there")).dir_path(), b!("hi", 0xff));
-        t!(s: Path::init("hi/there").dir_path(), "hi");
-        t!(s: Path::init("hi").dir_path(), ".");
-        t!(s: Path::init("/hi").dir_path(), "/");
-        t!(s: Path::init("/").dir_path(), "/");
-        t!(s: Path::init("..").dir_path(), "..");
-        t!(s: Path::init("../..").dir_path(), "../..");
+        t!(v: Path::new(b!("hi/there", 0x80)).dir_path(), b!("hi"));
+        t!(v: Path::new(b!("hi", 0xff, "/there")).dir_path(), b!("hi", 0xff));
+        t!(s: Path::new("hi/there").dir_path(), "hi");
+        t!(s: Path::new("hi").dir_path(), ".");
+        t!(s: Path::new("/hi").dir_path(), "/");
+        t!(s: Path::new("/").dir_path(), "/");
+        t!(s: Path::new("..").dir_path(), "..");
+        t!(s: Path::new("../..").dir_path(), "../..");
     }
 
     #[test]
@@ -1109,7 +1109,7 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $abs:expr, $rel:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     assert_eq!(path.is_absolute(), $abs);
                     assert_eq!(path.is_relative(), $rel);
                 }
@@ -1130,8 +1130,8 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $dest:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
-                    let dest = Path::init($dest);
+                    let path = Path::new($path);
+                    let dest = Path::new($dest);
                     assert_eq!(path.is_ancestor_of(&dest), $exp);
                 }
             )
@@ -1164,15 +1164,15 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $child:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
-                    let child = Path::init($child);
+                    let path = Path::new($path);
+                    let child = Path::new($child);
                     assert_eq!(path.ends_with_path(&child), $exp);
                 }
             );
             (v: $path:expr, $child:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
-                    let child = Path::init($child);
+                    let path = Path::new($path);
+                    let child = Path::new($child);
                     assert_eq!(path.ends_with_path(&child), $exp);
                 }
             )
@@ -1203,8 +1203,8 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $other:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
-                    let other = Path::init($other);
+                    let path = Path::new($path);
+                    let other = Path::new($other);
                     let res = path.path_relative_from(&other);
                     assert_eq!(res.as_ref().and_then(|x| x.as_str()), $exp);
                 }
@@ -1248,7 +1248,7 @@ mod tests {
         macro_rules! t(
             (s: $path:expr, $exp:expr) => (
                 {
-                    let path = Path::init($path);
+                    let path = Path::new($path);
                     let comps = path.components().to_owned_vec();
                     let exp: &[&str] = $exp;
                     let exps = exp.iter().map(|x| x.as_bytes()).to_owned_vec();
@@ -1262,7 +1262,7 @@ mod tests {
             );
             (v: [$($arg:expr),+], [$([$($exp:expr),*]),*]) => (
                 {
-                    let path = Path::init(b!($($arg),+));
+                    let path = Path::new(b!($($arg),+));
                     let comps = path.components().to_owned_vec();
                     let exp: &[&[u8]] = [$(b!($($exp),*)),*];
                     assert!(comps.as_slice() == exp, "components: Expected {:?}, found {:?}",
@@ -1297,7 +1297,7 @@ mod tests {
         macro_rules! t(
             (v: [$($arg:expr),+], $exp:expr) => (
                 {
-                    let path = Path::init(b!($($arg),+));
+                    let path = Path::new(b!($($arg),+));
                     let comps = path.str_components().to_owned_vec();
                     let exp: &[Option<&str>] = $exp;
                     assert!(comps.as_slice() == exp,
@@ -1327,7 +1327,7 @@ mod bench {
 
     #[bench]
     fn join_home_dir(bh: &mut BenchHarness) {
-        let posix_path = Path::init("/");
+        let posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.join("home");
         });
@@ -1335,7 +1335,7 @@ mod bench {
 
     #[bench]
     fn join_abs_path_home_dir(bh: &mut BenchHarness) {
-        let posix_path = Path::init("/");
+        let posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.join("/home");
         });
@@ -1343,7 +1343,7 @@ mod bench {
 
     #[bench]
     fn join_many_home_dir(bh: &mut BenchHarness) {
-        let posix_path = Path::init("/");
+        let posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.join_many(&["home"]);
         });
@@ -1351,7 +1351,7 @@ mod bench {
 
     #[bench]
     fn join_many_abs_path_home_dir(bh: &mut BenchHarness) {
-        let posix_path = Path::init("/");
+        let posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.join_many(&["/home"]);
         });
@@ -1359,7 +1359,7 @@ mod bench {
 
     #[bench]
     fn push_home_dir(bh: &mut BenchHarness) {
-        let mut posix_path = Path::init("/");
+        let mut posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.push("home");
         });
@@ -1367,7 +1367,7 @@ mod bench {
 
     #[bench]
     fn push_abs_path_home_dir(bh: &mut BenchHarness) {
-        let mut posix_path = Path::init("/");
+        let mut posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.push("/home");
         });
@@ -1375,7 +1375,7 @@ mod bench {
 
     #[bench]
     fn push_many_home_dir(bh: &mut BenchHarness) {
-        let mut posix_path = Path::init("/");
+        let mut posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.push_many(&["home"]);
         });
@@ -1383,7 +1383,7 @@ mod bench {
 
     #[bench]
     fn push_many_abs_path_home_dir(bh: &mut BenchHarness) {
-        let mut posix_path = Path::init("/");
+        let mut posix_path = Path::new("/");
         bh.iter(|| {
             posix_path.push_many(&["/home"]);
         });
@@ -1391,17 +1391,17 @@ mod bench {
 
     #[bench]
     fn ends_with_path_home_dir(bh: &mut BenchHarness) {
-        let posix_home_path = Path::init("/home");
+        let posix_home_path = Path::new("/home");
         bh.iter(|| {
-            posix_home_path.ends_with_path(&Path::init("home"));
+            posix_home_path.ends_with_path(&Path::new("home"));
         });
     }
 
     #[bench]
     fn ends_with_path_missmatch_jome_home(bh: &mut BenchHarness) {
-        let posix_home_path = Path::init("/home");
+        let posix_home_path = Path::new("/home");
         bh.iter(|| {
-            posix_home_path.ends_with_path(&Path::init("jome"));
+            posix_home_path.ends_with_path(&Path::new("jome"));
         });
     }
 }

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -61,7 +61,7 @@ impl OSRng {
     #[cfg(unix)]
     pub fn new() -> OSRng {
         use path::Path;
-        let reader = File::open(&Path::init("/dev/urandom"));
+        let reader = File::open(&Path::new("/dev/urandom"));
         let reader = reader.expect("Error opening /dev/urandom");
         let reader_rng = ReaderRng::new(reader);
 

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -281,7 +281,7 @@ fn run_(main: proc(), use_main_sched: bool) -> int {
 
     // Create a work queue for each scheduler, ntimes. Create an extra
     // for the main thread if that flag is set. We won't steal from it.
-    let mut pool = deque::BufferPool::init();
+    let mut pool = deque::BufferPool::new();
     let arr = vec::from_fn(nscheds, |_| pool.deque());
     let (workers, stealers) = vec::unzip(arr.move_iter());
 

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -1002,7 +1002,7 @@ mod test {
         do run_in_bare_thread {
 
             let sleepers = SleeperList::new();
-            let mut pool = BufferPool::init();
+            let mut pool = BufferPool::new();
             let (normal_worker, normal_stealer) = pool.deque();
             let (special_worker, special_stealer) = pool.deque();
             let queues = ~[normal_stealer, special_stealer];
@@ -1177,7 +1177,7 @@ mod test {
         do run_in_bare_thread {
             stress_factor().times(|| {
                 let sleepers = SleeperList::new();
-                let mut pool = BufferPool::init();
+                let mut pool = BufferPool::new();
                 let (worker, stealer) = pool.deque();
 
                 let mut sched = ~Scheduler::new(

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -381,7 +381,7 @@ pub fn next_test_unix() -> Path {
     if cfg!(unix) {
         os::tmpdir().join(rand::task_rng().gen_ascii_str(20))
     } else {
-        Path::init(r"\\.\pipe\" + rand::task_rng().gen_ascii_str(20))
+        Path::new(r"\\.\pipe\" + rand::task_rng().gen_ascii_str(20))
     }
 }
 

--- a/src/libstd/rt/test.rs
+++ b/src/libstd/rt/test.rs
@@ -36,7 +36,7 @@ use vec::{OwnedVector, MutableVector, ImmutableVector};
 
 pub fn new_test_uv_sched() -> Scheduler {
 
-    let mut pool = BufferPool::init();
+    let mut pool = BufferPool::new();
     let (worker, stealer) = pool.deque();
 
     let mut sched = Scheduler::new(new_event_loop(),
@@ -51,7 +51,7 @@ pub fn new_test_uv_sched() -> Scheduler {
 }
 
 pub fn new_test_sched() -> Scheduler {
-    let mut pool = BufferPool::init();
+    let mut pool = BufferPool::new();
     let (worker, stealer) = pool.deque();
 
     let mut sched = Scheduler::new(basic::event_loop(),
@@ -228,7 +228,7 @@ pub fn run_in_mt_newsched_task(f: proc()) {
         let mut handles = ~[];
         let mut scheds = ~[];
 
-        let mut pool = BufferPool::<~Task>::init();
+        let mut pool = BufferPool::<~Task>::new();
         let workers = range(0, nthreads).map(|_| pool.deque());
         let (workers, stealers) = vec::unzip(workers);
 

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -506,7 +506,7 @@ mod tests {
 
         let output = str::from_utf8_owned(prog.finish_with_output().output);
         let parent_dir = os::getcwd();
-        let child_dir = Path::init(output.trim());
+        let child_dir = Path::new(output.trim());
 
         let parent_stat = parent_dir.stat();
         let child_stat = child_dir.stat();
@@ -523,7 +523,7 @@ mod tests {
         let mut prog = run_pwd(Some(&parent_dir));
 
         let output = str::from_utf8_owned(prog.finish_with_output().output);
-        let child_dir = Path::init(output.trim());
+        let child_dir = Path::new(output.trim());
 
         let parent_stat = parent_dir.stat();
         let child_stat = child_dir.stat();

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -122,7 +122,7 @@ mod test {
     fn test_errors_do_not_crash() {
         // Open /dev/null as a library to get an error, and make sure
         // that only causes an error, and not a crash.
-        let path = GenericPath::init("/dev/null");
+        let path = GenericPath::new("/dev/null");
         match DynamicLibrary::open(Some(&path)) {
             Err(_) => {}
             Ok(_) => fail!("Successfully opened the empty library.")

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -82,7 +82,7 @@ pub fn expand_include(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     let file = get_single_str_from_tts(cx, sp, tts, "include!");
     let p = parse::new_sub_parser_from_file(
         cx.parse_sess(), cx.cfg(),
-        &res_rel_file(cx, sp, &Path::init(file)), sp);
+        &res_rel_file(cx, sp, &Path::new(file)), sp);
     base::MRExpr(p.parse_expr())
 }
 
@@ -90,7 +90,7 @@ pub fn expand_include(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
 pub fn expand_include_str(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let file = get_single_str_from_tts(cx, sp, tts, "include_str!");
-    let file = res_rel_file(cx, sp, &Path::init(file));
+    let file = res_rel_file(cx, sp, &Path::new(file));
     let bytes = match io::result(|| File::open(&file).read_to_end()) {
         Err(e) => {
             cx.span_fatal(sp, format!("couldn't read {}: {}",
@@ -112,7 +112,7 @@ pub fn expand_include_bin(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     use std::at_vec;
 
     let file = get_single_str_from_tts(cx, sp, tts, "include_bin!");
-    let file = res_rel_file(cx, sp, &Path::init(file));
+    let file = res_rel_file(cx, sp, &Path::new(file));
     match io::result(|| File::open(&file).read_to_end()) {
         Err(e) => {
             cx.span_fatal(sp, format!("couldn't read {}: {}",
@@ -156,7 +156,7 @@ fn topmost_expn_info(expn_info: @codemap::ExpnInfo) -> @codemap::ExpnInfo {
 fn res_rel_file(cx: @ExtCtxt, sp: codemap::Span, arg: &Path) -> Path {
     // NB: relative paths are resolved relative to the compilation unit
     if !arg.is_absolute() {
-        let mut cu = Path::init(cx.codemap().span_to_filename(sp));
+        let mut cu = Path::new(cx.codemap().span_to_filename(sp));
         cu.pop();
         cu.push(arg);
         cu

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -344,7 +344,7 @@ mod test {
     #[cfg(test)]
     fn to_json_str<'a, E: Encodable<extra::json::Encoder<'a>>>(val: &E) -> ~str {
         let mut writer = MemWriter::new();
-        let mut encoder = extra::json::Encoder::init(&mut writer as &mut io::Writer);
+        let mut encoder = extra::json::Encoder::new(&mut writer as &mut io::Writer);
         val.encode(&mut encoder);
         str::from_utf8_owned(writer.inner())
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4232,10 +4232,10 @@ impl Parser {
                     outer_attrs: &[ast::Attribute],
                     id_sp: Span)
                     -> (ast::item_, ~[ast::Attribute]) {
-        let mut prefix = Path::init(self.sess.cm.span_to_filename(*self.span));
+        let mut prefix = Path::new(self.sess.cm.span_to_filename(*self.span));
         prefix.pop();
         let mod_path_stack = &*self.mod_path_stack;
-        let mod_path = Path::init(".").join_many(*mod_path_stack);
+        let mod_path = Path::new(".").join_many(*mod_path_stack);
         let dir_path = prefix.join(&mod_path);
         let file_path = match ::attr::first_attr_value_str_by_name(
                 outer_attrs, "path") {

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -72,7 +72,7 @@ fn shift_push() {
 fn read_line() {
     use std::io::buffered::BufferedReader;
 
-    let mut path = Path::init(env!("CFG_SRC_DIR"));
+    let mut path = Path::new(env!("CFG_SRC_DIR"));
     path.push("src/test/bench/shootout-k-nucleotide.data");
 
     for _ in range(0, 3) {

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -123,7 +123,7 @@ fn main() {
     };
 
     let writer = if os::getenv("RUST_BENCH").is_some() {
-        let file = File::create(&Path::init("./shootout-fasta.data"));
+        let file = File::create(&Path::new("./shootout-fasta.data"));
         @mut file as @mut io::Writer
     } else {
         @mut io::stdout() as @mut io::Writer

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -35,7 +35,7 @@ fn make_complements() -> [u8, ..256] {
 fn main() {
     let complements = make_complements();
     let mut data = if std::os::getenv("RUST_BENCH").is_some() {
-        File::open(&Path::init("shootout-k-nucleotide.data")).read_to_end()
+        File::open(&Path::new("shootout-k-nucleotide.data")).read_to_end()
     } else {
         stdin().read_to_end()
     };

--- a/src/test/run-pass/glob-std.rs
+++ b/src/test/run-pass/glob-std.rs
@@ -22,14 +22,14 @@ use std::io;
 pub fn main() {
     fn mk_file(path: &str, directory: bool) {
         if directory {
-            io::fs::mkdir(&Path::init(path), io::UserRWX);
+            io::fs::mkdir(&Path::new(path), io::UserRWX);
         } else {
-            io::File::create(&Path::init(path));
+            io::File::create(&Path::new(path));
         }
     }
 
     fn abs_path(path: &str) -> Path {
-        os::getcwd().join(&Path::init(path))
+        os::getcwd().join(&Path::new(path))
     }
 
     fn glob_vec(pattern: &str) -> ~[Path] {

--- a/src/test/run-pass/issue-3424.rs
+++ b/src/test/run-pass/issue-3424.rs
@@ -23,7 +23,7 @@ fn tester()
 {
     let loader: rsrc_loader = proc(_path) {result::Ok(~"more blah")};
 
-    let path = path::Path::init("blah");
+    let path = path::Path::new("blah");
     assert!(loader(&path).is_ok());
 }
 

--- a/src/test/run-pass/issue-4016.rs
+++ b/src/test/run-pass/issue-4016.rs
@@ -18,7 +18,7 @@ trait JD : Decodable<json::Decoder> { }
 
 fn exec<T: JD>() {
     let doc = json::from_str("").unwrap();
-    let mut decoder = json::Decoder::init(doc);
+    let mut decoder = json::Decoder::new(doc);
     let _v: T = Decodable::decode(&mut decoder);
     fail!()
 }

--- a/src/test/run-pass/issue-4036.rs
+++ b/src/test/run-pass/issue-4036.rs
@@ -17,6 +17,6 @@ use self::extra::serialize;
 
 pub fn main() {
     let json = json::from_str("[1]").unwrap();
-    let mut decoder = json::Decoder::init(json);
+    let mut decoder = json::Decoder::new(json);
     let _x: ~[int] = serialize::Decodable::decode(&mut decoder);
 }

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -16,7 +16,7 @@ use extra::tempfile;
 use std::io::File;
 
 pub fn main() {
-    let dir = tempfile::TempDir::new_in(&Path::init("."), "").unwrap();
+    let dir = tempfile::TempDir::new_in(&Path::new("."), "").unwrap();
     let path = dir.path().join("file");
 
     {

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -30,7 +30,7 @@ use std::io::fs;
 
 fn test_tempdir() {
     let path = {
-        let p = TempDir::new_in(&Path::init("."), "foobar").unwrap();
+        let p = TempDir::new_in(&Path::new("."), "foobar").unwrap();
         let p = p.path();
         assert!(p.as_vec().ends_with(bytes!("foobar")));
         p.clone()
@@ -83,7 +83,7 @@ fn test_rm_tempdir() {
 // Ideally these would be in std::os but then core would need
 // to depend on std
 fn recursive_mkdir_rel() {
-    let path = Path::init("frob");
+    let path = Path::new("frob");
     let cwd = os::getcwd();
     debug!("recursive_mkdir_rel: Making: {} in cwd {} [{:?}]", path.display(),
            cwd.display(), path.exists());
@@ -94,21 +94,21 @@ fn recursive_mkdir_rel() {
 }
 
 fn recursive_mkdir_dot() {
-    let dot = Path::init(".");
+    let dot = Path::new(".");
     fs::mkdir_recursive(&dot, io::UserRWX);
-    let dotdot = Path::init("..");
+    let dotdot = Path::new("..");
     fs::mkdir_recursive(&dotdot, io::UserRWX);
 }
 
 fn recursive_mkdir_rel_2() {
-    let path = Path::init("./frob/baz");
+    let path = Path::new("./frob/baz");
     let cwd = os::getcwd();
     debug!("recursive_mkdir_rel_2: Making: {} in cwd {} [{:?}]", path.display(),
            cwd.display(), path.exists());
     fs::mkdir_recursive(&path, io::UserRWX);
     assert!(path.is_dir());
     assert!(path.dir_path().is_dir());
-    let path2 = Path::init("quux/blat");
+    let path2 = Path::new("quux/blat");
     debug!("recursive_mkdir_rel_2: Making: {} in cwd {}", path2.display(),
            cwd.display());
     fs::mkdir_recursive(&path2, io::UserRWX);


### PR DESCRIPTION
Rename the `*::init()` functions back to `*::new()`, since `new` is not
going to become a keyword.
