### PR TITLE
uv: Suppress a warning by using an absolute path

### DIFF
--- a/src/rt/libuv-auto-clean-trigger
+++ b/src/rt/libuv-auto-clean-trigger
@@ -1,0 +1,2 @@
+# Change the contents of this file to force a full rebuild of libuv
+2013-12-23


### PR DESCRIPTION
Turns out libuv's build system doesn't like us telling them that the build
directory is a relative location, as it always spits out a warning about a
circular dependency being dropped. By using an absolute path, turns out the
warnings isn't spit out, who knew?

Closes #11067
