### PR TITLE
Accept trailing commas in struct patterns

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2800,8 +2800,13 @@ impl Parser {
         let mut etc = false;
         let mut first = true;
         while *self.token != token::RBRACE {
-            if first { first = false; }
-            else { self.expect(&token::COMMA); }
+            if first {
+                first = false;
+            } else {
+                self.expect(&token::COMMA);
+                // accept trailing commas
+                if *self.token == token::RBRACE { break }
+            }
 
             etc = *self.token == token::UNDERSCORE || *self.token == token::DOTDOT;
             if *self.token == token::UNDERSCORE {

--- a/src/test/compile-fail/issue-10392-2.rs
+++ b/src/test/compile-fail/issue-10392-2.rs
@@ -1,0 +1,18 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A { foo: int }
+
+fn a() -> A { fail!() }
+
+fn main() {
+    let A { .., } = a(); //~ ERROR: expected `}`
+}
+

--- a/src/test/compile-fail/issue-10392.rs
+++ b/src/test/compile-fail/issue-10392.rs
@@ -1,0 +1,17 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A { foo: int }
+
+fn a() -> A { fail!() }
+
+fn main() {
+    let A { , } = a(); //~ ERROR: expected ident
+}

--- a/src/test/run-pass/issue-10392.rs
+++ b/src/test/run-pass/issue-10392.rs
@@ -1,0 +1,37 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A { foo: int }
+struct B { a: int, b: int, c: int }
+
+fn mka() -> A { fail!() }
+fn mkb() -> B { fail!() }
+
+fn test() {
+    let A { foo, } = mka();
+    let A {
+        foo,
+    } = mka();
+
+    let B { a, b, c, } = mkb();
+
+    match mka() {
+        A { foo: _foo, } => {}
+    }
+
+    match Some(mka()) {
+        Some(A { foo: _foo, }) => {}
+        None => {}
+    }
+}
+
+pub fn main() {
+    if false { test() }
+}


### PR DESCRIPTION
We decided in the 12/10/13 weekly meeting that trailing commas should be
accepted pretty much anywhere. They are currently not allowed in struct
patterns, and this commit adds support for that.

Closes #10392
