### PR TITLE
Don't use -Z prefer-dynamic at stage0

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -140,7 +140,8 @@ endif
 # snapshot will be generated with a statically linked rustc so we only have to
 # worry about the distribution of one file (with its native dynamic
 # dependencies)
-RUSTFLAGS_STAGE0 += -Z prefer-dynamic
+#
+# NOTE: after a snapshot (stage0), put this on stage0 as well
 RUSTFLAGS_STAGE1 += -C prefer-dynamic
 
 # platform-specific auto-configuration


### PR DESCRIPTION
This is blocking a snapshot because the stage0 target compiler comes from a
stage1 host compiler. This means that the stage0 compiler doesn't actually
understand the -Z prefer-dynamic flag and is dying as a result.

This will get added back to stage0 after a snapshot.
