### PR TITLE
Disallow implementation of cross-crate priv traits

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1196,6 +1196,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_trait_ref(ebml_w, ecx, trait_def.trait_ref, tag_item_trait_ref);
         encode_name(ecx, ebml_w, item.ident);
         encode_attributes(ebml_w, item.attrs);
+        encode_visibility(ebml_w, vis);
         for &method_def_id in ty::trait_method_def_ids(tcx, def_id).iter() {
             ebml_w.start_tag(tag_item_trait_method);
             encode_def_id(ebml_w, method_def_id);

--- a/src/test/auxiliary/cci_impl_lib.rs
+++ b/src/test/auxiliary/cci_impl_lib.rs
@@ -10,7 +10,7 @@
 
 #[crate_id="cci_impl_lib"];
 
-trait uint_helpers {
+pub trait uint_helpers {
     fn to(&self, v: uint, f: |uint|);
 }
 

--- a/src/test/auxiliary/issue_3979_traits.rs
+++ b/src/test/auxiliary/issue_3979_traits.rs
@@ -12,12 +12,12 @@
 
 #[crate_type = "lib"];
 
-trait Positioned {
+pub trait Positioned {
   fn SetX(&mut self, int);
   fn X(&self) -> int;
 }
 
-trait Movable: Positioned {
+pub trait Movable: Positioned {
   fn translate(&mut self, dx: int) {
     let x = self.X() + dx;
     self.SetX(x);

--- a/src/test/auxiliary/private_trait_xc.rs
+++ b/src/test/auxiliary/private_trait_xc.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub trait Foo { fn f(&self) -> int; }
-pub trait Bar { fn g(&self) -> int; }
-pub trait Baz { fn h(&self) -> int; }
-
-pub trait Quux: Foo + Bar + Baz { }
-
-impl<T:Foo + Bar + Baz> Quux for T { }
+trait Foo {}

--- a/src/test/auxiliary/trait_default_method_xc_aux.rs
+++ b/src/test/auxiliary/trait_default_method_xc_aux.rs
@@ -18,7 +18,7 @@ impl A for Something {
     fn f(&self) -> int { 10 }
 }
 
-trait B<T> {
+pub trait B<T> {
     fn thing<U>(&self, x: T, y: U) -> (T, U) { (x, y) }
     fn staticthing<U>(_z: &Self, x: T, y: U) -> (T, U) { (x, y) }
 }

--- a/src/test/compile-fail/issue-11593.rs
+++ b/src/test/compile-fail/issue-11593.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub trait Foo { fn f(&self) -> int; }
-pub trait Bar { fn g(&self) -> int; }
-pub trait Baz { fn h(&self) -> int; }
+// aux-build:private_trait_xc.rs
 
-pub trait Quux: Foo + Bar + Baz { }
+extern mod private_trait_xc;
 
-impl<T:Foo + Bar + Baz> Quux for T { }
+struct Bar;
+
+impl private_trait_xc::Foo for Bar {}
+//~^ ERROR: trait `Foo` is private
+
+fn main() {}
+


### PR DESCRIPTION
Turns out we were just forgetting to encode the privacy for trais, and
everything without privacy defaults to public!

Closes #11593
