### PR TITLE
Decode a float into integers

### DIFF
--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -532,6 +532,8 @@ pub trait Float: Real
     fn ln_1p(&self) -> Self;
     fn mul_add(&self, a: Self, b: Self) -> Self;
     fn next_after(&self, other: Self) -> Self;
+
+    fn integer_decode(&self) -> (u64, i16, i8);
 }
 
 /// Returns the exponential of the number, minus `1`, `exp(n) - 1`, in a way


### PR DESCRIPTION
The `integer_decode()` function decodes a float (f32/f64)
into integers containing the mantissa, exponent and sign.

It's needed for `rationalize()` implementation of #9838.

The code got ported from ABCL [1].

[1] http://abcl.org/trac/browser/trunk/abcl/src/org/armedbear/lisp/FloatFunctions.java?rev=14465#L94

I got the permission to use this code for Rust from Peter Graves (the ABCL copyright holder) . If there's any further IP clearance needed, let me know.
