### PR TITLE
RFC: Begin extracting frestanding components of libstd

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -49,12 +49,12 @@
 # automatically generated for all stage/host/target combinations.
 ################################################################################
 
-TARGET_CRATES := std extra green rustuv native flate arena glob
+TARGET_CRATES := prim std extra green rustuv native flate arena glob
 HOST_CRATES := syntax rustc rustdoc rustpkg
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustpkg rustdoc rustc
 
-DEPS_std := native:rustrt
+DEPS_std := prim native:rustrt
 DEPS_extra := std
 DEPS_green := std
 DEPS_rustuv := std native:uv native:uv_support

--- a/src/libextra/dlist.rs
+++ b/src/libextra/dlist.rs
@@ -86,7 +86,14 @@ impl<T> Rawlink<T> {
 
     /// Convert the `Rawlink` into an Option value
     fn resolve_immut(&self) -> Option<&T> {
-        unsafe { self.p.to_option() }
+        if self.p.is_null() {
+            None
+        } else {
+            unsafe {
+                let p: &T = &*self.p;
+                Some(p)
+            }
+        }
     }
 
     /// Convert the `Rawlink` into an Option value

--- a/src/libprim/cast.rs
+++ b/src/libprim/cast.rs
@@ -10,19 +10,7 @@
 
 //! Unsafe casting functions
 
-use mem;
-use unstable::intrinsics;
-use ptr::copy_nonoverlapping_memory;
-
-/// Casts the value at `src` to U. The two types must have the same length.
-#[inline]
-pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    let mut dest: U = intrinsics::uninit();
-    let dest_ptr: *mut u8 = transmute(&mut dest);
-    let src_ptr: *u8 = transmute(src);
-    copy_nonoverlapping_memory(dest_ptr, src_ptr, mem::size_of::<U>());
-    dest
-}
+use intrinsics;
 
 /**
  * Move a thing into the void
@@ -98,10 +86,15 @@ pub unsafe fn copy_lifetime_vec<'a,S,T>(_ptr: &'a [S], ptr: &T) -> &'a T {
     transmute_region(ptr)
 }
 
-
-/****************************************************************************
- * Tests
- ****************************************************************************/
+/// Casts the value at `src` to U. The two types must have the same length.
+#[inline]
+pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
+    let mut dest: U = intrinsics::uninit();
+    let dest_ptr: *mut u8 = transmute(&mut dest);
+    let src_ptr: *u8 = transmute(src);
+    intrinsics::copy_nonoverlapping_memory(dest_ptr, src_ptr, intrinsics::size_of::<U>());
+    dest
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/libprim/intrinsics.rs
+++ b/src/libprim/intrinsics.rs
@@ -43,7 +43,7 @@ A quick refresher on memory ordering:
 
 // This is needed to prevent duplicate lang item definitions.
 #[cfg(test)]
-pub use realstd::unstable::intrinsics::{TyDesc, Opaque, TyVisitor, TypeId};
+pub use realprim::intrinsics::{TyDesc, Opaque, TyVisitor, TypeId};
 
 pub type GlueFn = extern "Rust" fn(*i8);
 
@@ -502,10 +502,9 @@ extern "rust-intrinsic" {
 /// `TypeId` represents a globally unique identifier for a type
 #[lang="type_id"] // This needs to be kept in lockstep with the code in trans/intrinsic.rs and
                   // middle/lang_items.rs
-#[deriving(Eq, IterBytes)]
 #[cfg(not(test))]
 pub struct TypeId {
-    priv t: u64,
+    t: u64,
 }
 
 #[cfg(not(test))]

--- a/src/libprim/kinds.rs
+++ b/src/libprim/kinds.rs
@@ -89,7 +89,6 @@ pub mod marker {
     /// (for example, `S<&'static int>` is a subtype of `S<&'a int>`
     /// for some lifetime `'a`, but not the other way around).
     #[lang="covariant_type"]
-    #[deriving(Eq,Clone)]
     pub struct CovariantType<T>;
 
     /// A marker type whose type parameter `T` is considered to be
@@ -130,7 +129,6 @@ pub mod marker {
     /// function requires arguments of type `T`, it must also accept
     /// arguments of type `U`, hence such a conversion is safe.
     #[lang="contravariant_type"]
-    #[deriving(Eq,Clone)]
     pub struct ContravariantType<T>;
 
     /// A marker type whose type parameter `T` is considered to be
@@ -154,7 +152,6 @@ pub mod marker {
     /// never written, but in fact `Cell` uses unsafe code to achieve
     /// interior mutability.
     #[lang="invariant_type"]
-    #[deriving(Eq,Clone)]
     pub struct InvariantType<T>;
 
     /// As `CovariantType`, but for lifetime parameters. Using
@@ -174,7 +171,6 @@ pub mod marker {
     /// For more information about variance, refer to this Wikipedia
     /// article <http://en.wikipedia.org/wiki/Variance_%28computer_science%29>.
     #[lang="covariant_lifetime"]
-    #[deriving(Eq,Clone)]
     pub struct CovariantLifetime<'a>;
 
     /// As `ContravariantType`, but for lifetime parameters. Using
@@ -190,7 +186,6 @@ pub mod marker {
     /// For more information about variance, refer to this Wikipedia
     /// article <http://en.wikipedia.org/wiki/Variance_%28computer_science%29>.
     #[lang="contravariant_lifetime"]
-    #[deriving(Eq,Clone)]
     pub struct ContravariantLifetime<'a>;
 
     /// As `InvariantType`, but for lifetime parameters. Using
@@ -201,7 +196,6 @@ pub mod marker {
     /// and this pointer is itself stored in an inherently mutable
     /// location (such as a `Cell`).
     #[lang="invariant_lifetime"]
-    #[deriving(Eq,Clone)]
     pub struct InvariantLifetime<'a>;
 
     /// A type which is considered "not freezable", meaning that
@@ -209,7 +203,6 @@ pub mod marker {
     /// context or it is the referent of an `&T` pointer. This is
     /// typically embedded in other types, such as `Cell`.
     #[lang="no_freeze_bound"]
-    #[deriving(Eq,Clone)]
     pub struct NoFreeze;
 
     /// A type which is considered "not sendable", meaning that it cannot
@@ -217,19 +210,16 @@ pub mod marker {
     /// typically embedded in other types, such as `Gc`, to ensure that
     /// their instances remain thread-local.
     #[lang="no_send_bound"]
-    #[deriving(Eq,Clone)]
     pub struct NoSend;
 
     /// A type which is considered "not POD", meaning that it is not
     /// implicitly copyable. This is typically embedded in other types to
     /// ensure that they are never copied, even if they lack a destructor.
     #[lang="no_pod_bound"]
-    #[deriving(Eq,Clone)]
     pub struct NoPod;
 
     /// A type which is considered managed by the GC. This is typically
     /// embedded in other types.
     #[lang="managed_bound"]
-    #[deriving(Eq,Clone)]
     pub struct Managed;
 }

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -35,3 +35,5 @@ pub mod intrinsics;
 #[cfg(not(test))] pub mod kinds;
 pub mod mem;
 pub mod ptr;
+pub mod util;
+pub mod tuple;

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -20,6 +20,7 @@
 #[feature(globs)];
 #[feature(phase)];
 #[feature(macro_rules)];
+#[feature(managed_boxes)];
 
 #[cfg(test)] #[phase(syntax)] extern mod std;
 
@@ -36,5 +37,6 @@ pub mod intrinsics;
 #[cfg(not(test))] pub mod kinds;
 pub mod mem;
 pub mod ptr;
+pub mod raw;
 pub mod util;
 pub mod tuple;

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -19,6 +19,7 @@
 #[no_std];
 #[feature(globs)];
 #[feature(phase)];
+#[feature(macro_rules)];
 
 #[cfg(test)] #[phase(syntax)] extern mod std;
 

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_id = "prim#0.10-pre"];
+#[license = "MIT/ASL2"];
+#[crate_type = "rlib"];
+#[crate_type = "dylib"];
+#[doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
+      html_favicon_url = "http://www.rust-lang.org/favicon.ico",
+      html_root_url = "http://static.rust-lang.org/doc/master")];
+
+#[no_std];
+
+#[cfg(test)] extern mod realprim = "prim";
+#[cfg(test)] extern mod std;
+#[cfg(test)] extern mod rustuv;
+#[cfg(test)] extern mod green;
+#[cfg(test)] extern mod native;
+
+#[cfg(test)] pub use kinds = realprim::kinds;
+
+#[cfg(not(test))] pub mod kinds;

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -17,6 +17,10 @@
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
 #[no_std];
+#[feature(globs)];
+#[feature(phase)];
+
+#[cfg(test)] #[phase(syntax)] extern mod std;
 
 #[cfg(test)] extern mod realprim = "prim";
 #[cfg(test)] extern mod std;
@@ -28,3 +32,4 @@
 
 pub mod intrinsics;
 #[cfg(not(test))] pub mod kinds;
+pub mod mem;

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -34,3 +34,4 @@ pub mod cast;
 pub mod intrinsics;
 #[cfg(not(test))] pub mod kinds;
 pub mod mem;
+pub mod ptr;

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -26,4 +26,5 @@
 
 #[cfg(test)] pub use kinds = realprim::kinds;
 
+pub mod intrinsics;
 #[cfg(not(test))] pub mod kinds;

--- a/src/libprim/lib.rs
+++ b/src/libprim/lib.rs
@@ -30,6 +30,7 @@
 
 #[cfg(test)] pub use kinds = realprim::kinds;
 
+pub mod cast;
 pub mod intrinsics;
 #[cfg(not(test))] pub mod kinds;
 pub mod mem;

--- a/src/libprim/mem.rs
+++ b/src/libprim/mem.rs
@@ -10,7 +10,7 @@
 
 //! Functions relating to memory layout
 
-use unstable::intrinsics;
+use intrinsics;
 
 /// Returns the size of a type
 #[inline]

--- a/src/libprim/raw.rs
+++ b/src/libprim/raw.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use cast;
-use unstable::intrinsics::TyDesc;
+use intrinsics::TyDesc;
 
 /// The representation of a Rust managed box
 pub struct Box<T> {

--- a/src/libprim/tuple.rs
+++ b/src/libprim/tuple.rs
@@ -1,0 +1,202 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! tuple_extensions {
+    ($(
+        ($move_trait:ident, $immutable_trait:ident) {
+            $(($get_fn:ident, $get_ref_fn:ident) -> $T:ident {
+                $move_pattern:pat, $ref_pattern:pat => $ret:expr
+            })+
+        }
+    )+) => {
+        $(
+            pub trait $move_trait<$($T),+> {
+                $(fn $get_fn(self) -> $T;)+
+            }
+
+            impl<$($T),+> $move_trait<$($T),+> for ($($T,)+) {
+                $(
+                    #[inline]
+                    fn $get_fn(self) -> $T {
+                        let $move_pattern = self;
+                        $ret
+                    }
+                )+
+            }
+
+            pub trait $immutable_trait<$($T),+> {
+                $(fn $get_ref_fn<'a>(&'a self) -> &'a $T;)+
+            }
+
+            impl<$($T),+> $immutable_trait<$($T),+> for ($($T,)+) {
+                $(
+                    #[inline]
+                    fn $get_ref_fn<'a>(&'a self) -> &'a $T {
+                        let $ref_pattern = *self;
+                        $ret
+                    }
+                )+
+            }
+        )+
+    }
+
+}
+
+tuple_extensions! {
+    (Tuple1, ImmutableTuple1) {
+        (n0, n0_ref) -> A { (a,), (ref a,) => a }
+    }
+
+    (Tuple2, ImmutableTuple2) {
+        (n0, n0_ref) -> A { (a,_), (ref a,_) => a }
+        (n1, n1_ref) -> B { (_,b), (_,ref b) => b }
+    }
+
+    (Tuple3, ImmutableTuple3) {
+        (n0, n0_ref) -> A { (a,_,_), (ref a,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_), (_,ref b,_) => b }
+        (n2, n2_ref) -> C { (_,_,c), (_,_,ref c) => c }
+    }
+
+    (Tuple4, ImmutableTuple4) {
+        (n0, n0_ref) -> A { (a,_,_,_), (ref a,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_), (_,ref b,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_), (_,_,ref c,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d), (_,_,_,ref d) => d }
+    }
+
+    (Tuple5, ImmutableTuple5) {
+        (n0, n0_ref) -> A { (a,_,_,_,_), (ref a,_,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_,_), (_,ref b,_,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_,_), (_,_,ref c,_,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d,_), (_,_,_,ref d,_) => d }
+        (n4, n4_ref) -> E { (_,_,_,_,e), (_,_,_,_,ref e) => e }
+    }
+
+    (Tuple6, ImmutableTuple6) {
+        (n0, n0_ref) -> A { (a,_,_,_,_,_), (ref a,_,_,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_,_,_), (_,ref b,_,_,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_,_,_), (_,_,ref c,_,_,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d,_,_), (_,_,_,ref d,_,_) => d }
+        (n4, n4_ref) -> E { (_,_,_,_,e,_), (_,_,_,_,ref e,_) => e }
+        (n5, n5_ref) -> F { (_,_,_,_,_,f), (_,_,_,_,_,ref f) => f }
+    }
+
+    (Tuple7, ImmutableTuple7) {
+        (n0, n0_ref) -> A { (a,_,_,_,_,_,_), (ref a,_,_,_,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_,_,_,_), (_,ref b,_,_,_,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_,_,_,_), (_,_,ref c,_,_,_,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d,_,_,_), (_,_,_,ref d,_,_,_) => d }
+        (n4, n4_ref) -> E { (_,_,_,_,e,_,_), (_,_,_,_,ref e,_,_) => e }
+        (n5, n5_ref) -> F { (_,_,_,_,_,f,_), (_,_,_,_,_,ref f,_) => f }
+        (n6, n6_ref) -> G { (_,_,_,_,_,_,g), (_,_,_,_,_,_,ref g) => g }
+    }
+
+    (Tuple8, ImmutableTuple8) {
+        (n0, n0_ref) -> A { (a,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_,_,_,_,_), (_,_,ref c,_,_,_,_,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d,_,_,_,_), (_,_,_,ref d,_,_,_,_) => d }
+        (n4, n4_ref) -> E { (_,_,_,_,e,_,_,_), (_,_,_,_,ref e,_,_,_) => e }
+        (n5, n5_ref) -> F { (_,_,_,_,_,f,_,_), (_,_,_,_,_,ref f,_,_) => f }
+        (n6, n6_ref) -> G { (_,_,_,_,_,_,g,_), (_,_,_,_,_,_,ref g,_) => g }
+        (n7, n7_ref) -> H { (_,_,_,_,_,_,_,h), (_,_,_,_,_,_,_,ref h) => h }
+    }
+
+    (Tuple9, ImmutableTuple9) {
+        (n0, n0_ref) -> A { (a,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_) => d }
+        (n4, n4_ref) -> E { (_,_,_,_,e,_,_,_,_), (_,_,_,_,ref e,_,_,_,_) => e }
+        (n5, n5_ref) -> F { (_,_,_,_,_,f,_,_,_), (_,_,_,_,_,ref f,_,_,_) => f }
+        (n6, n6_ref) -> G { (_,_,_,_,_,_,g,_,_), (_,_,_,_,_,_,ref g,_,_) => g }
+        (n7, n7_ref) -> H { (_,_,_,_,_,_,_,h,_), (_,_,_,_,_,_,_,ref h,_) => h }
+        (n8, n8_ref) -> I { (_,_,_,_,_,_,_,_,i), (_,_,_,_,_,_,_,_,ref i) => i }
+    }
+
+    (Tuple10, ImmutableTuple10) {
+        (n0, n0_ref) -> A { (a,_,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_,_) => a }
+        (n1, n1_ref) -> B { (_,b,_,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_,_) => b }
+        (n2, n2_ref) -> C { (_,_,c,_,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_,_) => c }
+        (n3, n3_ref) -> D { (_,_,_,d,_,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_,_) => d }
+        (n4, n4_ref) -> E { (_,_,_,_,e,_,_,_,_,_), (_,_,_,_,ref e,_,_,_,_,_) => e }
+        (n5, n5_ref) -> F { (_,_,_,_,_,f,_,_,_,_), (_,_,_,_,_,ref f,_,_,_,_) => f }
+        (n6, n6_ref) -> G { (_,_,_,_,_,_,g,_,_,_), (_,_,_,_,_,_,ref g,_,_,_) => g }
+        (n7, n7_ref) -> H { (_,_,_,_,_,_,_,h,_,_), (_,_,_,_,_,_,_,ref h,_,_) => h }
+        (n8, n8_ref) -> I { (_,_,_,_,_,_,_,_,i,_), (_,_,_,_,_,_,_,_,ref i,_) => i }
+        (n9, n9_ref) -> J { (_,_,_,_,_,_,_,_,_,j), (_,_,_,_,_,_,_,_,_,ref j) => j }
+    }
+
+    (Tuple11, ImmutableTuple11) {
+        (n0,  n0_ref)  -> A { (a,_,_,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_,_,_) => a }
+        (n1,  n1_ref)  -> B { (_,b,_,_,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_,_,_) => b }
+        (n2,  n2_ref)  -> C { (_,_,c,_,_,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_,_,_) => c }
+        (n3,  n3_ref)  -> D { (_,_,_,d,_,_,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_,_,_) => d }
+        (n4,  n4_ref)  -> E { (_,_,_,_,e,_,_,_,_,_,_), (_,_,_,_,ref e,_,_,_,_,_,_) => e }
+        (n5,  n5_ref)  -> F { (_,_,_,_,_,f,_,_,_,_,_), (_,_,_,_,_,ref f,_,_,_,_,_) => f }
+        (n6,  n6_ref)  -> G { (_,_,_,_,_,_,g,_,_,_,_), (_,_,_,_,_,_,ref g,_,_,_,_) => g }
+        (n7,  n7_ref)  -> H { (_,_,_,_,_,_,_,h,_,_,_), (_,_,_,_,_,_,_,ref h,_,_,_) => h }
+        (n8,  n8_ref)  -> I { (_,_,_,_,_,_,_,_,i,_,_), (_,_,_,_,_,_,_,_,ref i,_,_) => i }
+        (n9,  n9_ref)  -> J { (_,_,_,_,_,_,_,_,_,j,_), (_,_,_,_,_,_,_,_,_,ref j,_) => j }
+        (n10, n10_ref) -> K { (_,_,_,_,_,_,_,_,_,_,k), (_,_,_,_,_,_,_,_,_,_,ref k) => k }
+    }
+
+    (Tuple12, ImmutableTuple12) {
+        (n0,  n0_ref)  -> A { (a,_,_,_,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_,_,_,_) => a }
+        (n1,  n1_ref)  -> B { (_,b,_,_,_,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_,_,_,_) => b }
+        (n2,  n2_ref)  -> C { (_,_,c,_,_,_,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_,_,_,_) => c }
+        (n3,  n3_ref)  -> D { (_,_,_,d,_,_,_,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_,_,_,_) => d }
+        (n4,  n4_ref)  -> E { (_,_,_,_,e,_,_,_,_,_,_,_), (_,_,_,_,ref e,_,_,_,_,_,_,_) => e }
+        (n5,  n5_ref)  -> F { (_,_,_,_,_,f,_,_,_,_,_,_), (_,_,_,_,_,ref f,_,_,_,_,_,_) => f }
+        (n6,  n6_ref)  -> G { (_,_,_,_,_,_,g,_,_,_,_,_), (_,_,_,_,_,_,ref g,_,_,_,_,_) => g }
+        (n7,  n7_ref)  -> H { (_,_,_,_,_,_,_,h,_,_,_,_), (_,_,_,_,_,_,_,ref h,_,_,_,_) => h }
+        (n8,  n8_ref)  -> I { (_,_,_,_,_,_,_,_,i,_,_,_), (_,_,_,_,_,_,_,_,ref i,_,_,_) => i }
+        (n9,  n9_ref)  -> J { (_,_,_,_,_,_,_,_,_,j,_,_), (_,_,_,_,_,_,_,_,_,ref j,_,_) => j }
+        (n10, n10_ref) -> K { (_,_,_,_,_,_,_,_,_,_,k,_), (_,_,_,_,_,_,_,_,_,_,ref k,_) => k }
+        (n11, n11_ref) -> L { (_,_,_,_,_,_,_,_,_,_,_,l), (_,_,_,_,_,_,_,_,_,_,_,ref l) => l }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_n_tuple() {
+        let t = (0u8, 1u16, 2u32, 3u64, 4u, 5i8, 6i16, 7i32, 8i64, 9i, 10f32, 11f64);
+        assert_eq!(t.n0(), 0u8);
+        assert_eq!(t.n1(), 1u16);
+        assert_eq!(t.n2(), 2u32);
+        assert_eq!(t.n3(), 3u64);
+        assert_eq!(t.n4(), 4u);
+        assert_eq!(t.n5(), 5i8);
+        assert_eq!(t.n6(), 6i16);
+        assert_eq!(t.n7(), 7i32);
+        assert_eq!(t.n8(), 8i64);
+        assert_eq!(t.n9(), 9i);
+        assert_eq!(t.n10(), 10f32);
+        assert_eq!(t.n11(), 11f64);
+
+        assert_eq!(t.n0_ref(), &0u8);
+        assert_eq!(t.n1_ref(), &1u16);
+        assert_eq!(t.n2_ref(), &2u32);
+        assert_eq!(t.n3_ref(), &3u64);
+        assert_eq!(t.n4_ref(), &4u);
+        assert_eq!(t.n5_ref(), &5i8);
+        assert_eq!(t.n6_ref(), &6i16);
+        assert_eq!(t.n7_ref(), &7i32);
+        assert_eq!(t.n8_ref(), &8i64);
+        assert_eq!(t.n9_ref(), &9i);
+        assert_eq!(t.n10_ref(), &10f32);
+        assert_eq!(t.n11_ref(), &11f64);
+    }
+}

--- a/src/libprim/util.rs
+++ b/src/libprim/util.rs
@@ -1,0 +1,70 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use cast;
+use intrinsics;
+use ptr;
+
+/**
+ * Swap the values at two mutable locations of the same type, without
+ * deinitialising or copying either one.
+ */
+#[inline]
+pub fn swap<T>(x: &mut T, y: &mut T) {
+    unsafe {
+        // Give ourselves some scratch space to work with
+        let mut tmp: T = intrinsics::uninit();
+        let t: *mut T = &mut tmp;
+
+        // Perform the swap, `&mut` pointers never alias
+        let x_raw: *mut T = x;
+        let y_raw: *mut T = y;
+        ptr::copy_nonoverlapping_memory(t, &*x_raw, 1);
+        ptr::copy_nonoverlapping_memory(x, &*y_raw, 1);
+        ptr::copy_nonoverlapping_memory(y, &*t, 1);
+
+        // y and t now point to the same thing, but we need to completely forget `tmp`
+        // because it's no longer relevant.
+        cast::forget(tmp);
+    }
+}
+
+/**
+ * Replace the value at a mutable location with a new one, returning the old
+ * value, without deinitialising or copying either one.
+ */
+#[inline]
+pub fn replace<T>(dest: &mut T, mut src: T) -> T {
+    swap(dest, &mut src);
+    src
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{swap, replace};
+
+    #[test]
+    fn test_swap() {
+        let mut x = 31337;
+        let mut y = 42;
+        swap(&mut x, &mut y);
+        assert_eq!(x, 42);
+        assert_eq!(y, 31337);
+    }
+
+    #[test]
+    fn test_replace() {
+        let mut x = 1;
+        let y = replace(&mut x, 2);
+        assert!(x == 2);
+        assert!(y == 1);
+    }
+}

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -10,7 +10,6 @@
 
 //! Unsafe casting functions
 
-use ptr::RawPtr;
 use mem;
 use unstable::intrinsics;
 use ptr::copy_nonoverlapping_memory;
@@ -72,13 +71,13 @@ pub unsafe fn transmute_region<'a,'b,T>(ptr: &'a T) -> &'b T {
 
 /// Coerce an immutable reference to be mutable.
 #[inline]
-pub unsafe fn transmute_mut_unsafe<T,P:RawPtr<T>>(ptr: P) -> *mut T {
+pub unsafe fn transmute_mut_unsafe<T>(ptr: *T) -> *mut T {
     transmute(ptr)
 }
 
 /// Coerce an immutable reference to be mutable.
 #[inline]
-pub unsafe fn transmute_immut_unsafe<T,P:RawPtr<T>>(ptr: P) -> *T {
+pub unsafe fn transmute_immut_unsafe<T>(ptr: *mut T) -> *T {
     transmute(ptr)
 }
 

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -105,21 +105,20 @@ pub unsafe fn copy_lifetime_vec<'a,S,T>(_ptr: &'a [S], ptr: &T) -> &'a T {
 
 #[cfg(test)]
 mod tests {
-    use cast::transmute;
-    use unstable::raw;
+    use super::*;
 
     #[test]
     fn test_transmute_copy() {
-        assert_eq!(1u, unsafe { ::cast::transmute_copy(&1) });
+        assert_eq!(1u, unsafe { transmute_copy(&1) });
     }
 
     #[test]
     fn test_transmute() {
         unsafe {
-            let x = @100u8;
-            let x: *raw::Box<u8> = transmute(x);
-            assert!((*x).data == 100);
-            let _x: @int = transmute(x);
+            let x = ~100u8;
+            let x: *u8 = transmute(x);
+            assert!(*x == 100);
+            let _x: ~u8 = transmute(x);
         }
     }
 

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -35,13 +35,6 @@ pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
 pub unsafe fn forget<T>(thing: T) { intrinsics::forget(thing); }
 
 /**
- * Force-increment the reference count on a shared box. If used
- * carelessly, this can leak the box.
- */
-#[inline]
-pub unsafe fn bump_box_refcount<T>(t: @T) { forget(t); }
-
-/**
  * Transform a value of one type into a value of another type.
  * Both types must have the same size and alignment.
  *
@@ -112,27 +105,12 @@ pub unsafe fn copy_lifetime_vec<'a,S,T>(_ptr: &'a [S], ptr: &T) -> &'a T {
 
 #[cfg(test)]
 mod tests {
-    use cast::{bump_box_refcount, transmute};
+    use cast::transmute;
     use unstable::raw;
 
     #[test]
     fn test_transmute_copy() {
         assert_eq!(1u, unsafe { ::cast::transmute_copy(&1) });
-    }
-
-    #[test]
-    fn test_bump_managed_refcount() {
-        unsafe {
-            let managed = @~"box box box";      // refcount 1
-            bump_box_refcount(managed);     // refcount 2
-            let ptr: *int = transmute(managed); // refcount 2
-            let _box1: @~str = ::cast::transmute_copy(&ptr);
-            let _box2: @~str = ::cast::transmute_copy(&ptr);
-            assert!(*_box1 == ~"box box box");
-            assert!(*_box2 == ~"box box box");
-            // Will destroy _box1 and _box2. Without the bump, this would
-            // use-after-free. With too many bumps, it would leak.
-        }
     }
 
     #[test]

--- a/src/libstd/clone.rs
+++ b/src/libstd/clone.rs
@@ -22,6 +22,7 @@ the `clone` method.
 */
 
 use std::kinds::Freeze;
+use prim::kinds::marker;
 
 /// A common trait for cloning an object.
 pub trait Clone {
@@ -210,6 +211,56 @@ extern_fn_deep_clone!(A, B, C, D, E)
 extern_fn_deep_clone!(A, B, C, D, E, F)
 extern_fn_deep_clone!(A, B, C, D, E, F, G)
 extern_fn_deep_clone!(A, B, C, D, E, F, G, H)
+
+impl<T> Clone for marker::CovariantType<T> {
+    #[inline]
+    fn clone(&self) -> marker::CovariantType<T> { *self }
+}
+
+impl<T> Clone for marker::ContravariantType<T> {
+    #[inline]
+    fn clone(&self) -> marker::ContravariantType<T> { *self }
+}
+
+impl<T> Clone for marker::InvariantType<T> {
+    #[inline]
+    fn clone(&self) -> marker::InvariantType<T> { *self }
+}
+
+impl<'a> Clone for marker::CovariantLifetime<'a> {
+    #[inline]
+    fn clone(&self) -> marker::CovariantLifetime<'a> { *self }
+}
+
+impl<'a> Clone for marker::ContravariantLifetime<'a> {
+    #[inline]
+    fn clone(&self) -> marker::ContravariantLifetime<'a> { *self }
+}
+
+impl<'a> Clone for marker::InvariantLifetime<'a> {
+    #[inline]
+    fn clone(&self) -> marker::InvariantLifetime<'a> { *self }
+}
+
+impl Clone for marker::NoFreeze {
+    #[inline]
+    fn clone(&self) -> marker::NoFreeze { *self }
+}
+
+impl Clone for marker::NoSend {
+    #[inline]
+    fn clone(&self) -> marker::NoSend { *self }
+}
+
+impl Clone for marker::NoPod {
+    #[inline]
+    fn clone(&self) -> marker::NoPod { marker::NoPod }
+}
+
+impl Clone for marker::Managed {
+    #[inline]
+    fn clone(&self) -> marker::Managed { *self }
+}
 
 #[test]
 fn test_owned_clone() {

--- a/src/libstd/clone.rs
+++ b/src/libstd/clone.rs
@@ -42,6 +42,20 @@ pub trait Clone {
     }
 }
 
+impl<T> Clone for *T {
+    #[inline]
+    fn clone(&self) -> *T {
+        *self
+    }
+}
+
+impl<T> Clone for *mut T {
+    #[inline]
+    fn clone(&self) -> *mut T {
+        *self
+    }
+}
+
 impl<T: Clone> Clone for ~T {
     /// Return a copy of the owned box.
     #[inline]

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -22,6 +22,8 @@ and `Eq` to overload the `==` and `!=` operators.
 
 #[allow(missing_doc)];
 
+use kinds::marker;
+
 /**
 * Trait for values that can be compared for equality and inequality.
 *
@@ -187,6 +189,56 @@ pub fn min<T:Ord>(v1: T, v2: T) -> T {
 #[inline]
 pub fn max<T:Ord>(v1: T, v2: T) -> T {
     if v1 > v2 { v1 } else { v2 }
+}
+
+impl<T> Eq for marker::CovariantType<T> {
+    #[inline]
+    fn eq(&self, _other: &marker::CovariantType<T>) -> bool { true }
+}
+
+impl<T> Eq for marker::ContravariantType<T> {
+    #[inline]
+    fn eq(&self, _other: &marker::ContravariantType<T>) -> bool { true }
+}
+
+impl<T> Eq for marker::InvariantType<T> {
+    #[inline]
+    fn eq(&self, _other: &marker::InvariantType<T>) -> bool { true }
+}
+
+impl<'a> Eq for marker::CovariantLifetime<'a> {
+    #[inline]
+    fn eq(&self, _other: &marker::CovariantLifetime<'a>) -> bool { true }
+}
+
+impl<'a> Eq for marker::ContravariantLifetime<'a> {
+    #[inline]
+    fn eq(&self, _other: &marker::ContravariantLifetime<'a>) -> bool { true }
+}
+
+impl<'a> Eq for marker::InvariantLifetime<'a> {
+    #[inline]
+    fn eq(&self, _other: &marker::InvariantLifetime<'a>) -> bool { true }
+}
+
+impl Eq for marker::NoFreeze {
+    #[inline]
+    fn eq(&self, _other: &marker::NoFreeze) -> bool { true }
+}
+
+impl Eq for marker::NoSend {
+    #[inline]
+    fn eq(&self, _other: &marker::NoSend) -> bool { true }
+}
+
+impl Eq for marker::NoPod {
+    #[inline]
+    fn eq(&self, _other: &marker::NoPod) -> bool { true }
+}
+
+impl Eq for marker::Managed {
+    #[inline]
+    fn eq(&self, _other: &marker::Managed) -> bool { true }
 }
 
 #[cfg(test)]

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -23,6 +23,7 @@ and `Eq` to overload the `==` and `!=` operators.
 #[allow(missing_doc)];
 
 use kinds::marker;
+use prim::intrinsics::TypeId;
 
 /**
 * Trait for values that can be compared for equality and inequality.
@@ -41,6 +42,12 @@ pub trait Eq {
 
     #[inline]
     fn ne(&self, other: &Self) -> bool { !self.eq(other) }
+}
+
+impl Eq for TypeId {
+    fn eq(&self, other: &TypeId) -> bool {
+        self.t == other.t
+    }
 }
 
 /// Trait for equality comparisons where `a == b` and `a != b` are strict inverses.

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -79,6 +79,7 @@ extern mod prim;
 #[cfg(test)] pub use cmp = realstd::cmp;
 
 pub use prim::kinds;
+pub use prim::mem;
 
 mod macros;
 
@@ -184,7 +185,6 @@ pub mod cleanup;
 pub mod condition;
 pub mod logging;
 pub mod util;
-pub mod mem;
 
 
 /* Unsupported interfaces */

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -81,6 +81,7 @@ extern mod prim;
 pub use prim::cast;
 pub use prim::kinds;
 pub use prim::mem;
+pub use prim::ptr;
 
 mod macros;
 
@@ -124,7 +125,6 @@ pub mod str;
 pub mod ascii;
 pub mod send_str;
 
-pub mod ptr;
 pub mod owned;
 pub mod managed;
 mod reference;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -78,6 +78,7 @@ extern mod prim;
 #[cfg(test)] pub use ops = realstd::ops;
 #[cfg(test)] pub use cmp = realstd::cmp;
 
+pub use prim::cast;
 pub use prim::kinds;
 pub use prim::mem;
 
@@ -178,7 +179,6 @@ pub mod io;
 pub mod path;
 pub mod rand;
 pub mod run;
-pub mod cast;
 pub mod fmt;
 pub mod cleanup;
 #[deprecated]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -61,6 +61,8 @@
 #[deny(missing_doc)];
 #[allow(unknown_features)];
 
+extern mod prim;
+
 // When testing libstd, bring in libuv as the I/O backend so tests can print
 // things and all of the std::io tests have an I/O interface to run on top
 // of
@@ -73,9 +75,10 @@
 
 // Make std testable by not duplicating lang items. See #2912
 #[cfg(test)] extern mod realstd = "std";
-#[cfg(test)] pub use kinds = realstd::kinds;
 #[cfg(test)] pub use ops = realstd::ops;
 #[cfg(test)] pub use cmp = realstd::cmp;
+
+pub use prim::kinds;
 
 mod macros;
 
@@ -129,7 +132,6 @@ pub mod gc;
 
 /* Core language traits */
 
-#[cfg(not(test))] pub mod kinds;
 #[cfg(not(test))] pub mod ops;
 #[cfg(not(test))] pub mod cmp;
 

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -91,8 +91,8 @@ pub fn is_not_null<T,P:RawPtr<T>>(ptr: P) -> bool { ptr.is_not_null() }
  * and destination may overlap.
  */
 #[inline]
-pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
-    intrinsics::copy_memory(dst, cast::transmute_immut_unsafe(src), count)
+pub unsafe fn copy_memory<T>(dst: *mut T, src: *T, count: uint) {
+    intrinsics::copy_memory(dst, src, count)
 }
 
 /**
@@ -102,10 +102,10 @@ pub unsafe fn copy_memory<T,P:RawPtr<T>>(dst: *mut T, src: P, count: uint) {
  * and destination may *not* overlap.
  */
 #[inline]
-pub unsafe fn copy_nonoverlapping_memory<T,P:RawPtr<T>>(dst: *mut T,
-                                                        src: P,
-                                                        count: uint) {
-    intrinsics::copy_nonoverlapping_memory(dst, cast::transmute_immut_unsafe(src), count)
+pub unsafe fn copy_nonoverlapping_memory<T>(dst: *mut T,
+                                            src: *T,
+                                            count: uint) {
+    intrinsics::copy_nonoverlapping_memory(dst, src, count)
 }
 
 /**
@@ -136,9 +136,9 @@ pub unsafe fn swap_ptr<T>(x: *mut T, y: *mut T) {
     let t: *mut T = &mut tmp;
 
     // Perform the swap
-    copy_nonoverlapping_memory(t, x, 1);
-    copy_memory(x, y, 1); // `x` and `y` may overlap
-    copy_nonoverlapping_memory(y, t, 1);
+    copy_nonoverlapping_memory(t, &*x, 1);
+    copy_memory(x, &*y, 1); // `x` and `y` may overlap
+    copy_nonoverlapping_memory(y, &*t, 1);
 
     // y and t now point to the same thing, but we need to completely forget `tmp`
     // because it's no longer relevant.

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -14,7 +14,6 @@ use cast;
 use clone::Clone;
 #[cfg(not(test))]
 use cmp::Equiv;
-use option::{Option, Some, None};
 use unstable::intrinsics;
 use util::swap;
 
@@ -197,7 +196,6 @@ pub trait RawPtr<T> {
     fn is_null(&self) -> bool;
     fn is_not_null(&self) -> bool;
     fn to_uint(&self) -> uint;
-    unsafe fn to_option(&self) -> Option<&T>;
     unsafe fn offset(self, count: int) -> Self;
 }
 
@@ -218,23 +216,6 @@ impl<T> RawPtr<T> for *T {
     /// Returns the address of this pointer.
     #[inline]
     fn to_uint(&self) -> uint { *self as uint }
-
-    ///
-    /// Returns `None` if the pointer is null, or else returns the value wrapped
-    /// in `Some`.
-    ///
-    /// # Safety Notes
-    ///
-    /// While this method is useful for null-safety, it is important to note
-    /// that this is still an unsafe operation because the returned value could
-    /// be pointing to invalid memory.
-    ///
-    #[inline]
-    unsafe fn to_option(&self) -> Option<&T> {
-        if self.is_null() { None } else {
-            Some(cast::transmute(*self))
-        }
-    }
 
     /// Calculates the offset from a pointer. The offset *must* be in-bounds of
     /// the object, or one-byte-past-the-end.
@@ -259,23 +240,6 @@ impl<T> RawPtr<T> for *mut T {
     /// Returns the address of this pointer.
     #[inline]
     fn to_uint(&self) -> uint { *self as uint }
-
-    ///
-    /// Returns `None` if the pointer is null, or else returns the value wrapped
-    /// in `Some`.
-    ///
-    /// # Safety Notes
-    ///
-    /// While this method is useful for null-safety, it is important to note
-    /// that this is still an unsafe operation because the returned value could
-    /// be pointing to invalid memory.
-    ///
-    #[inline]
-    unsafe fn to_option(&self) -> Option<&T> {
-        if self.is_null() { None } else {
-            Some(cast::transmute(*self))
-        }
-    }
 
     /// Calculates the offset from a pointer. The offset *must* be in-bounds of
     /// the object, or one-byte-past-the-end. An arithmetic overflow is also
@@ -497,23 +461,6 @@ pub mod ptr_tests {
         let mq = unsafe { mp.offset(1) };
         assert!(!mq.is_null());
         assert!(mq.is_not_null());
-    }
-
-    #[test]
-    fn test_to_option() {
-        unsafe {
-            let p: *int = null();
-            assert_eq!(p.to_option(), None);
-
-            let q: *int = &2;
-            assert_eq!(q.to_option().unwrap(), &2);
-
-            let p: *mut int = mut_null();
-            assert_eq!(p.to_option(), None);
-
-            let q: *mut int = &mut 2;
-            assert_eq!(q.to_option().unwrap(), &2);
-        }
     }
 
     #[test]

--- a/src/libstd/to_bytes.rs
+++ b/src/libstd/to_bytes.rs
@@ -18,6 +18,7 @@ use cast;
 use container::Container;
 use iter::Iterator;
 use option::{None, Option, Some};
+use prim::intrinsics::TypeId;
 use rc::Rc;
 use str::{Str, StrSlice};
 use vec::{Vector, ImmutableVector};
@@ -52,6 +53,13 @@ pub trait IterBytes {
     /// underlying memory endianness.
     ///
     fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool;
+}
+
+impl IterBytes for TypeId {
+    #[inline]
+    fn iter_bytes(&self, lsb0: bool, f: Cb) -> bool {
+        self.t.iter_bytes(lsb0, f)
+    }
 }
 
 impl IterBytes for bool {

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -16,6 +16,14 @@ use clone::Clone;
 #[cfg(not(test))] use cmp::*;
 #[cfg(not(test))] use default::Default;
 
+pub use prim::tuple::{ImmutableTuple1, ImmutableTuple2, ImmutableTuple3, ImmutableTuple4};
+pub use prim::tuple::{ImmutableTuple5, ImmutableTuple6, ImmutableTuple7, ImmutableTuple8};
+pub use prim::tuple::{ImmutableTuple9, ImmutableTuple10, ImmutableTuple11, ImmutableTuple12};
+pub use prim::tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
+pub use prim::tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
+pub use prim::tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
+
+
 /// Method extensions to pairs where both types satisfy the `Clone` bound
 pub trait CloneableTuple<T, U> {
     /// Return the first element of self
@@ -80,40 +88,12 @@ impl<T, U> ImmutableTuple<T, U> for (T, U) {
 
 macro_rules! tuple_impls {
     ($(
-        ($move_trait:ident, $immutable_trait:ident) {
-            $(($get_fn:ident, $get_ref_fn:ident) -> $T:ident {
-                $move_pattern:pat, $ref_pattern:pat => $ret:expr
-            })+
+       {
+            $(($get_ref_fn:ident) -> $T:ident;
+            )+
         }
     )+) => {
         $(
-            pub trait $move_trait<$($T),+> {
-                $(fn $get_fn(self) -> $T;)+
-            }
-
-            impl<$($T),+> $move_trait<$($T),+> for ($($T,)+) {
-                $(
-                    #[inline]
-                    fn $get_fn(self) -> $T {
-                        let $move_pattern = self;
-                        $ret
-                    }
-                )+
-            }
-
-            pub trait $immutable_trait<$($T),+> {
-                $(fn $get_ref_fn<'a>(&'a self) -> &'a $T;)+
-            }
-
-            impl<$($T),+> $immutable_trait<$($T),+> for ($($T,)+) {
-                $(
-                    #[inline]
-                    fn $get_ref_fn<'a>(&'a self) -> &'a $T {
-                        let $ref_pattern = *self;
-                        $ret
-                    }
-                )+
-            }
 
             impl<$($T:Clone),+> Clone for ($($T,)+) {
                 fn clone(&self) -> ($($T,)+) {
@@ -204,118 +184,118 @@ macro_rules! lexical_cmp {
 
 
 tuple_impls! {
-    (Tuple1, ImmutableTuple1) {
-        (n0, n0_ref) -> A { (a,), (ref a,) => a }
+    {
+        (n0_ref) -> A;
     }
 
-    (Tuple2, ImmutableTuple2) {
-        (n0, n0_ref) -> A { (a,_), (ref a,_) => a }
-        (n1, n1_ref) -> B { (_,b), (_,ref b) => b }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
     }
 
-    (Tuple3, ImmutableTuple3) {
-        (n0, n0_ref) -> A { (a,_,_), (ref a,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_), (_,ref b,_) => b }
-        (n2, n2_ref) -> C { (_,_,c), (_,_,ref c) => c }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
     }
 
-    (Tuple4, ImmutableTuple4) {
-        (n0, n0_ref) -> A { (a,_,_,_), (ref a,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_), (_,ref b,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_), (_,_,ref c,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d), (_,_,_,ref d) => d }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
     }
 
-    (Tuple5, ImmutableTuple5) {
-        (n0, n0_ref) -> A { (a,_,_,_,_), (ref a,_,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_,_), (_,ref b,_,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_,_), (_,_,ref c,_,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d,_), (_,_,_,ref d,_) => d }
-        (n4, n4_ref) -> E { (_,_,_,_,e), (_,_,_,_,ref e) => e }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
+        (n4_ref) -> E;
     }
 
-    (Tuple6, ImmutableTuple6) {
-        (n0, n0_ref) -> A { (a,_,_,_,_,_), (ref a,_,_,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_,_,_), (_,ref b,_,_,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_,_,_), (_,_,ref c,_,_,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d,_,_), (_,_,_,ref d,_,_) => d }
-        (n4, n4_ref) -> E { (_,_,_,_,e,_), (_,_,_,_,ref e,_) => e }
-        (n5, n5_ref) -> F { (_,_,_,_,_,f), (_,_,_,_,_,ref f) => f }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
+        (n4_ref) -> E;
+        (n5_ref) -> F;
     }
 
-    (Tuple7, ImmutableTuple7) {
-        (n0, n0_ref) -> A { (a,_,_,_,_,_,_), (ref a,_,_,_,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_,_,_,_), (_,ref b,_,_,_,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_,_,_,_), (_,_,ref c,_,_,_,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d,_,_,_), (_,_,_,ref d,_,_,_) => d }
-        (n4, n4_ref) -> E { (_,_,_,_,e,_,_), (_,_,_,_,ref e,_,_) => e }
-        (n5, n5_ref) -> F { (_,_,_,_,_,f,_), (_,_,_,_,_,ref f,_) => f }
-        (n6, n6_ref) -> G { (_,_,_,_,_,_,g), (_,_,_,_,_,_,ref g) => g }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
+        (n4_ref) -> E;
+        (n5_ref) -> F;
+        (n6_ref) -> G;
     }
 
-    (Tuple8, ImmutableTuple8) {
-        (n0, n0_ref) -> A { (a,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_,_,_,_,_), (_,_,ref c,_,_,_,_,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d,_,_,_,_), (_,_,_,ref d,_,_,_,_) => d }
-        (n4, n4_ref) -> E { (_,_,_,_,e,_,_,_), (_,_,_,_,ref e,_,_,_) => e }
-        (n5, n5_ref) -> F { (_,_,_,_,_,f,_,_), (_,_,_,_,_,ref f,_,_) => f }
-        (n6, n6_ref) -> G { (_,_,_,_,_,_,g,_), (_,_,_,_,_,_,ref g,_) => g }
-        (n7, n7_ref) -> H { (_,_,_,_,_,_,_,h), (_,_,_,_,_,_,_,ref h) => h }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
+        (n4_ref) -> E;
+        (n5_ref) -> F;
+        (n6_ref) -> G;
+        (n7_ref) -> H;
     }
 
-    (Tuple9, ImmutableTuple9) {
-        (n0, n0_ref) -> A { (a,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_) => d }
-        (n4, n4_ref) -> E { (_,_,_,_,e,_,_,_,_), (_,_,_,_,ref e,_,_,_,_) => e }
-        (n5, n5_ref) -> F { (_,_,_,_,_,f,_,_,_), (_,_,_,_,_,ref f,_,_,_) => f }
-        (n6, n6_ref) -> G { (_,_,_,_,_,_,g,_,_), (_,_,_,_,_,_,ref g,_,_) => g }
-        (n7, n7_ref) -> H { (_,_,_,_,_,_,_,h,_), (_,_,_,_,_,_,_,ref h,_) => h }
-        (n8, n8_ref) -> I { (_,_,_,_,_,_,_,_,i), (_,_,_,_,_,_,_,_,ref i) => i }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
+        (n4_ref) -> E;
+        (n5_ref) -> F;
+        (n6_ref) -> G;
+        (n7_ref) -> H;
+        (n8_ref) -> I;
     }
 
-    (Tuple10, ImmutableTuple10) {
-        (n0, n0_ref) -> A { (a,_,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_,_) => a }
-        (n1, n1_ref) -> B { (_,b,_,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_,_) => b }
-        (n2, n2_ref) -> C { (_,_,c,_,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_,_) => c }
-        (n3, n3_ref) -> D { (_,_,_,d,_,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_,_) => d }
-        (n4, n4_ref) -> E { (_,_,_,_,e,_,_,_,_,_), (_,_,_,_,ref e,_,_,_,_,_) => e }
-        (n5, n5_ref) -> F { (_,_,_,_,_,f,_,_,_,_), (_,_,_,_,_,ref f,_,_,_,_) => f }
-        (n6, n6_ref) -> G { (_,_,_,_,_,_,g,_,_,_), (_,_,_,_,_,_,ref g,_,_,_) => g }
-        (n7, n7_ref) -> H { (_,_,_,_,_,_,_,h,_,_), (_,_,_,_,_,_,_,ref h,_,_) => h }
-        (n8, n8_ref) -> I { (_,_,_,_,_,_,_,_,i,_), (_,_,_,_,_,_,_,_,ref i,_) => i }
-        (n9, n9_ref) -> J { (_,_,_,_,_,_,_,_,_,j), (_,_,_,_,_,_,_,_,_,ref j) => j }
+    {
+        (n0_ref) -> A;
+        (n1_ref) -> B;
+        (n2_ref) -> C;
+        (n3_ref) -> D;
+        (n4_ref) -> E;
+        (n5_ref) -> F;
+        (n6_ref) -> G;
+        (n7_ref) -> H;
+        (n8_ref) -> I;
+        (n9_ref) -> J;
     }
 
-    (Tuple11, ImmutableTuple11) {
-        (n0,  n0_ref)  -> A { (a,_,_,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_,_,_) => a }
-        (n1,  n1_ref)  -> B { (_,b,_,_,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_,_,_) => b }
-        (n2,  n2_ref)  -> C { (_,_,c,_,_,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_,_,_) => c }
-        (n3,  n3_ref)  -> D { (_,_,_,d,_,_,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_,_,_) => d }
-        (n4,  n4_ref)  -> E { (_,_,_,_,e,_,_,_,_,_,_), (_,_,_,_,ref e,_,_,_,_,_,_) => e }
-        (n5,  n5_ref)  -> F { (_,_,_,_,_,f,_,_,_,_,_), (_,_,_,_,_,ref f,_,_,_,_,_) => f }
-        (n6,  n6_ref)  -> G { (_,_,_,_,_,_,g,_,_,_,_), (_,_,_,_,_,_,ref g,_,_,_,_) => g }
-        (n7,  n7_ref)  -> H { (_,_,_,_,_,_,_,h,_,_,_), (_,_,_,_,_,_,_,ref h,_,_,_) => h }
-        (n8,  n8_ref)  -> I { (_,_,_,_,_,_,_,_,i,_,_), (_,_,_,_,_,_,_,_,ref i,_,_) => i }
-        (n9,  n9_ref)  -> J { (_,_,_,_,_,_,_,_,_,j,_), (_,_,_,_,_,_,_,_,_,ref j,_) => j }
-        (n10, n10_ref) -> K { (_,_,_,_,_,_,_,_,_,_,k), (_,_,_,_,_,_,_,_,_,_,ref k) => k }
+    {
+        (n0_ref)  -> A;
+        (n1_ref)  -> B;
+        (n2_ref)  -> C;
+        (n3_ref)  -> D;
+        (n4_ref)  -> E;
+        (n5_ref)  -> F;
+        (n6_ref)  -> G;
+        (n7_ref)  -> H;
+        (n8_ref)  -> I;
+        (n9_ref)  -> J;
+        (n10_ref) -> K;
     }
 
-    (Tuple12, ImmutableTuple12) {
-        (n0,  n0_ref)  -> A { (a,_,_,_,_,_,_,_,_,_,_,_), (ref a,_,_,_,_,_,_,_,_,_,_,_) => a }
-        (n1,  n1_ref)  -> B { (_,b,_,_,_,_,_,_,_,_,_,_), (_,ref b,_,_,_,_,_,_,_,_,_,_) => b }
-        (n2,  n2_ref)  -> C { (_,_,c,_,_,_,_,_,_,_,_,_), (_,_,ref c,_,_,_,_,_,_,_,_,_) => c }
-        (n3,  n3_ref)  -> D { (_,_,_,d,_,_,_,_,_,_,_,_), (_,_,_,ref d,_,_,_,_,_,_,_,_) => d }
-        (n4,  n4_ref)  -> E { (_,_,_,_,e,_,_,_,_,_,_,_), (_,_,_,_,ref e,_,_,_,_,_,_,_) => e }
-        (n5,  n5_ref)  -> F { (_,_,_,_,_,f,_,_,_,_,_,_), (_,_,_,_,_,ref f,_,_,_,_,_,_) => f }
-        (n6,  n6_ref)  -> G { (_,_,_,_,_,_,g,_,_,_,_,_), (_,_,_,_,_,_,ref g,_,_,_,_,_) => g }
-        (n7,  n7_ref)  -> H { (_,_,_,_,_,_,_,h,_,_,_,_), (_,_,_,_,_,_,_,ref h,_,_,_,_) => h }
-        (n8,  n8_ref)  -> I { (_,_,_,_,_,_,_,_,i,_,_,_), (_,_,_,_,_,_,_,_,ref i,_,_,_) => i }
-        (n9,  n9_ref)  -> J { (_,_,_,_,_,_,_,_,_,j,_,_), (_,_,_,_,_,_,_,_,_,ref j,_,_) => j }
-        (n10, n10_ref) -> K { (_,_,_,_,_,_,_,_,_,_,k,_), (_,_,_,_,_,_,_,_,_,_,ref k,_) => k }
-        (n11, n11_ref) -> L { (_,_,_,_,_,_,_,_,_,_,_,l), (_,_,_,_,_,_,_,_,_,_,_,ref l) => l }
+    {
+        (n0_ref)  -> A;
+        (n1_ref)  -> B;
+        (n2_ref)  -> C;
+        (n3_ref)  -> D;
+        (n4_ref)  -> E;
+        (n5_ref)  -> F;
+        (n6_ref)  -> G;
+        (n7_ref)  -> H;
+        (n8_ref)  -> I;
+        (n9_ref)  -> J;
+        (n10_ref) -> K;
+        (n11_ref) -> L;
     }
 }
 
@@ -346,37 +326,6 @@ mod tests {
         assert_eq!(a.first(), b.first());
         assert_eq!(a.second(), b.second());
     }
-
-    #[test]
-    fn test_n_tuple() {
-        let t = (0u8, 1u16, 2u32, 3u64, 4u, 5i8, 6i16, 7i32, 8i64, 9i, 10f32, 11f64);
-        assert_eq!(t.n0(), 0u8);
-        assert_eq!(t.n1(), 1u16);
-        assert_eq!(t.n2(), 2u32);
-        assert_eq!(t.n3(), 3u64);
-        assert_eq!(t.n4(), 4u);
-        assert_eq!(t.n5(), 5i8);
-        assert_eq!(t.n6(), 6i16);
-        assert_eq!(t.n7(), 7i32);
-        assert_eq!(t.n8(), 8i64);
-        assert_eq!(t.n9(), 9i);
-        assert_eq!(t.n10(), 10f32);
-        assert_eq!(t.n11(), 11f64);
-
-        assert_eq!(t.n0_ref(), &0u8);
-        assert_eq!(t.n1_ref(), &1u16);
-        assert_eq!(t.n2_ref(), &2u32);
-        assert_eq!(t.n3_ref(), &3u64);
-        assert_eq!(t.n4_ref(), &4u);
-        assert_eq!(t.n5_ref(), &5i8);
-        assert_eq!(t.n6_ref(), &6i16);
-        assert_eq!(t.n7_ref(), &7i32);
-        assert_eq!(t.n8_ref(), &8i64);
-        assert_eq!(t.n9_ref(), &9i);
-        assert_eq!(t.n10_ref(), &10f32);
-        assert_eq!(t.n11_ref(), &11f64);
-    }
-
     #[test]
     fn test_tuple_cmp() {
         let (small, big) = ((1u, 2u, 3u), (3u, 2u, 1u));

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -13,10 +13,11 @@
 use prelude::*;
 use libc::uintptr_t;
 
+pub use prim::intrinsics;
+
 pub mod dynamic_lib;
 
 pub mod finally;
-pub mod intrinsics;
 pub mod simd;
 #[cfg(not(test))]
 pub mod lang;

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -14,6 +14,7 @@ use prelude::*;
 use libc::uintptr_t;
 
 pub use prim::intrinsics;
+pub use prim::raw;
 
 pub mod dynamic_lib;
 
@@ -23,7 +24,6 @@ pub mod simd;
 pub mod lang;
 pub mod sync;
 pub mod mutex;
-pub mod raw;
 pub mod stack;
 
 /**

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -10,48 +10,13 @@
 
 //! Miscellaneous helpers for common patterns
 
-use cast;
-use ptr;
 use prelude::*;
-use unstable::intrinsics;
+
+pub use prim::util::{swap, replace};
 
 /// The identity function.
 #[inline]
 pub fn id<T>(x: T) -> T { x }
-
-/**
- * Swap the values at two mutable locations of the same type, without
- * deinitialising or copying either one.
- */
-#[inline]
-pub fn swap<T>(x: &mut T, y: &mut T) {
-    unsafe {
-        // Give ourselves some scratch space to work with
-        let mut tmp: T = intrinsics::uninit();
-        let t: *mut T = &mut tmp;
-
-        // Perform the swap, `&mut` pointers never alias
-        let x_raw: *mut T = x;
-        let y_raw: *mut T = y;
-        ptr::copy_nonoverlapping_memory(t, &*x_raw, 1);
-        ptr::copy_nonoverlapping_memory(x, &*y_raw, 1);
-        ptr::copy_nonoverlapping_memory(y, &*t, 1);
-
-        // y and t now point to the same thing, but we need to completely forget `tmp`
-        // because it's no longer relevant.
-        cast::forget(tmp);
-    }
-}
-
-/**
- * Replace the value at a mutable location with a new one, returning the old
- * value, without deinitialising or copying either one.
- */
-#[inline]
-pub fn replace<T>(dest: &mut T, mut src: T) -> T {
-    swap(dest, &mut src);
-    src
-}
 
 /// A non-copyable dummy type.
 #[deriving(Eq, TotalEq, Ord, TotalOrd)]

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -33,9 +33,9 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
         // Perform the swap, `&mut` pointers never alias
         let x_raw: *mut T = x;
         let y_raw: *mut T = y;
-        ptr::copy_nonoverlapping_memory(t, x_raw, 1);
-        ptr::copy_nonoverlapping_memory(x, y_raw, 1);
-        ptr::copy_nonoverlapping_memory(y, t, 1);
+        ptr::copy_nonoverlapping_memory(t, &*x_raw, 1);
+        ptr::copy_nonoverlapping_memory(x, &*y_raw, 1);
+        ptr::copy_nonoverlapping_memory(y, &*t, 1);
 
         // y and t now point to the same thing, but we need to completely forget `tmp`
         // because it's no longer relevant.

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1549,7 +1549,7 @@ impl<T> OwnedVector<T> for ~[T] {
             let p = self.as_mut_ptr().offset(i as int);
             // Shift everything over to make space. (Duplicating the
             // `i`th element into two consecutive places.)
-            ptr::copy_memory(p.offset(1), p, len - i);
+            ptr::copy_memory(p.offset(1), &*p, len - i);
             // Write it in, overwriting the first copy of the `i`th
             // element.
             intrinsics::move_val_init(&mut *p, x);
@@ -1568,7 +1568,7 @@ impl<T> OwnedVector<T> for ~[T] {
                 let ret = Some(ptr::read_ptr(ptr as *T));
 
                 // Shift everything down to fill in that spot.
-                ptr::copy_memory(ptr, ptr.offset(1), len - i - 1);
+                ptr::copy_memory(ptr, &*ptr.offset(1), len - i - 1);
                 self.set_len(len - 1);
 
                 ret
@@ -1863,7 +1863,7 @@ fn merge_sort<T>(v: &mut [T], compare: |&T, &T| -> Ordering) {
                 // that case, `i == j` so we don't copy. The
                 // `.offset(j)` is always in bounds.
                 ptr::copy_memory(buf_dat.offset(j + 1),
-                                 buf_dat.offset(j),
+                                 &*buf_dat.offset(j),
                                  i - j as uint);
                 ptr::copy_nonoverlapping_memory(buf_dat.offset(j), read_ptr, 1);
             }
@@ -1913,11 +1913,11 @@ fn merge_sort<T>(v: &mut [T], compare: |&T, &T| -> Ordering) {
                     if left == right_start {
                         // the number remaining in this run.
                         let elems = (right_end as uint - right as uint) / mem::size_of::<T>();
-                        ptr::copy_nonoverlapping_memory(out, right, elems);
+                        ptr::copy_nonoverlapping_memory(out, &*right, elems);
                         break;
                     } else if right == right_end {
                         let elems = (right_start as uint - left as uint) / mem::size_of::<T>();
-                        ptr::copy_nonoverlapping_memory(out, left, elems);
+                        ptr::copy_nonoverlapping_memory(out, &*left, elems);
                         break;
                     }
 
@@ -1931,7 +1931,7 @@ fn merge_sort<T>(v: &mut [T], compare: |&T, &T| -> Ordering) {
                     } else {
                         step(&mut left)
                     };
-                    ptr::copy_nonoverlapping_memory(out, to_copy, 1);
+                    ptr::copy_nonoverlapping_memory(out, &*to_copy, 1);
                     step(&mut out);
                 }
             }
@@ -1945,7 +1945,7 @@ fn merge_sort<T>(v: &mut [T], compare: |&T, &T| -> Ordering) {
     // write the result to `v` in one go, so that there are never two copies
     // of the same object in `v`.
     unsafe {
-        ptr::copy_nonoverlapping_memory(v.as_mut_ptr(), buf_dat, len);
+        ptr::copy_nonoverlapping_memory(v.as_mut_ptr(), &*buf_dat, len);
     }
 
     // increment the pointer, returning the old pointer.


### PR DESCRIPTION
This branch starts pulling modules out of std into a crate called 'prim'. This crate is intended to have no runtime requirements, no unique allocation or failure, and thus be suitable for use as the foundation of any Rust-based software. It currently includes kinds, intrinsics, mem, cast, ptr, and the swap and replace functions, which appear to be the lowest-level building blocks of std. It should also include most of 'option' but a rustc bug is preventing the move, probably `Drop`, and the comparison traits. `Clone` and some of the operators can't be moved because they have implementations for vectors that require allocation.

Beyond this I expect to add another crate that requires an allocator, adds clone, num, iter, vec, str, etc.

cc #11828
