### PR TITLE
rustc: allow "omitting" visit glue.

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -76,7 +76,8 @@ debugging_opts!(
         GEN_CRATE_MAP,
         PREFER_DYNAMIC,
         NO_INTEGRATED_AS,
-        LTO
+        LTO,
+        NOOP_REFLECTION
     ]
     0
 )
@@ -124,6 +125,8 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, u64)] {
      ("no-integrated-as",
       "Use external assembler rather than LLVM's integrated one", NO_INTEGRATED_AS),
      ("lto", "Perform LLVM link-time optimizations", LTO),
+     ("noop-reflection", "Avoid generating the visit glue (stops {:?} working)",
+      NOOP_REFLECTION)
     ]
 }
 
@@ -347,6 +350,9 @@ impl Session_ {
     }
     pub fn no_landing_pads(&self) -> bool {
         self.debugging_opt(NO_LANDING_PADS)
+    }
+    pub fn noop_reflection(&self) -> bool {
+        self.debugging_opt(NOOP_REFLECTION)
     }
 
     // pointless function, now...

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -267,10 +267,13 @@ fn call_tydesc_glue<'a>(cx: &'a Block<'a>, v: ValueRef, t: ty::t, field: uint)
     cx
 }
 
-fn make_visit_glue<'a>(bcx: &'a Block<'a>, v: ValueRef, t: ty::t)
+fn make_visit_glue<'a>(mut bcx: &'a Block<'a>, v: ValueRef, t: ty::t)
                    -> &'a Block<'a> {
     let _icx = push_ctxt("make_visit_glue");
-    let mut bcx = bcx;
+    if bcx.tcx().sess.noop_reflection() {
+        return bcx;
+    }
+
     let (visitor_trait, object_ty) = match ty::visitor_object_ty(bcx.tcx(),
                                                                  ty::ReStatic) {
         Ok(pair) => pair,

--- a/src/test/run-pass/noop-reflection.rs
+++ b/src/test/run-pass/noop-reflection.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast compile flags doesn't work
+// compile-flags: -Z noop-reflection
+
+pub fn main() {
+    assert_eq!(format!("{:?}", 1), ~"");
+}


### PR DESCRIPTION
This adds `-Z noop-reflection` which causes all visit glues to be
empty. As an example of its effects, an optimised libsyntax.so is 300
KB (5%) smaller and requires 14MB less memory to compile.

This is likely most useful for #[no_std] crates using closures or trait
objects (which require a tydesc to be created for their contained types)
to avoid the code bloat of the otherwise unused visit glue.
