### PR TITLE
Fix formatting in rust-guide document.

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -19,7 +19,7 @@
 [Macros](guide-macros.html)  
 [Packaging](guide-rustpkg.html)  
 [Testing](guide-testing.html)  
-[Conditions](guide-conditions.html)
+[Conditions](guide-conditions.html)  
 [Rust's Runtime](guide-runtime.html)
 
 # Libraries


### PR DESCRIPTION
Needs a line break here for readability.
