### PR TITLE
Get comm_adapters building again

### DIFF
--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -38,7 +38,7 @@ pub struct PortReader {
 }
 
 impl PortReader {
-    pub fn new(port: Port<~[u8]>) -> PortReader<P> {
+    pub fn new(port: Port<~[u8]>) -> PortReader {
         PortReader {
             buf: None,
             pos: 0,
@@ -94,7 +94,7 @@ pub struct ChanWriter {
 }
 
 impl ChanWriter {
-    pub fn new(chan: C) -> ChanWriter<C> {
+    pub fn new(chan: Chan<~[u8]>) -> ChanWriter {
         ChanWriter { chan: chan }
     }
 }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -335,6 +335,9 @@ pub mod signal;
 /// Utility implementations of Reader and Writer
 pub mod util;
 
+/// Adapatation of Chan/Port types to a Writer/Reader type.
+pub mod comm_adapters;
+
 /// The default buffer size for various I/O operations
 static DEFAULT_BUF_SIZE: uint = 1024 * 64;
 


### PR DESCRIPTION
I accidentally removed this module from compilation awhile back, this adds it
back in.

Closes #11076
