### PR TITLE
librustc: add LLVM LDFLAGS to deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,11 @@ before_script:
 # Note that this is meant to run in a "fairly small" amount of time, so this
 # isn't exhaustive at all.
 #
-# The "-lffi and -lncurses" are required for LLVM. The LLVM that rust builds
-# manually disables bringing in these two libraries, but the stock LLVM was
-# apparently built with these options. We provide these options when building so
-# the `rustc` binary can successfully link.
-#
 # As a result of https://github.com/travis-ci/travis-ci/issues/1066, we run
 # everything in one large command instead of multiple commands.
 script: |
   make tidy &&
-  RUSTFLAGS="-C link-args='-lffi -lncurses'" make -j4 rustc-stage1 &&
+  make -j4 rustc-stage1 &&
   make check-stage1-std check-stage1-rpass check-stage1-cfail check-stage1-rfail
 
 env:

--- a/src/etc/mklldeps.py
+++ b/src/etc/mklldeps.py
@@ -55,6 +55,7 @@ for llconfig in sys.argv[3:]:
 
     f.write("#[cfg(" + ', '.join(cfg) + ")]\n")
 
+    # LLVM libs
     args = [llconfig, '--libs']
     args.extend(components)
     proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -67,6 +68,21 @@ for llconfig in sys.argv[3:]:
     for lib in out.strip().split(' '):
         lib = lib[2:] # chop of the leading '-l'
         f.write("#[link(name = \"" + lib + "\", kind = \"static\")]\n")
+
+    # LLVM ldflags
+    args = [llconfig, '--ldflags']
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+
+    if err:
+        print("failed to run llconfig: args = `{}`".format(args))
+        sys.exit(1)
+
+    for lib in out.strip().split(' '):
+        if lib[:2] == "-l":
+            f.write("#[link(name = \"" + lib[2:] + "\")]\n")
+
+    #extra
     f.write("#[link(name = \"stdc++\")]\n")
     if os == 'win32':
         f.write("#[link(name = \"imagehlp\")]\n")


### PR DESCRIPTION
This commit let librustc automatically pickup LDFLAGS dependencies
inherited from LLVM, which may otherwise result in undefined
references to external symbols under certain linking environment.

A symptom of this issue is eg. a failure when trying to link against
librustc (due to unresolved ffi_\* symbols), while using a system-wide
LLVM.

Signed-off-by: Luca Bruno lucab@debian.org
