### PR TITLE
Mass rename if_ok! to try!

### DIFF
--- a/src/libextra/json.rs
+++ b/src/libextra/json.rs
@@ -246,7 +246,7 @@ use serialize::Encodable;
 use serialize;
 use collections::TreeMap;
 
-macro_rules! if_ok( ($e:expr) => (
+macro_rules! try( ($e:expr) => (
     match $e { Ok(e) => e, Err(e) => { self.error = Err(e); return } }
 ) )
 
@@ -342,7 +342,7 @@ impl<'a> Encoder<'a> {
 }
 
 impl<'a> serialize::Encoder for Encoder<'a> {
-    fn emit_nil(&mut self) { if_ok!(write!(self.wr, "null")) }
+    fn emit_nil(&mut self) { try!(write!(self.wr, "null")) }
 
     fn emit_uint(&mut self, v: uint) { self.emit_f64(v as f64); }
     fn emit_u64(&mut self, v: u64) { self.emit_f64(v as f64); }
@@ -358,20 +358,20 @@ impl<'a> serialize::Encoder for Encoder<'a> {
 
     fn emit_bool(&mut self, v: bool) {
         if v {
-            if_ok!(write!(self.wr, "true"));
+            try!(write!(self.wr, "true"));
         } else {
-            if_ok!(write!(self.wr, "false"));
+            try!(write!(self.wr, "false"));
         }
     }
 
     fn emit_f64(&mut self, v: f64) {
-        if_ok!(write!(self.wr, "{}", f64::to_str_digits(v, 6u)))
+        try!(write!(self.wr, "{}", f64::to_str_digits(v, 6u)))
     }
     fn emit_f32(&mut self, v: f32) { self.emit_f64(v as f64); }
 
     fn emit_char(&mut self, v: char) { self.emit_str(str::from_char(v)) }
     fn emit_str(&mut self, v: &str) {
-        if_ok!(write!(self.wr, "{}", escape_str(v)))
+        try!(write!(self.wr, "{}", escape_str(v)))
     }
 
     fn emit_enum(&mut self, _name: &str, f: |&mut Encoder<'a>|) { f(self) }
@@ -385,19 +385,19 @@ impl<'a> serialize::Encoder for Encoder<'a> {
         // Bunny => "Bunny"
         // Kangaroo(34,"William") => {"variant": "Kangaroo", "fields": [34,"William"]}
         if cnt == 0 {
-            if_ok!(write!(self.wr, "{}", escape_str(name)));
+            try!(write!(self.wr, "{}", escape_str(name)));
         } else {
-            if_ok!(write!(self.wr, "\\{\"variant\":"));
-            if_ok!(write!(self.wr, "{}", escape_str(name)));
-            if_ok!(write!(self.wr, ",\"fields\":["));
+            try!(write!(self.wr, "\\{\"variant\":"));
+            try!(write!(self.wr, "{}", escape_str(name)));
+            try!(write!(self.wr, ",\"fields\":["));
             f(self);
-            if_ok!(write!(self.wr, "]\\}"));
+            try!(write!(self.wr, "]\\}"));
         }
     }
 
     fn emit_enum_variant_arg(&mut self, idx: uint, f: |&mut Encoder<'a>|) {
         if idx != 0 {
-            if_ok!(write!(self.wr, ","));
+            try!(write!(self.wr, ","));
         }
         f(self);
     }
@@ -418,17 +418,17 @@ impl<'a> serialize::Encoder for Encoder<'a> {
     }
 
     fn emit_struct(&mut self, _: &str, _: uint, f: |&mut Encoder<'a>|) {
-        if_ok!(write!(self.wr, r"\{"));
+        try!(write!(self.wr, r"\{"));
         f(self);
-        if_ok!(write!(self.wr, r"\}"));
+        try!(write!(self.wr, r"\}"));
     }
 
     fn emit_struct_field(&mut self,
                          name: &str,
                          idx: uint,
                          f: |&mut Encoder<'a>|) {
-        if idx != 0 { if_ok!(write!(self.wr, ",")) }
-        if_ok!(write!(self.wr, "{}:", escape_str(name)));
+        if idx != 0 { try!(write!(self.wr, ",")) }
+        try!(write!(self.wr, "{}:", escape_str(name)));
         f(self);
     }
 
@@ -454,31 +454,31 @@ impl<'a> serialize::Encoder for Encoder<'a> {
     fn emit_option_some(&mut self, f: |&mut Encoder<'a>|) { f(self); }
 
     fn emit_seq(&mut self, _len: uint, f: |&mut Encoder<'a>|) {
-        if_ok!(write!(self.wr, "["));
+        try!(write!(self.wr, "["));
         f(self);
-        if_ok!(write!(self.wr, "]"));
+        try!(write!(self.wr, "]"));
     }
 
     fn emit_seq_elt(&mut self, idx: uint, f: |&mut Encoder<'a>|) {
         if idx != 0 {
-            if_ok!(write!(self.wr, ","));
+            try!(write!(self.wr, ","));
         }
         f(self)
     }
 
     fn emit_map(&mut self, _len: uint, f: |&mut Encoder<'a>|) {
-        if_ok!(write!(self.wr, r"\{"));
+        try!(write!(self.wr, r"\{"));
         f(self);
-        if_ok!(write!(self.wr, r"\}"));
+        try!(write!(self.wr, r"\}"));
     }
 
     fn emit_map_elt_key(&mut self, idx: uint, f: |&mut Encoder<'a>|) {
-        if idx != 0 { if_ok!(write!(self.wr, ",")) }
+        if idx != 0 { try!(write!(self.wr, ",")) }
         f(self)
     }
 
     fn emit_map_elt_val(&mut self, _idx: uint, f: |&mut Encoder<'a>|) {
-        if_ok!(write!(self.wr, ":"));
+        try!(write!(self.wr, ":"));
         f(self)
     }
 }
@@ -503,7 +503,7 @@ impl<'a> PrettyEncoder<'a> {
 }
 
 impl<'a> serialize::Encoder for PrettyEncoder<'a> {
-    fn emit_nil(&mut self) { if_ok!(write!(self.wr, "null")); }
+    fn emit_nil(&mut self) { try!(write!(self.wr, "null")); }
 
     fn emit_uint(&mut self, v: uint) { self.emit_f64(v as f64); }
     fn emit_u64(&mut self, v: u64) { self.emit_f64(v as f64); }
@@ -519,20 +519,20 @@ impl<'a> serialize::Encoder for PrettyEncoder<'a> {
 
     fn emit_bool(&mut self, v: bool) {
         if v {
-            if_ok!(write!(self.wr, "true"));
+            try!(write!(self.wr, "true"));
         } else {
-            if_ok!(write!(self.wr, "false"));
+            try!(write!(self.wr, "false"));
         }
     }
 
     fn emit_f64(&mut self, v: f64) {
-        if_ok!(write!(self.wr, "{}", f64::to_str_digits(v, 6u)));
+        try!(write!(self.wr, "{}", f64::to_str_digits(v, 6u)));
     }
     fn emit_f32(&mut self, v: f32) { self.emit_f64(v as f64); }
 
     fn emit_char(&mut self, v: char) { self.emit_str(str::from_char(v)) }
     fn emit_str(&mut self, v: &str) {
-        if_ok!(write!(self.wr, "{}", escape_str(v)));
+        try!(write!(self.wr, "{}", escape_str(v)));
     }
 
     fn emit_enum(&mut self, _name: &str, f: |&mut PrettyEncoder<'a>|) {
@@ -545,14 +545,14 @@ impl<'a> serialize::Encoder for PrettyEncoder<'a> {
                          cnt: uint,
                          f: |&mut PrettyEncoder<'a>|) {
         if cnt == 0 {
-            if_ok!(write!(self.wr, "{}", escape_str(name)));
+            try!(write!(self.wr, "{}", escape_str(name)));
         } else {
             self.indent += 2;
-            if_ok!(write!(self.wr, "[\n{}{},\n", spaces(self.indent),
+            try!(write!(self.wr, "[\n{}{},\n", spaces(self.indent),
                           escape_str(name)));
             f(self);
             self.indent -= 2;
-            if_ok!(write!(self.wr, "\n{}]", spaces(self.indent)));
+            try!(write!(self.wr, "\n{}]", spaces(self.indent)));
         }
     }
 
@@ -560,9 +560,9 @@ impl<'a> serialize::Encoder for PrettyEncoder<'a> {
                              idx: uint,
                              f: |&mut PrettyEncoder<'a>|) {
         if idx != 0 {
-            if_ok!(write!(self.wr, ",\n"));
+            try!(write!(self.wr, ",\n"));
         }
-        if_ok!(write!(self.wr, "{}", spaces(self.indent)));
+        try!(write!(self.wr, "{}", spaces(self.indent)));
         f(self)
     }
 
@@ -587,13 +587,13 @@ impl<'a> serialize::Encoder for PrettyEncoder<'a> {
                    len: uint,
                    f: |&mut PrettyEncoder<'a>|) {
         if len == 0 {
-            if_ok!(write!(self.wr, "\\{\\}"));
+            try!(write!(self.wr, "\\{\\}"));
         } else {
-            if_ok!(write!(self.wr, "\\{"));
+            try!(write!(self.wr, "\\{"));
             self.indent += 2;
             f(self);
             self.indent -= 2;
-            if_ok!(write!(self.wr, "\n{}\\}", spaces(self.indent)));
+            try!(write!(self.wr, "\n{}\\}", spaces(self.indent)));
         }
     }
 
@@ -602,11 +602,11 @@ impl<'a> serialize::Encoder for PrettyEncoder<'a> {
                          idx: uint,
                          f: |&mut PrettyEncoder<'a>|) {
         if idx == 0 {
-            if_ok!(write!(self.wr, "\n"));
+            try!(write!(self.wr, "\n"));
         } else {
-            if_ok!(write!(self.wr, ",\n"));
+            try!(write!(self.wr, ",\n"));
         }
-        if_ok!(write!(self.wr, "{}{}: ", spaces(self.indent), escape_str(name)));
+        try!(write!(self.wr, "{}{}: ", spaces(self.indent), escape_str(name)));
         f(self);
     }
 
@@ -635,50 +635,50 @@ impl<'a> serialize::Encoder for PrettyEncoder<'a> {
 
     fn emit_seq(&mut self, len: uint, f: |&mut PrettyEncoder<'a>|) {
         if len == 0 {
-            if_ok!(write!(self.wr, "[]"));
+            try!(write!(self.wr, "[]"));
         } else {
-            if_ok!(write!(self.wr, "["));
+            try!(write!(self.wr, "["));
             self.indent += 2;
             f(self);
             self.indent -= 2;
-            if_ok!(write!(self.wr, "\n{}]", spaces(self.indent)));
+            try!(write!(self.wr, "\n{}]", spaces(self.indent)));
         }
     }
 
     fn emit_seq_elt(&mut self, idx: uint, f: |&mut PrettyEncoder<'a>|) {
         if idx == 0 {
-            if_ok!(write!(self.wr, "\n"));
+            try!(write!(self.wr, "\n"));
         } else {
-            if_ok!(write!(self.wr, ",\n"));
+            try!(write!(self.wr, ",\n"));
         }
-        if_ok!(write!(self.wr, "{}", spaces(self.indent)));
+        try!(write!(self.wr, "{}", spaces(self.indent)));
         f(self)
     }
 
     fn emit_map(&mut self, len: uint, f: |&mut PrettyEncoder<'a>|) {
         if len == 0 {
-            if_ok!(write!(self.wr, "\\{\\}"));
+            try!(write!(self.wr, "\\{\\}"));
         } else {
-            if_ok!(write!(self.wr, "\\{"));
+            try!(write!(self.wr, "\\{"));
             self.indent += 2;
             f(self);
             self.indent -= 2;
-            if_ok!(write!(self.wr, "\n{}\\}", spaces(self.indent)));
+            try!(write!(self.wr, "\n{}\\}", spaces(self.indent)));
         }
     }
 
     fn emit_map_elt_key(&mut self, idx: uint, f: |&mut PrettyEncoder<'a>|) {
         if idx == 0 {
-            if_ok!(write!(self.wr, "\n"));
+            try!(write!(self.wr, "\n"));
         } else {
-            if_ok!(write!(self.wr, ",\n"));
+            try!(write!(self.wr, ",\n"));
         }
-        if_ok!(write!(self.wr, "{}", spaces(self.indent)));
+        try!(write!(self.wr, "{}", spaces(self.indent)));
         f(self);
     }
 
     fn emit_map_elt_val(&mut self, _idx: uint, f: |&mut PrettyEncoder<'a>|) {
-        if_ok!(write!(self.wr, ": "));
+        try!(write!(self.wr, ": "));
         f(self);
     }
 }

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -376,48 +376,48 @@ pub fn write_boxplot(w: &mut io::Writer, s: &Summary,
     let range_width = width_hint - overhead_width;;
     let char_step = range / (range_width as f64);
 
-    if_ok!(write!(w, "{} |", lostr));
+    try!(write!(w, "{} |", lostr));
 
     let mut c = 0;
     let mut v = lo;
 
     while c < range_width && v < s.min {
-        if_ok!(write!(w, " "));
+        try!(write!(w, " "));
         v += char_step;
         c += 1;
     }
-    if_ok!(write!(w, "["));
+    try!(write!(w, "["));
     c += 1;
     while c < range_width && v < q1 {
-        if_ok!(write!(w, "-"));
+        try!(write!(w, "-"));
         v += char_step;
         c += 1;
     }
     while c < range_width && v < q2 {
-        if_ok!(write!(w, "*"));
+        try!(write!(w, "*"));
         v += char_step;
         c += 1;
     }
-    if_ok!(write!(w, r"\#"));
+    try!(write!(w, r"\#"));
     c += 1;
     while c < range_width && v < q3 {
-        if_ok!(write!(w, "*"));
+        try!(write!(w, "*"));
         v += char_step;
         c += 1;
     }
     while c < range_width && v < s.max {
-        if_ok!(write!(w, "-"));
+        try!(write!(w, "-"));
         v += char_step;
         c += 1;
     }
-    if_ok!(write!(w, "]"));
+    try!(write!(w, "]"));
     while c < range_width {
-        if_ok!(write!(w, " "));
+        try!(write!(w, " "));
         v += char_step;
         c += 1;
     }
 
-    if_ok!(write!(w, "| {}", histr));
+    try!(write!(w, "| {}", histr));
     Ok(())
 }
 

--- a/src/libnative/io/pipe_unix.rs
+++ b/src/libnative/io/pipe_unix.rs
@@ -77,8 +77,8 @@ impl Drop for Inner {
 }
 
 fn connect(addr: &CString, ty: libc::c_int) -> IoResult<Inner> {
-    let (addr, len) = if_ok!(addr_to_sockaddr_un(addr));
-    let inner = Inner { fd: if_ok!(unix_socket(ty)) };
+    let (addr, len) = try!(addr_to_sockaddr_un(addr));
+    let inner = Inner { fd: try!(unix_socket(ty)) };
     let addrp = &addr as *libc::sockaddr_storage;
     match retry(|| unsafe {
         libc::connect(inner.fd, addrp as *libc::sockaddr,
@@ -90,8 +90,8 @@ fn connect(addr: &CString, ty: libc::c_int) -> IoResult<Inner> {
 }
 
 fn bind(addr: &CString, ty: libc::c_int) -> IoResult<Inner> {
-    let (addr, len) = if_ok!(addr_to_sockaddr_un(addr));
-    let inner = Inner { fd: if_ok!(unix_socket(ty)) };
+    let (addr, len) = try!(addr_to_sockaddr_un(addr));
+    let inner = Inner { fd: try!(unix_socket(ty)) };
     let addrp = &addr as *libc::sockaddr_storage;
     match unsafe {
         libc::bind(inner.fd, addrp as *libc::sockaddr, len as libc::socklen_t)
@@ -198,7 +198,7 @@ impl UnixDatagram {
     }
 
     pub fn sendto(&mut self, buf: &[u8], dst: &CString) -> IoResult<()> {
-        let (dst, len) = if_ok!(addr_to_sockaddr_un(dst));
+        let (dst, len) = try!(addr_to_sockaddr_un(dst));
         let dstp = &dst as *libc::sockaddr_storage;
         let ret = retry(|| unsafe {
             libc::sendto(self.fd(),

--- a/src/libnative/io/pipe_win32.rs
+++ b/src/libnative/io/pipe_win32.rs
@@ -262,7 +262,7 @@ impl UnixStream {
 impl rtio::RtioPipe for UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         if self.read.is_none() {
-            self.read = Some(if_ok!(Event::new(true, false)));
+            self.read = Some(try!(Event::new(true, false)));
         }
 
         let mut bytes_read = 0;
@@ -298,7 +298,7 @@ impl rtio::RtioPipe for UnixStream {
 
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         if self.write.is_none() {
-            self.write = Some(if_ok!(Event::new(true, false)));
+            self.write = Some(try!(Event::new(true, false)));
         }
 
         let mut offset = 0;
@@ -371,7 +371,7 @@ impl UnixListener {
     pub fn native_listen(self) -> IoResult<UnixAcceptor> {
         Ok(UnixAcceptor {
             listener: self,
-            event: if_ok!(Event::new(true, false)),
+            event: try!(Event::new(true, false)),
         })
     }
 }

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -161,7 +161,7 @@ impl Archive {
         // We skip any files explicitly desired for skipping, and we also skip
         // all SYMDEF files as these are just magical placeholders which get
         // re-created when we make a new archive anyway.
-        let files = if_ok!(fs::readdir(loc.path()));
+        let files = try!(fs::readdir(loc.path()));
         let mut inputs = ~[];
         for file in files.iter() {
             let filename = file.filename_str().unwrap();
@@ -170,7 +170,7 @@ impl Archive {
 
             let filename = format!("r-{}-{}", name, filename);
             let new_filename = file.with_filename(filename);
-            if_ok!(fs::rename(file, &new_filename));
+            try!(fs::rename(file, &new_filename));
             inputs.push(new_filename);
         }
         if inputs.len() == 0 { return Ok(()) }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -521,9 +521,9 @@ fn write_out_deps(sess: Session,
              })
              .collect()
     };
-    let mut file = if_ok!(io::File::create(&deps_filename));
+    let mut file = try!(io::File::create(&deps_filename));
     for path in out_filenames.iter() {
-        if_ok!(write!(&mut file as &mut Writer,
+        try!(write!(&mut file as &mut Writer,
                       "{}: {}\n\n", path.display(), files.connect(" ")));
     }
     Ok(())
@@ -575,21 +575,21 @@ impl pprust::PpAnn for IdentifiedAnnotation {
     fn post(&self, node: pprust::AnnNode) -> io::IoResult<()> {
         match node {
             pprust::NodeItem(s, item) => {
-                if_ok!(pp::space(&mut s.s));
-                if_ok!(pprust::synth_comment(s, item.id.to_str()));
+                try!(pp::space(&mut s.s));
+                try!(pprust::synth_comment(s, item.id.to_str()));
             }
             pprust::NodeBlock(s, blk) => {
-                if_ok!(pp::space(&mut s.s));
-                if_ok!(pprust::synth_comment(s, ~"block " + blk.id.to_str()));
+                try!(pp::space(&mut s.s));
+                try!(pprust::synth_comment(s, ~"block " + blk.id.to_str()));
             }
             pprust::NodeExpr(s, expr) => {
-                if_ok!(pp::space(&mut s.s));
-                if_ok!(pprust::synth_comment(s, expr.id.to_str()));
-                if_ok!(pprust::pclose(s));
+                try!(pp::space(&mut s.s));
+                try!(pprust::synth_comment(s, expr.id.to_str()));
+                try!(pprust::pclose(s));
             }
             pprust::NodePat(s, pat) => {
-                if_ok!(pp::space(&mut s.s));
-                if_ok!(pprust::synth_comment(s, ~"pat " + pat.id.to_str()));
+                try!(pp::space(&mut s.s));
+                try!(pprust::synth_comment(s, ~"pat " + pat.id.to_str()));
             }
         }
         Ok(())
@@ -611,12 +611,12 @@ impl pprust::PpAnn for TypedAnnotation {
         let tcx = self.analysis.ty_cx;
         match node {
             pprust::NodeExpr(s, expr) => {
-                if_ok!(pp::space(&mut s.s));
-                if_ok!(pp::word(&mut s.s, "as"));
-                if_ok!(pp::space(&mut s.s));
-                if_ok!(pp::word(&mut s.s,
+                try!(pp::space(&mut s.s));
+                try!(pp::word(&mut s.s, "as"));
+                try!(pp::space(&mut s.s));
+                try!(pp::word(&mut s.s,
                                 ppaux::ty_to_str(tcx, ty::expr_ty(tcx, expr))));
-                if_ok!(pprust::pclose(s));
+                try!(pprust::pclose(s));
             }
             _ => ()
         }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1088,11 +1088,11 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
 
 fn list_crate_attributes(md: ebml::Doc, hash: &str,
                          out: &mut io::Writer) -> io::IoResult<()> {
-    if_ok!(write!(out, "=Crate Attributes ({})=\n", hash));
+    try!(write!(out, "=Crate Attributes ({})=\n", hash));
 
     let r = get_attributes(md);
     for attr in r.iter() {
-        if_ok!(write!(out, "{}\n", pprust::attribute_to_str(attr)));
+        try!(write!(out, "{}\n", pprust::attribute_to_str(attr)));
     }
 
     write!(out, "\n\n")
@@ -1131,11 +1131,11 @@ pub fn get_crate_deps(data: &[u8]) -> ~[CrateDep] {
 }
 
 fn list_crate_deps(data: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
-    if_ok!(write!(out, "=External Dependencies=\n"));
+    try!(write!(out, "=External Dependencies=\n"));
 
     let r = get_crate_deps(data);
     for dep in r.iter() {
-        if_ok!(write!(out,
+        try!(write!(out,
                       "{} {}-{}-{}\n",
                       dep.cnum,
                       token::get_ident(dep.name),
@@ -1143,7 +1143,7 @@ fn list_crate_deps(data: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
                       dep.vers));
     }
 
-    if_ok!(write!(out, "\n"));
+    try!(write!(out, "\n"));
     Ok(())
 }
 
@@ -1164,7 +1164,7 @@ pub fn get_crate_vers(data: &[u8]) -> ~str {
 pub fn list_crate_metadata(bytes: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
     let hash = get_crate_hash(bytes);
     let md = reader::Doc(bytes);
-    if_ok!(list_crate_attributes(md, hash, out));
+    try!(list_crate_attributes(md, hash, out));
     list_crate_deps(bytes, out)
 }
 

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -113,8 +113,8 @@ impl<O:DataFlowOperator> pprust::PpAnn for DataFlowContext<O> {
 
             let comment_str = format!("id {}: {}{}{}",
                                       id, entry_str, gens_str, kills_str);
-            if_ok!(pprust::synth_comment(ps, comment_str));
-            if_ok!(pp::space(&mut ps.s));
+            try!(pprust::synth_comment(ps, comment_str));
+            try!(pp::space(&mut ps.s));
         }
         Ok(())
     }
@@ -351,10 +351,10 @@ impl<O:DataFlowOperator+Clone+'static> DataFlowContext<O> {
     fn pretty_print_to(&self, wr: ~io::Writer,
                        blk: &ast::Block) -> io::IoResult<()> {
         let mut ps = pprust::rust_printer_annotated(wr, self);
-        if_ok!(pprust::cbox(&mut ps, pprust::indent_unit));
-        if_ok!(pprust::ibox(&mut ps, 0u));
-        if_ok!(pprust::print_block(&mut ps, blk));
-        if_ok!(pp::eof(&mut ps.s));
+        try!(pprust::cbox(&mut ps, pprust::indent_unit));
+        try!(pprust::ibox(&mut ps, 0u));
+        try!(pprust::print_block(&mut ps, blk));
+        try!(pp::eof(&mut ps.s));
         Ok(())
     }
 }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -740,7 +740,7 @@ impl Liveness {
         for var_idx in range(0u, self.ir.num_vars.get()) {
             let idx = node_base_idx + var_idx;
             if test(idx).is_valid() {
-                if_ok!(write!(wr, " {}", Variable(var_idx).to_str()));
+                try!(write!(wr, " {}", Variable(var_idx).to_str()));
             }
         }
         Ok(())

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -29,7 +29,7 @@ impl<'a> fmt::Show for Escape<'a> {
         for (i, ch) in s.bytes().enumerate() {
             match ch as char {
                 '<' | '>' | '&' | '\'' | '"' => {
-                    if_ok!(fmt.buf.write(pile_o_bits.slice(last, i).as_bytes()));
+                    try!(fmt.buf.write(pile_o_bits.slice(last, i).as_bytes()));
                     let s = match ch as char {
                         '>' => "&gt;",
                         '<' => "&lt;",
@@ -38,7 +38,7 @@ impl<'a> fmt::Show for Escape<'a> {
                         '"' => "&quot;",
                         _ => unreachable!()
                     };
-                    if_ok!(fmt.buf.write(s.as_bytes()));
+                    try!(fmt.buf.write(s.as_bytes()));
                     last = i + 1;
                 }
                 _ => {}
@@ -46,7 +46,7 @@ impl<'a> fmt::Show for Escape<'a> {
         }
 
         if last < s.len() {
-            if_ok!(fmt.buf.write(pile_o_bits.slice_from(last).as_bytes()));
+            try!(fmt.buf.write(pile_o_bits.slice_from(last).as_bytes()));
         }
         Ok(())
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -50,46 +50,46 @@ impl PuritySpace {
 impl fmt::Show for clean::Generics {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.lifetimes.len() == 0 && self.type_params.len() == 0 { return Ok(()) }
-        if_ok!(f.buf.write("&lt;".as_bytes()));
+        try!(f.buf.write("&lt;".as_bytes()));
 
         for (i, life) in self.lifetimes.iter().enumerate() {
             if i > 0 {
-                if_ok!(f.buf.write(", ".as_bytes()));
+                try!(f.buf.write(", ".as_bytes()));
             }
-            if_ok!(write!(f.buf, "{}", *life));
+            try!(write!(f.buf, "{}", *life));
         }
 
         if self.type_params.len() > 0 {
             if self.lifetimes.len() > 0 {
-                if_ok!(f.buf.write(", ".as_bytes()));
+                try!(f.buf.write(", ".as_bytes()));
             }
 
             for (i, tp) in self.type_params.iter().enumerate() {
                 if i > 0 {
-                    if_ok!(f.buf.write(", ".as_bytes()))
+                    try!(f.buf.write(", ".as_bytes()))
                 }
-                if_ok!(f.buf.write(tp.name.as_bytes()));
+                try!(f.buf.write(tp.name.as_bytes()));
 
                 if tp.bounds.len() > 0 {
-                    if_ok!(f.buf.write(": ".as_bytes()));
+                    try!(f.buf.write(": ".as_bytes()));
                     for (i, bound) in tp.bounds.iter().enumerate() {
                         if i > 0 {
-                            if_ok!(f.buf.write(" + ".as_bytes()));
+                            try!(f.buf.write(" + ".as_bytes()));
                         }
-                        if_ok!(write!(f.buf, "{}", *bound));
+                        try!(write!(f.buf, "{}", *bound));
                     }
                 }
             }
         }
-        if_ok!(f.buf.write("&gt;".as_bytes()));
+        try!(f.buf.write("&gt;".as_bytes()));
         Ok(())
     }
 }
 
 impl fmt::Show for clean::Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if_ok!(f.buf.write("'".as_bytes()));
-        if_ok!(f.buf.write(self.get_ref().as_bytes()));
+        try!(f.buf.write("'".as_bytes()));
+        try!(f.buf.write(self.get_ref().as_bytes()));
         Ok(())
     }
 }
@@ -110,32 +110,32 @@ impl fmt::Show for clean::TyParamBound {
 impl fmt::Show for clean::Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.global {
-            if_ok!(f.buf.write("::".as_bytes()))
+            try!(f.buf.write("::".as_bytes()))
         }
         for (i, seg) in self.segments.iter().enumerate() {
             if i > 0 {
-                if_ok!(f.buf.write("::".as_bytes()))
+                try!(f.buf.write("::".as_bytes()))
             }
-            if_ok!(f.buf.write(seg.name.as_bytes()));
+            try!(f.buf.write(seg.name.as_bytes()));
 
             if seg.lifetimes.len() > 0 || seg.types.len() > 0 {
-                if_ok!(f.buf.write("&lt;".as_bytes()));
+                try!(f.buf.write("&lt;".as_bytes()));
                 let mut comma = false;
                 for lifetime in seg.lifetimes.iter() {
                     if comma {
-                        if_ok!(f.buf.write(", ".as_bytes()));
+                        try!(f.buf.write(", ".as_bytes()));
                     }
                     comma = true;
-                    if_ok!(write!(f.buf, "{}", *lifetime));
+                    try!(write!(f.buf, "{}", *lifetime));
                 }
                 for ty in seg.types.iter() {
                     if comma {
-                        if_ok!(f.buf.write(", ".as_bytes()));
+                        try!(f.buf.write(", ".as_bytes()));
                     }
                     comma = true;
-                    if_ok!(write!(f.buf, "{}", *ty));
+                    try!(write!(f.buf, "{}", *ty));
                 }
-                if_ok!(f.buf.write("&gt;".as_bytes()));
+                try!(f.buf.write("&gt;".as_bytes()));
             }
         }
         Ok(())
@@ -222,11 +222,11 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
                         let mut root = root;
                         for seg in path.segments.slice_to(amt).iter() {
                             if "super" == seg.name || "self" == seg.name {
-                                if_ok!(write!(w, "{}::", seg.name));
+                                try!(write!(w, "{}::", seg.name));
                             } else {
                                 root.push_str(seg.name);
                                 root.push_str("/");
-                                if_ok!(write!(w, "<a class='mod'
+                                try!(write!(w, "<a class='mod'
                                                     href='{}index.html'>{}</a>::",
                                               root,
                                               seg.name));
@@ -235,7 +235,7 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
                     }
                     None => {
                         for seg in path.segments.slice_to(amt).iter() {
-                            if_ok!(write!(w, "{}::", seg.name));
+                            try!(write!(w, "{}::", seg.name));
                         }
                     }
                 }
@@ -263,15 +263,15 @@ fn path(w: &mut io::Writer, path: &clean::Path, print_all: bool,
                         }
                     }
 
-                    if_ok!(write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
+                    try!(write!(w, "<a class='{}' href='{}' title='{}'>{}</a>",
                                   shortty, url, fqp.connect("::"), last.name));
                 }
 
                 _ => {
-                    if_ok!(write!(w, "{}", last.name));
+                    try!(write!(w, "{}", last.name));
                 }
             }
-            if_ok!(write!(w, "{}", generics));
+            try!(write!(w, "{}", generics));
             Ok(())
         })
     })
@@ -282,14 +282,14 @@ fn typarams(w: &mut io::Writer,
             typarams: &Option<~[clean::TyParamBound]>) -> fmt::Result {
     match *typarams {
         Some(ref params) => {
-            if_ok!(write!(w, "&lt;"));
+            try!(write!(w, "&lt;"));
             for (i, param) in params.iter().enumerate() {
                 if i > 0 {
-                    if_ok!(write!(w, ", "));
+                    try!(write!(w, ", "));
                 }
-                if_ok!(write!(w, "{}", *param));
+                try!(write!(w, "{}", *param));
             }
-            if_ok!(write!(w, "&gt;"));
+            try!(write!(w, "&gt;"));
             Ok(())
         }
         None => Ok(())
@@ -306,12 +306,12 @@ impl fmt::Show for clean::Type {
                 })
             }
             clean::ResolvedPath{id, typarams: ref tp, path: ref path} => {
-                if_ok!(resolved_path(f.buf, id, path, false));
+                try!(resolved_path(f.buf, id, path, false));
                 typarams(f.buf, tp)
             }
             clean::ExternalPath{path: ref path, typarams: ref tp,
                                 fqn: ref fqn, kind, krate} => {
-                if_ok!(external_path(f.buf, path, false, fqn.as_slice(), kind,
+                try!(external_path(f.buf, path, false, fqn.as_slice(), kind,
                                      krate))
                 typarams(f.buf, tp)
             }
@@ -364,12 +364,12 @@ impl fmt::Show for clean::Type {
                        decl.decl)
             }
             clean::Tuple(ref typs) => {
-                if_ok!(f.buf.write("(".as_bytes()));
+                try!(f.buf.write("(".as_bytes()));
                 for (i, typ) in typs.iter().enumerate() {
                     if i > 0 {
-                        if_ok!(f.buf.write(", ".as_bytes()))
+                        try!(f.buf.write(", ".as_bytes()))
                     }
-                    if_ok!(write!(f.buf, "{}", *typ));
+                    try!(write!(f.buf, "{}", *typ));
                 }
                 f.buf.write(")".as_bytes())
             }
@@ -407,11 +407,11 @@ impl fmt::Show for clean::Type {
 impl fmt::Show for clean::Arguments {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, input) in self.values.iter().enumerate() {
-            if i > 0 { if_ok!(write!(f.buf, ", ")); }
+            if i > 0 { try!(write!(f.buf, ", ")); }
             if input.name.len() > 0 {
-                if_ok!(write!(f.buf, "{}: ", input.name));
+                try!(write!(f.buf, "{}: ", input.name));
             }
-            if_ok!(write!(f.buf, "{}", input.type_));
+            try!(write!(f.buf, "{}", input.type_));
         }
         Ok(())
     }
@@ -495,12 +495,12 @@ impl fmt::Show for clean::ViewPath {
                 write!(f.buf, "use {}::*;", *src)
             }
             clean::ImportList(ref src, ref names) => {
-                if_ok!(write!(f.buf, "use {}::\\{", *src));
+                try!(write!(f.buf, "use {}::\\{", *src));
                 for (i, n) in names.iter().enumerate() {
                     if i > 0 {
-                        if_ok!(write!(f.buf, ", "));
+                        try!(write!(f.buf, ", "));
                     }
-                    if_ok!(write!(f.buf, "{}", *n));
+                    try!(write!(f.buf, "{}", *n));
                 }
                 write!(f.buf, "\\};")
             }
@@ -518,9 +518,9 @@ impl fmt::Show for clean::ImportSource {
             _ => {
                 for (i, seg) in self.path.segments.iter().enumerate() {
                     if i > 0 {
-                        if_ok!(write!(f.buf, "::"))
+                        try!(write!(f.buf, "::"))
                     }
-                    if_ok!(write!(f.buf, "{}", seg.name));
+                    try!(write!(f.buf, "{}", seg.name));
                 }
                 Ok(())
             }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -351,7 +351,7 @@ fn json_output(krate: clean::Crate, res: ~[plugins::PluginJson],
     json.insert(~"crate", crate_json);
     json.insert(~"plugins", json::Object(plugins_json));
 
-    let mut file = if_ok!(File::create(&dst));
-    if_ok!(json::Object(json).to_writer(&mut file));
+    let mut file = try!(File::create(&dst));
+    try!(json::Object(json).to_writer(&mut file));
     Ok(())
 }

--- a/src/libsemver/lib.rs
+++ b/src/libsemver/lib.rs
@@ -99,19 +99,19 @@ pub struct Version {
 impl fmt::Show for Version {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if_ok!(write!(f.buf, "{}.{}.{}", self.major, self.minor, self.patch))
+        try!(write!(f.buf, "{}.{}.{}", self.major, self.minor, self.patch))
         if !self.pre.is_empty() {
-            if_ok!(write!(f.buf, "-"));
+            try!(write!(f.buf, "-"));
             for (i, x) in self.pre.iter().enumerate() {
-                if i != 0 { if_ok!(write!(f.buf, ".")) };
-                if_ok!(x.fmt(f));
+                if i != 0 { try!(write!(f.buf, ".")) };
+                try!(x.fmt(f));
             }
         }
         if !self.build.is_empty() {
-            if_ok!(write!(f.buf, "+"));
+            try!(write!(f.buf, "+"));
             for (i, x) in self.build.iter().enumerate() {
-                if i != 0 { if_ok!(write!(f.buf, ".")) };
-                if_ok!(x.fmt(f));
+                if i != 0 { try!(write!(f.buf, ".")) };
+                try!(x.fmt(f));
             }
         }
         Ok(())

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -12,7 +12,7 @@
 
 use std::str;
 
-macro_rules! if_ok( ($e:expr) => (
+macro_rules! try( ($e:expr) => (
     match $e { Ok(e) => e, Err(e) => { self.last_error = Err(e); return } }
 ) )
 
@@ -665,18 +665,18 @@ pub mod writer {
             write_vuint(self.writer, tag_id);
 
             // Write a placeholder four-byte size.
-            self.size_positions.push(if_ok!(self.writer.tell()) as uint);
+            self.size_positions.push(try!(self.writer.tell()) as uint);
             let zeroes: &[u8] = &[0u8, 0u8, 0u8, 0u8];
-            if_ok!(self.writer.write(zeroes));
+            try!(self.writer.write(zeroes));
         }
 
         pub fn end_tag(&mut self) {
             let last_size_pos = self.size_positions.pop().unwrap();
-            let cur_pos = if_ok!(self.writer.tell());
-            if_ok!(self.writer.seek(last_size_pos as i64, io::SeekSet));
+            let cur_pos = try!(self.writer.tell());
+            try!(self.writer.seek(last_size_pos as i64, io::SeekSet));
             let size = (cur_pos as uint - last_size_pos - 4);
             write_sized_vuint(self.writer, size, 4u);
-            if_ok!(self.writer.seek(cur_pos as i64, io::SeekSet));
+            try!(self.writer.seek(cur_pos as i64, io::SeekSet));
 
             debug!("End tag (size = {})", size);
         }

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -702,7 +702,7 @@ pub unsafe fn write_unsafe(output: &mut io::Writer,
         curarg: args.iter(),
     };
     for piece in fmt.iter() {
-        if_ok!(formatter.run(piece, None));
+        try!(formatter.run(piece, None));
     }
     Ok(())
 }
@@ -859,13 +859,13 @@ impl<'a> Formatter<'a> {
                 for s in selectors.iter() {
                     if s.selector == value {
                         for piece in s.result.iter() {
-                            if_ok!(self.run(piece, Some(value)));
+                            try!(self.run(piece, Some(value)));
                         }
                         return Ok(());
                     }
                 }
                 for piece in default.iter() {
-                    if_ok!(self.run(piece, Some(value)));
+                    try!(self.run(piece, Some(value)));
                 }
                 Ok(())
             }
@@ -876,7 +876,7 @@ impl<'a> Formatter<'a> {
         ::uint::to_str_bytes(value, 10, |buf| {
             let valuestr = str::from_utf8(buf).unwrap();
             for piece in pieces.iter() {
-                if_ok!(self.run(piece, Some(valuestr)));
+                try!(self.run(piece, Some(valuestr)));
             }
             Ok(())
         })
@@ -917,12 +917,12 @@ impl<'a> Formatter<'a> {
         let sign = |this: &mut Formatter| {
             if !signprinted {
                 if this.flags & 1 << (FlagSignPlus as uint) != 0 && positive {
-                    if_ok!(this.buf.write(['+' as u8]));
+                    try!(this.buf.write(['+' as u8]));
                 } else if !positive {
-                    if_ok!(this.buf.write(['-' as u8]));
+                    try!(this.buf.write(['-' as u8]));
                 }
                 if this.flags & 1 << (FlagAlternate as uint) != 0 {
-                    if_ok!(this.buf.write(alternate_prefix.as_bytes()));
+                    try!(this.buf.write(alternate_prefix.as_bytes()));
                 }
                 signprinted = true;
             }
@@ -939,7 +939,7 @@ impl<'a> Formatter<'a> {
             Some(min) => {
                 if self.flags & 1 << (FlagSignAwareZeroPad as uint) != 0 {
                     self.fill = '0';
-                    if_ok!(sign(self));
+                    try!(sign(self));
                 }
                 self.with_padding(min - actual_len, parse::AlignRight, |me| {
                     emit(me)
@@ -1011,15 +1011,15 @@ impl<'a> Formatter<'a> {
             parse::AlignLeft | parse::AlignRight => self.align
         };
         if align == parse::AlignLeft {
-            if_ok!(f(self));
+            try!(f(self));
         }
         let mut fill = [0u8, ..4];
         let len = self.fill.encode_utf8(fill);
         for _ in range(0, padding) {
-            if_ok!(self.buf.write(fill.slice_to(len)));
+            try!(self.buf.write(fill.slice_to(len)));
         }
         if align == parse::AlignRight {
-            if_ok!(f(self));
+            try!(f(self));
         }
         Ok(())
     }

--- a/src/libstd/hashmap.rs
+++ b/src/libstd/hashmap.rs
@@ -599,15 +599,15 @@ impl<K:Hash + Eq + Clone,V:Clone> Clone for HashMap<K,V> {
 
 impl<A: fmt::Show + Hash + Eq, B: fmt::Show> fmt::Show for HashMap<A, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if_ok!(write!(f.buf, r"\{"))
+        try!(write!(f.buf, r"\{"))
         let mut first = true;
         for (key, value) in self.iter() {
             if first {
                 first = false;
             } else {
-                if_ok!(write!(f.buf, ", "));
+                try!(write!(f.buf, ", "));
             }
-            if_ok!(write!(f.buf, "{}: {}", *key, *value));
+            try!(write!(f.buf, "{}: {}", *key, *value));
         }
         write!(f.buf, r"\}")
     }
@@ -877,15 +877,15 @@ impl<T:Hash + Eq + Clone> Clone for HashSet<T> {
 
 impl<A: fmt::Show + Hash + Eq> fmt::Show for HashSet<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if_ok!(write!(f.buf, r"\{"))
+        try!(write!(f.buf, r"\{"))
         let mut first = true;
         for x in self.iter() {
             if first {
                 first = false;
             } else {
-                if_ok!(write!(f.buf, ", "));
+                try!(write!(f.buf, ", "));
             }
-            if_ok!(write!(f.buf, "{}", *x));
+            try!(write!(f.buf, "{}", *x));
         }
         write!(f.buf, r"\}")
     }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -88,7 +88,7 @@ impl<R: Reader> BufferedReader<R> {
 impl<R: Reader> Buffer for BufferedReader<R> {
     fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos == self.cap {
-            self.cap = if_ok!(self.inner.read(self.buf));
+            self.cap = try!(self.inner.read(self.buf));
             self.pos = 0;
         }
         Ok(self.buf.slice(self.pos, self.cap))
@@ -103,7 +103,7 @@ impl<R: Reader> Buffer for BufferedReader<R> {
 impl<R: Reader> Reader for BufferedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         let nread = {
-            let available = if_ok!(self.fill());
+            let available = try!(self.fill());
             let nread = cmp::min(available.len(), buf.len());
             vec::bytes::copy_memory(buf, available.slice_to(nread));
             nread
@@ -182,7 +182,7 @@ impl<W: Writer> BufferedWriter<W> {
 impl<W: Writer> Writer for BufferedWriter<W> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         if self.pos + buf.len() > self.buf.len() {
-            if_ok!(self.flush_buf());
+            try!(self.flush_buf());
         }
 
         if buf.len() > self.buf.len() {
@@ -233,9 +233,9 @@ impl<W: Writer> Writer for LineBufferedWriter<W> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         match buf.iter().rposition(|&b| b == '\n' as u8) {
             Some(i) => {
-                if_ok!(self.inner.write(buf.slice_to(i + 1)));
-                if_ok!(self.inner.flush());
-                if_ok!(self.inner.write(buf.slice_from(i + 1)));
+                try!(self.inner.write(buf.slice_to(i + 1)));
+                try!(self.inner.flush());
+                try!(self.inner.write(buf.slice_from(i + 1)));
                 Ok(())
             }
             None => self.inner.write(buf),

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -339,8 +339,8 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
         })
     }
 
-    let mut reader = if_ok!(File::open(from));
-    let mut writer = if_ok!(File::create(to));
+    let mut reader = try!(File::open(from));
+    let mut writer = try!(File::create(to));
     let mut buf = [0, ..io::DEFAULT_BUF_SIZE];
 
     loop {
@@ -349,10 +349,10 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
             Err(ref e) if e.kind == io::EndOfFile => { break }
             Err(e) => return Err(e)
         };
-        if_ok!(writer.write(buf.slice_to(amt)));
+        try!(writer.write(buf.slice_to(amt)));
     }
 
-    chmod(to, if_ok!(from.stat()).perm)
+    chmod(to, try!(from.stat()).perm)
 }
 
 /// Changes the permission mode bits found on a file or a directory. This
@@ -460,10 +460,10 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 /// // one possible implementation of fs::walk_dir only visiting files
 /// fn visit_dirs(dir: &Path, cb: |&Path|) -> io::IoResult<()> {
 ///     if dir.is_dir() {
-///         let contents = if_ok!(fs::readdir(dir));
+///         let contents = try!(fs::readdir(dir));
 ///         for entry in contents.iter() {
 ///             if entry.is_dir() {
-///                 if_ok!(visit_dirs(entry, |p| cb(p)));
+///                 try!(visit_dirs(entry, |p| cb(p)));
 ///             } else {
 ///                 cb(entry);
 ///             }
@@ -490,7 +490,7 @@ pub fn readdir(path: &Path) -> IoResult<~[Path]> {
 /// rooted at `path`. The path given will not be iterated over, and this will
 /// perform iteration in a top-down order.
 pub fn walk_dir(path: &Path) -> IoResult<Directories> {
-    Ok(Directories { stack: if_ok!(readdir(path)) })
+    Ok(Directories { stack: try!(readdir(path)) })
 }
 
 /// An iterator which walks over a directory
@@ -529,7 +529,7 @@ pub fn mkdir_recursive(path: &Path, mode: FilePermission) -> IoResult<()> {
         return Ok(())
     }
     if path.filename().is_some() {
-        if_ok!(mkdir_recursive(&path.dir_path(), mode));
+        try!(mkdir_recursive(&path.dir_path(), mode));
     }
     mkdir(path, mode)
 }
@@ -542,12 +542,12 @@ pub fn mkdir_recursive(path: &Path, mode: FilePermission) -> IoResult<()> {
 /// This function will return an `Err` value if an error happens. See
 /// `file::unlink` and `fs::readdir` for possible error conditions.
 pub fn rmdir_recursive(path: &Path) -> IoResult<()> {
-    let children = if_ok!(readdir(path));
+    let children = try!(readdir(path));
     for child in children.iter() {
         if child.is_dir() {
-            if_ok!(rmdir_recursive(child));
+            try!(rmdir_recursive(child));
         } else {
-            if_ok!(unlink(child));
+            try!(unlink(child));
         }
     }
     // Directory should now be empty

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -113,7 +113,7 @@ impl Writer for MemWriter {
 impl Seek for MemWriter {
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
-        let new = if_ok!(combine(style, self.pos, self.buf.len(), pos));
+        let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
         Ok(())
     }
@@ -183,7 +183,7 @@ impl Reader for MemReader {
 impl Seek for MemReader {
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
-        let new = if_ok!(combine(style, self.pos, self.buf.len(), pos));
+        let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
         Ok(())
     }
@@ -253,7 +253,7 @@ impl<'a> Writer for BufWriter<'a> {
 impl<'a> Seek for BufWriter<'a> {
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
-        let new = if_ok!(combine(style, self.pos, self.buf.len(), pos));
+        let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
         Ok(())
     }
@@ -313,7 +313,7 @@ impl<'a> Reader for BufReader<'a> {
 impl<'a> Seek for BufReader<'a> {
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
-        let new = if_ok!(combine(style, self.pos, self.buf.len(), pos));
+        let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
         Ok(())
     }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -365,7 +365,7 @@ pub struct IoError {
 
 impl fmt::Show for IoError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        if_ok!(fmt.buf.write_str(self.desc));
+        try!(fmt.buf.write_str(self.desc));
         match self.detail {
             Some(ref s) => write!(fmt.buf, " ({})", *s),
             None => Ok(())
@@ -581,7 +581,7 @@ pub trait Reader {
         let mut pos = 0;
         let mut i = nbytes;
         while i > 0 {
-            val += (if_ok!(self.read_u8()) as u64) << pos;
+            val += (try!(self.read_u8()) as u64) << pos;
             pos += 8;
             i -= 1;
         }
@@ -605,7 +605,7 @@ pub trait Reader {
         let mut i = nbytes;
         while i > 0 {
             i -= 1;
-            val += (if_ok!(self.read_u8()) as u64) << i * 8;
+            val += (try!(self.read_u8()) as u64) << i * 8;
         }
         Ok(val)
     }
@@ -1191,7 +1191,7 @@ pub trait Buffer: Reader {
     /// This function will also return error if the stream does not contain a
     /// valid utf-8 encoded codepoint as the next few bytes in the stream.
     fn read_char(&mut self) -> IoResult<char> {
-        let first_byte = if_ok!(self.read_byte());
+        let first_byte = try!(self.read_byte());
         let width = str::utf8_char_width(first_byte);
         if width == 1 { return Ok(first_byte as char) }
         if width == 0 { return Err(standard_error(InvalidInput)) } // not utf8
@@ -1199,7 +1199,7 @@ pub trait Buffer: Reader {
         {
             let mut start = 1;
             while start < width {
-                match if_ok!(self.read(buf.mut_slice(start, width))) {
+                match try!(self.read(buf.mut_slice(start, width))) {
                     n if n == width - start => break,
                     n if n < width - start => { start += n; }
                     _ => return Err(standard_error(InvalidInput)),

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -189,7 +189,7 @@ pub fn copy<R: Reader, W: Writer>(r: &mut R, w: &mut W) -> io::IoResult<()> {
             Err(ref e) if e.kind == io::EndOfFile => return Ok(()),
             Err(e) => return Err(e),
         };
-        if_ok!(w.write(buf.slice_to(len)));
+        try!(w.write(buf.slice_to(len)));
     }
 }
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -355,6 +355,6 @@ macro_rules! local_data_key(
 /// error if the value of the expression is `Err`. For more information, see
 /// `std::io`.
 #[macro_export]
-macro_rules! if_ok(
+macro_rules! try(
     ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
 )

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -161,9 +161,9 @@ macro_rules! write_tuple {
         write!($buf, "({},)", *$x)
     );
     ($buf:expr, $hd:expr, $($tl:expr),+) => ({
-        if_ok!(write!($buf, "("));
-        if_ok!(write!($buf, "{}", *$hd));
-        $(if_ok!(write!($buf, ", {}", *$tl));)+
+        try!(write!($buf, "("));
+        try!(write!($buf, "{}", *$hd));
+        $(try!(write!($buf, ", {}", *$tl));)+
         write!($buf, ")")
     });
 }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2645,15 +2645,15 @@ impl<A: DeepClone> DeepClone for ~[A] {
 
 impl<'a, T: fmt::Show> fmt::Show for &'a [T] {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if_ok!(write!(f.buf, "["));
+        try!(write!(f.buf, "["));
         let mut is_first = true;
         for x in self.iter() {
             if is_first {
                 is_first = false;
             } else {
-                if_ok!(write!(f.buf, ", "));
+                try!(write!(f.buf, ", "));
             }
-            if_ok!(write!(f.buf, "{}", *x))
+            try!(write!(f.buf, "{}", *x))
         }
         write!(f.buf, "]")
     }

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -299,7 +299,7 @@ impl Printer {
             if !self.scan_stack_empty {
                 self.check_stack(0);
                 let left = self.token[self.left].clone();
-                if_ok!(self.advance_left(left, self.size[self.left]));
+                try!(self.advance_left(left, self.size[self.left]));
             }
             self.indent(0);
             Ok(())
@@ -377,9 +377,9 @@ impl Printer {
                 }
             }
             let left = self.token[self.left].clone();
-            if_ok!(self.advance_left(left, self.size[self.left]));
+            try!(self.advance_left(left, self.size[self.left]));
             if self.left != self.right {
-                if_ok!(self.check_stream());
+                try!(self.check_stream());
             }
         }
         Ok(())
@@ -436,7 +436,7 @@ impl Printer {
                 self.left += 1u;
                 self.left %= self.buf_len;
                 let left = self.token[self.left].clone();
-                if_ok!(self.advance_left(left, self.size[self.left]));
+                try!(self.advance_left(left, self.size[self.left]));
             }
             ret
         } else {
@@ -491,7 +491,7 @@ impl Printer {
     }
     pub fn print_str(&mut self, s: &str) -> io::IoResult<()> {
         while self.pending_indentation > 0 {
-            if_ok!(write!(self.out, " "));
+            try!(write!(self.out, " "));
             self.pending_indentation -= 1;
         }
         write!(self.out, "{}", s)

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -30,10 +30,6 @@ use terminfo::searcher::open;
 use terminfo::parser::compiled::{parse, msys_terminfo};
 use terminfo::parm::{expand, Number, Variables};
 
-macro_rules! if_ok (
-    ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
-)
-
 pub mod terminfo;
 
 // FIXME (#2807): Windows support.
@@ -155,7 +151,7 @@ impl<T: Writer> Terminal<T> {
             let s = expand(*self.ti.strings.find_equiv(&("setaf")).unwrap(),
                            [Number(color as int)], &mut Variables::new());
             if s.is_ok() {
-                if_ok!(self.out.write(s.unwrap()));
+                try!(self.out.write(s.unwrap()));
                 return Ok(true)
             } else {
                 warn!("{}", s.unwrap_err());
@@ -176,7 +172,7 @@ impl<T: Writer> Terminal<T> {
             let s = expand(*self.ti.strings.find_equiv(&("setab")).unwrap(),
                            [Number(color as int)], &mut Variables::new());
             if s.is_ok() {
-                if_ok!(self.out.write(s.unwrap()));
+                try!(self.out.write(s.unwrap()));
                 return Ok(true)
             } else {
                 warn!("{}", s.unwrap_err());
@@ -198,7 +194,7 @@ impl<T: Writer> Terminal<T> {
                 if parm.is_some() {
                     let s = expand(*parm.unwrap(), [], &mut Variables::new());
                     if s.is_ok() {
-                        if_ok!(self.out.write(s.unwrap()));
+                        try!(self.out.write(s.unwrap()));
                         return Ok(true)
                     } else {
                         warn!("{}", s.unwrap_err());


### PR DESCRIPTION
This "bubble up an error" macro was originally named if_ok! in order to get it
landed, but after the fact it was discovered that this name is not exactly
desirable.

The name `if_ok!` isn't immediately clear that is has much to do with error
handling, and it doesn't look fantastic in all contexts (if if_ok!(...) {}). In
general, the agreed opinion about `if_ok!` is that is came in as subpar.

The name `try!` is more invocative of error handling, it's shorter by 2 letters,
and it looks fitting in almost all circumstances. One concern about the word
`try!` is that it's too invocative of exceptions, but the belief is that this
will be overcome with documentation and examples.

Close #12037
