### PR TITLE
Speed up green task spawning

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -57,7 +57,7 @@ TOOLS := compiletest rustdoc rustc
 
 DEPS_std := native:rustrt native:compiler-rt
 DEPS_extra := std term sync serialize getopts collections
-DEPS_green := std
+DEPS_green := std native:context_switch
 DEPS_rustuv := std native:uv native:uv_support
 DEPS_native := std
 DEPS_syntax := std extra term serialize collections

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -35,7 +35,7 @@
 # that's per-target so you're allowed to conditionally add files based on the
 # target.
 ################################################################################
-NATIVE_LIBS := rustrt sundown uv_support morestack miniz
+NATIVE_LIBS := rustrt sundown uv_support morestack miniz context_switch
 
 # $(1) is the target triple
 define NATIVE_LIBRARIES
@@ -54,9 +54,10 @@ NATIVE_DEPS_rustrt_$(1) := rust_builtin.c \
 			rust_android_dummy.c \
 			rust_test_helpers.c \
 			rust_try.ll \
-			arch/$$(HOST_$(1))/_context.S \
 			arch/$$(HOST_$(1))/record_sp.S
 NATIVE_DEPS_morestack_$(1) := arch/$$(HOST_$(1))/morestack.S
+NATIVE_DEPS_context_switch_$(1) := \
+			arch/$$(HOST_$(1))/_context.S
 
 ################################################################################
 # You shouldn't find it that necessary to edit anything below this line.

--- a/src/libgreen/coroutine.rs
+++ b/src/libgreen/coroutine.rs
@@ -11,8 +11,6 @@
 // Coroutines represent nothing more than a context and a stack
 // segment.
 
-use std::rt::env;
-
 use context::Context;
 use stack::{StackPool, Stack};
 
@@ -31,22 +29,6 @@ pub struct Coroutine {
 }
 
 impl Coroutine {
-    pub fn new(stack_pool: &mut StackPool,
-               stack_size: Option<uint>,
-               start: proc())
-               -> Coroutine {
-        let stack_size = match stack_size {
-            Some(size) => size,
-            None => env::min_stack()
-        };
-        let mut stack = stack_pool.take_stack(stack_size);
-        let initial_context = Context::new(start, &mut stack);
-        Coroutine {
-            current_stack_segment: stack,
-            saved_context: initial_context
-        }
-    }
-
     pub fn empty() -> Coroutine {
         Coroutine {
             current_stack_segment: unsafe { Stack::dummy_stack() },

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -756,7 +756,7 @@ impl Scheduler {
 
     /// Called by a running task to end execution, after which it will
     /// be recycled by the scheduler for reuse in a new task.
-    pub fn terminate_current_task(mut ~self, cur: ~GreenTask) {
+    pub fn terminate_current_task(mut ~self, cur: ~GreenTask) -> ! {
         // Similar to deschedule running task and then, but cannot go through
         // the task-blocking path. The task is already dying.
         let stask = self.sched_task.take_unwrap();

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -22,7 +22,7 @@ use std::cast;
 use std::rt::Runtime;
 use std::rt::rtio;
 use std::rt::local::Local;
-use std::rt::task::{Task, BlockedTask};
+use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::task::TaskOpts;
 use std::unstable::mutex::Mutex;
 
@@ -131,8 +131,7 @@ impl GreenTask {
             task.stdout = stdout;
             match notify_chan {
                 Some(chan) => {
-                    let on_exit = proc(task_result) { chan.send(task_result) };
-                    task.death.on_exit = Some(on_exit);
+                    task.death.on_exit = Some(SendMessage(chan));
                 }
                 None => {}
             }

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -19,13 +19,16 @@
 //! values.
 
 use std::cast;
+use std::rt::env;
 use std::rt::Runtime;
-use std::rt::rtio;
 use std::rt::local::Local;
+use std::rt::rtio;
 use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::task::TaskOpts;
 use std::unstable::mutex::Mutex;
+use std::unstable::raw;
 
+use context::Context;
 use coroutine::Coroutine;
 use sched::{Scheduler, SchedHandle, RunOnce};
 use stack::StackPool;
@@ -75,6 +78,50 @@ pub enum Home {
     HomeSched(SchedHandle),
 }
 
+/// Trampoline code for all new green tasks which are running around. This
+/// function is passed through to Context::new as the initial rust landing pad
+/// for all green tasks. This code is actually called after the initial context
+/// switch onto a green thread.
+///
+/// The first argument to this function is the `~GreenTask` pointer, and the
+/// next two arguments are the user-provided procedure for running code.
+///
+/// The goal for having this weird-looking function is to reduce the number of
+/// allocations done on a green-task startup as much as possible.
+extern fn bootstrap_green_task(task: uint, code: *(), env: *()) -> ! {
+    // Acquire ownership of the `proc()`
+    let start: proc() = unsafe {
+        cast::transmute(raw::Procedure { code: code, env: env })
+    };
+
+    // Acquire ownership of the `~GreenTask`
+    let mut task: ~GreenTask = unsafe { cast::transmute(task) };
+
+    // First code after swap to this new context. Run our cleanup job
+    task.pool_id = {
+        let sched = task.sched.get_mut_ref();
+        sched.run_cleanup_job();
+        sched.task_state.increment();
+        sched.pool_id
+    };
+
+    // Convert our green task to a libstd task and then execute the code
+    // requested. This is the "try/catch" block for this green task and
+    // is the wrapper for *all* code run in the task.
+    let mut start = Some(start);
+    let task = task.swap().run(|| start.take_unwrap()());
+
+    // Once the function has exited, it's time to run the termination
+    // routine. This means we need to context switch one more time but
+    // clean ourselves up on the other end. Since we have no way of
+    // preserving a handle to the GreenTask down to this point, this
+    // unfortunately must call `GreenTask::convert`. In order to avoid
+    // this we could add a `terminate` function to the `Runtime` trait
+    // in libstd, but that seems less appropriate since the coversion
+    // method exists.
+    GreenTask::convert(task).terminate()
+}
+
 impl GreenTask {
     /// Creates a new green task which is not homed to any particular scheduler
     /// and will not have any contained Task structure.
@@ -89,9 +136,20 @@ impl GreenTask {
                      stack_size: Option<uint>,
                      home: Home,
                      start: proc()) -> ~GreenTask {
+        // Allocate ourselves a GreenTask structure
         let mut ops = GreenTask::new_typed(None, TypeGreen(Some(home)));
-        let start = GreenTask::build_start_wrapper(start, ops.as_uint());
-        ops.coroutine = Some(Coroutine::new(stack_pool, stack_size, start));
+
+        // Allocate a stack for us to run on
+        let stack_size = stack_size.unwrap_or_else(|| env::min_stack());
+        let mut stack = stack_pool.take_stack(stack_size);
+        let context = Context::new(bootstrap_green_task, ops.as_uint(), start,
+                                   &mut stack);
+
+        // Package everything up in a coroutine and return
+        ops.coroutine = Some(Coroutine {
+            current_stack_segment: stack,
+            saved_context: context,
+        });
         return ops;
     }
 
@@ -153,46 +211,6 @@ impl GreenTask {
                 green
             }
             None => rtabort!("not a green task any more?"),
-        }
-    }
-
-    /// Builds a function which is the actual starting execution point for a
-    /// rust task. This function is the glue necessary to execute the libstd
-    /// task and then clean up the green thread after it exits.
-    ///
-    /// The second argument to this function is actually a transmuted copy of
-    /// the `GreenTask` pointer. Context switches in the scheduler silently
-    /// transfer ownership of the `GreenTask` to the other end of the context
-    /// switch, so because this is the first code that is running in this task,
-    /// it must first re-acquire ownership of the green task.
-    pub fn build_start_wrapper(start: proc(), ops: uint) -> proc() {
-        proc() {
-            // First code after swap to this new context. Run our
-            // cleanup job after we have re-acquired ownership of the green
-            // task.
-            let mut task: ~GreenTask = unsafe { GreenTask::from_uint(ops) };
-            task.pool_id = {
-                let sched = task.sched.get_mut_ref();
-                sched.run_cleanup_job();
-                sched.task_state.increment();
-                sched.pool_id
-            };
-
-            // Convert our green task to a libstd task and then execute the code
-            // requested. This is the "try/catch" block for this green task and
-            // is the wrapper for *all* code run in the task.
-            let mut start = Some(start);
-            let task = task.swap().run(|| start.take_unwrap()());
-
-            // Once the function has exited, it's time to run the termination
-            // routine. This means we need to context switch one more time but
-            // clean ourselves up on the other end. Since we have no way of
-            // preserving a handle to the GreenTask down to this point, this
-            // unfortunately must call `GreenTask::convert`. In order to avoid
-            // this we could add a `terminate` function to the `Runtime` trait
-            // in libstd, but that seems less appropriate since the coversion
-            // method exists.
-            GreenTask::convert(task).terminate();
         }
     }
 
@@ -278,9 +296,9 @@ impl GreenTask {
         Local::put(self.swap());
     }
 
-    fn terminate(mut ~self) {
+    fn terminate(mut ~self) -> ! {
         let sched = self.sched.take_unwrap();
-        sched.terminate_current_task(self);
+        sched.terminate_current_task(self)
     }
 
     // This function is used to remotely wakeup this green task back on to its

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -18,7 +18,7 @@ use std::cast;
 use std::rt::env;
 use std::rt::local::Local;
 use std::rt::rtio;
-use std::rt::task::{Task, BlockedTask};
+use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::rt::thread::Thread;
 use std::rt;
 use std::task::TaskOpts;
@@ -68,10 +68,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc()) {
     task.stderr = stderr;
     task.stdout = stdout;
     match notify_chan {
-        Some(chan) => {
-            let on_exit = proc(task_result) { chan.send(task_result) };
-            task.death.on_exit = Some(on_exit);
-        }
+        Some(chan) => { task.death.on_exit = Some(SendMessage(chan)); }
         None => {}
     }
 

--- a/src/libstd/unstable/raw.rs
+++ b/src/libstd/unstable/raw.rs
@@ -41,6 +41,12 @@ pub struct Closure {
     env: *(),
 }
 
+/// The representation of a Rust procedure (`proc()`)
+pub struct Procedure {
+    code: *(),
+    env: *(),
+}
+
 /// This trait is meant to map equivalences between raw structs and their
 /// corresponding rust values.
 pub trait Repr<T> {

--- a/src/rt/arch/arm/_context.S
+++ b/src/rt/arch/arm/_context.S
@@ -51,3 +51,11 @@ rust_swap_registers:
 	msr cpsr_cxsf, r2
 
 	mov pc, lr
+
+// For reasons of this existence, see the comments in x86_64/_context.S
+.globl rust_bootstrap_green_task
+rust_bootstrap_green_task:
+        mov r0, r0
+        mov r1, r3
+        mov r2, r4
+        mov pc, r5

--- a/src/rt/arch/x86_64/_context.S
+++ b/src/rt/arch/x86_64/_context.S
@@ -157,3 +157,36 @@ SWAP_REGISTERS:
         // Jump to the instruction pointer
         // found in regs:
         jmp *(RUSTRT_IP*8)(ARG1)
+
+// This function below, rust_bootstrap_green_task, is used to initialize a green
+// task. This code is the very first code that is run whenever a green task
+// starts. The only assumptions that this code makes is that it has a register
+// context previously set up by Context::new() and some values are in some
+// special registers.
+//
+// In theory the register context could be set up and then the context switching
+// would plop us directly into some 'extern "C" fn', but not all platforms have
+// the argument registers saved throughout a context switch (linux doesn't save
+// rdi/rsi, the first two argument registers). Instead of modifying all context
+// switches, instead the initial data for starting a green thread is shoved into
+// unrelated registers (r12/13, etc) which always need to be saved on context
+// switches anyway.
+//
+// With this strategy we get the benefit of being able to pass a fair bit of
+// contextual data from the start of a green task to its init function, as well
+// as not hindering any context switches.
+//
+// If you alter this code in any way, you likely need to update
+// src/libgreen/context.rs as well.
+
+#if defined(__APPLE__)
+#define BOOTSTRAP _rust_bootstrap_green_task
+#else
+#define BOOTSTRAP rust_bootstrap_green_task
+#endif
+.globl BOOTSTRAP
+BOOTSTRAP:
+    mov %r12, RUSTRT_ARG0_S
+    mov %r13, RUSTRT_ARG1_S
+    mov %r14, RUSTRT_ARG2_S
+    jmpq *%r15


### PR DESCRIPTION
These commits pick off some low-hanging fruit which were slowing down spawning green threads. The major speedup comes from fixing a bug in stack caching where we never used any cached stacks!

The program I used to benchmark is at the end. It was compiled with `rustc --opt-level=3 bench.rs --test` and run as `RUST_THREADS=1 ./bench --bench`. I chose to use `RUST_THREADS=1` due to #11730 as the profiles I was getting interfered too much when all the schedulers were in play (and shouldn't be after #11730 is fixed). All of the units below are in ns/iter as reported by `--bench` (lower is better).

|  | green | native | raw |
| --- | --- | --- | --- |
| osx before | 12699 | 24030 | 19734 |
| linux before | 10223 | 125983 | 122647 |
| osx after | 3847 | 25771 | 20835 |
| linux after | 2631 | 135398 | 122765 |

Note that this is _not_ a benchmark of spawning green tasks vs native tasks. I put in the native numbers just to get a ballpark of where green tasks are. This is benchmark is _clearly_ benefiting from stack caching. Also, OSX is clearly not 5x faster than linux, I think my VM is just much slower.

All in all, this ended up being a nice 4x speedup for spawning a green task when you're using a cached stack.

``` rust
extern mod extra;
extern mod native;
use std::rt::thread::Thread;

#[bench]
fn green(bh: &mut extra::test::BenchHarness) {
    let (p, c) = SharedChan::new();
    bh.iter(|| {
        let c = c.clone();
        spawn(proc() {
            c.send(());
        });
        p.recv();
    });
}

#[bench]
fn native(bh: &mut extra::test::BenchHarness) {
    let (p, c) = SharedChan::new();
    bh.iter(|| {
        let c = c.clone();
        native::task::spawn(proc() {
            c.send(());
        });
        p.recv();
    });
}

#[bench]
fn raw(bh: &mut extra::test::BenchHarness) {
    bh.iter(|| {
        Thread::start(proc() {}).join()
    });
}
```
