### PR TITLE
-Z debug-linker

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1013,12 +1013,13 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
     let mut cc_args = sess.targ_cfg.target_strs.cc_args.clone();
     cc_args.push_all_move(link_args(sess, dylib, tmpdir.path(),
                                     obj_filename, out_filename));
-    if (sess.opts.debugging_opts & session::PRINT_LINK_ARGS) != 0 {
-        println!("{} link args: '{}'", cc_prog, cc_args.connect("' '"));
-    }
-
     // May have not found libraries in the right formats.
     sess.abort_if_errors();
+
+    let debug_linker = (sess.opts.debugging_opts & session::DEBUG_LINKER) != 0;
+    if debug_linker { // show arguments we are passing to linker
+        sess.note(format!("{} arguments: '{}'", cc_prog, cc_args.connect("' '")));
+    }
 
     // Invoke the system linker
     debug!("{} {}", cc_prog, cc_args.connect(" "));
@@ -1031,6 +1032,9 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
                 sess.note(format!("{} arguments: '{}'", cc_prog, cc_args.connect("' '")));
                 sess.note(str::from_utf8_owned(prog.error + prog.output).unwrap());
                 sess.abort_if_errors();
+            }
+            else if debug_linker { // show linker output
+                sess.note(str::from_utf8_owned(prog.error + prog.output).unwrap());
             }
         },
         Err(e) => {

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -63,9 +63,9 @@ debugging_opts!(
         META_STATS,
         NO_OPT,
         GC,
-        PRINT_LINK_ARGS,
         PRINT_LLVM_PASSES,
-        LTO
+        LTO,
+        DEBUG_LINKER
     ]
     0
 )
@@ -90,13 +90,12 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, u64)] {
       COUNT_TYPE_SIZES),
      ("meta-stats", "gather metadata statistics", META_STATS),
      ("no-opt", "do not optimize, even if -O is passed", NO_OPT),
-     ("print-link-args", "Print the arguments passed to the linker",
-      PRINT_LINK_ARGS),
      ("gc", "Garbage collect shared data (experimental)", GC),
      ("print-llvm-passes",
       "Prints the llvm optimization passes being run",
       PRINT_LLVM_PASSES),
      ("lto", "Perform LLVM link-time optimizations", LTO),
+     ("debug-linker", "enable debug output from linker", DEBUG_LINKER)
     ]
 }
 


### PR DESCRIPTION
This adds "-Z debug-linker" switch, which:
- makes gcc output the command line it passes to ld,
- makes rustc echo gcc's stdout and stderr even when linking is successful.
