### PR TITLE
Rename Invert to Flip - Issue #10632

### DIFF
--- a/doc/guide-container.md
+++ b/doc/guide-container.md
@@ -336,8 +336,8 @@ The `DoubleEndedIterator` trait represents an iterator able to yield elements
 from either end of a range. It inherits from the `Iterator` trait and extends
 it with the `next_back` function.
 
-A `DoubleEndedIterator` can be flipped with the `flip` adaptor, returning
-another `DoubleEndedIterator` with `next` and `next_back` exchanged.
+A `DoubleEndedIterator` can have its direction changed with the `rev` adaptor,
+returning another `DoubleEndedIterator` with `next` and `next_back` exchanged.
 
 ~~~
 let xs = [1, 2, 3, 4, 5, 6];
@@ -347,7 +347,7 @@ println!("{:?}", it.next()); // prints `Some(&2)`
 println!("{:?}", it.next_back()); // prints `Some(&6)`
 
 // prints `5`, `4` and `3`
-for &x in it.flip() {
+for &x in it.rev() {
     println!("{}", x)
 }
 ~~~
@@ -366,7 +366,7 @@ let mut it = xs.iter().chain(ys.iter()).map(|&x| x * 2);
 println!("{:?}", it.next()); // prints `Some(2)`
 
 // prints `16`, `14`, `12`, `10`, `8`, `6`, `4`
-for x in it.flip() {
+for x in it.rev() {
     println!("{}", x);
 }
 ~~~

--- a/doc/guide-container.md
+++ b/doc/guide-container.md
@@ -336,7 +336,7 @@ The `DoubleEndedIterator` trait represents an iterator able to yield elements
 from either end of a range. It inherits from the `Iterator` trait and extends
 it with the `next_back` function.
 
-A `DoubleEndedIterator` can be flipped with the `invert` adaptor, returning
+A `DoubleEndedIterator` can be flipped with the `flip` adaptor, returning
 another `DoubleEndedIterator` with `next` and `next_back` exchanged.
 
 ~~~
@@ -347,7 +347,7 @@ println!("{:?}", it.next()); // prints `Some(&2)`
 println!("{:?}", it.next_back()); // prints `Some(&6)`
 
 // prints `5`, `4` and `3`
-for &x in it.invert() {
+for &x in it.flip() {
     println!("{}", x)
 }
 ~~~
@@ -366,7 +366,7 @@ let mut it = xs.iter().chain(ys.iter()).map(|&x| x * 2);
 println!("{:?}", it.next()); // prints `Some(2)`
 
 // prints `16`, `14`, `12`, `10`, `8`, `6`, `4`
-for x in it.invert() {
+for x in it.flip() {
     println!("{}", x);
 }
 ~~~

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -13,7 +13,7 @@
 
 use std::cmp;
 use std::iter::RandomAccessIterator;
-use std::iter::{Flip, Enumerate, Repeat, Map, Zip};
+use std::iter::{Rev, Enumerate, Repeat, Map, Zip};
 use std::num;
 use std::ops;
 use std::uint;
@@ -428,8 +428,8 @@ impl Bitv {
     }
 
     #[inline]
-    pub fn rev_iter<'a>(&'a self) -> Flip<Bits<'a>> {
-        self.iter().flip()
+    pub fn rev_iter<'a>(&'a self) -> Rev<Bits<'a>> {
+        self.iter().rev()
     }
 
     /// Returns `true` if all bits are 0

--- a/src/libextra/bitv.rs
+++ b/src/libextra/bitv.rs
@@ -13,7 +13,7 @@
 
 use std::cmp;
 use std::iter::RandomAccessIterator;
-use std::iter::{Invert, Enumerate, Repeat, Map, Zip};
+use std::iter::{Flip, Enumerate, Repeat, Map, Zip};
 use std::num;
 use std::ops;
 use std::uint;
@@ -387,7 +387,7 @@ impl Bitv {
         }
     }
 
-    /// Invert all bits
+    /// Flip all bits
     #[inline]
     pub fn negate(&mut self) {
         match self.rep {
@@ -428,8 +428,8 @@ impl Bitv {
     }
 
     #[inline]
-    pub fn rev_iter<'a>(&'a self) -> Invert<Bits<'a>> {
-        self.iter().invert()
+    pub fn rev_iter<'a>(&'a self) -> Flip<Bits<'a>> {
+        self.iter().flip()
     }
 
     /// Returns `true` if all bits are 0

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -25,7 +25,7 @@
 use std::cast;
 use std::ptr;
 use std::util;
-use std::iter::Invert;
+use std::iter::Flip;
 use std::iter;
 
 use container::Deque;
@@ -368,8 +368,8 @@ impl<T> DList<T> {
 
     /// Provide a reverse iterator
     #[inline]
-    pub fn rev_iter<'a>(&'a self) -> Invert<Items<'a, T>> {
-        self.iter().invert()
+    pub fn rev_iter<'a>(&'a self) -> Flip<Items<'a, T>> {
+        self.iter().flip()
     }
 
     /// Provide a forward iterator with mutable references
@@ -388,8 +388,8 @@ impl<T> DList<T> {
     }
     /// Provide a reverse iterator with mutable references
     #[inline]
-    pub fn mut_rev_iter<'a>(&'a mut self) -> Invert<MutItems<'a, T>> {
-        self.mut_iter().invert()
+    pub fn mut_rev_iter<'a>(&'a mut self) -> Flip<MutItems<'a, T>> {
+        self.mut_iter().flip()
     }
 
 
@@ -401,8 +401,8 @@ impl<T> DList<T> {
 
     /// Consume the list into an iterator yielding elements by value, in reverse
     #[inline]
-    pub fn move_rev_iter(self) -> Invert<MoveItems<T>> {
-        self.move_iter().invert()
+    pub fn move_rev_iter(self) -> Flip<MoveItems<T>> {
+        self.move_iter().flip()
     }
 }
 

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -25,7 +25,7 @@
 use std::cast;
 use std::ptr;
 use std::util;
-use std::iter::Flip;
+use std::iter::Rev;
 use std::iter;
 
 use container::Deque;
@@ -368,8 +368,8 @@ impl<T> DList<T> {
 
     /// Provide a reverse iterator
     #[inline]
-    pub fn rev_iter<'a>(&'a self) -> Flip<Items<'a, T>> {
-        self.iter().flip()
+    pub fn rev_iter<'a>(&'a self) -> Rev<Items<'a, T>> {
+        self.iter().rev()
     }
 
     /// Provide a forward iterator with mutable references
@@ -388,8 +388,8 @@ impl<T> DList<T> {
     }
     /// Provide a reverse iterator with mutable references
     #[inline]
-    pub fn mut_rev_iter<'a>(&'a mut self) -> Flip<MutItems<'a, T>> {
-        self.mut_iter().flip()
+    pub fn mut_rev_iter<'a>(&'a mut self) -> Rev<MutItems<'a, T>> {
+        self.mut_iter().rev()
     }
 
 
@@ -401,8 +401,8 @@ impl<T> DList<T> {
 
     /// Consume the list into an iterator yielding elements by value, in reverse
     #[inline]
-    pub fn move_rev_iter(self) -> Flip<MoveItems<T>> {
-        self.move_iter().flip()
+    pub fn move_rev_iter(self) -> Rev<MoveItems<T>> {
+        self.move_iter().rev()
     }
 }
 

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -15,7 +15,7 @@
 
 use std::num;
 use std::vec;
-use std::iter::{Invert, RandomAccessIterator};
+use std::iter::{Flip, RandomAccessIterator};
 
 use container::Deque;
 
@@ -192,8 +192,8 @@ impl<T> RingBuf<T> {
     }
 
     /// Back-to-front iterator.
-    pub fn rev_iter<'a>(&'a self) -> Invert<Items<'a, T>> {
-        self.iter().invert()
+    pub fn rev_iter<'a>(&'a self) -> Flip<Items<'a, T>> {
+        self.iter().flip()
     }
 
     /// Front-to-back iterator which returns mutable values.
@@ -223,8 +223,8 @@ impl<T> RingBuf<T> {
     }
 
     /// Back-to-front iterator which returns mutable values.
-    pub fn mut_rev_iter<'a>(&'a mut self) -> Invert<MutItems<'a, T>> {
-        self.mut_iter().invert()
+    pub fn mut_rev_iter<'a>(&'a mut self) -> Flip<MutItems<'a, T>> {
+        self.mut_iter().flip()
     }
 }
 

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -15,7 +15,7 @@
 
 use std::num;
 use std::vec;
-use std::iter::{Flip, RandomAccessIterator};
+use std::iter::{Rev, RandomAccessIterator};
 
 use container::Deque;
 
@@ -192,8 +192,8 @@ impl<T> RingBuf<T> {
     }
 
     /// Back-to-front iterator.
-    pub fn rev_iter<'a>(&'a self) -> Flip<Items<'a, T>> {
-        self.iter().flip()
+    pub fn rev_iter<'a>(&'a self) -> Rev<Items<'a, T>> {
+        self.iter().rev()
     }
 
     /// Front-to-back iterator which returns mutable values.
@@ -223,8 +223,8 @@ impl<T> RingBuf<T> {
     }
 
     /// Back-to-front iterator which returns mutable values.
-    pub fn mut_rev_iter<'a>(&'a mut self) -> Flip<MutItems<'a, T>> {
-        self.mut_iter().flip()
+    pub fn mut_rev_iter<'a>(&'a mut self) -> Rev<MutItems<'a, T>> {
+        self.mut_iter().rev()
     }
 }
 

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -15,7 +15,7 @@
 
 #[allow(missing_doc)];
 
-use std::iter::{Enumerate, FilterMap, Invert};
+use std::iter::{Enumerate, FilterMap, Flip};
 use std::util::replace;
 use std::vec;
 
@@ -140,14 +140,14 @@ impl<V> SmallIntMap<V> {
     /// An iterator visiting all key-value pairs in descending order by the keys.
     /// Iterator element type is (uint, &'r V)
     pub fn rev_iter<'r>(&'r self) -> RevEntries<'r, V> {
-        self.iter().invert()
+        self.iter().flip()
     }
 
     /// An iterator visiting all key-value pairs in descending order by the keys,
     /// with mutable references to the values
     /// Iterator element type is (uint, &'r mut V)
     pub fn mut_rev_iter<'r>(&'r mut self) -> RevMutEntries <'r, V> {
-        self.mut_iter().invert()
+        self.mut_iter().flip()
     }
 
     /// Empties the hash map, moving all values into the specified closure
@@ -241,7 +241,7 @@ pub struct Entries<'a, T> {
 
 iterator!(impl Entries -> (uint, &'a T), get_ref)
 double_ended_iterator!(impl Entries -> (uint, &'a T), get_ref)
-pub type RevEntries<'a, T> = Invert<Entries<'a, T>>;
+pub type RevEntries<'a, T> = Flip<Entries<'a, T>>;
 
 pub struct MutEntries<'a, T> {
     priv front: uint,
@@ -251,7 +251,7 @@ pub struct MutEntries<'a, T> {
 
 iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
 double_ended_iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
-pub type RevMutEntries<'a, T> = Invert<MutEntries<'a, T>>;
+pub type RevMutEntries<'a, T> = Flip<MutEntries<'a, T>>;
 
 #[cfg(test)]
 mod test_map {

--- a/src/libextra/smallintmap.rs
+++ b/src/libextra/smallintmap.rs
@@ -15,7 +15,7 @@
 
 #[allow(missing_doc)];
 
-use std::iter::{Enumerate, FilterMap, Flip};
+use std::iter::{Enumerate, FilterMap, Rev};
 use std::util::replace;
 use std::vec;
 
@@ -140,14 +140,14 @@ impl<V> SmallIntMap<V> {
     /// An iterator visiting all key-value pairs in descending order by the keys.
     /// Iterator element type is (uint, &'r V)
     pub fn rev_iter<'r>(&'r self) -> RevEntries<'r, V> {
-        self.iter().flip()
+        self.iter().rev()
     }
 
     /// An iterator visiting all key-value pairs in descending order by the keys,
     /// with mutable references to the values
     /// Iterator element type is (uint, &'r mut V)
     pub fn mut_rev_iter<'r>(&'r mut self) -> RevMutEntries <'r, V> {
-        self.mut_iter().flip()
+        self.mut_iter().rev()
     }
 
     /// Empties the hash map, moving all values into the specified closure
@@ -241,7 +241,7 @@ pub struct Entries<'a, T> {
 
 iterator!(impl Entries -> (uint, &'a T), get_ref)
 double_ended_iterator!(impl Entries -> (uint, &'a T), get_ref)
-pub type RevEntries<'a, T> = Flip<Entries<'a, T>>;
+pub type RevEntries<'a, T> = Rev<Entries<'a, T>>;
 
 pub struct MutEntries<'a, T> {
     priv front: uint,
@@ -251,7 +251,7 @@ pub struct MutEntries<'a, T> {
 
 iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
 double_ended_iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
-pub type RevMutEntries<'a, T> = Flip<MutEntries<'a, T>>;
+pub type RevMutEntries<'a, T> = Rev<MutEntries<'a, T>>;
 
 #[cfg(test)]
 mod test_map {

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -460,7 +460,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
             fail!("failure in dup3(err_fd, 2): {}", os::last_os_error());
         }
         // close all other fds
-        for fd in range(3, getdtablesize()).flip() {
+        for fd in range(3, getdtablesize()).rev() {
             if fd != output.fd() {
                 close(fd as c_int);
             }

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -460,7 +460,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
             fail!("failure in dup3(err_fd, 2): {}", os::last_os_error());
         }
         // close all other fds
-        for fd in range(3, getdtablesize()).invert() {
+        for fd in range(3, getdtablesize()).flip() {
             if fd != output.fd() {
                 close(fd as c_int);
             }

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -203,7 +203,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
          */
 
         let scopes = self.scopes.borrow();
-        for scope in scopes.get().iter().invert() {
+        for scope in scopes.get().iter().flip() {
             match scope.kind {
                 LoopScopeKind(id, _) => {
                     return id;
@@ -325,7 +325,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
                cleanup_scope);
 
         let mut scopes = self.scopes.borrow_mut();
-        for scope in scopes.get().mut_iter().invert() {
+        for scope in scopes.get().mut_iter().flip() {
             if scope.kind.is_ast_with_id(cleanup_scope) {
                 scope.cleanups.push(cleanup);
                 scope.clear_cached_exits();
@@ -368,7 +368,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
          */
 
         let scopes = self.scopes.borrow();
-        scopes.get().iter().invert().any(|s| s.needs_invoke())
+        scopes.get().iter().flip().any(|s| s.needs_invoke())
     }
 
     fn get_landing_pad(&self) -> BasicBlockRef {
@@ -415,7 +415,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
          * Returns the id of the current top-most AST scope, if any.
          */
         let scopes = self.scopes.borrow();
-        for scope in scopes.get().iter().invert() {
+        for scope in scopes.get().iter().flip() {
             match scope.kind {
                 CustomScopeKind | LoopScopeKind(..) => {}
                 AstScopeKind(i) => {
@@ -428,7 +428,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
 
     fn top_nonempty_cleanup_scope(&self) -> Option<uint> {
         let scopes = self.scopes.borrow();
-        scopes.get().iter().invert().position(|s| !s.cleanups.is_empty())
+        scopes.get().iter().flip().position(|s| !s.cleanups.is_empty())
     }
 
     fn is_valid_to_pop_custom_scope(&self, custom_scope: CustomScopeIndex) -> bool {
@@ -450,7 +450,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
 
         let mut bcx = bcx;
         if !bcx.unreachable.get() {
-            for cleanup in scope.cleanups.iter().invert() {
+            for cleanup in scope.cleanups.iter().flip() {
                 bcx = cleanup.trans(bcx);
             }
         }
@@ -619,7 +619,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
                 debug!("generating cleanups for {}", name);
                 let bcx_in = self.new_block(label.is_unwind(), name, None);
                 let mut bcx_out = bcx_in;
-                for cleanup in scope.cleanups.iter().invert() {
+                for cleanup in scope.cleanups.iter().flip() {
                     if cleanup_is_suitable_for(*cleanup, label) {
                         bcx_out = cleanup.trans(bcx_out);
                     }

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -203,7 +203,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
          */
 
         let scopes = self.scopes.borrow();
-        for scope in scopes.get().iter().flip() {
+        for scope in scopes.get().iter().rev() {
             match scope.kind {
                 LoopScopeKind(id, _) => {
                     return id;
@@ -325,7 +325,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
                cleanup_scope);
 
         let mut scopes = self.scopes.borrow_mut();
-        for scope in scopes.get().mut_iter().flip() {
+        for scope in scopes.get().mut_iter().rev() {
             if scope.kind.is_ast_with_id(cleanup_scope) {
                 scope.cleanups.push(cleanup);
                 scope.clear_cached_exits();
@@ -368,7 +368,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
          */
 
         let scopes = self.scopes.borrow();
-        scopes.get().iter().flip().any(|s| s.needs_invoke())
+        scopes.get().iter().rev().any(|s| s.needs_invoke())
     }
 
     fn get_landing_pad(&self) -> BasicBlockRef {
@@ -415,7 +415,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
          * Returns the id of the current top-most AST scope, if any.
          */
         let scopes = self.scopes.borrow();
-        for scope in scopes.get().iter().flip() {
+        for scope in scopes.get().iter().rev() {
             match scope.kind {
                 CustomScopeKind | LoopScopeKind(..) => {}
                 AstScopeKind(i) => {
@@ -428,7 +428,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
 
     fn top_nonempty_cleanup_scope(&self) -> Option<uint> {
         let scopes = self.scopes.borrow();
-        scopes.get().iter().flip().position(|s| !s.cleanups.is_empty())
+        scopes.get().iter().rev().position(|s| !s.cleanups.is_empty())
     }
 
     fn is_valid_to_pop_custom_scope(&self, custom_scope: CustomScopeIndex) -> bool {
@@ -450,7 +450,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
 
         let mut bcx = bcx;
         if !bcx.unreachable.get() {
-            for cleanup in scope.cleanups.iter().flip() {
+            for cleanup in scope.cleanups.iter().rev() {
                 bcx = cleanup.trans(bcx);
             }
         }
@@ -619,7 +619,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
                 debug!("generating cleanups for {}", name);
                 let bcx_in = self.new_block(label.is_unwind(), name, None);
                 let mut bcx_out = bcx_in;
-                for cleanup in scope.cleanups.iter().flip() {
+                for cleanup in scope.cleanups.iter().rev() {
                     if cleanup_is_suitable_for(*cleanup, label) {
                         bcx_out = cleanup.trans(bcx_out);
                     }

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -672,19 +672,19 @@ pub trait DoubleEndedIterator<A>: Iterator<A> {
 
     /// Flip the direction of the iterator
     ///
-    /// The inverted iterator flips the ends on an iterator that can already
+    /// The flipped iterator swaps the ends on an iterator that can already
     /// be iterated from the front and from the back.
     ///
     ///
-    /// If the iterator also implements RandomAccessIterator, the inverted
+    /// If the iterator also implements RandomAccessIterator, the flipped
     /// iterator is also random access, with the indices starting at the back
     /// of the original iterator.
     ///
-    /// Note: Random access with inverted indices still only applies to the first
+    /// Note: Random access with flipped indices still only applies to the first
     /// `uint::max_value` elements of the original iterator.
     #[inline]
-    fn invert(self) -> Invert<Self> {
-        Invert{iter: self}
+    fn flip(self) -> Flip<Self> {
+        Flip{iter: self}
     }
 }
 
@@ -759,30 +759,30 @@ pub trait ExactSize<A> : DoubleEndedIterator<A> {
 // Adaptors that may overflow in `size_hint` are not, i.e. `Chain`.
 impl<A, T: ExactSize<A>> ExactSize<(uint, A)> for Enumerate<T> {}
 impl<'a, A, T: ExactSize<A>> ExactSize<A> for Inspect<'a, A, T> {}
-impl<A, T: ExactSize<A>> ExactSize<A> for Invert<T> {}
+impl<A, T: ExactSize<A>> ExactSize<A> for Flip<T> {}
 impl<'a, A, B, T: ExactSize<A>> ExactSize<B> for Map<'a, A, B, T> {}
 impl<A, B, T: ExactSize<A>, U: ExactSize<B>> ExactSize<(A, B)> for Zip<T, U> {}
 
 /// An double-ended iterator with the direction inverted
 #[deriving(Clone)]
-pub struct Invert<T> {
+pub struct Flip<T> {
     priv iter: T
 }
 
-impl<A, T: DoubleEndedIterator<A>> Iterator<A> for Invert<T> {
+impl<A, T: DoubleEndedIterator<A>> Iterator<A> for Flip<T> {
     #[inline]
     fn next(&mut self) -> Option<A> { self.iter.next_back() }
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
-impl<A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for Invert<T> {
+impl<A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for Flip<T> {
     #[inline]
     fn next_back(&mut self) -> Option<A> { self.iter.next() }
 }
 
 impl<A, T: DoubleEndedIterator<A> + RandomAccessIterator<A>> RandomAccessIterator<A>
-    for Invert<T> {
+    for Flip<T> {
     #[inline]
     fn indexable(&self) -> uint { self.iter.indexable() }
     #[inline]
@@ -2590,12 +2590,12 @@ mod tests {
     }
 
     #[test]
-    fn test_invert() {
+    fn test_flip() {
         let xs = [2, 4, 6, 8, 10, 12, 14, 16];
         let mut it = xs.iter();
         it.next();
         it.next();
-        assert_eq!(it.invert().map(|&x| x).collect::<~[int]>(), ~[16, 14, 12, 10, 8, 6]);
+        assert_eq!(it.flip().map(|&x| x).collect::<~[int]>(), ~[16, 14, 12, 10, 8, 6]);
     }
 
     #[test]
@@ -2662,7 +2662,7 @@ mod tests {
     fn test_double_ended_chain() {
         let xs = [1, 2, 3, 4, 5];
         let ys = ~[7, 9, 11];
-        let mut it = xs.iter().chain(ys.iter()).invert();
+        let mut it = xs.iter().chain(ys.iter()).flip();
         assert_eq!(it.next().unwrap(), &11)
         assert_eq!(it.next().unwrap(), &9)
         assert_eq!(it.next_back().unwrap(), &1)
@@ -2764,10 +2764,10 @@ mod tests {
     }
 
     #[test]
-    fn test_random_access_invert() {
+    fn test_random_access_flip() {
         let xs = [1, 2, 3, 4, 5];
-        check_randacc_iter(xs.iter().invert(), xs.len());
-        let mut it = xs.iter().invert();
+        check_randacc_iter(xs.iter().flip(), xs.len());
+        let mut it = xs.iter().flip();
         it.next();
         it.next_back();
         it.next();
@@ -2833,13 +2833,13 @@ mod tests {
 
     #[test]
     fn test_double_ended_range() {
-        assert_eq!(range(11i, 14).invert().collect::<~[int]>(), ~[13i, 12, 11]);
-        for _ in range(10i, 0).invert() {
+        assert_eq!(range(11i, 14).flip().collect::<~[int]>(), ~[13i, 12, 11]);
+        for _ in range(10i, 0).flip() {
             fail!("unreachable");
         }
 
-        assert_eq!(range(11u, 14).invert().collect::<~[uint]>(), ~[13u, 12, 11]);
-        for _ in range(10u, 0).invert() {
+        assert_eq!(range(11u, 14).flip().collect::<~[uint]>(), ~[13u, 12, 11]);
+        for _ in range(10u, 0).flip() {
             fail!("unreachable");
         }
     }
@@ -2886,11 +2886,11 @@ mod tests {
 
         assert_eq!(range(0i, 5).collect::<~[int]>(), ~[0i, 1, 2, 3, 4]);
         assert_eq!(range(-10i, -1).collect::<~[int]>(), ~[-10, -9, -8, -7, -6, -5, -4, -3, -2]);
-        assert_eq!(range(0i, 5).invert().collect::<~[int]>(), ~[4, 3, 2, 1, 0]);
+        assert_eq!(range(0i, 5).flip().collect::<~[int]>(), ~[4, 3, 2, 1, 0]);
         assert_eq!(range(200, -5).collect::<~[int]>(), ~[]);
-        assert_eq!(range(200, -5).invert().collect::<~[int]>(), ~[]);
+        assert_eq!(range(200, -5).flip().collect::<~[int]>(), ~[]);
         assert_eq!(range(200, 200).collect::<~[int]>(), ~[]);
-        assert_eq!(range(200, 200).invert().collect::<~[int]>(), ~[]);
+        assert_eq!(range(200, 200).flip().collect::<~[int]>(), ~[]);
 
         assert_eq!(range(0i, 100).size_hint(), (100, Some(100)));
         // this test is only meaningful when sizeof uint < sizeof u64
@@ -2902,11 +2902,11 @@ mod tests {
     #[test]
     fn test_range_inclusive() {
         assert_eq!(range_inclusive(0i, 5).collect::<~[int]>(), ~[0i, 1, 2, 3, 4, 5]);
-        assert_eq!(range_inclusive(0i, 5).invert().collect::<~[int]>(), ~[5i, 4, 3, 2, 1, 0]);
+        assert_eq!(range_inclusive(0i, 5).flip().collect::<~[int]>(), ~[5i, 4, 3, 2, 1, 0]);
         assert_eq!(range_inclusive(200, -5).collect::<~[int]>(), ~[]);
-        assert_eq!(range_inclusive(200, -5).invert().collect::<~[int]>(), ~[]);
+        assert_eq!(range_inclusive(200, -5).flip().collect::<~[int]>(), ~[]);
         assert_eq!(range_inclusive(200, 200).collect::<~[int]>(), ~[200]);
-        assert_eq!(range_inclusive(200, 200).invert().collect::<~[int]>(), ~[200]);
+        assert_eq!(range_inclusive(200, 200).flip().collect::<~[int]>(), ~[200]);
     }
 
     #[test]

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -670,7 +670,7 @@ pub trait DoubleEndedIterator<A>: Iterator<A> {
     /// Yield an element from the end of the range, returning `None` if the range is empty.
     fn next_back(&mut self) -> Option<A>;
 
-    /// Flip the direction of the iterator
+    /// Change the direction of the iterator
     ///
     /// The flipped iterator swaps the ends on an iterator that can already
     /// be iterated from the front and from the back.
@@ -683,8 +683,8 @@ pub trait DoubleEndedIterator<A>: Iterator<A> {
     /// Note: Random access with flipped indices still only applies to the first
     /// `uint::max_value` elements of the original iterator.
     #[inline]
-    fn flip(self) -> Flip<Self> {
-        Flip{iter: self}
+    fn rev(self) -> Rev<Self> {
+        Rev{iter: self}
     }
 }
 
@@ -759,30 +759,30 @@ pub trait ExactSize<A> : DoubleEndedIterator<A> {
 // Adaptors that may overflow in `size_hint` are not, i.e. `Chain`.
 impl<A, T: ExactSize<A>> ExactSize<(uint, A)> for Enumerate<T> {}
 impl<'a, A, T: ExactSize<A>> ExactSize<A> for Inspect<'a, A, T> {}
-impl<A, T: ExactSize<A>> ExactSize<A> for Flip<T> {}
+impl<A, T: ExactSize<A>> ExactSize<A> for Rev<T> {}
 impl<'a, A, B, T: ExactSize<A>> ExactSize<B> for Map<'a, A, B, T> {}
 impl<A, B, T: ExactSize<A>, U: ExactSize<B>> ExactSize<(A, B)> for Zip<T, U> {}
 
 /// An double-ended iterator with the direction inverted
 #[deriving(Clone)]
-pub struct Flip<T> {
+pub struct Rev<T> {
     priv iter: T
 }
 
-impl<A, T: DoubleEndedIterator<A>> Iterator<A> for Flip<T> {
+impl<A, T: DoubleEndedIterator<A>> Iterator<A> for Rev<T> {
     #[inline]
     fn next(&mut self) -> Option<A> { self.iter.next_back() }
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
-impl<A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for Flip<T> {
+impl<A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for Rev<T> {
     #[inline]
     fn next_back(&mut self) -> Option<A> { self.iter.next() }
 }
 
 impl<A, T: DoubleEndedIterator<A> + RandomAccessIterator<A>> RandomAccessIterator<A>
-    for Flip<T> {
+    for Rev<T> {
     #[inline]
     fn indexable(&self) -> uint { self.iter.indexable() }
     #[inline]
@@ -2590,12 +2590,12 @@ mod tests {
     }
 
     #[test]
-    fn test_flip() {
+    fn test_rev() {
         let xs = [2, 4, 6, 8, 10, 12, 14, 16];
         let mut it = xs.iter();
         it.next();
         it.next();
-        assert_eq!(it.flip().map(|&x| x).collect::<~[int]>(), ~[16, 14, 12, 10, 8, 6]);
+        assert_eq!(it.rev().map(|&x| x).collect::<~[int]>(), ~[16, 14, 12, 10, 8, 6]);
     }
 
     #[test]
@@ -2662,7 +2662,7 @@ mod tests {
     fn test_double_ended_chain() {
         let xs = [1, 2, 3, 4, 5];
         let ys = ~[7, 9, 11];
-        let mut it = xs.iter().chain(ys.iter()).flip();
+        let mut it = xs.iter().chain(ys.iter()).rev();
         assert_eq!(it.next().unwrap(), &11)
         assert_eq!(it.next().unwrap(), &9)
         assert_eq!(it.next_back().unwrap(), &1)
@@ -2764,10 +2764,10 @@ mod tests {
     }
 
     #[test]
-    fn test_random_access_flip() {
+    fn test_random_access_rev() {
         let xs = [1, 2, 3, 4, 5];
-        check_randacc_iter(xs.iter().flip(), xs.len());
-        let mut it = xs.iter().flip();
+        check_randacc_iter(xs.iter().rev(), xs.len());
+        let mut it = xs.iter().rev();
         it.next();
         it.next_back();
         it.next();
@@ -2833,13 +2833,13 @@ mod tests {
 
     #[test]
     fn test_double_ended_range() {
-        assert_eq!(range(11i, 14).flip().collect::<~[int]>(), ~[13i, 12, 11]);
-        for _ in range(10i, 0).flip() {
+        assert_eq!(range(11i, 14).rev().collect::<~[int]>(), ~[13i, 12, 11]);
+        for _ in range(10i, 0).rev() {
             fail!("unreachable");
         }
 
-        assert_eq!(range(11u, 14).flip().collect::<~[uint]>(), ~[13u, 12, 11]);
-        for _ in range(10u, 0).flip() {
+        assert_eq!(range(11u, 14).rev().collect::<~[uint]>(), ~[13u, 12, 11]);
+        for _ in range(10u, 0).rev() {
             fail!("unreachable");
         }
     }
@@ -2886,11 +2886,11 @@ mod tests {
 
         assert_eq!(range(0i, 5).collect::<~[int]>(), ~[0i, 1, 2, 3, 4]);
         assert_eq!(range(-10i, -1).collect::<~[int]>(), ~[-10, -9, -8, -7, -6, -5, -4, -3, -2]);
-        assert_eq!(range(0i, 5).flip().collect::<~[int]>(), ~[4, 3, 2, 1, 0]);
+        assert_eq!(range(0i, 5).rev().collect::<~[int]>(), ~[4, 3, 2, 1, 0]);
         assert_eq!(range(200, -5).collect::<~[int]>(), ~[]);
-        assert_eq!(range(200, -5).flip().collect::<~[int]>(), ~[]);
+        assert_eq!(range(200, -5).rev().collect::<~[int]>(), ~[]);
         assert_eq!(range(200, 200).collect::<~[int]>(), ~[]);
-        assert_eq!(range(200, 200).flip().collect::<~[int]>(), ~[]);
+        assert_eq!(range(200, 200).rev().collect::<~[int]>(), ~[]);
 
         assert_eq!(range(0i, 100).size_hint(), (100, Some(100)));
         // this test is only meaningful when sizeof uint < sizeof u64
@@ -2902,11 +2902,11 @@ mod tests {
     #[test]
     fn test_range_inclusive() {
         assert_eq!(range_inclusive(0i, 5).collect::<~[int]>(), ~[0i, 1, 2, 3, 4, 5]);
-        assert_eq!(range_inclusive(0i, 5).flip().collect::<~[int]>(), ~[5i, 4, 3, 2, 1, 0]);
+        assert_eq!(range_inclusive(0i, 5).rev().collect::<~[int]>(), ~[5i, 4, 3, 2, 1, 0]);
         assert_eq!(range_inclusive(200, -5).collect::<~[int]>(), ~[]);
-        assert_eq!(range_inclusive(200, -5).flip().collect::<~[int]>(), ~[]);
+        assert_eq!(range_inclusive(200, -5).rev().collect::<~[int]>(), ~[]);
         assert_eq!(range_inclusive(200, 200).collect::<~[int]>(), ~[200]);
-        assert_eq!(range_inclusive(200, 200).flip().collect::<~[int]>(), ~[200]);
+        assert_eq!(range_inclusive(200, 200).rev().collect::<~[int]>(), ~[200]);
     }
 
     #[test]

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -17,7 +17,7 @@ use clone::Clone;
 use container::Container;
 use cmp::Eq;
 use from_str::FromStr;
-use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Invert, Iterator, Map};
+use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Flip, Iterator, Map};
 use option::{Option, Some, None};
 use str;
 use str::{CharSplits, OwnedStr, Str, StrVector, StrSlice};
@@ -35,7 +35,7 @@ pub type StrComponents<'a> = Map<'a, &'a str, Option<&'a str>,
 ///
 /// Each component is yielded as Option<&str> for compatibility with PosixPath, but
 /// every component in WindowsPath is guaranteed to be Some.
-pub type RevStrComponents<'a> = Invert<Map<'a, &'a str, Option<&'a str>,
+pub type RevStrComponents<'a> = Flip<Map<'a, &'a str, Option<&'a str>,
                                                  CharSplits<'a, char>>>;
 
 /// Iterator that yields successive components of a Path as &[u8]
@@ -571,8 +571,8 @@ impl GenericPath for Path {
 
     fn ends_with_path(&self, child: &Path) -> bool {
         if !child.is_relative() { return false; }
-        let mut selfit = self.str_components().invert();
-        let mut childit = child.str_components().invert();
+        let mut selfit = self.str_components().flip();
+        let mut childit = child.str_components().flip();
         loop {
             match (selfit.next(), childit.next()) {
                 (Some(a), Some(b)) => if a != b { return false; },
@@ -628,7 +628,7 @@ impl Path {
     /// Returns an iterator that yields each component of the path in reverse as an Option<&str>
     /// See str_components() for details.
     pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
-        self.str_components().invert()
+        self.str_components().flip()
     }
 
     /// Returns an iterator that yields each component of the path in turn as a &[u8].

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -17,7 +17,7 @@ use clone::Clone;
 use container::Container;
 use cmp::Eq;
 use from_str::FromStr;
-use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Flip, Iterator, Map};
+use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Rev, Iterator, Map};
 use option::{Option, Some, None};
 use str;
 use str::{CharSplits, OwnedStr, Str, StrVector, StrSlice};
@@ -35,7 +35,7 @@ pub type StrComponents<'a> = Map<'a, &'a str, Option<&'a str>,
 ///
 /// Each component is yielded as Option<&str> for compatibility with PosixPath, but
 /// every component in WindowsPath is guaranteed to be Some.
-pub type RevStrComponents<'a> = Flip<Map<'a, &'a str, Option<&'a str>,
+pub type RevStrComponents<'a> = Rev<Map<'a, &'a str, Option<&'a str>,
                                                  CharSplits<'a, char>>>;
 
 /// Iterator that yields successive components of a Path as &[u8]
@@ -571,8 +571,8 @@ impl GenericPath for Path {
 
     fn ends_with_path(&self, child: &Path) -> bool {
         if !child.is_relative() { return false; }
-        let mut selfit = self.str_components().flip();
-        let mut childit = child.str_components().flip();
+        let mut selfit = self.str_components().rev();
+        let mut childit = child.str_components().rev();
         loop {
             match (selfit.next(), childit.next()) {
                 (Some(a), Some(b)) => if a != b { return false; },
@@ -628,7 +628,7 @@ impl Path {
     /// Returns an iterator that yields each component of the path in reverse as an Option<&str>
     /// See str_components() for details.
     pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
-        self.str_components().flip()
+        self.str_components().rev()
     }
 
     /// Returns an iterator that yields each component of the path in turn as a &[u8].

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -102,7 +102,7 @@ use clone::{Clone, DeepClone};
 use container::{Container, Mutable};
 use iter::{Iterator, FromIterator, Extendable, range};
 use iter::{Filter, AdditiveIterator, Map};
-use iter::{Flip, DoubleEndedIterator, ExactSize};
+use iter::{Rev, DoubleEndedIterator, ExactSize};
 use libc;
 use num::{Saturating};
 use option::{None, Option, Some};
@@ -376,11 +376,11 @@ impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsets<'a> {
 
 /// External iterator for a string's characters in reverse order.
 /// Use with the `std::iter` module.
-pub type RevChars<'a> = Flip<Chars<'a>>;
+pub type RevChars<'a> = Rev<Chars<'a>>;
 
 /// External iterator for a string's characters and their byte offsets in reverse order.
 /// Use with the `std::iter` module.
-pub type RevCharOffsets<'a> = Flip<CharOffsets<'a>>;
+pub type RevCharOffsets<'a> = Rev<CharOffsets<'a>>;
 
 /// External iterator for a string's bytes.
 /// Use with the `std::iter` module.
@@ -389,7 +389,7 @@ pub type Bytes<'a> =
 
 /// External iterator for a string's bytes in reverse order.
 /// Use with the `std::iter` module.
-pub type RevBytes<'a> = Flip<Bytes<'a>>;
+pub type RevBytes<'a> = Rev<Bytes<'a>>;
 
 /// An iterator over the substrings of a string, separated by `sep`.
 #[deriving(Clone)]
@@ -405,7 +405,7 @@ pub struct CharSplits<'a, Sep> {
 
 /// An iterator over the substrings of a string, separated by `sep`,
 /// starting from the back of the string.
-pub type RevCharSplits<'a, Sep> = Flip<CharSplits<'a, Sep>>;
+pub type RevCharSplits<'a, Sep> = Rev<CharSplits<'a, Sep>>;
 
 /// An iterator over the substrings of a string, separated by `sep`,
 /// splitting at most `count` times.
@@ -486,7 +486,7 @@ for CharSplits<'a, Sep> {
         let mut next_split = None;
 
         if self.only_ascii {
-            for (idx, byte) in self.string.bytes().enumerate().flip() {
+            for (idx, byte) in self.string.bytes().enumerate().rev() {
                 if self.sep.matches(byte as char) && byte < 128u8 {
                     next_split = Some((idx, idx + 1));
                     break;
@@ -1980,7 +1980,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn chars_rev(&self) -> RevChars<'a> {
-        self.chars().flip()
+        self.chars().rev()
     }
 
     #[inline]
@@ -1990,7 +1990,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn bytes_rev(&self) -> RevBytes<'a> {
-        self.bytes().flip()
+        self.bytes().rev()
     }
 
     #[inline]
@@ -2000,7 +2000,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn char_indices_rev(&self) -> RevCharOffsets<'a> {
-        self.char_indices().flip()
+        self.char_indices().rev()
     }
 
     #[inline]
@@ -2035,7 +2035,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn rsplit<Sep: CharEq>(&self, sep: Sep) -> RevCharSplits<'a, Sep> {
-        self.split(sep).flip()
+        self.split(sep).rev()
     }
 
     #[inline]
@@ -3789,11 +3789,11 @@ mod tests {
     fn test_rev_split_char_iterator_no_trailing() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let mut split: ~[&str] = data.split('\n').flip().collect();
+        let mut split: ~[&str] = data.split('\n').rev().collect();
         split.reverse();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb", ""]);
 
-        let mut split: ~[&str] = data.split_terminator('\n').flip().collect();
+        let mut split: ~[&str] = data.split_terminator('\n').rev().collect();
         split.reverse();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb"]);
     }

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -102,7 +102,7 @@ use clone::{Clone, DeepClone};
 use container::{Container, Mutable};
 use iter::{Iterator, FromIterator, Extendable, range};
 use iter::{Filter, AdditiveIterator, Map};
-use iter::{Invert, DoubleEndedIterator, ExactSize};
+use iter::{Flip, DoubleEndedIterator, ExactSize};
 use libc;
 use num::{Saturating};
 use option::{None, Option, Some};
@@ -376,11 +376,11 @@ impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsets<'a> {
 
 /// External iterator for a string's characters in reverse order.
 /// Use with the `std::iter` module.
-pub type RevChars<'a> = Invert<Chars<'a>>;
+pub type RevChars<'a> = Flip<Chars<'a>>;
 
 /// External iterator for a string's characters and their byte offsets in reverse order.
 /// Use with the `std::iter` module.
-pub type RevCharOffsets<'a> = Invert<CharOffsets<'a>>;
+pub type RevCharOffsets<'a> = Flip<CharOffsets<'a>>;
 
 /// External iterator for a string's bytes.
 /// Use with the `std::iter` module.
@@ -389,7 +389,7 @@ pub type Bytes<'a> =
 
 /// External iterator for a string's bytes in reverse order.
 /// Use with the `std::iter` module.
-pub type RevBytes<'a> = Invert<Bytes<'a>>;
+pub type RevBytes<'a> = Flip<Bytes<'a>>;
 
 /// An iterator over the substrings of a string, separated by `sep`.
 #[deriving(Clone)]
@@ -405,7 +405,7 @@ pub struct CharSplits<'a, Sep> {
 
 /// An iterator over the substrings of a string, separated by `sep`,
 /// starting from the back of the string.
-pub type RevCharSplits<'a, Sep> = Invert<CharSplits<'a, Sep>>;
+pub type RevCharSplits<'a, Sep> = Flip<CharSplits<'a, Sep>>;
 
 /// An iterator over the substrings of a string, separated by `sep`,
 /// splitting at most `count` times.
@@ -486,7 +486,7 @@ for CharSplits<'a, Sep> {
         let mut next_split = None;
 
         if self.only_ascii {
-            for (idx, byte) in self.string.bytes().enumerate().invert() {
+            for (idx, byte) in self.string.bytes().enumerate().flip() {
                 if self.sep.matches(byte as char) && byte < 128u8 {
                     next_split = Some((idx, idx + 1));
                     break;
@@ -1980,7 +1980,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn chars_rev(&self) -> RevChars<'a> {
-        self.chars().invert()
+        self.chars().flip()
     }
 
     #[inline]
@@ -1990,7 +1990,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn bytes_rev(&self) -> RevBytes<'a> {
-        self.bytes().invert()
+        self.bytes().flip()
     }
 
     #[inline]
@@ -2000,7 +2000,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn char_indices_rev(&self) -> RevCharOffsets<'a> {
-        self.char_indices().invert()
+        self.char_indices().flip()
     }
 
     #[inline]
@@ -2035,7 +2035,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn rsplit<Sep: CharEq>(&self, sep: Sep) -> RevCharSplits<'a, Sep> {
-        self.split(sep).invert()
+        self.split(sep).flip()
     }
 
     #[inline]
@@ -3789,11 +3789,11 @@ mod tests {
     fn test_rev_split_char_iterator_no_trailing() {
         let data = "\nMäry häd ä little lämb\nLittle lämb\n";
 
-        let mut split: ~[&str] = data.split('\n').invert().collect();
+        let mut split: ~[&str] = data.split('\n').flip().collect();
         split.reverse();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb", ""]);
 
-        let mut split: ~[&str] = data.split_terminator('\n').invert().collect();
+        let mut split: ~[&str] = data.split_terminator('\n').flip().collect();
         split.reverse();
         assert_eq!(split, ~["", "Märy häd ä little lämb", "Little lämb"]);
     }

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -728,7 +728,7 @@ mod test_map {
     fn test_each_reverse_break() {
         let mut m = TrieMap::new();
 
-        for x in range(uint::max_value - 10000, uint::max_value).flip() {
+        for x in range(uint::max_value - 10000, uint::max_value).rev() {
             m.insert(x, x / 2);
         }
 
@@ -781,7 +781,7 @@ mod test_map {
         let last = uint::max_value;
 
         let mut map = TrieMap::new();
-        for x in range(first, last).flip() {
+        for x in range(first, last).rev() {
             map.insert(x, x / 2);
         }
 
@@ -803,7 +803,7 @@ mod test_map {
         let last = uint::max_value;
 
         let mut map = TrieMap::new();
-        for x in range(first, last).flip() {
+        for x in range(first, last).rev() {
             map.insert(x, x / 2);
         }
 

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -728,7 +728,7 @@ mod test_map {
     fn test_each_reverse_break() {
         let mut m = TrieMap::new();
 
-        for x in range(uint::max_value - 10000, uint::max_value).invert() {
+        for x in range(uint::max_value - 10000, uint::max_value).flip() {
             m.insert(x, x / 2);
         }
 
@@ -781,7 +781,7 @@ mod test_map {
         let last = uint::max_value;
 
         let mut map = TrieMap::new();
-        for x in range(first, last).invert() {
+        for x in range(first, last).flip() {
             map.insert(x, x / 2);
         }
 
@@ -803,7 +803,7 @@ mod test_map {
         let last = uint::max_value;
 
         let mut map = TrieMap::new();
-        for x in range(first, last).invert() {
+        for x in range(first, last).flip() {
             map.insert(x, x / 2);
         }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1067,7 +1067,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
 
     #[inline]
     fn rev_iter(self) -> RevItems<'a, T> {
-        self.iter().invert()
+        self.iter().flip()
     }
 
     #[inline]
@@ -1464,7 +1464,7 @@ impl<T> OwnedVector<T> for ~[T] {
 
     #[inline]
     fn move_rev_iter(self) -> RevMoveItems<T> {
-        self.move_iter().invert()
+        self.move_iter().flip()
     }
 
     fn reserve(&mut self, n: uint) {
@@ -2300,7 +2300,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     fn mut_rev_iter(self) -> RevMutItems<'a, T> {
-        self.mut_iter().invert()
+        self.mut_iter().flip()
     }
 
     #[inline]
@@ -2714,7 +2714,7 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
 }
 
 iterator!{struct Items -> *T, &'a T}
-pub type RevItems<'a, T> = Invert<Items<'a, T>>;
+pub type RevItems<'a, T> = Flip<Items<'a, T>>;
 
 impl<'a, T> ExactSize<&'a T> for Items<'a, T> {}
 impl<'a, T> ExactSize<&'a mut T> for MutItems<'a, T> {}
@@ -2724,7 +2724,7 @@ impl<'a, T> Clone for Items<'a, T> {
 }
 
 iterator!{struct MutItems -> *mut T, &'a mut T}
-pub type RevMutItems<'a, T> = Invert<MutItems<'a, T>>;
+pub type RevMutItems<'a, T> = Flip<MutItems<'a, T>>;
 
 /// An iterator over the subslices of the vector which are separated
 /// by elements that match `pred`.
@@ -2882,7 +2882,7 @@ impl<T> Drop for MoveItems<T> {
 }
 
 /// An iterator that moves out of a vector in reverse order.
-pub type RevMoveItems<T> = Invert<MoveItems<T>>;
+pub type RevMoveItems<T> = Flip<MoveItems<T>>;
 
 impl<A> FromIterator<A> for ~[A] {
     fn from_iterator<T: Iterator<A>>(iterator: &mut T) -> ~[A] {
@@ -3985,7 +3985,7 @@ mod tests {
         assert_eq!(v.chunks(3).collect::<~[&[int]]>(), ~[&[1i,2,3], &[4,5]]);
         assert_eq!(v.chunks(6).collect::<~[&[int]]>(), ~[&[1i,2,3,4,5]]);
 
-        assert_eq!(v.chunks(2).invert().collect::<~[&[int]]>(), ~[&[5i], &[3,4], &[1,2]]);
+        assert_eq!(v.chunks(2).flip().collect::<~[&[int]]>(), ~[&[5i], &[3,4], &[1,2]]);
         let it = v.chunks(2);
         assert_eq!(it.indexable(), 3);
         assert_eq!(it.idx(0).unwrap(), &[1,2]);
@@ -4241,9 +4241,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_splitator_invert() {
+    fn test_mut_splitator_flip() {
         let mut xs = [1,2,0,3,4,0,0,5,6,0];
-        for slice in xs.mut_split(|x| *x == 0).invert().take(4) {
+        for slice in xs.mut_split(|x| *x == 0).flip().take(4) {
             slice.reverse();
         }
         assert_eq!(xs, [1,2,0,4,3,0,0,6,5,0]);
@@ -4262,9 +4262,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_chunks_invert() {
+    fn test_mut_chunks_flip() {
         let mut v = [0u8, 1, 2, 3, 4, 5, 6];
-        for (i, chunk) in v.mut_chunks(3).invert().enumerate() {
+        for (i, chunk) in v.mut_chunks(3).flip().enumerate() {
             for x in chunk.mut_iter() {
                 *x = i as u8;
             }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1067,7 +1067,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
 
     #[inline]
     fn rev_iter(self) -> RevItems<'a, T> {
-        self.iter().flip()
+        self.iter().rev()
     }
 
     #[inline]
@@ -1464,7 +1464,7 @@ impl<T> OwnedVector<T> for ~[T] {
 
     #[inline]
     fn move_rev_iter(self) -> RevMoveItems<T> {
-        self.move_iter().flip()
+        self.move_iter().rev()
     }
 
     fn reserve(&mut self, n: uint) {
@@ -2300,7 +2300,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     fn mut_rev_iter(self) -> RevMutItems<'a, T> {
-        self.mut_iter().flip()
+        self.mut_iter().rev()
     }
 
     #[inline]
@@ -2714,7 +2714,7 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
 }
 
 iterator!{struct Items -> *T, &'a T}
-pub type RevItems<'a, T> = Flip<Items<'a, T>>;
+pub type RevItems<'a, T> = Rev<Items<'a, T>>;
 
 impl<'a, T> ExactSize<&'a T> for Items<'a, T> {}
 impl<'a, T> ExactSize<&'a mut T> for MutItems<'a, T> {}
@@ -2724,7 +2724,7 @@ impl<'a, T> Clone for Items<'a, T> {
 }
 
 iterator!{struct MutItems -> *mut T, &'a mut T}
-pub type RevMutItems<'a, T> = Flip<MutItems<'a, T>>;
+pub type RevMutItems<'a, T> = Rev<MutItems<'a, T>>;
 
 /// An iterator over the subslices of the vector which are separated
 /// by elements that match `pred`.
@@ -2882,7 +2882,7 @@ impl<T> Drop for MoveItems<T> {
 }
 
 /// An iterator that moves out of a vector in reverse order.
-pub type RevMoveItems<T> = Flip<MoveItems<T>>;
+pub type RevMoveItems<T> = Rev<MoveItems<T>>;
 
 impl<A> FromIterator<A> for ~[A] {
     fn from_iterator<T: Iterator<A>>(iterator: &mut T) -> ~[A] {
@@ -3985,7 +3985,7 @@ mod tests {
         assert_eq!(v.chunks(3).collect::<~[&[int]]>(), ~[&[1i,2,3], &[4,5]]);
         assert_eq!(v.chunks(6).collect::<~[&[int]]>(), ~[&[1i,2,3,4,5]]);
 
-        assert_eq!(v.chunks(2).flip().collect::<~[&[int]]>(), ~[&[5i], &[3,4], &[1,2]]);
+        assert_eq!(v.chunks(2).rev().collect::<~[&[int]]>(), ~[&[5i], &[3,4], &[1,2]]);
         let it = v.chunks(2);
         assert_eq!(it.indexable(), 3);
         assert_eq!(it.idx(0).unwrap(), &[1,2]);
@@ -4241,9 +4241,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_splitator_flip() {
+    fn test_mut_splitator_rev() {
         let mut xs = [1,2,0,3,4,0,0,5,6,0];
-        for slice in xs.mut_split(|x| *x == 0).flip().take(4) {
+        for slice in xs.mut_split(|x| *x == 0).rev().take(4) {
             slice.reverse();
         }
         assert_eq!(xs, [1,2,0,4,3,0,0,6,5,0]);
@@ -4262,9 +4262,9 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_chunks_flip() {
+    fn test_mut_chunks_rev() {
         let mut v = [0u8, 1, 2, 3, 4, 5, 6];
-        for (i, chunk) in v.mut_chunks(3).flip().enumerate() {
+        for (i, chunk) in v.mut_chunks(3).rev().enumerate() {
             for x in chunk.mut_iter() {
                 *x = i as u8;
             }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -556,7 +556,7 @@ impl SyntaxEnv {
     }
 
     fn find_escape_frame<'a>(&'a mut self) -> &'a mut MapChainFrame {
-        for (i, frame) in self.chain.mut_iter().enumerate().flip() {
+        for (i, frame) in self.chain.mut_iter().enumerate().rev() {
             if !frame.info.macros_escape || i == 0 {
                 return frame
             }
@@ -565,7 +565,7 @@ impl SyntaxEnv {
     }
 
     pub fn find<'a>(&'a self, k: &Name) -> Option<&'a SyntaxExtension> {
-        for frame in self.chain.iter().flip() {
+        for frame in self.chain.iter().rev() {
             match frame.map.find(k) {
                 Some(v) => return Some(v),
                 None => {}

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -556,7 +556,7 @@ impl SyntaxEnv {
     }
 
     fn find_escape_frame<'a>(&'a mut self) -> &'a mut MapChainFrame {
-        for (i, frame) in self.chain.mut_iter().enumerate().invert() {
+        for (i, frame) in self.chain.mut_iter().enumerate().flip() {
             if !frame.info.macros_escape || i == 0 {
                 return frame
             }
@@ -565,7 +565,7 @@ impl SyntaxEnv {
     }
 
     pub fn find<'a>(&'a self, k: &Name) -> Option<&'a SyntaxExtension> {
-        for frame in self.chain.iter().invert() {
+        for frame in self.chain.iter().flip() {
             match frame.map.find(k) {
                 Some(v) => return Some(v),
                 None => {}

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -52,13 +52,13 @@ fn descending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
     println!(" Descending integers:");
 
     timed("insert", || {
-        for i in range(0, n_keys).invert() {
+        for i in range(0, n_keys).flip() {
             map.insert(i, i + 1);
         }
     });
 
     timed("search", || {
-        for i in range(0, n_keys).invert() {
+        for i in range(0, n_keys).flip() {
             assert_eq!(map.find(&i).unwrap(), &(i + 1));
         }
     });

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -52,13 +52,13 @@ fn descending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
     println!(" Descending integers:");
 
     timed("insert", || {
-        for i in range(0, n_keys).flip() {
+        for i in range(0, n_keys).rev() {
             map.insert(i, i + 1);
         }
     });
 
     timed("search", || {
-        for i in range(0, n_keys).flip() {
+        for i in range(0, n_keys).rev() {
             assert_eq!(map.find(&i).unwrap(), &(i + 1));
         }
     });

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -220,7 +220,7 @@ fn handle_sol(raw_sol: &List<u64>, data: &mut Data) -> bool {
     // reverse order, i.e. the board rotated by half a turn.
     data.nb += 2;
     let sol1 = to_utf8(raw_sol);
-    let sol2: ~str = sol1.chars().flip().collect();
+    let sol2: ~str = sol1.chars().rev().collect();
 
     if data.nb == 2 {
         data.min = sol1.clone();

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -220,7 +220,7 @@ fn handle_sol(raw_sol: &List<u64>, data: &mut Data) -> bool {
     // reverse order, i.e. the board rotated by half a turn.
     data.nb += 2;
     let sol1 = to_utf8(raw_sol);
-    let sol2: ~str = sol1.chars().invert().collect();
+    let sol2: ~str = sol1.chars().flip().collect();
 
     if data.nb == 2 {
         data.min = sol1.clone();


### PR DESCRIPTION
Renamed the `invert()` function in `iter.rs` to `flip()`, from #10632 

Also renamed the `Invert<T>` type to `Flip<T>`.

Some related code comments changed. Documentation that I could find has
been updated, and all the instances I could locate where the
function/type were called have been updated as well.

This is my first contribution to Rust! Apologies in advance if I've snarfed the 
PR process, I'm not used to rebase.

I initially had issues with the `codegen` section of the tests failing, however
the `make check` process is not reporting any failures at this time. I think
that was a local env issue more than me facerolling my changes. :)
