### PR TITLE
Implement field shorthands in struct literal expressions.

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -543,6 +543,7 @@ impl<'a> LoweringContext<'a> {
             name: respan(f.ident.span, f.ident.node.name),
             expr: self.lower_expr(&f.expr),
             span: f.span,
+            is_shorthand: f.is_shorthand,
         }
     }
 
@@ -1682,6 +1683,7 @@ impl<'a> LoweringContext<'a> {
             },
             span: span,
             expr: expr,
+            is_shorthand: false,
         }
     }
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -817,6 +817,7 @@ pub struct Field {
     pub name: Spanned<Name>,
     pub expr: P<Expr>,
     pub span: Span,
+    pub is_shorthand: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1229,8 +1229,10 @@ impl<'a> State<'a> {
                            &fields[..],
                            |s, field| {
                                s.ibox(indent_unit)?;
-                               s.print_name(field.name.node)?;
-                               s.word_space(":")?;
+                               if !field.is_shorthand {
+                                    s.print_name(field.name.node)?;
+                                    s.word_space(":")?;
+                               }
                                s.print_expr(&field.expr)?;
                                s.end()
                            },

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -900,6 +900,7 @@ pub struct Field {
     pub ident: SpannedIdent,
     pub expr: P<Expr>,
     pub span: Span,
+    pub is_shorthand: bool,
 }
 
 pub type SpannedIdent = Spanned<Ident>;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -713,7 +713,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.expr(b.span, ast::ExprKind::Block(b))
     }
     fn field_imm(&self, span: Span, name: Ident, e: P<ast::Expr>) -> ast::Field {
-        ast::Field { ident: respan(span, name), expr: e, span: span }
+        ast::Field { ident: respan(span, name), expr: e, span: span, is_shorthand: false }
     }
     fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field>) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Struct(path, fields, None))

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -306,6 +306,9 @@ declare_features! (
 
     // Allows attributes on lifetime/type formal parameters in generics (RFC 1327)
     (active, generic_param_attrs, "1.11.0", Some(34761)),
+
+    // Allows field shorthands (`x` meaning `x: x`) in struct literal expressions.
+    (active, field_init_shorthand, "1.14.0", Some(37340)),
 );
 
 declare_features! (
@@ -1086,6 +1089,14 @@ impl<'a> Visitor for PostExpansionVisitor<'a> {
             }
             ast::ExprKind::InPlace(..) => {
                 gate_feature_post!(&self, placement_in_syntax, e.span, EXPLAIN_PLACEMENT_IN);
+            }
+            ast::ExprKind::Struct(_, ref fields, _) => {
+                for field in fields {
+                    if field.is_shorthand {
+                        gate_feature_post!(&self, field_init_shorthand, field.span,
+                                           "struct field shorthands are unstable");
+                    }
+                }
             }
             _ => {}
         }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -823,11 +823,12 @@ pub fn noop_fold_struct_field<T: Folder>(f: StructField, fld: &mut T) -> StructF
     }
 }
 
-pub fn noop_fold_field<T: Folder>(Field {ident, expr, span}: Field, folder: &mut T) -> Field {
+pub fn noop_fold_field<T: Folder>(f: Field, folder: &mut T) -> Field {
     Field {
-        ident: respan(ident.span, folder.fold_ident(ident.node)),
-        expr: folder.fold_expr(expr),
-        span: folder.new_span(span)
+        ident: respan(f.ident.span, folder.fold_ident(f.ident.node)),
+        expr: folder.fold_expr(f.expr),
+        span: folder.new_span(f.span),
+        is_shorthand: f.is_shorthand,
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1893,8 +1893,10 @@ impl<'a> State<'a> {
             &fields[..],
             |s, field| {
                 try!(s.ibox(INDENT_UNIT));
-                try!(s.print_ident(field.ident.node));
-                try!(s.word_space(":"));
+                if !field.is_shorthand {
+                    try!(s.print_ident(field.ident.node));
+                    try!(s.word_space(":"));
+                }
                 try!(s.print_expr(&field.expr));
                 s.end()
             },

--- a/src/test/compile-fail/feature-gate-field-init-shorthand.rs
+++ b/src/test/compile-fail/feature-gate-field-init-shorthand.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+struct Foo {
+    x: i32,
+    y: bool,
+    z: i32
+}
 
-fn removed_with() {
-    struct S {
-        foo: (),
-        bar: (),
-    }
-
-    let a = S { foo: (), bar: () };
-    let b = S { foo: (), with a };
-    //~^ ERROR expected one of `,` or `}`, found `a`
+fn main() {
+    let (x, y, z) = (1, true, 2);
+    let _ = Foo {
+        x, //~ ERROR struct field shorthands are unstable
+        y: y,
+        z //~ ERROR struct field shorthands are unstable
+    };
 }

--- a/src/test/compile-fail/struct-fields-shorthand-unresolved.rs
+++ b/src/test/compile-fail/struct-fields-shorthand-unresolved.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+#![feature(field_init_shorthand)]
 
-fn removed_with() {
-    struct S {
-        foo: (),
-        bar: (),
-    }
+struct Foo {
+    x: i32,
+    y: i32
+}
 
-    let a = S { foo: (), bar: () };
-    let b = S { foo: (), with a };
-    //~^ ERROR expected one of `,` or `}`, found `a`
+fn main() {
+    let x = 0;
+    let foo = Foo {
+        x,
+        y //~ ERROR unresolved name `y`
+    };
 }

--- a/src/test/compile-fail/struct-fields-shorthand.rs
+++ b/src/test/compile-fail/struct-fields-shorthand.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
+#![feature(field_init_shorthand)]
 
-fn removed_with() {
-    struct S {
-        foo: (),
-        bar: (),
-    }
-
-    let a = S { foo: (), bar: () };
-    let b = S { foo: (), with a };
-    //~^ ERROR expected one of `,` or `}`, found `a`
+struct Foo {
+    x: i32,
+    y: i32
 }
+
+fn main() {
+    let (x, y, z) = (0, 1, 2);
+    let foo = Foo {
+        x, y, z //~ ERROR struct `Foo` has no field named `z`
+    };
+}
+

--- a/src/test/parse-fail/struct-field-numeric-shorthand.rs
+++ b/src/test/parse-fail/struct-field-numeric-shorthand.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,13 +10,10 @@
 
 // compile-flags: -Z parse-only
 
-fn removed_with() {
-    struct S {
-        foo: (),
-        bar: (),
-    }
+#![feature(field_init_shorthand)]
 
-    let a = S { foo: (), bar: () };
-    let b = S { foo: (), with a };
-    //~^ ERROR expected one of `,` or `}`, found `a`
+struct Rgb(u8, u8, u8);
+
+fn main() {
+    let _ = Rgb { 0, 1, 2 }; //~ ERROR expected identifier, found `0`
 }

--- a/src/test/run-pass/struct-field-shorthand.rs
+++ b/src/test/run-pass/struct-field-shorthand.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(field_init_shorthand)]
+
+struct Foo {
+    x: i32,
+    y: bool,
+    z: i32
+}
+
+struct Bar {
+    x: i32
+}
+
+pub fn main() {
+    let (x, y, z) = (1, true, 2);
+    let a = Foo { x, y: y, z };
+    assert_eq!(a.x, x);
+    assert_eq!(a.y, y);
+    assert_eq!(a.z, z);
+
+    let b = Bar { x, };
+    assert_eq!(b.x, x);
+
+    let c = Foo { z, y, x };
+    assert_eq!(c.x, x);
+    assert_eq!(c.y, y);
+    assert_eq!(c.z, z);
+}


### PR DESCRIPTION
Implements #37340 in a straight-forward way: `Foo { x, y: f() }` parses as `Foo { x: x, y: f() }`.
Because of the added `is_shorthand` to `ast::Field`, this is `[syntax-breaking]` (cc @Manishearth).
- [x] Mark the fields as being a shorthand (the exact same way we do it in patterns), for pretty-printing.
- [x] Gate the shorthand syntax with `#![feature(field_init_shorthand)]`.
- [x] Don't parse numeric field as identifiers.
- [x] Arbitrary field order tests.
