### PR TITLE
Add no-pic debug flag to disable position independent code

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -121,6 +121,11 @@ pub mod write {
                 })
             }
 
+            let pic_mode = match sess.no_pic() {
+                true  => lib::llvm::RelocDynamicNoPic,
+                false => lib::llvm::RelocPIC
+            };
+
             let OptLevel = match sess.opts.optimize {
               session::No => lib::llvm::CodeGenLevelNone,
               session::Less => lib::llvm::CodeGenLevelLess,
@@ -141,7 +146,7 @@ pub mod write {
                         llvm::LLVMRustCreateTargetMachine(
                             T, CPU, Features,
                             lib::llvm::CodeModelDefault,
-                            lib::llvm::RelocPIC,
+                            pic_mode,
                             OptLevel,
                             true,
                             use_softfp,

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -60,6 +60,7 @@ debugging_opts!(
         NO_VERIFY,
         BORROWCK_STATS,
         NO_LANDING_PADS,
+        NO_PIC,
         DEBUG_LLVM,
         COUNT_TYPE_SIZES,
         META_STATS,
@@ -95,6 +96,7 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, u64)] {
      ("borrowck-stats", "gather borrowck statistics",  BORROWCK_STATS),
      ("no-landing-pads", "omit landing pads for unwinding",
       NO_LANDING_PADS),
+     ("no-pic", "do not produce position independent code", NO_PIC),
      ("debug-llvm", "enable debug output from LLVM", DEBUG_LLVM),
      ("count-type-sizes", "count the sizes of aggregate types",
       COUNT_TYPE_SIZES),
@@ -350,6 +352,9 @@ impl Session_ {
     }
     pub fn no_landing_pads(&self) -> bool {
         self.debugging_opt(NO_LANDING_PADS)
+    }
+    pub fn no_pic(&self) -> bool {
+        self.debugging_opt(NO_PIC)
     }
 
     // DEPRECATED. This function results in a lot of allocations when they


### PR DESCRIPTION
Probably don't want to be adding to the number of debug flags, but there seemed to be interest in adding this in #10942.

From the LLVM source DynamicNoPIC is "Relocatable external references, non-relocatable code". On platforms it isn't supported on it becomes either RelocStatic or RelocPIC.

Again, I haven't written a test. I couldn't see any existing ones for PIC stuff. Passes existing tests though.
