### PR TITLE
Use generic impls for `Hash`

### DIFF
--- a/src/libcollections/lru_cache.rs
+++ b/src/libcollections/lru_cache.rs
@@ -39,7 +39,7 @@
 
 use std::cast;
 use std::container::Container;
-use std::hash::{Hash, sip};
+use std::hash::Hash;
 use std::fmt;
 use std::ptr;
 
@@ -62,9 +62,9 @@ pub struct LruCache<K, V> {
     priv tail: *mut LruEntry<K, V>,
 }
 
-impl<K: Hash> Hash for KeyRef<K> {
-    fn hash(&self, s: &mut sip::SipState) {
-        unsafe {(*self.k).hash(s)}
+impl<S, K: Hash<S>> Hash<S> for KeyRef<K> {
+    fn hash(&self, state: &mut S) {
+        unsafe { (*self.k).hash(state) }
     }
 }
 

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -29,7 +29,7 @@ Rust extras are part of the standard Rust distribution.
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
-#[feature(macro_rules, globs, managed_boxes, asm)];
+#[feature(macro_rules, globs, managed_boxes, asm, default_type_params)];
 
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];

--- a/src/libextra/url.rs
+++ b/src/libextra/url.rs
@@ -14,7 +14,7 @@
 
 use std::cmp::Eq;
 use std::fmt;
-use std::hash::{Hash, sip};
+use std::hash::Hash;
 use std::io::BufReader;
 use std::from_str::FromStr;
 use std::uint;
@@ -849,15 +849,15 @@ impl fmt::Show for Path {
     }
 }
 
-impl Hash for Url {
-    fn hash(&self, s: &mut sip::SipState) {
-        self.to_str().hash(s)
+impl<S: Writer> Hash<S> for Url {
+    fn hash(&self, state: &mut S) {
+        self.to_str().hash(state)
     }
 }
 
-impl Hash for Path {
-    fn hash(&self, s: &mut sip::SipState) {
-        self.to_str().hash(s)
+impl<S: Writer> Hash<S> for Path {
+    fn hash(&self, state: &mut S) {
+        self.to_str().hash(state)
     }
 }
 

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -15,7 +15,7 @@ use c_str::{CString, ToCStr};
 use clone::Clone;
 use cmp::Eq;
 use from_str::FromStr;
-use hash::{Hash, sip};
+use io::Writer;
 use iter::{AdditiveIterator, Extendable, Iterator, Map};
 use option::{Option, None, Some};
 use str;
@@ -88,10 +88,10 @@ impl ToCStr for Path {
     }
 }
 
-impl Hash for Path {
+impl<H: Writer> ::hash::Hash<H> for Path {
     #[inline]
-    fn hash(&self, s: &mut sip::SipState) {
-        self.repr.hash(s)
+    fn hash(&self, hasher: &mut H) {
+        self.repr.hash(hasher)
     }
 }
 

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -17,7 +17,7 @@ use clone::Clone;
 use container::Container;
 use cmp::Eq;
 use from_str::FromStr;
-use hash::{Hash, sip};
+use io::Writer;
 use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Rev, Iterator, Map};
 use option::{Option, Some, None};
 use str;
@@ -112,10 +112,10 @@ impl ToCStr for Path {
     }
 }
 
-impl Hash for Path {
+impl<H: Writer> ::hash::Hash<H> for Path {
     #[inline]
-    fn hash(&self, s: &mut sip::SipState) {
-        self.repr.hash(s)
+    fn hash(&self, hasher: &mut H) {
+        self.repr.hash(hasher)
     }
 }
 

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -89,7 +89,7 @@ use clone::Clone;
 use cmp::{Eq, TotalEq, Ord, TotalOrd, Equiv, Ordering};
 use container::{Container, Mutable};
 use fmt;
-use hash::{Hash, sip};
+use io::Writer;
 use iter::{Iterator, FromIterator, Extendable, range};
 use iter::{Filter, AdditiveIterator, Map};
 use iter::{Rev, DoubleEndedIterator, ExactSize};
@@ -1331,10 +1331,13 @@ impl<'a> Default for MaybeOwned<'a> {
     fn default() -> MaybeOwned<'a> { Slice("") }
 }
 
-impl<'a> Hash for MaybeOwned<'a> {
+impl<'a, H: Writer> ::hash::Hash<H> for MaybeOwned<'a> {
     #[inline]
-    fn hash(&self, s: &mut sip::SipState) {
-        self.as_slice().hash(s)
+    fn hash(&self, hasher: &mut H) {
+        match *self {
+            Slice(s) => s.hash(hasher),
+            Owned(ref s) => s.hash(hasher),
+        }
     }
 }
 

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -59,6 +59,12 @@ Examples of string representations:
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 
+#[feature(default_type_params)];
+
+// NOTE remove the following two attributes after the next snapshot.
+#[allow(unrecognized_lint)];
+#[allow(default_type_param_usage)];
+
 // test harness access
 #[cfg(test)]
 extern crate test;
@@ -71,7 +77,7 @@ use std::char::Char;
 use std::default::Default;
 use std::fmt;
 use std::from_str::FromStr;
-use std::hash::{Hash, sip};
+use std::hash::Hash;
 use std::num::FromStrRadix;
 use std::str;
 use std::vec;
@@ -116,9 +122,10 @@ pub struct Uuid {
     /// The 128-bit number stored in 16 bytes
     bytes: UuidBytes
 }
-impl Hash for Uuid {
-    fn hash(&self, s: &mut sip::SipState) {
-        self.bytes.slice_from(0).hash(s)
+
+impl<S: Writer> Hash<S> for Uuid {
+    fn hash(&self, state: &mut S) {
+        self.bytes.hash(state)
     }
 }
 


### PR DESCRIPTION
cc @alexcrichton. This is my last outstanding patch from the Hash migration. It adds generic hash impls for many of the stdlib types. We might want to wait until we turn `#[feature(default_type_params)];` permanently on though before we land this PR.
