### PR TITLE
Output the correct library filename with --dep-info

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1087,7 +1087,7 @@ pub fn build_output_filenames(input: &Input,
             // We want to toss everything after the final '.'
             let dirpath = match *odir {
                 Some(ref d) => d.clone(),
-                None => os::getcwd(),
+                None => Path::new(".")
             };
 
             let mut stem = match *input {


### PR DESCRIPTION
Fixes #12174.
