### PR TITLE
Make `if` and `while` conditions temporary

### DIFF
--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -501,12 +501,17 @@ fn resolve_expr(visitor: &mut RegionResolutionVisitor,
             visitor.region_maps.mark_as_terminating_scope(otherwise.id);
         }
 
-        ast::ExprIf(_, then, None) => {
+        ast::ExprIf(expr, then, None) => {
+            visitor.region_maps.mark_as_terminating_scope(expr.id);
             visitor.region_maps.mark_as_terminating_scope(then.id);
         }
 
-        ast::ExprLoop(body, _) |
-        ast::ExprWhile(_, body) => {
+        ast::ExprLoop(body, _) => {
+            visitor.region_maps.mark_as_terminating_scope(body.id);
+        }
+
+        ast::ExprWhile(expr, body) => {
+            visitor.region_maps.mark_as_terminating_scope(expr.id);
             visitor.region_maps.mark_as_terminating_scope(body.id);
         }
 

--- a/src/test/run-pass/temporary-lifetime-for-conditions.rs
+++ b/src/test/run-pass/temporary-lifetime-for-conditions.rs
@@ -1,0 +1,50 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+// This test verifies that temporaries created for `while`'s
+// and `if` conditions are correctly cleaned up.
+
+struct Temporary;
+
+static mut DROPPED: int = 0;
+
+impl Drop for Temporary {
+    fn drop(&mut self) {
+        unsafe { DROPPED += 1; }
+    }
+}
+
+impl Temporary {
+    fn do(&self) -> bool {true}
+}
+
+fn borrow() -> ~Temporary { ~Temporary }
+
+
+pub fn main() {
+    let mut i = 0;
+
+    // This loop's condition
+    // should call `Temporary`'s
+    // `drop` 6 times.
+    while borrow().do() {
+        i += 1;
+        if i > 5 {
+            break;
+        }
+    }
+
+    // This if condition should
+    // call it 1 time
+    if borrow().do() {
+        unsafe { assert_eq!(DROPPED, 7) }
+    }
+}


### PR DESCRIPTION
Closes #12033

IR Before:

``` llvm
normal-return:                                    ; preds = %while_body
  %113 = load i64* %i
  %114 = sub i64 %113, 1
  store i64 %114, i64* %i
  br label %while_cond
```

IR After:

``` llvm
normal-return:                                    ; preds = %while_cond
  store i8 %11, i8* %0
  %18 = load i8* %0, !range !0
  call void @_ZN9Temporary9glue_drop19he4ee51d3c03b9cf4ajE(%struct.Temporary* %10)
  %19 = bitcast %struct.Temporary* %10 to i8*
  call void @_ZN2rt11global_heap14exchange_free_19h4fabdf24a2250163aj4v0.0E(i8* %19)
  %20 = icmp ne i8 %18, 0
  br i1 %20, label %while_body, label %while_exit
```
