### PR TITLE
Recognize LLVM 3.4 when building on opensuse with --llvm-root specified.

### DIFF
--- a/configure
+++ b/configure
@@ -591,7 +591,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.3|3.3svn|3.2|3.2svn)
+        (3.[2-4]svn|3.[2-4])
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)


### PR DESCRIPTION
Minor change for configuration script allows to build rust on openSUSE with using llvm installed from repos.
