### PR TITLE
Better error message for semicolon on last line of function

### DIFF
--- a/src/test/compile-fail/liveness-return-last-stmt-semi.rs
+++ b/src/test/compile-fail/liveness-return-last-stmt-semi.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// regression test for #8005
+
+#[feature(macro_rules)];
+
+macro_rules! test ( () => { fn foo() -> int { 1i; } } ) //~ ERROR  not all control paths return a value
+                                             //~^ NOTE consider removing this semicolon
+
+fn no_return() -> int {} //~ ERROR  not all control paths return a value
+
+fn bar(x: u32) -> u32 { //~ ERROR  not all control paths return a value
+    x * 2; //~ NOTE consider removing this semicolon
+}
+
+fn baz(x: u64) -> u32 { //~ ERROR  not all control paths return a value
+    x * 2;
+}
+
+fn main() {
+    test!();
+}


### PR DESCRIPTION
This is a patch for #8005, thanks @lfairy for the hint.

It seems like `block.expr` is None, if the last line of a function has a semi colon (= it ends with a statement).

@kmcallister does this error message cover the intended use cases? 
I'm not sure about the message, the wording and the span could probably be improved.
