### PR TITLE
Fixed an error in tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -1429,7 +1429,7 @@ For a more in-depth explanation of references and lifetimes, read the
 
 ## Freezing
 
-Lending an immutable pointer to an object freezes it and prevents mutation.
+Lending a mutable pointer to an object freezes it and prevents mutation.
 `Freeze` objects have freezing enforced statically at compile-time. An example
 of a non-`Freeze` type is [`RefCell<T>`][refcell].
 


### PR DESCRIPTION
The freezing reference section described lending an _immutable_ pointer but the example and logic suggest it should be a _mutable_ pointer.
