### PR TITLE
Add a Share kind

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -595,10 +595,10 @@ Other features provided by lang items include:
 - stack unwinding and general failure; the `eh_personality`, `fail_`
   and `fail_bounds_checks` lang items.
 - the traits in `std::kinds` used to indicate types that satisfy
-  various kinds; lang items `send`, `freeze` and `pod`.
+  various kinds; lang items `send`, `share` and `pod`.
 - the marker types and variance indicators found in
   `std::kinds::markers`; lang items `covariant_type`,
-  `contravariant_lifetime`, `no_freeze_bound`, etc.
+  `contravariant_lifetime`, `no_share_bound`, etc.
 
 Lang items are loaded lazily by the compiler; e.g. if one never uses
 `~` then there is no need to define functions for `exchange_malloc`

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2095,6 +2095,10 @@ and may not be overridden:
 Types are sendable
 unless they contain managed boxes, managed closures, or references.
 
+* `Share` - Types that are *threadsafe*
+These are types that are safe to be used across several threads with access to
+a `&T` pointer. `MutexArc` is an example of a *sharable* type with internal mutable data.
+
 * `Freeze` - Constant (immutable) types.
 These are types that do not contain anything intrinsically mutable.
 Intrinsically mutable values include `Cell` in the standard library.

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -603,6 +603,9 @@ fn parse_bounds(st: &mut PState, conv: conv_did) -> ty::ParamBounds {
             'P' => {
                 param_bounds.builtin_bounds.add(ty::BoundPod);
             }
+            'T' => {
+                param_bounds.builtin_bounds.add(ty::BoundShare);
+            }
             'I' => {
                 param_bounds.trait_bounds.push(@parse_trait_ref(st, |x,y| conv(x,y)));
             }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -410,6 +410,7 @@ fn enc_bounds(w: &mut MemWriter, cx: &ctxt, bs: &ty::ParamBounds) {
             ty::BoundStatic => mywrite!(w, "O"),
             ty::BoundSized => mywrite!(w, "Z"),
             ty::BoundPod => mywrite!(w, "P"),
+            ty::BoundShare => mywrite!(w, "T"),
         }
     }
 

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -518,11 +518,11 @@ impl<'a> CheckLoanCtxt<'a> {
                                             expr: &ast::Expr,
                                             cmt: mc::cmt)
                                             -> bool {
-            match cmt.freely_aliasable() {
+            match cmt.freely_aliasable(this.tcx()) {
                 None => {
                     return true;
                 }
-                Some(mc::AliasableStaticMut) => {
+                Some(mc::AliasableStaticMut(..)) => {
                     return true;
                 }
                 Some(cause) => {

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -69,6 +69,10 @@ impl<'a> Visitor<()> for BorrowckCtxt<'a> {
                 b: &Block, s: Span, n: NodeId, _: ()) {
         borrowck_fn(self, fk, fd, b, s, n);
     }
+
+    fn visit_item(&mut self, item: &ast::Item, _: ()) {
+        borrowck_item(self, item);
+    }
 }
 
 pub fn check_crate(tcx: &ty::ctxt,
@@ -117,6 +121,20 @@ pub fn check_crate(tcx: &ty::ctxt,
     }
 }
 
+fn borrowck_item(this: &mut BorrowckCtxt, item: &ast::Item) {
+    // Gather loans for items. Note that we don't need
+    // to check loans for single expressions. The check
+    // loan step is intended for things that have a data
+    // flow dependent conditions.
+    match item.node {
+        ast::ItemStatic(_, _, ex) => {
+            gather_loans::gather_loans_in_static_initializer(this, ex);
+        }
+        _ => {}
+    }
+    visit::walk_item(this, item, ());
+}
+
 fn borrowck_fn(this: &mut BorrowckCtxt,
                fk: &FnKind,
                decl: &ast::FnDecl,
@@ -127,7 +145,7 @@ fn borrowck_fn(this: &mut BorrowckCtxt,
 
     // Check the body of fn items.
     let (id_range, all_loans, move_data) =
-        gather_loans::gather_loans(this, decl, body);
+        gather_loans::gather_loans_in_fn(this, decl, body);
     let mut loan_dfcx =
         DataFlowContext::new(this.tcx,
                              this.method_map,

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -130,9 +130,10 @@ fn borrowck_item(this: &mut BorrowckCtxt, item: &ast::Item) {
         ast::ItemStatic(_, _, ex) => {
             gather_loans::gather_loans_in_static_initializer(this, ex);
         }
-        _ => {}
+        _ => {
+            visit::walk_item(this, item, ());
+        }
     }
-    visit::walk_item(this, item, ());
 }
 
 fn borrowck_fn(this: &mut BorrowckCtxt,
@@ -733,8 +734,8 @@ impl<'a> BorrowckCtxt<'a> {
                     span,
                     format!("{} in an aliasable location", prefix));
             }
-            mc::AliasableStatic |
-            mc::AliasableStaticMut => {
+            mc::AliasableStatic(..) |
+            mc::AliasableStaticMut(..) => {
                 self.tcx.sess.span_err(
                     span,
                     format!("{} in a static location", prefix));

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -233,6 +233,8 @@ lets_do_this! {
     ShrTraitLangItem,                "shr",                     shr_trait;
     IndexTraitLangItem,              "index",                   index_trait;
 
+    UnsafeTypeLangItem,              "unsafe",                  unsafe_type;
+
     DerefTraitLangItem,              "deref",                   deref_trait;
     DerefMutTraitLangItem,           "deref_mut",               deref_mut_trait;
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -22,7 +22,7 @@
 
 use driver::session::Session;
 use metadata::csearch::each_lang_item;
-use middle::ty::{BuiltinBound, BoundFreeze, BoundPod, BoundSend, BoundSized};
+use middle::ty;
 use syntax::ast;
 use syntax::ast_util::local_def;
 use syntax::attr::AttrMetaMethods;
@@ -82,15 +82,17 @@ impl LanguageItems {
         }
     }
 
-    pub fn to_builtin_kind(&self, id: ast::DefId) -> Option<BuiltinBound> {
+    pub fn to_builtin_kind(&self, id: ast::DefId) -> Option<ty::BuiltinBound> {
         if Some(id) == self.freeze_trait() {
-            Some(BoundFreeze)
+            Some(ty::BoundFreeze)
         } else if Some(id) == self.send_trait() {
-            Some(BoundSend)
+            Some(ty::BoundSend)
         } else if Some(id) == self.sized_trait() {
-            Some(BoundSized)
+            Some(ty::BoundSized)
         } else if Some(id) == self.pod_trait() {
-            Some(BoundPod)
+            Some(ty::BoundPod)
+        } else if Some(id) == self.share_trait() {
+            Some(ty::BoundShare)
         } else {
             None
         }
@@ -213,6 +215,7 @@ lets_do_this! {
     SendTraitLangItem,               "send",                    send_trait;
     SizedTraitLangItem,              "sized",                   sized_trait;
     PodTraitLangItem,                "pod",                     pod_trait;
+    ShareTraitLangItem,              "share",                   share_trait;
 
     DropTraitLangItem,               "drop",                    drop_trait;
 
@@ -274,5 +277,6 @@ lets_do_this! {
     NoFreezeItem,                    "no_freeze_bound",         no_freeze_bound;
     NoSendItem,                      "no_send_bound",           no_send_bound;
     NoPodItem,                       "no_pod_bound",            no_pod_bound;
+    NoShareItem,                     "no_share_bound",          no_share_bound;
     ManagedItem,                     "managed_bound",           managed_bound;
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -850,6 +850,7 @@ pub enum BuiltinBound {
     BoundFreeze,
     BoundSized,
     BoundPod,
+    BoundShare,
 }
 
 pub fn EmptyBuiltinBounds() -> BuiltinBounds {
@@ -862,6 +863,7 @@ pub fn AllBuiltinBounds() -> BuiltinBounds {
     set.add(BoundSend);
     set.add(BoundFreeze);
     set.add(BoundSized);
+    set.add(BoundShare);
     set
 }
 
@@ -1872,31 +1874,32 @@ macro_rules! def_type_content_sets(
 
 def_type_content_sets!(
     mod TC {
-        None                                = 0b0000__00000000__0000,
+        None                                = 0b0000_0000__0000_0000__0000,
 
         // Things that are interior to the value (first nibble):
-        InteriorUnsized                     = 0b0000__00000000__0001,
-        // InteriorAll                         = 0b0000__00000000__1111,
+        InteriorUnsized                     = 0b0000_0000__0000_0000__0001,
+        // InteriorAll                         = 0b0000_0000__0000_0000__1111,
 
         // Things that are owned by the value (second and third nibbles):
-        OwnsOwned                           = 0b0000__00000001__0000,
-        OwnsDtor                            = 0b0000__00000010__0000,
-        OwnsManaged /* see [1] below */     = 0b0000__00000100__0000,
-        OwnsAffine                          = 0b0000__00001000__0000,
-        OwnsAll                             = 0b0000__11111111__0000,
+        OwnsOwned                           = 0b0000_0000__0000_0001__0000,
+        OwnsDtor                            = 0b0000_0000__0000_0010__0000,
+        OwnsManaged /* see [1] below */     = 0b0000_0000__0000_0100__0000,
+        OwnsAffine                          = 0b0000_0000__0000_1000__0000,
+        OwnsAll                             = 0b0000_0000__1111_1111__0000,
 
         // Things that are reachable by the value in any way (fourth nibble):
-        ReachesNonsendAnnot                 = 0b0001__00000000__0000,
-        ReachesBorrowed                     = 0b0010__00000000__0000,
-        // ReachesManaged /* see [1] below */  = 0b0100__00000000__0000,
-        ReachesMutable                      = 0b1000__00000000__0000,
-        ReachesAll                          = 0b1111__00000000__0000,
+        ReachesNonsendAnnot                 = 0b0000_0001__0000_0000__0000,
+        ReachesBorrowed                     = 0b0000_0010__0000_0000__0000,
+        // ReachesManaged /* see [1] below */  = 0b0000_0100__0000_0000__0000,
+        ReachesMutable                      = 0b0000_1000__0000_0000__0000,
+        ReachesNoShare                      = 0b0001_0000__0000_0000__0000,
+        ReachesAll                          = 0b0001_1111__0000_0000__0000,
 
         // Things that cause values to *move* rather than *copy*
-        Moves                               = 0b0000__00001011__0000,
+        Moves                               = 0b0000_0000__0000_1011__0000,
 
         // Things that mean drop glue is necessary
-        NeedsDrop                           = 0b0000__00000111__0000,
+        NeedsDrop                           = 0b0000_0000__0000_0111__0000,
 
         // Things that prevent values from being sent
         //
@@ -1905,31 +1908,34 @@ def_type_content_sets!(
         //       both ReachesManaged and OwnsManaged so that when
         //       a parameter has a bound T:Send, we are able to deduce
         //       that it neither reaches nor owns a managed pointer.
-        Nonsendable                         = 0b0111__00000100__0000,
+        Nonsendable                         = 0b0000_0111__0000_0100__0000,
 
         // Things that prevent values from being considered freezable
-        Nonfreezable                        = 0b1000__00000000__0000,
+        Nonfreezable                        = 0b0000_1000__0000_0000__0000,
 
         // Things that prevent values from being considered 'static
-        Nonstatic                           = 0b0010__00000000__0000,
+        Nonstatic                           = 0b0000_0010__0000_0000__0000,
 
         // Things that prevent values from being considered sized
-        Nonsized                            = 0b0000__00000000__0001,
+        Nonsized                            = 0b0000_0000__0000_0000__0001,
+
+        // Things that prevent values from being shared
+        Nonsharable                         = 0b0001_0000__0000_0000__0000,
 
         // Things that make values considered not POD (would be same
         // as `Moves`, but for the fact that managed data `@` is
         // not considered POD)
-        Nonpod                              = 0b0000__00001111__0000,
+        Nonpod                              = 0b0000_0000__0000_1111__0000,
 
         // Bits to set when a managed value is encountered
         //
         // [1] Do not set the bits TC::OwnsManaged or
         //     TC::ReachesManaged directly, instead reference
         //     TC::Managed to set them both at once.
-        Managed                             = 0b0100__00000100__0000,
+        Managed                             = 0b0000_0100__0000_0100__0000,
 
         // All bits
-        All                                 = 0b1111__11111111__1111
+        All                                 = 0b1111_1111__1111_1111__1111
     }
 )
 
@@ -1945,6 +1951,7 @@ impl TypeContents {
             BoundSend => self.is_sendable(cx),
             BoundSized => self.is_sized(cx),
             BoundPod => self.is_pod(cx),
+            BoundShare => self.is_sharable(cx),
         }
     }
 
@@ -1962,6 +1969,10 @@ impl TypeContents {
 
     pub fn is_sendable(&self, _: &ctxt) -> bool {
         !self.intersects(TC::Nonsendable)
+    }
+
+    pub fn is_sharable(&self, _: &ctxt) -> bool {
+        !self.intersects(TC::Nonsharable)
     }
 
     pub fn owns_managed(&self) -> bool {
@@ -2284,6 +2295,8 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
             tc | TC::Managed
         } else if Some(did) == cx.lang_items.no_pod_bound() {
             tc | TC::OwnsAffine
+        } else if Some(did) == cx.lang_items.no_share_bound() {
+            tc | TC::ReachesNoShare
         } else {
             tc
         }
@@ -2362,6 +2375,7 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
                 BoundFreeze => TC::Nonfreezable,
                 BoundSized => TC::Nonsized,
                 BoundPod => TC::Nonpod,
+                BoundShare => TC::Nonsharable,
             };
         });
         return tc;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1878,7 +1878,8 @@ def_type_content_sets!(
 
         // Things that are interior to the value (first nibble):
         InteriorUnsized                     = 0b0000_0000__0000_0000__0001,
-        // InteriorAll                         = 0b0000_0000__0000_0000__1111,
+        InteriorUnsafe                      = 0b0000_0000__0000_0000__0010,
+        // InteriorAll                         = 0b00000000__00000000__1111,
 
         // Things that are owned by the value (second and third nibbles):
         OwnsOwned                           = 0b0000_0000__0000_0001__0000,
@@ -2297,6 +2298,8 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
             tc | TC::OwnsAffine
         } else if Some(did) == cx.lang_items.no_share_bound() {
             tc | TC::ReachesNoShare
+        } else if Some(did) == cx.lang_items.unsafe_type() {
+            tc | TC::InteriorUnsafe
         } else {
             tc
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1996,6 +1996,10 @@ impl TypeContents {
         !self.intersects(TC::Nonpod)
     }
 
+    pub fn interior_unsafe(&self) -> bool {
+        self.intersects(TC::InteriorUnsafe)
+    }
+
     pub fn moves_by_default(&self, _: &ctxt) -> bool {
         self.intersects(TC::Moves)
     }
@@ -2090,6 +2094,10 @@ pub fn type_is_sendable(cx: &ctxt, t: ty::t) -> bool {
 
 pub fn type_is_freezable(cx: &ctxt, t: ty::t) -> bool {
     type_contents(cx, t).is_freezable(cx)
+}
+
+pub fn type_interior_is_unsafe(cx: &ctxt, t: ty::t) -> bool {
+    type_contents(cx, t).interior_unsafe()
 }
 
 pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -674,6 +674,7 @@ impl Repr for ty::ParamBounds {
                 ty::BoundFreeze => ~"Freeze",
                 ty::BoundSized => ~"Sized",
                 ty::BoundPod => ~"Pod",
+                ty::BoundShare => ~"Share",
             });
         }
         for t in self.trait_bounds.iter() {
@@ -961,6 +962,7 @@ impl UserString for ty::BuiltinBound {
             ty::BoundFreeze => ~"Freeze",
             ty::BoundSized => ~"Sized",
             ty::BoundPod => ~"Pod",
+            ty::BoundShare => ~"Share",
         }
     }
 }

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -23,6 +23,7 @@ pub struct Cell<T> {
     priv value: T,
     priv marker1: marker::InvariantType<T>,
     priv marker2: marker::NoFreeze,
+    priv marker3: marker::NoShare,
 }
 
 impl<T:Pod> Cell<T> {
@@ -32,6 +33,7 @@ impl<T:Pod> Cell<T> {
             value: value,
             marker1: marker::InvariantType::<T>,
             marker2: marker::NoFreeze,
+            marker3: marker::NoShare,
         }
     }
 
@@ -75,6 +77,7 @@ pub struct RefCell<T> {
     priv marker1: marker::InvariantType<T>,
     priv marker2: marker::NoFreeze,
     priv marker3: marker::NoPod,
+    priv marker4: marker::NoShare,
 }
 
 // Values [1, MAX-1] represent the number of `Ref` active
@@ -90,6 +93,7 @@ impl<T> RefCell<T> {
             marker1: marker::InvariantType::<T>,
             marker2: marker::NoFreeze,
             marker3: marker::NoPod,
+            marker4: marker::NoShare,
             value: value,
             borrow: UNUSED,
         }

--- a/src/libstd/kinds.rs
+++ b/src/libstd/kinds.rs
@@ -46,6 +46,22 @@ pub trait Pod {
     // Empty.
 }
 
+/// Types that can be safely shared between threads, hence thread-safe.
+#[cfg(stage0)]
+pub trait Share {
+    // Empty
+}
+
+#[cfg(stage0)]
+impl<T> Share for T {}
+
+/// Types that can be safely shared between threads, hence thread-safe.
+#[cfg(not(stage0))]
+#[lang="share"]
+pub trait Share {
+    // Empty
+}
+
 /// Marker types are special types that are used with unsafe code to
 /// inform the compiler of special constraints. Marker types should
 /// only be needed when you are creating an abstraction that is
@@ -231,6 +247,13 @@ pub mod marker {
     #[lang="no_pod_bound"]
     #[deriving(Eq,Clone)]
     pub struct NoPod;
+
+    /// A type which is considered "not sharable", meaning that
+    /// its contents are not threadsafe, hence they cannot be
+    /// shared between tasks.
+    #[lang="no_share_bound"]
+    #[deriving(Eq,Clone)]
+    pub struct NoShare;
 
     /// A type which is considered managed by the GC. This is typically
     /// embedded in other types.

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -83,6 +83,7 @@
 #[cfg(test)] pub use kinds = realstd::kinds;
 #[cfg(test)] pub use ops = realstd::ops;
 #[cfg(test)] pub use cmp = realstd::cmp;
+#[cfg(test)] pub use ty = realstd::ty;
 
 pub mod macros;
 
@@ -138,6 +139,7 @@ pub mod gc;
 #[cfg(not(test))] pub mod kinds;
 #[cfg(not(test))] pub mod ops;
 #[cfg(not(test))] pub mod cmp;
+#[cfg(not(test))] pub mod ty;
 
 
 /* Common traits */
@@ -226,5 +228,6 @@ mod std {
     pub use rt;
     pub use str;
     pub use to_str;
+    pub use ty;
     pub use unstable;
 }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -20,7 +20,7 @@ generally useful to many Rust programs.
 */
 
 // Reexported core operators
-pub use kinds::{Freeze, Pod, Send, Sized};
+pub use kinds::{Freeze, Pod, Send, Sized, Share};
 pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
 pub use ops::{BitAnd, BitOr, BitXor};
 pub use ops::{Drop, Deref, DerefMut};

--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -42,7 +42,8 @@ struct RcBox<T> {
 #[unsafe_no_drop_flag]
 pub struct Rc<T> {
     priv ptr: *mut RcBox<T>,
-    priv marker: marker::NoSend
+    priv nosend: marker::NoSend,
+    priv noshare: marker::NoShare
 }
 
 impl<T> Rc<T> {
@@ -56,7 +57,8 @@ impl<T> Rc<T> {
                 // strong destructor is running, even if the weak
                 // pointer is stored inside the strong one.
                 ptr: transmute(~RcBox { value: value, strong: 1, weak: 1 }),
-                marker: marker::NoSend,
+                nosend: marker::NoSend,
+                noshare: marker::NoShare
             }
         }
     }
@@ -67,7 +69,11 @@ impl<T> Rc<T> {
     pub fn downgrade(&self) -> Weak<T> {
         unsafe {
             (*self.ptr).weak += 1;
-            Weak { ptr: self.ptr, marker: marker::NoSend }
+            Weak {
+                ptr: self.ptr,
+                nosend: marker::NoSend,
+                noshare: marker::NoShare
+            }
         }
     }
 }
@@ -107,7 +113,7 @@ impl<T> Clone for Rc<T> {
     fn clone(&self) -> Rc<T> {
         unsafe {
             (*self.ptr).strong += 1;
-            Rc { ptr: self.ptr, marker: marker::NoSend }
+            Rc { ptr: self.ptr, nosend: marker::NoSend, noshare: marker::NoShare }
         }
     }
 }
@@ -138,7 +144,8 @@ impl<T: Ord> Ord for Rc<T> {
 #[unsafe_no_drop_flag]
 pub struct Weak<T> {
     priv ptr: *mut RcBox<T>,
-    priv marker: marker::NoSend
+    priv nosend: marker::NoSend,
+    priv noshare: marker::NoShare
 }
 
 impl<T> Weak<T> {
@@ -149,7 +156,7 @@ impl<T> Weak<T> {
                 None
             } else {
                 (*self.ptr).strong += 1;
-                Some(Rc { ptr: self.ptr, marker: marker::NoSend })
+                Some(Rc { ptr: self.ptr, nosend: marker::NoSend, noshare: marker::NoShare })
             }
         }
     }
@@ -176,7 +183,7 @@ impl<T> Clone for Weak<T> {
     fn clone(&self) -> Weak<T> {
         unsafe {
             (*self.ptr).weak += 1;
-            Weak { ptr: self.ptr, marker: marker::NoSend }
+            Weak { ptr: self.ptr, nosend: marker::NoSend, noshare: marker::NoShare }
         }
     }
 }

--- a/src/libstd/ty.rs
+++ b/src/libstd/ty.rs
@@ -1,0 +1,79 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Types dealing with unsafe actions.
+
+use cast;
+use kinds::marker;
+
+/// Unsafe type that wraps a type T and indicates unsafe interior operations on the
+/// wrapped type. Types with an `Unsafe<T>` field are considered to have an *unsafe
+/// interior*. The Unsafe type is the only legal way to obtain aliasable data that is
+/// considered mutable. In general, transmuting an &T type into an &mut T is considered
+/// undefined behavior.
+///
+/// Although it is possible to put an Unsafe<T> into static item, it is not permitted to
+/// take the address of the static item if the item is not declared as mutable. This rule
+/// exists because immutable static items are stored in read-only memory, and thus any
+/// attempt to mutate their interior can cause segfaults. Immutable static items containing
+/// Unsafe<T> instances are still useful as read-only initializers, however, so we do not
+/// forbid them altogether.
+///
+/// Types like `Cell` and `RefCell` use this type to wrap their internal data.
+///
+/// Unsafe doesn't opt-out from any kind, instead, types with an `Unsafe` interior
+/// are expected to opt-out from kinds themselves.
+///
+/// # Example:
+///
+/// ```rust
+/// use std::ty::Unsafe;
+/// use std::kinds::marker;
+///
+/// struct NotThreadSafe<T> {
+///     value: Unsafe<T>,
+///     marker1: marker::NoShare
+/// }
+/// ```
+///
+/// **NOTE:** Unsafe<T> fields are public to allow static initializers. It is not recommended
+/// to access its fields directly, `get` should be used instead.
+#[cfg(not(stage0))]
+#[lang="unsafe"]
+pub struct Unsafe<T> {
+    /// Wrapped value
+    value: T,
+
+    /// Invariance marker
+    marker1: marker::InvariantType<T>
+}
+
+/// Unsafe type for stage0
+#[cfg(stage0)]
+pub struct Unsafe<T> {
+    /// Wrapped value
+    value: T,
+
+    /// Invariance marker
+    marker1: marker::InvariantType<T>
+}
+
+
+impl<T> Unsafe<T> {
+
+    /// Static constructor
+    pub fn new(value: T) -> Unsafe<T> {
+        Unsafe{value: value, marker1: marker::InvariantType}
+    }
+
+    /// Gets a mutable pointer to the wrapped value
+    #[inline]
+    pub unsafe fn get(&self) -> *mut T { cast::transmute(&self.value) }
+}

--- a/src/libstd/ty.rs
+++ b/src/libstd/ty.rs
@@ -65,7 +65,6 @@ pub struct Unsafe<T> {
     marker1: marker::InvariantType<T>
 }
 
-
 impl<T> Unsafe<T> {
 
     /// Static constructor

--- a/src/libstd/ty.rs
+++ b/src/libstd/ty.rs
@@ -76,4 +76,8 @@ impl<T> Unsafe<T> {
     /// Gets a mutable pointer to the wrapped value
     #[inline]
     pub unsafe fn get(&self) -> *mut T { cast::transmute(&self.value) }
+
+    /// Unwraps the value
+    #[inline]
+    pub unsafe fn unwrap(self) -> T { self.value }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1159,12 +1159,12 @@ mod test {
 
     use std::vec_ng::Vec;
 
-    fn is_freeze<T: Freeze>() {}
+    fn is_share<T: Share>() {}
 
-    // Assert that the AST remains Freeze (#10693).
+    // Assert that the AST remains sharable.
     #[test]
-    fn ast_is_freeze() {
-        is_freeze::<Item>();
+    fn ast_is_share() {
+        is_share::<Item>();
     }
 
     // are ASTs encodable?

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1159,14 +1159,6 @@ mod test {
 
     use std::vec_ng::Vec;
 
-    fn is_share<T: Share>() {}
-
-    // Assert that the AST remains sharable.
-    #[test]
-    fn ast_is_share() {
-        is_share::<Item>();
-    }
-
     // are ASTs encodable?
     #[test]
     fn check_asts_encodable() {

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -23,13 +23,16 @@ use std::hash::Hash;
 use std::rc::Rc;
 use std::vec_ng::Vec;
 
+#[cfg(stage0)]
+use std::kinds::Share;
+
 pub struct Interner<T> {
     priv map: RefCell<HashMap<T, Name>>,
     priv vect: RefCell<Vec<T> >,
 }
 
 // when traits can extend traits, we should extend index<Name,T> to get []
-impl<T:Eq + Hash + Freeze + Clone + 'static> Interner<T> {
+impl<T: Eq + Hash + Share + Clone + 'static> Interner<T> {
     pub fn new() -> Interner<T> {
         Interner {
             map: RefCell::new(HashMap::new()),

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -23,16 +23,13 @@ use std::hash::Hash;
 use std::rc::Rc;
 use std::vec_ng::Vec;
 
-#[cfg(stage0)]
-use std::kinds::Share;
-
 pub struct Interner<T> {
     priv map: RefCell<HashMap<T, Name>>,
     priv vect: RefCell<Vec<T> >,
 }
 
 // when traits can extend traits, we should extend index<Name,T> to get []
-impl<T: Eq + Hash + Share + Clone + 'static> Interner<T> {
+impl<T: Eq + Hash + Clone + 'static> Interner<T> {
     pub fn new() -> Interner<T> {
         Interner {
             map: RefCell::new(HashMap::new()),

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -16,17 +16,17 @@ struct arc_destruct<T> {
 }
 
 #[unsafe_destructor]
-impl<T:Freeze> Drop for arc_destruct<T> {
+impl<T: Share> Drop for arc_destruct<T> {
     fn drop(&mut self) {}
 }
 
-fn arc_destruct<T:Freeze>(data: int) -> arc_destruct<T> {
+fn arc_destruct<T: Share>(data: int) -> arc_destruct<T> {
     arc_destruct {
         _data: data
     }
 }
 
-fn arc<T:Freeze>(_data: T) -> arc_destruct<T> {
+fn arc<T: Share>(_data: T) -> arc_destruct<T> {
     arc_destruct(0)
 }
 

--- a/src/test/compile-fail/borrowck-forbid-static-unsafe-interior.rs
+++ b/src/test/compile-fail/borrowck-forbid-static-unsafe-interior.rs
@@ -1,0 +1,47 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verify that it is not possible to take the address of
+// static items with usnafe interior.
+
+use std::kinds::marker;
+use std::ty::Unsafe;
+
+struct MyUnsafe<T> {
+    value: Unsafe<T>
+}
+
+impl<T> MyUnsafe<T> {
+    fn forbidden(&self) {}
+}
+
+enum UnsafeEnum<T> {
+    VariantSafe,
+    VariantUnsafe(Unsafe<T>)
+}
+
+static STATIC1: UnsafeEnum<int> = VariantSafe;
+
+static STATIC2: Unsafe<int> = Unsafe{value: 1, marker1: marker::InvariantType};
+static STATIC3: MyUnsafe<int> = MyUnsafe{value: STATIC2};
+
+static STATIC4: &'static Unsafe<int> = &'static STATIC2;
+//~^ ERROR borrow of immutable static items with unsafe interior is not allowed
+
+
+fn main() {
+    let a = &STATIC1;
+    //~^ ERROR borrow of immutable static items with unsafe interior is not allowed
+
+    STATIC3.forbidden()
+    //~^ ERROR borrow of immutable static items with unsafe interior is not allowed
+}
+
+

--- a/src/test/compile-fail/builtin-superkinds-double-superkind.rs
+++ b/src/test/compile-fail/builtin-superkinds-double-superkind.rs
@@ -11,12 +11,12 @@
 // Test for traits that inherit from multiple builtin kinds at once,
 // testing that all such kinds must be present on implementing types.
 
-trait Foo : Send+Freeze { }
+trait Foo : Send+Share { }
 
-impl <T: Freeze> Foo for (T,) { } //~ ERROR cannot implement this trait
+impl <T: Share> Foo for (T,) { } //~ ERROR cannot implement this trait
 
 impl <T: Send> Foo for (T,T) { } //~ ERROR cannot implement this trait
 
-impl <T: Send+Freeze> Foo for (T,T,T) { } // (ok)
+impl <T: Send+Share> Foo for (T,T,T) { } // (ok)
 
 fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-self-type.rs
+++ b/src/test/compile-fail/builtin-superkinds-self-type.rs
@@ -11,13 +11,13 @@
 // Tests (negatively) the ability for the Self type in default methods
 // to use capabilities granted by builtin kinds as supertraits.
 
-trait Foo : Freeze {
+trait Foo : Share {
     fn foo(self, mut chan: Sender<Self>) {
         chan.send(self); //~ ERROR does not fulfill `Send`
     }
 }
 
-impl <T: Freeze> Foo for T { }
+impl <T: Share> Foo for T { }
 
 fn main() {
     let (tx, rx) = channel();

--- a/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
+++ b/src/test/compile-fail/builtin-superkinds-typaram-not-send.rs
@@ -12,6 +12,6 @@
 
 trait Foo : Send { }
 
-impl <T: Freeze> Foo for T { } //~ ERROR cannot implement this trait
+impl <T: Share> Foo for T { } //~ ERROR cannot implement this trait
 
 fn main() { }

--- a/src/test/compile-fail/cant-implement-builtin-kinds.rs
+++ b/src/test/compile-fail/cant-implement-builtin-kinds.rs
@@ -14,6 +14,6 @@ struct X<T>(T);
 
 impl <T> Send for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
 impl <T> Sized for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
-impl <T> Freeze for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
+impl <T> Share for X<T> { } //~ ERROR cannot provide an explicit implementation for a builtin kind
 
 fn main() { }

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -124,30 +124,6 @@ static STATIC18: @SafeStruct = @SafeStruct{field1: Variant1, field2: Variant2(0)
 static STATIC19: ~int = box 3;
 //~^ ERROR static items are not allowed to have owned pointers
 
-
-struct StructNoFreeze<'a> {
-    nf: &'a int
-}
-
-enum EnumNoFreeze<'a> {
-    FreezableVariant,
-    NonFreezableVariant(StructNoFreeze<'a>)
-}
-
-static STATIC20: StructNoFreeze<'static> = StructNoFreeze{nf: &'static mut 4};
-//~^ ERROR immutable static items must be `Freeze`
-
-static STATIC21: EnumNoFreeze<'static> = FreezableVariant;
-static STATIC22: EnumNoFreeze<'static> = NonFreezableVariant(StructNoFreeze{nf: &'static mut 4});
-//~^ ERROR immutable static items must be `Freeze`
-
-struct NFMarker {
-    nf: marker::NoFreeze
-}
-
-static STATIC23: NFMarker = NFMarker{nf: marker::NoFreeze};
-//~^ ERROR immutable static items must be `Freeze`
-
 pub fn main() {
     let y = { static x: ~int = ~3; x };
     //~^ ERROR static items are not allowed to have owned pointers

--- a/src/test/compile-fail/comm-not-freeze.rs
+++ b/src/test/compile-fail/comm-not-freeze.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn test<T: Freeze>() {}
+fn test<T: Share>() {}
 
 fn main() {
-    test::<Sender<int>>();        //~ ERROR: does not fulfill `Freeze`
-    test::<Receiver<int>>();        //~ ERROR: does not fulfill `Freeze`
-    test::<Sender<int>>();  //~ ERROR: does not fulfill `Freeze`
+    test::<Sender<int>>();        //~ ERROR: does not fulfill `Share`
+    test::<Receiver<int>>();        //~ ERROR: does not fulfill `Share`
+    test::<Sender<int>>();  //~ ERROR: does not fulfill `Share`
 }

--- a/src/test/compile-fail/issue-2611-4.rs
+++ b/src/test/compile-fail/issue-2611-4.rs
@@ -20,7 +20,7 @@ struct E {
 }
 
 impl A for E {
-  fn b<F:Freeze,G>(_x: F) -> F { fail!() } //~ ERROR type parameter 0 requires `Freeze`
+  fn b<F: Share, G>(_x: F) -> F { fail!() } //~ ERROR type parameter 0 requires `Share`
 }
 
 fn main() {}

--- a/src/test/compile-fail/marker-no-share.rs
+++ b/src/test/compile-fail/marker-no-share.rs
@@ -8,14 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::rc::Rc;
-use std::cell::RefCell;
+use std::kinds::marker;
 
-fn bar<T: Freeze>(_: T) {}
+fn foo<P: Share>(p: P) { }
 
-fn main() {
-    let x = Rc::new(RefCell::new(5));
-    bar(x);
-    //~^ ERROR instantiating a type parameter with an incompatible type
-    //         `std::rc::Rc<std::cell::RefCell<int>>`, which does not fulfill `Freeze`
+fn main()
+{
+    foo(marker::NoShare); //~ ERROR does not fulfill `Share`
 }

--- a/src/test/compile-fail/mut-not-freeze.rs
+++ b/src/test/compile-fail/mut-not-freeze.rs
@@ -10,9 +10,9 @@
 
 use std::cell::RefCell;
 
-fn f<T: Freeze>(_: T) {}
+fn f<T: Share>(_: T) {}
 
 fn main() {
     let x = RefCell::new(0);
-    f(x); //~ ERROR: which does not fulfill `Freeze`
+    f(x); //~ ERROR: which does not fulfill `Share`
 }

--- a/src/test/compile-fail/no_share-enum.rs
+++ b/src/test/compile-fail/no_share-enum.rs
@@ -10,13 +10,13 @@
 
 use std::kinds::marker;
 
-enum Foo { A(marker::NoFreeze) }
+enum Foo { A(marker::NoShare) }
 
-fn bar<T: Freeze>(_: T) {}
+fn bar<T: Share>(_: T) {}
 
 fn main() {
-    let x = A(marker::NoFreeze);
+    let x = A(marker::NoShare);
     bar(x);
     //~^ ERROR instantiating a type parameter with an incompatible type `Foo`,
-    //         which does not fulfill `Freeze`
+    //         which does not fulfill `Share`
 }

--- a/src/test/compile-fail/no_share-rc.rs
+++ b/src/test/compile-fail/no_share-rc.rs
@@ -8,15 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::kinds::marker;
+use std::rc::Rc;
+use std::cell::RefCell;
 
-struct Foo { a: int, m: marker::NoFreeze }
-
-fn bar<T: Freeze>(_: T) {}
+fn bar<T: Share>(_: T) {}
 
 fn main() {
-    let x = Foo { a: 5, m: marker::NoFreeze };
+    let x = Rc::new(RefCell::new(5));
     bar(x);
-    //~^ ERROR instantiating a type parameter with an incompatible type `Foo`,
-    //         which does not fulfill `Freeze`
+    //~^ ERROR instantiating a type parameter with an incompatible type
+    //         `std::rc::Rc<std::cell::RefCell<int>>`, which does not fulfill `Share`
 }

--- a/src/test/compile-fail/no_share-struct.rs
+++ b/src/test/compile-fail/no_share-struct.rs
@@ -10,9 +10,13 @@
 
 use std::kinds::marker;
 
-fn foo<P:Freeze>(p: P) { }
+struct Foo { a: int, m: marker::NoShare }
 
-fn main()
-{
-    foo(marker::NoFreeze); //~ ERROR does not fulfill `Freeze`
+fn bar<T: Share>(_: T) {}
+
+fn main() {
+    let x = Foo { a: 5, m: marker::NoShare };
+    bar(x);
+    //~^ ERROR instantiating a type parameter with an incompatible type `Foo`,
+    //         which does not fulfill `Share`
 }

--- a/src/test/run-pass/const-bound.rs
+++ b/src/test/run-pass/const-bound.rs
@@ -12,7 +12,7 @@
 // are const.
 
 
-fn foo<T:Freeze>(x: T) -> T { x }
+fn foo<T: Share>(x: T) -> T { x }
 
 struct F { field: int }
 

--- a/src/test/run-pass/issue-2611-3.rs
+++ b/src/test/run-pass/issue-2611-3.rs
@@ -12,7 +12,7 @@
 // than the traits require.
 
 trait A {
-  fn b<C:Freeze,D>(x: C) -> C;
+  fn b<C:Share,D>(x: C) -> C;
 }
 
 struct E {

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -65,10 +65,10 @@ pub fn main() {
     let dogge1 = Dogge { bark_decibels: 100, tricks_known: 42, name: ~"alan_turing" };
     let dogge2 = Dogge { bark_decibels: 55,  tricks_known: 11, name: ~"albert_einstein" };
     let fishe = Goldfyshe { swim_speed: 998, name: ~"alec_guinness" };
-    let arc = Arc::new(~[~catte  as ~Pet:Freeze+Send,
-                         ~dogge1 as ~Pet:Freeze+Send,
-                         ~fishe  as ~Pet:Freeze+Send,
-                         ~dogge2 as ~Pet:Freeze+Send]);
+    let arc = Arc::new(~[~catte  as ~Pet:Share+Send,
+                         ~dogge1 as ~Pet:Share+Send,
+                         ~fishe  as ~Pet:Share+Send,
+                         ~dogge2 as ~Pet:Share+Send]);
     let (tx1, rx1) = channel();
     let arc1 = arc.clone();
     task::spawn(proc() { check_legs(arc1); tx1.send(()); });
@@ -83,21 +83,21 @@ pub fn main() {
     rx3.recv();
 }
 
-fn check_legs(arc: Arc<~[~Pet:Freeze+Send]>) {
+fn check_legs(arc: Arc<~[~Pet:Share+Send]>) {
     let mut legs = 0;
     for pet in arc.get().iter() {
         legs += pet.num_legs();
     }
     assert!(legs == 12);
 }
-fn check_names(arc: Arc<~[~Pet:Freeze+Send]>) {
+fn check_names(arc: Arc<~[~Pet:Share+Send]>) {
     for pet in arc.get().iter() {
         pet.name(|name| {
             assert!(name[0] == 'a' as u8 && name[1] == 'l' as u8);
         })
     }
 }
-fn check_pedigree(arc: Arc<~[~Pet:Freeze+Send]>) {
+fn check_pedigree(arc: Arc<~[~Pet:Share+Send]>) {
     for pet in arc.get().iter() {
         assert!(pet.of_good_pedigree());
     }


### PR DESCRIPTION
`Share` implies that all _reachable_ content is _threadsafe_.

Threadsafe is defined as "exposing no operation that permits a data race if multiple threads have access to a &T pointer simultaneously". (NB: the type system should guarantee that if you have access to memory via a &T pointer, the only other way to gain access to that memory is through another &T pointer)...

Fixes #11781
cc #12577 
# What this PR will do
- [x] Add Share kind and
- [x]  Replace usages of Freeze with Share in bounds.
- [x] Add Unsafe<T> #12577
- [x] Forbid taking the address of a immutable static item with `Unsafe<T>` interior
# What's left to do in a separate PR (after the snapshot)?
- Remove `Freeze` completely 
