### PR TITLE
Add byteswap intrinsics for converting from big/little to host endian

### DIFF
--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -122,11 +122,9 @@ pub mod reader {
         fail!("vint too big");
     }
 
-    #[cfg(target_arch = "x86")]
-    #[cfg(target_arch = "x86_64")]
     pub fn vuint_at(data: &[u8], start: uint) -> Res {
         use std::ptr::offset;
-        use std::unstable::intrinsics::bswap32;
+        use std::unstable::intrinsics::from_be32;
 
         if data.len() - start < 4 {
             return vuint_at_slow(data, start);
@@ -136,7 +134,7 @@ pub mod reader {
             let (ptr, _): (*u8, uint) = transmute(data);
             let ptr = offset(ptr, start as int);
             let ptr: *i32 = transmute(ptr);
-            let val = bswap32(*ptr);
+            let val = from_be32(*ptr);
             let val: u32 = transmute(val);
             if (val & 0x80000000) != 0 {
                 Res {
@@ -160,11 +158,6 @@ pub mod reader {
                 }
             }
         }
-    }
-
-    #[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
-    pub fn vuint_at(data: &[u8], start: uint) -> Res {
-        vuint_at_slow(data, start)
     }
 
     pub fn Doc<'a>(data: &'a [u8]) -> Doc<'a> {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -26,15 +26,11 @@ use super::file::keep_going;
 #[cfg(windows)] pub type sock_t = libc::SOCKET;
 #[cfg(unix)]    pub type sock_t = super::file::fd_t;
 
-#[cfg(target_endian = "big")] pub fn htons(x: u16) -> u16 { x }
-#[cfg(target_endian = "big")] pub fn ntohs(x: u16) -> u16 { x }
-#[cfg(target_endian = "little")]
 pub fn htons(u: u16) -> u16 {
-    unsafe { intrinsics::bswap16(u as i16) as u16 }
+    intrinsics::to_be16(u as i16) as u16
 }
-#[cfg(target_endian = "little")]
 pub fn ntohs(u: u16) -> u16 {
-    unsafe { intrinsics::bswap16(u as i16) as u16 }
+    intrinsics::from_be16(u as i16) as u16
 }
 
 enum InAddr {

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -500,6 +500,19 @@ extern "rust-intrinsic" {
 #[cfg(target_endian = "little")] pub fn to_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
 #[cfg(target_endian = "big")]    pub fn to_be64(x: i64) -> i64 { x }
 
+#[cfg(target_endian = "little")] pub fn from_le16(x: i16) -> i16 { x }
+#[cfg(target_endian = "big")]    pub fn from_le16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "little")] pub fn from_le32(x: i32) -> i32 { x }
+#[cfg(target_endian = "big")]    pub fn from_le32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "little")] pub fn from_le64(x: i64) -> i64 { x }
+#[cfg(target_endian = "big")]    pub fn from_le64(x: i64) -> i64 { unsafe { bswap64(x) } }
+
+#[cfg(target_endian = "little")] pub fn from_be16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "big")]    pub fn from_be16(x: i16) -> i16 { x }
+#[cfg(target_endian = "little")] pub fn from_be32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "big")]    pub fn from_be32(x: i32) -> i32 { x }
+#[cfg(target_endian = "little")] pub fn from_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
+#[cfg(target_endian = "big")]    pub fn from_be64(x: i64) -> i64 { x }
 
 /// `TypeId` represents a globally unique identifier for a type
 #[lang="type_id"] // This needs to be kept in lockstep with the code in trans/intrinsic.rs and


### PR DESCRIPTION
This patchset adds intrinsics similar to the to_[be|le][16|32|64] intrinsics but for going in the reverse direction, e.g. from big/little endian to host endian. Implementation wise they do exactly the same as the corresponding to_\* functions but I think it anyway make sense to have them since using the to_\* functions in the reverse direction is not entirely intuitive.

The first patch adds the intrinsics and the two following changes instances of bswap\* to use the [to|from]_\* intrinsics instead.
