### PR TITLE
Allow SIMD types in generics. Closes #10604

### DIFF
--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// xfail-fast
+
 #[feature(simd)];
 
 use std::ops;

--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(simd)];
+
 use std::ops;
 
 #[simd] struct f32x4(f32, f32, f32, f32);
@@ -22,7 +24,7 @@ impl ops::Add<f32x4, f32x4> for f32x4 {
     }
 }
 
-fn main() {
+pub fn main() {
     let lr = f32x4(1.0f32, 2.0f32, 3.0f32, 4.0f32);
 
     // lame-o

--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -1,0 +1,34 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops;
+
+#[simd] struct f32x4(f32, f32, f32, f32);
+
+fn add<T: ops::Add<T, T>>(lhs: T, rhs: T) -> T {
+    lhs + rhs
+}
+
+impl ops::Add<f32x4, f32x4> for f32x4 {
+    fn add(&self, rhs: &f32x4) -> f32x4 {
+        *self + *rhs
+    }
+}
+
+fn main() {
+    let lr = f32x4(1.0f32, 2.0f32, 3.0f32, 4.0f32);
+
+    // lame-o
+    let f32x4(x, y, z, w) = add(lr, lr);
+    assert_eq!(x, 2.0f32);
+    assert_eq!(y, 4.0f32);
+    assert_eq!(z, 6.0f32);
+    assert_eq!(w, 8.0f32);
+}

--- a/src/test/run-pass/simd-issue-10604.rs
+++ b/src/test/run-pass/simd-issue-10604.rs
@@ -7,6 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// xfail-fast
+
 #[allow(experimental)];
 #[feature(simd)];
 

--- a/src/test/run-pass/simd-issue-10604.rs
+++ b/src/test/run-pass/simd-issue-10604.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _o = None::<std::unstable::simd::i32x4>;
+}

--- a/src/test/run-pass/simd-issue-10604.rs
+++ b/src/test/run-pass/simd-issue-10604.rs
@@ -7,7 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#[allow(experimental)];
+#[feature(simd)];
 
-fn main() {
+pub fn main() {
     let _o = None::<std::unstable::simd::i32x4>;
 }


### PR DESCRIPTION
Note that it still doesn't allow generic types to be marked with #[simd].
