### PR TITLE
Remove the io::Decorator trait

### DIFF
--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -935,7 +935,6 @@ mod tests {
     use serialize::Encodable;
     use serialize;
 
-    use std::io::Decorator;
     use std::io::mem::MemWriter;
     use std::option::{None, Option, Some};
 
@@ -948,7 +947,7 @@ mod tests {
                 let mut ebml_w = writer::Encoder(&mut wr);
                 v.encode(&mut ebml_w);
             }
-            let ebml_doc = reader::Doc(*wr.inner_ref());
+            let ebml_doc = reader::Doc(wr.get_ref());
             let mut deser = reader::Decoder(ebml_doc);
             let v1 = serialize::Decodable::decode(&mut deser);
             debug!("v1 == {:?}", v1);

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -21,7 +21,6 @@ use std::cast::transmute;
 use std::f64;
 use std::hashmap::HashMap;
 use std::io;
-use std::io::Decorator;
 use std::io::mem::MemWriter;
 use std::num;
 use std::str;
@@ -464,7 +463,7 @@ impl Json{
     pub fn to_pretty_str(&self) -> ~str {
         let mut s = MemWriter::new();
         self.to_pretty_writer(&mut s as &mut io::Writer);
-        str::from_utf8_owned(s.inner())
+        str::from_utf8_owned(s.unwrap())
     }
 }
 
@@ -1321,7 +1320,7 @@ impl to_str::ToStr for Json {
     fn to_str(&self) -> ~str {
         let mut s = MemWriter::new();
         self.to_writer(&mut s as &mut io::Writer);
-        str::from_utf8_owned(s.inner())
+        str::from_utf8_owned(s.unwrap())
     }
 }
 
@@ -1508,12 +1507,11 @@ mod tests {
 
     fn with_str_writer(f: |&mut io::Writer|) -> ~str {
         use std::io::mem::MemWriter;
-        use std::io::Decorator;
         use std::str;
 
         let mut m = MemWriter::new();
         f(&mut m as &mut io::Writer);
-        str::from_utf8_owned(m.inner())
+        str::from_utf8_owned(m.unwrap())
     }
 
     #[test]

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -991,10 +991,9 @@ mod tests {
     fn test_boxplot_nonpositive() {
         fn t(s: &Summary, expected: ~str) {
             use std::io::mem::MemWriter;
-            use std::io::Decorator;
             let mut m = MemWriter::new();
             write_boxplot(&mut m as &mut io::Writer, s, 30);
-            let out = str::from_utf8_owned(m.inner());
+            let out = str::from_utf8_owned(m.unwrap());
             assert_eq!(out, expected);
         }
 

--- a/src/libextra/term.rs
+++ b/src/libextra/term.rs
@@ -13,8 +13,6 @@
 #[allow(missing_doc)];
 
 
-use std::io::{Decorator, Writer};
-
 use std::os;
 use terminfo::*;
 use terminfo::searcher::open;
@@ -234,20 +232,12 @@ impl<T: Writer> Terminal<T> {
             color-8
         } else { color }
     }
-}
 
-impl<T: Writer> Decorator<T> for Terminal<T> {
-    fn inner(self) -> T {
-        self.out
-    }
+    pub fn unwrap(self) -> T { self.out }
 
-    fn inner_ref<'a>(&'a self) -> &'a T {
-        &self.out
-    }
+    pub fn get_ref<'a>(&'a self) -> &'a T { &self.out }
 
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut T {
-        &mut self.out
-    }
+    pub fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }
 }
 
 impl<T: Writer> Writer for Terminal<T> {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -673,7 +673,6 @@ pub fn run_tests_console(opts: &TestOpts,
 
 #[test]
 fn should_sort_failures_before_printing_them() {
-    use std::io::Decorator;
     use std::io::mem::MemWriter;
     use std::str;
 
@@ -705,7 +704,7 @@ fn should_sort_failures_before_printing_them() {
 
     st.write_failures();
     let s = match st.out {
-        Raw(ref m) => str::from_utf8(*m.inner_ref()),
+        Raw(ref m) => str::from_utf8(m.get_ref()),
         Pretty(_) => unreachable!()
     };
 

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -522,7 +522,6 @@ mod test {
     use std::str;
     use std::rand;
     use std::num::Zero;
-    use std::io::Decorator;
     use std::io::mem::MemWriter;
 
     #[test]
@@ -798,7 +797,7 @@ mod test {
         let u = Uuid::new_v4();
         let mut wr = MemWriter::new();
         u.encode(&mut ebml::writer::Encoder(&mut wr));
-        let doc = ebml::reader::Doc(wr.inner_ref().as_slice());
+        let doc = ebml::reader::Doc(wr.get_ref());
         let u2 = Decodable::decode(&mut ebml::reader::Decoder(doc));
         assert_eq!(u, u2);
     }

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -17,7 +17,7 @@ use arc::{Arc,RWArc};
 use treemap::TreeMap;
 use std::str;
 use std::io;
-use std::io::{File, Decorator};
+use std::io::File;
 use std::io::mem::MemWriter;
 
 /**
@@ -261,7 +261,7 @@ fn json_encode<'a, T:Encodable<json::Encoder<'a>>>(t: &T) -> ~str {
     let mut writer = MemWriter::new();
     let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
     t.encode(&mut encoder);
-    str::from_utf8_owned(writer.inner())
+    str::from_utf8_owned(writer.unwrap())
 }
 
 // FIXME(#5121)

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -25,7 +25,6 @@ use std::cast;
 use std::cell::{Cell, RefCell};
 use std::hashmap::{HashMap, HashSet};
 use std::io::mem::MemWriter;
-use std::io::{Writer, Seek, Decorator};
 use std::str;
 use std::vec;
 
@@ -1807,7 +1806,7 @@ pub static metadata_encoding_version : &'static [u8] =
 pub fn encode_metadata(parms: EncodeParams, crate: &Crate) -> ~[u8] {
     let mut wr = MemWriter::new();
     encode_metadata_inner(&mut wr, parms, crate);
-    wr.inner()
+    wr.unwrap()
 }
 
 fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, crate: &Crate) {
@@ -1900,7 +1899,7 @@ fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, crate: &Crate)
     ecx.stats.total_bytes.set(ebml_w.writer.tell());
 
     if (tcx.sess.meta_stats()) {
-        for e in ebml_w.writer.inner_ref().iter() {
+        for e in ebml_w.writer.get_ref().iter() {
             if *e == 0 {
                 ecx.stats.zero_bytes.set(ecx.stats.zero_bytes.get() + 1);
             }
@@ -1930,5 +1929,5 @@ pub fn encoded_ty(tcx: ty::ctxt, t: ty::t) -> ~str {
         abbrevs: tyencode::ac_no_abbrevs};
     let mut wr = MemWriter::new();
     tyencode::enc_ty(&mut wr, cx, t);
-    str::from_utf8_owned(wr.inner_ref().to_owned())
+    str::from_utf8_owned(wr.get_ref().to_owned())
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -13,7 +13,6 @@
 use std::cell::RefCell;
 use std::hashmap::HashMap;
 use std::io;
-use std::io::{Decorator, Writer, Seek};
 use std::io::mem::MemWriter;
 use std::str;
 use std::fmt;
@@ -73,7 +72,7 @@ pub fn enc_ty(w: &mut MemWriter, cx: @ctxt, t: ty::t) {
             None => {
                 let wr = &mut MemWriter::new();
                 enc_sty(wr, cx, &ty::get(t).sty);
-                let s = str::from_utf8(*wr.inner_ref()).to_managed();
+                let s = str::from_utf8(wr.get_ref()).to_managed();
                 let mut short_names_cache = cx.tcx
                                               .short_names_cache
                                               .borrow_mut();

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1465,7 +1465,6 @@ fn mk_ctxt() -> @fake_ext_ctxt {
 
 #[cfg(test)]
 fn roundtrip(in_item: Option<@ast::item>) {
-    use std::io::Decorator;
     use std::io::mem::MemWriter;
 
     let in_item = in_item.unwrap();
@@ -1474,7 +1473,7 @@ fn roundtrip(in_item: Option<@ast::item>) {
         let mut ebml_w = writer::Encoder(&mut wr);
         encode_item_ast(&mut ebml_w, in_item);
     }
-    let ebml_doc = reader::Doc(wr.inner_ref().as_slice());
+    let ebml_doc = reader::Doc(wr.get_ref());
     let out_item = decode_item_ast(ebml_doc);
 
     assert_eq!(in_item, out_item);

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -23,7 +23,6 @@ use std::local_data;
 use std::io;
 use std::io::File;
 use std::io::mem::MemWriter;
-use std::io::Decorator;
 use std::str;
 use extra::getopts;
 use extra::getopts::groups;
@@ -322,7 +321,7 @@ fn json_output(crate: clean::Crate, res: ~[plugins::PluginJson], dst: Path) {
             let mut encoder = json::Encoder::new(&mut w as &mut io::Writer);
             crate.encode(&mut encoder);
         }
-        str::from_utf8_owned(w.inner())
+        str::from_utf8_owned(w.unwrap())
     };
     let crate_json = match json::from_str(crate_json_str) {
         Ok(j) => j,

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -470,7 +470,6 @@ use prelude::*;
 
 use cast;
 use char::Char;
-use io::Decorator;
 use io::mem::MemWriter;
 use io;
 use str;
@@ -692,7 +691,7 @@ pub fn format(args: &Arguments) -> ~str {
 pub unsafe fn format_unsafe(fmt: &[rt::Piece], args: &[Argument]) -> ~str {
     let mut output = MemWriter::new();
     write_unsafe(&mut output as &mut io::Writer, fmt, args);
-    return str::from_utf8_owned(output.inner());
+    return str::from_utf8_owned(output.unwrap());
 }
 
 impl<'a> Formatter<'a> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -55,7 +55,7 @@ use prelude::*;
 
 use num;
 use vec;
-use super::{Stream, Decorator};
+use super::Stream;
 
 // libuv recommends 64k buffers to maximize throughput
 // https://groups.google.com/forum/#!topic/libuv/oQO1HJAIDdA
@@ -92,6 +92,17 @@ impl<R: Reader> BufferedReader<R> {
     pub fn new(inner: R) -> BufferedReader<R> {
         BufferedReader::with_capacity(DEFAULT_CAPACITY, inner)
     }
+
+    /// Gets a reference to the underlying reader.
+    ///
+    /// This type does not expose the ability to get a mutable reference to the
+    /// underlying reader because that could possibly corrupt the buffer.
+    pub fn get_ref<'a>(&'a self) -> &'a R { &self.inner }
+
+    /// Unwraps this buffer, returning the underlying reader.
+    ///
+    /// Note that any leftover data in the internal buffer is lost.
+    pub fn unwrap(self) -> R { self.inner }
 }
 
 impl<R: Reader> Buffer for BufferedReader<R> {
@@ -134,12 +145,6 @@ impl<R: Reader> Reader for BufferedReader<R> {
     }
 }
 
-impl<R: Reader> Decorator<R> for BufferedReader<R> {
-    fn inner(self) -> R { self.inner }
-    fn inner_ref<'a>(&'a self) -> &'a R { &self.inner }
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut R { &mut self.inner }
-}
-
 /// Wraps a Writer and buffers output to it
 ///
 /// Note that `BufferedWriter` will NOT flush its buffer when dropped.
@@ -173,6 +178,20 @@ impl<W: Writer> BufferedWriter<W> {
             self.pos = 0;
         }
     }
+
+    /// Gets a reference to the underlying writer.
+    ///
+    /// This type does not expose the ability to get a mutable reference to the
+    /// underlying reader because that could possibly corrupt the buffer.
+    pub fn get_ref<'a>(&'a self) -> &'a W { &self.inner }
+
+    /// Unwraps this buffer, returning the underlying writer.
+    ///
+    /// The buffer is flushed before returning the writer.
+    pub fn unwrap(mut self) -> W {
+        self.flush_buf();
+        self.inner
+    }
 }
 
 impl<W: Writer> Writer for BufferedWriter<W> {
@@ -196,12 +215,6 @@ impl<W: Writer> Writer for BufferedWriter<W> {
     }
 }
 
-impl<W: Writer> Decorator<W> for BufferedWriter<W> {
-    fn inner(mut self) -> W { self.flush_buf(); self.inner }
-    fn inner_ref<'a>(&'a self) -> &'a W { &self.inner }
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut W { &mut self.inner }
-}
-
 /// Wraps a Writer and buffers output to it, flushing whenever a newline (`0x0a`,
 /// `'\n'`) is detected.
 ///
@@ -218,6 +231,17 @@ impl<W: Writer> LineBufferedWriter<W> {
             inner: BufferedWriter::with_capacity(1024, inner)
         }
     }
+
+    /// Gets a reference to the underlying writer.
+    ///
+    /// This type does not expose the ability to get a mutable reference to the
+    /// underlying reader because that could possibly corrupt the buffer.
+    pub fn get_ref<'a>(&'a self) -> &'a W { self.inner.get_ref() }
+
+    /// Unwraps this buffer, returning the underlying writer.
+    ///
+    /// The internal buffer is flushed before returning the writer.
+    pub fn unwrap(mut self) -> W { self.inner.unwrap() }
 }
 
 impl<W: Writer> Writer for LineBufferedWriter<W> {
@@ -235,33 +259,12 @@ impl<W: Writer> Writer for LineBufferedWriter<W> {
     fn flush(&mut self) { self.inner.flush() }
 }
 
-impl<W: Writer> Decorator<W> for LineBufferedWriter<W> {
-    fn inner(self) -> W { self.inner.inner() }
-    fn inner_ref<'a>(&'a self) -> &'a W { self.inner.inner_ref() }
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut W { self.inner.inner_mut_ref() }
-}
-
 struct InternalBufferedWriter<W>(BufferedWriter<W>);
 
 impl<W> InternalBufferedWriter<W> {
     fn get_mut_ref<'a>(&'a mut self) -> &'a mut BufferedWriter<W> {
         let InternalBufferedWriter(ref mut w) = *self;
         return w;
-    }
-}
-
-impl<W: Writer> Decorator<W> for InternalBufferedWriter<W> {
-    fn inner(self) -> W {
-        let InternalBufferedWriter(s) = self;
-        s.inner()
-    }
-    fn inner_ref<'a>(&'a self) -> &'a W {
-        let InternalBufferedWriter(ref s) = *self;
-        s.inner_ref()
-    }
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut W {
-        let InternalBufferedWriter(ref mut s) = *self;
-        s.inner_mut_ref()
     }
 }
 
@@ -278,6 +281,8 @@ pub struct BufferedStream<S> {
 }
 
 impl<S: Stream> BufferedStream<S> {
+    /// Creates a new buffered stream with explicitly listed capacities for the
+    /// reader/writer buffer.
     pub fn with_capacities(reader_cap: uint, writer_cap: uint, inner: S)
                            -> BufferedStream<S> {
         let writer = BufferedWriter::with_capacity(writer_cap, inner);
@@ -287,9 +292,29 @@ impl<S: Stream> BufferedStream<S> {
         BufferedStream { inner: reader }
     }
 
+    /// Creates a new buffered stream with the default reader/writer buffer
+    /// capacities.
     pub fn new(inner: S) -> BufferedStream<S> {
         BufferedStream::with_capacities(DEFAULT_CAPACITY, DEFAULT_CAPACITY,
                                         inner)
+    }
+
+    /// Gets a reference to the underlying stream.
+    ///
+    /// This type does not expose the ability to get a mutable reference to the
+    /// underlying reader because that could possibly corrupt the buffer.
+    pub fn get_ref<'a>(&'a self) -> &'a S {
+        let InternalBufferedWriter(ref w) = self.inner.inner;
+        w.get_ref()
+    }
+
+    /// Unwraps this buffer, returning the underlying stream.
+    ///
+    /// The internal buffer is flushed before returning the stream. Any leftover
+    /// data in the read buffer is lost.
+    pub fn unwrap(self) -> S {
+        let InternalBufferedWriter(w) = self.inner.inner;
+        w.unwrap()
     }
 }
 
@@ -308,17 +333,8 @@ impl<S: Stream> Writer for BufferedStream<S> {
     fn flush(&mut self) { self.inner.inner.get_mut_ref().flush() }
 }
 
-impl<S: Stream> Decorator<S> for BufferedStream<S> {
-    fn inner(self) -> S { self.inner.inner.inner() }
-    fn inner_ref<'a>(&'a self) -> &'a S { self.inner.inner.inner_ref() }
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut S {
-        self.inner.inner.get_mut_ref().inner_mut_ref()
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use io::Decorator;
     use io;
     use prelude::*;
     use super::*;
@@ -397,45 +413,45 @@ mod test {
         let mut writer = BufferedWriter::with_capacity(2, inner);
 
         writer.write([0, 1]);
-        assert_eq!([], writer.inner_ref().inner_ref().as_slice());
+        assert_eq!([], writer.get_ref().get_ref());
 
         writer.write([2]);
-        assert_eq!([0, 1], writer.inner_ref().inner_ref().as_slice());
+        assert_eq!([0, 1], writer.get_ref().get_ref());
 
         writer.write([3]);
-        assert_eq!([0, 1], writer.inner_ref().inner_ref().as_slice());
+        assert_eq!([0, 1], writer.get_ref().get_ref());
 
         writer.flush();
-        assert_eq!([0, 1, 2, 3], writer.inner_ref().inner_ref().as_slice());
+        assert_eq!([0, 1, 2, 3], writer.get_ref().get_ref());
 
         writer.write([4]);
         writer.write([5]);
-        assert_eq!([0, 1, 2, 3], writer.inner_ref().inner_ref().as_slice());
+        assert_eq!([0, 1, 2, 3], writer.get_ref().get_ref());
 
         writer.write([6]);
         assert_eq!([0, 1, 2, 3, 4, 5],
-                   writer.inner_ref().inner_ref().as_slice());
+                   writer.get_ref().get_ref());
 
         writer.write([7, 8]);
         assert_eq!([0, 1, 2, 3, 4, 5, 6],
-                   writer.inner_ref().inner_ref().as_slice());
+                   writer.get_ref().get_ref());
 
         writer.write([9, 10, 11]);
         assert_eq!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-                   writer.inner_ref().inner_ref().as_slice());
+                   writer.get_ref().get_ref());
 
         writer.flush();
         assert_eq!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-                   writer.inner_ref().inner_ref().as_slice());
+                   writer.get_ref().get_ref());
     }
 
     #[test]
     fn test_buffered_writer_inner_flushes() {
         let mut w = BufferedWriter::with_capacity(3, MemWriter::new());
         w.write([0, 1]);
-        assert_eq!([], w.inner_ref().inner_ref().as_slice());
-        let w = w.inner();
-        assert_eq!([0, 1], w.inner_ref().as_slice());
+        assert_eq!([], w.get_ref().get_ref());
+        let w = w.unwrap();
+        assert_eq!([0, 1], w.get_ref());
     }
 
     // This is just here to make sure that we don't infinite loop in the
@@ -476,20 +492,20 @@ mod test {
     fn test_line_buffer() {
         let mut writer = LineBufferedWriter::new(MemWriter::new());
         writer.write([0]);
-        assert_eq!(*writer.inner_ref().inner_ref(), ~[]);
+        assert_eq!(writer.get_ref().get_ref(), []);
         writer.write([1]);
-        assert_eq!(*writer.inner_ref().inner_ref(), ~[]);
+        assert_eq!(writer.get_ref().get_ref(), []);
         writer.flush();
-        assert_eq!(*writer.inner_ref().inner_ref(), ~[0, 1]);
+        assert_eq!(writer.get_ref().get_ref(), [0, 1]);
         writer.write([0, '\n' as u8, 1, '\n' as u8, 2]);
-        assert_eq!(*writer.inner_ref().inner_ref(),
-            ~[0, 1, 0, '\n' as u8, 1, '\n' as u8]);
+        assert_eq!(writer.get_ref().get_ref(),
+            [0, 1, 0, '\n' as u8, 1, '\n' as u8]);
         writer.flush();
-        assert_eq!(*writer.inner_ref().inner_ref(),
-            ~[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2]);
+        assert_eq!(writer.get_ref().get_ref(),
+            [0, 1, 0, '\n' as u8, 1, '\n' as u8, 2]);
         writer.write([3, '\n' as u8]);
-        assert_eq!(*writer.inner_ref().inner_ref(),
-            ~[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
+        assert_eq!(writer.get_ref().get_ref(),
+            [0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
     }
 
     #[test]

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -132,7 +132,6 @@ pub fn u64_from_be_bytes(data: &[u8],
 #[cfg(test)]
 mod test {
     use unstable::finally::Finally;
-    use io::Decorator;
     use prelude::*;
     use io::mem::{MemReader, MemWriter};
     use io::{io_error, placeholder_error};
@@ -419,7 +418,7 @@ mod test {
             writer.write_le_u64(*i);
         }
 
-        let mut reader = MemReader::new(writer.inner());
+        let mut reader = MemReader::new(writer.unwrap());
         for i in uints.iter() {
             assert!(reader.read_le_u64() == *i);
         }
@@ -435,7 +434,7 @@ mod test {
             writer.write_be_u64(*i);
         }
 
-        let mut reader = MemReader::new(writer.inner());
+        let mut reader = MemReader::new(writer.unwrap());
         for i in uints.iter() {
             assert!(reader.read_be_u64() == *i);
         }
@@ -450,7 +449,7 @@ mod test {
             writer.write_be_i32(*i);
         }
 
-        let mut reader = MemReader::new(writer.inner());
+        let mut reader = MemReader::new(writer.unwrap());
         for i in ints.iter() {
             // this tests that the sign extension is working
             // (comparing the values as i32 would not test this)
@@ -466,7 +465,7 @@ mod test {
         let mut writer = MemWriter::new();
         writer.write(buf);
 
-        let mut reader = MemReader::new(writer.inner());
+        let mut reader = MemReader::new(writer.unwrap());
         let f = reader.read_be_f32();
         assert!(f == 8.1250);
     }
@@ -479,7 +478,7 @@ mod test {
         writer.write_be_f32(f);
         writer.write_le_f32(f);
 
-        let mut reader = MemReader::new(writer.inner());
+        let mut reader = MemReader::new(writer.unwrap());
         assert!(reader.read_be_f32() == 8.1250);
         assert!(reader.read_le_f32() == 8.1250);
     }

--- a/src/libstd/io/flate.rs
+++ b/src/libstd/io/flate.rs
@@ -34,26 +34,6 @@ impl<W: Writer> Writer for DeflateWriter<W> {
     fn flush(&mut self) { fail!() }
 }
 
-impl<W: Writer> Decorator<W> for DeflateWriter<W> {
-    fn inner(self) -> W {
-        match self {
-            DeflateWriter { inner_writer: w } => w
-        }
-    }
-
-    fn inner_ref<'a>(&'a self) -> &'a W {
-        match *self {
-            DeflateWriter { inner_writer: ref w } => w
-        }
-    }
-
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut W {
-        match *self {
-            DeflateWriter { inner_writer: ref mut w } => w
-        }
-    }
-}
-
 /// A Reader decorator that decompresses using the 'deflate' scheme
 pub struct InflateReader<R> {
     priv inner_reader: R
@@ -71,53 +51,4 @@ impl<R: Reader> Reader for InflateReader<R> {
     fn read(&mut self, _buf: &mut [u8]) -> Option<uint> { fail!() }
 
     fn eof(&mut self) -> bool { fail!() }
-}
-
-impl<R: Reader> Decorator<R> for InflateReader<R> {
-    fn inner(self) -> R {
-        match self {
-            InflateReader { inner_reader: r } => r
-        }
-    }
-
-    fn inner_ref<'a>(&'a self) -> &'a R {
-        match *self {
-            InflateReader { inner_reader: ref r } => r
-        }
-    }
-
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut R {
-        match *self {
-            InflateReader { inner_reader: ref mut r } => r
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use prelude::*;
-    use super::*;
-    use super::super::mem::*;
-    use super::super::Decorator;
-
-    use str;
-
-    #[test]
-    #[ignore]
-    fn smoke_test() {
-        let mem_writer = MemWriter::new();
-        let mut deflate_writer = DeflateWriter::new(mem_writer);
-        let in_msg: &str = "test";
-        let in_bytes = in_msg.as_bytes();
-        deflate_writer.write(in_bytes);
-        deflate_writer.flush();
-        let buf = deflate_writer.inner().inner();
-        let mem_reader = MemReader::new(buf);
-        let mut inflate_reader = InflateReader::new(mem_reader);
-        let mut out_bytes = [0, .. 100];
-        let bytes_read = inflate_reader.read(out_bytes).unwrap();
-        assert_eq!(bytes_read, in_bytes.len());
-        let out_msg = str::from_utf8(out_bytes);
-        assert_eq!(in_msg, out_msg);
-    }
 }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -113,7 +113,6 @@ Some examples of obvious things you might want to do
 * Writer - An I/O sink, writes bytes from a buffer
 * Stream - Typical I/O sources like files and sockets are both Readers and Writers,
   and are collectively referred to a `streams`.
-* Decorator - A Reader or Writer that composes with others to add additional capabilities
   such as encoding or decoding
 
 # Blocking and synchrony
@@ -1296,32 +1295,6 @@ impl<'a, T, A: Acceptor<T>> Iterator<Option<T>> for IncomingIterator<'a, A> {
     fn next(&mut self) -> Option<Option<T>> {
         Some(self.inc.accept())
     }
-}
-
-/// Common trait for decorator types.
-///
-/// Provides accessors to get the inner, 'decorated' values. The I/O library
-/// uses decorators to add functionality like compression and encryption to I/O
-/// streams.
-///
-/// # XXX
-///
-/// Is this worth having a trait for? May be overkill
-pub trait Decorator<T> {
-    /// Destroy the decorator and extract the decorated value
-    ///
-    /// # XXX
-    ///
-    /// Because this takes `self' one could never 'undecorate' a Reader/Writer
-    /// that has been boxed. Is that ok? This feature is mostly useful for
-    /// extracting the buffer from MemWriter
-    fn inner(self) -> T;
-
-    /// Take an immutable reference to the decorated value
-    fn inner_ref<'a>(&'a self) -> &'a T;
-
-    /// Take a mutable reference to the decorated value
-    fn inner_mut_ref<'a>(&'a mut self) -> &'a mut T;
 }
 
 pub fn standard_error(kind: IoErrorKind) -> IoError {

--- a/src/libstd/io/option.rs
+++ b/src/libstd/io/option.rs
@@ -106,7 +106,6 @@ impl<T, A: Acceptor<T>> Acceptor<T> for Option<A> {
 mod test {
     use prelude::*;
     use super::super::mem::*;
-    use io::Decorator;
     use super::super::{PreviousIoError, io_error};
 
     #[test]
@@ -114,7 +113,7 @@ mod test {
         let mut writer: Option<MemWriter> = Some(MemWriter::new());
         writer.write([0, 1, 2]);
         writer.flush();
-        assert_eq!(writer.unwrap().inner(), ~[0, 1, 2]);
+        assert_eq!(writer.unwrap().unwrap(), ~[0, 1, 2]);
     }
 
     #[test]

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -193,7 +193,6 @@ pub fn copy<R: Reader, W: Writer>(r: &mut R, w: &mut W) {
 
 #[cfg(test)]
 mod test {
-    use io::Decorator;
     use io::mem::{MemReader, MemWriter};
     use super::*;
     use prelude::*;
@@ -282,7 +281,7 @@ mod test {
                                    MemWriter::new());
         assert_eq!(~[0, 1, 2], r.read_to_end());
         let (_, w) = r.unwrap();
-        assert_eq!(~[0, 1, 2], w.inner());
+        assert_eq!(~[0, 1, 2], w.unwrap());
     }
 
     #[test]
@@ -291,6 +290,6 @@ mod test {
         let mut w = MemWriter::new();
         copy(&mut r, &mut w);
         assert!(r.eof());
-        assert_eq!(~[0, 1, 2, 3, 4], w.inner());
+        assert_eq!(~[0, 1, 2, 3, 4], w.unwrap());
     }
 }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -620,11 +620,10 @@ pub fn write_repr<T>(writer: &mut io::Writer, object: &T) {
 pub fn repr_to_str<T>(t: &T) -> ~str {
     use str;
     use io;
-    use io::Decorator;
 
     let mut result = io::mem::MemWriter::new();
     write_repr(&mut result as &mut io::Writer, t);
-    str::from_utf8_owned(result.inner())
+    str::from_utf8_owned(result.unwrap())
 }
 
 #[cfg(test)]
@@ -635,14 +634,13 @@ fn test_repr() {
     use prelude::*;
     use str;
     use str::Str;
-    use io::Decorator;
     use util::swap;
     use char::is_alphabetic;
 
     fn exact_test<T>(t: &T, e:&str) {
         let mut m = io::mem::MemWriter::new();
         write_repr(&mut m as &mut io::Writer, t);
-        let s = str::from_utf8_owned(m.inner());
+        let s = str::from_utf8_owned(m.unwrap());
         assert_eq!(s.as_slice(), e);
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -338,7 +338,6 @@ mod test {
     use extra::serialize::Encodable;
     use extra;
     use std::io;
-    use std::io::Decorator;
     use std::io::mem::MemWriter;
     use std::str;
     use codemap::{Span, BytePos, Spanned};
@@ -356,7 +355,7 @@ mod test {
         let mut writer = MemWriter::new();
         let mut encoder = extra::json::Encoder::new(&mut writer as &mut io::Writer);
         val.encode(&mut encoder);
-        str::from_utf8_owned(writer.inner())
+        str::from_utf8_owned(writer.unwrap())
     }
 
     // produce a codemap::span

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -32,7 +32,6 @@ use std::cell::RefCell;
 use std::char;
 use std::str;
 use std::io;
-use std::io::Decorator;
 use std::io::mem::MemWriter;
 
 // The &mut ps is stored here to prevent recursive type.
@@ -2322,7 +2321,7 @@ pub fn print_string(s: &mut ps, st: &str, style: ast::StrStyle) {
 // downcasts.
 unsafe fn get_mem_writer(writer: &mut ~io::Writer) -> ~str {
     let (_, wr): (uint, ~MemWriter) = cast::transmute_copy(writer);
-    let result = str::from_utf8_owned(wr.inner_ref().to_owned());
+    let result = str::from_utf8_owned(wr.get_ref().to_owned());
     cast::forget(wr);
     result
 }

--- a/src/test/run-pass/auto-encode.rs
+++ b/src/test/run-pass/auto-encode.rs
@@ -20,7 +20,6 @@ extern mod extra;
 // the common code.
 
 use std::hashmap::{HashMap, HashSet};
-use std::io::Decorator;
 
 use EBReader = extra::ebml::reader;
 use EBWriter = extra::ebml::writer;
@@ -38,7 +37,7 @@ fn test_ebml<'a, A:
     let mut wr = std::io::mem::MemWriter::new();
     let mut ebml_w = EBWriter::Encoder(&mut wr);
     a1.encode(&mut ebml_w);
-    let bytes = wr.inner_ref().as_slice();
+    let bytes = wr.get_ref();
 
     let d: extra::ebml::Doc<'a> = EBReader::Doc(bytes);
     let mut decoder: EBReader::Decoder<'a> = EBReader::Decoder(d);

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -19,7 +19,6 @@
 extern mod extra;
 
 use std::io::mem::MemWriter;
-use std::io::Decorator;
 use std::rand::{random, Rand};
 use extra::serialize::{Encodable, Decodable};
 use extra::ebml;
@@ -61,7 +60,7 @@ fn roundtrip<'a, T: Rand + Eq + Encodable<Encoder> +
     let mut w = MemWriter::new();
     let mut e = Encoder(&mut w);
     obj.encode(&mut e);
-    let doc = ebml::reader::Doc(@w.inner_ref().to_owned());
+    let doc = ebml::reader::Doc(@w.get_ref());
     let mut dec = Decoder(doc);
     let obj2 = Decodable::decode(&mut dec);
     assert!(obj == obj2);

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -14,7 +14,6 @@
 #[deny(warnings)];
 
 use std::fmt;
-use std::io::Decorator;
 use std::io::mem::MemWriter;
 use std::io;
 use std::io::Writer;
@@ -262,7 +261,7 @@ fn test_write() {
         writeln!(w, "{foo}", foo="bar");
     }
 
-    let s = str::from_utf8_owned(buf.inner());
+    let s = str::from_utf8_owned(buf.unwrap());
     t!(s, "34helloline\nbar\n");
 }
 
@@ -286,7 +285,7 @@ fn test_format_args() {
         format_args!(|args| { fmt::write(w, args) }, "test");
         format_args!(|args| { fmt::write(w, args) }, "{test}", test=3);
     }
-    let s = str::from_utf8_owned(buf.inner());
+    let s = str::from_utf8_owned(buf.unwrap());
     t!(s, "1test3");
 
     let s = format_args!(fmt::format, "hello {}", "world");


### PR DESCRIPTION
This is just an unnecessary trait that no one's ever going to parameterize over
and it's more useful to just define the methods directly on the types
themselves. The implementors of this type almost always don't want
inner_mut_ref() but they're forced to define it as well.
