### PR TITLE
Redo exported macro serialization

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -420,7 +420,7 @@ impl CrateLoader for Loader {
         }
     }
 
-    fn get_exported_macros(&mut self, cnum: ast::CrateNum) -> ~[@ast::Item] {
+    fn get_exported_macros(&mut self, cnum: ast::CrateNum) -> ~[~str] {
         csearch::get_exported_macros(self.env.sess.cstore, cnum)
     }
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -310,7 +310,7 @@ pub fn get_macro_registrar_fn(cstore: @cstore::CStore,
 
 pub fn get_exported_macros(cstore: @cstore::CStore,
                            crate_num: ast::CrateNum)
-                           -> ~[@ast::Item] {
+                           -> ~[~str] {
     let cdata = cstore.get_crate_data(crate_num);
     decoder::get_exported_macros(cdata)
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -23,7 +23,6 @@ use metadata::tydecode::{parse_ty_data, parse_def_id,
 use middle::ty::{ImplContainer, TraitContainer};
 use middle::ty;
 use middle::typeck;
-use middle::astencode;
 use middle::astencode::vtable_decoder_helpers;
 
 use std::at_vec;
@@ -1282,12 +1281,12 @@ pub fn get_macro_registrar_fn(cdata: Cmd) -> Option<ast::DefId> {
         .map(|doc| item_def_id(doc, cdata))
 }
 
-pub fn get_exported_macros(cdata: Cmd) -> ~[@ast::Item] {
+pub fn get_exported_macros(cdata: Cmd) -> ~[~str] {
     let macros = reader::get_doc(reader::Doc(cdata.data()),
                                  tag_exported_macros);
     let mut result = ~[];
     reader::tagged_docs(macros, tag_macro_def, |macro_doc| {
-        result.push(astencode::decode_exported_macro(macro_doc));
+        result.push(macro_doc.as_str());
         true
     });
     result

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2678,6 +2678,7 @@ pub fn crate_ctxt_to_encode_parms<'r>(cx: &'r CrateContext, ie: encoder::encode_
             cstore: cx.sess.cstore,
             encode_inlined_item: ie,
             reachable: cx.reachable,
+            codemap: cx.sess.codemap,
         }
 }
 

--- a/src/librustpkg/util.rs
+++ b/src/librustpkg/util.rs
@@ -626,7 +626,7 @@ impl<'a> base::CrateLoader for CrateLoader<'a> {
         self.loader.load_crate(crate)
     }
 
-    fn get_exported_macros(&mut self, cnum: ast::CrateNum) -> ~[@ast::Item] {
+    fn get_exported_macros(&mut self, cnum: ast::CrateNum) -> ~[~str] {
         self.loader.get_exported_macros(cnum)
     }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -299,7 +299,7 @@ pub struct MacroCrate {
 
 pub trait CrateLoader {
     fn load_crate(&mut self, crate: &ast::ViewItem) -> MacroCrate;
-    fn get_exported_macros(&mut self, crate_num: ast::CrateNum) -> ~[@ast::Item];
+    fn get_exported_macros(&mut self, crate_num: ast::CrateNum) -> ~[~str];
     fn get_registrar_symbol(&mut self, crate_num: ast::CrateNum) -> Option<~str>;
 }
 

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -250,7 +250,6 @@ pub mod rt {
                 @"<quote expansion>",
                 s,
                 self.cfg(),
-                ~[],
                 self.parse_sess());
             match res {
                 Some(ast) => ast,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -130,10 +130,10 @@ pub fn parse_item_from_source_str(
     name: @str,
     source: @str,
     cfg: ast::CrateConfig,
-    attrs: ~[ast::Attribute],
     sess: @ParseSess
 ) -> Option<@ast::Item> {
     let mut p = new_parser_from_source_str(sess, cfg, name, source);
+    let attrs = p.parse_outer_attributes();
     maybe_aborted(p.parse_item(attrs),p)
 }
 


### PR DESCRIPTION
The old method of serializing the AST gives totally bogus spans if the
expansion of an imported macro causes compilation errors. The best
solution seems to be to serialize the actual textual macro definition
and load it the same way the std-macros are. I'm not totally confident
that getting the source from the CodeMap will always do the right thing,
but it seems to work in simple cases.
