### PR TITLE
Improve handling of simultaneous rlibs and dylibs

### DIFF
--- a/src/test/auxiliary/issue-11908-1.rs
+++ b/src/test/auxiliary/issue-11908-1.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#[crate_id = "collections#0.10-pre"];
+#[crate_type = "dylib"];

--- a/src/test/auxiliary/issue-11908-2.rs
+++ b/src/test/auxiliary/issue-11908-2.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#[crate_id = "collections#0.10-pre"];
+#[crate_type = "rlib"];

--- a/src/test/compile-fail/issue-11908-1.rs
+++ b/src/test/compile-fail/issue-11908-1.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-11908-1.rs
+// ignore-android this test is incompatible with the android test runner
+// error-pattern: multiple dylib candidates for `collections` found
+
+// This test ensures that if you have the same rlib or dylib at two locations
+// in the same path that you don't hit an assertion in the compiler.
+//
+// Note that this relies on `libcollections` to be in the path somewhere else,
+// and then our aux-built libraries will collide with libcollections (they have
+// the same version listed)
+
+extern crate collections;
+
+fn main() {}

--- a/src/test/compile-fail/issue-11908-2.rs
+++ b/src/test/compile-fail/issue-11908-2.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-11908-2.rs
+// no-prefer-dynamic
+// ignore-android this test is incompatible with the android test runner
+// error-pattern: multiple rlib candidates for `collections` found
+
+// see comments in issue-11908-1 for what's going on here
+
+extern crate collections;
+
+fn main() {}
+


### PR DESCRIPTION
The first commit improves error messages during linking, and the second commit improves error messages during crate-loading time.

Closes #12297
Closes #12377
