### PR TITLE
Reduce the size of a rust install slightly

### DIFF
--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -16,7 +16,7 @@
 #
 # It requires the following variables to be set:
 #
-#   PREPARE_HOST - the host triple 
+#   PREPARE_HOST - the host triple
 #   PREPARE_TARGETS - the target triples, space separated
 #   PREPARE_DEST_DIR - the directory to put the image
 
@@ -172,7 +172,10 @@ prepare-target-$(2)-host-$(3)-$(1): \
         $$(if $$(findstring $(2),$$(CFG_HOST)), \
           $$(foreach crate,$$(HOST_CRATES), \
             $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(crate)),)
-# Only install if this host and target combo is being prepared
+# Only install if this host and target combo is being prepared. Also be sure to
+# *not* install the rlibs for host crates because there's no need to statically
+# link against most of them. They just produce a large amount of extra size
+# bloat.
 	$$(if $$(findstring $(1), $$(PREPARE_STAGE)),\
       $$(if $$(findstring $(2), $$(PREPARE_TARGETS)),\
         $$(if $$(findstring $(3), $$(PREPARE_HOST)),\
@@ -182,8 +185,7 @@ prepare-target-$(2)-host-$(3)-$(1): \
             $$(call PREPARE_LIB,$$(call CFG_RLIB_GLOB,$$(crate))))\
           $$(if $$(findstring $(2),$$(CFG_HOST)),\
             $$(foreach crate,$$(HOST_CRATES),\
-              $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$(2),$$(crate)))\
-              $$(call PREPARE_LIB,$$(call CFG_RLIB_GLOB,$$(crate)))),)\
+              $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$(2),$$(crate)))),)\
           $$(call PREPARE_LIB,libmorestack.a) \
           $$(call PREPARE_LIB,libcompiler-rt.a),),),)
 endef

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -16,6 +16,7 @@ use metadata::cstore;
 use util::common::time;
 
 use std::libc;
+use flate;
 
 pub fn run(sess: session::Session, llmod: ModuleRef,
            tm: TargetMachineRef, reachable: &[~str]) {
@@ -55,6 +56,8 @@ pub fn run(sess: session::Session, llmod: ModuleRef,
         let bc = time(sess.time_passes(), format!("read {}.bc", name), (), |_|
                       archive.read(format!("{}.bc", name)));
         let bc = bc.expect("missing bytecode in archive!");
+        let bc = time(sess.time_passes(), format!("inflate {}.bc", name), (), |_|
+                      flate::inflate_bytes(bc));
         let ptr = bc.as_ptr();
         debug!("linking {}", name);
         time(sess.time_passes(), format!("ll link {}", name), (), |()| unsafe {


### PR DESCRIPTION
Two optimizations:
1. Compress `foo.bc` in each rlib with `flate`. These are just taking up space and are only used with LTO, no need for LTO to be speedy.
2. Stop install `librustc.rlib` and friends, this is a _huge_ source of bloat. There's no need for us to install static libraries for these components.

cc #12440
