### PR TITLE
Move base64 out of extra.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ src/.DS_Store
 /doc/latex
 /doc/std
 /doc/arena
+/doc/base64
 /doc/extra
 /doc/flate
 /doc/glob

--- a/doc/index.md
+++ b/doc/index.md
@@ -38,6 +38,7 @@ li {list-style-type: none; }
 * [The Rust compiler, `librustc`](rustc/index.html)
 
 * [The `arena` allocation library](arena/index.html)
+* [The `base64` encoding library](base64/index.html)
 * [The `flate` compression library](flate/index.html)
 * [The `glob` file path matching library](glob/index.html)
 

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -49,7 +49,7 @@
 # automatically generated for all stage/host/target combinations.
 ################################################################################
 
-TARGET_CRATES := std extra green rustuv native flate arena glob
+TARGET_CRATES := std extra green rustuv native flate arena glob base64
 HOST_CRATES := syntax rustc rustdoc rustpkg
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustpkg rustdoc rustc
@@ -66,6 +66,7 @@ DEPS_rustpkg := rustc
 DEPS_flate := std native:miniz
 DEPS_arena := std extra
 DEPS_glob := std
+DEPS_base64 := std extra
 
 TOOL_DEPS_compiletest := extra green rustuv
 TOOL_DEPS_rustpkg := rustpkg green rustuv

--- a/src/libbase64/lib.rs
+++ b/src/libbase64/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,14 @@
 // except according to those terms.
 
 //! Base64 binary-to-text encoding
+
+#[crate_id = "base64#0.10-pre"];
+#[crate_type = "rlib"];
+#[crate_type = "dylib"];
+#[license = "MIT/ASL2"];
+
+extern mod extra;
+
 use std::str;
 
 /// Available encoding character sets
@@ -63,8 +71,8 @@ impl<'a> ToBase64 for &'a [u8] {
      * # Example
      *
      * ```rust
-     * extern mod extra;
-     * use extra::base64::{ToBase64, STANDARD};
+     * extern mod base64;
+     * use base64::{ToBase64, STANDARD};
      *
      * fn main () {
      *     let str = [52,32].to_base64(STANDARD);
@@ -189,8 +197,8 @@ impl<'a> FromBase64 for &'a str {
      * This converts a string literal to base64 and back.
      *
      * ```rust
-     * extern mod extra;
-     * use extra::base64::{ToBase64, FromBase64, STANDARD};
+     * extern mod base64;
+     * use base64::{ToBase64, FromBase64, STANDARD};
      * use std::str;
      *
      * fn main () {
@@ -261,8 +269,8 @@ impl<'a> FromBase64 for &'a str {
 
 #[cfg(test)]
 mod test {
-    use test::BenchHarness;
-    use base64::*;
+    use extra::test::BenchHarness;
+    use super::{ToBase64, FromBase64, STANDARD, URL_SAFE, Config};
 
     #[test]
     fn test_to_base64_basic() {

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -69,7 +69,6 @@ pub mod json;
 pub mod tempfile;
 pub mod term;
 pub mod time;
-pub mod base64;
 pub mod workcache;
 pub mod enum_set;
 #[path="num/bigint.rs"]


### PR DESCRIPTION
In accordance with the dissolution of libextra (#8784), this moves base64 out of libextra and into its own module.
