### PR TITLE
Stop unloading syntax libraries

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -20,7 +20,6 @@ use parse::token::{InternedString, intern, str_to_ident};
 use util::small_vector::SmallVector;
 
 use std::hashmap::HashMap;
-use std::unstable::dynamic_lib::DynamicLibrary;
 
 // new-style macro! tt code:
 //
@@ -143,8 +142,6 @@ pub struct BlockInfo {
     macros_escape : bool,
     // what are the pending renames?
     pending_renames : RenameList,
-    // references for crates loaded in this scope
-    macro_crates: ~[DynamicLibrary],
 }
 
 impl BlockInfo {
@@ -152,7 +149,6 @@ impl BlockInfo {
         BlockInfo {
             macros_escape: false,
             pending_renames: ~[],
-            macro_crates: ~[],
         }
     }
 }
@@ -549,10 +545,6 @@ impl SyntaxEnv {
 
     pub fn insert(&mut self, k: Name, v: SyntaxExtension) {
         self.find_escape_frame().map.insert(k, v);
-    }
-
-    pub fn insert_macro_crate(&mut self, lib: DynamicLibrary) {
-        self.find_escape_frame().info.macro_crates.push(lib);
     }
 
     pub fn info<'a>(&'a mut self) -> &'a mut BlockInfo {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -28,6 +28,7 @@ use visit;
 use visit::Visitor;
 use util::small_vector::SmallVector;
 
+use std::cast;
 use std::vec;
 use std::unstable::dynamic_lib::DynamicLibrary;
 use std::os;
@@ -469,9 +470,12 @@ fn load_extern_macros(crate: &ast::ViewItem, fld: &mut MacroExpander) {
             };
             fld.extsbox.insert(name, extension);
         });
-    }
 
-    fld.extsbox.insert_macro_crate(lib);
+        // Intentionally leak the dynamic library. We can't ever unload it
+        // since the library can do things that will outlive the expansion
+        // phase (e.g. make an @-box cycle or launch a task).
+        cast::forget(lib);
+    }
 }
 
 // expand a stmt

--- a/src/test/auxiliary/macro_crate_outlive_expansion_phase.rs
+++ b/src/test/auxiliary/macro_crate_outlive_expansion_phase.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+
+#[feature(macro_registrar)];
+
+extern mod syntax;
+
+use std::any::Any;
+use std::local_data;
+use syntax::ast::Name;
+use syntax::ext::base::SyntaxExtension;
+
+struct Foo {
+    foo: int
+}
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+#[macro_registrar]
+pub fn registrar(_: |Name, SyntaxExtension|) {
+    local_data_key!(foo: ~Any);
+    local_data::set(foo, ~Foo { foo: 10 } as ~Any);
+}
+

--- a/src/test/run-pass-fulldeps/macro-crate-outlive-expansion-phase.rs
+++ b/src/test/run-pass-fulldeps/macro-crate-outlive-expansion-phase.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:macro_crate_outlive_expansion_phase.rs
+// ignore-stage1
+// ignore-fast
+// ignore-android
+
+#[feature(phase)];
+
+#[phase(syntax)]
+extern mod macro_crate_outlive_expansion_phase;
+
+pub fn main() {}


### PR DESCRIPTION
Externally loaded libraries are able to do things that cause references
to them to survive past the expansion phase (e.g. creating @-box cycles,
launching a task or storing something in task local data). As such, the
library has to stay loaded for the lifetime of the process.

r? @pcwalton @alexcrichton
