### PR TITLE
librustc: Pass the node id so we don't fail on destructing struct variants

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1528,7 +1528,7 @@ fn compile_submatch_continue<'r,
         Some(ref rec_fields) => {
             let pat_ty = node_id_type(bcx, pat_id);
             let pat_repr = adt::represent_type(bcx.ccx(), pat_ty);
-            expr::with_field_tys(tcx, pat_ty, None, |discr, field_tys| {
+            expr::with_field_tys(tcx, pat_ty, Some(pat_id), |discr, field_tys| {
                 let rec_vals = rec_fields.map(|field_name| {
                         let ix = ty::field_idx_strict(tcx, field_name.name, field_tys);
                         adt::trans_field_ptr(bcx, pat_repr, val, discr, ix)
@@ -2208,7 +2208,7 @@ fn bind_irrefutable_pat<'a>(
             let tcx = bcx.tcx();
             let pat_ty = node_id_type(bcx, pat.id);
             let pat_repr = adt::represent_type(bcx.ccx(), pat_ty);
-            expr::with_field_tys(tcx, pat_ty, None, |discr, field_tys| {
+            expr::with_field_tys(tcx, pat_ty, Some(pat.id), |discr, field_tys| {
                 for f in fields.iter() {
                     let ix = ty::field_idx_strict(tcx, f.ident.name, field_tys);
                     let fldptr = adt::trans_field_ptr(bcx, pat_repr, val,

--- a/src/test/run-pass/issue-11577.rs
+++ b/src/test/run-pass/issue-11577.rs
@@ -1,0 +1,29 @@
+ // Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(struct_variant)];
+
+// Destructuring struct variants would ICE where regular structs wouldn't
+
+enum Foo {
+    VBar { num: int }
+}
+
+struct SBar { num: int }
+
+pub fn main() {
+    let vbar = VBar { num: 1 };
+    let VBar { num } = vbar;
+    assert_eq!(num, 1);
+
+    let sbar = SBar { num: 2 };
+    let SBar { num } = sbar;
+    assert_eq!(num, 2);
+}


### PR DESCRIPTION
We weren't passing the node id for the enum and hence it couldn't retrieve the field types for the struct variant we were trying to destructure.

Fixes #11577.
