### PR TITLE
Rename Copyable to Cloneable to ensure consistency with the Clone trait

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -99,7 +99,7 @@ syn keyword rustTrait Tuple9 Tuple10 Tuple11 Tuple12
 syn keyword rustTrait ImmutableTuple1 ImmutableTuple2 ImmutableTuple3 ImmutableTuple4
 syn keyword rustTrait ImmutableTuple5 ImmutableTuple6 ImmutableTuple7 ImmutableTuple8
 syn keyword rustTrait ImmutableTuple9 ImmutableTuple10 ImmutableTuple11 ImmutableTuple12
-syn keyword rustTrait ImmutableEqVector ImmutableTotalOrdVector ImmutableCopyableVector
+syn keyword rustTrait ImmutableEqVector ImmutableTotalOrdVector ImmutableCloneableVector
 syn keyword rustTrait OwnedVector OwnedCloneableVector OwnedEqVector MutableVector
 syn keyword rustTrait Vector VectorVector CloneableVector ImmutableVector
 

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -100,7 +100,7 @@ syn keyword rustTrait ImmutableTuple1 ImmutableTuple2 ImmutableTuple3 ImmutableT
 syn keyword rustTrait ImmutableTuple5 ImmutableTuple6 ImmutableTuple7 ImmutableTuple8
 syn keyword rustTrait ImmutableTuple9 ImmutableTuple10 ImmutableTuple11 ImmutableTuple12
 syn keyword rustTrait ImmutableEqVector ImmutableTotalOrdVector ImmutableCopyableVector
-syn keyword rustTrait OwnedVector OwnedCopyableVector OwnedEqVector MutableVector
+syn keyword rustTrait OwnedVector OwnedCloneableVector OwnedEqVector MutableVector
 syn keyword rustTrait Vector VectorVector CloneableVector ImmutableVector
 
 "syn keyword rustFunction stream

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -101,7 +101,7 @@ syn keyword rustTrait ImmutableTuple5 ImmutableTuple6 ImmutableTuple7 ImmutableT
 syn keyword rustTrait ImmutableTuple9 ImmutableTuple10 ImmutableTuple11 ImmutableTuple12
 syn keyword rustTrait ImmutableEqVector ImmutableTotalOrdVector ImmutableCopyableVector
 syn keyword rustTrait OwnedVector OwnedCopyableVector OwnedEqVector MutableVector
-syn keyword rustTrait Vector VectorVector CopyableVector ImmutableVector
+syn keyword rustTrait Vector VectorVector CloneableVector ImmutableVector
 
 "syn keyword rustFunction stream
 syn keyword rustTrait Port Chan GenericChan GenericSmartChan GenericPort Peekable

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -92,7 +92,7 @@ syn keyword rustTrait SendStr SendStrOwned SendStrStatic IntoSendStr
 syn keyword rustTrait Str StrVector StrSlice OwnedStr
 syn keyword rustTrait IterBytes
 syn keyword rustTrait ToStr IntoStr
-syn keyword rustTrait CopyableTuple ImmutableTuple
+syn keyword rustTrait CloneableTuple ImmutableTuple
 syn keyword rustTrait Tuple1 Tuple2 Tuple3 Tuple4
 syn keyword rustTrait Tuple5 Tuple6 Tuple7 Tuple8
 syn keyword rustTrait Tuple9 Tuple10 Tuple11 Tuple12

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -72,7 +72,7 @@ use ptr::RawPtr;
 use ptr;
 use str::StrSlice;
 use str;
-use vec::{CopyableVector, ImmutableVector, MutableVector};
+use vec::{CloneableVector, ImmutableVector, MutableVector};
 use vec;
 use unstable::intrinsics;
 

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -15,7 +15,7 @@ use cmp;
 use io;
 use option::{None, Option, Some};
 use super::{Reader, Writer};
-use vec::{bytes, CopyableVector, MutableVector, ImmutableVector};
+use vec::{bytes, CloneableVector, MutableVector, ImmutableVector};
 
 /// Allows reading from a port.
 ///

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -17,7 +17,7 @@ use option::{Option, Some, None};
 use super::{Reader, Writer, Seek, Buffer, IoError, SeekStyle, io_error,
             OtherIoError};
 use vec;
-use vec::{Vector, ImmutableVector, MutableVector, OwnedCopyableVector};
+use vec::{Vector, ImmutableVector, MutableVector, OwnedCloneableVector};
 
 /// Writes to an owned, growable byte vector
 ///

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -302,7 +302,7 @@ use str::{StrSlice, OwnedStr};
 use to_str::ToStr;
 use uint;
 use unstable::finally::Finally;
-use vec::{OwnedVector, MutableVector, ImmutableVector, OwnedCopyableVector};
+use vec::{OwnedVector, MutableVector, ImmutableVector, OwnedCloneableVector};
 use vec;
 
 // Reexports

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -18,7 +18,7 @@ use option::{None, Option, Some};
 use char;
 use str::{StrSlice};
 use str;
-use vec::{CopyableVector, ImmutableVector, MutableVector};
+use vec::{CloneableVector, ImmutableVector, MutableVector};
 use vec::OwnedVector;
 use num;
 use num::{NumCast, Zero, One, cast, Integer};

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -73,7 +73,7 @@ use str;
 use str::{OwnedStr, Str, StrSlice};
 use to_str::ToStr;
 use vec;
-use vec::{CopyableVector, OwnedCopyableVector, OwnedVector, Vector};
+use vec::{CloneableVector, OwnedCopyableVector, OwnedVector, Vector};
 use vec::{ImmutableEqVector, ImmutableVector};
 
 /// Typedef for POSIX file paths.

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -73,7 +73,7 @@ use str;
 use str::{OwnedStr, Str, StrSlice};
 use to_str::ToStr;
 use vec;
-use vec::{CloneableVector, OwnedCopyableVector, OwnedVector, Vector};
+use vec::{CloneableVector, OwnedCloneableVector, OwnedVector, Vector};
 use vec::{ImmutableEqVector, ImmutableVector};
 
 /// Typedef for POSIX file paths.

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -21,7 +21,7 @@ use str;
 use str::Str;
 use to_bytes::IterBytes;
 use vec;
-use vec::{CopyableVector, RevSplits, Splits, Vector, VectorVector,
+use vec::{CloneableVector, RevSplits, Splits, Vector, VectorVector,
           ImmutableEqVector, OwnedVector, ImmutableVector, OwnedCopyableVector};
 use super::{BytesContainer, GenericPath, GenericPathUnsafe};
 
@@ -332,7 +332,7 @@ impl Path {
 
     /// Returns a normalized byte vector representation of a path, by removing all empty
     /// components, and unnecessary . and .. components.
-    fn normalize<V: Vector<u8>+CopyableVector<u8>>(v: V) -> ~[u8] {
+    fn normalize<V: Vector<u8>+CloneableVector<u8>>(v: V) -> ~[u8] {
         // borrowck is being very picky
         let val = {
             let is_abs = !v.as_slice().is_empty() && v.as_slice()[0] == SEP_BYTE;

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -22,7 +22,7 @@ use str::Str;
 use to_bytes::IterBytes;
 use vec;
 use vec::{CloneableVector, RevSplits, Splits, Vector, VectorVector,
-          ImmutableEqVector, OwnedVector, ImmutableVector, OwnedCopyableVector};
+          ImmutableEqVector, OwnedVector, ImmutableVector, OwnedCloneableVector};
 use super::{BytesContainer, GenericPath, GenericPathUnsafe};
 
 /// Iterator that yields successive components of a Path as &[u8]

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -76,7 +76,7 @@ pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
 pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
 pub use vec::{ImmutableEqVector, ImmutableTotalOrdVector, ImmutableCopyableVector};
-pub use vec::{OwnedVector, OwnedCopyableVector,OwnedEqVector};
+pub use vec::{OwnedVector, OwnedCloneableVector,OwnedEqVector};
 pub use vec::{MutableVector, MutableTotalOrdVector};
 pub use vec::{Vector, VectorVector, CloneableVector, ImmutableVector};
 

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -68,7 +68,7 @@ pub use send_str::{SendStr, SendStrOwned, SendStrStatic, IntoSendStr};
 pub use str::{Str, StrVector, StrSlice, OwnedStr};
 pub use to_bytes::IterBytes;
 pub use to_str::{ToStr, IntoStr};
-pub use tuple::{CopyableTuple, ImmutableTuple};
+pub use tuple::{CloneableTuple, ImmutableTuple};
 pub use tuple::{ImmutableTuple1, ImmutableTuple2, ImmutableTuple3, ImmutableTuple4};
 pub use tuple::{ImmutableTuple5, ImmutableTuple6, ImmutableTuple7, ImmutableTuple8};
 pub use tuple::{ImmutableTuple9, ImmutableTuple10, ImmutableTuple11, ImmutableTuple12};

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -75,7 +75,7 @@ pub use tuple::{ImmutableTuple9, ImmutableTuple10, ImmutableTuple11, ImmutableTu
 pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
 pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
-pub use vec::{ImmutableEqVector, ImmutableTotalOrdVector, ImmutableCopyableVector};
+pub use vec::{ImmutableEqVector, ImmutableTotalOrdVector, ImmutableCloneableVector};
 pub use vec::{OwnedVector, OwnedCloneableVector,OwnedEqVector};
 pub use vec::{MutableVector, MutableTotalOrdVector};
 pub use vec::{Vector, VectorVector, CloneableVector, ImmutableVector};

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -78,7 +78,7 @@ pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
 pub use vec::{ImmutableEqVector, ImmutableTotalOrdVector, ImmutableCopyableVector};
 pub use vec::{OwnedVector, OwnedCopyableVector,OwnedEqVector};
 pub use vec::{MutableVector, MutableTotalOrdVector};
-pub use vec::{Vector, VectorVector, CopyableVector, ImmutableVector};
+pub use vec::{Vector, VectorVector, CloneableVector, ImmutableVector};
 
 // Reexported runtime types
 pub use comm::{Port, Chan, SharedChan};

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -112,7 +112,7 @@ use to_str::ToStr;
 use from_str::FromStr;
 use uint;
 use vec;
-use vec::{OwnedVector, OwnedCopyableVector, ImmutableVector, MutableVector};
+use vec::{OwnedVector, OwnedCloneableVector, ImmutableVector, MutableVector};
 use default::Default;
 use send_str::{SendStr, SendStrOwned};
 use unstable::raw::Repr;

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -594,7 +594,7 @@ impl<'a> Iterator<&'a str> for StrSplits<'a> {
 // Helper functions used for Unicode normalization
 fn canonical_sort(comb: &mut [(char, u8)]) {
     use iter::range;
-    use tuple::CopyableTuple;
+    use tuple::CloneableTuple;
 
     let len = comb.len();
     for i in range(0, len) {

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -17,7 +17,7 @@ use clone::Clone;
 #[cfg(not(test))] use default::Default;
 
 /// Method extensions to pairs where both types satisfy the `Clone` bound
-pub trait CopyableTuple<T, U> {
+pub trait CloneableTuple<T, U> {
     /// Return the first element of self
     fn first(&self) -> T;
     /// Return the second element of self
@@ -26,7 +26,7 @@ pub trait CopyableTuple<T, U> {
     fn swap(&self) -> (U, T);
 }
 
-impl<T:Clone,U:Clone> CopyableTuple<T, U> for (T, U) {
+impl<T:Clone,U:Clone> CloneableTuple<T, U> for (T, U) {
     /// Return the first element of self
     #[inline]
     fn first(&self) -> T {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1261,7 +1261,7 @@ impl<'a, T: TotalOrd> ImmutableTotalOrdVector<T> for &'a [T] {
 }
 
 /// Extension methods for vectors containing `Clone` elements.
-pub trait ImmutableCopyableVector<T> {
+pub trait ImmutableCloneableVector<T> {
     /**
      * Partitions the vector into those that satisfies the predicate, and
      * those that do not.
@@ -1273,7 +1273,7 @@ pub trait ImmutableCopyableVector<T> {
     fn permutations(self) -> Permutations<T>;
 }
 
-impl<'a,T:Clone> ImmutableCopyableVector<T> for &'a [T] {
+impl<'a,T:Clone> ImmutableCloneableVector<T> for &'a [T] {
     #[inline]
     fn partitioned(&self, f: |&T| -> bool) -> (~[T], ~[T]) {
         let mut lefts  = ~[];

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -798,8 +798,8 @@ impl<T> Container for ~[T] {
     }
 }
 
-/// Extension methods for vector slices with copyable elements
-pub trait CopyableVector<T> {
+/// Extension methods for vector slices with cloneable elements
+pub trait CloneableVector<T> {
     /// Copy `self` into a new owned vector
     fn to_owned(&self) -> ~[T];
 
@@ -808,7 +808,7 @@ pub trait CopyableVector<T> {
 }
 
 /// Extension methods for vector slices
-impl<'a, T: Clone> CopyableVector<T> for &'a [T] {
+impl<'a, T: Clone> CloneableVector<T> for &'a [T] {
     /// Returns a copy of `v`.
     #[inline]
     fn to_owned(&self) -> ~[T] {
@@ -824,7 +824,7 @@ impl<'a, T: Clone> CopyableVector<T> for &'a [T] {
 }
 
 /// Extension methods for owned vectors
-impl<T: Clone> CopyableVector<T> for ~[T] {
+impl<T: Clone> CloneableVector<T> for ~[T] {
     #[inline]
     fn to_owned(&self) -> ~[T] { self.clone() }
 
@@ -833,7 +833,7 @@ impl<T: Clone> CopyableVector<T> for ~[T] {
 }
 
 /// Extension methods for managed vectors
-impl<T: Clone> CopyableVector<T> for @[T] {
+impl<T: Clone> CloneableVector<T> for @[T] {
     #[inline]
     fn to_owned(&self) -> ~[T] { self.as_slice().to_owned() }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1698,7 +1698,7 @@ impl<T> Mutable for ~[T] {
 }
 
 /// Extension methods for owned vectors containing `Clone` elements.
-pub trait OwnedCopyableVector<T:Clone> {
+pub trait OwnedCloneableVector<T:Clone> {
     /// Iterates over the slice `rhs`, copies each element, and then appends it to
     /// the vector provided `v`. The `rhs` vector is traversed in-order.
     ///
@@ -1732,7 +1732,7 @@ pub trait OwnedCopyableVector<T:Clone> {
     fn grow_set(&mut self, index: uint, initval: &T, val: T);
 }
 
-impl<T:Clone> OwnedCopyableVector<T> for ~[T] {
+impl<T:Clone> OwnedCloneableVector<T> for ~[T] {
     #[inline]
     fn push_all(&mut self, rhs: &[T]) {
         let new_len = self.len() + rhs.len();


### PR DESCRIPTION
I found awkward to have `MutableCloneableVector` and `CloneableIterator` on the one hand, and `CopyableVector` etc. on the other hand.

The concerned traits are:
- `CopyableVector` --> `CloneableVector`
- `OwnedCopyableVector` --> `OwnedCloneableVector`
- `ImmutableCopyableVector` --> `ImmutableCloneableVector`
- `CopyableTuple` --> `CloneableTuple`
