### PR TITLE
Simplify std::num::Primitive trait definition

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -554,16 +554,7 @@ impl Bounded for f32 {
     fn max_value() -> f32 { 3.40282347e+38 }
 }
 
-impl Primitive for f32 {
-    #[inline]
-    fn bits(_: Option<f32>) -> uint { 32 }
-
-    #[inline]
-    fn bytes(_: Option<f32>) -> uint { Primitive::bits(Some(0f32)) / 8 }
-
-    #[inline]
-    fn is_signed(_: Option<f32>) -> bool { true }
-}
+impl Primitive for f32 {}
 
 impl Float for f32 {
     #[inline]
@@ -1171,13 +1162,6 @@ mod tests {
         assert!(NEG_INFINITY.is_negative());
         assert!((1f32/NEG_INFINITY).is_negative());
         assert!(!NAN.is_negative());
-    }
-
-    #[test]
-    fn test_primitive() {
-        let none: Option<f32> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<f32>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<f32>());
     }
 
     #[test]

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -96,6 +96,9 @@ delegate!(
     fn tanh(n: c_float) -> c_float = cmath::c_float::tanh
 )
 
+// FIXME(#11621): These constants should be deprecated once CTFE is implemented
+// in favour of calling their respective functions in `Bounded` and `Float`.
+
 pub static RADIX: uint = 2u;
 
 pub static MANTISSA_DIGITS: uint = 53u;
@@ -122,6 +125,10 @@ pub static NEG_INFINITY: f32 = -1.0_f32/0.0_f32;
 pub mod consts {
     // FIXME (requires Issue #1433 to fix): replace with mathematical
     // staticants from cmath.
+
+    // FIXME(#11621): These constants should be deprecated once CTFE is
+    // implemented in favour of calling their respective functions in `Real`.
+
     /// Archimedes' constant
     pub static PI: f32 = 3.14159265358979323846264338327950288_f32;
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -556,16 +556,7 @@ impl Bounded for f64 {
     fn max_value() -> f64 { 1.7976931348623157e+308 }
 }
 
-impl Primitive for f64 {
-    #[inline]
-    fn bits(_: Option<f64>) -> uint { 64 }
-
-    #[inline]
-    fn bytes(_: Option<f64>) -> uint { Primitive::bits(Some(0f64)) / 8 }
-
-    #[inline]
-    fn is_signed(_: Option<f64>) -> bool { true }
-}
+impl Primitive for f64 {}
 
 impl Float for f64 {
     #[inline]
@@ -1176,13 +1167,6 @@ mod tests {
         assert!(NEG_INFINITY.is_negative());
         assert!((1f64/NEG_INFINITY).is_negative());
         assert!(!NAN.is_negative());
-    }
-
-    #[test]
-    fn test_primitive() {
-        let none: Option<f64> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<f64>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<f64>());
     }
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -101,6 +101,9 @@ delegate!(
 
 // FIXME (#1433): obtain these in a different way
 
+// FIXME(#11621): These constants should be deprecated once CTFE is implemented
+// in favour of calling their respective functions in `Bounded` and `Float`.
+
 pub static RADIX: uint = 2u;
 
 pub static MANTISSA_DIGITS: uint = 53u;
@@ -129,6 +132,10 @@ pub static NEG_INFINITY: f64 = -1.0_f64/0.0_f64;
 pub mod consts {
     // FIXME (requires Issue #1433 to fix): replace with mathematical
     // constants from cmath.
+
+    // FIXME(#11621): These constants should be deprecated once CTFE is
+    // implemented in favour of calling their respective functions in `Real`.
+
     /// Archimedes' constant
     pub static PI: f64 = 3.14159265358979323846264338327950288_f64;
 

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -13,11 +13,19 @@
 
 macro_rules! int_module (($T:ty, $bits:expr) => (
 
+// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+// calling the `mem::size_of` function.
 pub static bits : uint = $bits;
+// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+// calling the `mem::size_of` function.
 pub static bytes : uint = ($bits / 8);
 
+// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+// calling the `Bounded::min_value` function.
 pub static min_value: $T = (-1 as $T) << (bits - 1);
 // FIXME(#9837): Compute min_value like this so the high bits that shouldn't exist are 0.
+// FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
+// calling the `Bounded::max_value` function.
 pub static max_value: $T = !min_value;
 
 impl CheckedDiv for $T {

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -361,16 +361,7 @@ impl Bounded for $T {
 
 impl Int for $T {}
 
-impl Primitive for $T {
-    #[inline]
-    fn bits(_: Option<$T>) -> uint { bits }
-
-    #[inline]
-    fn bytes(_: Option<$T>) -> uint { bits / 8 }
-
-    #[inline]
-    fn is_signed(_: Option<$T>) -> bool { true }
-}
+impl Primitive for $T {}
 
 // String conversion functions and impl str -> num
 
@@ -637,13 +628,6 @@ mod tests {
     #[test]
     fn test_bitcount() {
         assert_eq!((0b010101 as $T).population_count(), 3);
-    }
-
-    #[test]
-    fn test_primitive() {
-        let none: Option<$T> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<$T>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<$T>());
     }
 
     #[test]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -17,6 +17,7 @@
 
 use clone::{Clone, DeepClone};
 use cmp::{Eq, Ord};
+use mem::size_of;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 use ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 use option::{Option, Some, None};
@@ -381,19 +382,7 @@ pub trait Primitive: Clone
                    + Num
                    + NumCast
                    + Orderable
-                   + Bounded
-                   + Neg<Self>
-                   + Add<Self,Self>
-                   + Sub<Self,Self>
-                   + Mul<Self,Self>
-                   + Div<Self,Self>
-                   + Rem<Self,Self> {
-    // FIXME (#5527): These should be associated constants
-    // FIXME (#8888): Removing `unused_self` requires #8888 to be fixed.
-    fn bits(unused_self: Option<Self>) -> uint;
-    fn bytes(unused_self: Option<Self>) -> uint;
-    fn is_signed(unused_self: Option<Self>) -> bool;
-}
+                   + Bounded {}
 
 /// A collection of traits relevant to primitive signed and unsigned integers
 pub trait Int: Integer
@@ -536,7 +525,7 @@ pub trait ToPrimitive {
 macro_rules! impl_to_primitive_int_to_int(
     ($SrcT:ty, $DstT:ty) => (
         {
-            if Primitive::bits(None::<$SrcT>) <= Primitive::bits(None::<$DstT>) {
+            if size_of::<$SrcT>() <= size_of::<$DstT>() {
                 Some(*self as $DstT)
             } else {
                 let n = *self as i64;
@@ -621,7 +610,7 @@ macro_rules! impl_to_primitive_uint_to_int(
 macro_rules! impl_to_primitive_uint_to_uint(
     ($SrcT:ty, $DstT:ty) => (
         {
-            if Primitive::bits(None::<$SrcT>) <= Primitive::bits(None::<$DstT>) {
+            if size_of::<$SrcT>() <= size_of::<$DstT>() {
                 Some(*self as $DstT)
             } else {
                 let zero: $SrcT = Zero::zero();
@@ -677,7 +666,7 @@ impl_to_primitive_uint!(u64)
 
 macro_rules! impl_to_primitive_float_to_float(
     ($SrcT:ty, $DstT:ty) => (
-        if Primitive::bits(None::<$SrcT>) <= Primitive::bits(None::<$DstT>) {
+        if size_of::<$SrcT>() <= size_of::<$DstT>() {
             Some(*self as $DstT)
         } else {
             let n = *self as f64;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -285,16 +285,7 @@ impl ToStrRadix for $T {
     }
 }
 
-impl Primitive for $T {
-    #[inline]
-    fn bits(_: Option<$T>) -> uint { bits }
-
-    #[inline]
-    fn bytes(_: Option<$T>) -> uint { bits / 8 }
-
-    #[inline]
-    fn is_signed(_: Option<$T>) -> bool { false }
-}
+impl Primitive for $T {}
 
 impl Bitwise for $T {
     /// Counts the number of bits set. Wraps LLVM's `ctpop` intrinsic.
@@ -413,13 +404,6 @@ mod tests {
     #[test]
     fn test_bitcount() {
         assert_eq!((0b010101 as $T).population_count(), 3);
-    }
-
-    #[test]
-    fn test_primitive() {
-        let none: Option<$T> = None;
-        assert_eq!(Primitive::bits(none), mem::size_of::<$T>() * 8);
-        assert_eq!(Primitive::bytes(none), mem::size_of::<$T>());
     }
 
     #[test]


### PR DESCRIPTION
As part of #10387, this removes the `Primitive::{bits, bytes, is_signed}` methods and removes the trait's operator trait constraints for the reasons outlined below:
- The `Primitive::{bits, bytes}` associated functions were originally added to reflect the existing `BITS` and `BYTES`statics included in the numeric modules. These statics are only exist as a workaround for Rust's lack of CTFE, and should be deprecated in the future in favor of using the `std::mem::size_of` function (see #11621).
- `Primitive::is_signed` seems to be of little utility and does not seem to be used anywhere in the Rust compiler or libraries. It is also rather ugly to call due to the `Option<Self>` workaround for #8888.
- The operator trait constraints are already covered by the `Num` trait.
