### PR TITLE
Add span_note to ExtCtxt

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -384,6 +384,10 @@ impl<'a> ExtCtxt<'a> {
         self.print_backtrace();
         self.parse_sess.span_diagnostic.span_bug(sp, msg);
     }
+    pub fn span_note(&self, sp: Span, msg: &str) {
+        self.print_backtrace();
+        self.parse_sess.span_diagnostic.span_note(sp, msg);
+    }
     pub fn bug(&self, msg: &str) -> ! {
         self.print_backtrace();
         self.parse_sess.span_diagnostic.handler().bug(msg);


### PR DESCRIPTION
It was the only span_\* missing.
