### PR TITLE
libnum: Make RandBigInt trait public

### DIFF
--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -1261,7 +1261,7 @@ impl FromStrRadix for BigInt {
     }
 }
 
-trait RandBigInt {
+pub trait RandBigInt {
     /// Generate a random `BigUint` of the given bit size.
     fn gen_biguint(&mut self, bit_size: uint) -> BigUint;
 


### PR DESCRIPTION
Closes #12383.

Test suite did not capture this and can't as long as it is in the same module hierarchy. This is probably something that should be addressed in the future.
