### PR TITLE
Add a Travis-CI configuration for the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+# Use something that's not 'ruby' so we don't set up things like
+# RVM/bundler/ruby and whatnot. Right now 'rust' isn't a language on travis and
+# it treats unknown languages as ruby-like I believe.
+language: c
+
+# Before we start doing anything, install the latest stock LLVM. These are
+# maintained by LLVM, and more information can be found at llvm.org/apt.
+#
+# Right now, the highest version is 3.5, and our SVN version is roughly aligned
+# with the 3.5 API (hurray!)
+install:
+  - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
+  - sudo sh -c "echo 'deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
+  - sudo sh -c "echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main' >> /etc/apt/sources.list"
+  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install -y --force-yes -qq llvm-3.5 llvm-3.5-dev clang-3.5 lldb-3.5
+
+# All of the llvm tools are suffixed with "-3.5" which we don't want, so symlink
+# them all into a local directory and just use that
+#
+# FIXME: this shouldn't update the src/llvm sub-repo, that takes about a minute
+#        it's gotta download so much stuff.
+before_script:
+  - mkdir -p local-llvm/bin
+  - ln -nsf /usr/bin/llvm-config-3.5 local-llvm/bin/llvm-config
+  - ln -nsf /usr/bin/llvm-mc-3.5 local-llvm/bin/llvm-mc
+  - ln -nsf /usr/bin/llvm-as-3.5 local-llvm/bin/llvm-as
+  - ln -nsf /usr/bin/llvm-dis-3.5 local-llvm/bin/llvm-dis
+  - ln -nsf /usr/bin/llc-3.5 local-llvm/bin/llc
+  - ln -nsf /usr/include/llvm-3.5 local-llvm/include
+  - ./configure --disable-optimize-tests --llvm-root=`pwd`/local-llvm --enable-fast-make --enable-clang
+
+# Tidy everything up first, then build a few things, and then run a few tests.
+# Note that this is meant to run in a "fairly small" amount of time, so this
+# isn't exhaustive at all.
+#
+# The "-lffi and -lncurses" are required for LLVM. The LLVM that rust builds
+# manually disables bringing in these two libraries, but the stock LLVM was
+# apparently built with these options. We provide these options when building so
+# the `rustc` binary can successfully link.
+script:
+  - make tidy
+  - RUSTFLAGS="-C link-args='-lffi -lncurses'" make -j4 rustc-stage1
+  - make check-stage1-std check-stage1-rpass check-stage1-cfail check-stage1-rfail
+
+env:
+  - NO_BENCH=1
+
+# We track this ourselves, and in theory we don't have to update the LLVM repo
+# (but sadly we do right now anyway).
+git:
+  submodules: false

--- a/configure
+++ b/configure
@@ -604,7 +604,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[2-4]svn|3.[2-4])
+        (3.[2-5]svn|3.[2-5])
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)
@@ -626,7 +626,7 @@ then
                       | cut -d ' ' -f 2)
 
     case $CFG_CLANG_VERSION in
-        (3.0svn | 3.0 | 3.1* | 3.2* | 3.3* | 3.4* )
+        (3.0svn | 3.0 | 3.1* | 3.2* | 3.3* | 3.4* | 3.5* )
         step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
         CFG_C_COMPILER="clang"
         ;;

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -218,8 +218,12 @@ LLVM_TOOLS=bugpoint llc llvm-ar llvm-as llvm-dis llvm-mc opt llvm-extract
 define DEF_LLVM_VARS
 # The configure script defines these variables with the target triples
 # separated by Z. This defines new ones with the expected format.
+ifeq ($$(CFG_LLVM_ROOT),)
 CFG_LLVM_BUILD_DIR_$(1):=$$(CFG_LLVM_BUILD_DIR_$(subst -,_,$(1)))
 CFG_LLVM_INST_DIR_$(1):=$$(CFG_LLVM_INST_DIR_$(subst -,_,$(1)))
+else
+CFG_LLVM_INST_DIR_$(1):=$$(CFG_LLVM_ROOT)
+endif
 
 # Any rules that depend on LLVM should depend on LLVM_CONFIG
 LLVM_CONFIG_$(1):=$$(CFG_LLVM_INST_DIR_$(1))/bin/llvm-config$$(X_$(1))

--- a/src/test/compile-fail/gated-phase.rs
+++ b/src/test/compile-fail/gated-phase.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:macro_crate_test.rs
+// ignore-stage1
 
 #[phase(syntax)]
 //~^ ERROR compile time crate loading is experimental and possibly buggy


### PR DESCRIPTION
Travis CI provides an easy-to-use continuous integration infrastructure for
github repos to use. Travis will automatically test all PRs which are opened
against the rust repository, informing PR owners of the test results.

I believe that this will be a very convenient piece of infrastructure as we'll
be able to reduce the load on bors quite a bit. In theory all PRs opened have
had the full test suite run against them, but unfortunately this is rarely the
case (I'm a prime suspect). Travis will be able to provide easy and relatively
quick (~30min) feedback for PRs. By ensuring fewer failures on bors, we can
hopefully feed more successful jobs to bors.

Overall, I expect this to be very helpful for new contributors as well as
regular contributors as it's another layer of tests being run which will
hopefully catch things sooner. One of the most convenient parts about using
Travis is that there's very little burden in terms of maintenance, and if things
go wrong we can easily turn travis completely off.

Note that this is _not_ the metric by which a PR will be merged with. Using
travis will purely be another source for running tests, we will continue to gate
all PRs on bors.
