### PR TITLE
change FVN hash function to the FVN-1a variant

### DIFF
--- a/src/librustc/util/nodemap.rs
+++ b/src/librustc/util/nodemap.rs
@@ -118,8 +118,8 @@ impl Writer for FnvState {
     fn write(&mut self, bytes: &[u8]) -> io::IoResult<()> {
         let FnvState(mut hash) = *self;
         for byte in bytes.iter() {
-            hash = hash * 0x100000001b3;
             hash = hash ^ (*byte as u64);
+            hash = hash * 0x100000001b3;
         }
         *self = FnvState(hash);
         Ok(())


### PR DESCRIPTION
Minor change to the FVN hashing function based on recommendation on: http://en.wikipedia.org/wiki/Fowler_Noll_Vo_hash

cc @alexcrichton
