### PR TITLE
rustc: Improve crate id extraction

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -447,7 +447,7 @@ pub mod write {
  */
 
 pub fn build_link_meta(sess: Session,
-                       c: &ast::Crate,
+                       attrs: &[ast::Attribute],
                        output: &Path,
                        symbol_hasher: &mut Sha256)
                        -> LinkMeta {
@@ -458,7 +458,7 @@ pub fn build_link_meta(sess: Session,
         truncated_hash_result(symbol_hasher).to_managed()
     }
 
-    let pkgid = match attr::find_pkgid(c.attrs) {
+    let pkgid = match attr::find_pkgid(attrs) {
         None => {
             let stem = session::expect(
                 sess,

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -421,14 +421,15 @@ pub fn building_library(options: &options, crate: &ast::Crate) -> bool {
     }
 }
 
-pub fn collect_outputs(options: &options, crate: &ast::Crate) -> ~[OutputStyle] {
+pub fn collect_outputs(options: &options,
+                       attrs: &[ast::Attribute]) -> ~[OutputStyle] {
     // If we're generating a test executable, then ignore all other output
     // styles at all other locations
     if options.test {
         return ~[OutputExecutable];
     }
     let mut base = options.outputs.clone();
-    let mut iter = crate.attrs.iter().filter_map(|a| {
+    let mut iter = attrs.iter().filter_map(|a| {
         if "crate_type" == a.name() {
             match a.value_str() {
                 Some(n) if "rlib" == n => Some(OutputRlib),

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3096,7 +3096,7 @@ pub fn trans_crate(sess: session::Session,
     }
 
     let mut symbol_hasher = Sha256::new();
-    let link_meta = link::build_link_meta(sess, &crate, output,
+    let link_meta = link::build_link_meta(sess, crate.attrs, output,
                                           &mut symbol_hasher);
 
     // Append ".rc" to crate name as LLVM module identifier.

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -79,6 +79,16 @@ pub fn parse_crate_from_file(
     // why is there no p.abort_if_errors here?
 }
 
+pub fn parse_crate_attrs_from_file(
+    input: &Path,
+    cfg: ast::CrateConfig,
+    sess: @mut ParseSess
+) -> ~[ast::Attribute] {
+    let parser = new_parser_from_file(sess, cfg, input);
+    let (inner, _) = parser.parse_inner_attrs_and_next();
+    return inner;
+}
+
 pub fn parse_crate_from_source_str(
     name: @str,
     source: @str,
@@ -90,6 +100,20 @@ pub fn parse_crate_from_source_str(
                                        name,
                                        source);
     maybe_aborted(p.parse_crate_mod(),p)
+}
+
+pub fn parse_crate_attrs_from_source_str(
+    name: @str,
+    source: @str,
+    cfg: ast::CrateConfig,
+    sess: @mut ParseSess
+) -> ~[ast::Attribute] {
+    let p = new_parser_from_source_str(sess,
+                                       /*bad*/ cfg.clone(),
+                                       name,
+                                       source);
+    let (inner, _) = maybe_aborted(p.parse_inner_attrs_and_next(),p);
+    return inner;
 }
 
 pub fn parse_expr_from_source_str(

--- a/src/test/run-make/crate-data-smoke/Makefile
+++ b/src/test/run-make/crate-data-smoke/Makefile
@@ -1,0 +1,10 @@
+-include ../tools.mk
+
+all:
+	[ `$(RUSTC) --crate-id crate.rs` = "foo#0.9" ]
+	[ `$(RUSTC) --crate-name crate.rs` = "foo" ]
+	[ `$(RUSTC) --crate-file-name crate.rs` = "foo" ]
+	[ `$(RUSTC) --crate-file-name --lib --test crate.rs` = "foo" ]
+	[ `$(RUSTC) --crate-file-name --test lib.rs` = "mylib" ]
+	$(RUSTC) --crate-file-name lib.rs
+	$(RUSTC) --crate-file-name rlib.rs

--- a/src/test/run-make/crate-data-smoke/crate.rs
+++ b/src/test/run-make/crate-data-smoke/crate.rs
@@ -1,0 +1,7 @@
+#[crate_id = "foo#0.9"];
+
+// Querying about the crate metadata should *not* parse the entire crate, it
+// only needs the crate attributes (which are guaranteed to be at the top) be
+// sure that if we have an error like a missing module that we can still query
+// about the crate id.
+mod error;

--- a/src/test/run-make/crate-data-smoke/lib.rs
+++ b/src/test/run-make/crate-data-smoke/lib.rs
@@ -1,0 +1,2 @@
+#[crate_id = "mylib"];
+#[crate_type = "lib"];

--- a/src/test/run-make/crate-data-smoke/rlib.rs
+++ b/src/test/run-make/crate-data-smoke/rlib.rs
@@ -1,0 +1,2 @@
+#[crate_id = "mylib"];
+#[crate_type = "rlib"];


### PR DESCRIPTION
Right now the --crate-id and related flags are all process _after_ the entire
crate is parsed. This is less than desirable when used with makefiles because it
means that just to learn the output name of the crate you have to parse the
entire crate (unnecessary).

This commit changes the behavior to lift the handling of these flags much sooner
in the compilation process. This allows us to not have to parse the entire crate
and only have to worry about parsing the crate attributes themselves. The
related methods have all been updated to take an array of attributes rather than
a crate.

Additionally, this ceases duplication of the "what output are we producing"
logic in order to correctly handle things in the case of --test.

Finally, this adds tests for all of this functionality to ensure that it does
not regress.
