### PR TITLE
Mark by-value parameters that are passed on the stack as nocapture

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -282,6 +282,7 @@ pub fn decl_rust_fn(ccx: &CrateContext, has_env: bool,
                 if !type_is_immediate(ccx, arg_ty) {
                     unsafe {
                         llvm::LLVMAddAttribute(llarg, lib::llvm::NoAliasAttribute as c_uint);
+                        llvm::LLVMAddAttribute(llarg, lib::llvm::NoCaptureAttribute as c_uint);
                     }
                 }
             }


### PR DESCRIPTION
The by-value argument is a copy that is only valid for the duration of
the function call, therefore keeping any pointer to it that outlives the
call is illegal.
