### PR TITLE
Renamed ClonableIterator to CloneableIterator

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -78,7 +78,7 @@ syn keyword rustTrait Default
 syn keyword rustTrait Hash
 syn keyword rustTrait FromStr
 syn keyword rustTrait FromIterator Extendable
-syn keyword rustTrait Iterator DoubleEndedIterator RandomAccessIterator ClonableIterator
+syn keyword rustTrait Iterator DoubleEndedIterator RandomAccessIterator CloneableIterator
 syn keyword rustTrait OrdIterator MutableDoubleEndedIterator ExactSize
 syn keyword rustTrait Times
 

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -906,14 +906,14 @@ impl<A: Ord, T: Iterator<A>> OrdIterator<A> for T {
     }
 }
 
-/// A trait for iterators that are clonable.
-pub trait ClonableIterator {
+/// A trait for iterators that are cloneable.
+pub trait CloneableIterator {
     /// Repeats an iterator endlessly
     ///
     /// # Example
     ///
     /// ```rust
-    /// use std::iter::{ClonableIterator, count};
+    /// use std::iter::{CloneableIterator, count};
     ///
     /// let a = count(1,1).take(1);
     /// let mut cy = a.cycle();
@@ -923,7 +923,7 @@ pub trait ClonableIterator {
     fn cycle(self) -> Cycle<Self>;
 }
 
-impl<A, T: Clone + Iterator<A>> ClonableIterator for T {
+impl<A, T: Clone + Iterator<A>> CloneableIterator for T {
     #[inline]
     fn cycle(self) -> Cycle<T> {
         Cycle{orig: self.clone(), iter: self}

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -55,7 +55,7 @@ pub use default::Default;
 pub use from_str::FromStr;
 pub use hash::Hash;
 pub use iter::{FromIterator, Extendable};
-pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, ClonableIterator};
+pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIterator};
 pub use iter::{OrdIterator, MutableDoubleEndedIterator, ExactSize};
 pub use num::Times;
 pub use num::{Algebraic, Trigonometric, Exponential, Hyperbolic};


### PR DESCRIPTION
Rename all instances of ClonableIterator to CloneableIterator. This fixes bug https://github.com/mozilla/rust/issues/11132.
