### PR TITLE
Correctly ignore some tests on windows

### DIFF
--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1106,9 +1106,8 @@ mod test {
         file.fsync().unwrap();
         file.datasync().unwrap();
         drop(file);
-    })
+    } #[ignore(cfg(windows))])
 
-    #[ignore(cfg(windows))] // FIXME(#11638)
     iotest!(fn truncate_works() {
         let tmpdir = tmpdir();
         let path = tmpdir.join("in.txt");
@@ -1138,7 +1137,7 @@ mod test {
         assert_eq!(File::open(&path).read_to_end().unwrap(),
                    (bytes!("fo", 0, 0, 0, 0, "wut")).to_owned());
         drop(file);
-    })
+    } #[ignore(cfg(windows))]) // FIXME(#11638)
 
     iotest!(fn open_flavors() {
         let tmpdir = tmpdir();

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -192,7 +192,7 @@ mod tests {
         }, proc(_client) {
             // drop the client
         })
-    })
+    } #[ignore(cfg(windows))]) // FIXME(#12516)
 
     iotest!(fn write_begone() {
         smalltest(proc(mut server) {

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -814,7 +814,10 @@ mod tests {
     }
     #[cfg(windows)]
     pub fn sleeper() -> Process {
-        Process::new("timeout", [~"1000"]).unwrap()
+        // There's a `timeout` command on windows, but it doesn't like having
+        // its output piped, so instead just ping ourselves a few times with
+        // gaps inbetweeen so we're sure this process is alive for awhile
+        Process::new("ping", [~"127.0.0.1", ~"-n", ~"1000"]).unwrap()
     }
 
     iotest!(fn test_kill() {
@@ -828,5 +831,5 @@ mod tests {
         assert!(Process::kill(p.id(), 0).is_ok());
         p.signal_kill().unwrap();
         assert!(!p.wait().success());
-    } #[ignore(cfg(windows))]) // FIXME(#12516)
+    })
 }

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -823,11 +823,10 @@ mod tests {
         assert!(!p.wait().success());
     })
 
-    #[ignore(cfg(windows))]
     iotest!(fn test_exists() {
         let mut p = sleeper();
         assert!(Process::kill(p.id(), 0).is_ok());
         p.signal_kill().unwrap();
         assert!(!p.wait().success());
-    })
+    } #[ignore(cfg(windows))]) // FIXME(#12516)
 }


### PR DESCRIPTION
These two tests are notoriously flaky on the windows bots right now, so I'm
ignoring them until I can investigate them some more. The truncate_works test
has been flaky for quite some time, but it has gotten much worse recently. The
test_exists test has been flaky since the recent std::run rewrite landed.
Finally, the "unix pipe" test failure is a recent discovery on the try bots. I
haven't seen this failing much, but better safe than sorry!

cc #12516
