### PR TITLE
etc: licenseck: don't hardcode a specific year

### DIFF
--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -1,5 +1,5 @@
-// Copyright 2012-2013 The Rust Project Developers. See the
-// COPYRIGHT file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -1,5 +1,5 @@
-// Copyright 2012-2013 The Rust Project Developers. See the
-// COPYRIGHT file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1,5 +1,5 @@
-// Copyright 2012-2013 The Rust Project Developers. See the
-// COPYRIGHT file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/etc/licenseck.py
+++ b/src/etc/licenseck.py
@@ -8,20 +8,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-license0 = """\
-// Copyright 2012-2013 The Rust Project Developers. See the
-// COPYRIGHT file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-"""
-
-license1 = """\
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+license1 = """// Copyright """
+license2 = """ The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -32,20 +20,8 @@ license1 = """\
 // except according to those terms.
 """
 
-license2 = """\
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-"""
-
-license3 = """\
-# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+license3 = """# Copyright """
+license4 = """ The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.
 #
@@ -55,20 +31,6 @@ license3 = """\
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 """
-
-license4 = """\
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-"""
-
-licenses = [license0, license1, license2, license3, license4]
 
 exceptions = [
     "rt/rust_android_dummy.cpp", # BSD, chromium
@@ -82,20 +44,19 @@ exceptions = [
 ]
 
 def check_license(name, contents):
-    valid_license = False
-    for a_valid_license in licenses:
-        if contents.startswith(a_valid_license):
-            valid_license = True
-            break
-    if valid_license:
-        return True
-
+    # Whitelist check
     for exception in exceptions:
         if name.endswith(exception):
             return True
 
+    # Xfail check
     firstlineish = contents[:100]
     if firstlineish.find("xfail-license") != -1:
         return True
 
-    return False
+    # License check
+    boilerplate = contents[:500]
+    if (boilerplate.find(license1) == -1 or boilerplate.find(license2) == -1) and \
+       (boilerplate.find(license3) == -1 or boilerplate.find(license4) == -1):
+        return False
+    return True

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -1,5 +1,5 @@
-// Copyright 2012-2013 The Rust Project Developers. See the
-// COPYRIGHT file at the top-level directory of this distribution and at
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or


### PR DESCRIPTION
- don't check for an hardcoded copyright claim year, check the 2 surrounding strings instead
- logic: if either the `//` or `#`-style copyright patterns are found, don't invalidate
- cleanup hardcoded content and streamline the few files with different line breaks

r? @brson
