### PR TITLE
Make Iterator naming more consistent

### DIFF
--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -414,12 +414,12 @@ impl Bitv {
     }
 
     #[inline]
-    pub fn iter<'a>(&'a self) -> BitvIterator<'a> {
-        BitvIterator {bitv: self, next_idx: 0, end_idx: self.nbits}
+    pub fn iter<'a>(&'a self) -> Bits<'a> {
+        Bits {bitv: self, next_idx: 0, end_idx: self.nbits}
     }
 
     #[inline]
-    pub fn rev_iter<'a>(&'a self) -> Invert<BitvIterator<'a>> {
+    pub fn rev_iter<'a>(&'a self) -> Invert<Bits<'a>> {
         self.iter().invert()
     }
 
@@ -578,13 +578,13 @@ fn iterate_bits(base: uint, bits: uint, f: |uint| -> bool) -> bool {
 }
 
 /// An iterator for `Bitv`.
-pub struct BitvIterator<'a> {
+pub struct Bits<'a> {
     priv bitv: &'a Bitv,
     priv next_idx: uint,
     priv end_idx: uint,
 }
 
-impl<'a> Iterator<bool> for BitvIterator<'a> {
+impl<'a> Iterator<bool> for Bits<'a> {
     #[inline]
     fn next(&mut self) -> Option<bool> {
         if self.next_idx != self.end_idx {
@@ -602,7 +602,7 @@ impl<'a> Iterator<bool> for BitvIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator<bool> for BitvIterator<'a> {
+impl<'a> DoubleEndedIterator<bool> for Bits<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<bool> {
         if self.next_idx != self.end_idx {
@@ -614,9 +614,9 @@ impl<'a> DoubleEndedIterator<bool> for BitvIterator<'a> {
     }
 }
 
-impl<'a> ExactSize<bool> for BitvIterator<'a> {}
+impl<'a> ExactSize<bool> for Bits<'a> {}
 
-impl<'a> RandomAccessIterator<bool> for BitvIterator<'a> {
+impl<'a> RandomAccessIterator<bool> for Bits<'a> {
     #[inline]
     fn indexable(&self) -> uint {
         self.end_idx - self.next_idx
@@ -724,8 +724,8 @@ impl BitvSet {
         self.other_op(other, |w1, w2| w1 ^ w2);
     }
 
-    pub fn iter<'a>(&'a self) -> BitvSetIterator<'a> {
-        BitvSetIterator {set: self, next_idx: 0}
+    pub fn iter<'a>(&'a self) -> BitPositions<'a> {
+        BitPositions {set: self, next_idx: 0}
     }
 
     pub fn difference(&self, other: &BitvSet, f: |&uint| -> bool) -> bool {
@@ -871,7 +871,7 @@ impl BitvSet {
     /// and w1/w2 are the words coming from the two vectors self, other.
     fn commons<'a>(&'a self, other: &'a BitvSet)
         -> Map<'static, ((uint, &'a uint), &'a ~[uint]), (uint, uint, uint),
-               Zip<Enumerate<vec::VecIterator<'a, uint>>, Repeat<&'a ~[uint]>>> {
+               Zip<Enumerate<vec::Items<'a, uint>>, Repeat<&'a ~[uint]>>> {
         let min = num::min(self.bitv.storage.len(), other.bitv.storage.len());
         self.bitv.storage.slice(0, min).iter().enumerate()
             .zip(Repeat::new(&other.bitv.storage))
@@ -887,7 +887,7 @@ impl BitvSet {
     /// `other`.
     fn outliers<'a>(&'a self, other: &'a BitvSet)
         -> Map<'static, ((uint, &'a uint), uint), (bool, uint, uint),
-               Zip<Enumerate<vec::VecIterator<'a, uint>>, Repeat<uint>>> {
+               Zip<Enumerate<vec::Items<'a, uint>>, Repeat<uint>>> {
         let slen = self.bitv.storage.len();
         let olen = other.bitv.storage.len();
 
@@ -903,12 +903,12 @@ impl BitvSet {
     }
 }
 
-pub struct BitvSetIterator<'a> {
+pub struct BitPositions<'a> {
     priv set: &'a BitvSet,
     priv next_idx: uint
 }
 
-impl<'a> Iterator<uint> for BitvSetIterator<'a> {
+impl<'a> Iterator<uint> for BitPositions<'a> {
     #[inline]
     fn next(&mut self) -> Option<uint> {
         while self.next_idx < self.set.capacity() {

--- a/src/libextra/enum_set.rs
+++ b/src/libextra/enum_set.rs
@@ -77,8 +77,8 @@ impl<E:CLike> EnumSet<E> {
     }
 
     /// Returns an iterator over an EnumSet
-    pub fn iter(&self) -> EnumSetIterator<E> {
-        EnumSetIterator::new(self.bits)
+    pub fn iter(&self) -> Items<E> {
+        Items::new(self.bits)
     }
 }
 
@@ -101,18 +101,18 @@ impl<E:CLike> BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
 }
 
 /// An iterator over an EnumSet
-pub struct EnumSetIterator<E> {
+pub struct Items<E> {
     priv index: uint,
     priv bits: uint,
 }
 
-impl<E:CLike> EnumSetIterator<E> {
-    fn new(bits: uint) -> EnumSetIterator<E> {
-        EnumSetIterator { index: 0, bits: bits }
+impl<E:CLike> Items<E> {
+    fn new(bits: uint) -> Items<E> {
+        Items { index: 0, bits: bits }
     }
 }
 
-impl<E:CLike> Iterator<E> for EnumSetIterator<E> {
+impl<E:CLike> Iterator<E> for Items<E> {
     fn next(&mut self) -> Option<E> {
         if (self.bits == 0) {
             return None;

--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -11,7 +11,7 @@
 /*!
  * Support for matching file paths against Unix shell style patterns.
  *
- * The `glob` and `glob_with` functions, in concert with the `GlobIterator`
+ * The `glob` and `glob_with` functions, in concert with the `Paths`
  * type, allow querying the filesystem for all files that match a particular
  * pattern - just like the libc `glob` function (for an example see the `glob`
  * documentation). The methods on the `Pattern` type provide functionality
@@ -32,7 +32,7 @@ use std::path::is_sep;
  * An iterator that yields Paths from the filesystem that match a particular
  * pattern - see the `glob` function for more details.
  */
-pub struct GlobIterator {
+pub struct Paths {
     priv root: Path,
     priv dir_patterns: ~[Pattern],
     priv options: MatchOptions,
@@ -67,7 +67,7 @@ pub struct GlobIterator {
 /// /media/pictures/puppies.jpg
 /// ```
 ///
-pub fn glob(pattern: &str) -> GlobIterator {
+pub fn glob(pattern: &str) -> Paths {
     glob_with(pattern, MatchOptions::new())
 }
 
@@ -82,7 +82,7 @@ pub fn glob(pattern: &str) -> GlobIterator {
  *
  * Paths are yielded in alphabetical order, as absolute paths.
  */
-pub fn glob_with(pattern: &str, options: MatchOptions) -> GlobIterator {
+pub fn glob_with(pattern: &str, options: MatchOptions) -> Paths {
     #[cfg(windows)]
     fn check_windows_verbatim(p: &Path) -> bool { path::windows::is_verbatim(p) }
     #[cfg(not(windows))]
@@ -95,7 +95,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> GlobIterator {
         if check_windows_verbatim(pat_root.get_ref()) {
             // XXX: How do we want to handle verbatim paths? I'm inclined to return nothing,
             // since we can't very well find all UNC shares with a 1-letter server name.
-            return GlobIterator { root: root, dir_patterns: ~[], options: options, todo: ~[] };
+            return Paths { root: root, dir_patterns: ~[], options: options, todo: ~[] };
         }
         root.push(pat_root.get_ref());
     }
@@ -106,7 +106,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> GlobIterator {
 
     let todo = list_dir_sorted(&root).move_iter().map(|x|(x,0u)).to_owned_vec();
 
-    GlobIterator {
+    Paths {
         root: root,
         dir_patterns: dir_patterns,
         options: options,
@@ -114,7 +114,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> GlobIterator {
     }
 }
 
-impl Iterator<Path> for GlobIterator {
+impl Iterator<Path> for Paths {
 
     fn next(&mut self) -> Option<Path> {
         loop {

--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -36,8 +36,8 @@ impl<T:Ord> Mutable for PriorityQueue<T> {
 impl<T:Ord> PriorityQueue<T> {
     /// An iterator visiting all values in underlying vector, in
     /// arbitrary order.
-    pub fn iter<'a>(&'a self) -> PriorityQueueIterator<'a, T> {
-        PriorityQueueIterator { iter: self.data.iter() }
+    pub fn iter<'a>(&'a self) -> Items<'a, T> {
+        Items { iter: self.data.iter() }
     }
 
     /// Returns the greatest item in the queue - fails if empty
@@ -177,11 +177,11 @@ impl<T:Ord> PriorityQueue<T> {
 }
 
 /// PriorityQueue iterator
-pub struct PriorityQueueIterator <'a, T> {
-    priv iter: vec::VecIterator<'a, T>,
+pub struct Items <'a, T> {
+    priv iter: vec::Items<'a, T>,
 }
 
-impl<'a, T> Iterator<&'a T> for PriorityQueueIterator<'a, T> {
+impl<'a, T> Iterator<&'a T> for Items<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<(&'a T)> { self.iter.next() }
 

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -187,17 +187,17 @@ impl<T> RingBuf<T> {
     }
 
     /// Front-to-back iterator.
-    pub fn iter<'a>(&'a self) -> RingBufIterator<'a, T> {
-        RingBufIterator{index: 0, rindex: self.nelts, lo: self.lo, elts: self.elts}
+    pub fn iter<'a>(&'a self) -> Items<'a, T> {
+        Items{index: 0, rindex: self.nelts, lo: self.lo, elts: self.elts}
     }
 
     /// Back-to-front iterator.
-    pub fn rev_iter<'a>(&'a self) -> Invert<RingBufIterator<'a, T>> {
+    pub fn rev_iter<'a>(&'a self) -> Invert<Items<'a, T>> {
         self.iter().invert()
     }
 
     /// Front-to-back iterator which returns mutable values.
-    pub fn mut_iter<'a>(&'a mut self) -> RingBufMutIterator<'a, T> {
+    pub fn mut_iter<'a>(&'a mut self) -> MutItems<'a, T> {
         let start_index = raw_index(self.lo, self.elts.len(), 0);
         let end_index = raw_index(self.lo, self.elts.len(), self.nelts);
 
@@ -209,34 +209,34 @@ impl<T> RingBuf<T> {
             //    0 to end_index
             let (temp, remaining1) = self.elts.mut_split_at(start_index);
             let (remaining2, _) = temp.mut_split_at(end_index);
-            RingBufMutIterator { remaining1: remaining1,
+            MutItems { remaining1: remaining1,
                                  remaining2: remaining2,
                                  nelts: self.nelts }
         } else {
             // Items to iterate goes from start_index to end_index:
             let (empty, elts) = self.elts.mut_split_at(0);
             let remaining1 = elts.mut_slice(start_index, end_index);
-            RingBufMutIterator { remaining1: remaining1,
+            MutItems { remaining1: remaining1,
                                  remaining2: empty,
                                  nelts: self.nelts }
         }
     }
 
     /// Back-to-front iterator which returns mutable values.
-    pub fn mut_rev_iter<'a>(&'a mut self) -> Invert<RingBufMutIterator<'a, T>> {
+    pub fn mut_rev_iter<'a>(&'a mut self) -> Invert<MutItems<'a, T>> {
         self.mut_iter().invert()
     }
 }
 
 /// RingBuf iterator
-pub struct RingBufIterator<'a, T> {
+pub struct Items<'a, T> {
     priv lo: uint,
     priv index: uint,
     priv rindex: uint,
     priv elts: &'a [Option<T>],
 }
 
-impl<'a, T> Iterator<&'a T> for RingBufIterator<'a, T> {
+impl<'a, T> Iterator<&'a T> for Items<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a T> {
         if self.index == self.rindex {
@@ -254,7 +254,7 @@ impl<'a, T> Iterator<&'a T> for RingBufIterator<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a T> for RingBufIterator<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a T> {
         if self.index == self.rindex {
@@ -266,9 +266,9 @@ impl<'a, T> DoubleEndedIterator<&'a T> for RingBufIterator<'a, T> {
     }
 }
 
-impl<'a, T> ExactSize<&'a T> for RingBufIterator<'a, T> {}
+impl<'a, T> ExactSize<&'a T> for Items<'a, T> {}
 
-impl<'a, T> RandomAccessIterator<&'a T> for RingBufIterator<'a, T> {
+impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
     #[inline]
     fn indexable(&self) -> uint { self.rindex - self.index }
 
@@ -284,13 +284,13 @@ impl<'a, T> RandomAccessIterator<&'a T> for RingBufIterator<'a, T> {
 }
 
 /// RingBuf mutable iterator
-pub struct RingBufMutIterator<'a, T> {
+pub struct MutItems<'a, T> {
     priv remaining1: &'a mut [Option<T>],
     priv remaining2: &'a mut [Option<T>],
     priv nelts: uint,
 }
 
-impl<'a, T> Iterator<&'a mut T> for RingBufMutIterator<'a, T> {
+impl<'a, T> Iterator<&'a mut T> for MutItems<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a mut T> {
         if self.nelts == 0 {
@@ -312,7 +312,7 @@ impl<'a, T> Iterator<&'a mut T> for RingBufMutIterator<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a mut T> for RingBufMutIterator<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a mut T> for MutItems<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut T> {
         if self.nelts == 0 {
@@ -329,7 +329,7 @@ impl<'a, T> DoubleEndedIterator<&'a mut T> for RingBufMutIterator<'a, T> {
     }
 }
 
-impl<'a, T> ExactSize<&'a mut T> for RingBufMutIterator<'a, T> {}
+impl<'a, T> ExactSize<&'a mut T> for MutItems<'a, T> {}
 
 /// Grow is only called on full elts, so nelts is also len(elts), unlike
 /// elsewhere.

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -17,7 +17,6 @@
 
 use std::iter::{Enumerate, FilterMap, Invert};
 use std::util::replace;
-use std::vec::{VecIterator, VecMutIterator};
 use std::vec;
 
 #[allow(missing_doc)]
@@ -119,8 +118,8 @@ impl<V> SmallIntMap<V> {
 
     /// An iterator visiting all key-value pairs in ascending order by the keys.
     /// Iterator element type is (uint, &'r V)
-    pub fn iter<'r>(&'r self) -> SmallIntMapIterator<'r, V> {
-        SmallIntMapIterator {
+    pub fn iter<'r>(&'r self) -> Entries<'r, V> {
+        Entries {
             front: 0,
             back: self.v.len(),
             iter: self.v.iter()
@@ -130,8 +129,8 @@ impl<V> SmallIntMap<V> {
     /// An iterator visiting all key-value pairs in ascending order by the keys,
     /// with mutable references to the values
     /// Iterator element type is (uint, &'r mut V)
-    pub fn mut_iter<'r>(&'r mut self) -> SmallIntMapMutIterator<'r, V> {
-        SmallIntMapMutIterator {
+    pub fn mut_iter<'r>(&'r mut self) -> MutEntries<'r, V> {
+        MutEntries {
             front: 0,
             back: self.v.len(),
             iter: self.v.mut_iter()
@@ -140,21 +139,21 @@ impl<V> SmallIntMap<V> {
 
     /// An iterator visiting all key-value pairs in descending order by the keys.
     /// Iterator element type is (uint, &'r V)
-    pub fn rev_iter<'r>(&'r self) -> SmallIntMapRevIterator<'r, V> {
+    pub fn rev_iter<'r>(&'r self) -> RevEntries<'r, V> {
         self.iter().invert()
     }
 
     /// An iterator visiting all key-value pairs in descending order by the keys,
     /// with mutable references to the values
     /// Iterator element type is (uint, &'r mut V)
-    pub fn mut_rev_iter<'r>(&'r mut self) -> SmallIntMapMutRevIterator <'r, V> {
+    pub fn mut_rev_iter<'r>(&'r mut self) -> RevMutEntries <'r, V> {
         self.mut_iter().invert()
     }
 
     /// Empties the hash map, moving all values into the specified closure
     pub fn move_iter(&mut self)
         -> FilterMap<(uint, Option<V>), (uint, V),
-                Enumerate<vec::MoveIterator<Option<V>>>>
+                Enumerate<vec::MoveItems<Option<V>>>>
     {
         let values = replace(&mut self.v, ~[]);
         values.move_iter().enumerate().filter_map(|(i, v)| {
@@ -234,25 +233,25 @@ macro_rules! double_ended_iterator {
     }
 }
 
-pub struct SmallIntMapIterator<'a, T> {
+pub struct Entries<'a, T> {
     priv front: uint,
     priv back: uint,
-    priv iter: VecIterator<'a, Option<T>>
+    priv iter: vec::Items<'a, Option<T>>
 }
 
-iterator!(impl SmallIntMapIterator -> (uint, &'a T), get_ref)
-double_ended_iterator!(impl SmallIntMapIterator -> (uint, &'a T), get_ref)
-pub type SmallIntMapRevIterator<'a, T> = Invert<SmallIntMapIterator<'a, T>>;
+iterator!(impl Entries -> (uint, &'a T), get_ref)
+double_ended_iterator!(impl Entries -> (uint, &'a T), get_ref)
+pub type RevEntries<'a, T> = Invert<Entries<'a, T>>;
 
-pub struct SmallIntMapMutIterator<'a, T> {
+pub struct MutEntries<'a, T> {
     priv front: uint,
     priv back: uint,
-    priv iter: VecMutIterator<'a, Option<T>>
+    priv iter: vec::MutItems<'a, Option<T>>
 }
 
-iterator!(impl SmallIntMapMutIterator -> (uint, &'a mut T), get_mut_ref)
-double_ended_iterator!(impl SmallIntMapMutIterator -> (uint, &'a mut T), get_mut_ref)
-pub type SmallIntMapMutRevIterator<'a, T> = Invert<SmallIntMapMutIterator<'a, T>>;
+iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
+double_ended_iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
+pub type RevMutEntries<'a, T> = Invert<MutEntries<'a, T>>;
 
 #[cfg(test)]
 mod test_map {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -56,7 +56,7 @@ impl LanguageItems {
         }
     }
 
-    pub fn items<'a>(&'a self) -> Enumerate<vec::VecIterator<'a, Option<ast::DefId>>> {
+    pub fn items<'a>(&'a self) -> Enumerate<vec::Items<'a, Option<ast::DefId>>> {
         self.items.iter().enumerate()
     }
 

--- a/src/librustc/middle/trans/basic_block.rs
+++ b/src/librustc/middle/trans/basic_block.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 use lib::llvm::{llvm, BasicBlockRef};
-use middle::trans::value::{UserIterator, Value};
+use middle::trans::value::{Users, Value};
 use std::iter::{Filter, Map};
 
 pub struct BasicBlock(BasicBlockRef);
 
-pub type PredIterator<'a> = Map<'a, Value, BasicBlock, Filter<'a, Value, UserIterator>>;
+pub type Preds<'a> = Map<'a, Value, BasicBlock, Filter<'a, Value, Users>>;
 
 /**
  * Wrapper for LLVM BasicBlockRef
@@ -30,7 +30,7 @@ impl BasicBlock {
         }
     }
 
-    pub fn pred_iter(self) -> PredIterator {
+    pub fn pred_iter(self) -> Preds {
         self.as_value().user_iter()
             .filter(|user| user.is_a_terminator_inst())
             .map(|user| user.get_parent().unwrap())

--- a/src/librustc/middle/trans/value.rs
+++ b/src/librustc/middle/trans/value.rs
@@ -99,8 +99,8 @@ impl Value {
     }
 
     /// Returns an iterator for the users of this value
-    pub fn user_iter(self) -> UserIterator {
-        UserIterator {
+    pub fn user_iter(self) -> Users {
+        Users {
             next: self.get_first_use()
         }
     }
@@ -151,11 +151,11 @@ impl Use {
 }
 
 /// Iterator for the users of a value
-pub struct UserIterator {
+pub struct Users {
     priv next: Option<Use>
 }
 
-impl Iterator<Value> for UserIterator {
+impl Iterator<Value> for Users {
     fn next(&mut self) -> Option<Value> {
         let current = self.next;
 

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -171,8 +171,8 @@ impl CString {
     }
 
     /// Return a CString iterator.
-    pub fn iter<'a>(&'a self) -> CStringIterator<'a> {
-        CStringIterator {
+    pub fn iter<'a>(&'a self) -> CChars<'a> {
+        CChars {
             ptr: self.buf,
             lifetime: unsafe { cast::transmute(self.buf) },
         }
@@ -330,12 +330,12 @@ fn check_for_null(v: &[u8], buf: *mut libc::c_char) {
 /// External iterator for a CString's bytes.
 ///
 /// Use with the `std::iter` module.
-pub struct CStringIterator<'a> {
+pub struct CChars<'a> {
     priv ptr: *libc::c_char,
     priv lifetime: &'a libc::c_char, // FIXME: #5922
 }
 
-impl<'a> Iterator<libc::c_char> for CStringIterator<'a> {
+impl<'a> Iterator<libc::c_char> for CChars<'a> {
     fn next(&mut self) -> Option<libc::c_char> {
         let ch = unsafe { *self.ptr };
         if ch == 0 {

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -305,7 +305,7 @@ pub struct Port<T> {
 /// An iterator over messages received on a port, this iterator will block
 /// whenever `next` is called, waiting for a new message, and `None` will be
 /// returned when the corresponding channel has hung up.
-pub struct PortIterator<'a, T> {
+pub struct Messages<'a, T> {
     priv port: &'a Port<T>
 }
 
@@ -899,12 +899,12 @@ impl<T: Send> Port<T> {
 
     /// Returns an iterator which will block waiting for messages, but never
     /// `fail!`. It will return `None` when the channel has hung up.
-    pub fn iter<'a>(&'a self) -> PortIterator<'a, T> {
-        PortIterator { port: self }
+    pub fn iter<'a>(&'a self) -> Messages<'a, T> {
+        Messages { port: self }
     }
 }
 
-impl<'a, T: Send> Iterator<T> for PortIterator<'a, T> {
+impl<'a, T: Send> Iterator<T> for Messages<'a, T> {
     fn next(&mut self) -> Option<T> { self.port.recv_opt() }
 }
 

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -94,7 +94,7 @@ pub struct Handle<'port, T> {
     priv port: &'port mut Port<T>,
 }
 
-struct PacketIterator { priv cur: *mut Packet }
+struct Packets { priv cur: *mut Packet }
 
 impl Select {
     /// Creates a new selection structure. This set is initially empty and
@@ -267,7 +267,7 @@ impl Select {
         (*packet).selection_id = 0;
     }
 
-    fn iter(&self) -> PacketIterator { PacketIterator { cur: self.head } }
+    fn iter(&self) -> Packets { Packets { cur: self.head } }
 }
 
 impl<'port, T: Send> Handle<'port, T> {
@@ -300,7 +300,7 @@ impl<'port, T: Send> Drop for Handle<'port, T> {
     }
 }
 
-impl Iterator<*mut Packet> for PacketIterator {
+impl Iterator<*mut Packet> for Packets {
     fn next(&mut self) -> Option<*mut Packet> {
         if self.cur.is_null() {
             None

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -497,7 +497,7 @@ pub struct Formatter<'a> {
 
     /// Output buffer.
     buf: &'a mut io::Writer,
-    priv curarg: vec::VecIterator<'a, Argument<'a>>,
+    priv curarg: vec::Items<'a, Argument<'a>>,
     priv args: &'a [Argument<'a>],
 }
 

--- a/src/libstd/fmt/parse.rs
+++ b/src/libstd/fmt/parse.rs
@@ -168,7 +168,7 @@ pub struct SelectArm<'a> {
 /// necessary there's probably lots of room for improvement performance-wise.
 pub struct Parser<'a> {
     priv input: &'a str,
-    priv cur: str::CharOffsetIterator<'a>,
+    priv cur: str::CharOffsets<'a>,
     priv depth: uint,
 }
 

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -528,34 +528,34 @@ impl<K: Hash + Eq, V> HashMap<K, V> {
 
     /// An iterator visiting all keys in arbitrary order.
     /// Iterator element type is &'a K.
-    pub fn keys<'a>(&'a self) -> HashMapKeyIterator<'a, K, V> {
+    pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
         self.iter().map(|(k, _v)| k)
     }
 
     /// An iterator visiting all values in arbitrary order.
     /// Iterator element type is &'a V.
-    pub fn values<'a>(&'a self) -> HashMapValueIterator<'a, K, V> {
+    pub fn values<'a>(&'a self) -> Values<'a, K, V> {
         self.iter().map(|(_k, v)| v)
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order.
     /// Iterator element type is (&'a K, &'a V).
-    pub fn iter<'a>(&'a self) -> HashMapIterator<'a, K, V> {
-        HashMapIterator { iter: self.buckets.iter() }
+    pub fn iter<'a>(&'a self) -> Entries<'a, K, V> {
+        Entries { iter: self.buckets.iter() }
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order,
     /// with mutable references to the values.
     /// Iterator element type is (&'a K, &'a mut V).
-    pub fn mut_iter<'a>(&'a mut self) -> HashMapMutIterator<'a, K, V> {
-        HashMapMutIterator { iter: self.buckets.mut_iter() }
+    pub fn mut_iter<'a>(&'a mut self) -> MutEntries<'a, K, V> {
+        MutEntries { iter: self.buckets.mut_iter() }
     }
 
     /// Creates a consuming iterator, that is, one that moves each key-value
     /// pair out of the map in arbitrary order. The map cannot be used after
     /// calling this.
-    pub fn move_iter(self) -> HashMapMoveIterator<K, V> {
-        HashMapMoveIterator {iter: self.buckets.move_iter()}
+    pub fn move_iter(self) -> MoveEntries<K, V> {
+        MoveEntries {iter: self.buckets.move_iter()}
     }
 }
 
@@ -598,40 +598,40 @@ impl<K:Hash + Eq + Clone,V:Clone> Clone for HashMap<K,V> {
 
 /// HashMap iterator
 #[deriving(Clone)]
-pub struct HashMapIterator<'a, K, V> {
-    priv iter: vec::VecIterator<'a, Option<Bucket<K, V>>>,
+pub struct Entries<'a, K, V> {
+    priv iter: vec::Items<'a, Option<Bucket<K, V>>>,
 }
 
 /// HashMap mutable values iterator
-pub struct HashMapMutIterator<'a, K, V> {
-    priv iter: vec::VecMutIterator<'a, Option<Bucket<K, V>>>,
+pub struct MutEntries<'a, K, V> {
+    priv iter: vec::MutItems<'a, Option<Bucket<K, V>>>,
 }
 
 /// HashMap move iterator
-pub struct HashMapMoveIterator<K, V> {
-    priv iter: vec::MoveIterator<Option<Bucket<K, V>>>,
+pub struct MoveEntries<K, V> {
+    priv iter: vec::MoveItems<Option<Bucket<K, V>>>,
 }
 
 /// HashMap keys iterator
-pub type HashMapKeyIterator<'a, K, V> =
-    iter::Map<'static, (&'a K, &'a V), &'a K, HashMapIterator<'a, K, V>>;
+pub type Keys<'a, K, V> =
+    iter::Map<'static, (&'a K, &'a V), &'a K, Entries<'a, K, V>>;
 
 /// HashMap values iterator
-pub type HashMapValueIterator<'a, K, V> =
-    iter::Map<'static, (&'a K, &'a V), &'a V, HashMapIterator<'a, K, V>>;
+pub type Values<'a, K, V> =
+    iter::Map<'static, (&'a K, &'a V), &'a V, Entries<'a, K, V>>;
 
 /// HashSet iterator
 #[deriving(Clone)]
-pub struct HashSetIterator<'a, K> {
-    priv iter: vec::VecIterator<'a, Option<Bucket<K, ()>>>,
+pub struct SetItems<'a, K> {
+    priv iter: vec::Items<'a, Option<Bucket<K, ()>>>,
 }
 
 /// HashSet move iterator
-pub struct HashSetMoveIterator<K> {
-    priv iter: vec::MoveIterator<Option<Bucket<K, ()>>>,
+pub struct SetMoveItems<K> {
+    priv iter: vec::MoveItems<Option<Bucket<K, ()>>>,
 }
 
-impl<'a, K, V> Iterator<(&'a K, &'a V)> for HashMapIterator<'a, K, V> {
+impl<'a, K, V> Iterator<(&'a K, &'a V)> for Entries<'a, K, V> {
     #[inline]
     fn next(&mut self) -> Option<(&'a K, &'a V)> {
         for elt in self.iter {
@@ -644,7 +644,7 @@ impl<'a, K, V> Iterator<(&'a K, &'a V)> for HashMapIterator<'a, K, V> {
     }
 }
 
-impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for HashMapMutIterator<'a, K, V> {
+impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for MutEntries<'a, K, V> {
     #[inline]
     fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
         for elt in self.iter {
@@ -657,7 +657,7 @@ impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for HashMapMutIterator<'a, K, V> {
     }
 }
 
-impl<K, V> Iterator<(K, V)> for HashMapMoveIterator<K, V> {
+impl<K, V> Iterator<(K, V)> for MoveEntries<K, V> {
     #[inline]
     fn next(&mut self) -> Option<(K, V)> {
         for elt in self.iter {
@@ -670,7 +670,7 @@ impl<K, V> Iterator<(K, V)> for HashMapMoveIterator<K, V> {
     }
 }
 
-impl<'a, K> Iterator<&'a K> for HashSetIterator<'a, K> {
+impl<'a, K> Iterator<&'a K> for SetItems<'a, K> {
     #[inline]
     fn next(&mut self) -> Option<&'a K> {
         for elt in self.iter {
@@ -683,7 +683,7 @@ impl<'a, K> Iterator<&'a K> for HashSetIterator<'a, K> {
     }
 }
 
-impl<K> Iterator<K> for HashSetMoveIterator<K> {
+impl<K> Iterator<K> for SetMoveItems<K> {
     #[inline]
     fn next(&mut self) -> Option<K> {
         for elt in self.iter {
@@ -806,19 +806,19 @@ impl<T:Hash + Eq> HashSet<T> {
 
     /// An iterator visiting all elements in arbitrary order.
     /// Iterator element type is &'a T.
-    pub fn iter<'a>(&'a self) -> HashSetIterator<'a, T> {
-        HashSetIterator { iter: self.map.buckets.iter() }
+    pub fn iter<'a>(&'a self) -> SetItems<'a, T> {
+        SetItems { iter: self.map.buckets.iter() }
     }
 
     /// Creates a consuming iterator, that is, one that moves each value out
     /// of the set in arbitrary order. The set cannot be used after calling
     /// this.
-    pub fn move_iter(self) -> HashSetMoveIterator<T> {
-        HashSetMoveIterator {iter: self.map.buckets.move_iter()}
+    pub fn move_iter(self) -> SetMoveItems<T> {
+        SetMoveItems {iter: self.map.buckets.move_iter()}
     }
 
     /// Visit the values representing the difference
-    pub fn difference<'a>(&'a self, other: &'a HashSet<T>) -> SetAlgebraIter<'a, T> {
+    pub fn difference<'a>(&'a self, other: &'a HashSet<T>) -> SetAlgebraItems<'a, T> {
         Repeat::new(other)
             .zip(self.iter())
             .filter_map(|(other, elt)| {
@@ -828,13 +828,13 @@ impl<T:Hash + Eq> HashSet<T> {
 
     /// Visit the values representing the symmetric difference
     pub fn symmetric_difference<'a>(&'a self, other: &'a HashSet<T>)
-        -> Chain<SetAlgebraIter<'a, T>, SetAlgebraIter<'a, T>> {
+        -> Chain<SetAlgebraItems<'a, T>, SetAlgebraItems<'a, T>> {
         self.difference(other).chain(other.difference(self))
     }
 
     /// Visit the values representing the intersection
     pub fn intersection<'a>(&'a self, other: &'a HashSet<T>)
-        -> SetAlgebraIter<'a, T> {
+        -> SetAlgebraItems<'a, T> {
         Repeat::new(other)
             .zip(self.iter())
             .filter_map(|(other, elt)| {
@@ -844,7 +844,7 @@ impl<T:Hash + Eq> HashSet<T> {
 
     /// Visit the values representing the union
     pub fn union<'a>(&'a self, other: &'a HashSet<T>)
-        -> Chain<HashSetIterator<'a, T>, SetAlgebraIter<'a, T>> {
+        -> Chain<SetItems<'a, T>, SetAlgebraItems<'a, T>> {
         self.iter().chain(other.difference(self))
     }
 
@@ -882,9 +882,9 @@ impl<K: Eq + Hash> Default for HashSet<K> {
 // `Repeat` is used to feed the filter closure an explicit capture
 // of a reference to the other set
 /// Set operations iterator
-pub type SetAlgebraIter<'a, T> =
+pub type SetAlgebraItems<'a, T> =
     FilterMap<'static,(&'a HashSet<T>, &'a T), &'a T,
-              Zip<Repeat<&'a HashSet<T>>,HashSetIterator<'a,T>>>;
+              Zip<Repeat<&'a HashSet<T>>,SetItems<'a,T>>>;
 
 
 #[cfg(test)]

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -24,7 +24,7 @@ use vec::{OwnedVector, ImmutableVector};
 ///
 /// # Notes about the Iteration Protocol
 ///
-/// The `ByteIterator` may yield `None` and thus terminate
+/// The `Bytes` may yield `None` and thus terminate
 /// an iteration, but continue to yield elements if iteration
 /// is attempted again.
 ///
@@ -33,17 +33,17 @@ use vec::{OwnedVector, ImmutableVector};
 /// Raises the same conditions as the `read` method, for
 /// each call to its `.next()` method.
 /// Yields `None` if the condition is handled.
-pub struct ByteIterator<'r, T> {
+pub struct Bytes<'r, T> {
     priv reader: &'r mut T,
 }
 
-impl<'r, R: Reader> ByteIterator<'r, R> {
-    pub fn new(r: &'r mut R) -> ByteIterator<'r, R> {
-        ByteIterator { reader: r }
+impl<'r, R: Reader> Bytes<'r, R> {
+    pub fn new(r: &'r mut R) -> Bytes<'r, R> {
+        Bytes { reader: r }
     }
 }
 
-impl<'r, R: Reader> Iterator<u8> for ByteIterator<'r, R> {
+impl<'r, R: Reader> Iterator<u8> for Bytes<'r, R> {
     #[inline]
     fn next(&mut self) -> Option<u8> {
         self.reader.read_byte()

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -508,16 +508,16 @@ pub fn readdir(path: &Path) -> ~[Path] {
 /// Returns an iterator which will recursively walk the directory structure
 /// rooted at `path`. The path given will not be iterated over, and this will
 /// perform iteration in a top-down order.
-pub fn walk_dir(path: &Path) -> WalkIterator {
-    WalkIterator { stack: readdir(path) }
+pub fn walk_dir(path: &Path) -> Directories {
+    Directories { stack: readdir(path) }
 }
 
 /// An iterator which walks over a directory
-pub struct WalkIterator {
+pub struct Directories {
     priv stack: ~[Path],
 }
 
-impl Iterator<Path> for WalkIterator {
+impl Iterator<Path> for Directories {
     fn next(&mut self) -> Option<Path> {
         match self.stack.shift_opt() {
             Some(path) => {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -214,26 +214,26 @@ impl<T> Option<T> {
 
     /// Return an iterator over the possibly contained value
     #[inline]
-    pub fn iter<'r>(&'r self) -> OptionIterator<&'r T> {
+    pub fn iter<'r>(&'r self) -> Item<&'r T> {
         match *self {
-            Some(ref x) => OptionIterator{opt: Some(x)},
-            None => OptionIterator{opt: None}
+            Some(ref x) => Item{opt: Some(x)},
+            None => Item{opt: None}
         }
     }
 
     /// Return a mutable iterator over the possibly contained value
     #[inline]
-    pub fn mut_iter<'r>(&'r mut self) -> OptionIterator<&'r mut T> {
+    pub fn mut_iter<'r>(&'r mut self) -> Item<&'r mut T> {
         match *self {
-            Some(ref mut x) => OptionIterator{opt: Some(x)},
-            None => OptionIterator{opt: None}
+            Some(ref mut x) => Item{opt: Some(x)},
+            None => Item{opt: None}
         }
     }
 
     /// Return a consuming iterator over the possibly contained value
     #[inline]
-    pub fn move_iter(self) -> OptionIterator<T> {
-        OptionIterator{opt: self}
+    pub fn move_iter(self) -> Item<T> {
+        Item{opt: self}
     }
 
     /////////////////////////////////////////////////////////////////////////
@@ -401,11 +401,11 @@ impl<T> Default for Option<T> {
 
 /// An iterator that yields either one or zero elements
 #[deriving(Clone, DeepClone)]
-pub struct OptionIterator<A> {
+pub struct Item<A> {
     priv opt: Option<A>
 }
 
-impl<A> Iterator<A> for OptionIterator<A> {
+impl<A> Iterator<A> for Item<A> {
     #[inline]
     fn next(&mut self) -> Option<A> {
         self.opt.take()
@@ -420,14 +420,14 @@ impl<A> Iterator<A> for OptionIterator<A> {
     }
 }
 
-impl<A> DoubleEndedIterator<A> for OptionIterator<A> {
+impl<A> DoubleEndedIterator<A> for Item<A> {
     #[inline]
     fn next_back(&mut self) -> Option<A> {
         self.opt.take()
     }
 }
 
-impl<A> ExactSize<A> for OptionIterator<A> {}
+impl<A> ExactSize<A> for Item<A> {}
 
 /////////////////////////////////////////////////////////////////////////////
 // Free functions

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -93,29 +93,29 @@ pub use Path = self::windows::Path;
 
 /// Typedef for the platform-native component iterator
 #[cfg(unix)]
-pub use ComponentIter = self::posix::ComponentIter;
+pub use Components = self::posix::Components;
 /// Typedef for the platform-native reverse component iterator
 #[cfg(unix)]
-pub use RevComponentIter = self::posix::RevComponentIter;
+pub use RevComponents = self::posix::RevComponents;
 /// Typedef for the platform-native component iterator
 #[cfg(windows)]
-pub use ComponentIter = self::windows::ComponentIter;
+pub use Components = self::windows::Components;
 /// Typedef for the platform-native reverse component iterator
 #[cfg(windows)]
-pub use RevComponentIter = self::windows::RevComponentIter;
+pub use RevComponents = self::windows::RevComponents;
 
 /// Typedef for the platform-native str component iterator
 #[cfg(unix)]
-pub use StrComponentIter = self::posix::StrComponentIter;
+pub use StrComponents = self::posix::StrComponents;
 /// Typedef for the platform-native reverse str component iterator
 #[cfg(unix)]
-pub use RevStrComponentIter = self::posix::RevStrComponentIter;
+pub use RevStrComponents = self::posix::RevStrComponents;
 /// Typedef for the platform-native str component iterator
 #[cfg(windows)]
-pub use StrComponentIter = self::windows::StrComponentIter;
+pub use StrComponents = self::windows::StrComponents;
 /// Typedef for the platform-native reverse str component iterator
 #[cfg(windows)]
-pub use RevStrComponentIter = self::windows::RevStrComponentIter;
+pub use RevStrComponents = self::windows::RevStrComponents;
 
 /// Typedef for the platform-native separator char func
 #[cfg(unix)]

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -21,21 +21,21 @@ use str;
 use str::Str;
 use to_bytes::IterBytes;
 use vec;
-use vec::{CopyableVector, RSplitIterator, SplitIterator, Vector, VectorVector,
+use vec::{CopyableVector, RevSplits, Splits, Vector, VectorVector,
           ImmutableEqVector, OwnedVector, ImmutableVector, OwnedCopyableVector};
 use super::{BytesContainer, GenericPath, GenericPathUnsafe};
 
 /// Iterator that yields successive components of a Path as &[u8]
-pub type ComponentIter<'a> = SplitIterator<'a, u8>;
+pub type Components<'a> = Splits<'a, u8>;
 /// Iterator that yields components of a Path in reverse as &[u8]
-pub type RevComponentIter<'a> = RSplitIterator<'a, u8>;
+pub type RevComponents<'a> = RevSplits<'a, u8>;
 
 /// Iterator that yields successive components of a Path as Option<&str>
-pub type StrComponentIter<'a> = Map<'a, &'a [u8], Option<&'a str>,
-                                       ComponentIter<'a>>;
+pub type StrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
+                                       Components<'a>>;
 /// Iterator that yields components of a Path in reverse as Option<&str>
-pub type RevStrComponentIter<'a> = Map<'a, &'a [u8], Option<&'a str>,
-                                          RevComponentIter<'a>>;
+pub type RevStrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
+                                          RevComponents<'a>>;
 
 /// Represents a POSIX file path
 #[deriving(Clone, DeepClone)]
@@ -371,7 +371,7 @@ impl Path {
     /// Does not distinguish between absolute and relative paths, e.g.
     /// /a/b/c and a/b/c yield the same set of components.
     /// A path of "/" yields no components. A path of "." yields one component.
-    pub fn components<'a>(&'a self) -> ComponentIter<'a> {
+    pub fn components<'a>(&'a self) -> Components<'a> {
         let v = if self.repr[0] == sep_byte {
             self.repr.slice_from(1)
         } else { self.repr.as_slice() };
@@ -385,7 +385,7 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse.
     /// See components() for details.
-    pub fn rev_components<'a>(&'a self) -> RevComponentIter<'a> {
+    pub fn rev_components<'a>(&'a self) -> RevComponents<'a> {
         let v = if self.repr[0] == sep_byte {
             self.repr.slice_from(1)
         } else { self.repr.as_slice() };
@@ -399,13 +399,13 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path as Option<&str>.
     /// See components() for details.
-    pub fn str_components<'a>(&'a self) -> StrComponentIter<'a> {
+    pub fn str_components<'a>(&'a self) -> StrComponents<'a> {
         self.components().map(str::from_utf8_opt)
     }
 
     /// Returns an iterator that yields each component of the path in reverse as Option<&str>.
     /// See components() for details.
-    pub fn rev_str_components<'a>(&'a self) -> RevStrComponentIter<'a> {
+    pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
         self.rev_components().map(str::from_utf8_opt)
     }
 }

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -20,7 +20,7 @@ use from_str::FromStr;
 use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Invert, Iterator, Map};
 use option::{Option, Some, None};
 use str;
-use str::{CharSplitIterator, OwnedStr, Str, StrVector, StrSlice};
+use str::{CharSplits, OwnedStr, Str, StrVector, StrSlice};
 use to_bytes::IterBytes;
 use vec::{Vector, OwnedVector, ImmutableVector};
 use super::{contains_nul, BytesContainer, GenericPath, GenericPathUnsafe};
@@ -29,21 +29,21 @@ use super::{contains_nul, BytesContainer, GenericPath, GenericPathUnsafe};
 ///
 /// Each component is yielded as Option<&str> for compatibility with PosixPath, but
 /// every component in WindowsPath is guaranteed to be Some.
-pub type StrComponentIter<'a> = Map<'a, &'a str, Option<&'a str>,
-                                       CharSplitIterator<'a, char>>;
+pub type StrComponents<'a> = Map<'a, &'a str, Option<&'a str>,
+                                       CharSplits<'a, char>>;
 /// Iterator that yields components of a Path in reverse as &str
 ///
 /// Each component is yielded as Option<&str> for compatibility with PosixPath, but
 /// every component in WindowsPath is guaranteed to be Some.
-pub type RevStrComponentIter<'a> = Invert<Map<'a, &'a str, Option<&'a str>,
-                                                 CharSplitIterator<'a, char>>>;
+pub type RevStrComponents<'a> = Invert<Map<'a, &'a str, Option<&'a str>,
+                                                 CharSplits<'a, char>>>;
 
 /// Iterator that yields successive components of a Path as &[u8]
-pub type ComponentIter<'a> = Map<'a, Option<&'a str>, &'a [u8],
-                                    StrComponentIter<'a>>;
+pub type Components<'a> = Map<'a, Option<&'a str>, &'a [u8],
+                                    StrComponents<'a>>;
 /// Iterator that yields components of a Path in reverse as &[u8]
-pub type RevComponentIter<'a> = Map<'a, Option<&'a str>, &'a [u8],
-                                       RevStrComponentIter<'a>>;
+pub type RevComponents<'a> = Map<'a, Option<&'a str>, &'a [u8],
+                                       RevStrComponents<'a>>;
 
 /// Represents a Windows path
 // Notes for Windows path impl:
@@ -615,7 +615,7 @@ impl Path {
     /// \a\b\c and a\b\c.
     /// Does not distinguish between absolute and cwd-relative paths, e.g.
     /// C:\foo and C:foo.
-    pub fn str_components<'a>(&'a self) -> StrComponentIter<'a> {
+    pub fn str_components<'a>(&'a self) -> StrComponents<'a> {
         let s = match self.prefix {
             Some(_) => {
                 let plen = self.prefix_len();
@@ -632,13 +632,13 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse as an Option<&str>
     /// See str_components() for details.
-    pub fn rev_str_components<'a>(&'a self) -> RevStrComponentIter<'a> {
+    pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
         self.str_components().invert()
     }
 
     /// Returns an iterator that yields each component of the path in turn as a &[u8].
     /// See str_components() for details.
-    pub fn components<'a>(&'a self) -> ComponentIter<'a> {
+    pub fn components<'a>(&'a self) -> Components<'a> {
         fn convert<'a>(x: Option<&'a str>) -> &'a [u8] {
             #[inline];
             x.unwrap().as_bytes()
@@ -648,7 +648,7 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse as a &[u8].
     /// See str_components() for details.
-    pub fn rev_components<'a>(&'a self) -> RevComponentIter<'a> {
+    pub fn rev_components<'a>(&'a self) -> RevComponents<'a> {
         fn convert<'a>(x: Option<&'a str>) -> &'a [u8] {
             #[inline];
             x.unwrap().as_bytes()

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -79,7 +79,7 @@ pub struct Death {
     on_exit: Option<proc(TaskResult)>,
 }
 
-pub struct BlockedTaskIterator {
+pub struct BlockedTasks {
     priv inner: UnsafeArc<AtomicUint>,
 }
 
@@ -300,7 +300,7 @@ impl Drop for Task {
     }
 }
 
-impl Iterator<BlockedTask> for BlockedTaskIterator {
+impl Iterator<BlockedTask> for BlockedTasks {
     fn next(&mut self) -> Option<BlockedTask> {
         Some(Shared(self.inner.clone()))
     }
@@ -331,7 +331,7 @@ impl BlockedTask {
     }
 
     /// Converts one blocked task handle to a list of many handles to the same.
-    pub fn make_selectable(self, num_handles: uint) -> Take<BlockedTaskIterator>
+    pub fn make_selectable(self, num_handles: uint) -> Take<BlockedTasks>
     {
         let arc = match self {
             Owned(task) => {
@@ -340,7 +340,7 @@ impl BlockedTask {
             }
             Shared(arc) => arc.clone(),
         };
-        BlockedTaskIterator{ inner: arc }.take(num_handles)
+        BlockedTasks{ inner: arc }.take(num_handles)
     }
 
     /// Convert to an unsafe uint value. Useful for storing in a pipe's state

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -331,12 +331,12 @@ Section: Iterators
 /// External iterator for a string's characters.
 /// Use with the `std::iter` module.
 #[deriving(Clone)]
-pub struct CharIterator<'a> {
+pub struct Chars<'a> {
     /// The slice remaining to be iterated
     priv string: &'a str,
 }
 
-impl<'a> Iterator<char> for CharIterator<'a> {
+impl<'a> Iterator<char> for Chars<'a> {
     #[inline]
     fn next(&mut self) -> Option<char> {
         // Decode the next codepoint, then update
@@ -358,7 +358,7 @@ impl<'a> Iterator<char> for CharIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator<char> for CharIterator<'a> {
+impl<'a> DoubleEndedIterator<char> for Chars<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<char> {
         if self.string.len() != 0 {
@@ -376,13 +376,13 @@ impl<'a> DoubleEndedIterator<char> for CharIterator<'a> {
 /// External iterator for a string's characters and their byte offsets.
 /// Use with the `std::iter` module.
 #[deriving(Clone)]
-pub struct CharOffsetIterator<'a> {
+pub struct CharOffsets<'a> {
     /// The original string to be iterated
     priv string: &'a str,
-    priv iter: CharIterator<'a>,
+    priv iter: Chars<'a>,
 }
 
-impl<'a> Iterator<(uint, char)> for CharOffsetIterator<'a> {
+impl<'a> Iterator<(uint, char)> for CharOffsets<'a> {
     #[inline]
     fn next(&mut self) -> Option<(uint, char)> {
         // Compute the byte offset by using the pointer offset between
@@ -397,7 +397,7 @@ impl<'a> Iterator<(uint, char)> for CharOffsetIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsetIterator<'a> {
+impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsets<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<(uint, char)> {
         self.iter.next_back().map(|ch| {
@@ -410,24 +410,24 @@ impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsetIterator<'a> {
 
 /// External iterator for a string's characters in reverse order.
 /// Use with the `std::iter` module.
-pub type CharRevIterator<'a> = Invert<CharIterator<'a>>;
+pub type RevChars<'a> = Invert<Chars<'a>>;
 
 /// External iterator for a string's characters and their byte offsets in reverse order.
 /// Use with the `std::iter` module.
-pub type CharOffsetRevIterator<'a> = Invert<CharOffsetIterator<'a>>;
+pub type RevCharOffsets<'a> = Invert<CharOffsets<'a>>;
 
 /// External iterator for a string's bytes.
 /// Use with the `std::iter` module.
-pub type ByteIterator<'a> =
-    Map<'a, &'a u8, u8, vec::VecIterator<'a, u8>>;
+pub type Bytes<'a> =
+    Map<'a, &'a u8, u8, vec::Items<'a, u8>>;
 
 /// External iterator for a string's bytes in reverse order.
 /// Use with the `std::iter` module.
-pub type ByteRevIterator<'a> = Invert<ByteIterator<'a>>;
+pub type RevBytes<'a> = Invert<Bytes<'a>>;
 
 /// An iterator over the substrings of a string, separated by `sep`.
 #[deriving(Clone)]
-pub struct CharSplitIterator<'a, Sep> {
+pub struct CharSplits<'a, Sep> {
     /// The slice remaining to be iterated
     priv string: &'a str,
     priv sep: Sep,
@@ -439,27 +439,27 @@ pub struct CharSplitIterator<'a, Sep> {
 
 /// An iterator over the substrings of a string, separated by `sep`,
 /// starting from the back of the string.
-pub type CharRSplitIterator<'a, Sep> = Invert<CharSplitIterator<'a, Sep>>;
+pub type RevCharSplits<'a, Sep> = Invert<CharSplits<'a, Sep>>;
 
 /// An iterator over the substrings of a string, separated by `sep`,
 /// splitting at most `count` times.
 #[deriving(Clone)]
-pub struct CharSplitNIterator<'a, Sep> {
-    priv iter: CharSplitIterator<'a, Sep>,
+pub struct CharSplitsN<'a, Sep> {
+    priv iter: CharSplits<'a, Sep>,
     /// The number of splits remaining
     priv count: uint,
     priv invert: bool,
 }
 
 /// An iterator over the words of a string, separated by an sequence of whitespace
-pub type WordIterator<'a> =
-    Filter<'a, &'a str, CharSplitIterator<'a, extern "Rust" fn(char) -> bool>>;
+pub type Words<'a> =
+    Filter<'a, &'a str, CharSplits<'a, extern "Rust" fn(char) -> bool>>;
 
 /// An iterator over the lines of a string, separated by either `\n` or (`\r\n`).
-pub type AnyLineIterator<'a> =
-    Map<'a, &'a str, &'a str, CharSplitIterator<'a, char>>;
+pub type AnyLines<'a> =
+    Map<'a, &'a str, &'a str, CharSplits<'a, char>>;
 
-impl<'a, Sep> CharSplitIterator<'a, Sep> {
+impl<'a, Sep> CharSplits<'a, Sep> {
     #[inline]
     fn get_end(&mut self) -> Option<&'a str> {
         if !self.finished && (self.allow_trailing_empty || self.string.len() > 0) {
@@ -471,7 +471,7 @@ impl<'a, Sep> CharSplitIterator<'a, Sep> {
     }
 }
 
-impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplitIterator<'a, Sep> {
+impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplits<'a, Sep> {
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
         if self.finished { return None }
@@ -504,7 +504,7 @@ impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplitIterator<'a, Sep> {
 }
 
 impl<'a, Sep: CharEq> DoubleEndedIterator<&'a str>
-for CharSplitIterator<'a, Sep> {
+for CharSplits<'a, Sep> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a str> {
         if self.finished { return None }
@@ -545,7 +545,7 @@ for CharSplitIterator<'a, Sep> {
     }
 }
 
-impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplitNIterator<'a, Sep> {
+impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplitsN<'a, Sep> {
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
         if self.count != 0 {
@@ -560,7 +560,7 @@ impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplitNIterator<'a, Sep> {
 /// An iterator over the start and end indices of the matches of a
 /// substring within a larger string
 #[deriving(Clone)]
-pub struct MatchesIndexIterator<'a> {
+pub struct MatchIndices<'a> {
     priv haystack: &'a str,
     priv needle: &'a str,
     priv position: uint,
@@ -569,13 +569,13 @@ pub struct MatchesIndexIterator<'a> {
 /// An iterator over the substrings of a string separated by a given
 /// search string
 #[deriving(Clone)]
-pub struct StrSplitIterator<'a> {
-    priv it: MatchesIndexIterator<'a>,
+pub struct StrSplits<'a> {
+    priv it: MatchIndices<'a>,
     priv last_end: uint,
     priv finished: bool
 }
 
-impl<'a> Iterator<(uint, uint)> for MatchesIndexIterator<'a> {
+impl<'a> Iterator<(uint, uint)> for MatchIndices<'a> {
     #[inline]
     fn next(&mut self) -> Option<(uint, uint)> {
         // See Issue #1932 for why this is a naive search
@@ -606,7 +606,7 @@ impl<'a> Iterator<(uint, uint)> for MatchesIndexIterator<'a> {
     }
 }
 
-impl<'a> Iterator<&'a str> for StrSplitIterator<'a> {
+impl<'a> Iterator<&'a str> for StrSplits<'a> {
     #[inline]
     fn next(&mut self) -> Option<&'a str> {
         if self.finished { return None; }
@@ -654,14 +654,14 @@ enum NormalizationForm {
 /// External iterator for a string's normalization's characters.
 /// Use with the `std::iter` module.
 #[deriving(Clone)]
-struct NormalizationIterator<'a> {
+struct Normalizations<'a> {
     priv kind: NormalizationForm,
-    priv iter: CharIterator<'a>,
+    priv iter: Chars<'a>,
     priv buffer: ~[(char, u8)],
     priv sorted: bool
 }
 
-impl<'a> Iterator<char> for NormalizationIterator<'a> {
+impl<'a> Iterator<char> for Normalizations<'a> {
     #[inline]
     fn next(&mut self) -> Option<char> {
         use unicode::decompose::canonical_combining_class;
@@ -1347,23 +1347,23 @@ pub trait StrSlice<'a> {
     /// let v: ~[char] = "abc åäö".chars().collect();
     /// assert_eq!(v, ~['a', 'b', 'c', ' ', 'å', 'ä', 'ö']);
     /// ```
-    fn chars(&self) -> CharIterator<'a>;
+    fn chars(&self) -> Chars<'a>;
 
     /// An iterator over the characters of `self`, in reverse order.
-    fn chars_rev(&self) -> CharRevIterator<'a>;
+    fn chars_rev(&self) -> RevChars<'a>;
 
     /// An iterator over the bytes of `self`
-    fn bytes(&self) -> ByteIterator<'a>;
+    fn bytes(&self) -> Bytes<'a>;
 
     /// An iterator over the bytes of `self`, in reverse order
-    fn bytes_rev(&self) -> ByteRevIterator<'a>;
+    fn bytes_rev(&self) -> RevBytes<'a>;
 
     /// An iterator over the characters of `self` and their byte offsets.
-    fn char_indices(&self) -> CharOffsetIterator<'a>;
+    fn char_indices(&self) -> CharOffsets<'a>;
 
     /// An iterator over the characters of `self` and their byte offsets,
     /// in reverse order.
-    fn char_indices_rev(&self) -> CharOffsetRevIterator<'a>;
+    fn char_indices_rev(&self) -> RevCharOffsets<'a>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`.
@@ -1380,7 +1380,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = "lionXXtigerXleopard".split('X').collect();
     /// assert_eq!(v, ~["lion", "", "tiger", "leopard"]);
     /// ```
-    fn split<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'a, Sep>;
+    fn split<Sep: CharEq>(&self, sep: Sep) -> CharSplits<'a, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, restricted to splitting at most `count`
@@ -1398,7 +1398,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = "lionXXtigerXleopard".splitn('X', 2).collect();
     /// assert_eq!(v, ~["lion", "", "tigerXleopard"]);
     /// ```
-    fn splitn<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitNIterator<'a, Sep>;
+    fn splitn<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitsN<'a, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`.
@@ -1415,7 +1415,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = "A..B..".split_terminator('.').collect();
     /// assert_eq!(v, ~["A", "", "B", ""]);
     /// ```
-    fn split_terminator<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'a, Sep>;
+    fn split_terminator<Sep: CharEq>(&self, sep: Sep) -> CharSplits<'a, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, in reverse order.
@@ -1432,7 +1432,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = "lionXXtigerXleopard".rsplit('X').collect();
     /// assert_eq!(v, ~["leopard", "tiger", "", "lion"]);
     /// ```
-    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> CharRSplitIterator<'a, Sep>;
+    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> RevCharSplits<'a, Sep>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, starting from the end of the string.
@@ -1450,7 +1450,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = "lionXXtigerXleopard".rsplitn('X', 2).collect();
     /// assert_eq!(v, ~["leopard", "tiger", "lionX"]);
     /// ```
-    fn rsplitn<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitNIterator<'a, Sep>;
+    fn rsplitn<Sep: CharEq>(&self, sep: Sep, count: uint) -> CharSplitsN<'a, Sep>;
 
     /// An iterator over the start and end indices of the disjoint
     /// matches of `sep` within `self`.
@@ -1472,7 +1472,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[(uint, uint)] = "ababa".match_indices("aba").collect();
     /// assert_eq!(v, ~[(0, 3)]); // only the first `aba`
     /// ```
-    fn match_indices(&self, sep: &'a str) -> MatchesIndexIterator<'a>;
+    fn match_indices(&self, sep: &'a str) -> MatchIndices<'a>;
 
     /// An iterator over the substrings of `self` separated by `sep`.
     ///
@@ -1485,7 +1485,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = "1abcabc2".split_str("abc").collect();
     /// assert_eq!(v, ~["1", "", "2"]);
     /// ```
-    fn split_str(&self, &'a str) -> StrSplitIterator<'a>;
+    fn split_str(&self, &'a str) -> StrSplits<'a>;
 
     /// An iterator over the lines of a string (subsequences separated
     /// by `\n`). This does not include the empty string after a
@@ -1498,7 +1498,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = four_lines.lines().collect();
     /// assert_eq!(v, ~["foo", "bar", "", "baz"]);
     /// ```
-    fn lines(&self) -> CharSplitIterator<'a, char>;
+    fn lines(&self) -> CharSplits<'a, char>;
 
     /// An iterator over the lines of a string, separated by either
     /// `\n` or `\r\n`. As with `.lines()`, this does not include an
@@ -1511,7 +1511,7 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = four_lines.lines_any().collect();
     /// assert_eq!(v, ~["foo", "bar", "", "baz"]);
     /// ```
-    fn lines_any(&self) -> AnyLineIterator<'a>;
+    fn lines_any(&self) -> AnyLines<'a>;
 
     /// An iterator over the words of a string (subsequences separated
     /// by any sequence of whitespace). Sequences of whitespace are
@@ -1524,15 +1524,15 @@ pub trait StrSlice<'a> {
     /// let v: ~[&str] = some_words.words().collect();
     /// assert_eq!(v, ~["Mary", "had", "a", "little", "lamb"]);
     /// ```
-    fn words(&self) -> WordIterator<'a>;
+    fn words(&self) -> Words<'a>;
 
     /// An Iterator over the string in Unicode Normalization Form D
     /// (canonical decomposition).
-    fn nfd_chars(&self) -> NormalizationIterator<'a>;
+    fn nfd_chars(&self) -> Normalizations<'a>;
 
     /// An Iterator over the string in Unicode Normalization Form KD
     /// (compatibility decomposition).
-    fn nfkd_chars(&self) -> NormalizationIterator<'a>;
+    fn nfkd_chars(&self) -> Normalizations<'a>;
 
     /// Returns true if the string contains only whitespace.
     ///
@@ -2008,38 +2008,38 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn chars(&self) -> CharIterator<'a> {
-        CharIterator{string: *self}
+    fn chars(&self) -> Chars<'a> {
+        Chars{string: *self}
     }
 
     #[inline]
-    fn chars_rev(&self) -> CharRevIterator<'a> {
+    fn chars_rev(&self) -> RevChars<'a> {
         self.chars().invert()
     }
 
     #[inline]
-    fn bytes(&self) -> ByteIterator<'a> {
+    fn bytes(&self) -> Bytes<'a> {
         self.as_bytes().iter().map(|&b| b)
     }
 
     #[inline]
-    fn bytes_rev(&self) -> ByteRevIterator<'a> {
+    fn bytes_rev(&self) -> RevBytes<'a> {
         self.bytes().invert()
     }
 
     #[inline]
-    fn char_indices(&self) -> CharOffsetIterator<'a> {
-        CharOffsetIterator{string: *self, iter: self.chars()}
+    fn char_indices(&self) -> CharOffsets<'a> {
+        CharOffsets{string: *self, iter: self.chars()}
     }
 
     #[inline]
-    fn char_indices_rev(&self) -> CharOffsetRevIterator<'a> {
+    fn char_indices_rev(&self) -> RevCharOffsets<'a> {
         self.char_indices().invert()
     }
 
     #[inline]
-    fn split<Sep: CharEq>(&self, sep: Sep) -> CharSplitIterator<'a, Sep> {
-        CharSplitIterator {
+    fn split<Sep: CharEq>(&self, sep: Sep) -> CharSplits<'a, Sep> {
+        CharSplits {
             string: *self,
             only_ascii: sep.only_ascii(),
             sep: sep,
@@ -2050,8 +2050,8 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn splitn<Sep: CharEq>(&self, sep: Sep, count: uint)
-        -> CharSplitNIterator<'a, Sep> {
-        CharSplitNIterator {
+        -> CharSplitsN<'a, Sep> {
+        CharSplitsN {
             iter: self.split(sep),
             count: count,
             invert: false,
@@ -2060,22 +2060,22 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn split_terminator<Sep: CharEq>(&self, sep: Sep)
-        -> CharSplitIterator<'a, Sep> {
-        CharSplitIterator {
+        -> CharSplits<'a, Sep> {
+        CharSplits {
             allow_trailing_empty: false,
             ..self.split(sep)
         }
     }
 
     #[inline]
-    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> CharRSplitIterator<'a, Sep> {
+    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> RevCharSplits<'a, Sep> {
         self.split(sep).invert()
     }
 
     #[inline]
     fn rsplitn<Sep: CharEq>(&self, sep: Sep, count: uint)
-        -> CharSplitNIterator<'a, Sep> {
-        CharSplitNIterator {
+        -> CharSplitsN<'a, Sep> {
+        CharSplitsN {
             iter: self.split(sep),
             count: count,
             invert: true,
@@ -2083,9 +2083,9 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn match_indices(&self, sep: &'a str) -> MatchesIndexIterator<'a> {
+    fn match_indices(&self, sep: &'a str) -> MatchIndices<'a> {
         assert!(!sep.is_empty())
-        MatchesIndexIterator {
+        MatchIndices {
             haystack: *self,
             needle: sep,
             position: 0
@@ -2093,8 +2093,8 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn split_str(&self, sep: &'a str) -> StrSplitIterator<'a> {
-        StrSplitIterator {
+    fn split_str(&self, sep: &'a str) -> StrSplits<'a> {
+        StrSplits {
             it: self.match_indices(sep),
             last_end: 0,
             finished: false
@@ -2102,11 +2102,11 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn lines(&self) -> CharSplitIterator<'a, char> {
+    fn lines(&self) -> CharSplits<'a, char> {
         self.split_terminator('\n')
     }
 
-    fn lines_any(&self) -> AnyLineIterator<'a> {
+    fn lines_any(&self) -> AnyLines<'a> {
         self.lines().map(|line| {
             let l = line.len();
             if l > 0 && line[l - 1] == '\r' as u8 { line.slice(0, l - 1) }
@@ -2115,13 +2115,13 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn words(&self) -> WordIterator<'a> {
+    fn words(&self) -> Words<'a> {
         self.split(char::is_whitespace).filter(|s| !s.is_empty())
     }
 
     #[inline]
-    fn nfd_chars(&self) -> NormalizationIterator<'a> {
-        NormalizationIterator {
+    fn nfd_chars(&self) -> Normalizations<'a> {
+        Normalizations {
             iter: self.chars(),
             buffer: ~[],
             sorted: false,
@@ -2130,8 +2130,8 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn nfkd_chars(&self) -> NormalizationIterator<'a> {
-        NormalizationIterator {
+    fn nfkd_chars(&self) -> Normalizations<'a> {
+        Normalizations {
             iter: self.chars(),
             buffer: ~[],
             sorted: false,

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -115,8 +115,8 @@ impl<T> TrieMap<T> {
     }
 
     /// Get an iterator over the key-value pairs in the map
-    pub fn iter<'a>(&'a self) -> TrieMapIterator<'a, T> {
-        let mut iter = unsafe {TrieMapIterator::new()};
+    pub fn iter<'a>(&'a self) -> Entries<'a, T> {
+        let mut iter = unsafe {Entries::new()};
         iter.stack[0] = self.root.children.iter();
         iter.length = 1;
         iter.remaining_min = self.length;
@@ -127,8 +127,8 @@ impl<T> TrieMap<T> {
 
     /// Get an iterator over the key-value pairs in the map, with the
     /// ability to mutate the values.
-    pub fn mut_iter<'a>(&'a mut self) -> TrieMapMutIterator<'a, T> {
-        let mut iter = unsafe {TrieMapMutIterator::new()};
+    pub fn mut_iter<'a>(&'a mut self) -> MutEntries<'a, T> {
+        let mut iter = unsafe {MutEntries::new()};
         iter.stack[0] = self.root.children.mut_iter();
         iter.length = 1;
         iter.remaining_min = self.length;
@@ -221,8 +221,8 @@ macro_rules! bound {
 impl<T> TrieMap<T> {
     // If `upper` is true then returns upper_bound else returns lower_bound.
     #[inline]
-    fn bound<'a>(&'a self, key: uint, upper: bool) -> TrieMapIterator<'a, T> {
-        bound!(TrieMapIterator, self = self,
+    fn bound<'a>(&'a self, key: uint, upper: bool) -> Entries<'a, T> {
+        bound!(Entries, self = self,
                key = key, is_upper = upper,
                slice_from = slice_from, iter = iter,
                mutability = )
@@ -230,19 +230,19 @@ impl<T> TrieMap<T> {
 
     /// Get an iterator pointing to the first key-value pair whose key is not less than `key`.
     /// If all keys in the map are less than `key` an empty iterator is returned.
-    pub fn lower_bound<'a>(&'a self, key: uint) -> TrieMapIterator<'a, T> {
+    pub fn lower_bound<'a>(&'a self, key: uint) -> Entries<'a, T> {
         self.bound(key, false)
     }
 
     /// Get an iterator pointing to the first key-value pair whose key is greater than `key`.
     /// If all keys in the map are not greater than `key` an empty iterator is returned.
-    pub fn upper_bound<'a>(&'a self, key: uint) -> TrieMapIterator<'a, T> {
+    pub fn upper_bound<'a>(&'a self, key: uint) -> Entries<'a, T> {
         self.bound(key, true)
     }
     // If `upper` is true then returns upper_bound else returns lower_bound.
     #[inline]
-    fn mut_bound<'a>(&'a mut self, key: uint, upper: bool) -> TrieMapMutIterator<'a, T> {
-        bound!(TrieMapMutIterator, self = self,
+    fn mut_bound<'a>(&'a mut self, key: uint, upper: bool) -> MutEntries<'a, T> {
+        bound!(MutEntries, self = self,
                key = key, is_upper = upper,
                slice_from = mut_slice_from, iter = mut_iter,
                mutability = mut)
@@ -250,13 +250,13 @@ impl<T> TrieMap<T> {
 
     /// Get an iterator pointing to the first key-value pair whose key is not less than `key`.
     /// If all keys in the map are less than `key` an empty iterator is returned.
-    pub fn mut_lower_bound<'a>(&'a mut self, key: uint) -> TrieMapMutIterator<'a, T> {
+    pub fn mut_lower_bound<'a>(&'a mut self, key: uint) -> MutEntries<'a, T> {
         self.mut_bound(key, false)
     }
 
     /// Get an iterator pointing to the first key-value pair whose key is greater than `key`.
     /// If all keys in the map are not greater than `key` an empty iterator is returned.
-    pub fn mut_upper_bound<'a>(&'a mut self, key: uint) -> TrieMapMutIterator<'a, T> {
+    pub fn mut_upper_bound<'a>(&'a mut self, key: uint) -> MutEntries<'a, T> {
         self.mut_bound(key, true)
     }
 }
@@ -329,20 +329,20 @@ impl TrieSet {
 
     /// Get an iterator over the values in the set
     #[inline]
-    pub fn iter<'a>(&'a self) -> TrieSetIterator<'a> {
-        TrieSetIterator{iter: self.map.iter()}
+    pub fn iter<'a>(&'a self) -> SetItems<'a> {
+        SetItems{iter: self.map.iter()}
     }
 
     /// Get an iterator pointing to the first value that is not less than `val`.
     /// If all values in the set are less than `val` an empty iterator is returned.
-    pub fn lower_bound<'a>(&'a self, val: uint) -> TrieSetIterator<'a> {
-        TrieSetIterator{iter: self.map.lower_bound(val)}
+    pub fn lower_bound<'a>(&'a self, val: uint) -> SetItems<'a> {
+        SetItems{iter: self.map.lower_bound(val)}
     }
 
     /// Get an iterator pointing to the first value that key is greater than `val`.
     /// If all values in the set are not greater than `val` an empty iterator is returned.
-    pub fn upper_bound<'a>(&'a self, val: uint) -> TrieSetIterator<'a> {
-        TrieSetIterator{iter: self.map.upper_bound(val)}
+    pub fn upper_bound<'a>(&'a self, val: uint) -> SetItems<'a> {
+        SetItems{iter: self.map.upper_bound(val)}
     }
 }
 
@@ -474,8 +474,8 @@ fn remove<T>(count: &mut uint, child: &mut Child<T>, key: uint,
 }
 
 /// Forward iterator over a map
-pub struct TrieMapIterator<'a, T> {
-    priv stack: [vec::VecIterator<'a, Child<T>>, .. NUM_CHUNKS],
+pub struct Entries<'a, T> {
+    priv stack: [vec::Items<'a, Child<T>>, .. NUM_CHUNKS],
     priv length: uint,
     priv remaining_min: uint,
     priv remaining_max: uint
@@ -483,8 +483,8 @@ pub struct TrieMapIterator<'a, T> {
 
 /// Forward iterator over the key-value pairs of a map, with the
 /// values being mutable.
-pub struct TrieMapMutIterator<'a, T> {
-    priv stack: [vec::VecMutIterator<'a, Child<T>>, .. NUM_CHUNKS],
+pub struct MutEntries<'a, T> {
+    priv stack: [vec::MutItems<'a, Child<T>>, .. NUM_CHUNKS],
     priv length: uint,
     priv remaining_min: uint,
     priv remaining_max: uint
@@ -601,15 +601,15 @@ macro_rules! iterator_impl {
     }
 }
 
-iterator_impl! { TrieMapIterator, iter = iter, mutability = }
-iterator_impl! { TrieMapMutIterator, iter = mut_iter, mutability = mut }
+iterator_impl! { Entries, iter = iter, mutability = }
+iterator_impl! { MutEntries, iter = mut_iter, mutability = mut }
 
 /// Forward iterator over a set
-pub struct TrieSetIterator<'a> {
-    priv iter: TrieMapIterator<'a, ()>
+pub struct SetItems<'a> {
+    priv iter: Entries<'a, ()>
 }
 
-impl<'a> Iterator<uint> for TrieSetIterator<'a> {
+impl<'a> Iterator<uint> for SetItems<'a> {
     fn next(&mut self) -> Option<uint> {
         self.iter.next().map(|(key, _)| key)
     }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -25,7 +25,7 @@ This is a big module, but for a high-level overview:
 
 ## Structs
 
-Several structs that are useful for vectors, such as `VecIterator`, which
+Several structs that are useful for vectors, such as `Items`, which
 represents iteration over a vector.
 
 ## Traits
@@ -230,14 +230,14 @@ pub fn mut_ref_slice<'a, A>(s: &'a mut A) -> &'a mut [A] {
 
 /// An iterator over the slices of a vector separated by elements that
 /// match a predicate function.
-pub struct SplitIterator<'a, T> {
+pub struct Splits<'a, T> {
     priv v: &'a [T],
     priv n: uint,
     priv pred: 'a |t: &T| -> bool,
     priv finished: bool
 }
 
-impl<'a, T> Iterator<&'a [T]> for SplitIterator<'a, T> {
+impl<'a, T> Iterator<&'a [T]> for Splits<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.finished { return None; }
@@ -279,14 +279,14 @@ impl<'a, T> Iterator<&'a [T]> for SplitIterator<'a, T> {
 
 /// An iterator over the slices of a vector separated by elements that
 /// match a predicate function, from back to front.
-pub struct RSplitIterator<'a, T> {
+pub struct RevSplits<'a, T> {
     priv v: &'a [T],
     priv n: uint,
     priv pred: 'a |t: &T| -> bool,
     priv finished: bool
 }
 
-impl<'a, T> Iterator<&'a [T]> for RSplitIterator<'a, T> {
+impl<'a, T> Iterator<&'a [T]> for RevSplits<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.finished { return None; }
@@ -514,12 +514,12 @@ impl<T: Clone> Iterator<~[T]> for Permutations<T> {
 /// An iterator over the (overlapping) slices of length `size` within
 /// a vector.
 #[deriving(Clone)]
-pub struct WindowIter<'a, T> {
+pub struct Windows<'a, T> {
     priv v: &'a [T],
     priv size: uint
 }
 
-impl<'a, T> Iterator<&'a [T]> for WindowIter<'a, T> {
+impl<'a, T> Iterator<&'a [T]> for Windows<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.size > self.v.len() {
@@ -548,12 +548,12 @@ impl<'a, T> Iterator<&'a [T]> for WindowIter<'a, T> {
 /// When the vector len is not evenly divided by the chunk size,
 /// the last slice of the iteration will be the remainder.
 #[deriving(Clone)]
-pub struct ChunkIter<'a, T> {
+pub struct Chunks<'a, T> {
     priv v: &'a [T],
     priv size: uint
 }
 
-impl<'a, T> Iterator<&'a [T]> for ChunkIter<'a, T> {
+impl<'a, T> Iterator<&'a [T]> for Chunks<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a [T]> {
         if self.v.len() == 0 {
@@ -579,7 +579,7 @@ impl<'a, T> Iterator<&'a [T]> for ChunkIter<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a [T]> for ChunkIter<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a [T]> for Chunks<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.v.len() == 0 {
@@ -595,7 +595,7 @@ impl<'a, T> DoubleEndedIterator<&'a [T]> for ChunkIter<'a, T> {
     }
 }
 
-impl<'a, T> RandomAccessIterator<&'a [T]> for ChunkIter<'a, T> {
+impl<'a, T> RandomAccessIterator<&'a [T]> for Chunks<'a, T> {
     #[inline]
     fn indexable(&self) -> uint {
         self.v.len()/self.size + if self.v.len() % self.size != 0 { 1 } else { 0 }
@@ -866,29 +866,29 @@ pub trait ImmutableVector<'a, T> {
      */
     fn slice_to(&self, end: uint) -> &'a [T];
     /// Returns an iterator over the vector
-    fn iter(self) -> VecIterator<'a, T>;
+    fn iter(self) -> Items<'a, T>;
     /// Returns a reversed iterator over a vector
-    fn rev_iter(self) -> RevIterator<'a, T>;
+    fn rev_iter(self) -> RevItems<'a, T>;
     /// Returns an iterator over the subslices of the vector which are
     /// separated by elements that match `pred`.  The matched element
     /// is not contained in the subslices.
-    fn split(self, pred: 'a |&T| -> bool) -> SplitIterator<'a, T>;
+    fn split(self, pred: 'a |&T| -> bool) -> Splits<'a, T>;
     /// Returns an iterator over the subslices of the vector which are
     /// separated by elements that match `pred`, limited to splitting
     /// at most `n` times.  The matched element is not contained in
     /// the subslices.
-    fn splitn(self, n: uint, pred: 'a |&T| -> bool) -> SplitIterator<'a, T>;
+    fn splitn(self, n: uint, pred: 'a |&T| -> bool) -> Splits<'a, T>;
     /// Returns an iterator over the subslices of the vector which are
     /// separated by elements that match `pred`. This starts at the
     /// end of the vector and works backwards.  The matched element is
     /// not contained in the subslices.
-    fn rsplit(self, pred: 'a |&T| -> bool) -> RSplitIterator<'a, T>;
+    fn rsplit(self, pred: 'a |&T| -> bool) -> RevSplits<'a, T>;
     /// Returns an iterator over the subslices of the vector which are
     /// separated by elements that match `pred` limited to splitting
     /// at most `n` times. This starts at the end of the vector and
     /// works backwards.  The matched element is not contained in the
     /// subslices.
-    fn rsplitn(self,  n: uint, pred: 'a |&T| -> bool) -> RSplitIterator<'a, T>;
+    fn rsplitn(self,  n: uint, pred: 'a |&T| -> bool) -> RevSplits<'a, T>;
 
     /**
      * Returns an iterator over all contiguous windows of length
@@ -912,7 +912,7 @@ pub trait ImmutableVector<'a, T> {
      * ```
      *
      */
-    fn windows(self, size: uint) -> WindowIter<'a, T>;
+    fn windows(self, size: uint) -> Windows<'a, T>;
     /**
      *
      * Returns an iterator over `size` elements of the vector at a
@@ -937,7 +937,7 @@ pub trait ImmutableVector<'a, T> {
      * ```
      *
      */
-    fn chunks(self, size: uint) -> ChunkIter<'a, T>;
+    fn chunks(self, size: uint) -> Chunks<'a, T>;
 
     /// Returns the element of a vector at the given index, or `None` if the
     /// index is out of bounds
@@ -1055,15 +1055,15 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn iter(self) -> VecIterator<'a, T> {
+    fn iter(self) -> Items<'a, T> {
         unsafe {
             let p = self.as_ptr();
             if mem::size_of::<T>() == 0 {
-                VecIterator{ptr: p,
+                Items{ptr: p,
                             end: (p as uint + self.len()) as *T,
                             lifetime: None}
             } else {
-                VecIterator{ptr: p,
+                Items{ptr: p,
                             end: p.offset(self.len() as int),
                             lifetime: None}
             }
@@ -1071,18 +1071,18 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn rev_iter(self) -> RevIterator<'a, T> {
+    fn rev_iter(self) -> RevItems<'a, T> {
         self.iter().invert()
     }
 
     #[inline]
-    fn split(self, pred: 'a |&T| -> bool) -> SplitIterator<'a, T> {
+    fn split(self, pred: 'a |&T| -> bool) -> Splits<'a, T> {
         self.splitn(uint::max_value, pred)
     }
 
     #[inline]
-    fn splitn(self, n: uint, pred: 'a |&T| -> bool) -> SplitIterator<'a, T> {
-        SplitIterator {
+    fn splitn(self, n: uint, pred: 'a |&T| -> bool) -> Splits<'a, T> {
+        Splits {
             v: self,
             n: n,
             pred: pred,
@@ -1091,13 +1091,13 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn rsplit(self, pred: 'a |&T| -> bool) -> RSplitIterator<'a, T> {
+    fn rsplit(self, pred: 'a |&T| -> bool) -> RevSplits<'a, T> {
         self.rsplitn(uint::max_value, pred)
     }
 
     #[inline]
-    fn rsplitn(self, n: uint, pred: 'a |&T| -> bool) -> RSplitIterator<'a, T> {
-        RSplitIterator {
+    fn rsplitn(self, n: uint, pred: 'a |&T| -> bool) -> RevSplits<'a, T> {
+        RevSplits {
             v: self,
             n: n,
             pred: pred,
@@ -1106,15 +1106,15 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn windows(self, size: uint) -> WindowIter<'a, T> {
+    fn windows(self, size: uint) -> Windows<'a, T> {
         assert!(size != 0);
-        WindowIter { v: self, size: size }
+        Windows { v: self, size: size }
     }
 
     #[inline]
-    fn chunks(self, size: uint) -> ChunkIter<'a, T> {
+    fn chunks(self, size: uint) -> Chunks<'a, T> {
         assert!(size != 0);
-        ChunkIter { v: self, size: size }
+        Chunks { v: self, size: size }
     }
 
     #[inline]
@@ -1331,10 +1331,10 @@ pub trait OwnedVector<T> {
     ///   println!("{}", s);
     /// }
     /// ```
-    fn move_iter(self) -> MoveIterator<T>;
+    fn move_iter(self) -> MoveItems<T>;
     /// Creates a consuming iterator that moves out of the vector in
     /// reverse order.
-    fn move_rev_iter(self) -> MoveRevIterator<T>;
+    fn move_rev_iter(self) -> RevMoveItems<T>;
 
     /**
      * Reserves capacity for exactly `n` elements in the given vector.
@@ -1479,16 +1479,16 @@ pub trait OwnedVector<T> {
 
 impl<T> OwnedVector<T> for ~[T] {
     #[inline]
-    fn move_iter(self) -> MoveIterator<T> {
+    fn move_iter(self) -> MoveItems<T> {
         unsafe {
             let iter = cast::transmute(self.iter());
             let ptr = cast::transmute(self);
-            MoveIterator { allocation: ptr, iter: iter }
+            MoveItems { allocation: ptr, iter: iter }
         }
     }
 
     #[inline]
-    fn move_rev_iter(self) -> MoveRevIterator<T> {
+    fn move_rev_iter(self) -> RevMoveItems<T> {
         self.move_iter().invert()
     }
 
@@ -2065,18 +2065,18 @@ pub trait MutableVector<'a, T> {
     fn mut_slice_to(self, end: uint) -> &'a mut [T];
 
     /// Returns an iterator that allows modifying each value
-    fn mut_iter(self) -> VecMutIterator<'a, T>;
+    fn mut_iter(self) -> MutItems<'a, T>;
 
     /// Returns a mutable pointer to the last item in the vector.
     fn mut_last(self) -> &'a mut T;
 
     /// Returns a reversed iterator that allows modifying each value
-    fn mut_rev_iter(self) -> MutRevIterator<'a, T>;
+    fn mut_rev_iter(self) -> RevMutItems<'a, T>;
 
     /// Returns an iterator over the mutable subslices of the vector
     /// which are separated by elements that match `pred`.  The
     /// matched element is not contained in the subslices.
-    fn mut_split(self, pred: 'a |&T| -> bool) -> MutSplitIterator<'a, T>;
+    fn mut_split(self, pred: 'a |&T| -> bool) -> MutSplits<'a, T>;
 
     /**
      * Returns an iterator over `size` elements of the vector at a time.
@@ -2088,7 +2088,7 @@ pub trait MutableVector<'a, T> {
      *
      * Fails if `size` is 0.
      */
-    fn mut_chunks(self, chunk_size: uint) -> MutChunkIter<'a, T>;
+    fn mut_chunks(self, chunk_size: uint) -> MutChunks<'a, T>;
 
     /**
      * Returns a mutable reference to the first element in this slice
@@ -2317,15 +2317,15 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
     }
 
     #[inline]
-    fn mut_iter(self) -> VecMutIterator<'a, T> {
+    fn mut_iter(self) -> MutItems<'a, T> {
         unsafe {
             let p = self.as_mut_ptr();
             if mem::size_of::<T>() == 0 {
-                VecMutIterator{ptr: p,
+                MutItems{ptr: p,
                                end: (p as uint + self.len()) as *mut T,
                                lifetime: None}
             } else {
-                VecMutIterator{ptr: p,
+                MutItems{ptr: p,
                                end: p.offset(self.len() as int),
                                lifetime: None}
             }
@@ -2340,19 +2340,19 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
     }
 
     #[inline]
-    fn mut_rev_iter(self) -> MutRevIterator<'a, T> {
+    fn mut_rev_iter(self) -> RevMutItems<'a, T> {
         self.mut_iter().invert()
     }
 
     #[inline]
-    fn mut_split(self, pred: 'a |&T| -> bool) -> MutSplitIterator<'a, T> {
-        MutSplitIterator { v: self, pred: pred, finished: false }
+    fn mut_split(self, pred: 'a |&T| -> bool) -> MutSplits<'a, T> {
+        MutSplits { v: self, pred: pred, finished: false }
     }
 
     #[inline]
-    fn mut_chunks(self, chunk_size: uint) -> MutChunkIter<'a, T> {
+    fn mut_chunks(self, chunk_size: uint) -> MutChunks<'a, T> {
         assert!(chunk_size > 0);
-        MutChunkIter { v: self, chunk_size: chunk_size }
+        MutChunks { v: self, chunk_size: chunk_size }
     }
 
     fn mut_shift_ref(&mut self) -> &'a mut T {
@@ -2735,7 +2735,7 @@ macro_rules! iterator {
     }
 }
 
-impl<'a, T> RandomAccessIterator<&'a T> for VecIterator<'a, T> {
+impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
     #[inline]
     fn indexable(&self) -> uint {
         let (exact, _) = self.size_hint();
@@ -2754,28 +2754,28 @@ impl<'a, T> RandomAccessIterator<&'a T> for VecIterator<'a, T> {
     }
 }
 
-iterator!{struct VecIterator -> *T, &'a T}
-pub type RevIterator<'a, T> = Invert<VecIterator<'a, T>>;
+iterator!{struct Items -> *T, &'a T}
+pub type RevItems<'a, T> = Invert<Items<'a, T>>;
 
-impl<'a, T> ExactSize<&'a T> for VecIterator<'a, T> {}
-impl<'a, T> ExactSize<&'a mut T> for VecMutIterator<'a, T> {}
+impl<'a, T> ExactSize<&'a T> for Items<'a, T> {}
+impl<'a, T> ExactSize<&'a mut T> for MutItems<'a, T> {}
 
-impl<'a, T> Clone for VecIterator<'a, T> {
-    fn clone(&self) -> VecIterator<'a, T> { *self }
+impl<'a, T> Clone for Items<'a, T> {
+    fn clone(&self) -> Items<'a, T> { *self }
 }
 
-iterator!{struct VecMutIterator -> *mut T, &'a mut T}
-pub type MutRevIterator<'a, T> = Invert<VecMutIterator<'a, T>>;
+iterator!{struct MutItems -> *mut T, &'a mut T}
+pub type RevMutItems<'a, T> = Invert<MutItems<'a, T>>;
 
 /// An iterator over the subslices of the vector which are separated
 /// by elements that match `pred`.
-pub struct MutSplitIterator<'a, T> {
+pub struct MutSplits<'a, T> {
     priv v: &'a mut [T],
     priv pred: 'a |t: &T| -> bool,
     priv finished: bool
 }
 
-impl<'a, T> Iterator<&'a mut [T]> for MutSplitIterator<'a, T> {
+impl<'a, T> Iterator<&'a mut [T]> for MutSplits<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.finished { return None; }
@@ -2810,7 +2810,7 @@ impl<'a, T> Iterator<&'a mut [T]> for MutSplitIterator<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutSplitIterator<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutSplits<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.finished { return None; }
@@ -2834,12 +2834,12 @@ impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutSplitIterator<'a, T> {
 /// An iterator over a vector in (non-overlapping) mutable chunks (`size`  elements at a time). When
 /// the vector len is not evenly divided by the chunk size, the last slice of the iteration will be
 /// the remainder.
-pub struct MutChunkIter<'a, T> {
+pub struct MutChunks<'a, T> {
     priv v: &'a mut [T],
     priv chunk_size: uint
 }
 
-impl<'a, T> Iterator<&'a mut [T]> for MutChunkIter<'a, T> {
+impl<'a, T> Iterator<&'a mut [T]> for MutChunks<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a mut [T]> {
         if self.v.len() == 0 {
@@ -2865,7 +2865,7 @@ impl<'a, T> Iterator<&'a mut [T]> for MutChunkIter<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutChunkIter<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutChunks<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut [T]> {
         if self.v.len() == 0 {
@@ -2883,12 +2883,12 @@ impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutChunkIter<'a, T> {
 }
 
 /// An iterator that moves out of a vector.
-pub struct MoveIterator<T> {
+pub struct MoveItems<T> {
     priv allocation: *mut u8, // the block of memory allocated for the vector
-    priv iter: VecIterator<'static, T>
+    priv iter: Items<'static, T>
 }
 
-impl<T> Iterator<T> for MoveIterator<T> {
+impl<T> Iterator<T> for MoveItems<T> {
     #[inline]
     fn next(&mut self) -> Option<T> {
         unsafe {
@@ -2902,7 +2902,7 @@ impl<T> Iterator<T> for MoveIterator<T> {
     }
 }
 
-impl<T> DoubleEndedIterator<T> for MoveIterator<T> {
+impl<T> DoubleEndedIterator<T> for MoveItems<T> {
     #[inline]
     fn next_back(&mut self) -> Option<T> {
         unsafe {
@@ -2912,7 +2912,7 @@ impl<T> DoubleEndedIterator<T> for MoveIterator<T> {
 }
 
 #[unsafe_destructor]
-impl<T> Drop for MoveIterator<T> {
+impl<T> Drop for MoveItems<T> {
     fn drop(&mut self) {
         // destroy the remaining elements
         for _x in *self {}
@@ -2923,7 +2923,7 @@ impl<T> Drop for MoveIterator<T> {
 }
 
 /// An iterator that moves out of a vector in reverse order.
-pub type MoveRevIterator<T> = Invert<MoveIterator<T>>;
+pub type RevMoveItems<T> = Invert<MoveItems<T>>;
 
 impl<A> FromIterator<A> for ~[A] {
     fn from_iterator<T: Iterator<A>>(iterator: &mut T) -> ~[A] {

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -15,7 +15,7 @@
  * other useful things like `push()` and `len()`.
  */
 
-use std::vec::{VecIterator};
+use std::vec;
 
 #[deriving(Clone, Encodable, Decodable, IterBytes)]
 pub enum OptVec<T> {
@@ -112,10 +112,10 @@ impl<T> OptVec<T> {
     }
 
     #[inline]
-    pub fn iter<'r>(&'r self) -> OptVecIterator<'r, T> {
+    pub fn iter<'r>(&'r self) -> Items<'r, T> {
         match *self {
-            Empty => OptVecIterator{iter: None},
-            Vec(ref v) => OptVecIterator{iter: Some(v.iter())}
+            Empty => Items{iter: None},
+            Vec(ref v) => Items{iter: Some(v.iter())}
         }
     }
 
@@ -173,11 +173,11 @@ impl<T> Default for OptVec<T> {
     fn default() -> OptVec<T> { Empty }
 }
 
-pub struct OptVecIterator<'a, T> {
-    priv iter: Option<VecIterator<'a, T>>
+pub struct Items<'a, T> {
+    priv iter: Option<vec::Items<'a, T>>
 }
 
-impl<'a, T> Iterator<&'a T> for OptVecIterator<'a, T> {
+impl<'a, T> Iterator<&'a T> for Items<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a T> {
         match self.iter {
@@ -195,7 +195,7 @@ impl<'a, T> Iterator<&'a T> for OptVecIterator<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a T> for OptVecIterator<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a T> {
         match self.iter {

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use std::vec::MoveIterator;
+use std::vec;
 use std::util;
 
 /// A vector type optimized for cases where the size is almost always 0 or 1
@@ -80,7 +80,7 @@ impl<T> SmallVector<T> {
         }
     }
 
-    pub fn move_iter(self) -> SmallVectorMoveIterator<T> {
+    pub fn move_iter(self) -> MoveItems<T> {
         match self {
             Zero => ZeroIterator,
             One(v) => OneIterator(v),
@@ -89,13 +89,13 @@ impl<T> SmallVector<T> {
     }
 }
 
-pub enum SmallVectorMoveIterator<T> {
+pub enum MoveItems<T> {
     priv ZeroIterator,
     priv OneIterator(T),
-    priv ManyIterator(MoveIterator<T>),
+    priv ManyIterator(vec::MoveItems<T>),
 }
 
-impl<T> Iterator<T> for SmallVectorMoveIterator<T> {
+impl<T> Iterator<T> for MoveItems<T> {
     fn next(&mut self) -> Option<T> {
         match *self {
             ZeroIterator => None,


### PR DESCRIPTION
Most Iterators renamed to make their naming more consistent. Most significantly, the Iterator and Iter suffixes have been completely removed.
