### PR TITLE
Change HashMap to be hasher-generic

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -17,7 +17,11 @@
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 
-#[feature(macro_rules, managed_boxes)];
+#[feature(macro_rules, managed_boxes, default_type_params)];
+
+// NOTE remove the following two attributes after the next snapshot.
+#[allow(unrecognized_lint)];
+#[allow(default_type_param_usage)];
 
 #[cfg(test)] extern crate test;
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4926,7 +4926,7 @@ pub fn trait_method_of_method(tcx: ctxt,
 /// Creates a hash of the type `t` which will be the same no matter what crate
 /// context it's calculated within. This is used by the `type_id` intrinsic.
 pub fn hash_crate_independent(tcx: ctxt, t: t, local_hash: ~str) -> u64 {
-    let mut state = sip::SipState::new(0, 0);
+    let mut state = sip::SipState::new();
     macro_rules! byte( ($b:expr) => { ($b as u8).hash(&mut state) } );
     macro_rules! hash( ($e:expr) => { $e.hash(&mut state) } );
 

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -20,7 +20,11 @@ Core encoding and decoding interfaces.
 #[license = "MIT/ASL2"];
 #[allow(missing_doc)];
 #[forbid(non_camel_case_types)];
-#[feature(macro_rules,managed_boxes)];
+#[feature(macro_rules, managed_boxes, default_type_params)];
+
+// NOTE remove the following two attributes after the next snapshot.
+#[allow(unrecognized_lint)];
+#[allow(default_type_param_usage)];
 
 // test harness access
 #[cfg(test)]

--- a/src/libstd/hash/sip.rs
+++ b/src/libstd/hash/sip.rs
@@ -24,7 +24,9 @@
  * discouraged.
  */
 
+use clone::Clone;
 use container::Container;
+use default::Default;
 use io::{IoResult, Writer};
 use iter::Iterator;
 use result::Ok;
@@ -81,7 +83,13 @@ macro_rules! compress (
 impl SipState {
     /// Create a `SipState` that is keyed off the provided keys.
     #[inline]
-    pub fn new(key0: u64, key1: u64) -> SipState {
+    pub fn new() -> SipState {
+        SipState::new_with_keys(0, 0)
+    }
+
+    /// Create a `SipState` that is keyed off the provided keys.
+    #[inline]
+    pub fn new_with_keys(key0: u64, key1: u64) -> SipState {
         let mut state = SipState {
             k0: key0,
             k1: key1,
@@ -206,7 +214,22 @@ impl Writer for SipState {
     }
 }
 
-/// `Sip` computes the SipHash algorithm from a stream of bytes.
+impl Clone for SipState {
+    #[inline]
+    fn clone(&self) -> SipState {
+        *self
+    }
+}
+
+impl Default for SipState {
+    #[inline]
+    fn default() -> SipState {
+        SipState::new()
+    }
+}
+
+/// `SipHasher` computes the SipHash algorithm from a stream of bytes.
+#[deriving(Clone)]
 pub struct SipHasher {
     priv state: SipState,
 }
@@ -215,14 +238,16 @@ impl SipHasher {
     /// Create a `Sip`.
     #[inline]
     pub fn new() -> SipHasher {
-        SipHasher::new_with_keys(0, 0)
+        SipHasher {
+            state: SipState::new(),
+        }
     }
 
     /// Create a `Sip` that is keyed off the provided keys.
     #[inline]
     pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
         SipHasher {
-            state: SipState::new(key0, key1),
+            state: SipState::new_with_keys(key0, key1),
         }
     }
 }
@@ -230,23 +255,31 @@ impl SipHasher {
 impl Hasher<SipState> for SipHasher {
     #[inline]
     fn hash<T: Hash<SipState>>(&self, value: &T) -> u64 {
-        let mut state = self.state; // implicitly copy the state.
+        let mut state = self.state.clone();
         value.hash(&mut state);
         state.result()
     }
 }
 
+impl Default for SipHasher {
+    #[inline]
+    fn default() -> SipHasher {
+        SipHasher::new()
+    }
+}
 
 /// Hash a value using the SipHash algorithm.
 #[inline]
 pub fn hash<T: Hash<SipState>>(value: &T) -> u64 {
-    hash_with_keys(0, 0, value)
+    let mut state = SipState::new();
+    value.hash(&mut state);
+    state.result()
 }
 
 /// Hash a value with the SipHash algorithm with the provided keys.
 #[inline]
 pub fn hash_with_keys<T: Hash<SipState>>(k0: u64, k1: u64, value: &T) -> u64 {
-    let mut state = SipState::new(k0, k1);
+    let mut state = SipState::new_with_keys(k0, k1);
     value.hash(&mut state);
     state.result()
 }
@@ -350,8 +383,8 @@ mod tests {
         let k1 = 0x_0f_0e_0d_0c_0b_0a_09_08_u64;
         let mut buf : ~[u8] = ~[];
         let mut t = 0;
-        let mut state_inc = SipState::new(k0, k1);
-        let mut state_full = SipState::new(k0, k1);
+        let mut state_inc = SipState::new_with_keys(k0, k1);
+        let mut state_full = SipState::new_with_keys(k0, k1);
 
         fn to_hex_str(r: &[u8, ..8]) -> ~str {
             let mut s = ~"";

--- a/src/libstd/hash/sip.rs
+++ b/src/libstd/hash/sip.rs
@@ -231,23 +231,23 @@ impl Default for SipState {
 /// `SipHasher` computes the SipHash algorithm from a stream of bytes.
 #[deriving(Clone)]
 pub struct SipHasher {
-    priv state: SipState,
+    priv k0: u64,
+    priv k1: u64,
 }
 
 impl SipHasher {
     /// Create a `Sip`.
     #[inline]
     pub fn new() -> SipHasher {
-        SipHasher {
-            state: SipState::new(),
-        }
+        SipHasher::new_with_keys(0, 0)
     }
 
     /// Create a `Sip` that is keyed off the provided keys.
     #[inline]
     pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
         SipHasher {
-            state: SipState::new_with_keys(key0, key1),
+            k0: key0,
+            k1: key1,
         }
     }
 }
@@ -255,7 +255,7 @@ impl SipHasher {
 impl Hasher<SipState> for SipHasher {
     #[inline]
     fn hash<T: Hash<SipState>>(&self, value: &T) -> u64 {
-        let mut state = self.state.clone();
+        let mut state = SipState::new_with_keys(self.k0, self.k1);
         value.hash(&mut state);
         state.result()
     }


### PR DESCRIPTION
This PR allows `HashMap`s to work with custom hashers. Also with this patch are:
- a couple generic implementations of `Hash` for a variety of types.
- added `Default`, `Clone` impls to the hashers.
- added a `HashMap::with_hasher()` constructor.
