### PR TITLE
Minor clean up to a pile of unsafe code.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -65,7 +65,7 @@ DEPS_rustc := syntax native:rustllvm flate arena serialize sync getopts \
               collections time extra
 DEPS_rustdoc := rustc native:sundown serialize sync getopts collections \
                 test time
-DEPS_flate := std native:miniz
+DEPS_flate := std extra native:miniz
 DEPS_arena := std collections
 DEPS_glob := std
 DEPS_serialize := std

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -167,13 +167,12 @@ unsafe fn destroy_chunk(chunk: &Chunk) {
 // is necessary in order to properly do cleanup if a failure occurs
 // during an initializer.
 #[inline]
-unsafe fn bitpack_tydesc_ptr(p: *TyDesc, is_done: bool) -> uint {
-    let p_bits: uint = transmute(p);
-    p_bits | (is_done as uint)
+fn bitpack_tydesc_ptr(p: *TyDesc, is_done: bool) -> uint {
+    p as uint | (is_done as uint)
 }
 #[inline]
-unsafe fn un_bitpack_tydesc_ptr(p: uint) -> (*TyDesc, bool) {
-    (transmute(p & !1), p & 1 == 1)
+fn un_bitpack_tydesc_ptr(p: uint) -> (*TyDesc, bool) {
+    ((p & !1) as *TyDesc, p & 1 == 1)
 }
 
 impl Arena {

--- a/src/libextra/c_vec.rs
+++ b/src/libextra/c_vec.rs
@@ -35,7 +35,9 @@
  * if necessary.
  */
 
+use std::cast;
 use std::ptr;
+use std::raw;
 
 /**
  * The type representing a foreign chunk of memory
@@ -108,6 +110,20 @@ impl <T> CVec<T> {
             base: base,
             len: len,
             rsrc: DtorRes::new(Some(dtor))
+        }
+    }
+
+    /// View the stored data as a slice.
+    pub fn as_slice<'a>(&'a self) -> &'a [T] {
+        unsafe {
+            cast::transmute(raw::Slice { data: self.base as *T, len: self.len })
+        }
+    }
+
+    /// View the stored data as a mutable slice.
+    pub fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
+        unsafe {
+            cast::transmute(raw::Slice { data: self.base as *T, len: self.len })
         }
     }
 

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 use std::uint;
-use std::cast::{transmute, transmute_mut_unsafe,
-                transmute_region, transmute_mut_region};
+use std::cast::{transmute, transmute_mut_unsafe};
 use stack::Stack;
 use std::rt::stack;
 use std::raw;
@@ -55,10 +54,6 @@ impl Context {
         // Save and then immediately load the current context,
         // which we will then modify to call the given function when restored
         let mut regs = new_regs();
-        unsafe {
-            rust_swap_registers(transmute_mut_region(&mut *regs),
-                                transmute_region(&*regs));
-        };
 
         initialize_call_frame(&mut *regs,
                               init,

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -289,11 +289,8 @@ fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,
 }
 
 fn align_down(sp: *mut uint) -> *mut uint {
-    unsafe {
-        let sp: uint = transmute(sp);
-        let sp = sp & !(16 - 1);
-        transmute::<uint, *mut uint>(sp)
-    }
+    let sp = (sp as uint) & !(16 - 1);
+    sp as *mut uint
 }
 
 // ptr::mut_offset is positive ints only

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -266,7 +266,7 @@ impl GreenTask {
     // context switches
 
     pub fn as_uint(&self) -> uint {
-        unsafe { cast::transmute(self) }
+        self as *GreenTask as uint
     }
 
     pub unsafe fn from_uint(val: uint) -> ~GreenTask { cast::transmute(val) }

--- a/src/libnative/io/file.rs
+++ b/src/libnative/io/file.rs
@@ -91,7 +91,7 @@ impl FileDesc {
         #[cfg(not(windows))] type rlen = libc::size_t;
         let ret = retry(|| unsafe {
             libc::read(self.fd(),
-                       buf.as_ptr() as *mut libc::c_void,
+                       buf.as_mut_ptr() as *mut libc::c_void,
                        buf.len() as rlen) as libc::c_int
         });
         if ret == 0 {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -309,7 +309,7 @@ impl rtio::RtioTcpStream for TcpStream {
         let ret = retry(|| {
             unsafe {
                 libc::recv(self.fd(),
-                           buf.as_ptr() as *mut libc::c_void,
+                           buf.as_mut_ptr() as *mut libc::c_void,
                            buf.len() as wrlen,
                            0) as libc::c_int
             }

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -186,7 +186,7 @@ impl rt::Runtime for Ops {
         cur_task.put_runtime(self as ~rt::Runtime);
 
         unsafe {
-            let cur_task_dupe = *cast::transmute::<&~Task, &uint>(&cur_task);
+            let cur_task_dupe = &*cur_task as *Task;
             let task = BlockedTask::block(cur_task);
 
             if times == 1 {
@@ -218,7 +218,7 @@ impl rt::Runtime for Ops {
                 }
             }
             // re-acquire ownership of the task
-            cur_task = cast::transmute::<uint, ~Task>(cur_task_dupe);
+            cur_task = cast::transmute(cur_task_dupe);
         }
 
         // put the task back in TLS, and everything is as it once was.

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -944,7 +944,7 @@ fn link_rlib(sess: Session,
             // into the archive.
             let bc = obj_filename.with_extension("bc");
             match fs::File::open(&bc).read_to_end().and_then(|data| {
-                fs::File::create(&bc).write(flate::deflate_bytes(data))
+                fs::File::create(&bc).write(flate::deflate_bytes(data).as_slice())
             }) {
                 Ok(()) => {}
                 Err(e) => {

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -58,7 +58,7 @@ pub fn run(sess: session::Session, llmod: ModuleRef,
         let bc = bc.expect("missing bytecode in archive!");
         let bc = time(sess.time_passes(), format!("inflate {}.bc", name), (), |_|
                       flate::inflate_bytes(bc));
-        let ptr = bc.as_ptr();
+        let ptr = bc.as_slice().as_ptr();
         debug!("linking {}", name);
         time(sess.time_passes(), format!("ll link {}", name), (), |()| unsafe {
             if !llvm::LLVMRustLinkInExternalBitcode(llmod,

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -18,6 +18,7 @@ use metadata::loader;
 
 use std::cell::RefCell;
 use collections::HashMap;
+use extra::c_vec::CVec;
 use syntax::ast;
 use syntax::parse::token::IdentInterner;
 
@@ -28,7 +29,7 @@ use syntax::parse::token::IdentInterner;
 pub type cnum_map = @RefCell<HashMap<ast::CrateNum, ast::CrateNum>>;
 
 pub enum MetadataBlob {
-    MetadataVec(~[u8]),
+    MetadataVec(CVec<u8>),
     MetadataArchive(loader::ArchiveMetadata),
 }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2569,7 +2569,7 @@ pub fn write_metadata(cx: &CrateContext, krate: &ast::Crate) -> ~[u8] {
     let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
     let metadata = encoder::encode_metadata(encode_parms, krate);
     let compressed = encoder::metadata_encoding_version +
-                        flate::deflate_bytes(metadata);
+                        flate::deflate_bytes(metadata).as_slice();
     let llmeta = C_bytes(compressed);
     let llconst = C_struct([llmeta], false);
     let name = format!("rust_metadata_{}_{}_{}", cx.link_meta.crateid.name,

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -123,7 +123,7 @@ impl QueuePool {
         unsafe {
             assert_eq!(uvll::uv_async_init(loop_.handle, handle, async_cb), 0);
             uvll::uv_unref(handle);
-            let data: *c_void = *cast::transmute::<&~QueuePool, &*c_void>(&q);
+            let data = &*q as *QueuePool as *c_void;
             uvll::set_data_for_uv_handle(handle, data);
         }
 

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -161,9 +161,7 @@ pub mod reader {
         ];
 
         unsafe {
-            let (ptr, _): (*u8, uint) = transmute(data);
-            let ptr = ptr.offset(start as int);
-            let ptr: *i32 = transmute(ptr);
+            let ptr = data.as_ptr().offset(start as int) as *i32;
             let val = from_be32(*ptr) as u32;
 
             let i = (val >> 28u) as uint;

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -351,10 +351,8 @@ impl Float for f32 {
         static EXP_MASK: u32 = 0x7f800000;
         static MAN_MASK: u32 = 0x007fffff;
 
-        match (
-            unsafe { ::cast::transmute::<f32,u32>(*self) } & MAN_MASK,
-            unsafe { ::cast::transmute::<f32,u32>(*self) } & EXP_MASK,
-        ) {
+        let bits: u32 = unsafe {::cast::transmute(*self)};
+        match (bits & MAN_MASK, bits & EXP_MASK) {
             (0, 0)        => FPZero,
             (_, 0)        => FPSubnormal,
             (0, EXP_MASK) => FPInfinite,

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -353,10 +353,8 @@ impl Float for f64 {
         static EXP_MASK: u64 = 0x7ff0000000000000;
         static MAN_MASK: u64 = 0x000fffffffffffff;
 
-        match (
-            unsafe { ::cast::transmute::<f64,u64>(*self) } & MAN_MASK,
-            unsafe { ::cast::transmute::<f64,u64>(*self) } & EXP_MASK,
-        ) {
+        let bits: u64 = unsafe {::cast::transmute(*self)};
+        match (bits & MAN_MASK, bits & EXP_MASK) {
             (0, 0)        => FPZero,
             (_, 0)        => FPSubnormal,
             (0, EXP_MASK) => FPInfinite,


### PR DESCRIPTION
Commits for details. Highlights:
- `flate` returns `CVec<u8>` to save reallocating a whole new `&[u8]`
- a lot of `transmute`s removed outright or replaced with `as` (etc.)
