### PR TITLE
extra: move arena and glob to libarena and libglob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ src/.DS_Store
 /doc/html
 /doc/latex
 /doc/std
+/doc/arena
 /doc/extra
 /doc/flate
 /doc/green

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ src/.DS_Store
 /doc/arena
 /doc/extra
 /doc/flate
+/doc/glob
 /doc/green
 /doc/native
 /doc/rustc

--- a/doc/index.md
+++ b/doc/index.md
@@ -39,6 +39,7 @@ li {list-style-type: none; }
 
 * [The `arena` allocation library](arena/index.html)
 * [The `flate` compression library](flate/index.html)
+* [The `glob` file path matching library](glob/index.html)
 
 # Tooling
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -37,6 +37,7 @@ li {list-style-type: none; }
 * [The Rust parser, `libsyntax`](syntax/index.html)
 * [The Rust compiler, `librustc`](rustc/index.html)
 
+* [The `arena` allocation library](arena/index.html)
 * [The `flate` compression library](flate/index.html)
 
 # Tooling

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -49,7 +49,7 @@
 # automatically generated for all stage/host/target combinations.
 ################################################################################
 
-TARGET_CRATES := std extra green rustuv native flate arena
+TARGET_CRATES := std extra green rustuv native flate arena glob
 HOST_CRATES := syntax rustc rustdoc rustpkg
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustpkg rustdoc rustc
@@ -65,6 +65,7 @@ DEPS_rustdoc := rustc native:sundown
 DEPS_rustpkg := rustc
 DEPS_flate := std native:miniz
 DEPS_arena := std extra
+DEPS_glob := std
 
 TOOL_DEPS_compiletest := extra green rustuv
 TOOL_DEPS_rustpkg := rustpkg green rustuv

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -49,7 +49,7 @@
 # automatically generated for all stage/host/target combinations.
 ################################################################################
 
-TARGET_CRATES := std extra green rustuv native flate
+TARGET_CRATES := std extra green rustuv native flate arena
 HOST_CRATES := syntax rustc rustdoc rustpkg
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustpkg rustdoc rustc
@@ -60,10 +60,11 @@ DEPS_green := std
 DEPS_rustuv := std native:uv native:uv_support
 DEPS_native := std
 DEPS_syntax := std extra
-DEPS_rustc := syntax native:rustllvm flate
+DEPS_rustc := syntax native:rustllvm flate arena
 DEPS_rustdoc := rustc native:sundown
 DEPS_rustpkg := rustc
 DEPS_flate := std native:miniz
+DEPS_arena := std extra
 
 TOOL_DEPS_compiletest := extra green rustuv
 TOOL_DEPS_rustpkg := rustpkg green rustuv

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -15,10 +15,17 @@
 //! of individual objects while the arena itself is still alive. The benefit
 //! of an arena is very fast allocation; just a pointer bump.
 
+#[crate_id = "arena#0.10-pre"];
+#[crate_type = "rlib"];
+#[crate_type = "dylib"];
+#[license = "MIT/ASL2"];
 #[allow(missing_doc)];
+#[feature(managed_boxes)];
 
-use list::{List, Cons, Nil};
-use list;
+extern mod extra;
+
+use extra::list::{List, Cons, Nil};
+use extra::list;
 
 use std::at_vec;
 use std::cast::{transmute, transmute_mut, transmute_mut_region};
@@ -493,7 +500,7 @@ impl<T> Drop for TypedArena<T> {
 #[cfg(test)]
 mod test {
     use super::{Arena, TypedArena};
-    use test::BenchHarness;
+    use extra::test::BenchHarness;
 
     struct Point {
         x: int,

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -67,7 +67,6 @@ pub mod ebml;
 pub mod getopts;
 pub mod json;
 pub mod tempfile;
-pub mod glob;
 pub mod term;
 pub mod time;
 pub mod base64;

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -70,7 +70,6 @@ pub mod tempfile;
 pub mod glob;
 pub mod term;
 pub mod time;
-pub mod arena;
 pub mod base64;
 pub mod workcache;
 pub mod enum_set;

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -23,6 +23,11 @@
  * `glob`/`fnmatch` functions.
  */
 
+#[crate_id = "glob#0.10-pre"];
+#[crate_type = "rlib"];
+#[crate_type = "dylib"];
+#[license = "MIT/ASL2"];
+
 use std::{os, path};
 use std::io;
 use std::io::fs;
@@ -53,7 +58,7 @@ pub struct Paths {
 /// `puppies.jpg` and `hamsters.gif`:
 ///
 /// ```rust
-/// use extra::glob::glob;
+/// use glob::glob;
 ///
 /// for path in glob("/media/pictures/*.jpg") {
 ///     println!("{}", path.display());
@@ -297,7 +302,7 @@ impl Pattern {
      * # Example
      *
      * ```rust
-     * use extra::glob::Pattern;
+     * use glob::Pattern;
      *
      * assert!(Pattern::new("c?t").matches("cat"));
      * assert!(Pattern::new("k[!e]tteh").matches("kitteh"));
@@ -537,7 +542,7 @@ impl MatchOptions {
 #[cfg(test)]
 mod test {
     use std::os;
-    use super::*;
+    use super::{glob, Pattern, MatchOptions};
 
     #[test]
     fn test_absolute_pattern() {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -31,6 +31,7 @@ This API is completely unstable and subject to change.
 
 extern mod extra;
 extern mod flate;
+extern mod arena;
 extern mod syntax;
 
 use back::link;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -68,7 +68,7 @@ use util::common::indenter;
 use util::ppaux::{Repr, ty_to_str};
 use util::sha2::Sha256;
 
-use extra::arena::TypedArena;
+use arena::TypedArena;
 use extra::time;
 use std::c_str::ToCStr;
 use std::cell::{Cell, RefCell};

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -31,7 +31,7 @@ use middle::typeck;
 use util::ppaux::Repr;
 
 
-use extra::arena::TypedArena;
+use arena::TypedArena;
 use std::c_str::ToCStr;
 use std::cast::transmute;
 use std::cast;

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -193,8 +193,8 @@ represents the "variance transform" as defined in the paper:
 */
 
 use std::hashmap::HashMap;
-use extra::arena;
-use extra::arena::Arena;
+use arena;
+use arena::Arena;
 use middle::ty;
 use std::vec;
 use syntax::ast;

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -9,10 +9,11 @@
 // except according to those terms.
 
 extern mod extra;
+extern mod arena;
 
 use std::iter::range_step;
 use extra::future::Future;
-use extra::arena::TypedArena;
+use arena::TypedArena;
 
 enum Tree<'a> {
     Nil,

--- a/src/test/run-pass/glob-std.rs
+++ b/src/test/run-pass/glob-std.rs
@@ -12,8 +12,9 @@
 // xfail-win32 TempDir may cause IoError on windows: #10462
 
 extern mod extra;
+extern mod glob;
 
-use extra::glob::glob;
+use glob::glob;
 use extra::tempfile::TempDir;
 use std::unstable::finally::Finally;
 use std::{os, unstable};

--- a/src/test/run-pass/placement-new-arena.rs
+++ b/src/test/run-pass/placement-new-arena.rs
@@ -10,8 +10,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern mod extra;
-use extra::arena::Arena;
+extern mod arena;
+use arena::Arena;
 
 pub fn main() {
     let mut arena = Arena::new();

--- a/src/test/run-pass/regions-mock-tcx.rs
+++ b/src/test/run-pass/regions-mock-tcx.rs
@@ -16,10 +16,9 @@
 // - Multiple lifetime parameters
 // - Arenas
 
-extern mod extra;
+extern mod arena;
 
-use extra::arena;
-use extra::arena::Arena;
+use arena::Arena;
 use std::hashmap::HashMap;
 use std::cast;
 use std::libc;


### PR DESCRIPTION
In line with the dissolution of libextra - #8784 - this moves arena and glob into
their own respective modules. Updates .gitignore with the entries
doc/{arena,glob} in accordance.
