### PR TITLE
Update LLVM

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -166,7 +166,7 @@ LLVMRustWriteOutputFile(LLVMTargetMachineRef Target,
   PassManager *PM = unwrap<PassManager>(PMR);
 
   std::string ErrorInfo;
-  raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_Binary);
+  raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_None);
   if (ErrorInfo != "") {
     LLVMRustError = ErrorInfo.c_str();
     return false;
@@ -184,7 +184,7 @@ LLVMRustPrintModule(LLVMPassManagerRef PMR,
                     const char* path) {
   PassManager *PM = unwrap<PassManager>(PMR);
   std::string ErrorInfo;
-  raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_Binary);
+  raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_None);
   formatted_raw_ostream FOS(OS);
   PM->add(createPrintModulePass(FOS));
   PM->run(*unwrap(M));

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2014-02-11
+2014-02-25


### PR DESCRIPTION
Upstream LLVM has changed slightly such that our PassWrapper.cpp no longer
comiles (travis errors). This updates the bundled LLVM to the latest nightly
which will hopefully fix the travis errors we're seeing.
