### PR TITLE
Uppercase numeric constants

### DIFF
--- a/src/libextra/ebml.rs
+++ b/src/libextra/ebml.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -364,7 +364,7 @@ pub mod reader {
         fn read_u8 (&mut self) -> u8  { doc_as_u8 (self.next_doc(EsU8 )) }
         fn read_uint(&mut self) -> uint {
             let v = doc_as_u64(self.next_doc(EsUint));
-            if v > (::std::uint::max_value as u64) {
+            if v > (::std::uint::MAX as u64) {
                 fail!("uint {} too large for this architecture", v);
             }
             v as uint
@@ -384,7 +384,7 @@ pub mod reader {
         }
         fn read_int(&mut self) -> int {
             let v = doc_as_u64(self.next_doc(EsInt)) as i64;
-            if v > (int::max_value as i64) || v < (int::min_value as i64) {
+            if v > (int::MAX as i64) || v < (int::MIN as i64) {
                 debug!("FIXME \\#6122: Removing this makes this function miscompile");
                 fail!("int {} out of range for this architecture", v);
             }

--- a/src/libextra/getopts.rs
+++ b/src/libextra/getopts.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -848,7 +848,7 @@ pub mod groups {
         t("hello", 15, [~"hello"]);
         t("\nMary had a little lamb\nLittle lamb\n", 15,
             [~"Mary had a", ~"little lamb", ~"Little lamb"]);
-        t("\nMary had a little lamb\nLittle lamb\n", ::std::uint::max_value,
+        t("\nMary had a little lamb\nLittle lamb\n", ::std::uint::MAX,
             [~"Mary had a little lamb\nLittle lamb"]);
     }
 } // end groups module

--- a/src/libextra/num/bigint.rs
+++ b/src/libextra/num/bigint.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -1186,7 +1186,7 @@ impl ToPrimitive for BigInt {
                     if n < m {
                         Some(-(n as i64))
                     } else if n == m {
-                        Some(i64::min_value)
+                        Some(i64::MIN)
                     } else {
                         None
                     }
@@ -1213,7 +1213,7 @@ impl FromPrimitive for BigInt {
                 Some(BigInt::from_biguint(Plus, n))
             })
         } else if n < 0 {
-            FromPrimitive::from_u64(u64::max_value - (n as u64) + 1).and_then(
+            FromPrimitive::from_u64(u64::MAX - (n as u64) + 1).and_then(
                 |n| {
                     Some(BigInt::from_biguint(Minus, n))
                 })
@@ -1625,7 +1625,7 @@ mod biguint_tests {
 
         check(Zero::zero(), 0);
         check(One::one(), 1);
-        check(i64::max_value.to_biguint().unwrap(), i64::max_value);
+        check(i64::MAX.to_biguint().unwrap(), i64::MAX);
 
         check(BigUint::new(~[                   ]), 0);
         check(BigUint::new(~[ 1                 ]), (1 << (0*BigDigit::bits)));
@@ -1635,9 +1635,9 @@ mod biguint_tests {
         check(BigUint::new(~[ 0,  0,  1         ]), (1 << (2*BigDigit::bits)));
         check(BigUint::new(~[-1, -1, -1         ]), (1 << (3*BigDigit::bits)) - 1);
         check(BigUint::new(~[ 0,  0,  0,  1     ]), (1 << (3*BigDigit::bits)));
-        check(BigUint::new(~[-1, -1, -1, -1 >> 1]), i64::max_value);
+        check(BigUint::new(~[-1, -1, -1, -1 >> 1]), i64::MAX);
 
-        assert_eq!(i64::min_value.to_biguint(), None);
+        assert_eq!(i64::MIN.to_biguint(), None);
         assert_eq!(BigUint::new(~[-1, -1, -1, -1    ]).to_i64(), None);
         assert_eq!(BigUint::new(~[ 0,  0,  0,  0,  1]).to_i64(), None);
         assert_eq!(BigUint::new(~[-1, -1, -1, -1, -1]).to_i64(), None);
@@ -1654,15 +1654,15 @@ mod biguint_tests {
 
         check(Zero::zero(), 0);
         check(One::one(), 1);
-        check(i64::max_value.to_biguint().unwrap(), i64::max_value);
+        check(i64::MAX.to_biguint().unwrap(), i64::MAX);
 
         check(BigUint::new(~[           ]), 0);
         check(BigUint::new(~[ 1         ]), (1 << (0*BigDigit::bits)));
         check(BigUint::new(~[-1         ]), (1 << (1*BigDigit::bits)) - 1);
         check(BigUint::new(~[ 0,  1     ]), (1 << (1*BigDigit::bits)));
-        check(BigUint::new(~[-1, -1 >> 1]), i64::max_value);
+        check(BigUint::new(~[-1, -1 >> 1]), i64::MAX);
 
-        assert_eq!(i64::min_value.to_biguint(), None);
+        assert_eq!(i64::MIN.to_biguint(), None);
         assert_eq!(BigUint::new(~[-1, -1    ]).to_i64(), None);
         assert_eq!(BigUint::new(~[ 0,  0,  1]).to_i64(), None);
         assert_eq!(BigUint::new(~[-1, -1, -1]).to_i64(), None);
@@ -1679,8 +1679,8 @@ mod biguint_tests {
 
         check(Zero::zero(), 0);
         check(One::one(), 1);
-        check(u64::min_value.to_biguint().unwrap(), u64::min_value);
-        check(u64::max_value.to_biguint().unwrap(), u64::max_value);
+        check(u64::MIN.to_biguint().unwrap(), u64::MIN);
+        check(u64::MAX.to_biguint().unwrap(), u64::MAX);
 
         check(BigUint::new(~[              ]), 0);
         check(BigUint::new(~[ 1            ]), (1 << (0*BigDigit::bits)));
@@ -1690,7 +1690,7 @@ mod biguint_tests {
         check(BigUint::new(~[ 0,  0,  1    ]), (1 << (2*BigDigit::bits)));
         check(BigUint::new(~[-1, -1, -1    ]), (1 << (3*BigDigit::bits)) - 1);
         check(BigUint::new(~[ 0,  0,  0,  1]), (1 << (3*BigDigit::bits)));
-        check(BigUint::new(~[-1, -1, -1, -1]), u64::max_value);
+        check(BigUint::new(~[-1, -1, -1, -1]), u64::MAX);
 
         assert_eq!(BigUint::new(~[ 0,  0,  0,  0,  1]).to_u64(), None);
         assert_eq!(BigUint::new(~[-1, -1, -1, -1, -1]).to_u64(), None);
@@ -1707,14 +1707,14 @@ mod biguint_tests {
 
         check(Zero::zero(), 0);
         check(One::one(), 1);
-        check(u64::min_value.to_biguint().unwrap(), u64::min_value);
-        check(u64::max_value.to_biguint().unwrap(), u64::max_value);
+        check(u64::MIN.to_biguint().unwrap(), u64::MIN);
+        check(u64::MAX.to_biguint().unwrap(), u64::MAX);
 
         check(BigUint::new(~[      ]), 0);
         check(BigUint::new(~[ 1    ]), (1 << (0*BigDigit::bits)));
         check(BigUint::new(~[-1    ]), (1 << (1*BigDigit::bits)) - 1);
         check(BigUint::new(~[ 0,  1]), (1 << (1*BigDigit::bits)));
-        check(BigUint::new(~[-1, -1]), u64::max_value);
+        check(BigUint::new(~[-1, -1]), u64::MAX);
 
         assert_eq!(BigUint::new(~[ 0,  0,  1]).to_u64(), None);
         assert_eq!(BigUint::new(~[-1, -1, -1]).to_u64(), None);
@@ -2166,11 +2166,11 @@ mod bigint_tests {
 
         check(Zero::zero(), 0);
         check(One::one(), 1);
-        check(i64::min_value.to_bigint().unwrap(), i64::min_value);
-        check(i64::max_value.to_bigint().unwrap(), i64::max_value);
+        check(i64::MIN.to_bigint().unwrap(), i64::MIN);
+        check(i64::MAX.to_bigint().unwrap(), i64::MAX);
 
         assert_eq!(
-            (i64::max_value as u64 + 1).to_bigint().unwrap().to_i64(),
+            (i64::MAX as u64 + 1).to_bigint().unwrap().to_i64(),
             None);
 
         assert_eq!(
@@ -2196,14 +2196,14 @@ mod bigint_tests {
 
         check(Zero::zero(), 0);
         check(One::one(), 1);
-        check(u64::min_value.to_bigint().unwrap(), u64::min_value);
-        check(u64::max_value.to_bigint().unwrap(), u64::max_value);
+        check(u64::MIN.to_bigint().unwrap(), u64::MIN);
+        check(u64::MAX.to_bigint().unwrap(), u64::MAX);
 
         assert_eq!(
             BigInt::from_biguint(Plus, BigUint::new(~[1, 2, 3, 4, 5])).to_u64(),
             None);
 
-        let max_value: BigUint = FromPrimitive::from_u64(u64::max_value).unwrap();
+        let max_value: BigUint = FromPrimitive::from_u64(u64::MAX).unwrap();
         assert_eq!(BigInt::from_biguint(Minus, max_value).to_u64(), None);
         assert_eq!(BigInt::from_biguint(Minus, BigUint::new(~[1, 2, 3, 4, 5])).to_u64(), None);
     }

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -131,7 +131,7 @@ impl Context {
                 // If we're going back to one of the original contexts or
                 // something that's possibly not a "normal task", then reset
                 // the stack limit to 0 to make morestack never fail
-                None => stack::record_stack_bounds(0, uint::max_value),
+                None => stack::record_stack_bounds(0, uint::MAX),
             }
             rust_swap_registers(out_regs, in_regs)
         }

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -80,7 +80,7 @@ impl Clone for MovePathIndex {
 }
 
 static InvalidMovePathIndex: MovePathIndex =
-    MovePathIndex(uint::max_value);
+    MovePathIndex(uint::MAX);
 
 /// Index into `MoveData.moves`, used like a pointer
 #[deriving(Eq)]
@@ -93,7 +93,7 @@ impl MoveIndex {
 }
 
 static InvalidMoveIndex: MoveIndex =
-    MoveIndex(uint::max_value);
+    MoveIndex(uint::MAX);
 
 pub struct MovePath {
     /// Loan path corresponding to this move path

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -56,11 +56,11 @@ pub struct Edge<E> {
 
 #[deriving(Eq)]
 pub struct NodeIndex(uint);
-pub static InvalidNodeIndex: NodeIndex = NodeIndex(uint::max_value);
+pub static InvalidNodeIndex: NodeIndex = NodeIndex(uint::MAX);
 
 #[deriving(Eq)]
 pub struct EdgeIndex(uint);
-pub static InvalidEdgeIndex: EdgeIndex = EdgeIndex(uint::max_value);
+pub static InvalidEdgeIndex: EdgeIndex = EdgeIndex(uint::MAX);
 
 // Use a private field here to guarantee no more instances are created:
 pub struct Direction { priv repr: uint }

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -724,21 +724,21 @@ fn check_type_limits(cx: &Context, e: &ast::Expr) {
     // warnings are consistent between 32- and 64-bit platforms
     fn int_ty_range(int_ty: ast::IntTy) -> (i64, i64) {
         match int_ty {
-            ast::TyI =>    (i64::min_value,        i64::max_value),
-            ast::TyI8 =>   (i8::min_value  as i64, i8::max_value  as i64),
-            ast::TyI16 =>  (i16::min_value as i64, i16::max_value as i64),
-            ast::TyI32 =>  (i32::min_value as i64, i32::max_value as i64),
-            ast::TyI64 =>  (i64::min_value,        i64::max_value)
+            ast::TyI =>    (i64::MIN,        i64::MAX),
+            ast::TyI8 =>   (i8::MIN  as i64, i8::MAX  as i64),
+            ast::TyI16 =>  (i16::MIN as i64, i16::MAX as i64),
+            ast::TyI32 =>  (i32::MIN as i64, i32::MAX as i64),
+            ast::TyI64 =>  (i64::MIN,        i64::MAX)
         }
     }
 
     fn uint_ty_range(uint_ty: ast::UintTy) -> (u64, u64) {
         match uint_ty {
-            ast::TyU =>   (u64::min_value,         u64::max_value),
-            ast::TyU8 =>  (u8::min_value   as u64, u8::max_value   as u64),
-            ast::TyU16 => (u16::min_value  as u64, u16::max_value  as u64),
-            ast::TyU32 => (u32::min_value  as u64, u32::max_value  as u64),
-            ast::TyU64 => (u64::min_value,         u64::max_value)
+            ast::TyU =>   (u64::MIN,         u64::MAX),
+            ast::TyU8 =>  (u8::MIN   as u64, u8::MAX   as u64),
+            ast::TyU16 => (u16::MIN  as u64, u16::MAX  as u64),
+            ast::TyU32 => (u32::MIN  as u64, u32::MAX  as u64),
+            ast::TyU64 => (u64::MIN,         u64::MAX)
         }
     }
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -215,11 +215,11 @@ impl to_str::ToStr for Variable {
 
 impl LiveNode {
     pub fn is_valid(&self) -> bool {
-        self.get() != uint::max_value
+        self.get() != uint::MAX
     }
 }
 
-fn invalid_node() -> LiveNode { LiveNode(uint::max_value) }
+fn invalid_node() -> LiveNode { LiveNode(uint::MAX) }
 
 struct CaptureInfo {
     ln: LiveNode,

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -5112,7 +5112,7 @@ impl Resolver {
             let bindings = value_ribs.get()[j].bindings.borrow();
             for (&k, _) in bindings.get().iter() {
                 maybes.push(interner_get(k));
-                values.push(uint::max_value);
+                values.push(uint::MAX);
             }
         }
 
@@ -5126,7 +5126,7 @@ impl Resolver {
         }
 
         if values.len() > 0 &&
-            values[smallest] != uint::max_value &&
+            values[smallest] != uint::MAX &&
             values[smallest] < name.len() + 2 &&
             values[smallest] <= max_distance &&
             name != maybes[smallest] {

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -1010,7 +1010,7 @@ impl RegionVarBindings {
         // idea is to report errors that derive from independent
         // regions of the graph, but not those that derive from
         // overlapping locations.
-        let mut dup_vec = vec::from_elem(self.num_vars(), uint::max_value);
+        let mut dup_vec = vec::from_elem(self.num_vars(), uint::MAX);
 
         let mut opt_graph = None;
 
@@ -1238,7 +1238,7 @@ impl RegionVarBindings {
             let classification = var_data[node_idx.to_uint()].classification;
 
             // check whether we've visited this node on some previous walk
-            if dup_vec[node_idx.to_uint()] == uint::max_value {
+            if dup_vec[node_idx.to_uint()] == uint::MAX {
                 dup_vec[node_idx.to_uint()] = orig_node_idx.to_uint();
             } else if dup_vec[node_idx.to_uint()] != orig_node_idx.to_uint() {
                 state.dup_found = true;

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -231,7 +231,7 @@ pub fn unindent(s: &str) -> ~str {
     let lines = s.lines_any().collect::<~[&str]>();
     let mut saw_first_line = false;
     let mut saw_second_line = false;
-    let min_indent = lines.iter().fold(uint::max_value, |min_indent, line| {
+    let min_indent = lines.iter().fold(uint::MAX, |min_indent, line| {
 
         // After we see the first non-whitespace line, look at
         // the line we have. If it is not whitespace, and therefore
@@ -243,7 +243,7 @@ pub fn unindent(s: &str) -> ~str {
             !line.is_whitespace();
 
         let min_indent = if ignore_previous_indents {
-            uint::max_value
+            uint::MAX
         } else {
             min_indent
         };

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -367,7 +367,7 @@ struct Packet {
 // All implementations -- the fun part
 ///////////////////////////////////////////////////////////////////////////////
 
-static DISCONNECTED: int = int::min_value;
+static DISCONNECTED: int = int::MIN;
 static RESCHED_FREQ: int = 200;
 
 impl Packet {

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -182,7 +182,7 @@ impl Select {
             assert!(amt > 0);
 
             let mut ready_index = amt;
-            let mut ready_id = uint::max_value;
+            let mut ready_id = uint::MAX;
             let mut iter = self.iter().enumerate();
 
             // Acquire a number of blocking contexts, and block on each one
@@ -242,7 +242,7 @@ impl Select {
                 assert!(!(*packet).selecting.load(Relaxed));
             }
 
-            assert!(ready_id != uint::max_value);
+            assert!(ready_id != uint::MAX);
             return ready_id;
         }
     }

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -401,7 +401,7 @@ mod test {
 
     #[test]
     fn test_read_write_le_mem() {
-        let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::max_value];
+        let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::MAX];
 
         let mut writer = MemWriter::new();
         for i in uints.iter() {
@@ -417,7 +417,7 @@ mod test {
 
     #[test]
     fn test_read_write_be() {
-        let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::max_value];
+        let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::MAX];
 
         let mut writer = MemWriter::new();
         for i in uints.iter() {
@@ -432,7 +432,7 @@ mod test {
 
     #[test]
     fn test_read_be_int_n() {
-        let ints = [::i32::min_value, -123456, -42, -5, 0, 1, ::i32::max_value];
+        let ints = [::i32::MIN, -123456, -42, -5, 0, 1, ::i32::MAX];
 
         let mut writer = MemWriter::new();
         for i in ints.iter() {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -680,28 +680,28 @@ pub trait Reader {
     ///
     /// The number of bytes returned is system-dependant.
     fn read_le_uint(&mut self) -> uint {
-        self.read_le_uint_n(uint::bytes) as uint
+        self.read_le_uint_n(uint::BYTES) as uint
     }
 
     /// Reads a little-endian integer.
     ///
     /// The number of bytes returned is system-dependant.
     fn read_le_int(&mut self) -> int {
-        self.read_le_int_n(int::bytes) as int
+        self.read_le_int_n(int::BYTES) as int
     }
 
     /// Reads a big-endian unsigned integer.
     ///
     /// The number of bytes returned is system-dependant.
     fn read_be_uint(&mut self) -> uint {
-        self.read_be_uint_n(uint::bytes) as uint
+        self.read_be_uint_n(uint::BYTES) as uint
     }
 
     /// Reads a big-endian integer.
     ///
     /// The number of bytes returned is system-dependant.
     fn read_be_int(&mut self) -> int {
-        self.read_be_int_n(int::bytes) as int
+        self.read_be_int_n(int::BYTES) as int
     }
 
     /// Reads a big-endian `u64`.
@@ -915,22 +915,22 @@ pub trait Writer {
 
     /// Write a little-endian uint (number of bytes depends on system).
     fn write_le_uint(&mut self, n: uint) {
-        extensions::u64_to_le_bytes(n as u64, uint::bytes, |v| self.write(v))
+        extensions::u64_to_le_bytes(n as u64, uint::BYTES, |v| self.write(v))
     }
 
     /// Write a little-endian int (number of bytes depends on system).
     fn write_le_int(&mut self, n: int) {
-        extensions::u64_to_le_bytes(n as u64, int::bytes, |v| self.write(v))
+        extensions::u64_to_le_bytes(n as u64, int::BYTES, |v| self.write(v))
     }
 
     /// Write a big-endian uint (number of bytes depends on system).
     fn write_be_uint(&mut self, n: uint) {
-        extensions::u64_to_be_bytes(n as u64, uint::bytes, |v| self.write(v))
+        extensions::u64_to_be_bytes(n as u64, uint::BYTES, |v| self.write(v))
     }
 
     /// Write a big-endian int (number of bytes depends on system).
     fn write_be_int(&mut self, n: int) {
-        extensions::u64_to_be_bytes(n as u64, int::bytes, |v| self.write(v))
+        extensions::u64_to_be_bytes(n as u64, int::BYTES, |v| self.write(v))
     }
 
     /// Write a big-endian u64 (8 bytes).

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -681,7 +681,7 @@ pub trait DoubleEndedIterator<A>: Iterator<A> {
     /// of the original iterator.
     ///
     /// Note: Random access with flipped indices still only applies to the first
-    /// `uint::max_value` elements of the original iterator.
+    /// `uint::MAX` elements of the original iterator.
     #[inline]
     fn rev(self) -> Rev<Self> {
         Rev{iter: self}
@@ -713,7 +713,7 @@ impl<'a, A, T: DoubleEndedIterator<&'a mut A>> MutableDoubleEndedIterator for T 
 ///
 /// A `RandomAccessIterator` should be either infinite or a `DoubleEndedIterator`.
 pub trait RandomAccessIterator<A>: Iterator<A> {
-    /// Return the number of indexable elements. At most `std::uint::max_value`
+    /// Return the number of indexable elements. At most `std::uint::MAX`
     /// elements are indexable, even if the iterator represents a longer range.
     fn indexable(&self) -> uint;
 
@@ -952,7 +952,7 @@ impl<A, T: Clone + Iterator<A>> Iterator<A> for Cycle<T> {
         match self.orig.size_hint() {
             sz @ (0, Some(0)) => sz,
             (0, _) => (0, None),
-            _ => (uint::max_value, None)
+            _ => (uint::MAX, None)
         }
     }
 }
@@ -961,7 +961,7 @@ impl<A, T: Clone + RandomAccessIterator<A>> RandomAccessIterator<A> for Cycle<T>
     #[inline]
     fn indexable(&self) -> uint {
         if self.orig.indexable() > 0 {
-            uint::max_value
+            uint::MAX
         } else {
             0
         }
@@ -1823,7 +1823,7 @@ impl<A: Add<A, A> + Clone> Iterator<A> for Counter<A> {
 
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) {
-        (uint::max_value, None) // Too bad we can't specify an infinite lower bound
+        (uint::MAX, None) // Too bad we can't specify an infinite lower bound
     }
 }
 
@@ -2049,7 +2049,7 @@ impl<A: Clone> Iterator<A> for Repeat<A> {
     #[inline]
     fn next(&mut self) -> Option<A> { self.idx(0) }
     #[inline]
-    fn size_hint(&self) -> (uint, Option<uint>) { (uint::max_value, None) }
+    fn size_hint(&self) -> (uint, Option<uint>) { (uint::MAX, None) }
 }
 
 impl<A: Clone> DoubleEndedIterator<A> for Repeat<A> {
@@ -2059,7 +2059,7 @@ impl<A: Clone> DoubleEndedIterator<A> for Repeat<A> {
 
 impl<A: Clone> RandomAccessIterator<A> for Repeat<A> {
     #[inline]
-    fn indexable(&self) -> uint { uint::max_value }
+    fn indexable(&self) -> uint { uint::MAX }
     #[inline]
     fn idx(&self, _: uint) -> Option<A> { Some(self.element.clone()) }
 }
@@ -2417,7 +2417,7 @@ mod tests {
     fn test_cycle() {
         let cycle_len = 3;
         let it = count(0u, 1).take(cycle_len).cycle();
-        assert_eq!(it.size_hint(), (uint::max_value, None));
+        assert_eq!(it.size_hint(), (uint::MAX, None));
         for (i, x) in it.take(100).enumerate() {
             assert_eq!(i % cycle_len, x);
         }
@@ -2489,19 +2489,19 @@ mod tests {
         let v2 = &[10, 11, 12];
         let vi = v.iter();
 
-        assert_eq!(c.size_hint(), (uint::max_value, None));
+        assert_eq!(c.size_hint(), (uint::MAX, None));
         assert_eq!(vi.size_hint(), (10, Some(10)));
 
         assert_eq!(c.take(5).size_hint(), (5, Some(5)));
         assert_eq!(c.skip(5).size_hint().second(), None);
         assert_eq!(c.take_while(|_| false).size_hint(), (0, None));
         assert_eq!(c.skip_while(|_| false).size_hint(), (0, None));
-        assert_eq!(c.enumerate().size_hint(), (uint::max_value, None));
-        assert_eq!(c.chain(vi.map(|&i| i)).size_hint(), (uint::max_value, None));
+        assert_eq!(c.enumerate().size_hint(), (uint::MAX, None));
+        assert_eq!(c.chain(vi.map(|&i| i)).size_hint(), (uint::MAX, None));
         assert_eq!(c.zip(vi).size_hint(), (10, Some(10)));
         assert_eq!(c.scan(0, |_,_| Some(0)).size_hint(), (0, None));
         assert_eq!(c.filter(|_| false).size_hint(), (0, None));
-        assert_eq!(c.map(|_| 0).size_hint(), (uint::max_value, None));
+        assert_eq!(c.map(|_| 0).size_hint(), (uint::MAX, None));
         assert_eq!(c.filter_map(|_| Some(0)).size_hint(), (0, None));
 
         assert_eq!(vi.take(5).size_hint(), (5, Some(5)));
@@ -2894,7 +2894,7 @@ mod tests {
 
         assert_eq!(range(0i, 100).size_hint(), (100, Some(100)));
         // this test is only meaningful when sizeof uint < sizeof u64
-        assert_eq!(range(uint::max_value - 1, uint::max_value).size_hint(), (1, Some(1)));
+        assert_eq!(range(uint::MAX - 1, uint::MAX).size_hint(), (1, Some(1)));
         assert_eq!(range(-10i, -1).size_hint(), (9, Some(9)));
         assert_eq!(range(Foo, Foo).size_hint(), (0, None));
     }

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -123,7 +123,7 @@ impl CheckedMul for int {
 
 #[test]
 fn test_overflows() {
-    assert!((::int::max_value > 0));
-    assert!((::int::min_value <= 0));
-    assert!((::int::min_value + ::int::max_value + 1 == 0));
+    assert!((::int::MAX > 0));
+    assert!((::int::MIN <= 0));
+    assert!((::int::MIN + ::int::MAX + 1 == 0));
 }

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,23 +15,23 @@ macro_rules! int_module (($T:ty, $bits:expr) => (
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
-pub static bits : uint = $bits;
+pub static BITS : uint = $bits;
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
-pub static bytes : uint = ($bits / 8);
+pub static BYTES : uint = ($bits / 8);
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::min_value` function.
-pub static min_value: $T = (-1 as $T) << (bits - 1);
-// FIXME(#9837): Compute min_value like this so the high bits that shouldn't exist are 0.
+pub static MIN: $T = (-1 as $T) << (BITS - 1);
+// FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::max_value` function.
-pub static max_value: $T = !min_value;
+pub static MAX: $T = !MIN;
 
 impl CheckedDiv for $T {
     #[inline]
     fn checked_div(&self, v: &$T) -> Option<$T> {
-        if *v == 0 || (*self == min_value && *v == -1) {
+        if *v == 0 || (*self == MIN && *v == -1) {
             None
         } else {
             Some(self / *v)
@@ -361,10 +361,10 @@ impl Not<$T> for $T {
 
 impl Bounded for $T {
     #[inline]
-    fn min_value() -> $T { min_value }
+    fn min_value() -> $T { MIN }
 
     #[inline]
-    fn max_value() -> $T { max_value }
+    fn max_value() -> $T { MAX }
 }
 
 impl Int for $T {}
@@ -757,7 +757,7 @@ mod tests {
     fn test_signed_checked_div() {
         assert_eq!(10i.checked_div(&2), Some(5));
         assert_eq!(5i.checked_div(&0), None);
-        assert_eq!(int::min_value.checked_div(&-1), None);
+        assert_eq!(int::MIN.checked_div(&-1), None);
     }
 }
 

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -1159,25 +1159,25 @@ mod tests {
 
     #[test]
     fn test_cast_range_int_min() {
-        assert_eq!(int::min_value.to_int(),  Some(int::min_value as int));
-        assert_eq!(int::min_value.to_i8(),   None);
-        assert_eq!(int::min_value.to_i16(),  None);
-        // int::min_value.to_i32() is word-size specific
-        assert_eq!(int::min_value.to_i64(),  Some(int::min_value as i64));
-        assert_eq!(int::min_value.to_uint(), None);
-        assert_eq!(int::min_value.to_u8(),   None);
-        assert_eq!(int::min_value.to_u16(),  None);
-        assert_eq!(int::min_value.to_u32(),  None);
-        assert_eq!(int::min_value.to_u64(),  None);
+        assert_eq!(int::MIN.to_int(),  Some(int::MIN as int));
+        assert_eq!(int::MIN.to_i8(),   None);
+        assert_eq!(int::MIN.to_i16(),  None);
+        // int::MIN.to_i32() is word-size specific
+        assert_eq!(int::MIN.to_i64(),  Some(int::MIN as i64));
+        assert_eq!(int::MIN.to_uint(), None);
+        assert_eq!(int::MIN.to_u8(),   None);
+        assert_eq!(int::MIN.to_u16(),  None);
+        assert_eq!(int::MIN.to_u32(),  None);
+        assert_eq!(int::MIN.to_u64(),  None);
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(int::min_value.to_i32(), Some(int::min_value as i32));
+            assert_eq!(int::MIN.to_i32(), Some(int::MIN as i32));
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(int::min_value.to_i32(), None);
+            assert_eq!(int::MIN.to_i32(), None);
         }
 
         check_word_size();
@@ -1185,67 +1185,67 @@ mod tests {
 
     #[test]
     fn test_cast_range_i8_min() {
-        assert_eq!(i8::min_value.to_int(),  Some(i8::min_value as int));
-        assert_eq!(i8::min_value.to_i8(),   Some(i8::min_value as i8));
-        assert_eq!(i8::min_value.to_i16(),  Some(i8::min_value as i16));
-        assert_eq!(i8::min_value.to_i32(),  Some(i8::min_value as i32));
-        assert_eq!(i8::min_value.to_i64(),  Some(i8::min_value as i64));
-        assert_eq!(i8::min_value.to_uint(), None);
-        assert_eq!(i8::min_value.to_u8(),   None);
-        assert_eq!(i8::min_value.to_u16(),  None);
-        assert_eq!(i8::min_value.to_u32(),  None);
-        assert_eq!(i8::min_value.to_u64(),  None);
+        assert_eq!(i8::MIN.to_int(),  Some(i8::MIN as int));
+        assert_eq!(i8::MIN.to_i8(),   Some(i8::MIN as i8));
+        assert_eq!(i8::MIN.to_i16(),  Some(i8::MIN as i16));
+        assert_eq!(i8::MIN.to_i32(),  Some(i8::MIN as i32));
+        assert_eq!(i8::MIN.to_i64(),  Some(i8::MIN as i64));
+        assert_eq!(i8::MIN.to_uint(), None);
+        assert_eq!(i8::MIN.to_u8(),   None);
+        assert_eq!(i8::MIN.to_u16(),  None);
+        assert_eq!(i8::MIN.to_u32(),  None);
+        assert_eq!(i8::MIN.to_u64(),  None);
     }
 
     #[test]
     fn test_cast_range_i16_min() {
-        assert_eq!(i16::min_value.to_int(),  Some(i16::min_value as int));
-        assert_eq!(i16::min_value.to_i8(),   None);
-        assert_eq!(i16::min_value.to_i16(),  Some(i16::min_value as i16));
-        assert_eq!(i16::min_value.to_i32(),  Some(i16::min_value as i32));
-        assert_eq!(i16::min_value.to_i64(),  Some(i16::min_value as i64));
-        assert_eq!(i16::min_value.to_uint(), None);
-        assert_eq!(i16::min_value.to_u8(),   None);
-        assert_eq!(i16::min_value.to_u16(),  None);
-        assert_eq!(i16::min_value.to_u32(),  None);
-        assert_eq!(i16::min_value.to_u64(),  None);
+        assert_eq!(i16::MIN.to_int(),  Some(i16::MIN as int));
+        assert_eq!(i16::MIN.to_i8(),   None);
+        assert_eq!(i16::MIN.to_i16(),  Some(i16::MIN as i16));
+        assert_eq!(i16::MIN.to_i32(),  Some(i16::MIN as i32));
+        assert_eq!(i16::MIN.to_i64(),  Some(i16::MIN as i64));
+        assert_eq!(i16::MIN.to_uint(), None);
+        assert_eq!(i16::MIN.to_u8(),   None);
+        assert_eq!(i16::MIN.to_u16(),  None);
+        assert_eq!(i16::MIN.to_u32(),  None);
+        assert_eq!(i16::MIN.to_u64(),  None);
     }
 
     #[test]
     fn test_cast_range_i32_min() {
-        assert_eq!(i32::min_value.to_int(),  Some(i32::min_value as int));
-        assert_eq!(i32::min_value.to_i8(),   None);
-        assert_eq!(i32::min_value.to_i16(),  None);
-        assert_eq!(i32::min_value.to_i32(),  Some(i32::min_value as i32));
-        assert_eq!(i32::min_value.to_i64(),  Some(i32::min_value as i64));
-        assert_eq!(i32::min_value.to_uint(), None);
-        assert_eq!(i32::min_value.to_u8(),   None);
-        assert_eq!(i32::min_value.to_u16(),  None);
-        assert_eq!(i32::min_value.to_u32(),  None);
-        assert_eq!(i32::min_value.to_u64(),  None);
+        assert_eq!(i32::MIN.to_int(),  Some(i32::MIN as int));
+        assert_eq!(i32::MIN.to_i8(),   None);
+        assert_eq!(i32::MIN.to_i16(),  None);
+        assert_eq!(i32::MIN.to_i32(),  Some(i32::MIN as i32));
+        assert_eq!(i32::MIN.to_i64(),  Some(i32::MIN as i64));
+        assert_eq!(i32::MIN.to_uint(), None);
+        assert_eq!(i32::MIN.to_u8(),   None);
+        assert_eq!(i32::MIN.to_u16(),  None);
+        assert_eq!(i32::MIN.to_u32(),  None);
+        assert_eq!(i32::MIN.to_u64(),  None);
     }
 
     #[test]
     fn test_cast_range_i64_min() {
-        // i64::min_value.to_int() is word-size specific
-        assert_eq!(i64::min_value.to_i8(),   None);
-        assert_eq!(i64::min_value.to_i16(),  None);
-        assert_eq!(i64::min_value.to_i32(),  None);
-        assert_eq!(i64::min_value.to_i64(),  Some(i64::min_value as i64));
-        assert_eq!(i64::min_value.to_uint(), None);
-        assert_eq!(i64::min_value.to_u8(),   None);
-        assert_eq!(i64::min_value.to_u16(),  None);
-        assert_eq!(i64::min_value.to_u32(),  None);
-        assert_eq!(i64::min_value.to_u64(),  None);
+        // i64::MIN.to_int() is word-size specific
+        assert_eq!(i64::MIN.to_i8(),   None);
+        assert_eq!(i64::MIN.to_i16(),  None);
+        assert_eq!(i64::MIN.to_i32(),  None);
+        assert_eq!(i64::MIN.to_i64(),  Some(i64::MIN as i64));
+        assert_eq!(i64::MIN.to_uint(), None);
+        assert_eq!(i64::MIN.to_u8(),   None);
+        assert_eq!(i64::MIN.to_u16(),  None);
+        assert_eq!(i64::MIN.to_u32(),  None);
+        assert_eq!(i64::MIN.to_u64(),  None);
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(i64::min_value.to_int(), None);
+            assert_eq!(i64::MIN.to_int(), None);
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(i64::min_value.to_int(), Some(i64::min_value as int));
+            assert_eq!(i64::MIN.to_int(), Some(i64::MIN as int));
         }
 
         check_word_size();
@@ -1253,26 +1253,26 @@ mod tests {
 
     #[test]
     fn test_cast_range_int_max() {
-        assert_eq!(int::max_value.to_int(),  Some(int::max_value as int));
-        assert_eq!(int::max_value.to_i8(),   None);
-        assert_eq!(int::max_value.to_i16(),  None);
-        // int::max_value.to_i32() is word-size specific
-        assert_eq!(int::max_value.to_i64(),  Some(int::max_value as i64));
-        assert_eq!(int::max_value.to_u8(),   None);
-        assert_eq!(int::max_value.to_u16(),  None);
-        // int::max_value.to_u32() is word-size specific
-        assert_eq!(int::max_value.to_u64(),  Some(int::max_value as u64));
+        assert_eq!(int::MAX.to_int(),  Some(int::MAX as int));
+        assert_eq!(int::MAX.to_i8(),   None);
+        assert_eq!(int::MAX.to_i16(),  None);
+        // int::MAX.to_i32() is word-size specific
+        assert_eq!(int::MAX.to_i64(),  Some(int::MAX as i64));
+        assert_eq!(int::MAX.to_u8(),   None);
+        assert_eq!(int::MAX.to_u16(),  None);
+        // int::MAX.to_u32() is word-size specific
+        assert_eq!(int::MAX.to_u64(),  Some(int::MAX as u64));
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(int::max_value.to_i32(), Some(int::max_value as i32));
-            assert_eq!(int::max_value.to_u32(), Some(int::max_value as u32));
+            assert_eq!(int::MAX.to_i32(), Some(int::MAX as i32));
+            assert_eq!(int::MAX.to_u32(), Some(int::MAX as u32));
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(int::max_value.to_i32(), None);
-            assert_eq!(int::max_value.to_u32(), None);
+            assert_eq!(int::MAX.to_i32(), None);
+            assert_eq!(int::MAX.to_u32(), None);
         }
 
         check_word_size();
@@ -1280,69 +1280,69 @@ mod tests {
 
     #[test]
     fn test_cast_range_i8_max() {
-        assert_eq!(i8::max_value.to_int(),  Some(i8::max_value as int));
-        assert_eq!(i8::max_value.to_i8(),   Some(i8::max_value as i8));
-        assert_eq!(i8::max_value.to_i16(),  Some(i8::max_value as i16));
-        assert_eq!(i8::max_value.to_i32(),  Some(i8::max_value as i32));
-        assert_eq!(i8::max_value.to_i64(),  Some(i8::max_value as i64));
-        assert_eq!(i8::max_value.to_uint(), Some(i8::max_value as uint));
-        assert_eq!(i8::max_value.to_u8(),   Some(i8::max_value as u8));
-        assert_eq!(i8::max_value.to_u16(),  Some(i8::max_value as u16));
-        assert_eq!(i8::max_value.to_u32(),  Some(i8::max_value as u32));
-        assert_eq!(i8::max_value.to_u64(),  Some(i8::max_value as u64));
+        assert_eq!(i8::MAX.to_int(),  Some(i8::MAX as int));
+        assert_eq!(i8::MAX.to_i8(),   Some(i8::MAX as i8));
+        assert_eq!(i8::MAX.to_i16(),  Some(i8::MAX as i16));
+        assert_eq!(i8::MAX.to_i32(),  Some(i8::MAX as i32));
+        assert_eq!(i8::MAX.to_i64(),  Some(i8::MAX as i64));
+        assert_eq!(i8::MAX.to_uint(), Some(i8::MAX as uint));
+        assert_eq!(i8::MAX.to_u8(),   Some(i8::MAX as u8));
+        assert_eq!(i8::MAX.to_u16(),  Some(i8::MAX as u16));
+        assert_eq!(i8::MAX.to_u32(),  Some(i8::MAX as u32));
+        assert_eq!(i8::MAX.to_u64(),  Some(i8::MAX as u64));
     }
 
     #[test]
     fn test_cast_range_i16_max() {
-        assert_eq!(i16::max_value.to_int(),  Some(i16::max_value as int));
-        assert_eq!(i16::max_value.to_i8(),   None);
-        assert_eq!(i16::max_value.to_i16(),  Some(i16::max_value as i16));
-        assert_eq!(i16::max_value.to_i32(),  Some(i16::max_value as i32));
-        assert_eq!(i16::max_value.to_i64(),  Some(i16::max_value as i64));
-        assert_eq!(i16::max_value.to_uint(), Some(i16::max_value as uint));
-        assert_eq!(i16::max_value.to_u8(),   None);
-        assert_eq!(i16::max_value.to_u16(),  Some(i16::max_value as u16));
-        assert_eq!(i16::max_value.to_u32(),  Some(i16::max_value as u32));
-        assert_eq!(i16::max_value.to_u64(),  Some(i16::max_value as u64));
+        assert_eq!(i16::MAX.to_int(),  Some(i16::MAX as int));
+        assert_eq!(i16::MAX.to_i8(),   None);
+        assert_eq!(i16::MAX.to_i16(),  Some(i16::MAX as i16));
+        assert_eq!(i16::MAX.to_i32(),  Some(i16::MAX as i32));
+        assert_eq!(i16::MAX.to_i64(),  Some(i16::MAX as i64));
+        assert_eq!(i16::MAX.to_uint(), Some(i16::MAX as uint));
+        assert_eq!(i16::MAX.to_u8(),   None);
+        assert_eq!(i16::MAX.to_u16(),  Some(i16::MAX as u16));
+        assert_eq!(i16::MAX.to_u32(),  Some(i16::MAX as u32));
+        assert_eq!(i16::MAX.to_u64(),  Some(i16::MAX as u64));
     }
 
     #[test]
     fn test_cast_range_i32_max() {
-        assert_eq!(i32::max_value.to_int(),  Some(i32::max_value as int));
-        assert_eq!(i32::max_value.to_i8(),   None);
-        assert_eq!(i32::max_value.to_i16(),  None);
-        assert_eq!(i32::max_value.to_i32(),  Some(i32::max_value as i32));
-        assert_eq!(i32::max_value.to_i64(),  Some(i32::max_value as i64));
-        assert_eq!(i32::max_value.to_uint(), Some(i32::max_value as uint));
-        assert_eq!(i32::max_value.to_u8(),   None);
-        assert_eq!(i32::max_value.to_u16(),  None);
-        assert_eq!(i32::max_value.to_u32(),  Some(i32::max_value as u32));
-        assert_eq!(i32::max_value.to_u64(),  Some(i32::max_value as u64));
+        assert_eq!(i32::MAX.to_int(),  Some(i32::MAX as int));
+        assert_eq!(i32::MAX.to_i8(),   None);
+        assert_eq!(i32::MAX.to_i16(),  None);
+        assert_eq!(i32::MAX.to_i32(),  Some(i32::MAX as i32));
+        assert_eq!(i32::MAX.to_i64(),  Some(i32::MAX as i64));
+        assert_eq!(i32::MAX.to_uint(), Some(i32::MAX as uint));
+        assert_eq!(i32::MAX.to_u8(),   None);
+        assert_eq!(i32::MAX.to_u16(),  None);
+        assert_eq!(i32::MAX.to_u32(),  Some(i32::MAX as u32));
+        assert_eq!(i32::MAX.to_u64(),  Some(i32::MAX as u64));
     }
 
     #[test]
     fn test_cast_range_i64_max() {
-        // i64::max_value.to_int() is word-size specific
-        assert_eq!(i64::max_value.to_i8(),   None);
-        assert_eq!(i64::max_value.to_i16(),  None);
-        assert_eq!(i64::max_value.to_i32(),  None);
-        assert_eq!(i64::max_value.to_i64(),  Some(i64::max_value as i64));
-        // i64::max_value.to_uint() is word-size specific
-        assert_eq!(i64::max_value.to_u8(),   None);
-        assert_eq!(i64::max_value.to_u16(),  None);
-        assert_eq!(i64::max_value.to_u32(),  None);
-        assert_eq!(i64::max_value.to_u64(),  Some(i64::max_value as u64));
+        // i64::MAX.to_int() is word-size specific
+        assert_eq!(i64::MAX.to_i8(),   None);
+        assert_eq!(i64::MAX.to_i16(),  None);
+        assert_eq!(i64::MAX.to_i32(),  None);
+        assert_eq!(i64::MAX.to_i64(),  Some(i64::MAX as i64));
+        // i64::MAX.to_uint() is word-size specific
+        assert_eq!(i64::MAX.to_u8(),   None);
+        assert_eq!(i64::MAX.to_u16(),  None);
+        assert_eq!(i64::MAX.to_u32(),  None);
+        assert_eq!(i64::MAX.to_u64(),  Some(i64::MAX as u64));
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(i64::max_value.to_int(),  None);
-            assert_eq!(i64::max_value.to_uint(), None);
+            assert_eq!(i64::MAX.to_int(),  None);
+            assert_eq!(i64::MAX.to_uint(), None);
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(i64::max_value.to_int(),  Some(i64::max_value as int));
-            assert_eq!(i64::max_value.to_uint(), Some(i64::max_value as uint));
+            assert_eq!(i64::MAX.to_int(),  Some(i64::MAX as int));
+            assert_eq!(i64::MAX.to_uint(), Some(i64::MAX as uint));
         }
 
         check_word_size();
@@ -1350,96 +1350,96 @@ mod tests {
 
     #[test]
     fn test_cast_range_uint_min() {
-        assert_eq!(uint::min_value.to_int(),  Some(uint::min_value as int));
-        assert_eq!(uint::min_value.to_i8(),   Some(uint::min_value as i8));
-        assert_eq!(uint::min_value.to_i16(),  Some(uint::min_value as i16));
-        assert_eq!(uint::min_value.to_i32(),  Some(uint::min_value as i32));
-        assert_eq!(uint::min_value.to_i64(),  Some(uint::min_value as i64));
-        assert_eq!(uint::min_value.to_uint(), Some(uint::min_value as uint));
-        assert_eq!(uint::min_value.to_u8(),   Some(uint::min_value as u8));
-        assert_eq!(uint::min_value.to_u16(),  Some(uint::min_value as u16));
-        assert_eq!(uint::min_value.to_u32(),  Some(uint::min_value as u32));
-        assert_eq!(uint::min_value.to_u64(),  Some(uint::min_value as u64));
+        assert_eq!(uint::MIN.to_int(),  Some(uint::MIN as int));
+        assert_eq!(uint::MIN.to_i8(),   Some(uint::MIN as i8));
+        assert_eq!(uint::MIN.to_i16(),  Some(uint::MIN as i16));
+        assert_eq!(uint::MIN.to_i32(),  Some(uint::MIN as i32));
+        assert_eq!(uint::MIN.to_i64(),  Some(uint::MIN as i64));
+        assert_eq!(uint::MIN.to_uint(), Some(uint::MIN as uint));
+        assert_eq!(uint::MIN.to_u8(),   Some(uint::MIN as u8));
+        assert_eq!(uint::MIN.to_u16(),  Some(uint::MIN as u16));
+        assert_eq!(uint::MIN.to_u32(),  Some(uint::MIN as u32));
+        assert_eq!(uint::MIN.to_u64(),  Some(uint::MIN as u64));
     }
 
     #[test]
     fn test_cast_range_u8_min() {
-        assert_eq!(u8::min_value.to_int(),  Some(u8::min_value as int));
-        assert_eq!(u8::min_value.to_i8(),   Some(u8::min_value as i8));
-        assert_eq!(u8::min_value.to_i16(),  Some(u8::min_value as i16));
-        assert_eq!(u8::min_value.to_i32(),  Some(u8::min_value as i32));
-        assert_eq!(u8::min_value.to_i64(),  Some(u8::min_value as i64));
-        assert_eq!(u8::min_value.to_uint(), Some(u8::min_value as uint));
-        assert_eq!(u8::min_value.to_u8(),   Some(u8::min_value as u8));
-        assert_eq!(u8::min_value.to_u16(),  Some(u8::min_value as u16));
-        assert_eq!(u8::min_value.to_u32(),  Some(u8::min_value as u32));
-        assert_eq!(u8::min_value.to_u64(),  Some(u8::min_value as u64));
+        assert_eq!(u8::MIN.to_int(),  Some(u8::MIN as int));
+        assert_eq!(u8::MIN.to_i8(),   Some(u8::MIN as i8));
+        assert_eq!(u8::MIN.to_i16(),  Some(u8::MIN as i16));
+        assert_eq!(u8::MIN.to_i32(),  Some(u8::MIN as i32));
+        assert_eq!(u8::MIN.to_i64(),  Some(u8::MIN as i64));
+        assert_eq!(u8::MIN.to_uint(), Some(u8::MIN as uint));
+        assert_eq!(u8::MIN.to_u8(),   Some(u8::MIN as u8));
+        assert_eq!(u8::MIN.to_u16(),  Some(u8::MIN as u16));
+        assert_eq!(u8::MIN.to_u32(),  Some(u8::MIN as u32));
+        assert_eq!(u8::MIN.to_u64(),  Some(u8::MIN as u64));
     }
 
     #[test]
     fn test_cast_range_u16_min() {
-        assert_eq!(u16::min_value.to_int(),  Some(u16::min_value as int));
-        assert_eq!(u16::min_value.to_i8(),   Some(u16::min_value as i8));
-        assert_eq!(u16::min_value.to_i16(),  Some(u16::min_value as i16));
-        assert_eq!(u16::min_value.to_i32(),  Some(u16::min_value as i32));
-        assert_eq!(u16::min_value.to_i64(),  Some(u16::min_value as i64));
-        assert_eq!(u16::min_value.to_uint(), Some(u16::min_value as uint));
-        assert_eq!(u16::min_value.to_u8(),   Some(u16::min_value as u8));
-        assert_eq!(u16::min_value.to_u16(),  Some(u16::min_value as u16));
-        assert_eq!(u16::min_value.to_u32(),  Some(u16::min_value as u32));
-        assert_eq!(u16::min_value.to_u64(),  Some(u16::min_value as u64));
+        assert_eq!(u16::MIN.to_int(),  Some(u16::MIN as int));
+        assert_eq!(u16::MIN.to_i8(),   Some(u16::MIN as i8));
+        assert_eq!(u16::MIN.to_i16(),  Some(u16::MIN as i16));
+        assert_eq!(u16::MIN.to_i32(),  Some(u16::MIN as i32));
+        assert_eq!(u16::MIN.to_i64(),  Some(u16::MIN as i64));
+        assert_eq!(u16::MIN.to_uint(), Some(u16::MIN as uint));
+        assert_eq!(u16::MIN.to_u8(),   Some(u16::MIN as u8));
+        assert_eq!(u16::MIN.to_u16(),  Some(u16::MIN as u16));
+        assert_eq!(u16::MIN.to_u32(),  Some(u16::MIN as u32));
+        assert_eq!(u16::MIN.to_u64(),  Some(u16::MIN as u64));
     }
 
     #[test]
     fn test_cast_range_u32_min() {
-        assert_eq!(u32::min_value.to_int(),  Some(u32::min_value as int));
-        assert_eq!(u32::min_value.to_i8(),   Some(u32::min_value as i8));
-        assert_eq!(u32::min_value.to_i16(),  Some(u32::min_value as i16));
-        assert_eq!(u32::min_value.to_i32(),  Some(u32::min_value as i32));
-        assert_eq!(u32::min_value.to_i64(),  Some(u32::min_value as i64));
-        assert_eq!(u32::min_value.to_uint(), Some(u32::min_value as uint));
-        assert_eq!(u32::min_value.to_u8(),   Some(u32::min_value as u8));
-        assert_eq!(u32::min_value.to_u16(),  Some(u32::min_value as u16));
-        assert_eq!(u32::min_value.to_u32(),  Some(u32::min_value as u32));
-        assert_eq!(u32::min_value.to_u64(),  Some(u32::min_value as u64));
+        assert_eq!(u32::MIN.to_int(),  Some(u32::MIN as int));
+        assert_eq!(u32::MIN.to_i8(),   Some(u32::MIN as i8));
+        assert_eq!(u32::MIN.to_i16(),  Some(u32::MIN as i16));
+        assert_eq!(u32::MIN.to_i32(),  Some(u32::MIN as i32));
+        assert_eq!(u32::MIN.to_i64(),  Some(u32::MIN as i64));
+        assert_eq!(u32::MIN.to_uint(), Some(u32::MIN as uint));
+        assert_eq!(u32::MIN.to_u8(),   Some(u32::MIN as u8));
+        assert_eq!(u32::MIN.to_u16(),  Some(u32::MIN as u16));
+        assert_eq!(u32::MIN.to_u32(),  Some(u32::MIN as u32));
+        assert_eq!(u32::MIN.to_u64(),  Some(u32::MIN as u64));
     }
 
     #[test]
     fn test_cast_range_u64_min() {
-        assert_eq!(u64::min_value.to_int(),  Some(u64::min_value as int));
-        assert_eq!(u64::min_value.to_i8(),   Some(u64::min_value as i8));
-        assert_eq!(u64::min_value.to_i16(),  Some(u64::min_value as i16));
-        assert_eq!(u64::min_value.to_i32(),  Some(u64::min_value as i32));
-        assert_eq!(u64::min_value.to_i64(),  Some(u64::min_value as i64));
-        assert_eq!(u64::min_value.to_uint(), Some(u64::min_value as uint));
-        assert_eq!(u64::min_value.to_u8(),   Some(u64::min_value as u8));
-        assert_eq!(u64::min_value.to_u16(),  Some(u64::min_value as u16));
-        assert_eq!(u64::min_value.to_u32(),  Some(u64::min_value as u32));
-        assert_eq!(u64::min_value.to_u64(),  Some(u64::min_value as u64));
+        assert_eq!(u64::MIN.to_int(),  Some(u64::MIN as int));
+        assert_eq!(u64::MIN.to_i8(),   Some(u64::MIN as i8));
+        assert_eq!(u64::MIN.to_i16(),  Some(u64::MIN as i16));
+        assert_eq!(u64::MIN.to_i32(),  Some(u64::MIN as i32));
+        assert_eq!(u64::MIN.to_i64(),  Some(u64::MIN as i64));
+        assert_eq!(u64::MIN.to_uint(), Some(u64::MIN as uint));
+        assert_eq!(u64::MIN.to_u8(),   Some(u64::MIN as u8));
+        assert_eq!(u64::MIN.to_u16(),  Some(u64::MIN as u16));
+        assert_eq!(u64::MIN.to_u32(),  Some(u64::MIN as u32));
+        assert_eq!(u64::MIN.to_u64(),  Some(u64::MIN as u64));
     }
 
     #[test]
     fn test_cast_range_uint_max() {
-        assert_eq!(uint::max_value.to_int(),  None);
-        assert_eq!(uint::max_value.to_i8(),   None);
-        assert_eq!(uint::max_value.to_i16(),  None);
-        assert_eq!(uint::max_value.to_i32(),  None);
-        // uint::max_value.to_i64() is word-size specific
-        assert_eq!(uint::max_value.to_u8(),   None);
-        assert_eq!(uint::max_value.to_u16(),  None);
-        // uint::max_value.to_u32() is word-size specific
-        assert_eq!(uint::max_value.to_u64(),  Some(uint::max_value as u64));
+        assert_eq!(uint::MAX.to_int(),  None);
+        assert_eq!(uint::MAX.to_i8(),   None);
+        assert_eq!(uint::MAX.to_i16(),  None);
+        assert_eq!(uint::MAX.to_i32(),  None);
+        // uint::MAX.to_i64() is word-size specific
+        assert_eq!(uint::MAX.to_u8(),   None);
+        assert_eq!(uint::MAX.to_u16(),  None);
+        // uint::MAX.to_u32() is word-size specific
+        assert_eq!(uint::MAX.to_u64(),  Some(uint::MAX as u64));
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(uint::max_value.to_u32(), Some(uint::max_value as u32));
-            assert_eq!(uint::max_value.to_i64(), Some(uint::max_value as i64));
+            assert_eq!(uint::MAX.to_u32(), Some(uint::MAX as u32));
+            assert_eq!(uint::MAX.to_i64(), Some(uint::MAX as i64));
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(uint::max_value.to_u32(), None);
-            assert_eq!(uint::max_value.to_i64(), None);
+            assert_eq!(uint::MAX.to_u32(), None);
+            assert_eq!(uint::MAX.to_i64(), None);
         }
 
         check_word_size();
@@ -1447,53 +1447,53 @@ mod tests {
 
     #[test]
     fn test_cast_range_u8_max() {
-        assert_eq!(u8::max_value.to_int(),  Some(u8::max_value as int));
-        assert_eq!(u8::max_value.to_i8(),   None);
-        assert_eq!(u8::max_value.to_i16(),  Some(u8::max_value as i16));
-        assert_eq!(u8::max_value.to_i32(),  Some(u8::max_value as i32));
-        assert_eq!(u8::max_value.to_i64(),  Some(u8::max_value as i64));
-        assert_eq!(u8::max_value.to_uint(), Some(u8::max_value as uint));
-        assert_eq!(u8::max_value.to_u8(),   Some(u8::max_value as u8));
-        assert_eq!(u8::max_value.to_u16(),  Some(u8::max_value as u16));
-        assert_eq!(u8::max_value.to_u32(),  Some(u8::max_value as u32));
-        assert_eq!(u8::max_value.to_u64(),  Some(u8::max_value as u64));
+        assert_eq!(u8::MAX.to_int(),  Some(u8::MAX as int));
+        assert_eq!(u8::MAX.to_i8(),   None);
+        assert_eq!(u8::MAX.to_i16(),  Some(u8::MAX as i16));
+        assert_eq!(u8::MAX.to_i32(),  Some(u8::MAX as i32));
+        assert_eq!(u8::MAX.to_i64(),  Some(u8::MAX as i64));
+        assert_eq!(u8::MAX.to_uint(), Some(u8::MAX as uint));
+        assert_eq!(u8::MAX.to_u8(),   Some(u8::MAX as u8));
+        assert_eq!(u8::MAX.to_u16(),  Some(u8::MAX as u16));
+        assert_eq!(u8::MAX.to_u32(),  Some(u8::MAX as u32));
+        assert_eq!(u8::MAX.to_u64(),  Some(u8::MAX as u64));
     }
 
     #[test]
     fn test_cast_range_u16_max() {
-        assert_eq!(u16::max_value.to_int(),  Some(u16::max_value as int));
-        assert_eq!(u16::max_value.to_i8(),   None);
-        assert_eq!(u16::max_value.to_i16(),  None);
-        assert_eq!(u16::max_value.to_i32(),  Some(u16::max_value as i32));
-        assert_eq!(u16::max_value.to_i64(),  Some(u16::max_value as i64));
-        assert_eq!(u16::max_value.to_uint(), Some(u16::max_value as uint));
-        assert_eq!(u16::max_value.to_u8(),   None);
-        assert_eq!(u16::max_value.to_u16(),  Some(u16::max_value as u16));
-        assert_eq!(u16::max_value.to_u32(),  Some(u16::max_value as u32));
-        assert_eq!(u16::max_value.to_u64(),  Some(u16::max_value as u64));
+        assert_eq!(u16::MAX.to_int(),  Some(u16::MAX as int));
+        assert_eq!(u16::MAX.to_i8(),   None);
+        assert_eq!(u16::MAX.to_i16(),  None);
+        assert_eq!(u16::MAX.to_i32(),  Some(u16::MAX as i32));
+        assert_eq!(u16::MAX.to_i64(),  Some(u16::MAX as i64));
+        assert_eq!(u16::MAX.to_uint(), Some(u16::MAX as uint));
+        assert_eq!(u16::MAX.to_u8(),   None);
+        assert_eq!(u16::MAX.to_u16(),  Some(u16::MAX as u16));
+        assert_eq!(u16::MAX.to_u32(),  Some(u16::MAX as u32));
+        assert_eq!(u16::MAX.to_u64(),  Some(u16::MAX as u64));
     }
 
     #[test]
     fn test_cast_range_u32_max() {
-        // u32::max_value.to_int() is word-size specific
-        assert_eq!(u32::max_value.to_i8(),   None);
-        assert_eq!(u32::max_value.to_i16(),  None);
-        assert_eq!(u32::max_value.to_i32(),  None);
-        assert_eq!(u32::max_value.to_i64(),  Some(u32::max_value as i64));
-        assert_eq!(u32::max_value.to_uint(), Some(u32::max_value as uint));
-        assert_eq!(u32::max_value.to_u8(),   None);
-        assert_eq!(u32::max_value.to_u16(),  None);
-        assert_eq!(u32::max_value.to_u32(),  Some(u32::max_value as u32));
-        assert_eq!(u32::max_value.to_u64(),  Some(u32::max_value as u64));
+        // u32::MAX.to_int() is word-size specific
+        assert_eq!(u32::MAX.to_i8(),   None);
+        assert_eq!(u32::MAX.to_i16(),  None);
+        assert_eq!(u32::MAX.to_i32(),  None);
+        assert_eq!(u32::MAX.to_i64(),  Some(u32::MAX as i64));
+        assert_eq!(u32::MAX.to_uint(), Some(u32::MAX as uint));
+        assert_eq!(u32::MAX.to_u8(),   None);
+        assert_eq!(u32::MAX.to_u16(),  None);
+        assert_eq!(u32::MAX.to_u32(),  Some(u32::MAX as u32));
+        assert_eq!(u32::MAX.to_u64(),  Some(u32::MAX as u64));
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(u32::max_value.to_int(),  None);
+            assert_eq!(u32::MAX.to_int(),  None);
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(u32::max_value.to_int(),  Some(u32::max_value as int));
+            assert_eq!(u32::MAX.to_int(),  Some(u32::MAX as int));
         }
 
         check_word_size();
@@ -1501,25 +1501,25 @@ mod tests {
 
     #[test]
     fn test_cast_range_u64_max() {
-        assert_eq!(u64::max_value.to_int(),  None);
-        assert_eq!(u64::max_value.to_i8(),   None);
-        assert_eq!(u64::max_value.to_i16(),  None);
-        assert_eq!(u64::max_value.to_i32(),  None);
-        assert_eq!(u64::max_value.to_i64(),  None);
-        // u64::max_value.to_uint() is word-size specific
-        assert_eq!(u64::max_value.to_u8(),   None);
-        assert_eq!(u64::max_value.to_u16(),  None);
-        assert_eq!(u64::max_value.to_u32(),  None);
-        assert_eq!(u64::max_value.to_u64(),  Some(u64::max_value as u64));
+        assert_eq!(u64::MAX.to_int(),  None);
+        assert_eq!(u64::MAX.to_i8(),   None);
+        assert_eq!(u64::MAX.to_i16(),  None);
+        assert_eq!(u64::MAX.to_i32(),  None);
+        assert_eq!(u64::MAX.to_i64(),  None);
+        // u64::MAX.to_uint() is word-size specific
+        assert_eq!(u64::MAX.to_u8(),   None);
+        assert_eq!(u64::MAX.to_u16(),  None);
+        assert_eq!(u64::MAX.to_u32(),  None);
+        assert_eq!(u64::MAX.to_u64(),  Some(u64::MAX as u64));
 
         #[cfg(target_word_size = "32")]
         fn check_word_size() {
-            assert_eq!(u64::max_value.to_uint(), None);
+            assert_eq!(u64::MAX.to_uint(), None);
         }
 
         #[cfg(target_word_size = "64")]
         fn check_word_size() {
-            assert_eq!(u64::max_value.to_uint(), Some(u64::max_value as uint));
+            assert_eq!(u64::MAX.to_uint(), Some(u64::MAX as uint));
         }
 
         check_word_size();
@@ -1527,55 +1527,55 @@ mod tests {
 
     #[test]
     fn test_saturating_add_uint() {
-        use uint::max_value;
+        use uint::MAX;
         assert_eq!(3u.saturating_add(5u), 8u);
-        assert_eq!(3u.saturating_add(max_value-1), max_value);
-        assert_eq!(max_value.saturating_add(max_value), max_value);
-        assert_eq!((max_value-2).saturating_add(1), max_value-1);
+        assert_eq!(3u.saturating_add(MAX-1), MAX);
+        assert_eq!(MAX.saturating_add(MAX), MAX);
+        assert_eq!((MAX-2).saturating_add(1), MAX-1);
     }
 
     #[test]
     fn test_saturating_sub_uint() {
-        use uint::max_value;
+        use uint::MAX;
         assert_eq!(5u.saturating_sub(3u), 2u);
         assert_eq!(3u.saturating_sub(5u), 0u);
         assert_eq!(0u.saturating_sub(1u), 0u);
-        assert_eq!((max_value-1).saturating_sub(max_value), 0);
+        assert_eq!((MAX-1).saturating_sub(MAX), 0);
     }
 
     #[test]
     fn test_saturating_add_int() {
-        use int::{min_value,max_value};
+        use int::{MIN,MAX};
         assert_eq!(3i.saturating_add(5i), 8i);
-        assert_eq!(3i.saturating_add(max_value-1), max_value);
-        assert_eq!(max_value.saturating_add(max_value), max_value);
-        assert_eq!((max_value-2).saturating_add(1), max_value-1);
+        assert_eq!(3i.saturating_add(MAX-1), MAX);
+        assert_eq!(MAX.saturating_add(MAX), MAX);
+        assert_eq!((MAX-2).saturating_add(1), MAX-1);
         assert_eq!(3i.saturating_add(-5i), -2i);
-        assert_eq!(min_value.saturating_add(-1i), min_value);
-        assert_eq!((-2i).saturating_add(-max_value), min_value);
+        assert_eq!(MIN.saturating_add(-1i), MIN);
+        assert_eq!((-2i).saturating_add(-MAX), MIN);
     }
 
     #[test]
     fn test_saturating_sub_int() {
-        use int::{min_value,max_value};
+        use int::{MIN,MAX};
         assert_eq!(3i.saturating_sub(5i), -2i);
-        assert_eq!(min_value.saturating_sub(1i), min_value);
-        assert_eq!((-2i).saturating_sub(max_value), min_value);
+        assert_eq!(MIN.saturating_sub(1i), MIN);
+        assert_eq!((-2i).saturating_sub(MAX), MIN);
         assert_eq!(3i.saturating_sub(-5i), 8i);
-        assert_eq!(3i.saturating_sub(-(max_value-1)), max_value);
-        assert_eq!(max_value.saturating_sub(-max_value), max_value);
-        assert_eq!((max_value-2).saturating_sub(-1), max_value-1);
+        assert_eq!(3i.saturating_sub(-(MAX-1)), MAX);
+        assert_eq!(MAX.saturating_sub(-MAX), MAX);
+        assert_eq!((MAX-2).saturating_sub(-1), MAX-1);
     }
 
     #[test]
     fn test_checked_add() {
-        let five_less = uint::max_value - 5;
-        assert_eq!(five_less.checked_add(&0), Some(uint::max_value - 5));
-        assert_eq!(five_less.checked_add(&1), Some(uint::max_value - 4));
-        assert_eq!(five_less.checked_add(&2), Some(uint::max_value - 3));
-        assert_eq!(five_less.checked_add(&3), Some(uint::max_value - 2));
-        assert_eq!(five_less.checked_add(&4), Some(uint::max_value - 1));
-        assert_eq!(five_less.checked_add(&5), Some(uint::max_value));
+        let five_less = uint::MAX - 5;
+        assert_eq!(five_less.checked_add(&0), Some(uint::MAX - 5));
+        assert_eq!(five_less.checked_add(&1), Some(uint::MAX - 4));
+        assert_eq!(five_less.checked_add(&2), Some(uint::MAX - 3));
+        assert_eq!(five_less.checked_add(&3), Some(uint::MAX - 2));
+        assert_eq!(five_less.checked_add(&4), Some(uint::MAX - 1));
+        assert_eq!(five_less.checked_add(&5), Some(uint::MAX));
         assert_eq!(five_less.checked_add(&6), None);
         assert_eq!(five_less.checked_add(&7), None);
     }
@@ -1594,7 +1594,7 @@ mod tests {
 
     #[test]
     fn test_checked_mul() {
-        let third = uint::max_value / 3;
+        let third = uint::MAX / 3;
         assert_eq!(third.checked_mul(&0), Some(0));
         assert_eq!(third.checked_mul(&1), Some(third));
         assert_eq!(third.checked_mul(&2), Some(third * 2));

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -25,7 +25,7 @@ use option::{Option, Some, None};
 use str;
 use unstable::intrinsics;
 
-uint_module!(uint, int, ::int::bits)
+uint_module!(uint, int, ::int::BITS)
 
 ///
 /// Divide two numbers, return the result, rounded up.
@@ -234,9 +234,9 @@ fn test_next_power_of_two() {
 #[test]
 fn test_overflows() {
     use uint;
-    assert!((uint::max_value > 0u));
-    assert!((uint::min_value <= 0u));
-    assert!((uint::min_value + uint::max_value + 1u == 0u));
+    assert!((uint::MAX > 0u));
+    assert!((uint::MIN <= 0u));
+    assert!((uint::MIN + uint::MAX + 1u == 0u));
 }
 
 #[test]

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,11 +13,11 @@
 
 macro_rules! uint_module (($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
-pub static bits : uint = $bits;
-pub static bytes : uint = ($bits / 8);
+pub static BITS : uint = $bits;
+pub static BYTES : uint = ($bits / 8);
 
-pub static min_value: $T = 0 as $T;
-pub static max_value: $T = 0 as $T - 1 as $T;
+pub static MIN: $T = 0 as $T;
+pub static MAX: $T = 0 as $T - 1 as $T;
 
 impl CheckedDiv for $T {
     #[inline]
@@ -214,10 +214,10 @@ impl Not<$T> for $T {
 
 impl Bounded for $T {
     #[inline]
-    fn min_value() -> $T { min_value }
+    fn min_value() -> $T { MIN }
 
     #[inline]
-    fn max_value() -> $T { max_value }
+    fn max_value() -> $T { MAX }
 }
 
 impl Int for $T {}
@@ -398,7 +398,7 @@ mod tests {
         assert_eq!(0b0110 as $T, (0b1100 as $T).bitxor(&(0b1010 as $T)));
         assert_eq!(0b1110 as $T, (0b0111 as $T).shl(&(1 as $T)));
         assert_eq!(0b0111 as $T, (0b1110 as $T).shr(&(1 as $T)));
-        assert_eq!(max_value - (0b1011 as $T), (0b1011 as $T).not());
+        assert_eq!(MAX - (0b1011 as $T), (0b1011 as $T).not());
     }
 
     #[test]

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -441,7 +441,7 @@ impl<A> ExactSize<A> for Item<A> {}
 /// checking for overflow:
 ///
 ///     fn inc_conditionally(x: uint) -> Option<uint> {
-///         if x == uint::max_value { return None; }
+///         if x == uint::MAX { return None; }
 ///         else { return Some(x+1u); }
 ///     }
 ///     let v = [1u, 2, 3];

--- a/src/libstd/rand/rand_impls.rs
+++ b/src/libstd/rand/rand_impls.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,7 +19,7 @@ use uint;
 impl Rand for int {
     #[inline]
     fn rand<R: Rng>(rng: &mut R) -> int {
-        if int::bits == 32 {
+        if int::BITS == 32 {
             rng.gen::<i32>() as int
         } else {
             rng.gen::<i64>() as int
@@ -58,7 +58,7 @@ impl Rand for i64 {
 impl Rand for uint {
     #[inline]
     fn rand<R: Rng>(rng: &mut R) -> uint {
-        if uint::bits == 32 {
+        if uint::BITS == 32 {
             rng.gen::<u32>() as uint
         } else {
             rng.gen::<u64>() as uint

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -227,7 +227,7 @@ impl<T: fmt::Default, E: fmt::Default> fmt::Default for Result<T, E> {
 /// checking for overflow:
 ///
 ///     fn inc_conditionally(x: uint) -> Result<uint, &'static str> {
-///         if x == uint::max_value { return Err("overflow"); }
+///         if x == uint::MAX { return Err("overflow"); }
 ///         else { return Ok(x+1u); }
 ///     }
 ///     let v = [1u, 2, 3];

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -43,7 +43,7 @@ static DEFAULT_STACK_SIZE: uint = 1024 * 1024;
 extern fn thread_start(main: *libc::c_void) -> imp::rust_thread_return {
     use unstable::stack;
     unsafe {
-        stack::record_stack_bounds(0, uint::max_value);
+        stack::record_stack_bounds(0, uint::MAX);
         let f: ~proc() = cast::transmute(main);
         (*f)();
         cast::transmute(0 as imp::rust_thread_return)

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -21,7 +21,7 @@ use vec;
 static SHIFT: uint = 4;
 static SIZE: uint = 1 << SHIFT;
 static MASK: uint = SIZE - 1;
-static NUM_CHUNKS: uint = uint::bits / SHIFT;
+static NUM_CHUNKS: uint = uint::BITS / SHIFT;
 
 enum Child<T> {
     Internal(~TrieNode<T>),
@@ -396,7 +396,7 @@ impl<T> TrieNode<T> {
 // if this was done via a trait, the key could be generic
 #[inline]
 fn chunk(n: uint, idx: uint) -> uint {
-    let sh = uint::bits - (SHIFT * (idx + 1));
+    let sh = uint::BITS - (SHIFT * (idx + 1));
     (n >> sh) & MASK
 }
 
@@ -728,14 +728,14 @@ mod test_map {
     fn test_each_reverse_break() {
         let mut m = TrieMap::new();
 
-        for x in range(uint::max_value - 10000, uint::max_value).rev() {
+        for x in range(uint::MAX - 10000, uint::MAX).rev() {
             m.insert(x, x / 2);
         }
 
-        let mut n = uint::max_value - 1;
+        let mut n = uint::MAX - 1;
         m.each_reverse(|k, v| {
-            if n == uint::max_value - 5000 { false } else {
-                assert!(n > uint::max_value - 5000);
+            if n == uint::MAX - 5000 { false } else {
+                assert!(n > uint::MAX - 5000);
 
                 assert_eq!(*k, n);
                 assert_eq!(*v, n / 2);
@@ -777,8 +777,8 @@ mod test_map {
         let empty_map : TrieMap<uint> = TrieMap::new();
         assert_eq!(empty_map.iter().next(), None);
 
-        let first = uint::max_value - 10000;
-        let last = uint::max_value;
+        let first = uint::MAX - 10000;
+        let last = uint::MAX;
 
         let mut map = TrieMap::new();
         for x in range(first, last).rev() {
@@ -799,8 +799,8 @@ mod test_map {
         let mut empty_map : TrieMap<uint> = TrieMap::new();
         assert!(empty_map.mut_iter().next().is_none());
 
-        let first = uint::max_value - 10000;
-        let last = uint::max_value;
+        let first = uint::MAX - 10000;
+        let last = uint::MAX;
 
         let mut map = TrieMap::new();
         for x in range(first, last).rev() {
@@ -1014,7 +1014,7 @@ mod test_set {
     #[test]
     fn test_sane_chunk() {
         let x = 1;
-        let y = 1 << (uint::bits - 1);
+        let y = 1 << (uint::BITS - 1);
 
         let mut trie = TrieSet::new();
 

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -389,9 +389,9 @@ impl Once {
 
         let prev = self.cnt.fetch_add(1, atomics::SeqCst);
         if prev < 0 {
-            // Make sure we never overflow, we'll never have int::min_value
+            // Make sure we never overflow, we'll never have int::MIN
             // simultaneous calls to `doit` to make this value go back to 0
-            self.cnt.store(int::min_value, atomics::SeqCst);
+            self.cnt.store(int::MIN, atomics::SeqCst);
             return
         }
 
@@ -401,7 +401,7 @@ impl Once {
         unsafe { self.mutex.lock() }
         if self.cnt.load(atomics::SeqCst) > 0 {
             f();
-            let prev = self.cnt.swap(int::min_value, atomics::SeqCst);
+            let prev = self.cnt.swap(int::MIN, atomics::SeqCst);
             self.lock_cnt.store(prev, atomics::SeqCst);
         }
         unsafe { self.mutex.unlock() }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -1072,7 +1072,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
 
     #[inline]
     fn split(self, pred: 'a |&T| -> bool) -> Splits<'a, T> {
-        self.splitn(uint::max_value, pred)
+        self.splitn(uint::MAX, pred)
     }
 
     #[inline]
@@ -1087,7 +1087,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
 
     #[inline]
     fn rsplit(self, pred: 'a |&T| -> bool) -> RevSplits<'a, T> {
-        self.rsplitn(uint::max_value, pred)
+        self.rsplitn(uint::MAX, pred)
     }
 
     #[inline]

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -340,8 +340,8 @@ pub struct IdRange {
 impl IdRange {
     pub fn max() -> IdRange {
         IdRange {
-            min: u32::max_value,
-            max: u32::min_value,
+            min: u32::MAX,
+            max: u32::MIN,
         }
     }
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -78,7 +78,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
 
     /// remove a "[ \t]*\*" block from each line, if possible
     fn horizontal_trim(lines: ~[~str]) -> ~[~str] {
-        let mut i = uint::max_value;
+        let mut i = uint::MAX;
         let mut can_trim = true;
         let mut first = true;
         for line in lines.iter() {

--- a/src/test/run-fail/bounds-check-no-overflow.rs
+++ b/src/test/run-fail/bounds-check-no-overflow.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,10 +10,10 @@
 
 // error-pattern:index out of bounds: the len is 3 but the index is
 
-use std::uint::max_value;
+use std::uint;
 use std::mem::size_of;
 
 fn main() {
     let xs = [1, 2, 3];
-    xs[max_value / size_of::<int>() + 1];
+    xs[uint::MAX / size_of::<int>() + 1];
 }

--- a/src/test/run-fail/bug-2470-bounds-check-overflow-2.rs
+++ b/src/test/run-fail/bug-2470-bounds-check-overflow-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -21,7 +21,7 @@ fn main() {
     // length (in bytes), because the scaling of the index will cause it to
     // wrap around to a small number.
 
-    let idx = uint::max_value & !(uint::max_value >> 1u);
+    let idx = uint::MAX & !(uint::MAX >> 1u);
     error!("ov2 idx = 0x%x", idx);
 
     // This should fail.

--- a/src/test/run-fail/bug-2470-bounds-check-overflow-3.rs
+++ b/src/test/run-fail/bug-2470-bounds-check-overflow-3.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -23,7 +23,7 @@ fn main() {
 
     // This test is only meaningful on 32-bit hosts.
 
-    let idx = u64::max_value & !(u64::max_value >> 1u);
+    let idx = u64::MAX & !(u64::MAX >> 1u);
     error!("ov3 idx = 0x%8.8x%8.8x",
            (idx >> 32) as uint,
            idx as uint);

--- a/src/test/run-pass/deriving-primitive.rs
+++ b/src/test/run-pass/deriving-primitive.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,14 +13,14 @@ use std::int;
 
 #[deriving(Eq, FromPrimitive)]
 enum A {
-    Foo = int::max_value,
+    Foo = int::MAX,
     Bar = 1,
     Baz = 3,
     Qux,
 }
 
 pub fn main() {
-    let x: Option<A> = FromPrimitive::from_int(int::max_value);
+    let x: Option<A> = FromPrimitive::from_int(int::MAX);
     assert_eq!(x, Some(Foo));
 
     let x: Option<A> = FromPrimitive::from_int(1);


### PR DESCRIPTION
The following are renamed:
- `min_value` => `MIN`
- `max_value` => `MAX`
- `bits` => `BITS`
- `bytes` => `BYTES`

All tests pass, except for `run-pass/phase-syntax-link-does-resolve.rs`. I doubt that failure is related, though.

Fixes #10010.
