### PR TITLE
Don't include rpath lines in dependency lists

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -281,8 +281,7 @@ endif
 
 # The rustdoc executable, rpath included in case --disable-rpath was provided to
 # ./configure
-RUSTDOC = $(RPATH_VAR2_T_$(CFG_BUILD)_H_$(CFG_BUILD)) \
-	  $(HBIN2_H_$(CFG_BUILD))/rustdoc$(X_$(CFG_BUILD))
+RUSTDOC = $(HBIN2_H_$(CFG_BUILD))/rustdoc$(X_$(CFG_BUILD))
 
 # The library documenting macro
 #
@@ -297,7 +296,9 @@ doc/$(1)/index.html:							    \
 	    $$(foreach dep,$$(RUST_DEPS_$(1)),				    \
 		$$(TLIB2_T_$(CFG_BUILD)_H_$(CFG_BUILD))/stamp.$$(dep))
 	@$$(call E, rustdoc: $$@)
-	$$(Q)$$(RUSTDOC) --cfg stage2 $$<
+	$$(Q)$$(RPATH_VAR2_T_$(CFG_BUILD)_H_$(CFG_BUILD)) $$(RUSTDOC) \
+	    --cfg stage2 $$<
+
 endef
 
 $(foreach crate,$(CRATES),$(eval $(call libdoc,$(crate))))


### PR DESCRIPTION
The rpath variable should only be used when executing commands, if it leaks into
a dependency list is causes havoc with the dependencies.
