### PR TITLE
Add metadata from a tempdir instead of a build dir

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -890,8 +890,11 @@ fn link_rlib(sess: Session,
     match trans {
         Some(trans) => {
             // Instead of putting the metadata in an object file section, rlibs
-            // contain the metadata in a separate file.
-            let metadata = obj_filename.with_filename(METADATA_FILENAME);
+            // contain the metadata in a separate file. We use a temp directory
+            // here so concurrent builds in the same directory don't try to use
+            // the same filename for metadata (stomping over one another)
+            let tmpdir = TempDir::new("rustc").expect("needs a temp dir");
+            let metadata = tmpdir.path().join(METADATA_FILENAME);
             fs::File::create(&metadata).write(trans.metadata);
             a.add_file(&metadata, false);
             fs::unlink(&metadata);


### PR DESCRIPTION
Right now if you have concurrent builds of two libraries in the same directory
(such as rustc's bootstrapping process), it's possible that two libraries will
stomp over each others' metadata, producing corrupt rlibs.

By placing the metadata file in a tempdir we're guranteed to not conflict with
ay other builds happening concurrently. Normally this isn't a problem because
output filenames are scoped to the name of the crate, but metadata is special in
that it has the same name across all crates.
