### PR TITLE
Define arch for iOS/ARM

### DIFF
--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -1160,6 +1160,7 @@ pub mod types {
             }
         }
 
+        #[cfg(target_arch = "arm")]
         #[cfg(target_arch = "x86")]
         pub mod arch {
             pub mod c95 {


### PR DESCRIPTION
This fixes #11336

I guess the type sizes are correct for both OS X and iOS, but i am not certain.
In any case, i'd rather have any iOS build at all, so that we have something to improve upon.
