### PR TITLE
Mark allowed dead code and lang items as live

### DIFF
--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[no_std];
 #[allow(unused_variable)];
 #[deny(dead_code)];
 
@@ -85,3 +86,13 @@ fn foo() { //~ ERROR: code is never used
 fn bar() { //~ ERROR: code is never used
     foo();
 }
+
+// Code with #[allow(dead_code)] should be marked live (and thus anything it
+// calls is marked live)
+#[allow(dead_code)]
+fn g() { h(); }
+fn h() {}
+
+// Similarly, lang items are live
+#[lang="fail_"]
+fn fail(_: *u8, _: *u8, _: uint) -> ! { loop {} }


### PR DESCRIPTION
Dead code pass now explicitly checks for `#[allow(dead_code)]` and
`#[lang=".."]` attributes on items and marks them as live if they have
those attributes. The former is done so that if we want to suppress
warnings for a group of dead functions, we only have to annotate the
"root" of the call chain.

Close #11380 and #11440.
