### PR TITLE
rustc: Add a lint for the obsolete crate-level link attribute

### DIFF
--- a/src/etc/combine-tests.py
+++ b/src/etc/combine-tests.py
@@ -46,7 +46,6 @@ c.write(
 // AUTO-GENERATED FILE: DO NOT EDIT
 #[crate_id=\"run_pass_stage2#0.1\"];
 #[pkgid=\"run_pass_stage2#0.1\"];
-#[link(name=\"run_pass_stage2\", vers=\"0.1\")];
 #[feature(globs, macro_rules, struct_variant, managed_boxes)];
 #[allow(warnings)];
 """

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -872,6 +872,12 @@ fn check_crate_attrs_usage(cx: &Context, attrs: &[ast::Attribute]) {
         if !iter.any(|other_attr| { name.equiv(other_attr) }) {
             cx.span_lint(attribute_usage, attr.span, "unknown crate attribute");
         }
+        if name.equiv(& &"link") {
+            cx.tcx.sess.span_err(attr.span,
+                                 "obsolete crate `link` attribute");
+            cx.tcx.sess.note("the link attribute has been superceded by the crate_id \
+                             attribute, which has the format `#[crate_id = \"name#version\"]`");
+        }
     }
 }
 

--- a/src/test/auxiliary/cci_impl_lib.rs
+++ b/src/test/auxiliary/cci_impl_lib.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="cci_impl_lib"];
-// NOTE: remove after the next snapshot
-#[link(name="cci_impl_lib", vers="0.0")];
 
 trait uint_helpers {
     fn to(&self, v: uint, f: |uint|);

--- a/src/test/auxiliary/cci_iter_lib.rs
+++ b/src/test/auxiliary/cci_iter_lib.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="cci_iter_lib"];
-// NOTE: remove after the next snapshot
-#[link(name="cci_iter_lib", vers="0.0")];
 
 #[inline]
 pub fn iter<T>(v: &[T], f: |&T|) {

--- a/src/test/auxiliary/cci_no_inline_lib.rs
+++ b/src/test/auxiliary/cci_no_inline_lib.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="cci_no_inline_lib"];
-// NOTE: remove after the next snapshot
-#[link(name="cci_no_inline_lib", vers="0.0")];
 
 // same as cci_iter_lib, more-or-less, but not marked inline
 pub fn iter(v: ~[uint], f: |uint|) {

--- a/src/test/auxiliary/crate-method-reexport-grrrrrrr2.rs
+++ b/src/test/auxiliary/crate-method-reexport-grrrrrrr2.rs
@@ -10,8 +10,6 @@
 
 #[feature(managed_boxes)];
 #[crate_id="crate_method_reexport_grrrrrrr2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crate_method_reexport_grrrrrrr2")];
 
 pub use name_pool::add;
 

--- a/src/test/auxiliary/crateresolve1-1.rs
+++ b/src/test/auxiliary/crateresolve1-1.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve1#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve1",
-       vers = "0.1")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve1-2.rs
+++ b/src/test/auxiliary/crateresolve1-2.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve1#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve1",
-       vers = "0.2")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve1-3.rs
+++ b/src/test/auxiliary/crateresolve1-3.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve1#0.3"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve1",
-       vers = "0.3")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve2-1.rs
+++ b/src/test/auxiliary/crateresolve2-1.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve2#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve2",
-       vers = "0.1")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve2-2.rs
+++ b/src/test/auxiliary/crateresolve2-2.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve2#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve2",
-       vers = "0.2")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve2-3.rs
+++ b/src/test/auxiliary/crateresolve2-3.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve2#0.3"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve2",
-       vers = "0.3")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve3-1.rs
+++ b/src/test/auxiliary/crateresolve3-1.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve3#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve3",
-       vers = "0.1")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve3-2.rs
+++ b/src/test/auxiliary/crateresolve3-2.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve3#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve3",
-       vers = "0.2")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve4a-1.rs
+++ b/src/test/auxiliary/crateresolve4a-1.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve4a#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve4a", vers = "0.1")];
 #[crate_type = "lib"];
 
 pub fn f() -> int { 10 }

--- a/src/test/auxiliary/crateresolve4a-2.rs
+++ b/src/test/auxiliary/crateresolve4a-2.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve4a#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve4a", vers= "0.2")];
 #[crate_type = "lib"];
 
 pub fn g() -> int { 20 }

--- a/src/test/auxiliary/crateresolve4b-1.rs
+++ b/src/test/auxiliary/crateresolve4b-1.rs
@@ -11,8 +11,6 @@
 // aux-build:crateresolve4a-1.rs
 // aux-build:crateresolve4a-2.rs
 #[crate_id="crateresolve4b#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve4b", vers = "0.1")];
 #[crate_type = "lib"];
 
 extern mod crateresolve4a = "crateresolve4a#0.2";

--- a/src/test/auxiliary/crateresolve4b-2.rs
+++ b/src/test/auxiliary/crateresolve4b-2.rs
@@ -11,8 +11,6 @@
 // aux-build:crateresolve4a-1.rs
 // aux-build:crateresolve4a-2.rs
 #[crate_id="crateresolve4b#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve4b", vers = "0.2")];
 #[crate_type = "lib"];
 
 extern mod crateresolve4a = "crateresolve4a#0.1";

--- a/src/test/auxiliary/crateresolve5-1.rs
+++ b/src/test/auxiliary/crateresolve5-1.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve5#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve5",
-       vers = "0.1")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve5-2.rs
+++ b/src/test/auxiliary/crateresolve5-2.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="crateresolve5#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve5",
-       vers = "0.2")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/crateresolve8-1.rs
+++ b/src/test/auxiliary/crateresolve8-1.rs
@@ -10,9 +10,6 @@
 
 // default link meta for 'package_id' will be equal to filestem
 #[crate_id="crateresolve8#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "crateresolve8",
-       vers = "0.1")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/extern-crosscrate-source.rs
+++ b/src/test/auxiliary/extern-crosscrate-source.rs
@@ -9,10 +9,6 @@
 // except according to those terms.
 
 #[crate_id="externcallback#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "externcallback",
-       vers = "0.1")];
-
 #[crate_type = "lib"];
 
 use std::libc;

--- a/src/test/auxiliary/foreign_lib.rs
+++ b/src/test/auxiliary/foreign_lib.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="foreign_lib"];
-// NOTE: remove after the next snapshot
-#[link(name="foreign_lib", vers="0.0")];
 
 pub mod rustrt {
     use std::libc;

--- a/src/test/auxiliary/inline_dtor.rs
+++ b/src/test/auxiliary/inline_dtor.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="inline_dtor#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name="inline_dtor", vers="0.1")];
 
 pub struct Foo;
 

--- a/src/test/auxiliary/iss.rs
+++ b/src/test/auxiliary/iss.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="issue6919_3#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name="iss6919_3", vers="0.1")];
 
 // part of issue-6919.rs
 

--- a/src/test/auxiliary/issue-2380.rs
+++ b/src/test/auxiliary/issue-2380.rs
@@ -10,8 +10,6 @@
 
 #[feature(managed_boxes)];
 #[crate_id="a"];
-// NOTE: remove after the next snapshot
-#[link(name = "a", vers = "0.0")];
 #[crate_type = "lib"];
 
 pub trait i<T> { }

--- a/src/test/auxiliary/issue-2414-a.rs
+++ b/src/test/auxiliary/issue-2414-a.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="a#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "a", vers = "0.1")];
 #[crate_type = "lib"];
 
 type t1 = uint;

--- a/src/test/auxiliary/issue-2414-b.rs
+++ b/src/test/auxiliary/issue-2414-b.rs
@@ -11,8 +11,6 @@
 // xfail-fast
 
 #[crate_id="b#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "b", vers = "0.1")];
 #[crate_type = "lib"];
 
 extern mod a;

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -9,10 +9,6 @@
 // except according to those terms.
 
 #[crate_id="issue_2526#0.2"];
-// NOTE: remove after the next snapshot
-#[link(name = "issue_2526",
-       vers = "0.2",
-       uuid = "54cc1bc9-02b8-447c-a227-75ebc923bc29")];
 #[crate_type = "lib"];
 
 extern mod extra;

--- a/src/test/auxiliary/issue-2631-a.rs
+++ b/src/test/auxiliary/issue-2631-a.rs
@@ -10,8 +10,6 @@
 
 #[feature(managed_boxes)];
 #[crate_id="req"];
-// NOTE: remove after the next snapshot
-#[link(name = "req")];
 #[crate_type = "lib"];
 
 extern mod extra;

--- a/src/test/auxiliary/issue-3012-1.rs
+++ b/src/test/auxiliary/issue-3012-1.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="socketlib"];
-// NOTE: remove after the next snapshot
-#[link(name="socketlib", vers="0.0")];
 #[crate_type = "lib"];
 
 pub mod socket {

--- a/src/test/auxiliary/issue-4208-cc.rs
+++ b/src/test/auxiliary/issue-4208-cc.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="numeric#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "numeric",
-       vers = "0.1")];
 #[crate_type = "lib"];
 
 pub trait Trig<T> {

--- a/src/test/auxiliary/issue2378a.rs
+++ b/src/test/auxiliary/issue2378a.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[link (name = "issue2378a")];
 #[crate_type = "lib"];
 
 pub enum maybe<T> { just(T), nothing }

--- a/src/test/auxiliary/issue2378b.rs
+++ b/src/test/auxiliary/issue2378b.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[link (name = "issue2378b")];
 #[crate_type = "lib"];
 
 extern mod issue2378a;

--- a/src/test/auxiliary/issue_2242_a.rs
+++ b/src/test/auxiliary/issue_2242_a.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="a#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "a", vers = "0.1")];
 #[crate_type = "lib"];
 
 trait to_strz {

--- a/src/test/auxiliary/issue_2242_c.rs
+++ b/src/test/auxiliary/issue_2242_c.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="c#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "c", vers = "0.1")];
 #[crate_type = "lib"];
 
 extern mod a;

--- a/src/test/auxiliary/issue_3979_traits.rs
+++ b/src/test/auxiliary/issue_3979_traits.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="issue_3979_traits#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "issue_3979_traits",
-       vers = "0.1")];
 
 #[crate_type = "lib"];
 

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #[crate_id="lint_stability#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "lint_stability",
-       vers = "0.1")];
 #[crate_type = "lib"];
 
 #[deprecated]

--- a/src/test/auxiliary/static-methods-crate.rs
+++ b/src/test/auxiliary/static-methods-crate.rs
@@ -9,10 +9,6 @@
 // except according to those terms.
 
 #[crate_id="static_methods_crate#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "static_methods_crate",
-       vers = "0.1")];
-
 #[crate_type = "lib"];
 
 use std::int;

--- a/src/test/auxiliary/struct_variant_xc_aux.rs
+++ b/src/test/auxiliary/struct_variant_xc_aux.rs
@@ -9,9 +9,6 @@
 // except according to those terms.
 
 #[crate_id="struct_variant_xc_aux#0.1"];
-// NOTE: remove after the next snapshot
-#[link(name = "struct_variant_xc_aux",
-       vers = "0.1")];
 #[crate_type = "lib"];
 
 #[feature(struct_variant)];

--- a/src/test/run-pass/issue-1251.rs
+++ b/src/test/run-pass/issue-1251.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 #[crate_id="rust_get_test_int"];
-// NOTE: remove after the next snapshot
-#[link(name = "rust_get_test_int")];
 
 mod rustrt {
     use std::libc;

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -17,12 +17,6 @@
 #[attr4(attr5)];
 
 #[crate_id="extra#0.1"];
-// NOTE: remove after the next snapshot
-// Special linkage attributes for the crate
-#[link(name = "extra",
-       vers = "0.1",
-       uuid = "122bed0b-c19b-4b82-b0b7-7ae8aead7297",
-       url = "http://rust-lang.org/src/extra")];
 
 // These are attributes of the following mod
 #[attr1 = "val"]


### PR DESCRIPTION
This is set to _forbid_ and prints a note explaining how to fix the problem.
