### PR TITLE
Implement an unused result lint

### DIFF
--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -486,7 +486,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
                 (errno <<  8) as u8,
                 (errno <<  0) as u8,
             ];
-            output.inner_write(bytes);
+            assert!(output.inner_write(bytes).is_ok());
             intrinsics::abort();
         })
     }

--- a/src/libnative/io/timer_helper.rs
+++ b/src/libnative/io/timer_helper.rs
@@ -101,7 +101,7 @@ mod imp {
     }
 
     pub fn signal(fd: libc::c_int) {
-        FileDesc::new(fd, false).inner_write([0]);
+        FileDesc::new(fd, false).inner_write([0]).unwrap();
     }
 
     pub fn close(fd: libc::c_int) {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -187,7 +187,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
 
                 // drain the file descriptor
                 let mut buf = [0];
-                fd.inner_read(buf);
+                fd.inner_read(buf).unwrap();
             }
 
             -1 if os::errno() == libc::EINTR as int => {}

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -98,7 +98,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
             if fd == input {
                 let mut buf = [0, ..1];
                 // drain the input file descriptor of its input
-                FileDesc::new(fd, false).inner_read(buf);
+                FileDesc::new(fd, false).inner_read(buf).unwrap();
                 incoming = true;
             } else {
                 let mut bits = [0, ..8];
@@ -106,7 +106,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
                 //
                 // FIXME: should this perform a send() this number of
                 //      times?
-                FileDesc::new(fd, false).inner_read(bits);
+                FileDesc::new(fd, false).inner_read(bits).unwrap();
                 let remove = {
                     match map.find(&fd).expect("fd unregistered") {
                         &(ref c, oneshot) => !c.try_send(()) || oneshot

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -389,7 +389,7 @@ impl Drop for FileWatcher {
                 }
             }
             rtio::CloseSynchronously => {
-                execute_nop(|req, cb| unsafe {
+                let _ = execute_nop(|req, cb| unsafe {
                     uvll::uv_fs_close(self.loop_.handle, req, self.fd, cb)
                 });
             }

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -175,7 +175,7 @@ impl File {
     ///
     /// This function will raise on the `io_error` condition on failure.
     pub fn fsync(&mut self) {
-        self.fd.fsync().map_err(|e| io_error::cond.raise(e));
+        let _ = self.fd.fsync().map_err(|e| io_error::cond.raise(e));
     }
 
     /// This function is similar to `fsync`, except that it may not synchronize
@@ -187,7 +187,7 @@ impl File {
     ///
     /// This function will raise on the `io_error` condition on failure.
     pub fn datasync(&mut self) {
-        self.fd.datasync().map_err(|e| io_error::cond.raise(e));
+        let _ = self.fd.datasync().map_err(|e| io_error::cond.raise(e));
     }
 
     /// Either truncates or extends the underlying file, updating the size of
@@ -203,7 +203,7 @@ impl File {
     ///
     /// On error, this function will raise on the `io_error` condition.
     pub fn truncate(&mut self, size: i64) {
-        self.fd.truncate(size).map_err(|e| io_error::cond.raise(e));
+        let _ = self.fd.truncate(size).map_err(|e| io_error::cond.raise(e));
     }
 
     /// Tests whether this stream has reached EOF.

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -20,6 +20,7 @@ use to_str::ToStr;
 
 /// `Result` is a type that represents either success (`Ok`) or failure (`Err`).
 #[deriving(Clone, DeepClone, Eq, Ord, TotalEq, TotalOrd, ToStr)]
+#[must_use]
 pub enum Result<T, E> {
     /// Contains the success value
     Ok(T),

--- a/src/test/compile-fail/unused-result.rs
+++ b/src/test/compile-fail/unused-result.rs
@@ -1,0 +1,40 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deny(unused_result, unused_must_use)];
+#[allow(dead_code)];
+
+#[must_use]
+enum MustUse { Test }
+
+fn foo<T>() -> T { fail!() }
+
+fn bar() -> int { return foo::<int>(); }
+fn baz() -> MustUse { return foo::<MustUse>(); }
+
+#[allow(unused_result)]
+fn test() {
+    foo::<int>();
+    foo::<MustUse>(); //~ ERROR: unused result which must be used
+}
+
+#[allow(unused_result, unused_must_use)]
+fn test2() {
+    foo::<int>();
+    foo::<MustUse>();
+}
+
+fn main() {
+    foo::<int>(); //~ ERROR: unused result
+    foo::<MustUse>(); //~ ERROR: unused result which must be used
+
+    let _ = foo::<int>();
+    let _ = foo::<MustUse>();
+}


### PR DESCRIPTION
The general consensus is that we want to move away from conditions for I/O, and I propose a two-step plan for doing so:
1. Warn about unused `Result` types. When all of I/O returns `Result`, it will require you inspect the return value for an error _only if_ you have a result you want to look at. By default, for things like `write` returning `Result<(), Error>`, these will all go silently ignored. This lint will prevent blind ignorance of these return values, letting you know that there's something you should do about them.
2. Implement a `try!` macro:

```
macro_rules! try( ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) }) )
```

With these two tools combined, I feel that we get almost all the benefits of conditions. The first step (the lint) is a sanity check that you're not ignoring return values at callsites. The second step is to provide a convenience method of returning early out of a sequence of computations. After thinking about this for awhile, I don't think that we need the so-called "do-notation" in the compiler itself because I think it's just _too_ specialized. Additionally, the `try!` macro is super lightweight, easy to understand, and works almost everywhere. As soon as you want to do something more fancy, my answer is "use match".

Basically, with these two tools in action, I would be comfortable removing conditions. What do others think about this strategy?

---

This PR specifically implements the `unused_result` lint. I actually added two lints, `unused_result` and `unused_must_use`, and the first commit has the rationale for why `unused_result` is turned off by default.
