### PR TITLE
Remove re-exports of std::io::stdio::{print, println} in the prelude.

### DIFF
--- a/doc/guide-conditions.md
+++ b/doc/guide-conditions.md
@@ -275,7 +275,7 @@ fn main() {
 
     };
     if result.is_err() {
-            println("parsing failed");
+            println!("parsing failed");
     }
 }
 

--- a/doc/guide-container.md
+++ b/doc/guide-container.md
@@ -218,12 +218,12 @@ let xs = [2u, 3, 5, 7, 11, 13, 17];
 
 // print out all the elements in the vector
 for x in xs.iter() {
-    println(x.to_str())
+    println!("{}", *x)
 }
 
 // print out all but the first 3 elements in the vector
 for x in xs.iter().skip(3) {
-    println(x.to_str())
+    println!("{}", *x)
 }
 ~~~
 

--- a/doc/guide-pointers.md
+++ b/doc/guide-pointers.md
@@ -222,7 +222,7 @@ struct Point {
 fn main() {
     let a = Point { x: 10, y: 20 };
     do spawn {
-        println(a.x.to_str());
+        println!("{}", a.x);
     }
 }
 ~~~
@@ -239,7 +239,7 @@ struct Point {
 fn main() {
     let a = ~Point { x: 10, y: 20 };
     do spawn {
-        println(a.x.to_str());
+        println!("{}", a.x);
     }
 }
 ~~~
@@ -270,18 +270,22 @@ struct Point {
 fn main() {
     let a = ~Point { x: 10, y: 20 };
     let b = a;
-    println(b.x.to_str());
-    println(a.x.to_str());
+    println!("{}", b.x);
+    println!("{}", a.x);
 }
 ~~~
 
 You'll get this error:
 
 ~~~ {.notrust}
-test.rs:10:12: 10:13 error: use of moved value: `a`
-test.rs:10     println(a.x.to_str());
-                       ^
-test.rs:8:8: 8:9 note: `a` moved here because it has type `~Point`, which is moved by default (use `ref` to override)
+test.rs:10:20: 10:21 error: use of moved value: `a`
+test.rs:10     println!("{}", a.x);
+                              ^
+note: in expansion of format_args!
+<std-macros>:158:27: 158:81 note: expansion site
+<std-macros>:157:5: 159:6 note: in expansion of println!
+test.rs:10:5: 10:25 note: expansion site
+test.rs:8:9: 8:10 note: `a` moved here because it has type `~Point`, which is moved by default (use `ref` to override)
 test.rs:8     let b = a;
                   ^
 ~~~
@@ -297,8 +301,8 @@ struct Point {
 fn main() {
     let a = @Point { x: 10, y: 20 };
     let b = a;
-    println(b.x.to_str());
-    println(a.x.to_str());
+    println!("{}", b.x);
+    println!("{}", a.x);
 }
 ~~~
 
@@ -367,7 +371,7 @@ compile?
 
 ~~~rust{.xfail-test}
 fn main() {
-    println(x.to_str());
+    println!("{}", x);
     let x = 5;
 }
 ~~~

--- a/doc/guide-rustpkg.md
+++ b/doc/guide-rustpkg.md
@@ -143,7 +143,7 @@ Next, let's add a source file:
 #[license = "MIT"];
 
 pub fn world() {
-    println("Hello, world.");
+    println!("Hello, world.");
 }
 ~~~
 

--- a/doc/guide-tasks.md
+++ b/doc/guide-tasks.md
@@ -72,15 +72,15 @@ closure in the new task.
 # use std::task::spawn;
 
 // Print something profound in a different task using a named function
-fn print_message() { println("I am running in a different task!"); }
+fn print_message() { println!("I am running in a different task!"); }
 spawn(print_message);
 
 // Print something more profound in a different task using a lambda expression
-spawn(proc() println("I am also running in a different task!") );
+spawn(proc() println!("I am also running in a different task!") );
 
 // The canonical way to spawn is using `do` notation
 do spawn {
-    println("I too am running in a different task!");
+    println!("I too am running in a different task!");
 }
 ~~~~
 

--- a/doc/rust.md
+++ b/doc/rust.md
@@ -2668,7 +2668,7 @@ An example:
 let mut i = 0;
 
 while i < 10 {
-    println("hello\n");
+    println!("hello");
     i = i + 1;
 }
 ~~~~
@@ -3267,7 +3267,7 @@ impl Printable for int {
 }
 
 fn print(a: @Printable) {
-   println(a.to_string());
+   println!("{}", a.to_string());
 }
 
 fn main() {

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -130,7 +130,7 @@ we have a file `hello.rs` containing this program:
 
 ~~~~
 fn main() {
-    println("hello?");
+    println!("hello?");
 }
 ~~~~
 
@@ -140,12 +140,12 @@ Windows) which, upon running, will likely do exactly what you expect.
 
 The Rust compiler tries to provide useful information when it encounters an
 error. If you introduce an error into the program (for example, by changing
-`println` to some nonexistent function), and then compile it, you'll see
+`println!` to some nonexistent macro), and then compile it, you'll see
 an error message like this:
 
 ~~~~ {.notrust}
-hello.rs:2:4: 2:16 error: unresolved name: print_with_unicorns
-hello.rs:2     print_with_unicorns("hello?");
+hello.rs:2:5: 2:24 error: macro undefined: 'print_with_unicorns'
+hello.rs:2     print_with_unicorns!("hello?");
                ^~~~~~~~~~~~~~~~~~~
 ~~~~
 
@@ -424,11 +424,11 @@ compulsory, an `if` can have an optional `else` clause, and multiple
 
 ~~~~
 if false {
-    println("that's odd");
+    println!("that's odd");
 } else if true {
-    println("right");
+    println!("right");
 } else {
-    println("neither true nor false");
+    println!("neither true nor false");
 }
 ~~~~
 
@@ -456,10 +456,10 @@ executes its corresponding arm.
 ~~~~
 # let my_number = 1;
 match my_number {
-  0     => println("zero"),
-  1 | 2 => println("one or two"),
-  3..10 => println("three to ten"),
-  _     => println("something else")
+  0     => println!("zero"),
+  1 | 2 => println!("one or two"),
+  3..10 => println!("three to ten"),
+  _     => println!("something else")
 }
 ~~~~
 
@@ -484,8 +484,8 @@ commas are optional.
 ~~~
 # let my_number = 1;
 match my_number {
-  0 => { println("zero") }
-  _ => { println("something else") }
+  0 => { println!("zero") }
+  _ => { println!("something else") }
 }
 ~~~
 
@@ -563,7 +563,7 @@ let mut x = 5u;
 loop {
     x += x - 3;
     if x % 5 == 0 { break; }
-    println(x.to_str());
+    println!("{}", x);
 }
 ~~~~
 
@@ -613,8 +613,8 @@ origin.y += 1.0; // ERROR: assigning to immutable field
 # struct Point { x: f64, y: f64 }
 # let mypoint = Point { x: 0.0, y: 0.0 };
 match mypoint {
-    Point { x: 0.0, y: yy } => { println(yy.to_str());                     }
-    Point { x: xx,  y: yy } => { println(xx.to_str() + " " + yy.to_str()); }
+    Point { x: 0.0, y: yy } => println!("{}", yy),
+    Point { x: xx,  y: yy } => println!("{} {}", xx, yy),
 }
 ~~~~
 
@@ -629,7 +629,7 @@ reuses the field name as the binding name.
 # struct Point { x: f64, y: f64 }
 # let mypoint = Point { x: 0.0, y: 0.0 };
 match mypoint {
-    Point { x, .. } => { println(x.to_str()) }
+    Point { x, .. } => println!("{}", x),
 }
 ~~~
 
@@ -1777,7 +1777,7 @@ structure.
 ~~~~
 # fn call_it(op: proc(v: int)) { }
 call_it(proc(n) {
-    println(n.to_str());
+    println!("{}", n);
 });
 ~~~~
 
@@ -1787,7 +1787,7 @@ call for these functions.
 ~~~~
 # fn call_it(op: proc(v: int)) { }
 do call_it() |n| {
-    println(n.to_str());
+    println!("{}", n);
 }
 ~~~~
 
@@ -2124,7 +2124,7 @@ struct TimeBomb {
 impl Drop for TimeBomb {
     fn drop(&mut self) {
         for _ in range(0, self.explosivity) {
-            println("blam!");
+            println!("blam!");
         }
     }
 }
@@ -2168,7 +2168,7 @@ impl Printable for int {
 }
 
 impl Printable for ~str {
-    fn print(&self) { println(*self) }
+    fn print(&self) { println!("{}", *self) }
 }
 
 # 1.print();
@@ -2214,7 +2214,7 @@ trait Printable {
 impl Printable for int {}
 
 impl Printable for ~str {
-    fn print(&self) { println(*self) }
+    fn print(&self) { println!("{}", *self) }
 }
 
 impl Printable for bool {}
@@ -2561,7 +2561,7 @@ For example, for a simple hello world program your crate only consists of this c
 ~~~~
 // main.rs
 fn main() {
-    println("Hello world!");
+    println!("Hello world!");
 }
 ~~~~
 
@@ -2583,18 +2583,18 @@ All modules in a crate below the crate root are declared with the `mod` keyword:
 mod farm {
     // This is the body of module 'farm' declared in the crate root.
 
-    fn chicken() { println("cluck cluck"); }
-    fn cow() { println("mooo"); }
+    fn chicken() { println!("cluck cluck"); }
+    fn cow() { println!("mooo"); }
 
     mod barn {
         // Body of module 'barn'
 
-        fn hay() { println("..."); }
+        fn hay() { println!("..."); }
     }
 }
 
 fn main() {
-    println("Hello farm!");
+    println!("Hello farm!");
 }
 ~~~~
 
@@ -2611,12 +2611,12 @@ One way to do it is to simply fully qualifying it:
 
 ~~~~ {.xfail-test}
 mod farm {
-    fn chicken() { println("cluck cluck"); }
+    fn chicken() { println!("cluck cluck"); }
     // ...
 }
 
 fn main() {
-    println("Hello chicken!");
+    println!("Hello chicken!");
 
     ::farm::chicken(); // Won't compile yet, see further down
 }
@@ -2639,13 +2639,13 @@ _public_ with `pub`:
 
 ~~~~
 mod farm {
-    pub fn chicken() { println("cluck cluck"); }
-    pub fn cow() { println("mooo"); }
+    pub fn chicken() { println!("cluck cluck"); }
+    pub fn cow() { println!("mooo"); }
     // ...
 }
 
 fn main() {
-    println("Hello chicken!");
+    println!("Hello chicken!");
     ::farm::chicken(); // This compiles now
 }
 ~~~~
@@ -2725,18 +2725,18 @@ So, if we want to move the content of `mod farm` into it's own file, it would lo
 mod farm; // Compiler will look for 'farm.rs' and 'farm/mod.rs'
 
 fn main() {
-    println("Hello farm!");
+    println!("Hello farm!");
     ::farm::cow();
 }
 ~~~~
 
 ~~~~
 // farm.rs - contains body of module 'farm' in the crate root
-pub fn chicken() { println("cluck cluck"); }
-pub fn cow() { println("mooo"); }
+pub fn chicken() { println!("cluck cluck"); }
+pub fn cow() { println!("mooo"); }
 
 pub mod barn {
-    pub fn hay() { println("..."); }
+    pub fn hay() { println!("..."); }
 }
 # fn main() { }
 ~~~~
@@ -2843,7 +2843,7 @@ without the `::` prefix. For example, this imports `cow` into the local scope:
 
 ~~~
 use farm::cow;
-# mod farm { pub fn cow() { println("I'm a hidden ninja cow!") } }
+# mod farm { pub fn cow() { println!("I'm a hidden ninja cow!") } }
 # fn main() { cow() }
 ~~~
 
@@ -2861,7 +2861,7 @@ while adding a `self::` prefix will start in the current module:
 
 ~~~
 # mod workaround {
-# pub fn some_parent_item(){ println("...") }
+# pub fn some_parent_item(){ println!("...") }
 # mod foo {
 use super::some_parent_item;
 use self::some_child_module::some_item;
@@ -2883,8 +2883,8 @@ scope with corresponding `use` statements.
 # // XXX: Allow unused import in doc test
 use farm::cow;
 // ...
-# mod farm { pub fn cow() { println("Hidden ninja cow is hidden.") } }
-fn cow() { println("Mooo!") }
+# mod farm { pub fn cow() { println!("Hidden ninja cow is hidden.") } }
+fn cow() { println!("Mooo!") }
 
 fn main() {
     cow() // resolves to the locally defined cow() function
@@ -2902,7 +2902,7 @@ even if they refer to things inside them:
 ~~~
 use farm::cow;
 mod farm {
-    pub fn cow() { println("Moooooo?") }
+    pub fn cow() { println!("Moooooo?") }
 }
 
 fn main() { cow() }
@@ -2916,16 +2916,16 @@ use farm::cow;
 use farm::barn;
 
 mod farm {
-    pub fn chicken() { println("cluck cluck"); }
-    pub fn cow() { println("mooo"); }
+    pub fn chicken() { println!("cluck cluck"); }
+    pub fn cow() { println!("mooo"); }
 
     pub mod barn {
-        pub fn hay() { println("..."); }
+        pub fn hay() { println!("..."); }
     }
 }
 
 fn main() {
-    println("Hello farm!");
+    println!("Hello farm!");
 
     // Can now refer to those names directly:
     chicken();
@@ -2952,7 +2952,7 @@ pub fn foo() { bar(); }
 
 ~~~
 // c.rs
-pub fn bar() { println("Baz!"); }
+pub fn bar() { println!("Baz!"); }
 # fn main() {}
 ~~~
 
@@ -2963,8 +2963,8 @@ There also exist two short forms for importing multiple names at once:
 ~~~
 use farm::{chicken, cow};
 # mod farm {
-#     pub fn cow() { println("Did I already mention how hidden and ninja I am?") }
-#     pub fn chicken() { println("I'm Bat-chicken, guardian of the hidden tutorial code.") }
+#     pub fn cow() { println!("Did I already mention how hidden and ninja I am?") }
+#     pub fn chicken() { println!("I'm Bat-chicken, guardian of the hidden tutorial code.") }
 # }
 # fn main() { cow(); chicken() }
 ~~~
@@ -2974,8 +2974,8 @@ use farm::{chicken, cow};
 ~~~
 use farm::*;
 # mod farm {
-#     pub fn cow() { println("Bat-chicken? What a stupid name!") }
-#     pub fn chicken() { println("Says the 'hidden ninja' cow.") }
+#     pub fn cow() { println!("Bat-chicken? What a stupid name!") }
+#     pub fn chicken() { println!("Says the 'hidden ninja' cow.") }
 # }
 # fn main() { cow(); chicken() }
 ~~~
@@ -2988,7 +2988,7 @@ However, that's not all. You can also rename an item while you're bringing it in
 
 ~~~
 use egg_layer = farm::chicken;
-# mod farm { pub fn chicken() { println("Laying eggs is fun!")  } }
+# mod farm { pub fn chicken() { println!("Laying eggs is fun!")  } }
 // ...
 
 fn main() {
@@ -3010,11 +3010,11 @@ For that, you write `pub use`:
 mod farm {
     pub use self::barn::hay;
 
-    pub fn chicken() { println("cluck cluck"); }
-    pub fn cow() { println("mooo"); }
+    pub fn chicken() { println!("cluck cluck"); }
+    pub fn cow() { println!("mooo"); }
 
     mod barn {
-        pub fn hay() { println("..."); }
+        pub fn hay() { println!("..."); }
     }
 }
 
@@ -3082,7 +3082,7 @@ use farm::dog;
 use extra::rational::Ratio;
 
 mod farm {
-    pub fn dog() { println("woof"); }
+    pub fn dog() { println!("woof"); }
 }
 
 fn main() {
@@ -3180,7 +3180,7 @@ pub fn explore() -> &'static str { "world" }
 ~~~~ {.xfail-test}
 // main.rs
 extern mod world;
-fn main() { println("hello " + world::explore()); }
+fn main() { println!("hello {}", world::explore()); }
 ~~~~
 
 Now compile and run like this (adjust to your platform if necessary):
@@ -3200,7 +3200,7 @@ a hash representing the crates package ID.
 ## The standard library and the prelude
 
 While reading the examples in this tutorial, you might have asked yourself where all
-those magical predefined items like `println()` are coming from.
+those magical predefined items like `range` are coming from.
 
 The truth is, there's nothing magical about them: They are all defined normally
 in the `std` library, which is a crate that ships with Rust.
@@ -3219,19 +3219,24 @@ use std::prelude::*;
 
 The role of the `prelude` module is to re-export common definitions from `std`.
 
-This allows you to use common types and functions like `Option<T>` or `println`
+This allows you to use common types and functions like `Option<T>` or `range`
 without needing to import them. And if you need something from `std` that's not in the prelude,
 you just have to import it with an `use` statement.
 
-For example, it re-exports `println` which is defined in `std::io::stdio::println`:
+For example, it re-exports `range` which is defined in `std::iter::range`:
 
 ~~~
-use puts = std::io::stdio::println;
+use iter_range = std::iter::range;
 
 fn main() {
-    println("println is imported per default.");
-    puts("Doesn't hinder you from importing it under a different name yourself.");
-    ::std::io::stdio::println("Or from not using the automatic import.");
+    // range is imported by default
+    for _ in range(0, 10) {}
+
+    // Doesn't hinder you from importing it under a different name yourself
+    for _ in iter_range(0, 10) {}
+
+    // Or from not using the automatic import.
+    for _ in ::std::iter::range(0, 10) {}
 }
 ~~~
 

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -84,8 +84,8 @@ pub fn parse_config(args: ~[~str]) -> config {
     let args_ = args.tail();
     if args[1] == ~"-h" || args[1] == ~"--help" {
         let message = format!("Usage: {} [OPTIONS] [TESTNAME...]", argv0);
-        println(getopts::groups::usage(message, groups));
-        println("");
+        println!("{}", getopts::groups::usage(message, groups));
+        println!("");
         fail!()
     }
 
@@ -97,8 +97,8 @@ pub fn parse_config(args: ~[~str]) -> config {
 
     if matches.opt_present("h") || matches.opt_present("help") {
         let message = format!("Usage: {} [OPTIONS]  [TESTNAME...]", argv0);
-        println(getopts::groups::usage(message, groups));
-        println("");
+        println!("{}", getopts::groups::usage(message, groups));
+        println!("");
         fail!()
     }
 
@@ -219,8 +219,8 @@ pub fn run_tests(config: &config) {
     if config.target == ~"arm-linux-androideabi" {
         match config.mode{
             mode_debug_info => {
-                println("arm-linux-androideabi debug-info \
-                        test uses tcp 5039 port. please reserve it");
+                println!("arm-linux-androideabi debug-info \
+                         test uses tcp 5039 port. please reserve it");
                 //arm-linux-androideabi debug-info test uses remote debugger
                 //so, we test 1 task at once
                 os::setenv("RUST_TEST_TASKS","1");

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -53,5 +53,5 @@ pub fn path_div() -> ~str { ~";" }
 
 pub fn logv(config: &config, s: ~str) {
     debug!("{}", s);
-    if config.verbose { println(s); }
+    if config.verbose { println!("{}", s); }
 }

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -35,17 +35,17 @@
 //! use std::os;
 //!
 //! fn do_work(inp: &str, out: Option<~str>) {
-//!     println(inp);
-//!     println(match out {
-//!         Some(x) => x,
-//!         None => ~"No Output"
-//!     });
+//!     println!("{}", inp);
+//!     match out {
+//!         Some(x) => println!("{}", x),
+//!         None => println!("No Output"),
+//!     }
 //! }
 //!
 //! fn print_usage(program: &str, _opts: &[Opt]) {
 //!     println!("Usage: {} [options]", program);
-//!     println("-o\t\tOutput");
-//!     println("-h --help\tUsage");
+//!     println!("-o\t\tOutput");
+//!     println!("-h --help\tUsage");
 //! }
 //!
 //! fn main() {

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -226,10 +226,10 @@ fn optgroups() -> ~[getopts::groups::OptGroup] {
 
 fn usage(binary: &str, helpstr: &str) {
     let message = format!("Usage: {} [OPTIONS] [FILTER]", binary);
-    println(groups::usage(message, optgroups()));
-    println("");
+    println!("{}", groups::usage(message, optgroups()));
+    println!("");
     if helpstr == "help" {
-        println("\
+        println!("{}", "\
 The FILTER is matched against the name of all tests to run, and if any tests
 have a substring match, only those tests are run.
 

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -393,7 +393,7 @@ fn query_from_str(rawquery: &str) -> Query {
  * use extra::url;
  *
  * let query = ~[(~"title", ~"The Village"), (~"north", ~"52.91"), (~"west", ~"4.10")];
- * println(url::query_to_str(&query));  // title=The%20Village&north=52.91&west=4.10
+ * println!("{}", url::query_to_str(&query));  // title=The%20Village&north=52.91&west=4.10
  * ```
  */
 pub fn query_to_str(query: &Query) -> ~str {

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -34,7 +34,7 @@ use extra::uuid::Uuid;
 
 fn main() {
     let uuid1 = Uuid::new_v4();
-    println(uuid1.to_str());
+    println!("{}", uuid1.to_str());
 }
  ```
 

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -536,5 +536,5 @@ fn test() {
         }
     });
 
-    println(s);
+    println!("{}", s);
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -160,7 +160,7 @@ Additional help:
 }
 
 pub fn describe_warnings() {
-    println("
+    println!("
 Available lint options:
     -W <foo>           Warn about <foo>
     -A <foo>           Allow <foo>
@@ -181,7 +181,7 @@ Available lint options:
     fn padded(max: uint, s: &str) -> ~str {
         " ".repeat(max - s.len()) + s
     }
-    println("\nAvailable lint checks:\n");
+    println!("{}", "\nAvailable lint checks:\n"); // FIXME: #9970
     println!("    {}  {:7.7s}  {}",
              padded(max_key, "name"), "default", "meaning");
     println!("    {}  {:7.7s}  {}\n",
@@ -193,11 +193,11 @@ Available lint options:
                  lint::level_to_str(spec.default),
                  spec.desc);
     }
-    println("");
+    println!("");
 }
 
 pub fn describe_debug_flags() {
-    println("\nAvailable debug options:\n");
+    println!("{}", "\nAvailable debug options:\n"); // FIXME: #9970
     let r = session::debugging_opts_map();
     for tuple in r.iter() {
         match *tuple {
@@ -312,10 +312,10 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
                 }
             };
             if crate_id {
-                println(crateid.to_str());
+                println!("{}", crateid.to_str());
             }
             if crate_name {
-                println(crateid.name);
+                println!("{}", crateid.name);
             }
         }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1905,7 +1905,7 @@ fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, crate: &Crate)
             }
         }
 
-        println("metadata stats:");
+        println!("metadata stats:");
         println!("    inline bytes: {}", ecx.stats.inline_bytes.get());
         println!(" attribute bytes: {}", ecx.stats.attr_bytes.get());
         println!("       dep bytes: {}", ecx.stats.dep_bytes.get());

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -93,7 +93,7 @@ pub fn check_crate(tcx: ty::ctxt,
     visit::walk_crate(bccx, crate, ());
 
     if tcx.sess.borrowck_stats() {
-        println("--- borrowck stats ---");
+        println!("--- borrowck stats ---");
         println!("paths requiring guarantees: {}",
                  bccx.stats.guaranteed_paths.get());
         println!("paths requiring loans     : {}",

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3367,7 +3367,7 @@ pub fn trans_crate(sess: session::Session,
     // Translate the metadata.
     let metadata = write_metadata(ccx, &crate);
     if ccx.sess.trans_stats() {
-        println("--- trans stats ---");
+        println!("--- trans stats ---");
         println!("n_static_tydescs: {}", ccx.stats.n_static_tydescs.get());
         println!("n_glues_created: {}", ccx.stats.n_glues_created.get());
         println!("n_null_glues: {}", ccx.stats.n_null_glues.get());
@@ -3377,7 +3377,7 @@ pub fn trans_crate(sess: session::Session,
         println!("n_monos: {}", ccx.stats.n_monos.get());
         println!("n_inlines: {}", ccx.stats.n_inlines.get());
         println!("n_closures: {}", ccx.stats.n_closures.get());
-        println("fn stats:");
+        println!("fn stats:");
         {
             let mut fn_stats = ccx.stats.fn_stats.borrow_mut();
             fn_stats.get().sort_by(|&(_, _, insns_a), &(_, _, insns_b)| {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -105,14 +105,14 @@ pub fn opts() -> ~[groups::OptGroup] {
 }
 
 pub fn usage(argv0: &str) {
-    println(groups::usage(format!("{} [options] <input>", argv0), opts()));
+    println!("{}", groups::usage(format!("{} [options] <input>", argv0), opts()));
 }
 
 pub fn main_args(args: &[~str]) -> int {
     let matches = match groups::getopts(args.tail(), opts()) {
         Ok(m) => m,
         Err(err) => {
-            println(err.to_err_msg());
+            println!("{}", err.to_err_msg());
             return 1;
         }
     };
@@ -122,10 +122,10 @@ pub fn main_args(args: &[~str]) -> int {
     }
 
     if matches.free.len() == 0 {
-        println("expected an input file to act on");
+        println!("expected an input file to act on");
         return 1;
     } if matches.free.len() > 1 {
-        println("only one input file may be specified");
+        println!("only one input file may be specified");
         return 1;
     }
     let input = matches.free[0].as_slice();
@@ -135,11 +135,11 @@ pub fn main_args(args: &[~str]) -> int {
     }
 
     if matches.opt_strs("passes") == ~[~"list"] {
-        println("Available passes for running rustdoc:");
+        println!("Available passes for running rustdoc:");
         for &(name, _, description) in PASSES.iter() {
             println!("{:>20s} - {}", name, description);
         }
-        println("\nDefault passes for rustdoc:");
+        println!("{}", "\nDefault passes for rustdoc:"); // FIXME: #9970
         for &name in DEFAULT_PASSES.iter() {
             println!("{:>20s}", name);
         }

--- a/src/librustpkg/context.rs
+++ b/src/librustpkg/context.rs
@@ -269,43 +269,43 @@ pub fn flags_forbidden_for_cmd(flags: &RustcFlags,
     };
 
     if flags.linker.is_some() && cmd != BuildCmd && cmd != InstallCmd {
-        println("The --linker option can only be used with the build or install commands.");
+        println!("The --linker option can only be used with the build or install commands.");
         return true;
     }
     if flags.link_args.is_some() && cmd != BuildCmd && cmd != InstallCmd {
-        println("The --link-args option can only be used with the build or install commands.");
+        println!("The --link-args option can only be used with the build or install commands.");
         return true;
     }
 
     if !cfgs.is_empty() && cmd != BuildCmd && cmd != InstallCmd && cmd != TestCmd {
-        println("The --cfg option can only be used with the build, test, or install commands.");
+        println!("The --cfg option can only be used with the build, test, or install commands.");
         return true;
     }
 
     if user_supplied_opt_level && cmd != BuildCmd && cmd != InstallCmd {
-        println("The -O and --opt-level options can only be used with the build \
+        println!("The -O and --opt-level options can only be used with the build \
                     or install commands.");
         return true;
     }
 
     if flags.save_temps  && cmd != BuildCmd && cmd != InstallCmd {
-        println("The --save-temps option can only be used with the build \
+        println!("The --save-temps option can only be used with the build \
                     or install commands.");
         return true;
     }
 
     if flags.target.is_some()  && cmd != BuildCmd && cmd != InstallCmd {
-        println("The --target option can only be used with the build \
+        println!("The --target option can only be used with the build \
                     or install commands.");
         return true;
     }
     if flags.target_cpu.is_some()  && cmd != BuildCmd && cmd != InstallCmd {
-        println("The --target-cpu option can only be used with the build \
+        println!("The --target-cpu option can only be used with the build \
                     or install commands.");
         return true;
     }
     if flags.experimental_features.is_some() && cmd != BuildCmd && cmd != InstallCmd {
-        println("The -Z option can only be used with the build or install commands.");
+        println!("The -Z option can only be used with the build or install commands.");
         return true;
     }
 

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -364,9 +364,9 @@ impl CtxMethods for BuildContext {
                 }
             }
             ListCmd => {
-                println("Installed packages:");
+                println!("Installed packages:");
                 installed_packages::list_installed_packages(|pkg_id| {
-                    pkg_id.path.display().with_str(|s| println(s));
+                    pkg_id.path.display().with_str(|s| println!("{}", s));
                     true
                 });
             }
@@ -747,7 +747,7 @@ impl CtxMethods for BuildContext {
 }
 
 pub fn main() {
-    println("WARNING: The Rust package manager is experimental and may be unstable");
+    println!("WARNING: The Rust package manager is experimental and may be unstable");
     os::set_exit_status(main_args(os::args()));
 }
 

--- a/src/librustpkg/source_control.rs
+++ b/src/librustpkg/source_control.rs
@@ -38,8 +38,8 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                                                        target.as_str().unwrap().to_owned()]);
             let outp = opt_outp.expect("Failed to exec `git`");
             if !outp.status.success() {
-                println(str::from_utf8_owned(outp.output.clone()));
-                println(str::from_utf8_owned(outp.error));
+                println!("{}", str::from_utf8_owned(outp.output.clone()));
+                println!("{}", str::from_utf8_owned(outp.error));
                 return DirToUse(target.clone());
             }
             else {
@@ -54,8 +54,8 @@ pub fn safe_git_clone(source: &Path, v: &Version, target: &Path) -> CloneResult 
                              format!("--git-dir={}", git_dir.as_str().unwrap().to_owned()),
                              ~"checkout", format!("{}", *s)]).expect("Failed to exec `git`");
                         if !outp.status.success() {
-                            println(str::from_utf8_owned(outp.output.clone()));
-                            println(str::from_utf8_owned(outp.error));
+                            println!("{}", str::from_utf8_owned(outp.output.clone()));
+                            println!("{}", str::from_utf8_owned(outp.error));
                             return DirToUse(target.clone());
                         }
                     }

--- a/src/librustpkg/testsuite/fail/src/no-inferred-crates/src/zzyzx.rs
+++ b/src/librustpkg/testsuite/fail/src/no-inferred-crates/src/zzyzx.rs
@@ -16,5 +16,5 @@ The test runner should check that, after `rustpkg build hello-world`:
 */
 
 fn main() {
-    println(~"Hello world!");
+    println!("Hello world!");
 }

--- a/src/librustpkg/testsuite/pass/src/c-dependencies/pkg.rs
+++ b/src/librustpkg/testsuite/pass/src/c-dependencies/pkg.rs
@@ -36,7 +36,7 @@ pub fn main() {
     }
 
     if args[2] != ~"install" {
-        println(format!("Warning: I don't know how to {}", args[2]));
+        println!("Warning: I don't know how to {}", args[2]);
         return;
     }
 

--- a/src/librustpkg/testsuite/pass/src/hello-world/main.rs
+++ b/src/librustpkg/testsuite/pass/src/hello-world/main.rs
@@ -19,5 +19,5 @@ The test runner should check that, after `rustpkg build hello-world`:
 */
 
 fn main() {
-    println("Hello world!");
+    println!("Hello world!");
 }

--- a/src/librustpkg/usage.rs
+++ b/src/librustpkg/usage.rs
@@ -11,7 +11,7 @@
 use context::Command;
 
 pub fn general() {
-    println("Usage: rustpkg [options] <cmd> [args..]
+    println!("Usage: rustpkg [options] <cmd> [args..]
 
 Where <cmd> is one of:
     build, clean, do, info, install, list, prefer, test, uninstall, unprefer
@@ -24,7 +24,7 @@ Options:
 }
 
 pub fn build() {
-    println("rustpkg build [options..] [package-ID]
+    println!("rustpkg build [options..] [package-ID]
 
 Build the given package ID if specified. With no package ID argument,
 build the package in the current directory. In that case, the current
@@ -50,21 +50,21 @@ Options:
 }
 
 pub fn clean() {
-    println("rustpkg clean
+    println!("rustpkg clean
 
 Remove all build files in the work cache for the package in the current
 directory.");
 }
 
 pub fn do_cmd() {
-    println("rustpkg do <cmd>
+    println!(r"rustpkg do <cmd>
 
 Runs a command in the package script. You can listen to a command
-by tagging a function with the attribute `#[pkg_do(cmd)]`.");
+by tagging a function with the attribute `\#[pkg_do(cmd)]`.");
 }
 
 pub fn info() {
-    println("rustpkg [options..] info
+    println!("rustpkg [options..] info
 
 Probe the package script in the current directory for information.
 
@@ -73,13 +73,13 @@ Options:
 }
 
 pub fn list() {
-    println("rustpkg list
+    println!("rustpkg list
 
 List all installed packages.");
 }
 
 pub fn install() {
-    println("rustpkg install [options..] [package-ID]
+    println!(r"rustpkg install [options..] [package-ID]
 
 Install the given package ID if specified. With no package ID
 argument, install the package in the current directory.
@@ -89,7 +89,7 @@ In that case, the current directory must be a direct child of a
 Examples:
     rustpkg install
     rustpkg install github.com/mozilla/servo
-    rustpkg install github.com/mozilla/servo#0.1.2
+    rustpkg install github.com/mozilla/servo\#0.1.2
 
 Options:
     -c, --cfg      Pass a cfg flag to the package script
@@ -105,14 +105,14 @@ Options:
 }
 
 pub fn uninstall() {
-    println("rustpkg uninstall <id|name>[@version]
+    println!("rustpkg uninstall <id|name>[@version]
 
 Remove a package by id or name and optionally version. If the package(s)
 is/are depended on by another package then they cannot be removed.");
 }
 
 pub fn prefer() {
-    println("rustpkg [options..] prefer <id|name>[@version]
+    println!("rustpkg [options..] prefer <id|name>[@version]
 
 By default all binaries are given a unique name so that multiple versions can
 coexist. The prefer command will symlink the uniquely named binary to
@@ -130,7 +130,7 @@ Example:
 }
 
 pub fn unprefer() {
-    println("rustpkg [options..] unprefer <id|name>[@version]
+    println!("rustpkg [options..] unprefer <id|name>[@version]
 
 Remove all symlinks from the store to the binary directory for a package
 name and optionally version. If version is not supplied, the latest version
@@ -139,7 +139,7 @@ information.");
 }
 
 pub fn test() {
-    println("rustpkg [options..] test
+    println!("rustpkg [options..] test
 
 Build all test crates in the current directory with the test flag.
 Then, run all the resulting test executables, redirecting the output
@@ -150,7 +150,7 @@ Options:
 }
 
 pub fn init() {
-    println("rustpkg init
+    println!("rustpkg init
 
 This will turn the current working directory into a workspace. The first
 command you run when starting off a new project.

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -54,7 +54,7 @@ use num::FromPrimitive;
 ///
 /// ```
 /// std::bool::all_values(|x: bool| {
-///     println(x.to_str());
+///     println!("{}", x);
 /// })
 /// ```
 #[inline]

--- a/src/libstd/condition.rs
+++ b/src/libstd/condition.rs
@@ -51,8 +51,8 @@ my_error::cond.trap(|raised_int| {
     // condition, then the above handler will be invoked (so long as there's no
     // other nested handler).
 
-    println(my_error::cond.raise(3)); // prints "three"
-    println(my_error::cond.raise(4)); // prints "oh well"
+    println!("{}", my_error::cond.raise(3)); // prints "three"
+    println!("{}", my_error::cond.raise(4)); // prints "oh well"
 
 })
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -32,7 +32,7 @@ Some examples of obvious things you might want to do
     # let _g = ::std::io::ignore_io_error();
     let mut stdin = BufferedReader::new(stdin());
     for line in stdin.lines() {
-        print(line);
+        print!("{}", line);
     }
     ```
 
@@ -67,7 +67,7 @@ Some examples of obvious things you might want to do
     let path = Path::new("message.txt");
     let mut file = BufferedReader::new(File::open(&path));
     for line in file.lines() {
-        print(line);
+        print!("{}", line);
     }
     ```
 
@@ -204,7 +204,7 @@ io_error::cond.trap(|e: IoError| {
 });
 
 if error.is_some() {
-    println("failed to write my diary");
+    println!("failed to write my diary");
 }
 # ::std::io::fs::unlink(&Path::new("diary.txt"));
 ```

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -68,7 +68,7 @@ pub enum Signum {
 /// do spawn {
 ///     loop {
 ///         match listener.port.recv() {
-///             Interrupt => println("Got Interrupt'ed"),
+///             Interrupt => println!("Got Interrupt'ed"),
 ///             _ => (),
 ///         }
 ///     }

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -402,7 +402,7 @@ pub trait Iterator<A> {
     ///             .filter(|&x| x % 2 == 0)
     ///             .inspect(|&x| debug!("{} made it through", x))
     ///             .sum();
-    /// println(sum.to_str());
+    /// println!("{}", sum);
     /// ```
     #[inline]
     fn inspect<'r>(self, f: 'r |&A|) -> Inspect<'r, A, Self> {

--- a/src/libstd/ops.rs
+++ b/src/libstd/ops.rs
@@ -47,8 +47,8 @@
  *     }
  * }
  * fn main() {
- *     println(format!("{:?}", Point {x: 1, y: 0} + Point {x: 2, y: 3}));
- *     println(format!("{:?}", Point {x: 1, y: 0} - Point {x: 2, y: 3}));
+ *     println!("{:?}", Point {x: 1, y: 0} + Point {x: 2, y: 3});
+ *     println!("{:?}", Point {x: 1, y: 0} - Point {x: 2, y: 3});
  * }
  * ```
  *
@@ -72,7 +72,7 @@
  *
  * impl Drop for HasDrop {
  *   fn drop(&mut self) {
- *       println("Dropping!");
+ *       println!("Dropping!");
  *   }
  * }
  *
@@ -100,7 +100,7 @@ pub trait Drop {
  *
  * impl Add<Foo, Foo> for Foo {
  *     fn add(&self, _rhs: &Foo) -> Foo {
- *       println("Adding!");
+ *       println!("Adding!");
  *       *self
  *   }
  * }
@@ -129,7 +129,7 @@ pub trait Add<RHS,Result> {
  *
  * impl Sub<Foo, Foo> for Foo {
  *     fn sub(&self, _rhs: &Foo) -> Foo {
- *         println("Subtracting!");
+ *         println!("Subtracting!");
  *         *self
  *     }
  * }
@@ -158,7 +158,7 @@ pub trait Sub<RHS,Result> {
  *
  * impl Mul<Foo, Foo> for Foo {
  *     fn mul(&self, _rhs: &Foo) -> Foo {
- *         println("Multiplying!");
+ *         println!("Multiplying!");
  *         *self
  *     }
  * }
@@ -187,7 +187,7 @@ pub trait Mul<RHS,Result> {
  *
  * impl Div<Foo, Foo> for Foo {
  *     fn div(&self, _rhs: &Foo) -> Foo {
- *         println("Dividing!");
+ *         println!("Dividing!");
  *         *self
  *     }
  * }
@@ -216,7 +216,7 @@ pub trait Div<RHS,Result> {
  *
  * impl Rem<Foo, Foo> for Foo {
  *     fn rem(&self, _rhs: &Foo) -> Foo {
- *         println("Remainder-ing!");
+ *         println!("Remainder-ing!");
  *         *self
  *     }
  * }
@@ -245,7 +245,7 @@ pub trait Rem<RHS,Result> {
  *
  * impl Neg<Foo> for Foo {
  *     fn neg(&self) -> Foo {
- *         println("Negating!");
+ *         println!("Negating!");
  *         *self
  *     }
  * }
@@ -274,7 +274,7 @@ pub trait Neg<Result> {
  *
  * impl Not<Foo> for Foo {
  *     fn not(&self) -> Foo {
- *         println("Not-ing!");
+ *         println!("Not-ing!");
  *         *self
  *     }
  * }
@@ -303,7 +303,7 @@ pub trait Not<Result> {
  *
  * impl BitAnd<Foo, Foo> for Foo {
  *     fn bitand(&self, _rhs: &Foo) -> Foo {
- *         println("Bitwise And-ing!");
+ *         println!("Bitwise And-ing!");
  *         *self
  *     }
  * }
@@ -332,7 +332,7 @@ pub trait BitAnd<RHS,Result> {
  *
  * impl BitOr<Foo, Foo> for Foo {
  *     fn bitor(&self, _rhs: &Foo) -> Foo {
- *         println("Bitwise Or-ing!");
+ *         println!("Bitwise Or-ing!");
  *         *self
  *     }
  * }
@@ -361,7 +361,7 @@ pub trait BitOr<RHS,Result> {
  *
  * impl BitXor<Foo, Foo> for Foo {
  *     fn bitxor(&self, _rhs: &Foo) -> Foo {
- *         println("Bitwise Xor-ing!");
+ *         println!("Bitwise Xor-ing!");
  *         *self
  *     }
  * }
@@ -390,7 +390,7 @@ pub trait BitXor<RHS,Result> {
  *
  * impl Shl<Foo, Foo> for Foo {
  *     fn shl(&self, _rhs: &Foo) -> Foo {
- *         println("Shifting left!");
+ *         println!("Shifting left!");
  *         *self
  *     }
  * }
@@ -419,7 +419,7 @@ pub trait Shl<RHS,Result> {
  *
  * impl Shr<Foo, Foo> for Foo {
  *     fn shr(&self, _rhs: &Foo) -> Foo {
- *         println("Shifting right!");
+ *         println!("Shifting right!");
  *         *self
  *     }
  * }
@@ -449,7 +449,7 @@ pub trait Shr<RHS,Result> {
  *
  * impl Index<Foo, Foo> for Foo {
  *     fn index(&self, _rhs: &Foo) -> Foo {
- *         println("Indexing!");
+ *         println!("Indexing!");
  *         *self
  *     }
  * }

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -26,7 +26,7 @@
 //!
 //! // Take a reference to the contained string
 //! match msg {
-//!     Some(ref m) => io::println(*m),
+//!     Some(ref m) => println!("{}", *m),
 //!     None => ()
 //! }
 //!

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -40,7 +40,6 @@ pub use result::{Result, Ok, Err};
 // Reexported functions
 pub use from_str::from_str;
 pub use iter::range;
-pub use io::stdio::{print, println};
 
 // Reexported types and traits
 

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -244,7 +244,7 @@ pub trait Rng {
     /// ```rust
     /// use std::rand::{task_rng, Rng};
     ///
-    /// println(task_rng().gen_ascii_str(10));
+    /// println!("{}", task_rng().gen_ascii_str(10));
     /// ```
     fn gen_ascii_str(&mut self, len: uint) -> ~str {
         static GEN_ASCII_STR_CHARSET: &'static [u8] = bytes!("ABCDEFGHIJKLMNOPQRSTUVWXYZ\

--- a/src/libstd/rand/reseeding.rs
+++ b/src/libstd/rand/reseeding.rs
@@ -118,7 +118,7 @@ impl<S, R: SeedableRng<S>, Rsdr: Reseeder<R>>
 ///     let mut rng = ReseedingRng::new(rand::StdRng::new(), 10, rsdr);
 ///
 ///     // this will repeat, because it gets reseeded very regularly.
-///     println(rng.gen_ascii_str(100));
+///     println!("{}", rng.gen_ascii_str(100));
 /// }
 ///
 /// ```

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -634,6 +634,7 @@ fn test_repr() {
     use prelude::*;
     use str;
     use str::Str;
+    use io::stdio::println;
     use util::swap;
     use char::is_alphabetic;
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1591,8 +1591,8 @@ pub trait StrSlice<'a> {
     /// assert_eq!(d.len(), 23);
     ///
     /// // the two strings *look* the same
-    /// println(c);
-    /// println(d);
+    /// println!("{}", c);
+    /// println!("{}", d);
     /// ```
     fn char_len(&self) -> uint;
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1317,7 +1317,7 @@ pub trait OwnedVector<T> {
     /// let v = ~[~"a", ~"b"];
     /// for s in v.move_iter() {
     ///   // s has type ~str, not &~str
-    ///   println(s);
+    ///   println!("{}", s);
     /// }
     /// ```
     fn move_iter(self) -> MoveIterator<T>;

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -1127,7 +1127,7 @@ mod test {
         // - two renames of the same var.. can only happen if you use
         // local-expand to prevent the inner binding from being renamed
         // during the rename-pass caused by the first:
-        println("about to run bad test");
+        println!("about to run bad test");
         { let sc = unfold_test_sc(~[R(id(a,EMPTY_CTXT),50),
                                     R(id(a,EMPTY_CTXT),51)],
                                   EMPTY_CTXT,&mut t);

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1283,7 +1283,7 @@ mod test {
 
     //fn expand_and_resolve(crate_str: @str) -> ast::crate {
         //let expanded_ast = expand_crate_str(crate_str);
-        // println(format!("expanded: {:?}\n",expanded_ast));
+        // println!("expanded: {:?}\n",expanded_ast);
         //mtwt_resolve_crate(expanded_ast)
     //}
     //fn expand_and_resolve_and_pretty_print (crate_str : @str) -> ~str {
@@ -1396,7 +1396,7 @@ mod test {
                     let varref_marks = mtwt_marksof(varref.segments[0].identifier.ctxt,
                                                     invalid_name);
                     if (!(varref_name==binding_name)){
-                        println("uh oh, should match but doesn't:");
+                        println!("uh oh, should match but doesn't:");
                         println!("varref: {:?}",varref);
                         println!("binding: {:?}", bindings[binding_idx]);
                         ast_util::display_sctable(get_sctable());
@@ -1458,7 +1458,7 @@ foo_module!()
                                           && (@"xx" == (ident_to_str(&p.segments[0].identifier)))
                                      }).enumerate() {
             if (mtwt_resolve(v.segments[0].identifier) != resolved_binding) {
-                println("uh oh, xx binding didn't match xx varref:");
+                println!("uh oh, xx binding didn't match xx varref:");
                 println!("this is xx varref \\# {:?}",idx);
                 println!("binding: {:?}",cxbind);
                 println!("resolves to: {:?}",resolved_binding);
@@ -1466,7 +1466,7 @@ foo_module!()
                 println!("resolves to: {:?}",
                          mtwt_resolve(v.segments[0].identifier));
                 let table = get_sctable();
-                println("SC table:");
+                println!("SC table:");
 
                 {
                     let table = table.table.borrow();

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -21,7 +21,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt,
                       -> base::MacResult {
 
     cx.print_backtrace();
-    println(
+    println!("{}",
         print::pprust::tt_to_str(
             &ast::TTDelim(@tt.to_owned()),
             get_ident_interner()));

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -983,7 +983,7 @@ mod test {
     #[test] fn t1 () {
         let Env {string_reader} =
             setup(@"/* my source file */ \
-                    fn main() { io::println(~\"zebra\"); }\n");
+                    fn main() { println!(\"zebra\"); }\n");
         let id = str_to_ident("fn");
         let tok1 = string_reader.next_token();
         let tok2 = TokenAndSpan{

--- a/src/test/auxiliary/explicit_self_xcrate.rs
+++ b/src/test/auxiliary/explicit_self_xcrate.rs
@@ -20,6 +20,6 @@ pub struct Bar {
 impl Foo for Bar {
     #[inline(always)]
     fn f(&self) {
-        println((*self).x);
+        println!("{}", (*self).x);
     }
 }

--- a/src/test/auxiliary/moves_based_on_type_lib.rs
+++ b/src/test/auxiliary/moves_based_on_type_lib.rs
@@ -16,7 +16,7 @@ pub struct S {
 
 impl Drop for S {
     fn drop(&mut self) {
-        println("goodbye");
+        println!("goodbye");
     }
 }
 

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -27,7 +27,7 @@ fn timed(label: &str, f: ||) {
 }
 
 fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
-    println(" Ascending integers:");
+    println!(" Ascending integers:");
 
     timed("insert", || {
         for i in range(0u, n_keys) {
@@ -49,7 +49,7 @@ fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
 }
 
 fn descending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
-    println(" Descending integers:");
+    println!(" Descending integers:");
 
     timed("insert", || {
         for i in range(0, n_keys).invert() {
@@ -115,7 +115,8 @@ fn main() {
 
     println!("{} keys", n_keys);
 
-    println("\nTreeMap:");
+    // FIXME: #9970
+    println!("{}", "\nTreeMap:");
 
     {
         let mut map: TreeMap<uint,uint> = TreeMap::new();
@@ -128,12 +129,13 @@ fn main() {
     }
 
     {
-        println(" Random integers:");
+        println!(" Random integers:");
         let mut map: TreeMap<uint,uint> = TreeMap::new();
         vector(&mut map, n_keys, rand);
     }
 
-    println("\nHashMap:");
+    // FIXME: #9970
+    println!("{}", "\nHashMap:");
 
     {
         let mut map: HashMap<uint,uint> = HashMap::new();
@@ -146,12 +148,13 @@ fn main() {
     }
 
     {
-        println(" Random integers:");
+        println!(" Random integers:");
         let mut map: HashMap<uint,uint> = HashMap::new();
         vector(&mut map, n_keys, rand);
     }
 
-    println("\nTrieMap:");
+    // FIXME: #9970
+    println!("{}", "\nTrieMap:");
 
     {
         let mut map: TrieMap<uint> = TrieMap::new();
@@ -164,7 +167,7 @@ fn main() {
     }
 
     {
-        println(" Random integers:");
+        println!(" Random integers:");
         let mut map: TrieMap<uint> = TrieMap::new();
         vector(&mut map, n_keys, rand);
     }

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -123,7 +123,7 @@ impl Results {
 }
 
 fn write_header(header: &str) {
-    println(header);
+    println!("{}", header);
 }
 
 fn write_row(label: &str, value: f64) {

--- a/src/test/bench/noise.rs
+++ b/src/test/bench/noise.rs
@@ -118,8 +118,8 @@ fn main() {
 
     for y in range(0, 256) {
         for x in range(0, 256) {
-            print(symbols[(pixels[y*256+x] / 0.2f32) as int]);
+            print!("{}", symbols[(pixels[y*256+x] / 0.2f32) as int]);
         }
-        println("");
+        println!("");
     }
 }

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -78,7 +78,7 @@ fn main() {
         }).to_owned_vec();
 
     for message in messages.mut_iter() {
-        println(*message.get_ref());
+        println!("{}", *message.get_ref());
     }
 
     println!("long lived tree of depth {}\t check: {}",

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -20,8 +20,8 @@ fn print_complements() {
     let all = [Blue, Red, Yellow];
     for aa in all.iter() {
         for bb in all.iter() {
-            println(show_color(*aa) + " + " + show_color(*bb) +
-                    " -> " + show_color(transform(*aa, *bb)));
+            println!("{} + {} -> {}", show_color(*aa), show_color(*bb),
+                show_color(transform(*aa, *bb)));
         }
     }
 }
@@ -187,15 +187,15 @@ fn rendezvous(nn: uint, set: ~[color]) {
     }
 
     // print each color in the set
-    println(show_color_list(set));
+    println!("{}", show_color_list(set));
 
     // print each creature's stats
     for rep in report.iter() {
-        println(*rep);
+        println!("{}", *rep);
     }
 
     // print the total number of creatures met
-    println(show_number(creatures_met));
+    println!("{}", show_number(creatures_met));
 }
 
 fn main() {
@@ -211,10 +211,10 @@ fn main() {
     let nn = from_str::<uint>(args[1]).unwrap();
 
     print_complements();
-    println("");
+    println!("");
 
     rendezvous(nn, ~[Blue, Red, Yellow]);
-    println("");
+    println!("");
 
     rendezvous(nn,
         ~[Blue, Red, Yellow, Red, Yellow, Blue, Red, Yellow, Red, Blue]);

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -64,7 +64,7 @@ fn fannkuch_redux(n: i32) -> i32 {
             // Use incremental change to generate another permutation.
             loop {
                 if r == n {
-                    println(checksum.to_str());
+                    println!("{}", checksum);
                     return max_flips_count;
                 }
 

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -223,6 +223,6 @@ fn main() {
 
    // now fetch and print result messages
    for (ii, _sz) in sizes.iter().enumerate() {
-       println(from_child[ii].recv());
+       println!("{}", from_child[ii].recv());
    }
 }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -21,8 +21,8 @@ static LIMIT: f64 = 2.0;
 fn main() {
     let args = std::os::args();
     let (w, mut out) = if args.len() < 2 {
-        println("Test mode: do not dump the image because it's not utf8, \
-                which interferes with the test runner.");
+        println!("Test mode: do not dump the image because it's not utf8, \
+                  which interferes with the test runner.");
         (1000, ~DummyWriter as ~Writer)
     } else {
         (from_str(args[1]).unwrap(),

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -193,11 +193,11 @@ fn to_utf8(raw_sol: &List<u64>) -> ~str {
 // Prints a solution in ~str form.
 fn print_sol(sol: &str) {
     for (i, c) in sol.chars().enumerate() {
-        if (i) % 5 == 0 {println("");}
-        if (i + 5) % 10 == 0 {print(" ");}
+        if (i) % 5 == 0 { println!(""); }
+        if (i + 5) % 10 == 0 { print!(" "); }
         print!("{} ", c);
     }
-    println("");
+    println!("");
 }
 
 // The data managed during the search
@@ -277,5 +277,5 @@ fn main () {
     println!("{} solutions found", data.nb);
     print_sol(data.min);
     print_sol(data.max);
-    println("");
+    println!("");
 }

--- a/src/test/bench/shootout-pidigits.rs
+++ b/src/test/bench/shootout-pidigits.rs
@@ -80,7 +80,7 @@ fn pidigits(n: int) {
 
     let m = n % 10;
     if m != 0 {
-        for _ in range(m, 10) {print(" ");}
+        for _ in range(m, 10) { print!(" "); }
         print!("\t:{}\n", n);
     }
 }

--- a/src/test/compile-fail/borrowck-loan-local-as-both-mut-and-imm.rs
+++ b/src/test/compile-fail/borrowck-loan-local-as-both-mut-and-imm.rs
@@ -22,7 +22,7 @@ enum Either<T, U> { Left(T), Right(U) }
 
     fn g() {
         let mut x: Either<int,f64> = Left(3);
-        println(f(&mut x, &x).to_str()); //~ ERROR cannot borrow
+        println!("{}", f(&mut x, &x)); //~ ERROR cannot borrow
     }
 
     fn h() {

--- a/src/test/compile-fail/borrowck-move-out-of-struct-with-dtor.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-struct-with-dtor.rs
@@ -1,6 +1,6 @@
 struct S {f:~str}
 impl Drop for S {
-    fn drop(&mut self) { println(self.f); }
+    fn drop(&mut self) { println!("{}", self.f); }
 }
 
 fn move_in_match() {

--- a/src/test/compile-fail/borrowck-ref-into-rvalue.rs
+++ b/src/test/compile-fail/borrowck-ref-into-rvalue.rs
@@ -16,5 +16,5 @@ fn main() {
         },
         None => { fail!() }
     }
-    println(*msg);
+    println!("{}", *msg);
 }

--- a/src/test/compile-fail/by-move-pattern-binding.rs
+++ b/src/test/compile-fail/by-move-pattern-binding.rs
@@ -17,6 +17,6 @@ fn main() {
     };
     match &s.x {
         &Foo => {}
-        &Bar(ref identifier) => println(*identifier)
+        &Bar(ref identifier) => println!("{}", *identifier)
     };
 }

--- a/src/test/compile-fail/circular_modules_hello.rs
+++ b/src/test/compile-fail/circular_modules_hello.rs
@@ -13,5 +13,5 @@
 mod circular_modules_main;
 
 pub fn say_hello() {
-  println(circular_modules_main::hi_str());
+    println!("{}", circular_modules_main::hi_str());
 }

--- a/src/test/compile-fail/closure-reform-bad.rs
+++ b/src/test/compile-fail/closure-reform-bad.rs
@@ -7,7 +7,7 @@ fn call_bare(f: fn(&str)) {
 
 fn main() {
     let string = "world!";
-    let f: |&str| = |s| println(s + string);
+    let f: |&str| = |s| println!("{}", s + string);
     call_bare(f)    //~ ERROR mismatched types
 }
 

--- a/src/test/compile-fail/drop-on-non-struct.rs
+++ b/src/test/compile-fail/drop-on-non-struct.rs
@@ -15,7 +15,7 @@ type Foo = @[u8];
 impl Drop for Foo {   //~ ERROR the Drop trait may only be implemented
 //~^ ERROR cannot provide an extension implementation
     fn drop(&mut self) {
-        println("kaboom");
+        println!("kaboom");
     }
 }
 

--- a/src/test/compile-fail/explicit-call-to-dtor.rs
+++ b/src/test/compile-fail/explicit-call-to-dtor.rs
@@ -14,7 +14,7 @@ struct Foo {
 
 impl Drop for Foo {
     fn drop(&mut self) {
-        println("kaboom");
+        println!("kaboom");
     }
 }
 

--- a/src/test/compile-fail/explicit-call-to-supertrait-dtor.rs
+++ b/src/test/compile-fail/explicit-call-to-supertrait-dtor.rs
@@ -18,7 +18,7 @@ trait Bar : Drop {
 
 impl Drop for Foo {
     fn drop(&mut self) {
-        println("kaboom");
+        println!("kaboom");
     }
 }
 

--- a/src/test/compile-fail/functional-struct-update-noncopyable.rs
+++ b/src/test/compile-fail/functional-struct-update-noncopyable.rs
@@ -17,7 +17,7 @@ use extra::arc::Arc;
 struct A { y: Arc<int>, x: Arc<int> }
 
 impl Drop for A {
-    fn drop(&mut self) { println(format!("x={:?}", self.x.get())); }
+    fn drop(&mut self) { println!("x={:?}", self.x.get()); }
 }
 fn main() {
     let a = A { y: Arc::new(1), x: Arc::new(2) };

--- a/src/test/compile-fail/issue-10412.rs
+++ b/src/test/compile-fail/issue-10412.rs
@@ -24,8 +24,8 @@ impl<'self> Serializable<str> for &'self str {
 }
 
 fn main() {
-    println("hello");
+    println!("hello");
     let x = ~"foo";
     let y = x;
-    println(y);
+    println!("{}", y);
 }

--- a/src/test/compile-fail/issue-2548.rs
+++ b/src/test/compile-fail/issue-2548.rs
@@ -22,7 +22,7 @@ struct foo {
 impl Drop for foo {
     fn drop(&mut self) {
         unsafe {
-            println("Goodbye, World!");
+            println!("Goodbye, World!");
             self.x.set(self.x.get() + 1);
         }
     }

--- a/src/test/compile-fail/issue-3953.rs
+++ b/src/test/compile-fail/issue-3953.rs
@@ -31,8 +31,8 @@ impl Eq for Lol {
 
 fn main() {
     if Lol(2) == Lol(4) {
-        println("2 == 4");
+        println!("2 == 4");
     } else {
-        println("2 != 4");
+        println!("2 != 4");
     }
 }

--- a/src/test/compile-fail/issue-3973.rs
+++ b/src/test/compile-fail/issue-3973.rs
@@ -28,5 +28,5 @@ impl ToStr for Point { //~ ERROR implements a method not defined in the trait
 
 fn main() {
     let p = Point::new(0.0f, 0.0f);
-    io::println(p.to_str());
+    println!("{}", p.to_str());
 }

--- a/src/test/compile-fail/issue-5060-fail.rs
+++ b/src/test/compile-fail/issue-5060-fail.rs
@@ -12,13 +12,14 @@
 
 macro_rules! print_hd_tl (
     ($field_hd:ident, $($field_tl:ident),+) => ({
-        print(stringify!($field)); //~ ERROR unknown macro variable
-        print("::[");
+        print!("{}", stringify!($field)); //~ ERROR unknown macro variable
+        print!("::[");
         $(
-            print(stringify!($field_tl));
-            print(", ");
+            print!("{}", stringify!($field_tl));
+            print!(", ");
         )+
-        print("]\n");
+        // FIXME: #9970
+        print!("{}", "]\n");
     })
 )
 

--- a/src/test/compile-fail/match-vec-unreachable.rs
+++ b/src/test/compile-fail/match-vec-unreachable.rs
@@ -7,7 +7,7 @@ fn main() {
     }
 
     match ~[~"foo", ~"bar", ~"baz"] {
-        [a, _, _, ..] => { println(a); }
+        [a, _, _, ..] => { println!("{}", a); }
         [~"foo", ~"bar", ~"baz", ~"foo", ~"bar"] => { } //~ ERROR unreachable pattern
         _ => { }
     }

--- a/src/test/compile-fail/moves-based-on-type-block-bad.rs
+++ b/src/test/compile-fail/moves-based-on-type-block-bad.rs
@@ -18,7 +18,7 @@ fn main() {
         f(&s, |hellothere| {
             match hellothere.x {
                 ~Foo(_) => {}
-                ~Bar(x) => println(x.to_str()), //~ ERROR cannot move out
+                ~Bar(x) => println!("{}", x.to_str()), //~ ERROR cannot move out
                 ~Baz => {}
             }
         })

--- a/src/test/compile-fail/moves-based-on-type-capture-clause-bad.rs
+++ b/src/test/compile-fail/moves-based-on-type-capture-clause-bad.rs
@@ -3,7 +3,7 @@ use std::task;
 fn main() {
     let x = ~"Hello world!";
     do task::spawn {
-        println(x);
+        println!("{}", x);
     }
-    println(x); //~ ERROR use of moved value
+    println!("{}", x); //~ ERROR use of moved value
 }

--- a/src/test/compile-fail/no-implicit-prelude-nested.rs
+++ b/src/test/compile-fail/no-implicit-prelude-nested.rs
@@ -25,8 +25,7 @@ mod foo {
         impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
 
         fn foo() {
-            print("foo"); //~ ERROR: unresolved name
-            println("bar"); //~ ERROR: unresolved name
+            drop(2) //~ ERROR: unresolved name
         }
     }
 
@@ -38,8 +37,7 @@ mod foo {
     impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
 
     fn foo() {
-        print("foo"); //~ ERROR: unresolved name
-        println("bar"); //~ ERROR: unresolved name
+        drop(2) //~ ERROR: unresolved name
     }
 }
 
@@ -54,8 +52,7 @@ fn qux() {
         impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
 
         fn foo() {
-            print("foo"); //~ ERROR: unresolved name
-            println("bar"); //~ ERROR: unresolved name
+            drop(2) //~ ERROR: unresolved name
         }
     }
 }
@@ -63,6 +60,5 @@ fn qux() {
 
 fn main() {
     // these should work fine
-    print("foo");
-    println("bar");
+    drop(2)
 }

--- a/src/test/compile-fail/no-implicit-prelude.rs
+++ b/src/test/compile-fail/no-implicit-prelude.rs
@@ -24,6 +24,5 @@ impl ToStr for Test {} //~ ERROR: attempt to implement a nonexistent trait
 impl Writer for Test {} //~ ERROR: attempt to implement a nonexistent trait
 
 fn main() {
-    print("foo"); //~ ERROR: unresolved name
-    println("bar"); //~ ERROR: unresolved name
+    drop(2) //~ ERROR: unresolved name
 }

--- a/src/test/compile-fail/refutable-pattern-in-fn-arg.rs
+++ b/src/test/compile-fail/refutable-pattern-in-fn-arg.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    let f = |3: int| println("hello");  //~ ERROR refutable pattern
+    let f = |3: int| println!("hello");  //~ ERROR refutable pattern
     f(4);
 }

--- a/src/test/compile-fail/repeat-to-run-dtor-twice.rs
+++ b/src/test/compile-fail/repeat-to-run-dtor-twice.rs
@@ -18,7 +18,7 @@ struct Foo {
 
 impl Drop for Foo {
     fn drop(&mut self) {
-        println("Goodbye!");
+        println!("Goodbye!");
     }
 }
 

--- a/src/test/compile-fail/uninhabited-enum-cast.rs
+++ b/src/test/compile-fail/uninhabited-enum-cast.rs
@@ -1,7 +1,7 @@
 enum E {}
 
 fn f(e: E) {
-    println((e as int).to_str());   //~ ERROR non-scalar cast
+    println!("{}", (e as int).to_str());   //~ ERROR non-scalar cast
 }
 
 fn main() {}

--- a/src/test/compile-fail/unique-object-noncopyable.rs
+++ b/src/test/compile-fail/unique-object-noncopyable.rs
@@ -22,7 +22,7 @@ impl Drop for Bar {
 
 impl Foo for Bar {
     fn f(&self) {
-        println("hi");
+        println!("hi");
     }
 }
 

--- a/src/test/compile-fail/use-after-move-based-on-type.rs
+++ b/src/test/compile-fail/use-after-move-based-on-type.rs
@@ -11,5 +11,5 @@
 fn main() {
     let x = ~"Hello!";
     let _y = x;
-    println(x); //~ ERROR use of moved value
+    println!("{}", x); //~ ERROR use of moved value
 }

--- a/src/test/compile-fail/use-after-move-self-based-on-type.rs
+++ b/src/test/compile-fail/use-after-move-self-based-on-type.rs
@@ -17,5 +17,5 @@ impl S {
 
 fn main() {
     let x = S { x: 1 };
-    println(x.foo().to_str());
+    println!("{}", x.foo());
 }

--- a/src/test/compile-fail/use-after-move-self.rs
+++ b/src/test/compile-fail/use-after-move-self.rs
@@ -13,5 +13,5 @@ impl S {
 
 fn main() {
     let x = S { x: ~1 };
-    println(x.foo().to_str());
+    println!("{}", x.foo());
 }

--- a/src/test/debug-info/function-arg-initialization.rs
+++ b/src/test/debug-info/function-arg-initialization.rs
@@ -163,7 +163,7 @@ fn assignment(mut a: u64, b: u64, c: f64) {
 }
 
 fn function_call(x: u64, y: u64, z: f64) {
-    print("Hi!")
+    std::io::stdio::print("Hi!")
 }
 
 fn identifier(x: u64, y: u64, z: f64) -> u64 {

--- a/src/test/debug-info/function-prologue-stepping-no-split-stack.rs
+++ b/src/test/debug-info/function-prologue-stepping-no-split-stack.rs
@@ -162,7 +162,7 @@ fn assignment(mut a: u64, b: u64, c: f64) {
 
 #[no_split_stack]
 fn function_call(x: u64, y: u64, z: f64) {
-    print("Hi!")
+    std::io::stdio::print("Hi!")
 }
 
 #[no_split_stack]

--- a/src/test/run-pass/anon-trait-static-method.rs
+++ b/src/test/run-pass/anon-trait-static-method.rs
@@ -20,5 +20,5 @@ impl Foo {
 
 pub fn main() {
     let x = Foo::new();
-    println(x.x.to_str());
+    println!("{}", x.x);
 }

--- a/src/test/run-pass/anon_trait_static_method_exe.rs
+++ b/src/test/run-pass/anon_trait_static_method_exe.rs
@@ -16,5 +16,5 @@ use anon_trait_static_method_lib::Foo;
 
 pub fn main() {
     let x = Foo::new();
-    println(x.x.to_str());
+    println!("{}", x.x);
 }

--- a/src/test/run-pass/auto-ref-bounded-ty-param.rs
+++ b/src/test/run-pass/auto-ref-bounded-ty-param.rs
@@ -28,7 +28,7 @@ impl<T:Baz> Foo for T {
 
 impl Baz for Bar {
     fn g(&self) {
-        println(self.x.to_str());
+        println!("{}", self.x);
     }
 }
 

--- a/src/test/run-pass/bare-static-string.rs
+++ b/src/test/run-pass/bare-static-string.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let x: &'static str = "foo";
-    println(x);
+    println!("{}", x);
 }

--- a/src/test/run-pass/boxed-trait-with-vstore.rs
+++ b/src/test/run-pass/boxed-trait-with-vstore.rs
@@ -16,7 +16,7 @@ trait Foo {
 
 impl Foo for int {
     fn foo(@self) {
-        println("Hello world!");
+        println!("Hello world!");
     }
 }
 

--- a/src/test/run-pass/closure-reform.rs
+++ b/src/test/run-pass/closure-reform.rs
@@ -2,9 +2,10 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 use std::cast;
+use std::io::stdio::println;
 
 fn call_it(f: proc(~str) -> ~str) {
-    println(f(~"Fred"))
+    println!("{}", f(~"Fred"))
 }
 
 fn call_a_thunk(f: ||) {
@@ -57,9 +58,9 @@ pub fn main() {
 
     // Closures
 
-    call_a_thunk(|| println("Hello world!"));
+    call_a_thunk(|| println!("Hello world!"));
 
-    call_this(|s| println(s));
+    call_this(|s| println!("{}", s));
 
     call_that(|x, y| *x + *y);
 

--- a/src/test/run-pass/default-method-simple.rs
+++ b/src/test/run-pass/default-method-simple.rs
@@ -11,7 +11,7 @@
 
 trait Foo {
     fn f(&self) {
-        println("Hello!");
+        println!("Hello!");
         self.g();
     }
     fn g(&self);
@@ -23,7 +23,7 @@ struct A {
 
 impl Foo for A {
     fn g(&self) {
-        println("Goodbye!");
+        println!("Goodbye!");
     }
 }
 

--- a/src/test/run-pass/drop-trait-generic.rs
+++ b/src/test/run-pass/drop-trait-generic.rs
@@ -15,7 +15,7 @@ struct S<T> {
 #[unsafe_destructor]
 impl<T> ::std::ops::Drop for S<T> {
     fn drop(&mut self) {
-        println("bye");
+        println!("bye");
     }
 }
 

--- a/src/test/run-pass/drop-trait.rs
+++ b/src/test/run-pass/drop-trait.rs
@@ -14,7 +14,7 @@ struct Foo {
 
 impl Drop for Foo {
     fn drop(&mut self) {
-        println("bye");
+        println!("bye");
     }
 }
 

--- a/src/test/run-pass/expr-repeat-vstore.rs
+++ b/src/test/run-pass/expr-repeat-vstore.rs
@@ -2,15 +2,15 @@
 
 pub fn main() {
     let v: ~[int] = ~[ 1, ..5 ];
-    println(v[0].to_str());
-    println(v[1].to_str());
-    println(v[2].to_str());
-    println(v[3].to_str());
-    println(v[4].to_str());
+    println!("{}", v[0]);
+    println!("{}", v[1]);
+    println!("{}", v[2]);
+    println!("{}", v[3]);
+    println!("{}", v[4]);
     let v: @[int] = @[ 2, ..5 ];
-    println(v[0].to_str());
-    println(v[1].to_str());
-    println(v[2].to_str());
-    println(v[3].to_str());
-    println(v[4].to_str());
+    println!("{}", v[0]);
+    println!("{}", v[1]);
+    println!("{}", v[2]);
+    println!("{}", v[3]);
+    println!("{}", v[4]);
 }

--- a/src/test/run-pass/extern-mod-syntax.rs
+++ b/src/test/run-pass/extern-mod-syntax.rs
@@ -16,5 +16,5 @@ extern mod extra;
 use extra::json::Object;
 
 pub fn main() {
-    println("Hello world!");
+    println!("Hello world!");
 }

--- a/src/test/run-pass/float-literal-inference.rs
+++ b/src/test/run-pass/float-literal-inference.rs
@@ -14,9 +14,9 @@ struct S {
 
 pub fn main() {
     let x: f32 = 4.0;
-    println(x.to_str());
+    println!("{}", x);
     let y: f64 = 64.0;
-    println(y.to_str());
+    println!("{}", y);
     let z = S { z: 1.0 };
-    println(z.z.to_str());
+    println!("{}", z.z);
 }

--- a/src/test/run-pass/fn-pattern-expected-type-2.rs
+++ b/src/test/run-pass/fn-pattern-expected-type-2.rs
@@ -11,7 +11,7 @@
 pub fn main() {
     let v : &[(int,int)] = &[ (1, 2), (3, 4), (5, 6) ];
     for &(x, y) in v.iter() {
-        println(y.to_str());
-        println(x.to_str());
+        println!("{}", y);
+        println!("{}", x);
     }
 }

--- a/src/test/run-pass/hello.rs
+++ b/src/test/run-pass/hello.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 pub fn main() {
-    println("hello, world");
+    println!("hello, world");
 }

--- a/src/test/run-pass/impl-privacy-xc-2.rs
+++ b/src/test/run-pass/impl-privacy-xc-2.rs
@@ -6,5 +6,5 @@ extern mod impl_privacy_xc_2;
 pub fn main() {
     let fish1 = impl_privacy_xc_2::Fish { x: 1 };
     let fish2 = impl_privacy_xc_2::Fish { x: 2 };
-    println(if fish1.eq(&fish2) { "yes" } else { "no " });
+    if fish1.eq(&fish2) { println!("yes") } else { println!("no") };
 }

--- a/src/test/run-pass/issue-3389.rs
+++ b/src/test/run-pass/issue-3389.rs
@@ -15,7 +15,7 @@ struct trie_node {
 
 fn print_str_vector(vector: ~[~str]) {
     for string in vector.iter() {
-        println(*string);
+        println!("{}", *string);
     }
 }
 

--- a/src/test/run-pass/issue-3447.rs
+++ b/src/test/run-pass/issue-3447.rs
@@ -35,5 +35,5 @@ pub fn main() {
         element: S,
         next: None
     };
-    println(ls.element);
+    println!("{}", ls.element);
 }

--- a/src/test/run-pass/issue-3702.rs
+++ b/src/test/run-pass/issue-3702.rs
@@ -16,7 +16,7 @@ pub fn main() {
   }
 
   fn to_string(t: @Text) {
-    println(t.to_str());
+    println!("{}", t.to_str());
   }
 
 }

--- a/src/test/run-pass/issue-3847.rs
+++ b/src/test/run-pass/issue-3847.rs
@@ -18,5 +18,5 @@ pub fn main() {
         buildings::Tower { height: h } => { h }
     };
 
-    println(h.to_str());
+    println!("{}", h);
 }

--- a/src/test/run-pass/issue-4025.rs
+++ b/src/test/run-pass/issue-4025.rs
@@ -13,20 +13,20 @@
 */
 
 fn print1(b: bool, s1: &str, s2: &str) {
-    println(if b { s1 } else { s2 });
+    println!("{}", if b { s1 } else { s2 });
 }
 fn print2<'a, 'b>(b: bool, s1: &'a str, s2: &'b str) {
-    println(if b { s1 } else { s2 });
+    println!("{}", if b { s1 } else { s2 });
 }
 fn print3(b: bool, s1: &str, s2: &str) {
     let mut s: &str;
     if b { s = s1; } else { s = s2; }
-    println(s);
+    println!("{}", s);
 }
 fn print4<'a, 'b>(b: bool, s1: &'a str, s2: &'b str) {
     let mut s: &str;
     if b { s = s1; } else { s = s2; }
-    println(s);
+    println!("{}", s);
 }
 
 pub fn main() {}

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -111,7 +111,7 @@ priv fn cmd_to_str(cmd: ~[~str]) -> ~str {
 
 fn query(cmd: ~[~str], sb: TcpSocketBuf) -> Result {
   let cmd = cmd_to_str(cmd);
-  //io::println(cmd);
+  //println!("{}", cmd);
   sb.write_str(cmd);
   let res = parse_response(@sb as @io::Reader);
   res

--- a/src/test/run-pass/issue-4446.rs
+++ b/src/test/run-pass/issue-4446.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::io::println;
+
 pub fn main() {
     let (port, chan) = Chan::new();
 

--- a/src/test/run-pass/issue-4541.rs
+++ b/src/test/run-pass/issue-4541.rs
@@ -26,5 +26,5 @@ fn parse_args() -> ~str {
 }
 
 pub fn main() {
-    println(parse_args());
+    println!("{}", parse_args());
 }

--- a/src/test/run-pass/issue-5060.rs
+++ b/src/test/run-pass/issue-5060.rs
@@ -12,13 +12,14 @@
 
 macro_rules! print_hd_tl (
     ($field_hd:ident, $($field_tl:ident),+) => ({
-        print(stringify!($field_hd));
-        print("::[");
+        print!("{}", stringify!($field_hd));
+        print!("::[");
         $(
-            print(stringify!($field_tl));
-            print(", ");
+            print!("{}", stringify!($field_tl));
+            print!(", ");
         )+
-        print("]\n");
+        // FIXME: #9970
+        print!("{}", "]\n");
     })
 )
 

--- a/src/test/run-pass/issue-5321-immediates-with-bare-self.rs
+++ b/src/test/run-pass/issue-5321-immediates-with-bare-self.rs
@@ -14,7 +14,7 @@ trait Fooable {
 
 impl Fooable for uint {
     fn yes(self) {
-        self.times(|| println("yes"));
+        self.times(|| println!("yes"));
     }
 }
 

--- a/src/test/run-pass/issue-5708.rs
+++ b/src/test/run-pass/issue-5708.rs
@@ -24,7 +24,7 @@ trait Inner {
 }
 
 impl Inner for int {
-    fn print(&self) { print(format!("Inner: {}\n", *self)); }
+    fn print(&self) { print!("Inner: {}\n", *self); }
 }
 
 struct Outer<'a> {

--- a/src/test/run-pass/issue-7012.rs
+++ b/src/test/run-pass/issue-7012.rs
@@ -23,5 +23,5 @@ static test1: signature<'static> =  signature {
 
 pub fn main() {
   let test = &[0x243f6a88u32,0x85a308d3u32,0x13198a2eu32,0x03707344u32,0xa4093822u32,0x299f31d0u32];
-  println(format!("{}",test==test1.pattern));
+  println!("{}",test==test1.pattern);
 }

--- a/src/test/run-pass/issue-7563.rs
+++ b/src/test/run-pass/issue-7563.rs
@@ -7,7 +7,7 @@ struct B<'a> { b: int, pa: &'a A }
 
     impl IDummy for A {
         fn do_nothing(&self) {
-            println("A::do_nothing() is called");
+            println!("A::do_nothing() is called");
         }
     }
 

--- a/src/test/run-pass/issue-8498.rs
+++ b/src/test/run-pass/issue-8498.rs
@@ -15,7 +15,7 @@ pub fn main() {
     match &[(~5,~7)] {
         ps => {
            let (ref y, _) = ps[0];
-           println(fmt!("1. y = %d", **y));
+           println!("1. y = {}", **y);
            assert!(**y == 5);
         }
     }
@@ -24,8 +24,8 @@ pub fn main() {
     match Some(&[(~5,)]) {
         Some(ps) => {
            let (ref y,) = ps[0];
-           println(fmt!("2. y = %d", **y));
-           if **y != 5 { println("sadness"); }
+           println!("2. y = {}", **y);
+           if **y != 5 { println!("sadness"); }
         }
         None => ()
     }
@@ -34,7 +34,7 @@ pub fn main() {
     match Some(&[(~5,~7)]) {
         Some(ps) => {
            let (ref y, ref z) = ps[0];
-           println(fmt!("3. y = %d z = %d", **y, **z));
+           println!("3. y = {} z = {}", **y, **z);
            assert!(**y == 5);
         }
         None => ()

--- a/src/test/run-pass/let-assignability.rs
+++ b/src/test/run-pass/let-assignability.rs
@@ -11,7 +11,7 @@
 fn f() {
     let a = ~"hello";
     let b: &str = a;
-    println(b);
+    println!("{}", b);
 }
 
 pub fn main() {

--- a/src/test/run-pass/match-drop-strs-issue-4541.rs
+++ b/src/test/run-pass/match-drop-strs-issue-4541.rs
@@ -22,5 +22,5 @@ fn parse_args() -> ~str {
 }
 
 pub fn main() {
-    println(parse_args());
+    println!("{}", parse_args());
 }

--- a/src/test/run-pass/move-self.rs
+++ b/src/test/run-pass/move-self.rs
@@ -8,7 +8,7 @@ impl S {
     }
 
     pub fn bar(self) {
-        println(self.x);
+        println!("{}", self.x);
     }
 }
 

--- a/src/test/run-pass/moves-based-on-type-capture-clause.rs
+++ b/src/test/run-pass/moves-based-on-type-capture-clause.rs
@@ -3,6 +3,6 @@ use std::task;
 pub fn main() {
     let x = ~"Hello world!";
     do task::spawn {
-        println(x);
+        println!("{}", x);
     }
 }

--- a/src/test/run-pass/multibyte.rs
+++ b/src/test/run-pass/multibyte.rs
@@ -10,5 +10,5 @@
 
 // Test that multibyte characters don't crash the compiler
 pub fn main() {
-    println("마이너스 사인이 없으면");
+    println!("마이너스 사인이 없으면");
 }

--- a/src/test/run-pass/new-impl-syntax.rs
+++ b/src/test/run-pass/new-impl-syntax.rs
@@ -20,6 +20,6 @@ impl<T:ToStr> ToStr for PolymorphicThingy<T> {
 }
 
 pub fn main() {
-    println(Thingy { x: 1, y: 2 }.to_str());
-    println(PolymorphicThingy { x: Thingy { x: 1, y: 2 } }.to_str());
+    println!("{}", Thingy { x: 1, y: 2 }.to_str());
+    println!("{}", PolymorphicThingy { x: Thingy { x: 1, y: 2 } }.to_str());
 }

--- a/src/test/run-pass/new-import-syntax.rs
+++ b/src/test/run-pass/new-import-syntax.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 pub fn main() {
-    println("Hello world!");
+    println!("Hello world!");
 }

--- a/src/test/run-pass/option-ext.rs
+++ b/src/test/run-pass/option-ext.rs
@@ -13,6 +13,6 @@ pub fn main() {
     let f = thing.find_str("{{");
 
     if f.is_none() {
-        println("None!");
+        println!("None!");
     }
 }

--- a/src/test/run-pass/pattern-in-closure.rs
+++ b/src/test/run-pass/pattern-in-closure.rs
@@ -14,8 +14,8 @@ struct Foo {
 }
 
 pub fn main() {
-    let f = |(x, _): (int, int)| println((x + 1).to_str());
-    let g = |Foo { x: x, y: _y }: Foo| println((x + 1).to_str());
+    let f = |(x, _): (int, int)| println!("{}", x + 1);
+    let g = |Foo { x: x, y: _y }: Foo| println!("{}", x + 1);
     f((2, 3));
     g(Foo { x: 1, y: 2 });
 }

--- a/src/test/run-pass/shebang.rs
+++ b/src/test/run-pass/shebang.rs
@@ -11,4 +11,4 @@
 
 // pp-exact
 
-pub fn main() { println("Hello World"); }
+pub fn main() { println!("Hello World"); }

--- a/src/test/run-pass/tag-disr-val-shape.rs
+++ b/src/test/run-pass/tag-disr-val-shape.rs
@@ -18,7 +18,7 @@ enum color {
 
 pub fn main() {
     let act = format!("{:?}", red);
-    println(act);
+    println!("{}", act);
     assert_eq!(~"red", act);
     assert_eq!(~"green", format!("{:?}", green));
     assert_eq!(~"white", format!("{:?}", white));

--- a/src/test/run-pass/trait-coercion-generic.rs
+++ b/src/test/run-pass/trait-coercion-generic.rs
@@ -10,6 +10,8 @@
 
 #[feature(managed_boxes)];
 
+use std::io::println;
+
 trait Trait<T> {
     fn f(&self, x: T);
 }
@@ -21,7 +23,7 @@ struct Struct {
 
 impl Trait<&'static str> for Struct {
     fn f(&self, x: &'static str) {
-        println(~"Hi, " + x + ~"!");
+        println!("Hi, {}!", x);
     }
 }
 

--- a/src/test/run-pass/trait-coercion.rs
+++ b/src/test/run-pass/trait-coercion.rs
@@ -21,7 +21,7 @@ struct Struct {
 
 impl Trait for Struct {
     fn f(&self) {
-        println("Hi!");
+        println!("Hi!");
     }
 }
 

--- a/src/test/run-pass/trait-inheritance-self.rs
+++ b/src/test/run-pass/trait-inheritance-self.rs
@@ -12,7 +12,7 @@ struct S {
 
 impl Foo<S> for S {
     fn f(&self, x: &S) {
-        println(x.x.to_str());
+        println!("{}", x.x);
     }
 }
 

--- a/src/test/run-pass/trait-region-pointer-simple.rs
+++ b/src/test/run-pass/trait-region-pointer-simple.rs
@@ -18,7 +18,7 @@ struct A {
 
 impl Foo for A {
     fn f(&self) -> int {
-        println(~"Today's number is " + self.x.to_str());
+        println!("Today's number is {}", self.x);
         return self.x;
     }
 }

--- a/src/test/run-pass/trait-static-method-overwriting.rs
+++ b/src/test/run-pass/trait-static-method-overwriting.rs
@@ -21,7 +21,7 @@ mod base {
 
     impl ::base::HasNew<Foo> for Foo {
         fn new() -> Foo {
-            println("Foo");
+            println!("Foo");
             Foo { dummy: () }
         }
     }
@@ -32,7 +32,7 @@ mod base {
 
     impl ::base::HasNew<Bar> for Bar {
         fn new() -> Bar {
-            println("Bar");
+            println!("Bar");
             Bar { dummy: () }
         }
     }

--- a/src/test/run-pass/unit-like-struct.rs
+++ b/src/test/run-pass/unit-like-struct.rs
@@ -13,6 +13,6 @@ struct Foo;
 pub fn main() {
     let x: Foo = Foo;
     match x {
-        Foo => { println("hi"); }
+        Foo => { println!("hi"); }
     }
 }


### PR DESCRIPTION
The `print!` and `println!` macros are now the preferred method of printing, and so there is no reason to export the `stdio` functions in the prelude. The functions have also been replaced by their macro counterparts in the tutorial and other documentation so that newcomers don't get confused about what they should be using.
