### PR TITLE
Add a crate keyword and allow it to link external crates

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -456,7 +456,7 @@ pub fn expect<T:Clone>(sess: Session, opt: Option<T>, msg: || -> ~str) -> T {
     diagnostic::expect(sess.diagnostic(), opt, msg)
 }
 
-pub fn building_library(options: &Options, crate: &ast::Crate) -> bool {
+pub fn building_library(options: &Options, krate: &ast::Crate) -> bool {
     if options.test { return false }
     for output in options.crate_types.iter() {
         match *output {
@@ -464,7 +464,7 @@ pub fn building_library(options: &Options, crate: &ast::Crate) -> bool {
             CrateTypeStaticlib | CrateTypeDylib | CrateTypeRlib => return true
         }
     }
-    match syntax::attr::first_attr_value_str_by_name(crate.attrs, "crate_type") {
+    match syntax::attr::first_attr_value_str_by_name(krate.attrs, "crate_type") {
         Some(s) => {
             s.equiv(&("lib")) ||
             s.equiv(&("rlib")) ||

--- a/src/librustc/front/assign_node_ids_and_map.rs
+++ b/src/librustc/front/assign_node_ids_and_map.rs
@@ -24,6 +24,6 @@ impl ast_map::FoldOps for NodeIdAssigner {
     }
 }
 
-pub fn assign_node_ids_and_map(sess: Session, crate: ast::Crate) -> (ast::Crate, ast_map::Map) {
-    ast_map::map_crate(sess.diagnostic(), crate, NodeIdAssigner { sess: sess })
+pub fn assign_node_ids_and_map(sess: Session, krate: ast::Crate) -> (ast::Crate, ast_map::Map) {
+    ast_map::map_crate(sess.diagnostic(), krate, NodeIdAssigner { sess: sess })
 }

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -19,9 +19,9 @@ struct Context<'a> {
 
 // Support conditional compilation by transforming the AST, stripping out
 // any items that do not belong in the current configuration
-pub fn strip_unconfigured_items(crate: ast::Crate) -> ast::Crate {
-    let config = crate.config.clone();
-    strip_items(crate, |attrs| in_cfg(config, attrs))
+pub fn strip_unconfigured_items(krate: ast::Crate) -> ast::Crate {
+    let config = krate.config.clone();
+    strip_items(krate, |attrs| in_cfg(config, attrs))
 }
 
 impl<'a> fold::Folder for Context<'a> {
@@ -39,13 +39,13 @@ impl<'a> fold::Folder for Context<'a> {
     }
 }
 
-pub fn strip_items(crate: ast::Crate,
+pub fn strip_items(krate: ast::Crate,
                    in_cfg: |attrs: &[ast::Attribute]| -> bool)
                    -> ast::Crate {
     let mut ctxt = Context {
         in_cfg: in_cfg,
     };
-    ctxt.fold_crate(crate)
+    ctxt.fold_crate(krate)
 }
 
 fn filter_view_item<'r>(cx: &Context, view_item: &'r ast::ViewItem)

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -266,13 +266,13 @@ impl Visitor<()> for Context {
     }
 }
 
-pub fn check_crate(sess: Session, crate: &ast::Crate) {
+pub fn check_crate(sess: Session, krate: &ast::Crate) {
     let mut cx = Context {
         features: ~[],
         sess: sess,
     };
 
-    for attr in crate.attrs.iter() {
+    for attr in krate.attrs.iter() {
         if !attr.name().equiv(&("feature")) {
             continue
         }
@@ -315,7 +315,7 @@ pub fn check_crate(sess: Session, crate: &ast::Crate) {
         }
     }
 
-    visit::walk_crate(&mut cx, crate, ());
+    visit::walk_crate(&mut cx, krate, ());
 
     sess.abort_if_errors();
 }

--- a/src/librustc/front/show_span.rs
+++ b/src/librustc/front/show_span.rs
@@ -30,7 +30,7 @@ impl Visitor<()> for ShowSpanVisitor {
     }
 }
 
-pub fn run(sess: Session, crate: &ast::Crate) {
+pub fn run(sess: Session, krate: &ast::Crate) {
     let mut v = ShowSpanVisitor { sess: sess };
-    visit::walk_crate(&mut v, crate, ());
+    visit::walk_crate(&mut v, krate, ());
 }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -35,7 +35,7 @@ use syntax::visit;
 // Traverses an AST, reading all the information about use'd crates and extern
 // libraries necessary for later resolving, typechecking, linking, etc.
 pub fn read_crates(sess: Session,
-                   crate: &ast::Crate,
+                   krate: &ast::Crate,
                    os: loader::Os,
                    intr: @IdentInterner) {
     let mut e = Env {
@@ -45,12 +45,12 @@ pub fn read_crates(sess: Session,
         next_crate_num: 1,
         intr: intr
     };
-    visit_crate(&e, crate);
+    visit_crate(&e, krate);
     {
         let mut v = ReadCrateVisitor {
             e: &mut e
         };
-        visit::walk_crate(&mut v, crate, ());
+        visit::walk_crate(&mut v, krate, ());
     }
     let crate_cache = e.crate_cache.borrow();
     dump_crates(*crate_cache.get());
@@ -424,14 +424,14 @@ impl Loader {
 }
 
 impl CrateLoader for Loader {
-    fn load_crate(&mut self, crate: &ast::ViewItem) -> MacroCrate {
-        let info = extract_crate_info(crate).unwrap();
+    fn load_crate(&mut self, krate: &ast::ViewItem) -> MacroCrate {
+        let info = extract_crate_info(krate).unwrap();
         let cnum = resolve_crate(&mut self.env,
                                  info.ident.clone(),
                                  info.name.clone(),
                                  info.version.clone(),
                                  ~"",
-                                 crate.span);
+                                 krate.span);
         let library = self.env.sess.cstore.get_used_crate_source(cnum).unwrap();
         MacroCrate {
             lib: library.dylib,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -32,13 +32,13 @@ pub struct StaticMethodInfo {
 }
 
 pub fn get_symbol(cstore: @cstore::CStore, def: ast::DefId) -> ~str {
-    let cdata = cstore.get_crate_data(def.crate).data();
+    let cdata = cstore.get_crate_data(def.krate).data();
     return decoder::get_symbol(cdata, def.node);
 }
 
 pub fn get_type_param_count(cstore: @cstore::CStore, def: ast::DefId)
                          -> uint {
-    let cdata = cstore.get_crate_data(def.crate).data();
+    let cdata = cstore.get_crate_data(def.krate).data();
     return decoder::get_type_param_count(cdata, def.node);
 }
 
@@ -57,7 +57,7 @@ pub fn each_child_of_item(cstore: @cstore::CStore,
                           callback: |decoder::DefLike,
                                      ast::Ident,
                                      ast::Visibility|) {
-    let crate_data = cstore.get_crate_data(def_id.crate);
+    let crate_data = cstore.get_crate_data(def_id.krate);
     let get_crate_data: decoder::GetCrateDataCb = |cnum| {
         cstore.get_crate_data(cnum)
     };
@@ -86,7 +86,7 @@ pub fn each_top_level_item_of_crate(cstore: @cstore::CStore,
 
 pub fn get_item_path(tcx: ty::ctxt, def: ast::DefId) -> ast_map::Path {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     let path = decoder::get_item_path(cdata, def.node);
 
     // FIXME #1920: This path is not always correct if the crate is not linked
@@ -108,7 +108,7 @@ pub fn maybe_get_item_ast(tcx: ty::ctxt, def: ast::DefId,
                           decode_inlined_item: decoder::decode_inlined_item)
                        -> found_ast {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::maybe_get_item_ast(cdata, tcx, def.node,
                                 decode_inlined_item)
 }
@@ -116,19 +116,19 @@ pub fn maybe_get_item_ast(tcx: ty::ctxt, def: ast::DefId,
 pub fn get_enum_variants(tcx: ty::ctxt, def: ast::DefId)
                       -> ~[@ty::VariantInfo] {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     return decoder::get_enum_variants(cstore.intr, cdata, def.node, tcx)
 }
 
 /// Returns information about the given implementation.
 pub fn get_impl(tcx: ty::ctxt, impl_def_id: ast::DefId)
                 -> ty::Impl {
-    let cdata = tcx.cstore.get_crate_data(impl_def_id.crate);
+    let cdata = tcx.cstore.get_crate_data(impl_def_id.krate);
     decoder::get_impl(tcx.cstore.intr, cdata, impl_def_id.node, tcx)
 }
 
 pub fn get_method(tcx: ty::ctxt, def: ast::DefId) -> ty::Method {
-    let cdata = tcx.cstore.get_crate_data(def.crate);
+    let cdata = tcx.cstore.get_crate_data(def.krate);
     decoder::get_method(tcx.cstore.intr, cdata, def.node, tcx)
 }
 
@@ -136,19 +136,19 @@ pub fn get_method_name_and_explicit_self(cstore: @cstore::CStore,
                                          def: ast::DefId)
                                      -> (ast::Ident, ast::ExplicitSelf_)
 {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_method_name_and_explicit_self(cstore.intr, cdata, def.node)
 }
 
 pub fn get_trait_method_def_ids(cstore: @cstore::CStore,
                                 def: ast::DefId) -> ~[ast::DefId] {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_trait_method_def_ids(cdata, def.node)
 }
 
 pub fn get_item_variances(cstore: @cstore::CStore,
                           def: ast::DefId) -> ty::ItemVariances {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_item_variances(cdata, def.node)
 }
 
@@ -156,40 +156,40 @@ pub fn get_provided_trait_methods(tcx: ty::ctxt,
                                   def: ast::DefId)
                                -> ~[@ty::Method] {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_provided_trait_methods(cstore.intr, cdata, def.node, tcx)
 }
 
 pub fn get_supertraits(tcx: ty::ctxt, def: ast::DefId) -> ~[@ty::TraitRef] {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_supertraits(cdata, def.node, tcx)
 }
 
 pub fn get_type_name_if_impl(cstore: @cstore::CStore, def: ast::DefId)
                           -> Option<ast::Ident> {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_type_name_if_impl(cdata, def.node)
 }
 
 pub fn get_static_methods_if_impl(cstore: @cstore::CStore,
                                   def: ast::DefId)
                                -> Option<~[StaticMethodInfo]> {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_static_methods_if_impl(cstore.intr, cdata, def.node)
 }
 
 pub fn get_item_attrs(cstore: @cstore::CStore,
                       def_id: ast::DefId,
                       f: |~[@ast::MetaItem]|) {
-    let cdata = cstore.get_crate_data(def_id.crate);
+    let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_item_attrs(cdata, def_id.node, f)
 }
 
 pub fn get_struct_fields(cstore: @cstore::CStore,
                          def: ast::DefId)
                       -> ~[ty::field_ty] {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_struct_fields(cstore.intr, cdata, def.node)
 }
 
@@ -197,20 +197,20 @@ pub fn get_type(tcx: ty::ctxt,
                 def: ast::DefId)
              -> ty::ty_param_bounds_and_ty {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_type(cdata, def.node, tcx)
 }
 
 pub fn get_trait_def(tcx: ty::ctxt, def: ast::DefId) -> ty::TraitDef {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_trait_def(cdata, def.node, tcx)
 }
 
 pub fn get_field_type(tcx: ty::ctxt, class_id: ast::DefId,
                       def: ast::DefId) -> ty::ty_param_bounds_and_ty {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(class_id.crate);
+    let cdata = cstore.get_crate_data(class_id.krate);
     let all_items = reader::get_doc(reader::Doc(cdata.data()), tag_items);
     let class_doc = expect(tcx.diag,
                            decoder::maybe_find_item(class_id.node, all_items),
@@ -233,7 +233,7 @@ pub fn get_field_type(tcx: ty::ctxt, class_id: ast::DefId,
 pub fn get_impl_trait(tcx: ty::ctxt,
                       def: ast::DefId) -> Option<@ty::TraitRef> {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_impl_trait(cdata, def.node, tcx)
 }
 
@@ -241,7 +241,7 @@ pub fn get_impl_trait(tcx: ty::ctxt,
 pub fn get_impl_vtables(tcx: ty::ctxt,
                         def: ast::DefId) -> typeck::impl_res {
     let cstore = tcx.cstore;
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_impl_vtables(cdata, def.node, tcx)
 }
 
@@ -249,14 +249,14 @@ pub fn get_impl_method(cstore: @cstore::CStore,
                        def: ast::DefId,
                        mname: ast::Ident)
                     -> Option<ast::DefId> {
-    let cdata = cstore.get_crate_data(def.crate);
+    let cdata = cstore.get_crate_data(def.krate);
     decoder::get_impl_method(cstore.intr, cdata, def.node, mname)
 }
 
 pub fn get_item_visibility(cstore: @cstore::CStore,
                            def_id: ast::DefId)
                         -> ast::Visibility {
-    let cdata = cstore.get_crate_data(def_id.crate);
+    let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_item_visibility(cdata, def_id.node)
 }
 
@@ -277,14 +277,14 @@ pub fn each_impl(cstore: @cstore::CStore,
 pub fn each_implementation_for_type(cstore: @cstore::CStore,
                                     def_id: ast::DefId,
                                     callback: |ast::DefId|) {
-    let cdata = cstore.get_crate_data(def_id.crate);
+    let cdata = cstore.get_crate_data(def_id.krate);
     decoder::each_implementation_for_type(cdata, def_id.node, callback)
 }
 
 pub fn each_implementation_for_trait(cstore: @cstore::CStore,
                                      def_id: ast::DefId,
                                      callback: |ast::DefId|) {
-    let cdata = cstore.get_crate_data(def_id.crate);
+    let cdata = cstore.get_crate_data(def_id.krate);
     decoder::each_implementation_for_trait(cdata, def_id.node, callback)
 }
 
@@ -295,7 +295,7 @@ pub fn get_trait_of_method(cstore: @cstore::CStore,
                            def_id: ast::DefId,
                            tcx: ty::ctxt)
                            -> Option<ast::DefId> {
-    let cdata = cstore.get_crate_data(def_id.crate);
+    let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_trait_of_method(cdata, def_id.node, tcx)
 }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -57,7 +57,7 @@ type conv_did<'a> =
 
 pub struct PState<'a> {
     data: &'a [u8],
-    crate: ast::CrateNum,
+    krate: ast::CrateNum,
     pos: uint,
     tcx: ty::ctxt
 }
@@ -106,7 +106,7 @@ pub fn parse_state_from_data<'a>(data: &'a [u8], crate_num: ast::CrateNum,
                              pos: uint, tcx: ty::ctxt) -> PState<'a> {
     PState {
         data: data,
-        crate: crate_num,
+        krate: crate_num,
         pos: pos,
         tcx: tcx
     }
@@ -377,7 +377,7 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
         assert_eq!(next(st), ':');
         let len = parse_hex(st);
         assert_eq!(next(st), '#');
-        let key = ty::creader_cache_key {cnum: st.crate,
+        let key = ty::creader_cache_key {cnum: st.krate,
                                          pos: pos,
                                          len: len };
 
@@ -559,7 +559,7 @@ pub fn parse_def_id(buf: &[u8]) -> ast::DefId {
        None => fail!("internal error: parse_def_id: id expected, but found {:?}",
                      def_part)
     };
-    ast::DefId { crate: crate_num, node: def_num }
+    ast::DefId { krate: crate_num, node: def_num }
 }
 
 pub fn parse_type_param_def_data(data: &[u8], start: uint,

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -236,8 +236,8 @@ impl ExtendedDecodeContext {
          * refer to the current crate and to the new, inlined node-id.
          */
 
-        assert_eq!(did.crate, ast::LOCAL_CRATE);
-        ast::DefId { crate: ast::LOCAL_CRATE, node: self.tr_id(did.node) }
+        assert_eq!(did.krate, ast::LOCAL_CRATE);
+        ast::DefId { krate: ast::LOCAL_CRATE, node: self.tr_id(did.node) }
     }
     pub fn tr_span(&self, _span: Span) -> Span {
         codemap::DUMMY_SP // FIXME (#1972): handle span properly
@@ -989,7 +989,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         }
     }
 
-    let lid = ast::DefId { crate: ast::LOCAL_CRATE, node: id };
+    let lid = ast::DefId { krate: ast::LOCAL_CRATE, node: id };
     {
         let tcache = tcx.tcache.borrow();
         let r = tcache.get().find(&lid);
@@ -1350,7 +1350,7 @@ fn decode_side_tables(xcx: @ExtendedDecodeContext,
                     }
                     c::tag_table_tcache => {
                         let tpbt = val_dsr.read_ty_param_bounds_and_ty(xcx);
-                        let lid = ast::DefId { crate: ast::LOCAL_CRATE, node: id };
+                        let lid = ast::DefId { krate: ast::LOCAL_CRATE, node: id };
                         let mut tcache = dcx.tcx.tcache.borrow_mut();
                         tcache.get().insert(lid, tpbt);
                     }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -73,7 +73,7 @@ pub fn check_crate(tcx: ty::ctxt,
                    moves_map: moves::MovesMap,
                    moved_variables_set: moves::MovedVariablesSet,
                    capture_map: moves::CaptureMap,
-                   crate: &ast::Crate)
+                   krate: &ast::Crate)
                    -> root_map {
     let mut bccx = BorrowckCtxt {
         tcx: tcx,
@@ -91,7 +91,7 @@ pub fn check_crate(tcx: ty::ctxt,
     };
     let bccx = &mut bccx;
 
-    visit::walk_crate(bccx, crate, ());
+    visit::walk_crate(bccx, krate, ());
 
     if tcx.sess.borrowck_stats() {
         println!("--- borrowck stats ---");

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -42,7 +42,7 @@ impl Visitor<bool> for CheckCrateVisitor {
 }
 
 pub fn check_crate(sess: Session,
-                   crate: &Crate,
+                   krate: &Crate,
                    ast_map: ast_map::Map,
                    def_map: resolve::DefMap,
                    method_map: typeck::method_map,
@@ -54,7 +54,7 @@ pub fn check_crate(sess: Session,
         method_map: method_map,
         tcx: tcx,
     };
-    visit::walk_crate(&mut v, crate, false);
+    visit::walk_crate(&mut v, krate, false);
     sess.abort_if_errors();
 }
 

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -24,8 +24,8 @@ struct CheckLoopVisitor {
     tcx: ty::ctxt,
 }
 
-pub fn check_crate(tcx: ty::ctxt, crate: &ast::Crate) {
-    visit::walk_crate(&mut CheckLoopVisitor { tcx: tcx }, crate, Normal)
+pub fn check_crate(tcx: ty::ctxt, krate: &ast::Crate) {
+    visit::walk_crate(&mut CheckLoopVisitor { tcx: tcx }, krate, Normal)
 }
 
 impl Visitor<Context> for CheckLoopVisitor {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -52,13 +52,13 @@ impl Visitor<()> for CheckMatchVisitor {
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: method_map,
                    moves_map: moves::MovesMap,
-                   crate: &Crate) {
+                   krate: &Crate) {
     let cx = @MatchCheckCtxt {tcx: tcx,
                               method_map: method_map,
                               moves_map: moves_map};
     let mut v = CheckMatchVisitor { cx: cx };
 
-    visit::walk_crate(&mut v, crate, ());
+    visit::walk_crate(&mut v, krate, ());
 
     tcx.sess.abort_if_errors();
 }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -302,13 +302,13 @@ impl Visitor<()> for ConstEvalVisitor {
     }
 }
 
-pub fn process_crate(crate: &ast::Crate,
+pub fn process_crate(krate: &ast::Crate,
                      tcx: ty::ctxt) {
     let mut v = ConstEvalVisitor {
         tcx: tcx,
         ccache: HashMap::new(),
     };
-    visit::walk_crate(&mut v, crate, ());
+    visit::walk_crate(&mut v, krate, ());
     tcx.sess.abort_if_errors();
 }
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -254,7 +254,7 @@ impl Visitor<()> for LifeSeeder {
 fn create_and_seed_worklist(tcx: ty::ctxt,
                             exported_items: &privacy::ExportedItems,
                             reachable_symbols: &HashSet<ast::NodeId>,
-                            crate: &ast::Crate) -> ~[ast::NodeId] {
+                            krate: &ast::Crate) -> ~[ast::NodeId] {
     let mut worklist = ~[];
 
     // Preferably, we would only need to seed the worklist with reachable
@@ -279,7 +279,7 @@ fn create_and_seed_worklist(tcx: ty::ctxt,
     let mut life_seeder = LifeSeeder {
         worklist: worklist
     };
-    visit::walk_crate(&mut life_seeder, crate, ());
+    visit::walk_crate(&mut life_seeder, krate, ());
 
     return life_seeder.worklist;
 }
@@ -288,10 +288,10 @@ fn find_live(tcx: ty::ctxt,
              method_map: typeck::method_map,
              exported_items: &privacy::ExportedItems,
              reachable_symbols: &HashSet<ast::NodeId>,
-             crate: &ast::Crate)
+             krate: &ast::Crate)
              -> ~HashSet<ast::NodeId> {
     let worklist = create_and_seed_worklist(tcx, exported_items,
-                                            reachable_symbols, crate);
+                                            reachable_symbols, krate);
     let mut symbol_visitor = MarkSymbolVisitor::new(tcx, method_map, worklist);
     symbol_visitor.mark_live_symbols();
     symbol_visitor.live_symbols
@@ -412,9 +412,9 @@ pub fn check_crate(tcx: ty::ctxt,
                    method_map: typeck::method_map,
                    exported_items: &privacy::ExportedItems,
                    reachable_symbols: &HashSet<ast::NodeId>,
-                   crate: &ast::Crate) {
+                   krate: &ast::Crate) {
     let live_symbols = find_live(tcx, method_map, exported_items,
-                                 reachable_symbols, crate);
+                                 reachable_symbols, krate);
     let mut visitor = DeadVisitor { tcx: tcx, live_symbols: live_symbols };
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 }

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -175,12 +175,12 @@ impl Visitor<()> for EffectCheckVisitor {
 
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: method_map,
-                   crate: &ast::Crate) {
+                   krate: &ast::Crate) {
     let mut visitor = EffectCheckVisitor {
         tcx: tcx,
         method_map: method_map,
         unsafe_context: SafeContext,
     };
 
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -44,14 +44,14 @@ impl Visitor<()> for EntryContext {
     }
 }
 
-pub fn find_entry_point(session: Session, crate: &Crate, ast_map: ast_map::Map) {
+pub fn find_entry_point(session: Session, krate: &Crate, ast_map: ast_map::Map) {
     if session.building_library.get() {
         // No need to find a main function
         return;
     }
 
     // If the user wants no main function at all, then stop here.
-    if attr::contains_name(crate.attrs, "no_main") {
+    if attr::contains_name(krate.attrs, "no_main") {
         session.entry_type.set(Some(session::EntryNone));
         return
     }
@@ -65,7 +65,7 @@ pub fn find_entry_point(session: Session, crate: &Crate, ast_map: ast_map::Map) 
         non_main_fns: ~[],
     };
 
-    visit::walk_crate(&mut ctxt, crate, ());
+    visit::walk_crate(&mut ctxt, krate, ());
 
     configure_main(&mut ctxt);
 }

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -124,13 +124,13 @@ impl Visitor<()> for AnnotateFreevarsVisitor {
 // efficient as it fully recomputes the free variables at every
 // node of interest rather than building up the free variables in
 // one pass. This could be improved upon if it turns out to matter.
-pub fn annotate_freevars(def_map: resolve::DefMap, crate: &ast::Crate) ->
+pub fn annotate_freevars(def_map: resolve::DefMap, krate: &ast::Crate) ->
    freevar_map {
     let mut visitor = AnnotateFreevarsVisitor {
         def_map: def_map,
         freevars: HashMap::new(),
     };
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 
     let AnnotateFreevarsVisitor {
         freevars,

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -77,12 +77,12 @@ impl Visitor<()> for Context {
 
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: typeck::method_map,
-                   crate: &Crate) {
+                   krate: &Crate) {
     let mut ctx = Context {
         tcx: tcx,
         method_map: method_map,
     };
-    visit::walk_crate(&mut ctx, crate, ());
+    visit::walk_crate(&mut ctx, krate, ());
     tcx.sess.abort_if_errors();
 }
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -161,24 +161,24 @@ impl LanguageItemCollector {
         self.items.items[item_index] = Some(item_def_id);
     }
 
-    pub fn collect_local_language_items(&mut self, crate: &ast::Crate) {
+    pub fn collect_local_language_items(&mut self, krate: &ast::Crate) {
         let mut v = LanguageItemVisitor { this: self };
-        visit::walk_crate(&mut v, crate, ());
+        visit::walk_crate(&mut v, krate, ());
     }
 
     pub fn collect_external_language_items(&mut self) {
         let crate_store = self.session.cstore;
         crate_store.iter_crate_data(|crate_number, _crate_metadata| {
             each_lang_item(crate_store, crate_number, |node_id, item_index| {
-                let def_id = ast::DefId { crate: crate_number, node: node_id };
+                let def_id = ast::DefId { krate: crate_number, node: node_id };
                 self.collect_item(item_index, def_id);
                 true
             });
         })
     }
 
-    pub fn collect(&mut self, crate: &ast::Crate) {
-        self.collect_local_language_items(crate);
+    pub fn collect(&mut self, krate: &ast::Crate) {
+        self.collect_local_language_items(krate);
         self.collect_external_language_items();
     }
 }
@@ -196,10 +196,10 @@ pub fn extract(attrs: &[ast::Attribute]) -> Option<InternedString> {
     return None;
 }
 
-pub fn collect_language_items(crate: &ast::Crate,
+pub fn collect_language_items(krate: &ast::Crate,
                               session: Session) -> @LanguageItems {
     let mut collector = LanguageItemCollector::new(session);
-    collector.collect(crate);
+    collector.collect(krate);
     let LanguageItemCollector { items, .. } = collector;
     session.abort_if_errors();
     @items

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1341,7 +1341,7 @@ fn check_missing_doc_item(cx: &Context, it: &ast::Item) {
 
 fn check_missing_doc_method(cx: &Context, m: &ast::Method) {
     let did = ast::DefId {
-        crate: ast::LOCAL_CRATE,
+        krate: ast::LOCAL_CRATE,
         node: m.id
     };
 
@@ -1643,7 +1643,7 @@ impl<'a> IdVisitingOperation for Context<'a> {
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: typeck::method_map,
                    exported_items: &privacy::ExportedItems,
-                   crate: &ast::Crate) {
+                   krate: &ast::Crate) {
     let mut cx = Context {
         dict: @get_lint_dict(),
         cur: SmallIntMap::new(),
@@ -1664,19 +1664,19 @@ pub fn check_crate(tcx: ty::ctxt,
     for &(lint, level) in tcx.sess.opts.lint_opts.iter() {
         cx.set_level(lint, level, CommandLine);
     }
-    cx.with_lint_attrs(crate.attrs, |cx| {
+    cx.with_lint_attrs(krate.attrs, |cx| {
         cx.visit_id(ast::CRATE_NODE_ID);
         cx.visit_ids(|v| {
             v.visited_outermost = true;
-            visit::walk_crate(v, crate, ());
+            visit::walk_crate(v, krate, ());
         });
 
-        check_crate_attrs_usage(cx, crate.attrs);
+        check_crate_attrs_usage(cx, krate.attrs);
         // since the root module isn't visited as an item (because it isn't an item), warn for it
         // here.
-        check_missing_doc_attrs(cx, None, crate.attrs, crate.span, "crate");
+        check_missing_doc_attrs(cx, None, krate.attrs, krate.span, "crate");
 
-        visit::walk_crate(cx, crate, ());
+        visit::walk_crate(cx, krate, ());
     });
 
     // If we missed any lints added to the session, then there's a bug somewhere

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -176,11 +176,11 @@ impl Visitor<@IrMaps> for LivenessVisitor {
 pub fn check_crate(tcx: ty::ctxt,
                    method_map: typeck::method_map,
                    capture_map: moves::CaptureMap,
-                   crate: &Crate) {
+                   krate: &Crate) {
     let mut visitor = LivenessVisitor;
 
     let initial_maps = @IrMaps(tcx, method_map, capture_map);
-    visit::walk_crate(&mut visitor, crate, initial_maps);
+    visit::walk_crate(&mut visitor, krate, initial_maps);
     tcx.sess.abort_if_errors();
 }
 

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -209,7 +209,7 @@ impl visit::Visitor<()> for VisitContext {
 
 pub fn compute_moves(tcx: ty::ctxt,
                      method_map: method_map,
-                     crate: &Crate) -> MoveMaps
+                     krate: &Crate) -> MoveMaps
 {
     let mut visit_cx = VisitContext {
         tcx: tcx,
@@ -221,7 +221,7 @@ pub fn compute_moves(tcx: ty::ctxt,
         }
     };
     let visit_cx = &mut visit_cx;
-    visit::walk_crate(visit_cx, crate, ());
+    visit::walk_crate(visit_cx, krate, ());
     return visit_cx.move_maps;
 }
 

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -1091,13 +1091,13 @@ pub fn check_crate(tcx: ty::ctxt,
                    exp_map2: &resolve::ExportMap2,
                    external_exports: resolve::ExternalExports,
                    last_private_map: resolve::LastPrivateMap,
-                   crate: &ast::Crate) -> (ExportedItems, PublicItems) {
+                   krate: &ast::Crate) -> (ExportedItems, PublicItems) {
     // Figure out who everyone's parent is
     let mut visitor = ParentVisitor {
         parents: HashMap::new(),
         curparent: ast::DUMMY_NODE_ID,
     };
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 
     // Use the parent map to check the privacy of everything
     let mut visitor = PrivacyVisitor {
@@ -1110,7 +1110,7 @@ pub fn check_crate(tcx: ty::ctxt,
         external_exports: external_exports,
         last_private_map: last_private_map,
     };
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 
     // Sanity check to make sure that all privacy usage and controls are
     // reasonable.
@@ -1118,7 +1118,7 @@ pub fn check_crate(tcx: ty::ctxt,
         in_fn: false,
         tcx: tcx,
     };
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 
     tcx.sess.abort_if_errors();
 
@@ -1135,7 +1135,7 @@ pub fn check_crate(tcx: ty::ctxt,
     };
     loop {
         let before = visitor.exported_items.len();
-        visit::walk_crate(&mut visitor, crate, ());
+        visit::walk_crate(&mut visitor, krate, ());
         if before == visitor.exported_items.len() {
             break
         }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -207,7 +207,7 @@ impl ReachableContext {
     // eligible for inlining and false otherwise.
     fn def_id_represents_local_inlined_item(tcx: ty::ctxt, def_id: ast::DefId)
                                             -> bool {
-        if def_id.crate != ast::LOCAL_CRATE {
+        if def_id.krate != ast::LOCAL_CRATE {
             return false
         }
 
@@ -232,7 +232,7 @@ impl ReachableContext {
                 } else {
                     // Check the impl. If the generics on the self type of the
                     // impl require inlining, this method does too.
-                    assert!(impl_did.crate == ast::LOCAL_CRATE);
+                    assert!(impl_did.krate == ast::LOCAL_CRATE);
                     match tcx.items.find(impl_did.node) {
                         Some(ast_map::NodeItem(item, _)) => {
                             match item.node {
@@ -410,7 +410,7 @@ impl ReachableContext {
     fn mark_destructors_reachable(&self) {
         let destructor_for_type = self.tcx.destructor_for_type.borrow();
         for (_, destructor_def_id) in destructor_for_type.get().iter() {
-            if destructor_def_id.crate == ast::LOCAL_CRATE {
+            if destructor_def_id.krate == ast::LOCAL_CRATE {
                 let mut reachable_symbols = self.reachable_symbols
                                                 .borrow_mut();
                 reachable_symbols.get().insert(destructor_def_id.node);

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -908,7 +908,7 @@ impl<'a> Visitor<Context> for RegionResolutionVisitor<'a> {
     }
 }
 
-pub fn resolve_crate(sess: Session, crate: &ast::Crate) -> RegionMaps {
+pub fn resolve_crate(sess: Session, krate: &ast::Crate) -> RegionMaps {
     let maps = RegionMaps {
         scope_map: RefCell::new(HashMap::new()),
         var_map: RefCell::new(HashMap::new()),
@@ -922,7 +922,7 @@ pub fn resolve_crate(sess: Session, crate: &ast::Crate) -> RegionMaps {
             region_maps: &maps
         };
         let cx = Context { parent: None, var_parent: None };
-        visit::walk_crate(&mut visitor, crate, cx);
+        visit::walk_crate(&mut visitor, krate, cx);
     }
     return maps;
 }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -44,13 +44,13 @@ enum ScopeChain<'a> {
     RootScope
 }
 
-pub fn crate(sess: session::Session, crate: &ast::Crate)
+pub fn krate(sess: session::Session, krate: &ast::Crate)
              -> @RefCell<NamedRegionMap> {
     let mut ctxt = LifetimeContext {
         sess: sess,
         named_region_map: @RefCell::new(HashMap::new())
     };
-    visit::walk_crate(&mut ctxt, crate, &RootScope);
+    visit::walk_crate(&mut ctxt, krate, &RootScope);
     sess.abort_if_errors();
     ctxt.named_region_map
 }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -346,7 +346,7 @@ pub fn trans_fn_ref_with_vtables(
     // Check whether this fn has an inlined copy and, if so, redirect
     // def_id to the local id of the inlined copy.
     let def_id = {
-        if def_id.crate != ast::LOCAL_CRATE {
+        if def_id.krate != ast::LOCAL_CRATE {
             inline::maybe_instantiate_inline(ccx, def_id)
         } else {
             def_id
@@ -360,7 +360,7 @@ pub fn trans_fn_ref_with_vtables(
     let must_monomorphise;
     if type_params.len() > 0 || is_default {
         must_monomorphise = true;
-    } else if def_id.crate == ast::LOCAL_CRATE {
+    } else if def_id.krate == ast::LOCAL_CRATE {
         {
             let map_node = session::expect(
                 ccx.sess,
@@ -383,7 +383,7 @@ pub fn trans_fn_ref_with_vtables(
     // Create a monomorphic verison of generic functions
     if must_monomorphise {
         // Should be either intra-crate or inlined.
-        assert_eq!(def_id.crate, ast::LOCAL_CRATE);
+        assert_eq!(def_id.krate, ast::LOCAL_CRATE);
 
         let (val, must_cast) =
             monomorphize::monomorphic_fn(ccx, def_id, &substs,
@@ -403,7 +403,7 @@ pub fn trans_fn_ref_with_vtables(
 
     // Find the actual function pointer.
     let mut val = {
-        if def_id.crate == ast::LOCAL_CRATE {
+        if def_id.krate == ast::LOCAL_CRATE {
             // Internal reference.
             get_item_val(ccx, def_id.node)
         } else {
@@ -512,7 +512,7 @@ pub fn trans_lang_call<'a>(
                        args: &[ValueRef],
                        dest: Option<expr::Dest>)
                        -> Result<'a> {
-    let fty = if did.crate == ast::LOCAL_CRATE {
+    let fty = if did.krate == ast::LOCAL_CRATE {
         ty::node_id_to_type(bcx.ccx().tcx, did.node)
     } else {
         csearch::get_type(bcx.ccx().tcx, did).ty
@@ -541,7 +541,7 @@ pub fn trans_lang_call_with_type_params<'a>(
                                         dest: expr::Dest)
                                         -> &'a Block<'a> {
     let fty;
-    if did.crate == ast::LOCAL_CRATE {
+    if did.krate == ast::LOCAL_CRATE {
         fty = ty::node_id_to_type(bcx.tcx(), did.node);
     } else {
         fty = csearch::get_type(bcx.tcx(), did).ty;

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1398,7 +1398,7 @@ fn describe_enum_variant(cx: &CrateContext,
     // Could some consistency checks here: size, align, field count, discr type
 
     // Find the source code location of the variant's definition
-    let variant_definition_span = if variant_info.id.crate == ast::LOCAL_CRATE {
+    let variant_definition_span = if variant_info.id.krate == ast::LOCAL_CRATE {
         {
             match cx.tcx.items.find(variant_info.id.node) {
                 Some(ast_map::NodeVariant(ref variant, _, _)) => variant.span,
@@ -2261,7 +2261,7 @@ fn get_namespace_and_span_for_item(cx: &CrateContext,
                                    warning_span: Span)
                                 -> (DIScope, Span) {
     let containing_scope = namespace_for_item(cx, def_id, warning_span).scope;
-    let definition_span = if def_id.crate == ast::LOCAL_CRATE {
+    let definition_span = if def_id.krate == ast::LOCAL_CRATE {
         {
             let definition_span = match cx.tcx.items.find(def_id.node) {
                 Some(ast_map::NodeItem(item, _)) => item.span,
@@ -2782,8 +2782,8 @@ fn namespace_for_item(cx: &CrateContext,
     let namespace_path = {
         let mut item_path = ty::item_path(cx.tcx, def_id);
 
-        if (def_id.crate == ast::LOCAL_CRATE && item_path.len() < 1) ||
-           (def_id.crate != ast::LOCAL_CRATE && item_path.len() < 2) {
+        if (def_id.krate == ast::LOCAL_CRATE && item_path.len() < 1) ||
+           (def_id.krate != ast::LOCAL_CRATE && item_path.len() < 2) {
             cx.sess.bug(format!("debuginfo::namespace_for_item() - Item path too short: {}",
                 ast_map::path_to_str(item_path, token::get_ident_interner())));
         }
@@ -2791,7 +2791,7 @@ fn namespace_for_item(cx: &CrateContext,
         // remove the name of the item
         item_path.pop();
 
-        if def_id.crate == ast::LOCAL_CRATE {
+        if def_id.krate == ast::LOCAL_CRATE {
             // prepend crate name if not already present
             let crate_namespace_ident = token::str_to_ident(cx.link_meta.crateid.name);
             item_path.insert(0, ast_map::PathMod(crate_namespace_ident));

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -582,7 +582,7 @@ fn trans_def<'a>(bcx: &'a Block<'a>,
 
             fn get_did(ccx: @CrateContext, did: ast::DefId)
                        -> ast::DefId {
-                if did.crate != ast::LOCAL_CRATE {
+                if did.krate != ast::LOCAL_CRATE {
                     inline::maybe_instantiate_inline(ccx, did)
                 } else {
                     did
@@ -592,7 +592,7 @@ fn trans_def<'a>(bcx: &'a Block<'a>,
             fn get_val<'a>(bcx: &'a Block<'a>, did: ast::DefId, const_ty: ty::t)
                        -> ValueRef {
                 // For external constants, we don't inline.
-                if did.crate == ast::LOCAL_CRATE {
+                if did.krate == ast::LOCAL_CRATE {
                     // The LLVM global has the type of its initializer,
                     // which may not be equal to the enum's type for
                     // non-C-like enums.
@@ -1710,7 +1710,7 @@ fn trans_log_level<'a>(bcx: &'a Block<'a>)
             let external_srcs = ccx.external_srcs.borrow();
             srccrate = match external_srcs.get().find(&bcx.fcx.id) {
                 Some(&src) => {
-                    ccx.sess.cstore.get_crate_data(src.crate).name.clone()
+                    ccx.sess.cstore.get_crate_data(src.krate).name.clone()
                 }
                 None => ccx.link_meta.crateid.name.to_str(),
             };

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -184,7 +184,7 @@ pub fn trans_static_method_callee(bcx: &Block,
     let bound_index = ty::lookup_trait_def(bcx.tcx(), trait_id).
         generics.type_param_defs().len();
 
-    let mname = if method_id.crate == ast::LOCAL_CRATE {
+    let mname = if method_id.krate == ast::LOCAL_CRATE {
         {
             match bcx.tcx().items.get(method_id.node) {
                 ast_map::NodeTraitMethod(trait_method, _, _) => {

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -321,10 +321,10 @@ pub fn llvm_type_name(cx: &CrateContext,
     let tstr = ppaux::parameterized(cx.tcx, ty::item_path_str(cx.tcx, did),
                                     &ty::NonerasedRegions(opt_vec::Empty),
                                     tps, did, false);
-    if did.crate == 0 {
+    if did.krate == 0 {
         format!("{}.{}", name, tstr)
     } else {
-        format!("{}.{}[\\#{}]", name, tstr, did.crate)
+        format!("{}.{}[\\#{}]", name, tstr, did.krate)
     }
 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2187,7 +2187,7 @@ pub fn type_contents(cx: ctxt, ty: t) -> TypeContents {
                 // If this assertion failures, it is likely because of a
                 // failure in the cross-crate inlining code to translate a
                 // def-id.
-                assert_eq!(p.def_id.crate, ast::LOCAL_CRATE);
+                assert_eq!(p.def_id.krate, ast::LOCAL_CRATE);
 
                 let ty_param_defs = cx.ty_param_defs.borrow();
                 let tp_def = ty_param_defs.get().get(&p.def_id.node);
@@ -3842,8 +3842,8 @@ fn lookup_locally_or_in_crate_store<V:Clone>(
         None => { }
     }
 
-    if def_id.crate == ast::LOCAL_CRATE {
-        fail!("no def'n found for {:?} in tcx.{}", def_id, descr);
+    if def_id.krate == ast::LOCAL_CRATE {
+        fail!("No def'n found for {:?} in tcx.{}", def_id, descr);
     }
     let v = load_external();
     map.insert(def_id, v.clone());
@@ -3895,7 +3895,7 @@ pub fn impl_trait_ref(cx: ctxt, id: ast::DefId) -> Option<@TraitRef> {
         }
     }
 
-    let ret = if id.crate == ast::LOCAL_CRATE {
+    let ret = if id.krate == ast::LOCAL_CRATE {
         debug!("(impl_trait_ref) searching for trait impl {:?}", id);
         {
             match cx.items.find(id.node) {
@@ -4085,7 +4085,7 @@ pub fn has_dtor(cx: ctxt, struct_id: DefId) -> bool {
 }
 
 pub fn item_path(cx: ctxt, id: ast::DefId) -> ast_map::Path {
-    if id.crate != ast::LOCAL_CRATE {
+    if id.krate != ast::LOCAL_CRATE {
         return csearch::get_item_path(cx, id)
     }
 
@@ -4155,7 +4155,7 @@ pub fn enum_variants(cx: ctxt, id: ast::DefId) -> @~[@VariantInfo] {
         }
     }
 
-    let result = if ast::LOCAL_CRATE != id.crate {
+    let result = if ast::LOCAL_CRATE != id.krate {
         @csearch::get_enum_variants(cx, id)
     } else {
         /*
@@ -4274,7 +4274,7 @@ pub fn lookup_trait_def(cx: ctxt, did: ast::DefId) -> @ty::TraitDef {
             return trait_def;
         }
         None => {
-            assert!(did.crate != ast::LOCAL_CRATE);
+            assert!(did.krate != ast::LOCAL_CRATE);
             let trait_def = @csearch::get_trait_def(cx, did);
             trait_defs.get().insert(did, trait_def);
             return trait_def;
@@ -4348,7 +4348,7 @@ pub fn lookup_field_type(tcx: ctxt,
                          id: DefId,
                          substs: &substs)
                       -> ty::t {
-    let t = if id.crate == ast::LOCAL_CRATE {
+    let t = if id.krate == ast::LOCAL_CRATE {
         node_id_to_type(tcx, id.node)
     } else {
         {
@@ -4369,7 +4369,7 @@ pub fn lookup_field_type(tcx: ctxt,
 // Look up the list of field names and IDs for a given struct
 // Fails if the id is not bound to a struct.
 pub fn lookup_struct_fields(cx: ctxt, did: ast::DefId) -> ~[field_ty] {
-  if did.crate == ast::LOCAL_CRATE {
+  if did.krate == ast::LOCAL_CRATE {
       {
           match cx.items.find(did.node) {
            Some(ast_map::NodeItem(i,_)) => {
@@ -4799,7 +4799,7 @@ fn record_trait_implementation(tcx: ctxt,
 /// if necessary.
 pub fn populate_implementations_for_type_if_necessary(tcx: ctxt,
                                                       type_id: ast::DefId) {
-    if type_id.crate == LOCAL_CRATE {
+    if type_id.krate == LOCAL_CRATE {
         return
     }
     {
@@ -4867,7 +4867,7 @@ pub fn populate_implementations_for_type_if_necessary(tcx: ctxt,
 pub fn populate_implementations_for_trait_if_necessary(
         tcx: ctxt,
         trait_id: ast::DefId) {
-    if trait_id.crate == LOCAL_CRATE {
+    if trait_id.krate == LOCAL_CRATE {
         return
     }
     {
@@ -4931,7 +4931,7 @@ pub fn trait_id_of_impl(tcx: ctxt,
 /// the trait that the method belongs to. Otherwise, return `None`.
 pub fn trait_of_method(tcx: ctxt, def_id: ast::DefId)
                        -> Option<ast::DefId> {
-    if def_id.crate != LOCAL_CRATE {
+    if def_id.krate != LOCAL_CRATE {
         return csearch::get_trait_of_method(tcx.cstore, def_id, tcx);
     }
     let method;
@@ -5012,7 +5012,7 @@ pub fn hash_crate_independent(tcx: ctxt, t: t, local_hash: ~str) -> u64 {
         let h = if ast_util::is_local(did) {
             local_hash.clone()
         } else {
-            tcx.sess.cstore.get_crate_hash(did.crate)
+            tcx.sess.cstore.get_crate_hash(did.krate)
         };
         hash.input(h.as_bytes());
         iter(hash, &did.node);

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1297,7 +1297,7 @@ impl<'a> LookupContext<'a> {
     }
 
     fn report_static_candidate(&self, idx: uint, did: DefId) {
-        let span = if did.crate == ast::LOCAL_CRATE {
+        let span = if did.krate == ast::LOCAL_CRATE {
             {
                 match self.tcx().items.find(did.node) {
                   Some(ast_map::NodeMethod(m, _, _)) => m.span,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -312,9 +312,9 @@ impl Visitor<()> for CheckItemTypesVisitor {
     }
 }
 
-pub fn check_item_types(ccx: @CrateCtxt, crate: &ast::Crate) {
+pub fn check_item_types(ccx: @CrateCtxt, krate: &ast::Crate) {
     let mut visit = CheckItemTypesVisitor { ccx: ccx };
-    visit::walk_crate(&mut visit, crate, ());
+    visit::walk_crate(&mut visit, krate, ());
 }
 
 fn check_bare_fn(ccx: @CrateCtxt,
@@ -2648,7 +2648,7 @@ pub fn check_expr_with_unifier(fcx: @FnCtxt,
                                       Err(msg) => {
                                           tcx.sess.span_err(expr.span, msg);
                                           ast::DefId {
-                                              crate: ast::CRATE_NODE_ID,
+                                              krate: ast::CRATE_NODE_ID,
                                               node: ast::DUMMY_NODE_ID,
                                           }
                                       }
@@ -3624,7 +3624,7 @@ pub fn check_enum_variants(ccx: @CrateCtxt,
         return variants;
     }
 
-    let hint = ty::lookup_repr_hint(ccx.tcx, ast::DefId { crate: ast::LOCAL_CRATE, node: id });
+    let hint = ty::lookup_repr_hint(ccx.tcx, ast::DefId { krate: ast::LOCAL_CRATE, node: id });
     if hint != attr::ReprAny && vs.len() <= 1 {
         ccx.tcx.sess.span_err(sp, format!("unsupported representation for {}variant enum",
                                           if vs.len() == 1 { "uni" } else { "zero-" }))

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -631,7 +631,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
             // Identify the variable being closed over and its node-id.
             let def = freevar.def;
             let def_id = ast_util::def_id_of_def(def);
-            assert!(def_id.crate == ast::LOCAL_CRATE);
+            assert!(def_id.krate == ast::LOCAL_CRATE);
             let upvar_id = ty::UpvarId { var_id: def_id.node,
                                          closure_expr_id: expr.id };
 

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -73,7 +73,7 @@ impl visit::Visitor<()> for CollectItemTypesVisitor {
     }
 }
 
-pub fn collect_item_types(ccx: @CrateCtxt, crate: &ast::Crate) {
+pub fn collect_item_types(ccx: @CrateCtxt, krate: &ast::Crate) {
     fn collect_intrinsic_type(ccx: &CrateCtxt,
                               lang_item: ast::DefId) {
         let ty::ty_param_bounds_and_ty { ty: ty, .. } =
@@ -90,7 +90,7 @@ pub fn collect_item_types(ccx: @CrateCtxt, crate: &ast::Crate) {
     }
 
     let mut visitor = CollectItemTypesVisitor{ ccx: ccx };
-    visit::walk_crate(&mut visitor, crate, ());
+    visit::walk_crate(&mut visitor, krate, ());
 }
 
 pub trait ToTy {
@@ -107,7 +107,7 @@ impl AstConv for CrateCtxt {
     fn tcx(&self) -> ty::ctxt { self.tcx }
 
     fn get_item_ty(&self, id: ast::DefId) -> ty::ty_param_bounds_and_ty {
-        if id.crate != ast::LOCAL_CRATE {
+        if id.krate != ast::LOCAL_CRATE {
             return csearch::get_type(self.tcx, id)
         }
 
@@ -283,7 +283,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
 
         let tcx = ccx.tcx;
 
-        let dummy_defid = ast::DefId {crate: 0, node: 0};
+        let dummy_defid = ast::DefId {krate: 0, node: 0};
 
         // Represents [A',B',C']
         let num_trait_bounds = trait_ty_generics.type_param_defs().len();
@@ -765,7 +765,7 @@ pub fn instantiate_trait_ref(ccx: &CrateCtxt,
 }
 
 fn get_trait_def(ccx: &CrateCtxt, trait_id: ast::DefId) -> @ty::TraitDef {
-    if trait_id.crate != ast::LOCAL_CRATE {
+    if trait_id.krate != ast::LOCAL_CRATE {
         return ty::lookup_trait_def(ccx.tcx, trait_id)
     }
 

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -31,7 +31,7 @@ use syntax::parse::parse_crate_from_source_str;
 use syntax::{ast, attr, parse};
 
 struct Env {
-    crate: @ast::Crate,
+    krate: @ast::Crate,
     tcx: ty::ctxt,
     infcx: infer::infer_ctxt,
     err_messages: @DVec<~str>
@@ -59,7 +59,7 @@ fn setup_env(test_name: &str, source_string: &str) -> Env {
     let lang_items = LanguageItems::new();
 
     let parse_sess = parse::new_parse_sess(None);
-    let crate = parse_crate_from_source_str(
+    let krate = parse_crate_from_source_str(
         test_name.to_str(), @source_string.to_str(),
         cfg, parse_sess);
 
@@ -68,7 +68,7 @@ fn setup_env(test_name: &str, source_string: &str) -> Env {
 
     let infcx = infer::new_infer_ctxt(tcx);
 
-    return Env {crate: crate,
+    return Env {krate: krate,
                 tcx: tcx,
                 infcx: infcx,
                 err_messages: messages};
@@ -94,7 +94,7 @@ impl Env {
     }
 
     pub fn lookup_item(&self, names: &[~str]) -> ast::node_id {
-        return match search_mod(self, &self.crate.node.module, 0, names) {
+        return match search_mod(self, &self.krate.node.module, 0, names) {
             Some(id) => id,
             None => {
                 fail!("no item found: `%s`", names.connect("::"));

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -441,7 +441,7 @@ fn check_for_entry_fn(ccx: &CrateCtxt) {
 
 pub fn check_crate(tcx: ty::ctxt,
                    trait_map: resolve::TraitMap,
-                   crate: &ast::Crate)
+                   krate: &ast::Crate)
                 -> (method_map, vtable_map) {
     let time_passes = tcx.sess.time_passes();
     let ccx = @CrateCtxt {
@@ -452,20 +452,20 @@ pub fn check_crate(tcx: ty::ctxt,
     };
 
     time(time_passes, "type collecting", (), |_|
-        collect::collect_item_types(ccx, crate));
+        collect::collect_item_types(ccx, krate));
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
     tcx.sess.abort_if_errors();
 
     time(time_passes, "variance inference", (), |_|
-         variance::infer_variance(tcx, crate));
+         variance::infer_variance(tcx, krate));
 
     time(time_passes, "coherence checking", (), |_|
-        coherence::check_coherence(ccx, crate));
+        coherence::check_coherence(ccx, krate));
 
     time(time_passes, "type checking", (), |_|
-        check::check_item_types(ccx, crate));
+        check::check_item_types(ccx, krate));
 
     check_for_entry_fn(ccx);
     tcx.sess.abort_if_errors();

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -76,7 +76,7 @@ impl RegionScope for BindingRscope {
 
 pub fn bound_type_regions(defs: &[ty::RegionParameterDef])
                           -> OptVec<ty::Region> {
-    assert!(defs.iter().all(|def| def.def_id.crate == ast::LOCAL_CRATE));
+    assert!(defs.iter().all(|def| def.def_id.krate == ast::LOCAL_CRATE));
     defs.iter().enumerate().map(
         |(i, def)| ty::ReEarlyBound(def.def_id.node, i, def.ident)).collect()
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -781,7 +781,7 @@ impl Repr for ast::DefId {
         // Unfortunately, there seems to be no way to attempt to print
         // a path for a def-id, so I'll just make a best effort for now
         // and otherwise fallback to just printing the crate/node pair
-        if self.crate == ast::LOCAL_CRATE {
+        if self.krate == ast::LOCAL_CRATE {
             {
                 match tcx.items.find(self.node) {
                     Some(ast_map::NodeItem(..)) |

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -604,7 +604,7 @@ pub enum Type {
         typarams: Option<~[TyParamBound]>,
         fqn: ~[~str],
         kind: TypeKind,
-        crate: ast::CrateNum,
+        krate: ast::CrateNum,
     },
     // I have no idea how to usefully use this.
     TyParamBinder(ast::NodeId),
@@ -1239,7 +1239,7 @@ fn resolve_type(path: Path, tpbs: Option<~[TyParamBound]>,
             }
         }).to_owned_vec();
         ExternalPath{ path: path, typarams: tpbs, fqn: fqn, kind: kind,
-                      crate: def_id.crate }
+                      krate: def_id.krate }
     }
 }
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -28,7 +28,7 @@ use clean;
 use clean::Clean;
 
 pub struct DocContext {
-    crate: ast::Crate,
+    krate: ast::Crate,
     tycx: Option<middle::ty::ctxt>,
     sess: driver::session::Session
 }
@@ -73,15 +73,15 @@ fn get_ast_and_resolve(cpath: &Path,
         cfg.push(@dummy_spanned(ast::MetaWord(cfg_)));
     }
 
-    let crate = phase_1_parse_input(sess, cfg, &input);
+    let krate = phase_1_parse_input(sess, cfg, &input);
     let loader = &mut Loader::new(sess);
-    let (crate, ast_map) = phase_2_configure_and_expand(sess, loader, crate);
+    let (krate, ast_map) = phase_2_configure_and_expand(sess, loader, krate);
     let driver::driver::CrateAnalysis {
         exported_items, public_items, ty_cx, ..
-    } = phase_3_run_analysis_passes(sess, &crate, ast_map);
+    } = phase_3_run_analysis_passes(sess, &krate, ast_map);
 
-    debug!("crate: {:?}", crate);
-    return (DocContext { crate: crate, tycx: Some(ty_cx), sess: sess },
+    debug!("crate: {:?}", krate);
+    return (DocContext { krate: krate, tycx: Some(ty_cx), sess: sess },
             CrateAnalysis {
                 exported_items: exported_items,
                 public_items: public_items,
@@ -93,11 +93,11 @@ pub fn run_core (libs: HashSet<Path>, cfgs: ~[~str], path: &Path) -> (clean::Cra
     let ctxt = @ctxt;
     local_data::set(super::ctxtkey, ctxt);
 
-    let crate = {
+    let krate = {
         let mut v = RustdocVisitor::new(ctxt, Some(&analysis));
-        v.visit(&ctxt.crate);
+        v.visit(&ctxt.krate);
         v.clean()
     };
 
-    (crate, analysis)
+    (krate, analysis)
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -160,10 +160,10 @@ fn resolved_path(w: &mut io::Writer, id: ast::NodeId, p: &clean::Path,
 /// will invoke `path` with proper linking-style arguments.
 fn external_path(w: &mut io::Writer, p: &clean::Path, print_all: bool,
                  fqn: &[~str], kind: clean::TypeKind,
-                 crate: ast::CrateNum) -> fmt::Result {
+                 krate: ast::CrateNum) -> fmt::Result {
     path(w, p, print_all,
         |cache, loc| {
-            match *cache.extern_locations.get(&crate) {
+            match *cache.extern_locations.get(&krate) {
                 render::Remote(ref s) => Some(s.clone()),
                 render::Local => Some("../".repeat(loc.len())),
                 render::Unknown => None,
@@ -310,9 +310,9 @@ impl fmt::Show for clean::Type {
                 typarams(f.buf, tp)
             }
             clean::ExternalPath{path: ref path, typarams: ref tp,
-                                fqn: ref fqn, kind, crate} => {
+                                fqn: ref fqn, kind, krate} => {
                 if_ok!(external_path(f.buf, path, false, fqn.as_slice(), kind,
-                                     crate))
+                                     krate))
                 typarams(f.buf, tp)
             }
             clean::Self(..) => f.buf.write("Self".as_bytes()),

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -15,7 +15,7 @@ use std::io;
 pub struct Layout {
     logo: ~str,
     favicon: ~str,
-    crate: ~str,
+    krate: ~str,
 }
 
 pub struct Page<'a> {
@@ -37,7 +37,7 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
 
     <link href='http://fonts.googleapis.com/css?family=Oswald:700|Inconsolata:400'
           rel='stylesheet' type='text/css'>
-    <link rel=\"stylesheet\" type=\"text/css\" href=\"{root_path}{crate}/main.css\">
+    <link rel=\"stylesheet\" type=\"text/css\" href=\"{root_path}{krate}/main.css\">
 
     {favicon, select, none{} other{<link rel=\"shortcut icon\" href=\"#\" />}}
 </head>
@@ -51,7 +51,7 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
 
     <section class=\"sidebar\">
         {logo, select, none{} other{
-            <a href='{root_path}{crate}/index.html'><img src='#' alt=''/></a>
+            <a href='{root_path}{krate}/index.html'><img src='#' alt=''/></a>
         }}
 
         {sidebar}
@@ -77,9 +77,9 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
     <script>
         var rootPath = \"{root_path}\";
     </script>
-    <script src=\"{root_path}{crate}/jquery.js\"></script>
-    <script src=\"{root_path}{crate}/search-index.js\"></script>
-    <script src=\"{root_path}{crate}/main.js\"></script>
+    <script src=\"{root_path}{krate}/jquery.js\"></script>
+    <script src=\"{root_path}{krate}/search-index.js\"></script>
+    <script src=\"{root_path}{krate}/main.js\"></script>
 
     <div id=\"help\" class=\"hidden\">
         <div class=\"shortcuts\">
@@ -121,7 +121,7 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
     title     = page.title,
     favicon   = nonestr(layout.favicon),
     sidebar   = *sidebar,
-    crate     = layout.crate,
+    krate     = layout.krate,
     )
 }
 

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -21,7 +21,7 @@ use fold;
 use fold::DocFolder;
 
 /// Strip items marked `#[doc(hidden)]`
-pub fn strip_hidden(crate: clean::Crate) -> plugins::PluginResult {
+pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
     struct Stripper;
     impl fold::DocFolder for Stripper {
         fn fold_item(&mut self, i: Item) -> Option<Item> {
@@ -45,19 +45,19 @@ pub fn strip_hidden(crate: clean::Crate) -> plugins::PluginResult {
         }
     }
     let mut stripper = Stripper;
-    let crate = stripper.fold_crate(crate);
-    (crate, None)
+    let krate = stripper.fold_crate(krate);
+    (krate, None)
 }
 
 /// Strip private items from the point of view of a crate or externally from a
 /// crate, specified by the `xcrate` flag.
-pub fn strip_private(crate: clean::Crate) -> plugins::PluginResult {
+pub fn strip_private(krate: clean::Crate) -> plugins::PluginResult {
     // This stripper collects all *retained* nodes.
     let mut retained = HashSet::new();
     let exported_items = local_data::get(super::analysiskey, |analysis| {
         analysis.unwrap().exported_items.clone()
     });
-    let mut crate = crate;
+    let mut krate = krate;
 
     // strip all private items
     {
@@ -65,15 +65,15 @@ pub fn strip_private(crate: clean::Crate) -> plugins::PluginResult {
             retained: &mut retained,
             exported_items: &exported_items,
         };
-        crate = stripper.fold_crate(crate);
+        krate = stripper.fold_crate(krate);
     }
 
     // strip all private implementations of traits
     {
         let mut stripper = ImplStripper(&retained);
-        crate = stripper.fold_crate(crate);
+        krate = stripper.fold_crate(krate);
     }
-    (crate, None)
+    (krate, None)
 }
 
 struct Stripper<'a> {
@@ -174,7 +174,7 @@ impl<'a> fold::DocFolder for ImplStripper<'a> {
 }
 
 
-pub fn unindent_comments(crate: clean::Crate) -> plugins::PluginResult {
+pub fn unindent_comments(krate: clean::Crate) -> plugins::PluginResult {
     struct CommentCleaner;
     impl fold::DocFolder for CommentCleaner {
         fn fold_item(&mut self, i: Item) -> Option<Item> {
@@ -192,11 +192,11 @@ pub fn unindent_comments(crate: clean::Crate) -> plugins::PluginResult {
         }
     }
     let mut cleaner = CommentCleaner;
-    let crate = cleaner.fold_crate(crate);
-    (crate, None)
+    let krate = cleaner.fold_crate(krate);
+    (krate, None)
 }
 
-pub fn collapse_docs(crate: clean::Crate) -> plugins::PluginResult {
+pub fn collapse_docs(krate: clean::Crate) -> plugins::PluginResult {
     struct Collapser;
     impl fold::DocFolder for Collapser {
         fn fold_item(&mut self, i: Item) -> Option<Item> {
@@ -223,8 +223,8 @@ pub fn collapse_docs(crate: clean::Crate) -> plugins::PluginResult {
         }
     }
     let mut collapser = Collapser;
-    let crate = collapser.fold_crate(crate);
-    (crate, None)
+    let krate = collapser.fold_crate(krate);
+    (krate, None)
 }
 
 pub fn unindent(s: &str) -> ~str {

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -57,15 +57,15 @@ impl PluginManager {
         self.callbacks.push(plugin);
     }
     /// Run all the loaded plugins over the crate, returning their results
-    pub fn run_plugins(&self, crate: clean::Crate) -> (clean::Crate, ~[PluginJson]) {
+    pub fn run_plugins(&self, krate: clean::Crate) -> (clean::Crate, ~[PluginJson]) {
         let mut out_json = ~[];
-        let mut crate = crate;
+        let mut krate = krate;
         for &callback in self.callbacks.iter() {
-            let (c, res) = callback(crate);
-            crate = c;
+            let (c, res) = callback(krate);
+            krate = c;
             out_json.push(res);
         }
-        (crate, out_json)
+        (krate, out_json)
     }
 }
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -58,31 +58,31 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
                                       span_diagnostic_handler);
 
     let cfg = driver::build_configuration(sess);
-    let crate = driver::phase_1_parse_input(sess, cfg, &input);
+    let krate = driver::phase_1_parse_input(sess, cfg, &input);
     let loader = &mut Loader::new(sess);
-    let (crate, _) = driver::phase_2_configure_and_expand(sess, loader, crate);
+    let (krate, _) = driver::phase_2_configure_and_expand(sess, loader, krate);
 
     let ctx = @core::DocContext {
-        crate: crate,
+        krate: krate,
         tycx: None,
         sess: sess,
     };
     local_data::set(super::ctxtkey, ctx);
 
     let mut v = RustdocVisitor::new(ctx, None);
-    v.visit(&ctx.crate);
-    let crate = v.clean();
-    let (crate, _) = passes::unindent_comments(crate);
-    let (crate, _) = passes::collapse_docs(crate);
+    v.visit(&ctx.krate);
+    let krate = v.clean();
+    let (krate, _) = passes::unindent_comments(krate);
+    let (krate, _) = passes::collapse_docs(krate);
 
     let mut collector = Collector {
         tests: ~[],
         names: ~[],
         cnt: 0,
         libs: libs,
-        cratename: crate.name.to_owned(),
+        cratename: krate.name.to_owned(),
     };
-    collector.fold_crate(crate);
+    collector.fold_crate(krate);
 
     let args = matches.opt_strs("test-args");
     let mut args = args.iter().flat_map(|s| s.words()).map(|s| s.to_owned());

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -38,12 +38,12 @@ impl<'a> RustdocVisitor<'a> {
         }
     }
 
-    pub fn visit(&mut self, crate: &ast::Crate) {
-        self.attrs = crate.attrs.clone();
+    pub fn visit(&mut self, krate: &ast::Crate) {
+        self.attrs = krate.attrs.clone();
 
-        self.module = self.visit_mod_contents(crate.span, crate.attrs.clone(),
+        self.module = self.visit_mod_contents(krate.span, krate.attrs.clone(),
                                               ast::Public, ast::CRATE_NODE_ID,
-                                              &crate.module, None);
+                                              &krate.module, None);
     }
 
     pub fn visit_struct_def(&mut self, item: &ast::Item, sd: @ast::StructDef,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -181,7 +181,7 @@ pub type NodeId = u32;
 
 #[deriving(Clone, TotalEq, TotalOrd, Eq, Encodable, Decodable, IterBytes, ToStr)]
 pub struct DefId {
-    crate: CrateNum,
+    krate: CrateNum,
     node: NodeId,
 }
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -406,7 +406,7 @@ pub fn map_crate<F: 'static + FoldOps>(diag: @SpanHandler, c: Crate,
         diag: diag,
         fold_ops: fold_ops
     };
-    let crate = cx.fold_crate(c);
+    let krate = cx.fold_crate(c);
 
     if log_enabled!(logging::DEBUG) {
         let map = cx.map.map.borrow();
@@ -421,7 +421,7 @@ pub fn map_crate<F: 'static + FoldOps>(diag: @SpanHandler, c: Crate,
               entries, vector_length, (entries as f64 / vector_length as f64) * 100.);
     }
 
-    (crate, cx.map)
+    (krate, cx.map)
 }
 
 // Used for items loaded from external crate that are being inlined into this

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -38,10 +38,10 @@ pub fn path_to_ident(path: &Path) -> Ident {
 }
 
 pub fn local_def(id: NodeId) -> DefId {
-    ast::DefId { crate: LOCAL_CRATE, node: id }
+    ast::DefId { krate: LOCAL_CRATE, node: id }
 }
 
-pub fn is_local(did: ast::DefId) -> bool { did.crate == LOCAL_CRATE }
+pub fn is_local(did: ast::DefId) -> bool { did.krate == LOCAL_CRATE }
 
 pub fn stmt_id(s: &Stmt) -> NodeId {
     match s.node {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -268,7 +268,7 @@ pub struct MacroCrate {
 }
 
 pub trait CrateLoader {
-    fn load_crate(&mut self, crate: &ast::ViewItem) -> MacroCrate;
+    fn load_crate(&mut self, krate: &ast::ViewItem) -> MacroCrate;
     fn get_exported_macros(&mut self, crate_num: ast::CrateNum) -> ~[~str];
     fn get_registrar_symbol(&mut self, crate_num: ast::CrateNum) -> Option<~str>;
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -413,10 +413,10 @@ pub fn expand_view_item(vi: &ast::ViewItem,
     noop_fold_view_item(vi, fld)
 }
 
-fn load_extern_macros(crate: &ast::ViewItem, fld: &mut MacroExpander) {
-    let MacroCrate { lib, cnum } = fld.cx.loader.load_crate(crate);
+fn load_extern_macros(krate: &ast::ViewItem, fld: &mut MacroExpander) {
+    let MacroCrate { lib, cnum } = fld.cx.loader.load_crate(krate);
 
-    let crate_name = match crate.node {
+    let crate_name = match krate.node {
         ast::ViewItemExternMod(ref name, _, _) => {
             let string = token::get_ident(name.name);
             string.get().to_str()
@@ -452,19 +452,19 @@ fn load_extern_macros(crate: &ast::ViewItem, fld: &mut MacroExpander) {
         // this is fatal: there are almost certainly macros we need
         // inside this crate, so continue would spew "macro undefined"
         // errors
-        Err(err) => fld.cx.span_fatal(crate.span, err)
+        Err(err) => fld.cx.span_fatal(krate.span, err)
     };
 
     unsafe {
         let registrar: MacroCrateRegistrationFun = match lib.symbol(registrar) {
             Ok(registrar) => registrar,
             // again fatal if we can't register macros
-            Err(err) => fld.cx.span_fatal(crate.span, err)
+            Err(err) => fld.cx.span_fatal(krate.span, err)
         };
         registrar(|name, extension| {
             let extension = match extension {
-                NormalTT(ext, _) => NormalTT(ext, Some(crate.span)),
-                IdentTT(ext, _) => IdentTT(ext, Some(crate.span)),
+                NormalTT(ext, _) => NormalTT(ext, Some(krate.span)),
+                IdentTT(ext, _) => IdentTT(ext, Some(krate.span)),
                 ItemDecorator(ext) => ItemDecorator(ext),
             };
             fld.extsbox.insert(name, extension);
@@ -1032,10 +1032,10 @@ mod test {
         }
     }
 
-    //fn fake_print_crate(crate: &ast::Crate) {
+    //fn fake_print_crate(krate: &ast::Crate) {
     //    let mut out = ~std::io::stderr() as ~std::io::Writer;
     //    let mut s = pprust::rust_printer(out, get_ident_interner());
-    //    pprust::print_crate_(&mut s, crate);
+    //    pprust::print_crate_(&mut s, krate);
     //}
 
     fn expand_crate_str(crate_str: ~str) -> ast::Crate {

--- a/src/libsyntax/ext/registrar.rs
+++ b/src/libsyntax/ext/registrar.rs
@@ -35,16 +35,16 @@ impl Visitor<()> for MacroRegistrarContext {
 }
 
 pub fn find_macro_registrar(diagnostic: @diagnostic::SpanHandler,
-                            crate: &ast::Crate) -> Option<ast::DefId> {
+                            krate: &ast::Crate) -> Option<ast::DefId> {
     let mut ctx = MacroRegistrarContext { registrars: ~[] };
-    visit::walk_crate(&mut ctx, crate, ());
+    visit::walk_crate(&mut ctx, krate, ());
 
     match ctx.registrars.len() {
         0 => None,
         1 => {
             let (node_id, _) = ctx.registrars.pop().unwrap();
             Some(ast::DefId {
-                crate: ast::LOCAL_CRATE,
+                krate: ast::LOCAL_CRATE,
                 node: node_id
             })
         },

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -859,8 +859,8 @@ mod test {
 
     // this version doesn't care about getting comments or docstrings in.
     fn fake_print_crate(s: &mut pprust::State,
-                        crate: &ast::Crate) -> io::IoResult<()> {
-        pprust::print_mod(s, &crate.module, crate.attrs)
+                        krate: &ast::Crate) -> io::IoResult<()> {
+        pprust::print_mod(s, &krate.module, krate.attrs)
     }
 
     // change every identifier to "zz"

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -30,7 +30,6 @@ pub enum ObsoleteSyntax {
     ObsoleteSwap,
     ObsoleteUnsafeBlock,
     ObsoleteBareFnType,
-    ObsoleteNamedExternModule,
     ObsoleteMultipleLocalDecl,
     ObsoleteUnsafeExternFn,
     ObsoleteTraitFuncVisibility,
@@ -42,7 +41,6 @@ pub enum ObsoleteSyntax {
     ObsoleteBoxedClosure,
     ObsoleteClosureType,
     ObsoleteMultipleImport,
-    ObsoleteExternModAttributesInParens,
     ObsoleteManagedPattern,
     ObsoleteManagedString,
     ObsoleteManagedVec,
@@ -85,11 +83,6 @@ impl ParserObsoleteMethods for Parser {
             ObsoleteBareFnType => (
                 "bare function type",
                 "use `|A| -> B` or `extern fn(A) -> B` instead"
-            ),
-            ObsoleteNamedExternModule => (
-                "named external module",
-                "instead of `extern mod foo { ... }`, write `mod foo { \
-                 extern { ... } }`"
             ),
             ObsoleteMultipleLocalDecl => (
                 "declaration of multiple locals at once",
@@ -140,11 +133,6 @@ impl ParserObsoleteMethods for Parser {
             ObsoleteMultipleImport => (
                 "multiple imports",
                 "only one import is allowed per `use` statement"
-            ),
-            ObsoleteExternModAttributesInParens => (
-                "`extern mod` with linkage attribute list",
-                "use `extern mod foo = \"bar\";` instead of \
-                `extern mod foo (name = \"bar\")`"
             ),
             ObsoleteManagedPattern => (
                 "managed pointer pattern",

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -462,37 +462,38 @@ declare_special_idents_and_keywords! {
         (28,                         Loop,       "loop");
         (29,                         Match,      "match");
         (30,                         Mod,        "mod");
-        (31,                         Mut,        "mut");
-        (32,                         Once,       "once");
-        (33,                         Priv,       "priv");
-        (34,                         Pub,        "pub");
-        (35,                         Ref,        "ref");
-        (36,                         Return,     "return");
+        (31,                         Crate,      "crate");
+        (32,                         Mut,        "mut");
+        (33,                         Once,       "once");
+        (34,                         Priv,       "priv");
+        (35,                         Pub,        "pub");
+        (36,                         Ref,        "ref");
+        (37,                         Return,     "return");
         // Static and Self are also special idents (prefill de-dupes)
         (super::STATIC_KEYWORD_NAME, Static,     "static");
         (super::SELF_KEYWORD_NAME,   Self,       "self");
-        (37,                         Struct,     "struct");
-        (38,                         Super,      "super");
-        (39,                         True,       "true");
-        (40,                         Trait,      "trait");
-        (41,                         Type,       "type");
-        (42,                         Unsafe,     "unsafe");
-        (43,                         Use,        "use");
-        (44,                         While,      "while");
-        (45,                         Continue,   "continue");
-        (46,                         Proc,       "proc");
-        (47,                         Box,        "box");
+        (38,                         Struct,     "struct");
+        (39,                         Super,      "super");
+        (40,                         True,       "true");
+        (41,                         Trait,      "trait");
+        (42,                         Type,       "type");
+        (43,                         Unsafe,     "unsafe");
+        (44,                         Use,        "use");
+        (45,                         While,      "while");
+        (46,                         Continue,   "continue");
+        (47,                         Proc,       "proc");
+        (48,                         Box,        "box");
 
         'reserved:
-        (48,                         Alignof,    "alignof");
-        (49,                         Be,         "be");
-        (50,                         Offsetof,   "offsetof");
-        (51,                         Pure,       "pure");
-        (52,                         Sizeof,     "sizeof");
-        (53,                         Typeof,     "typeof");
-        (54,                         Unsized,    "unsized");
-        (55,                         Yield,      "yield");
-        (56,                         Do,         "do");
+        (49,                         Alignof,    "alignof");
+        (50,                         Be,         "be");
+        (51,                         Offsetof,   "offsetof");
+        (52,                         Pure,       "pure");
+        (53,                         Sizeof,     "sizeof");
+        (54,                         Typeof,     "typeof");
+        (55,                         Unsized,    "unsized");
+        (56,                         Yield,      "yield");
+        (57,                         Do,         "do");
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -116,7 +116,7 @@ pub static default_columns: uint = 78u;
 pub fn print_crate(cm: @CodeMap,
                    intr: @IdentInterner,
                    span_diagnostic: @diagnostic::SpanHandler,
-                   crate: &ast::Crate,
+                   krate: &ast::Crate,
                    filename: ~str,
                    input: &mut io::Reader,
                    out: ~io::Writer,
@@ -147,11 +147,11 @@ pub fn print_crate(cm: @CodeMap,
         boxes: RefCell::new(~[]),
         ann: ann
     };
-    print_crate_(&mut s, crate)
+    print_crate_(&mut s, krate)
 }
 
-pub fn print_crate_(s: &mut State, crate: &ast::Crate) -> io::IoResult<()> {
-    if_ok!(print_mod(s, &crate.module, crate.attrs));
+pub fn print_crate_(s: &mut State, krate: &ast::Crate) -> io::IoResult<()> {
+    if_ok!(print_mod(s, &krate.module, krate.attrs));
     if_ok!(print_remaining_comments(s));
     if_ok!(eof(&mut s.s));
     Ok(())

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -132,8 +132,8 @@ pub fn walk_inlined_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
 }
 
 
-pub fn walk_crate<E: Clone, V: Visitor<E>>(visitor: &mut V, crate: &Crate, env: E) {
-    visitor.visit_mod(&crate.module, crate.span, CRATE_NODE_ID, env)
+pub fn walk_crate<E: Clone, V: Visitor<E>>(visitor: &mut V, krate: &Crate, env: E) {
+    visitor.visit_mod(&krate.module, krate.span, CRATE_NODE_ID, env)
 }
 
 pub fn walk_mod<E: Clone, V: Visitor<E>>(visitor: &mut V, module: &Mod, env: E) {

--- a/src/test/compile-fail/extern-expected-fn-or-brace.rs
+++ b/src/test/compile-fail/extern-expected-fn-or-brace.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verifies that the expected token errors for `extern crate` are
+// raised
+
+extern "C" mod foo; //~ERROR expected `{` or `fn` but found `mod`

--- a/src/test/compile-fail/extern-foreign-crate.rs
+++ b/src/test/compile-fail/extern-foreign-crate.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verifies that the expected token errors for `extern crate` are
+// raised
+
+extern crate foo {} //~ERROR expected one of `=`, `;` but found `{`

--- a/src/test/compile-fail/obsolete-syntax.rs
+++ b/src/test/compile-fail/obsolete-syntax.rs
@@ -8,11 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern mod obsolete_name {
-    //~^ ERROR obsolete syntax: named external module
-    fn bar();
-}
-
 trait A {
     pub fn foo(); //~ ERROR: visibility not necessary
     pub fn bar(); //~ ERROR: visibility not necessary

--- a/src/test/run-pass/extern-foreign-crate.rs
+++ b/src/test/run-pass/extern-foreign-crate.rs
@@ -1,0 +1,14 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate extra;
+extern mod mystd = "std";
+
+pub fn main() {}


### PR DESCRIPTION
The first setp for #9880 is to add a new `crate` keyword. This PR does exactly that. I took a chance to refactor `parse_item_foreign_mod` and I broke it down into 2 separate methods to isolate each feature.

The next step will be to push a new stage0 snapshot and then get rid of all `extern mod` around the code.
