### PR TITLE
Invoke gcc with -nodefaultlibs

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1084,6 +1084,17 @@ fn link_args(sess: Session,
         args.push(metadata.as_str().unwrap().to_owned());
     }
 
+    // We want to prevent the compiler from accidentally leaking in any system
+    // libraries, so we explicitly ask gcc to not link to any libraries by
+    // default. Note that this does not happen for windows because windows pulls
+    // in some large number of libraries and I couldn't quite figure out which
+    // subset we wanted.
+    //
+    // FIXME(#11937) we should invoke the system linker directly
+    if sess.targ_cfg.os != abi::OsWin32 {
+        args.push(~"-nodefaultlibs");
+    }
+
     if sess.targ_cfg.os == abi::OsLinux {
         // GNU-style linkers will use this to omit linking to libraries which
         // don't actually fulfill any relocations, but only for libraries which

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -143,6 +143,16 @@ mod libunwind {
     pub type _Unwind_Exception_Cleanup_Fn = extern "C" fn(unwind_code: _Unwind_Reason_Code,
                                                           exception: *_Unwind_Exception);
 
+    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "win32")]
+    #[link(name = "gcc_s")]
+    extern {}
+
+    #[cfg(target_os = "android")]
+    #[link(name = "gcc")]
+    extern {}
+
     extern "C" {
         pub fn _Unwind_RaiseException(exception: *_Unwind_Exception) -> _Unwind_Reason_Code;
         pub fn _Unwind_DeleteException(exception: *_Unwind_Exception);

--- a/src/libstd/rtdeps.rs
+++ b/src/libstd/rtdeps.rs
@@ -22,6 +22,7 @@ extern {}
 // On linux librt and libdl are indirect dependencies via rustrt,
 // and binutils 2.22+ won't add them automatically
 #[cfg(target_os = "linux")]
+#[link(name = "c")]
 #[link(name = "dl")]
 #[link(name = "m")]
 #[link(name = "pthread")]
@@ -31,6 +32,7 @@ extern {}
 #[link(name = "dl")]
 #[link(name = "log")]
 #[link(name = "m")]
+#[link(name = "c")]
 extern {}
 
 #[cfg(target_os = "freebsd")]
@@ -39,5 +41,5 @@ extern {}
 extern {}
 
 #[cfg(target_os = "macos")]
-#[link(name = "pthread")]
+#[link(name = "System")]
 extern {}


### PR DESCRIPTION
This will hopefully bring us closer to #11937. We're still using gcc's idea of
"startup files", but this should prevent us from leaking in dependencies that we
don't quite want (libgcc for example once compiler-rt is what we use).
