### PR TITLE
Compiling with debug logging is never end.

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -211,17 +211,14 @@ pub fn get_field_type(tcx: ty::ctxt, class_id: ast::DefId,
     let cstore = tcx.cstore;
     let cdata = cstore.get_crate_data(class_id.crate);
     let all_items = reader::get_doc(reader::Doc(cdata.data()), tag_items);
-    debug!("Looking up {:?}", class_id);
     let class_doc = expect(tcx.diag,
                            decoder::maybe_find_item(class_id.node, all_items),
                            || format!("get_field_type: class ID {:?} not found",
                                    class_id) );
-    debug!("looking up {:?} : {:?}", def, class_doc);
     let the_field = expect(tcx.diag,
         decoder::maybe_find_item(def.node, class_doc),
         || format!("get_field_type: in class {:?}, field ID {:?} not found",
                  class_id, def) );
-    debug!("got field data {:?}", the_field);
     let ty = decoder::item_type(def, the_field, tcx, cdata);
     ty::ty_param_bounds_and_ty {
         generics: ty::Generics {type_param_defs: @~[],


### PR DESCRIPTION
When there is `println!` macro in the code, compiling is never end.

``` rust
// print.rs
fn main() {
  println!("Hello!");
}
```

``` bash
$ RUST_LOG=rustc rustc print.rs
```

And this is a part of output from stderr.

``` bash
# ...
Looking up syntax::ast::DefId{crate: 1u32, node: 176234u32}
looking up syntax::ast::DefId{crate: 1u32, node: 176235u32} : extra::ebml::Doc<>{data: &[168u8, 16u8, 0u8, 0u8, 16u8, 51u8, 101u8, 53u8, 97u8, 101u8, 98u8, 56u8, 51u8, 55u8, 97u8, 101u8, 49u8, 54u8, 50u8
# ...
# vector which has infinite length.
```
- note : rust 0.9, 0.10-pre
