### PR TITLE
std::os: Add get_path_env()

### DIFF
--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -189,15 +189,7 @@ fn get_sysroot(maybe_sysroot: &Option<@Path>) -> @Path {
     }
 }
 
-#[cfg(windows)]
-static PATH_ENTRY_SEPARATOR: &'static str = ";";
-#[cfg(not(windows))]
-static PATH_ENTRY_SEPARATOR: &'static str = ":";
-
-/// Returns RUST_PATH as a string, without default paths added
-pub fn get_rust_path() -> Option<~str> {
-    os::getenv("RUST_PATH")
-}
+pub static RUST_PATH: &'static str = "RUST_PATH";
 
 /// Returns the value of RUST_PATH, as a list
 /// of Paths. Includes default entries for, if they exist:
@@ -205,14 +197,7 @@ pub fn get_rust_path() -> Option<~str> {
 /// DIR/.rust for any DIR that's the current working directory
 /// or an ancestor of it
 pub fn rust_path() -> ~[Path] {
-    let mut env_rust_path: ~[Path] = match get_rust_path() {
-        Some(env_path) => {
-            let env_path_components: ~[&str] =
-                env_path.split_str(PATH_ENTRY_SEPARATOR).collect();
-            env_path_components.map(|&s| Path::new(s))
-        }
-        None => ~[]
-    };
+    let mut env_rust_path: ~[Path] = os::get_path_env(RUST_PATH);
     let mut cwd = os::getcwd();
     // now add in default entries
     let cwd_dot_rust = cwd.join(".rust");

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -236,6 +236,24 @@ pub fn getenv(n: &str) -> Option<~str> {
     }
 }
 
+#[cfg(windows)]
+static PATH_ENTRY_SEPARATOR: &'static str = ";";
+#[cfg(not(windows))]
+static PATH_ENTRY_SEPARATOR: &'static str = ":";
+
+/// Fetches the environment variable `n` from the current process and
+/// splits into strings.
+///
+/// On Unix, the list is separated by character ':'.
+/// On Windows, the list is separated by character ';'.
+pub fn get_path_env(n: &str) -> ~[Path] {
+    match getenv(n) {
+        Some(s) => {
+            s.split_str(PATH_ENTRY_SEPARATOR).map(|s| Path::new(s)).to_owned_vec()
+        }
+        None => ~[],
+    }
+}
 
 #[cfg(unix)]
 /// Sets the environment variable `n` to the value `v` for the currently running


### PR DESCRIPTION
This primary motivation is that there was no easy way to get list of
paths from `getenv("PATH")`, because it requires to split string with
os-depdent separator.
rustc also did same work for `RUST_PATH`, so this patch moves the
portion into std::os for public use.
