### PR TITLE
Added more scripts to tidy check

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -247,6 +247,16 @@ tidy:
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)find $(S)src/etc -name '*.py' \
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
+		$(Q)find $(S)src/doc -name '*.js' \
+		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
+		$(Q)find $(S)src/etc -name '*.sh' \
+		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
+		$(Q)find $(S)src/etc -name '*.pl' \
+		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
+		$(Q)find $(S)src/etc -name '*.c' \
+		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
+		$(Q)find $(S)src/etc -name '*.h' \
+		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)echo $(ALL_CS) \
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)echo $(ALL_HS) \

--- a/src/doc/lib/codemirror-node.js
+++ b/src/doc/lib/codemirror-node.js
@@ -1,3 +1,23 @@
+// Copyright (C) 2013 by Marijn Haverbeke <marijnh@gmail.com> and others
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 exports.htmlEscape = function(text) {
   var replacements = {"<": "&lt;", ">": "&gt;",
                       "&": "&amp;", "\"": "&quot;"};
@@ -105,7 +125,8 @@ exports.runMode = function(string, modespec, callback) {
       if (string == "\n")
         accum.push("<br>");
       else if (style)
-        accum.push("<span class=\"cm-" + exports.htmlEscape(style) + "\">" + exports.htmlEscape(string) + "</span>");
+        accum.push("<span class=\"cm-" + exports.htmlEscape(style) + "\">" +
+                    exports.htmlEscape(string) + "</span>");
       else
         accum.push(exports.htmlEscape(string));
     }

--- a/src/doc/lib/codemirror-rust.js
+++ b/src/doc/lib/codemirror-rust.js
@@ -1,3 +1,23 @@
+// Copyright (C) 2013 by Marijn Haverbeke <marijnh@gmail.com> and others
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 CodeMirror.defineMode("rust", function() {
   var indentUnit = 4, altIndentUnit = 2;
   var valKeywords = {
@@ -422,7 +442,8 @@ CodeMirror.defineMode("rust", function() {
           type = lexical.type, closing = firstChar == type;
       if (type == "stat") return lexical.indented + indentUnit;
       if (lexical.align) return lexical.column + (closing ? 0 : 1);
-      return lexical.indented + (closing ? 0 : (lexical.info == "match" ? altIndentUnit : indentUnit));
+      return lexical.indented +
+        (closing ? 0 : (lexical.info == "match" ? altIndentUnit : indentUnit));
     },
 
     electricChars: "{}"

--- a/src/doc/prep.js
+++ b/src/doc/prep.js
@@ -1,5 +1,15 @@
 #!/usr/local/bin/node
 
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 /***
  * Pandoc-style markdown preprocessor that drops extra directives
  * included for running doc code, and that optionally, when

--- a/src/etc/adb_run_wrapper.sh
+++ b/src/etc/adb_run_wrapper.sh
@@ -1,3 +1,14 @@
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+#
+# ignore-tidy-linelength
 #
 # usage : adb_run_wrapper [test dir - where test executables exist] [test executable]
 #

--- a/src/etc/check-links.pl
+++ b/src/etc/check-links.pl
@@ -1,4 +1,13 @@
 #!/usr/bin/perl -w
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 
 my $file = $ARGV[0];
 

--- a/src/etc/cmathconsts.c
+++ b/src/etc/cmathconsts.c
@@ -1,3 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+//
 // This is a helper C program for generating required math constants
 //
 // Should only be required when porting to a different target architecture

--- a/src/etc/emacs/run_rust_emacs_tests.sh
+++ b/src/etc/emacs/run_rust_emacs_tests.sh
@@ -1,3 +1,13 @@
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+#
 # This runs the test for emacs rust-mode.
 # It must be possible to find emacs via PATH.
 emacs -batch -l rust-mode.el -l rust-mode-tests.el -f ert-run-tests-batch-and-exit

--- a/src/etc/libc.c
+++ b/src/etc/libc.c
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 /*
  * This calculates the platform-variable portion of the libc module.
  * Move code in here only as you discover it is platform-variable.

--- a/src/etc/licenseck.py
+++ b/src/etc/licenseck.py
@@ -33,6 +33,8 @@ license4 = """ The Rust Project Developers. See the COPYRIGHT
 """
 
 exceptions = [
+    "doc/lib/codemirror-node.js", # MIT
+    "doc/lib/codemirror-rust.js", # MIT
     "rt/rust_android_dummy.cpp", # BSD, chromium
     "rt/rust_android_dummy.h", # BSD, chromium
     "rt/isaac/randport.cpp", # public domain

--- a/src/etc/local_stage0.sh
+++ b/src/etc/local_stage0.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
 
 TARG_DIR=$1
 PREFIX=$2
@@ -10,22 +19,22 @@ LIB_PREFIX=lib
 OS=`uname -s`
 case $OS in
     ("Linux"|"FreeBSD")
-	BIN_SUF=
-	LIB_SUF=.so
-	break
-	;;
+    BIN_SUF=
+    LIB_SUF=.so
+    break
+    ;;
     ("Darwin")
-	BIN_SUF=
-	LIB_SUF=.dylib
-	break
-	;;
+    BIN_SUF=
+    LIB_SUF=.dylib
+    break
+    ;;
     (*)
-	BIN_SUF=.exe
-	LIB_SUF=.dll
-	LIB_DIR=bin
-	LIB_PREFIX=
-	break
-	;;
+    BIN_SUF=.exe
+    LIB_SUF=.dll
+    LIB_DIR=bin
+    LIB_PREFIX=
+    break
+    ;;
 esac
 
 if [ -z $PREFIX ]; then

--- a/src/etc/mingw-fix-include/bits/c++config.h
+++ b/src/etc/mingw-fix-include/bits/c++config.h
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #ifndef _FIX_CXXCONFIG_H
 #define _FIX_CXXCONFIG_H 1
 

--- a/src/etc/mingw-fix-include/winbase.h
+++ b/src/etc/mingw-fix-include/winbase.h
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #ifndef _FIX_WINBASE_H
 #define _FIX_WINBASE_H 1
 

--- a/src/etc/mingw-fix-include/winsock2.h
+++ b/src/etc/mingw-fix-include/winsock2.h
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #ifndef _FIX_WINSOCK2_H
 #define _FIX_WINSOCK2_H 1
 


### PR DESCRIPTION
Extends the license and formatting check to `*.js` files in `src/doc` and `*.sh`, `*.pl`, `*.c`, and `*.h` files in `src/etc`. As best as I could tell, these files should be covered under the Rust project license.

cc @brson: Do any other scripts need a license? I'd like to double-check that this PR closes #4534.
