### PR TITLE
std: A few code size optimizations

### DIFF
--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -470,7 +470,7 @@ fn spawn_process_os(config: p::ProcessConfig,
                 Err(e) => {
                     assert!(e.kind == io::BrokenPipe ||
                             e.kind == io::EndOfFile,
-                            "unexpected error: {:?}", e);
+                            "unexpected error: {}", e);
                     Ok(SpawnProcessResult {
                         pid: pid,
                         handle: ptr::null()
@@ -744,7 +744,7 @@ fn waitpid(pid: pid_t) -> p::ProcessExit {
 
         let mut status = 0 as c_int;
         match retry(|| unsafe { wait::waitpid(pid, &mut status, 0) }) {
-            -1 => fail!("unknown waitpid error: {:?}", super::last_error()),
+            -1 => fail!("unknown waitpid error: {}", super::last_error()),
             _ => {
                 if imp::WIFEXITED(status) {
                     p::ExitStatus(imp::WEXITSTATUS(status) as int)

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -149,7 +149,14 @@ macro_rules! fail(
         // function to pass to format_args!, *and* we need the
         // file and line numbers right here; so an inner bare fn
         // is our only choice.
-        #[inline]
+        //
+        // LLVM doesn't tend to inline this, presumably because begin_unwind_fmt
+        // is #[cold] and #[inline(never)] and because this is flagged as cold
+        // as returning !. We really do want this to be inlined, however,
+        // because it's just a tiny wrapper. Small wins (156K to 149K in size)
+        // were seen when forcing this to be inlined, and that number just goes
+        // up with the number of calls to fail!()
+        #[inline(always)]
         fn run_fmt(fmt: &::std::fmt::Arguments) -> ! {
             ::std::rt::begin_unwind_fmt(fmt, file!(), line!())
         }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -532,19 +532,19 @@ pub fn from_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Div<T,T>+
         ) -> Option<T> {
     match exponent {
         ExpDec if radix >= DIGIT_E_RADIX       // decimal exponent 'e'
-          => fail!("from_str_bytes_common: radix {:?} incompatible with \
+          => fail!("from_str_bytes_common: radix {} incompatible with \
                     use of 'e' as decimal exponent", radix),
         ExpBin if radix >= DIGIT_P_RADIX       // binary exponent 'p'
-          => fail!("from_str_bytes_common: radix {:?} incompatible with \
+          => fail!("from_str_bytes_common: radix {} incompatible with \
                     use of 'p' as binary exponent", radix),
         _ if special && radix >= DIGIT_I_RADIX // first digit of 'inf'
-          => fail!("from_str_bytes_common: radix {:?} incompatible with \
+          => fail!("from_str_bytes_common: radix {} incompatible with \
                     special values 'inf' and 'NaN'", radix),
         _ if (radix as int) < 2
-          => fail!("from_str_bytes_common: radix {:?} to low, \
+          => fail!("from_str_bytes_common: radix {} to low, \
                     must lie in the range [2, 36]", radix),
         _ if (radix as int) > 36
-          => fail!("from_str_bytes_common: radix {:?} to high, \
+          => fail!("from_str_bytes_common: radix {} to high, \
                     must lie in the range [2, 36]", radix),
         _ => ()
     }

--- a/src/libstd/rt/crate_map.rs
+++ b/src/libstd/rt/crate_map.rs
@@ -123,7 +123,7 @@ fn version(crate_map: &CrateMap) -> i32 {
 
 fn do_iter_crate_map<'a>(
                      crate_map: &'a CrateMap<'a>,
-                     f: |&ModEntry|,
+                     f: |&'a ModEntry<'a>|,
                      visited: &mut ~[*CrateMap<'a>]) {
     let raw = crate_map as *CrateMap<'a>;
     if visited.bsearch(|a| (*a as uint).cmp(&(raw as uint))).is_some() {
@@ -149,7 +149,7 @@ fn do_iter_crate_map<'a>(
 }
 
 /// Iterates recursively over `crate_map` and all child crate maps
-pub fn iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: |&ModEntry|) {
+pub fn iter_crate_map<'a>(crate_map: &'a CrateMap<'a>, f: |&'a ModEntry<'a>|) {
     let mut v = ~[];
     do_iter_crate_map(crate_map, f, &mut v);
 }

--- a/src/libstd/sync/arc.rs
+++ b/src/libstd/sync/arc.rs
@@ -80,7 +80,8 @@ impl<T: Send> UnsafeArc<T> {
     #[inline]
     pub fn get(&self) -> *mut T {
         unsafe {
-            assert!((*self.data).count.load(Relaxed) > 0);
+            // FIXME(#12049): this needs some sort of debug assertion
+            if cfg!(test) { assert!((*self.data).count.load(Relaxed) > 0); }
             return &mut (*self.data).data as *mut T;
         }
     }
@@ -90,7 +91,8 @@ impl<T: Send> UnsafeArc<T> {
     #[inline]
     pub fn get_immut(&self) -> *T {
         unsafe {
-            assert!((*self.data).count.load(Relaxed) > 0);
+            // FIXME(#12049): this needs some sort of debug assertion
+            if cfg!(test) { assert!((*self.data).count.load(Relaxed) > 0); }
             return &(*self.data).data as *T;
         }
     }
@@ -109,7 +111,8 @@ impl<T: Send> Clone for UnsafeArc<T> {
         unsafe {
             // This barrier might be unnecessary, but I'm not sure...
             let old_count = (*self.data).count.fetch_add(1, Acquire);
-            assert!(old_count >= 1);
+            // FIXME(#12049): this needs some sort of debug assertion
+            if cfg!(test) { assert!(old_count >= 1); }
             return UnsafeArc { data: self.data };
         }
     }
@@ -127,7 +130,8 @@ impl<T> Drop for UnsafeArc<T>{
             // Must be acquire+release, not just release, to make sure this
             // doesn't get reordered to after the unwrapper pointer load.
             let old_count = (*self.data).count.fetch_sub(1, SeqCst);
-            assert!(old_count >= 1);
+            // FIXME(#12049): this needs some sort of debug assertion
+            if cfg!(test) { assert!(old_count >= 1); }
             if old_count == 1 {
                 let _: ~ArcData<T> = cast::transmute(self.data);
             }


### PR DESCRIPTION
I've been playing around with code size when linking to libstd recently, and these were some findings I found that really helped code size. I started out by eliminating all I/O implementations from libnative and instead just return an unimplemented error.

In doing so, a `fn main() {}` executable was ~378K before this patch, and about 170K after the patch. These size wins are all pretty minor, but they all seemed pretty reasonable to me. With native I/O not stubbed out, this takes the size of an LTO executable from 675K to 400K.
