### PR TITLE
Move logic for test output generation forward

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -722,17 +722,10 @@ pub fn link_binary(sess: Session,
                    obj_filename: &Path,
                    out_filename: &Path,
                    lm: &LinkMeta) -> ~[Path] {
-    // If we're generating a test executable, then ignore all other output
-    // styles at all other locations
-    let outputs = if sess.opts.test {
-        ~[session::OutputExecutable]
-    } else {
-        (*sess.outputs).clone()
-    };
-
     let mut out_filenames = ~[];
-    for output in outputs.move_iter() {
-        let out_file = link_binary_output(sess, trans, output, obj_filename, out_filename, lm);
+    for &output in sess.outputs.iter() {
+        let out_file = link_binary_output(sess, trans, output, obj_filename,
+                                          out_filename, lm);
         out_filenames.push(out_file);
     }
 

--- a/src/test/run-make/no-intermediate-extras/Makefile
+++ b/src/test/run-make/no-intermediate-extras/Makefile
@@ -1,0 +1,7 @@
+# Regression test for issue #10973
+
+-include ../tools.mk
+
+all:
+	$(RUSTC) --rlib --test foo.rs
+	rm $(TMPDIR)/foo.bc && exit 1 || exit 0


### PR DESCRIPTION
By performing this logic very late in the build process, it ended up leading to
bugs like those found in #10973 where certain stages of the build process
expected a particular output format which didn't end up being the case. In order
to fix this, the build output generation is moved very early in the build
process to the absolute first thing in phase 2.

Closes #10973
