### PR TITLE
Change `~[T]` to Vec<T> in librustc

### DIFF
--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -98,9 +98,17 @@ impl Archive {
             let archive = os::make_absolute(&self.dst);
             run_ar(self.sess, "x", Some(loc.path()), [&archive,
                                                       &Path::new(file)]);
-            fs::File::open(&loc.path().join(file)).read_to_end().unwrap()
+            let result: Vec<u8> =
+                fs::File::open(&loc.path().join(file)).read_to_end()
+                                                      .unwrap()
+                                                      .move_iter()
+                                                      .collect();
+            result
         } else {
-            run_ar(self.sess, "p", None, [&self.dst, &Path::new(file)]).output
+            run_ar(self.sess,
+                   "p",
+                   None,
+                   [&self.dst, &Path::new(file)]).output.move_iter().collect()
         }
     }
 
@@ -124,7 +132,7 @@ impl Archive {
         if lto {
             ignore.push(object.as_slice());
         }
-        self.add_archive(rlib, name, ignore)
+        self.add_archive(rlib, name, ignore.as_slice())
     }
 
     /// Adds an arbitrary file to this archive

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -16,6 +16,7 @@ use metadata::filesearch;
 use lib::llvm::{ArchiveRef, llvm};
 
 use std::cast;
+use std::vec_ng::Vec;
 use std::io::fs;
 use std::io;
 use std::libc;
@@ -41,7 +42,7 @@ fn run_ar(sess: Session, args: &str, cwd: Option<&Path>,
         paths: &[&Path]) -> ProcessOutput {
     let ar = get_ar_prog(sess);
 
-    let mut args = ~[args.to_owned()];
+    let mut args = vec!(args.to_owned());
     let mut paths = paths.iter().map(|p| p.as_str().unwrap().to_owned());
     args.extend(&mut paths);
     debug!("{} {}", ar, args.connect(" "));
@@ -89,7 +90,7 @@ impl Archive {
     }
 
     /// Read a file in the archive
-    pub fn read(&self, file: &str) -> ~[u8] {
+    pub fn read(&self, file: &str) -> Vec<u8> {
         // Apparently if "ar p" is used on windows, it generates a corrupt file
         // which has bad headers and LLVM will immediately choke on it
         if cfg!(windows) && cfg!(windows) { // FIXME(#10734) double-and
@@ -119,7 +120,7 @@ impl Archive {
                     lto: bool) -> io::IoResult<()> {
         let object = format!("{}.o", name);
         let bytecode = format!("{}.bc", name);
-        let mut ignore = ~[METADATA_FILENAME, bytecode.as_slice()];
+        let mut ignore = vec!(METADATA_FILENAME, bytecode.as_slice());
         if lto {
             ignore.push(object.as_slice());
         }
@@ -143,7 +144,7 @@ impl Archive {
     }
 
     /// Lists all files in an archive
-    pub fn files(&self) -> ~[~str] {
+    pub fn files(&self) -> Vec<~str> {
         let output = run_ar(self.sess, "t", None, [&self.dst]);
         let output = str::from_utf8(output.output).unwrap();
         // use lines_any because windows delimits output with `\r\n` instead of
@@ -168,7 +169,7 @@ impl Archive {
         // all SYMDEF files as these are just magical placeholders which get
         // re-created when we make a new archive anyway.
         let files = try!(fs::readdir(loc.path()));
-        let mut inputs = ~[];
+        let mut inputs = Vec::new();
         for file in files.iter() {
             let filename = file.filename_str().unwrap();
             if skip.iter().any(|s| *s == filename) { continue }
@@ -182,7 +183,7 @@ impl Archive {
         if inputs.len() == 0 { return Ok(()) }
 
         // Finally, add all the renamed files to this archive
-        let mut args = ~[&self.dst];
+        let mut args = vec!(&self.dst);
         args.extend(&mut inputs.iter());
         run_ar(self.sess, "r", None, args.as_slice());
         Ok(())

--- a/src/librustc/back/arm.rs
+++ b/src/librustc/back/arm.rs
@@ -15,9 +15,9 @@ use syntax::abi;
 
 pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::t {
     let cc_args = if target_triple.contains("thumb") {
-        ~[~"-mthumb"]
+        vec!(~"-mthumb")
     } else {
-        ~[~"-marm"]
+        vec!(~"-marm")
     };
     return target_strs::t {
         module_asm: ~"",

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -363,8 +363,8 @@ pub mod write {
         let vectorize_slp = !sess.opts.cg.no_vectorize_slp &&
                             sess.opts.optimize == session::Aggressive;
 
-        let mut llvm_c_strs = ~[];
-        let mut llvm_args = ~[];
+        let mut llvm_c_strs = Vec::new();
+        let mut llvm_args = Vec::new();
         {
             let add = |arg: &str| {
                 let s = arg.to_c_str();
@@ -781,8 +781,8 @@ fn remove(sess: Session, path: &Path) {
 pub fn link_binary(sess: Session,
                    trans: &CrateTranslation,
                    outputs: &OutputFilenames,
-                   id: &CrateId) -> ~[Path] {
-    let mut out_filenames = ~[];
+                   id: &CrateId) -> Vec<Path> {
+    let mut out_filenames = Vec::new();
     let crate_types = sess.crate_types.borrow();
     for &crate_type in crate_types.get().iter() {
         let out_file = link_binary_output(sess, trans, crate_type, outputs, id);
@@ -1071,7 +1071,7 @@ fn link_args(sess: Session,
              dylib: bool,
              tmpdir: &Path,
              obj_filename: &Path,
-             out_filename: &Path) -> ~[~str] {
+             out_filename: &Path) -> Vec<~str> {
 
     // The default library location, we need this to find the runtime.
     // The location of crates will be determined as needed.
@@ -1079,7 +1079,7 @@ fn link_args(sess: Session,
     let lib_path = sess.filesearch.get_target_lib_path();
     let stage: ~str = ~"-L" + lib_path.as_str().unwrap();
 
-    let mut args = ~[stage];
+    let mut args = vec!(stage);
 
     // FIXME (#9639): This needs to handle non-utf8 paths
     args.push_all([
@@ -1230,7 +1230,7 @@ fn link_args(sess: Session,
 // Also note that the native libraries linked here are only the ones located
 // in the current crate. Upstream crates with native library dependencies
 // may have their native library pulled in above.
-fn add_local_native_libraries(args: &mut ~[~str], sess: Session) {
+fn add_local_native_libraries(args: &mut Vec<~str> , sess: Session) {
     let addl_lib_search_paths = sess.opts.addl_lib_search_paths.borrow();
     for path in addl_lib_search_paths.get().iter() {
         // FIXME (#9639): This needs to handle non-utf8 paths
@@ -1263,7 +1263,7 @@ fn add_local_native_libraries(args: &mut ~[~str], sess: Session) {
 // Rust crates are not considered at all when creating an rlib output. All
 // dependencies will be linked when producing the final output (instead of
 // the intermediate rlib version)
-fn add_upstream_rust_crates(args: &mut ~[~str], sess: Session,
+fn add_upstream_rust_crates(args: &mut Vec<~str> , sess: Session,
                             dylib: bool, tmpdir: &Path) {
 
     // As a limitation of the current implementation, we require that everything
@@ -1347,7 +1347,7 @@ fn add_upstream_rust_crates(args: &mut ~[~str], sess: Session,
     // returning `None` if not all libraries could be found with that
     // preference.
     fn get_deps(cstore: &cstore::CStore,  preference: cstore::LinkagePreference)
-            -> Option<~[(ast::CrateNum, Path)]>
+            -> Option<Vec<(ast::CrateNum, Path)> >
     {
         let crates = cstore.get_used_crates(preference);
         if crates.iter().all(|&(_, ref p)| p.is_some()) {
@@ -1358,8 +1358,8 @@ fn add_upstream_rust_crates(args: &mut ~[~str], sess: Session,
     }
 
     // Adds the static "rlib" versions of all crates to the command line.
-    fn add_static_crates(args: &mut ~[~str], sess: Session, tmpdir: &Path,
-                         crates: ~[(ast::CrateNum, Path)]) {
+    fn add_static_crates(args: &mut Vec<~str> , sess: Session, tmpdir: &Path,
+                         crates: Vec<(ast::CrateNum, Path)> ) {
         for (cnum, cratepath) in crates.move_iter() {
             // When performing LTO on an executable output, all of the
             // bytecode from the upstream libraries has already been
@@ -1405,8 +1405,8 @@ fn add_upstream_rust_crates(args: &mut ~[~str], sess: Session,
     }
 
     // Same thing as above, but for dynamic crates instead of static crates.
-    fn add_dynamic_crates(args: &mut ~[~str], sess: Session,
-                          crates: ~[(ast::CrateNum, Path)]) {
+    fn add_dynamic_crates(args: &mut Vec<~str> , sess: Session,
+                          crates: Vec<(ast::CrateNum, Path)> ) {
         // If we're performing LTO, then it should have been previously required
         // that all upstream rust dependencies were available in an rlib format.
         assert!(!sess.lto());
@@ -1440,7 +1440,7 @@ fn add_upstream_rust_crates(args: &mut ~[~str], sess: Session,
 // generic function calls a native function, then the generic function must
 // be instantiated in the target crate, meaning that the native symbol must
 // also be resolved in the target crate.
-fn add_upstream_native_libraries(args: &mut ~[~str], sess: Session) {
+fn add_upstream_native_libraries(args: &mut Vec<~str> , sess: Session) {
     let cstore = sess.cstore;
     cstore.iter_crate_data(|cnum, _| {
         let libs = csearch::get_native_libraries(cstore, cnum);

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -34,6 +34,7 @@ use std::str;
 use std::io;
 use std::io::Process;
 use std::io::fs;
+use std::vec_ng::Vec;
 use flate;
 use serialize::hex::ToHex;
 use extra::tempfile::TempDir;
@@ -106,6 +107,7 @@ pub mod write {
     use std::io::Process;
     use std::libc::{c_uint, c_int};
     use std::str;
+    use std::vec_ng::Vec;
 
     // On android, we by default compile for armv7 processors. This enables
     // things like double word CAS instructions (rather than emulating them)
@@ -222,7 +224,7 @@ pub mod write {
 
             if sess.lto() {
                 time(sess.time_passes(), "all lto passes", (), |()|
-                     lto::run(sess, llmod, tm, trans.reachable));
+                     lto::run(sess, llmod, tm, trans.reachable.as_slice()));
 
                 if sess.opts.cg.save_temps {
                     output.with_extension("lto.bc").with_c_str(|buf| {
@@ -931,7 +933,8 @@ fn link_rlib(sess: Session,
             // the same filename for metadata (stomping over one another)
             let tmpdir = TempDir::new("rustc").expect("needs a temp dir");
             let metadata = tmpdir.path().join(METADATA_FILENAME);
-            match fs::File::create(&metadata).write(trans.metadata) {
+            match fs::File::create(&metadata).write(trans.metadata
+                                                         .as_slice()) {
                 Ok(..) => {}
                 Err(e) => {
                     sess.err(format!("failed to write {}: {}",
@@ -1035,7 +1038,7 @@ fn link_natively(sess: Session, dylib: bool, obj_filename: &Path,
     // Invoke the system linker
     debug!("{} {}", cc_prog, cc_args.connect(" "));
     let prog = time(sess.time_passes(), "running linker", (), |()|
-                    Process::output(cc_prog, cc_args));
+                    Process::output(cc_prog, cc_args.as_slice()));
     match prog {
         Ok(prog) => {
             if !prog.status.success() {
@@ -1198,7 +1201,7 @@ fn link_args(sess: Session,
     // where extern libraries might live, based on the
     // addl_lib_search_paths
     if !sess.opts.cg.no_rpath {
-        args.push_all(rpath::get_rpath_flags(sess, out_filename));
+        args.push_all(rpath::get_rpath_flags(sess, out_filename).as_slice());
     }
 
     // Stack growth requires statically linking a __morestack function
@@ -1210,7 +1213,7 @@ fn link_args(sess: Session,
 
     // Finally add all the linker arguments provided on the command line along
     // with any #[link_args] attributes found inside the crate
-    args.push_all(sess.opts.cg.link_args);
+    args.push_all(sess.opts.cg.link_args.as_slice());
     let used_link_args = sess.cstore.get_used_link_args();
     let used_link_args = used_link_args.borrow();
     for arg in used_link_args.get().iter() {

--- a/src/librustc/back/mips.rs
+++ b/src/librustc/back/mips.rs
@@ -63,6 +63,6 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
 
         target_triple: target_triple,
 
-        cc_args: ~[],
+        cc_args: Vec::new(),
     };
 }

--- a/src/librustc/back/mips.rs
+++ b/src/librustc/back/mips.rs
@@ -11,6 +11,7 @@
 use back::target_strs;
 use driver::session::sess_os_to_meta_os;
 use metadata::loader::meta_section_name;
+use std::vec_ng::Vec;
 use syntax::abi;
 
 pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::t {

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -15,6 +15,7 @@ use metadata::filesearch;
 
 use collections::HashSet;
 use std::{os, vec};
+use std::vec_ng::Vec;
 use syntax::abi;
 
 fn not_win32(os: abi::Os) -> bool {
@@ -49,7 +50,7 @@ pub fn get_rpath_flags(sess: session::Session, out_filename: &Path) -> Vec<~str>
 
     let rpaths = get_rpaths(os, sysroot, output, libs,
                             sess.opts.target_triple);
-    flags.push_all(rpaths_to_flags(rpaths));
+    flags.push_all(rpaths_to_flags(rpaths.as_slice()).as_slice());
     flags
 }
 
@@ -100,16 +101,16 @@ fn get_rpaths(os: abi::Os,
         }
     }
 
-    log_rpaths("relative", rel_rpaths);
-    log_rpaths("absolute", abs_rpaths);
-    log_rpaths("fallback", fallback_rpaths);
+    log_rpaths("relative", rel_rpaths.as_slice());
+    log_rpaths("absolute", abs_rpaths.as_slice());
+    log_rpaths("fallback", fallback_rpaths.as_slice());
 
     let mut rpaths = rel_rpaths;
-    rpaths.push_all(abs_rpaths);
-    rpaths.push_all(fallback_rpaths);
+    rpaths.push_all(abs_rpaths.as_slice());
+    rpaths.push_all(fallback_rpaths.as_slice());
 
     // Remove duplicates
-    let rpaths = minimize_rpaths(rpaths);
+    let rpaths = minimize_rpaths(rpaths.as_slice());
     return rpaths;
 }
 

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -21,15 +21,15 @@ fn not_win32(os: abi::Os) -> bool {
   os != abi::OsWin32
 }
 
-pub fn get_rpath_flags(sess: session::Session, out_filename: &Path) -> ~[~str] {
+pub fn get_rpath_flags(sess: session::Session, out_filename: &Path) -> Vec<~str> {
     let os = sess.targ_cfg.os;
 
     // No rpath on windows
     if os == abi::OsWin32 {
-        return ~[];
+        return Vec::new();
     }
 
-    let mut flags = ~[];
+    let mut flags = Vec::new();
 
     if sess.targ_cfg.os == abi::OsFreebsd {
         flags.push_all([~"-Wl,-rpath,/usr/local/lib/gcc46",
@@ -60,8 +60,8 @@ fn get_sysroot_absolute_rt_lib(sess: session::Session) -> Path {
     p
 }
 
-pub fn rpaths_to_flags(rpaths: &[~str]) -> ~[~str] {
-    let mut ret = ~[];
+pub fn rpaths_to_flags(rpaths: &[~str]) -> Vec<~str> {
+    let mut ret = Vec::new();
     for rpath in rpaths.iter() {
         ret.push("-Wl,-rpath," + *rpath);
     }
@@ -72,7 +72,7 @@ fn get_rpaths(os: abi::Os,
               sysroot: &Path,
               output: &Path,
               libs: &[Path],
-              target_triple: &str) -> ~[~str] {
+              target_triple: &str) -> Vec<~str> {
     debug!("sysroot: {}", sysroot.display());
     debug!("output: {}", output.display());
     debug!("libs:");
@@ -91,7 +91,7 @@ fn get_rpaths(os: abi::Os,
     let abs_rpaths = get_absolute_rpaths(libs);
 
     // And a final backup rpath to the global library location.
-    let fallback_rpaths = ~[get_install_prefix_rpath(target_triple)];
+    let fallback_rpaths = vec!(get_install_prefix_rpath(target_triple));
 
     fn log_rpaths(desc: &str, rpaths: &[~str]) {
         debug!("{} rpaths:", desc);
@@ -115,7 +115,7 @@ fn get_rpaths(os: abi::Os,
 
 fn get_rpaths_relative_to_output(os: abi::Os,
                                  output: &Path,
-                                 libs: &[Path]) -> ~[~str] {
+                                 libs: &[Path]) -> Vec<~str> {
     libs.iter().map(|a| get_rpath_relative_to_output(os, output, a)).collect()
 }
 
@@ -145,7 +145,7 @@ pub fn get_rpath_relative_to_output(os: abi::Os,
     prefix+"/"+relative.as_str().expect("non-utf8 component in path")
 }
 
-fn get_absolute_rpaths(libs: &[Path]) -> ~[~str] {
+fn get_absolute_rpaths(libs: &[Path]) -> Vec<~str> {
     libs.iter().map(|a| get_absolute_rpath(a)).collect()
 }
 
@@ -167,9 +167,9 @@ pub fn get_install_prefix_rpath(target_triple: &str) -> ~str {
     path.as_str().expect("non-utf8 component in rpath").to_owned()
 }
 
-pub fn minimize_rpaths(rpaths: &[~str]) -> ~[~str] {
+pub fn minimize_rpaths(rpaths: &[~str]) -> Vec<~str> {
     let mut set = HashSet::new();
-    let mut minimized = ~[];
+    let mut minimized = Vec::new();
     for rpath in rpaths.iter() {
         if set.insert(rpath.as_slice()) {
             minimized.push(rpath.clone());
@@ -190,7 +190,7 @@ mod test {
     #[test]
     fn test_rpaths_to_flags() {
         let flags = rpaths_to_flags([~"path1", ~"path2"]);
-        assert_eq!(flags, ~[~"-Wl,-rpath,path1", ~"-Wl,-rpath,path2"]);
+        assert_eq!(flags, vec!(~"-Wl,-rpath,path1", ~"-Wl,-rpath,path2"));
     }
 
     #[test]

--- a/src/librustc/back/target_strs.rs
+++ b/src/librustc/back/target_strs.rs
@@ -15,5 +15,5 @@ pub struct t {
     meta_sect_name: ~str,
     data_layout: ~str,
     target_triple: ~str,
-    cc_args: ~[~str],
+    cc_args: Vec<~str> ,
 }

--- a/src/librustc/back/target_strs.rs
+++ b/src/librustc/back/target_strs.rs
@@ -10,6 +10,8 @@
 
 #[allow(non_camel_case_types)];
 
+use std::vec_ng::Vec;
+
 pub struct t {
     module_asm: ~str,
     meta_sect_name: ~str,

--- a/src/librustc/back/x86.rs
+++ b/src/librustc/back/x86.rs
@@ -46,6 +46,6 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
 
         target_triple: target_triple,
 
-        cc_args: ~[~"-m32"],
+        cc_args: vec!(~"-m32"),
     };
 }

--- a/src/librustc/back/x86_64.rs
+++ b/src/librustc/back/x86_64.rs
@@ -54,6 +54,6 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
 
         target_triple: target_triple,
 
-        cc_args: ~[~"-m64"],
+        cc_args: vec!(~"-m64"),
     };
 }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -11,8 +11,8 @@
 
 use back::link;
 use back::{arm, x86, x86_64, mips};
-use driver::session::{Aggressive, CrateTypeExecutable, FullDebugInfo, LimitedDebugInfo,
-                      NoDebugInfo};
+use driver::session::{Aggressive, CrateTypeExecutable, CrateType,
+                      FullDebugInfo, LimitedDebugInfo, NoDebugInfo};
 use driver::session::{Session, Session_, No, Less, Default};
 use driver::session;
 use front;
@@ -36,7 +36,6 @@ use std::io;
 use std::io::fs;
 use std::io::MemReader;
 use std::os;
-use std::vec;
 use std::vec_ng::Vec;
 use std::vec_ng;
 use collections::HashMap;
@@ -434,7 +433,7 @@ pub fn phase_5_run_llvm_passes(sess: Session,
         time(sess.time_passes(), "LLVM passes", (), |_|
             link::write::run_passes(sess,
                                     trans,
-                                    sess.opts.output_types,
+                                    sess.opts.output_types.as_slice(),
                                     outputs));
     }
 }
@@ -767,18 +766,21 @@ pub fn host_triple() -> ~str {
 
 pub fn build_session_options(matches: &getopts::Matches)
                              -> @session::Options {
-    let crate_types = matches.opt_strs("crate-type").flat_map(|s| {
-        s.split(',').map(|part| {
-            match part {
+    let mut crate_types: Vec<CrateType> = Vec::new();
+    let unparsed_crate_types = matches.opt_strs("crate-type");
+    for unparsed_crate_type in unparsed_crate_types.iter() {
+        for part in unparsed_crate_type.split(',') {
+            let new_part = match part {
                 "lib"       => session::default_lib_output(),
                 "rlib"      => session::CrateTypeRlib,
                 "staticlib" => session::CrateTypeStaticlib,
                 "dylib"     => session::CrateTypeDylib,
                 "bin"       => session::CrateTypeExecutable,
                 _ => early_error(format!("unknown crate type: `{}`", part))
-            }
-        }).collect()
-    });
+            };
+            crate_types.push(new_part)
+        }
+    }
 
     let parse_only = matches.opt_present("parse-only");
     let no_trans = matches.opt_present("no-trans");
@@ -793,8 +795,10 @@ pub fn build_session_options(matches: &getopts::Matches)
 
         let level_short = level_name.slice_chars(0, 1);
         let level_short = level_short.to_ascii().to_upper().into_str();
-        let flags = vec_ng::append(matches.opt_strs(level_short),
-                                matches.opt_strs(level_name));
+        let flags = vec_ng::append(matches.opt_strs(level_short)
+                                          .move_iter()
+                                          .collect(),
+                                   matches.opt_strs(level_name));
         for lint_name in flags.iter() {
             let lint_name = lint_name.replace("-", "_");
             match lint_dict.find_equiv(&lint_name) {
@@ -828,23 +832,24 @@ pub fn build_session_options(matches: &getopts::Matches)
         unsafe { llvm::LLVMSetDebug(1); }
     }
 
-    let mut output_types = if parse_only || no_trans {
-        Vec::new()
-    } else {
-        matches.opt_strs("emit").flat_map(|s| {
-            s.split(',').map(|part| {
-                match part.as_slice() {
+    let mut output_types = Vec::new();
+    if !parse_only && !no_trans {
+        let unparsed_output_types = matches.opt_strs("emit");
+        for unparsed_output_type in unparsed_output_types.iter() {
+            for part in unparsed_output_type.split(',') {
+                let output_type = match part.as_slice() {
                     "asm"  => link::OutputTypeAssembly,
                     "ir"   => link::OutputTypeLlvmAssembly,
                     "bc"   => link::OutputTypeBitcode,
                     "obj"  => link::OutputTypeObject,
                     "link" => link::OutputTypeExe,
                     _ => early_error(format!("unknown emission type: `{}`", part))
-                }
-            }).collect()
-        })
+                };
+                output_types.push(output_type)
+            }
+        }
     };
-    output_types.sort();
+    output_types.as_mut_slice().sort();
     output_types.dedup();
     if output_types.len() == 0 {
         output_types.push(link::OutputTypeExe);
@@ -890,7 +895,7 @@ pub fn build_session_options(matches: &getopts::Matches)
         Path::new(s.as_slice())
     }).move_iter().collect();
 
-    let cfg = parse_cfgspecs(matches.opt_strs("cfg"));
+    let cfg = parse_cfgspecs(matches.opt_strs("cfg").move_iter().collect());
     let test = matches.opt_present("test");
     let write_dependency_info = (matches.opt_present("dep-info"),
                                  matches.opt_str("dep-info").map(|p| Path::new(p)));
@@ -1187,7 +1192,7 @@ mod test {
     #[test]
     fn test_switch_implies_cfg_test() {
         let matches =
-            &match getopts([~"--test"], optgroups()) {
+            &match getopts([~"--test"], optgroups().as_slice()) {
               Ok(m) => m,
               Err(f) => fail!("test_switch_implies_cfg_test: {}", f.to_err_msg())
             };
@@ -1202,7 +1207,8 @@ mod test {
     #[test]
     fn test_switch_implies_cfg_test_unless_cfg_test() {
         let matches =
-            &match getopts([~"--test", ~"--cfg=test"], optgroups()) {
+            &match getopts([~"--test", ~"--cfg=test"],
+                           optgroups().as_slice()) {
               Ok(m) => m,
               Err(f) => {
                 fail!("test_switch_implies_cfg_test_unless_cfg_test: {}",

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -145,7 +145,7 @@ pub fn build_configuration(sess: Session) -> ast::CrateConfig {
 }
 
 // Convert strings provided as --cfg [cfgspec] into a crate_cfg
-fn parse_cfgspecs(cfgspecs: ~[~str])
+fn parse_cfgspecs(cfgspecs: Vec<~str> )
                   -> ast::CrateConfig {
     cfgspecs.move_iter().map(|s| {
         let sess = parse::new_parse_sess();
@@ -399,8 +399,8 @@ pub struct CrateTranslation {
     module: ModuleRef,
     metadata_module: ModuleRef,
     link: LinkMeta,
-    metadata: ~[u8],
-    reachable: ~[~str],
+    metadata: Vec<u8> ,
+    reachable: Vec<~str> ,
 }
 
 /// Run the translation phase to LLVM, after which the AST and analysis can
@@ -489,7 +489,7 @@ fn write_out_deps(sess: Session,
                   krate: &ast::Crate) -> io::IoResult<()> {
     let id = link::find_crate_id(krate.attrs.as_slice(), outputs);
 
-    let mut out_filenames = ~[];
+    let mut out_filenames = Vec::new();
     for output_type in sess.opts.output_types.iter() {
         let file = outputs.path(*output_type);
         match *output_type {
@@ -524,7 +524,7 @@ fn write_out_deps(sess: Session,
 
     // Build a list of files used to compile the output and
     // write Makefile-compatible dependency rules
-    let files: ~[~str] = {
+    let files: Vec<~str> = {
         let files = sess.codemap.files.borrow();
         files.get()
              .iter()
@@ -786,14 +786,14 @@ pub fn build_session_options(matches: &getopts::Matches)
 
     let lint_levels = [lint::allow, lint::warn,
                        lint::deny, lint::forbid];
-    let mut lint_opts = ~[];
+    let mut lint_opts = Vec::new();
     let lint_dict = lint::get_lint_dict();
     for level in lint_levels.iter() {
         let level_name = lint::level_to_str(*level);
 
         let level_short = level_name.slice_chars(0, 1);
         let level_short = level_short.to_ascii().to_upper().into_str();
-        let flags = vec::append(matches.opt_strs(level_short),
+        let flags = vec_ng::append(matches.opt_strs(level_short),
                                 matches.opt_strs(level_name));
         for lint_name in flags.iter() {
             let lint_name = lint_name.replace("-", "_");
@@ -829,7 +829,7 @@ pub fn build_session_options(matches: &getopts::Matches)
     }
 
     let mut output_types = if parse_only || no_trans {
-        ~[]
+        Vec::new()
     } else {
         matches.opt_strs("emit").flat_map(|s| {
             s.split(',').map(|part| {
@@ -1005,7 +1005,7 @@ pub fn build_session_(sopts: @session::Options,
         working_dir: os::getcwd(),
         lints: RefCell::new(HashMap::new()),
         node_id: Cell::new(1),
-        crate_types: @RefCell::new(~[]),
+        crate_types: @RefCell::new(Vec::new()),
         features: front::feature_gate::Features::new()
     }
 }
@@ -1026,8 +1026,8 @@ pub fn parse_pretty(sess: Session, name: &str) -> PpMode {
 }
 
 // rustc command line options
-pub fn optgroups() -> ~[getopts::OptGroup] {
- ~[
+pub fn optgroups() -> Vec<getopts::OptGroup> {
+ vec!(
   optflag("h", "help", "Display this message"),
   optmulti("", "cfg", "Configure the compilation environment", "SPEC"),
   optmulti("L", "",   "Add a directory to the library search path", "PATH"),
@@ -1071,8 +1071,7 @@ pub fn optgroups() -> ~[getopts::OptGroup] {
   optmulti("F", "forbid", "Set lint forbidden", "OPT"),
   optmulti("C", "codegen", "Set a codegen option", "OPT[=VALUE]"),
   optmulti("Z", "", "Set internal debugging options", "FLAG"),
-  optflag( "v", "version", "Print version info and exit"),
- ]
+  optflag( "v", "version", "Print version info and exit"))
 }
 
 pub struct OutputFilenames {

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -74,8 +74,8 @@ debugging_opts!(
     0
 )
 
-pub fn debugging_opts_map() -> ~[(&'static str, &'static str, u64)] {
-    ~[("verbose", "in general, enable more debug printouts", VERBOSE),
+pub fn debugging_opts_map() -> Vec<(&'static str, &'static str, u64)> {
+    vec!(("verbose", "in general, enable more debug printouts", VERBOSE),
      ("time-passes", "measure time of each rustc pass", TIME_PASSES),
      ("count-llvm-insns", "count where LLVM \
                            instrs originate", COUNT_LLVM_INSNS),
@@ -102,8 +102,7 @@ pub fn debugging_opts_map() -> ~[(&'static str, &'static str, u64)] {
       PRINT_LLVM_PASSES),
      ("lto", "Perform LLVM link-time optimizations", LTO),
      ("ast-json", "Print the AST as JSON and halt", AST_JSON),
-     ("ast-json-noexpand", "Print the pre-expansion AST as JSON and halt", AST_JSON_NOEXPAND),
-    ]
+     ("ast-json-noexpand", "Print the pre-expansion AST as JSON and halt", AST_JSON_NOEXPAND))
 }
 
 #[deriving(Clone, Eq)]
@@ -125,13 +124,13 @@ pub enum DebugInfoLevel {
 pub struct Options {
     // The crate config requested for the session, which may be combined
     // with additional crate configurations during the compile process
-    crate_types: ~[CrateType],
+    crate_types: Vec<CrateType> ,
 
     gc: bool,
     optimize: OptLevel,
     debuginfo: DebugInfoLevel,
-    lint_opts: ~[(lint::Lint, lint::level)],
-    output_types: ~[back::link::OutputType],
+    lint_opts: Vec<(lint::Lint, lint::level)> ,
+    output_types: Vec<back::link::OutputType> ,
     // This was mutable for rustpkg, which updates search paths based on the
     // parsed code. It remains mutable in case its replacements wants to use
     // this.
@@ -192,9 +191,9 @@ pub struct Session_ {
     local_crate_source_file: Option<Path>,
     working_dir: Path,
     lints: RefCell<HashMap<ast::NodeId,
-                           ~[(lint::Lint, codemap::Span, ~str)]>>,
+                           Vec<(lint::Lint, codemap::Span, ~str)> >>,
     node_id: Cell<ast::NodeId>,
-    crate_types: @RefCell<~[CrateType]>,
+    crate_types: @RefCell<Vec<CrateType> >,
     features: front::feature_gate::Features
 }
 
@@ -259,7 +258,7 @@ impl Session_ {
             Some(arr) => { arr.push((lint, sp, msg)); return; }
             None => {}
         }
-        lints.get().insert(id, ~[(lint, sp, msg)]);
+        lints.get().insert(id, vec!((lint, sp, msg)));
     }
     pub fn next_node_id(&self) -> ast::NodeId {
         self.reserve_node_ids(1)
@@ -318,12 +317,22 @@ impl Session_ {
 /// Some reasonable defaults
 pub fn basic_options() -> @Options {
     @Options {
-        crate_types: ~[],
+        crate_types: Vec::new(),
         gc: false,
         optimize: No,
+<<<<<<< HEAD
         debuginfo: NoDebugInfo,
         lint_opts: ~[],
         output_types: ~[],
+||||||| merged common ancestors
+        debuginfo: false,
+        lint_opts: ~[],
+        output_types: ~[],
+=======
+        debuginfo: false,
+        lint_opts: Vec::new(),
+        output_types: Vec::new(),
+>>>>>>> librustc: Automatically change uses of `~[T]` to `Vec<T>` in rustc.
         addl_lib_search_paths: @RefCell::new(HashSet::new()),
         maybe_sysroot: None,
         target_triple: host_triple(),
@@ -394,7 +403,7 @@ macro_rules! cgoptions(
             }
         }
 
-        fn parse_list(slot: &mut ~[~str], v: Option<&str>) -> bool {
+        fn parse_list(slot: &mut Vec<~str> , v: Option<&str>) -> bool {
             match v {
                 Some(s) => {
                     for s in s.words() {
@@ -414,15 +423,15 @@ cgoptions!(
         "tool to assemble archives with"),
     linker: Option<~str> = (None, parse_opt_string,
         "system linker to link outputs with"),
-    link_args: ~[~str] = (~[], parse_list,
+    link_args: Vec<~str> = (Vec::new(), parse_list,
         "extra arguments to pass to the linker (space separated)"),
     target_cpu: ~str = (~"generic", parse_string,
         "select target processor (llc -mcpu=help for details)"),
     target_feature: ~str = (~"", parse_string,
         "target specific attributes (llc -mattr=help for details)"),
-    passes: ~[~str] = (~[], parse_list,
+    passes: Vec<~str> = (Vec::new(), parse_list,
         "a list of extra LLVM passes to run (space separated)"),
-    llvm_args: ~[~str] = (~[], parse_list,
+    llvm_args: Vec<~str> = (Vec::new(), parse_list,
         "a list of arguments to pass to llvm (space separated)"),
     save_temps: bool = (false, parse_bool,
         "save all temporary output files during compilation"),
@@ -476,11 +485,11 @@ pub fn default_lib_output() -> CrateType {
 }
 
 pub fn collect_crate_types(session: &Session,
-                           attrs: &[ast::Attribute]) -> ~[CrateType] {
+                           attrs: &[ast::Attribute]) -> Vec<CrateType> {
     // If we're generating a test executable, then ignore all other output
     // styles at all other locations
     if session.opts.test {
-        return ~[CrateTypeExecutable];
+        return Vec<CrateTypeExecutable> ;
     }
     let mut base = session.opts.crate_types.clone();
     let mut iter = attrs.iter().filter_map(|a| {

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -320,19 +320,9 @@ pub fn basic_options() -> @Options {
         crate_types: Vec::new(),
         gc: false,
         optimize: No,
-<<<<<<< HEAD
         debuginfo: NoDebugInfo,
-        lint_opts: ~[],
-        output_types: ~[],
-||||||| merged common ancestors
-        debuginfo: false,
-        lint_opts: ~[],
-        output_types: ~[],
-=======
-        debuginfo: false,
         lint_opts: Vec::new(),
         output_types: Vec::new(),
->>>>>>> librustc: Automatically change uses of `~[T]` to `Vec<T>` in rustc.
         addl_lib_search_paths: @RefCell::new(HashSet::new()),
         maybe_sysroot: None,
         target_triple: host_triple(),
@@ -403,7 +393,8 @@ macro_rules! cgoptions(
             }
         }
 
-        fn parse_list(slot: &mut Vec<~str> , v: Option<&str>) -> bool {
+        fn parse_list(slot: &mut ::std::vec_ng::Vec<~str>, v: Option<&str>)
+                      -> bool {
             match v {
                 Some(s) => {
                     for s in s.words() {
@@ -489,7 +480,7 @@ pub fn collect_crate_types(session: &Session,
     // If we're generating a test executable, then ignore all other output
     // styles at all other locations
     if session.opts.test {
-        return Vec<CrateTypeExecutable> ;
+        return vec!(CrateTypeExecutable)
     }
     let mut base = session.opts.crate_types.clone();
     let mut iter = attrs.iter().filter_map(|a| {
@@ -525,7 +516,7 @@ pub fn collect_crate_types(session: &Session,
     if base.len() == 0 {
         base.push(CrateTypeExecutable);
     }
-    base.sort();
+    base.as_mut_slice().sort();
     base.dedup();
     return base;
 }

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+use std::vec_ng::Vec;
 use syntax::fold::Folder;
 use syntax::{ast, fold, attr};
 use syntax::codemap;

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -58,7 +58,7 @@ fn filter_view_item<'r>(cx: &Context, view_item: &'r ast::ViewItem)
 }
 
 fn fold_mod(cx: &mut Context, m: &ast::Mod) -> ast::Mod {
-    let filtered_items: ~[&@ast::Item] = m.items.iter()
+    let filtered_items: Vec<&@ast::Item> = m.items.iter()
             .filter(|&a| item_in_cfg(cx, *a))
             .collect();
     let flattened_items = filtered_items.move_iter()
@@ -170,7 +170,7 @@ fn retain_stmt(cx: &Context, stmt: @ast::Stmt) -> bool {
 }
 
 fn fold_block(cx: &mut Context, b: ast::P<ast::Block>) -> ast::P<ast::Block> {
-    let resulting_stmts: ~[&@ast::Stmt] =
+    let resulting_stmts: Vec<&@ast::Stmt> =
         b.stmts.iter().filter(|&a| retain_stmt(cx, *a)).collect();
     let resulting_stmts = resulting_stmts.move_iter()
         .flat_map(|&stmt| cx.fold_stmt(stmt).move_iter())

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -85,7 +85,7 @@ impl Features {
 }
 
 struct Context {
-    features: ~[&'static str],
+    features: Vec<&'static str> ,
     sess: Session,
 }
 
@@ -280,7 +280,7 @@ impl Visitor<()> for Context {
 
 pub fn check_crate(sess: Session, krate: &ast::Crate) {
     let mut cx = Context {
-        features: ~[],
+        features: Vec::new(),
         sess: sess,
     };
 

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -31,6 +31,7 @@ use syntax::parse::token;
 use driver::session::Session;
 
 use std::cell::Cell;
+use std::vec_ng::Vec;
 
 /// This is a list of all known features since the beginning of time. This list
 /// can never shrink, it may only be expanded (in order to prevent old programs

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -40,7 +40,7 @@ use syntax::util::small_vector::SmallVector;
 
 struct Test {
     span: Span,
-    path: ~[ast::Ident],
+    path: Vec<ast::Ident> ,
     bench: bool,
     ignore: bool,
     should_fail: bool
@@ -48,9 +48,9 @@ struct Test {
 
 struct TestCtxt<'a> {
     sess: session::Session,
-    path: RefCell<~[ast::Ident]>,
+    path: RefCell<Vec<ast::Ident> >,
     ext_cx: ExtCtxt<'a>,
-    testfns: RefCell<~[Test]>,
+    testfns: RefCell<Vec<Test> >,
     is_test_crate: bool,
     config: ast::CrateConfig,
 }
@@ -171,8 +171,8 @@ fn generate_test_harness(sess: session::Session, krate: ast::Crate)
                                  loader: loader,
                                  deriving_hash_type_parameter: false,
                              }),
-        path: RefCell::new(~[]),
-        testfns: RefCell::new(~[]),
+        path: RefCell::new(Vec::new()),
+        testfns: RefCell::new(Vec::new()),
         is_test_crate: is_test_crate(&krate),
         config: krate.config.clone(),
     };
@@ -303,7 +303,7 @@ fn mk_std(cx: &TestCtxt) -> ast::ViewItem {
     let vi = if cx.is_test_crate {
         ast::ViewItemUse(
             vec!(@nospan(ast::ViewPathSimple(id_test,
-                                             path_node(~[id_test]),
+                                             path_node(vec!(id_test)),
                                              ast::DUMMY_NODE_ID))))
     } else {
         ast::ViewItemExternCrate(id_test,
@@ -363,7 +363,7 @@ fn nospan<T>(t: T) -> codemap::Spanned<T> {
     codemap::Spanned { node: t, span: DUMMY_SP }
 }
 
-fn path_node(ids: ~[ast::Ident]) -> ast::Path {
+fn path_node(ids: Vec<ast::Ident> ) -> ast::Path {
     ast::Path {
         span: DUMMY_SP,
         global: false,
@@ -375,7 +375,7 @@ fn path_node(ids: ~[ast::Ident]) -> ast::Path {
     }
 }
 
-fn path_node_global(ids: ~[ast::Ident]) -> ast::Path {
+fn path_node_global(ids: Vec<ast::Ident> ) -> ast::Path {
     ast::Path {
         span: DUMMY_SP,
         global: true,

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -93,7 +93,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
             path.get().push(i.ident);
         }
         debug!("current path: {}",
-               ast_util::path_name_i(self.cx.path.get()));
+               ast_util::path_name_i(self.cx.path.get().as_slice()));
 
         if is_test_fn(&self.cx, i) || is_bench_fn(i) {
             match i.node {
@@ -432,11 +432,12 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::Expr {
     let span = test.span;
     let path = test.path.clone();
 
-    debug!("encoding {}", ast_util::path_name_i(path));
+    debug!("encoding {}", ast_util::path_name_i(path.as_slice()));
 
     let name_lit: ast::Lit =
         nospan(ast::LitStr(token::intern_and_get_ident(
-                    ast_util::path_name_i(path)), ast::CookedStr));
+                    ast_util::path_name_i(path.as_slice())),
+                    ast::CookedStr));
 
     let name_expr = @ast::Expr {
           id: ast::DUMMY_NODE_ID,

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -53,8 +53,8 @@ use std::io;
 use std::os;
 use std::str;
 use std::task;
-use std::vec;
 use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::ast;
 use syntax::diagnostic::Emitter;
 use syntax::diagnostic;
@@ -149,7 +149,7 @@ Additional help:
     -C help             Print codegen options
     -W help             Print 'lint' options and default settings
     -Z help             Print internal options for debugging rustc\n",
-              getopts::usage(message, d::optgroups()));
+              getopts::usage(message, d::optgroups().as_slice()));
 }
 
 pub fn describe_warnings() {
@@ -165,7 +165,7 @@ Available lint options:
     let mut lint_dict = lint_dict.move_iter()
                                  .map(|(k, v)| (v, k))
                                  .collect::<Vec<(lint::LintSpec, &'static str)> >();
-    lint_dict.sort();
+    lint_dict.as_mut_slice().sort();
 
     let mut max_key = 0;
     for &(_, name) in lint_dict.iter() {
@@ -224,7 +224,7 @@ pub fn run_compiler(args: &[~str]) {
     if args.is_empty() { usage(binary); return; }
 
     let matches =
-        &match getopts::getopts(args, d::optgroups()) {
+        &match getopts::getopts(args, d::optgroups().as_slice()) {
           Ok(m) => m,
           Err(f) => {
             d::early_error(f.to_err_msg());
@@ -236,8 +236,10 @@ pub fn run_compiler(args: &[~str]) {
         return;
     }
 
-    let lint_flags = vec_ng::append(matches.opt_strs("W"),
-                                 matches.opt_strs("warn"));
+    let lint_flags = vec_ng::append(matches.opt_strs("W")
+                                           .move_iter()
+                                           .collect(),
+                                    matches.opt_strs("warn"));
     if lint_flags.iter().any(|x| x == &~"help") {
         describe_warnings();
         return;
@@ -312,8 +314,8 @@ pub fn run_compiler(args: &[~str]) {
     if crate_id || crate_name || crate_file_name {
         let attrs = parse_crate_attrs(sess, &input);
         let t_outputs = d::build_output_filenames(&input, &odir, &ofile,
-                                                  attrs, sess);
-        let id = link::find_crate_id(attrs, &t_outputs);
+                                                  attrs.as_slice(), sess);
+        let id = link::find_crate_id(attrs.as_slice(), &t_outputs);
 
         if crate_id {
             println!("{}", id.to_str());
@@ -322,7 +324,8 @@ pub fn run_compiler(args: &[~str]) {
             println!("{}", id.name);
         }
         if crate_file_name {
-            let crate_types = session::collect_crate_types(&sess, attrs);
+            let crate_types = session::collect_crate_types(&sess,
+                                                           attrs.as_slice());
             for &style in crate_types.iter() {
                 let fname = link::filename_for_input(&sess, style, &id,
                                                      &t_outputs.with_extension(""));

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -164,7 +164,7 @@ Available lint options:
     let lint_dict = lint::get_lint_dict();
     let mut lint_dict = lint_dict.move_iter()
                                  .map(|(k, v)| (v, k))
-                                 .collect::<~[(lint::LintSpec, &'static str)]>();
+                                 .collect::<Vec<(lint::LintSpec, &'static str)> >();
     lint_dict.sort();
 
     let mut max_key = 0;
@@ -236,7 +236,7 @@ pub fn run_compiler(args: &[~str]) {
         return;
     }
 
-    let lint_flags = vec::append(matches.opt_strs("W"),
+    let lint_flags = vec_ng::append(matches.opt_strs("W"),
                                  matches.opt_strs("warn"));
     if lint_flags.iter().any(|x| x == &~"help") {
         describe_warnings();
@@ -337,7 +337,7 @@ pub fn run_compiler(args: &[~str]) {
 }
 
 fn parse_crate_attrs(sess: session::Session, input: &d::Input) ->
-                     ~[ast::Attribute] {
+                     Vec<ast::Attribute> {
     let result = match *input {
         d::FileInput(ref ifile) => {
             parse::parse_crate_attrs_from_file(ifile,

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -58,8 +58,10 @@ pub fn read_crates(sess: Session,
         visit::walk_crate(&mut v, krate, ());
     }
     let crate_cache = e.crate_cache.borrow();
-    dump_crates(*crate_cache.get());
-    warn_if_multiple_versions(&mut e, sess.diagnostic(), *crate_cache.get());
+    dump_crates(crate_cache.get().as_slice());
+    warn_if_multiple_versions(&mut e,
+                              sess.diagnostic(),
+                              crate_cache.get().as_slice());
 }
 
 struct ReadCrateVisitor<'a> {
@@ -121,7 +123,7 @@ fn warn_if_multiple_versions(e: &mut Env,
 struct Env {
     sess: Session,
     os: loader::Os,
-    crate_cache: @RefCell<vec!(cache_entry)>,
+    crate_cache: @RefCell<Vec<cache_entry>>,
     next_crate_num: ast::CrateNum,
     intr: @IdentInterner
 }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -46,7 +46,7 @@ pub fn read_crates(sess: Session,
     let mut e = Env {
         sess: sess,
         os: os,
-        crate_cache: @RefCell::new(~[]),
+        crate_cache: @RefCell::new(Vec::new()),
         next_crate_num: 1,
         intr: intr
     };
@@ -121,7 +121,7 @@ fn warn_if_multiple_versions(e: &mut Env,
 struct Env {
     sess: Session,
     os: loader::Os,
-    crate_cache: @RefCell<~[cache_entry]>,
+    crate_cache: @RefCell<vec!(cache_entry)>,
     next_crate_num: ast::CrateNum,
     intr: @IdentInterner
 }
@@ -401,7 +401,7 @@ impl Loader {
             env: Env {
                 sess: sess,
                 os: os,
-                crate_cache: @RefCell::new(~[]),
+                crate_cache: @RefCell::new(Vec::new()),
                 next_crate_num: 1,
                 intr: token::get_ident_interner(),
             }

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -86,14 +86,14 @@ pub fn each_top_level_item_of_crate(cstore: @cstore::CStore,
                                           callback)
 }
 
-pub fn get_item_path(tcx: ty::ctxt, def: ast::DefId) -> ~[ast_map::PathElem] {
+pub fn get_item_path(tcx: ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> {
     let cstore = tcx.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     let path = decoder::get_item_path(cdata, def.node);
 
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
-    vec::append(~[ast_map::PathMod(token::intern(cdata.name))], path)
+    vec_ng::append(vec!(ast_map::PathMod(token::intern(cdata.name))), path)
 }
 
 pub enum found_ast {
@@ -114,7 +114,7 @@ pub fn maybe_get_item_ast(tcx: ty::ctxt, def: ast::DefId,
 }
 
 pub fn get_enum_variants(tcx: ty::ctxt, def: ast::DefId)
-                      -> ~[@ty::VariantInfo] {
+                      -> Vec<@ty::VariantInfo> {
     let cstore = tcx.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     return decoder::get_enum_variants(cstore.intr, cdata, def.node, tcx)
@@ -141,7 +141,7 @@ pub fn get_method_name_and_explicit_self(cstore: @cstore::CStore,
 }
 
 pub fn get_trait_method_def_ids(cstore: @cstore::CStore,
-                                def: ast::DefId) -> ~[ast::DefId] {
+                                def: ast::DefId) -> Vec<ast::DefId> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_trait_method_def_ids(cdata, def.node)
 }
@@ -154,13 +154,13 @@ pub fn get_item_variances(cstore: @cstore::CStore,
 
 pub fn get_provided_trait_methods(tcx: ty::ctxt,
                                   def: ast::DefId)
-                               -> ~[@ty::Method] {
+                               -> Vec<@ty::Method> {
     let cstore = tcx.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_provided_trait_methods(cstore.intr, cdata, def.node, tcx)
 }
 
-pub fn get_supertraits(tcx: ty::ctxt, def: ast::DefId) -> ~[@ty::TraitRef] {
+pub fn get_supertraits(tcx: ty::ctxt, def: ast::DefId) -> Vec<@ty::TraitRef> {
     let cstore = tcx.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_supertraits(cdata, def.node, tcx)
@@ -174,21 +174,21 @@ pub fn get_type_name_if_impl(cstore: @cstore::CStore, def: ast::DefId)
 
 pub fn get_static_methods_if_impl(cstore: @cstore::CStore,
                                   def: ast::DefId)
-                               -> Option<~[StaticMethodInfo]> {
+                               -> Option<Vec<StaticMethodInfo> > {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_static_methods_if_impl(cstore.intr, cdata, def.node)
 }
 
 pub fn get_item_attrs(cstore: @cstore::CStore,
                       def_id: ast::DefId,
-                      f: |~[@ast::MetaItem]|) {
+                      f: |Vec<@ast::MetaItem> |) {
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_item_attrs(cdata, def_id.node, f)
 }
 
 pub fn get_struct_fields(cstore: @cstore::CStore,
                          def: ast::DefId)
-                      -> ~[ty::field_ty] {
+                      -> Vec<ty::field_ty> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_struct_fields(cstore.intr, cdata, def.node)
 }
@@ -222,8 +222,8 @@ pub fn get_field_type(tcx: ty::ctxt, class_id: ast::DefId,
                  class_id, def) );
     let ty = decoder::item_type(def, the_field, tcx, cdata);
     ty::ty_param_bounds_and_ty {
-        generics: ty::Generics {type_param_defs: Rc::new(~[]),
-                                region_param_defs: Rc::new(~[])},
+        generics: ty::Generics {type_param_defs: Rc::new(Vec::new()),
+                                region_param_defs: Rc::new(Vec::new())},
         ty: ty
     }
 }
@@ -262,7 +262,7 @@ pub fn get_item_visibility(cstore: @cstore::CStore,
 
 pub fn get_native_libraries(cstore: @cstore::CStore,
                             crate_num: ast::CrateNum)
-                                -> ~[(cstore::NativeLibaryKind, ~str)] {
+                                -> Vec<(cstore::NativeLibaryKind, ~str)> {
     let cdata = cstore.get_crate_data(crate_num);
     decoder::get_native_libraries(cdata)
 }
@@ -308,7 +308,7 @@ pub fn get_macro_registrar_fn(cstore: @cstore::CStore,
 
 pub fn get_exported_macros(cstore: @cstore::CStore,
                            crate_num: ast::CrateNum)
-                           -> ~[~str] {
+                           -> Vec<~str> {
     let cdata = cstore.get_crate_data(crate_num);
     decoder::get_exported_macros(cdata)
 }

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -18,9 +18,10 @@ use metadata::decoder;
 use middle::ty;
 use middle::typeck;
 
-use std::vec;
 use reader = serialize::ebml::reader;
 use std::rc::Rc;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::diagnostic::expect;
@@ -93,7 +94,8 @@ pub fn get_item_path(tcx: ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> {
 
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
-    vec_ng::append(vec!(ast_map::PathMod(token::intern(cdata.name))), path)
+    vec_ng::append(vec!(ast_map::PathMod(token::intern(cdata.name))),
+                   path.as_slice())
 }
 
 pub enum found_ast {

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -18,6 +18,7 @@ use metadata::decoder;
 use metadata::loader;
 
 use std::cell::RefCell;
+use std::vec_ng::Vec;
 use collections::HashMap;
 use extra::c_vec::CVec;
 use syntax::ast;

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -67,9 +67,9 @@ pub struct CrateSource {
 pub struct CStore {
     priv metas: RefCell<HashMap<ast::CrateNum, @crate_metadata>>,
     priv extern_mod_crate_map: RefCell<extern_mod_crate_map>,
-    priv used_crate_sources: RefCell<~[CrateSource]>,
-    priv used_libraries: RefCell<~[(~str, NativeLibaryKind)]>,
-    priv used_link_args: RefCell<~[~str]>,
+    priv used_crate_sources: RefCell<Vec<CrateSource> >,
+    priv used_libraries: RefCell<Vec<(~str, NativeLibaryKind)> >,
+    priv used_link_args: RefCell<Vec<~str> >,
     intr: @IdentInterner
 }
 
@@ -81,9 +81,9 @@ impl CStore {
         CStore {
             metas: RefCell::new(HashMap::new()),
             extern_mod_crate_map: RefCell::new(HashMap::new()),
-            used_crate_sources: RefCell::new(~[]),
-            used_libraries: RefCell::new(~[]),
-            used_link_args: RefCell::new(~[]),
+            used_crate_sources: RefCell::new(Vec::new()),
+            used_libraries: RefCell::new(Vec::new()),
+            used_link_args: RefCell::new(Vec::new()),
             intr: intr
         }
     }
@@ -143,7 +143,7 @@ impl CStore {
     }
 
     pub fn get_used_crates(&self, prefer: LinkagePreference)
-                           -> ~[(ast::CrateNum, Option<Path>)] {
+                           -> Vec<(ast::CrateNum, Option<Path>)> {
         let used_crate_sources = self.used_crate_sources.borrow();
         used_crate_sources.get()
             .iter()
@@ -161,7 +161,7 @@ impl CStore {
     }
 
     pub fn get_used_libraries<'a>(&'a self)
-                              -> &'a RefCell<~[(~str, NativeLibaryKind)]> {
+                              -> &'a RefCell<Vec<(~str, NativeLibaryKind)> > {
         &self.used_libraries
     }
 
@@ -172,7 +172,7 @@ impl CStore {
         }
     }
 
-    pub fn get_used_link_args<'a>(&'a self) -> &'a RefCell<~[~str]> {
+    pub fn get_used_link_args<'a>(&'a self) -> &'a RefCell<Vec<~str> > {
         &self.used_link_args
     }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -33,7 +33,7 @@ use std::io;
 use std::io::extensions::u64_from_be_bytes;
 use std::option;
 use std::rc::Rc;
-use std::vec;
+use std::vec_ng::Vec;
 use serialize::ebml::reader;
 use serialize::ebml;
 use serialize::Decodable;
@@ -304,7 +304,7 @@ fn item_path(item_doc: ebml::Doc) -> Vec<ast_map::PathElem> {
     let len_doc = reader::get_doc(path_doc, tag_path_len);
     let len = reader::doc_as_u32(len_doc) as uint;
 
-    let mut result = vec::with_capacity(len);
+    let mut result = Vec::with_capacity(len);
     reader::docs(path_doc, |tag, elt_doc| {
         if tag == tag_path_elem_mod {
             let s = elt_doc.as_str_slice();
@@ -682,7 +682,7 @@ pub fn maybe_get_item_ast(cdata: Cmd, tcx: ty::ctxt, id: ast::NodeId,
                           -> csearch::found_ast {
     debug!("Looking up item: {}", id);
     let item_doc = lookup_item(id, cdata.data());
-    let path = item_path(item_doc).init().to_owned();
+    let path = Vec::from_slice(item_path(item_doc).init());
     match decode_inlined_item(cdata, tcx, path, item_doc) {
         Ok(ref ii) => csearch::found(*ii),
         Err(path) => {
@@ -1072,7 +1072,7 @@ fn get_attributes(md: ebml::Doc) -> Vec<ast::Attribute> {
             // Currently it's only possible to have a single meta item on
             // an attribute
             assert_eq!(meta_items.len(), 1u);
-            let meta_item = meta_items[0];
+            let meta_item = *meta_items.get(0);
             attrs.push(
                 codemap::Spanned {
                     node: ast::Attribute_ {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -250,8 +250,8 @@ fn item_ty_param_defs(item: ebml::Doc,
                       tcx: ty::ctxt,
                       cdata: Cmd,
                       tag: uint)
-                      -> Rc<~[ty::TypeParameterDef]> {
-    let mut bounds = ~[];
+                      -> Rc<Vec<ty::TypeParameterDef> > {
+    let mut bounds = Vec::new();
     reader::tagged_docs(item, tag, |p| {
         let bd = parse_type_param_def_data(
             p.data, p.start, cdata.cnum, tcx,
@@ -263,8 +263,8 @@ fn item_ty_param_defs(item: ebml::Doc,
 }
 
 fn item_region_param_defs(item_doc: ebml::Doc, cdata: Cmd)
-                          -> Rc<~[ty::RegionParameterDef]> {
-    let mut v = ~[];
+                          -> Rc<Vec<ty::RegionParameterDef> > {
+    let mut v = Vec::new();
     reader::tagged_docs(item_doc, tag_region_param_def, |rp_doc| {
             let ident_str_doc = reader::get_doc(rp_doc,
                                                 tag_region_param_def_ident);
@@ -287,8 +287,8 @@ fn item_ty_param_count(item: ebml::Doc) -> uint {
     n
 }
 
-fn enum_variant_ids(item: ebml::Doc, cdata: Cmd) -> ~[ast::DefId] {
-    let mut ids: ~[ast::DefId] = ~[];
+fn enum_variant_ids(item: ebml::Doc, cdata: Cmd) -> Vec<ast::DefId> {
+    let mut ids: Vec<ast::DefId> = Vec::new();
     let v = tag_items_data_item_variant;
     reader::tagged_docs(item, v, |p| {
         let ext = reader::with_doc_data(p, parse_def_id);
@@ -298,7 +298,7 @@ fn enum_variant_ids(item: ebml::Doc, cdata: Cmd) -> ~[ast::DefId] {
     return ids;
 }
 
-fn item_path(item_doc: ebml::Doc) -> ~[ast_map::PathElem] {
+fn item_path(item_doc: ebml::Doc) -> Vec<ast_map::PathElem> {
     let path_doc = reader::get_doc(item_doc, tag_path);
 
     let len_doc = reader::get_doc(path_doc, tag_path_len);
@@ -667,15 +667,15 @@ pub fn each_top_level_item_of_crate(intr: @IdentInterner,
                                 callback)
 }
 
-pub fn get_item_path(cdata: Cmd, id: ast::NodeId) -> ~[ast_map::PathElem] {
+pub fn get_item_path(cdata: Cmd, id: ast::NodeId) -> Vec<ast_map::PathElem> {
     item_path(lookup_item(id, cdata.data()))
 }
 
 pub type DecodeInlinedItem<'a> = 'a |cdata: @cstore::crate_metadata,
                                      tcx: ty::ctxt,
-                                     path: ~[ast_map::PathElem],
+                                     path: Vec<ast_map::PathElem> ,
                                      par_doc: ebml::Doc|
-                                     -> Result<ast::InlinedItem, ~[ast_map::PathElem]>;
+                                     -> Result<ast::InlinedItem, Vec<ast_map::PathElem> >;
 
 pub fn maybe_get_item_ast(cdata: Cmd, tcx: ty::ctxt, id: ast::NodeId,
                           decode_inlined_item: DecodeInlinedItem)
@@ -702,11 +702,11 @@ pub fn maybe_get_item_ast(cdata: Cmd, tcx: ty::ctxt, id: ast::NodeId,
 }
 
 pub fn get_enum_variants(intr: @IdentInterner, cdata: Cmd, id: ast::NodeId,
-                     tcx: ty::ctxt) -> ~[@ty::VariantInfo] {
+                     tcx: ty::ctxt) -> Vec<@ty::VariantInfo> {
     let data = cdata.data();
     let items = reader::get_doc(reader::Doc(data), tag_items);
     let item = find_item(id, items);
-    let mut infos: ~[@ty::VariantInfo] = ~[];
+    let mut infos: Vec<@ty::VariantInfo> = Vec::new();
     let variant_ids = enum_variant_ids(item, cdata);
     let mut disr_val = 0;
     for did in variant_ids.iter() {
@@ -716,7 +716,7 @@ pub fn get_enum_variants(intr: @IdentInterner, cdata: Cmd, id: ast::NodeId,
         let name = item_name(intr, item);
         let arg_tys = match ty::get(ctor_ty).sty {
           ty::ty_bare_fn(ref f) => f.sig.inputs.clone(),
-          _ => ~[], // Nullary enum variant.
+          _ => Vec::new(), // Nullary enum variant.
         };
         match variant_disr_val(item) {
           Some(val) => { disr_val = val; }
@@ -761,8 +761,8 @@ fn get_explicit_self(item: ebml::Doc) -> ast::ExplicitSelf_ {
 }
 
 fn item_impl_methods(intr: @IdentInterner, cdata: Cmd, item: ebml::Doc,
-                     tcx: ty::ctxt) -> ~[@ty::Method] {
-    let mut rslt = ~[];
+                     tcx: ty::ctxt) -> Vec<@ty::Method> {
+    let mut rslt = Vec::new();
     reader::tagged_docs(item, tag_item_impl_method, |doc| {
         let m_did = reader::with_doc_data(doc, parse_def_id);
         rslt.push(@get_method(intr, cdata, m_did.node, tcx));
@@ -838,10 +838,10 @@ pub fn get_method(intr: @IdentInterner, cdata: Cmd, id: ast::NodeId,
 }
 
 pub fn get_trait_method_def_ids(cdata: Cmd,
-                                id: ast::NodeId) -> ~[ast::DefId] {
+                                id: ast::NodeId) -> Vec<ast::DefId> {
     let data = cdata.data();
     let item = lookup_item(id, data);
-    let mut result = ~[];
+    let mut result = Vec::new();
     reader::tagged_docs(item, tag_item_trait_method, |mth| {
         result.push(item_def_id(mth, cdata));
         true
@@ -859,10 +859,10 @@ pub fn get_item_variances(cdata: Cmd, id: ast::NodeId) -> ty::ItemVariances {
 
 pub fn get_provided_trait_methods(intr: @IdentInterner, cdata: Cmd,
                                   id: ast::NodeId, tcx: ty::ctxt) ->
-        ~[@ty::Method] {
+        Vec<@ty::Method> {
     let data = cdata.data();
     let item = lookup_item(id, data);
-    let mut result = ~[];
+    let mut result = Vec::new();
 
     reader::tagged_docs(item, tag_item_trait_method, |mth_id| {
         let did = item_def_id(mth_id, cdata);
@@ -879,8 +879,8 @@ pub fn get_provided_trait_methods(intr: @IdentInterner, cdata: Cmd,
 
 /// Returns the supertraits of the given trait.
 pub fn get_supertraits(cdata: Cmd, id: ast::NodeId, tcx: ty::ctxt)
-                    -> ~[@ty::TraitRef] {
-    let mut results = ~[];
+                    -> Vec<@ty::TraitRef> {
+    let mut results = Vec::new();
     let item_doc = lookup_item(id, cdata.data());
     reader::tagged_docs(item_doc, tag_item_super_trait_ref, |trait_doc| {
         // NB. Only reads the ones that *aren't* builtin-bounds. See also
@@ -914,7 +914,7 @@ pub fn get_type_name_if_impl(cdata: Cmd,
 pub fn get_static_methods_if_impl(intr: @IdentInterner,
                                   cdata: Cmd,
                                   node_id: ast::NodeId)
-                               -> Option<~[StaticMethodInfo]> {
+                               -> Option<Vec<StaticMethodInfo> > {
     let item = lookup_item(node_id, cdata.data());
     if item_family(item) != Impl {
         return None;
@@ -927,13 +927,13 @@ pub fn get_static_methods_if_impl(intr: @IdentInterner,
 
     if !ret { return None }
 
-    let mut impl_method_ids = ~[];
+    let mut impl_method_ids = Vec::new();
     reader::tagged_docs(item, tag_item_impl_method, |impl_method_doc| {
         impl_method_ids.push(reader::with_doc_data(impl_method_doc, parse_def_id));
         true
     });
 
-    let mut static_impl_methods = ~[];
+    let mut static_impl_methods = Vec::new();
     for impl_method_id in impl_method_ids.iter() {
         let impl_method_doc = lookup_item(impl_method_id.node, cdata.data());
         let family = item_family(impl_method_doc);
@@ -975,7 +975,7 @@ pub fn get_tuple_struct_definition_if_ctor(cdata: Cmd,
 
 pub fn get_item_attrs(cdata: Cmd,
                       node_id: ast::NodeId,
-                      f: |~[@ast::MetaItem]|) {
+                      f: |Vec<@ast::MetaItem> |) {
     // The attributes for a tuple struct are attached to the definition, not the ctor;
     // we assume that someone passing in a tuple struct ctor is actually wanting to
     // look at the definition
@@ -1000,10 +1000,10 @@ fn struct_field_family_to_visibility(family: Family) -> ast::Visibility {
 }
 
 pub fn get_struct_fields(intr: @IdentInterner, cdata: Cmd, id: ast::NodeId)
-    -> ~[ty::field_ty] {
+    -> Vec<ty::field_ty> {
     let data = cdata.data();
     let item = lookup_item(id, data);
-    let mut result = ~[];
+    let mut result = Vec::new();
     reader::tagged_docs(item, tag_item_field, |an_item| {
         let f = item_family(an_item);
         if f == PublicField || f == PrivateField || f == InheritedField {
@@ -1035,8 +1035,8 @@ pub fn get_item_visibility(cdata: Cmd, id: ast::NodeId)
     item_visibility(lookup_item(id, cdata.data()))
 }
 
-fn get_meta_items(md: ebml::Doc) -> ~[@ast::MetaItem] {
-    let mut items: ~[@ast::MetaItem] = ~[];
+fn get_meta_items(md: ebml::Doc) -> Vec<@ast::MetaItem> {
+    let mut items: Vec<@ast::MetaItem> = Vec::new();
     reader::tagged_docs(md, tag_meta_item_word, |meta_item_doc| {
         let nd = reader::get_doc(meta_item_doc, tag_meta_item_name);
         let n = token::intern_and_get_ident(nd.as_str_slice());
@@ -1063,8 +1063,8 @@ fn get_meta_items(md: ebml::Doc) -> ~[@ast::MetaItem] {
     return items;
 }
 
-fn get_attributes(md: ebml::Doc) -> ~[ast::Attribute] {
-    let mut attrs: ~[ast::Attribute] = ~[];
+fn get_attributes(md: ebml::Doc) -> Vec<ast::Attribute> {
+    let mut attrs: Vec<ast::Attribute> = Vec::new();
     match reader::maybe_get_doc(md, tag_attributes) {
       option::Some(attrs_d) => {
         reader::tagged_docs(attrs_d, tag_attribute, |attr_doc| {
@@ -1102,7 +1102,7 @@ fn list_crate_attributes(md: ebml::Doc, hash: &Svh,
     write!(out, "\n\n")
 }
 
-pub fn get_crate_attributes(data: &[u8]) -> ~[ast::Attribute] {
+pub fn get_crate_attributes(data: &[u8]) -> Vec<ast::Attribute> {
     return get_attributes(reader::Doc(data));
 }
 
@@ -1113,8 +1113,8 @@ pub struct CrateDep {
     hash: Svh,
 }
 
-pub fn get_crate_deps(data: &[u8]) -> ~[CrateDep] {
-    let mut deps: ~[CrateDep] = ~[];
+pub fn get_crate_deps(data: &[u8]) -> Vec<CrateDep> {
+    let mut deps: Vec<CrateDep> = Vec::new();
     let cratedoc = reader::Doc(data);
     let depsdoc = reader::get_doc(cratedoc, tag_crate_deps);
     let mut crate_num = 1;
@@ -1255,10 +1255,10 @@ pub fn get_trait_of_method(cdata: Cmd, id: ast::NodeId, tcx: ty::ctxt)
 }
 
 
-pub fn get_native_libraries(cdata: Cmd) -> ~[(cstore::NativeLibaryKind, ~str)] {
+pub fn get_native_libraries(cdata: Cmd) -> Vec<(cstore::NativeLibaryKind, ~str)> {
     let libraries = reader::get_doc(reader::Doc(cdata.data()),
                                     tag_native_libraries);
-    let mut result = ~[];
+    let mut result = Vec::new();
     reader::tagged_docs(libraries, tag_native_libraries_lib, |lib_doc| {
         let kind_doc = reader::get_doc(lib_doc, tag_native_libraries_kind);
         let name_doc = reader::get_doc(lib_doc, tag_native_libraries_name);
@@ -1276,10 +1276,10 @@ pub fn get_macro_registrar_fn(cdata: Cmd) -> Option<ast::DefId> {
         .map(|doc| item_def_id(doc, cdata))
 }
 
-pub fn get_exported_macros(cdata: Cmd) -> ~[~str] {
+pub fn get_exported_macros(cdata: Cmd) -> Vec<~str> {
     let macros = reader::get_doc(reader::Doc(cdata.data()),
                                  tag_exported_macros);
-    let mut result = ~[];
+    let mut result = Vec::new();
     reader::tagged_docs(macros, tag_macro_def, |macro_doc| {
         result.push(macro_doc.as_str());
         true

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -324,7 +324,7 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
                             ebml_w: &mut writer::Encoder,
                             id: NodeId,
                             variants: &[P<Variant>],
-                            index: @RefCell<~[entry<i64>]>,
+                            index: @RefCell<Vec<entry<i64>> >,
                             generics: &ast::Generics) {
     debug!("encode_enum_variant_info(id={:?})", id);
 
@@ -687,11 +687,11 @@ fn encode_provided_source(ebml_w: &mut writer::Encoder,
 fn encode_info_for_struct(ecx: &EncodeContext,
                           ebml_w: &mut writer::Encoder,
                           fields: &[StructField],
-                          global_index: @RefCell<~[entry<i64>]>)
-                          -> ~[entry<i64>] {
+                          global_index: @RefCell<Vec<entry<i64>> >)
+                          -> Vec<entry<i64>> {
     /* Each class has its own index, since different classes
        may have fields with the same name */
-    let mut index = ~[];
+    let mut index = Vec::new();
     let tcx = ecx.tcx;
      /* We encode both private and public fields -- need to include
         private fields to get the offsets right */
@@ -726,7 +726,7 @@ fn encode_info_for_struct_ctor(ecx: &EncodeContext,
                                ebml_w: &mut writer::Encoder,
                                name: ast::Ident,
                                ctor_id: NodeId,
-                               index: @RefCell<~[entry<i64>]>,
+                               index: @RefCell<Vec<entry<i64>> >,
                                struct_id: NodeId) {
     {
         let mut index = index.borrow_mut();
@@ -888,13 +888,13 @@ fn encode_extension_implementations(ecx: &EncodeContext,
 fn encode_info_for_item(ecx: &EncodeContext,
                         ebml_w: &mut writer::Encoder,
                         item: &Item,
-                        index: @RefCell<~[entry<i64>]>,
+                        index: @RefCell<Vec<entry<i64>> >,
                         path: PathElems,
                         vis: ast::Visibility) {
     let tcx = ecx.tcx;
 
     fn add_to_index(item: &Item, ebml_w: &writer::Encoder,
-                     index: @RefCell<~[entry<i64>]>) {
+                     index: @RefCell<Vec<entry<i64>> >) {
         let mut index = index.borrow_mut();
         index.get().push(entry {
             val: item.id as i64,
@@ -1239,7 +1239,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
 fn encode_info_for_foreign_item(ecx: &EncodeContext,
                                 ebml_w: &mut writer::Encoder,
                                 nitem: &ForeignItem,
-                                index: @RefCell<~[entry<i64>]>,
+                                index: @RefCell<Vec<entry<i64>> >,
                                 path: PathElems,
                                 abi: AbiSet) {
     {
@@ -1284,7 +1284,7 @@ fn my_visit_expr(_e: &Expr) { }
 fn my_visit_item(i: &Item,
                  ebml_w: &mut writer::Encoder,
                  ecx_ptr: *int,
-                 index: @RefCell<~[entry<i64>]>) {
+                 index: @RefCell<Vec<entry<i64>> >) {
     let mut ebml_w = unsafe { ebml_w.unsafe_clone() };
     // See above
     let ecx: &EncodeContext = unsafe { cast::transmute(ecx_ptr) };
@@ -1296,7 +1296,7 @@ fn my_visit_item(i: &Item,
 fn my_visit_foreign_item(ni: &ForeignItem,
                          ebml_w: &mut writer::Encoder,
                          ecx_ptr:*int,
-                         index: @RefCell<~[entry<i64>]>) {
+                         index: @RefCell<Vec<entry<i64>> >) {
     // See above
     let ecx: &EncodeContext = unsafe { cast::transmute(ecx_ptr) };
     debug!("writing foreign item {}::{}",
@@ -1317,7 +1317,7 @@ fn my_visit_foreign_item(ni: &ForeignItem,
 struct EncodeVisitor<'a,'b> {
     ebml_w_for_visit_item: &'a mut writer::Encoder<'b>,
     ecx_ptr:*int,
-    index: @RefCell<~[entry<i64>]>,
+    index: @RefCell<Vec<entry<i64>> >,
 }
 
 impl<'a,'b> visit::Visitor<()> for EncodeVisitor<'a,'b> {
@@ -1344,8 +1344,8 @@ impl<'a,'b> visit::Visitor<()> for EncodeVisitor<'a,'b> {
 fn encode_info_for_items(ecx: &EncodeContext,
                          ebml_w: &mut writer::Encoder,
                          krate: &Crate)
-                         -> ~[entry<i64>] {
-    let index = @RefCell::new(~[]);
+                         -> Vec<entry<i64>> {
+    let index = @RefCell::new(Vec::new());
     ebml_w.start_tag(tag_items_data);
     {
         let mut index = index.borrow_mut();
@@ -1382,11 +1382,11 @@ fn encode_info_for_items(ecx: &EncodeContext,
 // Path and definition ID indexing
 
 fn create_index<T:Clone + Hash + 'static>(
-                index: ~[entry<T>])
-                -> ~[@~[entry<T>]] {
-    let mut buckets: ~[@RefCell<~[entry<T>]>] = ~[];
+                index: Vec<entry<T>> )
+                -> Vec<@Vec<entry<T>> > {
+    let mut buckets: Vec<@RefCell<Vec<entry<T>> >> = Vec::new();
     for _ in range(0u, 256u) {
-        buckets.push(@RefCell::new(~[]));
+        buckets.push(@RefCell::new(Vec::new()));
     }
     for elt in index.iter() {
         let h = hash::hash(&elt.val) as uint;
@@ -1394,7 +1394,7 @@ fn create_index<T:Clone + Hash + 'static>(
         bucket.get().push((*elt).clone());
     }
 
-    let mut buckets_frozen = ~[];
+    let mut buckets_frozen = Vec::new();
     for bucket in buckets.iter() {
         buckets_frozen.push(@/*bad*/(**bucket).get());
     }
@@ -1403,10 +1403,10 @@ fn create_index<T:Clone + Hash + 'static>(
 
 fn encode_index<T:'static>(
                 ebml_w: &mut writer::Encoder,
-                buckets: ~[@~[entry<T>]],
+                buckets: Vec<@Vec<entry<T>> > ,
                 write_fn: |&mut MemWriter, &T|) {
     ebml_w.start_tag(tag_index);
-    let mut bucket_locs = ~[];
+    let mut bucket_locs = Vec::new();
     ebml_w.start_tag(tag_index_buckets);
     for bucket in buckets.iter() {
         bucket_locs.push(ebml_w.writer.tell().unwrap());
@@ -1491,7 +1491,7 @@ fn encode_attributes(ebml_w: &mut writer::Encoder, attrs: &[Attribute]) {
 // metadata that Rust cares about for linking crates. If the user didn't
 // provide it we will throw it in anyway with a default value.
 fn synthesize_crate_attrs(ecx: &EncodeContext,
-                          krate: &Crate) -> ~[Attribute] {
+                          krate: &Crate) -> Vec<Attribute> {
 
     fn synthesize_crateid_attr(ecx: &EncodeContext) -> Attribute {
         assert!(!ecx.link_meta.crateid.name.is_empty());
@@ -1502,7 +1502,7 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
                 token::intern_and_get_ident(ecx.link_meta.crateid.to_str())))
     }
 
-    let mut attrs = ~[];
+    let mut attrs = Vec::new();
     for attr in krate.attrs.iter() {
         if !attr.name().equiv(&("crate_id")) {
             attrs.push(*attr);
@@ -1514,9 +1514,9 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
 }
 
 fn encode_crate_deps(ebml_w: &mut writer::Encoder, cstore: &cstore::CStore) {
-    fn get_ordered_deps(cstore: &cstore::CStore) -> ~[decoder::CrateDep] {
+    fn get_ordered_deps(cstore: &cstore::CStore) -> Vec<decoder::CrateDep> {
         // Pull the cnums and name,vers,hash out of cstore
-        let mut deps = ~[];
+        let mut deps = Vec::new();
         cstore.iter_crate_data(|key, val| {
             let dep = decoder::CrateDep {
                 cnum: key,
@@ -1767,7 +1767,7 @@ pub static metadata_encoding_version : &'static [u8] =
       0x74, //'t' as u8,
       0, 0, 0, 1 ];
 
-pub fn encode_metadata(parms: EncodeParams, krate: &Crate) -> ~[u8] {
+pub fn encode_metadata(parms: EncodeParams, krate: &Crate) -> Vec<u8> {
     let mut wr = MemWriter::new();
     encode_metadata_inner(&mut wr, parms, krate);
     wr.unwrap()

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -32,6 +32,7 @@ use std::hash;
 use std::hash::Hash;
 use std::io::MemWriter;
 use std::str;
+use std::vec_ng::Vec;
 use collections::HashMap;
 use syntax::abi::AbiSet;
 use syntax::ast::*;
@@ -367,9 +368,9 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
                 encode_index(ebml_w, bkts, write_i64);
             }
         }
-        if vi[i].disr_val != disr_val {
-            encode_disr_val(ecx, ebml_w, vi[i].disr_val);
-            disr_val = vi[i].disr_val;
+        if vi.get(i).disr_val != disr_val {
+            encode_disr_val(ecx, ebml_w, vi.get(i).disr_val);
+            disr_val = vi.get(i).disr_val;
         }
         encode_bounds_and_type(ebml_w, ecx,
                                &lookup_item_type(ecx.tcx, def_id));
@@ -1390,7 +1391,7 @@ fn create_index<T:Clone + Hash + 'static>(
     }
     for elt in index.iter() {
         let h = hash::hash(&elt.val) as uint;
-        let mut bucket = buckets[h % 256].borrow_mut();
+        let mut bucket = buckets.get_mut(h % 256).borrow_mut();
         bucket.get().push((*elt).clone());
     }
 
@@ -1770,7 +1771,7 @@ pub static metadata_encoding_version : &'static [u8] =
 pub fn encode_metadata(parms: EncodeParams, krate: &Crate) -> Vec<u8> {
     let mut wr = MemWriter::new();
     encode_metadata_inner(&mut wr, parms, krate);
-    wr.unwrap()
+    wr.unwrap().move_iter().collect()
 }
 
 fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, krate: &Crate) {
@@ -1822,7 +1823,7 @@ fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, krate: &Crate)
 
     let mut i = ebml_w.writer.tell().unwrap();
     let crate_attrs = synthesize_crate_attrs(&ecx, krate);
-    encode_attributes(&mut ebml_w, crate_attrs);
+    encode_attributes(&mut ebml_w, crate_attrs.as_slice());
     ecx.stats.attr_bytes.set(ebml_w.writer.tell().unwrap() - i);
 
     i = ebml_w.writer.tell().unwrap();

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -205,14 +205,14 @@ pub fn get_rust_path() -> Option<~str> {
 /// $HOME/.rust
 /// DIR/.rust for any DIR that's the current working directory
 /// or an ancestor of it
-pub fn rust_path() -> ~[Path] {
-    let mut env_rust_path: ~[Path] = match get_rust_path() {
+pub fn rust_path() -> Vec<Path> {
+    let mut env_rust_path: Vec<Path> = match get_rust_path() {
         Some(env_path) => {
-            let env_path_components: ~[&str] =
+            let env_path_components: Vec<&str> =
                 env_path.split_str(PATH_ENTRY_SEPARATOR).collect();
             env_path_components.map(|&s| Path::new(s))
         }
-        None => ~[]
+        None => Vec::new()
     };
     let mut cwd = os::getcwd();
     // now add in default entries

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -14,6 +14,7 @@ use std::cell::RefCell;
 use std::option;
 use std::os;
 use std::io::fs;
+use std::vec_ng::Vec;
 use collections::HashSet;
 
 pub enum FileMatch { FileMatches, FileDoesntMatch }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -183,7 +183,7 @@ impl<'a> Context<'a> {
         // A Library candidate is created if the metadata for the set of
         // libraries corresponds to the crate id and hash criteria that this
         // serach is being performed for.
-        let mut libraries = ~[];
+        let mut libraries = Vec::new();
         for (_hash, (rlibs, dylibs)) in candidates.move_iter() {
             let mut metadata = None;
             let rlib = self.extract_one(rlibs, "rlib", &mut metadata);

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -31,6 +31,7 @@ use std::io;
 use std::os::consts::{macos, freebsd, linux, android, win32};
 use std::str;
 use std::vec;
+use std::vec_ng::Vec;
 
 use collections::{HashMap, HashSet};
 use flate;
@@ -205,7 +206,7 @@ impl<'a> Context<'a> {
         // libraries or not.
         match libraries.len() {
             0 => None,
-            1 => Some(libraries[0]),
+            1 => Some(libraries.move_iter().next().unwrap()),
             _ => {
                 self.sess.span_err(self.span,
                     format!("multiple matching crates for `{}`",

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -20,6 +20,7 @@ use middle::ty;
 
 use std::str;
 use std::uint;
+use std::vec_ng::Vec;
 use syntax::abi::AbiSet;
 use syntax::abi;
 use syntax::ast;

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -177,7 +177,7 @@ fn parse_substs(st: &mut PState, conv: conv_did) -> ty::substs {
     let self_ty = parse_opt(st, |st| parse_ty(st, |x,y| conv(x,y)) );
 
     assert_eq!(next(st), '[');
-    let mut params: ~[ty::t] = ~[];
+    let mut params: Vec<ty::t> = Vec::new();
     while peek(st) != ']' { params.push(parse_ty(st, |x,y| conv(x,y))); }
     st.pos = st.pos + 1u;
 
@@ -362,7 +362,7 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
       }
       'T' => {
         assert_eq!(next(st), '[');
-        let mut params = ~[];
+        let mut params = Vec::new();
         while peek(st) != ']' { params.push(parse_ty(st, |x,y| conv(x,y))); }
         st.pos = st.pos + 1u;
         return ty::mk_tup(st.tcx, params);
@@ -520,7 +520,7 @@ fn parse_sig(st: &mut PState, conv: conv_did) -> ty::FnSig {
     assert_eq!(next(st), '[');
     let id = parse_uint(st) as ast::NodeId;
     assert_eq!(next(st), '|');
-    let mut inputs = ~[];
+    let mut inputs = Vec::new();
     while peek(st) != ']' {
         inputs.push(parse_ty(st, |x,y| conv(x,y)));
     }
@@ -583,7 +583,7 @@ fn parse_type_param_def(st: &mut PState, conv: conv_did) -> ty::TypeParameterDef
 fn parse_bounds(st: &mut PState, conv: conv_did) -> ty::ParamBounds {
     let mut param_bounds = ty::ParamBounds {
         builtin_bounds: ty::EmptyBuiltinBounds(),
-        trait_bounds: ~[]
+        trait_bounds: Vec::new()
     };
     loop {
         match next(st) {

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -286,7 +286,7 @@ fn enc_sty(w: &mut MemWriter, cx: @ctxt, st: &ty::sty) {
             enc_trait_store(w, cx, store);
             enc_mutability(w, mt);
             let bounds = ty::ParamBounds {builtin_bounds: bounds,
-                                          trait_bounds: ~[]};
+                                          trait_bounds: Vec::new()};
             enc_bounds(w, cx, &bounds);
             mywrite!(w, "]");
         }
@@ -383,7 +383,7 @@ fn enc_closure_ty(w: &mut MemWriter, cx: @ctxt, ft: &ty::ClosureTy) {
     enc_onceness(w, ft.onceness);
     enc_region(w, cx, ft.region);
     let bounds = ty::ParamBounds {builtin_bounds: ft.bounds,
-                                  trait_bounds: ~[]};
+                                  trait_bounds: Vec::new()};
     enc_bounds(w, cx, &bounds);
     enc_fn_sig(w, cx, &ft.sig);
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -19,6 +19,7 @@ use std::io;
 use std::io::MemWriter;
 use std::str;
 use std::fmt;
+use std::vec_ng::Vec;
 
 use middle::ty::param_ty;
 use middle::ty;

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -116,9 +116,9 @@ pub fn encode_exported_macro(ebml_w: &mut writer::Encoder, i: &ast::Item) {
 pub fn decode_inlined_item(cdata: @cstore::crate_metadata,
                            tcx: ty::ctxt,
                            maps: Maps,
-                           path: ~[ast_map::PathElem],
+                           path: Vec<ast_map::PathElem> ,
                            par_doc: ebml::Doc)
-                           -> Result<ast::InlinedItem, ~[ast_map::PathElem]> {
+                           -> Result<ast::InlinedItem, Vec<ast_map::PathElem> > {
     let dcx = @DecodeContext {
         cdata: cdata,
         tcx: tcx,
@@ -395,7 +395,7 @@ impl ast_map::FoldOps for AstRenumberer {
 
 fn renumber_and_map_ast(xcx: @ExtendedDecodeContext,
                         map: &ast_map::Map,
-                        path: ~[ast_map::PathElem],
+                        path: Vec<ast_map::PathElem> ,
                         ii: ast::InlinedItem) -> ast::InlinedItem {
     ast_map::map_decoded_item(map,
                               path.move_iter().collect(),
@@ -1100,7 +1100,7 @@ impl<'a> doc_decoder_helpers for ebml::Doc<'a> {
 
 trait ebml_decoder_decoder_helpers {
     fn read_ty(&mut self, xcx: @ExtendedDecodeContext) -> ty::t;
-    fn read_tys(&mut self, xcx: @ExtendedDecodeContext) -> ~[ty::t];
+    fn read_tys(&mut self, xcx: @ExtendedDecodeContext) -> Vec<ty::t> ;
     fn read_type_param_def(&mut self, xcx: @ExtendedDecodeContext)
                            -> ty::TypeParameterDef;
     fn read_ty_param_bounds_and_ty(&mut self, xcx: @ExtendedDecodeContext)
@@ -1119,7 +1119,7 @@ trait ebml_decoder_decoder_helpers {
                      tcx: ty::ctxt, cdata: @cstore::crate_metadata) -> ty::t;
     fn read_tys_noxcx(&mut self,
                       tcx: ty::ctxt,
-                      cdata: @cstore::crate_metadata) -> ~[ty::t];
+                      cdata: @cstore::crate_metadata) -> Vec<ty::t> ;
 }
 
 impl<'a> ebml_decoder_decoder_helpers for reader::Decoder<'a> {
@@ -1137,7 +1137,7 @@ impl<'a> ebml_decoder_decoder_helpers for reader::Decoder<'a> {
 
     fn read_tys_noxcx(&mut self,
                       tcx: ty::ctxt,
-                      cdata: @cstore::crate_metadata) -> ~[ty::t] {
+                      cdata: @cstore::crate_metadata) -> Vec<ty::t> {
         self.read_to_vec(|this| this.read_ty_noxcx(tcx, cdata) )
     }
 
@@ -1169,7 +1169,7 @@ impl<'a> ebml_decoder_decoder_helpers for reader::Decoder<'a> {
         }
     }
 
-    fn read_tys(&mut self, xcx: @ExtendedDecodeContext) -> ~[ty::t] {
+    fn read_tys(&mut self, xcx: @ExtendedDecodeContext) -> Vec<ty::t> {
         self.read_to_vec(|this| this.read_ty(xcx) )
     }
 
@@ -1510,14 +1510,14 @@ fn test_simplification() {
     let item = quote_item!(cx,
         fn new_int_alist<B>() -> alist<int, B> {
             fn eq_int(a: int, b: int) -> bool { a == b }
-            return alist {eq_fn: eq_int, data: ~[]};
+            return alist {eq_fn: eq_int, data: Vec::new()};
         }
     ).unwrap();
     let item_in = e::IIItemRef(item);
     let item_out = simplify_ast(item_in);
     let item_exp = ast::IIItem(quote_item!(cx,
         fn new_int_alist<B>() -> alist<int, B> {
-            return alist {eq_fn: eq_int, data: ~[]};
+            return alist {eq_fn: eq_int, data: Vec::new()};
         }
     ).unwrap());
     match (item_out, item_exp) {

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -143,11 +143,11 @@ impl<'a> CheckLoanCtxt<'a> {
         })
     }
 
-    pub fn loans_generated_by(&self, scope_id: ast::NodeId) -> ~[uint] {
+    pub fn loans_generated_by(&self, scope_id: ast::NodeId) -> Vec<uint> {
         //! Returns a vector of the loans that are generated as
         //! we encounter `scope_id`.
 
-        let mut result = ~[];
+        let mut result = Vec::new();
         self.dfcx_loans.each_gen_bit_frozen(scope_id, |loan_index| {
             result.push(loan_index);
             true

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -22,6 +22,7 @@ use mc = middle::mem_categorization;
 use middle::borrowck::*;
 use middle::moves;
 use middle::ty;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::codemap::Span;

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -70,10 +70,9 @@ struct GatherLoanCtxt<'a> {
     bccx: &'a BorrowckCtxt,
     id_range: IdRange,
     move_data: move_data::MoveData,
-    all_loans: @RefCell<~[Loan]>,
+    all_loans: @RefCell<Vec<Loan> >,
     item_ub: ast::NodeId,
-    repeating_ids: ~[ast::NodeId]
-}
+    repeating_ids: Vec<ast::NodeId> }
 
 impl<'a> visit::Visitor<()> for GatherLoanCtxt<'a> {
     fn visit_expr(&mut self, ex: &Expr, _: ()) {
@@ -103,13 +102,13 @@ impl<'a> visit::Visitor<()> for GatherLoanCtxt<'a> {
 }
 
 pub fn gather_loans(bccx: &BorrowckCtxt, decl: &ast::FnDecl, body: &ast::Block)
-                    -> (IdRange, @RefCell<~[Loan]>, move_data::MoveData) {
+                    -> (IdRange, @RefCell<Vec<Loan> >, move_data::MoveData) {
     let mut glcx = GatherLoanCtxt {
         bccx: bccx,
         id_range: IdRange::max(),
-        all_loans: @RefCell::new(~[]),
+        all_loans: @RefCell::new(Vec::new()),
         item_ub: body.id,
-        repeating_ids: ~[body.id],
+        repeating_ids: vec!(body.id),
         move_data: MoveData::new()
     };
     glcx.gather_fn_arg_patterns(decl, body);

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -27,6 +27,7 @@ use util::common::indenter;
 use util::ppaux::{Repr};
 
 use std::cell::RefCell;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::ast_util::IdRange;

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -12,7 +12,8 @@
  * Computes the restrictions that result from a borrow.
  */
 
-use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use middle::borrowck::*;
 use mc = middle::mem_categorization;
 use middle::ty;
@@ -173,9 +174,11 @@ impl<'a> RestrictionsContext<'a> {
             Safe => Safe,
             SafeIf(base_lp, base_vec) => {
                 let lp = @LpExtend(base_lp, mc, elem);
-                SafeIf(lp, vec::append_one(base_vec,
-                                           Restriction {loan_path: lp,
-                                                        set: restrictions}))
+                SafeIf(lp, vec_ng::append_one(base_vec,
+                                              Restriction {
+                                                  loan_path: lp,
+                                                  set: restrictions
+                                              }))
             }
         }
     }

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -21,7 +21,7 @@ use util::ppaux::Repr;
 
 pub enum RestrictionResult {
     Safe,
-    SafeIf(@LoanPath, ~[Restriction])
+    SafeIf(@LoanPath, Vec<Restriction> )
 }
 
 pub fn compute_restrictions(bccx: &BorrowckCtxt,
@@ -75,8 +75,8 @@ impl<'a> RestrictionsContext<'a> {
             mc::cat_upvar(ty::UpvarId {var_id: local_id, ..}, _) => {
                 // R-Variable
                 let lp = @LpVar(local_id);
-                SafeIf(lp, ~[Restriction {loan_path: lp,
-                                          set: restrictions}])
+                SafeIf(lp, vec!(Restriction {loan_path: lp,
+                                          set: restrictions}))
             }
 
             mc::cat_downcast(cmt_base) => {

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -24,6 +24,7 @@ use std::cell::{Cell, RefCell};
 use collections::HashMap;
 use std::ops::{BitOr, BitAnd};
 use std::result::{Result};
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util;
@@ -146,7 +147,7 @@ fn borrowck_fn(this: &mut BorrowckCtxt,
                                                       body);
 
     check_loans::check_loans(this, &loan_dfcx, flowed_moves,
-                             *all_loans.get(), body);
+                             all_loans.get().as_slice(), body);
 
     visit::walk_fn(this, fk, decl, body, sp, id, ());
 }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -209,7 +209,7 @@ pub struct Loan {
     loan_path: @LoanPath,
     cmt: mc::cmt,
     kind: ty::BorrowKind,
-    restrictions: ~[Restriction],
+    restrictions: Vec<Restriction> ,
     gen_scope: ast::NodeId,
     kill_scope: ast::NodeId,
     span: Span,

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -17,6 +17,7 @@ comments in the section "Moves and initialization" and in `doc.rs`.
 
 use std::cell::RefCell;
 use std::uint;
+use std::vec_ng::Vec;
 use collections::{HashMap, HashSet};
 use middle::borrowck::*;
 use middle::dataflow::DataFlowContext;
@@ -184,47 +185,47 @@ impl MoveData {
 
     fn path_loan_path(&self, index: MovePathIndex) -> @LoanPath {
         let paths = self.paths.borrow();
-        paths.get()[index.get()].loan_path
+        paths.get().get(index.get()).loan_path
     }
 
     fn path_parent(&self, index: MovePathIndex) -> MovePathIndex {
         let paths = self.paths.borrow();
-        paths.get()[index.get()].parent
+        paths.get().get(index.get()).parent
     }
 
     fn path_first_move(&self, index: MovePathIndex) -> MoveIndex {
         let paths = self.paths.borrow();
-        paths.get()[index.get()].first_move
+        paths.get().get(index.get()).first_move
     }
 
     fn path_first_child(&self, index: MovePathIndex) -> MovePathIndex {
         let paths = self.paths.borrow();
-        paths.get()[index.get()].first_child
+        paths.get().get(index.get()).first_child
     }
 
     fn path_next_sibling(&self, index: MovePathIndex) -> MovePathIndex {
         let paths = self.paths.borrow();
-        paths.get()[index.get()].next_sibling
+        paths.get().get(index.get()).next_sibling
     }
 
     fn set_path_first_move(&self,
                            index: MovePathIndex,
                            first_move: MoveIndex) {
         let mut paths = self.paths.borrow_mut();
-        paths.get()[index.get()].first_move = first_move
+        paths.get().get_mut(index.get()).first_move = first_move
     }
 
     fn set_path_first_child(&self,
                             index: MovePathIndex,
                             first_child: MovePathIndex) {
         let mut paths = self.paths.borrow_mut();
-        paths.get()[index.get()].first_child = first_child
+        paths.get().get_mut(index.get()).first_child = first_child
     }
 
     fn move_next_move(&self, index: MoveIndex) -> MoveIndex {
         //! Type safe indexing operator
         let moves = self.moves.borrow();
-        moves.get()[index.get()].next_move
+        moves.get().get(index.get()).next_move
     }
 
     fn is_var_path(&self, index: MovePathIndex) -> bool {
@@ -605,7 +606,7 @@ impl FlowedMoveData {
 
         self.dfcx_moves.each_gen_bit_frozen(id, |index| {
             let moves = self.move_data.moves.borrow();
-            let move = &moves.get()[index];
+            let move = moves.get().get(index);
             let moved_path = move.path;
             f(move, self.move_data.path_loan_path(moved_path))
         })
@@ -644,7 +645,7 @@ impl FlowedMoveData {
 
         self.dfcx_moves.each_bit_on_entry_frozen(id, |index| {
             let moves = self.move_data.moves.borrow();
-            let move = &moves.get()[index];
+            let move = moves.get().get(index);
             let moved_path = move.path;
             if base_indices.iter().any(|x| x == &moved_path) {
                 // Scenario 1 or 2: `loan_path` or some base path of
@@ -702,7 +703,7 @@ impl FlowedMoveData {
 
         self.dfcx_assign.each_bit_on_entry_frozen(id, |index| {
             let var_assignments = self.move_data.var_assignments.borrow();
-            let assignment = &var_assignments.get()[index];
+            let assignment = var_assignments.get().get(index);
             if assignment.path == loan_path_index && !f(assignment) {
                 false
             } else {

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -32,23 +32,23 @@ use util::ppaux::Repr;
 
 pub struct MoveData {
     /// Move paths. See section "Move paths" in `doc.rs`.
-    paths: RefCell<~[MovePath]>,
+    paths: RefCell<Vec<MovePath> >,
 
     /// Cache of loan path to move path index, for easy lookup.
     path_map: RefCell<HashMap<@LoanPath, MovePathIndex>>,
 
     /// Each move or uninitialized variable gets an entry here.
-    moves: RefCell<~[Move]>,
+    moves: RefCell<Vec<Move> >,
 
     /// Assignments to a variable, like `x = foo`. These are assigned
     /// bits for dataflow, since we must track them to ensure that
     /// immutable variables are assigned at most once along each path.
-    var_assignments: RefCell<~[Assignment]>,
+    var_assignments: RefCell<Vec<Assignment> >,
 
     /// Assignments to a path, like `x.f = foo`. These are not
     /// assigned dataflow bits, but we track them because they still
     /// kill move bits.
-    path_assignments: RefCell<~[Assignment]>,
+    path_assignments: RefCell<Vec<Assignment> >,
     assignee_ids: RefCell<HashSet<ast::NodeId>>,
 }
 
@@ -173,11 +173,11 @@ pub type AssignDataFlow = DataFlowContext<AssignDataFlowOperator>;
 impl MoveData {
     pub fn new() -> MoveData {
         MoveData {
-            paths: RefCell::new(~[]),
+            paths: RefCell::new(Vec::new()),
             path_map: RefCell::new(HashMap::new()),
-            moves: RefCell::new(~[]),
-            path_assignments: RefCell::new(~[]),
-            var_assignments: RefCell::new(~[]),
+            moves: RefCell::new(Vec::new()),
+            path_assignments: RefCell::new(Vec::new()),
+            var_assignments: RefCell::new(Vec::new()),
             assignee_ids: RefCell::new(HashSet::new()),
         }
     }

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -22,7 +22,7 @@ struct CFGBuilder {
     method_map: typeck::MethodMap,
     exit_map: NodeMap<CFGIndex>,
     graph: CFGGraph,
-    loop_scopes: ~[LoopScope],
+    loop_scopes: Vec<LoopScope> ,
 }
 
 struct LoopScope {
@@ -39,7 +39,7 @@ pub fn construct(tcx: ty::ctxt,
         graph: graph::Graph::new(),
         tcx: tcx,
         method_map: method_map,
-        loop_scopes: ~[]
+        loop_scopes: Vec::new()
     };
     let entry = cfg_builder.add_node(0, []);
     let exit = cfg_builder.block(blk, entry);
@@ -375,7 +375,7 @@ impl CFGBuilder {
 
             ast::ExprStruct(_, ref fields, base) => {
                 let base_exit = self.opt_expr(base, pred);
-                let field_exprs: ~[@ast::Expr] =
+                let field_exprs: Vec<@ast::Expr> =
                     fields.iter().map(|f| f.expr).collect();
                 self.straightline(expr, base_exit, field_exprs)
             }

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -12,6 +12,7 @@ use middle::cfg::*;
 use middle::graph;
 use middle::typeck;
 use middle::ty;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::opt_vec;
@@ -328,7 +329,7 @@ impl CFGBuilder {
 
             ast::ExprRet(v) => {
                 let v_exit = self.opt_expr(v, pred);
-                let loop_scope = self.loop_scopes[0];
+                let loop_scope = *self.loop_scopes.get(0);
                 self.add_exiting_edge(expr, v_exit,
                                       loop_scope, loop_scope.break_index);
                 self.add_node(expr.id, [])
@@ -377,7 +378,7 @@ impl CFGBuilder {
                 let base_exit = self.opt_expr(base, pred);
                 let field_exprs: Vec<@ast::Expr> =
                     fields.iter().map(|f| f.expr).collect();
-                self.straightline(expr, base_exit, field_exprs)
+                self.straightline(expr, base_exit, field_exprs.as_slice())
             }
 
             ast::ExprRepeat(elem, count, _) => {

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -207,8 +207,7 @@ struct CheckItemRecursionVisitor<'a> {
     sess: Session,
     ast_map: &'a ast_map::Map,
     def_map: resolve::DefMap,
-    idstack: ~[NodeId]
-}
+    idstack: Vec<NodeId> }
 
 // Make sure a const item doesn't recursively refer to itself
 // FIXME: Should use the dependency graph when it's available (#1356)
@@ -222,7 +221,7 @@ pub fn check_item_recursion<'a>(sess: Session,
         sess: sess,
         ast_map: ast_map,
         def_map: def_map,
-        idstack: ~[]
+        idstack: Vec::new()
     };
     visitor.visit_item(it, ());
 }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -15,6 +15,7 @@ use middle::ty;
 use middle::typeck;
 use util::ppaux;
 
+use std::vec_ng::Vec;
 use syntax::ast::*;
 use syntax::{ast_util, ast_map};
 use syntax::visit::Visitor;

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -21,7 +21,8 @@ use util::ppaux::ty_to_str;
 
 use std::cmp;
 use std::iter;
-use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::ast::*;
 use syntax::ast_util::{unguarded_pat, walk_pat};
 use syntax::codemap::{DUMMY_SP, Span};
@@ -152,7 +153,7 @@ fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
             });
 
             let v = vec!(*pat);
-            match is_useful(cx, &seen, v) {
+            match is_useful(cx, &seen, v.as_slice()) {
               not_useful => {
                 cx.tcx.sess.span_err(pat.span, "unreachable pattern");
               }
@@ -250,10 +251,14 @@ enum ctor {
 // Note: is_useful doesn't work on empty types, as the paper notes.
 // So it assumes that v is non-empty.
 fn is_useful(cx: &MatchCheckCtxt, m: &matrix, v: &[@Pat]) -> useful {
-    if m.len() == 0u { return useful_; }
-    if m[0].len() == 0u { return not_useful; }
-    let real_pat = match m.iter().find(|r| r[0].id != 0) {
-      Some(r) => r[0], None => v[0]
+    if m.len() == 0u {
+        return useful_;
+    }
+    if m.get(0).len() == 0u {
+        return not_useful
+    }
+    let real_pat = match m.iter().find(|r| r.get(0).id != 0) {
+      Some(r) => *r.get(0), None => v[0]
     };
     let left_ty = if real_pat.id == 0 { ty::mk_nil() }
                   else { ty::node_id_to_type(cx.tcx, real_pat.id) };
@@ -290,7 +295,7 @@ fn is_useful(cx: &MatchCheckCtxt, m: &matrix, v: &[@Pat]) -> useful {
               }
               ty::ty_unboxed_vec(..) | ty::ty_vec(..) => {
                 let max_len = m.rev_iter().fold(0, |max_len, r| {
-                  match r[0].node {
+                  match r.get(0).node {
                     PatVec(ref before, _, ref after) => {
                       cmp::max(before.len() + after.len(), max_len)
                     }
@@ -313,7 +318,9 @@ fn is_useful(cx: &MatchCheckCtxt, m: &matrix, v: &[@Pat]) -> useful {
           }
           Some(ref ctor) => {
             match is_useful(cx,
-                            &m.iter().filter_map(|r| default(cx, *r)).collect::<matrix>(),
+                            &m.iter().filter_map(|r| {
+                                default(cx, r.as_slice())
+                            }).collect::<matrix>(),
                             v.tail()) {
               useful_ => useful(left_ty, (*ctor).clone()),
               ref u => (*u).clone(),
@@ -334,10 +341,12 @@ fn is_useful_specialized(cx: &MatchCheckCtxt,
                              ctor: ctor,
                              arity: uint,
                              lty: ty::t)
-                          -> useful {
-    let ms = m.iter().filter_map(|r| specialize(cx, *r, &ctor, arity, lty)).collect::<matrix>();
+                             -> useful {
+    let ms = m.iter().filter_map(|r| {
+        specialize(cx, r.as_slice(), &ctor, arity, lty)
+    }).collect::<matrix>();
     let could_be_useful = is_useful(
-        cx, &ms, specialize(cx, v, &ctor, arity, lty).unwrap());
+        cx, &ms, specialize(cx, v, &ctor, arity, lty).unwrap().as_slice());
     match could_be_useful {
       useful_ => useful(lty, ctor),
       ref u => (*u).clone(),
@@ -408,14 +417,14 @@ fn missing_ctor(cx: &MatchCheckCtxt,
       ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_rptr(..) | ty::ty_tup(_) |
       ty::ty_struct(..) => {
         for r in m.iter() {
-            if !is_wild(cx, r[0]) { return None; }
+            if !is_wild(cx, *r.get(0)) { return None; }
         }
         return Some(single);
       }
       ty::ty_enum(eid, _) => {
         let mut found = Vec::new();
         for r in m.iter() {
-            let r = pat_ctor_id(cx, r[0]);
+            let r = pat_ctor_id(cx, *r.get(0));
             for id in r.iter() {
                 if !found.contains(id) {
                     found.push((*id).clone());
@@ -437,7 +446,7 @@ fn missing_ctor(cx: &MatchCheckCtxt,
         let mut true_found = false;
         let mut false_found = false;
         for r in m.iter() {
-            match pat_ctor_id(cx, r[0]) {
+            match pat_ctor_id(cx, *r.get(0)) {
               None => (),
               Some(val(const_bool(true))) => true_found = true,
               Some(val(const_bool(false))) => false_found = true,
@@ -452,7 +461,7 @@ fn missing_ctor(cx: &MatchCheckCtxt,
         let mut missing = true;
         let mut wrong = false;
         for r in m.iter() {
-          match r[0].node {
+          match r.get(0).node {
             PatVec(ref before, ref slice, ref after) => {
               let count = before.len() + after.len();
               if (count < n && slice.is_none()) || count > n {
@@ -475,7 +484,7 @@ fn missing_ctor(cx: &MatchCheckCtxt,
 
         // Find the lengths and slices of all vector patterns.
         let mut vec_pat_lens = m.iter().filter_map(|r| {
-            match r[0].node {
+            match r.get(0).node {
                 PatVec(ref before, ref slice, ref after) => {
                     Some((before.len() + after.len(), slice.is_some()))
                 }
@@ -566,10 +575,11 @@ fn specialize(cx: &MatchCheckCtxt,
         Pat{id: pat_id, node: n, span: pat_span} =>
             match n {
             PatWild => {
-                Some(vec_ng::append(vec::from_elem(arity, wild()), r.tail()))
+                Some(vec_ng::append(Vec::from_elem(arity, wild()), r.tail()))
             }
             PatWildMulti => {
-                Some(vec_ng::append(vec::from_elem(arity, wild_multi()), r.tail()))
+                Some(vec_ng::append(Vec::from_elem(arity, wild_multi()),
+                                    r.tail()))
             }
             PatIdent(_, _, _) => {
                 let opt_def = {
@@ -579,7 +589,7 @@ fn specialize(cx: &MatchCheckCtxt,
                 match opt_def {
                     Some(DefVariant(_, id, _)) => {
                         if variant(id) == *ctor_id {
-                            Some(r.tail().to_owned())
+                            Some(Vec::from_slice(r.tail()))
                         } else {
                             None
                         }
@@ -617,7 +627,7 @@ fn specialize(cx: &MatchCheckCtxt,
                             _ => fail!("type error")
                         };
                         if match_ {
-                            Some(r.tail().to_owned())
+                            Some(Vec::from_slice(r.tail()))
                         } else {
                             None
                         }
@@ -625,7 +635,7 @@ fn specialize(cx: &MatchCheckCtxt,
                     _ => {
                         Some(
                             vec_ng::append(
-                                vec::from_elem(arity, wild()),
+                                Vec::from_elem(arity, wild()),
                                 r.tail()
                             )
                         )
@@ -668,7 +678,7 @@ fn specialize(cx: &MatchCheckCtxt,
                             _ => fail!("type error")
                         };
                         if match_ {
-                            Some(r.tail().to_owned())
+                            Some(Vec::from_slice(r.tail()))
                         } else {
                             None
                         }
@@ -676,7 +686,7 @@ fn specialize(cx: &MatchCheckCtxt,
                     DefVariant(_, id, _) if variant(id) == *ctor_id => {
                         let args = match args {
                             Some(args) => args.iter().map(|x| *x).collect(),
-                            None => vec::from_elem(arity, wild())
+                            None => Vec::from_elem(arity, wild())
                         };
                         Some(vec_ng::append(args, r.tail()))
                     }
@@ -689,7 +699,7 @@ fn specialize(cx: &MatchCheckCtxt,
                             Some(args) => {
                                 new_args = args.iter().map(|x| *x).collect()
                             }
-                            None => new_args = vec::from_elem(arity, wild())
+                            None => new_args = Vec::from_elem(arity, wild())
                         }
                         Some(vec_ng::append(new_args, r.tail()))
                     }
@@ -781,13 +791,17 @@ fn specialize(cx: &MatchCheckCtxt,
                     single => true,
                     _ => fail!("type error")
                 };
-                if match_ { Some(r.tail().to_owned()) } else { None }
+                if match_ {
+                    Some(Vec::from_slice(r.tail()))
+                } else {
+                    None
+                }
             }
             PatRange(lo, hi) => {
                 let (c_lo, c_hi) = match *ctor_id {
                     val(ref v) => ((*v).clone(), (*v).clone()),
                     range(ref lo, ref hi) => ((*lo).clone(), (*hi).clone()),
-                    single => return Some(r.tail().to_owned()),
+                    single => return Some(Vec::from_slice(r.tail())),
                     _ => fail!("type error")
                 };
                 let v_lo = eval_const_expr(cx.tcx, lo);
@@ -797,7 +811,7 @@ fn specialize(cx: &MatchCheckCtxt,
                 let m2 = compare_const_vals(&c_hi, &v_hi);
                 match (m1, m2) {
                     (Some(val1), Some(val2)) if val1 >= 0 && val2 <= 0 => {
-                        Some(r.tail().to_owned())
+                        Some(Vec::from_slice(r.tail()))
                     },
                     (Some(_), Some(_)) => None,
                     _ => {
@@ -850,8 +864,11 @@ fn specialize(cx: &MatchCheckCtxt,
 }
 
 fn default(cx: &MatchCheckCtxt, r: &[@Pat]) -> Option<Vec<@Pat> > {
-    if is_wild(cx, r[0]) { Some(r.tail().to_owned()) }
-    else { None }
+    if is_wild(cx, r[0]) {
+        Some(Vec::from_slice(r.tail()))
+    } else {
+        None
+    }
 }
 
 fn check_local(v: &mut CheckMatchVisitor,

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -27,6 +27,7 @@ use syntax::{ast, ast_map, ast_util};
 use std::cell::RefCell;
 use collections::HashMap;
 use std::rc::Rc;
+use std::vec_ng::Vec;
 
 //
 // This pass classifies expressions by their constant-ness.

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -321,7 +321,7 @@ pub enum const_val {
     const_int(i64),
     const_uint(u64),
     const_str(InternedString),
-    const_binary(Rc<~[u8]>),
+    const_binary(Rc<Vec<u8> >),
     const_bool(bool)
 }
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -19,6 +19,7 @@ use middle::typeck;
 use util::nodemap::NodeSet;
 
 use collections::HashSet;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::{local_def, def_id_of_def, is_local};

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -49,7 +49,7 @@ fn should_explore(tcx: ty::ctxt, def_id: ast::DefId) -> bool {
 }
 
 struct MarkSymbolVisitor {
-    worklist: ~[ast::NodeId],
+    worklist: Vec<ast::NodeId> ,
     method_map: typeck::MethodMap,
     tcx: ty::ctxt,
     live_symbols: ~HashSet<ast::NodeId>,
@@ -58,7 +58,7 @@ struct MarkSymbolVisitor {
 impl MarkSymbolVisitor {
     fn new(tcx: ty::ctxt,
            method_map: typeck::MethodMap,
-           worklist: ~[ast::NodeId]) -> MarkSymbolVisitor {
+           worklist: Vec<ast::NodeId> ) -> MarkSymbolVisitor {
         MarkSymbolVisitor {
             worklist: worklist,
             method_map: method_map,
@@ -216,7 +216,7 @@ fn has_allow_dead_code_or_lang_attr(attrs: &[ast::Attribute]) -> bool {
 //   2) We are not sure to be live or not
 //     * Implementation of a trait method
 struct LifeSeeder {
-    worklist: ~[ast::NodeId],
+    worklist: Vec<ast::NodeId> ,
 }
 
 impl Visitor<()> for LifeSeeder {
@@ -254,8 +254,8 @@ impl Visitor<()> for LifeSeeder {
 fn create_and_seed_worklist(tcx: ty::ctxt,
                             exported_items: &privacy::ExportedItems,
                             reachable_symbols: &NodeSet,
-                            krate: &ast::Crate) -> ~[ast::NodeId] {
-    let mut worklist = ~[];
+                            krate: &ast::Crate) -> Vec<ast::NodeId> {
+    let mut worklist = Vec::new();
 
     // Preferably, we would only need to seed the worklist with reachable
     // symbols. However, since the set of reachable symbols differs

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -11,6 +11,7 @@
 
 use driver::session;
 use driver::session::Session;
+use std::vec_ng::Vec;
 use syntax::ast::{Crate, Name, NodeId, Item, ItemFn};
 use syntax::ast_map;
 use syntax::attr;

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -38,7 +38,7 @@ struct EntryContext<'a> {
 
     // The functions that one might think are 'main' but aren't, e.g.
     // main functions not defined at the top level. For diagnostics.
-    non_main_fns: ~[(NodeId, Span)],
+    non_main_fns: Vec<(NodeId, Span)> ,
 }
 
 impl<'a> Visitor<()> for EntryContext<'a> {
@@ -66,7 +66,7 @@ pub fn find_entry_point(session: Session, krate: &Crate, ast_map: &ast_map::Map)
         main_fn: None,
         attr_main_fn: None,
         start_fn: None,
-        non_main_fns: ~[],
+        non_main_fns: Vec::new(),
     };
 
     visit::walk_crate(&mut ctxt, krate, ());

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -29,12 +29,12 @@ pub struct freevar_entry {
     def: ast::Def, //< The variable being accessed free.
     span: Span     //< First span where it is accessed (there can be multiple)
 }
-pub type freevar_info = @~[@freevar_entry];
+pub type freevar_info = @Vec<@freevar_entry> ;
 pub type freevar_map = NodeMap<freevar_info>;
 
 struct CollectFreevarsVisitor {
     seen: NodeSet,
-    refs: ~[@freevar_entry],
+    refs: Vec<@freevar_entry> ,
     def_map: resolve::DefMap,
 }
 
@@ -90,7 +90,7 @@ impl Visitor<int> for CollectFreevarsVisitor {
 // in order to start the search.
 fn collect_freevars(def_map: resolve::DefMap, blk: &ast::Block) -> freevar_info {
     let seen = NodeSet::new();
-    let refs = ~[];
+    let refs = Vec::new();
 
     let mut v = CollectFreevarsVisitor {
         seen: seen,

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -17,6 +17,7 @@ use middle::resolve;
 use middle::ty;
 use util::nodemap::{NodeMap, NodeSet};
 
+use std::vec_ng::Vec;
 use syntax::codemap::Span;
 use syntax::{ast, ast_util};
 use syntax::visit;

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -35,7 +35,7 @@ be indexed by the direction (see the type `Direction`).
 */
 
 use std::uint;
-use std::vec;
+use std::vec_ng::Vec;
 
 pub struct Graph<N,E> {
     priv nodes: Vec<Node<N>> ,
@@ -77,13 +77,18 @@ impl EdgeIndex {
 
 impl<N,E> Graph<N,E> {
     pub fn new() -> Graph<N,E> {
-        Graph {nodes: Vec::new(), edges: Vec::new()}
+        Graph {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
     }
 
     pub fn with_capacity(num_nodes: uint,
                          num_edges: uint) -> Graph<N,E> {
-        Graph {nodes: vec::with_capacity(num_nodes),
-               edges: vec::with_capacity(num_edges)}
+        Graph {
+            nodes: Vec::with_capacity(num_nodes),
+            edges: Vec::with_capacity(num_edges),
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -91,13 +96,13 @@ impl<N,E> Graph<N,E> {
 
     #[inline]
     pub fn all_nodes<'a>(&'a self) -> &'a [Node<N>] {
-        let nodes: &'a [Node<N>] = self.nodes;
+        let nodes: &'a [Node<N>] = self.nodes.as_slice();
         nodes
     }
 
     #[inline]
     pub fn all_edges<'a>(&'a self) -> &'a [Edge<E>] {
-        let edges: &'a [Edge<E>] = self.edges;
+        let edges: &'a [Edge<E>] = self.edges.as_slice();
         edges
     }
 
@@ -118,15 +123,15 @@ impl<N,E> Graph<N,E> {
     }
 
     pub fn mut_node_data<'a>(&'a mut self, idx: NodeIndex) -> &'a mut N {
-        &mut self.nodes[idx.get()].data
+        &mut self.nodes.get_mut(idx.get()).data
     }
 
     pub fn node_data<'a>(&'a self, idx: NodeIndex) -> &'a N {
-        &self.nodes[idx.get()].data
+        &self.nodes.get(idx.get()).data
     }
 
     pub fn node<'a>(&'a self, idx: NodeIndex) -> &'a Node<N> {
-        &self.nodes[idx.get()]
+        self.nodes.get(idx.get())
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -143,8 +148,10 @@ impl<N,E> Graph<N,E> {
         let idx = self.next_edge_index();
 
         // read current first of the list of edges from each node
-        let source_first = self.nodes[source.get()].first_edge[Outgoing.repr];
-        let target_first = self.nodes[target.get()].first_edge[Incoming.repr];
+        let source_first = self.nodes.get(source.get())
+                                     .first_edge[Outgoing.repr];
+        let target_first = self.nodes.get(target.get())
+                                     .first_edge[Incoming.repr];
 
         // create the new edge, with the previous firsts from each node
         // as the next pointers
@@ -156,22 +163,22 @@ impl<N,E> Graph<N,E> {
         });
 
         // adjust the firsts for each node target be the next object.
-        self.nodes[source.get()].first_edge[Outgoing.repr] = idx;
-        self.nodes[target.get()].first_edge[Incoming.repr] = idx;
+        self.nodes.get_mut(source.get()).first_edge[Outgoing.repr] = idx;
+        self.nodes.get_mut(target.get()).first_edge[Incoming.repr] = idx;
 
         return idx;
     }
 
     pub fn mut_edge_data<'a>(&'a mut self, idx: EdgeIndex) -> &'a mut E {
-        &mut self.edges[idx.get()].data
+        &mut self.edges.get_mut(idx.get()).data
     }
 
     pub fn edge_data<'a>(&'a self, idx: EdgeIndex) -> &'a E {
-        &self.edges[idx.get()].data
+        &self.edges.get(idx.get()).data
     }
 
     pub fn edge<'a>(&'a self, idx: EdgeIndex) -> &'a Edge<E> {
-        &self.edges[idx.get()]
+        self.edges.get(idx.get())
     }
 
     pub fn first_adjacent(&self, node: NodeIndex, dir: Direction) -> EdgeIndex {
@@ -179,7 +186,7 @@ impl<N,E> Graph<N,E> {
         //! This is useful if you wish to modify the graph while walking
         //! the linked list of edges.
 
-        self.nodes[node.get()].first_edge[dir.repr]
+        self.nodes.get(node.get()).first_edge[dir.repr]
     }
 
     pub fn next_adjacent(&self, edge: EdgeIndex, dir: Direction) -> EdgeIndex {
@@ -187,7 +194,7 @@ impl<N,E> Graph<N,E> {
         //! This is useful if you wish to modify the graph while walking
         //! the linked list of edges.
 
-        self.edges[edge.get()].next_edge[dir.repr]
+        self.edges.get(edge.get()).next_edge[dir.repr]
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -231,7 +238,7 @@ impl<N,E> Graph<N,E> {
 
         let mut edge_idx = self.first_adjacent(node, dir);
         while edge_idx != InvalidEdgeIndex {
-            let edge = &self.edges[edge_idx.get()];
+            let edge = self.edges.get(edge_idx.get());
             if !f(edge_idx, edge) {
                 return false;
             }

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -38,8 +38,8 @@ use std::uint;
 use std::vec;
 
 pub struct Graph<N,E> {
-    priv nodes: ~[Node<N>],
-    priv edges: ~[Edge<E>],
+    priv nodes: Vec<Node<N>> ,
+    priv edges: Vec<Edge<E>> ,
 }
 
 pub struct Node<N> {
@@ -77,7 +77,7 @@ impl EdgeIndex {
 
 impl<N,E> Graph<N,E> {
     pub fn new() -> Graph<N,E> {
-        Graph {nodes: ~[], edges: ~[]}
+        Graph {nodes: Vec::new(), edges: Vec::new()}
     }
 
     pub fn with_capacity(num_nodes: uint,

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -16,6 +16,7 @@ use middle::typeck;
 use util::ppaux::{Repr, ty_to_str};
 use util::ppaux::UserString;
 
+use std::vec_ng::Vec;
 use syntax::ast::*;
 use syntax::attr;
 use syntax::codemap::Span;

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -94,7 +94,7 @@ fn check_struct_safe_for_destructor(cx: &mut Context,
         let struct_ty = ty::mk_struct(cx.tcx, struct_did, ty::substs {
             regions: ty::NonerasedRegions(opt_vec::Empty),
             self_ty: None,
-            tps: ~[]
+            tps: Vec::new()
         });
         if !ty::type_is_sendable(cx.tcx, struct_ty) {
             cx.tcx.sess.span_err(span,
@@ -533,7 +533,7 @@ pub fn check_cast_for_escaping_regions(
     // Collect up the regions that appear in the target type.  We want to
     // ensure that these lifetimes are shorter than all lifetimes that are in
     // the source type.  See test `src/test/compile-fail/regions-trait-2.rs`
-    let mut target_regions = ~[];
+    let mut target_regions = Vec::new();
     ty::walk_regions_and_ty(
         cx.tcx,
         target_ty,

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -33,6 +33,7 @@ use syntax::visit;
 use collections::HashMap;
 use std::iter::Enumerate;
 use std::vec;
+use std::vec_ng::Vec;
 
 // The actual lang items defined come at the end of this file in one handy table.
 // So you probably just want to nip down to the end.
@@ -72,10 +73,12 @@ impl LanguageItems {
     }
 
     pub fn require(&self, it: LangItem) -> Result<ast::DefId, ~str> {
-        match self.items[it as uint] {
-            Some(id) => Ok(id),
-            None => Err(format!("requires `{}` lang_item",
-                             LanguageItems::item_name(it as uint)))
+        match self.items.get(it as uint) {
+            &Some(id) => Ok(id),
+            &None => {
+                Err(format!("requires `{}` lang_item",
+                            LanguageItems::item_name(it as uint)))
+            }
         }
     }
 
@@ -95,7 +98,7 @@ impl LanguageItems {
 
     $(
         pub fn $method(&self) -> Option<ast::DefId> {
-            self.items[$variant as uint]
+            *self.items.get($variant as uint)
         }
     )*
 }
@@ -147,18 +150,18 @@ impl LanguageItemCollector {
 
     pub fn collect_item(&mut self, item_index: uint, item_def_id: ast::DefId) {
         // Check for duplicates.
-        match self.items.items[item_index] {
-            Some(original_def_id) if original_def_id != item_def_id => {
+        match self.items.items.get(item_index) {
+            &Some(original_def_id) if original_def_id != item_def_id => {
                 self.session.err(format!("duplicate entry for `{}`",
                                       LanguageItems::item_name(item_index)));
             }
-            Some(_) | None => {
+            &Some(_) | &None => {
                 // OK.
             }
         }
 
         // Matched.
-        self.items.items[item_index] = Some(item_def_id);
+        *self.items.items.get_mut(item_index) = Some(item_def_id);
     }
 
     pub fn collect_local_language_items(&mut self, krate: &ast::Crate) {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -47,7 +47,7 @@ pub enum LangItem {
 }
 
 pub struct LanguageItems {
-    items: ~[Option<ast::DefId>],
+    items: Vec<Option<ast::DefId>> ,
 }
 
 impl LanguageItems {
@@ -55,7 +55,7 @@ impl LanguageItems {
         fn foo(_: LangItem) -> Option<ast::DefId> { None }
 
         LanguageItems {
-            items: ~[$(foo($variant)),*]
+            items: vec!($(foo($variant)),*)
         }
     }
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -45,7 +45,6 @@ use middle::ty;
 use middle::typeck::astconv::{ast_ty_to_ty, AstConv};
 use middle::typeck::infer;
 use middle::typeck;
-use std::to_str::ToStr;
 use util::ppaux::{ty_to_str};
 
 use std::cmp;
@@ -54,10 +53,12 @@ use std::i16;
 use std::i32;
 use std::i64;
 use std::i8;
+use std::to_str::ToStr;
 use std::u16;
 use std::u32;
 use std::u64;
 use std::u8;
+use std::vec_ng::Vec;
 use collections::SmallIntMap;
 use syntax::ast_map;
 use syntax::ast_util::IdVisitingOperation;
@@ -1091,7 +1092,7 @@ fn check_unused_result(cx: &Context, s: &ast::Stmt) {
                 }
             } else {
                 csearch::get_item_attrs(cx.tcx.sess.cstore, did, |attrs| {
-                    if attr::contains_name(attrs, "must_use") {
+                    if attr::contains_name(attrs.as_slice(), "must_use") {
                         cx.span_lint(UnusedMustUse, s.span,
                                      "unused result which must be used");
                         warned = true;

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -432,7 +432,7 @@ struct Context<'a> {
     // When recursing into an attributed node of the ast which modifies lint
     // levels, this stack keeps track of the previous lint levels of whatever
     // was modified.
-    lint_stack: ~[(Lint, level, LintSource)],
+    lint_stack: Vec<(Lint, level, LintSource)> ,
 
     // id of the last visited negated expression
     negated_expr_id: ast::NodeId
@@ -1738,7 +1738,7 @@ pub fn check_crate(tcx: ty::ctxt,
         exported_items: exported_items,
         cur_struct_def_id: -1,
         is_doc_hidden: false,
-        lint_stack: ~[],
+        lint_stack: Vec::new(),
         negated_expr_id: -1
     };
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -261,8 +261,8 @@ pub struct IrMaps {
     live_node_map: RefCell<NodeMap<LiveNode>>,
     variable_map: RefCell<NodeMap<Variable>>,
     capture_info_map: RefCell<NodeMap<@~[CaptureInfo]>>,
-    var_kinds: RefCell<~[VarKind]>,
-    lnks: RefCell<~[LiveNodeKind]>,
+    var_kinds: RefCell<Vec<VarKind> >,
+    lnks: RefCell<Vec<LiveNodeKind> >,
 }
 
 fn IrMaps(tcx: ty::ctxt,
@@ -278,8 +278,8 @@ fn IrMaps(tcx: ty::ctxt,
         live_node_map: RefCell::new(NodeMap::new()),
         variable_map: RefCell::new(NodeMap::new()),
         capture_info_map: RefCell::new(NodeMap::new()),
-        var_kinds: RefCell::new(~[]),
-        lnks: RefCell::new(~[]),
+        var_kinds: RefCell::new(Vec::new()),
+        lnks: RefCell::new(Vec::new()),
     }
 }
 
@@ -347,12 +347,12 @@ impl IrMaps {
         }
     }
 
-    pub fn set_captures(&self, node_id: NodeId, cs: ~[CaptureInfo]) {
+    pub fn set_captures(&self, node_id: NodeId, cs: Vec<CaptureInfo> ) {
         let mut capture_info_map = self.capture_info_map.borrow_mut();
         capture_info_map.get().insert(node_id, @cs);
     }
 
-    pub fn captures(&self, expr: &Expr) -> @~[CaptureInfo] {
+    pub fn captures(&self, expr: &Expr) -> @Vec<CaptureInfo> {
         let capture_info_map = self.capture_info_map.borrow();
         match capture_info_map.get().find(&expr.id) {
           Some(&caps) => caps,
@@ -504,7 +504,7 @@ fn visit_expr(v: &mut LivenessVisitor, expr: &Expr, this: @IrMaps) {
         // construction site.
         let capture_map = this.capture_map.borrow();
         let cvs = capture_map.get().get(&expr.id);
-        let mut call_caps = ~[];
+        let mut call_caps = Vec::new();
         for cv in cvs.borrow().iter() {
             match moves::moved_variable_node_id_from_def(cv.def) {
               Some(rv) => {
@@ -590,11 +590,11 @@ pub struct Liveness {
     tcx: ty::ctxt,
     ir: @IrMaps,
     s: Specials,
-    successors: @RefCell<~[LiveNode]>,
-    users: @RefCell<~[Users]>,
+    successors: @RefCell<Vec<LiveNode> >,
+    users: @RefCell<Vec<Users> >,
     // The list of node IDs for the nested loop scopes
     // we're in.
-    loop_scope: @RefCell<~[NodeId]>,
+    loop_scope: @RefCell<Vec<NodeId> >,
     // mappings from loop node ID to LiveNode
     // ("break" label should map to loop node ID,
     // it probably doesn't now)
@@ -612,7 +612,7 @@ fn Liveness(ir: @IrMaps, specials: Specials) -> Liveness {
         users: @RefCell::new(vec::from_elem(ir.num_live_nodes.get() *
                                             ir.num_vars.get(),
                                             invalid_users())),
-        loop_scope: @RefCell::new(~[]),
+        loop_scope: @RefCell::new(Vec::new()),
         break_ln: @RefCell::new(NodeMap::new()),
         cont_ln: @RefCell::new(NodeMap::new()),
     }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -116,7 +116,7 @@ use std::fmt;
 use std::io;
 use std::str;
 use std::uint;
-use std::vec;
+use std::vec_ng::Vec;
 use syntax::ast::*;
 use syntax::codemap::Span;
 use syntax::parse::token::special_idents;
@@ -260,7 +260,7 @@ pub struct IrMaps {
     num_vars: Cell<uint>,
     live_node_map: RefCell<NodeMap<LiveNode>>,
     variable_map: RefCell<NodeMap<Variable>>,
-    capture_info_map: RefCell<NodeMap<@~[CaptureInfo]>>,
+    capture_info_map: RefCell<NodeMap<@Vec<CaptureInfo> >>,
     var_kinds: RefCell<Vec<VarKind> >,
     lnks: RefCell<Vec<LiveNodeKind> >,
 }
@@ -339,11 +339,11 @@ impl IrMaps {
 
     pub fn variable_name(&self, var: Variable) -> ~str {
         let var_kinds = self.var_kinds.borrow();
-        match var_kinds.get()[var.get()] {
-            Local(LocalInfo { ident: nm, .. }) | Arg(_, nm) => {
+        match var_kinds.get().get(var.get()) {
+            &Local(LocalInfo { ident: nm, .. }) | &Arg(_, nm) => {
                 token::get_ident(nm).get().to_str()
             },
-            ImplicitRet => ~"<implicit-ret>"
+            &ImplicitRet => ~"<implicit-ret>"
         }
     }
 
@@ -364,7 +364,7 @@ impl IrMaps {
 
     pub fn lnk(&self, ln: LiveNode) -> LiveNodeKind {
         let lnks = self.lnks.borrow();
-        lnks.get()[ln.get()]
+        *lnks.get().get(ln.get())
     }
 }
 
@@ -607,9 +607,9 @@ fn Liveness(ir: @IrMaps, specials: Specials) -> Liveness {
         ir: ir,
         tcx: ir.tcx,
         s: specials,
-        successors: @RefCell::new(vec::from_elem(ir.num_live_nodes.get(),
+        successors: @RefCell::new(Vec::from_elem(ir.num_live_nodes.get(),
                                                  invalid_node())),
-        users: @RefCell::new(vec::from_elem(ir.num_live_nodes.get() *
+        users: @RefCell::new(Vec::from_elem(ir.num_live_nodes.get() *
                                             ir.num_vars.get(),
                                             invalid_users())),
         loop_scope: @RefCell::new(Vec::new()),
@@ -686,7 +686,7 @@ impl Liveness {
                          -> Option<LiveNodeKind> {
         assert!(ln.is_valid());
         let users = self.users.borrow();
-        let reader = users.get()[self.idx(ln, var)].reader;
+        let reader = users.get().get(self.idx(ln, var)).reader;
         if reader.is_valid() {Some(self.ir.lnk(reader))} else {None}
     }
 
@@ -697,7 +697,7 @@ impl Liveness {
                         -> Option<LiveNodeKind> {
         let successor = {
             let successors = self.successors.borrow();
-            successors.get()[ln.get()]
+            *successors.get().get(ln.get())
         };
         self.live_on_entry(successor, var)
     }
@@ -705,14 +705,14 @@ impl Liveness {
     pub fn used_on_entry(&self, ln: LiveNode, var: Variable) -> bool {
         assert!(ln.is_valid());
         let users = self.users.borrow();
-        users.get()[self.idx(ln, var)].used
+        users.get().get(self.idx(ln, var)).used
     }
 
     pub fn assigned_on_entry(&self, ln: LiveNode, var: Variable)
                              -> Option<LiveNodeKind> {
         assert!(ln.is_valid());
         let users = self.users.borrow();
-        let writer = users.get()[self.idx(ln, var)].writer;
+        let writer = users.get().get(self.idx(ln, var)).writer;
         if writer.is_valid() {Some(self.ir.lnk(writer))} else {None}
     }
 
@@ -720,7 +720,7 @@ impl Liveness {
                             -> Option<LiveNodeKind> {
         let successor = {
             let successors = self.successors.borrow();
-            successors.get()[ln.get()]
+            *successors.get().get(ln.get())
         };
         self.assigned_on_entry(successor, var)
     }
@@ -795,14 +795,14 @@ impl Liveness {
                 write!(wr,
                        "[ln({}) of kind {:?} reads",
                        ln.get(),
-                       lnks.and_then(|lnks| Some(lnks.get()[ln.get()])));
+                       lnks.and_then(|lnks| Some(*lnks.get().get(ln.get()))));
             }
             let users = self.users.try_borrow();
             match users {
                 Some(users) => {
-                    self.write_vars(wr, ln, |idx| users.get()[idx].reader);
+                    self.write_vars(wr, ln, |idx| users.get().get(idx).reader);
                     write!(wr, "  writes");
-                    self.write_vars(wr, ln, |idx| users.get()[idx].writer);
+                    self.write_vars(wr, ln, |idx| users.get().get(idx).writer);
                 }
                 None => {
                     write!(wr, "  (users borrowed)");
@@ -811,7 +811,9 @@ impl Liveness {
             let successors = self.successors.try_borrow();
             match successors {
                 Some(successors) => {
-                    write!(wr, "  precedes {}]", successors.get()[ln.get()].to_str());
+                    write!(wr,
+                           "  precedes {}]",
+                           successors.get().get(ln.get()).to_str());
                 }
                 None => {
                     write!(wr, "  precedes (successors borrowed)]");
@@ -824,7 +826,7 @@ impl Liveness {
     pub fn init_empty(&self, ln: LiveNode, succ_ln: LiveNode) {
         {
             let mut successors = self.successors.borrow_mut();
-            successors.get()[ln.get()] = succ_ln;
+            *successors.get().get_mut(ln.get()) = succ_ln;
         }
 
         // It is not necessary to initialize the
@@ -841,12 +843,12 @@ impl Liveness {
         // more efficient version of init_empty() / merge_from_succ()
         {
             let mut successors = self.successors.borrow_mut();
-            successors.get()[ln.get()] = succ_ln;
+            *successors.get().get_mut(ln.get()) = succ_ln;
         }
 
         self.indices2(ln, succ_ln, |idx, succ_idx| {
             let mut users = self.users.borrow_mut();
-            users.get()[idx] = users.get()[succ_idx]
+            *users.get().get_mut(idx) = *users.get().get(succ_idx)
         });
         debug!("init_from_succ(ln={}, succ={})",
                self.ln_str(ln), self.ln_str(succ_ln));
@@ -862,12 +864,12 @@ impl Liveness {
         let mut changed = false;
         self.indices2(ln, succ_ln, |idx, succ_idx| {
             let mut users = self.users.borrow_mut();
-            changed |= copy_if_invalid(users.get()[succ_idx].reader,
-                                       &mut users.get()[idx].reader);
-            changed |= copy_if_invalid(users.get()[succ_idx].writer,
-                                       &mut users.get()[idx].writer);
-            if users.get()[succ_idx].used && !users.get()[idx].used {
-                users.get()[idx].used = true;
+            changed |= copy_if_invalid(users.get().get(succ_idx).reader,
+                                       &mut users.get().get_mut(idx).reader);
+            changed |= copy_if_invalid(users.get().get(succ_idx).writer,
+                                       &mut users.get().get_mut(idx).writer);
+            if users.get().get(succ_idx).used && !users.get().get(idx).used {
+                users.get().get_mut(idx).used = true;
                 changed = true;
             }
         });
@@ -893,8 +895,8 @@ impl Liveness {
     pub fn define(&self, writer: LiveNode, var: Variable) {
         let idx = self.idx(writer, var);
         let mut users = self.users.borrow_mut();
-        users.get()[idx].reader = invalid_node();
-        users.get()[idx].writer = invalid_node();
+        users.get().get_mut(idx).reader = invalid_node();
+        users.get().get_mut(idx).writer = invalid_node();
 
         debug!("{} defines {} (idx={}): {}", writer.to_str(), var.to_str(),
                idx, self.ln_str(writer));
@@ -904,7 +906,7 @@ impl Liveness {
     pub fn acc(&self, ln: LiveNode, var: Variable, acc: uint) {
         let idx = self.idx(ln, var);
         let mut users = self.users.borrow_mut();
-        let user = &mut users.get()[idx];
+        let user = users.get().get_mut(idx);
 
         if (acc & ACC_WRITE) != 0 {
             user.reader = invalid_node();

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -723,7 +723,7 @@ impl<TYPER:Typer> MemCategorizationContext<TYPER> {
         // know what type lies at the other end, so we just call it
         // `()` (the empty tuple).
 
-        let opaque_ty = ty::mk_tup(self.tcx(), ~[]);
+        let opaque_ty = ty::mk_tup(self.tcx(), Vec::new());
         return self.cat_deref_common(node, base_cmt, deref_cnt, opaque_ty);
     }
 

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -65,6 +65,7 @@
 use middle::ty;
 use util::ppaux::{ty_to_str, region_ptr_to_str, Repr};
 
+use std::vec_ng::Vec;
 use syntax::ast::{MutImmutable, MutMutable};
 use syntax::ast;
 use syntax::codemap::Span;

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -139,6 +139,7 @@ use util::nodemap::{NodeMap, NodeSet};
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::vec_ng::Vec;
 use syntax::ast::*;
 use syntax::ast_util;
 use syntax::visit;

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -159,7 +159,7 @@ pub struct CaptureVar {
     mode: CaptureMode // How variable is being accessed
 }
 
-pub type CaptureMap = @RefCell<NodeMap<Rc<~[CaptureVar]>>>;
+pub type CaptureMap = @RefCell<NodeMap<Rc<Vec<CaptureVar> >>>;
 
 pub type MovesMap = @RefCell<NodeSet>;
 
@@ -680,7 +680,7 @@ impl VisitContext {
         self.consume_expr(arg_expr)
     }
 
-    pub fn compute_captures(&mut self, fn_expr_id: NodeId) -> Rc<~[CaptureVar]> {
+    pub fn compute_captures(&mut self, fn_expr_id: NodeId) -> Rc<Vec<CaptureVar> > {
         debug!("compute_capture_vars(fn_expr_id={:?})", fn_expr_id);
         let _indenter = indenter();
 

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -88,8 +88,8 @@ pub fn pat_bindings(dm: resolve::DefMap,
     });
 }
 
-pub fn pat_binding_ids(dm: resolve::DefMap, pat: &Pat) -> ~[NodeId] {
-    let mut found = ~[];
+pub fn pat_binding_ids(dm: resolve::DefMap, pat: &Pat) -> Vec<NodeId> {
+    let mut found = Vec::new();
     pat_bindings(dm, pat, |_bm, b_id, _sp, _pt| found.push(b_id) );
     return found;
 }

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -12,6 +12,7 @@
 use middle::resolve;
 
 use collections::HashMap;
+use std::vec_ng::Vec;
 use syntax::ast::*;
 use syntax::ast_util::{path_to_ident, walk_pat};
 use syntax::codemap::Span;

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -92,11 +92,11 @@ struct ReachableContext {
     reachable_symbols: @RefCell<NodeSet>,
     // A worklist of item IDs. Each item ID in this worklist will be inlined
     // and will be scanned for further references.
-    worklist: @RefCell<~[ast::NodeId]>,
+    worklist: @RefCell<Vec<ast::NodeId> >,
 }
 
 struct MarkSymbolVisitor {
-    worklist: @RefCell<~[ast::NodeId]>,
+    worklist: @RefCell<Vec<ast::NodeId> >,
     method_map: typeck::MethodMap,
     tcx: ty::ctxt,
     reachable_symbols: @RefCell<NodeSet>,
@@ -190,7 +190,7 @@ impl ReachableContext {
             tcx: tcx,
             method_map: method_map,
             reachable_symbols: @RefCell::new(NodeSet::new()),
-            worklist: @RefCell::new(~[]),
+            worklist: @RefCell::new(Vec::new()),
         }
     }
 

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -21,6 +21,7 @@ use middle::privacy;
 use util::nodemap::NodeSet;
 
 use std::cell::RefCell;
+use std::vec_ng::Vec;
 use collections::HashSet;
 use syntax::ast;
 use syntax::ast_map;

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -27,6 +27,7 @@ use middle::ty;
 use util::nodemap::NodeMap;
 
 use std::cell::RefCell;
+use std::vec_ng::Vec;
 use collections::{HashMap, HashSet};
 use syntax::codemap::Span;
 use syntax::{ast, visit};
@@ -287,7 +288,7 @@ impl RegionMaps {
         let mut i = 0;
         while i < queue.len() {
             let free_region_map = self.free_region_map.borrow();
-            match free_region_map.get().find(&queue[i]) {
+            match free_region_map.get().find(queue.get(i)) {
                 Some(parents) => {
                     for parent in parents.iter() {
                         if *parent == sup {
@@ -369,7 +370,7 @@ impl RegionMaps {
         // where they diverge.  If one vector is a suffix of the other,
         // then the corresponding scope is a superscope of the other.
 
-        if a_ancestors[a_index] != b_ancestors[b_index] {
+        if *a_ancestors.get(a_index) != *b_ancestors.get(b_index) {
             return None;
         }
 
@@ -380,8 +381,8 @@ impl RegionMaps {
             if b_index == 0u { return Some(scope_b); }
             a_index -= 1u;
             b_index -= 1u;
-            if a_ancestors[a_index] != b_ancestors[b_index] {
-                return Some(a_ancestors[a_index + 1u]);
+            if *a_ancestors.get(a_index) != *b_ancestors.get(b_index) {
+                return Some(*a_ancestors.get(a_index + 1u));
             }
         }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -77,7 +77,7 @@ The region maps encode information about region relationships.
 pub struct RegionMaps {
     priv scope_map: RefCell<NodeMap<ast::NodeId>>,
     priv var_map: RefCell<NodeMap<ast::NodeId>>,
-    priv free_region_map: RefCell<HashMap<FreeRegion, ~[FreeRegion]>>,
+    priv free_region_map: RefCell<HashMap<FreeRegion, Vec<FreeRegion> >>,
     priv rvalue_scopes: RefCell<NodeMap<ast::NodeId>>,
     priv terminating_scopes: RefCell<HashSet<ast::NodeId>>,
 }
@@ -113,7 +113,7 @@ impl RegionMaps {
 
         debug!("relate_free_regions(sub={:?}, sup={:?})", sub, sup);
 
-        free_region_map.get().insert(sub, ~[sup]);
+        free_region_map.get().insert(sub, vec!(sup));
     }
 
     pub fn record_encl_scope(&self, sub: ast::NodeId, sup: ast::NodeId) {
@@ -283,7 +283,7 @@ impl RegionMaps {
         // doubles as a way to detect if we've seen a particular FR
         // before.  Note that we expect this graph to be an *extremely
         // shallow* tree.
-        let mut queue = ~[sub];
+        let mut queue = vec!(sub);
         let mut i = 0;
         while i < queue.len() {
             let free_region_map = self.free_region_map.borrow();
@@ -386,10 +386,9 @@ impl RegionMaps {
         }
 
         fn ancestors_of(this: &RegionMaps, scope: ast::NodeId)
-            -> ~[ast::NodeId]
-        {
+            -> Vec<ast::NodeId> {
             // debug!("ancestors_of(scope={})", scope);
-            let mut result = ~[scope];
+            let mut result = vec!(scope);
             let mut scope = scope;
             loop {
                 let scope_map = this.scope_map.borrow();

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -16,6 +16,7 @@ use middle::ty_fold::TypeFolder;
 use util::ppaux::Repr;
 
 use std::rc::Rc;
+use std::vec_ng::Vec;
 use syntax::codemap::Span;
 use syntax::opt_vec::OptVec;
 
@@ -88,7 +89,7 @@ impl<'a> TypeFolder for SubstFolder<'a> {
         match ty::get(t).sty {
             ty::ty_param(p) => {
                 if p.idx < self.substs.tps.len() {
-                    self.substs.tps[p.idx]
+                    *self.substs.tps.get(p.idx)
                 } else {
                     let root_msg = match self.root_ty {
                         Some(root) => format!(" in the substitution of `{}`",

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -130,10 +130,10 @@ impl<'a> TypeFolder for SubstFolder<'a> {
 ///////////////////////////////////////////////////////////////////////////
 // Other types
 
-impl<T:Subst> Subst for ~[T] {
+impl<T:Subst> Subst for Vec<T> {
     fn subst_spanned(&self, tcx: ty::ctxt,
                      substs: &ty::substs,
-                     span: Option<Span>) -> ~[T] {
+                     span: Option<Span>) -> Vec<T> {
         self.map(|t| t.subst_spanned(tcx, substs, span))
     }
 }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -421,10 +421,9 @@ impl<'a,'b> Clone for ArmData<'a, 'b> {
  */
 #[deriving(Clone)]
 struct Match<'a,'b> {
-    pats: ~[@ast::Pat],
+    pats: Vec<@ast::Pat> ,
     data: ArmData<'a,'b>,
-    bound_ptrs: ~[(Ident, ValueRef)]
-}
+    bound_ptrs: Vec<(Ident, ValueRef)> }
 
 impl<'a,'b> Repr for Match<'a,'b> {
     fn repr(&self, tcx: ty::ctxt) -> ~str {
@@ -452,7 +451,7 @@ fn expand_nested_bindings<'r,'b>(
                           m: &[Match<'r,'b>],
                           col: uint,
                           val: ValueRef)
-                          -> ~[Match<'r,'b>] {
+                          -> vec!(Match<'r,'b>) {
     debug!("expand_nested_bindings(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -463,9 +462,9 @@ fn expand_nested_bindings<'r,'b>(
     m.map(|br| {
         match br.pats[col].node {
             ast::PatIdent(_, ref path, Some(inner)) => {
-                let pats = vec::append(
+                let pats = vec_ng::append(
                     br.pats.slice(0u, col).to_owned(),
-                    vec::append(~[inner],
+                    vec_ng::append(vec!(inner),
                                 br.pats.slice(col + 1u,
                                            br.pats.len())));
 
@@ -491,7 +490,7 @@ fn assert_is_binding_or_wild(bcx: &Block, p: @ast::Pat) {
     }
 }
 
-type enter_pat<'a> = 'a |@ast::Pat| -> Option<~[@ast::Pat]>;
+type enter_pat<'a> = 'a |@ast::Pat| -> Option<Vec<@ast::Pat> >;
 
 fn enter_match<'r,'b>(
                bcx: &'b Block<'b>,
@@ -500,7 +499,7 @@ fn enter_match<'r,'b>(
                col: uint,
                val: ValueRef,
                e: enter_pat)
-               -> ~[Match<'r,'b>] {
+               -> vec!(Match<'r,'b>) {
     debug!("enter_match(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -508,13 +507,13 @@ fn enter_match<'r,'b>(
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    let mut result = ~[];
+    let mut result = Vec::new();
     for br in m.iter() {
         match e(br.pats[col]) {
             Some(sub) => {
                 let pats =
-                    vec::append(
-                        vec::append(sub, br.pats.slice(0u, col)),
+                    vec_ng::append(
+                        vec_ng::append(sub, br.pats.slice(0u, col)),
                         br.pats.slice(col + 1u, br.pats.len()));
 
                 let this = br.pats[col];
@@ -550,7 +549,7 @@ fn enter_default<'r,'b>(
                  col: uint,
                  val: ValueRef,
                  chk: &FailureHandler)
-                 -> ~[Match<'r,'b>] {
+                 -> vec!(Match<'r,'b>) {
     debug!("enter_default(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -561,8 +560,8 @@ fn enter_default<'r,'b>(
     // Collect all of the matches that can match against anything.
     let matches = enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
-          ast::PatWild | ast::PatWildMulti | ast::PatTup(_) => Some(~[]),
-          ast::PatIdent(_, _, None) if pat_is_binding(dm, p) => Some(~[]),
+          ast::PatWild | ast::PatWildMulti | ast::PatTup(_) => Some(Vec::new()),
+          ast::PatIdent(_, _, None) if pat_is_binding(dm, p) => Some(Vec::new()),
           _ => None
         }
     });
@@ -587,7 +586,7 @@ fn enter_default<'r,'b>(
         _ => false
     };
 
-    if is_exhaustive { ~[] } else { matches }
+    if is_exhaustive { Vec::new() } else { matches }
 }
 
 // <pcwalton> nmatsakis: what does enter_opt do?
@@ -621,7 +620,7 @@ fn enter_opt<'r,'b>(
              col: uint,
              variant_size: uint,
              val: ValueRef)
-             -> ~[Match<'r,'b>] {
+             -> vec!(Match<'r,'b>) {
     debug!("enter_opt(bcx={}, m={}, opt={:?}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -643,7 +642,7 @@ fn enter_opt<'r,'b>(
                 };
                 let const_def_id = ast_util::def_id_of_def(const_def);
                 if opt_eq(tcx, &lit(ConstLit(const_def_id)), opt) {
-                    Some(~[])
+                    Some(Vec::new())
                 } else {
                     None
                 }
@@ -664,16 +663,16 @@ fn enter_opt<'r,'b>(
             ast::PatIdent(_, _, None)
                     if pat_is_variant_or_struct(tcx.def_map, p) => {
                 if opt_eq(tcx, &variant_opt(bcx, p.id), opt) {
-                    Some(~[])
+                    Some(Vec::new())
                 } else {
                     None
                 }
             }
             ast::PatLit(l) => {
-                if opt_eq(tcx, &lit(ExprLit(l)), opt) {Some(~[])} else {None}
+                if opt_eq(tcx, &lit(ExprLit(l)), opt) {Some(Vec::new())} else {None}
             }
             ast::PatRange(l1, l2) => {
-                if opt_eq(tcx, &range(l1, l2), opt) {Some(~[])} else {None}
+                if opt_eq(tcx, &range(l1, l2), opt) {Some(Vec::new())} else {None}
             }
             ast::PatStruct(_, ref field_pats, _) => {
                 if opt_eq(tcx, &variant_opt(bcx, p.id), opt) {
@@ -695,7 +694,7 @@ fn enter_opt<'r,'b>(
                     // Reorder the patterns into the same order they were
                     // specified in the struct definition. Also fill in
                     // unspecified fields with dummy.
-                    let mut reordered_patterns = ~[];
+                    let mut reordered_patterns = Vec::new();
                     let r = ty::lookup_struct_fields(tcx, struct_id);
                     for field in r.iter() {
                             match field_pats.iter().find(|p| p.ident.name
@@ -722,7 +721,7 @@ fn enter_opt<'r,'b>(
                         let this_opt = vec_len(n, vec_len_ge(before.len()),
                                                (lo, hi));
                         if opt_eq(tcx, &this_opt, opt) {
-                            let mut new_before = ~[];
+                            let mut new_before = Vec::new();
                             for pat in before.iter() {
                                 new_before.push(*pat);
                             }
@@ -738,7 +737,7 @@ fn enter_opt<'r,'b>(
                     None if i >= lo && i <= hi => {
                         let n = before.len();
                         if opt_eq(tcx, &vec_len(n, vec_len_eq, (lo,hi)), opt) {
-                            let mut new_before = ~[];
+                            let mut new_before = Vec::new();
                             for pat in before.iter() {
                                 new_before.push(*pat);
                             }
@@ -778,7 +777,7 @@ fn enter_rec_or_struct<'r,'b>(
                        col: uint,
                        fields: &[ast::Ident],
                        val: ValueRef)
-                       -> ~[Match<'r,'b>] {
+                       -> vec!(Match<'r,'b>) {
     debug!("enter_rec_or_struct(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -790,7 +789,7 @@ fn enter_rec_or_struct<'r,'b>(
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatStruct(_, ref fpats, _) => {
-                let mut pats = ~[];
+                let mut pats = Vec::new();
                 for fname in fields.iter() {
                     match fpats.iter().find(|p| p.ident.name == fname.name) {
                         None => pats.push(dummy),
@@ -814,7 +813,7 @@ fn enter_tup<'r,'b>(
              col: uint,
              val: ValueRef,
              n_elts: uint)
-             -> ~[Match<'r,'b>] {
+             -> vec!(Match<'r,'b>) {
     debug!("enter_tup(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -826,7 +825,7 @@ fn enter_tup<'r,'b>(
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatTup(ref elts) => {
-                let mut new_elts = ~[];
+                let mut new_elts = Vec::new();
                 for elt in elts.iter() {
                     new_elts.push((*elt).clone())
                 }
@@ -847,7 +846,7 @@ fn enter_tuple_struct<'r,'b>(
                       col: uint,
                       val: ValueRef,
                       n_elts: uint)
-                      -> ~[Match<'r,'b>] {
+                      -> vec!(Match<'r,'b>) {
     debug!("enter_tuple_struct(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -875,7 +874,7 @@ fn enter_uniq<'r,'b>(
               m: &[Match<'r,'b>],
               col: uint,
               val: ValueRef)
-              -> ~[Match<'r,'b>] {
+              -> vec!(Match<'r,'b>) {
     debug!("enter_uniq(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -887,11 +886,11 @@ fn enter_uniq<'r,'b>(
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatUniq(sub) => {
-                Some(~[sub])
+                Some(vec!(sub))
             }
             _ => {
                 assert_is_binding_or_wild(bcx, p);
-                Some(~[dummy])
+                Some(vec!(dummy))
             }
         }
     })
@@ -904,7 +903,7 @@ fn enter_region<'r,
                 m: &[Match<'r,'b>],
                 col: uint,
                 val: ValueRef)
-                -> ~[Match<'r,'b>] {
+                -> vec!(Match<'r,'b>) {
     debug!("enter_region(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -916,11 +915,11 @@ fn enter_region<'r,
     enter_match(bcx, dm, m, col, val, |p| {
         match p.node {
             ast::PatRegion(sub) => {
-                Some(~[sub])
+                Some(vec!(sub))
             }
             _ => {
                 assert_is_binding_or_wild(bcx, p);
-                Some(~[dummy])
+                Some(vec!(dummy))
             }
         }
     })
@@ -929,9 +928,9 @@ fn enter_region<'r,
 // Returns the options in one column of matches. An option is something that
 // needs to be conditionally matched at runtime; for example, the discriminant
 // on a set of enum variants or a literal.
-fn get_options(bcx: &Block, m: &[Match], col: uint) -> ~[Opt] {
+fn get_options(bcx: &Block, m: &[Match], col: uint) -> Vec<Opt> {
     let ccx = bcx.ccx();
-    fn add_to_set(tcx: ty::ctxt, set: &mut ~[Opt], val: Opt) {
+    fn add_to_set(tcx: ty::ctxt, set: &mut Vec<Opt> , val: Opt) {
         if set.iter().any(|l| opt_eq(tcx, l, &val)) {return;}
         set.push(val);
     }
@@ -939,7 +938,7 @@ fn get_options(bcx: &Block, m: &[Match], col: uint) -> ~[Opt] {
     // conditions over-match, we need to be careful about them. This
     // means that in order to properly handle things in order, we need
     // to not always merge conditions.
-    fn add_veclen_to_set(set: &mut ~[Opt], i: uint,
+    fn add_veclen_to_set(set: &mut Vec<Opt> , i: uint,
                          len: uint, vlo: VecLenOpt) {
         match set.last() {
             // If the last condition in the list matches the one we want
@@ -952,7 +951,7 @@ fn get_options(bcx: &Block, m: &[Match], col: uint) -> ~[Opt] {
         }
     }
 
-    let mut found = ~[];
+    let mut found = Vec::new();
     for (i, br) in m.iter().enumerate() {
         let cur = br.pats[col];
         match cur.node {
@@ -1020,7 +1019,7 @@ fn get_options(bcx: &Block, m: &[Match], col: uint) -> ~[Opt] {
 }
 
 struct ExtractedBlock<'a> {
-    vals: ~[ValueRef],
+    vals: Vec<ValueRef> ,
     bcx: &'a Block<'a>,
 }
 
@@ -1108,8 +1107,8 @@ fn collect_record_or_struct_fields<'a>(
                                    bcx: &'a Block<'a>,
                                    m: &[Match],
                                    col: uint)
-                                   -> Option<~[ast::Ident]> {
-    let mut fields: ~[ast::Ident] = ~[];
+                                   -> Option<Vec<ast::Ident> > {
+    let mut fields: Vec<ast::Ident> = Vec::new();
     let mut found = false;
     for br in m.iter() {
         match br.pats[col].node {
@@ -1131,7 +1130,7 @@ fn collect_record_or_struct_fields<'a>(
         return None;
     }
 
-    fn extend(idents: &mut ~[ast::Ident], field_pats: &[ast::FieldPat]) {
+    fn extend(idents: &mut Vec<ast::Ident> , field_pats: &[ast::FieldPat]) {
         for field_pat in field_pats.iter() {
             let field_ident = field_pat.ident;
             if !idents.iter().any(|x| x.name == field_ident.name) {
@@ -1530,7 +1529,7 @@ fn compile_submatch_continue<'r,
     let tcx = bcx.tcx();
     let dm = tcx.def_map;
 
-    let vals_left = vec::append(vals.slice(0u, col).to_owned(),
+    let vals_left = vec_ng::append(vals.slice(0u, col).to_owned(),
                                 vals.slice(col + 1u, vals.len()));
     let ccx = bcx.fcx.ccx;
     let mut pat_id = 0;
@@ -1558,7 +1557,7 @@ fn compile_submatch_continue<'r,
                 compile_submatch(
                         bcx,
                         enter_rec_or_struct(bcx, dm, m, col, *rec_fields, val),
-                        vec::append(rec_vals, vals_left),
+                        vec_ng::append(rec_vals, vals_left),
                         chk);
             });
             return;
@@ -1577,7 +1576,7 @@ fn compile_submatch_continue<'r,
             adt::trans_field_ptr(bcx, tup_repr, val, 0, i)
         });
         compile_submatch(bcx, enter_tup(bcx, dm, m, col, val, n_tup_elts),
-                         vec::append(tup_vals, vals_left), chk);
+                         vec_ng::append(tup_vals, vals_left), chk);
         return;
     }
 
@@ -1601,7 +1600,7 @@ fn compile_submatch_continue<'r,
         compile_submatch(bcx,
                          enter_tuple_struct(bcx, dm, m, col, val,
                                             struct_element_count),
-                         vec::append(llstructvals, vals_left),
+                         vec_ng::append(llstructvals, vals_left),
                          chk);
         return;
     }
@@ -1609,14 +1608,14 @@ fn compile_submatch_continue<'r,
     if any_uniq_pat(m, col) {
         let llbox = Load(bcx, val);
         compile_submatch(bcx, enter_uniq(bcx, dm, m, col, val),
-                         vec::append(~[llbox], vals_left), chk);
+                         vec_ng::append(vec!(llbox), vals_left), chk);
         return;
     }
 
     if any_region_pat(m, col) {
         let loaded_val = Load(bcx, val);
         compile_submatch(bcx, enter_region(bcx, dm, m, col, val),
-                         vec::append(~[loaded_val], vals_left), chk);
+                         vec_ng::append(vec!(loaded_val), vals_left), chk);
         return;
     }
 
@@ -1773,7 +1772,7 @@ fn compile_submatch_continue<'r,
         }
 
         let mut size = 0u;
-        let mut unpacked = ~[];
+        let mut unpacked = Vec::new();
         match *opt {
             var(disr_val, repr) => {
                 let ExtractedBlock {vals: argvals, bcx: new_bcx} =
@@ -1796,7 +1795,7 @@ fn compile_submatch_continue<'r,
             lit(_) | range(_, _) => ()
         }
         let opt_ms = enter_opt(opt_cx, m, opt, col, size, val);
-        let opt_vals = vec::append(unpacked, vals_left);
+        let opt_vals = vec_ng::append(unpacked, vals_left);
 
         match branch_chk {
             None => compile_submatch(opt_cx, opt_ms, opt_vals, chk),
@@ -1884,8 +1883,8 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
         return bcx;
     }
 
-    let mut arm_datas = ~[];
-    let mut matches = ~[];
+    let mut arm_datas = Vec::new();
+    let mut matches = Vec::new();
     for arm in arms.iter() {
         let body = fcx.new_id_block("case_body", arm.body.id);
         let bindings_map = create_bindings_map(bcx, *arm.pats.get(0));
@@ -1897,9 +1896,9 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
         arm_datas.push(arm_data.clone());
         for p in arm.pats.iter() {
             matches.push(Match {
-                pats: ~[*p],
+                pats: vec!(*p),
                 data: arm_data.clone(),
-                bound_ptrs: ~[],
+                bound_ptrs: Vec::new(),
             });
         }
     }
@@ -1924,7 +1923,7 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
     let lldiscr = discr_datum.val;
     compile_submatch(bcx, matches, [lldiscr], &chk);
 
-    let mut arm_cxs = ~[];
+    let mut arm_cxs = Vec::new();
     for arm_data in arm_datas.iter() {
         let mut bcx = arm_data.bodycx;
 

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -223,9 +223,10 @@ use middle::ty;
 use util::common::indenter;
 use util::ppaux::{Repr, vec_map_to_str};
 
-use std::cell::Cell;
 use collections::HashMap;
-use std::vec;
+use std::cell::Cell;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::ast;
 use syntax::ast::Ident;
 use syntax::ast_util::path_to_ident;
@@ -438,9 +439,9 @@ impl<'a,'b> Repr for Match<'a,'b> {
 
 fn has_nested_bindings(m: &[Match], col: uint) -> bool {
     for br in m.iter() {
-        match br.pats[col].node {
-          ast::PatIdent(_, _, Some(_)) => return true,
-          _ => ()
+        match br.pats.get(col).node {
+            ast::PatIdent(_, _, Some(_)) => return true,
+            _ => ()
         }
     }
     return false;
@@ -451,7 +452,7 @@ fn expand_nested_bindings<'r,'b>(
                           m: &[Match<'r,'b>],
                           col: uint,
                           val: ValueRef)
-                          -> vec!(Match<'r,'b>) {
+                          -> Vec<Match<'r,'b>> {
     debug!("expand_nested_bindings(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -459,14 +460,14 @@ fn expand_nested_bindings<'r,'b>(
            bcx.val_to_str(val));
     let _indenter = indenter();
 
-    m.map(|br| {
-        match br.pats[col].node {
+    m.iter().map(|br| {
+        match br.pats.get(col).node {
             ast::PatIdent(_, ref path, Some(inner)) => {
                 let pats = vec_ng::append(
-                    br.pats.slice(0u, col).to_owned(),
+                    Vec::from_slice(br.pats.slice(0u, col)),
                     vec_ng::append(vec!(inner),
                                 br.pats.slice(col + 1u,
-                                           br.pats.len())));
+                                           br.pats.len())).as_slice());
 
                 let mut res = Match {
                     pats: pats,
@@ -478,7 +479,7 @@ fn expand_nested_bindings<'r,'b>(
             }
             _ => (*br).clone(),
         }
-    })
+    }).collect()
 }
 
 fn assert_is_binding_or_wild(bcx: &Block, p: @ast::Pat) {
@@ -499,7 +500,7 @@ fn enter_match<'r,'b>(
                col: uint,
                val: ValueRef,
                e: enter_pat)
-               -> vec!(Match<'r,'b>) {
+               -> Vec<Match<'r,'b>> {
     debug!("enter_match(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -509,14 +510,14 @@ fn enter_match<'r,'b>(
 
     let mut result = Vec::new();
     for br in m.iter() {
-        match e(br.pats[col]) {
+        match e(*br.pats.get(col)) {
             Some(sub) => {
                 let pats =
                     vec_ng::append(
                         vec_ng::append(sub, br.pats.slice(0u, col)),
                         br.pats.slice(col + 1u, br.pats.len()));
 
-                let this = br.pats[col];
+                let this = *br.pats.get(col);
                 let mut bound_ptrs = br.bound_ptrs.clone();
                 match this.node {
                     ast::PatIdent(_, ref path, None) => {
@@ -549,7 +550,7 @@ fn enter_default<'r,'b>(
                  col: uint,
                  val: ValueRef,
                  chk: &FailureHandler)
-                 -> vec!(Match<'r,'b>) {
+                 -> Vec<Match<'r,'b>> {
     debug!("enter_default(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -620,7 +621,7 @@ fn enter_opt<'r,'b>(
              col: uint,
              variant_size: uint,
              val: ValueRef)
-             -> vec!(Match<'r,'b>) {
+             -> Vec<Match<'r,'b>> {
     debug!("enter_opt(bcx={}, m={}, opt={:?}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -651,7 +652,7 @@ fn enter_opt<'r,'b>(
                 if opt_eq(tcx, &variant_opt(bcx, p.id), opt) {
                     // FIXME: Must we clone?
                     match *subpats {
-                        None => Some(vec::from_elem(variant_size, dummy)),
+                        None => Some(Vec::from_elem(variant_size, dummy)),
                         Some(ref subpats) => {
                             Some((*subpats).iter().map(|x| *x).collect())
                         }
@@ -761,7 +762,7 @@ fn enter_opt<'r,'b>(
                 // cause the default match to fire spuriously.
                 match *opt {
                     vec_len(..) => None,
-                    _ => Some(vec::from_elem(variant_size, dummy))
+                    _ => Some(Vec::from_elem(variant_size, dummy))
                 }
             }
         };
@@ -777,7 +778,7 @@ fn enter_rec_or_struct<'r,'b>(
                        col: uint,
                        fields: &[ast::Ident],
                        val: ValueRef)
-                       -> vec!(Match<'r,'b>) {
+                       -> Vec<Match<'r,'b>> {
     debug!("enter_rec_or_struct(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -800,7 +801,7 @@ fn enter_rec_or_struct<'r,'b>(
             }
             _ => {
                 assert_is_binding_or_wild(bcx, p);
-                Some(vec::from_elem(fields.len(), dummy))
+                Some(Vec::from_elem(fields.len(), dummy))
             }
         }
     })
@@ -813,7 +814,7 @@ fn enter_tup<'r,'b>(
              col: uint,
              val: ValueRef,
              n_elts: uint)
-             -> vec!(Match<'r,'b>) {
+             -> Vec<Match<'r,'b>> {
     debug!("enter_tup(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -833,7 +834,7 @@ fn enter_tup<'r,'b>(
             }
             _ => {
                 assert_is_binding_or_wild(bcx, p);
-                Some(vec::from_elem(n_elts, dummy))
+                Some(Vec::from_elem(n_elts, dummy))
             }
         }
     })
@@ -846,7 +847,7 @@ fn enter_tuple_struct<'r,'b>(
                       col: uint,
                       val: ValueRef,
                       n_elts: uint)
-                      -> vec!(Match<'r,'b>) {
+                      -> Vec<Match<'r,'b>> {
     debug!("enter_tuple_struct(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -862,7 +863,7 @@ fn enter_tuple_struct<'r,'b>(
             }
             _ => {
                 assert_is_binding_or_wild(bcx, p);
-                Some(vec::from_elem(n_elts, dummy))
+                Some(Vec::from_elem(n_elts, dummy))
             }
         }
     })
@@ -874,7 +875,7 @@ fn enter_uniq<'r,'b>(
               m: &[Match<'r,'b>],
               col: uint,
               val: ValueRef)
-              -> vec!(Match<'r,'b>) {
+              -> Vec<Match<'r,'b>> {
     debug!("enter_uniq(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -903,7 +904,7 @@ fn enter_region<'r,
                 m: &[Match<'r,'b>],
                 col: uint,
                 val: ValueRef)
-                -> vec!(Match<'r,'b>) {
+                -> Vec<Match<'r,'b>> {
     debug!("enter_region(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -945,15 +946,18 @@ fn get_options(bcx: &Block, m: &[Match], col: uint) -> Vec<Opt> {
             // to add, then extend its range. Otherwise, make a new
             // vec_len with a range just covering the new entry.
             Some(&vec_len(len2, vlo2, (start, end)))
-                 if len == len2 && vlo == vlo2 =>
-                 set[set.len() - 1] = vec_len(len, vlo, (start, end+1)),
+                 if len == len2 && vlo == vlo2 => {
+                let length = set.len();
+                 *set.get_mut(length - 1) =
+                     vec_len(len, vlo, (start, end+1))
+            }
             _ => set.push(vec_len(len, vlo, (i, i)))
         }
     }
 
     let mut found = Vec::new();
     for (i, br) in m.iter().enumerate() {
-        let cur = br.pats[col];
+        let cur = *br.pats.get(col);
         match cur.node {
             ast::PatLit(l) => {
                 add_to_set(ccx.tcx, &mut found, lit(ExprLit(l)));
@@ -1030,7 +1034,7 @@ fn extract_variant_args<'a>(
                         val: ValueRef)
                         -> ExtractedBlock<'a> {
     let _icx = push_ctxt("match::extract_variant_args");
-    let args = vec::from_fn(adt::num_args(repr, disr_val), |i| {
+    let args = Vec::from_fn(adt::num_args(repr, disr_val), |i| {
         adt::trans_field_ptr(bcx, repr, val, disr_val, i)
     });
 
@@ -1065,7 +1069,7 @@ fn extract_vec_elems<'a>(
     let (base, len) = vec_datum.get_vec_base_and_len(bcx);
     let vt = tvec::vec_types(bcx, node_id_type(bcx, pat_id));
 
-    let mut elems = vec::from_fn(elem_count, |i| {
+    let mut elems = Vec::from_fn(elem_count, |i| {
         match slice {
             None => GEPi(bcx, base, [i]),
             Some(n) if i < n => GEPi(bcx, base, [i]),
@@ -1091,7 +1095,7 @@ fn extract_vec_elems<'a>(
         Store(bcx, slice_begin,
               GEPi(bcx, scratch.val, [0u, abi::slice_elt_base]));
         Store(bcx, slice_len, GEPi(bcx, scratch.val, [0u, abi::slice_elt_len]));
-        elems[n] = scratch.val;
+        *elems.get_mut(n) = scratch.val;
     }
 
     ExtractedBlock { vals: elems, bcx: bcx }
@@ -1111,9 +1115,9 @@ fn collect_record_or_struct_fields<'a>(
     let mut fields: Vec<ast::Ident> = Vec::new();
     let mut found = false;
     for br in m.iter() {
-        match br.pats[col].node {
+        match br.pats.get(col).node {
           ast::PatStruct(_, ref fs, _) => {
-            match ty::get(node_id_type(bcx, br.pats[col].id)).sty {
+            match ty::get(node_id_type(bcx, br.pats.get(col).id)).sty {
               ty::ty_struct(..) => {
                    extend(&mut fields, fs.as_slice());
                    found = true;
@@ -1142,7 +1146,7 @@ fn collect_record_or_struct_fields<'a>(
 
 fn pats_require_rooting(bcx: &Block, m: &[Match], col: uint) -> bool {
     m.iter().any(|br| {
-        let pat_id = br.pats[col].id;
+        let pat_id = br.pats.get(col).id;
         let key = root_map_key {id: pat_id, derefs: 0u };
         let root_map = bcx.ccx().maps.root_map.borrow();
         root_map.get().contains_key(&key)
@@ -1156,7 +1160,7 @@ fn pats_require_rooting(bcx: &Block, m: &[Match], col: uint) -> bool {
 macro_rules! any_pat (
     ($m:expr, $pattern:pat) => (
         ($m).iter().any(|br| {
-            match br.pats[col].node {
+            match br.pats.get(col).node {
                 $pattern => true,
                 _ => false
             }
@@ -1178,7 +1182,7 @@ fn any_tup_pat(m: &[Match], col: uint) -> bool {
 
 fn any_tuple_struct_pat(bcx: &Block, m: &[Match], col: uint) -> bool {
     m.iter().any(|br| {
-        let pat = br.pats[col];
+        let pat = *br.pats.get(col);
         match pat.node {
             ast::PatEnum(_, Some(_)) => {
                 let def_map = bcx.tcx().def_map.borrow();
@@ -1255,10 +1259,10 @@ fn pick_col(m: &[Match]) -> uint {
           _ => 0u
         }
     }
-    let mut scores = vec::from_elem(m[0].pats.len(), 0u);
+    let mut scores = Vec::from_elem(m[0].pats.len(), 0u);
     for br in m.iter() {
         for (i, p) in br.pats.iter().enumerate() {
-            scores[i] += score(*p);
+            *scores.get_mut(i) += score(*p);
         }
     }
     let mut max_score = 0u;
@@ -1511,7 +1515,12 @@ fn compile_submatch<'r,
 
     if has_nested_bindings(m, col) {
         let expanded = expand_nested_bindings(bcx, m, col, val);
-        compile_submatch_continue(bcx, expanded, vals, chk, col, val)
+        compile_submatch_continue(bcx,
+                                  expanded.as_slice(),
+                                  vals,
+                                  chk,
+                                  col,
+                                  val)
     } else {
         compile_submatch_continue(bcx, m, vals, chk, col, val)
     }
@@ -1529,15 +1538,15 @@ fn compile_submatch_continue<'r,
     let tcx = bcx.tcx();
     let dm = tcx.def_map;
 
-    let vals_left = vec_ng::append(vals.slice(0u, col).to_owned(),
-                                vals.slice(col + 1u, vals.len()));
+    let vals_left = vec_ng::append(Vec::from_slice(vals.slice(0u, col)),
+                                   vals.slice(col + 1u, vals.len()));
     let ccx = bcx.fcx.ccx;
     let mut pat_id = 0;
     for br in m.iter() {
         // Find a real id (we're adding placeholder wildcard patterns, but
         // each column is guaranteed to have at least one real pattern)
         if pat_id == 0 {
-            pat_id = br.pats[col].id;
+            pat_id = br.pats.get(col).id;
         }
     }
 
@@ -1556,8 +1565,14 @@ fn compile_submatch_continue<'r,
                         });
                 compile_submatch(
                         bcx,
-                        enter_rec_or_struct(bcx, dm, m, col, *rec_fields, val),
-                        vec_ng::append(rec_vals, vals_left),
+                        enter_rec_or_struct(bcx,
+                                            dm,
+                                            m,
+                                            col,
+                                            rec_fields.as_slice(),
+                                            val).as_slice(),
+                        vec_ng::append(rec_vals,
+                                       vals_left.as_slice()).as_slice(),
                         chk);
             });
             return;
@@ -1572,11 +1587,19 @@ fn compile_submatch_continue<'r,
           ty::ty_tup(ref elts) => elts.len(),
           _ => ccx.sess.bug("non-tuple type in tuple pattern")
         };
-        let tup_vals = vec::from_fn(n_tup_elts, |i| {
+        let tup_vals = Vec::from_fn(n_tup_elts, |i| {
             adt::trans_field_ptr(bcx, tup_repr, val, 0, i)
         });
-        compile_submatch(bcx, enter_tup(bcx, dm, m, col, val, n_tup_elts),
-                         vec_ng::append(tup_vals, vals_left), chk);
+        compile_submatch(bcx,
+                         enter_tup(bcx,
+                                   dm,
+                                   m,
+                                   col,
+                                   val,
+                                   n_tup_elts).as_slice(),
+                         vec_ng::append(tup_vals,
+                                        vals_left.as_slice()).as_slice(),
+                         chk);
         return;
     }
 
@@ -1594,28 +1617,35 @@ fn compile_submatch_continue<'r,
         }
 
         let struct_repr = adt::represent_type(bcx.ccx(), struct_ty);
-        let llstructvals = vec::from_fn(struct_element_count, |i| {
+        let llstructvals = Vec::from_fn(struct_element_count, |i| {
             adt::trans_field_ptr(bcx, struct_repr, val, 0, i)
         });
         compile_submatch(bcx,
                          enter_tuple_struct(bcx, dm, m, col, val,
-                                            struct_element_count),
-                         vec_ng::append(llstructvals, vals_left),
+                                            struct_element_count).as_slice(),
+                         vec_ng::append(llstructvals,
+                                        vals_left.as_slice()).as_slice(),
                          chk);
         return;
     }
 
     if any_uniq_pat(m, col) {
         let llbox = Load(bcx, val);
-        compile_submatch(bcx, enter_uniq(bcx, dm, m, col, val),
-                         vec_ng::append(vec!(llbox), vals_left), chk);
+        compile_submatch(bcx,
+                         enter_uniq(bcx, dm, m, col, val).as_slice(),
+                         vec_ng::append(vec!(llbox),
+                                        vals_left.as_slice()).as_slice(),
+                         chk);
         return;
     }
 
     if any_region_pat(m, col) {
         let loaded_val = Load(bcx, val);
-        compile_submatch(bcx, enter_region(bcx, dm, m, col, val),
-                         vec_ng::append(vec!(loaded_val), vals_left), chk);
+        compile_submatch(bcx,
+                         enter_region(bcx, dm, m, col, val).as_slice(),
+                         vec_ng::append(vec!(loaded_val),
+                                        vals_left.as_slice()).as_slice(),
+                         chk);
         return;
     }
 
@@ -1626,7 +1656,7 @@ fn compile_submatch_continue<'r,
     let mut test_val = val;
     debug!("test_val={}", bcx.val_to_str(test_val));
     if opts.len() > 0u {
-        match opts[0] {
+        match *opts.get(0) {
             var(_, repr) => {
                 let (the_kind, val_opt) = adt::trans_switch(bcx, repr, val);
                 kind = the_kind;
@@ -1795,12 +1825,20 @@ fn compile_submatch_continue<'r,
             lit(_) | range(_, _) => ()
         }
         let opt_ms = enter_opt(opt_cx, m, opt, col, size, val);
-        let opt_vals = vec_ng::append(unpacked, vals_left);
+        let opt_vals = vec_ng::append(unpacked, vals_left.as_slice());
 
         match branch_chk {
-            None => compile_submatch(opt_cx, opt_ms, opt_vals, chk),
+            None => {
+                compile_submatch(opt_cx,
+                                 opt_ms.as_slice(),
+                                 opt_vals.as_slice(),
+                                 chk)
+            }
             Some(branch_chk) => {
-                compile_submatch(opt_cx, opt_ms, opt_vals, &branch_chk)
+                compile_submatch(opt_cx,
+                                 opt_ms.as_slice(),
+                                 opt_vals.as_slice(),
+                                 &branch_chk)
             }
         }
     }
@@ -1811,7 +1849,10 @@ fn compile_submatch_continue<'r,
             Br(bcx, else_cx.llbb);
         }
         if kind != single {
-            compile_submatch(else_cx, defaults, vals_left, chk);
+            compile_submatch(else_cx,
+                             defaults.as_slice(),
+                             vals_left.as_slice(),
+                             chk);
         }
     }
 }
@@ -1921,7 +1962,7 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
         }
     };
     let lldiscr = discr_datum.val;
-    compile_submatch(bcx, matches, [lldiscr], &chk);
+    compile_submatch(bcx, matches.as_slice(), [lldiscr], &chk);
 
     let mut arm_cxs = Vec::new();
     for arm_data in arm_datas.iter() {
@@ -1944,7 +1985,7 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
         arm_cxs.push(bcx);
     }
 
-    bcx = scope_cx.fcx.join_blocks(match_id, arm_cxs);
+    bcx = scope_cx.fcx.join_blocks(match_id, arm_cxs.as_slice());
     return bcx;
 }
 

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -83,7 +83,7 @@ pub enum Repr {
      * General-case enums: for each case there is a struct, and they
      * all start with a field for the discriminant.
      */
-    General(IntType, ~[Struct]),
+    General(IntType, Vec<Struct> ),
     /**
      * Two cases distinguished by a nullable pointer: the case with discriminant
      * `nndiscr` is represented by the struct `nonnull`, where the `ptrfield`th
@@ -96,7 +96,7 @@ pub enum Repr {
      * identity function.
      */
     NullablePointer{ nonnull: Struct, nndiscr: Disr, ptrfield: uint,
-                     nullfields: ~[ty::t] }
+                     nullfields: Vec<ty::t> }
 }
 
 /// For structs, and struct-like parts of anything fancier.
@@ -104,8 +104,7 @@ pub struct Struct {
     size: u64,
     align: u64,
     packed: bool,
-    fields: ~[ty::t]
-}
+    fields: Vec<ty::t> }
 
 /**
  * Convenience for `represent_type`.  There should probably be more or
@@ -217,7 +216,7 @@ fn represent_type_uncached(cx: &CrateContext, t: ty::t) -> Repr {
             let bounds = IntBounds { ulo: 0, uhi: (cases.len() - 1) as u64,
                                      slo: 0, shi: (cases.len() - 1) as i64 };
             let ity = range_to_inttype(cx, hint, &bounds);
-            let discr = ~[ty_of_inttype(ity)];
+            let discr = vec!(ty_of_inttype(ity));
             return General(ity, cases.map(|c| mk_struct(cx, discr + c.tys, false)))
         }
         _ => cx.sess.bug("adt::represent_type called on non-ADT type")
@@ -254,7 +253,7 @@ pub fn is_ffi_safe(tcx: ty::ctxt, def_id: ast::DefId) -> bool {
 }
 
 // this should probably all be in ty
-struct Case { discr: Disr, tys: ~[ty::t] }
+struct Case { discr: Disr, tys: Vec<ty::t> }
 impl Case {
     fn is_zerolen(&self, cx: &CrateContext) -> bool {
         mk_struct(cx, self.tys, false).size == 0
@@ -264,7 +263,7 @@ impl Case {
     }
 }
 
-fn get_cases(tcx: ty::ctxt, def_id: ast::DefId, substs: &ty::substs) -> ~[Case] {
+fn get_cases(tcx: ty::ctxt, def_id: ast::DefId, substs: &ty::substs) -> Vec<Case> {
     ty::enum_variants(tcx, def_id).map(|vi| {
         let arg_tys = vi.args.map(|&raw_ty| {
             ty::subst(tcx, substs, raw_ty)
@@ -438,9 +437,9 @@ fn generic_type_of(cx: &CrateContext, r: &Repr, name: Option<&str>, sizing: bool
             };
             assert_eq!(machine::llalign_of_min(cx, pad_ty) as u64, align);
             assert_eq!(align % discr_size, 0);
-            let fields = ~[discr_ty,
+            let fields = vec!(discr_ty,
                            Type::array(&discr_ty, align / discr_size - 1),
-                           pad_ty];
+                           pad_ty);
             match name {
                 None => Type::struct_(fields, false),
                 Some(name) => {
@@ -453,7 +452,7 @@ fn generic_type_of(cx: &CrateContext, r: &Repr, name: Option<&str>, sizing: bool
     }
 }
 
-fn struct_llfields(cx: &CrateContext, st: &Struct, sizing: bool) -> ~[Type] {
+fn struct_llfields(cx: &CrateContext, st: &Struct, sizing: bool) -> Vec<Type> {
     if sizing {
         st.fields.map(|&ty| type_of::sizing_type_of(cx, ty))
     } else {
@@ -741,7 +740,7 @@ pub fn trans_const(ccx: &CrateContext, r: &Repr, discr: Disr,
             let case = &cases[discr];
             let max_sz = cases.iter().map(|x| x.size).max().unwrap();
             let lldiscr = C_integral(ll_inttype(ccx, ity), discr as u64, true);
-            let contents = build_const_struct(ccx, case, ~[lldiscr] + vals);
+            let contents = build_const_struct(ccx, case, vec!(lldiscr) + vals);
             C_struct(contents + &[padding(max_sz - case.size)], false)
         }
         Univariant(ref st, _dro) => {
@@ -757,7 +756,7 @@ pub fn trans_const(ccx: &CrateContext, r: &Repr, discr: Disr,
                     // Always use null even if it's not the `ptrfield`th
                     // field; see #8506.
                     C_null(type_of::sizing_type_of(ccx, ty))
-                });
+                }).collect::<Vec<ValueRef> >();
                 C_struct(build_const_struct(ccx, nonnull, vals), false)
             }
         }
@@ -775,11 +774,11 @@ pub fn trans_const(ccx: &CrateContext, r: &Repr, discr: Disr,
  * will read the wrong memory.
  */
 fn build_const_struct(ccx: &CrateContext, st: &Struct, vals: &[ValueRef])
-    -> ~[ValueRef] {
+    -> Vec<ValueRef> {
     assert_eq!(vals.len(), st.fields.len());
 
     let mut offset = 0;
-    let mut cfields = ~[];
+    let mut cfields = Vec::new();
     for (i, &ty) in st.fields.iter().enumerate() {
         let llty = type_of::sizing_type_of(ccx, ty);
         let type_align = machine::llalign_of_min(ccx, llty)

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -32,8 +32,8 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
                         -> &'a Block<'a> {
     let fcx = bcx.fcx;
     let mut bcx = bcx;
-    let mut constraints = ~[];
-    let mut output_types = ~[];
+    let mut constraints = Vec::new();
+    let mut output_types = Vec::new();
 
     let temp_scope = fcx.push_custom_cleanup_scope();
 

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -12,8 +12,6 @@
 # Translation of inline assembly.
 */
 
-use std::c_str::ToCStr;
-
 use lib;
 use middle::trans::build::*;
 use middle::trans::callee;
@@ -22,9 +20,10 @@ use middle::trans::cleanup;
 use middle::trans::cleanup::CleanupMethods;
 use middle::trans::expr;
 use middle::trans::type_of;
-
 use middle::trans::type_::Type;
 
+use std::c_str::ToCStr;
+use std::vec_ng::Vec;
 use syntax::ast;
 
 // Take an inline assembly expression and splat it out via LLVM
@@ -88,9 +87,9 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
     let output_type = if num_outputs == 0 {
         Type::void()
     } else if num_outputs == 1 {
-        output_types[0]
+        *output_types.get(0)
     } else {
-        Type::struct_(output_types, false)
+        Type::struct_(output_types.as_slice(), false)
     };
 
     let dialect = match ia.dialect {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -73,11 +73,12 @@ use util::sha2::Sha256;
 use util::nodemap::NodeMap;
 
 use arena::TypedArena;
+use collections::HashMap;
 use std::c_str::ToCStr;
 use std::cell::{Cell, RefCell};
-use collections::HashMap;
 use std::libc::c_uint;
 use std::local_data;
+use std::vec_ng::Vec;
 use syntax::abi::{X86, X86_64, Arm, Mips, Rust, RustIntrinsic, OsWin32};
 use syntax::ast_map::PathName;
 use syntax::ast_util::{local_def, is_local};
@@ -99,7 +100,7 @@ local_data_key!(task_local_insn_key: Vec<&'static str> )
 pub fn with_insn_ctxt(blk: |&[&'static str]|) {
     local_data::get(task_local_insn_key, |c| {
         match c {
-            Some(ctx) => blk(*ctx),
+            Some(ctx) => blk(ctx.as_slice()),
             None => ()
         }
     })
@@ -543,7 +544,7 @@ pub fn get_res_dtor(ccx: @CrateContext,
         let tsubsts = ty::substs {
             regions: ty::ErasedRegions,
             self_ty: None,
-            tps: substs.to_owned()
+            tps: Vec::from_slice(substs),
         };
 
         let vtables = typeck::check::vtable::trans_resolve_method(ccx.tcx, did.node, &tsubsts);
@@ -752,8 +753,8 @@ pub fn iter_structural_ty<'r,
 
           match adt::trans_switch(cx, repr, av) {
               (_match::single, None) => {
-                  cx = iter_variant(cx, repr, av, variants[0],
-                                    substs.tps, f);
+                  cx = iter_variant(cx, repr, av, *variants.get(0),
+                                    substs.tps.as_slice(), f);
               }
               (_match::switch, Some(lldiscrim_a)) => {
                   cx = f(cx, lldiscrim_a, ty::mk_int());
@@ -775,8 +776,12 @@ pub fn iter_structural_ty<'r,
                                                 in iter_structural_ty")
                       }
                       let variant_cx =
-                          iter_variant(variant_cx, repr, av, *variant,
-                                       substs.tps, |x,y,z| f(x,y,z));
+                          iter_variant(variant_cx,
+                                       repr,
+                                       av,
+                                       *variant,
+                                       substs.tps.as_slice(),
+                                       |x,y,z| f(x,y,z));
                       Br(variant_cx, next_cx.llbb);
                   }
                   cx = next_cx;
@@ -876,7 +881,11 @@ pub fn trans_external_path(ccx: &CrateContext, did: ast::DefId, t: ty::t) -> Val
             match fn_ty.abis.for_target(ccx.sess.targ_cfg.os,
                                         ccx.sess.targ_cfg.arch) {
                 Some(Rust) | Some(RustIntrinsic) => {
-                    get_extern_rust_fn(ccx, fn_ty.sig.inputs, fn_ty.sig.output, name, did)
+                    get_extern_rust_fn(ccx,
+                                       fn_ty.sig.inputs.as_slice(),
+                                       fn_ty.sig.output,
+                                       name,
+                                       did)
                 }
                 Some(..) | None => {
                     let c = foreign::llvm_calling_convention(ccx, fn_ty.abis);
@@ -889,7 +898,11 @@ pub fn trans_external_path(ccx: &CrateContext, did: ast::DefId, t: ty::t) -> Val
             }
         }
         ty::ty_closure(ref f) => {
-            get_extern_rust_fn(ccx, f.sig.inputs, f.sig.output, name, did)
+            get_extern_rust_fn(ccx,
+                               f.sig.inputs.as_slice(),
+                               f.sig.output,
+                               name,
+                               did)
         }
         _ => {
             let llty = type_of(ccx, t);
@@ -935,7 +948,7 @@ pub fn invoke<'a>(
 
         let llresult = Invoke(bcx,
                               llfn,
-                              llargs,
+                              llargs.as_slice(),
                               normal_bcx.llbb,
                               landing_pad,
                               attributes);
@@ -951,7 +964,7 @@ pub fn invoke<'a>(
             None => debuginfo::clear_source_location(bcx.fcx)
         };
 
-        let llresult = Call(bcx, llfn, llargs, attributes);
+        let llresult = Call(bcx, llfn, llargs.as_slice(), attributes);
         return (llresult, bcx);
     }
 }
@@ -1231,7 +1244,10 @@ pub fn new_fn_ctxt<'a>(ccx: @CrateContext,
     let substd_output_type = match param_substs {
         None => output_type,
         Some(substs) => {
-            ty::subst_tps(ccx.tcx, substs.tys, substs.self_ty, output_type)
+            ty::subst_tps(ccx.tcx,
+                          substs.tys.as_slice(),
+                          substs.self_ty,
+                          output_type)
         }
     };
     let uses_outptr = type_of::return_uses_outptr(ccx, substd_output_type);
@@ -1289,7 +1305,7 @@ pub fn init_function<'a>(
         None => output_type,
         Some(substs) => {
             ty::subst_tps(fcx.ccx.tcx,
-                          substs.tys,
+                          substs.tys.as_slice(),
                           substs.self_ty,
                           output_type)
         }
@@ -1472,7 +1488,7 @@ pub fn trans_closure<'a>(ccx: @CrateContext,
 
     // Set up arguments to the function.
     let arg_tys = ty::ty_fn_args(node_id_type(bcx, id));
-    let arg_datums = create_datums_for_fn_args(&fcx, arg_tys);
+    let arg_datums = create_datums_for_fn_args(&fcx, arg_tys.as_slice());
 
     bcx = copy_args_to_allocas(&fcx,
                                arg_scope,
@@ -1583,7 +1599,7 @@ fn trans_enum_variant_or_tuple_like_struct(ccx: @CrateContext,
     let no_substs: &[ty::t] = [];
     let ty_param_substs = match param_substs {
         Some(ref substs) => {
-            let v: &[ty::t] = substs.tys;
+            let v: &[ty::t] = substs.tys.as_slice();
             v
         }
         None => {
@@ -1612,7 +1628,7 @@ fn trans_enum_variant_or_tuple_like_struct(ccx: @CrateContext,
 
     let arg_tys = ty::ty_fn_args(ctor_ty);
 
-    let arg_datums = create_datums_for_fn_args(&fcx, arg_tys);
+    let arg_datums = create_datums_for_fn_args(&fcx, arg_tys.as_slice());
 
     let bcx = fcx.entry_bcx.get().unwrap();
 
@@ -1636,7 +1652,7 @@ pub fn trans_enum_def(ccx: @CrateContext, enum_definition: &ast::EnumDef,
                       id: ast::NodeId, vi: @Vec<@ty::VariantInfo> ,
                       i: &mut uint) {
     for &variant in enum_definition.variants.iter() {
-        let disr_val = vi[*i].disr_val;
+        let disr_val = vi.get(*i).disr_val;
         *i += 1;
 
         match variant.node.kind {
@@ -1801,7 +1817,11 @@ fn register_fn(ccx: @CrateContext,
         _ => fail!("expected bare rust fn or an intrinsic")
     };
 
-    let llfn = decl_rust_fn(ccx, false, f.sig.inputs, f.sig.output, sym);
+    let llfn = decl_rust_fn(ccx,
+                            false,
+                            f.sig.inputs.as_slice(),
+                            f.sig.output,
+                            sym);
     finish_register_fn(ccx, sp, sym, node_id, llfn);
     llfn
 }
@@ -1893,8 +1913,10 @@ pub fn create_entry_wrapper(ccx: @CrateContext,
                 (rust_main, args)
             };
 
-            let result = llvm::LLVMBuildCall(bld, start_fn,
-                                             args.as_ptr(), args.len() as c_uint,
+            let result = llvm::LLVMBuildCall(bld,
+                                             start_fn,
+                                             args.as_ptr(),
+                                             args.len() as c_uint,
                                              noname());
 
             llvm::LLVMBuildRet(bld, result);
@@ -2476,7 +2498,7 @@ pub fn create_module_map(ccx: &CrateContext) -> (ValueRef, uint) {
         elts.push(elt);
     }
     unsafe {
-        llvm::LLVMSetInitializer(map, C_array(elttype, elts));
+        llvm::LLVMSetInitializer(map, C_array(elttype, elts.as_slice()));
     }
     return (map, keys.len())
 }
@@ -2564,7 +2586,8 @@ pub fn fill_crate_map(ccx: @CrateContext, map: ValueRef) {
         });
         lib::llvm::SetLinkage(vec_elements, lib::llvm::InternalLinkage);
 
-        llvm::LLVMSetInitializer(vec_elements, C_array(ccx.int_type, subcrates));
+        llvm::LLVMSetInitializer(vec_elements,
+                                 C_array(ccx.int_type, subcrates.as_slice()));
         let (mod_map, mod_count) = create_module_map(ccx);
 
         llvm::LLVMSetInitializer(map, C_struct(
@@ -2613,7 +2636,7 @@ pub fn write_metadata(cx: &CrateContext, krate: &ast::Crate) -> Vec<u8> {
     let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
     let metadata = encoder::encode_metadata(encode_parms, krate);
     let compressed = encoder::metadata_encoding_version +
-                        flate::deflate_bytes(metadata).as_slice();
+                        flate::deflate_bytes(metadata.as_slice()).as_slice();
     let llmeta = C_bytes(compressed);
     let llconst = C_struct([llmeta], false);
     let name = format!("rust_metadata_{}_{}_{}", cx.link_meta.crateid.name,
@@ -2744,12 +2767,12 @@ pub fn trans_crate(sess: session::Session,
     let link_meta = ccx.link_meta.clone();
     let llmod = ccx.llmod;
 
-    let mut reachable = {
+    let mut reachable: Vec<~str> = {
         let reachable_map = ccx.reachable.borrow();
         reachable_map.get().iter().filter_map(|id| {
             let item_symbols = ccx.item_symbols.borrow();
             item_symbols.get().find(id).map(|s| s.to_owned())
-        }).to_owned_vec()
+        }).collect()
     };
 
     // Make sure that some other crucial symbols are not eliminated from the

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -17,8 +17,10 @@ use middle::trans::base;
 use middle::trans::common::*;
 use middle::trans::machine::llalign_of_pref;
 use middle::trans::type_::Type;
-use std::libc::{c_uint, c_ulonglong, c_char};
+
 use collections::HashMap;
+use std::libc::{c_uint, c_ulonglong, c_char};
+use std::vec_ng::Vec;
 use syntax::codemap::Span;
 
 pub struct Builder<'a> {
@@ -542,7 +544,7 @@ impl<'a> Builder<'a> {
         } else {
             let v = ixs.iter().map(|i| C_i32(*i as i32)).collect::<Vec<ValueRef> >();
             self.count_insn("gepi");
-            self.inbounds_gep(base, v)
+            self.inbounds_gep(base, v.as_slice())
         }
     }
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -540,7 +540,7 @@ impl<'a> Builder<'a> {
             }
             self.inbounds_gep(base, small_vec.slice(0, ixs.len()))
         } else {
-            let v = ixs.iter().map(|i| C_i32(*i as i32)).collect::<~[ValueRef]>();
+            let v = ixs.iter().map(|i| C_i32(*i as i32)).collect::<Vec<ValueRef> >();
             self.count_insn("gepi");
             self.inbounds_gep(base, v)
         }

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -83,7 +83,7 @@ impl ArgType {
 /// comments are reverse-engineered and may be inaccurate. -NDM
 pub struct FnType {
     /// The LLVM types of each argument.
-    arg_tys: ~[ArgType],
+    arg_tys: Vec<ArgType> ,
 
     /// LLVM return type.
     ret_ty: ArgType,

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -16,6 +16,7 @@ use middle::trans::cabi_x86_64;
 use middle::trans::cabi_arm;
 use middle::trans::cabi_mips;
 use middle::trans::type_::Type;
+use std::vec_ng::Vec;
 use syntax::abi::{X86, X86_64, Arm, Mips};
 
 #[deriving(Clone, Eq)]

--- a/src/librustc/middle/trans/cabi_arm.rs
+++ b/src/librustc/middle/trans/cabi_arm.rs
@@ -14,11 +14,11 @@ use lib::llvm::{llvm, Integer, Pointer, Float, Double, Struct, Array};
 use lib::llvm::StructRetAttribute;
 use middle::trans::cabi::{FnType, ArgType};
 use middle::trans::context::CrateContext;
-
 use middle::trans::type_::Type;
 
 use std::cmp;
 use std::option::{None, Some};
+use std::vec_ng::Vec;
 
 fn align_up_to(off: uint, a: uint) -> uint {
     return (off + a - 1u) / a * a;

--- a/src/librustc/middle/trans/cabi_arm.rs
+++ b/src/librustc/middle/trans/cabi_arm.rs
@@ -131,7 +131,7 @@ pub fn compute_abi_info(_ccx: &CrateContext,
                         atys: &[Type],
                         rty: Type,
                         ret_def: bool) -> FnType {
-    let mut arg_tys = ~[];
+    let mut arg_tys = Vec::new();
     for &aty in atys.iter() {
         let ty = classify_arg_ty(aty);
         arg_tys.push(ty);

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -17,8 +17,9 @@ use lib::llvm::StructRetAttribute;
 use middle::trans::context::CrateContext;
 use middle::trans::context::task_llcx;
 use middle::trans::cabi::*;
-
 use middle::trans::type_::Type;
+
+use std::vec_ng::Vec;
 
 fn align_up_to(off: uint, a: uint) -> uint {
     return (off + a - 1u) / a * a;
@@ -155,7 +156,7 @@ fn coerce_to_int(size: uint) -> Vec<Type> {
 fn struct_ty(ty: Type) -> Type {
     let size = ty_size(ty) * 8;
     let fields = coerce_to_int(size);
-    return Type::struct_(fields, false);
+    return Type::struct_(fields.as_slice(), false);
 }
 
 pub fn compute_abi_info(_ccx: &CrateContext,

--- a/src/librustc/middle/trans/cabi_mips.rs
+++ b/src/librustc/middle/trans/cabi_mips.rs
@@ -132,9 +132,9 @@ fn padding_ty(align: uint, offset: uint) -> Option<Type> {
     return None;
 }
 
-fn coerce_to_int(size: uint) -> ~[Type] {
+fn coerce_to_int(size: uint) -> Vec<Type> {
     let int_ty = Type::i32();
-    let mut args = ~[];
+    let mut args = Vec::new();
 
     let mut n = size / 32;
     while n > 0 {
@@ -169,7 +169,7 @@ pub fn compute_abi_info(_ccx: &CrateContext,
     };
 
     let sret = ret_ty.is_indirect();
-    let mut arg_tys = ~[];
+    let mut arg_tys = Vec::new();
     let mut offset = if sret { 4 } else { 0 };
 
     for aty in atys.iter() {

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -20,7 +20,7 @@ pub fn compute_abi_info(ccx: &CrateContext,
                         atys: &[Type],
                         rty: Type,
                         ret_def: bool) -> FnType {
-    let mut arg_tys = ~[];
+    let mut arg_tys = Vec::new();
 
     let ret_ty;
     if !ret_def {

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -15,6 +15,7 @@ use super::cabi::*;
 use super::common::*;
 use super::machine::*;
 use middle::trans::type_::Type;
+use std::vec_ng::Vec;
 
 pub fn compute_abi_info(ccx: &CrateContext,
                         atys: &[Type],

--- a/src/librustc/middle/trans/cabi_x86_64.rs
+++ b/src/librustc/middle/trans/cabi_x86_64.rs
@@ -84,7 +84,7 @@ impl<'a> ClassList for &'a [RegClass] {
     }
 }
 
-fn classify_ty(ty: Type) -> ~[RegClass] {
+fn classify_ty(ty: Type) -> Vec<RegClass> {
     fn align(off: uint, ty: Type) -> uint {
         let a = ty_align(ty);
         return (off + a - 1u) / a * a;
@@ -304,7 +304,7 @@ fn llreg_ty(cls: &[RegClass]) -> Type {
         return len;
     }
 
-    let mut tys = ~[];
+    let mut tys = Vec::new();
     let mut i = 0u;
     let e = cls.len();
     while i < e {
@@ -352,7 +352,7 @@ pub fn compute_abi_info(_ccx: &CrateContext,
         }
     }
 
-    let mut arg_tys = ~[];
+    let mut arg_tys = Vec::new();
     for t in atys.iter() {
         let ty = x86_64_ty(*t, |cls| cls.is_pass_byval(), ByValAttribute);
         arg_tys.push(ty);

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -218,7 +218,7 @@ fn resolve_default_method_vtables(bcx: &Block,
                 vtables.len() - num_method_vtables;
             vtables.tailn(num_impl_type_parameters).to_owned()
         },
-        None => vec::from_elem(num_method_vtables, @~[])
+        None => vec::from_elem(num_method_vtables, @Vec::new())
     };
 
     let param_vtables = @(*trait_vtables_fixed + method_vtables);
@@ -640,7 +640,7 @@ pub fn trans_call_inner<'a>(
     // written in opt_llretslot (if it is Some) or `llresult` will be
     // set appropriately (otherwise).
     if is_rust_fn {
-        let mut llargs = ~[];
+        let mut llargs = Vec::new();
 
         // Push the out-pointer if we use an out-pointer for this
         // return type, otherwise push "undef".
@@ -666,7 +666,7 @@ pub fn trans_call_inner<'a>(
         // available, so we have to apply any attributes with ABI
         // implications directly to the call instruction. Right now,
         // the only attribute we need to worry about is `sret`.
-        let mut attrs = ~[];
+        let mut attrs = Vec::new();
         if type_of::return_uses_outptr(ccx, ret_ty) {
             attrs.push((1, StructRetAttribute));
         }
@@ -704,7 +704,7 @@ pub fn trans_call_inner<'a>(
         // they are always Rust fns.
         assert!(dest.is_some());
 
-        let mut llargs = ~[];
+        let mut llargs = Vec::new();
         bcx = trans_args(bcx, args, callee_ty, &mut llargs,
                          cleanup::CustomScope(arg_cleanup_scope), false);
         fcx.pop_custom_cleanup_scope(arg_cleanup_scope);
@@ -746,7 +746,7 @@ pub enum CallArgs<'a> {
 fn trans_args<'a>(cx: &'a Block<'a>,
                   args: CallArgs,
                   fn_ty: ty::t,
-                  llargs: &mut ~[ValueRef],
+                  llargs: &mut Vec<ValueRef> ,
                   arg_cleanup_scope: cleanup::ScopeId,
                   ignore_self: bool)
                   -> &'a Block<'a> {

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -349,7 +349,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
         assert!(self.is_valid_custom_scope(custom_scope));
 
         let mut scopes = self.scopes.borrow_mut();
-        let scope = &mut scopes.get()[custom_scope.index];
+        let scope = scopes.get().get_mut(custom_scope.index);
         scope.cleanups.push(cleanup);
         scope.clear_cached_exits();
     }
@@ -433,7 +433,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
     fn is_valid_custom_scope(&self, custom_scope: CustomScopeIndex) -> bool {
         let scopes = self.scopes.borrow();
         custom_scope.index < scopes.get().len() &&
-            scopes.get()[custom_scope.index].kind.is_temp()
+            scopes.get().get(custom_scope.index).kind.is_temp()
     }
 
     fn trans_scope_cleanups(&self, // cannot borrow self, will recurse

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -27,6 +27,7 @@ use util::ppaux::Repr;
 use util::ppaux::ty_to_str;
 
 use arena::TypedArena;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_util;
 
@@ -139,12 +140,12 @@ pub fn mk_closure_tys(tcx: ty::ctxt,
     // is the actual types that will be stored in the map, not the
     // logical types as the user sees them, so by-ref upvars must be
     // converted to ptrs.
-    let bound_tys = bound_values.map(|bv| {
+    let bound_tys = bound_values.iter().map(|bv| {
         match bv.action {
             EnvCopy | EnvMove => bv.datum.ty,
             EnvRef => ty::mk_mut_ptr(tcx, bv.datum.ty)
         }
-    });
+    }).collect();
     let cdata_ty = ty::mk_tup(tcx, bound_tys);
     debug!("cdata_ty={}", ty_to_str(tcx, cdata_ty));
     return cdata_ty;
@@ -199,7 +200,7 @@ pub fn store_environment<'a>(
     let tcx = ccx.tcx;
 
     // compute the type of the closure
-    let cdata_ty = mk_closure_tys(tcx, bound_values);
+    let cdata_ty = mk_closure_tys(tcx, bound_values.as_slice());
 
     // cbox_ty has the form of a tuple: (a, b, c) we want a ptr to a
     // tuple.  This could be a ptr in uniq or a box or on stack,
@@ -387,7 +388,11 @@ pub fn trans_expr_fn<'a>(
     let s = tcx.map.with_path(id, |path| {
         mangle_internal_name_by_path_and_seq(path, "closure")
     });
-    let llfn = decl_internal_rust_fn(ccx, true, f.sig.inputs, f.sig.output, s);
+    let llfn = decl_internal_rust_fn(ccx,
+                                     true,
+                                     f.sig.inputs.as_slice(),
+                                     f.sig.output,
+                                     s);
 
     // set an inline hint for all closures
     set_inline_hint(llfn);
@@ -396,11 +401,17 @@ pub fn trans_expr_fn<'a>(
         let capture_map = ccx.maps.capture_map.borrow();
         capture_map.get().get_copy(&id)
     };
-    let ClosureResult {llbox, cdata_ty, bcx} = build_closure(bcx, *cap_vars.borrow(), sigil);
+    let ClosureResult {llbox, cdata_ty, bcx} =
+        build_closure(bcx, cap_vars.borrow().as_slice(), sigil);
     trans_closure(ccx, decl, body, llfn,
                   bcx.fcx.param_substs, id,
                   [], ty::ty_fn_ret(fty),
-                  |bcx| load_environment(bcx, cdata_ty, *cap_vars.borrow(), sigil));
+                  |bcx| {
+                      load_environment(bcx,
+                                       cdata_ty,
+                                       cap_vars.borrow().as_slice(),
+                                       sigil)
+                  });
     fill_fn_pair(bcx, dest_addr, llfn, llbox);
 
     bcx
@@ -447,9 +458,13 @@ pub fn get_wrapper_for_bare_fn(ccx: @CrateContext,
         mangle_internal_name_by_path_and_seq(path, "as_closure")
     });
     let llfn = if is_local {
-        decl_internal_rust_fn(ccx, true, f.sig.inputs, f.sig.output, name)
+        decl_internal_rust_fn(ccx,
+                              true,
+                              f.sig.inputs.as_slice(),
+                              f.sig.output,
+                              name)
     } else {
-        decl_rust_fn(ccx, true, f.sig.inputs, f.sig.output, name)
+        decl_rust_fn(ccx, true, f.sig.inputs.as_slice(), f.sig.output, name)
     };
 
     {
@@ -470,7 +485,9 @@ pub fn get_wrapper_for_bare_fn(ccx: @CrateContext,
     init_function(&fcx, true, f.sig.output, None);
     let bcx = fcx.entry_bcx.get().unwrap();
 
-    let args = create_datums_for_fn_args(&fcx, ty::ty_fn_args(closure_ty));
+    let args = create_datums_for_fn_args(&fcx,
+                                         ty::ty_fn_args(closure_ty)
+                                            .as_slice());
     let mut llargs = Vec::new();
     match fcx.llretptr.get() {
         Some(llretptr) => {
@@ -480,7 +497,7 @@ pub fn get_wrapper_for_bare_fn(ccx: @CrateContext,
     }
     llargs.extend(&mut args.iter().map(|arg| arg.val));
 
-    let retval = Call(bcx, fn_ptr, llargs, []);
+    let retval = Call(bcx, fn_ptr, llargs.as_slice(), []);
     if type_is_zero_size(ccx, f.sig.output) || fcx.llretptr.get().is_some() {
         RetVoid(bcx);
     } else {

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -152,7 +152,7 @@ pub fn mk_closure_tys(tcx: ty::ctxt,
 
 fn tuplify_box_ty(tcx: ty::ctxt, t: ty::t) -> ty::t {
     let ptr = ty::mk_imm_ptr(tcx, ty::mk_i8());
-    ty::mk_tup(tcx, ~[ty::mk_uint(), ty::mk_nil_ptr(tcx), ptr, ptr, t])
+    ty::mk_tup(tcx, vec!(ty::mk_uint(), ty::mk_nil_ptr(tcx), ptr, ptr, t))
 }
 
 fn allocate_cbox<'a>(bcx: &'a Block<'a>,
@@ -191,7 +191,7 @@ pub struct ClosureResult<'a> {
 // Otherwise, it is stack allocated and copies pointers to the upvars.
 pub fn store_environment<'a>(
                          bcx: &'a Block<'a>,
-                         bound_values: ~[EnvValue],
+                         bound_values: Vec<EnvValue> ,
                          sigil: ast::Sigil)
                          -> ClosureResult<'a> {
     let _icx = push_ctxt("closure::store_environment");
@@ -258,7 +258,7 @@ fn build_closure<'a>(bcx0: &'a Block<'a>,
     let bcx = bcx0;
 
     // Package up the captured upvars
-    let mut env_vals = ~[];
+    let mut env_vals = Vec::new();
     for cap_var in cap_vars.iter() {
         debug!("Building closure: captured variable {:?}", *cap_var);
         let datum = expr::trans_local_var(bcx, cap_var.def);
@@ -471,7 +471,7 @@ pub fn get_wrapper_for_bare_fn(ccx: @CrateContext,
     let bcx = fcx.entry_bcx.get().unwrap();
 
     let args = create_datums_for_fn_args(&fcx, ty::ty_fn_args(closure_ty));
-    let mut llargs = ~[];
+    let mut llargs = Vec::new();
     match fcx.llretptr.get() {
         Some(llretptr) => {
             llargs.push(llretptr);

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -161,7 +161,7 @@ pub struct Stats {
     n_llvm_insns: Cell<uint>,
     llvm_insns: RefCell<HashMap<~str, uint>>,
     // (ident, time-in-ms, llvm-instructions)
-    fn_stats: RefCell<~[(~str, uint, uint)]>,
+    fn_stats: RefCell<Vec<(~str, uint, uint)> >,
 }
 
 pub struct BuilderRef_res {
@@ -187,7 +187,7 @@ pub type ExternMap = HashMap<~str, ValueRef>;
 // Here `self_ty` is the real type of the self parameter to this method. It
 // will only be set in the case of default methods.
 pub struct param_substs {
-    tys: ~[ty::t],
+    tys: Vec<ty::t> ,
     self_ty: Option<ty::t>,
     vtables: Option<typeck::vtable_res>,
     self_vtables: Option<typeck::vtable_param_res>
@@ -285,7 +285,7 @@ pub struct FunctionContext<'a> {
     debug_context: debuginfo::FunctionDebugContext,
 
     // Cleanup scopes.
-    scopes: RefCell<~[cleanup::CleanupScope<'a>]>,
+    scopes: RefCell<Vec<cleanup::CleanupScope<'a>> >,
 }
 
 impl<'a> FunctionContext<'a> {
@@ -639,7 +639,7 @@ pub fn C_binary_slice(cx: &CrateContext, data: &[u8]) -> ValueRef {
 pub fn C_zero_byte_arr(size: uint) -> ValueRef {
     unsafe {
         let mut i = 0u;
-        let mut elts: ~[ValueRef] = ~[];
+        let mut elts: Vec<ValueRef> = Vec::new();
         while i < size { elts.push(C_u8(0u)); i += 1u; }
         return llvm::LLVMConstArray(Type::i8().to_ref(),
                                     elts.as_ptr(), elts.len() as c_uint);
@@ -725,7 +725,7 @@ pub fn is_null(val: ValueRef) -> bool {
 // Used to identify cached monomorphized functions and vtables
 #[deriving(Eq, Hash)]
 pub enum mono_param_id {
-    mono_precise(ty::t, Option<@~[mono_id]>),
+    mono_precise(ty::t, Option<@Vec<mono_id> >),
     mono_any,
     mono_repr(uint /* size */,
               uint /* align */,
@@ -758,8 +758,7 @@ pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
 #[deriving(Eq, Hash)]
 pub struct mono_id_ {
     def: ast::DefId,
-    params: ~[mono_param_id]
-}
+    params: Vec<mono_param_id> }
 
 pub type mono_id = @mono_id_;
 
@@ -808,7 +807,7 @@ pub fn expr_ty_adjusted(bcx: &Block, ex: &ast::Expr) -> ty::t {
     monomorphize_type(bcx, t)
 }
 
-pub fn node_id_type_params(bcx: &Block, id: ast::NodeId, is_method: bool) -> ~[ty::t] {
+pub fn node_id_type_params(bcx: &Block, id: ast::NodeId, is_method: bool) -> Vec<ty::t> {
     let tcx = bcx.tcx();
     let params = if is_method {
         bcx.ccx().maps.method_map.borrow().get().get(&id).substs.tps.clone()
@@ -925,7 +924,7 @@ pub fn find_vtable(tcx: ty::ctxt,
     param_bounds[n_bound].clone()
 }
 
-pub fn dummy_substs(tps: ~[ty::t]) -> ty::substs {
+pub fn dummy_substs(tps: Vec<ty::t> ) -> ty::substs {
     substs {
         regions: ty::ErasedRegions,
         self_ty: None,

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -25,15 +25,16 @@ use middle::trans::consts;
 use middle::trans::expr;
 use middle::trans::inline;
 use middle::trans::machine;
+use middle::trans::type_::Type;
 use middle::trans::type_of;
 use middle::ty;
 use util::ppaux::{Repr, ty_to_str};
 
-use middle::trans::type_::Type;
-
 use std::c_str::ToCStr;
 use std::libc::c_uint;
 use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::{ast, ast_util};
 
 pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: ast::Lit)
@@ -303,8 +304,8 @@ fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
     let map_list = |exprs: &[@ast::Expr]| {
         exprs.iter().map(|&e| const_expr(cx, e, is_local))
              .fold((Vec::new(), true),
-                   |(L, all_inlineable), (val, inlineable)| {
-                (vec::append_one(L, val), all_inlineable && inlineable)
+                   |(l, all_inlineable), (val, inlineable)| {
+                (vec_ng::append_one(l, val), all_inlineable && inlineable)
              })
     };
     unsafe {
@@ -533,7 +534,7 @@ fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
               let ety = ty::expr_ty(cx.tcx, e);
               let repr = adt::represent_type(cx, ety);
               let (vals, inlineable) = map_list(es.as_slice());
-              (adt::trans_const(cx, repr, 0, vals), inlineable)
+              (adt::trans_const(cx, repr, 0, vals.as_slice()), inlineable)
           }
           ast::ExprStruct(_, ref fs, ref base_opt) => {
               let ety = ty::expr_ty(cx.tcx, e);
@@ -667,7 +668,8 @@ fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
                       let ety = ty::expr_ty(cx.tcx, e);
                       let repr = adt::represent_type(cx, ety);
                       let (arg_vals, inlineable) = map_list(args.as_slice());
-                      (adt::trans_const(cx, repr, 0, arg_vals), inlineable)
+                      (adt::trans_const(cx, repr, 0, arg_vals.as_slice()),
+                       inlineable)
                   }
                   Some(ast::DefVariant(enum_did, variant_did, _)) => {
                       let ety = ty::expr_ty(cx.tcx, e);
@@ -676,8 +678,10 @@ fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
                                                            enum_did,
                                                            variant_did);
                       let (arg_vals, inlineable) = map_list(args.as_slice());
-                      (adt::trans_const(cx, repr, vinfo.disr_val, arg_vals),
-                       inlineable)
+                      (adt::trans_const(cx,
+                                        repr,
+                                        vinfo.disr_val,
+                                        arg_vals.as_slice()), inlineable)
                   }
                   _ => cx.sess.span_bug(e.span, "expected a struct or variant def")
               }

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -302,8 +302,9 @@ fn const_expr_unadjusted(cx: @CrateContext, e: &ast::Expr,
                          is_local: bool) -> (ValueRef, bool) {
     let map_list = |exprs: &[@ast::Expr]| {
         exprs.iter().map(|&e| const_expr(cx, e, is_local))
-             .fold((~[], true), |(l, all_inlineable), (val, inlineable)| {
-                (vec::append_one(l, val), all_inlineable && inlineable)
+             .fold((Vec::new(), true),
+                   |(L, all_inlineable), (val, inlineable)| {
+                (vec::append_one(L, val), all_inlineable && inlineable)
              })
     };
     unsafe {

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -33,6 +33,7 @@ use std::cell::{Cell, RefCell};
 use std::c_str::ToCStr;
 use std::local_data;
 use std::libc::c_uint;
+use std::vec_ng::Vec;
 use collections::{HashMap, HashSet};
 use syntax::ast;
 use syntax::parse::token::InternedString;

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -226,7 +226,7 @@ impl CrateContext {
                    n_closures: Cell::new(0u),
                    n_llvm_insns: Cell::new(0u),
                    llvm_insns: RefCell::new(HashMap::new()),
-                   fn_stats: RefCell::new(~[]),
+                   fn_stats: RefCell::new(Vec::new()),
                  },
                  tydesc_type: tydesc_type,
                  int_type: int_type,
@@ -250,7 +250,7 @@ impl CrateContext {
                                indices: &[uint]) -> ValueRef {
         debug!("const_inbounds_gepi: pointer={} indices={:?}",
                self.tn.val_to_str(pointer), indices);
-        let v: ~[ValueRef] =
+        let v: Vec<ValueRef> =
             indices.iter().map(|i| C_i32(*i as i32)).collect();
         unsafe {
             llvm::LLVMConstInBoundsGEP(pointer,

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -343,7 +343,10 @@ pub fn trans_fail<'a>(
     let v_filename = PointerCast(bcx, v_filename, Type::i8p());
     let args = vec!(v_str, v_filename, C_int(ccx, v_line));
     let did = langcall(bcx, Some(sp), "", FailFnLangItem);
-    let bcx = callee::trans_lang_call(bcx, did, args, Some(expr::Ignore)).bcx;
+    let bcx = callee::trans_lang_call(bcx,
+                                      did,
+                                      args.as_slice(),
+                                      Some(expr::Ignore)).bcx;
     Unreachable(bcx);
     return bcx;
 }
@@ -358,7 +361,10 @@ pub fn trans_fail_bounds_check<'a>(
     let (filename, line) = filename_and_line_num_from_span(bcx, sp);
     let args = vec!(filename, line, index, len);
     let did = langcall(bcx, Some(sp), "", FailBoundsCheckFnLangItem);
-    let bcx = callee::trans_lang_call(bcx, did, args, Some(expr::Ignore)).bcx;
+    let bcx = callee::trans_lang_call(bcx,
+                                      did,
+                                      args.as_slice(),
+                                      Some(expr::Ignore)).bcx;
     Unreachable(bcx);
     return bcx;
 }

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -341,7 +341,7 @@ pub fn trans_fail<'a>(
     let v_line = loc.line as int;
     let v_str = PointerCast(bcx, v_fail_str, Type::i8p());
     let v_filename = PointerCast(bcx, v_filename, Type::i8p());
-    let args = ~[v_str, v_filename, C_int(ccx, v_line)];
+    let args = vec!(v_str, v_filename, C_int(ccx, v_line));
     let did = langcall(bcx, Some(sp), "", FailFnLangItem);
     let bcx = callee::trans_lang_call(bcx, did, args, Some(expr::Ignore)).bcx;
     Unreachable(bcx);
@@ -356,7 +356,7 @@ pub fn trans_fail_bounds_check<'a>(
                                -> &'a Block<'a> {
     let _icx = push_ctxt("trans_fail_bounds_check");
     let (filename, line) = filename_and_line_num_from_span(bcx, sp);
-    let args = ~[filename, line, index, len];
+    let args = vec!(filename, line, index, len);
     let did = langcall(bcx, Some(sp), "", FailBoundsCheckFnLangItem);
     let bcx = callee::trans_lang_call(bcx, did, args, Some(expr::Ignore)).bcx;
     Unreachable(bcx);

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -149,6 +149,7 @@ use std::libc::{c_uint, c_ulonglong, c_longlong};
 use std::ptr;
 use std::sync::atomics;
 use std::vec;
+use std::vec_ng::Vec;
 use syntax::codemap::{Span, Pos};
 use syntax::{abi, ast, codemap, ast_util, ast_map, opt_vec};
 use syntax::parse::token;
@@ -725,7 +726,10 @@ pub fn create_function_debug_context(cx: &CrateContext,
                 let return_type = match param_substs {
                     None => return_type,
                     Some(substs) => {
-                        ty::subst_tps(cx.tcx, substs.tys, substs.self_ty, return_type)
+                        ty::subst_tps(cx.tcx,
+                                      substs.tys.as_slice(),
+                                      substs.self_ty,
+                                      return_type)
                     }
                 };
 
@@ -740,7 +744,10 @@ pub fn create_function_debug_context(cx: &CrateContext,
             let arg_type = match param_substs {
                 None => arg_type,
                 Some(substs) => {
-                    ty::subst_tps(cx.tcx, substs.tys, substs.self_ty, arg_type)
+                    ty::subst_tps(cx.tcx,
+                                  substs.tys.as_slice(),
+                                  substs.self_ty,
+                                  arg_type)
                 }
             };
 
@@ -771,7 +778,8 @@ pub fn create_function_debug_context(cx: &CrateContext,
         name_to_append_suffix_to.push_char('<');
 
         // The list to be filled with template parameters:
-        let mut template_params: Vec<DIDescriptor> = vec::with_capacity(generics.ty_params.len() + 1);
+        let mut template_params: Vec<DIDescriptor> =
+            Vec::with_capacity(generics.ty_params.len() + 1);
 
         // Handle self type
         if has_self_type {
@@ -814,12 +822,12 @@ pub fn create_function_debug_context(cx: &CrateContext,
         let actual_types = match param_substs {
             Some(param_substs) => &param_substs.tys,
             None => {
-                return create_DIArray(DIB(cx), template_params);
+                return create_DIArray(DIB(cx), template_params.as_slice());
             }
         };
 
         for (index, &ast::TyParam{ ident: ident, .. }) in generics.ty_params.iter().enumerate() {
-            let actual_type = actual_types[index];
+            let actual_type = *actual_types.get(index);
             // Add actual type name to <...> clause of function name
             let actual_type_name = ppaux::ty_to_str(cx.tcx, actual_type);
             name_to_append_suffix_to.push_str(actual_type_name);
@@ -850,7 +858,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
 
         name_to_append_suffix_to.push_char('>');
 
-        return create_DIArray(DIB(cx), template_params);
+        return create_DIArray(DIB(cx), template_params.as_slice());
     }
 }
 
@@ -1250,7 +1258,7 @@ impl RecursiveTypeDescription {
                 set_members_of_composite_type(cx,
                                               metadata_stub,
                                               llvm_type,
-                                              member_descriptions,
+                                              member_descriptions.as_slice(),
                                               file_metadata,
                                               codemap::DUMMY_SP);
                 return metadata_stub;
@@ -1300,7 +1308,7 @@ fn prepare_tuple_metadata(cx: &CrateContext,
         llvm_type: tuple_llvm_type,
         file_metadata: file_metadata,
         member_description_factory: TupleMD(TupleMemberDescriptionFactory {
-            component_types: component_types.to_owned(),
+            component_types: Vec::from_slice(component_types),
             span: span,
         })
     }
@@ -1331,7 +1339,7 @@ impl GeneralMemberDescriptionFactory {
                 let (variant_type_metadata, variant_llvm_type, member_desc_factory) =
                     describe_enum_variant(cx,
                                           struct_def,
-                                          self.variants[i],
+                                          *self.variants.get(i),
                                           Some(self.discriminant_type_metadata),
                                           self.containing_scope,
                                           self.file_metadata,
@@ -1343,7 +1351,7 @@ impl GeneralMemberDescriptionFactory {
                 set_members_of_composite_type(cx,
                                               variant_type_metadata,
                                               variant_llvm_type,
-                                              member_descriptions,
+                                              member_descriptions.as_slice(),
                                               self.file_metadata,
                                               codemap::DUMMY_SP);
                 MemberDescription {
@@ -1387,8 +1395,11 @@ fn describe_enum_variant(cx: &CrateContext,
                          file_metadata: DIFile,
                          span: Span)
                       -> (DICompositeType, Type, MemberDescriptionFactory) {
-    let variant_llvm_type = Type::struct_(struct_def.fields.map(|&t| type_of::type_of(cx, t)),
-                                          struct_def.packed);
+    let variant_llvm_type =
+        Type::struct_(struct_def.fields
+                                .map(|&t| type_of::type_of(cx, t))
+                                .as_slice(),
+                      struct_def.packed);
     // Could some consistency checks here: size, align, field count, discr type
 
     // Find the source code location of the variant's definition
@@ -1491,7 +1502,7 @@ fn prepare_enum_metadata(cx: &CrateContext,
                     loc.line as c_uint,
                     bytes_to_bits(discriminant_size),
                     bytes_to_bits(discriminant_align),
-                    create_DIArray(DIB(cx), enumerators_metadata),
+                    create_DIArray(DIB(cx), enumerators_metadata.as_slice()),
                     discriminant_base_type_metadata)
             }
         })
@@ -1507,13 +1518,14 @@ fn prepare_enum_metadata(cx: &CrateContext,
             assert!(variants.len() == 1);
             let (metadata_stub,
                  variant_llvm_type,
-                 member_description_factory) = describe_enum_variant(cx,
-                                                                     struct_def,
-                                                                     variants[0],
-                                                                     None,
-                                                                     containing_scope,
-                                                                     file_metadata,
-                                                                     span);
+                 member_description_factory) =
+                    describe_enum_variant(cx,
+                                          struct_def,
+                                          *variants.get(0),
+                                          None,
+                                          containing_scope,
+                                          file_metadata,
+                                          span);
             UnfinishedMetadata {
                 cache_id: cache_id_for_type(enum_type),
                 metadata_stub: metadata_stub,
@@ -1565,13 +1577,14 @@ fn prepare_enum_metadata(cx: &CrateContext,
         adt::NullablePointer { nonnull: ref struct_def, nndiscr, .. } => {
             let (metadata_stub,
                  variant_llvm_type,
-                 member_description_factory) = describe_enum_variant(cx,
-                                                                     struct_def,
-                                                                     variants[nndiscr],
-                                                                     None,
-                                                                     containing_scope,
-                                                                     file_metadata,
-                                                                     span);
+                 member_description_factory) =
+                    describe_enum_variant(cx,
+                                          struct_def,
+                                          *variants.get(nndiscr as uint),
+                                          None,
+                                          containing_scope,
+                                          file_metadata,
+                                          span);
             UnfinishedMetadata {
                 cache_id: cache_id_for_type(enum_type),
                 metadata_stub: metadata_stub,
@@ -1679,7 +1692,7 @@ fn set_members_of_composite_type(cx: &CrateContext,
         .collect();
 
     unsafe {
-        let type_array = create_DIArray(DIB(cx), member_metadata);
+        let type_array = create_DIArray(DIB(cx), member_metadata.as_slice());
         llvm::LLVMDICompositeTypeSetTypeArray(composite_type_metadata, type_array);
     }
 }
@@ -1739,7 +1752,9 @@ fn boxed_type_metadata(cx: &CrateContext,
 
     let box_llvm_type = Type::at_box(cx, content_llvm_type);
     let member_llvm_types = box_llvm_type.field_types();
-    assert!(box_layout_is_correct(cx, member_llvm_types, content_llvm_type));
+    assert!(box_layout_is_correct(cx,
+                                  member_llvm_types.as_slice(),
+                                  content_llvm_type));
 
     let int_type = ty::mk_int();
     let nil_pointer_type = ty::mk_nil_ptr(cx.tcx);
@@ -1748,31 +1763,31 @@ fn boxed_type_metadata(cx: &CrateContext,
     let member_descriptions = [
         MemberDescription {
             name: ~"refcnt",
-            llvm_type: member_llvm_types[0],
+            llvm_type: *member_llvm_types.get(0),
             type_metadata: type_metadata(cx, int_type, codemap::DUMMY_SP),
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"drop_glue",
-            llvm_type: member_llvm_types[1],
+            llvm_type: *member_llvm_types.get(1),
             type_metadata: nil_pointer_type_metadata,
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"prev",
-            llvm_type: member_llvm_types[2],
+            llvm_type: *member_llvm_types.get(2),
             type_metadata: nil_pointer_type_metadata,
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"next",
-            llvm_type: member_llvm_types[3],
+            llvm_type: *member_llvm_types.get(3),
             type_metadata: nil_pointer_type_metadata,
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"val",
-            llvm_type: member_llvm_types[4],
+            llvm_type: *member_llvm_types.get(4),
             type_metadata: content_type_metadata,
             offset: ComputedMemberOffset,
         }
@@ -1859,19 +1874,19 @@ fn vec_metadata(cx: &CrateContext,
     let member_descriptions = [
         MemberDescription {
             name: ~"fill",
-            llvm_type: member_llvm_types[0],
+            llvm_type: *member_llvm_types.get(0),
             type_metadata: int_type_metadata,
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"alloc",
-            llvm_type: member_llvm_types[1],
+            llvm_type: *member_llvm_types.get(1),
             type_metadata: int_type_metadata,
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"elements",
-            llvm_type: member_llvm_types[2],
+            llvm_type: *member_llvm_types.get(2),
             type_metadata: array_type_metadata,
             offset: ComputedMemberOffset,
         }
@@ -1904,20 +1919,22 @@ fn vec_slice_metadata(cx: &CrateContext,
     let slice_type_name = ppaux::ty_to_str(cx.tcx, vec_type);
 
     let member_llvm_types = slice_llvm_type.field_types();
-    assert!(slice_layout_is_correct(cx, member_llvm_types, element_type));
+    assert!(slice_layout_is_correct(cx,
+                                    member_llvm_types.as_slice(),
+                                    element_type));
 
     let data_ptr_type = ty::mk_ptr(cx.tcx, ty::mt { ty: element_type, mutbl: ast::MutImmutable });
 
     let member_descriptions = [
         MemberDescription {
             name: ~"data_ptr",
-            llvm_type: member_llvm_types[0],
+            llvm_type: *member_llvm_types.get(0),
             type_metadata: type_metadata(cx, data_ptr_type, span),
             offset: ComputedMemberOffset,
         },
         MemberDescription {
             name: ~"length",
-            llvm_type: member_llvm_types[1],
+            llvm_type: *member_llvm_types.get(1),
             type_metadata: type_metadata(cx, ty::mk_uint(), span),
             offset: ComputedMemberOffset,
         },
@@ -1954,7 +1971,8 @@ fn subroutine_type_metadata(cx: &CrateContext,
     let loc = span_start(cx, span);
     let file_metadata = file_metadata(cx, loc.file.name);
 
-    let mut signature_metadata: Vec<DIType> = vec::with_capacity(signature.inputs.len() + 1);
+    let mut signature_metadata: Vec<DIType> =
+        Vec::with_capacity(signature.inputs.len() + 1);
 
     // return type
     signature_metadata.push(match ty::get(signature.output).sty {
@@ -1971,7 +1989,7 @@ fn subroutine_type_metadata(cx: &CrateContext,
         llvm::LLVMDIBuilderCreateSubroutineType(
             DIB(cx),
             file_metadata,
-            create_DIArray(DIB(cx), signature_metadata))
+            create_DIArray(DIB(cx), signature_metadata.as_slice()))
     };
 }
 
@@ -1993,7 +2011,7 @@ fn trait_metadata(cx: &CrateContext,
                ident_string.get();
     // Add type and region parameters
     let name = ppaux::parameterized(cx.tcx, name, &substs.regions,
-                                    substs.tps, def_id, true);
+                                    substs.tps.as_slice(), def_id, true);
 
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, def_id);
 
@@ -2121,7 +2139,10 @@ fn type_metadata(cx: &CrateContext,
             }
         },
         ty::ty_tup(ref elements) => {
-            prepare_tuple_metadata(cx, t, *elements, usage_site_span).finalize(cx)
+            prepare_tuple_metadata(cx,
+                                   t,
+                                   elements.as_slice(),
+                                   usage_site_span).finalize(cx)
         }
         _ => cx.sess.bug(format!("debuginfo: unexpected type in type_metadata: {:?}", sty))
     };

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -71,6 +71,7 @@ use middle::trans::machine::llsize_of;
 use middle::trans::type_::Type;
 
 use std::vec;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::codemap;
@@ -743,7 +744,7 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
             let repr = adt::represent_type(bcx.ccx(), expr_ty(bcx, expr));
             let numbered_fields: Vec<(uint, @ast::Expr)> =
                 args.iter().enumerate().map(|(i, arg)| (i, *arg)).collect();
-            trans_adt(bcx, repr, 0, numbered_fields, None, dest)
+            trans_adt(bcx, repr, 0, numbered_fields.as_slice(), None, dest)
         }
         ast::ExprLit(lit) => {
             match lit.node {
@@ -973,7 +974,7 @@ pub fn with_field_tys<R>(tcx: ty::ctxt,
 
     match ty::get(ty).sty {
         ty::ty_struct(did, ref substs) => {
-            op(0, struct_fields(tcx, did, substs))
+            op(0, struct_fields(tcx, did, substs).as_slice())
         }
 
         ty::ty_enum(_, ref substs) => {
@@ -995,7 +996,9 @@ pub fn with_field_tys<R>(tcx: ty::ctxt,
                             let variant_info = ty::enum_variant_with_id(
                                 tcx, enum_id, variant_id);
                             op(variant_info.disr_val,
-                               struct_fields(tcx, variant_id, substs))
+                               struct_fields(tcx,
+                                             variant_id,
+                                             substs).as_slice())
                         }
                         _ => {
                             tcx.sess.bug("resolve didn't map this expr to a \

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -741,7 +741,7 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
         }
         ast::ExprTup(ref args) => {
             let repr = adt::represent_type(bcx.ccx(), expr_ty(bcx, expr));
-            let numbered_fields: ~[(uint, @ast::Expr)] =
+            let numbered_fields: Vec<(uint, @ast::Expr)> =
                 args.iter().enumerate().map(|(i, arg)| (i, *arg)).collect();
             trans_adt(bcx, repr, 0, numbered_fields, None, dest)
         }
@@ -1047,7 +1047,7 @@ fn trans_rec_or_struct<'a>(
         });
         let optbase = match base {
             Some(base_expr) => {
-                let mut leftovers = ~[];
+                let mut leftovers = Vec::new();
                 for (i, b) in need_base.iter().enumerate() {
                     if *b {
                         leftovers.push((i, field_tys[i].mt.ty))
@@ -1081,8 +1081,7 @@ struct StructBaseInfo {
     /// The base expression; will be evaluated after all explicit fields.
     expr: @ast::Expr,
     /// The indices of fields to copy paired with their types.
-    fields: ~[(uint, ty::t)]
-}
+    fields: Vec<(uint, ty::t)> }
 
 /**
  * Constructs an ADT instance:
@@ -1709,7 +1708,7 @@ fn trans_log_level<'a>(bcx: &'a Block<'a>) -> DatumBlock<'a, Expr> {
                     _ => false
                 }
             });
-            let modpath: ~[ast_map::PathElem] = path.collect();
+            let modpath: Vec<ast_map::PathElem> = path.collect();
             let modname = ast_map::path_to_str(ast_map::Values(modpath.iter()));
             (modpath, modname)
         })

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -27,6 +27,7 @@ use middle::ty::FnSig;
 use middle::ty;
 use std::cmp;
 use std::libc::c_uint;
+use std::vec_ng::Vec;
 use syntax::abi::{Cdecl, Aapcs, C, AbiSet, Win64};
 use syntax::abi::{RustIntrinsic, Rust, Stdcall, Fastcall, System};
 use syntax::codemap::Span;
@@ -196,14 +197,14 @@ pub fn trans_native_call<'a>(
         ty::ty_bare_fn(ref fn_ty) => (fn_ty.abis, fn_ty.sig.clone()),
         _ => ccx.sess.bug("trans_native_call called on non-function type")
     };
-    let llsig = foreign_signature(ccx, &fn_sig, passed_arg_tys);
+    let llsig = foreign_signature(ccx, &fn_sig, passed_arg_tys.as_slice());
     let ret_def = !return_type_is_void(bcx.ccx(), fn_sig.output);
     let fn_type = cabi::compute_abi_info(ccx,
-                                         llsig.llarg_tys,
+                                         llsig.llarg_tys.as_slice(),
                                          llsig.llret_ty,
                                          ret_def);
 
-    let arg_tys: &[cabi::ArgType] = fn_type.arg_tys;
+    let arg_tys: &[cabi::ArgType] = fn_type.arg_tys.as_slice();
 
     let mut llargs_foreign = Vec::new();
 
@@ -228,7 +229,8 @@ pub fn trans_native_call<'a>(
         let mut llarg_rust = llarg_rust;
 
         // Does Rust pass this argument by pointer?
-        let rust_indirect = type_of::arg_is_indirect(ccx, passed_arg_tys[i]);
+        let rust_indirect = type_of::arg_is_indirect(ccx,
+                                                     *passed_arg_tys.get(i));
 
         debug!("argument {}, llarg_rust={}, rust_indirect={}, arg_ty={}",
                i,
@@ -239,7 +241,10 @@ pub fn trans_native_call<'a>(
         // Ensure that we always have the Rust value indirectly,
         // because it makes bitcasting easier.
         if !rust_indirect {
-            let scratch = base::alloca(bcx, type_of::type_of(ccx, passed_arg_tys[i]), "__arg");
+            let scratch =
+                base::alloca(bcx,
+                             type_of::type_of(ccx, *passed_arg_tys.get(i)),
+                             "__arg");
             Store(bcx, llarg_rust, scratch);
             llarg_rust = scratch;
         }
@@ -295,7 +300,11 @@ pub fn trans_native_call<'a>(
         None
     };
     let attrs = sret_attr.as_slice();
-    let llforeign_retval = CallWithConv(bcx, llfn, llargs_foreign, cc, attrs);
+    let llforeign_retval = CallWithConv(bcx,
+                                        llfn,
+                                        llargs_foreign.as_slice(),
+                                        cc,
+                                        attrs);
 
     // If the function we just called does not use an outpointer,
     // store the result into the rust outpointer. Cast the outpointer
@@ -466,7 +475,11 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @CrateContext,
                ccx.tcx.map.path_to_str(id),
                id, t.repr(tcx));
 
-        let llfn = base::decl_internal_rust_fn(ccx, false, f.sig.inputs, f.sig.output, ps);
+        let llfn = base::decl_internal_rust_fn(ccx,
+                                               false,
+                                               f.sig.inputs.as_slice(),
+                                               f.sig.output,
+                                               ps);
         base::set_llvm_fn_attrs(attrs, llfn);
         base::trans_fn(ccx, decl, body, llfn, None, id, []);
         llfn
@@ -579,10 +592,10 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @CrateContext,
         // Careful to adapt for cases where the native convention uses
         // a pointer and Rust does not or vice versa.
         for i in range(0, tys.fn_sig.inputs.len()) {
-            let rust_ty = tys.fn_sig.inputs[i];
-            let llrust_ty = tys.llsig.llarg_tys[i];
+            let rust_ty = *tys.fn_sig.inputs.get(i);
+            let llrust_ty = *tys.llsig.llarg_tys.get(i);
             let rust_indirect = type_of::arg_is_indirect(ccx, rust_ty);
-            let llforeign_arg_ty = tys.fn_ty.arg_tys[i];
+            let llforeign_arg_ty = *tys.fn_ty.arg_tys.get(i);
             let foreign_indirect = llforeign_arg_ty.is_indirect();
 
             // skip padding
@@ -730,7 +743,7 @@ fn foreign_signature(ccx: &CrateContext, fn_sig: &ty::FnSig, arg_tys: &[ty::t])
      * values by pointer like we do.
      */
 
-    let llarg_tys = arg_tys.map(|&arg| type_of(ccx, arg));
+    let llarg_tys = arg_tys.iter().map(|&arg| type_of(ccx, arg)).collect();
     let llret_ty = type_of::type_of(ccx, fn_sig.output);
     LlvmSignature {
         llarg_tys: llarg_tys,
@@ -750,10 +763,10 @@ fn foreign_types_for_fn_ty(ccx: &CrateContext,
         ty::ty_bare_fn(ref fn_ty) => fn_ty.sig.clone(),
         _ => ccx.sess.bug("foreign_types_for_fn_ty called on non-function type")
     };
-    let llsig = foreign_signature(ccx, &fn_sig, fn_sig.inputs);
+    let llsig = foreign_signature(ccx, &fn_sig, fn_sig.inputs.as_slice());
     let ret_def = !return_type_is_void(ccx, fn_sig.output);
     let fn_ty = cabi::compute_abi_info(ccx,
-                                       llsig.llarg_tys,
+                                       llsig.llarg_tys.as_slice(),
                                        llsig.llret_ty,
                                        ret_def);
     debug!("foreign_types_for_fn_ty(\
@@ -762,9 +775,9 @@ fn foreign_types_for_fn_ty(ccx: &CrateContext,
            fn_ty={} -> {}, \
            ret_def={}",
            ty.repr(ccx.tcx),
-           ccx.tn.types_to_str(llsig.llarg_tys),
+           ccx.tn.types_to_str(llsig.llarg_tys.as_slice()),
            ccx.tn.type_to_str(llsig.llret_ty),
-           ccx.tn.types_to_str(fn_ty.arg_tys.map(|t| t.ty)),
+           ccx.tn.types_to_str(fn_ty.arg_tys.map(|t| t.ty).as_slice()),
            ccx.tn.type_to_str(fn_ty.ret_ty.ty),
            ret_def);
 
@@ -810,9 +823,9 @@ fn lltype_for_fn_from_foreign_types(tys: &ForeignTypes) -> Type {
     }
 
     if tys.fn_sig.variadic {
-        Type::variadic_func(llargument_tys, &llreturn_ty)
+        Type::variadic_func(llargument_tys.as_slice(), &llreturn_ty)
     } else {
-        Type::func(llargument_tys, &llreturn_ty)
+        Type::func(llargument_tys.as_slice(), &llreturn_ty)
     }
 }
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -56,7 +56,7 @@ struct ForeignTypes {
 
 struct LlvmSignature {
     // LLVM versions of the types of this function's arguments.
-    llarg_tys: ~[Type],
+    llarg_tys: Vec<Type> ,
 
     // LLVM version of the type that this function returns.  Note that
     // this *may not be* the declared return type of the foreign
@@ -163,7 +163,7 @@ pub fn trans_native_call<'a>(
                          llfn: ValueRef,
                          llretptr: ValueRef,
                          llargs_rust: &[ValueRef],
-                         passed_arg_tys: ~[ty::t])
+                         passed_arg_tys: Vec<ty::t> )
                          -> &'a Block<'a> {
     /*!
      * Prepares a call to a native function. This requires adapting
@@ -205,7 +205,7 @@ pub fn trans_native_call<'a>(
 
     let arg_tys: &[cabi::ArgType] = fn_type.arg_tys;
 
-    let mut llargs_foreign = ~[];
+    let mut llargs_foreign = Vec::new();
 
     // If the foreign ABI expects return value by pointer, supply the
     // pointer that Rust gave us. Sometimes we have to bitcast
@@ -503,7 +503,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: @CrateContext,
         llvm::LLVMPositionBuilderAtEnd(builder, the_block);
 
         // Array for the arguments we will pass to the rust function.
-        let mut llrust_args = ~[];
+        let mut llrust_args = Vec::new();
         let mut next_foreign_arg_counter: c_uint = 0;
         let next_foreign_arg: |pad: bool| -> c_uint = |pad: bool| {
             next_foreign_arg_counter += if pad {
@@ -777,7 +777,7 @@ fn foreign_types_for_fn_ty(ccx: &CrateContext,
 }
 
 fn lltype_for_fn_from_foreign_types(tys: &ForeignTypes) -> Type {
-    let mut llargument_tys = ~[];
+    let mut llargument_tys = Vec::new();
 
     let ret_ty = tys.fn_ty.ret_ty;
     let llreturn_ty = if ret_ty.is_indirect() {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -245,7 +245,7 @@ fn trans_struct_drop<'a>(bcx: &'a Block<'a>,
 
     // Find and call the actual destructor
     let dtor_addr = get_res_dtor(bcx.ccx(), dtor_did,
-                                 class_did, substs.tps.clone());
+                                 class_did, substs.tps.as_slice());
 
     // The second argument is the "self" argument for drop
     let params = unsafe {
@@ -262,7 +262,7 @@ fn trans_struct_drop<'a>(bcx: &'a Block<'a>,
     // destructors if the user destructor fails.
     let field_scope = bcx.fcx.push_custom_cleanup_scope();
 
-    let self_arg = PointerCast(bcx, v0, params[0]);
+    let self_arg = PointerCast(bcx, v0, *params.get(0));
     let args = vec!(self_arg);
 
     // Add all the fields as a value which needs to be cleaned at the end of

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -263,7 +263,7 @@ fn trans_struct_drop<'a>(bcx: &'a Block<'a>,
     let field_scope = bcx.fcx.push_custom_cleanup_scope();
 
     let self_arg = PointerCast(bcx, v0, params[0]);
-    let args = ~[self_arg];
+    let args = vec!(self_arg);
 
     // Add all the fields as a value which needs to be cleaned at the end of
     // this scope.

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -25,6 +25,7 @@ use middle::trans::machine;
 use middle::trans::machine::llsize_of;
 use middle::trans::type_::Type;
 use middle::ty;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::parse::token;
@@ -212,7 +213,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
         let order = if split.len() == 2 {
             lib::llvm::SequentiallyConsistent
         } else {
-            match split[2] {
+            match *split.get(2) {
                 "relaxed" => lib::llvm::Monotonic,
                 "acq"     => lib::llvm::Acquire,
                 "rel"     => lib::llvm::Release,
@@ -221,7 +222,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             }
         };
 
-        match split[1] {
+        match *split.get(1) {
             "cxchg" => {
                 let old = AtomicCmpXchg(bcx, get_param(decl, first_real_arg),
                                         get_param(decl, first_real_arg + 1u),
@@ -284,7 +285,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             RetVoid(bcx);
         }
         "size_of" => {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llsize_of_real(ccx, lltp_ty) as uint));
         }
@@ -294,7 +295,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             // if the value is non-immediate. Note that, with
             // intrinsics, there are no argument cleanups to
             // concern ourselves with, so we can use an rvalue datum.
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             let mode = appropriate_rvalue_mode(ccx, tp_ty);
             let src = Datum {val: get_param(decl, first_real_arg + 1u),
                              ty: tp_ty,
@@ -303,17 +304,17 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             RetVoid(bcx);
         }
         "min_align_of" => {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_min(ccx, lltp_ty) as uint));
         }
         "pref_align_of"=> {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_pref(ccx, lltp_ty) as uint));
         }
         "get_tydesc" => {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             let static_ti = get_tydesc(ccx, tp_ty);
             glue::lazily_emit_visit_glue(ccx, static_ti);
 
@@ -328,7 +329,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
         "type_id" => {
             let hash = ty::hash_crate_independent(
                 ccx.tcx,
-                substs.tys[0],
+                *substs.tys.get(0),
                 &ccx.link_meta.crate_hash);
             // NB: This needs to be kept in lockstep with the TypeId struct in
             //     libstd/unstable/intrinsics.rs
@@ -342,7 +343,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             }
         }
         "init" => {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             match bcx.fcx.llretptr.get() {
                 Some(ptr) => { Store(bcx, C_null(lltp_ty), ptr); RetVoid(bcx); }
@@ -352,7 +353,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
         }
         "uninit" => {
             // Do nothing, this is effectively a no-op
-            let retty = substs.tys[0];
+            let retty = *substs.tys.get(0);
             if type_is_immediate(ccx, retty) && !return_type_is_void(ccx, retty) {
                 unsafe {
                     Ret(bcx, lib::llvm::llvm::LLVMGetUndef(type_of(ccx, retty).to_ref()));
@@ -365,7 +366,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             RetVoid(bcx);
         }
         "transmute" => {
-            let (in_type, out_type) = (substs.tys[0], substs.tys[1]);
+            let (in_type, out_type) = (*substs.tys.get(0), *substs.tys.get(1));
             let llintype = type_of::type_of(ccx, in_type);
             let llouttype = type_of::type_of(ccx, out_type);
 
@@ -432,11 +433,11 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             }
         }
         "needs_drop" => {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             Ret(bcx, C_bool(ty::type_needs_drop(ccx.tcx, tp_ty)));
         }
         "owns_managed" => {
-            let tp_ty = substs.tys[0];
+            let tp_ty = *substs.tys.get(0);
             Ret(bcx, C_bool(ty::type_contents(ccx.tcx, tp_ty).owns_managed()));
         }
         "visit_tydesc" => {
@@ -452,9 +453,11 @@ pub fn trans_intrinsic(ccx: @CrateContext,
             let lladdr = InBoundsGEP(bcx, ptr, [offset]);
             Ret(bcx, lladdr);
         }
-        "copy_nonoverlapping_memory" => copy_intrinsic(bcx, false, substs.tys[0]),
-        "copy_memory" => copy_intrinsic(bcx, true, substs.tys[0]),
-        "set_memory" => memset_intrinsic(bcx, substs.tys[0]),
+        "copy_nonoverlapping_memory" => {
+            copy_intrinsic(bcx, false, *substs.tys.get(0))
+        }
+        "copy_memory" => copy_intrinsic(bcx, true, *substs.tys.get(0)),
+        "set_memory" => memset_intrinsic(bcx, *substs.tys.get(0)),
         "ctlz8" => count_zeros_intrinsic(bcx, "llvm.ctlz.i8"),
         "ctlz16" => count_zeros_intrinsic(bcx, "llvm.ctlz.i16"),
         "ctlz32" => count_zeros_intrinsic(bcx, "llvm.ctlz.i32"),

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -207,7 +207,7 @@ pub fn trans_intrinsic(ccx: @CrateContext,
     // This requires that atomic intrinsics follow a specific naming pattern:
     // "atomic_<operation>[_<ordering>], and no ordering means SeqCst
     if name.get().starts_with("atomic_") {
-        let split: ~[&str] = name.get().split('_').collect();
+        let split: Vec<&str> = name.get().split('_').collect();
         assert!(split.len() >= 2, "Atomic intrinsic not correct format");
         let order = if split.len() == 2 {
             lib::llvm::SequentiallyConsistent

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -292,7 +292,7 @@ fn combine_impl_and_methods_tps(bcx: &Block,
                                 is_method: bool,
                                 rcvr_substs: &[ty::t],
                                 rcvr_origins: typeck::vtable_res)
-                                -> (~[ty::t], typeck::vtable_res) {
+                                -> (Vec<ty::t> , typeck::vtable_res) {
     /*!
     *
     * Creates a concatenated set of substitutions which includes
@@ -316,7 +316,7 @@ fn combine_impl_and_methods_tps(bcx: &Block,
     let node_substs = node_id_type_params(bcx, expr_id, is_method);
     debug!("rcvr_substs={:?}", rcvr_substs.repr(ccx.tcx));
     let ty_substs
-        = vec::append(rcvr_substs.to_owned(),
+        = vec_ng::append(rcvr_substs.to_owned(),
                       node_substs.tailn(node_substs.len() - n_m_tps));
     debug!("n_m_tps={:?}", n_m_tps);
     debug!("node_substs={:?}", node_substs.repr(ccx.tcx));
@@ -327,10 +327,10 @@ fn combine_impl_and_methods_tps(bcx: &Block,
     // exist, in which case we need to make them.
     let r_m_origins = match node_vtables(bcx, expr_id) {
         Some(vt) => vt,
-        None => @vec::from_elem(node_substs.len(), @~[])
+        None => @vec::from_elem(node_substs.len(), @Vec::new())
     };
     let vtables
-        = @vec::append(rcvr_origins.to_owned(),
+        = @vec_ng::append(rcvr_origins.to_owned(),
                        r_m_origins.tailn(r_m_origins.len() - n_m_tps));
 
     (ty_substs, vtables)
@@ -496,7 +496,7 @@ pub fn make_vtable(ccx: &CrateContext,
     unsafe {
         let _icx = push_ctxt("meth::make_vtable");
 
-        let mut components = ~[drop_glue];
+        let mut components = vec!(drop_glue);
         for &ptr in ptrs.iter() {
             components.push(ptr)
         }
@@ -517,7 +517,7 @@ fn emit_vtable_methods(bcx: &Block,
                        impl_id: ast::DefId,
                        substs: &[ty::t],
                        vtables: typeck::vtable_res)
-                       -> ~[ValueRef] {
+                       -> Vec<ValueRef> {
     let ccx = bcx.ccx();
     let tcx = ccx.tcx;
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -25,16 +25,16 @@ use middle::trans::expr::{SaveIn, Ignore};
 use middle::trans::expr;
 use middle::trans::glue;
 use middle::trans::monomorphize;
+use middle::trans::type_::Type;
 use middle::trans::type_of::*;
 use middle::ty;
 use middle::typeck;
 use util::common::indenter;
 use util::ppaux::Repr;
 
-use middle::trans::type_::Type;
-
 use std::c_str::ToCStr;
-use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::parse::token;
 use syntax::{ast, ast_map, visit};
 
@@ -202,18 +202,21 @@ pub fn trans_static_method_callee(bcx: &Block,
     let vtbls = ccx.maps.vtable_map.borrow().get().get_copy(&expr_id);
     let vtbls = resolve_vtables_in_fn_ctxt(bcx.fcx, vtbls);
 
-    match vtbls[bound_index][0] {
-        typeck::vtable_static(impl_did, ref rcvr_substs, rcvr_origins) => {
+    match vtbls.get(bound_index).get(0) {
+        &typeck::vtable_static(impl_did, ref rcvr_substs, rcvr_origins) => {
             assert!(rcvr_substs.iter().all(|t| !ty::type_needs_infer(*t)));
 
             let mth_id = method_with_name(ccx, impl_did, mname);
             let (callee_substs, callee_origins) =
                 combine_impl_and_methods_tps(
                     bcx, mth_id, expr_id, false,
-                    *rcvr_substs, rcvr_origins);
+                    rcvr_substs.as_slice(), rcvr_origins);
 
-            let llfn = trans_fn_ref_with_vtables(bcx, mth_id, expr_id,
-                                                 false, callee_substs,
+            let llfn = trans_fn_ref_with_vtables(bcx,
+                                                 mth_id,
+                                                 expr_id,
+                                                 false,
+                                                 callee_substs.as_slice(),
                                                  Some(callee_origins));
 
             let callee_ty = node_id_type(bcx, expr_id);
@@ -268,14 +271,14 @@ fn trans_monomorphized_callee<'a>(bcx: &'a Block<'a>,
           let (callee_substs, callee_origins) =
               combine_impl_and_methods_tps(
                   bcx, mth_id, expr_id, true,
-                  *rcvr_substs, rcvr_origins);
+                  rcvr_substs.as_slice(), rcvr_origins);
 
           // translate the function
           let llfn = trans_fn_ref_with_vtables(bcx,
                                                mth_id,
                                                expr_id,
                                                true,
-                                               callee_substs,
+                                               callee_substs.as_slice(),
                                                Some(callee_origins));
 
           Callee { bcx: bcx, data: Fn(llfn) }
@@ -316,8 +319,8 @@ fn combine_impl_and_methods_tps(bcx: &Block,
     let node_substs = node_id_type_params(bcx, expr_id, is_method);
     debug!("rcvr_substs={:?}", rcvr_substs.repr(ccx.tcx));
     let ty_substs
-        = vec_ng::append(rcvr_substs.to_owned(),
-                      node_substs.tailn(node_substs.len() - n_m_tps));
+        = vec_ng::append(Vec::from_slice(rcvr_substs),
+                         node_substs.tailn(node_substs.len() - n_m_tps));
     debug!("n_m_tps={:?}", n_m_tps);
     debug!("node_substs={:?}", node_substs.repr(ccx.tcx));
     debug!("ty_substs={:?}", ty_substs.repr(ccx.tcx));
@@ -327,11 +330,11 @@ fn combine_impl_and_methods_tps(bcx: &Block,
     // exist, in which case we need to make them.
     let r_m_origins = match node_vtables(bcx, expr_id) {
         Some(vt) => vt,
-        None => @vec::from_elem(node_substs.len(), @Vec::new())
+        None => @Vec::from_elem(node_substs.len(), @Vec::new())
     };
     let vtables
-        = @vec_ng::append(rcvr_origins.to_owned(),
-                       r_m_origins.tailn(r_m_origins.len() - n_m_tps));
+        = @vec_ng::append(Vec::from_slice(rcvr_origins.as_slice()),
+                          r_m_origins.tailn(r_m_origins.len() - n_m_tps));
 
     (ty_substs, vtables)
 }
@@ -460,7 +463,7 @@ pub fn get_vtable(bcx: &Block,
     let _icx = push_ctxt("meth::get_vtable");
 
     // Check the cache.
-    let hash_id = (self_ty, vtable_id(ccx, &origins[0]));
+    let hash_id = (self_ty, vtable_id(ccx, origins.get(0)));
     {
         let vtables = ccx.vtables.borrow();
         match vtables.get().find(&hash_id) {
@@ -470,18 +473,25 @@ pub fn get_vtable(bcx: &Block,
     }
 
     // Not in the cache. Actually build it.
-    let methods = origins.flat_map(|origin| {
+    let mut methods = Vec::new();
+    for origin in origins.iter() {
         match *origin {
             typeck::vtable_static(id, ref substs, sub_vtables) => {
-                emit_vtable_methods(bcx, id, *substs, sub_vtables)
+                let vtable_methods = emit_vtable_methods(bcx,
+                                                         id,
+                                                         substs.as_slice(),
+                                                         sub_vtables);
+                for vtable_method in vtable_methods.move_iter() {
+                    methods.push(vtable_method)
+                }
             }
             _ => ccx.sess.bug("get_vtable: expected a static origin"),
         }
-    });
+    }
 
     // Generate a destructor for the vtable.
     let drop_glue = glue::get_drop_glue(ccx, self_ty);
-    let vtable = make_vtable(ccx, drop_glue, methods);
+    let vtable = make_vtable(ccx, drop_glue, methods.as_slice());
 
     let mut vtables = ccx.vtables.borrow_mut();
     vtables.get().insert(hash_id, vtable);
@@ -501,7 +511,7 @@ pub fn make_vtable(ccx: &CrateContext,
             components.push(ptr)
         }
 
-        let tbl = C_struct(components, false);
+        let tbl = C_struct(components.as_slice(), false);
         let sym = token::gensym("vtable");
         let vt_gvar = format!("vtable{}", sym).with_c_str(|buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl).to_ref(), buf)
@@ -589,7 +599,7 @@ pub fn trans_trait_cast<'a>(bcx: &'a Block<'a>,
             *vtable_map.get().get(&id)
         };
         let res = resolve_vtables_in_fn_ctxt(bcx.fcx, res);
-        res[0]
+        *res.get(0)
     };
     let vtable = get_vtable(bcx, v_ty, origins);
     let llvtabledest = GEPi(bcx, lldest, [0u, abi::trt_field_vtable]);

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -299,7 +299,7 @@ pub fn make_mono_id(ccx: @CrateContext,
     // FIXME (possibly #5801): Need a lot of type hints to get
     // .collect() to work.
     let substs_iter = substs.self_ty.iter().chain(substs.tys.iter());
-    let precise_param_ids: ~[(ty::t, Option<@~[mono_id]>)] = match substs.vtables {
+    let precise_param_ids: Vec<(ty::t, Option<@Vec<mono_id> >)> = match substs.vtables {
       Some(vts) => {
         debug!("make_mono_id vtables={} substs={}",
                vts.repr(ccx.tcx), substs.tys.repr(ccx.tcx));
@@ -309,7 +309,7 @@ pub fn make_mono_id(ccx: @CrateContext,
             (*subst, if !v.is_empty() { Some(@v) } else { None })
         }).collect()
       }
-      None => substs_iter.map(|subst| (*subst, None::<@~[mono_id]>)).collect()
+      None => substs_iter.map(|subst| (*subst, None::<@Vec<mono_id> >)).collect()
     };
 
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -23,6 +23,7 @@ use middle::ty;
 use middle::typeck;
 use util::ppaux::Repr;
 
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::local_def;
@@ -51,7 +52,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
     let mut must_cast = false;
 
     let psubsts = @param_substs {
-        tys: real_substs.tps.to_owned(),
+        tys: real_substs.tps.clone(),
         vtables: vtables,
         self_ty: real_substs.self_ty.clone(),
         self_vtables: self_vtables
@@ -124,7 +125,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
 
     debug!("monomorphic_fn about to subst into {}", llitem_ty.repr(ccx.tcx));
     let mono_ty = match is_static_provided {
-        None => ty::subst_tps(ccx.tcx, psubsts.tys,
+        None => ty::subst_tps(ccx.tcx, psubsts.tys.as_slice(),
                               psubsts.self_ty, llitem_ty),
         Some(num_method_ty_params) => {
             // Static default methods are a little unfortunate, in
@@ -186,7 +187,7 @@ pub fn monomorphic_fn(ccx: @CrateContext,
 
     let mk_lldecl = || {
         let lldecl = decl_internal_rust_fn(ccx, false,
-                                           f.sig.inputs,
+                                           f.sig.inputs.as_slice(),
                                            f.sig.output, s);
         let mut monomorphized = ccx.monomorphized.borrow_mut();
         monomorphized.get().insert(hash_id, lldecl);

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -28,7 +28,8 @@ use util::ppaux::ty_to_str;
 use arena::TypedArena;
 use std::libc::c_uint;
 use std::option::{Some,None};
-use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::ast::DefId;
 use syntax::ast;
 use syntax::ast_map;
@@ -93,12 +94,12 @@ impl<'a> Reflector<'a> {
     pub fn visit(&mut self, ty_name: &str, args: &[ValueRef]) {
         let fcx = self.bcx.fcx;
         let tcx = self.bcx.tcx();
-        let mth_idx = ty::method_idx(
-            token::str_to_ident(~"visit_" + ty_name),
-            *self.visitor_methods).expect(format!("couldn't find visit method \
-                                                for {}", ty_name));
+        let mth_idx = ty::method_idx(token::str_to_ident(~"visit_" + ty_name),
+                                     self.visitor_methods.as_slice()).expect(
+                format!("couldn't find visit method for {}", ty_name));
         let mth_ty =
-            ty::mk_bare_fn(tcx, self.visitor_methods[mth_idx].fty.clone());
+            ty::mk_bare_fn(tcx,
+                           self.visitor_methods.get(mth_idx).fty.clone());
         let v = self.visitor_val;
         debug!("passing {} args:", args.len());
         let mut bcx = self.bcx;
@@ -134,7 +135,8 @@ impl<'a> Reflector<'a> {
         match vstore {
             ty::vstore_fixed(n) => {
                 let extra = vec_ng::append(vec!(self.c_uint(n)),
-                                        self.c_size_and_align(t));
+                                           self.c_size_and_align(t)
+                                               .as_slice());
                 (~"fixed", extra)
             }
             ty::vstore_slice(_) => (~"slice", Vec::new()),
@@ -172,18 +174,18 @@ impl<'a> Reflector<'a> {
 
           ty::ty_unboxed_vec(ref mt) => {
               let values = self.c_mt(mt);
-              self.visit("vec", values)
+              self.visit("vec", values.as_slice())
           }
 
           // Should rename to str_*/vec_*.
           ty::ty_str(vst) => {
               let (name, extra) = self.vstore_name_and_extra(t, vst);
-              self.visit(~"estr_" + name, extra)
+              self.visit(~"estr_" + name, extra.as_slice())
           }
           ty::ty_vec(ref mt, vst) => {
               let (name, extra) = self.vstore_name_and_extra(t, vst);
-              let extra = extra + self.c_mt(mt);
-              self.visit(~"evec_" + name, extra)
+              let extra = vec_ng::append(extra, self.c_mt(mt).as_slice());
+              self.visit(~"evec_" + name, extra.as_slice())
           }
           // Should remove mt from box and uniq.
           ty::ty_box(typ) => {
@@ -191,31 +193,31 @@ impl<'a> Reflector<'a> {
                   ty: typ,
                   mutbl: ast::MutImmutable,
               });
-              self.visit("box", extra)
+              self.visit("box", extra.as_slice())
           }
           ty::ty_uniq(typ) => {
               let extra = self.c_mt(&ty::mt {
                   ty: typ,
                   mutbl: ast::MutImmutable,
               });
-              self.visit("uniq", extra)
+              self.visit("uniq", extra.as_slice())
           }
           ty::ty_ptr(ref mt) => {
               let extra = self.c_mt(mt);
-              self.visit("ptr", extra)
+              self.visit("ptr", extra.as_slice())
           }
           ty::ty_rptr(_, ref mt) => {
               let extra = self.c_mt(mt);
-              self.visit("rptr", extra)
+              self.visit("rptr", extra.as_slice())
           }
 
           ty::ty_tup(ref tys) => {
-              let extra = vec!(self.c_uint(tys.len()))
-                  + self.c_size_and_align(t);
-              self.bracketed("tup", extra, |this| {
+              let extra = vec_ng::append(vec!(self.c_uint(tys.len())),
+                                         self.c_size_and_align(t).as_slice());
+              self.bracketed("tup", extra.as_slice(), |this| {
                   for (i, t) in tys.iter().enumerate() {
                       let extra = vec!(this.c_uint(i), this.c_tydesc(*t));
-                      this.visit("tup_field", extra);
+                      this.visit("tup_field", extra.as_slice());
                   }
               })
           }
@@ -230,9 +232,9 @@ impl<'a> Reflector<'a> {
                           self.c_uint(sigilval),
                           self.c_uint(fty.sig.inputs.len()),
                           self.c_uint(retval));
-            self.visit("enter_fn", extra);
+            self.visit("enter_fn", extra.as_slice());
             self.visit_sig(retval, &fty.sig);
-            self.visit("leave_fn", extra);
+            self.visit("leave_fn", extra.as_slice());
           }
 
           // FIXME (#2594): fetch constants out of intrinsic:: for the
@@ -245,33 +247,33 @@ impl<'a> Reflector<'a> {
                           self.c_uint(sigilval),
                           self.c_uint(fty.sig.inputs.len()),
                           self.c_uint(retval));
-            self.visit("enter_fn", extra);
+            self.visit("enter_fn", extra.as_slice());
             self.visit_sig(retval, &fty.sig);
-            self.visit("leave_fn", extra);
+            self.visit("leave_fn", extra.as_slice());
           }
 
           ty::ty_struct(did, ref substs) => {
               let fields = ty::struct_fields(tcx, did, substs);
               let mut named_fields = false;
               if !fields.is_empty() {
-                  named_fields =
-                        fields[0].ident.name != special_idents::unnamed_field.name;
+                  named_fields = fields.get(0).ident.name !=
+                      special_idents::unnamed_field.name;
               }
 
-              let extra = vec!(
+              let extra = vec_ng::append(vec!(
                   self.c_slice(token::intern_and_get_ident(ty_to_str(tcx,
                                                                      t))),
                   self.c_bool(named_fields),
                   self.c_uint(fields.len())
-              ) + self.c_size_and_align(t);
-              self.bracketed("class", extra, |this| {
+              ), self.c_size_and_align(t).as_slice());
+              self.bracketed("class", extra.as_slice(), |this| {
                   for (i, field) in fields.iter().enumerate() {
-                      let extra = vec!(
+                      let extra = vec_ng::append(vec!(
                         this.c_uint(i),
                         this.c_slice(token::get_ident(field.ident)),
                         this.c_bool(named_fields)
-                      ) + this.c_mt(&field.mt);
-                      this.visit("class_field", extra);
+                      ), this.c_mt(&field.mt).as_slice());
+                      this.visit("class_field", extra.as_slice());
                   }
               })
           }
@@ -319,16 +321,20 @@ impl<'a> Reflector<'a> {
                 llfdecl
             };
 
-            let enum_args = vec!(self.c_uint(variants.len()), make_get_disr())
-                + self.c_size_and_align(t);
-            self.bracketed("enum", enum_args, |this| {
+            let enum_args = vec_ng::append(vec!(self.c_uint(variants.len()),
+                                                make_get_disr()),
+                                           self.c_size_and_align(t)
+                                               .as_slice());
+            self.bracketed("enum", enum_args.as_slice(), |this| {
                 for (i, v) in variants.iter().enumerate() {
                     let name = token::get_ident(v.name);
                     let variant_args = vec!(this.c_uint(i),
                                          C_u64(v.disr_val),
                                          this.c_uint(v.args.len()),
                                          this.c_slice(name));
-                    this.bracketed("enum_variant", variant_args, |this| {
+                    this.bracketed("enum_variant",
+                                   variant_args.as_slice(),
+                                   |this| {
                         for (j, a) in v.args.iter().enumerate() {
                             let bcx = this.bcx;
                             let null = C_null(llptrty);
@@ -337,7 +343,8 @@ impl<'a> Reflector<'a> {
                             let field_args = vec!(this.c_uint(j),
                                                offset,
                                                this.c_tydesc(*a));
-                            this.visit("enum_variant_field", field_args);
+                            this.visit("enum_variant_field",
+                                       field_args.as_slice());
                         }
                     })
                 }
@@ -356,7 +363,7 @@ impl<'a> Reflector<'a> {
           ty::ty_err => self.leaf("err"),
           ty::ty_param(ref p) => {
               let extra = vec!(self.c_uint(p.idx));
-              self.visit("param", extra)
+              self.visit("param", extra.as_slice())
           }
           ty::ty_self(..) => self.leaf("self")
         }
@@ -368,12 +375,12 @@ impl<'a> Reflector<'a> {
             let extra = vec!(self.c_uint(i),
                          self.c_uint(modeval),
                          self.c_tydesc(*arg));
-            self.visit("fn_input", extra);
+            self.visit("fn_input", extra.as_slice());
         }
         let extra = vec!(self.c_uint(retval),
                       self.c_bool(sig.variadic),
                       self.c_tydesc(sig.output));
-        self.visit("fn_output", extra);
+        self.visit("fn_output", extra.as_slice());
     }
 }
 

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -20,8 +20,9 @@ use syntax::ast;
 use syntax::abi::{Architecture, X86, X86_64, Arm, Mips};
 
 use std::c_str::ToCStr;
-use std::vec;
 use std::cast;
+use std::vec;
+use std::vec_ng::Vec;
 
 use std::libc::{c_uint};
 
@@ -301,8 +302,8 @@ impl Type {
             if n_elts == 0 {
                 return Vec::new();
             }
-            let mut elts = vec::from_elem(n_elts, 0 as TypeRef);
-            llvm::LLVMGetStructElementTypes(self.to_ref(), &mut elts[0]);
+            let mut elts = Vec::from_elem(n_elts, 0 as TypeRef);
+            llvm::LLVMGetStructElementTypes(self.to_ref(), elts.get_mut(0));
             cast::transmute(elts)
         }
     }
@@ -314,7 +315,7 @@ impl Type {
     pub fn func_params(&self) -> Vec<Type> {
         unsafe {
             let n_args = llvm::LLVMCountParamTypes(self.to_ref()) as uint;
-            let args = vec::from_elem(n_args, 0 as TypeRef);
+            let args = Vec::from_elem(n_args, 0 as TypeRef);
             llvm::LLVMGetParamTypes(self.to_ref(), args.as_ptr());
             cast::transmute(args)
         }

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -295,11 +295,11 @@ impl Type {
         }
     }
 
-    pub fn field_types(&self) -> ~[Type] {
+    pub fn field_types(&self) -> Vec<Type> {
         unsafe {
             let n_elts = llvm::LLVMCountStructElementTypes(self.to_ref()) as uint;
             if n_elts == 0 {
-                return ~[];
+                return Vec::new();
             }
             let mut elts = vec::from_elem(n_elts, 0 as TypeRef);
             llvm::LLVMGetStructElementTypes(self.to_ref(), &mut elts[0]);
@@ -311,7 +311,7 @@ impl Type {
         ty!(llvm::LLVMGetReturnType(self.to_ref()))
     }
 
-    pub fn func_params(&self) -> ~[Type] {
+    pub fn func_params(&self) -> Vec<Type> {
         unsafe {
             let n_args = llvm::LLVMCountParamTypes(self.to_ref()) as uint;
             let args = vec::from_elem(n_args, 0 as TypeRef);

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -41,7 +41,7 @@ pub fn type_of_explicit_arg(ccx: &CrateContext, arg_ty: ty::t) -> Type {
 
 pub fn type_of_rust_fn(cx: &CrateContext, has_env: bool,
                        inputs: &[ty::t], output: ty::t) -> Type {
-    let mut atys: ~[Type] = ~[];
+    let mut atys: Vec<Type> = Vec::new();
 
     // Arg 0: Output pointer.
     // (if the output type is non-immediate)

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -19,6 +19,7 @@ use util::ppaux::Repr;
 
 use middle::trans::type_::Type;
 
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::opt_vec;
 
@@ -62,9 +63,9 @@ pub fn type_of_rust_fn(cx: &CrateContext, has_env: bool,
 
     // Use the output as the actual return value if it's immediate.
     if use_out_pointer || return_type_is_void(cx, output) {
-        Type::func(atys, &Type::void())
+        Type::func(atys.as_slice(), &Type::void())
     } else {
-        Type::func(atys, &lloutputtype)
+        Type::func(atys.as_slice(), &lloutputtype)
     }
 }
 
@@ -72,11 +73,14 @@ pub fn type_of_rust_fn(cx: &CrateContext, has_env: bool,
 pub fn type_of_fn_from_ty(cx: &CrateContext, fty: ty::t) -> Type {
     match ty::get(fty).sty {
         ty::ty_closure(ref f) => {
-            type_of_rust_fn(cx, true, f.sig.inputs, f.sig.output)
+            type_of_rust_fn(cx, true, f.sig.inputs.as_slice(), f.sig.output)
         }
         ty::ty_bare_fn(ref f) => {
             if f.abis.is_rust() || f.abis.is_intrinsic() {
-                type_of_rust_fn(cx, false, f.sig.inputs, f.sig.output)
+                type_of_rust_fn(cx,
+                                false,
+                                f.sig.inputs.as_slice(),
+                                f.sig.output)
             } else {
                 foreign::lltype_for_foreign_fn(cx, fty)
             }
@@ -216,7 +220,7 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
         // avoids creating more than one copy of the enum when one
         // of the enum's variants refers to the enum itself.
         let repr = adt::represent_type(cx, t);
-        let name = llvm_type_name(cx, an_enum, did, substs.tps);
+        let name = llvm_type_name(cx, an_enum, did, substs.tps.as_slice());
         adt::incomplete_type_of(cx, repr, name)
       }
       ty::ty_box(typ) => {
@@ -277,7 +281,10 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
               // in *after* placing it into the type cache. This prevents
               // infinite recursion with recursive struct types.
               let repr = adt::represent_type(cx, t);
-              let name = llvm_type_name(cx, a_struct, did, substs.tps);
+              let name = llvm_type_name(cx,
+                                        a_struct,
+                                        did,
+                                        substs.tps.as_slice());
               adt::incomplete_type_of(cx, repr, name)
           }
       }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -122,8 +122,7 @@ impl Method {
 pub struct Impl {
     did: DefId,
     ident: Ident,
-    methods: ~[@Method]
-}
+    methods: Vec<@Method> }
 
 #[deriving(Clone, Eq, Hash)]
 pub struct mt {
@@ -280,16 +279,16 @@ pub struct ctxt_ {
     // of this node.  This only applies to nodes that refer to entities
     // parameterized by type parameters, such as generic fns, types, or
     // other items.
-    node_type_substs: RefCell<NodeMap<~[t]>>,
+    node_type_substs: RefCell<NodeMap<vec!(t)>>,
 
     // Maps from a method to the method "descriptor"
     methods: RefCell<DefIdMap<@Method>>,
 
     // Maps from a trait def-id to a list of the def-ids of its methods
-    trait_method_def_ids: RefCell<DefIdMap<@~[DefId]>>,
+    trait_method_def_ids: RefCell<DefIdMap<@Vec<DefId> >>,
 
     // A cache for the trait_methods() routine
-    trait_methods_cache: RefCell<DefIdMap<@~[@Method]>>,
+    trait_methods_cache: RefCell<DefIdMap<@Vec<@Method> >>,
 
     impl_trait_cache: RefCell<DefIdMap<Option<@ty::TraitRef>>>,
 
@@ -305,14 +304,14 @@ pub struct ctxt_ {
     needs_unwind_cleanup_cache: RefCell<HashMap<t, bool>>,
     tc_cache: RefCell<HashMap<uint, TypeContents>>,
     ast_ty_to_ty_cache: RefCell<NodeMap<ast_ty_to_ty_cache_entry>>,
-    enum_var_cache: RefCell<DefIdMap<@~[@VariantInfo]>>,
+    enum_var_cache: RefCell<DefIdMap<@Vec<@VariantInfo> >>,
     ty_param_defs: RefCell<NodeMap<TypeParameterDef>>,
     adjustments: RefCell<NodeMap<@AutoAdjustment>>,
     normalized_cache: RefCell<HashMap<t, t>>,
     lang_items: @middle::lang_items::LanguageItems,
     // A mapping of fake provided method def_ids to the default implementation
     provided_method_sources: RefCell<DefIdMap<ast::DefId>>,
-    supertraits: RefCell<DefIdMap<@~[@TraitRef]>>,
+    supertraits: RefCell<DefIdMap<@Vec<@TraitRef> >>,
 
     // Maps from def-id of a type or region parameter to its
     // (inferred) variance.
@@ -328,12 +327,12 @@ pub struct ctxt_ {
     destructors: RefCell<DefIdSet>,
 
     // Maps a trait onto a list of impls of that trait.
-    trait_impls: RefCell<DefIdMap<@RefCell<~[@Impl]>>>,
+    trait_impls: RefCell<DefIdMap<@RefCell<Vec<@Impl> >>>,
 
     // Maps a def_id of a type to a list of its inherent impls.
     // Contains implementations of methods that are inherent to a type.
     // Methods in these implementations don't need to be exported.
-    inherent_impls: RefCell<DefIdMap<@RefCell<~[@Impl]>>>,
+    inherent_impls: RefCell<DefIdMap<@RefCell<Vec<@Impl> >>>,
 
     // Maps a def_id of an impl to an Impl structure.
     // Note that this contains all of the impls that we know about,
@@ -461,7 +460,7 @@ pub struct ClosureTy {
 #[deriving(Clone, Eq, Hash)]
 pub struct FnSig {
     binder_id: ast::NodeId,
-    inputs: ~[t],
+    inputs: vec!(t),
     output: t,
     variadic: bool
 }
@@ -684,7 +683,7 @@ pub enum RegionSubsts {
 #[deriving(Clone, Eq, Hash)]
 pub struct substs {
     self_ty: Option<ty::t>,
-    tps: ~[t],
+    tps: vec!(t),
     regions: RegionSubsts,
 }
 
@@ -756,7 +755,7 @@ pub enum sty {
     ty_closure(ClosureTy),
     ty_trait(DefId, substs, TraitStore, ast::Mutability, BuiltinBounds),
     ty_struct(DefId, substs),
-    ty_tup(~[t]),
+    ty_tup(vec!(t)),
 
     ty_param(param_ty), // type parameter
     ty_self(DefId), /* special, implicit `self` type parameter;
@@ -836,8 +835,7 @@ pub enum type_err {
 #[deriving(Eq, Hash)]
 pub struct ParamBounds {
     builtin_bounds: BuiltinBounds,
-    trait_bounds: ~[@TraitRef]
-}
+    trait_bounds: Vec<@TraitRef> }
 
 pub type BuiltinBounds = EnumSet<BuiltinBound>;
 
@@ -1006,10 +1004,10 @@ pub struct RegionParameterDef {
 #[deriving(Clone)]
 pub struct Generics {
     /// List of type parameters declared on the item.
-    type_param_defs: Rc<~[TypeParameterDef]>,
+    type_param_defs: Rc<Vec<TypeParameterDef> >,
 
     /// List of region parameters declared on the item.
-    region_param_defs: Rc<~[RegionParameterDef]>,
+    region_param_defs: Rc<Vec<RegionParameterDef> >,
 }
 
 impl Generics {
@@ -1048,7 +1046,7 @@ pub struct ParameterEnvironment {
     self_param_bound: Option<@TraitRef>,
 
     /// Bounds on each numbered type parameter
-    type_param_bounds: ~[ParamBounds],
+    type_param_bounds: Vec<ParamBounds> ,
 }
 
 /// A polytype.
@@ -1412,7 +1410,7 @@ pub fn mk_mut_unboxed_vec(cx: ctxt, ty: t) -> t {
     mk_t(cx, ty_unboxed_vec(mt {ty: ty, mutbl: ast::MutImmutable}))
 }
 
-pub fn mk_tup(cx: ctxt, ts: ~[t]) -> t { mk_t(cx, ty_tup(ts)) }
+pub fn mk_tup(cx: ctxt, ts: vec!(t)) -> t { mk_t(cx, ty_tup(ts)) }
 
 pub fn mk_closure(cx: ctxt, fty: ClosureTy) -> t {
     mk_t(cx, ty_closure(fty))
@@ -2391,7 +2389,7 @@ pub fn type_moves_by_default(cx: ctxt, ty: t) -> bool {
 
 // True if instantiating an instance of `r_ty` requires an instance of `r_ty`.
 pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
-    fn type_requires(cx: ctxt, seen: &mut ~[DefId],
+    fn type_requires(cx: ctxt, seen: &mut Vec<DefId> ,
                      r_ty: t, ty: t) -> bool {
         debug!("type_requires({}, {})?",
                ::util::ppaux::ty_to_str(cx, r_ty),
@@ -2409,7 +2407,7 @@ pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
         return r;
     }
 
-    fn subtypes_require(cx: ctxt, seen: &mut ~[DefId],
+    fn subtypes_require(cx: ctxt, seen: &mut Vec<DefId> ,
                         r_ty: t, ty: t) -> bool {
         debug!("subtypes_require({}, {})?",
                ::util::ppaux::ty_to_str(cx, r_ty),
@@ -2497,7 +2495,7 @@ pub fn is_instantiable(cx: ctxt, r_ty: t) -> bool {
         return r;
     }
 
-    let mut seen = ~[];
+    let mut seen = Vec::new();
     !subtypes_require(cx, &mut seen, r_ty, r_ty)
 }
 
@@ -2518,7 +2516,7 @@ pub enum Representability {
 pub fn is_type_representable(cx: ctxt, ty: t) -> Representability {
 
     // Iterate until something non-representable is found
-    fn find_nonrepresentable<It: Iterator<t>>(cx: ctxt, seen: &mut ~[DefId],
+    fn find_nonrepresentable<It: Iterator<t>>(cx: ctxt, seen: &mut Vec<DefId> ,
                                               mut iter: It) -> Representability {
         for ty in iter {
             let r = type_structurally_recursive(cx, seen, ty);
@@ -2531,7 +2529,7 @@ pub fn is_type_representable(cx: ctxt, ty: t) -> Representability {
 
     // Does the type `ty` directly (without indirection through a pointer)
     // contain any types on stack `seen`?
-    fn type_structurally_recursive(cx: ctxt, seen: &mut ~[DefId],
+    fn type_structurally_recursive(cx: ctxt, seen: &mut Vec<DefId> ,
                                    ty: t) -> Representability {
         debug!("type_structurally_recursive: {}",
                ::util::ppaux::ty_to_str(cx, ty));
@@ -2597,7 +2595,7 @@ pub fn is_type_representable(cx: ctxt, ty: t) -> Representability {
     // To avoid a stack overflow when checking an enum variant or struct that
     // contains a different, structurally recursive type, maintain a stack
     // of seen types and check recursion for each of them (issues #3008, #3779).
-    let mut seen: ~[DefId] = ~[];
+    let mut seen: Vec<DefId> = Vec::new();
     type_structurally_recursive(cx, &mut seen, ty)
 }
 
@@ -2788,10 +2786,10 @@ pub fn node_id_to_type_opt(cx: ctxt, id: ast::NodeId) -> Option<t> {
 }
 
 // FIXME(pcwalton): Makes a copy, bleh. Probably better to not do that.
-pub fn node_id_to_type_params(cx: ctxt, id: ast::NodeId) -> ~[t] {
+pub fn node_id_to_type_params(cx: ctxt, id: ast::NodeId) -> Vec<t> {
     let node_type_substs = cx.node_type_substs.borrow();
     match node_type_substs.get().find(&id) {
-      None => return ~[],
+      None => return Vec::new(),
       Some(ts) => return (*ts).clone(),
     }
 }
@@ -2822,7 +2820,7 @@ pub fn ty_fn_sig(fty: t) -> FnSig {
 }
 
 // Type accessors for substructures of types
-pub fn ty_fn_args(fty: t) -> ~[t] {
+pub fn ty_fn_args(fty: t) -> Vec<t> {
     match get(fty).sty {
         ty_bare_fn(ref f) => f.sig.inputs.clone(),
         ty_closure(ref f) => f.sig.inputs.clone(),
@@ -2925,7 +2923,7 @@ pub fn replace_closure_return_type(tcx: ctxt, fn_type: t, ret_type: t) -> t {
 }
 
 // Returns a vec of all the input and output types of fty.
-pub fn tys_in_fn_sig(sig: &FnSig) -> ~[t] {
+pub fn tys_in_fn_sig(sig: &FnSig) -> Vec<t> {
     vec::append_one(sig.inputs.map(|a| *a), sig.output)
 }
 
@@ -3213,7 +3211,7 @@ impl AutoRef {
 }
 
 pub struct ParamsTy {
-    params: ~[t],
+    params: vec!(t),
     ty: t
 }
 
@@ -3231,7 +3229,7 @@ pub fn expr_has_ty_params(cx: ctxt, expr: &ast::Expr) -> bool {
 }
 
 pub fn method_call_type_param_defs(tcx: ctxt, origin: typeck::MethodOrigin)
-                                   -> Rc<~[TypeParameterDef]> {
+                                   -> Rc<Vec<TypeParameterDef> > {
     match origin {
         typeck::MethodStatic(did) => {
             // n.b.: When we encode impl methods, the bounds
@@ -3250,7 +3248,7 @@ pub fn method_call_type_param_defs(tcx: ctxt, origin: typeck::MethodOrigin)
             // trait itself.  This ought to be harmonized.
             let trait_type_param_defs =
                 lookup_trait_def(tcx, trt_id).generics.type_param_defs();
-            Rc::new(vec::append(
+            Rc::new(vec_ng::append(
                 trait_type_param_defs.to_owned(),
                 ty::trait_method(tcx,
                                  trt_id,
@@ -3480,8 +3478,8 @@ pub fn method_idx(id: ast::Ident, meths: &[@Method]) -> Option<uint> {
 /// Returns a vector containing the indices of all type parameters that appear
 /// in `ty`.  The vector may contain duplicates.  Probably should be converted
 /// to a bitset or some other representation.
-pub fn param_tys_in_type(ty: t) -> ~[param_ty] {
-    let mut rslt = ~[];
+pub fn param_tys_in_type(ty: t) -> Vec<param_ty> {
+    let mut rslt = Vec::new();
     walk_ty(ty, |ty| {
         match get(ty).sty {
           ty_param(p) => {
@@ -3496,8 +3494,8 @@ pub fn param_tys_in_type(ty: t) -> ~[param_ty] {
 pub fn occurs_check(tcx: ctxt, sp: Span, vid: TyVid, rt: t) {
     // Returns a vec of all the type variables occurring in `ty`. It may
     // contain duplicates.  (Integral type vars aren't counted.)
-    fn vars_in_type(ty: t) -> ~[TyVid] {
-        let mut rslt = ~[];
+    fn vars_in_type(ty: t) -> Vec<TyVid> {
+        let mut rslt = Vec::new();
         walk_ty(ty, |ty| {
             match get(ty).sty {
               ty_infer(TyVar(v)) => rslt.push(v),
@@ -3742,7 +3740,7 @@ pub fn provided_source(cx: ctxt, id: ast::DefId) -> Option<ast::DefId> {
     provided_method_sources.get().find(&id).map(|x| *x)
 }
 
-pub fn provided_trait_methods(cx: ctxt, id: ast::DefId) -> ~[@Method] {
+pub fn provided_trait_methods(cx: ctxt, id: ast::DefId) -> Vec<@Method> {
     if is_local(id) {
         {
             match cx.map.find(id.node) {
@@ -3774,7 +3772,7 @@ pub fn provided_trait_methods(cx: ctxt, id: ast::DefId) -> ~[@Method] {
     }
 }
 
-pub fn trait_supertraits(cx: ctxt, id: ast::DefId) -> @~[@TraitRef] {
+pub fn trait_supertraits(cx: ctxt, id: ast::DefId) -> @Vec<@TraitRef> {
     // Check the cache.
     {
         let supertraits = cx.supertraits.borrow();
@@ -3796,7 +3794,7 @@ pub fn trait_supertraits(cx: ctxt, id: ast::DefId) -> @~[@TraitRef] {
     return result;
 }
 
-pub fn trait_ref_supertraits(cx: ctxt, trait_ref: &ty::TraitRef) -> ~[@TraitRef] {
+pub fn trait_ref_supertraits(cx: ctxt, trait_ref: &ty::TraitRef) -> Vec<@TraitRef> {
     let supertrait_refs = trait_supertraits(cx, trait_ref.def_id);
     supertrait_refs.map(
         |supertrait_ref| supertrait_ref.subst(cx, &trait_ref.substs))
@@ -3836,7 +3834,7 @@ pub fn trait_method(cx: ctxt, trait_did: ast::DefId, idx: uint) -> @Method {
 }
 
 
-pub fn trait_methods(cx: ctxt, trait_did: ast::DefId) -> @~[@Method] {
+pub fn trait_methods(cx: ctxt, trait_did: ast::DefId) -> @Vec<@Method> {
     let mut trait_methods_cache = cx.trait_methods_cache.borrow_mut();
     match trait_methods_cache.get().find(&trait_did) {
         Some(&methods) => methods,
@@ -3856,7 +3854,7 @@ pub fn method(cx: ctxt, id: ast::DefId) -> @Method {
     })
 }
 
-pub fn trait_method_def_ids(cx: ctxt, id: ast::DefId) -> @~[DefId] {
+pub fn trait_method_def_ids(cx: ctxt, id: ast::DefId) -> @Vec<DefId> {
     let mut trait_method_def_ids = cx.trait_method_def_ids.borrow_mut();
     lookup_locally_or_in_crate_store("trait_method_def_ids",
                                      id,
@@ -3934,8 +3932,8 @@ pub fn ty_to_def_id(ty: t) -> Option<ast::DefId> {
 // Enum information
 #[deriving(Clone)]
 pub struct VariantInfo {
-    args: ~[t],
-    arg_names: Option<~[ast::Ident]>,
+    args: vec!(t),
+    arg_names: Option<Vec<ast::Ident> >,
     ctor_ty: t,
     name: ast::Ident,
     id: ast::DefId,
@@ -3955,7 +3953,7 @@ impl VariantInfo {
 
         match ast_variant.node.kind {
             ast::TupleVariantKind(ref args) => {
-                let arg_tys = if args.len() > 0 { ty_fn_args(ctor_ty).map(|a| *a) } else { ~[] };
+                let arg_tys = if args.len() > 0 { ty_fn_args(ctor_ty).map(|a| *a) } else { Vec::new() };
 
                 return VariantInfo {
                     args: arg_tys,
@@ -3999,7 +3997,7 @@ impl VariantInfo {
 pub fn substd_enum_variants(cx: ctxt,
                             id: ast::DefId,
                             substs: &substs)
-                         -> ~[@VariantInfo] {
+                         -> Vec<@VariantInfo> {
     enum_variants(cx, id).iter().map(|variant_info| {
         let substd_args = variant_info.args.iter()
             .map(|aty| subst(cx, substs, *aty)).collect();
@@ -4080,7 +4078,7 @@ pub fn type_is_empty(cx: ctxt, t: t) -> bool {
      }
 }
 
-pub fn enum_variants(cx: ctxt, id: ast::DefId) -> @~[@VariantInfo] {
+pub fn enum_variants(cx: ctxt, id: ast::DefId) -> @Vec<@VariantInfo> {
     {
         let enum_var_cache = cx.enum_var_cache.borrow();
         match enum_var_cache.get().find(&id) {
@@ -4295,7 +4293,7 @@ pub fn lookup_field_type(tcx: ctxt,
 
 // Look up the list of field names and IDs for a given struct
 // Fails if the id is not bound to a struct.
-pub fn lookup_struct_fields(cx: ctxt, did: ast::DefId) -> ~[field_ty] {
+pub fn lookup_struct_fields(cx: ctxt, did: ast::DefId) -> Vec<field_ty> {
   if did.krate == ast::LOCAL_CRATE {
       {
           match cx.map.find(did.node) {
@@ -4342,7 +4340,7 @@ pub fn lookup_struct_field(cx: ctxt,
     }
 }
 
-fn struct_field_tys(fields: &[StructField]) -> ~[field_ty] {
+fn struct_field_tys(fields: &[StructField]) -> Vec<field_ty> {
     fields.map(|field| {
         match field.node.kind {
             NamedField(ident, visibility) => {
@@ -4366,7 +4364,7 @@ fn struct_field_tys(fields: &[StructField]) -> ~[field_ty] {
 // Returns a list of fields corresponding to the struct's items. trans uses
 // this. Takes a list of substs with which to instantiate field types.
 pub fn struct_fields(cx: ctxt, did: ast::DefId, substs: &substs)
-                     -> ~[field] {
+                     -> Vec<field> {
     lookup_struct_fields(cx, did).map(|f| {
        field {
             // FIXME #6993: change type of field to Name and get rid of new()
@@ -4451,7 +4449,7 @@ pub fn is_binopable(cx: ctxt, ty: t, op: ast::BinOp) -> bool {
     return tbl[tycat(cx, ty)][opcat(op)];
 }
 
-pub fn ty_params_to_tys(tcx: ty::ctxt, generics: &ast::Generics) -> ~[t] {
+pub fn ty_params_to_tys(tcx: ty::ctxt, generics: &ast::Generics) -> Vec<t> {
     vec::from_fn(generics.ty_params.len(), |i| {
         let id = generics.ty_params.get(i).id;
         ty::mk_param(tcx, i, ast_util::local_def(id))
@@ -4607,7 +4605,7 @@ pub fn each_bound_trait_and_supertraits(tcx: ctxt,
                                         -> bool {
     for &bound_trait_ref in bounds.iter() {
         let mut supertrait_set = HashMap::new();
-        let mut trait_refs = ~[];
+        let mut trait_refs = Vec::new();
         let mut i = 0;
 
         // Seed the worklist with the trait from the bound
@@ -4681,7 +4679,7 @@ pub fn visitor_object_ty(tcx: ctxt,
     let substs = substs {
         regions: ty::NonerasedRegions(opt_vec::Empty),
         self_ty: None,
-        tps: ~[]
+        tps: Vec::new()
     };
     let trait_ref = @TraitRef { def_id: trait_lang_item, substs: substs };
     Ok((trait_ref,
@@ -4708,7 +4706,7 @@ fn record_trait_implementation(tcx: ctxt,
     let mut trait_impls = tcx.trait_impls.borrow_mut();
     match trait_impls.get().find(&trait_def_id) {
         None => {
-            implementation_list = @RefCell::new(~[]);
+            implementation_list = @RefCell::new(Vec::new());
             trait_impls.get().insert(trait_def_id, implementation_list);
         }
         Some(&existing_implementation_list) => {
@@ -4763,7 +4761,7 @@ pub fn populate_implementations_for_type_if_necessary(tcx: ctxt,
             let mut inherent_impls = tcx.inherent_impls.borrow_mut();
             match inherent_impls.get().find(&type_id) {
                 None => {
-                    implementation_list = @RefCell::new(~[]);
+                    implementation_list = @RefCell::new(Vec::new());
                     inherent_impls.get().insert(type_id, implementation_list);
                 }
                 Some(&existing_implementation_list) => {
@@ -5128,7 +5126,7 @@ impl substs {
     pub fn empty() -> substs {
         substs {
             self_ty: None,
-            tps: ~[],
+            tps: Vec::new(),
             regions: NonerasedRegions(opt_vec::Empty)
         }
     }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -13,6 +13,8 @@
 use middle::ty;
 use util::ppaux::Repr;
 
+use std::vec_ng::Vec;
+
 pub trait TypeFolder {
     fn tcx(&self) -> ty::ctxt;
 
@@ -84,10 +86,8 @@ pub fn fold_opt_ty<T:TypeFolder>(this: &mut T,
     t.map(|t| this.fold_ty(t))
 }
 
-pub fn fold_ty_vec<T:TypeFolder>(this: &mut T,
-                                 tys: &[ty::t])
-                                 -> Vec<ty::t> {
-    tys.map(|t| this.fold_ty(*t))
+pub fn fold_ty_vec<T:TypeFolder>(this: &mut T, tys: &[ty::t]) -> Vec<ty::t> {
+    tys.iter().map(|t| this.fold_ty(*t)).collect()
 }
 
 pub fn super_fold_ty<T:TypeFolder>(this: &mut T,
@@ -110,14 +110,14 @@ pub fn super_fold_substs<T:TypeFolder>(this: &mut T,
 
     ty::substs { regions: regions,
                  self_ty: fold_opt_ty(this, substs.self_ty),
-                 tps: fold_ty_vec(this, substs.tps), }
+                 tps: fold_ty_vec(this, substs.tps.as_slice()), }
 }
 
 pub fn super_fold_sig<T:TypeFolder>(this: &mut T,
                                     sig: &ty::FnSig)
                                     -> ty::FnSig {
     ty::FnSig { binder_id: sig.binder_id,
-                inputs: fold_ty_vec(this, sig.inputs),
+                inputs: fold_ty_vec(this, sig.inputs.as_slice()),
                 output: this.fold_ty(sig.output),
                 variadic: sig.variadic }
 }
@@ -166,7 +166,7 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
                      bounds)
         }
         ty::ty_tup(ref ts) => {
-            ty::ty_tup(fold_ty_vec(this, *ts))
+            ty::ty_tup(fold_ty_vec(this, ts.as_slice()))
         }
         ty::ty_bare_fn(ref f) => {
             ty::ty_bare_fn(this.fold_bare_fn_ty(f))

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -86,7 +86,7 @@ pub fn fold_opt_ty<T:TypeFolder>(this: &mut T,
 
 pub fn fold_ty_vec<T:TypeFolder>(this: &mut T,
                                  tys: &[ty::t])
-                                 -> ~[ty::t] {
+                                 -> Vec<ty::t> {
     tys.map(|t| this.fold_ty(*t))
 }
 

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -136,7 +136,7 @@ fn opt_ast_region_to_region<AC:AstConv,RS:RegionScope>(
                 }
 
                 Ok(rs) => {
-                    rs[0]
+                    *rs.get(0)
                 }
             }
         }
@@ -791,7 +791,11 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope>(
         let expected_arg_ty = expected_sig.as_ref().and_then(|e| {
             // no guarantee that the correct number of expected args
             // were supplied
-            if i < e.inputs.len() {Some(e.inputs[i])} else {None}
+            if i < e.inputs.len() {
+                Some(*e.inputs.get(i))
+            } else {
+                None
+            }
         });
         ty_of_arg(this, &rb, a, expected_arg_ty)
     }).collect();

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -115,7 +115,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
     let fcx = pcx.fcx;
     let tcx = pcx.fcx.ccx.tcx;
 
-    let arg_types: ~[ty::t];
+    let arg_types: Vec<ty::t> ;
     let kind_name;
 
     // structure_of requires type variables to be resolved.
@@ -295,7 +295,7 @@ pub fn check_struct_pat_fields(pcx: &pat_ctxt,
                                span: Span,
                                path: &ast::Path,
                                fields: &[ast::FieldPat],
-                               class_fields: ~[ty::field_ty],
+                               class_fields: Vec<ty::field_ty> ,
                                class_id: ast::DefId,
                                substitutions: &ty::substs,
                                etc: bool) {
@@ -562,7 +562,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
                                           supplied_def_id,
                                           &ty::substs {
                                               self_ty: None,
-                                              tps: ~[],
+                                              tps: Vec::new(),
                                               regions: ty::ErasedRegions,
                                           });
                     }

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -319,7 +319,7 @@ pub fn check_struct_pat_fields(pcx: &pat_ctxt,
             }
             Some(&(index, ref mut used)) => {
                 *used = true;
-                let class_field = class_fields[index];
+                let class_field = *class_fields.get(index);
                 let field_type = ty::lookup_field_type(tcx,
                                                        class_id,
                                                        class_field.id,
@@ -585,7 +585,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
         match *s {
             ty::ty_tup(ref ex_elts) if e_count == ex_elts.len() => {
                 for (i, elt) in elts.iter().enumerate() {
-                    check_pat(pcx, *elt, ex_elts[i]);
+                    check_pat(pcx, *elt, *ex_elts.get(i));
                 }
                 fcx.write_ty(pat.id, expected);
             }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -139,8 +139,8 @@ pub fn lookup(
         m_name: m_name,
         supplied_tps: supplied_tps,
         impl_dups: @RefCell::new(HashSet::new()),
-        inherent_candidates: @RefCell::new(~[]),
-        extension_candidates: @RefCell::new(~[]),
+        inherent_candidates: @RefCell::new(Vec::new()),
+        extension_candidates: @RefCell::new(Vec::new()),
         deref_args: deref_args,
         check_traits: check_traits,
         autoderef_receiver: autoderef_receiver,
@@ -184,8 +184,8 @@ pub fn lookup_in_trait(
         m_name: m_name,
         supplied_tps: supplied_tps,
         impl_dups: @RefCell::new(HashSet::new()),
-        inherent_candidates: @RefCell::new(~[]),
-        extension_candidates: @RefCell::new(~[]),
+        inherent_candidates: @RefCell::new(Vec::new()),
+        extension_candidates: @RefCell::new(Vec::new()),
         deref_args: check::DoDerefArgs,
         check_traits: CheckTraitsOnly,
         autoderef_receiver: autoderef_receiver,
@@ -208,8 +208,8 @@ pub struct LookupContext<'a> {
     m_name: ast::Name,
     supplied_tps: &'a [ty::t],
     impl_dups: @RefCell<HashSet<DefId>>,
-    inherent_candidates: @RefCell<~[Candidate]>,
-    extension_candidates: @RefCell<~[Candidate]>,
+    inherent_candidates: @RefCell<Vec<Candidate> >,
+    extension_candidates: @RefCell<Vec<Candidate> >,
     deref_args: check::DerefArgs,
     check_traits: CheckTraitsFlag,
     autoderef_receiver: AutoderefReceiverFlag,
@@ -311,8 +311,8 @@ impl<'a> LookupContext<'a> {
     // Candidate collection (see comment at start of file)
 
     fn reset_candidates(&self) {
-        self.inherent_candidates.set(~[]);
-        self.extension_candidates.set(~[]);
+        self.inherent_candidates.set(Vec::new());
+        self.extension_candidates.set(Vec::new());
     }
 
     fn push_inherent_candidates(&self, self_ty: ty::t) {
@@ -584,7 +584,7 @@ impl<'a> LookupContext<'a> {
     }
 
     fn push_candidates_from_impl(&self,
-                                     candidates: &mut ~[Candidate],
+                                     candidates: &mut Vec<Candidate> ,
                                      impl_info: &ty::Impl) {
         {
             let mut impl_dups = self.impl_dups.borrow_mut();
@@ -892,10 +892,10 @@ impl<'a> LookupContext<'a> {
 
     fn consider_candidates(&self,
                            rcvr_ty: ty::t,
-                           candidates: &mut ~[Candidate])
+                           candidates: &mut Vec<Candidate> )
                            -> Option<MethodCallee> {
         // FIXME(pcwalton): Do we need to clone here?
-        let relevant_candidates: ~[Candidate] =
+        let relevant_candidates: Vec<Candidate> =
             candidates.iter().map(|c| (*c).clone()).
                 filter(|c| self.is_relevant(rcvr_ty, c)).collect();
 
@@ -917,8 +917,8 @@ impl<'a> LookupContext<'a> {
         Some(self.confirm_candidate(rcvr_ty, &relevant_candidates[0]))
     }
 
-    fn merge_candidates(&self, candidates: &[Candidate]) -> ~[Candidate] {
-        let mut merged = ~[];
+    fn merge_candidates(&self, candidates: &[Candidate]) -> Vec<Candidate> {
+        let mut merged = Vec::new();
         let mut i = 0;
         while i < candidates.len() {
             let candidate_a = &candidates[i];
@@ -1011,7 +1011,7 @@ impl<'a> LookupContext<'a> {
         // Construct the full set of type parameters for the method,
         // which is equal to the class tps + the method tps.
         let all_substs = substs {
-            tps: vec::append(candidate.rcvr_substs.tps.clone(), m_substs),
+            tps: vec_ng::append(candidate.rcvr_substs.tps.clone(), m_substs),
             regions: candidate.rcvr_substs.regions.clone(),
             self_ty: candidate.rcvr_substs.self_ty,
         };

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -100,7 +100,8 @@ use util::ppaux::Repr;
 use std::cell::RefCell;
 use collections::HashSet;
 use std::result;
-use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::ast::{DefId, SelfValue, SelfRegion};
 use syntax::ast::{SelfUniq, SelfStatic};
 use syntax::ast::{MutMutable, MutImmutable};
@@ -450,7 +451,7 @@ impl<'a> LookupContext<'a> {
                 self.get_method_index(new_trait_ref, trait_ref, method_num);
             let mut m = (*m).clone();
             // We need to fix up the transformed self type.
-            m.fty.sig.inputs[0] =
+            *m.fty.sig.inputs.get_mut(0) =
                 self.construct_transformed_self_ty_for_object(
                     did, &rcvr_substs, &m);
 
@@ -476,7 +477,13 @@ impl<'a> LookupContext<'a> {
                param_ty);
         self.push_inherent_candidates_from_bounds(
             rcvr_ty,
-            self.fcx.inh.param_env.type_param_bounds[param_ty.idx].trait_bounds,
+            self.fcx
+                .inh
+                .param_env
+                .type_param_bounds
+                .get(param_ty.idx)
+                .trait_bounds
+                .as_slice(),
             restrict_to,
             param_numbered(param_ty.idx));
     }
@@ -541,10 +548,9 @@ impl<'a> LookupContext<'a> {
             let trait_methods = ty::trait_methods(tcx, bound_trait_ref.def_id);
             match trait_methods.iter().position(|m| {
                 m.explicit_self != ast::SelfStatic &&
-                m.ident.name == self.m_name })
-            {
+                m.ident.name == self.m_name }) {
                 Some(pos) => {
-                    let method = trait_methods[pos];
+                    let method = *trait_methods.get(pos);
 
                     match mk_cand(bound_trait_ref, method, pos, this_bound_idx) {
                         Some(cand) => {
@@ -599,13 +605,16 @@ impl<'a> LookupContext<'a> {
                impl_info.methods.map(|m| m.ident).repr(self.tcx()));
 
         let idx = {
-            match impl_info.methods.iter().position(|m| m.ident.name == self.m_name) {
+            match impl_info.methods
+                           .iter()
+                           .position(|m| m.ident.name == self.m_name) {
                 Some(idx) => idx,
                 None => { return; } // No method with the right name.
             }
         };
 
-        let method = ty::method(self.tcx(), impl_info.methods[idx].def_id);
+        let method = ty::method(self.tcx(),
+                                impl_info.methods.get(idx).def_id);
 
         // determine the `self` of the impl with fresh
         // variables for each parameter:
@@ -899,7 +908,8 @@ impl<'a> LookupContext<'a> {
             candidates.iter().map(|c| (*c).clone()).
                 filter(|c| self.is_relevant(rcvr_ty, c)).collect();
 
-        let relevant_candidates = self.merge_candidates(relevant_candidates);
+        let relevant_candidates =
+            self.merge_candidates(relevant_candidates.as_slice());
 
         if relevant_candidates.len() == 0 {
             return None;
@@ -914,7 +924,7 @@ impl<'a> LookupContext<'a> {
             }
         }
 
-        Some(self.confirm_candidate(rcvr_ty, &relevant_candidates[0]))
+        Some(self.confirm_candidate(rcvr_ty, relevant_candidates.get(0)))
     }
 
     fn merge_candidates(&self, candidates: &[Candidate]) -> Vec<Candidate> {
@@ -1004,14 +1014,15 @@ impl<'a> LookupContext<'a> {
                      parameters given for this method");
                 self.fcx.infcx().next_ty_vars(num_method_tps)
             } else {
-                self.supplied_tps.to_owned()
+                Vec::from_slice(self.supplied_tps)
             }
         };
 
         // Construct the full set of type parameters for the method,
         // which is equal to the class tps + the method tps.
         let all_substs = substs {
-            tps: vec_ng::append(candidate.rcvr_substs.tps.clone(), m_substs),
+            tps: vec_ng::append(candidate.rcvr_substs.tps.clone(),
+                                m_substs.as_slice()),
             regions: candidate.rcvr_substs.regions.clone(),
             self_ty: candidate.rcvr_substs.self_ty,
         };
@@ -1031,7 +1042,7 @@ impl<'a> LookupContext<'a> {
                 let args = fn_sig.inputs.slice_from(1).iter().map(|t| {
                     t.subst(tcx, &all_substs)
                 });
-                Some(fn_sig.inputs[0]).move_iter().chain(args).collect()
+                Some(*fn_sig.inputs.get(0)).move_iter().chain(args).collect()
             }
             _ => fn_sig.inputs.subst(tcx, &all_substs)
         };
@@ -1050,7 +1061,7 @@ impl<'a> LookupContext<'a> {
             self.fcx.infcx().next_region_var(
                 infer::BoundRegionInFnCall(self.expr.span, br))
         });
-        let transformed_self_ty = fn_sig.inputs[0];
+        let transformed_self_ty = *fn_sig.inputs.get(0);
         let fty = ty::mk_bare_fn(tcx, ty::BareFnTy {
             sig: fn_sig,
             purity: bare_fn_ty.purity,
@@ -1118,7 +1129,7 @@ impl<'a> LookupContext<'a> {
                 ty::mk_err() // error reported in `enforce_object_limitations()`
             }
             ast::SelfRegion(..) | ast::SelfUniq => {
-                let transformed_self_ty = method_ty.fty.sig.inputs[0];
+                let transformed_self_ty = *method_ty.fty.sig.inputs.get(0);
                 match ty::get(transformed_self_ty).sty {
                     ty::ty_rptr(r, mt) => { // must be SelfRegion
                         ty::mk_trait(self.tcx(), trait_def_id,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -118,6 +118,8 @@ use collections::HashMap;
 use std::mem::replace;
 use std::result;
 use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 use syntax::abi::AbiSet;
 use syntax::ast::{Provided, Required};
 use syntax::ast;
@@ -902,7 +904,7 @@ fn compare_impl_method(tcx: ty::ctxt,
                 bound_region: ty::BrNamed(l.def_id, l.ident)})).
         collect();
     let dummy_substs = ty::substs {
-        tps: vec_ng::append(dummy_impl_tps, dummy_method_tps),
+        tps: vec_ng::append(dummy_impl_tps, dummy_method_tps.as_slice()),
         regions: ty::NonerasedRegions(dummy_impl_regions),
         self_ty: None };
 
@@ -929,7 +931,7 @@ fn compare_impl_method(tcx: ty::ctxt,
                      self_ty: self_ty } = trait_substs.subst(tcx, &dummy_substs);
         let substs = substs {
             regions: trait_regions,
-            tps: vec_ng::append(trait_tps, dummy_method_tps),
+            tps: vec_ng::append(trait_tps, dummy_method_tps.as_slice()),
             self_ty: self_ty,
         };
         debug!("trait_fty (pre-subst): {} substs={}",
@@ -988,7 +990,7 @@ impl FnCtxt {
 impl RegionScope for infer::InferCtxt {
     fn anon_regions(&self, span: Span, count: uint)
                     -> Result<Vec<ty::Region> , ()> {
-        Ok(vec::from_fn(count, |_| {
+        Ok(Vec::from_fn(count, |_| {
             self.next_region_var(infer::MiscVariable(span))
         }))
     }
@@ -1672,7 +1674,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
         let args = args.slice_from(1);
         if ty::type_is_error(method_fn_ty) {
             let err_inputs = err_args(args.len());
-            check_argument_types(fcx, sp, err_inputs, callee_expr,
+            check_argument_types(fcx, sp, err_inputs.as_slice(), callee_expr,
                                  args, deref_args, false);
             method_fn_ty
         } else {
@@ -1713,10 +1715,10 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
         let supplied_arg_count = args.len();
         let expected_arg_count = fn_inputs.len();
         let formal_tys = if expected_arg_count == supplied_arg_count {
-            fn_inputs.map(|a| *a)
+            fn_inputs.iter().map(|a| *a).collect()
         } else if variadic {
             if supplied_arg_count >= expected_arg_count {
-                fn_inputs.map(|a| *a)
+                fn_inputs.iter().map(|a| *a).collect()
             } else {
                 let msg = format!(
                     "this function takes at least {nexpected, plural, =1{# parameter} \
@@ -1782,7 +1784,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
 
                 if is_block == check_blocks {
                     debug!("checking the argument");
-                    let mut formal_ty = formal_tys[i];
+                    let mut formal_ty = *formal_tys.get(i);
 
                     match deref_args {
                         DoDerefArgs => {
@@ -1841,7 +1843,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
     }
 
     fn err_args(len: uint) -> Vec<ty::t> {
-        vec::from_fn(len, |_| ty::mk_err())
+        Vec::from_fn(len, |_| ty::mk_err())
     }
 
     fn write_call(fcx: @FnCtxt, call_expr: &ast::Expr, output: ty::t) {
@@ -1892,7 +1894,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
         });
 
         // Call the generic checker.
-        check_argument_types(fcx, call_expr.span, fn_sig.inputs, f,
+        check_argument_types(fcx, call_expr.span, fn_sig.inputs.as_slice(), f,
                              args, DontDerefArgs, fn_sig.variadic);
 
         write_call(fcx, call_expr, fn_sig.output);
@@ -2310,7 +2312,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                 // field
                 debug!("class named {}", ppaux::ty_to_str(tcx, base_t));
                 let cls_items = ty::lookup_struct_fields(tcx, base_id);
-                match lookup_field_ty(tcx, base_id, cls_items,
+                match lookup_field_ty(tcx, base_id, cls_items.as_slice(),
                                       field, &(*substs)) {
                     Some(field_ty) => {
                         // (2) look up what field's type is, and return it
@@ -2330,7 +2332,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                              base,
                              field,
                              expr_t,
-                             tps,
+                             tps.as_slice(),
                              DontDerefArgs,
                              CheckTraitsAndInherentMethods,
                              AutoderefReceiver) {
@@ -2484,7 +2486,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                                            class_id,
                                            id,
                                            substitutions,
-                                           class_fields,
+                                           class_fields.as_slice(),
                                            fields,
                                            base_expr.is_none());
         if ty::type_is_error(fcx.node_ty(id)) {
@@ -2542,7 +2544,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                                        variant_id,
                                        id,
                                        substitutions,
-                                       variant_fields,
+                                       variant_fields.as_slice(),
                                        fields,
                                        true);
         fcx.write_ty(id, enum_type);
@@ -2621,18 +2623,21 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                   // places: the exchange heap and the managed heap.
                   let definition = lookup_def(fcx, path.span, place.id);
                   let def_id = ast_util::def_id_of_def(definition);
-                  match tcx.lang_items.items[ExchangeHeapLangItem as uint] {
-                      Some(item_def_id) if def_id == item_def_id => {
+                  match tcx.lang_items
+                           .items
+                           .get(ExchangeHeapLangItem as uint) {
+                      &Some(item_def_id) if def_id == item_def_id => {
                           fcx.write_ty(id, ty::mk_uniq(tcx,
                                                        fcx.expr_ty(subexpr)));
                           checked = true
                       }
-                      Some(_) | None => {}
+                      &Some(_) | &None => {}
                   }
                   if !checked {
                       match tcx.lang_items
-                               .items[ManagedHeapLangItem as uint] {
-                          Some(item_def_id) if def_id == item_def_id => {
+                               .items
+                               .get(ManagedHeapLangItem as uint) {
+                          &Some(item_def_id) if def_id == item_def_id => {
                               // Assign the magic `Gc<T>` struct.
                               let gc_struct_id =
                                   match tcx.lang_items
@@ -2661,7 +2666,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                               fcx.write_ty(id, sty);
                               checked = true
                           }
-                          Some(_) | None => {}
+                          &Some(_) | &None => {}
                       }
                   }
               }
@@ -2750,7 +2755,8 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                                     ty::ty_struct(did, ref substs) => {
                                         let fields = ty::struct_fields(fcx.tcx(), did, substs);
                                         fields.len() == 1
-                                        && fields[0].ident == token::special_idents::unnamed_field
+                                        && fields.get(0).ident ==
+                                        token::special_idents::unnamed_field
                                     }
                                     _ => false
                                 };
@@ -3129,7 +3135,7 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
 
         let elt_ts = elts.iter().enumerate().map(|(i, e)| {
             let opt_hint = match flds {
-                Some(ref fs) if i < fs.len() => Some(fs[i]),
+                Some(ref fs) if i < fs.len() => Some(*fs.get(i)),
                 _ => None
             };
             check_expr_with_opt_hint(fcx, *e, opt_hint);
@@ -3492,7 +3498,7 @@ pub fn check_simd(tcx: ty::ctxt, sp: Span, id: ast::NodeId) {
                 tcx.sess.span_err(sp, "SIMD vector cannot be empty");
                 return;
             }
-            let e = ty::lookup_field_type(tcx, did, fields[0].id, substs);
+            let e = ty::lookup_field_type(tcx, did, fields.get(0).id, substs);
             if !fields.iter().all(
                          |f| ty::lookup_field_type(tcx, did, f.id, substs) == e) {
                 tcx.sess.span_err(sp, "SIMD vector should be homogeneous");
@@ -3805,7 +3811,7 @@ pub fn instantiate_path(fcx: @FnCtxt,
                                    .enumerate() {
             match self_parameter_index {
                 Some(index) if index == i => {
-                    tps.push(fcx.infcx().next_ty_vars(1)[0]);
+                    tps.push(*fcx.infcx().next_ty_vars(1).get(0));
                     pushed = true;
                 }
                 _ => {}
@@ -3829,7 +3835,7 @@ pub fn instantiate_path(fcx: @FnCtxt,
         for (i, default) in defaults.skip(ty_substs_len).enumerate() {
             match self_parameter_index {
                 Some(index) if index == i + ty_substs_len => {
-                    substs.tps.push(fcx.infcx().next_ty_vars(1)[0]);
+                    substs.tps.push(*fcx.infcx().next_ty_vars(1).get(0));
                     pushed = true;
                 }
                 _ => {}
@@ -3848,7 +3854,7 @@ pub fn instantiate_path(fcx: @FnCtxt,
 
         // If the self parameter goes at the end, insert it there.
         if !pushed && self_parameter_index.is_some() {
-            substs.tps.push(fcx.infcx().next_ty_vars(1)[0])
+            substs.tps.push(*fcx.infcx().next_ty_vars(1).get(0))
         }
 
         assert_eq!(substs.tps.len(), ty_param_count)
@@ -4028,7 +4034,7 @@ pub fn check_intrinsic_type(ccx: @CrateCtxt, it: &ast::ForeignItem) {
         assert!(split.len() >= 2, "Atomic intrinsic not correct format");
 
         //We only care about the operation here
-        match split[1] {
+        match *split.get(1) {
             "cxchg" => (1, vec!(ty::mk_mut_rptr(tcx,
                                              ty::ReLateBound(it.id, ty::BrAnon(0)),
                                              param(ccx, 0)),

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -13,7 +13,9 @@
 use middle::ty;
 use middle::ty_fold;
 use middle::ty_fold::TypeFolder;
+
 use collections::HashMap;
+use std::vec_ng::Vec;
 use util::ppaux::Repr;
 use util::ppaux;
 

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -74,7 +74,7 @@ pub fn relate_nested_regions(tcx: ty::ctxt,
      */
 
     let mut rr = RegionRelator { tcx: tcx,
-                                 stack: ~[],
+                                 stack: Vec::new(),
                                  relate_op: relate_op };
     match opt_region {
         Some(o_r) => { rr.stack.push(o_r); }
@@ -84,7 +84,7 @@ pub fn relate_nested_regions(tcx: ty::ctxt,
 
     struct RegionRelator<'a> {
         tcx: ty::ctxt,
-        stack: ~[ty::Region],
+        stack: Vec<ty::Region> ,
         relate_op: 'a |ty::Region, ty::Region|,
     }
 
@@ -147,7 +147,7 @@ pub fn relate_free_regions(tcx: ty::ctxt, fn_sig: &ty::FnSig) {
 
     debug!("relate_free_regions >>");
 
-    let mut all_tys = ~[];
+    let mut all_tys = Vec::new();
     for arg in fn_sig.inputs.iter() {
         all_tys.push(*arg);
     }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -26,9 +26,10 @@ use util::common::indenter;
 use util::ppaux;
 use util::ppaux::Repr;
 
-use std::cell::RefCell;
 use collections::HashSet;
+use std::cell::RefCell;
 use std::result;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::codemap::Span;
@@ -100,13 +101,13 @@ fn lookup_vtables(vcx: &VtableContext,
 
     // We do this backwards for reasons discussed above.
     assert_eq!(substs.tps.len(), type_param_defs.len());
-    let mut result =
+    let mut result: Vec<vtable_param_res> =
         substs.tps.rev_iter()
         .zip(type_param_defs.rev_iter())
         .map(|(ty, def)|
                    lookup_vtables_for_param(vcx, location_info, Some(substs),
                                             &*def.bounds, *ty, is_early))
-        .to_owned_vec();
+        .collect();
     result.reverse();
 
     assert_eq!(substs.tps.len(), result.len());
@@ -134,7 +135,10 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
     // ty is the value supplied for the type parameter A...
     let mut param_result = Vec::new();
 
-    ty::each_bound_trait_and_supertraits(tcx, type_param_bounds.trait_bounds, |trait_ref| {
+    ty::each_bound_trait_and_supertraits(tcx,
+                                         type_param_bounds.trait_bounds
+                                                          .as_slice(),
+                                         |trait_ref| {
         // ...and here trait_ref is each bound that was declared on A,
         // expressed in terms of the type parameters.
 
@@ -252,7 +256,11 @@ fn lookup_vtable(vcx: &VtableContext,
     let vtable_opt = match ty::get(ty).sty {
         ty::ty_param(param_ty {idx: n, ..}) => {
             let type_param_bounds: &[@ty::TraitRef] =
-                vcx.param_env.type_param_bounds[n].trait_bounds;
+                vcx.param_env
+                   .type_param_bounds
+                   .get(n)
+                   .trait_bounds
+                   .as_slice();
             lookup_vtable_from_bounds(vcx,
                                       location_info,
                                       type_param_bounds,
@@ -392,7 +400,7 @@ fn search_for_vtable(vcx: &VtableContext,
         // the type self_ty, and substs is bound to [T].
         debug!("The self ty is {} and its substs are {}",
                vcx.infcx.ty_to_str(for_ty),
-               vcx.infcx.tys_to_str(substs.tps));
+               vcx.infcx.tys_to_str(substs.tps.as_slice()));
 
         // Next, we unify trait_ref -- the type that we want to cast
         // to -- with of_trait_ref -- the trait that im implements. At
@@ -445,7 +453,7 @@ fn search_for_vtable(vcx: &VtableContext,
         debug!("The fixed-up substs are {} - \
                 they will be unified with the bounds for \
                 the target ty, {}",
-               vcx.infcx.tys_to_str(substs_f.tps),
+               vcx.infcx.tys_to_str(substs_f.tps.as_slice()),
                vcx.infcx.trait_ref_to_str(trait_ref));
 
         // Next, we unify the fixed-up substitutions for the impl self
@@ -465,14 +473,14 @@ fn search_for_vtable(vcx: &VtableContext,
 
     match found.len() {
         0 => { return None }
-        1 => return Some(found[0].clone()),
+        1 => return Some(found.get(0).clone()),
         _ => {
             if !is_early {
                 vcx.tcx().sess.span_err(
                     location_info.span,
                     "multiple applicable methods in scope");
             }
-            return Some(found[0].clone());
+            return Some(found.get(0).clone());
         }
     }
 }
@@ -701,11 +709,15 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
             debug!("vtable resolution on parameter bounds for method call {}",
                    ex.repr(fcx.tcx()));
             let type_param_defs = ty::method_call_type_param_defs(cx.tcx, method.origin);
-            if has_trait_bounds(*type_param_defs.borrow()) {
+            if has_trait_bounds(type_param_defs.borrow().as_slice()) {
                 let substs = fcx.method_ty_substs(ex.id);
                 let vcx = fcx.vtable_context();
-                let vtbls = lookup_vtables(&vcx, &location_info_for_expr(ex),
-                                           *type_param_defs.borrow(), &substs, is_early);
+                let vtbls = lookup_vtables(&vcx,
+                                           &location_info_for_expr(ex),
+                                           type_param_defs.borrow()
+                                                          .as_slice(),
+                                           &substs,
+                                           is_early);
                 if !is_early {
                     insert_vtables(fcx, ex.id, vtbls);
                 }
@@ -817,7 +829,7 @@ pub fn trans_resolve_method(tcx: ty::ctxt, id: ast::NodeId,
                             substs: &ty::substs) -> Option<vtable_res> {
     let generics = ty::lookup_item_type(tcx, ast_util::local_def(id)).generics;
     let type_param_defs = generics.type_param_defs.borrow();
-    if has_trait_bounds(*type_param_defs) {
+    if has_trait_bounds(type_param_defs.as_slice()) {
         let vcx = VtableContext {
             infcx: &infer::new_infer_ctxt(tcx),
             param_env: &ty::construct_parameter_environment(tcx, None, [], [], [], id)
@@ -827,7 +839,11 @@ pub fn trans_resolve_method(tcx: ty::ctxt, id: ast::NodeId,
             span: tcx.map.span(id)
         };
 
-        Some(lookup_vtables(&vcx, &loc_info, *type_param_defs, substs, false))
+        Some(lookup_vtables(&vcx,
+                            &loc_info,
+                            type_param_defs.as_slice(),
+                            substs,
+                            false))
     } else {
         None
     }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -132,7 +132,7 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
     let tcx = vcx.tcx();
 
     // ty is the value supplied for the type parameter A...
-    let mut param_result = ~[];
+    let mut param_result = Vec::new();
 
     ty::each_bound_trait_and_supertraits(tcx, type_param_bounds.trait_bounds, |trait_ref| {
         // ...and here trait_ref is each bound that was declared on A,
@@ -323,7 +323,7 @@ fn search_for_vtable(vcx: &VtableContext,
                      -> Option<vtable_origin> {
     let tcx = vcx.tcx();
 
-    let mut found = ~[];
+    let mut found = Vec::new();
     let mut impls_seen = HashSet::new();
 
     // Load the implementations from external metadata if necessary.
@@ -336,7 +336,7 @@ fn search_for_vtable(vcx: &VtableContext,
         let trait_impls = tcx.trait_impls.borrow();
         trait_impls.get()
                    .find(&trait_ref.def_id)
-                   .map_or(@RefCell::new(~[]), |x| *x)
+                   .map_or(@RefCell::new(Vec::new()), |x| *x)
     };
     // impls is the list of all impls in scope for trait_ref.
     let impls = impls.borrow();
@@ -614,7 +614,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
 
                       let param_bounds = ty::ParamBounds {
                           builtin_bounds: ty::EmptyBuiltinBounds(),
-                          trait_bounds: ~[target_trait_ref]
+                          trait_bounds: vec!(target_trait_ref)
                       };
                       let vtables =
                             lookup_vtables_for_param(&vcx,
@@ -625,7 +625,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
                                                      is_early);
 
                       if !is_early {
-                          insert_vtables(fcx, ex.id, @~[vtables]);
+                          insert_vtables(fcx, ex.id, @vec!(vtables));
                       }
 
                       // Now, if this is &trait, we need to link the
@@ -787,7 +787,7 @@ pub fn resolve_impl(tcx: ty::ctxt,
     // but that falls out of doing this.
     let param_bounds = ty::ParamBounds {
         builtin_bounds: ty::EmptyBuiltinBounds(),
-        trait_bounds: ~[impl_trait_ref]
+        trait_bounds: vec!(impl_trait_ref)
     };
     let t = ty::node_id_to_type(tcx, impl_item.id);
     let t = t.subst(tcx, &param_env.free_substs);

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -53,7 +53,7 @@ fn resolve_type_vars_in_type(fcx: @FnCtxt, sp: Span, typ: ty::t)
 }
 
 fn resolve_type_vars_in_types(fcx: @FnCtxt, sp: Span, tys: &[ty::t])
-                          -> ~[ty::t] {
+                          -> Vec<ty::t> {
     tys.map(|t| {
         match resolve_type_vars_in_type(fcx, sp, *t) {
             Some(t1) => t1,
@@ -78,7 +78,7 @@ fn resolve_method_map_entry(wbcx: &mut WbCtxt, sp: Span, id: ast::NodeId) {
                     return;
                 }
             };
-            let mut new_tps = ~[];
+            let mut new_tps = Vec::new();
             for &subst in method.substs.tps.iter() {
                 match resolve_type_vars_in_type(fcx, sp, subst) {
                     Some(t) => new_tps.push(t),
@@ -242,7 +242,7 @@ fn resolve_type_vars_for_node(wbcx: &mut WbCtxt, sp: Span, id: ast::NodeId)
         write_ty_to_tcx(tcx, id, t);
         let mut ret = Some(t);
         fcx.opt_node_ty_substs(id, |substs| {
-          let mut new_tps = ~[];
+          let mut new_tps = Vec::new();
           for subst in substs.tps.iter() {
               match resolve_type_vars_in_type(fcx, sp, *subst) {
                 Some(t) => new_tps.push(t),

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -28,6 +28,7 @@ use middle::typeck::write_ty_to_tcx;
 use util::ppaux;
 use util::ppaux::Repr;
 
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::print::pprust::pat_to_str;
@@ -54,12 +55,12 @@ fn resolve_type_vars_in_type(fcx: @FnCtxt, sp: Span, typ: ty::t)
 
 fn resolve_type_vars_in_types(fcx: @FnCtxt, sp: Span, tys: &[ty::t])
                           -> Vec<ty::t> {
-    tys.map(|t| {
+    tys.iter().map(|t| {
         match resolve_type_vars_in_type(fcx, sp, *t) {
             Some(t1) => t1,
             None => ty::mk_err()
         }
-    })
+    }).collect()
 }
 
 fn resolve_method_map_entry(wbcx: &mut WbCtxt, sp: Span, id: ast::NodeId) {
@@ -122,7 +123,9 @@ fn resolve_vtable_map_entry(fcx: @FnCtxt, sp: Span, id: ast::NodeId) {
                       origin: &vtable_origin) -> vtable_origin {
         match origin {
             &vtable_static(def_id, ref tys, origins) => {
-                let r_tys = resolve_type_vars_in_types(fcx, sp, *tys);
+                let r_tys = resolve_type_vars_in_types(fcx,
+                                                       sp,
+                                                       tys.as_slice());
                 let r_origins = resolve_origins(fcx, sp, origins);
                 vtable_static(def_id, r_tys, r_origins)
             }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -53,8 +53,8 @@ use std::vec;
 
 struct UniversalQuantificationResult {
     monotype: t,
-    type_variables: ~[ty::t],
-    type_param_defs: Rc<~[ty::TypeParameterDef]>
+    type_variables: Vec<ty::t> ,
+    type_param_defs: Rc<Vec<ty::TypeParameterDef> >
 }
 
 fn get_base_type(inference_context: &InferCtxt,
@@ -323,7 +323,7 @@ impl CoherenceChecker {
     // `ProvidedMethodInfo` instance into the `provided_method_sources` map.
     fn instantiate_default_methods(&self, impl_id: ast::DefId,
                                    trait_ref: &ty::TraitRef,
-                                   all_methods: &mut ~[@Method]) {
+                                   all_methods: &mut Vec<@Method> ) {
         let tcx = self.crate_context.tcx;
         debug!("instantiate_default_methods(impl_id={:?}, trait_ref={})",
                impl_id, trait_ref.repr(tcx));
@@ -354,7 +354,7 @@ impl CoherenceChecker {
             // construct the polytype for the method based on the method_ty
             let new_generics = ty::Generics {
                 type_param_defs:
-                    Rc::new(vec::append(
+                    Rc::new(vec_ng::append(
                         impl_poly_type.generics.type_param_defs().to_owned(),
                             new_method_ty.generics.type_param_defs())),
                 region_param_defs:
@@ -390,7 +390,7 @@ impl CoherenceChecker {
         let mut inherent_impls = tcx.inherent_impls.borrow_mut();
         match inherent_impls.get().find(&base_def_id) {
             None => {
-                implementation_list = @RefCell::new(~[]);
+                implementation_list = @RefCell::new(Vec::new());
                 inherent_impls.get().insert(base_def_id, implementation_list);
             }
             Some(&existing_implementation_list) => {
@@ -409,7 +409,7 @@ impl CoherenceChecker {
         let mut trait_impls = tcx.trait_impls.borrow_mut();
         match trait_impls.get().find(&base_def_id) {
             None => {
-                implementation_list = @RefCell::new(~[]);
+                implementation_list = @RefCell::new(Vec::new());
                 trait_impls.get().insert(base_def_id, implementation_list);
             }
             Some(&existing_implementation_list) => {
@@ -611,7 +611,7 @@ impl CoherenceChecker {
         let tcx = self.crate_context.tcx;
         match item.node {
             ItemImpl(_, ref trait_refs, _, ref ast_methods) => {
-                let mut methods = ~[];
+                let mut methods = Vec::new();
                 for ast_method in ast_methods.iter() {
                     methods.push(ty::method(tcx, local_def(ast_method.id)));
                 }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -46,10 +46,11 @@ use syntax::opt_vec;
 use syntax::parse::token;
 use syntax::visit;
 
-use std::cell::RefCell;
 use collections::HashSet;
+use std::cell::RefCell;
 use std::rc::Rc;
-use std::vec;
+use std::vec_ng::Vec;
+use std::vec_ng;
 
 struct UniversalQuantificationResult {
     monotype: t,
@@ -355,7 +356,8 @@ impl CoherenceChecker {
             let new_generics = ty::Generics {
                 type_param_defs:
                     Rc::new(vec_ng::append(
-                        impl_poly_type.generics.type_param_defs().to_owned(),
+                        Vec::from_slice(impl_poly_type.generics
+                                                      .type_param_defs()),
                             new_method_ty.generics.type_param_defs())),
                 region_param_defs:
                     impl_poly_type.generics.region_param_defs.clone()
@@ -722,7 +724,7 @@ impl CoherenceChecker {
                 // We'll error out later. For now, just don't ICE.
                 continue;
             }
-            let method_def_id = impl_info.methods[0].def_id;
+            let method_def_id = impl_info.methods.get(0).def_id;
 
             let self_type = self.get_self_type_for_implementation(*impl_info);
             match ty::get(self_type.ty).sty {
@@ -789,10 +791,10 @@ pub fn make_substs_for_receiver_types(tcx: ty::ctxt,
         num_trait_type_parameters + method.generics.type_param_defs().len();
 
     // the new method type will have the type parameters from the impl + method
-    let combined_tps = vec::from_fn(num_method_type_parameters, |i| {
+    let combined_tps = Vec::from_fn(num_method_type_parameters, |i| {
         if i < num_trait_type_parameters {
             // replace type parameters that come from trait with new value
-            trait_ref.substs.tps[i]
+            *trait_ref.substs.tps.get(i)
         } else {
             // replace type parameters that belong to method with another
             // type parameter, this time with the index adjusted

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -336,7 +336,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
         // the substitution to any traits that appear in their bounds.
 
         // add in the type parameters from the trait
-        let mut new_type_param_defs = ~[];
+        let mut new_type_param_defs = Vec::new();
         let substd_type_param_defs =
             trait_ty_generics.type_param_defs.subst(tcx, &substs);
         new_type_param_defs.push_all(*substd_type_param_defs.borrow());
@@ -349,7 +349,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
             def_id: dummy_defid,
             bounds: @ty::ParamBounds {
                 builtin_bounds: ty::EmptyBuiltinBounds(),
-                trait_bounds: ~[self_trait_ref]
+                trait_bounds: vec!(self_trait_ref)
             },
             default: None
         });
@@ -420,7 +420,7 @@ pub fn ensure_supertraits(ccx: &CrateCtxt,
     }
 
     let self_ty = ty::mk_self(ccx.tcx, local_def(id));
-    let mut ty_trait_refs: ~[@ty::TraitRef] = ~[];
+    let mut ty_trait_refs: Vec<@ty::TraitRef> = Vec::new();
     let mut bounds = ty::EmptyBuiltinBounds();
     for ast_trait_ref in ast_trait_refs.iter() {
         let trait_def_id = ty::trait_ref_to_def_id(ccx.tcx, ast_trait_ref);
@@ -494,7 +494,7 @@ fn convert_methods(ccx: &CrateCtxt,
                 // itself
                 ty_param_bounds_and_ty {
                     generics: ty::Generics {
-                        type_param_defs: Rc::new(vec::append(
+                        type_param_defs: Rc::new(vec_ng::append(
                             rcvr_ty_generics.type_param_defs().to_owned(),
                             m_ty_generics.type_param_defs())),
                         region_param_defs: rcvr_ty_generics.region_param_defs.clone(),
@@ -860,7 +860,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
             let tpt = ty_param_bounds_and_ty {
                 generics: ty::Generics {
                     type_param_defs: ty_generics.type_param_defs.clone(),
-                    region_param_defs: Rc::new(~[]),
+                    region_param_defs: Rc::new(Vec::new()),
                 },
                 ty: ty::mk_bare_fn(ccx.tcx, tofd)
             };
@@ -946,8 +946,8 @@ pub fn ty_of_foreign_item(ccx: &CrateCtxt,
         ast::ForeignItemStatic(t, _) => {
             ty::ty_param_bounds_and_ty {
                 generics: ty::Generics {
-                    type_param_defs: Rc::new(~[]),
-                    region_param_defs: Rc::new(~[]),
+                    type_param_defs: Rc::new(Vec::new()),
+                    region_param_defs: Rc::new(Vec::new()),
                 },
                 ty: ast_ty_to_ty(ccx, &ExplicitRscope, t)
             }
@@ -1008,7 +1008,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
 
         let mut param_bounds = ty::ParamBounds {
             builtin_bounds: ty::EmptyBuiltinBounds(),
-            trait_bounds: ~[]
+            trait_bounds: Vec::new()
         };
         for ast_bound in ast_bounds.iter() {
             match *ast_bound {
@@ -1083,7 +1083,7 @@ pub fn mk_item_substs(ccx: &CrateCtxt,
                       ty_generics: &ty::Generics,
                       self_ty: Option<ty::t>) -> ty::substs
 {
-    let params: ~[ty::t] =
+    let params: Vec<ty::t> =
         ty_generics.type_param_defs().iter().enumerate().map(
             |(i, t)| ty::mk_param(ccx.tcx, i, t.def_id)).collect();
 

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -82,7 +82,7 @@ pub trait Combine {
     fn contratys(&self, a: ty::t, b: ty::t) -> cres<ty::t>;
     fn tys(&self, a: ty::t, b: ty::t) -> cres<ty::t>;
 
-    fn tps(&self, as_: &[ty::t], bs: &[ty::t]) -> cres<~[ty::t]> {
+    fn tps(&self, as_: &[ty::t], bs: &[ty::t]) -> cres<Vec<ty::t> > {
 
         // Note: type parameters are always treated as *invariant*
         // (otherwise the type system would be unsound).  In the
@@ -396,7 +396,7 @@ pub fn eq_opt_regions<C:Combine>(
 
 pub fn super_fn_sigs<C:Combine>(this: &C, a: &ty::FnSig, b: &ty::FnSig) -> cres<ty::FnSig> {
 
-    fn argvecs<C:Combine>(this: &C, a_args: &[ty::t], b_args: &[ty::t]) -> cres<~[ty::t]> {
+    fn argvecs<C:Combine>(this: &C, a_args: &[ty::t], b_args: &[ty::t]) -> cres<Vec<ty::t> > {
         if a_args.len() == b_args.len() {
             result::collect(a_args.iter().zip(b_args.iter())
                             .map(|(a, b)| this.args(*a, *b)))

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -155,10 +155,16 @@ impl<'f> Combine for Glb<'f> {
             fold_regions_in_sig(
                 self.get_ref().infcx.tcx,
                 &sig0,
-                |r| generalize_region(self, snapshot,
-                                      new_vars, sig0.binder_id,
-                                      &a_map, a_vars, b_vars,
-                                      r));
+                |r| {
+                generalize_region(self,
+                                  snapshot,
+                                  new_vars.as_slice(),
+                                  sig0.binder_id,
+                                  &a_map,
+                                  a_vars.as_slice(),
+                                  b_vars.as_slice(),
+                                  r)
+            });
         debug!("sig1 = {}", sig1.inf_str(self.get_ref().infcx));
         return Ok(sig1);
 

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -522,7 +522,7 @@ pub fn lattice_var_and_t<L:LatticeDir + Combine,
 
 pub fn var_ids<T:Combine>(this: &T,
                           map: &HashMap<ty::BoundRegion, ty::Region>)
-                          -> ~[RegionVid] {
+                          -> Vec<RegionVid> {
     map.iter().map(|(_, r)| match *r {
             ty::ReInfer(ty::ReVar(r)) => { r }
             r => {

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -43,8 +43,10 @@ use middle::typeck::infer::lub::Lub;
 use middle::typeck::infer::unify::*;
 use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::InferStr;
-use collections::HashMap;
 use util::common::indenter;
+
+use collections::HashMap;
+use std::vec_ng::Vec;
 
 pub trait LatticeValue {
     fn sub(cf: &CombineFields, a: &Self, b: &Self) -> ures;

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -143,7 +143,7 @@ impl<'f> Combine for Lub<'f> {
             fold_regions_in_sig(
                 self.get_ref().infcx.tcx,
                 &sig0,
-                |r| generalize_region(self, snapshot, new_vars,
+                |r| generalize_region(self, snapshot, new_vars.as_slice(),
                                       sig0.binder_id, &a_map, r));
         return Ok(sig1);
 

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -260,7 +260,7 @@ pub fn fixup_err_to_str(f: fixup_err) -> ~str {
 fn new_ValsAndBindings<V:Clone,T:Clone>() -> ValsAndBindings<V, T> {
     ValsAndBindings {
         vals: SmallIntMap::new(),
-        bindings: ~[]
+        bindings: Vec::new()
     }
 }
 
@@ -622,7 +622,7 @@ impl InferCtxt {
         ty::mk_var(self.tcx, self.next_ty_var_id())
     }
 
-    pub fn next_ty_vars(&self, n: uint) -> ~[ty::t] {
+    pub fn next_ty_vars(&self, n: uint) -> Vec<ty::t> {
         vec::from_fn(n, |_i| self.next_ty_var())
     }
 
@@ -659,7 +659,7 @@ impl InferCtxt {
     pub fn next_region_vars(&self,
                             origin: RegionVariableOrigin,
                             count: uint)
-                            -> ~[ty::Region] {
+                            -> Vec<ty::Region> {
         vec::from_fn(count, |_| self.next_region_var(origin))
     }
 

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -21,6 +21,7 @@ pub use middle::typeck::infer::resolve::{resolve_ivar, resolve_all};
 pub use middle::typeck::infer::resolve::{resolve_nested_tvar};
 pub use middle::typeck::infer::resolve::{resolve_rvar};
 
+use collections::HashMap;
 use collections::SmallIntMap;
 use middle::ty::{TyVid, IntVid, FloatVid, RegionVid, Vid};
 use middle::ty;
@@ -37,9 +38,8 @@ use middle::typeck::infer::to_str::InferStr;
 use middle::typeck::infer::unify::{ValsAndBindings, Root};
 use middle::typeck::infer::error_reporting::ErrorReporting;
 use std::cell::{Cell, RefCell};
-use collections::HashMap;
 use std::result;
-use std::vec;
+use std::vec_ng::Vec;
 use syntax::ast::{MutImmutable, MutMutable};
 use syntax::ast;
 use syntax::codemap;
@@ -623,7 +623,7 @@ impl InferCtxt {
     }
 
     pub fn next_ty_vars(&self, n: uint) -> Vec<ty::t> {
-        vec::from_fn(n, |_i| self.next_ty_var())
+        Vec::from_fn(n, |_i| self.next_ty_var())
     }
 
     pub fn next_int_var_id(&self) -> IntVid {
@@ -660,7 +660,7 @@ impl InferCtxt {
                             origin: RegionVariableOrigin,
                             count: uint)
                             -> Vec<ty::Region> {
-        vec::from_fn(count, |_| self.next_region_var(origin))
+        Vec::from_fn(count, |_| self.next_region_var(origin))
     }
 
     pub fn fresh_bound_region(&self, binder_id: ast::NodeId) -> ty::Region {

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -83,7 +83,7 @@ pub struct ResolveState<'a> {
     infcx: &'a InferCtxt,
     modes: uint,
     err: Option<fixup_err>,
-    v_seen: ~[TyVid],
+    v_seen: Vec<TyVid> ,
     type_depth: uint
 }
 
@@ -92,7 +92,7 @@ pub fn resolver<'a>(infcx: &'a InferCtxt, modes: uint) -> ResolveState<'a> {
         infcx: infcx,
         modes: modes,
         err: None,
-        v_seen: ~[],
+        v_seen: Vec::new(),
         type_depth: 0
     }
 }

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -58,6 +58,7 @@ use middle::typeck::infer::unify::{Root, UnifyInferCtxtMethods};
 use util::common::{indent, indenter};
 use util::ppaux::ty_to_str;
 
+use std::vec_ng::Vec;
 use syntax::ast;
 
 pub static resolve_nested_tvar: uint = 0b0000000001;

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -46,7 +46,7 @@ static EMPTY_SOURCE_STR: &str = "/* Hello, world! */";
 
 fn setup_env(test_name: &str, source_string: &str) -> Env {
     let messages = @DVec();
-    let matches = getopts(~[~"-Z", ~"verbose"], optgroups()).get();
+    let matches = getopts(vec!(~"-Z", ~"verbose"), optgroups()).get();
     let diag = diagnostic::collect(messages);
     let sessopts = build_session_options(~"rustc", &matches, diag);
     let sess = build_session(sessopts, None, diag);
@@ -186,7 +186,7 @@ impl Env {
                           proto: ast::ProtoBare,
                           onceness: ast::Many,
                           region: ty::ReStatic,
-                          bounds: @~[]},
+                          bounds: @Vec::new()},
             sig: FnSig {
                 inputs: inputs,
                 output: output_ty,

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -17,6 +17,7 @@ use middle::typeck::infer::{Bounds, uok, ures};
 use middle::typeck::infer::InferCtxt;
 use middle::typeck::infer::to_str::InferStr;
 use std::cell::RefCell;
+use std::vec_ng::Vec;
 use syntax::ast;
 
 #[deriving(Clone)]

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -27,7 +27,7 @@ pub enum VarValue<V, T> {
 
 pub struct ValsAndBindings<V, T> {
     vals: SmallIntMap<VarValue<V, T>>,
-    bindings: ~[(V, VarValue<V, T>)],
+    bindings: Vec<(V, VarValue<V, T>)> ,
 }
 
 pub struct Node<V, T> {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -152,9 +152,9 @@ pub struct MethodCallee {
 // of the method to be invoked
 pub type MethodMap = @RefCell<NodeMap<MethodCallee>>;
 
-pub type vtable_param_res = @~[vtable_origin];
+pub type vtable_param_res = @Vec<vtable_origin> ;
 // Resolutions for bounds of all parameters, left to right, for a given path.
-pub type vtable_res = @~[vtable_param_res];
+pub type vtable_res = @Vec<vtable_param_res> ;
 
 #[deriving(Clone)]
 pub enum vtable_origin {
@@ -163,7 +163,7 @@ pub enum vtable_origin {
       from whence comes the vtable, and tys are the type substs.
       vtable_res is the vtable itself
      */
-    vtable_static(ast::DefId, ~[ty::t], vtable_res),
+    vtable_static(ast::DefId, Vec<ty::t> , vtable_res),
 
     /*
       Dynamic vtable, comes from a parameter that has a bound on it:
@@ -235,7 +235,7 @@ pub fn write_ty_to_tcx(tcx: ty::ctxt, node_id: ast::NodeId, ty: ty::t) {
 }
 pub fn write_substs_to_tcx(tcx: ty::ctxt,
                            node_id: ast::NodeId,
-                           substs: ~[ty::t]) {
+                           substs: Vec<ty::t> ) {
     if substs.len() > 0u {
         debug!("write_substs_to_tcx({}, {:?})", node_id,
                substs.map(|t| ppaux::ty_to_str(tcx, *t)));
@@ -271,8 +271,8 @@ pub fn lookup_def_ccx(ccx: &CrateCtxt, sp: Span, id: ast::NodeId)
 
 pub fn no_params(t: ty::t) -> ty::ty_param_bounds_and_ty {
     ty::ty_param_bounds_and_ty {
-        generics: ty::Generics {type_param_defs: Rc::new(~[]),
-                                region_param_defs: Rc::new(~[])},
+        generics: ty::Generics {type_param_defs: Rc::new(Vec::new()),
+                                region_param_defs: Rc::new(Vec::new())},
         ty: t
     }
 }
@@ -352,7 +352,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
                 abis: abi::AbiSet::Rust(),
                 sig: ty::FnSig {
                     binder_id: main_id,
-                    inputs: ~[],
+                    inputs: Vec::new(),
                     output: ty::mk_nil(),
                     variadic: false
                 }
@@ -398,10 +398,10 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
                 abis: abi::AbiSet::Rust(),
                 sig: ty::FnSig {
                     binder_id: start_id,
-                    inputs: ~[
+                    inputs: vec!(
                         ty::mk_int(),
                         ty::mk_imm_ptr(tcx, ty::mk_imm_ptr(tcx, ty::mk_u8()))
-                    ],
+                    ),
                     output: ty::mk_int(),
                     variadic: false
                 }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -72,6 +72,7 @@ use util::nodemap::{DefIdMap, NodeMap};
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::vec_ng::Vec;
 use collections::List;
 use syntax::codemap::Span;
 use syntax::print::pprust::*;

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -12,7 +12,7 @@
 use middle::ty;
 
 use std::cell::Cell;
-use std::vec;
+use std::vec_ng::Vec;
 use syntax::ast;
 use syntax::codemap::Span;
 use syntax::opt_vec::OptVec;
@@ -69,7 +69,7 @@ impl RegionScope for BindingRscope {
                     -> Result<Vec<ty::Region> , ()> {
         let idx = self.anon_bindings.get();
         self.anon_bindings.set(idx + count);
-        Ok(vec::from_fn(count, |i| ty::ReLateBound(self.binder_id,
+        Ok(Vec::from_fn(count, |i| ty::ReLateBound(self.binder_id,
                                                    ty::BrAnon(idx + i))))
     }
 }

--- a/src/librustc/middle/typeck/rscope.rs
+++ b/src/librustc/middle/typeck/rscope.rs
@@ -31,7 +31,7 @@ pub trait RegionScope {
     fn anon_regions(&self,
                     span: Span,
                     count: uint)
-                    -> Result<~[ty::Region], ()>;
+                    -> Result<Vec<ty::Region> , ()>;
 }
 
 // A scope in which all regions must be explicitly named
@@ -41,7 +41,7 @@ impl RegionScope for ExplicitRscope {
     fn anon_regions(&self,
                     _span: Span,
                     _count: uint)
-                    -> Result<~[ty::Region], ()> {
+                    -> Result<Vec<ty::Region> , ()> {
         Err(())
     }
 }
@@ -66,7 +66,7 @@ impl RegionScope for BindingRscope {
     fn anon_regions(&self,
                     _: Span,
                     count: uint)
-                    -> Result<~[ty::Region], ()> {
+                    -> Result<Vec<ty::Region> , ()> {
         let idx = self.anon_bindings.get();
         self.anon_bindings.set(idx + count);
         Ok(vec::from_fn(count, |i| ty::ReLateBound(self.binder_id,

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -261,7 +261,7 @@ struct TermsContext<'a> {
     inferred_map: HashMap<ast::NodeId, InferredIndex>,
 
     // Maps from an InferredIndex to the info for that variable.
-    inferred_infos: ~[InferredInfo<'a>],
+    inferred_infos: Vec<InferredInfo<'a>> ,
 }
 
 enum ParamKind { TypeParam, RegionParam, SelfParam }
@@ -282,7 +282,7 @@ fn determine_parameters_to_be_inferred<'a>(tcx: ty::ctxt,
         tcx: tcx,
         arena: arena,
         inferred_map: HashMap::new(),
-        inferred_infos: ~[],
+        inferred_infos: Vec::new(),
 
         // cache and share the variance struct used for items with
         // no type/region parameters
@@ -410,7 +410,7 @@ struct ConstraintContext<'a> {
     invariant: VarianceTermPtr<'a>,
     bivariant: VarianceTermPtr<'a>,
 
-    constraints: ~[Constraint<'a>],
+    constraints: Vec<Constraint<'a>> ,
 }
 
 /// Declares that the variable `decl_id` appears in a location with
@@ -457,7 +457,7 @@ fn add_constraints_from_crate<'a>(terms_cx: TermsContext<'a>,
         contravariant: contravariant,
         invariant: invariant,
         bivariant: bivariant,
-        constraints: ~[],
+        constraints: Vec::new(),
     };
     visit::walk_crate(&mut constraint_cx, krate, ());
     constraint_cx
@@ -835,11 +835,10 @@ impl<'a> ConstraintContext<'a> {
 
 struct SolveContext<'a> {
     terms_cx: TermsContext<'a>,
-    constraints: ~[Constraint<'a>],
+    constraints: Vec<Constraint<'a>> ,
 
     // Maps from an InferredIndex to the inferred value for that variable.
-    solutions: ~[ty::Variance]
-}
+    solutions: Vec<ty::Variance> }
 
 fn solve_constraints(constraints_cx: ConstraintContext) {
     let ConstraintContext { terms_cx, constraints, .. } = constraints_cx;

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -66,7 +66,7 @@ pub fn indenter() -> _indenter {
 
 pub fn field_expr(f: ast::Field) -> @ast::Expr { return f.expr; }
 
-pub fn field_exprs(fields: ~[ast::Field]) -> ~[@ast::Expr] {
+pub fn field_exprs(fields: Vec<ast::Field> ) -> Vec<@ast::Expr> {
     fields.map(|f| f.expr)
 }
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -16,6 +16,7 @@ use syntax::visit;
 use syntax::visit::Visitor;
 
 use std::local_data;
+use std::vec_ng::Vec;
 
 use time;
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -501,7 +501,7 @@ pub fn parameterized(cx: ctxt,
                      did: ast::DefId,
                      is_trait: bool) -> ~str {
 
-    let mut strs = ~[];
+    let mut strs = Vec::new();
     match *regions {
         ty::ErasedRegions => { }
         ty::NonerasedRegions(ref regions) => {
@@ -610,7 +610,7 @@ impl<T:Repr> Repr for OptVec<T> {
 
 // This is necessary to handle types like Option<~[T]>, for which
 // autoderef cannot convert the &[T] handler
-impl<T:Repr> Repr for ~[T] {
+impl<T:Repr> Repr for Vec<T> {
     fn repr(&self, tcx: ctxt) -> ~str {
         repr_vec(tcx, *self)
     }
@@ -658,7 +658,7 @@ impl Repr for ty::RegionSubsts {
 
 impl Repr for ty::ParamBounds {
     fn repr(&self, tcx: ctxt) -> ~str {
-        let mut res = ~[];
+        let mut res = Vec::new();
         for b in self.builtin_bounds.iter() {
             res.push(match b {
                 ty::BoundStatic => ~"'static",
@@ -973,7 +973,7 @@ impl<A:UserString> UserString for @A {
 impl UserString for ty::BuiltinBounds {
     fn user_string(&self, tcx: ctxt) -> ~str {
         if self.is_empty() { ~"<no-bounds>" } else {
-            let mut result = ~[];
+            let mut result = Vec::new();
             for bb in self.iter() {
                 result.push(bb.user_string(tcx));
             }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -22,6 +22,8 @@ use middle::ty::{ty_nil, ty_param, ty_ptr, ty_rptr, ty_self, ty_tup};
 use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_unboxed_vec, ty_infer};
 use middle::ty;
 use middle::typeck;
+
+use std::vec_ng::Vec;
 use syntax::abi::AbiSet;
 use syntax::ast_map;
 use syntax::codemap::{Span, Pos};
@@ -476,12 +478,17 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
       ty_self(..) => ~"Self",
       ty_enum(did, ref substs) | ty_struct(did, ref substs) => {
         let base = ty::item_path_str(cx, did);
-        parameterized(cx, base, &substs.regions, substs.tps, did, false)
+        parameterized(cx,
+                      base,
+                      &substs.regions,
+                      substs.tps.as_slice(),
+                      did,
+                      false)
       }
       ty_trait(did, ref substs, s, mutbl, ref bounds) => {
         let base = ty::item_path_str(cx, did);
         let ty = parameterized(cx, base, &substs.regions,
-                               substs.tps, did, true);
+                               substs.tps.as_slice(), did, true);
         let bound_sep = if bounds.is_empty() { "" } else { ":" };
         let bound_str = bounds.repr(cx);
         format!("{}{}{}{}{}", trait_store_to_str(cx, s), mutability_to_str(mutbl), ty,
@@ -521,7 +528,7 @@ pub fn parameterized(cx: ctxt,
     let num_defaults = if has_defaults {
         // We should have a borrowed version of substs instead of cloning.
         let mut substs = ty::substs {
-            tps: tps.to_owned(),
+            tps: Vec::from_slice(tps),
             regions: regions.clone(),
             self_ty: None
         };
@@ -612,7 +619,7 @@ impl<T:Repr> Repr for OptVec<T> {
 // autoderef cannot convert the &[T] handler
 impl<T:Repr> Repr for Vec<T> {
     fn repr(&self, tcx: ctxt) -> ~str {
-        repr_vec(tcx, *self)
+        repr_vec(tcx, self.as_slice())
     }
 }
 
@@ -989,10 +996,10 @@ impl UserString for ty::TraitRef {
             let mut all_tps = self.substs.tps.clone();
             for &t in self.substs.self_ty.iter() { all_tps.push(t); }
             parameterized(tcx, base, &self.substs.regions,
-                          all_tps, self.def_id, true)
+                          all_tps.as_slice(), self.def_id, true)
         } else {
             parameterized(tcx, base, &self.substs.regions,
-                          self.substs.tps, self.def_id, true)
+                          self.substs.tps.as_slice(), self.def_id, true)
         }
     }
 }

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -253,7 +253,7 @@ pub trait Digest {
 
     /// Convenience function that retrieves the result of a digest as a
     /// newly allocated vec of bytes.
-    fn result_bytes(&mut self) -> ~[u8] {
+    fn result_bytes(&mut self) -> Vec<u8> {
         let mut buf = vec::from_elem((self.output_bits()+7)/8, 0u8);
         self.result(buf);
         buf
@@ -576,7 +576,7 @@ mod tests {
     #[test]
     fn test_sha256() {
         // Examples from wikipedia
-        let wikipedia_tests = ~[
+        let wikipedia_tests = vec!(
             Test {
                 input: ~"",
                 output_str: ~"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -588,8 +588,7 @@ mod tests {
             Test {
                 input: ~"The quick brown fox jumps over the lazy dog.",
                 output_str: ~"ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"
-            },
-        ];
+            });
 
         let tests = wikipedia_tests;
 

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -110,6 +110,8 @@ impl Clean<ExternalCrate> for cstore::crate_metadata {
         ExternalCrate {
             name: self.name.to_owned(),
             attrs: decoder::get_crate_attributes(self.data()).clean()
+                                                             .move_iter()
+                                                             .collect(),
         }
     }
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -53,7 +53,7 @@ fn get_ast_and_resolve(cpath: &Path,
     let sessopts = @driver::session::Options {
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: @RefCell::new(libs),
-        crate_types: ~[driver::session::CrateTypeDylib],
+        crate_types: vec!(driver::session::CrateTypeDylib),
         .. (*rustc::driver::session::basic_options()).clone()
     };
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -44,7 +44,7 @@ pub fn run(input: &str, matches: &getopts::Matches) -> int {
     let sessopts = @session::Options {
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: libs,
-        crate_types: ~[session::CrateTypeDylib],
+        crate_types: vec!(session::CrateTypeDylib),
         .. (*session::basic_options()).clone()
     };
 
@@ -106,8 +106,8 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, should_fail: bool) 
     let sessopts = @session::Options {
         maybe_sysroot: Some(@os::self_exe_path().unwrap().dir_path()),
         addl_lib_search_paths: @RefCell::new(libs),
-        crate_types: ~[session::CrateTypeExecutable],
-        output_types: ~[link::OutputTypeExe],
+        crate_types: vec!(session::CrateTypeExecutable),
+        output_types: vec!(link::OutputTypeExe),
         cg: session::CodegenOptions {
             prefer_dynamic: true,
             .. session::basic_codegen_options()

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -20,6 +20,7 @@ use fmt;
 use iter::{DoubleEndedIterator, FromIterator, Extendable, Iterator};
 use libc::{free, c_void};
 use mem::{size_of, move_val_init};
+use mem;
 use num;
 use num::{CheckedMul, CheckedAdd};
 use ops::Drop;
@@ -66,6 +67,14 @@ impl<T> Vec<T> {
 }
 
 impl<T: Clone> Vec<T> {
+    pub fn from_slice(values: &[T]) -> Vec<T> {
+        let mut vector = Vec::new();
+        for value in values.iter() {
+            vector.push((*value).clone())
+        }
+        vector
+    }
+
     pub fn from_elem(length: uint, value: T) -> Vec<T> {
         unsafe {
             let mut xs = Vec::with_capacity(length);
@@ -283,6 +292,12 @@ impl<T> Vec<T> {
     }
 
     #[inline]
+    pub fn move_rev_iter(mut self) -> MoveItems<T> {
+        self.reverse();
+        self.move_iter()
+    }
+
+    #[inline]
     pub unsafe fn set_len(&mut self, len: uint) {
         self.len = len;
     }
@@ -320,6 +335,11 @@ impl<T> Vec<T> {
     #[inline]
     pub fn tail<'a>(&'a self) -> &'a [T] {
         self.as_slice().tail()
+    }
+
+    #[inline]
+    pub fn tailn<'a>(&'a self, n: uint) -> &'a [T] {
+        self.as_slice().tailn(n)
     }
 
     #[inline]
@@ -387,13 +407,40 @@ impl<T> Vec<T> {
         }
     }
 
+    #[inline]
+    pub fn mut_slice<'a>(&'a mut self, start: uint, end: uint)
+                     -> &'a mut [T] {
+        self.as_mut_slice().mut_slice(start, end)
+    }
+
+    #[inline]
+    pub fn reverse(&mut self) {
+        self.as_mut_slice().reverse()
+    }
+
+    #[inline]
     pub fn slice_from<'a>(&'a self, start: uint) -> &'a [T] {
         self.as_slice().slice_from(start)
     }
 
     #[inline]
+    pub fn slice_to<'a>(&'a self, end: uint) -> &'a [T] {
+        self.as_slice().slice_to(end)
+    }
+
+    #[inline]
     pub fn init<'a>(&'a self) -> &'a [T] {
         self.slice(0, self.len() - 1)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *T {
+        self.as_slice().as_ptr()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.truncate(0)
     }
 }
 
@@ -401,6 +448,90 @@ impl<T:Eq> Vec<T> {
     /// Return true if a vector contains an element with the given value
     pub fn contains(&self, x: &T) -> bool {
         self.as_slice().contains(x)
+    }
+
+    pub fn dedup(&mut self) {
+        unsafe {
+            // Although we have a mutable reference to `self`, we cannot make
+            // *arbitrary* changes. The `Eq` comparisons could fail, so we
+            // must ensure that the vector is in a valid state at all time.
+            //
+            // The way that we handle this is by using swaps; we iterate
+            // over all the elements, swapping as we go so that at the end
+            // the elements we wish to keep are in the front, and those we
+            // wish to reject are at the back. We can then truncate the
+            // vector. This operation is still O(n).
+            //
+            // Example: We start in this state, where `r` represents "next
+            // read" and `w` represents "next_write`.
+            //
+            //           r
+            //     +---+---+---+---+---+---+
+            //     | 0 | 1 | 1 | 2 | 3 | 3 |
+            //     +---+---+---+---+---+---+
+            //           w
+            //
+            // Comparing self[r] against self[w-1], tis is not a duplicate, so
+            // we swap self[r] and self[w] (no effect as r==w) and then increment both
+            // r and w, leaving us with:
+            //
+            //               r
+            //     +---+---+---+---+---+---+
+            //     | 0 | 1 | 1 | 2 | 3 | 3 |
+            //     +---+---+---+---+---+---+
+            //               w
+            //
+            // Comparing self[r] against self[w-1], this value is a duplicate,
+            // so we increment `r` but leave everything else unchanged:
+            //
+            //                   r
+            //     +---+---+---+---+---+---+
+            //     | 0 | 1 | 1 | 2 | 3 | 3 |
+            //     +---+---+---+---+---+---+
+            //               w
+            //
+            // Comparing self[r] against self[w-1], this is not a duplicate,
+            // so swap self[r] and self[w] and advance r and w:
+            //
+            //                       r
+            //     +---+---+---+---+---+---+
+            //     | 0 | 1 | 2 | 1 | 3 | 3 |
+            //     +---+---+---+---+---+---+
+            //                   w
+            //
+            // Not a duplicate, repeat:
+            //
+            //                           r
+            //     +---+---+---+---+---+---+
+            //     | 0 | 1 | 2 | 3 | 1 | 3 |
+            //     +---+---+---+---+---+---+
+            //                       w
+            //
+            // Duplicate, advance r. End of vec. Truncate to w.
+
+            let ln = self.len();
+            if ln < 1 { return; }
+
+            // Avoid bounds checks by using unsafe pointers.
+            let p = self.as_mut_slice().as_mut_ptr();
+            let mut r = 1;
+            let mut w = 1;
+
+            while r < ln {
+                let p_r = p.offset(r as int);
+                let p_wm1 = p.offset((w - 1) as int);
+                if *p_r != *p_wm1 {
+                    if r != w {
+                        let p_w = p_wm1.offset(1);
+                        mem::swap(&mut *p_r, &mut *p_w);
+                    }
+                    w += 1;
+                }
+                r += 1;
+            }
+
+            self.truncate(w);
+        }
     }
 }
 

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -14,10 +14,10 @@
 use cast::{forget, transmute};
 use clone::Clone;
 use cmp::{Ord, Eq, Ordering, TotalEq, TotalOrd};
-use container::Container;
+use container::{Container, Mutable};
 use default::Default;
 use fmt;
-use iter::{DoubleEndedIterator, FromIterator, Extendable, Iterator};
+use iter::{DoubleEndedIterator, FromIterator, Extendable, Iterator, Rev};
 use libc::{free, c_void};
 use mem::{size_of, move_val_init};
 use mem;
@@ -68,11 +68,7 @@ impl<T> Vec<T> {
 
 impl<T: Clone> Vec<T> {
     pub fn from_slice(values: &[T]) -> Vec<T> {
-        let mut vector = Vec::new();
-        for value in values.iter() {
-            vector.push((*value).clone())
-        }
-        vector
+        values.iter().map(|x| x.clone()).collect()
     }
 
     pub fn from_elem(length: uint, value: T) -> Vec<T> {
@@ -292,9 +288,8 @@ impl<T> Vec<T> {
     }
 
     #[inline]
-    pub fn move_rev_iter(mut self) -> MoveItems<T> {
-        self.reverse();
-        self.move_iter()
+    pub fn move_rev_iter(self) -> Rev<MoveItems<T>> {
+        self.move_iter().rev()
     }
 
     #[inline]
@@ -437,9 +432,12 @@ impl<T> Vec<T> {
     pub fn as_ptr(&self) -> *T {
         self.as_slice().as_ptr()
     }
+}
 
+impl<T> Mutable for Vec<T> {
+    /// Clear the vector, removing all values.
     #[inline]
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         self.truncate(0)
     }
 }


### PR DESCRIPTION
Change `~[T]` to Vec<T> in librustc.  Rebased and amended version of PR #12716.

Original author (or perhaps I should say meta-author) was @pcwalton, as is reflected in the commits.

I clean up!  :)
