### PR TITLE
Some libsyntax/librustc cleanups

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -686,7 +686,7 @@ pub fn host_triple() -> ~str {
     (env!("CFG_COMPILER")).to_owned()
 }
 
-pub fn build_session_options(binary: @str,
+pub fn build_session_options(binary: ~str,
                              matches: &getopts::Matches,
                              demitter: @diagnostic::Emitter)
                              -> @session::options {
@@ -1105,7 +1105,7 @@ pub fn build_output_filenames(input: &input,
     }
 }
 
-pub fn early_error(emitter: @diagnostic::Emitter, msg: &str) -> ! {
+pub fn early_error(emitter: &diagnostic::Emitter, msg: &str) -> ! {
     emitter.emit(None, msg, diagnostic::fatal);
     fail!();
 }
@@ -1135,7 +1135,7 @@ mod test {
               Err(f) => fail!("test_switch_implies_cfg_test: {}", f.to_err_msg())
             };
         let sessopts = build_session_options(
-            @"rustc",
+            ~"rustc",
             matches,
             @diagnostic::DefaultEmitter as @diagnostic::Emitter);
         let sess = build_session(sessopts,
@@ -1158,7 +1158,7 @@ mod test {
               }
             };
         let sessopts = build_session_options(
-            @"rustc",
+            ~"rustc",
             matches,
             @diagnostic::DefaultEmitter as @diagnostic::Emitter);
         let sess = build_session(sessopts,

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -883,7 +883,7 @@ pub fn build_session(sopts: @session::options, demitter: @diagnostic::Emitter)
 pub fn build_session_(sopts: @session::options,
                       cm: @codemap::CodeMap,
                       demitter: @diagnostic::Emitter,
-                      span_diagnostic_handler: @mut diagnostic::span_handler)
+                      span_diagnostic_handler: @mut diagnostic::SpanHandler)
                       -> Session {
     let target_cfg = build_target_config(sopts, demitter);
     let p_s = parse::new_parse_sess_special_handler(span_diagnostic_handler,

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -163,7 +163,7 @@ pub struct options {
     // will be added to the crate AST node.  This should not be used for
     // anything except building the full crate config prior to parsing.
     cfg: ast::CrateConfig,
-    binary: @str,
+    binary: ~str,
     test: bool,
     parse_only: bool,
     no_trans: bool,
@@ -395,7 +395,7 @@ pub fn basic_options() -> @options {
         target_cpu: ~"generic",
         target_feature: ~"",
         cfg: ~[],
-        binary: @"rustc",
+        binary: ~"rustc",
         test: false,
         parse_only: false,
         no_trans: false,

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -209,7 +209,7 @@ pub struct Session_ {
     // For a library crate, this is always none
     entry_fn: RefCell<Option<(NodeId, codemap::Span)>>,
     entry_type: Cell<Option<EntryFnType>>,
-    span_diagnostic: @mut diagnostic::span_handler,
+    span_diagnostic: @mut diagnostic::SpanHandler,
     filesearch: @filesearch::FileSearch,
     building_library: Cell<bool>,
     working_dir: Path,
@@ -292,7 +292,7 @@ impl Session_ {
 
         v
     }
-    pub fn diagnostic(&self) -> @mut diagnostic::span_handler {
+    pub fn diagnostic(&self) -> @mut diagnostic::SpanHandler {
         self.span_diagnostic
     }
     pub fn debugging_opt(&self, opt: uint) -> bool {

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -14,7 +14,7 @@ use driver::session::Session;
 use std::vec;
 use syntax::ast;
 use syntax::attr;
-use syntax::codemap::dummy_sp;
+use syntax::codemap::DUMMY_SP;
 use syntax::codemap;
 use syntax::fold::ast_fold;
 use syntax::fold;
@@ -47,7 +47,7 @@ fn no_prelude(attrs: &[ast::Attribute]) -> bool {
 fn spanned<T>(x: T) -> codemap::Spanned<T> {
     codemap::Spanned {
         node: x,
-        span: dummy_sp(),
+        span: DUMMY_SP,
     }
 }
 
@@ -66,7 +66,7 @@ impl fold::ast_fold for StandardLibraryInjector {
                                             ast::DUMMY_NODE_ID),
             attrs: ~[],
             vis: ast::private,
-            span: dummy_sp()
+            span: DUMMY_SP
         }];
 
         if use_uv(&crate) && !self.sess.building_library.get() {
@@ -77,7 +77,7 @@ impl fold::ast_fold for StandardLibraryInjector {
                                                 ast::DUMMY_NODE_ID),
                 attrs: ~[],
                 vis: ast::private,
-                span: dummy_sp()
+                span: DUMMY_SP
             });
             vis.push(ast::view_item {
                 node: ast::view_item_extern_mod(self.sess.ident_of("rustuv"),
@@ -86,7 +86,7 @@ impl fold::ast_fold for StandardLibraryInjector {
                                                 ast::DUMMY_NODE_ID),
                 attrs: ~[],
                 vis: ast::private,
-                span: dummy_sp()
+                span: DUMMY_SP
             });
         }
 
@@ -121,7 +121,7 @@ impl fold::ast_fold for StandardLibraryInjector {
 
     fn fold_mod(&mut self, module: &ast::_mod) -> ast::_mod {
         let prelude_path = ast::Path {
-            span: dummy_sp(),
+            span: DUMMY_SP,
             global: false,
             segments: ~[
                 ast::PathSegment {
@@ -143,7 +143,7 @@ impl fold::ast_fold for StandardLibraryInjector {
             node: ast::view_item_use(~[vp]),
             attrs: ~[],
             vis: ast::private,
-            span: dummy_sp(),
+            span: DUMMY_SP,
         };
 
         let vis = vec::append(~[vi2], module.view_items);

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -19,7 +19,7 @@ use std::vec;
 use syntax::ast_util::*;
 use syntax::attr::AttrMetaMethods;
 use syntax::attr;
-use syntax::codemap::{dummy_sp, Span, ExpnInfo, NameAndSpan, MacroAttribute};
+use syntax::codemap::{DUMMY_SP, Span, ExpnInfo, NameAndSpan, MacroAttribute};
 use syntax::codemap;
 use syntax::ext::base::ExtCtxt;
 use syntax::fold::ast_fold;
@@ -164,7 +164,7 @@ fn generate_test_harness(sess: session::Session, crate: ast::Crate)
     };
 
     cx.ext_cx.bt_push(ExpnInfo {
-        call_site: dummy_sp(),
+        call_site: DUMMY_SP,
         callee: NameAndSpan {
             name: @"test",
             format: MacroAttribute,
@@ -298,7 +298,7 @@ fn mk_std(cx: &TestCtxt) -> ast::view_item {
         node: vi,
         attrs: ~[],
         vis: ast::public,
-        span: dummy_sp()
+        span: DUMMY_SP
     }
 }
 
@@ -335,7 +335,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
         id: ast::DUMMY_NODE_ID,
         node: item_,
         vis: ast::public,
-        span: dummy_sp(),
+        span: DUMMY_SP,
      };
 
     debug!("Synthetic test module:\n{}\n",
@@ -345,12 +345,12 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::item {
 }
 
 fn nospan<T>(t: T) -> codemap::Spanned<T> {
-    codemap::Spanned { node: t, span: dummy_sp() }
+    codemap::Spanned { node: t, span: DUMMY_SP }
 }
 
 fn path_node(ids: ~[ast::Ident]) -> ast::Path {
     ast::Path {
-        span: dummy_sp(),
+        span: DUMMY_SP,
         global: false,
         segments: ids.move_iter().map(|identifier| ast::PathSegment {
             identifier: identifier,
@@ -362,7 +362,7 @@ fn path_node(ids: ~[ast::Ident]) -> ast::Path {
 
 fn path_node_global(ids: ~[ast::Ident]) -> ast::Path {
     ast::Path {
-        span: dummy_sp(),
+        span: DUMMY_SP,
         global: true,
         segments: ids.move_iter().map(|identifier| ast::PathSegment {
             identifier: identifier,
@@ -403,13 +403,13 @@ fn mk_test_descs(cx: &TestCtxt) -> @ast::Expr {
     let inner_expr = @ast::Expr {
         id: ast::DUMMY_NODE_ID,
         node: ast::ExprVec(descs, ast::MutImmutable),
-        span: dummy_sp(),
+        span: DUMMY_SP,
     };
 
     @ast::Expr {
         id: ast::DUMMY_NODE_ID,
         node: ast::ExprVstore(inner_expr, ast::ExprVstoreSlice),
-        span: dummy_sp(),
+        span: DUMMY_SP,
     }
 }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -197,7 +197,7 @@ pub fn describe_debug_flags() {
 
 pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
     let mut args = args.to_owned();
-    let binary = args.shift().to_managed();
+    let binary = args.shift();
 
     if args.is_empty() { usage(binary); return; }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -348,7 +348,7 @@ struct RustcEmitter {
 
 impl diagnostic::Emitter for RustcEmitter {
     fn emit(&self,
-            cmsp: Option<(@codemap::CodeMap, codemap::Span)>,
+            cmsp: Option<(&codemap::CodeMap, codemap::Span)>,
             msg: &str,
             lvl: diagnostic::level) {
         if lvl == diagnostic::fatal {

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -21,7 +21,7 @@ use syntax::ast;
 use syntax::abi;
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
-use syntax::codemap::{Span, dummy_sp};
+use syntax::codemap::{Span, DUMMY_SP};
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::token;
 use syntax::parse::token::ident_interner;
@@ -346,7 +346,7 @@ fn resolve_crate_deps(e: &mut Env, cdata: &[u8]) -> cstore::cnum_map {
             // This is a new one so we've got to load it
             // FIXME (#2404): Need better error reporting than just a bogus
             // span.
-            let fake_span = dummy_sp();
+            let fake_span = DUMMY_SP;
             let local_cnum = resolve_crate(e, cname_str, cname_str, dep.vers,
                                            dep.hash, fake_span);
             cnum_map.insert(extrn_cnum, local_cnum);

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -22,7 +22,7 @@ use syntax::abi;
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::{Span, dummy_sp};
-use syntax::diagnostic::span_handler;
+use syntax::diagnostic::SpanHandler;
 use syntax::parse::token;
 use syntax::parse::token::ident_interner;
 use syntax::crateid::CrateId;
@@ -86,7 +86,7 @@ fn dump_crates(crate_cache: &[cache_entry]) {
 }
 
 fn warn_if_multiple_versions(e: &mut Env,
-                             diag: @mut span_handler,
+                             diag: @mut SpanHandler,
                              crate_cache: &[cache_entry]) {
     if crate_cache.len() != 0u {
         let name = crate_cache[crate_cache.len() - 1].crateid.name.clone();

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1099,7 +1099,7 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
                         value: meta_item,
                         is_sugared_doc: false,
                     },
-                    span: codemap::dummy_sp()
+                    span: codemap::DUMMY_SP
                 });
             true
         });

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -39,7 +39,7 @@ use syntax::ast_map;
 use syntax::ast_util::*;
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
-use syntax::diagnostic::span_handler;
+use syntax::diagnostic::SpanHandler;
 use syntax::parse::token::special_idents;
 use syntax::ast_util;
 use syntax::visit::Visitor;
@@ -57,7 +57,7 @@ pub type encode_inlined_item<'a> = 'a |ecx: &EncodeContext,
                                              ii: ast::inlined_item|;
 
 pub struct EncodeParams<'a> {
-    diag: @mut span_handler,
+    diag: @mut SpanHandler,
     tcx: ty::ctxt,
     reexports2: middle::resolve::ExportMap2,
     item_symbols: &'a RefCell<HashMap<ast::NodeId, ~str>>,
@@ -83,7 +83,7 @@ struct Stats {
 }
 
 pub struct EncodeContext<'a> {
-    diag: @mut span_handler,
+    diag: @mut SpanHandler,
     tcx: ty::ctxt,
     stats: @Stats,
     reexports2: middle::resolve::ExportMap2,

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -19,7 +19,7 @@ use metadata::encoder;
 use metadata::filesearch::{FileMatches, FileDoesntMatch};
 use metadata::filesearch;
 use syntax::codemap::Span;
-use syntax::diagnostic::span_handler;
+use syntax::diagnostic::SpanHandler;
 use syntax::parse::token::ident_interner;
 use syntax::crateid::CrateId;
 use syntax::attr;
@@ -231,8 +231,8 @@ impl Context {
     }
 }
 
-pub fn note_crateid_attr(diag: @mut span_handler,
-                       crateid: &CrateId) {
+pub fn note_crateid_attr(diag: @mut SpanHandler,
+                         crateid: &CrateId) {
     diag.handler().note(format!("crate_id: {}", crateid.to_str()));
 }
 

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -24,7 +24,7 @@ use middle::ty;
 use syntax::abi::AbiSet;
 use syntax::ast;
 use syntax::ast::*;
-use syntax::diagnostic::span_handler;
+use syntax::diagnostic::SpanHandler;
 use syntax::print::pprust::*;
 
 macro_rules! mywrite( ($wr:expr, $($arg:tt)*) => (
@@ -32,7 +32,7 @@ macro_rules! mywrite( ($wr:expr, $($arg:tt)*) => (
 ) )
 
 pub struct ctxt {
-    diag: @mut span_handler,
+    diag: @mut SpanHandler,
     // Def -> str Callback:
     ds: extern "Rust" fn(DefId) -> ~str,
     // The type context.

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -218,7 +218,7 @@ impl ExtendedDecodeContext {
         ast::DefId { crate: ast::LOCAL_CRATE, node: self.tr_id(did.node) }
     }
     pub fn tr_span(&self, _span: Span) -> Span {
-        codemap::dummy_sp() // FIXME (#1972): handle span properly
+        codemap::DUMMY_SP // FIXME (#1972): handle span properly
     }
 }
 

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -23,7 +23,7 @@ use std::num;
 use std::vec;
 use syntax::ast::*;
 use syntax::ast_util::{unguarded_pat, walk_pat};
-use syntax::codemap::{Span, dummy_sp, Spanned};
+use syntax::codemap::{Span, DUMMY_SP, Spanned};
 use syntax::visit;
 use syntax::visit::{Visitor,fn_kind};
 
@@ -536,11 +536,11 @@ fn ctor_arity(cx: &MatchCheckCtxt, ctor: &ctor, ty: ty::t) -> uint {
 }
 
 fn wild() -> @Pat {
-    @Pat {id: 0, node: PatWild, span: dummy_sp()}
+    @Pat {id: 0, node: PatWild, span: DUMMY_SP}
 }
 
 fn wild_multi() -> @Pat {
-    @Pat {id: 0, node: PatWildMulti, span: dummy_sp()}
+    @Pat {id: 0, node: PatWildMulti, span: DUMMY_SP}
 }
 
 fn specialize(cx: &MatchCheckCtxt,

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -24,7 +24,7 @@ use syntax::parse::token;
 use syntax::parse::token::{ident_interner, interner_get};
 use syntax::parse::token::special_idents;
 use syntax::print::pprust::path_to_str;
-use syntax::codemap::{Span, dummy_sp, Pos};
+use syntax::codemap::{Span, DUMMY_SP, Pos};
 use syntax::opt_vec::OptVec;
 use syntax::visit;
 use syntax::visit::Visitor;
@@ -1643,7 +1643,7 @@ impl Resolver {
                                                   NormalModuleKind,
                                                   true,
                                                   is_public,
-                                                  dummy_sp());
+                                                  DUMMY_SP);
               }
             }
           }
@@ -1661,16 +1661,16 @@ impl Resolver {
             // public.
             let is_public = vis != ast::private;
             if is_struct {
-                child_name_bindings.define_type(def, dummy_sp(), is_public);
+                child_name_bindings.define_type(def, DUMMY_SP, is_public);
                 self.structs.insert(variant_id);
             } else {
-                child_name_bindings.define_value(def, dummy_sp(), is_public);
+                child_name_bindings.define_value(def, DUMMY_SP, is_public);
             }
           }
           DefFn(..) | DefStaticMethod(..) | DefStatic(..) => {
             debug!("(building reduced graph for external \
                     crate) building value (fn/static) {}", final_ident);
-            child_name_bindings.define_value(def, dummy_sp(), is_public);
+            child_name_bindings.define_value(def, DUMMY_SP, is_public);
           }
           DefTrait(def_id) => {
               debug!("(building reduced graph for external \
@@ -1711,7 +1711,7 @@ impl Resolver {
                   }
               }
 
-              child_name_bindings.define_type(def, dummy_sp(), is_public);
+              child_name_bindings.define_type(def, DUMMY_SP, is_public);
 
               // Define a module if necessary.
               let parent_link = self.get_parent_link(new_parent, ident);
@@ -1720,21 +1720,21 @@ impl Resolver {
                                                   TraitModuleKind,
                                                   true,
                                                   is_public,
-                                                  dummy_sp())
+                                                  DUMMY_SP)
           }
           DefTy(_) => {
               debug!("(building reduced graph for external \
                       crate) building type {}", final_ident);
 
-              child_name_bindings.define_type(def, dummy_sp(), is_public);
+              child_name_bindings.define_type(def, DUMMY_SP, is_public);
           }
           DefStruct(def_id) => {
             debug!("(building reduced graph for external \
                     crate) building type and value for {}",
                    final_ident);
-            child_name_bindings.define_type(def, dummy_sp(), is_public);
+            child_name_bindings.define_type(def, DUMMY_SP, is_public);
             if csearch::get_struct_fields(self.session.cstore, def_id).len() == 0 {
-                child_name_bindings.define_value(def, dummy_sp(), is_public);
+                child_name_bindings.define_value(def, DUMMY_SP, is_public);
             }
             self.structs.insert(def_id);
           }
@@ -1782,7 +1782,7 @@ impl Resolver {
                             self.add_child(ident,
                                            ModuleReducedGraphParent(root),
                                            OverwriteDuplicates,
-                                           dummy_sp());
+                                           DUMMY_SP);
 
                         self.handle_external_def(def,
                                                  visibility,
@@ -1814,7 +1814,7 @@ impl Resolver {
                                         final_ident,
                                         ModuleReducedGraphParent(root),
                                         OverwriteDuplicates,
-                                        dummy_sp());
+                                        DUMMY_SP);
 
                                 // Process the static methods. First,
                                 // create the module.
@@ -1842,7 +1842,7 @@ impl Resolver {
                                             ImplModuleKind,
                                             true,
                                             true,
-                                            dummy_sp());
+                                            DUMMY_SP);
                                         type_module =
                                             child_name_bindings.
                                                 get_module();
@@ -1864,13 +1864,13 @@ impl Resolver {
                                         self.add_child(ident,
                                                        new_parent,
                                                        OverwriteDuplicates,
-                                                       dummy_sp());
+                                                       DUMMY_SP);
                                     let def = DefFn(
                                         static_method_info.def_id,
                                         static_method_info.purity);
 
                                     method_name_bindings.define_value(
-                                        def, dummy_sp(),
+                                        def, DUMMY_SP,
                                         visibility == ast::public);
                                 }
                             }
@@ -5576,7 +5576,7 @@ impl Resolver {
         // because this means that they were generated in some fashion by the
         // compiler and we don't need to consider them.
         if vi.vis == public { return }
-        if vi.span == dummy_sp() { return }
+        if vi.span == DUMMY_SP { return }
 
         match vi.node {
             view_item_extern_mod(..) => {} // ignore

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -227,7 +227,7 @@ use syntax::ast;
 use syntax::ast::Ident;
 use syntax::ast_util::path_to_ident;
 use syntax::ast_util;
-use syntax::codemap::{Span, dummy_sp};
+use syntax::codemap::{Span, DUMMY_SP};
 
 // An option identifying a literal: either a unit-like struct or an
 // expression.
@@ -617,7 +617,7 @@ fn enter_opt<'r>(bcx: @Block,
     let _indenter = indenter();
 
     let tcx = bcx.tcx();
-    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: dummy_sp()};
+    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: DUMMY_SP};
     let mut i = 0;
     enter_match(bcx, tcx.def_map, m, col, val, |p| {
         let answer = match p.node {
@@ -758,7 +758,7 @@ fn enter_rec_or_struct<'r>(bcx: @Block,
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: dummy_sp()};
+    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: DUMMY_SP};
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatStruct(_, ref fpats, _) => {
@@ -793,7 +793,7 @@ fn enter_tup<'r>(bcx: @Block,
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: dummy_sp()};
+    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: DUMMY_SP};
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatTup(ref elts) => Some((*elts).clone()),
@@ -819,7 +819,7 @@ fn enter_tuple_struct<'r>(bcx: @Block,
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: dummy_sp()};
+    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: DUMMY_SP};
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatEnum(_, Some(ref elts)) => Some((*elts).clone()),
@@ -844,7 +844,7 @@ fn enter_box<'r>(bcx: @Block,
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: dummy_sp()};
+    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: DUMMY_SP};
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatBox(sub) => {
@@ -871,7 +871,7 @@ fn enter_uniq<'r>(bcx: @Block,
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: dummy_sp()};
+    let dummy = @ast::Pat {id: 0, node: ast::PatWild, span: DUMMY_SP};
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatUniq(sub) => {
@@ -898,7 +898,7 @@ fn enter_region<'r>(bcx: @Block,
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let dummy = @ast::Pat { id: 0, node: ast::PatWild, span: dummy_sp() };
+    let dummy = @ast::Pat { id: 0, node: ast::PatWild, span: DUMMY_SP };
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatRegion(sub) => {
@@ -1535,7 +1535,7 @@ fn compile_submatch_continue(mut bcx: @Block,
                                 vals.slice(col + 1u, vals.len()));
     let ccx = bcx.fcx.ccx;
     let mut pat_id = 0;
-    let mut pat_span = dummy_sp();
+    let mut pat_span = DUMMY_SP;
     for br in m.iter() {
         // Find a real id (we're adding placeholder wildcard patterns, but
         // each column is guaranteed to have at least one real pattern)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2107,7 +2107,7 @@ pub fn trans_enum_variant_or_tuple_like_struct<A:IdAndTy>(
             ty: varg.ty(),
             pat: ast_util::ident_to_pat(
                 ccx.tcx.sess.next_node_id(),
-                codemap::dummy_sp(),
+                codemap::DUMMY_SP,
                 special_idents::arg),
             id: varg.id(),
         }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -678,7 +678,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
     };
 
     // This can be the case for functions inlined from another crate
-    if span == codemap::dummy_sp() {
+    if span == codemap::DUMMY_SP {
         return FunctionWithoutDebugInfo;
     }
 
@@ -797,7 +797,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
                     }
                 };
 
-                signature.push(type_metadata(cx, return_type, codemap::dummy_sp()));
+                signature.push(type_metadata(cx, return_type, codemap::DUMMY_SP));
             }
         }
 
@@ -812,7 +812,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
                 }
             };
 
-            signature.push(type_metadata(cx, arg_type, codemap::dummy_sp()));
+            signature.push(type_metadata(cx, arg_type, codemap::DUMMY_SP));
         }
 
         return create_DIArray(DIB(cx), signature);
@@ -856,7 +856,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
             if cx.sess.opts.extra_debuginfo {
                 let actual_self_type_metadata = type_metadata(cx,
                                                               actual_self_type,
-                                                              codemap::dummy_sp());
+                                                              codemap::DUMMY_SP);
 
                 let ident = special_idents::type_self;
 
@@ -897,7 +897,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
 
             // Again, only create type information if extra_debuginfo is enabled
             if cx.sess.opts.extra_debuginfo {
-                let actual_type_metadata = type_metadata(cx, actual_type, codemap::dummy_sp());
+                let actual_type_metadata = type_metadata(cx, actual_type, codemap::DUMMY_SP);
                 let param_metadata = token::ident_to_str(&ident).with_c_str(|name| {
                     unsafe {
                         llvm::LLVMDIBuilderCreateTemplateTypeParameter(
@@ -1271,7 +1271,7 @@ impl RecursiveTypeDescription {
                                               llvm_type,
                                               member_descriptions,
                                               file_metadata,
-                                              codemap::dummy_sp());
+                                              codemap::DUMMY_SP);
                 return metadata_stub;
             }
         }
@@ -1364,7 +1364,7 @@ impl MemberDescriptionFactory for GeneralMemberDescriptionFactory {
                                               variant_llvm_type,
                                               member_descriptions,
                                               self.file_metadata,
-                                              codemap::dummy_sp());
+                                              codemap::DUMMY_SP);
                 MemberDescription {
                     name: @"",
                     llvm_type: variant_llvm_type,
@@ -1419,12 +1419,12 @@ fn describe_variant(cx: &CrateContext,
                 cx.sess.span_warn(span,
                     format!("debuginfo::enum_metadata()::adt_struct_metadata() - Unexpected node \
                           type: {:?}. This is a bug.", node));
-                codemap::dummy_sp()
+                codemap::DUMMY_SP
             }
         }
     } else {
         // For definitions from other crates we have no location information available.
-        codemap::dummy_sp()
+        codemap::DUMMY_SP
     };
 
     let metadata_stub = create_struct_stub(cx,
@@ -1511,7 +1511,7 @@ fn prepare_enum_metadata(cx: &CrateContext,
         let discriminant_llvm_type = adt::ll_inttype(cx, inttype);
         let (discriminant_size, discriminant_align) = size_and_align_of(cx, discriminant_llvm_type);
         let discriminant_base_type_metadata = type_metadata(cx, adt::ty_of_inttype(inttype),
-                                                            codemap::dummy_sp());
+                                                            codemap::DUMMY_SP);
         enum_name.with_c_str(|enum_name| {
             unsafe {
                 llvm::LLVMDIBuilderCreateEnumerationType(
@@ -1773,13 +1773,13 @@ fn boxed_type_metadata(cx: &CrateContext,
 
     let int_type = ty::mk_int();
     let nil_pointer_type = ty::mk_nil_ptr(cx.tcx);
-    let nil_pointer_type_metadata = type_metadata(cx, nil_pointer_type, codemap::dummy_sp());
+    let nil_pointer_type_metadata = type_metadata(cx, nil_pointer_type, codemap::DUMMY_SP);
 
     let member_descriptions = [
         MemberDescription {
             name: @"refcnt",
             llvm_type: member_llvm_types[0],
-            type_metadata: type_metadata(cx, int_type, codemap::dummy_sp()),
+            type_metadata: type_metadata(cx, int_type, codemap::DUMMY_SP),
             offset: ComputedMemberOffset,
         },
         MemberDescription {
@@ -2086,14 +2086,14 @@ fn type_metadata(cx: &CrateContext,
         let content_type_metadata = type_metadata(
             cx,
             type_in_box,
-            codemap::dummy_sp());
+            codemap::DUMMY_SP);
 
         let box_metadata = boxed_type_metadata(
             cx,
             Some(content_type_name),
             content_llvm_type,
             content_type_metadata,
-            codemap::dummy_sp());
+            codemap::DUMMY_SP);
 
         pointer_type_metadata(cx, pointer_type, box_metadata)
     }
@@ -2294,13 +2294,13 @@ fn get_namespace_and_span_for_item(cx: &CrateContext,
                 cx.sess.span_warn(warning_span,
                     format!("debuginfo::get_namespace_and_span_for_item() \
                              - Unexpected node type: {:?}", *node));
-                codemap::dummy_sp()
+                codemap::DUMMY_SP
             }
         };
         definition_span
     } else {
         // For external items there is no span information
-        codemap::dummy_sp()
+        codemap::DUMMY_SP
     };
 
     (containing_scope, definition_span)

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -267,7 +267,7 @@ pub type ctxt = @ctxt_;
 /// generates so that so that it can be reused and doesn't have to be redone
 /// later on.
 struct ctxt_ {
-    diag: @mut syntax::diagnostic::span_handler,
+    diag: @mut syntax::diagnostic::SpanHandler,
     interner: RefCell<HashMap<intern_key, ~t_box_>>,
     next_id: Cell<uint>,
     cstore: @metadata::cstore::CStore,

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -326,7 +326,7 @@ pub fn can_mk_subty(cx: @InferCtxt, a: ty::t, b: ty::t) -> ures {
     indent(|| {
         cx.probe(|| {
             let trace = TypeTrace {
-                origin: Misc(codemap::dummy_sp()),
+                origin: Misc(codemap::DUMMY_SP),
                 values: Types(expected_found(true, a, b))
             };
             cx.sub(true, trace).tys(a, b)
@@ -418,7 +418,7 @@ pub fn can_mk_coercety(cx: @InferCtxt, a: ty::t, b: ty::t) -> ures {
     indent(|| {
         cx.probe(|| {
             let trace = TypeTrace {
-                origin: Misc(codemap::dummy_sp()),
+                origin: Misc(codemap::DUMMY_SP),
                 values: Types(expected_found(true, a, b))
             };
             Coerce(cx.combine_fields(true, trace)).tys(a, b)
@@ -927,7 +927,7 @@ impl RegionVariableOrigin {
             BoundRegionInFnCall(a, _) => a,
             BoundRegionInFnType(a, _) => a,
             BoundRegionInTypeOrImpl(a) => a,
-            BoundRegionInCoherence => codemap::dummy_sp(),
+            BoundRegionInCoherence => codemap::DUMMY_SP,
         }
     }
 }

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -29,7 +29,7 @@ use extra::getopts::{opt_present};
 use extra::getopts;
 use extra::getopts;
 use extra::oldmap::HashMap;
-use syntax::codemap::dummy_sp;
+use syntax::codemap::DUMMY_SP;
 use syntax::parse::parse_crate_from_source_str;
 use syntax::{ast, attr, parse};
 
@@ -221,9 +221,9 @@ impl Env {
         ty::mk_imm_rptr(self.tcx, ty::ReStatic, self.t_int())
     }
 
-    pub fn lub() -> Lub { Lub(self.infcx.combine_fields(true, dummy_sp())) }
+    pub fn lub() -> Lub { Lub(self.infcx.combine_fields(true, DUMMY_SP)) }
 
-    pub fn glb() -> Glb { Glb(self.infcx.combine_fields(true, dummy_sp())) }
+    pub fn glb() -> Glb { Glb(self.infcx.combine_fields(true, DUMMY_SP)) }
 
     pub fn resolve_regions(exp_count: uint) {
         debug!("resolve_regions(%u)", exp_count);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -49,7 +49,7 @@ fn get_ast_and_resolve(cpath: &Path,
     let input = file_input(cpath.clone());
 
     let sessopts = @driver::session::options {
-        binary: @"rustdoc",
+        binary: ~"rustdoc",
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: @RefCell::new(libs),
         outputs: ~[driver::session::OutputDylib],

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -40,7 +40,7 @@ impl Module {
             name       : name,
             id: 0,
             vis: ast::private,
-            where: syntax::codemap::dummy_sp(),
+            where: syntax::codemap::DUMMY_SP,
             attrs      : ~[],
             structs    : ~[],
             enums      : ~[],

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -38,7 +38,7 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
     let libs = @RefCell::new(libs.move_iter().collect());
 
     let sessopts = @session::options {
-        binary: @"rustdoc",
+        binary: ~"rustdoc",
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: libs,
         outputs: ~[session::OutputDylib],
@@ -98,7 +98,7 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>) {
     let input = driver::str_input(test);
 
     let sessopts = @session::options {
-        binary: @"rustdoctest",
+        binary: ~"rustdoctest",
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: @RefCell::new(libs),
         outputs: ~[session::OutputExecutable],

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -101,7 +101,7 @@ impl<'a> PkgScript<'a> {
                  workspace: &Path,
                  id: &'a CrateId) -> PkgScript<'a> {
         // Get the executable name that was invoked
-        let binary = os::args()[0].to_managed();
+        let binary = os::args()[0].to_owned();
         // Build the rustc session data structures to pass
         // to the compiler
         debug!("pkgscript parse: {}", sysroot.display());

--- a/src/librustpkg/tests.rs
+++ b/src/librustpkg/tests.rs
@@ -1823,7 +1823,7 @@ fn test_linker_build() {
     let workspace = create_local_package(&p_id);
     let workspace = workspace.path();
     let matches = getopts([], optgroups());
-    let options = build_session_options(@"rustpkg",
+    let options = build_session_options(~"rustpkg",
                                         matches.as_ref().unwrap(),
                                         @diagnostic::DefaultEmitter as
                                             @diagnostic::Emitter);

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -19,7 +19,7 @@ use extra::workcache;
 use rustc::driver::{driver, session};
 use extra::getopts::groups::getopts;
 use syntax::ast_util::*;
-use syntax::codemap::{dummy_sp, Spanned};
+use syntax::codemap::{DUMMY_SP, Spanned};
 use syntax::ext::base::ExtCtxt;
 use syntax::{ast, attr, codemap, diagnostic, fold, visit};
 use syntax::attr::AttrMetaMethods;
@@ -631,7 +631,7 @@ pub fn find_and_install_dependencies(context: &BuildContext,
 pub fn mk_string_lit(s: @str) -> ast::lit {
     Spanned {
         node: ast::lit_str(s, ast::CookedStr),
-        span: dummy_sp()
+        span: DUMMY_SP
     }
 }
 

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -189,7 +189,7 @@ pub fn compile_input(context: &BuildContext,
     // Make the output directory if it doesn't exist already
     fs::mkdir_recursive(&out_dir, io::UserRWX);
 
-    let binary = os::args()[0].to_managed();
+    let binary = os::args()[0].to_owned();
 
     debug!("flags: {}", flags.connect(" "));
     debug!("cfgs: {}", cfgs.connect(" "));

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -15,7 +15,7 @@ use ast_util::{inlined_item_utils, stmt_id};
 use ast_util;
 use codemap::Span;
 use codemap;
-use diagnostic::span_handler;
+use diagnostic::SpanHandler;
 use parse::token::get_ident_interner;
 use parse::token::ident_interner;
 use parse::token::special_idents;
@@ -152,7 +152,7 @@ pub type map = @mut HashMap<NodeId, ast_node>;
 pub struct Ctx {
     map: map,
     path: path,
-    diag: @mut span_handler,
+    diag: @mut SpanHandler,
 }
 
 impl Ctx {
@@ -373,7 +373,7 @@ impl Visitor<()> for Ctx {
     }
 }
 
-pub fn map_crate(diag: @mut span_handler, c: &Crate) -> map {
+pub fn map_crate(diag: @mut SpanHandler, c: &Crate) -> map {
     let cx = @mut Ctx {
         map: @mut HashMap::new(),
         path: ~[],
@@ -386,7 +386,7 @@ pub fn map_crate(diag: @mut span_handler, c: &Crate) -> map {
 // Used for items loaded from external crate that are being inlined into this
 // crate.  The `path` should be the path to the item but should not include
 // the item itself.
-pub fn map_decoded_item(diag: @mut span_handler,
+pub fn map_decoded_item(diag: @mut SpanHandler,
                         map: map,
                         path: path,
                         ii: &inlined_item) {

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -14,7 +14,7 @@ use ast;
 use ast::{Attribute, Attribute_, MetaItem, MetaWord, MetaNameValue, MetaList};
 use codemap::{Span, Spanned, spanned, dummy_spanned};
 use codemap::BytePos;
-use diagnostic::span_handler;
+use diagnostic::SpanHandler;
 use parse::comments::{doc_comment_style, strip_doc_comment_decoration};
 use crateid::CrateId;
 
@@ -355,7 +355,7 @@ pub fn find_stability<AM: AttrMetaMethods, It: Iterator<AM>>(mut metas: It) -> O
     None
 }
 
-pub fn require_unique_names(diagnostic: @mut span_handler,
+pub fn require_unique_names(diagnostic: @mut SpanHandler,
                             metas: &[@MetaItem]) {
     let mut set = HashSet::new();
     for meta in metas.iter() {
@@ -381,7 +381,7 @@ pub fn require_unique_names(diagnostic: @mut span_handler,
  * present (before fields, if any) with that type; reprensentation
  * optimizations which would remove it will not be done.
  */
-pub fn find_repr_attr(diagnostic: @mut span_handler, attr: @ast::MetaItem, acc: ReprAttr)
+pub fn find_repr_attr(diagnostic: @mut SpanHandler, attr: @ast::MetaItem, acc: ReprAttr)
     -> ReprAttr {
     let mut acc = acc;
     match attr.node {

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -90,6 +90,8 @@ pub struct Span {
     expn_info: Option<@ExpnInfo>
 }
 
+pub static DUMMY_SP: Span = Span { lo: BytePos(0), hi: BytePos(0), expn_info: None };
+
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub struct Spanned<T> {
     node: T,
@@ -112,7 +114,7 @@ impl<S:Encoder> Encodable<S> for Span {
 
 impl<D:Decoder> Decodable<D> for Span {
     fn decode(_d: &mut D) -> Span {
-        dummy_sp()
+        DUMMY_SP
     }
 }
 
@@ -125,18 +127,13 @@ pub fn respan<T>(sp: Span, t: T) -> Spanned<T> {
 }
 
 pub fn dummy_spanned<T>(t: T) -> Spanned<T> {
-    respan(dummy_sp(), t)
+    respan(DUMMY_SP, t)
 }
 
 /* assuming that we're not in macro expansion */
 pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
     Span {lo: lo, hi: hi, expn_info: None}
 }
-
-// make this a const, once the compiler supports it
-pub fn dummy_sp() -> Span { return mk_sp(BytePos(0), BytePos(0)); }
-
-
 
 /// A source code location used for error reporting
 pub struct Loc {
@@ -350,7 +347,7 @@ impl CodeMap {
 
     pub fn span_to_str(&self, sp: Span) -> ~str {
         let files = &*self.files;
-        if files.len() == 0 && sp == dummy_sp() {
+        if files.len() == 0 && sp == DUMMY_SP {
             return ~"no-location";
         }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -12,7 +12,6 @@ use ast;
 use ast::Name;
 use codemap;
 use codemap::{CodeMap, Span, ExpnInfo};
-use diagnostic::span_handler;
 use ext;
 use ext::expand;
 use parse;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -12,7 +12,7 @@ use abi::AbiSet;
 use ast::{P, Ident};
 use ast;
 use ast_util;
-use codemap::{Span, respan, dummy_sp};
+use codemap::{Span, respan, DUMMY_SP};
 use ext::base::ExtCtxt;
 use ext::quote::rt::*;
 use fold::ast_fold;
@@ -321,7 +321,7 @@ impl AstBuilder for ExtCtxt {
 
     fn ty_option(&self, ty: P<ast::Ty>) -> P<ast::Ty> {
         self.ty_path(
-            self.path_all(dummy_sp(),
+            self.path_all(DUMMY_SP,
                           true,
                           ~[
                               self.ident_of("std"),
@@ -348,7 +348,7 @@ impl AstBuilder for ExtCtxt {
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
             node: ast::ty_nil,
-            span: dummy_sp(),
+            span: DUMMY_SP,
         })
     }
 
@@ -361,13 +361,13 @@ impl AstBuilder for ExtCtxt {
     // incorrect code.
     fn ty_vars(&self, ty_params: &OptVec<ast::TyParam>) -> ~[P<ast::Ty>] {
         opt_vec::take_vec(
-            ty_params.map(|p| self.ty_ident(dummy_sp(), p.ident)))
+            ty_params.map(|p| self.ty_ident(DUMMY_SP, p.ident)))
     }
 
     fn ty_vars_global(&self, ty_params: &OptVec<ast::TyParam>) -> ~[P<ast::Ty>] {
         opt_vec::take_vec(
             ty_params.map(|p| self.ty_path(
-                self.path_global(dummy_sp(), ~[p.ident]), None)))
+                self.path_global(DUMMY_SP, ~[p.ident]), None)))
     }
 
     fn strip_bounds(&self, generics: &Generics) -> Generics {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1279,12 +1279,12 @@ mod test {
     // make a MetaWord outer attribute with the given name
     fn make_dummy_attr(s: @str) -> ast::Attribute {
         Spanned {
-            span:codemap::dummy_sp(),
+            span:codemap::DUMMY_SP,
             node: Attribute_ {
                 style: AttrOuter,
                 value: @Spanned {
                     node: MetaWord(s),
-                    span: codemap::dummy_sp(),
+                    span: codemap::DUMMY_SP,
                 },
                 is_sugared_doc: false,
             }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -11,7 +11,7 @@
 use ast::{Ident, matcher_, matcher, match_tok, match_nonterminal, match_seq};
 use ast::{tt_delim};
 use ast;
-use codemap::{Span, Spanned, dummy_sp};
+use codemap::{Span, Spanned, DUMMY_SP};
 use ext::base::{AnyMacro, ExtCtxt, MacResult, MRAny, MRDef, MacroDef};
 use ext::base::{NormalTT, SyntaxExpanderTTTrait};
 use ext::base;
@@ -109,7 +109,7 @@ fn generic_extension(cx: &ExtCtxt,
     }
 
     // Which arm's failure should we report? (the one furthest along)
-    let mut best_fail_spot = dummy_sp();
+    let mut best_fail_spot = DUMMY_SP;
     let mut best_fail_msg = ~"internal error: ran no matchers";
 
     let s_d = cx.parse_sess().span_diagnostic;
@@ -178,7 +178,7 @@ pub fn add_new_extension(cx: &mut ExtCtxt,
     fn ms(m: matcher_) -> matcher {
         Spanned {
             node: m.clone(),
-            span: dummy_sp()
+            span: DUMMY_SP
         }
     }
 

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -10,7 +10,7 @@
 
 use ast;
 use ast::{token_tree, tt_delim, tt_tok, tt_seq, tt_nonterminal,Ident};
-use codemap::{Span, dummy_sp};
+use codemap::{Span, DUMMY_SP};
 use diagnostic::SpanHandler;
 use ext::tt::macro_parser::{named_match, matched_seq, matched_nonterminal};
 use parse::token::{EOF, INTERPOLATED, IDENT, Token, nt_ident};
@@ -66,7 +66,7 @@ pub fn new_tt_reader(sp_diag: @mut SpanHandler,
         repeat_len: ~[],
         /* dummy values, never read: */
         cur_tok: EOF,
-        cur_span: dummy_sp()
+        cur_span: DUMMY_SP
     };
     tt_next_token(r); /* get cur_tok and cur_span set up */
     return r;

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -11,7 +11,7 @@
 use ast;
 use ast::{token_tree, tt_delim, tt_tok, tt_seq, tt_nonterminal,Ident};
 use codemap::{Span, dummy_sp};
-use diagnostic::span_handler;
+use diagnostic::SpanHandler;
 use ext::tt::macro_parser::{named_match, matched_seq, matched_nonterminal};
 use parse::token::{EOF, INTERPOLATED, IDENT, Token, nt_ident};
 use parse::token::{ident_to_str};
@@ -30,7 +30,7 @@ struct TtFrame {
 }
 
 pub struct TtReader {
-    sp_diag: @mut span_handler,
+    sp_diag: @mut SpanHandler,
     // the unzipped tree:
     stack: @mut TtFrame,
     /* for MBE-style macro transcription */
@@ -45,7 +45,7 @@ pub struct TtReader {
 /** This can do Macro-By-Example transcription. On the other hand, if
  *  `src` contains no `tt_seq`s and `tt_nonterminal`s, `interp` can (and
  *  should) be none. */
-pub fn new_tt_reader(sp_diag: @mut span_handler,
+pub fn new_tt_reader(sp_diag: @mut SpanHandler,
                      interp: Option<HashMap<Ident,@named_match>>,
                      src: ~[ast::token_tree])
                   -> @mut TtReader {

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -342,7 +342,7 @@ pub struct lit {
 // it appears this function is called only from pprust... that's
 // probably not a good thing.
 pub fn gather_comments_and_literals(span_diagnostic:
-                                    @mut diagnostic::span_handler,
+                                    @mut diagnostic::SpanHandler,
                                     path: @str,
                                     srdr: &mut io::Reader)
                                  -> (~[cmnt], ~[lit]) {

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -81,7 +81,7 @@ pub fn new_low_level_string_reader(span_diagnostic: @mut SpanHandler,
         filemap: filemap,
         /* dummy values; not read */
         peek_tok: token::EOF,
-        peek_span: codemap::dummy_sp()
+        peek_span: codemap::DUMMY_SP
     };
     bump(r);
     return r;

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -11,7 +11,7 @@
 use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos, Span};
 use codemap;
-use diagnostic::span_handler;
+use diagnostic::SpanHandler;
 use ext::tt::transcribe::{tt_next_token};
 use ext::tt::transcribe::{dup_tt_reader};
 use parse::token;
@@ -29,7 +29,7 @@ pub trait reader {
     fn is_eof(@mut self) -> bool;
     fn next_token(@mut self) -> TokenAndSpan;
     fn fatal(@mut self, ~str) -> !;
-    fn span_diag(@mut self) -> @mut span_handler;
+    fn span_diag(@mut self) -> @mut SpanHandler;
     fn peek(@mut self) -> TokenAndSpan;
     fn dup(@mut self) -> @mut reader;
 }
@@ -41,7 +41,7 @@ pub struct TokenAndSpan {
 }
 
 pub struct StringReader {
-    span_diagnostic: @mut span_handler,
+    span_diagnostic: @mut SpanHandler,
     src: @str,
     // The absolute offset within the codemap of the next character to read
     pos: BytePos,
@@ -57,7 +57,7 @@ pub struct StringReader {
     peek_span: Span
 }
 
-pub fn new_string_reader(span_diagnostic: @mut span_handler,
+pub fn new_string_reader(span_diagnostic: @mut SpanHandler,
                          filemap: @codemap::FileMap)
                       -> @mut StringReader {
     let r = new_low_level_string_reader(span_diagnostic, filemap);
@@ -66,7 +66,7 @@ pub fn new_string_reader(span_diagnostic: @mut span_handler,
 }
 
 /* For comments.rs, which hackily pokes into 'pos' and 'curr' */
-pub fn new_low_level_string_reader(span_diagnostic: @mut span_handler,
+pub fn new_low_level_string_reader(span_diagnostic: @mut SpanHandler,
                                    filemap: @codemap::FileMap)
                                 -> @mut StringReader {
     // Force the initial reader bump to start on a fresh line
@@ -118,7 +118,7 @@ impl reader for StringReader {
     fn fatal(@mut self, m: ~str) -> ! {
         self.span_diagnostic.span_fatal(self.peek_span, m)
     }
-    fn span_diag(@mut self) -> @mut span_handler { self.span_diagnostic }
+    fn span_diag(@mut self) -> @mut SpanHandler { self.span_diagnostic }
     fn peek(@mut self) -> TokenAndSpan {
         // XXX(pcwalton): Bad copy!
         TokenAndSpan {
@@ -139,7 +139,7 @@ impl reader for TtReader {
     fn fatal(@mut self, m: ~str) -> ! {
         self.sp_diag.span_fatal(self.cur_span, m);
     }
-    fn span_diag(@mut self) -> @mut span_handler { self.sp_diag }
+    fn span_diag(@mut self) -> @mut SpanHandler { self.sp_diag }
     fn peek(@mut self) -> TokenAndSpan {
         TokenAndSpan {
             tok: self.cur_tok.clone(),

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -14,7 +14,7 @@
 use ast;
 use codemap::{Span, CodeMap, FileMap, FileSubstr};
 use codemap;
-use diagnostic::{span_handler, mk_span_handler, mk_handler, Emitter};
+use diagnostic::{SpanHandler, mk_span_handler, mk_handler, Emitter};
 use parse::attr::parser_attr;
 use parse::lexer::reader;
 use parse::parser::Parser;
@@ -41,7 +41,7 @@ pub mod obsolete;
 // info about a parsing session.
 pub struct ParseSess {
     cm: @codemap::CodeMap, // better be the same as the one in the reader!
-    span_diagnostic: @mut span_handler, // better be the same as the one in the reader!
+    span_diagnostic: @mut SpanHandler, // better be the same as the one in the reader!
     /// Used to determine and report recursive mod inclusions
     included_mod_stack: ~[Path],
 }
@@ -55,7 +55,7 @@ pub fn new_parse_sess(demitter: Option<@Emitter>) -> @mut ParseSess {
     }
 }
 
-pub fn new_parse_sess_special_handler(sh: @mut span_handler,
+pub fn new_parse_sess_special_handler(sh: @mut SpanHandler,
                                       cm: @codemap::CodeMap)
                                    -> @mut ParseSess {
     @mut ParseSess {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -118,7 +118,7 @@ pub static default_columns: uint = 78u;
 // copy forward.
 pub fn print_crate(cm: @CodeMap,
                    intr: @ident_interner,
-                   span_diagnostic: @mut diagnostic::span_handler,
+                   span_diagnostic: @mut diagnostic::SpanHandler,
                    crate: &ast::Crate,
                    filename: @str,
                    input: @mut io::Reader,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2422,7 +2422,7 @@ mod test {
             inputs: ~[],
             output: ast::P(ast::Ty {id: 0,
                                     node: ast::ty_nil,
-                                    span: codemap::dummy_sp()}),
+                                    span: codemap::DUMMY_SP}),
             cf: ast::return_val,
             variadic: false
         };
@@ -2436,7 +2436,7 @@ mod test {
     fn test_variant_to_str() {
         let ident = token::str_to_ident("principal_skinner");
 
-        let var = codemap::respan(codemap::dummy_sp(), ast::variant_ {
+        let var = codemap::respan(codemap::DUMMY_SP, ast::variant_ {
             name: ident,
             attrs: ~[],
             // making this up as I go.... ?


### PR DESCRIPTION
This patchset removes some `@`s and unnecessary traits,
and replaces a function (`dummy_sp()`) returning constant value
by static variable.
