### PR TITLE
Cleaned up `std::any`.

### DIFF
--- a/src/libgreen/simple.rs
+++ b/src/libgreen/simple.rs
@@ -11,6 +11,7 @@
 //! A small module implementing a simple "runtime" used for bootstrapping a rust
 //! scheduler pool and then interacting with it.
 
+use std::any::Any;
 use std::cast;
 use std::rt::Runtime;
 use std::rt::local::Local;

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -18,6 +18,7 @@
 //! contains the rust task itself in order to juggle around ownership of the
 //! values.
 
+use std::any::Any;
 use std::cast;
 use std::rt::env;
 use std::rt::Runtime;

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -14,6 +14,7 @@
 //! by rust tasks. This implements the necessary API traits laid out by std::rt
 //! in order to spawn new tasks and deschedule the current task.
 
+use std::any::Any;
 use std::cast;
 use std::rt::env;
 use std::rt::local::Local;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -46,6 +46,7 @@ use middle::lint;
 
 use d = driver::driver;
 
+use std::any::AnyRefExt;
 use std::cmp;
 use std::io;
 use std::os;

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2229,6 +2229,7 @@ mod tests {
         B(~str)
     }
     fn check_err<T: Decodable<Decoder>>(to_parse: &'static str, expected_error: &str) {
+        use std::any::AnyRefExt;
         use std::task;
         let res = task::try(proc() {
             // either fails in `decode` (which is what we want), or

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -35,7 +35,6 @@ pub use mem::drop;
 
 // Reexported types and traits
 
-pub use any::{Any, AnyOwnExt, AnyRefExt, AnyMutRefExt};
 pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr, IntoBytes};
 pub use c_str::ToCStr;
 pub use char::Char;

--- a/src/libstd/raw.rs
+++ b/src/libstd/raw.rs
@@ -10,6 +10,13 @@
 
 #[allow(missing_doc)];
 
+//! Contains struct definitions for the layout of compiler built-in types.
+//!
+//! They can be used as targets of transmutes in unsafe code for manipulating
+//! the raw representations directly.
+//!
+//! Their definitition should always match the ABI defined in `rustc::back::abi`.
+
 use cast;
 
 /// The representation of a Rust managed box
@@ -49,13 +56,22 @@ pub struct Procedure {
     env: *(),
 }
 
+/// The representation of a Rust trait object.
+///
+/// This struct does not have a `Repr` implementation
+/// because there is no way to refer to all trait objects generically.
+pub struct TraitObject {
+    vtable: *(),
+    data: *(),
+}
+
 /// This trait is meant to map equivalences between raw structs and their
 /// corresponding rust values.
 pub trait Repr<T> {
     /// This function "unwraps" a rust value (without consuming it) into its raw
     /// struct representation. This can be used to read/write different values
     /// for the struct. This is a safe method because by default it does not
-    /// give write-access to the struct returned.
+    /// enable write-access to the fields of the return value in safe code.
     #[inline]
     fn repr(&self) -> T { unsafe { cast::transmute_copy(self) } }
 }

--- a/src/libsync/sync/mod.rs
+++ b/src/libsync/sync/mod.rs
@@ -976,6 +976,8 @@ mod tests {
     }
     #[test]
     fn test_mutex_killed_simple() {
+        use std::any::Any;
+
         // Mutex must get automatically unlocked if failed/killed within.
         let m = Mutex::new();
         let m2 = m.clone();
@@ -992,6 +994,8 @@ mod tests {
     #[ignore(reason = "linked failure")]
     #[test]
     fn test_mutex_killed_cond() {
+        use std::any::Any;
+
         // Getting killed during cond wait must not corrupt the mutex while
         // unwinding (e.g. double unlock).
         let m = Mutex::new();
@@ -1019,6 +1023,7 @@ mod tests {
     #[ignore(reason = "linked failure")]
     #[test]
     fn test_mutex_killed_broadcast() {
+        use std::any::Any;
         use std::unstable::finally::Finally;
 
         let m = Mutex::new();
@@ -1329,6 +1334,8 @@ mod tests {
     }
     #[cfg(test)]
     fn rwlock_kill_helper(mode1: RWLockMode, mode2: RWLockMode) {
+        use std::any::Any;
+
         // Mutex must get automatically unlocked if failed/killed within.
         let x = RWLock::new();
         let x2 = x.clone();

--- a/src/test/run-fail/fail-macro-any.rs
+++ b/src/test/run-fail/fail-macro-any.rs
@@ -11,5 +11,5 @@
 // error-pattern:failed at '~Any'
 
 fn main() {
-    fail!(~413 as ~Any);
+    fail!(~413 as ~::std::any::Any);
 }

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -10,6 +10,7 @@
 
 // Make sure the destructor is run for unit-like structs.
 
+use std::any::AnyOwnExt;
 use std::task;
 
 struct Foo;


### PR DESCRIPTION
- Added `TraitObject` representation to `std::raw`.
- Added doc to `std::raw`.
- Removed `Any::as_void_ptr()` and `Any::as_mut_void_ptr()`
  methods as they are uneccessary now after the removal of
  headers on owned boxes. This reduces the number of virtual calls needed from 2 to 1.
- Made the `..Ext` implementations work directly with the repr of
  a trait object.
- Removed `Any`-related traits from the prelude.
- Added bench.

Bench before/after:

```
7 ns/iter (+/- 0)
4 ns/iter (+/- 0)
```
