### PR TITLE
Purge @-boxes from the reading half of EBML

### DIFF
--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -792,7 +792,7 @@ mod test {
         let u = Uuid::new_v4();
         let wr = @mut MemWriter::new();
         u.encode(&mut ebml::writer::Encoder(wr));
-        let doc = ebml::reader::Doc(@wr.inner_ref().to_owned());
+        let doc = ebml::reader::Doc(wr.inner_ref().as_slice());
         let u2 = Decodable::decode(&mut ebml::reader::Decoder(doc));
         assert_eq!(u, u2);
     }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -267,9 +267,9 @@ fn resolve_crate(e: @mut Env,
             dylib, rlib, metadata
         } = load_ctxt.load_library_crate();
 
-        let attrs = decoder::get_crate_attributes(metadata);
+        let attrs = decoder::get_crate_attributes(metadata.as_slice());
         let pkgid = attr::find_pkgid(attrs).unwrap();
-        let hash = decoder::get_crate_hash(metadata);
+        let hash = decoder::get_crate_hash(metadata.as_slice());
 
         // Claim this crate number and cache it
         let cnum = e.next_crate_num;
@@ -282,7 +282,7 @@ fn resolve_crate(e: @mut Env,
         e.next_crate_num += 1;
 
         // Now resolve the crates referenced by this crate
-        let cnum_map = resolve_crate_deps(e, metadata);
+        let cnum_map = resolve_crate_deps(e, metadata.as_slice());
 
         let cmeta = @cstore::crate_metadata {
             name: name,
@@ -307,7 +307,7 @@ fn resolve_crate(e: @mut Env,
 }
 
 // Go through the crate metadata and load any crates that it references
-fn resolve_crate_deps(e: @mut Env, cdata: @~[u8]) -> cstore::cnum_map {
+fn resolve_crate_deps(e: @mut Env, cdata: &[u8]) -> cstore::cnum_map {
     debug!("resolving deps of external crate");
     // The map from crate numbers in the crate we're resolving to local crate
     // numbers

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -31,13 +31,13 @@ pub struct StaticMethodInfo {
 }
 
 pub fn get_symbol(cstore: @mut cstore::CStore, def: ast::DefId) -> ~str {
-    let cdata = cstore::get_crate_data(cstore, def.crate).data;
+    let cdata = cstore::get_crate_data(cstore, def.crate).data();
     return decoder::get_symbol(cdata, def.node);
 }
 
 pub fn get_type_param_count(cstore: @mut cstore::CStore, def: ast::DefId)
                          -> uint {
-    let cdata = cstore::get_crate_data(cstore, def.crate).data;
+    let cdata = cstore::get_crate_data(cstore, def.crate).data();
     return decoder::get_type_param_count(cdata, def.node);
 }
 
@@ -210,7 +210,7 @@ pub fn get_field_type(tcx: ty::ctxt, class_id: ast::DefId,
                       def: ast::DefId) -> ty::ty_param_bounds_and_ty {
     let cstore = tcx.cstore;
     let cdata = cstore::get_crate_data(cstore, class_id.crate);
-    let all_items = reader::get_doc(reader::Doc(cdata.data), tag_items);
+    let all_items = reader::get_doc(reader::Doc(cdata.data()), tag_items);
     debug!("Looking up {:?}", class_id);
     let class_doc = expect(tcx.diag,
                            decoder::maybe_find_item(class_id.node, all_items),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1526,8 +1526,8 @@ fn encode_crate_deps(ecx: &EncodeContext,
         cstore::iter_crate_data(cstore, |key, val| {
             let dep = decoder::CrateDep {cnum: key,
                        name: ecx.tcx.sess.ident_of(val.name),
-                       vers: decoder::get_crate_vers(val.data),
-                       hash: decoder::get_crate_hash(val.data)};
+                       vers: decoder::get_crate_vers(val.data()),
+                       hash: decoder::get_crate_hash(val.data())};
             deps.push(dep);
         });
 

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -102,7 +102,7 @@ impl Clean<ExternalCrate> for cstore::crate_metadata {
     fn clean(&self) -> ExternalCrate {
         ExternalCrate {
             name: self.name.to_owned(),
-            attrs: decoder::get_crate_attributes(self.data).clean()
+            attrs: decoder::get_crate_attributes(self.data()).clean()
         }
     }
 }

--- a/src/test/run-pass/auto-encode.rs
+++ b/src/test/run-pass/auto-encode.rs
@@ -10,6 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-test FIXME(#5121)
+
 #[feature(managed_boxes)];
 
 extern mod extra;
@@ -28,18 +30,18 @@ use std::io;
 use extra::serialize::{Decodable, Encodable};
 use extra::time;
 
-fn test_ebml<A:
+fn test_ebml<'a, A:
     Eq +
     Encodable<EBWriter::Encoder> +
-    Decodable<EBReader::Decoder>
+    Decodable<EBReader::Decoder<'a>>
 >(a1: &A) {
     let mut wr = @mut std::io::mem::MemWriter::new();
     let mut ebml_w = EBWriter::Encoder(wr);
     a1.encode(&mut ebml_w);
-    let bytes = wr.inner_ref().to_owned();
+    let bytes = wr.inner_ref().as_slice();
 
-    let d = EBReader::Doc(@bytes);
-    let mut decoder = EBReader::Decoder(d);
+    let d: extra::ebml::Doc<'a> = EBReader::Doc(bytes);
+    let mut decoder: EBReader::Decoder<'a> = EBReader::Decoder(d);
     let a2: A = Decodable::decode(&mut decoder);
     assert!(*a1 == a2);
 }

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -12,6 +12,7 @@
 // job done at least
 
 // xfail-fast
+// xfail-test FIXME(#5121)
 
 #[feature(struct_variant, managed_boxes)];
 
@@ -54,7 +55,8 @@ struct G<T> {
     t: T
 }
 
-fn roundtrip<T: Rand + Eq + Encodable<Encoder> + Decodable<Decoder>>() {
+fn roundtrip<'a, T: Rand + Eq + Encodable<Encoder> +
+                    Decodable<Decoder<'a>>>() {
     let obj: T = random();
     let w = @mut MemWriter::new();
     let mut e = Encoder(w);


### PR DESCRIPTION
Now that the metadata is an owned value with a lifetime of a borrowed byte
slice, it's possible to have future optimizations where the metadata doesn't
need to be copied around (very expensive operation).
