### PR TITLE
De-closure-ify/remove vec & str .as_{imm,mut}_buf

### DIFF
--- a/src/libextra/flate.rs
+++ b/src/libextra/flate.rs
@@ -44,21 +44,18 @@ static TINFL_FLAG_PARSE_ZLIB_HEADER : c_int = 0x1; // parse zlib header and adle
 static TDEFL_WRITE_ZLIB_HEADER : c_int = 0x01000; // write zlib header and adler32 checksum
 
 fn deflate_bytes_internal(bytes: &[u8], flags: c_int) -> ~[u8] {
-    bytes.as_imm_buf(|b, len| {
-        unsafe {
-            let mut outsz : size_t = 0;
-            let res =
-                rustrt::tdefl_compress_mem_to_heap(b as *c_void,
-                                                   len as size_t,
-                                                   &mut outsz,
-                                                   flags);
-            assert!(res as int != 0);
+    unsafe {
+        let mut outsz : size_t = 0;
+        let res = rustrt::tdefl_compress_mem_to_heap(bytes.as_ptr() as *c_void,
+                                                     bytes.len() as size_t,
+                                                     &mut outsz,
+                                                     flags);
+        assert!(res as int != 0);
             let out = vec::raw::from_buf_raw(res as *u8,
                                              outsz as uint);
-            libc::free(res);
-            out
-        }
-    })
+        libc::free(res);
+        out
+    }
 }
 
 pub fn deflate_bytes(bytes: &[u8]) -> ~[u8] {
@@ -70,21 +67,18 @@ pub fn deflate_bytes_zlib(bytes: &[u8]) -> ~[u8] {
 }
 
 fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> ~[u8] {
-    bytes.as_imm_buf(|b, len| {
-        unsafe {
-            let mut outsz : size_t = 0;
-            let res =
-                rustrt::tinfl_decompress_mem_to_heap(b as *c_void,
-                                                     len as size_t,
-                                                     &mut outsz,
-                                                     flags);
-            assert!(res as int != 0);
-            let out = vec::raw::from_buf_raw(res as *u8,
-                                            outsz as uint);
-            libc::free(res);
-            out
-        }
-    })
+    unsafe {
+        let mut outsz : size_t = 0;
+        let res = rustrt::tinfl_decompress_mem_to_heap(bytes.as_ptr() as *c_void,
+                                                       bytes.len() as size_t,
+                                                       &mut outsz,
+                                                       flags);
+        assert!(res as int != 0);
+        let out = vec::raw::from_buf_raw(res as *u8,
+                                         outsz as uint);
+        libc::free(res);
+        out
+    }
 }
 
 pub fn inflate_bytes(bytes: &[u8]) -> ~[u8] {

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -354,9 +354,7 @@ pub mod write {
             add(*arg);
         }
 
-        llvm_args.as_imm_buf(|p, len| {
-            llvm::LLVMRustSetLLVMOptions(len as c_int, p);
-        })
+        llvm::LLVMRustSetLLVMOptions(llvm_args.len() as c_int, llvm_args.as_ptr());
     }
 
     unsafe fn populate_llvm_passes(fpm: lib::llvm::PassManagerRef,

--- a/src/librustc/back/manifest.rs
+++ b/src/librustc/back/manifest.rs
@@ -55,7 +55,7 @@ mod windows {
         let mut t = s.to_utf16();
         // Null terminate before passing on.
         t.push(0u16);
-        t.as_imm_buf(|buf, _len| f(buf))
+        f(t.as_ptr())
     }
 
     #[link_name = "kernel32"]
@@ -86,14 +86,12 @@ mod windows {
                 return Err(format!("failure in BeginUpdateResourceW: {}", os::last_os_error()));
             }
 
-            let ok = manifest.as_imm_buf(|p, len| {
-                UpdateResourceW(hUpdate,
-                                MAKEINTRESOURCEW(24), // RT_MANIFEST
-                                MAKEINTRESOURCEW(1),  // CREATEPROCESS_MANIFEST_RESOURCE_ID
-                                0,                    // LANG_NEUTRAL, SUBLANG_NEUTRAL
-                                p as LPCVOID,
-                                len as u32)
-            });
+            let ok = UpdateResourceW(hUpdate,
+                                     MAKEINTRESOURCEW(24), // RT_MANIFEST
+                                     MAKEINTRESOURCEW(1),  // CREATEPROCESS_MANIFEST_RESOURCE_ID
+                                     0,                    // LANG_NEUTRAL, SUBLANG_NEUTRAL
+                                     manifest.as_ptr() as LPCVOID,
+                                     manifest.len() as u32);
             if ok == FALSE {
                 return Err(format!("failure in UpdateResourceW: {}", os::last_os_error()));
             }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2414,9 +2414,9 @@ pub fn create_entry_wrapper(ccx: @mut CrateContext,
                 (rust_main, args)
             };
 
-            let result = args.as_imm_buf(|buf, len| {
-                llvm::LLVMBuildCall(bld, start_fn, buf, len as c_uint, noname())
-            });
+            let result = llvm::LLVMBuildCall(bld, start_fn,
+                                             args.as_ptr(), args.len() as c_uint,
+                                             noname());
 
             llvm::LLVMBuildRet(bld, result);
         }

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -464,11 +464,11 @@ impl Builder {
             let min = llvm::LLVMConstInt(t, lo, signed);
             let max = llvm::LLVMConstInt(t, hi, signed);
 
-            [min, max].as_imm_buf(|ptr, len| {
-                llvm::LLVMSetMetadata(value, lib::llvm::MD_range as c_uint,
-                                      llvm::LLVMMDNodeInContext(self.ccx.llcx,
-                                                                ptr, len as c_uint));
-            })
+            let v = [min, max];
+
+            llvm::LLVMSetMetadata(value, lib::llvm::MD_range as c_uint,
+                                  llvm::LLVMMDNodeInContext(self.ccx.llcx,
+                                                            v.as_ptr(), v.len() as c_uint));
         }
 
         value

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -894,9 +894,9 @@ pub fn C_cstr(cx: &mut CrateContext, s: @str) -> ValueRef {
             None => ()
         }
 
-        let sc = s.as_imm_buf(|buf, buflen| {
-            llvm::LLVMConstStringInContext(cx.llcx, buf as *c_char, buflen as c_uint, False)
-        });
+        let sc = llvm::LLVMConstStringInContext(cx.llcx,
+                                                s.as_ptr() as *c_char, s.len() as c_uint,
+                                                False);
 
         let gsym = token::gensym("str");
         let g = format!("str{}", gsym).with_c_str(|buf| {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -952,17 +952,16 @@ pub fn C_zero_byte_arr(size: uint) -> ValueRef {
 
 pub fn C_struct(elts: &[ValueRef], packed: bool) -> ValueRef {
     unsafe {
-        elts.as_imm_buf(|ptr, len| {
-            llvm::LLVMConstStructInContext(base::task_llcx(), ptr, len as c_uint, packed as Bool)
-        })
+
+        llvm::LLVMConstStructInContext(base::task_llcx(),
+                                       elts.as_ptr(), elts.len() as c_uint,
+                                       packed as Bool)
     }
 }
 
 pub fn C_named_struct(T: Type, elts: &[ValueRef]) -> ValueRef {
     unsafe {
-        elts.as_imm_buf(|ptr, len| {
-            llvm::LLVMConstNamedStruct(T.to_ref(), ptr, len as c_uint)
-        })
+        llvm::LLVMConstNamedStruct(T.to_ref(), elts.as_ptr(), elts.len() as c_uint)
     }
 }
 
@@ -988,9 +987,7 @@ pub fn get_param(fndecl: ValueRef, param: uint) -> ValueRef {
 pub fn const_get_elt(cx: &CrateContext, v: ValueRef, us: &[c_uint])
                   -> ValueRef {
     unsafe {
-        let r = us.as_imm_buf(|p, len| {
-            llvm::LLVMConstExtractValue(v, p, len as c_uint)
-        });
+        let r = llvm::LLVMConstExtractValue(v, us.as_ptr(), us.len() as c_uint);
 
         debug!("const_get_elt(v={}, us={:?}, r={})",
                cx.tn.val_to_str(v), us, cx.tn.val_to_str(r));

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -646,11 +646,9 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @mut CrateContext,
         }
 
         // Perform the call itself
-        let llrust_ret_val = llrust_args.as_imm_buf(|ptr, len| {
-            debug!("calling llrustfn = {}", ccx.tn.val_to_str(llrustfn));
-            llvm::LLVMBuildCall(builder, llrustfn, ptr,
-                                len as c_uint, noname())
-        });
+        debug!("calling llrustfn = {}", ccx.tn.val_to_str(llrustfn));
+        let llrust_ret_val = llvm::LLVMBuildCall(builder, llrustfn, llrust_args.as_ptr(),
+                                                 llrust_args.len() as c_uint, noname());
 
         // Get the return value where the foreign fn expects it.
         let llforeign_ret_ty = match tys.fn_ty.ret_ty.cast {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -106,9 +106,8 @@ fn render(w: &mut io::Writer, s: &str) {
         let markdown = sd_markdown_new(extensions, 16, &callbacks,
                                        &options as *html_renderopt as *libc::c_void);
 
-        s.as_imm_buf(|data, len| {
-            sd_markdown_render(ob, data, len as libc::size_t, markdown);
-        });
+
+        sd_markdown_render(ob, s.as_ptr(), s.len() as libc::size_t, markdown);
         sd_markdown_free(markdown);
 
         vec::raw::buf_as_slice((*ob).data, (*ob).size as uint, |buf| {

--- a/src/librustuv/process.rs
+++ b/src/librustuv/process.rs
@@ -70,7 +70,7 @@ impl Process {
                     },
                     flags: 0,
                     stdio_count: stdio.len() as libc::c_int,
-                    stdio: stdio.as_imm_buf(|p, _| p),
+                    stdio: stdio.as_ptr(),
                     uid: 0,
                     gid: 0,
                 };
@@ -163,7 +163,7 @@ fn with_argv<T>(prog: &str, args: &[~str], f: |**libc::c_char| -> T) -> T {
         c_args.push(s.with_ref(|p| p));
     }
     c_args.push(ptr::null());
-    c_args.as_imm_buf(|buf, _| f(buf))
+    f(c_args.as_ptr())
 }
 
 /// Converts the environment to the env array expected by libuv
@@ -182,7 +182,7 @@ fn with_env<T>(env: Option<&[(~str, ~str)]>, f: |**libc::c_char| -> T) -> T {
         c_envp.push(s.with_ref(|p| p));
     }
     c_envp.push(ptr::null());
-    c_envp.as_imm_buf(|buf, _| f(buf))
+    f(c_envp.as_ptr())
 }
 
 impl HomingIO for Process {

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -267,17 +267,16 @@ impl<'a> ToCStr for &'a [u8] {
     }
 
     unsafe fn to_c_str_unchecked(&self) -> CString {
-        self.as_imm_buf(|self_buf, self_len| {
-            let buf = libc::malloc(self_len as libc::size_t + 1) as *mut u8;
-            if buf.is_null() {
-                fail!("failed to allocate memory!");
-            }
+        let self_len = self.len();
+        let buf = libc::malloc(self_len as libc::size_t + 1) as *mut u8;
+        if buf.is_null() {
+            fail!("failed to allocate memory!");
+        }
 
-            ptr::copy_memory(buf, self_buf, self_len);
-            *ptr::mut_offset(buf, self_len as int) = 0;
+        ptr::copy_memory(buf, self.as_ptr(), self_len);
+        *ptr::mut_offset(buf, self_len as int) = 0;
 
-            CString::new(buf as *libc::c_char, true)
-        })
+        CString::new(buf as *libc::c_char, true)
     }
 
     fn with_c_str<T>(&self, f: |*libc::c_char| -> T) -> T {

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -295,13 +295,12 @@ unsafe fn with_c_str<T>(v: &[u8], checked: bool, f: |*libc::c_char| -> T) -> T {
         vec::bytes::copy_memory(buf, v);
         buf[v.len()] = 0;
 
-        buf.as_mut_buf(|buf, _| {
-            if checked {
-                check_for_null(v, buf as *mut libc::c_char);
-            }
+        let buf = buf.as_mut_ptr();
+        if checked {
+            check_for_null(v, buf as *mut libc::c_char);
+        }
 
-            f(buf as *libc::c_char)
-        })
+        f(buf as *libc::c_char)
     } else if checked {
         v.to_c_str().with_ref(f)
     } else {

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -573,15 +573,14 @@ mod bench {
 
     #[inline]
     fn check(s: &str, c_str: *libc::c_char) {
-        s.as_imm_buf(|s_buf, s_len| {
-            for i in range(0, s_len) {
-                unsafe {
-                    assert_eq!(
-                        *ptr::offset(s_buf, i as int) as libc::c_char,
-                        *ptr::offset(c_str, i as int));
-                }
+        let s_buf = s.as_ptr();
+        for i in range(0, s.len()) {
+            unsafe {
+                assert_eq!(
+                    *ptr::offset(s_buf, i as int) as libc::c_char,
+                    *ptr::offset(c_str, i as int));
             }
-        })
+        }
     }
 
     static s_short: &'static str = "Mary";

--- a/src/libstd/io/native/file.rs
+++ b/src/libstd/io/native/file.rs
@@ -37,8 +37,8 @@ fn keep_going(data: &[u8], f: |*u8, uint| -> i64) -> i64 {
     #[cfg(windows)] static eintr: int = 0; // doesn't matter
     #[cfg(not(windows))] static eintr: int = libc::EINTR as int;
 
-    let (data, origamt) = data.as_imm_buf(|data, amt| (data, amt));
-    let mut data = data;
+    let origamt = data.len();
+    let mut data = data.as_ptr();
     let mut amt = origamt;
     while amt > 0 {
         let mut ret;

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -436,10 +436,10 @@ mod tests {
     #[test]
     fn test_get_str() {
         let x = ~"test";
-        let addr_x = x.as_imm_buf(|buf, _len| buf);
+        let addr_x = x.as_ptr();
         let opt = Some(x);
         let y = opt.unwrap();
-        let addr_y = y.as_imm_buf(|buf, _len| buf);
+        let addr_y = y.as_ptr();
         assert_eq!(addr_x, addr_y);
     }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -130,7 +130,7 @@ pub mod win32 {
         let mut t = s.to_utf16();
         // Null terminate before passing on.
         t.push(0u16);
-        t.as_imm_buf(|buf, _len| f(buf))
+        f(t.as_ptr())
     }
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -72,13 +72,11 @@ pub fn getcwd() -> Path {
     use libc::DWORD;
     use libc::GetCurrentDirectoryW;
     let mut buf = [0 as u16, ..BUF_BYTES];
-    buf.as_mut_buf(|buf, len| {
-        unsafe {
-            if libc::GetCurrentDirectoryW(len as DWORD, buf) == 0 as DWORD {
-                fail!();
-            }
+    unsafe {
+        if libc::GetCurrentDirectoryW(buf.len() as DWORD, buf.as_mut_ptr()) == 0 as DWORD {
+            fail!();
         }
-    });
+    }
     Path::new(str::from_utf16(buf))
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -59,15 +59,12 @@ static BUF_BYTES : uint = 2048u;
 #[cfg(unix)]
 pub fn getcwd() -> Path {
     let mut buf = [0 as libc::c_char, ..BUF_BYTES];
-    buf.as_mut_buf(|buf, len| {
-        unsafe {
-            if libc::getcwd(buf, len as size_t).is_null() {
-                fail!()
-            }
-
-            Path::new(CString::new(buf as *c_char, false))
+    unsafe {
+        if libc::getcwd(buf.as_mut_ptr(), buf.len() as size_t).is_null() {
+            fail!()
         }
-    })
+        Path::new(CString::new(buf.as_ptr(), false))
+    }
 }
 
 #[cfg(windows)]
@@ -103,20 +100,17 @@ pub mod win32 {
             let mut res = None;
             let mut done = false;
             while !done {
-                let mut k: DWORD = 0;
                 let mut buf = vec::from_elem(n as uint, 0u16);
-                buf.as_mut_buf(|b, _sz| {
-                    k = f(b, TMPBUF_SZ as DWORD);
-                    if k == (0 as DWORD) {
-                        done = true;
-                    } else if (k == n &&
-                               libc::GetLastError() ==
-                               libc::ERROR_INSUFFICIENT_BUFFER as DWORD) {
-                        n *= (2 as DWORD);
-                    } else {
-                        done = true;
-                    }
-                });
+                let k = f(buf.as_mut_ptr(), TMPBUF_SZ as DWORD);
+                if k == (0 as DWORD) {
+                    done = true;
+                } else if (k == n &&
+                           libc::GetLastError() ==
+                           libc::ERROR_INSUFFICIENT_BUFFER as DWORD) {
+                    n *= (2 as DWORD);
+                } else {
+                    done = true;
+                }
                 if k != 0 && done {
                     let sub = buf.slice(0, k as uint);
                     res = option::Some(str::from_utf16(sub));
@@ -363,10 +357,8 @@ pub fn self_exe_path() -> Option<Path> {
             if err != 0 { return None; }
             if sz == 0 { return None; }
             let mut v: ~[u8] = vec::with_capacity(sz as uint);
-            let err = v.as_mut_buf(|buf,_| {
-                sysctl(mib.as_ptr(), mib.len() as ::libc::c_uint,
-                       buf as *mut c_void, &mut sz, ptr::null(), 0u as size_t)
-            });
+            let err = sysctl(mib.as_ptr(), mib.len() as ::libc::c_uint,
+                             v.as_mut_ptr() as *mut c_void, &mut sz, ptr::null(), 0u as size_t);
             if err != 0 { return None; }
             if sz == 0 { return None; }
             v.set_len(sz as uint - 1); // chop off trailing NUL
@@ -394,9 +386,7 @@ pub fn self_exe_path() -> Option<Path> {
             _NSGetExecutablePath(ptr::mut_null(), &mut sz);
             if sz == 0 { return None; }
             let mut v: ~[u8] = vec::with_capacity(sz as uint);
-            let err = v.as_mut_buf(|buf, _| {
-                _NSGetExecutablePath(buf as *mut i8, &mut sz)
-            });
+            let err = _NSGetExecutablePath(v.as_mut_ptr() as *mut i8, &mut sz);
             if err != 0 { return None; }
             v.set_len(sz as uint - 1); // chop off trailing NUL
             Some(v)
@@ -628,15 +618,14 @@ pub fn last_os_error() -> ~str {
 
         let mut buf = [0 as c_char, ..TMPBUF_SZ];
 
-        buf.as_mut_buf(|buf, len| {
-            unsafe {
-                if strerror_r(errno() as c_int, buf, len as size_t) < 0 {
-                    fail!("strerror_r failure");
-                }
-
-                str::raw::from_c_str(buf as *c_char)
+        let p = buf.as_mut_ptr();
+        unsafe {
+            if strerror_r(errno() as c_int, p, buf.len() as size_t) < 0 {
+                fail!("strerror_r failure");
             }
-        })
+
+            str::raw::from_c_str(p as *c_char)
+        }
     }
 
     #[cfg(windows)]
@@ -669,19 +658,17 @@ pub fn last_os_error() -> ~str {
         let mut buf = [0 as WCHAR, ..TMPBUF_SZ];
 
         unsafe {
-            buf.as_mut_buf(|buf, len| {
-                let res = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM |
-                                         FORMAT_MESSAGE_IGNORE_INSERTS,
-                                         ptr::mut_null(),
-                                         err,
-                                         langId,
-                                         buf,
-                                         len as DWORD,
-                                         ptr::null());
-                if res == 0 {
-                    fail!("[{}] FormatMessage failure", errno());
-                }
-            });
+            let res = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM |
+                                     FORMAT_MESSAGE_IGNORE_INSERTS,
+                                     ptr::mut_null(),
+                                     err,
+                                     langId,
+                                     buf.as_mut_ptr(),
+                                     buf.len() as DWORD,
+                                     ptr::null());
+            if res == 0 {
+                fail!("[{}] FormatMessage failure", errno());
+            }
 
             str::from_utf16(buf)
         }

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -511,10 +511,9 @@ pub mod ptr_tests {
             "there".with_c_str(|p1| {
                 "thing".with_c_str(|p2| {
                     let v = ~[p0, p1, p2, null()];
-                    v.as_imm_buf(|vp, len| {
-                        assert_eq!(unsafe { buf_len(vp) }, 3u);
-                        assert_eq!(len, 4u);
-                    })
+                    unsafe {
+                        assert_eq!(buf_len(v.as_ptr()), 3u);
+                    }
                 })
             })
         })
@@ -623,23 +622,21 @@ pub mod ptr_tests {
                 one, two, three
             ];
 
-            arr.as_imm_buf(|arr_ptr, arr_len| {
-                let mut ctr = 0;
-                let mut iteration_count = 0;
-                array_each_with_len(arr_ptr, arr_len, |e| {
-                     let actual = str::raw::from_c_str(e);
-                     let expected = expected_arr[ctr].with_ref(|buf| {
-                         str::raw::from_c_str(buf)
-                     });
-                     debug!(
-                         "test_ptr_array_each_with_len e: {}, a: {}",
-                         expected, actual);
-                     assert_eq!(actual, expected);
-                     ctr += 1;
-                     iteration_count += 1;
+            let mut ctr = 0;
+            let mut iteration_count = 0;
+            array_each_with_len(arr.as_ptr(), arr.len(), |e| {
+                    let actual = str::raw::from_c_str(e);
+                    let expected = expected_arr[ctr].with_ref(|buf| {
+                            str::raw::from_c_str(buf)
+                        });
+                    debug!(
+                        "test_ptr_array_each_with_len e: {}, a: {}",
+                        expected, actual);
+                    assert_eq!(actual, expected);
+                    ctr += 1;
+                    iteration_count += 1;
                 });
-                assert_eq!(iteration_count, 3u);
-            })
+            assert_eq!(iteration_count, 3u);
         }
     }
 
@@ -660,23 +657,22 @@ pub mod ptr_tests {
                 one, two, three
             ];
 
-            arr.as_imm_buf(|arr_ptr, _| {
-                let mut ctr = 0;
-                let mut iteration_count = 0;
-                array_each(arr_ptr, |e| {
-                     let actual = str::raw::from_c_str(e);
-                     let expected = expected_arr[ctr].with_ref(|buf| {
-                         str::raw::from_c_str(buf)
-                     });
-                     debug!(
-                         "test_ptr_array_each e: {}, a: {}",
-                         expected, actual);
-                     assert_eq!(actual, expected);
-                     ctr += 1;
-                     iteration_count += 1;
+            let arr_ptr = arr.as_ptr();
+            let mut ctr = 0;
+            let mut iteration_count = 0;
+            array_each(arr_ptr, |e| {
+                    let actual = str::raw::from_c_str(e);
+                    let expected = expected_arr[ctr].with_ref(|buf| {
+                        str::raw::from_c_str(buf)
+                    });
+                    debug!(
+                        "test_ptr_array_each e: {}, a: {}",
+                        expected, actual);
+                    assert_eq!(actual, expected);
+                    ctr += 1;
+                    iteration_count += 1;
                 });
-                assert_eq!(iteration_count, 3);
-            })
+            assert_eq!(iteration_count, 3);
         }
     }
 

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -111,9 +111,7 @@ impl Rng for OSRng {
                                    pbBuffer: *mut BYTE);
         }
 
-        v.as_mut_buf(|ptr, len| {
-            unsafe {rust_win32_rand_gen(self.hcryptprov, len as DWORD, ptr)}
-        })
+        unsafe {rust_win32_rand_gen(self.hcryptprov, v.len() as DWORD, v.as_mut_ptr())}
     }
 }
 

--- a/src/libstd/rt/sched.rs
+++ b/src/libstd/rt/sched.rs
@@ -914,13 +914,11 @@ fn new_sched_rng() -> XorShiftRng {
     let mut seeds = [0u32, .. 4];
     let size = mem::size_of_val(&seeds);
     loop {
-        let nbytes = seeds.as_mut_buf(|buf, _| {
-            unsafe {
-                libc::read(fd,
-                           buf as *mut libc::c_void,
-                           size as libc::size_t)
-            }
-        });
+        let nbytes = unsafe {
+            libc::read(fd,
+                       seeds.as_mut_ptr() as *mut libc::c_void,
+                       size as libc::size_t)
+        };
         rtassert!(nbytes as uint == size);
 
         if !seeds.iter().all(|x| *x == 0) {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -111,6 +111,7 @@ use vec;
 use vec::{OwnedVector, OwnedCopyableVector, ImmutableVector, MutableVector};
 use default::Default;
 use send_str::{SendStr, SendStrOwned};
+use unstable::raw::Repr;
 
 /*
 Section: Conditions
@@ -382,11 +383,7 @@ impl<'a> Iterator<(uint, char)> for CharOffsetIterator<'a> {
     fn next(&mut self) -> Option<(uint, char)> {
         // Compute the byte offset by using the pointer offset between
         // the original string slice and the iterator's remaining part
-        let offset = self.string.as_imm_buf(|a, _| {
-            self.iter.string.as_imm_buf(|b, _| {
-                b as uint - a as uint
-            })
-        });
+        let offset = self.iter.string.as_ptr() as uint - self.string.as_ptr() as uint;
         self.iter.next().map(|ch| (offset, ch))
     }
 
@@ -400,11 +397,8 @@ impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsetIterator<'a> {
     #[inline]
     fn next_back(&mut self) -> Option<(uint, char)> {
         self.iter.next_back().map(|ch| {
-            let offset = self.string.as_imm_buf(|a, _| {
-                self.iter.string.as_imm_buf(|b, len| {
-                    b as uint - a as uint + len
-                })
-            });
+            let offset = self.iter.string.len() +
+                    self.iter.string.as_ptr() as uint - self.string.as_ptr() as uint;
             (offset, ch)
         })
     }
@@ -748,41 +742,30 @@ pub fn replace(s: &str, from: &str, to: &str) -> ~str {
 Section: Comparing strings
 */
 
+// share the implementation of the lang-item vs. non-lang-item
+// eq_slice.
+#[inline]
+fn eq_slice_(a: &str, b: &str) -> bool {
+    a.len() == b.len() && unsafe {
+        libc::memcmp(a.as_ptr() as *libc::c_void,
+                     b.as_ptr() as *libc::c_void,
+                     a.len() as libc::size_t) == 0
+    }
+}
+
 /// Bytewise slice equality
 #[cfg(not(test))]
 #[lang="str_eq"]
 #[inline]
 pub fn eq_slice(a: &str, b: &str) -> bool {
-    a.as_imm_buf(|ap, alen| {
-        b.as_imm_buf(|bp, blen| {
-            if (alen != blen) { false }
-            else {
-                unsafe {
-                    libc::memcmp(ap as *libc::c_void,
-                                 bp as *libc::c_void,
-                                 alen as libc::size_t) == 0
-                }
-            }
-        })
-    })
+    eq_slice_(a, b)
 }
 
 /// Bytewise slice equality
 #[cfg(test)]
 #[inline]
 pub fn eq_slice(a: &str, b: &str) -> bool {
-    a.as_imm_buf(|ap, alen| {
-        b.as_imm_buf(|bp, blen| {
-            if (alen != blen) { false }
-            else {
-                unsafe {
-                    libc::memcmp(ap as *libc::c_void,
-                                 bp as *libc::c_void,
-                                 alen as libc::size_t) == 0
-                }
-            }
-        })
-    })
+    eq_slice_(a, b)
 }
 
 /// Bytewise string equality
@@ -1080,12 +1063,10 @@ pub mod raw {
     /// Caller must check slice boundaries!
     #[inline]
     pub unsafe fn slice_unchecked<'a>(s: &'a str, begin: uint, end: uint) -> &'a str {
-        s.as_imm_buf(|sbuf, _n| {
-             cast::transmute(Slice {
-                 data: sbuf.offset(begin as int),
-                 len: end - begin,
-             })
-        })
+        cast::transmute(Slice {
+                data: s.as_ptr().offset(begin as int),
+                len: end - begin,
+            })
     }
 
     /// Appends a byte to a string.
@@ -1309,7 +1290,7 @@ impl<'a> Str for @str {
 impl<'a> Container for &'a str {
     #[inline]
     fn len(&self) -> uint {
-        self.as_imm_buf(|_p, n| n)
+        self.repr().len
     }
 }
 
@@ -1997,10 +1978,12 @@ pub trait StrSlice<'a> {
     /// ```
     fn subslice_offset(&self, inner: &str) -> uint;
 
-    /// Work with the byte buffer and length of a slice.
+    /// Return an unsafe pointer to the strings buffer.
     ///
-    /// The buffer does not have a null terminator.
-    fn as_imm_buf<T>(&self, f: |*u8, uint| -> T) -> T;
+    /// The caller must ensure that the string outlives this pointer,
+    /// and that it is not reallocated (e.g. by pushing to the
+    /// string).
+    fn as_ptr(&self) -> *u8;
 }
 
 impl<'a> StrSlice<'a> for &'a str {
@@ -2278,15 +2261,14 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn to_owned(&self) -> ~str {
-        self.as_imm_buf(|src, len| {
-            unsafe {
-                let mut v = vec::with_capacity(len);
+        let len = self.len();
+        unsafe {
+            let mut v = vec::with_capacity(len);
 
-                ptr::copy_memory(v.as_mut_ptr(), src, len);
-                v.set_len(len);
-                ::cast::transmute(v)
-            }
-        })
+            ptr::copy_memory(v.as_mut_ptr(), self.as_ptr(), len);
+            v.set_len(len);
+            ::cast::transmute(v)
+        }
     }
 
     #[inline]
@@ -2482,27 +2464,19 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     fn subslice_offset(&self, inner: &str) -> uint {
-        self.as_imm_buf(|a, a_len| {
-            inner.as_imm_buf(|b, b_len| {
-                let a_start: uint;
-                let a_end: uint;
-                let b_start: uint;
-                let b_end: uint;
-                unsafe {
-                    a_start = cast::transmute(a); a_end = a_len + cast::transmute(a);
-                    b_start = cast::transmute(b); b_end = b_len + cast::transmute(b);
-                }
-                assert!(a_start <= b_start);
-                assert!(b_end <= a_end);
-                b_start - a_start
-            })
-        })
+        let a_start = self.as_ptr() as uint;
+        let a_end = a_start + self.len();
+        let b_start = inner.as_ptr() as uint;
+        let b_end = b_start + inner.len();
+
+        assert!(a_start <= b_start);
+        assert!(b_end <= a_end);
+        b_start - a_start
     }
 
     #[inline]
-    fn as_imm_buf<T>(&self, f: |*u8, uint| -> T) -> T {
-        let v: &[u8] = unsafe { cast::transmute(*self) };
-        f(v.as_ptr(), v.len())
+    fn as_ptr(&self) -> *u8 {
+        self.repr().data
     }
 }
 
@@ -3391,19 +3365,15 @@ mod tests {
     }
 
     #[test]
-    fn test_as_imm_buf() {
-        "".as_imm_buf(|_, len| assert_eq!(len, 0));
-
-        "hello".as_imm_buf(|buf, len| {
-            assert_eq!(len, 5);
-            unsafe {
-                assert_eq!(*ptr::offset(buf, 0), 'h' as u8);
-                assert_eq!(*ptr::offset(buf, 1), 'e' as u8);
-                assert_eq!(*ptr::offset(buf, 2), 'l' as u8);
-                assert_eq!(*ptr::offset(buf, 3), 'l' as u8);
-                assert_eq!(*ptr::offset(buf, 4), 'o' as u8);
-            }
-        })
+    fn test_as_ptr() {
+        let buf = "hello".as_ptr();
+        unsafe {
+            assert_eq!(*ptr::offset(buf, 0), 'h' as u8);
+            assert_eq!(*ptr::offset(buf, 1), 'e' as u8);
+            assert_eq!(*ptr::offset(buf, 2), 'l' as u8);
+            assert_eq!(*ptr::offset(buf, 3), 'l' as u8);
+            assert_eq!(*ptr::offset(buf, 4), 'o' as u8);
+        }
     }
 
     #[test]
@@ -3936,10 +3906,10 @@ mod tests {
         assert_eq!(s.as_slice(), "");
 
         let mut s = ~"12345";
-        let p = s.as_imm_buf(|p,_| p);
+        let p = s.as_ptr();
         s.truncate(3);
         s.push_str("6");
-        let p_ = s.as_imm_buf(|p,_| p);
+        let p_ = s.as_ptr();
         assert_eq!(p_, p);
     }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -2502,7 +2502,7 @@ impl<'a> StrSlice<'a> for &'a str {
     #[inline]
     fn as_imm_buf<T>(&self, f: |*u8, uint| -> T) -> T {
         let v: &[u8] = unsafe { cast::transmute(*self) };
-        v.as_imm_buf(f)
+        f(v.as_ptr(), v.len())
     }
 }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1000,7 +1000,7 @@ pub mod raw {
     /// Create a Rust string from a *u8 buffer of the given length
     pub unsafe fn from_buf_len(buf: *u8, len: uint) -> ~str {
         let mut v: ~[u8] = vec::with_capacity(len);
-        v.as_mut_buf(|vbuf, _len| ptr::copy_memory(vbuf, buf as *u8, len));
+        ptr::copy_memory(v.as_mut_ptr(), buf as *u8, len);
         v.set_len(len);
 
         assert!(is_utf8(v));
@@ -2282,7 +2282,7 @@ impl<'a> StrSlice<'a> for &'a str {
             unsafe {
                 let mut v = vec::with_capacity(len);
 
-                v.as_mut_buf(|dst, _| ptr::copy_memory(dst, src, len));
+                ptr::copy_memory(v.as_mut_ptr(), src, len);
                 v.set_len(len);
                 ::cast::transmute(v)
             }
@@ -2697,7 +2697,8 @@ impl OwnedStr for ~str {
     #[inline]
     fn as_mut_buf<T>(&mut self, f: |*mut u8, uint| -> T) -> T {
         unsafe {
-            raw::as_owned_vec(self).as_mut_buf(f)
+            let v = raw::as_owned_vec(self);
+            f(v.as_mut_ptr(), v.len())
         }
     }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1681,15 +1681,16 @@ impl<T> OwnedVector<T> for ~[T] {
         self.pop()
     }
     fn truncate(&mut self, newlen: uint) {
-        self.as_mut_buf(|p, oldlen| {
-            assert!(newlen <= oldlen);
-            unsafe {
-                // This loop is optimized out for non-drop types.
-                for i in range(newlen, oldlen) {
-                    ptr::read_and_zero_ptr(ptr::mut_offset(p, i as int));
-                }
+        let oldlen = self.len();
+        assert!(newlen <= oldlen);
+
+        unsafe {
+            let p = self.as_mut_ptr();
+            // This loop is optimized out for non-drop types.
+            for i in range(newlen, oldlen) {
+                ptr::read_and_zero_ptr(p.offset(i as int));
             }
-        });
+        }
         unsafe { self.set_len(newlen); }
     }
 
@@ -2053,9 +2054,6 @@ pub trait MutableVector<'a, T> {
     /// `self` and `src` must not overlap. Fails if `self` is
     /// shorter than `src`.
     unsafe fn copy_memory(self, src: &[T]);
-
-    /// Similar to `as_imm_buf` but passing a `*mut T`
-    fn as_mut_buf<U>(self, f: |*mut T, uint| -> U) -> U;
 }
 
 impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
@@ -2063,14 +2061,12 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
     fn mut_slice(self, start: uint, end: uint) -> &'a mut [T] {
         assert!(start <= end);
         assert!(end <= self.len());
-        self.as_mut_buf(|p, _len| {
-            unsafe {
-                cast::transmute(Slice {
-                    data: ptr::mut_offset(p, start as int) as *T,
+        unsafe {
+            cast::transmute(Slice {
+                    data: self.as_mut_ptr().offset(start as int) as *T,
                     len: (end - start)
                 })
-            }
-        })
+        }
     }
 
     #[inline]
@@ -2189,17 +2185,9 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     unsafe fn copy_memory(self, src: &[T]) {
-        self.as_mut_buf(|p_dst, len_dst| {
-            let len_src = src.len();
-            assert!(len_dst >= len_src);
-            ptr::copy_nonoverlapping_memory(p_dst, src.as_ptr(), len_src)
-        })
-    }
-
-    #[inline]
-    fn as_mut_buf<U>(self, f: |*mut T, uint| -> U) -> U {
-        let Slice{ data, len } = self.repr();
-        f(data as *mut T, len)
+        let len_src = src.len();
+        assert!(self.len() >= len_src);
+        ptr::copy_nonoverlapping_memory(self.as_mut_ptr(), src.as_ptr(), len_src)
     }
 }
 
@@ -2283,7 +2271,7 @@ pub mod raw {
     pub unsafe fn from_buf_raw<T>(ptr: *T, elts: uint) -> ~[T] {
         let mut dst = with_capacity(elts);
         dst.set_len(elts);
-        dst.as_mut_buf(|p_dst, _len_dst| ptr::copy_memory(p_dst, ptr, elts));
+        ptr::copy_memory(dst.as_mut_ptr(), ptr, elts);
         dst
     }
 
@@ -2315,6 +2303,7 @@ pub mod raw {
 
 /// Operations on `[u8]`.
 pub mod bytes {
+    use container::Container;
     use vec::MutableVector;
     use ptr;
 
@@ -2327,9 +2316,7 @@ pub mod bytes {
     impl<'a> MutableByteVector for &'a mut [u8] {
         #[inline]
         fn set_memory(self, value: u8) {
-            self.as_mut_buf(|p, len| {
-                unsafe { ptr::set_memory(p, value, len) };
-            })
+            unsafe { ptr::set_memory(self.as_mut_ptr(), value, self.len()) };
         }
     }
 
@@ -2351,9 +2338,7 @@ pub mod bytes {
         let old_len = dst.len();
         dst.reserve_additional(src.len());
         unsafe {
-            dst.as_mut_buf(|p_dst, len_dst| {
-                ptr::copy_memory(p_dst.offset(len_dst as int), src.as_ptr(), src.len())
-            });
+            ptr::copy_memory(dst.as_mut_ptr().offset(old_len as int), src.as_ptr(), src.len());
             dst.set_len(old_len + src.len());
         }
     }
@@ -3532,15 +3517,6 @@ mod tests {
             }
             i += 1;
         }
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_as_mut_buf_fail() {
-        let mut v = [(~0, @0), (~0, @0), (~0, @0), (~0, @0)];
-        v.as_mut_buf(|_buf, _i| {
-            fail!()
-        })
     }
 
     #[test]

--- a/src/test/run-fail/bug-2470-bounds-check-overflow.rs
+++ b/src/test/run-fail/bug-2470-bounds-check-overflow.rs
@@ -21,16 +21,15 @@ fn main() {
     // huge).
 
     let x = ~[1u,2u,3u];
-    x.as_imm_buf(|p, _len| {
-        let base = p as uint;
-        let idx = base / mem::size_of::<uint>();
-        error!("ov1 base = 0x{:x}", base);
-        error!("ov1 idx = 0x{:x}", idx);
-        error!("ov1 sizeof::<uint>() = 0x{:x}", mem::size_of::<uint>());
-        error!("ov1 idx * sizeof::<uint>() = 0x{:x}",
-               idx * mem::size_of::<uint>());
 
-        // This should fail.
-        error!("ov1 0x{:x}",  x[idx]);
-    })
+    let base = x.as_ptr() as uint;
+    let idx = base / mem::size_of::<uint>();
+    error!("ov1 base = 0x{:x}", base);
+    error!("ov1 idx = 0x{:x}", idx);
+    error!("ov1 sizeof::<uint>() = 0x{:x}", mem::size_of::<uint>());
+    error!("ov1 idx * sizeof::<uint>() = 0x{:x}",
+           idx * mem::size_of::<uint>());
+
+    // This should fail.
+    error!("ov1 0x{:x}",  x[idx]);
 }


### PR DESCRIPTION
For `str.as_mut_buf`, un-closure-ification is achieved by outright removal (see commit message). The others are replaced by `.as_ptr`, `.as_mut_ptr` and `.len`
