### PR TITLE
syntax::ext: replace span_fatal with span_err in many places.

### DIFF
--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -59,9 +59,12 @@ pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     while continue_ {
         match state {
             Asm => {
-                let (s, style) =
-                    expr_to_str(cx, p.parse_expr(),
-                                "inline assembly must be a string literal.");
+                let (s, style) = match expr_to_str(cx, p.parse_expr(),
+                                                   "inline assembly must be a string literal.") {
+                    Some((s, st)) => (s, st),
+                    // let compilation continue
+                    None => return MacResult::dummy_expr(),
+                };
                 asm = s;
                 asm_str_style = Some(style);
             }

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -20,7 +20,10 @@ use std::char;
 
 pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> base::MacResult {
     // Gather all argument expressions
-    let exprs = get_exprs_from_tts(cx, sp, tts);
+    let exprs = match get_exprs_from_tts(cx, sp, tts) {
+        None => return MacResult::dummy_expr(),
+        Some(e) => e,
+    };
     let mut bytes = ~[];
 
     for expr in exprs.iter() {

--- a/src/libsyntax/ext/concat.rs
+++ b/src/libsyntax/ext/concat.rs
@@ -18,7 +18,10 @@ use ext::build::AstBuilder;
 pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
                          sp: codemap::Span,
                          tts: &[ast::TokenTree]) -> base::MacResult {
-    let es = base::get_exprs_from_tts(cx, sp, tts);
+    let es = match base::get_exprs_from_tts(cx, sp, tts) {
+        Some(e) => e,
+        None => return base::MacResult::dummy_expr()
+    };
     let mut accumulator = ~"";
     for e in es.move_iter() {
         let e = cx.expand_expr(e);

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -23,12 +23,18 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         if i & 1 == 1 {
             match *e {
                 ast::TTTok(_, token::COMMA) => (),
-                _ => cx.span_fatal(sp, "concat_idents! expecting comma.")
+                _ => {
+                    cx.span_err(sp, "concat_idents! expecting comma.");
+                    return MacResult::dummy_expr();
+                }
             }
         } else {
             match *e {
                 ast::TTTok(_, token::IDENT(ident,_)) => res_str.push_str(cx.str_of(ident)),
-                _ => cx.span_fatal(sp, "concat_idents! requires ident args.")
+                _ => {
+                    cx.span_err(sp, "concat_idents! requires ident args.");
+                    return MacResult::dummy_expr();
+                }
             }
         }
     }

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -70,8 +70,9 @@ fn default_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Exp
             }
         }
         StaticEnum(..) => {
-            cx.span_fatal(span, "`Default` cannot be derived for enums, \
-                                 only structs")
+            cx.span_err(span, "`Default` cannot be derived for enums, only structs");
+            // let compilation continue
+            cx.expr_uint(span, 0)
         }
         _ => cx.bug("Non-static method in `deriving(Default)`")
     };

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -73,7 +73,9 @@ fn rand_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
         }
         StaticEnum(_, ref variants) => {
             if variants.is_empty() {
-                cx.span_fatal(span, "`Rand` cannot be derived for enums with no variants");
+                cx.span_err(span, "`Rand` cannot be derived for enums with no variants");
+                // let compilation continue
+                return cx.expr_uint(span, 0);
             }
 
             let variant_count = cx.expr_uint(span, variants.len());

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -86,8 +86,9 @@ fn zero_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
             }
         }
         StaticEnum(..) => {
-            cx.span_fatal(span, "`Zero` cannot be derived for enums, \
-                                 only structs")
+            cx.span_err(span, "`Zero` cannot be derived for enums, only structs");
+            // let compilation continue
+            cx.expr_uint(span, 0)
         }
         _ => cx.bug("Non-static method in `deriving(Zero)`")
     };

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -46,19 +46,24 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
                 // Token-tree macros:
                 MacInvocTT(ref pth, ref tts, ctxt) => {
                     if (pth.segments.len() > 1u) {
-                        fld.cx.span_fatal(
+                        fld.cx.span_err(
                             pth.span,
                             format!("expected macro name without module \
                                   separators"));
+                        // let compilation continue
+                        return e;
                     }
                     let extname = &pth.segments[0].identifier;
                     let extnamestr = ident_to_str(extname);
                     // leaving explicit deref here to highlight unbox op:
                     let marked_after = match fld.extsbox.find(&extname.name) {
                         None => {
-                            fld.cx.span_fatal(
+                            fld.cx.span_err(
                                 pth.span,
-                                format!("macro undefined: '{}'", extnamestr))
+                                format!("macro undefined: '{}'", extnamestr));
+
+                            // let compilation continue
+                            return e;
                         }
                         Some(&NormalTT(ref expandfun, exp_span)) => {
                             fld.cx.bt_push(ExpnInfo {
@@ -87,13 +92,14 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
                                 MRExpr(e) => e,
                                 MRAny(any_macro) => any_macro.make_expr(),
                                 _ => {
-                                    fld.cx.span_fatal(
+                                    fld.cx.span_err(
                                         pth.span,
                                         format!(
                                             "non-expr macro in expr pos: {}",
                                             extnamestr
                                         )
-                                    )
+                                    );
+                                    return e;
                                 }
                             };
 
@@ -101,10 +107,11 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
                             mark_expr(expanded,fm)
                         }
                         _ => {
-                            fld.cx.span_fatal(
+                            fld.cx.span_err(
                                 pth.span,
                                 format!("'{}' is not a tt-style macro", extnamestr)
-                            )
+                            );
+                            return e;
                         }
                     };
 
@@ -299,15 +306,20 @@ pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
     let extnamestr = ident_to_str(extname);
     let fm = fresh_mark();
     let expanded = match fld.extsbox.find(&extname.name) {
-        None => fld.cx.span_fatal(pth.span,
-                                  format!("macro undefined: '{}!'", extnamestr)),
+        None => {
+            fld.cx.span_err(pth.span,
+                            format!("macro undefined: '{}!'", extnamestr));
+            // let compilation continue
+            return SmallVector::zero();
+        }
 
         Some(&NormalTT(ref expander, span)) => {
             if it.ident.name != parse::token::special_idents::invalid.name {
-                fld.cx.span_fatal(pth.span,
-                                  format!("macro {}! expects no ident argument, \
-                                           given '{}'", extnamestr,
-                                           ident_to_str(&it.ident)));
+                fld.cx.span_err(pth.span,
+                                format!("macro {}! expects no ident argument, \
+                                        given '{}'", extnamestr,
+                                        ident_to_str(&it.ident)));
+                return SmallVector::zero();
             }
             fld.cx.bt_push(ExpnInfo {
                 call_site: it.span,
@@ -324,9 +336,9 @@ pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
         }
         Some(&IdentTT(ref expander, span)) => {
             if it.ident.name == parse::token::special_idents::invalid.name {
-                fld.cx.span_fatal(pth.span,
-                                  format!("macro {}! expects an ident argument",
-                                          extnamestr));
+                fld.cx.span_err(pth.span,
+                                format!("macro {}! expects an ident argument", extnamestr));
+                return SmallVector::zero();
             }
             fld.cx.bt_push(ExpnInfo {
                 call_site: it.span,
@@ -341,9 +353,10 @@ pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
             let marked_ctxt = new_mark(fm,ctxt);
             expander.expand(fld.cx, it.span, it.ident, marked_tts, marked_ctxt)
         }
-        _ => fld.cx.span_fatal(it.span,
-                               format!("{}! is not legal in item position",
-                                       extnamestr))
+        _ => {
+            fld.cx.span_err(it.span, format!("{}! is not legal in item position", extnamestr));
+            return SmallVector::zero();
+        }
     };
 
     let items = match expanded {
@@ -353,8 +366,8 @@ pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
                 .collect()
         }
         MRExpr(_) => {
-            fld.cx.span_fatal(pth.span, format!("expr macro in item position: {}",
-                                                extnamestr))
+            fld.cx.span_err(pth.span, format!("expr macro in item position: {}", extnamestr));
+            return SmallVector::zero();
         }
         MRAny(any_macro) => {
             any_macro.make_items().move_iter()
@@ -418,12 +431,16 @@ fn load_extern_macros(crate: &ast::ViewItem, fld: &mut MacroExpander) {
 
     let lib = match DynamicLibrary::open(Some(&path)) {
         Ok(lib) => lib,
+        // this is fatal: there are almost certainly macros we need
+        // inside this crate, so continue would spew "macro undefined"
+        // errors
         Err(err) => fld.cx.span_fatal(crate.span, err)
     };
 
     unsafe {
         let registrar: MacroCrateRegistrationFun = match lib.symbol(registrar) {
             Ok(registrar) => registrar,
+            // again fatal if we can't register macros
             Err(err) => fld.cx.span_fatal(crate.span, err)
         };
         registrar(|name, extension| {
@@ -454,14 +471,15 @@ pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<@Stmt> {
         _ => return expand_non_macro_stmt(s, fld)
     };
     if (pth.segments.len() > 1u) {
-        fld.cx.span_fatal(pth.span,
-                          "expected macro name without module separators");
+        fld.cx.span_err(pth.span, "expected macro name without module separators");
+        return SmallVector::zero();
     }
     let extname = &pth.segments[0].identifier;
     let extnamestr = ident_to_str(extname);
     let marked_after = match fld.extsbox.find(&extname.name) {
         None => {
-            fld.cx.span_fatal(pth.span, format!("macro undefined: '{}'", extnamestr))
+            fld.cx.span_err(pth.span, format!("macro undefined: '{}'", extnamestr));
+            return SmallVector::zero();
         }
 
         Some(&NormalTT(ref expandfun, exp_span)) => {
@@ -493,26 +511,27 @@ pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<@Stmt> {
                     }
                 }
                 MRAny(any_macro) => any_macro.make_stmt(),
-                _ => fld.cx.span_fatal(
-                    pth.span,
-                    format!("non-stmt macro in stmt pos: {}", extnamestr))
+                _ => {
+                    fld.cx.span_err(pth.span,
+                                    format!("non-stmt macro in stmt pos: {}", extnamestr));
+                    return SmallVector::zero();
+                }
             };
 
             mark_stmt(expanded,fm)
         }
 
         _ => {
-            fld.cx.span_fatal(pth.span,
-                              format!("'{}' is not a tt-style macro",
-                                      extnamestr))
+            fld.cx.span_err(pth.span, format!("'{}' is not a tt-style macro", extnamestr));
+            return SmallVector::zero();
         }
     };
 
     // Keep going, outside-in.
     let fully_expanded = fld.fold_stmt(marked_after);
     if fully_expanded.is_empty() {
-        fld.cx.span_fatal(pth.span,
-                      "macro didn't expand to a statement");
+        fld.cx.span_err(pth.span, "macro didn't expand to a statement");
+        return SmallVector::zero();
     }
     fld.cx.bt_pop();
     let fully_expanded: SmallVector<@Stmt> = fully_expanded.move_iter()

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -748,8 +748,11 @@ pub fn expand_args(ecx: &mut ExtCtxt, sp: Span,
     // Be sure to recursively expand macros just in case the format string uses
     // a macro to build the format expression.
     let expr = cx.ecx.expand_expr(efmt);
-    let (fmt, _) = expr_to_str(cx.ecx, expr,
-                               "format argument must be a string literal.");
+    let fmt = match expr_to_str(cx.ecx, expr,
+                                     "format argument must be a string literal.") {
+        Some((fmt, _)) => fmt,
+        None => return MacResult::dummy_expr()
+    };
 
     let mut err = false;
     parse::parse_error::cond.trap(|m| {

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -33,7 +33,8 @@ pub fn expand_trace_macros(cx: &mut ExtCtxt,
     } else if rust_parser.is_keyword(keywords::False) {
         cx.set_trace_macros(false);
     } else {
-        cx.span_fatal(sp, "trace_macros! only accepts `true` or `false`")
+        cx.span_err(sp, "trace_macros! only accepts `true` or `false`");
+        return base::MacResult::dummy_expr();
     }
 
     rust_parser.bump();

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -183,8 +183,8 @@ pub fn nameize(p_s: @ParseSess, ms: &[Matcher], res: &[@NamedMatch])
                 node: MatchNonterminal(ref bind_name, _, idx), span: sp
           } => {
             if ret_val.contains_key(bind_name) {
-                p_s.span_diagnostic.span_fatal(sp, ~"Duplicated bind name: "+
-                                               ident_to_str(bind_name))
+                p_s.span_diagnostic.span_fatal(sp,
+                                               "Duplicated bind name: "+ ident_to_str(bind_name))
             }
             ret_val.insert(*bind_name, res[idx]);
           }

--- a/src/test/compile-fail/macros-nonfatal-errors.rs
+++ b/src/test/compile-fail/macros-nonfatal-errors.rs
@@ -1,0 +1,48 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// test that errors in a (selection) of macros don't kill compilation
+// immediately, so that we get more errors listed at a time.
+
+#[feature(asm)];
+
+#[deriving(Default, //~ ERROR
+           Rand, //~ ERROR
+           Zero)] //~ ERROR
+enum CantDeriveThose {}
+
+fn main() {
+    doesnt_exist!(); //~ ERROR
+
+    bytes!(invalid); //~ ERROR
+
+    asm!(invalid); //~ ERROR
+
+    concat_idents!("not", "idents"); //~ ERROR
+
+    option_env!(invalid); //~ ERROR
+    env!(invalid); //~ ERROR
+    env!(foo, abr, baz); //~ ERROR
+    env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST"); //~ ERROR
+
+    foo::blah!(); //~ ERROR
+
+    format!(); //~ ERROR
+    format!(invalid); //~ ERROR
+
+    include!(invalid); //~ ERROR
+
+    include_str!(invalid); //~ ERROR
+    include_str!("i'd be quite surprised if a file with this name existed"); //~ ERROR
+    include_bin!(invalid); //~ ERROR
+    include_bin!("i'd be quite surprised if a file with this name existed"); //~ ERROR
+
+    trace_macros!(invalid); //~ ERROR
+}


### PR DESCRIPTION
This means that compilation continues for longer, and so we can see more
errors per compile. This is mildly more user-friendly because it stops
users having to run rustc n times to see n macro errors: just run it
once to see all of them.
