### PR TITLE
Support arbitrary stdout/stderr/logger handles

### DIFF
--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -118,13 +118,17 @@ impl GreenTask {
                      f: proc()) -> ~GreenTask {
         let TaskOpts {
             watched: _watched,
-            notify_chan, name, stack_size
+            notify_chan, name, stack_size,
+            stderr, stdout, logger,
         } = opts;
 
         let mut green = GreenTask::new(pool, stack_size, f);
         {
             let task = green.task.get_mut_ref();
             task.name = name;
+            task.logger = logger;
+            task.stderr = stderr;
+            task.stdout = stdout;
             match notify_chan {
                 Some(chan) => {
                     let on_exit = proc(task_result) { chan.send(task_result) };

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -34,7 +34,7 @@ pub mod io;
 pub mod task;
 
 // XXX: this should not exist here
-#[cfg(stage0)]
+#[cfg(stage0, nativestart)]
 #[lang = "start"]
 pub fn lang_start(main: *u8, argc: int, argv: **u8) -> int {
     use std::cast;

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -55,11 +55,15 @@ pub fn spawn(f: proc()) {
 pub fn spawn_opts(opts: TaskOpts, f: proc()) {
     let TaskOpts {
         watched: _watched,
-        notify_chan, name, stack_size
+        notify_chan, name, stack_size,
+        logger, stderr, stdout,
     } = opts;
 
     let mut task = ~Task::new();
     task.name = name;
+    task.logger = logger;
+    task.stderr = stderr;
+    task.stdout = stdout;
     match notify_chan {
         Some(chan) => {
             let on_exit = proc(task_result) { chan.send(task_result) };

--- a/src/libstd/rt/logging.rs
+++ b/src/libstd/rt/logging.rs
@@ -8,13 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use fmt;
 use from_str::from_str;
 use libc::exit;
 use option::{Some, None, Option};
-use io;
-use io::stdio::StdWriter;
-use io::buffered::LineBufferedWriter;
 use rt::crate_map::{ModEntry, CrateMap, iter_crate_map, get_crate_map};
 use str::StrSlice;
 use vec::{ImmutableVector, MutableTotalOrdVector};
@@ -165,28 +161,6 @@ fn update_log_settings(crate_map: &CrateMap, settings: ~str) {
                   {} of them. You may have mistyped a RUST_LOG spec. \n\
                   Use RUST_LOG=::help to see the list of crates and modules.\n",
                  dirs.len(), n_matches);
-    }
-}
-
-pub trait Logger {
-    fn log(&mut self, args: &fmt::Arguments);
-}
-
-/// This logger emits output to the stderr of the process, and contains a lazily
-/// initialized event-loop driven handle to the stream.
-pub struct StdErrLogger {
-    priv handle: LineBufferedWriter<StdWriter>,
-}
-
-impl StdErrLogger {
-    pub fn new() -> StdErrLogger {
-        StdErrLogger { handle: LineBufferedWriter::new(io::stderr()) }
-    }
-}
-
-impl Logger for StdErrLogger {
-    fn log(&mut self, args: &fmt::Arguments) {
-        fmt::writeln(&mut self.handle as &mut io::Writer, args);
     }
 }
 

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -20,6 +20,7 @@ use cleanup;
 use io::Writer;
 use iter::{Iterator, Take};
 use local_data;
+use logging::Logger;
 use ops::Drop;
 use option::{Option, Some, None};
 use prelude::drop;
@@ -29,7 +30,6 @@ use rt::borrowck::BorrowRecord;
 use rt::borrowck;
 use rt::local::Local;
 use rt::local_heap::LocalHeap;
-use rt::logging::StdErrLogger;
 use rt::rtio::LocalIo;
 use rt::unwind::Unwinder;
 use send_str::SendStr;
@@ -58,8 +58,9 @@ pub struct Task {
     // Dynamic borrowck debugging info
     borrow_list: Option<~[BorrowRecord]>,
 
-    logger: Option<StdErrLogger>,
-    stdout_handle: Option<~Writer>,
+    logger: Option<~Logger>,
+    stdout: Option<~Writer>,
+    stderr: Option<~Writer>,
 
     priv imp: Option<~Runtime>,
 }
@@ -97,7 +98,8 @@ impl Task {
             name: None,
             borrow_list: None,
             logger: None,
-            stdout_handle: None,
+            stdout: None,
+            stderr: None,
             imp: None,
         }
     }
@@ -126,12 +128,20 @@ impl Task {
 
             // Run the task main function, then do some cleanup.
             f.finally(|| {
-                fn flush(w: Option<~Writer>) {
-                    match w {
-                        Some(mut w) => { w.flush(); }
-                        None => {}
-                    }
+                fn close_outputs() {
+                    let mut task = Local::borrow(None::<Task>);
+                    let logger = task.get().logger.take();
+                    let stderr = task.get().stderr.take();
+                    let stdout = task.get().stdout.take();
+                    drop(task);
+                    drop(logger); // loggers are responsible for flushing
+                    match stdout { Some(mut w) => w.flush(), None => {} }
+                    match stderr { Some(mut w) => w.flush(), None => {} }
                 }
+
+                // First, flush/destroy the user stdout/logger because these
+                // destructors can run arbitrary code.
+                close_outputs();
 
                 // First, destroy task-local storage. This may run user dtors.
                 //
@@ -164,16 +174,12 @@ impl Task {
                 // Destroy remaining boxes. Also may run user dtors.
                 unsafe { cleanup::annihilate(); }
 
-                // Finally flush and destroy any output handles which the task
-                // owns. There are no boxes here, and no user destructors should
-                // run after this any more.
-                let mut task = Local::borrow(None::<Task>);
-                let stdout = task.get().stdout_handle.take();
-                let logger = task.get().logger.take();
-                drop(task);
-
-                flush(stdout);
-                drop(logger);
+                // Finally, just in case user dtors printed/logged during TLS
+                // cleanup and annihilation, re-destroy stdout and the logger.
+                // Note that these will have been initialized with a
+                // runtime-provided type which we have control over what the
+                // destructor does.
+                close_outputs();
             })
         };
 

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -1,0 +1,46 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+// exec-env:RUST_LOG=info
+
+#[no_uv];
+extern mod native;
+
+use std::fmt;
+use std::io::comm_adapters::{PortReader, ChanWriter};
+use std::logging::{set_logger, Logger};
+
+struct MyWriter(ChanWriter);
+
+impl Logger for MyWriter {
+    fn log(&mut self, _level: u32, args: &fmt::Arguments) {
+        let MyWriter(ref mut inner) = *self;
+        fmt::writeln(inner as &mut Writer, args);
+    }
+}
+
+#[start]
+fn start(argc: int, argv: **u8) -> int {
+    do native::start(argc, argv) {
+        main();
+    }
+}
+
+fn main() {
+    let (p, c) = Chan::new();
+    let (mut r, w) = (PortReader::new(p), ChanWriter::new(c));
+    do spawn {
+        set_logger(~MyWriter(w) as ~Logger);
+        debug!("debug");
+        info!("info");
+    }
+    assert_eq!(r.read_to_str(), ~"info\n");
+}


### PR DESCRIPTION
This will allow capturing of common things like logging messages, stdout prints
(using stdio println), and failure messages (printed to stderr).  Any new prints
added to libstd should be funneled through these task handles to allow capture
as well.

Additionally, this commit redirects logging back through a `Logger` trait so the
log level can be usefully consumed by an arbitrary logger.

This commit also introduces methods to set the task-local stdout handles:
- std::io::stdio::set_stdout
- std::io::stdio::set_stderr
- std::io::logging::set_logger

These methods all return the previous logger just in case it needs to be used
for inspection.

I plan on using this infrastructure for extra::test soon, but we don't quite
have the primitives that I'd like to use for it, so it doesn't migrate
extra::test at this time.

Closes #6369
