### PR TITLE
Implement List's any function

### DIFF
--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -63,6 +63,26 @@ pub fn find<T:Clone>(ls: @List<T>, f: |&T| -> bool) -> Option<T> {
     };
 }
 
+/**
+ * Returns true if a list contains an element that matches a given predicate
+ *
+ * Apply function `f` to each element of `ls`, starting from the first.
+ * When function `f` returns true then it also returns true. If `f` matches no
+ * elements then false is returned.
+ */
+pub fn any<T>(ls: @List<T>, f: |&T| -> bool) -> bool {
+    let mut ls = ls;
+    loop {
+        ls = match *ls {
+            Cons(ref hd, tl) => {
+                if f(hd) { return true; }
+                tl
+            }
+            Nil => return false
+        }
+    };
+}
+
 /// Returns true if a list contains an element with the given value
 pub fn has<T:Eq>(ls: @List<T>, elt: T) -> bool {
     let mut found = false;
@@ -220,6 +240,15 @@ mod tests {
         let empty = @list::Nil::<int>;
         assert_eq!(list::find(l, match_), option::None::<int>);
         assert_eq!(list::find(empty, match_), option::None::<int>);
+    }
+
+    #[test]
+    fn test_any() {
+        fn match_(i: &int) -> bool { return *i == 2; }
+        let l = from_vec([0, 1, 2]);
+        let empty = @list::Nil::<int>;
+        assert_eq!(list::any(l, match_), true);
+        assert_eq!(list::any(empty, match_), false);
     }
 
     #[test]


### PR DESCRIPTION
This is needed for cases where we only need to know if a list item matches the given predicate (eg. in Servo, we need to know if attributes from different DOM elements are equal).
