### PR TITLE
lint: add lint for use of a `~[T]`.

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -12,6 +12,7 @@
 
 #[allow(non_camel_case_types)];
 #[deny(warnings)];
+#[allow(deprecated_owned_vector)];
 
 extern crate test;
 extern crate getopts;

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -21,6 +21,7 @@
 #[license = "MIT/ASL2"];
 #[allow(missing_doc)];
 #[feature(managed_boxes)];
+#[allow(deprecated_owned_vector)];
 
 extern crate collections;
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -22,6 +22,7 @@
 // NOTE remove the following two attributes after the next snapshot.
 #[allow(unrecognized_lint)];
 #[allow(default_type_param_usage)];
+#[allow(deprecated_owned_vector)];
 
 extern crate rand;
 

--- a/src/libextra/lib.rs
+++ b/src/libextra/lib.rs
@@ -31,6 +31,7 @@ Rust extras are part of the standard Rust distribution.
 
 #[feature(macro_rules, globs, managed_boxes, asm, default_type_params)];
 
+#[allow(deprecated_owned_vector)];
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];
 

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -90,6 +90,7 @@ pub fn inflate_bytes_zlib(bytes: &[u8]) -> CVec<u8> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(deprecated_owned_vector)];
     extern crate rand;
 
     use super::{inflate_bytes, deflate_bytes};

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -81,6 +81,7 @@
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 #[allow(missing_doc)];
+#[allow(deprecated_owned_vector)];
 
 #[feature(globs)];
 

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -27,6 +27,7 @@
 #[crate_type = "rlib"];
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
+#[allow(deprecated_owned_vector)];
 
 use std::cell::Cell;
 use std::{cmp, os, path};

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -174,6 +174,7 @@
 // NB this does *not* include globs, please keep it that way.
 #[feature(macro_rules)];
 #[allow(visible_private_types)];
+#[allow(deprecated_owned_vector)];
 
 extern crate rand;
 

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -50,6 +50,7 @@
       html_root_url = "http://static.rust-lang.org/doc/master")];
 #[deny(unused_result, unused_must_use)];
 #[allow(non_camel_case_types)];
+#[allow(deprecated_owned_vector)];
 
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the

--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -14,6 +14,7 @@
 #[crate_type = "rlib"];
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
+#[allow(deprecated_owned_vector)];
 
 extern crate rand;
 

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -71,6 +71,7 @@ println!("{:?}", tuple_ptr)
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
 #[feature(macro_rules, managed_boxes)];
+#[allow(deprecated_owned_vector)];
 
 use std::cast;
 use std::kinds::marker;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -28,6 +28,7 @@ This API is completely unstable and subject to change.
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
 #[allow(deprecated)];
+#[allow(deprecated_owned_vector)];
 #[feature(macro_rules, globs, struct_variant, managed_boxes)];
 #[feature(quote, default_type_params)];
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -14,6 +14,7 @@
 #[crate_type = "dylib"];
 #[crate_type = "rlib"];
 
+#[allow(deprecated_owned_vector)];
 #[feature(globs, struct_variant, managed_boxes, macro_rules)];
 
 extern crate syntax;

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -166,6 +166,9 @@ fn maketest(s: &str, cratename: &str, loose_feature_gating: bool) -> ~str {
     let mut prog = ~r"
 #[deny(warnings)];
 #[allow(unused_variable, dead_assignment, unused_mut, attribute_usage, dead_code)];
+
+// FIXME: remove when ~[] disappears from tests.
+#[allow(deprecated_owned_vector)];
 ";
 
     if loose_feature_gating {

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -42,6 +42,7 @@ via `close` and `delete` methods.
 #[feature(macro_rules)];
 #[deny(unused_result, unused_must_use)];
 #[allow(visible_private_types)];
+#[allow(deprecated_owned_vector)];
 
 #[cfg(test)] extern crate green;
 

--- a/src/libsemver/lib.rs
+++ b/src/libsemver/lib.rs
@@ -33,6 +33,8 @@
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 
+#[allow(deprecated_owned_vector)];
+
 use std::char;
 use std::cmp;
 use std::fmt;

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -25,6 +25,7 @@ Core encoding and decoding interfaces.
 // NOTE remove the following two attributes after the next snapshot.
 #[allow(unrecognized_lint)];
 #[allow(default_type_param_usage)];
+#[allow(deprecated_owned_vector)];
 
 // test harness access
 #[cfg(test)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -65,6 +65,7 @@
 #[deny(non_camel_case_types)];
 #[deny(missing_doc)];
 #[allow(unknown_features)];
+#[allow(deprecated_owned_vector)];
 
 // When testing libstd, bring in libuv as the I/O backend so tests can print
 // things and all of the std::io tests have an I/O interface to run on top

--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Migrate documentation over from `std::vec` when it is removed.
-#[doc(hidden)];
+// Migrate documentation over from `std::vec` progressively.  (This is
+// shown in docs so that people have something to refer too, even if
+// the page is rather empty.)
+#[allow(missing_doc)];
 
 use cast::{forget, transmute};
 use clone::Clone;

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -17,6 +17,8 @@
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 
+#[allow(deprecated_owned_vector)];
+
 pub use arc::{Arc, MutexArc, RWArc, RWWriteMode, RWReadMode, ArcCondvar, CowArc};
 pub use sync::{Mutex, RWLock, Condvar, Semaphore, RWLockWriteMode,
     RWLockReadMode, Barrier, one, mutex};

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -32,6 +32,7 @@ This API is completely unstable and subject to change.
 
 #[allow(deprecated)];
 #[deny(non_camel_case_types)];
+#[allow(deprecated_owned_vector)];
 
 extern crate serialize;
 extern crate term;

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -22,6 +22,7 @@
 #[feature(macro_rules)];
 #[deny(non_camel_case_types)];
 #[allow(missing_doc)];
+#[allow(deprecated_owned_vector)];
 
 extern crate collections;
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -30,6 +30,7 @@
 #[crate_type = "dylib"];
 
 #[feature(asm)];
+#[allow(deprecated_owned_vector)];
 
 extern crate collections;
 extern crate extra;

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -14,6 +14,7 @@
 #[license = "MIT/ASL2"];
 
 #[allow(missing_doc)];
+#[allow(deprecated_owned_vector)];
 
 extern crate serialize;
 

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -59,6 +59,8 @@ Examples of string representations:
 #[crate_type = "dylib"];
 #[license = "MIT/ASL2"];
 
+#[allow(deprecated_owned_vector)];
+
 #[feature(default_type_params)];
 
 // NOTE remove the following two attributes after the next snapshot.

--- a/src/test/compile-fail/issue-8727.rs
+++ b/src/test/compile-fail/issue-8727.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[allow(deprecated_owned_vector)];
 
 // Verify the compiler fails with an error on infinite function
 // recursions.

--- a/src/test/compile-fail/lint-deprecated-owned-vector.rs
+++ b/src/test/compile-fail/lint-deprecated-owned-vector.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deny(unreachable_code)];
-#[allow(unused_variable)];
-#[allow(dead_code)];
-#[allow(deprecated_owned_vector)];
+#[deny(deprecated_owned_vector)];
 
-fn fail_len(v: ~[int]) -> uint {
-    let mut i = 3;
-    fail!();
-    for x in v.iter() { i += 1u; }
-    //~^ ERROR: unreachable statement
-    return i;
+fn main() {
+    ~[1]; //~ ERROR use of deprecated `~[]`
+    //~^ ERROR use of deprecated `~[]`
+    std::vec::with_capacity::<int>(10); //~ ERROR use of deprecated `~[]`
 }
-fn main() {}

--- a/src/test/compile-fail/lint-heap-memory.rs
+++ b/src/test/compile-fail/lint-heap-memory.rs
@@ -11,6 +11,7 @@
 #[feature(managed_boxes)];
 #[forbid(heap_memory)];
 #[allow(dead_code)];
+#[allow(deprecated_owned_vector)];
 
 struct Foo {
     x: @int //~ ERROR type uses managed

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -11,6 +11,7 @@
 #[feature(globs)];
 #[deny(unused_imports)];
 #[allow(dead_code)];
+#[allow(deprecated_owned_vector)];
 
 use cal = bar::c::cc;
 

--- a/src/test/compile-fail/lint-unused-mut-variables.rs
+++ b/src/test/compile-fail/lint-unused-mut-variables.rs
@@ -13,6 +13,7 @@
 #[allow(dead_assignment)];
 #[allow(unused_variable)];
 #[allow(dead_code)];
+#[allow(deprecated_owned_vector)];
 #[deny(unused_mut)];
 
 fn main() {

--- a/src/test/compile-fail/lint-unused-unsafe.rs
+++ b/src/test/compile-fail/lint-unused-unsafe.rs
@@ -12,6 +12,7 @@
 
 #[allow(dead_code)];
 #[deny(unused_unsafe)];
+#[allow(deprecated_owned_vector)];
 
 mod foo {
     extern {

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -13,6 +13,7 @@
 #[feature(macro_rules)];
 #[deny(warnings)];
 #[allow(unused_must_use)];
+#[allow(deprecated_owned_vector)];
 
 use std::fmt;
 use std::io::MemWriter;


### PR DESCRIPTION
lint: add lint for use of a `~[T]`.

This is useless at the moment (since pretty much every crate uses
`~[]`), but should help avoid regressions once completely removed from a
crate.
