### PR TITLE
native: Don't use timerfd on Android

### DIFF
--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -48,11 +48,11 @@ pub mod net;
 
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "android")]
 #[path = "timer_other.rs"]
 pub mod timer;
 
 #[cfg(target_os = "linux")]
-#[cfg(target_os = "android")]
 #[path = "timer_timerfd.rs"]
 pub mod timer;
 

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -301,6 +301,7 @@ mod imp {
     }
 }
 
+#[cfg(target_os = "android")]
 #[cfg(target_os = "freebsd")]
 mod imp {
     use std::libc;


### PR DESCRIPTION
It doesn't seem to exist.
