### PR TITLE
enable mutex lowering and hardware floating point on gnueabihf. closes #10482

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -330,7 +330,7 @@ CFG_PATH_MUNGE_arm-unknown-linux-gnueabihf := true
 CFG_LDPATH_arm-unknown-linux-gnueabihf :=
 CFG_RUN_arm-unknown-linux-gnueabihf=$(2)
 CFG_RUN_TARG_arm-unknown-linux-gnueabihf=$(call CFG_RUN_arm-unknown-linux-gnueabihf,,$(2))
-RUSTC_FLAGS_arm-unknown-linux-gnueabihf :=
+RUSTC_FLAGS_arm-unknown-linux-gnueabihf := -C target-feature=+v7,+vfp3
 RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabihf :=
 
 # arm-unknown-linux-gnueabi configuration


### PR DESCRIPTION
This enables the lowering of llvm 64b intrinsics to hardware ops, resolving issues around `__kernel_cmpxchg64` on older kernels on ARM devices, and also enables use of the hardware floating point unit, resolving https://github.com/mozilla/rust/issues/10482.
