### PR TITLE
Avoid compiler error about glob imports in getopts example

### DIFF
--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -31,7 +31,7 @@
 //!
 //! ~~~{.rust}
 //! extern mod extra;
-//! use extra::getopts::*;
+//! use extra::getopts::{optopt,optflag,getopts};
 //! use std::os;
 //!
 //! fn do_work(inp: &str, out: Option<~str>) {

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -31,7 +31,7 @@
 //!
 //! ~~~{.rust}
 //! extern mod extra;
-//! use extra::getopts::{optopt,optflag,getopts};
+//! use extra::getopts::{optopt,optflag,getopts,Opt};
 //! use std::os;
 //!
 //! fn do_work(inp: &str, out: Option<~str>) {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -138,7 +138,6 @@ fn maketest(s: &str, cratename: &str) -> @str {
     let mut prog = ~r"
 #[deny(warnings)];
 #[allow(unused_variable, dead_assignment, unused_mut, attribute_usage, dead_code)];
-#[feature(macro_rules, globs, struct_variant, managed_boxes)];
 ";
     if s.contains("extra") {
         prog.push_str("extern mod extra;\n");

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -38,11 +38,15 @@ there are three common kinds of strings in rust:
 As an example, here's a few different kinds of strings.
 
 ```rust
-let owned_string = ~"I am an owned string";
-let managed_string = @"This string is garbage-collected";
-let borrowed_string1 = "This string is borrowed with the 'static lifetime";
-let borrowed_string2: &str = owned_string;   // owned strings can be borrowed
-let borrowed_string3: &str = managed_string; // managed strings can also be borrowed
+#[feature(managed_boxes)];
+
+fn main() {
+    let owned_string = ~"I am an owned string";
+    let managed_string = @"This string is garbage-collected";
+    let borrowed_string1 = "This string is borrowed with the 'static lifetime";
+    let borrowed_string2: &str = owned_string;   // owned strings can be borrowed
+    let borrowed_string3: &str = managed_string; // managed strings can also be borrowed
+}
  ```
 
 From the example above, you can see that rust has 3 different kinds of string


### PR DESCRIPTION
Ran into this in practice, fixing it to improve example correctness.
