### PR TITLE
std::io: Add .lines() method to Buffer

### DIFF
--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -19,10 +19,7 @@ pub fn load_errors(testfile: &Path) -> ~[ExpectedError] {
     let mut error_patterns = ~[];
     let mut rdr = BufferedReader::new(File::open(testfile).unwrap());
     let mut line_num = 1u;
-    loop {
-        let ln = match rdr.read_line() {
-            Some(ln) => ln, None => break,
-        };
+    for ln in rdr.lines() {
         error_patterns.push_all_move(parse_expected(line_num, ln));
         line_num += 1u;
     }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -107,11 +107,7 @@ fn iter_header(testfile: &Path, it: |&str| -> bool) -> bool {
     use std::io::File;
 
     let mut rdr = BufferedReader::new(File::open(testfile).unwrap());
-    loop {
-        let ln = match rdr.read_line() {
-            Some(ln) => ln, None => break
-        };
-
+    for ln in rdr.lines() {
         // Assume that any directives will be found before the first
         // module or function. This doesn't seem to be an optimization
         // with a warm page cache. Maybe with a cold one.

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -454,6 +454,28 @@ mod test {
             ~[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
     }
 
+    #[test]
+    fn test_read_line() {
+        let in_buf = MemReader::new(bytes!("a\nb\nc").to_owned());
+        let mut reader = BufferedReader::with_capacity(2, in_buf);
+        assert_eq!(reader.read_line(), Some(~"a\n"));
+        assert_eq!(reader.read_line(), Some(~"b\n"));
+        assert_eq!(reader.read_line(), Some(~"c"));
+        assert_eq!(reader.read_line(), None);
+    }
+
+    #[test]
+    fn test_lines() {
+        let in_buf = MemReader::new(bytes!("a\nb\nc").to_owned());
+        let mut reader = BufferedReader::with_capacity(2, in_buf);
+        let mut it = reader.lines();
+        assert_eq!(it.next(), Some(~"a\n"));
+        assert_eq!(it.next(), Some(~"b\n"));
+        assert_eq!(it.next(), Some(~"c"));
+        assert_eq!(it.next(), None);
+    }
+
+
     #[bench]
     fn bench_buffered_reader(bh: &mut Harness) {
         bh.iter(|| {

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -77,8 +77,7 @@ fn read_line() {
 
     for _ in range(0, 3) {
         let mut reader = BufferedReader::new(File::open(&path).unwrap());
-        while !reader.eof() {
-            reader.read_line();
+        for _line in reader.lines() {
         }
     }
 }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -188,14 +188,7 @@ fn main() {
    // reading the sequence of interest
    let mut proc_mode = false;
 
-   loop {
-       let line = {
-           let _guard = io::ignore_io_error();
-           match rdr.read_line() {
-               Some(ln) => ln,
-               None => break,
-           }
-       };
+   for line in rdr.lines() {
        let line = line.trim().to_owned();
 
        if line.len() == 0u { continue; }

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -18,7 +18,6 @@ use std::io;
 use std::io::stdio::StdReader;
 use std::io::buffered::BufferedReader;
 use std::os;
-use std::uint;
 use std::unstable::intrinsics::cttz16;
 use std::vec;
 
@@ -72,10 +71,7 @@ impl Sudoku {
         assert!(reader.read_line().unwrap() == ~"9,9"); /* assert first line is exactly "9,9" */
 
         let mut g = vec::from_fn(10u, { |_i| ~[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8] });
-        loop {
-            let line = match reader.read_line() {
-                Some(ln) => ln, None => break
-            };
+        for line in reader.lines() {
             let comps: ~[&str] = line.trim().split(',').collect();
 
             if comps.len() == 3u {


### PR DESCRIPTION
The `.lines()` method creates an iterator which yields line with trailing '\n'.
(So it is slightly different to `StrSlice.lines()`; I don't know if it's worth to synchronize them.)
