### PR TITLE
Upgrade LLVM again

### DIFF
--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -107,12 +107,16 @@ LLVMRustDisposeTargetMachine(LLVMTargetMachineRef TM) {
 // passes for a target to a pass manager. We export that functionality through
 // this function.
 extern "C" void
-LLVMRustAddAnalysisPasses(LLVMTargetMachineRef TM,
-                          LLVMPassManagerRef PMR,
-                          LLVMModuleRef M) {
-    PassManagerBase *PM = unwrap(PMR);
-    PM->add(new DataLayout(unwrap(M)));
-    unwrap(TM)->addAnalysisPasses(*PM);
+LLVMRustAddAnalysisPasses(LLVMTargetMachineRef LTM,
+                          LLVMPassManagerRef LPM,
+                          LLVMModuleRef LM) {
+    PassManagerBase *PM = unwrap(LPM);
+    Module *M = unwrap(LM);
+    TargetMachine *TM = unwrap(LTM);
+
+    M->setDataLayout(TM->getDataLayout());
+    PM->add(new DataLayoutPass(M));
+    TM->addAnalysisPasses(*PM);
 }
 
 // Unfortunately, the LLVM C API doesn't provide a way to set the `LibraryInfo`

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2014-02-25
+2014-02-26


### PR DESCRIPTION
It appears that LLVM has made another breaking change to our `PassWrapper.cpp` file, causing our travis builds to break. This appears to be breaking more frequently than I had anticipated, which is unfortunate.

I looked into installing and using LLVM 3.4 from their nightly repos (which is claimed to be stable), but apparently the llvm-3.4 package is missing from the repos, so it wasn't much of a success.

I'm curious what others' opinions on this are. I'm not a big fan of building LLVM all the time, but I also like having travis builds...
