### PR TITLE
Tweak the interface of std::io

### DIFF
--- a/doc/complement-cheatsheet.md
+++ b/doc/complement-cheatsheet.md
@@ -62,8 +62,8 @@ let reader : File = File::open(&path).unwrap_or_else(on_error);
 Use the [`lines`](http://static.rust-lang.org/doc/master/std/io/trait.Buffer.html#method.lines) method on a [`BufferedReader`](http://static.rust-lang.org/doc/master/std/io/buffered/struct.BufferedReader.html).
 
 ~~~
-use std::io::buffered::BufferedReader;
-# use std::io::mem::MemReader;
+use std::io::BufferedReader;
+# use std::io::MemReader;
 
 # let reader = MemReader::new(~[]);
 

--- a/doc/guide-conditions.md
+++ b/doc/guide-conditions.md
@@ -46,12 +46,11 @@ An example program that does this task reads like this:
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\
@@ -245,13 +244,12 @@ and trapping its exit status using `task::try`:
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 use std::task;
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\
@@ -350,12 +348,11 @@ but similarly clear as the version that used `fail!` in the logic where the erro
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\
@@ -420,12 +417,11 @@ and replaces bad input lines with the pair `(-1,-1)`:
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\
@@ -496,12 +492,11 @@ Changing the condition's return type from `(int,int)` to `Option<(int,int)>` wil
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\
@@ -582,12 +577,11 @@ This can be encoded in the handler API by introducing a helper type: `enum Malfo
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
 use std::io::File;
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\
@@ -707,12 +701,11 @@ a second condition and a helper function will suffice:
 ~~~~
 # #[allow(unused_imports)];
 # extern mod extra;
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 # mod BufferedReader {
 #     use std::io::File;
-#     use std::io::mem::MemReader;
-#     use std::io::buffered::BufferedReader;
+#     use std::io::MemReader;
+#     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
 #                                        34 56\n\
 #                                        789 123\n\

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::buffered::BufferedReader;
-use std::io::File;
+use std::io::{BufferedReader, File};
 
 pub struct ExpectedError { line: uint, kind: ~str, msg: ~str }
 

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -103,8 +103,7 @@ pub fn is_test_ignored(config: &config, testfile: &Path) -> bool {
 }
 
 fn iter_header(testfile: &Path, it: |&str| -> bool) -> bool {
-    use std::io::buffered::BufferedReader;
-    use std::io::File;
+    use std::io::{BufferedReader, File};
 
     let mut rdr = BufferedReader::new(File::open(testfile).unwrap());
     for ln in rdr.lines() {

--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -582,7 +582,7 @@ pub mod writer {
     use std::clone::Clone;
     use std::io;
     use std::io::{Writer, Seek};
-    use std::io::mem::MemWriter;
+    use std::io::MemWriter;
     use std::io::extensions::u64_to_be_bytes;
 
     // ebml writing
@@ -935,7 +935,7 @@ mod tests {
     use serialize::Encodable;
     use serialize;
 
-    use std::io::mem::MemWriter;
+    use std::io::MemWriter;
     use std::option::{None, Option, Some};
 
     #[test]

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -21,7 +21,7 @@ use std::cast::transmute;
 use std::f64;
 use std::hashmap::HashMap;
 use std::io;
-use std::io::mem::MemWriter;
+use std::io::MemWriter;
 use std::num;
 use std::str;
 use std::to_str;
@@ -1506,7 +1506,7 @@ mod tests {
     }
 
     fn with_str_writer(f: |&mut io::Writer|) -> ~str {
-        use std::io::mem::MemWriter;
+        use std::io::MemWriter;
         use std::str;
 
         let mut m = MemWriter::new();

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -998,7 +998,7 @@ mod tests {
     #[test]
     fn test_boxplot_nonpositive() {
         fn t(s: &Summary, expected: ~str) {
-            use std::io::mem::MemWriter;
+            use std::io::MemWriter;
             let mut m = MemWriter::new();
             write_boxplot(&mut m as &mut io::Writer, s, 30);
             let out = str::from_utf8_owned(m.unwrap());

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -673,7 +673,7 @@ pub fn run_tests_console(opts: &TestOpts,
 
 #[test]
 fn should_sort_failures_before_printing_them() {
-    use std::io::mem::MemWriter;
+    use std::io::MemWriter;
     use std::str;
 
     let test_a = TestDesc {

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -10,8 +10,7 @@
 
 #[allow(missing_doc)];
 
-use std::io::Reader;
-use std::io::mem::BufReader;
+use std::io::BufReader;
 use std::libc;
 use std::num;
 use std::str;

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -12,8 +12,7 @@
 
 #[allow(missing_doc)];
 
-use std::io::{Reader, Seek};
-use std::io::mem::BufReader;
+use std::io::BufReader;
 use std::cmp::Eq;
 use std::hashmap::HashMap;
 use std::to_bytes;

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -522,7 +522,7 @@ mod test {
     use std::str;
     use std::rand;
     use std::num::Zero;
-    use std::io::mem::MemWriter;
+    use std::io::MemWriter;
 
     #[test]
     fn test_new_nil() {

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -17,8 +17,7 @@ use arc::{Arc,RWArc};
 use treemap::TreeMap;
 use std::str;
 use std::io;
-use std::io::File;
-use std::io::mem::MemWriter;
+use std::io::{File, MemWriter};
 
 /**
 *

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -30,7 +30,7 @@ use std::cell::{Cell, RefCell};
 use std::hashmap::{HashMap,HashSet};
 use std::io;
 use std::io::fs;
-use std::io::mem::MemReader;
+use std::io::MemReader;
 use std::os;
 use std::vec;
 use extra::getopts::groups::{optopt, optmulti, optflag, optflagopt};

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -24,7 +24,7 @@ use middle;
 use std::cast;
 use std::cell::{Cell, RefCell};
 use std::hashmap::{HashMap, HashSet};
-use std::io::mem::MemWriter;
+use std::io::MemWriter;
 use std::str;
 use std::vec;
 

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::hashmap::HashMap;
 use std::io;
-use std::io::mem::MemWriter;
+use std::io::MemWriter;
 use std::str;
 use std::fmt;
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1456,7 +1456,7 @@ fn mk_ctxt() -> @fake_ext_ctxt {
 
 #[cfg(test)]
 fn roundtrip(in_item: Option<@ast::Item>) {
-    use std::io::mem::MemWriter;
+    use std::io::MemWriter;
 
     let in_item = in_item.unwrap();
     let mut wr = MemWriter::new();

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -794,8 +794,9 @@ impl Liveness {
     }
 
     pub fn ln_str(&self, ln: LiveNode) -> ~str {
-        str::from_utf8_owned(io::mem::with_mem_writer(|wr| {
-            let wr = wr as &mut io::Writer;
+        let mut wr = io::MemWriter::new();
+        {
+            let wr = &mut wr as &mut io::Writer;
             {
                 let lnks = self.ir.lnks.try_borrow();
                 write!(wr,
@@ -823,7 +824,8 @@ impl Liveness {
                     write!(wr, "  precedes (successors borrowed)]");
                 }
             }
-        }))
+        }
+        str::from_utf8_owned(wr.unwrap())
     }
 
     pub fn init_empty(&self, ln: LiveNode, succ_ln: LiveNode) {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -36,10 +36,8 @@
 use std::fmt;
 use std::hashmap::{HashMap, HashSet};
 use std::local_data;
-use std::io::buffered::BufferedWriter;
 use std::io;
-use std::io::fs;
-use std::io::File;
+use std::io::{fs, File, BufferedWriter};
 use std::str;
 use std::vec;
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -21,8 +21,7 @@ extern mod extra;
 
 use std::local_data;
 use std::io;
-use std::io::File;
-use std::io::mem::MemWriter;
+use std::io::{File, MemWriter};
 use std::str;
 use extra::getopts;
 use extra::getopts::groups;

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -242,7 +242,7 @@ actually invoking the `write` function defined in this module. Example usage is:
 ```rust
 use std::io;
 
-let mut w = io::mem::MemWriter::new();
+let mut w = io::MemWriter::new();
 write!(&mut w as &mut io::Writer, "Hello {}!", "world");
 ```
 
@@ -470,7 +470,7 @@ use prelude::*;
 
 use cast;
 use char::Char;
-use io::mem::MemWriter;
+use io::MemWriter;
 use io;
 use str;
 use repr;

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -141,7 +141,7 @@ pub fn u64_from_be_bytes(data: &[u8],
 mod test {
     use unstable::finally::Finally;
     use prelude::*;
-    use io::mem::{MemReader, MemWriter};
+    use io::{MemReader, MemWriter};
     use io::{io_error, placeholder_error};
 
     struct InitialZeroByteReader {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -26,7 +26,7 @@ Some examples of obvious things you might want to do
 * Read lines from stdin
 
     ```rust
-    use std::io::buffered::BufferedReader;
+    use std::io::BufferedReader;
     use std::io::stdin;
 
     # let _g = ::std::io::ignore_io_error();
@@ -60,7 +60,7 @@ Some examples of obvious things you might want to do
 * Iterate over the lines of a file
 
     ```rust
-    use std::io::buffered::BufferedReader;
+    use std::io::BufferedReader;
     use std::io::File;
 
     # let _g = ::std::io::ignore_io_error();
@@ -74,7 +74,7 @@ Some examples of obvious things you might want to do
 * Pull the lines of a file into a vector of strings
 
     ```rust
-    use std::io::buffered::BufferedReader;
+    use std::io::BufferedReader;
     use std::io::File;
 
     # let _g = ::std::io::ignore_io_error();
@@ -321,6 +321,11 @@ pub use self::net::udp::UdpStream;
 pub use self::pipe::PipeStream;
 pub use self::process::Process;
 
+pub use self::mem::{MemReader, BufReader, MemWriter, BufWriter};
+pub use self::buffered::{BufferedReader, BufferedWriter, BufferedStream,
+                         LineBufferedWriter};
+pub use self::comm_adapters::{PortReader, ChanWriter};
+
 /// Various utility functions useful for writing I/O tests
 pub mod test;
 
@@ -337,16 +342,13 @@ pub mod process;
 pub mod net;
 
 /// Readers and Writers for memory buffers and strings.
-pub mod mem;
+mod mem;
 
 /// Non-blocking access to stdin, stdout, stderr
 pub mod stdio;
 
 /// Implementations for Option
 mod option;
-
-/// Basic stream compression. XXX: Belongs with other flate code
-pub mod flate;
 
 /// Extension traits
 pub mod extensions;
@@ -355,7 +357,7 @@ pub mod extensions;
 pub mod timer;
 
 /// Buffered I/O wrappers
-pub mod buffered;
+mod buffered;
 
 /// Signal handling
 pub mod signal;
@@ -364,9 +366,11 @@ pub mod signal;
 pub mod util;
 
 /// Adapatation of Chan/Port types to a Writer/Reader type.
-pub mod comm_adapters;
+mod comm_adapters;
 
 /// The default buffer size for various I/O operations
+// libuv recommends 64k buffers to maximize throughput
+// https://groups.google.com/forum/#!topic/libuv/oQO1HJAIDdA
 static DEFAULT_BUF_SIZE: uint = 1024 * 64;
 
 /// The type passed to I/O condition handlers to indicate error
@@ -1098,11 +1102,10 @@ pub trait Buffer: Reader {
     /// # Example
     ///
     /// ```rust
-    /// use std::io::buffered::BufferedReader;
-    /// use std::io;
+    /// use std::io::{BufferedReader, stdin};
     /// # let _g = ::std::io::ignore_io_error();
     ///
-    /// let mut reader = BufferedReader::new(io::stdin());
+    /// let mut reader = BufferedReader::new(stdin());
     ///
     /// let input = reader.read_line().unwrap_or(~"nothing");
     /// ```

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -28,9 +28,8 @@ out.write(bytes!("Hello, world!"));
 
 use container::Container;
 use fmt;
-use io::buffered::LineBufferedWriter;
 use io::{Reader, Writer, io_error, IoError, OtherIoError,
-         standard_error, EndOfFile};
+         standard_error, EndOfFile, LineBufferedWriter};
 use libc;
 use option::{Option, Some, None};
 use prelude::drop;

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -171,7 +171,7 @@ pub fn copy<R: Reader, W: Writer>(r: &mut R, w: &mut W) {
 
 #[cfg(test)]
 mod test {
-    use io::mem::{MemReader, MemWriter};
+    use io::{MemReader, MemWriter};
     use super::*;
     use prelude::*;
 

--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -96,7 +96,7 @@ start, print out all modules registered for logging, and then exit.
 */
 
 use fmt;
-use io::buffered::LineBufferedWriter;
+use io::LineBufferedWriter;
 use io;
 use io::Writer;
 use ops::Drop;

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -25,9 +25,9 @@ use rand::Rng;
 ///
 /// ```rust
 /// use std::rand::{reader, Rng};
-/// use std::io::mem;
+/// use std::io::MemReader;
 ///
-/// let mut rng = reader::ReaderRng::new(mem::MemReader::new(~[1,2,3,4,5,6,7,8]));
+/// let mut rng = reader::ReaderRng::new(MemReader::new(~[1,2,3,4,5,6,7,8]));
 /// println!("{:x}", rng.gen::<uint>());
 /// ```
 pub struct ReaderRng<R> {
@@ -76,7 +76,7 @@ impl<R: Reader> Rng for ReaderRng<R> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use io::mem::MemReader;
+    use io::MemReader;
     use cast;
     use rand::*;
     use prelude::*;

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -621,7 +621,7 @@ pub fn repr_to_str<T>(t: &T) -> ~str {
     use str;
     use io;
 
-    let mut result = io::mem::MemWriter::new();
+    let mut result = io::MemWriter::new();
     write_repr(&mut result as &mut io::Writer, t);
     str::from_utf8_owned(result.unwrap())
 }
@@ -639,7 +639,7 @@ fn test_repr() {
     use char::is_alphabetic;
 
     fn exact_test<T>(t: &T, e:&str) {
-        let mut m = io::mem::MemWriter::new();
+        let mut m = io::MemWriter::new();
         write_repr(&mut m as &mut io::Writer, t);
         let s = str::from_utf8_owned(m.unwrap());
         assert_eq!(s.as_slice(), e);

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -359,15 +359,14 @@ pub trait ToBytes {
 
 impl<A:IterBytes> ToBytes for A {
     fn to_bytes(&self, lsb0: bool) -> ~[u8] {
-        use io::mem;
         use io::Writer;
 
-        mem::with_mem_writer(|wr| {
-            self.iter_bytes(lsb0, |bytes| {
-                wr.write(bytes);
-                true
-            });
-        })
+        let mut m = ::io::MemWriter::new();
+        self.iter_bytes(lsb0, |bytes| {
+            m.write(bytes);
+            true
+        });
+        m.unwrap()
     }
 }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -337,7 +337,7 @@ mod test {
     use extra::serialize::Encodable;
     use extra;
     use std::io;
-    use std::io::mem::MemWriter;
+    use std::io::MemWriter;
     use std::str;
     use codemap::{Span, BytePos, Spanned};
     use opt_vec;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -32,7 +32,7 @@ use std::cell::RefCell;
 use std::char;
 use std::str;
 use std::io;
-use std::io::mem::MemWriter;
+use std::io::MemWriter;
 
 // The &mut State is stored here to prevent recursive type.
 pub enum AnnNode<'a,'b> {

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -70,7 +70,7 @@ fn shift_push() {
 }
 
 fn read_line() {
-    use std::io::buffered::BufferedReader;
+    use std::io::BufferedReader;
 
     let mut path = Path::new(env!("CFG_SRC_DIR"));
     path.push("src/test/bench/shootout-k-nucleotide.data");

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -15,8 +15,7 @@
  */
 
 use std::io;
-use std::io::buffered::BufferedWriter;
-use std::io::File;
+use std::io::{BufferedWriter, File};
 use std::num::min;
 use std::os;
 

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -145,10 +145,7 @@ fn make_sequence_processor(sz: uint,
 
 // given a FASTA file on stdin, process sequence THREE
 fn main() {
-    use std::io::Reader;
-    use std::io::stdio;
-    use std::io::mem::MemReader;
-    use std::io::buffered::BufferedReader;
+    use std::io::{stdio, MemReader, BufferedReader};
 
     let rdr = if os::getenv("RUST_BENCH").is_some() {
         let foo = include_bin!("shootout-k-nucleotide.data");

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::io::buffered::BufferedWriter;
+use std::io::BufferedWriter;
 
 struct DummyWriter;
 impl Writer for DummyWriter {

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -16,7 +16,7 @@ extern mod extra;
 
 use std::io;
 use std::io::stdio::StdReader;
-use std::io::buffered::BufferedReader;
+use std::io::BufferedReader;
 use std::os;
 use std::unstable::intrinsics::cttz16;
 use std::vec;

--- a/src/test/run-pass/auto-encode.rs
+++ b/src/test/run-pass/auto-encode.rs
@@ -34,7 +34,7 @@ fn test_ebml<'a, A:
     Encodable<EBWriter::Encoder> +
     Decodable<EBReader::Decoder<'a>>
 >(a1: &A) {
-    let mut wr = std::io::mem::MemWriter::new();
+    let mut wr = std::io::MemWriter::new();
     let mut ebml_w = EBWriter::Encoder(&mut wr);
     a1.encode(&mut ebml_w);
     let bytes = wr.get_ref();

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -16,7 +16,7 @@
 extern mod native;
 
 use std::fmt;
-use std::io::comm_adapters::{PortReader, ChanWriter};
+use std::io::{PortReader, ChanWriter};
 use std::logging::{set_logger, Logger};
 
 struct MyWriter(ChanWriter);

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -18,7 +18,7 @@
 
 extern mod extra;
 
-use std::io::mem::MemWriter;
+use std::io::MemWriter;
 use std::rand::{random, Rand};
 use extra::serialize::{Encodable, Decodable};
 use extra::ebml;

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -14,9 +14,8 @@
 #[deny(warnings)];
 
 use std::fmt;
-use std::io::mem::MemWriter;
+use std::io::MemWriter;
 use std::io;
-use std::io::Writer;
 use std::str;
 
 struct A;


### PR DESCRIPTION
- Reexport io::mem and io::buffered structs directly under io, make mem/buffered
  private modules
- Remove with_mem_writer
- Remove DEFAULT_CAPACITY and use DEFAULT_BUF_SIZE (in io::buffered)

cc #11119
