### PR TITLE
Add travis jobs for tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+script:
+  - ./configure
+  - make tidy


### PR DESCRIPTION
I'm creating this PR to extend the discussion that started [here](https://mail.mozilla.org/pipermail/rust-dev/2014-February/008733.html) and as an example of what we could do to improve our pre-gating / pre-review process.

Here's the [link](https://travis-ci.org/FlaPer87/rust/builds/19245016) to the job executed by this commit.

If we decided to extend this to other `lite` jobs, the configure and make process will need to be tweaked a bit - for example, `--disable-optimize` - to ensure that it runs faster and just does a pre-check on the PR.

This definitely needs more discussion. 
