### PR TITLE
std: Improve some I/O documentation

### DIFF
--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -42,6 +42,7 @@ pub struct PortReader {
 }
 
 impl PortReader {
+    /// Wraps a `Port` in a `PortReader` structure
     pub fn new(port: Port<~[u8]>) -> PortReader {
         PortReader {
             buf: None,
@@ -96,10 +97,11 @@ impl Reader for PortReader {
 /// writer.write("hello, world".as_bytes());
 /// ```
 pub struct ChanWriter {
-    chan: Chan<~[u8]>,
+    priv chan: Chan<~[u8]>,
 }
 
 impl ChanWriter {
+    /// Wraps a channel in a `ChanWriter` structure
     pub fn new(chan: Chan<~[u8]>) -> ChanWriter {
         ChanWriter { chan: chan }
     }

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -10,6 +10,8 @@
 
 //! Utility mixins that apply to all Readers and Writers
 
+#[allow(missing_doc)];
+
 // FIXME: Not sure how this should be structured
 // FIXME: Iteration should probably be considered separately
 

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -224,6 +224,8 @@ pub struct BufWriter<'a> {
 }
 
 impl<'a> BufWriter<'a> {
+    /// Creates a new `BufWriter` which will wrap the specified buffer. The
+    /// writer initially starts at position 0.
     pub fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a> {
         BufWriter {
             buf: buf,

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -17,6 +17,8 @@ getaddrinfo()
 
 */
 
+#[allow(missing_doc)];
+
 use io::IoResult;
 use io::net::ip::{SocketAddr, IpAddr};
 use option::{Option, Some, None};

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(missing_doc)];
+
 use container::Container;
 use fmt;
 use from_str::FromStr;

--- a/src/libstd/io/net/mod.rs
+++ b/src/libstd/io/net/mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Networking I/O
+
 pub use self::addrinfo::get_host_addresses;
 
 pub mod addrinfo;

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(missing_doc)];
+
 use clone::Clone;
 use result::{Ok, Err};
 use io::net::ip::SocketAddr;

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -22,6 +22,8 @@ instances as clients.
 
 */
 
+#[allow(missing_doc)];
+
 use prelude::*;
 
 use c_str::ToCStr;

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -13,6 +13,8 @@
 //! Currently these aren't particularly useful, there only exists bindings
 //! enough so that pipes can be created to child processes.
 
+#[allow(missing_doc)];
+
 use prelude::*;
 use io::IoResult;
 use libc;
@@ -46,6 +48,7 @@ impl PipeStream {
         })
     }
 
+    #[doc(hidden)]
     pub fn new(inner: ~RtioPipe) -> PipeStream {
         PipeStream { obj: inner }
     }

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -29,6 +29,7 @@ use result::{Ok, Err};
 use rt::rtio::{IoFactory, LocalIo, RtioSignal};
 use vec::{ImmutableVector, OwnedVector};
 
+/// Signals that can be sent and received
 #[repr(int)]
 #[deriving(Eq, Hash)]
 pub enum Signum {

--- a/src/libstd/io/test.rs
+++ b/src/libstd/io/test.rs
@@ -121,6 +121,7 @@ fn base_port() -> u16 {
     return final_base;
 }
 
+/// Raises the file descriptor limit when running tests if necessary
 pub fn raise_fd_limit() {
     unsafe { darwin_fd_limit::raise_fd_limit() }
 }

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -15,33 +15,52 @@ Synchronous Timers
 This module exposes the functionality to create timers, block the current task,
 and create ports which will receive notifications after a period of time.
 
-# Example
-
-```rust,ignore
-
-use std::io::Timer;
-
-let mut timer = Timer::new().unwrap();
-timer.sleep(10); // block the task for awhile
-
-let timeout = timer.oneshot(10);
-// do some work
-timeout.recv(); // wait for the timeout to expire
-
-let periodic = timer.periodic(10);
-loop {
-    periodic.recv();
-    // this loop is only executed once every 10ms
-}
-
-```
-
 */
 
 use comm::Port;
 use rt::rtio::{IoFactory, LocalIo, RtioTimer};
 use io::IoResult;
 
+/// A synchronous timer object
+///
+/// Values of this type can be used to put the current task to sleep for a
+/// period of time. Handles to this timer can also be created in the form of
+/// ports which will receive notifications over time.
+///
+/// # Example
+///
+/// ```
+/// # fn main() {}
+/// # fn foo() {
+/// use std::io::Timer;
+///
+/// let mut timer = Timer::new().unwrap();
+/// timer.sleep(10); // block the task for awhile
+///
+/// let timeout = timer.oneshot(10);
+/// // do some work
+/// timeout.recv(); // wait for the timeout to expire
+///
+/// let periodic = timer.periodic(10);
+/// loop {
+///     periodic.recv();
+///     // this loop is only executed once every 10ms
+/// }
+/// # }
+/// ```
+///
+/// If only sleeping is necessary, then a convenience api is provided through
+/// the `io::timer` module.
+///
+/// ```
+/// # fn main() {}
+/// # fn foo() {
+/// use std::io::timer;
+///
+/// // Put this task to sleep for 5 seconds
+/// timer::sleep(5000);
+/// # }
+/// ```
 pub struct Timer {
     priv obj: ~RtioTimer
 }


### PR DESCRIPTION
This lowers the #[allow(missing_doc)] directive into some of the lower modules
which are less mature. Most I/O modules now require comprehensive documentation.
