### PR TITLE
Changed NonCamelCaseTypes lint to warn by default

### DIFF
--- a/src/doc/guide-macros.md
+++ b/src/doc/guide-macros.md
@@ -11,17 +11,17 @@ which both pattern-match on their input and both return early in one case,
 doing nothing otherwise:
 
 ~~~~
-# enum t { special_a(uint), special_b(uint) };
+# enum T { SpecialA(uint), SpecialB(uint) };
 # fn f() -> uint {
-# let input_1 = special_a(0);
-# let input_2 = special_a(0);
+# let input_1 = SpecialA(0);
+# let input_2 = SpecialA(0);
 match input_1 {
-    special_a(x) => { return x; }
+    SpecialA(x) => { return x; }
     _ => {}
 }
 // ...
 match input_2 {
-    special_b(x) => { return x; }
+    SpecialB(x) => { return x; }
     _ => {}
 }
 # return 0u;
@@ -37,12 +37,12 @@ lightweight custom syntax extensions, themselves defined using the
 the pattern in the above code:
 
 ~~~~
-# enum t { special_a(uint), special_b(uint) };
+# enum T { SpecialA(uint), SpecialB(uint) };
 # fn f() -> uint {
-# let input_1 = special_a(0);
-# let input_2 = special_a(0);
+# let input_1 = SpecialA(0);
+# let input_2 = SpecialA(0);
 macro_rules! early_return(
-    ($inp:expr $sp:ident) => ( // invoke it like `(input_5 special_e)`
+    ($inp:expr $sp:ident) => ( // invoke it like `(input_5 SpecialE)`
         match $inp {
             $sp(x) => { return x; }
             _ => {}
@@ -50,9 +50,9 @@ macro_rules! early_return(
     );
 )
 // ...
-early_return!(input_1 special_a);
+early_return!(input_1 SpecialA);
 // ...
-early_return!(input_2 special_b);
+early_return!(input_2 SpecialB);
 # return 0;
 # }
 ~~~~
@@ -155,10 +155,10 @@ separator token (a comma-separated list could be written `$(...),*`), and `+`
 instead of `*` to mean "at least one".
 
 ~~~~
-# enum t { special_a(uint),special_b(uint),special_c(uint),special_d(uint)};
+# enum T { SpecialA(uint),SpecialB(uint),SpecialC(uint),SpecialD(uint)};
 # fn f() -> uint {
-# let input_1 = special_a(0);
-# let input_2 = special_a(0);
+# let input_1 = SpecialA(0);
+# let input_2 = SpecialA(0);
 macro_rules! early_return(
     ($inp:expr, [ $($sp:ident)|+ ]) => (
         match $inp {
@@ -170,9 +170,9 @@ macro_rules! early_return(
     );
 )
 // ...
-early_return!(input_1, [special_a|special_c|special_d]);
+early_return!(input_1, [SpecialA|SpecialC|SpecialD]);
 // ...
-early_return!(input_2, [special_b]);
+early_return!(input_2, [SpecialB]);
 # return 0;
 # }
 ~~~~
@@ -215,14 +215,14 @@ solves the problem.
 Now consider code like the following:
 
 ~~~~
-# enum t1 { good_1(t2, uint), bad_1 };
-# struct t2 { body: t3 }
-# enum t3 { good_2(uint), bad_2};
-# fn f(x: t1) -> uint {
+# enum T1 { Good1(T2, uint), Bad1};
+# struct T2 { body: T3 }
+# enum T3 { Good2(uint), Bad2};
+# fn f(x: T1) -> uint {
 match x {
-    good_1(g1, val) => {
+    Good1(g1, val) => {
         match g1.body {
-            good_2(result) => {
+            Good2(result) => {
                 // complicated stuff goes here
                 return result + val;
             },
@@ -261,13 +261,13 @@ macro_rules! biased_match (
     )
 )
 
-# enum t1 { good_1(t2, uint), bad_1 };
-# struct t2 { body: t3 }
-# enum t3 { good_2(uint), bad_2};
-# fn f(x: t1) -> uint {
-biased_match!((x)       ~ (good_1(g1, val)) else { return 0 };
+# enum T1 { Good1(T2, uint), Bad1};
+# struct T2 { body: T3 }
+# enum T3 { Good2(uint), Bad2};
+# fn f(x: T1) -> uint {
+biased_match!((x)       ~ (Good1(g1, val)) else { return 0 };
               binds g1, val )
-biased_match!((g1.body) ~ (good_2(result) )
+biased_match!((g1.body) ~ (Good2(result) )
                   else { fail!("Didn't get good_2") };
               binds result )
 // complicated stuff goes here
@@ -365,13 +365,13 @@ macro_rules! biased_match (
 )
 
 
-# enum t1 { good_1(t2, uint), bad_1 };
-# struct t2 { body: t3 }
-# enum t3 { good_2(uint), bad_2};
-# fn f(x: t1) -> uint {
+# enum T1 { Good1(T2, uint), Bad1};
+# struct T2 { body: T3 }
+# enum T3 { Good2(uint), Bad2};
+# fn f(x: T1) -> uint {
 biased_match!(
-    (x)       ~ (good_1(g1, val)) else { return 0 };
-    (g1.body) ~ (good_2(result) ) else { fail!("Didn't get good_2") };
+    (x)       ~ (Good1(g1, val)) else { return 0 };
+    (g1.body) ~ (Good2(result) ) else { fail!("Didn't get Good2") };
     binds val, result )
 // complicated stuff goes here
 return result + val;

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -470,7 +470,7 @@ Two examples of paths with type arguments:
 # use std::hashmap::HashMap;
 # fn f() {
 # fn id<T>(t: T) -> T { t }
-type t = HashMap<int,~str>;  // Type arguments used in a type expression
+type T = HashMap<int,~str>;  // Type arguments used in a type expression
 let x = id::<int>(10);         // Type arguments used in a call expression
 # }
 ~~~~
@@ -701,7 +701,7 @@ An example of a module:
 
 ~~~~
 mod math {
-    type complex = (f64, f64);
+    type Complex = (f64, f64);
     fn sin(f: f64) -> f64 {
         ...
 # fail!();
@@ -2824,13 +2824,13 @@ provided by an implementation of `std::iter::Iterator`.
 An example of a for loop over the contents of a vector:
 
 ~~~~
-# type foo = int;
-# fn bar(f: foo) { }
+# type Foo = int;
+# fn bar(f: Foo) { }
 # let a = 0;
 # let b = 0;
 # let c = 0;
 
-let v: &[foo] = &[a, b, c];
+let v: &[Foo] = &[a, b, c];
 
 for e in v.iter() {
     bar(*e);

--- a/src/libnative/io/file.rs
+++ b/src/libnative/io/file.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 //! Blocking posix-based file I/O
+
+#[allow(non_camel_case_types)];
 
 use std::sync::arc::UnsafeArc;
 use std::c_str::CString;

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+#[allow(non_camel_case_types)];
 
 use std::cast;
 use std::io::net::ip;

--- a/src/libnative/io/timer_helper.rs
+++ b/src/libnative/io/timer_helper.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -19,6 +19,8 @@
 //! `shutdown` is only called when the entire program is finished. No new timers
 //! can be created in the future and there must be no active timers at that
 //! time.
+
+#[allow(non_camel_case_types)];
 
 use std::cast;
 use std::rt;
@@ -98,6 +100,7 @@ mod imp {
 
     use io::file::FileDesc;
 
+    #[allow(non_camel_case_types)]
     pub type signal = libc::c_int;
 
     pub fn new() -> (signal, signal) {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -46,6 +46,8 @@
 //!
 //! Note that all time units in this file are in *milliseconds*.
 
+#[allow(non_camel_case_types)];
+
 use std::comm::Data;
 use std::hashmap::HashMap;
 use std::libc;

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -27,6 +27,8 @@
 //! to block the calling thread.
 //!
 //! As with timer_other, all units in this file are in units of millseconds.
+
+#[allow(non_camel_case_types)];
 
 use std::comm::Data;
 use std::libc;

--- a/src/librustc/back/target_strs.rs
+++ b/src/librustc/back/target_strs.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 pub struct t {
     module_asm: ~str,

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[allow(non_uppercase_pattern_statics)];
+#[allow(non_camel_case_types)];
 
 use std::c_str::ToCStr;
 use std::cell::RefCell;

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+#[allow(non_camel_case_types)];
 
 use std::cast;
 use syntax::crateid::CrateId;

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+#[allow(non_camel_case_types)];
 
 //! Validates all used crates and extern libraries and loads their metadata
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -10,6 +10,7 @@
 
 // Searching for information from the cstore
 
+#[allow(non_camel_case_types)];
 
 use metadata::common::*;
 use metadata::cstore;

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 // The crate store - a central repo for information collected about external
 // crates and libraries

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,7 @@
 
 // Decoding metadata from a single crate's metadata
 
+#[allow(non_camel_case_types)];
 
 use metadata::cstore::crate_metadata;
 use metadata::common::*;

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // Metadata encoding
 
 #[allow(unused_must_use)]; // everything is just a MemWriter, can't fail
+#[allow(non_camel_case_types)];
 
 use metadata::common::*;
 use metadata::cstore;

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+#[allow(non_camel_case_types)];
 
 use std::cell::RefCell;
 use std::option;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -14,6 +14,7 @@
 // tjc note: Would be great to have a `match check` macro equivalent
 // for some of these
 
+#[allow(non_camel_case_types)];
 
 use middle::ty;
 

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // Type encoding
 
 #[allow(unused_must_use)]; // as with encoding, everything is a no-fail MemWriter
+#[allow(non_camel_case_types)];
 
 use std::cell::RefCell;
 use std::hashmap::HashMap;

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use c = metadata::common;
 use cstore = metadata::cstore;

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,7 @@
 
 /*! See doc.rs for a thorough explanation of the borrow checker */
 
+#[allow(non_camel_case_types)];
 
 use mc = middle::mem_categorization;
 use middle::ty;

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use middle::const_eval::{compare_const_vals, lookup_const_by_id};
 use middle::const_eval::{eval_const_expr, const_val, const_bool, const_float};

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use metadata::csearch;
 use middle::astencode;

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // A pass that annotates for each loops and functions with the free
 // variables that they contain.
 
+#[allow(non_camel_case_types)];
 
 use middle::resolve;
 use middle::ty;

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -33,6 +33,8 @@
 //! modify the Context visitor appropriately. If you're adding lints from the
 //! Context itself, span_lint should be used instead of add_lint.
 
+#[allow(non_camel_case_types)];
+
 use driver::session;
 use metadata::csearch;
 use middle::dead::DEAD_CODE_LINT_STR;
@@ -189,7 +191,7 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
      LintSpec {
         lint: NonCamelCaseTypes,
         desc: "types, variants and traits should have camel case names",
-        default: allow
+        default: warn
      }),
 
     ("non_uppercase_statics",

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -60,6 +60,7 @@
  * tied to `x`. The type of `x'` will be a borrowed pointer.
  */
 
+#[allow(non_camel_case_types)];
 
 use middle::ty;
 use util::ppaux::{ty_to_str, region_ptr_to_str, Repr};

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
+
 use driver::session::Session;
 use metadata::csearch;
 use metadata::decoder::{DefLike, DlDef, DlField, DlImpl};

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -192,6 +192,7 @@
  *
  */
 
+#[allow(non_camel_case_types)];
 
 use back::abi;
 use lib::llvm::{llvm, ValueRef, BasicBlockRef};

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -23,6 +23,7 @@
 //     but one TypeRef corresponds to many `ty::t`s; for instance, tup(int, int,
 //     int) and rec(x=int, y=int, z=int) will have the same TypeRef.
 
+#[allow(non_camel_case_types)];
 
 use back::link::{mangle_exported_name};
 use back::{link, abi};

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+#[allow(non_camel_case_types)];
 
 //! Code that is useful in various trans modules.
 

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -30,6 +30,8 @@
  *
  * See doc.rs for more comments.
  */
+
+#[allow(non_camel_case_types)];
 
 use back::abi;
 use back::link;

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use back::abi;
 use lib;

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use middle::trans::adt;
 use middle::trans::common::*;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
+
 use driver::session;
 use metadata::csearch;
 use metadata;

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use middle::pat_util::{PatIdMap, pat_id_map, pat_is_binding, pat_is_const};
 use middle::ty;

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,7 @@
 
 /*! See doc.rs for documentation */
 
+#[allow(non_camel_case_types)];
 
 pub use middle::ty::IntVarValue;
 pub use middle::typeck::infer::resolve::resolve_and_force_all_but_regions;

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -59,6 +59,7 @@ independently:
 
 */
 
+#[allow(non_camel_case_types)];
 
 use driver::session;
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(non_camel_case_types)];
 
 use syntax::ast;
 use syntax::codemap::{Span};

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -24,6 +24,8 @@
 //! // ... something using html
 //! ```
 
+#[allow(non_camel_case_types)];
+
 use std::cast;
 use std::fmt;
 use std::io;

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -15,12 +15,12 @@ use dl = std::unstable::dynamic_lib;
 
 pub type PluginJson = Option<(~str, json::Json)>;
 pub type PluginResult = (clean::Crate, PluginJson);
-pub type plugin_callback = extern fn (clean::Crate) -> PluginResult;
+pub type PluginCallback = extern fn (clean::Crate) -> PluginResult;
 
 /// Manages loading and running of plugins
 pub struct PluginManager {
     priv dylibs: ~[dl::DynamicLibrary],
-    priv callbacks: ~[plugin_callback],
+    priv callbacks: ~[PluginCallback],
     /// The directory plugins will be loaded from
     prefix: Path,
 }
@@ -53,7 +53,7 @@ impl PluginManager {
     ///
     /// This is to run passes over the cleaned crate. Plugins run this way
     /// correspond to the A-aux tag on Github.
-    pub fn add_plugin(&mut self, plugin: plugin_callback) {
+    pub fn add_plugin(&mut self, plugin: PluginCallback) {
         self.callbacks.push(plugin);
     }
     /// Run all the loaded plugins over the crate, returning their results

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -10,6 +10,7 @@
 
 #[no_std];
 #[allow(unused_variable)];
+#[allow(non_camel_case_types)];
 #[deny(dead_code)];
 
 #[crate_type="lib"];

--- a/src/test/compile-fail/lint-dead-code-3.rs
+++ b/src/test/compile-fail/lint-dead-code-3.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[allow(unused_variable)];
+#[allow(non_camel_case_types)];
 #[deny(dead_code)];
 
 #[crate_type="lib"];

--- a/src/test/compile-fail/lint-unused-import-tricky-names.rs
+++ b/src/test/compile-fail/lint-unused-import-tricky-names.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[deny(unused_imports)];
+#[allow(non_camel_case_types)];
 #[allow(dead_code)];
 
 // Regression test for issue #6633


### PR DESCRIPTION
This first part of my attempts to fix #11432.

In this one I only set NonCamelCaseTypes to warn by default and tried to fix errors that were reported by `make check`.

Please feel free to let me know if I missed something or didn't do it the right way.

Thanks.
