### PR TITLE
Support linking of rlib files in rustpkg

### DIFF
--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -261,21 +261,21 @@ fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Opti
                 Some(i) => {
                     debug!("Maybe {} is a version", f_name.slice(i + 1, f_name.len()));
                     match try_parsing_version(f_name.slice(i + 1, f_name.len())) {
-                       Some(ref found_vers) if version == found_vers => {
-                           match f_name.slice(0, i).rfind('-') {
-                               Some(j) => {
+                        Some(ref found_vers) if version == found_vers => {
+                            match f_name.slice(0, i).rfind('-') {
+                                Some(j) => {
                                     let lib_prefix = match p_path.extension_str() {
                                         Some(ref s) if dll_filetype == *s => &dll_prefix,
                                         _ => &rlib_prefix,
                                     };
                                     debug!("Maybe {} equals {}", f_name.slice(0, j), *lib_prefix);
                                     if f_name.slice(0, j) == *lib_prefix {
-                                       result_filename = Some(p_path.clone());
-                                   }
-                                   break;
-                               }
-                               None => break
-                           }
+                                        result_filename = Some(p_path.clone());
+                                    }
+                                    break;
+                                }
+                                None => break
+                            }
 
                        }
                        _ => { f_name = f_name.slice(0, i); }

--- a/src/librustpkg/path_util.rs
+++ b/src/librustpkg/path_util.rs
@@ -226,10 +226,13 @@ fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Opti
     };
     debug!("dir has {:?} entries", dir_contents.len());
 
-    let lib_prefix = format!("{}{}", os::consts::DLL_PREFIX, short_name);
-    let lib_filetype = os::consts::DLL_EXTENSION;
+    let dll_prefix = format!("{}{}", os::consts::DLL_PREFIX, short_name);
+    let dll_filetype = os::consts::DLL_EXTENSION;
+    let rlib_prefix = format!("{}{}", "lib", short_name);
+    let rlib_filetype = "rlib";
 
-    debug!("lib_prefix = {} and lib_filetype = {}", lib_prefix, lib_filetype);
+    debug!("dll_prefix = {} and dll_filetype = {}", dll_prefix, dll_filetype);
+    debug!("rlib_prefix = {} and rlib_filetype = {}", rlib_prefix, rlib_filetype);
 
     // Find a filename that matches the pattern:
     // (lib_prefix)-hash-(version)(lib_suffix)
@@ -238,7 +241,7 @@ fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Opti
         debug!("p = {}, p's extension is {:?}", p.display(), extension);
         match extension {
             None => false,
-            Some(ref s) => lib_filetype == *s
+            Some(ref s) => dll_filetype == *s || rlib_filetype == *s,
         }
     });
 
@@ -261,8 +264,12 @@ fn library_in(short_name: &str, version: &Version, dir_to_search: &Path) -> Opti
                        Some(ref found_vers) if version == found_vers => {
                            match f_name.slice(0, i).rfind('-') {
                                Some(j) => {
-                                   debug!("Maybe {} equals {}", f_name.slice(0, j), lib_prefix);
-                                   if f_name.slice(0, j) == lib_prefix {
+                                    let lib_prefix = match p_path.extension_str() {
+                                        Some(ref s) if dll_filetype == *s => &dll_prefix,
+                                        _ => &rlib_prefix,
+                                    };
+                                    debug!("Maybe {} equals {}", f_name.slice(0, j), *lib_prefix);
+                                    if f_name.slice(0, j) == *lib_prefix {
                                        result_filename = Some(p_path.clone());
                                    }
                                    break;


### PR DESCRIPTION
Currently `rustpkg` only looks for shared libraries. After this patch it also looks for `*.rlib` files.
