### PR TITLE
Fix inconsistency in tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -646,7 +646,7 @@ match mypoint {
 ## Enums
 
 Enums are datatypes that have several alternate representations. For
-example, consider the type shown earlier:
+example, consider the following type:
 
 ~~~~
 # struct Point { x: f64, y: f64 }


### PR DESCRIPTION
Text refers to "the type shown earlier", when the type in
question was not in fact shown earlier.  I assume this is
an artifact of an earlier revision.
