### PR TITLE
Ignore #[phase] on use view items

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -394,15 +394,20 @@ pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
 pub fn expand_view_item(vi: &ast::ViewItem,
                         fld: &mut MacroExpander)
                         -> ast::ViewItem {
-    let should_load = vi.attrs.iter().any(|attr| {
-        attr.name().get() == "phase" &&
-            attr.meta_item_list().map_or(false, |phases| {
-                attr::contains_name(phases, "syntax")
-            })
-    });
+    match vi.node {
+        ast::ViewItemExternMod(..) => {
+            let should_load = vi.attrs.iter().any(|attr| {
+                attr.name().get() == "phase" &&
+                    attr.meta_item_list().map_or(false, |phases| {
+                        attr::contains_name(phases, "syntax")
+                    })
+            });
 
-    if should_load {
-        load_extern_macros(vi, fld);
+            if should_load {
+                load_extern_macros(vi, fld);
+            }
+        }
+        ast::ViewItemUse(_) => {}
     }
 
     noop_fold_view_item(vi, fld)

--- a/src/test/run-pass/phase-use-ignored.rs
+++ b/src/test/run-pass/phase-use-ignored.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//xfail-fast
+
+#[feature(phase)];
+
+#[phase(syntax)]
+use std::mem;
+
+fn main() {}
+


### PR DESCRIPTION
It could throw an error but I think it's best to not since `#[phase(..)]` syntax in other places would be silently ignored.

Closes #11806
