### PR TITLE
Add lint for variables whose names contain uppercase characters

### DIFF
--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -266,14 +266,14 @@ impl Mul<BigUint, BigUint> for BigUint {
         //   (a1*b1 + a0*b0 - (a1-b0)*(b1-a0)) * base +
         //   a0*b0
         let half_len = cmp::max(s_len, o_len) / 2;
-        let (sHi, sLo) = cut_at(self,  half_len);
-        let (oHi, oLo) = cut_at(other, half_len);
+        let (s_hi, s_lo) = cut_at(self,  half_len);
+        let (o_hi, o_lo) = cut_at(other, half_len);
 
-        let ll = sLo * oLo;
-        let hh = sHi * oHi;
+        let ll = s_lo * o_lo;
+        let hh = s_hi * o_hi;
         let mm = {
-            let (s1, n1) = sub_sign(sHi, sLo);
-            let (s2, n2) = sub_sign(oHi, oLo);
+            let (s1, n1) = sub_sign(s_hi, s_lo);
+            let (s2, n2) = sub_sign(o_hi, o_lo);
             match (s1, s2) {
                 (Equal, _) | (_, Equal) => hh + ll,
                 (Less, Greater) | (Greater, Less) => hh + ll + (n1 * n2),
@@ -1778,10 +1778,10 @@ mod biguint_tests {
     #[test]
     fn test_add() {
         for elm in sum_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigUint::from_slice(aVec);
-            let b = BigUint::from_slice(bVec);
-            let c = BigUint::from_slice(cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
 
             assert!(a + b == c);
             assert!(b + a == c);
@@ -1791,10 +1791,10 @@ mod biguint_tests {
     #[test]
     fn test_sub() {
         for elm in sum_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigUint::from_slice(aVec);
-            let b = BigUint::from_slice(bVec);
-            let c = BigUint::from_slice(cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
 
             assert!(c - a == b);
             assert!(c - b == a);
@@ -1842,21 +1842,21 @@ mod biguint_tests {
     #[test]
     fn test_mul() {
         for elm in mul_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigUint::from_slice(aVec);
-            let b = BigUint::from_slice(bVec);
-            let c = BigUint::from_slice(cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
 
             assert!(a * b == c);
             assert!(b * a == c);
         }
 
         for elm in div_rem_quadruples.iter() {
-            let (aVec, bVec, cVec, dVec) = *elm;
-            let a = BigUint::from_slice(aVec);
-            let b = BigUint::from_slice(bVec);
-            let c = BigUint::from_slice(cVec);
-            let d = BigUint::from_slice(dVec);
+            let (a_vec, b_vec, c_vec, d_vec) = *elm;
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
+            let d = BigUint::from_slice(d_vec);
 
             assert!(a == b * c + d);
             assert!(a == c * b + d);
@@ -1866,10 +1866,10 @@ mod biguint_tests {
     #[test]
     fn test_div_rem() {
         for elm in mul_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigUint::from_slice(aVec);
-            let b = BigUint::from_slice(bVec);
-            let c = BigUint::from_slice(cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
 
             if !a.is_zero() {
                 assert_eq!(c.div_rem(&a), (b.clone(), Zero::zero()));
@@ -1880,11 +1880,11 @@ mod biguint_tests {
         }
 
         for elm in div_rem_quadruples.iter() {
-            let (aVec, bVec, cVec, dVec) = *elm;
-            let a = BigUint::from_slice(aVec);
-            let b = BigUint::from_slice(bVec);
-            let c = BigUint::from_slice(cVec);
-            let d = BigUint::from_slice(dVec);
+            let (a_vec, b_vec, c_vec, d_vec) = *elm;
+            let a = BigUint::from_slice(a_vec);
+            let b = BigUint::from_slice(b_vec);
+            let c = BigUint::from_slice(c_vec);
+            let d = BigUint::from_slice(d_vec);
 
             if !b.is_zero() { assert!(a.div_rem(&b) == (c, d)); }
         }
@@ -2351,10 +2351,10 @@ mod bigint_tests {
     #[test]
     fn test_add() {
         for elm in sum_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
 
             assert!(a + b == c);
             assert!(b + a == c);
@@ -2370,10 +2370,10 @@ mod bigint_tests {
     #[test]
     fn test_sub() {
         for elm in sum_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
 
             assert!(c - a == b);
             assert!(c - b == a);
@@ -2427,10 +2427,10 @@ mod bigint_tests {
     #[test]
     fn test_mul() {
         for elm in mul_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
 
             assert!(a * b == c);
             assert!(b * a == c);
@@ -2440,11 +2440,11 @@ mod bigint_tests {
         }
 
         for elm in div_rem_quadruples.iter() {
-            let (aVec, bVec, cVec, dVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
-            let d = BigInt::from_slice(Plus, dVec);
+            let (a_vec, b_vec, c_vec, d_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
+            let d = BigInt::from_slice(Plus, d_vec);
 
             assert!(a == b * c + d);
             assert!(a == c * b + d);
@@ -2479,21 +2479,21 @@ mod bigint_tests {
         }
 
         for elm in mul_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
 
             if !a.is_zero() { check(&c, &a, &b, &Zero::zero()); }
             if !b.is_zero() { check(&c, &b, &a, &Zero::zero()); }
         }
 
         for elm in div_rem_quadruples.iter() {
-            let (aVec, bVec, cVec, dVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
-            let d = BigInt::from_slice(Plus, dVec);
+            let (a_vec, b_vec, c_vec, d_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
+            let d = BigInt::from_slice(Plus, d_vec);
 
             if !b.is_zero() {
                 check(&a, &b, &c, &d);
@@ -2522,21 +2522,21 @@ mod bigint_tests {
             check_sub(&a.neg(), &b.neg(), q, &r.neg());
         }
         for elm in mul_triples.iter() {
-            let (aVec, bVec, cVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
+            let (a_vec, b_vec, c_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
 
             if !a.is_zero() { check(&c, &a, &b, &Zero::zero()); }
             if !b.is_zero() { check(&c, &b, &a, &Zero::zero()); }
         }
 
         for elm in div_rem_quadruples.iter() {
-            let (aVec, bVec, cVec, dVec) = *elm;
-            let a = BigInt::from_slice(Plus, aVec);
-            let b = BigInt::from_slice(Plus, bVec);
-            let c = BigInt::from_slice(Plus, cVec);
-            let d = BigInt::from_slice(Plus, dVec);
+            let (a_vec, b_vec, c_vec, d_vec) = *elm;
+            let a = BigInt::from_slice(Plus, a_vec);
+            let b = BigInt::from_slice(Plus, b_vec);
+            let c = BigInt::from_slice(Plus, c_vec);
+            let d = BigInt::from_slice(Plus, d_vec);
 
             if !b.is_zero() {
                 check(&a, &b, &c, &d);

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -68,15 +68,15 @@ pub fn llvm_err(sess: Session, msg: ~str) -> ! {
 
 pub fn WriteOutputFile(
         sess: Session,
-        Target: lib::llvm::TargetMachineRef,
-        PM: lib::llvm::PassManagerRef,
-        M: ModuleRef,
-        Output: &Path,
-        FileType: lib::llvm::FileType) {
+        target: lib::llvm::TargetMachineRef,
+        pm: lib::llvm::PassManagerRef,
+        m: ModuleRef,
+        output: &Path,
+        file_type: lib::llvm::FileType) {
     unsafe {
-        Output.with_c_str(|Output| {
+        output.with_c_str(|output| {
             let result = llvm::LLVMRustWriteOutputFile(
-                    Target, PM, M, Output, FileType);
+                    target, pm, m, output, file_type);
             if !result {
                 llvm_err(sess, ~"could not write output");
             }
@@ -138,7 +138,7 @@ pub mod write {
                 })
             }
 
-            let OptLevel = match sess.opts.optimize {
+            let opt_level = match sess.opts.optimize {
               session::No => lib::llvm::CodeGenLevelNone,
               session::Less => lib::llvm::CodeGenLevelLess,
               session::Default => lib::llvm::CodeGenLevelDefault,
@@ -152,14 +152,14 @@ pub mod write {
                              (sess.targ_cfg.os == abi::OsMacos &&
                               sess.targ_cfg.arch == abi::X86_64);
 
-            let tm = sess.targ_cfg.target_strs.target_triple.with_c_str(|T| {
-                sess.opts.cg.target_cpu.with_c_str(|CPU| {
-                    target_feature(&sess).with_c_str(|Features| {
+            let tm = sess.targ_cfg.target_strs.target_triple.with_c_str(|t| {
+                sess.opts.cg.target_cpu.with_c_str(|cpu| {
+                    target_feature(&sess).with_c_str(|features| {
                         llvm::LLVMRustCreateTargetMachine(
-                            T, CPU, Features,
+                            t, cpu, features,
                             lib::llvm::CodeModelDefault,
                             lib::llvm::RelocPIC,
-                            OptLevel,
+                            opt_level,
                             true,
                             use_softfp,
                             no_fp_elim
@@ -185,7 +185,7 @@ pub mod write {
             if !sess.opts.cg.no_prepopulate_passes {
                 llvm::LLVMRustAddAnalysisPasses(tm, fpm, llmod);
                 llvm::LLVMRustAddAnalysisPasses(tm, mpm, llmod);
-                populate_llvm_passes(fpm, mpm, llmod, OptLevel);
+                populate_llvm_passes(fpm, mpm, llmod, opt_level);
             }
 
             for pass in sess.opts.cg.passes.iter() {

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1774,25 +1774,25 @@ pub mod llvm {
     }
 }
 
-pub fn SetInstructionCallConv(Instr: ValueRef, CC: CallConv) {
+pub fn SetInstructionCallConv(instr: ValueRef, cc: CallConv) {
     unsafe {
-        llvm::LLVMSetInstructionCallConv(Instr, CC as c_uint);
+        llvm::LLVMSetInstructionCallConv(instr, cc as c_uint);
     }
 }
-pub fn SetFunctionCallConv(Fn: ValueRef, CC: CallConv) {
+pub fn SetFunctionCallConv(fn_: ValueRef, cc: CallConv) {
     unsafe {
-        llvm::LLVMSetFunctionCallConv(Fn, CC as c_uint);
+        llvm::LLVMSetFunctionCallConv(fn_, cc as c_uint);
     }
 }
-pub fn SetLinkage(Global: ValueRef, Link: Linkage) {
+pub fn SetLinkage(global: ValueRef, link: Linkage) {
     unsafe {
-        llvm::LLVMSetLinkage(Global, Link as c_uint);
+        llvm::LLVMSetLinkage(global, link as c_uint);
     }
 }
 
-pub fn SetUnnamedAddr(Global: ValueRef, Unnamed: bool) {
+pub fn SetUnnamedAddr(global: ValueRef, unnamed: bool) {
     unsafe {
-        llvm::LLVMSetUnnamedAddr(Global, Unnamed as Bool);
+        llvm::LLVMSetUnnamedAddr(global, unnamed as Bool);
     }
 }
 
@@ -1802,20 +1802,20 @@ pub fn set_thread_local(global: ValueRef, is_thread_local: bool) {
     }
 }
 
-pub fn ConstICmp(Pred: IntPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
+pub fn ConstICmp(pred: IntPredicate, v1: ValueRef, v2: ValueRef) -> ValueRef {
     unsafe {
-        llvm::LLVMConstICmp(Pred as c_ushort, V1, V2)
+        llvm::LLVMConstICmp(pred as c_ushort, v1, v2)
     }
 }
-pub fn ConstFCmp(Pred: RealPredicate, V1: ValueRef, V2: ValueRef) -> ValueRef {
+pub fn ConstFCmp(pred: RealPredicate, v1: ValueRef, v2: ValueRef) -> ValueRef {
     unsafe {
-        llvm::LLVMConstFCmp(Pred as c_ushort, V1, V2)
+        llvm::LLVMConstFCmp(pred as c_ushort, v1, v2)
     }
 }
 
-pub fn SetFunctionAttribute(Fn: ValueRef, attr: Attribute) {
+pub fn SetFunctionAttribute(fn_: ValueRef, attr: Attribute) {
     unsafe {
-        llvm::LLVMAddFunctionAttr(Fn, attr as c_uint)
+        llvm::LLVMAddFunctionAttr(fn_, attr as c_uint)
     }
 }
 /* Memory-managed object interface to type handles. */
@@ -1879,9 +1879,9 @@ impl Drop for target_data_res {
     }
 }
 
-pub fn target_data_res(TD: TargetDataRef) -> target_data_res {
+pub fn target_data_res(td: TargetDataRef) -> target_data_res {
     target_data_res {
-        TD: TD
+        TD: td
     }
 }
 
@@ -1915,9 +1915,9 @@ impl Drop for pass_manager_res {
     }
 }
 
-pub fn pass_manager_res(PM: PassManagerRef) -> pass_manager_res {
+pub fn pass_manager_res(pm: PassManagerRef) -> pass_manager_res {
     pass_manager_res {
-        PM: PM
+        PM: pm
     }
 }
 
@@ -1982,9 +1982,9 @@ impl Drop for section_iter_res {
     }
 }
 
-pub fn section_iter_res(SI: SectionIteratorRef) -> section_iter_res {
+pub fn section_iter_res(si: SectionIteratorRef) -> section_iter_res {
     section_iter_res {
-        SI: SI
+        SI: si
     }
 }
 

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1868,20 +1868,20 @@ impl TypeNames {
 /* Memory-managed interface to target data. */
 
 pub struct target_data_res {
-    TD: TargetDataRef,
+    td: TargetDataRef,
 }
 
 impl Drop for target_data_res {
     fn drop(&mut self) {
         unsafe {
-            llvm::LLVMDisposeTargetData(self.TD);
+            llvm::LLVMDisposeTargetData(self.td);
         }
     }
 }
 
 pub fn target_data_res(td: TargetDataRef) -> target_data_res {
     target_data_res {
-        TD: td
+        td: td
     }
 }
 
@@ -1904,20 +1904,20 @@ pub fn mk_target_data(string_rep: &str) -> TargetData {
 /* Memory-managed interface to pass managers. */
 
 pub struct pass_manager_res {
-    PM: PassManagerRef,
+    pm: PassManagerRef,
 }
 
 impl Drop for pass_manager_res {
     fn drop(&mut self) {
         unsafe {
-            llvm::LLVMDisposePassManager(self.PM);
+            llvm::LLVMDisposePassManager(self.pm);
         }
     }
 }
 
 pub fn pass_manager_res(pm: PassManagerRef) -> pass_manager_res {
     pass_manager_res {
-        PM: pm
+        pm: pm
     }
 }
 
@@ -1971,20 +1971,20 @@ impl Drop for ObjectFile {
 /* Memory-managed interface to section iterators. */
 
 pub struct section_iter_res {
-    SI: SectionIteratorRef,
+    si: SectionIteratorRef,
 }
 
 impl Drop for section_iter_res {
     fn drop(&mut self) {
         unsafe {
-            llvm::LLVMDisposeSectionIterator(self.SI);
+            llvm::LLVMDisposeSectionIterator(self.si);
         }
     }
 }
 
 pub fn section_iter_res(si: SectionIteratorRef) -> section_iter_res {
     section_iter_res {
-        SI: si
+        si: si
     }
 }
 

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -82,12 +82,12 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
 
     debug!("Asm Constraints: {:?}", constraints);
 
-    let numOutputs = outputs.len();
+    let num_outputs = outputs.len();
 
     // Depending on how many outputs we have, the return type is different
-    let output_type = if numOutputs == 0 {
+    let output_type = if num_outputs == 0 {
         Type::void()
-    } else if numOutputs == 1 {
+    } else if num_outputs == 1 {
         output_types[0]
     } else {
         Type::struct_(output_types, false)
@@ -112,7 +112,7 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
     });
 
     // Again, based on how many outputs we have
-    if numOutputs == 1 {
+    if num_outputs == 1 {
         Store(bcx, r, *outputs.get(0));
     } else {
         for (i, o) in outputs.iter().enumerate() {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1853,7 +1853,7 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
                 llvm::LLVMAppendBasicBlockInContext(ccx.llcx, llfn, buf)
             }
         });
-        let bld = ccx.builder.B;
+        let bld = ccx.builder.b;
         unsafe {
             llvm::LLVMPositionBuilderAtEnd(bld, llbb);
 

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -54,64 +54,64 @@ pub fn RetVoid(cx: &Block) {
     B(cx).ret_void();
 }
 
-pub fn Ret(cx: &Block, V: ValueRef) {
+pub fn Ret(cx: &Block, v: ValueRef) {
     if cx.unreachable.get() { return; }
     check_not_terminated(cx);
     terminate(cx, "Ret");
-    B(cx).ret(V);
+    B(cx).ret(v);
 }
 
-pub fn AggregateRet(cx: &Block, RetVals: &[ValueRef]) {
+pub fn AggregateRet(cx: &Block, ret_vals: &[ValueRef]) {
     if cx.unreachable.get() { return; }
     check_not_terminated(cx);
     terminate(cx, "AggregateRet");
-    B(cx).aggregate_ret(RetVals);
+    B(cx).aggregate_ret(ret_vals);
 }
 
-pub fn Br(cx: &Block, Dest: BasicBlockRef) {
+pub fn Br(cx: &Block, dest: BasicBlockRef) {
     if cx.unreachable.get() { return; }
     check_not_terminated(cx);
     terminate(cx, "Br");
-    B(cx).br(Dest);
+    B(cx).br(dest);
 }
 
 pub fn CondBr(cx: &Block,
-              If: ValueRef,
-              Then: BasicBlockRef,
-              Else: BasicBlockRef) {
+              if_: ValueRef,
+              then: BasicBlockRef,
+              else_: BasicBlockRef) {
     if cx.unreachable.get() { return; }
     check_not_terminated(cx);
     terminate(cx, "CondBr");
-    B(cx).cond_br(If, Then, Else);
+    B(cx).cond_br(if_, then, else_);
 }
 
-pub fn Switch(cx: &Block, V: ValueRef, Else: BasicBlockRef, NumCases: uint)
+pub fn Switch(cx: &Block, v: ValueRef, else_: BasicBlockRef, num_cases: uint)
     -> ValueRef {
-    if cx.unreachable.get() { return _Undef(V); }
+    if cx.unreachable.get() { return _Undef(v); }
     check_not_terminated(cx);
     terminate(cx, "Switch");
-    B(cx).switch(V, Else, NumCases)
+    B(cx).switch(v, else_, num_cases)
 }
 
-pub fn AddCase(S: ValueRef, OnVal: ValueRef, Dest: BasicBlockRef) {
+pub fn AddCase(s: ValueRef, on_val: ValueRef, dest: BasicBlockRef) {
     unsafe {
-        if llvm::LLVMIsUndef(S) == lib::llvm::True { return; }
-        llvm::LLVMAddCase(S, OnVal, Dest);
+        if llvm::LLVMIsUndef(s) == lib::llvm::True { return; }
+        llvm::LLVMAddCase(s, on_val, dest);
     }
 }
 
-pub fn IndirectBr(cx: &Block, Addr: ValueRef, NumDests: uint) {
+pub fn IndirectBr(cx: &Block, addr: ValueRef, num_dests: uint) {
     if cx.unreachable.get() { return; }
     check_not_terminated(cx);
     terminate(cx, "IndirectBr");
-    B(cx).indirect_br(Addr, NumDests);
+    B(cx).indirect_br(addr, num_dests);
 }
 
 pub fn Invoke(cx: &Block,
-              Fn: ValueRef,
-              Args: &[ValueRef],
-              Then: BasicBlockRef,
-              Catch: BasicBlockRef,
+              fn_: ValueRef,
+              args: &[ValueRef],
+              then: BasicBlockRef,
+              catch: BasicBlockRef,
               attributes: &[(uint, lib::llvm::Attribute)])
               -> ValueRef {
     if cx.unreachable.get() {
@@ -120,9 +120,9 @@ pub fn Invoke(cx: &Block,
     check_not_terminated(cx);
     terminate(cx, "Invoke");
     debug!("Invoke({} with arguments ({}))",
-           cx.val_to_str(Fn),
-           Args.map(|a| cx.val_to_str(*a)).connect(", "));
-    B(cx).invoke(Fn, Args, Then, Catch, attributes)
+           cx.val_to_str(fn_),
+           args.map(|a| cx.val_to_str(*a)).connect(", "));
+    B(cx).invoke(fn_, args, then, catch, attributes)
 }
 
 pub fn Unreachable(cx: &Block) {
@@ -142,208 +142,208 @@ pub fn _Undef(val: ValueRef) -> ValueRef {
 }
 
 /* Arithmetic */
-pub fn Add(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).add(LHS, RHS)
+pub fn Add(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).add(lhs, rhs)
 }
 
-pub fn NSWAdd(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).nswadd(LHS, RHS)
+pub fn NSWAdd(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).nswadd(lhs, rhs)
 }
 
-pub fn NUWAdd(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).nuwadd(LHS, RHS)
+pub fn NUWAdd(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).nuwadd(lhs, rhs)
 }
 
-pub fn FAdd(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).fadd(LHS, RHS)
+pub fn FAdd(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).fadd(lhs, rhs)
 }
 
-pub fn Sub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).sub(LHS, RHS)
+pub fn Sub(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).sub(lhs, rhs)
 }
 
-pub fn NSWSub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).nswsub(LHS, RHS)
+pub fn NSWSub(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).nswsub(lhs, rhs)
 }
 
-pub fn NUWSub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).nuwsub(LHS, RHS)
+pub fn NUWSub(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).nuwsub(lhs, rhs)
 }
 
-pub fn FSub(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).fsub(LHS, RHS)
+pub fn FSub(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).fsub(lhs, rhs)
 }
 
-pub fn Mul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).mul(LHS, RHS)
+pub fn Mul(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).mul(lhs, rhs)
 }
 
-pub fn NSWMul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).nswmul(LHS, RHS)
+pub fn NSWMul(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).nswmul(lhs, rhs)
 }
 
-pub fn NUWMul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).nuwmul(LHS, RHS)
+pub fn NUWMul(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).nuwmul(lhs, rhs)
 }
 
-pub fn FMul(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).fmul(LHS, RHS)
+pub fn FMul(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).fmul(lhs, rhs)
 }
 
-pub fn UDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).udiv(LHS, RHS)
+pub fn UDiv(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).udiv(lhs, rhs)
 }
 
-pub fn SDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).sdiv(LHS, RHS)
+pub fn SDiv(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).sdiv(lhs, rhs)
 }
 
-pub fn ExactSDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).exactsdiv(LHS, RHS)
+pub fn ExactSDiv(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).exactsdiv(lhs, rhs)
 }
 
-pub fn FDiv(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).fdiv(LHS, RHS)
+pub fn FDiv(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).fdiv(lhs, rhs)
 }
 
-pub fn URem(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).urem(LHS, RHS)
+pub fn URem(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).urem(lhs, rhs)
 }
 
-pub fn SRem(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).srem(LHS, RHS)
+pub fn SRem(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).srem(lhs, rhs)
 }
 
-pub fn FRem(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).frem(LHS, RHS)
+pub fn FRem(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).frem(lhs, rhs)
 }
 
-pub fn Shl(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).shl(LHS, RHS)
+pub fn Shl(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).shl(lhs, rhs)
 }
 
-pub fn LShr(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).lshr(LHS, RHS)
+pub fn LShr(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).lshr(lhs, rhs)
 }
 
-pub fn AShr(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).ashr(LHS, RHS)
+pub fn AShr(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).ashr(lhs, rhs)
 }
 
-pub fn And(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).and(LHS, RHS)
+pub fn And(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).and(lhs, rhs)
 }
 
-pub fn Or(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).or(LHS, RHS)
+pub fn Or(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).or(lhs, rhs)
 }
 
-pub fn Xor(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).xor(LHS, RHS)
+pub fn Xor(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).xor(lhs, rhs)
 }
 
-pub fn BinOp(cx: &Block, Op: Opcode, LHS: ValueRef, RHS: ValueRef)
+pub fn BinOp(cx: &Block, op: Opcode, lhs: ValueRef, rhs: ValueRef)
           -> ValueRef {
-    if cx.unreachable.get() { return _Undef(LHS); }
-    B(cx).binop(Op, LHS, RHS)
+    if cx.unreachable.get() { return _Undef(lhs); }
+    B(cx).binop(op, lhs, rhs)
 }
 
-pub fn Neg(cx: &Block, V: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(V); }
-    B(cx).neg(V)
+pub fn Neg(cx: &Block, v: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(v); }
+    B(cx).neg(v)
 }
 
-pub fn NSWNeg(cx: &Block, V: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(V); }
-    B(cx).nswneg(V)
+pub fn NSWNeg(cx: &Block, v: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(v); }
+    B(cx).nswneg(v)
 }
 
-pub fn NUWNeg(cx: &Block, V: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(V); }
-    B(cx).nuwneg(V)
+pub fn NUWNeg(cx: &Block, v: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(v); }
+    B(cx).nuwneg(v)
 }
-pub fn FNeg(cx: &Block, V: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(V); }
-    B(cx).fneg(V)
+pub fn FNeg(cx: &Block, v: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(v); }
+    B(cx).fneg(v)
 }
 
-pub fn Not(cx: &Block, V: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(V); }
-    B(cx).not(V)
+pub fn Not(cx: &Block, v: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(v); }
+    B(cx).not(v)
 }
 
 /* Memory */
-pub fn Malloc(cx: &Block, Ty: Type) -> ValueRef {
+pub fn Malloc(cx: &Block, ty: Type) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
-        B(cx).malloc(Ty)
+        B(cx).malloc(ty)
     }
 }
 
-pub fn ArrayMalloc(cx: &Block, Ty: Type, Val: ValueRef) -> ValueRef {
+pub fn ArrayMalloc(cx: &Block, ty: Type, val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
-        B(cx).array_malloc(Ty, Val)
+        B(cx).array_malloc(ty, val)
     }
 }
 
-pub fn Alloca(cx: &Block, Ty: Type, name: &str) -> ValueRef {
+pub fn Alloca(cx: &Block, ty: Type, name: &str) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(Ty.ptr_to().to_ref()); }
-        AllocaFcx(cx.fcx, Ty, name)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.ptr_to().to_ref()); }
+        AllocaFcx(cx.fcx, ty, name)
     }
 }
 
-pub fn AllocaFcx(fcx: &FunctionContext, Ty: Type, name: &str) -> ValueRef {
+pub fn AllocaFcx(fcx: &FunctionContext, ty: Type, name: &str) -> ValueRef {
     let b = fcx.ccx.builder();
     b.position_before(fcx.alloca_insert_pt.get().unwrap());
-    b.alloca(Ty, name)
+    b.alloca(ty, name)
 }
 
-pub fn ArrayAlloca(cx: &Block, Ty: Type, Val: ValueRef) -> ValueRef {
+pub fn ArrayAlloca(cx: &Block, ty: Type, val: ValueRef) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(Ty.ptr_to().to_ref()); }
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.ptr_to().to_ref()); }
         let b = cx.fcx.ccx.builder();
         b.position_before(cx.fcx.alloca_insert_pt.get().unwrap());
-        b.array_alloca(Ty, Val)
+        b.array_alloca(ty, val)
     }
 }
 
-pub fn Free(cx: &Block, PointerVal: ValueRef) {
+pub fn Free(cx: &Block, pointer_val: ValueRef) {
     if cx.unreachable.get() { return; }
-    B(cx).free(PointerVal)
+    B(cx).free(pointer_val)
 }
 
-pub fn Load(cx: &Block, PointerVal: ValueRef) -> ValueRef {
+pub fn Load(cx: &Block, pointer_val: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable.get() {
-            let ty = val_ty(PointerVal);
+            let ty = val_ty(pointer_val);
             let eltty = if ty.kind() == lib::llvm::Array {
                 ty.element_type()
             } else {
@@ -351,33 +351,33 @@ pub fn Load(cx: &Block, PointerVal: ValueRef) -> ValueRef {
             };
             return llvm::LLVMGetUndef(eltty.to_ref());
         }
-        B(cx).load(PointerVal)
+        B(cx).load(pointer_val)
     }
 }
 
-pub fn VolatileLoad(cx: &Block, PointerVal: ValueRef) -> ValueRef {
+pub fn VolatileLoad(cx: &Block, pointer_val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).volatile_load(PointerVal)
+        B(cx).volatile_load(pointer_val)
     }
 }
 
-pub fn AtomicLoad(cx: &Block, PointerVal: ValueRef, order: AtomicOrdering) -> ValueRef {
+pub fn AtomicLoad(cx: &Block, pointer_val: ValueRef, order: AtomicOrdering) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable.get() {
             return llvm::LLVMGetUndef(ccx.int_type.to_ref());
         }
-        B(cx).atomic_load(PointerVal, order)
+        B(cx).atomic_load(pointer_val, order)
     }
 }
 
 
-pub fn LoadRangeAssert(cx: &Block, PointerVal: ValueRef, lo: c_ulonglong,
+pub fn LoadRangeAssert(cx: &Block, pointer_val: ValueRef, lo: c_ulonglong,
                        hi: c_ulonglong, signed: lib::llvm::Bool) -> ValueRef {
     if cx.unreachable.get() {
         let ccx = cx.fcx.ccx;
-        let ty = val_ty(PointerVal);
+        let ty = val_ty(pointer_val);
         let eltty = if ty.kind() == lib::llvm::Array {
             ty.element_type()
         } else {
@@ -387,29 +387,29 @@ pub fn LoadRangeAssert(cx: &Block, PointerVal: ValueRef, lo: c_ulonglong,
             llvm::LLVMGetUndef(eltty.to_ref())
         }
     } else {
-        B(cx).load_range_assert(PointerVal, lo, hi, signed)
+        B(cx).load_range_assert(pointer_val, lo, hi, signed)
     }
 }
 
-pub fn Store(cx: &Block, Val: ValueRef, Ptr: ValueRef) {
+pub fn Store(cx: &Block, val: ValueRef, ptr: ValueRef) {
     if cx.unreachable.get() { return; }
-    B(cx).store(Val, Ptr)
+    B(cx).store(val, ptr)
 }
 
-pub fn VolatileStore(cx: &Block, Val: ValueRef, Ptr: ValueRef) {
+pub fn VolatileStore(cx: &Block, val: ValueRef, ptr: ValueRef) {
     if cx.unreachable.get() { return; }
-    B(cx).volatile_store(Val, Ptr)
+    B(cx).volatile_store(val, ptr)
 }
 
-pub fn AtomicStore(cx: &Block, Val: ValueRef, Ptr: ValueRef, order: AtomicOrdering) {
+pub fn AtomicStore(cx: &Block, val: ValueRef, ptr: ValueRef, order: AtomicOrdering) {
     if cx.unreachable.get() { return; }
-    B(cx).atomic_store(Val, Ptr, order)
+    B(cx).atomic_store(val, ptr, order)
 }
 
-pub fn GEP(cx: &Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
+pub fn GEP(cx: &Block, pointer: ValueRef, indices: &[ValueRef]) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
-        B(cx).gep(Pointer, Indices)
+        B(cx).gep(pointer, indices)
     }
 }
 
@@ -423,199 +423,199 @@ pub fn GEPi(cx: &Block, base: ValueRef, ixs: &[uint]) -> ValueRef {
     }
 }
 
-pub fn InBoundsGEP(cx: &Block, Pointer: ValueRef, Indices: &[ValueRef]) -> ValueRef {
+pub fn InBoundsGEP(cx: &Block, pointer: ValueRef, indices: &[ValueRef]) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
-        B(cx).inbounds_gep(Pointer, Indices)
+        B(cx).inbounds_gep(pointer, indices)
     }
 }
 
-pub fn StructGEP(cx: &Block, Pointer: ValueRef, Idx: uint) -> ValueRef {
+pub fn StructGEP(cx: &Block, pointer: ValueRef, idx: uint) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().ptr_to().to_ref()); }
-        B(cx).struct_gep(Pointer, Idx)
+        B(cx).struct_gep(pointer, idx)
     }
 }
 
-pub fn GlobalString(cx: &Block, _Str: *c_char) -> ValueRef {
+pub fn GlobalString(cx: &Block, _str: *c_char) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
-        B(cx).global_string(_Str)
+        B(cx).global_string(_str)
     }
 }
 
-pub fn GlobalStringPtr(cx: &Block, _Str: *c_char) -> ValueRef {
+pub fn GlobalStringPtr(cx: &Block, _str: *c_char) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i8p().to_ref()); }
-        B(cx).global_string_ptr(_Str)
+        B(cx).global_string_ptr(_str)
     }
 }
 
 /* Casts */
-pub fn Trunc(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn Trunc(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).trunc(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).trunc(val, dest_ty)
     }
 }
 
-pub fn ZExt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn ZExt(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).zext(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).zext(val, dest_ty)
     }
 }
 
-pub fn SExt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SExt(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).sext(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).sext(val, dest_ty)
     }
 }
 
-pub fn FPToUI(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPToUI(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).fptoui(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).fptoui(val, dest_ty)
     }
 }
 
-pub fn FPToSI(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPToSI(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).fptosi(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).fptosi(val, dest_ty)
     }
 }
 
-pub fn UIToFP(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn UIToFP(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).uitofp(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).uitofp(val, dest_ty)
     }
 }
 
-pub fn SIToFP(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SIToFP(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).sitofp(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).sitofp(val, dest_ty)
     }
 }
 
-pub fn FPTrunc(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPTrunc(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).fptrunc(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).fptrunc(val, dest_ty)
     }
 }
 
-pub fn FPExt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPExt(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).fpext(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).fpext(val, dest_ty)
     }
 }
 
-pub fn PtrToInt(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn PtrToInt(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).ptrtoint(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).ptrtoint(val, dest_ty)
     }
 }
 
-pub fn IntToPtr(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn IntToPtr(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).inttoptr(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).inttoptr(val, dest_ty)
     }
 }
 
-pub fn BitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn BitCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).bitcast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).bitcast(val, dest_ty)
     }
 }
 
-pub fn ZExtOrBitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn ZExtOrBitCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).zext_or_bitcast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).zext_or_bitcast(val, dest_ty)
     }
 }
 
-pub fn SExtOrBitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn SExtOrBitCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).sext_or_bitcast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).sext_or_bitcast(val, dest_ty)
     }
 }
 
-pub fn TruncOrBitCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn TruncOrBitCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).trunc_or_bitcast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).trunc_or_bitcast(val, dest_ty)
     }
 }
 
-pub fn Cast(cx: &Block, Op: Opcode, Val: ValueRef, DestTy: Type, _: *u8)
+pub fn Cast(cx: &Block, op: Opcode, val: ValueRef, dest_ty: Type, _: *u8)
      -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).cast(Op, Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).cast(op, val, dest_ty)
     }
 }
 
-pub fn PointerCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn PointerCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).pointercast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).pointercast(val, dest_ty)
     }
 }
 
-pub fn IntCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn IntCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).intcast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).intcast(val, dest_ty)
     }
 }
 
-pub fn FPCast(cx: &Block, Val: ValueRef, DestTy: Type) -> ValueRef {
+pub fn FPCast(cx: &Block, val: ValueRef, dest_ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(DestTy.to_ref()); }
-        B(cx).fpcast(Val, DestTy)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(dest_ty.to_ref()); }
+        B(cx).fpcast(val, dest_ty)
     }
 }
 
 
 /* Comparisons */
-pub fn ICmp(cx: &Block, Op: IntPredicate, LHS: ValueRef, RHS: ValueRef)
+pub fn ICmp(cx: &Block, op: IntPredicate, lhs: ValueRef, rhs: ValueRef)
      -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
-        B(cx).icmp(Op, LHS, RHS)
+        B(cx).icmp(op, lhs, rhs)
     }
 }
 
-pub fn FCmp(cx: &Block, Op: RealPredicate, LHS: ValueRef, RHS: ValueRef)
+pub fn FCmp(cx: &Block, op: RealPredicate, lhs: ValueRef, rhs: ValueRef)
      -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
-        B(cx).fcmp(Op, LHS, RHS)
+        B(cx).fcmp(op, lhs, rhs)
     }
 }
 
 /* Miscellaneous instructions */
-pub fn EmptyPhi(cx: &Block, Ty: Type) -> ValueRef {
+pub fn EmptyPhi(cx: &Block, ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(Ty.to_ref()); }
-        B(cx).empty_phi(Ty)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.to_ref()); }
+        B(cx).empty_phi(ty)
     }
 }
 
-pub fn Phi(cx: &Block, Ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> ValueRef {
+pub fn Phi(cx: &Block, ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(Ty.to_ref()); }
-        B(cx).phi(Ty, vals, bbs)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.to_ref()); }
+        B(cx).phi(ty, vals, bbs)
     }
 }
 
@@ -626,10 +626,10 @@ pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     }
 }
 
-pub fn _UndefReturn(cx: &Block, Fn: ValueRef) -> ValueRef {
+pub fn _UndefReturn(cx: &Block, fn_: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
-        let ty = val_ty(Fn);
+        let ty = val_ty(fn_);
         let retty = if ty.kind() == lib::llvm::Integer {
             ty.return_type()
         } else {
@@ -655,16 +655,16 @@ pub fn InlineAsmCall(cx: &Block, asm: *c_char, cons: *c_char,
     B(cx).inline_asm_call(asm, cons, inputs, output, volatile, alignstack, dia)
 }
 
-pub fn Call(cx: &Block, Fn: ValueRef, Args: &[ValueRef],
+pub fn Call(cx: &Block, fn_: ValueRef, args: &[ValueRef],
             attributes: &[(uint, lib::llvm::Attribute)]) -> ValueRef {
-    if cx.unreachable.get() { return _UndefReturn(cx, Fn); }
-    B(cx).call(Fn, Args, attributes)
+    if cx.unreachable.get() { return _UndefReturn(cx, fn_); }
+    B(cx).call(fn_, args, attributes)
 }
 
-pub fn CallWithConv(cx: &Block, Fn: ValueRef, Args: &[ValueRef], Conv: CallConv,
+pub fn CallWithConv(cx: &Block, fn_: ValueRef, args: &[ValueRef], conv: CallConv,
                     attributes: &[(uint, lib::llvm::Attribute)]) -> ValueRef {
-    if cx.unreachable.get() { return _UndefReturn(cx, Fn); }
-    B(cx).call_with_conv(Fn, Args, Conv, attributes)
+    if cx.unreachable.get() { return _UndefReturn(cx, fn_); }
+    B(cx).call_with_conv(fn_, args, conv, attributes)
 }
 
 pub fn AtomicFence(cx: &Block, order: AtomicOrdering) {
@@ -672,81 +672,81 @@ pub fn AtomicFence(cx: &Block, order: AtomicOrdering) {
     B(cx).atomic_fence(order)
 }
 
-pub fn Select(cx: &Block, If: ValueRef, Then: ValueRef, Else: ValueRef) -> ValueRef {
-    if cx.unreachable.get() { return _Undef(Then); }
-    B(cx).select(If, Then, Else)
+pub fn Select(cx: &Block, if_: ValueRef, then: ValueRef, else_: ValueRef) -> ValueRef {
+    if cx.unreachable.get() { return _Undef(then); }
+    B(cx).select(if_, then, else_)
 }
 
-pub fn VAArg(cx: &Block, list: ValueRef, Ty: Type) -> ValueRef {
+pub fn VAArg(cx: &Block, list: ValueRef, ty: Type) -> ValueRef {
     unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(Ty.to_ref()); }
-        B(cx).va_arg(list, Ty)
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.to_ref()); }
+        B(cx).va_arg(list, ty)
     }
 }
 
-pub fn ExtractElement(cx: &Block, VecVal: ValueRef, Index: ValueRef) -> ValueRef {
-    unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).extract_element(VecVal, Index)
-    }
-}
-
-pub fn InsertElement(cx: &Block, VecVal: ValueRef, EltVal: ValueRef,
-                     Index: ValueRef) -> ValueRef {
+pub fn ExtractElement(cx: &Block, vec_val: ValueRef, index: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).insert_element(VecVal, EltVal, Index)
+        B(cx).extract_element(vec_val, index)
     }
 }
 
-pub fn ShuffleVector(cx: &Block, V1: ValueRef, V2: ValueRef,
-                     Mask: ValueRef) -> ValueRef {
+pub fn InsertElement(cx: &Block, vec_val: ValueRef, elt_val: ValueRef,
+                     index: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).shuffle_vector(V1, V2, Mask)
+        B(cx).insert_element(vec_val, elt_val, index)
     }
 }
 
-pub fn VectorSplat(cx: &Block, NumElts: uint, EltVal: ValueRef) -> ValueRef {
+pub fn ShuffleVector(cx: &Block, v1: ValueRef, v2: ValueRef,
+                     mask: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).vector_splat(NumElts, EltVal)
+        B(cx).shuffle_vector(v1, v2, mask)
     }
 }
 
-pub fn ExtractValue(cx: &Block, AggVal: ValueRef, Index: uint) -> ValueRef {
+pub fn VectorSplat(cx: &Block, num_elts: uint, elt_val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).extract_value(AggVal, Index)
+        B(cx).vector_splat(num_elts, elt_val)
     }
 }
 
-pub fn InsertValue(cx: &Block, AggVal: ValueRef, EltVal: ValueRef, Index: uint) -> ValueRef {
+pub fn ExtractValue(cx: &Block, agg_val: ValueRef, index: uint) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
-        B(cx).insert_value(AggVal, EltVal, Index)
+        B(cx).extract_value(agg_val, index)
     }
 }
 
-pub fn IsNull(cx: &Block, Val: ValueRef) -> ValueRef {
+pub fn InsertValue(cx: &Block, agg_val: ValueRef, elt_val: ValueRef, index: uint) -> ValueRef {
+    unsafe {
+        if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::nil().to_ref()); }
+        B(cx).insert_value(agg_val, elt_val, index)
+    }
+}
+
+pub fn IsNull(cx: &Block, val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
-        B(cx).is_null(Val)
+        B(cx).is_null(val)
     }
 }
 
-pub fn IsNotNull(cx: &Block, Val: ValueRef) -> ValueRef {
+pub fn IsNotNull(cx: &Block, val: ValueRef) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(Type::i1().to_ref()); }
-        B(cx).is_not_null(Val)
+        B(cx).is_not_null(val)
     }
 }
 
-pub fn PtrDiff(cx: &Block, LHS: ValueRef, RHS: ValueRef) -> ValueRef {
+pub fn PtrDiff(cx: &Block, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         if cx.unreachable.get() { return llvm::LLVMGetUndef(ccx.int_type.to_ref()); }
-        B(cx).ptrdiff(LHS, RHS)
+        B(cx).ptrdiff(lhs, rhs)
     }
 }
 
@@ -755,21 +755,21 @@ pub fn Trap(cx: &Block) {
     B(cx).trap();
 }
 
-pub fn LandingPad(cx: &Block, Ty: Type, PersFn: ValueRef,
-                  NumClauses: uint) -> ValueRef {
+pub fn LandingPad(cx: &Block, ty: Type, pers_fn: ValueRef,
+                  num_clauses: uint) -> ValueRef {
     check_not_terminated(cx);
     assert!(!cx.unreachable.get());
-    B(cx).landing_pad(Ty, PersFn, NumClauses)
+    B(cx).landing_pad(ty, pers_fn, num_clauses)
 }
 
-pub fn SetCleanup(cx: &Block, LandingPad: ValueRef) {
-    B(cx).set_cleanup(LandingPad)
+pub fn SetCleanup(cx: &Block, landing_pad: ValueRef) {
+    B(cx).set_cleanup(landing_pad)
 }
 
-pub fn Resume(cx: &Block, Exn: ValueRef) -> ValueRef {
+pub fn Resume(cx: &Block, exn: ValueRef) -> ValueRef {
     check_not_terminated(cx);
     terminate(cx, "Resume");
-    B(cx).resume(Exn)
+    B(cx).resume(exn)
 }
 
 // Atomic Operations

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -362,37 +362,37 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub fn neg(&self, V: ValueRef) -> ValueRef {
+    pub fn neg(&self, v: ValueRef) -> ValueRef {
         self.count_insn("neg");
         unsafe {
-            llvm::LLVMBuildNeg(self.llbuilder, V, noname())
+            llvm::LLVMBuildNeg(self.llbuilder, v, noname())
         }
     }
 
-    pub fn nswneg(&self, V: ValueRef) -> ValueRef {
+    pub fn nswneg(&self, v: ValueRef) -> ValueRef {
         self.count_insn("nswneg");
         unsafe {
-            llvm::LLVMBuildNSWNeg(self.llbuilder, V, noname())
+            llvm::LLVMBuildNSWNeg(self.llbuilder, v, noname())
         }
     }
 
-    pub fn nuwneg(&self, V: ValueRef) -> ValueRef {
+    pub fn nuwneg(&self, v: ValueRef) -> ValueRef {
         self.count_insn("nuwneg");
         unsafe {
-            llvm::LLVMBuildNUWNeg(self.llbuilder, V, noname())
+            llvm::LLVMBuildNUWNeg(self.llbuilder, v, noname())
         }
     }
-    pub fn fneg(&self, V: ValueRef) -> ValueRef {
+    pub fn fneg(&self, v: ValueRef) -> ValueRef {
         self.count_insn("fneg");
         unsafe {
-            llvm::LLVMBuildFNeg(self.llbuilder, V, noname())
+            llvm::LLVMBuildFNeg(self.llbuilder, v, noname())
         }
     }
 
-    pub fn not(&self, V: ValueRef) -> ValueRef {
+    pub fn not(&self, v: ValueRef) -> ValueRef {
         self.count_insn("not");
         unsafe {
-            llvm::LLVMBuildNot(self.llbuilder, V, noname())
+            llvm::LLVMBuildNot(self.llbuilder, v, noname())
         }
     }
 
@@ -561,17 +561,17 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub fn global_string(&self, _Str: *c_char) -> ValueRef {
+    pub fn global_string(&self, _str: *c_char) -> ValueRef {
         self.count_insn("globalstring");
         unsafe {
-            llvm::LLVMBuildGlobalString(self.llbuilder, _Str, noname())
+            llvm::LLVMBuildGlobalString(self.llbuilder, _str, noname())
         }
     }
 
-    pub fn global_string_ptr(&self, _Str: *c_char) -> ValueRef {
+    pub fn global_string_ptr(&self, _str: *c_char) -> ValueRef {
         self.count_insn("globalstringptr");
         unsafe {
-            llvm::LLVMBuildGlobalStringPtr(self.llbuilder, _Str, noname())
+            llvm::LLVMBuildGlobalStringPtr(self.llbuilder, _str, noname())
         }
     }
 
@@ -857,9 +857,9 @@ impl<'a> Builder<'a> {
     pub fn vector_splat(&self, num_elts: uint, elt: ValueRef) -> ValueRef {
         unsafe {
             let elt_ty = val_ty(elt);
-            let Undef = llvm::LLVMGetUndef(Type::vector(&elt_ty, num_elts as u64).to_ref());
-            let vec = self.insert_element(Undef, elt, C_i32(0));
-            self.shuffle_vector(vec, Undef, C_null(Type::vector(&Type::i32(), num_elts as u64)))
+            let undef = llvm::LLVMGetUndef(Type::vector(&elt_ty, num_elts as u64).to_ref());
+            let vec = self.insert_element(undef, elt, C_i32(0));
+            self.shuffle_vector(vec, undef, C_null(Type::vector(&Type::i32(), num_elts as u64)))
         }
     }
 
@@ -902,17 +902,17 @@ impl<'a> Builder<'a> {
 
     pub fn trap(&self) {
         unsafe {
-            let BB: BasicBlockRef = llvm::LLVMGetInsertBlock(self.llbuilder);
-            let FN: ValueRef = llvm::LLVMGetBasicBlockParent(BB);
-            let M: ModuleRef = llvm::LLVMGetGlobalParent(FN);
-            let T: ValueRef = "llvm.trap".with_c_str(|buf| {
-                llvm::LLVMGetNamedFunction(M, buf)
+            let bb: BasicBlockRef = llvm::LLVMGetInsertBlock(self.llbuilder);
+            let fn_: ValueRef = llvm::LLVMGetBasicBlockParent(bb);
+            let m: ModuleRef = llvm::LLVMGetGlobalParent(fn_);
+            let t: ValueRef = "llvm.trap".with_c_str(|buf| {
+                llvm::LLVMGetNamedFunction(m, buf)
             });
-            assert!((T as int != 0));
+            assert!((t as int != 0));
             let args: &[ValueRef] = [];
             self.count_insn("trap");
             llvm::LLVMBuildCall(
-                self.llbuilder, T, args.as_ptr(), args.len() as c_uint, noname());
+                self.llbuilder, t, args.as_ptr(), args.len() as c_uint, noname());
         }
     }
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -36,7 +36,7 @@ pub fn noname() -> *c_char {
 impl<'a> Builder<'a> {
     pub fn new(ccx: &'a CrateContext) -> Builder<'a> {
         Builder {
-            llbuilder: ccx.builder.B,
+            llbuilder: ccx.builder.b,
             ccx: ccx,
         }
     }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -164,20 +164,20 @@ pub struct Stats {
 }
 
 pub struct BuilderRef_res {
-    B: BuilderRef,
+    b: BuilderRef,
 }
 
 impl Drop for BuilderRef_res {
     fn drop(&mut self) {
         unsafe {
-            llvm::LLVMDisposeBuilder(self.B);
+            llvm::LLVMDisposeBuilder(self.b);
         }
     }
 }
 
 pub fn BuilderRef_res(b: BuilderRef) -> BuilderRef_res {
     BuilderRef_res {
-        B: b
+        b: b
     }
 }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -175,9 +175,9 @@ impl Drop for BuilderRef_res {
     }
 }
 
-pub fn BuilderRef_res(B: BuilderRef) -> BuilderRef_res {
+pub fn BuilderRef_res(b: BuilderRef) -> BuilderRef_res {
     BuilderRef_res {
-        B: B
+        B: b
     }
 }
 
@@ -654,9 +654,9 @@ pub fn C_struct(elts: &[ValueRef], packed: bool) -> ValueRef {
     }
 }
 
-pub fn C_named_struct(T: Type, elts: &[ValueRef]) -> ValueRef {
+pub fn C_named_struct(t: Type, elts: &[ValueRef]) -> ValueRef {
     unsafe {
-        llvm::LLVMConstNamedStruct(T.to_ref(), elts.as_ptr(), elts.len() as c_uint)
+        llvm::LLVMConstNamedStruct(t.to_ref(), elts.as_ptr(), elts.len() as c_uint)
     }
 }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -302,8 +302,8 @@ fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
                          is_local: bool) -> (ValueRef, bool) {
     let map_list = |exprs: &[@ast::Expr]| {
         exprs.iter().map(|&e| const_expr(cx, e, is_local))
-             .fold((~[], true), |(L, all_inlineable), (val, inlineable)| {
-                (vec::append_one(L, val), all_inlineable && inlineable)
+             .fold((~[], true), |(l, all_inlineable), (val, inlineable)| {
+                (vec::append_one(l, val), all_inlineable && inlineable)
              })
     };
     unsafe {

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -330,17 +330,17 @@ pub fn trans_fail<'a>(
                   sp: Span,
                   fail_str: InternedString)
                   -> &'a Block<'a> {
-    let V_fail_str = C_cstr(bcx.ccx(), fail_str);
+    let v_fail_str = C_cstr(bcx.ccx(), fail_str);
     let _icx = push_ctxt("trans_fail_value");
     let ccx = bcx.ccx();
     let sess = bcx.sess();
     let loc = sess.parse_sess.cm.lookup_char_pos(sp.lo);
-    let V_filename = C_cstr(bcx.ccx(),
+    let v_filename = C_cstr(bcx.ccx(),
                             token::intern_and_get_ident(loc.file.name));
-    let V_line = loc.line as int;
-    let V_str = PointerCast(bcx, V_fail_str, Type::i8p());
-    let V_filename = PointerCast(bcx, V_filename, Type::i8p());
-    let args = ~[V_str, V_filename, C_int(ccx, V_line)];
+    let v_line = loc.line as int;
+    let v_str = PointerCast(bcx, v_fail_str, Type::i8p());
+    let v_filename = PointerCast(bcx, v_filename, Type::i8p());
+    let args = ~[v_str, v_filename, C_int(ccx, v_line)];
     let did = langcall(bcx, Some(sp), "", FailFnLangItem);
     let bcx = callee::trans_lang_call(bcx, did, args, Some(expr::Ignore)).bcx;
     Unreachable(bcx);

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -2171,7 +2171,7 @@ fn set_debug_location(cx: &CrateContext, debug_location: DebugLocation) {
     };
 
     unsafe {
-        llvm::LLVMSetCurrentDebugLocation(cx.builder.B, metadata_node);
+        llvm::LLVMSetCurrentDebugLocation(cx.builder.b, metadata_node);
     }
 
     debug_context(cx).current_debug_location.set(debug_location);

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -499,7 +499,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @CrateContext,
             "the block".with_c_str(
                 |s| llvm::LLVMAppendBasicBlockInContext(ccx.llcx, llwrapfn, s));
 
-        let builder = ccx.builder.B;
+        let builder = ccx.builder.b;
         llvm::LLVMPositionBuilderAtEnd(builder, the_block);
 
         // Array for the arguments we will pass to the rust function.

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -269,39 +269,39 @@ pub trait Digest {
 // A structure that represents that state of a digest computation for the SHA-2 512 family of digest
 // functions
 struct Engine256State {
-    H0: u32,
-    H1: u32,
-    H2: u32,
-    H3: u32,
-    H4: u32,
-    H5: u32,
-    H6: u32,
-    H7: u32,
+    h0: u32,
+    h1: u32,
+    h2: u32,
+    h3: u32,
+    h4: u32,
+    h5: u32,
+    h6: u32,
+    h7: u32,
 }
 
 impl Engine256State {
     fn new(h: &[u32, ..8]) -> Engine256State {
         return Engine256State {
-            H0: h[0],
-            H1: h[1],
-            H2: h[2],
-            H3: h[3],
-            H4: h[4],
-            H5: h[5],
-            H6: h[6],
-            H7: h[7]
+            h0: h[0],
+            h1: h[1],
+            h2: h[2],
+            h3: h[3],
+            h4: h[4],
+            h5: h[5],
+            h6: h[6],
+            h7: h[7]
         };
     }
 
     fn reset(&mut self, h: &[u32, ..8]) {
-        self.H0 = h[0];
-        self.H1 = h[1];
-        self.H2 = h[2];
-        self.H3 = h[3];
-        self.H4 = h[4];
-        self.H5 = h[5];
-        self.H6 = h[6];
-        self.H7 = h[7];
+        self.h0 = h[0];
+        self.h1 = h[1];
+        self.h2 = h[2];
+        self.h3 = h[3];
+        self.h4 = h[4];
+        self.h5 = h[5];
+        self.h6 = h[6];
+        self.h7 = h[7];
     }
 
     fn process_block(&mut self, data: &[u8]) {
@@ -329,14 +329,14 @@ impl Engine256State {
             ((x >> 17) | (x << 15)) ^ ((x >> 19) | (x << 13)) ^ (x >> 10)
         }
 
-        let mut a = self.H0;
-        let mut b = self.H1;
-        let mut c = self.H2;
-        let mut d = self.H3;
-        let mut e = self.H4;
-        let mut f = self.H5;
-        let mut g = self.H6;
-        let mut h = self.H7;
+        let mut a = self.h0;
+        let mut b = self.h1;
+        let mut c = self.h2;
+        let mut d = self.h3;
+        let mut e = self.h4;
+        let mut f = self.h5;
+        let mut g = self.h6;
+        let mut h = self.h7;
 
         let mut w = [0u32, ..64];
 
@@ -393,14 +393,14 @@ impl Engine256State {
             sha2_round!(b, c, d, e, f, g, h, a, K32, t + 7);
         }
 
-        self.H0 += a;
-        self.H1 += b;
-        self.H2 += c;
-        self.H3 += d;
-        self.H4 += e;
-        self.H5 += f;
-        self.H6 += g;
-        self.H7 += h;
+        self.h0 += a;
+        self.h1 += b;
+        self.h2 += c;
+        self.h3 += d;
+        self.h4 += e;
+        self.h5 += f;
+        self.h6 += g;
+        self.h7 += h;
     }
 }
 
@@ -494,14 +494,14 @@ impl Digest for Sha256 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u32_be(out.mut_slice(0, 4), self.engine.state.H0);
-        write_u32_be(out.mut_slice(4, 8), self.engine.state.H1);
-        write_u32_be(out.mut_slice(8, 12), self.engine.state.H2);
-        write_u32_be(out.mut_slice(12, 16), self.engine.state.H3);
-        write_u32_be(out.mut_slice(16, 20), self.engine.state.H4);
-        write_u32_be(out.mut_slice(20, 24), self.engine.state.H5);
-        write_u32_be(out.mut_slice(24, 28), self.engine.state.H6);
-        write_u32_be(out.mut_slice(28, 32), self.engine.state.H7);
+        write_u32_be(out.mut_slice(0, 4), self.engine.state.h0);
+        write_u32_be(out.mut_slice(4, 8), self.engine.state.h1);
+        write_u32_be(out.mut_slice(8, 12), self.engine.state.h2);
+        write_u32_be(out.mut_slice(12, 16), self.engine.state.h3);
+        write_u32_be(out.mut_slice(16, 20), self.engine.state.h4);
+        write_u32_be(out.mut_slice(20, 24), self.engine.state.h5);
+        write_u32_be(out.mut_slice(24, 28), self.engine.state.h6);
+        write_u32_be(out.mut_slice(28, 32), self.engine.state.h7);
     }
 
     fn reset(&mut self) {

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -338,12 +338,12 @@ impl Engine256State {
         let mut g = self.H6;
         let mut h = self.H7;
 
-        let mut W = [0u32, ..64];
+        let mut w = [0u32, ..64];
 
         // Sha-512 and Sha-256 use basically the same calculations which are implemented
         // by these macros. Inlining the calculations seems to result in better generated code.
         macro_rules! schedule_round( ($t:expr) => (
-                W[$t] = sigma1(W[$t - 2]) + W[$t - 7] + sigma0(W[$t - 15]) + W[$t - 16];
+                w[$t] = sigma1(w[$t - 2]) + w[$t - 7] + sigma0(w[$t - 15]) + w[$t - 16];
                 )
         )
 
@@ -351,14 +351,14 @@ impl Engine256State {
             ($A:ident, $B:ident, $C:ident, $D:ident,
              $E:ident, $F:ident, $G:ident, $H:ident, $K:ident, $t:expr) => (
                 {
-                    $H += sum1($E) + ch($E, $F, $G) + $K[$t] + W[$t];
+                    $H += sum1($E) + ch($E, $F, $G) + $K[$t] + w[$t];
                     $D += $H;
                     $H += sum0($A) + maj($A, $B, $C);
                 }
              )
         )
 
-        read_u32v_be(W.mut_slice(0, 16), data);
+        read_u32v_be(w.mut_slice(0, 16), data);
 
         // Putting the message schedule inside the same loop as the round calculations allows for
         // the compiler to generate better code.

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -199,9 +199,9 @@ impl<'a> FromBase64 for &'a str {
      *     println!("base64 output: {}", hello_str);
      *     let res = hello_str.from_base64();
      *     if res.is_ok() {
-     *       let optBytes = str::from_utf8_owned(res.unwrap());
-     *       if optBytes.is_some() {
-     *         println!("decoded from base64: {}", optBytes.unwrap());
+     *       let opt_bytes = str::from_utf8_owned(res.unwrap());
+     *       if opt_bytes.is_some() {
+     *         println!("decoded from base64: {}", opt_bytes.unwrap());
      *       }
      *     }
      * }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1672,15 +1672,15 @@ mod tests {
             ]"
         );
 
-        let longTestList = List(~[
+        let long_test_list = List(~[
             Boolean(false),
             Null,
             List(~[String(~"foo\nbar"), Number(3.5)])]);
 
-        assert_eq!(longTestList.to_str(),
+        assert_eq!(long_test_list.to_str(),
             ~"[false,null,[\"foo\\nbar\",3.5]]");
         assert_eq!(
-            longTestList.to_pretty_str(),
+            long_test_list.to_pretty_str(),
             ~"\
             [\n  \
                 false,\n  \
@@ -1710,7 +1710,7 @@ mod tests {
             }"
         );
 
-        let complexObj = mk_object([
+        let complex_obj = mk_object([
                 (~"b", List(~[
                     mk_object([(~"c", String(~"\x0c\r"))]),
                     mk_object([(~"d", String(~""))])
@@ -1718,7 +1718,7 @@ mod tests {
             ]);
 
         assert_eq!(
-            complexObj.to_str(),
+            complex_obj.to_str(),
             ~"{\
                 \"b\":[\
                     {\"c\":\"\\f\\r\"},\
@@ -1727,7 +1727,7 @@ mod tests {
             }"
         );
         assert_eq!(
-            complexObj.to_pretty_str(),
+            complex_obj.to_pretty_str(),
             ~"\
             {\n  \
                 \"b\": [\n    \

--- a/src/libstd/hash/mod.rs
+++ b/src/libstd/hash/mod.rs
@@ -181,7 +181,7 @@ macro_rules! impl_hash_tuple(
     );
 )
 
-impl_hash_tuple!(A0 A1 A2 A3 A4 A5 A6 A7)
+impl_hash_tuple!(a0 a1 a2 a3 a4 a5 a6 a7)
 
 impl<'a, S: Writer, T: Hash<S>> Hash<S> for &'a [T] {
     #[inline]

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -85,8 +85,8 @@ impl Reader for UdpStream {
 
 impl Writer for UdpStream {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
-        let connectedTo = self.connectedTo;
-        self.as_socket(|sock| sock.sendto(buf, connectedTo))
+        let connected_to = self.connectedTo;
+        self.as_socket(|sock| sock.sendto(buf, connected_to))
     }
 }
 

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -36,7 +36,7 @@ impl UdpSocket {
     }
 
     pub fn connect(self, other: SocketAddr) -> UdpStream {
-        UdpStream { socket: self, connectedTo: other }
+        UdpStream { socket: self, connected_to: other }
     }
 
     pub fn socket_name(&mut self) -> IoResult<SocketAddr> {
@@ -59,7 +59,7 @@ impl Clone for UdpSocket {
 
 pub struct UdpStream {
     priv socket: UdpSocket,
-    priv connectedTo: SocketAddr
+    priv connected_to: SocketAddr
 }
 
 impl UdpStream {
@@ -72,7 +72,7 @@ impl UdpStream {
 
 impl Reader for UdpStream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
-        let peer = self.connectedTo;
+        let peer = self.connected_to;
         self.as_socket(|sock| {
             match sock.recvfrom(buf) {
                 Ok((_nread, src)) if src != peer => Ok(0),
@@ -85,7 +85,7 @@ impl Reader for UdpStream {
 
 impl Writer for UdpStream {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
-        let connected_to = self.connectedTo;
+        let connected_to = self.connected_to;
         self.as_socket(|sock| sock.sendto(buf, connected_to))
     }
 }

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -65,6 +65,7 @@
 #[allow(non_camel_case_types)];
 #[allow(non_uppercase_statics)];
 #[allow(missing_doc)];
+#[allow(uppercase_variables)];
 
 // Initial glob-exports mean that all the contents of all the modules
 // wind up exported, if you're interested in writing platform-specific code.

--- a/src/libstd/rand/distributions/mod.rs
+++ b/src/libstd/rand/distributions/mod.rs
@@ -213,8 +213,8 @@ mod ziggurat_tables;
 fn ziggurat<R:Rng>(
             rng: &mut R,
             symmetric: bool,
-            X: ziggurat_tables::ZigTable,
-            F: ziggurat_tables::ZigTable,
+            x_tab: ziggurat_tables::ZigTable,
+            f_tab: ziggurat_tables::ZigTable,
             pdf: 'static |f64| -> f64,
             zero_case: 'static |&mut R, f64| -> f64)
             -> f64 {
@@ -233,19 +233,19 @@ fn ziggurat<R:Rng>(
         // u is either U(-1, 1) or U(0, 1) depending on if this is a
         // symmetric distribution or not.
         let u = if symmetric {2.0 * f - 1.0} else {f};
-        let x = u * X[i];
+        let x = u * x_tab[i];
 
         let test_x = if symmetric {num::abs(x)} else {x};
 
-        // algebraically equivalent to |u| < X[i+1]/X[i] (or u < X[i+1]/X[i])
-        if test_x < X[i + 1] {
+        // algebraically equivalent to |u| < x_tab[i+1]/x_tab[i] (or u < x_tab[i+1]/x_tab[i])
+        if test_x < x_tab[i + 1] {
             return x;
         }
         if i == 0 {
             return zero_case(rng, u);
         }
         // algebraically equivalent to f1 + DRanU()*(f0 - f1) < 1
-        if F[i + 1] + (F[i] - F[i + 1]) * rng.gen() < pdf(x) {
+        if f_tab[i + 1] + (f_tab[i] - f_tab[i + 1]) * rng.gen() < pdf(x) {
             return x;
         }
     }

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -803,11 +803,11 @@ mod test {
 
     #[test]
     fn test_sample() {
-        let MIN_VAL = 1;
-        let MAX_VAL = 100;
+        let min_val = 1;
+        let max_val = 100;
 
         let mut r = rng();
-        let vals = range(MIN_VAL, MAX_VAL).to_owned_vec();
+        let vals = range(min_val, max_val).to_owned_vec();
         let small_sample = r.sample(vals.iter(), 5);
         let large_sample = r.sample(vals.iter(), vals.len() + 5);
 
@@ -815,7 +815,7 @@ mod test {
         assert_eq!(large_sample.len(), vals.len());
 
         assert!(small_sample.iter().all(|e| {
-            **e >= MIN_VAL && **e <= MAX_VAL
+            **e >= min_val && **e <= max_val
         }));
     }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -575,9 +575,9 @@ fn canonical_sort(comb: &mut [(char, u8)]) {
     for i in range(0, len) {
         let mut swapped = false;
         for j in range(1, len-i) {
-            let classA = *comb[j-1].ref1();
-            let classB = *comb[j].ref1();
-            if classA != 0 && classB != 0 && classA > classB {
+            let class_a = *comb[j-1].ref1();
+            let class_b = *comb[j].ref1();
+            if class_a != 0 && class_b != 0 && class_a > class_b {
                 comb.swap(j-1, j);
                 swapped = true;
             }
@@ -3427,8 +3427,8 @@ mod tests {
         let repl = ~"دولة الكويت";
 
         let a = ~"ประเ";
-        let A = ~"دولة الكويتทศไทย中华";
-        assert_eq!(data.replace(a, repl), A);
+        let a2 = ~"دولة الكويتทศไทย中华";
+        assert_eq!(data.replace(a, repl), a2);
     }
 
     #[test]
@@ -3437,8 +3437,8 @@ mod tests {
         let repl = ~"دولة الكويت";
 
         let b = ~"ะเ";
-        let B = ~"ปรدولة الكويتทศไทย中华";
-        assert_eq!(data.replace(b,   repl), B);
+        let b2 = ~"ปรدولة الكويتทศไทย中华";
+        assert_eq!(data.replace(b, repl), b2);
     }
 
     #[test]
@@ -3447,8 +3447,8 @@ mod tests {
         let repl = ~"دولة الكويت";
 
         let c = ~"中华";
-        let C = ~"ประเทศไทยدولة الكويت";
-        assert_eq!(data.replace(c, repl), C);
+        let c2 = ~"ประเทศไทยدولة الكويت";
+        assert_eq!(data.replace(c, repl), c2);
     }
 
     #[test]

--- a/src/libsync/sync/mod.rs
+++ b/src/libsync/sync/mod.rs
@@ -217,7 +217,7 @@ impl<'a> Condvar<'a> {
      * wait() is equivalent to wait_on(0).
      */
     pub fn wait_on(&self, condvar_id: uint) {
-        let mut WaitEnd = None;
+        let mut wait_end = None;
         let mut out_of_bounds = None;
         // Release lock, 'atomically' enqueuing ourselves in so doing.
         unsafe {
@@ -230,7 +230,7 @@ impl<'a> Condvar<'a> {
                     }
                     // Create waiter nobe, and enqueue ourself to
                     // be woken up by a signaller.
-                    WaitEnd = Some(state.blocked[condvar_id].wait_end());
+                    wait_end = Some(state.blocked[condvar_id].wait_end());
                 } else {
                     out_of_bounds = Some(state.blocked.len());
                 }
@@ -244,7 +244,7 @@ impl<'a> Condvar<'a> {
             // signaller already sent -- I mean 'unconditionally' in contrast
             // with acquire().)
             (|| {
-                let _ = WaitEnd.take_unwrap().recv();
+                let _ = wait_end.take_unwrap().recv();
             }).finally(|| {
                 // Reacquire the condvar.
                 match self.order {

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -339,12 +339,12 @@ fn highlight_lines(err: &mut EmitterWriter,
         for _ in range(0, skip) { s.push_char(' '); }
         let orig = fm.get_line(*lines.lines.get(0) as int);
         for pos in range(0u, left-skip) {
-            let curChar = orig[pos] as char;
+            let cur_char = orig[pos] as char;
             // Whenever a tab occurs on the previous line, we insert one on
             // the error-point-squiggly-line as well (instead of a space).
             // That way the squiggly line will usually appear in the correct
             // position.
-            match curChar {
+            match cur_char {
                 '\t' => s.push_char('\t'),
                 _ => s.push_char(' '),
             };

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -124,10 +124,10 @@ pub fn buf_str(toks: Vec<Token> , szs: Vec<int> , left: uint, right: uint,
     let n = toks.len();
     assert_eq!(n, szs.len());
     let mut i = left;
-    let mut L = lim;
+    let mut l = lim;
     let mut s = ~"[";
-    while i != right && L != 0u {
-        L -= 1u;
+    while i != right && l != 0u {
+        l -= 1u;
         if i != left {
             s.push_str(", ");
         }
@@ -427,15 +427,15 @@ impl Printer {
         self.right %= self.buf_len;
         assert!((self.right != self.left));
     }
-    pub fn advance_left(&mut self, x: Token, L: int) -> io::IoResult<()> {
+    pub fn advance_left(&mut self, x: Token, l: int) -> io::IoResult<()> {
         debug!("advnce_left ~[{},{}], sizeof({})={}", self.left, self.right,
-               self.left, L);
-        if L >= 0 {
-            let ret = self.print(x.clone(), L);
+               self.left, l);
+        if l >= 0 {
+            let ret = self.print(x.clone(), l);
             match x {
               Break(b) => self.left_total += b.blank_space,
               String(_, len) => {
-                assert_eq!(len, L); self.left_total += len;
+                assert_eq!(len, l); self.left_total += len;
               }
               _ => ()
             }
@@ -510,8 +510,8 @@ impl Printer {
         }
         write!(self.out, "{}", s)
     }
-    pub fn print(&mut self, x: Token, L: int) -> io::IoResult<()> {
-        debug!("print {} {} (remaining line space={})", tok_str(x.clone()), L,
+    pub fn print(&mut self, x: Token, l: int) -> io::IoResult<()> {
+        debug!("print {} {} (remaining line space={})", tok_str(x.clone()), l,
                self.space);
         debug!("{}", buf_str(self.token.clone(),
                              self.size.clone(),
@@ -520,7 +520,7 @@ impl Printer {
                              6));
         match x {
           Begin(b) => {
-            if L > self.space {
+            if l > self.space {
                 let col = self.margin - self.space + b.offset;
                 debug!("print Begin -> push broken block at col {}", col);
                 self.print_stack.push(PrintStackElem {
@@ -560,7 +560,7 @@ impl Printer {
                 ret
               }
               Broken(Inconsistent) => {
-                if L > self.space {
+                if l > self.space {
                     debug!("print Break({}+{}) w/ newline in inconsistent",
                            top.offset, b.offset);
                     let ret = self.print_newline(top.offset + b.offset);
@@ -578,8 +578,8 @@ impl Printer {
           }
           String(s, len) => {
             debug!("print String({})", s);
-            assert_eq!(L, len);
-            // assert!(L <= space);
+            assert_eq!(l, len);
+            // assert!(l <= space);
             self.space -= len;
             self.print_str(s)
           }

--- a/src/test/compile-fail/lint-uppercase-variables.rs
+++ b/src/test/compile-fail/lint-uppercase-variables.rs
@@ -1,0 +1,34 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deny(uppercase_variables)];
+
+use std::io::File;
+use std::io::IoError;
+
+fn test(Xx: uint) { //~ ERROR variable names should start with a lowercase character
+    println!("{}", Xx);
+}
+
+fn main() {
+    let Test: uint = 0; //~ ERROR variable names should start with a lowercase character
+    println!("{}", Test);
+
+    let mut f = File::open(&Path::new("something.txt"));
+    let mut buff = [0u8, ..16];
+    match f.read(buff) {
+        Ok(cnt) => println!("read this many bytes: {}", cnt),
+        Err(IoError{ kind: EndOfFile, .. }) => println!("Got end of file: {}", EndOfFile.to_str()),
+                        //~^ ERROR variable names should start with a lowercase character
+    }
+
+    test(1);
+}
+

--- a/src/test/compile-fail/lint-uppercase-variables.rs
+++ b/src/test/compile-fail/lint-uppercase-variables.rs
@@ -13,6 +13,10 @@
 use std::io::File;
 use std::io::IoError;
 
+struct Something {
+    X: uint //~ ERROR structure field names should start with a lowercase character
+}
+
 fn test(Xx: uint) { //~ ERROR variable names should start with a lowercase character
     println!("{}", Xx);
 }
@@ -30,5 +34,7 @@ fn main() {
     }
 
     test(1);
+
+    let _ = Something { X: 0 };
 }
 


### PR DESCRIPTION
I added a new lint for variables whose names contain uppercase characters, since, by convention, variable names should be all lowercase. What motivated me to work on this was when I ran into something like the following:

``` rust
use std::io::File;
use std::io::IoError;

fn main() {
    let mut f = File::open(&Path::new("/something.txt"));
    let mut buff = [0u8, ..16];
    match f.read(buff) {
        Ok(cnt) => println!("read this many bytes: {}", cnt),
        Err(IoError{ kind: EndOfFile, .. }) => println!("Got end of file: {}", EndOfFile.to_str()),
    }
}
```

I then got compile errors when I tried to add a wildcard match pattern at the end which I found very confusing since I believed that the 2nd match arm was only matching the EndOfFile condition. The problem is that I hadn't imported io::EndOfFile into the local scope. So, I thought that I was using EndOfFile as a sub-pattern, however, what I was actually doing was creating a new local variable named EndOfFile. This lint makes this error easier to spot by providing a warning that the variable name EndOfFile contains a uppercase characters which provides a nice hint as to why the code isn't doing what is intended.

The lint warns on local bindings as well:

``` rust
let Hi = 0;
```

And also struct fields:

``` rust
struct Something {
    X: uint
}
```
