### PR TITLE
Clean and tidy some traits

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -66,7 +66,7 @@ syn keyword   rustEnumVariant Ok Err
 
 " Types and traits {{{3
 syn keyword rustTrait Any AnyOwnExt AnyRefExt AnyMutRefExt
-syn keyword rustTrait Ascii AsciiCast OwnedAsciiCast AsciiStr ToBytesConsume
+syn keyword rustTrait Ascii AsciiCast OwnedAsciiCast AsciiStr IntoBytes
 syn keyword rustTrait Bool
 syn keyword rustTrait ToCStr
 syn keyword rustTrait Char
@@ -94,7 +94,7 @@ syn keyword rustTrait Buffer Writer Reader Seek
 syn keyword rustTrait SendStr SendStrOwned SendStrStatic IntoSendStr
 syn keyword rustTrait Str StrVector StrSlice OwnedStr
 syn keyword rustTrait IterBytes
-syn keyword rustTrait ToStr ToStrConsume
+syn keyword rustTrait ToStr IntoStr
 syn keyword rustTrait CopyableTuple ImmutableTuple
 syn keyword rustTrait Tuple1 Tuple2 Tuple3 Tuple4
 syn keyword rustTrait Tuple5 Tuple6 Tuple7 Tuple8

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -10,7 +10,7 @@
 
 //! Operations on ASCII strings and characters.
 
-use to_str::{ToStr,ToStrConsume};
+use to_str::{ToStr,IntoStr};
 use str;
 use str::StrSlice;
 use str::OwnedStr;
@@ -294,7 +294,7 @@ impl<'a> AsciiStr for &'a [Ascii] {
     }
 }
 
-impl ToStrConsume for ~[Ascii] {
+impl IntoStr for ~[Ascii] {
     #[inline]
     fn into_str(self) -> ~str {
         unsafe { cast::transmute(self) }
@@ -309,12 +309,12 @@ impl IterBytes for Ascii {
 }
 
 /// Trait to convert to a owned byte array by consuming self
-pub trait ToBytesConsume {
+pub trait IntoBytes {
     /// Converts to a owned byte array by consuming self
     fn into_bytes(self) -> ~[u8];
 }
 
-impl ToBytesConsume for ~[Ascii] {
+impl IntoBytes for ~[Ascii] {
     fn into_bytes(self) -> ~[u8] {
         unsafe { cast::transmute(self) }
     }

--- a/src/libstd/either.rs
+++ b/src/libstd/either.rs
@@ -13,13 +13,10 @@
 #[allow(missing_doc)];
 
 use option::{Some, None};
-use option;
 use clone::Clone;
 use container::Container;
 use cmp::Eq;
 use iter::{Iterator, FilterMap};
-use result::Result;
-use result;
 use str::StrSlice;
 use vec;
 use vec::{OwnedVector, ImmutableVector};
@@ -105,101 +102,6 @@ impl<L, R> Either<L, R> {
     }
 }
 
-/// A generic trait for converting a value to a `Either`
-pub trait ToEither<L, R> {
-    /// Convert to the `either` type
-    fn to_either(&self) -> Either<L, R>;
-}
-
-/// A generic trait for converting a value to a `Either`
-pub trait IntoEither<L, R> {
-    /// Convert to the `either` type
-    fn into_either(self) -> Either<L, R>;
-}
-
-/// A generic trait for converting a value to a `Either`
-pub trait AsEither<L, R> {
-    /// Convert to the `either` type
-    fn as_either<'a>(&'a self) -> Either<&'a L, &'a R>;
-}
-
-impl<L, R: Clone> option::ToOption<R> for Either<L, R> {
-    #[inline]
-    fn to_option(&self)-> option::Option<R> {
-        match *self {
-            Left(_) => None,
-            Right(ref r) => Some(r.clone()),
-        }
-    }
-}
-
-impl<L, R> option::IntoOption<R> for Either<L, R> {
-    #[inline]
-    fn into_option(self)-> option::Option<R> {
-        match self {
-            Left(_) => None,
-            Right(r) => Some(r),
-        }
-    }
-}
-
-impl<L, R> option::AsOption<R> for Either<L, R> {
-    #[inline]
-    fn as_option<'a>(&'a self) -> option::Option<&'a R> {
-        match *self {
-            Left(_) => None,
-            Right(ref r) => Some(r),
-        }
-    }
-}
-
-impl<L: Clone, R: Clone> result::ToResult<R, L> for Either<L, R> {
-    #[inline]
-    fn to_result(&self)-> result::Result<R, L> {
-        match *self {
-            Left(ref l) => result::Err(l.clone()),
-            Right(ref r) => result::Ok(r.clone()),
-        }
-    }
-}
-
-impl<L, R> result::IntoResult<R, L> for Either<L, R> {
-    #[inline]
-    fn into_result(self)-> result::Result<R, L> {
-        match self {
-            Left(l) => result::Err(l),
-            Right(r) => result::Ok(r),
-        }
-    }
-}
-
-impl<L, R> result::AsResult<R, L> for Either<L, R> {
-    #[inline]
-    fn as_result<'a>(&'a self) -> result::Result<&'a R, &'a L> {
-        match *self {
-            Left(ref l) => result::Err(l),
-            Right(ref r) => result::Ok(r),
-        }
-    }
-}
-
-impl<L: Clone, R: Clone> ToEither<L, R> for Either<L, R> {
-    fn to_either(&self) -> Either<L, R> { self.clone() }
-}
-
-impl<L, R> IntoEither<L, R> for Either<L, R> {
-    fn into_either(self) -> Either<L, R> { self }
-}
-
-impl<L, R> AsEither<L, R> for Either<L, R> {
-    fn as_either<'a>(&'a self) -> Either<&'a L, &'a R> {
-        match *self {
-            Left(ref l) => Left(l),
-            Right(ref r) => Right(r),
-        }
-    }
-}
-
 /// An iterator yielding the `Left` values of its source
 pub type Lefts<L, R, Iter> = FilterMap<'static, Either<L, R>, L, Iter>;
 
@@ -250,11 +152,6 @@ pub fn partition<L, R>(eithers: ~[Either<L, R>]) -> (~[L], ~[R]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use option::{IntoOption, ToOption, AsOption};
-    use option;
-    use result::{IntoResult, ToResult, AsResult};
-    use result;
 
     #[test]
     fn test_either_left() {
@@ -347,89 +244,5 @@ mod tests {
         let (lefts, rights) = partition(input);
         assert_eq!(lefts.len(), 0u);
         assert_eq!(rights.len(), 0u);
-    }
-
-    #[test]
-    pub fn test_to_option() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.to_option(), option::Some(100));
-        assert_eq!(left.to_option(), option::None);
-    }
-
-    #[test]
-    pub fn test_into_option() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.into_option(), option::Some(100));
-        assert_eq!(left.into_option(), option::None);
-    }
-
-    #[test]
-    pub fn test_as_option() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.as_option().unwrap(), &100);
-        assert_eq!(left.as_option(), option::None);
-    }
-
-    #[test]
-    pub fn test_to_result() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.to_result(), result::Ok(100));
-        assert_eq!(left.to_result(), result::Err(404));
-    }
-
-    #[test]
-    pub fn test_into_result() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.into_result(), result::Ok(100));
-        assert_eq!(left.into_result(), result::Err(404));
-    }
-
-    #[test]
-    pub fn test_as_result() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        let x = 100;
-        assert_eq!(right.as_result(), result::Ok(&x));
-
-        let x = 404;
-        assert_eq!(left.as_result(), result::Err(&x));
-    }
-
-    #[test]
-    pub fn test_to_either() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.to_either(), Right(100));
-        assert_eq!(left.to_either(), Left(404));
-    }
-
-    #[test]
-    pub fn test_into_either() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.into_either(), Right(100));
-        assert_eq!(left.into_either(), Left(404));
-    }
-
-    #[test]
-    pub fn test_as_either() {
-        let right: Either<int, int> = Right(100);
-        let left: Either<int, int> = Left(404);
-
-        assert_eq!(right.as_either().unwrap_right(), &100);
-        assert_eq!(left.as_either().unwrap_left(), &404);
     }
 }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -45,8 +45,6 @@ use default::Default;
 use fmt;
 use iter::{Iterator, DoubleEndedIterator, ExactSize};
 use kinds::Send;
-use result::{IntoResult, ToResult, AsResult};
-use result::{Result, Ok, Err};
 use str::OwnedStr;
 use to_str::ToStr;
 use util;
@@ -360,81 +358,8 @@ impl<T: Default> Option<T> {
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// Constructor extension trait
-/////////////////////////////////////////////////////////////////////////////
-
-/// A generic trait for converting a value to a `Option`
-pub trait ToOption<T> {
-    /// Convert to the `option` type
-    fn to_option(&self) -> Option<T>;
-}
-
-/// A generic trait for converting a value to a `Option`
-pub trait IntoOption<T> {
-    /// Convert to the `option` type
-    fn into_option(self) -> Option<T>;
-}
-
-/// A generic trait for converting a value to a `Option`
-pub trait AsOption<T> {
-    /// Convert to the `option` type
-    fn as_option<'a>(&'a self) -> Option<&'a T>;
-}
-
-impl<T: Clone> ToOption<T> for Option<T> {
-    #[inline]
-    fn to_option(&self) -> Option<T> { self.clone() }
-}
-
-impl<T> IntoOption<T> for Option<T> {
-    #[inline]
-    fn into_option(self) -> Option<T> { self }
-}
-
-impl<T> AsOption<T> for Option<T> {
-    #[inline]
-    fn as_option<'a>(&'a self) -> Option<&'a T> {
-        match *self {
-            Some(ref x) => Some(x),
-            None => None,
-        }
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
-
-impl<T: Clone> ToResult<T, ()> for Option<T> {
-    #[inline]
-    fn to_result(&self) -> Result<T, ()> {
-        match *self {
-            Some(ref x) => Ok(x.clone()),
-            None => Err(()),
-        }
-    }
-}
-
-impl<T> IntoResult<T, ()> for Option<T> {
-    #[inline]
-    fn into_result(self) -> Result<T, ()> {
-        match self {
-            Some(x) => Ok(x),
-            None => Err(()),
-        }
-    }
-}
-
-impl<T> AsResult<T, ()> for Option<T> {
-    #[inline]
-    fn as_result<'a>(&'a self) -> Result<&'a T, &'a ()> {
-        static UNIT: () = ();
-        match *self {
-            Some(ref t) => Ok(t),
-            None => Err(&UNIT),
-        }
-    }
-}
 
 impl<T: fmt::Default> fmt::Default for Option<T> {
     #[inline]
@@ -493,8 +418,6 @@ impl<A> ExactSize<A> for OptionIterator<A> {}
 mod tests {
     use super::*;
 
-    use result::{IntoResult, ToResult};
-    use result::{Ok, Err};
     use str::StrSlice;
     use util;
 
@@ -731,50 +654,5 @@ mod tests {
         assert_eq!(x, None);
         assert!(!x.mutate_default(0i, |i| i+1));
         assert_eq!(x, Some(0i));
-    }
-
-    #[test]
-    pub fn test_to_option() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.to_option(), Some(100));
-        assert_eq!(none.to_option(), None);
-    }
-
-    #[test]
-    pub fn test_into_option() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.into_option(), Some(100));
-        assert_eq!(none.into_option(), None);
-    }
-
-    #[test]
-    pub fn test_as_option() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.as_option().unwrap(), &100);
-        assert_eq!(none.as_option(), None);
-    }
-
-    #[test]
-    pub fn test_to_result() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.to_result(), Ok(100));
-        assert_eq!(none.to_result(), Err(()));
-    }
-
-    #[test]
-    pub fn test_into_result() {
-        let some: Option<int> = Some(100);
-        let none: Option<int> = None;
-
-        assert_eq!(some.into_result(), Ok(100));
-        assert_eq!(none.into_result(), Err(()));
     }
 }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -45,7 +45,7 @@ pub use io::stdio::{print, println};
 // Reexported types and traits
 
 pub use any::{Any, AnyOwnExt, AnyRefExt, AnyMutRefExt};
-pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr, ToBytesConsume};
+pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr, IntoBytes};
 pub use bool::Bool;
 pub use c_str::ToCStr;
 pub use char::Char;
@@ -71,7 +71,7 @@ pub use io::{Buffer, Writer, Reader, Seek};
 pub use send_str::{SendStr, SendStrOwned, SendStrStatic, IntoSendStr};
 pub use str::{Str, StrVector, StrSlice, OwnedStr};
 pub use to_bytes::IterBytes;
-pub use to_str::{ToStr, ToStrConsume};
+pub use to_str::{ToStr, IntoStr};
 pub use tuple::{CopyableTuple, ImmutableTuple};
 pub use tuple::{ImmutableTuple1, ImmutableTuple2, ImmutableTuple3, ImmutableTuple4};
 pub use tuple::{ImmutableTuple5, ImmutableTuple6, ImmutableTuple7, ImmutableTuple8};

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -15,7 +15,6 @@ use cmp::Eq;
 use fmt;
 use iter::Iterator;
 use option::{None, Option, Some};
-use option::{ToOption, IntoOption, AsOption};
 use str::OwnedStr;
 use to_str::ToStr;
 use vec::OwnedVector;
@@ -205,80 +204,8 @@ impl<T, E> Result<T, E> {
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// Constructor extension trait
-/////////////////////////////////////////////////////////////////////////////
-
-/// A generic trait for converting a value to a `Result`
-pub trait ToResult<T, E> {
-    /// Convert to the `result` type
-    fn to_result(&self) -> Result<T, E>;
-}
-
-/// A generic trait for converting a value to a `Result`
-pub trait IntoResult<T, E> {
-    /// Convert to the `result` type
-    fn into_result(self) -> Result<T, E>;
-}
-
-/// A generic trait for converting a value to a `Result`
-pub trait AsResult<T, E> {
-    /// Convert to the `result` type
-    fn as_result<'a>(&'a self) -> Result<&'a T, &'a E>;
-}
-
-impl<T: Clone, E: Clone> ToResult<T, E> for Result<T, E> {
-    #[inline]
-    fn to_result(&self) -> Result<T, E> { self.clone() }
-}
-
-impl<T, E> IntoResult<T, E> for Result<T, E> {
-    #[inline]
-    fn into_result(self) -> Result<T, E> { self }
-}
-
-impl<T, E> AsResult<T, E> for Result<T, E> {
-    #[inline]
-    fn as_result<'a>(&'a self) -> Result<&'a T, &'a E> {
-        match *self {
-            Ok(ref t) => Ok(t),
-            Err(ref e) => Err(e),
-        }
-    }
-}
-
-/////////////////////////////////////////////////////////////////////////////
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
-
-impl<T: Clone, E> ToOption<T> for Result<T, E> {
-    #[inline]
-    fn to_option(&self) -> Option<T> {
-        match *self {
-            Ok(ref t) => Some(t.clone()),
-            Err(_) => None,
-        }
-    }
-}
-
-impl<T, E> IntoOption<T> for Result<T, E> {
-    #[inline]
-    fn into_option(self) -> Option<T> {
-        match self {
-            Ok(t) => Some(t),
-            Err(_) => None,
-        }
-    }
-}
-
-impl<T, E> AsOption<T> for Result<T, E> {
-    #[inline]
-    fn as_option<'a>(&'a self) -> Option<&'a T> {
-        match *self {
-            Ok(ref t) => Some(t),
-            Err(_) => None,
-        }
-    }
-}
 
 impl<T: fmt::Default, E: fmt::Default> fmt::Default for Result<T, E> {
     #[inline]
@@ -364,8 +291,6 @@ mod tests {
     use super::*;
 
     use iter::range;
-    use option::{IntoOption, ToOption, AsOption};
-    use option::{Some, None};
     use vec::ImmutableVector;
     use to_str::ToStr;
 
@@ -458,63 +383,6 @@ mod tests {
         assert_eq!(fold_(functions.iter()
                         .map(|f| (*f)())),
                    Err(1));
-    }
-
-    #[test]
-    pub fn test_to_option() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.to_option(), Some(100));
-        assert_eq!(err.to_option(), None);
-    }
-
-    #[test]
-    pub fn test_into_option() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.into_option(), Some(100));
-        assert_eq!(err.into_option(), None);
-    }
-
-    #[test]
-    pub fn test_as_option() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.as_option().unwrap(), &100);
-        assert_eq!(err.as_option(), None);
-    }
-
-    #[test]
-    pub fn test_to_result() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.to_result(), Ok(100));
-        assert_eq!(err.to_result(), Err(404));
-    }
-
-    #[test]
-    pub fn test_into_result() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        assert_eq!(ok.into_result(), Ok(100));
-        assert_eq!(err.into_result(), Err(404));
-    }
-
-    #[test]
-    pub fn test_as_result() {
-        let ok: Result<int, int> = Ok(100);
-        let err: Result<int, int> = Err(404);
-
-        let x = 100;
-        assert_eq!(ok.as_result(), Ok(&x));
-
-        let x = 404;
-        assert_eq!(err.as_result(), Err(&x));
     }
 
     #[test]

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -30,7 +30,7 @@ pub trait ToStr {
 }
 
 /// Trait for converting a type to a string, consuming it in the process.
-pub trait ToStrConsume {
+pub trait IntoStr {
     /// Consume and convert to a string.
     fn into_str(self) -> ~str;
 }


### PR DESCRIPTION
### Remove {As,Into,To}{Option,Either,Result} traits.

Expanded, that is:
- `AsOption`
- `IntoOption`
- `ToOption`
- `AsEither`
- `IntoEither`
- `ToEither`
- `AsResult`
- `IntoResult`
- `ToResult`

These were defined for each other but never _used_ anywhere. They are
all trivial and so removal will have negligible effect upon anyone.
`Either` has fallen out of favour (and its implementation of these
traits of dubious semantics), `Option<T>` → `Result<T, ()>` was never
really useful and `Result<T, E>` → `Option<T>` should now be done with
`Result.ok()` (mirrored with `Result.err()` for even more usefulness).

In summary, there's really no point in any of these remaining.
### Rename To{Str,Bytes}Consume traits to Into*.

That is:
- `ToStrConsume` → `IntoStr`;
- `ToBytesConsume` → `IntoBytes`.
