### PR TITLE
Fix infinite loop in MemReader::read_until.

### DIFF
--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -312,7 +312,11 @@ impl<'a> Seek for BufReader<'a> {
 
 impl<'a> Buffer for BufReader<'a> {
     fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> {
-        Ok(self.buf.slice_from(self.pos))
+        if self.pos < self.buf.len() {
+            Ok(self.buf.slice_from(self.pos))
+        } else {
+            Err(io::standard_error(io::EndOfFile))
+        }
     }
     fn consume(&mut self, amt: uint) { self.pos += amt; }
 }
@@ -448,6 +452,10 @@ mod test {
         assert_eq!(buf, [1, 2, 3, 4]);
         assert_eq!(reader.read(buf), Ok(3));
         assert_eq!(buf.slice(0, 3), [5, 6, 7]);
+        assert!(reader.read(buf).is_err());
+        let mut reader = BufReader::new(in_buf);
+        assert_eq!(reader.read_until(3).unwrap(), ~[0, 1, 2, 3]);
+        assert_eq!(reader.read_until(3).unwrap(), ~[4, 5, 6, 7]);
         assert!(reader.read(buf).is_err());
     }
 


### PR DESCRIPTION
I don't know if anything depends on MemReader::fill returning an empty slice instead of EndOfFile, but I'm pretty sure that MemReader::read_until should not go into an infinite loop.
