### PR TITLE
Rename reserve to reserve_exact and reserve_at_least to reserve

### DIFF
--- a/src/libextra/priority_queue.rs
+++ b/src/libextra/priority_queue.rs
@@ -51,10 +51,14 @@ impl<T:Ord> PriorityQueue<T> {
     /// Returns the number of elements the queue can hold without reallocating
     pub fn capacity(&self) -> uint { self.data.capacity() }
 
-    pub fn reserve(&mut self, n: uint) { self.data.reserve(n) }
+    /// Reserve capacity for exactly n elements in the PriorityQueue.
+    /// Do nothing if the capacity is already sufficient.
+    pub fn reserve_exact(&mut self, n: uint) { self.data.reserve_exact(n) }
 
-    pub fn reserve_at_least(&mut self, n: uint) {
-        self.data.reserve_at_least(n)
+    /// Reserve capacity for at least n elements in the PriorityQueue.
+    /// Do nothing if the capacity is already sufficient.
+    pub fn reserve(&mut self, n: uint) {
+        self.data.reserve(n)
     }
 
     /// Pop the greatest item from the queue - fails if empty
@@ -203,7 +207,7 @@ impl<T: Ord> Extendable<T> for PriorityQueue<T> {
         let (lower, _) = iter.size_hint();
 
         let len = self.capacity();
-        self.reserve_at_least(len + lower);
+        self.reserve(len + lower);
 
         for elem in *iter {
             self.push(elem);

--- a/src/libextra/ringbuf.rs
+++ b/src/libextra/ringbuf.rs
@@ -168,8 +168,8 @@ impl<T> RingBuf<T> {
     /// # Arguments
     ///
     /// * n - The number of elements to reserve space for
-    pub fn reserve(&mut self, n: uint) {
-        self.elts.reserve(n);
+    pub fn reserve_exact(&mut self, n: uint) {
+        self.elts.reserve_exact(n);
     }
 
     /// Reserve capacity for at least `n` elements in the given RingBuf,
@@ -182,8 +182,8 @@ impl<T> RingBuf<T> {
     /// # Arguments
     ///
     /// * n - The number of elements to reserve space for
-    pub fn reserve_at_least(&mut self, n: uint) {
-        self.elts.reserve_at_least(n);
+    pub fn reserve(&mut self, n: uint) {
+        self.elts.reserve(n);
     }
 
     /// Front-to-back iterator.
@@ -641,26 +641,26 @@ mod tests {
     }
 
     #[test]
-    fn test_reserve() {
+    fn test_reserve_exact() {
         let mut d = RingBuf::new();
         d.push_back(0u64);
-        d.reserve(50);
+        d.reserve_exact(50);
         assert_eq!(d.elts.capacity(), 50);
         let mut d = RingBuf::new();
         d.push_back(0u32);
-        d.reserve(50);
+        d.reserve_exact(50);
         assert_eq!(d.elts.capacity(), 50);
     }
 
     #[test]
-    fn test_reserve_at_least() {
+    fn test_reserve() {
         let mut d = RingBuf::new();
         d.push_back(0u64);
-        d.reserve_at_least(50);
+        d.reserve(50);
         assert_eq!(d.elts.capacity(), 64);
         let mut d = RingBuf::new();
         d.push_back(0u32);
-        d.reserve_at_least(50);
+        d.reserve(50);
         assert_eq!(d.elts.capacity(), 64);
     }
 

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -384,7 +384,7 @@ impl<K: Hash + Eq, V> HashMap<K, V> {
     }
 
     /// Reserve space for at least `n` elements in the hash table.
-    pub fn reserve_at_least(&mut self, n: uint) {
+    pub fn reserve(&mut self, n: uint) {
         if n > self.buckets.len() {
             let buckets = n * 4 / 3 + 1;
             self.resize(num::next_power_of_two(buckets));
@@ -793,8 +793,8 @@ impl<T:Hash + Eq> HashSet<T> {
     }
 
     /// Reserve space for at least `n` elements in the hash table.
-    pub fn reserve_at_least(&mut self, n: uint) {
-        self.map.reserve_at_least(n)
+    pub fn reserve(&mut self, n: uint) {
+        self.map.reserve(n)
     }
 
     /// Returns true if the hash set contains a value equivalent to the

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -104,7 +104,7 @@ use iter::{Iterator, FromIterator, Extendable, range};
 use iter::{Filter, AdditiveIterator, Map};
 use iter::{Rev, DoubleEndedIterator, ExactSize};
 use libc;
-use num::{Saturating, checked_next_power_of_two};
+use num::Saturating;
 use option::{None, Option, Some};
 use ptr;
 use ptr::RawPtr;
@@ -186,12 +186,7 @@ pub fn from_char(ch: char) -> ~str {
 
 /// Convert a vector of chars to a string
 pub fn from_chars(chs: &[char]) -> ~str {
-    let mut buf = ~"";
-    buf.reserve(chs.len());
-    for ch in chs.iter() {
-        buf.push_char(*ch)
-    }
-    buf
+    chs.iter().map(|c| *c).collect()
 }
 
 #[doc(hidden)]
@@ -875,8 +870,7 @@ pub fn utf16_chars(v: &[u16], f: |char|) {
 
 /// Allocates a new string from the utf-16 slice provided
 pub fn from_utf16(v: &[u16]) -> ~str {
-    let mut buf = ~"";
-    buf.reserve(v.len());
+    let mut buf = with_capacity(v.len());
     utf16_chars(v, |ch| buf.push_char(ch));
     buf
 }
@@ -2166,8 +2160,7 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     fn escape_default(&self) -> ~str {
-        let mut out: ~str = ~"";
-        out.reserve_at_least(self.len());
+        let mut out = with_capacity(self.len());
         for c in self.chars() {
             c.escape_default(|c| out.push_char(c));
         }
@@ -2175,8 +2168,7 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     fn escape_unicode(&self) -> ~str {
-        let mut out: ~str = ~"";
-        out.reserve_at_least(self.len());
+        let mut out = with_capacity(self.len());
         for c in self.chars() {
             c.escape_unicode(|c| out.push_char(c));
         }
@@ -2508,7 +2500,7 @@ pub trait OwnedStr {
     ///
     /// * s - A string
     /// * n - The number of bytes to reserve space for
-    fn reserve(&mut self, n: uint);
+    fn reserve_exact(&mut self, n: uint);
 
     /// Reserves capacity for at least `n` bytes in the given string.
     ///
@@ -2526,7 +2518,7 @@ pub trait OwnedStr {
     ///
     /// * s - A string
     /// * n - The number of bytes to reserve space for
-    fn reserve_at_least(&mut self, n: uint);
+    fn reserve(&mut self, n: uint);
 
     /// Returns the number of single-byte characters the string can hold without
     /// reallocating
@@ -2552,7 +2544,7 @@ impl OwnedStr for ~str {
     #[inline]
     fn push_str_no_overallocate(&mut self, rhs: &str) {
         let new_cap = self.len() + rhs.len();
-        self.reserve(new_cap);
+        self.reserve_exact(new_cap);
         self.push_str(rhs);
     }
 
@@ -2631,15 +2623,17 @@ impl OwnedStr for ~str {
     }
 
     #[inline]
-    fn reserve(&mut self, n: uint) {
+    fn reserve_exact(&mut self, n: uint) {
         unsafe {
-            raw::as_owned_vec(self).reserve(n)
+            raw::as_owned_vec(self).reserve_exact(n)
         }
     }
 
     #[inline]
-    fn reserve_at_least(&mut self, n: uint) {
-        self.reserve(checked_next_power_of_two(n).unwrap_or(n))
+    fn reserve(&mut self, n: uint) {
+        unsafe {
+            raw::as_owned_vec(self).reserve(n)
+        }
     }
 
     #[inline]
@@ -2711,7 +2705,7 @@ impl Extendable<char> for ~str {
     fn extend<T: Iterator<char>>(&mut self, iterator: &mut T) {
         let (lower, _) = iterator.size_hint();
         let reserve = lower + self.len();
-        self.reserve_at_least(reserve);
+        self.reserve(reserve);
         for ch in *iterator {
             self.push_char(ch)
         }


### PR DESCRIPTION
Changes in std::{str,vec,hashmap} and extra::{priority_queue,ringbuf}.
Fixes #11949
