### PR TITLE
Fix Vim float highlighting and some keyword highlight

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Patrick Walton <pcwalton@mozilla.com>
 " Maintainer:   Ben Blum <bblum@cs.cmu.edu>
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
-" Last Change:  2013 Dec 04
+" Last Change:  2013 Dec 10
 
 if version < 600
   syntax clear
@@ -160,14 +160,15 @@ syn match     rustHexNumber   display "\<0x[a-fA-F0-9_]\+\%([iu]\%(8\|16\|32\|64
 syn match     rustOctNumber   display "\<0o[0-7_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
 syn match     rustBinNumber   display "\<0b[01_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
 
-" To mark it as a float, it must have at least one of the three things integral values don't have:
+" Special case for numbers of the form "1." which are float literals, unless followed by
+" an identifier, which makes them integer literals with a method call or field access.
+" (This must go first so the others take precedence.)
+syn match     rustFloat       display "\<[0-9][0-9_]*\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\@!"
+" To mark a number as a normal float, it must have at least one of the three things integral values don't have:
 " a decimal point and more numbers; an exponent; and a type suffix.
 syn match     rustFloat       display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\%([eE][+-]\=[0-9_]\+\)\=\(f32\|f64\)\="
 syn match     rustFloat       display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\=\%([eE][+-]\=[0-9_]\+\)\(f32\|f64\)\="
 syn match     rustFloat       display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\=\%([eE][+-]\=[0-9_]\+\)\=\(f32\|f64\)"
-" Special case for numbers of the form "1." which are float literals, unless followed by
-" an identifier, which makes them integer literals with a method call or field access.
-syn match     rustFloat       display "\<[0-9][0-9_]*\.\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\@!"
 
 " For the benefit of delimitMate
 syn region rustLifetimeCandidate display start=/&'\%(\([^'\\]\|\\\(['nrt0\\\"]\|x\x\{2}\|u\x\{4}\|U\x\{8}\)\)'\)\@!/ end=/[[:cntrl:][:space:][:punct:]]\@=\|$/ contains=rustSigil,rustLifetime

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -19,9 +19,8 @@ syn keyword   rustOperator    as
 syn match     rustAssert      "\<assert\(\w\)*!" contained
 syn match     rustFail        "\<fail\(\w\)*!" contained
 syn keyword   rustKeyword     break continue do extern
-syn keyword   rustKeyword     in if impl let log
-syn keyword   rustKeyword     for impl let log
-syn keyword   rustKeyword     loop mod once priv pub
+syn keyword   rustKeyword     for in if impl let
+syn keyword   rustKeyword     loop once priv pub
 syn keyword   rustKeyword     return
 syn keyword   rustKeyword     unsafe while
 syn keyword   rustKeyword     use nextgroup=rustModPath skipwhite
@@ -29,13 +28,14 @@ syn keyword   rustKeyword     use nextgroup=rustModPath skipwhite
 syn keyword   rustKeyword     mod trait struct enum type nextgroup=rustIdentifier skipwhite
 syn keyword   rustKeyword     fn nextgroup=rustFuncName skipwhite
 syn keyword   rustKeyword     proc
-syn keyword   rustStorage     const mut ref static
+syn keyword   rustStorage     mut ref static
+syn keyword   rustObsoleteStorage const
 
 syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 
 " Reserved (but not yet used) keywords {{{2
-syn keyword   rustKeyword     alignof be offsetof pure sizeof typeof yield
+syn keyword   rustReservedKeyword alignof be offsetof pure sizeof typeof yield
 
 " Built-in types {{{2
 syn keyword   rustType        int uint float char bool u8 u16 u32 u64 f32
@@ -228,6 +228,7 @@ hi def link rustSelf          Constant
 hi def link rustFloat         Float
 hi def link rustOperator      Operator
 hi def link rustKeyword       Keyword
+hi def link rustReservedKeyword Error
 hi def link rustConditional   Conditional
 hi def link rustIdentifier    Identifier
 hi def link rustCapsIdent     rustIdentifier
@@ -248,6 +249,7 @@ hi def link rustTodo          Todo
 hi def link rustAttribute     PreProc
 hi def link rustDeriving      PreProc
 hi def link rustStorage       StorageClass
+hi def link rustObsoleteStorage Error
 hi def link rustLifetime      Special
 
 " Other Suggestions:


### PR DESCRIPTION
### Fix up float highlighting in Vim.

This fixes a regression introduced in #10793.

Having a colorscheme which highlights Float the same as Number (I
believe most do), I hadn't noticed that having the special case of "5."
floats (which was one of the added features in #10793) last made it take
precedence, and so it was left to @thestinger to notice it.

The regression meant that in `5.0`, the `5.` was a `rustFloat` (linked
by default to `Float`) and the `0` was a `rustDecNumber` (linked by
default to `Number`), and for `5.0f32` the `5.` was a `rustFloat` and
the `0f32` was a second `rustFloat` (and thus appeared correctly, though
for the wrong reason).
### Vim keyword highlighting improvements.
- Removed the `log` keyword;
- Removed keyword duplicates;
- Highlighted `const` as `Error` rather than `StorageClass`; and
- Highlighted all the reserved keywords as `Error` rather than as
  `Keyword`.

(As usual, these highlightings can be overridden if desired.)
