### PR TITLE
Inline reexports in rustdoc

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -209,6 +209,7 @@ pub fn phase_2_configure_and_expand(sess: Session,
 pub struct CrateAnalysis {
     exp_map2: middle::resolve::ExportMap2,
     exported_items: middle::privacy::ExportedItems,
+    public_items: middle::privacy::PublicItems,
     ty_cx: ty::ctxt,
     maps: astencode::Maps,
     reachable: @RefCell<HashSet<ast::NodeId>>
@@ -268,9 +269,10 @@ pub fn phase_3_run_analysis_passes(sess: Session,
                                           method_map, ty_cx));
 
     let maps = (external_exports, last_private_map);
-    let exported_items = time(time_passes, "privacy checking", maps, |(a, b)|
-             middle::privacy::check_crate(ty_cx, &method_map, &exp_map2,
-                                          a, b, crate));
+    let (exported_items, public_items) =
+            time(time_passes, "privacy checking", maps, |(a, b)|
+                 middle::privacy::check_crate(ty_cx, &method_map, &exp_map2,
+                                              a, b, crate));
 
     time(time_passes, "effect checking", (), |_|
          middle::effect::check_crate(ty_cx, method_map, crate));
@@ -322,6 +324,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
         exp_map2: exp_map2,
         ty_cx: ty_cx,
         exported_items: exported_items,
+        public_items: public_items,
         maps: astencode::Maps {
             root_map: root_map,
             method_map: method_map,

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -72,7 +72,7 @@ pub struct Crate {
     externs: HashMap<ast::CrateNum, ExternalCrate>,
 }
 
-impl Clean<Crate> for visit_ast::RustdocVisitor {
+impl<'a> Clean<Crate> for visit_ast::RustdocVisitor<'a> {
     fn clean(&self) -> Crate {
         use syntax::attr::find_crateid;
         let cx = local_data::get(super::ctxtkey, |x| *x.unwrap());

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -67,7 +67,7 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
     };
     local_data::set(super::ctxtkey, ctx);
 
-    let mut v = RustdocVisitor::new();
+    let mut v = RustdocVisitor::new(ctx, None);
     v.visit(&ctx.crate);
     let crate = v.clean();
     let (crate, _) = passes::unindent_comments(crate);

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -13,169 +13,278 @@
 
 use syntax::abi::AbiSet;
 use syntax::ast;
+use syntax::ast_util;
+use syntax::ast_map;
 use syntax::codemap::Span;
 
+use core;
 use doctree::*;
 
-pub struct RustdocVisitor {
+pub struct RustdocVisitor<'a> {
     module: Module,
     attrs: ~[ast::Attribute],
+    cx: &'a core::DocContext,
+    analysis: Option<&'a core::CrateAnalysis>,
 }
 
-impl RustdocVisitor {
-    pub fn new() -> RustdocVisitor {
+impl<'a> RustdocVisitor<'a> {
+    pub fn new<'b>(cx: &'b core::DocContext,
+                   analysis: Option<&'b core::CrateAnalysis>) -> RustdocVisitor<'b> {
         RustdocVisitor {
             module: Module::new(None),
             attrs: ~[],
+            cx: cx,
+            analysis: analysis,
         }
     }
-}
 
-impl RustdocVisitor {
     pub fn visit(&mut self, crate: &ast::Crate) {
         self.attrs = crate.attrs.clone();
-        fn visit_struct_def(item: &ast::item, sd: @ast::struct_def, generics:
-                            &ast::Generics) -> Struct {
-            debug!("Visiting struct");
-            let struct_type = struct_type_from_def(sd);
-            Struct {
-                id: item.id,
-                struct_type: struct_type,
-                name: item.ident,
-                vis: item.vis,
-                attrs: item.attrs.clone(),
-                generics: generics.clone(),
-                fields: sd.fields.clone(),
-                where: item.span
-            }
-        }
 
-        fn visit_enum_def(it: &ast::item, def: &ast::enum_def, params: &ast::Generics) -> Enum {
-            debug!("Visiting enum");
-            let mut vars: ~[Variant] = ~[];
-            for x in def.variants.iter() {
-                vars.push(Variant {
-                    name: x.node.name,
-                    attrs: x.node.attrs.clone(),
-                    vis: x.node.vis,
-                    id: x.node.id,
-                    kind: x.node.kind.clone(),
-                    where: x.span,
-                });
-            }
-            Enum {
-                name: it.ident,
-                variants: vars,
-                vis: it.vis,
-                generics: params.clone(),
-                attrs: it.attrs.clone(),
-                id: it.id,
-                where: it.span,
-            }
-        }
+        self.module = self.visit_mod_contents(crate.span, crate.attrs.clone(),
+                                              ast::public, ast::CRATE_NODE_ID,
+                                              &crate.module, None);
+    }
 
-        fn visit_fn(item: &ast::item, fd: &ast::fn_decl, purity: &ast::purity,
-                     _abi: &AbiSet, gen: &ast::Generics) -> Function {
-            debug!("Visiting fn");
-            Function {
-                id: item.id,
-                vis: item.vis,
-                attrs: item.attrs.clone(),
-                decl: fd.clone(),
-                name: item.ident,
-                where: item.span,
-                generics: gen.clone(),
-                purity: *purity,
-            }
-        }
+    pub fn visit_struct_def(&mut self, item: &ast::item, sd: @ast::struct_def,
 
-        fn visit_mod_contents(span: Span, attrs: ~[ast::Attribute], vis:
-                              ast::visibility, id: ast::NodeId, m: &ast::_mod,
+                        generics: &ast::Generics) -> Struct {
+        debug!("Visiting struct");
+        let struct_type = struct_type_from_def(sd);
+        Struct {
+            id: item.id,
+            struct_type: struct_type,
+            name: item.ident,
+            vis: item.vis,
+            attrs: item.attrs.clone(),
+            generics: generics.clone(),
+            fields: sd.fields.clone(),
+            where: item.span
+        }
+    }
+
+    pub fn visit_enum_def(&mut self, it: &ast::item, def: &ast::enum_def,
+                      params: &ast::Generics) -> Enum {
+        debug!("Visiting enum");
+        let mut vars: ~[Variant] = ~[];
+        for x in def.variants.iter() {
+            vars.push(Variant {
+                name: x.node.name,
+                attrs: x.node.attrs.clone(),
+                vis: x.node.vis,
+                id: x.node.id,
+                kind: x.node.kind.clone(),
+                where: x.span,
+            });
+        }
+        Enum {
+            name: it.ident,
+            variants: vars,
+            vis: it.vis,
+            generics: params.clone(),
+            attrs: it.attrs.clone(),
+            id: it.id,
+            where: it.span,
+        }
+    }
+
+    pub fn visit_fn(&mut self, item: &ast::item, fd: &ast::fn_decl,
+                    purity: &ast::purity, _abi: &AbiSet,
+                    gen: &ast::Generics) -> Function {
+        debug!("Visiting fn");
+        Function {
+            id: item.id,
+            vis: item.vis,
+            attrs: item.attrs.clone(),
+            decl: fd.clone(),
+            name: item.ident,
+            where: item.span,
+            generics: gen.clone(),
+            purity: *purity,
+        }
+    }
+
+    pub fn visit_mod_contents(&mut self, span: Span, attrs: ~[ast::Attribute],
+                              vis: ast::visibility, id: ast::NodeId,
+                              m: &ast::_mod,
                               name: Option<ast::Ident>) -> Module {
-            let mut om = Module::new(name);
-            om.view_items = m.view_items.clone();
-            om.where = span;
-            om.attrs = attrs;
-            om.vis = vis;
-            om.id = id;
-            for i in m.items.iter() {
-                visit_item(*i, &mut om);
-            }
-            om
+        let mut om = Module::new(name);
+        for item in m.view_items.iter() {
+            self.visit_view_item(item, &mut om);
         }
+        om.where = span;
+        om.attrs = attrs;
+        om.vis = vis;
+        om.id = id;
+        for i in m.items.iter() {
+            self.visit_item(*i, &mut om);
+        }
+        om
+    }
 
-        fn visit_item(item: &ast::item, om: &mut Module) {
-            debug!("Visiting item {:?}", item);
-            match item.node {
-                ast::item_mod(ref m) => {
-                    om.mods.push(visit_mod_contents(item.span, item.attrs.clone(),
-                                                    item.vis, item.id, m,
-                                                    Some(item.ident)));
-                },
-                ast::item_enum(ref ed, ref gen) => om.enums.push(visit_enum_def(item, ed, gen)),
-                ast::item_struct(sd, ref gen) => om.structs.push(visit_struct_def(item, sd, gen)),
-                ast::item_fn(fd, ref pur, ref abi, ref gen, _) =>
-                    om.fns.push(visit_fn(item, fd, pur, abi, gen)),
-                ast::item_ty(ty, ref gen) => {
-                    let t = Typedef {
-                        ty: ty,
-                        gen: gen.clone(),
-                        name: item.ident,
-                        id: item.id,
-                        attrs: item.attrs.clone(),
-                        where: item.span,
-                        vis: item.vis,
-                    };
-                    om.typedefs.push(t);
-                },
-                ast::item_static(ty, ref mut_, ref exp) => {
-                    let s = Static {
-                        type_: ty,
-                        mutability: mut_.clone(),
-                        expr: exp.clone(),
-                        id: item.id,
-                        name: item.ident,
-                        attrs: item.attrs.clone(),
-                        where: item.span,
-                        vis: item.vis,
-                    };
-                    om.statics.push(s);
-                },
-                ast::item_trait(ref gen, ref tr, ref met) => {
-                    let t = Trait {
-                        name: item.ident,
-                        methods: met.clone(),
-                        generics: gen.clone(),
-                        parents: tr.clone(),
-                        id: item.id,
-                        attrs: item.attrs.clone(),
-                        where: item.span,
-                        vis: item.vis,
-                    };
-                    om.traits.push(t);
-                },
-                ast::item_impl(ref gen, ref tr, ty, ref meths) => {
-                    let i = Impl {
-                        generics: gen.clone(),
-                        trait_: tr.clone(),
-                        for_: ty,
-                        methods: meths.clone(),
-                        attrs: item.attrs.clone(),
-                        id: item.id,
-                        where: item.span,
-                        vis: item.vis,
-                    };
-                    om.impls.push(i);
-                },
-                ast::item_foreign_mod(ref fm) => {
-                    om.foreigns.push(fm.clone());
+    pub fn visit_view_item(&mut self, item: &ast::view_item, om: &mut Module) {
+        if item.vis != ast::public {
+            return om.view_items.push(item.clone());
+        }
+        let item = match item.node {
+            ast::view_item_use(ref paths) => {
+                // rustc no longer supports "use foo, bar;"
+                assert_eq!(paths.len(), 1);
+                match self.visit_view_path(paths[0], om) {
+                    None => return,
+                    Some(path) => {
+                        ast::view_item {
+                            node: ast::view_item_use(~[path]),
+                            .. item.clone()
+                        }
+                    }
                 }
-                _ => (),
+            }
+            ast::view_item_extern_mod(..) => item.clone()
+        };
+        om.view_items.push(item);
+    }
+
+    fn visit_view_path(&mut self, path: @ast::view_path,
+                       om: &mut Module) -> Option<@ast::view_path> {
+        match path.node {
+            ast::view_path_simple(_, _, id) => {
+                if self.resolve_id(id, false, om) { return None }
+            }
+            ast::view_path_list(ref p, ref paths, ref b) => {
+                let mut mine = ~[];
+                for path in paths.iter() {
+                    if !self.resolve_id(path.node.id, false, om) {
+                        mine.push(path.clone());
+                    }
+                }
+
+                if mine.len() == 0 { return None }
+                return Some(@::syntax::codemap::Spanned {
+                    node: ast::view_path_list(p.clone(), mine, b.clone()),
+                    span: path.span,
+                })
+            }
+
+            // these are feature gated anyway
+            ast::view_path_glob(_, id) => {
+                if self.resolve_id(id, true, om) { return None }
             }
         }
+        return Some(path);
+    }
 
-        self.module = visit_mod_contents(crate.span, crate.attrs.clone(),
-                                         ast::public, ast::CRATE_NODE_ID,
-                                         &crate.module, None);
+    fn resolve_id(&mut self, id: ast::NodeId, glob: bool,
+                  om: &mut Module) -> bool {
+        let def = {
+            let dm = match self.cx.tycx {
+                Some(tcx) => tcx.def_map.borrow(),
+                None => return false,
+            };
+            ast_util::def_id_of_def(*dm.get().get(&id))
+        };
+        if !ast_util::is_local(def) { return false }
+        let analysis = match self.analysis {
+            Some(analysis) => analysis, None => return false
+        };
+        if analysis.public_items.contains(&def.node) { return false }
+
+        let item = {
+            let items = self.cx.tycx.unwrap().items.borrow();
+            *items.get().get(&def.node)
+        };
+        match item {
+            ast_map::node_item(it, _) => {
+                if glob {
+                    match it.node {
+                        ast::item_mod(ref m) => {
+                            for vi in m.view_items.iter() {
+                                self.visit_view_item(vi, om);
+                            }
+                            for i in m.items.iter() {
+                                self.visit_item(*i, om);
+                            }
+                        }
+                        _ => { fail!("glob not mapped to a module"); }
+                    }
+                } else {
+                    self.visit_item(it, om);
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn visit_item(&mut self, item: &ast::item, om: &mut Module) {
+        debug!("Visiting item {:?}", item);
+        match item.node {
+            ast::item_mod(ref m) => {
+                om.mods.push(self.visit_mod_contents(item.span, item.attrs.clone(),
+                                                item.vis, item.id, m,
+                                                Some(item.ident)));
+            },
+            ast::item_enum(ref ed, ref gen) =>
+                om.enums.push(self.visit_enum_def(item, ed, gen)),
+            ast::item_struct(sd, ref gen) =>
+                om.structs.push(self.visit_struct_def(item, sd, gen)),
+            ast::item_fn(fd, ref pur, ref abi, ref gen, _) =>
+                om.fns.push(self.visit_fn(item, fd, pur, abi, gen)),
+            ast::item_ty(ty, ref gen) => {
+                let t = Typedef {
+                    ty: ty,
+                    gen: gen.clone(),
+                    name: item.ident,
+                    id: item.id,
+                    attrs: item.attrs.clone(),
+                    where: item.span,
+                    vis: item.vis,
+                };
+                om.typedefs.push(t);
+            },
+            ast::item_static(ty, ref mut_, ref exp) => {
+                let s = Static {
+                    type_: ty,
+                    mutability: mut_.clone(),
+                    expr: exp.clone(),
+                    id: item.id,
+                    name: item.ident,
+                    attrs: item.attrs.clone(),
+                    where: item.span,
+                    vis: item.vis,
+                };
+                om.statics.push(s);
+            },
+            ast::item_trait(ref gen, ref tr, ref met) => {
+                let t = Trait {
+                    name: item.ident,
+                    methods: met.clone(),
+                    generics: gen.clone(),
+                    parents: tr.clone(),
+                    id: item.id,
+                    attrs: item.attrs.clone(),
+                    where: item.span,
+                    vis: item.vis,
+                };
+                om.traits.push(t);
+            },
+            ast::item_impl(ref gen, ref tr, ty, ref meths) => {
+                let i = Impl {
+                    generics: gen.clone(),
+                    trait_: tr.clone(),
+                    for_: ty,
+                    methods: meths.clone(),
+                    attrs: item.attrs.clone(),
+                    id: item.id,
+                    where: item.span,
+                    vis: item.vis,
+                };
+                om.impls.push(i);
+            },
+            ast::item_foreign_mod(ref fm) => {
+                om.foreigns.push(fm.clone());
+            }
+            _ => (),
+        }
     }
 }


### PR DESCRIPTION
If a reexport comes from a non-public module, then the documentation for the
reexport will be inlined into the module that exports it, but if the reexport is
targeted at a public type (like the prelude), then it is not inlined but rather
hyperlinked.
