### PR TITLE
Fix inline assembly

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1259,14 +1259,15 @@ impl Liveness {
           }
 
           ExprInlineAsm(ref ia) => {
-            let succ = ia.inputs.rev_iter().fold(succ, |succ, &(_, expr)| {
-                self.propagate_through_expr(expr, succ)
-            });
-            ia.outputs.rev_iter().fold(succ, |succ, &(_, expr)| {
+            let succ = ia.outputs.rev_iter().fold(succ, |succ, &(_, expr)| {
                 // see comment on lvalues in
                 // propagate_through_lvalue_components()
                 let succ = self.write_lvalue(expr, succ, ACC_WRITE);
                 self.propagate_through_lvalue_components(expr, succ)
+            });
+            // Inputs are executed first. Propagate last because of rev order
+            ia.inputs.rev_iter().fold(succ, |succ, &(_, expr)| {
+                self.propagate_through_expr(expr, succ)
             })
           }
 

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -1,0 +1,41 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-fast #[feature] doesn't work with check-fast
+#[feature(asm)];
+
+#[allow(dead_code)];
+
+#[cfg(target_arch = "x86")]
+#[cfg(target_arch = "x86_64")]
+pub fn main() {
+    // assignment not dead
+    let mut x: int = 0;
+    unsafe {
+        // extra colon
+        asm!("mov $1, $0" : "=r"(x) : "r"(5u), "0"(x) : : "cc");
+        //~^ WARNING unrecognized option
+    }
+    assert_eq!(x, 5);
+
+    unsafe {
+        // comma in place of a colon
+        asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8u) : "cc", "volatile");
+        //~^ WARNING expected a clobber, but found an option
+    }
+    assert_eq!(x, 13);
+}
+
+// #[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+// pub fn main() {}
+
+// At least one error is needed so that compilation fails
+#[static_assert]
+static b: bool = false; //~ ERROR static assertion failed

--- a/src/test/run-pass/asm-in-out-operand.rs
+++ b/src/test/run-pass/asm-in-out-operand.rs
@@ -1,0 +1,67 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-fast #[feature] doesn't work with check-fast
+#[feature(asm)];
+
+#[cfg(target_arch = "x86")]
+#[cfg(target_arch = "x86_64")]
+unsafe fn next_power_of_2(n: u32) -> u32 {
+    let mut tmp = n;
+    asm!("dec $0" : "+rm"(tmp) :: "cc");
+    let mut shift = 1u;
+    while shift <= 16 {
+        asm!(
+            "shr %cl, $2
+            or $2, $0
+            shl $$1, $1"
+            : "+&rm"(tmp), "+{ecx}"(shift) : "r"(tmp) : "cc"
+        );
+    }
+    asm!("inc $0" : "+rm"(tmp) :: "cc");
+    return tmp;
+}
+
+#[cfg(target_arch = "x86")]
+#[cfg(target_arch = "x86_64")]
+pub fn main() {
+    unsafe {
+        assert_eq!(64, next_power_of_2(37));
+        assert_eq!(2147483648, next_power_of_2(2147483647));
+    }
+
+    let mut y: int = 5;
+    let x: int;
+    unsafe {
+        // Treat the output as initialization.
+        asm!(
+            "shl $2, $1
+            add $3, $1
+            mov $1, $0"
+            : "=r"(x), "+r"(y) : "i"(3u), "ir"(7u) : "cc"
+        );
+    }
+    assert_eq!(x, 47);
+    assert_eq!(y, 47);
+
+    let mut x = x + 1;
+    assert_eq!(x, 48);
+
+    unsafe {
+        // Assignment to mutable.
+        // Early clobber "&":
+        // Forbids the use of a single register by both operands.
+        asm!("shr $$2, $1; add $1, $0" : "+&r"(x) : "r"(x) : "cc");
+    }
+    assert_eq!(x, 60);
+}
+
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+pub fn main() {}


### PR DESCRIPTION
## read+write modifier '+'

This small sugar was left out in the original implementation (#5359).

When an output operand with the '+' modifier is encountered, we store the index of that operand alongside the expression to create and append an input operand later. The following lines are equivalent:

```
asm!("" : "+m"(expr));
asm!("" : "=m"(expr) : "0"(expr));
```
## misplaced options and clobbers give a warning

It's really annoying when a small typo might change behavior without any warning.

```
asm!("mov $1, $0" : "=r"(x) : "r"(8u) : "cc" , "volatile");
//~^ WARNING expected a clobber, but found an option
```
## liveness

Fixed incorrect order of propagation.
Sometimes it caused spurious warnings in code: `warning: value assigned to`i`is never read, #[warn(dead_assignment)] on by default`

~~Note: Rebased on top of another PR. (uses other changes)~~
- [x] Implement read+write
- [x] Warn about misplaced options
- [x] Fix liveness (`dead_assignment` lint)
- [x] Add all tests
