### PR TITLE
Don't recursively expand undefined macros

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -64,7 +64,11 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
                                         extnamestr.get()));
 
                             // let compilation continue
-                            return e;
+                            return @ast::Expr {
+                                id: ast::DUMMY_NODE_ID,
+                                node: ast::ExprLogLevel,
+                                span: e.span,
+                            }
                         }
                         Some(&NormalTT(ref expandfun, exp_span)) => {
                             fld.cx.bt_push(ExpnInfo {

--- a/src/test/compile-fail/issue-11692.rs
+++ b/src/test/compile-fail/issue-11692.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    print!(test!());
+    //~^ ERROR: macro undefined: 'test'
+    //~^^ ERROR: macro undefined: 'test'
+    //~^^^ ERROR: format argument must be a string literal
+
+    concat!(test!());
+    //~^ ERROR: macro undefined: 'test'
+    //~^^ ERROR: expected a literal
+}


### PR DESCRIPTION
This led to infinite recursion when compiling a macro which inside used an
undefined macro. Instead some dummy expression is returned for the result of
expansion (rather than the macro itself).

Closes #11692
