### PR TITLE
rustc: Clean up error reporting

### DIFF
--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -27,6 +27,11 @@ pub trait Emitter {
             lvl: Level);
 }
 
+/// This structure is used to signify that a task has failed with a fatal error
+/// from the diagnostics. You can use this with the `Any` trait to figure out
+/// how a rustc task died (if so desired).
+pub struct FatalError;
+
 // a span-handler is like a handler but also
 // accepts span information for source-location
 // reporting.
@@ -38,7 +43,7 @@ pub struct SpanHandler {
 impl SpanHandler {
     pub fn span_fatal(@self, sp: Span, msg: &str) -> ! {
         self.handler.emit(Some((&*self.cm, sp)), msg, Fatal);
-        fail!();
+        fail!(FatalError);
     }
     pub fn span_err(@self, sp: Span, msg: &str) {
         self.handler.emit(Some((&*self.cm, sp)), msg, Error);
@@ -72,7 +77,7 @@ pub struct Handler {
 impl Handler {
     pub fn fatal(@self, msg: &str) -> ! {
         self.emit.emit(None, msg, Fatal);
-        fail!();
+        fail!(FatalError);
     }
     pub fn err(@self, msg: &str) {
         self.emit.emit(None, msg, Error);


### PR DESCRIPTION
This commit re-works how the monitor() function works and how it both receives
and transmits errors. There are a few cases in which the compiler can abort:
1. A normal compiler error. In this case, the compiler raises a FatalError as
   the failure value of the task. If this happens, then the monitor task does
   nothing. It ignores all stderr output of the child task and it also
   suppresses the failure message of the main task itself. This means that on a
   normal compiler error just the error message itself is printed.
2. A normal internal compiler error. These are invoked from sess.span_bug() and
   friends. In these cases, they follow the same path (raising a FatalError),
   but they will also print an ICE message which has a URL to go report a bug.
3. An actual compiler bug. This happens whenever anything calls fail!() instead
   of going through the session itself. In this case, we print out stuff about
   RUST_LOG=2 and we by default capture all stderr and print via warn!() so it's
   only printed out with the RUST_LOG var set.
