### PR TITLE
Remove the std::num::Times trait

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -78,7 +78,6 @@ syn keyword rustTrait FromStr
 syn keyword rustTrait FromIterator Extendable
 syn keyword rustTrait Iterator DoubleEndedIterator RandomAccessIterator CloneableIterator
 syn keyword rustTrait OrdIterator MutableDoubleEndedIterator ExactSize
-syn keyword rustTrait Times
 
 syn keyword rustTrait Algebraic Trigonometric Exponential Hyperbolic
 syn keyword rustTrait Bitwise Bounded Integer Fractional Real RealExt

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -770,19 +770,19 @@ mod tests {
 
         task::spawn(proc() {
             arc2.write(|num| {
-                10.times(|| {
+                for _ in range(0, 10) {
                     let tmp = *num;
                     *num = -1;
                     task::deschedule();
                     *num = tmp + 1;
-                });
+                }
                 c.send(());
             })
         });
 
         // Readers try to catch the writer in the act
         let mut children = ~[];
-        5.times(|| {
+        for _ in range(0, 5) {
             let arc3 = arc.clone();
             let mut builder = task::task();
             children.push(builder.future_result());
@@ -791,7 +791,7 @@ mod tests {
                     assert!(*num >= 0);
                 })
             });
-        });
+        }
 
         // Wait for children to pass their asserts
         for r in children.mut_iter() {
@@ -836,7 +836,7 @@ mod tests {
 
         // Reader tasks
         let mut reader_convos = ~[];
-        10.times(|| {
+        for _ in range(0, 10) {
             let ((rp1, rc1), (rp2, rc2)) = (Chan::new(), Chan::new());
             reader_convos.push((rc1, rp2));
             let arcn = arc.clone();
@@ -847,7 +847,7 @@ mod tests {
                     rc2.send(());
                 })
             });
-        });
+        }
 
         // Writer task
         let arc2 = arc.clone();
@@ -944,7 +944,7 @@ mod tests {
             read_mode.read(|state| {
                 // if writer mistakenly got in, make sure it mutates state
                 // before we assert on it
-                5.times(|| task::deschedule());
+                for _ in range(0, 5) { task::deschedule(); }
                 // make sure writer didn't get in.
                 assert!(*state);
             })
@@ -956,6 +956,6 @@ mod tests {
         // helped to expose the race nearly 100% of the time... but adding
         // deschedules in the intuitively-right locations made it even less likely,
         // and I wasn't sure why :( . This is a mediocre "next best" option.
-        8.times(|| test_rw_write_cond_downgrade_read_race_helper());
+        for _ in range(0, 8) { test_rw_write_cond_downgrade_read_race_helper(); }
     }
 }

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -336,11 +336,11 @@ mod test {
         use std::rand::{task_rng, random, Rng};
         use std::vec;
 
-        1000.times(|| {
+        for _ in range(0, 1000) {
             let times = task_rng().gen_range(1u, 100);
             let v = vec::from_fn(times, |_| random::<u8>());
             assert_eq!(v.to_base64(STANDARD).from_base64().unwrap(), v);
-        })
+        }
     }
 
     #[bench]

--- a/src/libextra/comm.rs
+++ b/src/libextra/comm.rs
@@ -127,9 +127,9 @@ mod test {
         // Rendezvous streams should be able to handle any number of messages being sent
         let (port, chan) = rendezvous();
         spawn(proc() {
-            10000.times(|| { chan.send(()) })
+            for _ in range(0, 10000) { chan.send(()); }
         });
-        10000.times(|| { port.recv() })
+        for _ in range(0, 10000) { port.recv(); }
     }
 
     #[test]

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -1036,11 +1036,11 @@ mod tests {
 
     #[test]
     fn test_fuzz() {
-        25.times(|| {
+        for _ in range(0, 25) {
             fuzz_test(3);
             fuzz_test(16);
             fuzz_test(189);
-        })
+        }
     }
 
     #[cfg(test)]

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -726,9 +726,9 @@ pub mod groups {
             // here we just need to indent the start of the description
             let rowlen = row.char_len();
             if rowlen < 24 {
-                (24 - rowlen).times(|| {
-                    row.push_char(' ')
-                })
+                for _ in range(0, 24 - rowlen) {
+                    row.push_char(' ');
+                }
             } else {
                 row.push_str(desc_sep)
             }

--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -282,7 +282,7 @@ fn escape_str(s: &str) -> ~str {
 
 fn spaces(n: uint) -> ~str {
     let mut ss = ~"";
-    n.times(|| ss.push_str(" "));
+    for _ in range(0, n) { ss.push_str(" "); }
     return ss;
 }
 

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -2052,22 +2052,22 @@ mod biguint_tests {
     fn test_rand_range() {
         let mut rng = task_rng();
 
-        10.times(|| {
+        for _ in range(0, 10) {
             assert_eq!(rng.gen_bigint_range(&FromPrimitive::from_uint(236).unwrap(),
                                             &FromPrimitive::from_uint(237).unwrap()),
                        FromPrimitive::from_uint(236).unwrap());
-        });
+        }
 
         let l = FromPrimitive::from_uint(403469000 + 2352).unwrap();
         let u = FromPrimitive::from_uint(403469000 + 3513).unwrap();
-        1000.times(|| {
+        for _ in range(0, 1000) {
             let n: BigUint = rng.gen_biguint_below(&u);
             assert!(n < u);
 
             let n: BigUint = rng.gen_biguint_range(&l, &u);
             assert!(n >= l);
             assert!(n < u);
-        })
+        }
     }
 
     #[test]
@@ -2550,19 +2550,19 @@ mod bigint_tests {
     fn test_rand_range() {
         let mut rng = task_rng();
 
-        10.times(|| {
+        for _ in range(0, 10) {
             assert_eq!(rng.gen_bigint_range(&FromPrimitive::from_uint(236).unwrap(),
                                             &FromPrimitive::from_uint(237).unwrap()),
                        FromPrimitive::from_uint(236).unwrap());
-        });
+        }
 
         fn check(l: BigInt, u: BigInt) {
             let mut rng = task_rng();
-            1000.times(|| {
+            for _ in range(0, 1000) {
                 let n: BigInt = rng.gen_bigint_range(&l, &u);
                 assert!(n >= l);
                 assert!(n < u);
-            });
+            }
         }
         let l: BigInt = FromPrimitive::from_uint(403469000 + 2352).unwrap();
         let u: BigInt = FromPrimitive::from_uint(403469000 + 3513).unwrap();

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -571,9 +571,9 @@ mod tests {
     fn bench_grow(b: &mut test::BenchHarness) {
         let mut deq = RingBuf::new();
         b.iter(|| {
-            65.times(|| {
+            for _ in range(0, 65) {
                 deq.push_front(1);
-            })
+            }
         })
     }
 

--- a/src/libextra/task_pool.rs
+++ b/src/libextra/task_pool.rs
@@ -86,7 +86,7 @@ fn test_task_pool() {
         g
     };
     let mut pool = TaskPool::new(4, f);
-    8.times(|| {
+    for _ in range(0, 8) {
         pool.execute(proc(i) println!("Hello from thread {}!", *i));
-    })
+    }
 }

--- a/src/libextra/treemap.rs
+++ b/src/libextra/treemap.rs
@@ -1150,8 +1150,8 @@ mod test_treemap {
 
         let mut rng: rand::IsaacRng = rand::SeedableRng::from_seed(&[42]);
 
-        3.times(|| {
-            90.times(|| {
+        for _ in range(0, 3) {
+            for _ in range(0, 90) {
                 let k = rng.gen();
                 let v = rng.gen();
                 if !ctrl.iter().any(|x| x == &(k, v)) {
@@ -1160,16 +1160,16 @@ mod test_treemap {
                     check_structure(&map);
                     check_equal(ctrl, &map);
                 }
-            });
+            }
 
-            30.times(|| {
+            for _ in range(0, 30) {
                 let r = rng.gen_range(0, ctrl.len());
                 let (key, _) = ctrl.remove(r).unwrap();
                 assert!(map.remove(&key));
                 check_structure(&map);
                 check_equal(ctrl, &map);
-            });
-        })
+            }
+        }
     }
 
     #[test]

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -103,15 +103,15 @@ mod tests {
     fn test_flate_round_trip() {
         let mut r = rand::rng();
         let mut words = ~[];
-        20.times(|| {
+        for _ in range(0, 20) {
             let range = r.gen_range(1u, 10);
             words.push(r.gen_vec::<u8>(range));
-        });
-        20.times(|| {
+        }
+        for _ in range(0, 20) {
             let mut input = ~[];
-            2000.times(|| {
+            for _ in range(0, 2000) {
                 input.push_all(r.choose(words));
-            });
+            }
             debug!("de/inflate of {} bytes of random word-sequences",
                    input.len());
             let cmp = deflate_bytes(input);
@@ -120,7 +120,7 @@ mod tests {
                    input.len(), cmp.len(),
                    100.0 * ((cmp.len() as f64) / (input.len() as f64)));
             assert_eq!(input, out);
-        });
+        }
     }
 
     #[test]

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -1275,13 +1275,13 @@ mod test {
     fn multithreading() {
         run(proc() {
             let mut ports = ~[];
-            10.times(|| {
+            for _ in range(0, 10) {
                 let (port, chan) = Chan::new();
                 spawn(proc() {
                     chan.send(());
                 });
                 ports.push(port);
-            });
+            }
 
             loop {
                 match ports.pop() {
@@ -1410,7 +1410,7 @@ mod test {
     fn single_threaded_yield() {
         use std::task::deschedule;
         run(proc() {
-            5.times(deschedule);
+            for _ in range(0, 5) { deschedule(); }
         });
     }
 

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -534,7 +534,7 @@ mod tests {
     fn yield_test() {
         let (p, c) = Chan::new();
         spawn_opts(TaskOpts::new(), proc() {
-            10.times(task::deschedule);
+            for _ in range(0, 10) { task::deschedule(); }
             c.send(());
         });
         p.recv();

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -312,7 +312,7 @@ mod tests {
     fn yield_test() {
         let (p, c) = Chan::new();
         spawn(proc() {
-            10.times(task::deschedule);
+            for _ in range(0, 10) { task::deschedule(); }
             c.send(());
         });
         p.recv();

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -214,11 +214,11 @@ impl<O:DataFlowOperator> DataFlowContext<O> {
         });
         if expanded {
             let entry = if self.oper.initial_value() { uint::MAX } else {0};
-            self.words_per_id.times(|| {
+            for _ in range(0, self.words_per_id) {
                 self.gens.push(0);
                 self.kills.push(0);
                 self.on_entry.push(entry);
-            })
+            }
         }
         let start = *n * self.words_per_id;
         let end = start + self.words_per_id;

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -540,10 +540,10 @@ impl<'a> Context<'a> {
 
         // rollback
         self.is_doc_hidden = old_is_doc_hidden;
-        pushed.times(|| {
+        for _ in range(0, pushed) {
             let (lint, lvl, src) = self.lint_stack.pop().unwrap();
             self.set_level(lint, lvl, src);
-        })
+        }
     }
 
     fn visit_ids(&self, f: |&mut ast_util::IdVisitor<Context>|) {

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -229,12 +229,12 @@ pub fn const_expr(cx: @CrateContext, e: &ast::Expr, is_local: bool) -> (ValueRef
                 ty::AutoDerefRef(ref adj) => {
                     let mut ty = ety;
                     let mut maybe_ptr = None;
-                    adj.autoderefs.times(|| {
+                    for _ in range(0, adj.autoderefs) {
                         let (dv, dt) = const_deref(cx, llconst, ty, false);
                         maybe_ptr = Some(llconst);
                         llconst = dv;
                         ty = dt;
-                    });
+                    }
 
                     match adj.autoref {
                         None => { }

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -38,11 +38,11 @@ fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
     unsafe {
         let mut x: *mut i32 = transmute(dst.unsafe_mut_ref(0));
         let mut y: *i32 = transmute(input.unsafe_ref(0));
-        dst.len().times(|| {
+        for _ in range(0, dst.len()) {
             *x = to_be32(*y);
             x = x.offset(1);
             y = y.offset(1);
-        });
+        }
     }
 }
 

--- a/src/librustpkg/sha1.rs
+++ b/src/librustpkg/sha1.rs
@@ -51,11 +51,11 @@ fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
     unsafe {
         let mut x: *mut i32 = transmute(dst.unsafe_mut_ref(0));
         let mut y: *i32 = transmute(input.unsafe_ref(0));
-        dst.len().times(|| {
+        for _ in range(0, dst.len()) {
             *x = to_be32(*y);
             x = x.offset(1);
             y = y.offset(1);
-        })
+        }
     }
 }
 

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -1227,17 +1227,17 @@ mod test {
     })
 
     test!(fn oneshot_multi_thread_close_stress() {
-        stress_factor().times(|| {
+        for _ in range(0, stress_factor()) {
             let (port, chan) = Chan::<int>::new();
             spawn(proc() {
                 let _p = port;
             });
             let _chan = chan;
-        })
+        }
     })
 
     test!(fn oneshot_multi_thread_send_close_stress() {
-        stress_factor().times(|| {
+        for _ in range(0, stress_factor()) {
             let (port, chan) = Chan::<int>::new();
             spawn(proc() {
                 let _p = port;
@@ -1245,11 +1245,11 @@ mod test {
             task::try(proc() {
                 chan.send(1);
             });
-        })
+        }
     })
 
     test!(fn oneshot_multi_thread_recv_close_stress() {
-        stress_factor().times(|| {
+        for _ in range(0, stress_factor()) {
             let (port, chan) = Chan::<int>::new();
             spawn(proc() {
                 let port = port;
@@ -1264,11 +1264,11 @@ mod test {
                     let _chan = chan;
                 });
             });
-        })
+        }
     })
 
     test!(fn oneshot_multi_thread_send_recv_stress() {
-        stress_factor().times(|| {
+        for _ in range(0, stress_factor()) {
             let (port, chan) = Chan::<~int>::new();
             spawn(proc() {
                 chan.send(~10);
@@ -1276,11 +1276,11 @@ mod test {
             spawn(proc() {
                 assert!(port.recv() == ~10);
             });
-        })
+        }
     })
 
     test!(fn stream_send_recv_stress() {
-        stress_factor().times(|| {
+        for _ in range(0, stress_factor()) {
             let (port, chan) = Chan::<~int>::new();
 
             send(chan, 0);
@@ -1303,29 +1303,29 @@ mod test {
                     recv(port, i + 1);
                 });
             }
-        })
+        }
     })
 
     test!(fn recv_a_lot() {
         // Regression test that we don't run out of stack in scheduler context
         let (port, chan) = Chan::new();
-        10000.times(|| { chan.send(()) });
-        10000.times(|| { port.recv() });
+        for _ in range(0, 10000) { chan.send(()); }
+        for _ in range(0, 10000) { port.recv(); }
     })
 
     test!(fn shared_chan_stress() {
         let (port, chan) = SharedChan::new();
         let total = stress_factor() + 100;
-        total.times(|| {
+        for _ in range(0, total) {
             let chan_clone = chan.clone();
             spawn(proc() {
                 chan_clone.send(());
             });
-        });
+        }
 
-        total.times(|| {
+        for _ in range(0, total) {
             port.recv();
-        });
+        }
     })
 
     test!(fn test_nested_recv_iter() {

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -379,10 +379,10 @@ mod test {
         let (p3, c3) = Chan::<int>::new();
 
         spawn(proc() {
-            20.times(task::deschedule);
+            for _ in range(0, 20) { task::deschedule(); }
             c1.send(1);
             p3.recv();
-            20.times(task::deschedule);
+            for _ in range(0, 20) { task::deschedule(); }
         });
 
         select! (
@@ -402,7 +402,7 @@ mod test {
         let (p3, c3) = Chan::<()>::new();
 
         spawn(proc() {
-            20.times(task::deschedule);
+            for _ in range(0, 20) { task::deschedule(); }
             c1.send(1);
             c2.send(2);
             p3.recv();

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -355,15 +355,15 @@ mod test {
 
     iotest!(fn multiple_connect_serial_ip4() {
         let addr = next_test_ip4();
-        let max = 10;
+        let max = 10u;
         let (port, chan) = Chan::new();
 
         spawn(proc() {
             port.recv();
-            max.times(|| {
+            for _ in range(0, max) {
                 let mut stream = TcpStream::connect(addr);
                 stream.write([99]);
-            });
+            }
         });
 
         let mut acceptor = TcpListener::bind(addr).listen();
@@ -377,15 +377,15 @@ mod test {
 
     iotest!(fn multiple_connect_serial_ip6() {
         let addr = next_test_ip6();
-        let max = 10;
+        let max = 10u;
         let (port, chan) = Chan::new();
 
         spawn(proc() {
             port.recv();
-            max.times(|| {
+            for _ in range(0, max) {
                 let mut stream = TcpStream::connect(addr);
                 stream.write([99]);
-            });
+            }
         });
 
         let mut acceptor = TcpListener::bind(addr).listen();

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -234,20 +234,20 @@ mod tests {
 
         spawn(proc() {
             port.recv();
-            times.times(|| {
+            for _ in range(0, times) {
                 let mut stream = UnixStream::connect(&path2);
                 stream.write([100]);
-            })
+            }
         });
 
         let mut acceptor = UnixListener::bind(&path1).listen();
         chan.send(());
-        times.times(|| {
+        for _ in range(0, times) {
             let mut client = acceptor.accept();
             let mut buf = [0];
             client.read(buf);
             assert_eq!(buf[0], 100);
-        })
+        }
     }
 
     #[test]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -139,18 +139,6 @@ pub trait Signed: Num
 
 pub trait Unsigned: Num {}
 
-/// Times trait
-///
-/// ```rust
-/// let ten = 10u;
-/// let mut accum = 0;
-/// ten.times(|| { accum += 1; })
-/// ```
-///
-pub trait Times {
-    fn times(&self, it: ||);
-}
-
 pub trait Integer: Num
                  + Orderable
                  + Div<Self,Self>

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -20,7 +20,6 @@ use num::{Bitwise, Bounded};
 use num::{CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};
 use num::{ToStrRadix, FromStrRadix};
-use num;
 use option::{Option, Some, None};
 use str;
 use unstable::intrinsics;
@@ -79,27 +78,6 @@ pub fn div_round(x: uint, y: uint) -> uint {
 /// is either `x/y` or `x/y + 1`.
 ///
 pub fn div_floor(x: uint, y: uint) -> uint { return x / y; }
-
-impl num::Times for uint {
-    #[inline]
-    ///
-    /// A convenience form for basic repetition. Given a uint `x`,
-    /// `x.times(|| { ... })` executes the given block x times.
-    ///
-    /// Equivalent to `for uint::range(0, x) |_| { ... }`.
-    ///
-    /// Not defined on all integer types to permit unambiguous
-    /// use with integer literals of inferred integer-type as
-    /// the self-value (eg. `100.times(|| { ... })`).
-    ///
-    fn times(&self, it: ||) {
-        let mut i = *self;
-        while i > 0 {
-            it();
-            i -= 1;
-        }
-    }
-}
 
 /// Returns the smallest power of 2 greater than or equal to `n`
 #[inline]
@@ -244,13 +222,4 @@ fn test_div() {
     assert!((div_floor(3u, 4u) == 0u));
     assert!((div_ceil(3u, 4u)  == 1u));
     assert!((div_round(3u, 4u) == 1u));
-}
-
-#[test]
-pub fn test_times() {
-    use num::Times;
-    let ten = 10 as uint;
-    let mut accum = 0;
-    ten.times(|| { accum += 1; });
-    assert!((accum == 10));
 }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -57,7 +57,6 @@ pub use hash::Hash;
 pub use iter::{FromIterator, Extendable};
 pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIterator};
 pub use iter::{OrdIterator, MutableDoubleEndedIterator, ExactSize};
-pub use num::Times;
 pub use num::{Integer, Real, Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};
 pub use num::{Orderable, Signed, Unsigned, Round};
 pub use num::{Primitive, Int, Float, ToStrRadix, ToPrimitive, FromPrimitive};

--- a/src/libstd/rand/isaac.rs
+++ b/src/libstd/rand/isaac.rs
@@ -12,7 +12,6 @@
 
 use rand::{Rng, SeedableRng, OSRng};
 use iter::{Iterator, range, range_step, Repeat};
-use num::Times;
 use option::{None, Some};
 use vec::{raw, MutableVector, ImmutableVector};
 use mem;
@@ -95,7 +94,7 @@ impl IsaacRng {
             }}
         );
 
-        4.times(|| mix!());
+        for _ in range(0, 4) { mix!(); }
 
         if use_rsl {
             macro_rules! memloop (

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -14,6 +14,7 @@ use codemap;
 use std::cell::Cell;
 use std::io;
 use std::io::stdio::StdWriter;
+use std::iter::range;
 use std::local_data;
 use extra::term;
 
@@ -320,7 +321,7 @@ fn highlight_lines(cm: &codemap::CodeMap,
         // Skip is the number of characters we need to skip because they are
         // part of the 'filename:line ' part of the previous line.
         let skip = fm.name.len() + digits + 3u;
-        skip.times(|| s.push_char(' '));
+        for _ in range(0, skip) { s.push_char(' '); }
         let orig = fm.get_line(lines.lines[0] as int);
         for pos in range(0u, left-skip) {
             let curChar = (orig[pos] as char);
@@ -339,7 +340,7 @@ fn highlight_lines(cm: &codemap::CodeMap,
         if hi.col != lo.col {
             // the ^ already takes up one space
             let num_squigglies = hi.col.to_uint()-lo.col.to_uint()-1u;
-            num_squigglies.times(|| s.push_char('~'));
+            for _ in range(0, num_squigglies) { s.push_char('~'); }
         }
         print_maybe_styled(s + "\n", term::attr::ForegroundColor(lvl.color()));
     }
@@ -378,7 +379,7 @@ fn custom_highlight_lines(cm: &codemap::CodeMap,
     // Span seems to use half-opened interval, so subtract 1
     let skip = last_line_start.len() + hi.col.to_uint() - 1;
     let mut s = ~"";
-    skip.times(|| s.push_char(' '));
+    for _ in range(0, skip) { s.push_char(' '); }
     s.push_char('^');
     print_maybe_styled(s + "\n", term::attr::ForegroundColor(lvl.color()));
 }

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -396,9 +396,9 @@ pub fn parse(sess: @ParseSess,
                 }
                 cur_eis.push(ei);
 
-                rust_parser.tokens_consumed.times(|| {
+                for _ in range(0, rust_parser.tokens_consumed) {
                     let _ = rdr.next_token();
-                });
+                }
             }
         }
 

--- a/src/test/bench/rt-messaging-ping-pong.rs
+++ b/src/test/bench/rt-messaging-ping-pong.rs
@@ -29,25 +29,25 @@ fn ping_pong_bench(n: uint, m: uint) {
         spawn(proc() {
             let chan = ca;
             let port = pb;
-            n.times(|| {
+            for _ in range(0, n) {
                 chan.send(());
                 port.recv();
-            })
+            }
         });
 
         spawn(proc() {
             let chan = cb;
             let port = pa;
-            n.times(|| {
+            for _ in range(0, n) {
                 port.recv();
                 chan.send(());
-            })
+            }
         });
     }
 
-    m.times(|| {
+    for _ in range(0, m) {
         run_pair(n)
-    })
+    }
 }
 
 

--- a/src/test/bench/rt-spawn-rate.rs
+++ b/src/test/bench/rt-spawn-rate.rs
@@ -26,8 +26,8 @@ fn main() {
         100000
     };
 
-    n.times(|| {
+    for _ in range(0, n) {
         spawn(proc() {});
-    })
+    }
 
 }

--- a/src/test/compile-fail/borrowck-lend-flow-loop.rs
+++ b/src/test/compile-fail/borrowck-lend-flow-loop.rs
@@ -39,9 +39,9 @@ fn block_overarching_alias_mut() {
 
     let mut v = ~3;
     let mut x = &mut v;
-    3.times(|| {
+    for _ in range(0, 3) {
         borrow(v); //~ ERROR cannot borrow
-    });
+    }
     *x = ~5;
 }
 

--- a/src/test/compile-fail/implicit-method-bind.rs
+++ b/src/test/compile-fail/implicit-method-bind.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let _f = 10.times; //~ ERROR attempted to take value of method
+    let _f = 10i.abs; //~ ERROR attempted to take value of method
 }

--- a/src/test/run-fail/extern-fail.rs
+++ b/src/test/run-fail/extern-fail.rs
@@ -41,11 +41,11 @@ fn count(n: uint) -> uint {
 }
 
 fn main() {
-    10u.times(proc() {
+    for _ in range(0, 10u) {
         task::spawn(proc() {
             let result = count(5u);
             info!("result = %?", result);
             fail!();
         });
-    });
+    }
 }

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -20,5 +20,5 @@ fn bitv_test() {
 }
 
 pub fn main() {
-    10000.times(|| bitv_test());
+    for _ in range(0, 10000) { bitv_test(); }
 }

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -72,9 +72,9 @@ pub fn main() {
     roundtrip::<C>();
     roundtrip::<D>();
 
-    20.times(|| {
+    for _ in range(0, 20) {
         roundtrip::<E>();
         roundtrip::<F>();
         roundtrip::<G<int>>();
-    })
+    }
 }

--- a/src/test/run-pass/deriving-rand.rs
+++ b/src/test/run-pass/deriving-rand.rs
@@ -34,10 +34,10 @@ enum D {
 
 pub fn main() {
     // check there's no segfaults
-    20.times(|| {
+    for _ in range(0, 20) {
         rand::random::<A>();
         rand::random::<B>();
         rand::random::<C>();
         rand::random::<D>();
-    })
+    }
 }

--- a/src/test/run-pass/extern-stress.rs
+++ b/src/test/run-pass/extern-stress.rs
@@ -41,9 +41,9 @@ fn count(n: uint) -> uint {
 }
 
 pub fn main() {
-    100u.times(|| {
+    for _ in range(0, 100u) {
         task::spawn(proc() {
             assert_eq!(count(5u), 16u);
         });
-    })
+    }
 }

--- a/src/test/run-pass/extern-yield.rs
+++ b/src/test/run-pass/extern-yield.rs
@@ -38,11 +38,11 @@ fn count(n: uint) -> uint {
 }
 
 pub fn main() {
-    10u.times(|| {
+    for _ in range(0, 10u) {
         task::spawn(proc() {
             let result = count(5u);
             info!("result = {}", result);
             assert_eq!(result, 16u);
         });
-    })
+    }
 }

--- a/src/test/run-pass/issue-3211.rs
+++ b/src/test/run-pass/issue-3211.rs
@@ -1,6 +1,6 @@
 pub fn main() {
     let mut x = 0;
-    4096.times(|| x += 1);
+    for _ in range(0, 4096) { x += 1; }
     assert_eq!(x, 4096);
     println!("x = {}", x);
 }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -65,7 +65,7 @@ fn AsciiArt(width: uint, height: uint, fill: char) -> AsciiArt {
     // Use an anonymous function to build a vector of vectors containing
     // blank characters for each position in our canvas.
     let lines = vec::build(Some(height), |push| {
-        height.times(|| push(vec::from_elem(width, '.')))
+        for _ in range(0, height) { push(vec::from_elem(width, '.')); }
     });
 
     // Rust code often returns values by omitting the trailing semi-colon

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -44,17 +44,16 @@ priv fn parse_data(len: uint, io: @io::Reader) -> Result {
 }
 
 priv fn parse_list(len: uint, io: @io::Reader) -> Result {
-  let mut list: ~[Result] = ~[];
-    len.times(proc() {
-    let v =
-        match io.read_char() {
-        '$' => parse_bulk(io),
-        ':' => parse_int(io),
-         _ => fail!()
-    });
-    list.push(v);
+    let mut list: ~[Result] = ~[];
+    for _ in range(0, len) {
+        let v = match io.read_char() {
+            '$' => parse_bulk(io),
+            ':' => parse_int(io),
+             _ => fail!()
+        };
+        list.push(v);
     }
-  return List(list);
+    return List(list);
 }
 
 priv fn chop(s: ~str) -> ~str {

--- a/src/test/run-pass/issue-4401.rs
+++ b/src/test/run-pass/issue-4401.rs
@@ -1,6 +1,6 @@
 pub fn main() {
     let mut count = 0;
-    999_999.times(|| count += 1);
+    for _ in range(0, 999_999) { count += 1; }
     assert_eq!(count, 999_999);
     println!("{}", count);
 }

--- a/src/test/run-pass/issue-5321-immediates-with-bare-self.rs
+++ b/src/test/run-pass/issue-5321-immediates-with-bare-self.rs
@@ -14,7 +14,7 @@ trait Fooable {
 
 impl Fooable for uint {
     fn yes(self) {
-        self.times(|| println!("yes"));
+        for _ in range(0, self) { println!("yes"); }
     }
 }
 

--- a/src/test/run-pass/numeric-method-autoexport.rs
+++ b/src/test/run-pass/numeric-method-autoexport.rs
@@ -31,9 +31,6 @@ pub fn main() {
     assert_eq!(15u32.add(&6u32), 21u32);
     assert_eq!(15u64.add(&6u64), 21u64);
 
-    // times
-     15u.times(|| {});
-
 // floats
     // num
     assert_eq!(10f32.to_int().unwrap(), 10);


### PR DESCRIPTION
`Times::times` was always a second-class loop because it did not support the `break` and `continue` operations. Its playful appeal (which I liked) was then lost after `do` was disabled for closures. It's time to let this one go.
