### PR TITLE
Allow configuration of uid/gid/detach on processes

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -51,10 +51,7 @@ pub fn run(lib_path: &str,
     let env = env + target_env(lib_path, prog);
     let mut opt_process = run::Process::new(prog, args, run::ProcessOptions {
         env: Some(env),
-        dir: None,
-        in_fd: None,
-        out_fd: None,
-        err_fd: None
+        .. run::ProcessOptions::new()
     });
 
     match opt_process {
@@ -83,10 +80,7 @@ pub fn run_background(lib_path: &str,
     let env = env + target_env(lib_path, prog);
     let opt_process = run::Process::new(prog, args, run::ProcessOptions {
         env: Some(env),
-        dir: None,
-        in_fd: None,
-        out_fd: None,
-        err_fd: None
+        .. run::ProcessOptions::new()
     });
 
     match opt_process {

--- a/src/librustuv/process.rs
+++ b/src/librustuv/process.rs
@@ -58,6 +58,16 @@ impl Process {
 
         let ret = with_argv(config.program, config.args, |argv| {
             with_env(config.env, |envp| {
+                let mut flags = 0;
+                if config.uid.is_some() {
+                    flags |= uvll::PROCESS_SETUID;
+                }
+                if config.gid.is_some() {
+                    flags |= uvll::PROCESS_SETGID;
+                }
+                if config.detach {
+                    flags |= uvll::PROCESS_DETACHED;
+                }
                 let options = uvll::uv_process_options_t {
                     exit_cb: on_exit,
                     file: unsafe { *argv },
@@ -67,11 +77,11 @@ impl Process {
                         Some(ref cwd) => cwd.with_ref(|p| p),
                         None => ptr::null(),
                     },
-                    flags: 0,
+                    flags: flags as libc::c_uint,
                     stdio_count: stdio.len() as libc::c_int,
                     stdio: stdio.as_ptr(),
-                    uid: 0,
-                    gid: 0,
+                    uid: config.uid.unwrap_or(0) as uvll::uv_uid_t,
+                    gid: config.gid.unwrap_or(0) as uvll::uv_gid_t,
                 };
 
                 let handle = UvHandle::alloc(None::<Process>, uvll::UV_PROCESS);

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -159,7 +159,7 @@ pub use libc::funcs::c95::stdio::{fread, freopen, fseek, fsetpos, ftell};
 pub use libc::funcs::c95::stdio::{fwrite, perror, puts, remove, rewind};
 pub use libc::funcs::c95::stdio::{setbuf, setvbuf, tmpfile, ungetc};
 
-pub use libc::funcs::c95::stdlib::{abs, atof, atoi, calloc, exit};
+pub use libc::funcs::c95::stdlib::{abs, atof, atoi, calloc, exit, _exit};
 pub use libc::funcs::c95::stdlib::{free, getenv, labs, malloc, rand};
 pub use libc::funcs::c95::stdlib::{realloc, srand, strtod, strtol};
 pub use libc::funcs::c95::stdlib::{strtoul, system};
@@ -1769,6 +1769,9 @@ pub mod consts {
             pub static MAX_PROTOCOL_CHAIN: DWORD = 7;
             pub static WSAPROTOCOL_LEN: DWORD = 255;
             pub static INVALID_SOCKET: DWORD = !0;
+
+            pub static DETACHED_PROCESS: DWORD = 0x00000008;
+            pub static CREATE_NEW_PROCESS_GROUP: DWORD = 0x00000200;
         }
         pub mod sysconf {
         }
@@ -3340,6 +3343,7 @@ pub mod funcs {
                 pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
                 pub fn free(p: *mut c_void);
                 pub fn exit(status: c_int) -> !;
+                pub fn _exit(status: c_int) -> !;
                 // Omitted: atexit.
                 pub fn system(s: *c_char) -> c_int;
                 pub fn getenv(s: *c_char) -> *c_char;

--- a/src/libstd/run.rs
+++ b/src/libstd/run.rs
@@ -88,6 +88,20 @@ pub struct ProcessOptions<'a> {
      * and Process.error() will fail.
      */
     err_fd: Option<c_int>,
+
+    /// The uid to assume for the child process. For more information, see the
+    /// documentation in `io::process::ProcessConfig` about this field.
+    uid: Option<uint>,
+
+    /// The gid to assume for the child process. For more information, see the
+    /// documentation in `io::process::ProcessConfig` about this field.
+    gid: Option<uint>,
+
+    /// Flag as to whether the child process will be the leader of a new process
+    /// group or not. This allows the parent process to exit while the child is
+    /// still running. For more information, see the documentation in
+    /// `io::process::ProcessConfig` about this field.
+    detach: bool,
 }
 
 impl <'a> ProcessOptions<'a> {
@@ -99,6 +113,9 @@ impl <'a> ProcessOptions<'a> {
             in_fd: None,
             out_fd: None,
             err_fd: None,
+            uid: None,
+            gid: None,
+            detach: false,
         }
     }
 }
@@ -128,7 +145,9 @@ impl Process {
      */
     pub fn new(prog: &str, args: &[~str],
                options: ProcessOptions) -> io::IoResult<Process> {
-        let ProcessOptions { env, dir, in_fd, out_fd, err_fd } = options;
+        let ProcessOptions {
+            env, dir, in_fd, out_fd, err_fd, uid, gid, detach
+        } = options;
         let env = env.as_ref().map(|a| a.as_slice());
         let cwd = dir.as_ref().map(|a| a.as_str().unwrap());
         fn rtify(fd: Option<c_int>, input: bool) -> process::StdioContainer {
@@ -145,6 +164,9 @@ impl Process {
             env: env,
             cwd: cwd,
             io: rtio,
+            uid: uid,
+            gid: gid,
+            detach: detach,
         };
         process::Process::new(rtconfig).map(|p| Process { inner: p })
     }
@@ -302,11 +324,10 @@ impl Process {
  */
 pub fn process_status(prog: &str, args: &[~str]) -> io::IoResult<ProcessExit> {
     Process::new(prog, args, ProcessOptions {
-        env: None,
-        dir: None,
         in_fd: Some(unsafe { libc::dup(libc::STDIN_FILENO) }),
         out_fd: Some(unsafe { libc::dup(libc::STDOUT_FILENO) }),
-        err_fd: Some(unsafe { libc::dup(libc::STDERR_FILENO) })
+        err_fd: Some(unsafe { libc::dup(libc::STDERR_FILENO) }),
+        .. ProcessOptions::new()
     }).map(|mut p| p.finish())
 }
 
@@ -396,11 +417,10 @@ mod tests {
         let pipe_err = os::pipe();
 
         let mut process = run::Process::new("cat", [], run::ProcessOptions {
-            dir: None,
-            env: None,
             in_fd: Some(pipe_in.input),
             out_fd: Some(pipe_out.out),
-            err_fd: Some(pipe_err.out)
+            err_fd: Some(pipe_err.out),
+            .. run::ProcessOptions::new()
         }).unwrap();
 
         os::close(pipe_in.input as int);

--- a/src/rt/libuv-auto-clean-trigger
+++ b/src/rt/libuv-auto-clean-trigger
@@ -1,2 +1,2 @@
 # Change the contents of this file to force a full rebuild of libuv
-2013-12-23
+2014-02-16

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -33,7 +33,10 @@ pub fn main () {
         args : &[~"child"],
         env : None,
         cwd : None,
-        io : &[]
+        io : &[],
+        uid: None,
+        gid: None,
+        detach: false,
     };
 
     let mut p = process::Process::new(config).unwrap();

--- a/src/test/run-pass/process-detach.rs
+++ b/src/test/run-pass/process-detach.rs
@@ -1,0 +1,56 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-fast
+// ignore-win32
+// ignore-android
+
+// This test ensures that the 'detach' field on processes does the right thing.
+// By detaching the child process, they should be put into a separate process
+// group. We test this by spawning a detached process, then killing our own
+// group with a signal.
+//
+// Note that the first thing we do is put ourselves in our own process group so
+// we don't interfere with other running tests.
+
+use std::libc;
+use std::io::process;
+use std::io::signal::{Listener, Interrupt};
+
+fn main() {
+    unsafe { libc::setsid(); }
+
+    let config = process::ProcessConfig {
+        program : "/bin/sh",
+        args : &[~"-c", ~"read a"],
+        io : &[process::CreatePipe(true, false)],
+        detach: true,
+        .. process::ProcessConfig::new()
+    };
+
+    // we shouldn't die because of an interrupt
+    let mut l = Listener::new();
+    l.register(Interrupt).unwrap();
+
+    // spawn the child
+    let mut p = process::Process::new(config).unwrap();
+
+    // send an interrupt to everyone in our process group
+    unsafe { libc::funcs::posix88::signal::kill(0, libc::SIGINT); }
+
+    // Wait for the child process to die (terminate it's stdin and the read
+    // should fail).
+    drop(p.io[0].take());
+    match p.wait() {
+        process::ExitStatus(..) => {}
+        process::ExitSignal(..) => fail!()
+    }
+}
+


### PR DESCRIPTION
This just copies the libuv implementation for libnative which seems reasonable
enough (uid/gid fail on windows).

Closes #12082
