### PR TITLE
Add NaNs, infinities and overflows support to sum

### DIFF
--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -1117,8 +1117,8 @@ mod tests {
     fn test_sum_overflow_f64() {
         let n = f64::MAX_VALUE;
         println!("{} ", [n, -n, n, n / 10.0].sum());
-	println!("{} ", [n, -n, n, 0.1 * n].sum());
-	error!("n {} ; sum {}", n, [n, -n, n, n / 10.0].sum())
+        println!("{} ", [n, -n, n, 0.1 * n].sum());
+        error!("n {} ; sum {}", n, [n, -n, n, n / 10.0].sum())
     }
 }
 

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -1116,7 +1116,9 @@ mod tests {
     #[should_fail]
     fn test_sum_overflow_f64() {
         let n = f64::MAX_VALUE;
-        [n, -n, n, n / 10.0].sum();
+        println!("{} ", [n, -n, n, n / 10.0].sum());
+	println!("{} ", [n, -n, n, 0.1 * n].sum());
+	error!("n {} ; sum {}", n, [n, -n, n, n / 10.0].sum())
     }
 }
 


### PR DESCRIPTION
Stats::sum handles `NaNs` and `Infinities` as elements in the list.
In addition to that, it also detects overflows.

@huonw - your review, please. :-)

Attempting to fix https://github.com/mozilla/rust/issues/11059

(BTW, thanks to @cmr, @sfackler, dybt, @bjz, huon, eibwen for the support on the IRC)
