### PR TITLE
Make size_of, align_of, and element_offset functions return u64 instead of uint in trans::machine

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1646,7 +1646,7 @@ fn set_members_of_composite_type(cx: &CrateContext,
         .map(|(i, member_description)| {
             let (member_size, member_align) = size_and_align_of(cx, member_description.llvm_type);
             let member_offset = match member_description.offset {
-                FixedMemberOffset { bytes } => bytes,
+                FixedMemberOffset { bytes } => bytes as u64,
                 ComputedMemberOffset => machine::llelement_offset(cx, composite_llvm_type, i)
             };
 
@@ -1815,7 +1815,7 @@ fn fixed_vec_metadata(cx: &CrateContext,
     return unsafe {
         llvm::LLVMDIBuilderCreateArrayType(
             DIB(cx),
-            bytes_to_bits(element_type_size * len),
+            bytes_to_bits(element_type_size * (len as u64)),
             bytes_to_bits(element_type_align),
             element_type_metadata,
             subscripts)
@@ -2211,11 +2211,11 @@ fn span_start(cx: &CrateContext, span: Span) -> codemap::Loc {
     cx.sess.codemap.lookup_char_pos(span.lo)
 }
 
-fn size_and_align_of(cx: &CrateContext, llvm_type: Type) -> (uint, uint) {
+fn size_and_align_of(cx: &CrateContext, llvm_type: Type) -> (u64, u64) {
     (machine::llsize_of_alloc(cx, llvm_type), machine::llalign_of_min(cx, llvm_type))
 }
 
-fn bytes_to_bits(bytes: uint) -> c_ulonglong {
+fn bytes_to_bits(bytes: u64) -> c_ulonglong {
     (bytes * 8) as c_ulonglong
 }
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -341,7 +341,7 @@ pub fn trans_native_call<'a>(
             let llalign = cmp::min(llforeign_align, llrust_align);
             debug!("llrust_size={:?}", llrust_size);
             base::call_memcpy(bcx, llretptr_i8, llscratch_i8,
-                              C_uint(ccx, llrust_size), llalign as u32);
+                              C_uint(ccx, llrust_size as uint), llalign as u32);
         }
     }
 

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -247,7 +247,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
         "size_of" => {
             let tp_ty = substs.tys[0];
             let lltp_ty = type_of::type_of(ccx, tp_ty);
-            Ret(bcx, C_uint(ccx, machine::llsize_of_real(ccx, lltp_ty)));
+            Ret(bcx, C_uint(ccx, machine::llsize_of_real(ccx, lltp_ty) as uint));
         }
         "move_val_init" => {
             // Create a datum reflecting the value being moved.
@@ -266,12 +266,12 @@ pub fn trans_intrinsic(ccx: @CrateContext,
         "min_align_of" => {
             let tp_ty = substs.tys[0];
             let lltp_ty = type_of::type_of(ccx, tp_ty);
-            Ret(bcx, C_uint(ccx, machine::llalign_of_min(ccx, lltp_ty)));
+            Ret(bcx, C_uint(ccx, machine::llalign_of_min(ccx, lltp_ty) as uint));
         }
         "pref_align_of"=> {
             let tp_ty = substs.tys[0];
             let lltp_ty = type_of::type_of(ccx, tp_ty);
-            Ret(bcx, C_uint(ccx, machine::llalign_of_pref(ccx, lltp_ty)));
+            Ret(bcx, C_uint(ccx, machine::llalign_of_pref(ccx, lltp_ty) as uint));
         }
         "get_tydesc" => {
             let tp_ty = substs.tys[0];
@@ -337,7 +337,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
                         _ => fail!("transmute has non-expr arg"),
                     }
                 };
-                let pluralize = |n| if 1u == n { "" } else { "s" };
+                let pluralize = |n| if 1 == n { "" } else { "s" };
                 ccx.sess.span_fatal(sp,
                                     format!("transmute called on types with \
                                           different sizes: {} ({} bit{}) to \

--- a/src/librustc/middle/trans/machine.rs
+++ b/src/librustc/middle/trans/machine.rs
@@ -21,17 +21,17 @@ use middle::trans::type_::Type;
 // compute sizeof / alignof
 
 // Returns the number of bytes clobbered by a Store to this type.
-pub fn llsize_of_store(cx: &CrateContext, ty: Type) -> uint {
+pub fn llsize_of_store(cx: &CrateContext, ty: Type) -> u64 {
     unsafe {
-        return llvm::LLVMStoreSizeOfType(cx.td.lltd, ty.to_ref()) as uint;
+        return llvm::LLVMStoreSizeOfType(cx.td.lltd, ty.to_ref()) as u64;
     }
 }
 
 // Returns the number of bytes between successive elements of type T in an
 // array of T. This is the "ABI" size. It includes any ABI-mandated padding.
-pub fn llsize_of_alloc(cx: &CrateContext, ty: Type) -> uint {
+pub fn llsize_of_alloc(cx: &CrateContext, ty: Type) -> u64 {
     unsafe {
-        return llvm::LLVMABISizeOfType(cx.td.lltd, ty.to_ref()) as uint;
+        return llvm::LLVMABISizeOfType(cx.td.lltd, ty.to_ref()) as u64;
     }
 }
 
@@ -43,12 +43,12 @@ pub fn llsize_of_alloc(cx: &CrateContext, ty: Type) -> uint {
 // that LLVM *does* distinguish between e.g. a 1-bit value and an 8-bit value
 // at the codegen level! In general you should prefer `llbitsize_of_real`
 // below.
-pub fn llsize_of_real(cx: &CrateContext, ty: Type) -> uint {
+pub fn llsize_of_real(cx: &CrateContext, ty: Type) -> u64 {
     unsafe {
-        let nbits = llvm::LLVMSizeOfTypeInBits(cx.td.lltd, ty.to_ref()) as uint;
-        if nbits & 7u != 0u {
+        let nbits = llvm::LLVMSizeOfTypeInBits(cx.td.lltd, ty.to_ref()) as u64;
+        if nbits & 7 != 0 {
             // Not an even number of bytes, spills into "next" byte.
-            1u + (nbits >> 3)
+            1 + (nbits >> 3)
         } else {
             nbits >> 3
         }
@@ -56,9 +56,9 @@ pub fn llsize_of_real(cx: &CrateContext, ty: Type) -> uint {
 }
 
 /// Returns the "real" size of the type in bits.
-pub fn llbitsize_of_real(cx: &CrateContext, ty: Type) -> uint {
+pub fn llbitsize_of_real(cx: &CrateContext, ty: Type) -> u64 {
     unsafe {
-        llvm::LLVMSizeOfTypeInBits(cx.td.lltd, ty.to_ref()) as uint
+        llvm::LLVMSizeOfTypeInBits(cx.td.lltd, ty.to_ref()) as u64
     }
 }
 
@@ -71,7 +71,7 @@ pub fn llsize_of(cx: &CrateContext, ty: Type) -> ValueRef {
     // there's no need for that contrivance.  The instruction
     // selection DAG generator would flatten that GEP(1) node into a
     // constant of the type's alloc size, so let's save it some work.
-    return C_uint(cx, llsize_of_alloc(cx, ty));
+    return C_uint(cx, llsize_of_alloc(cx, ty) as uint);
 }
 
 // Returns the "default" size of t (see above), or 1 if the size would
@@ -89,18 +89,18 @@ pub fn nonzero_llsize_of(cx: &CrateContext, ty: Type) -> ValueRef {
 // The preferred alignment may be larger than the alignment used when
 // packing the type into structs. This will be used for things like
 // allocations inside a stack frame, which LLVM has a free hand in.
-pub fn llalign_of_pref(cx: &CrateContext, ty: Type) -> uint {
+pub fn llalign_of_pref(cx: &CrateContext, ty: Type) -> u64 {
     unsafe {
-        return llvm::LLVMPreferredAlignmentOfType(cx.td.lltd, ty.to_ref()) as uint;
+        return llvm::LLVMPreferredAlignmentOfType(cx.td.lltd, ty.to_ref()) as u64;
     }
 }
 
 // Returns the minimum alignment of a type required by the platform.
 // This is the alignment that will be used for struct fields, arrays,
 // and similar ABI-mandated things.
-pub fn llalign_of_min(cx: &CrateContext, ty: Type) -> uint {
+pub fn llalign_of_min(cx: &CrateContext, ty: Type) -> u64 {
     unsafe {
-        return llvm::LLVMABIAlignmentOfType(cx.td.lltd, ty.to_ref()) as uint;
+        return llvm::LLVMABIAlignmentOfType(cx.td.lltd, ty.to_ref()) as u64;
     }
 }
 
@@ -114,8 +114,8 @@ pub fn llalign_of(cx: &CrateContext, ty: Type) -> ValueRef {
     }
 }
 
-pub fn llelement_offset(cx: &CrateContext, struct_ty: Type, element: uint) -> uint {
+pub fn llelement_offset(cx: &CrateContext, struct_ty: Type, element: uint) -> u64 {
     unsafe {
-        return llvm::LLVMOffsetOfElement(cx.td.lltd, struct_ty.to_ref(), element as u32) as uint;
+        return llvm::LLVMOffsetOfElement(cx.td.lltd, struct_ty.to_ref(), element as u32) as u64;
     }
 }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -73,8 +73,8 @@ impl<'a> Reflector<'a> {
         let tr = type_of(self.bcx.ccx(), t);
         let s = machine::llsize_of_real(self.bcx.ccx(), tr);
         let a = machine::llalign_of_min(self.bcx.ccx(), tr);
-        return ~[self.c_uint(s),
-             self.c_uint(a)];
+        return ~[self.c_uint(s as uint),
+             self.c_uint(a as uint)];
     }
 
     pub fn c_tydesc(&mut self, t: ty::t) -> ValueRef {

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -164,7 +164,7 @@ pub struct VecTypes {
     unit_ty: ty::t,
     llunit_ty: Type,
     llunit_size: ValueRef,
-    llunit_alloc_size: uint
+    llunit_alloc_size: u64
 }
 
 impl VecTypes {


### PR DESCRIPTION
For #5172
