### PR TITLE
rustc: Introduce Strict Version Hashes

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -58,6 +58,7 @@ clean-generic-$(2)-$(1):
          -name '*.[odasS]' -o \
          -name '*.so' -o      \
          -name '*.dylib' -o   \
+         -name '*.rlib' -o   \
          -name 'stamp.*' -o   \
          -name '*.lib' -o     \
          -name '*.dll' -o     \

--- a/src/librustc/back/svh.rs
+++ b/src/librustc/back/svh.rs
@@ -1,0 +1,112 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Calculation and management of a Strict Version Hash for crates
+//!
+//! # Today's ABI problem
+//!
+//! In today's implementation of rustc, it is incredibly difficult to achieve
+//! forward binary compatibility without resorting to C-like interfaces. Within
+//! rust code itself, abi details such as symbol names suffer from a variety of
+//! unrelated factors to code changing such as the "def id drift" problem. This
+//! ends up yielding confusing error messages about metadata mismatches and
+//! such.
+//!
+//! The core of this problem is when when an upstream dependency changes and
+//! downstream dependants are not recompiled. This causes compile errors because
+//! the upstream crate's metadata has changed but the downstream crates are
+//! still referencing the older crate's metadata.
+//!
+//! This problem exists for many reasons, the primary of which is that rust does
+//! not currently support forwards ABI compatibility (in place upgrades of a
+//! crate).
+//!
+//! # SVH and how it alleviates the problem
+//!
+//! With all of this knowledge on hand, this module contains the implementation
+//! of a notion of a "Strict Version Hash" for a crate. This is essentially a
+//! hash of all contents of a crate which can somehow be exposed to downstream
+//! crates.
+//!
+//! This hash is currently calculated by just hashing the AST, but this is
+//! obviously wrong (doc changes should not result in an incompatible ABI).
+//! Implementation-wise, this is required at this moment in time.
+//!
+//! By encoding this strict version hash into all crate's metadata, stale crates
+//! can be detected immediately and error'd about by rustc itself.
+//!
+//! # Relevant links
+//!
+//! Original issue: https://github.com/mozilla/rust/issues/10207
+
+use std::fmt;
+use std::hash::Hash;
+use std::hash::sip::SipState;
+use std::iter::range_step;
+use syntax::ast;
+
+#[deriving(Clone, Eq)]
+pub struct Svh {
+    priv hash: ~str,
+}
+
+impl Svh {
+    pub fn new(hash: &str) -> Svh {
+        assert!(hash.len() == 16);
+        Svh { hash: hash.to_owned() }
+    }
+
+    pub fn as_str<'a>(&'a self) -> &'a str {
+        self.hash.as_slice()
+    }
+
+    pub fn calculate(krate: &ast::Crate) -> Svh {
+        // FIXME: see above for why this is wrong, it shouldn't just hash the
+        //        crate.  Fixing this would require more in-depth analysis in
+        //        this function about what portions of the crate are reachable
+        //        in tandem with bug fixes throughout the rest of the compiler.
+        //
+        //        Note that for now we actually exclude some top-level things
+        //        from the crate like the CrateConfig/span. The CrateConfig
+        //        contains command-line `--cfg` flags, so this means that the
+        //        stage1/stage2 AST for libstd and such is different hash-wise
+        //        when it's actually the exact same representation-wise.
+        //
+        //        As a first stab at only hashing the relevant parts of the
+        //        AST, this only hashes the module/attrs, not the CrateConfig
+        //        field.
+        //
+        // FIXME: this should use SHA1, not SipHash. SipHash is not built to
+        //        avoid collisions.
+        let mut state = SipState::new();
+        krate.module.hash(&mut state);
+        krate.attrs.hash(&mut state);
+
+        let hash = state.result();
+        return Svh {
+            hash: range_step(0, 64, 4).map(|i| hex(hash >> i)).collect()
+        };
+
+        fn hex(b: u64) -> char {
+            let b = (b & 0xf) as u8;
+            let b = match b {
+                0 .. 9 => '0' as u8 + b,
+                _ => 'a' as u8 + b - 10,
+            };
+            b as char
+        }
+    }
+}
+
+impl fmt::Show for Svh {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad(self.as_str())
+    }
+}

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -433,7 +433,7 @@ pub fn phase_6_link_output(sess: Session,
          link::link_binary(sess,
                            trans,
                            outputs,
-                           &trans.link));
+                           &trans.link.crateid));
 }
 
 pub fn stop_after_phase_3(sess: Session) -> bool {
@@ -472,8 +472,7 @@ fn write_out_deps(sess: Session,
                   input: &Input,
                   outputs: &OutputFilenames,
                   krate: &ast::Crate) -> io::IoResult<()> {
-    let lm = link::build_link_meta(krate.attrs, outputs,
-                                   &mut ::util::sha2::Sha256::new());
+    let id = link::find_crate_id(krate.attrs, outputs);
 
     let mut out_filenames = ~[];
     for output_type in sess.opts.output_types.iter() {
@@ -482,7 +481,7 @@ fn write_out_deps(sess: Session,
             link::OutputTypeExe => {
                 let crate_types = sess.crate_types.borrow();
                 for output in crate_types.get().iter() {
-                    let p = link::filename_for_input(&sess, *output, &lm, &file);
+                    let p = link::filename_for_input(&sess, *output, &id, &file);
                     out_filenames.push(p);
                 }
             }

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -12,6 +12,7 @@
 
 use std::cast;
 use syntax::crateid::CrateId;
+use back::svh::Svh;
 
 // EBML enum definitions and utils shared by the encoder and decoder
 
@@ -207,8 +208,8 @@ pub static tag_macro_registrar_fn: uint = 0x63;
 pub static tag_exported_macros: uint = 0x64;
 pub static tag_macro_def: uint = 0x65;
 
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub struct LinkMeta {
     crateid: CrateId,
-    crate_hash: ~str,
+    crate_hash: Svh,
 }

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -70,12 +70,12 @@ pub static tag_crate_deps: uint = 0x18;
 pub static tag_crate_dep: uint = 0x19;
 
 pub static tag_crate_hash: uint = 0x1a;
+pub static tag_crate_crateid: uint = 0x1b;
 
-pub static tag_parent_item: uint = 0x1b;
+pub static tag_parent_item: uint = 0x1c;
 
-pub static tag_crate_dep_name: uint = 0x1c;
-pub static tag_crate_dep_hash: uint = 0x1d;
-pub static tag_crate_dep_vers: uint = 0x1e;
+pub static tag_crate_dep_crateid: uint = 0x1d;
+pub static tag_crate_dep_hash: uint = 0x1e;
 
 pub static tag_mod_impl: uint = 0x1f;
 

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -13,6 +13,7 @@
 // The crate store - a central repo for information collected about external
 // crates and libraries
 
+use back::svh::Svh;
 use metadata::decoder;
 use metadata::loader;
 
@@ -92,7 +93,7 @@ impl CStore {
         *metas.get().get(&cnum)
     }
 
-    pub fn get_crate_hash(&self, cnum: ast::CrateNum) -> ~str {
+    pub fn get_crate_hash(&self, cnum: ast::CrateNum) -> Svh {
         let cdata = self.get_crate_data(cnum);
         decoder::get_crate_hash(cdata.data())
     }

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -21,6 +21,7 @@ use collections::HashMap;
 use extra::c_vec::CVec;
 use syntax::ast;
 use syntax::parse::token::IdentInterner;
+use syntax::crateid::CrateId;
 
 // A map from external crate numbers (as decoded from some crate file) to
 // local crate numbers (as generated during this session). Each external
@@ -96,9 +97,9 @@ impl CStore {
         decoder::get_crate_hash(cdata.data())
     }
 
-    pub fn get_crate_vers(&self, cnum: ast::CrateNum) -> ~str {
+    pub fn get_crate_id(&self, cnum: ast::CrateNum) -> CrateId {
         let cdata = self.get_crate_data(cnum);
-        decoder::get_crate_vers(cdata.data())
+        decoder::get_crate_id(cdata.data())
     }
 
     pub fn set_crate_data(&self, cnum: ast::CrateNum, data: @crate_metadata) {
@@ -191,41 +192,6 @@ impl CStore {
         let extern_mod_crate_map = self.extern_mod_crate_map.borrow();
         extern_mod_crate_map.get().find(&emod_id).map(|x| *x)
     }
-
-    // returns hashes of crates directly used by this crate. Hashes are sorted by
-    // (crate name, crate version, crate hash) in lexicographic order (not semver)
-    pub fn get_dep_hashes(&self) -> ~[~str] {
-        let mut result = ~[];
-
-        let extern_mod_crate_map = self.extern_mod_crate_map.borrow();
-        for (_, &cnum) in extern_mod_crate_map.get().iter() {
-            let cdata = self.get_crate_data(cnum);
-            let hash = decoder::get_crate_hash(cdata.data());
-            let vers = decoder::get_crate_vers(cdata.data());
-            debug!("Add hash[{}]: {} {}", cdata.name, vers, hash);
-            result.push(crate_hash {
-                name: cdata.name.clone(),
-                vers: vers,
-                hash: hash
-            });
-        }
-
-        result.sort();
-
-        debug!("sorted:");
-        for x in result.iter() {
-            debug!("  hash[{}]: {}", x.name, x.hash);
-        }
-
-        result.move_iter().map(|crate_hash { hash, ..}| hash).collect()
-    }
-}
-
-#[deriving(Clone, TotalEq, TotalOrd)]
-struct crate_hash {
-    name: ~str,
-    vers: ~str,
-    hash: ~str,
 }
 
 impl crate_metadata {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -12,6 +12,7 @@
 
 #[allow(non_camel_case_types)];
 
+use back::svh::Svh;
 use metadata::cstore::crate_metadata;
 use metadata::common::*;
 use metadata::csearch::StaticMethodInfo;
@@ -1089,9 +1090,9 @@ fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
     return attrs;
 }
 
-fn list_crate_attributes(md: ebml::Doc, hash: &str,
+fn list_crate_attributes(md: ebml::Doc, hash: &Svh,
                          out: &mut io::Writer) -> io::IoResult<()> {
-    try!(write!(out, "=Crate Attributes ({})=\n", hash));
+    try!(write!(out, "=Crate Attributes ({})=\n", *hash));
 
     let r = get_attributes(md);
     for attr in r.iter() {
@@ -1109,7 +1110,7 @@ pub fn get_crate_attributes(data: &[u8]) -> ~[ast::Attribute] {
 pub struct CrateDep {
     cnum: ast::CrateNum,
     crate_id: CrateId,
-    hash: ~str,
+    hash: Svh,
 }
 
 pub fn get_crate_deps(data: &[u8]) -> ~[CrateDep] {
@@ -1123,7 +1124,7 @@ pub fn get_crate_deps(data: &[u8]) -> ~[CrateDep] {
     }
     reader::tagged_docs(depsdoc, tag_crate_dep, |depdoc| {
         let crate_id = from_str(docstr(depdoc, tag_crate_dep_crateid)).unwrap();
-        let hash = docstr(depdoc, tag_crate_dep_hash);
+        let hash = Svh::new(docstr(depdoc, tag_crate_dep_hash));
         deps.push(CrateDep {
             cnum: crate_num,
             crate_id: crate_id,
@@ -1144,10 +1145,10 @@ fn list_crate_deps(data: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
     Ok(())
 }
 
-pub fn get_crate_hash(data: &[u8]) -> ~str {
+pub fn get_crate_hash(data: &[u8]) -> Svh {
     let cratedoc = reader::Doc(data);
     let hashdoc = reader::get_doc(cratedoc, tag_crate_hash);
-    hashdoc.as_str_slice().to_str()
+    Svh::new(hashdoc.as_str_slice())
 }
 
 pub fn get_crate_id(data: &[u8]) -> CrateId {
@@ -1159,7 +1160,7 @@ pub fn get_crate_id(data: &[u8]) -> CrateId {
 pub fn list_crate_metadata(bytes: &[u8], out: &mut io::Writer) -> io::IoResult<()> {
     let hash = get_crate_hash(bytes);
     let md = reader::Doc(bytes);
-    try!(list_crate_attributes(md, hash, out));
+    try!(list_crate_attributes(md, &hash, out));
     list_crate_deps(bytes, out)
 }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -13,6 +13,7 @@
 #[allow(unused_must_use)]; // everything is just a MemWriter, can't fail
 #[allow(non_camel_case_types)];
 
+use back::svh::Svh;
 use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
@@ -1733,14 +1734,14 @@ fn encode_crate_dep(ebml_w: &mut writer::Encoder,
     ebml_w.writer.write(dep.crate_id.to_str().as_bytes());
     ebml_w.end_tag();
     ebml_w.start_tag(tag_crate_dep_hash);
-    ebml_w.writer.write(dep.hash.as_bytes());
+    ebml_w.writer.write(dep.hash.as_str().as_bytes());
     ebml_w.end_tag();
     ebml_w.end_tag();
 }
 
-fn encode_hash(ebml_w: &mut writer::Encoder, hash: &str) {
+fn encode_hash(ebml_w: &mut writer::Encoder, hash: &Svh) {
     ebml_w.start_tag(tag_crate_hash);
-    ebml_w.writer.write(hash.as_bytes());
+    ebml_w.writer.write(hash.as_str().as_bytes());
     ebml_w.end_tag();
 }
 
@@ -1809,7 +1810,7 @@ fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, krate: &Crate)
     let mut ebml_w = writer::Encoder(wr);
 
     encode_crate_id(&mut ebml_w, &ecx.link_meta.crateid);
-    encode_hash(&mut ebml_w, ecx.link_meta.crate_hash);
+    encode_hash(&mut ebml_w, &ecx.link_meta.crate_hash);
 
     let mut i = ebml_w.writer.tell().unwrap();
     let crate_attrs = synthesize_crate_attrs(&ecx, krate);

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -40,6 +40,7 @@ use syntax::ast_util::*;
 use syntax::ast_util;
 use syntax::attr::AttrMetaMethods;
 use syntax::attr;
+use syntax::crateid::CrateId;
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::token::InternedString;
 use syntax::parse::token::special_idents;
@@ -1510,8 +1511,7 @@ fn encode_crate_deps(ebml_w: &mut writer::Encoder, cstore: &cstore::CStore) {
         cstore.iter_crate_data(|key, val| {
             let dep = decoder::CrateDep {
                 cnum: key,
-                name: token::str_to_ident(val.name),
-                vers: decoder::get_crate_vers(val.data()),
+                crate_id: decoder::get_crate_id(val.data()),
                 hash: decoder::get_crate_hash(val.data())
             };
             deps.push(dep);
@@ -1729,12 +1729,8 @@ fn encode_misc_info(ecx: &EncodeContext,
 fn encode_crate_dep(ebml_w: &mut writer::Encoder,
                     dep: decoder::CrateDep) {
     ebml_w.start_tag(tag_crate_dep);
-    ebml_w.start_tag(tag_crate_dep_name);
-    let s = token::get_ident(dep.name);
-    ebml_w.writer.write(s.get().as_bytes());
-    ebml_w.end_tag();
-    ebml_w.start_tag(tag_crate_dep_vers);
-    ebml_w.writer.write(dep.vers.as_bytes());
+    ebml_w.start_tag(tag_crate_dep_crateid);
+    ebml_w.writer.write(dep.crate_id.to_str().as_bytes());
     ebml_w.end_tag();
     ebml_w.start_tag(tag_crate_dep_hash);
     ebml_w.writer.write(dep.hash.as_bytes());
@@ -1745,6 +1741,12 @@ fn encode_crate_dep(ebml_w: &mut writer::Encoder,
 fn encode_hash(ebml_w: &mut writer::Encoder, hash: &str) {
     ebml_w.start_tag(tag_crate_hash);
     ebml_w.writer.write(hash.as_bytes());
+    ebml_w.end_tag();
+}
+
+fn encode_crate_id(ebml_w: &mut writer::Encoder, crate_id: &CrateId) {
+    ebml_w.start_tag(tag_crate_crateid);
+    ebml_w.writer.write(crate_id.to_str().as_bytes());
     ebml_w.end_tag();
 }
 
@@ -1806,6 +1808,7 @@ fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, krate: &Crate)
 
     let mut ebml_w = writer::Encoder(wr);
 
+    encode_crate_id(&mut ebml_w, &ecx.link_meta.crateid);
     encode_hash(&mut ebml_w, ecx.link_meta.crate_hash);
 
     let mut i = ebml_w.writer.tell().unwrap();

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -11,6 +11,7 @@
 //! Finds crate binaries and loads their metadata
 
 use back::archive::{ArchiveRO, METADATA_FILENAME};
+use back::svh::Svh;
 use driver::session::Session;
 use lib::llvm::{False, llvm, ObjectFile, mk_section_iter};
 use metadata::cstore::{MetadataBlob, MetadataVec, MetadataArchive};
@@ -21,7 +22,6 @@ use syntax::codemap::Span;
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::token::IdentInterner;
 use syntax::crateid::CrateId;
-use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 
 use std::c_str::ToCStr;
@@ -49,9 +49,11 @@ pub struct Context<'a> {
     span: Span,
     ident: &'a str,
     crate_id: &'a CrateId,
-    hash: &'a str,
+    id_hash: &'a str,
+    hash: Option<&'a Svh>,
     os: Os,
-    intr: @IdentInterner
+    intr: @IdentInterner,
+    rejected_via_hash: bool,
 }
 
 pub struct Library {
@@ -79,23 +81,34 @@ fn realpath(p: &Path) -> Path {
 }
 
 impl<'a> Context<'a> {
-    pub fn load_library_crate(&self, root_ident: Option<&str>) -> Library {
+    pub fn load_library_crate(&mut self, root_ident: Option<&str>) -> Library {
         match self.find_library_crate() {
             Some(t) => t,
             None => {
                 self.sess.abort_if_errors();
-                let message = match root_ident {
-                    None => format!("can't find crate for `{}`", self.ident),
-                    Some(c) => format!("can't find crate for `{}` which `{}` depends on",
-                                       self.ident,
-                                       c)
+                let message = if self.rejected_via_hash {
+                    format!("found possibly newer version of crate `{}`",
+                            self.ident)
+                } else {
+                    format!("can't find crate for `{}`", self.ident)
                 };
-                self.sess.span_fatal(self.span, message);
+                let message = match root_ident {
+                    None => message,
+                    Some(c) => format!("{} which `{}` depends on", message, c),
+                };
+                self.sess.span_err(self.span, message);
+
+                if self.rejected_via_hash {
+                    self.sess.span_note(self.span, "perhaps this crate needs \
+                                                    to be recompiled?");
+                }
+                self.sess.abort_if_errors();
+                unreachable!()
             }
         }
     }
 
-    fn find_library_crate(&self) -> Option<Library> {
+    fn find_library_crate(&mut self) -> Option<Library> {
         let filesearch = self.sess.filesearch;
         let (dyprefix, dysuffix) = self.dylibname();
 
@@ -212,13 +225,8 @@ impl<'a> Context<'a> {
                         None => {}
                     }
                     let data = lib.metadata.as_slice();
-                    let attrs = decoder::get_crate_attributes(data);
-                    match attr::find_crateid(attrs) {
-                        None => {}
-                        Some(crateid) => {
-                            note_crateid_attr(self.sess.diagnostic(), &crateid);
-                        }
-                    }
+                    let crate_id = decoder::get_crate_id(data);
+                    note_crateid_attr(self.sess.diagnostic(), &crate_id);
                 }
                 None
             }
@@ -240,18 +248,21 @@ impl<'a> Context<'a> {
         debug!("matching -- {}, middle: {}", file, middle);
         let mut parts = middle.splitn('-', 1);
         let hash = match parts.next() { Some(h) => h, None => return None };
-        debug!("matching -- {}, hash: {}", file, hash);
+        debug!("matching -- {}, hash: {} (want {})", file, hash, self.id_hash);
         let vers = match parts.next() { Some(v) => v, None => return None };
-        debug!("matching -- {}, vers: {}", file, vers);
+        debug!("matching -- {}, vers: {} (want {})", file, vers,
+               self.crate_id.version);
         match self.crate_id.version {
             Some(ref version) if version.as_slice() != vers => return None,
-            Some(..) | None => {}
+            Some(..) => {} // check the hash
+
+            // hash is irrelevant, no version specified
+            None => return Some(hash.to_owned())
         }
-        debug!("matching -- {}, vers ok (requested {})", file,
-               self.crate_id.version);
+        debug!("matching -- {}, vers ok", file);
         // hashes in filenames are prefixes of the "true hash"
-        if self.hash.is_empty() || self.hash.starts_with(hash) {
-            debug!("matching -- {}, hash ok (requested {})", file, self.hash);
+        if self.id_hash == hash.as_slice() {
+            debug!("matching -- {}, hash ok", file);
             Some(hash.to_owned())
         } else {
             None
@@ -270,7 +281,7 @@ impl<'a> Context<'a> {
     // FIXME(#10786): for an optimization, we only read one of the library's
     //                metadata sections. In theory we should read both, but
     //                reading dylib metadata is quite slow.
-    fn extract_one(&self, m: HashSet<Path>, flavor: &str,
+    fn extract_one(&mut self, m: HashSet<Path>, flavor: &str,
                    slot: &mut Option<MetadataBlob>) -> Option<Path> {
         if m.len() == 0 { return None }
         if m.len() > 1 {
@@ -290,7 +301,7 @@ impl<'a> Context<'a> {
             info!("{} reading meatadata from: {}", flavor, lib.display());
             match get_metadata_section(self.os, &lib) {
                 Some(blob) => {
-                    if crate_matches(blob.as_slice(), self.crate_id, self.hash){
+                    if self.crate_matches(blob.as_slice()) {
                         *slot = Some(blob);
                     } else {
                         info!("metadata mismatch");
@@ -304,6 +315,22 @@ impl<'a> Context<'a> {
             }
         }
         return Some(lib);
+    }
+
+    fn crate_matches(&mut self, crate_data: &[u8]) -> bool {
+        let other_id = decoder::get_crate_id(crate_data);
+        if !self.crate_id.matches(&other_id) { return false }
+        match self.hash {
+            None => true,
+            Some(hash) => {
+                if *hash != decoder::get_crate_hash(crate_data) {
+                    self.rejected_via_hash = true;
+                    false
+                } else {
+                    true
+                }
+            }
+        }
     }
 
     // Returns the corresponding (prefix, suffix) that files need to have for
@@ -321,15 +348,6 @@ impl<'a> Context<'a> {
 
 pub fn note_crateid_attr(diag: @SpanHandler, crateid: &CrateId) {
     diag.handler().note(format!("crate_id: {}", crateid.to_str()));
-}
-
-fn crate_matches(crate_data: &[u8], crate_id: &CrateId, hash: &str) -> bool {
-    let other_id = decoder::get_crate_id(crate_data);
-    if !crate_id.matches(&other_id) { return false }
-    if hash != "" && hash != decoder::get_crate_hash(crate_data).as_slice() {
-        return false
-    }
-    return true;
 }
 
 impl ArchiveMetadata {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2488,7 +2488,7 @@ pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
         let cdata = cstore.get_crate_data(i);
         let nm = symname(format!("_rust_crate_map_{}", cdata.name),
                          cstore.get_crate_hash(i),
-                         cstore.get_crate_vers(i));
+                         cstore.get_crate_id(i).version_or_default());
         let cr = nm.with_c_str(|buf| {
             unsafe {
                 llvm::LLVMAddGlobal(ccx.llmod, ccx.int_type.to_ref(), buf)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2453,7 +2453,8 @@ pub fn decl_crate_map(sess: session::Session, mapmeta: LinkMeta,
     let sym_name = if is_top {
         ~"_rust_crate_map_toplevel"
     } else {
-        symname("_rust_crate_map_" + mapmeta.crateid.name, mapmeta.crate_hash,
+        symname("_rust_crate_map_" + mapmeta.crateid.name,
+                mapmeta.crate_hash.as_str(),
                 mapmeta.crateid.version_or_default())
     };
 
@@ -2487,7 +2488,7 @@ pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
     while cstore.have_crate_data(i) {
         let cdata = cstore.get_crate_data(i);
         let nm = symname(format!("_rust_crate_map_{}", cdata.name),
-                         cstore.get_crate_hash(i),
+                         cstore.get_crate_hash(i).as_str(),
                          cstore.get_crate_id(i).version_or_default());
         let cr = nm.with_c_str(|buf| {
             unsafe {
@@ -2609,9 +2610,7 @@ pub fn trans_crate(sess: session::Session,
         }
     }
 
-    let mut symbol_hasher = Sha256::new();
-    let link_meta = link::build_link_meta(krate.attrs, output,
-                                          &mut symbol_hasher);
+    let link_meta = link::build_link_meta(&krate, output);
 
     // Append ".rs" to crate name as LLVM module identifier.
     //
@@ -2621,16 +2620,16 @@ pub fn trans_crate(sess: session::Session,
     // crashes if the module identifer is same as other symbols
     // such as a function name in the module.
     // 1. http://llvm.org/bugs/show_bug.cgi?id=11479
-    let llmod_id = link_meta.crateid.name.clone() + ".rs";
+    let llmod_id = link_meta.crateid.name + ".rs";
 
     let ccx = @CrateContext::new(sess,
-                                     llmod_id,
-                                     analysis.ty_cx,
-                                     analysis.exp_map2,
-                                     analysis.maps,
-                                     symbol_hasher,
-                                     link_meta,
-                                     analysis.reachable);
+                                 llmod_id,
+                                 analysis.ty_cx,
+                                 analysis.exp_map2,
+                                 analysis.maps,
+                                 Sha256::new(),
+                                 link_meta,
+                                 analysis.reachable);
     {
         let _icx = push_ctxt("text");
         trans_mod(ccx, &krate.module);

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -329,7 +329,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             let hash = ty::hash_crate_independent(
                 ccx.tcx,
                 substs.tys[0],
-                ccx.link_meta.crate_hash.clone());
+                &ccx.link_meta.crate_hash);
             // NB: This needs to be kept in lockstep with the TypeId struct in
             //     libstd/unstable/intrinsics.rs
             let val = C_named_struct(type_of::type_of(ccx, output_type), [C_u64(hash)]);

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -10,6 +10,7 @@
 
 #[allow(non_camel_case_types)];
 
+use back::svh::Svh;
 use driver::session;
 use metadata::csearch;
 use metadata;
@@ -4882,7 +4883,7 @@ pub fn trait_method_of_method(tcx: ctxt,
 
 /// Creates a hash of the type `t` which will be the same no matter what crate
 /// context it's calculated within. This is used by the `type_id` intrinsic.
-pub fn hash_crate_independent(tcx: ctxt, t: t, local_hash: ~str) -> u64 {
+pub fn hash_crate_independent(tcx: ctxt, t: t, svh: &Svh) -> u64 {
     let mut state = sip::SipState::new();
     macro_rules! byte( ($b:expr) => { ($b as u8).hash(&mut state) } );
     macro_rules! hash( ($e:expr) => { $e.hash(&mut state) } );
@@ -4913,11 +4914,11 @@ pub fn hash_crate_independent(tcx: ctxt, t: t, local_hash: ~str) -> u64 {
     };
     let did = |state: &mut sip::SipState, did: DefId| {
         let h = if ast_util::is_local(did) {
-            local_hash.clone()
+            svh.clone()
         } else {
             tcx.sess.cstore.get_crate_hash(did.krate)
         };
-        h.as_bytes().hash(state);
+        h.as_str().hash(state);
         did.node.hash(state);
     };
     let mt = |state: &mut sip::SipState, mt: mt| {

--- a/src/libsyntax/crateid.rs
+++ b/src/libsyntax/crateid.rs
@@ -107,6 +107,15 @@ impl CrateId {
     pub fn short_name_with_version(&self) -> ~str {
         format!("{}-{}", self.name, self.version_or_default())
     }
+
+    pub fn matches(&self, other: &CrateId) -> bool {
+        // FIXME: why does this not match on `path`?
+        if self.name != other.name { return false }
+        match (&self.version, &other.version) {
+            (&Some(ref v1), &Some(ref v2)) => v1 == v2,
+            _ => true,
+        }
+    }
 }
 
 #[test]

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -135,5 +135,6 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span,
     // phew, not our responsibility any more!
     format::expand_preparsed_format_args(cx, span,
                                          format_closure,
-                                         format_string, exprs, HashMap::new())
+                                         format_string, exprs, ~[],
+                                         HashMap::new())
 }

--- a/src/test/auxiliary/changing-crates-a1.rs
+++ b/src/test/auxiliary/changing-crates-a1.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_id = "a"];
+
+pub fn foo<T>() {}

--- a/src/test/auxiliary/changing-crates-a2.rs
+++ b/src/test/auxiliary/changing-crates-a2.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_id = "a"];
+
+pub fn foo<T>() { println!("hello!"); }
+

--- a/src/test/auxiliary/changing-crates-b.rs
+++ b/src/test/auxiliary/changing-crates-b.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_id = "b"];
+
+extern crate a;
+
+pub fn foo() { a::foo::<int>(); }

--- a/src/test/compile-fail/bad-crate-id.rs
+++ b/src/test/compile-fail/bad-crate-id.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo = ""; //~ ERROR: malformed crate id
+extern crate bar = "#a"; //~ ERROR: malformed crate id
+
+fn main() {}

--- a/src/test/compile-fail/changing-crates.rs
+++ b/src/test/compile-fail/changing-crates.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// note that these aux-build directives must be in this order
+// aux-build:changing-crates-a1.rs
+// aux-build:changing-crates-b.rs
+// aux-build:changing-crates-a2.rs
+
+extern crate a;
+extern crate b; //~ ERROR: found possibly newer version of crate `a` which `b` depends on
+//~^ NOTE: perhaps this crate needs to be recompiled
+
+fn main() {}

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -139,6 +139,7 @@ pub fn main() {
 
     test_write();
     test_print();
+    test_order();
 
     // make sure that format! doesn't move out of local variables
     let a = ~3;
@@ -201,4 +202,19 @@ fn test_format_args() {
 
     let s = format_args!(fmt::format, "hello {}", "world");
     t!(s, "hello world");
+}
+
+fn test_order() {
+    // Make sure format!() arguments are always evaluated in a left-to-right
+    // ordering
+    fn foo() -> int {
+        static mut FOO: int = 0;
+        unsafe {
+            FOO += 1;
+            FOO
+        }
+    }
+    assert_eq!(format!("{} {} {a} {b} {} {c}",
+                       foo(), foo(), foo(), a=foo(), b=foo(), c=foo()),
+               ~"1 2 4 5 3 6");
 }


### PR DESCRIPTION
These hashes are used to detect changes to upstream crates and generate errors which mention that crates possibly need recompilation.

More details can be found in the respective commit messages below. This change is also accompanied with a much needed refactoring of some of the crate loading code to focus more on crate ids instead of name/version pairs.

Closes #12601
