### PR TITLE
Enable 64-bit checked multiplication on 32-bit

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1122,13 +1122,6 @@ fn link_args(sess: Session,
         args.push(~"-Wl,--allow-multiple-definition");
     }
 
-    // Stack growth requires statically linking a __morestack function
-    args.push(~"-lmorestack");
-    // compiler-rt contains implementations of low-level LLVM helpers
-    // It should go before platform and user libraries, so it has first dibs
-    // at resolving symbols that also appear in libgcc.
-    args.push(~"-lcompiler-rt");
-
     add_local_native_libraries(&mut args, sess);
     add_upstream_rust_crates(&mut args, sess, dylib, tmpdir);
     add_upstream_native_libraries(&mut args, sess);
@@ -1162,6 +1155,13 @@ fn link_args(sess: Session,
     if !sess.opts.cg.no_rpath {
         args.push_all(rpath::get_rpath_flags(sess, out_filename));
     }
+
+    // Stack growth requires statically linking a __morestack function
+    args.push(~"-lmorestack");
+    // compiler-rt contains implementations of low-level LLVM helpers
+    // It should go before platform and user libraries, so it has first dibs
+    // at resolving symbols that also appear in libgcc.
+    args.push(~"-lcompiler-rt");
 
     // Finally add all the linker arguments provided on the command line along
     // with any #[link_args] attributes found inside the crate

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -60,8 +60,6 @@ impl CheckedSub for i64 {
     }
 }
 
-// FIXME: #8449: should not be disabled on 32-bit
-#[cfg(target_word_size = "64")]
 impl CheckedMul for i64 {
     #[inline]
     fn checked_mul(&self, v: &i64) -> Option<i64> {

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -426,7 +426,7 @@ pub trait Int: Integer
              + Bitwise
              + CheckedAdd
              + CheckedSub
-             // + CheckedMul // FIXME #8849: currently not impled on 32-bit
+             + CheckedMul
              + CheckedDiv {}
 
 /// Returns the smallest power of 2 greater than or equal to `n`.

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -47,8 +47,6 @@ impl CheckedSub for u64 {
     }
 }
 
-// FIXME: #8449: should not be disabled on 32-bit
-#[cfg(target_word_size = "64")]
 impl CheckedMul for u64 {
     #[inline]
     fn checked_mul(&self, v: &u64) -> Option<u64> {


### PR DESCRIPTION
This was just waiting for compiler-rt support, which was added in #12027

Closes #8449
