### PR TITLE
Added link to fourcc docs

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -40,6 +40,7 @@ li {list-style-type: none; }
 * [The `arena` allocation library](arena/index.html)
 * [The `collections` library](collections/index.html)
 * [The `flate` compression library](flate/index.html)
+* [The `fourcc` four-character code library](fourcc/index.html)
 * [The `getopts` argument parsing library](getopts/index.html)
 * [The `glob` file path matching library](glob/index.html)
 * [The `semver` version collation library](semver/index.html)


### PR DESCRIPTION
Added a link to `fourcc` docs to the list of libraries
