### PR TITLE
New Attribute Syntax (#2569)

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -92,7 +92,8 @@ impl ParserAttr for Parser {
                         self.fatal("An inner attribute was not permitted in this context.");
                     }
                 } else {
-                    self.warn("The syntax for inner attributes have changed. Use `#![lang(foo)]` instead.");
+                    //self.warn("The syntax for inner attributes have changed.
+                    //    Use `#![lang(foo)]` instead.");
                 }
 
                 // #![lang(foo)]
@@ -119,7 +120,7 @@ impl ParserAttr for Parser {
             // need to bump the token.
             ast::AttrInner
         } else if permit_inner && self.token == token::SEMI {
-            self.warn("This uses the old attribute syntax. Semicolons are not longer required.");
+            //self.warn("This uses the old attribute syntax. Semicolons are not longer required.");
             self.bump();
             ast::AttrInner
         } else {

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -91,6 +91,8 @@ impl ParserAttr for Parser {
                     if !permit_inner {
                         self.fatal("An inner attribute was not permitted in this context.");
                     }
+                } else {
+                    self.warn("The syntax for inner attributes have changed. Use `#![lang(foo)]` instead.");
                 }
 
                 // #![lang(foo)]
@@ -117,6 +119,7 @@ impl ParserAttr for Parser {
             // need to bump the token.
             ast::AttrInner
         } else if permit_inner && self.token == token::SEMI {
+            self.warn("This uses the old attribute syntax. Semicolons are not longer required.");
             self.bump();
             ast::AttrInner
         } else {

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -40,11 +40,9 @@ impl ParserAttr for Parser {
                 attrs.push(self.parse_attribute(false));
               }
               token::POUND => {
-                println!("\\# found (outer)")
                 // #[foo(bar)]
                 //  ^ denotes an outer attribute.
                 if self.look_ahead(1, |t| *t != token::LBRACKET) {
-                    println!("LBRACKET not found. Oops.");
                     break;
                 }
 
@@ -83,7 +81,6 @@ impl ParserAttr for Parser {
                 (attr.span, attr.node.value)
             }
             token::POUND => {
-                println!("\\# found");
                 let lo = self.span.lo;
                 self.bump();
 
@@ -91,7 +88,6 @@ impl ParserAttr for Parser {
                 //  ^
                 if self.eat(&token::NOT) {
                     inner_attr_bang = true;
-                    println!("new attribute syntax found. Checking context validity.");
                     if !permit_inner {
                         self.fatal("An inner attribute was not permitted in this context.");
                     }
@@ -100,14 +96,12 @@ impl ParserAttr for Parser {
                 // #![lang(foo)]
                 //   ^
                 self.expect(&token::LBRACKET);
-                println!("lbracket found");
 
                 let meta_item = self.parse_meta_item();
 
                 // #![lang(foo)]
                 //             ^
                 self.expect(&token::RBRACKET);
-                println!("rbracket found");
 
                 let hi = self.span.hi;
                 (mk_sp(lo, hi), meta_item)
@@ -119,12 +113,10 @@ impl ParserAttr for Parser {
             }
         };
         let style = if inner_attr_bang {
-            println!("new attribute syntax found");
             // The new attribute syntax doesn't require a `;`, so we don't
             // need to bump the token.
             ast::AttrInner
         } else if permit_inner && self.token == token::SEMI {
-            println!("semicolon found.");
             self.bump();
             ast::AttrInner
         } else {
@@ -161,7 +153,6 @@ impl ParserAttr for Parser {
                 }
                 token::POUND => {
                     let mut backwards_syntax = true;
-                    println!("\\# found (inner)");
                     // #![foo(bar)]
                     //  ^ denotes an inner attribute.
                     // The backwards compatible syntax should not contain
@@ -171,7 +162,6 @@ impl ParserAttr for Parser {
                         if self.look_ahead(2, |t| *t != token::LBRACKET) {
                             break;
                         }
-                        println!("found new syntax (!)");
                     }
 
                     if self.look_ahead(1, |t| *t != token::LBRACKET) {

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -12,7 +12,7 @@ use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos};
 use diagnostic;
 use parse::lexer::{is_whitespace, with_str_from, Reader};
-use parse::lexer::{StringReader, bump, is_eof, nextch_is, TokenAndSpan};
+use parse::lexer::{StringReader, bump, peek, is_eof, nextch_is, TokenAndSpan};
 use parse::lexer::{is_line_non_doc_comment, is_block_non_doc_comment};
 use parse::lexer;
 use parse::token;
@@ -332,7 +332,11 @@ fn consume_comment(rdr: &StringReader,
     } else if rdr.curr_is('/') && nextch_is(rdr, '*') {
         read_block_comment(rdr, code_to_the_left, comments);
     } else if rdr.curr_is('#') && nextch_is(rdr, '!') {
-        read_shebang_comment(rdr, code_to_the_left, comments);
+        // Make sure the following token is **not** the beginning
+        // of an inner attribute, which starts with the same syntax.
+        if peek(rdr, 2).unwrap() != '[' {
+            read_shebang_comment(rdr, code_to_the_left, comments);
+        }
     } else { fail!(); }
     debug!("<<< consume comment");
 }

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -270,9 +270,21 @@ pub fn bump(rdr: &StringReader) {
         rdr.curr.set(None);
     }
 }
+
+// EFFECT: Peek 'n' characters ahead.
+pub fn peek(rdr: &StringReader, n: uint) -> Option<char> {
+    let offset = byte_offset(rdr, rdr.pos.get()).to_uint() + (n - 1);
+    if offset < (rdr.filemap.src).len() {
+        Some(rdr.filemap.src.char_at(offset))
+    } else {
+        None
+    }
+}
+
 pub fn is_eof(rdr: &StringReader) -> bool {
     rdr.curr.get().is_none()
 }
+
 pub fn nextch(rdr: &StringReader) -> Option<char> {
     let offset = byte_offset(rdr, rdr.pos.get()).to_uint();
     if offset < (rdr.filemap.src).len() {
@@ -369,6 +381,12 @@ fn consume_any_line_comment(rdr: &StringReader)
         }
     } else if rdr.curr_is('#') {
         if nextch_is(rdr, '!') {
+
+            // Parse an inner attribute.
+            if peek(rdr, 2).unwrap() == '[' {
+                return None;
+            }
+
             // I guess this is the only way to figure out if
             // we're at the beginning of the file...
             let cmap = @CodeMap::new();

--- a/src/test/compile-fail/attr.rs
+++ b/src/test/compile-fail/attr.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}
+
+#![lang(foo)] //~ ERROR An inner attribute was not permitted in this context.
+fn foo() {}

--- a/src/test/run-pass/attr-mix-new.rs
+++ b/src/test/run-pass/attr-mix-new.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-# foo(bar)
+#[foo(bar)]
 mod foo {
-  #^ feature(globs);
+  #![feature(globs)]
 }
 
 fn main() {}

--- a/src/test/run-pass/attr-mix-new.rs
+++ b/src/test/run-pass/attr-mix-new.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+# foo(bar)
+mod foo {
+  #^ feature(globs);
+}
+
+fn main() {}

--- a/src/test/run-pass/attr-shebang.rs
+++ b/src/test/run-pass/attr-shebang.rs
@@ -1,0 +1,5 @@
+// ignore-license
+#![foo]
+
+
+fn main() {}

--- a/src/test/run-pass/attr-shebang.rs
+++ b/src/test/run-pass/attr-shebang.rs
@@ -1,3 +1,4 @@
-#[main]
+#![allow(unknown_features)]
+#![feature(bogus)]
+fn main() { }
 // ignore-license
-fn foo() {}

--- a/src/test/run-pass/attr-shebang.rs
+++ b/src/test/run-pass/attr-shebang.rs
@@ -1,5 +1,3 @@
+#[main]
 // ignore-license
-#![foo]
-
-
-fn main() {}
+fn foo() {}

--- a/src/test/run-pass/attr.rs
+++ b/src/test/run-pass/attr.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#main
+fn foo() {
+}

--- a/src/test/run-pass/attr.rs
+++ b/src/test/run-pass/attr.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#main
+#[main]
 fn foo() {
 }


### PR DESCRIPTION
This implements the currently leading (inner) attribute syntax (#2569) while keeping backwards compatibility. Everything compiles and passes (including two new tests).

New Syntax:

inner: `#![foo(bar)]` (without a semicolon)
outer: stays the same.

The new syntax also supports semicolons for backward compability.
