### PR TITLE
Scan the entire crate for exported macros

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1720,6 +1720,7 @@ impl<'a, 'b> Visitor<()> for MacroDefVisitor<'a, 'b> {
             }
             _ => {}
         }
+        visit::walk_item(self, item, ());
     }
 }
 

--- a/src/test/auxiliary/macro_export_inner_module.rs
+++ b/src/test/auxiliary/macro_export_inner_module.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(macro_rules)];
+
+pub mod inner {
+    #[macro_export]
+    macro_rules! foo(
+        () => (1)
+    )
+}

--- a/src/test/run-pass/macro-export-inner-module.rs
+++ b/src/test/run-pass/macro-export-inner-module.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//aux-build:macro_export_inner_module.rs
+//xfail-stage1
+//xfail-fast
+
+#[feature(phase)];
+
+#[phase(syntax)]
+extern mod macro_export_inner_module;
+
+pub fn main() {
+    assert_eq!(1, foo!());
+}


### PR DESCRIPTION
It previously missed anything in an inner module.
