### PR TITLE
provide a warning at  at configure time if cc, gcc, and g++ point to a mixture of clang and gcc. Fixes issue #10959

### DIFF
--- a/configure
+++ b/configure
@@ -559,6 +559,27 @@ then
         step_msg "on OS X 10.9, forcing use of clang"
         CFG_ENABLE_CLANG=1
         putvar CFG_ENABLE_CLANG
+    else 
+        # on OS X, with xcode 5 and newer, certain developers may have 
+        # cc, gcc and g++ point to a  mixture of clang and gcc
+        # if so, this will create very strange build errors 
+        # this last stanza is to detect some such problems and save the future rust
+        # contributor some time solving that issue.
+        # this detection could be generalized to other OSes aside from OS X
+        # but the issue seems most likely to happen on OS X
+
+        chk_cc () {
+            $1 --version 2> /dev/null | grep -q $2
+        }
+        # check that gcc, cc and g++ all point to the same compiler.
+        # note that for xcode 5, g++ points to clang, not clang++
+        if !((chk_cc gcc clang  && chk_cc g++ clang) ||
+            (chk_cc gcc gcc  &&( chk_cc g++ g++ || chk g++ gcc))) then
+            err "the gcc and g++ in your path point to different compilers. 
+Check which versions are in your path with  cc --version and g++ --version. 
+To resolve this problem, either fix your PATH  or run configure with --enable-clang"
+        fi
+
     fi
 fi
 


### PR DESCRIPTION
 @alexcrichton and others: heres a proof of concept patch for configure that (for now is OS X only) checks at the very end of the configure script if `cc`, `gcc`, and `g++` possibly point to the same compiler or not.

The way its currently done is i call `cc  --version`, `gcc --version` and `g++ --version` and check if theres any matchings for the word `clang`, `gcc` or `g++`.  So it doesn't rule out miss matched gcc versions or the like, but thats a bit more implausible I think.
