### PR TITLE
Implement Container for some Reader/Writers

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -113,6 +113,12 @@ impl<R: Reader> Reader for BufferedReader<R> {
     }
 }
 
+impl<R: Container> Container for BufferedReader<R> {
+    fn len(&self) -> uint {
+        self.inner.len()
+    }
+}
+
 /// Wraps a Writer and buffers output to it
 ///
 /// Note that `BufferedWriter` will NOT flush its buffer when dropped.
@@ -200,6 +206,12 @@ impl<W: Writer> Writer for BufferedWriter<W> {
     }
 }
 
+impl<W: Container> Container for BufferedWriter<W> {
+    fn len(&self) -> uint {
+        self.inner.len()
+    }
+}
+
 /// Wraps a Writer and buffers output to it, flushing whenever a newline (`0x0a`,
 /// `'\n'`) is detected.
 ///
@@ -245,6 +257,12 @@ impl<W: Writer> Writer for LineBufferedWriter<W> {
     fn flush(&mut self) -> IoResult<()> { self.inner.flush() }
 }
 
+impl<W: Container> Container for LineBufferedWriter<W> {
+    fn len(&self) -> uint {
+        self.inner.len()
+    }
+}
+
 struct InternalBufferedWriter<W>(BufferedWriter<W>);
 
 impl<W> InternalBufferedWriter<W> {
@@ -257,6 +275,13 @@ impl<W> InternalBufferedWriter<W> {
 impl<W: Reader> Reader for InternalBufferedWriter<W> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         self.get_mut_ref().inner.read(buf)
+    }
+}
+
+impl<W: Container> Container for InternalBufferedWriter<W> {
+    fn len(&self) -> uint {
+        let InternalBufferedWriter(ref inner) = *self;
+        inner.len()
     }
 }
 
@@ -341,6 +366,12 @@ impl<S: Stream> Writer for BufferedStream<S> {
     }
     fn flush(&mut self) -> IoResult<()> {
         self.inner.inner.get_mut_ref().flush()
+    }
+}
+
+impl<S: Container> Container for BufferedStream<S> {
+    fn len(&self) -> uint {
+        self.inner.len()
     }
 }
 

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -360,6 +360,7 @@ mod test {
     use super::*;
     use io::*;
     use io;
+    use container::Container;
 
     #[test]
     fn test_mem_writer() {
@@ -576,5 +577,24 @@ mod test {
         let mut buf = [0];
         let mut r = BufWriter::new(buf);
         assert!(r.seek(-1, SeekSet).is_err());
+    }
+
+    #[test]
+    fn len() {
+        let buf = [0xff];
+        let r = BufReader::new(buf);
+        assert_eq!(r.len(), buf.len());
+
+        let r = MemReader::new(~[10]);
+        assert_eq!(r.len(), 1);
+
+        let mut r = MemWriter::new();
+        let str = "abc";
+        r.write_str(str).unwrap();
+        assert_eq!(r.len(), str.len());
+
+        let mut buf = [0];
+        let r = BufWriter::new(buf);
+        assert_eq!(r.len(), 1);
     }
 }

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -119,6 +119,12 @@ impl Seek for MemWriter {
     }
 }
 
+impl Container for MemWriter {
+    fn len(&self) -> uint {
+        self.buf.len()
+    }
+}
+
 /// Reads from an owned byte vector
 ///
 /// # Example
@@ -200,6 +206,12 @@ impl Buffer for MemReader {
     fn consume(&mut self, amt: uint) { self.pos += amt; }
 }
 
+impl Container for MemReader {
+    fn len(&self) -> uint {
+        self.buf.len()
+    }
+}
+
 /// Writes to a fixed-size byte slice
 ///
 /// If a write will not fit in the buffer, it returns an error and does not
@@ -256,6 +268,12 @@ impl<'a> Seek for BufWriter<'a> {
         let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
         Ok(())
+    }
+}
+
+impl<'a> Container for BufWriter<'a> {
+    fn len(&self) -> uint {
+        self.buf.len()
     }
 }
 
@@ -328,6 +346,12 @@ impl<'a> Buffer for BufReader<'a> {
         }
     }
     fn consume(&mut self, amt: uint) { self.pos += amt; }
+}
+
+impl<'a> Container for BufReader<'a> {
+    fn len(&self) -> uint {
+        self.buf.len()
+    }
 }
 
 #[cfg(test)]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -677,6 +677,12 @@ impl<'a, R: Reader> Reader for RefReader<'a, R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { self.inner.read(buf) }
 }
 
+impl<'a, R: Container> Container for RefReader<'a, R> {
+    fn len(&self) -> uint {
+        self.inner.len()
+    }
+}
+
 fn extend_sign(val: u64, nbytes: uint) -> i64 {
     let shift = (8 - nbytes) * 8;
     (val << shift) as i64 >> shift
@@ -884,6 +890,12 @@ pub struct RefWriter<'a, W> {
 impl<'a, W: Writer> Writer for RefWriter<'a, W> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.inner.write(buf) }
     fn flush(&mut self) -> IoResult<()> { self.inner.flush() }
+}
+
+impl<'a, W: Container> Container for RefWriter<'a, W> {
+    fn len(&self) -> uint {
+        self.inner.len()
+    }
 }
 
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1322,3 +1322,24 @@ pub static UserExec: FilePermission = UserDir;
 
 /// A mask for all possible permission bits
 pub static AllPermissions: FilePermission = 0x1ff;
+
+#[cfg(test)]
+mod tests {
+    use prelude::*;
+    use io::*;
+    use io::mem::{BufReader, BufWriter};
+    use container::Container;
+
+    #[test]
+    fn len() {
+        let buf = [0xff];
+        let mut r = BufReader::new(buf);
+        let r = r.by_ref();
+        assert_eq!(r.len(), buf.len());
+
+        let mut buf = [0];
+        let mut r = BufWriter::new(buf);
+        let r = r.by_ref();
+        assert_eq!(r.len(), 1);
+    }
+}

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,7 @@
 
 use prelude::*;
 use cmp;
+use container::Container;
 use io;
 use vec::bytes::MutableByteVector;
 
@@ -49,6 +50,12 @@ impl<R: Reader> Reader for LimitReader<R> {
             self.limit -= len;
             len
         })
+    }
+}
+
+impl<R> Container for LimitReader<R> {
+    fn len(&self) -> uint {
+        self.limit
     }
 }
 

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -206,6 +206,7 @@ mod test {
     use io::{MemReader, MemWriter};
     use super::*;
     use prelude::*;
+    use container::Container;
 
     #[test]
     fn test_limit_reader_unlimited() {
@@ -311,5 +312,12 @@ mod test {
         let mut w = MemWriter::new();
         copy(&mut r, &mut w).unwrap();
         assert_eq!(~[0, 1, 2, 3, 4], w.unwrap());
+    }
+
+    #[test]
+    fn len() {
+        let r = MemReader::new(~[0, 1, 2, 4]);
+        let r = LimitReader::new(r, 3);
+        assert_eq!(r.len(), 3);
     }
 }


### PR DESCRIPTION
It seems useful to have the ability to query the length of some Reader/Writers. I implemented it for Reader/Writers for which it made the most sense to me. E.g. I omitted TeeReader as it's not clear what length would refer to in that case.

Notably missing is the implementation of this for File, but I don't know if it can be done in general, as the stat function can fail. Maybe this isn't the right approach at all and a new trait is required (akin to Iterator's `size_hint`).

My use case, incidentally, is to pass a Rust Reader/Writer to a C library custom file interface which, amongst other things, requires me to report the size of the 'file'.
