### PR TITLE
Add backticks

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3689,15 +3689,15 @@ pub fn type_err_to_str(cx: ctxt, err: &type_err) -> ~str {
             }
         }
         terr_integer_as_char => {
-            format!("expected an integral type but found char")
+            format!("expected an integral type but found `char`")
         }
         terr_int_mismatch(ref values) => {
-            format!("expected {} but found {}",
+            format!("expected `{}` but found `{}`",
                  values.expected.to_str(),
                  values.found.to_str())
         }
         terr_float_mismatch(ref values) => {
-            format!("expected {} but found {}",
+            format!("expected `{}` but found `{}`",
                  values.expected.to_str(),
                  values.found.to_str())
         }
@@ -3765,13 +3765,13 @@ pub fn provided_trait_methods(cx: ctxt, id: ast::DefId) -> ~[@Method] {
                         }
                         _ => {
                             cx.sess.bug(format!("provided_trait_methods: \
-                                                 {:?} is not a trait",
+                                                 `{:?}` is not a trait",
                                                 id))
                         }
                     }
                 }
                 _ => {
-                    cx.sess.bug(format!("provided_trait_methods: {:?} is not \
+                    cx.sess.bug(format!("provided_trait_methods: `{:?}` is not \
                                          a trait",
                                         id))
                 }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -768,7 +768,7 @@ pub fn instantiate_trait_ref(ccx: &CrateCtxt,
         _ => {
             ccx.tcx.sess.span_fatal(
                 ast_trait_ref.path.span,
-                format!("{} is not a trait",
+                format!("`{}` is not a trait",
                     path_to_str(&ast_trait_ref.path)));
         }
     }

--- a/src/test/compile-fail/issue-2330.rs
+++ b/src/test/compile-fail/issue-2330.rs
@@ -15,7 +15,7 @@ trait channel<T> {
 }
 
 // `chan` is not a trait, it's an enum
-impl chan for int { //~ ERROR chan is not a trait
+impl chan for int { //~ ERROR `chan` is not a trait
     fn send(&self, v: int) { fail!() }
 }
 

--- a/src/test/compile-fail/issue-3907.rs
+++ b/src/test/compile-fail/issue-3907.rs
@@ -17,7 +17,7 @@ struct S {
     name: int
 }
 
-impl Foo for S { //~ ERROR: Foo is not a trait
+impl Foo for S { //~ ERROR: `Foo` is not a trait
     fn bar() { }
 }
 


### PR DESCRIPTION
Not all of those messages are covered by tests. I am not sure how to trigger them and where to put those tests.

Also some message patterns in the existing tests are not complete.
For example, i find `error: mismatched types: expected "i32" but found "char" (expected i32 but found char)` a bit repetitive, but as i can see there is no test covering that.
