### PR TITLE
Fix ICE on const of nullable enum with fields in null case.

### DIFF
--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -730,7 +730,6 @@ pub fn trans_const(ccx: &CrateContext, r: &Repr, discr: Disr,
             if discr == nndiscr {
                 C_struct(build_const_struct(ccx, nonnull, vals), false)
             } else {
-                assert_eq!(vals.len(), 0);
                 let vals = nonnull.fields.iter().enumerate().map(|(i, &ty)| {
                     let llty = type_of::sizing_type_of(ccx, ty);
                     if i == ptrfield { C_null(llty) } else { C_undef(llty) }

--- a/src/test/run-pass/enum-nullable-const-null-with-fields.rs
+++ b/src/test/run-pass/enum-nullable-const-null-with-fields.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::result::{Result,Ok};
+static C: Result<(), ~int> = Ok(());
+
+// This is because of yet another bad assertion (ICE) about the null side of a nullable enum.
+// So we won't actually compile if the bug is present, but we check the value in main anyway.
+
+pub fn main() {
+    assert!(C.is_ok());
+}


### PR DESCRIPTION
That is, if you have an enum type that is subject to the nullable
pointer optimization, but the null variant has a nonzero number of
fields, and you declare a static whose value is of that variant, then
that used to be an ICE but this change fixes it.
