### PR TITLE
Tweak how preference factors into linkage

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -537,10 +537,6 @@ TEST_SREQ$(1)_T_$(2)_H_$(3) = \
 # remove directive, if present, from CFG_RUSTC_FLAGS (issue #7898).
 CTEST_RUSTC_FLAGS := $$(subst --cfg ndebug,,$$(CFG_RUSTC_FLAGS))
 
-# There's no need our entire test suite to take up gigabytes of space on disk
-# including copies of libstd/libextra all over the place
-CTEST_RUSTC_FLAGS := $$(CTEST_RUSTC_FLAGS) -C prefer-dynamic
-
 # The tests can not be optimized while the rest of the compiler is optimized, so
 # filter out the optimization (if any) from rustc and then figure out if we need
 # to be optimized

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -32,6 +32,8 @@ pub struct TestProps {
     force_host: bool,
     // Check stdout for error-pattern output as well as stderr
     check_stdout: bool,
+    // Don't force a --crate-type=dylib flag on the command line
+    no_prefer_dynamic: bool,
 }
 
 // Load any test directives embedded in the file
@@ -45,6 +47,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut check_lines = ~[];
     let mut force_host = false;
     let mut check_stdout = false;
+    let mut no_prefer_dynamic = false;
     iter_header(testfile, |ln| {
         match parse_error_pattern(ln) {
           Some(ep) => error_patterns.push(ep),
@@ -65,6 +68,10 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         if !check_stdout {
             check_stdout = parse_check_stdout(ln);
+        }
+
+        if !no_prefer_dynamic {
+            no_prefer_dynamic = parse_no_prefer_dynamic(ln);
         }
 
         match parse_aux_build(ln) {
@@ -99,6 +106,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         check_lines: check_lines,
         force_host: force_host,
         check_stdout: check_stdout,
+        no_prefer_dynamic: no_prefer_dynamic,
     };
 }
 
@@ -165,6 +173,10 @@ fn parse_force_host(line: &str) -> bool {
 
 fn parse_check_stdout(line: &str) -> bool {
     parse_name_directive(line, "check-stdout")
+}
+
+fn parse_no_prefer_dynamic(line: &str) -> bool {
+    parse_name_directive(line, "no-prefer-dynamic")
 }
 
 fn parse_exec_env(line: &str) -> Option<(~str, ~str)> {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -704,9 +704,13 @@ fn compose_and_run_compiler(
     for rel_ab in props.aux_builds.iter() {
         let abs_ab = config.aux_base.join(rel_ab.as_slice());
         let aux_props = load_props(&abs_ab);
+        let crate_type = if aux_props.no_prefer_dynamic {
+            ~[]
+        } else {
+            ~[~"--crate-type=dylib"]
+        };
         let aux_args =
-            make_compile_args(config, &aux_props, ~[~"--crate-type=dylib"]
-                                                  + extra_link_args,
+            make_compile_args(config, &aux_props, crate_type + extra_link_args,
                               |a,b| {
                                   let f = make_lib_name(a, b, testfile);
                                   ThisDirectory(f.dir_path())
@@ -770,6 +774,10 @@ fn make_compile_args(config: &config,
                      ~"-L", config.build_base.as_str().unwrap().to_owned(),
                      ~"--target=" + target]
         + extras;
+    if !props.no_prefer_dynamic {
+        args.push(~"-C");
+        args.push(~"prefer-dynamic");
+    }
     let path = match xform_file {
         ThisFile(path) => { args.push(~"-o"); path }
         ThisDirectory(path) => { args.push(~"--out-dir"); path }

--- a/src/test/auxiliary/issue-12133-dylib.rs
+++ b/src/test/auxiliary/issue-12133-dylib.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#[crate_type = "dylib"];

--- a/src/test/auxiliary/issue-12133-rlib.rs
+++ b/src/test/auxiliary/issue-12133-rlib.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#[crate_type = "rlib"];

--- a/src/test/compile-fail/issue-12133-1.rs
+++ b/src/test/compile-fail/issue-12133-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12133-rlib.rs
+// aux-build:issue-12133-dylib.rs
+
+// error-pattern: dynamic linking is preferred, but dependencies were not found
+
+extern crate a = "issue-12133-rlib";
+extern crate b = "issue-12133-dylib";
+
+fn main() {}

--- a/src/test/compile-fail/issue-12133-2.rs
+++ b/src/test/compile-fail/issue-12133-2.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12133-rlib.rs
+// aux-build:issue-12133-dylib.rs
+// no-prefer-dynamic
+
+// error-pattern: dependencies were not all found in either dylib or rlib format
+
+extern crate a = "issue-12133-rlib";
+extern crate b = "issue-12133-dylib";
+
+fn main() {}

--- a/src/test/compile-fail/issue-12133-3.rs
+++ b/src/test/compile-fail/issue-12133-3.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12133-rlib.rs
+// aux-build:issue-12133-dylib.rs
+// no-prefer-dynamic
+
+// error-pattern: dylib output requested, but some depenencies could not
+
+#[crate_type = "dylib"];
+
+extern crate a = "issue-12133-rlib";
+extern crate b = "issue-12133-dylib";


### PR DESCRIPTION
The new methodology can be found in the re-worded comment, but the gist of it is
that -C prefer-dynamic doesn't turn off static linkage. The error messages
should also be a little more sane now.

Closes #12133
