### PR TITLE
test: Relax a debuginfo test

### DIFF
--- a/src/test/debug-info/limited-debuginfo.rs
+++ b/src/test/debug-info/limited-debuginfo.rs
@@ -14,10 +14,10 @@
 
 // Make sure functions have proper names
 // debugger:info functions
-// check:static void limited-debuginfo::main();
-// check:static void limited-debuginfo::some_function();
-// check:static void limited-debuginfo::some_other_function();
-// check:static void limited-debuginfo::zzz();
+// check:static void [...]main();
+// check:static void [...]some_function();
+// check:static void [...]some_other_function();
+// check:static void [...]zzz();
 
 // debugger:rbreak zzz
 // debugger:run


### PR DESCRIPTION
This test is blocking a snapshot. Apparently the snapshot bot doesn't print
'limited-debuginfo::main()' but rather just 'main()'. Who knew?
