### PR TITLE
Use LLVM's integrated assembler on Windows

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -352,13 +352,7 @@ pub fn phase_5_run_llvm_passes(sess: Session,
                                trans: &CrateTranslation,
                                outputs: &OutputFilenames) {
 
-    // On Windows, LLVM integrated assembler emits bad stack unwind tables when
-    // segmented stacks are enabled.  However, unwind info directives in assembly
-    // output are OK, so we generate assembly first and then run it through
-    // an external assembler.
-    if sess.targ_cfg.os == abi::OsWin32 &&
-        (sess.opts.output_type == link::output_type_object ||
-         sess.opts.output_type == link::output_type_exe) {
+    if sess.no_integrated_as() {
         let output_type = link::output_type_assembly;
         let asm_filename = outputs.obj_filename.with_extension("s");
 
@@ -371,7 +365,7 @@ pub fn phase_5_run_llvm_passes(sess: Session,
 
         link::write::run_assembler(sess, &asm_filename, &outputs.obj_filename);
 
-        // Remove assembly source unless --save-temps was specified
+        // Remove assembly source, unless --save-temps was specified
         if !sess.opts.save_temps {
             fs::unlink(&asm_filename);
         }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -66,6 +66,7 @@ pub static no_prepopulate_passes:   uint = 1 << 25;
 pub static use_softfp:              uint = 1 << 26;
 pub static gen_crate_map:           uint = 1 << 27;
 pub static prefer_dynamic:          uint = 1 << 28;
+pub static no_integrated_as:        uint = 1 << 29;
 
 pub fn debugging_opts_map() -> ~[(&'static str, &'static str, uint)] {
     ~[("verbose", "in general, enable more debug printouts", verbose),
@@ -117,6 +118,8 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, uint)] {
      ("soft-float", "Generate software floating point library calls", use_softfp),
      ("gen-crate-map", "Force generation of a toplevel crate map", gen_crate_map),
      ("prefer-dynamic", "Prefer dynamic linking to static linking", prefer_dynamic),
+     ("no-integrated-as",
+      "Use external assembler rather than LLVM's integrated one", no_integrated_as),
     ]
 }
 
@@ -334,6 +337,9 @@ impl Session_ {
     }
     pub fn prefer_dynamic(&self) -> bool {
         self.debugging_opt(prefer_dynamic)
+    }
+    pub fn no_integrated_as(&self) -> bool {
+        self.debugging_opt(no_integrated_as)
     }
 
     // pointless function, now...

--- a/src/test/run-pass/test-runner-hides-main.rs
+++ b/src/test/run-pass/test-runner-hides-main.rs
@@ -10,6 +10,7 @@
 
 // compile-flags:--test
 // xfail-fast
+// xfail-win32 #10872
 
 extern mod extra;
 


### PR DESCRIPTION
Last LLVM update seems to have fixed whatever prevented LLVM integrated assembler from generating correct unwind tables on Windows.   This PR switches Windows builds to use internal assembler by default.
Compilation via external assembler can still be requested via the newly added `-Z no-integrated-as` option.

Closes #8809
