### PR TITLE
Allow ref and mut modifiers for short form field patterns

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2814,18 +2814,33 @@ impl Parser {
             }
 
             let lo1 = self.last_span.lo;
+            let bind_type = if self.eat_keyword(keywords::Mut) {
+                BindByValue(MutMutable)
+            } else if self.eat_keyword(keywords::Ref) {
+                BindByRef(self.parse_mutability())
+            } else {
+                BindByValue(MutImmutable)
+            };
+
             let fieldname = self.parse_ident();
             let hi1 = self.last_span.lo;
             let fieldpath = ast_util::ident_to_path(mk_sp(lo1, hi1),
                                                     fieldname);
             let subpat;
             if *self.token == token::COLON {
+                match bind_type {
+                    BindByRef(..) | BindByValue(MutMutable) =>
+                        self.fatal(format!("unexpected `{}`",
+                                   self.this_token_to_str())),
+                    _ => {}
+                }
+
                 self.bump();
                 subpat = self.parse_pat();
             } else {
                 subpat = @ast::Pat {
                     id: ast::DUMMY_NODE_ID,
-                    node: PatIdent(BindByValue(MutImmutable), fieldpath, None),
+                    node: PatIdent(bind_type, fieldpath, None),
                     span: *self.last_span
                 };
             }

--- a/src/test/compile-fail/bind-struct-early-modifiers.rs
+++ b/src/test/compile-fail/bind-struct-early-modifiers.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    struct Foo { x: int }
+    match Foo { x: 10 } {
+        Foo { ref x: ref x } => {}, //~ ERROR unexpected `:`
+        _ => {}
+    }
+}

--- a/src/test/run-pass/bind-field-short-with-modifiers.rs
+++ b/src/test/run-pass/bind-field-short-with-modifiers.rs
@@ -1,0 +1,31 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    struct Foo { x: int, y: int }
+    let mut f = Foo { x: 10, y: 0 };
+    match f {
+        Foo { ref mut x, .. } => *x = 11,
+    }
+    match f {
+        Foo { ref x, ref y } => {
+            assert_eq!(f.x, 11);
+            assert_eq!(f.y, 0);
+        }
+    }
+    match f {
+        Foo { mut x, y: ref mut y } => {
+            x = 12;
+            *y = 1;
+        }
+    }
+    assert_eq!(f.x, 11);
+    assert_eq!(f.y, 1);
+}


### PR DESCRIPTION
Previously, if you wanted to bind a field mutably or by ref, you had to
do something like Foo { x: ref mut x }. You can now just do
Foo { ref mut x }.

Closes #6137
