### PR TITLE
Fix comment on ast::DefStruct

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -254,9 +254,14 @@ pub enum Def {
               NodeId,  // expr node that creates the closure
               NodeId), // id for the block/body of the closure expr
 
-    /// Note that if it's a tuple struct's definition, the node id
-    /// of the DefId refers to the struct_def.ctor_id (whereas normally it
-    /// refers to the item definition's id).
+    /// Note that if it's a tuple struct's definition, the node id of the DefId
+    /// may either refer to the item definition's id or the struct_def.ctor_id.
+    ///
+    /// The cases that I have encountered so far are (this is not exhaustive):
+    /// - If it's a ty_path referring to some tuple struct, then DefMap maps
+    ///   it to a def whose id is the item definition's id.
+    /// - If it's an ExprPath referring to some tuple struct, then DefMap maps
+    ///   it to a def whose id is the struct_def.ctor_id.
     DefStruct(DefId),
     DefTyParamBinder(NodeId), /* struct, impl or trait with ty params */
     DefRegion(NodeId),


### PR DESCRIPTION
A comment that I previously added to ast::DefStruct is incorrect. Here's the modification.
