### PR TITLE
Fix formatting of some code blocks in pdf docs

### DIFF
--- a/doc/guide-macros.md
+++ b/doc/guide-macros.md
@@ -278,6 +278,7 @@ return result + val;
 This solves the indentation problem. But if we have a lot of chained matches
 like this, we might prefer to write a single macro invocation. The input
 pattern we want is clear:
+
 ~~~~
 # macro_rules! b(
     ( $( ($e:expr) ~ ($p:pat) else $err:stmt ; )*
@@ -304,6 +305,7 @@ input patterns:
     ( binds $( $bind_res:ident ),* )
 # => (0))
 ~~~~
+
 ...and:
 
 ~~~~

--- a/doc/guide-tasks.md
+++ b/doc/guide-tasks.md
@@ -263,6 +263,7 @@ With `extra::future`, rust has a mechanism for requesting a computation and gett
 later.
 
 The basic example below illustrates this.
+
 ~~~
 # fn make_a_sandwich() {};
 fn fib(n: u64) -> u64 {
@@ -283,6 +284,7 @@ the future needs to be mutable so that it can save the result for next time `get
 
 Here is another example showing how futures allow you to background computations. The workload will
 be distributed on the available cores.
+
 ~~~
 # use std::vec;
 fn partial_sum(start: uint) -> f64 {
@@ -317,6 +319,7 @@ acts as a reference to the shared data and only this reference is shared and clo
 
 Here is a small example showing how to use Arcs. We wish to run concurrently several computations on
 a single large vector of floats. Each task needs the full vector to perform its duty.
+
 ~~~
 # use std::vec;
 # use std::rand;
@@ -348,6 +351,7 @@ fn main() {
 The function `pnorm` performs a simple computation on the vector (it computes the sum of its items
 at the power given as argument and takes the inverse power of this value). The Arc on the vector is
 created by the line
+
 ~~~
 # use extra::arc::Arc;
 # use std::vec;
@@ -355,7 +359,9 @@ created by the line
 # let numbers = vec::from_fn(1000000, |_| rand::random::<f64>());
 let numbers_arc=Arc::new(numbers);
 ~~~
+
 and a clone of it is sent to each task
+
 ~~~
 # use extra::arc::Arc;
 # use std::vec;
@@ -365,9 +371,11 @@ and a clone of it is sent to each task
 # let (port, chan)  = Chan::new();
 chan.send(numbers_arc.clone());
 ~~~
+
 copying only the wrapper and not its contents.
 
 Each task recovers the underlying data by
+
 ~~~
 # use extra::arc::Arc;
 # use std::vec;
@@ -379,6 +387,7 @@ Each task recovers the underlying data by
 # let local_arc : Arc<~[f64]> = port.recv();
 let task_numbers = local_arc.get();
 ~~~
+
 and can use it as if it were local.
 
 The `arc` module also implements Arcs around mutable data that are not covered here.

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -845,6 +845,7 @@ If a sequence of such redirections form a cycle or cannot be resolved unambiguou
 they represent a compile-time error.
 
 An example of re-exporting:
+
 ~~~~
 # fn main() { }
 mod quux {
@@ -868,6 +869,7 @@ All rules regarding accessing declared modules in `use` declarations applies to 
 and `extern mod` declarations.
 
 An example of what will and will not work for `use` items:
+
 ~~~~
 # #[allow(unused_imports)];
 use foo::extra;          // good: foo is at the root of the crate
@@ -1184,6 +1186,7 @@ a = Cat;
 ~~~~
 
 Enumeration constructors can have either named or unnamed fields:
+
 ~~~~
 enum Animal {
     Dog (~str, f64),

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -2790,6 +2790,7 @@ For example, if we move the `animals` module above into its own file...
 mod plants;
 mod animals;
 ~~~
+
 ~~~ {.ignore}
 // src/animals.rs or src/animals/mod.rs
 mod fish;
@@ -2797,6 +2798,7 @@ mod mammals {
     mod humans;
 }
 ~~~
+
 ...then the source files of `mod animals`'s submodules can
 either be placed right next to that of its parents, or in a subdirectory if `animals` source file is:
 
@@ -2959,6 +2961,7 @@ pub fn bar() { println("Baz!"); }
 There also exist two short forms for importing multiple names at once:
 
 1. Explicit mention multiple names as the last element of an `use` path:
+
 ~~~
 use farm::{chicken, cow};
 # mod farm {
@@ -2969,6 +2972,7 @@ use farm::{chicken, cow};
 ~~~
 
 2. Import everything in a module with a wildcard:
+
 ~~~
 use farm::*;
 # mod farm {


### PR DESCRIPTION
I was reading through the tutorial and manual pdfs and noticed some of the code blocks have glitches in their formatting:

![](http://i.imgur.com/9HXZ4dW.png)
![](http://i.imgur.com/Ds2By6j.png)

Putting empty lines around the blocks fixes this. I did a search through the other markdown files and made the change there as well.
