### PR TITLE
Update restrictions on rustdoc source rendering

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -418,8 +418,10 @@ impl<'a> SourceCollector<'a> {
         // can't have the source to it anyway.
         let contents = match File::open(&p).read_to_end() {
             Ok(r) => r,
-            // eew macro hacks
-            Err(..) if filename == "<std-macros>" => return Ok(()),
+            // macros from other libraries get special filenames which we can
+            // safely ignore
+            Err(..) if filename.starts_with("<") &&
+                       filename.ends_with("macros>") => return Ok(()),
             Err(e) => return Err(e)
         };
         let contents = str::from_utf8_owned(contents).unwrap();


### PR DESCRIPTION
The std macros used to be injected with a filename of "<std-macros>", but macros
are now injected with a filename of "<{} macros>" where `{}` is filled in with
the crate name. This updates rustdoc to understand this new system so it'll
render source more frequently.
