### PR TITLE
rustdoc: whitelist the headers that get a § on hover.

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -209,7 +209,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
         };
 
         // Render the HTML
-        let text = format!(r#"<h{lvl} id="{id}"><a
+        let text = format!(r#"<h{lvl} id="{id}" class='section-link'><a
                            href="\#{id}">{sec_len,plural,=0{}other{{sec} }}{}</a></h{lvl}>"#,
                            s, lvl = level, id = id,
                            sec_len = sec.len(), sec = sec);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1064,7 +1064,9 @@ fn item_module(w: &mut Writer, cx: &Context,
                 clean::ForeignStaticItem(..)   => ("ffi-statics", "Foreign Statics"),
                 clean::MacroItem(..)           => ("macros", "Macros"),
             };
-            try!(write!(w, "<h2 id='{id}'><a href=\"\\#{id}\">{name}</a></h2>\n<table>",
+            try!(write!(w,
+                        "<h2 id='{id}' class='section-link'>\
+                        <a href=\"\\#{id}\">{name}</a></h2>\n<table>",
                         id = short, name = name));
         }
 

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -317,16 +317,11 @@ pre.rust .doccomment { color: #4D4D4C; }
 pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
 pre.rust .lifetime { color: #B76514; }
 
-h1:hover a:after,
-h2:hover a:after,
-h3:hover a:after,
-h4:hover a:after,
-h5:hover a:after,
-h6:hover a:after {
+h1.section-link:hover a:after,
+h2.section-link:hover a:after,
+h3.section-link:hover a:after,
+h4.section-link:hover a:after,
+h5.section-link:hover a:after,
+h6.section-link:hover a:after {
   content: ' § ';
-}
-
-h1.fqn:hover a:after,
-:hover a.fnname:after {
-  content: none;
 }


### PR DESCRIPTION
rustdoc: whitelist the headers that get a § on hover.

Previously the :hover rules were making the links to the traits/types in
something like

```
impl<K: Hash + Eq, V> ... { ... }
```

be displayed with a trailing `§` when hovered over. This commit
restricts that behaviour to specific headers, i.e. those that are known
to be section headers (like those rendered in markdown doc-comments, and
the "Modules", "Functions" etc. headings).
