### PR TITLE
rename ast::ViewItemExternMod to ast::ViewItemExternCrate ...

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -134,7 +134,7 @@ impl Visitor<()> for Context {
                     }
                 }
             }
-            ast::ViewItemExternMod(..) => {
+            ast::ViewItemExternCrate(..) => {
                 for attr in i.attrs.iter() {
                     if attr.name().get() == "phase"{
                         self.gate_feature("phase", attr.span,

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -74,7 +74,7 @@ pub fn with_version(krate: &str) -> Option<(InternedString, ast::StrStyle)> {
 impl fold::Folder for StandardLibraryInjector {
     fn fold_crate(&mut self, krate: ast::Crate) -> ast::Crate {
         let mut vis = vec!(ast::ViewItem {
-            node: ast::ViewItemExternMod(token::str_to_ident("std"),
+            node: ast::ViewItemExternCrate(token::str_to_ident("std"),
                                          with_version("std"),
                                          ast::DUMMY_NODE_ID),
             attrs: vec!(
@@ -90,7 +90,7 @@ impl fold::Folder for StandardLibraryInjector {
 
         if use_uv(&krate) && !self.sess.building_library.get() {
             vis.push(ast::ViewItem {
-                node: ast::ViewItemExternMod(token::str_to_ident("green"),
+                node: ast::ViewItemExternCrate(token::str_to_ident("green"),
                                              with_version("green"),
                                              ast::DUMMY_NODE_ID),
                 attrs: Vec::new(),
@@ -98,7 +98,7 @@ impl fold::Folder for StandardLibraryInjector {
                 span: DUMMY_SP
             });
             vis.push(ast::ViewItem {
-                node: ast::ViewItemExternMod(token::str_to_ident("rustuv"),
+                node: ast::ViewItemExternCrate(token::str_to_ident("rustuv"),
                                              with_version("rustuv"),
                                              ast::DUMMY_NODE_ID),
                 attrs: Vec::new(),

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -306,7 +306,7 @@ fn mk_std(cx: &TestCtxt) -> ast::ViewItem {
                                              path_node(~[id_test]),
                                              ast::DUMMY_NODE_ID))))
     } else {
-        ast::ViewItemExternMod(id_test,
+        ast::ViewItemExternCrate(id_test,
                                with_version("test"),
                                ast::DUMMY_NODE_ID)
     };

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -167,7 +167,7 @@ struct CrateInfo {
 
 fn extract_crate_info(e: &Env, i: &ast::ViewItem) -> Option<CrateInfo> {
     match i.node {
-        ast::ViewItemExternMod(ident, ref path_opt, id) => {
+        ast::ViewItemExternCrate(ident, ref path_opt, id) => {
             let ident = token::get_ident(ident);
             debug!("resolving extern crate stmt. ident: {:?} path_opt: {:?}",
                    ident, path_opt);

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -845,7 +845,7 @@ impl<'a> Visitor<()> for PrivacyVisitor<'a> {
 
     fn visit_view_item(&mut self, a: &ast::ViewItem, _: ()) {
         match a.node {
-            ast::ViewItemExternMod(..) => {}
+            ast::ViewItemExternCrate(..) => {}
             ast::ViewItemUse(ref uses) => {
                 for vpath in uses.iter() {
                     match vpath.node {
@@ -976,7 +976,7 @@ impl Visitor<()> for SanePrivacyVisitor {
                                                     reachable");
                 } else {
                     match i.node {
-                        ast::ViewItemExternMod(..) => {
+                        ast::ViewItemExternCrate(..) => {
                             self.tcx.sess.span_err(i.span, "`pub` visibility \
                                                             is not allowed");
                         }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1516,7 +1516,7 @@ impl Resolver {
                 }
             }
 
-            ViewItemExternMod(name, _, node_id) => {
+            ViewItemExternCrate(name, _, node_id) => {
                 // n.b. we don't need to look at the path option here, because cstore already did
                 match self.session.cstore.find_extern_mod_stmt_cnum(node_id) {
                     Some(crate_id) => {
@@ -5415,7 +5415,7 @@ impl Resolver {
         if vi.span == DUMMY_SP { return }
 
         match vi.node {
-            ViewItemExternMod(..) => {} // ignore
+            ViewItemExternCrate(..) => {} // ignore
             ViewItemUse(ref path) => {
                 for p in path.iter() {
                     match p.node {

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1066,19 +1066,19 @@ impl Clean<Item> for ast::ViewItem {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub enum ViewItemInner {
-    ExternMod(~str, Option<~str>, ast::NodeId),
+    ExternCrate(~str, Option<~str>, ast::NodeId),
     Import(~[ViewPath])
 }
 
 impl Clean<ViewItemInner> for ast::ViewItem_ {
     fn clean(&self) -> ViewItemInner {
         match self {
-            &ast::ViewItemExternMod(ref i, ref p, ref id) => {
+            &ast::ViewItemExternCrate(ref i, ref p, ref id) => {
                 let string = match *p {
                     None => None,
                     Some((ref x, _)) => Some(x.get().to_owned()),
                 };
-                ExternMod(i.clean(), string, *id)
+                ExternCrate(i.clean(), string, *id)
             }
             &ast::ViewItemUse(ref vp) => {
                 Import(vp.clean().move_iter().collect())

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -960,8 +960,8 @@ fn item_module(w: &mut Writer, cx: &Context,
         match (&i1.inner, &i2.inner) {
             (&clean::ViewItemItem(ref a), &clean::ViewItemItem(ref b)) => {
                 match (&a.inner, &b.inner) {
-                    (&clean::ExternMod(..), _) => Less,
-                    (_, &clean::ExternMod(..)) => Greater,
+                    (&clean::ExternCrate(..), _) => Less,
+                    (_, &clean::ExternCrate(..)) => Greater,
                     _ => idx1.cmp(&idx2),
                 }
             }
@@ -1056,7 +1056,7 @@ fn item_module(w: &mut Writer, cx: &Context,
 
             clean::ViewItemItem(ref item) => {
                 match item.inner {
-                    clean::ExternMod(ref name, ref src, _) => {
+                    clean::ExternCrate(ref name, ref src, _) => {
                         try!(write!(w, "<tr><td><code>extern crate {}",
                                       name.as_slice()));
                         match *src {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -147,7 +147,7 @@ impl<'a> RustdocVisitor<'a> {
                     }
                 }
             }
-            ast::ViewItemExternMod(..) => item.clone()
+            ast::ViewItemExternCrate(..) => item.clone()
         };
         om.view_items.push(item);
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1019,7 +1019,7 @@ pub enum ViewItem_ {
     // optional (InternedString,StrStyle): if present, this is a location
     // (containing arbitrary characters) from which to fetch the crate sources
     // For example, extern crate whatever = "github.com/mozilla/rust"
-    ViewItemExternMod(Ident, Option<(InternedString,StrStyle)>, NodeId),
+    ViewItemExternCrate(Ident, Option<(InternedString,StrStyle)>, NodeId),
     ViewItemUse(Vec<@ViewPath> ),
 }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -375,7 +375,7 @@ impl<'a, O: IdVisitingOperation> Visitor<()> for IdVisitor<'a, O> {
 
     fn visit_view_item(&mut self, view_item: &ViewItem, env: ()) {
         match view_item.node {
-            ViewItemExternMod(_, _, node_id) => {
+            ViewItemExternCrate(_, _, node_id) => {
                 self.operation.visit_id(node_id)
             }
             ViewItemUse(ref view_paths) => {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -424,7 +424,7 @@ pub fn expand_view_item(vi: &ast::ViewItem,
                         fld: &mut MacroExpander)
                         -> ast::ViewItem {
     match vi.node {
-        ast::ViewItemExternMod(..) => {
+        ast::ViewItemExternCrate(..) => {
             let should_load = vi.attrs.iter().any(|attr| {
                 attr.name().get() == "phase" &&
                     attr.meta_item_list().map_or(false, |phases| {
@@ -446,7 +446,7 @@ fn load_extern_macros(krate: &ast::ViewItem, fld: &mut MacroExpander) {
     let MacroCrate { lib, cnum } = fld.cx.ecfg.loader.load_crate(krate);
 
     let crate_name = match krate.node {
-        ast::ViewItemExternMod(name, _, _) => name,
+        ast::ViewItemExternCrate(name, _, _) => name,
         _ => unreachable!()
     };
     let name = format!("<{} macros>", token::get_ident(crate_name));

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -514,8 +514,8 @@ fn fold_variant_arg_<T: Folder>(va: &VariantArg, folder: &mut T) -> VariantArg {
 pub fn noop_fold_view_item<T: Folder>(vi: &ViewItem, folder: &mut T)
                                        -> ViewItem{
     let inner_view_item = match vi.node {
-        ViewItemExternMod(ref ident, ref string, node_id) => {
-            ViewItemExternMod(ident.clone(),
+        ViewItemExternCrate(ref ident, ref string, node_id) => {
+            ViewItemExternCrate(ident.clone(),
                               (*string).clone(),
                               folder.new_id(node_id))
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -55,7 +55,7 @@ use ast::{TyInfer, TypeMethod};
 use ast::{TyNil, TyParam, TyParamBound, TyPath, TyPtr, TyRptr};
 use ast::{TyTup, TyU32, TyUniq, TyVec, UnUniq};
 use ast::{UnnamedField, UnsafeBlock, UnsafeFn, ViewItem};
-use ast::{ViewItem_, ViewItemExternMod, ViewItemUse};
+use ast::{ViewItem_, ViewItemExternCrate, ViewItemUse};
 use ast::{ViewPath, ViewPathGlob, ViewPathList, ViewPathSimple};
 use ast::Visibility;
 use ast;
@@ -4361,7 +4361,7 @@ impl Parser {
         };
 
         IoviViewItem(ast::ViewItem {
-                node: ViewItemExternMod(ident, maybe_path, ast::DUMMY_NODE_ID),
+                node: ViewItemExternCrate(ident, maybe_path, ast::DUMMY_NODE_ID),
                 attrs: attrs,
                 vis: visibility,
                 span: mk_sp(lo, self.last_span.hi)
@@ -5017,11 +5017,11 @@ impl Parser {
                             // `extern crate` must precede `use`.
                             extern_mod_allowed = false;
                         }
-                        ViewItemExternMod(..) if !extern_mod_allowed => {
+                        ViewItemExternCrate(..) if !extern_mod_allowed => {
                             self.span_err(view_item.span,
                                           "\"extern crate\" declarations are not allowed here");
                         }
-                        ViewItemExternMod(..) => {}
+                        ViewItemExternCrate(..) => {}
                     }
                     view_items.push(view_item);
                 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2065,7 +2065,7 @@ pub fn print_view_item(s: &mut State, item: &ast::ViewItem) -> io::IoResult<()> 
     try!(print_outer_attributes(s, item.attrs.as_slice()));
     try!(print_visibility(s, item.vis));
     match item.node {
-        ast::ViewItemExternMod(id, ref optional_path, _) => {
+        ast::ViewItemExternCrate(id, ref optional_path, _) => {
             try!(head(s, "extern crate"));
             try!(print_ident(s, id));
             for &(ref p, style) in optional_path.iter() {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -148,7 +148,7 @@ pub fn walk_mod<E: Clone, V: Visitor<E>>(visitor: &mut V, module: &Mod, env: E) 
 
 pub fn walk_view_item<E: Clone, V: Visitor<E>>(visitor: &mut V, vi: &ViewItem, env: E) {
     match vi.node {
-        ViewItemExternMod(name, _, _) => {
+        ViewItemExternCrate(name, _, _) => {
             visitor.visit_ident(vi.span, name, env)
         }
         ViewItemUse(ref paths) => {


### PR DESCRIPTION
rename ast::ViewItemExternMod to ast::ViewItemExternCrate
rename rustdoc::clean::ExternMod to rustdoc::clean::ExternCrate
because `extern mod` is out.
