### PR TITLE
Remove reference to @str in comment

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1064,8 +1064,8 @@ pub struct ViewItem {
 #[deriving(Clone, Eq, Encodable, Decodable, IterBytes)]
 pub enum ViewItem_ {
     // ident: name used to refer to this crate in the code
-    // optional @str: if present, this is a location (containing
-    // arbitrary characters) from which to fetch the crate sources
+    // optional (InternedString,StrStyle): if present, this is a location
+    // (containing arbitrary characters) from which to fetch the crate sources
     // For example, extern mod whatever = "github.com/mozilla/rust"
     ViewItemExternMod(Ident, Option<(InternedString,StrStyle)>, NodeId),
     ViewItemUse(~[@ViewPath]),


### PR DESCRIPTION
This tiny pull request updates a comment referring to `@str` which was replaced by `(InternedString,StrStyle)` .

related to #10516
