### PR TITLE
Discard MTWT & interner tables from TLD after they stop being useful.

### DIFF
--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -126,6 +126,15 @@ pub fn display_sctable(table: &SCTable) {
     }
 }
 
+/// Clear the tables from TLD to reclaim memory.
+pub fn clear_tables() {
+    with_sctable(|table| {
+        *table.table.borrow_mut().get() = Vec::new();
+        *table.mark_memo.borrow_mut().get() = HashMap::new();
+        *table.rename_memo.borrow_mut().get() = HashMap::new();
+    });
+    with_resolve_table_mut(|table| *table = HashMap::new());
+}
 
 // Add a value to the end of a vec, return its index
 fn idx_push<T>(vec: &mut Vec<T> , val: T) -> u32 {

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -84,6 +84,11 @@ impl<T:Eq + Hash + Freeze + Clone + 'static> Interner<T> {
             None => None,
         }
     }
+
+    pub fn clear(&self) {
+        *self.map.borrow_mut().get() = HashMap::new();
+        *self.vect.borrow_mut().get() = Vec::new();
+    }
 }
 
 #[deriving(Clone, Eq, Hash, Ord)]
@@ -221,6 +226,11 @@ impl StrInterner {
             Some(v) => Some(*v),
             None => None,
         }
+    }
+
+    pub fn clear(&self) {
+        *self.map.borrow_mut().get() = HashMap::new();
+        *self.vect.borrow_mut().get() = Vec::new();
     }
 }
 


### PR DESCRIPTION
Sadly, this seems to make memory usage worse (unless `Vec<T>` makes it worse and this PR doesn't change that much, which is entirely possible).
