### PR TITLE
Add ignore-cross-compile directive for compiletest

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -108,6 +108,8 @@ pub fn is_test_ignored(config: &config, testfile: &Path) -> bool {
         else if parse_name_directive(ln, ignore_stage(config)) { false }
         else if config.mode == common::mode_pretty &&
             parse_name_directive(ln, "ignore-pretty") { false }
+        else if config.target != config.host &&
+            parse_name_directive(ln, "ignore-cross-compile") { false }
         else { true }
     });
 

--- a/src/test/compile-fail/syntax-extension-fourcc-bad-len.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-bad-len.rs
@@ -10,7 +10,7 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 

--- a/src/test/compile-fail/syntax-extension-fourcc-invalid-endian.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-invalid-endian.rs
@@ -10,7 +10,7 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 

--- a/src/test/compile-fail/syntax-extension-fourcc-non-ascii-str.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-non-ascii-str.rs
@@ -10,7 +10,7 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 

--- a/src/test/compile-fail/syntax-extension-fourcc-non-literal.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-non-literal.rs
@@ -10,7 +10,7 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 

--- a/src/test/compile-fail/syntax-extension-fourcc-unsupported-literal.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-unsupported-literal.rs
@@ -10,7 +10,7 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 


### PR DESCRIPTION
Loadable syntax extensions don't work when cross compiling (see #12102), so the
fourcc tests all need to be ignored. They're valuable tests, so they shouldn't
be outright ignored, so they're now flagged with ignore-cross-compile
