### PR TITLE
check for broken pipe when streaming the output.

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -29,7 +29,7 @@ out.write(bytes!("Hello, world!"));
 use container::Container;
 use fmt;
 use io::{Reader, Writer, io_error, IoError, OtherIoError,
-         standard_error, EndOfFile, LineBufferedWriter};
+         standard_error, EndOfFile, LineBufferedWriter, BrokenPipe};
 use libc;
 use option::{Option, Some, None};
 use prelude::drop;
@@ -353,7 +353,13 @@ impl Writer for StdWriter {
         };
         match ret {
             Ok(()) => {}
-            Err(e) => io_error::cond.raise(e)
+            Err(e) => {
+                // BrokenPipe (EPIPE) occurs when receiving process exits
+                // with error (i.e., non-zero) status
+                if e.kind != BrokenPipe {
+                   io_error::cond.raise(e)
+               }
+            }
         }
     }
 }


### PR DESCRIPTION
For instance, if we give command:

```
$rust | xargs -v
```

we get,

```
xargs: illegal option -- v

usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]

             [-L number] [-n number [-x]] [-P maxprocs] [-s size]

             [utility [argument ...]]

error: internal compiler error: unexpected failure

This message reflects a bug in the Rust compiler.

We would appreciate a bug report: http://static.rust-lang.org/doc/master/complement-bugreport.html

note: the compiler hit an unexpected failure path. this is a bug

task '<main>' failed at 'Unhandled condition: io_error: io::IoError{kind: BrokenPipe, desc: "broken pipe", detail: None}', /Users/abhay/devel/rust/rust/src/libstd/condition.rs:139
```

The `BrokenPipe` (or `EPIPE`) occurs when the receiving-end process returns non-zero exit-status.

I tested raising the condition with following `C` code:

```
//C File: test_line.c
#include <stdio.h>

int main() {
    char *line = NULL;
    size_t linecap = 0;
    ssize_t linelen;

    while ((linelen = getline(&line, &linecap, stdin)) > 0)
        fwrite(line, linelen, 1, stdout);   

    return 1;
}

```

The above code returns 1 after reading everything from the piped process.
The commands i executed:

```
$clang test_line.c -o test_line
$rustc | ./test_line
```

The last command gave the `unexpected failure` error.

This patch checks if raised condition is not BrokenPipe, and otherwise, it raised the condition.
