### PR TITLE
change result::collect to take an iterator, and adds option::collect

### DIFF
--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -117,7 +117,6 @@ mod test {
     use prelude::*;
     use super::*;
     use io;
-    use comm;
     use task;
 
     #[test]
@@ -136,7 +135,7 @@ mod test {
 
         assert_eq!(false, reader.eof());
 
-        assert_eq!(Some(0), reader.read(~[]));
+        assert_eq!(Some(0), reader.read([]));
         assert_eq!(false, reader.eof());
 
         assert_eq!(Some(3), reader.read(buf));


### PR DESCRIPTION
This patch changes `result::collect` (and adds a new `option::collect`) from creating a `~[T]` to take an `Iterator`. This makes the function much more flexible, and may replace the need for #10989.

This patch is a little more complicated than it needs to be because of #11084. Once that is fixed we can replace the `CollectIterator` with a `Scan` iterator.

It also fixes a test warning.
