### PR TITLE
Implement native UDP I/O

### DIFF
--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -166,8 +166,8 @@ impl rtio::IoFactory for IoFactory {
     fn tcp_bind(&mut self, addr: SocketAddr) -> IoResult<~RtioTcpListener> {
         net::TcpListener::bind(addr).map(|s| ~s as ~RtioTcpListener)
     }
-    fn udp_bind(&mut self, _addr: SocketAddr) -> IoResult<~RtioUdpSocket> {
-        Err(unimpl())
+    fn udp_bind(&mut self, addr: SocketAddr) -> IoResult<~RtioUdpSocket> {
+        net::UdpSocket::bind(addr).map(|u| ~u as ~RtioUdpSocket)
     }
     fn unix_bind(&mut self, _path: &CString) -> IoResult<~RtioUnixListener> {
         Err(unimpl())

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -104,11 +104,10 @@ mod test {
     use io::test::*;
     use prelude::*;
 
-    #[test]  #[ignore]
-    fn bind_error() {
+    iotest!(fn bind_error() {
         let mut called = false;
         io_error::cond.trap(|e| {
-            assert!(e.kind == PermissionDenied);
+            assert_eq!(e.kind, PermissionDenied);
             called = true;
         }).inside(|| {
             let addr = SocketAddr { ip: Ipv4Addr(0, 0, 0, 0), port: 1 };
@@ -116,13 +115,13 @@ mod test {
             assert!(socket.is_none());
         });
         assert!(called);
-    }
+    } #[ignore(cfg(windows))])
 
-    #[test]
-    fn socket_smoke_test_ip4() {
+    iotest!(fn socket_smoke_test_ip4() {
         let server_ip = next_test_ip4();
         let client_ip = next_test_ip4();
         let (port, chan) = Chan::new();
+        let (port2, chan2) = Chan::new();
 
         do spawn {
             match UdpSocket::bind(client_ip) {
@@ -132,6 +131,7 @@ mod test {
                 }
                 None => fail!()
             }
+            chan2.send(());
         }
 
         match UdpSocket::bind(server_ip) {
@@ -149,10 +149,10 @@ mod test {
             }
             None => fail!()
         }
-    }
+        port2.recv();
+    })
 
-    #[test]
-    fn socket_smoke_test_ip6() {
+    iotest!(fn socket_smoke_test_ip6() {
         let server_ip = next_test_ip6();
         let client_ip = next_test_ip6();
         let (port, chan) = Chan::<()>::new();
@@ -182,13 +182,13 @@ mod test {
             }
             None => fail!()
         }
-    }
+    })
 
-    #[test]
-    fn stream_smoke_test_ip4() {
+    iotest!(fn stream_smoke_test_ip4() {
         let server_ip = next_test_ip4();
         let client_ip = next_test_ip4();
         let (port, chan) = Chan::new();
+        let (port2, chan2) = Chan::new();
 
         do spawn {
             match UdpSocket::bind(client_ip) {
@@ -200,6 +200,7 @@ mod test {
                 }
                 None => fail!()
             }
+            chan2.send(());
         }
 
         match UdpSocket::bind(server_ip) {
@@ -218,13 +219,14 @@ mod test {
             }
             None => fail!()
         }
-    }
+        port2.recv();
+    })
 
-    #[test]
-    fn stream_smoke_test_ip6() {
+    iotest!(fn stream_smoke_test_ip6() {
         let server_ip = next_test_ip6();
         let client_ip = next_test_ip6();
         let (port, chan) = Chan::new();
+        let (port2, chan2) = Chan::new();
 
         do spawn {
             match UdpSocket::bind(client_ip) {
@@ -236,6 +238,7 @@ mod test {
                 }
                 None => fail!()
             }
+            chan2.send(());
         }
 
         match UdpSocket::bind(server_ip) {
@@ -254,9 +257,10 @@ mod test {
             }
             None => fail!()
         }
-    }
+        port2.recv();
+    })
 
-    fn socket_name(addr: SocketAddr) {
+    pub fn socket_name(addr: SocketAddr) {
         let server = UdpSocket::bind(addr);
 
         assert!(server.is_some());
@@ -269,13 +273,11 @@ mod test {
         assert_eq!(addr, so_name.unwrap());
     }
 
-    #[test]
-    fn socket_name_ip4() {
+    iotest!(fn socket_name_ip4() {
         socket_name(next_test_ip4());
-    }
+    })
 
-    #[test]
-    fn socket_name_ip6() {
+    iotest!(fn socket_name_ip6() {
         socket_name(next_test_ip6());
-    }
+    })
 }

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -243,6 +243,8 @@ pub mod types {
                 }
             }
             pub mod bsd44 {
+                use libc::types::os::arch::c95::c_uint;
+
                 pub type socklen_t = u32;
                 pub type sa_family_t = u16;
                 pub type in_port_t = u16;
@@ -274,6 +276,14 @@ pub mod types {
                 }
                 pub struct in6_addr {
                     s6_addr: [u16, ..8]
+                }
+                pub struct ip_mreq {
+                    imr_multiaddr: in_addr,
+                    imr_interface: in_addr,
+                }
+                pub struct ip6_mreq {
+                    ipv6mr_multiaddr: in6_addr,
+                    ipv6mr_interface: c_uint,
                 }
             }
         }
@@ -575,6 +585,8 @@ pub mod types {
                 }
             }
             pub mod bsd44 {
+                use libc::types::os::arch::c95::c_uint;
+
                 pub type socklen_t = u32;
                 pub type sa_family_t = u8;
                 pub type in_port_t = u16;
@@ -611,6 +623,14 @@ pub mod types {
                 }
                 pub struct in6_addr {
                     s6_addr: [u16, ..8]
+                }
+                pub struct ip_mreq {
+                    imr_multiaddr: in_addr,
+                    imr_interface: in_addr,
+                }
+                pub struct ip6_mreq {
+                    ipv6mr_multiaddr: in6_addr,
+                    ipv6mr_interface: c_uint,
                 }
             }
         }
@@ -772,6 +792,14 @@ pub mod types {
                 }
                 pub struct in6_addr {
                     s6_addr: [u16, ..8]
+                }
+                pub struct ip_mreq {
+                    imr_multiaddr: in_addr,
+                    imr_interface: in_addr,
+                }
+                pub struct ip6_mreq {
+                    ipv6mr_multiaddr: in6_addr,
+                    ipv6mr_interface: c_uint,
                 }
             }
         }
@@ -1015,7 +1043,7 @@ pub mod types {
             }
 
             pub mod bsd44 {
-                use libc::types::os::arch::c95::c_int;
+                use libc::types::os::arch::c95::{c_int, c_uint};
 
                 pub type socklen_t = c_int;
                 pub type sa_family_t = u8;
@@ -1053,6 +1081,14 @@ pub mod types {
                 }
                 pub struct in6_addr {
                     s6_addr: [u16, ..8]
+                }
+                pub struct ip_mreq {
+                    imr_multiaddr: in_addr,
+                    imr_interface: in_addr,
+                }
+                pub struct ip6_mreq {
+                    ipv6mr_multiaddr: in6_addr,
+                    ipv6mr_interface: c_uint,
                 }
             }
         }
@@ -1364,10 +1400,20 @@ pub mod consts {
             pub static SOCK_STREAM: c_int = 1;
             pub static SOCK_DGRAM: c_int = 2;
             pub static IPPROTO_TCP: c_int = 6;
+            pub static IPPROTO_IP: c_int = 0;
+            pub static IPPROTO_IPV6: c_int = 41;
+            pub static IP_MULTICAST_TTL: c_int = 3;
+            pub static IP_MULTICAST_LOOP: c_int = 4;
+            pub static IP_ADD_MEMBERSHIP: c_int = 5;
+            pub static IP_DROP_MEMBERSHIP: c_int = 6;
+            pub static IPV6_ADD_MEMBERSHIP: c_int = 5;
+            pub static IPV6_DROP_MEMBERSHIP: c_int = 6;
+            pub static IP_TTL: c_int = 4;
 
             pub static TCP_NODELAY: c_int = 0x0001;
             pub static SOL_SOCKET: c_int = 0xffff;
             pub static SO_KEEPALIVE: c_int = 8;
+            pub static SO_BROADCAST: c_int = 32;
         }
         pub mod extra {
             use libc::types::os::arch::c95::c_int;
@@ -2070,10 +2116,20 @@ pub mod consts {
             pub static SOCK_STREAM: c_int = 1;
             pub static SOCK_DGRAM: c_int = 2;
             pub static IPPROTO_TCP: c_int = 6;
+            pub static IPPROTO_IP: c_int = 0;
+            pub static IPPROTO_IPV6: c_int = 41;
+            pub static IP_MULTICAST_TTL: c_int = 33;
+            pub static IP_MULTICAST_LOOP: c_int = 34;
+            pub static IP_TTL: c_int = 2;
+            pub static IP_ADD_MEMBERSHIP: c_int = 35;
+            pub static IP_DROP_MEMBERSHIP: c_int = 36;
+            pub static IPV6_ADD_MEMBERSHIP: c_int = 20;
+            pub static IPV6_DROP_MEMBERSHIP: c_int = 21;
 
             pub static TCP_NODELAY: c_int = 1;
             pub static SOL_SOCKET: c_int = 1;
             pub static SO_KEEPALIVE: c_int = 9;
+            pub static SO_BROADCAST: c_int = 6;
         }
         #[cfg(target_arch = "x86")]
         #[cfg(target_arch = "x86_64")]
@@ -2497,11 +2553,21 @@ pub mod consts {
             pub static SOCK_STREAM: c_int = 1;
             pub static SOCK_DGRAM: c_int = 2;
             pub static IPPROTO_TCP: c_int = 6;
+            pub static IPPROTO_IP: c_int = 0;
+            pub static IPPROTO_IPV6: c_int = 41;
+            pub static IP_MULTICAST_TTL: c_int = 10;
+            pub static IP_MULTICAST_LOOP: c_int = 11;
+            pub static IP_TTL: c_int = 4;
+            pub static IP_ADD_MEMBERSHIP: c_int = 12;
+            pub static IP_DROP_MEMBERSHIP: c_int = 13;
+            pub static IPV6_ADD_MEMBERSHIP: c_int = 12;
+            pub static IPV6_DROP_MEMBERSHIP: c_int = 13;
 
             pub static TCP_NODELAY: c_int = 1;
             pub static TCP_KEEPIDLE: c_int = 256;
             pub static SOL_SOCKET: c_int = 0xffff;
             pub static SO_KEEPALIVE: c_int = 0x0008;
+            pub static SO_BROADCAST: c_int = 0x0020;
         }
         pub mod extra {
             use libc::types::os::arch::c95::c_int;
@@ -2862,11 +2928,21 @@ pub mod consts {
             pub static SOCK_STREAM: c_int = 1;
             pub static SOCK_DGRAM: c_int = 2;
             pub static IPPROTO_TCP: c_int = 6;
+            pub static IPPROTO_IP: c_int = 0;
+            pub static IPPROTO_IPV6: c_int = 41;
+            pub static IP_MULTICAST_TTL: c_int = 10;
+            pub static IP_MULTICAST_LOOP: c_int = 11;
+            pub static IP_TTL: c_int = 4;
+            pub static IP_ADD_MEMBERSHIP: c_int = 12;
+            pub static IP_DROP_MEMBERSHIP: c_int = 13;
+            pub static IPV6_ADD_MEMBERSHIP: c_int = 12;
+            pub static IPV6_DROP_MEMBERSHIP: c_int = 13;
 
             pub static TCP_NODELAY: c_int = 0x01;
             pub static TCP_KEEPALIVE: c_int = 0x10;
             pub static SOL_SOCKET: c_int = 0xffff;
             pub static SO_KEEPALIVE: c_int = 0x0008;
+            pub static SO_BROADCAST: c_int = 0x0020;
         }
         pub mod extra {
             use libc::types::os::arch::c95::c_int;
@@ -3573,6 +3649,12 @@ pub mod funcs {
                         flags: c_int) -> ssize_t;
             pub fn send(socket: c_int, buf: *mut c_void, len: size_t,
                         flags: c_int) -> ssize_t;
+            pub fn recvfrom(socket: c_int, buf: *mut c_void, len: size_t,
+                            flags: c_int, addr: *mut sockaddr,
+                            addrlen: *mut socklen_t) -> ssize_t;
+            pub fn sendto(socket: c_int, buf: *c_void, len: size_t,
+                          flags: c_int, addr: *sockaddr,
+                          addrlen: socklen_t) -> ssize_t;
         }
     }
 
@@ -3581,6 +3663,7 @@ pub mod funcs {
         use libc::types::common::c95::{c_void};
         use libc::types::os::common::bsd44::{socklen_t, sockaddr, SOCKET};
         use libc::types::os::arch::c95::c_int;
+        use libc::types::os::arch::posix88::ssize_t;
 
         extern "system" {
             pub fn socket(domain: c_int, ty: c_int, protocol: c_int) -> SOCKET;
@@ -3602,6 +3685,12 @@ pub mod funcs {
                         flags: c_int) -> c_int;
             pub fn send(socket: SOCKET, buf: *mut c_void, len: c_int,
                         flags: c_int) -> c_int;
+            pub fn recvfrom(socket: SOCKET, buf: *mut c_void, len: c_int,
+                            flags: c_int, addr: *mut sockaddr,
+                            addrlen: *mut c_int) -> ssize_t;
+            pub fn sendto(socket: SOCKET, buf: *c_void, len: c_int,
+                          flags: c_int, addr: *sockaddr,
+                          addrlen: c_int) -> c_int;
         }
     }
 


### PR DESCRIPTION
I personally do not have huge amounts of experience in this area, so there's likely a thing or two wrong around the edges. I tried to just copy what libuv is doing as closely as possible with a few tweaks in a few places, but all of the `std::io::net::udp` tests are now run in both native and green settings so the published functionality is all being tested.
