### PR TITLE
Types appearing in fn types shouldn't require an owned bound

### DIFF
--- a/src/test/run-pass/issue-2992.rs
+++ b/src/test/run-pass/issue-2992.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verify that types appearing in fn types shouldn't require an owned bound.
+
+fn enclose<A: Send+Clone>(a: A) -> proc() -> A {
+  proc() a.clone()
+}
+
+pub fn main() {}


### PR DESCRIPTION
Regression test

Closes #2992
