### PR TITLE
Handle attributes on cross-crate tuple-structs correctly

### DIFF
--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -35,6 +35,8 @@ pub static tag_items_data_item_variant: uint = 0x0eu;
 
 pub static tag_items_data_parent_item: uint = 0x0fu;
 
+pub static tag_items_data_item_is_tuple_struct_ctor: uint = 0x10u;
+
 pub static tag_index: uint = 0x11u;
 
 pub static tag_index_buckets: uint = 0x12u;

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -778,6 +778,12 @@ fn encode_info_for_struct_ctor(ecx: &EncodeContext,
         encode_symbol(ecx, ebml_w, ctor_id);
     }
 
+    // indicate that this is a tuple struct ctor, because downstream users will normally want
+    // the tuple struct definition, but without this there is no way for them to tell that
+    // they actually have a ctor rather than a normal function
+    ebml_w.start_tag(tag_items_data_item_is_tuple_struct_ctor);
+    ebml_w.end_tag();
+
     ebml_w.end_tag();
 }
 

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -159,3 +159,17 @@ pub enum Enum {
     #[locked]
     LockedVariant,
 }
+
+#[deprecated]
+pub struct DeprecatedTupleStruct(int);
+#[experimental]
+pub struct ExperimentalTupleStruct(int);
+#[unstable]
+pub struct UnstableTupleStruct(int);
+pub struct UnmarkedTupleStruct(int);
+#[stable]
+pub struct StableTupleStruct(int);
+#[frozen]
+pub struct FrozenTupleStruct(int);
+#[locked]
+pub struct LockedTupleStruct(int);

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -101,6 +101,14 @@ mod cross_crate {
         let _ = StableVariant;
         let _ = FrozenVariant;
         let _ = LockedVariant;
+
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item
+        let _ = ExperimentalTupleStruct (1); //~ ERROR use of experimental item
+        let _ = UnstableTupleStruct (1); //~ ERROR use of unstable item
+        let _ = UnmarkedTupleStruct (1); //~ ERROR use of unmarked item
+        let _ = StableTupleStruct (1);
+        let _ = FrozenTupleStruct (1);
+        let _ = LockedTupleStruct (1);
     }
 
     fn test_method_param<F: Trait>(foo: F) {
@@ -277,6 +285,20 @@ mod this_crate {
         LockedVariant,
     }
 
+    #[deprecated]
+    pub struct DeprecatedTupleStruct(int);
+    #[experimental]
+    pub struct ExperimentalTupleStruct(int);
+    #[unstable]
+    pub struct UnstableTupleStruct(int);
+    pub struct UnmarkedTupleStruct(int);
+    #[stable]
+    pub struct StableTupleStruct(int);
+    #[frozen]
+    pub struct FrozenTupleStruct(int);
+    #[locked]
+    pub struct LockedTupleStruct(int);
+
     fn test() {
         let foo = MethodTester;
 
@@ -356,6 +378,14 @@ mod this_crate {
         let _ = StableVariant;
         let _ = FrozenVariant;
         let _ = LockedVariant;
+
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item
+        let _ = ExperimentalTupleStruct (1); //~ ERROR use of experimental item
+        let _ = UnstableTupleStruct (1); //~ ERROR use of unstable item
+        let _ = UnmarkedTupleStruct (1); //~ ERROR use of unmarked item
+        let _ = StableTupleStruct (1);
+        let _ = FrozenTupleStruct (1);
+        let _ = LockedTupleStruct (1);
     }
 
     fn test_method_param<F: Trait>(foo: F) {

--- a/src/test/compile-fail/simd-experimental.rs
+++ b/src/test/compile-fail/simd-experimental.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// xfail-test FIXME #11741 tuple structs ignore stability attributes
-
 #[deny(experimental)];
 
 use std::unstable::simd;


### PR DESCRIPTION
Fixes #11741
Added tests and removed xfail-fast from run-pass/simd-experimental which is now fixed (see #11738).
