### PR TITLE
Clean up std::task docs, make TaskBuilder a real builder

### DIFF
--- a/src/libextra/test.rs
+++ b/src/libextra/test.rs
@@ -904,15 +904,14 @@ pub fn run_test(force_ignore: bool,
                       monitor_ch: Chan<MonitorMsg>,
                       testfn: proc()) {
         spawn(proc() {
-            let mut task = task::task();
             let (p, c) = Chan::new();
             let mut reader = PortReader::new(p);
             let stdout = ChanWriter::new(c.clone());
             let stderr = ChanWriter::new(c);
-            match desc.name {
-                DynTestName(ref name) => task.name(name.clone()),
-                StaticTestName(name) => task.name(name),
-            }
+            let mut task = task::task().named(match desc.name {
+                DynTestName(ref name) => name.clone().into_maybe_owned(),
+                StaticTestName(name) => name.into_maybe_owned(),
+            });
             task.opts.stdout = Some(~stdout as ~Writer);
             task.opts.stderr = Some(~stderr as ~Writer);
             let result_future = task.future_result();

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -175,7 +175,6 @@ impl GreenTask {
                      opts: TaskOpts,
                      f: proc()) -> ~GreenTask {
         let TaskOpts {
-            watched: _watched,
             notify_chan, name, stack_size,
             stderr, stdout, logger,
         } = opts;

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -57,7 +57,6 @@ pub fn spawn(f: proc()) {
 /// inside the task.
 pub fn spawn_opts(opts: TaskOpts, f: proc()) {
     let TaskOpts {
-        watched: _watched,
         notify_chan, name, stack_size,
         logger, stderr, stdout,
     } = opts;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -371,8 +371,7 @@ pub fn monitor(f: proc()) {
     #[cfg(not(rtopt))]
     static STACK_SIZE: uint = 20000000; // 20MB
 
-    let mut task_builder = task::task();
-    task_builder.name("rustc");
+    let mut task_builder = task::task().named("rustc");
 
     // FIXME: Hacks on hacks. If the env is trying to override the stack size
     // then *don't* set it explicitly.

--- a/src/test/run-fail/fail-task-name-owned.rs
+++ b/src/test/run-fail/fail-task-name-owned.rs
@@ -13,9 +13,7 @@
 use std::task;
 
 fn main() {
-    let mut t = task::task();
-    t.name(~"owned name");
-    t.try(proc() {
+    task::task().named(~"owned name").try(proc() {
         fail!("test");
         1
     }).unwrap()

--- a/src/test/run-fail/fail-task-name-send-str.rs
+++ b/src/test/run-fail/fail-task-name-send-str.rs
@@ -11,9 +11,7 @@
 // error-pattern:task 'send name' failed at 'test'
 
 fn main() {
-    let mut t = ::std::task::task();
-    t.name("send name".into_maybe_owned());
-    t.try(proc() {
+    ::std::task::task().named("send name".into_maybe_owned()).try(proc() {
         fail!("test");
         3
     }).unwrap()

--- a/src/test/run-fail/fail-task-name-static.rs
+++ b/src/test/run-fail/fail-task-name-static.rs
@@ -11,9 +11,7 @@
 // error-pattern:task 'static name' failed at 'test'
 
 fn main() {
-    let mut t = ::std::task::task();
-    t.name("static name");
-    t.try(proc() {
+    ::std::task::task().named("static name").try(proc() {
         fail!("test");
     }).unwrap()
 }


### PR DESCRIPTION
Delete all the documentation from std::task that references linked
failure.

Tweak TaskBuilder to be more builder-like. `.name()` is now `.named()` and
`.add_wrapper()` is now `.with_wrapper()`. Remove `.watched()` and
`.unwatched()` as they didn't actually do anything.

Closes #6399.
