### PR TITLE
Reorganise std::unstable::mutex to add an RAII unlocker to the mutex & replace LittleLock

### DIFF
--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -15,7 +15,7 @@ use std::rt::rtio::{RemoteCallback, PausableIdleCallback, Callback, EventLoop};
 use std::rt::task::BlockedTask;
 use std::rt::task::Task;
 use std::sync::deque;
-use std::unstable::mutex::StaticNativeMutex;
+use std::unstable::mutex::NativeMutex;
 use std::unstable::raw;
 
 use TaskState;
@@ -764,7 +764,7 @@ impl Scheduler {
         // to it, but we're guaranteed that the task won't exit until we've
         // unlocked the lock so there's no worry of this memory going away.
         let cur = self.change_task_context(cur, next, |sched, mut task| {
-            let lock: *mut StaticNativeMutex = &mut task.nasty_deschedule_lock;
+            let lock: *mut NativeMutex = &mut task.nasty_deschedule_lock;
             unsafe {
                 let _guard = (*lock).lock();
                 f(sched, BlockedTask::block(task.swap()));

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -15,7 +15,7 @@ use std::rt::rtio::{RemoteCallback, PausableIdleCallback, Callback, EventLoop};
 use std::rt::task::BlockedTask;
 use std::rt::task::Task;
 use std::sync::deque;
-use std::unstable::mutex::Mutex;
+use std::unstable::mutex::StaticNativeMutex;
 use std::unstable::raw;
 
 use TaskState;
@@ -764,7 +764,7 @@ impl Scheduler {
         // to it, but we're guaranteed that the task won't exit until we've
         // unlocked the lock so there's no worry of this memory going away.
         let cur = self.change_task_context(cur, next, |sched, mut task| {
-            let lock: *mut Mutex = &mut task.nasty_deschedule_lock;
+            let lock: *mut StaticNativeMutex = &mut task.nasty_deschedule_lock;
             unsafe {
                 let _guard = (*lock).lock();
                 f(sched, BlockedTask::block(task.swap()));
@@ -1453,8 +1453,8 @@ mod test {
 
     #[test]
     fn test_spawn_sched_blocking() {
-        use std::unstable::mutex::{Mutex, MUTEX_INIT};
-        static mut LOCK: Mutex = MUTEX_INIT;
+        use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+        static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
         // Testing that a task in one scheduler can block in foreign code
         // without affecting other schedulers

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -25,7 +25,7 @@ use std::rt::local::Local;
 use std::rt::rtio;
 use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::task::TaskOpts;
-use std::unstable::mutex::StaticNativeMutex;
+use std::unstable::mutex::NativeMutex;
 use std::unstable::raw;
 
 use context::Context;
@@ -65,7 +65,7 @@ pub struct GreenTask {
     pool_id: uint,
 
     // See the comments in the scheduler about why this is necessary
-    nasty_deschedule_lock: StaticNativeMutex,
+    nasty_deschedule_lock: NativeMutex,
 }
 
 pub enum TaskType {
@@ -163,7 +163,7 @@ impl GreenTask {
             task_type: task_type,
             sched: None,
             handle: None,
-            nasty_deschedule_lock: unsafe { StaticNativeMutex::new() },
+            nasty_deschedule_lock: unsafe { NativeMutex::new() },
             task: Some(~Task::new()),
         }
     }
@@ -322,7 +322,7 @@ impl GreenTask {
     // uncontended except for when the task is rescheduled).
     fn reawaken_remotely(mut ~self) {
         unsafe {
-            let mtx = &mut self.nasty_deschedule_lock as *mut StaticNativeMutex;
+            let mtx = &mut self.nasty_deschedule_lock as *mut NativeMutex;
             let handle = self.handle.get_mut_ref() as *mut SchedHandle;
             let _guard = (*mtx).lock();
             (*handle).send(RunOnce(self));
@@ -476,12 +476,6 @@ impl Runtime for GreenTask {
     fn can_block(&self) -> bool { false }
 
     fn wrap(~self) -> ~Any { self as ~Any }
-}
-
-impl Drop for GreenTask {
-    fn drop(&mut self) {
-        unsafe { self.nasty_deschedule_lock.destroy(); }
-    }
 }
 
 #[cfg(test)]

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -324,9 +324,8 @@ impl GreenTask {
         unsafe {
             let mtx = &mut self.nasty_deschedule_lock as *mut Mutex;
             let handle = self.handle.get_mut_ref() as *mut SchedHandle;
-            (*mtx).lock();
+            let _guard = (*mtx).lock();
             (*handle).send(RunOnce(self));
-            (*mtx).unlock();
         }
     }
 }

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -25,7 +25,7 @@ use std::rt::local::Local;
 use std::rt::rtio;
 use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::task::TaskOpts;
-use std::unstable::mutex::Mutex;
+use std::unstable::mutex::StaticNativeMutex;
 use std::unstable::raw;
 
 use context::Context;
@@ -65,7 +65,7 @@ pub struct GreenTask {
     pool_id: uint,
 
     // See the comments in the scheduler about why this is necessary
-    nasty_deschedule_lock: Mutex,
+    nasty_deschedule_lock: StaticNativeMutex,
 }
 
 pub enum TaskType {
@@ -163,7 +163,7 @@ impl GreenTask {
             task_type: task_type,
             sched: None,
             handle: None,
-            nasty_deschedule_lock: unsafe { Mutex::new() },
+            nasty_deschedule_lock: unsafe { StaticNativeMutex::new() },
             task: Some(~Task::new()),
         }
     }
@@ -322,7 +322,7 @@ impl GreenTask {
     // uncontended except for when the task is rescheduled).
     fn reawaken_remotely(mut ~self) {
         unsafe {
-            let mtx = &mut self.nasty_deschedule_lock as *mut Mutex;
+            let mtx = &mut self.nasty_deschedule_lock as *mut StaticNativeMutex;
             let handle = self.handle.get_mut_ref() as *mut SchedHandle;
             let _guard = (*mtx).lock();
             (*handle).send(RunOnce(self));

--- a/src/libnative/bookkeeping.rs
+++ b/src/libnative/bookkeeping.rs
@@ -17,10 +17,10 @@
 //! The green counterpart for this is bookkeeping on sched pools.
 
 use std::sync::atomics;
-use std::unstable::mutex::{Mutex, MUTEX_INIT};
+use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
 
 static mut TASK_COUNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
-static mut TASK_LOCK: Mutex = MUTEX_INIT;
+static mut TASK_LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
 pub fn increment() {
     let _ = unsafe { TASK_COUNT.fetch_add(1, atomics::SeqCst) };

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -218,9 +218,9 @@ pub fn init() {
     }
 
     unsafe {
-        use std::unstable::mutex::{Mutex, MUTEX_INIT};
+        use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
         static mut INITIALIZED: bool = false;
-        static mut LOCK: Mutex = MUTEX_INIT;
+        static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
         let _guard = LOCK.lock();
         if !INITIALIZED {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -222,7 +222,7 @@ pub fn init() {
         static mut INITIALIZED: bool = false;
         static mut LOCK: Mutex = MUTEX_INIT;
 
-        LOCK.lock();
+        let _guard = LOCK.lock();
         if !INITIALIZED {
             let mut data: WSADATA = mem::init();
             let ret = WSAStartup(0x202,      // version 2.2
@@ -230,7 +230,6 @@ pub fn init() {
             assert_eq!(ret, 0);
             INITIALIZED = true;
         }
-        LOCK.unlock();
     }
 }
 

--- a/src/libnative/io/timer_helper.rs
+++ b/src/libnative/io/timer_helper.rs
@@ -22,7 +22,7 @@
 
 use std::cast;
 use std::rt;
-use std::unstable::mutex::{Mutex, MUTEX_INIT};
+use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
 
 use bookkeeping;
 use io::timer::{Req, Shutdown};
@@ -37,7 +37,7 @@ static mut HELPER_CHAN: *mut Chan<Req> = 0 as *mut Chan<Req>;
 static mut HELPER_SIGNAL: imp::signal = 0 as imp::signal;
 
 pub fn boot(helper: fn(imp::signal, Port<Req>)) {
-    static mut LOCK: Mutex = MUTEX_INIT;
+    static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
     static mut INITIALIZED: bool = false;
 
     unsafe {

--- a/src/libnative/io/timer_helper.rs
+++ b/src/libnative/io/timer_helper.rs
@@ -41,7 +41,7 @@ pub fn boot(helper: fn(imp::signal, Port<Req>)) {
     static mut INITIALIZED: bool = false;
 
     unsafe {
-        LOCK.lock();
+        let mut _guard = LOCK.lock();
         if !INITIALIZED {
             let (msgp, msgc) = Chan::new();
             // promote this to a shared channel
@@ -58,7 +58,6 @@ pub fn boot(helper: fn(imp::signal, Port<Req>)) {
             rt::at_exit(proc() { shutdown() });
             INITIALIZED = true;
         }
-        LOCK.unlock();
     }
 }
 

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -22,7 +22,7 @@ use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::rt::thread::Thread;
 use std::rt;
 use std::task::TaskOpts;
-use std::unstable::mutex::Mutex;
+use std::unstable::mutex::StaticNativeMutex;
 use std::unstable::stack;
 
 use io;
@@ -40,7 +40,7 @@ pub fn new(stack_bounds: (uint, uint)) -> ~Task {
 
 fn ops() -> ~Ops {
     ~Ops {
-        lock: unsafe { Mutex::new() },
+        lock: unsafe { StaticNativeMutex::new() },
         awoken: false,
         io: io::IoFactory::new(),
         // these *should* get overwritten
@@ -109,7 +109,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc()) {
 // This structure is the glue between channels and the 1:1 scheduling mode. This
 // structure is allocated once per task.
 struct Ops {
-    lock: Mutex,       // native synchronization
+    lock: StaticNativeMutex,       // native synchronization
     awoken: bool,      // used to prevent spurious wakeups
     io: io::IoFactory, // local I/O factory
 

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -22,7 +22,7 @@ use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::rt::thread::Thread;
 use std::rt;
 use std::task::TaskOpts;
-use std::unstable::mutex::StaticNativeMutex;
+use std::unstable::mutex::NativeMutex;
 use std::unstable::stack;
 
 use io;
@@ -40,7 +40,7 @@ pub fn new(stack_bounds: (uint, uint)) -> ~Task {
 
 fn ops() -> ~Ops {
     ~Ops {
-        lock: unsafe { StaticNativeMutex::new() },
+        lock: unsafe { NativeMutex::new() },
         awoken: false,
         io: io::IoFactory::new(),
         // these *should* get overwritten
@@ -109,7 +109,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc()) {
 // This structure is the glue between channels and the 1:1 scheduling mode. This
 // structure is allocated once per task.
 struct Ops {
-    lock: StaticNativeMutex,       // native synchronization
+    lock: NativeMutex,       // native synchronization
     awoken: bool,      // used to prevent spurious wakeups
     io: io::IoFactory, // local I/O factory
 
@@ -248,12 +248,6 @@ impl rt::Runtime for Ops {
 
     fn local_io<'a>(&'a mut self) -> Option<rtio::LocalIo<'a>> {
         Some(rtio::LocalIo::new(&mut self.io as &mut rtio::IoFactory))
-    }
-}
-
-impl Drop for Ops {
-    fn drop(&mut self) {
-        unsafe { self.lock.destroy() }
     }
 }
 

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -23,7 +23,7 @@
 use std::cast;
 use std::libc::{c_void, c_int};
 use std::rt::task::BlockedTask;
-use std::unstable::sync::LittleLock;
+use std::unstable::mutex::NativeMutex;
 use std::sync::arc::UnsafeArc;
 use mpsc = std::sync::mpsc_queue;
 
@@ -39,7 +39,7 @@ enum Message {
 
 struct State {
     handle: *uvll::uv_async_t,
-    lock: LittleLock, // see comments in async_cb for why this is needed
+    lock: NativeMutex, // see comments in async_cb for why this is needed
     queue: mpsc::Queue<Message>,
 }
 
@@ -112,7 +112,7 @@ impl QueuePool {
         let handle = UvHandle::alloc(None::<AsyncWatcher>, uvll::UV_ASYNC);
         let state = UnsafeArc::new(State {
             handle: handle,
-            lock: LittleLock::new(),
+            lock: unsafe {NativeMutex::new()},
             queue: mpsc::Queue::new(),
         });
         let q = ~QueuePool {

--- a/src/libstd/comm/shared.rs
+++ b/src/libstd/comm/shared.rs
@@ -28,7 +28,7 @@ use rt::local::Local;
 use rt::task::{Task, BlockedTask};
 use rt::thread::Thread;
 use sync::atomics;
-use unstable::mutex::Mutex;
+use unstable::mutex::StaticNativeMutex;
 use vec::OwnedVector;
 
 use mpsc = sync::mpsc_queue;
@@ -53,7 +53,7 @@ pub struct Packet<T> {
 
     // this lock protects various portions of this implementation during
     // select()
-    select_lock: Mutex,
+    select_lock: StaticNativeMutex,
 }
 
 pub enum Failure {
@@ -72,7 +72,7 @@ impl<T: Send> Packet<T> {
             channels: atomics::AtomicInt::new(2),
             port_dropped: atomics::AtomicBool::new(false),
             sender_drain: atomics::AtomicInt::new(0),
-            select_lock: unsafe { Mutex::new() },
+            select_lock: unsafe { StaticNativeMutex::new() },
         };
         // see comments in inherit_blocker about why we grab this lock
         unsafe { p.select_lock.lock_noguard() }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -44,7 +44,6 @@ use ptr;
 use str;
 use str::{Str, StrSlice};
 use fmt;
-use unstable::finally::Finally;
 use sync::atomics::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
 use path::{Path, GenericPath};
 use iter::Iterator;
@@ -146,15 +145,12 @@ Serialize access through a global lock.
 */
 fn with_env_lock<T>(f: || -> T) -> T {
     use unstable::mutex::{Mutex, MUTEX_INIT};
-    use unstable::finally::Finally;
 
     static mut lock: Mutex = MUTEX_INIT;
 
     unsafe {
-        return (|| {
-            lock.lock();
-            f()
-        }).finally(|| lock.unlock());
+        let _guard = lock.lock();
+        f()
     }
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -144,9 +144,9 @@ Accessing environment variables is not generally threadsafe.
 Serialize access through a global lock.
 */
 fn with_env_lock<T>(f: || -> T) -> T {
-    use unstable::mutex::{Mutex, MUTEX_INIT};
+    use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
 
-    static mut lock: Mutex = MUTEX_INIT;
+    static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
     unsafe {
         let _guard = lock.lock();

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -68,7 +68,6 @@ mod imp {
     use option::{Option, Some, None};
     use ptr::RawPtr;
     use iter::Iterator;
-    use unstable::finally::Finally;
     use unstable::mutex::{Mutex, MUTEX_INIT};
     use mem;
 
@@ -111,16 +110,10 @@ mod imp {
     }
 
     fn with_lock<T>(f: || -> T) -> T {
-        (|| {
-            unsafe {
-                lock.lock();
-                f()
-            }
-        }).finally(|| {
-            unsafe {
-                lock.unlock();
-            }
-        })
+        unsafe {
+            let _guard = lock.lock();
+            f()
+        }
     }
 
     fn get_global_ptr() -> *mut Option<~~[~[u8]]> {

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -68,11 +68,11 @@ mod imp {
     use option::{Option, Some, None};
     use ptr::RawPtr;
     use iter::Iterator;
-    use unstable::mutex::{Mutex, MUTEX_INIT};
+    use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     use mem;
 
     static mut global_args_ptr: uint = 0;
-    static mut lock: Mutex = MUTEX_INIT;
+    static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
     #[cfg(not(test))]
     pub unsafe fn init(argc: int, argv: **u8) {

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -152,8 +152,8 @@ pub mod dl {
     }
 
     pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, ~str> {
-        use unstable::mutex::{Mutex, MUTEX_INIT};
-        static mut lock: Mutex = MUTEX_INIT;
+        use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+        static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
         unsafe {
             // dlerror isn't thread safe, so we need to lock around this entire
             // sequence

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -157,7 +157,7 @@ pub mod dl {
         unsafe {
             // dlerror isn't thread safe, so we need to lock around this entire
             // sequence
-            lock.lock();
+            let _guard = lock.lock();
             let _old_error = dlerror();
 
             let result = f();
@@ -168,7 +168,7 @@ pub mod dl {
             } else {
                 Err(str::raw::from_c_str(last_error))
             };
-            lock.unlock();
+
             ret
         }
     }

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -459,7 +459,7 @@ mod test {
     use rt::thread::Thread;
 
     #[test]
-    fn somke_lock() {
+    fn smoke_lock() {
         static mut lock: Mutex = MUTEX_INIT;
         unsafe {
             let _guard = lock.lock();
@@ -467,7 +467,7 @@ mod test {
     }
 
     #[test]
-    fn somke_cond() {
+    fn smoke_cond() {
         static mut lock: Mutex = MUTEX_INIT;
         unsafe {
             let mut guard = lock.lock();
@@ -477,6 +477,32 @@ mod test {
             });
             guard.wait();
             drop(guard);
+
+            t.join();
+        }
+    }
+
+    #[test]
+    fn smoke_lock_noguard() {
+        static mut lock: Mutex = MUTEX_INIT;
+        unsafe {
+            lock.lock_noguard();
+            lock.unlock_noguard();
+        }
+    }
+
+    #[test]
+    fn smoke_cond_noguard() {
+        static mut lock: Mutex = MUTEX_INIT;
+        unsafe {
+            lock.lock_noguard();
+            let t = Thread::start(proc() {
+                lock.lock_noguard();
+                lock.signal_noguard();
+                lock.unlock_noguard();
+            });
+            lock.wait_noguard();
+            lock.unlock_noguard();
 
             t.join();
         }

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -13,10 +13,10 @@ use kinds::Send;
 use ops::Drop;
 use option::Option;
 use sync::arc::UnsafeArc;
-use unstable::mutex::{Mutex, LockGuard};
+use unstable::mutex::{StaticNativeMutex, LockGuard};
 
 pub struct LittleLock {
-    priv l: Mutex,
+    priv l: StaticNativeMutex,
 }
 
 pub struct LittleGuard<'a> {
@@ -31,7 +31,7 @@ impl Drop for LittleLock {
 
 impl LittleLock {
     pub fn new() -> LittleLock {
-        unsafe { LittleLock { l: Mutex::new() } }
+        unsafe { LittleLock { l: StaticNativeMutex::new() } }
     }
 
     pub unsafe fn lock<'a>(&'a mut self) -> LittleGuard<'a> {

--- a/src/libsync/sync/mutex.rs
+++ b/src/libsync/sync/mutex.rs
@@ -143,6 +143,7 @@ pub struct StaticMutex {
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
+#[must_use]
 pub struct Guard<'a> {
     priv lock: &'a mut StaticMutex,
 }

--- a/src/libsync/sync/mutex.rs
+++ b/src/libsync/sync/mutex.rs
@@ -133,7 +133,7 @@ pub struct StaticMutex {
     /// uint-cast of the native thread waiting for this mutex
     priv native_blocker: uint,
     /// an OS mutex used by native threads
-    priv lock: mutex::Mutex,
+    priv lock: mutex::StaticNativeMutex,
 
     /// A concurrent mpsc queue used by green threads, along with a count used
     /// to figure out when to dequeue and enqueue.
@@ -150,7 +150,7 @@ pub struct Guard<'a> {
 /// Static initialization of a mutex. This constant can be used to initialize
 /// other mutex constants.
 pub static MUTEX_INIT: StaticMutex = StaticMutex {
-    lock: mutex::MUTEX_INIT,
+    lock: mutex::NATIVE_MUTEX_INIT,
     state: atomics::INIT_ATOMIC_UINT,
     flavor: Unlocked,
     green_blocker: 0,
@@ -441,7 +441,7 @@ impl Mutex {
                 native_blocker: 0,
                 green_cnt: atomics::AtomicUint::new(0),
                 q: q::Queue::new(),
-                lock: unsafe { mutex::Mutex::new() },
+                lock: unsafe { mutex::StaticNativeMutex::new() },
             }
         }
     }

--- a/src/libsync/sync/mutex.rs
+++ b/src/libsync/sync/mutex.rs
@@ -288,11 +288,11 @@ impl StaticMutex {
     // `lock()` function on an OS mutex
     fn native_lock(&mut self, t: ~Task) {
         Local::put(t);
-        unsafe { self.lock.lock(); }
+        unsafe { self.lock.lock_noguard(); }
     }
 
     fn native_unlock(&mut self) {
-        unsafe { self.lock.unlock(); }
+        unsafe { self.lock.unlock_noguard(); }
     }
 
     fn green_lock(&mut self, t: ~Task) {


### PR DESCRIPTION
- adds a `LockGuard` type returned by `.lock` and `.trylock` that unlocks the mutex in the destructor
- renames `mutex::Mutex` to `StaticNativeMutex` 
- adds a `NativeMutex` type with a destructor
- removes `LittleLock`
- adds `#[must_use]` to `sync::mutex::Guard` to remind people to use it
