### PR TITLE
 Correctly reset steals when hitting MAX_STEALS

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -867,7 +867,6 @@ impl num::FromStrRadix for f32 {
 #[cfg(test)]
 mod tests {
     use f32::*;
-    use prelude::*;
 
     use num::*;
     use num;

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -869,7 +869,6 @@ impl num::FromStrRadix for f64 {
 #[cfg(test)]
 mod tests {
     use f64::*;
-    use prelude::*;
 
     use num::*;
     use num;

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -65,7 +65,6 @@ use rt::task::Task;
 use str::{Str, SendStr, IntoMaybeOwned};
 
 #[cfg(test)] use any::{AnyOwnExt, AnyRefExt};
-#[cfg(test)] use ptr;
 #[cfg(test)] use result;
 
 /// Indicates the manner in which a task exited.


### PR DESCRIPTION
The previous code erroneously assumed that 'steals > cnt' was always true, but
that was a false assumption. The code was altered to decrement steals to a
minimum of 0 instead of taking all of cnt into account.

I didn't include the exact test from #12295 because it could run for quite
awhile, and instead set the threshold for MAX_STEALS to much lower during
testing. I found that this triggered the old bug quite frequently when running
without this fix.

Closes #12295
