### PR TITLE
Generate --dep-info earlier in the compillation

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -167,6 +167,7 @@ pub struct options {
     test: bool,
     parse_only: bool,
     no_trans: bool,
+    no_analysis: bool,
     debugging_opts: uint,
     android_cross_path: Option<~str>,
     /// Whether to write dependency files. It's (enabled, optional filename).
@@ -398,6 +399,7 @@ pub fn basic_options() -> @options {
         test: false,
         parse_only: false,
         no_trans: false,
+        no_analysis: false,
         debugging_opts: 0u,
         android_cross_path: None,
         write_dependency_info: (false, None),

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -405,7 +405,7 @@ pub fn compile_crate_from_input(input: &Path,
     // -c
     if driver::stop_after_phase_5(sess)
         || stop_before == Link || stop_before == Assemble { return Some(outputs.out_filename); }
-    driver::phase_6_link_output(sess, &translation, &file_input, outputs);
+    driver::phase_6_link_output(sess, &translation, outputs);
 
     // Register dependency on the source file
     // FIXME (#9639): This needs to handle non-utf8 paths


### PR DESCRIPTION
The `--dep-info` command line option allows a nice way to generate make-style dependencies, but it currently does so alongside building of the output binary. This isn't a problem for make, as it mixes dependency graph generation and actual building, but it is problematic for other tools (e.g. CMake) which keep them separate.

To play more nicely with those tools, I've moved the --dep-info output from phase 6 (linking) up to after phase 2 (expansion of macros). Also, since there was no prior option to do so, I added a command line switch (`--no-analysis`) to stop compilation just before phase 3 (type-checking) which speeds this up even further.

Here's the beginning of a CMake function which is enabled by this change:

``` cmake
function(get_rust_deps root_file out_var)
    execute_process(COMMAND rustc ${RUSTC_FLAGS} --no-analysis --dep-info "${CMAKE_BINARY_DIR}/.deps" "${root_file}")

    # Read and parse the dependency information
    file(READ "${CMAKE_BINARY_DIR}/.deps" crate_deps)
    file(REMOVE "${CMAKE_BINARY_DIR}/.deps")
    # parsing follows...
```
