### PR TITLE
Fix error output for module operations on types.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -3035,9 +3035,8 @@ impl Resolver {
                     Some(type_def) => {
                         match type_def.module_def {
                             None => {
-                                error!("!!! (resolving module in lexical \
-                                        scope) module wasn't actually a \
-                                        module!");
+                                debug!("(resolving module in lexical scope) \
+                                        module definition not found");
                                 return Failed;
                             }
                             Some(module_def) => {
@@ -3046,8 +3045,8 @@ impl Resolver {
                         }
                     }
                     None => {
-                        error!("!!! (resolving module in lexical scope) module
-                                wasn't actually a module!");
+                        debug!("(resolving module in lexical scope) \
+                                type defintion not found");
                         return Failed;
                     }
                 }

--- a/src/test/compile-fail/call-method-using-module-syntax.rs
+++ b/src/test/compile-fail/call-method-using-module-syntax.rs
@@ -1,0 +1,16 @@
+struct T;
+
+trait Test {
+    fn hello() -> uint;
+}
+
+impl Test for T {
+    fn hello() { 5 }
+}
+
+fn main() {
+    T::hello();
+    //~^ ERROR unresolved name
+    //~^^ ERROR use of undeclared module `T`
+    //~^^^ ERROR unresolved name `T::hello`
+}


### PR DESCRIPTION
Replace the error messages (shown when a non-module type is used as a
module) with internal debug messages. This is in line with the nearby
error behavior.

Closes #10551.
