### PR TITLE
syntax: Add support for trait bounds on procs

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -893,13 +893,14 @@ impl Parser {
     // Parses a procedure type (`proc`). The initial `proc` keyword must
     // already have been parsed.
     pub fn parse_proc_type(&mut self) -> Ty_ {
+        let bounds = self.parse_optional_ty_param_bounds();
         let (decl, lifetimes) = self.parse_ty_fn_decl(false);
         TyClosure(@ClosureTy {
             sigil: OwnedSigil,
             region: None,
             purity: ImpureFn,
             onceness: Once,
-            bounds: None,
+            bounds: bounds,
             decl: decl,
             lifetimes: lifetimes,
         })

--- a/src/test/compile-fail/proc-bounds.rs
+++ b/src/test/compile-fail/proc-bounds.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn is_send<T: Send>() {}
+fn is_freeze<T: Freeze>() {}
+fn is_static<T: 'static>() {}
+
+fn main() {
+    is_send::<proc:()>();
+    //~^ ERROR: instantiating a type parameter with an incompatible type
+
+    is_freeze::<proc:()>();
+    //~^ ERROR: instantiating a type parameter with an incompatible type
+
+    is_static::<proc:()>();
+    //~^ ERROR: instantiating a type parameter with an incompatible type
+}
+

--- a/src/test/run-pass/proc-bounds.rs
+++ b/src/test/run-pass/proc-bounds.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<T>() {}
+fn bar<T>(_: T) {}
+
+fn is_send<T: Send>() {}
+fn is_freeze<T: Freeze>() {}
+fn is_static<T: 'static>() {}
+
+pub fn main() {
+    foo::<proc()>();
+    foo::<proc:()>();
+    foo::<proc:Send()>();
+    foo::<proc:Send + Freeze()>();
+    foo::<proc:'static + Send + Freeze()>();
+
+    is_send::<proc:Send()>();
+    is_freeze::<proc:Freeze()>();
+    is_static::<proc:'static()>();
+
+
+    let a = 3;
+    bar::<proc:()>(proc() {
+        let b = &a;
+        println!("{}", *b);
+    });
+}


### PR DESCRIPTION
This is needed to make progress on #10296 as the default bounds will no longer
include Send. I believe that this was the originally intended syntax for procs,
and it just hasn't been necessary up until now.
