### PR TITLE
add an experimental tag for Gc<T> due to cycles

### DIFF
--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -16,6 +16,8 @@ collector is task-local so `Gc<T>` is not sendable.
 
 */
 
+#[allow(experimental)];
+
 use kinds::Send;
 use clone::{Clone, DeepClone};
 use managed;
@@ -24,6 +26,9 @@ use managed;
 #[lang="gc"]
 #[cfg(not(test))]
 #[no_send]
+#[experimental = "Gc is currently based on reference-counting and will not collect cycles until \
+                  task annihilation. For now, cycles need to be broken manually by using `Rc<T>` \
+                  with a non-owning `Weak<T>` pointer. A tracing garbage collector is planned."]
 pub struct Gc<T> {
     priv ptr: @T
 }


### PR DESCRIPTION
This type isn't yet very useful since it only pretends cycles won't be
a problem. Anyone using it should be made aware that they're going to
leak.
