### PR TITLE
Do not ignore errors running llvm-config

### DIFF
--- a/src/etc/mklldeps.py
+++ b/src/etc/mklldeps.py
@@ -49,7 +49,7 @@ for llconfig in sys.argv[3:]:
 
     args = [llconfig, '--libs']
     args.extend(components)
-    proc = subprocess.Popen(args, stdout = subprocess.PIPE)
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = proc.communicate()
 
     if err:


### PR DESCRIPTION
Standard error was not captured, ignoring any errors from llvm-config.
