### PR TITLE
Convert std::vec::raw::{init_elem, copy_memory} to methods, and remove aliasing &[] and &mut[]

### DIFF
--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -219,9 +219,7 @@ impl Uuid {
         }
 
         let mut uuid = Uuid{ bytes: [0, .. 16] };
-        unsafe {
-            vec::raw::copy_memory(uuid.bytes, b);
-        }
+        vec::bytes::copy_memory(uuid.bytes, b);
         Some(uuid)
     }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2060,7 +2060,7 @@ pub trait MutableVector<'a, T> {
      */
     unsafe fn init_elem(self, i: uint, val: T);
 
-    /// Copies data from `src` to `self`
+    /// Copies data from `src` to `self`.
     ///
     /// `self` and `src` must not overlap. Fails if `self` is
     /// shorter than `src`.
@@ -2208,7 +2208,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
         self.as_mut_buf(|p_dst, len_dst| {
             src.as_imm_buf(|p_src, len_src| {
                 assert!(len_dst >= len_src)
-                ptr::copy_memory(p_dst, p_src, len_src)
+                ptr::copy_nonoverlapping_memory(p_dst, p_src, len_src)
             })
         })
     }
@@ -2350,10 +2350,10 @@ pub mod bytes {
         }
     }
 
-    /// Copies data from one vector to another.
+    /// Copies data from `src` to `dst`
     ///
-    /// Copies `src` to `dst`. Fails if the length of `dst` is less
-    /// than the length of `src`.
+    /// `src` and `dst` must not overlap. Fails if the length of `dst`
+    /// is less than the length of `src`.
     #[inline]
     pub fn copy_memory(dst: &mut [u8], src: &[u8]) {
         // Bound checks are done at .copy_memory.

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2196,11 +2196,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     unsafe fn init_elem(self, i: uint, val: T) {
-        let mut alloc = Some(val);
-        self.as_mut_buf(|p, _len| {
-            intrinsics::move_val_init(&mut(*ptr::mut_offset(p, i as int)),
-                                      alloc.take_unwrap());
-        })
+        intrinsics::move_val_init(&mut (*self.as_mut_ptr().offset(i as int)), val);
     }
 
     #[inline]

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2350,13 +2350,10 @@ pub mod bytes {
         }
     }
 
-    /**
-      * Copies data from one vector to another.
-      *
-      * Copies `src` to `dst`. The source and destination may
-      * overlap. Fails if the length of `dst` is less than the length
-      * of `src`.
-      */
+    /// Copies data from one vector to another.
+    ///
+    /// Copies `src` to `dst`. Fails if the length of `dst` is less
+    /// than the length of `src`.
     #[inline]
     pub fn copy_memory(dst: &mut [u8], src: &[u8]) {
         // Bound checks are done at .copy_memory.


### PR DESCRIPTION
The removal of the aliasing &mut[] and &[] from `shift_opt` also comes with its simplification.

The above also allows the use of `copy_nonoverlapping_memory` in `[].copy_memory` (I did an audit of each use of `.copy_memory` and `std::vec::bytes::copy_memory`, and I believe none of them are called with arguments can ever alias). This changes requires that `unsafe` code using `copy_memory` **needs** to respect the aliasing rules of `&mut[]`.
