### PR TITLE
Avoid unused variable warning in quote_*!

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -530,7 +530,7 @@ fn mk_tt(cx: &ExtCtxt, sp: Span, tt: &ast::TokenTree) -> ~[@ast::Stmt] {
     match *tt {
 
         ast::TTTok(sp, ref tok) => {
-            let e_sp = cx.expr_ident(sp, id_ext("sp"));
+            let e_sp = cx.expr_ident(sp, id_ext("_sp"));
             let e_tok = cx.expr_call_ident(sp,
                                            id_ext("TTTok"),
                                            ~[e_sp, mk_token(cx, sp, tok)]);
@@ -628,7 +628,7 @@ fn expand_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                                    ~[]);
 
     let stmt_let_sp = cx.stmt_let(sp, false,
-                                  id_ext("sp"),
+                                  id_ext("_sp"),
                                   e_sp);
 
     let stmt_let_tt = cx.stmt_let(sp, true,

--- a/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
+++ b/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast
+
+#[deny(unused_variable)];
+
+extern mod syntax;
+
+use syntax::ext::base::ExtCtxt;
+
+fn test(cx: &mut ExtCtxt) {
+    let foo = 10i;
+    let _e = quote_expr!(cx, $foo);
+}
+
+pub fn main() { }


### PR DESCRIPTION
The provided span isn't used in all cases (namely primitives).
