### PR TITLE
mk: restore check-notidy.

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -171,7 +171,9 @@ endif
 # Main test targets
 ######################################################################
 
-check: cleantestlibs cleantmptestlogs tidy all check-stage2
+check: cleantmptestlogs cleantestlibs tidy check-notidy
+
+check-notidy: cleantmptestlogs cleantestlibs all check-stage2
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
 check-lite: cleantestlibs cleantmptestlogs \


### PR DESCRIPTION
tidy has some limitations (e.g. the "checked in binaries" check doesn't
and can't actually check git), and so it's useful to run tests without
running tidy occasionally.
