### PR TITLE
debuginfo: Properly support `self` passed by value.

### DIFF
--- a/src/test/debug-info/by-value-self-argument-in-trait-impl.rs
+++ b/src/test/debug-info/by-value-self-argument-in-trait-impl.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-win32: FIXME (#10474)
 // xfail-android: FIXME(#10381)
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/generic-method-on-generic-struct.rs
+++ b/src/test/debug-info/generic-method-on-generic-struct.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = {8888, -8888}}
+// debugger:print self
+// check:$4 = {x = {8888, -8888}}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {x = 1234.5}
+// check:$7 = {x = 1234.5}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 1234.5}
+// debugger:print self
+// check:$10 = {x = 1234.5}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {x = 1234.5}
+// check:$13 = {x = 1234.5}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10.5
+// check:$15 = -10.5
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {x = -1}
+// check:$16 = {x = -1}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12.5
+// check:$18 = -12.5
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = -1}
+// debugger:print self
+// check:$19 = {x = -1}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print *arg2
-// check:$18 = {-14, 14}
+// check:$21 = {-14, 14}
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {x = -1}
+// check:$22 = {x = -1}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print *arg2
-// check:$21 = {-16, 16.5}
+// check:$24 = {-16, 16.5}
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/method-on-enum.rs
+++ b/src/test/debug-info/method-on-enum.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {{Variant2, [...]}, {Variant2, 117901063}}
+// debugger:print self
+// check:$4 = {{Variant2, [...]}, {Variant2, 117901063}}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
+// check:$7 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
+// debugger:print self
+// check:$10 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
+// check:$13 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10
+// check:$15 = -10
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {{Variant2, [...]}, {Variant2, 117901063}}
+// check:$16 = {{Variant2, [...]}, {Variant2, 117901063}}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12
+// check:$18 = -12
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {{Variant2, [...]}, {Variant2, 117901063}}
+// debugger:print self
+// check:$19 = {{Variant2, [...]}, {Variant2, 117901063}}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print arg2
-// check:$18 = -14
+// check:$21 = -14
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {{Variant2, [...]}, {Variant2, 117901063}}
+// check:$22 = {{Variant2, [...]}, {Variant2, 117901063}}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print arg2
-// check:$21 = -16
+// check:$24 = -16
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/method-on-generic-struct.rs
+++ b/src/test/debug-info/method-on-generic-struct.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = {8888, -8888}}
+// debugger:print self
+// check:$4 = {x = {8888, -8888}}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {x = 1234.5}
+// check:$7 = {x = 1234.5}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 1234.5}
+// debugger:print self
+// check:$10 = {x = 1234.5}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {x = 1234.5}
+// check:$13 = {x = 1234.5}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10
+// check:$15 = -10
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {x = -1}
+// check:$16 = {x = -1}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12
+// check:$18 = -12
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = -1}
+// debugger:print self
+// check:$19 = {x = -1}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print arg2
-// check:$18 = -14
+// check:$21 = -14
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {x = -1}
+// check:$22 = {x = -1}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print arg2
-// check:$21 = -16
+// check:$24 = -16
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/method-on-struct.rs
+++ b/src/test/debug-info/method-on-struct.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 100}
+// debugger:print self
+// check:$4 = {x = 100}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {x = 200}
+// check:$7 = {x = 200}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 200}
+// debugger:print self
+// check:$10 = {x = 200}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {x = 200}
+// check:$13 = {x = 200}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10
+// check:$15 = -10
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {x = 300}
+// check:$16 = {x = 300}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12
+// check:$18 = -12
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 300}
+// debugger:print self
+// check:$19 = {x = 300}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print arg2
-// check:$18 = -14
+// check:$21 = -14
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {x = 300}
+// check:$22 = {x = 300}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print arg2
-// check:$21 = -16
+// check:$24 = -16
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/method-on-trait.rs
+++ b/src/test/debug-info/method-on-trait.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 100}
+// debugger:print self
+// check:$4 = {x = 100}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {x = 200}
+// check:$7 = {x = 200}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 200}
+// debugger:print self
+// check:$10 = {x = 200}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {x = 200}
+// check:$13 = {x = 200}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10
+// check:$15 = -10
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {x = 300}
+// check:$16 = {x = 300}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12
+// check:$18 = -12
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 300}
+// debugger:print self
+// check:$19 = {x = 300}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print arg2
-// check:$18 = -14
+// check:$21 = -14
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {x = 300}
+// check:$22 = {x = 300}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print arg2
-// check:$21 = -16
+// check:$24 = -16
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/method-on-tuple-struct.rs
+++ b/src/test/debug-info/method-on-tuple-struct.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {100, -100.5}
+// debugger:print self
+// check:$4 = {100, -100.5}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {200, -200.5}
+// check:$7 = {200, -200.5}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {200, -200.5}
+// debugger:print self
+// check:$10 = {200, -200.5}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {200, -200.5}
+// check:$13 = {200, -200.5}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10
+// check:$15 = -10
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {300, -300.5}
+// check:$16 = {300, -300.5}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12
+// check:$18 = -12
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {300, -300.5}
+// debugger:print self
+// check:$19 = {300, -300.5}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print arg2
-// check:$18 = -14
+// check:$21 = -14
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {300, -300.5}
+// check:$22 = {300, -300.5}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print arg2
-// check:$21 = -16
+// check:$24 = -16
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/self-in-default-method.rs
+++ b/src/test/debug-info/self-in-default-method.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 100}
+// debugger:print self
+// check:$4 = {x = 100}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {x = 200}
+// check:$7 = {x = 200}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 200}
+// debugger:print self
+// check:$10 = {x = 200}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {x = 200}
+// check:$13 = {x = 200}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10
+// check:$15 = -10
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {x = 300}
+// check:$16 = {x = 300}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12
+// check:$18 = -12
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 300}
+// debugger:print self
+// check:$19 = {x = 300}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print arg2
-// check:$18 = -14
+// check:$21 = -14
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {x = 300}
+// check:$22 = {x = 300}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print arg2
-// check:$21 = -16
+// check:$24 = -16
 // debugger:continue
 
 #[feature(managed_boxes)];

--- a/src/test/debug-info/self-in-generic-default-method.rs
+++ b/src/test/debug-info/self-in-generic-default-method.rs
@@ -26,72 +26,72 @@
 
 // STACK BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 987}
+// debugger:print self
+// check:$4 = {x = 987}
 // debugger:print arg1
-// check:$4 = -3
+// check:$5 = -3
 // debugger:print arg2
-// check:$5 = -4
+// check:$6 = -4
 // debugger:continue
 
 // OWNED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$6 = {x = 879}
+// check:$7 = {x = 879}
 // debugger:print arg1
-// check:$7 = -5
+// check:$8 = -5
 // debugger:print arg2
-// check:$8 = -6
+// check:$9 = -6
 // debugger:continue
 
 // OWNED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 879}
+// debugger:print self
+// check:$10 = {x = 879}
 // debugger:print arg1
-// check:$9 = -7
+// check:$11 = -7
 // debugger:print arg2
-// check:$10 = -8
+// check:$12 = -8
 // debugger:continue
 
 // OWNED MOVED
 // debugger:finish
 // debugger:print *self
-// check:$11 = {x = 879}
+// check:$13 = {x = 879}
 // debugger:print arg1
-// check:$12 = -9
+// check:$14 = -9
 // debugger:print arg2
-// check:$13 = -10.5
+// check:$15 = -10.5
 // debugger:continue
 
 // MANAGED BY REF
 // debugger:finish
 // debugger:print *self
-// check:$14 = {x = 897}
+// check:$16 = {x = 897}
 // debugger:print arg1
-// check:$15 = -11
+// check:$17 = -11
 // debugger:print arg2
-// check:$16 = -12.5
+// check:$18 = -12.5
 // debugger:continue
 
 // MANAGED BY VAL
 // debugger:finish
-// d ebugger:print self -- ignored for now because of issue #8512
-// c heck:$X = {x = 897}
+// debugger:print self
+// check:$19 = {x = 897}
 // debugger:print arg1
-// check:$17 = -13
+// check:$20 = -13
 // debugger:print *arg2
-// check:$18 = {-14, 14}
+// check:$21 = {-14, 14}
 // debugger:continue
 
 // MANAGED SELF
 // debugger:finish
 // debugger:print self->val
-// check:$19 = {x = 897}
+// check:$22 = {x = 897}
 // debugger:print arg1
-// check:$20 = -15
+// check:$23 = -15
 // debugger:print *arg2
-// check:$21 = {-16, 16.5}
+// check:$24 = {-16, 16.5}
 // debugger:continue
 
 #[feature(managed_boxes)];


### PR DESCRIPTION
As the title says. The trans changes will lead to an auxiliary alloca being created that allows debug info to track the `self` argument. This alloca is only created in debug builds however. Otherwise very little had to be done after I managed to navigate to some degree the jungle that is self-argument handling `:P` 

Closes #10549
