### PR TITLE
extra: Capture stdout/stderr of tests by default

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -30,6 +30,8 @@ pub struct TestProps {
     check_lines: ~[~str],
     // Flag to force a crate to be built with the host architecture
     force_host: bool,
+    // Check stdout for error-pattern output as well as stderr
+    check_stdout: bool,
 }
 
 // Load any test directives embedded in the file
@@ -42,6 +44,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut debugger_cmds = ~[];
     let mut check_lines = ~[];
     let mut force_host = false;
+    let mut check_stdout = false;
     iter_header(testfile, |ln| {
         match parse_error_pattern(ln) {
           Some(ep) => error_patterns.push(ep),
@@ -58,6 +61,10 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         if !force_host {
             force_host = parse_force_host(ln);
+        }
+
+        if !check_stdout {
+            check_stdout = parse_check_stdout(ln);
         }
 
         match parse_aux_build(ln) {
@@ -91,6 +98,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         debugger_cmds: debugger_cmds,
         check_lines: check_lines,
         force_host: force_host,
+        check_stdout: check_stdout,
     };
 }
 
@@ -153,6 +161,10 @@ fn parse_check_line(line: &str) -> Option<~str> {
 
 fn parse_force_host(line: &str) -> bool {
     parse_name_directive(line, "force-host")
+}
+
+fn parse_check_stdout(line: &str) -> bool {
+    parse_name_directive(line, "check-stdout")
 }
 
 fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -452,7 +452,12 @@ fn check_error_patterns(props: &TestProps,
     let mut next_err_idx = 0u;
     let mut next_err_pat = &props.error_patterns[next_err_idx];
     let mut done = false;
-    for line in ProcRes.stderr.lines() {
+    let output_to_check = if props.check_stdout {
+        ProcRes.stdout + ProcRes.stderr
+    } else {
+        ProcRes.stderr.clone()
+    };
+    for line in output_to_check.lines() {
         if line.contains(*next_err_pat) {
             debug!("found error pattern {}", *next_err_pat);
             next_err_idx += 1u;

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -96,6 +96,12 @@ impl ChanWriter {
     }
 }
 
+impl Clone for ChanWriter {
+    fn clone(&self) -> ChanWriter {
+        ChanWriter { chan: self.chan.clone() }
+    }
+}
+
 impl Writer for ChanWriter {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         if !self.chan.try_send(buf.to_owned()) {

--- a/src/test/run-fail/run-unexported-tests.rs
+++ b/src/test/run-fail/run-unexported-tests.rs
@@ -10,6 +10,7 @@
 
 // error-pattern:runned an unexported test
 // compile-flags:--test
+// check-stdout
 
 extern mod extra;
 

--- a/src/test/run-fail/test-fail.rs
+++ b/src/test/run-fail/test-fail.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// check-stdout
 // error-pattern:task 'test_foo' failed at
 // compile-flags: --test
 


### PR DESCRIPTION
When tests fail, their stdout and stderr is printed as part of the summary, but
this helps suppress failure messages from #[should_fail] tests and generally
clean up the output of the test runner.
