### PR TITLE
Cleaning up core crates dependencies on libextra

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -60,9 +60,9 @@ DEPS_extra := std term sync serialize getopts collections
 DEPS_green := std
 DEPS_rustuv := std native:uv native:uv_support
 DEPS_native := std
-DEPS_syntax := std extra term serialize collections
+DEPS_syntax := std term serialize collections
 DEPS_rustc := syntax native:rustllvm flate arena serialize sync getopts \
-              collections
+              collections extra
 DEPS_rustdoc := rustc native:sundown serialize sync getopts collections
 DEPS_flate := std native:miniz
 DEPS_arena := std collections

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -15,7 +15,7 @@ use syntax::visit;
 use syntax::visit::Visitor;
 
 use std::local_data;
-use extra;
+use extra::time;
 
 pub fn time<T, U>(do_it: bool, what: &str, u: U, f: |U| -> T) -> T {
     local_data_key!(depth: uint);
@@ -24,9 +24,9 @@ pub fn time<T, U>(do_it: bool, what: &str, u: U, f: |U| -> T) -> T {
     let old = local_data::get(depth, |d| d.map(|a| *a).unwrap_or(0));
     local_data::set(depth, old + 1);
 
-    let start = extra::time::precise_time_s();
+    let start = time::precise_time_s();
     let rv = f(u);
-    let end = extra::time::precise_time_s();
+    let end = time::precise_time_s();
 
     println!("{}time: {:3.3f} s\t{}", "  ".repeat(old), end - start, what);
     local_data::set(depth, old);

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -32,7 +32,7 @@ This API is completely unstable and subject to change.
 
 #[deny(non_camel_case_types)];
 
-extern mod extra;
+#[cfg(test)] extern mod extra;
 extern mod serialize;
 extern mod term;
 extern mod collections;


### PR DESCRIPTION
A key part of splitting, and therefore removing libextra (#8784) would be to remove other core crates' dependencies on it.

I've started off with libsyntax, which didn't even require anything from libextra.

When I went to go and cleanup librustc, I came across a few requirements, and I'm not sure how these should be handled. Some just don't seem like they need to be in their own crate:
- `extra::time`. My initial thought would be a `libtime`, but perhaps it could go in `libstd`?
- `extra::tempfile`. I think this should be part of `std::io::fs`, but I wanted to check first.
- `extra::enum_set`. I honestly have no idea where this would belong.

Any input on where those three should go?
