### PR TITLE
Surface some common intrinsics in std::mem

### DIFF
--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -178,7 +178,6 @@ use std::cast;
 use std::libc::{c_void, size_t, malloc, free};
 use std::mem;
 use std::ptr;
-use std::unstable::intrinsics;
 
 // Define a wrapper around the handle returned by the foreign code.
 // Unique<T> has the same semantics as ~T
@@ -200,7 +199,7 @@ impl<T: Send> Unique<T> {
             // `*ptr` is uninitialized, and `*ptr = value` would attempt to destroy it
             // move_val_init moves a value into this memory without
             // attempting to drop the original value.
-            intrinsics::move_val_init(&mut *ptr, value);
+            mem::move_val_init(&mut *ptr, value);
             Unique{ptr: ptr}
         }
     }

--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -176,6 +176,7 @@ and `free`:
 ~~~~
 use std::cast;
 use std::libc::{c_void, size_t, malloc, free};
+use std::mem;
 use std::ptr;
 use std::unstable::intrinsics;
 
@@ -226,7 +227,7 @@ impl<T: Send> Unique<T> {
 impl<T: Send> Drop for Unique<T> {
     fn drop(&mut self) {
         unsafe {
-            let x = intrinsics::uninit(); // dummy value to swap in
+            let x = mem::uninit(); // dummy value to swap in
             // We need to move the object out of the box, so that
             // the destructor is called (at the end of this scope.)
             ptr::replace_ptr(self.ptr, x);

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -32,10 +32,10 @@ use collections::list;
 use std::cast::{transmute, transmute_mut, transmute_mut_region};
 use std::cast;
 use std::cell::{Cell, RefCell};
+use std::mem;
 use std::num;
 use std::ptr;
 use std::kinds::marker;
-use std::mem;
 use std::rc::Rc;
 use std::rt::global_heap;
 use std::unstable::intrinsics::{TyDesc, get_tydesc};
@@ -216,7 +216,7 @@ impl Arena {
         unsafe {
             let ptr = self.alloc_pod_inner(mem::size_of::<T>(), mem::min_align_of::<T>());
             let ptr: *mut T = transmute(ptr);
-            intrinsics::move_val_init(&mut (*ptr), op());
+            mem::move_val_init(&mut (*ptr), op());
             return transmute(ptr);
         }
     }
@@ -278,7 +278,7 @@ impl Arena {
             // has *not* been initialized yet.
             *ty_ptr = transmute(tydesc);
             // Actually initialize it
-            intrinsics::move_val_init(&mut(*ptr), op());
+            mem::move_val_init(&mut(*ptr), op());
             // Now that we are done, update the tydesc to indicate that
             // the object is there.
             *ty_ptr = bitpack_tydesc_ptr(tydesc, true);
@@ -379,7 +379,7 @@ impl TypedArenaChunk {
         let mut chunk = unsafe {
             let chunk = global_heap::exchange_malloc(size);
             let mut chunk: ~TypedArenaChunk = cast::transmute(chunk);
-            intrinsics::move_val_init(&mut chunk.next, next);
+            mem::move_val_init(&mut chunk.next, next);
             chunk
         };
 
@@ -466,7 +466,7 @@ impl<T> TypedArena<T> {
             }
 
             let ptr: &'a mut T = cast::transmute(this.ptr);
-            intrinsics::move_val_init(ptr, object);
+            mem::move_val_init(ptr, object);
             this.ptr = this.ptr.offset(1);
             let ptr: &'a T = ptr;
             ptr

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -13,7 +13,7 @@
 #[allow(missing_doc)];
 
 use std::clone::Clone;
-use std::unstable::intrinsics::{move_val_init, init};
+use std::mem::{move_val_init, init};
 use std::util::{replace, swap};
 use std::vec;
 

--- a/src/libnative/io/file.rs
+++ b/src/libnative/io/file.rs
@@ -16,9 +16,9 @@ use std::io::IoError;
 use std::io;
 use std::libc::{c_int, c_void};
 use std::libc;
+use std::mem;
 use std::os;
 use std::rt::rtio;
-use std::unstable::intrinsics;
 use std::vec;
 
 use io::{IoResult, retry};
@@ -147,7 +147,7 @@ impl rtio::RtioFileStream for FileDesc {
         #[cfg(windows)]
         fn os_pread(fd: c_int, buf: *u8, amt: uint, offset: u64) -> IoResult<int> {
             unsafe {
-                let mut overlap: libc::OVERLAPPED = intrinsics::init();
+                let mut overlap: libc::OVERLAPPED = mem::init();
                 let handle = libc::get_osfhandle(fd) as libc::HANDLE;
                 let mut bytes_read = 0;
                 overlap.Offset = offset as libc::DWORD;
@@ -179,7 +179,7 @@ impl rtio::RtioFileStream for FileDesc {
         #[cfg(windows)]
         fn os_pwrite(fd: c_int, buf: *u8, amt: uint, offset: u64) -> IoResult<()> {
             unsafe {
-                let mut overlap: libc::OVERLAPPED = intrinsics::init();
+                let mut overlap: libc::OVERLAPPED = mem::init();
                 let handle = libc::get_osfhandle(fd) as libc::HANDLE;
                 overlap.Offset = offset as libc::DWORD;
                 overlap.OffsetHigh = (offset >> 32) as libc::DWORD;
@@ -867,7 +867,7 @@ pub fn stat(p: &CString) -> IoResult<io::FileStat> {
 
     #[cfg(windows)]
     fn os_stat(p: &CString) -> IoResult<io::FileStat> {
-        let mut stat: libc::stat = unsafe { intrinsics::uninit() };
+        let mut stat: libc::stat = unsafe { mem::uninit() };
         as_utf16_p(p.as_str().unwrap(), |up| {
             match retry(|| unsafe { libc::wstat(up, &mut stat) }) {
                 0 => Ok(mkstat(&stat, p)),
@@ -878,7 +878,7 @@ pub fn stat(p: &CString) -> IoResult<io::FileStat> {
 
     #[cfg(unix)]
     fn os_stat(p: &CString) -> IoResult<io::FileStat> {
-        let mut stat: libc::stat = unsafe { intrinsics::uninit() };
+        let mut stat: libc::stat = unsafe { mem::uninit() };
         match retry(|| unsafe { libc::stat(p.with_ref(|p| p), &mut stat) }) {
             0 => Ok(mkstat(&stat, p)),
             _ => Err(super::last_error()),
@@ -897,7 +897,7 @@ pub fn lstat(p: &CString) -> IoResult<io::FileStat> {
 
     #[cfg(unix)]
     fn os_lstat(p: &CString) -> IoResult<io::FileStat> {
-        let mut stat: libc::stat = unsafe { intrinsics::uninit() };
+        let mut stat: libc::stat = unsafe { mem::uninit() };
         match retry(|| unsafe { libc::lstat(p.with_ref(|p| p), &mut stat) }) {
             0 => Ok(mkstat(&stat, p)),
             _ => Err(super::last_error()),

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -68,7 +68,7 @@ fn ip_to_inaddr(ip: ip::IpAddr) -> InAddr {
 
 fn addr_to_sockaddr(addr: ip::SocketAddr) -> (libc::sockaddr_storage, uint) {
     unsafe {
-        let storage: libc::sockaddr_storage = intrinsics::init();
+        let storage: libc::sockaddr_storage = mem::init();
         let len = match ip_to_inaddr(addr.ip) {
             InAddr(inaddr) => {
                 let storage: *mut libc::sockaddr_in = cast::transmute(&storage);
@@ -138,7 +138,7 @@ fn sockname(fd: sock_t,
                                          *mut libc::socklen_t) -> libc::c_int)
     -> IoResult<ip::SocketAddr>
 {
-    let mut storage: libc::sockaddr_storage = unsafe { intrinsics::init() };
+    let mut storage: libc::sockaddr_storage = unsafe { mem::init() };
     let mut len = mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
     unsafe {
         let storage = &mut storage as *mut libc::sockaddr_storage;
@@ -225,7 +225,7 @@ pub fn init() {
 
         LOCK.lock();
         if !INITIALIZED {
-            let mut data: WSADATA = intrinsics::init();
+            let mut data: WSADATA = mem::init();
             let ret = WSAStartup(0x202,      // version 2.2
                                  &mut data);
             assert_eq!(ret, 0);
@@ -438,7 +438,7 @@ impl TcpAcceptor {
 
     pub fn native_accept(&mut self) -> IoResult<TcpStream> {
         unsafe {
-            let mut storage: libc::sockaddr_storage = intrinsics::init();
+            let mut storage: libc::sockaddr_storage = mem::init();
             let storagep = &mut storage as *mut libc::sockaddr_storage;
             let size = mem::size_of::<libc::sockaddr_storage>();
             let mut size = size as libc::socklen_t;
@@ -543,7 +543,7 @@ impl rtio::RtioSocket for UdpSocket {
 impl rtio::RtioUdpSocket for UdpSocket {
     fn recvfrom(&mut self, buf: &mut [u8]) -> IoResult<(uint, ip::SocketAddr)> {
         unsafe {
-            let mut storage: libc::sockaddr_storage = intrinsics::init();
+            let mut storage: libc::sockaddr_storage = mem::init();
             let storagep = &mut storage as *mut libc::sockaddr_storage;
             let mut addrlen: libc::socklen_t =
                     mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -15,7 +15,6 @@ use std::libc;
 use std::mem;
 use std::rt::rtio;
 use std::sync::arc::UnsafeArc;
-use std::unstable::intrinsics;
 
 use super::{IoResult, retry};
 use super::file::keep_going;
@@ -28,10 +27,10 @@ use super::file::keep_going;
 #[cfg(unix)]    pub type sock_t = super::file::fd_t;
 
 pub fn htons(u: u16) -> u16 {
-    intrinsics::to_be16(u as i16) as u16
+    mem::to_be16(u as i16) as u16
 }
 pub fn ntohs(u: u16) -> u16 {
-    intrinsics::from_be16(u as i16) as u16
+    mem::from_be16(u as i16) as u16
 }
 
 enum InAddr {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -49,11 +49,11 @@
 use std::comm::Data;
 use std::hashmap::HashMap;
 use std::libc;
+use std::mem;
 use std::os;
 use std::ptr;
 use std::rt::rtio;
 use std::sync::atomics;
-use std::unstable::intrinsics;
 
 use io::file::FileDesc;
 use io::IoResult;
@@ -87,17 +87,17 @@ pub enum Req {
 // returns the current time (in milliseconds)
 fn now() -> u64 {
     unsafe {
-        let mut now: libc::timeval = intrinsics::init();
+        let mut now: libc::timeval = mem::init();
         assert_eq!(imp::gettimeofday(&mut now, ptr::null()), 0);
         return (now.tv_sec as u64) * 1000 + (now.tv_usec as u64) / 1000;
     }
 }
 
 fn helper(input: libc::c_int, messages: Port<Req>) {
-    let mut set: imp::fd_set = unsafe { intrinsics::init() };
+    let mut set: imp::fd_set = unsafe { mem::init() };
 
     let mut fd = FileDesc::new(input, true);
-    let mut timeout: libc::timeval = unsafe { intrinsics::init() };
+    let mut timeout: libc::timeval = unsafe { mem::init() };
 
     // active timers are those which are able to be selected upon (and it's a
     // sorted list, and dead timers are those which have expired, but ownership

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -34,7 +34,7 @@ use std::ptr;
 use std::os;
 use std::rt::rtio;
 use std::hashmap::HashMap;
-use std::unstable::intrinsics;
+use std::mem;
 
 use io::file::FileDesc;
 use io::IoResult;
@@ -75,7 +75,7 @@ fn helper(input: libc::c_int, messages: Port<Req>) {
     }
 
     add(efd, input);
-    let events: [imp::epoll_event, ..16] = unsafe { intrinsics::init() };
+    let events: [imp::epoll_event, ..16] = unsafe { mem::init() };
     let mut map: HashMap<libc::c_int, (Chan<()>, bool)> = HashMap::new();
     'outer: loop {
         let n = match unsafe {

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -22,7 +22,7 @@ use extra::hex::ToHex;
 /// format.
 fn write_u32_be(dst: &mut[u8], input: u32) {
     use std::cast::transmute;
-    use std::unstable::intrinsics::to_be32;
+    use std::mem::to_be32;
     assert!(dst.len() == 4);
     unsafe {
         let x: *mut i32 = transmute(dst.unsafe_mut_ref(0));
@@ -33,7 +33,7 @@ fn write_u32_be(dst: &mut[u8], input: u32) {
 /// Read a vector of bytes into a vector of u32s. The values are read in big-endian format.
 fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
     use std::cast::transmute;
-    use std::unstable::intrinsics::to_be32;
+    use std::mem::to_be32;
     assert!(dst.len() * 4 == input.len());
     unsafe {
         let mut x: *mut i32 = transmute(dst.unsafe_mut_ref(0));

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -28,6 +28,7 @@ use std::cast;
 use std::fmt;
 use std::io;
 use std::libc;
+use std::mem;
 use std::str;
 use std::unstable::intrinsics;
 use std::vec;
@@ -144,7 +145,7 @@ pub fn render(w: &mut io::Writer, s: &str) -> fmt::Result {
             flags: 0,
             link_attributes: None,
         };
-        let mut callbacks: sd_callbacks = intrinsics::init();
+        let mut callbacks: sd_callbacks = mem::init();
 
         sdhtml_renderer(&callbacks, &options, 0);
         let opaque = my_opaque {
@@ -197,7 +198,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                          MKDEXT_STRIKETHROUGH;
         let callbacks = sd_callbacks {
             blockcode: block,
-            other: intrinsics::init()
+            other: mem::init()
         };
 
         let tests = tests as *mut ::test::Collector as *libc::c_void;

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -80,7 +80,7 @@ pub fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
 
 fn addr_to_sockaddr(addr: ip::SocketAddr) -> (libc::sockaddr_storage, uint) {
     unsafe {
-        let mut storage: libc::sockaddr_storage = intrinsics::init();
+        let mut storage: libc::sockaddr_storage = mem::init();
         let len = match addr.ip {
             ip::Ipv4Addr(a, b, c, d) => {
                 let storage: &mut libc::sockaddr_in =
@@ -134,7 +134,7 @@ fn socket_name(sk: SocketNameKind,
     };
 
     // Allocate a sockaddr_storage since we don't know if it's ipv4 or ipv6
-    let mut sockaddr: libc::sockaddr_storage = unsafe { intrinsics::init() };
+    let mut sockaddr: libc::sockaddr_storage = unsafe { mem::init() };
     let mut namelen = mem::size_of::<libc::sockaddr_storage>() as c_int;
 
     let sockaddr_p = &mut sockaddr as *mut libc::sockaddr_storage;

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -17,7 +17,6 @@ use std::mem;
 use std::ptr;
 use std::rt::rtio;
 use std::rt::task::BlockedTask;
-use std::unstable::intrinsics;
 
 use access::Access;
 use homing::{HomingIO, HomeHandle};
@@ -33,8 +32,8 @@ use uvll;
 /// Generic functions related to dealing with sockaddr things
 ////////////////////////////////////////////////////////////////////////////////
 
-pub fn htons(u: u16) -> u16 { intrinsics::to_be16(u as i16) as u16 }
-pub fn ntohs(u: u16) -> u16 { intrinsics::from_be16(u as i16) as u16 }
+pub fn htons(u: u16) -> u16 { mem::to_be16(u as i16) as u16 }
+pub fn ntohs(u: u16) -> u16 { mem::from_be16(u as i16) as u16 }
 
 pub fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
                         len: uint) -> ip::SocketAddr {

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -132,7 +132,7 @@ pub mod reader {
 
     pub fn vuint_at(data: &[u8], start: uint) -> Res {
         use std::ptr::offset;
-        use std::unstable::intrinsics::from_be32;
+        use std::mem::from_be32;
 
         if data.len() - start < 4 {
             return vuint_at_slow(data, start);

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -70,6 +70,7 @@ use kinds::marker;
 use ops::Drop;
 use cmp::Eq;
 use clone::Clone;
+use mem;
 use option::{Option, Some, None};
 use ptr::RawPtr;
 use ptr;
@@ -77,7 +78,6 @@ use str::StrSlice;
 use str;
 use vec::{ImmutableVector, MutableVector};
 use vec;
-use unstable::intrinsics;
 use rt::global_heap::malloc_raw;
 
 /// The representation of a C String.
@@ -327,7 +327,7 @@ impl<'a> ToCStr for &'a [u8] {
 // Unsafe function that handles possibly copying the &[u8] into a stack array.
 unsafe fn with_c_str<T>(v: &[u8], checked: bool, f: |*libc::c_char| -> T) -> T {
     if v.len() < BUF_LEN {
-        let mut buf: [u8, .. BUF_LEN] = intrinsics::uninit();
+        let mut buf: [u8, .. BUF_LEN] = mem::uninit();
         vec::bytes::copy_memory(buf, v);
         buf[v.len()] = 0;
 

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -18,7 +18,7 @@ use ptr::copy_nonoverlapping_memory;
 /// Casts the value at `src` to U. The two types must have the same length.
 #[inline]
 pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
-    let mut dest: U = intrinsics::uninit();
+    let mut dest: U = mem::uninit();
     let dest_ptr: *mut u8 = transmute(&mut dest);
     let src_ptr: *u8 = transmute(src);
     copy_nonoverlapping_memory(dest_ptr, src_ptr, mem::size_of::<U>());

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -51,7 +51,7 @@ impl<'r, R: Reader> Iterator<u8> for Bytes<'r, R> {
 }
 
 pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
-    use unstable::intrinsics::{to_le16, to_le32, to_le64};
+    use mem::{to_le16, to_le32, to_le64};
     use cast::transmute;
 
     // LLVM fails to properly optimize this when using shifts instead of the to_le* intrinsics
@@ -77,7 +77,7 @@ pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
 }
 
 pub fn u64_to_be_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
-    use unstable::intrinsics::{to_be16, to_be32, to_be64};
+    use mem::{to_be16, to_be32, to_be64};
     use cast::transmute;
 
     // LLVM fails to properly optimize this when using shifts instead of the to_be* intrinsics
@@ -105,7 +105,7 @@ pub fn u64_from_be_bytes(data: &[u8],
                          size: uint)
                       -> u64 {
     use ptr::{copy_nonoverlapping_memory, offset, mut_offset};
-    use unstable::intrinsics::from_be64;
+    use mem::from_be64;
     use vec::MutableVector;
 
     assert!(size <= 8u);

--- a/src/libstd/mem.rs
+++ b/src/libstd/mem.rs
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Functions relating to memory layout
+//! Basic functions for dealing with memory
+//!
+//! This module contains functions for querying the size and alignment of
+//! types, initializing and manipulating memory.
 
 #[allow(missing_doc)]; // FIXME
 

--- a/src/libstd/mem.rs
+++ b/src/libstd/mem.rs
@@ -68,6 +68,21 @@ pub fn pref_align_of_val<T>(_val: &T) -> uint {
     pref_align_of::<T>()
 }
 
+/// Create a value initialized to zero.
+///
+/// `init` is unsafe because it returns a zeroed-out datum,
+/// which is unsafe unless T is Pod.
+#[inline]
+pub unsafe fn init<T>() -> T {
+    intrinsics::init()
+}
+
+/// Create an uninitialized value.
+#[inline]
+pub unsafe fn uninit<T>() -> T {
+    intrinsics::uninit()
+}
+
 #[cfg(test)]
 mod tests {
     use mem::*;

--- a/src/libstd/mem.rs
+++ b/src/libstd/mem.rs
@@ -10,7 +10,10 @@
 
 //! Functions relating to memory layout
 
+#[allow(missing_doc)]; // FIXME
+
 use unstable::intrinsics;
+use unstable::intrinsics::{bswap16, bswap32, bswap64};
 
 /// Returns the size of a type
 #[inline]
@@ -90,6 +93,34 @@ pub unsafe fn uninit<T>() -> T {
 pub unsafe fn move_val_init<T>(dst: &mut T, src: T) {
     intrinsics::move_val_init(dst, src)
 }
+
+#[cfg(target_endian = "little")] #[inline] pub fn to_le16(x: i16) -> i16 { x }
+#[cfg(target_endian = "big")]    #[inline] pub fn to_le16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "little")] #[inline] pub fn to_le32(x: i32) -> i32 { x }
+#[cfg(target_endian = "big")]    #[inline] pub fn to_le32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "little")] #[inline] pub fn to_le64(x: i64) -> i64 { x }
+#[cfg(target_endian = "big")]    #[inline] pub fn to_le64(x: i64) -> i64 { unsafe { bswap64(x) } }
+
+#[cfg(target_endian = "little")] #[inline] pub fn to_be16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "big")]    #[inline] pub fn to_be16(x: i16) -> i16 { x }
+#[cfg(target_endian = "little")] #[inline] pub fn to_be32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "big")]    #[inline] pub fn to_be32(x: i32) -> i32 { x }
+#[cfg(target_endian = "little")] #[inline] pub fn to_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
+#[cfg(target_endian = "big")]    #[inline] pub fn to_be64(x: i64) -> i64 { x }
+
+#[cfg(target_endian = "little")] #[inline] pub fn from_le16(x: i16) -> i16 { x }
+#[cfg(target_endian = "big")]    #[inline] pub fn from_le16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "little")] #[inline] pub fn from_le32(x: i32) -> i32 { x }
+#[cfg(target_endian = "big")]    #[inline] pub fn from_le32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "little")] #[inline] pub fn from_le64(x: i64) -> i64 { x }
+#[cfg(target_endian = "big")]    #[inline] pub fn from_le64(x: i64) -> i64 { unsafe { bswap64(x) } }
+
+#[cfg(target_endian = "little")] #[inline] pub fn from_be16(x: i16) -> i16 { unsafe { bswap16(x) } }
+#[cfg(target_endian = "big")]    #[inline] pub fn from_be16(x: i16) -> i16 { x }
+#[cfg(target_endian = "little")] #[inline] pub fn from_be32(x: i32) -> i32 { unsafe { bswap32(x) } }
+#[cfg(target_endian = "big")]    #[inline] pub fn from_be32(x: i32) -> i32 { x }
+#[cfg(target_endian = "little")] #[inline] pub fn from_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
+#[cfg(target_endian = "big")]    #[inline] pub fn from_be64(x: i64) -> i64 { x }
 
 
 #[cfg(test)]

--- a/src/libstd/mem.rs
+++ b/src/libstd/mem.rs
@@ -83,6 +83,15 @@ pub unsafe fn uninit<T>() -> T {
     intrinsics::uninit()
 }
 
+/// Move a value to an uninitialized memory location.
+///
+/// Drop glue is not run on the destination.
+#[inline]
+pub unsafe fn move_val_init<T>(dst: &mut T, src: T) {
+    intrinsics::move_val_init(dst, src)
+}
+
+
 #[cfg(test)]
 mod tests {
     use mem::*;

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -15,6 +15,7 @@ use clone::Clone;
 #[cfg(not(test))]
 use cmp::Equiv;
 use iter::{range, Iterator};
+use mem;
 use option::{Option, Some, None};
 use unstable::intrinsics;
 use util::swap;
@@ -132,7 +133,7 @@ pub unsafe fn zero_memory<T>(dst: *mut T, count: uint) {
 #[inline]
 pub unsafe fn swap_ptr<T>(x: *mut T, y: *mut T) {
     // Give ourselves some scratch space to work with
-    let mut tmp: T = intrinsics::uninit();
+    let mut tmp: T = mem::uninit();
     let t: *mut T = &mut tmp;
 
     // Perform the swap
@@ -160,7 +161,7 @@ pub unsafe fn replace_ptr<T>(dest: *mut T, mut src: T) -> T {
  */
 #[inline(always)]
 pub unsafe fn read_ptr<T>(src: *T) -> T {
-    let mut tmp: T = intrinsics::uninit();
+    let mut tmp: T = mem::uninit();
     copy_nonoverlapping_memory(&mut tmp, src, 1);
     tmp
 }

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -205,17 +205,17 @@ mod imp {
     use cmp;
     use libc::consts::os::posix01::{PTHREAD_CREATE_JOINABLE, PTHREAD_STACK_MIN};
     use libc;
+    use mem;
     use os;
     use ptr;
-    use unstable::intrinsics;
     use unstable::stack::RED_ZONE;
 
     pub type rust_thread = libc::pthread_t;
     pub type rust_thread_return = *u8;
 
     pub unsafe fn create(stack: uint, p: ~proc()) -> rust_thread {
-        let mut native: libc::pthread_t = intrinsics::uninit();
-        let mut attr: libc::pthread_attr_t = intrinsics::uninit();
+        let mut native: libc::pthread_t = mem::uninit();
+        let mut attr: libc::pthread_attr_t = mem::uninit();
         assert_eq!(pthread_attr_init(&mut attr), 0);
         assert_eq!(pthread_attr_setdetachstate(&mut attr,
                                                PTHREAD_CREATE_JOINABLE), 0);

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -16,7 +16,7 @@ use iter::{Extendable, FromIterator, Iterator};
 use mem;
 use uint;
 use util::replace;
-use unstable::intrinsics::init;
+use mem::init;
 use vec;
 use ptr::RawPtr;
 use vec::{ImmutableVector, Items, MutableVector, MutItems, OwnedVector};

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -439,33 +439,6 @@ extern "rust-intrinsic" {
     pub fn u64_mul_with_overflow(x: u64, y: u64) -> (u64, bool);
 }
 
-#[cfg(target_endian = "little")] #[inline] pub fn to_le16(x: i16) -> i16 { x }
-#[cfg(target_endian = "big")]    #[inline] pub fn to_le16(x: i16) -> i16 { unsafe { bswap16(x) } }
-#[cfg(target_endian = "little")] #[inline] pub fn to_le32(x: i32) -> i32 { x }
-#[cfg(target_endian = "big")]    #[inline] pub fn to_le32(x: i32) -> i32 { unsafe { bswap32(x) } }
-#[cfg(target_endian = "little")] #[inline] pub fn to_le64(x: i64) -> i64 { x }
-#[cfg(target_endian = "big")]    #[inline] pub fn to_le64(x: i64) -> i64 { unsafe { bswap64(x) } }
-
-#[cfg(target_endian = "little")] #[inline] pub fn to_be16(x: i16) -> i16 { unsafe { bswap16(x) } }
-#[cfg(target_endian = "big")]    #[inline] pub fn to_be16(x: i16) -> i16 { x }
-#[cfg(target_endian = "little")] #[inline] pub fn to_be32(x: i32) -> i32 { unsafe { bswap32(x) } }
-#[cfg(target_endian = "big")]    #[inline] pub fn to_be32(x: i32) -> i32 { x }
-#[cfg(target_endian = "little")] #[inline] pub fn to_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
-#[cfg(target_endian = "big")]    #[inline] pub fn to_be64(x: i64) -> i64 { x }
-
-#[cfg(target_endian = "little")] #[inline] pub fn from_le16(x: i16) -> i16 { x }
-#[cfg(target_endian = "big")]    #[inline] pub fn from_le16(x: i16) -> i16 { unsafe { bswap16(x) } }
-#[cfg(target_endian = "little")] #[inline] pub fn from_le32(x: i32) -> i32 { x }
-#[cfg(target_endian = "big")]    #[inline] pub fn from_le32(x: i32) -> i32 { unsafe { bswap32(x) } }
-#[cfg(target_endian = "little")] #[inline] pub fn from_le64(x: i64) -> i64 { x }
-#[cfg(target_endian = "big")]    #[inline] pub fn from_le64(x: i64) -> i64 { unsafe { bswap64(x) } }
-
-#[cfg(target_endian = "little")] #[inline] pub fn from_be16(x: i16) -> i16 { unsafe { bswap16(x) } }
-#[cfg(target_endian = "big")]    #[inline] pub fn from_be16(x: i16) -> i16 { x }
-#[cfg(target_endian = "little")] #[inline] pub fn from_be32(x: i32) -> i32 { unsafe { bswap32(x) } }
-#[cfg(target_endian = "big")]    #[inline] pub fn from_be32(x: i32) -> i32 { x }
-#[cfg(target_endian = "little")] #[inline] pub fn from_be64(x: i64) -> i64 { unsafe { bswap64(x) } }
-#[cfg(target_endian = "big")]    #[inline] pub fn from_be64(x: i64) -> i64 { x }
 
 /// `TypeId` represents a globally unique identifier for a type
 #[lang="type_id"] // This needs to be kept in lockstep with the code in trans/intrinsic.rs and

--- a/src/libstd/unstable/intrinsics.rs
+++ b/src/libstd/unstable/intrinsics.rs
@@ -288,8 +288,7 @@ extern "rust-intrinsic" {
     /// Create a value initialized to zero.
     ///
     /// `init` is unsafe because it returns a zeroed-out datum,
-    /// which is unsafe unless T is POD. We don't have a POD
-    /// kind yet. (See #4074).
+    /// which is unsafe unless T is Pod.
     pub fn init<T>() -> T;
 
     /// Create an uninitialized value.

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -92,7 +92,7 @@ mod imp {
     use libc;
     use self::os::{PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER,
                    pthread_mutex_t, pthread_cond_t};
-    use unstable::intrinsics;
+    use mem;
 
     type pthread_mutexattr_t = libc::c_void;
     type pthread_condattr_t = libc::c_void;
@@ -208,8 +208,8 @@ mod imp {
     impl Mutex {
         pub unsafe fn new() -> Mutex {
             let mut m = Mutex {
-                lock: intrinsics::init(),
-                cond: intrinsics::init(),
+                lock: mem::init(),
+                cond: mem::init(),
             };
 
             pthread_mutex_init(&mut m.lock, 0 as *libc::c_void);

--- a/src/libstd/util.rs
+++ b/src/libstd/util.rs
@@ -11,8 +11,8 @@
 //! Miscellaneous helpers for common patterns
 
 use cast;
+use mem;
 use ptr;
-use unstable::intrinsics;
 
 /// The identity function.
 #[inline]
@@ -26,7 +26,7 @@ pub fn id<T>(x: T) -> T { x }
 pub fn swap<T>(x: &mut T, y: &mut T) {
     unsafe {
         // Give ourselves some scratch space to work with
-        let mut tmp: T = intrinsics::uninit();
+        let mut tmp: T = mem::uninit();
         let t: *mut T = &mut tmp;
 
         // Perform the swap, `&mut` pointers never alias

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -120,7 +120,6 @@ use mem::size_of;
 use kinds::marker;
 use uint;
 use unstable::finally::Finally;
-use unstable::intrinsics;
 use unstable::raw::{Repr, Slice, Vec};
 use util;
 
@@ -137,7 +136,7 @@ pub fn from_fn<T>(n_elts: uint, op: |uint| -> T) -> ~[T] {
         let mut i: uint = 0u;
         (|| {
             while i < n_elts {
-                intrinsics::move_val_init(&mut(*ptr::mut_offset(p, i as int)), op(i));
+                mem::move_val_init(&mut(*ptr::mut_offset(p, i as int)), op(i));
                 i += 1u;
             }
         }).finally(|| {
@@ -164,7 +163,7 @@ pub fn from_elem<T:Clone>(n_elts: uint, t: T) -> ~[T] {
         let mut i = 0u;
         (|| {
             while i < n_elts {
-                intrinsics::move_val_init(&mut(*ptr::mut_offset(p, i as int)), t.clone());
+                mem::move_val_init(&mut(*ptr::mut_offset(p, i as int)), t.clone());
                 i += 1u;
             }
         }).finally(|| {
@@ -1495,7 +1494,7 @@ impl<T> OwnedVector<T> for ~[T] {
             (**repr).fill += mem::nonzero_size_of::<T>();
             let p = to_unsafe_ptr(&((**repr).data));
             let p = ptr::offset(p, fill as int) as *mut T;
-            intrinsics::move_val_init(&mut(*p), t);
+            mem::move_val_init(&mut(*p), t);
         }
     }
 
@@ -1552,7 +1551,7 @@ impl<T> OwnedVector<T> for ~[T] {
             ptr::copy_memory(p.offset(1), p, len - i);
             // Write it in, overwriting the first copy of the `i`th
             // element.
-            intrinsics::move_val_init(&mut *p, x);
+            mem::move_val_init(&mut *p, x);
             self.set_len(len + 1);
         }
     }
@@ -2397,7 +2396,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     unsafe fn init_elem(self, i: uint, val: T) {
-        intrinsics::move_val_init(&mut (*self.as_mut_ptr().offset(i as int)), val);
+        mem::move_val_init(&mut (*self.as_mut_ptr().offset(i as int)), val);
     }
 
     #[inline]

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -17,14 +17,13 @@ use clone::Clone;
 use iter::{DoubleEndedIterator, Iterator};
 use num::CheckedMul;
 use container::Container;
-use mem::size_of;
+use mem::{size_of, move_val_init};
 use cast::{forget, transmute};
 use rt::global_heap::{malloc_raw, realloc_raw};
 use vec::{ImmutableVector, Items, MutableVector};
 use unstable::raw::Slice;
 use ptr::{offset, read_ptr};
 use libc::{free, c_void};
-use unstable::intrinsics::move_val_init;
 
 pub struct Vec<T> {
     priv len: uint,

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -203,7 +203,7 @@ impl Uuid {
     /// * `d3` A 16-bit word
     /// * `d4` Array of 8 octets
     pub fn from_fields(d1: u32, d2: u16, d3: u16, d4: &[u8]) -> Uuid {
-        use std::unstable::intrinsics::{to_be16, to_be32};
+        use std::mem::{to_be16, to_be32};
 
         // First construct a temporary field-based struct
         let mut fields = UuidFields {
@@ -329,7 +329,7 @@ impl Uuid {
     ///
     /// Example: `550e8400-e29b-41d4-a716-446655440000`
     pub fn to_hyphenated_str(&self) -> ~str {
-        use std::unstable::intrinsics::{to_be16, to_be32};
+        use std::mem::{to_be16, to_be32};
         // Convert to field-based struct as it matches groups in output.
         // Ensure fields are in network byte order, as per RFC.
         let mut uf: UuidFields;

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -16,8 +16,8 @@ use std::cast::transmute;
 use std::i32::range;
 use std::libc::{STDIN_FILENO, c_int, fdopen, fgets, fileno, fopen, fstat};
 use std::libc::{stat, strlen};
+use std::mem::init;
 use std::ptr::null;
-use std::unstable::intrinsics::init;
 use std::vec::{reverse};
 
 static LINE_LEN: uint = 80;

--- a/src/test/run-pass/issue-10714.rs
+++ b/src/test/run-pass/issue-10714.rs
@@ -10,5 +10,5 @@
 
 enum v {}
 pub fn main() {
-    let y: v = unsafe { ::std::unstable::intrinsics::uninit() };
+    let y: v = unsafe { ::std::mem::uninit() };
 }

--- a/src/test/run-pass/type-use-i1-versus-i8.rs
+++ b/src/test/run-pass/type-use-i1-versus-i8.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::unstable;
+use std::mem;
 
 pub fn main() {
     unsafe {
         let mut x: bool = false;
         // this line breaks it
-        unstable::intrinsics::move_val_init(&mut x, false);
+        mem::move_val_init(&mut x, false);
     }
 }

--- a/src/test/run-pass/uninit-empty-types.rs
+++ b/src/test/run-pass/uninit-empty-types.rs
@@ -11,14 +11,14 @@
 // Test the uninit() construct returning various empty types.
 
 use std::vec;
-use std::unstable::intrinsics;
+use std::mem;
 
 #[deriving(Clone)]
 struct Foo;
 
 pub fn main() {
     unsafe {
-        let _x: Foo = intrinsics::uninit();
-        let _x: [Foo, ..2] = intrinsics::uninit();
+        let _x: Foo = mem::uninit();
+        let _x: [Foo, ..2] = mem::uninit();
     }
 }


### PR DESCRIPTION
As mentioned https://github.com/mozilla/rust/pull/11956#issuecomment-34561655 I've taken some of the most commonly-used intrinsics and put them in a more logical place, reduced the amount of code looking in `unstable::intrinsics`.

r? @thestinger
