### PR TITLE
Miscellaneous Vim improvements

### DIFF
--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
-" Last Change:  2013 Jul 10
+" Last Change:  2014 Feb 27
 
 if exists("b:did_ftplugin")
 	finish
@@ -42,4 +42,55 @@ if exists("g:loaded_delimitMate")
 	let b:delimitMate_excluded_regions = delimitMate#Get("excluded_regions") . ',rustLifetimeCandidate,rustGenericLifetimeCandidate'
 endif
 
-let b:undo_ftplugin = "setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd< | if exists('b:rust_original_delimitMate_excluded_regions') | let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions | unlet b:rust_original_delimitMate_excluded_regions | elseif exists('b:delimitMate_excluded_regions') | unlet b:delimitMate_excluded_regions | endif"
+" Bind motion commands to support hanging indents
+nnoremap <silent> <buffer> [[ :call <SID>Rust_Jump('n', 'Back')<CR>
+nnoremap <silent> <buffer> ]] :call <SID>Rust_Jump('n', 'Forward')<CR>
+xnoremap <silent> <buffer> [[ :call <SID>Rust_Jump('v', 'Back')<CR>
+xnoremap <silent> <buffer> ]] :call <SID>Rust_Jump('v', 'Forward')<CR>
+onoremap <silent> <buffer> [[ :call <SID>Rust_Jump('o', 'Back')<CR>
+onoremap <silent> <buffer> ]] :call <SID>Rust_Jump('o', 'Forward')<CR>
+
+let b:undo_ftplugin = "
+		\setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
+		\|if exists('b:rust_original_delimitMate_excluded_regions')
+		  \|let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions
+		  \|unlet b:rust_original_delimitMate_excluded_regions
+		\|elseif exists('b:delimitMate_excluded_regions')
+		  \|unlet b:delimitMate_excluded_regions
+		\|endif
+		\|nunmap <buffer> [[
+		\|nunmap <buffer> ]]
+		\|xunmap <buffer> [[
+		\|xunmap <buffer> ]]
+		\|ounmap <buffer> [[
+		\|ounmap <buffer> ]]
+		\"
+
+if exists('*<SID>Rust_Jump') | finish | endif
+
+function! <SID>Rust_Jump(mode, function) range
+	let cnt = v:count1
+	normal! m'
+	if a:mode ==# 'v'
+		norm! gv
+	endif
+	let foldenable = &foldenable
+	set nofoldenable
+	while cnt > 0
+		execute "call <SID>Rust_Jump_" . a:function . "()"
+		let cnt = cnt - 1
+	endwhile
+	let &foldenable = foldenable
+endfunction
+
+function! <SID>Rust_Jump_Back()
+	call search('{', 'b')
+	keepjumps normal! w99[{
+endfunction
+
+function! <SID>Rust_Jump_Forward()
+	normal! j0
+	call search('{', 'b')
+	keepjumps normal! w99[{%
+	call search('{')
+endfunction

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Patrick Walton <pcwalton@mozilla.com>
 " Maintainer:   Ben Blum <bblum@cs.cmu.edu>
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
-" Last Change:  2014 Feb 14
+" Last Change:  2014 Feb 27
 
 if version < 600
   syntax clear

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -19,7 +19,7 @@ syn keyword   rustOperator    as
 syn match     rustAssert      "\<assert\(\w\)*!" contained
 syn match     rustFail        "\<fail\(\w\)*!" contained
 syn keyword   rustKeyword     break continue do
-syn keyword   rustKeyword     extern nextgroup=rustExternCrate skipwhite
+syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite
 syn keyword   rustKeyword     for in if impl let
 syn keyword   rustKeyword     loop once priv pub
 syn keyword   rustKeyword     return
@@ -35,6 +35,7 @@ syn keyword   rustObsoleteStorage const
 syn keyword   rustInvalidBareKeyword crate
 
 syn keyword   rustExternCrate crate contained nextgroup=rustIdentifier skipwhite
+syn keyword   rustObsoleteExternMod mod contained nextgroup=rustIdentifier skipwhite
 
 syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
@@ -247,6 +248,7 @@ hi def link rustObsoleteStorage Error
 hi def link rustLifetime      Special
 hi def link rustInvalidBareKeyword Error
 hi def link rustExternCrate   rustKeyword
+hi def link rustObsoleteExternMod Error
 
 " Other Suggestions:
 " hi rustAttribute ctermfg=cyan

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -18,7 +18,7 @@ syn keyword   rustOperator    as
 
 syn match     rustAssert      "\<assert\(\w\)*!" contained
 syn match     rustFail        "\<fail\(\w\)*!" contained
-syn keyword   rustKeyword     break continue do
+syn keyword   rustKeyword     break continue
 syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite
 syn keyword   rustKeyword     for in if impl let
 syn keyword   rustKeyword     loop once priv pub
@@ -41,7 +41,7 @@ syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:spac
 syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 
 " Reserved (but not yet used) keywords {{{2
-syn keyword   rustReservedKeyword alignof be offsetof pure sizeof typeof yield
+syn keyword   rustReservedKeyword alignof be do offsetof pure sizeof typeof yield
 
 " Built-in types {{{2
 syn keyword   rustType        int uint float char bool u8 u16 u32 u64 f32

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -52,8 +52,7 @@ syn keyword   rustType        f64 i8 i16 i32 i64 str Self
 " to make it easy to update.
 
 " Core operators {{{3
-syn keyword   rustTrait       Sized
-syn keyword   rustTrait       Freeze Send
+syn keyword   rustTrait       Freeze Pod Send Sized
 syn keyword   rustTrait       Add Sub Mul Div Rem Neg Not
 syn keyword   rustTrait       BitAnd BitOr BitXor
 syn keyword   rustTrait       Drop
@@ -64,32 +63,25 @@ syn keyword   rustEnum        Result
 syn keyword   rustEnumVariant Ok Err
 
 " Functions {{{3
-"syn keyword rustFunction print println
-"syn keyword rustFunction range
 "syn keyword rustFunction from_str
+"syn keyword rustFunction range
+"syn keyword rustFunction drop
 
 " Types and traits {{{3
 syn keyword rustTrait Any AnyOwnExt AnyRefExt AnyMutRefExt
 syn keyword rustTrait Ascii AsciiCast OwnedAsciiCast AsciiStr IntoBytes
-syn keyword rustTrait Bool
 syn keyword rustTrait ToCStr
 syn keyword rustTrait Char
 syn keyword rustTrait Clone DeepClone
 syn keyword rustTrait Eq Ord TotalEq TotalOrd Ordering Equiv
 syn keyword rustEnumVariant Less Equal Greater
 syn keyword rustTrait Container Mutable Map MutableMap Set MutableSet
-syn keyword rustTrait Default
-syn keyword rustTrait Hash
-syn keyword rustTrait FromStr
 syn keyword rustTrait FromIterator Extendable
 syn keyword rustTrait Iterator DoubleEndedIterator RandomAccessIterator CloneableIterator
 syn keyword rustTrait OrdIterator MutableDoubleEndedIterator ExactSize
-
-syn keyword rustTrait Algebraic Trigonometric Exponential Hyperbolic
-syn keyword rustTrait Bitwise Bounded Fractional
-syn keyword rustTrait Num NumCast CheckedAdd CheckedSub CheckedMul CheckedDiv
-syn keyword rustTrait Orderable Signed Unsigned Round
-syn keyword rustTrait Primitive Int Float ToStrRadix ToPrimitive FromPrimitive
+syn keyword rustTrait Num NumCast CheckedAdd CheckedSub CheckedMul
+syn keyword rustTrait Signed Unsigned Round
+syn keyword rustTrait Primitive Int Float ToPrimitive FromPrimitive
 syn keyword rustTrait GenericPath Path PosixPath WindowsPath
 syn keyword rustTrait RawPtr
 syn keyword rustTrait Buffer Writer Reader Seek
@@ -99,19 +91,16 @@ syn keyword rustTrait Tuple1 Tuple2 Tuple3 Tuple4
 syn keyword rustTrait Tuple5 Tuple6 Tuple7 Tuple8
 syn keyword rustTrait Tuple9 Tuple10 Tuple11 Tuple12
 syn keyword rustTrait ImmutableEqVector ImmutableTotalOrdVector ImmutableCloneableVector
-syn keyword rustTrait OwnedVector OwnedCloneableVector OwnedEqVector MutableVector
+syn keyword rustTrait OwnedVector OwnedCloneableVector OwnedEqVector
+syn keyword rustTrait MutableVector MutableTotalOrdVector
 syn keyword rustTrait Vector VectorVector CloneableVector ImmutableVector
 
 "syn keyword rustFunction stream
-syn keyword rustTrait Port Chan GenericChan GenericSmartChan GenericPort Peekable
+syn keyword rustTrait Port Chan
 "syn keyword rustFunction spawn
 
 syn keyword   rustSelf        self
 syn keyword   rustBoolean     true false
-
-syn keyword   rustConstant    Some None       " option
-syn keyword   rustConstant    Ok Err          " result
-syn keyword   rustConstant    Less Equal Greater " Ordering
 
 " Other syntax {{{2
 


### PR DESCRIPTION
- Highlight the `mod` in `extern mod x;` as Error.
- Downgrade `do` to a reserved keyword (i.e. highlight it as Error).
- Update prelude items.
- Fix Vim section movements (`[[` et al.) for standard Rust style (originally from #11492).
