### PR TITLE
export std::comm::select! macro

### DIFF
--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -41,6 +41,7 @@
 //!     }
 //! )
 //! ```
+#[macro_escape];
 
 #[allow(dead_code)];
 
@@ -60,6 +61,7 @@ use sync::atomics::{Relaxed, SeqCst};
 use task;
 use uint;
 
+#[macro_export]
 macro_rules! select {
     (
         $name1:pat = $port1:ident.$meth1:ident() => $code1:expr,


### PR DESCRIPTION
This exports the select! macro so it can actually be used
