### PR TITLE
Renamed LIBDIR_RELATIVE to CFG_LIBDIR_RELATIVE

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -417,7 +417,7 @@ export CFG_ENABLE_MINGW_CROSS
 export CFG_PREFIX
 export CFG_LIBDIR
 export CFG_RUSTLIBDIR
-export LIBDIR_RELATIVE
+export CFG_LIBDIR_RELATIVE
 
 ######################################################################
 # Subprograms
@@ -435,7 +435,7 @@ define SREQ
 # Destinations of artifacts for the host compiler
 HROOT$(1)_H_$(3) = $(3)/stage$(1)
 HBIN$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/bin
-HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(LIBDIR_RELATIVE)
+HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)
 
 # Destinations of artifacts for target architectures
 TROOT$(1)_T_$(2)_H_$(3) = $$(HLIB$(1)_H_$(3))/$$(CFG_RUSTLIBDIR)/$(2)

--- a/configure
+++ b/configure
@@ -401,13 +401,13 @@ valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 # On windows we just store the libraries in the bin directory because
 # there's no rpath
 # FIXME: Thise needs to parameterized over target triples. Do it in platform.mk
-LIBDIR_RELATIVE=lib
+CFG_LIBDIR_RELATIVE=lib
 if [ "$CFG_OSTYPE" = "pc-mingw32" ]
 then
-    LIBDIR_RELATIVE=bin
+    CFG_LIBDIR_RELATIVE=bin
 fi
 
-valopt libdir "${CFG_PREFIX}/${LIBDIR_RELATIVE}" "install libraries"
+valopt libdir "${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries"
 valopt rustlibdir "rustlib" "subdirectory name for rustc's libraries"
 
 # Validate Options
@@ -771,16 +771,16 @@ do
             make_dir $h/stage$i/bin
 
             # host lib dir
-            make_dir $h/stage$i/$LIBDIR_RELATIVE
+            make_dir $h/stage$i/$CFG_LIBDIR_RELATIVE
 
             # host test dir
             make_dir $h/stage$i/test
 
             # target bin dir
-            make_dir $h/stage$i/$LIBDIR_RELATIVE/$CFG_RUSTLIBDIR/$t/bin
+            make_dir $h/stage$i/$CFG_LIBDIR_RELATIVE/$CFG_RUSTLIBDIR/$t/bin
 
             # target lib dir
-            make_dir $h/stage$i/$LIBDIR_RELATIVE/$CFG_RUSTLIBDIR/$t/lib
+            make_dir $h/stage$i/$CFG_LIBDIR_RELATIVE/$CFG_RUSTLIBDIR/$t/lib
         done
     done
 
@@ -1036,7 +1036,7 @@ putvar CFG_TARGET
 putvar CFG_C_COMPILER
 putvar CFG_LIBDIR
 putvar CFG_RUSTLIBDIR
-putvar LIBDIR_RELATIVE
+putvar CFG_LIBDIR_RELATIVE
 putvar CFG_DISABLE_MANAGE_SUBMODULES
 putvar CFG_ANDROID_CROSS_PATH
 putvar CFG_MINGW32_CROSS_PATH

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -149,7 +149,7 @@ $$(HLIB$(2)_H_$(4))/$(CFG_LIBNATIVE_$(4)): \
 $$(HBIN$(2)_H_$(4))/:
 	mkdir -p $$@
 
-ifneq ($(LIBDIR_RELATIVE),bin)
+ifneq ($(CFG_LIBDIR_RELATIVE),bin)
 $$(HLIB$(2)_H_$(4))/:
 	mkdir -p $$@
 endif

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -103,13 +103,13 @@ endif
 ifdef CFG_WINDOWSY_$(1)
   CFG_TESTLIB_$(1)=$$(CFG_BUILD_DIR)$$(2)/$$(strip \
    $$(if $$(findstring stage0,$$(1)), \
-       stage0/$$(LIBDIR_RELATIVE), \
+       stage0/$$(CFG_LIBDIR_RELATIVE), \
       $$(if $$(findstring stage1,$$(1)), \
-           stage1/$$(LIBDIR_RELATIVE), \
+           stage1/$$(CFG_LIBDIR_RELATIVE), \
           $$(if $$(findstring stage2,$$(1)), \
-               stage2/$$(LIBDIR_RELATIVE), \
+               stage2/$$(CFG_LIBDIR_RELATIVE), \
                $$(if $$(findstring stage3,$$(1)), \
-                    stage3/$$(LIBDIR_RELATIVE), \
+                    stage3/$$(CFG_LIBDIR_RELATIVE), \
                )))))/$$(CFG_RUSTLIBDIR)/$$(CFG_BUILD)/lib
   CFG_RUN_TEST_$(1)=$$(call CFG_RUN_$(1),$$(call CFG_TESTLIB_$(1),$$(1),$$(3)),$$(1))
 endif

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -244,7 +244,7 @@ pub fn rust_path() -> ~[Path] {
 // The name of the directory rustc expects libraries to be located.
 // On Unix should be "lib", on windows "bin"
 pub fn libdir() -> ~str {
-    (env!("LIBDIR_RELATIVE")).to_owned()
+    (env!("CFG_LIBDIR_RELATIVE")).to_owned()
 }
 
 // The name of rustc's own place to organize libraries.


### PR DESCRIPTION
Renamed `LIBDIR_RELATIVE` to `CFG_LIBDIR_RELATIVE`. It's not a configurable variable, but it looks out of place without the `CFG_` prefix.

Fixes #11420
