### PR TITLE
syntax: allow stmt/expr macro invocations to be delimited by {}.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3184,15 +3184,35 @@ impl Parser {
             let pth = self.parse_path(NoTypesAllowed).path;
             self.bump();
 
-            let id = if self.token == token::LPAREN {
+            let id = if self.token == token::LPAREN || self.token == token::LBRACE {
                 token::special_idents::invalid // no special identifier
             } else {
                 self.parse_ident()
             };
 
+            // check that we're pointing at delimiters (need to check
+            // again after the `if`, because of `parse_ident`
+            // consuming more tokens).
+            let (bra, ket) = match self.token {
+                token::LPAREN => (token::LPAREN, token::RPAREN),
+                token::LBRACE => (token::LBRACE, token::RBRACE),
+                _ => {
+                    // we only expect an ident if we didn't parse one
+                    // above.
+                    let ident_str = if id == token::special_idents::invalid {
+                        "identifier, "
+                    } else {
+                        ""
+                    };
+                    let tok_str = self.this_token_to_str();
+                    self.fatal(format!("expected {}`(` or `\\{`, but found `{}`",
+                                       ident_str, tok_str))
+                }
+            };
+
             let tts = self.parse_unspanned_seq(
-                &token::LPAREN,
-                &token::RPAREN,
+                &bra,
+                &ket,
                 seq_sep_none(),
                 |p| p.parse_token_tree()
             );

--- a/src/test/compile-fail/macro-bad-delimiter-ident.rs
+++ b/src/test/compile-fail/macro-bad-delimiter-ident.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    foo! bar < //~ ERROR expected `(` or `{`, but found `<`
+}

--- a/src/test/compile-fail/macro-mismatched-delim-brace-paren.rs
+++ b/src/test/compile-fail/macro-mismatched-delim-brace-paren.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    foo! {
+        bar, "baz", 1, 2.0
+    ) //~ ERROR incorrect close delimiter
+}

--- a/src/test/compile-fail/macro-mismatched-delim-paren-brace.rs
+++ b/src/test/compile-fail/macro-mismatched-delim-paren-brace.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    foo! (
+        bar, "baz", 1, 2.0
+    } //~ ERROR incorrect close delimiter
+}

--- a/src/test/run-pass/macro-with-braces-in-expr-position.rs
+++ b/src/test/run-pass/macro-with-braces-in-expr-position.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(macro_rules)];
+
+macro_rules! expr (($e: expr) => { $e })
+
+macro_rules! spawn {
+    ($($code: tt)*) => {
+        expr!(spawn(proc() {$($code)*}))
+    }
+}
+
+pub fn main() {
+    spawn! {
+        info!("stmt");
+    };
+    let _ = spawn! {
+        info!("expr");
+    };
+}


### PR DESCRIPTION
This makes using control-flow-y macros like `spawn! { ... }` more fluent
and natural.

cc #11892.
