### PR TITLE
Add pointer to extended-help entry for `-C help` codegen options.

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -141,6 +141,7 @@ pub fn usage(argv0: &str) {
     let message = format!("Usage: {} [OPTIONS] INPUT", argv0);
     println!("{}\n\
 Additional help:
+    -C help             Print codegen options
     -W help             Print 'lint' options and default settings
     -Z help             Print internal options for debugging rustc\n",
               getopts::usage(message, d::optgroups()));


### PR DESCRIPTION
(The fact that this flag has a large collection of suboptions qualifies it for an entry in the "Additional help" section.)
