### PR TITLE
test: Ignore some phase(syntax) tests

### DIFF
--- a/src/test/compile-fail/macro-crate-unexported-macro.rs
+++ b/src/test/compile-fail/macro-crate-unexported-macro.rs
@@ -11,6 +11,7 @@
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 // ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 

--- a/src/test/compile-fail/phase-syntax-doesnt-resolve.rs
+++ b/src/test/compile-fail/phase-syntax-doesnt-resolve.rs
@@ -11,6 +11,7 @@
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 // ignore-android
+// ignore-cross-compile #12102
 
 #[feature(phase)];
 


### PR DESCRIPTION
These tests are failing on the snap builders, and are now tagged with a FIXME.

cc #12102
