### PR TITLE
Reserve `do` as a keyword

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -492,6 +492,7 @@ declare_special_idents_and_keywords! {
         (53,                         Typeof,     "typeof");
         (54,                         Unsized,    "unsized");
         (55,                         Yield,      "yield");
+        (56,                         Do,         "do");
     }
 }
 

--- a/src/test/compile-fail/keyword-do-as-identifier.rs
+++ b/src/test/compile-fail/keyword-do-as-identifier.rs
@@ -1,0 +1,13 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let do = "bar"; //~ error: ident
+}

--- a/src/test/run-pass/temporary-lifetime-for-conditions.rs
+++ b/src/test/run-pass/temporary-lifetime-for-conditions.rs
@@ -23,7 +23,7 @@ impl Drop for Temporary {
 }
 
 impl Temporary {
-    fn do(&self) -> bool {true}
+    fn do_stuff(&self) -> bool {true}
 }
 
 fn borrow() -> ~Temporary { ~Temporary }
@@ -35,7 +35,7 @@ pub fn main() {
     // This loop's condition
     // should call `Temporary`'s
     // `drop` 6 times.
-    while borrow().do() {
+    while borrow().do_stuff() {
         i += 1;
         if i > 5 {
             break;
@@ -44,7 +44,7 @@ pub fn main() {
 
     // This if condition should
     // call it 1 time
-    if borrow().do() {
+    if borrow().do_stuff() {
         unsafe { assert_eq!(DROPPED, 7) }
     }
 }


### PR DESCRIPTION
This resolves issue #12157. Does that do it already or is there something else that needs taking care of?  

As a side note, there seems to be some documentation, in which the old existence of the do keyword is explained. The list of keywords is not up-to-date either. But these are certainly separate issues.
