### PR TITLE
Warn about unnecessary parentheses upon assignment

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -407,11 +407,8 @@ fn get_metadata_section_imp(os: Os, filename: &Path) -> Option<MetadataBlob> {
                 debug!("checking {} bytes of metadata-version stamp",
                        vlen);
                 let minsz = cmp::min(vlen, csz);
-                let mut version_ok = false;
-                vec::raw::buf_as_slice(cvbuf, minsz, |buf0| {
-                    version_ok = (buf0 ==
-                                  encoder::metadata_encoding_version);
-                });
+                let version_ok = vec::raw::buf_as_slice(cvbuf, minsz,
+                    |buf0| buf0 == encoder::metadata_encoding_version);
                 if !version_ok { return None; }
 
                 let cvbuf1 = cvbuf.offset(vlen as int);

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -95,11 +95,10 @@ impl<'a> GuaranteeLifetimeContext<'a> {
                 let base_scope = self.scope(base);
 
                 // L-Deref-Managed-Imm-User-Root
-                let omit_root = (
+                let omit_root =
                     self.bccx.is_subregion_of(self.loan_region, base_scope) &&
                     self.is_rvalue_or_immutable(base) &&
-                    !self.is_moved(base)
-                );
+                    !self.is_moved(base);
 
                 if !omit_root {
                     // L-Deref-Managed-Imm-Compiler-Root

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -891,7 +891,7 @@ fn bitwise(out_vec: &mut [uint], in_vec: &[uint], op: |uint, uint| -> uint)
         let old_val = *out_elt;
         let new_val = op(old_val, *in_elt);
         *out_elt = new_val;
-        changed |= (old_val != new_val);
+        changed |= old_val != new_val;
     }
     changed
 }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -143,10 +143,8 @@ pub fn monomorphic_fn(ccx: @CrateContext,
             // This is a bit unfortunate.
 
             let idx = psubsts.tys.len() - num_method_ty_params;
-            let substs =
-                (psubsts.tys.slice(0, idx) +
-                 &[psubsts.self_ty.unwrap()] +
-                 psubsts.tys.tailn(idx));
+            let substs = psubsts.tys.slice(0, idx) +
+                &[psubsts.self_ty.unwrap()] + psubsts.tys.tailn(idx);
             debug!("static default: changed substitution to {}",
                    substs.repr(ccx.tcx));
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2293,8 +2293,8 @@ pub fn type_contents(cx: ctxt, ty: t) -> TypeContents {
                        bounds: BuiltinBounds)
                        -> TypeContents {
         // These are the type contents of the (opaque) interior
-        let contents = (TC::ReachesMutable.when(mutbl == ast::MutMutable) |
-                        kind_bounds_to_contents(cx, bounds, []));
+        let contents = TC::ReachesMutable.when(mutbl == ast::MutMutable) |
+            kind_bounds_to_contents(cx, bounds, []);
 
         match store {
             UniqTraitStore => {

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -674,7 +674,7 @@ pub mod writer {
             let last_size_pos = self.size_positions.pop().unwrap();
             let cur_pos = try!(self.writer.tell());
             try!(self.writer.seek(last_size_pos as i64, io::SeekSet));
-            let size = (cur_pos as uint - last_size_pos - 4);
+            let size = cur_pos as uint - last_size_pos - 4;
             write_sized_vuint(self.writer, size, 4u);
             try!(self.writer.seek(cur_pos as i64, io::SeekSet));
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -119,7 +119,7 @@ pub mod win32 {
                 } else if k == n &&
                           libc::GetLastError() ==
                           libc::ERROR_INSUFFICIENT_BUFFER as DWORD {
-                    n *= (2 as DWORD);
+                    n *= 2 as DWORD;
                 } else if k >= n {
                     n = k;
                 } else {
@@ -225,7 +225,7 @@ pub fn env_as_bytes() -> ~[(~[u8],~[u8])] {
             for p in input.iter() {
                 let vs: ~[&[u8]] = p.splitn(1, |b| *b == '=' as u8).collect();
                 let key = vs[0].to_owned();
-                let val = (if vs.len() < 2 { ~[] } else { vs[1].to_owned() });
+                let val = if vs.len() < 2 { ~[] } else { vs[1].to_owned() };
                 pairs.push((key, val));
             }
             pairs

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -202,7 +202,7 @@ impl AbiSet {
     }
 
     pub fn add(&mut self, abi: Abi) {
-        self.bits |= (1 << abi.index());
+        self.bits |= 1 << abi.index();
     }
 
     pub fn each(&self, op: |abi: Abi| -> bool) -> bool {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1224,6 +1224,6 @@ mod test {
             },
         };
         // doesn't matter which encoder we use....
-        let _f = (&e as &serialize::Encodable<json::Encoder>);
+        let _f = &e as &serialize::Encodable<json::Encoder>;
     }
 }

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -329,7 +329,7 @@ fn highlight_lines(cm: &codemap::CodeMap,
         for _ in range(0, skip) { s.push_char(' '); }
         let orig = fm.get_line(lines.lines[0] as int);
         for pos in range(0u, left-skip) {
-            let curChar = (orig[pos] as char);
+            let curChar = orig[pos] as char;
             // Whenever a tab occurs on the previous line, we insert one on
             // the error-point-squiggly-line as well (instead of a space).
             // That way the squiggly line will usually appear in the correct

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -259,7 +259,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                             ' ' => flags.space = true,
                             '.' => fstate = FormatStatePrecision,
                             '0'..'9' => {
-                                flags.width = (cur as uint - '0' as uint);
+                                flags.width = cur as uint - '0' as uint;
                                 fstate = FormatStateWidth;
                             }
                             _ => unreachable!()
@@ -359,7 +359,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         flags.space = true;
                     }
                     (FormatStateFlags,'0'..'9') => {
-                        flags.width = (cur as uint - '0' as uint);
+                        flags.width = cur as uint - '0' as uint;
                         *fstate = FormatStateWidth;
                     }
                     (FormatStateFlags,'.') => {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1047,7 +1047,7 @@ impl MetricMap {
             let r = match selfmap.find(k) {
                 None => MetricRemoved,
                 Some(v) => {
-                    let delta = (v.value - vold.value);
+                    let delta = v.value - vold.value;
                     let noise = match noise_pct {
                         None => f64::max(vold.noise.abs(), v.noise.abs()),
                         Some(pct) => vold.value * pct / 100.0

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -296,7 +296,7 @@ impl Uuid {
     ///
     /// This represents the algorithm used to generate the contents
     pub fn get_version(&self) -> Option<UuidVersion> {
-        let v = (self.bytes[6] >> 4);
+        let v = self.bytes[6] >> 4;
         match v {
             1 => Some(Version1Mac),
             2 => Some(Version2Dce),

--- a/src/test/compile-fail/lint-unnecessary-parens.rs
+++ b/src/test/compile-fail/lint-unnecessary-parens.rs
@@ -22,4 +22,7 @@ fn main() {
     match (true) { //~ ERROR unnecessary parentheses around `match` head expression
         _ => {}
     }
+    let mut _a = (0); //~ ERROR unnecessary parentheses around assigned value
+    _a = (0); //~ ERROR unnecessary parentheses around assigned value
+    _a += (1); //~ ERROR unnecessary parentheses around assigned value
 }


### PR DESCRIPTION
Fixes #12350.

Parentheses around assignment statements such as

``` rust
let mut a = (0);
a = (1);
a += (2);
```

are not necessary and therefore an unnecessary_parens warning is raised when
statements like this occur.

NOTE: In `let` declarations this does not work as intended. Is it possible that they do not count as assignment expressions (`ExprAssign`)? (edit: this is fixed by now)

Furthermore, there are some cases that I fixed in the rest of the code, where parentheses could potentially enhance readability. Compare these lines:

``` rust
a = b == c;
a = (b == c);
```

Thus, after having worked on this I'm not entirely sure, whether we should go through with this patch or not. Probably a matter of debate. ;)
