### PR TITLE
std: Tweak stack overflow printing for robustness

### DIFF
--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -1,0 +1,50 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-fast
+
+#[feature(asm)];
+
+use std::io::Process;
+use std::os;
+use std::str;
+
+// lifted from the test module
+pub fn black_box<T>(dummy: T) { unsafe { asm!("" : : "r"(&dummy)) } }
+
+fn silent_recurse() {
+    let buf = [0, ..1000];
+    black_box(buf);
+    silent_recurse();
+}
+
+fn loud_recurse() {
+    println!("hello!");
+    loud_recurse();
+}
+
+fn main() {
+    let args = os::args();
+    if args.len() > 1 && args[1].as_slice() == "silent" {
+        silent_recurse();
+    } else if args.len() > 1 && args[1].as_slice() == "loud" {
+        loud_recurse();
+    } else {
+        let silent = Process::output(args[0], [~"silent"]).unwrap();
+        assert!(!silent.status.success());
+        let error = str::from_utf8_lossy(silent.error);
+        assert!(error.as_slice().contains("has overflowed its stack"));
+
+        let loud = Process::output(args[0], [~"loud"]).unwrap();
+        assert!(!loud.status.success());
+        let error = str::from_utf8_lossy(silent.error);
+        assert!(error.as_slice().contains("has overflowed its stack"));
+    }
+}


### PR DESCRIPTION
The printing of the error message on stack overflow had two sometimes false
assumptions previously. The first is that a local task was always available (it
called Local::take) and the second is that it used `println!` instead of
manually writing.

The first assumption isn't necessarily true because while stack overflow will
likely only be detected in situations that a local task is available, it's not
guaranteed to always be in TLS. For example, during a `println!` call a task
may be blocking, causing it to be unavailable. By using Local::try_take(), we
can be resilient against these occurrences.

The second assumption could lead to odd behavior because the stdout logger can
be overwritten to run arbitrary code. Currently this should be possible, but the
utility is much diminished because a stack overflow translates to an abort()
instead of a failure.
