### PR TITLE
Remove io::io_error

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -234,7 +234,13 @@ pub fn run_tests(config: &config) {
     // For context, see #8904
     io::test::raise_fd_limit();
     let res = test::run_tests_console(&opts, tests);
-    if !res { fail!("Some tests failed"); }
+    match res {
+        Ok(true) => {}
+        Ok(false) => fail!("Some tests failed"),
+        Err(e) => {
+            println!("I/O failure during tests: {}", e);
+        }
+    }
 }
 
 pub fn test_opts(config: &config) -> test::TestOpts {
@@ -255,7 +261,7 @@ pub fn make_tests(config: &config) -> ~[test::TestDescAndFn] {
     debug!("making tests from {}",
            config.src_base.display());
     let mut tests = ~[];
-    let dirs = fs::readdir(&config.src_base);
+    let dirs = fs::readdir(&config.src_base).unwrap();
     for file in dirs.iter() {
         let file = file.clone();
         debug!("inspecting file {}", file.display());

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -58,9 +58,9 @@ pub fn run(lib_path: &str,
     });
 
     match opt_process {
-        Some(ref mut process) => {
+        Ok(ref mut process) => {
             for input in input.iter() {
-                process.input().write(input.as_bytes());
+                process.input().write(input.as_bytes()).unwrap();
             }
             let run::ProcessOutput { status, output, error } = process.finish_with_output();
 
@@ -70,7 +70,7 @@ pub fn run(lib_path: &str,
                 err: str::from_utf8_owned(error).unwrap()
             })
         },
-        None => None
+        Err(..) => None
     }
 }
 
@@ -90,13 +90,13 @@ pub fn run_background(lib_path: &str,
     });
 
     match opt_process {
-        Some(mut process) => {
+        Ok(mut process) => {
             for input in input.iter() {
-                process.input().write(input.as_bytes());
+                process.input().write(input.as_bytes()).unwrap();
             }
 
             Some(process)
         },
-        None => None
+        Err(..) => None
     }
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -153,7 +153,7 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
     let rounds =
         match props.pp_exact { Some(_) => 1, None => 2 };
 
-    let src = File::open(testfile).read_to_end();
+    let src = File::open(testfile).read_to_end().unwrap();
     let src = str::from_utf8_owned(src).unwrap();
     let mut srcs = ~[src];
 
@@ -175,7 +175,7 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
     let mut expected = match props.pp_exact {
         Some(ref file) => {
             let filepath = testfile.dir_path().join(file);
-            let s = File::open(&filepath).read_to_end();
+            let s = File::open(&filepath).read_to_end().unwrap();
             str::from_utf8_owned(s).unwrap()
           }
           None => { srcs[srcs.len() - 2u].clone() }
@@ -318,8 +318,10 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
                 //waiting 1 second for gdbserver start
                 timer::sleep(1000);
                 let result = task::try(proc() {
-                    tcp::TcpStream::connect(
-                        SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 5039 });
+                    tcp::TcpStream::connect(SocketAddr {
+                        ip: Ipv4Addr(127, 0, 0, 1),
+                        port: 5039,
+                    }).unwrap();
                 });
                 if result.is_err() {
                     continue;
@@ -361,7 +363,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
                                stdout: out,
                                stderr: err,
                                cmdline: cmdline};
-            process.force_destroy();
+            process.force_destroy().unwrap();
         }
 
         _=> {
@@ -727,7 +729,7 @@ fn compose_and_run_compiler(
 
 fn ensure_dir(path: &Path) {
     if path.is_dir() { return; }
-    fs::mkdir(path, io::UserRWX);
+    fs::mkdir(path, io::UserRWX).unwrap();
 }
 
 fn compose_and_run(config: &config, testfile: &Path,
@@ -852,7 +854,7 @@ fn dump_output(config: &config, testfile: &Path, out: &str, err: &str) {
 fn dump_output_file(config: &config, testfile: &Path,
                     out: &str, extension: &str) {
     let outfile = make_out_name(config, testfile, extension);
-    File::create(&outfile).write(out.as_bytes());
+    File::create(&outfile).write(out.as_bytes()).unwrap();
 }
 
 fn make_out_name(config: &config, testfile: &Path, extension: &str) -> Path {
@@ -1003,7 +1005,7 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
 fn _arm_push_aux_shared_library(config: &config, testfile: &Path) {
     let tdir = aux_output_dir_name(config, testfile);
 
-    let dirs = fs::readdir(&tdir);
+    let dirs = fs::readdir(&tdir).unwrap();
     for file in dirs.iter() {
         if file.extension_str() == Some("so") {
             // FIXME (#9639): This needs to handle non-utf8 paths
@@ -1099,7 +1101,7 @@ fn disassemble_extract(config: &config, _props: &TestProps,
 
 
 fn count_extracted_lines(p: &Path) -> uint {
-    let x = File::open(&p.with_extension("ll")).read_to_end();
+    let x = File::open(&p.with_extension("ll")).read_to_end().unwrap();
     let x = str::from_utf8_owned(x).unwrap();
     x.lines().len()
 }

--- a/src/doc/guide-conditions.md
+++ b/src/doc/guide-conditions.md
@@ -47,7 +47,7 @@ An example program that does this task reads like this:
 # #[allow(unused_imports)];
 use std::io::{BufferedReader, File};
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{File, IoResult};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -55,7 +55,7 @@ use std::io::{BufferedReader, File};
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -71,7 +71,6 @@ fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
 
     // Path takes a generic by-value, rather than by reference
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
     let mut reader = BufferedReader::new(File::open(&path));
 
@@ -245,7 +244,7 @@ and trapping its exit status using `task::try`:
 use std::io::{BufferedReader, File};
 use std::task;
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{File, IoResult};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -253,7 +252,7 @@ use std::task;
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -277,7 +276,6 @@ fn main() {
 
 fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
 
     let mut reader = BufferedReader::new(File::open(&path));
@@ -347,7 +345,7 @@ but similarly clear as the version that used `fail!` in the logic where the erro
 # #[allow(unused_imports)];
 use std::io::{BufferedReader, File};
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{File, IoResult};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -355,7 +353,7 @@ use std::io::{BufferedReader, File};
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -374,7 +372,6 @@ fn main() {
 
 fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
 
     let mut reader = BufferedReader::new(File::open(&path));
@@ -415,7 +412,7 @@ and replaces bad input lines with the pair `(-1,-1)`:
 # #[allow(unused_imports)];
 use std::io::{BufferedReader, File};
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{File, IoResult};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -423,7 +420,7 @@ use std::io::{BufferedReader, File};
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -447,7 +444,6 @@ fn main() {
 
 fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
 
     let mut reader = BufferedReader::new(File::open(&path));
@@ -489,7 +485,7 @@ Changing the condition's return type from `(int,int)` to `Option<(int,int)>` wil
 # #[allow(unused_imports)];
 use std::io::{BufferedReader, File};
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{IoResult, File};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -497,7 +493,7 @@ use std::io::{BufferedReader, File};
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -522,7 +518,6 @@ fn main() {
 
 fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
 
     let mut reader = BufferedReader::new(File::open(&path));
@@ -573,7 +568,7 @@ This can be encoded in the handler API by introducing a helper type: `enum Malfo
 # #[allow(unused_imports)];
 use std::io::{BufferedReader, File};
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{File, IoResult};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -581,7 +576,7 @@ use std::io::{BufferedReader, File};
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -615,7 +610,6 @@ fn main() {
 
 fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
 
     let mut reader = BufferedReader::new(File::open(&path));
@@ -696,7 +690,7 @@ a second condition and a helper function will suffice:
 # #[allow(unused_imports)];
 use std::io::{BufferedReader, File};
 # mod BufferedReader {
-#     use std::io::File;
+#     use std::io::{File, IoResult};
 #     use std::io::MemReader;
 #     use std::io::BufferedReader;
 #     static s : &'static [u8] = bytes!("1 2\n\
@@ -704,7 +698,7 @@ use std::io::{BufferedReader, File};
 #                                        789 123\n\
 #                                        45 67\n\
 #                                        ");
-#     pub fn new(_inner: Option<File>) -> BufferedReader<MemReader> {
+#     pub fn new(_inner: IoResult<File>) -> BufferedReader<MemReader> {
 #           BufferedReader::new(MemReader::new(s.to_owned()))
 #     }
 # }
@@ -752,7 +746,6 @@ fn parse_int(x: &str) -> int {
 
 fn read_int_pairs() -> ~[(int,int)] {
     let mut pairs = ~[];
-#    let _g = std::io::ignore_io_error();
     let path = Path::new(&"foo.txt");
 
     let mut reader = BufferedReader::new(File::open(&path));

--- a/src/etc/combine-tests.py
+++ b/src/etc/combine-tests.py
@@ -69,6 +69,7 @@ extern mod run_pass_stage2;
 use run_pass_stage2::*;
 use std::io;
 use std::io::Writer;
+#[allow(warnings)]
 fn main() {
     let mut out = io::stdout();
 """

--- a/src/libextra/arc.rs
+++ b/src/libextra/arc.rs
@@ -637,7 +637,7 @@ mod tests {
     fn test_mutex_arc_poison() {
         let arc = ~MutexArc::new(1);
         let arc2 = ~arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.access(|one| {
                 assert_eq!(*one, 2);
             })
@@ -668,7 +668,7 @@ mod tests {
     fn test_mutex_arc_access_in_unwind() {
         let arc = MutexArc::new(1i);
         let arc2 = arc.clone();
-        task::try::<()>(proc() {
+        let _ = task::try::<()>(proc() {
             struct Unwinder {
                 i: MutexArc<int>
             }
@@ -687,7 +687,7 @@ mod tests {
     fn test_rw_arc_poison_wr() {
         let arc = RWArc::new(1);
         let arc2 = arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.write(|one| {
                 assert_eq!(*one, 2);
             })
@@ -701,7 +701,7 @@ mod tests {
     fn test_rw_arc_poison_ww() {
         let arc = RWArc::new(1);
         let arc2 = arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.write(|one| {
                 assert_eq!(*one, 2);
             })
@@ -714,7 +714,7 @@ mod tests {
     fn test_rw_arc_poison_dw() {
         let arc = RWArc::new(1);
         let arc2 = arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.write_downgrade(|mut write_mode| {
                 write_mode.write(|one| {
                     assert_eq!(*one, 2);
@@ -729,7 +729,7 @@ mod tests {
     fn test_rw_arc_no_poison_rr() {
         let arc = RWArc::new(1);
         let arc2 = arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.read(|one| {
                 assert_eq!(*one, 2);
             })
@@ -742,7 +742,7 @@ mod tests {
     fn test_rw_arc_no_poison_rw() {
         let arc = RWArc::new(1);
         let arc2 = arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.read(|one| {
                 assert_eq!(*one, 2);
             })
@@ -755,7 +755,7 @@ mod tests {
     fn test_rw_arc_no_poison_dr() {
         let arc = RWArc::new(1);
         let arc2 = arc.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             arc2.write_downgrade(|write_mode| {
                 let read_mode = arc2.downgrade(write_mode);
                 read_mode.read(|one| {
@@ -800,7 +800,7 @@ mod tests {
 
         // Wait for children to pass their asserts
         for r in children.mut_iter() {
-            r.recv();
+            let _ = r.recv();
         }
 
         // Wait for writer to finish
@@ -814,7 +814,7 @@ mod tests {
     fn test_rw_arc_access_in_unwind() {
         let arc = RWArc::new(1i);
         let arc2 = arc.clone();
-        task::try::<()>(proc() {
+        let _ = task::try::<()>(proc() {
             struct Unwinder {
                 i: RWArc<int>
             }

--- a/src/libextra/base64.rs
+++ b/src/libextra/base64.rs
@@ -359,7 +359,7 @@ mod test {
                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
         let b = s.as_bytes().to_base64(STANDARD);
         bh.iter(|| {
-            b.from_base64();
+            b.from_base64().unwrap();
         });
         bh.bytes = b.len() as u64;
     }

--- a/src/libextra/hex.rs
+++ b/src/libextra/hex.rs
@@ -201,7 +201,7 @@ mod tests {
                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
         let b = s.as_bytes().to_hex();
         bh.iter(|| {
-            b.from_hex();
+            b.from_hex().unwrap();
         });
         bh.bytes = b.len() as u64;
     }

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -34,6 +34,11 @@ Rust extras are part of the standard Rust distribution.
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];
 
+#[cfg(stage0)]
+macro_rules! if_ok (
+    ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
+)
+
 // Utility modules
 
 pub mod c_vec;

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -322,14 +322,15 @@ pub fn winsorize(samples: &mut [f64], pct: f64) {
 }
 
 /// Render writes the min, max and quartiles of the provided `Summary` to the provided `Writer`.
-pub fn write_5_number_summary(w: &mut io::Writer, s: &Summary) {
+pub fn write_5_number_summary(w: &mut io::Writer,
+                              s: &Summary) -> io::IoResult<()> {
     let (q1,q2,q3) = s.quartiles;
     write!(w, "(min={}, q1={}, med={}, q3={}, max={})",
                      s.min,
                      q1,
                      q2,
                      q3,
-                     s.max);
+                     s.max)
 }
 
 /// Render a boxplot to the provided writer. The boxplot shows the min, max and quartiles of the
@@ -344,7 +345,8 @@ pub fn write_5_number_summary(w: &mut io::Writer, s: &Summary) {
 ///   10 |        [--****#******----------]          | 40
 /// ~~~~
 
-pub fn write_boxplot(w: &mut io::Writer, s: &Summary, width_hint: uint) {
+pub fn write_boxplot(w: &mut io::Writer, s: &Summary,
+                     width_hint: uint) -> io::IoResult<()> {
 
     let (q1,q2,q3) = s.quartiles;
 
@@ -374,48 +376,49 @@ pub fn write_boxplot(w: &mut io::Writer, s: &Summary, width_hint: uint) {
     let range_width = width_hint - overhead_width;;
     let char_step = range / (range_width as f64);
 
-    write!(w, "{} |", lostr);
+    if_ok!(write!(w, "{} |", lostr));
 
     let mut c = 0;
     let mut v = lo;
 
     while c < range_width && v < s.min {
-        write!(w, " ");
+        if_ok!(write!(w, " "));
         v += char_step;
         c += 1;
     }
-    write!(w, "[");
+    if_ok!(write!(w, "["));
     c += 1;
     while c < range_width && v < q1 {
-        write!(w, "-");
+        if_ok!(write!(w, "-"));
         v += char_step;
         c += 1;
     }
     while c < range_width && v < q2 {
-        write!(w, "*");
+        if_ok!(write!(w, "*"));
         v += char_step;
         c += 1;
     }
-    write!(w, r"\#");
+    if_ok!(write!(w, r"\#"));
     c += 1;
     while c < range_width && v < q3 {
-        write!(w, "*");
+        if_ok!(write!(w, "*"));
         v += char_step;
         c += 1;
     }
     while c < range_width && v < s.max {
-        write!(w, "-");
+        if_ok!(write!(w, "-"));
         v += char_step;
         c += 1;
     }
-    write!(w, "]");
+    if_ok!(write!(w, "]"));
     while c < range_width {
-        write!(w, " ");
+        if_ok!(write!(w, " "));
         v += char_step;
         c += 1;
     }
 
-    write!(w, "| {}", histr);
+    if_ok!(write!(w, "| {}", histr));
+    Ok(())
 }
 
 /// Returns a HashMap with the number of occurrences of every element in the

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -456,11 +456,11 @@ mod tests {
 
         let mut w = io::stdout();
         let w = &mut w as &mut io::Writer;
-        write!(w, "\n");
-        write_5_number_summary(w, &summ2);
-        write!(w, "\n");
-        write_boxplot(w, &summ2, 50);
-        write!(w, "\n");
+        (write!(w, "\n")).unwrap();
+        write_5_number_summary(w, &summ2).unwrap();
+        (write!(w, "\n")).unwrap();
+        write_boxplot(w, &summ2, 50).unwrap();
+        (write!(w, "\n")).unwrap();
 
         assert_eq!(summ.sum, summ2.sum);
         assert_eq!(summ.min, summ2.min);
@@ -1003,7 +1003,7 @@ mod tests {
         fn t(s: &Summary, expected: ~str) {
             use std::io::MemWriter;
             let mut m = MemWriter::new();
-            write_boxplot(&mut m as &mut io::Writer, s, 30);
+            write_boxplot(&mut m as &mut io::Writer, s, 30).unwrap();
             let out = str::from_utf8_owned(m.unwrap()).unwrap();
             assert_eq!(out, expected);
         }

--- a/src/libextra/sync.rs
+++ b/src/libextra/sync.rs
@@ -959,7 +959,7 @@ mod tests {
     fn test_mutex_cond_no_waiter() {
         let m = Mutex::new();
         let m2 = m.clone();
-        task::try(proc() {
+        let _ = task::try(proc() {
             m.lock_cond(|_x| { })
         });
         m2.lock_cond(|cond| {

--- a/src/libextra/tempfile.rs
+++ b/src/libextra/tempfile.rs
@@ -38,7 +38,7 @@ impl TempDir {
         let mut r = rand::rng();
         for _ in range(0u, 1000) {
             let p = tmpdir.join(r.gen_ascii_str(16) + suffix);
-            match io::result(|| fs::mkdir(&p, io::UserRWX)) {
+            match fs::mkdir(&p, io::UserRWX) {
                 Err(..) => {}
                 Ok(()) => return Some(TempDir { path: Some(p) })
             }
@@ -73,7 +73,8 @@ impl Drop for TempDir {
     fn drop(&mut self) {
         for path in self.path.iter() {
             if path.exists() {
-                fs::rmdir_recursive(path);
+                // FIXME: is failing the right thing to do?
+                fs::rmdir_recursive(path).unwrap();
             }
         }
     }

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -163,7 +163,11 @@ pub fn test_main(args: &[~str], tests: ~[TestDescAndFn]) {
             Some(Err(msg)) => fail!("{}", msg),
             None => return
         };
-    if !run_tests_console(&opts, tests) { fail!("Some tests failed"); }
+    match run_tests_console(&opts, tests) {
+        Ok(true) => {}
+        Ok(false) => fail!("Some tests failed"),
+        Err(e) => fail!("io error when running tests: {}", e),
+    }
 }
 
 // A variant optimized for invocation with a static test vector.
@@ -359,16 +363,17 @@ struct ConsoleTestState<T> {
 }
 
 impl<T: Writer> ConsoleTestState<T> {
-    pub fn new(opts: &TestOpts, _: Option<T>) -> ConsoleTestState<StdWriter> {
+    pub fn new(opts: &TestOpts,
+               _: Option<T>) -> io::IoResult<ConsoleTestState<StdWriter>> {
         let log_out = match opts.logfile {
-            Some(ref path) => File::create(path),
+            Some(ref path) => Some(if_ok!(File::create(path))),
             None => None
         };
         let out = match term::Terminal::new(io::stdout()) {
             Err(_) => Raw(io::stdout()),
             Ok(t) => Pretty(t)
         };
-        ConsoleTestState {
+        Ok(ConsoleTestState {
             out: out,
             log_out: log_out,
             use_color: use_color(),
@@ -380,100 +385,103 @@ impl<T: Writer> ConsoleTestState<T> {
             metrics: MetricMap::new(),
             failures: ~[],
             max_name_len: 0u,
-        }
+        })
     }
 
-    pub fn write_ok(&mut self) {
-        self.write_pretty("ok", term::color::GREEN);
+    pub fn write_ok(&mut self) -> io::IoResult<()> {
+        self.write_pretty("ok", term::color::GREEN)
     }
 
-    pub fn write_failed(&mut self) {
-        self.write_pretty("FAILED", term::color::RED);
+    pub fn write_failed(&mut self) -> io::IoResult<()> {
+        self.write_pretty("FAILED", term::color::RED)
     }
 
-    pub fn write_ignored(&mut self) {
-        self.write_pretty("ignored", term::color::YELLOW);
+    pub fn write_ignored(&mut self) -> io::IoResult<()> {
+        self.write_pretty("ignored", term::color::YELLOW)
     }
 
-    pub fn write_metric(&mut self) {
-        self.write_pretty("metric", term::color::CYAN);
+    pub fn write_metric(&mut self) -> io::IoResult<()> {
+        self.write_pretty("metric", term::color::CYAN)
     }
 
-    pub fn write_bench(&mut self) {
-        self.write_pretty("bench", term::color::CYAN);
+    pub fn write_bench(&mut self) -> io::IoResult<()> {
+        self.write_pretty("bench", term::color::CYAN)
     }
 
-    pub fn write_added(&mut self) {
-        self.write_pretty("added", term::color::GREEN);
+    pub fn write_added(&mut self) -> io::IoResult<()> {
+        self.write_pretty("added", term::color::GREEN)
     }
 
-    pub fn write_improved(&mut self) {
-        self.write_pretty("improved", term::color::GREEN);
+    pub fn write_improved(&mut self) -> io::IoResult<()> {
+        self.write_pretty("improved", term::color::GREEN)
     }
 
-    pub fn write_removed(&mut self) {
-        self.write_pretty("removed", term::color::YELLOW);
+    pub fn write_removed(&mut self) -> io::IoResult<()> {
+        self.write_pretty("removed", term::color::YELLOW)
     }
 
-    pub fn write_regressed(&mut self) {
-        self.write_pretty("regressed", term::color::RED);
+    pub fn write_regressed(&mut self) -> io::IoResult<()> {
+        self.write_pretty("regressed", term::color::RED)
     }
 
     pub fn write_pretty(&mut self,
                         word: &str,
-                        color: term::color::Color) {
+                        color: term::color::Color) -> io::IoResult<()> {
         match self.out {
             Pretty(ref mut term) => {
                 if self.use_color {
-                    term.fg(color);
+                    if_ok!(term.fg(color));
                 }
-                term.write(word.as_bytes());
+                if_ok!(term.write(word.as_bytes()));
                 if self.use_color {
-                    term.reset();
+                    if_ok!(term.reset());
                 }
+                Ok(())
             }
             Raw(ref mut stdout) => stdout.write(word.as_bytes())
         }
     }
 
-    pub fn write_plain(&mut self, s: &str) {
+    pub fn write_plain(&mut self, s: &str) -> io::IoResult<()> {
         match self.out {
             Pretty(ref mut term) => term.write(s.as_bytes()),
             Raw(ref mut stdout) => stdout.write(s.as_bytes())
         }
     }
 
-    pub fn write_run_start(&mut self, len: uint) {
+    pub fn write_run_start(&mut self, len: uint) -> io::IoResult<()> {
         self.total = len;
         let noun = if len != 1 { &"tests" } else { &"test" };
-        self.write_plain(format!("\nrunning {} {}\n", len, noun));
+        self.write_plain(format!("\nrunning {} {}\n", len, noun))
     }
 
-    pub fn write_test_start(&mut self, test: &TestDesc, align: NamePadding) {
+    pub fn write_test_start(&mut self, test: &TestDesc,
+                            align: NamePadding) -> io::IoResult<()> {
         let name = test.padded_name(self.max_name_len, align);
-        self.write_plain(format!("test {} ... ", name));
+        self.write_plain(format!("test {} ... ", name))
     }
 
-    pub fn write_result(&mut self, result: &TestResult) {
-        match *result {
+    pub fn write_result(&mut self, result: &TestResult) -> io::IoResult<()> {
+        if_ok!(match *result {
             TrOk => self.write_ok(),
             TrFailed => self.write_failed(),
             TrIgnored => self.write_ignored(),
             TrMetrics(ref mm) => {
-                self.write_metric();
-                self.write_plain(format!(": {}", fmt_metrics(mm)));
+                if_ok!(self.write_metric());
+                self.write_plain(format!(": {}", fmt_metrics(mm)))
             }
             TrBench(ref bs) => {
-                self.write_bench();
-                self.write_plain(format!(": {}", fmt_bench_samples(bs)));
+                if_ok!(self.write_bench());
+                self.write_plain(format!(": {}", fmt_bench_samples(bs)))
             }
-        }
-        self.write_plain("\n");
+        });
+        self.write_plain("\n")
     }
 
-    pub fn write_log(&mut self, test: &TestDesc, result: &TestResult) {
+    pub fn write_log(&mut self, test: &TestDesc,
+                     result: &TestResult) -> io::IoResult<()> {
         match self.log_out {
-            None => (),
+            None => Ok(()),
             Some(ref mut o) => {
                 let s = format!("{} {}\n", match *result {
                         TrOk => ~"ok",
@@ -482,24 +490,25 @@ impl<T: Writer> ConsoleTestState<T> {
                         TrMetrics(ref mm) => fmt_metrics(mm),
                         TrBench(ref bs) => fmt_bench_samples(bs)
                     }, test.name.to_str());
-                o.write(s.as_bytes());
+                o.write(s.as_bytes())
             }
         }
     }
 
-    pub fn write_failures(&mut self) {
-        self.write_plain("\nfailures:\n");
+    pub fn write_failures(&mut self) -> io::IoResult<()> {
+        if_ok!(self.write_plain("\nfailures:\n"));
         let mut failures = ~[];
         for f in self.failures.iter() {
             failures.push(f.name.to_str());
         }
         failures.sort();
         for name in failures.iter() {
-            self.write_plain(format!("    {}\n", name.to_str()));
+            if_ok!(self.write_plain(format!("    {}\n", name.to_str())));
         }
+        Ok(())
     }
 
-    pub fn write_metric_diff(&mut self, diff: &MetricDiff) {
+    pub fn write_metric_diff(&mut self, diff: &MetricDiff) -> io::IoResult<()> {
         let mut noise = 0;
         let mut improved = 0;
         let mut regressed = 0;
@@ -511,77 +520,82 @@ impl<T: Writer> ConsoleTestState<T> {
                 LikelyNoise => noise += 1,
                 MetricAdded => {
                     added += 1;
-                    self.write_added();
-                    self.write_plain(format!(": {}\n", *k));
+                    if_ok!(self.write_added());
+                    if_ok!(self.write_plain(format!(": {}\n", *k)));
                 }
                 MetricRemoved => {
                     removed += 1;
-                    self.write_removed();
-                    self.write_plain(format!(": {}\n", *k));
+                    if_ok!(self.write_removed());
+                    if_ok!(self.write_plain(format!(": {}\n", *k)));
                 }
                 Improvement(pct) => {
                     improved += 1;
-                    self.write_plain(format!(": {}", *k));
-                    self.write_improved();
-                    self.write_plain(format!(" by {:.2f}%\n", pct as f64));
+                    if_ok!(self.write_plain(format!(": {}", *k)));
+                    if_ok!(self.write_improved());
+                    if_ok!(self.write_plain(format!(" by {:.2f}%\n", pct as f64)));
                 }
                 Regression(pct) => {
                     regressed += 1;
-                    self.write_plain(format!(": {}", *k));
-                    self.write_regressed();
-                    self.write_plain(format!(" by {:.2f}%\n", pct as f64));
+                    if_ok!(self.write_plain(format!(": {}", *k)));
+                    if_ok!(self.write_regressed());
+                    if_ok!(self.write_plain(format!(" by {:.2f}%\n", pct as f64)));
                 }
             }
         }
-        self.write_plain(format!("result of ratchet: {} matrics added, {} removed, \
-                                  {} improved, {} regressed, {} noise\n",
-                                 added, removed, improved, regressed, noise));
+        if_ok!(self.write_plain(format!("result of ratchet: {} matrics added, \
+                                        {} removed, {} improved, {} regressed, \
+                                        {} noise\n",
+                                       added, removed, improved, regressed,
+                                       noise)));
         if regressed == 0 {
-            self.write_plain("updated ratchet file\n");
+            if_ok!(self.write_plain("updated ratchet file\n"));
         } else {
-            self.write_plain("left ratchet file untouched\n");
+            if_ok!(self.write_plain("left ratchet file untouched\n"));
         }
+        Ok(())
     }
 
     pub fn write_run_finish(&mut self,
                             ratchet_metrics: &Option<Path>,
-                            ratchet_pct: Option<f64>) -> bool {
+                            ratchet_pct: Option<f64>) -> io::IoResult<bool> {
         assert!(self.passed + self.failed + self.ignored + self.measured == self.total);
 
         let ratchet_success = match *ratchet_metrics {
             None => true,
             Some(ref pth) => {
-                self.write_plain(format!("\nusing metrics ratcher: {}\n", pth.display()));
+                if_ok!(self.write_plain(format!("\nusing metrics ratcher: {}\n",
+                                        pth.display())));
                 match ratchet_pct {
                     None => (),
                     Some(pct) =>
-                        self.write_plain(format!("with noise-tolerance forced to: {}%\n",
-                                                 pct))
+                        if_ok!(self.write_plain(format!("with noise-tolerance \
+                                                         forced to: {}%\n",
+                                                        pct)))
                 }
                 let (diff, ok) = self.metrics.ratchet(pth, ratchet_pct);
-                self.write_metric_diff(&diff);
+                if_ok!(self.write_metric_diff(&diff));
                 ok
             }
         };
 
         let test_success = self.failed == 0u;
         if !test_success {
-            self.write_failures();
+            if_ok!(self.write_failures());
         }
 
         let success = ratchet_success && test_success;
 
-        self.write_plain("\ntest result: ");
+        if_ok!(self.write_plain("\ntest result: "));
         if success {
             // There's no parallelism at this point so it's safe to use color
-            self.write_ok();
+            if_ok!(self.write_ok());
         } else {
-            self.write_failed();
+            if_ok!(self.write_failed());
         }
         let s = format!(". {} passed; {} failed; {} ignored; {} measured\n\n",
                         self.passed, self.failed, self.ignored, self.measured);
-        self.write_plain(s);
-        return success;
+        if_ok!(self.write_plain(s));
+        return Ok(success);
     }
 }
 
@@ -611,15 +625,16 @@ pub fn fmt_bench_samples(bs: &BenchSamples) -> ~str {
 
 // A simple console test runner
 pub fn run_tests_console(opts: &TestOpts,
-                         tests: ~[TestDescAndFn]) -> bool {
-    fn callback<T: Writer>(event: &TestEvent, st: &mut ConsoleTestState<T>) {
+                         tests: ~[TestDescAndFn]) -> io::IoResult<bool> {
+    fn callback<T: Writer>(event: &TestEvent,
+                           st: &mut ConsoleTestState<T>) -> io::IoResult<()> {
         debug!("callback(event={:?})", event);
         match (*event).clone() {
             TeFiltered(ref filtered_tests) => st.write_run_start(filtered_tests.len()),
             TeWait(ref test, padding) => st.write_test_start(test, padding),
             TeResult(test, result) => {
-                st.write_log(&test, &result);
-                st.write_result(&result);
+                if_ok!(st.write_log(&test, &result));
+                if_ok!(st.write_result(&result));
                 match result {
                     TrOk => st.passed += 1,
                     TrIgnored => st.ignored += 1,
@@ -643,10 +658,11 @@ pub fn run_tests_console(opts: &TestOpts,
                         st.failures.push(test);
                     }
                 }
+                Ok(())
             }
         }
     }
-    let mut st = ConsoleTestState::new(opts, None::<StdWriter>);
+    let mut st = if_ok!(ConsoleTestState::new(opts, None::<StdWriter>));
     fn len_if_padded(t: &TestDescAndFn) -> uint {
         match t.testfn.padding() {
             PadNone => 0u,
@@ -661,12 +677,13 @@ pub fn run_tests_console(opts: &TestOpts,
         },
         None => {}
     }
-    run_tests(opts, tests, |x| callback(&x, &mut st));
+    if_ok!(run_tests(opts, tests, |x| callback(&x, &mut st)));
     match opts.save_metrics {
         None => (),
         Some(ref pth) => {
-            st.metrics.save(pth);
-            st.write_plain(format!("\nmetrics saved to: {}", pth.display()));
+            if_ok!(st.metrics.save(pth));
+            if_ok!(st.write_plain(format!("\nmetrics saved to: {}",
+                                          pth.display())));
         }
     }
     return st.write_run_finish(&opts.ratchet_metrics, opts.ratchet_noise_percent);
@@ -728,11 +745,11 @@ pub type MonitorMsg = (TestDesc, TestResult);
 
 fn run_tests(opts: &TestOpts,
              tests: ~[TestDescAndFn],
-             callback: |e: TestEvent|) {
+             callback: |e: TestEvent| -> io::IoResult<()>) -> io::IoResult<()> {
     let filtered_tests = filter_tests(opts, tests);
     let filtered_descs = filtered_tests.map(|t| t.desc.clone());
 
-    callback(TeFiltered(filtered_descs));
+    if_ok!(callback(TeFiltered(filtered_descs)));
 
     let (filtered_tests, filtered_benchs_and_metrics) =
         filtered_tests.partition(|e| {
@@ -760,7 +777,7 @@ fn run_tests(opts: &TestOpts,
                 // We are doing one test at a time so we can print the name
                 // of the test before we run it. Useful for debugging tests
                 // that hang forever.
-                callback(TeWait(test.desc.clone(), test.testfn.padding()));
+                if_ok!(callback(TeWait(test.desc.clone(), test.testfn.padding())));
             }
             run_test(!opts.run_tests, test, ch.clone());
             pending += 1;
@@ -768,20 +785,21 @@ fn run_tests(opts: &TestOpts,
 
         let (desc, result) = p.recv();
         if concurrency != 1 {
-            callback(TeWait(desc.clone(), PadNone));
+            if_ok!(callback(TeWait(desc.clone(), PadNone)));
         }
-        callback(TeResult(desc, result));
+        if_ok!(callback(TeResult(desc, result)));
         pending -= 1;
     }
 
     // All benchmarks run at the end, in serial.
     // (this includes metric fns)
     for b in filtered_benchs_and_metrics.move_iter() {
-        callback(TeWait(b.desc.clone(), b.testfn.padding()));
+        if_ok!(callback(TeWait(b.desc.clone(), b.testfn.padding())));
         run_test(!opts.run_benchmarks, b, ch.clone());
         let (test, result) = p.recv();
-        callback(TeResult(test, result));
+        if_ok!(callback(TeResult(test, result)));
     }
+    Ok(())
 }
 
 fn get_concurrency() -> uint {
@@ -943,17 +961,22 @@ impl MetricMap {
     }
 
     /// Load MetricDiff from a file.
+    ///
+    /// # Failure
+    ///
+    /// This function will fail if the path does not exist or the path does not
+    /// contain a valid metric map.
     pub fn load(p: &Path) -> MetricMap {
         assert!(p.exists());
-        let mut f = File::open(p);
+        let mut f = File::open(p).unwrap();
         let value = json::from_reader(&mut f as &mut io::Reader).unwrap();
         let mut decoder = json::Decoder::new(value);
         MetricMap(Decodable::decode(&mut decoder))
     }
 
     /// Write MetricDiff to a file.
-    pub fn save(&self, p: &Path) {
-        let mut file = File::create(p);
+    pub fn save(&self, p: &Path) -> io::IoResult<()> {
+        let mut file = if_ok!(File::create(p));
         let MetricMap(ref map) = *self;
         map.to_json().to_pretty_writer(&mut file)
     }
@@ -1060,7 +1083,7 @@ impl MetricMap {
 
         if ok {
             debug!("rewriting file '{:?}' with updated metrics", p);
-            self.save(p);
+            self.save(p).unwrap();
         }
         return (diff, ok)
     }

--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -720,7 +720,7 @@ fn should_sort_failures_before_printing_them() {
         failures: ~[test_b, test_a]
     };
 
-    st.write_failures();
+    st.write_failures().unwrap();
     let s = match st.out {
         Raw(ref m) => str::from_utf8(m.get_ref()).unwrap(),
         Pretty(_) => unreachable!()
@@ -1485,7 +1485,7 @@ mod tests {
         m2.insert_metric("runtime", 1100.0, 2.0);
         m2.insert_metric("throughput", 50.0, 2.0);
 
-        m1.save(&pth);
+        m1.save(&pth).unwrap();
 
         // Ask for a ratchet that should fail to advance.
         let (diff1, ok1) = m2.ratchet(&pth, None);

--- a/src/libextra/time.rs
+++ b/src/libextra/time.rs
@@ -766,14 +766,14 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
 
         let mut buf = [0];
         let c = match rdr.read(buf) {
-            Some(..) => buf[0] as char,
-            None => break
+            Ok(..) => buf[0] as char,
+            Err(..) => break
         };
         match c {
             '%' => {
                 let ch = match rdr.read(buf) {
-                    Some(..) => buf[0] as char,
-                    None => break
+                    Ok(..) => buf[0] as char,
+                    Err(..) => break
                 };
                 match parse_type(s, pos, ch, &mut tm) {
                     Ok(next) => pos = next,
@@ -787,7 +787,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ~str> {
         }
     }
 
-    if pos == len && rdr.tell() as uint == format.len() {
+    if pos == len && rdr.tell().unwrap() == format.len() as u64 {
         Ok(Tm {
             tm_sec: tm.tm_sec,
             tm_min: tm.tm_min,
@@ -1017,12 +1017,12 @@ pub fn strftime(format: &str, tm: &Tm) -> ~str {
     loop {
         let mut b = [0];
         let ch = match rdr.read(b) {
-            Some(..) => b[0],
-            None => break,
+            Ok(..) => b[0],
+            Err(..) => break,
         };
         match ch as char {
             '%' => {
-                rdr.read(b);
+                rdr.read(b).unwrap();
                 let s = parse_type(b[0] as char, tm);
                 buf.push_all(s.as_bytes());
             }

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -102,8 +102,8 @@ fn encode_inner(s: &str, full_url: bool) -> ~str {
     loop {
         let mut buf = [0];
         let ch = match rdr.read(buf) {
-            None => break,
-            Some(..) => buf[0] as char,
+            Err(..) => break,
+            Ok(..) => buf[0] as char,
         };
 
         match ch {
@@ -166,14 +166,14 @@ fn decode_inner(s: &str, full_url: bool) -> ~str {
     loop {
         let mut buf = [0];
         let ch = match rdr.read(buf) {
-            None => break,
-            Some(..) => buf[0] as char
+            Err(..) => break,
+            Ok(..) => buf[0] as char
         };
         match ch {
           '%' => {
             let mut bytes = [0, 0];
             match rdr.read(bytes) {
-                Some(2) => {}
+                Ok(2) => {}
                 _ => fail!() // FIXME: malformed url?
             }
             let ch = uint::parse_bytes(bytes, 16u).unwrap() as u8 as char;
@@ -228,8 +228,8 @@ fn encode_plus(s: &str) -> ~str {
     loop {
         let mut buf = [0];
         let ch = match rdr.read(buf) {
-            Some(..) => buf[0] as char,
-            None => break,
+            Ok(..) => buf[0] as char,
+            Err(..) => break,
         };
         match ch {
           'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '.' | '-' => {
@@ -282,8 +282,8 @@ pub fn decode_form_urlencoded(s: &[u8]) -> HashMap<~str, ~[~str]> {
     loop {
         let mut buf = [0];
         let ch = match rdr.read(buf) {
-            Some(..) => buf[0] as char,
-            None => break,
+            Ok(..) => buf[0] as char,
+            Err(..) => break,
         };
         match ch {
             '&' | ';' => {
@@ -307,7 +307,7 @@ pub fn decode_form_urlencoded(s: &[u8]) -> HashMap<~str, ~[~str]> {
                     '%' => {
                         let mut bytes = [0, 0];
                         match rdr.read(bytes) {
-                            Some(2) => {}
+                            Ok(2) => {}
                             _ => fail!() // FIXME: malformed?
                         }
                         uint::parse_bytes(bytes, 16u).unwrap() as u8 as char
@@ -347,12 +347,12 @@ fn split_char_first(s: &str, c: char) -> (~str, ~str) {
     loop {
         let mut buf = [0];
         let ch = match rdr.read(buf) {
-            Some(..) => buf[0] as char,
-            None => break,
+            Ok(..) => buf[0] as char,
+            Err(..) => break,
         };
         if ch == c {
             // found a match, adjust markers
-            index = (rdr.tell() as uint) - 1;
+            index = (rdr.tell().unwrap() as uint) - 1;
             mat = 1;
             break;
         }

--- a/src/libextra/uuid.rs
+++ b/src/libextra/uuid.rs
@@ -821,7 +821,7 @@ mod bench {
     pub fn parse_str(bh: &mut BenchHarness) {
         let s = "urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4";
         bh.iter(|| {
-            Uuid::parse_string(s);
+            Uuid::parse_string(s).unwrap();
         })
     }
 }

--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -473,13 +473,13 @@ fn test() {
     fn make_path(filename: ~str) -> Path {
         let pth = os::self_exe_path().expect("workcache::test failed").with_filename(filename);
         if pth.exists() {
-            fs::unlink(&pth);
+            fs::unlink(&pth).unwrap();
         }
         return pth;
     }
 
     let pth = make_path(~"foo.c");
-    File::create(&pth).write(bytes!("int main() { return 0; }"));
+    File::create(&pth).write(bytes!("int main() { return 0; }")).unwrap();
 
     let db_path = make_path(~"db.json");
 
@@ -491,7 +491,8 @@ fn test() {
         let subcx = cx.clone();
         let pth = pth.clone();
 
-        let file_content = from_utf8_owned(File::open(&pth).read_to_end()).unwrap();
+        let contents = File::open(&pth).read_to_end().unwrap();
+        let file_content = from_utf8_owned(contents).unwrap();
 
         // FIXME (#9639): This needs to handle non-utf8 paths
         prep.declare_input("file", pth.as_str().unwrap(), file_content);
@@ -500,7 +501,7 @@ fn test() {
             // FIXME (#9639): This needs to handle non-utf8 paths
             run::process_status("gcc", [pth.as_str().unwrap().to_owned(),
                                         ~"-o",
-                                        out.as_str().unwrap().to_owned()]);
+                                        out.as_str().unwrap().to_owned()]).unwrap();
 
             let _proof_of_concept = subcx.prep("subfn");
             // Could run sub-rules inside here.

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -29,7 +29,6 @@
 #[license = "MIT/ASL2"];
 
 use std::{os, path};
-use std::io;
 use std::io::fs;
 use std::path::is_sep;
 
@@ -153,7 +152,7 @@ impl Iterator<Path> for Paths {
 }
 
 fn list_dir_sorted(path: &Path) -> ~[Path] {
-    match io::result(|| fs::readdir(path)) {
+    match fs::readdir(path) {
         Ok(mut children) => {
             children.sort_by(|p1, p2| p2.filename().cmp(&p1.filename()));
             children

--- a/src/libgreen/macros.rs
+++ b/src/libgreen/macros.rs
@@ -56,16 +56,17 @@ pub fn dumb_println(args: &fmt::Arguments) {
 
     struct Stderr;
     impl io::Writer for Stderr {
-        fn write(&mut self, data: &[u8]) {
+        fn write(&mut self, data: &[u8]) -> io::IoResult<()> {
             unsafe {
                 libc::write(libc::STDERR_FILENO,
                             data.as_ptr() as *libc::c_void,
                             data.len() as libc::size_t);
             }
+            Ok(()) // just ignore the result
         }
     }
     let mut w = Stderr;
-    fmt::writeln(&mut w as &mut io::Writer, args);
+    let _ = fmt::writeln(&mut w as &mut io::Writer, args);
 }
 
 pub fn abort(msg: &str) -> ! {

--- a/src/libnative/bookkeeping.rs
+++ b/src/libnative/bookkeeping.rs
@@ -23,7 +23,7 @@ static mut TASK_COUNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
 static mut TASK_LOCK: Mutex = MUTEX_INIT;
 
 pub fn increment() {
-    unsafe { TASK_COUNT.fetch_add(1, atomics::SeqCst); }
+    let _ = unsafe { TASK_COUNT.fetch_add(1, atomics::SeqCst) };
 }
 
 pub fn decrement() {

--- a/src/libnative/io/file.rs
+++ b/src/libnative/io/file.rs
@@ -561,7 +561,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
                         }
                         more_files = FindNextFileW(find_handle, wfd_ptr as HANDLE);
                     }
-                    FindClose(find_handle);
+                    assert!(FindClose(find_handle) != 0);
                     free(wfd_ptr as *mut c_void);
                     Ok(paths)
                 } else {
@@ -683,7 +683,9 @@ pub fn readlink(p: &CString) -> IoResult<Path> {
                                   ptr::mut_null())
             })
         };
-        if handle == ptr::mut_null() { return Err(super::last_error()) }
+        if handle as int == libc::INVALID_HANDLE_VALUE as int {
+            return Err(super::last_error())
+        }
         let ret = fill_utf16_buf_and_decode(|buf, sz| {
             unsafe {
                 libc::GetFinalPathNameByHandleW(handle, buf as *u16, sz,
@@ -694,7 +696,7 @@ pub fn readlink(p: &CString) -> IoResult<Path> {
             Some(s) => Ok(Path::new(s)),
             None => Err(super::last_error()),
         };
-        unsafe { libc::CloseHandle(handle) };
+        assert!(unsafe { libc::CloseHandle(handle) } != 0);
         return ret;
 
     }

--- a/src/libnative/io/file.rs
+++ b/src/libnative/io/file.rs
@@ -111,17 +111,14 @@ impl FileDesc {
 }
 
 impl io::Reader for FileDesc {
-    fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
-        match self.inner_read(buf) { Ok(n) => Some(n), Err(..) => None }
+    fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
+        self.inner_read(buf)
     }
 }
 
 impl io::Writer for FileDesc {
-    fn write(&mut self, buf: &[u8]) {
-        match self.inner_write(buf) {
-            Ok(()) => {}
-            Err(e) => { io::io_error::cond.raise(e); }
-        }
+    fn write(&mut self, buf: &[u8]) -> io::IoResult<()> {
+        self.inner_write(buf)
     }
 }
 

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -112,8 +112,8 @@ fn setsockopt<T>(fd: sock_t, opt: libc::c_int, val: libc::c_int,
     }
 }
 
-#[cfg(windows)] unsafe fn close(sock: sock_t) { libc::closesocket(sock); }
-#[cfg(unix)]    unsafe fn close(sock: sock_t) { libc::close(sock); }
+#[cfg(windows)] unsafe fn close(sock: sock_t) { let _ = libc::closesocket(sock); }
+#[cfg(unix)]    unsafe fn close(sock: sock_t) { let _ = libc::close(sock); }
 
 fn sockname(fd: sock_t,
             f: extern "system" unsafe fn(sock_t, *mut libc::sockaddr,

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -149,9 +149,8 @@ impl rtio::RtioProcess for Process {
         unsafe fn killpid(pid: pid_t, signal: int) -> Result<(), io::IoError> {
             match signal {
                 io::process::PleaseExitSignal | io::process::MustDieSignal => {
-                    libc::funcs::extra::kernel32::TerminateProcess(
-                        cast::transmute(pid), 1);
-                    Ok(())
+                    let ret = libc::TerminateProcess(pid as libc::HANDLE, 1);
+                    super::mkerr_winbool(ret)
                 }
                 _ => Err(io::IoError {
                     kind: io::OtherIoError,
@@ -255,9 +254,9 @@ fn spawn_process_os(prog: &str, args: &[~str],
             })
         });
 
-        CloseHandle(si.hStdInput);
-        CloseHandle(si.hStdOutput);
-        CloseHandle(si.hStdError);
+        assert!(CloseHandle(si.hStdInput) != 0);
+        assert!(CloseHandle(si.hStdOutput) != 0);
+        assert!(CloseHandle(si.hStdError) != 0);
 
         match create_err {
             Some(err) => return Err(err),
@@ -269,7 +268,7 @@ fn spawn_process_os(prog: &str, args: &[~str],
         // able to close it later. We don't close the process handle however
         // because std::we want the process id to stay valid at least until the
         // calling code closes the process handle.
-        CloseHandle(pi.hThread);
+        assert!(CloseHandle(pi.hThread) != 0);
 
         Ok(SpawnProcessResult {
             pid: pi.dwProcessId as pid_t,
@@ -576,9 +575,9 @@ fn with_dirp<T>(d: Option<&Path>, cb: |*libc::c_char| -> T) -> T {
 
 #[cfg(windows)]
 fn free_handle(handle: *()) {
-    unsafe {
-        libc::funcs::extra::kernel32::CloseHandle(cast::transmute(handle));
-    }
+    assert!(unsafe {
+        libc::CloseHandle(cast::transmute(handle)) != 0
+    })
 }
 
 #[cfg(unix)]
@@ -629,15 +628,15 @@ fn waitpid(pid: pid_t) -> p::ProcessExit {
             loop {
                 let mut status = 0;
                 if GetExitCodeProcess(process, &mut status) == FALSE {
-                    CloseHandle(process);
+                    assert!(CloseHandle(process) != 0);
                     fail!("failure in GetExitCodeProcess: {}", os::last_os_error());
                 }
                 if status != STILL_ACTIVE {
-                    CloseHandle(process);
+                    assert!(CloseHandle(process) != 0);
                     return p::ExitStatus(status as int);
                 }
                 if WaitForSingleObject(process, INFINITE) == WAIT_FAILED {
-                    CloseHandle(process);
+                    assert!(CloseHandle(process) != 0);
                     fail!("failure in WaitForSingleObject: {}", os::last_os_error());
                 }
             }

--- a/src/libnative/io/timer_helper.rs
+++ b/src/libnative/io/timer_helper.rs
@@ -126,11 +126,11 @@ mod imp {
     }
 
     pub fn signal(handle: HANDLE) {
-        unsafe { SetEvent(handle); }
+        assert!(unsafe { SetEvent(handle) != 0 });
     }
 
     pub fn close(handle: HANDLE) {
-        unsafe { CloseHandle(handle); }
+        assert!(unsafe { CloseHandle(handle) != 0 });
     }
 
     extern "system" {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -187,7 +187,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
 
                 // drain the file descriptor
                 let mut buf = [0];
-                fd.inner_read(buf).unwrap();
+                assert_eq!(fd.inner_read(buf).unwrap(), 1);
             }
 
             -1 if os::errno() == libc::EINTR as int => {}
@@ -216,7 +216,8 @@ impl Timer {
     }
 
     pub fn sleep(ms: u64) {
-        unsafe { libc::usleep((ms * 1000) as libc::c_uint); }
+        // FIXME: this can fail because of EINTR, what do do?
+        let _ = unsafe { libc::usleep((ms * 1000) as libc::c_uint) };
     }
 
     fn inner(&mut self) -> ~Inner {

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -96,7 +96,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
             if fd == input {
                 let mut buf = [0, ..1];
                 // drain the input file descriptor of its input
-                FileDesc::new(fd, false).inner_read(buf).unwrap();
+                let _ = FileDesc::new(fd, false).inner_read(buf).unwrap();
                 incoming = true;
             } else {
                 let mut bits = [0, ..8];
@@ -104,7 +104,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
                 //
                 // FIXME: should this perform a send() this number of
                 //      times?
-                FileDesc::new(fd, false).inner_read(bits).unwrap();
+                let _ = FileDesc::new(fd, false).inner_read(bits).unwrap();
                 let remove = {
                     match map.find(&fd).expect("fd unregistered") {
                         &(ref c, oneshot) => !c.try_send(()) || oneshot
@@ -166,7 +166,8 @@ impl Timer {
     }
 
     pub fn sleep(ms: u64) {
-        unsafe { libc::usleep((ms * 1000) as libc::c_uint); }
+        // FIXME: this can fail because of EINTR, what do do?
+        let _ = unsafe { libc::usleep((ms * 1000) as libc::c_uint) };
     }
 
     fn remove(&mut self) {

--- a/src/libnative/io/timer_win32.rs
+++ b/src/libnative/io/timer_win32.rs
@@ -62,8 +62,8 @@ fn helper(input: libc::HANDLE, messages: Port<Req>) {
                         c.send(());
                         match objs.iter().position(|&o| o == obj) {
                             Some(i) => {
-                                objs.remove(i);
-                                chans.remove(i - 1);
+                                drop(objs.remove(i));
+                                drop(chans.remove(i - 1));
                             }
                             None => {}
                         }
@@ -83,8 +83,8 @@ fn helper(input: libc::HANDLE, messages: Port<Req>) {
                 }
             };
             if remove {
-                objs.remove(idx as uint);
-                chans.remove(idx as uint - 1);
+                drop(objs.remove(idx as uint));
+                drop(chans.remove(idx as uint - 1));
             }
         }
     }
@@ -133,7 +133,7 @@ impl rtio::RtioTimer for Timer {
                                   ptr::mut_null(), 0)
         }, 1);
 
-        unsafe { imp::WaitForSingleObject(self.obj, libc::INFINITE); }
+        let _ = unsafe { imp::WaitForSingleObject(self.obj, libc::INFINITE) };
     }
 
     fn oneshot(&mut self, msecs: u64) -> Port<()> {
@@ -173,7 +173,7 @@ impl rtio::RtioTimer for Timer {
 impl Drop for Timer {
     fn drop(&mut self) {
         self.remove();
-        unsafe { libc::CloseHandle(self.obj); }
+        assert!(unsafe { libc::CloseHandle(self.obj) != 0 });
     }
 }
 

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -21,6 +21,7 @@
 #[doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://static.rust-lang.org/doc/master")];
+#[deny(unused_result, unused_must_use)];
 
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the
@@ -61,9 +62,10 @@ pub fn start(argc: int, argv: **u8, main: proc()) -> int {
     rt::init(argc, argv);
     let mut exit_code = None;
     let mut main = Some(main);
-    task::new((my_stack_bottom, my_stack_top)).run(|| {
+    let t = task::new((my_stack_bottom, my_stack_top)).run(|| {
         exit_code = Some(run(main.take_unwrap()));
     });
+    drop(t);
     unsafe { rt::cleanup(); }
     // If the exit code wasn't set, then the task block must have failed.
     return exit_code.unwrap_or(rt::DEFAULT_ERROR_CODE);

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -103,7 +103,8 @@ pub fn spawn_opts(opts: TaskOpts, f: proc()) {
         let mut f = Some(f);
         let mut task = task;
         task.put_runtime(ops as ~rt::Runtime);
-        task.run(|| { f.take_unwrap()() });
+        let t = task.run(|| { f.take_unwrap()() });
+        drop(t);
         bookkeeping::decrement();
     })
 }

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -17,6 +17,7 @@ use lib::llvm::{ArchiveRef, llvm};
 
 use std::cast;
 use std::io::fs;
+use std::io;
 use std::libc;
 use std::os;
 use std::run::{ProcessOptions, Process, ProcessOutput};
@@ -50,9 +51,8 @@ fn run_ar(sess: Session, args: &str, cwd: Option<&Path>,
         Some(p) => { debug!("inside {}", p.display()); }
         None => {}
     }
-    let mut opt_prog = Process::new(ar, args.as_slice(), opts);
-    match opt_prog {
-        Some(ref mut prog) => {
+    match Process::new(ar, args.as_slice(), opts) {
+        Ok(mut prog) => {
             let o = prog.finish_with_output();
             if !o.status.success() {
                 sess.err(format!("{} {} failed with: {}", ar, args.connect(" "),
@@ -63,8 +63,8 @@ fn run_ar(sess: Session, args: &str, cwd: Option<&Path>,
             }
             o
         },
-        None => {
-            sess.err(format!("could not exec `{}`", ar));
+        Err(e) => {
+            sess.err(format!("could not exec `{}`: {}", ar, e));
             sess.abort_if_errors();
             fail!("rustc::back::archive::run_ar() should not reach this point");
         }
@@ -94,7 +94,7 @@ impl Archive {
             let archive = os::make_absolute(&self.dst);
             run_ar(self.sess, "x", Some(loc.path()), [&archive,
                                                       &Path::new(file)]);
-            fs::File::open(&loc.path().join(file)).read_to_end()
+            fs::File::open(&loc.path().join(file)).read_to_end().unwrap()
         } else {
             run_ar(self.sess, "p", None, [&self.dst, &Path::new(file)]).output
         }
@@ -102,9 +102,9 @@ impl Archive {
 
     /// Adds all of the contents of a native library to this archive. This will
     /// search in the relevant locations for a library named `name`.
-    pub fn add_native_library(&mut self, name: &str) {
+    pub fn add_native_library(&mut self, name: &str) -> io::IoResult<()> {
         let location = self.find_library(name);
-        self.add_archive(&location, name, []);
+        self.add_archive(&location, name, [])
     }
 
     /// Adds all of the contents of the rlib at the specified path to this
@@ -112,14 +112,15 @@ impl Archive {
     ///
     /// This ignores adding the bytecode from the rlib, and if LTO is enabled
     /// then the object file also isn't added.
-    pub fn add_rlib(&mut self, rlib: &Path, name: &str, lto: bool) {
+    pub fn add_rlib(&mut self, rlib: &Path, name: &str,
+                    lto: bool) -> io::IoResult<()> {
         let object = format!("{}.o", name);
         let bytecode = format!("{}.bc", name);
         let mut ignore = ~[METADATA_FILENAME, bytecode.as_slice()];
         if lto {
             ignore.push(object.as_slice());
         }
-        self.add_archive(rlib, name, ignore);
+        self.add_archive(rlib, name, ignore)
     }
 
     /// Adds an arbitrary file to this archive
@@ -144,7 +145,8 @@ impl Archive {
         str::from_utf8(output.output).unwrap().lines().map(|s| s.to_owned()).collect()
     }
 
-    fn add_archive(&mut self, archive: &Path, name: &str, skip: &[&str]) {
+    fn add_archive(&mut self, archive: &Path, name: &str,
+                   skip: &[&str]) -> io::IoResult<()> {
         let loc = TempDir::new("rsar").unwrap();
 
         // First, extract the contents of the archive to a temporary directory
@@ -159,7 +161,7 @@ impl Archive {
         // We skip any files explicitly desired for skipping, and we also skip
         // all SYMDEF files as these are just magical placeholders which get
         // re-created when we make a new archive anyway.
-        let files = fs::readdir(loc.path());
+        let files = if_ok!(fs::readdir(loc.path()));
         let mut inputs = ~[];
         for file in files.iter() {
             let filename = file.filename_str().unwrap();
@@ -168,7 +170,7 @@ impl Archive {
 
             let filename = format!("r-{}-{}", name, filename);
             let new_filename = file.with_filename(filename);
-            fs::rename(file, &new_filename);
+            if_ok!(fs::rename(file, &new_filename));
             inputs.push(new_filename);
         }
 
@@ -176,6 +178,7 @@ impl Archive {
         let mut args = ~[&self.dst];
         args.extend(&mut inputs.iter());
         run_ar(self.sess, "r", None, args.as_slice());
+        Ok(())
     }
 
     fn find_library(&self, name: &str) -> Path {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -241,8 +241,8 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
       1u => {
         let ifile = matches.free[0].as_slice();
         if ifile == "-" {
-            let src =
-                str::from_utf8_owned(io::stdin().read_to_end()).unwrap();
+            let contents = io::stdin().read_to_end().unwrap();
+            let src = str::from_utf8_owned(contents).unwrap();
             (d::StrInput(src), None)
         } else {
             (d::FileInput(Path::new(ifile)), Some(Path::new(ifile)))

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -54,6 +54,11 @@ use syntax::diagnostic::Emitter;
 use syntax::diagnostic;
 use syntax::parse;
 
+#[cfg(stage0)]
+macro_rules! if_ok (
+    ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
+)
+
 pub mod middle {
     pub mod trans;
     pub mod ty;
@@ -267,7 +272,7 @@ pub fn run_compiler(args: &[~str], demitter: @diagnostic::Emitter) {
           d::FileInput(ref ifile) => {
             let mut stdout = io::stdout();
             d::list_metadata(sess, &(*ifile),
-                                  &mut stdout as &mut io::Writer);
+                             &mut stdout as &mut io::Writer).unwrap();
           }
           d::StrInput(_) => {
             d::early_error(demitter, "can not list metadata for stdin");

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1160,12 +1160,12 @@ fn list_crate_deps(data: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
     let r = get_crate_deps(data);
     for dep in r.iter() {
         let string = token::get_ident(dep.name.name);
-        write!(out,
-               "{} {}-{}-{}\n",
-               dep.cnum,
-               string.get(),
-               dep.hash,
-               dep.vers);
+        if_ok!(write!(out,
+                      "{} {}-{}-{}\n",
+                      dep.cnum,
+                      string.get(),
+                      dep.hash,
+                      dep.vers));
     }
 
     if_ok!(write!(out, "\n"));

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1111,15 +1111,15 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
 }
 
 fn list_crate_attributes(intr: @IdentInterner, md: ebml::Doc, hash: &str,
-                         out: &mut io::Writer) {
-    write!(out, "=Crate Attributes ({})=\n", hash);
+                         out: &mut io::Writer) -> io::IoResult<()> {
+    if_ok!(write!(out, "=Crate Attributes ({})=\n", hash));
 
     let r = get_attributes(md);
     for attr in r.iter() {
-        write!(out, "{}\n", pprust::attribute_to_str(attr, intr));
+        if_ok!(write!(out, "{}\n", pprust::attribute_to_str(attr, intr)));
     }
 
-    write!(out, "\n\n");
+    write!(out, "\n\n")
 }
 
 pub fn get_crate_attributes(data: &[u8]) -> ~[ast::Attribute] {
@@ -1154,8 +1154,8 @@ pub fn get_crate_deps(data: &[u8]) -> ~[CrateDep] {
     return deps;
 }
 
-fn list_crate_deps(data: &[u8], out: &mut io::Writer) {
-    write!(out, "=External Dependencies=\n");
+fn list_crate_deps(data: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
+    if_ok!(write!(out, "=External Dependencies=\n"));
 
     let r = get_crate_deps(data);
     for dep in r.iter() {
@@ -1168,7 +1168,8 @@ fn list_crate_deps(data: &[u8], out: &mut io::Writer) {
                dep.vers);
     }
 
-    write!(out, "\n");
+    if_ok!(write!(out, "\n"));
+    Ok(())
 }
 
 pub fn get_crate_hash(data: &[u8]) -> ~str {
@@ -1186,11 +1187,11 @@ pub fn get_crate_vers(data: &[u8]) -> ~str {
 }
 
 pub fn list_crate_metadata(intr: @IdentInterner, bytes: &[u8],
-                           out: &mut io::Writer) {
+                           out: &mut io::Writer) -> io::IoResult<()> {
     let hash = get_crate_hash(bytes);
     let md = reader::Doc(bytes);
-    list_crate_attributes(intr, md, hash, out);
-    list_crate_deps(bytes, out);
+    if_ok!(list_crate_attributes(intr, md, hash, out));
+    list_crate_deps(bytes, out)
 }
 
 // Translates a def_id from an external crate to a def_id for the current

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -11,7 +11,6 @@
 use std::cell::RefCell;
 use std::option;
 use std::os;
-use std::io;
 use std::io::fs;
 use std::hashmap::HashSet;
 
@@ -93,7 +92,7 @@ impl FileSearch {
     pub fn search(&self, pick: pick) {
         self.for_each_lib_search_path(|lib_search_path| {
             debug!("searching {}", lib_search_path.display());
-            match io::result(|| fs::readdir(lib_search_path)) {
+            match fs::readdir(lib_search_path) {
                 Ok(files) => {
                     let mut rslt = FileDoesntMatch;
                     let is_rlib = |p: & &Path| {
@@ -163,8 +162,8 @@ pub fn get_or_default_sysroot() -> Path {
     // Follow symlinks.  If the resolved path is relative, make it absolute.
     fn canonicalize(path: Option<Path>) -> Option<Path> {
         path.and_then(|mut path|
-            match io::io_error::cond.trap(|_| ()).inside(|| fs::readlink(&path)) {
-                Some(canon) => {
+            match fs::readlink(&path) {
+                Ok(canon) => {
                     if canon.is_absolute() {
                         Some(canon)
                     } else {
@@ -172,7 +171,7 @@ pub fn get_or_default_sysroot() -> Path {
                         Some(path.join(canon))
                     }
                 },
-                None => Some(path),
+                Err(..) => Some(path),
             })
     }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -381,13 +381,13 @@ pub fn read_meta_section_name(os: Os) -> &'static str {
 pub fn list_file_metadata(intr: @IdentInterner,
                           os: Os,
                           path: &Path,
-                          out: &mut io::Writer) {
+                          out: &mut io::Writer) -> io::IoResult<()> {
     match get_metadata_section(os, path) {
       option::Some(bytes) => decoder::list_crate_metadata(intr,
                                                           bytes.as_slice(),
                                                           out),
       option::None => {
-        write!(out, "could not find metadata in {}.\n", path.display())
+          write!(out, "could not find metadata in {}.\n", path.display())
       }
     }
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -10,6 +10,8 @@
 
 // Type encoding
 
+#[allow(unused_must_use)]; // as with encoding, everything is a no-fail MemWriter
+
 use std::cell::RefCell;
 use std::hashmap::HashMap;
 use std::io;
@@ -92,9 +94,9 @@ pub fn enc_ty(w: &mut MemWriter, cx: @ctxt, t: ty::t) {
                   None => {}
               }
           }
-          let pos = w.tell();
+          let pos = w.tell().unwrap();
           enc_sty(w, cx, &ty::get(t).sty);
-          let end = w.tell();
+          let end = w.tell().unwrap();
           let len = end - pos;
           fn estimate_sz(u: u64) -> u64 {
               let mut n = u;

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -736,14 +736,15 @@ impl Liveness {
     pub fn write_vars(&self,
                       wr: &mut io::Writer,
                       ln: LiveNode,
-                      test: |uint| -> LiveNode) {
+                      test: |uint| -> LiveNode) -> io::IoResult<()> {
         let node_base_idx = self.idx(ln, Variable(0));
         for var_idx in range(0u, self.ir.num_vars.get()) {
             let idx = node_base_idx + var_idx;
             if test(idx).is_valid() {
-                write!(wr, " {}", Variable(var_idx).to_str());
+                if_ok!(write!(wr, " {}", Variable(var_idx).to_str()));
             }
         }
+        Ok(())
     }
 
     pub fn find_loop_scope(&self,
@@ -781,6 +782,7 @@ impl Liveness {
         *loop_scope.get().last().unwrap()
     }
 
+    #[allow(unused_must_use)]
     pub fn ln_str(&self, ln: LiveNode) -> ~str {
         let mut wr = io::MemWriter::new();
         {

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -20,7 +20,7 @@ use std::fmt;
 pub struct Escape<'a>(&'a str);
 
 impl<'a> fmt::Show for Escape<'a> {
-    fn fmt(s: &Escape<'a>, fmt: &mut fmt::Formatter) {
+    fn fmt(s: &Escape<'a>, fmt: &mut fmt::Formatter) -> fmt::Result {
         // Because the internet is always right, turns out there's not that many
         // characters to escape: http://stackoverflow.com/questions/7381974
         let Escape(s) = *s;
@@ -29,7 +29,7 @@ impl<'a> fmt::Show for Escape<'a> {
         for (i, ch) in s.bytes().enumerate() {
             match ch as char {
                 '<' | '>' | '&' | '\'' | '"' => {
-                    fmt.buf.write(pile_o_bits.slice(last, i).as_bytes());
+                    if_ok!(fmt.buf.write(pile_o_bits.slice(last, i).as_bytes()));
                     let s = match ch as char {
                         '>' => "&gt;",
                         '<' => "&lt;",
@@ -38,7 +38,7 @@ impl<'a> fmt::Show for Escape<'a> {
                         '"' => "&quot;",
                         _ => unreachable!()
                     };
-                    fmt.buf.write(s.as_bytes());
+                    if_ok!(fmt.buf.write(s.as_bytes()));
                     last = i + 1;
                 }
                 _ => {}
@@ -46,7 +46,8 @@ impl<'a> fmt::Show for Escape<'a> {
         }
 
         if last < s.len() {
-            fmt.buf.write(pile_o_bits.slice_from(last).as_bytes());
+            if_ok!(fmt.buf.write(pile_o_bits.slice_from(last).as_bytes()));
         }
+        Ok(())
     }
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -48,7 +48,6 @@ impl PuritySpace {
 }
 
 impl fmt::Show for clean::Generics {
-impl fmt::Default for clean::Generics {
     fn fmt(g: &clean::Generics, f: &mut fmt::Formatter) -> fmt::Result {
         if g.lifetimes.len() == 0 && g.type_params.len() == 0 { return Ok(()) }
         if_ok!(f.buf.write("&lt;".as_bytes()));

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -48,85 +48,105 @@ impl PuritySpace {
 }
 
 impl fmt::Show for clean::Generics {
-    fn fmt(g: &clean::Generics, f: &mut fmt::Formatter) {
-        if g.lifetimes.len() == 0 && g.type_params.len() == 0 { return }
-        f.buf.write("&lt;".as_bytes());
+impl fmt::Default for clean::Generics {
+    fn fmt(g: &clean::Generics, f: &mut fmt::Formatter) -> fmt::Result {
+        if g.lifetimes.len() == 0 && g.type_params.len() == 0 { return Ok(()) }
+        if_ok!(f.buf.write("&lt;".as_bytes()));
 
         for (i, life) in g.lifetimes.iter().enumerate() {
-            if i > 0 { f.buf.write(", ".as_bytes()); }
-            write!(f.buf, "{}", *life);
+            if i > 0 {
+                if_ok!(f.buf.write(", ".as_bytes()));
+            }
+            if_ok!(write!(f.buf, "{}", *life));
         }
 
         if g.type_params.len() > 0 {
-            if g.lifetimes.len() > 0 { f.buf.write(", ".as_bytes()); }
+            if g.lifetimes.len() > 0 {
+                if_ok!(f.buf.write(", ".as_bytes()));
+            }
 
             for (i, tp) in g.type_params.iter().enumerate() {
-                if i > 0 { f.buf.write(", ".as_bytes()) }
-                f.buf.write(tp.name.as_bytes());
+                if i > 0 {
+                    if_ok!(f.buf.write(", ".as_bytes()))
+                }
+                if_ok!(f.buf.write(tp.name.as_bytes()));
 
                 if tp.bounds.len() > 0 {
-                    f.buf.write(": ".as_bytes());
+                    if_ok!(f.buf.write(": ".as_bytes()));
                     for (i, bound) in tp.bounds.iter().enumerate() {
-                        if i > 0 { f.buf.write(" + ".as_bytes()); }
-                        write!(f.buf, "{}", *bound);
+                        if i > 0 {
+                            if_ok!(f.buf.write(" + ".as_bytes()));
+                        }
+                        if_ok!(write!(f.buf, "{}", *bound));
                     }
                 }
             }
         }
-        f.buf.write("&gt;".as_bytes());
+        if_ok!(f.buf.write("&gt;".as_bytes()));
+        Ok(())
     }
 }
 
 impl fmt::Show for clean::Lifetime {
-    fn fmt(l: &clean::Lifetime, f: &mut fmt::Formatter) {
-        f.buf.write("'".as_bytes());
-        f.buf.write(l.get_ref().as_bytes());
+    fn fmt(l: &clean::Lifetime, f: &mut fmt::Formatter) -> fmt::Result {
+        if_ok!(f.buf.write("'".as_bytes()));
+        if_ok!(f.buf.write(l.get_ref().as_bytes()));
+        Ok(())
     }
 }
 
 impl fmt::Show for clean::TyParamBound {
-    fn fmt(bound: &clean::TyParamBound, f: &mut fmt::Formatter) {
+    fn fmt(bound: &clean::TyParamBound, f: &mut fmt::Formatter) -> fmt::Result {
         match *bound {
             clean::RegionBound => {
                 f.buf.write("'static".as_bytes())
             }
             clean::TraitBound(ref ty) => {
-                write!(f.buf, "{}", *ty);
+                write!(f.buf, "{}", *ty)
             }
         }
     }
 }
 
 impl fmt::Show for clean::Path {
-    fn fmt(path: &clean::Path, f: &mut fmt::Formatter) {
-        if path.global { f.buf.write("::".as_bytes()) }
+    fn fmt(path: &clean::Path, f: &mut fmt::Formatter) -> fmt::Result {
+        if path.global {
+            if_ok!(f.buf.write("::".as_bytes()))
+        }
         for (i, seg) in path.segments.iter().enumerate() {
-            if i > 0 { f.buf.write("::".as_bytes()) }
-            f.buf.write(seg.name.as_bytes());
+            if i > 0 {
+                if_ok!(f.buf.write("::".as_bytes()))
+            }
+            if_ok!(f.buf.write(seg.name.as_bytes()));
 
             if seg.lifetimes.len() > 0 || seg.types.len() > 0 {
-                f.buf.write("&lt;".as_bytes());
+                if_ok!(f.buf.write("&lt;".as_bytes()));
                 let mut comma = false;
                 for lifetime in seg.lifetimes.iter() {
-                    if comma { f.buf.write(", ".as_bytes()); }
+                    if comma {
+                        if_ok!(f.buf.write(", ".as_bytes()));
+                    }
                     comma = true;
-                    write!(f.buf, "{}", *lifetime);
+                    if_ok!(write!(f.buf, "{}", *lifetime));
                 }
                 for ty in seg.types.iter() {
-                    if comma { f.buf.write(", ".as_bytes()); }
+                    if comma {
+                        if_ok!(f.buf.write(", ".as_bytes()));
+                    }
                     comma = true;
-                    write!(f.buf, "{}", *ty);
+                    if_ok!(write!(f.buf, "{}", *ty));
                 }
-                f.buf.write("&gt;".as_bytes());
+                if_ok!(f.buf.write("&gt;".as_bytes()));
             }
         }
+        Ok(())
     }
 }
 
 /// Used when rendering a `ResolvedPath` structure. This invokes the `path`
 /// rendering function with the necessary arguments for linking to a local path.
 fn resolved_path(w: &mut io::Writer, id: ast::NodeId, p: &clean::Path,
-                 print_all: bool) {
+                 print_all: bool) -> fmt::Result {
     path(w, p, print_all,
         |_cache, loc| { Some("../".repeat(loc.len())) },
         |cache| {
@@ -134,13 +154,14 @@ fn resolved_path(w: &mut io::Writer, id: ast::NodeId, p: &clean::Path,
                 None => None,
                 Some(&(ref fqp, shortty)) => Some((fqp.clone(), shortty))
             }
-        });
+        })
 }
 
 /// Used when rendering an `ExternalPath` structure. Like `resolved_path` this
 /// will invoke `path` with proper linking-style arguments.
 fn external_path(w: &mut io::Writer, p: &clean::Path, print_all: bool,
-                 fqn: &[~str], kind: clean::TypeKind, crate: ast::CrateNum) {
+                 fqn: &[~str], kind: clean::TypeKind,
+                 crate: ast::CrateNum) -> fmt::Result {
     path(w, p, print_all,
         |cache, loc| {
             match *cache.extern_locations.get(&crate) {
@@ -161,7 +182,9 @@ fn external_path(w: &mut io::Writer, p: &clean::Path, print_all: bool,
 
 fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
         root: |&render::Cache, &[~str]| -> Option<~str>,
-        info: |&render::Cache| -> Option<(~[~str], &'static str)>) {
+        info: |&render::Cache| -> Option<(~[~str], &'static str)>)
+    -> fmt::Result
+{
     // The generics will get written to both the title and link
     let mut generics = ~"";
     let last = path.segments.last().unwrap();
@@ -200,20 +223,20 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
                         let mut root = root;
                         for seg in path.segments.slice_to(amt).iter() {
                             if "super" == seg.name || "self" == seg.name {
-                                write!(w, "{}::", seg.name);
+                                if_ok!(write!(w, "{}::", seg.name));
                             } else {
                                 root.push_str(seg.name);
                                 root.push_str("/");
-                                write!(w, "<a class='mod'
-                                              href='{}index.html'>{}</a>::",
-                                       root,
-                                       seg.name);
+                                if_ok!(write!(w, "<a class='mod'
+                                                    href='{}index.html'>{}</a>::",
+                                              root,
+                                              seg.name));
                             }
                         }
                     }
                     None => {
                         for seg in path.segments.slice_to(amt).iter() {
-                            write!(w, "{}::", seg.name);
+                            if_ok!(write!(w, "{}::", seg.name));
                         }
                     }
                 }
@@ -241,51 +264,57 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
                         }
                     }
 
-                    write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
-                           shortty, url, fqp.connect("::"), last.name);
+                    if_ok!(write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
+                                  shortty, url, fqp.connect("::"), last.name));
                 }
 
                 _ => {
-                    write!(w, "{}", last.name);
+                    if_ok!(write!(w, "{}", last.name));
                 }
             }
-            write!(w, "{}", generics);
+            if_ok!(write!(w, "{}", generics));
+            Ok(())
         })
     })
 }
 
 /// Helper to render type parameters
-fn typarams(w: &mut io::Writer, typarams: &Option<~[clean::TyParamBound]>) {
+fn typarams(w: &mut io::Writer,
+            typarams: &Option<~[clean::TyParamBound]>) -> fmt::Result {
     match *typarams {
         Some(ref params) => {
-            write!(w, "&lt;");
+            if_ok!(write!(w, "&lt;"));
             for (i, param) in params.iter().enumerate() {
-                if i > 0 { write!(w, ", "); }
-                write!(w, "{}", *param);
+                if i > 0 {
+                    if_ok!(write!(w, ", "));
+                }
+                if_ok!(write!(w, "{}", *param));
             }
-            write!(w, "&gt;");
+            if_ok!(write!(w, "&gt;"));
+            Ok(())
         }
-        None => {}
+        None => Ok(())
     }
 }
 
 impl fmt::Show for clean::Type {
-    fn fmt(g: &clean::Type, f: &mut fmt::Formatter) {
+    fn fmt(g: &clean::Type, f: &mut fmt::Formatter) -> fmt::Result {
         match *g {
             clean::TyParamBinder(id) | clean::Generic(id) => {
                 local_data::get(cache_key, |cache| {
                     let m = cache.unwrap().get();
-                    f.buf.write(m.typarams.get(&id).as_bytes());
+                    f.buf.write(m.typarams.get(&id).as_bytes())
                 })
             }
             clean::ResolvedPath{id, typarams: ref tp, path: ref path} => {
-                resolved_path(f.buf, id, path, false);
-                typarams(f.buf, tp);
+                if_ok!(resolved_path(f.buf, id, path, false));
+                typarams(f.buf, tp)
             }
             clean::ExternalPath{path: ref path, typarams: ref tp,
                                 fqn: ref fqn, kind, crate} => {
-                external_path(f.buf, path, false, fqn.as_slice(), kind, crate);
-                typarams(f.buf, tp);
+                if_ok!(external_path(f.buf, path, false, fqn.as_slice(), kind,
+                                     crate))
+                typarams(f.buf, tp)
             }
             clean::Self(..) => f.buf.write("Self".as_bytes()),
             clean::Primitive(prim) => {
@@ -306,7 +335,7 @@ impl fmt::Show for clean::Type {
                     ast::TyBool => "bool",
                     ast::TyChar => "char",
                 };
-                f.buf.write(s.as_bytes());
+                f.buf.write(s.as_bytes())
             }
             clean::Closure(ref decl) => {
                 let region = match decl.region {
@@ -322,7 +351,7 @@ impl fmt::Show for clean::Type {
                            ast::ManagedSigil => format!("@{}fn({})", region, decl.decl.inputs),
                        },
                        arrow = match decl.decl.output { clean::Unit => "no", _ => "yes" },
-                       ret = decl.decl.output);
+                       ret = decl.decl.output)
                 // FIXME: where are bounds and lifetimes printed?!
             }
             clean::BareFunction(ref decl) => {
@@ -333,19 +362,21 @@ impl fmt::Show for clean::Type {
                            ref s => " " + *s + " ",
                        },
                        decl.generics,
-                       decl.decl);
+                       decl.decl)
             }
             clean::Tuple(ref typs) => {
-                f.buf.write("(".as_bytes());
+                if_ok!(f.buf.write("(".as_bytes()));
                 for (i, typ) in typs.iter().enumerate() {
-                    if i > 0 { f.buf.write(", ".as_bytes()) }
-                    write!(f.buf, "{}", *typ);
+                    if i > 0 {
+                        if_ok!(f.buf.write(", ".as_bytes()))
+                    }
+                    if_ok!(write!(f.buf, "{}", *typ));
                 }
-                f.buf.write(")".as_bytes());
+                f.buf.write(")".as_bytes())
             }
             clean::Vector(ref t) => write!(f.buf, "[{}]", **t),
             clean::FixedVector(ref t, ref s) => {
-                write!(f.buf, "[{}, ..{}]", **t, *s);
+                write!(f.buf, "[{}, ..{}]", **t, *s)
             }
             clean::String => f.buf.write("str".as_bytes()),
             clean::Bool => f.buf.write("bool".as_bytes()),
@@ -368,23 +399,23 @@ impl fmt::Show for clean::Type {
                            clean::Mutable => "mut ",
                            clean::Immutable => "",
                        },
-                       **ty);
+                       **ty)
             }
         }
     }
 }
 
 impl fmt::Show for clean::FnDecl {
-    fn fmt(d: &clean::FnDecl, f: &mut fmt::Formatter) {
+    fn fmt(d: &clean::FnDecl, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f.buf, "({args}){arrow, select, yes{ -&gt; {ret}} other{}}",
                args = d.inputs,
                arrow = match d.output { clean::Unit => "no", _ => "yes" },
-               ret = d.output);
+               ret = d.output)
     }
 }
 
 impl fmt::Show for ~[clean::Argument] {
-    fn fmt(inputs: &~[clean::Argument], f: &mut fmt::Formatter) {
+    fn fmt(inputs: &~[clean::Argument], f: &mut fmt::Formatter) -> fmt::Result {
         let mut args = ~"";
         for (i, input) in inputs.iter().enumerate() {
             if i > 0 { args.push_str(", "); }
@@ -393,12 +424,12 @@ impl fmt::Show for ~[clean::Argument] {
             }
             args.push_str(format!("{}", input.type_));
         }
-        f.buf.write(args.as_bytes());
+        f.buf.write(args.as_bytes())
     }
 }
 
 impl<'a> fmt::Show for Method<'a> {
-    fn fmt(m: &Method<'a>, f: &mut fmt::Formatter) {
+    fn fmt(m: &Method<'a>, f: &mut fmt::Formatter) -> fmt::Result {
         let Method(selfty, d) = *m;
         let mut args = ~"";
         match *selfty {
@@ -429,74 +460,79 @@ impl<'a> fmt::Show for Method<'a> {
         write!(f.buf, "({args}){arrow, select, yes{ -&gt; {ret}} other{}}",
                args = args,
                arrow = match d.output { clean::Unit => "no", _ => "yes" },
-               ret = d.output);
+               ret = d.output)
     }
 }
 
 impl fmt::Show for VisSpace {
-    fn fmt(v: &VisSpace, f: &mut fmt::Formatter) {
+    fn fmt(v: &VisSpace, f: &mut fmt::Formatter) -> fmt::Result {
         match v.get() {
-            Some(ast::Public) => { write!(f.buf, "pub "); }
-            Some(ast::Private) => { write!(f.buf, "priv "); }
-            Some(ast::Inherited) | None => {}
+            Some(ast::Public) => write!(f.buf, "pub "),
+            Some(ast::Private) => write!(f.buf, "priv "),
+            Some(ast::Inherited) | None => Ok(())
         }
     }
 }
 
 impl fmt::Show for PuritySpace {
-    fn fmt(p: &PuritySpace, f: &mut fmt::Formatter) {
+    fn fmt(p: &PuritySpace, f: &mut fmt::Formatter) -> fmt::Result {
         match p.get() {
             ast::UnsafeFn => write!(f.buf, "unsafe "),
             ast::ExternFn => write!(f.buf, "extern "),
-            ast::ImpureFn => {}
+            ast::ImpureFn => Ok(())
         }
     }
 }
 
 impl fmt::Show for clean::ViewPath {
-    fn fmt(v: &clean::ViewPath, f: &mut fmt::Formatter) {
+    fn fmt(v: &clean::ViewPath, f: &mut fmt::Formatter) -> fmt::Result {
         match *v {
             clean::SimpleImport(ref name, ref src) => {
                 if *name == src.path.segments.last().unwrap().name {
-                    write!(f.buf, "use {};", *src);
+                    write!(f.buf, "use {};", *src)
                 } else {
-                    write!(f.buf, "use {} = {};", *name, *src);
+                    write!(f.buf, "use {} = {};", *name, *src)
                 }
             }
             clean::GlobImport(ref src) => {
-                write!(f.buf, "use {}::*;", *src);
+                write!(f.buf, "use {}::*;", *src)
             }
             clean::ImportList(ref src, ref names) => {
-                write!(f.buf, "use {}::\\{", *src);
+                if_ok!(write!(f.buf, "use {}::\\{", *src));
                 for (i, n) in names.iter().enumerate() {
-                    if i > 0 { write!(f.buf, ", "); }
-                    write!(f.buf, "{}", *n);
+                    if i > 0 {
+                        if_ok!(write!(f.buf, ", "));
+                    }
+                    if_ok!(write!(f.buf, "{}", *n));
                 }
-                write!(f.buf, "\\};");
+                write!(f.buf, "\\};")
             }
         }
     }
 }
 
 impl fmt::Show for clean::ImportSource {
-    fn fmt(v: &clean::ImportSource, f: &mut fmt::Formatter) {
+    fn fmt(v: &clean::ImportSource, f: &mut fmt::Formatter) -> fmt::Result {
         match v.did {
             // FIXME: shouldn't be restricted to just local imports
             Some(did) if ast_util::is_local(did) => {
-                resolved_path(f.buf, did.node, &v.path, true);
+                resolved_path(f.buf, did.node, &v.path, true)
             }
             _ => {
                 for (i, seg) in v.path.segments.iter().enumerate() {
-                    if i > 0 { write!(f.buf, "::") }
-                    write!(f.buf, "{}", seg.name);
+                    if i > 0 {
+                        if_ok!(write!(f.buf, "::"))
+                    }
+                    if_ok!(write!(f.buf, "{}", seg.name));
                 }
+                Ok(())
             }
         }
     }
 }
 
 impl fmt::Show for clean::ViewListIdent {
-    fn fmt(v: &clean::ViewListIdent, f: &mut fmt::Formatter) {
+    fn fmt(v: &clean::ViewListIdent, f: &mut fmt::Formatter) -> fmt::Result {
         match v.source {
             // FIXME: shouldn't be limited to just local imports
             Some(did) if ast_util::is_local(did) => {
@@ -508,7 +544,7 @@ impl fmt::Show for clean::ViewListIdent {
                         types: ~[],
                     }]
                 };
-                resolved_path(f.buf, did.node, &path, false);
+                resolved_path(f.buf, did.node, &path, false)
             }
             _ => write!(f.buf, "{}", v.name),
         }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -26,6 +26,7 @@ pub struct Page<'a> {
 
 pub fn render<T: fmt::Show, S: fmt::Show>(
     dst: &mut io::Writer, layout: &Layout, page: &Page, sidebar: &S, t: &T)
+    -> fmt::Result
 {
     write!(dst,
 "<!DOCTYPE html>
@@ -121,7 +122,7 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
     favicon   = nonestr(layout.favicon),
     sidebar   = *sidebar,
     crate     = layout.crate,
-    );
+    )
 }
 
 fn nonestr<'a>(s: &'a str) -> &'a str {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -109,7 +109,7 @@ fn stripped_filtered_line<'a>(s: &'a str) -> Option<&'a str> {
     }
 }
 
-pub fn render(w: &mut io::Writer, s: &str) {
+pub fn render(w: &mut io::Writer, s: &str) -> fmt::Result {
     extern fn block(ob: *buf, text: *buf, lang: *buf, opaque: *libc::c_void) {
         unsafe {
             let my_opaque: &my_opaque = cast::transmute(opaque);
@@ -159,11 +159,12 @@ pub fn render(w: &mut io::Writer, s: &str) {
         sd_markdown_render(ob, s.as_ptr(), s.len() as libc::size_t, markdown);
         sd_markdown_free(markdown);
 
-        vec::raw::buf_as_slice((*ob).data, (*ob).size as uint, |buf| {
-            w.write(buf);
+        let ret = vec::raw::buf_as_slice((*ob).data, (*ob).size as uint, |buf| {
+            w.write(buf)
         });
 
         bufrelease(ob);
+        ret
     }
 }
 
@@ -210,10 +211,10 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
 }
 
 impl<'a> fmt::Show for Markdown<'a> {
-    fn fmt(md: &Markdown<'a>, fmt: &mut fmt::Formatter) {
+    fn fmt(md: &Markdown<'a>, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Markdown(md) = *md;
         // This is actually common enough to special-case
-        if md.len() == 0 { return; }
-        render(fmt.buf, md.as_slice());
+        if md.len() == 0 { return Ok(()) }
+        render(fmt.buf, md.as_slice())
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -804,13 +804,13 @@ impl<'a> fmt::Show for Item<'a> {
     fn fmt(it: &Item<'a>, fmt: &mut fmt::Formatter) -> fmt::Result {
         match attr::find_stability(it.item.attrs.iter()) {
             Some(ref stability) => {
-                write!(fmt.buf,
+                if_ok!(write!(fmt.buf,
                        "<a class='stability {lvl}' title='{reason}'>{lvl}</a>",
                        lvl = stability.level.to_str(),
                        reason = match stability.text {
                            Some(ref s) => (*s).clone(),
                            None => InternedString::new(""),
-                       });
+                       }));
             }
             None => {}
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -195,7 +195,7 @@ local_data_key!(pub cache_key: Arc<Cache>)
 local_data_key!(pub current_location_key: ~[~str])
 
 /// Generates the documentation for `crate` into the directory `dst`
-pub fn run(mut crate: clean::Crate, dst: Path) {
+pub fn run(mut crate: clean::Crate, dst: Path) -> io::IoResult<()> {
     let mut cx = Context {
         dst: dst,
         current: ~[],
@@ -208,7 +208,7 @@ pub fn run(mut crate: clean::Crate, dst: Path) {
         },
         include_sources: true,
     };
-    mkdir(&cx.dst);
+    if_ok!(mkdir(&cx.dst));
 
     match crate.module.as_ref().map(|m| m.doc_list().unwrap_or(&[])) {
         Some(attrs) => {
@@ -248,47 +248,55 @@ pub fn run(mut crate: clean::Crate, dst: Path) {
 
     // Add all the static files
     let mut dst = cx.dst.join(crate.name.as_slice());
-    mkdir(&dst);
-    write(dst.join("jquery.js"), include_str!("static/jquery-2.0.3.min.js"));
-    write(dst.join("main.js"), include_str!("static/main.js"));
-    write(dst.join("main.css"), include_str!("static/main.css"));
-    write(dst.join("normalize.css"), include_str!("static/normalize.css"));
+    if_ok!(mkdir(&dst));
+    if_ok!(write(dst.join("jquery.js"),
+                 include_str!("static/jquery-2.0.3.min.js")));
+    if_ok!(write(dst.join("main.js"), include_str!("static/main.js")));
+    if_ok!(write(dst.join("main.css"), include_str!("static/main.css")));
+    if_ok!(write(dst.join("normalize.css"),
+                 include_str!("static/normalize.css")));
 
     // Publish the search index
     {
         dst.push("search-index.js");
         let mut w = BufferedWriter::new(File::create(&dst).unwrap());
         let w = &mut w as &mut Writer;
-        write!(w, "var searchIndex = [");
+        if_ok!(write!(w, "var searchIndex = ["));
         for (i, item) in cache.search_index.iter().enumerate() {
-            if i > 0 { write!(w, ","); }
-            write!(w, "\\{ty:\"{}\",name:\"{}\",path:\"{}\",desc:{}",
-                   item.ty, item.name, item.path,
-                   item.desc.to_json().to_str())
+            if i > 0 {
+                if_ok!(write!(w, ","));
+            }
+            if_ok!(write!(w, "\\{ty:\"{}\",name:\"{}\",path:\"{}\",desc:{}",
+                          item.ty, item.name, item.path,
+                          item.desc.to_json().to_str()));
             match item.parent {
-                Some(id) => { write!(w, ",parent:'{}'", id); }
+                Some(id) => {
+                    if_ok!(write!(w, ",parent:'{}'", id));
+                }
                 None => {}
             }
-            write!(w, "\\}");
+            if_ok!(write!(w, "\\}"));
         }
-        write!(w, "];");
-        write!(w, "var allPaths = \\{");
+        if_ok!(write!(w, "];"));
+        if_ok!(write!(w, "var allPaths = \\{"));
         for (i, (&id, &(ref fqp, short))) in cache.paths.iter().enumerate() {
-            if i > 0 { write!(w, ","); }
-            write!(w, "'{}':\\{type:'{}',name:'{}'\\}",
-                   id, short, *fqp.last().unwrap());
+            if i > 0 {
+                if_ok!(write!(w, ","));
+            }
+            if_ok!(write!(w, "'{}':\\{type:'{}',name:'{}'\\}",
+                          id, short, *fqp.last().unwrap()));
         }
-        write!(w, "\\};");
-        w.flush();
+        if_ok!(write!(w, "\\};"));
+        if_ok!(w.flush());
     }
 
     // Render all source files (this may turn into a giant no-op)
     {
         info!("emitting source files");
         let dst = cx.dst.join("src");
-        mkdir(&dst);
+        if_ok!(mkdir(&dst));
         let dst = dst.join(crate.name.as_slice());
-        mkdir(&dst);
+        if_ok!(mkdir(&dst));
         let mut folder = SourceCollector {
             dst: dst,
             seen: HashSet::new(),
@@ -302,27 +310,23 @@ pub fn run(mut crate: clean::Crate, dst: Path) {
     }
 
     // And finally render the whole crate's documentation
-    cx.crate(crate, cache);
+    cx.crate(crate, cache)
 }
 
 /// Writes the entire contents of a string to a destination, not attempting to
 /// catch any errors.
-fn write(dst: Path, contents: &str) {
-    File::create(&dst).write(contents.as_bytes());
+fn write(dst: Path, contents: &str) -> io::IoResult<()> {
+    File::create(&dst).write(contents.as_bytes())
 }
 
 /// Makes a directory on the filesystem, failing the task if an error occurs and
 /// skipping if the directory already exists.
-fn mkdir(path: &Path) {
-    io::io_error::cond.trap(|err| {
-        error!("Couldn't create directory `{}`: {}",
-                path.display(), err.desc);
-        fail!()
-    }).inside(|| {
-        if !path.is_dir() {
-            fs::mkdir(path, io::UserRWX);
-        }
-    })
+fn mkdir(path: &Path) -> io::IoResult<()> {
+    if !path.exists() {
+        fs::mkdir(path, io::UserRWX)
+    } else {
+        Ok(())
+    }
 }
 
 /// Takes a path to a source file and cleans the path to it. This canonicalizes
@@ -387,15 +391,17 @@ impl<'a> DocFolder for SourceCollector<'a> {
             // something like that), so just don't include sources for the
             // entire crate. The other option is maintaining this mapping on a
             // per-file basis, but that's probably not worth it...
-            self.cx.include_sources = self.emit_source(item.source.filename);
+            self.cx.include_sources = match self.emit_source(item.source.filename) {
+                Ok(()) => true,
+                Err(e) => {
+                    println!("warning: source code was requested to be rendered, \
+                              but processing `{}` had an error: {}",
+                             item.source.filename, e);
+                    println!("         skipping rendering of source code");
+                    false
+                }
+            };
             self.seen.insert(item.source.filename.clone());
-
-            if !self.cx.include_sources {
-                println!("warning: source code was requested to be rendered, \
-                          but `{}` is a missing source file.",
-                         item.source.filename);
-                println!("         skipping rendering of source code");
-            }
         }
 
         self.fold_item_recur(item)
@@ -404,30 +410,18 @@ impl<'a> DocFolder for SourceCollector<'a> {
 
 impl<'a> SourceCollector<'a> {
     /// Renders the given filename into its corresponding HTML source file.
-    fn emit_source(&mut self, filename: &str) -> bool {
+    fn emit_source(&mut self, filename: &str) -> io::IoResult<()> {
         let p = Path::new(filename);
 
-        // Read the contents of the file
-        let mut contents = ~[];
-        {
-            let mut buf = [0, ..1024];
-            // If we couldn't open this file, then just returns because it
-            // probably means that it's some standard library macro thing and we
-            // can't have the source to it anyway.
-            let mut r = match io::result(|| File::open(&p)) {
-                Ok(r) => r,
-                // eew macro hacks
-                Err(..) => return filename == "<std-macros>"
-            };
-
-            // read everything
-            loop {
-                match r.read(buf) {
-                    Some(n) => contents.push_all(buf.slice_to(n)),
-                    None => break
-                }
-            }
-        }
+        // If we couldn't open this file, then just returns because it
+        // probably means that it's some standard library macro thing and we
+        // can't have the source to it anyway.
+        let contents = match File::open(&p).read_to_end() {
+            Ok(r) => r,
+            // eew macro hacks
+            Err(..) if filename == "<std-macros>" => return Ok(()),
+            Err(e) => return Err(e)
+        };
         let contents = str::from_utf8_owned(contents).unwrap();
 
         // Create the intermediate directories
@@ -435,12 +429,12 @@ impl<'a> SourceCollector<'a> {
         let mut root_path = ~"../../";
         clean_srcpath(p.dirname(), |component| {
             cur.push(component);
-            mkdir(&cur);
+            mkdir(&cur).unwrap();
             root_path.push_str("../");
         });
 
         cur.push(p.filename().expect("source has no filename") + bytes!(".html"));
-        let mut w = BufferedWriter::new(File::create(&cur).unwrap());
+        let mut w = BufferedWriter::new(if_ok!(File::create(&cur)));
 
         let title = cur.filename_display().with_str(|s| format!("{} -- source", s));
         let page = layout::Page {
@@ -448,10 +442,10 @@ impl<'a> SourceCollector<'a> {
             ty: "source",
             root_path: root_path,
         };
-        layout::render(&mut w as &mut Writer, &self.cx.layout,
-                       &page, &(""), &Source(contents.as_slice()));
-        w.flush();
-        return true;
+        if_ok!(layout::render(&mut w as &mut Writer, &self.cx.layout,
+                              &page, &(""), &Source(contents.as_slice())));
+        if_ok!(w.flush());
+        return Ok(());
     }
 }
 
@@ -665,7 +659,7 @@ impl Context {
 
         info!("Recursing into {}", self.dst.display());
 
-        mkdir(&self.dst);
+        mkdir(&self.dst).unwrap();
         let ret = f(self);
 
         info!("Recursed; leaving {}", self.dst.display());
@@ -683,10 +677,10 @@ impl Context {
     ///
     /// This currently isn't parallelized, but it'd be pretty easy to add
     /// parallelization to this function.
-    fn crate(self, mut crate: clean::Crate, cache: Cache) {
+    fn crate(self, mut crate: clean::Crate, cache: Cache) -> io::IoResult<()> {
         let mut item = match crate.module.take() {
             Some(i) => i,
-            None => return
+            None => return Ok(())
         };
         item.name = Some(crate.name);
 
@@ -696,12 +690,13 @@ impl Context {
         let mut work = ~[(self, item)];
         loop {
             match work.pop() {
-                Some((mut cx, item)) => cx.item(item, |cx, item| {
+                Some((mut cx, item)) => if_ok!(cx.item(item, |cx, item| {
                     work.push((cx.clone(), item));
-                }),
+                })),
                 None => break,
             }
         }
+        Ok(())
     }
 
     /// Non-parellelized version of rendering an item. This will take the input
@@ -709,9 +704,10 @@ impl Context {
     /// all sub-items which need to be rendered.
     ///
     /// The rendering driver uses this closure to queue up more work.
-    fn item(&mut self, item: clean::Item, f: |&mut Context, clean::Item|) {
+    fn item(&mut self, item: clean::Item,
+            f: |&mut Context, clean::Item|) -> io::IoResult<()> {
         fn render(w: io::File, cx: &mut Context, it: &clean::Item,
-                  pushname: bool) {
+                  pushname: bool) -> io::IoResult<()> {
             info!("Rendering an item to {}", w.path().display());
             // A little unfortunate that this is done like this, but it sure
             // does make formatting *a lot* nicer.
@@ -733,10 +729,10 @@ impl Context {
             // of the pain by using a buffered writer instead of invoking the
             // write sycall all the time.
             let mut writer = BufferedWriter::new(w);
-            layout::render(&mut writer as &mut Writer, &cx.layout, &page,
-                           &Sidebar{ cx: cx, item: it },
-                           &Item{ cx: cx, item: it });
-            writer.flush();
+            if_ok!(layout::render(&mut writer as &mut Writer, &cx.layout, &page,
+                                  &Sidebar{ cx: cx, item: it },
+                                  &Item{ cx: cx, item: it }));
+            writer.flush()
         }
 
         match item.inner {
@@ -748,7 +744,8 @@ impl Context {
                 self.recurse(name, |this| {
                     let item = item.take_unwrap();
                     let dst = this.dst.join("index.html");
-                    render(File::create(&dst).unwrap(), this, &item, false);
+                    let dst = if_ok!(File::create(&dst));
+                    if_ok!(render(dst, this, &item, false));
 
                     let m = match item.inner {
                         clean::ModuleItem(m) => m,
@@ -758,6 +755,7 @@ impl Context {
                     for item in m.items.move_iter() {
                         f(this,item);
                     }
+                    Ok(())
                 })
             }
 
@@ -765,10 +763,11 @@ impl Context {
             // pages dedicated to them.
             _ if item.name.is_some() => {
                 let dst = self.dst.join(item_path(&item));
-                render(File::create(&dst).unwrap(), self, &item, true);
+                let dst = if_ok!(File::create(&dst));
+                render(dst, self, &item, true)
             }
 
-            _ => {}
+            _ => Ok(())
         }
     }
 }
@@ -802,7 +801,7 @@ impl<'a> Item<'a> {
 }
 
 impl<'a> fmt::Show for Item<'a> {
-    fn fmt(it: &Item<'a>, fmt: &mut fmt::Formatter) {
+    fn fmt(it: &Item<'a>, fmt: &mut fmt::Formatter) -> fmt::Result {
         match attr::find_stability(it.item.attrs.iter()) {
             Some(ref stability) => {
                 write!(fmt.buf,
@@ -826,23 +825,24 @@ impl<'a> fmt::Show for Item<'a> {
             } else {
                 format!("{}-{}", it.item.source.loline, it.item.source.hiline)
             };
-            write!(fmt.buf,
-                   "<a class='source'
-                       href='{root}src/{crate}/{path}.html\\#{href}'>[src]</a>",
-                   root = it.cx.root_path,
-                   crate = it.cx.layout.crate,
-                   path = path.connect("/"),
-                   href = href);
+            if_ok!(write!(fmt.buf,
+                          "<a class='source'
+                              href='{root}src/{crate}/{path}.html\\#{href}'>\
+                              [src]</a>",
+                          root = it.cx.root_path,
+                          crate = it.cx.layout.crate,
+                          path = path.connect("/"),
+                          href = href));
         }
 
         // Write the breadcrumb trail header for the top
-        write!(fmt.buf, "<h1 class='fqn'>");
+        if_ok!(write!(fmt.buf, "<h1 class='fqn'>"));
         match it.item.inner {
-            clean::ModuleItem(..) => write!(fmt.buf, "Module "),
-            clean::FunctionItem(..) => write!(fmt.buf, "Function "),
-            clean::TraitItem(..) => write!(fmt.buf, "Trait "),
-            clean::StructItem(..) => write!(fmt.buf, "Struct "),
-            clean::EnumItem(..) => write!(fmt.buf, "Enum "),
+            clean::ModuleItem(..) => if_ok!(write!(fmt.buf, "Module ")),
+            clean::FunctionItem(..) => if_ok!(write!(fmt.buf, "Function ")),
+            clean::TraitItem(..) => if_ok!(write!(fmt.buf, "Trait ")),
+            clean::StructItem(..) => if_ok!(write!(fmt.buf, "Struct ")),
+            clean::EnumItem(..) => if_ok!(write!(fmt.buf, "Enum ")),
             _ => {}
         }
         let cur = it.cx.current.as_slice();
@@ -852,11 +852,11 @@ impl<'a> fmt::Show for Item<'a> {
             for _ in range(0, cur.len() - i - 1) {
                 trail.push_str("../");
             }
-            write!(fmt.buf, "<a href='{}index.html'>{}</a>::",
-                   trail, component.as_slice());
+            if_ok!(write!(fmt.buf, "<a href='{}index.html'>{}</a>::",
+                          trail, component.as_slice()));
         }
-        write!(fmt.buf, "<a class='{}' href=''>{}</a></h1>",
-               shortty(it.item), it.item.name.get_ref().as_slice());
+        if_ok!(write!(fmt.buf, "<a class='{}' href=''>{}</a></h1>",
+                      shortty(it.item), it.item.name.get_ref().as_slice()));
 
         match it.item.inner {
             clean::ModuleItem(ref m) => item_module(fmt.buf, it.cx,
@@ -867,7 +867,7 @@ impl<'a> fmt::Show for Item<'a> {
             clean::StructItem(ref s) => item_struct(fmt.buf, it.item, s),
             clean::EnumItem(ref e) => item_enum(fmt.buf, it.item, e),
             clean::TypedefItem(ref t) => item_typedef(fmt.buf, it.item, t),
-            _ => {}
+            _ => Ok(())
         }
     }
 }
@@ -903,18 +903,19 @@ fn shorter<'a>(s: Option<&'a str>) -> &'a str {
     }
 }
 
-fn document(w: &mut Writer, item: &clean::Item) {
+fn document(w: &mut Writer, item: &clean::Item) -> fmt::Result {
     match item.doc_value() {
         Some(s) => {
-            write!(w, "<div class='docblock'>{}</div>", Markdown(s));
+            if_ok!(write!(w, "<div class='docblock'>{}</div>", Markdown(s)));
         }
         None => {}
     }
+    Ok(())
 }
 
 fn item_module(w: &mut Writer, cx: &Context,
-               item: &clean::Item, items: &[clean::Item]) {
-    document(w, item);
+               item: &clean::Item, items: &[clean::Item]) -> fmt::Result {
+    if_ok!(document(w, item));
     debug!("{:?}", items);
     let mut indices = vec::from_fn(items.len(), |i| i);
 
@@ -965,10 +966,10 @@ fn item_module(w: &mut Writer, cx: &Context,
         let myty = shortty(myitem);
         if myty != curty {
             if curty != "" {
-                write!(w, "</table>");
+                if_ok!(write!(w, "</table>"));
             }
             curty = myty;
-            write!(w, "<h2>{}</h2>\n<table>", match myitem.inner {
+            if_ok!(write!(w, "<h2>{}</h2>\n<table>", match myitem.inner {
                 clean::ModuleItem(..)          => "Modules",
                 clean::StructItem(..)          => "Structs",
                 clean::EnumItem(..)            => "Enums",
@@ -984,24 +985,26 @@ fn item_module(w: &mut Writer, cx: &Context,
                 clean::VariantItem(..)         => "Variants",
                 clean::ForeignFunctionItem(..) => "Foreign Functions",
                 clean::ForeignStaticItem(..)   => "Foreign Statics",
-            });
+            }));
         }
 
         match myitem.inner {
             clean::StaticItem(ref s) | clean::ForeignStaticItem(ref s) => {
                 struct Initializer<'a>(&'a str);
                 impl<'a> fmt::Show for Initializer<'a> {
-                    fn fmt(s: &Initializer<'a>, f: &mut fmt::Formatter) {
+                    fn fmt(s: &Initializer<'a>,
+                           f: &mut fmt::Formatter) -> fmt::Result {
                         let Initializer(s) = *s;
-                        if s.len() == 0 { return; }
-                        write!(f.buf, "<code> = </code>");
+                        if s.len() == 0 { return Ok(()); }
+                        if_ok!(write!(f.buf, "<code> = </code>"));
                         let tag = if s.contains("\n") { "pre" } else { "code" };
-                        write!(f.buf, "<{tag}>{}</{tag}>",
-                               s.as_slice(), tag=tag);
+                        if_ok!(write!(f.buf, "<{tag}>{}</{tag}>",
+                                      s.as_slice(), tag=tag));
+                        Ok(())
                     }
                 }
 
-                write!(w, "
+                if_ok!(write!(w, "
                     <tr>
                         <td><code>{}static {}: {}</code>{}</td>
                         <td class='docblock'>{}&nbsp;</td>
@@ -1011,27 +1014,27 @@ fn item_module(w: &mut Writer, cx: &Context,
                 *myitem.name.get_ref(),
                 s.type_,
                 Initializer(s.expr),
-                Markdown(blank(myitem.doc_value())));
+                Markdown(blank(myitem.doc_value()))));
             }
 
             clean::ViewItemItem(ref item) => {
                 match item.inner {
                     clean::ExternMod(ref name, ref src, _) => {
-                        write!(w, "<tr><td><code>extern mod {}",
-                               name.as_slice());
+                        if_ok!(write!(w, "<tr><td><code>extern mod {}",
+                                      name.as_slice()));
                         match *src {
-                            Some(ref src) => write!(w, " = \"{}\"",
-                                                    src.as_slice()),
+                            Some(ref src) => if_ok!(write!(w, " = \"{}\"",
+                                                           src.as_slice())),
                             None => {}
                         }
-                        write!(w, ";</code></td></tr>");
+                        if_ok!(write!(w, ";</code></td></tr>"));
                     }
 
                     clean::Import(ref imports) => {
                         for import in imports.iter() {
-                            write!(w, "<tr><td><code>{}{}</code></td></tr>",
-                                   VisSpace(myitem.visibility),
-                                   *import);
+                            if_ok!(write!(w, "<tr><td><code>{}{}</code></td></tr>",
+                                          VisSpace(myitem.visibility),
+                                          *import));
                         }
                     }
                 }
@@ -1040,7 +1043,7 @@ fn item_module(w: &mut Writer, cx: &Context,
 
             _ => {
                 if myitem.name.is_none() { continue }
-                write!(w, "
+                if_ok!(write!(w, "
                     <tr>
                         <td><a class='{class}' href='{href}'
                                title='{title}'>{}</a></td>
@@ -1051,24 +1054,26 @@ fn item_module(w: &mut Writer, cx: &Context,
                 Markdown(shorter(myitem.doc_value())),
                 class = shortty(myitem),
                 href = item_path(myitem),
-                title = full_path(cx, myitem));
+                title = full_path(cx, myitem)));
             }
         }
     }
-    write!(w, "</table>");
+    write!(w, "</table>")
 }
 
-fn item_function(w: &mut Writer, it: &clean::Item, f: &clean::Function) {
-    write!(w, "<pre class='fn'>{vis}{purity}fn {name}{generics}{decl}</pre>",
+fn item_function(w: &mut Writer, it: &clean::Item,
+                 f: &clean::Function) -> fmt::Result {
+    if_ok!(write!(w, "<pre class='fn'>{vis}{purity}fn {name}{generics}{decl}</pre>",
            vis = VisSpace(it.visibility),
            purity = PuritySpace(f.purity),
            name = it.name.get_ref().as_slice(),
            generics = f.generics,
-           decl = f.decl);
-    document(w, it);
+           decl = f.decl));
+    document(w, it)
 }
 
-fn item_trait(w: &mut Writer, it: &clean::Item, t: &clean::Trait) {
+fn item_trait(w: &mut Writer, it: &clean::Item,
+              t: &clean::Trait) -> fmt::Result {
     let mut parents = ~"";
     if t.parents.len() > 0 {
         parents.push_str(": ");
@@ -1079,99 +1084,102 @@ fn item_trait(w: &mut Writer, it: &clean::Item, t: &clean::Trait) {
     }
 
     // Output the trait definition
-    write!(w, "<pre class='trait'>{}trait {}{}{} ",
-           VisSpace(it.visibility),
-           it.name.get_ref().as_slice(),
-           t.generics,
-           parents);
+    if_ok!(write!(w, "<pre class='trait'>{}trait {}{}{} ",
+                  VisSpace(it.visibility),
+                  it.name.get_ref().as_slice(),
+                  t.generics,
+                  parents));
     let required = t.methods.iter().filter(|m| m.is_req()).to_owned_vec();
     let provided = t.methods.iter().filter(|m| !m.is_req()).to_owned_vec();
 
     if t.methods.len() == 0 {
-        write!(w, "\\{ \\}");
+        if_ok!(write!(w, "\\{ \\}"));
     } else {
-        write!(w, "\\{\n");
+        if_ok!(write!(w, "\\{\n"));
         for m in required.iter() {
-            write!(w, "    ");
-            render_method(w, m.item(), true);
-            write!(w, ";\n");
+            if_ok!(write!(w, "    "));
+            if_ok!(render_method(w, m.item(), true));
+            if_ok!(write!(w, ";\n"));
         }
         if required.len() > 0 && provided.len() > 0 {
-            w.write("\n".as_bytes());
+            if_ok!(w.write("\n".as_bytes()));
         }
         for m in provided.iter() {
-            write!(w, "    ");
-            render_method(w, m.item(), true);
-            write!(w, " \\{ ... \\}\n");
+            if_ok!(write!(w, "    "));
+            if_ok!(render_method(w, m.item(), true));
+            if_ok!(write!(w, " \\{ ... \\}\n"));
         }
-        write!(w, "\\}");
+        if_ok!(write!(w, "\\}"));
     }
-    write!(w, "</pre>");
+    if_ok!(write!(w, "</pre>"));
 
     // Trait documentation
-    document(w, it);
+    if_ok!(document(w, it));
 
-    fn meth(w: &mut Writer, m: &clean::TraitMethod) {
-        write!(w, "<h3 id='{}.{}' class='method'><code>",
-               shortty(m.item()),
-               *m.item().name.get_ref());
-        render_method(w, m.item(), false);
-        write!(w, "</code></h3>");
-        document(w, m.item());
+    fn meth(w: &mut Writer, m: &clean::TraitMethod) -> fmt::Result {
+        if_ok!(write!(w, "<h3 id='{}.{}' class='method'><code>",
+                      shortty(m.item()),
+                      *m.item().name.get_ref()));
+        if_ok!(render_method(w, m.item(), false));
+        if_ok!(write!(w, "</code></h3>"));
+        if_ok!(document(w, m.item()));
+        Ok(())
     }
 
     // Output the documentation for each function individually
     if required.len() > 0 {
-        write!(w, "
+        if_ok!(write!(w, "
             <h2 id='required-methods'>Required Methods</h2>
             <div class='methods'>
-        ");
+        "));
         for m in required.iter() {
-            meth(w, *m);
+            if_ok!(meth(w, *m));
         }
-        write!(w, "</div>");
+        if_ok!(write!(w, "</div>"));
     }
     if provided.len() > 0 {
-        write!(w, "
+        if_ok!(write!(w, "
             <h2 id='provided-methods'>Provided Methods</h2>
             <div class='methods'>
-        ");
+        "));
         for m in provided.iter() {
-            meth(w, *m);
+            if_ok!(meth(w, *m));
         }
-        write!(w, "</div>");
+        if_ok!(write!(w, "</div>"));
     }
 
     local_data::get(cache_key, |cache| {
         let cache = cache.unwrap().get();
         match cache.implementors.find(&it.id) {
             Some(implementors) => {
-                write!(w, "
+                if_ok!(write!(w, "
                     <h2 id='implementors'>Implementors</h2>
                     <ul class='item-list'>
-                ");
+                "));
                 for i in implementors.iter() {
                     match *i {
                         PathType(ref ty) => {
-                            write!(w, "<li><code>{}</code></li>", *ty);
+                            if_ok!(write!(w, "<li><code>{}</code></li>", *ty));
                         }
                         OtherType(ref generics, ref trait_, ref for_) => {
-                            write!(w, "<li><code>impl{} {} for {}</code></li>",
-                                   *generics, *trait_, *for_);
+                            if_ok!(write!(w, "<li><code>impl{} {} for {}</code></li>",
+                                          *generics, *trait_, *for_));
                         }
                     }
                 }
-                write!(w, "</ul>");
+                if_ok!(write!(w, "</ul>"));
             }
             None => {}
         }
+        Ok(())
     })
 }
 
-fn render_method(w: &mut Writer, meth: &clean::Item, withlink: bool) {
+fn render_method(w: &mut Writer, meth: &clean::Item,
+                 withlink: bool) -> fmt::Result {
     fn fun(w: &mut Writer, it: &clean::Item, purity: ast::Purity,
            g: &clean::Generics, selfty: &clean::SelfTy, d: &clean::FnDecl,
-           withlink: bool) {
+           withlink: bool) -> fmt::Result {
         write!(w, "{}fn {withlink, select,
                             true{<a href='\\#{ty}.{name}'
                                     class='fnname'>{name}</a>}
@@ -1185,118 +1193,125 @@ fn render_method(w: &mut Writer, meth: &clean::Item, withlink: bool) {
                name = it.name.get_ref().as_slice(),
                generics = *g,
                decl = Method(selfty, d),
-               withlink = if withlink {"true"} else {"false"});
+               withlink = if withlink {"true"} else {"false"})
     }
     match meth.inner {
         clean::TyMethodItem(ref m) => {
-            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl, withlink);
+            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl, withlink)
         }
         clean::MethodItem(ref m) => {
-            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl, withlink);
+            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl, withlink)
         }
         _ => unreachable!()
     }
 }
 
-fn item_struct(w: &mut Writer, it: &clean::Item, s: &clean::Struct) {
-    write!(w, "<pre class='struct'>");
-    render_struct(w, it, Some(&s.generics), s.struct_type, s.fields,
-                  s.fields_stripped, "", true);
-    write!(w, "</pre>");
+fn item_struct(w: &mut Writer, it: &clean::Item,
+               s: &clean::Struct) -> fmt::Result {
+    if_ok!(write!(w, "<pre class='struct'>"));
+    if_ok!(render_struct(w, it, Some(&s.generics), s.struct_type, s.fields,
+                         s.fields_stripped, "", true));
+    if_ok!(write!(w, "</pre>"));
 
-    document(w, it);
+    if_ok!(document(w, it));
     match s.struct_type {
         doctree::Plain if s.fields.len() > 0 => {
-            write!(w, "<h2 class='fields'>Fields</h2>\n<table>");
+            if_ok!(write!(w, "<h2 class='fields'>Fields</h2>\n<table>"));
             for field in s.fields.iter() {
-                write!(w, "<tr><td id='structfield.{name}'>\
-                                <code>{name}</code></td><td>",
-                       name = field.name.get_ref().as_slice());
-                document(w, field);
-                write!(w, "</td></tr>");
+                if_ok!(write!(w, "<tr><td id='structfield.{name}'>\
+                                  <code>{name}</code></td><td>",
+                              name = field.name.get_ref().as_slice()));
+                if_ok!(document(w, field));
+                if_ok!(write!(w, "</td></tr>"));
             }
-            write!(w, "</table>");
+            if_ok!(write!(w, "</table>"));
         }
         _ => {}
     }
-    render_methods(w, it);
+    render_methods(w, it)
 }
 
-fn item_enum(w: &mut Writer, it: &clean::Item, e: &clean::Enum) {
-    write!(w, "<pre class='enum'>{}enum {}{}",
-           VisSpace(it.visibility),
-           it.name.get_ref().as_slice(),
-           e.generics);
+fn item_enum(w: &mut Writer, it: &clean::Item, e: &clean::Enum) -> fmt::Result {
+    if_ok!(write!(w, "<pre class='enum'>{}enum {}{}",
+                  VisSpace(it.visibility),
+                  it.name.get_ref().as_slice(),
+                  e.generics));
     if e.variants.len() == 0 && !e.variants_stripped {
-        write!(w, " \\{\\}");
+        if_ok!(write!(w, " \\{\\}"));
     } else {
-        write!(w, " \\{\n");
+        if_ok!(write!(w, " \\{\n"));
         for v in e.variants.iter() {
-            write!(w, "    ");
+            if_ok!(write!(w, "    "));
             let name = v.name.get_ref().as_slice();
             match v.inner {
                 clean::VariantItem(ref var) => {
                     match var.kind {
-                        clean::CLikeVariant => write!(w, "{}", name),
+                        clean::CLikeVariant => if_ok!(write!(w, "{}", name)),
                         clean::TupleVariant(ref tys) => {
-                            write!(w, "{}(", name);
+                            if_ok!(write!(w, "{}(", name));
                             for (i, ty) in tys.iter().enumerate() {
-                                if i > 0 { write!(w, ", ") }
-                                write!(w, "{}", *ty);
+                                if i > 0 {
+                                    if_ok!(write!(w, ", "))
+                                }
+                                if_ok!(write!(w, "{}", *ty));
                             }
-                            write!(w, ")");
+                            if_ok!(write!(w, ")"));
                         }
                         clean::StructVariant(ref s) => {
-                            render_struct(w, v, None, s.struct_type, s.fields,
-                                          s.fields_stripped, "    ", false);
+                            if_ok!(render_struct(w, v, None, s.struct_type,
+                                                 s.fields, s.fields_stripped,
+                                                 "    ", false));
                         }
                     }
                 }
                 _ => unreachable!()
             }
-            write!(w, ",\n");
+            if_ok!(write!(w, ",\n"));
         }
 
         if e.variants_stripped {
-            write!(w, "    // some variants omitted\n");
+            if_ok!(write!(w, "    // some variants omitted\n"));
         }
-        write!(w, "\\}");
+        if_ok!(write!(w, "\\}"));
     }
-    write!(w, "</pre>");
+    if_ok!(write!(w, "</pre>"));
 
-    document(w, it);
+    if_ok!(document(w, it));
     if e.variants.len() > 0 {
-        write!(w, "<h2 class='variants'>Variants</h2>\n<table>");
+        if_ok!(write!(w, "<h2 class='variants'>Variants</h2>\n<table>"));
         for variant in e.variants.iter() {
-            write!(w, "<tr><td id='variant.{name}'><code>{name}</code></td><td>",
-                   name = variant.name.get_ref().as_slice());
-            document(w, variant);
+            if_ok!(write!(w, "<tr><td id='variant.{name}'><code>{name}</code></td><td>",
+                          name = variant.name.get_ref().as_slice()));
+            if_ok!(document(w, variant));
             match variant.inner {
                 clean::VariantItem(ref var) => {
                     match var.kind {
                         clean::StructVariant(ref s) => {
-                            write!(w, "<h3 class='fields'>Fields</h3>\n<table>");
+                            if_ok!(write!(w, "<h3 class='fields'>Fields</h3>\n
+                                              <table>"));
                             for field in s.fields.iter() {
-                                write!(w, "<tr><td id='variant.{v}.field.{f}'>\
-                                           <code>{f}</code></td><td>",
-                                       v = variant.name.get_ref().as_slice(),
-                                       f = field.name.get_ref().as_slice());
-                                document(w, field);
-                                write!(w, "</td></tr>");
+                                if_ok!(write!(w, "<tr><td \
+                                                  id='variant.{v}.field.{f}'>\
+                                                  <code>{f}</code></td><td>",
+                                              v = variant.name.get_ref().as_slice(),
+                                              f = field.name.get_ref().as_slice()));
+                                if_ok!(document(w, field));
+                                if_ok!(write!(w, "</td></tr>"));
                             }
-                            write!(w, "</table>");
+                            if_ok!(write!(w, "</table>"));
                         }
                         _ => ()
                     }
                 }
                 _ => ()
             }
-            write!(w, "</td></tr>");
+            if_ok!(write!(w, "</td></tr>"));
         }
-        write!(w, "</table>");
+        if_ok!(write!(w, "</table>"));
 
     }
-    render_methods(w, it);
+    if_ok!(render_methods(w, it));
+    Ok(())
 }
 
 fn render_struct(w: &mut Writer, it: &clean::Item,
@@ -1305,54 +1320,59 @@ fn render_struct(w: &mut Writer, it: &clean::Item,
                  fields: &[clean::Item],
                  fields_stripped: bool,
                  tab: &str,
-                 structhead: bool) {
-    write!(w, "{}{}{}",
-           VisSpace(it.visibility),
-           if structhead {"struct "} else {""},
-           it.name.get_ref().as_slice());
+                 structhead: bool) -> fmt::Result {
+    if_ok!(write!(w, "{}{}{}",
+                  VisSpace(it.visibility),
+                  if structhead {"struct "} else {""},
+                  it.name.get_ref().as_slice()));
     match g {
-        Some(g) => write!(w, "{}", *g),
+        Some(g) => if_ok!(write!(w, "{}", *g)),
         None => {}
     }
     match ty {
         doctree::Plain => {
-            write!(w, " \\{\n{}", tab);
+            if_ok!(write!(w, " \\{\n{}", tab));
             for field in fields.iter() {
                 match field.inner {
                     clean::StructFieldItem(ref ty) => {
-                        write!(w, "    {}{}: {},\n{}",
-                               VisSpace(field.visibility),
-                               field.name.get_ref().as_slice(),
-                               ty.type_,
-                               tab);
+                        if_ok!(write!(w, "    {}{}: {},\n{}",
+                                      VisSpace(field.visibility),
+                                      field.name.get_ref().as_slice(),
+                                      ty.type_,
+                                      tab));
                     }
                     _ => unreachable!()
                 }
             }
 
             if fields_stripped {
-                write!(w, "    // some fields omitted\n{}", tab);
+                if_ok!(write!(w, "    // some fields omitted\n{}", tab));
             }
-            write!(w, "\\}");
+            if_ok!(write!(w, "\\}"));
         }
         doctree::Tuple | doctree::Newtype => {
-            write!(w, "(");
+            if_ok!(write!(w, "("));
             for (i, field) in fields.iter().enumerate() {
-                if i > 0 { write!(w, ", ") }
+                if i > 0 {
+                    if_ok!(write!(w, ", "));
+                }
                 match field.inner {
                     clean::StructFieldItem(ref field) => {
-                        write!(w, "{}", field.type_);
+                        if_ok!(write!(w, "{}", field.type_));
                     }
                     _ => unreachable!()
                 }
             }
-            write!(w, ");");
+            if_ok!(write!(w, ");"));
         }
-        doctree::Unit => { write!(w, ";"); }
+        doctree::Unit => {
+            if_ok!(write!(w, ";"));
+        }
     }
+    Ok(())
 }
 
-fn render_methods(w: &mut Writer, it: &clean::Item) {
+fn render_methods(w: &mut Writer, it: &clean::Item) -> fmt::Result {
     local_data::get(cache_key, |cache| {
         let c = cache.unwrap().get();
         match c.impls.find(&it.id) {
@@ -1367,29 +1387,31 @@ fn render_methods(w: &mut Writer, it: &clean::Item) {
                 let traits = traits.to_owned_vec();
 
                 if non_trait.len() > 0 {
-                    write!(w, "<h2 id='methods'>Methods</h2>");
+                    if_ok!(write!(w, "<h2 id='methods'>Methods</h2>"));
                     for &(ref i, ref dox) in non_trait.move_iter() {
-                        render_impl(w, i, dox);
+                        if_ok!(render_impl(w, i, dox));
                     }
                 }
                 if traits.len() > 0 {
-                    write!(w, "<h2 id='implementations'>Trait \
-                               Implementations</h2>");
+                    if_ok!(write!(w, "<h2 id='implementations'>Trait \
+                                      Implementations</h2>"));
                     for &(ref i, ref dox) in traits.move_iter() {
-                        render_impl(w, i, dox);
+                        if_ok!(render_impl(w, i, dox));
                     }
                 }
             }
             None => {}
         }
+        Ok(())
     })
 }
 
-fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
-    write!(w, "<h3 class='impl'><code>impl{} ", i.generics);
+fn render_impl(w: &mut Writer, i: &clean::Impl,
+               dox: &Option<~str>) -> fmt::Result {
+    if_ok!(write!(w, "<h3 class='impl'><code>impl{} ", i.generics));
     let trait_id = match i.trait_ {
         Some(ref ty) => {
-            write!(w, "{} for ", *ty);
+            if_ok!(write!(w, "{} for ", *ty));
             match *ty {
                 clean::ResolvedPath { id, .. } => Some(id),
                 _ => None,
@@ -1397,32 +1419,32 @@ fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
         }
         None => None
     };
-    write!(w, "{}</code></h3>", i.for_);
+    if_ok!(write!(w, "{}</code></h3>", i.for_));
     match *dox {
         Some(ref dox) => {
-            write!(w, "<div class='docblock'>{}</div>",
-                   Markdown(dox.as_slice()));
+            if_ok!(write!(w, "<div class='docblock'>{}</div>",
+                          Markdown(dox.as_slice())));
         }
         None => {}
     }
 
-    fn docmeth(w: &mut Writer, item: &clean::Item) -> bool {
-        write!(w, "<h4 id='method.{}' class='method'><code>",
-               *item.name.get_ref());
-        render_method(w, item, false);
-        write!(w, "</code></h4>\n");
+    fn docmeth(w: &mut Writer, item: &clean::Item) -> io::IoResult<bool> {
+        if_ok!(write!(w, "<h4 id='method.{}' class='method'><code>",
+                      *item.name.get_ref()));
+        if_ok!(render_method(w, item, false));
+        if_ok!(write!(w, "</code></h4>\n"));
         match item.doc_value() {
             Some(s) => {
-                write!(w, "<div class='docblock'>{}</div>", Markdown(s));
-                true
+                if_ok!(write!(w, "<div class='docblock'>{}</div>", Markdown(s)));
+                Ok(true)
             }
-            None => false
+            None => Ok(false)
         }
     }
 
-    write!(w, "<div class='methods'>");
+    if_ok!(write!(w, "<div class='methods'>"));
     for meth in i.methods.iter() {
-        if docmeth(w, meth) {
+        if if_ok!(docmeth(w, meth)) {
             continue
         }
 
@@ -1431,7 +1453,7 @@ fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
             None => continue,
             Some(id) => id,
         };
-        local_data::get(cache_key, |cache| {
+        if_ok!(local_data::get(cache_key, |cache| {
             let cache = cache.unwrap().get();
             match cache.traits.find(&trait_id) {
                 Some(t) => {
@@ -1440,9 +1462,9 @@ fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
                         Some(method) => {
                             match method.item().doc_value() {
                                 Some(s) => {
-                                    write!(w,
-                                           "<div class='docblock'>{}</div>",
-                                           Markdown(s));
+                                    if_ok!(write!(w,
+                                                  "<div class='docblock'>{}</div>",
+                                                  Markdown(s)));
                                 }
                                 None => {}
                             }
@@ -1452,7 +1474,8 @@ fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
                 }
                 None => {}
             }
-        })
+            Ok(())
+        }))
     }
 
     // If we've implemented a trait, then also emit documentation for all
@@ -1460,7 +1483,7 @@ fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
     match trait_id {
         None => {}
         Some(id) => {
-            local_data::get(cache_key, |cache| {
+            if_ok!(local_data::get(cache_key, |cache| {
                 let cache = cache.unwrap().get();
                 match cache.traits.find(&id) {
                     Some(t) => {
@@ -1471,50 +1494,56 @@ fn render_impl(w: &mut Writer, i: &clean::Impl, dox: &Option<~str>) {
                                 None => {}
                             }
 
-                            docmeth(w, method.item());
+                            if_ok!(docmeth(w, method.item()));
                         }
                     }
                     None => {}
                 }
-            })
+                Ok(())
+            }))
         }
     }
-    write!(w, "</div>");
+    if_ok!(write!(w, "</div>"));
+    Ok(())
 }
 
-fn item_typedef(w: &mut Writer, it: &clean::Item, t: &clean::Typedef) {
-    write!(w, "<pre class='typedef'>type {}{} = {};</pre>",
-           it.name.get_ref().as_slice(),
-           t.generics,
-           t.type_);
+fn item_typedef(w: &mut Writer, it: &clean::Item,
+                t: &clean::Typedef) -> fmt::Result {
+    if_ok!(write!(w, "<pre class='typedef'>type {}{} = {};</pre>",
+                  it.name.get_ref().as_slice(),
+                  t.generics,
+                  t.type_));
 
-    document(w, it);
+    document(w, it)
 }
 
 impl<'a> fmt::Show for Sidebar<'a> {
-    fn fmt(s: &Sidebar<'a>, fmt: &mut fmt::Formatter) {
+    fn fmt(s: &Sidebar<'a>, fmt: &mut fmt::Formatter) -> fmt::Result {
         let cx = s.cx;
         let it = s.item;
-        write!(fmt.buf, "<p class='location'>");
+        if_ok!(write!(fmt.buf, "<p class='location'>"));
         let len = cx.current.len() - if it.is_mod() {1} else {0};
         for (i, name) in cx.current.iter().take(len).enumerate() {
-            if i > 0 { write!(fmt.buf, "&\\#8203;::") }
-            write!(fmt.buf, "<a href='{}index.html'>{}</a>",
-                   cx.root_path.slice_to((cx.current.len() - i - 1) * 3), *name);
+            if i > 0 {
+                if_ok!(write!(fmt.buf, "&\\#8203;::"));
+            }
+            if_ok!(write!(fmt.buf, "<a href='{}index.html'>{}</a>",
+                          cx.root_path.slice_to((cx.current.len() - i - 1) * 3),
+                          *name));
         }
-        write!(fmt.buf, "</p>");
+        if_ok!(write!(fmt.buf, "</p>"));
 
         fn block(w: &mut Writer, short: &str, longty: &str,
-                 cur: &clean::Item, cx: &Context) {
+                 cur: &clean::Item, cx: &Context) -> fmt::Result {
             let items = match cx.sidebar.find_equiv(&short) {
                 Some(items) => items.as_slice(),
-                None => return
+                None => return Ok(())
             };
-            write!(w, "<div class='block {}'><h2>{}</h2>", short, longty);
+            if_ok!(write!(w, "<div class='block {}'><h2>{}</h2>", short, longty));
             for item in items.iter() {
                 let class = if cur.name.get_ref() == item &&
                                short == shortty(cur) { "current" } else { "" };
-                write!(w, "<a class='{ty} {class}' href='{curty, select,
+                if_ok!(write!(w, "<a class='{ty} {class}' href='{curty, select,
                                 mod{../}
                                 other{}
                            }{tysel, select,
@@ -1525,16 +1554,18 @@ impl<'a> fmt::Show for Sidebar<'a> {
                        tysel = short,
                        class = class,
                        curty = shortty(cur),
-                       name = item.as_slice());
+                       name = item.as_slice()));
             }
-            write!(w, "</div>");
+            if_ok!(write!(w, "</div>"));
+            Ok(())
         }
 
-        block(fmt.buf, "mod", "Modules", it, cx);
-        block(fmt.buf, "struct", "Structs", it, cx);
-        block(fmt.buf, "enum", "Enums", it, cx);
-        block(fmt.buf, "trait", "Traits", it, cx);
-        block(fmt.buf, "fn", "Functions", it, cx);
+        if_ok!(block(fmt.buf, "mod", "Modules", it, cx));
+        if_ok!(block(fmt.buf, "struct", "Structs", it, cx));
+        if_ok!(block(fmt.buf, "enum", "Enums", it, cx));
+        if_ok!(block(fmt.buf, "trait", "Traits", it, cx));
+        if_ok!(block(fmt.buf, "fn", "Functions", it, cx));
+        Ok(())
     }
 }
 
@@ -1557,7 +1588,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<~str, ~[~str]> {
 }
 
 impl<'a> fmt::Show for Source<'a> {
-    fn fmt(s: &Source<'a>, fmt: &mut fmt::Formatter) {
+    fn fmt(s: &Source<'a>, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Source(s) = *s;
         let lines = s.lines().len();
         let mut cols = 0;
@@ -1566,13 +1597,14 @@ impl<'a> fmt::Show for Source<'a> {
             cols += 1;
             tmp /= 10;
         }
-        write!(fmt.buf, "<pre class='line-numbers'>");
+        if_ok!(write!(fmt.buf, "<pre class='line-numbers'>"));
         for i in range(1, lines + 1) {
-            write!(fmt.buf, "<span id='{0:u}'>{0:1$u}</span>\n", i, cols);
+            if_ok!(write!(fmt.buf, "<span id='{0:u}'>{0:1$u}</span>\n", i, cols));
         }
-        write!(fmt.buf, "</pre>");
-        write!(fmt.buf, "<pre class='rust'>");
-        write!(fmt.buf, "{}", Escape(s.as_slice()));
-        write!(fmt.buf, "</pre>");
+        if_ok!(write!(fmt.buf, "</pre>"));
+        if_ok!(write!(fmt.buf, "<pre class='rust'>"));
+        if_ok!(write!(fmt.buf, "{}", Escape(s.as_slice())));
+        if_ok!(write!(fmt.buf, "</pre>"));
+        Ok(())
     }
 }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -127,8 +127,8 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>) {
     let exe = outdir.path().join("rust_out");
     let out = run::process_output(exe.as_str().unwrap(), []);
     match out {
-        None => fail!("couldn't run the test"),
-        Some(out) => {
+        Err(e) => fail!("couldn't run the test: {}", e),
+        Ok(out) => {
             if !out.status.success() {
                 fail!("test executable failed:\n{}",
                       str::from_utf8(out.error));

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -140,9 +140,9 @@ impl FsRequest {
             let mut paths = ~[];
             let path = CString::new(path.with_ref(|p| p), false);
             let parent = Path::new(path);
-            c_str::from_c_multistring(req.get_ptr() as *libc::c_char,
-                                      Some(req.get_result() as uint),
-                                      |rel| {
+            let _ = c_str::from_c_multistring(req.get_ptr() as *libc::c_char,
+                                              Some(req.get_result() as uint),
+                                              |rel| {
                 let p = rel.as_bytes();
                 paths.push(parent.join(p.slice_to(rel.len())));
             });
@@ -378,7 +378,8 @@ impl Drop for FileWatcher {
             rtio::CloseAsynchronously => {
                 unsafe {
                     let req = uvll::malloc_req(uvll::UV_FS);
-                    uvll::uv_fs_close(self.loop_.handle, req, self.fd, close_cb);
+                    assert_eq!(uvll::uv_fs_close(self.loop_.handle, req,
+                                                 self.fd, close_cb), 0);
                 }
 
                 extern fn close_cb(req: *uvll::uv_fs_t) {

--- a/src/librustuv/homing.rs
+++ b/src/librustuv/homing.rs
@@ -176,7 +176,7 @@ mod test {
         });
 
         let task = pool.task(TaskOpts::new(), proc() {
-            port.recv();
+            drop(port.recv());
         });
         pool.spawn_sched().send(sched::TaskFromFriend(task));
 
@@ -197,7 +197,7 @@ mod test {
             let listener = UdpWatcher::bind(local_loop(), addr2);
             chan.send((listener.unwrap(), addr1));
             let mut listener = UdpWatcher::bind(local_loop(), addr1).unwrap();
-            listener.sendto([1, 2, 3, 4], addr2);
+            listener.sendto([1, 2, 3, 4], addr2).unwrap();
         });
 
         let task = pool.task(TaskOpts::new(), proc() {

--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -52,7 +52,7 @@ impl IdleWatcher {
                 let data = uvll::get_data_for_uv_handle(handle);
                 let f: ~proc() = cast::transmute(data);
                 (*f)();
-                uvll::uv_idle_stop(handle);
+                assert_eq!(uvll::uv_idle_stop(handle), 0);
                 uvll::uv_close(handle, close_cb);
             }
         }
@@ -122,7 +122,7 @@ mod test {
                     }
                 }
             };
-            task.wake().map(|t| t.reawaken(true));
+            let _ = task.wake().map(|t| t.reawaken(true));
         }
     }
 

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -40,6 +40,7 @@ via `close` and `delete` methods.
 #[crate_type = "dylib"];
 
 #[feature(macro_rules)];
+#[deny(unused_result, unused_must_use)];
 
 #[cfg(test)] extern mod green;
 
@@ -207,7 +208,7 @@ fn wait_until_woken_after(slot: *mut Option<BlockedTask>, f: ||) {
 
 fn wakeup(slot: &mut Option<BlockedTask>) {
     assert!(slot.is_some());
-    slot.take_unwrap().wake().map(|t| t.reawaken(true));
+    let _ = slot.take_unwrap().wake().map(|t| t.reawaken(true));
 }
 
 pub struct Request {
@@ -276,7 +277,7 @@ impl Loop {
     pub fn wrap(handle: *uvll::uv_loop_t) -> Loop { Loop { handle: handle } }
 
     pub fn run(&mut self) {
-        unsafe { uvll::uv_run(self.handle, uvll::RUN_DEFAULT) };
+        assert_eq!(unsafe { uvll::uv_run(self.handle, uvll::RUN_DEFAULT) }, 0);
     }
 
     pub fn close(&mut self) {

--- a/src/librustuv/macros.rs
+++ b/src/librustuv/macros.rs
@@ -34,11 +34,11 @@ pub fn dumb_println(args: &fmt::Arguments) {
     struct Stderr;
     impl io::Writer for Stderr {
         fn write(&mut self, data: &[u8]) -> io::IoResult<()> {
-            unsafe {
+            let _ = unsafe {
                 libc::write(libc::STDERR_FILENO,
                             data.as_ptr() as *libc::c_void,
-                            data.len() as libc::size_t);
-            }
+                            data.len() as libc::size_t)
+            };
             Ok(()) // just ignore the errors
         }
     }

--- a/src/librustuv/macros.rs
+++ b/src/librustuv/macros.rs
@@ -33,14 +33,15 @@ pub fn dumb_println(args: &fmt::Arguments) {
 
     struct Stderr;
     impl io::Writer for Stderr {
-        fn write(&mut self, data: &[u8]) {
+        fn write(&mut self, data: &[u8]) -> io::IoResult<()> {
             unsafe {
                 libc::write(libc::STDERR_FILENO,
                             data.as_ptr() as *libc::c_void,
                             data.len() as libc::size_t);
             }
+            Ok(()) // just ignore the errors
         }
     }
     let mut w = Stderr;
-    fmt::writeln(&mut w as &mut io::Writer, args);
+    let _ = fmt::writeln(&mut w as &mut io::Writer, args);
 }

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -953,11 +953,11 @@ mod test {
         spawn(proc() {
             let port2 = port.recv();
             let mut stream = TcpWatcher::connect(local_loop(), addr).unwrap();
-            stream.write([0, 1, 2, 3, 4, 5, 6, 7]);
-            stream.write([0, 1, 2, 3, 4, 5, 6, 7]);
+            stream.write([0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
+            stream.write([0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
             port2.recv();
-            stream.write([0, 1, 2, 3, 4, 5, 6, 7]);
-            stream.write([0, 1, 2, 3, 4, 5, 6, 7]);
+            stream.write([0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
+            stream.write([0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
             port2.recv();
         });
 
@@ -1008,7 +1008,7 @@ mod test {
         while stream.is_err() {
             stream = TcpWatcher::connect(local_loop(), addr);
         }
-        stream.unwrap().write([0, 1, 2, 3, 4, 5, 6, 7]);
+        stream.unwrap().write([0, 1, 2, 3, 4, 5, 6, 7]).unwrap();
     }
 
     #[should_fail] #[test]
@@ -1028,7 +1028,7 @@ mod test {
             let w = TcpListener::bind(local_loop(), addr).unwrap();
             let mut w = w.listen().unwrap();
             chan.send(());
-            w.accept();
+            drop(w.accept().unwrap());
         });
         port.recv();
         let _w = TcpWatcher::connect(local_loop(), addr).unwrap();

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -306,7 +306,7 @@ mod tests {
             let p = PipeListener::bind(local_loop(), &path2.to_c_str()).unwrap();
             let mut p = p.listen().unwrap();
             chan.send(());
-            p.accept();
+            drop(p.accept().unwrap());
         });
         port.recv();
         let _c = PipeWatcher::connect(local_loop(), &path.to_c_str()).unwrap();

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -67,7 +67,7 @@ extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {
     loop {
         match state.consumer.pop() {
             mpsc::Data(Task(task)) => {
-                task.wake().map(|t| t.reawaken(true));
+                let _ = task.wake().map(|t| t.reawaken(true));
             }
             mpsc::Data(Increment) => unsafe {
                 if state.refcnt == 0 {

--- a/src/librustuv/signal.rs
+++ b/src/librustuv/signal.rs
@@ -86,7 +86,7 @@ mod test {
                                          chan);
 
         spawn(proc() {
-            port.try_recv();
+            let _ = port.recv_opt();
         });
 
         // when we drop the SignalWatcher we're going to destroy the channel,

--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -138,11 +138,11 @@ extern fn timer_cb(handle: *uvll::uv_timer_t, status: c_int) {
 
     match timer.action.take_unwrap() {
         WakeTask(task) => {
-            task.wake().map(|t| t.reawaken(true));
+            let _ = task.wake().map(|t| t.reawaken(true));
         }
-        SendOnce(chan) => { chan.try_send(()); }
+        SendOnce(chan) => { let _ = chan.try_send(()); }
         SendMany(chan, id) => {
-            chan.try_send(());
+            let _ = chan.try_send(());
 
             // Note that the above operation could have performed some form of
             // scheduling. This means that the timer may have decided to insert
@@ -246,7 +246,7 @@ mod test {
         let timer_port = timer.period(1000);
 
         spawn(proc() {
-            timer_port.recv_opt();
+            let _ = timer_port.recv_opt();
         });
 
         // when we drop the TimerWatcher we're going to destroy the channel,
@@ -260,10 +260,10 @@ mod test {
         let timer_port = timer.period(1000);
 
         spawn(proc() {
-            timer_port.recv_opt();
+            let _ = timer_port.recv_opt();
         });
 
-        timer.oneshot(1);
+        drop(timer.oneshot(1));
     }
     #[test]
     fn reset_doesnt_switch_tasks2() {
@@ -272,7 +272,7 @@ mod test {
         let timer_port = timer.period(1000);
 
         spawn(proc() {
-            timer_port.recv_opt();
+            let _ = timer_port.recv_opt();
         });
 
         timer.sleep(1);
@@ -299,7 +299,7 @@ mod test {
     #[test]
     fn receiver_goes_away_oneshot() {
         let mut timer1 = TimerWatcher::new(local_loop());
-        timer1.oneshot(1);
+        drop(timer1.oneshot(1));
         let mut timer2 = TimerWatcher::new(local_loop());
         // while sleeping, the prevous timer should fire and not have its
         // callback do something terrible.
@@ -309,7 +309,7 @@ mod test {
     #[test]
     fn receiver_goes_away_period() {
         let mut timer1 = TimerWatcher::new(local_loop());
-        timer1.period(1);
+        drop(timer1.period(1));
         let mut timer2 = TimerWatcher::new(local_loop());
         // while sleeping, the prevous timer should fire and not have its
         // callback do something terrible.

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -71,7 +71,7 @@ impl Drop for UvEventLoop {
         // after the loop has been closed because during the closing of the loop
         // the handle is required to be used apparently.
         let handle = self.uvio.handle_pool.get_ref().handle();
-        self.uvio.handle_pool.take();
+        drop(self.uvio.handle_pool.take());
         self.uvio.loop_.close();
         unsafe { uvll::free_handle(handle) }
     }

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -1252,7 +1252,7 @@ mod test {
             spawn(proc() {
                 let _p = port;
             });
-            task::try(proc() {
+            let _ = task::try(proc() {
                 chan.send(1);
             });
         }

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -477,35 +477,26 @@ will look like `"\\{"`.
 
 */
 
-#[cfg(not(stage0))]
-use prelude::*;
-
 use cast;
 use char::Char;
+use container::Container;
 use io::MemWriter;
 use io;
-use str;
+use iter::{Iterator, range};
+use num::Signed;
+use option::{Option,Some,None};
 use repr;
+use result::{Ok, Err};
+use str::StrSlice;
+use str;
 use util;
+use vec::ImmutableVector;
 use vec;
 
 // NOTE this is just because the `prelude::*` import above includes
 // default::Default, so the reexport doesn't work.
 #[cfg(stage0)]
 pub use Default = fmt::Show; // export required for `format!()` etc.
-
-#[cfg(stage0)]
-use container::Container;
-#[cfg(stage0)]
-use iter::{Iterator, range};
-#[cfg(stage0)]
-use option::{Option,Some,None};
-#[cfg(stage0)]
-use vec::ImmutableVector;
-#[cfg(stage0)]
-use str::StrSlice;
-#[cfg(stage0)]
-use num::Signed;
 
 pub mod parse;
 pub mod rt;
@@ -628,7 +619,7 @@ macro_rules! uniform_fn_call_workaround {
     ($( $name: ident, $trait_: ident; )*) => {
         $(
             #[doc(hidden)]
-            pub fn $name<T: $trait_>(x: &T, fmt: &mut Formatter) {
+            pub fn $name<T: $trait_>(x: &T, fmt: &mut Formatter) -> Result {
                 $trait_::fmt(x, fmt)
             }
             )*

--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -27,13 +27,14 @@
 #[allow(missing_doc)];
 
 use container::Container;
+use io::{Writer, IoResult};
 use iter::Iterator;
+use num::ToStrRadix;
 use option::{Some, None};
-use io::Writer;
+use result::Ok;
 use str::OwnedStr;
 use to_bytes::IterBytes;
 use vec::ImmutableVector;
-use num::ToStrRadix;
 
 // Alias `SipState` to `State`.
 pub use State = hash::SipState;
@@ -164,7 +165,7 @@ macro_rules! compress (
 impl Writer for SipState {
     // Methods for io::writer
     #[inline]
-    fn write(&mut self, msg: &[u8]) {
+    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
         let length = msg.len();
         self.length += length;
 
@@ -180,7 +181,7 @@ impl Writer for SipState {
                     t += 1;
                 }
                 self.ntail += length;
-                return;
+                return Ok(())
             }
 
             let mut t = 0;
@@ -222,17 +223,14 @@ impl Writer for SipState {
             t += 1
         }
         self.ntail = left;
-    }
-
-    fn flush(&mut self) {
-        // No-op
+        Ok(())
     }
 }
 
 impl Streaming for SipState {
     #[inline]
     fn input(&mut self, buf: &[u8]) {
-        self.write(buf);
+        self.write(buf).unwrap();
     }
 
     #[inline]

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -31,14 +31,13 @@ use vec;
 /// ```rust
 /// use std::io::{BufferedReader, File};
 ///
-/// # let _g = ::std::io::ignore_io_error();
 /// let file = File::open(&Path::new("message.txt"));
 /// let mut reader = BufferedReader::new(file);
 ///
 /// let mut buf = [0, ..100];
 /// match reader.read(buf) {
-///     Some(nread) => println!("Read {} bytes", nread),
-///     None => println!("At the end of the file!")
+///     Ok(nread) => println!("Read {} bytes", nread),
+///     Err(e) => println!("error reading: {}", e)
 /// }
 /// ```
 pub struct BufferedReader<R> {
@@ -121,9 +120,9 @@ impl<R: Reader> Reader for BufferedReader<R> {
 /// # Example
 ///
 /// ```rust
+/// # #[allow(unused_must_use)];
 /// use std::io::{BufferedWriter, File};
 ///
-/// # let _g = ::std::io::ignore_io_error();
 /// let file = File::open(&Path::new("message.txt"));
 /// let mut writer = BufferedWriter::new(file);
 ///
@@ -268,9 +267,9 @@ impl<W: Reader> Reader for InternalBufferedWriter<W> {
 /// # Example
 ///
 /// ```rust
+/// # #[allow(unused_must_use)];
 /// use std::io::{BufferedStream, File};
 ///
-/// # let _g = ::std::io::ignore_io_error();
 /// let file = File::open(&Path::new("message.txt"));
 /// let mut stream = BufferedStream::new(file);
 ///
@@ -279,8 +278,8 @@ impl<W: Reader> Reader for InternalBufferedWriter<W> {
 ///
 /// let mut buf = [0, ..100];
 /// match stream.read(buf) {
-///     Some(nread) => println!("Read {} bytes", nread),
-///     None => println!("At the end of the stream!")
+///     Ok(nread) => println!("Read {} bytes", nread),
+///     Err(e) => println!("error reading: {}", e)
 /// }
 /// ```
 pub struct BufferedStream<S> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -88,7 +88,7 @@ impl<R: Reader> BufferedReader<R> {
 
 impl<R: Reader> Buffer for BufferedReader<R> {
     fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> {
-        while self.pos == self.cap {
+        if self.pos == self.cap {
             self.cap = if_ok!(self.inner.read(self.buf));
             self.pos = 0;
         }
@@ -360,13 +360,13 @@ mod test {
     pub struct NullStream;
 
     impl Reader for NullStream {
-        fn read(&mut self, _: &mut [u8]) -> Option<uint> {
-            None
+        fn read(&mut self, _: &mut [u8]) -> io::IoResult<uint> {
+            Err(io::standard_error(io::EndOfFile))
         }
     }
 
     impl Writer for NullStream {
-        fn write(&mut self, _: &[u8]) { }
+        fn write(&mut self, _: &[u8]) -> io::IoResult<()> { Ok(()) }
     }
 
     /// A dummy reader intended at testing short-reads propagation.
@@ -375,8 +375,11 @@ mod test {
     }
 
     impl Reader for ShortReader {
-        fn read(&mut self, _: &mut [u8]) -> Option<uint> {
-            self.lengths.shift()
+        fn read(&mut self, _: &mut [u8]) -> io::IoResult<uint> {
+            match self.lengths.shift() {
+                Some(i) => Ok(i),
+                None => Err(io::standard_error(io::EndOfFile))
+            }
         }
     }
 
@@ -387,24 +390,24 @@ mod test {
 
         let mut buf = [0, 0, 0];
         let nread = reader.read(buf);
-        assert_eq!(Some(2), nread);
+        assert_eq!(Ok(2), nread);
         assert_eq!([0, 1, 0], buf);
 
         let mut buf = [0];
         let nread = reader.read(buf);
-        assert_eq!(Some(1), nread);
+        assert_eq!(Ok(1), nread);
         assert_eq!([2], buf);
 
         let mut buf = [0, 0, 0];
         let nread = reader.read(buf);
-        assert_eq!(Some(1), nread);
+        assert_eq!(Ok(1), nread);
         assert_eq!([3, 0, 0], buf);
 
         let nread = reader.read(buf);
-        assert_eq!(Some(1), nread);
+        assert_eq!(Ok(1), nread);
         assert_eq!([4, 0, 0], buf);
 
-        assert_eq!(None, reader.read(buf));
+        assert!(reader.read(buf).is_err());
     }
 
     #[test]
@@ -412,35 +415,35 @@ mod test {
         let inner = MemWriter::new();
         let mut writer = BufferedWriter::with_capacity(2, inner);
 
-        writer.write([0, 1]);
+        writer.write([0, 1]).unwrap();
         assert_eq!([], writer.get_ref().get_ref());
 
-        writer.write([2]);
+        writer.write([2]).unwrap();
         assert_eq!([0, 1], writer.get_ref().get_ref());
 
-        writer.write([3]);
+        writer.write([3]).unwrap();
         assert_eq!([0, 1], writer.get_ref().get_ref());
 
-        writer.flush();
+        writer.flush().unwrap();
         assert_eq!([0, 1, 2, 3], writer.get_ref().get_ref());
 
-        writer.write([4]);
-        writer.write([5]);
+        writer.write([4]).unwrap();
+        writer.write([5]).unwrap();
         assert_eq!([0, 1, 2, 3], writer.get_ref().get_ref());
 
-        writer.write([6]);
+        writer.write([6]).unwrap();
         assert_eq!([0, 1, 2, 3, 4, 5],
                    writer.get_ref().get_ref());
 
-        writer.write([7, 8]);
+        writer.write([7, 8]).unwrap();
         assert_eq!([0, 1, 2, 3, 4, 5, 6],
                    writer.get_ref().get_ref());
 
-        writer.write([9, 10, 11]);
+        writer.write([9, 10, 11]).unwrap();
         assert_eq!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
                    writer.get_ref().get_ref());
 
-        writer.flush();
+        writer.flush().unwrap();
         assert_eq!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
                    writer.get_ref().get_ref());
     }
@@ -448,7 +451,7 @@ mod test {
     #[test]
     fn test_buffered_writer_inner_flushes() {
         let mut w = BufferedWriter::with_capacity(3, MemWriter::new());
-        w.write([0, 1]);
+        w.write([0, 1]).unwrap();
         assert_eq!([], w.get_ref().get_ref());
         let w = w.unwrap();
         assert_eq!([0, 1], w.get_ref());
@@ -461,47 +464,49 @@ mod test {
         struct S;
 
         impl io::Writer for S {
-            fn write(&mut self, _: &[u8]) {}
+            fn write(&mut self, _: &[u8]) -> io::IoResult<()> { Ok(()) }
         }
 
         impl io::Reader for S {
-            fn read(&mut self, _: &mut [u8]) -> Option<uint> { None }
+            fn read(&mut self, _: &mut [u8]) -> io::IoResult<uint> {
+                Err(io::standard_error(io::EndOfFile))
+            }
         }
 
         let mut stream = BufferedStream::new(S);
         let mut buf = [];
-        stream.read(buf);
-        stream.write(buf);
-        stream.flush();
+        assert!(stream.read(buf).is_err());
+        stream.write(buf).unwrap();
+        stream.flush().unwrap();
     }
 
     #[test]
     fn test_read_until() {
         let inner = MemReader::new(~[0, 1, 2, 1, 0]);
         let mut reader = BufferedReader::with_capacity(2, inner);
-        assert_eq!(reader.read_until(0), Some(~[0]));
-        assert_eq!(reader.read_until(2), Some(~[1, 2]));
-        assert_eq!(reader.read_until(1), Some(~[1]));
-        assert_eq!(reader.read_until(8), Some(~[0]));
-        assert_eq!(reader.read_until(9), None);
+        assert_eq!(reader.read_until(0), Ok(~[0]));
+        assert_eq!(reader.read_until(2), Ok(~[1, 2]));
+        assert_eq!(reader.read_until(1), Ok(~[1]));
+        assert_eq!(reader.read_until(8), Ok(~[0]));
+        assert!(reader.read_until(9).is_err());
     }
 
     #[test]
     fn test_line_buffer() {
         let mut writer = LineBufferedWriter::new(MemWriter::new());
-        writer.write([0]);
+        writer.write([0]).unwrap();
         assert_eq!(writer.get_ref().get_ref(), []);
-        writer.write([1]);
+        writer.write([1]).unwrap();
         assert_eq!(writer.get_ref().get_ref(), []);
-        writer.flush();
+        writer.flush().unwrap();
         assert_eq!(writer.get_ref().get_ref(), [0, 1]);
-        writer.write([0, '\n' as u8, 1, '\n' as u8, 2]);
+        writer.write([0, '\n' as u8, 1, '\n' as u8, 2]).unwrap();
         assert_eq!(writer.get_ref().get_ref(),
             [0, 1, 0, '\n' as u8, 1, '\n' as u8]);
-        writer.flush();
+        writer.flush().unwrap();
         assert_eq!(writer.get_ref().get_ref(),
             [0, 1, 0, '\n' as u8, 1, '\n' as u8, 2]);
-        writer.write([3, '\n' as u8]);
+        writer.write([3, '\n' as u8]).unwrap();
         assert_eq!(writer.get_ref().get_ref(),
             [0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
     }
@@ -510,10 +515,10 @@ mod test {
     fn test_read_line() {
         let in_buf = MemReader::new(bytes!("a\nb\nc").to_owned());
         let mut reader = BufferedReader::with_capacity(2, in_buf);
-        assert_eq!(reader.read_line(), Some(~"a\n"));
-        assert_eq!(reader.read_line(), Some(~"b\n"));
-        assert_eq!(reader.read_line(), Some(~"c"));
-        assert_eq!(reader.read_line(), None);
+        assert_eq!(reader.read_line(), Ok(~"a\n"));
+        assert_eq!(reader.read_line(), Ok(~"b\n"));
+        assert_eq!(reader.read_line(), Ok(~"c"));
+        assert!(reader.read_line().is_err());
     }
 
     #[test]
@@ -532,20 +537,20 @@ mod test {
         let inner = ShortReader{lengths: ~[0, 1, 2, 0, 1, 0]};
         let mut reader = BufferedReader::new(inner);
         let mut buf = [0, 0];
-        assert_eq!(reader.read(buf), Some(0));
-        assert_eq!(reader.read(buf), Some(1));
-        assert_eq!(reader.read(buf), Some(2));
-        assert_eq!(reader.read(buf), Some(0));
-        assert_eq!(reader.read(buf), Some(1));
-        assert_eq!(reader.read(buf), Some(0));
-        assert_eq!(reader.read(buf), None);
+        assert_eq!(reader.read(buf), Ok(0));
+        assert_eq!(reader.read(buf), Ok(1));
+        assert_eq!(reader.read(buf), Ok(2));
+        assert_eq!(reader.read(buf), Ok(0));
+        assert_eq!(reader.read(buf), Ok(1));
+        assert_eq!(reader.read(buf), Ok(0));
+        assert!(reader.read(buf).is_err());
     }
 
     #[test]
     fn read_char_buffered() {
         let buf = [195u8, 159u8];
         let mut reader = BufferedReader::with_capacity(1, BufReader::new(buf));
-        assert_eq!(reader.read_char(), Some('ß'));
+        assert_eq!(reader.read_char(), Ok('ß'));
     }
 
     #[bench]

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -14,7 +14,7 @@ use comm::{Port, Chan};
 use cmp;
 use io;
 use option::{None, Option, Some};
-use super::{Reader, Writer};
+use super::{Reader, Writer, IoResult};
 use vec::{bytes, CloneableVector, MutableVector, ImmutableVector};
 
 /// Allows reading from a port.
@@ -49,7 +49,7 @@ impl PortReader {
 }
 
 impl Reader for PortReader {
-    fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         let mut num_read = 0;
         loop {
             match self.buf {
@@ -71,10 +71,9 @@ impl Reader for PortReader {
             self.closed = self.buf.is_none();
         }
         if self.closed && num_read == 0 {
-            io::io_error::cond.raise(io::standard_error(io::EndOfFile));
-            None
+            Err(io::standard_error(io::EndOfFile))
         } else {
-            Some(num_read)
+            Ok(num_read)
         }
     }
 }
@@ -98,13 +97,15 @@ impl ChanWriter {
 }
 
 impl Writer for ChanWriter {
-    fn write(&mut self, buf: &[u8]) {
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         if !self.chan.try_send(buf.to_owned()) {
-            io::io_error::cond.raise(io::IoError {
+            Err(io::IoError {
                 kind: io::BrokenPipe,
                 desc: "Pipe closed",
                 detail: None
-            });
+            })
+        } else {
+            Ok(())
         }
     }
 }

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -46,7 +46,7 @@ impl<'r, R: Reader> Bytes<'r, R> {
 impl<'r, R: Reader> Iterator<u8> for Bytes<'r, R> {
     #[inline]
     fn next(&mut self) -> Option<u8> {
-        self.reader.read_byte()
+        self.reader.read_byte().ok()
     }
 }
 

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -125,23 +125,22 @@ pub fn u64_from_be_bytes(data: &[u8],
 
 #[cfg(test)]
 mod test {
-    use unstable::finally::Finally;
     use prelude::*;
+    use io;
     use io::{MemReader, MemWriter};
-    use io::{io_error, placeholder_error};
 
     struct InitialZeroByteReader {
         count: int,
     }
 
     impl Reader for InitialZeroByteReader {
-        fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
+        fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
             if self.count == 0 {
                 self.count = 1;
-                Some(0)
+                Ok(0)
             } else {
                 buf[0] = 10;
-                Some(1)
+                Ok(1)
             }
         }
     }
@@ -149,17 +148,16 @@ mod test {
     struct EofReader;
 
     impl Reader for EofReader {
-        fn read(&mut self, _: &mut [u8]) -> Option<uint> {
-            None
+        fn read(&mut self, _: &mut [u8]) -> io::IoResult<uint> {
+            Err(io::standard_error(io::EndOfFile))
         }
     }
 
     struct ErroringReader;
 
     impl Reader for ErroringReader {
-        fn read(&mut self, _: &mut [u8]) -> Option<uint> {
-            io_error::cond.raise(placeholder_error());
-            None
+        fn read(&mut self, _: &mut [u8]) -> io::IoResult<uint> {
+            Err(io::standard_error(io::InvalidInput))
         }
     }
 
@@ -168,16 +166,16 @@ mod test {
     }
 
     impl Reader for PartialReader {
-        fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
+        fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
             if self.count == 0 {
                 self.count = 1;
                 buf[0] = 10;
                 buf[1] = 11;
-                Some(2)
+                Ok(2)
             } else {
                 buf[0] = 12;
                 buf[1] = 13;
-                Some(2)
+                Ok(2)
             }
         }
     }
@@ -187,14 +185,13 @@ mod test {
     }
 
     impl Reader for ErroringLaterReader {
-        fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
+        fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
             if self.count == 0 {
                 self.count = 1;
                 buf[0] = 10;
-                Some(1)
+                Ok(1)
             } else {
-                io_error::cond.raise(placeholder_error());
-                None
+                Err(io::standard_error(io::InvalidInput))
             }
         }
     }
@@ -204,19 +201,19 @@ mod test {
     }
 
     impl Reader for ThreeChunkReader {
-        fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
+        fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
             if self.count == 0 {
                 self.count = 1;
                 buf[0] = 10;
                 buf[1] = 11;
-                Some(2)
+                Ok(2)
             } else if self.count == 1 {
                 self.count = 2;
                 buf[0] = 12;
                 buf[1] = 13;
-                Some(2)
+                Ok(2)
             } else {
-                None
+                Err(io::standard_error(io::EndOfFile))
             }
         }
     }
@@ -225,7 +222,7 @@ mod test {
     fn read_byte() {
         let mut reader = MemReader::new(~[10]);
         let byte = reader.read_byte();
-        assert!(byte == Some(10));
+        assert!(byte == Ok(10));
     }
 
     #[test]
@@ -234,24 +231,21 @@ mod test {
             count: 0,
         };
         let byte = reader.read_byte();
-        assert!(byte == Some(10));
+        assert!(byte == Ok(10));
     }
 
     #[test]
     fn read_byte_eof() {
         let mut reader = EofReader;
         let byte = reader.read_byte();
-        assert!(byte == None);
+        assert!(byte.is_err());
     }
 
     #[test]
     fn read_byte_error() {
         let mut reader = ErroringReader;
-        io_error::cond.trap(|_| {
-        }).inside(|| {
-            let byte = reader.read_byte();
-            assert!(byte == None);
-        });
+        let byte = reader.read_byte();
+        assert!(byte.is_err());
     }
 
     #[test]
@@ -267,23 +261,21 @@ mod test {
     fn bytes_eof() {
         let mut reader = EofReader;
         let byte = reader.bytes().next();
-        assert!(byte == None);
+        assert!(byte.is_none());
     }
 
     #[test]
     fn bytes_error() {
         let mut reader = ErroringReader;
         let mut it = reader.bytes();
-        io_error::cond.trap(|_| ()).inside(|| {
-            let byte = it.next();
-            assert!(byte == None);
-        })
+        let byte = it.next();
+        assert!(byte.is_none());
     }
 
     #[test]
     fn read_bytes() {
         let mut reader = MemReader::new(~[10, 11, 12, 13]);
-        let bytes = reader.read_bytes(4);
+        let bytes = reader.read_bytes(4).unwrap();
         assert!(bytes == ~[10, 11, 12, 13]);
     }
 
@@ -292,24 +284,21 @@ mod test {
         let mut reader = PartialReader {
             count: 0,
         };
-        let bytes = reader.read_bytes(4);
+        let bytes = reader.read_bytes(4).unwrap();
         assert!(bytes == ~[10, 11, 12, 13]);
     }
 
     #[test]
     fn read_bytes_eof() {
         let mut reader = MemReader::new(~[10, 11]);
-        io_error::cond.trap(|_| {
-        }).inside(|| {
-            assert!(reader.read_bytes(4) == ~[10, 11]);
-        })
+        assert!(reader.read_bytes(4).is_err());
     }
 
     #[test]
     fn push_bytes() {
         let mut reader = MemReader::new(~[10, 11, 12, 13]);
         let mut buf = ~[8, 9];
-        reader.push_bytes(&mut buf, 4);
+        reader.push_bytes(&mut buf, 4).unwrap();
         assert!(buf == ~[8, 9, 10, 11, 12, 13]);
     }
 
@@ -319,7 +308,7 @@ mod test {
             count: 0,
         };
         let mut buf = ~[8, 9];
-        reader.push_bytes(&mut buf, 4);
+        reader.push_bytes(&mut buf, 4).unwrap();
         assert!(buf == ~[8, 9, 10, 11, 12, 13]);
     }
 
@@ -327,11 +316,8 @@ mod test {
     fn push_bytes_eof() {
         let mut reader = MemReader::new(~[10, 11]);
         let mut buf = ~[8, 9];
-        io_error::cond.trap(|_| {
-        }).inside(|| {
-            reader.push_bytes(&mut buf, 4);
-            assert!(buf == ~[8, 9, 10, 11]);
-        })
+        assert!(reader.push_bytes(&mut buf, 4).is_err());
+        assert!(buf == ~[8, 9, 10, 11]);
     }
 
     #[test]
@@ -340,30 +326,8 @@ mod test {
             count: 0,
         };
         let mut buf = ~[8, 9];
-        io_error::cond.trap(|_| { } ).inside(|| {
-            reader.push_bytes(&mut buf, 4);
-        });
+        assert!(reader.push_bytes(&mut buf, 4).is_err());
         assert!(buf == ~[8, 9, 10]);
-    }
-
-    #[test]
-    #[should_fail]
-    #[ignore] // borrow issues with RefCell
-    fn push_bytes_fail_reset_len() {
-        // push_bytes unsafely sets the vector length. This is testing that
-        // upon failure the length is reset correctly.
-        let _reader = ErroringLaterReader {
-            count: 0,
-        };
-        // FIXME (#7049): Figure out some other way to do this.
-        //let buf = RefCell::new(~[8, 9]);
-        (|| {
-            //reader.push_bytes(buf.borrow_mut().get(), 4);
-        }).finally(|| {
-            // NB: Using rtassert here to trigger abort on failure since this is a should_fail test
-            // FIXME: #7049 This fails because buf is still borrowed
-            //rtassert!(buf.borrow().get() == ~[8, 9, 10]);
-        })
     }
 
     #[test]
@@ -371,7 +335,7 @@ mod test {
         let mut reader = ThreeChunkReader {
             count: 0,
         };
-        let buf = reader.read_to_end();
+        let buf = reader.read_to_end().unwrap();
         assert!(buf == ~[10, 11, 12, 13]);
     }
 
@@ -381,7 +345,7 @@ mod test {
         let mut reader = ThreeChunkReader {
             count: 0,
         };
-        let buf = reader.read_to_end();
+        let buf = reader.read_to_end().unwrap();
         assert!(buf == ~[10, 11]);
     }
 
@@ -391,12 +355,12 @@ mod test {
 
         let mut writer = MemWriter::new();
         for i in uints.iter() {
-            writer.write_le_u64(*i);
+            writer.write_le_u64(*i).unwrap();
         }
 
         let mut reader = MemReader::new(writer.unwrap());
         for i in uints.iter() {
-            assert!(reader.read_le_u64() == *i);
+            assert!(reader.read_le_u64().unwrap() == *i);
         }
     }
 
@@ -407,12 +371,12 @@ mod test {
 
         let mut writer = MemWriter::new();
         for i in uints.iter() {
-            writer.write_be_u64(*i);
+            writer.write_be_u64(*i).unwrap();
         }
 
         let mut reader = MemReader::new(writer.unwrap());
         for i in uints.iter() {
-            assert!(reader.read_be_u64() == *i);
+            assert!(reader.read_be_u64().unwrap() == *i);
         }
     }
 
@@ -422,14 +386,14 @@ mod test {
 
         let mut writer = MemWriter::new();
         for i in ints.iter() {
-            writer.write_be_i32(*i);
+            writer.write_be_i32(*i).unwrap();
         }
 
         let mut reader = MemReader::new(writer.unwrap());
         for i in ints.iter() {
             // this tests that the sign extension is working
             // (comparing the values as i32 would not test this)
-            assert!(reader.read_be_int_n(4) == *i as i64);
+            assert!(reader.read_be_int_n(4).unwrap() == *i as i64);
         }
     }
 
@@ -439,10 +403,10 @@ mod test {
         let buf = ~[0x41, 0x02, 0x00, 0x00];
 
         let mut writer = MemWriter::new();
-        writer.write(buf);
+        writer.write(buf).unwrap();
 
         let mut reader = MemReader::new(writer.unwrap());
-        let f = reader.read_be_f32();
+        let f = reader.read_be_f32().unwrap();
         assert!(f == 8.1250);
     }
 
@@ -451,12 +415,12 @@ mod test {
         let f:f32 = 8.1250;
 
         let mut writer = MemWriter::new();
-        writer.write_be_f32(f);
-        writer.write_le_f32(f);
+        writer.write_be_f32(f).unwrap();
+        writer.write_le_f32(f).unwrap();
 
         let mut reader = MemReader::new(writer.unwrap());
-        assert!(reader.read_be_f32() == 8.1250);
-        assert!(reader.read_le_f32() == 8.1250);
+        assert!(reader.read_be_f32().unwrap() == 8.1250);
+        assert!(reader.read_le_f32().unwrap() == 8.1250);
     }
 
     #[test]

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -25,6 +25,7 @@ use vec::{Vector, ImmutableVector, MutableVector, OwnedCloneableVector};
 /// # Example
 ///
 /// ```rust
+/// # #[allow(unused_must_use)];
 /// use std::io::MemWriter;
 ///
 /// let mut w = MemWriter::new();
@@ -113,11 +114,12 @@ impl Seek for MemWriter {
 /// # Example
 ///
 /// ```rust
+/// # #[allow(unused_must_use)];
 /// use std::io::MemReader;
 ///
 /// let mut r = MemReader::new(~[0, 1, 2]);
 ///
-/// assert_eq!(r.read_to_end(), ~[0, 1, 2]);
+/// assert_eq!(r.read_to_end().unwrap(), ~[0, 1, 2]);
 /// ```
 pub struct MemReader {
     priv buf: ~[u8],
@@ -182,12 +184,13 @@ impl Buffer for MemReader {
 
 /// Writes to a fixed-size byte slice
 ///
-/// If a write will not fit in the buffer, it raises the `io_error`
-/// condition and does not write any data.
+/// If a write will not fit in the buffer, it returns an error and does not
+/// write any data.
 ///
 /// # Example
 ///
 /// ```rust
+/// # #[allow(unused_must_use)];
 /// use std::io::BufWriter;
 ///
 /// let mut buf = [0, ..4];
@@ -252,12 +255,13 @@ impl<'a> Seek for BufWriter<'a> {
 /// # Example
 ///
 /// ```rust
+/// # #[allow(unused_must_use)];
 /// use std::io::BufReader;
 ///
 /// let mut buf = [0, 1, 2, 3];
 /// let mut r = BufReader::new(buf);
 ///
-/// assert_eq!(r.read_to_end(), ~[0, 1, 2, 3]);
+/// assert_eq!(r.read_to_end().unwrap(), ~[0, 1, 2, 3]);
 /// ```
 pub struct BufReader<'a> {
     priv buf: &'a [u8],

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -46,6 +46,7 @@ Some examples of obvious things you might want to do
 * Write a line to a file
 
     ```rust
+    # #[allow(unused_must_use)];
     use std::io::File;
 
     let mut file = File::create(&Path::new("message.txt"));
@@ -83,6 +84,7 @@ Some examples of obvious things you might want to do
   `write_str` and `write_line` methods.
 
     ```rust,should_fail
+    # #[allow(unused_must_use)];
     use std::io::net::ip::SocketAddr;
     use std::io::net::tcp::TcpStream;
 
@@ -188,6 +190,7 @@ be an error.
 If you wanted to handle the error though you might write:
 
 ```rust
+# #[allow(unused_must_use)];
 use std::io::File;
 
 match File::create(&Path::new("diary.txt")).write(bytes!("Met a girl.\n")) {
@@ -360,7 +363,7 @@ pub struct IoError {
     detail: Option<~str>
 }
 
-impl fmt::Default for IoError {
+impl fmt::Show for IoError {
     fn fmt(err: &IoError, fmt: &mut fmt::Formatter) -> fmt::Result {
         if_ok!(fmt.buf.write_str(err.desc));
         match err.detail {
@@ -515,14 +518,13 @@ pub trait Reader {
     /// Returns any non-EOF error immediately. Previously read bytes are
     /// discarded when an error is returned.
     ///
-    /// When EOF is encountered, all bytes read up to that point are returned,
-    /// but if 0 bytes have been read then the EOF error is returned.
+    /// When EOF is encountered, all bytes read up to that point are returned.
     fn read_to_end(&mut self) -> IoResult<~[u8]> {
         let mut buf = vec::with_capacity(DEFAULT_BUF_SIZE);
         loop {
             match self.push_bytes(&mut buf, DEFAULT_BUF_SIZE) {
                 Ok(()) => {}
-                Err(ref e) if buf.len() > 0 && e.kind == EndOfFile => break,
+                Err(ref e) if e.kind == EndOfFile => break,
                 Err(e) => return Err(e)
             }
         }

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -70,10 +70,6 @@ pub struct Info {
 
 /// Easy name resolution. Given a hostname, returns the list of IP addresses for
 /// that hostname.
-///
-/// # Failure
-///
-/// On failure, this will raise on the `io_error` condition.
 pub fn get_host_addresses(host: &str) -> IoResult<~[IpAddr]> {
     lookup(Some(host), None, None).map(|a| a.map(|i| i.address.ip))
 }
@@ -87,10 +83,6 @@ pub fn get_host_addresses(host: &str) -> IoResult<~[IpAddr]> {
 /// * servname - an optional service name, listed in the system services
 /// * hint - see the hint structure, and "man -s 3 getaddrinfo", for how this
 ///          controls lookup
-///
-/// # Failure
-///
-/// On failure, this will raise on the `io_error` condition.
 ///
 /// FIXME: this is not public because the `Hint` structure is not ready for public
 ///      consumption just yet.

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -116,6 +116,6 @@ mod test {
     iotest!(fn issue_10663() {
         // Something should happen here, but this certainly shouldn't cause
         // everything to die. The actual outcome we don't care too much about.
-        get_host_addresses("example.com");
+        get_host_addresses("example.com").unwrap();
     } #[ignore])
 }

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -17,8 +17,9 @@ getaddrinfo()
 
 */
 
-use option::{Option, Some, None};
+use io::IoResult;
 use io::net::ip::{SocketAddr, IpAddr};
+use option::{Option, Some, None};
 use rt::rtio::{IoFactory, LocalIo};
 use vec::ImmutableVector;
 
@@ -73,7 +74,7 @@ pub struct Info {
 /// # Failure
 ///
 /// On failure, this will raise on the `io_error` condition.
-pub fn get_host_addresses(host: &str) -> Option<~[IpAddr]> {
+pub fn get_host_addresses(host: &str) -> IoResult<~[IpAddr]> {
     lookup(Some(host), None, None).map(|a| a.map(|i| i.address.ip))
 }
 
@@ -94,7 +95,7 @@ pub fn get_host_addresses(host: &str) -> Option<~[IpAddr]> {
 /// FIXME: this is not public because the `Hint` structure is not ready for public
 ///      consumption just yet.
 fn lookup(hostname: Option<&str>, servname: Option<&str>, hint: Option<Hint>)
-          -> Option<~[Info]> {
+          -> IoResult<~[Info]> {
     LocalIo::maybe_raise(|io| io.get_host_addresses(hostname, servname, hint))
 }
 

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -192,9 +192,10 @@ mod test {
 
         match stream.read(buf) {
             Ok(..) => fail!(),
-            Err(ref e) if cfg!(windows) => assert_eq!(e.kind, NotConnected),
-            Err(ref e) if cfg!(unix) => assert_eq!(e.kind, EndOfFile),
-            Err(..) => fail!(),
+            Err(ref e) => {
+                assert!(e.kind == NotConnected || e.kind == EndOfFile,
+                        "unknown kind: {:?}", e.kind);
+            }
         }
     })
 
@@ -217,9 +218,10 @@ mod test {
 
         match stream.read(buf) {
             Ok(..) => fail!(),
-            Err(ref e) if cfg!(windows) => assert_eq!(e.kind, NotConnected),
-            Err(ref e) if cfg!(unix) => assert_eq!(e.kind, EndOfFile),
-            Err(..) => fail!(),
+            Err(ref e) => {
+                assert!(e.kind == NotConnected || e.kind == EndOfFile,
+                        "unknown kind: {:?}", e.kind);
+            }
         }
     })
 

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -45,11 +45,6 @@ impl UnixStream {
     ///
     /// The returned stream will be closed when the object falls out of scope.
     ///
-    /// # Failure
-    ///
-    /// This function will raise on the `io_error` condition if the connection
-    /// could not be made.
-    ///
     /// # Example
     ///
     /// ```rust
@@ -85,11 +80,6 @@ impl UnixListener {
     /// specified socket. The server will be named by `path`.
     ///
     /// This listener will be closed when it falls out of scope.
-    ///
-    /// # Failure
-    ///
-    /// This function will raise on the `io_error` condition if the specified
-    /// path could not be bound.
     ///
     /// # Example
     ///

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -73,12 +73,12 @@ mod test {
         let (p, c) = Chan::new();
         spawn(proc() {
             let mut out = out;
-            out.write([10]);
+            out.write([10]).unwrap();
             p.recv(); // don't close the pipe until the other read has finished
         });
 
         let mut buf = [0, ..10];
-        input.read(buf);
+        input.read(buf).unwrap();
         c.send(());
     })
 }

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -32,16 +32,14 @@ impl PipeStream {
     ///
     /// # Example
     ///
-    ///     use std::libc;
-    ///     use std::io::pipe;
+    /// ```rust
+    /// # #[allow(unused_must_use)];
+    /// use std::libc;
+    /// use std::io::pipe::PipeStream;
     ///
-    ///     let mut pipe = PipeStream::open(libc::STDERR_FILENO);
-    ///     pipe.write(bytes!("Hello, stderr!"));
-    ///
-    /// # Failure
-    ///
-    /// If the pipe cannot be created, an error will be raised on the
-    /// `io_error` condition.
+    /// let mut pipe = PipeStream::open(libc::STDERR_FILENO);
+    /// pipe.write(bytes!("Hello, stderr!"));
+    /// ```
     pub fn open(fd: libc::c_int) -> IoResult<PipeStream> {
         LocalIo::maybe_raise(|io| {
             io.pipe_open(fd).map(|obj| PipeStream { obj: obj })

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -141,7 +141,7 @@ impl Process {
     /// Note that this is purely a wrapper around libuv's `uv_process_kill`
     /// function.
     ///
-    /// If the signal delivery fails, then the `io_error` condition is raised on
+    /// If the signal delivery fails, the corresponding error is returned.
     pub fn signal(&mut self, signal: int) -> IoResult<()> {
         self.handle.kill(signal)
     }

--- a/src/libstd/io/result.rs
+++ b/src/libstd/io/result.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Implementations of I/O traits for the Option type
+//! Implementations of I/O traits for the IoResult type
 //!
 //! I/O constructors return option types to allow errors to be handled.
-//! These implementations allow e.g. `Option<File>` to be used
-//! as a `Reader` without unwrapping the option first.
+//! These implementations allow e.g. `IoResult<File>` to be used
+//! as a `Reader` without unwrapping the result first.
 
 use clone::Clone;
 use result::{Ok, Err};

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -203,6 +203,7 @@ mod test {
     fn test_io_signal_invalid_signum() {
         use io;
         use super::User1;
+        use result::{Ok, Err};
         let mut s = Listener::new();
         let mut called = false;
         match s.register(User1) {

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -113,11 +113,10 @@ impl Listener {
     /// a signal, and a later call to `recv` will return the signal that was
     /// received while no task was waiting on it.
     ///
-    /// # Failure
+    /// # Error
     ///
     /// If this function fails to register a signal handler, then an error will
-    /// be raised on the `io_error` condition and the function will return
-    /// false.
+    /// be returned.
     pub fn register(&mut self, signum: Signum) -> io::IoResult<()> {
         if self.handles.contains_key(&signum) {
             return Ok(()); // self is already listening to signum, so succeed
@@ -206,13 +205,11 @@ mod test {
         use super::User1;
         let mut s = Listener::new();
         let mut called = false;
-        io::io_error::cond.trap(|_| {
-            called = true;
-        }).inside(|| {
-            if s.register(User1) {
+        match s.register(User1) {
+            Ok(..) => {
                 fail!("Unexpected successful registry of signum {:?}", User1);
             }
-        });
-        assert!(called);
+            Err(..) => {}
+        }
     }
 }

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -20,10 +20,11 @@ definitions for a number of signals.
 */
 
 use clone::Clone;
+use result::{Ok, Err};
 use comm::{Port, SharedChan};
 use container::{Map, MutableMap};
 use hashmap;
-use option::{Some, None};
+use io;
 use rt::rtio::{IoFactory, LocalIo, RtioSignal};
 
 #[repr(int)]
@@ -117,18 +118,18 @@ impl Listener {
     /// If this function fails to register a signal handler, then an error will
     /// be raised on the `io_error` condition and the function will return
     /// false.
-    pub fn register(&mut self, signum: Signum) -> bool {
+    pub fn register(&mut self, signum: Signum) -> io::IoResult<()> {
         if self.handles.contains_key(&signum) {
-            return true; // self is already listening to signum, so succeed
+            return Ok(()); // self is already listening to signum, so succeed
         }
         match LocalIo::maybe_raise(|io| {
             io.signal(signum, self.chan.clone())
         }) {
-            Some(handle) => {
+            Ok(handle) => {
                 self.handles.insert(signum, handle);
-                true
+                Ok(())
             }
-            None => false
+            Err(e) => Err(e)
         }
     }
 

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -160,7 +160,7 @@ mod test {
     #[test] #[cfg(unix, not(target_os="android"))] // FIXME(#10378)
     fn test_io_signal_smoketest() {
         let mut signal = Listener::new();
-        signal.register(Interrupt);
+        signal.register(Interrupt).unwrap();
         sigint();
         timer::sleep(10);
         match signal.port.recv() {
@@ -173,8 +173,8 @@ mod test {
     fn test_io_signal_two_signal_one_signum() {
         let mut s1 = Listener::new();
         let mut s2 = Listener::new();
-        s1.register(Interrupt);
-        s2.register(Interrupt);
+        s1.register(Interrupt).unwrap();
+        s2.register(Interrupt).unwrap();
         sigint();
         timer::sleep(10);
         match s1.port.recv() {
@@ -191,8 +191,8 @@ mod test {
     fn test_io_signal_unregister() {
         let mut s1 = Listener::new();
         let mut s2 = Listener::new();
-        s1.register(Interrupt);
-        s2.register(Interrupt);
+        s1.register(Interrupt).unwrap();
+        s2.register(Interrupt).unwrap();
         s2.unregister(Interrupt);
         sigint();
         timer::sleep(10);

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -28,7 +28,7 @@ out.write(bytes!("Hello, world!"));
 
 use container::Container;
 use fmt;
-use io::{Reader, Writer, io_error, IoError, OtherIoError,
+use io::{Reader, Writer, IoResult, IoError, OtherIoError,
          standard_error, EndOfFile, LineBufferedWriter};
 use libc;
 use option::{Option, Some, None};
@@ -114,7 +114,8 @@ fn reset_helper(w: ~Writer,
     match f(t.get(), w) {
         Some(mut w) => {
             drop(t);
-            w.flush();
+            // FIXME: is failing right here?
+            w.flush().unwrap();
             Some(w)
         }
         None => None
@@ -155,9 +156,9 @@ pub fn set_stderr(stderr: ~Writer) -> Option<~Writer> {
 //          // io1 aliases io2
 //      })
 //  })
-fn with_task_stdout(f: |&mut Writer|) {
+fn with_task_stdout(f: |&mut Writer| -> IoResult<()> ) {
     let task: Option<~Task> = Local::try_take();
-    match task {
+    let result = match task {
         Some(mut task) => {
             // Printing may run arbitrary code, so ensure that the task is in
             // TLS to allow all std services. Note that this means a print while
@@ -169,7 +170,7 @@ fn with_task_stdout(f: |&mut Writer|) {
             if my_stdout.is_none() {
                 my_stdout = Some(~LineBufferedWriter::new(stdout()) as ~Writer);
             }
-            f(*my_stdout.get_mut_ref());
+            let ret = f(*my_stdout.get_mut_ref());
 
             // Note that we need to be careful when putting the stdout handle
             // back into the task. If the handle was set to `Some` while
@@ -184,22 +185,29 @@ fn with_task_stdout(f: |&mut Writer|) {
             let prev = util::replace(&mut t.get().stdout, my_stdout);
             drop(t);
             drop(prev);
+            ret
         }
 
         None => {
             struct Stdout;
             impl Writer for Stdout {
-                fn write(&mut self, data: &[u8]) {
+                fn write(&mut self, data: &[u8]) -> IoResult<()> {
                     unsafe {
                         libc::write(libc::STDOUT_FILENO,
                                     data.as_ptr() as *libc::c_void,
                                     data.len() as libc::size_t);
                     }
+                    Ok(()) // just ignore the results
                 }
             }
             let mut io = Stdout;
-            f(&mut io as &mut Writer);
+            f(&mut io as &mut Writer)
         }
+    };
+
+    match result {
+        Ok(()) => {}
+        Err(e) => fail!("failed printing to stdout: {}", e),
     }
 }
 
@@ -226,8 +234,7 @@ pub fn print(s: &str) {
 /// `\n` character is printed to the console after the string.
 pub fn println(s: &str) {
     with_task_stdout(|io| {
-        io.write(s.as_bytes());
-        io.write(['\n' as u8]);
+        io.write(s.as_bytes()).and_then(|()| io.write(['\n' as u8]))
     })
 }
 
@@ -249,7 +256,7 @@ pub struct StdReader {
 }
 
 impl Reader for StdReader {
-    fn read(&mut self, buf: &mut [u8]) -> Option<uint> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         let ret = match self.inner {
             TTY(ref mut tty) => tty.read(buf),
             File(ref mut file) => file.read(buf).map(|i| i as uint),
@@ -260,15 +267,8 @@ impl Reader for StdReader {
             // return an actual EOF error, but apparently for stdin it's a
             // little different. Hence, here we convert a 0 length read to an
             // end-of-file indicator so the caller knows to stop reading.
-            Ok(0) => {
-                io_error::cond.raise(standard_error(EndOfFile));
-                None
-            }
-            Ok(amt) => Some(amt),
-            Err(e) => {
-                io_error::cond.raise(e);
-                None
-            }
+            Ok(0) => { Err(standard_error(EndOfFile)) }
+            ret @ Ok(..) | ret @ Err(..) => ret,
         }
     }
 }
@@ -289,24 +289,15 @@ impl StdWriter {
     ///
     /// This function will raise on the `io_error` condition if an error
     /// happens.
-    pub fn winsize(&mut self) -> Option<(int, int)> {
+    pub fn winsize(&mut self) -> IoResult<(int, int)> {
         match self.inner {
-            TTY(ref mut tty) => {
-                match tty.get_winsize() {
-                    Ok(p) => Some(p),
-                    Err(e) => {
-                        io_error::cond.raise(e);
-                        None
-                    }
-                }
-            }
+            TTY(ref mut tty) => tty.get_winsize(),
             File(..) => {
-                io_error::cond.raise(IoError {
+                Err(IoError {
                     kind: OtherIoError,
                     desc: "stream is not a tty",
                     detail: None,
-                });
-                None
+                })
             }
         }
     }
@@ -318,20 +309,15 @@ impl StdWriter {
     ///
     /// This function will raise on the `io_error` condition if an error
     /// happens.
-    pub fn set_raw(&mut self, raw: bool) {
+    pub fn set_raw(&mut self, raw: bool) -> IoResult<()> {
         match self.inner {
-            TTY(ref mut tty) => {
-                match tty.set_raw(raw) {
-                    Ok(()) => {},
-                    Err(e) => io_error::cond.raise(e),
-                }
-            }
+            TTY(ref mut tty) => tty.set_raw(raw),
             File(..) => {
-                io_error::cond.raise(IoError {
+                Err(IoError {
                     kind: OtherIoError,
                     desc: "stream is not a tty",
                     detail: None,
-                });
+                })
             }
         }
     }
@@ -346,14 +332,10 @@ impl StdWriter {
 }
 
 impl Writer for StdWriter {
-    fn write(&mut self, buf: &[u8]) {
-        let ret = match self.inner {
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        match self.inner {
             TTY(ref mut tty) => tty.write(buf),
             File(ref mut file) => file.write(buf),
-        };
-        match ret {
-            Ok(()) => {}
-            Err(e) => io_error::cond.raise(e)
         }
     }
 }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -18,6 +18,7 @@ about the stream or terminal that it is attached to.
 # Example
 
 ```rust
+# #[allow(unused_must_use)];
 use std::io;
 
 let mut out = io::stdout();
@@ -283,12 +284,12 @@ impl StdWriter {
     /// when the writer is attached to something like a terminal, this is used
     /// to fetch the dimensions of the terminal.
     ///
-    /// If successful, returns Some((width, height)).
+    /// If successful, returns `Ok((width, height))`.
     ///
-    /// # Failure
+    /// # Error
     ///
-    /// This function will raise on the `io_error` condition if an error
-    /// happens.
+    /// This function will return an error if the output stream is not actually
+    /// connected to a TTY instance, or if querying the TTY instance fails.
     pub fn winsize(&mut self) -> IoResult<(int, int)> {
         match self.inner {
             TTY(ref mut tty) => tty.get_winsize(),
@@ -305,10 +306,10 @@ impl StdWriter {
     /// Controls whether this output stream is a "raw stream" or simply a normal
     /// stream.
     ///
-    /// # Failure
+    /// # Error
     ///
-    /// This function will raise on the `io_error` condition if an error
-    /// happens.
+    /// This function will return an error if the output stream is not actually
+    /// connected to a TTY instance, or if querying the TTY instance fails.
     pub fn set_raw(&mut self, raw: bool) -> IoResult<()> {
         match self.inner {
             TTY(ref mut tty) => tty.set_raw(raw),

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -358,7 +358,7 @@ mod tests {
             set_stdout(~w as ~Writer);
             println!("hello!");
         });
-        assert_eq!(r.read_to_str(), ~"hello!\n");
+        assert_eq!(r.read_to_str().unwrap(), ~"hello!\n");
     })
 
     iotest!(fn capture_stderr() {
@@ -370,7 +370,7 @@ mod tests {
             set_stderr(~w as ~Writer);
             fail!("my special message");
         });
-        let s = r.read_to_str();
+        let s = r.read_to_str().unwrap();
         assert!(s.contains("my special message"));
     })
 }

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -39,8 +39,8 @@ loop {
 */
 
 use comm::Port;
-use option::Option;
 use rt::rtio::{IoFactory, LocalIo, RtioTimer};
+use io::IoResult;
 
 pub struct Timer {
     priv obj: ~RtioTimer
@@ -48,7 +48,8 @@ pub struct Timer {
 
 /// Sleep the current task for `msecs` milliseconds.
 pub fn sleep(msecs: u64) {
-    let mut timer = Timer::new().expect("timer::sleep: could not create a Timer");
+    let timer = Timer::new();
+    let mut timer = timer.ok().expect("timer::sleep: could not create a Timer");
 
     timer.sleep(msecs)
 }
@@ -57,7 +58,7 @@ impl Timer {
     /// Creates a new timer which can be used to put the current task to sleep
     /// for a number of milliseconds, or to possibly create channels which will
     /// get notified after an amount of time has passed.
-    pub fn new() -> Option<Timer> {
+    pub fn new() -> IoResult<Timer> {
         LocalIo::maybe_raise(|io| io.timer_init().map(|t| Timer { obj: t }))
     }
 

--- a/src/libstd/logging.rs
+++ b/src/libstd/logging.rs
@@ -102,6 +102,7 @@ use io::Writer;
 use ops::Drop;
 use option::{Some, None, Option};
 use prelude::drop;
+use result::{Ok, Err};
 use rt::local::Local;
 use rt::task::Task;
 use util;
@@ -131,13 +132,19 @@ struct DefaultLogger {
 impl Logger for DefaultLogger {
     // by default, just ignore the level
     fn log(&mut self, _level: u32, args: &fmt::Arguments) {
-        fmt::writeln(&mut self.handle, args);
+        match fmt::writeln(&mut self.handle, args) {
+            Err(e) => fail!("failed to log: {}", e),
+            Ok(()) => {}
+        }
     }
 }
 
 impl Drop for DefaultLogger {
     fn drop(&mut self) {
-        self.handle.flush();
+        match self.handle.flush() {
+            Err(e) => fail!("failed to flush a logger: {}", e),
+            Ok(()) => {}
+        }
     }
 }
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -197,3 +197,8 @@ macro_rules! local_data_key (
         pub static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
     )
 )
+
+#[macro_export]
+macro_rules! if_ok (
+    ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
+)

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -382,7 +382,7 @@ impl<T: Default> Option<T> {
 
 impl<T: fmt::Show> fmt::Show for Option<T> {
     #[inline]
-    fn fmt(s: &Option<T>, f: &mut fmt::Formatter) {
+    fn fmt(s: &Option<T>, f: &mut fmt::Formatter) -> fmt::Result {
         match *s {
             Some(ref t) => write!(f.buf, "Some({})", *t),
             None        => write!(f.buf, "None")

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1492,7 +1492,6 @@ mod tests {
         use result::{Ok, Err};
         use os::*;
         use libc::*;
-        use io;
         use io::fs;
 
         #[cfg(unix)]
@@ -1537,8 +1536,7 @@ mod tests {
             close(fd);
         }
 
-        let _guard = io::ignore_io_error();
-        fs::unlink(&path);
+        fs::unlink(&path).unwrap();
     }
 
     // More recursive_mkdir tests are in extra::tempfile

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1535,6 +1535,7 @@ mod tests {
             assert!(*chunk.data == 0xbe);
             close(fd);
         }
+        drop(chunk);
 
         fs::unlink(&path).unwrap();
     }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -929,7 +929,7 @@ pub enum MapError {
 }
 
 impl fmt::Show for MapError {
-    fn fmt(val: &MapError, out: &mut fmt::Formatter) {
+    fn fmt(val: &MapError, out: &mut fmt::Formatter) -> fmt::Result {
         let str = match *val {
             ErrFdNotAvail => "fd not available for reading or writing",
             ErrInvalidFd => "Invalid fd",
@@ -944,23 +944,19 @@ impl fmt::Show for MapError {
             ErrAlreadyExists => "File mapping for specified file already exists",
             ErrZeroLength => "Zero-length mapping not allowed",
             ErrUnknown(code) => {
-                write!(out.buf, "Unknown error = {}", code);
-                return
+                return write!(out.buf, "Unknown error = {}", code)
             },
             ErrVirtualAlloc(code) => {
-                write!(out.buf, "VirtualAlloc failure = {}", code);
-                return
+                return write!(out.buf, "VirtualAlloc failure = {}", code)
             },
             ErrCreateFileMappingW(code) => {
-                format!("CreateFileMappingW failure = {}", code);
-                return
+                return write!(out.buf, "CreateFileMappingW failure = {}", code)
             },
             ErrMapViewOfFile(code) => {
-                write!(out.buf, "MapViewOfFile failure = {}", code);
-                return
+                return write!(out.buf, "MapViewOfFile failure = {}", code)
             }
         };
-        write!(out.buf, "{}", str);
+        write!(out.buf, "{}", str)
     }
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -372,9 +372,9 @@ pub fn self_exe_name() -> Option<Path> {
     fn load_self() -> Option<~[u8]> {
         use std::io;
 
-        match io::result(|| io::fs::readlink(&Path::new("/proc/self/exe"))) {
-            Ok(Some(path)) => Some(path.as_vec().to_owned()),
-            Ok(None) | Err(..) => None
+        match io::fs::readlink(&Path::new("/proc/self/exe")) {
+            Ok(path) => Some(path.as_vec().to_owned()),
+            Err(..) => None
         }
     }
 

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -533,7 +533,7 @@ pub struct Display<'a, P> {
 }
 
 impl<'a, P: GenericPath> fmt::Show for Display<'a, P> {
-    fn fmt(d: &Display<P>, f: &mut fmt::Formatter) {
+    fn fmt(d: &Display<P>, f: &mut fmt::Formatter) -> fmt::Display {
         d.with_str(|s| f.pad(s))
     }
 }

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -533,7 +533,7 @@ pub struct Display<'a, P> {
 }
 
 impl<'a, P: GenericPath> fmt::Show for Display<'a, P> {
-    fn fmt(d: &Display<P>, f: &mut fmt::Formatter) -> fmt::Display {
+    fn fmt(d: &Display<P>, f: &mut fmt::Formatter) -> fmt::Result {
         d.with_str(|s| f.pad(s))
     }
 }

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -62,7 +62,7 @@ impl OSRng {
     pub fn new() -> OSRng {
         use path::Path;
         let reader = File::open(&Path::new("/dev/urandom"));
-        let reader = reader.expect("Error opening /dev/urandom");
+        let reader = reader.ok().expect("Error opening /dev/urandom");
         let reader_rng = ReaderRng::new(reader);
 
         OSRng { inner: reader_rng }

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -11,7 +11,7 @@
 //! A wrapper around any Reader to treat it as an RNG.
 
 use container::Container;
-use option::{Some, None};
+use result::{Ok, Err};
 use io::Reader;
 
 use rand::Rng;
@@ -49,26 +49,26 @@ impl<R: Reader> Rng for ReaderRng<R> {
         // platform just involves blitting the bytes into the memory
         // of the u32, similarly for BE on BE; avoiding byteswapping.
         if cfg!(target_endian="little") {
-            self.reader.read_le_u32()
+            self.reader.read_le_u32().unwrap()
         } else {
-            self.reader.read_be_u32()
+            self.reader.read_be_u32().unwrap()
         }
     }
     fn next_u64(&mut self) -> u64 {
         // see above for explanation.
         if cfg!(target_endian="little") {
-            self.reader.read_le_u64()
+            self.reader.read_le_u64().unwrap()
         } else {
-            self.reader.read_be_u64()
+            self.reader.read_be_u64().unwrap()
         }
     }
     fn fill_bytes(&mut self, v: &mut [u8]) {
         if v.len() == 0 { return }
         match self.reader.read(v) {
-            Some(n) if n == v.len() => return,
-            Some(n) => fail!("ReaderRng.fill_bytes could not fill buffer: \
-                              read {} out of {} bytes.", n, v.len()),
-            None => fail!("ReaderRng.fill_bytes reached eof.")
+            Ok(n) if n == v.len() => return,
+            Ok(n) => fail!("ReaderRng.fill_bytes could not fill buffer: \
+                            read {} out of {} bytes.", n, v.len()),
+            Err(e) => fail!("ReaderRng.fill_bytes error: {}", e)
         }
     }
 }

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -66,6 +66,8 @@ impl<V:TyVisitor + MovePtr> MovePtrAdaptor<V> {
     pub fn bump_past<T>(&mut self) {
         self.bump(mem::size_of::<T>());
     }
+
+    pub fn unwrap(self) -> V { self.inner }
 }
 
 /// Abstract type-directed pointer-movement using the MovePtr trait

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -208,7 +208,7 @@ impl<T, E> Result<T, E> {
 
 impl<T: fmt::Show, E: fmt::Show> fmt::Show for Result<T, E> {
     #[inline]
-    fn fmt(s: &Result<T, E>, f: &mut fmt::Formatter) {
+    fn fmt(s: &Result<T, E>, f: &mut fmt::Formatter) -> fmt::Result {
         match *s {
             Ok(ref t) => write!(f.buf, "Ok({})", *t),
             Err(ref e) => write!(f.buf, "Err({})", *e)

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -119,6 +119,7 @@ impl Task {
 
             // Run the task main function, then do some cleanup.
             f.finally(|| {
+                #[allow(unused_must_use)]
                 fn close_outputs() {
                     let mut task = Local::borrow(None::<Task>);
                     let logger = task.get().logger.take();
@@ -126,8 +127,8 @@ impl Task {
                     let stdout = task.get().stdout.take();
                     drop(task);
                     drop(logger); // loggers are responsible for flushing
-                    match stdout { Some(mut w) => w.flush(), None => {} }
-                    match stderr { Some(mut w) => w.flush(), None => {} }
+                    match stdout { Some(mut w) => { w.flush(); }, None => {} }
+                    match stderr { Some(mut w) => { w.flush(); }, None => {} }
                 }
 
                 // First, flush/destroy the user stdout/logger because these

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -464,9 +464,10 @@ fn begin_unwind_inner(msg: ~Any, file: &'static str, line: uint) -> ! {
             match task.stderr.take() {
                 Some(mut stderr) => {
                     Local::put(task);
-                    format_args!(|args| ::fmt::writeln(stderr, args),
-                                 "task '{}' failed at '{}', {}:{}",
-                                 n, msg_s, file, line);
+                    // FIXME: what to do when the task printing fails?
+                    let _err = format_args!(|args| ::fmt::writeln(stderr, args),
+                                            "task '{}' failed at '{}', {}:{}",
+                                            n, msg_s, file, line);
                     task = Local::take();
 
                     match util::replace(&mut task.stderr, Some(stderr)) {

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -11,10 +11,12 @@
 use container::Container;
 use fmt;
 use from_str::FromStr;
+use io::IoResult;
 use iter::Iterator;
 use libc;
 use option::{Some, None, Option};
 use os;
+use result::Ok;
 use str::StrSlice;
 use unstable::running_on_valgrind;
 use vec::ImmutableVector;
@@ -73,16 +75,17 @@ pub fn dumb_println(args: &fmt::Arguments) {
 
     struct Stderr;
     impl io::Writer for Stderr {
-        fn write(&mut self, data: &[u8]) {
+        fn write(&mut self, data: &[u8]) -> IoResult<()> {
             unsafe {
                 libc::write(libc::STDERR_FILENO,
                             data.as_ptr() as *libc::c_void,
                             data.len() as libc::size_t);
             }
+            Ok(()) // yes, we're lying
         }
     }
     let mut w = Stderr;
-    fmt::writeln(&mut w as &mut io::Writer, args);
+    let _ = fmt::writeln(&mut w as &mut io::Writer, args);
 }
 
 pub fn abort(msg: &str) -> ! {

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -11,6 +11,7 @@
 //! Utilities for spawning and managing processes
 
 #[allow(missing_doc)];
+#[deny(unused_must_use)];
 
 use comm::SharedChan;
 use io::Reader;
@@ -258,10 +259,10 @@ impl Process {
      * On Posix OSs SIGTERM will be sent to the process. On Win32
      * TerminateProcess(..) will be called.
      */
-    pub fn destroy(&mut self) {
-        // This should never fail because we own the process
-        self.inner.signal(io::process::PleaseExitSignal).unwrap();
+    pub fn destroy(&mut self) -> io::IoResult<()> {
+        let ret = self.inner.signal(io::process::PleaseExitSignal);
         self.finish();
+        return ret;
     }
 
     /**
@@ -271,10 +272,11 @@ impl Process {
      * On Posix OSs SIGKILL will be sent to the process. On Win32
      * TerminateProcess(..) will be called.
      */
-    pub fn force_destroy(&mut self) {
+    pub fn force_destroy(&mut self) -> io::IoResult<()> {
         // This should never fail because we own the process
-        self.inner.signal(io::process::MustDieSignal).unwrap();
+        let ret = self.inner.signal(io::process::MustDieSignal);
         self.finish();
+        return ret;
 
     }
 }
@@ -330,33 +332,25 @@ mod tests {
     use task::spawn;
     use unstable::running_on_valgrind;
     use io::pipe::PipeStream;
-    use io::{io_error, FileNotFound};
+    use io::{FileNotFound};
     use libc::c_int;
 
     #[test]
     #[cfg(not(target_os="android"))] // FIXME(#10380)
     fn test_process_status() {
-        let mut status = run::process_status("false", []).expect("failed to exec `false`");
+        let mut status = run::process_status("false", []).unwrap();
         assert!(status.matches_exit_status(1));
 
-        status = run::process_status("true", []).expect("failed to exec `true`");
+        status = run::process_status("true", []).unwrap();
         assert!(status.success());
     }
 
     #[test]
     fn test_process_output_fail_to_start() {
-        // If the executable does not exist, then the io_error condition should be raised with
-        // IoErrorKind FileNotFound.
-
-        let mut trapped_io_error = false;
-        let opt_outp = io_error::cond.trap(|e| {
-            trapped_io_error = true;
-            assert_eq!(e.kind, FileNotFound);
-        }).inside(|| -> Option<run::ProcessOutput> {
-            run::process_output("/no-binary-by-this-name-should-exist", [])
-        });
-        assert!(trapped_io_error);
-        assert!(opt_outp.is_none());
+        match run::process_output("/no-binary-by-this-name-should-exist", []) {
+            Err(e) => assert_eq!(e.kind, FileNotFound),
+            Ok(..) => fail!()
+        }
     }
 
     #[test]
@@ -364,7 +358,7 @@ mod tests {
     fn test_process_output_output() {
 
         let run::ProcessOutput {status, output, error}
-             = run::process_output("echo", [~"hello"]).expect("failed to exec `echo`");
+             = run::process_output("echo", [~"hello"]).unwrap();
         let output_str = str::from_utf8_owned(output).unwrap();
 
         assert!(status.success());
@@ -380,7 +374,7 @@ mod tests {
     fn test_process_output_error() {
 
         let run::ProcessOutput {status, output, error}
-             = run::process_output("mkdir", [~"."]).expect("failed to exec `mkdir`");
+             = run::process_output("mkdir", [~"."]).unwrap();
 
         assert!(status.matches_exit_status(1));
         assert_eq!(output, ~[]);
@@ -401,7 +395,7 @@ mod tests {
             in_fd: Some(pipe_in.input),
             out_fd: Some(pipe_out.out),
             err_fd: Some(pipe_err.out)
-        }).expect("failed to exec `cat`");
+        }).unwrap();
 
         os::close(pipe_in.input as int);
         os::close(pipe_out.out as int);
@@ -419,27 +413,18 @@ mod tests {
 
     fn writeclose(fd: c_int, s: &str) {
         let mut writer = PipeStream::open(fd);
-        writer.write(s.as_bytes());
+        writer.write(s.as_bytes()).unwrap();
     }
 
     fn readclose(fd: c_int) -> ~str {
-        let mut res = ~[];
-        let mut reader = PipeStream::open(fd);
-        let mut buf = [0, ..1024];
-        loop {
-            match reader.read(buf) {
-                Some(n) => { res.push_all(buf.slice_to(n)); }
-                None => break
-            }
-        }
-        str::from_utf8_owned(res).unwrap()
+        PipeStream::open(fd).read_to_str().unwrap()
     }
 
     #[test]
     #[cfg(not(target_os="android"))] // FIXME(#10380)
     fn test_finish_once() {
         let mut prog = run::Process::new("false", [], run::ProcessOptions::new())
-            .expect("failed to exec `false`");
+            .unwrap();
         assert!(prog.finish().matches_exit_status(1));
     }
 
@@ -447,7 +432,7 @@ mod tests {
     #[cfg(not(target_os="android"))] // FIXME(#10380)
     fn test_finish_twice() {
         let mut prog = run::Process::new("false", [], run::ProcessOptions::new())
-            .expect("failed to exec `false`");
+            .unwrap();
         assert!(prog.finish().matches_exit_status(1));
         assert!(prog.finish().matches_exit_status(1));
     }
@@ -457,7 +442,7 @@ mod tests {
     fn test_finish_with_output_once() {
 
         let mut prog = run::Process::new("echo", [~"hello"], run::ProcessOptions::new())
-            .expect("failed to exec `echo`");
+            .unwrap();
         let run::ProcessOutput {status, output, error}
             = prog.finish_with_output();
         let output_str = str::from_utf8_owned(output).unwrap();
@@ -475,7 +460,7 @@ mod tests {
     fn test_finish_with_output_twice() {
 
         let mut prog = run::Process::new("echo", [~"hello"], run::ProcessOptions::new())
-            .expect("failed to exec `echo`");
+            .unwrap();
         let run::ProcessOutput {status, output, error}
             = prog.finish_with_output();
 
@@ -504,14 +489,14 @@ mod tests {
         run::Process::new("pwd", [], run::ProcessOptions {
             dir: dir,
             .. run::ProcessOptions::new()
-        }).expect("failed to exec `pwd`")
+        }).unwrap()
     }
     #[cfg(unix,target_os="android")]
     fn run_pwd(dir: Option<&Path>) -> run::Process {
         run::Process::new("/system/bin/sh", [~"-c",~"pwd"], run::ProcessOptions {
             dir: dir,
             .. run::ProcessOptions::new()
-        }).expect("failed to exec `/system/bin/sh`")
+        }).unwrap()
     }
 
     #[cfg(windows)]
@@ -519,7 +504,7 @@ mod tests {
         run::Process::new("cmd", [~"/c", ~"cd"], run::ProcessOptions {
             dir: dir,
             .. run::ProcessOptions::new()
-        }).expect("failed to run `cmd`")
+        }).unwrap()
     }
 
     #[test]
@@ -530,8 +515,8 @@ mod tests {
         let parent_dir = os::getcwd();
         let child_dir = Path::new(output.trim());
 
-        let parent_stat = parent_dir.stat();
-        let child_stat = child_dir.stat();
+        let parent_stat = parent_dir.stat().unwrap();
+        let child_stat = child_dir.stat().unwrap();
 
         assert_eq!(parent_stat.unstable.device, child_stat.unstable.device);
         assert_eq!(parent_stat.unstable.inode, child_stat.unstable.inode);
@@ -547,8 +532,8 @@ mod tests {
         let output = str::from_utf8_owned(prog.finish_with_output().output).unwrap();
         let child_dir = Path::new(output.trim());
 
-        let parent_stat = parent_dir.stat();
-        let child_stat = child_dir.stat();
+        let parent_stat = parent_dir.stat().unwrap();
+        let child_stat = child_dir.stat().unwrap();
 
         assert_eq!(parent_stat.unstable.device, child_stat.unstable.device);
         assert_eq!(parent_stat.unstable.inode, child_stat.unstable.inode);
@@ -559,14 +544,14 @@ mod tests {
         run::Process::new("env", [], run::ProcessOptions {
             env: env,
             .. run::ProcessOptions::new()
-        }).expect("failed to exec `env`")
+        }).unwrap()
     }
     #[cfg(unix,target_os="android")]
     fn run_env(env: Option<~[(~str, ~str)]>) -> run::Process {
         run::Process::new("/system/bin/sh", [~"-c",~"set"], run::ProcessOptions {
             env: env,
             .. run::ProcessOptions::new()
-        }).expect("failed to exec `/system/bin/sh`")
+        }).unwrap()
     }
 
     #[cfg(windows)]
@@ -574,7 +559,7 @@ mod tests {
         run::Process::new("cmd", [~"/c", ~"set"], run::ProcessOptions {
             env: env,
             .. run::ProcessOptions::new()
-        }).expect("failed to run `cmd`")
+        }).unwrap()
     }
 
     #[test]

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -541,7 +541,7 @@ fn test_avoid_copying_the_body_task_spawn() {
 #[test]
 fn test_avoid_copying_the_body_try() {
     avoid_copying_the_body(|f| {
-        try(proc() {
+        let _ = try(proc() {
             f()
         });
     })

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -349,7 +349,7 @@ impl<A:IterBytes> ToBytes for A {
 
         let mut m = ::io::MemWriter::new();
         self.iter_bytes(lsb0, |bytes| {
-            m.write(bytes);
+            m.write(bytes).unwrap();
             true
         });
         m.unwrap()

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -200,7 +200,7 @@ mod tests {
             // accesses will also fail.
             let x = Exclusive::new(1);
             let x2 = x.clone();
-            task::try(proc() {
+            let _ = task::try(proc() {
                 x2.with(|one| assert_eq!(*one, 2))
             });
             x.with(|one| assert_eq!(*one, 1));

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -957,14 +957,13 @@ mod test {
     use ast_util;
     use codemap;
     use codemap::Spanned;
-    use fold;
     use fold::*;
     use ext::base::{CrateLoader, MacroCrate};
     use parse;
     use parse::token::{fresh_mark, gensym, intern};
     use parse::token;
     use util::parser_testing::{string_to_crate, string_to_crate_and_sess};
-    use util::parser_testing::{string_to_pat, string_to_tts, strs_to_idents};
+    use util::parser_testing::{string_to_pat, strs_to_idents};
     use visit;
     use visit::Visitor;
 
@@ -1253,14 +1252,14 @@ mod test {
                     let varref_name = mtwt_resolve(varref.segments[0].identifier);
                     let varref_marks = mtwt_marksof(varref.segments[0].identifier.ctxt,
                                                     invalid_name);
-                    if (!(varref_name==binding_name)){
+                    if !(varref_name==binding_name) {
                         println!("uh oh, should match but doesn't:");
                         println!("varref: {:?}",varref);
                         println!("binding: {:?}", bindings[binding_idx]);
                         ast_util::display_sctable(get_sctable());
                     }
                     assert_eq!(varref_name,binding_name);
-                    if (bound_ident_check) {
+                    if bound_ident_check {
                         // we're checking bound-identifier=?, and the marks
                         // should be the same, too:
                         assert_eq!(varref_marks,binding_marks.clone());
@@ -1269,7 +1268,7 @@ mod test {
                     let fail = (varref.segments.len() == 1)
                         && (mtwt_resolve(varref.segments[0].identifier) == binding_name);
                     // temp debugging:
-                    if (fail) {
+                    if fail {
                         println!("failure on test {}",test_idx);
                         println!("text of test case: \"{}\"", teststr);
                         println!("");

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -20,7 +20,6 @@ use parse::token::get_ident_interner;
 use parse::token;
 use print::pprust;
 
-use std::io;
 use std::io::File;
 use std::rc::Rc;
 use std::str;
@@ -109,9 +108,9 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         None => return MacResult::dummy_expr()
     };
     let file = res_rel_file(cx, sp, &Path::new(file));
-    let bytes = match io::result(|| File::open(&file).read_to_end()) {
+    let bytes = match File::open(&file).read_to_end() {
         Err(e) => {
-            cx.span_err(sp, format!("couldn't read {}: {}", file.display(), e.desc));
+            cx.span_err(sp, format!("couldn't read {}: {}", file.display(), e));
             return MacResult::dummy_expr();
         }
         Ok(bytes) => bytes,
@@ -141,9 +140,9 @@ pub fn expand_include_bin(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         None => return MacResult::dummy_expr()
     };
     let file = res_rel_file(cx, sp, &Path::new(file));
-    match io::result(|| File::open(&file).read_to_end()) {
+    match File::open(&file).read_to_end() {
         Err(e) => {
-            cx.span_err(sp, format!("couldn't read {}: {}", file.display(), e.desc));
+            cx.span_err(sp, format!("couldn't read {}: {}", file.display(), e));
             return MacResult::dummy_expr();
         }
         Ok(bytes) => {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -861,6 +861,7 @@ pub fn noop_fold_stmt<T: Folder>(s: &Stmt, folder: &mut T) -> SmallVector<@Stmt>
 
 #[cfg(test)]
 mod test {
+    use std::io;
     use ast;
     use util::parser_testing::{string_to_crate, matches_codepattern};
     use parse::token;
@@ -868,8 +869,9 @@ mod test {
     use super::*;
 
     // this version doesn't care about getting comments or docstrings in.
-    fn fake_print_crate(s: &mut pprust::State, crate: &ast::Crate) {
-        pprust::print_mod(s, &crate.module, crate.attrs);
+    fn fake_print_crate(s: &mut pprust::State,
+                        crate: &ast::Crate) -> io::IoResult<()> {
+        pprust::print_mod(s, &crate.module, crate.attrs)
     }
 
     // change every identifier to "zz"

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -33,6 +33,11 @@ This API is completely unstable and subject to change.
 extern mod extra;
 extern mod term;
 
+#[cfg(stage0)]
+macro_rules! if_ok (
+    ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
+)
+
 pub mod util {
     pub mod interner;
     #[cfg(test)]

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -350,7 +350,8 @@ pub fn gather_comments_and_literals(span_diagnostic:
                                     path: ~str,
                                     srdr: &mut io::Reader)
                                  -> (~[Comment], ~[Literal]) {
-    let src = str::from_utf8_owned(srdr.read_to_end()).unwrap();
+    let src = srdr.read_to_end().unwrap();
+    let src = str::from_utf8_owned(src).unwrap();
     let cm = CodeMap::new();
     let filemap = cm.new_filemap(path, src);
     let rdr = lexer::new_low_level_string_reader(span_diagnostic, filemap);

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -19,7 +19,6 @@ use parse::attr::ParserAttr;
 use parse::parser::Parser;
 
 use std::cell::RefCell;
-use std::io;
 use std::io::File;
 use std::str;
 
@@ -232,10 +231,10 @@ pub fn file_to_filemap(sess: @ParseSess, path: &Path, spanopt: Option<Span>)
             None => sess.span_diagnostic.handler().fatal(msg),
         }
     };
-    let bytes = match io::result(|| File::open(path).read_to_end()) {
+    let bytes = match File::open(path).read_to_end() {
         Ok(bytes) => bytes,
         Err(e) => {
-            err(format!("couldn't read {}: {}", path.display(), e.desc));
+            err(format!("couldn't read {}: {}", path.display(), e));
             unreachable!()
         }
     };

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -588,8 +588,8 @@ impl BytesContainer for InternedString {
 }
 
 impl fmt::Show for InternedString {
-    fn fmt(obj: &InternedString, f: &mut fmt::Formatter) {
-        write!(f.buf, "{}", obj.string.as_slice());
+    fn fmt(obj: &InternedString, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f.buf, "{}", obj.string.as_slice())
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -43,8 +43,8 @@ pub enum AnnNode<'a,'b> {
 }
 
 pub trait PpAnn {
-    fn pre(&self, _node: AnnNode) {}
-    fn post(&self, _node: AnnNode) {}
+    fn pre(&self, _node: AnnNode) -> io::IoResult<()> { Ok(()) }
+    fn post(&self, _node: AnnNode) -> io::IoResult<()> { Ok(()) }
 }
 
 pub struct NoAnn;
@@ -67,20 +67,20 @@ pub struct State {
     ann: @PpAnn
 }
 
-pub fn ibox(s: &mut State, u: uint) {
+pub fn ibox(s: &mut State, u: uint) -> io::IoResult<()> {
     {
         let mut boxes = s.boxes.borrow_mut();
         boxes.get().push(pp::Inconsistent);
     }
-    pp::ibox(&mut s.s, u);
+    pp::ibox(&mut s.s, u)
 }
 
-pub fn end(s: &mut State) {
+pub fn end(s: &mut State) -> io::IoResult<()> {
     {
         let mut boxes = s.boxes.borrow_mut();
         boxes.get().pop().unwrap();
     }
-    pp::end(&mut s.s);
+    pp::end(&mut s.s)
 }
 
 pub fn rust_printer(writer: ~io::Writer, intr: @IdentInterner) -> State {
@@ -121,7 +121,7 @@ pub fn print_crate(cm: @CodeMap,
                    input: &mut io::Reader,
                    out: ~io::Writer,
                    ann: @PpAnn,
-                   is_expanded: bool) {
+                   is_expanded: bool) -> io::IoResult<()> {
     let (cmnts, lits) = comments::gather_comments_and_literals(
         span_diagnostic,
         filename,
@@ -147,13 +147,14 @@ pub fn print_crate(cm: @CodeMap,
         boxes: RefCell::new(~[]),
         ann: ann
     };
-    print_crate_(&mut s, crate);
+    print_crate_(&mut s, crate)
 }
 
-pub fn print_crate_(s: &mut State, crate: &ast::Crate) {
-    print_mod(s, &crate.module, crate.attrs);
-    print_remaining_comments(s);
-    eof(&mut s.s);
+pub fn print_crate_(s: &mut State, crate: &ast::Crate) -> io::IoResult<()> {
+    if_ok!(print_mod(s, &crate.module, crate.attrs));
+    if_ok!(print_remaining_comments(s));
+    if_ok!(eof(&mut s.s));
+    Ok(())
 }
 
 pub fn ty_to_str(ty: &ast::Ty, intr: @IdentInterner) -> ~str {
@@ -203,10 +204,10 @@ pub fn fun_to_str(decl: &ast::FnDecl, purity: ast::Purity, name: ast::Ident,
     let wr = ~MemWriter::new();
     let mut s = rust_printer(wr as ~io::Writer, intr);
     print_fn(&mut s, decl, Some(purity), AbiSet::Rust(),
-             name, generics, opt_explicit_self, ast::Inherited);
-    end(&mut s); // Close the head box
-    end(&mut s); // Close the outer box
-    eof(&mut s.s);
+             name, generics, opt_explicit_self, ast::Inherited).unwrap();
+    end(&mut s).unwrap(); // Close the head box
+    end(&mut s).unwrap(); // Close the outer box
+    eof(&mut s.s).unwrap();
     unsafe {
         get_mem_writer(&mut s.s.out)
     }
@@ -216,11 +217,11 @@ pub fn block_to_str(blk: &ast::Block, intr: @IdentInterner) -> ~str {
     let wr = ~MemWriter::new();
     let mut s = rust_printer(wr as ~io::Writer, intr);
     // containing cbox, will be closed by print-block at }
-    cbox(&mut s, indent_unit);
+    cbox(&mut s, indent_unit).unwrap();
     // head-ibox, will be closed by print-block after {
-    ibox(&mut s, 0u);
-    print_block(&mut s, blk);
-    eof(&mut s.s);
+    ibox(&mut s, 0u).unwrap();
+    print_block(&mut s, blk).unwrap();
+    eof(&mut s.s).unwrap();
     unsafe {
         get_mem_writer(&mut s.s.out)
     }
@@ -238,63 +239,73 @@ pub fn variant_to_str(var: &ast::Variant, intr: @IdentInterner) -> ~str {
     to_str(var, print_variant, intr)
 }
 
-pub fn cbox(s: &mut State, u: uint) {
+pub fn cbox(s: &mut State, u: uint) -> io::IoResult<()> {
     {
         let mut boxes = s.boxes.borrow_mut();
         boxes.get().push(pp::Consistent);
     }
-    pp::cbox(&mut s.s, u);
+    pp::cbox(&mut s.s, u)
 }
 
 // "raw box"
-pub fn rbox(s: &mut State, u: uint, b: pp::Breaks) {
+pub fn rbox(s: &mut State, u: uint, b: pp::Breaks) -> io::IoResult<()> {
     {
         let mut boxes = s.boxes.borrow_mut();
         boxes.get().push(b);
     }
-    pp::rbox(&mut s.s, u, b);
+    pp::rbox(&mut s.s, u, b)
 }
 
-pub fn nbsp(s: &mut State) { word(&mut s.s, " "); }
+pub fn nbsp(s: &mut State) -> io::IoResult<()> { word(&mut s.s, " ") }
 
-pub fn word_nbsp(s: &mut State, w: &str) { word(&mut s.s, w); nbsp(s); }
+pub fn word_nbsp(s: &mut State, w: &str) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, w));
+    nbsp(s)
+}
 
-pub fn word_space(s: &mut State, w: &str) { word(&mut s.s, w); space(&mut s.s); }
+pub fn word_space(s: &mut State, w: &str) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, w));
+    space(&mut s.s)
+}
 
-pub fn popen(s: &mut State) { word(&mut s.s, "("); }
+pub fn popen(s: &mut State) -> io::IoResult<()> { word(&mut s.s, "(") }
 
-pub fn pclose(s: &mut State) { word(&mut s.s, ")"); }
+pub fn pclose(s: &mut State) -> io::IoResult<()> { word(&mut s.s, ")") }
 
-pub fn head(s: &mut State, w: &str) {
+pub fn head(s: &mut State, w: &str) -> io::IoResult<()> {
     // outer-box is consistent
-    cbox(s, indent_unit);
+    if_ok!(cbox(s, indent_unit));
     // head-box is inconsistent
-    ibox(s, w.len() + 1);
+    if_ok!(ibox(s, w.len() + 1));
     // keyword that starts the head
     if !w.is_empty() {
-        word_nbsp(s, w);
+        if_ok!(word_nbsp(s, w));
     }
+    Ok(())
 }
 
-pub fn bopen(s: &mut State) {
-    word(&mut s.s, "{");
-    end(s); // close the head-box
+pub fn bopen(s: &mut State) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, "{"));
+    if_ok!(end(s)); // close the head-box
+    Ok(())
 }
 
-pub fn bclose_(s: &mut State, span: codemap::Span, indented: uint) {
-    bclose_maybe_open(s, span, indented, true);
+pub fn bclose_(s: &mut State, span: codemap::Span,
+               indented: uint) -> io::IoResult<()> {
+    bclose_maybe_open(s, span, indented, true)
 }
 pub fn bclose_maybe_open (s: &mut State, span: codemap::Span,
-                          indented: uint, close_box: bool) {
-    maybe_print_comment(s, span.hi);
-    break_offset_if_not_bol(s, 1u, -(indented as int));
-    word(&mut s.s, "}");
+                          indented: uint, close_box: bool) -> io::IoResult<()> {
+    if_ok!(maybe_print_comment(s, span.hi));
+    if_ok!(break_offset_if_not_bol(s, 1u, -(indented as int)));
+    if_ok!(word(&mut s.s, "}"));
     if close_box {
-        end(s); // close the outer-box
+        if_ok!(end(s)); // close the outer-box
     }
+    Ok(())
 }
-pub fn bclose(s: &mut State, span: codemap::Span) {
-    bclose_(s, span, indent_unit);
+pub fn bclose(s: &mut State, span: codemap::Span) -> io::IoResult<()> {
+    bclose_(s, span, indent_unit)
 }
 
 pub fn is_begin(s: &mut State) -> bool {
@@ -316,15 +327,20 @@ pub fn in_cbox(s: &mut State) -> bool {
     return boxes.get()[len - 1u] == pp::Consistent;
 }
 
-pub fn hardbreak_if_not_bol(s: &mut State) {
+pub fn hardbreak_if_not_bol(s: &mut State) -> io::IoResult<()> {
     if !is_bol(s) {
-        hardbreak(&mut s.s)
+        if_ok!(hardbreak(&mut s.s))
     }
+    Ok(())
 }
-pub fn space_if_not_bol(s: &mut State) { if !is_bol(s) { space(&mut s.s); } }
-pub fn break_offset_if_not_bol(s: &mut State, n: uint, off: int) {
+pub fn space_if_not_bol(s: &mut State) -> io::IoResult<()> {
+    if !is_bol(s) { if_ok!(space(&mut s.s)); }
+    Ok(())
+}
+pub fn break_offset_if_not_bol(s: &mut State, n: uint,
+                               off: int) -> io::IoResult<()> {
     if !is_bol(s) {
-        break_offset(&mut s.s, n, off);
+        if_ok!(break_offset(&mut s.s, n, off));
     } else {
         if off != 0 && s.s.last_token().is_hardbreak_tok() {
             // We do something pretty sketchy here: tuck the nonzero
@@ -333,26 +349,31 @@ pub fn break_offset_if_not_bol(s: &mut State, n: uint, off: int) {
             s.s.replace_last_token(pp::hardbreak_tok_offset(off));
         }
     }
+    Ok(())
 }
 
 // Synthesizes a comment that was not textually present in the original source
 // file.
-pub fn synth_comment(s: &mut State, text: ~str) {
-    word(&mut s.s, "/*");
-    space(&mut s.s);
-    word(&mut s.s, text);
-    space(&mut s.s);
-    word(&mut s.s, "*/");
+pub fn synth_comment(s: &mut State, text: ~str) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, "/*"));
+    if_ok!(space(&mut s.s));
+    if_ok!(word(&mut s.s, text));
+    if_ok!(space(&mut s.s));
+    if_ok!(word(&mut s.s, "*/"));
+    Ok(())
 }
 
-pub fn commasep<T>(s: &mut State, b: Breaks, elts: &[T], op: |&mut State, &T|) {
-    rbox(s, 0u, b);
+pub fn commasep<T>(s: &mut State, b: Breaks, elts: &[T],
+                   op: |&mut State, &T| -> io::IoResult<()>)
+    -> io::IoResult<()>
+{
+    if_ok!(rbox(s, 0u, b));
     let mut first = true;
     for elt in elts.iter() {
-        if first { first = false; } else { word_space(s, ","); }
-        op(s, elt);
+        if first { first = false; } else { if_ok!(word_space(s, ",")); }
+        if_ok!(op(s, elt));
     }
-    end(s);
+    end(s)
 }
 
 
@@ -360,177 +381,200 @@ pub fn commasep_cmnt<T>(
                      s: &mut State,
                      b: Breaks,
                      elts: &[T],
-                     op: |&mut State, &T|,
-                     get_span: |&T| -> codemap::Span) {
-    rbox(s, 0u, b);
+                     op: |&mut State, &T| -> io::IoResult<()>,
+                     get_span: |&T| -> codemap::Span) -> io::IoResult<()> {
+    if_ok!(rbox(s, 0u, b));
     let len = elts.len();
     let mut i = 0u;
     for elt in elts.iter() {
-        maybe_print_comment(s, get_span(elt).hi);
-        op(s, elt);
+        if_ok!(maybe_print_comment(s, get_span(elt).hi));
+        if_ok!(op(s, elt));
         i += 1u;
         if i < len {
-            word(&mut s.s, ",");
-            maybe_print_trailing_comment(s, get_span(elt),
-                                         Some(get_span(&elts[i]).hi));
-            space_if_not_bol(s);
+            if_ok!(word(&mut s.s, ","));
+            if_ok!(maybe_print_trailing_comment(s, get_span(elt),
+                                                Some(get_span(&elts[i]).hi)));
+            if_ok!(space_if_not_bol(s));
         }
     }
-    end(s);
+    end(s)
 }
 
-pub fn commasep_exprs(s: &mut State, b: Breaks, exprs: &[@ast::Expr]) {
-    commasep_cmnt(s, b, exprs, |p, &e| print_expr(p, e), |e| e.span);
+pub fn commasep_exprs(s: &mut State, b: Breaks,
+                      exprs: &[@ast::Expr]) -> io::IoResult<()> {
+    commasep_cmnt(s, b, exprs, |p, &e| print_expr(p, e), |e| e.span)
 }
 
-pub fn print_mod(s: &mut State, _mod: &ast::Mod, attrs: &[ast::Attribute]) {
-    print_inner_attributes(s, attrs);
+pub fn print_mod(s: &mut State, _mod: &ast::Mod,
+                 attrs: &[ast::Attribute]) -> io::IoResult<()> {
+    if_ok!(print_inner_attributes(s, attrs));
     for vitem in _mod.view_items.iter() {
-        print_view_item(s, vitem);
+        if_ok!(print_view_item(s, vitem));
     }
-    for item in _mod.items.iter() { print_item(s, *item); }
+    for item in _mod.items.iter() {
+        if_ok!(print_item(s, *item));
+    }
+    Ok(())
 }
 
 pub fn print_foreign_mod(s: &mut State, nmod: &ast::ForeignMod,
-                         attrs: &[ast::Attribute]) {
-    print_inner_attributes(s, attrs);
+                         attrs: &[ast::Attribute]) -> io::IoResult<()> {
+    if_ok!(print_inner_attributes(s, attrs));
     for vitem in nmod.view_items.iter() {
-        print_view_item(s, vitem);
+        if_ok!(print_view_item(s, vitem));
     }
-    for item in nmod.items.iter() { print_foreign_item(s, *item); }
+    for item in nmod.items.iter() {
+        if_ok!(print_foreign_item(s, *item));
+    }
+    Ok(())
 }
 
-pub fn print_opt_lifetime(s: &mut State, lifetime: &Option<ast::Lifetime>) {
+pub fn print_opt_lifetime(s: &mut State,
+                          lifetime: &Option<ast::Lifetime>) -> io::IoResult<()> {
     for l in lifetime.iter() {
-        print_lifetime(s, l);
-        nbsp(s);
+        if_ok!(print_lifetime(s, l));
+        if_ok!(nbsp(s));
     }
+    Ok(())
 }
 
-pub fn print_type(s: &mut State, ty: &ast::Ty) {
-    maybe_print_comment(s, ty.span.lo);
-    ibox(s, 0u);
+pub fn print_type(s: &mut State, ty: &ast::Ty) -> io::IoResult<()> {
+    if_ok!(maybe_print_comment(s, ty.span.lo));
+    if_ok!(ibox(s, 0u));
     match ty.node {
-        ast::TyNil => word(&mut s.s, "()"),
-        ast::TyBot => word(&mut s.s, "!"),
-        ast::TyBox(ty) => { word(&mut s.s, "@"); print_type(s, ty); }
-        ast::TyUniq(ty) => { word(&mut s.s, "~"); print_type(s, ty); }
-        ast::TyVec(ty) => {
-            word(&mut s.s, "[");
-            print_type(s, ty);
-            word(&mut s.s, "]");
+        ast::TyNil => if_ok!(word(&mut s.s, "()")),
+        ast::TyBot => if_ok!(word(&mut s.s, "!")),
+        ast::TyBox(ty) => {
+            if_ok!(word(&mut s.s, "@"));
+            if_ok!(print_type(s, ty));
         }
-        ast::TyPtr(ref mt) => { word(&mut s.s, "*"); print_mt(s, mt); }
+        ast::TyUniq(ty) => {
+            if_ok!(word(&mut s.s, "~"));
+            if_ok!(print_type(s, ty));
+        }
+        ast::TyVec(ty) => {
+            if_ok!(word(&mut s.s, "["));
+            if_ok!(print_type(s, ty));
+            if_ok!(word(&mut s.s, "]"));
+        }
+        ast::TyPtr(ref mt) => {
+            if_ok!(word(&mut s.s, "*"));
+            if_ok!(print_mt(s, mt));
+        }
         ast::TyRptr(ref lifetime, ref mt) => {
-            word(&mut s.s, "&");
-            print_opt_lifetime(s, lifetime);
-            print_mt(s, mt);
+            if_ok!(word(&mut s.s, "&"));
+            if_ok!(print_opt_lifetime(s, lifetime));
+            if_ok!(print_mt(s, mt));
         }
         ast::TyTup(ref elts) => {
-            popen(s);
-            commasep(s, Inconsistent, *elts, print_type_ref);
+            if_ok!(popen(s));
+            if_ok!(commasep(s, Inconsistent, *elts, print_type_ref));
             if elts.len() == 1 {
-                word(&mut s.s, ",");
+                if_ok!(word(&mut s.s, ","));
             }
-            pclose(s);
+            if_ok!(pclose(s));
         }
         ast::TyBareFn(f) => {
             let generics = ast::Generics {
                 lifetimes: f.lifetimes.clone(),
                 ty_params: opt_vec::Empty
             };
-            print_ty_fn(s, Some(f.abis), None, &None,
-                        f.purity, ast::Many, f.decl, None, &None,
-                        Some(&generics), None);
+            if_ok!(print_ty_fn(s, Some(f.abis), None, &None,
+                               f.purity, ast::Many, f.decl, None, &None,
+                               Some(&generics), None));
         }
         ast::TyClosure(f) => {
             let generics = ast::Generics {
                 lifetimes: f.lifetimes.clone(),
                 ty_params: opt_vec::Empty
             };
-            print_ty_fn(s, None, Some(f.sigil), &f.region,
-                        f.purity, f.onceness, f.decl, None, &f.bounds,
-                        Some(&generics), None);
+            if_ok!(print_ty_fn(s, None, Some(f.sigil), &f.region,
+                               f.purity, f.onceness, f.decl, None, &f.bounds,
+                               Some(&generics), None));
         }
-        ast::TyPath(ref path, ref bounds, _) => print_bounded_path(s, path, bounds),
+        ast::TyPath(ref path, ref bounds, _) => {
+            if_ok!(print_bounded_path(s, path, bounds));
+        }
         ast::TyFixedLengthVec(ty, v) => {
-            word(&mut s.s, "[");
-            print_type(s, ty);
-            word(&mut s.s, ", ..");
-            print_expr(s, v);
-            word(&mut s.s, "]");
+            if_ok!(word(&mut s.s, "["));
+            if_ok!(print_type(s, ty));
+            if_ok!(word(&mut s.s, ", .."));
+            if_ok!(print_expr(s, v));
+            if_ok!(word(&mut s.s, "]"));
         }
         ast::TyTypeof(e) => {
-            word(&mut s.s, "typeof(");
-            print_expr(s, e);
-            word(&mut s.s, ")");
+            if_ok!(word(&mut s.s, "typeof("));
+            if_ok!(print_expr(s, e));
+            if_ok!(word(&mut s.s, ")"));
         }
         ast::TyInfer => {
             fail!("print_type shouldn't see a ty_infer");
         }
     }
-    end(s);
+    end(s)
 }
 
-pub fn print_type_ref(s: &mut State, ty: &P<ast::Ty>) {
-    print_type(s, *ty);
+pub fn print_type_ref(s: &mut State, ty: &P<ast::Ty>) -> io::IoResult<()> {
+    print_type(s, *ty)
 }
 
-pub fn print_foreign_item(s: &mut State, item: &ast::ForeignItem) {
-    hardbreak_if_not_bol(s);
-    maybe_print_comment(s, item.span.lo);
-    print_outer_attributes(s, item.attrs);
+pub fn print_foreign_item(s: &mut State,
+                          item: &ast::ForeignItem) -> io::IoResult<()> {
+    if_ok!(hardbreak_if_not_bol(s));
+    if_ok!(maybe_print_comment(s, item.span.lo));
+    if_ok!(print_outer_attributes(s, item.attrs));
     match item.node {
-      ast::ForeignItemFn(decl, ref generics) => {
-        print_fn(s, decl, None, AbiSet::Rust(), item.ident, generics, None,
-                 item.vis);
-        end(s); // end head-ibox
-        word(&mut s.s, ";");
-        end(s); // end the outer fn box
-      }
-      ast::ForeignItemStatic(t, m) => {
-        head(s, visibility_qualified(item.vis, "static"));
-        if m {
-            word_space(s, "mut");
+        ast::ForeignItemFn(decl, ref generics) => {
+            if_ok!(print_fn(s, decl, None, AbiSet::Rust(), item.ident, generics,
+            None, item.vis));
+            if_ok!(end(s)); // end head-ibox
+            if_ok!(word(&mut s.s, ";"));
+            if_ok!(end(s)); // end the outer fn box
         }
-        print_ident(s, item.ident);
-        word_space(s, ":");
-        print_type(s, t);
-        word(&mut s.s, ";");
-        end(s); // end the head-ibox
-        end(s); // end the outer cbox
-      }
+        ast::ForeignItemStatic(t, m) => {
+            if_ok!(head(s, visibility_qualified(item.vis, "static")));
+            if m {
+                if_ok!(word_space(s, "mut"));
+            }
+            if_ok!(print_ident(s, item.ident));
+            if_ok!(word_space(s, ":"));
+            if_ok!(print_type(s, t));
+            if_ok!(word(&mut s.s, ";"));
+            if_ok!(end(s)); // end the head-ibox
+            if_ok!(end(s)); // end the outer cbox
+        }
     }
+    Ok(())
 }
 
-pub fn print_item(s: &mut State, item: &ast::Item) {
-    hardbreak_if_not_bol(s);
-    maybe_print_comment(s, item.span.lo);
-    print_outer_attributes(s, item.attrs);
+pub fn print_item(s: &mut State, item: &ast::Item) -> io::IoResult<()> {
+    if_ok!(hardbreak_if_not_bol(s));
+    if_ok!(maybe_print_comment(s, item.span.lo));
+    if_ok!(print_outer_attributes(s, item.attrs));
     {
         let ann_node = NodeItem(s, item);
-        s.ann.pre(ann_node);
+        if_ok!(s.ann.pre(ann_node));
     }
     match item.node {
       ast::ItemStatic(ty, m, expr) => {
-        head(s, visibility_qualified(item.vis, "static"));
+        if_ok!(head(s, visibility_qualified(item.vis, "static")));
         if m == ast::MutMutable {
-            word_space(s, "mut");
+            if_ok!(word_space(s, "mut"));
         }
-        print_ident(s, item.ident);
-        word_space(s, ":");
-        print_type(s, ty);
-        space(&mut s.s);
-        end(s); // end the head-ibox
+        if_ok!(print_ident(s, item.ident));
+        if_ok!(word_space(s, ":"));
+        if_ok!(print_type(s, ty));
+        if_ok!(space(&mut s.s));
+        if_ok!(end(s)); // end the head-ibox
 
-        word_space(s, "=");
-        print_expr(s, expr);
-        word(&mut s.s, ";");
-        end(s); // end the outer cbox
+        if_ok!(word_space(s, "="));
+        if_ok!(print_expr(s, expr));
+        if_ok!(word(&mut s.s, ";"));
+        if_ok!(end(s)); // end the outer cbox
 
       }
       ast::ItemFn(decl, purity, abi, ref typarams, body) => {
-        print_fn(
+        if_ok!(print_fn(
             s,
             decl,
             Some(purity),
@@ -539,150 +583,153 @@ pub fn print_item(s: &mut State, item: &ast::Item) {
             typarams,
             None,
             item.vis
-        );
-        word(&mut s.s, " ");
-        print_block_with_attrs(s, body, item.attrs);
+        ));
+        if_ok!(word(&mut s.s, " "));
+        if_ok!(print_block_with_attrs(s, body, item.attrs));
       }
       ast::ItemMod(ref _mod) => {
-        head(s, visibility_qualified(item.vis, "mod"));
-        print_ident(s, item.ident);
-        nbsp(s);
-        bopen(s);
-        print_mod(s, _mod, item.attrs);
-        bclose(s, item.span);
+        if_ok!(head(s, visibility_qualified(item.vis, "mod")));
+        if_ok!(print_ident(s, item.ident));
+        if_ok!(nbsp(s));
+        if_ok!(bopen(s));
+        if_ok!(print_mod(s, _mod, item.attrs));
+        if_ok!(bclose(s, item.span));
       }
       ast::ItemForeignMod(ref nmod) => {
-        head(s, "extern");
-        word_nbsp(s, nmod.abis.to_str());
-        bopen(s);
-        print_foreign_mod(s, nmod, item.attrs);
-        bclose(s, item.span);
+        if_ok!(head(s, "extern"));
+        if_ok!(word_nbsp(s, nmod.abis.to_str()));
+        if_ok!(bopen(s));
+        if_ok!(print_foreign_mod(s, nmod, item.attrs));
+        if_ok!(bclose(s, item.span));
       }
       ast::ItemTy(ty, ref params) => {
-        ibox(s, indent_unit);
-        ibox(s, 0u);
-        word_nbsp(s, visibility_qualified(item.vis, "type"));
-        print_ident(s, item.ident);
-        print_generics(s, params);
-        end(s); // end the inner ibox
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(ibox(s, 0u));
+        if_ok!(word_nbsp(s, visibility_qualified(item.vis, "type")));
+        if_ok!(print_ident(s, item.ident));
+        if_ok!(print_generics(s, params));
+        if_ok!(end(s)); // end the inner ibox
 
-        space(&mut s.s);
-        word_space(s, "=");
-        print_type(s, ty);
-        word(&mut s.s, ";");
-        end(s); // end the outer ibox
+        if_ok!(space(&mut s.s));
+        if_ok!(word_space(s, "="));
+        if_ok!(print_type(s, ty));
+        if_ok!(word(&mut s.s, ";"));
+        if_ok!(end(s)); // end the outer ibox
       }
       ast::ItemEnum(ref enum_definition, ref params) => {
-        print_enum_def(
+        if_ok!(print_enum_def(
             s,
             enum_definition,
             params,
             item.ident,
             item.span,
             item.vis
-        );
+        ));
       }
       ast::ItemStruct(struct_def, ref generics) => {
-          head(s, visibility_qualified(item.vis, "struct"));
-          print_struct(s, struct_def, generics, item.ident, item.span);
+          if_ok!(head(s, visibility_qualified(item.vis, "struct")));
+          if_ok!(print_struct(s, struct_def, generics, item.ident, item.span));
       }
 
       ast::ItemImpl(ref generics, ref opt_trait, ty, ref methods) => {
-        head(s, visibility_qualified(item.vis, "impl"));
+        if_ok!(head(s, visibility_qualified(item.vis, "impl")));
         if generics.is_parameterized() {
-            print_generics(s, generics);
-            space(&mut s.s);
+            if_ok!(print_generics(s, generics));
+            if_ok!(space(&mut s.s));
         }
 
         match opt_trait {
             &Some(ref t) => {
-                print_trait_ref(s, t);
-                space(&mut s.s);
-                word_space(s, "for");
+                if_ok!(print_trait_ref(s, t));
+                if_ok!(space(&mut s.s));
+                if_ok!(word_space(s, "for"));
             }
             &None => ()
         };
 
-        print_type(s, ty);
+        if_ok!(print_type(s, ty));
 
-        space(&mut s.s);
-        bopen(s);
-        print_inner_attributes(s, item.attrs);
+        if_ok!(space(&mut s.s));
+        if_ok!(bopen(s));
+        if_ok!(print_inner_attributes(s, item.attrs));
         for meth in methods.iter() {
-           print_method(s, *meth);
+           if_ok!(print_method(s, *meth));
         }
-        bclose(s, item.span);
+        if_ok!(bclose(s, item.span));
       }
       ast::ItemTrait(ref generics, ref traits, ref methods) => {
-        head(s, visibility_qualified(item.vis, "trait"));
-        print_ident(s, item.ident);
-        print_generics(s, generics);
+        if_ok!(head(s, visibility_qualified(item.vis, "trait")));
+        if_ok!(print_ident(s, item.ident));
+        if_ok!(print_generics(s, generics));
         if traits.len() != 0u {
-            word(&mut s.s, ":");
+            if_ok!(word(&mut s.s, ":"));
             for (i, trait_) in traits.iter().enumerate() {
-                nbsp(s);
+                if_ok!(nbsp(s));
                 if i != 0 {
-                    word_space(s, "+");
+                    if_ok!(word_space(s, "+"));
                 }
-                print_path(s, &trait_.path, false);
+                if_ok!(print_path(s, &trait_.path, false));
             }
         }
-        word(&mut s.s, " ");
-        bopen(s);
+        if_ok!(word(&mut s.s, " "));
+        if_ok!(bopen(s));
         for meth in methods.iter() {
-            print_trait_method(s, meth);
+            if_ok!(print_trait_method(s, meth));
         }
-        bclose(s, item.span);
+        if_ok!(bclose(s, item.span));
       }
       // I think it's reasonable to hide the context here:
       ast::ItemMac(codemap::Spanned { node: ast::MacInvocTT(ref pth, ref tts, _),
                                    ..}) => {
-        print_visibility(s, item.vis);
-        print_path(s, pth, false);
-        word(&mut s.s, "! ");
-        print_ident(s, item.ident);
-        cbox(s, indent_unit);
-        popen(s);
-        print_tts(s, &(tts.as_slice()));
-        pclose(s);
-        end(s);
+        if_ok!(print_visibility(s, item.vis));
+        if_ok!(print_path(s, pth, false));
+        if_ok!(word(&mut s.s, "! "));
+        if_ok!(print_ident(s, item.ident));
+        if_ok!(cbox(s, indent_unit));
+        if_ok!(popen(s));
+        if_ok!(print_tts(s, &(tts.as_slice())));
+        if_ok!(pclose(s));
+        if_ok!(end(s));
       }
     }
     {
         let ann_node = NodeItem(s, item);
-        s.ann.post(ann_node);
+        if_ok!(s.ann.post(ann_node));
     }
+    Ok(())
 }
 
-fn print_trait_ref(s: &mut State, t: &ast::TraitRef) {
-    print_path(s, &t.path, false);
+fn print_trait_ref(s: &mut State, t: &ast::TraitRef) -> io::IoResult<()> {
+    print_path(s, &t.path, false)
 }
 
 pub fn print_enum_def(s: &mut State, enum_definition: &ast::EnumDef,
                       generics: &ast::Generics, ident: ast::Ident,
-                      span: codemap::Span, visibility: ast::Visibility) {
-    head(s, visibility_qualified(visibility, "enum"));
-    print_ident(s, ident);
-    print_generics(s, generics);
-    space(&mut s.s);
-    print_variants(s, enum_definition.variants, span);
+                      span: codemap::Span,
+                      visibility: ast::Visibility) -> io::IoResult<()> {
+    if_ok!(head(s, visibility_qualified(visibility, "enum")));
+    if_ok!(print_ident(s, ident));
+    if_ok!(print_generics(s, generics));
+    if_ok!(space(&mut s.s));
+    if_ok!(print_variants(s, enum_definition.variants, span));
+    Ok(())
 }
 
 pub fn print_variants(s: &mut State,
                       variants: &[P<ast::Variant>],
-                      span: codemap::Span) {
-    bopen(s);
+                      span: codemap::Span) -> io::IoResult<()> {
+    if_ok!(bopen(s));
     for &v in variants.iter() {
-        space_if_not_bol(s);
-        maybe_print_comment(s, v.span.lo);
-        print_outer_attributes(s, v.node.attrs);
-        ibox(s, indent_unit);
-        print_variant(s, v);
-        word(&mut s.s, ",");
-        end(s);
-        maybe_print_trailing_comment(s, v.span, None);
+        if_ok!(space_if_not_bol(s));
+        if_ok!(maybe_print_comment(s, v.span.lo));
+        if_ok!(print_outer_attributes(s, v.node.attrs));
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(print_variant(s, v));
+        if_ok!(word(&mut s.s, ","));
+        if_ok!(end(s));
+        if_ok!(maybe_print_trailing_comment(s, v.span, None));
     }
-    bclose(s, span);
+    bclose(s, span)
 }
 
 pub fn visibility_to_str(vis: ast::Visibility) -> ~str {
@@ -700,60 +747,62 @@ pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> ~str {
     }
 }
 
-pub fn print_visibility(s: &mut State, vis: ast::Visibility) {
+pub fn print_visibility(s: &mut State, vis: ast::Visibility) -> io::IoResult<()> {
     match vis {
         ast::Private | ast::Public =>
-        word_nbsp(s, visibility_to_str(vis)),
+            if_ok!(word_nbsp(s, visibility_to_str(vis))),
         ast::Inherited => ()
     }
+    Ok(())
 }
 
 pub fn print_struct(s: &mut State,
                     struct_def: &ast::StructDef,
                     generics: &ast::Generics,
                     ident: ast::Ident,
-                    span: codemap::Span) {
-    print_ident(s, ident);
-    print_generics(s, generics);
+                    span: codemap::Span) -> io::IoResult<()> {
+    if_ok!(print_ident(s, ident));
+    if_ok!(print_generics(s, generics));
     if ast_util::struct_def_is_tuple_like(struct_def) {
         if !struct_def.fields.is_empty() {
-            popen(s);
-            commasep(s, Inconsistent, struct_def.fields, |s, field| {
+            if_ok!(popen(s));
+            if_ok!(commasep(s, Inconsistent, struct_def.fields, |s, field| {
                 match field.node.kind {
                     ast::NamedField(..) => fail!("unexpected named field"),
                     ast::UnnamedField => {
-                        maybe_print_comment(s, field.span.lo);
-                        print_type(s, field.node.ty);
+                        if_ok!(maybe_print_comment(s, field.span.lo));
+                        if_ok!(print_type(s, field.node.ty));
                     }
                 }
-            });
-            pclose(s);
+                Ok(())
+            }));
+            if_ok!(pclose(s));
         }
-        word(&mut s.s, ";");
-        end(s);
-        end(s); // close the outer-box
+        if_ok!(word(&mut s.s, ";"));
+        if_ok!(end(s));
+        end(s) // close the outer-box
     } else {
-        nbsp(s);
-        bopen(s);
-        hardbreak_if_not_bol(s);
+        if_ok!(nbsp(s));
+        if_ok!(bopen(s));
+        if_ok!(hardbreak_if_not_bol(s));
 
         for field in struct_def.fields.iter() {
             match field.node.kind {
                 ast::UnnamedField => fail!("unexpected unnamed field"),
                 ast::NamedField(ident, visibility) => {
-                    hardbreak_if_not_bol(s);
-                    maybe_print_comment(s, field.span.lo);
-                    print_outer_attributes(s, field.node.attrs);
-                    print_visibility(s, visibility);
-                    print_ident(s, ident);
-                    word_nbsp(s, ":");
-                    print_type(s, field.node.ty);
-                    word(&mut s.s, ",");
+                    if_ok!(hardbreak_if_not_bol(s));
+                    if_ok!(maybe_print_comment(s, field.span.lo));
+                    if_ok!(print_outer_attributes(s, field.node.attrs));
+                    if_ok!(print_visibility(s, visibility));
+                    if_ok!(print_ident(s, ident));
+                    if_ok!(word_nbsp(s, ":"));
+                    if_ok!(print_type(s, field.node.ty));
+                    if_ok!(word(&mut s.s, ","));
                 }
             }
         }
 
-        bclose(s, span);
+        bclose(s, span)
     }
 }
 
@@ -764,191 +813,219 @@ pub fn print_struct(s: &mut State,
 /// appropriate macro, transcribe back into the grammar we just parsed from,
 /// and then pretty-print the resulting AST nodes (so, e.g., we print
 /// expression arguments as expressions). It can be done! I think.
-pub fn print_tt(s: &mut State, tt: &ast::TokenTree) {
+pub fn print_tt(s: &mut State, tt: &ast::TokenTree) -> io::IoResult<()> {
     match *tt {
-      ast::TTDelim(ref tts) => print_tts(s, &(tts.as_slice())),
-      ast::TTTok(_, ref tk) => {
-          word(&mut s.s, parse::token::to_str(s.intr, tk));
-      }
-      ast::TTSeq(_, ref tts, ref sep, zerok) => {
-        word(&mut s.s, "$(");
-        for tt_elt in (*tts).iter() { print_tt(s, tt_elt); }
-        word(&mut s.s, ")");
-        match *sep {
-          Some(ref tk) => word(&mut s.s, parse::token::to_str(s.intr, tk)),
-          None => ()
+        ast::TTDelim(ref tts) => print_tts(s, &(tts.as_slice())),
+        ast::TTTok(_, ref tk) => {
+            word(&mut s.s, parse::token::to_str(s.intr, tk))
         }
-        word(&mut s.s, if zerok { "*" } else { "+" });
-      }
-      ast::TTNonterminal(_, name) => {
-        word(&mut s.s, "$");
-        print_ident(s, name);
-      }
+        ast::TTSeq(_, ref tts, ref sep, zerok) => {
+            if_ok!(word(&mut s.s, "$("));
+            for tt_elt in (*tts).iter() {
+                if_ok!(print_tt(s, tt_elt));
+            }
+            if_ok!(word(&mut s.s, ")"));
+            match *sep {
+                Some(ref tk) => {
+                    if_ok!(word(&mut s.s, parse::token::to_str(s.intr, tk)));
+                }
+                None => ()
+            }
+            word(&mut s.s, if zerok { "*" } else { "+" })
+        }
+        ast::TTNonterminal(_, name) => {
+            if_ok!(word(&mut s.s, "$"));
+            print_ident(s, name)
+        }
     }
 }
 
-pub fn print_tts(s: &mut State, tts: & &[ast::TokenTree]) {
-    ibox(s, 0);
+pub fn print_tts(s: &mut State, tts: & &[ast::TokenTree]) -> io::IoResult<()> {
+    if_ok!(ibox(s, 0));
     for (i, tt) in tts.iter().enumerate() {
         if i != 0 {
-            space(&mut s.s);
+            if_ok!(space(&mut s.s));
         }
-        print_tt(s, tt);
+        if_ok!(print_tt(s, tt));
     }
-    end(s);
+    end(s)
 }
 
-pub fn print_variant(s: &mut State, v: &ast::Variant) {
-    print_visibility(s, v.node.vis);
+pub fn print_variant(s: &mut State, v: &ast::Variant) -> io::IoResult<()> {
+    if_ok!(print_visibility(s, v.node.vis));
     match v.node.kind {
         ast::TupleVariantKind(ref args) => {
-            print_ident(s, v.node.name);
+            if_ok!(print_ident(s, v.node.name));
             if !args.is_empty() {
-                popen(s);
-                fn print_variant_arg(s: &mut State, arg: &ast::VariantArg) {
-                    print_type(s, arg.ty);
+                if_ok!(popen(s));
+                fn print_variant_arg(s: &mut State,
+                                     arg: &ast::VariantArg) -> io::IoResult<()> {
+                    print_type(s, arg.ty)
                 }
-                commasep(s, Consistent, *args, print_variant_arg);
-                pclose(s);
+                if_ok!(commasep(s, Consistent, *args, print_variant_arg));
+                if_ok!(pclose(s));
             }
         }
         ast::StructVariantKind(struct_def) => {
-            head(s, "");
+            if_ok!(head(s, ""));
             let generics = ast_util::empty_generics();
-            print_struct(s, struct_def, &generics, v.node.name, v.span);
+            if_ok!(print_struct(s, struct_def, &generics, v.node.name, v.span));
         }
     }
     match v.node.disr_expr {
       Some(d) => {
-        space(&mut s.s);
-        word_space(s, "=");
-        print_expr(s, d);
+        if_ok!(space(&mut s.s));
+        if_ok!(word_space(s, "="));
+        if_ok!(print_expr(s, d));
       }
       _ => ()
     }
+    Ok(())
 }
 
-pub fn print_ty_method(s: &mut State, m: &ast::TypeMethod) {
-    hardbreak_if_not_bol(s);
-    maybe_print_comment(s, m.span.lo);
-    print_outer_attributes(s, m.attrs);
-    print_ty_fn(s,
-                None,
-                None,
-                &None,
-                m.purity,
-                ast::Many,
-                m.decl,
-                Some(m.ident),
-                &None,
-                Some(&m.generics),
-                Some(m.explicit_self.node));
-    word(&mut s.s, ";");
+pub fn print_ty_method(s: &mut State, m: &ast::TypeMethod) -> io::IoResult<()> {
+    if_ok!(hardbreak_if_not_bol(s));
+    if_ok!(maybe_print_comment(s, m.span.lo));
+    if_ok!(print_outer_attributes(s, m.attrs));
+    if_ok!(print_ty_fn(s,
+                       None,
+                       None,
+                       &None,
+                       m.purity,
+                       ast::Many,
+                       m.decl,
+                       Some(m.ident),
+                       &None,
+                       Some(&m.generics),
+                       Some(m.explicit_self.node)));
+    word(&mut s.s, ";")
 }
 
-pub fn print_trait_method(s: &mut State, m: &ast::TraitMethod) {
+pub fn print_trait_method(s: &mut State,
+                          m: &ast::TraitMethod) -> io::IoResult<()> {
     match *m {
         Required(ref ty_m) => print_ty_method(s, ty_m),
         Provided(m) => print_method(s, m)
     }
 }
 
-pub fn print_method(s: &mut State, meth: &ast::Method) {
-    hardbreak_if_not_bol(s);
-    maybe_print_comment(s, meth.span.lo);
-    print_outer_attributes(s, meth.attrs);
-    print_fn(s, meth.decl, Some(meth.purity), AbiSet::Rust(),
-             meth.ident, &meth.generics, Some(meth.explicit_self.node),
-             meth.vis);
-    word(&mut s.s, " ");
-    print_block_with_attrs(s, meth.body, meth.attrs);
+pub fn print_method(s: &mut State, meth: &ast::Method) -> io::IoResult<()> {
+    if_ok!(hardbreak_if_not_bol(s));
+    if_ok!(maybe_print_comment(s, meth.span.lo));
+    if_ok!(print_outer_attributes(s, meth.attrs));
+    if_ok!(print_fn(s, meth.decl, Some(meth.purity), AbiSet::Rust(),
+                    meth.ident, &meth.generics, Some(meth.explicit_self.node),
+                    meth.vis));
+    if_ok!(word(&mut s.s, " "));
+    print_block_with_attrs(s, meth.body, meth.attrs)
 }
 
-pub fn print_outer_attributes(s: &mut State, attrs: &[ast::Attribute]) {
+pub fn print_outer_attributes(s: &mut State,
+                              attrs: &[ast::Attribute]) -> io::IoResult<()> {
     let mut count = 0;
     for attr in attrs.iter() {
         match attr.node.style {
-          ast::AttrOuter => { print_attribute(s, attr); count += 1; }
+          ast::AttrOuter => {
+              if_ok!(print_attribute(s, attr));
+              count += 1;
+          }
           _ => {/* fallthrough */ }
         }
     }
-    if count > 0 { hardbreak_if_not_bol(s); }
+    if count > 0 {
+        if_ok!(hardbreak_if_not_bol(s));
+    }
+    Ok(())
 }
 
-pub fn print_inner_attributes(s: &mut State, attrs: &[ast::Attribute]) {
+pub fn print_inner_attributes(s: &mut State,
+                              attrs: &[ast::Attribute]) -> io::IoResult<()> {
     let mut count = 0;
     for attr in attrs.iter() {
         match attr.node.style {
           ast::AttrInner => {
-            print_attribute(s, attr);
+            if_ok!(print_attribute(s, attr));
             if !attr.node.is_sugared_doc {
-                word(&mut s.s, ";");
+                if_ok!(word(&mut s.s, ";"));
             }
             count += 1;
           }
           _ => {/* fallthrough */ }
         }
     }
-    if count > 0 { hardbreak_if_not_bol(s); }
+    if count > 0 {
+        if_ok!(hardbreak_if_not_bol(s));
+    }
+    Ok(())
 }
 
-pub fn print_attribute(s: &mut State, attr: &ast::Attribute) {
-    hardbreak_if_not_bol(s);
-    maybe_print_comment(s, attr.span.lo);
+pub fn print_attribute(s: &mut State, attr: &ast::Attribute) -> io::IoResult<()> {
+    if_ok!(hardbreak_if_not_bol(s));
+    if_ok!(maybe_print_comment(s, attr.span.lo));
     if attr.node.is_sugared_doc {
         let comment = attr.value_str().unwrap();
+<<<<<<< HEAD
         word(&mut s.s, comment.get());
+=======
+        if_ok!(word(&mut s.s, comment));
+>>>>>>> syntax: Remove io_error usage
     } else {
-        word(&mut s.s, "#[");
-        print_meta_item(s, attr.meta());
-        word(&mut s.s, "]");
+        if_ok!(word(&mut s.s, "#["));
+        if_ok!(print_meta_item(s, attr.meta()));
+        if_ok!(word(&mut s.s, "]"));
     }
+    Ok(())
 }
 
 
-pub fn print_stmt(s: &mut State, st: &ast::Stmt) {
-    maybe_print_comment(s, st.span.lo);
+pub fn print_stmt(s: &mut State, st: &ast::Stmt) -> io::IoResult<()> {
+    if_ok!(maybe_print_comment(s, st.span.lo));
     match st.node {
       ast::StmtDecl(decl, _) => {
-        print_decl(s, decl);
+        if_ok!(print_decl(s, decl));
       }
       ast::StmtExpr(expr, _) => {
-        space_if_not_bol(s);
-        print_expr(s, expr);
+        if_ok!(space_if_not_bol(s));
+        if_ok!(print_expr(s, expr));
       }
       ast::StmtSemi(expr, _) => {
-        space_if_not_bol(s);
-        print_expr(s, expr);
-        word(&mut s.s, ";");
+        if_ok!(space_if_not_bol(s));
+        if_ok!(print_expr(s, expr));
+        if_ok!(word(&mut s.s, ";"));
       }
       ast::StmtMac(ref mac, semi) => {
-        space_if_not_bol(s);
-        print_mac(s, mac);
-        if semi { word(&mut s.s, ";"); }
+        if_ok!(space_if_not_bol(s));
+        if_ok!(print_mac(s, mac));
+        if semi {
+            if_ok!(word(&mut s.s, ";"));
+        }
       }
     }
-    if parse::classify::stmt_ends_with_semi(st) { word(&mut s.s, ";"); }
-    maybe_print_trailing_comment(s, st.span, None);
+    if parse::classify::stmt_ends_with_semi(st) {
+        if_ok!(word(&mut s.s, ";"));
+    }
+    maybe_print_trailing_comment(s, st.span, None)
 }
 
-pub fn print_block(s: &mut State, blk: &ast::Block) {
-    print_possibly_embedded_block(s, blk, BlockNormal, indent_unit);
+pub fn print_block(s: &mut State, blk: &ast::Block) -> io::IoResult<()> {
+    print_possibly_embedded_block(s, blk, BlockNormal, indent_unit)
 }
 
-pub fn print_block_unclosed(s: &mut State, blk: &ast::Block) {
+pub fn print_block_unclosed(s: &mut State, blk: &ast::Block) -> io::IoResult<()> {
     print_possibly_embedded_block_(s, blk, BlockNormal, indent_unit, &[],
-                                 false);
+                                   false)
 }
 
-pub fn print_block_unclosed_indent(s: &mut State, blk: &ast::Block, indented: uint) {
-    print_possibly_embedded_block_(s, blk, BlockNormal, indented, &[], false);
+pub fn print_block_unclosed_indent(s: &mut State, blk: &ast::Block,
+                                   indented: uint) -> io::IoResult<()> {
+    print_possibly_embedded_block_(s, blk, BlockNormal, indented, &[], false)
 }
 
 pub fn print_block_with_attrs(s: &mut State,
                               blk: &ast::Block,
-                              attrs: &[ast::Attribute]) {
+                              attrs: &[ast::Attribute]) -> io::IoResult<()> {
     print_possibly_embedded_block_(s, blk, BlockNormal, indent_unit, attrs,
-                                  true);
+                                  true)
 }
 
 enum EmbedType {
@@ -959,9 +1036,9 @@ enum EmbedType {
 pub fn print_possibly_embedded_block(s: &mut State,
                                      blk: &ast::Block,
                                      embedded: EmbedType,
-                                     indented: uint) {
+                                     indented: uint) -> io::IoResult<()> {
     print_possibly_embedded_block_(
-        s, blk, embedded, indented, &[], true);
+        s, blk, embedded, indented, &[], true)
 }
 
 pub fn print_possibly_embedded_block_(s: &mut State,
@@ -969,102 +1046,123 @@ pub fn print_possibly_embedded_block_(s: &mut State,
                                       embedded: EmbedType,
                                       indented: uint,
                                       attrs: &[ast::Attribute],
-                                      close_box: bool) {
+                                      close_box: bool) -> io::IoResult<()> {
     match blk.rules {
-      ast::UnsafeBlock(..) => word_space(s, "unsafe"),
+      ast::UnsafeBlock(..) => if_ok!(word_space(s, "unsafe")),
       ast::DefaultBlock => ()
     }
-    maybe_print_comment(s, blk.span.lo);
+    if_ok!(maybe_print_comment(s, blk.span.lo));
     {
         let ann_node = NodeBlock(s, blk);
-        s.ann.pre(ann_node);
+        if_ok!(s.ann.pre(ann_node));
     }
-    match embedded {
+    if_ok!(match embedded {
         BlockBlockFn => end(s),
         BlockNormal => bopen(s)
+    });
+
+    if_ok!(print_inner_attributes(s, attrs));
+
+    for vi in blk.view_items.iter() {
+        if_ok!(print_view_item(s, vi));
     }
-
-    print_inner_attributes(s, attrs);
-
-    for vi in blk.view_items.iter() { print_view_item(s, vi); }
     for st in blk.stmts.iter() {
-        print_stmt(s, *st);
+        if_ok!(print_stmt(s, *st));
     }
     match blk.expr {
       Some(expr) => {
-        space_if_not_bol(s);
-        print_expr(s, expr);
-        maybe_print_trailing_comment(s, expr.span, Some(blk.span.hi));
+        if_ok!(space_if_not_bol(s));
+        if_ok!(print_expr(s, expr));
+        if_ok!(maybe_print_trailing_comment(s, expr.span, Some(blk.span.hi)));
       }
       _ => ()
     }
-    bclose_maybe_open(s, blk.span, indented, close_box);
+    if_ok!(bclose_maybe_open(s, blk.span, indented, close_box));
     {
         let ann_node = NodeBlock(s, blk);
-        s.ann.post(ann_node);
+        if_ok!(s.ann.post(ann_node));
     }
+    Ok(())
 }
 
 pub fn print_if(s: &mut State, test: &ast::Expr, blk: &ast::Block,
-                elseopt: Option<@ast::Expr>, chk: bool) {
-    head(s, "if");
-    if chk { word_nbsp(s, "check"); }
-    print_expr(s, test);
-    space(&mut s.s);
-    print_block(s, blk);
-    fn do_else(s: &mut State, els: Option<@ast::Expr>) {
+                elseopt: Option<@ast::Expr>, chk: bool) -> io::IoResult<()> {
+    if_ok!(head(s, "if"));
+    if chk { if_ok!(word_nbsp(s, "check")); }
+    if_ok!(print_expr(s, test));
+    if_ok!(space(&mut s.s));
+    if_ok!(print_block(s, blk));
+    fn do_else(s: &mut State, els: Option<@ast::Expr>) -> io::IoResult<()> {
         match els {
-          Some(_else) => {
-            match _else.node {
-              // "another else-if"
-              ast::ExprIf(i, t, e) => {
-                cbox(s, indent_unit - 1u);
-                ibox(s, 0u);
-                word(&mut s.s, " else if ");
-                print_expr(s, i);
-                space(&mut s.s);
-                print_block(s, t);
-                do_else(s, e);
-              }
-              // "final else"
-              ast::ExprBlock(b) => {
-                cbox(s, indent_unit - 1u);
-                ibox(s, 0u);
-                word(&mut s.s, " else ");
-                print_block(s, b);
-              }
-              // BLEAH, constraints would be great here
-              _ => {
-                  fail!("print_if saw if with weird alternative");
-              }
+            Some(_else) => {
+                match _else.node {
+                    // "another else-if"
+                    ast::ExprIf(i, t, e) => {
+                        if_ok!(cbox(s, indent_unit - 1u));
+                        if_ok!(ibox(s, 0u));
+                        if_ok!(word(&mut s.s, " else if "));
+                        if_ok!(print_expr(s, i));
+                        if_ok!(space(&mut s.s));
+                        if_ok!(print_block(s, t));
+                        if_ok!(do_else(s, e));
+                    }
+                    // "final else"
+                    ast::ExprBlock(b) => {
+                        if_ok!(cbox(s, indent_unit - 1u));
+                        if_ok!(ibox(s, 0u));
+                        if_ok!(word(&mut s.s, " else "));
+                        if_ok!(print_block(s, b));
+                    }
+                    // BLEAH, constraints would be great here
+                    _ => {
+                        fail!("print_if saw if with weird alternative");
+                    }
+                }
             }
-          }
-          _ => {/* fall through */ }
+            _ => {/* fall through */ }
         }
+        Ok(())
     }
-    do_else(s, elseopt);
+    do_else(s, elseopt)
 }
 
-pub fn print_mac(s: &mut State, m: &ast::Mac) {
+pub fn print_mac(s: &mut State, m: &ast::Mac) -> io::IoResult<()> {
     match m.node {
       // I think it's reasonable to hide the ctxt here:
       ast::MacInvocTT(ref pth, ref tts, _) => {
-        print_path(s, pth, false);
-        word(&mut s.s, "!");
-        popen(s);
-        print_tts(s, &tts.as_slice());
-        pclose(s);
+        if_ok!(print_path(s, pth, false));
+        if_ok!(word(&mut s.s, "!"));
+        if_ok!(popen(s));
+        if_ok!(print_tts(s, &tts.as_slice()));
+        pclose(s)
       }
     }
 }
 
+<<<<<<< HEAD
 pub fn print_expr_vstore(s: &mut State, t: ast::ExprVstore) {
+=======
+pub fn print_vstore(s: &mut State, t: ast::Vstore) -> io::IoResult<()> {
+    match t {
+        ast::VstoreFixed(Some(i)) => word(&mut s.s, format!("{}", i)),
+        ast::VstoreFixed(None) => word(&mut s.s, "_"),
+        ast::VstoreUniq => word(&mut s.s, "~"),
+        ast::VstoreBox => word(&mut s.s, "@"),
+        ast::VstoreSlice(ref r) => {
+            if_ok!(word(&mut s.s, "&"));
+            print_opt_lifetime(s, r)
+        }
+    }
+}
+
+pub fn print_expr_vstore(s: &mut State, t: ast::ExprVstore) -> io::IoResult<()> {
+>>>>>>> syntax: Remove io_error usage
     match t {
       ast::ExprVstoreUniq => word(&mut s.s, "~"),
       ast::ExprVstoreSlice => word(&mut s.s, "&"),
       ast::ExprVstoreMutSlice => {
-        word(&mut s.s, "&");
-        word(&mut s.s, "mut");
+        if_ok!(word(&mut s.s, "&"));
+        word(&mut s.s, "mut")
       }
     }
 }
@@ -1072,222 +1170,227 @@ pub fn print_expr_vstore(s: &mut State, t: ast::ExprVstore) {
 pub fn print_call_pre(s: &mut State,
                       sugar: ast::CallSugar,
                       base_args: &mut ~[@ast::Expr])
-                   -> Option<@ast::Expr> {
+                   -> io::IoResult<Option<@ast::Expr>> {
     match sugar {
         ast::ForSugar => {
-            head(s, "for");
-            Some(base_args.pop().unwrap())
+            if_ok!(head(s, "for"));
+            Ok(Some(base_args.pop().unwrap()))
         }
-        ast::NoSugar => None
+        ast::NoSugar => Ok(None)
     }
 }
 
 pub fn print_call_post(s: &mut State,
                        sugar: ast::CallSugar,
                        blk: &Option<@ast::Expr>,
-                       base_args: &mut ~[@ast::Expr]) {
+                       base_args: &mut ~[@ast::Expr]) -> io::IoResult<()> {
     if sugar == ast::NoSugar || !base_args.is_empty() {
-        popen(s);
-        commasep_exprs(s, Inconsistent, *base_args);
-        pclose(s);
+        if_ok!(popen(s));
+        if_ok!(commasep_exprs(s, Inconsistent, *base_args));
+        if_ok!(pclose(s));
     }
     if sugar != ast::NoSugar {
-        nbsp(s);
+        if_ok!(nbsp(s));
         // not sure if this can happen
-        print_expr(s, blk.unwrap());
+        if_ok!(print_expr(s, blk.unwrap()));
     }
+    Ok(())
 }
 
-pub fn print_expr(s: &mut State, expr: &ast::Expr) {
-    fn print_field(s: &mut State, field: &ast::Field) {
-        ibox(s, indent_unit);
-        print_ident(s, field.ident.node);
-        word_space(s, ":");
-        print_expr(s, field.expr);
-        end(s);
+pub fn print_expr(s: &mut State, expr: &ast::Expr) -> io::IoResult<()> {
+    fn print_field(s: &mut State, field: &ast::Field) -> io::IoResult<()> {
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(print_ident(s, field.ident.node));
+        if_ok!(word_space(s, ":"));
+        if_ok!(print_expr(s, field.expr));
+        if_ok!(end(s));
+        Ok(())
     }
     fn get_span(field: &ast::Field) -> codemap::Span { return field.span; }
 
-    maybe_print_comment(s, expr.span.lo);
-    ibox(s, indent_unit);
+    if_ok!(maybe_print_comment(s, expr.span.lo));
+    if_ok!(ibox(s, indent_unit));
     {
         let ann_node = NodeExpr(s, expr);
-        s.ann.pre(ann_node);
+        if_ok!(s.ann.pre(ann_node));
     }
     match expr.node {
         ast::ExprVstore(e, v) => {
-            print_expr_vstore(s, v);
-            print_expr(s, e);
+            if_ok!(print_expr_vstore(s, v));
+            if_ok!(print_expr(s, e));
         },
         ast::ExprBox(p, e) => {
-            word(&mut s.s, "box");
-            word(&mut s.s, "(");
-            print_expr(s, p);
-            word_space(s, ")");
-            print_expr(s, e);
+            if_ok!(word(&mut s.s, "box"));
+            if_ok!(word(&mut s.s, "("));
+            if_ok!(print_expr(s, p));
+            if_ok!(word_space(s, ")"));
+            if_ok!(print_expr(s, e));
         }
       ast::ExprVec(ref exprs, mutbl) => {
-        ibox(s, indent_unit);
-        word(&mut s.s, "[");
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(word(&mut s.s, "["));
         if mutbl == ast::MutMutable {
-            word(&mut s.s, "mut");
-            if exprs.len() > 0u { nbsp(s); }
+            if_ok!(word(&mut s.s, "mut"));
+            if exprs.len() > 0u { if_ok!(nbsp(s)); }
         }
-        commasep_exprs(s, Inconsistent, *exprs);
-        word(&mut s.s, "]");
-        end(s);
+        if_ok!(commasep_exprs(s, Inconsistent, *exprs));
+        if_ok!(word(&mut s.s, "]"));
+        if_ok!(end(s));
       }
 
       ast::ExprRepeat(element, count, mutbl) => {
-        ibox(s, indent_unit);
-        word(&mut s.s, "[");
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(word(&mut s.s, "["));
         if mutbl == ast::MutMutable {
-            word(&mut s.s, "mut");
-            nbsp(s);
+            if_ok!(word(&mut s.s, "mut"));
+            if_ok!(nbsp(s));
         }
-        print_expr(s, element);
-        word(&mut s.s, ",");
-        word(&mut s.s, "..");
-        print_expr(s, count);
-        word(&mut s.s, "]");
-        end(s);
+        if_ok!(print_expr(s, element));
+        if_ok!(word(&mut s.s, ","));
+        if_ok!(word(&mut s.s, ".."));
+        if_ok!(print_expr(s, count));
+        if_ok!(word(&mut s.s, "]"));
+        if_ok!(end(s));
       }
 
       ast::ExprStruct(ref path, ref fields, wth) => {
-        print_path(s, path, true);
-        word(&mut s.s, "{");
-        commasep_cmnt(s, Consistent, (*fields), print_field, get_span);
+        if_ok!(print_path(s, path, true));
+        if_ok!(word(&mut s.s, "{"));
+        if_ok!(commasep_cmnt(s, Consistent, (*fields), print_field, get_span));
         match wth {
             Some(expr) => {
-                ibox(s, indent_unit);
+                if_ok!(ibox(s, indent_unit));
                 if !fields.is_empty() {
-                    word(&mut s.s, ",");
-                    space(&mut s.s);
+                    if_ok!(word(&mut s.s, ","));
+                    if_ok!(space(&mut s.s));
                 }
-                word(&mut s.s, "..");
-                print_expr(s, expr);
-                end(s);
+                if_ok!(word(&mut s.s, ".."));
+                if_ok!(print_expr(s, expr));
+                if_ok!(end(s));
             }
-            _ => (word(&mut s.s, ","))
+            _ => if_ok!(word(&mut s.s, ","))
         }
-        word(&mut s.s, "}");
+        if_ok!(word(&mut s.s, "}"));
       }
       ast::ExprTup(ref exprs) => {
-        popen(s);
-        commasep_exprs(s, Inconsistent, *exprs);
+        if_ok!(popen(s));
+        if_ok!(commasep_exprs(s, Inconsistent, *exprs));
         if exprs.len() == 1 {
-            word(&mut s.s, ",");
+            if_ok!(word(&mut s.s, ","));
         }
-        pclose(s);
+        if_ok!(pclose(s));
       }
       ast::ExprCall(func, ref args, sugar) => {
         let mut base_args = (*args).clone();
-        let blk = print_call_pre(s, sugar, &mut base_args);
-        print_expr(s, func);
-        print_call_post(s, sugar, &blk, &mut base_args);
+        let blk = if_ok!(print_call_pre(s, sugar, &mut base_args));
+        if_ok!(print_expr(s, func));
+        if_ok!(print_call_post(s, sugar, &blk, &mut base_args));
       }
       ast::ExprMethodCall(_, ident, ref tys, ref args, sugar) => {
         let mut base_args = args.slice_from(1).to_owned();
-        let blk = print_call_pre(s, sugar, &mut base_args);
-        print_expr(s, args[0]);
-        word(&mut s.s, ".");
-        print_ident(s, ident);
+        let blk = if_ok!(print_call_pre(s, sugar, &mut base_args));
+        if_ok!(print_expr(s, args[0]));
+        if_ok!(word(&mut s.s, "."));
+        if_ok!(print_ident(s, ident));
         if tys.len() > 0u {
-            word(&mut s.s, "::<");
-            commasep(s, Inconsistent, *tys, print_type_ref);
-            word(&mut s.s, ">");
+            if_ok!(word(&mut s.s, "::<"));
+            if_ok!(commasep(s, Inconsistent, *tys, print_type_ref));
+            if_ok!(word(&mut s.s, ">"));
         }
-        print_call_post(s, sugar, &blk, &mut base_args);
+        if_ok!(print_call_post(s, sugar, &blk, &mut base_args));
       }
       ast::ExprBinary(_, op, lhs, rhs) => {
-        print_expr(s, lhs);
-        space(&mut s.s);
-        word_space(s, ast_util::binop_to_str(op));
-        print_expr(s, rhs);
+        if_ok!(print_expr(s, lhs));
+        if_ok!(space(&mut s.s));
+        if_ok!(word_space(s, ast_util::binop_to_str(op)));
+        if_ok!(print_expr(s, rhs));
       }
       ast::ExprUnary(_, op, expr) => {
-        word(&mut s.s, ast_util::unop_to_str(op));
-        print_expr(s, expr);
+        if_ok!(word(&mut s.s, ast_util::unop_to_str(op)));
+        if_ok!(print_expr(s, expr));
       }
       ast::ExprAddrOf(m, expr) => {
-        word(&mut s.s, "&");
-        print_mutability(s, m);
+        if_ok!(word(&mut s.s, "&"));
+        if_ok!(print_mutability(s, m));
         // Avoid `& &e` => `&&e`.
         match (m, &expr.node) {
-            (ast::MutImmutable, &ast::ExprAddrOf(..)) => space(&mut s.s),
+            (ast::MutImmutable, &ast::ExprAddrOf(..)) => if_ok!(space(&mut s.s)),
             _ => { }
         }
-        print_expr(s, expr);
+        if_ok!(print_expr(s, expr));
       }
-      ast::ExprLit(lit) => print_literal(s, lit),
+      ast::ExprLit(lit) => if_ok!(print_literal(s, lit)),
       ast::ExprCast(expr, ty) => {
-        print_expr(s, expr);
-        space(&mut s.s);
-        word_space(s, "as");
-        print_type(s, ty);
+        if_ok!(print_expr(s, expr));
+        if_ok!(space(&mut s.s));
+        if_ok!(word_space(s, "as"));
+        if_ok!(print_type(s, ty));
       }
       ast::ExprIf(test, blk, elseopt) => {
-        print_if(s, test, blk, elseopt, false);
+        if_ok!(print_if(s, test, blk, elseopt, false));
       }
       ast::ExprWhile(test, blk) => {
-        head(s, "while");
-        print_expr(s, test);
-        space(&mut s.s);
-        print_block(s, blk);
+        if_ok!(head(s, "while"));
+        if_ok!(print_expr(s, test));
+        if_ok!(space(&mut s.s));
+        if_ok!(print_block(s, blk));
       }
       ast::ExprForLoop(pat, iter, blk, opt_ident) => {
         for ident in opt_ident.iter() {
-            word(&mut s.s, "'");
-            print_ident(s, *ident);
-            word_space(s, ":");
+            if_ok!(word(&mut s.s, "'"));
+            if_ok!(print_ident(s, *ident));
+            if_ok!(word_space(s, ":"));
         }
-        head(s, "for");
-        print_pat(s, pat);
-        space(&mut s.s);
-        word_space(s, "in");
-        print_expr(s, iter);
-        space(&mut s.s);
-        print_block(s, blk);
+        if_ok!(head(s, "for"));
+        if_ok!(print_pat(s, pat));
+        if_ok!(space(&mut s.s));
+        if_ok!(word_space(s, "in"));
+        if_ok!(print_expr(s, iter));
+        if_ok!(space(&mut s.s));
+        if_ok!(print_block(s, blk));
       }
       ast::ExprLoop(blk, opt_ident) => {
         for ident in opt_ident.iter() {
-            word(&mut s.s, "'");
-            print_ident(s, *ident);
-            word_space(s, ":");
+            if_ok!(word(&mut s.s, "'"));
+            if_ok!(print_ident(s, *ident));
+            if_ok!(word_space(s, ":"));
         }
-        head(s, "loop");
-        space(&mut s.s);
-        print_block(s, blk);
+        if_ok!(head(s, "loop"));
+        if_ok!(space(&mut s.s));
+        if_ok!(print_block(s, blk));
       }
       ast::ExprMatch(expr, ref arms) => {
-        cbox(s, indent_unit);
-        ibox(s, 4);
-        word_nbsp(s, "match");
-        print_expr(s, expr);
-        space(&mut s.s);
-        bopen(s);
+        if_ok!(cbox(s, indent_unit));
+        if_ok!(ibox(s, 4));
+        if_ok!(word_nbsp(s, "match"));
+        if_ok!(print_expr(s, expr));
+        if_ok!(space(&mut s.s));
+        if_ok!(bopen(s));
         let len = arms.len();
         for (i, arm) in arms.iter().enumerate() {
-            space(&mut s.s);
-            cbox(s, indent_unit);
-            ibox(s, 0u);
+            if_ok!(space(&mut s.s));
+            if_ok!(cbox(s, indent_unit));
+            if_ok!(ibox(s, 0u));
             let mut first = true;
             for p in arm.pats.iter() {
                 if first {
                     first = false;
-                } else { space(&mut s.s); word_space(s, "|"); }
-                print_pat(s, *p);
+                } else {
+                    if_ok!(space(&mut s.s));
+                    if_ok!(word_space(s, "|"));
+                }
+                if_ok!(print_pat(s, *p));
             }
-            space(&mut s.s);
+            if_ok!(space(&mut s.s));
             match arm.guard {
               Some(e) => {
-                word_space(s, "if");
-                print_expr(s, e);
-                space(&mut s.s);
+                if_ok!(word_space(s, "if"));
+                if_ok!(print_expr(s, e));
+                if_ok!(space(&mut s.s));
               }
               None => ()
             }
-            word_space(s, "=>");
+            if_ok!(word_space(s, "=>"));
 
             // Extract the expression from the extra block the parser adds
             // in the case of foo => expr
@@ -1301,28 +1404,28 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) {
                         match expr.node {
                             ast::ExprBlock(blk) => {
                                 // the block will close the pattern's ibox
-                                print_block_unclosed_indent(
-                                    s, blk, indent_unit);
+                                if_ok!(print_block_unclosed_indent(
+                                    s, blk, indent_unit));
                             }
                             _ => {
-                                end(s); // close the ibox for the pattern
-                                print_expr(s, expr);
+                                if_ok!(end(s)); // close the ibox for the pattern
+                                if_ok!(print_expr(s, expr));
                             }
                         }
                         if !expr_is_simple_block(expr)
                             && i < len - 1 {
-                            word(&mut s.s, ",");
+                            if_ok!(word(&mut s.s, ","));
                         }
-                        end(s); // close enclosing cbox
+                        if_ok!(end(s)); // close enclosing cbox
                     }
                     None => fail!()
                 }
             } else {
                 // the block will close the pattern's ibox
-                print_block_unclosed_indent(s, arm.body, indent_unit);
+                if_ok!(print_block_unclosed_indent(s, arm.body, indent_unit));
             }
         }
-        bclose_(s, expr.span, indent_unit);
+        if_ok!(bclose_(s, expr.span, indent_unit));
       }
       ast::ExprFnBlock(decl, body) => {
         // in do/for blocks we don't want to show an empty
@@ -1330,26 +1433,26 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) {
         // we are inside.
         //
         // if !decl.inputs.is_empty() {
-        print_fn_block_args(s, decl);
-        space(&mut s.s);
+        if_ok!(print_fn_block_args(s, decl));
+        if_ok!(space(&mut s.s));
         // }
         assert!(body.stmts.is_empty());
         assert!(body.expr.is_some());
         // we extract the block, so as not to create another set of boxes
         match body.expr.unwrap().node {
             ast::ExprBlock(blk) => {
-                print_block_unclosed(s, blk);
+                if_ok!(print_block_unclosed(s, blk));
             }
             _ => {
                 // this is a bare expression
-                print_expr(s, body.expr.unwrap());
-                end(s); // need to close a box
+                if_ok!(print_expr(s, body.expr.unwrap()));
+                if_ok!(end(s)); // need to close a box
             }
         }
         // a box will be closed by print_expr, but we didn't want an overall
         // wrapper so we closed the corresponding opening. so create an
         // empty box to satisfy the close.
-        ibox(s, 0);
+        if_ok!(ibox(s, 0));
       }
       ast::ExprProc(decl, body) => {
         // in do/for blocks we don't want to show an empty
@@ -1357,100 +1460,104 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) {
         // we are inside.
         //
         // if !decl.inputs.is_empty() {
-        print_proc_args(s, decl);
-        space(&mut s.s);
+        if_ok!(print_proc_args(s, decl));
+        if_ok!(space(&mut s.s));
         // }
         assert!(body.stmts.is_empty());
         assert!(body.expr.is_some());
         // we extract the block, so as not to create another set of boxes
         match body.expr.unwrap().node {
             ast::ExprBlock(blk) => {
-                print_block_unclosed(s, blk);
+                if_ok!(print_block_unclosed(s, blk));
             }
             _ => {
                 // this is a bare expression
-                print_expr(s, body.expr.unwrap());
-                end(s); // need to close a box
+                if_ok!(print_expr(s, body.expr.unwrap()));
+                if_ok!(end(s)); // need to close a box
             }
         }
         // a box will be closed by print_expr, but we didn't want an overall
         // wrapper so we closed the corresponding opening. so create an
         // empty box to satisfy the close.
-        ibox(s, 0);
+        if_ok!(ibox(s, 0));
       }
       ast::ExprBlock(blk) => {
         // containing cbox, will be closed by print-block at }
-        cbox(s, indent_unit);
+        if_ok!(cbox(s, indent_unit));
         // head-box, will be closed by print-block after {
-        ibox(s, 0u);
-        print_block(s, blk);
+        if_ok!(ibox(s, 0u));
+        if_ok!(print_block(s, blk));
       }
       ast::ExprAssign(lhs, rhs) => {
-        print_expr(s, lhs);
-        space(&mut s.s);
-        word_space(s, "=");
-        print_expr(s, rhs);
+        if_ok!(print_expr(s, lhs));
+        if_ok!(space(&mut s.s));
+        if_ok!(word_space(s, "="));
+        if_ok!(print_expr(s, rhs));
       }
       ast::ExprAssignOp(_, op, lhs, rhs) => {
-        print_expr(s, lhs);
-        space(&mut s.s);
-        word(&mut s.s, ast_util::binop_to_str(op));
-        word_space(s, "=");
-        print_expr(s, rhs);
+        if_ok!(print_expr(s, lhs));
+        if_ok!(space(&mut s.s));
+        if_ok!(word(&mut s.s, ast_util::binop_to_str(op)));
+        if_ok!(word_space(s, "="));
+        if_ok!(print_expr(s, rhs));
       }
       ast::ExprField(expr, id, ref tys) => {
-        print_expr(s, expr);
-        word(&mut s.s, ".");
-        print_ident(s, id);
+        if_ok!(print_expr(s, expr));
+        if_ok!(word(&mut s.s, "."));
+        if_ok!(print_ident(s, id));
         if tys.len() > 0u {
-            word(&mut s.s, "::<");
-            commasep(s, Inconsistent, *tys, print_type_ref);
-            word(&mut s.s, ">");
+            if_ok!(word(&mut s.s, "::<"));
+            if_ok!(commasep(s, Inconsistent, *tys, print_type_ref));
+            if_ok!(word(&mut s.s, ">"));
         }
       }
       ast::ExprIndex(_, expr, index) => {
-        print_expr(s, expr);
-        word(&mut s.s, "[");
-        print_expr(s, index);
-        word(&mut s.s, "]");
+        if_ok!(print_expr(s, expr));
+        if_ok!(word(&mut s.s, "["));
+        if_ok!(print_expr(s, index));
+        if_ok!(word(&mut s.s, "]"));
       }
-      ast::ExprPath(ref path) => print_path(s, path, true),
+      ast::ExprPath(ref path) => if_ok!(print_path(s, path, true)),
       ast::ExprBreak(opt_ident) => {
-        word(&mut s.s, "break");
-        space(&mut s.s);
+        if_ok!(word(&mut s.s, "break"));
+        if_ok!(space(&mut s.s));
         for ident in opt_ident.iter() {
-            word(&mut s.s, "'");
-            print_name(s, *ident);
-            space(&mut s.s);
+            if_ok!(word(&mut s.s, "'"));
+            if_ok!(print_name(s, *ident));
+            if_ok!(space(&mut s.s));
         }
       }
       ast::ExprAgain(opt_ident) => {
-        word(&mut s.s, "continue");
-        space(&mut s.s);
+        if_ok!(word(&mut s.s, "continue"));
+        if_ok!(space(&mut s.s));
         for ident in opt_ident.iter() {
-            word(&mut s.s, "'");
-            print_name(s, *ident);
-            space(&mut s.s)
+            if_ok!(word(&mut s.s, "'"));
+            if_ok!(print_name(s, *ident));
+            if_ok!(space(&mut s.s))
         }
       }
       ast::ExprRet(result) => {
-        word(&mut s.s, "return");
+        if_ok!(word(&mut s.s, "return"));
         match result {
-          Some(expr) => { word(&mut s.s, " "); print_expr(s, expr); }
+          Some(expr) => {
+              if_ok!(word(&mut s.s, " "));
+              if_ok!(print_expr(s, expr));
+          }
           _ => ()
         }
       }
       ast::ExprLogLevel => {
-        word(&mut s.s, "__log_level");
-        popen(s);
-        pclose(s);
+        if_ok!(word(&mut s.s, "__log_level"));
+        if_ok!(popen(s));
+        if_ok!(pclose(s));
       }
       ast::ExprInlineAsm(ref a) => {
         if a.volatile {
-            word(&mut s.s, "__volatile__ asm!");
+            if_ok!(word(&mut s.s, "__volatile__ asm!"));
         } else {
-            word(&mut s.s, "asm!");
+            if_ok!(word(&mut s.s, "asm!"));
         }
+<<<<<<< HEAD
         popen(s);
         print_string(s, a.asm.get(), a.asm_str_style);
         word_space(s, ":");
@@ -1472,58 +1579,87 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) {
         word_space(s, ":");
         print_string(s, a.clobbers.get(), ast::CookedStr);
         pclose(s);
+=======
+        if_ok!(popen(s));
+        if_ok!(print_string(s, a.asm, a.asm_str_style));
+        if_ok!(word_space(s, ":"));
+        for &(co, o) in a.outputs.iter() {
+            if_ok!(print_string(s, co, ast::CookedStr));
+            if_ok!(popen(s));
+            if_ok!(print_expr(s, o));
+            if_ok!(pclose(s));
+            if_ok!(word_space(s, ","));
+        }
+        if_ok!(word_space(s, ":"));
+        for &(co, o) in a.inputs.iter() {
+            if_ok!(print_string(s, co, ast::CookedStr));
+            if_ok!(popen(s));
+            if_ok!(print_expr(s, o));
+            if_ok!(pclose(s));
+            if_ok!(word_space(s, ","));
+        }
+        if_ok!(word_space(s, ":"));
+        if_ok!(print_string(s, a.clobbers, ast::CookedStr));
+        if_ok!(pclose(s));
+>>>>>>> syntax: Remove io_error usage
       }
-      ast::ExprMac(ref m) => print_mac(s, m),
+      ast::ExprMac(ref m) => if_ok!(print_mac(s, m)),
       ast::ExprParen(e) => {
-          popen(s);
-          print_expr(s, e);
-          pclose(s);
+          if_ok!(popen(s));
+          if_ok!(print_expr(s, e));
+          if_ok!(pclose(s));
       }
     }
     {
         let ann_node = NodeExpr(s, expr);
-        s.ann.post(ann_node);
+        if_ok!(s.ann.post(ann_node));
     }
-    end(s);
+    end(s)
 }
 
-pub fn print_local_decl(s: &mut State, loc: &ast::Local) {
-    print_pat(s, loc.pat);
+pub fn print_local_decl(s: &mut State, loc: &ast::Local) -> io::IoResult<()> {
+    if_ok!(print_pat(s, loc.pat));
     match loc.ty.node {
         ast::TyInfer => {}
-        _ => { word_space(s, ":"); print_type(s, loc.ty); }
+        _ => {
+            if_ok!(word_space(s, ":"));
+            if_ok!(print_type(s, loc.ty));
+        }
     }
+    Ok(())
 }
 
-pub fn print_decl(s: &mut State, decl: &ast::Decl) {
-    maybe_print_comment(s, decl.span.lo);
+pub fn print_decl(s: &mut State, decl: &ast::Decl) -> io::IoResult<()> {
+    if_ok!(maybe_print_comment(s, decl.span.lo));
     match decl.node {
       ast::DeclLocal(ref loc) => {
-        space_if_not_bol(s);
-        ibox(s, indent_unit);
-        word_nbsp(s, "let");
+        if_ok!(space_if_not_bol(s));
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(word_nbsp(s, "let"));
 
-        fn print_local(s: &mut State, loc: &ast::Local) {
-            ibox(s, indent_unit);
-            print_local_decl(s, loc);
-            end(s);
+        fn print_local(s: &mut State, loc: &ast::Local) -> io::IoResult<()> {
+            if_ok!(ibox(s, indent_unit));
+            if_ok!(print_local_decl(s, loc));
+            if_ok!(end(s));
             match loc.init {
               Some(init) => {
-                nbsp(s);
-                word_space(s, "=");
-                print_expr(s, init);
+                if_ok!(nbsp(s));
+                if_ok!(word_space(s, "="));
+                if_ok!(print_expr(s, init));
               }
               _ => ()
             }
+            Ok(())
         }
 
-        print_local(s, *loc);
-        end(s);
+        if_ok!(print_local(s, *loc));
+        end(s)
       }
       ast::DeclItem(item) => print_item(s, item)
     }
 }
 
+<<<<<<< HEAD
 pub fn print_ident(s: &mut State, ident: ast::Ident) {
     let string = token::get_ident(ident.name);
     word(&mut s.s, string.get());
@@ -1532,22 +1668,33 @@ pub fn print_ident(s: &mut State, ident: ast::Ident) {
 pub fn print_name(s: &mut State, name: ast::Name) {
     let string = token::get_ident(name);
     word(&mut s.s, string.get());
+=======
+pub fn print_ident(s: &mut State, ident: ast::Ident) -> io::IoResult<()> {
+    word(&mut s.s, ident_to_str(&ident))
 }
 
-pub fn print_for_decl(s: &mut State, loc: &ast::Local, coll: &ast::Expr) {
-    print_local_decl(s, loc);
-    space(&mut s.s);
-    word_space(s, "in");
-    print_expr(s, coll);
+pub fn print_name(s: &mut State, name: ast::Name) -> io::IoResult<()> {
+    word(&mut s.s, interner_get(name))
+>>>>>>> syntax: Remove io_error usage
+}
+
+pub fn print_for_decl(s: &mut State, loc: &ast::Local,
+                      coll: &ast::Expr) -> io::IoResult<()> {
+    if_ok!(print_local_decl(s, loc));
+    if_ok!(space(&mut s.s));
+    if_ok!(word_space(s, "in"));
+    print_expr(s, coll)
 }
 
 fn print_path_(s: &mut State,
                path: &ast::Path,
                colons_before_params: bool,
-               opt_bounds: &Option<OptVec<ast::TyParamBound>>) {
-    maybe_print_comment(s, path.span.lo);
+               opt_bounds: &Option<OptVec<ast::TyParamBound>>)
+    -> io::IoResult<()>
+{
+    if_ok!(maybe_print_comment(s, path.span.lo));
     if path.global {
-        word(&mut s.s, "::");
+        if_ok!(word(&mut s.s, "::"));
     }
 
     let mut first = true;
@@ -1555,198 +1702,207 @@ fn print_path_(s: &mut State,
         if first {
             first = false
         } else {
-            word(&mut s.s, "::")
+            if_ok!(word(&mut s.s, "::"))
         }
 
-        print_ident(s, segment.identifier);
+        if_ok!(print_ident(s, segment.identifier));
 
         // If this is the last segment, print the bounds.
         if i == path.segments.len() - 1 {
             match *opt_bounds {
                 None => {}
-                Some(ref bounds) => print_bounds(s, bounds, true),
+                Some(ref bounds) => if_ok!(print_bounds(s, bounds, true)),
             }
         }
 
         if !segment.lifetimes.is_empty() || !segment.types.is_empty() {
             if colons_before_params {
-                word(&mut s.s, "::")
+                if_ok!(word(&mut s.s, "::"))
             }
-            word(&mut s.s, "<");
+            if_ok!(word(&mut s.s, "<"));
 
             let mut comma = false;
             for lifetime in segment.lifetimes.iter() {
                 if comma {
-                    word_space(s, ",")
+                    if_ok!(word_space(s, ","))
                 }
-                print_lifetime(s, lifetime);
+                if_ok!(print_lifetime(s, lifetime));
                 comma = true;
             }
 
             if !segment.types.is_empty() {
                 if comma {
-                    word_space(s, ",")
+                    if_ok!(word_space(s, ","))
                 }
-                commasep(s,
-                         Inconsistent,
-                         segment.types.map_to_vec(|&t| t),
-                         print_type_ref);
+                if_ok!(commasep(s,
+                                Inconsistent,
+                                segment.types.map_to_vec(|&t| t),
+                                print_type_ref));
             }
 
-            word(&mut s.s, ">")
+            if_ok!(word(&mut s.s, ">"))
         }
     }
+    Ok(())
 }
 
-pub fn print_path(s: &mut State, path: &ast::Path, colons_before_params: bool) {
+pub fn print_path(s: &mut State, path: &ast::Path,
+                  colons_before_params: bool) -> io::IoResult<()> {
     print_path_(s, path, colons_before_params, &None)
 }
 
 pub fn print_bounded_path(s: &mut State, path: &ast::Path,
-                          bounds: &Option<OptVec<ast::TyParamBound>>) {
+                          bounds: &Option<OptVec<ast::TyParamBound>>)
+    -> io::IoResult<()>
+{
     print_path_(s, path, false, bounds)
 }
 
-pub fn print_pat(s: &mut State, pat: &ast::Pat) {
-    maybe_print_comment(s, pat.span.lo);
+pub fn print_pat(s: &mut State, pat: &ast::Pat) -> io::IoResult<()> {
+    if_ok!(maybe_print_comment(s, pat.span.lo));
     {
         let ann_node = NodePat(s, pat);
-        s.ann.pre(ann_node);
+        if_ok!(s.ann.pre(ann_node));
     }
     /* Pat isn't normalized, but the beauty of it
      is that it doesn't matter */
     match pat.node {
-      ast::PatWild => word(&mut s.s, "_"),
-      ast::PatWildMulti => word(&mut s.s, ".."),
+      ast::PatWild => if_ok!(word(&mut s.s, "_")),
+      ast::PatWildMulti => if_ok!(word(&mut s.s, "..")),
       ast::PatIdent(binding_mode, ref path, sub) => {
           match binding_mode {
               ast::BindByRef(mutbl) => {
-                  word_nbsp(s, "ref");
-                  print_mutability(s, mutbl);
+                  if_ok!(word_nbsp(s, "ref"));
+                  if_ok!(print_mutability(s, mutbl));
               }
               ast::BindByValue(ast::MutImmutable) => {}
               ast::BindByValue(ast::MutMutable) => {
-                  word_nbsp(s, "mut");
+                  if_ok!(word_nbsp(s, "mut"));
               }
           }
-          print_path(s, path, true);
+          if_ok!(print_path(s, path, true));
           match sub {
               Some(p) => {
-                  word(&mut s.s, "@");
-                  print_pat(s, p);
+                  if_ok!(word(&mut s.s, "@"));
+                  if_ok!(print_pat(s, p));
               }
               None => ()
           }
       }
       ast::PatEnum(ref path, ref args_) => {
-        print_path(s, path, true);
+        if_ok!(print_path(s, path, true));
         match *args_ {
-          None => word(&mut s.s, "(..)"),
+          None => if_ok!(word(&mut s.s, "(..)")),
           Some(ref args) => {
             if !args.is_empty() {
-              popen(s);
-              commasep(s, Inconsistent, *args,
-                       |s, &p| print_pat(s, p));
-              pclose(s);
+              if_ok!(popen(s));
+              if_ok!(commasep(s, Inconsistent, *args,
+                              |s, &p| print_pat(s, p)));
+              if_ok!(pclose(s));
             } else { }
           }
         }
       }
       ast::PatStruct(ref path, ref fields, etc) => {
-        print_path(s, path, true);
-        word(&mut s.s, "{");
-        fn print_field(s: &mut State, f: &ast::FieldPat) {
-            cbox(s, indent_unit);
-            print_ident(s, f.ident);
-            word_space(s, ":");
-            print_pat(s, f.pat);
-            end(s);
+        if_ok!(print_path(s, path, true));
+        if_ok!(word(&mut s.s, "{"));
+        fn print_field(s: &mut State, f: &ast::FieldPat) -> io::IoResult<()> {
+            if_ok!(cbox(s, indent_unit));
+            if_ok!(print_ident(s, f.ident));
+            if_ok!(word_space(s, ":"));
+            if_ok!(print_pat(s, f.pat));
+            if_ok!(end(s));
+            Ok(())
         }
         fn get_span(f: &ast::FieldPat) -> codemap::Span { return f.pat.span; }
-        commasep_cmnt(s, Consistent, *fields,
-                      |s, f| print_field(s,f),
-                      get_span);
+        if_ok!(commasep_cmnt(s, Consistent, *fields,
+                             |s, f| print_field(s,f),
+                             get_span));
         if etc {
-            if fields.len() != 0u { word_space(s, ","); }
-            word(&mut s.s, "..");
+            if fields.len() != 0u { if_ok!(word_space(s, ",")); }
+            if_ok!(word(&mut s.s, ".."));
         }
-        word(&mut s.s, "}");
+        if_ok!(word(&mut s.s, "}"));
       }
       ast::PatTup(ref elts) => {
-        popen(s);
-        commasep(s, Inconsistent, *elts, |s, &p| print_pat(s, p));
+        if_ok!(popen(s));
+        if_ok!(commasep(s, Inconsistent, *elts, |s, &p| print_pat(s, p)));
         if elts.len() == 1 {
-            word(&mut s.s, ",");
+            if_ok!(word(&mut s.s, ","));
         }
-        pclose(s);
+        if_ok!(pclose(s));
       }
       ast::PatUniq(inner) => {
-          word(&mut s.s, "~");
-          print_pat(s, inner);
+          if_ok!(word(&mut s.s, "~"));
+          if_ok!(print_pat(s, inner));
       }
       ast::PatRegion(inner) => {
-          word(&mut s.s, "&");
-          print_pat(s, inner);
+          if_ok!(word(&mut s.s, "&"));
+          if_ok!(print_pat(s, inner));
       }
-      ast::PatLit(e) => print_expr(s, e),
+      ast::PatLit(e) => if_ok!(print_expr(s, e)),
       ast::PatRange(begin, end) => {
-        print_expr(s, begin);
-        space(&mut s.s);
-        word(&mut s.s, "..");
-        print_expr(s, end);
+        if_ok!(print_expr(s, begin));
+        if_ok!(space(&mut s.s));
+        if_ok!(word(&mut s.s, ".."));
+        if_ok!(print_expr(s, end));
       }
       ast::PatVec(ref before, slice, ref after) => {
-        word(&mut s.s, "[");
-        commasep(s, Inconsistent, *before, |s, &p| print_pat(s, p));
+        if_ok!(word(&mut s.s, "["));
+        if_ok!(commasep(s, Inconsistent, *before, |s, &p| print_pat(s, p)));
         for &p in slice.iter() {
-            if !before.is_empty() { word_space(s, ","); }
+            if !before.is_empty() { if_ok!(word_space(s, ",")); }
             match *p {
                 ast::Pat { node: ast::PatWildMulti, .. } => {
                     // this case is handled by print_pat
                 }
-                _ => word(&mut s.s, ".."),
+                _ => if_ok!(word(&mut s.s, "..")),
             }
-            print_pat(s, p);
-            if !after.is_empty() { word_space(s, ","); }
+            if_ok!(print_pat(s, p));
+            if !after.is_empty() { if_ok!(word_space(s, ",")); }
         }
-        commasep(s, Inconsistent, *after, |s, &p| print_pat(s, p));
-        word(&mut s.s, "]");
+        if_ok!(commasep(s, Inconsistent, *after, |s, &p| print_pat(s, p)));
+        if_ok!(word(&mut s.s, "]"));
       }
     }
     {
         let ann_node = NodePat(s, pat);
-        s.ann.post(ann_node);
+        if_ok!(s.ann.post(ann_node));
     }
+    Ok(())
 }
 
-pub fn explicit_self_to_str(explicit_self: &ast::ExplicitSelf_, intr: @IdentInterner) -> ~str {
-    to_str(explicit_self, |a, &b| { print_explicit_self(a, b, ast::MutImmutable); () }, intr)
+pub fn explicit_self_to_str(explicit_self: &ast::ExplicitSelf_,
+                            intr: @IdentInterner) -> ~str {
+    to_str(explicit_self, |a, &b| {
+        print_explicit_self(a, b, ast::MutImmutable).map(|_| ())
+    }, intr)
 }
 
 // Returns whether it printed anything
 fn print_explicit_self(s: &mut State,
                        explicit_self: ast::ExplicitSelf_,
-                       mutbl: ast::Mutability) -> bool {
-    print_mutability(s, mutbl);
+                       mutbl: ast::Mutability) -> io::IoResult<bool> {
+    if_ok!(print_mutability(s, mutbl));
     match explicit_self {
-        ast::SelfStatic => { return false; }
+        ast::SelfStatic => { return Ok(false); }
         ast::SelfValue => {
-            word(&mut s.s, "self");
+            if_ok!(word(&mut s.s, "self"));
         }
         ast::SelfUniq => {
-            word(&mut s.s, "~self");
+            if_ok!(word(&mut s.s, "~self"));
         }
         ast::SelfRegion(ref lt, m) => {
-            word(&mut s.s, "&");
-            print_opt_lifetime(s, lt);
-            print_mutability(s, m);
-            word(&mut s.s, "self");
+            if_ok!(word(&mut s.s, "&"));
+            if_ok!(print_opt_lifetime(s, lt));
+            if_ok!(print_mutability(s, m));
+            if_ok!(word(&mut s.s, "self"));
         }
         ast::SelfBox => {
-            word(&mut s.s, "@self");
+            if_ok!(word(&mut s.s, "@self"));
         }
     }
-    return true;
+    return Ok(true);
 }
 
 pub fn print_fn(s: &mut State,
@@ -1756,20 +1912,24 @@ pub fn print_fn(s: &mut State,
                 name: ast::Ident,
                 generics: &ast::Generics,
                 opt_explicit_self: Option<ast::ExplicitSelf_>,
-                vis: ast::Visibility) {
-    head(s, "");
-    print_fn_header_info(s, opt_explicit_self, purity, abis, ast::Many, None, vis);
-    nbsp(s);
-    print_ident(s, name);
-    print_generics(s, generics);
-    print_fn_args_and_ret(s, decl, opt_explicit_self);
+                vis: ast::Visibility) -> io::IoResult<()> {
+    if_ok!(head(s, ""));
+    if_ok!(print_fn_header_info(s, opt_explicit_self, purity, abis,
+                                ast::Many, None, vis));
+    if_ok!(nbsp(s));
+    if_ok!(print_ident(s, name));
+    if_ok!(print_generics(s, generics));
+    if_ok!(print_fn_args_and_ret(s, decl, opt_explicit_self));
+    Ok(())
 }
 
 pub fn print_fn_args(s: &mut State, decl: &ast::FnDecl,
-                 opt_explicit_self: Option<ast::ExplicitSelf_>) {
+                     opt_explicit_self: Option<ast::ExplicitSelf_>)
+    -> io::IoResult<()>
+{
     // It is unfortunate to duplicate the commasep logic, but we want the
     // self type and the args all in the same box.
-    rbox(s, 0u, Inconsistent);
+    if_ok!(rbox(s, 0u, Inconsistent));
     let mut first = true;
     for &explicit_self in opt_explicit_self.iter() {
         let m = match explicit_self {
@@ -1779,7 +1939,7 @@ pub fn print_fn_args(s: &mut State, decl: &ast::FnDecl,
                 _ => ast::MutImmutable
             }
         };
-        first = !print_explicit_self(s, explicit_self, m);
+        first = !if_ok!(print_explicit_self(s, explicit_self, m));
     }
 
     // HACK(eddyb) ignore the separately printed self argument.
@@ -1790,107 +1950,116 @@ pub fn print_fn_args(s: &mut State, decl: &ast::FnDecl,
     };
 
     for arg in args.iter() {
-        if first { first = false; } else { word_space(s, ","); }
-        print_arg(s, arg);
+        if first { first = false; } else { if_ok!(word_space(s, ",")); }
+        if_ok!(print_arg(s, arg));
     }
 
-    end(s);
+    end(s)
 }
 
 pub fn print_fn_args_and_ret(s: &mut State, decl: &ast::FnDecl,
-                             opt_explicit_self: Option<ast::ExplicitSelf_>) {
-    popen(s);
-    print_fn_args(s, decl, opt_explicit_self);
+                             opt_explicit_self: Option<ast::ExplicitSelf_>)
+    -> io::IoResult<()>
+{
+    if_ok!(popen(s));
+    if_ok!(print_fn_args(s, decl, opt_explicit_self));
     if decl.variadic {
-        word(&mut s.s, ", ...");
+        if_ok!(word(&mut s.s, ", ..."));
     }
-    pclose(s);
+    if_ok!(pclose(s));
 
-    maybe_print_comment(s, decl.output.span.lo);
+    if_ok!(maybe_print_comment(s, decl.output.span.lo));
     match decl.output.node {
         ast::TyNil => {}
         _ => {
-            space_if_not_bol(s);
-            word_space(s, "->");
-            print_type(s, decl.output);
+            if_ok!(space_if_not_bol(s));
+            if_ok!(word_space(s, "->"));
+            if_ok!(print_type(s, decl.output));
         }
     }
+    Ok(())
 }
 
-pub fn print_fn_block_args(s: &mut State, decl: &ast::FnDecl) {
-    word(&mut s.s, "|");
-    print_fn_args(s, decl, None);
-    word(&mut s.s, "|");
+pub fn print_fn_block_args(s: &mut State,
+                           decl: &ast::FnDecl) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, "|"));
+    if_ok!(print_fn_args(s, decl, None));
+    if_ok!(word(&mut s.s, "|"));
 
     match decl.output.node {
         ast::TyInfer => {}
         _ => {
-            space_if_not_bol(s);
-            word_space(s, "->");
-            print_type(s, decl.output);
+            if_ok!(space_if_not_bol(s));
+            if_ok!(word_space(s, "->"));
+            if_ok!(print_type(s, decl.output));
         }
     }
 
-    maybe_print_comment(s, decl.output.span.lo);
+    maybe_print_comment(s, decl.output.span.lo)
 }
 
-pub fn print_proc_args(s: &mut State, decl: &ast::FnDecl) {
-    word(&mut s.s, "proc");
-    word(&mut s.s, "(");
-    print_fn_args(s, decl, None);
-    word(&mut s.s, ")");
+pub fn print_proc_args(s: &mut State, decl: &ast::FnDecl) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, "proc"));
+    if_ok!(word(&mut s.s, "("));
+    if_ok!(print_fn_args(s, decl, None));
+    if_ok!(word(&mut s.s, ")"));
 
     match decl.output.node {
         ast::TyInfer => {}
         _ => {
-            space_if_not_bol(s);
-            word_space(s, "->");
-            print_type(s, decl.output);
+            if_ok!(space_if_not_bol(s));
+            if_ok!(word_space(s, "->"));
+            if_ok!(print_type(s, decl.output));
         }
     }
 
-    maybe_print_comment(s, decl.output.span.lo);
+    maybe_print_comment(s, decl.output.span.lo)
 }
 
 pub fn print_bounds(s: &mut State, bounds: &OptVec<ast::TyParamBound>,
-                    print_colon_anyway: bool) {
+                    print_colon_anyway: bool) -> io::IoResult<()> {
     if !bounds.is_empty() {
-        word(&mut s.s, ":");
+        if_ok!(word(&mut s.s, ":"));
         let mut first = true;
         for bound in bounds.iter() {
-            nbsp(s);
+            if_ok!(nbsp(s));
             if first {
                 first = false;
             } else {
-                word_space(s, "+");
+                if_ok!(word_space(s, "+"));
             }
 
-            match *bound {
+            if_ok!(match *bound {
                 TraitTyParamBound(ref tref) => print_trait_ref(s, tref),
                 RegionTyParamBound => word(&mut s.s, "'static"),
-            }
+            })
         }
     } else if print_colon_anyway {
-        word(&mut s.s, ":");
+        if_ok!(word(&mut s.s, ":"));
     }
+    Ok(())
 }
 
-pub fn print_lifetime(s: &mut State, lifetime: &ast::Lifetime) {
-    word(&mut s.s, "'");
-    print_ident(s, lifetime.ident);
+pub fn print_lifetime(s: &mut State,
+                      lifetime: &ast::Lifetime) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, "'"));
+    print_ident(s, lifetime.ident)
 }
 
-pub fn print_generics(s: &mut State, generics: &ast::Generics) {
+pub fn print_generics(s: &mut State,
+                      generics: &ast::Generics) -> io::IoResult<()> {
     let total = generics.lifetimes.len() + generics.ty_params.len();
     if total > 0 {
-        word(&mut s.s, "<");
-        fn print_item(s: &mut State, generics: &ast::Generics, idx: uint) {
+        if_ok!(word(&mut s.s, "<"));
+        fn print_item(s: &mut State, generics: &ast::Generics,
+                      idx: uint) -> io::IoResult<()> {
             if idx < generics.lifetimes.len() {
                 let lifetime = generics.lifetimes.get(idx);
-                print_lifetime(s, lifetime);
+                print_lifetime(s, lifetime)
             } else {
                 let idx = idx - generics.lifetimes.len();
                 let param = generics.ty_params.get(idx);
+<<<<<<< HEAD
                 print_ident(s, param.ident);
                 print_bounds(s, &param.bounds, false);
                 match param.default {
@@ -1901,6 +2070,10 @@ pub fn print_generics(s: &mut State, generics: &ast::Generics) {
                     }
                     _ => {}
                 }
+=======
+                if_ok!(print_ident(s, param.ident));
+                print_bounds(s, &param.bounds, false)
+>>>>>>> syntax: Remove io_error usage
             }
         }
 
@@ -1909,15 +2082,17 @@ pub fn print_generics(s: &mut State, generics: &ast::Generics) {
             ints.push(i);
         }
 
-        commasep(s, Inconsistent, ints,
-                 |s, &i| print_item(s, generics, i));
-        word(&mut s.s, ">");
+        if_ok!(commasep(s, Inconsistent, ints,
+                        |s, &i| print_item(s, generics, i)));
+        if_ok!(word(&mut s.s, ">"));
     }
+    Ok(())
 }
 
-pub fn print_meta_item(s: &mut State, item: &ast::MetaItem) {
-    ibox(s, indent_unit);
+pub fn print_meta_item(s: &mut State, item: &ast::MetaItem) -> io::IoResult<()> {
+    if_ok!(ibox(s, indent_unit));
     match item.node {
+<<<<<<< HEAD
       ast::MetaWord(ref name) => word(&mut s.s, name.get()),
       ast::MetaNameValue(ref name, ref value) => {
         word_space(s, name.get());
@@ -1932,90 +2107,116 @@ pub fn print_meta_item(s: &mut State, item: &ast::MetaItem) {
                  items.as_slice(),
                  |p, &i| print_meta_item(p, i));
         pclose(s);
+=======
+      ast::MetaWord(name) => { if_ok!(word(&mut s.s, name)); }
+      ast::MetaNameValue(name, value) => {
+        if_ok!(word_space(s, name));
+        if_ok!(word_space(s, "="));
+        if_ok!(print_literal(s, &value));
+      }
+      ast::MetaList(name, ref items) => {
+        if_ok!(word(&mut s.s, name));
+        if_ok!(popen(s));
+        if_ok!(commasep(s,
+                        Consistent,
+                        items.as_slice(),
+                        |p, &i| print_meta_item(p, i)));
+        if_ok!(pclose(s));
+>>>>>>> syntax: Remove io_error usage
       }
     }
-    end(s);
+    end(s)
 }
 
-pub fn print_view_path(s: &mut State, vp: &ast::ViewPath) {
+pub fn print_view_path(s: &mut State, vp: &ast::ViewPath) -> io::IoResult<()> {
     match vp.node {
       ast::ViewPathSimple(ident, ref path, _) => {
         // FIXME(#6993) can't compare identifiers directly here
         if path.segments.last().unwrap().identifier.name != ident.name {
-            print_ident(s, ident);
-            space(&mut s.s);
-            word_space(s, "=");
+            if_ok!(print_ident(s, ident));
+            if_ok!(space(&mut s.s));
+            if_ok!(word_space(s, "="));
         }
-        print_path(s, path, false);
+        print_path(s, path, false)
       }
 
       ast::ViewPathGlob(ref path, _) => {
-        print_path(s, path, false);
-        word(&mut s.s, "::*");
+        if_ok!(print_path(s, path, false));
+        word(&mut s.s, "::*")
       }
 
       ast::ViewPathList(ref path, ref idents, _) => {
         if path.segments.is_empty() {
-            word(&mut s.s, "{");
+            if_ok!(word(&mut s.s, "{"));
         } else {
-            print_path(s, path, false);
-            word(&mut s.s, "::{");
+            if_ok!(print_path(s, path, false));
+            if_ok!(word(&mut s.s, "::{"));
         }
-        commasep(s, Inconsistent, (*idents), |s, w| {
-            print_ident(s, w.node.name);
-        });
-        word(&mut s.s, "}");
+        if_ok!(commasep(s, Inconsistent, (*idents), |s, w| {
+            print_ident(s, w.node.name)
+        }));
+        word(&mut s.s, "}")
       }
     }
 }
 
-pub fn print_view_paths(s: &mut State, vps: &[@ast::ViewPath]) {
-    commasep(s, Inconsistent, vps, |p, &vp| print_view_path(p, vp));
+pub fn print_view_paths(s: &mut State,
+                        vps: &[@ast::ViewPath]) -> io::IoResult<()> {
+    commasep(s, Inconsistent, vps, |p, &vp| print_view_path(p, vp))
 }
 
-pub fn print_view_item(s: &mut State, item: &ast::ViewItem) {
-    hardbreak_if_not_bol(s);
-    maybe_print_comment(s, item.span.lo);
-    print_outer_attributes(s, item.attrs);
-    print_visibility(s, item.vis);
+pub fn print_view_item(s: &mut State, item: &ast::ViewItem) -> io::IoResult<()> {
+    if_ok!(hardbreak_if_not_bol(s));
+    if_ok!(maybe_print_comment(s, item.span.lo));
+    if_ok!(print_outer_attributes(s, item.attrs));
+    if_ok!(print_visibility(s, item.vis));
     match item.node {
         ast::ViewItemExternMod(id, ref optional_path, _) => {
-            head(s, "extern mod");
-            print_ident(s, id);
+            if_ok!(head(s, "extern mod"));
+            if_ok!(print_ident(s, id));
             for &(ref p, style) in optional_path.iter() {
+<<<<<<< HEAD
                 space(&mut s.s);
                 word(&mut s.s, "=");
                 space(&mut s.s);
                 print_string(s, p.get(), style);
+=======
+                if_ok!(space(&mut s.s));
+                if_ok!(word(&mut s.s, "="));
+                if_ok!(space(&mut s.s));
+                if_ok!(print_string(s, *p, style));
+>>>>>>> syntax: Remove io_error usage
             }
         }
 
         ast::ViewItemUse(ref vps) => {
-            head(s, "use");
-            print_view_paths(s, *vps);
+            if_ok!(head(s, "use"));
+            if_ok!(print_view_paths(s, *vps));
         }
     }
-    word(&mut s.s, ";");
-    end(s); // end inner head-block
-    end(s); // end outer head-block
+    if_ok!(word(&mut s.s, ";"));
+    if_ok!(end(s)); // end inner head-block
+    if_ok!(end(s)); // end outer head-block
+    Ok(())
 }
 
-pub fn print_mutability(s: &mut State, mutbl: ast::Mutability) {
+pub fn print_mutability(s: &mut State,
+                        mutbl: ast::Mutability) -> io::IoResult<()> {
     match mutbl {
       ast::MutMutable => word_nbsp(s, "mut"),
-      ast::MutImmutable => {/* nothing */ }
+      ast::MutImmutable => Ok(()),
     }
 }
 
-pub fn print_mt(s: &mut State, mt: &ast::MutTy) {
-    print_mutability(s, mt.mutbl);
-    print_type(s, mt.ty);
+pub fn print_mt(s: &mut State, mt: &ast::MutTy) -> io::IoResult<()> {
+    if_ok!(print_mutability(s, mt.mutbl));
+    print_type(s, mt.ty)
 }
 
-pub fn print_arg(s: &mut State, input: &ast::Arg) {
-    ibox(s, indent_unit);
+pub fn print_arg(s: &mut State, input: &ast::Arg) -> io::IoResult<()> {
+    if_ok!(ibox(s, indent_unit));
     match input.ty.node {
-        ast::TyInfer => print_pat(s, input.pat),
+        ast::TyInfer => if_ok!(print_pat(s, input.pat)),
         _ => {
             match input.pat.node {
                 ast::PatIdent(_, ref path, _) if
@@ -2025,15 +2226,15 @@ pub fn print_arg(s: &mut State, input: &ast::Arg) {
                     // Do nothing.
                 }
                 _ => {
-                    print_pat(s, input.pat);
-                    word(&mut s.s, ":");
-                    space(&mut s.s);
+                    if_ok!(print_pat(s, input.pat));
+                    if_ok!(word(&mut s.s, ":"));
+                    if_ok!(space(&mut s.s));
                 }
             }
-            print_type(s, input.ty);
+            if_ok!(print_type(s, input.ty));
         }
     }
-    end(s);
+    end(s)
 }
 
 pub fn print_ty_fn(s: &mut State,
@@ -2046,120 +2247,137 @@ pub fn print_ty_fn(s: &mut State,
                    id: Option<ast::Ident>,
                    opt_bounds: &Option<OptVec<ast::TyParamBound>>,
                    generics: Option<&ast::Generics>,
-                   opt_explicit_self: Option<ast::ExplicitSelf_>) {
-    ibox(s, indent_unit);
+                   opt_explicit_self: Option<ast::ExplicitSelf_>)
+    -> io::IoResult<()>
+{
+    if_ok!(ibox(s, indent_unit));
 
     // Duplicates the logic in `print_fn_header_info()`.  This is because that
     // function prints the sigil in the wrong place.  That should be fixed.
     if opt_sigil == Some(ast::OwnedSigil) && onceness == ast::Once {
-        word(&mut s.s, "proc");
+        if_ok!(word(&mut s.s, "proc"));
     } else if opt_sigil == Some(ast::BorrowedSigil) {
-        print_extern_opt_abis(s, opt_abis);
+        if_ok!(print_extern_opt_abis(s, opt_abis));
         for lifetime in opt_region.iter() {
-            print_lifetime(s, lifetime);
+            if_ok!(print_lifetime(s, lifetime));
         }
-        print_purity(s, purity);
-        print_onceness(s, onceness);
+        if_ok!(print_purity(s, purity));
+        if_ok!(print_onceness(s, onceness));
     } else {
-        print_opt_abis_and_extern_if_nondefault(s, opt_abis);
-        print_opt_sigil(s, opt_sigil);
-        print_opt_lifetime(s, opt_region);
-        print_purity(s, purity);
-        print_onceness(s, onceness);
-        word(&mut s.s, "fn");
+        if_ok!(print_opt_abis_and_extern_if_nondefault(s, opt_abis));
+        if_ok!(print_opt_sigil(s, opt_sigil));
+        if_ok!(print_opt_lifetime(s, opt_region));
+        if_ok!(print_purity(s, purity));
+        if_ok!(print_onceness(s, onceness));
+        if_ok!(word(&mut s.s, "fn"));
     }
 
-    match id { Some(id) => { word(&mut s.s, " "); print_ident(s, id); } _ => () }
+    match id {
+        Some(id) => {
+            if_ok!(word(&mut s.s, " "));
+            if_ok!(print_ident(s, id));
+        }
+        _ => ()
+    }
 
     if opt_sigil != Some(ast::BorrowedSigil) {
         opt_bounds.as_ref().map(|bounds| print_bounds(s, bounds, true));
     }
 
-    match generics { Some(g) => print_generics(s, g), _ => () }
-    zerobreak(&mut s.s);
+    match generics { Some(g) => if_ok!(print_generics(s, g)), _ => () }
+    if_ok!(zerobreak(&mut s.s));
 
     if opt_sigil == Some(ast::BorrowedSigil) {
-        word(&mut s.s, "|");
+        if_ok!(word(&mut s.s, "|"));
     } else {
-        popen(s);
+        if_ok!(popen(s));
     }
 
-    print_fn_args(s, decl, opt_explicit_self);
+    if_ok!(print_fn_args(s, decl, opt_explicit_self));
 
     if opt_sigil == Some(ast::BorrowedSigil) {
-        word(&mut s.s, "|");
+        if_ok!(word(&mut s.s, "|"));
 
         opt_bounds.as_ref().map(|bounds| print_bounds(s, bounds, true));
     } else {
         if decl.variadic {
-            word(&mut s.s, ", ...");
+            if_ok!(word(&mut s.s, ", ..."));
         }
-        pclose(s);
+        if_ok!(pclose(s));
     }
 
-    maybe_print_comment(s, decl.output.span.lo);
+    if_ok!(maybe_print_comment(s, decl.output.span.lo));
 
     match decl.output.node {
         ast::TyNil => {}
         _ => {
-            space_if_not_bol(s);
-            ibox(s, indent_unit);
-            word_space(s, "->");
-            if decl.cf == ast::NoReturn { word_nbsp(s, "!"); }
-            else { print_type(s, decl.output); }
-            end(s);
+            if_ok!(space_if_not_bol(s));
+            if_ok!(ibox(s, indent_unit));
+            if_ok!(word_space(s, "->"));
+            if decl.cf == ast::NoReturn {
+                if_ok!(word_nbsp(s, "!"));
+            } else {
+                if_ok!(print_type(s, decl.output));
+            }
+            if_ok!(end(s));
         }
     }
 
-    end(s);
+    end(s)
 }
 
 pub fn maybe_print_trailing_comment(s: &mut State, span: codemap::Span,
-                                    next_pos: Option<BytePos>) {
+                                    next_pos: Option<BytePos>)
+    -> io::IoResult<()>
+{
     let cm;
-    match s.cm { Some(ccm) => cm = ccm, _ => return }
+    match s.cm { Some(ccm) => cm = ccm, _ => return Ok(()) }
     match next_comment(s) {
-      Some(ref cmnt) => {
-        if (*cmnt).style != comments::Trailing { return; }
-        let span_line = cm.lookup_char_pos(span.hi);
-        let comment_line = cm.lookup_char_pos((*cmnt).pos);
-        let mut next = (*cmnt).pos + BytePos(1);
-        match next_pos { None => (), Some(p) => next = p }
-        if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
-               span_line.line == comment_line.line {
-            print_comment(s, cmnt);
-            s.cur_cmnt_and_lit.cur_cmnt += 1u;
+        Some(ref cmnt) => {
+            if (*cmnt).style != comments::Trailing { return Ok(()) }
+            let span_line = cm.lookup_char_pos(span.hi);
+            let comment_line = cm.lookup_char_pos((*cmnt).pos);
+            let mut next = (*cmnt).pos + BytePos(1);
+            match next_pos { None => (), Some(p) => next = p }
+            if span.hi < (*cmnt).pos && (*cmnt).pos < next &&
+                span_line.line == comment_line.line {
+                    if_ok!(print_comment(s, cmnt));
+                    s.cur_cmnt_and_lit.cur_cmnt += 1u;
+                }
         }
-      }
-      _ => ()
+        _ => ()
     }
+    Ok(())
 }
 
-pub fn print_remaining_comments(s: &mut State) {
+pub fn print_remaining_comments(s: &mut State) -> io::IoResult<()> {
     // If there aren't any remaining comments, then we need to manually
     // make sure there is a line break at the end.
-    if next_comment(s).is_none() { hardbreak(&mut s.s); }
+    if next_comment(s).is_none() {
+        if_ok!(hardbreak(&mut s.s));
+    }
     loop {
         match next_comment(s) {
-          Some(ref cmnt) => {
-            print_comment(s, cmnt);
-            s.cur_cmnt_and_lit.cur_cmnt += 1u;
-          }
-          _ => break
+            Some(ref cmnt) => {
+                if_ok!(print_comment(s, cmnt));
+                s.cur_cmnt_and_lit.cur_cmnt += 1u;
+            }
+            _ => break
         }
     }
+    Ok(())
 }
 
-pub fn print_literal(s: &mut State, lit: &ast::Lit) {
-    maybe_print_comment(s, lit.span.lo);
+pub fn print_literal(s: &mut State, lit: &ast::Lit) -> io::IoResult<()> {
+    if_ok!(maybe_print_comment(s, lit.span.lo));
     match next_lit(s, lit.span.lo) {
       Some(ref ltrl) => {
-        word(&mut s.s, (*ltrl).lit);
-        return;
+        return word(&mut s.s, (*ltrl).lit);
       }
       _ => ()
     }
     match lit.node {
+<<<<<<< HEAD
       ast::LitStr(ref st, style) => print_string(s, st.get(), style),
       ast::LitChar(ch) => {
           let mut res = ~"'";
@@ -2176,19 +2394,52 @@ pub fn print_literal(s: &mut State, lit: &ast::Lit) {
             word(&mut s.s,
                  (i as u64).to_str_radix(10u)
                  + ast_util::int_ty_to_str(t));
+=======
+        ast::LitStr(st, style) => print_string(s, st, style),
+        ast::LitChar(ch) => {
+            let mut res = ~"'";
+            char::from_u32(ch).unwrap().escape_default(|c| res.push_char(c));
+            res.push_char('\'');
+            word(&mut s.s, res)
         }
-      }
-      ast::LitUint(u, t) => {
-        word(&mut s.s,
-             u.to_str_radix(10u)
-             + ast_util::uint_ty_to_str(t));
-      }
-      ast::LitIntUnsuffixed(i) => {
-        if i < 0_i64 {
-            word(&mut s.s, ~"-" + (-i as u64).to_str_radix(10u));
-        } else {
-            word(&mut s.s, (i as u64).to_str_radix(10u));
+        ast::LitInt(i, t) => {
+            if i < 0_i64 {
+                word(&mut s.s, ~"-" + (-i as u64).to_str_radix(10u)
+                               + ast_util::int_ty_to_str(t))
+            } else {
+                word(&mut s.s, (i as u64).to_str_radix(10u)
+                                + ast_util::int_ty_to_str(t))
+            }
+>>>>>>> syntax: Remove io_error usage
         }
+        ast::LitUint(u, t) => {
+            word(&mut s.s, u.to_str_radix(10u) + ast_util::uint_ty_to_str(t))
+        }
+        ast::LitIntUnsuffixed(i) => {
+            if i < 0_i64 {
+                word(&mut s.s, ~"-" + (-i as u64).to_str_radix(10u))
+            } else {
+                word(&mut s.s, (i as u64).to_str_radix(10u))
+            }
+        }
+        ast::LitFloat(f, t) => {
+            word(&mut s.s, f.to_owned() + ast_util::float_ty_to_str(t))
+        }
+        ast::LitFloatUnsuffixed(f) => word(&mut s.s, f),
+        ast::LitNil => word(&mut s.s, "()"),
+        ast::LitBool(val) => {
+            if val { word(&mut s.s, "true") } else { word(&mut s.s, "false") }
+        }
+        ast::LitBinary(arr) => {
+            if_ok!(ibox(s, indent_unit));
+            if_ok!(word(&mut s.s, "["));
+            if_ok!(commasep_cmnt(s, Inconsistent, arr,
+                                 |s, u| word(&mut s.s, format!("{}", *u)),
+                                 |_| lit.span));
+            if_ok!(word(&mut s.s, "]"));
+            end(s)
+        }
+<<<<<<< HEAD
       }
       ast::LitFloat(ref f, t) => {
         word(&mut s.s, f.get() + ast_util::float_ty_to_str(t));
@@ -2206,6 +2457,8 @@ pub fn print_literal(s: &mut State, lit: &ast::Lit) {
         word(&mut s.s, "]");
         end(s);
       }
+=======
+>>>>>>> syntax: Remove io_error usage
     }
 }
 
@@ -2228,49 +2481,55 @@ pub fn next_lit(s: &mut State, pos: BytePos) -> Option<comments::Literal> {
     }
 }
 
-pub fn maybe_print_comment(s: &mut State, pos: BytePos) {
+pub fn maybe_print_comment(s: &mut State, pos: BytePos) -> io::IoResult<()> {
     loop {
         match next_comment(s) {
           Some(ref cmnt) => {
             if (*cmnt).pos < pos {
-                print_comment(s, cmnt);
+                if_ok!(print_comment(s, cmnt));
                 s.cur_cmnt_and_lit.cur_cmnt += 1u;
             } else { break; }
           }
           _ => break
         }
     }
+    Ok(())
 }
 
-pub fn print_comment(s: &mut State, cmnt: &comments::Comment) {
+pub fn print_comment(s: &mut State,
+                     cmnt: &comments::Comment) -> io::IoResult<()> {
     match cmnt.style {
         comments::Mixed => {
             assert_eq!(cmnt.lines.len(), 1u);
-            zerobreak(&mut s.s);
-            word(&mut s.s, cmnt.lines[0]);
-            zerobreak(&mut s.s);
+            if_ok!(zerobreak(&mut s.s));
+            if_ok!(word(&mut s.s, cmnt.lines[0]));
+            if_ok!(zerobreak(&mut s.s));
         }
         comments::Isolated => {
-            pprust::hardbreak_if_not_bol(s);
+            if_ok!(pprust::hardbreak_if_not_bol(s));
             for line in cmnt.lines.iter() {
                 // Don't print empty lines because they will end up as trailing
                 // whitespace
-                if !line.is_empty() { word(&mut s.s, *line); }
-                hardbreak(&mut s.s);
+                if !line.is_empty() {
+                    if_ok!(word(&mut s.s, *line));
+                }
+                if_ok!(hardbreak(&mut s.s));
             }
         }
         comments::Trailing => {
-            word(&mut s.s, " ");
+            if_ok!(word(&mut s.s, " "));
             if cmnt.lines.len() == 1u {
-                word(&mut s.s, cmnt.lines[0]);
-                hardbreak(&mut s.s);
+                if_ok!(word(&mut s.s, cmnt.lines[0]));
+                if_ok!(hardbreak(&mut s.s));
             } else {
-                ibox(s, 0u);
+                if_ok!(ibox(s, 0u));
                 for line in cmnt.lines.iter() {
-                    if !line.is_empty() { word(&mut s.s, *line); }
-                    hardbreak(&mut s.s);
+                    if !line.is_empty() {
+                        if_ok!(word(&mut s.s, *line));
+                    }
+                    if_ok!(hardbreak(&mut s.s));
                 }
-                end(s);
+                if_ok!(end(s));
             }
         }
         comments::BlankLine => {
@@ -2279,19 +2538,23 @@ pub fn print_comment(s: &mut State, cmnt: &comments::Comment) {
                 pp::String(s, _) => ";" == s,
                 _ => false
             };
-            if is_semi || is_begin(s) || is_end(s) { hardbreak(&mut s.s); }
-            hardbreak(&mut s.s);
+            if is_semi || is_begin(s) || is_end(s) {
+                if_ok!(hardbreak(&mut s.s));
+            }
+            if_ok!(hardbreak(&mut s.s));
         }
     }
+    Ok(())
 }
 
-pub fn print_string(s: &mut State, st: &str, style: ast::StrStyle) {
+pub fn print_string(s: &mut State, st: &str,
+                    style: ast::StrStyle) -> io::IoResult<()> {
     let st = match style {
         ast::CookedStr => format!("\"{}\"", st.escape_default()),
         ast::RawStr(n) => format!("r{delim}\"{string}\"{delim}",
                                   delim="#".repeat(n), string=st)
     };
-    word(&mut s.s, st);
+    word(&mut s.s, st)
 }
 
 // FIXME(pcwalton): A nasty function to extract the string from an `io::Writer`
@@ -2304,11 +2567,12 @@ unsafe fn get_mem_writer(writer: &mut ~io::Writer) -> ~str {
     result
 }
 
-pub fn to_str<T>(t: &T, f: |&mut State, &T|, intr: @IdentInterner) -> ~str {
+pub fn to_str<T>(t: &T, f: |&mut State, &T| -> io::IoResult<()>,
+                 intr: @IdentInterner) -> ~str {
     let wr = ~MemWriter::new();
     let mut s = rust_printer(wr as ~io::Writer, intr);
-    f(&mut s, t);
-    eof(&mut s.s);
+    f(&mut s, t).unwrap();
+    eof(&mut s.s).unwrap();
     unsafe {
         get_mem_writer(&mut s.s.out)
     }
@@ -2327,44 +2591,52 @@ pub fn next_comment(s: &mut State) -> Option<comments::Comment> {
     }
 }
 
-pub fn print_opt_purity(s: &mut State, opt_purity: Option<ast::Purity>) {
+pub fn print_opt_purity(s: &mut State,
+                        opt_purity: Option<ast::Purity>) -> io::IoResult<()> {
     match opt_purity {
         Some(ast::ImpureFn) => { }
         Some(purity) => {
-            word_nbsp(s, purity_to_str(purity));
+            if_ok!(word_nbsp(s, purity_to_str(purity)));
         }
         None => {}
     }
+    Ok(())
 }
 
 pub fn print_opt_abis_and_extern_if_nondefault(s: &mut State,
-                                               opt_abis: Option<AbiSet>) {
+                                               opt_abis: Option<AbiSet>)
+    -> io::IoResult<()>
+{
     match opt_abis {
         Some(abis) if !abis.is_rust() => {
-            word_nbsp(s, "extern");
-            word_nbsp(s, abis.to_str());
+            if_ok!(word_nbsp(s, "extern"));
+            if_ok!(word_nbsp(s, abis.to_str()));
         }
         Some(_) | None => {}
     };
+    Ok(())
 }
 
-pub fn print_extern_opt_abis(s: &mut State, opt_abis: Option<AbiSet>) {
+pub fn print_extern_opt_abis(s: &mut State,
+                             opt_abis: Option<AbiSet>) -> io::IoResult<()> {
     match opt_abis {
         Some(abis) => {
-            word_nbsp(s, "extern");
-            word_nbsp(s, abis.to_str());
+            if_ok!(word_nbsp(s, "extern"));
+            if_ok!(word_nbsp(s, abis.to_str()));
         }
         None => {}
-    };
+    }
+    Ok(())
 }
 
-pub fn print_opt_sigil(s: &mut State, opt_sigil: Option<ast::Sigil>) {
+pub fn print_opt_sigil(s: &mut State,
+                       opt_sigil: Option<ast::Sigil>) -> io::IoResult<()> {
     match opt_sigil {
-        Some(ast::BorrowedSigil) => { word(&mut s.s, "&"); }
-        Some(ast::OwnedSigil) => { word(&mut s.s, "~"); }
-        Some(ast::ManagedSigil) => { word(&mut s.s, "@"); }
-        None => {}
-    };
+        Some(ast::BorrowedSigil) => word(&mut s.s, "&"),
+        Some(ast::OwnedSigil) => word(&mut s.s, "~"),
+        Some(ast::ManagedSigil) => word(&mut s.s, "@"),
+        None => Ok(())
+    }
 }
 
 pub fn print_fn_header_info(s: &mut State,
@@ -2373,23 +2645,24 @@ pub fn print_fn_header_info(s: &mut State,
                             abis: AbiSet,
                             onceness: ast::Onceness,
                             opt_sigil: Option<ast::Sigil>,
-                            vis: ast::Visibility) {
-    word(&mut s.s, visibility_qualified(vis, ""));
+                            vis: ast::Visibility) -> io::IoResult<()> {
+    if_ok!(word(&mut s.s, visibility_qualified(vis, "")));
 
     if abis != AbiSet::Rust() {
-        word_nbsp(s, "extern");
-        word_nbsp(s, abis.to_str());
+        if_ok!(word_nbsp(s, "extern"));
+        if_ok!(word_nbsp(s, abis.to_str()));
 
         if opt_purity != Some(ast::ExternFn) {
-            print_opt_purity(s, opt_purity);
+            if_ok!(print_opt_purity(s, opt_purity));
         }
     } else {
-        print_opt_purity(s, opt_purity);
+        if_ok!(print_opt_purity(s, opt_purity));
     }
 
-    print_onceness(s, onceness);
-    word(&mut s.s, "fn");
-    print_opt_sigil(s, opt_sigil);
+    if_ok!(print_onceness(s, onceness));
+    if_ok!(word(&mut s.s, "fn"));
+    if_ok!(print_opt_sigil(s, opt_sigil));
+    Ok(())
 }
 
 pub fn purity_to_str(p: ast::Purity) -> &'static str {
@@ -2407,17 +2680,17 @@ pub fn onceness_to_str(o: ast::Onceness) -> &'static str {
     }
 }
 
-pub fn print_purity(s: &mut State, p: ast::Purity) {
+pub fn print_purity(s: &mut State, p: ast::Purity) -> io::IoResult<()> {
     match p {
-      ast::ImpureFn => (),
+      ast::ImpureFn => Ok(()),
       _ => word_nbsp(s, purity_to_str(p))
     }
 }
 
-pub fn print_onceness(s: &mut State, o: ast::Onceness) {
+pub fn print_onceness(s: &mut State, o: ast::Onceness) -> io::IoResult<()> {
     match o {
-        ast::Once => { word_nbsp(s, "once"); }
-        ast::Many => {}
+        ast::Once => word_nbsp(s, "once"),
+        ast::Many => Ok(())
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2059,21 +2059,17 @@ pub fn print_generics(s: &mut State,
             } else {
                 let idx = idx - generics.lifetimes.len();
                 let param = generics.ty_params.get(idx);
-<<<<<<< HEAD
-                print_ident(s, param.ident);
-                print_bounds(s, &param.bounds, false);
+                if_ok!(print_ident(s, param.ident));
+                if_ok!(print_bounds(s, &param.bounds, false));
                 match param.default {
                     Some(default) => {
-                        space(&mut s.s);
-                        word_space(s, "=");
-                        print_type(s, default);
+                        if_ok!(space(&mut s.s));
+                        if_ok!(word_space(s, "="));
+                        if_ok!(print_type(s, default));
                     }
                     _ => {}
                 }
-=======
-                if_ok!(print_ident(s, param.ident));
-                print_bounds(s, &param.bounds, false)
->>>>>>> syntax: Remove io_error usage
+                Ok(())
             }
         }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -964,11 +964,7 @@ pub fn print_attribute(s: &mut State, attr: &ast::Attribute) -> io::IoResult<()>
     if_ok!(maybe_print_comment(s, attr.span.lo));
     if attr.node.is_sugared_doc {
         let comment = attr.value_str().unwrap();
-<<<<<<< HEAD
-        word(&mut s.s, comment.get());
-=======
-        if_ok!(word(&mut s.s, comment));
->>>>>>> syntax: Remove io_error usage
+        if_ok!(word(&mut s.s, comment.get()));
     } else {
         if_ok!(word(&mut s.s, "#["));
         if_ok!(print_meta_item(s, attr.meta()));
@@ -1139,24 +1135,7 @@ pub fn print_mac(s: &mut State, m: &ast::Mac) -> io::IoResult<()> {
     }
 }
 
-<<<<<<< HEAD
-pub fn print_expr_vstore(s: &mut State, t: ast::ExprVstore) {
-=======
-pub fn print_vstore(s: &mut State, t: ast::Vstore) -> io::IoResult<()> {
-    match t {
-        ast::VstoreFixed(Some(i)) => word(&mut s.s, format!("{}", i)),
-        ast::VstoreFixed(None) => word(&mut s.s, "_"),
-        ast::VstoreUniq => word(&mut s.s, "~"),
-        ast::VstoreBox => word(&mut s.s, "@"),
-        ast::VstoreSlice(ref r) => {
-            if_ok!(word(&mut s.s, "&"));
-            print_opt_lifetime(s, r)
-        }
-    }
-}
-
 pub fn print_expr_vstore(s: &mut State, t: ast::ExprVstore) -> io::IoResult<()> {
->>>>>>> syntax: Remove io_error usage
     match t {
       ast::ExprVstoreUniq => word(&mut s.s, "~"),
       ast::ExprVstoreSlice => word(&mut s.s, "&"),
@@ -1557,51 +1536,27 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) -> io::IoResult<()> {
         } else {
             if_ok!(word(&mut s.s, "asm!"));
         }
-<<<<<<< HEAD
-        popen(s);
-        print_string(s, a.asm.get(), a.asm_str_style);
-        word_space(s, ":");
-        for &(ref co, o) in a.outputs.iter() {
-            print_string(s, co.get(), ast::CookedStr);
-            popen(s);
-            print_expr(s, o);
-            pclose(s);
-            word_space(s, ",");
-        }
-        word_space(s, ":");
-        for &(ref co, o) in a.inputs.iter() {
-            print_string(s, co.get(), ast::CookedStr);
-            popen(s);
-            print_expr(s, o);
-            pclose(s);
-            word_space(s, ",");
-        }
-        word_space(s, ":");
-        print_string(s, a.clobbers.get(), ast::CookedStr);
-        pclose(s);
-=======
         if_ok!(popen(s));
-        if_ok!(print_string(s, a.asm, a.asm_str_style));
+        if_ok!(print_string(s, a.asm.get(), a.asm_str_style));
         if_ok!(word_space(s, ":"));
-        for &(co, o) in a.outputs.iter() {
-            if_ok!(print_string(s, co, ast::CookedStr));
+        for &(ref co, o) in a.outputs.iter() {
+            if_ok!(print_string(s, co.get(), ast::CookedStr));
             if_ok!(popen(s));
             if_ok!(print_expr(s, o));
             if_ok!(pclose(s));
             if_ok!(word_space(s, ","));
         }
         if_ok!(word_space(s, ":"));
-        for &(co, o) in a.inputs.iter() {
-            if_ok!(print_string(s, co, ast::CookedStr));
+        for &(ref co, o) in a.inputs.iter() {
+            if_ok!(print_string(s, co.get(), ast::CookedStr));
             if_ok!(popen(s));
             if_ok!(print_expr(s, o));
             if_ok!(pclose(s));
             if_ok!(word_space(s, ","));
         }
         if_ok!(word_space(s, ":"));
-        if_ok!(print_string(s, a.clobbers, ast::CookedStr));
+        if_ok!(print_string(s, a.clobbers.get(), ast::CookedStr));
         if_ok!(pclose(s));
->>>>>>> syntax: Remove io_error usage
       }
       ast::ExprMac(ref m) => if_ok!(print_mac(s, m)),
       ast::ExprParen(e) => {
@@ -1659,23 +1614,14 @@ pub fn print_decl(s: &mut State, decl: &ast::Decl) -> io::IoResult<()> {
     }
 }
 
-<<<<<<< HEAD
-pub fn print_ident(s: &mut State, ident: ast::Ident) {
-    let string = token::get_ident(ident.name);
-    word(&mut s.s, string.get());
-}
-
-pub fn print_name(s: &mut State, name: ast::Name) {
-    let string = token::get_ident(name);
-    word(&mut s.s, string.get());
-=======
 pub fn print_ident(s: &mut State, ident: ast::Ident) -> io::IoResult<()> {
-    word(&mut s.s, ident_to_str(&ident))
+    let string = token::get_ident(ident.name);
+    word(&mut s.s, string.get())
 }
 
 pub fn print_name(s: &mut State, name: ast::Name) -> io::IoResult<()> {
-    word(&mut s.s, interner_get(name))
->>>>>>> syntax: Remove io_error usage
+    let string = token::get_ident(name);
+    word(&mut s.s, string.get())
 }
 
 pub fn print_for_decl(s: &mut State, loc: &ast::Local,
@@ -2088,38 +2034,23 @@ pub fn print_generics(s: &mut State,
 pub fn print_meta_item(s: &mut State, item: &ast::MetaItem) -> io::IoResult<()> {
     if_ok!(ibox(s, indent_unit));
     match item.node {
-<<<<<<< HEAD
-      ast::MetaWord(ref name) => word(&mut s.s, name.get()),
-      ast::MetaNameValue(ref name, ref value) => {
-        word_space(s, name.get());
-        word_space(s, "=");
-        print_literal(s, value);
-      }
-      ast::MetaList(ref name, ref items) => {
-        word(&mut s.s, name.get());
-        popen(s);
-        commasep(s,
-                 Consistent,
-                 items.as_slice(),
-                 |p, &i| print_meta_item(p, i));
-        pclose(s);
-=======
-      ast::MetaWord(name) => { if_ok!(word(&mut s.s, name)); }
-      ast::MetaNameValue(name, value) => {
-        if_ok!(word_space(s, name));
-        if_ok!(word_space(s, "="));
-        if_ok!(print_literal(s, &value));
-      }
-      ast::MetaList(name, ref items) => {
-        if_ok!(word(&mut s.s, name));
-        if_ok!(popen(s));
-        if_ok!(commasep(s,
-                        Consistent,
-                        items.as_slice(),
-                        |p, &i| print_meta_item(p, i)));
-        if_ok!(pclose(s));
->>>>>>> syntax: Remove io_error usage
-      }
+        ast::MetaWord(ref name) => {
+            if_ok!(word(&mut s.s, name.get()));
+        }
+        ast::MetaNameValue(ref name, ref value) => {
+            if_ok!(word_space(s, name.get()));
+            if_ok!(word_space(s, "="));
+            if_ok!(print_literal(s, value));
+        }
+        ast::MetaList(ref name, ref items) => {
+            if_ok!(word(&mut s.s, name.get()));
+            if_ok!(popen(s));
+            if_ok!(commasep(s,
+                            Consistent,
+                            items.as_slice(),
+                            |p, &i| print_meta_item(p, i)));
+            if_ok!(pclose(s));
+        }
     }
     end(s)
 }
@@ -2171,17 +2102,10 @@ pub fn print_view_item(s: &mut State, item: &ast::ViewItem) -> io::IoResult<()> 
             if_ok!(head(s, "extern mod"));
             if_ok!(print_ident(s, id));
             for &(ref p, style) in optional_path.iter() {
-<<<<<<< HEAD
-                space(&mut s.s);
-                word(&mut s.s, "=");
-                space(&mut s.s);
-                print_string(s, p.get(), style);
-=======
                 if_ok!(space(&mut s.s));
                 if_ok!(word(&mut s.s, "="));
                 if_ok!(space(&mut s.s));
-                if_ok!(print_string(s, *p, style));
->>>>>>> syntax: Remove io_error usage
+                if_ok!(print_string(s, p.get(), style));
             }
         }
 
@@ -2373,88 +2297,54 @@ pub fn print_literal(s: &mut State, lit: &ast::Lit) -> io::IoResult<()> {
       _ => ()
     }
     match lit.node {
-<<<<<<< HEAD
       ast::LitStr(ref st, style) => print_string(s, st.get(), style),
       ast::LitChar(ch) => {
           let mut res = ~"'";
           char::from_u32(ch).unwrap().escape_default(|c| res.push_char(c));
           res.push_char('\'');
-          word(&mut s.s, res);
+          word(&mut s.s, res)
       }
       ast::LitInt(i, t) => {
         if i < 0_i64 {
             word(&mut s.s,
                  ~"-" + (-i as u64).to_str_radix(10u)
-                 + ast_util::int_ty_to_str(t));
+                 + ast_util::int_ty_to_str(t))
         } else {
             word(&mut s.s,
                  (i as u64).to_str_radix(10u)
-                 + ast_util::int_ty_to_str(t));
-=======
-        ast::LitStr(st, style) => print_string(s, st, style),
-        ast::LitChar(ch) => {
-            let mut res = ~"'";
-            char::from_u32(ch).unwrap().escape_default(|c| res.push_char(c));
-            res.push_char('\'');
-            word(&mut s.s, res)
+                 + ast_util::int_ty_to_str(t))
         }
-        ast::LitInt(i, t) => {
-            if i < 0_i64 {
-                word(&mut s.s, ~"-" + (-i as u64).to_str_radix(10u)
-                               + ast_util::int_ty_to_str(t))
-            } else {
-                word(&mut s.s, (i as u64).to_str_radix(10u)
-                                + ast_util::int_ty_to_str(t))
-            }
->>>>>>> syntax: Remove io_error usage
-        }
-        ast::LitUint(u, t) => {
-            word(&mut s.s, u.to_str_radix(10u) + ast_util::uint_ty_to_str(t))
-        }
-        ast::LitIntUnsuffixed(i) => {
-            if i < 0_i64 {
-                word(&mut s.s, ~"-" + (-i as u64).to_str_radix(10u))
-            } else {
-                word(&mut s.s, (i as u64).to_str_radix(10u))
-            }
-        }
-        ast::LitFloat(f, t) => {
-            word(&mut s.s, f.to_owned() + ast_util::float_ty_to_str(t))
-        }
-        ast::LitFloatUnsuffixed(f) => word(&mut s.s, f),
-        ast::LitNil => word(&mut s.s, "()"),
-        ast::LitBool(val) => {
-            if val { word(&mut s.s, "true") } else { word(&mut s.s, "false") }
-        }
-        ast::LitBinary(arr) => {
-            if_ok!(ibox(s, indent_unit));
-            if_ok!(word(&mut s.s, "["));
-            if_ok!(commasep_cmnt(s, Inconsistent, arr,
-                                 |s, u| word(&mut s.s, format!("{}", *u)),
-                                 |_| lit.span));
-            if_ok!(word(&mut s.s, "]"));
-            end(s)
-        }
-<<<<<<< HEAD
       }
+      ast::LitUint(u, t) => {
+        word(&mut s.s,
+             u.to_str_radix(10u)
+             + ast_util::uint_ty_to_str(t))
+      }
+      ast::LitIntUnsuffixed(i) => {
+        if i < 0_i64 {
+            word(&mut s.s, ~"-" + (-i as u64).to_str_radix(10u))
+        } else {
+            word(&mut s.s, (i as u64).to_str_radix(10u))
+        }
+      }
+
       ast::LitFloat(ref f, t) => {
-        word(&mut s.s, f.get() + ast_util::float_ty_to_str(t));
+        word(&mut s.s, f.get() + ast_util::float_ty_to_str(t))
       }
       ast::LitFloatUnsuffixed(ref f) => word(&mut s.s, f.get()),
       ast::LitNil => word(&mut s.s, "()"),
       ast::LitBool(val) => {
-        if val { word(&mut s.s, "true"); } else { word(&mut s.s, "false"); }
+        if val { word(&mut s.s, "true") } else { word(&mut s.s, "false") }
       }
       ast::LitBinary(ref arr) => {
-        ibox(s, indent_unit);
-        word(&mut s.s, "[");
-        commasep_cmnt(s, Inconsistent, *arr.borrow(), |s, u| word(&mut s.s, format!("{}", *u)),
-                      |_| lit.span);
-        word(&mut s.s, "]");
-        end(s);
+        if_ok!(ibox(s, indent_unit));
+        if_ok!(word(&mut s.s, "["));
+        if_ok!(commasep_cmnt(s, Inconsistent, *arr.borrow(),
+                             |s, u| word(&mut s.s, format!("{}", *u)),
+                             |_| lit.span));
+        if_ok!(word(&mut s.s, "]"));
+        end(s)
       }
-=======
->>>>>>> syntax: Remove io_error usage
     }
 }
 

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -101,30 +101,30 @@ pub fn matches_codepattern(a : &str, b : &str) -> bool {
     let mut idx_a = 0;
     let mut idx_b = 0;
     loop {
-        if (idx_a == a.len() && idx_b == b.len()) {
+        if idx_a == a.len() && idx_b == b.len() {
             return true;
         }
-        else if (idx_a == a.len()) {return false;}
-        else if (idx_b == b.len()) {
+        else if idx_a == a.len() {return false;}
+        else if idx_b == b.len() {
             // maybe the stuff left in a is all ws?
-            if (is_whitespace(a.char_at(idx_a))) {
-                return (scan_for_non_ws_or_end(a,idx_a) == a.len());
+            if is_whitespace(a.char_at(idx_a)) {
+                return scan_for_non_ws_or_end(a,idx_a) == a.len();
             } else {
                 return false;
             }
         }
         // ws in both given and pattern:
-        else if (is_whitespace(a.char_at(idx_a))
-           && is_whitespace(b.char_at(idx_b))) {
+        else if is_whitespace(a.char_at(idx_a))
+           && is_whitespace(b.char_at(idx_b)) {
             idx_a = scan_for_non_ws_or_end(a,idx_a);
             idx_b = scan_for_non_ws_or_end(b,idx_b);
         }
         // ws in given only:
-        else if (is_whitespace(a.char_at(idx_a))) {
+        else if is_whitespace(a.char_at(idx_a)) {
             idx_a = scan_for_non_ws_or_end(a,idx_a);
         }
         // *don't* silently eat ws in expected only.
-        else if (a.char_at(idx_a) == b.char_at(idx_b)) {
+        else if a.char_at(idx_a) == b.char_at(idx_b) {
             idx_a += 1;
             idx_b += 1;
         }

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -141,45 +141,48 @@ impl<T: Writer> Terminal<T> {
     /// If the color is a bright color, but the terminal only supports 8 colors,
     /// the corresponding normal color will be used instead.
     ///
-    /// Returns true if the color was set, false otherwise.
-    pub fn fg(&mut self, color: color::Color) -> bool {
+    /// Returns Ok(true) if the color was set, Ok(false) otherwise, and Err(e)
+    /// if there was an I/O error
+    pub fn fg(&mut self, color: color::Color) -> io::IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
             let s = expand(*self.ti.strings.find_equiv(&("setaf")).unwrap(),
                            [Number(color as int)], &mut Variables::new());
             if s.is_ok() {
-                self.out.write(s.unwrap());
-                return true
+                if_ok!(self.out.write(s.unwrap()));
+                return Ok(true)
             } else {
                 warn!("{}", s.unwrap_err());
             }
         }
-        false
+        Ok(false)
     }
     /// Sets the background color to the given color.
     ///
     /// If the color is a bright color, but the terminal only supports 8 colors,
     /// the corresponding normal color will be used instead.
     ///
-    /// Returns true if the color was set, false otherwise.
-    pub fn bg(&mut self, color: color::Color) -> bool {
+    /// Returns Ok(true) if the color was set, Ok(false) otherwise, and Err(e)
+    /// if there was an I/O error
+    pub fn bg(&mut self, color: color::Color) -> io::IoResult<bool> {
         let color = self.dim_if_necessary(color);
         if self.num_colors > color {
             let s = expand(*self.ti.strings.find_equiv(&("setab")).unwrap(),
                            [Number(color as int)], &mut Variables::new());
             if s.is_ok() {
-                self.out.write(s.unwrap());
-                return true
+                if_ok!(self.out.write(s.unwrap()));
+                return Ok(true)
             } else {
                 warn!("{}", s.unwrap_err());
             }
         }
-        false
+        Ok(false)
     }
 
     /// Sets the given terminal attribute, if supported.
-    /// Returns true if the attribute was supported, false otherwise.
-    pub fn attr(&mut self, attr: attr::Attr) -> bool {
+    /// Returns Ok(true) if the attribute was supported, Ok(false) otherwise,
+    /// and Err(e) if there was an I/O error.
+    pub fn attr(&mut self, attr: attr::Attr) -> io::IoResult<bool> {
         match attr {
             attr::ForegroundColor(c) => self.fg(c),
             attr::BackgroundColor(c) => self.bg(c),
@@ -189,13 +192,13 @@ impl<T: Writer> Terminal<T> {
                 if parm.is_some() {
                     let s = expand(*parm.unwrap(), [], &mut Variables::new());
                     if s.is_ok() {
-                        self.out.write(s.unwrap());
-                        return true
+                        if_ok!(self.out.write(s.unwrap()));
+                        return Ok(true)
                     } else {
                         warn!("{}", s.unwrap_err());
                     }
                 }
-                false
+                Ok(false)
             }
         }
     }
@@ -214,7 +217,7 @@ impl<T: Writer> Terminal<T> {
     }
 
     /// Resets all terminal attributes and color to the default.
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self) -> io::IoResult<()> {
         let mut cap = self.ti.strings.find_equiv(&("sgr0"));
         if cap.is_none() {
             // are there any terminals that have color/attrs and not sgr0?
@@ -228,7 +231,7 @@ impl<T: Writer> Terminal<T> {
             expand(*op, [], &mut Variables::new())
         });
         if s.is_ok() {
-            self.out.write(s.unwrap());
+            return self.out.write(s.unwrap())
         } else if self.num_colors > 0 {
             warn!("{}", s.unwrap_err());
         } else {
@@ -236,6 +239,7 @@ impl<T: Writer> Terminal<T> {
             // but it's not worth testing all known attributes just for this.
             debug!("{}", s.unwrap_err());
         }
+        Ok(())
     }
 
     fn dim_if_necessary(&self, color: color::Color) -> color::Color {
@@ -252,11 +256,11 @@ impl<T: Writer> Terminal<T> {
 }
 
 impl<T: Writer> Writer for Terminal<T> {
-    fn write(&mut self, buf: &[u8]) {
-        self.out.write(buf);
+    fn write(&mut self, buf: &[u8]) -> io::IoResult<()> {
+        self.out.write(buf)
     }
 
-    fn flush(&mut self) {
-        self.out.flush();
+    fn flush(&mut self) -> io::IoResult<()> {
+        self.out.flush()
     }
 }

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -19,14 +19,20 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
+#[feature(macro_rules)];
 #[deny(non_camel_case_types)];
 #[allow(missing_doc)];
 
 use std::os;
+use std::io;
 use terminfo::TermInfo;
 use terminfo::searcher::open;
 use terminfo::parser::compiled::{parse, msys_terminfo};
 use terminfo::parm::{expand, Number, Variables};
+
+macro_rules! if_ok (
+    ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
+)
 
 pub mod terminfo;
 

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -162,6 +162,10 @@ pub static stringnames: &'static[&'static str] = &'static[ "cbt", "_", "cr", "cs
 /// Parse a compiled terminfo entry, using long capability names if `longnames` is true
 pub fn parse(file: &mut io::Reader,
              longnames: bool) -> Result<~TermInfo, ~str> {
+    macro_rules! if_ok( ($e:expr) => (
+        match $e { Ok(e) => e, Err(e) => return Err(format!("{}", e)) }
+    ) )
+
     let bnames;
     let snames;
     let nnames;
@@ -177,17 +181,17 @@ pub fn parse(file: &mut io::Reader,
     }
 
     // Check magic number
-    let magic = file.read_le_u16();
+    let magic = if_ok!(file.read_le_u16());
     if magic != 0x011A {
         return Err(format!("invalid magic number: expected {:x} but found {:x}",
                            0x011A, magic as uint));
     }
 
-    let names_bytes          = file.read_le_i16() as int;
-    let bools_bytes          = file.read_le_i16() as int;
-    let numbers_count        = file.read_le_i16() as int;
-    let string_offsets_count = file.read_le_i16() as int;
-    let string_table_bytes   = file.read_le_i16() as int;
+    let names_bytes          = if_ok!(file.read_le_i16()) as int;
+    let bools_bytes          = if_ok!(file.read_le_i16()) as int;
+    let numbers_count        = if_ok!(file.read_le_i16()) as int;
+    let string_offsets_count = if_ok!(file.read_le_i16()) as int;
+    let string_table_bytes   = if_ok!(file.read_le_i16()) as int;
 
     assert!(names_bytes          > 0);
 
@@ -216,18 +220,21 @@ pub fn parse(file: &mut io::Reader,
     }
 
     // don't read NUL
-    let names_str = str::from_utf8_owned(file.read_bytes(names_bytes as uint - 1)).unwrap();
+    let bytes = if_ok!(file.read_bytes(names_bytes as uint - 1));
+    let names_str = match str::from_utf8_owned(bytes) {
+        Some(s) => s, None => return Err(~"input not utf-8"),
+    };
 
     let term_names: ~[~str] = names_str.split('|').map(|s| s.to_owned()).collect();
 
-    file.read_byte(); // consume NUL
+    if_ok!(file.read_byte()); // consume NUL
 
     debug!("term names: {:?}", term_names);
 
     let mut bools_map = HashMap::new();
     if bools_bytes != 0 {
         for i in range(0, bools_bytes) {
-            let b = file.read_byte().unwrap();
+            let b = if_ok!(file.read_byte());
             if b < 0 {
                 error!("EOF reading bools after {} entries", i);
                 return Err(~"error: expected more bools but hit EOF");
@@ -242,13 +249,13 @@ pub fn parse(file: &mut io::Reader,
 
     if (bools_bytes + names_bytes) % 2 == 1 {
         debug!("adjusting for padding between bools and numbers");
-        file.read_byte(); // compensate for padding
+        if_ok!(file.read_byte()); // compensate for padding
     }
 
     let mut numbers_map = HashMap::new();
     if numbers_count != 0 {
         for i in range(0, numbers_count) {
-            let n = file.read_le_u16();
+            let n = if_ok!(file.read_le_u16());
             if n != 0xFFFF {
                 debug!("{}\\#{}", nnames[i], n);
                 numbers_map.insert(nnames[i].to_owned(), n);
@@ -263,12 +270,12 @@ pub fn parse(file: &mut io::Reader,
     if string_offsets_count != 0 {
         let mut string_offsets = vec::with_capacity(10);
         for _ in range(0, string_offsets_count) {
-            string_offsets.push(file.read_le_u16());
+            string_offsets.push(if_ok!(file.read_le_u16()));
         }
 
         debug!("offsets: {:?}", string_offsets);
 
-        let string_table = file.read_bytes(string_table_bytes as uint);
+        let string_table = if_ok!(file.read_bytes(string_table_bytes as uint));
 
         if string_table.len() != string_table_bytes as uint {
             error!("EOF reading string table after {} bytes, wanted {}", string_table.len(),

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -77,8 +77,8 @@ pub fn open(term: &str) -> Result<File, ~str> {
     match get_dbpath_for_term(term) {
         Some(x) => {
             match File::open(x) {
-                Some(file) => Ok(file),
-                None => Err(~"error opening file"),
+                Ok(file) => Ok(file),
+                Err(e) => Err(format!("error opening file: {}", e)),
             }
         }
         None => Err(format!("could not find terminfo entry for {}", term))

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -106,7 +106,7 @@ fn test_get_dbpath_for_term() {
 #[test]
 #[ignore(reason = "see test_get_dbpath_for_term")]
 fn test_open() {
-    open("screen");
+    open("screen").unwrap();
     let t = open("nonexistent terminal that hopefully does not exist");
     assert!(t.is_err());
 }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -8,11 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::io;
 use std::io::BufferedWriter;
 
 struct DummyWriter;
 impl Writer for DummyWriter {
-    fn write(&mut self, _: &[u8]) {}
+    fn write(&mut self, _: &[u8]) -> io::IoResult<()> { Ok(()) }
 }
 
 static ITER: int = 50;

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -36,11 +36,12 @@ fn make_complements() -> [u8, ..256] {
 
 fn main() {
     let complements = make_complements();
-    let mut data = if std::os::getenv("RUST_BENCH").is_some() {
+    let data = if std::os::getenv("RUST_BENCH").is_some() {
         File::open(&Path::new("shootout-k-nucleotide.data")).read_to_end()
     } else {
         stdin().read_to_end()
     };
+    let mut data = data.unwrap();
 
     for seq in data.mut_split(|c| *c == '>' as u8) {
         // skip header and last \n

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -43,5 +43,5 @@ fn main() {
         debug!("debug");
         info!("info");
     });
-    assert_eq!(r.read_to_str(), ~"info\n");
+    assert_eq!(r.read_to_str().unwrap(), ~"info\n");
 }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -12,6 +12,7 @@
 
 #[feature(macro_rules)];
 #[deny(warnings)];
+#[allow(unused_must_use)];
 
 use std::fmt;
 use std::io::MemWriter;
@@ -22,10 +23,14 @@ struct A;
 struct B;
 
 impl fmt::Signed for A {
-    fn fmt(_: &A, f: &mut fmt::Formatter) { f.buf.write("aloha".as_bytes()); }
+    fn fmt(_: &A, f: &mut fmt::Formatter) -> fmt::Result {
+        f.buf.write("aloha".as_bytes())
+    }
 }
 impl fmt::Signed for B {
-    fn fmt(_: &B, f: &mut fmt::Formatter) { f.buf.write("adios".as_bytes()); }
+    fn fmt(_: &B, f: &mut fmt::Formatter) -> fmt::Result {
+        f.buf.write("adios".as_bytes())
+    }
 }
 
 macro_rules! t(($a:expr, $b:expr) => { assert_eq!($a, $b.to_owned()) })
@@ -286,9 +291,9 @@ fn test_format_args() {
     let mut buf = MemWriter::new();
     {
         let w = &mut buf as &mut io::Writer;
-        format_args!(|args| { fmt::write(w, args) }, "{}", 1);
-        format_args!(|args| { fmt::write(w, args) }, "test");
-        format_args!(|args| { fmt::write(w, args) }, "{test}", test=3);
+        format_args!(|args| { fmt::write(w, args); }, "{}", 1);
+        format_args!(|args| { fmt::write(w, args); }, "test");
+        format_args!(|args| { fmt::write(w, args); }, "{test}", test=3);
     }
     let s = str::from_utf8_owned(buf.unwrap()).unwrap();
     t!(s, "1test3");

--- a/src/test/run-pass/issue-8398.rs
+++ b/src/test/run-pass/issue-8398.rs
@@ -11,7 +11,7 @@
 use std::io;
 
 fn foo(a: &mut io::Writer) {
-    a.write([])
+    a.write([]).unwrap();
 }
 
 pub fn main(){}

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -17,10 +17,11 @@ use std::fmt;
 struct Foo(Cell<int>);
 
 impl fmt::Show for Foo {
-    fn fmt(f: &Foo, _fmt: &mut fmt::Formatter) {
+    fn fmt(f: &Foo, _fmt: &mut fmt::Formatter) -> fmt::Result {
         let Foo(ref f) = *f;
         assert!(f.get() == 0);
         f.set(1);
+        Ok(())
     }
 }
 

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -19,8 +19,7 @@ pub fn main() {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }
     } else {
-        let status = run::process_status(args[0], [~"signal"])
-            .expect("failed to exec `signal`");
+        let status = run::process_status(args[0], [~"signal"]).unwrap();
         // Windows does not have signal, so we get exit status 0xC0000028 (STATUS_BAD_STACK).
         match status {
             process::ExitSignal(_) if cfg!(unix) => {},

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -21,8 +21,8 @@ pub fn main() {
 
     {
         match File::create(&path) {
-            None => unreachable!(),
-            Some(f) => {
+            Err(..) => unreachable!(),
+            Ok(f) => {
                 let mut f = f;
                 for _ in range(0u, 1000) {
                     f.write([0]);
@@ -32,5 +32,5 @@ pub fn main() {
     }
 
     assert!(path.exists());
-    assert_eq!(path.stat().size, 1000);
+    assert_eq!(path.stat().unwrap().size, 1000);
 }


### PR DESCRIPTION
Turns out this was a little more far-reaching than I thought it was.

The first commit is the crux of this stack of commits. The `io::io_error` condition is completely removed and the `read` and `write` methods are altered to return `IoResult<T>`. This turned out to be an incredibly far-reaching change!

Overall, I'm very happy with how this turned out (in addition with the `unused_must_use` lint). I had to almost rewrite the pretty printer in `libsyntax` as well as the the formatting in `librustdoc` (as one would expect). These two modules do _tons_ of I/O, and I believe that it's definitely improved.

This pull request also introduces the `if_ok!()` macro for returning-early from something that returns a result. I made quite liberal use of this in mostly the pretty printer and html renderer, and I found its usage generally quite pleasant and convenient to have. I didn't really feel like adding any other macro while I was using it, and I figured that pretty printing could be nicer, but it's nowhere near horrid today.

This may be a controversial issue closing, but I'm going to say it.

Closes #6163
