### PR TITLE
Inject a libstd version, but not for stage3

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -418,6 +418,7 @@ export CFG_PREFIX
 export CFG_LIBDIR
 export CFG_RUSTLIBDIR
 export CFG_LIBDIR_RELATIVE
+export CFG_DISABLE_INJECT_STD_VERSION
 
 ######################################################################
 # Subprograms

--- a/configure
+++ b/configure
@@ -381,6 +381,7 @@ opt clang 0 "prefer clang to gcc for building the runtime"
 opt ccache 0 "invoke gcc/clang via ccache to reuse object files between builds"
 opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
 opt pax-flags 0 "apply PaX flags to rustc binaries (required for GRSecurity/PaX-patched kernels)"
+opt inject-std-version 1 "inject the current compiler version of libstd into programs"
 valopt prefix "/usr/local" "set installation prefix"
 valopt local-rust-root "/usr/local" "set prefix for local rust binary"
 valopt llvm-root "" "set LLVM root"
@@ -1042,6 +1043,7 @@ putvar CFG_DISABLE_MANAGE_SUBMODULES
 putvar CFG_ANDROID_CROSS_PATH
 putvar CFG_MINGW32_CROSS_PATH
 putvar CFG_MANDIR
+putvar CFG_DISABLE_INJECT_STD_VERSION
 
 # Avoid spurious warnings from clang by feeding it original source on
 # ccache-miss rather than preprocessed input.

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -20,7 +20,8 @@ Rust extras are part of the standard Rust distribution.
 
 */
 
-#[crate_id = "extra#0.10-pre"];
+// NOTE: upgrade to 0.10-pre after the next snapshot
+#[crate_id = "extra#0.9"];
 #[comment = "Rust extras"];
 #[license = "MIT/ASL2"];
 #[crate_type = "rlib"];

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -13,6 +13,7 @@
 
 use driver::session;
 use front::config;
+use front::std_inject::with_version;
 
 use std::cell::RefCell;
 use std::vec;
@@ -292,7 +293,7 @@ fn mk_std(cx: &TestCtxt) -> ast::ViewItem {
                                           ast::DUMMY_NODE_ID))])
     } else {
         ast::ViewItemExternMod(id_extra,
-                               None,
+                               with_version("extra"),
                                ast::DUMMY_NODE_ID)
     };
     ast::ViewItem {


### PR DESCRIPTION
This should go back to the old behavior while preserving the snapshot ease.
