### PR TITLE
rustc: Streamline error messages for i18n, using `plural` whenever possible

### DIFF
--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -376,17 +376,14 @@ pub fn trans_intrinsic(ccx: @CrateContext,
                     ast_map::NodeExpr(e) => e.span,
                     _ => fail!("transmute has non-expr arg"),
                 };
-                let pluralize = |n| if 1 == n { "" } else { "s" };
                 ccx.sess.span_fatal(sp,
-                                    format!("transmute called on types with \
-                                          different sizes: {} ({} bit{}) to \
-                                          {} ({} bit{})",
-                                         ty_to_str(ccx.tcx, in_type),
-                                         in_type_size,
-                                         pluralize(in_type_size),
-                                         ty_to_str(ccx.tcx, out_type),
-                                         out_type_size,
-                                         pluralize(out_type_size)));
+                    format!("transmute called on types with different sizes: \
+                             {intype} ({insize, plural, =1{# bit} other{# bits}}) to \
+                             {outtype} ({outsize, plural, =1{# bit} other{# bits}})",
+                            intype = ty_to_str(ccx.tcx, in_type),
+                            insize = in_type_size as uint,
+                            outtype = ty_to_str(ccx.tcx, out_type),
+                            outsize = out_type_size as uint));
             }
 
             if !return_type_is_void(ccx, out_type) {

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -247,12 +247,13 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
     if arg_len > 0 {
         // N-ary variant.
         if arg_len != subpats_len {
-            let s = format!("this pattern has {} field{}, but the corresponding {} has {} field{}",
-                         subpats_len,
-                         if subpats_len == 1u { ~"" } else { ~"s" },
-                         kind_name,
-                         arg_len,
-                         if arg_len == 1u { ~"" } else { ~"s" });
+            let s = format!("this pattern has \
+                             {npat, plural, =1{# field} other{# fields}}, \
+                             but the corresponding {kind} has \
+                             {narg, plural, =1{# field} other{# fields}}",
+                         npat = subpats_len,
+                         kind = kind_name,
+                         narg = arg_len);
             tcx.sess.span_err(pat.span, s);
             error_happened = true;
         }
@@ -266,11 +267,11 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
         }
     } else if subpats_len > 0 {
         tcx.sess.span_err(pat.span,
-                          format!("this pattern has {} field{}, but the corresponding {} has no \
-                                fields",
-                               subpats_len,
-                               if subpats_len == 1u { "" } else { "s" },
-                               kind_name));
+                          format!("this pattern has \
+                                   {npat, plural, =1{# field} other{# fields}}, \
+                                   but the corresponding {kind} has no fields",
+                               npat = subpats_len,
+                               kind = kind_name));
         error_happened = true;
     }
 

--- a/src/test/compile-fail/bad-mid-path-type-params.rs
+++ b/src/test/compile-fail/bad-mid-path-type-params.rs
@@ -43,10 +43,10 @@ impl Trait<int> for S2 {
 fn foo<'a>() {
     let _ = S::new::<int,f64>(1, 1.0);
     //~^ ERROR the impl referenced by this path needs 1 type parameter, but 0 type parameters were supplied
-    let _ = S::<'a,int>::new::<f64>(1, 1.0); //~ ERROR expected 0 lifetime parameter(s)
+    let _ = S::<'a,int>::new::<f64>(1, 1.0); //~ ERROR expected 0 lifetime parameters
     let _: S2 = Trait::new::<int,f64>(1, 1.0);
     //~^ ERROR the trait referenced by this path needs 1 type parameter, but 0 type parameters were supplied
-    let _: S2 = Trait::<'a,int>::new::<f64>(1, 1.0); //~ ERROR expected 0 lifetime parameter(s)
+    let _: S2 = Trait::<'a,int>::new::<f64>(1, 1.0); //~ ERROR expected 0 lifetime parameters
 }
 
 fn main() {}


### PR DESCRIPTION
While we are not yet ready for compiler i18n, this also keeps the error handling code clean. The set of altered error messages was obtained by grepping for `"s"` and `(s)`, so there might be some missing messages.
