### PR TITLE
format_args: allow omission of format string

### DIFF
--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -48,6 +48,11 @@ pub fn main() {
     t!(format!("hello"), "hello");
     t!(format!("hello \\{"), "hello {");
 
+    // No format string uses default poly formatters
+    t!(format!(1), "1");
+    t!(format!(1, 2), "1 2");
+    t!(format!(1, "foo", 2, true), "1 \"foo\" 2 true");
+
     // default formatters should work
     t!(format!("{}", 1i), "1");
     t!(format!("{}", 1i8), "1");


### PR DESCRIPTION
A default format string of Poly {:?} is generated to match the number
of passed arguments. This propagates to all fmt macros, such as println!,
debug!, format!, write!, etc.

Example: println!("{:?}", value); => println!(value);

fixes #12015
