### PR TITLE
Update `make dist` components

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -27,18 +27,11 @@ PKG_FILES := \
     $(S)doc                                    \
     $(addprefix $(S)src/,                      \
       README.md                                \
-      driver                                   \
-      librustc                                 \
       compiletest                              \
+      driver                                   \
       etc                                      \
-      libextra                                 \
-      libstd                                   \
-      libsyntax                                \
-      librustuv				       \
-      libgreen 				       \
-      libnative 			       \
+      $(foreach crate,$(CRATES),lib$(crate))   \
       rt                                       \
-      librustdoc                               \
       rustllvm                                 \
       snapshots.txt                            \
       test)                                    \

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -26,7 +26,7 @@ PKG_FILES := \
     $(S)man                                    \
     $(S)doc                                    \
     $(addprefix $(S)src/,                      \
-      README.txt                               \
+      README.md                                \
       driver                                   \
       librustc                                 \
       compiletest                              \


### PR DESCRIPTION
`make dist` or building from a generated tarball is currently not possible due to some files that have been renamed and the ongoing libextra split. This PR fixes all (current) issues in order to build rust from the .tar.gz source alone.
