### PR TITLE
Upgrade libuv to fix a leak on OSX

### DIFF
--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -359,8 +359,7 @@ mod tests {
         let mut trapped_io_error = false;
         let opt_outp = io_error::cond.trap(|e| {
             trapped_io_error = true;
-            // FIXME(#11023)
-            assert_eq!(e.kind, if cfg!(windows) { OtherIoError } else { FileNotFound });
+            assert_eq!(e.kind, FileNotFound);
         }).inside(|| -> Option<run::ProcessOutput> {
             run::process_output("no-binary-by-this-name-should-exist", [])
         });


### PR DESCRIPTION
I haven't landed this fix upstream just yet, but it's opened as
joyent/libuv#1048. For now, I've locally merged it into my fork, and I've
upgraded our repo to point to the new revision.

Closes #11027
