### PR TITLE
std: Export the select! macro

### DIFF
--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -58,22 +58,6 @@ use rt::task::{Task, BlockedTask};
 use super::Port;
 use uint;
 
-macro_rules! select {
-    (
-        $($name:pat = $port:ident.$meth:ident() => $code:expr),+
-    ) => ({
-        use std::comm::Select;
-        let sel = Select::new();
-        $( let mut $port = sel.handle(&$port); )+
-        unsafe {
-            $( $port.add(); )+
-        }
-        let ret = sel.wait();
-        $( if ret == $port.id() { let $name = $port.$meth(); $code } else )+
-        { unreachable!() }
-    })
-}
-
 /// The "port set" of the select interface. This structure is used to manage a
 /// set of ports which are being selected over.
 pub struct Select {


### PR DESCRIPTION
Mark it as #[experimental] for now. In theory this attribute will be read in the
future. I believe that the implementation is solid enough for general use,
although I would not be surprised if there were bugs in it still. I think that
it's at the point now where public usage of it will start to uncover hopefully
the last few remaining bugs.

Closes #12044
