### PR TITLE
Update llvm.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/llvm"]
 	path = src/llvm
-	url = https://github.com/alexcrichton/llvm.git
+	url = https://github.com/luqmana/llvm.git
 	branch = master
 [submodule "src/libuv"]
 	path = src/libuv

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -81,9 +81,7 @@ LLVMRustCreateTargetMachine(const char *triple,
     TargetOptions Options;
     Options.NoFramePointerElim = true;
     Options.EnableSegmentedStacks = EnableSegmentedStacks;
-    Options.FloatABIType =
-         (Trip.getEnvironment() == Triple::GNUEABIHF) ? FloatABI::Hard :
-                                                        FloatABI::Default;
+    Options.FloatABIType = FloatABI::Default;
     Options.UseSoftFloat = UseSoftFloat;
     if (UseSoftFloat) {
         Options.FloatABIType = FloatABI::Soft;

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2013-12-18
+2013-12-29


### PR DESCRIPTION
No longer need to handle GNUEABIHF and hard floats since LLVM should now choose the right default. Fixes #11164.
