### PR TITLE
extra::test: define an opaque function to assist with accurate benchmarking.

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -536,18 +536,18 @@ mod test {
                 x: 1,
                 y: 2,
                 z: 3,
-            });
+            })
         })
     }
 
     #[bench]
     pub fn bench_pod_nonarena(bh: &mut BenchHarness) {
         bh.iter(|| {
-            let _ = ~Point {
+            ~Point {
                 x: 1,
                 y: 2,
                 z: 3,
-            };
+            }
         })
     }
 
@@ -561,7 +561,7 @@ mod test {
                     y: 2,
                     z: 3,
                 }
-            });
+            })
         })
     }
 
@@ -588,17 +588,17 @@ mod test {
             arena.alloc(Nonpod {
                 string: ~"hello world",
                 array: ~[ 1, 2, 3, 4, 5 ],
-            });
+            })
         })
     }
 
     #[bench]
     pub fn bench_nonpod_nonarena(bh: &mut BenchHarness) {
         bh.iter(|| {
-            let _ = ~Nonpod {
+            ~Nonpod {
                 string: ~"hello world",
                 array: ~[ 1, 2, 3, 4, 5 ],
-            };
+            }
         })
     }
 
@@ -606,10 +606,10 @@ mod test {
     pub fn bench_nonpod_old_arena(bh: &mut BenchHarness) {
         let arena = Arena::new();
         bh.iter(|| {
-            let _ = arena.alloc(|| Nonpod {
+            arena.alloc(|| Nonpod {
                 string: ~"hello world",
                 array: ~[ 1, 2, 3, 4, 5 ],
-            });
+            })
         })
     }
 }

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -29,7 +29,7 @@ Rust extras are part of the standard Rust distribution.
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
-#[feature(macro_rules, globs, managed_boxes)];
+#[feature(macro_rules, globs, managed_boxes, asm)];
 
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];


### PR DESCRIPTION
This allows a result to be marked as "used" by passing it to a function
LLVM cannot see inside (unless LTO is enabled).

Closes #8261.
