### PR TITLE
Fix staticlib outputs linking to blank archives

### DIFF
--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -173,6 +173,7 @@ impl Archive {
             if_ok!(fs::rename(file, &new_filename));
             inputs.push(new_filename);
         }
+        if inputs.len() == 0 { return Ok(()) }
 
         // Finally, add all the renamed files to this archive
         let mut args = ~[&self.dst];

--- a/src/test/run-make/staticlib-blank-lib/Makefile
+++ b/src/test/run-make/staticlib-blank-lib/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all:
+	ar crus libfoo.a foo.rs
+	ar d libfoo.a foo.rs
+	$(RUSTC) foo.rs

--- a/src/test/run-make/staticlib-blank-lib/foo.rs
+++ b/src/test/run-make/staticlib-blank-lib/foo.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type = "staticlib"];
+
+#[link(name = "foo", kind = "static")]
+extern {}
+
+fn main() {}


### PR DESCRIPTION
When creating a staticlib, it unzips all static archives it finds and then
inserts the files manually into the output file. This process is done through
`ar`, and `ar` doesn't like if you specify you want to add files and you don't
give it any files.

This case arose whenever you linked to an archive that didn't have any contents
or all of the contents were filtered out. This just involved ignoring the case
where the number of inputs we have is 0, because we don't have any files to add
anyway.
