### PR TITLE
rustc: Explicitly mention type params with missing `'static` bounds

### DIFF
--- a/src/test/compile-fail/owned-ptr-static-bound.rs
+++ b/src/test/compile-fail/owned-ptr-static-bound.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait A<T> {}
+struct B<'a, T>(&'a A<T>);
+
+trait X {}
+impl<'a, T> X for B<'a, T> {}
+
+fn f<'a, T, U>(v: ~A<T>) -> ~X: {
+    ~B(v) as ~X: //~ ERROR value may contain references; add `'static` bound to `T`
+}
+
+fn g<'a, T, U>(v: ~A<U>) -> ~X: {
+    ~B(v) as ~X: //~ ERROR value may contain references; add `'static` bound to `U`
+}
+
+fn h<'a, T: 'static>(v: ~A<T>) -> ~X: {
+    ~B(v) as ~X: // ok
+}
+
+fn main() {}
+


### PR DESCRIPTION
This is inspired by the [question](http://www.reddit.com/r/rust/comments/1yy57k/unsolved_question_from_irc/) (re-)posted to /r/rust. The error message in this question correctly states that one should add `'static` to the trait bounds, but does not state which trait bounds. This PR makes that explicit by appending two words.

This also renames `check_durable` to `check_static` and removes the outdated comment as a cleanup.
