### PR TITLE
Don't always modify the symbol table in rlibs

### DIFF
--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -103,8 +103,9 @@ impl Archive {
     }
 
     /// Adds an arbitrary file to this archive
-    pub fn add_file(&mut self, file: &Path) {
-        run_ar(self.sess, "r", None, [&self.dst, file]);
+    pub fn add_file(&mut self, file: &Path, has_symbols: bool) {
+        let cmd = if has_symbols {"r"} else {"rS"};
+        run_ar(self.sess, cmd, None, [&self.dst, file]);
     }
 
     /// Removes a file from this archive
@@ -112,6 +113,12 @@ impl Archive {
         run_ar(self.sess, "d", None, [&self.dst, &Path::new(file)]);
     }
 
+    /// Update all symbols in the archive (runs 'ar s' over it)
+    pub fn update_symbols(&mut self) {
+        run_ar(self.sess, "s", None, [&self.dst]);
+    }
+
+    /// List all files in an archive
     pub fn files(&self) -> ~[~str] {
         let output = run_ar(self.sess, "t", None, [&self.dst]);
         str::from_utf8(output.output).lines().map(|s| s.to_owned()).collect()

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -982,16 +982,21 @@ fn link_rlib(sess: Session,
             // contain the metadata in a separate file.
             let metadata = obj_filename.with_filename(METADATA_FILENAME);
             fs::File::create(&metadata).write(trans.metadata);
-            a.add_file(&metadata);
+            a.add_file(&metadata, false);
             fs::unlink(&metadata);
 
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
             let bc = obj_filename.with_extension("bc");
-            a.add_file(&bc);
+            a.add_file(&bc, false);
             if !sess.opts.save_temps {
                 fs::unlink(&bc);
             }
+
+            // Now that we've added files, some platforms need us to now update
+            // the symbol table in the archive (because some platforms die when
+            // adding files to the archive without symbols).
+            a.update_symbols();
         }
 
         None => {}


### PR DESCRIPTION
Turns out that one some platforms the ar/ranlib tool will die with an assertion
if the file being added doesn't actually have any symbols (or if it's just not
an object file presumably).

This functionality is already all exercised on the bots, it just turns out that
the bots don't have an ar tool which dies in this situation, so it's difficult
for me to add a test.

Closes #10907
