### PR TITLE
Add support for ARM thumb architecture

### DIFF
--- a/src/librustc/back/arm.rs
+++ b/src/librustc/back/arm.rs
@@ -14,6 +14,11 @@ use metadata::loader::meta_section_name;
 use syntax::abi;
 
 pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::t {
+    let cc_args = if target_triple.contains("thumb") {
+        ~[~"-mthumb"]
+    } else {
+        ~[~"-marm"]
+    };
     return target_strs::t {
         module_asm: ~"",
 
@@ -63,6 +68,6 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
 
         target_triple: target_triple,
 
-        cc_args: ~[~"-marm"],
+        cc_args: cc_args,
     };
 }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -661,6 +661,7 @@ static architecture_abis : &'static [(&'static str, abi::Architecture)] = &'stat
 
     ("arm",    abi::Arm),
     ("xscale", abi::Arm),
+    ("thumb",  abi::Arm),
 
     ("mips",   abi::Mips)];
 


### PR DESCRIPTION
To build for the cortex-M series ARM processors LLC needs to be told to build for the thumb instruction set. There are two ways to do this, either with the triple "thumb*-*-*" or with -march=thumb (which just overrides the triple anyway). I chose the first way.

The following will fail because the local cc doesn't know what to do with -mthumb.

```
rustc test.rs --lib --target thumb-linux-eab
error: linking with `cc` failed: exit code: 1
note: cc: error: unrecognized command line option ‘-mthumb’
```

Changing the linker works as expected.

```
rustc test.rs --lib --target thumb-linux-eabi --linker arm-none-eabi-gcc
```

Ideally I'd have the triple thumb-none-eabi, but adding a new OS looks like much more work (and I'm not familiar enough with what it does to know if it is needed).
