### PR TITLE
Change struct fields to inherit privacy of the struct

### DIFF
--- a/doc/guide-container.md
+++ b/doc/guide-container.md
@@ -90,7 +90,7 @@ Reaching the end of the iterator is signalled by returning `None` instead of
 # fn main() {}
 /// A stream of N zeroes
 struct ZeroStream {
-    priv remaining: uint
+    remaining: uint
 }
 
 impl ZeroStream {
@@ -305,7 +305,7 @@ The `ZeroStream` from earlier can provide an exact lower and upper bound:
 # fn main() {}
 /// A stream of N zeroes
 struct ZeroStream {
-    priv remaining: uint
+    remaining: uint
 }
 
 impl ZeroStream {

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -148,7 +148,7 @@ impl<T:Freeze + Send> Clone for Arc<T> {
  ****************************************************************************/
 
 #[doc(hidden)]
-struct MutexArcInner<T> { priv lock: Mutex, priv failed: bool, priv data: T }
+struct MutexArcInner<T> { lock: Mutex, failed: bool, data: T }
 
 /// An Arc with mutable data protected by a blocking mutex.
 #[no_freeze]
@@ -312,7 +312,7 @@ impl PoisonOnFail {
  ****************************************************************************/
 
 #[doc(hidden)]
-struct RWArcInner<T> { priv lock: RWLock, priv failed: bool, priv data: T }
+struct RWArcInner<T> { lock: RWLock, failed: bool, data: T }
 /**
  * A dual-mode Arc protected by a reader-writer lock. The data can be accessed
  * mutably or immutably, and immutably-accessing tasks may run concurrently.

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -38,12 +38,12 @@ pub struct DList<T> {
 }
 
 type Link<T> = Option<~Node<T>>;
-struct Rawlink<T> { priv p: *mut T }
+struct Rawlink<T> { p: *mut T }
 
 struct Node<T> {
-    priv next: Link<T>,
-    priv prev: Rawlink<Node<T>>,
-    priv value: T,
+    next: Link<T>,
+    prev: Rawlink<Node<T>>,
+    value: T,
 }
 
 /// Double-ended DList iterator

--- a/src/libextra/lru_cache.rs
+++ b/src/libextra/lru_cache.rs
@@ -43,13 +43,13 @@ use std::to_bytes::Cb;
 use std::ptr;
 use std::cast;
 
-struct KeyRef<K> { priv k: *K }
+struct KeyRef<K> { k: *K }
 
 struct LruEntry<K, V> {
-    priv key: Option<K>,
-    priv value: Option<V>,
-    priv next: *mut LruEntry<K, V>,
-    priv prev: *mut LruEntry<K, V>,
+    key: Option<K>,
+    value: Option<V>,
+    next: *mut LruEntry<K, V>,
+    prev: *mut LruEntry<K, V>,
 }
 
 /// An LRU Cache.

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -709,8 +709,8 @@ pub struct Barrier {
 
 // The inner state of a double barrier
 struct BarrierState {
-    priv count: uint,
-    priv generation_id: uint,
+    count: uint,
+    generation_id: uint,
 }
 
 impl Barrier {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -257,7 +257,7 @@ pub type ctxt = @ctxt_;
 /// The data structure to keep track of all the information that typechecker
 /// generates so that so that it can be reused and doesn't have to be redone
 /// later on.
-struct ctxt_ {
+pub struct ctxt_ {
     diag: @syntax::diagnostic::SpanHandler,
     interner: RefCell<HashMap<intern_key, ~t_box_>>,
     next_id: Cell<uint>,

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -109,8 +109,8 @@ trait FixedBuffer {
 
 /// A FixedBuffer of 64 bytes useful for implementing Sha256 which has a 64 byte blocksize.
 struct FixedBuffer64 {
-    priv buffer: [u8, ..64],
-    priv buffer_idx: uint,
+    buffer: [u8, ..64],
+    buffer_idx: uint,
 }
 
 impl FixedBuffer64 {

--- a/src/librustpkg/package_source.rs
+++ b/src/librustpkg/package_source.rs
@@ -78,8 +78,8 @@ fn prefixes(p: &Path) -> Prefixes {
 }
 
 struct Prefixes {
-    priv components: ~[~str],
-    priv remaining: ~[~str]
+    components: ~[~str],
+    remaining: ~[~str]
 }
 
 impl Iterator<(Path, Path)> for Prefixes {

--- a/src/librustuv/homing.rs
+++ b/src/librustuv/homing.rs
@@ -126,7 +126,7 @@ pub trait HomingIO {
 /// task back to its appropriate home (if applicable). The field is used to
 /// assert that we are where we think we are.
 struct HomingMissile {
-    priv io_home: uint,
+    io_home: uint,
 }
 
 impl HomingMissile {

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -95,7 +95,7 @@ pub struct Handle<'port, T> {
     priv port: &'port mut Port<T>,
 }
 
-struct Packets { priv cur: *mut Packet }
+struct Packets { cur: *mut Packet }
 
 impl Select {
     /// Creates a new selection structure. This set is initially empty and

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -122,7 +122,7 @@ struct PathSegmentAndBoundSet {
 }
 
 /// A path paired with optional type bounds.
-struct PathAndBounds {
+pub struct PathAndBounds {
     path: ast::Path,
     bounds: Option<OptVec<TyParamBound>>,
 }

--- a/src/test/auxiliary/iss.rs
+++ b/src/test/auxiliary/iss.rs
@@ -13,7 +13,7 @@
 // part of issue-6919.rs
 
 struct C<'a> {
-    k: 'a ||,
+    pub k: 'a ||,
 }
 
 fn no_op() { }

--- a/src/test/auxiliary/struct-field-privacy.rs
+++ b/src/test/auxiliary/struct-field-privacy.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A {
+    a: int,
+    pub b: int,
+}
+
+pub struct B {
+    a: int,
+    priv b: int,
+}

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -18,8 +18,8 @@ fn iterate<'a, T>(x: T, f: 'a |&T| -> T) -> Iterate<'a, T> {
     Iterate {f: f, next: x}
 }
 struct Iterate<'a, T> {
-    priv f: 'a |&T| -> T,
-    priv next: T
+    f: 'a |&T| -> T,
+    next: T
 }
 impl<'a, T> Iterator<T> for Iterate<'a, T> {
     fn next(&mut self) -> Option<T> {
@@ -35,7 +35,7 @@ enum List<'a, T> {
     Cons(T, &'a List<'a, T>)
 }
 struct ListIterator<'a, T> {
-    priv cur: &'a List<'a, T>
+    cur: &'a List<'a, T>
 }
 impl<'a, T> List<'a, T> {
     fn iter(&'a self) -> ListIterator<'a, T> {

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -20,7 +20,7 @@
 
 struct Foo {
     a: int,
-    priv b: int,
+    b: int,
 }
 
 pub struct PubFoo { //~ ERROR: missing documentation
@@ -99,7 +99,7 @@ mod a {
 enum Baz {
     BazA {
         a: int,
-        priv b: int
+        b: int
     },
     BarB
 }

--- a/src/test/compile-fail/mutable-class-fields-2.rs
+++ b/src/test/compile-fail/mutable-class-fields-2.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-  priv meows : uint,
+  meows : uint,
 
   how_hungry : int,
 }

--- a/src/test/compile-fail/mutable-class-fields.rs
+++ b/src/test/compile-fail/mutable-class-fields.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-  priv meows : uint,
+  meows : uint,
   how_hungry : int,
 }
 

--- a/src/test/compile-fail/struct-field-privacy.rs
+++ b/src/test/compile-fail/struct-field-privacy.rs
@@ -1,0 +1,51 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:struct-field-privacy.rs
+
+extern mod xc = "struct-field-privacy";
+
+struct A {
+    a: int,
+}
+
+mod inner {
+    struct A {
+        a: int,
+        pub b: int,
+        priv c: int, //~ ERROR: unnecessary `priv` visibility
+    }
+    pub struct B {
+        a: int,
+        priv b: int,
+        pub c: int, //~ ERROR: unnecessary `pub` visibility
+    }
+}
+
+fn test(a: A, b: inner::A, c: inner::B, d: xc::A, e: xc::B) {
+    //~^ ERROR: type `A` is private
+    //~^^ ERROR: struct `A` is private
+
+    a.a;
+    b.a; //~ ERROR: field `a` is private
+    b.b;
+    b.c; //~ ERROR: field `c` is private
+    c.a;
+    c.b; //~ ERROR: field `b` is private
+    c.c;
+
+    d.a; //~ ERROR: field `a` is private
+    d.b;
+
+    e.a;
+    e.b; //~ ERROR: field `b` is private
+}
+
+fn main() {}

--- a/src/test/compile-fail/useless-priv.rs
+++ b/src/test/compile-fail/useless-priv.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct A { pub i: int }         //~ ERROR: unnecessary `pub`
-struct B { priv i: int }        // don't warn b/c B can still be returned
+struct A { pub i: int }
+struct B { priv i: int }        //~ ERROR: unnecessary `priv`
 pub enum C { pub Variant }      //~ ERROR: unnecessary `pub`
 enum D { priv Variant2 }        //~ ERROR: unnecessary `priv`
 

--- a/src/test/run-pass/class-cast-to-trait-multiple-types.rs
+++ b/src/test/run-pass/class-cast-to-trait-multiple-types.rs
@@ -15,7 +15,7 @@ trait noisy {
 }
 
 struct dog {
-  priv barks: uint,
+  barks: uint,
 
   volume: int,
 }
@@ -50,7 +50,7 @@ fn dog() -> dog {
 
 #[deriving(Clone)]
 struct cat {
-  priv meows: uint,
+  meows: uint,
 
   how_hungry: int,
   name: ~str,

--- a/src/test/run-pass/class-cast-to-trait.rs
+++ b/src/test/run-pass/class-cast-to-trait.rs
@@ -15,7 +15,7 @@ trait noisy {
 }
 
 struct cat {
-  priv meows: uint,
+  meows: uint,
   how_hungry: int,
   name: ~str,
 }

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -27,7 +27,7 @@ impl cmp::Eq for cat_type {
 // ok: T should be in scope when resolving the trait ref for map
 struct cat<T> {
     // Yes, you can have negative meows
-    priv meows : int,
+    meows : int,
 
     how_hungry : int,
     name : T,

--- a/src/test/run-pass/class-implement-trait-cross-crate.rs
+++ b/src/test/run-pass/class-implement-trait-cross-crate.rs
@@ -14,7 +14,7 @@ extern mod cci_class_trait;
 use cci_class_trait::animals::noisy;
 
 struct cat {
-  priv meows: uint,
+  meows: uint,
 
   how_hungry : int,
   name : ~str,

--- a/src/test/run-pass/class-implement-traits.rs
+++ b/src/test/run-pass/class-implement-traits.rs
@@ -16,7 +16,7 @@ trait noisy {
 
 #[deriving(Clone)]
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
     name : ~str,

--- a/src/test/run-pass/class-methods.rs
+++ b/src/test/run-pass/class-methods.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-  priv meows : uint,
+  meows : uint,
 
   how_hungry : int,
 }

--- a/src/test/run-pass/class-poly-methods.rs
+++ b/src/test/run-pass/class-poly-methods.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 struct cat<U> {
-    priv info : ~[U],
-    priv meows : uint,
+    info : ~[U],
+    meows : uint,
 
     how_hungry : int,
 }

--- a/src/test/run-pass/class-separate-impl.rs
+++ b/src/test/run-pass/class-separate-impl.rs
@@ -12,7 +12,7 @@
 
 // xfail-fast
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
     name : ~str,

--- a/src/test/run-pass/class-typarams.rs
+++ b/src/test/run-pass/class-typarams.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat<U> {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
 }

--- a/src/test/run-pass/classes-simple-method.rs
+++ b/src/test/run-pass/classes-simple-method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
 }

--- a/src/test/run-pass/classes-simple.rs
+++ b/src/test/run-pass/classes-simple.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
 }

--- a/src/test/run-pass/classes.rs
+++ b/src/test/run-pass/classes.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
     name : ~str,

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -47,8 +47,8 @@ struct Rect {
 struct AsciiArt {
     width: uint,
     height: uint,
-    priv fill: char,
-    priv lines: ~[~[char]],
+    fill: char,
+    lines: ~[~[char]],
 
     // This struct can be quite large so we'll disable copying: developers need
     // to either pass these structs around via references or move them.

--- a/src/test/run-pass/private-class-field.rs
+++ b/src/test/run-pass/private-class-field.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
 }

--- a/src/test/run-pass/private-method.rs
+++ b/src/test/run-pass/private-method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct cat {
-    priv meows : uint,
+    meows : uint,
 
     how_hungry : int,
 }


### PR DESCRIPTION
See #11522, but the idea is for private structs to have private fields by default, whereas public structs will continue to have public fields by default.
