### PR TITLE
Fix the size of the _Unwind_Exception struct

### DIFF
--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -122,7 +122,10 @@ mod libunwind {
 
     pub type _Unwind_Word = uintptr_t;
 
-    #[cfg(not(target_arch = "arm"))]
+    #[cfg(target_arch = "x86")]
+    pub static unwinder_private_data_size: int = 5;
+
+    #[cfg(target_arch = "x86_64")]
     pub static unwinder_private_data_size: int = 2;
 
     #[cfg(target_arch = "arm")]


### PR DESCRIPTION
On OSX 32-bit, the private fields are 5 words long, not 2. I found this
segfaulting before this change, and after this change it no longer segfaulted.
