### PR TITLE
Str::slice_chars() is O(end), not O(end - begin)

### DIFF
--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -1997,8 +1997,8 @@ pub trait StrSlice<'a> {
     /// handle edge cases such as leaving a combining character as the
     /// first code point of the string.
     ///
-    /// Due to the design of UTF-8, this operation is `O(end -
-    /// begin)`. See `slice`, `slice_to` and `slice_from` for `O(1)`
+    /// Due to the design of UTF-8, this operation is `O(end)`.
+    /// See `slice`, `slice_to` and `slice_from` for `O(1)`
     /// variants that use byte indices rather than code point
     /// indices.
     ///


### PR DESCRIPTION
Feel free to reject this if I’m mistaken, but the `count` in the for loop does look like it’s going from 0 to `end`.
