### PR TITLE
rustc: check instantiability of fixed length vectors properly.

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2287,6 +2287,12 @@ pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
                ::util::ppaux::ty_to_str(cx, ty));
 
         let r = match get(ty).sty {
+            // fixed length vectors need special treatment compared to
+            // normal vectors, since they don't necessarily have the
+            // possibilty to have length zero.
+            ty_vec(_, vstore_fixed(0)) => false, // don't need no contents
+            ty_vec(mt, vstore_fixed(_)) => type_requires(cx, seen, r_ty, mt.ty),
+
             ty_nil |
             ty_bot |
             ty_bool |

--- a/src/test/compile-fail/uninstantiable-fixed-length-vec.rs
+++ b/src/test/compile-fail/uninstantiable-fixed-length-vec.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// issue #11659, the compiler needs to know that a fixed length vector
+// always requires instantiable contents to instantiable itself
+// (unlike a ~[] vector which can have length zero).
+
+// ~ to avoid infinite size.
+struct Uninstantiable { //~ ERROR cannot be instantiated without an instance of itself
+    p: ~[Uninstantiable, .. 1]
+}
+
+struct Instantiable { p: ~[Instantiable, .. 0] }
+
+
+fn main() {
+    let _ = None::<Uninstantiable>;
+    let _ = Instantiable { p: ~([]) };
+}


### PR DESCRIPTION
Previously, they were treated like ~[] and &[](which can have length
0), but fixed length vectors are fixed length, i.e. we know at compile
time if it's possible to have length zero (which is only for [T, .. 0]).

Fixes #11659.
