### PR TITLE
Simplify and rename macro API

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -13,7 +13,7 @@ use ast::{TTDelim};
 use ast;
 use codemap::{Span, Spanned, DUMMY_SP};
 use ext::base::{AnyMacro, ExtCtxt, MacResult, MRAny, MRDef, MacroDef};
-use ext::base::{NormalTT, SyntaxExpanderTTTrait};
+use ext::base::{NormalTT, MacroExpander};
 use ext::base;
 use ext::tt::macro_parser::{Success, Error, Failure};
 use ext::tt::macro_parser::{NamedMatch, MatchedSeq, MatchedNonterminal};
@@ -87,18 +87,17 @@ impl AnyMacro for ParserAnyMacro {
     }
 }
 
-struct MacroRulesSyntaxExpanderTTFun {
+struct MacroRulesMacroExpander {
     name: Ident,
     lhses: @~[@NamedMatch],
     rhses: @~[@NamedMatch],
 }
 
-impl SyntaxExpanderTTTrait for MacroRulesSyntaxExpanderTTFun {
+impl MacroExpander for MacroRulesMacroExpander {
     fn expand(&self,
               cx: &mut ExtCtxt,
               sp: Span,
-              arg: &[ast::TokenTree],
-              _: ast::SyntaxContext)
+              arg: &[ast::TokenTree])
               -> MacResult {
         generic_extension(cx, sp, self.name, arg, *self.lhses, *self.rhses)
     }
@@ -175,8 +174,7 @@ fn generic_extension(cx: &ExtCtxt,
 pub fn add_new_extension(cx: &mut ExtCtxt,
                          sp: Span,
                          name: Ident,
-                         arg: ~[ast::TokenTree],
-                         _: ast::SyntaxContext)
+                         arg: ~[ast::TokenTree])
                          -> base::MacResult {
     // these spans won't matter, anyways
     fn ms(m: Matcher_) -> Matcher {
@@ -224,7 +222,7 @@ pub fn add_new_extension(cx: &mut ExtCtxt,
         _ => cx.span_bug(sp, "wrong-structured rhs")
     };
 
-    let exp = ~MacroRulesSyntaxExpanderTTFun {
+    let exp = ~MacroRulesMacroExpander {
         name: name,
         lhses: lhses,
         rhses: rhses,

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -27,8 +27,8 @@ macro_rules! unexported_macro (() => (3))
 #[macro_registrar]
 pub fn macro_registrar(register: |Name, SyntaxExtension|) {
     register(token::intern("make_a_1"),
-        NormalTT(~SyntaxExpanderTT {
-            expander: SyntaxExpanderTTExpanderWithoutContext(expand_make_a_1),
+        NormalTT(~BasicMacroExpander {
+            expander: expand_make_a_1,
             span: None,
         },
         None));


### PR DESCRIPTION
Now that procedural macros can be implemented outside of the compiler,
it's more important to have a reasonable API to work with. Here are the
basic changes:
- Rename SyntaxExpanderTTTrait to MacroExpander, SyntaxExpanderTT to
  BasicMacroExpander, etc. I think "procedural macro" is the right
  term for these now, right? The other option would be SynExtExpander
  or something like that.
- Stop passing the SyntaxContext to extensions. This was only ever used
  by macro_rules, which doesn't even use it anymore. I can't think of
  a context in which an external extension would need it, and removal
  allows the API to be significantly simpler - no more
  SyntaxExpanderTTItemExpanderWithoutContext wrappers to worry about.
