### PR TITLE
Demote self to an (almost) regular argument and remove the env param.

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -895,7 +895,7 @@ pub fn run_test(force_ignore: bool,
             return;
         }
         StaticBenchFn(benchfn) => {
-            let bs = ::test::bench::benchmark(benchfn);
+            let bs = ::test::bench::benchmark(|harness| benchfn(harness));
             monitor_ch.send((desc, TrBench(bs)));
             return;
         }

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -176,24 +176,23 @@ pub static tag_link_args_arg: uint = 0x7a;
 
 pub static tag_item_method_tps: uint = 0x7b;
 pub static tag_item_method_fty: uint = 0x7c;
-pub static tag_item_method_transformed_self_ty: uint = 0x7d;
 
-pub static tag_mod_child: uint = 0x7e;
-pub static tag_misc_info: uint = 0x7f;
-pub static tag_misc_info_crate_items: uint = 0x80;
+pub static tag_mod_child: uint = 0x7d;
+pub static tag_misc_info: uint = 0x7e;
+pub static tag_misc_info_crate_items: uint = 0x7f;
 
-pub static tag_item_method_provided_source: uint = 0x81;
-pub static tag_item_impl_vtables: uint = 0x82;
+pub static tag_item_method_provided_source: uint = 0x80;
+pub static tag_item_impl_vtables: uint = 0x81;
 
-pub static tag_impls: uint = 0x83;
-pub static tag_impls_impl: uint = 0x84;
+pub static tag_impls: uint = 0x82;
+pub static tag_impls_impl: uint = 0x83;
 
-pub static tag_items_data_item_inherent_impl: uint = 0x85;
-pub static tag_items_data_item_extension_impl: uint = 0x86;
+pub static tag_items_data_item_inherent_impl: uint = 0x84;
+pub static tag_items_data_item_extension_impl: uint = 0x85;
 
-pub static tag_path_elem_pretty_name: uint = 0x87;
-pub static tag_path_elem_pretty_name_ident: uint = 0x88;
-pub static tag_path_elem_pretty_name_extra: uint = 0x89;
+pub static tag_path_elem_pretty_name: uint = 0x86;
+pub static tag_path_elem_pretty_name_ident: uint = 0x87;
+pub static tag_path_elem_pretty_name_extra: uint = 0x88;
 
 pub static tag_region_param_def: uint = 0x100;
 pub static tag_region_param_def_ident: uint = 0x101;

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -227,16 +227,6 @@ fn doc_method_fty(doc: ebml::Doc, tcx: ty::ctxt, cdata: Cmd) -> ty::BareFnTy {
                           |_, did| translate_def_id(cdata, did))
 }
 
-fn doc_transformed_self_ty(doc: ebml::Doc,
-                           tcx: ty::ctxt,
-                           cdata: Cmd) -> Option<ty::t>
-{
-    reader::maybe_get_doc(doc, tag_item_method_transformed_self_ty).map(|tp| {
-        parse_ty_data(tp.data, cdata.cnum, tp.start, tcx,
-                      |_, did| translate_def_id(cdata, did))
-    })
-}
-
 pub fn item_type(_item_id: ast::DefId, item: ebml::Doc,
                  tcx: ty::ctxt, cdata: Cmd) -> ty::t {
     doc_type(item, tcx, cdata)
@@ -781,9 +771,9 @@ fn get_explicit_self(item: ebml::Doc) -> ast::ExplicitSelf_ {
     let explicit_self_kind = string[0];
     match explicit_self_kind as char {
         's' => ast::SelfStatic,
-        'v' => ast::SelfValue(get_mutability(string[1])),
+        'v' => ast::SelfValue,
         '@' => ast::SelfBox,
-        '~' => ast::SelfUniq(get_mutability(string[1])),
+        '~' => ast::SelfUniq,
         // FIXME(#4846) expl. region
         '&' => ast::SelfRegion(None, get_mutability(string[1])),
         _ => fail!("unknown self type code: `{}`", explicit_self_kind as char)
@@ -847,7 +837,6 @@ pub fn get_method(intr: @IdentInterner, cdata: Cmd, id: ast::NodeId,
     let type_param_defs = item_ty_param_defs(method_doc, tcx, cdata,
                                              tag_item_method_tps);
     let rp_defs = item_region_param_defs(method_doc, tcx, cdata);
-    let transformed_self_ty = doc_transformed_self_ty(method_doc, tcx, cdata);
     let fty = doc_method_fty(method_doc, tcx, cdata);
     let vis = item_visibility(method_doc);
     let explicit_self = get_explicit_self(method_doc);
@@ -859,7 +848,6 @@ pub fn get_method(intr: @IdentInterner, cdata: Cmd, id: ast::NodeId,
             type_param_defs: type_param_defs,
             region_param_defs: rp_defs,
         },
-        transformed_self_ty,
         fty,
         explicit_self,
         vis,

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -374,10 +374,6 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
         return ty::mk_bare_fn(st.tcx, parse_bare_fn_ty(st, |x,y| conv(x,y)));
       }
       'Y' => return ty::mk_type(st.tcx),
-      'C' => {
-        let sigil = parse_sigil(st);
-        return ty::mk_opaque_closure_ptr(st.tcx, sigil);
-      }
       '#' => {
         let pos = parse_hex(st);
         assert_eq!(next(st), ':');

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -327,10 +327,6 @@ fn enc_sty(w: &mut MemWriter, cx: @ctxt, st: &ty::sty) {
             mywrite!(w, "s{}|", (cx.ds)(did));
         }
         ty::ty_type => mywrite!(w, "Y"),
-        ty::ty_opaque_closure_ptr(p) => {
-            mywrite!(w, "C&");
-            enc_sigil(w, p);
-        }
         ty::ty_struct(def, ref substs) => {
             mywrite!(w, "a[{}|", (cx.ds)(def));
             enc_substs(w, cx, substs);

--- a/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
@@ -133,8 +133,7 @@ fn check_is_legal_to_move_from(bccx: &BorrowckCtxt,
 
         mc::cat_rvalue(..) |
         mc::cat_local(..) |
-        mc::cat_arg(..) |
-        mc::cat_self(..) => {
+        mc::cat_arg(..) => {
             true
         }
 

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -76,7 +76,6 @@ impl<'a> GuaranteeLifetimeContext<'a> {
             mc::cat_copied_upvar(..) |                  // L-Local
             mc::cat_local(..) |                         // L-Local
             mc::cat_arg(..) |                           // L-Local
-            mc::cat_self(..) |                          // L-Local
             mc::cat_deref(_, _, mc::region_ptr(..)) |   // L-Deref-Borrowed
             mc::cat_deref(_, _, mc::unsafe_ptr(..)) => {
                 let scope = self.scope(cmt);
@@ -261,7 +260,6 @@ impl<'a> GuaranteeLifetimeContext<'a> {
 
         match cmt.guarantor().cat {
             mc::cat_local(id) |
-            mc::cat_self(id) |
             mc::cat_arg(id) => {
                 let moved_variables_set = self.bccx
                                               .moved_variables_set
@@ -303,8 +301,7 @@ impl<'a> GuaranteeLifetimeContext<'a> {
                 ty::ReStatic
             }
             mc::cat_local(local_id) |
-            mc::cat_arg(local_id) |
-            mc::cat_self(local_id) => {
+            mc::cat_arg(local_id) => {
                 ty::ReScope(self.bccx.tcx.region_maps.var_scope(local_id))
             }
             mc::cat_deref(_, _, mc::unsafe_ptr(..)) => {

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -74,8 +74,7 @@ impl<'a> RestrictionsContext<'a> {
             }
 
             mc::cat_local(local_id) |
-            mc::cat_arg(local_id) |
-            mc::cat_self(local_id) => {
+            mc::cat_arg(local_id) => {
                 // R-Variable
                 let lp = @LpVar(local_id);
                 SafeIf(lp, ~[Restriction {loan_path: lp,

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -355,8 +355,8 @@ impl CFGBuilder {
                 self.call(expr, pred, func, *args)
             }
 
-            ast::ExprMethodCall(_, rcvr, _, _, ref args, _) => {
-                self.call(expr, pred, rcvr, *args)
+            ast::ExprMethodCall(_, _, _, ref args, _) => {
+                self.call(expr, pred, args[0], args.slice_from(1))
             }
 
             ast::ExprIndex(_, l, r) |
@@ -410,7 +410,6 @@ impl CFGBuilder {
             ast::ExprLogLevel |
             ast::ExprMac(..) |
             ast::ExprInlineAsm(..) |
-            ast::ExprSelf |
             ast::ExprFnBlock(..) |
             ast::ExprProc(..) |
             ast::ExprLit(..) |

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -120,7 +120,7 @@ impl Visitor<()> for EffectCheckVisitor {
 
     fn visit_expr(&mut self, expr: &ast::Expr, _:()) {
         match expr.node {
-            ast::ExprMethodCall(callee_id, _, _, _, _, _) => {
+            ast::ExprMethodCall(callee_id, _, _, _, _) => {
                 let base_type = ty::node_id_to_type(self.tcx, callee_id);
                 debug!("effect: method call case, base type is {}",
                        ppaux::ty_to_str(self.tcx, base_type));

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -48,7 +48,7 @@ impl Visitor<int> for CollectFreevarsVisitor {
             ast::ExprFnBlock(..) | ast::ExprProc(..) => {
                 visit::walk_expr(self, expr, depth + 1)
             }
-            ast::ExprPath(..) | ast::ExprSelf => {
+            ast::ExprPath(..) => {
                 let mut i = 0;
                 let def_map = self.def_map.borrow();
                 match def_map.get().find(&expr.id) {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -454,9 +454,8 @@ fn check_imm_free_var(cx: &Context, def: Def, sp: Span) {
                 sp,
                 "mutable variables cannot be implicitly captured");
         }
-        DefLocal(..) | DefArg(..) => { /* ok */ }
+        DefLocal(..) | DefArg(..) | DefBinding(..) => { /* ok */ }
         DefUpvar(_, def1, _, _) => { check_imm_free_var(cx, *def1, sp); }
-        DefBinding(..) | DefSelf(..) => { /*ok*/ }
         _ => {
             cx.tcx.sess.span_bug(
                 sp,

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -227,10 +227,9 @@ pub fn compute_moves(tcx: ty::ctxt,
 
 pub fn moved_variable_node_id_from_def(def: Def) -> Option<NodeId> {
     match def {
-      DefBinding(nid, _) |
-      DefArg(nid, _) |
-      DefLocal(nid, _) |
-      DefSelf(nid, _) => Some(nid),
+        DefBinding(nid, _) |
+        DefArg(nid, _) |
+        DefLocal(nid, _) => Some(nid),
 
       _ => None
     }
@@ -344,7 +343,7 @@ impl VisitContext {
         debug!("comp_mode = {:?}", comp_mode);
 
         match expr.node {
-            ExprPath(..) | ExprSelf => {
+            ExprPath(..) => {
                 match comp_mode {
                     Move => {
                         let def_map = self.tcx.def_map.borrow();
@@ -413,10 +412,7 @@ impl VisitContext {
                 self.use_fn_args(callee.id, *args);
             }
 
-            ExprMethodCall(callee_id, rcvr, _, _, ref args, _) => { // callee.m(args)
-                // Implicit self is equivalent to & mode, but every
-                // other kind should be + mode.
-                self.use_receiver(rcvr);
+            ExprMethodCall(callee_id, _, _, ref args, _) => { // callee.m(args)
                 self.use_fn_args(callee_id, *args);
             }
 
@@ -620,7 +616,7 @@ impl VisitContext {
             return false;
         }
 
-        self.use_receiver(receiver_expr);
+        self.use_fn_arg(receiver_expr);
 
         // for overloaded operatrs, we are always passing in a
         // reference, so it's always read mode:
@@ -673,11 +669,6 @@ impl VisitContext {
                 }
             }
         })
-    }
-
-    pub fn use_receiver(&mut self,
-                        receiver_expr: @Expr) {
-        self.use_fn_arg(receiver_expr);
     }
 
     pub fn use_fn_args(&mut self,

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -688,9 +688,9 @@ impl<'a> Visitor<()> for PrivacyVisitor<'a> {
                     _ => {}
                 }
             }
-            ast::ExprMethodCall(_, base, ident, _, _, _) => {
+            ast::ExprMethodCall(_, ident, _, ref args, _) => {
                 // see above
-                let t = ty::type_autoderef(ty::expr_ty(self.tcx, base));
+                let t = ty::type_autoderef(ty::expr_ty(self.tcx, args[0]));
                 match ty::get(t).sty {
                     ty::ty_enum(_, _) | ty::ty_struct(_, _) => {
                         let method_map = self.method_map.borrow();

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -820,12 +820,6 @@ fn resolve_fn(visitor: &mut RegionResolutionVisitor,
     // The arguments and `self` are parented to the body of the fn.
     let decl_cx = Context {parent: Some(body.id),
                            var_parent: Some(body.id)};
-    match *fk {
-        visit::FkMethod(_, _, method) => {
-            visitor.region_maps.record_var_scope(method.self_id, body.id);
-        }
-        _ => {}
-    }
     visit::walk_fn_decl(visitor, decl, decl_cx);
 
     // The body of the fn itself is either a root scope (top-level fn)

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -337,8 +337,8 @@ fn trans_opt<'a>(bcx: &'a Block<'a>, o: &Opt) -> opt_result<'a> {
             return adt::trans_case(bcx, repr, disr_val);
         }
         range(l1, l2) => {
-            let (l1, _) = consts::const_expr(ccx, l1);
-            let (l2, _) = consts::const_expr(ccx, l2);
+            let (l1, _) = consts::const_expr(ccx, l1, true);
+            let (l2, _) = consts::const_expr(ccx, l2, true);
             return range_result(rslt(bcx, l1), rslt(bcx, l2));
         }
         vec_len(n, vec_len_eq, _) => {

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -797,6 +797,11 @@ impl Builder {
     pub fn call(&self, llfn: ValueRef, args: &[ValueRef],
                 attributes: &[(uint, lib::llvm::Attribute)]) -> ValueRef {
         self.count_insn("call");
+
+        debug!("Call {} with args ({})",
+               self.ccx.tn.val_to_str(llfn),
+               args.map(|&v| self.ccx.tn.val_to_str(v)).connect(", "));
+
         unsafe {
             let v = llvm::LLVMBuildCall(self.llbuilder, llfn, args.as_ptr(),
                                         args.len() as c_uint, noname());

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -52,13 +52,6 @@ use syntax::ast;
 use syntax::abi::AbiSet;
 use syntax::ast_map;
 
-// Represents a (possibly monomorphized) top-level fn item or method
-// item.  Note that this is just the fn-ptr and is not a Rust closure
-// value (which is a pair).
-pub struct FnData {
-    llfn: ValueRef,
-}
-
 pub struct MethodData {
     llfn: ValueRef,
     llself: ValueRef,
@@ -66,8 +59,13 @@ pub struct MethodData {
 
 pub enum CalleeData {
     Closure(Datum<Lvalue>),
-    Fn(FnData),
-    Method(MethodData)
+
+    // Represents a (possibly monomorphized) top-level fn item or method
+    // item. Note that this is just the fn-ptr and is not a Rust closure
+    // value (which is a pair).
+    Fn(/* llfn */ ValueRef),
+
+    TraitMethod(MethodData)
 }
 
 pub struct Callee<'a> {
@@ -95,7 +93,7 @@ fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {
         match ty::get(datum.ty).sty {
             ty::ty_bare_fn(..) => {
                 let llval = datum.to_llscalarish(bcx);
-                return Callee {bcx: bcx, data: Fn(FnData {llfn: llval})};
+                return Callee {bcx: bcx, data: Fn(llval)};
             }
             ty::ty_closure(..) => {
                 let datum = unpack_datum!(
@@ -111,8 +109,8 @@ fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {
         }
     }
 
-    fn fn_callee<'a>(bcx: &'a Block<'a>, fd: FnData) -> Callee<'a> {
-        return Callee {bcx: bcx, data: Fn(fd)};
+    fn fn_callee<'a>(bcx: &'a Block<'a>, llfn: ValueRef) -> Callee<'a> {
+        return Callee {bcx: bcx, data: Fn(llfn)};
     }
 
     fn trans_def<'a>(bcx: &'a Block<'a>, def: ast::Def, ref_expr: &ast::Expr)
@@ -143,8 +141,7 @@ fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {
             ast::DefArg(..) |
             ast::DefLocal(..) |
             ast::DefBinding(..) |
-            ast::DefUpvar(..) |
-            ast::DefSelf(..) => {
+            ast::DefUpvar(..) => {
                 datum_callee(bcx, ref_expr)
             }
             ast::DefMod(..) | ast::DefForeignMod(..) | ast::DefTrait(..) |
@@ -171,7 +168,7 @@ pub fn trans_fn_ref_to_callee<'a>(
 }
 
 pub fn trans_fn_ref(bcx: &Block, def_id: ast::DefId, ref_id: ast::NodeId)
-                    -> FnData {
+                    -> ValueRef {
     /*!
      *
      * Translates a reference (with id `ref_id`) to the fn/method
@@ -248,7 +245,7 @@ pub fn trans_fn_ref_with_vtables(
         ref_id: ast::NodeId,  // node id of use of fn; may be zero if N/A
         type_params: &[ty::t], // values for fn's ty params
         vtables: Option<typeck::vtable_res>) // vtables for the call
-     -> FnData {
+     -> ValueRef {
     /*!
      * Translates a reference to a fn/method item, monomorphizing and
      * inlining as it goes.
@@ -399,9 +396,9 @@ pub fn trans_fn_ref_with_vtables(
             let ref_ty = common::node_id_type(bcx, ref_id);
 
             val = PointerCast(
-                bcx, val, type_of::type_of_fn_from_ty(ccx, None, ref_ty).ptr_to());
+                bcx, val, type_of::type_of_fn_from_ty(ccx, ref_ty).ptr_to());
         }
-        return FnData {llfn: val};
+        return val;
     }
 
     // Find the actual function pointer.
@@ -438,13 +435,13 @@ pub fn trans_fn_ref_with_vtables(
     // This can occur on either a crate-local or crate-external
     // reference. It also occurs when testing libcore and in some
     // other weird situations. Annoying.
-    let llty = type_of::type_of_fn_from_ty(ccx, None, fn_tpt.ty);
+    let llty = type_of::type_of_fn_from_ty(ccx, fn_tpt.ty);
     let llptrty = llty.ptr_to();
     if val_ty(val) != llptrty {
         val = BitCast(bcx, val, llptrty);
     }
 
-    return FnData {llfn: val};
+    val
 }
 
 // ______________________________________________________________________
@@ -465,8 +462,7 @@ pub fn trans_call<'a>(
                      node_id_type(in_cx, id),
                      |cx, _| trans(cx, f),
                      args,
-                     Some(dest),
-                     DontAutorefArg).bcx
+                     Some(dest)).bcx
 }
 
 pub fn trans_method_call<'a>(
@@ -478,9 +474,7 @@ pub fn trans_method_call<'a>(
                          dest: expr::Dest)
                          -> &'a Block<'a> {
     let _icx = push_ctxt("trans_method_call");
-    debug!("trans_method_call(call_ex={}, rcvr={})",
-           call_ex.repr(in_cx.tcx()),
-           rcvr.repr(in_cx.tcx()));
+    debug!("trans_method_call(call_ex={})", call_ex.repr(in_cx.tcx()));
     trans_call_inner(
         in_cx,
         Some(common::expr_info(call_ex)),
@@ -509,8 +503,7 @@ pub fn trans_method_call<'a>(
             }
         },
         args,
-        Some(dest),
-        DontAutorefArg).bcx
+        Some(dest)).bcx
 }
 
 pub fn trans_lang_call<'a>(
@@ -537,8 +530,7 @@ pub fn trans_lang_call<'a>(
                                                                     None)
                              },
                              ArgVals(args),
-                             dest,
-                             DontAutorefArg)
+                             dest)
 }
 
 pub fn trans_lang_call_with_type_params<'a>(
@@ -569,20 +561,20 @@ pub fn trans_lang_call_with_type_params<'a>(
 
             let new_llval;
             match callee.data {
-                Fn(fn_data) => {
+                Fn(llfn) => {
                     let substituted = ty::subst_tps(callee.bcx.tcx(),
                                                     type_params,
                                                     None,
                                                     fty);
                     let llfnty = type_of::type_of(callee.bcx.ccx(),
                                                       substituted);
-                    new_llval = PointerCast(callee.bcx, fn_data.llfn, llfnty);
+                    new_llval = PointerCast(callee.bcx, llfn, llfnty);
                 }
                 _ => fail!()
             }
-            Callee { bcx: callee.bcx, data: Fn(FnData { llfn: new_llval }) }
+            Callee { bcx: callee.bcx, data: Fn(new_llval) }
         },
-        ArgVals(args), Some(dest), DontAutorefArg).bcx;
+        ArgVals(args), Some(dest)).bcx;
 }
 
 pub fn trans_call_inner<'a>(
@@ -594,8 +586,7 @@ pub fn trans_call_inner<'a>(
                                      arg_cleanup_scope: cleanup::ScopeId|
                                      -> Callee<'a>,
                         args: CallArgs,
-                        dest: Option<expr::Dest>,
-                        autoref_arg: AutorefArg)
+                        dest: Option<expr::Dest>)
                         -> Result<'a> {
     /*!
      * This behemoth of a function translates function calls.
@@ -627,25 +618,22 @@ pub fn trans_call_inner<'a>(
     let callee = get_callee(bcx, cleanup::CustomScope(arg_cleanup_scope));
     let mut bcx = callee.bcx;
 
-    let (llfn, llenv) = unsafe {
-        match callee.data {
-            Fn(d) => {
-                (d.llfn, llvm::LLVMGetUndef(Type::opaque_box(ccx).ptr_to().to_ref()))
-            }
-            Method(d) => {
-                // Weird but true: we pass self in the *environment* slot!
-                (d.llfn, d.llself)
-            }
-            Closure(d) => {
-                // Closures are represented as (llfn, llclosure) pair:
-                // load the requisite values out.
-                let pair = d.to_llref();
-                let llfn = GEPi(bcx, pair, [0u, abi::fn_field_code]);
-                let llfn = Load(bcx, llfn);
-                let llenv = GEPi(bcx, pair, [0u, abi::fn_field_box]);
-                let llenv = Load(bcx, llenv);
-                (llfn, llenv)
-            }
+    let (llfn, llenv, llself) = match callee.data {
+        Fn(llfn) => {
+            (llfn, None, None)
+        }
+        TraitMethod(d) => {
+            (d.llfn, None, Some(d.llself))
+        }
+        Closure(d) => {
+            // Closures are represented as (llfn, llclosure) pair:
+            // load the requisite values out.
+            let pair = d.to_llref();
+            let llfn = GEPi(bcx, pair, [0u, abi::fn_field_code]);
+            let llfn = Load(bcx, llfn);
+            let llenv = GEPi(bcx, pair, [0u, abi::fn_field_box]);
+            let llenv = Load(bcx, llenv);
+            (llfn, Some(llenv), None)
         }
     };
 
@@ -694,13 +682,17 @@ pub fn trans_call_inner<'a>(
             llargs.push(opt_llretslot.unwrap());
         }
 
-        // Push the environment.
-        llargs.push(llenv);
+        // Push the environment (or a trait object's self).
+        match (llenv, llself) {
+            (Some(llenv), None) => llargs.push(llenv),
+            (None, Some(llself)) => llargs.push(llself),
+            _ => {}
+        }
 
         // Push the arguments.
-        bcx = trans_args(bcx, args, callee_ty,
-                         autoref_arg, &mut llargs,
-                         cleanup::CustomScope(arg_cleanup_scope));
+        bcx = trans_args(bcx, args, callee_ty, &mut llargs,
+                         cleanup::CustomScope(arg_cleanup_scope),
+                         llself.is_some());
 
         fcx.pop_custom_cleanup_scope(arg_cleanup_scope);
 
@@ -718,11 +710,10 @@ pub fn trans_call_inner<'a>(
         match ty::get(ret_ty).sty {
             // `~` pointer return values never alias because ownership
             // is transferred
-            ty::ty_uniq(..) |
-                ty::ty_vec(_, ty::vstore_uniq) => {
+            ty::ty_uniq(..) | ty::ty_vec(_, ty::vstore_uniq) => {
                 attrs.push((0, NoAliasAttribute));
             }
-            _ => ()
+            _ => {}
         }
 
         // Invoke the actual rust fn and update bcx/llresult.
@@ -748,13 +739,12 @@ pub fn trans_call_inner<'a>(
         assert!(dest.is_some());
 
         let mut llargs = ~[];
-        bcx = trans_args(bcx, args, callee_ty,
-                         autoref_arg, &mut llargs,
-                         cleanup::CustomScope(arg_cleanup_scope));
+        bcx = trans_args(bcx, args, callee_ty, &mut llargs,
+                         cleanup::CustomScope(arg_cleanup_scope), false);
         fcx.pop_custom_cleanup_scope(arg_cleanup_scope);
         let arg_tys = match args {
             ArgExprs(a) => a.iter().map(|x| expr_ty(bcx, *x)).collect(),
-            ArgVals(_) => fail!("expected arg exprs.")
+            _ => fail!("expected arg exprs.")
         };
         bcx = foreign::trans_native_call(bcx, callee_ty,
                                          llfn, opt_llretslot.unwrap(), llargs, arg_tys);
@@ -782,18 +772,18 @@ pub fn trans_call_inner<'a>(
 
 pub enum CallArgs<'a> {
     ArgExprs(&'a [@ast::Expr]),
+    // HACK used only by trans_overloaded_op.
+    ArgAutorefSecond(&'a ast::Expr, Option<&'a ast::Expr>),
     ArgVals(&'a [ValueRef])
 }
 
-pub fn trans_args<'a>(
-                  cx: &'a Block<'a>,
+fn trans_args<'a>(cx: &'a Block<'a>,
                   args: CallArgs,
                   fn_ty: ty::t,
-                  autoref_arg: AutorefArg,
                   llargs: &mut ~[ValueRef],
-                  arg_cleanup_scope: cleanup::ScopeId)
-                  -> &'a Block<'a>
-{
+                  arg_cleanup_scope: cleanup::ScopeId,
+                  ignore_self: bool)
+                  -> &'a Block<'a> {
     let _icx = push_ctxt("trans_args");
     let arg_tys = ty::ty_fn_args(fn_ty);
     let variadic = ty::fn_is_variadic(fn_ty);
@@ -804,28 +794,50 @@ pub fn trans_args<'a>(
     // This will be needed if this is a generic call, because the callee has
     // to cast her view of the arguments to the caller's view.
     match args {
-      ArgExprs(arg_exprs) => {
-        let num_formal_args = arg_tys.len();
-        for (i, arg_expr) in arg_exprs.iter().enumerate() {
-            let arg_ty = if i >= num_formal_args {
-                assert!(variadic);
-                expr_ty_adjusted(cx, *arg_expr)
-            } else {
-                arg_tys[i]
-            };
-            let arg_val = unpack_result!(bcx, {
-                trans_arg_expr(bcx,
-                               arg_ty,
-                               *arg_expr,
-                               arg_cleanup_scope,
-                               autoref_arg)
-            });
-            llargs.push(arg_val);
+        ArgExprs(arg_exprs) => {
+            let num_formal_args = arg_tys.len();
+            for (i, arg_expr) in arg_exprs.iter().enumerate() {
+                if i == 0 && ignore_self {
+                    continue;
+                }
+                let arg_ty = if i >= num_formal_args {
+                    assert!(variadic);
+                    expr_ty_adjusted(cx, *arg_expr)
+                } else {
+                    arg_tys[i]
+                };
+                llargs.push(unpack_result!(bcx, {
+                    trans_arg_expr(bcx, arg_ty, *arg_expr,
+                                   arg_cleanup_scope,
+                                   DontAutorefArg)
+                }));
+            }
         }
-      }
-      ArgVals(vs) => {
-        llargs.push_all(vs);
-      }
+        ArgAutorefSecond(arg_expr, arg2) => {
+            assert!(!variadic);
+
+            llargs.push(unpack_result!(bcx, {
+                trans_arg_expr(bcx, arg_tys[0], arg_expr,
+                               arg_cleanup_scope,
+                               DontAutorefArg)
+            }));
+
+            match arg2 {
+                Some(arg2_expr) => {
+                    assert_eq!(arg_tys.len(), 2);
+
+                    llargs.push(unpack_result!(bcx, {
+                        trans_arg_expr(bcx, arg_tys[1], arg2_expr,
+                                       arg_cleanup_scope,
+                                       DoAutorefArg)
+                    }));
+                }
+                None => assert_eq!(arg_tys.len(), 1)
+            }
+        }
+        ArgVals(vs) => {
+            llargs.push_all(vs);
+        }
     }
 
     bcx

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -680,7 +680,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
 
         // The exception handling personality function.
         let def_id = common::langcall(pad_bcx, None, "", EhPersonalityLangItem);
-        let llpersonality = callee::trans_fn_ref(pad_bcx, def_id, 0).llfn;
+        let llpersonality = callee::trans_fn_ref(pad_bcx, def_id, 0);
 
         // The only landing pad clause will be 'cleanup'
         let llretval = build::LandingPad(pad_bcx, llretty, llpersonality, 1u);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -19,6 +19,7 @@ use middle::const_eval;
 use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::base::push_ctxt;
+use middle::trans::closure;
 use middle::trans::common::*;
 use middle::trans::consts;
 use middle::trans::expr;
@@ -85,11 +86,12 @@ pub fn const_ptrcast(cx: &CrateContext, a: ValueRef, t: Type) -> ValueRef {
     }
 }
 
-fn const_vec(cx: @CrateContext, e: &ast::Expr, es: &[@ast::Expr]) -> (ValueRef, Type, bool) {
+fn const_vec(cx: @CrateContext, e: &ast::Expr,
+             es: &[@ast::Expr], is_local: bool) -> (ValueRef, Type, bool) {
     let vec_ty = ty::expr_ty(cx.tcx, e);
     let unit_ty = ty::sequence_element_type(cx.tcx, vec_ty);
     let llunitty = type_of::type_of(cx, unit_ty);
-    let (vs, inlineable) = vec::unzip(es.iter().map(|e| const_expr(cx, *e)));
+    let (vs, inlineable) = vec::unzip(es.iter().map(|e| const_expr(cx, *e, is_local)));
     // If the vector contains enums, an LLVM array won't work.
     let v = if vs.iter().any(|vi| val_ty(*vi) != llunitty) {
         C_struct(vs, false)
@@ -187,11 +189,12 @@ pub fn get_const_val(cx: @CrateContext,
      !non_inlineable_statics.get().contains(&def_id.node))
 }
 
-pub fn const_expr(cx: @CrateContext, e: &ast::Expr) -> (ValueRef, bool) {
-    let (llconst, inlineable) = const_expr_unadjusted(cx, e);
+pub fn const_expr(cx: @CrateContext, e: &ast::Expr, is_local: bool) -> (ValueRef, bool) {
+    let (llconst, inlineable) = const_expr_unadjusted(cx, e, is_local);
     let mut llconst = llconst;
     let mut inlineable = inlineable;
     let ety = ty::expr_ty(cx.tcx, e);
+    let ety_adjusted = ty::expr_ty_adjusted(cx.tcx, e);
     let adjustment = {
         let adjustments = cx.tcx.adjustments.borrow();
         adjustments.get().find_copy(&e.id)
@@ -201,10 +204,13 @@ pub fn const_expr(cx: @CrateContext, e: &ast::Expr) -> (ValueRef, bool) {
         Some(adj) => {
             match *adj {
                 ty::AutoAddEnv(ty::ReStatic, ast::BorrowedSigil) => {
-                    llconst = C_struct([
-                        llconst,
-                        C_null(Type::opaque_box(cx).ptr_to())
-                    ], false)
+                    let def = ty::resolve_expr(cx.tcx, e);
+                    let wrapper = closure::get_wrapper_for_bare_fn(cx,
+                                                                   ety_adjusted,
+                                                                   def,
+                                                                   llconst,
+                                                                   is_local);
+                    llconst = C_struct([wrapper, C_null(Type::i8p())], false)
                 }
                 ty::AutoAddEnv(ref r, ref s) => {
                     cx.sess
@@ -277,7 +283,6 @@ pub fn const_expr(cx: @CrateContext, e: &ast::Expr) -> (ValueRef, bool) {
         }
     }
 
-    let ety_adjusted = ty::expr_ty_adjusted(cx.tcx, e);
     let llty = type_of::sizing_type_of(cx, ety_adjusted);
     let csize = machine::llsize_of_alloc(cx, val_ty(llconst));
     let tsize = machine::llsize_of_alloc(cx, llty);
@@ -296,22 +301,21 @@ pub fn const_expr(cx: @CrateContext, e: &ast::Expr) -> (ValueRef, bool) {
 
 // the bool returned is whether this expression can be inlined into other crates
 // if it's assigned to a static.
-fn const_expr_unadjusted(cx: @CrateContext,
-                         e: &ast::Expr) -> (ValueRef, bool) {
-    fn map_list(cx: @CrateContext,
-                exprs: &[@ast::Expr]) -> (~[ValueRef], bool) {
-        exprs.iter().map(|&e| const_expr(cx, e))
+fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
+                         is_local: bool) -> (ValueRef, bool) {
+    let map_list = |exprs: &[@ast::Expr]| {
+        exprs.iter().map(|&e| const_expr(cx, e, is_local))
              .fold((~[], true), |(L, all_inlineable), (val, inlineable)| {
-                    (vec::append_one(L, val), all_inlineable && inlineable)
+                (vec::append_one(L, val), all_inlineable && inlineable)
              })
-    }
+    };
     unsafe {
         let _icx = push_ctxt("const_expr");
         return match e.node {
           ast::ExprLit(lit) => (consts::const_lit(cx, e, *lit), true),
           ast::ExprBinary(_, b, e1, e2) => {
-            let (te1, _) = const_expr(cx, e1);
-            let (te2, _) = const_expr(cx, e2);
+            let (te1, _) = const_expr(cx, e1, is_local);
+            let (te2, _) = const_expr(cx, e2, is_local);
 
             let te2 = base::cast_shift_const_rhs(b, te1, te2);
 
@@ -392,7 +396,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
             }, true)
           },
           ast::ExprUnary(_, u, e) => {
-            let (te, _) = const_expr(cx, e);
+            let (te, _) = const_expr(cx, e, is_local);
             let ty = ty::expr_ty(cx.tcx, e);
             let is_float = ty::type_is_fp(ty);
             return (match u {
@@ -421,7 +425,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
           ast::ExprField(base, field, _) => {
               let bt = ty::expr_ty_adjusted(cx.tcx, base);
               let brepr = adt::represent_type(cx, bt);
-              let (bv, inlineable) = const_expr(cx, base);
+              let (bv, inlineable) = const_expr(cx, base, is_local);
               expr::with_field_tys(cx.tcx, bt, None, |discr, field_tys| {
                   let ix = ty::field_idx_strict(cx.tcx, field.name, field_tys);
                   (adt::const_get_field(cx, brepr, bv, discr, ix), inlineable)
@@ -430,7 +434,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
 
           ast::ExprIndex(_, base, index) => {
               let bt = ty::expr_ty_adjusted(cx.tcx, base);
-              let (bv, inlineable) = const_expr(cx, base);
+              let (bv, inlineable) = const_expr(cx, base, is_local);
               let iv = match const_eval::eval_const_expr(cx.tcx, index) {
                   const_eval::const_int(i) => i as u64,
                   const_eval::const_uint(u) => u,
@@ -471,7 +475,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
             let ety = ty::expr_ty(cx.tcx, e);
             let llty = type_of::type_of(cx, ety);
             let basety = ty::expr_ty(cx.tcx, base);
-            let (v, inlineable) = const_expr(cx, base);
+            let (v, inlineable) = const_expr(cx, base, is_local);
             return (match (expr::cast_type_kind(basety),
                            expr::cast_type_kind(ety)) {
 
@@ -522,13 +526,13 @@ fn const_expr_unadjusted(cx: @CrateContext,
             }, inlineable)
           }
           ast::ExprAddrOf(ast::MutImmutable, sub) => {
-              let (e, _) = const_expr(cx, sub);
+              let (e, _) = const_expr(cx, sub, is_local);
               (const_addr_of(cx, e), false)
           }
           ast::ExprTup(ref es) => {
               let ety = ty::expr_ty(cx.tcx, e);
               let repr = adt::represent_type(cx, ety);
-              let (vals, inlineable) = map_list(cx, *es);
+              let (vals, inlineable) = map_list(*es);
               (adt::trans_const(cx, repr, 0, vals), inlineable)
           }
           ast::ExprStruct(_, ref fs, ref base_opt) => {
@@ -537,7 +541,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
               let tcx = cx.tcx;
 
               let base_val = match *base_opt {
-                Some(base) => Some(const_expr(cx, base)),
+                Some(base) => Some(const_expr(cx, base, is_local)),
                 None => None
               };
 
@@ -545,7 +549,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
                   let cs = field_tys.iter().enumerate()
                       .map(|(ix, &field_ty)| {
                       match fs.iter().find(|f| field_ty.ident.name == f.ident.node.name) {
-                          Some(f) => const_expr(cx, (*f).expr),
+                          Some(f) => const_expr(cx, (*f).expr, is_local),
                           None => {
                               match base_val {
                                 Some((bv, inlineable)) => {
@@ -563,19 +567,19 @@ fn const_expr_unadjusted(cx: @CrateContext,
               })
           }
           ast::ExprVec(ref es, ast::MutImmutable) => {
-            let (v, _, inlineable) = const_vec(cx, e, *es);
+            let (v, _, inlineable) = const_vec(cx, e, *es, is_local);
             (v, inlineable)
           }
           ast::ExprVstore(sub, ast::ExprVstoreSlice) => {
             match sub.node {
               ast::ExprLit(ref lit) => {
                 match lit.node {
-                    ast::LitStr(..) => { const_expr(cx, sub) }
+                    ast::LitStr(..) => { const_expr(cx, sub, is_local) }
                     _ => { cx.sess.span_bug(e.span, "bad const-slice lit") }
                 }
               }
               ast::ExprVec(ref es, ast::MutImmutable) => {
-                let (cv, llunitty, _) = const_vec(cx, e, *es);
+                let (cv, llunitty, _) = const_vec(cx, e, *es, is_local);
                 let llty = val_ty(cv);
                 let gv = "const".with_c_str(|name| {
                     llvm::LLVMAddGlobal(cx.llmod, llty.to_ref(), name)
@@ -598,7 +602,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
                 const_eval::const_uint(i) => i as uint,
                 _ => cx.sess.span_bug(count.span, "count must be integral const expression.")
             };
-            let vs = vec::from_elem(n, const_expr(cx, elem).first());
+            let vs = vec::from_elem(n, const_expr(cx, elem, is_local).first());
             let v = if vs.iter().any(|vi| val_ty(*vi) != llunitty) {
                 C_struct(vs, false)
             } else {
@@ -656,7 +660,7 @@ fn const_expr_unadjusted(cx: @CrateContext,
                   Some(ast::DefStruct(_)) => {
                       let ety = ty::expr_ty(cx.tcx, e);
                       let repr = adt::represent_type(cx, ety);
-                      let (arg_vals, inlineable) = map_list(cx, *args);
+                      let (arg_vals, inlineable) = map_list(*args);
                       (adt::trans_const(cx, repr, 0, arg_vals), inlineable)
                   }
                   Some(ast::DefVariant(enum_did, variant_did, _)) => {
@@ -665,14 +669,14 @@ fn const_expr_unadjusted(cx: @CrateContext,
                       let vinfo = ty::enum_variant_with_id(cx.tcx,
                                                            enum_did,
                                                            variant_did);
-                      let (arg_vals, inlineable) = map_list(cx, *args);
+                      let (arg_vals, inlineable) = map_list(*args);
                       (adt::trans_const(cx, repr, vinfo.disr_val, arg_vals),
                        inlineable)
                   }
                   _ => cx.sess.span_bug(e.span, "expected a struct or variant def")
               }
           }
-          ast::ExprParen(e) => { const_expr(cx, e) }
+          ast::ExprParen(e) => { const_expr(cx, e, is_local) }
           _ => cx.sess.span_bug(e.span,
                   "bad constant expression type in consts::const_expr")
         };

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -91,6 +91,9 @@ pub struct CrateContext {
 
      impl_method_cache: RefCell<HashMap<(ast::DefId, ast::Name), ast::DefId>>,
 
+     // Cache of closure wrappers for bare fn's.
+     closure_bare_wrapper_cache: RefCell<HashMap<ValueRef, ValueRef>>,
+
      module_data: RefCell<HashMap<~str, ValueRef>>,
      lltypes: RefCell<HashMap<ty::t, Type>>,
      llsizingtypes: RefCell<HashMap<ty::t, Type>>,
@@ -201,6 +204,7 @@ impl CrateContext {
                   const_values: RefCell::new(HashMap::new()),
                   extern_const_values: RefCell::new(HashMap::new()),
                   impl_method_cache: RefCell::new(HashMap::new()),
+                  closure_bare_wrapper_cache: RefCell::new(HashMap::new()),
                   module_data: RefCell::new(HashMap::new()),
                   lltypes: RefCell::new(HashMap::new()),
                   llsizingtypes: RefCell::new(HashMap::new()),

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -309,7 +309,7 @@ pub fn trans_ret<'a>(bcx: &'a Block<'a>,
         Some(x) => {
             bcx = expr::trans_into(bcx, x, dest);
         }
-        _ => ()
+        _ => {}
     }
     let cleanup_llbb = fcx.return_exit_block();
     Br(bcx, cleanup_llbb);

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -480,18 +480,10 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @CrateContext,
                id,
                t.repr(tcx));
 
-        let llfndecl = base::decl_internal_rust_fn(ccx, None, f.sig.inputs, f.sig.output, ps);
-        base::set_llvm_fn_attrs(attrs, llfndecl);
-        base::trans_fn(ccx,
-                       (*path).clone(),
-                       decl,
-                       body,
-                       llfndecl,
-                       None,
-                       None,
-                       id,
-                       []);
-        return llfndecl;
+        let llfn = base::decl_internal_rust_fn(ccx, false, f.sig.inputs, f.sig.output, ps);
+        base::set_llvm_fn_attrs(attrs, llfn);
+        base::trans_fn(ccx, (*path).clone(), decl, body, llfn, None, id, []);
+        llfn
     }
 
     unsafe fn build_wrap_fn(ccx: @CrateContext,
@@ -596,11 +588,6 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @CrateContext,
             // value that the Rust fn returns.
             return_alloca = None;
         };
-
-        // Push an (null) env pointer
-        let env_pointer = base::null_env_ptr(ccx);
-        debug!("env pointer={}", ccx.tn.val_to_str(env_pointer));
-        llrust_args.push(env_pointer);
 
         // Build up the arguments to the call to the rust function.
         // Careful to adapt for cases where the native convention uses

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -14,7 +14,6 @@ use middle::astencode;
 use middle::trans::base::{push_ctxt, trans_item, get_item_val, trans_fn};
 use middle::trans::common::*;
 use middle::ty;
-use util::ppaux::ty_to_str;
 
 use std::vec;
 use syntax::ast;
@@ -160,25 +159,7 @@ pub fn maybe_instantiate_inline(ccx: @CrateContext, fn_id: ast::DefId)
               let llfn = get_item_val(ccx, mth.id);
               let path = vec::append_one(
                   ty::item_path(ccx.tcx, impl_did), PathName(mth.ident));
-              let self_kind = match mth.explicit_self.node {
-                  ast::SelfStatic => None,
-                  _ => {
-                      let self_ty = ty::node_id_to_type(ccx.tcx,
-                                                        mth.self_id);
-                      debug!("calling inline trans_fn with self_ty {}",
-                             ty_to_str(ccx.tcx, self_ty));
-                      Some(self_ty)
-                  }
-              };
-              trans_fn(ccx,
-                       path,
-                       mth.decl,
-                       mth.body,
-                       llfn,
-                       self_kind,
-                       None,
-                       mth.id,
-                       []);
+              trans_fn(ccx, path, mth.decl, mth.body, llfn, None, mth.id, []);
           }
           local_def(mth.id)
         }

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -153,13 +153,8 @@ pub fn trans_intrinsic(ccx: @CrateContext,
 
     let output_type = ty::ty_fn_ret(ty::node_id_to_type(ccx.tcx, item.id));
 
-    let fcx = new_fn_ctxt_detailed(ccx,
-                                   path,
-                                   decl,
-                                   item.id,
-                                   output_type,
-                                   Some(substs),
-                                   Some(item.span));
+    let fcx = new_fn_ctxt_detailed(ccx, path, decl, item.id, false, output_type,
+                                   Some(substs), Some(item.span));
     init_function(&fcx, true, output_type, Some(substs));
 
     set_always_inline(fcx.llfn);
@@ -420,7 +415,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             // FIXME This is a hack to grab the address of this particular
             // native function. There should be a general in-language
             // way to do this
-            let llfty = type_of_rust_fn(bcx.ccx(), None, [], ty::mk_nil());
+            let llfty = type_of_rust_fn(bcx.ccx(), false, [], ty::mk_nil());
             let morestack_addr = decl_cdecl_fn(bcx.ccx().llmod, "__morestack",
                                                llfty, ty::mk_nil());
             let morestack_addr = PointerCast(bcx, morestack_addr,

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -213,8 +213,10 @@ pub fn monomorphic_fn(ccx: @CrateContext,
     let s = mangle_exported_name(ccx, pt.clone(), mono_ty);
     debug!("monomorphize_fn mangled to {}", s);
 
-    let mk_lldecl = |self_ty| {
-        let lldecl = decl_internal_rust_fn(ccx, self_ty, f.sig.inputs, f.sig.output, s);
+    let mk_lldecl = || {
+        let lldecl = decl_internal_rust_fn(ccx, false,
+                                           f.sig.inputs,
+                                           f.sig.output, s);
         let mut monomorphized = ccx.monomorphized.borrow_mut();
         monomorphized.get().insert(hash_id, lldecl);
         lldecl
@@ -227,17 +229,9 @@ pub fn monomorphic_fn(ccx: @CrateContext,
                 node: ast::ItemFn(decl, _, _, _, body),
                 ..
             } => {
-                let d = mk_lldecl(None);
+                let d = mk_lldecl();
                 set_llvm_fn_attrs(i.attrs, d);
-                trans_fn(ccx,
-                         pt,
-                         decl,
-                         body,
-                         d,
-                         None,
-                         Some(psubsts),
-                         fn_id.node,
-                         []);
+                trans_fn(ccx, pt, decl, body, d, Some(psubsts), fn_id.node, []);
                 d
             }
             _ => {
@@ -246,7 +240,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
           }
       }
       ast_map::NodeForeignItem(i, _, _, _) => {
-          let d = mk_lldecl(None);
+          let d = mk_lldecl();
           intrinsic::trans_intrinsic(ccx, d, i, pt, psubsts, i.attrs,
                                      ref_id);
           d
@@ -254,7 +248,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
       ast_map::NodeVariant(v, enum_item, _) => {
         let tvs = ty::enum_variants(ccx.tcx, local_def(enum_item.id));
         let this_tv = *tvs.iter().find(|tv| { tv.id.node == fn_id.node}).unwrap();
-        let d = mk_lldecl(None);
+        let d = mk_lldecl();
         set_inline_hint(d);
         match v.node.kind {
             ast::TupleVariantKind(ref args) => {
@@ -272,24 +266,19 @@ pub fn monomorphic_fn(ccx: @CrateContext,
         d
       }
       ast_map::NodeMethod(mth, _, _) => {
-        meth::trans_method(ccx, pt, mth, Some(psubsts), |self_ty| {
-            let d = mk_lldecl(self_ty);
-            set_llvm_fn_attrs(mth.attrs, d);
-            d
-        })
+        let d = mk_lldecl();
+        set_llvm_fn_attrs(mth.attrs, d);
+        trans_fn(ccx, pt, mth.decl, mth.body, d, Some(psubsts), mth.id, []);
+        d
       }
       ast_map::NodeTraitMethod(method, _, pt) => {
           match *method {
               ast::Provided(mth) => {
-                meth::trans_method(ccx,
-                                   (*pt).clone(),
-                                   mth,
-                                   Some(psubsts),
-                                   |self_ty| {
-                    let d = mk_lldecl(self_ty);
-                    set_llvm_fn_attrs(mth.attrs, d);
-                    d
-                })
+                  let d = mk_lldecl();
+                  set_llvm_fn_attrs(mth.attrs, d);
+                  trans_fn(ccx, (*pt).clone(), mth.decl, mth.body,
+                           d, Some(psubsts), mth.id, []);
+                  d
               }
               _ => {
                 ccx.tcx.sess.bug(format!("Can't monomorphize a {:?}",
@@ -298,7 +287,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
           }
       }
       ast_map::NodeStructCtor(struct_def, _, _) => {
-        let d = mk_lldecl(None);
+        let d = mk_lldecl();
         set_inline_hint(d);
         base::trans_tuple_struct(ccx,
                                  struct_def.fields,

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -13,7 +13,7 @@ use lib::llvm::{ValueRef, llvm};
 use middle::trans::adt;
 use middle::trans::base::*;
 use middle::trans::build::*;
-use middle::trans::callee::{ArgVals, DontAutorefArg};
+use middle::trans::callee::ArgVals;
 use middle::trans::callee;
 use middle::trans::common::*;
 use middle::trans::datum::*;
@@ -111,7 +111,7 @@ impl<'a> Reflector<'a> {
                                                          mth_ty,
                                                          mth_idx,
                                                          v),
-            ArgVals(args), None, DontAutorefArg));
+            ArgVals(args), None));
         let result = bool_to_i1(bcx, result);
         let next_bcx = fcx.new_temp_block("next");
         CondBr(bcx, result, next_bcx.llbb, self.final_bcx.llbb);
@@ -292,12 +292,10 @@ impl<'a> Reflector<'a> {
                                                                sub_path,
                                                                "get_disr");
 
-                let llfdecl = decl_internal_rust_fn(ccx, None, [opaqueptrty], ty::mk_u64(), sym);
-                let fcx = new_fn_ctxt(ccx,
-                                      ~[],
-                                      llfdecl,
-                                      ty::mk_u64(),
-                                      None);
+                let llfdecl = decl_internal_rust_fn(ccx, false,
+                                                    [opaqueptrty],
+                                                    ty::mk_u64(), sym);
+                let fcx = new_fn_ctxt(ccx, ~[], llfdecl, false, ty::mk_u64(), None);
                 init_function(&fcx, false, ty::mk_u64(), None);
 
                 let arg = unsafe {
@@ -358,12 +356,7 @@ impl<'a> Reflector<'a> {
               self.visit("param", extra)
           }
           ty::ty_self(..) => self.leaf("self"),
-          ty::ty_type => self.leaf("type"),
-          ty::ty_opaque_closure_ptr(ck) => {
-              let ckval = ast_sigil_constant(ck);
-              let extra = ~[self.c_uint(ckval)];
-              self.visit("closure_ptr", extra)
-          }
+          ty::ty_type => self.leaf("type")
         }
     }
 

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -189,7 +189,6 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_nil | ty::ty_bot | ty::ty_bool | ty::ty_char |
         ty::ty_int(_) | ty::ty_uint(_) |
         ty::ty_float(_) | ty::ty_type |
-        ty::ty_opaque_closure_ptr(_) |
         ty::ty_err | ty::ty_infer(_) |
         ty::ty_param(..) | ty::ty_self(_) => {
             (*sty).clone()

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -712,7 +712,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: @FnCtxt, is_early: bool) {
       ast::ExprUnary(callee_id, _, _) |
       ast::ExprAssignOp(callee_id, _, _, _) |
       ast::ExprIndex(callee_id, _, _) |
-      ast::ExprMethodCall(callee_id, _, _, _, _, _) => {
+      ast::ExprMethodCall(callee_id, _, _, _, _) => {
         match ty::method_call_type_param_defs(cx.tcx, fcx.inh.method_map, ex.id) {
           Some(type_param_defs) => {
             debug!("vtable resolution on parameter bounds for method call {}",

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -24,8 +24,7 @@ use middle::ty::{ty_str, ty_vec, ty_float, ty_infer, ty_int, ty_nil};
 use middle::ty::{ty_param, ty_param_bounds_and_ty, ty_ptr};
 use middle::ty::{ty_rptr, ty_self, ty_struct, ty_trait, ty_tup};
 use middle::ty::{ty_type, ty_uint, ty_uniq, ty_bare_fn, ty_closure};
-use middle::ty::{ty_opaque_closure_ptr, ty_unboxed_vec};
-use middle::ty::{type_is_ty_var};
+use middle::ty::{ty_unboxed_vec, type_is_ty_var};
 use middle::subst::Subst;
 use middle::ty;
 use middle::ty::{Impl, Method};
@@ -84,7 +83,7 @@ pub fn get_base_type(inference_context: @InferCtxt,
         ty_nil | ty_bot | ty_bool | ty_char | ty_int(..) | ty_uint(..) | ty_float(..) |
         ty_str(..) | ty_vec(..) | ty_bare_fn(..) | ty_closure(..) | ty_tup(..) |
         ty_infer(..) | ty_param(..) | ty_self(..) | ty_type |
-        ty_opaque_closure_ptr(..) | ty_unboxed_vec(..) | ty_err | ty_box(_) |
+        ty_unboxed_vec(..) | ty_err | ty_box(_) |
         ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
             debug!("(getting base type) no base type; found {:?}",
                    get(original_type).sty);
@@ -819,9 +818,6 @@ fn subst_receiver_types_in_method_ty(tcx: ty::ctxt,
 
         // method types *can* appear in the generic bounds
         method.generics.subst(tcx, &combined_substs),
-
-        // method tps cannot appear in the self_ty, so use `substs` from trait ref
-        method.transformed_self_ty.subst(tcx, &trait_ref.substs),
 
         // method types *can* appear in the fty
         method.fty.subst(tcx, &combined_substs),

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -380,15 +380,13 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                  m_decl: &ast::FnDecl) -> ty::Method
     {
         let trait_self_ty = ty::mk_self(this.tcx, local_def(trait_id));
-        let (transformed_self_ty, fty) =
-            astconv::ty_of_method(this, *m_id, *m_purity,
-                                  trait_self_ty, *m_explicit_self, m_decl);
+        let fty = astconv::ty_of_method(this, *m_id, *m_purity, trait_self_ty,
+                                        *m_explicit_self, m_decl);
         let num_trait_type_params = trait_generics.type_param_defs.len();
         ty::Method::new(
             *m_ident,
             // FIXME(#5121) -- distinguish early vs late lifetime params
             ty_generics(this, m_generics, num_trait_type_params),
-            transformed_self_ty,
             fty,
             m_explicit_self.node,
             // assume public, because this is only invoked on trait methods
@@ -512,10 +510,9 @@ fn convert_methods(ccx: &CrateCtxt,
                     rcvr_generics: &ast::Generics,
                     rcvr_visibility: ast::Visibility) -> ty::Method
     {
-        let (transformed_self_ty, fty) =
-            astconv::ty_of_method(ccx, m.id, m.purity,
-                                  untransformed_rcvr_ty,
-                                  m.explicit_self, m.decl);
+        let fty = astconv::ty_of_method(ccx, m.id, m.purity,
+                                        untransformed_rcvr_ty,
+                                        m.explicit_self, m.decl);
 
         // if the method specifies a visibility, use that, otherwise
         // inherit the visibility from the impl (so `foo` in `pub impl
@@ -528,7 +525,6 @@ fn convert_methods(ccx: &CrateCtxt,
             m.ident,
             // FIXME(#5121) -- distinguish early vs late lifetime params
             ty_generics(ccx, &m.generics, num_rcvr_type_params),
-            transformed_self_ty,
             fty,
             m.explicit_self.node,
             method_vis,

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -25,7 +25,7 @@ use middle::ty::{TyVid, IntVid, FloatVid, RegionVid, Vid};
 use middle::ty;
 use middle::ty_fold;
 use middle::ty_fold::TypeFolder;
-use middle::typeck::check::regionmanip::{replace_bound_regions_in_fn_sig};
+use middle::typeck::check::regionmanip::replace_bound_regions_in_fn_sig;
 use middle::typeck::infer::coercion::Coerce;
 use middle::typeck::infer::combine::{Combine, CombineFields, eq_tys};
 use middle::typeck::infer::region_inference::{RegionVarBindings};
@@ -809,8 +809,8 @@ impl InferCtxt {
                                                     -> (ty::FnSig,
                                                         HashMap<ty::BoundRegion,
                                                                 ty::Region>) {
-        let (map, _, fn_sig) =
-            replace_bound_regions_in_fn_sig(self.tcx, None, fsig, |br| {
+        let (map, fn_sig) =
+            replace_bound_regions_in_fn_sig(self.tcx, fsig, |br| {
                 let rvar = self.next_region_var(
                     BoundRegionInFnType(trace.origin.span(), br));
                 debug!("Bound region {} maps to {:?}",

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -171,8 +171,8 @@ impl Combine for Sub {
 
         // Second, we instantiate each bound region in the supertype with a
         // fresh concrete region.
-        let (skol_map, _, b_sig) = {
-            replace_bound_regions_in_fn_sig(self.get_ref().infcx.tcx, None, b, |br| {
+        let (skol_map, b_sig) = {
+            replace_bound_regions_in_fn_sig(self.get_ref().infcx.tcx, b, |br| {
                 let skol = self.get_ref().infcx.region_vars.new_skolemized(br);
                 debug!("Bound region {} skolemized to {:?}",
                        bound_region_to_str(self.get_ref().infcx.tcx, "", false, br),

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -144,13 +144,6 @@ pub struct method_object {
 
 #[deriving(Clone)]
 pub struct method_map_entry {
-    // the type of the self parameter, which is not reflected in the fn type
-    // (FIXME #3446)
-    self_ty: ty::t,
-
-    // the type of explicit self on the method
-    explicit_self: ast::ExplicitSelf_,
-
     // method details being invoked
     origin: method_origin,
 }
@@ -264,10 +257,10 @@ pub fn write_tpt_to_tcx(tcx: ty::ctxt,
 pub fn lookup_def_tcx(tcx: ty::ctxt, sp: Span, id: ast::NodeId) -> ast::Def {
     let def_map = tcx.def_map.borrow();
     match def_map.get().find(&id) {
-      Some(&x) => x,
-      _ => {
-        tcx.sess.span_fatal(sp, "internal error looking up a definition")
-      }
+        Some(&x) => x,
+        _ => {
+            tcx.sess.span_fatal(sp, "internal error looking up a definition")
+        }
     }
 }
 

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -472,22 +472,6 @@ impl<'a> Visitor<()> for ConstraintContext<'a> {
             ast::ItemTrait(..) => {
                 let methods = ty::trait_methods(tcx, did);
                 for method in methods.iter() {
-                    match method.transformed_self_ty {
-                        Some(self_ty) => {
-                            // The implicit self parameter is basically
-                            // equivalent to a normal parameter declared
-                            // like:
-                            //
-                            //     self : self_ty
-                            //
-                            // where self_ty is `&Self` or `&mut Self`
-                            // or whatever.
-                            self.add_constraints_from_ty(
-                                self_ty, self.contravariant);
-                        }
-                        None => {}
-                    }
-
                     self.add_constraints_from_sig(
                         &method.fty.sig, self.covariant);
                 }
@@ -691,8 +675,8 @@ impl<'a> ConstraintContext<'a> {
                 self.add_constraints_from_sig(sig, variance);
             }
 
-            ty::ty_infer(..) | ty::ty_err | ty::ty_type |
-            ty::ty_opaque_closure_ptr(..) | ty::ty_unboxed_vec(..) => {
+            ty::ty_infer(..) | ty::ty_err |
+            ty::ty_type | ty::ty_unboxed_vec(..) => {
                 self.tcx().sess.bug(
                     format!("Unexpected type encountered in \
                             variance inference: {}",

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -18,10 +18,8 @@ use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region,
                  ReEmpty};
 use middle::ty::{ty_bool, ty_char, ty_bot, ty_box, ty_struct, ty_enum};
 use middle::ty::{ty_err, ty_str, ty_vec, ty_float, ty_bare_fn, ty_closure};
-use middle::ty::{ty_nil, ty_opaque_closure_ptr, ty_param};
-use middle::ty::{ty_ptr, ty_rptr, ty_self, ty_tup, ty_type, ty_uniq};
-use middle::ty::{ty_trait, ty_int};
-use middle::ty::{ty_uint, ty_unboxed_vec, ty_infer};
+use middle::ty::{ty_nil, ty_param, ty_ptr, ty_rptr, ty_self, ty_tup, ty_type};
+use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_unboxed_vec, ty_infer};
 use middle::ty;
 use middle::typeck;
 use syntax::abi::AbiSet;
@@ -501,10 +499,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_vec(ref mt, vs) => {
         vstore_ty_to_str(cx, mt, vs)
       }
-      ty_str(vs) => format!("{}{}", vstore_to_str(cx, vs), "str"),
-      ty_opaque_closure_ptr(ast::BorrowedSigil) => ~"&closure",
-      ty_opaque_closure_ptr(ast::ManagedSigil) => ~"@closure",
-      ty_opaque_closure_ptr(ast::OwnedSigil) => ~"~closure",
+      ty_str(vs) => format!("{}{}", vstore_to_str(cx, vs), "str")
     }
 }
 
@@ -800,11 +795,10 @@ impl Repr for ty::Variance {
 
 impl Repr for ty::Method {
     fn repr(&self, tcx: ctxt) -> ~str {
-        format!("method(ident: {}, generics: {}, transformed_self_ty: {}, \
-                fty: {}, explicit_self: {}, vis: {}, def_id: {})",
+        format!("method(ident: {}, generics: {}, fty: {}, \
+                explicit_self: {}, vis: {}, def_id: {})",
                 self.ident.repr(tcx),
                 self.generics.repr(tcx),
-                self.transformed_self_ty.repr(tcx),
                 self.fty.repr(tcx),
                 self.explicit_self.repr(tcx),
                 self.vis.repr(tcx),
@@ -847,12 +841,7 @@ impl Repr for ty::FnSig {
 
 impl Repr for typeck::method_map_entry {
     fn repr(&self, tcx: ctxt) -> ~str {
-        format!("method_map_entry \\{self_arg: {}, \
-              explicit_self: {}, \
-              origin: {}\\}",
-             self.self_ty.repr(tcx),
-             self.explicit_self.repr(tcx),
-             self.origin.repr(tcx))
+        format!("method_map_entry \\{origin: {}\\}", self.origin.repr(tcx))
     }
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -682,7 +682,7 @@ impl Context {
     ///
     /// This currently isn't parallelized, but it'd be pretty easy to add
     /// parallelization to this function.
-    fn crate(mut self, mut crate: clean::Crate, cache: Cache) {
+    fn crate(self, mut crate: clean::Crate, cache: Cache) {
         let mut item = match crate.module.take() {
             Some(i) => i,
             None => return

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -338,7 +338,7 @@ impl rtio::RtioSocket for TcpListener {
 }
 
 impl rtio::RtioTcpListener for TcpListener {
-    fn listen(mut ~self) -> Result<~rtio::RtioTcpAcceptor, IoError> {
+    fn listen(~self) -> Result<~rtio::RtioTcpAcceptor, IoError> {
         // create the acceptor object from ourselves
         let mut acceptor = ~TcpAcceptor { listener: self };
 

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -174,7 +174,7 @@ impl PipeListener {
 }
 
 impl RtioUnixListener for PipeListener {
-    fn listen(mut ~self) -> Result<~RtioUnixAcceptor, IoError> {
+    fn listen(~self) -> Result<~RtioUnixAcceptor, IoError> {
         // create the acceptor object from ourselves
         let mut acceptor = ~PipeAcceptor { listener: self };
 

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -230,7 +230,7 @@ impl<W: Writer> LineBufferedWriter<W> {
     /// Unwraps this buffer, returning the underlying writer.
     ///
     /// The internal buffer is flushed before returning the writer.
-    pub fn unwrap(mut self) -> W { self.inner.unwrap() }
+    pub fn unwrap(self) -> W { self.inner.unwrap() }
 }
 
 impl<W: Writer> Writer for LineBufferedWriter<W> {

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -451,13 +451,8 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         true
     }
 
-    fn visit_opaque_box(&mut self) -> bool {
-        self.align_to::<@u8>();
-        if ! self.inner.visit_opaque_box() { return false; }
-        self.bump_past::<@u8>();
-        true
-    }
-
+    // NOTE remove after next snapshot
+    #[cfg(stage0)]
     fn visit_closure_ptr(&mut self, ck: uint) -> bool {
         self.align_to::<proc()>();
         if ! self.inner.visit_closure_ptr(ck) {

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -580,14 +580,8 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
     fn visit_self(&mut self) -> bool { true }
     fn visit_type(&mut self) -> bool { true }
 
-    fn visit_opaque_box(&mut self) -> bool {
-        self.writer.write(['@' as u8]);
-        self.get::<&raw::Box<()>>(|this, b| {
-            let p = ptr::to_unsafe_ptr(&b.data) as *u8;
-            this.visit_ptr_inner(p, b.type_desc);
-        })
-    }
-
+    // NOTE remove after next snapshot
+    #[cfg(stage0)]
     fn visit_closure_ptr(&mut self, _ck: uint) -> bool { true }
 }
 

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -164,7 +164,9 @@ pub trait TyVisitor {
     fn visit_param(&mut self, i: uint) -> bool;
     fn visit_self(&mut self) -> bool;
     fn visit_type(&mut self) -> bool;
-    fn visit_opaque_box(&mut self) -> bool;
+
+    // NOTE remove after next snapshot
+    #[cfg(stage0)]
     fn visit_closure_ptr(&mut self, ck: uint) -> bool;
 }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -60,19 +60,19 @@ pub fn variant_def_ids(d: Def) -> Option<(DefId, DefId)> {
 
 pub fn def_id_of_def(d: Def) -> DefId {
     match d {
-      DefFn(id, _) | DefStaticMethod(id, _, _) | DefMod(id) |
-      DefForeignMod(id) | DefStatic(id, _) |
-      DefVariant(_, id, _) | DefTy(id) | DefTyParam(id, _) |
-      DefUse(id) | DefStruct(id) | DefTrait(id) | DefMethod(id, _) => {
-        id
-      }
-      DefArg(id, _) | DefLocal(id, _) | DefSelf(id, _) | DefSelfTy(id)
-      | DefUpvar(id, _, _, _) | DefBinding(id, _) | DefRegion(id)
-      | DefTyParamBinder(id) | DefLabel(id) => {
-        local_def(id)
-      }
+        DefFn(id, _) | DefStaticMethod(id, _, _) | DefMod(id) |
+        DefForeignMod(id) | DefStatic(id, _) |
+        DefVariant(_, id, _) | DefTy(id) | DefTyParam(id, _) |
+        DefUse(id) | DefStruct(id) | DefTrait(id) | DefMethod(id, _) => {
+            id
+        }
+        DefArg(id, _) | DefLocal(id, _) | DefSelfTy(id)
+        | DefUpvar(id, _, _, _) | DefBinding(id, _) | DefRegion(id)
+        | DefTyParamBinder(id) | DefLabel(id) => {
+            local_def(id)
+        }
 
-      DefPrimTy(_) => fail!()
+        DefPrimTy(_) => fail!()
     }
 }
 
@@ -292,16 +292,6 @@ pub fn struct_field_visibility(field: ast::StructField) -> Visibility {
     }
 }
 
-/* True if d is either a def_self, or a chain of def_upvars
- referring to a def_self */
-pub fn is_self(d: ast::Def) -> bool {
-  match d {
-    DefSelf(..)           => true,
-    DefUpvar(_, d, _, _) => is_self(*d),
-    _                     => false
-  }
-}
-
 /// Maps a binary operator to its precedence
 pub fn operator_prec(op: ast::BinOp) -> uint {
   match op {
@@ -504,11 +494,8 @@ impl<'a, O: IdVisitingOperation> Visitor<()> for IdVisitor<'a, O> {
         self.operation.visit_id(node_id);
 
         match *function_kind {
-            visit::FkItemFn(_, generics, _, _) => {
-                self.visit_generics_helper(generics)
-            }
-            visit::FkMethod(_, generics, method) => {
-                self.operation.visit_id(method.self_id);
+            visit::FkItemFn(_, generics, _, _) |
+            visit::FkMethod(_, generics, _) => {
                 self.visit_generics_helper(generics)
             }
             visit::FkFnBlock => {}

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -18,6 +18,7 @@ use ext::quote::rt::*;
 use fold::Folder;
 use opt_vec;
 use opt_vec::OptVec;
+use parse::token::special_idents;
 
 pub struct Field {
     ident: ast::Ident,
@@ -478,7 +479,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.expr_path(self.path_ident(span, id))
     }
     fn expr_self(&self, span: Span) -> @ast::Expr {
-        self.expr(span, ast::ExprSelf)
+        self.expr_ident(span, special_idents::self_)
     }
 
     fn expr_binary(&self, sp: Span, op: ast::BinOp,
@@ -523,9 +524,9 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn expr_method_call(&self, span: Span,
                         expr: @ast::Expr,
                         ident: ast::Ident,
-                        args: ~[@ast::Expr]) -> @ast::Expr {
-        self.expr(span,
-                  ast::ExprMethodCall(ast::DUMMY_NODE_ID, expr, ident, ~[], args, ast::NoSugar))
+                        mut args: ~[@ast::Expr]) -> @ast::Expr {
+        args.unshift(expr);
+        self.expr(span, ast::ExprMethodCall(ast::DUMMY_NODE_ID, ident, ~[], args, ast::NoSugar))
     }
     fn expr_block(&self, b: P<ast::Block>) -> @ast::Expr {
         self.expr(b.span, ast::ExprBlock(b))

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -551,9 +551,14 @@ impl<'a> MethodDef<'a> {
         // create the generics that aren't for Self
         let fn_generics = self.generics.to_generics(trait_.cx, trait_.span, type_ident, generics);
 
+        let self_arg = match explicit_self.node {
+            ast::SelfStatic => None,
+            _ => Some(ast::Arg::new_self(trait_.span, ast::MutImmutable))
+        };
         let args = arg_types.move_iter().map(|(name, ty)| {
             trait_.cx.arg(trait_.span, name, ty)
-        }).collect();
+        });
+        let args = self_arg.move_iter().chain(args).collect();
 
         let ret_type = self.get_ret_ty(trait_, generics, type_ident);
 
@@ -578,7 +583,6 @@ impl<'a> MethodDef<'a> {
             body: body_block,
             id: ast::DUMMY_NODE_ID,
             span: trait_.span,
-            self_id: ast::DUMMY_NODE_ID,
             vis: ast::Inherited,
         }
     }

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -244,13 +244,13 @@ pub fn get_explicit_self(cx: &ExtCtxt, span: Span, self_ptr: &Option<PtrTy>)
     let self_path = cx.expr_self(span);
     match *self_ptr {
         None => {
-            (self_path, respan(span, ast::SelfValue(ast::MutImmutable)))
+            (self_path, respan(span, ast::SelfValue))
         }
         Some(ref ptr) => {
             let self_ty = respan(
                 span,
                 match *ptr {
-                    Send => ast::SelfUniq(ast::MutImmutable),
+                    Send => ast::SelfUniq,
                     Managed => ast::SelfBox,
                     Borrowed(ref lt, mutbl) => {
                         let lt = lt.map(|s| cx.lifetime(span, cx.ident_of(s)));

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -306,9 +306,7 @@ pub trait Folder {
 
     fn fold_explicit_self_(&mut self, es: &ExplicitSelf_) -> ExplicitSelf_ {
         match *es {
-            SelfStatic | SelfValue(_) | SelfUniq(_) | SelfBox => {
-                *es
-            }
+            SelfStatic | SelfValue | SelfUniq | SelfBox => *es,
             SelfRegion(ref lifetime, m) => {
                 SelfRegion(fold_opt_lifetime(lifetime, self), m)
             }
@@ -666,7 +664,6 @@ pub fn noop_fold_method<T: Folder>(m: &Method, folder: &mut T) -> @Method {
         body: folder.fold_block(m.body),
         id: folder.new_id(m.id),
         span: folder.new_span(m.span),
-        self_id: folder.new_id(m.self_id),
         vis: m.vis
     }
 }
@@ -737,10 +734,9 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
                      args.map(|&x| folder.fold_expr(x)),
                      blk)
         }
-        ExprMethodCall(callee_id, f, i, ref tps, ref args, blk) => {
+        ExprMethodCall(callee_id, i, ref tps, ref args, blk) => {
             ExprMethodCall(
                 folder.new_id(callee_id),
-                folder.fold_expr(f),
                 folder.fold_ident(i),
                 tps.map(|&x| folder.fold_ty(x)),
                 args.map(|&x| folder.fold_expr(x)),
@@ -811,7 +807,6 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
                       folder.fold_expr(er))
         }
         ExprPath(ref pth) => ExprPath(folder.fold_path(pth)),
-        ExprSelf => ExprSelf,
         ExprLogLevel => ExprLogLevel,
         ExprBreak(opt_ident) => ExprBreak(opt_ident),
         ExprAgain(opt_ident) => ExprAgain(opt_ident),

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -31,8 +31,8 @@ pub fn expr_requires_semi_to_be_stmt(e: @ast::Expr) -> bool {
       | ast::ExprForLoop(..)
       | ast::ExprCall(_, _, ast::DoSugar)
       | ast::ExprCall(_, _, ast::ForSugar)
-      | ast::ExprMethodCall(_, _, _, _, _, ast::DoSugar)
-      | ast::ExprMethodCall(_, _, _, _, _, ast::ForSugar) => false,
+      | ast::ExprMethodCall(_, _, _, _, ast::DoSugar)
+      | ast::ExprMethodCall(_, _, _, _, ast::ForSugar) => false,
       _ => true
     }
 }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -186,7 +186,7 @@ fn walk_explicit_self<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                explicit_self: &ExplicitSelf,
                                                env: E) {
     match explicit_self.node {
-        SelfStatic | SelfValue(_) | SelfBox | SelfUniq(_) => {}
+        SelfStatic | SelfValue | SelfBox | SelfUniq => {}
         SelfRegion(ref lifetime, _) => {
             visitor.visit_opt_lifetime_ref(explicit_self.span, lifetime, env)
         }
@@ -654,12 +654,11 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
             }
             visitor.visit_expr(callee_expression, env.clone())
         }
-        ExprMethodCall(_, callee, _, ref types, ref arguments, _) => {
+        ExprMethodCall(_, _, ref types, ref arguments, _) => {
             walk_exprs(visitor, *arguments, env.clone());
             for &typ in types.iter() {
                 visitor.visit_ty(typ, env.clone())
             }
-            visitor.visit_expr(callee, env.clone())
         }
         ExprBinary(_, _, left_expression, right_expression) => {
             visitor.visit_expr(left_expression, env.clone());
@@ -734,7 +733,7 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
         ExprPath(ref path) => {
             visitor.visit_path(path, expression.id, env.clone())
         }
-        ExprSelf | ExprBreak(_) | ExprAgain(_) => {}
+        ExprBreak(_) | ExprAgain(_) => {}
         ExprRet(optional_expression) => {
             walk_expr_opt(visitor, optional_expression, env.clone())
         }

--- a/src/test/compile-fail/coerce-bare-fn-to-closure-and-proc.rs
+++ b/src/test/compile-fail/coerce-bare-fn-to-closure-and-proc.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct A;
-impl A {
-    fn m(&self) {
-        fn x() {
-            self.m() //~ ERROR can't capture dynamic environment in a fn item
-            //~^ ERROR unresolved name `self`
-        }
-    }
+fn foo() {}
+
+fn main() {
+    let f = foo;
+    let f_closure: || = f;
+    //~^ ERROR: cannot coerce non-statically resolved bare fn
+    let f_proc: proc() = f;
+    //~^ ERROR: cannot coerce non-statically resolved bare fn
 }
-fn main() {}

--- a/src/test/compile-fail/lint-unused-mut-self.rs
+++ b/src/test/compile-fail/lint-unused-mut-self.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct A;
-impl A {
-    fn m(&self) {
-        fn x() {
-            self.m() //~ ERROR can't capture dynamic environment in a fn item
-            //~^ ERROR unresolved name `self`
-        }
-    }
+#[allow(dead_assignment)];
+#[allow(unused_variable)];
+#[allow(dead_code)];
+#[deny(unused_mut)];
+
+struct Foo;
+impl Foo {
+    fn foo(mut self) {} //~ ERROR: variable does not need to be mutable
+    fn bar(mut ~self) {} //~ ERROR: variable does not need to be mutable
 }
+
 fn main() {}

--- a/src/test/compile-fail/trait-impl-different-num-params.rs
+++ b/src/test/compile-fail/trait-impl-different-num-params.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,7 +13,7 @@ trait foo {
 }
 impl foo for int {
     fn bar(&self) -> int {
-        //~^ ERROR method `bar` has 0 parameters but the declaration in trait `foo::bar` has 1
+        //~^ ERROR method `bar` has 1 parameter but the declaration in trait `foo::bar` has 2
         *self
     }
 }

--- a/src/test/run-pass/coerce-to-closure-and-proc.rs
+++ b/src/test/run-pass/coerce-to-closure-and-proc.rs
@@ -1,0 +1,47 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn id<T>(x: T) -> T {
+    x
+}
+
+#[deriving(Eq)]
+struct Foo<T>(T);
+
+#[deriving(Eq)]
+enum Bar<T> {
+    Bar(T)
+}
+
+pub fn main() {
+    let f: |int| -> int = id;
+    assert_eq!(f(5), 5);
+
+    let f: proc(int) -> int = id;
+    assert_eq!(f(5), 5);
+
+    let f: |int| -> Foo<int> = Foo;
+    assert_eq!(f(5), Foo(5));
+
+    let f: proc(int) -> Foo<int> = Foo;
+    assert_eq!(f(5), Foo(5));
+
+    let f: |int| -> Bar<int> = Bar;
+    assert_eq!(f(5), Bar(5));
+
+    let f: proc(int) -> Bar<int> = Bar;
+    assert_eq!(f(5), Bar(5));
+
+    let f: |int| -> Option<int> = Some;
+    assert_eq!(f(5), Some(5));
+
+    let f: proc(int) -> Option<int> = Some;
+    assert_eq!(f(5), Some(5));
+}

--- a/src/test/run-pass/expr-block-fn.rs
+++ b/src/test/run-pass/expr-block-fn.rs
@@ -13,7 +13,7 @@
 fn test_fn() {
     type t = 'static || -> int;
     fn ten() -> int { return 10; }
-    let rs: t = { ten };
+    let rs: t = ten;
     assert!((rs() == 10));
 }
 

--- a/src/test/run-pass/reflect-visit-data.rs
+++ b/src/test/run-pass/reflect-visit-data.rs
@@ -436,20 +436,6 @@ impl<V:TyVisitor + movable_ptr> TyVisitor for ptr_visit_adaptor<V> {
         if ! self.inner().visit_type() { return false; }
         true
     }
-
-    fn visit_opaque_box(&mut self) -> bool {
-        self.align_to::<@u8>();
-        if ! self.inner().visit_opaque_box() { return false; }
-        self.bump_past::<@u8>();
-        true
-    }
-
-    fn visit_closure_ptr(&mut self, ck: uint) -> bool {
-        self.align_to::<(uint,uint)>();
-        if ! self.inner().visit_closure_ptr(ck) { return false; }
-        self.bump_past::<(uint,uint)>();
-        true
-    }
 }
 
 struct my_visitor(@RefCell<Stuff>);
@@ -611,8 +597,6 @@ impl TyVisitor for my_visitor {
     fn visit_param(&mut self, _i: uint) -> bool { true }
     fn visit_self(&mut self) -> bool { true }
     fn visit_type(&mut self) -> bool { true }
-    fn visit_opaque_box(&mut self) -> bool { true }
-    fn visit_closure_ptr(&mut self, _ck: uint) -> bool { true }
 }
 
 fn get_tydesc_for<T>(_t: T) -> *TyDesc {

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -137,8 +137,6 @@ impl TyVisitor for MyVisitor {
     fn visit_param(&mut self, _i: uint) -> bool { true }
     fn visit_self(&mut self) -> bool { true }
     fn visit_type(&mut self) -> bool { true }
-    fn visit_opaque_box(&mut self) -> bool { true }
-    fn visit_closure_ptr(&mut self, _ck: uint) -> bool { true }
 }
 
 fn visit_ty<T>(v: &mut MyVisitor) {


### PR DESCRIPTION
Non-exhaustive change list:
- `self` is now present in argument lists (modulo type-checking code I don't trust myself to refactor)
- methods have the same calling convention as bare functions (including the self argument)
- the env param is gone from all bare functions (and methods), only used by closures and `proc`s
- bare functions can only be coerced to closures and `proc`s if they are statically resolved, as they now require creating a wrapper specific to that function, to avoid indirect wrappers (equivalent to `impl<..Args, Ret> Fn<..Args, Ret> for fn(..Args) -> Ret`) that might not be optimizable by LLVM and don't work for `proc`s
- refactored some `trans::closure` code, leading to the removal of `trans::glue::make_free_glue` and `ty_opaque_closure_ptr`
