### PR TITLE
Guarantee comm primitives are not Freeze

### DIFF
--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -292,6 +292,7 @@ impl<T: Send> Consumer<T>{
 
 /// The receiving-half of Rust's channel type. This half can only be owned by
 /// one task
+#[no_freeze] // can't share ports in an arc
 pub struct Port<T> {
     priv queue: Consumer<T>,
 }
@@ -305,12 +306,15 @@ pub struct PortIterator<'a, T> {
 
 /// The sending-half of Rust's channel type. This half can only be owned by one
 /// task
+#[no_freeze] // can't share chans in an arc
 pub struct Chan<T> {
     priv queue: spsc::Producer<T, Packet>,
 }
 
 /// The sending-half of Rust's channel type. This half can be shared among many
 /// tasks by creating copies of itself through the `clone` method.
+#[no_freeze] // technically this implementation is shareable, but it shouldn't
+             // be required to be shareable in an arc
 pub struct SharedChan<T> {
     priv queue: mpsc::Producer<T, Packet>,
 }

--- a/src/test/compile-fail/comm-not-freeze.rs
+++ b/src/test/compile-fail/comm-not-freeze.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn test<T: Freeze>() {}
+
+fn main() {
+    test::<Chan<int>>();        //~ ERROR: does not fulfill `Freeze`
+    test::<Port<int>>();        //~ ERROR: does not fulfill `Freeze`
+    test::<SharedChan<int>>();  //~ ERROR: does not fulfill `Freeze`
+}


### PR DESCRIPTION
None of these primitives should be Freeze because sharing them in an Arc is a
very bad idea.

Closes #11039
