### PR TITLE
rustc: remove some unnecessary `transmute`s.

### DIFF
--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -20,7 +20,6 @@ use syntax::codemap::Span;
 use middle::trans::builder::Builder;
 use middle::trans::type_::Type;
 
-use std::cast;
 use std::libc::{c_uint, c_ulonglong, c_char};
 
 pub fn terminate(cx: &Block, _: &str) {
@@ -623,9 +622,7 @@ pub fn Phi(cx: &Block, Ty: Type, vals: &[ValueRef], bbs: &[BasicBlockRef]) -> Va
 pub fn AddIncomingToPhi(phi: ValueRef, val: ValueRef, bb: BasicBlockRef) {
     unsafe {
         if llvm::LLVMIsUndef(phi) == lib::llvm::True { return; }
-        let valptr = cast::transmute(&val);
-        let bbptr = cast::transmute(&bb);
-        llvm::LLVMAddIncoming(phi, valptr, bbptr, 1 as c_uint);
+        llvm::LLVMAddIncoming(phi, &val, &bb, 1 as c_uint);
     }
 }
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -17,7 +17,6 @@ use middle::trans::base;
 use middle::trans::common::*;
 use middle::trans::machine::llalign_of_pref;
 use middle::trans::type_::Type;
-use std::cast;
 use std::hashmap::HashMap;
 use std::libc::{c_uint, c_ulonglong, c_char};
 use syntax::codemap::Span;
@@ -30,10 +29,8 @@ pub struct Builder<'a> {
 // This is a really awful way to get a zero-length c-string, but better (and a
 // lot more efficient) than doing str::as_c_str("", ...) every time.
 pub fn noname() -> *c_char {
-    unsafe {
-        static cnull: uint = 0u;
-        cast::transmute(&cnull)
-    }
+    static cnull: c_char = 0;
+    &cnull as *c_char
 }
 
 impl<'a> Builder<'a> {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -30,8 +30,6 @@ use util::ppaux::Repr;
 
 use arena::TypedArena;
 use std::c_str::ToCStr;
-use std::cast::transmute;
-use std::cast;
 use std::cell::{Cell, RefCell};
 use std::hashmap::HashMap;
 use std::libc::{c_uint, c_longlong, c_ulonglong, c_char};
@@ -668,7 +666,7 @@ pub fn C_array(ty: Type, elts: &[ValueRef]) -> ValueRef {
 
 pub fn C_bytes(bytes: &[u8]) -> ValueRef {
     unsafe {
-        let ptr = cast::transmute(bytes.as_ptr());
+        let ptr = bytes.as_ptr() as *c_char;
         return llvm::LLVMConstStringInContext(base::task_llcx(), ptr, bytes.len() as c_uint, True);
     }
 }


### PR DESCRIPTION
These can all be done by implicit or explicit &T -> *T casts, which are
more restricted and so are safer.
