### PR TITLE
Add a stack_bounds function to the Runtime trait

### DIFF
--- a/src/libgreen/simple.rs
+++ b/src/libgreen/simple.rs
@@ -75,6 +75,7 @@ impl Runtime for SimpleTask {
         fail!()
     }
     fn local_io<'a>(&'a mut self) -> Option<rtio::LocalIo<'a>> { None }
+    fn stack_bounds(&self) -> Option<(uint, uint)> { None }
     fn wrap(~self) -> ~Any { fail!() }
 }
 

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -450,6 +450,13 @@ impl Runtime for GreenTask {
         }
     }
 
+    fn stack_bounds(&self) -> Option<(uint, uint)> {
+        self.coroutine.as_ref().map(|c| {
+            (c.current_stack_segment.start() as uint,
+             c.current_stack_segment.end() as uint)
+        })
+    }
+
     fn wrap(~self) -> ~Any { self as ~Any }
 }
 

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -159,6 +159,7 @@ pub trait Runtime {
     // you're in.
     fn spawn_sibling(~self, cur_task: ~Task, opts: TaskOpts, f: proc());
     fn local_io<'a>(&'a mut self) -> Option<rtio::LocalIo<'a>>;
+    fn stack_bounds(&self) -> Option<(uint, uint)>; // (lo, hi)
 
     // XXX: This is a serious code smell and this should not exist at all.
     fn wrap(~self) -> ~Any;

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -277,6 +277,13 @@ impl Task {
     pub fn local_io<'a>(&'a mut self) -> Option<LocalIo<'a>> {
         self.imp.get_mut_ref().local_io()
     }
+
+    /// Returns the stack bounds for this task in (lo, hi) format. The stack
+    /// bounds may not be known for all tasks, so the return value may be
+    /// `None`.
+    pub fn stack_bounds(&self) -> Option<(uint, uint)> {
+        self.imp.get_ref().stack_bounds()
+    }
 }
 
 impl Drop for Task {


### PR DESCRIPTION
This allows inspection of the current task's bounds regardless of what the
underlying task is.

Closes #11293
