### PR TITLE
Fix a pretty printer crash on `/***`.

### DIFF
--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -260,7 +260,7 @@ fn read_block_comment(rdr: &StringReader,
     let mut curr_line = ~"/*";
 
     // doc-comments are not really comments, they are attributes
-    if rdr.curr_is('*') || rdr.curr_is('!') {
+    if (rdr.curr_is('*') && !nextch_is(rdr, '*')) || rdr.curr_is('!') {
         while !(rdr.curr_is('*') && nextch_is(rdr, '/')) && !is_eof(rdr) {
             curr_line.push_char(rdr.curr.get().unwrap());
             bump(rdr);

--- a/src/test/pretty/block-comment-multiple-asterisks.rs
+++ b/src/test/pretty/block-comment-multiple-asterisks.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact
+/***
+More than two asterisks means that it isn't a doc comment.
+*/


### PR DESCRIPTION
The pretty printer was treating block comments with more than two
asterisks after the first slash (e.g. `/***`) as doc comments (which are
attributes), whereas in actual fact they are just regular comments.
