### PR TITLE
Add a lint for non-exported local types in visible type signatures.

### DIFF
--- a/src/libextra/btree.rs
+++ b/src/libextra/btree.rs
@@ -22,10 +22,10 @@
 ///number of elements that a given node can contain.
 #[allow(missing_doc)]
 pub struct BTree<K, V> {
-    root: Node<K, V>,
-    len: uint,
-    lower_bound: uint,
-    upper_bound: uint
+    priv root: Node<K, V>,
+    priv len: uint,
+    priv lower_bound: uint,
+    priv upper_bound: uint
 }
 
 //We would probably want to remove the dependence on the Clone trait in the future.
@@ -47,9 +47,9 @@ impl<K: TotalOrd, V> BTree<K, V> {
 
     ///Helper function for clone: returns new BTree with supplied root node,
     ///length, and lower bound.  For use when the length is known already.
-    pub fn new_with_node_len(n: Node<K, V>,
-                             length: uint,
-                             lb: uint) -> BTree<K, V> {
+    fn new_with_node_len(n: Node<K, V>,
+                         length: uint,
+                         lb: uint) -> BTree<K, V> {
         BTree {
             root: n,
             len: length,
@@ -590,4 +590,3 @@ mod test_btree {
     }
 
 }
-

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -202,7 +202,8 @@ pub struct TestOpts {
     logfile: Option<Path>
 }
 
-type OptRes = Result<TestOpts, ~str>;
+/// Result of parsing the options.
+pub type OptRes = Result<TestOpts, ~str>;
 
 fn optgroups() -> ~[getopts::groups::OptGroup] {
     ~[groups::optflag("", "ignored", "Run ignored tests"),
@@ -722,7 +723,8 @@ enum TestEvent {
     TeResult(TestDesc, TestResult),
 }
 
-type MonitorMsg = (TestDesc, TestResult);
+/// The message sent to the test monitor from the individual runners.
+pub type MonitorMsg = (TestDesc, TestResult);
 
 fn run_tests(opts: &TestOpts,
              tests: ~[TestDescAndFn],

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[allow(missing_doc)];
+#[allow(visible_local_types)];
 
 use json;
 use json::ToJson;

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -166,9 +166,9 @@ pub struct SchedPool {
 /// keep track of how many tasks are currently running in the pool and then
 /// sending on a channel once the entire pool has been drained of all tasks.
 #[deriving(Clone)]
-struct TaskState {
-    cnt: UnsafeArc<AtomicUint>,
-    done: SharedChan<()>,
+pub struct TaskState {
+    priv cnt: UnsafeArc<AtomicUint>,
+    priv done: SharedChan<()>,
 }
 
 impl SchedPool {

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -40,52 +40,52 @@ pub struct Scheduler {
     /// reawoken on the wrong pool of schedulers.
     pool_id: uint,
     /// There are N work queues, one per scheduler.
-    work_queue: deque::Worker<~GreenTask>,
+    priv work_queue: deque::Worker<~GreenTask>,
     /// Work queues for the other schedulers. These are created by
     /// cloning the core work queues.
-    work_queues: ~[deque::Stealer<~GreenTask>],
+    priv work_queues: ~[deque::Stealer<~GreenTask>],
     /// The queue of incoming messages from other schedulers.
     /// These are enqueued by SchedHandles after which a remote callback
     /// is triggered to handle the message.
-    message_queue: mpsc::Consumer<SchedMessage, ()>,
+    priv message_queue: mpsc::Consumer<SchedMessage, ()>,
     /// Producer used to clone sched handles from
-    message_producer: mpsc::Producer<SchedMessage, ()>,
+    priv message_producer: mpsc::Producer<SchedMessage, ()>,
     /// A shared list of sleeping schedulers. We'll use this to wake
     /// up schedulers when pushing work onto the work queue.
-    sleeper_list: SleeperList,
+    priv sleeper_list: SleeperList,
     /// Indicates that we have previously pushed a handle onto the
     /// SleeperList but have not yet received the Wake message.
     /// Being `true` does not necessarily mean that the scheduler is
     /// not active since there are multiple event sources that may
     /// wake the scheduler. It just prevents the scheduler from pushing
     /// multiple handles onto the sleeper list.
-    sleepy: bool,
+    priv sleepy: bool,
     /// A flag to indicate we've received the shutdown message and should
     /// no longer try to go to sleep, but exit instead.
-    no_sleep: bool,
+    priv no_sleep: bool,
     stack_pool: StackPool,
     /// The scheduler runs on a special task. When it is not running
     /// it is stored here instead of the work queue.
-    sched_task: Option<~GreenTask>,
+    priv sched_task: Option<~GreenTask>,
     /// An action performed after a context switch on behalf of the
     /// code running before the context switch
-    cleanup_job: Option<CleanupJob>,
+    priv cleanup_job: Option<CleanupJob>,
     /// If the scheduler shouldn't run some tasks, a friend to send
     /// them to.
-    friend_handle: Option<SchedHandle>,
+    priv friend_handle: Option<SchedHandle>,
     /// Should this scheduler run any task, or only pinned tasks?
-    run_anything: bool,
+    priv run_anything: bool,
     /// A fast XorShift rng for scheduler use
-    rng: XorShiftRng,
+    priv rng: XorShiftRng,
     /// A togglable idle callback
-    idle_callback: Option<~PausableIdleCallback>,
+    priv idle_callback: Option<~PausableIdleCallback>,
     /// A countdown that starts at a random value and is decremented
     /// every time a yield check is performed. When it hits 0 a task
     /// will yield.
-    yield_check_count: uint,
+    priv yield_check_count: uint,
     /// A flag to tell the scheduler loop it needs to do some stealing
     /// in order to introduce randomness as part of a yield
-    steal_for_yield: bool,
+    priv steal_for_yield: bool,
     /// Bookeeping for the number of tasks which are currently running around
     /// inside this pool of schedulers
     task_state: TaskState,

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -62,7 +62,7 @@ pub mod timer;
 
 mod timer_helper;
 
-type IoResult<T> = Result<T, IoError>;
+pub type IoResult<T> = Result<T, IoError>;
 
 fn unimpl() -> IoError {
     IoError {

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -45,6 +45,7 @@ pub struct Timer {
     priv on_worker: bool,
 }
 
+#[allow(visible_local_types)]
 pub enum Req {
     NewTimer(libc::c_int, Chan<()>, bool, imp::itimerspec),
     RemoveTimer(libc::c_int, Chan<()>),

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -331,7 +331,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     }
 
     time(time_passes, "lint checking", (), |_|
-         lint::check_crate(ty_cx, method_map, &exported_items, crate));
+         lint::check_crate(ty_cx, method_map, &exported_items, &public_items, crate));
 
     CrateAnalysis {
         exp_map2: exp_map2,

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,6 +29,8 @@ This API is completely unstable and subject to change.
 
 #[feature(macro_rules, globs, struct_variant, managed_boxes)];
 
+#[allow(visible_local_types)];
+
 extern mod extra;
 extern mod syntax;
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1544,8 +1544,14 @@ impl<'a> Visitor<()> for Context<'a> {
         })
     }
 
-    // FIXME(#10894) should continue recursing
-    fn visit_ty(&mut self, _t: &ast::Ty, _: ()) {}
+    fn visit_ty(&mut self, t: &ast::Ty, _: ()) {
+        match t.node {
+            // FIXME(#10894) should continue recursing through fixed
+            // length vectors
+            ast::TyFixedLengthVec(ty, _) => self.visit_ty(ty, ()),
+            _ => visit::walk_ty(self, t, ())
+        }
+    }
 }
 
 impl<'a> IdVisitingOperation for Context<'a> {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -98,7 +98,7 @@ pub enum ExternalLocation {
 }
 
 /// Different ways an implementor of a trait can be rendered.
-enum Implementor {
+pub enum Implementor {
     /// Paths are displayed specially by omitting the `impl XX for` cruft
     PathType(clean::Type),
     /// This is the generic representation of an trait implementor, used for

--- a/src/librustpkg/lib.rs
+++ b/src/librustpkg/lib.rs
@@ -15,6 +15,7 @@
 #[crate_type = "dylib"];
 
 #[feature(globs, managed_boxes)];
+#[allow(visible_local_types)];
 
 extern mod extra;
 extern mod rustc;

--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -133,7 +133,7 @@ fn each_ai_flag(_f: |c_int, ai::Flag|) {
 }
 
 // Traverse the addrinfo linked list, producing a vector of Rust socket addresses
-pub fn accum_addrinfo(addr: &Addrinfo) -> ~[ai::Info] {
+fn accum_addrinfo(addr: &Addrinfo) -> ~[ai::Info] {
     unsafe {
         let mut addr = addr.handle;
 

--- a/src/librustuv/homing.rs
+++ b/src/librustuv/homing.rs
@@ -53,6 +53,7 @@ pub struct HomeHandle {
 }
 
 impl HomeHandle {
+    #[allow(visible_local_types)]
     pub fn new(id: uint, pool: &mut QueuePool) -> HomeHandle {
         HomeHandle { queue: pool.queue(), id: id }
     }

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -65,6 +65,8 @@ pub use self::signal::SignalWatcher;
 pub use self::timer::TimerWatcher;
 pub use self::tty::TtyWatcher;
 
+pub use self::homing::HomeHandle;
+
 mod macros;
 
 mod queue;

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -243,7 +243,7 @@ use vec::OwnedVector;
 use spsc = sync::spsc_queue;
 use mpsc = sync::mpsc_queue;
 
-pub use self::select::Select;
+pub use self::select::{Select, Handle};
 
 macro_rules! test (
     { fn $name:ident() $b:block $($a:attr)*} => (

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -89,6 +89,7 @@ pub struct Select {
 /// This handle is used to keep the port in the set as well as interact with the
 /// underlying port.
 pub struct Handle<'port, T> {
+    /// A unique ID for this Handle.
     id: uint,
     priv selector: &'port Select,
     priv port: &'port mut Port<T>,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1268,7 +1268,7 @@ pub trait Acceptor<T> {
 /// The Some contains another Option representing whether the connection attempt was succesful.
 /// A successful connection will be wrapped in Some.
 /// A failed connection is represented as a None and raises a condition.
-struct IncomingConnections<'a, A> {
+pub struct IncomingConnections<'a, A> {
     priv inc: &'a mut A,
 }
 

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -113,10 +113,10 @@ pub mod logging;
 pub mod crate_map;
 
 /// The runtime needs to be able to put a pointer into thread-local storage.
-mod local_ptr;
+pub mod local_ptr;
 
 /// Bindings to pthread/windows thread-local storage.
-mod thread_local_storage;
+pub mod thread_local_storage;
 
 /// Stack unwinding
 pub mod unwind;

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -265,6 +265,7 @@ fn rust_exception_class() -> uw::_Unwind_Exception_Class {
 
 #[cfg(not(target_arch = "arm"), not(test))]
 #[doc(hidden)]
+#[allow(visible_local_types)]
 pub mod eabi {
     use uw = super::libunwind;
     use libc::c_int;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -620,7 +620,7 @@ enum NormalizationForm {
 /// External iterator for a string's normalization's characters.
 /// Use with the `std::iter` module.
 #[deriving(Clone)]
-struct Normalizations<'a> {
+pub struct Normalizations<'a> {
     priv kind: NormalizationForm,
     priv iter: Chars<'a>,
     priv buffer: ~[(char, u8)],

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -47,7 +47,7 @@ pub enum Architecture {
 static IntelBits: u32 = (1 << (X86 as uint)) | (1 << (X86_64 as uint));
 static ArmBits: u32 = (1 << (Arm as uint));
 
-struct AbiData {
+pub struct AbiData {
     abi: Abi,
 
     // Name of this ABI as we like it called.
@@ -58,7 +58,7 @@ struct AbiData {
     abi_arch: AbiArchitecture
 }
 
-enum AbiArchitecture {
+pub enum AbiArchitecture {
     RustArch,   // Not a real ABI (e.g., intrinsic)
     AllArch,    // An ABI that specifies cross-platform defaults (e.g., "C")
     Archs(u32)  // Multiple architectures (bitset)

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -56,7 +56,7 @@ pub type SyntaxExpanderTTFunNoCtxt =
     fn(ecx: &mut ExtCtxt, span: codemap::Span, token_tree: &[ast::TokenTree])
        -> MacResult;
 
-enum SyntaxExpanderTTExpander {
+pub enum SyntaxExpanderTTExpander {
     SyntaxExpanderTTExpanderWithoutContext(SyntaxExpanderTTFunNoCtxt),
 }
 
@@ -75,7 +75,7 @@ impl SyntaxExpanderTTTrait for SyntaxExpanderTT {
     }
 }
 
-enum SyntaxExpanderTTItemExpander {
+pub enum SyntaxExpanderTTItemExpander {
     SyntaxExpanderTTItemExpanderWithContext(SyntaxExpanderTTItemFun),
     SyntaxExpanderTTItemExpanderWithoutContext(SyntaxExpanderTTItemFunNoCtxt),
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -620,8 +620,8 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
 // from a given thingy and puts them in a mutable
 // array (passed in to the traversal)
 #[deriving(Clone)]
-struct NewNameFinderContext {
-    ident_accumulator: ~[ast::Ident],
+pub struct NewNameFinderContext {
+    priv ident_accumulator: ~[ast::Ident],
 }
 
 impl Visitor<()> for NewNameFinderContext {
@@ -710,8 +710,8 @@ pub fn expand_block_elts(b: &Block, fld: &mut MacroExpander) -> P<Block> {
     })
 }
 
-struct IdentRenamer<'a> {
-    renames: &'a mut RenameList,
+pub struct IdentRenamer<'a> {
+    priv renames: &'a mut RenameList,
 }
 
 impl<'a> Folder for IdentRenamer<'a> {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -87,14 +87,14 @@ use std::vec;
 
 #[allow(non_camel_case_types)]
 #[deriving(Eq)]
-enum restriction {
+pub enum restriction {
     UNRESTRICTED,
     RESTRICT_STMT_EXPR,
     RESTRICT_NO_BAR_OP,
     RESTRICT_NO_BAR_OR_DOUBLEBAR_OP,
 }
 
-type ItemInfo = (Ident, Item_, Option<~[Attribute]>);
+pub type ItemInfo = (Ident, Item_, Option<~[Attribute]>);
 
 /// How to parse a path. There are four different kinds of paths, all of which
 /// are parsed somewhat differently.
@@ -116,13 +116,13 @@ pub enum PathParsingMode {
 
 /// A pair of a path segment and group of type parameter bounds. (See `ast.rs`
 /// for the definition of a path segment.)
-struct PathSegmentAndBoundSet {
+pub struct PathSegmentAndBoundSet {
     segment: ast::PathSegment,
     bound_set: Option<OptVec<TyParamBound>>,
 }
 
 /// A path paired with optional type bounds.
-struct PathAndBounds {
+pub struct PathAndBounds {
     path: ast::Path,
     bounds: Option<OptVec<TyParamBound>>,
 }

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -139,12 +139,12 @@ pub fn buf_str(toks: ~[Token], szs: ~[int], left: uint, right: uint,
     return s;
 }
 
-enum PrintStackBreak {
+pub enum PrintStackBreak {
     Fits,
     Broken(Breaks),
 }
 
-struct PrintStackElem {
+pub struct PrintStackElem {
     offset: int,
     pbreak: PrintStackBreak
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -951,7 +951,7 @@ pub fn print_block_with_attrs(s: &mut State,
                                   true);
 }
 
-enum EmbedType {
+pub enum EmbedType {
     BlockBlockFn,
     BlockNormal,
 }

--- a/src/test/compile-fail/lint-visible-local-types.rs
+++ b/src/test/compile-fail/lint-visible-local-types.rs
@@ -1,0 +1,100 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deny(visible_local_types)];
+#[allow(dead_code, unused_variable)];
+
+pub use Reexport = Reexported;
+
+struct Private;
+struct Reexported;
+pub struct Public;
+
+
+trait PrivTrait {
+    fn ok_1(&self, ok_1: Public, ok_2: Reexported, ok_3: Private) {}
+    fn ok_2(&self, ok_1: Public, ok_2: Reexported, ok_3: Private);
+}
+
+impl PrivTrait for Public {
+    fn ok_2(&self, ok_1: Public, ok_2: Reexported, ok_3: Private) {}
+}
+
+pub trait PubTrait {
+    fn err_1(&self,
+             ok_1: Public,
+             ok_2: Reexported,
+             err: Private) {} //~ ERROR non-exported type used in exported method signature
+
+    fn err_2(&self, err: Private);  //~ ERROR non-exported type used in exported method signature
+}
+
+impl PubTrait for Option<Private> {
+    fn err_2(&self, ok: Private) {}
+}
+
+impl Private {
+    pub fn ok() -> Private { Private }
+}
+impl Public {
+    pub fn err() -> Private { //~ ERROR non-exported type used in exported method signature
+        Private
+    }
+}
+
+pub struct PublicStruct {
+    priv ok_1: Private,
+
+    ok_2: Public,
+    ok_3: Reexported,
+    err: Private //~ ERROR non-exported type used in exported struct field
+}
+
+struct PrivateStruct {
+    ok_1: Public,
+    ok_2: Private
+}
+
+
+pub enum PublicEnum {
+    priv PubOk1(Private),
+
+    PubOk2(Public),
+    PubOk3(Reexported),
+    PubErr(Private) //~ ERROR non-exported type used in exported enum variant
+}
+
+enum PrivateEnum {
+    PrivOk1(Private),
+    PrivOk2(Public),
+
+    pub PrivOk3(Public),
+    pub PrivOk4(Reexported),
+    pub PrivErr(Private) // FIXME #11680 (ERROR non-exported type used in exported enum variant)
+}
+
+pub fn public_fn<Ok: PrivTrait>(
+    ok_1: Public,
+    ok_2: &PrivTrait,
+    ok_3: Reexported,
+    err_1: Private, //~ ERROR non-exported type used in exported function signature
+    err_2: || -> Private //~ ERROR non-exported type used in exported function signature
+        ) -> Option<Private> { //~ ERROR non-exported type used in exported function signature
+    None
+}
+
+fn private_fn<Ok: PrivTrait>(
+    ok_1: Public,
+    ok_2: Private,
+    ok_3: &PrivTrait,
+    ok_4: || -> Private
+        ) -> Option<Private> {
+    None
+}


### PR DESCRIPTION
Except for traits, to allow them to be used as closed type-classes and/or PIMPL-style polymorphic trait objects

``` rust
struct Private;
pub fn warning(x: Private) {}

trait Priv {}
pub fn ok<T: Priv>() {}
```
