### PR TITLE
Fix the representation of C void pointers in LLVM IR

### DIFF
--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -194,8 +194,19 @@ pub mod types {
             This type is only useful as a pointer target. Do not use it as a
             return type for FFI functions which have the `void` return type in
             C. Use the unit type `()` or omit the return type instead.
+
+            For LLVM to recognize the void pointer type and by extension
+            functions like malloc(), we need to have it represented as i8* in
+            LLVM bitcode. The enum used here ensures this and prevents misuse
+            of the "raw" type by only having private variants.. We need two
+            variants, because the compiler complains about the repr attribute
+            otherwise.
             */
-            pub enum c_void {}
+            #[repr(u8)]
+            pub enum c_void {
+                priv variant1,
+                priv variant2
+            }
             pub enum FILE {}
             pub enum fpos_t {}
         }


### PR DESCRIPTION
Currently, we have c_void defined to be represented as an empty struct,
but LLVM expects C's void\* to be represented as i8*. That means we
currently generate code in which LLVM doesn't recognize malloc() and
free() and can't apply certain optimization that would remove calls to
those functions.
