### PR TITLE
encode trait lifetime params in metadata to allow cross-crate usage

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1140,6 +1140,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_ty_type_param_defs(ebml_w, ecx,
                                   trait_def.generics.type_param_defs,
                                   tag_items_data_item_ty_param_bounds);
+        encode_region_param_defs(ebml_w, ecx,
+                                 trait_def.generics.region_param_defs);
         encode_trait_ref(ebml_w, ecx, trait_def.trait_ref, tag_item_trait_ref);
         encode_name(ecx, ebml_w, item.ident);
         encode_attributes(ebml_w, item.attrs);

--- a/src/test/auxiliary/xcrate-trait-lifetime-param.rs
+++ b/src/test/auxiliary/xcrate-trait-lifetime-param.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait FromBuf<'a> {
+    fn from_buf(&'a [u8]) -> Self;
+}

--- a/src/test/run-pass/xcrate-trait-lifetime-param.rs
+++ b/src/test/run-pass/xcrate-trait-lifetime-param.rs
@@ -1,0 +1,26 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// aux-build:xcrate-trait-lifetime-param.rs
+
+extern mod other(name = "xcrate-trait-lifetime-param");
+
+struct Reader<'a> {
+    b : &'a [u8]
+}
+
+impl <'a> other::FromBuf<'a> for Reader<'a> {
+    fn from_buf(b : &'a [u8]) -> Reader<'a> {
+        Reader { b : b }
+    }
+}
+
+pub fn main () {}


### PR DESCRIPTION
Before applying this patch, the included testcase fails with:

```
src/test/run-pass/xcrate-trait-lifetime-param.rs:20:10: 20:28 error: wrong number of lifetime parameters: expected 0 but found 1
src/test/run-pass/xcrate-trait-lifetime-param.rs:20 impl <'a> other::FromBuf<'a> for Reader<'a> {
                                                              ^~~~~~~~~~~~~~~~~~
```

There's another example in my comments to #10506.
