### PR TITLE
Fix bug: Include metdata for tuple struct constructor

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -766,6 +766,8 @@ fn encode_info_for_struct_ctor(ecx: &EncodeContext,
     ebml_w.start_tag(tag_items_data_item);
     encode_def_id(ebml_w, local_def(ctor_id));
     encode_family(ebml_w, 'f');
+    encode_bounds_and_type(ebml_w, ecx,
+                           &lookup_item_type(ecx.tcx, local_def(ctor_id)));
     encode_name(ecx, ebml_w, name);
     encode_type(ecx, ebml_w, node_id_to_type(ecx.tcx, ctor_id));
     encode_path(ecx, ebml_w, path, ast_map::PathName(name));

--- a/src/test/auxiliary/issue_10031_aux.rs
+++ b/src/test/auxiliary/issue_10031_aux.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Wrap<A>(A);

--- a/src/test/run-pass/issue-10031.rs
+++ b/src/test/run-pass/issue-10031.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// xfail-fast - check-fast doesn't understand aux-build
+// aux-build:issue_10031_aux.rs
+extern mod issue_10031_aux;
+
+pub fn main() {
+    let _ = issue_10031_aux::Wrap(());
+}


### PR DESCRIPTION
Fix #10031.
