### PR TITLE
Update rustc/syntax docs now that rustdoc lexes all non-`notrust` code blocks.

### DIFF
--- a/src/librustc/middle/typeck/infer/doc.rs
+++ b/src/librustc/middle/typeck/infer/doc.rs
@@ -45,11 +45,13 @@ There are several critical invariants which we maintain:
 > types lie in between.  The bottom type is then the Null type.
 > So the tree looks like:
 >
->             Object
->             /    \
->         String   Other
->             \    /
->             (null)
+> ```notrust
+>         Object
+>         /    \
+>     String   Other
+>         \    /
+>         (null)
+> ```
 >
 > So the upper bound type is the "supertype" and the lower bound is the
 > "subtype" (also, super and sub mean upper and lower in Latin, or something
@@ -104,18 +106,20 @@ Pictorally, what this does is to take two distinct variables with
 (hopefully not completely) distinct type ranges and produce one with
 the intersection.
 
-                      B.ub                  B.ub
-                       /\                    /
-               A.ub   /  \           A.ub   /
-               /   \ /    \              \ /
-              /     X      \              UB
-             /     / \      \            / \
-            /     /   /      \          /   /
-            \     \  /       /          \  /
-             \      X       /             LB
-              \    / \     /             / \
-               \  /   \   /             /   \
-               A.lb    B.lb          A.lb    B.lb
+```notrust
+                  B.ub                  B.ub
+                   /\                    /
+           A.ub   /  \           A.ub   /
+           /   \ /    \              \ /
+          /     X      \              UB
+         /     / \      \            / \
+        /     /   /      \          /   /
+        \     \  /       /          \  /
+         \      X       /             LB
+          \    / \     /             / \
+           \  /   \   /             /   \
+           A.lb    B.lb          A.lb    B.lb
+```
 
 
 ### Option 2: Relate UB/LB
@@ -125,20 +129,22 @@ bounds in such a way that, whatever happens, we know that A <: B will hold.
 This can be achieved by ensuring that A.ub <: B.lb.  In practice there
 are two ways to do that, depicted pictorally here:
 
-        Before                Option #1            Option #2
+```notrust
+    Before                Option #1            Option #2
 
-                 B.ub                B.ub                B.ub
-                  /\                 /  \                /  \
-          A.ub   /  \        A.ub   /(B')\       A.ub   /(B')\
-          /   \ /    \           \ /     /           \ /     /
-         /     X      \         __UB____/             UB    /
-        /     / \      \       /  |                   |    /
-       /     /   /      \     /   |                   |   /
-       \     \  /       /    /(A')|                   |  /
-        \      X       /    /     LB            ______LB/
-         \    / \     /    /     / \           / (A')/ \
-          \  /   \   /     \    /   \          \    /   \
-          A.lb    B.lb       A.lb    B.lb        A.lb    B.lb
+             B.ub                B.ub                B.ub
+              /\                 /  \                /  \
+      A.ub   /  \        A.ub   /(B')\       A.ub   /(B')\
+      /   \ /    \           \ /     /           \ /     /
+     /     X      \         __UB____/             UB    /
+    /     / \      \       /  |                   |    /
+   /     /   /      \     /   |                   |   /
+   \     \  /       /    /(A')|                   |  /
+    \      X       /    /     LB            ______LB/
+     \    / \     /    /     / \           / (A')/ \
+      \  /   \   /     \    /   \          \    /   \
+      A.lb    B.lb       A.lb    B.lb        A.lb    B.lb
+```
 
 In these diagrams, UB and LB are defined as before.  As you can see,
 the new ranges `A'` and `B'` are quite different from the range that
@@ -158,13 +164,15 @@ course, it depends on the program.
 
 The main case which fails today that I would like to support is:
 
-    fn foo<T>(x: T, y: T) { ... }
+```notrust
+fn foo<T>(x: T, y: T) { ... }
 
-    fn bar() {
-        let x: @mut int = @mut 3;
-        let y: @int = @3;
-        foo(x, y);
-    }
+fn bar() {
+    let x: @mut int = @mut 3;
+    let y: @int = @3;
+    foo(x, y);
+}
+```
 
 In principle, the inferencer ought to find that the parameter `T` to
 `foo(x, y)` is `@const int`.  Today, however, it does not; this is

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -59,7 +59,7 @@ associated with. It is only not `None` when the associated field has
 an identifier in the source code. For example, the `x`s in the
 following snippet
 
-~~~ignore
+~~~notrust
 struct A { x : int }
 
 struct B(int);
@@ -83,7 +83,7 @@ variants, it is represented as a count of 0.
 
 The following simplified `Eq` is used for in-code examples:
 
-~~~ignore
+~~~notrust
 trait Eq {
     fn eq(&self, other: &Self);
 }
@@ -101,7 +101,7 @@ above `Eq`, `A`, `B` and `C`.
 
 When generating the `expr` for the `A` impl, the `SubstructureFields` is
 
-~~~ignore
+~~~notrust
 Struct(~[FieldInfo {
            span: <span of x>
            name: Some(<ident of x>),
@@ -112,7 +112,7 @@ Struct(~[FieldInfo {
 
 For the `B` impl, called with `B(a)` and `B(b)`,
 
-~~~ignore
+~~~notrust
 Struct(~[FieldInfo {
           span: <span of `int`>,
           name: None,
@@ -126,7 +126,7 @@ Struct(~[FieldInfo {
 When generating the `expr` for a call with `self == C0(a)` and `other
 == C0(b)`, the SubstructureFields is
 
-~~~ignore
+~~~notrust
 EnumMatching(0, <ast::Variant for C0>,
              ~[FieldInfo {
                 span: <span of int>
@@ -138,7 +138,7 @@ EnumMatching(0, <ast::Variant for C0>,
 
 For `C1 {x}` and `C1 {x}`,
 
-~~~ignore
+~~~notrust
 EnumMatching(1, <ast::Variant for C1>,
              ~[FieldInfo {
                 span: <span of x>
@@ -150,7 +150,7 @@ EnumMatching(1, <ast::Variant for C1>,
 
 For `C0(a)` and `C1 {x}` ,
 
-~~~ignore
+~~~notrust
 EnumNonMatching(~[(0, <ast::Variant for B0>,
                    ~[(<span of int>, None, <expr for &a>)]),
                   (1, <ast::Variant for B1>,
@@ -164,7 +164,7 @@ EnumNonMatching(~[(0, <ast::Variant for B0>,
 
 A static method on the above would result in,
 
-~~~~ignore
+~~~~notrust
 StaticStruct(<ast::StructDef of A>, Named(~[(<ident of x>, <span of x>)]))
 
 StaticStruct(<ast::StructDef of B>, Unnamed(~[<span of x>]))
@@ -625,7 +625,7 @@ impl<'a> MethodDef<'a> {
     }
 
     /**
-   ~~~ignore
+   ~~~
     #[deriving(Eq)]
     struct A { x: int, y: int }
 
@@ -725,7 +725,7 @@ impl<'a> MethodDef<'a> {
     }
 
     /**
-   ~~~ignore
+   ~~~
     #[deriving(Eq)]
     enum A {
         A1
@@ -768,7 +768,7 @@ impl<'a> MethodDef<'a> {
     /**
     Creates the nested matches for an enum definition recursively, i.e.
 
-   ~~~ignore
+   ~~~notrust
     match self {
        Variant1 => match other { Variant1 => matching, Variant2 => nonmatching, ... },
        Variant2 => match other { Variant1 => nonmatching, Variant2 => matching, ... },
@@ -1172,7 +1172,7 @@ pub fn cs_fold(use_foldl: bool,
 Call the method that is being derived on all the fields, and then
 process the collected results. i.e.
 
-~~~ignore
+~~~
 f(cx, span, ~[self_1.method(__arg_1_1, __arg_2_1),
               self_2.method(__arg_1_2, __arg_2_2)])
 ~~~


### PR DESCRIPTION
This includes blocks made by indentation, so they need to be changed to
explicitly have `notrust ...` fences..
