### PR TITLE
Move macro_rules! macros to libstd

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -75,6 +75,8 @@
 #[cfg(test)] pub use kinds = realstd::kinds;
 #[cfg(test)] pub use ops = realstd::ops;
 #[cfg(test)] pub use cmp = realstd::cmp;
+
+mod macros;
 
 mod rtdeps;
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -1,0 +1,192 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#[macro_escape];
+
+#[macro_export]
+macro_rules! ignore (($($x:tt)*) => (()))
+
+#[macro_export]
+macro_rules! log(
+    ($lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= __log_level() {
+            format_args!(|args| {
+                ::std::logging::log(lvl, args)
+            }, $($arg)+)
+        }
+    })
+)
+#[macro_export]
+macro_rules! error( ($($arg:tt)*) => (log!(1u32, $($arg)*)) )
+#[macro_export]
+macro_rules! warn ( ($($arg:tt)*) => (log!(2u32, $($arg)*)) )
+#[macro_export]
+macro_rules! info ( ($($arg:tt)*) => (log!(3u32, $($arg)*)) )
+#[macro_export]
+macro_rules! debug( ($($arg:tt)*) => (
+    if cfg!(not(ndebug)) { log!(4u32, $($arg)*) }
+))
+
+#[macro_export]
+macro_rules! log_enabled(
+    ($lvl:expr) => ( {
+        let lvl = $lvl;
+        lvl <= __log_level() && (lvl != 4 || cfg!(not(ndebug)))
+    } )
+)
+
+#[macro_export]
+macro_rules! fail(
+    () => (
+        fail!("explicit failure")
+    );
+    ($msg:expr) => (
+        ::std::rt::begin_unwind($msg, file!(), line!())
+    );
+    ($fmt:expr, $($arg:tt)*) => (
+        ::std::rt::begin_unwind(format!($fmt, $($arg)*), file!(), line!())
+    )
+)
+
+#[macro_export]
+macro_rules! assert(
+    ($cond:expr) => {
+        if !$cond {
+            fail!("assertion failed: {:s}", stringify!($cond))
+        }
+    };
+    ($cond:expr, $msg:expr) => {
+        if !$cond {
+            fail!($msg)
+        }
+    };
+    ($cond:expr, $( $arg:expr ),+) => {
+        if !$cond {
+            fail!( $($arg),+ )
+        }
+    }
+)
+
+#[macro_export]
+macro_rules! assert_eq (
+    ($given:expr , $expected:expr) => (
+        {
+            let given_val = &($given);
+            let expected_val = &($expected);
+            // check both directions of equality....
+            if !((*given_val == *expected_val) &&
+                 (*expected_val == *given_val)) {
+                fail!("assertion failed: `(left == right) && (right == left)` \
+                       (left: `{:?}`, right: `{:?}`)", *given_val, *expected_val)
+            }
+        }
+    )
+)
+
+/// A utility macro for indicating unreachable code. It will fail if
+/// executed. This is occasionally useful to put after loops that never
+/// terminate normally, but instead directly return from a function.
+///
+/// # Example
+///
+/// ```rust
+/// fn choose_weighted_item(v: &[Item]) -> Item {
+///     assert!(!v.is_empty());
+///     let mut so_far = 0u;
+///     for item in v.iter() {
+///         so_far += item.weight;
+///         if so_far > 100 {
+///             return item;
+///         }
+///     }
+///     // The above loop always returns, so we must hint to the
+///     // type checker that it isn't possible to get down here
+///     unreachable!();
+/// }
+/// ```
+#[macro_export]
+macro_rules! unreachable (() => (
+    fail!("internal error: entered unreachable code");
+))
+
+#[macro_export]
+macro_rules! condition (
+
+    { pub $c:ident: $input:ty -> $out:ty; } => {
+
+        pub mod $c {
+            #[allow(unused_imports)];
+            #[allow(non_uppercase_statics)];
+            #[allow(missing_doc)];
+
+            use super::*;
+
+            local_data_key!(key: @::std::condition::Handler<$input, $out>)
+
+            pub static cond :
+                ::std::condition::Condition<$input,$out> =
+                ::std::condition::Condition {
+                    name: stringify!($c),
+                    key: key
+                };
+        }
+    };
+
+    { $c:ident: $input:ty -> $out:ty; } => {
+
+        mod $c {
+            #[allow(unused_imports)];
+            #[allow(non_uppercase_statics)];
+            #[allow(dead_code)];
+
+            use super::*;
+
+            local_data_key!(key: @::std::condition::Handler<$input, $out>)
+
+            pub static cond :
+                ::std::condition::Condition<$input,$out> =
+                ::std::condition::Condition {
+                    name: stringify!($c),
+                    key: key
+                };
+        }
+    }
+)
+
+#[macro_export]
+macro_rules! format(($($arg:tt)*) => (
+    format_args!(::std::fmt::format, $($arg)*)
+))
+#[macro_export]
+macro_rules! write(($dst:expr, $($arg:tt)*) => (
+    format_args!(|args| { ::std::fmt::write($dst, args) }, $($arg)*)
+))
+#[macro_export]
+macro_rules! writeln(($dst:expr, $($arg:tt)*) => (
+    format_args!(|args| { ::std::fmt::writeln($dst, args) }, $($arg)*)
+))
+#[macro_export]
+macro_rules! print (
+    ($($arg:tt)*) => (format_args!(::std::io::stdio::print_args, $($arg)*))
+)
+#[macro_export]
+macro_rules! println (
+    ($($arg:tt)*) => (format_args!(::std::io::stdio::println_args, $($arg)*))
+)
+
+#[macro_export]
+macro_rules! local_data_key (
+    ($name:ident: $ty:ty) => (
+        static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
+    );
+    (pub $name:ident: $ty:ty) => (
+        pub static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
+    )
+)

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -10,9 +10,6 @@
 #[macro_escape];
 
 #[macro_export]
-macro_rules! ignore (($($x:tt)*) => (()))
-
-#[macro_export]
 macro_rules! log(
     ($lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -11,9 +11,7 @@
 // error-pattern:mismatched types: expected `char` but found
 // Issue #876
 
-#[no_std];
-
-extern mod std;
+#[no_implicit_prelude];
 
 fn last<T>(v: ~[&T]) -> std::option::Option<T> {
     fail!();


### PR DESCRIPTION
They all have to go into a single module at the moment unfortunately.
Ideally, the logging macros would live in std::logging, condition! would
live in std::condition, format! in std::fmt, etc. However, this
introduces cyclic dependencies between those modules and the macros they
use which the current expansion system can't deal with. We may be able
to get around this by changing the expansion phase to a two-pass system
but that's for a later PR.

Closes #2247
cc #11763
