### PR TITLE
Implement a lint for the use of private types in exported type signatures

### DIFF
--- a/src/libextra/workcache.rs
+++ b/src/libextra/workcache.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[allow(missing_doc)];
+#[allow(visible_private_types)];
 
 use serialize::json;
 use serialize::json::ToJson;

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -173,6 +173,7 @@
 
 // NB this does *not* include globs, please keep it that way.
 #[feature(macro_rules)];
+#[allow(visible_private_types)];
 
 use std::mem::replace;
 use std::os;

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -71,6 +71,7 @@ struct Inner {
     id: uint,
 }
 
+#[allow(visible_private_types)]
 pub enum Req {
     // Add a new timer to the helper thread.
     NewTimer(~Inner),

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -44,6 +44,7 @@ pub struct Timer {
     priv on_worker: bool,
 }
 
+#[allow(visible_private_types)]
 pub enum Req {
     NewTimer(libc::c_int, Chan<()>, bool, imp::itimerspec),
     RemoveTimer(libc::c_int, Chan<()>),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -30,6 +30,8 @@ This API is completely unstable and subject to change.
 #[feature(macro_rules, globs, struct_variant, managed_boxes)];
 #[feature(quote)];
 
+#[allow(visible_private_types)];
+
 extern crate extra;
 extern crate flate;
 extern crate arena;

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -98,6 +98,7 @@ pub enum Lint {
     UnusedMut,
     UnnecessaryAllocation,
     DeadCode,
+    VisiblePrivateTypes,
     UnnecessaryTypecast,
 
     MissingDoc,
@@ -310,6 +311,12 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
      LintSpec {
         lint: DeadCode,
         desc: "detect piece of code that will never be used",
+        default: warn
+    }),
+    ("visible_private_types",
+     LintSpec {
+        lint: VisiblePrivateTypes,
+        desc: "detect use of private types in exported type signatures",
         default: warn
     }),
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -99,7 +99,7 @@ pub enum ExternalLocation {
 }
 
 /// Different ways an implementor of a trait can be rendered.
-enum Implementor {
+pub enum Implementor {
     /// Paths are displayed specially by omitting the `impl XX for` cruft
     PathType(clean::Type),
     /// This is the generic representation of a trait implementor, used for

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -41,6 +41,7 @@ via `close` and `delete` methods.
 
 #[feature(macro_rules)];
 #[deny(unused_result, unused_must_use)];
+#[allow(visible_private_types)];
 
 #[cfg(test)] extern crate green;
 

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -1130,7 +1130,7 @@ pub mod types {
                     Data4: [BYTE, ..8],
                 }
 
-                struct WSAPROTOCOLCHAIN {
+                pub struct WSAPROTOCOLCHAIN {
                     ChainLen: c_int,
                     ChainEntries: [DWORD, ..MAX_PROTOCOL_CHAIN],
                 }

--- a/src/libstd/rt/local.rs
+++ b/src/libstd/rt/local.rs
@@ -24,6 +24,7 @@ pub trait Local<Borrowed> {
     unsafe fn try_unsafe_borrow() -> Option<*mut Self>;
 }
 
+#[allow(visible_private_types)]
 impl Local<local_ptr::Borrowed<Task>> for Task {
     #[inline]
     fn put(value: ~Task) { unsafe { local_ptr::put(value) } }
@@ -127,4 +128,3 @@ mod test {
     }
 
 }
-

--- a/src/libstd/rt/local_ptr.rs
+++ b/src/libstd/rt/local_ptr.rs
@@ -366,6 +366,7 @@ pub mod native {
 
     #[inline]
     #[cfg(not(test))]
+    #[allow(visible_private_types)]
     pub fn maybe_tls_key() -> Option<tls::Key> {
         unsafe {
             // NB: This is a little racy because, while the key is

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -280,6 +280,7 @@ fn rust_exception_class() -> uw::_Unwind_Exception_Class {
 
 #[cfg(not(target_arch = "arm"), not(test))]
 #[doc(hidden)]
+#[allow(visible_private_types)]
 pub mod eabi {
     use uw = super::libunwind;
     use libc::c_int;
@@ -333,6 +334,7 @@ pub mod eabi {
 // ARM EHABI uses a slightly different personality routine signature,
 // but otherwise works the same.
 #[cfg(target_arch = "arm", not(test))]
+#[allow(visible_private_types)]
 pub mod eabi {
     use uw = super::libunwind;
     use libc::c_int;

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -17,7 +17,7 @@
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 
-pub use arc::{Arc, MutexArc, RWArc, RWWriteMode, RWReadMode, Condvar, CowArc};
+pub use arc::{Arc, MutexArc, RWArc, RWWriteMode, RWReadMode, ArcCondvar, CowArc};
 pub use sync::{Mutex, RWLock, Condvar, Semaphore, RWLockWriteMode,
     RWLockReadMode, Barrier, one, mutex};
 pub use comm::{DuplexStream, SyncChan, SyncPort, rendezvous};

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -48,7 +48,7 @@ pub enum Architecture {
 static IntelBits: u32 = (1 << (X86 as uint)) | (1 << (X86_64 as uint));
 static ArmBits: u32 = (1 << (Arm as uint));
 
-struct AbiData {
+pub struct AbiData {
     abi: Abi,
 
     // Name of this ABI as we like it called.
@@ -59,7 +59,7 @@ struct AbiData {
     abi_arch: AbiArchitecture
 }
 
-enum AbiArchitecture {
+pub enum AbiArchitecture {
     RustArch,   // Not a real ABI (e.g., intrinsic)
     AllArch,    // An ABI that specifies cross-platform defaults (e.g., "C")
     Archs(u32)  // Multiple architectures (bitset)

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -31,6 +31,7 @@ This API is completely unstable and subject to change.
 #[feature(quote)];
 
 #[deny(non_camel_case_types)];
+#[allow(visible_private_types)];
 
 extern crate serialize;
 extern crate term;

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -193,9 +193,11 @@ fn walk_explicit_self<E: Clone, V: Visitor<E>>(visitor: &mut V,
     }
 }
 
-fn walk_trait_ref<E: Clone, V: Visitor<E>>(visitor: &mut V,
-                                           trait_ref: &TraitRef,
-                                           env: E) {
+/// Like with walk_method_helper this doesn't correspond to a method
+/// in Visitor, and so it gets a _helper suffix.
+pub fn walk_trait_ref_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                      trait_ref: &TraitRef,
+                                                      env: E) {
     visitor.visit_path(&trait_ref.path, trait_ref.ref_id, env)
 }
 
@@ -239,7 +241,8 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
                  ref methods) => {
             visitor.visit_generics(type_parameters, env.clone());
             match *trait_reference {
-                Some(ref trait_reference) => walk_trait_ref(visitor, trait_reference, env.clone()),
+                Some(ref trait_reference) => walk_trait_ref_helper(visitor,
+                                                                   trait_reference, env.clone()),
                 None => ()
             }
             visitor.visit_ty(typ, env.clone());
@@ -459,7 +462,7 @@ pub fn walk_ty_param_bounds<E: Clone, V: Visitor<E>>(visitor: &mut V,
     for bound in bounds.iter() {
         match *bound {
             TraitTyParamBound(ref typ) => {
-                walk_trait_ref(visitor, typ, env.clone())
+                walk_trait_ref_helper(visitor, typ, env.clone())
             }
             RegionTyParamBound => {}
         }

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -11,6 +11,7 @@
 #[no_std];
 #[allow(unused_variable)];
 #[allow(non_camel_case_types)];
+#[allow(visible_private_types)];
 #[deny(dead_code)];
 
 #[crate_type="lib"];

--- a/src/test/compile-fail/lint-visible-private-types.rs
+++ b/src/test/compile-fail/lint-visible-private-types.rs
@@ -1,0 +1,129 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(struct_variant)];
+#[deny(visible_private_types)];
+#[allow(dead_code)];
+#[crate_type="lib"];
+
+struct Private<T>;
+pub struct Public<T>;
+
+impl Private<Public<int>> {
+    pub fn a(&self) -> Private<int> { fail!() }
+    fn b(&self) -> Private<int> { fail!() }
+
+    pub fn c() -> Private<int> { fail!() }
+    fn d() -> Private<int> { fail!() }
+}
+impl Private<int> {
+    pub fn e(&self) -> Private<int> { fail!() }
+    fn f(&self) -> Private<int> { fail!() }
+}
+
+impl Public<Private<int>> {
+    pub fn a(&self) -> Private<int> { fail!() }
+    fn b(&self) -> Private<int> { fail!() }
+
+    pub fn c() -> Private<int> { fail!() } //~ ERROR private type in exported type signature
+    fn d() -> Private<int> { fail!() }
+}
+impl Public<int> {
+    pub fn e(&self) -> Private<int> { fail!() } //~ ERROR private type in exported type signature
+    fn f(&self) -> Private<int> { fail!() }
+}
+
+pub fn x(_: Private<int>) {} //~ ERROR private type in exported type signature
+
+fn y(_: Private<int>) {}
+
+
+pub struct Foo {
+    x: Private<int>, //~ ERROR private type in exported type signature
+    priv y: Private<int>
+}
+
+struct Bar {
+    x: Private<int>,
+}
+
+pub enum Baz {
+    Baz1(Private<int>), //~ ERROR private type in exported type signature
+    Baz2 {
+        x: Private<int>, //~ ERROR private type in exported type signature
+        priv y: Private<int>
+    },
+
+    priv Baz3(Private<int>),
+    priv Baz4 {
+        x: Private<int>,
+    }
+}
+
+enum Qux {
+    Qux1(Private<int>),
+    Qux2 {
+        x: Private<int>,
+    }
+}
+
+pub trait PubTrait {
+    fn foo(&self) -> Private<int> { fail!( )} //~ ERROR private type in exported type signature
+    fn bar(&self) -> Private<int>; //~ ERROR private type in exported type signature
+    fn baz() -> Private<int>; //~ ERROR private type in exported type signature
+}
+
+impl PubTrait for Public<int> {
+    fn bar(&self) -> Private<int> { fail!() }
+    fn baz() -> Private<int> { fail!() }
+}
+impl PubTrait for Public<Private<int>> {
+    fn bar(&self) -> Private<int> { fail!() }
+    fn baz() -> Private<int> { fail!() }
+}
+
+impl PubTrait for Private<int> {
+    fn bar(&self) -> Private<int> { fail!() }
+    fn baz() -> Private<int> { fail!() }
+}
+impl PubTrait for (Private<int>,) {
+    fn bar(&self) -> Private<int> { fail!() }
+    fn baz() -> Private<int> { fail!() }
+}
+
+
+trait PrivTrait {
+    fn foo(&self) -> Private<int> { fail!( )}
+    fn bar(&self) -> Private<int>;
+}
+impl PrivTrait for Private<int> {
+    fn bar(&self) -> Private<int> { fail!() }
+}
+impl PrivTrait for (Private<int>,) {
+    fn bar(&self) -> Private<int> { fail!() }
+}
+
+pub trait ParamTrait<T> {
+    fn foo() -> T;
+}
+
+impl ParamTrait<Private<int>> //~ ERROR private type in exported type signature
+   for Public<int> {
+    fn foo() -> Private<int> { fail!() }
+}
+
+impl ParamTrait<Private<int>> for Private<int> {
+    fn foo() -> Private<int> { fail!( )}
+}
+
+impl<T: ParamTrait<Private<int>>>  //~ ERROR private type in exported type signature
+     ParamTrait<T> for Public<i8> {
+    fn foo() -> T { fail!() }
+}


### PR DESCRIPTION
These are types that are in exported type signatures, but are not
exported themselves, e.g.

```
struct Foo { ... }

pub fn bar() -> Foo { ... }
```

will warn about the Foo.

Such types are not listed in documentation, and cannot be named outside
the crate in which they are declared, which is very user-unfriendly.

cc #10573.
