### PR TITLE
Fix rust-align-to-expr-after-brace, closes #11239.

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -54,7 +54,9 @@
     ;; We don't want to indent out to the open bracket if the
     ;; open bracket ends the line
     (when (not (looking-at "[[:blank:]]*\\(?://.*\\)?$"))
-      (when (looking-at "[[:space:]]") (forward-to-word 1))
+      (when (looking-at "[[:space:]]")
+	(forward-word 1)
+	(backward-word 1))
       (current-column))))
 
 (defun rust-mode-indent-line ()


### PR DESCRIPTION
forward-to-word is undefined, and so Emacs would throw errors in
rust-align-to-expr-after-brace. This change yields the expected
behavior discussed in issue #11239 by handling the case when
whitespace follows a left bracket.
