### PR TITLE
Use the least significant beat to determine if int/uint is even

### DIFF
--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -308,7 +308,7 @@ impl Integer for $T {
 
     /// Returns `true` if the number is divisible by `2`
     #[inline]
-    fn is_even(&self) -> bool { self.is_multiple_of(&2) }
+    fn is_even(&self) -> bool { self & 1 == 0 }
 
     /// Returns `true` if the number is not divisible by `2`
     #[inline]

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -169,7 +169,7 @@ impl Integer for $T {
 
     /// Returns `true` if the number is divisible by `2`
     #[inline]
-    fn is_even(&self) -> bool { self.is_multiple_of(&2) }
+    fn is_even(&self) -> bool { self & 1 == 0 }
 
     /// Returns `true` if the number is not divisible by `2`
     #[inline]


### PR DESCRIPTION
This implementation should be a bit more optimal than calling `self.is_multiple_of(&2)`
