### PR TITLE
Support imports of the form `use {foo,bar}`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4813,6 +4813,21 @@ impl Parser {
     fn parse_view_path(&self) -> @view_path {
         let lo = self.span.lo;
 
+        if *self.token == token::LBRACE {
+            // use {foo,bar}
+            let idents = self.parse_unspanned_seq(
+                &token::LBRACE, &token::RBRACE,
+                seq_sep_trailing_allowed(token::COMMA),
+                |p| p.parse_path_list_ident());
+            let path = ast::Path {
+                span: mk_sp(lo, self.span.hi),
+                global: false,
+                segments: ~[]
+            };
+            return @spanned(lo, self.span.hi,
+                            view_path_list(path, idents, ast::DUMMY_NODE_ID));
+        }
+
         let first_ident = self.parse_ident();
         let mut path = ~[first_ident];
         debug!("parsed view_path: {}", self.id_to_str(first_ident));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1935,8 +1935,12 @@ pub fn print_view_path(s: @ps, vp: &ast::view_path) {
       }
 
       ast::view_path_list(ref path, ref idents, _) => {
-        print_path(s, path, false);
-        word(s.s, "::{");
+        if path.segments.is_empty() {
+            word(s.s, "{");
+        } else {
+            print_path(s, path, false);
+            word(s.s, "::{");
+        }
         commasep(s, inconsistent, (*idents), |s, w| {
             print_ident(s, w.node.name);
         });

--- a/src/test/run-pass/issue-10806.rs
+++ b/src/test/run-pass/issue-10806.rs
@@ -1,0 +1,45 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+
+pub fn foo() -> int {
+    3
+}
+pub fn bar() -> int {
+    4
+}
+
+pub mod baz {
+    use {foo, bar};
+    pub fn quux() -> int {
+        foo() + bar()
+    }
+}
+
+pub mod grault {
+    use {foo};
+    pub fn garply() -> int {
+        foo()
+    }
+}
+
+pub mod waldo {
+    use {};
+    pub fn plugh() -> int {
+        0
+    }
+}
+
+fn main() {
+    let _x = baz::quux();
+    let _y = grault::garply();
+    let _z = waldo::plugh();
+}


### PR DESCRIPTION
This fixes #10806.
