### PR TITLE
std::io: Faster BufferedReader:read_byte.

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -129,6 +129,17 @@ impl<R: Reader> Reader for BufferedReader<R> {
         Some(nread)
     }
 
+    fn read_byte(&mut self) -> Option<u8> {
+        if self.pos == self.cap {
+            if self.fill().len() == 0 {
+                return None;
+            }
+        }
+        let c = self.buf[self.pos];
+        self.pos += 1;
+        Some(c)
+    }
+
     fn eof(&mut self) -> bool {
         self.pos == self.cap && self.inner.eof()
     }


### PR DESCRIPTION
Replace Reader's default implementation to take benefit of that
particular fixed size / very small reads situation.

Brings a 2x perf improvement on a lightweight wc-like test app (300
iterations, `/usr/share/dict/web2', MBA laptop).
