### PR TITLE
rustc: Move local native libs back in link-args

### DIFF
--- a/src/test/run-make/issue-12446/Makefile
+++ b/src/test/run-make/issue-12446/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all: $(call STATICLIB,foo)
+	$(RUSTC) foo.rs
+	$(RUSTC) bar.rs
+	$(call RUN,bar)

--- a/src/test/run-make/issue-12446/bar.rs
+++ b/src/test/run-make/issue-12446/bar.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;
+
+#[link(name = "foo")]
+extern {}
+
+fn main() {
+    foo::foo();
+}

--- a/src/test/run-make/issue-12446/foo.c
+++ b/src/test/run-make/issue-12446/foo.c
@@ -1,0 +1,1 @@
+void some_c_symbol() {}

--- a/src/test/run-make/issue-12446/foo.rs
+++ b/src/test/run-make/issue-12446/foo.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type = "rlib"];
+
+extern {
+    fn some_c_symbol();
+}
+
+pub fn foo() {
+    unsafe { some_c_symbol() }
+}


### PR DESCRIPTION
With linkers on unix systems, libraries on the right of the command line are
used to resolve symbols in those on the left of the command line. This means
that arguments must have a right-to-left dependency chain (things on the left
depend on things on the right).

This is currently done by ordering the linker arguments as
1. Local object
2. Local native libraries
3. Upstream rust libraries
4. Upstream native libraries

This commit swaps the order of 2 and 3 so upstream rust libraries have access to
local native libraries. It has been seen that some upstream crates don't specify
the library that they link to because the name varies per platform (e.g.
lua/glfw/etc).

This commit enables building these libraries by allowing the upstream rust crate
to have access to local native libraries. I believe that the failure mode for
this scheme is when an upstream rust crate depends on a symbol in an upstream
library which is then redefined in a local library. This failure mode is
incredibly uncommon, and the failure mode also varies per platform (OSX behaves
differently), so I believe that a change like this is fine to make.

Closes #12446
