### PR TITLE
rustc: Don't error on the rlib symlinks

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -67,6 +67,18 @@ pub struct ArchiveMetadata {
     priv data: &'static [u8],
 }
 
+// FIXME(#11857) this should be a "real" realpath
+fn realpath(p: &Path) -> Path {
+    use std::os;
+    use std::io::fs;
+
+    let path = os::make_absolute(p);
+    match fs::readlink(&path) {
+        Ok(p) => p,
+        Err(..) => path
+    }
+}
+
 impl Context {
     pub fn load_library_crate(&self, root_ident: Option<~str>) -> Library {
         match self.find_library_crate() {
@@ -121,7 +133,7 @@ impl Context {
                             (HashSet::new(), HashSet::new())
                         });
                         let (ref mut rlibs, _) = *slot;
-                        rlibs.insert(path.clone());
+                        rlibs.insert(realpath(path));
                         FileMatches
                     }
                     None => {
@@ -138,7 +150,7 @@ impl Context {
                             (HashSet::new(), HashSet::new())
                         });
                         let (_, ref mut dylibs) = *slot;
-                        dylibs.insert(path.clone());
+                        dylibs.insert(realpath(path));
                         FileMatches
                     }
                     None => {

--- a/src/test/run-make/symlinked-libraries/Makefile
+++ b/src/test/run-make/symlinked-libraries/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	mkdir -p $(TMPDIR)/other
+	ln -nsf $(TMPDIR)/$(call DYLIB_GLOB,foo) $(TMPDIR)/other
+	$(RUSTC) bar.rs -L $(TMPDIR)/other

--- a/src/test/run-make/symlinked-libraries/bar.rs
+++ b/src/test/run-make/symlinked-libraries/bar.rs
@@ -1,0 +1,15 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;
+
+fn main() {
+    foo::bar();
+}

--- a/src/test/run-make/symlinked-libraries/foo.rs
+++ b/src/test/run-make/symlinked-libraries/foo.rs
@@ -1,0 +1,13 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type = "dylib"];
+
+pub fn bar() {}


### PR DESCRIPTION
This commit implements a layman's version of realpath() for metadata::loader to
use in order to not error on symlinks pointing to the same file.

Closes #12459
