### PR TITLE
Revert "show options for -W help and -W"

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1011,7 +1011,7 @@ pub fn optgroups() -> ~[getopts::groups::OptGroup] {
                           for details)", "FEATURE"),
   optopt("", "android-cross-path",
          "The path to the Android NDK", "PATH"),
-  optflagopt("W", "warn",
+  optmulti("W", "warn",
                         "Set lint warnings", "OPT"),
   optmulti("A", "allow",
                         "Set lint allowed", "OPT"),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -227,14 +227,9 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
         return;
     }
 
-    // Display the available lint options if "-W help" or only "-W" is given.
     let lint_flags = vec::append(matches.opt_strs("W"),
                                  matches.opt_strs("warn"));
-
-    let show_lint_options = lint_flags.iter().any(|x| x == &~"help") ||
-        (matches.opt_present("W") && lint_flags.is_empty());
-
-    if show_lint_options {
+    if lint_flags.iter().any(|x| x == &~"help") {
         describe_warnings();
         return;
     }


### PR DESCRIPTION
Reverted according to https://github.com/mozilla/rust/issues/11458#issuecomment-32269477. Fixes #11458.
