### PR TITLE
Implement clone() for TcpStream, UnixStream, and UdpSocket

### DIFF
--- a/src/librustuv/access.rs
+++ b/src/librustuv/access.rs
@@ -1,0 +1,109 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// An exclusive access primitive
+///
+/// This primitive is used to gain exclusive access to read() and write() in uv.
+/// It is assumed that all invocations of this struct happen on the same thread
+/// (the uv event loop).
+
+use std::cast;
+use std::sync::arc::UnsafeArc;
+use std::rt::task::{BlockedTask, Task};
+use std::rt::local::Local;
+
+use homing::HomingMissile;
+
+pub struct Access {
+    priv inner: UnsafeArc<Inner>,
+}
+
+pub struct Guard<'a> {
+    priv access: &'a mut Access,
+    priv missile: Option<HomingMissile>,
+}
+
+struct Inner {
+    queue: ~[BlockedTask],
+    held: bool,
+}
+
+impl Access {
+    pub fn new() -> Access {
+        Access {
+            inner: UnsafeArc::new(Inner {
+                queue: ~[],
+                held: false,
+            })
+        }
+    }
+
+    pub fn grant<'a>(&'a mut self, missile: HomingMissile) -> Guard<'a> {
+        // This unsafety is actually OK because the homing missile argument
+        // guarantees that we're on the same event loop as all the other objects
+        // attempting to get access granted.
+        let inner: &mut Inner = unsafe { cast::transmute(self.inner.get()) };
+
+        if inner.held {
+            let t: ~Task = Local::take();
+            t.deschedule(1, |task| {
+                inner.queue.push(task);
+                Ok(())
+            });
+            assert!(inner.held);
+        } else {
+            inner.held = true;
+        }
+
+        Guard { access: self, missile: Some(missile) }
+    }
+}
+
+impl Clone for Access {
+    fn clone(&self) -> Access {
+        Access { inner: self.inner.clone() }
+    }
+}
+
+#[unsafe_destructor]
+impl<'a> Drop for Guard<'a> {
+    fn drop(&mut self) {
+        // This guard's homing missile is still armed, so we're guaranteed to be
+        // on the same I/O event loop, so this unsafety should be ok.
+        assert!(self.missile.is_some());
+        let inner: &mut Inner = unsafe {
+            cast::transmute(self.access.inner.get())
+        };
+
+        match inner.queue.shift() {
+            // Here we have found a task that was waiting for access, and we
+            // current have the "access lock" we need to relinquish access to
+            // this sleeping task.
+            //
+            // To do so, we first drop out homing missile and we then reawaken
+            // the task. In reawakening the task, it will be immediately
+            // scheduled on this scheduler. Because we might be woken up on some
+            // other scheduler, we drop our homing missile before we reawaken
+            // the task.
+            Some(task) => {
+                drop(self.missile.take());
+                let _ = task.wake().map(|t| t.reawaken());
+            }
+            None => { inner.held = false; }
+        }
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        assert!(!self.held);
+        assert_eq!(self.queue.len(), 0);
+    }
+}

--- a/src/librustuv/homing.rs
+++ b/src/librustuv/homing.rs
@@ -125,8 +125,8 @@ pub trait HomingIO {
 /// After a homing operation has been completed, this will return the current
 /// task back to its appropriate home (if applicable). The field is used to
 /// assert that we are where we think we are.
-struct HomingMissile {
-    io_home: uint,
+pub struct HomingMissile {
+    priv io_home: uint,
 }
 
 impl HomingMissile {

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -68,8 +68,10 @@ pub use self::tty::TtyWatcher;
 
 mod macros;
 
-mod queue;
+mod access;
 mod homing;
+mod queue;
+mod rc;
 
 /// The implementation of `rtio` for libuv
 pub mod uvio;

--- a/src/librustuv/rc.rs
+++ b/src/librustuv/rc.rs
@@ -1,0 +1,49 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Simple refcount structure for cloning handles
+///
+/// This is meant to be an unintrusive solution to cloning handles in rustuv.
+/// The handles themselves shouldn't be sharing memory because there are bits of
+/// state in the rust objects which shouldn't be shared across multiple users of
+/// the same underlying uv object, hence Rc is not used and this simple counter
+/// should suffice.
+
+use std::sync::arc::UnsafeArc;
+
+pub struct Refcount {
+    priv rc: UnsafeArc<uint>,
+}
+
+impl Refcount {
+    /// Creates a new refcount of 1
+    pub fn new() -> Refcount {
+        Refcount { rc: UnsafeArc::new(1) }
+    }
+
+    fn increment(&self) {
+        unsafe { *self.rc.get() += 1; }
+    }
+
+    /// Returns whether the refcount just hit 0 or not
+    pub fn decrement(&self) -> bool {
+        unsafe {
+            *self.rc.get() -= 1;
+            *self.rc.get() == 0
+        }
+    }
+}
+
+impl Clone for Refcount {
+    fn clone(&self) -> Refcount {
+        self.increment();
+        Refcount { rc: self.rc.clone() }
+    }
+}

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -51,6 +51,12 @@ impl PipeStream {
     }
 }
 
+impl Clone for PipeStream {
+    fn clone(&self) -> PipeStream {
+        PipeStream { obj: self.obj.clone() }
+    }
+}
+
 impl Reader for PipeStream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { self.obj.read(buf) }
 }

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -960,6 +960,8 @@ pub mod types {
             }
             pub mod extra {
                 use ptr;
+                use libc::consts::os::extra::{MAX_PROTOCOL_CHAIN,
+                                              WSAPROTOCOL_LEN};
                 use libc::types::common::c95::c_void;
                 use libc::types::os::arch::c95::{c_char, c_int, c_uint, size_t};
                 use libc::types::os::arch::c95::{c_long, c_ulong};
@@ -1106,6 +1108,47 @@ pub mod types {
                 }
 
                 pub type LPFILETIME = *mut FILETIME;
+
+                pub struct GUID {
+                    Data1: DWORD,
+                    Data2: DWORD,
+                    Data3: DWORD,
+                    Data4: [BYTE, ..8],
+                }
+
+                struct WSAPROTOCOLCHAIN {
+                    ChainLen: c_int,
+                    ChainEntries: [DWORD, ..MAX_PROTOCOL_CHAIN],
+                }
+
+                pub type LPWSAPROTOCOLCHAIN = *mut WSAPROTOCOLCHAIN;
+
+                pub struct WSAPROTOCOL_INFO {
+                    dwServiceFlags1: DWORD,
+                    dwServiceFlags2: DWORD,
+                    dwServiceFlags3: DWORD,
+                    dwServiceFlags4: DWORD,
+                    dwProviderFlags: DWORD,
+                    ProviderId: GUID,
+                    dwCatalogEntryId: DWORD,
+                    ProtocolChain: WSAPROTOCOLCHAIN,
+                    iVersion: c_int,
+                    iAddressFamily: c_int,
+                    iMaxSockAddr: c_int,
+                    iMinSockAddr: c_int,
+                    iSocketType: c_int,
+                    iProtocol: c_int,
+                    iProtocolMaxOffset: c_int,
+                    iNetworkByteOrder: c_int,
+                    iSecurityScheme: c_int,
+                    dwMessageSize: DWORD,
+                    dwProviderReserved: DWORD,
+                    szProtocol: [u8, ..WSAPROTOCOL_LEN+1],
+                }
+
+                pub type LPWSAPROTOCOL_INFO = *mut WSAPROTOCOL_INFO;
+
+                pub type GROUP = c_uint;
             }
         }
     }
@@ -1721,6 +1764,10 @@ pub mod consts {
             pub static FILE_BEGIN: DWORD = 0;
             pub static FILE_CURRENT: DWORD = 1;
             pub static FILE_END: DWORD = 2;
+
+            pub static MAX_PROTOCOL_CHAIN: DWORD = 7;
+            pub static WSAPROTOCOL_LEN: DWORD = 255;
+            pub static INVALID_SOCKET: DWORD = !0;
         }
         pub mod sysconf {
         }
@@ -4098,6 +4145,8 @@ pub mod funcs {
                             lpFrequency: *mut LARGE_INTEGER) -> BOOL;
                 pub fn QueryPerformanceCounter(
                             lpPerformanceCount: *mut LARGE_INTEGER) -> BOOL;
+
+                pub fn GetCurrentProcessId() -> DWORD;
             }
         }
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -480,7 +480,6 @@ mod tests {
 
     use iter::range;
     use str::StrSlice;
-    use util;
     use kinds::marker;
     use vec::ImmutableVector;
 

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -203,6 +203,7 @@ pub trait RtioTcpStream : RtioSocket {
     fn nodelay(&mut self) -> Result<(), IoError>;
     fn keepalive(&mut self, delay_in_seconds: uint) -> Result<(), IoError>;
     fn letdie(&mut self) -> Result<(), IoError>;
+    fn clone(&self) -> ~RtioTcpStream;
 }
 
 pub trait RtioSocket {
@@ -224,6 +225,8 @@ pub trait RtioUdpSocket : RtioSocket {
 
     fn hear_broadcasts(&mut self) -> Result<(), IoError>;
     fn ignore_broadcasts(&mut self) -> Result<(), IoError>;
+
+    fn clone(&self) -> ~RtioUdpSocket;
 }
 
 pub trait RtioTimer {
@@ -253,6 +256,7 @@ pub trait RtioProcess {
 pub trait RtioPipe {
     fn read(&mut self, buf: &mut [u8]) -> Result<uint, IoError>;
     fn write(&mut self, buf: &[u8]) -> Result<(), IoError>;
+    fn clone(&self) -> ~RtioPipe;
 }
 
 pub trait RtioUnixListener {

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -380,7 +380,6 @@ mod test {
 
     use super::{Mutex, MUTEX_INIT};
     use rt::thread::Thread;
-    use task;
 
     #[test]
     fn somke_lock() {

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -69,7 +69,6 @@ impl Void {
 mod tests {
     use super::*;
     use prelude::*;
-    use mem::size_of;
 
     #[test]
     fn identity_crisis() {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -4253,7 +4253,7 @@ mod tests {
         let h = x.mut_last();
         assert_eq!(*h.unwrap(), 5);
 
-        let mut y: &mut [int] = [];
+        let y: &mut [int] = [];
         assert!(y.mut_last().is_none());
     }
 }


### PR DESCRIPTION
This is part of the overall strategy I would like to take when approaching
issue #11165. The only two I/O objects that reasonably want to be "split" are
the network stream objects. Everything else can be "split" by just creating
another version.

The initial idea I had was the literally split the object into a reader and a
writer half, but that would just introduce lots of clutter with extra interfaces
that were a little unnnecssary, or it would return a ~Reader and a ~Writer which
means you couldn't access things like the remote peer name or local socket name.

The solution I found to be nicer was to just clone the stream itself. The clone
is just a clone of the handle, nothing fancy going on at the kernel level.
Conceptually I found this very easy to wrap my head around (everything else
supports clone()), and it solved the "split" problem at the same time.

The cloning support is pretty specific per platform/lib combination:
- native/win32 - uses some specific WSA apis to clone the SOCKET handle
- native/unix - uses dup() to get another file descriptor
- green/all - This is where things get interesting. When we support full clones
            of a handle, this implies that we're allowing simultaneous writes
            and reads to happen. It turns out that libuv doesn't support two
            simultaneous reads or writes of the same object. It does support
            _one_ read and _one_ write at the same time, however. Some extra
            infrastructure was added to just block concurrent writers/readers
            until the previous read/write operation was completed.

I've added tests to the tcp/unix modules to make sure that this functionality is
supported everywhere.
