### PR TITLE
Fix the snapshot and cross compilation

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -56,7 +56,11 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/$(CFG_RUNTIME_$(2)): \
 
 # SNAP a5fa1d9 remove this after the stage0 snapshot from rules below
 ifeq ($(1),0)
+ifeq ($(3),$$(findstring $(3),$$(NON_BUILD_HOST)))
+LFLAGS_$(1)_$(2)_$(3) :=
+else
 LFLAGS_$(1)_$(2)_$(3) := -L $$(TLIB$(1)_T_$(2)_H_$(3))
+endif
 else
 LFLAGS_$(1)_$(2)_$(3) :=
 endif


### PR DESCRIPTION
If we bootstrap a cross compile from a stage1 compiler, then the stage1 compiler
already knows about the rustc => rustlib change, so we need to not add the extra
flag if it's a stage0 version of a target from a stage1 of another target.
