### PR TITLE
libsyntax: ext cleanup

### DIFF
--- a/src/librustc/front/assign_node_ids.rs
+++ b/src/librustc/front/assign_node_ids.rs
@@ -18,14 +18,14 @@ struct NodeIdAssigner {
 }
 
 impl ast_fold for NodeIdAssigner {
-    fn new_id(&self, old_id: ast::NodeId) -> ast::NodeId {
+    fn new_id(&mut self, old_id: ast::NodeId) -> ast::NodeId {
         assert_eq!(old_id, ast::DUMMY_NODE_ID);
         self.sess.next_node_id()
     }
 }
 
 pub fn assign_node_ids(sess: Session, crate: ast::Crate) -> ast::Crate {
-    let fold = NodeIdAssigner {
+    let mut fold = NodeIdAssigner {
         sess: sess,
     };
     fold.fold_crate(crate)

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -56,7 +56,7 @@ struct StandardLibraryInjector {
 }
 
 impl fold::ast_fold for StandardLibraryInjector {
-    fn fold_crate(&self, crate: ast::Crate) -> ast::Crate {
+    fn fold_crate(&mut self, crate: ast::Crate) -> ast::Crate {
         let version = STD_VERSION.to_managed();
         let vers_item = attr::mk_name_value_item_str(@"vers", version);
         let mut vis = ~[ast::view_item {
@@ -108,7 +108,7 @@ impl fold::ast_fold for StandardLibraryInjector {
         }
     }
 
-    fn fold_item(&self, item: @ast::item) -> SmallVector<@ast::item> {
+    fn fold_item(&mut self, item: @ast::item) -> SmallVector<@ast::item> {
         if !no_prelude(item.attrs) {
             // only recur if there wasn't `#[no_implicit_prelude];`
             // on this item, i.e. this means that the prelude is not
@@ -119,7 +119,7 @@ impl fold::ast_fold for StandardLibraryInjector {
         }
     }
 
-    fn fold_mod(&self, module: &ast::_mod) -> ast::_mod {
+    fn fold_mod(&mut self, module: &ast::_mod) -> ast::_mod {
         let prelude_path = ast::Path {
             span: dummy_sp(),
             global: false,
@@ -158,7 +158,7 @@ impl fold::ast_fold for StandardLibraryInjector {
 }
 
 fn inject_libstd_ref(sess: Session, crate: ast::Crate) -> ast::Crate {
-    let fold = StandardLibraryInjector {
+    let mut fold = StandardLibraryInjector {
         sess: sess,
     };
     fold.fold_crate(crate)

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -67,7 +67,7 @@ struct TestHarnessGenerator {
 }
 
 impl fold::ast_fold for TestHarnessGenerator {
-    fn fold_crate(&self, c: ast::Crate) -> ast::Crate {
+    fn fold_crate(&mut self, c: ast::Crate) -> ast::Crate {
         let folded = fold::noop_fold_crate(c, self);
 
         // Add a special __test module to the crate that will contain code
@@ -78,7 +78,7 @@ impl fold::ast_fold for TestHarnessGenerator {
         }
     }
 
-    fn fold_item(&self, i: @ast::item) -> SmallVector<@ast::item> {
+    fn fold_item(&mut self, i: @ast::item) -> SmallVector<@ast::item> {
         {
             let mut path = self.cx.path.borrow_mut();
             path.get().push(i.ident);
@@ -122,7 +122,7 @@ impl fold::ast_fold for TestHarnessGenerator {
         res
     }
 
-    fn fold_mod(&self, m: &ast::_mod) -> ast::_mod {
+    fn fold_mod(&mut self, m: &ast::_mod) -> ast::_mod {
         // Remove any #[main] from the AST so it doesn't clash with
         // the one we're going to add. Only if compiling an executable.
 
@@ -172,7 +172,7 @@ fn generate_test_harness(sess: session::Session, crate: ast::Crate)
         }
     });
 
-    let fold = TestHarnessGenerator {
+    let mut fold = TestHarnessGenerator {
         cx: cx
     };
     let res = fold.fold_crate(crate);

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -301,7 +301,7 @@ struct NestedItemsDropper {
 }
 
 impl fold::ast_fold for NestedItemsDropper {
-    fn fold_block(&self, blk: ast::P<ast::Block>) -> ast::P<ast::Block> {
+    fn fold_block(&mut self, blk: ast::P<ast::Block>) -> ast::P<ast::Block> {
         let stmts_sans_items = blk.stmts.iter().filter_map(|stmt| {
             match stmt.node {
                 ast::StmtExpr(_, _) | ast::StmtSemi(_, _) |
@@ -340,7 +340,7 @@ impl fold::ast_fold for NestedItemsDropper {
 // nested items, as otherwise it would get confused when translating
 // inlined items.
 fn simplify_ast(ii: &ast::inlined_item) -> ast::inlined_item {
-    let fld = NestedItemsDropper {
+    let mut fld = NestedItemsDropper {
         contents: (),
     };
 
@@ -365,17 +365,17 @@ struct AstRenumberer {
 }
 
 impl fold::ast_fold for AstRenumberer {
-    fn new_id(&self, id: ast::NodeId) -> ast::NodeId {
+    fn new_id(&mut self, id: ast::NodeId) -> ast::NodeId {
         self.xcx.tr_id(id)
     }
-    fn new_span(&self, span: Span) -> Span {
+    fn new_span(&mut self, span: Span) -> Span {
         self.xcx.tr_span(span)
     }
 }
 
 fn renumber_ast(xcx: @ExtendedDecodeContext, ii: ast::inlined_item)
     -> ast::inlined_item {
-    let fld = AstRenumberer {
+    let mut fld = AstRenumberer {
         xcx: xcx,
     };
     match ii {

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -80,7 +80,7 @@ struct ReadyCtx {
     fns: ~[ListenerFn]
 }
 
-fn fold_mod(_ctx: @mut ReadyCtx, m: &ast::_mod, fold: &CrateSetup)
+fn fold_mod(_ctx: @mut ReadyCtx, m: &ast::_mod, fold: &mut CrateSetup)
             -> ast::_mod {
     fn strip_main(item: @ast::item) -> @ast::item {
         @ast::item {
@@ -101,7 +101,7 @@ fn fold_mod(_ctx: @mut ReadyCtx, m: &ast::_mod, fold: &CrateSetup)
     }, fold)
 }
 
-fn fold_item(ctx: @mut ReadyCtx, item: @ast::item, fold: &CrateSetup)
+fn fold_item(ctx: @mut ReadyCtx, item: @ast::item, fold: &mut CrateSetup)
              -> SmallVector<@ast::item> {
     ctx.path.push(item.ident);
 
@@ -145,10 +145,10 @@ struct CrateSetup {
 }
 
 impl fold::ast_fold for CrateSetup {
-    fn fold_item(&self, item: @ast::item) -> SmallVector<@ast::item> {
+    fn fold_item(&mut self, item: @ast::item) -> SmallVector<@ast::item> {
         fold_item(self.ctx, item, self)
     }
-    fn fold_mod(&self, module: &ast::_mod) -> ast::_mod {
+    fn fold_mod(&mut self, module: &ast::_mod) -> ast::_mod {
         fold_mod(self.ctx, module, self)
     }
 }
@@ -162,7 +162,7 @@ pub fn ready_crate(sess: session::Session,
         path: ~[],
         fns: ~[]
     };
-    let fold = CrateSetup {
+    let mut fold = CrateSetup {
         ctx: ctx,
     };
     fold.fold_crate(crate)

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -75,7 +75,7 @@ struct ListenerFn {
 
 struct ReadyCtx {
     sess: session::Session,
-    ext_cx: @ExtCtxt,
+    ext_cx: ExtCtxt,
     path: ~[ast::Ident],
     fns: ~[ListenerFn]
 }

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -37,7 +37,7 @@ fn next_state(s: State) -> Option<State> {
     }
 }
 
-pub fn expand_asm(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
                -> base::MacResult {
     let p = parse::new_parser_from_tts(cx.parse_sess(),
                                        cx.cfg(),

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -37,7 +37,7 @@ fn next_state(s: State) -> Option<State> {
     }
 }
 
-pub fn expand_asm(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_asm(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
                -> base::MacResult {
     let p = parse::new_parser_from_tts(cx.parse_sess(),
                                        cx.cfg(),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -324,11 +324,11 @@ impl ExtCtxt {
         loop {
             match e.node {
                 ast::ExprMac(..) => {
-                    let expander = expand::MacroExpander {
+                    let mut expander = expand::MacroExpander {
                         extsbox: @mut syntax_expander_table(),
                         cx: self,
                     };
-                    e = expand::expand_expr(e, &expander);
+                    e = expand::expand_expr(e, &mut expander);
                 }
                 _ => return e
             }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -45,7 +45,7 @@ pub struct SyntaxExpanderTT {
 
 pub trait SyntaxExpanderTTTrait {
     fn expand(&self,
-              ecx: &ExtCtxt,
+              ecx: &mut ExtCtxt,
               span: Span,
               token_tree: &[ast::token_tree],
               context: ast::SyntaxContext)
@@ -53,7 +53,7 @@ pub trait SyntaxExpanderTTTrait {
 }
 
 pub type SyntaxExpanderTTFunNoCtxt =
-    fn(ecx: &ExtCtxt, span: codemap::Span, token_tree: &[ast::token_tree])
+    fn(ecx: &mut ExtCtxt, span: codemap::Span, token_tree: &[ast::token_tree])
        -> MacResult;
 
 enum SyntaxExpanderTTExpander {
@@ -62,7 +62,7 @@ enum SyntaxExpanderTTExpander {
 
 impl SyntaxExpanderTTTrait for SyntaxExpanderTT {
     fn expand(&self,
-              ecx: &ExtCtxt,
+              ecx: &mut ExtCtxt,
               span: Span,
               token_tree: &[ast::token_tree],
               _: ast::SyntaxContext)
@@ -87,7 +87,7 @@ pub struct SyntaxExpanderTTItem {
 
 pub trait SyntaxExpanderTTItemTrait {
     fn expand(&self,
-              cx: &ExtCtxt,
+              cx: &mut ExtCtxt,
               sp: Span,
               ident: ast::Ident,
               token_tree: ~[ast::token_tree],
@@ -97,7 +97,7 @@ pub trait SyntaxExpanderTTItemTrait {
 
 impl SyntaxExpanderTTItemTrait for SyntaxExpanderTTItem {
     fn expand(&self,
-              cx: &ExtCtxt,
+              cx: &mut ExtCtxt,
               sp: Span,
               ident: ast::Ident,
               token_tree: ~[ast::token_tree],
@@ -115,11 +115,11 @@ impl SyntaxExpanderTTItemTrait for SyntaxExpanderTTItem {
 }
 
 pub type SyntaxExpanderTTItemFun =
-    fn(&ExtCtxt, Span, ast::Ident, ~[ast::token_tree], ast::SyntaxContext)
+    fn(&mut ExtCtxt, Span, ast::Ident, ~[ast::token_tree], ast::SyntaxContext)
        -> MacResult;
 
 pub type SyntaxExpanderTTItemFunNoCtxt =
-    fn(&ExtCtxt, Span, ast::Ident, ~[ast::token_tree]) -> MacResult;
+    fn(&mut ExtCtxt, Span, ast::Ident, ~[ast::token_tree]) -> MacResult;
 
 pub trait AnyMacro {
     fn make_expr(&self) -> @ast::Expr;
@@ -320,7 +320,7 @@ impl ExtCtxt {
         }
     }
 
-    pub fn expand_expr(&self, mut e: @ast::Expr) -> @ast::Expr {
+    pub fn expand_expr(&mut self, mut e: @ast::Expr) -> @ast::Expr {
         loop {
             match e.node {
                 ast::ExprMac(..) => {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -324,12 +324,11 @@ impl ExtCtxt {
         loop {
             match e.node {
                 ast::ExprMac(..) => {
-                    let extsbox = @mut syntax_expander_table();
                     let expander = expand::MacroExpander {
-                        extsbox: extsbox,
+                        extsbox: @mut syntax_expander_table(),
                         cx: self,
                     };
-                    e = expand::expand_expr(extsbox, self, e, &expander);
+                    e = expand::expand_expr(e, &expander);
                 }
                 _ => return e
             }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -35,7 +35,7 @@ pub struct MacroDef {
     ext: SyntaxExtension
 }
 
-pub type ItemDecorator = extern "Rust" fn(@ExtCtxt,
+pub type ItemDecorator = extern "Rust" fn(&ExtCtxt,
                                           Span,
                                           @ast::MetaItem,
                                           ~[@ast::item])
@@ -48,7 +48,7 @@ pub struct SyntaxExpanderTT {
 
 pub trait SyntaxExpanderTTTrait {
     fn expand(&self,
-              ecx: @ExtCtxt,
+              ecx: &ExtCtxt,
               span: Span,
               token_tree: &[ast::token_tree],
               context: ast::SyntaxContext)
@@ -56,7 +56,7 @@ pub trait SyntaxExpanderTTTrait {
 }
 
 pub type SyntaxExpanderTTFunNoCtxt =
-    extern "Rust" fn(ecx: @ExtCtxt,
+    extern "Rust" fn(ecx: &ExtCtxt,
                      span: codemap::Span,
                      token_tree: &[ast::token_tree])
                      -> MacResult;
@@ -67,7 +67,7 @@ enum SyntaxExpanderTTExpander {
 
 impl SyntaxExpanderTTTrait for SyntaxExpanderTT {
     fn expand(&self,
-              ecx: @ExtCtxt,
+              ecx: &ExtCtxt,
               span: Span,
               token_tree: &[ast::token_tree],
               _: ast::SyntaxContext)
@@ -92,7 +92,7 @@ pub struct SyntaxExpanderTTItem {
 
 pub trait SyntaxExpanderTTItemTrait {
     fn expand(&self,
-              cx: @ExtCtxt,
+              cx: &ExtCtxt,
               sp: Span,
               ident: ast::Ident,
               token_tree: ~[ast::token_tree],
@@ -102,7 +102,7 @@ pub trait SyntaxExpanderTTItemTrait {
 
 impl SyntaxExpanderTTItemTrait for SyntaxExpanderTTItem {
     fn expand(&self,
-              cx: @ExtCtxt,
+              cx: &ExtCtxt,
               sp: Span,
               ident: ast::Ident,
               token_tree: ~[ast::token_tree],
@@ -119,7 +119,7 @@ impl SyntaxExpanderTTItemTrait for SyntaxExpanderTTItem {
     }
 }
 
-pub type SyntaxExpanderTTItemFun = extern "Rust" fn(@ExtCtxt,
+pub type SyntaxExpanderTTItemFun = extern "Rust" fn(&ExtCtxt,
                                                     Span,
                                                     ast::Ident,
                                                     ~[ast::token_tree],
@@ -127,7 +127,7 @@ pub type SyntaxExpanderTTItemFun = extern "Rust" fn(@ExtCtxt,
                                                     -> MacResult;
 
 pub type SyntaxExpanderTTItemFunNoCtxt =
-    extern "Rust" fn(@ExtCtxt, Span, ast::Ident, ~[ast::token_tree])
+    extern "Rust" fn(&ExtCtxt, Span, ast::Ident, ~[ast::token_tree])
                      -> MacResult;
 
 pub trait AnyMacro {
@@ -319,8 +319,8 @@ pub struct ExtCtxt {
 
 impl ExtCtxt {
     pub fn new(parse_sess: @mut parse::ParseSess, cfg: ast::CrateConfig)
-               -> @ExtCtxt {
-        @ExtCtxt {
+               -> ExtCtxt {
+        ExtCtxt {
             parse_sess: parse_sess,
             cfg: cfg,
             backtrace: @mut None,
@@ -329,7 +329,7 @@ impl ExtCtxt {
         }
     }
 
-    pub fn expand_expr(@self, mut e: @ast::Expr) -> @ast::Expr {
+    pub fn expand_expr(&self, mut e: @ast::Expr) -> @ast::Expr {
         loop {
             match e.node {
                 ast::ExprMac(..) => {
@@ -417,7 +417,7 @@ impl ExtCtxt {
     }
 }
 
-pub fn expr_to_str(cx: @ExtCtxt, expr: @ast::Expr, err_msg: &str) -> (@str, ast::StrStyle) {
+pub fn expr_to_str(cx: &ExtCtxt, expr: @ast::Expr, err_msg: &str) -> (@str, ast::StrStyle) {
     match expr.node {
       ast::ExprLit(l) => match l.node {
         ast::lit_str(s, style) => (s, style),
@@ -427,14 +427,14 @@ pub fn expr_to_str(cx: @ExtCtxt, expr: @ast::Expr, err_msg: &str) -> (@str, ast:
     }
 }
 
-pub fn check_zero_tts(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree],
+pub fn check_zero_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree],
                       name: &str) {
     if tts.len() != 0 {
         cx.span_fatal(sp, format!("{} takes no arguments", name));
     }
 }
 
-pub fn get_single_str_from_tts(cx: @ExtCtxt,
+pub fn get_single_str_from_tts(cx: &ExtCtxt,
                                sp: Span,
                                tts: &[ast::token_tree],
                                name: &str)
@@ -450,7 +450,7 @@ pub fn get_single_str_from_tts(cx: @ExtCtxt,
     }
 }
 
-pub fn get_exprs_from_tts(cx: @ExtCtxt,
+pub fn get_exprs_from_tts(cx: &ExtCtxt,
                           sp: Span,
                           tts: &[ast::token_tree]) -> ~[@ast::Expr] {
     let p = parse::new_parser_from_tts(cx.parse_sess(),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -35,11 +35,8 @@ pub struct MacroDef {
     ext: SyntaxExtension
 }
 
-pub type ItemDecorator = extern "Rust" fn(&ExtCtxt,
-                                          Span,
-                                          @ast::MetaItem,
-                                          ~[@ast::item])
-                                          -> ~[@ast::item];
+pub type ItemDecorator =
+    fn(&ExtCtxt, Span, @ast::MetaItem, ~[@ast::item]) -> ~[@ast::item];
 
 pub struct SyntaxExpanderTT {
     expander: SyntaxExpanderTTExpander,
@@ -56,10 +53,8 @@ pub trait SyntaxExpanderTTTrait {
 }
 
 pub type SyntaxExpanderTTFunNoCtxt =
-    extern "Rust" fn(ecx: &ExtCtxt,
-                     span: codemap::Span,
-                     token_tree: &[ast::token_tree])
-                     -> MacResult;
+    fn(ecx: &ExtCtxt, span: codemap::Span, token_tree: &[ast::token_tree])
+       -> MacResult;
 
 enum SyntaxExpanderTTExpander {
     SyntaxExpanderTTExpanderWithoutContext(SyntaxExpanderTTFunNoCtxt),
@@ -119,16 +114,12 @@ impl SyntaxExpanderTTItemTrait for SyntaxExpanderTTItem {
     }
 }
 
-pub type SyntaxExpanderTTItemFun = extern "Rust" fn(&ExtCtxt,
-                                                    Span,
-                                                    ast::Ident,
-                                                    ~[ast::token_tree],
-                                                    ast::SyntaxContext)
-                                                    -> MacResult;
+pub type SyntaxExpanderTTItemFun =
+    fn(&ExtCtxt, Span, ast::Ident, ~[ast::token_tree], ast::SyntaxContext)
+       -> MacResult;
 
 pub type SyntaxExpanderTTItemFunNoCtxt =
-    extern "Rust" fn(&ExtCtxt, Span, ast::Ident, ~[ast::token_tree])
-                     -> MacResult;
+    fn(&ExtCtxt, Span, ast::Ident, ~[ast::token_tree]) -> MacResult;
 
 pub trait AnyMacro {
     fn make_expr(&self) -> @ast::Expr;

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -297,15 +297,15 @@ pub fn syntax_expander_table() -> SyntaxEnv {
 pub struct ExtCtxt {
     parse_sess: @mut parse::ParseSess,
     cfg: ast::CrateConfig,
-    backtrace: @mut Option<@ExpnInfo>,
+    backtrace: Option<@ExpnInfo>,
 
     // These two @mut's should really not be here,
     // but the self types for CtxtRepr are all wrong
     // and there are bugs in the code for object
     // types that make this hard to get right at the
     // moment. - nmatsakis
-    mod_path: @mut ~[ast::Ident],
-    trace_mac: @mut bool
+    mod_path: ~[ast::Ident],
+    trace_mac: bool
 }
 
 impl ExtCtxt {
@@ -314,9 +314,9 @@ impl ExtCtxt {
         ExtCtxt {
             parse_sess: parse_sess,
             cfg: cfg,
-            backtrace: @mut None,
-            mod_path: @mut ~[],
-            trace_mac: @mut false
+            backtrace: None,
+            mod_path: ~[],
+            trace_mac: false
         }
     }
 
@@ -339,32 +339,32 @@ impl ExtCtxt {
     pub fn parse_sess(&self) -> @mut parse::ParseSess { self.parse_sess }
     pub fn cfg(&self) -> ast::CrateConfig { self.cfg.clone() }
     pub fn call_site(&self) -> Span {
-        match *self.backtrace {
+        match self.backtrace {
             Some(@ExpnInfo {call_site: cs, ..}) => cs,
             None => self.bug("missing top span")
         }
     }
     pub fn print_backtrace(&self) { }
-    pub fn backtrace(&self) -> Option<@ExpnInfo> { *self.backtrace }
-    pub fn mod_push(&self, i: ast::Ident) { self.mod_path.push(i); }
-    pub fn mod_pop(&self) { self.mod_path.pop(); }
-    pub fn mod_path(&self) -> ~[ast::Ident] { (*self.mod_path).clone() }
-    pub fn bt_push(&self, ei: codemap::ExpnInfo) {
+    pub fn backtrace(&self) -> Option<@ExpnInfo> { self.backtrace }
+    pub fn mod_push(&mut self, i: ast::Ident) { self.mod_path.push(i); }
+    pub fn mod_pop(&mut self) { self.mod_path.pop(); }
+    pub fn mod_path(&self) -> ~[ast::Ident] { self.mod_path.clone() }
+    pub fn bt_push(&mut self, ei: codemap::ExpnInfo) {
         match ei {
             ExpnInfo {call_site: cs, callee: ref callee} => {
-                *self.backtrace =
+                self.backtrace =
                     Some(@ExpnInfo {
                         call_site: Span {lo: cs.lo, hi: cs.hi,
-                                         expn_info: *self.backtrace},
+                                         expn_info: self.backtrace},
                         callee: *callee});
             }
         }
     }
-    pub fn bt_pop(&self) {
-        match *self.backtrace {
+    pub fn bt_pop(&mut self) {
+        match self.backtrace {
             Some(@ExpnInfo {
                 call_site: Span {expn_info: prev, ..}, ..}) => {
-                *self.backtrace = prev
+                self.backtrace = prev
             }
             _ => self.bug("tried to pop without a push")
         }
@@ -394,10 +394,10 @@ impl ExtCtxt {
         self.parse_sess.span_diagnostic.handler().bug(msg);
     }
     pub fn trace_macros(&self) -> bool {
-        *self.trace_mac
+        self.trace_mac
     }
-    pub fn set_trace_macros(&self, x: bool) {
-        *self.trace_mac = x
+    pub fn set_trace_macros(&mut self, x: bool) {
+        self.trace_mac = x
     }
     pub fn str_of(&self, id: ast::Ident) -> @str {
         ident_to_str(&id)

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -908,7 +908,7 @@ struct Duplicator<'a> {
 }
 
 impl<'a> ast_fold for Duplicator<'a> {
-    fn new_id(&self, _: NodeId) -> NodeId {
+    fn new_id(&mut self, _: NodeId) -> NodeId {
         ast::DUMMY_NODE_ID
     }
 }
@@ -925,7 +925,7 @@ pub trait Duplicate {
 
 impl Duplicate for @ast::Expr {
     fn duplicate(&self, cx: &ExtCtxt) -> @ast::Expr {
-        let folder = Duplicator {
+        let mut folder = Duplicator {
             cx: cx,
         };
         folder.fold_expr(*self)

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -236,7 +236,7 @@ pub trait AstBuilder {
                      vis: ast::visibility, path: ~[ast::Ident]) -> ast::view_item;
 }
 
-impl<'a> AstBuilder for &'a ExtCtxt {
+impl AstBuilder for ExtCtxt {
     fn path(&self, span: Span, strs: ~[ast::Ident]) -> ast::Path {
         self.path_all(span, false, strs, opt_vec::Empty, ~[])
     }
@@ -686,12 +686,12 @@ impl<'a> AstBuilder for &'a ExtCtxt {
     }
     fn lambda0(&self, _span: Span, blk: P<ast::Block>) -> @ast::Expr {
         let blk_e = self.expr(blk.span, ast::ExprBlock(blk));
-        quote_expr!(*self, || $blk_e )
+        quote_expr!(self, || $blk_e )
     }
 
     fn lambda1(&self, _span: Span, blk: P<ast::Block>, ident: ast::Ident) -> @ast::Expr {
         let blk_e = self.expr(blk.span, ast::ExprBlock(blk));
-        quote_expr!(*self, |$ident| $blk_e )
+        quote_expr!(self, |$ident| $blk_e )
     }
 
     fn lambda_expr(&self, span: Span, ids: ~[ast::Ident], expr: @ast::Expr) -> @ast::Expr {

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -18,7 +18,7 @@ use ext::build::AstBuilder;
 
 use std::char;
 
-pub fn expand_syntax_ext(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
+pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
     // Gather all argument expressions
     let exprs = get_exprs_from_tts(cx, sp, tts);
     let mut bytes = ~[];

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -18,7 +18,7 @@ use ext::build::AstBuilder;
 
 use std::char;
 
-pub fn expand_syntax_ext(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
+pub fn expand_syntax_ext(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
     // Gather all argument expressions
     let exprs = get_exprs_from_tts(cx, sp, tts);
     let mut bytes = ~[];

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -25,7 +25,7 @@ use parse;
 use parse::token;
 use parse::attr::parser_attr;
 
-pub fn expand_cfg(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
+pub fn expand_cfg(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
     let p = parse::new_parser_from_tts(cx.parse_sess(), cx.cfg(), tts.to_owned());
 
     let mut cfgs = ~[];

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -25,7 +25,7 @@ use parse;
 use parse::token;
 use parse::attr::parser_attr;
 
-pub fn expand_cfg(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
+pub fn expand_cfg(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree]) -> base::MacResult {
     let p = parse::new_parser_from_tts(cx.parse_sess(), cx.cfg(), tts.to_owned());
 
     let mut cfgs = ~[];

--- a/src/libsyntax/ext/concat.rs
+++ b/src/libsyntax/ext/concat.rs
@@ -15,7 +15,7 @@ use codemap;
 use ext::base;
 use ext::build::AstBuilder;
 
-pub fn expand_syntax_ext(cx: &base::ExtCtxt,
+pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
                          sp: codemap::Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let es = base::get_exprs_from_tts(cx, sp, tts);

--- a/src/libsyntax/ext/concat.rs
+++ b/src/libsyntax/ext/concat.rs
@@ -15,7 +15,7 @@ use codemap;
 use ext::base;
 use ext::build::AstBuilder;
 
-pub fn expand_syntax_ext(cx: @base::ExtCtxt,
+pub fn expand_syntax_ext(cx: &base::ExtCtxt,
                          sp: codemap::Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let es = base::get_exprs_from_tts(cx, sp, tts);

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -16,7 +16,7 @@ use opt_vec;
 use parse::token;
 use parse::token::{str_to_ident};
 
-pub fn expand_syntax_ext(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let mut res_str = ~"";
     for (i, e) in tts.iter().enumerate() {

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -16,7 +16,7 @@ use opt_vec;
 use parse::token;
 use parse::token::{str_to_ident};
 
-pub fn expand_syntax_ext(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_syntax_ext(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let mut res_str = ~"";
     for (i, e) in tts.iter().enumerate() {

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -14,7 +14,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_clone(cx: @ExtCtxt,
+pub fn expand_deriving_clone(cx: &ExtCtxt,
                              span: Span,
                              mitem: @MetaItem,
                              in_items: ~[@item])
@@ -42,7 +42,7 @@ pub fn expand_deriving_clone(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-pub fn expand_deriving_deep_clone(cx: @ExtCtxt,
+pub fn expand_deriving_deep_clone(cx: &ExtCtxt,
                                   span: Span,
                                   mitem: @MetaItem,
                                   in_items: ~[@item])
@@ -74,7 +74,7 @@ pub fn expand_deriving_deep_clone(cx: @ExtCtxt,
 
 fn cs_clone(
     name: &str,
-    cx: @ExtCtxt, span: Span,
+    cx: &ExtCtxt, span: Span,
     substr: &Substructure) -> @Expr {
     let clone_ident = substr.method_ident;
     let ctor_ident;

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -14,17 +14,17 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_eq(cx: @ExtCtxt,
+pub fn expand_deriving_eq(cx: &ExtCtxt,
                           span: Span,
                           mitem: @MetaItem,
                           in_items: ~[@item]) -> ~[@item] {
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
-    fn cs_eq(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+    fn cs_eq(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
         cs_and(|cx, span, _, _| cx.expr_bool(span, false),
                                  cx, span, substr)
     }
-    fn cs_ne(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+    fn cs_ne(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
         cs_or(|cx, span, _, _| cx.expr_bool(span, true),
               cx, span, substr)
     }

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -15,7 +15,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_ord(cx: @ExtCtxt,
+pub fn expand_deriving_ord(cx: &ExtCtxt,
                            span: Span,
                            mitem: @MetaItem,
                            in_items: ~[@item]) -> ~[@item] {
@@ -51,7 +51,7 @@ pub fn expand_deriving_ord(cx: @ExtCtxt,
 }
 
 /// Strict inequality.
-fn cs_op(less: bool, equal: bool, cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn cs_op(less: bool, equal: bool, cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let op = if less {ast::BiLt} else {ast::BiGt};
     cs_fold(
         false, // need foldr,

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -14,11 +14,11 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_totaleq(cx: @ExtCtxt,
+pub fn expand_deriving_totaleq(cx: &ExtCtxt,
                                span: Span,
                                mitem: @MetaItem,
                                in_items: ~[@item]) -> ~[@item] {
-    fn cs_equals(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+    fn cs_equals(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
         cs_and(|cx, span, _, _| cx.expr_bool(span, false),
                cx, span, substr)
     }

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -16,7 +16,7 @@ use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 use std::cmp::{Ordering, Equal, Less, Greater};
 
-pub fn expand_deriving_totalord(cx: @ExtCtxt,
+pub fn expand_deriving_totalord(cx: &ExtCtxt,
                                 span: Span,
                                 mitem: @MetaItem,
                                 in_items: ~[@item]) -> ~[@item] {
@@ -44,7 +44,7 @@ pub fn expand_deriving_totalord(cx: @ExtCtxt,
 }
 
 
-pub fn ordering_const(cx: @ExtCtxt, span: Span, cnst: Ordering) -> ast::Path {
+pub fn ordering_const(cx: &ExtCtxt, span: Span, cnst: Ordering) -> ast::Path {
     let cnst = match cnst {
         Less => "Less",
         Equal => "Equal",
@@ -56,7 +56,7 @@ pub fn ordering_const(cx: @ExtCtxt, span: Span, cnst: Ordering) -> ast::Path {
                      cx.ident_of(cnst)])
 }
 
-pub fn cs_cmp(cx: @ExtCtxt, span: Span,
+pub fn cs_cmp(cx: &ExtCtxt, span: Span,
               substr: &Substructure) -> @Expr {
     let test_id = cx.ident_of("__test");
     let equals_path = ordering_const(cx, span, Equal);

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -19,7 +19,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_decodable(cx: @ExtCtxt,
+pub fn expand_deriving_decodable(cx: &ExtCtxt,
                                  span: Span,
                                  mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
@@ -51,7 +51,7 @@ pub fn expand_deriving_decodable(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn decodable_substructure(cx: @ExtCtxt, span: Span,
+fn decodable_substructure(cx: &ExtCtxt, span: Span,
                           substr: &Substructure) -> @Expr {
     let decoder = substr.nonself_args[0];
     let recurse = ~[cx.ident_of("extra"),
@@ -132,7 +132,7 @@ fn decodable_substructure(cx: @ExtCtxt, span: Span,
 /// Create a decoder for a single enum variant/struct:
 /// - `outer_pat_ident` is the name of this enum variant/struct
 /// - `getarg` should retrieve the `uint`-th field with name `@str`.
-fn decode_static_fields(cx: @ExtCtxt,
+fn decode_static_fields(cx: &ExtCtxt,
                         outer_span: Span,
                         outer_pat_ident: Ident,
                         fields: &StaticFields,

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -14,7 +14,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_default(cx: @ExtCtxt,
+pub fn expand_deriving_default(cx: &ExtCtxt,
                             span: Span,
                             mitem: @MetaItem,
                             in_items: ~[@item])
@@ -41,7 +41,7 @@ pub fn expand_deriving_default(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn default_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn default_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let default_ident = ~[
         cx.ident_of("std"),
         cx.ident_of("default"),

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -81,7 +81,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_encodable(cx: @ExtCtxt,
+pub fn expand_deriving_encodable(cx: &ExtCtxt,
                                  span: Span,
                                  mitem: @MetaItem,
                                  in_items: ~[@item]) -> ~[@item] {
@@ -113,7 +113,7 @@ pub fn expand_deriving_encodable(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn encodable_substructure(cx: @ExtCtxt, span: Span,
+fn encodable_substructure(cx: &ExtCtxt, span: Span,
                           substr: &Substructure) -> @Expr {
     let encoder = substr.nonself_args[0];
     // throw an underscore in front to suppress unused variable warnings

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -190,7 +190,7 @@ mod ty;
 
 pub struct TraitDef<'a> {
     /// The extension context
-    cx: @ExtCtxt,
+    cx: &'a ExtCtxt,
     /// The span for the current #[deriving(Foo)] header.
     span: Span,
 
@@ -300,7 +300,7 @@ Combine the values of all the fields together. The last argument is
 all the fields of all the structures, see above for details.
 */
 pub type CombineSubstructureFunc<'a> =
-    'a |@ExtCtxt, Span, &Substructure| -> @Expr;
+    'a |&ExtCtxt, Span, &Substructure| -> @Expr;
 
 /**
 Deal with non-matching enum variants, the arguments are a list
@@ -308,7 +308,7 @@ representing each variant: (variant index, ast::variant instance,
 [variant fields]), and a list of the nonself args of the type
 */
 pub type EnumNonMatchFunc<'a> =
-    'a |@ExtCtxt,
+    'a |&ExtCtxt,
            Span,
            &[(uint, P<ast::variant>, ~[(Span, Option<Ident>, @Expr)])],
            &[@Expr]|
@@ -1076,10 +1076,10 @@ Fold the fields. `use_foldl` controls whether this is done
 left-to-right (`true`) or right-to-left (`false`).
 */
 pub fn cs_fold(use_foldl: bool,
-               f: |@ExtCtxt, Span, @Expr, @Expr, &[@Expr]| -> @Expr,
+               f: |&ExtCtxt, Span, @Expr, @Expr, &[@Expr]| -> @Expr,
                base: @Expr,
                enum_nonmatch_f: EnumNonMatchFunc,
-               cx: @ExtCtxt,
+               cx: &ExtCtxt,
                trait_span: Span,
                substructure: &Substructure)
                -> @Expr {
@@ -1115,9 +1115,9 @@ f(cx, span, ~[self_1.method(__arg_1_1, __arg_2_1),
 ~~~
 */
 #[inline]
-pub fn cs_same_method(f: |@ExtCtxt, Span, ~[@Expr]| -> @Expr,
+pub fn cs_same_method(f: |&ExtCtxt, Span, ~[@Expr]| -> @Expr,
                       enum_nonmatch_f: EnumNonMatchFunc,
-                      cx: @ExtCtxt,
+                      cx: &ExtCtxt,
                       trait_span: Span,
                       substructure: &Substructure)
                       -> @Expr {
@@ -1149,10 +1149,10 @@ fields. `use_foldl` controls whether this is done left-to-right
 */
 #[inline]
 pub fn cs_same_method_fold(use_foldl: bool,
-                           f: |@ExtCtxt, Span, @Expr, @Expr| -> @Expr,
+                           f: |&ExtCtxt, Span, @Expr, @Expr| -> @Expr,
                            base: @Expr,
                            enum_nonmatch_f: EnumNonMatchFunc,
-                           cx: @ExtCtxt,
+                           cx: &ExtCtxt,
                            trait_span: Span,
                            substructure: &Substructure)
                            -> @Expr {
@@ -1179,7 +1179,7 @@ on all the fields.
 #[inline]
 pub fn cs_binop(binop: ast::BinOp, base: @Expr,
                 enum_nonmatch_f: EnumNonMatchFunc,
-                cx: @ExtCtxt, trait_span: Span,
+                cx: &ExtCtxt, trait_span: Span,
                 substructure: &Substructure) -> @Expr {
     cs_same_method_fold(
         true, // foldl is good enough
@@ -1197,7 +1197,7 @@ pub fn cs_binop(binop: ast::BinOp, base: @Expr,
 /// cs_binop with binop == or
 #[inline]
 pub fn cs_or(enum_nonmatch_f: EnumNonMatchFunc,
-             cx: @ExtCtxt, span: Span,
+             cx: &ExtCtxt, span: Span,
              substructure: &Substructure) -> @Expr {
     cs_binop(ast::BiOr, cx.expr_bool(span, false),
              enum_nonmatch_f,
@@ -1207,7 +1207,7 @@ pub fn cs_or(enum_nonmatch_f: EnumNonMatchFunc,
 /// cs_binop with binop == and
 #[inline]
 pub fn cs_and(enum_nonmatch_f: EnumNonMatchFunc,
-              cx: @ExtCtxt, span: Span,
+              cx: &ExtCtxt, span: Span,
               substructure: &Substructure) -> @Expr {
     cs_binop(ast::BiAnd, cx.expr_bool(span, true),
              enum_nonmatch_f,

--- a/src/libsyntax/ext/deriving/iter_bytes.rs
+++ b/src/libsyntax/ext/deriving/iter_bytes.rs
@@ -15,7 +15,7 @@ use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
 
-pub fn expand_deriving_iter_bytes(cx: @ExtCtxt,
+pub fn expand_deriving_iter_bytes(cx: &ExtCtxt,
                                   span: Span,
                                   mitem: @MetaItem,
                                   in_items: ~[@item]) -> ~[@item] {
@@ -45,7 +45,7 @@ pub fn expand_deriving_iter_bytes(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn iter_bytes_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn iter_bytes_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let (lsb0, f)= match substr.nonself_args {
         [l, f] => (l, f),
         _ => cx.span_bug(span, "Incorrect number of arguments in `deriving(IterBytes)`")

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -46,20 +46,20 @@ pub mod totalord;
 
 pub mod generic;
 
-pub type ExpandDerivingStructDefFn<'a> = 'a |@ExtCtxt,
+pub type ExpandDerivingStructDefFn<'a> = 'a |&ExtCtxt,
                                                    Span,
                                                    x: &struct_def,
                                                    Ident,
                                                    y: &Generics|
                                                    -> @item;
-pub type ExpandDerivingEnumDefFn<'a> = 'a |@ExtCtxt,
+pub type ExpandDerivingEnumDefFn<'a> = 'a |&ExtCtxt,
                                                  Span,
                                                  x: &enum_def,
                                                  Ident,
                                                  y: &Generics|
                                                  -> @item;
 
-pub fn expand_meta_deriving(cx: @ExtCtxt,
+pub fn expand_meta_deriving(cx: &ExtCtxt,
                             _span: Span,
                             mitem: @MetaItem,
                             in_items: ~[@item])

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -15,7 +15,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_from_primitive(cx: @ExtCtxt,
+pub fn expand_deriving_from_primitive(cx: &ExtCtxt,
                                       span: Span,
                                       mitem: @MetaItem,
                                       in_items: ~[@item]) -> ~[@item] {
@@ -64,7 +64,7 @@ pub fn expand_deriving_from_primitive(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn cs_from(name: &str, cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn cs_from(name: &str, cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let n = match substr.nonself_args {
         [n] => n,
         _ => cx.span_bug(span, "Incorrect number of arguments in `deriving(FromPrimitive)`")

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -16,7 +16,7 @@ use ext::build::{AstBuilder};
 use ext::deriving::generic::*;
 use opt_vec;
 
-pub fn expand_deriving_rand(cx: @ExtCtxt,
+pub fn expand_deriving_rand(cx: &ExtCtxt,
                             span: Span,
                             mitem: @MetaItem,
                             in_items: ~[@item])
@@ -50,7 +50,7 @@ pub fn expand_deriving_rand(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn rand_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn rand_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let rng = match substr.nonself_args {
         [rng] => ~[ rng ],
         _ => cx.bug("Incorrect number of arguments to `rand` in `deriving(Rand)`")
@@ -130,7 +130,7 @@ fn rand_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
         _ => cx.bug("Non-static method in `deriving(Rand)`")
     };
 
-    fn rand_thing(cx: @ExtCtxt,
+    fn rand_thing(cx: &ExtCtxt,
                   span: Span,
                   ctor_ident: Ident,
                   summary: &StaticFields,

--- a/src/libsyntax/ext/deriving/to_str.rs
+++ b/src/libsyntax/ext/deriving/to_str.rs
@@ -15,7 +15,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_to_str(cx: @ExtCtxt,
+pub fn expand_deriving_to_str(cx: &ExtCtxt,
                               span: Span,
                               mitem: @MetaItem,
                               in_items: ~[@item])
@@ -47,7 +47,7 @@ pub fn expand_deriving_to_str(cx: @ExtCtxt,
 // doesn't invoke the to_str() method on each field. Hence we mirror
 // the logic of the repr_to_str() method, but with tweaks to call to_str()
 // on sub-fields.
-fn to_str_substructure(cx: @ExtCtxt, span: Span,
+fn to_str_substructure(cx: &ExtCtxt, span: Span,
                        substr: &Substructure) -> @Expr {
     let to_str = cx.ident_of("to_str");
 

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -58,7 +58,7 @@ impl<'a> Path<'a> {
     }
 
     pub fn to_ty(&self,
-                 cx: @ExtCtxt,
+                 cx: &ExtCtxt,
                  span: Span,
                  self_ty: Ident,
                  self_generics: &Generics)
@@ -66,7 +66,7 @@ impl<'a> Path<'a> {
         cx.ty_path(self.to_path(cx, span, self_ty, self_generics), None)
     }
     pub fn to_path(&self,
-                   cx: @ExtCtxt,
+                   cx: &ExtCtxt,
                    span: Span,
                    self_ty: Ident,
                    self_generics: &Generics)
@@ -110,14 +110,14 @@ pub fn nil_ty() -> Ty<'static> {
     Tuple(~[])
 }
 
-fn mk_lifetime(cx: @ExtCtxt, span: Span, lt: &Option<&str>) -> Option<ast::Lifetime> {
+fn mk_lifetime(cx: &ExtCtxt, span: Span, lt: &Option<&str>) -> Option<ast::Lifetime> {
     match *lt {
         Some(ref s) => Some(cx.lifetime(span, cx.ident_of(*s))),
         None => None
     }
 }
 
-fn mk_lifetimes(cx: @ExtCtxt, span: Span, lt: &Option<&str>) -> OptVec<ast::Lifetime> {
+fn mk_lifetimes(cx: &ExtCtxt, span: Span, lt: &Option<&str>) -> OptVec<ast::Lifetime> {
     match *lt {
         Some(ref s) => opt_vec::with(cx.lifetime(span, cx.ident_of(*s))),
         None => opt_vec::Empty
@@ -126,7 +126,7 @@ fn mk_lifetimes(cx: @ExtCtxt, span: Span, lt: &Option<&str>) -> OptVec<ast::Life
 
 impl<'a> Ty<'a> {
     pub fn to_ty(&self,
-                 cx: @ExtCtxt,
+                 cx: &ExtCtxt,
                  span: Span,
                  self_ty: Ident,
                  self_generics: &Generics)
@@ -164,7 +164,7 @@ impl<'a> Ty<'a> {
     }
 
     pub fn to_path(&self,
-                   cx: @ExtCtxt,
+                   cx: &ExtCtxt,
                    span: Span,
                    self_ty: Ident,
                    self_generics: &Generics)
@@ -189,7 +189,7 @@ impl<'a> Ty<'a> {
 }
 
 
-fn mk_ty_param(cx: @ExtCtxt, span: Span, name: &str, bounds: &[Path],
+fn mk_ty_param(cx: &ExtCtxt, span: Span, name: &str, bounds: &[Path],
                self_ident: Ident, self_generics: &Generics) -> ast::TyParam {
     let bounds = opt_vec::from(
         bounds.map(|b| {
@@ -219,7 +219,7 @@ impl<'a> LifetimeBounds<'a> {
         }
     }
     pub fn to_generics(&self,
-                       cx: @ExtCtxt,
+                       cx: &ExtCtxt,
                        span: Span,
                        self_ty: Ident,
                        self_generics: &Generics)
@@ -239,7 +239,7 @@ impl<'a> LifetimeBounds<'a> {
 }
 
 
-pub fn get_explicit_self(cx: @ExtCtxt, span: Span, self_ptr: &Option<PtrTy>)
+pub fn get_explicit_self(cx: &ExtCtxt, span: Span, self_ptr: &Option<PtrTy>)
     -> (@Expr, ast::explicit_self) {
     let self_path = cx.expr_self(span);
     match *self_ptr {

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -14,7 +14,7 @@ use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 
-pub fn expand_deriving_zero(cx: @ExtCtxt,
+pub fn expand_deriving_zero(cx: &ExtCtxt,
                             span: Span,
                             mitem: @MetaItem,
                             in_items: ~[@item])
@@ -57,7 +57,7 @@ pub fn expand_deriving_zero(cx: @ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn zero_substructure(cx: @ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn zero_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
     let zero_ident = ~[
         cx.ident_of("std"),
         cx.ident_of("num"),

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -22,7 +22,7 @@ use ext::build::AstBuilder;
 
 use std::os;
 
-pub fn expand_option_env(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_option_env(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let var = get_single_str_from_tts(cx, sp, tts, "option_env!");
 
@@ -33,7 +33,7 @@ pub fn expand_option_env(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     MRExpr(e)
 }
 
-pub fn expand_env(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_env(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let exprs = get_exprs_from_tts(cx, sp, tts);
 

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -22,7 +22,7 @@ use ext::build::AstBuilder;
 
 use std::os;
 
-pub fn expand_option_env(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_option_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let var = get_single_str_from_tts(cx, sp, tts, "option_env!");
 
@@ -33,7 +33,7 @@ pub fn expand_option_env(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     MRExpr(e)
 }
 
-pub fn expand_env(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let exprs = get_exprs_from_tts(cx, sp, tts);
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -32,7 +32,7 @@ use util::small_vector::SmallVector;
 use std::vec;
 
 pub fn expand_expr(extsbox: @mut SyntaxEnv,
-                   cx: @ExtCtxt,
+                   cx: &ExtCtxt,
                    e: @ast::Expr,
                    fld: &MacroExpander)
                    -> @ast::Expr {
@@ -214,7 +214,7 @@ pub fn expand_expr(extsbox: @mut SyntaxEnv,
 // NB: there is some redundancy between this and expand_item, below, and
 // they might benefit from some amount of semantic and language-UI merger.
 pub fn expand_mod_items(extsbox: @mut SyntaxEnv,
-                        cx: @ExtCtxt,
+                        cx: &ExtCtxt,
                         module_: &ast::_mod,
                         fld: &MacroExpander)
                         -> ast::_mod {
@@ -271,7 +271,7 @@ static special_block_name : &'static str = " block";
 
 // When we enter a module, record it, for the sake of `module!`
 pub fn expand_item(extsbox: @mut SyntaxEnv,
-                   cx: @ExtCtxt,
+                   cx: &ExtCtxt,
                    it: @ast::item,
                    fld: &MacroExpander)
                    -> SmallVector<@ast::item> {
@@ -298,7 +298,7 @@ pub fn contains_macro_escape(attrs: &[ast::Attribute]) -> bool {
 // Support for item-position macro invocations, exactly the same
 // logic as for expression-position macro invocations.
 pub fn expand_item_mac(extsbox: @mut SyntaxEnv,
-                       cx: @ExtCtxt,
+                       cx: &ExtCtxt,
                        it: @ast::item,
                        fld: &MacroExpander)
                        -> SmallVector<@ast::item> {
@@ -407,7 +407,7 @@ fn insert_macro(exts: SyntaxEnv, name: ast::Name, transformer: @Transformer) {
 
 // expand a stmt
 pub fn expand_stmt(extsbox: @mut SyntaxEnv,
-                   cx: @ExtCtxt,
+                   cx: &ExtCtxt,
                    s: &Stmt,
                    fld: &MacroExpander)
                    -> SmallVector<@Stmt> {
@@ -625,7 +625,7 @@ pub fn new_name_finder(idents: ~[ast::Ident]) -> NewNameFinderContext {
 
 // expand a block. pushes a new exts_frame, then calls expand_block_elts
 pub fn expand_block(extsbox: @mut SyntaxEnv,
-                    _: @ExtCtxt,
+                    _: &ExtCtxt,
                     blk: &Block,
                     fld: &MacroExpander)
                     -> P<Block> {
@@ -690,7 +690,7 @@ pub fn renames_to_fold(renames: @mut ~[(ast::Ident,ast::Name)]) -> @ast_fold {
     } as @ast_fold
 }
 
-pub fn new_span(cx: @ExtCtxt, sp: Span) -> Span {
+pub fn new_span(cx: &ExtCtxt, sp: Span) -> Span {
     /* this discards information in the case of macro-defining macros */
     Span {
         lo: sp.lo,
@@ -949,12 +949,12 @@ pub fn inject_std_macros(parse_sess: @mut parse::ParseSess,
     injector.fold_crate(c)
 }
 
-pub struct MacroExpander {
+pub struct MacroExpander<'a> {
     extsbox: @mut SyntaxEnv,
-    cx: @ExtCtxt,
+    cx: &'a ExtCtxt,
 }
 
-impl ast_fold for MacroExpander {
+impl<'a> ast_fold for MacroExpander<'a> {
     fn fold_expr(&self, expr: @ast::Expr) -> @ast::Expr {
         expand_expr(self.extsbox,
                     self.cx,
@@ -1005,10 +1005,10 @@ pub fn expand_crate(parse_sess: @mut parse::ParseSess,
     // every method/element of AstFoldFns in fold.rs.
     let extsbox = syntax_expander_table();
     let cx = ExtCtxt::new(parse_sess, cfg.clone());
-    let expander = @MacroExpander {
+    let expander = MacroExpander {
         extsbox: @mut extsbox,
-        cx: cx,
-    } as @ast_fold;
+        cx: &cx,
+    };
 
     let ret = expander.fold_crate(c);
     parse_sess.span_diagnostic.handler().abort_if_errors();
@@ -1159,7 +1159,7 @@ pub fn mtwt_cancel_outer_mark(tts: &[ast::token_tree], ctxt: ast::SyntaxContext)
     mark_tts(tts,outer_mark)
 }
 
-fn original_span(cx: @ExtCtxt) -> @codemap::ExpnInfo {
+fn original_span(cx: &ExtCtxt) -> @codemap::ExpnInfo {
     let mut relevant_info = cx.backtrace();
     let mut einfo = relevant_info.unwrap();
     loop {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -932,7 +932,7 @@ pub fn inject_std_macros(parse_sess: @mut parse::ParseSess,
 
 pub struct MacroExpander<'a> {
     extsbox: @mut SyntaxEnv,
-    cx: &'a ExtCtxt,
+    cx: &'a mut ExtCtxt,
 }
 
 impl<'a> ast_fold for MacroExpander<'a> {
@@ -970,10 +970,10 @@ pub fn expand_crate(parse_sess: @mut parse::ParseSess,
     // exts table through the fold, but that would require updating
     // every method/element of AstFoldFns in fold.rs.
     let extsbox = syntax_expander_table();
-    let cx = ExtCtxt::new(parse_sess, cfg.clone());
+    let mut cx = ExtCtxt::new(parse_sess, cfg.clone());
     let mut expander = MacroExpander {
         extsbox: @mut extsbox,
-        cx: &cx,
+        cx: &mut cx,
     };
 
     let ret = expander.fold_crate(c);

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -15,7 +15,7 @@ use codemap::Span;
 use ext::base;
 use ext::build::AstBuilder;
 
-pub fn expand_syntax_ext(ecx: &base::ExtCtxt, sp: Span,
+pub fn expand_syntax_ext(ecx: &mut base::ExtCtxt, sp: Span,
                          _tts: &[ast::token_tree]) -> base::MacResult {
     ecx.span_err(sp, "`fmt!` is deprecated, use `format!` instead");
     ecx.parse_sess.span_diagnostic.span_note(sp,

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -15,7 +15,7 @@ use codemap::Span;
 use ext::base;
 use ext::build::AstBuilder;
 
-pub fn expand_syntax_ext(ecx: @base::ExtCtxt, sp: Span,
+pub fn expand_syntax_ext(ecx: &base::ExtCtxt, sp: Span,
                          _tts: &[ast::token_tree]) -> base::MacResult {
     ecx.span_err(sp, "`fmt!` is deprecated, use `format!` instead");
     ecx.parse_sess.span_diagnostic.span_note(sp,

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -28,8 +28,8 @@ enum ArgumentType {
     String,
 }
 
-struct Context {
-    ecx: @ExtCtxt,
+struct Context<'a> {
+    ecx: &'a ExtCtxt,
     fmtsp: Span,
 
     // Parsed argument expressions and the types that we've found so far for
@@ -50,7 +50,7 @@ struct Context {
     next_arg: uint,
 }
 
-impl Context {
+impl<'a> Context<'a> {
     /// Parses the arguments from the given list of tokens, returning None if
     /// there's a parse error so we can continue parsing other format! expressions.
     fn parse_args(&mut self, sp: Span,
@@ -722,7 +722,7 @@ impl Context {
     }
 }
 
-pub fn expand_args(ecx: @ExtCtxt, sp: Span,
+pub fn expand_args(ecx: &ExtCtxt, sp: Span,
                    tts: &[ast::token_tree]) -> base::MacResult {
     let mut cx = Context {
         ecx: ecx,

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -29,7 +29,7 @@ enum ArgumentType {
 }
 
 struct Context<'a> {
-    ecx: &'a ExtCtxt,
+    ecx: &'a mut ExtCtxt,
     fmtsp: Span,
 
     // Parsed argument expressions and the types that we've found so far for
@@ -722,7 +722,7 @@ impl<'a> Context<'a> {
     }
 }
 
-pub fn expand_args(ecx: &ExtCtxt, sp: Span,
+pub fn expand_args(ecx: &mut ExtCtxt, sp: Span,
                    tts: &[ast::token_tree]) -> base::MacResult {
     let mut cx = Context {
         ecx: ecx,
@@ -739,19 +739,20 @@ pub fn expand_args(ecx: &ExtCtxt, sp: Span,
     };
     let (extra, efmt) = match cx.parse_args(sp, tts) {
         (extra, Some(e)) => (extra, e),
-        (_, None) => { return MRExpr(ecx.expr_uint(sp, 2)); }
+        (_, None) => { return MRExpr(cx.ecx.expr_uint(sp, 2)); }
     };
     cx.fmtsp = efmt.span;
     // Be sure to recursively expand macros just in case the format string uses
     // a macro to build the format expression.
-    let (fmt, _) = expr_to_str(ecx, ecx.expand_expr(efmt),
+    let expr = cx.ecx.expand_expr(efmt);
+    let (fmt, _) = expr_to_str(cx.ecx, expr,
                                "format argument must be a string literal.");
 
     let mut err = false;
     parse::parse_error::cond.trap(|m| {
         if !err {
             err = true;
-            ecx.span_err(efmt.span, m);
+            cx.ecx.span_err(efmt.span, m);
         }
     }).inside(|| {
         for piece in parse::Parser::new(fmt) {
@@ -767,12 +768,12 @@ pub fn expand_args(ecx: &ExtCtxt, sp: Span,
     // Make sure that all arguments were used and all arguments have types.
     for (i, ty) in cx.arg_types.iter().enumerate() {
         if ty.is_none() {
-            ecx.span_err(cx.args[i].span, "argument never used");
+            cx.ecx.span_err(cx.args[i].span, "argument never used");
         }
     }
     for (name, e) in cx.names.iter() {
         if !cx.name_types.contains_key(name) {
-            ecx.span_err(e.span, "named argument never used");
+            cx.ecx.span_err(e.span, "named argument never used");
         }
     }
 

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -15,7 +15,7 @@ use ext::base;
 use print;
 use parse::token::{get_ident_interner};
 
-pub fn expand_syntax_ext(cx: &ExtCtxt,
+pub fn expand_syntax_ext(cx: &mut ExtCtxt,
                          sp: codemap::Span,
                          tt: &[ast::token_tree])
                       -> base::MacResult {

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -15,7 +15,7 @@ use ext::base;
 use print;
 use parse::token::{get_ident_interner};
 
-pub fn expand_syntax_ext(cx: @ExtCtxt,
+pub fn expand_syntax_ext(cx: &ExtCtxt,
                          sp: codemap::Span,
                          tt: &[ast::token_tree])
                       -> base::MacResult {

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -40,11 +40,11 @@ pub mod rt {
     pub use codemap::{BytePos, Span, dummy_spanned};
 
     pub trait ToTokens {
-        fn to_tokens(&self, _cx: @ExtCtxt) -> ~[token_tree];
+        fn to_tokens(&self, _cx: &ExtCtxt) -> ~[token_tree];
     }
 
     impl ToTokens for ~[token_tree] {
-        fn to_tokens(&self, _cx: @ExtCtxt) -> ~[token_tree] {
+        fn to_tokens(&self, _cx: &ExtCtxt) -> ~[token_tree] {
             (*self).clone()
         }
     }
@@ -56,7 +56,7 @@ pub mod rt {
         pub fn to_source() -> ~str;
 
         // If you can make source, you can definitely make tokens.
-        pub fn to_tokens(cx: @ExtCtxt) -> ~[token_tree] {
+        pub fn to_tokens(cx: &ExtCtxt) -> ~[token_tree] {
             cx.parse_tts(self.to_source())
         }
     }
@@ -199,7 +199,7 @@ pub mod rt {
     macro_rules! impl_to_tokens(
         ($t:ty) => (
             impl ToTokens for $t {
-                fn to_tokens(&self, cx: @ExtCtxt) -> ~[token_tree] {
+                fn to_tokens(&self, cx: &ExtCtxt) -> ~[token_tree] {
                     cx.parse_tts(self.to_source())
                 }
             }
@@ -209,7 +209,7 @@ pub mod rt {
     macro_rules! impl_to_tokens_self(
         ($t:ty) => (
             impl<'a> ToTokens for $t {
-                fn to_tokens(&self, cx: @ExtCtxt) -> ~[token_tree] {
+                fn to_tokens(&self, cx: &ExtCtxt) -> ~[token_tree] {
                     cx.parse_tts(self.to_source())
                 }
             }
@@ -289,7 +289,7 @@ pub mod rt {
 
 }
 
-pub fn expand_quote_tokens(cx: @ExtCtxt,
+pub fn expand_quote_tokens(cx: &ExtCtxt,
                            sp: Span,
                            tts: &[ast::token_tree]) -> base::MacResult {
     let (cx_expr, expr) = expand_tts(cx, sp, tts);
@@ -297,14 +297,14 @@ pub fn expand_quote_tokens(cx: @ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_expr(cx: @ExtCtxt,
+pub fn expand_quote_expr(cx: &ExtCtxt,
                          sp: Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let expanded = expand_parse_call(cx, sp, "parse_expr", ~[], tts);
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_item(cx: @ExtCtxt,
+pub fn expand_quote_item(cx: &ExtCtxt,
                          sp: Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let e_attrs = cx.expr_vec_uniq(sp, ~[]);
@@ -313,7 +313,7 @@ pub fn expand_quote_item(cx: @ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_pat(cx: @ExtCtxt,
+pub fn expand_quote_pat(cx: &ExtCtxt,
                         sp: Span,
                         tts: &[ast::token_tree]) -> base::MacResult {
     let e_refutable = cx.expr_lit(sp, ast::lit_bool(true));
@@ -322,7 +322,7 @@ pub fn expand_quote_pat(cx: @ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_ty(cx: @ExtCtxt,
+pub fn expand_quote_ty(cx: &ExtCtxt,
                        sp: Span,
                        tts: &[ast::token_tree]) -> base::MacResult {
     let e_param_colons = cx.expr_lit(sp, ast::lit_bool(false));
@@ -331,7 +331,7 @@ pub fn expand_quote_ty(cx: @ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_stmt(cx: @ExtCtxt,
+pub fn expand_quote_stmt(cx: &ExtCtxt,
                          sp: Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let e_attrs = cx.expr_vec_uniq(sp, ~[]);
@@ -349,7 +349,7 @@ fn id_ext(str: &str) -> ast::Ident {
 }
 
 // Lift an ident to the expr that evaluates to that ident.
-fn mk_ident(cx: @ExtCtxt, sp: Span, ident: ast::Ident) -> @ast::Expr {
+fn mk_ident(cx: &ExtCtxt, sp: Span, ident: ast::Ident) -> @ast::Expr {
     let e_str = cx.expr_str(sp, cx.str_of(ident));
     cx.expr_method_call(sp,
                         cx.expr_ident(sp, id_ext("ext_cx")),
@@ -357,7 +357,7 @@ fn mk_ident(cx: @ExtCtxt, sp: Span, ident: ast::Ident) -> @ast::Expr {
                         ~[e_str])
 }
 
-fn mk_binop(cx: @ExtCtxt, sp: Span, bop: token::binop) -> @ast::Expr {
+fn mk_binop(cx: &ExtCtxt, sp: Span, bop: token::binop) -> @ast::Expr {
     let name = match bop {
         PLUS => "PLUS",
         MINUS => "MINUS",
@@ -373,7 +373,7 @@ fn mk_binop(cx: @ExtCtxt, sp: Span, bop: token::binop) -> @ast::Expr {
     cx.expr_ident(sp, id_ext(name))
 }
 
-fn mk_token(cx: @ExtCtxt, sp: Span, tok: &token::Token) -> @ast::Expr {
+fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> @ast::Expr {
 
     match *tok {
         BINOP(binop) => {
@@ -528,7 +528,7 @@ fn mk_token(cx: @ExtCtxt, sp: Span, tok: &token::Token) -> @ast::Expr {
 }
 
 
-fn mk_tt(cx: @ExtCtxt, sp: Span, tt: &ast::token_tree)
+fn mk_tt(cx: &ExtCtxt, sp: Span, tt: &ast::token_tree)
     -> ~[@ast::Stmt] {
 
     match *tt {
@@ -570,7 +570,7 @@ fn mk_tt(cx: @ExtCtxt, sp: Span, tt: &ast::token_tree)
     }
 }
 
-fn mk_tts(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+fn mk_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> ~[@ast::Stmt] {
     let mut ss = ~[];
     for tt in tts.iter() {
@@ -579,7 +579,7 @@ fn mk_tts(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     ss
 }
 
-fn expand_tts(cx: @ExtCtxt,
+fn expand_tts(cx: &ExtCtxt,
               sp: Span,
               tts: &[ast::token_tree]) -> (@ast::Expr, @ast::Expr) {
 
@@ -652,7 +652,7 @@ fn expand_tts(cx: @ExtCtxt,
     (cx_expr, block)
 }
 
-fn expand_wrapper(cx: @ExtCtxt,
+fn expand_wrapper(cx: &ExtCtxt,
                   sp: Span,
                   cx_expr: @ast::Expr,
                   expr: @ast::Expr) -> @ast::Expr {
@@ -667,7 +667,7 @@ fn expand_wrapper(cx: @ExtCtxt,
     cx.expr_block(cx.block_all(sp, uses, ~[stmt_let_ext_cx], Some(expr)))
 }
 
-fn expand_parse_call(cx: @ExtCtxt,
+fn expand_parse_call(cx: &ExtCtxt,
                      sp: Span,
                      parse_method: &str,
                      arg_exprs: ~[@ast::Expr],

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -289,7 +289,7 @@ pub mod rt {
 
 }
 
-pub fn expand_quote_tokens(cx: &ExtCtxt,
+pub fn expand_quote_tokens(cx: &mut ExtCtxt,
                            sp: Span,
                            tts: &[ast::token_tree]) -> base::MacResult {
     let (cx_expr, expr) = expand_tts(cx, sp, tts);
@@ -297,14 +297,14 @@ pub fn expand_quote_tokens(cx: &ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_expr(cx: &ExtCtxt,
+pub fn expand_quote_expr(cx: &mut ExtCtxt,
                          sp: Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let expanded = expand_parse_call(cx, sp, "parse_expr", ~[], tts);
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_item(cx: &ExtCtxt,
+pub fn expand_quote_item(cx: &mut ExtCtxt,
                          sp: Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let e_attrs = cx.expr_vec_uniq(sp, ~[]);
@@ -313,7 +313,7 @@ pub fn expand_quote_item(cx: &ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_pat(cx: &ExtCtxt,
+pub fn expand_quote_pat(cx: &mut ExtCtxt,
                         sp: Span,
                         tts: &[ast::token_tree]) -> base::MacResult {
     let e_refutable = cx.expr_lit(sp, ast::lit_bool(true));
@@ -322,7 +322,7 @@ pub fn expand_quote_pat(cx: &ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_ty(cx: &ExtCtxt,
+pub fn expand_quote_ty(cx: &mut ExtCtxt,
                        sp: Span,
                        tts: &[ast::token_tree]) -> base::MacResult {
     let e_param_colons = cx.expr_lit(sp, ast::lit_bool(false));
@@ -331,7 +331,7 @@ pub fn expand_quote_ty(cx: &ExtCtxt,
     base::MRExpr(expanded)
 }
 
-pub fn expand_quote_stmt(cx: &ExtCtxt,
+pub fn expand_quote_stmt(cx: &mut ExtCtxt,
                          sp: Span,
                          tts: &[ast::token_tree]) -> base::MacResult {
     let e_attrs = cx.expr_vec_uniq(sp, ~[]);

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -28,7 +28,7 @@ use std::str;
 // a given file into the current one.
 
 /* line!(): expands to the current line number */
-pub fn expand_line(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_line(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "line!");
 
@@ -39,7 +39,7 @@ pub fn expand_line(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
 }
 
 /* col!(): expands to the current column number */
-pub fn expand_col(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_col(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "col!");
 
@@ -51,7 +51,7 @@ pub fn expand_col(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
 /* file!(): expands to the current filename */
 /* The filemap (`loc.file`) contains a bunch more information we could spit
  * out if we wanted. */
-pub fn expand_file(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_file(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "file!");
 
@@ -61,13 +61,13 @@ pub fn expand_file(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     base::MRExpr(cx.expr_str(topmost.call_site, filename))
 }
 
-pub fn expand_stringify(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_stringify(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let s = pprust::tts_to_str(tts, get_ident_interner());
     base::MRExpr(cx.expr_str(sp, s.to_managed()))
 }
 
-pub fn expand_mod(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_mod(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "module_path!");
     base::MRExpr(cx.expr_str(sp,
@@ -77,7 +77,7 @@ pub fn expand_mod(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
 // include! : parse the given file as an expr
 // This is generally a bad idea because it's going to behave
 // unhygienically.
-pub fn expand_include(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_include(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let file = get_single_str_from_tts(cx, sp, tts, "include!");
     // The file will be added to the code map by the parser
@@ -88,7 +88,7 @@ pub fn expand_include(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
 }
 
 // include_str! : read the given file, insert it as a literal string expr
-pub fn expand_include_str(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_include_str(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let file = get_single_str_from_tts(cx, sp, tts, "include_str!");
     let file = res_rel_file(cx, sp, &Path::new(file));
@@ -120,7 +120,7 @@ pub fn expand_include_str(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
     }
 }
 
-pub fn expand_include_bin(cx: @ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_include_bin(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
         -> base::MacResult
 {
     use std::at_vec;
@@ -167,7 +167,7 @@ fn topmost_expn_info(expn_info: @codemap::ExpnInfo) -> @codemap::ExpnInfo {
 
 // resolve a file-system path to an absolute file-system path (if it
 // isn't already)
-fn res_rel_file(cx: @ExtCtxt, sp: codemap::Span, arg: &Path) -> Path {
+fn res_rel_file(cx: &ExtCtxt, sp: codemap::Span, arg: &Path) -> Path {
     // NB: relative paths are resolved relative to the compilation unit
     if !arg.is_absolute() {
         let mut cu = Path::new(cx.codemap().span_to_filename(sp));

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -28,7 +28,7 @@ use std::str;
 // a given file into the current one.
 
 /* line!(): expands to the current line number */
-pub fn expand_line(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_line(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "line!");
 
@@ -39,7 +39,7 @@ pub fn expand_line(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
 }
 
 /* col!(): expands to the current column number */
-pub fn expand_col(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_col(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "col!");
 
@@ -51,7 +51,7 @@ pub fn expand_col(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
 /* file!(): expands to the current filename */
 /* The filemap (`loc.file`) contains a bunch more information we could spit
  * out if we wanted. */
-pub fn expand_file(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_file(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "file!");
 
@@ -61,13 +61,13 @@ pub fn expand_file(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     base::MRExpr(cx.expr_str(topmost.call_site, filename))
 }
 
-pub fn expand_stringify(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_stringify(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let s = pprust::tts_to_str(tts, get_ident_interner());
     base::MRExpr(cx.expr_str(sp, s.to_managed()))
 }
 
-pub fn expand_mod(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_mod(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "module_path!");
     base::MRExpr(cx.expr_str(sp,
@@ -77,7 +77,7 @@ pub fn expand_mod(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
 // include! : parse the given file as an expr
 // This is generally a bad idea because it's going to behave
 // unhygienically.
-pub fn expand_include(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_include(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let file = get_single_str_from_tts(cx, sp, tts, "include!");
     // The file will be added to the code map by the parser
@@ -88,7 +88,7 @@ pub fn expand_include(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
 }
 
 // include_str! : read the given file, insert it as a literal string expr
-pub fn expand_include_str(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
     -> base::MacResult {
     let file = get_single_str_from_tts(cx, sp, tts, "include_str!");
     let file = res_rel_file(cx, sp, &Path::new(file));
@@ -120,7 +120,7 @@ pub fn expand_include_str(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
     }
 }
 
-pub fn expand_include_bin(cx: &ExtCtxt, sp: Span, tts: &[ast::token_tree])
+pub fn expand_include_bin(cx: &mut ExtCtxt, sp: Span, tts: &[ast::token_tree])
         -> base::MacResult
 {
     use std::at_vec;
@@ -167,7 +167,7 @@ fn topmost_expn_info(expn_info: @codemap::ExpnInfo) -> @codemap::ExpnInfo {
 
 // resolve a file-system path to an absolute file-system path (if it
 // isn't already)
-fn res_rel_file(cx: &ExtCtxt, sp: codemap::Span, arg: &Path) -> Path {
+fn res_rel_file(cx: &mut ExtCtxt, sp: codemap::Span, arg: &Path) -> Path {
     // NB: relative paths are resolved relative to the compilation unit
     if !arg.is_absolute() {
         let mut cu = Path::new(cx.codemap().span_to_filename(sp));

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -16,7 +16,7 @@ use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
 use parse::token::keywords;
 
-pub fn expand_trace_macros(cx: @ExtCtxt,
+pub fn expand_trace_macros(cx: &ExtCtxt,
                            sp: Span,
                            tt: &[ast::token_tree])
                         -> base::MacResult {

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -16,7 +16,7 @@ use parse::lexer::{new_tt_reader, reader};
 use parse::parser::Parser;
 use parse::token::keywords;
 
-pub fn expand_trace_macros(cx: &ExtCtxt,
+pub fn expand_trace_macros(cx: &mut ExtCtxt,
                            sp: Span,
                            tt: &[ast::token_tree])
                         -> base::MacResult {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -83,7 +83,7 @@ struct MacroRulesSyntaxExpanderTTFun {
 
 impl SyntaxExpanderTTTrait for MacroRulesSyntaxExpanderTTFun {
     fn expand(&self,
-              cx: &ExtCtxt,
+              cx: &mut ExtCtxt,
               sp: Span,
               arg: &[ast::token_tree],
               _: ast::SyntaxContext)
@@ -168,7 +168,7 @@ fn generic_extension(cx: &ExtCtxt,
 // this procedure performs the expansion of the
 // macro_rules! macro. It parses the RHS and adds
 // an extension to the current context.
-pub fn add_new_extension(cx: &ExtCtxt,
+pub fn add_new_extension(cx: &mut ExtCtxt,
                          sp: Span,
                          name: Ident,
                          arg: ~[ast::token_tree],

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -83,7 +83,7 @@ struct MacroRulesSyntaxExpanderTTFun {
 
 impl SyntaxExpanderTTTrait for MacroRulesSyntaxExpanderTTFun {
     fn expand(&self,
-              cx: @ExtCtxt,
+              cx: &ExtCtxt,
               sp: Span,
               arg: &[ast::token_tree],
               _: ast::SyntaxContext)
@@ -93,7 +93,7 @@ impl SyntaxExpanderTTTrait for MacroRulesSyntaxExpanderTTFun {
 }
 
 // Given `lhses` and `rhses`, this is the new macro we create
-fn generic_extension(cx: @ExtCtxt,
+fn generic_extension(cx: &ExtCtxt,
                      sp: Span,
                      name: Ident,
                      arg: &[ast::token_tree],
@@ -168,7 +168,7 @@ fn generic_extension(cx: @ExtCtxt,
 // this procedure performs the expansion of the
 // macro_rules! macro. It parses the RHS and adds
 // an extension to the current context.
-pub fn add_new_extension(cx: @ExtCtxt,
+pub fn add_new_extension(cx: &ExtCtxt,
                          sp: Span,
                          name: Ident,
                          arg: ~[ast::token_tree],

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -16,7 +16,7 @@ extern mod syntax;
 
 use syntax::ext::base::ExtCtxt;
 
-fn syntax_extension(cx: @ExtCtxt) {
+fn syntax_extension(cx: &ExtCtxt) {
     let e_toks : ~[syntax::ast::token_tree] = quote_tokens!(cx, 1 + 2);
     let p_toks : ~[syntax::ast::token_tree] = quote_tokens!(cx, (x, 1 .. 4, *));
 


### PR DESCRIPTION
- Pass `&ExtCtxt` instead of `@ExtCtxt`.
- Stop passing duplicate parameters around in `expand`.
- Make `ast_fold` methods take `&mut self`.

After these, it should be possible to remove the `@mut` boxes from `ExtCtxt` altogether, though #11167 is doing some of that so I'm holding off on that for now. This will probably conflict with that PR, so I'm guessing that one will have to be rebased on top of the other.

r? @pcwalton
