### PR TITLE
Improve the spans of some deriving traits

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# xfail-license
+# Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""
+This script creates a pile of compile-fail tests check that all the
+derivings have spans that point to the fields, rather than the
+#[deriving(...)] line.
+
+sample usage: src/etc/generate-deriving-span-tests.py
+"""
+
+import sys, os, datetime, stat
+
+TEST_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../test/compile-fail'))
+
+YEAR = datetime.datetime.now().year
+
+TEMPLATE = """// Copyright {year} The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+{error_deriving}
+struct Error;
+{code}
+fn main() {{}}
+"""
+
+ENUM_STRING = """
+#[deriving({traits})]
+enum Enum {{
+   A(
+     Error {errors}
+     )
+}}
+"""
+ENUM_STRUCT_VARIANT_STRING = """
+#[deriving({traits})]
+enum Enum {{
+   A {{
+     x: Error {errors}
+   }}
+}}
+"""
+STRUCT_STRING = """
+#[deriving({traits})]
+struct Struct {{
+    x: Error {errors}
+}}
+"""
+STRUCT_TUPLE_STRING = """
+#[deriving({traits})]
+struct Struct(
+    Error {errors}
+);
+"""
+
+ENUM_TUPLE, ENUM_STRUCT, STRUCT_FIELDS, STRUCT_TUPLE = range(4)
+
+def create_test_case(type, trait, super_traits, number_of_errors):
+    string = [ENUM_STRING, ENUM_STRUCT_VARIANT_STRING, STRUCT_STRING, STRUCT_TUPLE_STRING][type]
+    all_traits = ','.join([trait] + super_traits)
+    super_traits = ','.join(super_traits)
+    error_deriving = '#[deriving(%s)]' % super_traits if super_traits else ''
+
+    errors = '\n'.join('//~%s ERROR' % ('^' * n) for n in range(error_count))
+    code = string.format(traits = all_traits, errors = errors)
+    return TEMPLATE.format(year = YEAR, error_deriving=error_deriving, code = code)
+
+def write_file(name, string):
+    test_file = os.path.join(TEST_DIR, 'deriving-span-%s.rs' % name)
+
+    # set write permission if file exists, so it can be changed
+    if os.path.exists(test_file):
+        os.chmod(test_file, stat.S_IWUSR)
+
+    with open(test_file, 'wt') as f:
+        f.write(string)
+
+    # mark file read-only
+    os.chmod(test_file, stat.S_IRUSR|stat.S_IRGRP|stat.S_IROTH)
+
+
+
+ENUM = 1
+STRUCT = 2
+ALL = STRUCT | ENUM
+
+traits = {
+    'Zero': (STRUCT, [], 1),
+    'Default': (STRUCT, [], 1),
+    'FromPrimitive': (0, [], 0), # only works for C-like enums
+
+    'Decodable': (0, [], 0), # FIXME: quoting gives horrible spans
+    'Encodable': (0, [], 0), # FIXME: quoting gives horrible spans
+}
+
+for (trait, supers, errs) in [('Rand', [], 1),
+                              ('Clone', [], 1), ('DeepClone', ['Clone'], 1),
+                              ('Eq', [], 2), ('Ord', [], 8),
+                              ('TotalEq', [], 2), ('TotalOrd', ['TotalEq'], 2)]:
+    traits[trait] = (ALL, supers, errs)
+
+for (trait, (types, super_traits, error_count)) in traits.items():
+    mk = lambda ty: create_test_case(ty, trait, super_traits, error_count)
+    if types & ENUM:
+        write_file(trait + '-enum', mk(ENUM_TUPLE))
+        write_file(trait + '-enum-struct-variant', mk(ENUM_STRUCT))
+    if types & STRUCT:
+        write_file(trait + '-struct', mk(STRUCT_FIELDS))
+        write_file(trait + '-tuple-struct', mk(STRUCT_TUPLE))

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -41,7 +41,7 @@ pub fn expand_deriving_default(cx: &ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn default_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn default_substructure(cx: &ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
     let default_ident = ~[
         cx.ident_of("std"),
         cx.ident_of("default"),
@@ -55,25 +55,25 @@ fn default_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Exp
             match *summary {
                 Unnamed(ref fields) => {
                     if fields.is_empty() {
-                        cx.expr_ident(span, substr.type_ident)
+                        cx.expr_ident(trait_span, substr.type_ident)
                     } else {
                         let exprs = fields.map(|sp| default_call(*sp));
-                        cx.expr_call_ident(span, substr.type_ident, exprs)
+                        cx.expr_call_ident(trait_span, substr.type_ident, exprs)
                     }
                 }
                 Named(ref fields) => {
                     let default_fields = fields.map(|&(ident, span)| {
                         cx.field_imm(span, ident, default_call(span))
                     });
-                    cx.expr_struct_ident(span, substr.type_ident, default_fields)
+                    cx.expr_struct_ident(trait_span, substr.type_ident, default_fields)
                 }
             }
         }
         StaticEnum(..) => {
-            cx.span_err(span, "`Default` cannot be derived for enums, only structs");
+            cx.span_err(trait_span, "`Default` cannot be derived for enums, only structs");
             // let compilation continue
-            cx.expr_uint(span, 0)
+            cx.expr_uint(trait_span, 0)
         }
-        _ => cx.bug("Non-static method in `deriving(Default)`")
+        _ => cx.span_bug(trait_span, "Non-static method in `deriving(Default)`")
     };
 }

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -169,8 +169,9 @@ StaticStruct(<ast::StructDef of A>, Named(~[(<ident of x>, <span of x>)]))
 
 StaticStruct(<ast::StructDef of B>, Unnamed(~[<span of x>]))
 
-StaticEnum(<ast::EnumDef of C>, ~[(<ident of C0>, Unnamed(~[<span of int>])),
-                                  (<ident of C1>, Named(~[(<ident of x>, <span of x>)]))])
+StaticEnum(<ast::EnumDef of C>, ~[(<ident of C0>, <span of C0>, Unnamed(~[<span of int>])),
+                                  (<ident of C1>, <span of C1>,
+                                   Named(~[(<ident of x>, <span of x>)]))])
 ~~~
 
 */
@@ -291,7 +292,7 @@ pub enum SubstructureFields<'a> {
     /// A static method where Self is a struct.
     StaticStruct(&'a ast::StructDef, StaticFields),
     /// A static method where Self is an enum.
-    StaticEnum(&'a ast::EnumDef, ~[(Ident, StaticFields)])
+    StaticEnum(&'a ast::EnumDef, ~[(Ident, Span, StaticFields)])
 }
 
 
@@ -905,7 +906,7 @@ impl<'a> MethodDef<'a> {
                     trait_.summarise_struct(struct_def)
                 }
             };
-            (ident, summary)
+            (ident, v.span, summary)
         });
         self.call_substructure_method(trait_, type_ident,
                                       self_args, nonself_args,

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -68,6 +68,7 @@ enum C {
     C0(int),
     C1 { x: int }
 }
+~~~
 
 The `int`s in `B` and `C0` don't have an identifier, so the
 `Option<ident>`s would be `None` for them.

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -57,7 +57,7 @@ pub fn expand_deriving_zero(cx: &ExtCtxt,
     trait_def.expand(mitem, in_items)
 }
 
-fn zero_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn zero_substructure(cx: &ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
     let zero_ident = ~[
         cx.ident_of("std"),
         cx.ident_of("num"),
@@ -71,24 +71,24 @@ fn zero_substructure(cx: &ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
             match *summary {
                 Unnamed(ref fields) => {
                     if fields.is_empty() {
-                        cx.expr_ident(span, substr.type_ident)
+                        cx.expr_ident(trait_span, substr.type_ident)
                     } else {
                         let exprs = fields.map(|sp| zero_call(*sp));
-                        cx.expr_call_ident(span, substr.type_ident, exprs)
+                        cx.expr_call_ident(trait_span, substr.type_ident, exprs)
                     }
                 }
                 Named(ref fields) => {
                     let zero_fields = fields.map(|&(ident, span)| {
                         cx.field_imm(span, ident, zero_call(span))
                     });
-                    cx.expr_struct_ident(span, substr.type_ident, zero_fields)
+                    cx.expr_struct_ident(trait_span, substr.type_ident, zero_fields)
                 }
             }
         }
         StaticEnum(..) => {
-            cx.span_err(span, "`Zero` cannot be derived for enums, only structs");
+            cx.span_err(trait_span, "`Zero` cannot be derived for enums, only structs");
             // let compilation continue
-            cx.expr_uint(span, 0)
+            cx.expr_uint(trait_span, 0)
         }
         _ => cx.bug("Non-static method in `deriving(Zero)`")
     };

--- a/src/test/compile-fail/deriving-span-Clone-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Clone-enum-struct-variant.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Clone)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+   }
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Clone-enum.rs
+++ b/src/test/compile-fail/deriving-span-Clone-enum.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Clone)]
+enum Enum {
+   A(
+     Error //~ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Clone-struct.rs
+++ b/src/test/compile-fail/deriving-span-Clone-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Clone)]
+struct Struct {
+    x: Error //~ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Clone-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Clone-tuple-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Clone)]
+struct Struct(
+    Error //~ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-DeepClone-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-DeepClone-enum-struct-variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct NotEq;
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
 
-#[deriving(Eq)]
-struct Foo {
-    x: NotEq //~ ERROR mismatched types
-        //~^ ERROR failed to find an implementation of trait std::cmp::Eq for NotEq
+#[feature(struct_variant)];
+extern mod extra;
+
+#[deriving(Clone)]
+struct Error;
+
+#[deriving(DeepClone,Clone)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+   }
 }
 
-pub fn main() {}
+fn main() {}

--- a/src/test/compile-fail/deriving-span-DeepClone-enum.rs
+++ b/src/test/compile-fail/deriving-span-DeepClone-enum.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+#[deriving(Clone)]
+struct Error;
+
+#[deriving(DeepClone,Clone)]
+enum Enum {
+   A(
+     Error //~ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-DeepClone-struct.rs
+++ b/src/test/compile-fail/deriving-span-DeepClone-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+#[deriving(Clone)]
+struct Error;
+
+#[deriving(DeepClone,Clone)]
+struct Struct {
+    x: Error //~ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-DeepClone-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-DeepClone-tuple-struct.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct NotEq;
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
 
-#[deriving(Eq)]
-struct Foo (
-    NotEq //~ ERROR mismatched types
-        //~^ ERROR failed to find an implementation of trait std::cmp::Eq for NotEq
-        );
+#[feature(struct_variant)];
+extern mod extra;
 
-pub fn main() {}
+#[deriving(Clone)]
+struct Error;
+
+#[deriving(DeepClone,Clone)]
+struct Struct(
+    Error //~ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Default-struct.rs
+++ b/src/test/compile-fail/deriving-span-Default-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Default)]
+struct Struct {
+    x: Error //~ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Default-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Default-tuple-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Default)]
+struct Struct(
+    Error //~ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Eq-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Eq-enum-struct-variant.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Eq)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+//~^ ERROR
+   }
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Eq-enum.rs
+++ b/src/test/compile-fail/deriving-span-Eq-enum.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Eq)]
+enum Enum {
+   A(
+     Error //~ ERROR
+//~^ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Eq-struct.rs
+++ b/src/test/compile-fail/deriving-span-Eq-struct.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Eq)]
+struct Struct {
+    x: Error //~ ERROR
+//~^ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Eq-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Eq-tuple-struct.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Eq)]
+struct Struct(
+    Error //~ ERROR
+//~^ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Ord-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Ord-enum-struct-variant.rs
@@ -1,0 +1,33 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Ord)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+//~^ ERROR
+//~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
+//~^^^^^ ERROR
+//~^^^^^^ ERROR
+//~^^^^^^^ ERROR
+   }
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Ord-enum.rs
+++ b/src/test/compile-fail/deriving-span-Ord-enum.rs
@@ -1,0 +1,33 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Ord)]
+enum Enum {
+   A(
+     Error //~ ERROR
+//~^ ERROR
+//~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
+//~^^^^^ ERROR
+//~^^^^^^ ERROR
+//~^^^^^^^ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Ord-struct.rs
+++ b/src/test/compile-fail/deriving-span-Ord-struct.rs
@@ -1,0 +1,31 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Ord)]
+struct Struct {
+    x: Error //~ ERROR
+//~^ ERROR
+//~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
+//~^^^^^ ERROR
+//~^^^^^^ ERROR
+//~^^^^^^^ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Ord-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Ord-tuple-struct.rs
@@ -1,0 +1,31 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Ord)]
+struct Struct(
+    Error //~ ERROR
+//~^ ERROR
+//~^^ ERROR
+//~^^^ ERROR
+//~^^^^ ERROR
+//~^^^^^ ERROR
+//~^^^^^^ ERROR
+//~^^^^^^^ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Rand-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Rand-enum-struct-variant.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Rand)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+   }
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Rand-enum.rs
+++ b/src/test/compile-fail/deriving-span-Rand-enum.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Rand)]
+enum Enum {
+   A(
+     Error //~ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Rand-struct.rs
+++ b/src/test/compile-fail/deriving-span-Rand-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Rand)]
+struct Struct {
+    x: Error //~ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Rand-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Rand-tuple-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Rand)]
+struct Struct(
+    Error //~ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalEq-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-enum-struct-variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
 #[feature(struct_variant)];
+extern mod extra;
 
-struct NotEq;
 
-#[deriving(Eq)]
-enum Foo {
-    Bar {
-        x: NotEq //~ ERROR mismatched types
-        //~^ ERROR failed to find an implementation of trait std::cmp::Eq for NotEq
-    }
+struct Error;
+
+#[deriving(TotalEq)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+//~^ ERROR
+   }
 }
 
-pub fn main() {}
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalEq-enum.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-enum.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(TotalEq)]
+enum Enum {
+   A(
+     Error //~ ERROR
+//~^ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalEq-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-struct.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(TotalEq)]
+struct Struct {
+    x: Error //~ ERROR
+//~^ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalEq-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-tuple-struct.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(TotalEq)]
+struct Struct(
+    Error //~ ERROR
+//~^ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-enum-struct-variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
 #[feature(struct_variant)];
+extern mod extra;
 
-struct NotEq;
+#[deriving(TotalEq)]
+struct Error;
 
-#[deriving(Eq)]
-enum Foo {
-    Bar(NotEq), //~ ERROR mismatched types
-        //~^ ERROR failed to find an implementation of trait std::cmp::Eq for NotEq
-    Baz { x: NotEq }
+#[deriving(TotalOrd,TotalEq)]
+enum Enum {
+   A {
+     x: Error //~ ERROR
+//~^ ERROR
+   }
 }
 
-pub fn main() {}
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalOrd-enum.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-enum.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+#[deriving(TotalEq)]
+struct Error;
+
+#[deriving(TotalOrd,TotalEq)]
+enum Enum {
+   A(
+     Error //~ ERROR
+//~^ ERROR
+     )
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalOrd-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-struct.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+#[deriving(TotalEq)]
+struct Error;
+
+#[deriving(TotalOrd,TotalEq)]
+struct Struct {
+    x: Error //~ ERROR
+//~^ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-TotalOrd-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-tuple-struct.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+#[deriving(TotalEq)]
+struct Error;
+
+#[deriving(TotalOrd,TotalEq)]
+struct Struct(
+    Error //~ ERROR
+//~^ ERROR
+);
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Zero-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Zero)]
+struct Struct {
+    x: Error //~ ERROR
+}
+
+fn main() {}

--- a/src/test/compile-fail/deriving-span-Zero-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-tuple-struct.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file was auto-generated using 'src/etc/generate-keyword-span-tests.py'
+
+#[feature(struct_variant)];
+extern mod extra;
+
+
+struct Error;
+
+#[deriving(Zero)]
+struct Struct(
+    Error //~ ERROR
+);
+
+fn main() {}


### PR DESCRIPTION
I'd forgotten to update them when I changed this a while ago; it now displays error messages linked to the struct/variant field, rather than the `#[deriving(Trait)]` line, for all traits.

This also adds a very large number of autogenerated tests. I can easily remove/tone down that commit if necessary.
