### PR TITLE
move extra::test to libtest

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -50,7 +50,7 @@
 ################################################################################
 
 TARGET_CRATES := std extra green rustuv native flate arena glob term semver \
-                 uuid serialize sync getopts collections num
+                 uuid serialize sync getopts collections num test
 HOST_CRATES := syntax rustc rustdoc fourcc
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustdoc rustc
@@ -63,7 +63,8 @@ DEPS_native := std
 DEPS_syntax := std term serialize collections
 DEPS_rustc := syntax native:rustllvm flate arena serialize sync getopts \
               collections extra
-DEPS_rustdoc := rustc native:sundown serialize sync getopts collections
+DEPS_rustdoc := rustc native:sundown serialize sync getopts collections \
+                test
 DEPS_flate := std native:miniz
 DEPS_arena := std collections
 DEPS_glob := std
@@ -76,8 +77,9 @@ DEPS_getopts := std
 DEPS_collections := std serialize
 DEPS_fourcc := syntax std
 DEPS_num := std extra
+DEPS_test := std extra collections getopts serialize term
 
-TOOL_DEPS_compiletest := extra green rustuv getopts
+TOOL_DEPS_compiletest := test green rustuv getopts
 TOOL_DEPS_rustdoc := rustdoc green rustuv
 TOOL_DEPS_rustc := rustc green rustuv
 TOOL_SOURCE_compiletest := $(S)src/compiletest/compiletest.rs

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -13,16 +13,13 @@
 #[allow(non_camel_case_types)];
 #[deny(warnings)];
 
-extern crate extra;
+extern crate test;
 extern crate getopts;
 
 use std::os;
 use std::io;
 use std::io::fs;
-
 use getopts::{optopt, optflag, reqopt};
-use extra::test;
-
 use common::config;
 use common::mode_run_pass;
 use common::mode_run_fail;

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -34,7 +34,7 @@ use std::str;
 use std::task;
 use std::vec;
 
-use extra::test::MetricMap;
+use test::MetricMap;
 
 pub fn run(config: config, testfile: ~str) {
 

--- a/src/doc/guide-testing.md
+++ b/src/doc/guide-testing.md
@@ -170,7 +170,7 @@ runner.
 
 The type signature of a benchmark function differs from a unit test:
 it takes a mutable reference to type
-`extra::test::BenchHarness`. Inside the benchmark function, any
+`test::BenchHarness`. Inside the benchmark function, any
 time-variable or "setup" code should execute first, followed by a call
 to `iter` on the benchmark harness, passing a closure that contains
 the portion of the benchmark you wish to actually measure the
@@ -185,9 +185,10 @@ amount.
 For example:
 
 ~~~
-extern crate extra;
+extern crate test;
+
 use std::vec;
-use extra::test::BenchHarness;
+use test::BenchHarness;
 
 #[bench]
 fn bench_sum_1024_ints(b: &mut BenchHarness) {
@@ -243,8 +244,8 @@ recognize that some calculation has no external effects and remove
 it entirely.
 
 ~~~
-extern crate extra;
-use extra::test::BenchHarness;
+extern crate test;
+use test::BenchHarness;
 
 #[bench]
 fn bench_xor_1000_ints(bh: &mut BenchHarness) {
@@ -273,15 +274,15 @@ example above by adjusting the `bh.iter` call to
 bh.iter(|| range(0, 1000).fold(0, |old, new| old ^ new))
 ~~~
 
-Or, the other option is to call the generic `extra::test::black_box`
+Or, the other option is to call the generic `test::black_box`
 function, which is an opaque "black box" to the optimizer and so
 forces it to consider any argument as used.
 
 ~~~
-use extra::test::black_box
+extern crate test;
 
 bh.iter(|| {
-        black_box(range(0, 1000).fold(0, |old, new| old ^ new));
+        test::black_box(range(0, 1000).fold(0, |old, new| old ^ new));
     });
 ~~~
 

--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -154,7 +154,7 @@ testing this code, the `fib` function will be included (so it can compile).
 
 Running tests often requires some special configuration to filter tests, find
 libraries, or try running ignored examples. The testing framework that rustdoc
-uses is build on `extra::test`, which is also used when you compile crates with
+uses is build on crate `test`, which is also used when you compile crates with
 rustc's `--test` flag. Extra arguments can be passed to rustdoc's test harness
 with the `--test-args` flag.
 

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -503,10 +503,10 @@ impl<T> Drop for TypedArena<T> {
 }
 
 #[cfg(test)]
-mod test {
-    extern crate extra;
+mod tests {
+    extern crate test;
+    use self::test::BenchHarness;
     use super::{Arena, TypedArena};
-    use self::extra::test::BenchHarness;
 
     struct Point {
         x: int,

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -938,7 +938,8 @@ impl<'a> Iterator<uint> for BitPositions<'a> {
 
 #[cfg(test)]
 mod tests {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
 
     use bitv::{Bitv, SmallBitv, BigBitv, BitvSet, from_bools, from_fn,
                from_bytes};

--- a/src/libcollections/deque.rs
+++ b/src/libcollections/deque.rs
@@ -41,10 +41,11 @@ pub trait Deque<T> : Mutable {
 
 #[cfg(test)]
 pub mod bench {
+    extern crate test;
+    use self::test::BenchHarness;
     use std::container::MutableMap;
     use std::{vec, rand};
     use std::rand::Rng;
-    use extra::test::BenchHarness;
 
     pub fn insert_rand_n<M:MutableMap<uint,uint>>(n: uint,
                                                   map: &mut M,

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -657,8 +657,9 @@ impl<D:Decoder,T:Decodable<D>> Decodable<D> for DList<T> {
 
 #[cfg(test)]
 mod tests {
+    extern crate test;
+    use self::test::BenchHarness;
     use deque::Deque;
-    use extra::test;
     use std::rand;
     use super::{DList, Node, ListInsertion};
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -20,7 +20,7 @@
 #[feature(macro_rules, managed_boxes)];
 
 extern crate serialize;
-#[cfg(test)] extern crate extra; // benchmark tests need this
+#[cfg(test)] extern crate test;
 
 pub use bitv::Bitv;
 pub use btree::BTree;

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -431,8 +431,9 @@ impl<D:Decoder,T:Decodable<D>> Decodable<D> for RingBuf<T> {
 
 #[cfg(test)]
 mod tests {
+    extern crate test;
+    use self::test::BenchHarness;
     use deque::Deque;
-    use extra::test;
     use std::clone::Clone;
     use std::cmp::Eq;
     use super::RingBuf;

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -470,9 +470,9 @@ mod test_map {
 
 #[cfg(test)]
 mod bench {
-
+    extern crate test;
+    use self::test::BenchHarness;
     use super::SmallIntMap;
-    use extra::test::BenchHarness;
     use deque::bench::{insert_rand_n, insert_seq_n, find_rand_n, find_seq_n};
 
     // Find seq

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -1494,9 +1494,9 @@ mod test_treemap {
 
 #[cfg(test)]
 mod bench {
-
+    extern crate test;
+    use self::test::BenchHarness;
     use super::TreeMap;
-    use extra::test::BenchHarness;
     use deque::bench::{insert_rand_n, insert_seq_n, find_rand_n, find_seq_n};
 
     // Find seq

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -36,15 +36,10 @@ Rust extras are part of the standard Rust distribution.
 
 extern crate sync;
 extern crate serialize;
-
 extern crate collections;
 
 // Utility modules
-
 pub mod c_vec;
-
-// And ... other stuff
-
 pub mod url;
 pub mod json;
 pub mod tempfile;
@@ -56,15 +51,11 @@ pub mod stats;
 #[cfg(unicode)]
 mod unicode;
 
-// Compiler support modules
-
-pub mod test;
-
 // A curious inner-module that's not exported that contains the binding
 // 'extra' so that macro-expanded references to extra::serialize and such
 // can be resolved within libextra.
 #[doc(hidden)]
 pub mod extra {
     pub use serialize;
-    pub use test;
 }
+

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -1025,7 +1025,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use std::vec;
     use stats::Stats;
 

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -2546,11 +2546,12 @@ mod bigint_tests {
 
 #[cfg(test)]
 mod bench {
-    use super::{BigInt, BigUint};
+    extern crate test;
+    use self::test::BenchHarness;
+    use super::BigUint;
     use std::iter;
     use std::mem::replace;
     use std::num::{FromPrimitive, Zero, One};
-    use extra::test::BenchHarness;
 
     fn factorial(n: uint) -> BigUint {
         let mut f: BigUint = One::one();

--- a/src/libnum/rational.rs
+++ b/src/libnum/rational.rs
@@ -430,8 +430,7 @@ mod test {
 
     mod arith {
         use super::{_0, _1, _2, _1_2, _3_2, _neg1_2, to_big};
-        use super::super::{Ratio, Rational, BigRational};
-
+        use super::super::{Ratio, Rational};
 
         #[test]
         fn test_add() {

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -635,7 +635,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use super::{Sha256, FixedBuffer, Digest};
 
     #[bench]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -23,6 +23,7 @@ extern crate serialize;
 extern crate sync;
 extern crate getopts;
 extern crate collections;
+extern crate testing = "test";
 
 use std::local_data;
 use std::io;

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -10,10 +10,10 @@
 
 use clean;
 
-use extra;
+use extra::json;
 use dl = std::unstable::dynamic_lib;
 
-pub type PluginJson = Option<(~str, extra::json::Json)>;
+pub type PluginJson = Option<(~str, json::Json)>;
 pub type PluginResult = (clean::Crate, PluginJson);
 pub type plugin_callback = extern fn (clean::Crate) -> PluginResult;
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -15,8 +15,8 @@ use std::os;
 use std::run;
 use std::str;
 
+use testing;
 use extra::tempfile::TempDir;
-use extra::test;
 use rustc::back::link;
 use rustc::driver::driver;
 use rustc::driver::session;
@@ -89,7 +89,7 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
     let mut args = args.to_owned_vec();
     args.unshift(~"rustdoctest");
 
-    test::test_main(args, collector.tests);
+    testing::test_main(args, collector.tests);
 
     0
 }
@@ -164,7 +164,7 @@ fn maketest(s: &str, cratename: &str) -> ~str {
 }
 
 pub struct Collector {
-    priv tests: ~[test::TestDescAndFn],
+    priv tests: ~[testing::TestDescAndFn],
     priv names: ~[~str],
     priv libs: @RefCell<HashSet<Path>>,
     priv cnt: uint,
@@ -180,13 +180,13 @@ impl Collector {
         let libs = (*libs.get()).clone();
         let cratename = self.cratename.to_owned();
         debug!("Creating test {}: {}", name, test);
-        self.tests.push(test::TestDescAndFn {
-            desc: test::TestDesc {
-                name: test::DynTestName(name),
+        self.tests.push(testing::TestDescAndFn {
+            desc: testing::TestDesc {
+                name: testing::DynTestName(name),
                 ignore: false,
                 should_fail: false, // compiler failures are test failures
             },
-            testfn: test::DynTestFn(proc() {
+            testfn: testing::DynTestFn(proc() {
                 runtest(test, cratename, libs, should_fail);
             }),
         });

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -260,8 +260,9 @@ impl<'a> FromBase64 for &'a str {
 }
 
 #[cfg(test)]
-mod test {
-    use extra::test::BenchHarness;
+mod tests {
+    extern crate test;
+    use self::test::BenchHarness;
     use base64::{Config, FromBase64, ToBase64, STANDARD, URL_SAFE};
 
     #[test]

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -1037,8 +1037,9 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
+    extern crate test;
+    use self::test::BenchHarness;
     use ebml::reader;
-    use extra::test::BenchHarness;
 
     #[bench]
     pub fn vuint_at_A_aligned(bh: &mut BenchHarness) {

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -139,7 +139,8 @@ impl<'a> FromHex for &'a str {
 
 #[cfg(test)]
 mod tests {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use hex::{FromHex, ToHex};
 
     #[test]

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -24,7 +24,7 @@ Core encoding and decoding interfaces.
 
 // test harness access
 #[cfg(test)]
-extern crate extra;
+extern crate test;
 
 pub use self::serialize::{Decoder, Encoder, Decodable, Encodable,
     DecoderHelpers, EncoderHelpers};

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -664,7 +664,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use libc;
     use prelude::*;
 

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -346,11 +346,12 @@ impl<S: Stream> Writer for BufferedStream<S> {
 
 #[cfg(test)]
 mod test {
+    extern crate test;
     use io;
     use prelude::*;
     use super::*;
     use super::super::mem::{MemReader, MemWriter, BufReader};
-    use Harness = extra::test::BenchHarness;
+    use Harness = self::test::BenchHarness;
 
     /// A type, free to create, primarily intended for benchmarking creation of
     /// wrappers that, just for construction, don't need a Reader/Writer that

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -456,7 +456,8 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use container::Container;
 
     macro_rules! u64_from_be_bytes_bench_impl(

--- a/src/libstd/mem.rs
+++ b/src/libstd/mem.rs
@@ -267,8 +267,8 @@ mod tests {
 /// Completely miscellaneous language-construct benchmarks.
 #[cfg(test)]
 mod bench {
-
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use option::{Some,None};
 
     // Static/dynamic method dispatch

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -865,7 +865,6 @@ impl num::FromStrRadix for f32 {
 #[cfg(test)]
 mod tests {
     use f32::*;
-
     use num::*;
     use num;
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -867,7 +867,6 @@ impl num::FromStrRadix for f64 {
 #[cfg(test)]
 mod tests {
     use f64::*;
-
     use num::*;
     use num;
 

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1734,10 +1734,11 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
+    extern crate test;
+    use self::test::BenchHarness;
     use num;
     use vec;
     use prelude::*;
-    use extra::test::BenchHarness;
 
     #[bench]
     fn bench_pow_function(b: &mut BenchHarness) {

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -803,7 +803,8 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use rand::{XorShiftRng, Rng};
     use to_str::ToStr;
     use f64;

--- a/src/libstd/ops.rs
+++ b/src/libstd/ops.rs
@@ -466,8 +466,8 @@ pub trait Index<Index,Result> {
 
 #[cfg(test)]
 mod bench {
-
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use ops::Drop;
 
     // Overhead of dtors

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -1250,7 +1250,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use super::*;
     use prelude::*;
 

--- a/src/libstd/rand/distributions/exponential.rs
+++ b/src/libstd/rand/distributions/exponential.rs
@@ -119,7 +119,8 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use mem::size_of;
     use prelude::*;
     use rand::{XorShiftRng, RAND_BENCH_N};

--- a/src/libstd/rand/distributions/gamma.rs
+++ b/src/libstd/rand/distributions/gamma.rs
@@ -371,7 +371,8 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use mem::size_of;
     use prelude::*;
     use rand::distributions::IndependentSample;

--- a/src/libstd/rand/distributions/normal.rs
+++ b/src/libstd/rand/distributions/normal.rs
@@ -187,7 +187,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use mem::size_of;
     use prelude::*;
     use rand::{XorShiftRng, RAND_BENCH_N};

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -845,8 +845,9 @@ static RAND_BENCH_N: u64 = 100;
 
 #[cfg(test)]
 mod bench {
+    extern crate test;
+    use self::test::BenchHarness;
     use prelude::*;
-    use extra::test::BenchHarness;
     use rand::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng, RAND_BENCH_N};
     use mem::size_of;
 

--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -107,7 +107,8 @@ pub unsafe fn exchange_free(ptr: *u8) {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
 
     #[bench]
     fn alloc_owned_small(bh: &mut BenchHarness) {

--- a/src/libstd/rt/local_heap.rs
+++ b/src/libstd/rt/local_heap.rs
@@ -308,7 +308,8 @@ pub fn live_allocs() -> *mut Box {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
 
     #[bench]
     fn alloc_managed_small(bh: &mut BenchHarness) {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -4498,7 +4498,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use super::*;
     use prelude::*;
 

--- a/src/libstd/trie.rs
+++ b/src/libstd/trie.rs
@@ -902,10 +902,11 @@ mod test_map {
 
 #[cfg(test)]
 mod bench_map {
+    extern crate test;
+    use self::test::BenchHarness;
     use super::*;
     use prelude::*;
     use rand::{weak_rng, Rng};
-    use extra::test::BenchHarness;
 
     #[bench]
     fn bench_iter_small(bh: &mut BenchHarness) {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -4360,7 +4360,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use extra::test::BenchHarness;
+    extern crate test;
+    use self::test::BenchHarness;
     use mem;
     use prelude::*;
     use ptr;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1196,8 +1196,9 @@ pub enum InlinedItem {
 
 #[cfg(test)]
 mod test {
+    extern crate extra;
+    use self::extra::json;
     use serialize;
-    use extra;
     use codemap::*;
     use super::*;
 
@@ -1223,6 +1224,6 @@ mod test {
             },
         };
         // doesn't matter which encoder we use....
-        let _f = (&e as &serialize::Encodable<extra::json::Encoder>);
+        let _f = (&e as &serialize::Encodable<json::Encoder>);
     }
 }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -32,7 +32,6 @@ This API is completely unstable and subject to change.
 
 #[deny(non_camel_case_types)];
 
-#[cfg(test)] extern crate extra;
 extern crate serialize;
 extern crate term;
 extern crate collections;

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -283,9 +283,10 @@ pub fn maybe_aborted<T>(result: T, mut p: Parser) -> T {
 
 #[cfg(test)]
 mod test {
+    extern crate extra;
+    use self::extra::json;
     use super::*;
     use serialize::Encodable;
-    use extra;
     use std::io;
     use std::io::MemWriter;
     use std::str;
@@ -300,9 +301,9 @@ mod test {
     use util::parser_testing::string_to_stmt;
 
     #[cfg(test)]
-    fn to_json_str<'a, E: Encodable<extra::json::Encoder<'a>>>(val: &E) -> ~str {
+    fn to_json_str<'a, E: Encodable<json::Encoder<'a>>>(val: &E) -> ~str {
         let mut writer = MemWriter::new();
-        let mut encoder = extra::json::Encoder::new(&mut writer as &mut io::Writer);
+        let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
         val.encode(&mut encoder);
         str::from_utf8_owned(writer.unwrap()).unwrap()
     }

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -61,7 +61,7 @@ Examples of string representations:
 
 // test harness access
 #[cfg(test)]
-extern crate extra;
+extern crate test;
 extern crate serialize;
 
 use std::str;
@@ -812,8 +812,9 @@ mod test {
 
 #[cfg(test)]
 mod bench {
+    extern crate test;
+    use self::test::BenchHarness;
     use super::Uuid;
-    use extra::test::BenchHarness;
 
     #[bench]
     pub fn create_uuids(bh: &mut BenchHarness) {


### PR DESCRIPTION
I don't think `extra` is a good/meaningful name for a library. `libextra` should disappear, and we move all of its sub modules out of it. This PR is just one of that steps: move `extra::test` to `libtest`.

I didn't add `libtest` to doc index, because it's an internal library currently.

**Update:**

All comments addressed. All tests passed. Rebased and squashed.
