### PR TITLE
A couple cleanup patches to the new Hash framework

### DIFF
--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -97,7 +97,7 @@ fn resize_at(capacity: uint) -> uint {
     (capacity * 3) / 4
 }
 
-impl<K:Hash + Eq,V> HashMap<K, V> {
+impl<K:Hash + Eq, V> HashMap<K, V> {
     #[inline]
     fn to_bucket(&self, h: uint) -> uint {
         // A good hash function with entropy spread over all of the

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -722,7 +722,7 @@ pub fn is_null(val: ValueRef) -> bool {
 }
 
 // Used to identify cached monomorphized functions and vtables
-#[deriving(Eq,Hash)]
+#[deriving(Eq, Hash)]
 pub enum mono_param_id {
     mono_precise(ty::t, Option<@~[mono_id]>),
     mono_any,
@@ -732,7 +732,7 @@ pub enum mono_param_id {
               datum::RvalueMode),
 }
 
-#[deriving(Eq,Hash)]
+#[deriving(Eq, Hash)]
 pub enum MonoDataClass {
     MonoBits,    // Anything not treated differently from arbitrary integer data
     MonoNonNull, // Non-null pointers (used for optional-pointer optimization)
@@ -754,8 +754,7 @@ pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
     }
 }
 
-
-#[deriving(Eq,Hash)]
+#[deriving(Eq, Hash)]
 pub struct mono_id_ {
     def: ast::DefId,
     params: ~[mono_param_id]

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -150,7 +150,7 @@ pub struct field_ty {
 
 // Contains information needed to resolve types and (in the future) look up
 // the types of AST nodes.
-#[deriving(Eq,Hash)]
+#[deriving(Eq, Hash)]
 pub struct creader_cache_key {
     cnum: CrateNum,
     pos: uint,

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -18,13 +18,12 @@ use str::OwnedStr;
 use container::Container;
 use cast;
 use fmt;
-use hash::{Hash, sip};
 use iter::Iterator;
 use vec::{ImmutableVector, MutableVector, Vector};
 use option::{Option, Some, None};
 
 /// Datatype to hold one ascii character. It wraps a `u8`, with the highest bit always zero.
-#[deriving(Clone, Eq, Ord, TotalOrd, TotalEq)]
+#[deriving(Clone, Eq, Ord, TotalOrd, TotalEq, Hash)]
 pub struct Ascii { priv chr: u8 }
 
 impl Ascii {
@@ -303,13 +302,6 @@ impl IntoStr for ~[Ascii] {
     #[inline]
     fn into_str(self) -> ~str {
         unsafe { cast::transmute(self) }
-    }
-}
-
-impl Hash for Ascii {
-    #[inline]
-    fn hash(&self, s: &mut sip::SipState) {
-        self.to_byte().hash(s)
     }
 }
 

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -55,7 +55,6 @@ pub struct SocketAddr {
     port: Port,
 }
 
-
 impl fmt::Show for SocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.ip {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -149,7 +149,6 @@ pub mod container;
 pub mod default;
 pub mod any;
 
-
 /* Common data structures */
 
 pub mod option;

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::hash::{Hash, sip};
 use std::fmt;
 use std::fmt::Show;
 
 #[deriving(Eq)]
 pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, }
 
-#[deriving(Eq)]
+#[deriving(Eq, Hash)]
 pub enum Abi {
     // NB: This ordering MUST match the AbiDatas array below.
     // (This is ensured by the test indices_are_correct().)
@@ -264,12 +263,6 @@ impl AbiSet {
         }
 
         return None;
-    }
-}
-
-impl Hash for Abi {
-    fn hash(&self, s: &mut sip::SipState) {
-        self.index().hash(s)
     }
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -107,7 +107,7 @@ pub struct SCTable {
 pub static EMPTY_CTXT : SyntaxContext = 0;
 pub static ILLEGAL_CTXT : SyntaxContext = 1;
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub enum SyntaxContext_ {
     EmptyCtxt,
     Mark (Mrk,SyntaxContext),
@@ -332,7 +332,7 @@ impl Eq for MetaItem_ {
     }
 }
 
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub struct Block {
     view_items: ~[ViewItem],
     stmts: ~[@Stmt],
@@ -467,7 +467,7 @@ pub enum Stmt_ {
 // FIXME (pending discussion of #1697, #2178...): local should really be
 // a refinement on pat.
 /// Local represents a `let` statement, e.g., `let <pat>:<ty> = <expr>;`
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub struct Local {
     ty: P<Ty>,
     pat: @Pat,
@@ -478,7 +478,7 @@ pub struct Local {
 
 pub type Decl = Spanned<Decl_>;
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub enum Decl_ {
     // a local (let) binding:
     DeclLocal(@Local),
@@ -514,7 +514,7 @@ pub enum UnsafeSource {
     UserProvided,
 }
 
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub struct Expr {
     id: NodeId,
     node: Expr_,
@@ -732,7 +732,7 @@ pub struct MutTy {
     mutbl: Mutability,
 }
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub struct TypeField {
     ident: Ident,
     mt: MutTy,
@@ -836,7 +836,7 @@ impl fmt::Show for Onceness {
     }
 }
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub struct ClosureTy {
     sigil: Sigil,
     region: Option<Lifetime>,
@@ -967,7 +967,7 @@ pub enum ExplicitSelf_ {
 
 pub type ExplicitSelf = Spanned<ExplicitSelf_>;
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub struct Method {
     ident: Ident,
     attrs: ~[Attribute],
@@ -987,7 +987,7 @@ pub struct Mod {
     items: ~[@Item],
 }
 
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub struct ForeignMod {
     abis: AbiSet,
     view_items: ~[ViewItem],
@@ -1074,14 +1074,14 @@ pub type Attribute = Spanned<Attribute_>;
 // Distinguishes between Attributes that decorate items and Attributes that
 // are contained as statements within items. These two cases need to be
 // distinguished for pretty-printing.
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub enum AttrStyle {
     AttrOuter,
     AttrInner,
 }
 
 // doc-comments are promoted to attributes that have is_sugared_doc = true
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub struct Attribute_ {
     style: AttrStyle,
     value: @MetaItem,
@@ -1095,13 +1095,13 @@ pub struct Attribute_ {
   If this impl is an ItemImpl, the impl_id is redundant (it could be the
   same as the impl's node id).
  */
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub struct TraitRef {
     path: Path,
     ref_id: NodeId,
 }
 
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub enum Visibility {
     Public,
     Private,
@@ -1117,7 +1117,7 @@ impl Visibility {
     }
 }
 
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub struct StructField_ {
     kind: StructFieldKind,
     id: NodeId,
@@ -1127,13 +1127,13 @@ pub struct StructField_ {
 
 pub type StructField = Spanned<StructField_>;
 
-#[deriving(Clone, Eq, Encodable, Decodable,Hash)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash)]
 pub enum StructFieldKind {
     NamedField(Ident, Visibility),
     UnnamedField // element of a tuple-like struct
 }
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub struct StructDef {
     fields: ~[StructField], /* fields, not including ctor */
     /* ID of the constructor. This is only used for tuple- or enum-like
@@ -1173,7 +1173,7 @@ pub enum Item_ {
     ItemMac(Mac),
 }
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub struct ForeignItem {
     ident: Ident,
     attrs: ~[Attribute],
@@ -1183,7 +1183,7 @@ pub struct ForeignItem {
     vis: Visibility,
 }
 
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub enum ForeignItem_ {
     ForeignItemFn(P<FnDecl>, Generics),
     ForeignItemStatic(P<Ty>, /* is_mutbl */ bool),
@@ -1192,7 +1192,7 @@ pub enum ForeignItem_ {
 // The data we save and restore about an inlined item or method.  This is not
 // part of the AST that we parse from a file, but it becomes part of the tree
 // that we trans.
-#[deriving(Eq, Encodable, Decodable,Hash)]
+#[deriving(Eq, Encodable, Decodable, Hash)]
 pub enum InlinedItem {
     IIItem(@Item),
     IIMethod(DefId /* impl id */, bool /* is provided */, @Method),

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -38,7 +38,7 @@ pub struct BytePos(u32);
 /// A character offset. Because of multibyte utf8 characters, a byte offset
 /// is not equivalent to a character offset. The CodeMap will convert BytePos
 /// values to CharPos values as necessary.
-#[deriving(Eq,Hash, Ord)]
+#[deriving(Eq, Hash, Ord)]
 pub struct CharPos(uint);
 
 // FIXME: Lots of boilerplate in these impls, but so far my attempts to fix

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -75,8 +75,7 @@ impl<T:Eq + Hash + Freeze + Clone + 'static> Interner<T> {
         vect.get().len()
     }
 
-    pub fn find_equiv<Q:Hash + Equiv<T>>(&self, val: &Q)
-                                              -> Option<Name> {
+    pub fn find_equiv<Q:Hash + Equiv<T>>(&self, val: &Q) -> Option<Name> {
         let map = self.map.borrow();
         match map.get().find_equiv(val) {
             Some(v) => Some(*v),
@@ -207,8 +206,7 @@ impl StrInterner {
         vect.get().len()
     }
 
-    pub fn find_equiv<Q:Hash + Equiv<RcStr>>(&self, val: &Q)
-                                                         -> Option<Name> {
+    pub fn find_equiv<Q:Hash + Equiv<RcStr>>(&self, val: &Q) -> Option<Name> {
         let map = self.map.borrow();
         match map.get().find_equiv(val) {
             Some(v) => Some(*v),

--- a/src/test/run-pass/deriving-global.rs
+++ b/src/test/run-pass/deriving-global.rs
@@ -27,18 +27,21 @@ mod submod {
     // function calls, then being in a submodule will (correctly)
     // cause errors about unrecognised module `std` (or `extra`)
     #[deriving(Eq, Ord, TotalEq, TotalOrd,
+               Hash,
                Clone, DeepClone,
                Show, Rand,
                Encodable, Decodable)]
     enum A { A1(uint), A2(int) }
 
     #[deriving(Eq, Ord, TotalEq, TotalOrd,
+               Hash,
                Clone, DeepClone,
                Show, Rand,
                Encodable, Decodable)]
     struct B { x: uint, y: int }
 
     #[deriving(Eq, Ord, TotalEq, TotalOrd,
+               Hash,
                Clone, DeepClone,
                Show, Rand,
                Encodable, Decodable)]

--- a/src/test/run-pass/deriving-meta-multiple.rs
+++ b/src/test/run-pass/deriving-meta-multiple.rs
@@ -10,8 +10,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
-#[deriving(Clone)]
+use std::hash::hash;
+
+#[deriving(Eq, Clone, Hash)]
 struct Foo {
     bar: uint,
     baz: int
@@ -22,4 +23,5 @@ pub fn main() {
 
     a == a;    // check for Eq impl w/o testing its correctness
     a.clone(); // check for Clone impl w/o testing its correctness
+    hash(&a);  // check for Hash impl w/o testing its correctness
 }

--- a/src/test/run-pass/deriving-meta.rs
+++ b/src/test/run-pass/deriving-meta.rs
@@ -10,7 +10,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq, Clone)]
+use std::hash::hash;
+
+#[deriving(Eq, Clone, Hash)]
 struct Foo {
     bar: uint,
     baz: int
@@ -21,4 +23,5 @@ pub fn main() {
 
     a == a;    // check for Eq impl w/o testing its correctness
     a.clone(); // check for Clone impl w/o testing its correctness
+    hash(&a);  // check for Hash impl w/o testing its correctness
 }

--- a/src/test/run-pass/deriving-via-extension-type-params.rs
+++ b/src/test/run-pass/deriving-via-extension-type-params.rs
@@ -10,8 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
-#[deriving(Hash)]
+#[deriving(Eq, Hash)]
 struct Foo<T> {
     x: int,
     y: T,


### PR DESCRIPTION
This patch series does a couple things:
- replaces manual `Hash` implementations with `#[deriving(Hash)]`
- adds `Hash` back to `std::prelude`
- minor cleanup of whitespace and variable names.
