### PR TITLE
Use explicit lifetimes for LLVM allocas

### DIFF
--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -244,6 +244,11 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
          * instance of `ty`
          */
 
+        self.schedule_clean(cleanup_scope, ~LifetimeEnd {
+            val: val,
+            ty: ty
+        });
+
         if !ty::type_needs_drop(self.ccx.tcx, ty) { return; }
         let drop = ~DropValue {
             is_immediate: false,
@@ -828,6 +833,22 @@ impl Cleanup for DropValue {
         } else {
             glue::drop_ty(bcx, self.val, self.ty)
         }
+    }
+}
+
+pub struct LifetimeEnd {
+    val: ValueRef,
+    ty: ty::t,
+}
+
+impl Cleanup for LifetimeEnd {
+    fn clean_on_unwind(&self) -> bool {
+        false
+    }
+
+    fn trans<'a>(&self, bcx: &'a Block<'a>) -> &'a Block<'a> {
+        base::call_lifetime_end(bcx, self.val, self.ty);
+        bcx
     }
 }
 

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -80,6 +80,8 @@ pub fn get_simple_intrinsic(ccx: @CrateContext, item: &ast::ForeignItem) -> Opti
         "bswap16" => Some(ccx.intrinsics.get_copy(&("llvm.bswap.i16"))),
         "bswap32" => Some(ccx.intrinsics.get_copy(&("llvm.bswap.i32"))),
         "bswap64" => Some(ccx.intrinsics.get_copy(&("llvm.bswap.i64"))),
+        "lifetime_start" => Some(ccx.intrinsics.get_copy(&("llvm.lifetime.start"))),
+        "lifetime_end" => Some(ccx.intrinsics.get_copy(&("llvm.lifetime.end"))),
         _ => None
     }
 }


### PR DESCRIPTION
Currently, stack allocated variables live for the whole duration of the
function they're allocated in. This means that LLVM can't put two
allocas into the same stack space, even if they're never used at the
same time.

By using the LLVM intrinsics to declare the lifetime of allocas, we
allow LLVM to use the same stack space for allocas that have
non-overlapping lifetimes, reducing stack usage. In certain situations
this even allows LLVM to remove duplicated code that previously only
differed in which part of the stack it used.
