### PR TITLE
Remove unnecessary substitution of type params when generating vtable methods.

### DIFF
--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -630,11 +630,8 @@ fn emit_vtable_methods(bcx: @Block,
         debug!("(making impl vtable) emitting method {} at subst {}",
                m.repr(tcx),
                substs.repr(tcx));
-        let fty = ty::subst_tps(tcx,
-                                substs,
-                                None,
-                                ty::mk_bare_fn(tcx, m.fty.clone()));
-        if m.generics.has_type_params() || ty::type_has_self(fty) {
+        if m.generics.has_type_params() ||
+           ty::type_has_self(ty::mk_bare_fn(tcx, m.fty.clone())) {
             debug!("(making impl vtable) method has self or type params: {}",
                    tcx.sess.str_of(ident));
             C_null(Type::nil().ptr_to())

--- a/src/test/run-pass/trait-cast-generic.rs
+++ b/src/test/run-pass/trait-cast-generic.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Testing casting of a generic Struct to a Trait with a generic method.
+// This is test for issue 10955.
+#[allow(unused_variable)];
+
+trait Foo {
+    fn f<A>(a: A) -> A {
+        a
+    }
+}
+
+struct Bar<T> {
+    x: T,
+}
+
+impl<T> Foo for Bar<T> { }
+
+pub fn main() {
+    let a = Bar { x: 1 };
+    let b = &a as &Foo;
+}


### PR DESCRIPTION
So, like I mentioned in issue #10955 it doesn't seem like we need to call `ty::subst_tps` when the method is generic. But then I realized that this function doesn't mutate any of its input, and the return value is unused. Plus the type param substitution seems to be taken care of in `trans_fn_ref_with_vtables`, so I thought I'd just try to remove it. As far as I can tell everything works.

This closes #10955.
