### PR TITLE
rustdoc: syntax highlight macro definitions, colour $... substitutions.

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -146,7 +146,7 @@ pub fn render(w: &mut io::Writer, s: &str) -> fmt::Result {
                 };
 
                 if !rendered {
-                    let output = highlight::highlight(text).to_c_str();
+                    let output = highlight::highlight(text, None).to_c_str();
                     output.with_ref(|r| {
                         bufputs(ob, r)
                     })

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1630,13 +1630,13 @@ impl<'a> fmt::Show for Source<'a> {
             try!(write!(fmt.buf, "<span id='{0:u}'>{0:1$u}</span>\n", i, cols));
         }
         try!(write!(fmt.buf, "</pre>"));
-        try!(write!(fmt.buf, "{}", highlight::highlight(s.as_slice())));
+        try!(write!(fmt.buf, "{}", highlight::highlight(s.as_slice(), None)));
         Ok(())
     }
 }
 
 fn item_macro(w: &mut Writer, it: &clean::Item,
               t: &clean::Macro) -> fmt::Result {
-    try!(write!(w, "<pre class='macro'>{}</pre>", t.source));
+    try!(w.write_str(highlight::highlight(t.source, Some("macro"))));
     document(w, it)
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -315,6 +315,7 @@ pre.rust .op { color: #cc782f; }
 pre.rust .comment { color: #533add; }
 pre.rust .doccomment { color: #d343d0; }
 pre.rust .macro { color: #d343d0; }
+pre.rust .macro-nonterminal { color: #d343d0; }
 pre.rust .string { color: #c13928; }
 pre.rust .lifetime { color: #d343d0; }
 pre.rust .attribute { color: #d343d0 !important; }


### PR DESCRIPTION
Macro definitions are just their raw source code, and so should be
highlighted where possible. Also, $ident non-terminal substitutions are
special, and so are worthy of a little special treatment.
