### PR TITLE
rustuv: Re-work sockaddr glue to not use malloc

### DIFF
--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use ai = std::io::net::addrinfo;
+use std::cast;
 use std::libc::c_int;
 use std::ptr::null;
 use std::rt::task::BlockedTask;
@@ -138,7 +139,8 @@ pub fn accum_addrinfo(addr: &Addrinfo) -> ~[ai::Info] {
 
         let mut addrs = ~[];
         loop {
-            let rustaddr = net::sockaddr_to_socket_addr((*addr).ai_addr);
+            let rustaddr = net::sockaddr_to_addr(cast::transmute((*addr).ai_addr),
+                                                 (*addr).ai_addrlen as uint);
 
             let mut flags = 0;
             each_ai_flag(|cval, aival| {

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -47,7 +47,7 @@ via `close` and `delete` methods.
 use std::cast;
 use std::io;
 use std::io::IoError;
-use std::libc::{c_int, malloc};
+use std::libc::c_int;
 use std::ptr::null;
 use std::ptr;
 use std::rt::local::Local;

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -30,8 +30,7 @@
 #[allow(non_camel_case_types)]; // C types
 
 use std::libc::{size_t, c_int, c_uint, c_void, c_char, c_double};
-use std::libc::ssize_t;
-use std::libc::free;
+use std::libc::{ssize_t, sockaddr, free};
 use std::libc;
 use std::rt::global_heap::malloc_raw;
 
@@ -250,11 +249,6 @@ pub type uv_signal_cb = extern "C" fn(handle: *uv_signal_t,
                                       signum: c_int);
 pub type uv_fs_cb = extern "C" fn(req: *uv_fs_t);
 
-pub type sockaddr = c_void;
-
-#[cfg(unix)]
-pub type socklen_t = c_int;
-
 // XXX: This is a standard C type. Could probably be defined in libc
 #[cfg(target_os = "android")]
 #[cfg(target_os = "linux")]
@@ -263,7 +257,7 @@ pub struct addrinfo {
     ai_family: c_int,
     ai_socktype: c_int,
     ai_protocol: c_int,
-    ai_addrlen: socklen_t,
+    ai_addrlen: libc::socklen_t,
     ai_addr: *sockaddr,
     ai_canonname: *char,
     ai_next: *addrinfo
@@ -276,7 +270,7 @@ pub struct addrinfo {
     ai_family: c_int,
     ai_socktype: c_int,
     ai_protocol: c_int,
-    ai_addrlen: socklen_t,
+    ai_addrlen: libc::socklen_t,
     ai_canonname: *char,
     ai_addr: *sockaddr,
     ai_next: *addrinfo
@@ -537,15 +531,6 @@ extern {}
 extern {
     fn rust_uv_loop_new() -> *c_void;
 
-    // dealing with sockaddr things
-    pub fn rust_sockaddr_size() -> c_int;
-    pub fn rust_malloc_ip4_addr(s: *c_char, port: c_int) -> *sockaddr;
-    pub fn rust_malloc_ip6_addr(s: *c_char, port: c_int) -> *sockaddr;
-    pub fn rust_ip4_port(src: *sockaddr) -> c_uint;
-    pub fn rust_ip6_port(src: *sockaddr) -> c_uint;
-    pub fn rust_is_ipv4_sockaddr(addr: *sockaddr) -> c_int;
-    pub fn rust_is_ipv6_sockaddr(addr: *sockaddr) -> c_int;
-
     #[cfg(test)]
     fn rust_uv_handle_type_max() -> uintptr_t;
     #[cfg(test)]
@@ -609,20 +594,14 @@ extern {
     pub fn uv_tcp_connect(c: *uv_connect_t, h: *uv_tcp_t,
                           addr: *sockaddr, cb: uv_connect_cb) -> c_int;
     pub fn uv_tcp_bind(t: *uv_tcp_t, addr: *sockaddr) -> c_int;
-    pub fn uv_ip4_name(src: *sockaddr, dst: *c_char,
-                       size: size_t) -> c_int;
-    pub fn uv_ip6_name(src: *sockaddr, dst: *c_char,
-                       size: size_t) -> c_int;
     pub fn uv_tcp_nodelay(h: *uv_tcp_t, enable: c_int) -> c_int;
     pub fn uv_tcp_keepalive(h: *uv_tcp_t, enable: c_int,
                             delay: c_uint) -> c_int;
     pub fn uv_tcp_simultaneous_accepts(h: *uv_tcp_t, enable: c_int) -> c_int;
-    pub fn uv_tcp_getsockname(h: *uv_tcp_t, name: *sockaddr,
+    pub fn uv_tcp_getsockname(h: *uv_tcp_t, name: *mut sockaddr,
                               len: *mut c_int) -> c_int;
-    pub fn uv_tcp_getpeername(h: *uv_tcp_t, name: *sockaddr,
+    pub fn uv_tcp_getpeername(h: *uv_tcp_t, name: *mut sockaddr,
                               len: *mut c_int) -> c_int;
-    pub fn uv_ip4_addr(ip: *c_char, port: c_int, addr: *sockaddr) -> c_int;
-    pub fn uv_ip6_addr(ip: *c_char, port: c_int, addr: *sockaddr) -> c_int;
 
     // udp bindings
     pub fn uv_udp_init(l: *uv_loop_t, h: *uv_udp_t) -> c_int;
@@ -638,7 +617,7 @@ extern {
     pub fn uv_udp_set_multicast_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int;
     pub fn uv_udp_set_ttl(handle: *uv_udp_t, ttl: c_int) -> c_int;
     pub fn uv_udp_set_broadcast(handle: *uv_udp_t, on: c_int) -> c_int;
-    pub fn uv_udp_getsockname(h: *uv_udp_t, name: *sockaddr,
+    pub fn uv_udp_getsockname(h: *uv_udp_t, name: *mut sockaddr,
                               len: *mut c_int) -> c_int;
 
     // timer bindings

--- a/src/rt/rust_uv.c
+++ b/src/rt/rust_uv.c
@@ -87,50 +87,6 @@ rust_uv_set_data_for_req(uv_req_t* req, void* data) {
     req->data = data;
 }
 
-int
-rust_sockaddr_size() {
-    return sizeof(struct sockaddr_storage);
-}
-
-struct sockaddr*
-rust_malloc_ip4_addr(char *name, int port) {
-    struct sockaddr_in *addr = (struct sockaddr_in*) calloc(1, rust_sockaddr_size());
-    assert(addr != NULL);
-    addr->sin_port = htons(port);
-    assert(uv_inet_pton(AF_INET, name, &addr->sin_addr) == 0);
-    addr->sin_family = AF_INET;
-    return (struct sockaddr*) addr;
-}
-
-struct sockaddr*
-rust_malloc_ip6_addr(char *name, int port) {
-    struct sockaddr_in6 *addr = (struct sockaddr_in6*) calloc(1, rust_sockaddr_size());
-    assert(addr != NULL);
-    addr->sin6_port = htons(port);
-    assert(uv_inet_pton(AF_INET6, name, &addr->sin6_addr) == 0);
-    addr->sin6_family = AF_INET6;
-    return (struct sockaddr*) addr;
-}
-
-unsigned int
-rust_ip4_port(struct sockaddr_in* src) {
-    return ntohs(src->sin_port);
-}
-unsigned int
-rust_ip6_port(struct sockaddr_in6* src) {
-    return ntohs(src->sin6_port);
-}
-
-int
-rust_is_ipv4_sockaddr(struct sockaddr* addr) {
-    return addr->sa_family == AF_INET;
-}
-
-int
-rust_is_ipv6_sockaddr(struct sockaddr* addr) {
-    return addr->sa_family == AF_INET6;
-}
-
 uintptr_t
 rust_uv_handle_type_max() {
   return UV_HANDLE_TYPE_MAX;


### PR DESCRIPTION
This means we can purge even more C from src/rt!
