### PR TITLE
Implement Unix domain sockets in libnative

### DIFF
--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -181,10 +181,10 @@ impl rtio::IoFactory for IoFactory {
         net::UdpSocket::bind(addr).map(|u| ~u as ~RtioUdpSocket)
     }
     fn unix_bind(&mut self, _path: &CString) -> IoResult<~RtioUnixListener> {
-        Err(unimpl())
+        net::UnixListener::bind(_path).map(|s| ~s as ~RtioUnixListener)
     }
     fn unix_connect(&mut self, _path: &CString) -> IoResult<~RtioPipe> {
-        Err(unimpl())
+        net::UnixStream::connect(_path, libc::SOCK_STREAM).map(|s| ~s as ~RtioPipe)
     }
     fn get_host_addresses(&mut self, _host: Option<&str>, _servname: Option<&str>,
                           _hint: Option<ai::Hint>) -> IoResult<~[ai::Info]> {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -15,6 +15,7 @@ use std::libc;
 use std::mem;
 use std::rt::rtio;
 use std::unstable::intrinsics;
+use std::c_str::CString;
 
 use super::{IoResult, retry};
 use super::file::keep_going;
@@ -88,6 +89,22 @@ fn addr_to_sockaddr(addr: ip::SocketAddr) -> (libc::sockaddr_storage, uint) {
     }
 }
 
+fn addr_to_sockaddr_un(addr: &CString) -> (libc::sockaddr_storage, uint) {
+    unsafe {
+        let storage: libc::sockaddr_storage = intrinsics::init();
+        let s: *mut libc::sockaddr_un = cast::transmute(&storage);
+        (*s).sun_family = libc::AF_UNIX as libc::sa_family_t;
+        let mut i = 0;
+        for c in addr.iter() {
+          (*s).sun_path[i] = c;
+          i += 1;
+        }
+
+        let len = mem::size_of::<libc::sa_family_t>() + i + 1; //count the null terminator
+        return (storage, len);
+    }
+}
+
 fn socket(addr: ip::SocketAddr, ty: libc::c_int) -> IoResult<sock_t> {
     unsafe {
         let fam = match addr.ip {
@@ -97,6 +114,15 @@ fn socket(addr: ip::SocketAddr, ty: libc::c_int) -> IoResult<sock_t> {
         match libc::socket(fam, ty, 0) {
             -1 => Err(super::last_error()),
             fd => Ok(fd),
+        }
+    }
+}
+
+fn unix_socket(ty: libc::c_int) -> IoResult<sock_t> {
+    unsafe {
+        match libc::socket(libc::AF_UNIX, ty, 0) {
+            -1 => Err(super::last_error()),
+            fd => Ok(fd)
         }
     }
 }
@@ -169,6 +195,25 @@ fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
                 ip: ip::Ipv6Addr(a, b, c, d, e, f, g, h),
                 port: ntohs(storage.sin6_port),
             })
+        }
+        _ => {
+            Err(io::standard_error(io::OtherIoError))
+        }
+    }
+}
+
+fn sockaddr_to_unix(storage: &libc::sockaddr_storage,
+                    len: uint) -> IoResult<CString> {
+    match storage.ss_family as libc::c_int {
+        libc::AF_UNIX => {
+            assert!(len as uint <= mem::size_of::<libc::sockaddr_un>());
+            let storage: &libc::sockaddr_un = unsafe {
+                cast::transmute(storage)
+            };
+            unsafe {
+                let buf:[libc::c_char, ..libc::sun_len] = storage.sun_path;
+                Ok(CString::new(buf.as_ptr(), false))
+            }
         }
         _ => {
             Err(io::standard_error(io::OtherIoError))
@@ -584,3 +629,244 @@ impl rtio::RtioUdpSocket for UdpSocket {
 impl Drop for UdpSocket {
     fn drop(&mut self) { unsafe { close(self.fd) } }
 }
+
+
+#[cfg(not(windows))]
+////////////////////////////////////////////////////////////////////////////////
+// Unix
+////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Unix streams
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct UnixStream {
+    priv fd: sock_t,
+}
+
+impl UnixStream {
+    pub fn connect(addr: &CString, ty: libc::c_int) -> IoResult<UnixStream> {
+        // the sun_path length is limited to SUN_LEN (with null)
+        if(addr.len() > libc::sun_len -1) {
+            return Err(io::IoError {
+                kind: io::OtherIoError,
+                desc: "path must be smaller than SUN_LEN",
+                detail: None,
+            })
+        }
+        unsafe {
+            unix_socket(ty).and_then(|fd| {
+                let (addr, len) = addr_to_sockaddr_un(addr);
+                let ret = UnixStream{ fd: fd };
+                let addrp = &addr as *libc::sockaddr_storage;
+                match retry(|| {
+                  libc::connect(fd, addrp as *libc::sockaddr,
+                                 len as libc::socklen_t)
+                }) {
+                    -1 => return Err(super::last_error()),
+                    _  => return Ok(ret)
+                }
+            })
+        }
+    }
+
+    pub fn dgram_bind(addr: &CString) -> IoResult<UnixStream> {
+        // the sun_path length is limited to SUN_LEN (with null)
+        if(addr.len() > libc::sun_len - 1) {
+            return Err(io::IoError {
+                kind: io::OtherIoError,
+                desc: "path must be smaller than SUN_LEN",
+                detail: None,
+            })
+        }
+        unsafe {
+            unix_socket(libc::SOCK_DGRAM).and_then(|fd| {
+                let (addr, len) = addr_to_sockaddr_un(addr);
+                let ret = UnixStream{ fd: fd };
+                let addrp = &addr as *libc::sockaddr_storage;
+                match libc::bind(fd, addrp as *libc::sockaddr,
+                                 len as libc::socklen_t) {
+                    -1 => return Err(super::last_error()),
+                    _  => return Ok(ret)
+                }
+            })
+        }
+    }
+
+    pub fn fd(&self) -> sock_t { self.fd }
+}
+
+impl rtio::RtioPipe for UnixStream {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+        let ret = retry(|| {
+            unsafe {
+                libc::recv(self.fd,
+                           buf.as_ptr() as *mut libc::c_void,
+                           buf.len() as wrlen,
+                           0) as libc::c_int
+            }
+        });
+        if ret == 0 {
+            Err(io::standard_error(io::EndOfFile))
+        } else if ret < 0 {
+            Err(super::last_error())
+        } else {
+            Ok(ret as uint)
+        }
+    }
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        let ret = keep_going(buf, |buf, len| {
+            unsafe {
+                libc::send(self.fd,
+                           buf as *mut libc::c_void,
+                           len as wrlen,
+                           0) as i64
+            }
+        });
+        if ret < 0 {
+            Err(super::last_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl rtio::RtioDatagramPipe for UnixStream { 
+    fn recvfrom(&mut self, buf: &mut [u8]) -> IoResult<(uint, CString)> {
+        unsafe {
+            let mut storage: libc::sockaddr_storage = intrinsics::init();
+            let storagep = &mut storage as *mut libc::sockaddr_storage;
+            let mut addrlen: libc::socklen_t =
+                    mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+            let ret = retry(|| {
+                libc::recvfrom(self.fd,
+                               buf.as_ptr() as *mut libc::c_void,
+                               buf.len() as msglen_t,
+                               0,
+                               storagep as *mut libc::sockaddr,
+                               &mut addrlen) as libc::c_int
+            });
+            if ret < 0 { return Err(super::last_error()) }
+            sockaddr_to_unix(&storage, addrlen as uint).and_then(|addr| {
+                Ok((ret as uint, addr))
+            })
+        }
+    }
+ 
+    fn sendto(&mut self, buf: &[u8], dst: &CString) -> IoResult<()> {
+        let (dst, len) = addr_to_sockaddr_un(dst);
+        let dstp = &dst as *libc::sockaddr_storage;
+        unsafe {
+            let ret = retry(|| {
+                libc::sendto(self.fd,
+                             buf.as_ptr() as *libc::c_void,
+                             buf.len() as msglen_t,
+                             0,
+                             dstp as *libc::sockaddr,
+                             len as libc::socklen_t) as libc::c_int
+            });
+            match ret {
+                -1 => Err(super::last_error()),
+                n if n as uint != buf.len() => {
+                    Err(io::IoError {
+                        kind: io::OtherIoError,
+                        desc: "couldn't send entire packet at once",
+                        detail: None,
+                    })
+                }
+                _ => Ok(())
+            }
+        }
+
+    }
+}
+
+impl Drop for UnixStream {
+    fn drop(&mut self) { unsafe { close(self.fd); } }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Unix Listener
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct UnixListener {
+    priv fd: sock_t,
+}
+
+impl UnixListener {
+    pub fn bind(addr: &CString) -> IoResult<UnixListener> {
+        // the sun_path length is limited to SUN_LEN (with null)
+        if(addr.len() > libc::sun_len - 1) {
+            return Err(io::IoError {
+                kind: io::OtherIoError,
+                desc: "path must be smaller than SUN_LEN",
+                detail: None,
+            })
+        }
+        unsafe {
+            unix_socket(libc::SOCK_STREAM).and_then(|fd| {
+                let (addr, len) = addr_to_sockaddr_un(addr);
+                let ret = UnixListener{ fd: fd };
+                let addrp = &addr as *libc::sockaddr_storage;
+                match libc::bind(fd, addrp as *libc::sockaddr,
+                                 len as libc::socklen_t) {
+                    -1 => return Err(super::last_error()),
+                    _  => return Ok(ret)
+                }
+            })
+        }
+    }
+
+    pub fn fd(&self) -> sock_t { self.fd }
+
+    pub fn native_listen(self, backlog: int) -> IoResult<UnixAcceptor> {
+        match unsafe { libc::listen(self.fd, backlog as libc::c_int) } {
+            -1 => Err(super::last_error()),
+            _ => Ok(UnixAcceptor { listener: self })
+        }
+    }
+}
+
+impl rtio::RtioUnixListener for UnixListener {
+    fn listen(~self) -> IoResult<~rtio::RtioUnixAcceptor> {
+        self.native_listen(128).map(|a| ~a as ~rtio::RtioUnixAcceptor)
+    }
+}
+
+impl Drop for UnixListener {
+    fn drop(&mut self) { unsafe { close(self.fd); } }
+}
+
+pub struct UnixAcceptor {
+    priv listener: UnixListener,
+}
+
+impl UnixAcceptor {
+    pub fn fd(&self) -> sock_t { self.listener.fd }
+
+    pub fn native_accept(&mut self) -> IoResult<UnixStream> {
+        unsafe {
+            let mut storage: libc::sockaddr_storage = intrinsics::init();
+            let storagep = &mut storage as *mut libc::sockaddr_storage;
+            let size = mem::size_of::<libc::sockaddr_storage>();
+            let mut size = size as libc::socklen_t;
+            match retry(|| {
+                libc::accept(self.fd(),
+                             storagep as *mut libc::sockaddr,
+                             &mut size as *mut libc::socklen_t) as libc::c_int
+            }) as sock_t {
+                -1 => Err(super::last_error()),
+                fd => Ok(UnixStream { fd: fd })
+            }
+        }
+    }
+}
+
+impl rtio::RtioUnixAcceptor for UnixAcceptor {
+    fn accept(&mut self) -> IoResult<~rtio::RtioPipe> {
+        self.native_accept().map(|s| ~s as ~rtio::RtioPipe)
+    }
+}
+
+

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -52,12 +52,14 @@ impl UnixStream {
     ///
     /// # Example
     ///
+    ///```rust
     ///     use std::io::net::unix::UnixStream;
+    ///     use std::path::posix::Path;
     ///
-    ///     let server = Path("path/to/my/socket");
+    ///     let server = Path::new("path/to/my/socket");
     ///     let mut stream = UnixStream::connect(&server);
     ///     stream.write([1, 2, 3]);
-    ///
+    ///```
     pub fn connect<P: ToCStr>(path: &P) -> Option<UnixStream> {
         LocalIo::maybe_raise(|io| {
             io.unix_connect(&path.to_c_str()).map(UnixStream::new)
@@ -91,6 +93,7 @@ impl UnixListener {
     ///
     /// # Example
     ///
+    ///````rust
     ///     use std::io::net::unix::UnixListener;
     ///
     ///     let server = Path("path/to/my/socket");
@@ -99,7 +102,7 @@ impl UnixListener {
     ///         let mut client = client;
     ///         client.write([1, 2, 3, 4]);
     ///     }
-    ///
+    ///```
     pub fn bind<P: ToCStr>(path: &P) -> Option<UnixListener> {
         LocalIo::maybe_raise(|io| {
             io.unix_bind(&path.to_c_str()).map(|s| UnixListener { obj: s })

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -267,8 +267,9 @@ pub mod types {
                 pub enum timezone {}
             }
             pub mod bsd44 {
-                use libc::types::os::arch::c95::c_uint;
+                use libc::types::os::arch::c95::{c_char, c_uint};
 
+                pub static sun_len:uint = 108;
                 pub type socklen_t = u32;
                 pub type sa_family_t = u16;
                 pub type in_port_t = u16;
@@ -308,6 +309,10 @@ pub mod types {
                 pub struct ip6_mreq {
                     ipv6mr_multiaddr: in6_addr,
                     ipv6mr_interface: c_uint,
+                }
+                pub struct sockaddr_un {
+                    sun_family: sa_family_t,
+                    sun_path: [c_char, ..108]
                 }
             }
         }
@@ -626,6 +631,7 @@ pub mod types {
             pub mod bsd44 {
                 use libc::types::os::arch::c95::c_uint;
 
+                pub static sun_len:uint = 104;
                 pub type socklen_t = u32;
                 pub type sa_family_t = u8;
                 pub type in_port_t = u16;
@@ -670,6 +676,11 @@ pub mod types {
                 pub struct ip6_mreq {
                     ipv6mr_multiaddr: in6_addr,
                     ipv6mr_interface: c_uint,
+                }
+                pub struct sockaddr_un {
+                    sun_len: u8,
+                    sun_family: sa_family_t,
+                    sun_path: [c_char, ..104]
                 }
             }
         }
@@ -813,6 +824,7 @@ pub mod types {
             pub mod bsd44 {
                 use libc::types::os::arch::c95::{c_int, c_uint};
 
+                pub static sun_len:uint = 108;
                 pub type SOCKET = c_uint;
                 pub type socklen_t = c_int;
                 pub type sa_family_t = u16;
@@ -853,6 +865,10 @@ pub mod types {
                 pub struct ip6_mreq {
                     ipv6mr_multiaddr: in6_addr,
                     ipv6mr_interface: c_uint,
+                }
+                pub struct sockaddr_un {
+                    sun_family: sa_family_t,
+                    sun_path: [c_char, ..108]
                 }
             }
         }
@@ -1121,8 +1137,9 @@ pub mod types {
             }
 
             pub mod bsd44 {
-                use libc::types::os::arch::c95::{c_int, c_uint};
+                use libc::types::os::arch::c95::{c_char, c_int, c_uint};
 
+                pub static sun_len:uint = 104;
                 pub type socklen_t = c_int;
                 pub type sa_family_t = u8;
                 pub type in_port_t = u16;
@@ -1167,6 +1184,11 @@ pub mod types {
                 pub struct ip6_mreq {
                     ipv6mr_multiaddr: in6_addr,
                     ipv6mr_interface: c_uint,
+                }
+                pub struct sockaddr_un {
+                    sun_len: u8,
+                    sun_family: sa_family_t,
+                    sun_path: [c_char, ..104]
                 }
             }
         }
@@ -2207,6 +2229,7 @@ pub mod consts {
             pub static MADV_UNMERGEABLE : c_int = 13;
             pub static MADV_HWPOISON : c_int = 100;
 
+            pub static AF_UNIX: c_int = 1;
             pub static AF_INET: c_int = 2;
             pub static AF_INET6: c_int = 10;
             pub static SOCK_STREAM: c_int = 1;
@@ -3022,6 +3045,7 @@ pub mod consts {
             pub static MINCORE_REFERENCED_OTHER : c_int = 0x8;
             pub static MINCORE_MODIFIED_OTHER : c_int = 0x10;
 
+            pub static AF_UNIX: c_int = 1;
             pub static AF_INET: c_int = 2;
             pub static AF_INET6: c_int = 30;
             pub static SOCK_STREAM: c_int = 1;

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -266,6 +266,11 @@ pub trait RtioPipe {
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError>;
 }
 
+pub trait RtioDatagramPipe : RtioPipe {
+    fn recvfrom(&mut self, buf: &mut [u8]) -> Result<(uint, CString), IoError>;
+    fn sendto(&mut self, buf: &[u8], dst: &CString) -> Result<(), IoError>;
+}
+
 pub trait RtioUnixListener {
     fn listen(~self) -> Result<~RtioUnixAcceptor, IoError>;
 }


### PR DESCRIPTION
Fix #11201
No Windows named pipes for now and the libuv implementation is missing too
There is a special case for datagram sockets like /dev/log
