### PR TITLE
Actually block in a windows cvar

### DIFF
--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -1019,7 +1019,6 @@ mod test {
     })
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#11003)
     fn send_from_outside_runtime() {
         let (p, c) = Chan::<int>::new();
         let (p1, c1) = Chan::new();
@@ -1044,7 +1043,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#11003)
     fn recv_from_outside_runtime() {
         let (p, c) = Chan::<int>::new();
         let (dp, dc) = Chan::new();
@@ -1061,7 +1059,6 @@ mod test {
     }
 
     #[test]
-    #[ignore(cfg(windows))] // FIXME(#11003)
     fn no_runtime() {
         let (p1, c1) = Chan::<int>::new();
         let (p2, c2) = Chan::<int>::new();

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -286,7 +286,7 @@ mod imp {
 
     pub unsafe fn wait(cond: *c_void, m: *c_void) {
         unlock(m);
-        WaitForSingleObject(cond as HANDLE, 0);
+        WaitForSingleObject(cond as HANDLE, libc::INFINITE);
         lock(m);
     }
 


### PR DESCRIPTION
Turns out with an argument of 0 the function always returns immediately!

Closes #11003
