### PR TITLE
rustc: Remove __rust_crate_map_toplevel alias

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2641,24 +2641,6 @@ pub fn trans_crate(sess: session::Session,
     decl_gc_metadata(ccx, llmod_id);
     fill_crate_map(ccx, ccx.crate_map);
 
-    // win32: wart with exporting crate_map symbol
-    // We set the crate map (_rust_crate_map_toplevel) to use dll_export
-    // linkage but that ends up causing the linker to look for a
-    // __rust_crate_map_toplevel symbol (extra underscore) which it will
-    // subsequently fail to find. So to mitigate that we just introduce
-    // an alias from the symbol it expects to the one that actually exists.
-    if ccx.sess.targ_cfg.os == OsWin32 && !ccx.sess.building_library.get() {
-
-        let maptype = val_ty(ccx.crate_map).to_ref();
-
-        "__rust_crate_map_toplevel".with_c_str(|buf| {
-            unsafe {
-                llvm::LLVMAddAlias(ccx.llmod, maptype,
-                                   ccx.crate_map, buf);
-            }
-        })
-    }
-
     glue::emit_tydescs(ccx);
     if ccx.sess.opts.debuginfo {
         debuginfo::finalize(ccx);

--- a/src/libstd/rt/crate_map.rs
+++ b/src/libstd/rt/crate_map.rs
@@ -93,14 +93,21 @@ pub fn get_crate_map() -> Option<&'static CrateMap<'static>> {
 
     let sym = unsafe {
         let module = dl::open_internal();
-        let rust_crate_map_toplevel = if cfg!(target_arch = "x86") {
-            "__rust_crate_map_toplevel"
-        } else {
-            "_rust_crate_map_toplevel"
-        };
+        let rust_crate_map_toplevel = "_rust_crate_map_toplevel";
         let sym = rust_crate_map_toplevel.with_c_str(|buf| {
             dl::symbol(module, buf)
         });
+
+        // NOTE remove this after snapshot
+        let sym = if sym.is_null() {
+            let rust_crate_map_toplevel = "__rust_crate_map_toplevel";
+            rust_crate_map_toplevel.with_c_str(|buf| {
+                dl::symbol(module, buf)
+            })
+        } else {
+            sym
+        };
+
         dl::close(module);
         sym
     };


### PR DESCRIPTION
It was a hack to workaround llvm bug: when
`_rust_crate_map_toplevel` is dll-exported, llvm generated
`-export:__rust_crate_map_toplevel,data` where extra underscore
is due to unnecessary mangling. Then linker tries to find
`__rust_crate_map_toplevel` symbol, but it doesn't exist.
Therefore alias was added to prevent the link failure.
(See http://llvm.org/bugs/show_bug.cgi?id=10174 for details.)

It also caused LTO issue: llvm's LTO pass removes
`__rust_crate_map_toplevel` alias for some reason I don't know,
so build failed at link time.

Fixes #12471
