### PR TITLE
Make base64::config fields public again

### DIFF
--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -22,11 +22,11 @@ pub enum CharacterSet {
 /// Contains configuration parameters for `to_base64`.
 pub struct Config {
     /// Character set to use
-    priv char_set: CharacterSet,
+    char_set: CharacterSet,
     /// True to pad output with `=` characters
-    priv pad: bool,
+    pad: bool,
     /// `Some(len)` to wrap lines at `len`, `None` to disable line wrapping
-    priv line_length: Option<uint>
+    line_length: Option<uint>
 }
 
 /// Configuration for RFC 4648 standard base64 encoding


### PR DESCRIPTION
These got swept up in the great privatizing of 2013.
