### PR TITLE
Fix test run summary counts

### DIFF
--- a/src/etc/check-summary.py
+++ b/src/etc/check-summary.py
@@ -7,13 +7,20 @@ if __name__ == '__main__':
     summaries = []
     def summarise(fname):
         summary = {}
-        fd = open(fname)
-        for line in fd:
-            status, test = line.strip().split(' ', 1)
-            if not summary.has_key(status):
-                summary[status] = []
-            summary[status].append(test)
-        summaries.append((fname, summary))
+        with open(fname) as fd:
+            for line in fd:
+                splitline = line.strip().split(' ')
+                if len(splitline) == 1:
+                    continue
+                status = splitline[0]
+                test = splitline[-1]
+                # track bench runs
+                if splitline[1] == 'ns/iter':
+                    status = 'bench'
+                if not summary.has_key(status):
+                    summary[status] = []
+                summary[status].append(test)
+            summaries.append((fname, summary))
     def count(t):
         return sum(map(lambda (f, s): len(s.get(t, [])), summaries))
     logfiles = sys.argv[1:]
@@ -21,8 +28,9 @@ if __name__ == '__main__':
     ok = count('ok')
     failed = count('failed')
     ignored = count('ignored')
-    print "summary of %d test runs: %d passed; %d failed; %d ignored" % \
-            (len(logfiles), ok, failed, ignored)
+    measured = count('bench')
+    print "summary of %d test runs: %d passed; %d failed; %d ignored; %d measured" % \
+            (len(logfiles), ok, failed, ignored, measured)
     print ""
     if failed > 0:
         print "failed tests:"

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -474,7 +474,7 @@ impl<T: Writer> ConsoleTestState<T> {
         match self.log_out {
             None => (),
             Some(ref mut o) => {
-                let s = format!("{} {}", match *result {
+                let s = format!("{} {}\n", match *result {
                         TrOk => ~"ok",
                         TrFailed => ~"failed",
                         TrIgnored => ~"ignored",


### PR DESCRIPTION
The test run summary currently prints the wrong number of tests run. This PR fixes it by adding a newline to the log output, and also adds support for counting bench runs.

Closes #11381
