### PR TITLE
Don't allow impls to force public types

### DIFF
--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -932,7 +932,8 @@ impl<'a> Iterator<uint> for BitvSetIterator<'a> {
 mod tests {
     use extra::test::BenchHarness;
 
-    use bitv::*;
+    use bitv::{Bitv, SmallBitv, BigBitv, BitvSet, from_bools, from_fn,
+               from_bytes};
     use bitv;
 
     use std::uint;

--- a/src/libextra/btree.rs
+++ b/src/libextra/btree.rs
@@ -407,7 +407,7 @@ impl<K: Clone + TotalOrd, V: Clone> Clone for BranchElt<K, V> {
 #[cfg(test)]
 mod test_btree{
 
-    use super::*;
+    use super::{BTree, LeafElt};
 
     ///Tests the functionality of the add methods (which are unfinished).
     #[test]

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -329,7 +329,7 @@ impl Sem<~[WaitQueue]> {
  ****************************************************************************/
 
 /// A counting, blocking, bounded-waiting semaphore.
-struct Semaphore { priv sem: Sem<()> }
+pub struct Semaphore { priv sem: Sem<()> }
 
 
 impl Clone for Semaphore {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -670,7 +670,6 @@ fn should_sort_failures_before_printing_them() {
     use std::io::Decorator;
     use std::io::mem::MemWriter;
     use std::str;
-    fn dummy() {}
 
     let test_a = TestDesc {
         name: StaticTestName("a"),
@@ -1296,8 +1295,6 @@ mod tests {
 
     #[test]
     pub fn filter_for_ignored_option() {
-        fn dummy() {}
-
         // When we run ignored tests the test filter should filter out all the
         // unignored tests and flip the ignore flag on the rest to false
 
@@ -1441,6 +1438,7 @@ mod tests {
         assert_eq!(diff2.len(), 7);
     }
 
+    #[test]
     pub fn ratchet_test() {
 
         let dpth = TempDir::new("test-ratchet").expect("missing test for ratchet");

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -884,7 +884,7 @@ impl<T: TotalOrd> Extendable<T> for TreeSet<T> {
 #[cfg(test)]
 mod test_treemap {
 
-    use super::*;
+    use super::{TreeMap, TreeNode};
 
     use std::rand::Rng;
     use std::rand;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1258,11 +1258,16 @@ impl Resolver {
                                 let parent_link =
                                     self.get_parent_link(new_parent, ident);
                                 let def_id = local_def(item.id);
+                                let ns = TypeNS;
+                                let is_public =
+                                    !name_bindings.defined_in_namespace(ns) ||
+                                     name_bindings.defined_in_public_namespace(ns);
+
                                 name_bindings.define_module(parent_link,
                                                             Some(def_id),
                                                             ImplModuleKind,
                                                             false,
-                                                            true,
+                                                            is_public,
                                                             sp);
 
                                 ModuleReducedGraphParent(

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -130,7 +130,7 @@ pub fn push_ctxt(s: &'static str) -> _InsnCtxt {
     _InsnCtxt { _x: () }
 }
 
-struct StatRecorder<'a> {
+pub struct StatRecorder<'a> {
     ccx: @mut CrateContext,
     name: &'a str,
     start: u64,

--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -303,6 +303,7 @@ impl Streaming for SipState {
 mod tests {
     use super::*;
     use prelude::*;
+    use super::SipState;
 
     // Hash just the bytes of the slice, without length prefix
     struct Bytes<'a>(&'a [u8]);

--- a/src/libstd/rt/mpmc_bounded_queue.rs
+++ b/src/libstd/rt/mpmc_bounded_queue.rs
@@ -51,7 +51,7 @@ struct State<T> {
     pad3: [u8, ..64],
 }
 
-struct Queue<T> {
+pub struct Queue<T> {
     priv state: UnsafeArc<State<T>>,
 }
 

--- a/src/test/compile-fail/issue-10545.rs
+++ b/src/test/compile-fail/issue-10545.rs
@@ -1,0 +1,20 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+mod a {
+    struct S;
+    impl S { }
+}
+
+fn foo(_: a::S) { //~ ERROR: type `S` is private
+}
+
+fn main() {}


### PR DESCRIPTION
This code in resolve accidentally forced all types with an impl to become
public. This fixes it by default inheriting the privacy of what was previously
there and then becoming `true` if nothing else exits.

Closes #10545
