### PR TITLE
mk: Fix llvmdeps.rs dependencies

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -47,11 +47,11 @@ endef
 $(foreach host,$(CFG_HOST), \
     $(eval LLVM_CONFIGS := $(LLVM_CONFIGS) $(LLVM_CONFIG_$(host))))
 
+$(foreach host,$(CFG_HOST), \
+ $(eval $(call DEF_LLVM_RULES,$(host))))
+
 $(S)src/librustc/lib/llvmdeps.rs: \
 		    $(LLVM_CONFIGS) \
 		    $(S)src/etc/mklldeps.py
 	$(Q)$(CFG_PYTHON) $(S)src/etc/mklldeps.py \
 	    "$@" "$(LLVM_COMPONENTS)" $(LLVM_CONFIGS)
-
-$(foreach host,$(CFG_HOST), \
- $(eval $(call DEF_LLVM_RULES,$(host))))


### PR DESCRIPTION
In a multi-host build the mklldeps.py tool is getting called before
all the llvm-configs are built. I am not actually sure the cause. I
had convinced myself that DEF_LLVM_RULES needed to be called before
the llvmdeps.rs rule, but now looking at it again I can't see why.

Here's the error: http://buildbot.rust-lang.org/builders/dist2-linux/builds/11/steps/compile/logs/stdio

r? @alexcrichton
