### PR TITLE
Tighten up float literal lexing.

### DIFF
--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -463,6 +463,19 @@ fn scan_digits(rdr: @StringReader, radix: uint) -> ~str {
     };
 }
 
+fn check_float_base(rdr: @StringReader, start_bpos: BytePos, last_bpos: BytePos,
+                    base: uint) {
+    match base {
+      16u => fatal_span(rdr, start_bpos, last_bpos,
+                      ~"hexadecimal float literal is not supported"),
+      8u => fatal_span(rdr, start_bpos, last_bpos,
+                     ~"octal float literal is not supported"),
+      2u => fatal_span(rdr, start_bpos, last_bpos,
+                     ~"binary float literal is not supported"),
+      _ => ()
+    }
+}
+
 fn scan_number(c: char, rdr: @StringReader) -> token::Token {
     let mut num_str;
     let mut base = 10u;
@@ -540,17 +553,6 @@ fn scan_number(c: char, rdr: @StringReader) -> token::Token {
         num_str.push_char('.');
         num_str.push_str(dec_part);
     }
-    if is_float {
-        match base {
-          16u => fatal_span(rdr, start_bpos, rdr.last_pos.get(),
-                            ~"hexadecimal float literal is not supported"),
-          8u => fatal_span(rdr, start_bpos, rdr.last_pos.get(),
-                           ~"octal float literal is not supported"),
-          2u => fatal_span(rdr, start_bpos, rdr.last_pos.get(),
-                           ~"binary float literal is not supported"),
-          _ => ()
-        }
-    }
     match scan_exponent(rdr, start_bpos) {
       Some(ref s) => {
         is_float = true;
@@ -566,10 +568,12 @@ fn scan_number(c: char, rdr: @StringReader) -> token::Token {
         if c == '3' && n == '2' {
             bump(rdr);
             bump(rdr);
+            check_float_base(rdr, start_bpos, rdr.last_pos.get(), base);
             return token::LIT_FLOAT(str_to_ident(num_str), ast::TyF32);
         } else if c == '6' && n == '4' {
             bump(rdr);
             bump(rdr);
+            check_float_base(rdr, start_bpos, rdr.last_pos.get(), base);
             return token::LIT_FLOAT(str_to_ident(num_str), ast::TyF64);
             /* FIXME (#2252): if this is out of range for either a
             32-bit or 64-bit float, it won't be noticed till the
@@ -580,6 +584,7 @@ fn scan_number(c: char, rdr: @StringReader) -> token::Token {
         }
     }
     if is_float {
+        check_float_base(rdr, start_bpos, rdr.last_pos.get(), base);
         return token::LIT_FLOAT_UNSUFFIXED(str_to_ident(num_str));
     } else {
         if num_str.len() == 0u {

--- a/src/test/compile-fail/lex-bad-fp-base-1.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-1.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = 0o1.0; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-2.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let b = 0o2f32; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-3.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-3.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let c = 0o3.0f32; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-4.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-4.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let d = 0o4e4; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-5.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-5.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let e = 0o5.0e5; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-6.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-6.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let f = 0o6e6f32; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-7.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-7.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let g = 0o7.0e7f64; //~ ERROR: octal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-8.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-8.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let h = 0x8.0e+9; //~ ERROR: hexadecimal float literal is not supported
+}

--- a/src/test/compile-fail/lex-bad-fp-base-9.rs
+++ b/src/test/compile-fail/lex-bad-fp-base-9.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let i = 0x9.0e-9; //~ ERROR: hexadecimal float literal is not supported
+}


### PR DESCRIPTION
This fixes the incorrect lexing of things like:

``` rust
let b = 0o2f32;
let d = 0o4e6;
let f = 0o6e6f32;
```

and brings the float literal lexer in line with the description of the float literals in the manual.
