### PR TITLE
Add linting for `crate_type` attribute values.

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -167,7 +167,7 @@ pub fn phase_2_configure_and_expand(sess: Session,
     let time_passes = sess.time_passes();
 
     sess.building_library.set(session::building_library(sess.opts, &crate));
-    sess.outputs.set(session::collect_outputs(sess.opts, crate.attrs));
+    sess.outputs.set(session::collect_outputs(&sess, crate.attrs));
 
     time(time_passes, "gated feature checking", (), |_|
          front::feature_gate::check_crate(sess, &crate));

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -309,7 +309,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
         if crate_file_name {
             let lm = link::build_link_meta(sess, attrs, &t_outputs.obj_filename,
                                            &mut ::util::sha2::Sha256::new());
-            let outputs = session::collect_outputs(sopts, attrs);
+            let outputs = session::collect_outputs(&sess, attrs);
             for &style in outputs.iter() {
                 let fname = link::filename_for_input(&sess, style, &lm,
                                                      &t_outputs.out_filename);

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -80,6 +80,7 @@ pub enum lint {
     unsafe_block,
     attribute_usage,
     unknown_features,
+    unknown_crate_type,
 
     managed_heap_memory,
     owned_heap_memory,
@@ -335,6 +336,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
         desc: "unknown features found in create-level #[feature] directives",
         default: deny,
     }),
+
+     ("unknown_crate_type",
+     LintSpec {
+         lint: unknown_crate_type,
+         desc: "unknown crate type found in #[crate_type] directive",
+         default: deny,
+     }),
 ];
 
 /*

--- a/src/test/compile-fail/invalid-crate-type.rs
+++ b/src/test/compile-fail/invalid-crate-type.rs
@@ -1,0 +1,6 @@
+// regression test for issue 11256
+#[crate_type="foo"];    //~ ERROR invalid `crate_type` value
+
+fn main() {
+    return
+}

--- a/src/test/compile-fail/no_crate_type.rs
+++ b/src/test/compile-fail/no_crate_type.rs
@@ -1,0 +1,6 @@
+// regresion test for issue 11256
+#[crate_type];  //~ ERROR `crate_type` requires a value
+
+fn main() {
+    return
+}


### PR DESCRIPTION
This ensures that the `crate_type` attribute always contains a value,
and does not contain an invalid value.

Fixes #11256.
