### PR TITLE
Lift $dst outside the closure in write!

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -145,16 +145,18 @@ macro_rules! format(
 
 #[macro_export]
 macro_rules! write(
-    ($dst:expr, $($arg:tt)*) => (
-        format_args!(|args| { ::std::fmt::write($dst, args) }, $($arg)*)
-    )
+    ($dst:expr, $($arg:tt)*) => ({
+        let dst: &mut ::std::io::Writer = $dst;
+        format_args!(|args| { ::std::fmt::write(dst, args) }, $($arg)*)
+    })
 )
 
 #[macro_export]
 macro_rules! writeln(
-    ($dst:expr, $($arg:tt)*) => (
-        format_args!(|args| { ::std::fmt::writeln($dst, args) }, $($arg)*)
-    )
+    ($dst:expr, $($arg:tt)*) => ({
+        let dst: &mut ::std::io::Writer = $dst;
+        format_args!(|args| { ::std::fmt::writeln(dst, args) }, $($arg)*)
+    })
 )
 
 #[macro_export]

--- a/src/test/run-pass/colorful-write-macros.rs
+++ b/src/test/run-pass/colorful-write-macros.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[allow(unused_must_use, dead_code)];
+
+use std::io::MemWriter;
+
+struct Foo<'a> {
+    writer: &'a mut Writer,
+    other: &'a str,
+}
+
+fn borrowing_writer_from_struct_and_formatting_struct_field(foo: Foo) {
+    write!(foo.writer, "{}", foo.other);
+}
+
+pub fn main() {
+    let mut w = MemWriter::new();
+    write!(&mut w as &mut Writer, "");
+    write!(&mut w, ""); // should coerce
+}


### PR DESCRIPTION
If you were writing to something along the lines of `self.foo` then with the new
closure rules it meant that you were borrowing `self` for the entirety of the
closure, meaning that you couldn't format other fields of `self` at the same
time as writing to a buffer contained in `self`.

By lifting the borrow outside of the closure the borrow checker can better
understand that you're only borrowing one of the fields at a time. This had to
use type ascription as well in order to preserve trait object coercions.
