### PR TITLE
use libnative for rustc and rustdoc binaries.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -81,8 +81,8 @@ DEPS_test := std extra collections getopts serialize term
 DEPS_time := std serialize
 
 TOOL_DEPS_compiletest := test green rustuv getopts
-TOOL_DEPS_rustdoc := rustdoc green rustuv
-TOOL_DEPS_rustc := rustc green rustuv
+TOOL_DEPS_rustdoc := rustdoc native
+TOOL_DEPS_rustc := rustc native
 TOOL_SOURCE_compiletest := $(S)src/compiletest/compiletest.rs
 TOOL_SOURCE_rustdoc := $(S)src/driver/driver.rs
 TOOL_SOURCE_rustc := $(S)src/driver/driver.rs

--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -8,10 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[no_uv];
+
+// These tools have no real use for libgreen/libuv (not much IO/task
+// spawning).
+extern crate native;
+
 #[cfg(rustdoc)]
 extern crate this = "rustdoc";
 
 #[cfg(rustc)]
 extern crate this = "rustc";
 
-fn main() { this::main() }
+#[start]
+fn start(argc: int, argv: **u8) -> int {
+    native::start(argc, argv, this::main)
+}

--- a/src/test/compile-fail/issue-5806.rs
+++ b/src/test/compile-fail/issue-5806.rs
@@ -19,6 +19,6 @@
 // except according to those terms.
 
 #[path = "../compile-fail"]
-mod foo; //~ ERROR: illegal operation on a directory
+mod foo; //~ ERROR: directory
 
 fn main() {}


### PR DESCRIPTION
libuv is buggy and causes issues when (e.g.) running with stdin being a
pipe, and the compiler doesn't spawn many tasks at all, so the
advantages of libgreen aren't helpful. Hence, libnative is more reliable
and perfectly sufficient.
