### PR TITLE
Remove references to guide-conditions

### DIFF
--- a/configure
+++ b/configure
@@ -803,7 +803,6 @@ do
     make_dir $h/test/doc-guide-pointers
     make_dir $h/test/doc-guide-container
     make_dir $h/test/doc-guide-tasks
-    make_dir $h/test/doc-guide-conditions
     make_dir $h/test/doc-complement-cheatsheet
     make_dir $h/test/doc-rust
 done

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -19,7 +19,6 @@ li {list-style-type: none; }
 * [Foreign Function Interface](guide-ffi.html)
 * [Macros](guide-macros.html)
 * [Testing](guide-testing.html)
-* [Conditions](guide-conditions.html)
 * [Rust's Runtime](guide-runtime.html)
 
 # Libraries


### PR DESCRIPTION
std::condition was removed in 454882dcb7fdb03867d695a88335e2d2c8f7561a
but there are still links to the guide. Removing them.
