### PR TITLE
Added a test that checks that unary structs can be mutably borrowed.

### DIFF
--- a/src/test/run-pass/issue-11267.rs
+++ b/src/test/run-pass/issue-11267.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that unary structs can be mutably borrowed.
+
+struct Empty;
+
+impl Iterator<int> for Empty {
+    fn next(&mut self) -> Option<int> { None }
+}
+
+fn do_something_with(a : &mut Iterator<int>) {
+    println!("{}", a.next())
+}
+
+fn main() {
+    do_something_with(&mut Empty);
+}


### PR DESCRIPTION
Closes #11267
