### PR TITLE
Fix a spuriously tripped assert in select()

### DIFF
--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -199,11 +199,14 @@ impl Select {
                 if (*packet).decrement() {
                     Ok(())
                 } else {
+                    // Empty to_wake first to avoid tripping an assertion in
+                    // abort_selection in the disconnected case.
+                    let task = (*packet).to_wake.take_unwrap();
                     (*packet).abort_selection(false);
                     (*packet).selecting.store(false, SeqCst);
                     ready_index = i;
                     ready_id = (*packet).selection_id;
-                    Err((*packet).to_wake.take_unwrap())
+                    Err(task)
                 }
             });
 


### PR DESCRIPTION
The race here happened when a port had its deschedule in select() canceled, but
the other chan had already been dropped. This meant that the DISCONNECTED case
was hit in abort_selection, but the to_wake cell hadn't been emptied yet (this
was done after aborting), causing an assert in abort_selection to trip.

To fix this, the to_wake cell is just emptied before abort_selection is called
(we know that we're the owner of it already).
