### PR TITLE
Rename `fmt::Default` to `fmt::Format`

### DIFF
--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -19,7 +19,7 @@ use std::fmt;
 /// string when passed to a format string.
 pub struct Escape<'a>(&'a str);
 
-impl<'a> fmt::Default for Escape<'a> {
+impl<'a> fmt::Format for Escape<'a> {
     fn fmt(s: &Escape<'a>, fmt: &mut fmt::Formatter) {
         // Because the internet is always right, turns out there's not that many
         // characters to escape: http://stackoverflow.com/questions/7381974

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -10,7 +10,7 @@
 
 //! HTML formatting module
 //!
-//! This module contains a large number of `fmt::Default` implementations for
+//! This module contains a large number of `fmt::Format` implementations for
 //! various types in `rustdoc::clean`. These implementations all currently
 //! assume that HTML output is desired, although it may be possible to redesign
 //! them in the future to instead emit any format desired.
@@ -35,7 +35,7 @@ pub struct PuritySpace(ast::purity);
 /// Wrapper struct for properly emitting a method declaration.
 pub struct Method<'a>(&'a clean::SelfTy, &'a clean::FnDecl);
 
-impl fmt::Default for clean::Generics {
+impl fmt::Format for clean::Generics {
     fn fmt(g: &clean::Generics, f: &mut fmt::Formatter) {
         if g.lifetimes.len() == 0 && g.type_params.len() == 0 { return }
         f.buf.write("&lt;".as_bytes());
@@ -65,14 +65,14 @@ impl fmt::Default for clean::Generics {
     }
 }
 
-impl fmt::Default for clean::Lifetime {
+impl fmt::Format for clean::Lifetime {
     fn fmt(l: &clean::Lifetime, f: &mut fmt::Formatter) {
         f.buf.write("'".as_bytes());
         f.buf.write(l.as_bytes());
     }
 }
 
-impl fmt::Default for clean::TyParamBound {
+impl fmt::Format for clean::TyParamBound {
     fn fmt(bound: &clean::TyParamBound, f: &mut fmt::Formatter) {
         match *bound {
             clean::RegionBound => {
@@ -85,7 +85,7 @@ impl fmt::Default for clean::TyParamBound {
     }
 }
 
-impl fmt::Default for clean::Path {
+impl fmt::Format for clean::Path {
     fn fmt(path: &clean::Path, f: &mut fmt::Formatter) {
         if path.global { f.buf.write("::".as_bytes()) }
         for (i, seg) in path.segments.iter().enumerate() {
@@ -257,7 +257,7 @@ fn typarams(w: &mut io::Writer, typarams: &Option<~[clean::TyParamBound]>) {
     }
 }
 
-impl fmt::Default for clean::Type {
+impl fmt::Format for clean::Type {
     fn fmt(g: &clean::Type, f: &mut fmt::Formatter) {
         match *g {
             clean::TyParamBinder(id) | clean::Generic(id) => {
@@ -362,7 +362,7 @@ impl fmt::Default for clean::Type {
     }
 }
 
-impl fmt::Default for clean::FnDecl {
+impl fmt::Format for clean::FnDecl {
     fn fmt(d: &clean::FnDecl, f: &mut fmt::Formatter) {
         write!(f.buf, "({args}){arrow, select, yes{ -&gt; {ret}} other{}}",
                args = d.inputs,
@@ -371,7 +371,7 @@ impl fmt::Default for clean::FnDecl {
     }
 }
 
-impl fmt::Default for ~[clean::Argument] {
+impl fmt::Format for ~[clean::Argument] {
     fn fmt(inputs: &~[clean::Argument], f: &mut fmt::Formatter) {
         let mut args = ~"";
         for (i, input) in inputs.iter().enumerate() {
@@ -385,7 +385,7 @@ impl fmt::Default for ~[clean::Argument] {
     }
 }
 
-impl<'a> fmt::Default for Method<'a> {
+impl<'a> fmt::Format for Method<'a> {
     fn fmt(m: &Method<'a>, f: &mut fmt::Formatter) {
         let Method(selfty, d) = *m;
         let mut args = ~"";
@@ -422,7 +422,7 @@ impl<'a> fmt::Default for Method<'a> {
     }
 }
 
-impl fmt::Default for VisSpace {
+impl fmt::Format for VisSpace {
     fn fmt(v: &VisSpace, f: &mut fmt::Formatter) {
         match **v {
             Some(ast::public) => { write!(f.buf, "pub "); }
@@ -432,7 +432,7 @@ impl fmt::Default for VisSpace {
     }
 }
 
-impl fmt::Default for PuritySpace {
+impl fmt::Format for PuritySpace {
     fn fmt(p: &PuritySpace, f: &mut fmt::Formatter) {
         match **p {
             ast::unsafe_fn => write!(f.buf, "unsafe "),
@@ -442,7 +442,7 @@ impl fmt::Default for PuritySpace {
     }
 }
 
-impl fmt::Default for clean::ViewPath {
+impl fmt::Format for clean::ViewPath {
     fn fmt(v: &clean::ViewPath, f: &mut fmt::Formatter) {
         match *v {
             clean::SimpleImport(ref name, ref src) => {
@@ -467,7 +467,7 @@ impl fmt::Default for clean::ViewPath {
     }
 }
 
-impl fmt::Default for clean::ImportSource {
+impl fmt::Format for clean::ImportSource {
     fn fmt(v: &clean::ImportSource, f: &mut fmt::Formatter) {
         match v.did {
             // XXX: shouldn't be restricted to just local imports
@@ -484,7 +484,7 @@ impl fmt::Default for clean::ImportSource {
     }
 }
 
-impl fmt::Default for clean::ViewListIdent {
+impl fmt::Format for clean::ViewListIdent {
     fn fmt(v: &clean::ViewListIdent, f: &mut fmt::Formatter) {
         match v.source {
             // XXX: shouldn't be limited to just local imports

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -24,7 +24,7 @@ pub struct Page<'a> {
     root_path: &'a str,
 }
 
-pub fn render<T: fmt::Default, S: fmt::Default>(
+pub fn render<T: fmt::Format, S: fmt::Format>(
     dst: &mut io::Writer, layout: &Layout, page: &Page, sidebar: &S, t: &T)
 {
     write!(dst,

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -14,7 +14,7 @@
 //! (bundled into the rust runtime). This module self-contains the C bindings
 //! and necessary legwork to render markdown, and exposes all of the
 //! functionality through a unit-struct, `Markdown`, which has an implementation
-//! of `fmt::Default`. Example usage:
+//! of `fmt::Format`. Example usage:
 //!
 //! ```rust
 //! let s = "My *markdown* _text_";
@@ -30,7 +30,7 @@ use std::str;
 use std::unstable::intrinsics;
 use std::vec;
 
-/// A unit struct which has the `fmt::Default` trait implemented. When
+/// A unit struct which has the `fmt::Format` trait implemented. When
 /// formatted, this struct will emit the HTML corresponding to the rendered
 /// version of the contained markdown string.
 pub struct Markdown<'a>(&'a str);
@@ -207,7 +207,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
     }
 }
 
-impl<'a> fmt::Default for Markdown<'a> {
+impl<'a> fmt::Format for Markdown<'a> {
     fn fmt(md: &Markdown<'a>, fmt: &mut fmt::Formatter) {
         // This is actually common enough to special-case
         if md.len() == 0 { return; }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -782,7 +782,7 @@ impl<'a> Item<'a> {
     }
 }
 
-impl<'a> fmt::Default for Item<'a> {
+impl<'a> fmt::Format for Item<'a> {
     fn fmt(it: &Item<'a>, fmt: &mut fmt::Formatter) {
         match attr::find_stability(it.item.attrs.iter()) {
             Some(stability) => {
@@ -970,7 +970,7 @@ fn item_module(w: &mut Writer, cx: &Context,
         match myitem.inner {
             clean::StaticItem(ref s) | clean::ForeignStaticItem(ref s) => {
                 struct Initializer<'a>(&'a str);
-                impl<'a> fmt::Default for Initializer<'a> {
+                impl<'a> fmt::Format for Initializer<'a> {
                     fn fmt(s: &Initializer<'a>, f: &mut fmt::Formatter) {
                         if s.len() == 0 { return; }
                         write!(f.buf, "<code> = </code>");
@@ -1470,7 +1470,7 @@ fn item_typedef(w: &mut Writer, it: &clean::Item, t: &clean::Typedef) {
     document(w, it);
 }
 
-impl<'a> fmt::Default for Sidebar<'a> {
+impl<'a> fmt::Format for Sidebar<'a> {
     fn fmt(s: &Sidebar<'a>, fmt: &mut fmt::Formatter) {
         let cx = s.cx;
         let it = s.item;
@@ -1535,7 +1535,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<~str, ~[~str]> {
     return map;
 }
 
-impl<'a> fmt::Default for Source<'a> {
+impl<'a> fmt::Format for Source<'a> {
     fn fmt(s: &Source<'a>, fmt: &mut fmt::Formatter) {
         let lines = s.lines().len();
         let mut cols = 0;

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -147,13 +147,13 @@ The current mapping of types to traits is:
 * `p` ⇒ `Pointer`
 * `t` ⇒ `Binary`
 * `f` ⇒ `Float`
-* *nothing* ⇒ `Default`
+* *nothing* ⇒ `Format`
 
 What this means is that any type of argument which implements the
 `std::fmt::Binary` trait can then be formatted with `{:t}`. Implementations are
 provided for these traits for a number of primitive types by the standard
 library as well. If no format is specified (as in `{}` or `{:6}`), then the
-format trait used is the `Default` trait. This is one of the more commonly
+format trait used is the `Format` trait. This is one of the more commonly
 implemented traits when formatting a custom type.
 
 When implementing a format trait for your own time, you will have to implement a
@@ -184,7 +184,7 @@ struct Vector2D {
     y: int,
 }
 
-impl fmt::Default for Vector2D {
+impl fmt::Format for Vector2D {
     fn fmt(obj: &Vector2D, f: &mut fmt::Formatter) {
         // The `f.buf` value is of the type `&mut io::Writer`, which is what th
         // write! macro is expecting. Note that this formatting ignores the
@@ -481,6 +481,18 @@ use vec;
 pub mod parse;
 pub mod rt;
 
+/// NOTE: This is a temporary fix as we purge the `fmt::Default` trait from the
+/// compiler. This should be removed at the next snapshot.
+#[cfg(stage0)]
+#[allow(missing_doc)]
+pub mod Default {
+    use super::{Format, Formatter};
+
+    pub fn fmt<T: Format>(obj: &T, f: &mut Formatter) {
+        Format::fmt(obj, f);
+    }
+}
+
 /// A struct to represent both where to emit formatting strings to and how they
 /// should be formatted. A mutable version of this is passed to all formatting
 /// traits.
@@ -541,7 +553,7 @@ pub struct Arguments<'a> {
 /// to this trait. There is not an explicit way of selecting this trait to be
 /// used for formatting, it is only if no other format is specified.
 #[allow(missing_doc)]
-pub trait Default { fn fmt(&Self, &mut Formatter); }
+pub trait Format { fn fmt(&Self, &mut Formatter); }
 
 /// Format trait for the `b` character
 #[allow(missing_doc)]
@@ -1119,10 +1131,10 @@ impl<T> Pointer for *mut T {
     fn fmt(t: &*mut T, f: &mut Formatter) { Pointer::fmt(&(*t as *T), f) }
 }
 
-// Implementation of Default for various core types
+// Implementation of Format for various core types
 
 macro_rules! delegate(($ty:ty to $other:ident) => {
-    impl<'a> Default for $ty {
+    impl<'a> Format for $ty {
         fn fmt(me: &$ty, f: &mut Formatter) {
             $other::fmt(me, f)
         }
@@ -1146,10 +1158,10 @@ delegate!(char to Char)
 delegate!(f32 to Float)
 delegate!(f64 to Float)
 
-impl<T> Default for *T {
+impl<T> Format for *T {
     fn fmt(me: &*T, f: &mut Formatter) { Pointer::fmt(me, f) }
 }
-impl<T> Default for *mut T {
+impl<T> Format for *mut T {
     fn fmt(me: &*mut T, f: &mut Formatter) { Pointer::fmt(me, f) }
 }
 

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -91,7 +91,7 @@ pub enum ProcessExit {
     ExitSignal(int),
 }
 
-impl fmt::Default for ProcessExit {
+impl fmt::Format for ProcessExit {
     /// Format a ProcessExit enum, to nicely present the information.
     fn fmt(obj: &ProcessExit, f: &mut fmt::Formatter) {
         match *obj {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -361,7 +361,7 @@ impl<T: Default> Option<T> {
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
 
-impl<T: fmt::Default> fmt::Default for Option<T> {
+impl<T: fmt::Format> fmt::Format for Option<T> {
     #[inline]
     fn fmt(s: &Option<T>, f: &mut fmt::Formatter) {
         match *s {

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -184,14 +184,14 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// Converts the Path into an owned byte vector
     fn into_vec(self) -> ~[u8];
 
-    /// Returns an object that implements `fmt::Default` for printing paths
+    /// Returns an object that implements `fmt::Format` for printing paths
     ///
     /// This will print the equivalent of `to_display_str()` when used with a {} format parameter.
     fn display<'a>(&'a self) -> Display<'a, Self> {
         Display{ path: self, filename: false }
     }
 
-    /// Returns an object that implements `fmt::Default` for printing filenames
+    /// Returns an object that implements `fmt::Format` for printing filenames
     ///
     /// This will print the equivalent of `to_filename_display_str()` when used with a {}
     /// format parameter. If there is no filename, nothing will be printed.
@@ -527,7 +527,7 @@ pub struct Display<'a, P> {
     priv filename: bool
 }
 
-impl<'a, P: GenericPath> fmt::Default for Display<'a, P> {
+impl<'a, P: GenericPath> fmt::Format for Display<'a, P> {
     fn fmt(d: &Display<P>, f: &mut fmt::Formatter) {
         d.with_str(|s| f.pad(s))
     }

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -205,7 +205,7 @@ impl<T, E> Result<T, E> {
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
 
-impl<T: fmt::Default, E: fmt::Default> fmt::Default for Result<T, E> {
+impl<T: fmt::Format, E: fmt::Format> fmt::Format for Result<T, E> {
     #[inline]
     fn fmt(s: &Result<T, E>, f: &mut fmt::Formatter) {
         match *s {

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -675,7 +675,7 @@ impl<'a> Context<'a> {
         let fmt_trait = match ty {
             Known(tyname) => {
                 match tyname.as_slice() {
-                    ""  => "Default",
+                    ""  => "Format",
                     "?" => "Poly",
                     "b" => "Bool",
                     "c" => "Char",

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 struct Foo(Cell<int>);
 
-impl fmt::Default for Foo {
+impl fmt::Format for Foo {
     fn fmt(f: &Foo, _fmt: &mut fmt::Formatter) {
         assert!(f.get() == 0);
         f.set(1);


### PR DESCRIPTION
This is in preparation for adding a `#[deriving(Format)]` and removing the `ToStr` trait, as discussed in #9806.
