### PR TITLE
Generalize item_span into node_span, which works on more types.

### DIFF
--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -501,3 +501,24 @@ pub fn item_span(items: map,
         }
     }
 }
+
+pub fn node_span(items: map,
+                 id: ast::NodeId)
+                 -> Span {
+    match items.find(&id) {
+        Some(&node_item(item, _)) => item.span,
+        Some(&node_foreign_item(foreign_item, _, _, _)) => foreign_item.span,
+        Some(&node_trait_method(@required(ref type_method), _, _)) => type_method.span,
+        Some(&node_trait_method(@provided(ref method), _, _)) => method.span,
+        Some(&node_method(method, _, _)) => method.span,
+        Some(&node_variant(variant, _, _)) => variant.span,
+        Some(&node_expr(expr)) => expr.span,
+        Some(&node_stmt(stmt)) => stmt.span,
+        Some(&node_arg(pat)) => pat.span,
+        Some(&node_local(_)) => fail!("node_local"),
+        Some(&node_block(block)) => block.span,
+        Some(&node_struct_ctor(_, item, _)) => item.span,
+        Some(&node_callee_scope(expr)) => expr.span,
+        None => fail!("None"),
+    }
+}


### PR DESCRIPTION
I actually suspect the function shouldn't be written in this particular way, so I'd like some commentary. (This function is not used by anything yet, but I'm working on better error messages so it will come in handy for another patch)

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
