### PR TITLE
Fix the build documentation parsing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -103,7 +103,7 @@
 #
 # </tips>
 #
-# <nittygritty>
+# <nitty-gritty>
 #
 # # The Rust Build System
 #
@@ -157,7 +157,7 @@
 #
 # Admittedly this is a little convoluted.
 #
-# </nittygritty>
+# </nitty-gritty>
 #
 
 ######################################################################

--- a/Makefile.in
+++ b/Makefile.in
@@ -19,12 +19,16 @@
 #
 # First, start with one of these build targets:
 #
-#   * all - The default. Builds a complete, bootstrapped compiler.
+#   * all - The default. Build a complete, bootstrapped compiler.
 #           `rustc` will be in `${target-triple}/stage2/bin/`. Run it
 #           directly from the build directory if you like. This also
 #           comes with docs in `doc/`.
 #
 #   * check - Run the complete test suite
+#
+#   * clean - Clean the build repertory. It is advised to run this
+#             command if you want to build Rust again, after an update
+#             of the git repository.
 #
 #   * install - Install Rust. Note that installation is not necessary
 #               to use the compiler.
@@ -152,7 +156,7 @@
 # libraries are managed and versioned without polluting the common
 # areas of the filesystem.
 #
-# General rust binaries may stil live in the host bin directory; they
+# General rust binaries may still live in the host bin directory; they
 # will just link against the libraries in the target lib directory.
 #
 # Admittedly this is a little convoluted.

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -446,13 +446,13 @@ all: $(ALL_TARGET_RULES) $(GENERATED) docs
 # $(1) is the name of the doc <section> in Makefile.in
 # pick everything between tags | remove first line | remove last line
 # | remove extra (?) line | strip leading `#` from lines
-SHOW_DOCS = $(Q)awk '/$(1)/,/<\/$(1)>/' $(S)/Makefile.in | sed '1d' | sed '$$d' | sed 's/^\# \?//'
+SHOW_DOCS = $(Q)awk '/<$(1)>/,/<\/$(1)>/' $(S)/Makefile.in | sed '1d' | sed '$$d' | sed 's/^\# \?//'
 
 help:
 	$(call SHOW_DOCS,help)
 
-hot-tips:
-	$(call SHOW_DOCS,hottips)
+tips:
+	$(call SHOW_DOCS,tips)
 
 nitty-gritty:
-	$(call SHOW_DOCS,nittygritty)
+	$(call SHOW_DOCS,nitty-gritty)


### PR DESCRIPTION
The command `make tips` did not work properly because of a flaw in the regexp parsing Makefile.in for documentation (`SHOW_DOCS`). I fixed it and also added a note about `make clean` in the build documentation (`make help`).
