### PR TITLE
Remove some non-essential trait re-exports from the prelude.

### DIFF
--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -53,6 +53,7 @@
 //! ```
 
 use std::cmp::max;
+use std::default::Default;
 use std::fmt;
 use std::hash::{Hash, Hasher, sip};
 use std::iter::{FilterMap, Chain, Repeat, Zip};

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -16,6 +16,7 @@ use std::cmp::Eq;
 use std::fmt;
 use std::hash::{Hash, sip};
 use std::io::BufReader;
+use std::from_str::FromStr;
 use std::uint;
 
 use collections::HashMap;

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -20,6 +20,7 @@ use Integer;
 
 use std::cmp;
 use std::fmt;
+use std::from_str::FromStr;
 use std::num::{Bitwise, ToPrimitive, FromPrimitive};
 use std::num::{Zero, One, ToStrRadix, FromStrRadix};
 use std::rand::Rng;
@@ -1397,6 +1398,7 @@ mod biguint_tests {
     use super::{Plus, BigInt, RandBigInt, ToBigInt};
 
     use std::cmp::{Less, Equal, Greater};
+    use std::from_str::FromStr;
     use std::i64;
     use std::num::{Zero, One, FromStrRadix};
     use std::num::{ToPrimitive, FromPrimitive};

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -1400,7 +1400,7 @@ mod biguint_tests {
     use std::cmp::{Less, Equal, Greater};
     use std::from_str::FromStr;
     use std::i64;
-    use std::num::{Zero, One, FromStrRadix};
+    use std::num::{Zero, One, FromStrRadix, ToStrRadix};
     use std::num::{ToPrimitive, FromPrimitive};
     use std::rand::{task_rng};
     use std::str;
@@ -2058,7 +2058,7 @@ mod bigint_tests {
 
     use std::cmp::{Less, Equal, Greater};
     use std::i64;
-    use std::num::{Zero, One, FromStrRadix};
+    use std::num::{Zero, One, FromStrRadix, ToStrRadix};
     use std::num::{ToPrimitive, FromPrimitive};
     use std::rand::{task_rng};
     use std::u64;

--- a/src/libnum/rational.rs
+++ b/src/libnum/rational.rs
@@ -333,7 +333,7 @@ impl<T: FromStrRadix + Clone + Integer + Ord>
 mod test {
 
     use super::{Ratio, Rational, BigRational};
-    use std::num::{Zero,One,FromStrRadix,FromPrimitive};
+    use std::num::{Zero, One, FromStrRadix, FromPrimitive, ToStrRadix};
     use std::from_str::FromStr;
 
     pub static _0 : Rational = Ratio { numer: 0, denom: 1};

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -295,6 +295,7 @@ impl Default for bool {
 mod tests {
     use prelude::*;
     use super::all_values;
+    use from_str::FromStr;
 
     #[test]
     fn test_bool() {

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -340,6 +340,7 @@ impl FromStr for SocketAddr {
 mod test {
     use prelude::*;
     use super::*;
+    use from_str::FromStr;
 
     #[test]
     fn test_from_str_ipv4() {

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -15,6 +15,7 @@ use prelude::*;
 
 use cmath;
 use default::Default;
+use from_str::FromStr;
 use libc::{c_float, c_int};
 use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
 use num::{Zero, One, Bounded, strconv};

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -16,6 +16,7 @@ use prelude::*;
 
 use cmath;
 use default::Default;
+use from_str::FromStr;
 use libc::{c_double, c_int};
 use num::{FPCategory, FPNaN, FPInfinite , FPZero, FPSubnormal, FPNormal};
 use num::{Zero, One, Bounded, strconv};

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded, CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};
 use num::{ToStrRadix, FromStrRadix};

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded, CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};
 use num::{ToStrRadix, FromStrRadix};

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 #[cfg(target_word_size = "64")]
 use num::CheckedMul;
 use num::{Bitwise, Bounded, CheckedAdd, CheckedSub};

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded, CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};
 use num::{ToStrRadix, FromStrRadix};

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded, CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};
 use num::{ToStrRadix, FromStrRadix};

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -295,8 +295,9 @@ mod tests {
     use int;
     use i32;
     use num;
-    use num::CheckedDiv;
     use num::Bitwise;
+    use num::CheckedDiv;
+    use num::ToStrRadix;
 
     #[test]
     fn test_overflows() {

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded};
 use num::{CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded};
 use num::{CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded};
 #[cfg(target_word_size = "64")]
 use num::CheckedMul;

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded};
 use num::{CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -15,6 +15,7 @@
 use prelude::*;
 
 use default::Default;
+use from_str::FromStr;
 use num::{Bitwise, Bounded};
 use num::{CheckedAdd, CheckedSub, CheckedMul};
 use num::{CheckedDiv, Zero, One, strconv};

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -233,6 +233,7 @@ mod tests {
     use num;
     use num::CheckedDiv;
     use num::Bitwise;
+    use num::ToStrRadix;
     use u16;
 
     #[test]

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -43,7 +43,6 @@ pub use char::Char;
 pub use clone::{Clone, DeepClone};
 pub use cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
 pub use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
-pub use default::Default;
 pub use from_str::FromStr;
 pub use iter::{FromIterator, Extendable};
 pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIterator};

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -48,7 +48,7 @@ pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIte
 pub use iter::{OrdIterator, MutableDoubleEndedIterator, ExactSize};
 pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};
 pub use num::{Signed, Unsigned, Round};
-pub use num::{Primitive, Int, Float, ToStrRadix, ToPrimitive, FromPrimitive};
+pub use num::{Primitive, Int, Float, ToPrimitive, FromPrimitive};
 pub use path::{GenericPath, Path, PosixPath, WindowsPath};
 pub use ptr::RawPtr;
 pub use io::{Buffer, Writer, Reader, Seek};

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -43,7 +43,6 @@ pub use char::Char;
 pub use clone::{Clone, DeepClone};
 pub use cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
 pub use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
-pub use from_str::FromStr;
 pub use iter::{FromIterator, Extendable};
 pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIterator};
 pub use iter::{OrdIterator, MutableDoubleEndedIterator, ExactSize};

--- a/src/libstd/rand/reseeding.rs
+++ b/src/libstd/rand/reseeding.rs
@@ -144,6 +144,7 @@ impl Default for ReseedWithDefault {
 mod test {
     use prelude::*;
     use super::*;
+    use default::Default;
     use rand::{SeedableRng, Rng};
 
     struct Counter {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -3072,6 +3072,7 @@ impl Default for ~str {
 #[cfg(test)]
 mod tests {
     use iter::AdditiveIterator;
+    use default::Default;
     use prelude::*;
     use str::*;
 

--- a/src/libsyntax/crateid.rs
+++ b/src/libsyntax/crateid.rs
@@ -17,6 +17,9 @@ use std::fmt;
 /// `1.0`. If no crate name is given after the hash, the name is inferred to
 /// be the last component of the path. If no version is given, it is inferred
 /// to be `0.0`.
+
+use std::from_str::FromStr;
+
 #[deriving(Clone, Eq)]
 pub struct CrateId {
     /// A path which represents the codes origin. By convention this is the

--- a/src/libsyntax/opt_vec.rs
+++ b/src/libsyntax/opt_vec.rs
@@ -16,6 +16,7 @@
  */
 
 use std::vec;
+use std::default::Default;
 
 #[deriving(Clone, Encodable, Decodable, Hash)]
 pub enum OptVec<T> {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -42,6 +42,7 @@ use term::color::{Color, RED, YELLOW, GREEN, CYAN};
 use std::cmp;
 use std::f64;
 use std::fmt;
+use std::from_str::FromStr;
 use std::io::stdio::StdWriter;
 use std::io::{File, PortReader, ChanWriter};
 use std::io;

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -66,6 +66,7 @@ extern crate serialize;
 
 use std::cast::{transmute,transmute_copy};
 use std::char::Char;
+use std::default::Default;
 use std::fmt;
 use std::hash::{Hash, sip};
 use std::num::FromStrRadix;

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -68,6 +68,7 @@ use std::cast::{transmute,transmute_copy};
 use std::char::Char;
 use std::default::Default;
 use std::fmt;
+use std::from_str::FromStr;
 use std::hash::{Hash, sip};
 use std::num::FromStrRadix;
 use std::rand::Rng;

--- a/src/test/bench/shootout-threadring.rs
+++ b/src/test/bench/shootout-threadring.rs
@@ -55,6 +55,8 @@ fn roundtrip(id: int, n_tasks: int, p: &Port<int>, ch: &Chan<int>) {
 }
 
 fn main() {
+    use std::from_str::FromStr;
+
     let args = if os::getenv("RUST_BENCH").is_some() {
         ~[~"", ~"2000000", ~"503"]
     }


### PR DESCRIPTION
`Default` only contains a static method. It provides no extension methods that are commonly used in client code.

`FromStr` already has its only static method, `from_str`, re-exported in the prelude. Implementing the trait itself is less common.

`ToStrRadix` is being phased out in favor of using `std::fmt::radix`, and the `to_str_radix` method is rather specialised to warrant a global re-export.

r? @brson 
