### PR TITLE
mk: remove -fno-omit-frame-pointer

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -26,11 +26,6 @@ endef
 $(foreach t,$(CFG_TARGET),$(eval $(call DEF_OSTYPE_VAR,$(t))))
 $(foreach t,$(CFG_TARGET),$(info cfg: os for $(t) is $(OSTYPE_$(t))))
 
-# FIXME: no-omit-frame-pointer is just so that task_start_wrapper
-# has a frame pointer and the stack walker can understand it. Turning off
-# frame pointers everywhere is overkill
-CFG_GCCISH_CFLAGS += -fno-omit-frame-pointer
-
 # On Darwin, we need to run dsymutil so the debugging information ends
 # up in the right place.  On other platforms, it automatically gets
 # embedded into the executable, so use a no-op command.
@@ -160,7 +155,6 @@ CFG_DEF_SUFFIX_x86_64-unknown-linux-gnu := .linux.def
 CFG_LLC_FLAGS_x86_64-unknown-linux-gnu :=
 CFG_INSTALL_NAME_x86_64-unknown-linux-gnu =
 CFG_LIBUV_LINK_FLAGS_x86_64-unknown-linux-gnu =
-CFG_LLVM_BUILD_ENV_x86_64-unknown-linux-gnu="CXXFLAGS=-fno-omit-frame-pointer"
 CFG_EXE_SUFFIX_x86_64-unknown-linux-gnu =
 CFG_WINDOWSY_x86_64-unknown-linux-gnu :=
 CFG_UNIXY_x86_64-unknown-linux-gnu := 1
@@ -188,7 +182,6 @@ CFG_DEF_SUFFIX_i686-unknown-linux-gnu := .linux.def
 CFG_LLC_FLAGS_i686-unknown-linux-gnu :=
 CFG_INSTALL_NAME_i686-unknown-linux-gnu =
 CFG_LIBUV_LINK_FLAGS_i686-unknown-linux-gnu =
-CFG_LLVM_BUILD_ENV_i686-unknown-linux-gnu="CXXFLAGS=-fno-omit-frame-pointer"
 CFG_EXE_SUFFIX_i686-unknown-linux-gnu =
 CFG_WINDOWSY_i686-unknown-linux-gnu :=
 CFG_UNIXY_i686-unknown-linux-gnu := 1

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -128,6 +128,9 @@ pub mod write {
             };
             let use_softfp = sess.opts.debugging_opts & session::USE_SOFTFP != 0;
 
+            // FIXME: #11906: Omitting frame pointers breaks retrieving the value of a parameter.
+            let no_fp_elim = sess.opts.debuginfo;
+
             let tm = sess.targ_cfg.target_strs.target_triple.with_c_str(|T| {
                 sess.opts.target_cpu.with_c_str(|CPU| {
                     sess.opts.target_feature.with_c_str(|Features| {
@@ -137,7 +140,8 @@ pub mod write {
                             lib::llvm::RelocPIC,
                             OptLevel,
                             true,
-                            use_softfp
+                            use_softfp,
+                            no_fp_elim
                         )
                     })
                 })

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1728,7 +1728,8 @@ pub mod llvm {
                                            Reloc: RelocMode,
                                            Level: CodeGenOptLevel,
                                            EnableSegstk: bool,
-                                           UseSoftFP: bool) -> TargetMachineRef;
+                                           UseSoftFP: bool,
+                                           NoFramePointerElim: bool) -> TargetMachineRef;
         pub fn LLVMRustDisposeTargetMachine(T: TargetMachineRef);
         pub fn LLVMRustAddAnalysisPasses(T: TargetMachineRef,
                                          PM: PassManagerRef,

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -68,7 +68,8 @@ LLVMRustCreateTargetMachine(const char *triple,
                             Reloc::Model RM,
                             CodeGenOpt::Level OptLevel,
                             bool EnableSegmentedStacks,
-                            bool UseSoftFloat) {
+                            bool UseSoftFloat,
+                            bool NoFramePointerElim) {
     std::string Error;
     Triple Trip(Triple::normalize(triple));
     const llvm::Target *TheTarget = TargetRegistry::lookupTarget(Trip.getTriple(),
@@ -79,7 +80,7 @@ LLVMRustCreateTargetMachine(const char *triple,
     }
 
     TargetOptions Options;
-    Options.NoFramePointerElim = true;
+    Options.NoFramePointerElim = NoFramePointerElim;
     Options.EnableSegmentedStacks = EnableSegmentedStacks;
     Options.FloatABIType = FloatABI::Default;
     Options.UseSoftFloat = UseSoftFloat;

--- a/src/test/debug-info/function-prologue-stepping-no-split-stack.rs
+++ b/src/test/debug-info/function-prologue-stepping-no-split-stack.rs
@@ -244,6 +244,3 @@ fn main() {
     while_expr(40, 41, 42);
     loop_expr(43, 44, 45);
 }
-
-
-


### PR DESCRIPTION
This is still used for Rust code (`Options.NoFramePointerElim = true`).
