### PR TITLE
Fix a deadlock in a libgreen test

### DIFF
--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -1433,7 +1433,7 @@ mod test {
             drop(handle);
 
             let mut handle = pool.spawn_sched();
-            handle.send(TaskFromFriend(pool.task(TaskOpts::new(), proc() {
+            handle.send(PinnedTask(pool.task(TaskOpts::new(), proc() {
                 // Wait until the other task has its lock
                 start_po.recv();
 


### PR DESCRIPTION
Turns out when you grab an OS mutex, you need to be careful about when and where
things are scheduled!

I've confirmed that I could fairly reliably get a deadlock (1 in 100 times ish) before this, and I cannot get a deadlock after this (after 1000+ runs).

Closes #11200
