### PR TITLE
Rename foo_opt to foo and drop the old foo behavior

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -159,10 +159,10 @@ fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {
         let mut strs: ~[~str] = nv.splitn('=', 1).map(|s| s.to_owned()).collect();
 
         match strs.len() {
-          1u => (strs.pop(), ~""),
+          1u => (strs.pop().unwrap(), ~""),
           2u => {
-              let end = strs.pop();
-              (strs.pop(), end)
+              let end = strs.pop().unwrap();
+              (strs.pop().unwrap(), end)
           }
           n => fail!("Expected 1 or 2 strings, not {}", n)
         }

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -66,8 +66,8 @@ pub fn run(lib_path: &str,
 
             Some(Result {
                 status: status,
-                out: str::from_utf8_owned(output),
-                err: str::from_utf8_owned(error)
+                out: str::from_utf8_owned(output).unwrap(),
+                err: str::from_utf8_owned(error).unwrap()
             })
         },
         None => None

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -788,7 +788,7 @@ fn make_run_args(config: &config, _props: &TestProps, testfile: &Path) ->
     let exe_file = make_exe_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
     args.push(exe_file.as_str().unwrap().to_owned());
-    let prog = args.shift();
+    let prog = args.shift().unwrap();
     return ProcArgs {prog: prog, args: args};
 }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -917,7 +917,7 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
 
     // get bare program string
     let mut tvec: ~[~str] = args.prog.split('/').map(|ts| ts.to_owned()).collect();
-    let prog_short = tvec.pop();
+    let prog_short = tvec.pop().unwrap();
 
     // copy to target
     let copy_result = procsrv::run("", config.adb_path,

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -308,7 +308,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
 
             let adb_arg = format!("export LD_LIBRARY_PATH={}; gdbserver :5039 {}/{}",
                                   config.adb_test_dir.clone(), config.adb_test_dir.clone(),
-                                  str::from_utf8(exe_file.filename().unwrap()));
+                                  str::from_utf8(exe_file.filename().unwrap()).unwrap());
 
             let mut process = procsrv::run_background("", config.adb_path,
                                                       [~"shell",adb_arg.clone()],

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -154,7 +154,7 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
         match props.pp_exact { Some(_) => 1, None => 2 };
 
     let src = File::open(testfile).read_to_end();
-    let src = str::from_utf8_owned(src);
+    let src = str::from_utf8_owned(src).unwrap();
     let mut srcs = ~[src];
 
     let mut round = 0;
@@ -176,7 +176,7 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
         Some(ref file) => {
             let filepath = testfile.dir_path().join(file);
             let s = File::open(&filepath).read_to_end();
-            str::from_utf8_owned(s)
+            str::from_utf8_owned(s).unwrap()
           }
           None => { srcs[srcs.len() - 2u].clone() }
         };
@@ -1100,7 +1100,7 @@ fn disassemble_extract(config: &config, _props: &TestProps,
 
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end();
-    let x = str::from_utf8_owned(x);
+    let x = str::from_utf8_owned(x).unwrap();
     x.lines().len()
 }
 

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -198,7 +198,7 @@ impl<'a> FromBase64 for &'a str {
      *     println!("base64 output: {}", hello_str);
      *     let res = hello_str.from_base64();
      *     if res.is_ok() {
-     *       let optBytes = str::from_utf8_owned_opt(res.unwrap());
+     *       let optBytes = str::from_utf8_owned(res.unwrap());
      *       if optBytes.is_some() {
      *         println!("decoded from base64: {}", optBytes.unwrap());
      *       }

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -1049,7 +1049,7 @@ mod tests {
             match r % 6 {
                 0 => {
                     m.pop_back();
-                    if v.len() > 0 { v.pop(); }
+                    v.pop();
                 }
                 1 => {
                     m.pop_front();

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -1053,7 +1053,7 @@ mod tests {
                 }
                 1 => {
                     m.pop_front();
-                    if v.len() > 0 { v.shift(); }
+                    v.shift();
                 }
                 2 | 4 =>  {
                     m.push_front(-i);

--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -651,7 +651,7 @@ pub mod writer {
         }
 
         pub fn end_tag(&mut self) {
-            let last_size_pos = self.size_positions.pop();
+            let last_size_pos = self.size_positions.pop().unwrap();
             let cur_pos = self.writer.tell();
             self.writer.seek(last_size_pos as i64, io::SeekSet);
             let size = (cur_pos as uint - last_size_pos - 4);

--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -30,7 +30,7 @@ impl<'doc> Doc<'doc> {
     }
 
     pub fn as_str_slice<'a>(&'a self) -> &'a str {
-        str::from_utf8(self.data.slice(self.start, self.end))
+        str::from_utf8(self.data.slice(self.start, self.end)).unwrap()
     }
 
     pub fn as_str(&self) -> ~str {

--- a/src/libextra/glob.rs
+++ b/src/libextra/glob.rs
@@ -122,7 +122,7 @@ impl Iterator<Path> for Paths {
                 return None;
             }
 
-            let (path,idx) = self.todo.pop();
+            let (path,idx) = self.todo.pop().unwrap();
             let ref pattern = self.dir_patterns[idx];
 
             if pattern.matches_with(match path.filename_str() {

--- a/src/libextra/hex.rs
+++ b/src/libextra/hex.rs
@@ -96,7 +96,7 @@ impl<'a> FromHex for &'a str {
      *     println!("{}", hello_str);
      *     let bytes = hello_str.from_hex().unwrap();
      *     println!("{:?}", bytes);
-     *     let result_str = str::from_utf8_owned(bytes);
+     *     let result_str = str::from_utf8_owned(bytes).unwrap();
      *     println!("{}", result_str);
      * }
      * ```

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -1028,7 +1028,7 @@ impl<T : Iterator<char>> Parser<T> {
         while !self.eof() {
             self.parse_whitespace();
 
-            if self.ch != '\"' {
+            if self.ch != '"' {
                 return self.error(~"key must be a string");
             }
 
@@ -1117,7 +1117,7 @@ impl Decoder {
 impl serialize::Decoder for Decoder {
     fn read_nil(&mut self) -> () {
         debug!("read_nil");
-        match self.stack.pop() {
+        match self.stack.pop().unwrap() {
             Null => (),
             value => self.expected("null", &value)
         }
@@ -1137,7 +1137,7 @@ impl serialize::Decoder for Decoder {
 
     fn read_bool(&mut self) -> bool {
         debug!("read_bool");
-        match self.stack.pop() {
+        match self.stack.pop().unwrap() {
             Boolean(b) => b,
             value => self.expected("boolean", &value)
         }
@@ -1145,7 +1145,7 @@ impl serialize::Decoder for Decoder {
 
     fn read_f64(&mut self) -> f64 {
         debug!("read_f64");
-        match self.stack.pop() {
+        match self.stack.pop().unwrap() {
             Number(f) => f,
             value => self.expected("number", &value)
         }
@@ -1168,7 +1168,7 @@ impl serialize::Decoder for Decoder {
 
     fn read_str(&mut self) -> ~str {
         debug!("read_str");
-        match self.stack.pop() {
+        match self.stack.pop().unwrap() {
             String(s) => s,
             value => self.expected("string", &value)
         }
@@ -1184,7 +1184,7 @@ impl serialize::Decoder for Decoder {
                             f: |&mut Decoder, uint| -> T)
                             -> T {
         debug!("read_enum_variant(names={:?})", names);
-        let name = match self.stack.pop() {
+        let name = match self.stack.pop().unwrap() {
             String(s) => s,
             Object(mut o) => {
                 let n = match o.pop(&~"variant") {
@@ -1249,7 +1249,7 @@ impl serialize::Decoder for Decoder {
                       -> T {
         debug!("read_struct(name={}, len={})", name, len);
         let value = f(self);
-        self.stack.pop();
+        self.stack.pop().unwrap();
         value
     }
 
@@ -1259,7 +1259,7 @@ impl serialize::Decoder for Decoder {
                             f: |&mut Decoder| -> T)
                             -> T {
         debug!("read_struct_field(name={}, idx={})", name, idx);
-        match self.stack.pop() {
+        match self.stack.pop().unwrap() {
             Object(mut obj) => {
                 let value = match obj.pop(&name.to_owned()) {
                     None => self.missing_field(name, obj),
@@ -1302,7 +1302,7 @@ impl serialize::Decoder for Decoder {
     }
 
     fn read_option<T>(&mut self, f: |&mut Decoder, bool| -> T) -> T {
-        match self.stack.pop() {
+        match self.stack.pop().unwrap() {
             Null => f(self, false),
             value => { self.stack.push(value); f(self, true) }
         }
@@ -1310,7 +1310,7 @@ impl serialize::Decoder for Decoder {
 
     fn read_seq<T>(&mut self, f: |&mut Decoder, uint| -> T) -> T {
         debug!("read_seq()");
-        let len = match self.stack.pop() {
+        let len = match self.stack.pop().unwrap() {
             List(list) => {
                 let len = list.len();
                 for v in list.move_rev_iter() {
@@ -1330,7 +1330,7 @@ impl serialize::Decoder for Decoder {
 
     fn read_map<T>(&mut self, f: |&mut Decoder, uint| -> T) -> T {
         debug!("read_map()");
-        let len = match self.stack.pop() {
+        let len = match self.stack.pop().unwrap() {
             Object(obj) => {
                 let len = obj.len();
                 for (key, value) in obj.move_iter() {

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -312,7 +312,7 @@ impl<'a> Encoder<'a> {
     /// Encode the specified struct into a json str
     pub fn str_encode<T:Encodable<Encoder<'a>>>(to_encode_object: &T) -> ~str  {
         let buff:~[u8] = Encoder::buffer_encode(to_encode_object);
-        str::from_utf8_owned(buff)
+        str::from_utf8_owned(buff).unwrap()
     }
 }
 
@@ -684,7 +684,7 @@ impl Json{
     pub fn to_pretty_str(&self) -> ~str {
         let mut s = MemWriter::new();
         self.to_pretty_writer(&mut s as &mut io::Writer);
-        str::from_utf8_owned(s.unwrap())
+        str::from_utf8_owned(s.unwrap()).unwrap()
     }
 }
 
@@ -1067,7 +1067,7 @@ impl<T : Iterator<char>> Parser<T> {
 
 /// Decodes a json value from an `&mut io::Reader`
 pub fn from_reader(rdr: &mut io::Reader) -> Result<Json, Error> {
-    let s = str::from_utf8_owned(rdr.read_to_end());
+    let s = str::from_utf8_owned(rdr.read_to_end()).unwrap();
     let mut parser = Parser::new(s.chars());
     parser.parse()
 }
@@ -1541,7 +1541,7 @@ impl to_str::ToStr for Json {
     fn to_str(&self) -> ~str {
         let mut s = MemWriter::new();
         self.to_writer(&mut s as &mut io::Writer);
-        str::from_utf8_owned(s.unwrap())
+        str::from_utf8_owned(s.unwrap()).unwrap()
     }
 }
 
@@ -1732,7 +1732,7 @@ mod tests {
 
         let mut m = MemWriter::new();
         f(&mut m as &mut io::Writer);
-        str::from_utf8_owned(m.unwrap())
+        str::from_utf8_owned(m.unwrap()).unwrap()
     }
 
     #[test]

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -385,7 +385,7 @@ impl Integer for BigUint {
         }
 
         let mut shift = 0;
-        let mut n = *other.data.last();
+        let mut n = *other.data.last().unwrap();
         while n < (1 << BigDigit::bits - 2) {
             n <<= 1;
             shift += 1;
@@ -434,7 +434,7 @@ impl Integer for BigUint {
             }
 
             let an = a.data.slice(a.data.len() - n, a.data.len());
-            let bn = *b.data.last();
+            let bn = *b.data.last().unwrap();
             let mut d = ~[];
             let mut carry = 0;
             for elt in an.rev_iter() {
@@ -798,7 +798,7 @@ impl BigUint {
     /// Determines the fewest bits necessary to express the `BigUint`.
     pub fn bits(&self) -> uint {
         if self.is_zero() { return 0; }
-        let zeros = self.data.last().leading_zeros();
+        let zeros = self.data.last().unwrap().leading_zeros();
         return self.data.len()*BigDigit::bits - (zeros as uint);
     }
 }

--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -234,7 +234,7 @@ mod tests {
         sorted.sort();
         let mut heap = PriorityQueue::from_vec(data);
         while !heap.is_empty() {
-            assert_eq!(heap.top(), sorted.last());
+            assert_eq!(heap.top(), sorted.last().unwrap());
             assert_eq!(heap.pop(), sorted.pop());
         }
     }

--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -59,7 +59,7 @@ impl<T:Ord> PriorityQueue<T> {
 
     /// Pop the greatest item from the queue - fails if empty
     pub fn pop(&mut self) -> T {
-        let mut item = self.data.pop();
+        let mut item = self.data.pop().unwrap();
         if !self.is_empty() {
             swap(&mut item, &mut self.data[0]);
             self.siftdown(0);
@@ -235,7 +235,7 @@ mod tests {
         let mut heap = PriorityQueue::from_vec(data);
         while !heap.is_empty() {
             assert_eq!(heap.top(), sorted.last().unwrap());
-            assert_eq!(heap.pop(), sorted.pop());
+            assert_eq!(heap.pop(), sorted.pop().unwrap());
         }
     }
 

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -1001,7 +1001,7 @@ mod tests {
             use std::io::MemWriter;
             let mut m = MemWriter::new();
             write_boxplot(&mut m as &mut io::Writer, s, 30);
-            let out = str::from_utf8_owned(m.unwrap());
+            let out = str::from_utf8_owned(m.unwrap()).unwrap();
             assert_eq!(out, expected);
         }
 

--- a/src/libextra/terminfo/parm.rs
+++ b/src/libextra/terminfo/parm.rs
@@ -121,7 +121,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 match cur {
                     '%' => { output.push(c); state = Nothing },
                     'c' => if stack.len() > 0 {
-                        match stack.pop() {
+                        match stack.pop().unwrap() {
                             // if c is 0, use 0200 (128) for ncurses compatibility
                             Number(c) => output.push(if c == 0 { 128 } else { c } as u8),
                             _       => return Err(~"a non-char was used with %c")
@@ -133,82 +133,82 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     '\'' => state = CharConstant,
                     '{' => state = IntConstant(0),
                     'l' => if stack.len() > 0 {
-                        match stack.pop() {
+                        match stack.pop().unwrap() {
                             String(s) => stack.push(Number(s.len() as int)),
                             _         => return Err(~"a non-str was used with %l")
                         }
                     } else { return Err(~"stack is empty") },
                     '+' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x + y)),
                             _ => return Err(~"non-numbers on stack with +")
                         }
                     } else { return Err(~"stack is empty") },
                     '-' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x - y)),
                             _ => return Err(~"non-numbers on stack with -")
                         }
                     } else { return Err(~"stack is empty") },
                     '*' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x * y)),
                             _ => return Err(~"non-numbers on stack with *")
                         }
                     } else { return Err(~"stack is empty") },
                     '/' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x / y)),
                             _ => return Err(~"non-numbers on stack with /")
                         }
                     } else { return Err(~"stack is empty") },
                     'm' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x % y)),
                             _ => return Err(~"non-numbers on stack with %")
                         }
                     } else { return Err(~"stack is empty") },
                     '&' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x & y)),
                             _ => return Err(~"non-numbers on stack with &")
                         }
                     } else { return Err(~"stack is empty") },
                     '|' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x | y)),
                             _ => return Err(~"non-numbers on stack with |")
                         }
                     } else { return Err(~"stack is empty") },
                     '^' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(x ^ y)),
                             _ => return Err(~"non-numbers on stack with ^")
                         }
                     } else { return Err(~"stack is empty") },
                     '=' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(if x == y { 1 }
                                                                         else { 0 })),
                             _ => return Err(~"non-numbers on stack with =")
                         }
                     } else { return Err(~"stack is empty") },
                     '>' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(if x > y { 1 }
                                                                         else { 0 })),
                             _ => return Err(~"non-numbers on stack with >")
                         }
                     } else { return Err(~"stack is empty") },
                     '<' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(y), Number(x)) => stack.push(Number(if x < y { 1 }
                                                                         else { 0 })),
                             _ => return Err(~"non-numbers on stack with <")
                         }
                     } else { return Err(~"stack is empty") },
                     'A' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(0), Number(_)) => stack.push(Number(0)),
                             (Number(_), Number(0)) => stack.push(Number(0)),
                             (Number(_), Number(_)) => stack.push(Number(1)),
@@ -216,21 +216,21 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         }
                     } else { return Err(~"stack is empty") },
                     'O' => if stack.len() > 1 {
-                        match (stack.pop(), stack.pop()) {
+                        match (stack.pop().unwrap(), stack.pop().unwrap()) {
                             (Number(0), Number(0)) => stack.push(Number(0)),
                             (Number(_), Number(_)) => stack.push(Number(1)),
                             _ => return Err(~"non-numbers on stack with logical or")
                         }
                     } else { return Err(~"stack is empty") },
                     '!' => if stack.len() > 0 {
-                        match stack.pop() {
+                        match stack.pop().unwrap() {
                             Number(0) => stack.push(Number(1)),
                             Number(_) => stack.push(Number(0)),
                             _ => return Err(~"non-number on stack with logical not")
                         }
                     } else { return Err(~"stack is empty") },
                     '~' => if stack.len() > 0 {
-                        match stack.pop() {
+                        match stack.pop().unwrap() {
                             Number(x) => stack.push(Number(!x)),
                             _         => return Err(~"non-number on stack with %~")
                         }
@@ -246,7 +246,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     // printf-style support for %doxXs
                     'd'|'o'|'x'|'X'|'s' => if stack.len() > 0 {
                         let flags = Flags::new();
-                        let res = format(stack.pop(), FormatOp::from_char(cur), flags);
+                        let res = format(stack.pop().unwrap(), FormatOp::from_char(cur), flags);
                         if res.is_err() { return res }
                         output.push_all(res.unwrap())
                     } else { return Err(~"stack is empty") },
@@ -270,7 +270,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     // conditionals
                     '?' => (),
                     't' => if stack.len() > 0 {
-                        match stack.pop() {
+                        match stack.pop().unwrap() {
                             Number(0) => state = SeekIfElse(0),
                             Number(_) => (),
                             _         => return Err(~"non-number on stack with conditional")
@@ -293,12 +293,12 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 if cur >= 'A' && cur <= 'Z' {
                     if stack.len() > 0 {
                         let idx = (cur as u8) - ('A' as u8);
-                        vars.sta[idx] = stack.pop();
+                        vars.sta[idx] = stack.pop().unwrap();
                     } else { return Err(~"stack is empty") }
                 } else if cur >= 'a' && cur <= 'z' {
                     if stack.len() > 0 {
                         let idx = (cur as u8) - ('a' as u8);
-                        vars.dyn[idx] = stack.pop();
+                        vars.dyn[idx] = stack.pop().unwrap();
                     } else { return Err(~"stack is empty") }
                 } else {
                     return Err(~"bad variable name in %P");
@@ -341,7 +341,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 old_state = Nothing;
                 match (*fstate, cur) {
                     (_,'d')|(_,'o')|(_,'x')|(_,'X')|(_,'s') => if stack.len() > 0 {
-                        let res = format(stack.pop(), FormatOp::from_char(cur), *flags);
+                        let res = format(stack.pop().unwrap(), FormatOp::from_char(cur), *flags);
                         if res.is_err() { return res }
                         output.push_all(res.unwrap());
                         old_state = state; // will cause state to go to Nothing

--- a/src/libextra/terminfo/parser/compiled.rs
+++ b/src/libextra/terminfo/parser/compiled.rs
@@ -216,7 +216,7 @@ pub fn parse(file: &mut io::Reader,
     }
 
     // don't read NUL
-    let names_str = str::from_utf8_owned(file.read_bytes(names_bytes as uint - 1));
+    let names_str = str::from_utf8_owned(file.read_bytes(names_bytes as uint - 1)).unwrap();
 
     let term_names: ~[~str] = names_str.split('|').map(|s| s.to_owned()).collect();
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -704,7 +704,7 @@ fn should_sort_failures_before_printing_them() {
 
     st.write_failures();
     let s = match st.out {
-        Raw(ref m) => str::from_utf8(m.get_ref()),
+        Raw(ref m) => str::from_utf8(m.get_ref()).unwrap(),
         Pretty(_) => unreachable!()
     };
 

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -753,7 +753,7 @@ fn run_tests(opts: &TestOpts,
 
     while pending > 0 || !remaining.is_empty() {
         while pending < concurrency && !remaining.is_empty() {
-            let test = remaining.pop();
+            let test = remaining.pop().unwrap();
             if concurrency == 1 {
                 // We are doing one test at a time so we can print the name
                 // of the test before we run it. Useful for debugging tests

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -1030,7 +1030,7 @@ pub fn strftime(format: &str, tm: &Tm) -> ~str {
         }
     }
 
-    str::from_utf8_owned(buf)
+    str::from_utf8_owned(buf).unwrap()
 }
 
 #[cfg(test)]

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -1164,7 +1164,7 @@ mod test_treemap {
 
             30.times(|| {
                 let r = rng.gen_range(0, ctrl.len());
-                let (key, _) = ctrl.remove(r);
+                let (key, _) = ctrl.remove(r).unwrap();
                 assert!(map.remove(&key));
                 check_structure(&map);
                 check_equal(ctrl, &map);

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -359,7 +359,7 @@ macro_rules! define_iterator {
                         }
                         self.stack.push(node);
                     } else {
-                        let node = self.stack.pop();
+                        let node = self.stack.pop().unwrap();
                         let next_node = if forward {
                             addr!(& $($addr_mut)* node.right)
                         } else {
@@ -496,7 +496,7 @@ impl<K, V> Iterator<(K, V)> for MoveEntries<K,V> {
                 left: left,
                 right: right,
                 level: level
-            } = self.stack.pop();
+            } = self.stack.pop().unwrap();
 
             match left {
                 Some(~left) => {

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -313,7 +313,7 @@ impl Uuid {
             s[i*2+0] = digit[0];
             s[i*2+1] = digit[1];
         }
-        str::from_utf8_owned(s)
+        str::from_utf8_owned(s).unwrap()
     }
 
     /// Returns a string of hexadecimal digits, separated into groups with a hyphen.

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -243,7 +243,7 @@ fn json_encode<'a, T:Encodable<json::Encoder<'a>>>(t: &T) -> ~str {
     let mut writer = MemWriter::new();
     let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
     t.encode(&mut encoder);
-    str::from_utf8_owned(writer.unwrap())
+    str::from_utf8_owned(writer.unwrap()).unwrap()
 }
 
 // FIXME(#5121)
@@ -491,7 +491,7 @@ fn test() {
         let subcx = cx.clone();
         let pth = pth.clone();
 
-        let file_content = from_utf8_owned(File::open(&pth).read_to_end());
+        let file_content = from_utf8_owned(File::open(&pth).read_to_end()).unwrap();
 
         // FIXME (#9639): This needs to handle non-utf8 paths
         prep.declare_input("file", pth.as_str().unwrap(), file_content);

--- a/src/libgreen/basic.rs
+++ b/src/libgreen/basic.rs
@@ -84,7 +84,7 @@ impl BasicLoop {
             }
             RemoveRemote(i) => {
                 match self.remotes.iter().position(|&(id, _)| id == i) {
-                    Some(i) => { self.remotes.remove(i); }
+                    Some(i) => { self.remotes.remove(i).unwrap(); }
                     None => unreachable!()
                 }
             }

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -1285,8 +1285,11 @@ mod test {
                 ports.push(port);
             });
 
-            while !ports.is_empty() {
-                ports.pop().recv();
+            loop {
+                match ports.pop() {
+                    Some(port) => port.recv(),
+                    None => break,
+                }
             }
         }
     }

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -57,8 +57,8 @@ fn run_ar(sess: Session, args: &str, cwd: Option<&Path>,
             if !o.status.success() {
                 sess.err(format!("{} {} failed with: {}", ar, args.connect(" "),
                                  o.status));
-                sess.note(format!("stdout ---\n{}", str::from_utf8(o.output)));
-                sess.note(format!("stderr ---\n{}", str::from_utf8(o.error)));
+                sess.note(format!("stdout ---\n{}", str::from_utf8(o.output).unwrap()));
+                sess.note(format!("stderr ---\n{}", str::from_utf8(o.error).unwrap()));
                 sess.abort_if_errors();
             }
             o
@@ -141,7 +141,7 @@ impl Archive {
     /// Lists all files in an archive
     pub fn files(&self) -> ~[~str] {
         let output = run_ar(self.sess, "t", None, [&self.dst]);
-        str::from_utf8(output.output).lines().map(|s| s.to_owned()).collect()
+        str::from_utf8(output.output).unwrap().lines().map(|s| s.to_owned()).collect()
     }
 
     fn add_archive(&mut self, archive: &Path, name: &str, skip: &[&str]) {

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -298,7 +298,7 @@ pub mod write {
                 if !prog.status.success() {
                     sess.err(format!("linking with `{}` failed: {}", cc, prog.status));
                     sess.note(format!("{} arguments: '{}'", cc, args.connect("' '")));
-                    sess.note(str::from_utf8_owned(prog.error + prog.output));
+                    sess.note(str::from_utf8_owned(prog.error + prog.output).unwrap());
                     sess.abort_if_errors();
                 }
             },
@@ -1007,7 +1007,7 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
             if !prog.status.success() {
                 sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
                 sess.note(format!("{} arguments: '{}'", cc_prog, cc_args.connect("' '")));
-                sess.note(str::from_utf8_owned(prog.error + prog.output));
+                sess.note(str::from_utf8_owned(prog.error + prog.output).unwrap());
                 sess.abort_if_errors();
             }
         },

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -179,17 +179,17 @@ impl Visitor<()> for Context {
     fn visit_mac(&mut self, macro: &ast::Mac, _: ()) {
         let ast::MacInvocTT(ref path, _, _) = macro.node;
 
-        if path.segments.last().identifier == self.sess.ident_of("macro_rules") {
+        if path.segments.last().unwrap().identifier == self.sess.ident_of("macro_rules") {
             self.gate_feature("macro_rules", path.span, "macro definitions are \
                 not stable enough for use and are subject to change");
         }
 
-        else if path.segments.last().identifier == self.sess.ident_of("asm") {
+        else if path.segments.last().unwrap().identifier == self.sess.ident_of("asm") {
             self.gate_feature("asm", path.span, "inline assembly is not \
                 stable enough for use and is subject to change");
         }
 
-        else if path.segments.last().identifier == self.sess.ident_of("log_syntax") {
+        else if path.segments.last().unwrap().identifier == self.sess.ident_of("log_syntax") {
             self.gate_feature("log_syntax", path.span, "`log_syntax!` is not \
                 stable enough for use and is subject to change");
         }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -190,7 +190,7 @@ pub fn describe_debug_flags() {
 
 pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
     let mut args = args.to_owned();
-    let binary = args.shift();
+    let binary = args.shift().unwrap();
 
     if args.is_empty() { usage(binary); return; }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -234,7 +234,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
       1u => {
         let ifile = matches.free[0].as_slice();
         if "-" == ifile {
-            let src = str::from_utf8_owned(io::stdin().read_to_end());
+            let src = str::from_utf8_owned(io::stdin().read_to_end()).unwrap();
             d::StrInput(src.to_managed())
         } else {
             d::FileInput(Path::new(ifile))

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1989,5 +1989,5 @@ pub fn encoded_ty(tcx: ty::ctxt, t: ty::t) -> ~str {
         abbrevs: tyencode::ac_no_abbrevs};
     let mut wr = MemWriter::new();
     tyencode::enc_ty(&mut wr, cx, t);
-    str::from_utf8_owned(wr.get_ref().to_owned())
+    str::from_utf8_owned(wr.get_ref().to_owned()).unwrap()
 }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -97,7 +97,7 @@ pub fn parse_ident(st: &mut PState, last: char) -> ast::Ident {
 
 fn parse_ident_(st: &mut PState, is_last: |char| -> bool) -> ast::Ident {
     scan(st, is_last, |bytes| {
-            st.tcx.sess.ident_of(str::from_utf8(bytes))
+            st.tcx.sess.ident_of(str::from_utf8(bytes).unwrap())
         })
 }
 
@@ -476,7 +476,7 @@ fn parse_abi_set(st: &mut PState) -> AbiSet {
     let mut abis = AbiSet::empty();
     while peek(st) != ']' {
          scan(st, |c| c == ',', |bytes| {
-                 let abi_str = str::from_utf8(bytes).to_owned();
+                 let abi_str = str::from_utf8(bytes).unwrap().to_owned();
                  let abi = abi::lookup(abi_str).expect(abi_str);
                  abis.add(abi);
               });

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -72,7 +72,7 @@ pub fn enc_ty(w: &mut MemWriter, cx: @ctxt, t: ty::t) {
             None => {
                 let wr = &mut MemWriter::new();
                 enc_sty(wr, cx, &ty::get(t).sty);
-                let s = str::from_utf8(wr.get_ref()).to_managed();
+                let s = str::from_utf8(wr.get_ref()).unwrap().to_managed();
                 let mut short_names_cache = cx.tcx
                                               .short_names_cache
                                               .borrow_mut();

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -445,7 +445,7 @@ impl<'a> GatherLoanCtxt<'a> {
             return;
         }
 
-        let root_ub = { *self.repeating_ids.last() }; // FIXME(#5074)
+        let root_ub = { *self.repeating_ids.last().unwrap() }; // FIXME(#5074)
 
         // Check that the lifetime of the borrow does not exceed
         // the lifetime of the data being borrowed.

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -339,7 +339,7 @@ impl<'a> GatherLoanCtxt<'a> {
     }
 
     pub fn pop_repeating_id(&mut self, id: ast::NodeId) {
-        let popped = self.repeating_ids.pop();
+        let popped = self.repeating_ids.pop().unwrap();
         assert_eq!(id, popped);
     }
 

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -495,7 +495,7 @@ impl CFGBuilder {
                   label: Option<ast::Name>) -> LoopScope {
         match label {
             None => {
-                return *self.loop_scopes.last();
+                return *self.loop_scopes.last().unwrap();
             }
 
             Some(_) => {

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -504,7 +504,7 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
 
                     // add the bits from any early return via `break`,
                     // `continue`, or `return` into `func_bits`
-                    let loop_scope = loop_scopes.pop();
+                    let loop_scope = loop_scopes.pop().unwrap();
                     join_bits(&self.dfcx.oper, loop_scope.break_bits, func_bits);
 
                     // add `func_bits` to the entry bits for `expr`,
@@ -563,7 +563,7 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
                 });
                 self.walk_block(blk, body_bits, loop_scopes);
                 self.add_to_entry_set(expr.id, body_bits);
-                let new_loop_scope = loop_scopes.pop();
+                let new_loop_scope = loop_scopes.pop().unwrap();
                 copy_bits(new_loop_scope.break_bits, in_out);
             }
 
@@ -588,7 +588,7 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
                 self.walk_block(blk, body_bits, loop_scopes);
                 self.add_to_entry_set(expr.id, body_bits);
 
-                let new_loop_scope = loop_scopes.pop();
+                let new_loop_scope = loop_scopes.pop().unwrap();
                 assert_eq!(new_loop_scope.loop_id, expr.id);
                 copy_bits(new_loop_scope.break_bits, in_out);
             }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -129,7 +129,7 @@ impl MarkSymbolVisitor {
     fn mark_live_symbols(&mut self) {
         let mut scanned = HashSet::new();
         while self.worklist.len() > 0 {
-            let id = self.worklist.pop();
+            let id = self.worklist.pop().unwrap();
             if scanned.contains(&id) {
                 continue
             }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1077,7 +1077,7 @@ fn check_pat_non_uppercase_statics(cx: &Context, p: &ast::Pat) {
     match (&p.node, def_map.get().find(&p.id)) {
         (&ast::PatIdent(_, ref path, _), Some(&ast::DefStatic(_, false))) => {
             // last identifier alone is right choice for this lint.
-            let ident = path.segments.last().identifier;
+            let ident = path.segments.last().unwrap().identifier;
             let s = cx.tcx.sess.str_of(ident);
             if s.chars().any(|c| c.is_lowercase()) {
                 cx.span_lint(NonUppercasePatternStatics, path.span,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -524,7 +524,7 @@ impl<'a> Context<'a> {
         // rollback
         self.is_doc_hidden = old_is_doc_hidden;
         pushed.times(|| {
-            let (lint, lvl, src) = self.lint_stack.pop();
+            let (lint, lvl, src) = self.lint_stack.pop().unwrap();
             self.set_level(lint, lvl, src);
         })
     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -825,7 +825,7 @@ impl Liveness {
                 }
             }
         }
-        str::from_utf8_owned(wr.unwrap())
+        str::from_utf8_owned(wr.unwrap()).unwrap()
     }
 
     pub fn init_empty(&self, ln: LiveNode, succ_ln: LiveNode) {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -790,7 +790,7 @@ impl Liveness {
 
     pub fn last_loop_scope(&self) -> NodeId {
         let loop_scope = self.loop_scope.borrow();
-        *loop_scope.get().last()
+        *loop_scope.get().last().unwrap()
     }
 
     pub fn ln_str(&self, ln: LiveNode) -> ~str {
@@ -1593,7 +1593,7 @@ impl Liveness {
             } else {
                 let ends_with_stmt = match body.expr {
                     None if body.stmts.len() > 0 =>
-                        match body.stmts.last().node {
+                        match body.stmts.last().unwrap().node {
                             StmtSemi(e, _) => {
                                 let t_stmt = ty::expr_ty(self.tcx, e);
                                 ty::get(t_stmt).sty == ty::get(t_ret).sty
@@ -1603,7 +1603,7 @@ impl Liveness {
                     _ => false
                 };
                 if ends_with_stmt {
-                    let last_stmt = body.stmts.last();
+                    let last_stmt = body.stmts.last().unwrap();
                     let span_semicolon = Span {
                         lo: last_stmt.span.hi,
                         hi: last_stmt.span.hi,

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -595,7 +595,7 @@ impl<'a> PrivacyVisitor<'a> {
             match *self.last_private_map.get(&path_id) {
                 resolve::AllPublic => {},
                 resolve::DependsOn(def) => {
-                    let name = token::ident_to_str(&path.segments.last()
+                    let name = token::ident_to_str(&path.segments.last().unwrap()
                                                         .identifier);
                     self.ensure_public(span, def, Some(origdid),
                                        format!("{} `{}`", tyname, name));

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -284,7 +284,7 @@ impl ReachableContext {
                 if worklist.get().len() == 0 {
                     break
                 }
-                let search_item = worklist.get().pop();
+                let search_item = worklist.get().pop().unwrap();
                 if scanned.contains(&search_item) {
                     continue
                 }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1476,7 +1476,7 @@ impl Resolver {
                     match view_path.node {
                         ViewPathSimple(binding, ref full_path, id) => {
                             let source_ident =
-                                full_path.segments.last().identifier;
+                                full_path.segments.last().unwrap().identifier;
                             let subclass = @SingleImport(binding,
                                                          source_ident);
                             self.build_import_directive(module_,
@@ -4303,7 +4303,7 @@ impl Resolver {
 
                 // First, check to see whether the name is a primitive type.
                 if path.segments.len() == 1 {
-                    let id = path.segments.last().identifier;
+                    let id = path.segments.last().unwrap().identifier;
 
                     match self.primitive_type_table
                             .primitive_types
@@ -4342,7 +4342,7 @@ impl Resolver {
                                 debug!("(resolving type) resolved `{}` to \
                                         type {:?}",
                                        self.session.str_of(path.segments
-                                                               .last()
+                                                               .last().unwrap()
                                                                .identifier),
                                        def);
                                 result_def = Some(def);
@@ -4561,7 +4561,7 @@ impl Resolver {
                                 path.span,
                                 format!("`{}` is not an enum variant or constant",
                                      self.session.str_of(
-                                         path.segments.last().identifier)))
+                                         path.segments.last().unwrap().identifier)))
                         }
                         None => {
                             self.resolve_error(path.span,
@@ -4592,7 +4592,7 @@ impl Resolver {
                                 format!("`{}` is not an enum variant, struct or const",
                                      self.session
                                          .str_of(path.segments
-                                                     .last()
+                                                     .last().unwrap()
                                                      .identifier)));
                         }
                         None => {
@@ -4601,7 +4601,7 @@ impl Resolver {
                                                     struct or const `{}`",
                                                     self.session
                                                         .str_of(path.segments
-                                                                    .last()
+                                                                    .last().unwrap()
                                                                     .identifier)));
                         }
                     }
@@ -4722,7 +4722,7 @@ impl Resolver {
 
         let unqualified_def =
                 self.resolve_identifier(path.segments
-                                            .last()
+                                            .last().unwrap()
                                             .identifier,
                                         namespace,
                                         check_ribs,
@@ -4883,7 +4883,7 @@ impl Resolver {
             }
         }
 
-        let ident = path.segments.last().identifier;
+        let ident = path.segments.last().unwrap().identifier;
         let def = match self.resolve_definition_of_name_in_module(containing_module,
                                                         ident,
                                                         namespace) {
@@ -4952,7 +4952,7 @@ impl Resolver {
             }
         }
 
-        let name = path.segments.last().identifier;
+        let name = path.segments.last().unwrap().identifier;
         match self.resolve_definition_of_name_in_module(containing_module,
                                                         name,
                                                         namespace) {

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -575,7 +575,7 @@ fn enter_default<'r,'b>(
     // non guarded matches, and thus by exhaustiveness, we know that
     // we don't need any default cases. If the check *isn't* nonexhaustive
     // (because chk is Some), then we need the defaults anyways.
-    let is_exhaustive = match matches.last_opt() {
+    let is_exhaustive = match matches.last() {
         Some(m) if m.data.arm.guard.is_some() && chk.is_infallible() => true,
         _ => false
     };
@@ -913,7 +913,7 @@ fn get_options(bcx: &Block, m: &[Match], col: uint) -> ~[Opt] {
     // to not always merge conditions.
     fn add_veclen_to_set(set: &mut ~[Opt], i: uint,
                          len: uint, vlo: VecLenOpt) {
-        match set.last_opt() {
+        match set.last() {
             // If the last condition in the list matches the one we want
             // to add, then extend its range. Otherwise, make a new
             // vec_len with a range just covering the new entry.

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2014,7 +2014,7 @@ fn exported_name(ccx: &CrateContext, path: ast_map::Path,
 
         // Don't mangle
         _ if attr::contains_name(attrs, "no_mangle")
-            => path_elem_to_str(*path.last(), token::get_ident_interner()),
+            => path_elem_to_str(*path.last().unwrap(), token::get_ident_interner()),
 
         // Usual name mangling
         _ => mangle_exported_name(ccx, path, ty)

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -475,7 +475,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
 
     fn top_scope<R>(&self, f: |&CleanupScope<'a>| -> R) -> R {
         let scopes = self.scopes.borrow();
-        f(scopes.get().last())
+        f(scopes.get().last().unwrap())
     }
 
     fn trans_cleanups_to_exit_scope(&self,
@@ -568,7 +568,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
             // and this scope is that loop, then stop popping and set
             // `prev_llbb` to the appropriate exit block from the loop.
             popped_scopes.push(self.pop_scope());
-            let scope = popped_scopes.last();
+            let scope = popped_scopes.last().unwrap();
             match label {
                 UnwindExit | ReturnExit => { }
                 LoopExit(id, exit) => {

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -396,8 +396,11 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
         let llbb = self.get_or_create_landing_pad();
 
         // Push the scopes we removed back on:
-        while !popped_scopes.is_empty() {
-            self.push_scope(popped_scopes.pop());
+        loop {
+            match popped_scopes.pop() {
+                Some(scope) => self.push_scope(scope),
+                None => break
+            }
         }
 
         assert_eq!(self.scopes_len(), orig_scopes_len);
@@ -470,7 +473,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
                self.scopes_len() - 1);
 
         let mut scopes = self.scopes.borrow_mut();
-        scopes.get().pop()
+        scopes.get().pop().unwrap()
     }
 
     fn top_scope<R>(&self, f: |&CleanupScope<'a>| -> R) -> R {
@@ -608,7 +611,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
         // At this point, `popped_scopes` is empty, and so the final block
         // that we return to the user is `Cleanup(AST 24)`.
         while !popped_scopes.is_empty() {
-            let mut scope = popped_scopes.pop();
+            let mut scope = popped_scopes.pop().unwrap();
 
             if scope.cleanups.iter().any(|c| cleanup_is_suitable_for(*c, label))
             {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2336,7 +2336,7 @@ pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
                 seen.push(did);
                 let fields = struct_fields(cx, did, substs);
                 let r = fields.iter().any(|f| type_requires(cx, seen, r_ty, f.mt.ty));
-                seen.pop();
+                seen.pop().unwrap();
                 r
             }
 
@@ -2357,7 +2357,7 @@ pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
                         type_requires(cx, seen, r_ty, sty)
                     })
                 });
-                seen.pop();
+                seen.pop().unwrap();
                 r
             }
         };

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -170,9 +170,9 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
     // region with the current anon region binding (in other words,
     // whatever & would get replaced with).
     let expected_num_region_params = decl_generics.region_param_defs.len();
-    let supplied_num_region_params = path.segments.last().lifetimes.len();
+    let supplied_num_region_params = path.segments.last().unwrap().lifetimes.len();
     let regions = if expected_num_region_params == supplied_num_region_params {
-        path.segments.last().lifetimes.map(
+        path.segments.last().unwrap().lifetimes.map(
             |l| ast_region_to_region(this.tcx(), l))
     } else {
         let anon_regions =
@@ -373,7 +373,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
         }
 
         if (flags & NO_REGIONS) != 0u {
-            if !path.segments.last().lifetimes.is_empty() {
+            if !path.segments.last().unwrap().lifetimes.is_empty() {
                 tcx.sess.span_err(
                     path.span,
                     "region parameters are not allowed on this type");

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3827,9 +3827,9 @@ pub fn instantiate_path(fcx: @FnCtxt,
     // determine the region parameters, using the value given by the user
     // (if any) and otherwise using a fresh region variable
     let num_expected_regions = tpt.generics.region_param_defs.len();
-    let num_supplied_regions = pth.segments.last().lifetimes.len();
+    let num_supplied_regions = pth.segments.last().unwrap().lifetimes.len();
     let regions = if num_expected_regions == num_supplied_regions {
-        pth.segments.last().lifetimes.map(
+        pth.segments.last().unwrap().lifetimes.map(
             |l| ast_region_to_region(fcx.tcx(), l))
     } else {
         if num_supplied_regions != 0 {

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -107,7 +107,7 @@ pub fn relate_nested_regions(tcx: ty::ctxt,
                     self.relate(r);
                     self.stack.push(r);
                     ty_fold::super_fold_ty(self, mt.ty);
-                    self.stack.pop();
+                    self.stack.pop().unwrap();
                 }
 
                 _ => {

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -489,7 +489,7 @@ pub fn uok() -> ures {
 fn rollback_to<V:Clone + Vid,T:Clone>(vb: &mut ValsAndBindings<V, T>,
                                       len: uint) {
     while vb.bindings.len() != len {
-        let (vid, old_v) = vb.bindings.pop();
+        let (vid, old_v) = vb.bindings.pop().unwrap();
         vb.vals.insert(vid.to_uint(), old_v);
     }
 }

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -150,7 +150,7 @@ impl RegionVarBindings {
         debug!("RegionVarBindings: commit()");
         let mut undo_log = self.undo_log.borrow_mut();
         while undo_log.get().len() > 0 {
-            undo_log.get().pop();
+            undo_log.get().pop().unwrap();
         }
     }
 
@@ -158,14 +158,14 @@ impl RegionVarBindings {
         debug!("RegionVarBindings: rollback_to({})", snapshot);
         let mut undo_log = self.undo_log.borrow_mut();
         while undo_log.get().len() > snapshot {
-            let undo_item = undo_log.get().pop();
+            let undo_item = undo_log.get().pop().unwrap();
             debug!("undo_item={:?}", undo_item);
             match undo_item {
               Snapshot => {}
               AddVar(vid) => {
                 let mut var_origins = self.var_origins.borrow_mut();
                 assert_eq!(var_origins.get().len(), vid.to_uint() + 1);
-                var_origins.get().pop();
+                var_origins.get().pop().unwrap();
               }
               AddConstraint(ref constraint) => {
                 let mut constraints = self.constraints.borrow_mut();
@@ -1234,7 +1234,7 @@ impl RegionVarBindings {
         process_edges(self, &mut state, graph, orig_node_idx, dir);
 
         while !state.stack.is_empty() {
-            let node_idx = state.stack.pop();
+            let node_idx = state.stack.pop().unwrap();
             let classification = var_data[node_idx.to_uint()].classification;
 
             // check whether we've visited this node on some previous walk

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -242,7 +242,7 @@ impl ResolveState {
                 ty::mk_var(tcx, vid)
               }
             };
-            self.v_seen.pop();
+            self.v_seen.pop().unwrap();
             return t1;
         }
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -164,7 +164,7 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
         info: |&render::Cache| -> Option<(~[~str], &'static str)>) {
     // The generics will get written to both the title and link
     let mut generics = ~"";
-    let last = path.segments.last();
+    let last = path.segments.last().unwrap();
     if last.lifetimes.len() > 0 || last.types.len() > 0 {
         let mut counter = 0;
         generics.push_str("&lt;");
@@ -230,13 +230,13 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
                     }
                     match shortty {
                         "mod" => {
-                            url.push_str(*fqp.last());
+                            url.push_str(*fqp.last().unwrap());
                             url.push_str("/index.html");
                         }
                         _ => {
                             url.push_str(shortty);
                             url.push_str(".");
-                            url.push_str(*fqp.last());
+                            url.push_str(*fqp.last().unwrap());
                             url.push_str(".html");
                         }
                     }
@@ -457,7 +457,7 @@ impl fmt::Default for clean::ViewPath {
     fn fmt(v: &clean::ViewPath, f: &mut fmt::Formatter) {
         match *v {
             clean::SimpleImport(ref name, ref src) => {
-                if *name == src.path.segments.last().name {
+                if *name == src.path.segments.last().unwrap().name {
                     write!(f.buf, "use {};", *src);
                 } else {
                     write!(f.buf, "use {} = {};", *name, *src);

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -112,7 +112,7 @@ pub fn render(w: &mut io::Writer, s: &str) {
         unsafe {
             let my_opaque: &my_opaque = cast::transmute(opaque);
             vec::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {
-                let text = str::from_utf8(text);
+                let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().filter(|l| stripped_filtered_line(*l).is_none());
                 let text = lines.to_owned_vec().connect("\n");
 
@@ -172,14 +172,14 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
             let (test, shouldfail, ignore) =
                 vec::raw::buf_as_slice((*lang).data,
                                        (*lang).size as uint, |lang| {
-                    let s = str::from_utf8(lang);
+                    let s = str::from_utf8(lang).unwrap();
                     (s.contains("rust"), s.contains("should_fail"),
                      s.contains("ignore"))
                 });
             if !test { return }
             vec::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {
                 let tests: &mut ::test::Collector = intrinsics::transmute(opaque);
-                let text = str::from_utf8(text);
+                let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().map(|l| stripped_filtered_line(l).unwrap_or(l));
                 let text = lines.to_owned_vec().connect("\n");
                 tests.add_test(text, ignore, shouldfail);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -427,7 +427,7 @@ impl<'a> SourceCollector<'a> {
                 }
             }
         }
-        let contents = str::from_utf8_owned(contents);
+        let contents = str::from_utf8_owned(contents).unwrap();
 
         // Create the intermediate directories
         let mut cur = self.dst.clone();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -635,8 +635,8 @@ impl DocFolder for Cache {
             i => i,
         };
 
-        if pushed { self.stack.pop(); }
-        if parent_pushed { self.parent_stack.pop(); }
+        if pushed { self.stack.pop().unwrap(); }
+        if parent_pushed { self.parent_stack.pop().unwrap(); }
         self.privmod = orig_privmod;
         return ret;
     }
@@ -673,7 +673,7 @@ impl Context {
         self.dst = prev;
         let len = self.root_path.len();
         self.root_path.truncate(len - 3);
-        self.current.pop();
+        self.current.pop().unwrap();
 
         return ret;
     }
@@ -693,11 +693,13 @@ impl Context {
         local_data::set(cache_key, Arc::new(cache));
 
         let mut work = ~[(self, item)];
-        while work.len() > 0 {
-            let (mut cx, item) = work.pop();
-            cx.item(item, |cx, item| {
-                work.push((cx.clone(), item));
-            })
+        loop {
+            match work.pop() {
+                Some((mut cx, item)) => cx.item(item, |cx, item| {
+                    work.push((cx.clone(), item));
+                }),
+                None => break,
+            }
         }
     }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -275,7 +275,7 @@ pub fn run(mut crate: clean::Crate, dst: Path) {
         for (i, (&id, &(ref fqp, short))) in cache.paths.iter().enumerate() {
             if i > 0 { write!(w, ","); }
             write!(w, "'{}':\\{type:'{}',name:'{}'\\}",
-                   id, short, *fqp.last());
+                   id, short, *fqp.last().unwrap());
         }
         write!(w, "\\};");
         w.flush();
@@ -522,7 +522,7 @@ impl DocFolder for Cache {
                     clean::TyMethodItem(..) |
                     clean::StructFieldItem(..) |
                     clean::VariantItem(..) => {
-                        Some((Some(*self.parent_stack.last()),
+                        Some((Some(*self.parent_stack.last().unwrap()),
                               self.stack.slice_to(self.stack.len() - 1)))
 
                     }
@@ -530,7 +530,7 @@ impl DocFolder for Cache {
                         if self.parent_stack.len() == 0 {
                             None
                         } else {
-                            let last = self.parent_stack.last();
+                            let last = self.parent_stack.last().unwrap();
                             let amt = match self.paths.find(last) {
                                 Some(&(_, "trait")) => self.stack.len() - 1,
                                 Some(..) | None => self.stack.len(),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -330,7 +330,7 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
             let mut encoder = json::Encoder::new(&mut w as &mut io::Writer);
             crate.encode(&mut encoder);
         }
-        str::from_utf8_owned(w.unwrap())
+        str::from_utf8_owned(w.unwrap()).unwrap()
     };
     let crate_json = match json::from_str(crate_json_str) {
         Ok(j) => j,

--- a/src/librustpkg/crate_id.rs
+++ b/src/librustpkg/crate_id.rs
@@ -121,7 +121,7 @@ impl Iterator<(Path, Path)> for Prefixes {
             None
         }
         else {
-            let last = self.components.pop();
+            let last = self.components.pop().unwrap();
             self.remaining.unshift(last);
             // converting to str and then back is a little unfortunate
             Some((Path::new(self.components.connect("/")),

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -193,7 +193,7 @@ impl<'a> PkgScript<'a> {
                         Some(output) => {
                             debug!("run_custom: second pkg command did {:?}", output.status);
                             // Run the configs() function to get the configs
-                            let cfgs = str::from_utf8(output.output).words()
+                            let cfgs = str::from_utf8(output.output).unwrap().words()
                                 .map(|w| w.to_owned()).collect();
                             Some((cfgs, output.status))
                         },

--- a/src/librustpkg/source_control.rs
+++ b/src/librustpkg/source_control.rs
@@ -38,8 +38,8 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                                                        target.as_str().unwrap().to_owned()]);
             let outp = opt_outp.expect("Failed to exec `git`");
             if !outp.status.success() {
-                println!("{}", str::from_utf8_owned(outp.output.clone()));
-                println!("{}", str::from_utf8_owned(outp.error));
+                println!("{}", str::from_utf8_owned(outp.output.clone()).unwrap());
+                println!("{}", str::from_utf8_owned(outp.error).unwrap());
                 return DirToUse(target.clone());
             }
             else {
@@ -54,8 +54,8 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                              format!("--git-dir={}", git_dir.as_str().unwrap().to_owned()),
                              ~"checkout", format!("{}", *s)]).expect("Failed to exec `git`");
                         if !outp.status.success() {
-                            println!("{}", str::from_utf8_owned(outp.output.clone()));
-                            println!("{}", str::from_utf8_owned(outp.error));
+                            println!("{}", str::from_utf8_owned(outp.output.clone()).unwrap());
+                            println!("{}", str::from_utf8_owned(outp.error).unwrap());
                             return DirToUse(target.clone());
                         }
                     }
@@ -114,8 +114,8 @@ pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
                                                target.as_str().unwrap().to_owned()]);
     let outp = opt_outp.expect("Failed to exec `git`");
     if !outp.status.success() {
-         debug!("{}", str::from_utf8_owned(outp.output.clone()));
-         debug!("{}", str::from_utf8_owned(outp.error));
+         debug!("{}", str::from_utf8_owned(outp.output.clone()).unwrap());
+         debug!("{}", str::from_utf8_owned(outp.error).unwrap());
          cond.raise((source.to_owned(), target.clone()))
     }
     else {
@@ -125,8 +125,8 @@ pub fn git_clone_url(source: &str, target: &Path, v: &Version) {
                                                          target);
                     let outp = opt_outp.expect("Failed to exec `git`");
                     if !outp.status.success() {
-                        debug!("{}", str::from_utf8_owned(outp.output.clone()));
-                        debug!("{}", str::from_utf8_owned(outp.error));
+                        debug!("{}", str::from_utf8_owned(outp.output.clone()).unwrap());
+                        debug!("{}", str::from_utf8_owned(outp.error).unwrap());
                         cond.raise((source.to_owned(), target.clone()))
                     }
             }

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -143,7 +143,7 @@ fn run_git(args: &[~str], env: Option<~[(~str, ~str)]>, cwd: &Path, err_msg: &st
     let rslt = prog.finish_with_output();
     if !rslt.status.success() {
         fail!("{} [git returned {:?}, output = {}, error = {}]", err_msg,
-           rslt.status, str::from_utf8(rslt.output), str::from_utf8(rslt.error));
+           rslt.status, str::from_utf8(rslt.output).unwrap(), str::from_utf8(rslt.error).unwrap());
     }
 }
 
@@ -279,13 +279,13 @@ fn command_line_test_with_env(args: &[~str], cwd: &Path, env: Option<~[(~str, ~s
     }).expect(format!("failed to exec `{}`", cmd));
     let output = prog.finish_with_output();
     debug!("Output from command {} with args {:?} was {} \\{{}\\}[{:?}]",
-           cmd, args, str::from_utf8(output.output),
-           str::from_utf8(output.error),
+           cmd, args, str::from_utf8(output.output).unwrap(),
+           str::from_utf8(output.error).unwrap(),
            output.status);
     if !output.status.success() {
         debug!("Command {} {:?} failed with exit code {:?}; its output was --- {} {} ---",
               cmd, args, output.status,
-              str::from_utf8(output.output), str::from_utf8(output.error));
+              str::from_utf8(output.output).unwrap(), str::from_utf8(output.error).unwrap());
         Fail(output)
     }
     else {
@@ -445,7 +445,7 @@ fn built_library_exists(repo: &Path, short_name: &str) -> bool {
 fn command_line_test_output(args: &[~str]) -> ~[~str] {
     let mut result = ~[];
     let p_output = command_line_test(args, &os::getcwd());
-    let test_output = str::from_utf8(p_output.output);
+    let test_output = str::from_utf8(p_output.output).unwrap();
     for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
@@ -459,7 +459,7 @@ fn command_line_test_output_with_env(args: &[~str], env: ~[(~str, ~str)]) -> ~[~
         Fail(_) => fail!("Command-line test failed"),
         Success(r) => r
     };
-    let test_output = str::from_utf8(p_output.output);
+    let test_output = str::from_utf8(p_output.output).unwrap();
     for s in test_output.split('\n') {
         result.push(s.to_owned());
     }
@@ -1199,7 +1199,7 @@ fn test_uninstall() {
     let workspace = create_local_package(&CrateId::new("foo"));
     command_line_test([~"uninstall", ~"foo"], workspace.path());
     let output = command_line_test([~"list"], workspace.path());
-    assert!(!str::from_utf8(output.output).contains("foo"));
+    assert!(!str::from_utf8(output.output).unwrap().contains("foo"));
 }
 
 #[test]
@@ -1269,8 +1269,8 @@ fn test_extern_mod() {
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
-              str::from_utf8(outp.output),
-              str::from_utf8(outp.error));
+              str::from_utf8(outp.output).unwrap(),
+              str::from_utf8(outp.error).unwrap());
     }
     assert!(exec_file.exists() && is_executable(&exec_file));
 }
@@ -1324,8 +1324,8 @@ fn test_extern_mod_simpler() {
     let outp = prog.finish_with_output();
     if !outp.status.success() {
         fail!("output was {}, error was {}",
-              str::from_utf8(outp.output),
-              str::from_utf8(outp.error));
+              str::from_utf8(outp.output).unwrap(),
+              str::from_utf8(outp.error).unwrap());
     }
     assert!(exec_file.exists() && is_executable(&exec_file));
 }
@@ -2092,7 +2092,7 @@ fn test_rustpkg_test_creates_exec() {
 fn test_rustpkg_test_output() {
     let workspace = create_local_package_with_test(&CrateId::new("foo"));
     let output = command_line_test([~"test", ~"foo"], workspace.path());
-    let output_str = str::from_utf8(output.output);
+    let output_str = str::from_utf8(output.output).unwrap();
     // The first two assertions are separate because test output may
     // contain color codes, which could appear between "test f" and "ok".
     assert!(output_str.contains("test f"));
@@ -2123,7 +2123,7 @@ fn test_rustpkg_test_cfg() {
               "#[test] #[cfg(not(foobar))] fn f() { assert!('a' != 'a'); }");
     let output = command_line_test([~"test", ~"--cfg", ~"foobar", ~"foo"],
                                    foo_workspace);
-    let output_str = str::from_utf8(output.output);
+    let output_str = str::from_utf8(output.output).unwrap();
     assert!(output_str.contains("0 passed; 0 failed; 0 ignored; 0 measured"));
 }
 
@@ -2424,8 +2424,8 @@ fn correct_error_dependency() {
         Fail(ProcessOutput{ error: error, output: output, .. }) => {
             assert!(str::is_utf8(error));
             assert!(str::is_utf8(output));
-            let error_str = str::from_utf8(error);
-            let out_str   = str::from_utf8(output);
+            let error_str = str::from_utf8(error).unwrap();
+            let out_str   = str::from_utf8(output).unwrap();
             debug!("ss = {}", error_str);
             debug!("out_str = {}", out_str);
             if out_str.contains("Package badpkg depends on some_package_that_doesnt_exist") &&

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -1191,7 +1191,7 @@ fn test_info() {
     let expected_info = ~"package foo"; // fill in
     let workspace = create_local_package(&CrateId::new("foo"));
     let output = command_line_test([~"info", ~"foo"], workspace.path());
-    assert_eq!(str::from_utf8_owned(output.output), expected_info);
+    assert_eq!(str::from_utf8_owned(output.output).unwrap(), expected_info);
 }
 
 #[test]

--- a/src/librustpkg/version.rs
+++ b/src/librustpkg/version.rs
@@ -115,7 +115,7 @@ pub fn try_getting_local_version(local_path: &Path) -> Option<Version> {
         }
 
         let mut output = None;
-        let output_text = str::from_utf8(outp.output);
+        let output_text = str::from_utf8(outp.output).unwrap();
         for l in output_text.lines() {
             if !l.is_whitespace() {
                 output = Some(l);
@@ -147,8 +147,8 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
         let outp = opt_outp.expect("Failed to exec `git`");
         if outp.status.success() {
             debug!("Cloned it... ( {}, {} )",
-                   str::from_utf8(outp.output),
-                   str::from_utf8(outp.error));
+                   str::from_utf8(outp.output).unwrap(),
+                   str::from_utf8(outp.error).unwrap());
             let mut output = None;
             let git_dir = tmp_dir.join(".git");
             debug!("(getting version, now getting tags) executing \\{git --git-dir={} tag -l\\}",
@@ -158,7 +158,7 @@ pub fn try_getting_version(remote_path: &Path) -> Option<Version> {
                                                ["--git-dir=" + git_dir.as_str().unwrap(),
                                                 ~"tag", ~"-l"]);
             let outp = opt_outp.expect("Failed to exec `git`");
-            let output_text = str::from_utf8(outp.output);
+            let output_text = str::from_utf8(outp.output).unwrap();
             debug!("Full output: ( {} ) [{:?}]", output_text, outp.status);
             for l in output_text.lines() {
                 debug!("A line of output: {}", l);

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -488,7 +488,7 @@ mod test {
 
             let nread = result.unwrap();
             assert!(nread > 0);
-            let read_str = str::from_utf8(read_mem.slice_to(nread as uint));
+            let read_str = str::from_utf8(read_mem.slice_to(nread as uint)).unwrap();
             assert_eq!(read_str, "hello");
         }
         // unlink

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -167,7 +167,7 @@ impl CString {
         if self.buf.is_null() { return None; }
         let buf = self.as_bytes();
         let buf = buf.slice_to(buf.len()-1); // chop off the trailing NUL
-        str::from_utf8_opt(buf)
+        str::from_utf8(buf)
     }
 
     /// Return a CString iterator.

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -691,7 +691,7 @@ pub fn format(args: &Arguments) -> ~str {
 pub unsafe fn format_unsafe(fmt: &[rt::Piece], args: &[Argument]) -> ~str {
     let mut output = MemWriter::new();
     write_unsafe(&mut output as &mut io::Writer, fmt, args);
-    return str::from_utf8_owned(output.unwrap());
+    return str::from_utf8_owned(output.unwrap()).unwrap();
 }
 
 impl<'a> Formatter<'a> {

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -812,7 +812,7 @@ impl<'a> Formatter<'a> {
 
     fn runplural(&mut self, value: uint, pieces: &[rt::Piece]) {
         ::uint::to_str_bytes(value, 10, |buf| {
-            let valuestr = str::from_utf8(buf);
+            let valuestr = str::from_utf8(buf).unwrap();
             for piece in pieces.iter() {
                 self.run(piece, Some(valuestr));
             }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -370,7 +370,7 @@ mod test {
 
     impl Reader for ShortReader {
         fn read(&mut self, _: &mut [u8]) -> Option<uint> {
-            self.lengths.shift_opt()
+            self.lengths.shift()
         }
     }
 

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -805,7 +805,7 @@ mod test {
             }
         }
         unlink(filename);
-        let read_str = str::from_utf8(read_mem);
+        let read_str = str::from_utf8(read_mem).unwrap();
         assert_eq!(read_str, message);
     })
 
@@ -829,7 +829,7 @@ mod test {
             tell_pos_post_read = read_stream.tell();
         }
         unlink(filename);
-        let read_str = str::from_utf8(read_mem);
+        let read_str = str::from_utf8(read_mem).unwrap();
         assert_eq!(read_str, message.slice(4, 8));
         assert_eq!(tell_pos_pre_read, set_cursor);
         assert_eq!(tell_pos_post_read, message.len() as u64);
@@ -854,7 +854,7 @@ mod test {
             read_stream.read(read_mem);
         }
         unlink(filename);
-        let read_str = str::from_utf8(read_mem);
+        let read_str = str::from_utf8(read_mem).unwrap();
         assert!(read_str == final_msg.to_owned());
     })
 
@@ -876,15 +876,15 @@ mod test {
 
             read_stream.seek(-4, SeekEnd);
             read_stream.read(read_mem);
-            assert_eq!(str::from_utf8(read_mem), chunk_three);
+            assert_eq!(str::from_utf8(read_mem).unwrap(), chunk_three);
 
             read_stream.seek(-9, SeekCur);
             read_stream.read(read_mem);
-            assert_eq!(str::from_utf8(read_mem), chunk_two);
+            assert_eq!(str::from_utf8(read_mem).unwrap(), chunk_two);
 
             read_stream.seek(0, SeekSet);
             read_stream.read(read_mem);
-            assert_eq!(str::from_utf8(read_mem), chunk_one);
+            assert_eq!(str::from_utf8(read_mem).unwrap(), chunk_one);
         }
         unlink(filename);
     })
@@ -958,7 +958,7 @@ mod test {
             {
                 let n = f.filestem_str();
                 File::open(f).read(mem);
-                let read_str = str::from_utf8(mem);
+                let read_str = str::from_utf8(mem).unwrap();
                 let expected = match n {
                     None|Some("") => fail!("really shouldn't happen.."),
                     Some(n) => prefix+n

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -519,7 +519,7 @@ pub struct Directories {
 
 impl Iterator<Path> for Directories {
     fn next(&mut self) -> Option<Path> {
-        match self.stack.shift_opt() {
+        match self.stack.shift() {
             Some(path) => {
                 if path.is_dir() {
                     self.stack.push_all_move(readdir(&path));

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -754,7 +754,7 @@ mod test {
             let mut read_buf = [0, .. 1028];
             let read_str = match read_stream.read(read_buf).unwrap() {
                 -1|0 => fail!("shouldn't happen"),
-                n => str::from_utf8_owned(read_buf.slice_to(n).to_owned())
+                n => str::from_utf8_owned(read_buf.slice_to(n).to_owned()).unwrap()
             };
             assert_eq!(read_str, message.to_owned());
         }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1202,7 +1202,7 @@ pub trait Buffer: Reader {
                 }
             }
         }
-        match str::from_utf8_opt(buf.slice_to(width)) {
+        match str::from_utf8(buf.slice_to(width)) {
             Some(s) => Some(s.char_at(0)),
             None => None
         }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -607,7 +607,7 @@ pub trait Reader {
     /// This function will raise all the same conditions as the `read` method,
     /// along with raising a condition if the input is not valid UTF-8.
     fn read_to_str(&mut self) -> ~str {
-        match str::from_utf8_owned_opt(self.read_to_end()) {
+        match str::from_utf8_owned(self.read_to_end()) {
             Some(s) => s,
             None => {
                 io_error::cond.raise(standard_error(InvalidInput));
@@ -1117,7 +1117,7 @@ pub trait Buffer: Reader {
     /// The task will also fail if sequence of bytes leading up to
     /// the newline character are not valid UTF-8.
     fn read_line(&mut self) -> Option<~str> {
-        self.read_until('\n' as u8).map(str::from_utf8_owned)
+        self.read_until('\n' as u8).map(|line| str::from_utf8_owned(line).unwrap())
     }
 
     /// Create an iterator that reads a line on each iteration until EOF.

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -254,7 +254,7 @@ mod tests {
         loop {
             match input.read(buf) {
                 None => { break }
-                Some(n) => { ret.push_str(str::from_utf8(buf.slice_to(n))); }
+                Some(n) => { ret.push_str(str::from_utf8(buf.slice_to(n)).unwrap()); }
             }
         }
         return ret;

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -161,8 +161,11 @@ impl Drop for Process {
     fn drop(&mut self) {
         // Close all I/O before exiting to ensure that the child doesn't wait
         // forever to print some text or something similar.
-        for _ in range(0, self.io.len()) {
-            self.io.pop();
+        loop {
+            match self.io.pop() {
+                Some(_) => (),
+                None => break,
+            }
         }
 
         self.wait();

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -351,7 +351,7 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Float+Round+
                 char::from_digit(val, radix).unwrap() as u8
             };
 
-            let extra_digit = ascii2value(buf.pop());
+            let extra_digit = ascii2value(buf.pop().unwrap());
             if extra_digit >= radix / 2 { // -> need to round
                 let mut i: int = buf.len() as int - 1;
                 loop {

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -427,7 +427,7 @@ pub fn float_to_str_common<T:NumCast+Zero+One+Eq+Ord+NumStrConv+Float+Round+
         sign: SignFormat, digits: SignificantDigits) -> (~str, bool) {
     let (bytes, special) = float_to_str_bytes_common(num, radix,
                                negative_zero, sign, digits);
-    (str::from_utf8_owned(bytes), special)
+    (str::from_utf8_owned(bytes).unwrap(), special)
 }
 
 // Some constants for from_str_bytes_common's input validation,

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -426,7 +426,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
         let t: Option<T> = None;
         if BytesContainer::is_str(t) {
             for p in paths.iter() {
-                self.push(p.container_as_str())
+                self.push(p.container_as_str().unwrap())
             }
         } else {
             for p in paths.iter() {
@@ -499,18 +499,9 @@ pub trait BytesContainer {
     fn container_into_owned_bytes(self) -> ~[u8] {
         self.container_as_bytes().to_owned()
     }
-    /// Returns the receiver interpreted as a utf-8 string
-    ///
-    /// # Failure
-    ///
-    /// Raises `str::null_byte` if not utf-8
-    #[inline]
-    fn container_as_str<'a>(&'a self) -> &'a str {
-        str::from_utf8(self.container_as_bytes())
-    }
     /// Returns the receiver interpreted as a utf-8 string, if possible
     #[inline]
-    fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
+    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8_opt(self.container_as_bytes())
     }
     /// Returns whether .container_as_str() is guaranteed to not fail
@@ -589,11 +580,7 @@ impl<'a> BytesContainer for &'a str {
         self.as_bytes()
     }
     #[inline]
-    fn container_as_str<'a>(&'a self) -> &'a str {
-        *self
-    }
-    #[inline]
-    fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
+    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         Some(*self)
     }
     #[inline]
@@ -610,11 +597,7 @@ impl BytesContainer for ~str {
         self.into_bytes()
     }
     #[inline]
-    fn container_as_str<'a>(&'a self) -> &'a str {
-        self.as_slice()
-    }
-    #[inline]
-    fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
+    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         Some(self.as_slice())
     }
     #[inline]
@@ -627,11 +610,7 @@ impl BytesContainer for @str {
         self.as_bytes()
     }
     #[inline]
-    fn container_as_str<'a>(&'a self) -> &'a str {
-        self.as_slice()
-    }
-    #[inline]
-    fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
+    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         Some(self.as_slice())
     }
     #[inline]

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -189,7 +189,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// If the path is not representable in utf-8, this returns None.
     #[inline]
     fn as_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8_opt(self.as_vec())
+        str::from_utf8(self.as_vec())
     }
 
     /// Returns the path as a byte vector
@@ -220,7 +220,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `dirname` for details.
     #[inline]
     fn dirname_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8_opt(self.dirname())
+        str::from_utf8(self.dirname())
     }
     /// Returns the file component of `self`, as a byte vector.
     /// If `self` represents the root of the file hierarchy, returns None.
@@ -230,7 +230,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `filename` for details.
     #[inline]
     fn filename_str<'a>(&'a self) -> Option<&'a str> {
-        self.filename().and_then(str::from_utf8_opt)
+        self.filename().and_then(str::from_utf8)
     }
     /// Returns the stem of the filename of `self`, as a byte vector.
     /// The stem is the portion of the filename just before the last '.'.
@@ -252,7 +252,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `filestem` for details.
     #[inline]
     fn filestem_str<'a>(&'a self) -> Option<&'a str> {
-        self.filestem().and_then(str::from_utf8_opt)
+        self.filestem().and_then(str::from_utf8)
     }
     /// Returns the extension of the filename of `self`, as an optional byte vector.
     /// The extension is the portion of the filename just after the last '.'.
@@ -275,7 +275,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// See `extension` for details.
     #[inline]
     fn extension_str<'a>(&'a self) -> Option<&'a str> {
-        self.extension().and_then(str::from_utf8_opt)
+        self.extension().and_then(str::from_utf8)
     }
 
     /// Replaces the filename portion of the path with the given byte vector or string.
@@ -502,7 +502,7 @@ pub trait BytesContainer {
     /// Returns the receiver interpreted as a utf-8 string, if possible
     #[inline]
     fn container_as_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8_opt(self.container_as_bytes())
+        str::from_utf8(self.container_as_bytes())
     }
     /// Returns whether .container_as_str() is guaranteed to not fail
     // FIXME (#8888): Remove unused arg once ::<for T> works

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -402,13 +402,13 @@ impl Path {
     /// Returns an iterator that yields each component of the path as Option<&str>.
     /// See components() for details.
     pub fn str_components<'a>(&'a self) -> StrComponents<'a> {
-        self.components().map(str::from_utf8_opt)
+        self.components().map(str::from_utf8)
     }
 
     /// Returns an iterator that yields each component of the path in reverse as Option<&str>.
     /// See components() for details.
     pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
-        self.rev_components().map(str::from_utf8_opt)
+        self.rev_components().map(str::from_utf8)
     }
 }
 
@@ -691,7 +691,7 @@ mod tests {
             (s: $path:expr, $op:ident, $exp:expr, opt) => (
                 {
                     let path = Path::new($path);
-                    let left = path.$op().map(|x| str::from_utf8(x));
+                    let left = path.$op().map(|x| str::from_utf8(x).unwrap());
                     assert_eq!(left, $exp);
                 }
             );

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -426,7 +426,7 @@ fn normalize_helper<'a>(v: &'a [u8], is_abs: bool) -> Option<~[&'a [u8]]> {
         else if comp == bytes!("..") {
             if is_abs && comps.is_empty() { changed = true }
             else if comps.len() == n_up { comps.push(dot_dot_static); n_up += 1 }
-            else { comps.pop(); changed = true }
+            else { comps.pop().unwrap(); changed = true }
         } else { comps.push(comp) }
     }
     if changed {

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1025,7 +1025,7 @@ fn normalize_helper<'a>(s: &'a str, prefix: Option<PathPrefix>) -> (bool,Option<
             };
             if (is_abs || has_abs_prefix) && comps.is_empty() { changed = true }
             else if comps.len() == n_up { comps.push(".."); n_up += 1 }
-            else { comps.pop(); changed = true }
+            else { comps.pop().unwrap(); changed = true }
         } else { comps.push(comp) }
     }
     if !changed && !prefix_is_verbatim(prefix) {

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -154,7 +154,7 @@ impl GenericPathUnsafe for Path {
     ///
     /// # Failure
     ///
-    /// Raises the `str::not_utf8` condition if not valid UTF-8.
+    /// Fails if not valid UTF-8.
     #[inline]
     unsafe fn new_unchecked<T: BytesContainer>(path: T) -> Path {
         let (prefix, path) = Path::normalize_(path.container_as_str().unwrap());
@@ -168,7 +168,7 @@ impl GenericPathUnsafe for Path {
     ///
     /// # Failure
     ///
-    /// Raises the `str::not_utf8` condition if not valid UTF-8.
+    /// Fails if not valid UTF-8.
     unsafe fn set_filename_unchecked<T: BytesContainer>(&mut self, filename: T) {
         let filename = filename.container_as_str().unwrap();
         match self.sepidx_or_prefix_len() {
@@ -591,7 +591,7 @@ impl Path {
     /// # Failure
     ///
     /// Raises the `null_byte` condition if the vector contains a NUL.
-    /// Raises the `str::not_utf8` condition if invalid UTF-8.
+    /// Fails if invalid UTF-8.
     #[inline]
     pub fn new<T: BytesContainer>(path: T) -> Path {
         GenericPath::new(path)

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -129,11 +129,7 @@ impl BytesContainer for Path {
         self.into_vec()
     }
     #[inline]
-    fn container_as_str<'a>(&'a self) -> &'a str {
-        self.as_str().unwrap()
-    }
-    #[inline]
-    fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
+    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         self.as_str()
     }
     #[inline]
@@ -146,11 +142,7 @@ impl<'a> BytesContainer for &'a Path {
         self.as_vec()
     }
     #[inline]
-    fn container_as_str<'a>(&'a self) -> &'a str {
-        self.as_str().unwrap()
-    }
-    #[inline]
-    fn container_as_str_opt<'a>(&'a self) -> Option<&'a str> {
+    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         self.as_str()
     }
     #[inline]
@@ -165,7 +157,7 @@ impl GenericPathUnsafe for Path {
     /// Raises the `str::not_utf8` condition if not valid UTF-8.
     #[inline]
     unsafe fn new_unchecked<T: BytesContainer>(path: T) -> Path {
-        let (prefix, path) = Path::normalize_(path.container_as_str());
+        let (prefix, path) = Path::normalize_(path.container_as_str().unwrap());
         assert!(!path.is_empty());
         let mut ret = Path{ repr: path, prefix: prefix, sepidx: None };
         ret.update_sepidx();
@@ -178,7 +170,7 @@ impl GenericPathUnsafe for Path {
     ///
     /// Raises the `str::not_utf8` condition if not valid UTF-8.
     unsafe fn set_filename_unchecked<T: BytesContainer>(&mut self, filename: T) {
-        let filename = filename.container_as_str();
+        let filename = filename.container_as_str().unwrap();
         match self.sepidx_or_prefix_len() {
             None if ".." == self.repr => {
                 let mut s = str::with_capacity(3 + filename.len());
@@ -224,7 +216,7 @@ impl GenericPathUnsafe for Path {
     /// the new path is relative to. Otherwise, the new path will be treated
     /// as if it were absolute and will replace the receiver outright.
     unsafe fn push_unchecked<T: BytesContainer>(&mut self, path: T) {
-        let path = path.container_as_str();
+        let path = path.container_as_str().unwrap();
         fn is_vol_abs(path: &str, prefix: Option<PathPrefix>) -> bool {
             // assume prefix is Some(DiskPrefix)
             let rest = path.slice_from(prefix_len(prefix));
@@ -311,7 +303,7 @@ impl GenericPathUnsafe for Path {
 impl GenericPath for Path {
     #[inline]
     fn new_opt<T: BytesContainer>(path: T) -> Option<Path> {
-        let s = path.container_as_str_opt();
+        let s = path.container_as_str();
         match s {
             None => None,
             Some(s) => {

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -123,7 +123,7 @@ impl<'a> MovePtr for ReprVisitor<'a> {
         self.ptr_stk.push(self.ptr);
     }
     fn pop_ptr(&mut self) {
-        self.ptr = self.ptr_stk.pop();
+        self.ptr = self.ptr_stk.pop().unwrap();
     }
 }
 
@@ -471,7 +471,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
                                 n_fields: uint,
                                 name: &str) -> bool {
         let mut write = false;
-        match self.var_stk.pop() {
+        match self.var_stk.pop().unwrap() {
             SearchingFor(sought) => {
                 if disr_val == sought {
                     self.var_stk.push(Matched);
@@ -534,7 +534,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
                         _sz: uint,
                         _align: uint)
                         -> bool {
-        match self.var_stk.pop() {
+        match self.var_stk.pop().unwrap() {
             SearchingFor(..) => fail!("enum value matched no variant"),
             _ => true
         }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -608,7 +608,7 @@ pub fn repr_to_str<T>(t: &T) -> ~str {
 
     let mut result = io::MemWriter::new();
     write_repr(&mut result as &mut io::Writer, t);
-    str::from_utf8_owned(result.unwrap())
+    str::from_utf8_owned(result.unwrap()).unwrap()
 }
 
 #[cfg(test)]
@@ -626,7 +626,7 @@ fn test_repr() {
     fn exact_test<T>(t: &T, e:&str) {
         let mut m = io::MemWriter::new();
         write_repr(&mut m as &mut io::Writer, t);
-        let s = str::from_utf8_owned(m.unwrap());
+        let s = str::from_utf8_owned(m.unwrap()).unwrap();
         assert_eq!(s.as_slice(), e);
     }
 

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -372,7 +372,7 @@ mod tests {
 
         let run::ProcessOutput {status, output, error}
              = run::process_output("echo", [~"hello"]).expect("failed to exec `echo`");
-        let output_str = str::from_utf8_owned(output);
+        let output_str = str::from_utf8_owned(output).unwrap();
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_owned(), ~"hello");
@@ -439,7 +439,7 @@ mod tests {
                 None => break
             }
         }
-        str::from_utf8_owned(res)
+        str::from_utf8_owned(res).unwrap()
     }
 
     #[test]
@@ -467,7 +467,7 @@ mod tests {
             .expect("failed to exec `echo`");
         let run::ProcessOutput {status, output, error}
             = prog.finish_with_output();
-        let output_str = str::from_utf8_owned(output);
+        let output_str = str::from_utf8_owned(output).unwrap();
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_owned(), ~"hello");
@@ -486,7 +486,7 @@ mod tests {
         let run::ProcessOutput {status, output, error}
             = prog.finish_with_output();
 
-        let output_str = str::from_utf8_owned(output);
+        let output_str = str::from_utf8_owned(output).unwrap();
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_owned(), ~"hello");
@@ -533,7 +533,7 @@ mod tests {
     fn test_keep_current_working_dir() {
         let mut prog = run_pwd(None);
 
-        let output = str::from_utf8_owned(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
         let parent_dir = os::getcwd();
         let child_dir = Path::new(output.trim());
 
@@ -551,7 +551,7 @@ mod tests {
         let parent_dir = os::getcwd().dir_path();
         let mut prog = run_pwd(Some(&parent_dir));
 
-        let output = str::from_utf8_owned(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
         let child_dir = Path::new(output.trim());
 
         let parent_stat = parent_dir.stat();
@@ -590,7 +590,7 @@ mod tests {
         if running_on_valgrind() { return; }
 
         let mut prog = run_env(None);
-        let output = str::from_utf8_owned(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
 
         let r = os::env();
         for &(ref k, ref v) in r.iter() {
@@ -604,7 +604,7 @@ mod tests {
         if running_on_valgrind() { return; }
 
         let mut prog = run_env(None);
-        let output = str::from_utf8_owned(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
 
         let r = os::env();
         for &(ref k, ref v) in r.iter() {
@@ -623,7 +623,7 @@ mod tests {
         new_env.push((~"RUN_TEST_NEW_ENV", ~"123"));
 
         let mut prog = run_env(Some(new_env));
-        let output = str::from_utf8_owned(prog.finish_with_output().output);
+        let output = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
 
         assert!(output.contains("RUN_TEST_NEW_ENV=123"));
     }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -666,7 +666,7 @@ impl<'a> Iterator<char> for Normalizations<'a> {
     fn next(&mut self) -> Option<char> {
         use unicode::decompose::canonical_combining_class;
 
-        match self.buffer.head_opt() {
+        match self.buffer.head() {
             Some(&(c, 0)) => {
                 self.sorted = false;
                 self.buffer.shift();

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -703,7 +703,7 @@ impl<'a> Iterator<char> for Normalizations<'a> {
             self.sorted = true;
         }
 
-        match self.buffer.shift_opt() {
+        match self.buffer.shift() {
             Some((c, 0)) => {
                 self.sorted = false;
                 Some(c)

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -118,14 +118,6 @@ use send_str::{SendStr, SendStrOwned};
 use unstable::raw::Repr;
 
 /*
-Section: Conditions
-*/
-
-condition! {
-    pub not_utf8: (~str) -> ~str;
-}
-
-/*
 Section: Creating a string
 */
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -161,17 +161,8 @@ pub fn from_utf8_owned_opt(vv: ~[u8]) -> Option<~str> {
 /// Once the slice has been validated as utf-8, it is transmuted in-place and
 /// returned as a '&str' instead of a '&[u8]'
 ///
-/// # Failure
-///
-/// Fails if invalid UTF-8
-pub fn from_utf8<'a>(v: &'a [u8]) -> &'a str {
-    from_utf8_opt(v).expect("from_utf8: not utf-8")
-}
-
-/// Converts a vector to a string slice without performing any allocations.
-///
 /// Returns None if the slice is not utf-8.
-pub fn from_utf8_opt<'a>(v: &'a [u8]) -> Option<&'a str> {
+pub fn from_utf8<'a>(v: &'a [u8]) -> Option<&'a str> {
     if is_utf8(v) {
         Some(unsafe { raw::from_utf8(v) })
     } else { None }
@@ -3436,7 +3427,7 @@ mod tests {
         let s1: ~str = ~"All mimsy were the borogoves";
 
         let v: ~[u8] = s1.as_bytes().to_owned();
-        let s2: ~str = from_utf8(v).to_owned();
+        let s2: ~str = from_utf8(v).unwrap().to_owned();
         let mut i: uint = 0u;
         let n1: uint = s1.len();
         let n2: uint = v.len();
@@ -3961,29 +3952,13 @@ mod tests {
     #[test]
     fn test_str_from_utf8() {
         let xs = bytes!("hello");
-        assert_eq!(from_utf8(xs), "hello");
+        assert_eq!(from_utf8(xs), Some("hello"));
 
         let xs = bytes!("ศไทย中华Việt Nam");
-        assert_eq!(from_utf8(xs), "ศไทย中华Việt Nam");
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_str_from_utf8_invalid() {
-        let xs = bytes!("hello", 0xff);
-        let _ = from_utf8(xs);
-    }
-
-    #[test]
-    fn test_str_from_utf8_opt() {
-        let xs = bytes!("hello");
-        assert_eq!(from_utf8_opt(xs), Some("hello"));
-
-        let xs = bytes!("ศไทย中华Việt Nam");
-        assert_eq!(from_utf8_opt(xs), Some("ศไทย中华Việt Nam"));
+        assert_eq!(from_utf8(xs), Some("ศไทย中华Việt Nam"));
 
         let xs = bytes!("hello", 0xff);
-        assert_eq!(from_utf8_opt(xs), None);
+        assert_eq!(from_utf8(xs), None);
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -129,26 +129,9 @@ condition! {
 Section: Creating a string
 */
 
-/// Consumes a vector of bytes to create a new utf-8 string
-///
-/// # Failure
-///
-/// Raises the `not_utf8` condition if invalid UTF-8
-pub fn from_utf8_owned(vv: ~[u8]) -> ~str {
-    use str::not_utf8::cond;
-
-    if !is_utf8(vv) {
-        let first_bad_byte = *vv.iter().find(|&b| !is_utf8([*b])).unwrap();
-        cond.raise(format!("from_utf8: input is not UTF-8; first bad byte is {}",
-                           first_bad_byte))
-    } else {
-        unsafe { raw::from_utf8_owned(vv) }
-    }
-}
-
 /// Consumes a vector of bytes to create a new utf-8 string.
 /// Returns None if the vector contains invalid UTF-8.
-pub fn from_utf8_owned_opt(vv: ~[u8]) -> Option<~str> {
+pub fn from_utf8_owned(vv: ~[u8]) -> Option<~str> {
     if is_utf8(vv) {
         Some(unsafe { raw::from_utf8_owned(vv) })
     } else {
@@ -3964,22 +3947,13 @@ mod tests {
     #[test]
     fn test_str_from_utf8_owned() {
         let xs = bytes!("hello").to_owned();
-        assert_eq!(from_utf8_owned(xs), ~"hello");
+        assert_eq!(from_utf8_owned(xs), Some(~"hello"));
 
         let xs = bytes!("ศไทย中华Việt Nam").to_owned();
-        assert_eq!(from_utf8_owned(xs), ~"ศไทย中华Việt Nam");
-    }
-
-    #[test]
-    fn test_str_from_utf8_owned_opt() {
-        let xs = bytes!("hello").to_owned();
-        assert_eq!(from_utf8_owned_opt(xs), Some(~"hello"));
-
-        let xs = bytes!("ศไทย中华Việt Nam").to_owned();
-        assert_eq!(from_utf8_owned_opt(xs), Some(~"ศไทย中华Việt Nam"));
+        assert_eq!(from_utf8_owned(xs), Some(~"ศไทย中华Việt Nam"));
 
         let xs = bytes!("hello", 0xff).to_owned();
-        assert_eq!(from_utf8_owned_opt(xs), None);
+        assert_eq!(from_utf8_owned(xs), None);
     }
 
     #[test]

--- a/src/libstd/sync/deque.rs
+++ b/src/libstd/sync/deque.rs
@@ -157,7 +157,7 @@ impl<T: Send> BufferPool<T> {
         unsafe {
             self.pool.with(|pool| {
                 match pool.iter().position(|x| x.size() >= (1 << bits)) {
-                    Some(i) => pool.remove(i),
+                    Some(i) => pool.remove(i).unwrap(),
                     None => ~Buffer::new(bits)
                 }
             })

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -952,10 +952,8 @@ pub trait ImmutableVector<'a, T> {
     fn init(&self) -> &'a [T];
     /// Returns all but the last `n' elements of a vector
     fn initn(&self, n: uint) -> &'a [T];
-    /// Returns the last element of a vector, failing if the vector is empty.
-    fn last(&self) -> &'a T;
     /// Returns the last element of a vector, or `None` if it is empty.
-    fn last_opt(&self) -> Option<&'a T>;
+    fn last(&self) -> Option<&'a T>;
     /**
      * Apply a function to each element of a vector and return a concatenation
      * of each result vector
@@ -1142,13 +1140,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn last(&self) -> &'a T {
-        if self.len() == 0 { fail!("last: empty vector") }
-        &self[self.len() - 1]
-    }
-
-    #[inline]
-    fn last_opt(&self) -> Option<&'a T> {
+    fn last(&self) -> Option<&'a T> {
             if self.len() == 0 { None } else { Some(&self[self.len() - 1]) }
     }
 
@@ -3116,27 +3108,12 @@ mod tests {
 
     #[test]
     fn test_last() {
-        let mut a = ~[11];
-        assert_eq!(a.last(), &11);
-        a = ~[11, 12];
-        assert_eq!(a.last(), &12);
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_last_empty() {
-        let a: ~[int] = ~[];
-        a.last();
-    }
-
-    #[test]
-    fn test_last_opt() {
         let mut a = ~[];
-        assert_eq!(a.last_opt(), None);
+        assert_eq!(a.last(), None);
         a = ~[11];
-        assert_eq!(a.last_opt().unwrap(), &11);
+        assert_eq!(a.last().unwrap(), &11);
         a = ~[11, 12];
-        assert_eq!(a.last_opt().unwrap(), &12);
+        assert_eq!(a.last().unwrap(), &12);
     }
 
     #[test]

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1381,10 +1381,8 @@ pub trait OwnedVector<T> {
     /// assert!(a == ~[~1, ~2, ~3, ~4]);
     /// ```
     fn push_all_move(&mut self, rhs: ~[T]);
-    /// Remove the last element from a vector and return it, failing if it is empty
-    fn pop(&mut self) -> T;
     /// Remove the last element from a vector and return it, or `None` if it is empty
-    fn pop_opt(&mut self) -> Option<T>;
+    fn pop(&mut self) -> Option<T>;
     /// Removes the first element from a vector and return it
     fn shift(&mut self) -> T;
     /// Removes the first element from a vector and return it, or `None` if it is empty
@@ -1565,7 +1563,7 @@ impl<T> OwnedVector<T> for ~[T] {
         }
     }
 
-    fn pop_opt(&mut self) -> Option<T> {
+    fn pop(&mut self) -> Option<T> {
         match self.len() {
             0  => None,
             ln => {
@@ -1578,11 +1576,6 @@ impl<T> OwnedVector<T> for ~[T] {
         }
     }
 
-
-    #[inline]
-    fn pop(&mut self) -> T {
-        self.pop_opt().expect("pop: empty vector")
-    }
 
     #[inline]
     fn shift(&mut self) -> T {
@@ -3168,28 +3161,16 @@ mod tests {
         assert_eq!(vec.slice_to(0), &[]);
     }
 
-    #[test]
-    fn test_pop() {
-        // Test on-heap pop.
-        let mut v = ~[1, 2, 3, 4, 5];
-        let e = v.pop();
-        assert_eq!(v.len(), 4u);
-        assert_eq!(v[0], 1);
-        assert_eq!(v[1], 2);
-        assert_eq!(v[2], 3);
-        assert_eq!(v[3], 4);
-        assert_eq!(e, 5);
-    }
 
     #[test]
-    fn test_pop_opt() {
+    fn test_pop() {
         let mut v = ~[5];
-        let e = v.pop_opt();
+        let e = v.pop();
         assert_eq!(v.len(), 0);
         assert_eq!(e, Some(5));
-        let f = v.pop_opt();
+        let f = v.pop();
         assert_eq!(f, None);
-        let g = v.pop_opt();
+        let g = v.pop();
         assert_eq!(g, None);
     }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -942,10 +942,8 @@ pub trait ImmutableVector<'a, T> {
     /// Returns the element of a vector at the given index, or `None` if the
     /// index is out of bounds
     fn get(&self, index: uint) -> Option<&'a T>;
-    /// Returns the first element of a vector, failing if the vector is empty.
-    fn head(&self) -> &'a T;
     /// Returns the first element of a vector, or `None` if it is empty
-    fn head_opt(&self) -> Option<&'a T>;
+    fn head(&self) -> Option<&'a T>;
     /// Returns all but the first element of a vector
     fn tail(&self) -> &'a [T];
     /// Returns all but the first `n' elements of a vector
@@ -1123,13 +1121,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn head(&self) -> &'a T {
-        if self.len() == 0 { fail!("head: empty vector") }
-        &self[0]
-    }
-
-    #[inline]
-    fn head_opt(&self) -> Option<&'a T> {
+    fn head(&self) -> Option<&'a T> {
         if self.len() == 0 { None } else { Some(&self[0]) }
     }
 
@@ -3054,27 +3046,12 @@ mod tests {
 
     #[test]
     fn test_head() {
-        let mut a = ~[11];
-        assert_eq!(a.head(), &11);
-        a = ~[11, 12];
-        assert_eq!(a.head(), &11);
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_head_empty() {
-        let a: ~[int] = ~[];
-        a.head();
-    }
-
-    #[test]
-    fn test_head_opt() {
         let mut a = ~[];
-        assert_eq!(a.head_opt(), None);
+        assert_eq!(a.head(), None);
         a = ~[11];
-        assert_eq!(a.head_opt().unwrap(), &11);
+        assert_eq!(a.head().unwrap(), &11);
         a = ~[11, 12];
-        assert_eq!(a.head_opt().unwrap(), &11);
+        assert_eq!(a.head().unwrap(), &11);
     }
 
     #[test]

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1399,18 +1399,14 @@ pub trait OwnedVector<T> {
     /// # Example
     /// ```rust
     /// let mut v = ~[1, 2, 3];
-    /// assert_eq!(v.remove_opt(1), Some(2));
+    /// assert_eq!(v.remove(1), Some(2));
     /// assert_eq!(v, ~[1, 3]);
     ///
-    /// assert_eq!(v.remove_opt(4), None);
+    /// assert_eq!(v.remove(4), None);
     /// // v is unchanged:
     /// assert_eq!(v, ~[1, 3]);
     /// ```
-    fn remove_opt(&mut self, i: uint) -> Option<T>;
-
-    /// Remove and return the element at position i within v, shifting
-    /// all elements after position i one position to the left.
-    fn remove(&mut self, i: uint) -> T;
+    fn remove(&mut self, i: uint) -> Option<T>;
 
     /**
      * Remove an element from anywhere in the vector and return it, replacing it
@@ -1577,7 +1573,7 @@ impl<T> OwnedVector<T> for ~[T] {
 
     #[inline]
     fn shift(&mut self) -> Option<T> {
-        self.remove_opt(0)
+        self.remove(0)
     }
 
     #[inline]
@@ -1604,15 +1600,7 @@ impl<T> OwnedVector<T> for ~[T] {
         }
     }
 
-    #[inline]
-    fn remove(&mut self, i: uint) -> T {
-        match self.remove_opt(i) {
-            Some(t) => t,
-            None => fail!("remove: the len is {} but the index is {}", self.len(), i)
-        }
-    }
-
-    fn remove_opt(&mut self, i: uint) -> Option<T> {
+    fn remove(&mut self, i: uint) -> Option<T> {
         let len = self.len();
         if i < len {
             unsafe { // infallible
@@ -3617,48 +3605,26 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_opt() {
+    fn test_remove() {
         let mut a = ~[1,2,3,4];
 
-        assert_eq!(a.remove_opt(2), Some(3));
+        assert_eq!(a.remove(2), Some(3));
         assert_eq!(a, ~[1,2,4]);
 
-        assert_eq!(a.remove_opt(2), Some(4));
+        assert_eq!(a.remove(2), Some(4));
         assert_eq!(a, ~[1,2]);
 
-        assert_eq!(a.remove_opt(2), None);
+        assert_eq!(a.remove(2), None);
         assert_eq!(a, ~[1,2]);
 
-        assert_eq!(a.remove_opt(0), Some(1));
+        assert_eq!(a.remove(0), Some(1));
         assert_eq!(a, ~[2]);
 
-        assert_eq!(a.remove_opt(0), Some(2));
+        assert_eq!(a.remove(0), Some(2));
         assert_eq!(a, ~[]);
 
-        assert_eq!(a.remove_opt(0), None);
-        assert_eq!(a.remove_opt(10), None);
-    }
-
-    #[test]
-    fn test_remove() {
-        let mut a = ~[1, 2, 3, 4];
-        a.remove(2);
-        assert_eq!(a, ~[1, 2, 4]);
-
-        let mut a = ~[1, 2, 3];
-        a.remove(0);
-        assert_eq!(a, ~[2, 3]);
-
-        let mut a = ~[1];
-        a.remove(0);
-        assert_eq!(a, ~[]);
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_remove_oob() {
-        let mut a = ~[1, 2, 3];
-        a.remove(3);
+        assert_eq!(a.remove(0), None);
+        assert_eq!(a.remove(10), None);
     }
 
     #[test]

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1383,10 +1383,8 @@ pub trait OwnedVector<T> {
     fn push_all_move(&mut self, rhs: ~[T]);
     /// Remove the last element from a vector and return it, or `None` if it is empty
     fn pop(&mut self) -> Option<T>;
-    /// Removes the first element from a vector and return it
-    fn shift(&mut self) -> T;
     /// Removes the first element from a vector and return it, or `None` if it is empty
-    fn shift_opt(&mut self) -> Option<T>;
+    fn shift(&mut self) -> Option<T>;
     /// Prepend an element to the vector
     fn unshift(&mut self, x: T);
 
@@ -1578,14 +1576,11 @@ impl<T> OwnedVector<T> for ~[T] {
 
 
     #[inline]
-    fn shift(&mut self) -> T {
-        self.shift_opt().expect("shift: empty vector")
-    }
-
-    fn shift_opt(&mut self) -> Option<T> {
+    fn shift(&mut self) -> Option<T> {
         self.remove_opt(0)
     }
 
+    #[inline]
     fn unshift(&mut self, x: T) {
         self.insert(0, x)
     }
@@ -1645,7 +1640,7 @@ impl<T> OwnedVector<T> for ~[T] {
         if index < ln - 1 {
             self.swap(index, ln - 1);
         }
-        self.pop()
+        self.pop().unwrap()
     }
     fn truncate(&mut self, newlen: uint) {
         let oldlen = self.len();
@@ -3580,21 +3575,11 @@ mod tests {
     #[test]
     fn test_shift() {
         let mut x = ~[1, 2, 3];
-        assert_eq!(x.shift(), 1);
+        assert_eq!(x.shift(), Some(1));
         assert_eq!(&x, &~[2, 3]);
-        assert_eq!(x.shift(), 2);
-        assert_eq!(x.shift(), 3);
-        assert_eq!(x.len(), 0);
-    }
-
-    #[test]
-    fn test_shift_opt() {
-        let mut x = ~[1, 2, 3];
-        assert_eq!(x.shift_opt(), Some(1));
-        assert_eq!(&x, &~[2, 3]);
-        assert_eq!(x.shift_opt(), Some(2));
-        assert_eq!(x.shift_opt(), Some(3));
-        assert_eq!(x.shift_opt(), None);
+        assert_eq!(x.shift(), Some(2));
+        assert_eq!(x.shift(), Some(3));
+        assert_eq!(x.shift(), None);
         assert_eq!(x.len(), 0);
     }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -941,7 +941,7 @@ pub trait ImmutableVector<'a, T> {
 
     /// Returns the element of a vector at the given index, or `None` if the
     /// index is out of bounds
-    fn get_opt(&self, index: uint) -> Option<&'a T>;
+    fn get(&self, index: uint) -> Option<&'a T>;
     /// Returns the first element of a vector, failing if the vector is empty.
     fn head(&self) -> &'a T;
     /// Returns the first element of a vector, or `None` if it is empty
@@ -1118,7 +1118,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
     }
 
     #[inline]
-    fn get_opt(&self, index: uint) -> Option<&'a T> {
+    fn get(&self, index: uint) -> Option<&'a T> {
         if index < self.len() { Some(&self[index]) } else { None }
     }
 
@@ -3043,13 +3043,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_opt() {
+    fn test_get() {
         let mut a = ~[11];
-        assert_eq!(a.get_opt(1), None);
+        assert_eq!(a.get(1), None);
         a = ~[11, 12];
-        assert_eq!(a.get_opt(1).unwrap(), &12);
+        assert_eq!(a.get(1).unwrap(), &12);
         a = ~[11, 12, 13];
-        assert_eq!(a.get_opt(1).unwrap(), &12);
+        assert_eq!(a.get(1).unwrap(), &12);
     }
 
     #[test]

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -340,7 +340,7 @@ impl<F: FoldOps> Folder for Ctx<F> {
             _ => {}
         }
 
-        self.path.pop();
+        self.path.pop().unwrap();
 
         SmallVector::one(i)
     }

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -106,7 +106,7 @@ fn pretty_ty(ty: &Ty, itr: @IdentInterner, out: &mut ~str) {
         // need custom handling.
         TyNil => { out.push_str("$NIL$"); return }
         TyPath(ref path, _, _) => {
-            out.push_str(itr.get(path.segments.last().identifier.name));
+            out.push_str(itr.get(path.segments.last().unwrap().identifier.name));
             return
         }
         TyTup(ref tys) => {
@@ -139,7 +139,7 @@ pub fn impl_pretty_name(trait_ref: &Option<TraitRef>, ty: &Ty) -> PathElem {
     match *trait_ref {
         None => pretty = ~"",
         Some(ref trait_ref) => {
-            pretty = itr.get(trait_ref.path.segments.last().identifier.name).to_owned();
+            pretty = itr.get(trait_ref.path.segments.last().unwrap().identifier.name).to_owned();
             pretty.push_char('$');
         }
     };

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -31,7 +31,7 @@ pub fn path_name_i(idents: &[Ident]) -> ~str {
 // totally scary function: ignores all but the last element, should have
 // a different name
 pub fn path_to_ident(path: &Path) -> Ident {
-    path.segments.last().identifier
+    path.segments.last().unwrap().identifier
 }
 
 pub fn local_def(id: NodeId) -> DefId {
@@ -913,7 +913,7 @@ pub fn xorPush(marks: &mut ~[Mrk], mark: Mrk) {
 // get the last element of a mutable array.
 // FIXME #4903: , must be a separate procedure for now.
 pub fn getLast(arr: &~[Mrk]) -> Mrk {
-    *arr.last()
+    *arr.last().unwrap()
 }
 
 // are two paths equal when compared unhygienically?

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -904,7 +904,7 @@ pub fn mtwt_outer_mark(ctxt: SyntaxContext) -> Mrk {
 /// case pop and discard (so two of the same marks cancel)
 pub fn xorPush(marks: &mut ~[Mrk], mark: Mrk) {
     if (marks.len() > 0) && (getLast(marks) == mark) {
-        marks.pop();
+        marks.pop().unwrap();
     } else {
         marks.push(mark);
     }

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -269,12 +269,9 @@ impl CodeMap {
 
     pub fn new_filemap(&self, filename: FileName, src: @str) -> @FileMap {
         let mut files = self.files.borrow_mut();
-        let start_pos = if files.get().len() == 0 {
-            0
-        } else {
-            let last_start = files.get().last().start_pos.to_uint();
-            let last_len = files.get().last().src.len();
-            last_start + last_len
+        let start_pos = match files.get().last() {
+            None => 0,
+            Some(last) => last.start_pos.to_uint() + last.src.len(),
         };
 
         let filemap = @FileMap {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -356,7 +356,7 @@ impl<'a> ExtCtxt<'a> {
     pub fn print_backtrace(&self) { }
     pub fn backtrace(&self) -> Option<@ExpnInfo> { self.backtrace }
     pub fn mod_push(&mut self, i: ast::Ident) { self.mod_path.push(i); }
-    pub fn mod_pop(&mut self) { self.mod_path.pop(); }
+    pub fn mod_pop(&mut self) { self.mod_path.pop().unwrap(); }
     pub fn mod_path(&self) -> ~[ast::Ident] { self.mod_path.clone() }
     pub fn bt_push(&mut self, ei: codemap::ExpnInfo) {
         match ei {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -253,7 +253,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 lifetimes: OptVec<ast::Lifetime>,
                 types: ~[P<ast::Ty>])
                 -> ast::Path {
-        let last_identifier = idents.pop();
+        let last_identifier = idents.pop().unwrap();
         let mut segments: ~[ast::PathSegment] = idents.move_iter()
                                                       .map(|ident| {
             ast::PathSegment {

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -841,7 +841,7 @@ impl<'a> MethodDef<'a> {
                                                      matching,
                                                      matches_so_far,
                                                      match_count + 1);
-                matches_so_far.pop();
+                matches_so_far.pop().unwrap();
                 arms.push(cx.arm(trait_.span, ~[ pattern ], arm_expr));
 
                 if enum_def.variants.len() > 1 {
@@ -875,7 +875,7 @@ impl<'a> MethodDef<'a> {
                                                          new_matching,
                                                          matches_so_far,
                                                          match_count + 1);
-                    matches_so_far.pop();
+                    matches_so_far.pop().unwrap();
 
                     let arm = cx.arm(trait_.span, ~[ pattern ], arm_expr);
                     arms.push(arm);

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -920,7 +920,7 @@ enum StructType {
 // general helper methods.
 impl<'a> TraitDef<'a> {
     fn set_expn_info(&self, mut to_set: Span) -> Span {
-        let trait_name = match self.path.path.last_opt() {
+        let trait_name = match self.path.path.last() {
             None => self.cx.span_bug(self.span, "trait with empty path in generic `deriving`"),
             Some(name) => *name
         };

--- a/src/libsyntax/ext/registrar.rs
+++ b/src/libsyntax/ext/registrar.rs
@@ -42,7 +42,7 @@ pub fn find_macro_registrar(diagnostic: @diagnostic::SpanHandler,
     match ctx.registrars.len() {
         0 => None,
         1 => {
-            let (node_id, _) = ctx.registrars.pop();
+            let (node_id, _) = ctx.registrars.pop().unwrap();
             Some(ast::DefId {
                 crate: ast::LOCAL_CRATE,
                 node: node_id

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -109,7 +109,7 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         }
         Ok(bytes) => bytes,
     };
-    match str::from_utf8_owned_opt(bytes) {
+    match str::from_utf8_owned(bytes) {
         Some(src) => {
             // Add this input file to the code map to make it available as
             // dependency information

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -238,8 +238,11 @@ pub fn parse(sess: @ParseSess,
         let TokenAndSpan {tok: tok, sp: sp} = rdr.peek();
 
         /* we append new items to this while we go */
-        while !cur_eis.is_empty() { /* for each Earley Item */
-            let ei = cur_eis.pop();
+        loop {
+            let ei = match cur_eis.pop() {
+                None => break, /* for each Earley Item */
+                Some(ei) => ei,
+            };
 
             let idx = ei.idx;
             let len = ei.elts.len();
@@ -347,7 +350,7 @@ pub fn parse(sess: @ParseSess,
             if eof_eis.len() == 1u {
                 let mut v = ~[];
                 for dv in eof_eis[0u].matches.mut_iter() {
-                    v.push(dv.pop());
+                    v.push(dv.pop().unwrap());
                 }
                 return Success(nameize(sess, ms, v));
             } else if eof_eis.len() > 1u {
@@ -376,13 +379,13 @@ pub fn parse(sess: @ParseSess,
             } else if next_eis.len() > 0u {
                 /* Now process the next token */
                 while next_eis.len() > 0u {
-                    cur_eis.push(next_eis.pop());
+                    cur_eis.push(next_eis.pop().unwrap());
                 }
                 rdr.next_token();
             } else /* bb_eis.len() == 1 */ {
                 let mut rust_parser = Parser(sess, cfg.clone(), rdr.dup());
 
-                let mut ei = bb_eis.pop();
+                let mut ei = bb_eis.pop().unwrap();
                 match ei.elts[ei.idx].node {
                   MatchNonterminal(_, ref name, idx) => {
                     ei.matches[idx].push(@MatchedNonterminal(

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -190,7 +190,8 @@ pub fn tt_next_token(r: &TtReader) -> TokenAndSpan {
         if !r.stack.get().dotdotdoted || {
                 let repeat_idx = r.repeat_idx.borrow();
                 let repeat_len = r.repeat_len.borrow();
-                *repeat_idx.get().last() == *repeat_len.get().last() - 1
+                *repeat_idx.get().last().unwrap() ==
+                *repeat_len.get().last().unwrap() - 1
             } {
 
             match r.stack.get().up {

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -204,8 +204,8 @@ pub fn tt_next_token(r: &TtReader) -> TokenAndSpan {
                     {
                         let mut repeat_idx = r.repeat_idx.borrow_mut();
                         let mut repeat_len = r.repeat_len.borrow_mut();
-                        repeat_idx.get().pop();
-                        repeat_len.get().pop();
+                        repeat_idx.get().pop().unwrap();
+                        repeat_len.get().pop().unwrap();
                     }
                 }
 

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -55,10 +55,10 @@ impl<T> OptVec<T> {
         }
     }
 
-    pub fn last<'a>(&'a self) -> &'a T {
+    pub fn last<'a>(&'a self) -> Option<&'a T> {
         match *self {
             Vec(ref v) => v.last(),
-            Empty => fail!("last on empty opt_vec")
+            Empty => None
         }
     }
 

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -48,10 +48,10 @@ impl<T> OptVec<T> {
         }
     }
 
-    pub fn pop(&mut self) -> T {
+    pub fn pop(&mut self) -> Option<T> {
         match *self {
             Vec(ref mut v) => v.pop(),
-            Empty => fail!("pop from empty opt_vec")
+            Empty => None
         }
     }
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -351,7 +351,7 @@ pub fn gather_comments_and_literals(span_diagnostic:
                                     path: @str,
                                     srdr: &mut io::Reader)
                                  -> (~[Comment], ~[Literal]) {
-    let src = str::from_utf8_owned(srdr.read_to_end()).to_managed();
+    let src = str::from_utf8_owned(srdr.read_to_end()).unwrap().to_managed();
     let cm = CodeMap::new();
     let filemap = cm.new_filemap(path, src);
     let rdr = lexer::new_low_level_string_reader(span_diagnostic, filemap);

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -246,7 +246,7 @@ pub fn file_to_filemap(sess: @ParseSess, path: &Path, spanopt: Option<Span>)
             unreachable!()
         }
     };
-    match str::from_utf8_owned_opt(bytes) {
+    match str::from_utf8_owned(bytes) {
         Some(s) => {
             return string_to_filemap(sess, s.to_managed(),
                                      path.as_str().unwrap().to_managed());
@@ -315,7 +315,7 @@ mod test {
         let mut writer = MemWriter::new();
         let mut encoder = extra::json::Encoder::new(&mut writer as &mut io::Writer);
         val.encode(&mut encoder);
-        str::from_utf8_owned(writer.unwrap())
+        str::from_utf8_owned(writer.unwrap()).unwrap()
     }
 
     // produce a codemap::span

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1753,19 +1753,19 @@ impl Parser {
                 return self.mk_expr(lo, hi, ExprLit(lit));
             }
             let mut es = ~[self.parse_expr()];
-            self.commit_expr(*es.last(), &[], &[token::COMMA, token::RPAREN]);
+            self.commit_expr(*es.last().unwrap(), &[], &[token::COMMA, token::RPAREN]);
             while self.token == token::COMMA {
                 self.bump();
                 if self.token != token::RPAREN {
                     es.push(self.parse_expr());
-                    self.commit_expr(*es.last(), &[], &[token::COMMA, token::RPAREN]);
+                    self.commit_expr(*es.last().unwrap(), &[], &[token::COMMA, token::RPAREN]);
                 }
                 else {
                     trailing_comma = true;
                 }
             }
             hi = self.span.hi;
-            self.commit_expr_expecting(*es.last(), token::RPAREN);
+            self.commit_expr_expecting(*es.last().unwrap(), token::RPAREN);
 
             return if es.len() == 1 && !trailing_comma {
                 self.mk_expr(lo, self.span.hi, ExprParen(es[0]))
@@ -1924,7 +1924,8 @@ impl Parser {
 
                     fields.push(self.parse_field());
                     while self.token != token::RBRACE {
-                        self.commit_expr(fields.last().expr, &[token::COMMA], &[token::RBRACE]);
+                        self.commit_expr(fields.last().unwrap().expr,
+                                         &[token::COMMA], &[token::RBRACE]);
 
                         if self.eat(&token::DOTDOT) {
                             base = Some(self.parse_expr());
@@ -1939,7 +1940,7 @@ impl Parser {
                     }
 
                     hi = pth.span.hi;
-                    self.commit_expr_expecting(fields.last().expr, token::RBRACE);
+                    self.commit_expr_expecting(fields.last().unwrap().expr, token::RBRACE);
                     ex = ExprStruct(pth, fields, base);
                     return self.mk_expr(lo, hi, ex);
                 }
@@ -2092,7 +2093,7 @@ impl Parser {
                   // This is a conservative error: only report the last unclosed delimiter. The
                   // previous unclosed delimiters could actually be closed! The parser just hasn't
                   // gotten to them yet.
-                  match p.open_braces.last_opt() {
+                  match p.open_braces.last() {
                       None => {}
                       Some(&sp) => p.span_note(sp, "unclosed delimiter"),
                   };

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2158,7 +2158,7 @@ impl Parser {
 
                 // Parse the close delimiter.
                 result.push(parse_any_tt_tok(self));
-                self.open_braces.pop();
+                self.open_braces.pop().unwrap();
 
                 TTDelim(@result)
             }
@@ -3593,7 +3593,7 @@ impl Parser {
                 }
             );
 
-        let variadic = match args.pop_opt() {
+        let variadic = match args.pop() {
             Some(None) => true,
             Some(x) => {
                 // Need to put back that last arg
@@ -4218,7 +4218,7 @@ impl Parser {
     }
 
     fn pop_mod_path(&mut self) {
-        self.mod_path_stack.pop();
+        self.mod_path_stack.pop().unwrap();
     }
 
     // read a module from a source file.

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -511,7 +511,7 @@ impl Printer {
             debug!("print End -> pop End");
             let print_stack = &mut self.print_stack;
             assert!((print_stack.len() != 0u));
-            print_stack.pop();
+            print_stack.pop().unwrap();
           }
           Break(b) => {
             let top = self.get_top();

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2316,7 +2316,7 @@ pub fn print_string(s: &mut State, st: &str, style: ast::StrStyle) {
 // downcasts.
 unsafe fn get_mem_writer(writer: &mut ~io::Writer) -> ~str {
     let (_, wr): (uint, ~MemWriter) = cast::transmute_copy(writer);
-    let result = str::from_utf8_owned(wr.get_ref().to_owned());
+    let result = str::from_utf8_owned(wr.get_ref().to_owned()).unwrap();
     cast::forget(wr);
     result
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -78,7 +78,7 @@ pub fn ibox(s: &mut State, u: uint) {
 pub fn end(s: &mut State) {
     {
         let mut boxes = s.boxes.borrow_mut();
-        boxes.get().pop();
+        boxes.get().pop().unwrap();
     }
     pp::end(&mut s.s);
 }
@@ -1090,11 +1090,11 @@ pub fn print_call_pre(s: &mut State,
     match sugar {
         ast::DoSugar => {
             head(s, "do");
-            Some(base_args.pop())
+            Some(base_args.pop().unwrap())
         }
         ast::ForSugar => {
             head(s, "for");
-            Some(base_args.pop())
+            Some(base_args.pop().unwrap())
         }
         ast::NoSugar => None
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1947,7 +1947,7 @@ pub fn print_view_path(s: &mut State, vp: &ast::ViewPath) {
     match vp.node {
       ast::ViewPathSimple(ident, ref path, _) => {
         // FIXME(#6993) can't compare identifiers directly here
-        if path.segments.last().identifier.name != ident.name {
+        if path.segments.last().unwrap().identifier.name != ident.name {
             print_ident(s, ident);
             space(&mut s.s);
             word_space(s, "=");

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -65,7 +65,7 @@ fn shift_push() {
     let mut v2 = ~[];
 
     while v1.len() > 0 {
-        v2.push(v1.shift());
+        v2.push(v1.shift().unwrap());
     }
 }
 

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -40,7 +40,7 @@ fn recv(p: &pipe) -> uint {
             while state.is_empty() {
                 cond.wait();
             }
-            state.pop()
+            state.pop().unwrap()
         })
     }
 }

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -37,7 +37,7 @@ fn recv(p: &pipe) -> uint {
         while state.is_empty() {
             cond.wait();
         }
-        state.pop()
+        state.pop().unwrap()
     })
 }
 

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -59,7 +59,7 @@ impl Code {
         }
 
         reverse(result);
-        str::from_utf8_owned(result)
+        str::from_utf8_owned(result).unwrap()
     }
 }
 

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -187,7 +187,7 @@ fn to_utf8(raw_sol: &List<u64>) -> ~str {
             if m & 1 << i != 0 {sol[i] = '0' as u8 + id;}
         }
     }
-    std::str::from_utf8_owned(sol)
+    std::str::from_utf8_owned(sol).unwrap()
 }
 
 // Prints a solution in ~str form.

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -91,7 +91,7 @@ fn recurse_or_fail(depth: int, st: Option<State>) {
                 unique: ~Cons((), @*st.unique),
                 tuple: (@Cons((), st.tuple.first()),
                         ~Cons((), @*st.tuple.second())),
-                vec: st.vec + &[@Cons((), *st.vec.last())],
+                vec: st.vec + &[@Cons((), *st.vec.last().unwrap())],
                 res: r(@Cons((), st.res._l))
             }
           }

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -62,14 +62,14 @@ fn test_destroy_actually_kills(force: bool) {
     fn process_exists(pid: libc::pid_t) -> bool {
         let run::ProcessOutput {output, ..} = run::process_output("ps", [~"-p", pid.to_str()])
             .expect("failed to exec `ps`");
-        str::from_utf8_owned(output).contains(pid.to_str())
+        str::from_utf8_owned(output).unwrap().contains(pid.to_str())
     }
 
     #[cfg(unix,target_os="android")]
     fn process_exists(pid: libc::pid_t) -> bool {
         let run::ProcessOutput {output, ..} = run::process_output("/system/bin/ps", [pid.to_str()])
             .expect("failed to exec `/system/bin/ps`");
-        str::from_utf8_owned(output).contains(~"root")
+        str::from_utf8_owned(output).unwrap().contains(~"root")
     }
 
     #[cfg(windows)]

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -81,7 +81,7 @@ mod map_reduce {
               mapper_done => { num_mappers -= 1; }
               find_reducer(k, cc) => {
                 let mut c;
-                match reducers.find(&str::from_utf8(k).to_owned()) {
+                match reducers.find(&str::from_utf8(k).unwrap().to_owned()) {
                   Some(&_c) => { c = _c; }
                   None => { c = 0; }
                 }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -260,7 +260,7 @@ fn test_write() {
         writeln!(w, "{foo}", foo="bar");
     }
 
-    let s = str::from_utf8_owned(buf.unwrap());
+    let s = str::from_utf8_owned(buf.unwrap()).unwrap();
     t!(s, "34helloline\nbar\n");
 }
 
@@ -284,7 +284,7 @@ fn test_format_args() {
         format_args!(|args| { fmt::write(w, args) }, "test");
         format_args!(|args| { fmt::write(w, args) }, "{test}", test=3);
     }
-    let s = str::from_utf8_owned(buf.unwrap());
+    let s = str::from_utf8_owned(buf.unwrap()).unwrap();
     t!(s, "1test3");
 
     let s = format_args!(fmt::format, "hello {}", "world");


### PR DESCRIPTION
[On 2013-12-06, I wrote to the rust-dev mailing list](https://mail.mozilla.org/pipermail/rust-dev/2013-December/007263.html):

> Subject: Let’s avoid having both foo() and foo_opt()
> 
> We have some functions and methods such as [std::str::from_utf8](http://static.rust-lang.org/doc/master/std/str/fn.from_utf8.html) that may succeed and give a result, or fail when the input is invalid.
> 1. Sometimes we assume the input is valid and don’t want to deal with the error case. Task failure works nicely.
> 2. Sometimes we do want to do something different on invalid input, so returning an `Option<T>` works best.
> 
> And so we end up with both `from_utf8` and `from_utf8`. This particular case is worse because we also have `from_utf8_owned` and `from_utf8_owned_opt`, to cover everything.
> 
> Multiplying names like this is just not good design. I’d like to reduce this pattern.
> 
> Getting behavior 1. when you have 2. is easy: just call `.unwrap()` on the Option. I think we should rename every `foo_opt()` function or method to just `foo`, remove the old `foo()` behavior, and tell people (through documentation) to use `foo().unwrap()` if they want it back?
> 
> The downsides are that unwrap is more verbose and gives less helpful error messages on task failure. But I think it’s worth it.

The email discussion has gone around long enough. Let’s discuss a concrete proposal. For the following functions or methods, I removed `foo` (that caused task failure) and renamed `foo_opt` (that returns `Option`) to just `foo`.

Vector methods:
- `get_opt` (rename only, `get` did not exist as it would have been just `[]`)
- `head_opt`
- `last_opt`
- `pop_opt`
- `shift_opt`
- `remove_opt`

`std::path::BytesContainer` method:
- `container_as_str_opt`

`std::str` functions:
- `from_utf8_opt`
- `from_utf8_owned_opt` (also remove the now unused `not_utf8` condition)

Is there something else that should recieve the same treatement?

I did not rename `recv_opt` on channels based on @brson’s [feedback](https://mail.mozilla.org/pipermail/rust-dev/2013-December/007270.html).

Feel free to pick only some of these commits.
