### PR TITLE
Disallowed patterns in extern fn declarations.

### DIFF
--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1040,12 +1040,23 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
                              ast_generics: &ast::Generics,
                              abis: AbiSet)
                           -> ty::ty_param_bounds_and_ty {
+
+    for i in decl.inputs.iter() {
+        match (*i).pat.node {
+            ast::PatIdent(_, _, _) => (),
+            ast::PatWild => (),
+            _ => ccx.tcx.sess.span_err((*i).pat.span,
+                    "patterns aren't allowed in foreign function declarations")
+        }
+    }
+
     let ty_generics = ty_generics(ccx, ast_generics, 0);
     let rb = BindingRscope::new(def_id.node);
     let input_tys = decl.inputs
                         .iter()
                         .map(|a| ty_of_arg(ccx, &rb, a, None))
                         .collect();
+
     let output_ty = ast_ty_to_ty(ccx, &rb, decl.output);
 
     let t_fn = ty::mk_bare_fn(

--- a/src/test/compile-fail/issue-10877.rs
+++ b/src/test/compile-fail/issue-10877.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo { x: int }
+extern {
+    fn foo(1: ());
+    //~^ ERROR: patterns aren't allowed in foreign function declarations
+    fn bar((): int);
+    //~^ ERROR: patterns aren't allowed in foreign function declarations
+    fn baz(Foo { x }: int);
+    //~^ ERROR: patterns aren't allowed in foreign function declarations
+    fn qux((x,y): ());
+    //~^ ERROR: patterns aren't allowed in foreign function declarations
+    fn this_is_actually_ok(a: uint);
+    fn and_so_is_this(_: uint);
+}
+fn main() {}


### PR DESCRIPTION
Fixes #10877

There was another PR which attempted to fix this in the parser (#11804) and which was closed due to inactivity.
This PR modifies typeck instead (as suggested in #11804), which indeed seems to be simpler than modifying the parser and allows for a better error message.
