### PR TITLE
Force all lang items to be reachable

### DIFF
--- a/src/test/auxiliary/lang-item-public.rs
+++ b/src/test/auxiliary/lang-item-public.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_std];
+
+#[lang="fail_"]
+fn fail(_: *i8, _: *i8, _: uint) -> ! { loop {} }
+
+#[no_mangle]
+pub extern "C" fn rust_stack_exhausted() {}

--- a/src/test/run-pass/lang-item-public.rs
+++ b/src/test/run-pass/lang-item-public.rs
@@ -1,0 +1,38 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:lang-item-public.rs
+// ignore-fast
+// ignore-android
+
+#[no_std];
+
+extern crate lang_lib = "lang-item-public";
+
+#[cfg(target_os = "linux")]
+#[link(name = "c")]
+extern {}
+
+#[cfg(target_os = "android")]
+#[link(name = "c")]
+extern {}
+
+#[cfg(target_os = "freebsd")]
+#[link(name = "execinfo")]
+extern {}
+
+#[cfg(target_os = "macos")]
+#[link(name = "System")]
+extern {}
+
+#[start]
+fn main(_: int, _: **u8) -> int {
+    1 % 1
+}


### PR DESCRIPTION
This prevents linker errors as found in #11591

Closes #11591
