### PR TITLE
make FileStat hashable, and Paths serializable

### DIFF
--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -14,6 +14,7 @@
 Core encoding and decoding interfaces.
 */
 
+use std::path;
 use std::rc::Rc;
 use std::vec;
 use std::vec_ng::Vec;
@@ -622,6 +623,32 @@ impl<
                 d.read_seq_elt(4, |d| Decodable::decode(d))
             )
         })
+    }
+}
+
+impl<E: Encoder> Encodable<E> for path::posix::Path {
+    fn encode(&self, e: &mut E) {
+        self.as_vec().encode(e)
+    }
+}
+
+impl<D: Decoder> Decodable<D> for path::posix::Path {
+    fn decode(d: &mut D) -> path::posix::Path {
+        let bytes: ~[u8] = Decodable::decode(d);
+        path::posix::Path::new(bytes)
+    }
+}
+
+impl<E: Encoder> Encodable<E> for path::windows::Path {
+    fn encode(&self, e: &mut E) {
+        self.as_vec().encode(e)
+    }
+}
+
+impl<D: Decoder> Decodable<D> for path::windows::Path {
+    fn decode(d: &mut D) -> path::windows::Path {
+        let bytes: ~[u8] = Decodable::decode(d);
+        path::windows::Path::new(bytes)
     }
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1320,7 +1320,7 @@ pub enum FileAccess {
 }
 
 /// Different kinds of files which can be identified by a call to stat
-#[deriving(Eq, Show)]
+#[deriving(Eq, Show, Hash)]
 pub enum FileType {
     /// This is a normal file, corresponding to `S_IFREG`
     TypeFile,
@@ -1358,6 +1358,7 @@ pub enum FileType {
 /// println!("byte size: {}", info.size);
 /// # }
 /// ```
+#[deriving(Hash)]
 pub struct FileStat {
     /// The path that this stat structure is describing
     path: Path,
@@ -1399,6 +1400,7 @@ pub struct FileStat {
 /// have different meanings or no meaning at all on some platforms.
 #[unstable]
 #[allow(missing_doc)]
+#[deriving(Hash)]
 pub struct UnstableFileStat {
     device: u64,
     inode: u64,

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -88,10 +88,10 @@ impl ToCStr for Path {
     }
 }
 
-impl<H: Writer> ::hash::Hash<H> for Path {
+impl<S: Writer> ::hash::Hash<S> for Path {
     #[inline]
-    fn hash(&self, hasher: &mut H) {
-        self.repr.hash(hasher)
+    fn hash(&self, state: &mut S) {
+        self.repr.hash(state)
     }
 }
 

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -112,10 +112,10 @@ impl ToCStr for Path {
     }
 }
 
-impl<H: Writer> ::hash::Hash<H> for Path {
+impl<S: Writer> ::hash::Hash<S> for Path {
     #[inline]
-    fn hash(&self, hasher: &mut H) {
-        self.repr.hash(hasher)
+    fn hash(&self, state: &mut S) {
+        self.repr.hash(state)
     }
 }
 

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -24,12 +24,12 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
 
     let (path, generics, args) = if cx.ecfg.deriving_hash_type_parameter {
         (Path::new_(vec!("std", "hash", "Hash"), None,
-                    vec!(~Literal(Path::new_local("__H"))), true),
+                    vec!(~Literal(Path::new_local("__S"))), true),
          LifetimeBounds {
              lifetimes: Vec::new(),
-             bounds: vec!(("__H", vec!(Path::new(vec!("std", "io", "Writer"))))),
+             bounds: vec!(("__S", vec!(Path::new(vec!("std", "io", "Writer"))))),
          },
-         Path::new_local("__H"))
+         Path::new_local("__S"))
     } else {
         (Path::new(vec!("std", "hash", "Hash")),
          LifetimeBounds::empty(),


### PR DESCRIPTION
This PR makes `std::io::FileStat` hashable, and `Path` serializable as a byte array.
