### PR TITLE
std: Change assert_eq!() to use {} instead of {:?}

### DIFF
--- a/src/doc/guide-container.md
+++ b/src/doc/guide-container.md
@@ -384,7 +384,7 @@ the trailing underscore is a workaround for issue #5898 and will be removed.
 ~~~
 let mut ys = [1, 2, 3, 4, 5];
 ys.mut_iter().reverse_();
-assert_eq!(ys, [5, 4, 3, 2, 1]);
+assert!(ys == [5, 4, 3, 2, 1]);
 ~~~
 
 ## Random-access iterators

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1688,7 +1688,7 @@ let x = Rc::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 let y = x.clone(); // a new owner
 let z = x; // this moves `x` into `z`, rather than creating a new owner
 
-assert_eq!(*z.borrow(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+assert!(*z.borrow() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
 // the variable is mutable, but not the contents of the box
 let mut a = Rc::new([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
@@ -1707,7 +1707,7 @@ let x = Gc::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 let y = x; // does not perform a move, unlike with `Rc`
 let z = x;
 
-assert_eq!(*z.borrow(), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+assert!(*z.borrow() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 ~~~
 
 With shared ownership, mutability cannot be inherited so the boxes are always immutable. However,

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -1542,7 +1542,7 @@ mod tests {
 
         let mut b = a.clone();
 
-        assert_eq!(&a, &b);
+        assert!(a == b);
 
         assert!(b.remove(&1));
         assert!(a.contains(&1));
@@ -1561,7 +1561,7 @@ mod tests {
         let mut r = rng();
         let mut bitv = 0 as uint;
         b.iter(|| {
-            bitv |= (1 << ((r.next_u32() as uint) % uint::BITS));
+            bitv |= 1 << ((r.next_u32() as uint) % uint::BITS);
             &bitv
         })
     }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -982,11 +982,11 @@ mod tests {
     fn test_eq() {
         let mut n: DList<u8> = list_from([]);
         let mut m = list_from([]);
-        assert_eq!(&n, &m);
+        assert!(n == m);
         n.push_front(1);
         assert!(n != m);
         m.push_back(1);
-        assert_eq!(&n, &m);
+        assert!(n == m);
 
         let n = list_from([2,3,4]);
         let m = list_from([1,2,3]);

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -141,7 +141,7 @@ mod test {
 
     use enum_set::{EnumSet, CLike};
 
-    #[deriving(Eq)]
+    #[deriving(Eq, Show)]
     #[repr(uint)]
     enum Foo {
         A, B, C

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -1065,7 +1065,7 @@ mod test_map {
         let mut observed = 0;
         for (k, v) in m.iter() {
             assert_eq!(*v, *k * 2);
-            observed |= (1 << *k);
+            observed |= 1 << *k;
         }
         assert_eq!(observed, 0xFFFF_FFFF);
     }
@@ -1293,7 +1293,7 @@ mod test_set {
         }
         let mut observed = 0;
         for k in a.iter() {
-            observed |= (1 << *k);
+            observed |= 1 << *k;
         }
         assert_eq!(observed, 0xFFFF_FFFF);
     }

--- a/src/libcollections/list.rs
+++ b/src/libcollections/list.rs
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn test_from_vec_empty() {
         let empty : list::List<int> = List::from_vec([]);
-        assert_eq!(empty, Nil::<int>);
+        assert!(empty == Nil::<int>);
     }
 
     #[test]
@@ -222,8 +222,8 @@ mod tests {
 
     #[test]
     fn test_append() {
-        assert_eq!(List::from_vec([1, 2, 3, 4]),
-                   List::from_vec([1, 2]).append(List::from_vec([3, 4])));
+        assert!(List::from_vec([1, 2, 3, 4]) ==
+                List::from_vec([1, 2]).append(List::from_vec([3, 4])));
     }
 
     #[test]
@@ -232,6 +232,6 @@ mod tests {
         let new_list = list.unshift(0);
         assert_eq!(list.len(), 1u);
         assert_eq!(new_list.len(), 2u);
-        assert_eq!(new_list, List::from_vec([0, 1]));
+        assert!(new_list == List::from_vec([0, 1]));
     }
 }

--- a/src/libcollections/lru_cache.rs
+++ b/src/libcollections/lru_cache.rs
@@ -277,7 +277,7 @@ mod tests {
 
     fn assert_opt_eq<V: Eq>(opt: Option<&V>, v: V) {
         assert!(opt.is_some());
-        assert_eq!(opt.unwrap(), &v);
+        assert!(opt.unwrap() == &v);
     }
 
     #[test]

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -409,6 +409,7 @@ mod tests {
     use deque::Deque;
     use std::clone::Clone;
     use std::cmp::Eq;
+    use std::fmt::Show;
     use super::RingBuf;
 
     #[test]
@@ -493,7 +494,7 @@ mod tests {
     }
 
     #[cfg(test)]
-    fn test_parameterized<T:Clone + Eq>(a: T, b: T, c: T, d: T) {
+    fn test_parameterized<T:Clone + Eq + Show>(a: T, b: T, c: T, d: T) {
         let mut deq = RingBuf::new();
         assert_eq!(deq.len(), 0);
         deq.push_front(a.clone());
@@ -578,21 +579,21 @@ mod tests {
         })
     }
 
-    #[deriving(Clone, Eq)]
+    #[deriving(Clone, Eq, Show)]
     enum Taggy {
         One(int),
         Two(int, int),
         Three(int, int, int),
     }
 
-    #[deriving(Clone, Eq)]
+    #[deriving(Clone, Eq, Show)]
     enum Taggypar<T> {
         Onepar(int),
         Twopar(int, int),
         Threepar(int, int, int),
     }
 
-    #[deriving(Clone, Eq)]
+    #[deriving(Clone, Eq, Show)]
     struct RecCy {
         x: int,
         y: int,
@@ -812,7 +813,7 @@ mod tests {
     #[test]
     fn test_eq() {
         let mut d = RingBuf::new();
-        assert_eq!(&d, &RingBuf::with_capacity(0));
+        assert!(d == RingBuf::with_capacity(0));
         d.push_front(137);
         d.push_front(17);
         d.push_front(42);
@@ -822,11 +823,11 @@ mod tests {
         e.push_back(17);
         e.push_back(137);
         e.push_back(137);
-        assert_eq!(&e, &d);
+        assert!(&e == &d);
         e.pop_back();
         e.push_back(0);
         assert!(e != d);
         e.clear();
-        assert_eq!(e, RingBuf::new());
+        assert!(e == RingBuf::new());
     }
 }

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -1361,7 +1361,7 @@ mod tests {
                                 aliases: ~[] }];
         let verbose = reqopt("b", "banana", "some bananas", "VAL");
 
-        assert_eq!(verbose.long_to_short(), short);
+        assert!(verbose.long_to_short() == short);
     }
 
     #[test]

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -829,7 +829,7 @@ fn get_radix_base(radix: uint) -> (uint, uint) {
 }
 
 /// A Sign is a `BigInt`'s composing element.
-#[deriving(Eq, Clone)]
+#[deriving(Eq, Clone, Show)]
 pub enum Sign { Minus, Zero, Plus }
 
 impl Ord for Sign {

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -215,7 +215,7 @@ mod test {
     #[test]
     fn test_minimize1() {
         let res = minimize_rpaths([~"rpath1", ~"rpath2", ~"rpath1"]);
-        assert_eq!(res.as_slice(), [~"rpath1", ~"rpath2"]);
+        assert!(res.as_slice() == [~"rpath1", ~"rpath2"]);
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod test {
                                    ~"1a", ~"4a", ~"1a",
                                    ~"2",  ~"3",  ~"4a",
                                    ~"3"]);
-        assert_eq!(res.as_slice(), [~"1a", ~"2", ~"4a", ~"3"]);
+        assert!(res.as_slice() == [~"1a", ~"2", ~"4a", ~"3"]);
     }
 
     #[test]

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1468,7 +1468,7 @@ fn roundtrip(in_item: Option<@ast::Item>) {
     let ebml_doc = reader::Doc(wr.get_ref());
     let out_item = decode_item_ast(ebml_doc);
 
-    assert_eq!(in_item, out_item);
+    assert!(in_item == out_item);
 }
 
 #[test]

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -349,19 +349,19 @@ mod test {
                                       start_data: N,
                                       expected_incoming: &[(E,N)],
                                       expected_outgoing: &[(E,N)]) {
-        assert_eq!(graph.node_data(start_index), &start_data);
+        assert!(graph.node_data(start_index) == &start_data);
 
         let mut counter = 0;
         graph.each_incoming_edge(start_index, |edge_index, edge| {
-            assert_eq!(graph.edge_data(edge_index), &edge.data);
+            assert!(graph.edge_data(edge_index) == &edge.data);
             assert!(counter < expected_incoming.len());
             debug!("counter={:?} expected={:?} edge_index={:?} edge={:?}",
                    counter, expected_incoming[counter], edge_index, edge);
             match expected_incoming[counter] {
                 (ref e, ref n) => {
-                    assert_eq!(e, &edge.data);
-                    assert_eq!(n, graph.node_data(edge.source));
-                    assert_eq!(start_index, edge.target);
+                    assert!(e == &edge.data);
+                    assert!(n == graph.node_data(edge.source));
+                    assert!(start_index == edge.target);
                 }
             }
             counter += 1;
@@ -371,15 +371,15 @@ mod test {
 
         let mut counter = 0;
         graph.each_outgoing_edge(start_index, |edge_index, edge| {
-            assert_eq!(graph.edge_data(edge_index), &edge.data);
+            assert!(graph.edge_data(edge_index) == &edge.data);
             assert!(counter < expected_outgoing.len());
             debug!("counter={:?} expected={:?} edge_index={:?} edge={:?}",
                    counter, expected_outgoing[counter], edge_index, edge);
             match expected_outgoing[counter] {
                 (ref e, ref n) => {
-                    assert_eq!(e, &edge.data);
-                    assert_eq!(start_index, edge.source);
-                    assert_eq!(n, graph.node_data(edge.target));
+                    assert!(e == &edge.data);
+                    assert!(start_index == edge.source);
+                    assert!(n == graph.node_data(edge.target));
                 }
             }
             counter += 1;

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -25,7 +25,7 @@ use std::cast;
 
 use std::libc::{c_uint};
 
-#[deriving(Clone, Eq)]
+#[deriving(Clone, Eq, Show)]
 pub struct Type {
     priv rf: TypeRef
 }

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -761,7 +761,7 @@ impl RegionVarBindings {
 
 // ______________________________________________________________________
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum Classification { Expanding, Contracting }
 
 enum VarValue { NoValue, Value(Region), ErrorValue }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1588,20 +1588,20 @@ mod tests {
     use std::io;
     use collections::TreeMap;
 
-    #[deriving(Eq, Encodable, Decodable)]
+    #[deriving(Eq, Encodable, Decodable, Show)]
     enum Animal {
         Dog,
         Frog(~str, int)
     }
 
-    #[deriving(Eq, Encodable, Decodable)]
+    #[deriving(Eq, Encodable, Decodable, Show)]
     struct Inner {
         a: (),
         b: uint,
         c: ~[~str],
     }
 
-    #[deriving(Eq, Encodable, Decodable)]
+    #[deriving(Eq, Encodable, Decodable, Show)]
     struct Outer {
         inner: ~[Inner],
     }

--- a/src/libstd/any.rs
+++ b/src/libstd/any.rs
@@ -167,7 +167,7 @@ mod tests {
     use prelude::*;
     use super::*;
 
-    #[deriving(Eq)]
+    #[deriving(Eq, Show)]
     struct Test;
 
     static TEST: &'static str = "Test";

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -475,7 +475,7 @@ mod tests {
     use char::from_u32;
 
     macro_rules! v2ascii (
-        ( [$($e:expr),*]) => ( [$(Ascii{chr:$e}),*]);
+        ( [$($e:expr),*]) => (&[$(Ascii{chr:$e}),*]);
         (&[$($e:expr),*]) => (&[$(Ascii{chr:$e}),*]);
         (~[$($e:expr),*]) => (~[$(Ascii{chr:$e}),*]);
     )

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -293,9 +293,9 @@ mod tests {
 
     #[test]
     fn test_totalord() {
-        assert_eq!(true.cmp(&true), Equal);
-        assert_eq!(false.cmp(&false), Equal);
-        assert_eq!(true.cmp(&false), Greater);
-        assert_eq!(false.cmp(&true), Less);
+        assert!(true.cmp(&true) == Equal);
+        assert!(false.cmp(&false) == Equal);
+        assert!(true.cmp(&false) == Greater);
+        assert!(false.cmp(&true) == Less);
     }
 }

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -10,12 +10,13 @@
 
 //! Types dealing with dynamic mutability
 
+use cast;
 use clone::{Clone, DeepClone};
 use cmp::Eq;
+use fmt;
+use kinds::{marker, Pod};
 use ops::Drop;
 use option::{None, Option, Some};
-use cast;
-use kinds::{marker, Pod};
 
 /// A mutable memory location that admits only `Pod` data.
 pub struct Cell<T> {
@@ -58,6 +59,12 @@ impl<T:Pod> Clone for Cell<T> {
 impl<T:Eq + Pod> Eq for Cell<T> {
     fn eq(&self, other: &Cell<T>) -> bool {
         self.get() == other.get()
+    }
+}
+
+impl<T: fmt::Show> fmt::Show for Cell<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f.buf, r"Cell \{ value: {} \}", self.value)
     }
 }
 

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -72,7 +72,7 @@ totaleq_impl!(uint)
 
 totaleq_impl!(char)
 
-#[deriving(Clone, Eq)]
+#[deriving(Clone, Eq, Show)]
 pub enum Ordering { Less = -1, Equal = 0, Greater = 1 }
 
 /// Trait for types that form a total order

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -313,7 +313,7 @@ pub struct Chan<T> {
 
 /// This enumeration is the list of the possible reasons that try_recv could not
 /// return data when called.
-#[deriving(Eq, Clone)]
+#[deriving(Eq, Clone, Show)]
 pub enum TryRecvResult<T> {
     /// This channel is currently empty, but the sender(s) have not yet
     /// disconnected, so data may yet become available.

--- a/src/libstd/fmt/parse.rs
+++ b/src/libstd/fmt/parse.rs
@@ -657,7 +657,7 @@ mod tests {
 
     fn same(fmt: &'static str, p: ~[Piece<'static>]) {
         let mut parser = Parser::new(fmt);
-        assert_eq!(p, parser.collect());
+        assert!(p == parser.collect());
     }
 
     fn fmtdflt() -> FormatSpec<'static> {

--- a/src/libstd/intrinsics.rs
+++ b/src/libstd/intrinsics.rs
@@ -444,7 +444,7 @@ extern "rust-intrinsic" {
 /// `TypeId` represents a globally unique identifier for a type
 #[lang="type_id"] // This needs to be kept in lockstep with the code in trans/intrinsic.rs and
                   // middle/lang_items.rs
-#[deriving(Eq, Hash)]
+#[deriving(Eq, Hash, Show)]
 #[cfg(not(test))]
 pub struct TypeId {
     priv t: u64,

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -391,21 +391,21 @@ mod test {
         let mut buf = [0, 0, 0];
         let nread = reader.read(buf);
         assert_eq!(Ok(2), nread);
-        assert_eq!([0, 1, 0], buf);
+        assert_eq!(buf.as_slice(), &[0, 1, 0]);
 
         let mut buf = [0];
         let nread = reader.read(buf);
         assert_eq!(Ok(1), nread);
-        assert_eq!([2], buf);
+        assert_eq!(buf.as_slice(), &[2]);
 
         let mut buf = [0, 0, 0];
         let nread = reader.read(buf);
         assert_eq!(Ok(1), nread);
-        assert_eq!([3, 0, 0], buf);
+        assert_eq!(buf.as_slice(), &[3, 0, 0]);
 
         let nread = reader.read(buf);
         assert_eq!(Ok(1), nread);
-        assert_eq!([4, 0, 0], buf);
+        assert_eq!(buf.as_slice(), &[4, 0, 0]);
 
         assert!(reader.read(buf).is_err());
     }
@@ -416,35 +416,35 @@ mod test {
         let mut writer = BufferedWriter::with_capacity(2, inner);
 
         writer.write([0, 1]).unwrap();
-        assert_eq!([], writer.get_ref().get_ref());
+        assert_eq!(writer.get_ref().get_ref(), &[]);
 
         writer.write([2]).unwrap();
-        assert_eq!([0, 1], writer.get_ref().get_ref());
+        assert_eq!(writer.get_ref().get_ref(), &[0, 1]);
 
         writer.write([3]).unwrap();
-        assert_eq!([0, 1], writer.get_ref().get_ref());
+        assert_eq!(writer.get_ref().get_ref(), &[0, 1]);
 
         writer.flush().unwrap();
-        assert_eq!([0, 1, 2, 3], writer.get_ref().get_ref());
+        assert_eq!(&[0, 1, 2, 3], writer.get_ref().get_ref());
 
         writer.write([4]).unwrap();
         writer.write([5]).unwrap();
-        assert_eq!([0, 1, 2, 3], writer.get_ref().get_ref());
+        assert_eq!(&[0, 1, 2, 3], writer.get_ref().get_ref());
 
         writer.write([6]).unwrap();
-        assert_eq!([0, 1, 2, 3, 4, 5],
+        assert_eq!(&[0, 1, 2, 3, 4, 5],
                    writer.get_ref().get_ref());
 
         writer.write([7, 8]).unwrap();
-        assert_eq!([0, 1, 2, 3, 4, 5, 6],
+        assert_eq!(&[0, 1, 2, 3, 4, 5, 6],
                    writer.get_ref().get_ref());
 
         writer.write([9, 10, 11]).unwrap();
-        assert_eq!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
                    writer.get_ref().get_ref());
 
         writer.flush().unwrap();
-        assert_eq!([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        assert_eq!(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
                    writer.get_ref().get_ref());
     }
 
@@ -452,9 +452,9 @@ mod test {
     fn test_buffered_writer_inner_flushes() {
         let mut w = BufferedWriter::with_capacity(3, MemWriter::new());
         w.write([0, 1]).unwrap();
-        assert_eq!([], w.get_ref().get_ref());
+        assert_eq!(&[], w.get_ref().get_ref());
         let w = w.unwrap();
-        assert_eq!([0, 1], w.get_ref());
+        assert_eq!(&[0, 1], w.get_ref());
     }
 
     // This is just here to make sure that we don't infinite loop in the
@@ -495,20 +495,20 @@ mod test {
     fn test_line_buffer() {
         let mut writer = LineBufferedWriter::new(MemWriter::new());
         writer.write([0]).unwrap();
-        assert_eq!(writer.get_ref().get_ref(), []);
+        assert_eq!(writer.get_ref().get_ref(), &[]);
         writer.write([1]).unwrap();
-        assert_eq!(writer.get_ref().get_ref(), []);
+        assert_eq!(writer.get_ref().get_ref(), &[]);
         writer.flush().unwrap();
-        assert_eq!(writer.get_ref().get_ref(), [0, 1]);
+        assert_eq!(writer.get_ref().get_ref(), &[0, 1]);
         writer.write([0, '\n' as u8, 1, '\n' as u8, 2]).unwrap();
         assert_eq!(writer.get_ref().get_ref(),
-            [0, 1, 0, '\n' as u8, 1, '\n' as u8]);
+                   &[0, 1, 0, '\n' as u8, 1, '\n' as u8]);
         writer.flush().unwrap();
         assert_eq!(writer.get_ref().get_ref(),
-            [0, 1, 0, '\n' as u8, 1, '\n' as u8, 2]);
+                   &[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2]);
         writer.write([3, '\n' as u8]).unwrap();
         assert_eq!(writer.get_ref().get_ref(),
-            [0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
+            &[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
     }
 
     #[test]

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -216,7 +216,7 @@ impl Buffer for MemReader {
 ///     let mut w = BufWriter::new(buf);
 ///     w.write([0, 1, 2]);
 /// }
-/// assert_eq!(buf, [0, 1, 2, 0]);
+/// assert!(buf == [0, 1, 2, 0]);
 /// ```
 pub struct BufWriter<'a> {
     priv buf: &'a mut [u8],
@@ -348,24 +348,24 @@ mod test {
         writer.write([1, 2, 3]).unwrap();
         writer.write([4, 5, 6, 7]).unwrap();
         assert_eq!(writer.tell(), Ok(8));
-        assert_eq!(writer.get_ref(), [0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(writer.get_ref(), &[0, 1, 2, 3, 4, 5, 6, 7]);
 
         writer.seek(0, SeekSet).unwrap();
         assert_eq!(writer.tell(), Ok(0));
         writer.write([3, 4]).unwrap();
-        assert_eq!(writer.get_ref(), [3, 4, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(writer.get_ref(), &[3, 4, 2, 3, 4, 5, 6, 7]);
 
         writer.seek(1, SeekCur).unwrap();
         writer.write([0, 1]).unwrap();
-        assert_eq!(writer.get_ref(), [3, 4, 2, 0, 1, 5, 6, 7]);
+        assert_eq!(writer.get_ref(), &[3, 4, 2, 0, 1, 5, 6, 7]);
 
         writer.seek(-1, SeekEnd).unwrap();
         writer.write([1, 2]).unwrap();
-        assert_eq!(writer.get_ref(), [3, 4, 2, 0, 1, 5, 6, 1, 2]);
+        assert_eq!(writer.get_ref(), &[3, 4, 2, 0, 1, 5, 6, 1, 2]);
 
         writer.seek(1, SeekEnd).unwrap();
         writer.write([1]).unwrap();
-        assert_eq!(writer.get_ref(), [3, 4, 2, 0, 1, 5, 6, 1, 2, 0, 1]);
+        assert_eq!(writer.get_ref(), &[3, 4, 2, 0, 1, 5, 6, 1, 2, 0, 1]);
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod test {
             writer.write([4, 5, 6, 7]).unwrap();
             assert_eq!(writer.tell(), Ok(8));
         }
-        assert_eq!(buf, [0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(buf.as_slice(), &[0, 1, 2, 3, 4, 5, 6, 7]);
     }
 
     #[test]
@@ -408,7 +408,7 @@ mod test {
             assert_eq!(writer.tell(), Ok(8));
 
         }
-        assert_eq!(buf, [1, 3, 2, 0, 0, 0, 0, 4]);
+        assert_eq!(buf.as_slice(), &[1, 3, 2, 0, 0, 0, 0, 4]);
     }
 
     #[test]
@@ -432,13 +432,13 @@ mod test {
         let mut buf = [0];
         assert_eq!(reader.read(buf), Ok(1));
         assert_eq!(reader.tell(), Ok(1));
-        assert_eq!(buf, [0]);
+        assert_eq!(buf.as_slice(), &[0]);
         let mut buf = [0, ..4];
         assert_eq!(reader.read(buf), Ok(4));
         assert_eq!(reader.tell(), Ok(5));
-        assert_eq!(buf, [1, 2, 3, 4]);
+        assert_eq!(buf.as_slice(), &[1, 2, 3, 4]);
         assert_eq!(reader.read(buf), Ok(3));
-        assert_eq!(buf.slice(0, 3), [5, 6, 7]);
+        assert_eq!(buf.slice(0, 3), &[5, 6, 7]);
         assert!(reader.read(buf).is_err());
         let mut reader = MemReader::new(~[0, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(reader.read_until(3).unwrap(), ~[0, 1, 2, 3]);
@@ -456,13 +456,13 @@ mod test {
         let mut buf = [0];
         assert_eq!(reader.read(buf), Ok(1));
         assert_eq!(reader.tell(), Ok(1));
-        assert_eq!(buf, [0]);
+        assert_eq!(buf.as_slice(), &[0]);
         let mut buf = [0, ..4];
         assert_eq!(reader.read(buf), Ok(4));
         assert_eq!(reader.tell(), Ok(5));
-        assert_eq!(buf, [1, 2, 3, 4]);
+        assert_eq!(buf.as_slice(), &[1, 2, 3, 4]);
         assert_eq!(reader.read(buf), Ok(3));
-        assert_eq!(buf.slice(0, 3), [5, 6, 7]);
+        assert_eq!(buf.slice(0, 3), &[5, 6, 7]);
         assert!(reader.read(buf).is_err());
         let mut reader = BufReader::new(in_buf);
         assert_eq!(reader.read_until(3).unwrap(), ~[0, 1, 2, 3]);

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1286,7 +1286,7 @@ pub enum FileAccess {
 }
 
 /// Different kinds of files which can be identified by a call to stat
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 pub enum FileType {
     /// This is a normal file, corresponding to `S_IFREG`
     TypeFile,

--- a/src/libstd/io/result.rs
+++ b/src/libstd/io/result.rs
@@ -111,7 +111,7 @@ mod test {
             Ok(MemReader::new(~[0, 1, 2, 3]));
         let mut buf = [0, 0];
         reader.read(buf).unwrap();
-        assert_eq!(buf, [0, 1]);
+        assert_eq!(buf.as_slice(), &[0, 1]);
     }
 
     #[test]

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -31,7 +31,7 @@ use vec::{ImmutableVector, OwnedVector};
 
 /// Signals that can be sent and received
 #[repr(int)]
-#[deriving(Eq, Hash)]
+#[deriving(Eq, Hash, Show)]
 pub enum Signum {
     /// Equivalent to SIGBREAK, delivered when the user presses Ctrl-Break.
     Break = 21i,

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -983,7 +983,7 @@ impl<A: Ord, T: Iterator<A>> OrdIterator<A> for T {
 }
 
 /// `MinMaxResult` is an enum returned by `min_max`. See `OrdIterator::min_max` for more detail.
-#[deriving(Clone, Eq)]
+#[deriving(Clone, Eq, Show)]
 pub enum MinMaxResult<T> {
     /// Empty iterator
     NoElements,
@@ -2507,7 +2507,7 @@ mod tests {
                    .collect::<~[uint]>();
 
         assert_eq!(n, xs.len());
-        assert_eq!(xs, ys.as_slice());
+        assert_eq!(xs.as_slice(), ys.as_slice());
     }
 
     #[test]
@@ -2824,11 +2824,11 @@ mod tests {
         assert_eq!(len, b.indexable());
         let mut n = 0;
         for (i, elt) in a.enumerate() {
-            assert_eq!(Some(elt), b.idx(i));
+            assert!(Some(elt) == b.idx(i));
             n += 1;
         }
         assert_eq!(n, len);
-        assert_eq!(None, b.idx(n));
+        assert!(None == b.idx(n));
         // call recursively to check after picking off an element
         if len > 0 {
             b.next();
@@ -3051,7 +3051,7 @@ mod tests {
     fn test_reverse() {
         let mut ys = [1, 2, 3, 4, 5];
         ys.mut_iter().reverse_();
-        assert_eq!(ys, [5, 4, 3, 2, 1]);
+        assert!(ys == [5, 4, 3, 2, 1]);
     }
 
     #[test]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -224,7 +224,7 @@ macro_rules! assert_eq(
         if !((*given_val == *expected_val) &&
              (*expected_val == *given_val)) {
             fail!("assertion failed: `(left == right) && (right == left)` \
-                   (left: `{:?}`, right: `{:?}`)", *given_val, *expected_val)
+                   (left: `{}`, right: `{}`)", *given_val, *expected_val)
         }
     })
 )

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -295,7 +295,7 @@ pub fn checked_next_power_of_two<T: Unsigned + Int>(n: T) -> Option<T> {
 }
 
 /// Used for representing the classification of floating point numbers
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 pub enum FPCategory {
     /// "Not a Number", often obtained by dividing by zero
     FPNaN,
@@ -1075,7 +1075,7 @@ pub trait CheckedDiv: Div<Self, Self> {
 
 /// Helper function for testing numeric operations
 #[cfg(test)]
-pub fn test_num<T:Num + NumCast>(ten: T, two: T) {
+pub fn test_num<T:Num + NumCast + Show>(ten: T, two: T) {
     assert_eq!(ten.add(&two),  cast(12).unwrap());
     assert_eq!(ten.sub(&two),  cast(8).unwrap());
     assert_eq!(ten.mul(&two),  cast(20).unwrap());
@@ -1650,7 +1650,7 @@ mod tests {
     test_checked_next_power_of_two!(test_checked_next_power_of_two_u64, u64)
     test_checked_next_power_of_two!(test_checked_next_power_of_two_uint, uint)
 
-    #[deriving(Eq)]
+    #[deriving(Eq, Show)]
     struct Value { x: int }
 
     impl ToPrimitive for Value {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1535,7 +1535,7 @@ mod tests {
         let oldhome = getenv("HOME");
 
         setenv("HOME", "/home/MountainView");
-        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
+        assert!(os::homedir() == Some(Path::new("/home/MountainView")));
 
         setenv("HOME", "");
         assert!(os::homedir().is_none());
@@ -1556,16 +1556,16 @@ mod tests {
         assert!(os::homedir().is_none());
 
         setenv("HOME", "/home/MountainView");
-        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
+        assert!(os::homedir() == Some(Path::new("/home/MountainView")));
 
         setenv("HOME", "");
 
         setenv("USERPROFILE", "/home/MountainView");
-        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
+        assert!(os::homedir() == Some(Path::new("/home/MountainView")));
 
         setenv("HOME", "/home/MountainView");
         setenv("USERPROFILE", "/home/PaloAlto");
-        assert_eq!(os::homedir(), Some(Path::new("/home/MountainView")));
+        assert!(os::homedir() == Some(Path::new("/home/MountainView")));
 
         for s in oldhome.iter() { setenv("HOME", *s) }
         for s in olduserprofile.iter() { setenv("USERPROFILE", *s) }

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -455,13 +455,13 @@ mod tests {
         (s: $path:expr, $exp:expr) => (
             {
                 let path = $path;
-                assert_eq!(path.as_str(), Some($exp));
+                assert!(path.as_str() == Some($exp));
             }
         );
         (v: $path:expr, $exp:expr) => (
             {
                 let path = $path;
-                assert_eq!(path.as_vec(), $exp);
+                assert!(path.as_vec() == $exp);
             }
         )
     )
@@ -484,7 +484,7 @@ mod tests {
         t!(v: Path::new(b!("a/b/c", 0xff)), b!("a/b/c", 0xff));
         t!(v: Path::new(b!(0xff, "/../foo", 0x80)), b!("foo", 0x80));
         let p = Path::new(b!("a/b/c", 0xff));
-        assert_eq!(p.as_str(), None);
+        assert!(p.as_str() == None);
 
         t!(s: Path::new(""), ".");
         t!(s: Path::new("/"), "/");
@@ -509,19 +509,19 @@ mod tests {
         t!(s: Path::new("foo/../../.."), "../..");
         t!(s: Path::new("foo/../../bar"), "../bar");
 
-        assert_eq!(Path::new(b!("foo/bar")).into_vec(), b!("foo/bar").to_owned());
-        assert_eq!(Path::new(b!("/foo/../../bar")).into_vec(),
+        assert!(Path::new(b!("foo/bar")).into_vec() == b!("foo/bar").to_owned());
+        assert!(Path::new(b!("/foo/../../bar")).into_vec() ==
                    b!("/bar").to_owned());
 
         let p = Path::new(b!("foo/bar", 0x80));
-        assert_eq!(p.as_str(), None);
+        assert!(p.as_str() == None);
     }
 
     #[test]
     fn test_opt_paths() {
-        assert_eq!(Path::new_opt(b!("foo/bar", 0)), None);
+        assert!(Path::new_opt(b!("foo/bar", 0)) == None);
         t!(v: Path::new_opt(b!("foo/bar")).unwrap(), b!("foo/bar"));
-        assert_eq!(Path::new_opt("foo/bar\0"), None);
+        assert!(Path::new_opt("foo/bar\0") == None);
         t!(s: Path::new_opt("foo/bar").unwrap(), "foo/bar");
     }
 
@@ -550,7 +550,7 @@ mod tests {
             ($path:expr, $disp:ident, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    assert_eq!(path.$disp().to_str(), ~$exp);
+                    assert!(path.$disp().to_str() == ~$exp);
                 }
             )
         )
@@ -566,14 +566,14 @@ mod tests {
                 {
                     let path = Path::new($path);
                     let mo = path.display().as_maybe_owned();
-                    assert_eq!(mo.as_slice(), $exp);
+                    assert!(mo.as_slice() == $exp);
                 }
             );
             ($path:expr, $exp:expr, filename) => (
                 {
                     let path = Path::new($path);
                     let mo = path.filename_display().as_maybe_owned();
-                    assert_eq!(mo.as_slice(), $exp);
+                    assert!(mo.as_slice() == $exp);
                 }
             )
         )
@@ -593,9 +593,9 @@ mod tests {
                 {
                     let path = Path::new($path);
                     let f = format!("{}", path.display());
-                    assert_eq!(f.as_slice(), $exp);
+                    assert!(f.as_slice() == $exp);
                     let f = format!("{}", path.filename_display());
-                    assert_eq!(f.as_slice(), $expf);
+                    assert!(f.as_slice() == $expf);
                 }
             )
         )
@@ -615,21 +615,21 @@ mod tests {
             (s: $path:expr, $op:ident, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    assert_eq!(path.$op(), ($exp).as_bytes());
+                    assert!(path.$op() == ($exp).as_bytes());
                 }
             );
             (s: $path:expr, $op:ident, $exp:expr, opt) => (
                 {
                     let path = Path::new($path);
                     let left = path.$op().map(|x| str::from_utf8(x).unwrap());
-                    assert_eq!(left, $exp);
+                    assert!(left == $exp);
                 }
             );
             (v: $path:expr, $op:ident, $exp:expr) => (
                 {
                     let arg = $path;
                     let path = Path::new(arg);
-                    assert_eq!(path.$op(), $exp);
+                    assert!(path.$op() == $exp);
                 }
             );
         )
@@ -703,7 +703,7 @@ mod tests {
                     let mut p1 = Path::new(path);
                     let p2 = p1.clone();
                     p1.push(join);
-                    assert_eq!(p1, p2.join(join));
+                    assert!(p1 == p2.join(join));
                 }
             )
         )
@@ -722,7 +722,7 @@ mod tests {
                     let mut p = Path::new($path);
                     let push = Path::new($push);
                     p.push(&push);
-                    assert_eq!(p.as_str(), Some($exp));
+                    assert!(p.as_str() == Some($exp));
                 }
             )
         )
@@ -742,14 +742,14 @@ mod tests {
                 {
                     let mut p = Path::new($path);
                     p.push_many($push);
-                    assert_eq!(p.as_str(), Some($exp));
+                    assert!(p.as_str() == Some($exp));
                 }
             );
             (v: $path:expr, $push:expr, $exp:expr) => (
                 {
                     let mut p = Path::new($path);
                     p.push_many($push);
-                    assert_eq!(p.as_vec(), $exp);
+                    assert!(p.as_vec() == $exp);
                 }
             )
         )
@@ -770,16 +770,16 @@ mod tests {
                 {
                     let mut p = Path::new($path);
                     let result = p.pop();
-                    assert_eq!(p.as_str(), Some($left));
-                    assert_eq!(result, $right);
+                    assert!(p.as_str() == Some($left));
+                    assert!(result == $right);
                 }
             );
             (v: [$($path:expr),+], [$($left:expr),+], $right:expr) => (
                 {
                     let mut p = Path::new(b!($($path),+));
                     let result = p.pop();
-                    assert_eq!(p.as_vec(), b!($($left),+));
-                    assert_eq!(result, $right);
+                    assert!(p.as_vec() == b!($($left),+));
+                    assert!(result == $right);
                 }
             )
         )
@@ -802,8 +802,8 @@ mod tests {
 
     #[test]
     fn test_root_path() {
-        assert_eq!(Path::new(b!("a/b/c")).root_path(), None);
-        assert_eq!(Path::new(b!("/a/b/c")).root_path(), Some(Path::new("/")));
+        assert!(Path::new(b!("a/b/c")).root_path() == None);
+        assert!(Path::new(b!("/a/b/c")).root_path() == Some(Path::new("/")));
     }
 
     #[test]
@@ -827,7 +827,7 @@ mod tests {
                     let path = Path::new($path);
                     let join = Path::new($join);
                     let res = path.join(&join);
-                    assert_eq!(res.as_str(), Some($exp));
+                    assert!(res.as_str() == Some($exp));
                 }
             )
         )
@@ -847,14 +847,14 @@ mod tests {
                 {
                     let path = Path::new($path);
                     let res = path.join_many($join);
-                    assert_eq!(res.as_str(), Some($exp));
+                    assert!(res.as_str() == Some($exp));
                 }
             );
             (v: $path:expr, $join:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
                     let res = path.join_many($join);
-                    assert_eq!(res.as_vec(), $exp);
+                    assert!(res.as_vec() == $exp);
                 }
             )
         )
@@ -928,7 +928,7 @@ mod tests {
                     let mut p1 = Path::new(path);
                     p1.$set(arg);
                     let p2 = Path::new(path);
-                    assert_eq!(p1, p2.$with(arg));
+                    assert!(p1 == p2.$with(arg));
                 }
             );
             (v: $path:expr, $set:ident, $with:ident, $arg:expr) => (
@@ -938,7 +938,7 @@ mod tests {
                     let mut p1 = Path::new(path);
                     p1.$set(arg);
                     let p2 = Path::new(path);
-                    assert_eq!(p1, p2.$with(arg));
+                    assert!(p1 == p2.$with(arg));
                 }
             )
         )
@@ -989,10 +989,10 @@ mod tests {
             (v: $path:expr, $filename:expr, $dirname:expr, $filestem:expr, $ext:expr) => (
                 {
                     let path = $path;
-                    assert_eq!(path.filename(), $filename);
-                    assert_eq!(path.dirname(), $dirname);
-                    assert_eq!(path.filestem(), $filestem);
-                    assert_eq!(path.extension(), $ext);
+                    assert!(path.filename() == $filename);
+                    assert!(path.dirname() == $dirname);
+                    assert!(path.filestem() == $filestem);
+                    assert!(path.extension() == $ext);
                 }
             )
         )

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1097,13 +1097,13 @@ mod tests {
         (s: $path:expr, $exp:expr) => (
             {
                 let path = $path;
-                assert_eq!(path.as_str(), Some($exp));
+                assert!(path.as_str() == Some($exp));
             }
         );
         (v: $path:expr, $exp:expr) => (
             {
                 let path = $path;
-                assert_eq!(path.as_vec(), $exp);
+                assert!(path.as_vec() == $exp);
             }
         )
     )
@@ -1270,10 +1270,10 @@ mod tests {
 
     #[test]
     fn test_opt_paths() {
-        assert_eq!(Path::new_opt(b!("foo\\bar", 0)), None);
-        assert_eq!(Path::new_opt(b!("foo\\bar", 0x80)), None);
+        assert!(Path::new_opt(b!("foo\\bar", 0)) == None);
+        assert!(Path::new_opt(b!("foo\\bar", 0x80)) == None);
         t!(v: Path::new_opt(b!("foo\\bar")).unwrap(), b!("foo\\bar"));
-        assert_eq!(Path::new_opt("foo\\bar\0"), None);
+        assert!(Path::new_opt("foo\\bar\0") == None);
         t!(s: Path::new_opt("foo\\bar").unwrap(), "foo\\bar");
     }
 
@@ -1343,7 +1343,7 @@ mod tests {
                 {
                     let path = $path;
                     let path = Path::new(path);
-                    assert_eq!(path.$op(), Some($exp));
+                    assert!(path.$op() == Some($exp));
                 }
             );
             (s: $path:expr, $op:ident, $exp:expr, opt) => (
@@ -1351,14 +1351,14 @@ mod tests {
                     let path = $path;
                     let path = Path::new(path);
                     let left = path.$op();
-                    assert_eq!(left, $exp);
+                    assert!(left == $exp);
                 }
             );
             (v: $path:expr, $op:ident, $exp:expr) => (
                 {
                     let path = $path;
                     let path = Path::new(path);
-                    assert_eq!(path.$op(), $exp);
+                    assert!(path.$op() == $exp);
                 }
             )
         )
@@ -1469,7 +1469,7 @@ mod tests {
                     let mut p1 = Path::new(path);
                     let p2 = p1.clone();
                     p1.push(join);
-                    assert_eq!(p1, p2.join(join));
+                    assert!(p1 == p2.join(join));
                 }
             )
         )
@@ -1483,9 +1483,9 @@ mod tests {
 
         // we do want to check one odd case though to ensure the prefix is re-parsed
         let mut p = Path::new("\\\\?\\C:");
-        assert_eq!(prefix(&p), Some(VerbatimPrefix(2)));
+        assert!(prefix(&p) == Some(VerbatimPrefix(2)));
         p.push("foo");
-        assert_eq!(prefix(&p), Some(VerbatimDiskPrefix));
+        assert!(prefix(&p) == Some(VerbatimDiskPrefix));
         assert_eq!(p.as_str(), Some("\\\\?\\C:\\foo"));
 
         // and another with verbatim non-normalized paths
@@ -1586,7 +1586,7 @@ mod tests {
                     assert!(p.as_str() == Some(left),
                         "`{}`.pop() failed; expected remainder `{}`, found `{}`",
                         pstr, left, p.as_str().unwrap());
-                    assert_eq!(result, $right);
+                    assert!(result == $right);
                 }
             );
             (v: [$($path:expr),+], [$($left:expr),+], $right:expr) => (
@@ -1594,7 +1594,7 @@ mod tests {
                     let mut p = Path::new(b!($($path),+));
                     let result = p.pop();
                     assert_eq!(p.as_vec(), b!($($left),+));
-                    assert_eq!(result, $right);
+                    assert!(result == $right);
                 }
             )
         )
@@ -1637,16 +1637,16 @@ mod tests {
 
     #[test]
     fn test_root_path() {
-        assert_eq!(Path::new("a\\b\\c").root_path(), None);
-        assert_eq!(Path::new("\\a\\b\\c").root_path(), Some(Path::new("\\")));
-        assert_eq!(Path::new("C:a").root_path(), Some(Path::new("C:")));
-        assert_eq!(Path::new("C:\\a").root_path(), Some(Path::new("C:\\")));
-        assert_eq!(Path::new("\\\\a\\b\\c").root_path(), Some(Path::new("\\\\a\\b")));
-        assert_eq!(Path::new("\\\\?\\a\\b").root_path(), Some(Path::new("\\\\?\\a")));
-        assert_eq!(Path::new("\\\\?\\C:\\a").root_path(), Some(Path::new("\\\\?\\C:\\")));
-        assert_eq!(Path::new("\\\\?\\UNC\\a\\b\\c").root_path(),
-                   Some(Path::new("\\\\?\\UNC\\a\\b")));
-        assert_eq!(Path::new("\\\\.\\a\\b").root_path(), Some(Path::new("\\\\.\\a")));
+        assert!(Path::new("a\\b\\c").root_path() == None);
+        assert!(Path::new("\\a\\b\\c").root_path() == Some(Path::new("\\")));
+        assert!(Path::new("C:a").root_path() == Some(Path::new("C:")));
+        assert!(Path::new("C:\\a").root_path() == Some(Path::new("C:\\")));
+        assert!(Path::new("\\\\a\\b\\c").root_path() == Some(Path::new("\\\\a\\b")));
+        assert!(Path::new("\\\\?\\a\\b").root_path() == Some(Path::new("\\\\?\\a")));
+        assert!(Path::new("\\\\?\\C:\\a").root_path() == Some(Path::new("\\\\?\\C:\\")));
+        assert!(Path::new("\\\\?\\UNC\\a\\b\\c").root_path() ==
+                Some(Path::new("\\\\?\\UNC\\a\\b")));
+        assert!(Path::new("\\\\.\\a\\b").root_path() == Some(Path::new("\\\\.\\a")));
     }
 
     #[test]
@@ -1808,7 +1808,7 @@ mod tests {
                     let mut p1 = Path::new(path);
                     p1.$set(arg);
                     let p2 = Path::new(path);
-                    assert_eq!(p1, p2.$with(arg));
+                    assert!(p1 == p2.$with(arg));
                 }
             );
             (v: $path:expr, $set:ident, $with:ident, $arg:expr) => (
@@ -1818,7 +1818,7 @@ mod tests {
                     let mut p1 = Path::new(path);
                     p1.$set(arg);
                     let p2 = Path::new(path);
-                    assert_eq!(p1, p2.$with(arg));
+                    assert!(p1 == p2.$with(arg));
                 }
             )
         )
@@ -1870,10 +1870,10 @@ mod tests {
             (v: $path:expr, $filename:expr, $dirname:expr, $filestem:expr, $ext:expr) => (
                 {
                     let path = $path;
-                    assert_eq!(path.filename(), $filename);
-                    assert_eq!(path.dirname(), $dirname);
-                    assert_eq!(path.filestem(), $filestem);
-                    assert_eq!(path.extension(), $ext);
+                    assert!(path.filename() == $filename);
+                    assert!(path.dirname() == $dirname);
+                    assert!(path.filestem() == $filestem);
+                    assert!(path.extension() == $ext);
                 }
             )
         )
@@ -2325,7 +2325,7 @@ mod tests {
                     let path = Path::new($path);
                     let exp: Option<&str> = $exp;
                     let exp = exp.map(|s| Path::new(s));
-                    assert_eq!(make_non_verbatim(&path), exp);
+                    assert!(make_non_verbatim(&path) == exp);
                 }
             )
         )

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -636,6 +636,6 @@ pub mod ptr_tests {
         let mut xs = [0u8, ..20];
         let ptr = xs.as_mut_ptr();
         unsafe { set_memory(ptr, 5u8, xs.len()); }
-        assert_eq!(xs, [5u8, ..20]);
+        assert!(xs == [5u8, ..20]);
     }
 }

--- a/src/libstd/rand/distributions/mod.rs
+++ b/src/libstd/rand/distributions/mod.rs
@@ -257,7 +257,7 @@ mod tests {
     use rand::*;
     use super::*;
 
-    #[deriving(Eq)]
+    #[deriving(Eq, Show)]
     struct ConstRand(uint);
     impl Rand for ConstRand {
         fn rand<R: Rng>(_: &mut R) -> ConstRand {

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -111,7 +111,7 @@ mod test {
         let mut rng = ReaderRng::new(MemReader::new(v.to_owned()));
         rng.fill_bytes(w);
 
-        assert_eq!(v, w);
+        assert!(v == w);
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -858,7 +858,7 @@ pub struct UTF16Items<'a> {
     priv iter: vec::Items<'a, u16>
 }
 /// The possibilities for values decoded from a `u16` stream.
-#[deriving(Eq, TotalEq, Clone)]
+#[deriving(Eq, TotalEq, Clone, Show)]
 pub enum UTF16Item {
     /// A valid codepoint.
     ScalarValue(char),
@@ -3743,7 +3743,7 @@ mod tests {
         ];
         assert_eq!("".as_bytes(), &[]);
         assert_eq!("abc".as_bytes(), &['a' as u8, 'b' as u8, 'c' as u8]);
-        assert_eq!("ศไทย中华Việt Nam".as_bytes(), v);
+        assert_eq!("ศไทย中华Việt Nam".as_bytes(), v.as_slice());
     }
 
     #[test]
@@ -4442,11 +4442,11 @@ mod tests {
         assert!(o.lt(&Slice("bcdef")));
         assert_eq!(Owned(~""), Default::default());
 
-        assert_eq!(s.cmp(&o), Equal);
+        assert!(s.cmp(&o) == Equal);
         assert!(s.equals(&o));
         assert!(s.equiv(&o));
 
-        assert_eq!(o.cmp(&s), Equal);
+        assert!(o.cmp(&s) == Equal);
         assert!(o.equals(&s));
         assert!(o.equiv(&s));
     }

--- a/src/libstd/sync/deque.rs
+++ b/src/libstd/sync/deque.rs
@@ -97,7 +97,7 @@ pub struct Stealer<T> {
 }
 
 /// When stealing some data, this is an enumeration of the possible outcomes.
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 pub enum Stolen<T> {
     /// The deque was empty at the time of stealing
     Empty,

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -345,10 +345,10 @@ mod tests {
         assert!(!big.equals(&small));
 
         // TotalOrd
-        assert_eq!(small.cmp(&small), Equal);
-        assert_eq!(big.cmp(&big), Equal);
-        assert_eq!(small.cmp(&big), Less);
-        assert_eq!(big.cmp(&small), Greater);
+        assert!(small.cmp(&small) == Equal);
+        assert!(big.cmp(&big) == Equal);
+        assert!(small.cmp(&big) == Less);
+        assert!(big.cmp(&small) == Greater);
     }
 
     #[test]

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -2127,7 +2127,7 @@ pub trait MutableVector<'a, T> {
     /// ```rust
     /// let mut v = ["a", "b", "c", "d"];
     /// v.swap(1, 3);
-    /// assert_eq!(v, ["a", "d", "c", "b"]);
+    /// assert!(v == ["a", "d", "c", "b"]);
     /// ```
     fn swap(self, a: uint, b: uint);
 
@@ -2148,24 +2148,23 @@ pub trait MutableVector<'a, T> {
     /// // scoped to restrict the lifetime of the borrows
     /// {
     ///    let (left, right) = v.mut_split_at(0);
-    ///    assert_eq!(left, &mut []);
-    ///    assert_eq!(right, &mut [1, 2, 3, 4, 5, 6]);
+    ///    assert!(left == &mut []);
+    ///    assert!(right == &mut [1, 2, 3, 4, 5, 6]);
     /// }
     ///
     /// {
     ///     let (left, right) = v.mut_split_at(2);
-    ///     assert_eq!(left, &mut [1, 2]);
-    ///     assert_eq!(right, &mut [3, 4, 5, 6]);
+    ///     assert!(left == &mut [1, 2]);
+    ///     assert!(right == &mut [3, 4, 5, 6]);
     /// }
     ///
     /// {
     ///     let (left, right) = v.mut_split_at(6);
-    ///     assert_eq!(left, &mut [1, 2, 3, 4, 5, 6]);
-    ///     assert_eq!(right, &mut []);
+    ///     assert!(left == &mut [1, 2, 3, 4, 5, 6]);
+    ///     assert!(right == &mut []);
     /// }
     /// ```
-    fn mut_split_at(self, mid: uint) -> (&'a mut [T],
-                                      &'a mut [T]);
+    fn mut_split_at(self, mid: uint) -> (&'a mut [T], &'a mut [T]);
 
     /// Reverse the order of elements in a vector, in place.
     ///
@@ -2174,7 +2173,7 @@ pub trait MutableVector<'a, T> {
     /// ```rust
     /// let mut v = [1, 2, 3];
     /// v.reverse();
-    /// assert_eq!(v, [3, 2, 1]);
+    /// assert!(v == [3, 2, 1]);
     /// ```
     fn reverse(self);
 
@@ -2189,11 +2188,11 @@ pub trait MutableVector<'a, T> {
     /// ```rust
     /// let mut v = [5i, 4, 1, 3, 2];
     /// v.sort_by(|a, b| a.cmp(b));
-    /// assert_eq!(v, [1, 2, 3, 4, 5]);
+    /// assert!(v == [1, 2, 3, 4, 5]);
     ///
     /// // reverse sorting
     /// v.sort_by(|a, b| b.cmp(a));
-    /// assert_eq!(v, [5, 4, 3, 2, 1]);
+    /// assert!(v == [5, 4, 3, 2, 1]);
     /// ```
     fn sort_by(self, compare: |&T, &T| -> Ordering);
 
@@ -2434,12 +2433,12 @@ pub trait MutableCloneableVector<T> {
     /// let mut dst = [0, 0, 0];
     /// let src = [1, 2];
     ///
-    /// assert_eq!(dst.copy_from(src), 2);
-    /// assert_eq!(dst, [1, 2, 0]);
+    /// assert!(dst.copy_from(src) == 2);
+    /// assert!(dst == [1, 2, 0]);
     ///
     /// let src2 = [3, 4, 5, 6];
-    /// assert_eq!(dst.copy_from(src2), 3);
-    /// assert_eq!(dst, [3, 4, 5]);
+    /// assert!(dst.copy_from(src2) == 3);
+    /// assert!(dst == [3, 4, 5]);
     /// ```
     fn copy_from(self, &[T]) -> uint;
 }
@@ -2467,7 +2466,7 @@ pub trait MutableTotalOrdVector<T> {
     /// let mut v = [-5, 4, 1, -3, 2];
     ///
     /// v.sort();
-    /// assert_eq!(v, [-5, -3, 1, 2, 4]);
+    /// assert!(v == [-5, -3, 1, 2, 4]);
     /// ```
     fn sort(self);
 }
@@ -3391,12 +3390,12 @@ mod tests {
         for (i, (a, b)) in ElementSwaps::new(v.len()).enumerate() {
             v.swap(a, b);
             match i {
-                0 => assert_eq!(v, [1, 3, 2]),
-                1 => assert_eq!(v, [3, 1, 2]),
-                2 => assert_eq!(v, [3, 2, 1]),
-                3 => assert_eq!(v, [2, 3, 1]),
-                4 => assert_eq!(v, [2, 1, 3]),
-                5 => assert_eq!(v, [1, 2, 3]),
+                0 => assert!(v == [1, 3, 2]),
+                1 => assert!(v == [3, 1, 2]),
+                2 => assert!(v == [3, 2, 1]),
+                3 => assert!(v == [2, 3, 1]),
+                4 => assert!(v == [2, 1, 3]),
+                5 => assert!(v == [1, 2, 3]),
                 _ => fail!(),
             }
         }
@@ -3530,7 +3529,7 @@ mod tests {
 
         let mut v = [0xDEADBEEFu];
         v.sort();
-        assert_eq!(v, [0xDEADBEEF]);
+        assert!(v == [0xDEADBEEF]);
     }
 
     #[test]
@@ -3896,7 +3895,7 @@ mod tests {
         for x in xs.mut_iter() {
             *x += 1;
         }
-        assert_eq!(xs, [2, 3, 4, 5, 6])
+        assert!(xs == [2, 3, 4, 5, 6])
     }
 
     #[test]
@@ -3920,7 +3919,7 @@ mod tests {
         for (i,x) in xs.mut_rev_iter().enumerate() {
             *x += i;
         }
-        assert_eq!(xs, [5, 5, 5, 5, 5])
+        assert!(xs == [5, 5, 5, 5, 5])
     }
 
     #[test]
@@ -4048,19 +4047,19 @@ mod tests {
         let mut a = [1,2,3,4,5];
         let b = ~[6,7,8];
         assert_eq!(a.move_from(b, 0, 3), 3);
-        assert_eq!(a, [6,7,8,4,5]);
+        assert!(a == [6,7,8,4,5]);
         let mut a = [7,2,8,1];
         let b = ~[3,1,4,1,5,9];
         assert_eq!(a.move_from(b, 0, 6), 4);
-        assert_eq!(a, [3,1,4,1]);
+        assert!(a == [3,1,4,1]);
         let mut a = [1,2,3,4];
         let b = ~[5,6,7,8,9,0];
         assert_eq!(a.move_from(b, 2, 3), 1);
-        assert_eq!(a, [7,2,3,4]);
+        assert!(a == [7,2,3,4]);
         let mut a = [1,2,3,4,5];
         let b = ~[5,6,7,8,9,0];
         assert_eq!(a.mut_slice(2,4).move_from(b,1,6), 2);
-        assert_eq!(a, [1,2,6,7,5]);
+        assert!(a == [1,2,6,7,5]);
     }
 
     #[test]
@@ -4068,18 +4067,18 @@ mod tests {
         let mut a = [1,2,3,4,5];
         let b = [6,7,8];
         assert_eq!(a.copy_from(b), 3);
-        assert_eq!(a, [6,7,8,4,5]);
+        assert!(a == [6,7,8,4,5]);
         let mut c = [7,2,8,1];
         let d = [3,1,4,1,5,9];
         assert_eq!(c.copy_from(d), 4);
-        assert_eq!(c, [3,1,4,1]);
+        assert!(c == [3,1,4,1]);
     }
 
     #[test]
     fn test_reverse_part() {
         let mut values = [1,2,3,4,5];
         values.mut_slice(1, 4).reverse();
-        assert_eq!(values, [1,4,3,2,5]);
+        assert!(values == [1,4,3,2,5]);
     }
 
     #[test]
@@ -4117,9 +4116,9 @@ mod tests {
         use vec::bytes::MutableByteVector;
         let mut values = [1u8,2,3,4,5];
         values.mut_slice(0,5).set_memory(0xAB);
-        assert_eq!(values, [0xAB, 0xAB, 0xAB, 0xAB, 0xAB]);
+        assert!(values == [0xAB, 0xAB, 0xAB, 0xAB, 0xAB]);
         values.mut_slice(2,4).set_memory(0xFF);
-        assert_eq!(values, [0xAB, 0xAB, 0xFF, 0xFF, 0xAB]);
+        assert!(values == [0xAB, 0xAB, 0xFF, 0xFF, 0xAB]);
     }
 
     #[test]
@@ -4145,18 +4144,18 @@ mod tests {
         let mut values = [1u8,2,3,4,5];
         {
             let (left, right) = values.mut_split_at(2);
-            assert_eq!(left.slice(0, left.len()), [1, 2]);
+            assert!(left.slice(0, left.len()) == [1, 2]);
             for p in left.mut_iter() {
                 *p += 1;
             }
 
-            assert_eq!(right.slice(0, right.len()), [3, 4, 5]);
+            assert!(right.slice(0, right.len()) == [3, 4, 5]);
             for p in right.mut_iter() {
                 *p += 2;
             }
         }
 
-        assert_eq!(values, [2, 3, 5, 6, 7]);
+        assert!(values == [2, 3, 5, 6, 7]);
     }
 
     #[deriving(Clone, Eq)]
@@ -4280,13 +4279,13 @@ mod tests {
         for slice in xs.mut_split(|x| *x == 0) {
             slice.reverse();
         }
-        assert_eq!(xs, [0,1,0,3,2,0,0,5,4,0]);
+        assert!(xs == [0,1,0,3,2,0,0,5,4,0]);
 
         let mut xs = [0,1,0,2,3,0,0,4,5,0,6,7];
         for slice in xs.mut_split(|x| *x == 0).take(5) {
             slice.reverse();
         }
-        assert_eq!(xs, [0,1,0,3,2,0,0,5,4,0,6,7]);
+        assert!(xs == [0,1,0,3,2,0,0,5,4,0,6,7]);
     }
 
     #[test]
@@ -4295,7 +4294,7 @@ mod tests {
         for slice in xs.mut_split(|x| *x == 0).rev().take(4) {
             slice.reverse();
         }
-        assert_eq!(xs, [1,2,0,4,3,0,0,6,5,0]);
+        assert!(xs == [1,2,0,4,3,0,0,6,5,0]);
     }
 
     #[test]
@@ -4307,7 +4306,7 @@ mod tests {
             }
         }
         let result = [0u8, 0, 0, 1, 1, 1, 2];
-        assert_eq!(v, result);
+        assert!(v == result);
     }
 
     #[test]
@@ -4319,7 +4318,7 @@ mod tests {
             }
         }
         let result = [2u8, 2, 2, 1, 1, 1, 0];
-        assert_eq!(v, result);
+        assert!(v == result);
     }
 
     #[test]

--- a/src/libsync/sync/mutex.rs
+++ b/src/libsync/sync/mutex.rs
@@ -94,7 +94,7 @@ pub struct Mutex {
     priv lock: StaticMutex,
 }
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum Flavor {
     Unlocked,
     TryLockAcquisition,

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -979,7 +979,7 @@ mod test {
 
     // because of the SCTable, I now need a tidy way of
     // creating syntax objects. Sigh.
-    #[deriving(Clone, Eq)]
+    #[deriving(Clone, Eq, Show)]
     enum TestSC {
         M(Mrk),
         R(Ident,Name)
@@ -1024,9 +1024,9 @@ mod test {
         assert_eq!(unfold_test_sc(test_sc.clone(),EMPTY_CTXT,&mut t),4);
         {
             let table = t.table.borrow();
-            assert_eq!(table.get()[2],Mark(9,0));
-            assert_eq!(table.get()[3],Rename(id(101,0),14,2));
-            assert_eq!(table.get()[4],Mark(3,3));
+            assert!(table.get()[2] == Mark(9,0));
+            assert!(table.get()[3] == Rename(id(101,0),14,2));
+            assert!(table.get()[4] == Mark(3,3));
         }
         assert_eq!(refold_test_sc(4,&t),test_sc);
     }
@@ -1045,8 +1045,8 @@ mod test {
         assert_eq!(unfold_marks(~[3,7],EMPTY_CTXT,&mut t),3);
         {
             let table = t.table.borrow();
-            assert_eq!(table.get()[2],Mark(7,0));
-            assert_eq!(table.get()[3],Mark(3,2));
+            assert!(table.get()[2] == Mark(7,0));
+            assert!(table.get()[3] == Mark(3,2));
         }
     }
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -455,7 +455,7 @@ fn int_type_of_word(s: &str) -> Option<IntType> {
     }
 }
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 pub enum ReprAttr {
     ReprAny,
     ReprInt(Span, IntType),
@@ -472,7 +472,7 @@ impl ReprAttr {
     }
 }
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 pub enum IntType {
     SignedInt(ast::IntTy),
     UnsignedInt(ast::UintTy)

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -32,13 +32,13 @@ pub trait Pos {
 
 /// A byte offset. Keep this small (currently 32-bits), as AST contains
 /// a lot of them.
-#[deriving(Clone, Eq, Hash, Ord)]
+#[deriving(Clone, Eq, Hash, Ord, Show)]
 pub struct BytePos(u32);
 
 /// A character offset. Because of multibyte utf8 characters, a byte offset
 /// is not equivalent to a character offset. The CodeMap will convert BytePos
 /// values to CharPos values as necessary.
-#[deriving(Eq, Hash, Ord)]
+#[deriving(Eq, Hash, Ord, Show)]
 pub struct CharPos(uint);
 
 // FIXME: Lots of boilerplate in these impls, but so far my attempts to fix
@@ -84,7 +84,7 @@ are *absolute* positions from the beginning of the codemap, not positions
 relative to FileMaps. Methods on the CodeMap can be used to relate spans back
 to the original source.
 */
-#[deriving(Clone, Hash)]
+#[deriving(Clone, Show, Hash)]
 pub struct Span {
     lo: BytePos,
     hi: BytePos,
@@ -160,7 +160,7 @@ pub struct LocWithOpt {
 pub struct FileMapAndLine {fm: @FileMap, line: uint}
 pub struct FileMapAndBytePos {fm: @FileMap, pos: BytePos}
 
-#[deriving(Clone, Hash)]
+#[deriving(Clone, Hash, Show)]
 pub enum MacroFormat {
     // e.g. #[deriving(...)] <item>
     MacroAttribute,
@@ -168,7 +168,7 @@ pub enum MacroFormat {
     MacroBang
 }
 
-#[deriving(Clone, Hash)]
+#[deriving(Clone, Hash, Show)]
 pub struct NameAndSpan {
     name: ~str,
     // the format with which the macro was invoked.
@@ -177,7 +177,7 @@ pub struct NameAndSpan {
 }
 
 /// Extra information for tracking macro expansion of spans
-#[deriving(Hash)]
+#[deriving(Hash, Show)]
 pub struct ExpnInfo {
     call_site: Span,
     callee: NameAndSpan

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -32,7 +32,7 @@ pub trait Reader {
     fn dup(&self) -> ~Reader:;
 }
 
-#[deriving(Clone, Eq)]
+#[deriving(Clone, Eq, Show)]
 pub struct TokenAndSpan {
     tok: token::Token,
     sp: Span,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -312,7 +312,7 @@ mod test {
     }
 
     #[test] fn path_exprs_1() {
-        assert_eq!(string_to_expr(~"a"),
+        assert!(string_to_expr(~"a") ==
                    @ast::Expr{
                     id: ast::DUMMY_NODE_ID,
                     node: ast::ExprPath(ast::Path {
@@ -331,7 +331,7 @@ mod test {
     }
 
     #[test] fn path_exprs_2 () {
-        assert_eq!(string_to_expr(~"::a::b"),
+        assert!(string_to_expr(~"::a::b") ==
                    @ast::Expr {
                     id: ast::DUMMY_NODE_ID,
                     node: ast::ExprPath(ast::Path {
@@ -542,7 +542,7 @@ mod test {
     }
 
     #[test] fn ret_expr() {
-        assert_eq!(string_to_expr(~"return d"),
+        assert!(string_to_expr(~"return d") ==
                    @ast::Expr{
                     id: ast::DUMMY_NODE_ID,
                     node:ast::ExprRet(Some(@ast::Expr{
@@ -565,7 +565,7 @@ mod test {
     }
 
     #[test] fn parse_stmt_1 () {
-        assert_eq!(string_to_stmt(~"b;"),
+        assert!(string_to_stmt(~"b;") ==
                    @Spanned{
                        node: ast::StmtExpr(@ast::Expr {
                            id: ast::DUMMY_NODE_ID,
@@ -592,7 +592,7 @@ mod test {
 
     #[test] fn parse_ident_pat () {
         let mut parser = string_to_parser(~"b");
-        assert_eq!(parser.parse_pat(),
+        assert!(parser.parse_pat() ==
                    @ast::Pat{id: ast::DUMMY_NODE_ID,
                              node: ast::PatIdent(
                                 ast::BindByValue(ast::MutImmutable),
@@ -615,7 +615,7 @@ mod test {
     // check the contents of the tt manually:
     #[test] fn parse_fundecl () {
         // this test depends on the intern order of "fn" and "int"
-        assert_eq!(string_to_item(~"fn a (b : int) { b; }"),
+        assert!(string_to_item(~"fn a (b : int) { b; }") ==
                   Some(
                       @ast::Item{ident:str_to_ident("a"),
                             attrs:~[],

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -23,7 +23,7 @@ use std::local_data;
 use std::path::BytesContainer;
 
 #[allow(non_camel_case_types)]
-#[deriving(Clone, Encodable, Decodable, Eq, Hash)]
+#[deriving(Clone, Encodable, Decodable, Eq, Hash, Show)]
 pub enum BinOp {
     PLUS,
     MINUS,
@@ -38,7 +38,7 @@ pub enum BinOp {
 }
 
 #[allow(non_camel_case_types)]
-#[deriving(Clone, Encodable, Decodable, Eq, Hash)]
+#[deriving(Clone, Encodable, Decodable, Eq, Hash, Show)]
 pub enum Token {
     /* Expression-operator symbols. */
     EQ,
@@ -116,6 +116,24 @@ pub enum Nonterminal {
     NtPath(~ast::Path),
     NtTT(  @ast::TokenTree), // needs @ed to break a circularity
     NtMatchers(~[ast::Matcher])
+}
+
+impl fmt::Show for Nonterminal {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            NtItem(..) => f.pad("NtItem(..)"),
+            NtBlock(..) => f.pad("NtBlock(..)"),
+            NtStmt(..) => f.pad("NtStmt(..)"),
+            NtPat(..) => f.pad("NtPat(..)"),
+            NtExpr(..) => f.pad("NtExpr(..)"),
+            NtTy(..) => f.pad("NtTy(..)"),
+            NtIdent(..) => f.pad("NtIdent(..)"),
+            NtAttr(..) => f.pad("NtAttr(..)"),
+            NtPath(..) => f.pad("NtPath(..)"),
+            NtTT(..) => f.pad("NtTT(..)"),
+            NtMatchers(..) => f.pad("NtMatchers(..)"),
+        }
+    }
 }
 
 pub fn binop_to_str(o: BinOp) -> ~str {

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -18,6 +18,7 @@ use collections::HashMap;
 use std::cast;
 use std::cell::RefCell;
 use std::cmp::Equiv;
+use std::fmt;
 use std::hash::Hash;
 use std::rc::Rc;
 
@@ -111,6 +112,13 @@ impl Str for RcStr {
     #[inline]
     fn into_owned(self) -> ~str {
         self.string.borrow().to_owned()
+    }
+}
+
+impl fmt::Show for RcStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Show;
+        self.as_slice().fmt(f)
     }
 }
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -163,7 +163,7 @@ pub struct TestDescAndFn {
     testfn: TestFn,
 }
 
-#[deriving(Clone, Encodable, Decodable, Eq)]
+#[deriving(Clone, Encodable, Decodable, Eq, Show)]
 pub struct Metric {
     priv value: f64,
     priv noise: f64
@@ -186,7 +186,7 @@ impl Clone for MetricMap {
 }
 
 /// Analysis of a single change in metric
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 pub enum MetricChange {
     LikelyNoise,
     MetricAdded,
@@ -1341,7 +1341,7 @@ mod tests {
         let (p, ch) = Chan::new();
         run_test(false, desc, ch);
         let (_, res, _) = p.recv();
-        assert_eq!(res, TrIgnored);
+        assert!(res == TrIgnored);
     }
 
     #[test]
@@ -1358,7 +1358,7 @@ mod tests {
         let (p, ch) = Chan::new();
         run_test(false, desc, ch);
         let (_, res, _) = p.recv();
-        assert_eq!(res, TrOk);
+        assert!(res == TrOk);
     }
 
     #[test]
@@ -1375,7 +1375,7 @@ mod tests {
         let (p, ch) = Chan::new();
         run_test(false, desc, ch);
         let (_, res, _) = p.recv();
-        assert_eq!(res, TrFailed);
+        assert!(res == TrFailed);
     }
 
     #[test]

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -64,7 +64,7 @@ mod imp {
 /// A record specifying a time value in seconds and nanoseconds.
 
 
-#[deriving(Clone, DeepClone, Eq, Encodable, Decodable)]
+#[deriving(Clone, DeepClone, Eq, Encodable, Decodable, Show)]
 pub struct Timespec { sec: i64, nsec: i32 }
 /*
  * Timespec assumes that pre-epoch Timespecs have negative sec and positive
@@ -191,7 +191,7 @@ pub fn tzset() {
     }
 }
 
-#[deriving(Clone, DeepClone, Eq, Encodable, Decodable)]
+#[deriving(Clone, DeepClone, Eq, Encodable, Decodable, Show)]
 pub struct Tm {
     tm_sec: i32, // seconds after the minute ~[0-60]
     tm_min: i32, // minutes after the hour ~[0-59]
@@ -1138,7 +1138,7 @@ mod tests {
         let time = Timespec::new(1234567890, 54321);
         let local = at(time);
 
-        error!("time_at: {:?}", local);
+        debug!("time_at: {:?}", local);
 
         assert_eq!(local.tm_sec, 30_i32);
         assert_eq!(local.tm_min, 31_i32);
@@ -1355,7 +1355,7 @@ mod tests {
         let utc   = at_utc(time);
         let local = at(time);
 
-        error!("test_ctime: {:?} {:?}", utc.ctime(), local.ctime());
+        debug!("test_ctime: {:?} {:?}", utc.ctime(), local.ctime());
 
         assert_eq!(utc.ctime(), ~"Fri Feb 13 23:31:30 2009");
         assert_eq!(local.ctime(), ~"Fri Feb 13 15:31:30 2009");

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -13,6 +13,7 @@ use std::cmp::Eq;
 pub trait MyNum : Add<Self,Self> + Sub<Self,Self> + Mul<Self,Self> + Eq {
 }
 
+#[deriving(Show)]
 pub struct MyInt {
     val: int
 }

--- a/src/test/run-pass/assert-eq-macro-success.rs
+++ b/src/test/run-pass/assert-eq-macro-success.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Point { x : int }
 
 pub fn main() {

--- a/src/test/run-pass/binops.rs
+++ b/src/test/run-pass/binops.rs
@@ -63,7 +63,7 @@ fn test_ptr() {
     }
 }
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct p {
   x: int,
   y: int,

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -12,6 +12,7 @@
 
 use std::cmp;
 
+#[deriving(Show)]
 enum cat_type { tuxedo, tabby, tortoiseshell }
 
 impl cmp::Eq for cat_type {

--- a/src/test/run-pass/coerce-to-closure-and-proc.rs
+++ b/src/test/run-pass/coerce-to-closure-and-proc.rs
@@ -12,10 +12,10 @@ fn id<T>(x: T) -> T {
     x
 }
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo<T>(T);
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum Bar<T> {
     Bar(T)
 }

--- a/src/test/run-pass/const-cross-crate-extern.rs
+++ b/src/test/run-pass/const-cross-crate-extern.rs
@@ -16,5 +16,5 @@ use cci_const::bar;
 static foo: extern "C" fn() = bar;
 
 pub fn main() {
-    assert_eq!(foo, bar);
+    assert!(foo == bar);
 }

--- a/src/test/run-pass/const-extern-function.rs
+++ b/src/test/run-pass/const-extern-function.rs
@@ -18,6 +18,6 @@ struct S {
 }
 
 pub fn main() {
-    assert_eq!(foopy, f);
-    assert_eq!(f, s.f);
+    assert!(foopy == f);
+    assert!(f == s.f);
 }

--- a/src/test/run-pass/const-struct.rs
+++ b/src/test/run-pass/const-struct.rs
@@ -10,6 +10,7 @@
 
 use std::cmp;
 
+#[deriving(Show)]
 struct foo { a: int, b: int, c: int }
 
 impl cmp::Eq for foo {

--- a/src/test/run-pass/deriving-primitive.rs
+++ b/src/test/run-pass/deriving-primitive.rs
@@ -11,7 +11,7 @@
 use std::num::FromPrimitive;
 use std::int;
 
-#[deriving(Eq, FromPrimitive)]
+#[deriving(Eq, FromPrimitive, Show)]
 enum A {
     Foo = int::MAX,
     Bar = 1,

--- a/src/test/run-pass/deriving-via-extension-c-enum.rs
+++ b/src/test/run-pass/deriving-via-extension-c-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum Foo {
     Bar,
     Baz,

--- a/src/test/run-pass/deriving-via-extension-enum.rs
+++ b/src/test/run-pass/deriving-via-extension-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum Foo {
     Bar(int, int),
     Baz(f64, f64)

--- a/src/test/run-pass/deriving-via-extension-struct-empty.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-empty.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo;
 
 pub fn main() {

--- a/src/test/run-pass/deriving-via-extension-struct-like-enum-variant.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-like-enum-variant.rs
@@ -10,7 +10,7 @@
 
 #[feature(struct_variant)];
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum S {
     X { x: int, y: int },
     Y

--- a/src/test/run-pass/deriving-via-extension-struct-tuple.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-tuple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo(int, int, ~str);
 
 pub fn main() {

--- a/src/test/run-pass/deriving-via-extension-struct.rs
+++ b/src/test/run-pass/deriving-via-extension-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo {
     x: int,
     y: int,

--- a/src/test/run-pass/deriving-via-extension-type-params.rs
+++ b/src/test/run-pass/deriving-via-extension-type-params.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq, Hash)]
+#[deriving(Eq, Hash, Show)]
 struct Foo<T> {
     x: int,
     y: T,

--- a/src/test/run-pass/empty-tag.rs
+++ b/src/test/run-pass/empty-tag.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[deriving(Show)]
 enum chan { chan_t, }
 
 impl Eq for chan {

--- a/src/test/run-pass/expr-if-struct.rs
+++ b/src/test/run-pass/expr-if-struct.rs
@@ -21,6 +21,7 @@ fn test_rec() {
     assert_eq!(rs.i, 100);
 }
 
+#[deriving(Show)]
 enum mood { happy, sad, }
 
 impl Eq for mood {

--- a/src/test/run-pass/expr-match-struct.rs
+++ b/src/test/run-pass/expr-match-struct.rs
@@ -20,6 +20,7 @@ fn test_rec() {
     assert_eq!(rs.i, 100);
 }
 
+#[deriving(Show)]
 enum mood { happy, sad, }
 
 impl Eq for mood {

--- a/src/test/run-pass/extern-compare-with-return-type.rs
+++ b/src/test/run-pass/extern-compare-with-return-type.rs
@@ -20,13 +20,13 @@ extern fn uintvoidret(_x: uint) {}
 extern fn uintuintuintuintret(x: uint, y: uint, z: uint) -> uint { x+y+z }
 
 pub fn main() {
-    assert_eq!(voidret1, voidret1);
+    assert!(voidret1 == voidret1);
     assert!(voidret1 != voidret2);
 
-    assert_eq!(uintret, uintret);
+    assert!(uintret == uintret);
 
-    assert_eq!(uintvoidret, uintvoidret);
+    assert!(uintvoidret == uintvoidret);
 
-    assert_eq!(uintuintuintuintret, uintuintuintuintret);
+    assert!(uintuintuintuintret == uintuintuintuintret);
 }
 

--- a/src/test/run-pass/extern-pass-TwoU32s.rs
+++ b/src/test/run-pass/extern-pass-TwoU32s.rs
@@ -11,7 +11,7 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct TwoU32s {
     one: u32, two: u32
 }

--- a/src/test/run-pass/extern-pass-TwoU64s.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s.rs
@@ -13,7 +13,7 @@
 
 // ignore-win32 #9205
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct TwoU64s {
     one: u64, two: u64
 }

--- a/src/test/run-pass/extern-take-value.rs
+++ b/src/test/run-pass/extern-take-value.rs
@@ -19,6 +19,6 @@ pub fn main() {
     let b: extern "C" fn() = f;
     let c: extern "C" fn() = g;
 
-    assert_eq!(a, b);
+    assert!(a == b);
     assert!(a != c);
 }

--- a/src/test/run-pass/generic-default-type-params.rs
+++ b/src/test/run-pass/generic-default-type-params.rs
@@ -50,10 +50,10 @@ fn default_foo(x: Foo) {
     assert_eq!(x.baz(), (1, 'a'));
 }
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct BazHelper<T>(T);
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 // Ensure that we can use previous type parameters in defaults.
 struct Baz<T, U = BazHelper<T>, V = Option<U>>(T, U, V);
 

--- a/src/test/run-pass/glob-std.rs
+++ b/src/test/run-pass/glob-std.rs
@@ -11,6 +11,8 @@
 // ignore-fast check-fast doesn't like 'extern crate extra'
 // ignore-win32 TempDir may cause IoError on windows: #10462
 
+#[feature(macro_rules)];
+
 extern crate extra;
 extern crate glob;
 
@@ -19,6 +21,12 @@ use extra::tempfile::TempDir;
 use std::unstable::finally::Finally;
 use std::{os, unstable};
 use std::io;
+
+macro_rules! assert_eq ( ($e1:expr, $e2:expr) => (
+    if $e1 != $e2 {
+        fail!("{} != {}", stringify!($e1), stringify!($e2))
+    }
+) )
 
 pub fn main() {
     fn mk_file(path: &str, directory: bool) {

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -26,7 +26,7 @@ pub mod pipes {
         payload: Option<T>
     }
 
-    #[deriving(Eq)]
+    #[deriving(Eq, Show)]
     #[repr(int)]
     pub enum state {
         empty,

--- a/src/test/run-pass/monomorphize-abi-alignment.rs
+++ b/src/test/run-pass/monomorphize-abi-alignment.rs
@@ -20,9 +20,9 @@
 
 struct S<T> { i:u8, t:T }
 impl<T> S<T> { fn unwrap(self) -> T { self.t } }
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct A((u32, u32));
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct B(u64);
 
 pub fn main() {

--- a/src/test/run-pass/newtype-temporary.rs
+++ b/src/test/run-pass/newtype-temporary.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo(uint);
 
 fn foo() -> Foo {

--- a/src/test/run-pass/operator-overloading.rs
+++ b/src/test/run-pass/operator-overloading.rs
@@ -13,6 +13,7 @@
 use std::cmp;
 use std::ops;
 
+#[deriving(Show)]
 struct Point {
     x: int,
     y: int

--- a/src/test/run-pass/packed-struct-generic-layout.rs
+++ b/src/test/run-pass/packed-struct-generic-layout.rs
@@ -22,7 +22,7 @@ pub fn main() {
         let s = S { a: 0xff_ff_ff_ffu32, b: 1, c: 0xaa_aa_aa_aa as i32 };
         let transd : [u8, .. 9] = cast::transmute(s);
         // Don't worry about endianness, the numbers are palindromic.
-        assert_eq!(transd,
+        assert!(transd ==
                    [0xff, 0xff, 0xff, 0xff,
                     1,
                     0xaa, 0xaa, 0xaa, 0xaa]);
@@ -31,7 +31,7 @@ pub fn main() {
         let s = S { a: 1u8, b: 2u8, c: 0b10000001_10000001 as i16};
         let transd : [u8, .. 4] = cast::transmute(s);
         // Again, no endianness problems.
-        assert_eq!(transd,
+        assert!(transd ==
                    [1, 2, 0b10000001, 0b10000001]);
     }
 }

--- a/src/test/run-pass/packed-struct-layout.rs
+++ b/src/test/run-pass/packed-struct-layout.rs
@@ -26,11 +26,11 @@ pub fn main() {
     unsafe {
         let s4 = S4 { a: 1, b: [2,3,4] };
         let transd : [u8, .. 4] = cast::transmute(s4);
-        assert_eq!(transd, [1, 2, 3, 4]);
+        assert!(transd == [1, 2, 3, 4]);
 
         let s5 = S5 { a: 1, b: 0xff_00_00_ff };
         let transd : [u8, .. 5] = cast::transmute(s5);
         // Don't worry about endianness, the u32 is palindromic.
-        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
+        assert!(transd == [1, 0xff, 0, 0, 0xff]);
     }
 }

--- a/src/test/run-pass/packed-struct-vec.rs
+++ b/src/test/run-pass/packed-struct-vec.rs
@@ -13,7 +13,7 @@
 use std::mem;
 
 #[packed]
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo {
     bar: u8,
     baz: u64

--- a/src/test/run-pass/packed-tuple-struct-layout.rs
+++ b/src/test/run-pass/packed-tuple-struct-layout.rs
@@ -20,11 +20,11 @@ pub fn main() {
     unsafe {
         let s4 = S4(1, [2,3,4]);
         let transd : [u8, .. 4] = cast::transmute(s4);
-        assert_eq!(transd, [1, 2, 3, 4]);
+        assert!(transd == [1, 2, 3, 4]);
 
         let s5 = S5(1, 0xff_00_00_ff);
         let transd : [u8, .. 5] = cast::transmute(s5);
         // Don't worry about endianness, the u32 is palindromic.
-        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
+        assert!(transd == [1, 0xff, 0, 0, 0xff]);
     }
 }

--- a/src/test/run-pass/regions-mock-tcx.rs
+++ b/src/test/run-pass/regions-mock-tcx.rs
@@ -27,6 +27,7 @@ use std::mem;
 
 type Type<'tcx> = &'tcx TypeStructure<'tcx>;
 
+#[deriving(Show)]
 enum TypeStructure<'tcx> {
     TypeInt,
     TypeFunction(Type<'tcx>, Type<'tcx>),

--- a/src/test/run-pass/repeat-expr-in-static.rs
+++ b/src/test/run-pass/repeat-expr-in-static.rs
@@ -12,5 +12,5 @@ static FOO: [int, ..4] = [32, ..4];
 static BAR: [int, ..4] = [32, 32, 32, 32];
 
 pub fn main() {
-    assert_eq!(FOO, BAR);
+    assert!(FOO == BAR);
 }

--- a/src/test/run-pass/small-enums-with-fields.rs
+++ b/src/test/run-pass/small-enums-with-fields.rs
@@ -12,7 +12,7 @@
 
 use std::mem::size_of;
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 enum Either<T, U> { Left(T), Right(U) }
 
 macro_rules! check {

--- a/src/test/run-pass/struct-lit-functional-update-no-fields.rs
+++ b/src/test/run-pass/struct-lit-functional-update-no-fields.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq,Clone)]
+#[deriving(Show,Eq,Clone)]
 struct Foo<T> {
     bar: T,
     baz: T

--- a/src/test/run-pass/structured-compare.rs
+++ b/src/test/run-pass/structured-compare.rs
@@ -10,6 +10,7 @@
 
 
 
+#[deriving(Show)]
 enum foo { large, small, }
 
 impl Eq for foo {

--- a/src/test/run-pass/task-comm-16.rs
+++ b/src/test/run-pass/task-comm-16.rs
@@ -45,6 +45,7 @@ fn test_str() {
     assert_eq!(s1[3], 't' as u8);
 }
 
+#[deriving(Show)]
 enum t {
     tag1,
     tag2(int),

--- a/src/test/run-pass/trait-inheritance-overloading-simple.rs
+++ b/src/test/run-pass/trait-inheritance-overloading-simple.rs
@@ -12,6 +12,7 @@ use std::cmp::Eq;
 
 trait MyNum : Eq { }
 
+#[deriving(Show)]
 struct MyInt { val: int }
 
 impl Eq for MyInt {

--- a/src/test/run-pass/trait-inheritance-overloading.rs
+++ b/src/test/run-pass/trait-inheritance-overloading.rs
@@ -12,6 +12,7 @@ use std::cmp::Eq;
 
 trait MyNum : Add<Self,Self> + Sub<Self,Self> + Mul<Self,Self> + Eq { }
 
+#[deriving(Show)]
 struct MyInt { val: int }
 
 impl Add<MyInt, MyInt> for MyInt {

--- a/src/test/run-pass/tuple-struct-constructor-pointer.rs
+++ b/src/test/run-pass/tuple-struct-constructor-pointer.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Foo(int);
-#[deriving(Eq)]
+#[deriving(Eq, Show)]
 struct Bar(int, int);
 
 pub fn main() {

--- a/src/test/run-pass/unique-kinds.rs
+++ b/src/test/run-pass/unique-kinds.rs
@@ -13,7 +13,7 @@ use std::cmp::Eq;
 fn sendable() {
 
     fn f<T:Send + Eq>(i: T, j: T) {
-        assert_eq!(i, j);
+        assert!(i == j);
     }
 
     fn g<T:Send + Eq>(i: T, j: T) {
@@ -31,7 +31,7 @@ fn sendable() {
 fn copyable() {
 
     fn f<T:Eq>(i: T, j: T) {
-        assert_eq!(i, j);
+        assert!(i == j);
     }
 
     fn g<T:Eq>(i: T, j: T) {
@@ -49,7 +49,7 @@ fn copyable() {
 fn noncopyable() {
 
     fn f<T:Eq>(i: T, j: T) {
-        assert_eq!(i, j);
+        assert!(i == j);
     }
 
     fn g<T:Eq>(i: T, j: T) {

--- a/src/test/run-pass/vec-matching-autoslice.rs
+++ b/src/test/run-pass/vec-matching-autoslice.rs
@@ -13,7 +13,7 @@ pub fn main() {
     match x {
         [2, _, _] => fail!(),
         [1, a, b] => {
-            assert_eq!([a, b], [2, 3]);
+            assert!([a, b] == [2, 3]);
         }
         [_, _, _] => fail!(),
     }


### PR DESCRIPTION
Formatting via reflection has been a little questionable for some time now, and
it's a little unfortunate that one of the standard macros will silently use
reflection when you weren't expecting it. This adds small bits of code bloat to
libraries, as well as not always being necessary. In light of this information,
this commit switches assert_eq!() to using {} in the error message instead of
{:?}.

In updating existing code, there were a few error cases that I encountered:
- It's impossible to define Show for [T, ..N]. I think DST will alleviate this
  because we can define Show for [T].
- A few types here and there just needed a #[deriving(Show)]
- Type parameters needed a Show bound, I often moved this to `assert!(a == b)`
- `Path` doesn't implement `Show`, so assert_eq!() cannot be used on two paths.
  I don't think this is much of a regression though because {:?} on paths looks
  awful (it's a byte array).

Concretely speaking, this shaved 10K off a 656K binary. Not a lot, but sometime
significant for smaller binaries.
