### PR TITLE
Ignore another fourcc test on cross compiles

### DIFF
--- a/src/test/run-pass-fulldeps/syntax-extension-fourcc.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-fourcc.rs
@@ -11,7 +11,7 @@
 // ignore-fast Feature gating doesn't work
 // ignore-stage1
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile
 
 #[feature(phase)];
 


### PR DESCRIPTION
Hurray more snapshot blockers!
