### PR TITLE
Enable rust to build with LLVM 3.3/3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,32 +3,23 @@
 # it treats unknown languages as ruby-like I believe.
 language: c
 
-# Before we start doing anything, install the latest stock LLVM. These are
-# maintained by LLVM, and more information can be found at llvm.org/apt.
-#
-# Right now, the highest version is 3.5, and our SVN version is roughly aligned
-# with the 3.5 API (hurray!)
+# Before we start doing anything, install a stock LLVM
 install:
-  - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
-  - sudo sh -c "echo 'deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
-  - sudo sh -c "echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main' >> /etc/apt/sources.list"
-  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes -qq llvm-3.5 llvm-3.5-dev clang-3.5 lldb-3.5
+  - sudo apt-get install llvm-3.3 llvm-3.3-dev clang-3.3 lldb-3.3
 
-# All of the llvm tools are suffixed with "-3.5" which we don't want, so symlink
+# All of the llvm tools are suffixed with "-3.3" which we don't want, so symlink
 # them all into a local directory and just use that
 #
 # FIXME: this shouldn't update the src/llvm sub-repo, that takes about a minute
 #        it's gotta download so much stuff.
 before_script:
   - mkdir -p local-llvm/bin
-  - ln -nsf /usr/bin/llvm-config-3.5 local-llvm/bin/llvm-config
-  - ln -nsf /usr/bin/llvm-mc-3.5 local-llvm/bin/llvm-mc
-  - ln -nsf /usr/bin/llvm-as-3.5 local-llvm/bin/llvm-as
-  - ln -nsf /usr/bin/llvm-dis-3.5 local-llvm/bin/llvm-dis
-  - ln -nsf /usr/bin/llc-3.5 local-llvm/bin/llc
-  - ln -nsf /usr/include/llvm-3.5 local-llvm/include
+  - ln -nsf /usr/bin/llvm-config-3.3 local-llvm/bin/llvm-config
+  - ln -nsf /usr/bin/llvm-mc-3.3 local-llvm/bin/llvm-mc
+  - ln -nsf /usr/bin/llvm-as-3.3 local-llvm/bin/llvm-as
+  - ln -nsf /usr/bin/llvm-dis-3.3 local-llvm/bin/llvm-dis
+  - ln -nsf /usr/bin/llc-3.3 local-llvm/bin/llc
+  - ln -nsf /usr/include/llvm-3.3 local-llvm/include
   - ./configure --disable-optimize-tests --llvm-root=`pwd`/local-llvm --enable-fast-make --enable-clang
 
 # Tidy everything up first, then build a few things, and then run a few tests.

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -166,7 +166,11 @@ LLVMRustWriteOutputFile(LLVMTargetMachineRef Target,
   PassManager *PM = unwrap<PassManager>(PMR);
 
   std::string ErrorInfo;
+#if LLVM_VERSION_MINOR >= 4
   raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_None);
+#else
+  raw_fd_ostream OS(path, ErrorInfo, raw_fd_ostream::F_Binary);
+#endif
   if (ErrorInfo != "") {
     LLVMRustError = ErrorInfo.c_str();
     return false;
@@ -184,9 +188,21 @@ LLVMRustPrintModule(LLVMPassManagerRef PMR,
                     const char* path) {
   PassManager *PM = unwrap<PassManager>(PMR);
   std::string ErrorInfo;
+
+#if LLVM_VERSION_MINOR >= 4
   raw_fd_ostream OS(path, ErrorInfo, sys::fs::F_None);
+#else
+  raw_fd_ostream OS(path, ErrorInfo, raw_fd_ostream::F_Binary);
+#endif
+
   formatted_raw_ostream FOS(OS);
+
+#if LLVM_VERSION_MINOR >= 5
   PM->add(createPrintModulePass(FOS));
+#else
+  PM->add(createPrintModulePass(&FOS));
+#endif
+
   PM->run(*unwrap(M));
 }
 

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -16,7 +16,6 @@
 #include "llvm/PassManager.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/Analysis/Passes.h"
 #include "llvm/Analysis/Lint.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -51,6 +50,12 @@
 #include "llvm-c/BitReader.h"
 #include "llvm-c/ExecutionEngine.h"
 #include "llvm-c/Object.h"
+
+#if LLVM_VERSION_MINOR >= 5
+#include "llvm/IR/IRPrintingPasses.h"
+#else
+#include "llvm/Assembly/PrintModulePass.h"
+#endif
 
 // Used by RustMCJITMemoryManager::getPointerToNamedFunction()
 // to get around glibc issues. See the function for more information.


### PR DESCRIPTION
In doing so, revert travis to not using a 3.5 build because it seems to be changing enough that it's breaking our C++ glue frequently enough.
