### PR TITLE
rt: Define exp10 on Android

### DIFF
--- a/src/rt/rust_android_dummy.c
+++ b/src/rt/rust_android_dummy.c
@@ -28,6 +28,11 @@ double log2( double n )
     return log( n ) / log( 2 );
 }
 
+double exp10( double x )
+{
+    return pow( 10, x );
+}
+
 void telldir()
 {
 }


### PR DESCRIPTION
LLVM appears to generate calls to exp10 on ARM and bionic does not define it.

This makes code that links to libextra (which I guess does some exponentiation on the stat module) link correctly.
