### PR TITLE
Support ANSI colors in msys terminals. See #2807

### DIFF
--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -316,6 +316,21 @@ pub fn parse(file: &mut io::Reader,
     Ok(~TermInfo {names: term_names, bools: bools_map, numbers: numbers_map, strings: string_map })
 }
 
+/// Create a dummy TermInfo struct for msys terminals
+pub fn msys_terminfo() -> ~TermInfo {
+    let mut strings = HashMap::new();
+    strings.insert(~"sgr0", bytes!("\x1b[0m").to_owned());
+    strings.insert(~"bold", bytes!("\x1b[1m;").to_owned());
+    strings.insert(~"setaf", bytes!("\x1b[3%p1%dm").to_owned());
+    strings.insert(~"setab", bytes!("\x1b[4%p1%dm").to_owned());
+    ~TermInfo {
+        names: ~[~"cygwin"], // msys is a fork of an older cygwin version
+        bools: HashMap::new(),
+        numbers: HashMap::new(),
+        strings: strings
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Enable ANSI colors if TERM is set to cygwin and terminfo is not available (msys terminal on Windows). See #2807
