### PR TITLE
Start the span for a path in a view_path at the correct place.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4925,6 +4925,7 @@ impl Parser {
           token::EQ => {
             // x = foo::bar
             self.bump();
+            let path_lo = self.span.lo;
             path = ~[self.parse_ident()];
             while self.token == token::MOD_SEP {
                 self.bump();
@@ -4932,7 +4933,7 @@ impl Parser {
                 path.push(id);
             }
             let path = ast::Path {
-                span: mk_sp(lo, self.span.hi),
+                span: mk_sp(path_lo, self.span.hi),
                 global: false,
                 segments: path.move_iter().map(|identifier| {
                     ast::PathSegment {


### PR DESCRIPTION
...at the start of the path, rather than at the start of the view_path.

Fixes #11317
