### PR TITLE
Fix building compiling on OS X 10.9

### DIFF
--- a/configure
+++ b/configure
@@ -549,6 +549,19 @@ then
     err "either clang or gcc is required"
 fi
 
+# OS X 10.9, gcc is actually clang. This can cause some confusion in the build
+# system, so if we find that gcc is clang, we should just use clang directly.
+if [ $CFG_OSTYPE = apple-darwin -a -z "$CFG_ENABLE_CLANG" ]
+then
+    CFG_OSX_GCC_VERSION=$("$CFG_GCC" --version 2>&1 | grep "Apple LLVM version")
+    if [ $? -eq 0 ]
+    then
+        step_msg "on OS X 10.9, forcing use of clang"
+        CFG_ENABLE_CLANG=1
+        putvar CFG_ENABLE_CLANG
+    fi
+fi
+
 if [ ! -z "$CFG_LLVM_ROOT" -a -e "$CFG_LLVM_ROOT/bin/llvm-config" ]
 then
     step_msg "using custom LLVM at $CFG_LLVM_ROOT"

--- a/configure
+++ b/configure
@@ -469,8 +469,8 @@ then
     PV_MINOR=${PV_MAJOR_MINOR#* }
     if [ "$PV_MAJOR" -lt "$MIN_PV_MAJOR" ] || [ "$PV_MINOR" -lt "$MIN_PV_MINOR" ]
     then
-		step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. Need at least $MIN_PV_MAJOR.$MIN_PV_MINOR. Disabling"
-		BAD_PANDOC=1
+        step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. Need at least $MIN_PV_MAJOR.$MIN_PV_MINOR. Disabling"
+        BAD_PANDOC=1
     fi
 fi
 
@@ -544,7 +544,6 @@ then
     putvar CFG_ENABLE_CLANG
 fi
 
-
 if [ -z "$CFG_ENABLE_CLANG" -a -z "$CFG_GCC" ]
 then
     err "either clang or gcc is required"
@@ -558,12 +557,12 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-	(3.3|3.3svn|3.2|3.2svn)
-	    msg "found ok version of LLVM: $LLVM_VERSION"
-	    ;;
-	(*)
-	    err "bad LLVM version: $LLVM_VERSION, need >=3.0svn"
-	    ;;
+        (3.3|3.3svn|3.2|3.2svn)
+            msg "found ok version of LLVM: $LLVM_VERSION"
+            ;;
+        (*)
+            err "bad LLVM version: $LLVM_VERSION, need >=3.0svn"
+            ;;
     esac
 fi
 
@@ -571,7 +570,7 @@ if [ ! -z "$CFG_ENABLE_CLANG" ]
 then
     if [ -z "$CFG_CLANG" ]
     then
-	err "clang requested but not found"
+        err "clang requested but not found"
     fi
     CFG_CLANG_VERSION=$("$CFG_CLANG" \
                       --version \


### PR DESCRIPTION
This modifies the `configure` to set `CFG_ENABLE_CLANG=1` if `gcc` is actually `clang`. This is needed because OS X's clang enables warning on unused command line arguments. Our build system suppresses this by default, but when `CFG_ENABLE_CLANGE=0`, we do not. This causes one of the tests to fail. This patch changes rust to directly use clang, which fixes the build failure.

Closes #10811
