### PR TITLE
rustc: Switch defaults from libgreen to libnative

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -19,6 +19,8 @@ extern crate test;
 extern crate getopts;
 #[phase(link, syntax)]
 extern crate log;
+extern crate green;
+extern crate rustuv;
 
 use std::os;
 use std::io;
@@ -40,6 +42,9 @@ pub mod header;
 pub mod runtest;
 pub mod common;
 pub mod errors;
+
+#[start]
+fn start(argc: int, argv: **u8) -> int { green::start(argc, argv, main) }
 
 pub fn main() {
     let args = os::args();

--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[no_uv];
+#[no_uv]; // remove this after stage0
+#[allow(attribute_usage)]; // remove this after stage0
+extern crate native; // remove this after stage0
 
 #[cfg(rustdoc)]
 extern crate this = "rustdoc";
@@ -16,7 +18,9 @@ extern crate this = "rustdoc";
 #[cfg(rustc)]
 extern crate this = "rustc";
 
-extern crate native;
+#[cfg(not(stage0))]
+fn main() { this::main() }
 
+#[cfg(stage0)]
 #[start]
 fn start(argc: int, argv: **u8) -> int { native::start(argc, argv, this::main) }

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -209,7 +209,7 @@ pub mod stack;
 pub mod task;
 
 #[lang = "start"]
-#[cfg(not(test))]
+#[cfg(not(test), stage0)]
 pub fn lang_start(main: *u8, argc: int, argv: **u8) -> int {
     use std::cast;
     start(argc, argv, proc() {

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -58,6 +58,7 @@
 
 use std::os;
 use std::rt;
+use std::str;
 
 pub mod io;
 pub mod task;
@@ -67,6 +68,16 @@ pub mod task;
 static OS_DEFAULT_STACK_ESTIMATE: uint = 1 << 20;
 #[cfg(unix, not(android))]
 static OS_DEFAULT_STACK_ESTIMATE: uint = 2 * (1 << 20);
+
+#[lang = "start"]
+#[cfg(not(test), not(stage0))]
+pub fn lang_start(main: *u8, argc: int, argv: **u8) -> int {
+    use std::cast;
+    start(argc, argv, proc() {
+        let main: extern "Rust" fn() = unsafe { cast::transmute(main) };
+        main();
+    })
+}
 
 /// Executes the given procedure after initializing the runtime with the given
 /// argc/argv.
@@ -90,7 +101,12 @@ pub fn start(argc: int, argv: **u8, main: proc()) -> int {
     rt::init(argc, argv);
     let mut exit_code = None;
     let mut main = Some(main);
-    let t = task::new((my_stack_bottom, my_stack_top)).run(|| {
+    let mut task = task::new((my_stack_bottom, my_stack_top));
+    task.name = Some(str::Slice("<main>"));
+    let t = task.run(|| {
+        unsafe {
+            rt::stack::record_stack_bounds(my_stack_bottom, my_stack_top);
+        }
         exit_code = Some(run(main.take_unwrap()));
     });
     drop(t);

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -46,8 +46,8 @@ fn use_std(krate: &ast::Crate) -> bool {
     !attr::contains_name(krate.attrs.as_slice(), "no_std")
 }
 
-fn use_uv(krate: &ast::Crate) -> bool {
-    !attr::contains_name(krate.attrs.as_slice(), "no_uv")
+fn use_start(krate: &ast::Crate) -> bool {
+    !attr::contains_name(krate.attrs.as_slice(), "no_start")
 }
 
 fn no_prelude(attrs: &[ast::Attribute]) -> bool {
@@ -87,18 +87,10 @@ impl<'a> fold::Folder for StandardLibraryInjector<'a> {
             span: DUMMY_SP
         });
 
-        if use_uv(&krate) && !self.sess.building_library.get() {
+        if use_start(&krate) && !self.sess.building_library.get() {
             vis.push(ast::ViewItem {
-                node: ast::ViewItemExternCrate(token::str_to_ident("green"),
-                                             with_version("green"),
-                                             ast::DUMMY_NODE_ID),
-                attrs: Vec::new(),
-                vis: ast::Inherited,
-                span: DUMMY_SP
-            });
-            vis.push(ast::ViewItem {
-                node: ast::ViewItemExternCrate(token::str_to_ident("rustuv"),
-                                             with_version("rustuv"),
+                node: ast::ViewItemExternCrate(token::str_to_ident("native"),
+                                             with_version("native"),
                                              ast::DUMMY_NODE_ID),
                 attrs: Vec::new(),
                 vis: ast::Inherited,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -961,7 +961,7 @@ fn check_heap_item(cx: &Context, it: &ast::Item) {
 }
 
 static crate_attrs: &'static [&'static str] = &[
-    "crate_type", "feature", "no_uv", "no_main", "no_std", "crate_id",
+    "crate_type", "feature", "no_start", "no_main", "no_std", "crate_id",
     "desc", "comment", "license", "copyright", // not used in rustc now
 ];
 

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -45,6 +45,7 @@ via `close` and `delete` methods.
 #[allow(deprecated_owned_vector)]; // NOTE: remove after stage0
 
 #[cfg(test)] extern crate green;
+#[cfg(test)] extern crate realrustuv = "rustuv";
 
 use std::cast;
 use std::fmt;
@@ -68,6 +69,16 @@ pub use self::process::Process;
 pub use self::signal::SignalWatcher;
 pub use self::timer::TimerWatcher;
 pub use self::tty::TtyWatcher;
+
+// Run tests with libgreen instead of libnative.
+//
+// FIXME: This egregiously hacks around starting the test runner in a different
+//        threading mode than the default by reaching into the auto-generated
+//        '__test' module.
+#[cfg(test)] #[start]
+fn start(argc: int, argv: **u8) -> int {
+    green::start(argc, argv, __test::main)
+}
 
 mod macros;
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -81,6 +81,16 @@
 #[cfg(stage0)]
 pub use vec_ng = vec;
 
+// Run tests with libgreen instead of libnative.
+//
+// FIXME: This egregiously hacks around starting the test runner in a different
+//        threading mode than the default by reaching into the auto-generated
+//        '__test' module.
+#[cfg(test)] #[start]
+fn start(argc: int, argv: **u8) -> int {
+    green::start(argc, argv, __test::main)
+}
+
 pub mod macros;
 
 mod rtdeps;

--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -387,65 +387,6 @@ rust_unset_sigprocmask() {
 
 #endif
 
-#if defined(__WIN32__)
-void
-win32_require(LPCTSTR fn, BOOL ok) {
-    if (!ok) {
-        LPTSTR buf;
-        DWORD err = GetLastError();
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                      FORMAT_MESSAGE_FROM_SYSTEM |
-                      FORMAT_MESSAGE_IGNORE_INSERTS,
-                      NULL, err,
-                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                      (LPTSTR) &buf, 0, NULL );
-        fprintf(stderr, "%s failed with error %ld: %s", fn, err, buf);
-        LocalFree((HLOCAL)buf);
-        abort();
-    }
-}
-
-void
-rust_win32_rand_acquire(HCRYPTPROV* phProv) {
-    win32_require
-        (_T("CryptAcquireContext"),
-         // changes to the parameters here should be reflected in the docs of
-         // rand::os::OSRng
-         CryptAcquireContext(phProv, NULL, NULL, PROV_RSA_FULL,
-                             CRYPT_VERIFYCONTEXT|CRYPT_SILENT));
-
-}
-void
-rust_win32_rand_gen(HCRYPTPROV hProv, DWORD dwLen, BYTE* pbBuffer) {
-    win32_require
-        (_T("CryptGenRandom"), CryptGenRandom(hProv, dwLen, pbBuffer));
-}
-void
-rust_win32_rand_release(HCRYPTPROV hProv) {
-    win32_require
-        (_T("CryptReleaseContext"), CryptReleaseContext(hProv, 0));
-}
-
-#else
-
-// these symbols are listed in rustrt.def.in, so they need to exist; but they
-// should never be called.
-
-void
-rust_win32_rand_acquire() {
-    abort();
-}
-void
-rust_win32_rand_gen() {
-    abort();
-}
-void
-rust_win32_rand_release() {
-    abort();
-}
-
-#endif
-
 //
 // Local Variables:
 // mode: C++

--- a/src/test/run-fail/native-failure.rs
+++ b/src/test/run-fail/native-failure.rs
@@ -11,8 +11,6 @@
 // ignore-android (FIXME #11419)
 // error-pattern:explicit failure
 
-#[no_uv];
-
 extern crate native;
 
 #[start]

--- a/src/test/run-make/bootstrap-from-c-with-green/lib.rs
+++ b/src/test/run-make/bootstrap-from-c-with-green/lib.rs
@@ -10,7 +10,6 @@
 
 #[crate_id="boot#0.1"];
 #[crate_type="dylib"];
-#[no_uv];
 
 extern crate rustuv;
 extern crate green;

--- a/src/test/run-make/bootstrap-from-c-with-native/lib.rs
+++ b/src/test/run-make/bootstrap-from-c-with-native/lib.rs
@@ -10,7 +10,6 @@
 
 #[crate_id="boot#0.1"];
 #[crate_type="dylib"];
-#[no_uv];
 
 extern crate native;
 

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -14,10 +14,9 @@
 
 #[feature(phase)];
 
-#[no_uv];
-extern crate native;
 #[phase(syntax, link)]
 extern crate log;
+extern crate native;
 
 use std::fmt;
 use std::io::{ChanReader, ChanWriter};

--- a/src/test/run-pass/native-print-no-runtime.rs
+++ b/src/test/run-pass/native-print-no-runtime.rs
@@ -10,8 +10,6 @@
 
 // ignore-fast
 
-#[no_uv];
-
 #[start]
 pub fn main(_: int, _: **u8) -> int {
     println!("hello");

--- a/src/test/run-pass/process-detach.rs
+++ b/src/test/run-pass/process-detach.rs
@@ -20,9 +20,15 @@
 // Note that the first thing we do is put ourselves in our own process group so
 // we don't interfere with other running tests.
 
+extern crate green;
+extern crate rustuv;
+
 use std::libc;
 use std::io::process;
 use std::io::signal::{Listener, Interrupt};
+
+#[start]
+fn start(argc: int, argv: **u8) -> int { green::start(argc, argv, main) }
 
 fn main() {
     unsafe { libc::setsid(); }


### PR DESCRIPTION
The compiler will no longer inject libgreen as the default runtime for rust
programs, this commit switches it over to libnative by default. Now that
libnative has baked for some time, it is ready enough to start getting more
serious usage as the default runtime for rustc generated binaries.

We've found that there isn't really a correct decision in choosing a 1:1 or M:N
runtime as a default for all applications, but it seems that a larger number of
programs today would work more reasonably with a native default rather than a
green default.

With this commit come a number of bugfixes:
- The main native task is now named `<main>`
- The main native task has the stack bounds set up properly
- #[no_uv] was renamed to #[no_start]
- The core-run-destroy test was rewritten for both libnative and libgreen and
  one of the tests was modified to be more robust.
- The process-detach test was locked to libgreen because it uses signal handling
