### PR TITLE
Mark live codes in struct/enum for dead-code pass

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -107,6 +107,8 @@ impl MarkSymbolVisitor {
                 match item.node {
                     ast::item_fn(..)
                     | ast::item_ty(..)
+                    | ast::item_enum(..)
+                    | ast::item_struct(..)
                     | ast::item_static(..) => {
                         visit::walk_item(self, item, ());
                     }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -290,6 +290,10 @@ pub fn walk_variant<E:Clone, V:Visitor<E>>(visitor:&mut V,
                                      env.clone())
         }
     }
+    match variant.node.disr_expr {
+        Some(expr) => visitor.visit_expr(expr, env),
+        None => ()
+    }
 }
 
 pub fn skip_ty<E, V:Visitor<E>>(_: &mut V, _: &Ty, _: E) {

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -27,6 +27,7 @@ static priv_static: int = 0; //~ ERROR: code is never used
 static used_static: int = 0;
 pub static used_static2: int = used_static;
 static USED_STATIC: int = 0;
+static STATIC_USED_IN_ENUM_DISCRIMINANT: uint = 10;
 
 pub type typ = ~UsedStruct4;
 pub struct PubStruct();
@@ -41,8 +42,15 @@ struct SemiUsedStruct;
 impl SemiUsedStruct {
     fn la_la_la() {}
 }
+struct StructUsedAsField;
+struct StructUsedInEnum;
+pub struct PubStruct2 {
+    struct_used_as_field: *StructUsedAsField
+}
 
 pub enum pub_enum { foo1, bar1 }
+pub enum pub_enum2 { a(~StructUsedInEnum) }
+pub enum pub_enum3 { Foo = STATIC_USED_IN_ENUM_DISCRIMINANT }
 enum priv_enum { foo2, bar2 } //~ ERROR: code is never used
 enum used_enum { foo3, bar3 }
 


### PR DESCRIPTION
Types used inside live struct or enum are now marked live.

Fix #10956 and #10993.
