### PR TITLE
Improve the ctags function regular expression.

### DIFF
--- a/src/etc/ctags.rust
+++ b/src/etc/ctags.rust
@@ -1,6 +1,6 @@
 --langdef=Rust
 --langmap=Rust:.rs
---regex-Rust=/^[ \t]*(pub[ \t]+)?fn[ \t]+([a-zA-Z0-9_]+)/\2/f,functions,function definitions/
+--regex-Rust=/^[ \t]*(#\[[^\]]\][ \t]*)*(pub[ \t]+)?(extern[ \t]+)?("[^"]+"[ \t]+)?(unsafe[ \t]+)?fn[ \t]+([a-zA-Z0-9_]+)/\6/f,functions,function definitions/
 --regex-Rust=/^[ \t]*(pub[ \t]+)?type[ \t]+([a-zA-Z0-9_]+)/\2/T,types,type definitions/
 --regex-Rust=/^[ \t]*(pub[ \t]+)?enum[ \t]+([a-zA-Z0-9_]+)/\2/g,enum,enumeration names/
 --regex-Rust=/^[ \t]*(pub[ \t]+)?struct[ \t]+([a-zA-Z0-9_]+)/\2/s,structure names/


### PR DESCRIPTION
Before it would only catch lines starting `fn` or `pub fn`.

Now it can cope with:
- attributes (e.g. `#[test] fn`)
- external functions (e.g. `extern fn`, `extern "C" fn`)
- unsafe functions (e.g. `unsafe fn`)

… and any correct combination of these
(e.g. `#[test] extern "C" unsafe fn`).
