### PR TITLE
s/Second borrow/Previous borrow/ in error messages.

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -238,7 +238,7 @@ impl<'a> CheckLoanCtxt<'a> {
                              self.bccx.loan_path_to_str(new_loan.loan_path)));
                     self.bccx.span_note(
                         old_loan.span,
-                        format!("second borrow of `{}` as mutable occurs here",
+                        format!("previous borrow of `{}` as mutable occurs here",
                              self.bccx.loan_path_to_str(new_loan.loan_path)));
                     return false;
                 }
@@ -253,7 +253,7 @@ impl<'a> CheckLoanCtxt<'a> {
                              self.bccx.mut_to_str(old_loan.mutbl)));
                     self.bccx.span_note(
                         old_loan.span,
-                        format!("second borrow of `{}` occurs here",
+                        format!("previous borrow of `{}` occurs here",
                              self.bccx.loan_path_to_str(new_loan.loan_path)));
                     return false;
                 }


### PR DESCRIPTION
When a borrow occurs twice illegally, Rust will label the other borrow
as the "second borrow".  This is quite confusing, as the "second borrow"
usually happened before the flagged barrow (e.g. as far as dataflow
is concerned, the first borrow is OK, the second borrow is illegal.)
This patch renames "second borrow" to "previous borrow", to make the
spatial relationship between the two borrows clearer.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
