### PR TITLE
Unhide lines in rustdoc's doc -- Closes #11645

### DIFF
--- a/doc/rustdoc.md
+++ b/doc/rustdoc.md
@@ -139,9 +139,14 @@ that one can still write things like `#[deriving(Eq)]`).
 
 ~~~
 ```rust
-# // showing 'fib' in this documentation would just be tedious and detracts from
-# // what's actualy being documented.
-# fn fib(n: int) { n + 2 }
+# /!\ The three following lines are comments, which are usually stripped off by
+# the doc-generating tool.  In order to display them anyway in this particular
+# case, the character following the leading '#' is not a usual space like in
+# these first five lines but a non breakable one.
+# 
+# // showing 'fib' in this documentation would just be tedious and detracts from
+# // what's actualy being documented.
+# fn fib(n: int) { n + 2 }
 
 do spawn { fib(200); }
 ```


### PR DESCRIPTION
The doc-generating tool comments out the lines that match `/$# /` (note the space), which is not what is wanted here. And it lets live the lines matching `/$#[^ ]/`. But we still want to see a space. So I replaced the normal space by a non breakable one, which fools the parser into displaying the line.
