### PR TITLE
rustc: make error messages containing generic more self-explanatory.

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -810,7 +810,7 @@ impl Vid for TyVid {
 }
 
 impl ToStr for TyVid {
-    fn to_str(&self) -> ~str { format!("<V{}>", self.to_uint()) }
+    fn to_str(&self) -> ~str { format!("<generic \\#{}>", self.to_uint()) }
 }
 
 impl Vid for IntVid {
@@ -818,7 +818,7 @@ impl Vid for IntVid {
 }
 
 impl ToStr for IntVid {
-    fn to_str(&self) -> ~str { format!("<VI{}>", self.to_uint()) }
+    fn to_str(&self) -> ~str { format!("<generic integer \\#{}>", self.to_uint()) }
 }
 
 impl Vid for FloatVid {
@@ -826,7 +826,7 @@ impl Vid for FloatVid {
 }
 
 impl ToStr for FloatVid {
-    fn to_str(&self) -> ~str { format!("<VF{}>", self.to_uint()) }
+    fn to_str(&self) -> ~str { format!("<generic float \\#{}>", self.to_uint()) }
 }
 
 impl Vid for RegionVid {

--- a/src/test/compile-fail/issue-3680.rs
+++ b/src/test/compile-fail/issue-3680.rs
@@ -10,6 +10,6 @@
 
 fn main() {
     match None {
-        Err(_) => () //~ ERROR mismatched types: expected `std::option::Option<<V1>>` but found `std::result::Result<<V2>,<V3>>`
+        Err(_) => () //~ ERROR mismatched types: expected `std::option::Option<<generic #1>>` but found `std::result::Result<<generic #2>,<generic #3>>`
     }
 }

--- a/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
+++ b/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Regression test for issue #4968
+struct Foo<T,U>(T);
 
-static A: (int,int) = (4,2);
 fn main() {
-    match 42 { A => () } //~ ERROR mismatched types: expected `<generic integer #0>` but found `(int,int)` (expected integral variable but found tuple)
+    match Foo(1.1) {
+        1 => {}
+        //~^ ERROR expected `Foo<<generic float #0>,<generic #2>>` but found `<generic integer #0>`
+    }
+
 }


### PR DESCRIPTION
Unsuffixed literals like 1 and 1.1, and free type parameters sometimes
have to be printed in error messages, which ended up with <V0>, <VI0>
and <VF0>. This change puts the words "generic" and "integer"/"float"
into the message so it's not a completely black box.
