### PR TITLE
Allow optional filename argument for --dep-info

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -168,8 +168,8 @@ pub struct options {
     no_trans: bool,
     debugging_opts: uint,
     android_cross_path: Option<~str>,
-    /// Whether to write .d dependency files
-    write_dependency_info: bool,
+    /// Whether to write dependency files. It's (enabled, optional filename).
+    write_dependency_info: (bool, Option<Path>),
     /// Crate id-related things to maybe print. It's (crate_id, crate_name, crate_file_name).
     print_metas: (bool, bool, bool),
 }
@@ -397,7 +397,7 @@ pub fn basic_options() -> @options {
         no_trans: false,
         debugging_opts: 0u,
         android_cross_path: None,
-        write_dependency_info: false,
+        write_dependency_info: (false, None),
         print_metas: (false, false, false),
     }
 }

--- a/src/test/run-make/dep-info-custom/Makefile
+++ b/src/test/run-make/dep-info-custom/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) --dep-info --lib lib.rs
+	$(RUSTC) --dep-info $(TMPDIR)/custom-deps-file.d --lib lib.rs
 	sleep 1
 	touch foo.rs
 	-rm -f $(TMPDIR)/done

--- a/src/test/run-make/dep-info-custom/Makefile.foo
+++ b/src/test/run-make/dep-info-custom/Makefile.foo
@@ -1,0 +1,7 @@
+LIB := $(shell $(RUSTC) --crate-file-name --lib lib.rs)
+
+$(TMPDIR)/$(LIB):
+	$(RUSTC) --dep-info $(TMPDIR)/custom-deps-file.d --lib lib.rs
+	touch $(TMPDIR)/done
+
+-include $(TMPDIR)/custom-deps-file.d

--- a/src/test/run-make/dep-info-custom/bar.rs
+++ b/src/test/run-make/dep-info-custom/bar.rs
@@ -1,0 +1,1 @@
+pub fn bar() {}

--- a/src/test/run-make/dep-info-custom/foo.rs
+++ b/src/test/run-make/dep-info-custom/foo.rs
@@ -1,0 +1,1 @@
+pub fn foo() {}

--- a/src/test/run-make/dep-info-custom/lib.rs
+++ b/src/test/run-make/dep-info-custom/lib.rs
@@ -1,0 +1,4 @@
+#[crate_id="foo#0.1"];
+
+pub mod foo;
+pub mod bar;

--- a/src/test/run-make/dep-info/Makefile
+++ b/src/test/run-make/dep-info/Makefile
@@ -1,4 +1,5 @@
 -include ../tools.mk
+
 all:
 	$(RUSTC) --dep-info --lib lib.rs
 	sleep 1

--- a/src/test/run-make/dep-info/Makefile.foo
+++ b/src/test/run-make/dep-info/Makefile.foo
@@ -1,10 +1,6 @@
-ifeq ($(shell uname),Darwin)
-LIBEXT=dylib
-else
-LIBEXT=so
-endif
+LIB := $(shell $(RUSTC) --crate-file-name --lib lib.rs)
 
-$(TMPDIR)/libfoo-b517899a-0.1.$(LIBEXT):
+$(TMPDIR)/$(LIB):
 	$(RUSTC) --dep-info --lib lib.rs
 	touch $(TMPDIR)/done
 


### PR DESCRIPTION
Using --dep-info writes Makefile-compatible dependency info to a file that is by default named based on the crate source filename. This adds an optional string argument to the --dep-info option which allows to write dependency info to an arbitrary filename.

cc #10698
