### PR TITLE
Emacs: always jump the cursor if needed on indent

### DIFF
--- a/src/etc/emacs/rust-mode-tests.el
+++ b/src/etc/emacs/rust-mode-tests.el
@@ -570,6 +570,11 @@ fn indenting_middle_of_line() {
                pull_me_back_in();
 }
 }
+
+fn indented_already() {
+    
+    // The previous line already has its spaces
+}
 "
 
       ;; Symbol -> (line column)
@@ -596,7 +601,15 @@ fn indenting_middle_of_line() {
                                   (after-whitespace-indent-start (13 1))
                                   (after-whitespace-indent-target (13 8))
                                   (middle-pull-indent-start (15 19))
-                                  (middle-pull-indent-target (15 12))))
+                                  (middle-pull-indent-target (15 12))
+                                  (blank-line-indented-already-bol-start (20 0))
+                                  (blank-line-indented-already-bol-target (20 4))
+                                  (blank-line-indented-already-middle-start (20 2))
+                                  (blank-line-indented-already-middle-target (20 4))
+                                  (nonblank-line-indented-already-bol-start (21 0))
+                                  (nonblank-line-indented-already-bol-target (21 4))
+                                  (nonblank-line-indented-already-middle-start (21 2))
+                                  (nonblank-line-indented-already-middle-target (21 4))))
 
 (defun rust-get-buffer-pos (pos-symbol)
   "Get buffer position from POS-SYMBOL.
@@ -792,4 +805,32 @@ All positions are position symbols found in `rust-test-positions-alist'."
    rust-test-indent-motion-string
    'middle-pull-indent-start
    'middle-pull-indent-target
+   #'indent-for-tab-command))
+
+(ert-deftest indent-line-blank-line-indented-already-bol ()
+  (rust-test-motion
+   rust-test-indent-motion-string
+   'blank-line-indented-already-bol-start
+   'blank-line-indented-already-bol-target
+   #'indent-for-tab-command))
+
+(ert-deftest indent-line-blank-line-indented-already-middle ()
+  (rust-test-motion
+   rust-test-indent-motion-string
+   'blank-line-indented-already-middle-start
+   'blank-line-indented-already-middle-target
+   #'indent-for-tab-command))
+
+(ert-deftest indent-line-nonblank-line-indented-already-bol ()
+  (rust-test-motion
+   rust-test-indent-motion-string
+   'nonblank-line-indented-already-bol-start
+   'nonblank-line-indented-already-bol-target
+   #'indent-for-tab-command))
+
+(ert-deftest indent-line-nonblank-line-indented-already-middle ()
+  (rust-test-motion
+   rust-test-indent-motion-string
+   'nonblank-line-indented-already-middle-start
+   'nonblank-line-indented-already-middle-target
    #'indent-for-tab-command))

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -140,14 +140,14 @@
                     ;; Otherwise, we are continuing the same expression from the previous line,
                     ;; so add one additional indent level
                     (+ baseline rust-indent-offset))))))))))
-    (when (not (eq (current-indentation) indent))
-      ;; If we're at the beginning of the line (before or at the current
-      ;; indentation), jump with the indentation change.  Otherwise, save the
-      ;; excursion so that adding the indentations will leave us at the
-      ;; equivalent position within the line to where we were before.
-      (if (<= (current-column) (current-indentation))
-          (indent-line-to indent)
-        (save-excursion (indent-line-to indent))))))
+
+    ;; If we're at the beginning of the line (before or at the current
+    ;; indentation), jump with the indentation change.  Otherwise, save the
+    ;; excursion so that adding the indentations will leave us at the
+    ;; equivalent position within the line to where we were before.
+    (if (<= (current-column) (current-indentation))
+        (indent-line-to indent)
+      (save-excursion (indent-line-to indent)))))
 
 
 ;; Font-locking definitions and helpers


### PR DESCRIPTION
The rust-mode-indent-line function had a check, which ran after all the
calculations for how to indent had already happened, that skipped
actually performing the indent if the line was already at the right
indentation.

Because of that, the cursor did not jump to the indentation if the line
wasn't changing.  This was particularly annoying if there was nothing
but spaces on the line and you were at the beginning of it--it looked
like the indent just wasn't working.

This removes the check and adds test cases to cover this.
