### PR TITLE
Add test case for #3243, which was fixed as part of fix for #3511.

### DIFF
--- a/src/test/compile-fail/regions-return-stack-allocated-vec.rs
+++ b/src/test/compile-fail/regions-return-stack-allocated-vec.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test
-fn function() -> &mut [int] {
-    let mut x: &'static mut [int] = &[1,2,3];
-    x[0] = 12345;
-    x //~ ERROR bad
+// Test that we cannot return a stack allocated slice
+
+fn function(x: int) -> &'static [int] {
+    &[x] //~ ERROR mismatched types
 }
 
 fn main() {
-    let x = function();
-    error!("%?", x);
+    let x = function(1);
+    let y = x[0];
 }


### PR DESCRIPTION
(Lifetime of stack allocated vectors was not being enforced)

Closes #3243.
