### PR TITLE
Remove duplicate function in std::ptr with std::ptr::RawPtr

### DIFF
--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -195,7 +195,7 @@ impl<T: Send> Unique<T> {
     pub fn new(value: T) -> Unique<T> {
         unsafe {
             let ptr = malloc(std::mem::size_of::<T>() as size_t) as *mut T;
-            assert!(!ptr::is_null(ptr));
+            assert!(!ptr.is_null());
             // `*ptr` is uninitialized, and `*ptr = value` would attempt to destroy it
             // move_val_init moves a value into this memory without
             // attempting to drop the original value.

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -34,7 +34,6 @@ use std::cast;
 use std::cell::{Cell, RefCell};
 use std::mem;
 use std::num;
-use std::ptr;
 use std::kinds::marker;
 use std::rc::Rc;
 use std::rt::global_heap;
@@ -144,7 +143,7 @@ unsafe fn destroy_chunk(chunk: &Chunk) {
     let fill = chunk.fill.get();
 
     while idx < fill {
-        let tydesc_data: *uint = transmute(ptr::offset(buf, idx as int));
+        let tydesc_data: *uint = transmute(buf.offset(idx as int));
         let (tydesc, is_done) = un_bitpack_tydesc_ptr(*tydesc_data);
         let (size, align) = ((*tydesc).size, (*tydesc).align);
 
@@ -155,7 +154,7 @@ unsafe fn destroy_chunk(chunk: &Chunk) {
         //debug!("freeing object: idx = {}, size = {}, align = {}, done = {}",
         //       start, size, align, is_done);
         if is_done {
-            ((*tydesc).drop_glue)(ptr::offset(buf, start as int) as *i8);
+            ((*tydesc).drop_glue)(buf.offset(start as int) as *i8);
         }
 
         // Find where the next tydesc lives
@@ -261,7 +260,7 @@ impl Arena {
             //       start, n_bytes, align, head.fill);
 
             let buf = self.head.as_ptr();
-            return (ptr::offset(buf, tydesc_start as int), ptr::offset(buf, start as int));
+            return (buf.offset(tydesc_start as int), buf.offset(start as int));
         }
     }
 

--- a/src/libextra/c_vec.rs
+++ b/src/libextra/c_vec.rs
@@ -119,7 +119,7 @@ impl <T> CVec<T> {
     pub fn get<'a>(&'a self, ofs: uint) -> &'a T {
         assert!(ofs < self.len);
         unsafe {
-            &*ptr::mut_offset(self.base, ofs as int)
+            &*self.base.offset(ofs as int)
         }
     }
 
@@ -131,7 +131,7 @@ impl <T> CVec<T> {
     pub fn get_mut<'a>(&'a mut self, ofs: uint) -> &'a mut T {
         assert!(ofs < self.len);
         unsafe {
-            &mut *ptr::mut_offset(self.base, ofs as int)
+            &mut *self.base.offset(ofs as int)
         }
     }
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -30,7 +30,6 @@ use std::io;
 use std::num;
 use std::option;
 use std::os::consts::{macos, freebsd, linux, android, win32};
-use std::ptr;
 use std::str;
 use std::vec;
 use flate;
@@ -340,7 +339,7 @@ fn get_metadata_section_imp(os: Os, filename: &Path) -> Option<MetadataBlob> {
                 });
                 if !version_ok { return None; }
 
-                let cvbuf1 = ptr::offset(cvbuf, vlen as int);
+                let cvbuf1 = cvbuf.offset(vlen as int);
                 debug!("inflating {} bytes of compressed metadata",
                        csz - vlen);
                 vec::raw::buf_as_slice(cvbuf1, csz-vlen, |bytes| {

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -21,7 +21,6 @@ use std::cast;
 use std::hashmap::HashMap;
 use std::libc::{c_uint, c_ulonglong, c_char};
 use syntax::codemap::Span;
-use std::ptr::is_not_null;
 
 pub struct Builder<'a> {
     llbuilder: BuilderRef,
@@ -492,7 +491,7 @@ impl<'a> Builder<'a> {
         debug!("Store {} -> {}",
                self.ccx.tn.val_to_str(val),
                self.ccx.tn.val_to_str(ptr));
-        assert!(is_not_null(self.llbuilder));
+        assert!(self.llbuilder.is_not_null());
         self.count_insn("store");
         unsafe {
             llvm::LLVMBuildStore(self.llbuilder, val, ptr);
@@ -503,7 +502,7 @@ impl<'a> Builder<'a> {
         debug!("Store {} -> {}",
                self.ccx.tn.val_to_str(val),
                self.ccx.tn.val_to_str(ptr));
-        assert!(is_not_null(self.llbuilder));
+        assert!(self.llbuilder.is_not_null());
         self.count_insn("store.volatile");
         unsafe {
             let insn = llvm::LLVMBuildStore(self.llbuilder, val, ptr);

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -426,7 +426,7 @@ mod test {
         unsafe {
             let base = transmute::<*u8, *mut u8>(buf.base);
             (*base) = 1;
-            (*ptr::mut_offset(base, 1)) = 2;
+            (*base.offset(1)) = 2;
         }
 
         assert!(slice[0] == 1);

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -131,7 +131,6 @@ pub mod reader {
     }
 
     pub fn vuint_at(data: &[u8], start: uint) -> Res {
-        use std::ptr::offset;
         use std::mem::from_be32;
 
         if data.len() - start < 4 {
@@ -163,7 +162,7 @@ pub mod reader {
 
         unsafe {
             let (ptr, _): (*u8, uint) = transmute(data);
-            let ptr = offset(ptr, start as int);
+            let ptr = ptr.offset(start as int);
             let ptr: *i32 = transmute(ptr);
             let val = from_be32(*ptr) as u32;
 

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -310,7 +310,7 @@ impl<'a> ToCStr for &'a [u8] {
         let buf = malloc_raw(self_len + 1);
 
         ptr::copy_memory(buf, self.as_ptr(), self_len);
-        *ptr::mut_offset(buf, self_len as int) = 0;
+        *buf.offset(self_len as int) = 0;
 
         CString::new(buf as *libc::c_char, true)
     }
@@ -368,7 +368,7 @@ impl<'a> Iterator<libc::c_char> for CChars<'a> {
         if ch == 0 {
             None
         } else {
-            self.ptr = unsafe { ptr::offset(self.ptr, 1) };
+            self.ptr = unsafe { self.ptr.offset(1) };
             Some(ch)
         }
     }
@@ -429,18 +429,18 @@ mod tests {
     fn test_str_to_c_str() {
         "".to_c_str().with_ref(|buf| {
             unsafe {
-                assert_eq!(*ptr::offset(buf, 0), 0);
+                assert_eq!(*buf.offset(0), 0);
             }
         });
 
         "hello".to_c_str().with_ref(|buf| {
             unsafe {
-                assert_eq!(*ptr::offset(buf, 0), 'h' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 1), 'e' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 2), 'l' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 3), 'l' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 4), 'o' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 5), 0);
+                assert_eq!(*buf.offset(0), 'h' as libc::c_char);
+                assert_eq!(*buf.offset(1), 'e' as libc::c_char);
+                assert_eq!(*buf.offset(2), 'l' as libc::c_char);
+                assert_eq!(*buf.offset(3), 'l' as libc::c_char);
+                assert_eq!(*buf.offset(4), 'o' as libc::c_char);
+                assert_eq!(*buf.offset(5), 0);
             }
         })
     }
@@ -450,28 +450,28 @@ mod tests {
         let b: &[u8] = [];
         b.to_c_str().with_ref(|buf| {
             unsafe {
-                assert_eq!(*ptr::offset(buf, 0), 0);
+                assert_eq!(*buf.offset(0), 0);
             }
         });
 
         let _ = bytes!("hello").to_c_str().with_ref(|buf| {
             unsafe {
-                assert_eq!(*ptr::offset(buf, 0), 'h' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 1), 'e' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 2), 'l' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 3), 'l' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 4), 'o' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 5), 0);
+                assert_eq!(*buf.offset(0), 'h' as libc::c_char);
+                assert_eq!(*buf.offset(1), 'e' as libc::c_char);
+                assert_eq!(*buf.offset(2), 'l' as libc::c_char);
+                assert_eq!(*buf.offset(3), 'l' as libc::c_char);
+                assert_eq!(*buf.offset(4), 'o' as libc::c_char);
+                assert_eq!(*buf.offset(5), 0);
             }
         });
 
         let _ = bytes!("foo", 0xff).to_c_str().with_ref(|buf| {
             unsafe {
-                assert_eq!(*ptr::offset(buf, 0), 'f' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 1), 'o' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 2), 'o' as libc::c_char);
-                assert_eq!(*ptr::offset(buf, 3), 0xff as i8);
-                assert_eq!(*ptr::offset(buf, 4), 0);
+                assert_eq!(*buf.offset(0), 'f' as libc::c_char);
+                assert_eq!(*buf.offset(1), 'o' as libc::c_char);
+                assert_eq!(*buf.offset(2), 'o' as libc::c_char);
+                assert_eq!(*buf.offset(3), 0xff as i8);
+                assert_eq!(*buf.offset(4), 0);
             }
         });
     }
@@ -634,7 +634,6 @@ mod bench {
     use extra::test::BenchHarness;
     use libc;
     use prelude::*;
-    use ptr;
 
     #[inline]
     fn check(s: &str, c_str: *libc::c_char) {
@@ -642,8 +641,8 @@ mod bench {
         for i in range(0, s.len()) {
             unsafe {
                 assert_eq!(
-                    *ptr::offset(s_buf, i as int) as libc::c_char,
-                    *ptr::offset(c_str, i as int));
+                    *s_buf.offset(i as int) as libc::c_char,
+                    *c_str.offset(i as int));
             }
         }
     }

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -18,6 +18,7 @@ use iter::Iterator;
 use option::Option;
 use io::Reader;
 use vec::{OwnedVector, ImmutableVector};
+use ptr::RawPtr;
 
 /// An iterator that reads a single byte on each iteration,
 /// until `.read_byte()` returns `None`.
@@ -104,7 +105,7 @@ pub fn u64_from_be_bytes(data: &[u8],
                          start: uint,
                          size: uint)
                       -> u64 {
-    use ptr::{copy_nonoverlapping_memory, offset, mut_offset};
+    use ptr::{copy_nonoverlapping_memory};
     use mem::from_be64;
     use vec::MutableVector;
 
@@ -116,9 +117,9 @@ pub fn u64_from_be_bytes(data: &[u8],
 
     let mut buf = [0u8, ..8];
     unsafe {
-        let ptr = offset(data.as_ptr(), start as int);
+        let ptr = data.as_ptr().offset(start as int);
         let out = buf.as_mut_ptr();
-        copy_nonoverlapping_memory(mut_offset(out, (8 - size) as int), ptr, size);
+        copy_nonoverlapping_memory(out.offset((8 - size) as int), ptr, size);
         from_be64(*(out as *i64)) as u64
     }
 }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -23,6 +23,7 @@ use io;
 use iter::Iterator;
 use option::{Some, None, Option};
 use ptr;
+use ptr::RawPtr;
 use reflect;
 use reflect::{MovePtr, align};
 use result::{Ok, Err};
@@ -221,7 +222,7 @@ impl<'a> ReprVisitor<'a> {
                 if_ok!(self, self.writer.write(", ".as_bytes()));
             }
             self.visit_ptr_inner(p as *u8, inner);
-            p = align(unsafe { ptr::offset(p, sz as int) as uint }, al) as *u8;
+            p = align(unsafe { p.offset(sz as int) as uint }, al) as *u8;
             left -= dec;
         }
         if_ok!(self, self.writer.write([']' as u8]));

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1242,7 +1242,7 @@ pub mod raw {
         let mut i = 0;
         while *curr != 0 {
             i += 1;
-            curr = ptr::offset(buf, i);
+            curr = buf.offset(i);
         }
         from_buf_len(buf as *u8, i as uint)
     }
@@ -1272,7 +1272,7 @@ pub mod raw {
         let mut len = 0u;
         while *curr != 0u8 {
             len += 1u;
-            curr = ptr::offset(s, len as int);
+            curr = s.offset(len as int);
         }
         let v = Slice { data: s, len: len };
         assert!(is_utf8(::cast::transmute(v)));
@@ -2921,7 +2921,6 @@ impl Default for ~str {
 mod tests {
     use iter::AdditiveIterator;
     use prelude::*;
-    use ptr;
     use str::*;
 
     #[test]
@@ -3549,11 +3548,11 @@ mod tests {
     fn test_as_ptr() {
         let buf = "hello".as_ptr();
         unsafe {
-            assert_eq!(*ptr::offset(buf, 0), 'h' as u8);
-            assert_eq!(*ptr::offset(buf, 1), 'e' as u8);
-            assert_eq!(*ptr::offset(buf, 2), 'l' as u8);
-            assert_eq!(*ptr::offset(buf, 3), 'l' as u8);
-            assert_eq!(*ptr::offset(buf, 4), 'o' as u8);
+            assert_eq!(*buf.offset(0), 'h' as u8);
+            assert_eq!(*buf.offset(1), 'e' as u8);
+            assert_eq!(*buf.offset(2), 'l' as u8);
+            assert_eq!(*buf.offset(3), 'l' as u8);
+            assert_eq!(*buf.offset(4), 'o' as u8);
         }
     }
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -137,7 +137,7 @@ pub fn from_fn<T>(n_elts: uint, op: |uint| -> T) -> ~[T] {
             &mut i, (),
             |i, ()| while *i < n_elts {
                 mem::move_val_init(
-                    &mut(*ptr::mut_offset(p, *i as int)),
+                    &mut(*p.offset(*i as int)),
                     op(*i));
                 *i += 1u;
             },
@@ -165,7 +165,7 @@ pub fn from_elem<T:Clone>(n_elts: uint, t: T) -> ~[T] {
             &mut i, (),
             |i, ()| while *i < n_elts {
                 mem::move_val_init(
-                    &mut(*ptr::mut_offset(p, *i as int)),
+                    &mut(*p.offset(*i as int)),
                     t.clone());
                 *i += 1u;
             },
@@ -1495,7 +1495,7 @@ impl<T> OwnedVector<T> for ~[T] {
             let fill = (**repr).fill;
             (**repr).fill += mem::nonzero_size_of::<T>();
             let p = to_unsafe_ptr(&((**repr).data));
-            let p = ptr::offset(p, fill as int) as *mut T;
+            let p = p.offset(fill as int) as *mut T;
             mem::move_val_init(&mut(*p), t);
         }
     }
@@ -1509,7 +1509,7 @@ impl<T> OwnedVector<T> for ~[T] {
         unsafe { // Note: infallible.
             let self_p = self.as_mut_ptr();
             let rhs_p = rhs.as_ptr();
-            ptr::copy_memory(ptr::mut_offset(self_p, self_len as int), rhs_p, rhs_len);
+            ptr::copy_memory(self_p.offset(self_len as int), rhs_p, rhs_len);
             self.set_len(new_len);
             rhs.set_len(0);
         }
@@ -1796,11 +1796,11 @@ impl<T:Eq> OwnedEqVector<T> for ~[T] {
             let mut w = 1;
 
             while r < ln {
-                let p_r = ptr::mut_offset(p, r as int);
-                let p_wm1 = ptr::mut_offset(p, (w - 1) as int);
+                let p_r = p.offset(r as int);
+                let p_wm1 = p.offset((w - 1) as int);
                 if *p_r != *p_wm1 {
                     if r != w {
-                        let p_w = ptr::mut_offset(p_wm1, 1);
+                        let p_w = p_wm1.offset(1);
                         mem::swap(&mut *p_r, &mut *p_w);
                     }
                     w += 1;
@@ -2383,7 +2383,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     unsafe fn unsafe_mut_ref(self, index: uint) -> &'a mut T {
-        cast::transmute(ptr::mut_offset(self.repr().data as *mut T, index as int))
+        cast::transmute((self.repr().data as *mut T).offset(index as int))
     }
 
     #[inline]
@@ -2484,6 +2484,7 @@ pub unsafe fn from_buf<T>(ptr: *T, elts: uint) -> ~[T] {
 pub mod raw {
     use cast;
     use ptr;
+    use ptr::RawPtr;
     use vec::{with_capacity, MutableVector, OwnedVector};
     use unstable::raw::Slice;
 
@@ -2542,7 +2543,7 @@ pub mod raw {
     pub unsafe fn shift_ptr<T>(slice: &mut Slice<T>) -> *T {
         if slice.len == 0 { fail!("shift on empty slice"); }
         let head: *T = slice.data;
-        slice.data = ptr::offset(slice.data, 1);
+        slice.data = slice.data.offset(1);
         slice.len -= 1;
         head
     }
@@ -2554,7 +2555,7 @@ pub mod raw {
      */
     pub unsafe fn pop_ptr<T>(slice: &mut Slice<T>) -> *T {
         if slice.len == 0 { fail!("pop on empty slice"); }
-        let tail: *T = ptr::offset(slice.data, (slice.len - 1) as int);
+        let tail: *T = slice.data.offset((slice.len - 1) as int);
         slice.len -= 1;
         tail
     }

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -22,7 +22,8 @@ use cast::{forget, transmute};
 use rt::global_heap::{malloc_raw, realloc_raw};
 use vec::{ImmutableVector, Items, MutableVector};
 use unstable::raw::Slice;
-use ptr::{offset, read_ptr};
+use ptr::read_ptr;
+use ptr::RawPtr;
 use libc::{free, c_void};
 
 pub struct Vec<T> {
@@ -135,7 +136,7 @@ impl<T> Vec<T> {
         }
 
         unsafe {
-            let end = offset(self.ptr as *T, self.len as int) as *mut T;
+            let end = (self.ptr as *T).offset(self.len as int) as *mut T;
             move_val_init(&mut *end, value);
             self.len += 1;
         }


### PR DESCRIPTION
This pull request remove the functions `std::ptr::{offset, mut_offset, is_null, is_not_null}`, which are duplicate with the corresponding methods in `std::ptr::RawPtr`.

I don't know if these changes are acceptable / needed, but if it is, maybe we can remove `std::ptr::{null, mut_null}`, to use only `std::ptr::RawPtr::null`
