### PR TITLE
Disowned the Visitor.

### DIFF
--- a/src/librustc/front/assign_node_ids_and_map.rs
+++ b/src/librustc/front/assign_node_ids_and_map.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,22 +11,19 @@
 use driver::session::Session;
 
 use syntax::ast;
-use syntax::fold::ast_fold;
+use syntax::ast_map;
 
 struct NodeIdAssigner {
-    sess: Session,
+    sess: Session
 }
 
-impl ast_fold for NodeIdAssigner {
-    fn new_id(&mut self, old_id: ast::NodeId) -> ast::NodeId {
+impl ast_map::FoldOps for NodeIdAssigner {
+    fn new_id(&self, old_id: ast::NodeId) -> ast::NodeId {
         assert_eq!(old_id, ast::DUMMY_NODE_ID);
         self.sess.next_node_id()
     }
 }
 
-pub fn assign_node_ids(sess: Session, crate: ast::Crate) -> ast::Crate {
-    let mut fold = NodeIdAssigner {
-        sess: sess,
-    };
-    fold.fold_crate(crate)
+pub fn assign_node_ids_and_map(sess: Session, crate: ast::Crate) -> (ast::Crate, ast_map::map) {
+    ast_map::map_crate(sess.diagnostic(), crate, NodeIdAssigner { sess: sess })
 }

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -119,7 +119,7 @@ impl Visitor<()> for Context {
         visit::walk_view_item(self, i, ())
     }
 
-    fn visit_item(&mut self, i: @ast::item, _:()) {
+    fn visit_item(&mut self, i: &ast::item, _:()) {
         for attr in i.attrs.iter() {
             if "thread_local" == attr.name() {
                 self.gate_feature("thread_local", i.span,
@@ -187,7 +187,7 @@ impl Visitor<()> for Context {
         visit::walk_ty(self, t, ());
     }
 
-    fn visit_expr(&mut self, e: @ast::Expr, _: ()) {
+    fn visit_expr(&mut self, e: &ast::Expr, _: ()) {
         match e.node {
             ast::ExprUnary(_, ast::UnBox, _) |
             ast::ExprVstore(_, ast::ExprVstoreBox) => {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -81,7 +81,7 @@ pub mod front {
     pub mod config;
     pub mod test;
     pub mod std_inject;
-    pub mod assign_node_ids;
+    pub mod assign_node_ids_and_map;
     pub mod feature_gate;
 }
 

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -58,11 +58,11 @@ struct ReadCrateVisitor<'a> {
 }
 
 impl<'a> visit::Visitor<()> for ReadCrateVisitor<'a> {
-    fn visit_view_item(&mut self, a:&ast::view_item, _:()) {
+    fn visit_view_item(&mut self, a: &ast::view_item, _: ()) {
         visit_view_item(self.e, a);
         visit::walk_view_item(self, a, ());
     }
-    fn visit_item(&mut self, a:@ast::item, _:()) {
+    fn visit_item(&mut self, a: &ast::item, _: ()) {
         visit_item(self.e, a);
         visit::walk_item(self, a, ());
     }
@@ -164,7 +164,7 @@ fn visit_view_item(e: &mut Env, i: &ast::view_item) {
   }
 }
 
-fn visit_item(e: &Env, i: @ast::item) {
+fn visit_item(e: &Env, i: &ast::item) {
     match i.node {
         ast::item_foreign_mod(ref fm) => {
             if fm.abis.is_rust() || fm.abis.is_intrinsic() {

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -30,30 +30,29 @@ use syntax::visit::Visitor;
 use syntax::visit;
 use util::ppaux::Repr;
 
-#[deriving(Clone)]
 struct CheckLoanCtxt<'a> {
     bccx: &'a BorrowckCtxt,
     dfcx_loans: &'a LoanDataFlow,
-    move_data: @move_data::FlowedMoveData,
+    move_data: move_data::FlowedMoveData,
     all_loans: &'a [Loan],
 }
 
 impl<'a> Visitor<()> for CheckLoanCtxt<'a> {
 
-    fn visit_expr(&mut self, ex:@ast::Expr, _:()) {
+    fn visit_expr(&mut self, ex: &ast::Expr, _: ()) {
         check_loans_in_expr(self, ex);
     }
-    fn visit_local(&mut self, l:@ast::Local, _:()) {
+    fn visit_local(&mut self, l: &ast::Local, _: ()) {
         check_loans_in_local(self, l);
     }
-    fn visit_block(&mut self, b:ast::P<ast::Block>, _:()) {
+    fn visit_block(&mut self, b: &ast::Block, _: ()) {
         check_loans_in_block(self, b);
     }
-    fn visit_pat(&mut self, p:&ast::Pat, _:()) {
+    fn visit_pat(&mut self, p: &ast::Pat, _: ()) {
         check_loans_in_pat(self, p);
     }
-    fn visit_fn(&mut self, fk:&visit::fn_kind, fd:&ast::fn_decl,
-                b:ast::P<ast::Block>, s:Span, n:ast::NodeId, _:()) {
+    fn visit_fn(&mut self, fk: &visit::fn_kind, fd: &ast::fn_decl,
+                b: &ast::Block, s: Span, n: ast::NodeId, _: ()) {
         check_loans_in_fn(self, fk, fd, b, s, n);
     }
 
@@ -65,13 +64,13 @@ pub fn check_loans(bccx: &BorrowckCtxt,
                    dfcx_loans: &LoanDataFlow,
                    move_data: move_data::FlowedMoveData,
                    all_loans: &[Loan],
-                   body: ast::P<ast::Block>) {
+                   body: &ast::Block) {
     debug!("check_loans(body id={:?})", body.id);
 
     let mut clcx = CheckLoanCtxt {
         bccx: bccx,
         dfcx_loans: dfcx_loans,
-        move_data: @move_data,
+        move_data: move_data,
         all_loans: all_loans,
     };
 
@@ -107,9 +106,9 @@ impl<'a> CheckLoanCtxt<'a> {
         //! Like `each_issued_loan()`, but only considers loans that are
         //! currently in scope.
 
-        let region_maps = self.tcx().region_maps;
+        let tcx = self.tcx();
         self.each_issued_loan(scope_id, |loan| {
-            if region_maps.is_subscope_of(scope_id, loan.kill_scope) {
+            if tcx.region_maps.is_subscope_of(scope_id, loan.kill_scope) {
                 op(loan)
             } else {
                 true
@@ -190,9 +189,8 @@ impl<'a> CheckLoanCtxt<'a> {
                new_loan.repr(self.tcx()));
 
         // Should only be called for loans that are in scope at the same time.
-        let region_maps = self.tcx().region_maps;
-        assert!(region_maps.scopes_intersect(old_loan.kill_scope,
-                                             new_loan.kill_scope));
+        assert!(self.tcx().region_maps.scopes_intersect(old_loan.kill_scope,
+                                                        new_loan.kill_scope));
 
         self.report_error_if_loan_conflicts_with_restriction(
             old_loan, new_loan, old_loan, new_loan) &&
@@ -290,7 +288,7 @@ impl<'a> CheckLoanCtxt<'a> {
         });
     }
 
-    pub fn check_assignment(&self, expr: @ast::Expr) {
+    pub fn check_assignment(&self, expr: &ast::Expr) {
         // We don't use cat_expr() here because we don't want to treat
         // auto-ref'd parameters in overloaded operators as rvalues.
         let adj = {
@@ -401,7 +399,7 @@ impl<'a> CheckLoanCtxt<'a> {
         }
 
         fn check_for_aliasable_mutable_writes(this: &CheckLoanCtxt,
-                                              expr: @ast::Expr,
+                                              expr: &ast::Expr,
                                               cmt: mc::cmt) -> bool {
             //! Safety checks related to writes to aliasable, mutable locations
 
@@ -422,7 +420,7 @@ impl<'a> CheckLoanCtxt<'a> {
         }
 
         fn check_for_aliasability_violation(this: &CheckLoanCtxt,
-                                            expr: @ast::Expr,
+                                            expr: &ast::Expr,
                                             cmt: mc::cmt) -> bool {
             let mut cmt = cmt;
 
@@ -467,7 +465,7 @@ impl<'a> CheckLoanCtxt<'a> {
 
         fn check_for_assignment_to_restricted_or_frozen_location(
             this: &CheckLoanCtxt,
-            expr: @ast::Expr,
+            expr: &ast::Expr,
             cmt: mc::cmt) -> bool
         {
             //! Check for assignments that violate the terms of an
@@ -601,7 +599,7 @@ impl<'a> CheckLoanCtxt<'a> {
     }
 
     pub fn report_illegal_mutation(&self,
-                                   expr: @ast::Expr,
+                                   expr: &ast::Expr,
                                    loan_path: &LoanPath,
                                    loan: &Loan) {
         self.bccx.span_err(
@@ -614,7 +612,7 @@ impl<'a> CheckLoanCtxt<'a> {
                  self.bccx.loan_path_to_str(loan_path)));
     }
 
-    fn check_move_out_from_expr(&self, expr: @ast::Expr) {
+    fn check_move_out_from_expr(&self, expr: &ast::Expr) {
         match expr.node {
             ast::ExprFnBlock(..) | ast::ExprProc(..) => {
                 // moves due to capture clauses are checked
@@ -668,7 +666,7 @@ impl<'a> CheckLoanCtxt<'a> {
     }
 
     pub fn check_call(&self,
-                      _expr: @ast::Expr,
+                      _expr: &ast::Expr,
                       _callee: Option<@ast::Expr>,
                       _callee_id: ast::NodeId,
                       _callee_span: Span,
@@ -686,7 +684,7 @@ impl<'a> CheckLoanCtxt<'a> {
 fn check_loans_in_fn<'a>(this: &mut CheckLoanCtxt<'a>,
                          fk: &visit::fn_kind,
                          decl: &ast::fn_decl,
-                         body: ast::P<ast::Block>,
+                         body: &ast::Block,
                          sp: Span,
                          id: ast::NodeId) {
     match *fk {
@@ -746,12 +744,12 @@ fn check_loans_in_fn<'a>(this: &mut CheckLoanCtxt<'a>,
 }
 
 fn check_loans_in_local<'a>(this: &mut CheckLoanCtxt<'a>,
-                            local: @ast::Local) {
+                            local: &ast::Local) {
     visit::walk_local(this, local, ());
 }
 
 fn check_loans_in_expr<'a>(this: &mut CheckLoanCtxt<'a>,
-                           expr: @ast::Expr) {
+                           expr: &ast::Expr) {
     visit::walk_expr(this, expr, ());
 
     debug!("check_loans_in_expr(expr={})",
@@ -818,7 +816,7 @@ fn check_loans_in_pat<'a>(this: &mut CheckLoanCtxt<'a>,
 }
 
 fn check_loans_in_block<'a>(this: &mut CheckLoanCtxt<'a>,
-                            blk: ast::P<ast::Block>)
+                            blk: &ast::Block)
 {
     visit::walk_block(this, blk, ());
     this.check_for_conflicting_loans(blk.id);

--- a/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
@@ -33,18 +33,16 @@ pub fn gather_decl(bccx: &BorrowckCtxt,
 
 pub fn gather_move_from_expr(bccx: &BorrowckCtxt,
                              move_data: &MoveData,
-                             move_expr: @ast::Expr,
+                             move_expr: &ast::Expr,
                              cmt: mc::cmt) {
-    gather_move_from_expr_or_pat(bccx, move_data, move_expr.id,
-                                 MoveExpr(move_expr), cmt);
+    gather_move_from_expr_or_pat(bccx, move_data, move_expr.id, MoveExpr, cmt);
 }
 
 pub fn gather_move_from_pat(bccx: &BorrowckCtxt,
                             move_data: &MoveData,
-                            move_pat: @ast::Pat,
+                            move_pat: &ast::Pat,
                             cmt: mc::cmt) {
-    gather_move_from_expr_or_pat(bccx, move_data, move_pat.id,
-                                 MovePat(move_pat), cmt);
+    gather_move_from_expr_or_pat(bccx, move_data, move_pat.id, MovePat, cmt);
 }
 
 fn gather_move_from_expr_or_pat(bccx: &BorrowckCtxt,
@@ -68,7 +66,7 @@ fn gather_move_from_expr_or_pat(bccx: &BorrowckCtxt,
 
 pub fn gather_captures(bccx: &BorrowckCtxt,
                        move_data: &MoveData,
-                       closure_expr: @ast::Expr) {
+                       closure_expr: &ast::Expr) {
     let capture_map = bccx.capture_map.borrow();
     let captured_vars = capture_map.get().get(&closure_expr.id);
     for captured_var in captured_vars.iter() {
@@ -77,7 +75,7 @@ pub fn gather_captures(bccx: &BorrowckCtxt,
                 let fvar_id = ast_util::def_id_of_def(captured_var.def).node;
                 let loan_path = @LpVar(fvar_id);
                 move_data.add_move(bccx.tcx, loan_path, closure_expr.id,
-                                   Captured(closure_expr));
+                                   Captured);
             }
             moves::CapCopy | moves::CapRef => {}
         }

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -33,7 +33,7 @@ use syntax::codemap::Span;
 use syntax::print::pprust;
 use syntax::visit;
 use syntax::visit::{Visitor, fn_kind};
-use syntax::ast::{P, Expr, fn_decl, Block, NodeId, Stmt, Pat, Local};
+use syntax::ast::{Expr, fn_decl, Block, NodeId, Stmt, Pat, Local};
 
 mod lifetime;
 mod restrictions;
@@ -68,50 +68,50 @@ mod gather_moves;
 struct GatherLoanCtxt<'a> {
     bccx: &'a BorrowckCtxt,
     id_range: id_range,
-    move_data: @move_data::MoveData,
+    move_data: move_data::MoveData,
     all_loans: @RefCell<~[Loan]>,
     item_ub: ast::NodeId,
     repeating_ids: ~[ast::NodeId]
 }
 
 impl<'a> visit::Visitor<()> for GatherLoanCtxt<'a> {
-    fn visit_expr(&mut self, ex:@Expr, _:()) {
+    fn visit_expr(&mut self, ex: &Expr, _: ()) {
         gather_loans_in_expr(self, ex);
     }
-    fn visit_block(&mut self, b:P<Block>, _:()) {
+    fn visit_block(&mut self, b: &Block, _: ()) {
         gather_loans_in_block(self, b);
     }
-    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:P<Block>,
-                s:Span, n:NodeId, _:()) {
+    fn visit_fn(&mut self, fk: &fn_kind, fd: &fn_decl, b: &Block,
+                s: Span, n: NodeId, _: ()) {
         gather_loans_in_fn(self, fk, fd, b, s, n);
     }
-    fn visit_stmt(&mut self, s:@Stmt, _:()) {
+    fn visit_stmt(&mut self, s: &Stmt, _: ()) {
         visit::walk_stmt(self, s, ());
     }
-    fn visit_pat(&mut self, p:&Pat, _:()) {
+    fn visit_pat(&mut self, p: &Pat, _: ()) {
         add_pat_to_id_range(self, p);
     }
-    fn visit_local(&mut self, l:@Local, _:()) {
+    fn visit_local(&mut self, l: &Local, _: ()) {
         gather_loans_in_local(self, l);
     }
 
     // #7740: Do not visit items here, not even fn items nor methods
     // of impl items; the outer loop in borrowck/mod will visit them
     // for us in turn.  Thus override visit_item's walk with a no-op.
-    fn visit_item(&mut self, _:@ast::item, _:()) { }
+    fn visit_item(&mut self, _: &ast::item, _: ()) { }
 }
 
 pub fn gather_loans(bccx: &BorrowckCtxt,
                     decl: &ast::fn_decl,
-                    body: ast::P<ast::Block>)
-                    -> (id_range, @RefCell<~[Loan]>, @move_data::MoveData) {
+                    body: &ast::Block)
+                    -> (id_range, @RefCell<~[Loan]>, move_data::MoveData) {
     let mut glcx = GatherLoanCtxt {
         bccx: bccx,
         id_range: id_range::max(),
         all_loans: @RefCell::new(~[]),
         item_ub: body.id,
         repeating_ids: ~[body.id],
-        move_data: @MoveData::new()
+        move_data: MoveData::new()
     };
     glcx.gather_fn_arg_patterns(decl, body);
 
@@ -132,7 +132,7 @@ fn add_pat_to_id_range(this: &mut GatherLoanCtxt,
 fn gather_loans_in_fn(this: &mut GatherLoanCtxt,
                       fk: &fn_kind,
                       decl: &ast::fn_decl,
-                      body: ast::P<ast::Block>,
+                      body: &ast::Block,
                       sp: Span,
                       id: ast::NodeId) {
     match fk {
@@ -151,20 +151,20 @@ fn gather_loans_in_fn(this: &mut GatherLoanCtxt,
 }
 
 fn gather_loans_in_block(this: &mut GatherLoanCtxt,
-                         blk: ast::P<ast::Block>) {
+                         blk: &ast::Block) {
     this.id_range.add(blk.id);
     visit::walk_block(this, blk, ());
 }
 
 fn gather_loans_in_local(this: &mut GatherLoanCtxt,
-                         local: @ast::Local) {
+                         local: &ast::Local) {
     match local.init {
         None => {
             // Variable declarations without initializers are considered "moves":
             let tcx = this.bccx.tcx;
             pat_util::pat_bindings(tcx.def_map, local.pat, |_, id, span, _| {
                 gather_moves::gather_decl(this.bccx,
-                                          this.move_data,
+                                          &this.move_data,
                                           id,
                                           span,
                                           id);
@@ -175,7 +175,7 @@ fn gather_loans_in_local(this: &mut GatherLoanCtxt,
             let tcx = this.bccx.tcx;
             pat_util::pat_bindings(tcx.def_map, local.pat, |_, id, span, _| {
                 gather_moves::gather_assignment(this.bccx,
-                                                this.move_data,
+                                                &this.move_data,
                                                 id,
                                                 span,
                                                 @LpVar(id),
@@ -191,7 +191,7 @@ fn gather_loans_in_local(this: &mut GatherLoanCtxt,
 
 
 fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
-                        ex: @ast::Expr) {
+                        ex: &ast::Expr) {
     let bccx = this.bccx;
     let tcx = bccx.tcx;
 
@@ -220,7 +220,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
     if this.bccx.is_move(ex.id) {
         let cmt = this.bccx.cat_expr(ex);
         gather_moves::gather_move_from_expr(
-            this.bccx, this.move_data, ex, cmt);
+            this.bccx, &this.move_data, ex, cmt);
     }
 
     // Special checks for various kinds of expressions:
@@ -247,7 +247,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
           let l_cmt = this.bccx.cat_expr(l);
           match opt_loan_path(l_cmt) {
               Some(l_lp) => {
-                  gather_moves::gather_assignment(this.bccx, this.move_data,
+                  gather_moves::gather_assignment(this.bccx, &this.move_data,
                                                   ex.id, ex.span,
                                                   l_lp, l.id);
               }
@@ -309,7 +309,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
       }
 
       ast::ExprFnBlock(..) | ast::ExprProc(..) => {
-          gather_moves::gather_captures(this.bccx, this.move_data, ex);
+          gather_moves::gather_captures(this.bccx, &this.move_data, ex);
           visit::walk_expr(this, ex, ());
       }
 
@@ -318,7 +318,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
               let out_cmt = this.bccx.cat_expr(out);
               match opt_loan_path(out_cmt) {
                   Some(out_lp) => {
-                      gather_moves::gather_assignment(this.bccx, this.move_data,
+                      gather_moves::gather_assignment(this.bccx, &this.move_data,
                                                       ex.id, ex.span,
                                                       out_lp, out.id);
                   }
@@ -349,7 +349,7 @@ impl<'a> GatherLoanCtxt<'a> {
     }
 
     pub fn guarantee_adjustments(&mut self,
-                                 expr: @ast::Expr,
+                                 expr: &ast::Expr,
                                  adjustment: &ty::AutoAdjustment) {
         debug!("guarantee_adjustments(expr={}, adjustment={:?})",
                expr.repr(self.tcx()), adjustment);
@@ -639,8 +639,7 @@ impl<'a> GatherLoanCtxt<'a> {
         //! notably method arguments, the loan may be introduced only
         //! later, once it comes into scope.
 
-        let rm = self.bccx.tcx.region_maps;
-        if rm.is_subscope_of(borrow_id, loan_scope) {
+        if self.bccx.tcx.region_maps.is_subscope_of(borrow_id, loan_scope) {
             borrow_id
         } else {
             loan_scope
@@ -668,12 +667,11 @@ impl<'a> GatherLoanCtxt<'a> {
         //! with immutable `&` pointers, because borrows of such pointers
         //! do not require restrictions and hence do not cause a loan.
 
-        let rm = self.bccx.tcx.region_maps;
-        let lexical_scope = rm.encl_scope(lp.node_id());
-        if rm.is_subscope_of(lexical_scope, loan_scope) {
+        let lexical_scope = self.bccx.tcx.region_maps.encl_scope(lp.node_id());
+        if self.bccx.tcx.region_maps.is_subscope_of(lexical_scope, loan_scope) {
             lexical_scope
         } else {
-            assert!(rm.is_subscope_of(loan_scope, lexical_scope));
+            assert!(self.bccx.tcx.region_maps.is_subscope_of(loan_scope, lexical_scope));
             loan_scope
         }
     }
@@ -704,7 +702,7 @@ impl<'a> GatherLoanCtxt<'a> {
 
     fn gather_pat(&mut self,
                   discr_cmt: mc::cmt,
-                  root_pat: @ast::Pat,
+                  root_pat: &ast::Pat,
                   arm_match_ids: Option<(ast::NodeId, ast::NodeId)>) {
         /*!
          * Walks patterns, examining the bindings to determine if they
@@ -755,7 +753,7 @@ impl<'a> GatherLoanCtxt<'a> {
                       // No borrows here, but there may be moves
                       if self.bccx.is_move(pat.id) {
                           gather_moves::gather_move_from_pat(
-                              self.bccx, self.move_data, pat, cmt);
+                              self.bccx, &self.move_data, pat, cmt);
                       }
                   }
                 }
@@ -804,7 +802,7 @@ impl<'a> GatherLoanCtxt<'a> {
         })
     }
 
-    pub fn vec_slice_info(&self, pat: @ast::Pat, slice_ty: ty::t)
+    pub fn vec_slice_info(&self, pat: &ast::Pat, slice_ty: ty::t)
                           -> (ast::Mutability, ty::Region) {
         /*!
          *
@@ -831,8 +829,7 @@ impl<'a> GatherLoanCtxt<'a> {
         }
     }
 
-    pub fn pat_is_binding(&self, pat: @ast::Pat) -> bool {
+    pub fn pat_is_binding(&self, pat: &ast::Pat) -> bool {
         pat_util::pat_is_binding(self.bccx.tcx.def_map, pat)
     }
 }
-

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -53,12 +53,7 @@ pub struct MoveData {
 }
 
 pub struct FlowedMoveData {
-    move_data: @MoveData,
-    //         ^~~~~~~~~
-    // It makes me sad to use @ here, except that due to
-    // the old visitor design, this is what gather_loans
-    // used to have to produce, and this code hasn't been
-    // updated.
+    move_data: MoveData,
 
     dfcx_moves: MoveDataFlow,
 
@@ -120,10 +115,10 @@ pub struct MovePath {
 }
 
 pub enum MoveKind {
-    Declared,               // When declared, variables start out "moved".
-    MoveExpr(@ast::Expr),   // Expression or binding that moves a variable
-    MovePat(@ast::Pat),     // By-move binding
-    Captured(@ast::Expr),   // Closure creation that moves a value
+    Declared,   // When declared, variables start out "moved".
+    MoveExpr,   // Expression or binding that moves a variable
+    MovePat,    // By-move binding
+    Captured    // Closure creation that moves a value
 }
 
 pub struct Move {
@@ -137,7 +132,7 @@ pub struct Move {
     kind: MoveKind,
 
     /// Next node in linked list of moves from `path`, or `InvalidMoveIndex`
-    next_move: MoveIndex,
+    next_move: MoveIndex
 }
 
 pub struct Assignment {
@@ -568,7 +563,7 @@ impl MoveData {
 }
 
 impl FlowedMoveData {
-    pub fn new(move_data: @MoveData,
+    pub fn new(move_data: MoveData,
                tcx: ty::ctxt,
                method_map: typeck::method_map,
                id_range: ast_util::id_range,

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -29,11 +29,11 @@ pub fn check_crate(tcx: ty::ctxt, crate: &ast::Crate) {
 }
 
 impl Visitor<Context> for CheckLoopVisitor {
-    fn visit_item(&mut self, i: @ast::item, _cx: Context) {
+    fn visit_item(&mut self, i: &ast::item, _cx: Context) {
         visit::walk_item(self, i, Normal);
     }
 
-    fn visit_expr(&mut self, e: @ast::Expr, cx:Context) {
+    fn visit_expr(&mut self, e: &ast::Expr, cx:Context) {
         match e.node {
             ast::ExprWhile(e, b) => {
                 self.visit_expr(e, cx);

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -38,14 +38,14 @@ struct CheckMatchVisitor {
 }
 
 impl Visitor<()> for CheckMatchVisitor {
-    fn visit_expr(&mut self, ex:@Expr, e:()) {
-        check_expr(self, self.cx, ex, e);
+    fn visit_expr(&mut self, ex: &Expr, _: ()) {
+        check_expr(self, self.cx, ex, ());
     }
-    fn visit_local(&mut self, l:@Local, e:()) {
-        check_local(self, self.cx, l, e);
+    fn visit_local(&mut self, l: &Local, _: ()) {
+        check_local(self, self.cx, l, ());
     }
-    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:P<Block>, s:Span, n:NodeId, e:()) {
-        check_fn(self, self.cx, fk, fd, b, s, n, e);
+    fn visit_fn(&mut self, fk: &fn_kind, fd: &fn_decl, b: &Block, s: Span, n: NodeId, _: ()) {
+        check_fn(self, self.cx, fk, fd, b, s, n, ());
     }
 }
 
@@ -65,7 +65,7 @@ pub fn check_crate(tcx: ty::ctxt,
 
 fn check_expr(v: &mut CheckMatchVisitor,
                   cx: @MatchCheckCtxt,
-                  ex: @Expr,
+                  ex: &Expr,
                   s: ()) {
     visit::walk_expr(v, ex, s);
     match ex.node {
@@ -830,7 +830,7 @@ fn default(cx: &MatchCheckCtxt, r: &[@Pat]) -> Option<~[@Pat]> {
 
 fn check_local(v: &mut CheckMatchVisitor,
                    cx: &MatchCheckCtxt,
-                   loc: @Local,
+                   loc: &Local,
                    s: ()) {
     visit::walk_local(v, loc, s);
     if is_refutable(cx, loc.pat) {
@@ -846,7 +846,7 @@ fn check_fn(v: &mut CheckMatchVisitor,
                 cx: &MatchCheckCtxt,
                 kind: &visit::fn_kind,
                 decl: &fn_decl,
-                body: P<Block>,
+                body: &Block,
                 sp: Span,
                 id: NodeId,
                 s: ()) {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -296,7 +296,7 @@ impl ConstEvalVisitor {
 }
 
 impl Visitor<()> for ConstEvalVisitor {
-    fn visit_expr_post(&mut self, e:@Expr, _:()) {
+    fn visit_expr_post(&mut self, e: &Expr, _: ()) {
         self.classify(e);
     }
 }

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -753,7 +753,6 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
         //! concern items that are going out of scope).
 
         let tcx = self.tcx();
-        let region_maps = tcx.region_maps;
 
         debug!("pop_scopes(from_expr={}, to_scope={:?}, in_out={})",
                from_expr.repr(tcx), to_scope.loop_id,
@@ -763,7 +762,7 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
         while id != to_scope.loop_id {
             self.dfcx.apply_kill(id, in_out);
 
-            match region_maps.opt_encl_scope(id) {
+            match tcx.region_maps.opt_encl_scope(id) {
                 Some(i) => { id = i; }
                 None => {
                     tcx.sess.span_bug(

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -174,7 +174,7 @@ impl MarkSymbolVisitor {
 
 impl Visitor<()> for MarkSymbolVisitor {
 
-    fn visit_expr(&mut self, expr: @ast::Expr, _: ()) {
+    fn visit_expr(&mut self, expr: &ast::Expr, _: ()) {
         match expr.node {
             ast::ExprMethodCall(..) => {
                 self.lookup_and_handle_method(&expr.id, expr.span);
@@ -190,7 +190,7 @@ impl Visitor<()> for MarkSymbolVisitor {
         visit::walk_path(self, path, ());
     }
 
-    fn visit_item(&mut self, _item: @ast::item, _: ()) {
+    fn visit_item(&mut self, _item: &ast::item, _: ()) {
         // Do not recurse into items. These items will be added to the
         // worklist and recursed into manually if necessary.
     }
@@ -204,7 +204,7 @@ struct TraitMethodSeeder {
 }
 
 impl Visitor<()> for TraitMethodSeeder {
-    fn visit_item(&mut self, item: @ast::item, _: ()) {
+    fn visit_item(&mut self, item: &ast::item, _: ()) {
         match item.node {
             ast::item_impl(_, Some(ref _trait_ref), _, ref methods) => {
                 for method in methods.iter() {
@@ -265,7 +265,7 @@ fn find_live(tcx: ty::ctxt,
     symbol_visitor.live_symbols
 }
 
-fn should_warn(item: @ast::item) -> bool {
+fn should_warn(item: &ast::item) -> bool {
     match item.node {
         ast::item_static(..)
         | ast::item_fn(..)
@@ -335,7 +335,7 @@ impl DeadVisitor {
 }
 
 impl Visitor<()> for DeadVisitor {
-    fn visit_item(&mut self, item: @ast::item, _: ()) {
+    fn visit_item(&mut self, item: &ast::item, _: ()) {
         let ctor_id = get_struct_ctor_id(item);
         if !self.symbol_is_live(item.id, ctor_id) && should_warn(item) {
             self.warn_dead_code(item.id, item.span, &item.ident);
@@ -343,7 +343,7 @@ impl Visitor<()> for DeadVisitor {
         visit::walk_item(self, item, ());
     }
 
-    fn visit_foreign_item(&mut self, fi: @ast::foreign_item, _: ()) {
+    fn visit_foreign_item(&mut self, fi: &ast::foreign_item, _: ()) {
         if !self.symbol_is_live(fi.id, None) {
             self.warn_dead_code(fi.id, fi.span, &fi.ident);
         }
@@ -351,7 +351,7 @@ impl Visitor<()> for DeadVisitor {
     }
 
     fn visit_fn(&mut self, fk: &visit::fn_kind,
-                _: &ast::fn_decl, block: ast::P<ast::Block>,
+                _: &ast::fn_decl, block: &ast::Block,
                 span: codemap::Span, id: ast::NodeId, _: ()) {
         // Have to warn method here because methods are not ast::item
         match *fk {
@@ -367,7 +367,7 @@ impl Visitor<()> for DeadVisitor {
     }
 
     // Overwrite so that we don't warn the trait method itself.
-    fn visit_trait_method(&mut self, trait_method :&ast::trait_method, _: ()) {
+    fn visit_trait_method(&mut self, trait_method: &ast::trait_method, _: ()) {
         match *trait_method {
             ast::provided(method) => visit::walk_block(self, method.body, ()),
             ast::required(_) => ()

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -82,7 +82,7 @@ impl EffectCheckVisitor {
 
 impl Visitor<()> for EffectCheckVisitor {
     fn visit_fn(&mut self, fn_kind: &visit::fn_kind, fn_decl: &ast::fn_decl,
-                block: ast::P<ast::Block>, span: Span, node_id: ast::NodeId, _:()) {
+                block: &ast::Block, span: Span, node_id: ast::NodeId, _:()) {
 
         let (is_item_fn, is_unsafe_fn) = match *fn_kind {
             visit::fk_item_fn(_, _, purity, _) =>
@@ -104,7 +104,7 @@ impl Visitor<()> for EffectCheckVisitor {
         self.unsafe_context = old_unsafe_context
     }
 
-    fn visit_block(&mut self, block: ast::P<ast::Block>, _:()) {
+    fn visit_block(&mut self, block: &ast::Block, _:()) {
         let old_unsafe_context = self.unsafe_context;
         let is_unsafe = match block.rules {
             ast::UnsafeBlock(..) => true, ast::DefaultBlock => false
@@ -118,7 +118,7 @@ impl Visitor<()> for EffectCheckVisitor {
         self.unsafe_context = old_unsafe_context
     }
 
-    fn visit_expr(&mut self, expr: @ast::Expr, _:()) {
+    fn visit_expr(&mut self, expr: &ast::Expr, _:()) {
         match expr.node {
             ast::ExprMethodCall(callee_id, _, _, _, _, _) => {
                 let base_type = ty::node_id_to_type(self.tcx, callee_id);

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -39,7 +39,7 @@ struct EntryContext {
 }
 
 impl Visitor<()> for EntryContext {
-    fn visit_item(&mut self, item:@item, _:()) {
+    fn visit_item(&mut self, item: &item, _:()) {
         find_item(item, self);
     }
 }
@@ -70,7 +70,7 @@ pub fn find_entry_point(session: Session, crate: &Crate, ast_map: ast_map::map) 
     configure_main(&mut ctxt);
 }
 
-fn find_item(item: @item, ctxt: &mut EntryContext) {
+fn find_item(item: &item, ctxt: &mut EntryContext) {
     match item.node {
         item_fn(..) => {
             if item.ident.name == special_idents::main.name {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -58,18 +58,19 @@ pub struct Context {
 
 impl Visitor<()> for Context {
 
-    fn visit_expr(&mut self, ex:@Expr, _:()) {
+    fn visit_expr(&mut self, ex: &Expr, _: ()) {
         check_expr(self, ex);
     }
 
-    fn visit_fn(&mut self, fk:&visit::fn_kind, fd:&fn_decl, b:P<Block>, s:Span, n:NodeId, _:()) {
+    fn visit_fn(&mut self, fk: &visit::fn_kind, fd: &fn_decl,
+                b: &Block, s: Span, n: NodeId, _: ()) {
         check_fn(self, fk, fd, b, s, n);
     }
 
-    fn visit_ty(&mut self, t:&Ty, _:()) {
+    fn visit_ty(&mut self, t: &Ty, _: ()) {
         check_ty(self, t);
     }
-    fn visit_item(&mut self, i:@item, _:()) {
+    fn visit_item(&mut self, i: &item, _: ()) {
         check_item(self, i);
     }
 }
@@ -115,7 +116,7 @@ fn check_struct_safe_for_destructor(cx: &mut Context,
     }
 }
 
-fn check_impl_of_trait(cx: &mut Context, it: @item, trait_ref: &trait_ref, self_type: &Ty) {
+fn check_impl_of_trait(cx: &mut Context, it: &item, trait_ref: &trait_ref, self_type: &Ty) {
     let def_map = cx.tcx.def_map.borrow();
     let ast_trait_def = def_map.get()
                                .find(&trait_ref.ref_id)
@@ -158,7 +159,7 @@ fn check_impl_of_trait(cx: &mut Context, it: @item, trait_ref: &trait_ref, self_
     }
 }
 
-fn check_item(cx: &mut Context, item: @item) {
+fn check_item(cx: &mut Context, item: &item) {
     if !attr::contains_name(item.attrs, "unsafe_destructor") {
         match item.node {
             item_impl(_, Some(ref trait_ref), self_type, _) => {
@@ -247,7 +248,7 @@ fn check_fn(
     cx: &mut Context,
     fk: &visit::fn_kind,
     decl: &fn_decl,
-    body: P<Block>,
+    body: &Block,
     sp: Span,
     fn_id: NodeId) {
 
@@ -262,7 +263,7 @@ fn check_fn(
     visit::walk_fn(cx, fk, decl, body, sp, fn_id, ());
 }
 
-pub fn check_expr(cx: &mut Context, e: @Expr) {
+pub fn check_expr(cx: &mut Context, e: &Expr) {
     debug!("kind::check_expr({})", expr_to_str(e, cx.tcx.sess.intr()));
 
     // Handle any kind bounds on type parameters

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -109,7 +109,7 @@ struct LanguageItemVisitor<'a> {
 }
 
 impl<'a> Visitor<()> for LanguageItemVisitor<'a> {
-    fn visit_item(&mut self, item: @ast::item, _: ()) {
+    fn visit_item(&mut self, item: &ast::item, _: ()) {
         match extract(item.attrs) {
             Some(value) => {
                 let item_index = self.this.item_refs.find_equiv(&value).map(|x| *x);

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1303,7 +1303,7 @@ fn check_stability(cx: &Context, e: &ast::Expr) {
 }
 
 impl<'a> Visitor<()> for Context<'a> {
-    fn visit_item(&mut self, it: @ast::item, _: ()) {
+    fn visit_item(&mut self, it: &ast::item, _: ()) {
         self.with_lint_attrs(it.attrs, |cx| {
             check_item_ctypes(cx, it);
             check_item_non_camel_case_types(cx, it);
@@ -1318,7 +1318,7 @@ impl<'a> Visitor<()> for Context<'a> {
         })
     }
 
-    fn visit_foreign_item(&mut self, it: @ast::foreign_item, _: ()) {
+    fn visit_foreign_item(&mut self, it: &ast::foreign_item, _: ()) {
         self.with_lint_attrs(it.attrs, |cx| {
             check_attrs_usage(cx, it.attrs);
             visit::walk_foreign_item(cx, it, ());
@@ -1339,7 +1339,7 @@ impl<'a> Visitor<()> for Context<'a> {
         visit::walk_pat(self, p, ());
     }
 
-    fn visit_expr(&mut self, e: @ast::Expr, _: ()) {
+    fn visit_expr(&mut self, e: &ast::Expr, _: ()) {
         match e.node {
             ast::ExprUnary(_, ast::UnNeg, expr) => {
                 // propagate negation, if the negation itself isn't negated
@@ -1365,14 +1365,14 @@ impl<'a> Visitor<()> for Context<'a> {
         visit::walk_expr(self, e, ());
     }
 
-    fn visit_stmt(&mut self, s: @ast::Stmt, _: ()) {
+    fn visit_stmt(&mut self, s: &ast::Stmt, _: ()) {
         check_path_statement(self, s);
 
         visit::walk_stmt(self, s, ());
     }
 
     fn visit_fn(&mut self, fk: &visit::fn_kind, decl: &ast::fn_decl,
-                body: ast::P<ast::Block>, span: Span, id: ast::NodeId, _: ()) {
+                body: &ast::Block, span: Span, id: ast::NodeId, _: ()) {
         let recurse = |this: &mut Context| {
             visit::walk_fn(this, fk, decl, body, span, id, ());
         };
@@ -1404,7 +1404,7 @@ impl<'a> Visitor<()> for Context<'a> {
     }
 
     fn visit_struct_def(&mut self,
-                        s: @ast::struct_def,
+                        s: &ast::struct_def,
                         i: ast::Ident,
                         g: &ast::Generics,
                         id: ast::NodeId,

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -164,12 +164,12 @@ fn live_node_kind_to_str(lnk: LiveNodeKind, cx: ty::ctxt) -> ~str {
 struct LivenessVisitor;
 
 impl Visitor<@IrMaps> for LivenessVisitor {
-    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:P<Block>, s:Span, n:NodeId, e:@IrMaps) {
+    fn visit_fn(&mut self, fk: &fn_kind, fd: &fn_decl, b: &Block, s: Span, n: NodeId, e: @IrMaps) {
         visit_fn(self, fk, fd, b, s, n, e);
     }
-    fn visit_local(&mut self, l:@Local, e:@IrMaps) { visit_local(self, l, e); }
-    fn visit_expr(&mut self, ex:@Expr, e:@IrMaps) { visit_expr(self, ex, e); }
-    fn visit_arm(&mut self, a:&Arm, e:@IrMaps) { visit_arm(self, a, e); }
+    fn visit_local(&mut self, l: &Local, e: @IrMaps) { visit_local(self, l, e); }
+    fn visit_expr(&mut self, ex: &Expr, e: @IrMaps) { visit_expr(self, ex, e); }
+    fn visit_arm(&mut self, a: &Arm, e: @IrMaps) { visit_arm(self, a, e); }
 }
 
 pub fn check_crate(tcx: ty::ctxt,
@@ -364,16 +364,16 @@ impl IrMaps {
 }
 
 impl Visitor<()> for Liveness {
-    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:P<Block>, s:Span, n:NodeId, _:()) {
+    fn visit_fn(&mut self, fk: &fn_kind, fd: &fn_decl, b: &Block, s: Span, n: NodeId, _: ()) {
         check_fn(self, fk, fd, b, s, n);
     }
-    fn visit_local(&mut self, l:@Local, _:()) {
+    fn visit_local(&mut self, l: &Local, _: ()) {
         check_local(self, l);
     }
-    fn visit_expr(&mut self, ex:@Expr, _:()) {
+    fn visit_expr(&mut self, ex: &Expr, _: ()) {
         check_expr(self, ex);
     }
-    fn visit_arm(&mut self, a:&Arm, _:()) {
+    fn visit_arm(&mut self, a: &Arm, _: ()) {
         check_arm(self, a);
     }
 }
@@ -381,7 +381,7 @@ impl Visitor<()> for Liveness {
 fn visit_fn(v: &mut LivenessVisitor,
             fk: &visit::fn_kind,
             decl: &fn_decl,
-            body: P<Block>,
+            body: &Block,
             sp: Span,
             id: NodeId,
             this: @IrMaps) {
@@ -443,7 +443,7 @@ fn visit_fn(v: &mut LivenessVisitor,
     lsets.warn_about_unused_args(decl, entry_ln);
 }
 
-fn visit_local(v: &mut LivenessVisitor, local: @Local, this: @IrMaps) {
+fn visit_local(v: &mut LivenessVisitor, local: &Local, this: @IrMaps) {
     let def_map = this.tcx.def_map;
     pat_util::pat_bindings(def_map, local.pat, |bm, p_id, sp, path| {
         debug!("adding local variable {}", p_id);
@@ -490,7 +490,7 @@ fn visit_arm(v: &mut LivenessVisitor, arm: &Arm, this: @IrMaps) {
     visit::walk_arm(v, arm, this);
 }
 
-fn visit_expr(v: &mut LivenessVisitor, expr: @Expr, this: @IrMaps) {
+fn visit_expr(v: &mut LivenessVisitor, expr: &Expr, this: @IrMaps) {
     match expr.node {
       // live nodes required for uses or definitions of variables:
       ExprPath(_) | ExprSelf => {
@@ -1472,7 +1472,7 @@ impl Liveness {
 // _______________________________________________________________________
 // Checking for error conditions
 
-fn check_local(this: &mut Liveness, local: @Local) {
+fn check_local(this: &mut Liveness, local: &Local) {
     match local.init {
       Some(_) => {
         this.warn_about_unused_or_dead_vars_in_pat(local.pat);
@@ -1508,7 +1508,7 @@ fn check_arm(this: &mut Liveness, arm: &Arm) {
     visit::walk_arm(this, arm, ());
 }
 
-fn check_expr(this: &mut Liveness, expr: @Expr) {
+fn check_expr(this: &mut Liveness, expr: &Expr) {
     match expr.node {
       ExprAssign(l, r) => {
         this.check_lvalue(l);

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -216,7 +216,7 @@ pub fn deref_kind(tcx: ty::ctxt, t: ty::t) -> deref_kind {
 
 pub fn cat_expr(tcx: ty::ctxt,
                 method_map: typeck::method_map,
-                expr: @ast::Expr)
+                expr: &ast::Expr)
              -> cmt {
     let mcx = &mem_categorization_ctxt {
         tcx: tcx, method_map: method_map
@@ -226,7 +226,7 @@ pub fn cat_expr(tcx: ty::ctxt,
 
 pub fn cat_expr_unadjusted(tcx: ty::ctxt,
                            method_map: typeck::method_map,
-                           expr: @ast::Expr)
+                           expr: &ast::Expr)
                         -> cmt {
     let mcx = &mem_categorization_ctxt {
         tcx: tcx, method_map: method_map
@@ -237,7 +237,7 @@ pub fn cat_expr_unadjusted(tcx: ty::ctxt,
 pub fn cat_expr_autoderefd(
     tcx: ty::ctxt,
     method_map: typeck::method_map,
-    expr: @ast::Expr,
+    expr: &ast::Expr,
     autoderefs: uint) -> cmt
 {
     let mcx = &mem_categorization_ctxt {
@@ -265,12 +265,12 @@ pub trait ast_node {
     fn span(&self) -> Span;
 }
 
-impl ast_node for @ast::Expr {
+impl ast_node for ast::Expr {
     fn id(&self) -> ast::NodeId { self.id }
     fn span(&self) -> Span { self.span }
 }
 
-impl ast_node for @ast::Pat {
+impl ast_node for ast::Pat {
     fn id(&self) -> ast::NodeId { self.id }
     fn span(&self) -> Span { self.span }
 }
@@ -325,15 +325,15 @@ impl MutabilityCategory {
 }
 
 impl mem_categorization_ctxt {
-    pub fn expr_ty(&self, expr: @ast::Expr) -> ty::t {
+    pub fn expr_ty(&self, expr: &ast::Expr) -> ty::t {
         ty::expr_ty(self.tcx, expr)
     }
 
-    pub fn pat_ty(&self, pat: @ast::Pat) -> ty::t {
+    pub fn pat_ty(&self, pat: &ast::Pat) -> ty::t {
         ty::node_id_to_type(self.tcx, pat.id)
     }
 
-    pub fn cat_expr(&self, expr: @ast::Expr) -> cmt {
+    pub fn cat_expr(&self, expr: &ast::Expr) -> cmt {
         let adjustments = self.tcx.adjustments.borrow();
         match adjustments.get().find(&expr.id) {
             None => {
@@ -375,7 +375,7 @@ impl mem_categorization_ctxt {
         }
     }
 
-    pub fn cat_expr_autoderefd(&self, expr: @ast::Expr, autoderefs: uint)
+    pub fn cat_expr_autoderefd(&self, expr: &ast::Expr, autoderefs: uint)
                                -> cmt {
         let mut cmt = self.cat_expr_unadjusted(expr);
         for deref in range(1u, autoderefs + 1) {
@@ -384,7 +384,7 @@ impl mem_categorization_ctxt {
         return cmt;
     }
 
-    pub fn cat_expr_unadjusted(&self, expr: @ast::Expr) -> cmt {
+    pub fn cat_expr_unadjusted(&self, expr: &ast::Expr) -> cmt {
         debug!("cat_expr: id={} expr={}",
                expr.id, pprust::expr_to_str(expr, self.tcx.sess.intr()));
 
@@ -577,7 +577,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_rvalue_node<N:ast_node>(&self,
-                                       node: N,
+                                       node: &N,
                                        expr_ty: ty::t) -> cmt {
         self.cat_rvalue(node.id(),
                         node.span(),
@@ -614,7 +614,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_field<N:ast_node>(&self,
-                                 node: N,
+                                 node: &N,
                                  base_cmt: cmt,
                                  f_name: ast::Ident,
                                  f_ty: ty::t)
@@ -629,7 +629,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_deref_fn_or_obj<N:ast_node>(&self,
-                                           node: N,
+                                           node: &N,
                                            base_cmt: cmt,
                                            deref_cnt: uint)
                                            -> cmt {
@@ -644,7 +644,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_deref<N:ast_node>(&self,
-                                 node: N,
+                                 node: &N,
                                  base_cmt: cmt,
                                  deref_cnt: uint)
                                  -> cmt {
@@ -662,7 +662,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_deref_common<N:ast_node>(&self,
-                                        node: N,
+                                        node: &N,
                                         base_cmt: cmt,
                                         deref_cnt: uint,
                                         deref_ty: ty::t)
@@ -706,7 +706,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_index<N:ast_node>(&self,
-                                 elt: N,
+                                 elt: &N,
                                  base_cmt: cmt,
                                  derefs: uint)
                                  -> cmt {
@@ -786,7 +786,7 @@ impl mem_categorization_ctxt {
           }
         };
 
-        fn interior<N: ast_node>(elt: N,
+        fn interior<N: ast_node>(elt: &N,
                                  of_cmt: cmt,
                                  vec_ty: ty::t,
                                  mutbl: MutabilityCategory,
@@ -803,7 +803,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_imm_interior<N:ast_node>(&self,
-                                        node: N,
+                                        node: &N,
                                         base_cmt: cmt,
                                         interior_ty: ty::t,
                                         interior: InteriorKind)
@@ -818,7 +818,7 @@ impl mem_categorization_ctxt {
     }
 
     pub fn cat_downcast<N:ast_node>(&self,
-                                    node: N,
+                                    node: &N,
                                     base_cmt: cmt,
                                     downcast_ty: ty::t)
                                     -> cmt {
@@ -833,8 +833,8 @@ impl mem_categorization_ctxt {
 
     pub fn cat_pattern(&self,
                        cmt: cmt,
-                       pat: @ast::Pat,
-                       op: |cmt, @ast::Pat|) {
+                       pat: &ast::Pat,
+                       op: |cmt, &ast::Pat|) {
         // Here, `cmt` is the categorization for the value being
         // matched and pat is the pattern it is being matched against.
         //

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -193,14 +193,14 @@ enum UseMode {
 }
 
 impl visit::Visitor<()> for VisitContext {
-    fn visit_fn(&mut self, fk:&visit::fn_kind, fd:&fn_decl,
-                b:P<Block>, s:Span, n:NodeId, _:()) {
+    fn visit_fn(&mut self, fk: &visit::fn_kind, fd: &fn_decl,
+                b: &Block, s: Span, n: NodeId, _: ()) {
         compute_modes_for_fn(self, fk, fd, b, s, n);
     }
-    fn visit_expr(&mut self, ex:@Expr, _:()) {
+    fn visit_expr(&mut self, ex: &Expr, _: ()) {
         compute_modes_for_expr(self, ex);
     }
-    fn visit_local(&mut self, l:@Local, _:()) {
+    fn visit_local(&mut self, l: &Local, _: ()) {
         compute_modes_for_local(self, l);
     }
     // FIXME(#10894) should continue recursing
@@ -240,7 +240,7 @@ pub fn moved_variable_node_id_from_def(def: Def) -> Option<NodeId> {
 // Expressions
 
 fn compute_modes_for_local<'a>(cx: &mut VisitContext,
-                               local: @Local) {
+                               local: &Local) {
     cx.use_pat(local.pat);
     for &init in local.init.iter() {
         cx.use_expr(init, Read);
@@ -250,7 +250,7 @@ fn compute_modes_for_local<'a>(cx: &mut VisitContext,
 fn compute_modes_for_fn(cx: &mut VisitContext,
                         fk: &visit::fn_kind,
                         decl: &fn_decl,
-                        body: P<Block>,
+                        body: &Block,
                         span: Span,
                         id: NodeId) {
     for a in decl.inputs.iter() {
@@ -260,7 +260,7 @@ fn compute_modes_for_fn(cx: &mut VisitContext,
 }
 
 fn compute_modes_for_expr(cx: &mut VisitContext,
-                          expr: @Expr)
+                          expr: &Expr)
 {
     cx.consume_expr(expr);
 }
@@ -272,7 +272,7 @@ impl VisitContext {
         }
     }
 
-    pub fn consume_expr(&mut self, expr: @Expr) {
+    pub fn consume_expr(&mut self, expr: &Expr) {
         /*!
          * Indicates that the value of `expr` will be consumed,
          * meaning either copied or moved depending on its type.
@@ -311,7 +311,7 @@ impl VisitContext {
     }
 
     pub fn use_expr(&mut self,
-                    expr: @Expr,
+                    expr: &Expr,
                     expr_mode: UseMode) {
         /*!
          * Indicates that `expr` is used with a given mode.  This will

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -44,7 +44,7 @@ fn generics_require_inlining(generics: &ast::Generics) -> bool {
 // Returns true if the given item must be inlined because it may be
 // monomorphized or it was marked with `#[inline]`. This will only return
 // true for functions.
-fn item_might_be_inlined(item: @ast::item) -> bool {
+fn item_might_be_inlined(item: &ast::item) -> bool {
     if attributes_specify_inlining(item.attrs) {
         return true
     }
@@ -105,7 +105,7 @@ struct MarkSymbolVisitor {
 
 impl Visitor<()> for MarkSymbolVisitor {
 
-    fn visit_expr(&mut self, expr:@ast::Expr, _:()) {
+    fn visit_expr(&mut self, expr: &ast::Expr, _: ()) {
 
         match expr.node {
             ast::ExprPath(_) => {
@@ -187,7 +187,7 @@ impl Visitor<()> for MarkSymbolVisitor {
         visit::walk_expr(self, expr, ())
     }
 
-    fn visit_item(&mut self, _item: @ast::item, _: ()) {
+    fn visit_item(&mut self, _item: &ast::item, _: ()) {
         // Do not recurse into items. These items will be added to the worklist
         // and recursed into manually if necessary.
     }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -30,7 +30,7 @@ use std::hashmap::{HashMap, HashSet};
 use syntax::codemap::Span;
 use syntax::{ast, visit};
 use syntax::visit::{Visitor,fn_kind};
-use syntax::ast::{P,Block,item,fn_decl,NodeId,Arm,Pat,Stmt,Expr,Local};
+use syntax::ast::{Block,item,fn_decl,NodeId,Arm,Pat,Stmt,Expr,Local};
 
 /**
 The region maps encode information about region relationships.
@@ -69,7 +69,7 @@ struct RegionResolutionVisitor {
     sess: Session,
 
     // Generated maps:
-    region_maps: @RegionMaps,
+    region_maps: RegionMaps,
 }
 
 
@@ -333,7 +333,7 @@ fn parent_to_expr(visitor: &mut RegionResolutionVisitor,
 }
 
 fn resolve_block(visitor: &mut RegionResolutionVisitor,
-                 blk: ast::P<ast::Block>,
+                 blk: &ast::Block,
                  cx: Context) {
     // Record the parent of this block.
     parent_to_expr(visitor, cx, blk.id, blk.span);
@@ -359,7 +359,7 @@ fn resolve_pat(visitor: &mut RegionResolutionVisitor,
 }
 
 fn resolve_stmt(visitor: &mut RegionResolutionVisitor,
-                stmt: @ast::Stmt,
+                stmt: &ast::Stmt,
                 cx: Context) {
     match stmt.node {
         ast::StmtDecl(..) => {
@@ -376,7 +376,7 @@ fn resolve_stmt(visitor: &mut RegionResolutionVisitor,
 }
 
 fn resolve_expr(visitor: &mut RegionResolutionVisitor,
-                expr: @ast::Expr,
+                expr: &ast::Expr,
                 cx: Context) {
     parent_to_expr(visitor, cx, expr.id, expr.span);
 
@@ -417,7 +417,7 @@ fn resolve_expr(visitor: &mut RegionResolutionVisitor,
 }
 
 fn resolve_local(visitor: &mut RegionResolutionVisitor,
-                 local: @ast::Local,
+                 local: &ast::Local,
                  cx: Context) {
     assert_eq!(cx.var_parent, cx.parent);
     parent_to_expr(visitor, cx, local.id, local.span);
@@ -425,7 +425,7 @@ fn resolve_local(visitor: &mut RegionResolutionVisitor,
 }
 
 fn resolve_item(visitor: &mut RegionResolutionVisitor,
-                item: @ast::item,
+                item: &ast::item,
                 cx: Context) {
     // Items create a new outer block scope as far as we're concerned.
     let new_cx = Context {var_parent: None, parent: None, ..cx};
@@ -435,7 +435,7 @@ fn resolve_item(visitor: &mut RegionResolutionVisitor,
 fn resolve_fn(visitor: &mut RegionResolutionVisitor,
               fk: &visit::fn_kind,
               decl: &ast::fn_decl,
-              body: ast::P<ast::Block>,
+              body: &ast::Block,
               sp: Span,
               id: ast::NodeId,
               cx: Context) {
@@ -476,47 +476,46 @@ fn resolve_fn(visitor: &mut RegionResolutionVisitor,
 
 impl Visitor<Context> for RegionResolutionVisitor {
 
-    fn visit_block(&mut self, b:P<Block>, cx:Context) {
+    fn visit_block(&mut self, b: &Block, cx: Context) {
         resolve_block(self, b, cx);
     }
 
-    fn visit_item(&mut self, i:@item, cx:Context) {
+    fn visit_item(&mut self, i: &item, cx: Context) {
         resolve_item(self, i, cx);
     }
 
-    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:P<Block>, s:Span, n:NodeId, cx:Context) {
+    fn visit_fn(&mut self, fk: &fn_kind, fd: &fn_decl,
+                b: &Block, s: Span, n: NodeId, cx: Context) {
         resolve_fn(self, fk, fd, b, s, n, cx);
     }
-    fn visit_arm(&mut self, a:&Arm, cx:Context) {
+    fn visit_arm(&mut self, a: &Arm, cx: Context) {
         resolve_arm(self, a, cx);
     }
-    fn visit_pat(&mut self, p:&Pat, cx:Context) {
+    fn visit_pat(&mut self, p: &Pat, cx: Context) {
         resolve_pat(self, p, cx);
     }
-    fn visit_stmt(&mut self, s:@Stmt, cx:Context) {
+    fn visit_stmt(&mut self, s: &Stmt, cx: Context) {
         resolve_stmt(self, s, cx);
     }
-    fn visit_expr(&mut self, ex:@Expr, cx:Context) {
+    fn visit_expr(&mut self, ex: &Expr, cx: Context) {
         resolve_expr(self, ex, cx);
     }
-    fn visit_local(&mut self, l:@Local, cx:Context) {
+    fn visit_local(&mut self, l: &Local, cx: Context) {
         resolve_local(self, l, cx);
     }
 }
 
-pub fn resolve_crate(sess: Session, crate: &ast::Crate) -> @RegionMaps {
-    let region_maps = @RegionMaps {
-        scope_map: RefCell::new(HashMap::new()),
-        free_region_map: RefCell::new(HashMap::new()),
-        cleanup_scopes: RefCell::new(HashSet::new()),
-    };
-    let cx = Context {parent: None,
-                      var_parent: None};
+pub fn resolve_crate(sess: Session, crate: &ast::Crate) -> RegionMaps {
     let mut visitor = RegionResolutionVisitor {
         sess: sess,
-        region_maps: region_maps,
+        region_maps: RegionMaps {
+            scope_map: RefCell::new(HashMap::new()),
+            free_region_map: RefCell::new(HashMap::new()),
+            cleanup_scopes: RefCell::new(HashSet::new())
+        }
     };
+    let cx = Context { parent: None, var_parent: None };
     visit::walk_crate(&mut visitor, crate, cx);
-    return region_maps;
+    return visitor.region_maps;
 }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -137,22 +137,22 @@ enum SelfBinding {
 }
 
 impl Visitor<()> for Resolver {
-    fn visit_item(&mut self, item:@item, _:()) {
+    fn visit_item(&mut self, item: &item, _: ()) {
         self.resolve_item(item);
     }
-    fn visit_arm(&mut self, arm:&Arm, _:()) {
+    fn visit_arm(&mut self, arm: &Arm, _: ()) {
         self.resolve_arm(arm);
     }
-    fn visit_block(&mut self, block:P<Block>, _:()) {
+    fn visit_block(&mut self, block: &Block, _: ()) {
         self.resolve_block(block);
     }
-    fn visit_expr(&mut self, expr:@Expr, _:()) {
+    fn visit_expr(&mut self, expr: &Expr, _: ()) {
         self.resolve_expr(expr);
     }
-    fn visit_local(&mut self, local:@Local, _:()) {
+    fn visit_local(&mut self, local: &Local, _: ()) {
         self.resolve_local(local);
     }
-    fn visit_ty(&mut self, ty:&Ty, _:()) {
+    fn visit_ty(&mut self, ty: &Ty, _: ()) {
         self.resolve_type(ty);
     }
 }
@@ -898,13 +898,13 @@ struct BuildReducedGraphVisitor<'a> {
 
 impl<'a> Visitor<ReducedGraphParent> for BuildReducedGraphVisitor<'a> {
 
-    fn visit_item(&mut self, item:@item, context:ReducedGraphParent) {
+    fn visit_item(&mut self, item: &item, context: ReducedGraphParent) {
         let p = self.resolver.build_reduced_graph_for_item(item, context);
         visit::walk_item(self, item, p);
     }
 
-    fn visit_foreign_item(&mut self, foreign_item: @foreign_item,
-                          context:ReducedGraphParent) {
+    fn visit_foreign_item(&mut self, foreign_item: &foreign_item,
+                          context: ReducedGraphParent) {
         self.resolver.build_reduced_graph_for_foreign_item(foreign_item,
                                                            context,
                                                            |r, c| {
@@ -913,11 +913,11 @@ impl<'a> Visitor<ReducedGraphParent> for BuildReducedGraphVisitor<'a> {
         })
     }
 
-    fn visit_view_item(&mut self, view_item:&view_item, context:ReducedGraphParent) {
+    fn visit_view_item(&mut self, view_item: &view_item, context: ReducedGraphParent) {
         self.resolver.build_reduced_graph_for_view_item(view_item, context);
     }
 
-    fn visit_block(&mut self, block:P<Block>, context:ReducedGraphParent) {
+    fn visit_block(&mut self, block: &Block, context: ReducedGraphParent) {
         let np = self.resolver.build_reduced_graph_for_block(block, context);
         visit::walk_block(self, block, np);
     }
@@ -927,7 +927,7 @@ impl<'a> Visitor<ReducedGraphParent> for BuildReducedGraphVisitor<'a> {
 struct UnusedImportCheckVisitor<'a> { resolver: &'a Resolver }
 
 impl<'a> Visitor<()> for UnusedImportCheckVisitor<'a> {
-    fn visit_view_item(&mut self, vi:&view_item, _:()) {
+    fn visit_view_item(&mut self, vi: &view_item, _: ()) {
         self.resolver.check_for_item_unused_imports(vi);
         visit::walk_view_item(self, vi, ());
     }
@@ -1141,7 +1141,7 @@ impl Resolver {
 
     /// Constructs the reduced graph for one item.
     fn build_reduced_graph_for_item(&mut self,
-                                        item: @item,
+                                        item: &item,
                                         parent: ReducedGraphParent)
                                             -> ReducedGraphParent
     {
@@ -1550,7 +1550,7 @@ impl Resolver {
 
     /// Constructs the reduced graph for one foreign item.
     fn build_reduced_graph_for_foreign_item(&mut self,
-                                            foreign_item: @foreign_item,
+                                            foreign_item: &foreign_item,
                                             parent: ReducedGraphParent,
                                             f: |&mut Resolver,
                                                 ReducedGraphParent|) {
@@ -3633,7 +3633,7 @@ impl Resolver {
         visit::walk_crate(self, crate, ());
     }
 
-    fn resolve_item(&mut self, item: @item) {
+    fn resolve_item(&mut self, item: &item) {
         debug!("(resolving item) resolving {}",
                self.session.str_of(item.ident));
 
@@ -4170,7 +4170,7 @@ impl Resolver {
         visit::walk_mod(self, module_, ());
     }
 
-    fn resolve_local(&mut self, local: @Local) {
+    fn resolve_local(&mut self, local: &Local) {
         // Resolve the type.
         self.resolve_type(local.ty);
 
@@ -4268,7 +4268,7 @@ impl Resolver {
         value_ribs.get().pop();
     }
 
-    fn resolve_block(&mut self, block: P<Block>) {
+    fn resolve_block(&mut self, block: &Block) {
         debug!("(resolving block) entering block");
         {
             let mut value_ribs = self.value_ribs.borrow_mut();
@@ -5152,7 +5152,7 @@ impl Resolver {
         }
     }
 
-    fn resolve_expr(&mut self, expr: @Expr) {
+    fn resolve_expr(&mut self, expr: &Expr) {
         // First, record candidate traits for this expression if it could
         // result in the invocation of a method call.
 
@@ -5324,8 +5324,7 @@ impl Resolver {
         }
     }
 
-    fn record_candidate_traits_for_expr_if_necessary(&mut self,
-                                                         expr: @Expr) {
+    fn record_candidate_traits_for_expr_if_necessary(&mut self, expr: &Expr) {
         match expr.node {
             ExprField(_, ident, _) => {
                 // FIXME(#6890): Even though you can't treat a method like a

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -57,7 +57,7 @@ pub fn crate(sess: session::Session, crate: &ast::Crate)
 
 impl<'a> Visitor<&'a ScopeChain<'a>> for LifetimeContext {
     fn visit_item(&mut self,
-                  item: @ast::item,
+                  item: &ast::item,
                   _: &'a ScopeChain<'a>) {
         let scope = match item.node {
             ast::item_fn(..) | // fn lifetimes get added in visit_fn below
@@ -84,7 +84,7 @@ impl<'a> Visitor<&'a ScopeChain<'a>> for LifetimeContext {
     fn visit_fn(&mut self,
                 fk: &visit::fn_kind,
                 fd: &ast::fn_decl,
-                b: ast::P<ast::Block>,
+                b: &ast::Block,
                 s: Span,
                 n: ast::NodeId,
                 scope: &'a ScopeChain<'a>) {
@@ -132,7 +132,7 @@ impl<'a> Visitor<&'a ScopeChain<'a>> for LifetimeContext {
     }
 
     fn visit_block(&mut self,
-                   b: ast::P<ast::Block>,
+                   b: &ast::Block,
                    scope: &'a ScopeChain<'a>) {
         let scope1 = BlockScope(b.id, scope);
         debug!("pushing block scope {}", b.id);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2203,7 +2203,7 @@ pub struct TransItemVisitor {
 }
 
 impl Visitor<()> for TransItemVisitor {
-    fn visit_item(&mut self, i: @ast::item, _:()) {
+    fn visit_item(&mut self, i: &ast::item, _:()) {
         trans_item(self.ccx, i);
     }
 }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -331,7 +331,7 @@ pub fn create_captured_var_metadata(bcx: @Block,
         None => {
             cx.sess.span_bug(span, "debuginfo::create_captured_var_metadata() - NodeId not found");
         }
-        Some(ast_map::node_local(ident)) => ident,
+        Some(ast_map::node_local(ident, _)) => ident,
         Some(ast_map::node_arg(@ast::Pat { node: ast::PatIdent(_, ref path, _), .. })) => {
             ast_util::path_to_ident(path)
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -276,7 +276,7 @@ struct ctxt_ {
 
     named_region_map: @RefCell<resolve_lifetime::NamedRegionMap>,
 
-    region_maps: @middle::region::RegionMaps,
+    region_maps: middle::region::RegionMaps,
 
     // Stores the types for various nodes in the AST.  Note that this table
     // is not guaranteed to be populated until after typeck.  See
@@ -966,7 +966,7 @@ pub fn mk_ctxt(s: session::Session,
                named_region_map: @RefCell<resolve_lifetime::NamedRegionMap>,
                amap: ast_map::map,
                freevars: freevars::freevar_map,
-               region_maps: @middle::region::RegionMaps,
+               region_maps: middle::region::RegionMaps,
                lang_items: middle::lang_items::LanguageItems)
             -> ctxt {
     @ctxt_ {

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -26,8 +26,8 @@ use syntax::codemap::Span;
 use syntax::print::pprust;
 
 pub fn check_match(fcx: @FnCtxt,
-                   expr: @ast::Expr,
-                   discrim: @ast::Expr,
+                   expr: &ast::Expr,
+                   discrim: &ast::Expr,
                    arms: &[ast::Arm]) {
     let tcx = fcx.ccx.tcx;
 
@@ -106,7 +106,7 @@ pub struct pat_ctxt {
     map: PatIdMap,
 }
 
-pub fn check_pat_variant(pcx: &pat_ctxt, pat: @ast::Pat, path: &ast::Path,
+pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
                          subpats: &Option<~[@ast::Pat]>, expected: ty::t) {
 
     // Typecheck the path.
@@ -418,7 +418,7 @@ pub fn check_struct_like_enum_variant_pat(pcx: &pat_ctxt,
 
 // Pattern checking is top-down rather than bottom-up so that bindings get
 // their types immediately.
-pub fn check_pat(pcx: &pat_ctxt, pat: @ast::Pat, expected: ty::t) {
+pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
     let fcx = pcx.fcx;
     let tcx = pcx.fcx.ccx.tcx;
 
@@ -662,7 +662,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: @ast::Pat, expected: ty::t) {
 // Helper function to check @, ~ and & patterns
 pub fn check_pointer_pat(pcx: &pat_ctxt,
                          pointer_kind: PointerKind,
-                         inner: @ast::Pat,
+                         inner: &ast::Pat,
                          pat_id: ast::NodeId,
                          span: Span,
                          expected: ty::t) {

--- a/src/librustc/middle/typeck/check/demand.rs
+++ b/src/librustc/middle/typeck/check/demand.rs
@@ -56,7 +56,7 @@ pub fn eqtype(fcx: @FnCtxt, sp: Span, expected: ty::t, actual: ty::t) {
 }
 
 // Checks that the type `actual` can be coerced to `expected`.
-pub fn coerce(fcx: @FnCtxt, sp: Span, expected: ty::t, expr: @ast::Expr) {
+pub fn coerce(fcx: @FnCtxt, sp: Span, expected: ty::t, expr: &ast::Expr) {
     let expr_ty = fcx.expr_ty(expr);
     match fcx.mk_assignty(expr, expr_ty, expected) {
       result::Ok(()) => { /* ok */ }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -122,8 +122,8 @@ pub fn lookup(
         fcx: @FnCtxt,
 
         // In a call `a.b::<X, Y, ...>(...)`:
-        expr: @ast::Expr,                   // The expression `a.b(...)`.
-        self_expr: @ast::Expr,              // The expression `a`.
+        expr: &ast::Expr,                   // The expression `a.b(...)`.
+        self_expr: &ast::Expr,              // The expression `a`.
         callee_id: NodeId,                  /* Where to store `a.b`'s type,
                                              * also the scope of the call */
         m_name: ast::Name,                  // The name `b`.
@@ -170,8 +170,8 @@ pub fn lookup(
 
 pub struct LookupContext<'a> {
     fcx: @FnCtxt,
-    expr: @ast::Expr,
-    self_expr: @ast::Expr,
+    expr: &'a ast::Expr,
+    self_expr: &'a ast::Expr,
     callee_id: NodeId,
     m_name: ast::Name,
     supplied_tps: &'a [ty::t],

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -544,28 +544,26 @@ fn insert_vtables(fcx: @FnCtxt,
     vtable_map.get().insert(callee_id, vtables);
 }
 
-pub fn location_info_for_expr(expr: @ast::Expr) -> LocationInfo {
+pub fn location_info_for_expr(expr: &ast::Expr) -> LocationInfo {
     LocationInfo {
         span: expr.span,
         id: expr.id
     }
 }
-pub fn location_info_for_item(item: @ast::item) -> LocationInfo {
+pub fn location_info_for_item(item: &ast::item) -> LocationInfo {
     LocationInfo {
         span: item.span,
         id: item.id
     }
 }
 
-pub fn early_resolve_expr(ex: @ast::Expr,
-                          fcx: @FnCtxt,
-                          is_early: bool) {
+pub fn early_resolve_expr(ex: &ast::Expr, fcx: @FnCtxt, is_early: bool) {
     debug!("vtable: early_resolve_expr() ex with id {:?} (early: {}): {}",
            ex.id, is_early, expr_to_str(ex, fcx.tcx().sess.intr()));
     let _indent = indenter();
 
     let cx = fcx.ccx;
-    let resolve_object_cast = |src: @ast::Expr, target_ty: ty::t| {
+    let resolve_object_cast = |src: &ast::Expr, target_ty: ty::t| {
       match ty::get(target_ty).sty {
           // Bounds of type's contents are not checked here, but in kind.rs.
           ty::ty_trait(target_def_id, ref target_substs, store,
@@ -753,15 +751,14 @@ pub fn early_resolve_expr(ex: @ast::Expr,
     }
 }
 
-fn resolve_expr(fcx: @FnCtxt,
-                ex: @ast::Expr) {
+fn resolve_expr(fcx: @FnCtxt, ex: &ast::Expr) {
     let mut fcx = fcx;
     early_resolve_expr(ex, fcx, false);
     visit::walk_expr(&mut fcx, ex, ());
 }
 
 pub fn resolve_impl(ccx: @CrateCtxt,
-                    impl_item: @ast::item,
+                    impl_item: &ast::item,
                     impl_generics: &ty::Generics,
                     impl_trait_ref: &ty::TraitRef) {
     let param_env = ty::construct_parameter_environment(
@@ -817,17 +814,16 @@ pub fn resolve_impl(ccx: @CrateCtxt,
 }
 
 impl visit::Visitor<()> for @FnCtxt {
-    fn visit_expr(&mut self, ex:@ast::Expr, _:()) {
+    fn visit_expr(&mut self, ex: &ast::Expr, _: ()) {
         resolve_expr(*self, ex);
     }
-    fn visit_item(&mut self, _:@ast::item, _:()) {
+    fn visit_item(&mut self, _: &ast::item, _: ()) {
         // no-op
     }
 }
 
 // Detect points where a trait-bounded type parameter is
 // instantiated, resolve the impls for the parameters.
-pub fn resolve_in_block(fcx: @FnCtxt, bl: ast::P<ast::Block>) {
-    let mut fcx = fcx;
+pub fn resolve_in_block(mut fcx: @FnCtxt, bl: &ast::Block) {
     visit::walk_block(&mut fcx, bl, ());
 }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -242,13 +242,13 @@ struct WbCtxt {
     success: bool,
 }
 
-fn visit_stmt(s: @ast::Stmt, wbcx: &mut WbCtxt) {
+fn visit_stmt(s: &ast::Stmt, wbcx: &mut WbCtxt) {
     if !wbcx.success { return; }
     resolve_type_vars_for_node(wbcx, s.span, ty::stmt_node_id(s));
     visit::walk_stmt(wbcx, s, ());
 }
 
-fn visit_expr(e: @ast::Expr, wbcx: &mut WbCtxt) {
+fn visit_expr(e: &ast::Expr, wbcx: &mut WbCtxt) {
     if !wbcx.success {
         return;
     }
@@ -296,7 +296,7 @@ fn visit_expr(e: @ast::Expr, wbcx: &mut WbCtxt) {
     visit::walk_expr(wbcx, e, ());
 }
 
-fn visit_block(b: ast::P<ast::Block>, wbcx: &mut WbCtxt) {
+fn visit_block(b: &ast::Block, wbcx: &mut WbCtxt) {
     if !wbcx.success {
         return;
     }
@@ -319,7 +319,7 @@ fn visit_pat(p: &ast::Pat, wbcx: &mut WbCtxt) {
     visit::walk_pat(wbcx, p, ());
 }
 
-fn visit_local(l: @ast::Local, wbcx: &mut WbCtxt) {
+fn visit_local(l: &ast::Local, wbcx: &mut WbCtxt) {
     if !wbcx.success { return; }
     let var_ty = wbcx.fcx.local_ty(l.span, l.id);
     match resolve_type(wbcx.fcx.infcx(), var_ty, resolve_all | force_all) {
@@ -341,22 +341,22 @@ fn visit_local(l: @ast::Local, wbcx: &mut WbCtxt) {
     }
     visit::walk_local(wbcx, l, ());
 }
-fn visit_item(_item: @ast::item, _wbcx: &mut WbCtxt) {
+fn visit_item(_item: &ast::item, _wbcx: &mut WbCtxt) {
     // Ignore items
 }
 
 impl Visitor<()> for WbCtxt {
-    fn visit_item(&mut self, i:@ast::item, _:()) { visit_item(i, self); }
-    fn visit_stmt(&mut self, s:@ast::Stmt, _:()) { visit_stmt(s, self); }
-    fn visit_expr(&mut self, ex:@ast::Expr, _:()) { visit_expr(ex, self); }
-    fn visit_block(&mut self, b:ast::P<ast::Block>, _:()) { visit_block(b, self); }
-    fn visit_pat(&mut self, p:&ast::Pat, _:()) { visit_pat(p, self); }
-    fn visit_local(&mut self, l:@ast::Local, _:()) { visit_local(l, self); }
+    fn visit_item(&mut self, i: &ast::item, _: ()) { visit_item(i, self); }
+    fn visit_stmt(&mut self, s: &ast::Stmt, _: ()) { visit_stmt(s, self); }
+    fn visit_expr(&mut self, ex:&ast::Expr, _: ()) { visit_expr(ex, self); }
+    fn visit_block(&mut self, b: &ast::Block, _: ()) { visit_block(b, self); }
+    fn visit_pat(&mut self, p: &ast::Pat, _: ()) { visit_pat(p, self); }
+    fn visit_local(&mut self, l: &ast::Local, _: ()) { visit_local(l, self); }
     // FIXME(#10894) should continue recursing
-    fn visit_ty(&mut self, _t: &ast::Ty, _:()) {}
+    fn visit_ty(&mut self, _t: &ast::Ty, _: ()) {}
 }
 
-pub fn resolve_type_vars_in_expr(fcx: @FnCtxt, e: @ast::Expr) -> bool {
+pub fn resolve_type_vars_in_expr(fcx: @FnCtxt, e: &ast::Expr) -> bool {
     let mut wbcx = WbCtxt { fcx: fcx, success: true };
     let wbcx = &mut wbcx;
     wbcx.visit_expr(e, ());
@@ -365,7 +365,7 @@ pub fn resolve_type_vars_in_expr(fcx: @FnCtxt, e: @ast::Expr) -> bool {
 
 pub fn resolve_type_vars_in_fn(fcx: @FnCtxt,
                                decl: &ast::fn_decl,
-                               blk: ast::P<ast::Block>,
+                               blk: &ast::Block,
                                self_info: Option<SelfInfo>) -> bool {
     let mut wbcx = WbCtxt { fcx: fcx, success: true };
     let wbcx = &mut wbcx;

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -61,11 +61,11 @@ struct CollectItemTypesVisitor {
 }
 
 impl visit::Visitor<()> for CollectItemTypesVisitor {
-    fn visit_item(&mut self, i:@ast::item, _:()) {
+    fn visit_item(&mut self, i: &ast::item, _: ()) {
         convert(self.ccx, i);
         visit::walk_item(self, i, ());
     }
-    fn visit_foreign_item(&mut self, i:@ast::foreign_item, _:()) {
+    fn visit_foreign_item(&mut self, i: &ast::foreign_item, _: ()) {
         convert_foreign(self.ccx, i);
         visit::walk_foreign_item(self, i, ());
     }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -109,7 +109,8 @@ pub enum TypeOrigin {
     MethodCompatCheck(Span),
 
     // Checking that this expression can be assigned where it needs to be
-    ExprAssignable(@ast::Expr),
+    // FIXME(eddyb) #11161 is the original Expr required?
+    ExprAssignable(Span),
 
     // Relating trait refs when resolving vtables
     RelateTraitRefs(Span),
@@ -845,7 +846,7 @@ impl TypeOrigin {
     pub fn span(&self) -> Span {
         match *self {
             MethodCompatCheck(span) => span,
-            ExprAssignable(expr) => expr.span,
+            ExprAssignable(span) => span,
             Misc(span) => span,
             RelateTraitRefs(span) => span,
             RelateSelfType(span) => span,

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -534,8 +534,7 @@ impl RegionVarBindings {
 
 impl RegionVarBindings {
     fn is_subregion_of(&self, sub: Region, sup: Region) -> bool {
-        let rm = self.tcx.region_maps;
-        rm.is_subregion_of(sub, sup)
+        self.tcx.region_maps.is_subregion_of(sub, sup)
     }
 
     fn lub_concrete_regions(&self, a: Region, b: Region) -> Region {
@@ -571,8 +570,7 @@ impl RegionVarBindings {
             // A "free" region can be interpreted as "some region
             // at least as big as the block fr.scope_id".  So, we can
             // reasonably compare free regions and scopes:
-            let rm = self.tcx.region_maps;
-            match rm.nearest_common_ancestor(fr.scope_id, s_id) {
+            match self.tcx.region_maps.nearest_common_ancestor(fr.scope_id, s_id) {
               // if the free region's scope `fr.scope_id` is bigger than
               // the scope region `s_id`, then the LUB is the free
               // region itself:
@@ -588,8 +586,7 @@ impl RegionVarBindings {
             // The region corresponding to an outer block is a
             // subtype of the region corresponding to an inner
             // block.
-            let rm = self.tcx.region_maps;
-            match rm.nearest_common_ancestor(a_id, b_id) {
+            match self.tcx.region_maps.nearest_common_ancestor(a_id, b_id) {
               Some(r_id) => ReScope(r_id),
               _ => ReStatic
             }
@@ -628,10 +625,9 @@ impl RegionVarBindings {
                   a: &FreeRegion,
                   b: &FreeRegion) -> ty::Region
         {
-            let rm = this.tcx.region_maps;
-            if rm.sub_free_region(*a, *b) {
+            if this.tcx.region_maps.sub_free_region(*a, *b) {
                 ty::ReFree(*b)
-            } else if rm.sub_free_region(*b, *a) {
+            } else if this.tcx.region_maps.sub_free_region(*b, *a) {
                 ty::ReFree(*a)
             } else {
                 ty::ReStatic
@@ -681,8 +677,7 @@ impl RegionVarBindings {
                 // than the scope `s_id`, then we can say that the GLB
                 // is the scope `s_id`.  Otherwise, as we do not know
                 // big the free region is precisely, the GLB is undefined.
-                let rm = self.tcx.region_maps;
-                match rm.nearest_common_ancestor(fr.scope_id, s_id) {
+                match self.tcx.region_maps.nearest_common_ancestor(fr.scope_id, s_id) {
                     Some(r_id) if r_id == fr.scope_id => Ok(s),
                     _ => Err(ty::terr_regions_no_overlap(b, a))
                 }
@@ -729,10 +724,9 @@ impl RegionVarBindings {
                   a: &FreeRegion,
                   b: &FreeRegion) -> cres<ty::Region>
         {
-            let rm = this.tcx.region_maps;
-            if rm.sub_free_region(*a, *b) {
+            if this.tcx.region_maps.sub_free_region(*a, *b) {
                 Ok(ty::ReFree(*a))
-            } else if rm.sub_free_region(*b, *a) {
+            } else if this.tcx.region_maps.sub_free_region(*b, *a) {
                 Ok(ty::ReFree(*b))
             } else {
                 this.intersect_scopes(ty::ReFree(*a), ty::ReFree(*b),
@@ -753,8 +747,7 @@ impl RegionVarBindings {
         // it.  Otherwise fail.
         debug!("intersect_scopes(scope_a={:?}, scope_b={:?}, region_a={:?}, region_b={:?})",
                scope_a, scope_b, region_a, region_b);
-        let rm = self.tcx.region_maps;
-        match rm.nearest_common_ancestor(scope_a, scope_b) {
+        match self.tcx.region_maps.nearest_common_ancestor(scope_a, scope_b) {
             Some(r_id) if scope_a == r_id => Ok(ReScope(scope_b)),
             Some(r_id) if scope_b == r_id => Ok(ReScope(scope_a)),
             _ => Err(ty::terr_regions_no_overlap(region_a, region_b))

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -327,9 +327,7 @@ impl<'a> TermsContext<'a> {
 }
 
 impl<'a> Visitor<()> for TermsContext<'a> {
-    fn visit_item(&mut self,
-                  item: @ast::item,
-                  (): ()) {
+    fn visit_item(&mut self, item: &ast::item, _: ()) {
         debug!("add_inferreds for item {}", item.repr(self.tcx));
 
         let inferreds_on_entry = self.num_inferred();
@@ -434,9 +432,7 @@ fn add_constraints_from_crate<'a>(terms_cx: TermsContext<'a>,
 }
 
 impl<'a> Visitor<()> for ConstraintContext<'a> {
-    fn visit_item(&mut self,
-                  item: @ast::item,
-                  (): ()) {
+    fn visit_item(&mut self, item: &ast::item, _: ()) {
         let did = ast_util::local_def(item.id);
         let tcx = self.terms_cx.tcx;
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -74,7 +74,7 @@ struct LoopQueryVisitor<'a> {
 }
 
 impl<'a> Visitor<()> for LoopQueryVisitor<'a> {
-    fn visit_expr(&mut self, e: @ast::Expr, _: ()) {
+    fn visit_expr(&mut self, e: &ast::Expr, _: ()) {
         self.flag |= (self.p)(&e.node);
         match e.node {
           // Skip inner loops, since a break in the inner loop isn't a
@@ -87,7 +87,7 @@ impl<'a> Visitor<()> for LoopQueryVisitor<'a> {
 
 // Takes a predicate p, returns true iff p is true for any subexpressions
 // of b -- skipping any inner loops (loop, while, loop_body)
-pub fn loop_query(b: ast::P<ast::Block>, p: |&ast::Expr_| -> bool) -> bool {
+pub fn loop_query(b: &ast::Block, p: |&ast::Expr_| -> bool) -> bool {
     let mut v = LoopQueryVisitor {
         p: p,
         flag: false,
@@ -97,12 +97,12 @@ pub fn loop_query(b: ast::P<ast::Block>, p: |&ast::Expr_| -> bool) -> bool {
 }
 
 struct BlockQueryVisitor<'a> {
-    p: 'a |@ast::Expr| -> bool,
+    p: 'a |&ast::Expr| -> bool,
     flag: bool,
 }
 
 impl<'a> Visitor<()> for BlockQueryVisitor<'a> {
-    fn visit_expr(&mut self, e: @ast::Expr, _:()) {
+    fn visit_expr(&mut self, e: &ast::Expr, _: ()) {
         self.flag |= (self.p)(e);
         visit::walk_expr(self, e, ())
     }
@@ -110,7 +110,7 @@ impl<'a> Visitor<()> for BlockQueryVisitor<'a> {
 
 // Takes a predicate p, returns true iff p is true for any subexpressions
 // of b -- skipping any inner loops (loop, while, loop_body)
-pub fn block_query(b: ast::P<ast::Block>, p: |@ast::Expr| -> bool) -> bool {
+pub fn block_query(b: ast::P<ast::Block>, p: |&ast::Expr| -> bool) -> bool {
     let mut v = BlockQueryVisitor {
         p: p,
         flag: false,
@@ -119,7 +119,7 @@ pub fn block_query(b: ast::P<ast::Block>, p: |@ast::Expr| -> bool) -> bool {
     return v.flag;
 }
 
-pub fn local_rhs_span(l: @ast::Local, def: Span) -> Span {
+pub fn local_rhs_span(l: &ast::Local, def: Span) -> Span {
     match l.init {
       Some(i) => return i.span,
       _ => return def

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -72,11 +72,11 @@ fn get_ast_and_resolve(cpath: &Path,
         cfg.push(@dummy_spanned(ast::MetaWord(cfg_.to_managed())));
     }
 
-    let mut crate = phase_1_parse_input(sess, cfg.clone(), &input);
-    crate = phase_2_configure_and_expand(sess, cfg, crate);
+    let crate = phase_1_parse_input(sess, cfg.clone(), &input);
+    let (crate, ast_map) = phase_2_configure_and_expand(sess, cfg, crate);
     let driver::driver::CrateAnalysis {
         exported_items, ty_cx, ..
-    } = phase_3_run_analysis_passes(sess, &crate);
+    } = phase_3_run_analysis_passes(sess, &crate, ast_map);
 
     debug!("crate: {:?}", crate);
     return (DocContext { crate: crate, tycx: Some(ty_cx), sess: sess },

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -57,8 +57,8 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
                                       span_diagnostic_handler);
 
     let cfg = driver::build_configuration(sess);
-    let mut crate = driver::phase_1_parse_input(sess, cfg.clone(), &input);
-    crate = driver::phase_2_configure_and_expand(sess, cfg, crate);
+    let crate = driver::phase_1_parse_input(sess, cfg.clone(), &input);
+    let (crate, _) = driver::phase_2_configure_and_expand(sess, cfg, crate);
 
     let ctx = @core::DocContext {
         crate: crate,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1128,7 +1128,7 @@ mod test {
 
     impl Visitor<()> for NewPathExprFinderContext {
 
-        fn visit_expr(&mut self, expr: @ast::Expr, _: ()) {
+        fn visit_expr(&mut self, expr: &ast::Expr, _: ()) {
             match *expr {
                 ast::Expr{id:_,span:_,node:ast::ExprPath(ref p)} => {
                     self.path_accumulator.push(p.clone());

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -64,34 +64,34 @@ pub fn generics_of_fn(fk: &fn_kind) -> Generics {
     }
 }
 
-pub trait Visitor<E:Clone> {
+pub trait Visitor<E: Clone> {
     fn visit_ident(&mut self, _sp: Span, _ident: Ident, _e: E) {
         /*! Visit the idents */
     }
-    fn visit_mod(&mut self, m:&_mod, _s:Span, _n:NodeId, e:E) { walk_mod(self, m, e) }
-    fn visit_view_item(&mut self, i:&view_item, e:E) { walk_view_item(self, i, e) }
-    fn visit_foreign_item(&mut self, i:@foreign_item, e:E) { walk_foreign_item(self, i, e) }
-    fn visit_item(&mut self, i:@item, e:E) { walk_item(self, i, e) }
-    fn visit_local(&mut self, l:@Local, e:E) { walk_local(self, l, e) }
-    fn visit_block(&mut self, b:P<Block>, e:E) { walk_block(self, b, e) }
-    fn visit_stmt(&mut self, s:@Stmt, e:E) { walk_stmt(self, s, e) }
-    fn visit_arm(&mut self, a:&Arm, e:E) { walk_arm(self, a, e) }
-    fn visit_pat(&mut self, p:&Pat, e:E) { walk_pat(self, p, e) }
-    fn visit_decl(&mut self, d:@Decl, e:E) { walk_decl(self, d, e) }
-    fn visit_expr(&mut self, ex:@Expr, e:E) { walk_expr(self, ex, e) }
-    fn visit_expr_post(&mut self, _ex:@Expr, _e:E) { }
-    fn visit_ty(&mut self, t:&Ty, e:E) { walk_ty(self, t, e) }
-    fn visit_generics(&mut self, g:&Generics, e:E) { walk_generics(self, g, e) }
-    fn visit_fn(&mut self, fk:&fn_kind, fd:&fn_decl, b:P<Block>, s:Span, n:NodeId, e:E) {
+    fn visit_mod(&mut self, m: &_mod, _s: Span, _n: NodeId, e: E) { walk_mod(self, m, e) }
+    fn visit_view_item(&mut self, i: &view_item, e: E) { walk_view_item(self, i, e) }
+    fn visit_foreign_item(&mut self, i: &foreign_item, e: E) { walk_foreign_item(self, i, e) }
+    fn visit_item(&mut self, i: &item, e: E) { walk_item(self, i, e) }
+    fn visit_local(&mut self, l: &Local, e: E) { walk_local(self, l, e) }
+    fn visit_block(&mut self, b: &Block, e: E) { walk_block(self, b, e) }
+    fn visit_stmt(&mut self, s: &Stmt, e: E) { walk_stmt(self, s, e) }
+    fn visit_arm(&mut self, a: &Arm, e: E) { walk_arm(self, a, e) }
+    fn visit_pat(&mut self, p: &Pat, e: E) { walk_pat(self, p, e) }
+    fn visit_decl(&mut self, d: &Decl, e: E) { walk_decl(self, d, e) }
+    fn visit_expr(&mut self, ex: &Expr, e: E) { walk_expr(self, ex, e) }
+    fn visit_expr_post(&mut self, _ex: &Expr, _e: E) { }
+    fn visit_ty(&mut self, t: &Ty, e: E) { walk_ty(self, t, e) }
+    fn visit_generics(&mut self, g: &Generics, e: E) { walk_generics(self, g, e) }
+    fn visit_fn(&mut self, fk: &fn_kind, fd: &fn_decl, b: &Block, s: Span, n: NodeId, e: E) {
         walk_fn(self, fk, fd, b, s, n , e)
     }
-    fn visit_ty_method(&mut self, t:&TypeMethod, e:E) { walk_ty_method(self, t, e) }
-    fn visit_trait_method(&mut self, t:&trait_method, e:E) { walk_trait_method(self, t, e) }
-    fn visit_struct_def(&mut self, s:@struct_def, i:Ident, g:&Generics, n:NodeId, e:E) {
+    fn visit_ty_method(&mut self, t: &TypeMethod, e: E) { walk_ty_method(self, t, e) }
+    fn visit_trait_method(&mut self, t: &trait_method, e: E) { walk_trait_method(self, t, e) }
+    fn visit_struct_def(&mut self, s: &struct_def, i: Ident, g: &Generics, n: NodeId, e: E) {
         walk_struct_def(self, s, i, g, n, e)
     }
-    fn visit_struct_field(&mut self, s:&struct_field, e:E) { walk_struct_field(self, s, e) }
-    fn visit_variant(&mut self, v:&variant, g:&Generics, e:E) { walk_variant(self, v, g, e) }
+    fn visit_struct_field(&mut self, s: &struct_field, e: E) { walk_struct_field(self, s, e) }
+    fn visit_variant(&mut self, v: &variant, g: &Generics, e: E) { walk_variant(self, v, g, e) }
     fn visit_opt_lifetime_ref(&mut self,
                               _span: Span,
                               opt_lifetime: &Option<Lifetime>,
@@ -115,7 +115,7 @@ pub trait Visitor<E:Clone> {
     fn visit_explicit_self(&mut self, es: &explicit_self, e: E) {
         walk_explicit_self(self, es, e)
     }
-    fn visit_mac(&mut self, macro:&mac, e:E) {
+    fn visit_mac(&mut self, macro: &mac, e: E) {
         walk_mac(self, macro, e)
     }
     fn visit_path(&mut self, path: &Path, _id: ast::NodeId, e: E) {
@@ -123,11 +123,11 @@ pub trait Visitor<E:Clone> {
     }
 }
 
-pub fn walk_crate<E:Clone, V:Visitor<E>>(visitor: &mut V, crate: &Crate, env: E) {
+pub fn walk_crate<E: Clone, V: Visitor<E>>(visitor: &mut V, crate: &Crate, env: E) {
     visitor.visit_mod(&crate.module, crate.span, CRATE_NODE_ID, env)
 }
 
-pub fn walk_mod<E:Clone, V:Visitor<E>>(visitor: &mut V, module: &_mod, env: E) {
+pub fn walk_mod<E: Clone, V: Visitor<E>>(visitor: &mut V, module: &_mod, env: E) {
     for view_item in module.view_items.iter() {
         visitor.visit_view_item(view_item, env.clone())
     }
@@ -137,7 +137,7 @@ pub fn walk_mod<E:Clone, V:Visitor<E>>(visitor: &mut V, module: &_mod, env: E) {
     }
 }
 
-pub fn walk_view_item<E:Clone, V:Visitor<E>>(visitor: &mut V, vi: &view_item, env: E) {
+pub fn walk_view_item<E: Clone, V: Visitor<E>>(visitor: &mut V, vi: &view_item, env: E) {
     match vi.node {
         view_item_extern_mod(name, _, _) => {
             visitor.visit_ident(vi.span, name, env)
@@ -164,7 +164,7 @@ pub fn walk_view_item<E:Clone, V:Visitor<E>>(visitor: &mut V, vi: &view_item, en
     }
 }
 
-pub fn walk_local<E:Clone, V:Visitor<E>>(visitor: &mut V, local: &Local, env: E) {
+pub fn walk_local<E: Clone, V: Visitor<E>>(visitor: &mut V, local: &Local, env: E) {
     visitor.visit_pat(local.pat, env.clone());
     visitor.visit_ty(local.ty, env.clone());
     match local.init {
@@ -173,9 +173,9 @@ pub fn walk_local<E:Clone, V:Visitor<E>>(visitor: &mut V, local: &Local, env: E)
     }
 }
 
-fn walk_explicit_self<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                             explicit_self: &explicit_self,
-                                             env: E) {
+fn walk_explicit_self<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                               explicit_self: &explicit_self,
+                                               env: E) {
     match explicit_self.node {
         sty_static | sty_value(_) | sty_box(_) | sty_uniq(_) => {
         }
@@ -185,13 +185,13 @@ fn walk_explicit_self<E:Clone, V:Visitor<E>>(visitor: &mut V,
     }
 }
 
-fn walk_trait_ref<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                            trait_ref: &ast::trait_ref,
-                            env: E) {
+fn walk_trait_ref<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                           trait_ref: &trait_ref,
+                                           env: E) {
     visitor.visit_path(&trait_ref.path, trait_ref.ref_id, env)
 }
 
-pub fn walk_item<E:Clone, V:Visitor<E>>(visitor: &mut V, item: &item, env: E) {
+pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &item, env: E) {
     visitor.visit_ident(item.span, item.ident, env.clone());
     match item.node {
         item_static(typ, _, expr) => {
@@ -261,19 +261,19 @@ pub fn walk_item<E:Clone, V:Visitor<E>>(visitor: &mut V, item: &item, env: E) {
     }
 }
 
-pub fn walk_enum_def<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                               enum_definition: &ast::enum_def,
-                               generics: &Generics,
-                               env: E) {
+pub fn walk_enum_def<E: Clone, V:Visitor<E>>(visitor: &mut V,
+                                             enum_definition: &enum_def,
+                                             generics: &Generics,
+                                             env: E) {
     for &variant in enum_definition.variants.iter() {
         visitor.visit_variant(variant, generics, env.clone());
     }
 }
 
-pub fn walk_variant<E:Clone, V:Visitor<E>>(visitor:&mut V,
-                                           variant: &variant,
-                                           generics: &Generics,
-                                           env: E) {
+pub fn walk_variant<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                             variant: &variant,
+                                             generics: &Generics,
+                                             env: E) {
     visitor.visit_ident(variant.span, variant.node.name, env.clone());
 
     match variant.node.kind {
@@ -296,11 +296,11 @@ pub fn walk_variant<E:Clone, V:Visitor<E>>(visitor:&mut V,
     }
 }
 
-pub fn skip_ty<E, V:Visitor<E>>(_: &mut V, _: &Ty, _: E) {
+pub fn skip_ty<E, V: Visitor<E>>(_: &mut V, _: &Ty, _: E) {
     // Empty!
 }
 
-pub fn walk_ty<E:Clone, V:Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
+pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
     match typ.node {
         ty_uniq(ty) | ty_vec(ty) | ty_box(ty) => {
             visitor.visit_ty(ty, env)
@@ -357,15 +357,15 @@ pub fn walk_ty<E:Clone, V:Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
     }
 }
 
-fn walk_lifetime_decls<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                              lifetimes: &OptVec<Lifetime>,
-                                              env: E) {
+fn walk_lifetime_decls<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                lifetimes: &OptVec<Lifetime>,
+                                                env: E) {
     for l in lifetimes.iter() {
         visitor.visit_lifetime_decl(l, env.clone());
     }
 }
 
-pub fn walk_path<E:Clone, V:Visitor<E>>(visitor: &mut V, path: &Path, env: E) {
+pub fn walk_path<E: Clone, V: Visitor<E>>(visitor: &mut V, path: &Path, env: E) {
     for segment in path.segments.iter() {
         visitor.visit_ident(path.span, segment.identifier, env.clone());
 
@@ -378,7 +378,7 @@ pub fn walk_path<E:Clone, V:Visitor<E>>(visitor: &mut V, path: &Path, env: E) {
     }
 }
 
-pub fn walk_pat<E:Clone, V:Visitor<E>>(visitor: &mut V, pattern: &Pat, env: E) {
+pub fn walk_pat<E: Clone, V: Visitor<E>>(visitor: &mut V, pattern: &Pat, env: E) {
     match pattern.node {
         PatEnum(ref path, ref children) => {
             visitor.visit_path(path, pattern.id, env.clone());
@@ -431,9 +431,9 @@ pub fn walk_pat<E:Clone, V:Visitor<E>>(visitor: &mut V, pattern: &Pat, env: E) {
     }
 }
 
-pub fn walk_foreign_item<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                   foreign_item: &foreign_item,
-                                   env: E) {
+pub fn walk_foreign_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                  foreign_item: &foreign_item,
+                                                  env: E) {
     visitor.visit_ident(foreign_item.span, foreign_item.ident, env.clone());
 
     match foreign_item.node {
@@ -445,9 +445,9 @@ pub fn walk_foreign_item<E:Clone, V:Visitor<E>>(visitor: &mut V,
     }
 }
 
-pub fn walk_ty_param_bounds<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                      bounds: &OptVec<TyParamBound>,
-                                      env: E) {
+pub fn walk_ty_param_bounds<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                     bounds: &OptVec<TyParamBound>,
+                                                     env: E) {
     for bound in bounds.iter() {
         match *bound {
             TraitTyParamBound(ref typ) => {
@@ -458,18 +458,18 @@ pub fn walk_ty_param_bounds<E:Clone, V:Visitor<E>>(visitor: &mut V,
     }
 }
 
-pub fn walk_generics<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                               generics: &Generics,
-                               env: E) {
+pub fn walk_generics<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                              generics: &Generics,
+                                              env: E) {
     for type_parameter in generics.ty_params.iter() {
         walk_ty_param_bounds(visitor, &type_parameter.bounds, env.clone())
     }
     walk_lifetime_decls(visitor, &generics.lifetimes, env);
 }
 
-pub fn walk_fn_decl<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                              function_declaration: &fn_decl,
-                              env: E) {
+pub fn walk_fn_decl<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                             function_declaration: &fn_decl,
+                                             env: E) {
     for argument in function_declaration.inputs.iter() {
         visitor.visit_pat(argument.pat, env.clone());
         visitor.visit_ty(argument.ty, env.clone())
@@ -481,9 +481,9 @@ pub fn walk_fn_decl<E:Clone, V:Visitor<E>>(visitor: &mut V,
 // visit_fn() and check for fk_method().  I named this visit_method_helper()
 // because it is not a default impl of any method, though I doubt that really
 // clarifies anything. - Niko
-pub fn walk_method_helper<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                    method: &method,
-                                    env: E) {
+pub fn walk_method_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                   method: &method,
+                                                   env: E) {
     visitor.visit_ident(method.span, method.ident, env.clone());
     visitor.visit_fn(&fk_method(method.ident, &method.generics, method),
                      method.decl,
@@ -493,13 +493,13 @@ pub fn walk_method_helper<E:Clone, V:Visitor<E>>(visitor: &mut V,
                      env)
 }
 
-pub fn walk_fn<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                         function_kind: &fn_kind,
-                         function_declaration: &fn_decl,
-                         function_body: P<Block>,
-                         _span: Span,
-                         _: NodeId,
-                         env: E) {
+pub fn walk_fn<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                        function_kind: &fn_kind,
+                                        function_declaration: &fn_decl,
+                                        function_body: &Block,
+                                        _span: Span,
+                                        _: NodeId,
+                                        env: E) {
     walk_fn_decl(visitor, function_declaration, env.clone());
 
     match *function_kind {
@@ -518,9 +518,9 @@ pub fn walk_fn<E:Clone, V:Visitor<E>>(visitor: &mut V,
     visitor.visit_block(function_body, env)
 }
 
-pub fn walk_ty_method<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                             method_type: &TypeMethod,
-                                             env: E) {
+pub fn walk_ty_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                               method_type: &TypeMethod,
+                                               env: E) {
     visitor.visit_ident(method_type.span, method_type.ident, env.clone());
     visitor.visit_explicit_self(&method_type.explicit_self, env.clone());
     for argument_type in method_type.decl.inputs.iter() {
@@ -530,9 +530,9 @@ pub fn walk_ty_method<E:Clone, V:Visitor<E>>(visitor: &mut V,
     visitor.visit_ty(method_type.decl.output, env);
 }
 
-pub fn walk_trait_method<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                   trait_method: &trait_method,
-                                   env: E) {
+pub fn walk_trait_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                  trait_method: &trait_method,
+                                                  env: E) {
     match *trait_method {
         required(ref method_type) => {
             visitor.visit_ty_method(method_type, env)
@@ -541,20 +541,20 @@ pub fn walk_trait_method<E:Clone, V:Visitor<E>>(visitor: &mut V,
     }
 }
 
-pub fn walk_struct_def<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                 struct_definition: @struct_def,
-                                 _: ast::Ident,
-                                 _: &Generics,
-                                 _: NodeId,
-                                 env: E) {
+pub fn walk_struct_def<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                struct_definition: &struct_def,
+                                                _: Ident,
+                                                _: &Generics,
+                                                _: NodeId,
+                                                env: E) {
     for field in struct_definition.fields.iter() {
         visitor.visit_struct_field(field, env.clone())
     }
 }
 
-pub fn walk_struct_field<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                                   struct_field: &struct_field,
-                                   env: E) {
+pub fn walk_struct_field<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                  struct_field: &struct_field,
+                                                  env: E) {
     match struct_field.node.kind {
         named_field(name, _) => {
             visitor.visit_ident(struct_field.span, name, env.clone())
@@ -565,7 +565,7 @@ pub fn walk_struct_field<E:Clone, V:Visitor<E>>(visitor: &mut V,
     visitor.visit_ty(struct_field.node.ty, env)
 }
 
-pub fn walk_block<E:Clone, V:Visitor<E>>(visitor: &mut V, block: P<Block>, env: E) {
+pub fn walk_block<E: Clone, V: Visitor<E>>(visitor: &mut V, block: &Block, env: E) {
     for view_item in block.view_items.iter() {
         visitor.visit_view_item(view_item, env.clone())
     }
@@ -575,7 +575,7 @@ pub fn walk_block<E:Clone, V:Visitor<E>>(visitor: &mut V, block: P<Block>, env: 
     walk_expr_opt(visitor, block.expr, env)
 }
 
-pub fn walk_stmt<E:Clone, V:Visitor<E>>(visitor: &mut V, statement: &Stmt, env: E) {
+pub fn walk_stmt<E: Clone, V: Visitor<E>>(visitor: &mut V, statement: &Stmt, env: E) {
     match statement.node {
         StmtDecl(declaration, _) => visitor.visit_decl(declaration, env),
         StmtExpr(expression, _) | StmtSemi(expression, _) => {
@@ -585,35 +585,35 @@ pub fn walk_stmt<E:Clone, V:Visitor<E>>(visitor: &mut V, statement: &Stmt, env: 
     }
 }
 
-pub fn walk_decl<E:Clone, V:Visitor<E>>(visitor: &mut V, declaration: &Decl, env: E) {
+pub fn walk_decl<E: Clone, V: Visitor<E>>(visitor: &mut V, declaration: &Decl, env: E) {
     match declaration.node {
         DeclLocal(ref local) => visitor.visit_local(*local, env),
         DeclItem(item) => visitor.visit_item(item, env),
     }
 }
 
-pub fn walk_expr_opt<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                         optional_expression: Option<@Expr>,
-                         env: E) {
+pub fn walk_expr_opt<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                              optional_expression: Option<@Expr>,
+                                              env: E) {
     match optional_expression {
         None => {}
         Some(expression) => visitor.visit_expr(expression, env),
     }
 }
 
-pub fn walk_exprs<E:Clone, V:Visitor<E>>(visitor: &mut V,
-                            expressions: &[@Expr],
-                            env: E) {
+pub fn walk_exprs<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                           expressions: &[@Expr],
+                                           env: E) {
     for expression in expressions.iter() {
         visitor.visit_expr(*expression, env.clone())
     }
 }
 
-pub fn walk_mac<E, V:Visitor<E>>(_: &mut V, _: &mac, _: E) {
+pub fn walk_mac<E, V: Visitor<E>>(_: &mut V, _: &mac, _: E) {
     // Empty!
 }
 
-pub fn walk_expr<E:Clone, V:Visitor<E>>(visitor: &mut V, expression: @Expr, env: E) {
+pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, env: E) {
     match expression.node {
         ExprVstore(subexpression, _) => {
             visitor.visit_expr(subexpression, env.clone())
@@ -745,7 +745,7 @@ pub fn walk_expr<E:Clone, V:Visitor<E>>(visitor: &mut V, expression: @Expr, env:
     visitor.visit_expr_post(expression, env.clone())
 }
 
-pub fn walk_arm<E:Clone, V:Visitor<E>>(visitor: &mut V, arm: &Arm, env: E) {
+pub fn walk_arm<E: Clone, V: Visitor<E>>(visitor: &mut V, arm: &Arm, env: E) {
     for pattern in arm.pats.iter() {
         visitor.visit_pat(*pattern, env.clone())
     }


### PR DESCRIPTION
The primary user of `@T`/`P<T>` references from `Visitor` was `ast_map`, which in turn had two users (phase 3 in rustc and a step in loading items from metadata).
Both of them have been rewritten to use `ast_map` as a folder (this might speed up the compilation time of stage2 rustc by 100-200ms just because a fold + a visit are merged together).
