### PR TITLE
Suggest explicit lifetime parameter

### DIFF
--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -202,6 +202,7 @@ pub enum SubregionOrigin {
 /// Reasons to create a region inference variable
 ///
 /// See `error_reporting.rs` for more details
+#[deriving(Clone)]
 pub enum RegionVariableOrigin {
     // Region variables created for ill-categorized reasons,
     // mostly indicates places in need of refactoring

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -398,6 +398,11 @@ impl<T> Vec<T> {
         self.insert(0, element)
     }
 
+    #[inline]
+    pub fn shift(&mut self) -> Option<T> {
+        self.remove(0)
+    }
+
     pub fn insert(&mut self, index: uint, element: T) {
         let len = self.len();
         assert!(index <= len);
@@ -417,6 +422,30 @@ impl<T> Vec<T> {
                 move_val_init(&mut *p, element);
             }
             self.set_len(len + 1);
+        }
+    }
+
+    fn remove(&mut self, index: uint) -> Option<T> {
+        let len = self.len();
+        if index < len {
+            unsafe { // infallible
+                let ret;
+                {
+                    let slice = self.as_mut_slice();
+                    // the place we are taking from.
+                    let ptr = slice.as_mut_ptr().offset(index as int);
+                    // copy it out, unsafely having a copy of the value on
+                    // the stack and in the vector at the same time.
+                    ret = Some(ptr::read(ptr as *T));
+
+                    // Shift everything down to fill in that spot.
+                    ptr::copy_memory(ptr, &*ptr.offset(1), len - index - 1);
+                }
+                self.set_len(len - 1);
+                ret
+            }
+        } else {
+            None
         }
     }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -11,6 +11,7 @@
 use ast::*;
 use ast;
 use ast_util;
+use codemap;
 use codemap::Span;
 use opt_vec;
 use parse::token;
@@ -206,6 +207,12 @@ pub fn ident_to_pat(id: NodeId, s: Span, i: Ident) -> @Pat {
     @ast::Pat { id: id,
                 node: PatIdent(BindByValue(MutImmutable), ident_to_path(s, i), None),
                 span: s }
+}
+
+pub fn name_to_dummy_lifetime(name: Name) -> Lifetime {
+    Lifetime { id: DUMMY_NODE_ID,
+               span: codemap::DUMMY_SP,
+               name: name }
 }
 
 pub fn is_unguarded(a: &Arm) -> bool {
@@ -681,6 +688,20 @@ pub fn lit_is_str(lit: @Lit) -> bool {
     match lit.node {
         LitStr(..) => true,
         _ => false,
+    }
+}
+
+pub fn get_inner_tys(ty: P<Ty>) -> Vec<P<Ty>> {
+    match ty.node {
+        ast::TyRptr(_, mut_ty) | ast::TyPtr(mut_ty) => {
+            vec!(mut_ty.ty)
+        }
+        ast::TyBox(ty)
+        | ast::TyVec(ty)
+        | ast::TyUniq(ty)
+        | ast::TyFixedLengthVec(ty, _) => vec!(ty),
+        ast::TyTup(ref tys) => tys.clone(),
+        _ => Vec::new()
     }
 }
 

--- a/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param.rs
+++ b/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param.rs
@@ -1,0 +1,58 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+struct Foo<'x> { bar: int }
+fn foo1(x: &Foo) -> &int {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn foo1<'a>(x: &'a Foo) -> &'a int
+    &x.bar //~ ERROR: cannot infer
+}
+
+fn foo2<'a, 'b>(x: &'a Foo) -> &'b int {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn foo2<'c>(x: &'c Foo) -> &'c int
+    &x.bar //~ ERROR: cannot infer
+}
+
+fn foo3(x: &Foo) -> (&int, &int) {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn foo3<'a>(x: &'a Foo) -> (&'a int, &'a int)
+    (&x.bar, &x.bar) //~ ERROR: cannot infer
+    //~^ ERROR: cannot infer
+}
+
+fn foo4<'a, 'b>(x: &'a Foo) -> (&'b int, &'a int, &int) {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn foo4<'c>(x: &'c Foo) -> (&'c int, &'c int, &'c int)
+    (&x.bar, &x.bar, &x.bar) //~ ERROR: cannot infer
+    //~^ ERROR: cannot infer
+}
+
+fn foo5(x: &int) -> &int {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn foo5<'a>(x: &'a int) -> &'a int
+    x //~ ERROR: mismatched types
+    //~^ ERROR: cannot infer
+}
+
+struct Bar<'x, 'y, 'z> { bar: &'y int, baz: int }
+fn bar1(x: &Bar) -> (&int, &int, &int) {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn bar1<'a, 'b, 'c, 'd>(x: &'d Bar<'b, 'a, 'c>) -> (&'a int, &'d int, &'d int)
+    (x.bar, &x.baz, &x.baz) //~ ERROR: mismatched types
+    //~^ ERROR: cannot infer
+    //~^^ ERROR: cannot infer
+}
+
+fn bar2<'a, 'b, 'c>(x: &Bar<'a, 'b, 'c>) -> (&int, &int, &int) {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn bar2<'d, 'e, 'a, 'c>(x: &'e Bar<'a, 'd, 'c>) -> (&'d int, &'e int, &'e int)
+    (x.bar, &x.baz, &x.baz) //~ ERROR: mismatched types
+    //~^ ERROR: cannot infer
+    //~^^ ERROR: cannot infer
+}
+
+
+fn main() {}


### PR DESCRIPTION
For the following code snippet:

``` rust
struct Foo { bar: int }
fn foo1(x: &Foo) -> &int {
    &x.bar
}
```

This PR generates the following error message:

``` rust
test.rs:2:1: 4:2 note: consider using an explicit lifetime parameter as shown: fn foo1<'a>(x: &'a Foo) -> &'a int
test.rs:2 fn foo1(x: &Foo) -> &int {
test.rs:3     &x.bar
test.rs:4 }
test.rs:3:5: 3:11 error: cannot infer an appropriate lifetime for borrow expression due to conflicting requirements
test.rs:3     &x.bar
              ^~~~~~
```

Currently it does not support methods.
