### PR TITLE
Forbid unnecessary visibility on view items

### DIFF
--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -73,7 +73,7 @@ impl fold::Folder for StandardLibraryInjector {
                                          with_version("std"),
                                          ast::DUMMY_NODE_ID),
             attrs: ~[],
-            vis: ast::Private,
+            vis: ast::Inherited,
             span: DUMMY_SP
         }];
 
@@ -83,7 +83,7 @@ impl fold::Folder for StandardLibraryInjector {
                                              with_version("green"),
                                              ast::DUMMY_NODE_ID),
                 attrs: ~[],
-                vis: ast::Private,
+                vis: ast::Inherited,
                 span: DUMMY_SP
             });
             vis.push(ast::ViewItem {
@@ -91,7 +91,7 @@ impl fold::Folder for StandardLibraryInjector {
                                              with_version("rustuv"),
                                              ast::DUMMY_NODE_ID),
                 attrs: ~[],
-                vis: ast::Private,
+                vis: ast::Inherited,
                 span: DUMMY_SP
             });
         }
@@ -147,7 +147,7 @@ impl fold::Folder for StandardLibraryInjector {
         let vi2 = ast::ViewItem {
             node: ast::ViewItemUse(~[vp]),
             attrs: ~[],
-            vis: ast::Private,
+            vis: ast::Inherited,
             span: DUMMY_SP,
         };
 

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -299,7 +299,7 @@ fn mk_std(cx: &TestCtxt) -> ast::ViewItem {
     ast::ViewItem {
         node: vi,
         attrs: ~[],
-        vis: ast::Public,
+        vis: ast::Inherited,
         span: DUMMY_SP
     }
 }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -648,7 +648,7 @@ fn expand_wrapper(cx: &ExtCtxt,
                   sp: Span,
                   cx_expr: @ast::Expr,
                   expr: @ast::Expr) -> @ast::Expr {
-    let uses = ~[ cx.view_use_glob(sp, ast::Public,
+    let uses = ~[ cx.view_use_glob(sp, ast::Inherited,
                                    ids_ext(~[~"syntax",
                                              ~"ext",
                                              ~"quote",

--- a/src/test/compile-fail/issue-9957.rs
+++ b/src/test/compile-fail/issue-9957.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub extern mod std; //~ ERROR: `pub` visibility is not allowed
+priv extern mod std; //~ ERROR: unnecessary visibility qualifier
+extern mod std;
+
+pub use std::bool;
+priv use std::bool; //~ ERROR: unnecessary visibility qualifier
+use std::bool;
+
+fn main() {
+    pub use std::bool; //~ ERROR: imports in functions are never reachable
+    priv use std::bool; //~ ERROR: unnecessary visibility qualifier
+    use std::bool;
+}


### PR DESCRIPTION
For `use` statements, this means disallowing qualifiers when in functions and
disallowing `priv` outside of functions.

For `extern mod` statements, this means disallowing everything everywhere. It
may have been envisioned for `pub extern mod foo` to be a thing, but it
currently doesn't do anything (resolve doesn't pick it up), so better to err on
the side of forwards-compatibility and forbid it entirely for now.

Closes #9957
