### PR TITLE
libnative: fix epoll_event struct layout

### DIFF
--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -59,7 +59,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
     fn add(efd: libc::c_int, fd: libc::c_int) {
         let event = imp::epoll_event {
             events: imp::EPOLLIN as u32,
-            data: imp::epoll_data_t { fd: fd, pad: 0, }
+            data: fd as i64,
         };
         let ret = unsafe {
             imp::epoll_ctl(efd, imp::EPOLL_CTL_ADD, fd, &event)
@@ -67,9 +67,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
         assert_eq!(ret, 0);
     }
     fn del(efd: libc::c_int, fd: libc::c_int) {
-        let event = imp::epoll_event {
-            events: 0, data: imp::epoll_data_t { fd: 0, pad: 0, }
-        };
+        let event = imp::epoll_event { events: 0, data: 0 };
         let ret = unsafe {
             imp::epoll_ctl(efd, imp::EPOLL_CTL_DEL, fd, &event)
         };
@@ -93,7 +91,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
         let mut incoming = false;
         debug!("{} events to process", n);
         for event in events.slice_to(n as uint).iter() {
-            let fd = event.data.fd;
+            let fd = event.data as libc::c_int;
             debug!("data on fd {} (input = {})", fd, input);
             if fd == input {
                 let mut buf = [0, ..1];
@@ -261,14 +259,17 @@ mod imp {
     pub static EPOLLHUP: libc::c_int = 0x010;
     pub static EPOLLONESHOT: libc::c_int = 1 << 30;
 
+    #[cfg(target_arch = "x86_64")]
+    #[packed]
     pub struct epoll_event {
         events: u32,
-        data: epoll_data_t,
+        data: i64,
     }
 
-    pub struct epoll_data_t {
-        fd: i32,
-        pad: u32,
+    #[cfg(not(target_arch = "x86_64"))]
+    pub struct epoll_event {
+        events: u32,
+        data: i64,
     }
 
     pub struct timespec {


### PR DESCRIPTION
Make the definition of epoll_event use natural alignment on all
architectures except x86_64.

Before this commit, the struct was always 12 bytes big, which works okay
on x86 and x86_64 but not on ARM and MIPS, where it should be 16 bytes
big with the `data` field aligned on an 8 byte boundary.
