### PR TITLE
Fix a segfault in the rustuv tests

### DIFF
--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -168,6 +168,18 @@ mod test {
 
     #[test] #[should_fail]
     fn smoke_fail() {
+        // By default, the test harness is capturing our stderr output through a
+        // channel. This means that when we start failing and "print" our error
+        // message, we could be switched to running on another test. The
+        // IdleWatcher assumes that we're already running on the same task, so
+        // it can cause serious problems and internal race conditions.
+        //
+        // To fix this bug, we just set our stderr to a null writer which will
+        // never reschedule us, so we're guaranteed to stay on the same
+        // task/event loop.
+        use std::io;
+        drop(io::stdio::set_stderr(~io::util::NullWriter));
+
         let (mut idle, _chan) = mk(1);
         idle.resume();
         fail!();

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -433,7 +433,6 @@ fn local_loop() -> &'static mut uvio::UvIoFactory {
 #[cfg(test)]
 mod test {
     use std::cast::transmute;
-    use std::ptr;
     use std::unstable::run_in_bare_thread;
 
     use super::{slice_to_uv_buf, Loop};


### PR DESCRIPTION
The details can be found in the comments I added to the test, but the gist of it
is that capturing output injects rescheduling a green task on failure, which
wasn't desired for the test in question.

cc #12340
