### PR TITLE
Expand nested items within a backtrace.

### DIFF
--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -39,6 +39,14 @@ impl<T> FromIterator<T> for SmallVector<T> {
     }
 }
 
+impl<T> Extendable<T> for SmallVector<T> {
+    fn extend<I: Iterator<T>>(&mut self, iter: &mut I) {
+        for val in *iter {
+            self.push(val);
+        }
+    }
+}
+
 impl<T> SmallVector<T> {
     pub fn zero() -> SmallVector<T> {
         Zero


### PR DESCRIPTION
Fixes a regression from #4913 which causes items to be exanded with spans lacking expn_info from the context's current backtrace.
