### PR TITLE
Inline Finallyalizer::drop, allowing LLVM to optimize `finally`.

### DIFF
--- a/src/libstd/unstable/finally.rs
+++ b/src/libstd/unstable/finally.rs
@@ -62,6 +62,7 @@ struct Finallyalizer<'a> {
 
 #[unsafe_destructor]
 impl<'a> Drop for Finallyalizer<'a> {
+    #[inline]
     fn drop(&mut self) {
         (self.dtor)();
     }


### PR DESCRIPTION
- fixes the vec::from_elem regression caused by #8780
- added 5 benchmarks for allocating a 1KB `~[u8]` and zeroing it
- closes #7136
