### PR TITLE
Generalize item_span into node_span, which works on more types.

### DIFF
--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -916,7 +916,7 @@ impl<'a> SolveContext<'a> {
             // attribute and report an error with various results if found.
             if ty::has_attr(tcx, item_def_id, "rustc_variance") {
                 let found = item_variances.repr(tcx);
-                tcx.sess.span_err(ast_map::item_span(tcx.items, item_id), found);
+                tcx.sess.span_err(ast_map::node_span(tcx.items, item_id), found);
             }
 
             let newly_added = item_variance_map.insert(item_def_id,

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -490,14 +490,23 @@ pub fn node_item_query<Result>(items: map, id: NodeId, query: |@item| -> Result,
     }
 }
 
-pub fn item_span(items: map,
+pub fn node_span(items: map,
                  id: ast::NodeId)
                  -> Span {
     match items.find(&id) {
         Some(&node_item(item, _)) => item.span,
-        r => {
-            fail!(format!("item_span: expected item with id {} but found {:?}",
-                           id, r))
-        }
+        Some(&node_foreign_item(foreign_item, _, _, _)) => foreign_item.span,
+        Some(&node_trait_method(@required(ref type_method), _, _)) => type_method.span,
+        Some(&node_trait_method(@provided(ref method), _, _)) => method.span,
+        Some(&node_method(method, _, _)) => method.span,
+        Some(&node_variant(variant, _, _)) => variant.span,
+        Some(&node_expr(expr)) => expr.span,
+        Some(&node_stmt(stmt)) => stmt.span,
+        Some(&node_arg(pat)) => pat.span,
+        Some(&node_local(_)) => fail!("node_span: cannot get span from node_local"),
+        Some(&node_block(block)) => block.span,
+        Some(&node_struct_ctor(_, item, _)) => item.span,
+        Some(&node_callee_scope(expr)) => expr.span,
+        None => fail!("node_span: could not find id {}", id),
     }
 }


### PR DESCRIPTION
On the advice of @huonw, I've just replaced item_span outright.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
