### PR TITLE
Fix SIMD bit shifts

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -30,7 +30,7 @@ use driver::session;
 use driver::session::Session;
 use driver::driver::{CrateAnalysis, CrateTranslation};
 use lib::llvm::{ModuleRef, ValueRef, BasicBlockRef};
-use lib::llvm::{llvm, True};
+use lib::llvm::{llvm, True, Vector};
 use lib;
 use metadata::common::LinkMeta;
 use metadata::{csearch, encoder};
@@ -827,8 +827,10 @@ pub fn cast_shift_rhs(op: ast::BinOp,
     // Shifts may have any size int on the rhs
     unsafe {
         if ast_util::is_shift_binop(op) {
-            let rhs_llty = val_ty(rhs);
-            let lhs_llty = val_ty(lhs);
+            let mut rhs_llty = val_ty(rhs);
+            let mut lhs_llty = val_ty(lhs);
+            if rhs_llty.kind() == Vector { rhs_llty = rhs_llty.element_type() }
+            if lhs_llty.kind() == Vector { lhs_llty = lhs_llty.element_type() }
             let rhs_sz = llvm::LLVMGetIntTypeWidth(rhs_llty.to_ref());
             let lhs_sz = llvm::LLVMGetIntTypeWidth(lhs_llty.to_ref());
             if lhs_sz < rhs_sz {

--- a/src/test/run-pass/simd-binop.rs
+++ b/src/test/run-pass/simd-binop.rs
@@ -10,7 +10,7 @@
 
 #[allow(experimental)];
 
-use std::unstable::simd::{i32x4, f32x4};
+use std::unstable::simd::{i32x4, f32x4, u32x4};
 
 fn test_int(e: i32) -> i32 {
     let v = i32x4(e, 0i32, 0i32, 0i32);
@@ -24,7 +24,15 @@ fn test_float(e: f32) -> f32 {
     e2
 }
 
+pub fn test_shift(e: u32) -> u32 {
+    let v = u32x4(e, 0u32, 0u32, 0u32);
+    let one = u32x4(1u32, 0u32, 0u32, 0u32);
+    let u32x4(e2, _, _, _) = v << one >> one;
+    e2
+}
+
 pub fn main() {
     assert_eq!(test_int(3i32), 9i32);
     assert_eq!(test_float(3f32), 9f32);
+    assert_eq!(test_shift(3u32), 3u32);
 }


### PR DESCRIPTION
For the purpose of deciding whether to truncate or extend the right hand side of bit shifts, use the size of the element type for SIMD vector types.

Fix #11900.
