### PR TITLE
Update comment in contravariant test

### DIFF
--- a/src/test/compile-fail/regions-variance-contravariant-use-covariant.rs
+++ b/src/test/compile-fail/regions-variance-contravariant-use-covariant.rs
@@ -15,8 +15,8 @@
 // variance inference works in the first place.
 
 // This is contravariant with respect to 'a, meaning that
-// Contravariant<'foo> <: Contravariant<'static> because
-// 'foo <= 'static
+// Contravariant<'long> <: Contravariant<'short> iff
+// 'short <= 'long
 struct Contravariant<'a> {
     f: &'a int
 }


### PR DESCRIPTION
The current comment actually describes _co_-variance.
Fixing this to describe contravariance while keeping 'static in the definition was tricky so just changed to use 'short and 'long.

I found the typo in my attempt to understand the concept of variance itself and the comment confused me. I mention this to point out that I'm new to the concept so may have still got the definition wrong, so please review with care :)
