### PR TITLE
Consolidate codegen-related compiler flags

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -141,7 +141,7 @@ endif
 # worry about the distribution of one file (with its native dynamic
 # dependencies)
 RUSTFLAGS_STAGE0 += -Z prefer-dynamic
-RUSTFLAGS_STAGE1 += -Z prefer-dynamic
+RUSTFLAGS_STAGE1 += -C prefer-dynamic
 
 # platform-specific auto-configuration
 include $(CFG_SRC_DIR)mk/platform.mk

--- a/man/rustc.1
+++ b/man/rustc.1
@@ -27,17 +27,14 @@ Display this message
 \fB\-L\fR PATH
 Add a directory to the library search path
 .TP
-\fB\-\-linker\fR LINKER
-Program to use for linking instead of the default
-.TP
-\fB\-\-link-args\fR FLAGS
-A space-separated list of flags passed to the linker
-.TP
 \fB\-\-ls\fR
 List the symbols defined by a library crate
 .TP
 \fB\-\-no\-trans\fR
 Run all passes except translation; no output
+.TP
+\fB\-g\fR, \fB\-\-debuginfo\fR
+Emit DWARF debug information into object files generated.
 .TP
 \fB\-O\fR
 Equivalent to \fI\-\-opt\-level=2\fR
@@ -47,11 +44,6 @@ Write output to <filename>. Ignored if more than one --emit is specified.
 .TP
 \fB\-\-opt\-level\fR LEVEL
 Optimize with possible levels 0-3
-.TP
-\fB\-\-passes\fR NAMES
-Comma- or space-separated list of optimization passes. Overrides
-the default passes for the optimization level. A value of 'list'
-will list the available passes.
 .TP
 \fB\-\-out\-dir\fR DIR
 Write output to compiler-chosen filename in <dir>. Ignored if -o is specified.
@@ -66,9 +58,6 @@ Pretty-print the input instead of compiling; valid types are: normal
 expanded, with type annotations), or identified (fully parenthesized,
 AST nodes and blocks with IDs)
 .TP
-\fB\-\-save\-temps\fR
-Write intermediate files (.bc, .opt.bc, .o) in addition to normal output
-.TP
 \fB\-\-sysroot\fR PATH
 Override the system root
 .TP
@@ -79,12 +68,6 @@ Build a test harness
 Target triple cpu-manufacturer-kernel[-os] to compile for (see
 http://sources.redhat.com/autobook/autobook/autobook_17.html
 for details)
-.TP
-\fB\-\-target-feature\fR TRIPLE
-Target-specific attributes (see llc -mattr=help for details)
-.TP
-\fB\-\-android-cross-path\fR PATH
-The path to the Android NDK
 .TP
 \fB\-W\fR help
 Print 'lint' options and default settings
@@ -104,8 +87,79 @@ Set lint forbidden
 \fB\-Z\fR FLAG
 Set internal debugging options. Use "-Z help" to print available options.
 .TP
+\fB\-C\fR FLAG[=VAL], \fB\-\-codegen\fR FLAG[=VAL]
+Set a codegen-related flag to the value specifie.d Use "-C help" to print
+available flags. See CODEGEN OPTIONS below
+.TP
 \fB\-v\fR, \fB\-\-version\fR
 Print version info and exit
+
+.SH CODEGEN OPTIONS
+
+.TP
+\fBar\fR=/path/to/ar
+Path to the archive utility to use when assembling archives.
+.TP
+\fBlinker\fR=/path/to/cc
+Path to the linker utility to use when linking libraries, executables, and
+objects.
+.TP
+\fBlink-args\fR='-flag1 -flag2'
+A space-separated list of extra arguments to pass to the linker when the linker
+is invoked.
+.TP
+\fBtarget-cpu\fR=help
+Selects a target processor. If the value is 'help', then a list of available
+cpus is printed.
+.TP
+\fBtarget-feature\fR='+feature1 -feature2'
+A space-separated list of features to enable or disable for the target. A
+preceding '+' enables a feature while a preceding '-' disables it. Available
+features can be discovered through target-cpu=help.
+.TP
+\fBpasses\fR=list
+A space-separated list of extra LLVM passes to run. A value of 'list' will
+cause rustc to print all known passes and exit. The passes specified are
+appended at the end of the normal pass manager.
+.TP
+\fBllvm-args\fR='-arg1 -arg2'
+A space-separted list of argument to pass through to LLVM.
+.TP
+\fBsave-temps\fR
+If specified, the compiler will save more files (.bc, .o, .no-opt.bc) generated
+throughout compilation in the output directory.
+.TP
+\fBandroid-cross-path\fR=path/to/ndk/bin
+Directory to find the Android NDK cross-compilation tools
+.TP
+\fBno-rpath\fR
+If specified, then the rpath value for dynamic libraries will not be set in
+either dynamic library or executable outputs.
+.TP
+\fBno-prepopulate-passes\fR
+Suppresses pre-population of the LLVM pass manager that is run over the module.
+.TP
+\fBno-vectorize-loops\fR
+Suppresses running the loop vectorization LLVM pass, regardless of optimization
+level.
+.TP
+\fBno-vectorize-slp\fR
+Suppresses running the LLVM SLP vectorization pass, regardless of optimization
+level.
+.TP
+\fBsoft-float\fR
+Generates software floating point library calls instead of hardware
+instructions.
+.TP
+\fBgen-crate-map\fR
+Forces generate of a toplevel crate map. May be required for logging to work
+when rust is embedded into another application.
+.TP
+\fBprefer-dynamic\fR
+Prefers dynamic linking to static linking.
+.TP
+\fBno-integrated-as\fR
+Force usage of an external assembler rather than LLVM's integrated one.
 
 .SH "EXAMPLES"
 To build an executable from a source file with a main function:
@@ -117,8 +171,8 @@ To build a library from a source file:
 To build either with a crate (.rs) file:
     $ rustc hello.rs
 
-To build an executable with debug info (experimental):
-    $ rustc -Z debug-info -o hello hello.rs
+To build an executable with debug info:
+    $ rustc -g -o hello hello.rs
 
 .SH "SEE ALSO"
 

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -300,8 +300,8 @@ CFG_PATH_MUNGE_arm-linux-androideabi := true
 CFG_LDPATH_arm-linux-androideabi :=
 CFG_RUN_arm-linux-androideabi=
 CFG_RUN_TARG_arm-linux-androideabi=
-RUSTC_FLAGS_arm-linux-androideabi :=--android-cross-path=$(CFG_ANDROID_CROSS_PATH)
-RUSTC_CROSS_FLAGS_arm-linux-androideabi :=--android-cross-path=$(CFG_ANDROID_CROSS_PATH)
+RUSTC_FLAGS_arm-linux-androideabi :=-C android-cross-path=$(CFG_ANDROID_CROSS_PATH)
+RUSTC_CROSS_FLAGS_arm-linux-androideabi :=-C android-cross-path=$(CFG_ANDROID_CROSS_PATH)
 
 # arm-unknown-linux-gnueabihf configuration
 CROSS_PREFIX_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -530,7 +530,7 @@ CTEST_RUSTC_FLAGS := $$(subst --cfg ndebug,,$$(CFG_RUSTC_FLAGS))
 
 # There's no need our entire test suite to take up gigabytes of space on disk
 # including copies of libstd/libextra all over the place
-CTEST_RUSTC_FLAGS := $$(CTEST_RUSTC_FLAGS) -Z prefer-dynamic
+CTEST_RUSTC_FLAGS := $$(CTEST_RUSTC_FLAGS) -C prefer-dynamic
 
 # The tests can not be optimized while the rest of the compiler is optimized, so
 # filter out the optimization (if any) from rustc and then figure out if we need

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -332,8 +332,8 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
             let args = split_maybe_args(&config.rustcflags);
             let mut tool_path:~str = ~"";
             for arg in args.iter() {
-                if arg.contains("--android-cross-path=") {
-                    tool_path = arg.replace("--android-cross-path=","");
+                if arg.contains("android-cross-path=") {
+                    tool_path = arg.replace("android-cross-path=","");
                     break;
                 }
             }
@@ -1054,7 +1054,7 @@ fn compile_test_and_save_bitcode(config: &config, props: &TestProps,
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
     let link_args = ~[~"-L", aux_dir.as_str().unwrap().to_owned()];
-    let llvm_args = ~[~"--emit=obj", ~"--crate-type=lib", ~"--save-temps"];
+    let llvm_args = ~[~"--emit=obj", ~"--crate-type=lib", ~"-C", ~"save-temps"];
     let args = make_compile_args(config, props,
                                  link_args + llvm_args,
                                  |a, b| ThisFile(make_o_name(a, b)), testfile);

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3761,7 +3761,7 @@ dependencies will be used:
    with the above limitations in dynamic and static libraries, it is required
    for all upstream dependencies to be in the same format. The next question is
    whether to prefer a dynamic or a static format. The compiler currently favors
-   static linking over dynamic linking, but this can be inverted with the `-Z
+   static linking over dynamic linking, but this can be inverted with the `-C
    prefer-dynamic` flag to the compiler.
 
    What this means is that first the compiler will attempt to find all upstream

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -19,7 +19,7 @@ use std::libc;
 
 pub fn run(sess: session::Session, llmod: ModuleRef,
            tm: TargetMachineRef, reachable: &[~str]) {
-    if sess.prefer_dynamic() {
+    if sess.opts.cg.prefer_dynamic {
         sess.err("cannot prefer dynamic linking when performing LTO");
         sess.note("only 'staticlib' and 'bin' outputs are supported with LTO");
         sess.abort_if_errors();

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1371,7 +1371,7 @@ fn insert_lllocals<'a>(bcx: &'a Block<'a>,
             llmap.get().insert(binding_info.id, datum);
         }
 
-        if bcx.sess().opts.extra_debuginfo {
+        if bcx.sess().opts.debuginfo {
             debuginfo::create_match_binding_metadata(bcx,
                                                      ident,
                                                      binding_info.id,
@@ -2030,7 +2030,7 @@ pub fn store_arg<'a>(mut bcx: &'a Block<'a>,
             // like `x: T`
             let arg_ty = node_id_type(bcx, pat.id);
             if type_of::arg_is_indirect(bcx.ccx(), arg_ty)
-                && !bcx.ccx().sess.opts.extra_debuginfo {
+                && !bcx.ccx().sess.opts.debuginfo {
                 // Don't copy an indirect argument to an alloca, the caller
                 // already put it in a temporary alloca and gave it up, unless
                 // we emit extra-debug-info, which requires local allocas :(.

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -568,7 +568,7 @@ pub fn get_res_dtor(ccx: @CrateContext,
 
 // Structural comparison: a rather involved form of glue.
 pub fn maybe_name_value(cx: &CrateContext, v: ValueRef, s: &str) {
-    if cx.sess.opts.save_temps {
+    if cx.sess.opts.cg.save_temps {
         s.with_c_str(|buf| {
             unsafe {
                 llvm::LLVMSetValueName(v, buf)
@@ -1389,7 +1389,7 @@ fn copy_args_to_allocas<'a>(fcx: &FunctionContext<'a>,
 
         bcx = _match::store_arg(bcx, args[i].pat, arg_datum, arg_scope_id);
 
-        if fcx.ccx.sess.opts.extra_debuginfo {
+        if fcx.ccx.sess.opts.debuginfo {
             debuginfo::create_argument_metadata(bcx, &args[i]);
         }
     }
@@ -2510,7 +2510,7 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     let mut n_subcrates = 1;
     let cstore = sess.cstore;
     while cstore.have_crate_data(n_subcrates) { n_subcrates += 1; }
-    let is_top = !sess.building_library.get() || sess.gen_crate_map();
+    let is_top = !sess.building_library.get() || sess.opts.cg.gen_crate_map;
     let sym_name = if is_top {
         ~"_rust_crate_map_toplevel"
     } else {

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -298,7 +298,7 @@ fn load_environment<'a>(bcx: &'a Block<'a>, cdata_ty: ty::t,
 
     // Store the pointer to closure data in an alloca for debug info because that's what the
     // llvm.dbg.declare intrinsic expects
-    let env_pointer_alloca = if bcx.ccx().sess.opts.extra_debuginfo {
+    let env_pointer_alloca = if bcx.ccx().sess.opts.debuginfo {
         let alloc = alloc_ty(bcx, ty::mk_mut_ptr(bcx.tcx(), cdata_ty), "__debuginfo_env_ptr");
         Store(bcx, llcdata, alloc);
         Some(alloc)

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -151,7 +151,7 @@ impl CrateContext {
             let tn = TypeNames::new();
 
             let mut intrinsics = base::declare_intrinsics(llmod);
-            if sess.opts.extra_debuginfo {
+            if sess.opts.debuginfo {
                 base::declare_dbg_intrinsics(llmod, &mut intrinsics);
             }
             let int_type = Type::int(targ_cfg.arch);

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -56,7 +56,7 @@ pub fn trans_stmt<'a>(cx: &'a Block<'a>,
             match d.node {
                 ast::DeclLocal(ref local) => {
                     bcx = init_local(bcx, *local);
-                    if cx.sess().opts.extra_debuginfo {
+                    if cx.sess().opts.debuginfo {
                         debuginfo::create_local_var_metadata(bcx, *local);
                     }
                 }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -707,7 +707,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
                               fn_decl: &ast::FnDecl,
                               param_substs: Option<@param_substs>,
                               error_span: Span) -> DIArray {
-        if !cx.sess.opts.extra_debuginfo {
+        if !cx.sess.opts.debuginfo {
             return create_DIArray(DIB(cx), []);
         }
 
@@ -784,8 +784,8 @@ pub fn create_function_debug_context(cx: &CrateContext,
                 name_to_append_suffix_to.push_str(",");
             }
 
-            // Only create type information if extra_debuginfo is enabled
-            if cx.sess.opts.extra_debuginfo {
+            // Only create type information if debuginfo is enabled
+            if cx.sess.opts.debuginfo {
                 let actual_self_type_metadata = type_metadata(cx,
                                                               actual_self_type,
                                                               codemap::DUMMY_SP);
@@ -829,8 +829,8 @@ pub fn create_function_debug_context(cx: &CrateContext,
                 name_to_append_suffix_to.push_str(",");
             }
 
-            // Again, only create type information if extra_debuginfo is enabled
-            if cx.sess.opts.extra_debuginfo {
+            // Again, only create type information if debuginfo is enabled
+            if cx.sess.opts.debuginfo {
                 let actual_type_metadata = type_metadata(cx, actual_type, codemap::DUMMY_SP);
                 let param_metadata_string = token::get_ident(ident.name);
                 let param_metadata = param_metadata_string.get()

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -105,8 +105,11 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>) {
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: @RefCell::new(libs),
         crate_types: ~[session::CrateTypeExecutable],
-        debugging_opts: session::PREFER_DYNAMIC,
         output_types: ~[link::OutputTypeExe],
+        cg: session::CodegenOptions {
+            prefer_dynamic: true,
+            .. session::basic_codegen_options()
+        },
         .. (*session::basic_options()).clone()
     };
 

--- a/src/test/compile-fail/issue-10755.rs
+++ b/src/test/compile-fail/issue-10755.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --linker=llllll
+// compile-flags: -C linker=llllll
 // error-pattern: the linker `llllll`
 
 fn main() {

--- a/src/test/compile-fail/issue-11154.rs
+++ b/src/test/compile-fail/issue-11154.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z lto -Z prefer-dynamic
+// compile-flags: -Z lto -C prefer-dynamic
 
 // error-pattern: cannot prefer dynamic linking
 

--- a/src/test/debug-info/basic-types-metadata.rs
+++ b/src/test/debug-info/basic-types-metadata.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/basic-types.rs
+++ b/src/test/debug-info/basic-types.rs
@@ -16,7 +16,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-basic.rs
+++ b/src/test/debug-info/borrowed-basic.rs
@@ -13,7 +13,7 @@
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-c-style-enum.rs
+++ b/src/test/debug-info/borrowed-c-style-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-enum.rs
+++ b/src/test/debug-info/borrowed-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-managed-basic.rs
+++ b/src/test/debug-info/borrowed-managed-basic.rs
@@ -15,7 +15,7 @@
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-struct.rs
+++ b/src/test/debug-info/borrowed-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-tuple.rs
+++ b/src/test/debug-info/borrowed-tuple.rs
@@ -12,7 +12,7 @@
 
 #[feature(managed_boxes)];
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/borrowed-unique-basic.rs
+++ b/src/test/debug-info/borrowed-unique-basic.rs
@@ -13,7 +13,7 @@
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/box.rs
+++ b/src/test/debug-info/box.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/boxed-struct.rs
+++ b/src/test/debug-info/boxed-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/boxed-vec.rs
+++ b/src/test/debug-info/boxed-vec.rs
@@ -12,7 +12,7 @@
 
 #[feature(managed_boxes)];
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/by-value-non-immediate-argument.rs
+++ b/src/test/debug-info/by-value-non-immediate-argument.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/by-value-self-argument-in-trait-impl.rs
+++ b/src/test/debug-info/by-value-self-argument-in-trait-impl.rs
@@ -12,7 +12,7 @@
 
 #[feature(managed_boxes)];
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/c-style-enum-in-composite.rs
+++ b/src/test/debug-info/c-style-enum-in-composite.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/c-style-enum.rs
+++ b/src/test/debug-info/c-style-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/closure-in-generic-function.rs
+++ b/src/test/debug-info/closure-in-generic-function.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/destructured-fn-argument.rs
+++ b/src/test/debug-info/destructured-fn-argument.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/destructured-local.rs
+++ b/src/test/debug-info/destructured-local.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/evec-in-struct.rs
+++ b/src/test/debug-info/evec-in-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/function-arg-initialization.rs
+++ b/src/test/debug-info/function-arg-initialization.rs
@@ -17,7 +17,7 @@
 // before the arguments have been properly loaded when setting the breakpoint via the function name.
 // Therefore the setup here sets them using line numbers (so be careful when changing this file).
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:break function-arg-initialization.rs:139
 // debugger:break function-arg-initialization.rs:154

--- a/src/test/debug-info/function-arguments.rs
+++ b/src/test/debug-info/function-arguments.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/function-prologue-stepping-no-split-stack.rs
+++ b/src/test/debug-info/function-prologue-stepping-no-split-stack.rs
@@ -16,7 +16,7 @@
 // consequence, and as opposed to regular Rust functions, we can set the breakpoints via the
 // function name (and don't have to fall back on using line numbers).
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak immediate_args
 // debugger:rbreak binding

--- a/src/test/debug-info/generic-function.rs
+++ b/src/test/debug-info/generic-function.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/generic-functions-nested.rs
+++ b/src/test/debug-info/generic-functions-nested.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/generic-method-on-generic-struct.rs
+++ b/src/test/debug-info/generic-method-on-generic-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/generic-static-method-on-struct-and-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/generic-struct-style-enum.rs
+++ b/src/test/debug-info/generic-struct-style-enum.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print union on
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/generic-struct.rs
+++ b/src/test/debug-info/generic-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/generic-trait-generic-static-default-method.rs
+++ b/src/test/debug-info/generic-trait-generic-static-default-method.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/generic-tuple-style-enum.rs
+++ b/src/test/debug-info/generic-tuple-style-enum.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print union on
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/include_string.rs
+++ b/src/test/debug-info/include_string.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/issue11600.rs
+++ b/src/test/debug-info/issue11600.rs
@@ -19,7 +19,7 @@ fn main() {
 // This test case checks whether compile unit names are set correctly, so that the correct default
 // source file can be found.
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:list
 // check:1[...]fn main() {
 // check:2[...]let args : ~[~str] = ::std::os::args();

--- a/src/test/debug-info/lexical-scope-in-for-loop.rs
+++ b/src/test/debug-info/lexical-scope-in-for-loop.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-if.rs
+++ b/src/test/debug-info/lexical-scope-in-if.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-match.rs
+++ b/src/test/debug-info/lexical-scope-in-match.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-parameterless-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-parameterless-closure.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z debug-info
+// compile-flags:-g
 // debugger:run
 
 // Nothing to do here really, just make sure it compiles. See issue #8513.

--- a/src/test/debug-info/lexical-scope-in-stack-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-stack-closure.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debug-info/lexical-scope-in-unconditional-loop.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-unique-closure.rs
+++ b/src/test/debug-info/lexical-scope-in-unique-closure.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-in-while.rs
+++ b/src/test/debug-info/lexical-scope-in-while.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scope-with-macro.rs
+++ b/src/test/debug-info/lexical-scope-with-macro.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/lexical-scopes-in-block-expression.rs
+++ b/src/test/debug-info/lexical-scopes-in-block-expression.rs
@@ -11,7 +11,7 @@
 // xfail-win32
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/managed-enum.rs
+++ b/src/test/debug-info/managed-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/managed-pointer-within-unique-vec.rs
+++ b/src/test/debug-info/managed-pointer-within-unique-vec.rs
@@ -12,7 +12,7 @@
 
 #[feature(managed_boxes)];
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/managed-pointer-within-unique.rs
+++ b/src/test/debug-info/managed-pointer-within-unique.rs
@@ -12,7 +12,7 @@
 
 #[feature(managed_boxes)];
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/method-on-enum.rs
+++ b/src/test/debug-info/method-on-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/method-on-generic-struct.rs
+++ b/src/test/debug-info/method-on-generic-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/method-on-struct.rs
+++ b/src/test/debug-info/method-on-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/method-on-trait.rs
+++ b/src/test/debug-info/method-on-trait.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/method-on-tuple-struct.rs
+++ b/src/test/debug-info/method-on-tuple-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/multiple-functions-equal-var-names.rs
+++ b/src/test/debug-info/multiple-functions-equal-var-names.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/multiple-functions.rs
+++ b/src/test/debug-info/multiple-functions.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debug-info/name-shadowing-and-scope-nesting.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/nil-enum.rs
+++ b/src/test/debug-info/nil-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/option-like-enum.rs
+++ b/src/test/debug-info/option-like-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/packed-struct-with-destructor.rs
+++ b/src/test/debug-info/packed-struct-with-destructor.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/packed-struct.rs
+++ b/src/test/debug-info/packed-struct.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/recursive-enum.rs
+++ b/src/test/debug-info/recursive-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:run
 
 // Test whether compiling a recursive enum definition crashes debug info generation. The test case

--- a/src/test/debug-info/recursive-struct.rs
+++ b/src/test/debug-info/recursive-struct.rs
@@ -12,7 +12,7 @@
 
 #[feature(managed_boxes)];
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/self-in-default-method.rs
+++ b/src/test/debug-info/self-in-default-method.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/self-in-generic-default-method.rs
+++ b/src/test/debug-info/self-in-generic-default-method.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/shadowed-argument.rs
+++ b/src/test/debug-info/shadowed-argument.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/shadowed-variable.rs
+++ b/src/test/debug-info/shadowed-variable.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/simple-lexical-scope.rs
+++ b/src/test/debug-info/simple-lexical-scope.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/simple-struct.rs
+++ b/src/test/debug-info/simple-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/simple-tuple.rs
+++ b/src/test/debug-info/simple-tuple.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/static-method-on-struct-and-enum.rs
+++ b/src/test/debug-info/static-method-on-struct-and-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/struct-in-enum.rs
+++ b/src/test/debug-info/struct-in-enum.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print union on
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/struct-in-struct.rs
+++ b/src/test/debug-info/struct-in-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/struct-style-enum.rs
+++ b/src/test/debug-info/struct-style-enum.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print union on
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/struct-with-destructor.rs
+++ b/src/test/debug-info/struct-with-destructor.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/trait-generic-static-default-method.rs
+++ b/src/test/debug-info/trait-generic-static-default-method.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 

--- a/src/test/debug-info/trait-pointers.rs
+++ b/src/test/debug-info/trait-pointers.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:run
 
 #[allow(unused_variable)];

--- a/src/test/debug-info/tuple-in-struct.rs
+++ b/src/test/debug-info/tuple-in-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/tuple-in-tuple.rs
+++ b/src/test/debug-info/tuple-in-tuple.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/tuple-struct.rs
+++ b/src/test/debug-info/tuple-struct.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/tuple-style-enum.rs
+++ b/src/test/debug-info/tuple-style-enum.rs
@@ -11,7 +11,7 @@
 // xfail-tidy-linelength
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print union on
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/unique-enum.rs
+++ b/src/test/debug-info/unique-enum.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/var-captured-in-nested-closure.rs
+++ b/src/test/debug-info/var-captured-in-nested-closure.rs
@@ -11,7 +11,7 @@
 // xfail-win32: FIXME #10474
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/var-captured-in-sendable-closure.rs
+++ b/src/test/debug-info/var-captured-in-sendable-closure.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/var-captured-in-stack-closure.rs
+++ b/src/test/debug-info/var-captured-in-stack-closure.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish

--- a/src/test/debug-info/vec-slices.rs
+++ b/src/test/debug-info/vec-slices.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/debug-info/vec.rs
+++ b/src/test/debug-info/vec.rs
@@ -10,7 +10,7 @@
 
 // xfail-android: FIXME(#10381)
 
-// compile-flags:-Z extra-debug-info
+// compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
 // debugger:run

--- a/src/test/run-make/bootstrap-from-c-with-green/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-green/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) lib.rs -Z gen-crate-map
+	$(RUSTC) lib.rs -C gen-crate-map
 	ln -nsf $(call DYLIB,boot-*) $(call DYLIB,boot)
 	$(CC) main.c -o $(call RUN,main) -lboot -Wl,-rpath,$(TMPDIR)
 	$(call RUN,main)

--- a/src/test/run-make/bootstrap-from-c-with-native/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-native/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) lib.rs -Z gen-crate-map
+	$(RUSTC) lib.rs -C gen-crate-map
 	ln -nsf $(call DYLIB,boot-*) $(call DYLIB,boot)
 	$(CC) main.c -o $(call RUN,main) -lboot -Wl,-rpath,$(TMPDIR)
 	$(call RUN,main)

--- a/src/test/run-make/c-link-to-rust-staticlib/Makefile
+++ b/src/test/run-make/c-link-to-rust-staticlib/Makefile
@@ -5,9 +5,9 @@ ifneq ($(shell uname),Darwin)
 endif
 
 all:
-	$(RUSTC) foo.rs -Z gen-crate-map
+	$(RUSTC) foo.rs -C gen-crate-map
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++ 
+	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++
 	$(call RUN,bar)
 	rm $(call STATICLIB,foo*)
 	$(call RUN,bar)

--- a/src/test/run-make/lto-smoke-c/Makefile
+++ b/src/test/run-make/lto-smoke-c/Makefile
@@ -5,7 +5,7 @@ ifneq ($(shell uname),Darwin)
 endif
 
 all:
-	$(RUSTC) foo.rs -Z gen-crate-map -Z lto
+	$(RUSTC) foo.rs -C gen-crate-map -Z lto
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
 	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++
 	$(call RUN,bar)

--- a/src/test/run-make/mixing-deps/Makefile
+++ b/src/test/run-make/mixing-deps/Makefile
@@ -2,6 +2,6 @@
 
 all:
 	$(RUSTC) both.rs
-	$(RUSTC) dylib.rs -Z prefer-dynamic
+	$(RUSTC) dylib.rs -C prefer-dynamic
 	$(RUSTC) prog.rs
 	$(call RUN,prog)

--- a/src/test/run-make/prefer-dylib/Makefile
+++ b/src/test/run-make/prefer-dylib/Makefile
@@ -2,7 +2,7 @@
 
 all:
 	$(RUSTC) bar.rs --crate-type=dylib --crate-type=rlib
-	$(RUSTC) foo.rs -Z prefer-dynamic
+	$(RUSTC) foo.rs -C prefer-dynamic
 	$(call RUN,foo)
 	rm $(TMPDIR)/*bar*
 	$(call FAILS,foo)

--- a/src/test/run-make/prune-link-args/Makefile
+++ b/src/test/run-make/prune-link-args/Makefile
@@ -1,6 +1,6 @@
 -include ../tools.mk
 # Notice the space in the end, this emulates the output of pkg-config
-RUSTC_FLAGS = --link-args "-lc "
+RUSTC_FLAGS = -C link-args="-lc "
 
 all:
 	$(RUSTC) $(RUSTC_FLAGS) empty.rs

--- a/src/test/run-pass/issue-7712.rs
+++ b/src/test/run-pass/issue-7712.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-Z debug-info
+// compile-flags:-g
 
 pub trait TraitWithDefaultMethod {
     fn method(self) {


### PR DESCRIPTION
Move them all behind a new -C switch. This migrates some -Z flags and some
top-level flags behind this -C codegen option.

The -C flag takes values of the form "-C name=value" where the "=value" is
optional for some flags.

Flags affected:
- --llvm-args           => -C llvm-args
- --passes              => -C passes
- --ar                  => -C ar
- --linker              => -C linker
- --link-args           => -C link-args
- --target-cpu          => -C target-cpu
- --target-feature      => -C target-fature
- --android-cross-path  => -C android-cross-path
- --save-temps          => -C save-temps
- --no-rpath            => -C no-rpath
- -Z no-prepopulate     => -C no-prepopulate-passes
- -Z no-vectorize-loops => -C no-vectorize-loops
- -Z no-vectorize-slp   => -C no-vectorize-slp
- -Z soft-float         => -C soft-float
- -Z gen-crate-map      => -C gen-crate-map
- -Z prefer-dynamic     => -C prefer-dynamic
- -Z no-integrated-as   => -C no-integrated-as

As a bonus, this also promotes the -Z extra-debug-info flag to a first class -g
or --debuginfo flag.
- -Z debug-info         => removed
- -Z extra-debug-info   => -g or --debuginfo

Closes #9770
Closes #12000
