### PR TITLE
test: Add the ability to force a host target

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -626,9 +626,10 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         --aux-base $$(S)src/test/auxiliary/                 \
         --stage-id stage$(1)-$(2)							\
         --target $(2)                                       \
+        --host $(3)                                       \
         --adb-path=$(CFG_ADB)                          \
         --adb-test-dir=$(CFG_ADB_TEST_DIR)                  \
-        --rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) --target=$(2)" \
+        --rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS)" \
         $$(CTEST_TESTARGS)
 
 CTEST_DEPS_rpass_$(1)-T-$(2)-H-$(3) = $$(RPASS_TESTS)

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -86,6 +86,9 @@ pub struct config {
     // Target system to be tested
     target: ~str,
 
+    // Host triple for the compiler being invoked
+    host: ~str,
+
     // Extra parameter to run adb on arm-linux-androideabi
     adb_path: ~str,
 

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -73,6 +73,7 @@ pub fn parse_config(args: ~[~str]) -> config {
                  "percent change in metrics to consider noise", "N"),
           optflag("", "jit", "run tests under the JIT"),
           optopt("", "target", "the target to build for", "TARGET"),
+          optopt("", "host", "the host to build for", "HOST"),
           optopt("", "adb-path", "path to the android debugger", "PATH"),
           optopt("", "adb-test-dir", "path to tests for the android debugger", "PATH"),
           optopt("", "test-shard", "run shard A, of B shards, worth of the testsuite", "A.B"),
@@ -134,6 +135,7 @@ pub fn parse_config(args: ~[~str]) -> config {
         rustcflags: matches.opt_str("rustcflags"),
         jit: matches.opt_present("jit"),
         target: opt_str2(matches.opt_str("target")).to_str(),
+        host: opt_str2(matches.opt_str("host")).to_str(),
         adb_path: opt_str2(matches.opt_str("adb-path")).to_str(),
         adb_test_dir:
             opt_str2(matches.opt_str("adb-test-dir")).to_str(),
@@ -167,6 +169,7 @@ pub fn log_config(config: &config) {
     logv(c, format!("rustcflags: {}", opt_str(&config.rustcflags)));
     logv(c, format!("jit: {}", config.jit));
     logv(c, format!("target: {}", config.target));
+    logv(c, format!("host: {}", config.host));
     logv(c, format!("adb_path: {}", config.adb_path));
     logv(c, format!("adb_test_dir: {}", config.adb_test_dir));
     logv(c, format!("adb_device_status: {}", config.adb_device_status));

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -28,6 +28,8 @@ pub struct TestProps {
     debugger_cmds: ~[~str],
     // Lines to check if they appear in the expected debugger output
     check_lines: ~[~str],
+    // Flag to force a crate to be built with the host architecture
+    force_host: bool,
 }
 
 // Load any test directives embedded in the file
@@ -39,6 +41,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut pp_exact = None;
     let mut debugger_cmds = ~[];
     let mut check_lines = ~[];
+    let mut force_host = false;
     iter_header(testfile, |ln| {
         match parse_error_pattern(ln) {
           Some(ep) => error_patterns.push(ep),
@@ -51,6 +54,10 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         if pp_exact.is_none() {
             pp_exact = parse_pp_exact(ln, testfile);
+        }
+
+        if !force_host {
+            force_host = parse_force_host(ln);
         }
 
         match parse_aux_build(ln) {
@@ -82,7 +89,8 @@ pub fn load_props(testfile: &Path) -> TestProps {
         aux_builds: aux_builds,
         exec_env: exec_env,
         debugger_cmds: debugger_cmds,
-        check_lines: check_lines
+        check_lines: check_lines,
+        force_host: force_host,
     };
 }
 
@@ -140,6 +148,10 @@ fn parse_debugger_cmd(line: &str) -> Option<~str> {
 
 fn parse_check_line(line: &str) -> Option<~str> {
     parse_name_value_directive(line, ~"check")
+}
+
+fn parse_force_host(line: &str) -> bool {
+    parse_name_directive(line, "force-host")
 }
 
 fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -691,8 +691,9 @@ fn compose_and_run_compiler(
 
     for rel_ab in props.aux_builds.iter() {
         let abs_ab = config.aux_base.join(rel_ab.as_slice());
+        let aux_props = load_props(&abs_ab);
         let aux_args =
-            make_compile_args(config, props, ~[~"--lib"] + extra_link_args,
+            make_compile_args(config, &aux_props, ~[~"--lib"] + extra_link_args,
                               |a,b| make_lib_name(a, b, testfile), &abs_ab);
         let auxres = compose_and_run(config, &abs_ab, aux_args, ~[],
                                      config.compile_lib_path, None);
@@ -738,10 +739,16 @@ fn make_compile_args(config: &config,
                      testfile: &Path)
                      -> ProcArgs {
     let xform_file = xform(config, testfile);
+    let target = if props.force_host {
+        config.host.as_slice()
+    } else {
+        config.target.as_slice()
+    };
     // FIXME (#9639): This needs to handle non-utf8 paths
     let mut args = ~[testfile.as_str().unwrap().to_owned(),
                      ~"-o", xform_file.as_str().unwrap().to_owned(),
-                     ~"-L", config.build_base.as_str().unwrap().to_owned()]
+                     ~"-L", config.build_base.as_str().unwrap().to_owned(),
+                     ~"--target=" + target]
         + extras;
     args.push_all_move(split_maybe_args(&config.rustcflags));
     args.push_all_move(split_maybe_args(&props.compile_flags));

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// force-host
+
 #[feature(globs, macro_registrar, macro_rules)];
 
 extern mod syntax;

--- a/src/test/run-pass/phase-syntax-link-does-resolve.rs
+++ b/src/test/run-pass/phase-syntax-link-does-resolve.rs
@@ -11,6 +11,18 @@
 // aux-build:macro_crate_test.rs
 // xfail-stage1
 // xfail-fast
+// xfail-android
+// force-host
+
+// You'll note that there's lots of directives above. This is a very particular
+// test in which we're both linking to a macro crate and loading macros from it.
+// This implies that both versions are the host architecture, meaning this test
+// must also be compiled with the host arch.
+//
+// Hence, xfail-stage1 because macros are unstable around there, xfail-fast
+// because this doesn't work with that test runner, xfail-android because it
+// can't run host binaries, and force-host to make this test build as the host
+// arch.
 
 #[feature(phase)];
 


### PR DESCRIPTION
The new macro loading infrastructure needs the ability to force a
procedural-macro crate to be built with the host architecture rather than the
target architecture (because the compiler is just about to dlopen it).
