### PR TITLE
syntax: make match arms store the expr directly.

### DIFF
--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -300,7 +300,7 @@ impl CFGBuilder {
                     guard_exit = self.opt_expr(arm.guard, guard_exit); // 2
                     let pats_exit = self.pats_any(arm.pats.as_slice(),
                                                   guard_exit); // 3
-                    let body_exit = self.block(arm.body, pats_exit);    // 4
+                    let body_exit = self.expr(arm.body, pats_exit);      // 4
                     self.add_contained_edge(body_exit, expr_exit);       // 5
                 }
                 expr_exit

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -534,7 +534,7 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
                     self.walk_pat_alternatives(arm.pats.as_slice(),
                                                body,
                                                loop_scopes);
-                    self.walk_block(arm.body, body, loop_scopes);
+                    self.walk_expr(arm.body, body, loop_scopes);
                     join_bits(&self.dfcx.oper, body, in_out);
                 }
             }
@@ -915,4 +915,3 @@ fn bit_str(bit: uint) -> ~str {
     let lobits = 1 << (bit & 0xFF);
     format!("[{}:{}-{:02x}]", bit, byte, lobits)
 }
-

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1125,7 +1125,7 @@ impl Liveness {
             let mut first_merge = true;
             for arm in arms.iter() {
                 let body_succ =
-                    self.propagate_through_block(arm.body, succ);
+                    self.propagate_through_expr(arm.body, succ);
                 let guard_succ =
                     self.propagate_through_opt_expr(arm.guard, body_succ);
                 let arm_succ =

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -632,7 +632,7 @@ impl VisitContext {
             self.consume_expr(*guard);
         }
 
-        self.consume_block(arm.body);
+        self.consume_expr(arm.body);
     }
 
     pub fn use_pat(&mut self, pat: @Pat) {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4248,7 +4248,7 @@ impl Resolver {
         self.check_consistent_bindings(arm);
 
         visit::walk_expr_opt(self, arm.guard, ());
-        self.resolve_block(arm.body);
+        self.resolve_expr(arm.body);
 
         let mut value_ribs = self.value_ribs.borrow_mut();
         value_ribs.get().pop();

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1939,7 +1939,7 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
         let cleanup_scope = fcx.push_custom_cleanup_scope();
         bcx = insert_lllocals(bcx, arm_data.bindings_map,
                               cleanup::CustomScope(cleanup_scope));
-        bcx = controlflow::trans_block(bcx, arm_data.arm.body, dest);
+        bcx = expr::trans_into(bcx, arm_data.arm.body, dest);
         bcx = fcx.pop_and_trans_custom_cleanup_scope(bcx, cleanup_scope);
         arm_cxs.push(bcx);
     }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -2665,7 +2665,7 @@ fn populate_scope_map(cx: &CrateContext,
                             walk_expr(cx, *guard_exp, scope_stack, scope_map)
                         }
 
-                        walk_block(cx, arm_ref.body, scope_stack, scope_map);
+                        walk_expr(cx, arm_ref.body, scope_stack, scope_map);
                     })
                 }
             }

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -13,7 +13,7 @@
 use middle::pat_util::{PatIdMap, pat_id_map, pat_is_binding, pat_is_const};
 use middle::ty;
 use middle::typeck::check::demand;
-use middle::typeck::check::{check_block, check_expr_has_type, FnCtxt};
+use middle::typeck::check::{check_expr, check_expr_has_type, FnCtxt};
 use middle::typeck::check::{instantiate_path, lookup_def};
 use middle::typeck::check::{structure_of, valid_range_bounds};
 use middle::typeck::infer;
@@ -74,7 +74,7 @@ pub fn check_match(fcx: @FnCtxt,
           },
           None => ()
         }
-        check_block(fcx, arm.body);
+        check_expr(fcx, arm.body);
         let bty = fcx.node_ty(arm.body.id);
         saw_err = saw_err || ty::type_is_error(bty);
         if guard_err {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -491,7 +491,7 @@ pub enum Decl_ {
 pub struct Arm {
     pats: Vec<@Pat> ,
     guard: Option<@Expr>,
-    body: P<Block>,
+    body: @Expr,
 }
 
 #[deriving(Clone, Eq, Encodable, Decodable, Hash)]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -679,7 +679,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         ast::Arm {
             pats: pats,
             guard: None,
-            body: self.block_expr(expr)
+            body: expr
         }
     }
 

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -110,7 +110,7 @@ fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure
                         let arm = ast::Arm {
                             pats: vec!(cx.pat_wild(span)),
                             guard: Some(guard),
-                            body: cx.block_expr(body),
+                            body: body,
                         };
 
                         arms.push(arm);
@@ -129,7 +129,7 @@ fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure
             let arm = ast::Arm {
                 pats: vec!(cx.pat_wild(trait_span)),
                 guard: None,
-                body: cx.block_expr(cx.expr_none(trait_span)),
+                body: cx.expr_none(trait_span),
             };
             arms.push(arm);
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -117,7 +117,7 @@ pub trait Folder {
         Arm {
             pats: a.pats.map(|x| self.fold_pat(*x)),
             guard: a.guard.map(|x| self.fold_expr(x)),
-            body: self.fold_block(a.body),
+            body: self.fold_expr(a.body),
         }
     }
 
@@ -933,4 +933,3 @@ mod test {
                      ~"zz!zz((zz$zz:zz$(zz $zz:zz)zz+=>(zz$(zz$zz$zz)+)))");
     }
 }
-

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2634,16 +2634,7 @@ impl Parser {
                 self.eat(&token::COMMA);
             }
 
-            let blk = P(ast::Block {
-                view_items: Vec::new(),
-                stmts: Vec::new(),
-                expr: Some(expr),
-                id: ast::DUMMY_NODE_ID,
-                rules: DefaultBlock,
-                span: expr.span,
-            });
-
-            arms.push(ast::Arm { pats: pats, guard: guard, body: blk });
+            arms.push(ast::Arm { pats: pats, guard: guard, body: expr });
         }
         let hi = self.span.hi;
         self.bump();

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1352,38 +1352,22 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) -> io::IoResult<()> {
             }
             try!(word_space(s, "=>"));
 
-            // Extract the expression from the extra block the parser adds
-            // in the case of foo => expr
-            if arm.body.view_items.is_empty() &&
-                arm.body.stmts.is_empty() &&
-                arm.body.rules == ast::DefaultBlock &&
-                arm.body.expr.is_some()
-            {
-                match arm.body.expr {
-                    Some(expr) => {
-                        match expr.node {
-                            ast::ExprBlock(blk) => {
-                                // the block will close the pattern's ibox
-                                try!(print_block_unclosed_indent(
-                                    s, blk, indent_unit));
-                            }
-                            _ => {
-                                try!(end(s)); // close the ibox for the pattern
-                                try!(print_expr(s, expr));
-                            }
-                        }
-                        if !expr_is_simple_block(expr)
-                            && i < len - 1 {
-                            try!(word(&mut s.s, ","));
-                        }
-                        try!(end(s)); // close enclosing cbox
-                    }
-                    None => fail!()
+            match arm.body.node {
+                ast::ExprBlock(blk) => {
+                    // the block will close the pattern's ibox
+                    try!(print_block_unclosed_indent(
+                                s, blk, indent_unit));
                 }
-            } else {
-                // the block will close the pattern's ibox
-                try!(print_block_unclosed_indent(s, arm.body, indent_unit));
+                _ => {
+                    try!(end(s)); // close the ibox for the pattern
+                    try!(print_expr(s, arm.body));
+                }
             }
+            if !expr_is_simple_block(expr)
+                && i < len - 1 {
+                try!(word(&mut s.s, ","));
+            }
+            try!(end(s)); // close enclosing cbox
         }
         try!(bclose_(s, expr.span, indent_unit));
       }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -765,5 +765,5 @@ pub fn walk_arm<E: Clone, V: Visitor<E>>(visitor: &mut V, arm: &Arm, env: E) {
         visitor.visit_pat(*pattern, env.clone())
     }
     walk_expr_opt(visitor, arm.guard, env.clone());
-    visitor.visit_block(arm.body, env)
+    visitor.visit_expr(arm.body, env)
 }


### PR DESCRIPTION
syntax: make match arms store the expr directly.

Previously `ast::Arm` was always storing a single `ast::Expr` wrapped in an
`ast::Block` (for historical reasons, AIUI), so we might as just store
that expr directly.

Closes #3085.
