### PR TITLE
librustc: Add missing case for the `Pod` bound in `tydecode`.

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -590,14 +590,17 @@ fn parse_bounds(st: &mut PState, conv: conv_did) -> ty::ParamBounds {
             'Z' => {
                 param_bounds.builtin_bounds.add(ty::BoundSized);
             }
+            'P' => {
+                param_bounds.builtin_bounds.add(ty::BoundPod);
+            }
             'I' => {
                 param_bounds.trait_bounds.push(@parse_trait_ref(st, |x,y| conv(x,y)));
             }
             '.' => {
                 return param_bounds;
             }
-            _ => {
-                fail!("parse_bounds: bad bounds")
+            c => {
+                fail!("parse_bounds: bad bounds ('{}')", c)
             }
         }
     }

--- a/src/test/auxiliary/kinds_in_metadata.rs
+++ b/src/test/auxiliary/kinds_in_metadata.rs
@@ -1,0 +1,9 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests that metadata serialization works for the `Pod` kind.
+
+#[crate_type="lib"];
+
+pub fn f<T:Pod>() {}
+

--- a/src/test/auxiliary/trait_superkinds_in_metadata.rs
+++ b/src/test/auxiliary/trait_superkinds_in_metadata.rs
@@ -15,3 +15,4 @@
 
 pub trait RequiresFreeze : Freeze { }
 pub trait RequiresRequiresFreezeAndSend : RequiresFreeze + Send { }
+pub trait RequiresPod : Pod { }

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -16,11 +16,14 @@
 
 extern mod trait_superkinds_in_metadata;
 use trait_superkinds_in_metadata::{RequiresRequiresFreezeAndSend, RequiresFreeze};
+use trait_superkinds_in_metadata::{RequiresPod};
 
 struct X<T>(T);
 
 impl <T:Freeze> RequiresFreeze for X<T> { }
 
 impl <T:Freeze+Send> RequiresRequiresFreezeAndSend for X<T> { }
+
+impl <T:Pod> RequiresPod for X<T> { }
 
 fn main() { }

--- a/src/test/run-pass/kinds-in-metadata.rs
+++ b/src/test/run-pass/kinds-in-metadata.rs
@@ -1,0 +1,16 @@
+// xfail-fast
+// aux-build:kinds_in_metadata.rs
+
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests that metadata serialization works for the `Pod` kind.
+
+extern mod kinds_in_metadata;
+
+use kinds_in_metadata::f;
+
+pub fn main() {
+    f::<int>();
+}
+


### PR DESCRIPTION
r? @brson
