### PR TITLE
std,extra: Make some types public and others private

### DIFF
--- a/src/libextra/btree.rs
+++ b/src/libextra/btree.rs
@@ -22,10 +22,10 @@
 ///number of elements that a given node can contain.
 #[allow(missing_doc)]
 pub struct BTree<K, V> {
-    root: Node<K, V>,
-    len: uint,
-    lower_bound: uint,
-    upper_bound: uint
+    priv root: Node<K, V>,
+    priv len: uint,
+    priv lower_bound: uint,
+    priv upper_bound: uint
 }
 
 //We would probably want to remove the dependence on the Clone trait in the future.
@@ -47,9 +47,9 @@ impl<K: TotalOrd, V> BTree<K, V> {
 
     ///Helper function for clone: returns new BTree with supplied root node,
     ///length, and lower bound.  For use when the length is known already.
-    pub fn new_with_node_len(n: Node<K, V>,
-                             length: uint,
-                             lb: uint) -> BTree<K, V> {
+    fn new_with_node_len(n: Node<K, V>,
+                         length: uint,
+                         lb: uint) -> BTree<K, V> {
         BTree {
             root: n,
             len: length,
@@ -590,4 +590,3 @@ mod test_btree {
     }
 
 }
-

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -202,7 +202,8 @@ pub struct TestOpts {
     logfile: Option<Path>
 }
 
-type OptRes = Result<TestOpts, ~str>;
+/// Result of parsing the options.
+pub type OptRes = Result<TestOpts, ~str>;
 
 fn optgroups() -> ~[getopts::groups::OptGroup] {
     ~[groups::optflag("", "ignored", "Run ignored tests"),
@@ -722,7 +723,8 @@ enum TestEvent {
     TeResult(TestDesc, TestResult),
 }
 
-type MonitorMsg = (TestDesc, TestResult);
+/// The message sent to the test monitor from the individual runners.
+pub type MonitorMsg = (TestDesc, TestResult);
 
 fn run_tests(opts: &TestOpts,
              tests: ~[TestDescAndFn],

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -63,7 +63,7 @@ pub mod timer;
 
 mod timer_helper;
 
-type IoResult<T> = Result<T, IoError>;
+pub type IoResult<T> = Result<T, IoError>;
 
 fn unimpl() -> IoError {
     IoError {

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -243,7 +243,7 @@ use vec::OwnedVector;
 use spsc = sync::spsc_queue;
 use mpsc = sync::mpsc_queue;
 
-pub use self::select::Select;
+pub use self::select::{Select, Handle};
 
 macro_rules! test (
     { fn $name:ident() $b:block $($a:attr)*} => (

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -89,6 +89,7 @@ pub struct Select {
 /// This handle is used to keep the port in the set as well as interact with the
 /// underlying port.
 pub struct Handle<'port, T> {
+    /// A unique ID for this Handle.
     id: uint,
     priv selector: &'port Select,
     priv port: &'port mut Port<T>,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1268,7 +1268,7 @@ pub trait Acceptor<T> {
 /// The Some contains another Option representing whether the connection attempt was succesful.
 /// A successful connection will be wrapped in Some.
 /// A failed connection is represented as a None and raises a condition.
-struct IncomingConnections<'a, A> {
+pub struct IncomingConnections<'a, A> {
     priv inc: &'a mut A,
 }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -620,7 +620,7 @@ enum NormalizationForm {
 /// External iterator for a string's normalization's characters.
 /// Use with the `std::iter` module.
 #[deriving(Clone)]
-struct Normalizations<'a> {
+pub struct Normalizations<'a> {
     priv kind: NormalizationForm,
     priv iter: Chars<'a>,
     priv buffer: ~[(char, u8)],


### PR DESCRIPTION
These are either returned from public functions, and really should
appear in the documentation, but don't since they're private, or are
implementation details that are currently public.
