### PR TITLE
Guard a maybe_yield in Chan with can_resched

### DIFF
--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -599,7 +599,7 @@ impl<T: Send> Chan<T> {
                 // the TLS overhead can be a bit much.
                 n => {
                     assert!(n >= 0);
-                    if n > 0 && n % RESCHED_FREQ == 0 {
+                    if can_resched && n > 0 && n % RESCHED_FREQ == 0 {
                         let task: ~Task = Local::take();
                         task.maybe_yield();
                     }


### PR DESCRIPTION
I forgot to add this back in after I removed can_resched and then realized I had
to add it back.
