### PR TITLE
Capture rustc output in rustdoc tests

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -931,7 +931,7 @@ pub fn build_session(sopts: @session::Options,
                      -> Session {
     let codemap = @codemap::CodeMap::new();
     let diagnostic_handler =
-        diagnostic::mk_handler();
+        diagnostic::default_handler();
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, codemap);
 
@@ -1149,7 +1149,8 @@ pub fn build_output_filenames(input: &Input,
 }
 
 pub fn early_error(msg: &str) -> ! {
-    diagnostic::DefaultEmitter.emit(None, msg, diagnostic::Fatal);
+    let mut emitter = diagnostic::EmitterWriter::stderr();
+    emitter.emit(None, msg, diagnostic::Fatal);
     fail!(diagnostic::FatalError);
 }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -394,7 +394,8 @@ pub fn monitor(f: proc()) {
         Err(value) => {
             // Task failed without emitting a fatal diagnostic
             if !value.is::<diagnostic::FatalError>() {
-                diagnostic::DefaultEmitter.emit(
+                let mut emitter = diagnostic::EmitterWriter::stderr();
+                emitter.emit(
                     None,
                     diagnostic::ice_msg("unexpected failure"),
                     diagnostic::Error);
@@ -404,9 +405,7 @@ pub fn monitor(f: proc()) {
                      this is a bug",
                 ];
                 for note in xs.iter() {
-                    diagnostic::DefaultEmitter.emit(None,
-                                                    *note,
-                                                    diagnostic::Note)
+                    emitter.emit(None, *note, diagnostic::Note)
                 }
 
                 println!("{}", r.read_to_str());

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -58,7 +58,7 @@ fn get_ast_and_resolve(cpath: &Path,
     };
 
 
-    let diagnostic_handler = syntax::diagnostic::mk_handler();
+    let diagnostic_handler = syntax::diagnostic::default_handler();
     let span_diagnostic_handler =
         syntax::diagnostic::mk_span_handler(diagnostic_handler, parsesess.cm);
 

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -28,7 +28,7 @@ use t = syntax::parse::token;
 /// Highlights some source code, returning the HTML output.
 pub fn highlight(src: &str) -> ~str {
     let sess = parse::new_parse_sess();
-    let handler = diagnostic::mk_handler();
+    let handler = diagnostic::default_handler();
     let span_handler = diagnostic::mk_span_handler(handler, sess.cm);
     let fm = parse::string_to_filemap(sess, src.to_owned(), ~"<stdin>");
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -25,6 +25,7 @@ use rustc::metadata::creader::Loader;
 use getopts;
 use syntax::diagnostic;
 use syntax::parse;
+use syntax::codemap::CodeMap;
 
 use core;
 use clean;
@@ -35,7 +36,6 @@ use passes;
 use visit_ast::RustdocVisitor;
 
 pub fn run(input: &str, matches: &getopts::Matches) -> int {
-    let parsesess = parse::new_parse_sess();
     let input_path = Path::new(input);
     let input = driver::FileInput(input_path.clone());
     let libs = matches.opt_strs("L").map(|s| Path::new(s.as_slice()));
@@ -49,9 +49,12 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
     };
 
 
+    let cm = @CodeMap::new();
     let diagnostic_handler = diagnostic::mk_handler();
     let span_diagnostic_handler =
-        diagnostic::mk_span_handler(diagnostic_handler, parsesess.cm);
+        diagnostic::mk_span_handler(diagnostic_handler, cm);
+    let parsesess = parse::new_parse_sess_special_handler(span_diagnostic_handler,
+                                                          cm);
 
     let sess = driver::build_session_(sessopts,
                                       Some(input_path),

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -50,7 +50,7 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
 
 
     let cm = @CodeMap::new();
-    let diagnostic_handler = diagnostic::mk_handler();
+    let diagnostic_handler = diagnostic::default_handler();
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, cm);
     let parsesess = parse::new_parse_sess_special_handler(span_diagnostic_handler,
@@ -115,7 +115,30 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, should_fail: bool) 
         .. (*session::basic_options()).clone()
     };
 
-    let diagnostic_handler = diagnostic::mk_handler();
+    // Shuffle around a few input and output handles here. We're going to pass
+    // an explicit handle into rustc to collect output messages, but we also
+    // want to catch the error message that rustc prints when it fails.
+    //
+    // We take our task-local stderr (likely set by the test runner), and move
+    // it into another task. This helper task then acts as a sink for both the
+    // stderr of this task and stderr of rustc itself, copying all the info onto
+    // the stderr channel we originally started with.
+    //
+    // The basic idea is to not use a default_handler() for rustc, and then also
+    // not print things by default to the actual stderr.
+    let (p, c) = Chan::new();
+    let w1 = io::ChanWriter::new(c);
+    let w2 = w1.clone();
+    let old = io::stdio::set_stderr(~w1);
+    spawn(proc() {
+        let mut p = io::PortReader::new(p);
+        let mut err = old.unwrap_or(~io::stderr() as ~Writer);
+        io::util::copy(&mut p, &mut err).unwrap();
+    });
+    let emitter = diagnostic::EmitterWriter::new(~w2);
+
+    // Compile the code
+    let diagnostic_handler = diagnostic::mk_handler(~emitter);
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, parsesess.cm);
 
@@ -129,6 +152,7 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, should_fail: bool) 
     let cfg = driver::build_configuration(sess);
     driver::compile_input(sess, cfg, &input, &out, &None);
 
+    // Run the code!
     let exe = outdir.path().join("rust_out");
     let out = Process::output(exe.as_str().unwrap(), []);
     match out {

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -1004,6 +1004,7 @@ mod test {
     use diagnostic;
     use parse::token;
     use parse::token::{str_to_ident};
+    use std::io::util;
 
     // represents a testing reader (incl. both reader and interner)
     struct Env {
@@ -1014,7 +1015,10 @@ mod test {
     fn setup(teststr: ~str) -> Env {
         let cm = CodeMap::new();
         let fm = cm.new_filemap(~"zebra.rs", teststr);
-        let span_handler = diagnostic::mk_span_handler(diagnostic::mk_handler(), @cm);
+        let writer = ~util::NullWriter;
+        let emitter = diagnostic::EmitterWriter::new(writer);
+        let handler = diagnostic::mk_handler(~emitter);
+        let span_handler = diagnostic::mk_span_handler(handler, @cm);
         Env {
             string_reader: new_string_reader(span_handler,fm)
         }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -14,7 +14,7 @@
 use ast;
 use codemap::{Span, CodeMap, FileMap};
 use codemap;
-use diagnostic::{SpanHandler, mk_span_handler, mk_handler};
+use diagnostic::{SpanHandler, mk_span_handler, default_handler};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 
@@ -49,7 +49,7 @@ pub fn new_parse_sess() -> @ParseSess {
     let cm = @CodeMap::new();
     @ParseSess {
         cm: cm,
-        span_diagnostic: mk_span_handler(mk_handler(), cm),
+        span_diagnostic: mk_span_handler(default_handler(), cm),
         included_mod_stack: RefCell::new(~[]),
     }
 }


### PR DESCRIPTION
This helps prevent the unfortunate interleavings found in #12623.
