### PR TITLE
Refactor collections::list

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3256,10 +3256,10 @@ An example of a *recursive* type and its use:
 ~~~~
 enum List<T> {
   Nil,
-  Cons(T, @List<T>)
+  Cons(T, ~List<T>)
 }
 
-let a: List<int> = Cons(7, @Cons(13, @Nil));
+let a: List<int> = Cons(7, ~Cons(13, ~Nil));
 ~~~~
 
 ### Pointer types

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -25,7 +25,6 @@
 extern crate collections;
 
 use collections::list::{List, Cons, Nil};
-use collections::list;
 
 use std::cast::{transmute, transmute_mut, transmute_mut_region};
 use std::cast;
@@ -44,7 +43,7 @@ use std::vec;
 // The way arena uses arrays is really deeply awful. The arrays are
 // allocated, and have capacities reserved, but the fill for the array
 // will always stay at 0.
-#[deriving(Clone)]
+#[deriving(Clone, Eq)]
 struct Chunk {
     data: Rc<RefCell<~[u8]>>,
     fill: Cell<uint>,
@@ -119,13 +118,11 @@ impl Drop for Arena {
     fn drop(&mut self) {
         unsafe {
             destroy_chunk(&self.head);
-
-            list::each(self.chunks.get(), |chunk| {
+            for chunk in self.chunks.get().iter() {
                 if !chunk.is_pod.get() {
                     destroy_chunk(chunk);
                 }
-                true
-            });
+            }
         }
     }
 }

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -61,6 +61,14 @@ impl<T> List<T> {
           Cons(ref head, _) => Some(head)
         }
     }
+
+    /// Returns all but the first element of a list
+    pub fn tail(&self) -> Option<@List<T>> {
+        match *self {
+            Nil => None,
+            Cons(_, tail) => Some(tail)
+        }
+    }
 }
 
 impl<T> Container for List<T> {
@@ -75,14 +83,6 @@ impl<T:Eq> List<T> {
     /// Returns true if a list contains an element with the given value
     pub fn contains(&self, element: T) -> bool {
         self.iter().any(|list_element| *list_element == element)
-    }
-}
-
-/// Returns all but the first element of a list
-pub fn tail<T>(list: @List<T>) -> @List<T> {
-    match *list {
-        Cons(_, tail) => return tail,
-        Nil => fail!("list empty")
     }
 }
 
@@ -117,7 +117,7 @@ fn push<T:Clone>(ll: &mut @list<T>, vv: T) {
 
 #[cfg(test)]
 mod tests {
-    use list::{List, Nil, tail};
+    use list::{List, Nil};
     use list;
 
     #[test]
@@ -143,13 +143,13 @@ mod tests {
 
     #[test]
     fn test_from_vec() {
-        let list = @List::from_vec([0, 1, 2]);
+        let list = List::from_vec([0, 1, 2]);
         assert_eq!(list.head().unwrap(), &0);
 
-        let mut tail = tail(list);
+        let mut tail = list.tail().unwrap();
         assert_eq!(tail.head().unwrap(), &1);
 
-        tail = tail(tail);
+        tail = tail.tail().unwrap();
         assert_eq!(tail.head().unwrap(), &2);
     }
 

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -118,34 +118,6 @@ fn push<T:Clone>(ll: &mut @list<T>, vv: T) {
 }
 */
 
-/// Iterate over a list
-pub fn iter<T>(list: @List<T>, f: |&T|) {
-    let mut cur = list;
-    loop {
-        cur = match *cur {
-          Cons(ref head, tail) => {
-            f(head);
-            tail
-          }
-          Nil => break
-        }
-    }
-}
-
-/// Iterate over a list
-pub fn each<T>(list: @List<T>, f: |&T| -> bool) -> bool {
-    let mut cur = list;
-    loop {
-        cur = match *cur {
-          Cons(ref head, tail) => {
-            if !f(head) { return false; }
-            tail
-          }
-          Nil => { return true; }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use list::{List, Nil, head, tail};

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -17,6 +17,42 @@ pub enum List<T> {
     Nil,
 }
 
+pub struct Items<'a, T> {
+    priv head: &'a List<T>,
+    priv next: Option<&'a @List<T>>
+}
+
+impl<'a, T> Iterator<&'a T> for Items<'a, T> {
+    fn next(&mut self) -> Option<&'a T> {
+        match self.next {
+            None => match *self.head {
+                Nil => None,
+                Cons(ref value, ref tail) => {
+                    self.next = Some(tail);
+                    Some(value)
+                }
+            },
+            Some(next) => match **next {
+                Nil => None,
+                Cons(ref value, ref tail) => {
+                    self.next = Some(tail);
+                    Some(value)
+                }
+            }
+        }
+    }
+}
+
+impl<T> List<T> {
+    /// Returns a forward iterator
+    pub fn iter<'a>(&'a self) -> Items<'a, T> {
+        Items {
+            head: self,
+            next: None
+        }
+    }
+}
+
 /**
  * Left fold
  *
@@ -180,6 +216,16 @@ mod tests {
     use list;
 
     use std::option;
+
+    #[test]
+    fn test_iter() {
+        let list = List::from_vec([0, 1, 2]);
+        let mut iter = list.iter();
+        assert_eq!(&0, iter.next().unwrap());
+        assert_eq!(&1, iter.next().unwrap());
+        assert_eq!(&2, iter.next().unwrap());
+        assert_eq!(None, iter.next());
+    }
 
     #[test]
     fn test_is_empty() {

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -10,8 +10,6 @@
 
 //! A standard, garbage-collected linked list.
 
-
-
 #[deriving(Clone, Eq)]
 #[allow(missing_doc)]
 pub enum List<T> {
@@ -33,30 +31,30 @@ pub fn from_vec<T:Clone + 'static>(v: &[T]) -> @List<T> {
  *
  * # Arguments
  *
- * * ls - The list to fold
+ * * list - The list to fold
  * * z - The initial value
  * * f - The function to apply
  */
-pub fn foldl<T:Clone,U>(z: T, ls: @List<U>, f: |&T, &U| -> T) -> T {
+pub fn foldl<T:Clone,U>(z: T, list: @List<U>, f: |&T, &U| -> T) -> T {
     let mut accum: T = z;
-    iter(ls, |elt| accum = f(&accum, elt));
+    iter(list, |element| accum = f(&accum, element));
     accum
 }
 
 /**
  * Search for an element that matches a given predicate
  *
- * Apply function `f` to each element of `ls`, starting from the first.
+ * Apply function `f` to each element of `list`, starting from the first.
  * When function `f` returns true then an option containing the element
  * is returned. If `f` matches no elements then none is returned.
  */
-pub fn find<T:Clone>(ls: @List<T>, f: |&T| -> bool) -> Option<T> {
-    let mut ls = ls;
+pub fn find<T:Clone>(list: @List<T>, f: |&T| -> bool) -> Option<T> {
+    let mut list = list;
     loop {
-        ls = match *ls {
-          Cons(ref hd, tl) => {
-            if f(hd) { return Some((*hd).clone()); }
-            tl
+        list = match *list {
+          Cons(ref head, tail) => {
+            if f(head) { return Some((*head).clone()); }
+            tail
           }
           Nil => return None
         }
@@ -66,17 +64,17 @@ pub fn find<T:Clone>(ls: @List<T>, f: |&T| -> bool) -> Option<T> {
 /**
  * Returns true if a list contains an element that matches a given predicate
  *
- * Apply function `f` to each element of `ls`, starting from the first.
+ * Apply function `f` to each element of `list`, starting from the first.
  * When function `f` returns true then it also returns true. If `f` matches no
  * elements then false is returned.
  */
-pub fn any<T>(ls: @List<T>, f: |&T| -> bool) -> bool {
-    let mut ls = ls;
+pub fn any<T>(list: @List<T>, f: |&T| -> bool) -> bool {
+    let mut list = list;
     loop {
-        ls = match *ls {
-            Cons(ref hd, tl) => {
-                if f(hd) { return true; }
-                tl
+        list = match *list {
+            Cons(ref head, tail) => {
+                if f(head) { return true; }
+                tail
             }
             Nil => return false
         }
@@ -84,53 +82,53 @@ pub fn any<T>(ls: @List<T>, f: |&T| -> bool) -> bool {
 }
 
 /// Returns true if a list contains an element with the given value
-pub fn has<T:Eq>(ls: @List<T>, elt: T) -> bool {
+pub fn has<T:Eq>(list: @List<T>, element: T) -> bool {
     let mut found = false;
-    each(ls, |e| {
-        if *e == elt { found = true; false } else { true }
+    each(list, |e| {
+        if *e == element { found = true; false } else { true }
     });
     return found;
 }
 
 /// Returns true if the list is empty
-pub fn is_empty<T>(ls: @List<T>) -> bool {
-    match *ls {
+pub fn is_empty<T>(list: @List<T>) -> bool {
+    match *list {
         Nil => true,
         _ => false
     }
 }
 
 /// Returns the length of a list
-pub fn len<T>(ls: @List<T>) -> uint {
+pub fn len<T>(list: @List<T>) -> uint {
     let mut count = 0u;
-    iter(ls, |_e| count += 1u);
+    iter(list, |_e| count += 1u);
     count
 }
 
 /// Returns all but the first element of a list
-pub fn tail<T>(ls: @List<T>) -> @List<T> {
-    match *ls {
-        Cons(_, tl) => return tl,
+pub fn tail<T>(list: @List<T>) -> @List<T> {
+    match *list {
+        Cons(_, tail) => return tail,
         Nil => fail!("list empty")
     }
 }
 
 /// Returns the first element of a list
-pub fn head<T:Clone>(ls: @List<T>) -> T {
-    match *ls {
-      Cons(ref hd, _) => (*hd).clone(),
+pub fn head<T:Clone>(list: @List<T>) -> T {
+    match *list {
+      Cons(ref head, _) => (*head).clone(),
       // makes me sad
       _ => fail!("head invoked on empty list")
     }
 }
 
 /// Appends one list to another
-pub fn append<T:Clone + 'static>(l: @List<T>, m: @List<T>) -> @List<T> {
-    match *l {
-      Nil => return m,
-      Cons(ref x, xs) => {
-        let rest = append(xs, m);
-        return @Cons((*x).clone(), rest);
+pub fn append<T:Clone + 'static>(list: @List<T>, other: @List<T>) -> @List<T> {
+    match *list {
+      Nil => return other,
+      Cons(ref head, tail) => {
+        let rest = append(tail, other);
+        return @Cons((*head).clone(), rest);
       }
     }
 }
@@ -144,13 +142,13 @@ fn push<T:Clone>(ll: &mut @list<T>, vv: T) {
 */
 
 /// Iterate over a list
-pub fn iter<T>(l: @List<T>, f: |&T|) {
-    let mut cur = l;
+pub fn iter<T>(list: @List<T>, f: |&T|) {
+    let mut cur = list;
     loop {
         cur = match *cur {
-          Cons(ref hd, tl) => {
-            f(hd);
-            tl
+          Cons(ref head, tail) => {
+            f(head);
+            tail
           }
           Nil => break
         }
@@ -158,13 +156,13 @@ pub fn iter<T>(l: @List<T>, f: |&T|) {
 }
 
 /// Iterate over a list
-pub fn each<T>(l: @List<T>, f: |&T| -> bool) -> bool {
-    let mut cur = l;
+pub fn each<T>(list: @List<T>, f: |&T| -> bool) -> bool {
+    let mut cur = list;
     loop {
         cur = match *cur {
-          Cons(ref hd, tl) => {
-            if !f(hd) { return false; }
-            tl
+          Cons(ref head, tail) => {
+            if !f(head) { return false; }
+            tail
           }
           Nil => { return true; }
         }
@@ -191,11 +189,11 @@ mod tests {
 
     #[test]
     fn test_from_vec() {
-        let l = from_vec([0, 1, 2]);
+        let list = from_vec([0, 1, 2]);
 
-        assert_eq!(head(l), 0);
+        assert_eq!(head(list), 0);
 
-        let tail_l = tail(l);
+        let tail_l = tail(list);
         assert_eq!(head(tail_l), 1);
 
         let tail_tail_l = tail(tail_l);
@@ -211,9 +209,9 @@ mod tests {
     #[test]
     fn test_foldl() {
         fn add(a: &uint, b: &int) -> uint { return *a + (*b as uint); }
-        let l = from_vec([0, 1, 2, 3, 4]);
+        let list = from_vec([0, 1, 2, 3, 4]);
         let empty = @list::Nil::<int>;
-        assert_eq!(list::foldl(0u, l, add), 10u);
+        assert_eq!(list::foldl(0u, list, add), 10u);
         assert_eq!(list::foldl(0u, empty, add), 0u);
     }
 
@@ -222,50 +220,50 @@ mod tests {
         fn sub(a: &int, b: &int) -> int {
             *a - *b
         }
-        let l = from_vec([1, 2, 3, 4]);
-        assert_eq!(list::foldl(0, l, sub), -10);
+        let list = from_vec([1, 2, 3, 4]);
+        assert_eq!(list::foldl(0, list, sub), -10);
     }
 
     #[test]
     fn test_find_success() {
         fn match_(i: &int) -> bool { return *i == 2; }
-        let l = from_vec([0, 1, 2]);
-        assert_eq!(list::find(l, match_), option::Some(2));
+        let list = from_vec([0, 1, 2]);
+        assert_eq!(list::find(list, match_), option::Some(2));
     }
 
     #[test]
     fn test_find_fail() {
         fn match_(_i: &int) -> bool { return false; }
-        let l = from_vec([0, 1, 2]);
+        let list = from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
-        assert_eq!(list::find(l, match_), option::None::<int>);
+        assert_eq!(list::find(list, match_), option::None::<int>);
         assert_eq!(list::find(empty, match_), option::None::<int>);
     }
 
     #[test]
     fn test_any() {
         fn match_(i: &int) -> bool { return *i == 2; }
-        let l = from_vec([0, 1, 2]);
+        let list = from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
-        assert_eq!(list::any(l, match_), true);
+        assert_eq!(list::any(list, match_), true);
         assert_eq!(list::any(empty, match_), false);
     }
 
     #[test]
     fn test_has() {
-        let l = from_vec([5, 8, 6]);
+        let list = from_vec([5, 8, 6]);
         let empty = @list::Nil::<int>;
-        assert!((list::has(l, 5)));
-        assert!((!list::has(l, 7)));
-        assert!((list::has(l, 8)));
+        assert!((list::has(list, 5)));
+        assert!((!list::has(list, 7)));
+        assert!((list::has(list, 8)));
         assert!((!list::has(empty, 5)));
     }
 
     #[test]
     fn test_len() {
-        let l = from_vec([0, 1, 2]);
+        let list = from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
-        assert_eq!(list::len(l), 3u);
+        assert_eq!(list::len(list), 3u);
         assert_eq!(list::len(empty), 0u);
     }
 

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -53,26 +53,6 @@ impl<T> List<T> {
     }
 }
 
-/**
- * Returns true if a list contains an element that matches a given predicate
- *
- * Apply function `f` to each element of `list`, starting from the first.
- * When function `f` returns true then it also returns true. If `f` matches no
- * elements then false is returned.
- */
-pub fn any<T>(list: @List<T>, f: |&T| -> bool) -> bool {
-    let mut list = list;
-    loop {
-        list = match *list {
-            Cons(ref head, tail) => {
-                if f(head) { return true; }
-                tail
-            }
-            Nil => return false
-        }
-    };
-}
-
 /// Returns true if a list contains an element with the given value
 pub fn has<T:Eq>(list: @List<T>, element: T) -> bool {
     let mut found = false;
@@ -251,11 +231,13 @@ mod tests {
 
     #[test]
     fn test_any() {
-        fn match_(i: &int) -> bool { return *i == 2; }
-        let list = @List::from_vec([0, 1, 2]);
-        let empty = @list::Nil::<int>;
-        assert_eq!(list::any(list, match_), true);
-        assert_eq!(list::any(empty, match_), false);
+        fn match_(i: &int) -> bool { *i == 2 }
+
+        let empty = Nil::<int>;
+        assert_eq!(empty.iter().any(match_), false);
+
+        let list = List::from_vec([0, 1, 2]);
+        assert_eq!(list.iter().any(match_), true);
     }
 
     #[test]

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -54,25 +54,6 @@ impl<T> List<T> {
 }
 
 /**
- * Left fold
- *
- * Applies `f` to `u` and the first element in the list, then applies `f` to
- * the result of the previous call and the second element, and so on,
- * returning the accumulated result.
- *
- * # Arguments
- *
- * * list - The list to fold
- * * z - The initial value
- * * f - The function to apply
- */
-pub fn foldl<T:Clone,U>(z: T, list: @List<U>, f: |&T, &U| -> T) -> T {
-    let mut accum: T = z;
-    iter(list, |element| accum = f(&accum, element));
-    accum
-}
-
-/**
  * Search for an element that matches a given predicate
  *
  * Apply function `f` to each element of `list`, starting from the first.
@@ -258,21 +239,17 @@ mod tests {
     }
 
     #[test]
-    fn test_foldl() {
-        fn add(a: &uint, b: &int) -> uint { return *a + (*b as uint); }
-        let list = @List::from_vec([0, 1, 2, 3, 4]);
-        let empty = @list::Nil::<int>;
-        assert_eq!(list::foldl(0u, list, add), 10u);
-        assert_eq!(list::foldl(0u, empty, add), 0u);
-    }
+    fn test_fold() {
+        fn add_(a: uint, b: &uint) -> uint { a + *b }
+        fn subtract_(a: uint, b: &uint) -> uint { a - *b }
 
-    #[test]
-    fn test_foldl2() {
-        fn sub(a: &int, b: &int) -> int {
-            *a - *b
-        }
-        let list = @List::from_vec([1, 2, 3, 4]);
-        assert_eq!(list::foldl(0, list, sub), -10);
+        let empty = Nil::<uint>;
+        assert_eq!(empty.iter().fold(0u, add_), 0u);
+        assert_eq!(empty.iter().fold(10u, subtract_), 10u);
+
+        let list = List::from_vec([0u, 1u, 2u, 3u, 4u]);
+        assert_eq!(list.iter().fold(0u, add_), 10u);
+        assert_eq!(list.iter().fold(10u, subtract_), 0u);
     }
 
     #[test]

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -53,6 +53,14 @@ impl<T> List<T> {
             next: None
         }
     }
+
+    /// Returns the first element of a list
+    pub fn head<'a>(&'a self) -> Option<&'a T> {
+        match *self {
+          Nil => None,
+          Cons(ref head, _) => Some(head)
+        }
+    }
 }
 
 impl<T> Container for List<T> {
@@ -75,15 +83,6 @@ pub fn tail<T>(list: @List<T>) -> @List<T> {
     match *list {
         Cons(_, tail) => return tail,
         Nil => fail!("list empty")
-    }
-}
-
-/// Returns the first element of a list
-pub fn head<T:Clone>(list: @List<T>) -> T {
-    match *list {
-      Cons(ref head, _) => (*head).clone(),
-      // makes me sad
-      _ => fail!("head invoked on empty list")
     }
 }
 
@@ -118,7 +117,7 @@ fn push<T:Clone>(ll: &mut @list<T>, vv: T) {
 
 #[cfg(test)]
 mod tests {
-    use list::{List, Nil, head, tail};
+    use list::{List, Nil, tail};
     use list;
 
     #[test]
@@ -145,14 +144,13 @@ mod tests {
     #[test]
     fn test_from_vec() {
         let list = @List::from_vec([0, 1, 2]);
+        assert_eq!(list.head().unwrap(), &0);
 
-        assert_eq!(head(list), 0);
+        let mut tail = tail(list);
+        assert_eq!(tail.head().unwrap(), &1);
 
-        let tail_l = tail(list);
-        assert_eq!(head(tail_l), 1);
-
-        let tail_tail_l = tail(tail_l);
-        assert_eq!(head(tail_tail_l), 2);
+        tail = tail(tail);
+        assert_eq!(tail.head().unwrap(), &2);
     }
 
     #[test]

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -54,26 +54,6 @@ impl<T> List<T> {
 }
 
 /**
- * Search for an element that matches a given predicate
- *
- * Apply function `f` to each element of `list`, starting from the first.
- * When function `f` returns true then an option containing the element
- * is returned. If `f` matches no elements then none is returned.
- */
-pub fn find<T:Clone>(list: @List<T>, f: |&T| -> bool) -> Option<T> {
-    let mut list = list;
-    loop {
-        list = match *list {
-          Cons(ref head, tail) => {
-            if f(head) { return Some((*head).clone()); }
-            tail
-          }
-          Nil => return None
-        }
-    };
-}
-
-/**
  * Returns true if a list contains an element that matches a given predicate
  *
  * Apply function `f` to each element of `list`, starting from the first.
@@ -196,8 +176,6 @@ mod tests {
     use list::{List, Nil, head, is_empty, tail};
     use list;
 
-    use std::option;
-
     #[test]
     fn test_iter() {
         let list = List::from_vec([0, 1, 2]);
@@ -254,18 +232,21 @@ mod tests {
 
     #[test]
     fn test_find_success() {
-        fn match_(i: &int) -> bool { return *i == 2; }
-        let list = @List::from_vec([0, 1, 2]);
-        assert_eq!(list::find(list, match_), option::Some(2));
+        fn match_(i: & &int) -> bool { **i == 2 }
+
+        let list = List::from_vec([0, 1, 2]);
+        assert_eq!(list.iter().find(match_).unwrap(), &2);
     }
 
     #[test]
     fn test_find_fail() {
-        fn match_(_i: &int) -> bool { return false; }
-        let list = @List::from_vec([0, 1, 2]);
-        let empty = @list::Nil::<int>;
-        assert_eq!(list::find(list, match_), option::None::<int>);
-        assert_eq!(list::find(empty, match_), option::None::<int>);
+        fn match_(_i: & &int) -> bool { false }
+
+        let empty = Nil::<int>;
+        assert_eq!(empty.iter().find(match_), None);
+
+        let list = List::from_vec([0, 1, 2]);
+        assert_eq!(list.iter().find(match_), None);
     }
 
     #[test]

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -17,11 +17,6 @@ pub enum List<T> {
     Nil,
 }
 
-/// Create a list from a vector
-pub fn from_vec<T:Clone + 'static>(v: &[T]) -> @List<T> {
-    v.rev_iter().fold(@Nil::<T>, |t, h| @Cons((*h).clone(), t))
-}
-
 /**
  * Left fold
  *
@@ -133,6 +128,16 @@ pub fn append<T:Clone + 'static>(list: @List<T>, other: @List<T>) -> @List<T> {
     }
 }
 
+impl<T:'static + Clone> List<T> {
+    /// Create a list from a vector
+    pub fn from_vec(v: &[T]) -> List<T> {
+        match v.len() {
+            0 => Nil,
+            _ => v.rev_iter().fold(Nil, |tail, value: &T| Cons(value.clone(), @tail))
+        }
+    }
+}
+
 /*
 /// Push one element into the front of a list, returning a new list
 /// THIS VERSION DOESN'T ACTUALLY WORK
@@ -171,16 +176,16 @@ pub fn each<T>(list: @List<T>, f: |&T| -> bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use list::{List, Nil, from_vec, head, is_empty, tail};
+    use list::{List, Nil, head, is_empty, tail};
     use list;
 
     use std::option;
 
     #[test]
     fn test_is_empty() {
-        let empty : @list::List<int> = from_vec([]);
-        let full1 = from_vec([1]);
-        let full2 = from_vec(['r', 'u']);
+        let empty : @list::List<int> = @List::from_vec([]);
+        let full1 = @List::from_vec([1]);
+        let full2 = @List::from_vec(['r', 'u']);
 
         assert!(is_empty(empty));
         assert!(!is_empty(full1));
@@ -189,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_from_vec() {
-        let list = from_vec([0, 1, 2]);
+        let list = @List::from_vec([0, 1, 2]);
 
         assert_eq!(head(list), 0);
 
@@ -202,14 +207,14 @@ mod tests {
 
     #[test]
     fn test_from_vec_empty() {
-        let empty : @list::List<int> = from_vec([]);
-        assert_eq!(empty, @list::Nil::<int>);
+        let empty : list::List<int> = List::from_vec([]);
+        assert_eq!(empty, Nil::<int>);
     }
 
     #[test]
     fn test_foldl() {
         fn add(a: &uint, b: &int) -> uint { return *a + (*b as uint); }
-        let list = from_vec([0, 1, 2, 3, 4]);
+        let list = @List::from_vec([0, 1, 2, 3, 4]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::foldl(0u, list, add), 10u);
         assert_eq!(list::foldl(0u, empty, add), 0u);
@@ -220,21 +225,21 @@ mod tests {
         fn sub(a: &int, b: &int) -> int {
             *a - *b
         }
-        let list = from_vec([1, 2, 3, 4]);
+        let list = @List::from_vec([1, 2, 3, 4]);
         assert_eq!(list::foldl(0, list, sub), -10);
     }
 
     #[test]
     fn test_find_success() {
         fn match_(i: &int) -> bool { return *i == 2; }
-        let list = from_vec([0, 1, 2]);
+        let list = @List::from_vec([0, 1, 2]);
         assert_eq!(list::find(list, match_), option::Some(2));
     }
 
     #[test]
     fn test_find_fail() {
         fn match_(_i: &int) -> bool { return false; }
-        let list = from_vec([0, 1, 2]);
+        let list = @List::from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::find(list, match_), option::None::<int>);
         assert_eq!(list::find(empty, match_), option::None::<int>);
@@ -243,7 +248,7 @@ mod tests {
     #[test]
     fn test_any() {
         fn match_(i: &int) -> bool { return *i == 2; }
-        let list = from_vec([0, 1, 2]);
+        let list = @List::from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::any(list, match_), true);
         assert_eq!(list::any(empty, match_), false);
@@ -251,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_has() {
-        let list = from_vec([5, 8, 6]);
+        let list = @List::from_vec([5, 8, 6]);
         let empty = @list::Nil::<int>;
         assert!((list::has(list, 5)));
         assert!((!list::has(list, 7)));
@@ -261,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        let list = from_vec([0, 1, 2]);
+        let list = @List::from_vec([0, 1, 2]);
         let empty = @list::Nil::<int>;
         assert_eq!(list::len(list), 3u);
         assert_eq!(list::len(empty), 0u);
@@ -269,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_append() {
-        assert!(from_vec([1,2,3,4])
-            == list::append(list::from_vec([1,2]), list::from_vec([3,4])));
+        assert!(@List::from_vec([1,2,3,4])
+            == list::append(@List::from_vec([1,2]), @List::from_vec([3,4])));
     }
 }

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -105,15 +105,12 @@ impl<T:'static + Clone> List<T> {
             }
         }
     }
-}
 
-/*
-/// Push one element into the front of a list, returning a new list
-/// THIS VERSION DOESN'T ACTUALLY WORK
-fn push<T:Clone>(ll: &mut @list<T>, vv: T) {
-    ll = &mut @cons(vv, *ll)
+    /// Push one element into the front of a list, returning a new list
+    pub fn unshift(&self, element: T) -> List<T> {
+        Cons(element, @(self.clone()))
+    }
 }
-*/
 
 #[cfg(test)]
 mod tests {
@@ -227,5 +224,14 @@ mod tests {
     fn test_append() {
         assert_eq!(List::from_vec([1, 2, 3, 4]),
                    List::from_vec([1, 2]).append(List::from_vec([3, 4])));
+    }
+
+    #[test]
+    fn test_unshift() {
+        let list = List::from_vec([1]);
+        let new_list = list.unshift(0);
+        assert_eq!(list.len(), 1u);
+        assert_eq!(new_list.len(), 2u);
+        assert_eq!(new_list, List::from_vec([0, 1]));
     }
 }

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -58,6 +58,9 @@ impl<T> List<T> {
 impl<T> Container for List<T> {
     /// Returns the length of a list
     fn len(&self) -> uint { self.iter().len() }
+
+    /// Returns true if the list is empty
+    fn is_empty(&self) -> bool { match *self { Nil => true, _ => false } }
 }
 
 /// Returns true if a list contains an element with the given value
@@ -67,14 +70,6 @@ pub fn has<T:Eq>(list: @List<T>, element: T) -> bool {
         if *e == element { found = true; false } else { true }
     });
     return found;
-}
-
-/// Returns true if the list is empty
-pub fn is_empty<T>(list: @List<T>) -> bool {
-    match *list {
-        Nil => true,
-        _ => false
-    }
 }
 
 /// Returns all but the first element of a list
@@ -153,7 +148,7 @@ pub fn each<T>(list: @List<T>, f: |&T| -> bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use list::{List, Nil, head, is_empty, tail};
+    use list::{List, Nil, head, tail};
     use list;
 
     #[test]
@@ -168,13 +163,13 @@ mod tests {
 
     #[test]
     fn test_is_empty() {
-        let empty : @list::List<int> = @List::from_vec([]);
-        let full1 = @List::from_vec([1]);
-        let full2 = @List::from_vec(['r', 'u']);
+        let empty : list::List<int> = List::from_vec([]);
+        let full1 = List::from_vec([1]);
+        let full2 = List::from_vec(['r', 'u']);
 
-        assert!(is_empty(empty));
-        assert!(!is_empty(full1));
-        assert!(!is_empty(full2));
+        assert!(empty.is_empty());
+        assert!(!full1.is_empty());
+        assert!(!full2.is_empty());
     }
 
     #[test]

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -86,23 +86,23 @@ impl<T:Eq> List<T> {
     }
 }
 
-/// Appends one list to another
-pub fn append<T:Clone + 'static>(list: @List<T>, other: @List<T>) -> @List<T> {
-    match *list {
-      Nil => return other,
-      Cons(ref head, tail) => {
-        let rest = append(tail, other);
-        return @Cons((*head).clone(), rest);
-      }
-    }
-}
-
 impl<T:'static + Clone> List<T> {
     /// Create a list from a vector
     pub fn from_vec(v: &[T]) -> List<T> {
         match v.len() {
             0 => Nil,
             _ => v.rev_iter().fold(Nil, |tail, value: &T| Cons(value.clone(), @tail))
+        }
+    }
+
+    /// Appends one list to another, returning a new list
+    pub fn append(&self, other: List<T>) -> List<T> {
+        match other {
+            Nil => return self.clone(),
+            _ => match *self {
+                Nil => return other,
+                Cons(ref value, tail) => Cons(value.clone(), @tail.append(other))
+            }
         }
     }
 }
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_append() {
-        assert!(@List::from_vec([1,2,3,4])
-            == list::append(@List::from_vec([1,2]), @List::from_vec([3,4])));
+        assert_eq!(List::from_vec([1, 2, 3, 4]),
+                   List::from_vec([1, 2]).append(List::from_vec([3, 4])));
     }
 }

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -10,6 +10,8 @@
 
 //! A standard, garbage-collected linked list.
 
+use std::container::Container;
+
 #[deriving(Clone, Eq)]
 #[allow(missing_doc)]
 pub enum List<T> {
@@ -53,6 +55,11 @@ impl<T> List<T> {
     }
 }
 
+impl<T> Container for List<T> {
+    /// Returns the length of a list
+    fn len(&self) -> uint { self.iter().len() }
+}
+
 /// Returns true if a list contains an element with the given value
 pub fn has<T:Eq>(list: @List<T>, element: T) -> bool {
     let mut found = false;
@@ -68,13 +75,6 @@ pub fn is_empty<T>(list: @List<T>) -> bool {
         Nil => true,
         _ => false
     }
-}
-
-/// Returns the length of a list
-pub fn len<T>(list: @List<T>) -> uint {
-    let mut count = 0u;
-    iter(list, |_e| count += 1u);
-    count
 }
 
 /// Returns all but the first element of a list
@@ -252,10 +252,11 @@ mod tests {
 
     #[test]
     fn test_len() {
-        let list = @List::from_vec([0, 1, 2]);
-        let empty = @list::Nil::<int>;
-        assert_eq!(list::len(list), 3u);
-        assert_eq!(list::len(empty), 0u);
+        let empty = Nil::<int>;
+        assert_eq!(empty.len(), 0u);
+
+        let list = List::from_vec([0, 1, 2]);
+        assert_eq!(list.len(), 3u);
     }
 
     #[test]

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -63,13 +63,11 @@ impl<T> Container for List<T> {
     fn is_empty(&self) -> bool { match *self { Nil => true, _ => false } }
 }
 
-/// Returns true if a list contains an element with the given value
-pub fn has<T:Eq>(list: @List<T>, element: T) -> bool {
-    let mut found = false;
-    each(list, |e| {
-        if *e == element { found = true; false } else { true }
-    });
-    return found;
+impl<T:Eq> List<T> {
+    /// Returns true if a list contains an element with the given value
+    pub fn contains(&self, element: T) -> bool {
+        self.iter().any(|list_element| *list_element == element)
+    }
 }
 
 /// Returns all but the first element of a list
@@ -208,13 +206,14 @@ mod tests {
     }
 
     #[test]
-    fn test_has() {
-        let list = @List::from_vec([5, 8, 6]);
-        let empty = @list::Nil::<int>;
-        assert!((list::has(list, 5)));
-        assert!((!list::has(list, 7)));
-        assert!((list::has(list, 8)));
-        assert!((!list::has(empty, 5)));
+    fn test_contains() {
+        let empty = Nil::<int>;
+        assert!((!empty.contains(5)));
+
+        let list = List::from_vec([5, 8, 6]);
+        assert!((list.contains(5)));
+        assert!((!list.contains(7)));
+        assert!((list.contains(8)));
     }
 
     #[test]

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -73,7 +73,6 @@ use std::cell::RefCell;
 use collections::HashMap;
 use std::rc::Rc;
 use collections::List;
-use collections::list;
 use syntax::codemap::Span;
 use syntax::print::pprust::*;
 use syntax::{ast, ast_map, abi};
@@ -311,23 +310,18 @@ pub fn require_same_types(tcx: ty::ctxt,
 // corresponding ty::Region
 pub type isr_alist = @List<(ty::BoundRegion, ty::Region)>;
 
-trait get_and_find_region {
-    fn get(&self, br: ty::BoundRegion) -> ty::Region;
-    fn find(&self, br: ty::BoundRegion) -> Option<ty::Region>;
+trait get_region<'a, T:'static> {
+    fn get(&'a self, br: ty::BoundRegion) -> ty::Region;
 }
 
-impl get_and_find_region for isr_alist {
-    fn get(&self, br: ty::BoundRegion) -> ty::Region {
-        self.find(br).unwrap()
-    }
-
-    fn find(&self, br: ty::BoundRegion) -> Option<ty::Region> {
-        let mut ret = None;
-        list::each(*self, |isr| {
+impl<'a, T:'static> get_region <'a, T> for isr_alist {
+    fn get(&'a self, br: ty::BoundRegion) -> ty::Region {
+        let mut region = None;
+        for isr in self.iter() {
             let (isr_br, isr_r) = *isr;
-            if isr_br == br { ret = Some(isr_r); false } else { true }
-        });
-        ret
+            if isr_br == br { region = Some(isr_r); break; }
+        };
+        region.unwrap()
     }
 }
 

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -55,6 +55,12 @@ impl<T:Pod> Clone for Cell<T> {
     }
 }
 
+impl<T:Eq + Pod> Eq for Cell<T> {
+    fn eq(&self, other: &Cell<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
 /// A mutable memory location with dynamically checked borrow rules
 pub struct RefCell<T> {
     priv value: T,
@@ -273,11 +279,14 @@ mod test {
     #[test]
     fn smoketest_cell() {
         let x = Cell::new(10);
+        assert_eq!(x, Cell::new(10));
         assert_eq!(x.get(), 10);
         x.set(20);
+        assert_eq!(x, Cell::new(20));
         assert_eq!(x.get(), 20);
 
         let y = Cell::new((30, 40));
+        assert_eq!(y, Cell::new((30, 40)));
         assert_eq!(y.get(), (30, 40));
     }
 

--- a/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
@@ -11,7 +11,7 @@
 // except according to those terms.
 
 extern crate collections;
-use collections::list;
+use collections::list::List;
 
 #[deriving(Clone)]
 enum foo {
@@ -24,8 +24,8 @@ fn check_log<T>(exp: ~str, v: T) {
 }
 
 pub fn main() {
-    let x = list::from_vec([a(22u), b(~"hi")]);
-    let exp = ~"@Cons(a(22u), @Cons(b(~\"hi\"), @Nil))";
+    let x = List::from_vec([a(22u), b(~"hi")]);
+    let exp = ~"Cons(a(22u), @Cons(b(~\"hi\"), @Nil))";
     let act = format!("{:?}", x);
     assert!(act == exp);
     check_log(exp, x);

--- a/src/test/run-pass/non-boolean-pure-fns.rs
+++ b/src/test/run-pass/non-boolean-pure-fns.rs
@@ -14,19 +14,19 @@
 
 extern crate collections;
 
-use collections::list::{List, Cons, Nil, head};
+use collections::list::{List, Cons, Nil};
 
-fn pure_length_go<T:Clone>(ls: @List<T>, acc: uint) -> uint {
+fn pure_length_go<T>(ls: @List<T>, acc: uint) -> uint {
     match *ls { Nil => { acc } Cons(_, tl) => { pure_length_go(tl, acc + 1u) } }
 }
 
-fn pure_length<T:Clone>(ls: @List<T>) -> uint { pure_length_go(ls, 0u) }
+fn pure_length<T>(ls: @List<T>) -> uint { pure_length_go(ls, 0u) }
 
-fn nonempty_list<T:Clone>(ls: @List<T>) -> bool { pure_length(ls) > 0u }
+fn nonempty_list<T>(ls: @List<T>) -> bool { pure_length(ls) > 0u }
 
 fn safe_head<T:Clone>(ls: @List<T>) -> T {
     assert!(!ls.is_empty());
-    return head(ls);
+    return ls.head().unwrap().clone();
 }
 
 pub fn main() {

--- a/src/test/run-pass/non-boolean-pure-fns.rs
+++ b/src/test/run-pass/non-boolean-pure-fns.rs
@@ -14,7 +14,7 @@
 
 extern crate collections;
 
-use collections::list::{List, Cons, Nil, head, is_empty};
+use collections::list::{List, Cons, Nil, head};
 
 fn pure_length_go<T:Clone>(ls: @List<T>, acc: uint) -> uint {
     match *ls { Nil => { acc } Cons(_, tl) => { pure_length_go(tl, acc + 1u) } }
@@ -25,7 +25,7 @@ fn pure_length<T:Clone>(ls: @List<T>) -> uint { pure_length_go(ls, 0u) }
 fn nonempty_list<T:Clone>(ls: @List<T>) -> bool { pure_length(ls) > 0u }
 
 fn safe_head<T:Clone>(ls: @List<T>) -> T {
-    assert!(!is_empty(ls));
+    assert!(!ls.is_empty());
     return head(ls);
 }
 


### PR DESCRIPTION
This PR includes:
- Create an iterator for `List<T>` called `Items<T>`;
- Move all list operations inside `List<T>` impl;
- Removed functions that are already provided by `Iterator` trait;
- Refactor on `len()` and `is_empty` using `Container` trait;
- Bunch of minor fixes;

A replacement for using @ is intended, but still in discussion.

Closes #12344.
