### PR TITLE
Update docs index to use lists

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -4,52 +4,54 @@
 <style type="text/css">
 #TOC { display: none; }
 .header-section-number { display: none; }
+li {list-style-type: none; }
 </style>
 
-[The Rust tutorial](tutorial.html)  ([PDF](tutorial.pdf))  
-[The Rust reference manual](rust.html) ([PDF](rust.pdf))  
+* [The Rust tutorial](tutorial.html)  (* [PDF](tutorial.pdf))
+* [The Rust reference manual](rust.html) (* [PDF](rust.pdf))
 
 # Guides
 
-[Pointers](guide-pointers.html)  
-[References and Lifetimes](guide-lifetimes.html)  
-[Containers and Iterators](guide-container.html)  
-[Tasks and Communication](guide-tasks.html)  
-[Foreign Function Interface](guide-ffi.html)  
-[Macros](guide-macros.html)  
-[Packaging](guide-rustpkg.html)  
-[Testing](guide-testing.html)  
-[Conditions](guide-conditions.html)  
-[Rust's Runtime](guide-runtime.html)
+* [Pointers](guide-pointers.html)
+* [References and Lifetimes](guide-lifetimes.html)
+* [Containers and Iterators](guide-container.html)
+* [Tasks and Communication](guide-tasks.html)
+* [Foreign Function Interface](guide-ffi.html)
+* [Macros](guide-macros.html)
+* [Packaging](guide-rustpkg.html)
+* [Testing](guide-testing.html)
+* [Conditions](guide-conditions.html)
+* [Rust's Runtime](guide-runtime.html)
 
 # Libraries
 
-[The standard library, `libstd`](std/index.html)  
-[The extra library, `libextra`](extra/index.html)
+* [The standard library, `libstd`](std/index.html)
+* [The extra library, `libextra`](extra/index.html)
 
-[The M:N runtime library, `libgreen`](green/index.html)  
-[The 1:1 runtime library, `libnative`](native/index.html)
+* [The M:N runtime library, `libgreen`](green/index.html)
+* [The 1:1 runtime library, `libnative`](native/index.html)
 
-[The Rust libuv library, `librustuv`](rustuv/index.html)  
-[The Rust packaging library, `librustpkg`](rustpkg/index.html)
+* [The Rust libuv library, `librustuv`](rustuv/index.html)
+* [The Rust packaging library, `librustpkg`](rustpkg/index.html)
 
-[The Rust parser, `libsyntax`](syntax/index.html)  
-[The Rust compiler, `librustc`](rustc/index.html)
+* [The Rust parser, `libsyntax`](syntax/index.html)
+* [The Rust compiler, `librustc`](rustc/index.html)
 
 # Tooling
 
-[The `rustpkg` manual](rustpkg.html)
+* [The `rustdoc` manual](rustdoc.html)
+* [The `rustpkg` manual](rustpkg.html)
 
 # FAQs
 
-[Language FAQ](complement-lang-faq.html)  
-[Project FAQ](complement-project-faq.html)  
-[Usage FAQ](complement-usage-faq.html)  
-[Code cheatsheet](complement-cheatsheet.html) - "How do I do X?"  
-[How to submit a bug report](complement-bugreport.html)
+* [Language FAQ](complement-lang-faq.html)
+* [Project FAQ](complement-project-faq.html)
+* [Usage FAQ](complement-usage-faq.html)
+* [Code cheatsheet](complement-cheatsheet.html) - "How do I do X?"  
+* [How to submit a bug report](complement-bugreport.html)
 
 # External resources
 
-The Rust [IRC channel](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) - `#rust` on irc.mozilla.org  
-The Rust community on [Reddit](http://reddit.com/r/rust)  
-The Rust [wiki](http://github.com/mozilla/rust/wiki)
+* The Rust [IRC channel](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) - `#rust` on irc.mozilla.org  
+* The Rust community on [Reddit](http://reddit.com/r/rust)
+* The Rust [wiki](http://github.com/mozilla/rust/wiki)


### PR DESCRIPTION
This is a bit cleaner and means we don't need whitespace at the end of each line to force line breaks.
