### PR TITLE
Use the full version string for the windows installer exe

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -44,7 +44,7 @@ clean-misc:
 	$(Q)rm -Rf $(DOCS)
 	$(Q)rm -Rf $(GENERATED)
 	$(Q)rm -Rf tmp/*
-	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz dist
+	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz $(PKG_NAME)-*.exe dist
 	$(Q)rm -Rf $(foreach ext, \
                  html aux cp fn ky log pdf pg toc tp vr cps epub, \
                  $(wildcard doc/*.$(ext)))

--- a/src/etc/pkg/rust.iss
+++ b/src/etc/pkg/rust.iss
@@ -19,7 +19,7 @@ DisableStartupPrompt=true
 
 OutputDir=.\
 SourceDir=.\
-OutputBaseFilename=rust-{#CFG_VERSION_WIN}-install
+OutputBaseFilename=rust-{#CFG_VERSION}-install
 DefaultDirName={pf32}\Rust
 
 Compression=lzma2/ultra


### PR DESCRIPTION
The makefiles and the windows installer disagree on the name of this file. In practical terms this change only means that the '-pre' installers will be named 'rust-0.9-pre-install.exe' instead 'rust-0.9-install.exe'.
