### PR TITLE
Stop returning error strings in From{Base64,Hex}

### DIFF
--- a/src/libextra/comm.rs
+++ b/src/libextra/comm.rs
@@ -127,9 +127,9 @@ mod test {
         // Rendezvous streams should be able to handle any number of messages being sent
         let (port, chan) = rendezvous();
         do spawn {
-            1000000.times(|| { chan.send(()) })
+            10000.times(|| { chan.send(()) })
         }
-        1000000.times(|| { port.recv() })
+        10000.times(|| { port.recv() })
     }
 
     #[test]


### PR DESCRIPTION
An enum allows callers to deal with errors in a more reasonable way.
