### PR TITLE
Fix #10755 - ICE: `--linker=`

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -33,6 +33,7 @@ use std::os::consts::{macos, freebsd, linux, android, win32};
 use std::ptr;
 use std::run;
 use std::str;
+use std::io;
 use std::io::fs;
 use extra::tempfile::TempDir;
 use syntax::abi;
@@ -97,6 +98,7 @@ pub mod write {
     use util::common::time;
 
     use std::c_str::ToCStr;
+    use std::io;
     use std::libc::{c_uint, c_int};
     use std::path::Path;
     use std::run;
@@ -310,7 +312,11 @@ pub mod write {
             assembly.as_str().unwrap().to_owned()];
 
         debug!("{} '{}'", cc, args.connect("' '"));
-        match run::process_output(cc, args) {
+        let opt_prog = {
+            let _guard = io::ignore_io_error();
+            run::process_output(cc, args)
+        };
+        match opt_prog {
             Some(prog) => {
                 if !prog.status.success() {
                     sess.err(format!("linking with `{}` failed: {}", cc, prog.status));
@@ -320,7 +326,7 @@ pub mod write {
                 }
             },
             None => {
-                sess.err(format!("could not exec `{}`", cc));
+                sess.err(format!("could not exec the linker `{}`", cc));
                 sess.abort_if_errors();
             }
         }
@@ -948,8 +954,11 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
 
     // Invoke the system linker
     debug!("{} {}", cc_prog, cc_args.connect(" "));
-    let opt_prog = time(sess.time_passes(), "running linker", (), |()|
-                        run::process_output(cc_prog, cc_args));
+    let opt_prog = {
+        let _guard = io::ignore_io_error();
+        time(sess.time_passes(), "running linker", (), |()|
+             run::process_output(cc_prog, cc_args))
+    };
 
     match opt_prog {
         Some(prog) => {
@@ -961,7 +970,7 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
             }
         },
         None => {
-            sess.err(format!("could not exec `{}`", cc_prog));
+            sess.err(format!("could not exec the linker `{}`", cc_prog));
             sess.abort_if_errors();
         }
     }

--- a/src/test/compile-fail/issue-10755.rs
+++ b/src/test/compile-fail/issue-10755.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --linker=llllll
+// error-pattern: the linker `llllll`
+
+fn main() {
+}


### PR DESCRIPTION
Trap the io_error condition so that a more informative error message is
displayed when the linker program cannot be started, such as when the
name of the linker binary is accidentally mistyped.

closes #10755
