### PR TITLE
Fix #10262 Emacs syntax table.

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -17,6 +17,7 @@
 
     ;; Strings
     (modify-syntax-entry ?\" "\"" table)
+    (modify-syntax-entry ?\' "\"" table)
     (modify-syntax-entry ?\\ "\\" table)
 
     ;; _ is a word-char


### PR DESCRIPTION
I added single quotes to the Emacs syntax table as regular strings. This fixes behavior with single-stringified brackets messing up indentation. This fixes #10262.
