### PR TITLE
Minor cleanups now that #9629 is fixed

### DIFF
--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -795,7 +795,8 @@ pub struct ByRef<'a, T> {
 impl<'a, A, T: Iterator<A>> Iterator<A> for ByRef<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<A> { self.iter.next() }
-    // FIXME: #9629 we cannot implement &self methods like size_hint on ByRef
+    #[inline]
+    fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
 impl<'a, A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for ByRef<'a, T> {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2528,13 +2528,13 @@ impl<'a, T> Iterator<&'a mut [T]> for MutSplitIterator<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) {
-        if self.finished { return (0, Some(0)) }
-
-        // if the predicate doesn't match anything, we yield one slice
-        // if it matches every element, we yield len+1 empty slices.
-        // FIXME #9629
-        //(1, Some(self.v.len() + 1))
-        (1, None)
+        if self.finished {
+            (0, Some(0))
+        } else {
+            // if the predicate doesn't match anything, we yield one slice
+            // if it matches every element, we yield len+1 empty slices.
+            (1, Some(self.v.len() + 1))
+        }
     }
 }
 
@@ -2547,10 +2547,7 @@ impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutSplitIterator<'a, T> {
             None => {
                 self.finished = true;
                 let tmp = util::replace(&mut self.v, &mut []);
-                let len = tmp.len();
-                let (head, tail) = tmp.mut_split_at(len);
-                self.v = tail;
-                Some(head)
+                Some(tmp)
             }
             Some(idx) => {
                 let tmp = util::replace(&mut self.v, &mut []);


### PR DESCRIPTION
3 minor clean-ups now that #9629 is fixed:
- Update MutChunkIter to remove the `remainder` that existed just to allow the size_hint() method to be implemented. This is no longer necessary since we can just access the length of the slice directly.
- Update MutSplitIterator to address the FIXME in its size_hint() method. This method was only partially implemented due to the issue. Also, implement a minor optimization in the case that its the last iteration.
- Update ByRef iterator to implement the size_hint() method.

I noticed that MutSplitIterator returns an empty slice if called on an empty slice. I don't know if this is intended or not, but I left the `finished` field in-place to preserve this behavior.

@TeXitoi @blake2-ppc
