### PR TITLE
Update comments in the prelude

### DIFF
--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -14,17 +14,8 @@ The standard module imported by default into all Rust modules
 
 Many programming languages have a 'prelude': a particular subset of the
 libraries that come with the language. Every program imports the prelude by
-default.
-
-For example, it would be annoying to add `use std::io::println;` to every single
-program, and the vast majority of Rust programs will wish to print to standard
-output. Therefore, it makes sense to import it into every program.
-
-Rust's prelude has three main parts:
-
-1. io::print and io::println.
-2. Core operators, such as `Add`, `Mul`, and `Not`.
-3. Various types and traits, such as `Clone`, `Eq`, and `comm::Chan`.
+default. The prelude imports various core parts of the library that are
+generally useful to many Rust programs.
 
 */
 


### PR DESCRIPTION
The comments say that the prelude imports std::io::println since it would
be annoying to have to import it in every program that uses it. However,
the prelude doesn't actually import that function anymore. So, update the
comments to better match reality.
