### PR TITLE
std: mark two helper functions #[inline].

### DIFF
--- a/src/libstd/char.rs
+++ b/src/libstd/char.rs
@@ -69,6 +69,7 @@ static TAG_FOUR_B: uint = 240u;
 pub static MAX: char = '\U0010ffff';
 
 /// Convert from `u32` to a character.
+#[inline]
 pub fn from_u32(i: u32) -> Option<char> {
     // catch out-of-bounds and surrogates
     if (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF) {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1061,6 +1061,7 @@ static UTF8_CHAR_WIDTH: [u8, ..256] = [
 ];
 
 /// Given a first byte, determine how many bytes are in this UTF-8 character
+#[inline]
 pub fn utf8_char_width(b: u8) -> uint {
     return UTF8_CHAR_WIDTH[b] as uint;
 }


### PR DESCRIPTION
`str::utf8_char_width` and `char::from_u32` are tiny, which means it's a
big performance hit to call them in a tight loop outside libstd.
