### PR TITLE
Add new target 'make dist-osx' to create a .pkg installer for OS X

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -107,7 +107,7 @@ distcheck: dist
 
 else
 
-dist: $(PKG_TAR)
+dist: $(PKG_TAR) $(PKG_OSX)
 
 distcheck: $(PKG_TAR)
 	$(Q)rm -Rf dist
@@ -133,7 +133,7 @@ ifeq ($(CFG_OSTYPE), apple-darwin)
 
 dist-prepare-osx: PREPARE_HOST=$(CFG_BUILD)
 dist-prepare-osx: PREPARE_TARGETS=$(CFG_BUILD)
-dist-prepare-osx: PREPARE_DEST_DIR=pkgroot
+dist-prepare-osx: PREPARE_DEST_DIR=tmp/dist/pkgroot
 dist-prepare-osx: PREPARE_STAGE=2
 dist-prepare-osx: PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-prepare-osx: PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
@@ -143,9 +143,9 @@ dist-prepare-osx: prepare-base
 
 $(PKG_OSX): Distribution.xml LICENSE.txt dist-prepare-osx
 	@$(call E, making OS X pkg)
-	$(Q)pkgbuild --identifier org.rust-lang.rust --root pkgroot rust.pkg
+	$(Q)pkgbuild --identifier org.rust-lang.rust --root tmp/dist/pkgroot rust.pkg
 	$(Q)productbuild --distribution Distribution.xml --resources . $(PKG_OSX)
-	$(Q)rm -rf pkgroot rust.pkg
+	$(Q)rm -rf tmp rust.pkg
 
 dist-osx: $(PKG_OSX)
 

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -12,6 +12,10 @@ PKG_ICO = $(S)src/etc/pkg/rust-logo.ico
 PKG_EXE = $(PKG_DIR)-install.exe
 endif
 
+ifeq ($(CFG_OSTYPE), apple-darwin)
+PKG_OSX = $(PKG_DIR).pkg
+endif
+
 PKG_GITMODULES := $(S)src/libuv $(S)src/llvm $(S)src/gyp $(S)src/compiler-rt
 
 PKG_FILES := \
@@ -41,10 +45,10 @@ PKG_FILES := \
 
 UNROOTED_PKG_FILES := $(patsubst $(S)%,./%,$(PKG_FILES))
 
-ifdef CFG_ISCC
 LICENSE.txt: $(S)COPYRIGHT $(S)LICENSE-APACHE $(S)LICENSE-MIT
 	cat $^ > $@
 
+ifdef CFG_ISCC
 %.iss: $(S)src/etc/pkg/%.iss
 	cp $< $@
 
@@ -121,6 +125,34 @@ distcheck: $(PKG_TAR)
 	@echo
 	@echo -----------------------------------------------
 	@echo $(PKG_TAR) ready for distribution
+	@echo -----------------------------------------------
+
+endif
+
+ifeq ($(CFG_OSTYPE), apple-darwin)
+
+dist-prepare-osx: PREPARE_HOST=$(CFG_BUILD)
+dist-prepare-osx: PREPARE_TARGETS=$(CFG_BUILD)
+dist-prepare-osx: PREPARE_DEST_DIR=pkgroot
+dist-prepare-osx: PREPARE_STAGE=2
+dist-prepare-osx: PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
+dist-prepare-osx: PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
+dist-prepare-osx: PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
+dist-prepare-osx: PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
+dist-prepare-osx: prepare-base
+
+$(PKG_OSX): Distribution.xml LICENSE.txt dist-prepare-osx
+	@$(call E, making OS X pkg)
+	$(Q)pkgbuild --identifier org.rust-lang.rust --root pkgroot rust.pkg
+	$(Q)productbuild --distribution Distribution.xml --resources . $(PKG_OSX)
+	$(Q)rm -rf pkgroot rust.pkg
+
+dist-osx: $(PKG_OSX)
+
+distcheck-osx: $(PKG_OSX)
+	@echo
+	@echo -----------------------------------------------
+	@echo $(PKG_OSX) ready for distribution
 	@echo -----------------------------------------------
 
 endif

--- a/src/etc/pkg/Distribution.xml
+++ b/src/etc/pkg/Distribution.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="2">
+    <title>Rust</title>
+    <license file="LICENSE.txt" mime-type="text/plain"/>
+    <pkg-ref id="org.rust-lang.rust"/>
+    <options customize="never" require-scripts="false" hostArchitectures="i386,x86_64"/>
+    <volume-check>
+        <allowed-os-versions>
+            <os-version min="10.7"/>
+        </allowed-os-versions>
+    </volume-check>
+    <choices-outline>
+        <line choice="default">
+            <line choice="org.rust-lang.rust"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="org.rust-lang.rust" visible="false">
+        <pkg-ref id="org.rust-lang.rust"/>
+    </choice>
+    <pkg-ref id="org.rust-lang.rust" version="0" onConclusion="none">rust.pkg</pkg-ref>
+</installer-gui-script>


### PR DESCRIPTION
This adds a new make target 'dist-osx' to create a .pkg installer for OS X, working toward #9876. This of course only works on OS X.
