### PR TITLE
Add a lint for lets/matches which won't do anything

### DIFF
--- a/src/test/compile-fail/lint-irrefutable-match-without-binding.rs
+++ b/src/test/compile-fail/lint-irrefutable-match-without-binding.rs
@@ -1,0 +1,50 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deny(irrefutable_match_without_binding)];
+#[allow(unused_variable)];
+
+fn main() {
+    let a = 8;
+    let _ = a; //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+    let _ = 99; //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+    let (_, _) = (1, 2); //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+    let ((_, _), ()) = (((), ()), ()); //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+    let () = (); //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+    match 23 { //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+        _ => { }
+    }
+    match (1, 2) { //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+        (_, _) => { }
+    }
+    match false { //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+        false|true => { }
+    }
+    match [1, 2] { //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+        [..] => { }
+    }
+    match [1, 2] { //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+        [_, _] => { }
+    }
+    match ~666 { //~ ERROR: irrefutable let or match without any bindings (equivalent to inner expression)
+        ~_ => { }
+    }
+
+    match false { // okay: more than one arm
+        false => { },
+        _ => { }
+    }
+    match [1, 2] {
+        [..v] => { }
+    }
+    let ((_, (_, a)), ()) = ((1, (2, 3)), ()); // okay: has a binding
+    let ((_, (_, ref a)), ()) = ((1, (2, 3)), ()); // okay: has a binding
+    let ~ref x = ~789;
+}


### PR DESCRIPTION
in other words irrefutable ones without any bindings. This will be useful once the semantics of `_` in patterns changes to "ignore" instead of "drop" (#10488). Closes #11088.

For now it defaults to "allow", so I don't think there's any harm in this going in before #10488 itself, but please **DON'T** r+ this unless you're in a position to decide (or it has been decided).

If I run the tests with it set to "deny", things break in all of the expected places, with the exception that `deriving` code for unit structs also appears to trigger it. That should presumably be fixed before it gets changed to something other than "allow" (along with of course the expected failures).
