### PR TITLE
test: un-xfail some tests.

### DIFF
--- a/src/test/run-pass/tag-align-dyn-u64.rs
+++ b/src/test/run-pass/tag-align-dyn-u64.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test #7340 fails on 32-bit linux
 use std::ptr;
 
 enum a_tag<A> {

--- a/src/test/run-pass/tag-align-dyn-variants.rs
+++ b/src/test/run-pass/tag-align-dyn-variants.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test #7340 fails on 32-bit linux
 use std::ptr;
 
 enum a_tag<A,B> {

--- a/src/test/run-pass/tag-align-u64.rs
+++ b/src/test/run-pass/tag-align-u64.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test #7340 fails on 32-bit linux
 use std::ptr;
 
 enum a_tag {


### PR DESCRIPTION
I don't actually know if they are fixed and there are no 32-bit linux try bots, but bors' queue is pretty much empty.
