### PR TITLE
Factoring bigint, rational, and complex out of libextra into libnum.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -50,7 +50,7 @@
 ################################################################################
 
 TARGET_CRATES := std extra green rustuv native flate arena glob term semver \
-                 uuid serialize sync getopts collections
+                 uuid serialize sync getopts collections num
 HOST_CRATES := syntax rustc rustdoc fourcc
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustdoc rustc
@@ -75,6 +75,7 @@ DEPS_sync := std
 DEPS_getopts := std
 DEPS_collections := std serialize
 DEPS_fourcc := syntax std
+DEPS_num := std extra
 
 TOOL_DEPS_compiletest := extra green rustuv getopts
 TOOL_DEPS_rustdoc := rustdoc green rustuv

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -38,6 +38,7 @@ li {list-style-type: none; }
 * [The Rust compiler, `librustc`](rustc/index.html)
 
 * [The `arena` allocation library](arena/index.html)
+* [The `num` arbitrary precision numerics library](num/index.html)
 * [The `collections` library](collections/index.html)
 * [The `flate` compression library](flate/index.html)
 * [The `fourcc` four-character code library](fourcc/index.html)

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -3026,12 +3026,12 @@ In Rust terminology, we need a way to refer to other crates.
 For that, Rust offers you the `extern mod` declaration:
 
 ~~~
-extern mod extra;
-// extra ships with Rust, you'll find more details further down.
+extern mod num;
+// `num` ships with Rust (much like `extra`; more details further down).
 
 fn main() {
     // The rational number '1/2':
-    let one_half = ::extra::rational::Ratio::new(1, 2);
+    let one_half = ::num::rational::Ratio::new(1, 2);
 }
 ~~~
 
@@ -3056,10 +3056,10 @@ of both `use` and local declarations.
 Which can result in something like this:
 
 ~~~
-extern mod extra;
+extern mod num;
 
 use farm::dog;
-use extra::rational::Ratio;
+use num::rational::Ratio;
 
 mod farm {
     pub fn dog() { println!("woof"); }
@@ -3224,9 +3224,9 @@ See the [API documentation][stddoc] for details.
 
 ## The extra library
 
-Rust also ships with the [extra library], an accumulation of useful things,
+Rust ships with crates such as the [extra library], an accumulation of useful things,
 that are however not important enough to deserve a place in the standard
-library.  You can use them by linking to `extra` with an `extern mod extra;`.
+library.  You can link to a library such as `extra` with an `extern mod extra;`.
 
 [extra library]: extra/index.html
 

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -62,12 +62,6 @@ pub mod time;
 pub mod base64;
 pub mod workcache;
 pub mod enum_set;
-#[path="num/bigint.rs"]
-pub mod bigint;
-#[path="num/rational.rs"]
-pub mod rational;
-#[path="num/complex.rs"]
-pub mod complex;
 pub mod stats;
 pub mod hex;
 

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -16,9 +16,6 @@ A `BigUint` is represented as an array of `BigDigit`s.
 A `BigInt` is a combination of `BigUint` and `Sign`.
 */
 
-#[allow(missing_doc)];
-#[allow(non_uppercase_statics)];
-
 use std::cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater};
 use std::num;
 use std::num::{Zero, One, ToStrRadix, FromStrRadix, Orderable};
@@ -48,7 +45,7 @@ pub type BigDigit = u32;
 pub static ZERO_BIG_DIGIT: BigDigit = 0;
 
 pub mod BigDigit {
-    use bigint::BigDigit;
+    use super::BigDigit;
 
     #[cfg(target_word_size = "32")]
     pub static bits: uint = 16;
@@ -1433,8 +1430,8 @@ impl BigInt {
 
 #[cfg(test)]
 mod biguint_tests {
-    use super::*;
-    use super::RandBigInt;
+    use super::{BigDigit, BigUint, ToBigUint};
+    use super::{Plus, BigInt, RandBigInt, ToBigInt};
 
     use std::cmp::{Less, Equal, Greater};
     use std::i64;
@@ -2090,8 +2087,8 @@ mod biguint_tests {
 
 #[cfg(test)]
 mod bigint_tests {
-    use super::*;
-    use super::RandBigInt;
+    use super::{BigDigit, BigUint, ToBigUint};
+    use super::{Sign, Minus, Zero, Plus, BigInt, RandBigInt, ToBigInt};
 
     use std::cmp::{Less, Equal, Greater};
     use std::i64;
@@ -2591,7 +2588,7 @@ mod bigint_tests {
 
 #[cfg(test)]
 mod bench {
-    use super::*;
+    use super::{BigInt, BigUint};
     use std::iter;
     use std::mem::replace;
     use std::num::{FromPrimitive, Zero, One};

--- a/src/libnum/complex.rs
+++ b/src/libnum/complex.rs
@@ -191,7 +191,7 @@ impl<T: ToStrRadix + Num + Ord> ToStrRadix for Cmplx<T> {
 mod test {
     #[allow(non_uppercase_statics)];
 
-    use super::*;
+    use super::{Complex64, Cmplx};
     use std::num::{Zero,One,Real};
 
     pub static _0_0i : Complex64 = Cmplx { re: 0.0, im: 0.0 };
@@ -285,7 +285,7 @@ mod test {
     }
 
     mod arith {
-        use super::*;
+        use super::{_0_0i, _1_0i, _1_1i, _0_1i, _neg1_1i, _05_05i, all_consts};
         use std::num::Zero;
 
         #[test]

--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(macro_rules)];
+
+#[crate_id = "num#0.10-pre"];
+#[crate_type = "rlib"];
+#[crate_type = "dylib"];
+#[license = "MIT/ASL2"];
+
+extern mod extra;
+
+pub mod bigint;
+pub mod rational;
+pub mod complex;

--- a/src/libnum/rational.rs
+++ b/src/libnum/rational.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,11 +10,10 @@
 
 //! Rational numbers
 
-
 use std::cmp;
 use std::from_str::FromStr;
 use std::num::{Zero,One,ToStrRadix,FromStrRadix,Round};
-use super::bigint::{BigInt, BigUint, Sign, Plus, Minus};
+use bigint::{BigInt, BigUint, Sign, Plus, Minus};
 
 /// Represents the ratio between 2 numbers.
 #[deriving(Clone)]
@@ -349,7 +348,7 @@ impl<T: FromStrRadix + Clone + Integer + Ord>
 #[cfg(test)]
 mod test {
 
-    use super::*;
+    use super::{Ratio, Rational, BigRational};
     use std::num::{Zero,One,FromStrRadix,FromPrimitive};
     use std::from_str::FromStr;
 
@@ -449,8 +448,8 @@ mod test {
 
 
     mod arith {
-        use super::*;
-        use super::super::*;
+        use super::{_0, _1, _2, _1_2, _3_2, _neg1_2, to_big};
+        use super::super::{Ratio, Rational, BigRational};
 
 
         #[test]

--- a/src/test/bench/shootout-pidigits.rs
+++ b/src/test/bench/shootout-pidigits.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern mod extra;
+extern mod num;
 
 use std::from_str::FromStr;
 use std::num::One;
 use std::num::Zero;
 use std::num::FromPrimitive;
-use extra::bigint::BigInt;
+use num::bigint::BigInt;
 
 struct Context {
     numer: BigInt,


### PR DESCRIPTION
Removed use of globs present in earlier versions of modules.

Fix tutorial.md to reflect `extra::rational` ==> `num::rational`.
