### PR TITLE
Fix C function FFI example in the Rust cheatsheet

### DIFF
--- a/src/doc/complement-cheatsheet.md
+++ b/src/doc/complement-cheatsheet.md
@@ -211,7 +211,7 @@ Description            C signature                                    Equivalent
 ---------------------- ---------------------------------------------- ------------------------------------------
 no parameters          `void foo(void);`                              `fn foo();`
 return value           `int foo(void);`                               `fn foo() -> c_int;`
-function parameters    `void foo(int x, int y);`                      `fn foo(x: int, y: int);`
+function parameters    `void foo(int x, int y);`                      `fn foo(x: c_int, y: c_int);`
 in-out pointers        `void foo(const int* in_ptr, int* out_ptr);`   `fn foo(in_ptr: *c_int, out_ptr: *mut c_int);`
 
 Note: The Rust signatures should be wrapped in an `extern "ABI" { ... }` block.


### PR DESCRIPTION
Fix C function FFI example in the Rust cheatsheet

It incorrectly used `int` (Rust type) for `int` (C type) where it should have been `c_int` (Rust).
