### PR TITLE
Fix typo in doc of Binary trait in std::fmt

### DIFF
--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -580,7 +580,7 @@ pub trait Unsigned { fn fmt(&self, &mut Formatter) -> Result; }
 /// Format trait for the `o` character
 #[allow(missing_doc)]
 pub trait Octal { fn fmt(&self, &mut Formatter) -> Result; }
-/// Format trait for the `b` character
+/// Format trait for the `t` character
 #[allow(missing_doc)]
 pub trait Binary { fn fmt(&self, &mut Formatter) -> Result; }
 /// Format trait for the `x` character


### PR DESCRIPTION
Yep, that's a one-character correction in the doc ;)
Cheers,
M
