### PR TITLE
Ignore all newline characters in Base64 decoder

### DIFF
--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -237,8 +237,9 @@ impl<'a> FromBase64 for &'a str {
         }
 
         for (idx, byte) in it {
-            if (byte as char) != '=' {
-                return Err(InvalidBase64Character(self.char_at(idx), idx));
+            match byte as char {
+                '='|'\r'|'\n' => continue,
+                _ => return Err(InvalidBase64Character(self.char_at(idx), idx)),
             }
         }
 
@@ -310,6 +311,8 @@ mod test {
     fn test_from_base64_newlines() {
         assert_eq!("Zm9v\r\nYmFy".from_base64().unwrap(),
                    "foobar".as_bytes().to_owned());
+        assert_eq!("Zm9vYg==\r\n".from_base64().unwrap(),
+                   "foob".as_bytes().to_owned());
     }
 
     #[test]


### PR DESCRIPTION
Ignore all newline characters in Base64 decoder to make it compatible with other Base64 decoders.

Most of the Base64 decoder implementations ignore all newline characters in the input string. There are some examples:

Python:

``` python
>>> "\nA\nQ\n=\n=\n".decode("base64")
'\x01'
```

Ruby:

``` ruby
irb(main):001:0> "\nA\nQ\n=\n=\n".unpack("m")
=> ["\001"]
```

Erlang:

``` erlang
1> base64:decode("\nA\nQ\n=\n=\n").
<<1>>
```

Moreover some Base64 encoders append newline character at the end of the output string by default:

Python:

``` python
>>> "\1".encode("base64")
'AQ==\n'
```

Ruby:

``` ruby
irb(main):001:0> ["\1"].pack("m")
=> "AQ==\n"
```

So I think it's fairly important for Rust Base64 decoder to accept Base64 inputs even with newline characters in the padding.
