### PR TITLE
debuginfo: Fix Issue #11083

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1653,7 +1653,8 @@ pub mod llvm {
                                             AlignInBits: c_ulonglong,
                                             Flags: c_uint,
                                             Elements: ValueRef,
-                                            RunTimeLang: c_uint)
+                                            RunTimeLang: c_uint,
+                                            UniqueId: *c_char)
                                             -> ValueRef;
 
         pub fn LLVMSetUnnamedAddr(GlobalVar: ValueRef, UnnamedAddr: Bool);

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -442,7 +442,8 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateUnionType(
     uint64_t AlignInBits,
     unsigned Flags,
     LLVMValueRef Elements,
-    unsigned RunTimeLang)
+    unsigned RunTimeLang,
+    const char* UniqueId)
 {
     return wrap(Builder->createUnionType(
         unwrapDI<DIDescriptor>(Scope),
@@ -453,7 +454,8 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateUnionType(
         AlignInBits,
         Flags,
         unwrapDI<DIArray>(Elements),
-        RunTimeLang));
+        RunTimeLang,
+        UniqueId));
 }
 
 extern "C" void LLVMSetUnnamedAddr(LLVMValueRef Value, LLVMBool Unnamed) {

--- a/src/test/debug-info/recursive-enum.rs
+++ b/src/test/debug-info/recursive-enum.rs
@@ -1,0 +1,33 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-android: FIXME(#10381)
+
+// compile-flags:-Z extra-debug-info
+// debugger:run
+
+// Test whether compiling a recursive enum definition crashes debug info generation. The test case
+// is taken from issue #11083.
+
+#[allow(unused_variable)];
+
+pub struct Window<'a> {
+    callbacks: WindowCallbacks<'a>
+}
+
+struct WindowCallbacks<'a> {
+    pos_callback: Option<WindowPosCallback<'a>>,
+}
+
+pub type WindowPosCallback<'a> = 'a |&Window, i32, i32|;
+
+fn main() {
+    let x = WindowCallbacks { pos_callback: None };
+}


### PR DESCRIPTION
This pull request fixes #11083. The problem was that recursive type definitions were not properly handled for enum types, leading to problems with LLVM's metadata "uniquing". This bug has already been fixed for struct types some time ago (#9658) but I seem to have forgotten about enums back then. I added the offending code from issue #11083 as a test case.
