### PR TITLE
test: single-variant enum can't be dereferenced

### DIFF
--- a/src/test/compile-fail/issue-9814.rs
+++ b/src/test/compile-fail/issue-9814.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verify that single-variant enums cant be de-referenced
+// Regression test for issue #9814
+
+enum Foo { Bar(int) }
+
+fn main() {
+    let _ = *Bar(2); //~ ERROR type `Foo` cannot be dereferenced
+}


### PR DESCRIPTION
Closes #9814
