### PR TITLE
rustc: Optimize reading metadata by 4x

### DIFF
--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use back::archive::Archive;
+use back::archive::ArchiveRO;
 use back::link;
 use driver::session;
 use lib::llvm::{ModuleRef, TargetMachineRef, llvm, True, False};
@@ -43,10 +43,11 @@ pub fn run(sess: session::Session, llmod: ModuleRef,
             }
         };
 
-        let archive = Archive::open(sess, path);
+        let archive = ArchiveRO::open(&path).expect("wanted an rlib");
         debug!("reading {}", name);
         let bc = time(sess.time_passes(), format!("read {}.bc", name), (), |_|
                       archive.read(format!("{}.bc", name)));
+        let bc = bc.expect("missing bytecode in archive!");
         let ptr = bc.as_ptr();
         debug!("linking {}", name);
         time(sess.time_passes(), format!("ll link {}", name), (), |()| unsafe {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1100,7 +1100,6 @@ pub fn early_error(emitter: @diagnostic::Emitter, msg: &str) -> ! {
 
 pub fn list_metadata(sess: Session, path: &Path, out: @mut io::Writer) {
     metadata::loader::list_file_metadata(
-        sess,
         token::get_ident_interner(),
         session::sess_os_to_meta_os(sess.targ_cfg.os), path, out);
 }

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -257,6 +257,8 @@ pub enum Pass_opaque {}
 pub type PassRef = *Pass_opaque;
 pub enum TargetMachine_opaque {}
 pub type TargetMachineRef = *TargetMachine_opaque;
+pub enum Archive_opaque {}
+pub type ArchiveRef = *Archive_opaque;
 
 pub mod debuginfo {
     use super::{ValueRef};
@@ -300,7 +302,7 @@ pub mod llvm {
     use super::{Bool, BuilderRef, ContextRef, MemoryBufferRef, ModuleRef};
     use super::{ObjectFileRef, Opcode, PassManagerRef, PassManagerBuilderRef};
     use super::{SectionIteratorRef, TargetDataRef, TypeKind, TypeRef, UseRef};
-    use super::{ValueRef, TargetMachineRef, FileType};
+    use super::{ValueRef, TargetMachineRef, FileType, ArchiveRef};
     use super::{CodeGenModel, RelocMode, CodeGenOptLevel};
     use super::debuginfo::*;
     use std::libc::{c_char, c_int, c_longlong, c_ushort, c_uint, c_ulonglong,
@@ -1748,6 +1750,11 @@ pub mod llvm {
                                           syms: **c_char,
                                           len: size_t);
         pub fn LLVMRustMarkAllFunctionsNounwind(M: ModuleRef);
+
+        pub fn LLVMRustOpenArchive(path: *c_char) -> ArchiveRef;
+        pub fn LLVMRustArchiveReadSection(AR: ArchiveRef, name: *c_char,
+                                          out_len: *mut size_t) -> *c_char;
+        pub fn LLVMRustDestroyArchive(AR: ArchiveRef);
     }
 }
 

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -15,6 +15,7 @@
 
 use metadata::cstore;
 use metadata::decoder;
+use metadata::loader;
 
 use std::hashmap::HashMap;
 use extra;
@@ -29,6 +30,7 @@ pub type cnum_map = @mut HashMap<ast::CrateNum, ast::CrateNum>;
 
 pub enum MetadataBlob {
     MetadataVec(~[u8]),
+    MetadataArchive(loader::ArchiveMetadata),
 }
 
 pub struct crate_metadata {
@@ -216,6 +218,7 @@ impl MetadataBlob {
     pub fn as_slice<'a>(&'a self) -> &'a [u8] {
         match *self {
             MetadataVec(ref vec) => vec.as_slice(),
+            MetadataArchive(ref ar) => ar.as_slice(),
         }
     }
 }


### PR DESCRIPTION
We were previously reading metadata via `ar p`, but as learned from rustdoc
awhile back, spawning a process to do something is pretty slow. Turns out LLVM
has an Archive class to read archives, but it cannot write archives.

This commits adds bindings to the read-only version of the LLVM archive class
(with a new type that only has a read() method), and then it uses this class
when reading the metadata out of rlibs. When you put this in tandem of not
compressing the metadata, reading the metadata is 4x faster than it used to be
The timings I got for reading metadata from the respective libraries was:

```
libstd-04ff901e-0.9-pre.dylib    => 100ms
libstd-04ff901e-0.9-pre.rlib     => 23ms
librustuv-7945354c-0.9-pre.dylib => 4ms
librustuv-7945354c-0.9-pre.rlib  => 1ms
librustc-5b94a16f-0.9-pre.dylib  => 87ms
librustc-5b94a16f-0.9-pre.rlib   => 35ms
libextra-a6ebb16f-0.9-pre.dylib  => 63ms
libextra-a6ebb16f-0.9-pre.rlib   => 15ms
libsyntax-2e4c0458-0.9-pre.dylib => 86ms
libsyntax-2e4c0458-0.9-pre.rlib  => 22ms
```

In order to always take advantage of these faster metadata read-times, I sort
the files in filesearch based on whether they have an rlib extension or not
(prefer all rlib files first).

Overall, this halved the compile time for a `fn main() {}` crate from 0.185s to
0.095s on my system (when preferring dynamic linking). Reading metadata is still
the slowest pass of the compiler at 0.035s, but it's getting pretty close to
linking at 0.021s! The next best optimization is to just not copy the metadata
from LLVM because that's the most expensive part of reading metadata right now.
