### PR TITLE
Fix typos with repeated words

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -322,7 +322,7 @@ CSREQ$(1)_T_$(2)_H_$(3) = \
 	$$(foreach dep,$$(HOST_CRATES),$$(HLIB$(1)_H_$(3))/stamp.$$(dep))
 
 ifeq ($(1),0)
-# Don't run the the stage0 compiler under valgrind - that ship has sailed
+# Don't run the stage0 compiler under valgrind - that ship has sailed
 CFG_VALGRIND_COMPILE$(1) =
 else
 CFG_VALGRIND_COMPILE$(1) = $$(CFG_VALGRIND_COMPILE)

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -2485,7 +2485,7 @@ before the expression they apply to.
 `*`
   : Dereference. When applied to a [pointer](#pointer-types) it denotes the pointed-to location.
     For pointers to mutable locations, the resulting [lvalue](#lvalues-rvalues-and-temporaries) can be assigned to.
-    On non-pointer types, it calls calls the `deref` method of the `std::ops::Deref` trait, or the
+    On non-pointer types, it calls the `deref` method of the `std::ops::Deref` trait, or the
     `deref_mut` method of the `std::ops::DerefMut` trait (if implemented by the type and required
     for an outer expression that will or could mutate the dereference), and produces the
     result of dereferencing the `&` or `&mut` borrowed pointer returned from the overload method.

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -304,7 +304,7 @@ mod test_map {
     fn test_insert_with_key() {
         let mut map = SmallIntMap::new();
 
-        // given a new key, initialize it with this new count, given
+        // given a new key, initialize it with this new count,
         // given an existing key, add more to its count
         fn addMoreToCount(_k: uint, v0: uint, v1: uint) -> uint {
             v0 + v1

--- a/src/libextra/stats.rs
+++ b/src/libextra/stats.rs
@@ -103,7 +103,7 @@ pub trait Stats {
     fn median_abs_dev_pct(self) -> f64;
 
     /// Percentile: the value below which `pct` percent of the values in `self` fall. For example,
-    /// percentile(95.0) will return the value `v` such that that 95% of the samples `s` in `self`
+    /// percentile(95.0) will return the value `v` such that 95% of the samples `s` in `self`
     /// satisfy `s <= v`.
     ///
     /// Calculated by linear interpolation between closest ranks.

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -284,7 +284,7 @@ pub struct PoolConfig {
 }
 
 impl PoolConfig {
-    /// Returns the default configuration, as determined the the environment
+    /// Returns the default configuration, as determined the environment
     /// variables of this process.
     pub fn new() -> PoolConfig {
         PoolConfig {

--- a/src/librustc/back/svh.rs
+++ b/src/librustc/back/svh.rs
@@ -19,7 +19,7 @@
 //! ends up yielding confusing error messages about metadata mismatches and
 //! such.
 //!
-//! The core of this problem is when when an upstream dependency changes and
+//! The core of this problem is when an upstream dependency changes and
 //! downstream dependants are not recompiled. This causes compile errors because
 //! the upstream crate's metadata has changed but the downstream crates are
 //! still referencing the older crate's metadata.

--- a/src/librustc/middle/borrowck/doc.rs
+++ b/src/librustc/middle/borrowck/doc.rs
@@ -212,7 +212,7 @@ borrow checker works, let's look a bit more closely now at the precise
 conditions that it uses. For simplicity I will ignore const loans.
 
 I will present the rules in a modified form of standard inference
-rules, which looks as as follows:
+rules, which looks as follows:
 
 ```notrust
 PREDICATE(X, Y, Z)                  // Rule-Name

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4294,7 +4294,7 @@ impl Resolver {
 
             TyPath(ref path, ref bounds, path_id) => {
                 // This is a path in the type namespace. Walk through scopes
-                // scopes looking for it.
+                // looking for it.
                 let mut result_def = None;
 
                 // First, check to see whether the name is a primitive type.

--- a/src/librustc/middle/trans/doc.rs
+++ b/src/librustc/middle/trans/doc.rs
@@ -40,7 +40,7 @@ up expressions into:
 ## The Datum module
 
 A `Datum` encapsulates the result of evaluating a Rust expression.  It
-contains a `ValueRef` indicating the result, a `ty::t` describing the
+contains a `ValueRef` indicating the result, a `ty::t` describing
 the Rust type, but also a *kind*. The kind indicates whether the datum
 has cleanup scheduled (lvalue) or not (rvalue) and -- in the case of
 rvalues -- whether or not the value is "by ref" or "by value".

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -600,7 +600,7 @@ pub enum BorrowKind {
  *   be a sublifetime of `'x...'z`.
  * - The closure creator knows which upvars were borrowed by the closure
  *   and thus `x...z` will be reserved for `'x...'z` respectively.
- * - Through mutation, the borrowed upvars can actually escape the
+ * - Through mutation, the borrowed upvars can actually escape
  *   the closure, so sometimes it is necessary for them to be larger
  *   than the closure lifetime itself.
  */
@@ -3377,8 +3377,8 @@ pub fn expr_kind(tcx: ctxt,
                     // the AST type in cast node---but (at the time of this
                     // writing) it's not easy to distinguish casts to traits
                     // from other casts based on the AST.  This should be
-                    // easier in the future, when casts to traits would like
-                    // like @Foo, ~Foo, or &Foo.
+                    // easier in the future, when casts to traits
+                    // would like @Foo, ~Foo, or &Foo.
                     RvalueDatumExpr
                 }
             }
@@ -4240,7 +4240,7 @@ pub fn lookup_simd(tcx: ctxt, did: DefId) -> bool {
     has_attr(tcx, did, "simd")
 }
 
-// Obtain the the representation annotation for a definition.
+// Obtain the representation annotation for a definition.
 pub fn lookup_repr_hint(tcx: ctxt, did: DefId) -> attr::ReprAttr {
     let mut acc = attr::ReprAny;
     ty::each_attr(tcx, did, |meta| {

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -277,7 +277,7 @@ impl<'f> CombineFieldsLatticeMethods for CombineFields<'f> {
         let _indent = indenter();
 
         // First, relate the lower/upper bounds of A and B.
-        // Note that these relations *must* hold for us to
+        // Note that these relations *must* hold for us
         // to be able to merge A and B at all, and relating
         // them explicitly gives the type inferencer more
         // information and helps to produce tighter bounds

--- a/src/librustc/middle/typeck/infer/region_inference/doc.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/doc.rs
@@ -149,7 +149,7 @@ In this example, there is a region for the fn body block as a whole,
 and then a subregion for the declaration of the local variable.
 Within that, there are sublifetimes for the assignment pattern and
 also the expression `x + y`. The expression itself has sublifetimes
-for evaluating `x` and and `y`.
+for evaluating `x` and `y`.
 
 ## Function calls
 

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -197,7 +197,7 @@ impl Repr for vtable_origin {
 pub type vtable_map = @RefCell<HashMap<ast::NodeId, vtable_res>>;
 
 
-// Information about the vtable resolutions for for a trait impl.
+// Information about the vtable resolutions for a trait impl.
 // Mostly the information is important for implementing default
 // methods.
 #[deriving(Clone)]

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -18,7 +18,7 @@ use syntax::codemap::Span;
 use syntax::opt_vec::OptVec;
 
 /// Defines strategies for handling regions that are omitted.  For
-/// example, if one writes the type `&Foo`, then the lifetime of of
+/// example, if one writes the type `&Foo`, then the lifetime of
 /// this reference has been omitted. When converting this
 /// type, the generic functions in astconv will invoke `anon_regions`
 /// on the provided region-scope to decide how to translate this

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -766,7 +766,7 @@ impl Clean<Item> for doctree::Struct {
     }
 }
 
-/// This is a more limited form of the standard Struct, different in that it
+/// This is a more limited form of the standard Struct, different in that
 /// it lacks the things most items have (name, id, parameterization). Found
 /// only as a variant in an enum.
 #[deriving(Clone, Encodable, Decodable)]

--- a/src/libstd/comm/shared.rs
+++ b/src/libstd/comm/shared.rs
@@ -302,7 +302,7 @@ impl<T: Send> Packet<T> {
             }
         };
         match ret {
-            // See the discussion in the stream implementation for why we we
+            // See the discussion in the stream implementation for why we
             // might decrement steals.
             Some(data) => {
                 if self.steals > MAX_STEALS {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -50,7 +50,7 @@ pub struct BufferedReader<R> {
 }
 
 impl<R: Reader> BufferedReader<R> {
-    /// Creates a new `BufferedReader` with with the specified buffer capacity
+    /// Creates a new `BufferedReader` with the specified buffer capacity
     pub fn with_capacity(cap: uint, inner: R) -> BufferedReader<R> {
         // It's *much* faster to create an uninitialized buffer than it is to
         // fill everything in with 0. This buffer is entirely an implementation
@@ -137,7 +137,7 @@ pub struct BufferedWriter<W> {
 }
 
 impl<W: Writer> BufferedWriter<W> {
-    /// Creates a new `BufferedWriter` with with the specified buffer capacity
+    /// Creates a new `BufferedWriter` with the specified buffer capacity
     pub fn with_capacity(cap: uint, inner: W) -> BufferedWriter<W> {
         // See comments in BufferedReader for why this uses unsafe code.
         let mut buf = vec::with_capacity(cap);

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -103,7 +103,7 @@ impl File {
     /// `FileMode` and `FileAccess` provide information about the permissions
     /// context in which a given stream is created. More information about them
     /// can be found in `std::io`'s docs. If a file is opened with `Write`
-    /// or `ReadWrite` access, then it will be created it it does not already
+    /// or `ReadWrite` access, then it will be created it does not already
     /// exist.
     ///
     /// Note that, with this function, a `File` is returned regardless of the

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -377,7 +377,7 @@ pub trait Reader {
     ///
     /// # Error
     ///
-    /// Fails with the same conditions as `read`. Additionally returns error on
+    /// Fails with the same conditions as `read`. Additionally returns error
     /// on EOF. Note that if an error is returned, then some number of bytes may
     /// have already been consumed from the underlying reader, and they are lost
     /// (not returned as part of the error). If this is unacceptable, then it is

--- a/src/libstd/kinds.rs
+++ b/src/libstd/kinds.rs
@@ -84,10 +84,10 @@ pub mod marker {
     /// The type system would currently infer that the value of
     /// the type parameter `T` is irrelevant, and hence a `S<int>` is
     /// a subtype of `S<~[int]>` (or, for that matter, `S<U>` for
-    /// for any `U`). But this is incorrect because `get()` converts the
+    /// any `U`). But this is incorrect because `get()` converts the
     /// `*()` into a `*T` and reads from it. Therefore, we should include the
     /// a marker field `CovariantType<T>` to inform the type checker that
-    /// `S<T>` is a subtype of `S<U>` if `T` is a a subtype of `U`
+    /// `S<T>` is a subtype of `S<U>` if `T` is a subtype of `U`
     /// (for example, `S<&'static int>` is a subtype of `S<&'a int>`
     /// for some lifetime `'a`, but not the other way around).
     #[lang="covariant_type"]
@@ -125,7 +125,7 @@ pub mod marker {
     /// The type system would currently infer that the value of
     /// the type parameter `T` is irrelevant, and hence a `S<int>` is
     /// a subtype of `S<~[int]>` (or, for that matter, `S<U>` for
-    /// for any `U`). But this is incorrect because `get()` converts the
+    /// any `U`). But this is incorrect because `get()` converts the
     /// `*()` into a `fn(T)` and then passes a value of type `T` to it.
     ///
     /// Supplying a `ContravariantType` marker would correct the

--- a/src/libsync/sync/mutex.rs
+++ b/src/libsync/sync/mutex.rs
@@ -53,7 +53,7 @@
 // leading to fairly decent performance for both native threads and green
 // threads on various workloads (uncontended and contended).
 //
-// The crux of this implementation is an atomic work which is CAS'd on many many
+// The crux of this implementation is an atomic work which is CAS'd on many
 // times in order to manage a few flags about who's blocking where and whether
 // it's locked or not.
 

--- a/src/test/bench/rt-messaging-ping-pong.rs
+++ b/src/test/bench/rt-messaging-ping-pong.rs
@@ -22,7 +22,7 @@ extern crate extra;
 use std::os;
 use std::uint;
 
-// This is a simple bench that creates M pairs of of tasks. These
+// This is a simple bench that creates M pairs of tasks. These
 // tasks ping-pong back and forth over a pair of streams. This is a
 // cannonical message-passing benchmark as it heavily strains message
 // passing and almost nothing else.

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test performance of a task "spawn ladder", in which children task have many
+// Test performance of a task "spawn ladder", in which children task have
 // many ancestor taskgroups, but with only a few such groups alive at a time.
 // Each child task has to enlist as a descendant in each of its ancestor
 // groups, but that shouldn't have to happen for already-dead groups.

--- a/src/test/run-fail/rt-set-exit-status-fail.rs
+++ b/src/test/run-fail/rt-set-exit-status-fail.rs
@@ -15,7 +15,7 @@ use std::os;
 fn main() {
     error!("whatever");
     // Setting the exit status only works when the scheduler terminates
-    // normally. In this case we're going to fail, so instead of of
+    // normally. In this case we're going to fail, so instead of
     // returning 50 the process will return the typical rt failure code.
     os::set_exit_status(50);
     fail!();


### PR DESCRIPTION
Cosmetic changes at best, but there are so many such typos that I couldn't ignore them. :) Some occurrences of typos are linked to the generated documentations but no changes should break the builds.
