### PR TITLE
mark allocation-happy Vec<T> methods as deprecated

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -27,6 +27,7 @@ This API is completely unstable and subject to change.
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
+#[allow(deprecated)];
 #[feature(macro_rules, globs, struct_variant, managed_boxes)];
 #[feature(quote)];
 

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -350,6 +350,7 @@ impl<T> Vec<T> {
     }
 
     #[inline]
+    #[deprecated="Use `xs.iter().map(closure)` instead."]
     pub fn map<U>(&self, f: |t: &T| -> U) -> Vec<U> {
         self.iter().map(f).collect()
     }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -30,6 +30,7 @@ This API is completely unstable and subject to change.
 #[allow(unknown_features)];// Note: remove it after a snapshot.
 #[feature(quote)];
 
+#[allow(deprecated)];
 #[deny(non_camel_case_types)];
 
 extern crate serialize;


### PR DESCRIPTION
This exists for the sake of compatibility during the ~[T] -> Vec<T>
transition. It will be removed in the future.
