### PR TITLE
Replace Ident with Name in for loops

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -5191,7 +5191,7 @@ impl Resolver {
                         let rib = label_ribs.get()[label_ribs.get().len() -
                                                    1];
                         let mut bindings = rib.bindings.borrow_mut();
-                        bindings.get().insert(label.name, def_like);
+                        bindings.get().insert(label, def_like);
                     }
 
                     visit::walk_expr(this, expr, ());

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -33,7 +33,7 @@ pub fn P<T: 'static>(value: T) -> P<T> {
 }
 
 // FIXME #6993: in librustc, uses of "ident" should be replaced
-// by just "Name".
+// with just "Name".
 
 // an identifier contains a Name (index into the interner
 // table) and a SyntaxContext to track renaming and
@@ -551,11 +551,8 @@ pub enum Expr_ {
     ExprCast(@Expr, P<Ty>),
     ExprIf(@Expr, P<Block>, Option<@Expr>),
     ExprWhile(@Expr, P<Block>),
-    // FIXME #6993: change to Option<Name>
-    ExprForLoop(@Pat, @Expr, P<Block>, Option<Ident>),
-    // Conditionless loop (can be exited with break, cont, or ret)
-    // FIXME #6993: change to Option<Name>
-    ExprLoop(P<Block>, Option<Ident>),
+    ExprForLoop(@Pat, @Expr, P<Block>, Option<Name>),
+    ExprLoop(P<Block>, Option<Name>),
     ExprMatch(@Expr, ~[Arm]),
     ExprFnBlock(P<FnDecl>, P<Block>),
     ExprProc(P<FnDecl>, P<Block>),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -134,8 +134,7 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
 
         // Desugar expr_for_loop
         // From: `['<ident>:] for <src_pat> in <src_expr> <src_loop_block>`
-        // FIXME #6993: change type of opt_ident to Option<Name>
-        ast::ExprForLoop(src_pat, src_expr, src_loop_block, opt_ident) => {
+        ast::ExprForLoop(src_pat, src_expr, src_loop_block, opt_name) => {
             // Expand any interior macros etc.
             // NB: we don't fold pats yet. Curious.
             let src_expr = fld.fold_expr(src_expr).clone();
@@ -165,8 +164,7 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
 
             // `None => break ['<ident>];`
             let none_arm = {
-                // FIXME #6993: this map goes away:
-                let break_expr = fld.cx.expr(span, ast::ExprBreak(opt_ident.map(|x| x.name)));
+                let break_expr = fld.cx.expr(span, ast::ExprBreak(opt_name));
                 let none_pat = fld.cx.pat_ident(span, none_ident);
                 fld.cx.arm(span, ~[none_pat], break_expr)
             };
@@ -188,7 +186,7 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
             // ['ident:] loop { ... }
             let loop_expr = fld.cx.expr(span,
                                         ast::ExprLoop(fld.cx.block_expr(match_expr),
-                                                      opt_ident));
+                                                      opt_name));
 
             // `i => loop { ... }`
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -250,6 +250,10 @@ pub trait Folder {
         i
     }
 
+    fn fold_name(&mut self, n: Name) -> Name {
+        n
+    }
+
     fn fold_path(&mut self, p: &Path) -> Path {
         ast::Path {
             span: self.new_span(p.span),
@@ -763,15 +767,15 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
         ExprWhile(cond, body) => {
             ExprWhile(folder.fold_expr(cond), folder.fold_block(body))
         }
-        ExprForLoop(pat, iter, body, ref maybe_ident) => {
+        ExprForLoop(pat, iter, body, ref opt_name) => {
             ExprForLoop(folder.fold_pat(pat),
                         folder.fold_expr(iter),
                         folder.fold_block(body),
-                        maybe_ident.map(|i| folder.fold_ident(i)))
+                        opt_name.map(|x| folder.fold_name(x)))
         }
-        ExprLoop(body, opt_ident) => {
+        ExprLoop(body, opt_name) => {
             ExprLoop(folder.fold_block(body),
-                     opt_ident.map(|x| folder.fold_ident(x)))
+                     opt_name.map(|x| folder.fold_name(x)))
         }
         ExprMatch(expr, ref arms) => {
             ExprMatch(folder.fold_expr(expr),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1810,10 +1810,11 @@ impl Parser {
             let lifetime = self.get_lifetime();
             self.bump();
             self.expect(&token::COLON);
+            let name = Some(lifetime.name);
             if self.eat_keyword(keywords::For) {
-                return self.parse_for_expr(Some(lifetime))
+                return self.parse_for_expr(name)
             } else if self.eat_keyword(keywords::Loop) {
-                return self.parse_loop_expr(Some(lifetime))
+                return self.parse_loop_expr(name)
             } else {
                 self.fatal("expected `for` or `loop` after a label")
             }
@@ -2535,7 +2536,7 @@ impl Parser {
     }
 
     // parse a 'for' .. 'in' expression ('for' token already eaten)
-    pub fn parse_for_expr(&mut self, opt_ident: Option<ast::Ident>) -> @Expr {
+    pub fn parse_for_expr(&mut self, opt_name: Option<ast::Name>) -> @Expr {
         // Parse: `for <src_pat> in <src_expr> <src_loop_block>`
 
         let lo = self.last_span.lo;
@@ -2545,7 +2546,7 @@ impl Parser {
         let loop_block = self.parse_block();
         let hi = self.span.hi;
 
-        self.mk_expr(lo, hi, ExprForLoop(pat, expr, loop_block, opt_ident))
+        self.mk_expr(lo, hi, ExprForLoop(pat, expr, loop_block, opt_name))
     }
 
     pub fn parse_while_expr(&mut self) -> @Expr {
@@ -2556,7 +2557,7 @@ impl Parser {
         return self.mk_expr(lo, hi, ExprWhile(cond, body));
     }
 
-    pub fn parse_loop_expr(&mut self, opt_ident: Option<ast::Ident>) -> @Expr {
+    pub fn parse_loop_expr(&mut self, opt_name: Option<ast::Name>) -> @Expr {
         // loop headers look like 'loop {' or 'loop unsafe {'
         let is_loop_header =
             self.token == token::LBRACE
@@ -2568,10 +2569,10 @@ impl Parser {
             let lo = self.last_span.lo;
             let body = self.parse_block();
             let hi = body.span.hi;
-            return self.mk_expr(lo, hi, ExprLoop(body, opt_ident));
+            return self.mk_expr(lo, hi, ExprLoop(body, opt_name));
         } else {
             // This is an obsolete 'continue' expression
-            if opt_ident.is_some() {
+            if opt_name.is_some() {
                 self.span_err(self.last_span,
                               "a label may not be used with a `loop` expression");
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1317,7 +1317,7 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) -> io::IoResult<()> {
       ast::ExprForLoop(pat, iter, blk, opt_ident) => {
         for ident in opt_ident.iter() {
             if_ok!(word(&mut s.s, "'"));
-            if_ok!(print_ident(s, *ident));
+            if_ok!(print_name(s, *ident));
             if_ok!(word_space(s, ":"));
         }
         if_ok!(head(s, "for"));
@@ -1331,7 +1331,7 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) -> io::IoResult<()> {
       ast::ExprLoop(blk, opt_ident) => {
         for ident in opt_ident.iter() {
             if_ok!(word(&mut s.s, "'"));
-            if_ok!(print_ident(s, *ident));
+            if_ok!(print_name(s, *ident));
             if_ok!(word_space(s, ":"));
         }
         if_ok!(head(s, "loop"));


### PR DESCRIPTION
Cleaning up `Ident` usage in `rustc`. This patch replaces `Ident` usage in `ExprFor` and `ExprForLoop`

cc #6993
