### PR TITLE
test: 'ratcher' is not a word

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -608,7 +608,7 @@ impl<T: Writer> ConsoleTestState<T> {
         let ratchet_success = match *ratchet_metrics {
             None => true,
             Some(ref pth) => {
-                try!(self.write_plain(format!("\nusing metrics ratcher: {}\n",
+                try!(self.write_plain(format!("\nusing metrics ratchet: {}\n",
                                         pth.display())));
                 match ratchet_pct {
                     None => (),


### PR DESCRIPTION
I've watched this message roll by a hundred times and only thought, "I wonder what a 'ratcher' is". Turns out it's nothing.
