### PR TITLE
Use the libsyntax PkgId parser in Rustpkg, but keep Rustpkg's version sm...

### DIFF
--- a/src/librustpkg/crate_id.rs
+++ b/src/librustpkg/crate_id.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 use version::{try_getting_version, try_getting_local_version,
-              Version, NoVersion, split_version};
+              Version, NoVersion, ExactRevision};
 use std::hash::Streaming;
 use std::hash;
+use syntax::crateid;
 
 /// Path-fragment identifier of a package such as
 /// 'github.com/graydon/test'; path must be a relative
@@ -45,27 +46,14 @@ impl CrateId {
     pub fn new(s: &str) -> CrateId {
         use conditions::bad_pkg_id::cond;
 
-        let mut given_version = None;
-
-        // Did the user request a specific version?
-        let s = match split_version(s) {
-            Some((path, v)) => {
-                given_version = Some(v);
-                path
-            }
-            None => {
-                s
-            }
-        };
-
-        let path = Path::new(s);
-        if !path.is_relative() {
-            return cond.raise((path, ~"absolute crate_id"));
+        let raw_crateid: Option<crateid::CrateId> = from_str(s);
+        if raw_crateid.is_none() {
+            return cond.raise((Path::new(s), ~"bad crateid"))
         }
-        if path.filename().is_none() {
-            return cond.raise((path, ~"0-length crate_id"));
-        }
-        let short_name = path.filestem_str().expect(format!("Strange path! {}", s));
+        let raw_crateid = raw_crateid.unwrap();
+        let crateid::CrateId { path, name, version } = raw_crateid;
+        let path = Path::new(path);
+        let given_version = version.map(|v| ExactRevision(v));
 
         let version = match given_version {
             Some(v) => v,
@@ -79,8 +67,8 @@ impl CrateId {
         };
 
         CrateId {
-            path: path.clone(),
-            short_name: short_name.to_owned(),
+            path: path,
+            short_name: name,
             version: version
         }
     }

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -26,7 +26,7 @@ use extra::getopts::groups::getopts;
 use std::run::ProcessOutput;
 use installed_packages::list_installed_packages;
 use crate_id::{CrateId};
-use version::{ExactRevision, NoVersion, Version, Tagged};
+use version::{ExactRevision, NoVersion, Version};
 use path_util::{target_executable_in_workspace, target_test_in_workspace,
                target_bench_in_workspace, make_dir_rwx,
                library_in_workspace, installed_library_in_workspace,
@@ -35,7 +35,6 @@ use path_util::{target_executable_in_workspace, target_test_in_workspace,
                chmod_read_only, platform_library_name};
 use rustc::back::link::get_cc_prog;
 use rustc::metadata::filesearch::{rust_path, libdir, rustlibdir};
-use rustc::driver::session;
 use rustc::driver::driver::{build_session, build_session_options, host_triple, optgroups};
 use syntax::diagnostic;
 use target::*;
@@ -73,14 +72,6 @@ fn git_repo_pkg() -> CrateId {
         path: Path::new("mockgithub.com/catamorphism/test-pkg"),
         short_name: ~"test-pkg",
         version: NoVersion
-    }
-}
-
-fn git_repo_pkg_with_tag(a_tag: ~str) -> CrateId {
-    CrateId {
-        path: Path::new("mockgithub.com/catamorphism/test-pkg"),
-        short_name: ~"test-pkg",
-        version: Tagged(a_tag)
     }
 }
 
@@ -485,12 +476,6 @@ fn lib_output_file_name(workspace: &Path, short_name: &str) -> Path {
                          workspace,
                          "build",
                          &NoVersion).expect("lib_output_file_name")
-}
-
-fn output_file_name(workspace: &Path, short_name: ~str) -> Path {
-    target_build_dir(workspace).join(short_name.as_slice())
-                               .join(format!("{}{}", short_name,
-                                             os::consts::EXE_SUFFIX))
 }
 
 #[cfg(target_os = "linux")]

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -1894,9 +1894,11 @@ fn crateid_pointing_to_subdir() {
     fs::mkdir_recursive(&foo_dir, io::UserRWX);
     fs::mkdir_recursive(&bar_dir, io::UserRWX);
     writeFile(&foo_dir.join("lib.rs"),
-              "#[crate_id=\"mockgithub.com/mozilla/some_repo/extras/foo\"]; pub fn f() {}");
+              "#[crate_id=\"mockgithub.com/mozilla/some_repo/extras/rust-foo#foo:0.0\"];" +
+              "pub fn f() {}");
     writeFile(&bar_dir.join("lib.rs"),
-              "#[crate_id=\"mockgithub.com/mozilla/some_repo/extras/bar\"]; pub fn g() {}");
+              "#[crate_id=\"mockgithub.com/mozilla/some_repo/extras/rust-bar#bar:0.0\"];" +
+              "pub fn g() {}");
 
     debug!("Creating a file in {}", workspace.display());
     let testpkg_dir = workspace.join_many(["src", "testpkg-0.0"]);
@@ -2318,7 +2320,7 @@ fn find_sources_in_cwd() {
     let source_dir = temp_dir.join("foo");
     fs::mkdir_recursive(&source_dir, io::UserRWX);
     writeFile(&source_dir.join("main.rs"),
-              r#"#[crate_id="foo"]; fn main() { let _x = (); }"#);
+              r#"#[crate_id="rust-foo#foo:0.0"]; fn main() { let _x = (); }"#);
     command_line_test([~"install", ~"foo"], &source_dir);
     assert_executable_exists(&source_dir.join(".rust"), "foo");
 }

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -746,8 +746,8 @@ fn test_crate_ids_must_be_relative_path_like() {
             CrateId::new("github.com/catamorphism/test-pkg").to_str());
 
     cond.trap(|(p, e)| {
-        assert!(p.filename().is_none())
-        assert!("0-length crate_id" == e);
+        assert!(p.filename().is_none());
+        assert!("bad crateid" == e);
         whatever.clone()
     }).inside(|| {
         let x = CrateId::new("");
@@ -757,7 +757,7 @@ fn test_crate_ids_must_be_relative_path_like() {
     cond.trap(|(p, e)| {
         let abs = os::make_absolute(&Path::new("foo/bar/quux"));
         assert_eq!(p, abs);
-        assert!("absolute crate_id" == e);
+        assert!("bad crateid" == e);
         whatever.clone()
     }).inside(|| {
         let zp = os::make_absolute(&Path::new("foo/bar/quux"));


### PR DESCRIPTION
...arts.

This fixes a bug where new syntax crate IDs would cause rustpkg to fail to
build crates.
