### PR TITLE
Add docs for more crates

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -13,6 +13,7 @@
 ######################################################################
 
 DOCS :=
+CDOCS :=
 DOCS_L10N :=
 
 BASE_DOC_OPTS := --from=markdown --standalone --toc --number-sections
@@ -232,12 +233,21 @@ doc/$(1)/index.html: $$(RUSTDOC) $$(TLIB2_T_$(3)_H_$(3))/$(CFG_STDLIB_$(3))
 DOCS += doc/$(1)/index.html
 endef
 
+define compiledoc
+doc/$(1)/index.html: $$(RUSTDOC) $$(TLIB2_T_$(3)_H_$(3))/$(CFG_STDLIB_$(3))
+	@$$(call E, rustdoc: $$@)
+	$(Q)$(RUSTDOC) --cfg stage2 $(2)
+
+CDOCS += doc/$(1)/index.html
+endef
+
 $(eval $(call libdoc,std,$(STDLIB_CRATE),$(CFG_BUILD)))
 $(eval $(call libdoc,extra,$(EXTRALIB_CRATE),$(CFG_BUILD)))
 $(eval $(call libdoc,native,$(LIBNATIVE_CRATE),$(CFG_BUILD)))
 $(eval $(call libdoc,green,$(LIBGREEN_CRATE),$(CFG_BUILD)))
-$(eval $(call libdoc,rustc,$(COMPILER_CRATE),$(CFG_BUILD)))
-$(eval $(call libdoc,syntax,$(LIBSYNTAX_CRATE),$(CFG_BUILD)))
+
+$(eval $(call compiledoc,rustc,$(COMPILER_CRATE),$(CFG_BUILD)))
+$(eval $(call compiledoc,syntax,$(LIBSYNTAX_CRATE),$(CFG_BUILD)))
 
 
 ifdef CFG_DISABLE_DOCS
@@ -260,6 +270,7 @@ doc/version_info.html: version_info.html.template $(MKFILE_DEPS) \
 GENERATED += doc/version.md doc/version_info.html
 
 docs: $(DOCS)
+compiler-docs: $(CDOCS)
 
 docs-l10n: $(DOCS_L10N)
 

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -234,6 +234,10 @@ endef
 
 $(eval $(call libdoc,std,$(STDLIB_CRATE),$(CFG_BUILD)))
 $(eval $(call libdoc,extra,$(EXTRALIB_CRATE),$(CFG_BUILD)))
+$(eval $(call libdoc,native,$(LIBNATIVE_CRATE),$(CFG_BUILD)))
+$(eval $(call libdoc,green,$(LIBGREEN_CRATE),$(CFG_BUILD)))
+$(eval $(call libdoc,rustc,$(COMPILER_CRATE),$(CFG_BUILD)))
+$(eval $(call libdoc,syntax,$(LIBSYNTAX_CRATE),$(CFG_BUILD)))
 
 
 ifdef CFG_DISABLE_DOCS

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1123,6 +1123,8 @@ fn lit_to_str(lit: &ast::lit) -> ~str {
 
 fn name_from_pat(p: &ast::Pat) -> ~str {
     use syntax::ast::*;
+    debug!("Trying to get a name from pattern: {:?}", p);
+
     match p.node {
         PatWild => ~"_",
         PatWildMulti => ~"..",
@@ -1134,9 +1136,12 @@ fn name_from_pat(p: &ast::Pat) -> ~str {
         PatBox(p) => name_from_pat(p),
         PatUniq(p) => name_from_pat(p),
         PatRegion(p) => name_from_pat(p),
-        PatLit(..) => fail!("tried to get argument name from pat_lit, \
-                            which is not allowed in function arguments"),
-        PatRange(..) => fail!("tried to get argument name from pat_range, \
+        PatLit(..) => {
+            warn!("tried to get argument name from PatLit, \
+                  which is silly in function arguments");
+            ~"()"
+        },
+        PatRange(..) => fail!("tried to get argument name from PatRange, \
                               which is not allowed in function arguments"),
         PatVec(..) => fail!("tried to get argument name from pat_vec, \
                              which is not allowed in function arguments")


### PR DESCRIPTION
Some people have requested this, and I think it's quite useful to have
documentation for the compiler libraries. libnative and libgreen are
self-explanatory I think.
