### PR TITLE
Implement the #[boot] attribute

### DIFF
--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -56,8 +56,18 @@ pub mod sleeper_list;
 pub mod stack;
 pub mod task;
 
+#[boot]
+#[cfg(not(stage0))]
+pub fn boot(main: fn()) {
+    simple::task().run(|| {
+        do run {
+            main();
+        };
+    });
+}
+
 #[lang = "start"]
-#[cfg(not(test))]
+#[cfg(not(test), stage0)]
 pub fn lang_start(main: *u8, argc: int, argv: **u8) -> int {
     use std::cast;
     do start(argc, argv) {

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -33,27 +33,23 @@ mod bookeeping;
 pub mod io;
 pub mod task;
 
-// XXX: this should not exist here
-#[cfg(stage0, nativestart)]
-#[lang = "start"]
-pub fn lang_start(main: *u8, argc: int, argv: **u8) -> int {
-    use std::cast;
-    use std::task;
-
-    do start(argc, argv) {
+#[cfg(not(stage0))]
+#[boot]
+pub fn boot(main: fn()) {
+    task::new().run(||{
+        use std::task;
         // Instead of invoking main directly on this thread, invoke it on
         // another spawned thread that we are guaranteed to know the size of the
         // stack of. Currently, we do not have a method of figuring out the size
         // of the main thread's stack, so for stack overflow detection to work
         // we must spawn the task in a subtask which we know the stack size of.
-        let main: extern "Rust" fn() = unsafe { cast::transmute(main) };
         let mut task = task::task();
         task.name("<main>");
         match do task.try { main() } {
             Ok(()) => { os::set_exit_status(0); }
             Err(..) => { os::set_exit_status(rt::DEFAULT_ERROR_CODE); }
         }
-    }
+    });
 }
 
 /// Executes the given procedure after initializing the runtime with the given

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -107,10 +107,10 @@ pub fn spawn_opts(opts: TaskOpts, f: proc()) {
 
 // This structure is the glue between channels and the 1:1 scheduling mode. This
 // structure is allocated once per task.
-struct Ops {
-    lock: Mutex,       // native synchronization
-    awoken: bool,      // used to prevent spurious wakeups
-    io: io::IoFactory, // local I/O factory
+pub struct Ops {
+    priv lock: Mutex,       // native synchronization
+    priv awoken: bool,      // used to prevent spurious wakeups
+    priv io: io::IoFactory, // local I/O factory
 
     // This field holds the known bounds of the stack in (lo, hi) form. Not all
     // native tasks necessarily know their precise bounds, hence this is

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -248,6 +248,9 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     time(time_passes, "looking for entry point", (),
          |_| middle::entry::find_entry_point(sess, crate, ast_map));
 
+    time(time_passes, "looking for boot function", (),
+         |_| middle::entry::find_boot_fn(sess, crate));
+
     let freevars = time(time_passes, "freevar finding", (), |_|
                         freevars::annotate_freevars(def_map, crate));
 
@@ -912,6 +915,7 @@ pub fn build_session_(sopts: @session::options,
         // For a library crate, this is always none
         entry_fn: RefCell::new(None),
         entry_type: Cell::new(None),
+        boot_fn: Cell::new(None),
         span_diagnostic: span_diagnostic_handler,
         filesearch: filesearch,
         building_library: Cell::new(false),

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -17,16 +17,15 @@ use metadata::filesearch;
 use metadata;
 use middle::lint;
 
+use syntax;
+use syntax::abi;
+use syntax::ast;
 use syntax::attr::AttrMetaMethods;
-use syntax::ast::NodeId;
-use syntax::ast::{IntTy, UintTy};
 use syntax::codemap::Span;
+use syntax::codemap;
 use syntax::diagnostic;
 use syntax::parse::ParseSess;
-use syntax::{ast, codemap};
-use syntax::abi;
 use syntax::parse::token;
-use syntax;
 
 use std::cell::{Cell, RefCell};
 use std::hashmap::{HashMap,HashSet};
@@ -35,8 +34,8 @@ pub struct config {
     os: abi::Os,
     arch: abi::Architecture,
     target_strs: target_strs::t,
-    int_type: IntTy,
-    uint_type: UintTy,
+    int_type: ast::IntTy,
+    uint_type: ast::UintTy,
 }
 
 pub static verbose:                 uint = 1 <<  0;
@@ -210,6 +209,7 @@ pub struct Session_ {
     entry_fn: RefCell<Option<(NodeId, codemap::Span)>>,
     entry_type: Cell<Option<EntryFnType>>,
     span_diagnostic: @diagnostic::SpanHandler,
+    boot_fn: Cell<Option<ast::DefId>>,
     filesearch: @filesearch::FileSearch,
     building_library: Cell<bool>,
     working_dir: Path,

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -204,6 +204,8 @@ pub static tag_native_libraries_lib: uint = 0x104;
 pub static tag_native_libraries_name: uint = 0x105;
 pub static tag_native_libraries_kind: uint = 0x106;
 
+pub static tag_boot_fn: uint = 0x107;
+
 #[deriving(Clone)]
 pub struct LinkMeta {
     crateid: CrateId,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -301,3 +301,8 @@ pub fn get_trait_of_method(cstore: @cstore::CStore,
     decoder::get_trait_of_method(cdata, def_id.node, tcx)
 }
 
+pub fn get_boot_fn(cstore: @mut cstore::CStore,
+                   crate: ast::CrateNum) -> Option<ast::DefId> {
+    let cdata = cstore.get_crate_data(crate);
+    decoder::get_boot_fn(cdata)
+}

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1275,3 +1275,9 @@ pub fn get_native_libraries(cdata: Cmd) -> ~[(cstore::NativeLibaryKind, ~str)] {
     });
     return result;
 }
+
+pub fn get_boot_fn(cdata: Cmd) -> Option<ast::DefId> {
+    reader::maybe_get_doc(reader::Doc(cdata.data()), tag_boot_fn).map(|doc| {
+        item_def_id(doc, cdata)
+    })
+}

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -877,7 +877,7 @@ fn check_heap_item(cx: &Context, it: &ast::Item) {
 }
 
 static crate_attrs: &'static [&'static str] = &[
-    "crate_type", "feature", "no_uv", "no_main", "no_std", "crate_id",
+    "crate_type", "feature", "no_uv", "no_main", "no_std", "crate_id", "no_boot",
     "desc", "comment", "license", "copyright", // not used in rustc now
 ];
 
@@ -906,7 +906,7 @@ static other_attrs: &'static [&'static str] = &[
 
     // fn-level
     "test", "bench", "should_fail", "ignore", "inline", "lang", "main", "start",
-    "no_split_stack", "cold",
+    "no_split_stack", "cold", "boot",
 
     // internal attribute: bypass privacy inside items
     "!resolve_unexported",

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -30,7 +30,6 @@ use std::libc::c_uint;
 use std::vec;
 use syntax::abi::{Cdecl, Aapcs, C, AbiSet, Win64};
 use syntax::abi::{RustIntrinsic, Rust, Stdcall, Fastcall, System};
-use syntax::codemap::Span;
 use syntax::parse::token::special_idents;
 use syntax::{ast};
 use syntax::{attr, ast_map};
@@ -408,7 +407,6 @@ pub fn trans_foreign_mod(ccx: @CrateContext,
 // correct code in the first place, but this is much simpler.
 
 pub fn register_rust_fn_with_foreign_abi(ccx: @CrateContext,
-                                         sp: Span,
                                          sym: ~str,
                                          node_id: ast::NodeId)
                                          -> ValueRef {
@@ -425,7 +423,6 @@ pub fn register_rust_fn_with_foreign_abi(ccx: @CrateContext,
         _ => lib::llvm::CCallConv
     };
     let llfn = base::register_fn_llvmty(ccx,
-                                        sp,
                                         sym,
                                         node_id,
                                         cconv,

--- a/src/libstd/unstable/lang.rs
+++ b/src/libstd/unstable/lang.rs
@@ -79,3 +79,19 @@ pub unsafe fn check_not_borrowed(a: *u8,
                                  line: size_t) {
     borrowck::check_not_borrowed(a, file, line)
 }
+
+#[lang = "start"]
+#[cfg(not(stage0))]
+pub fn lang_start(main: *u8, boot: *u8, argc: int, argv: **u8) -> int {
+    use cast;
+    use rt;
+    use os;
+    rt::init(argc, argv);
+    {
+        let main: fn() = unsafe { cast::transmute(main) };
+        let boot: fn(fn()) = unsafe { cast::transmute(boot) };
+        boot(main);
+    }
+    unsafe { rt::cleanup(); }
+    os::get_exit_status()
+}

--- a/src/test/compile-fail/boot-1.rs
+++ b/src/test/compile-fail/boot-1.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: no #[boot] functions found
+
+#[no_boot];
+
+fn main() {}

--- a/src/test/compile-fail/boot-2.rs
+++ b/src/test/compile-fail/boot-2.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: too many #[boot] functions found
+
+#[no_boot];
+
+#[boot] extern mod green;
+#[boot] extern mod native;
+
+fn main() {}
+

--- a/src/test/compile-fail/boot-3.rs
+++ b/src/test/compile-fail/boot-3.rs
@@ -1,0 +1,22 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: too many #[boot] functions found
+
+#[no_boot];
+
+#[boot] extern mod green;
+
+#[boot]
+fn boot() {}
+
+fn main() {}
+
+

--- a/src/test/compile-fail/boot-4.rs
+++ b/src/test/compile-fail/boot-4.rs
@@ -1,0 +1,19 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: too many #[boot] functions found
+
+#[boot]
+fn boot() {}
+
+fn main() {}
+
+
+

--- a/src/test/run-pass/boot-1.rs
+++ b/src/test/run-pass/boot-1.rs
@@ -1,0 +1,16 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_boot];
+
+#[boot] fn boot(_: fn()) {}
+
+fn main() {}
+

--- a/src/test/run-pass/boot-2.rs
+++ b/src/test/run-pass/boot-2.rs
@@ -1,0 +1,29 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_boot];
+
+#[boot] extern mod green;
+
+use std::rt::task::Task;
+use std::rt::local::Local;
+use std::rt::Runtime;
+
+fn main() {
+    let mut t = Local::borrow(None::<Task>);
+    match t.get().maybe_take_runtime::<green::task::GreenTask>() {
+        Some(rt) => {
+            t.get().put_runtime(rt as ~Runtime);
+        }
+        None => fail!()
+    }
+}
+
+

--- a/src/test/run-pass/boot-3.rs
+++ b/src/test/run-pass/boot-3.rs
@@ -1,0 +1,30 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_boot];
+
+#[boot] extern mod native;
+
+use std::rt::task::Task;
+use std::rt::local::Local;
+use std::rt::Runtime;
+
+fn main() {
+    let mut t = Local::borrow(None::<Task>);
+    match t.get().maybe_take_runtime::<native::task::Ops>() {
+        Some(rt) => {
+            t.get().put_runtime(rt as ~Runtime);
+        }
+        None => fail!()
+    }
+}
+
+
+

--- a/src/test/run-pass/boot-4.rs
+++ b/src/test/run-pass/boot-4.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern mod native;
+extern mod green;
+
+fn main() {
+}


### PR DESCRIPTION
Before this patch there was no ability to link to both libnative and libgreen
and specify which should be used to boot the main function. This commit moves
this logic into a #[boot] attribute which can allow control over this. The
changes made are:
1. The lang_start function is moved back into libstd with the signature:
   fn(*u8, *u8, int, *u8) or (main, boot, argc, argv)
2. Functions can now be tagged with #[boot] to indicate that the function can be
   used to boot a rust crate. This boot function is serialized to metadata.
3. Imports of external modules can also be tagged with #[boot] to indicate that
   the crate's boot-function should be used to boot the runtime
4. Only one #[boot] function/crate is allowed in an executable, more than one is
   an error (along with zero as well).
5. The compiler will automatically inject '#[boot] extern mod green;' for now,
   this can be overrided with #[no_boot].

With this new attribute, control over how a crate boots can be fine-tuned per
executable and libraries can specify arbitrary boot functions. The boot function
is purely responsible for dictating what context the 'main' function is run in,
runtime initialization via rt::init is not the responsibility of the boot
function. Finally, the boot function is also responsible for blocking until all
rust tasks have exited.
