### PR TITLE
Mark top level module as a crate in rustdoc

### DIFF
--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -186,6 +186,7 @@ pub enum ItemEnum {
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Module {
     items: ~[Item],
+    is_crate: bool,
 }
 
 impl Clean<Item> for doctree::Module {
@@ -202,6 +203,7 @@ impl Clean<Item> for doctree::Module {
             visibility: self.vis.clean(),
             id: self.id,
             inner: ModuleItem(Module {
+               is_crate: self.is_crate,
                items: [self.structs.clean(), self.enums.clean(),
                        self.fns.clean(), self.foreigns.clean().concat_vec(),
                        self.mods.clean(), self.typedefs.clean(),

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -33,6 +33,7 @@ pub struct Module {
     foreigns: ~[ast::ForeignMod],
     view_items: ~[ast::ViewItem],
     macros: ~[Macro],
+    is_crate: bool,
 }
 
 impl Module {
@@ -54,6 +55,7 @@ impl Module {
             view_items : ~[],
             foreigns   : ~[],
             macros     : ~[],
+            is_crate   : false,
         }
     }
 }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -87,7 +87,10 @@ pub trait DocFolder {
     }
 
     fn fold_mod(&mut self, m: Module) -> Module {
-        Module { items: m.items.move_iter().filter_map(|i| self.fold_item(i)).collect() }
+        Module {
+            is_crate: m.is_crate,
+            items: m.items.move_iter().filter_map(|i| self.fold_item(i)).collect()
+        }
     }
 
     fn fold_crate(&mut self, mut c: Crate) -> Crate {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -863,7 +863,11 @@ impl<'a> fmt::Show for Item<'a> {
         // Write the breadcrumb trail header for the top
         try!(write!(fmt.buf, "<h1 class='fqn'>"));
         match self.item.inner {
-            clean::ModuleItem(..) => try!(write!(fmt.buf, "Module ")),
+            clean::ModuleItem(ref m) => if m.is_crate {
+                    try!(write!(fmt.buf, "Crate "));
+                } else {
+                    try!(write!(fmt.buf, "Module "));
+                },
             clean::FunctionItem(..) => try!(write!(fmt.buf, "Function ")),
             clean::TraitItem(..) => try!(write!(fmt.buf, "Trait ")),
             clean::StructItem(..) => try!(write!(fmt.buf, "Struct ")),

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -44,6 +44,7 @@ impl<'a> RustdocVisitor<'a> {
         self.module = self.visit_mod_contents(krate.span, krate.attrs.clone(),
                                               ast::Public, ast::CRATE_NODE_ID,
                                               &krate.module, None);
+        self.module.is_crate = true;
     }
 
     pub fn visit_struct_def(&mut self, item: &ast::Item, sd: @ast::StructDef,


### PR DESCRIPTION
This PR for #12507 marks the top level `Module` in rustdoc as a crate and does render the header accordingly.
