### PR TITLE
Move fourcc to HOST_CRATES

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -50,8 +50,8 @@
 ################################################################################
 
 TARGET_CRATES := std extra green rustuv native flate arena glob term semver \
-                 uuid serialize sync getopts collections fourcc
-HOST_CRATES := syntax rustc rustdoc
+                 uuid serialize sync getopts collections
+HOST_CRATES := syntax rustc rustdoc fourcc
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustdoc rustc
 


### PR DESCRIPTION
It depends on libsyntax, which is a host crate, so it can't be in the target
crates section.
