### PR TITLE
Improve invalid operator assignment handling.

### DIFF
--- a/src/test/compile-fail/assignment-operator-unimplemented.rs
+++ b/src/test/compile-fail/assignment-operator-unimplemented.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Regression test for issue #5239
+struct Foo;
 
 fn main() {
-    let x: |int| -> int = |ref x| { x += 1; }; //~ ERROR binary assignment operation += cannot be applied to type `&int`
+  let mut a = Foo;
+  let ref b = Foo;
+  a += *b; //~ Error: binary assignment operation += cannot be applied to type `Foo`
 }


### PR DESCRIPTION
So far the following code

```
struct Foo;

fn main() {
  let mut t = Foo;
  let ref b = Foo;
  a += *b;
}
```

errors with 

```
test.rs:15:3: 13:11 error: binary operation + cannot be applied to type `Foo`
test.rs:15   *a += *b;
```

Since assignment-operators are no longer expanded to `left = left OP right` but are independents operators it should be 

```
test.rs:15:3: 13:11 error: binary operation += cannot be applied to type `Foo`
test.rs:15   *a += *b;
```

to make it clear that implementing Add for Foo is not gonna work. (cf issues #11143, #11344)

Besides that, we also need to typecheck the rhs expression even if the operator has no implementation, or we end up with unknown types for the nodes of the rhs and an ICE later on while resolving types. (once again cf #11143 and #11344).

This probably would get fixed with #5992, but in the meantime it's a confusing error to stumble upon.
@pcwalton, you wrote the original code, what do you think?
(closes #11143 and #11344)
