### PR TITLE
cmp: switch `min` and `max` to `TotalOrd`

### DIFF
--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -353,8 +353,6 @@ fn pnorm(nums: &~[f64], p: uint) -> f64 {
 
 fn main() {
     let numbers = vec::from_fn(1000000, |_| rand::random::<f64>());
-    println!("Inf-norm = {}",  *numbers.iter().max().unwrap());
-
     let numbers_arc = Arc::new(numbers);
 
     for num in range(1u, 10) {

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -184,12 +184,12 @@ pub trait Equiv<T> {
 }
 
 #[inline]
-pub fn min<T:Ord>(v1: T, v2: T) -> T {
+pub fn min<T: TotalOrd>(v1: T, v2: T) -> T {
     if v1 < v2 { v1 } else { v2 }
 }
 
 #[inline]
-pub fn max<T:Ord>(v1: T, v2: T) -> T {
+pub fn max<T: TotalOrd>(v1: T, v2: T) -> T {
     if v1 > v2 { v1 } else { v2 }
 }
 

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -68,7 +68,7 @@ use cmp;
 use num::{Zero, One, CheckedAdd, CheckedSub, Saturating, ToPrimitive, Int};
 use option::{Option, Some, None};
 use ops::{Add, Mul, Sub};
-use cmp::{Eq, Ord};
+use cmp::{Eq, Ord, TotalOrd};
 use clone::Clone;
 use uint;
 use mem;
@@ -626,7 +626,7 @@ pub trait Iterator<A> {
     /// assert_eq!(*xs.iter().max_by(|x| x.abs()).unwrap(), -10);
     /// ```
     #[inline]
-    fn max_by<B: Ord>(&mut self, f: |&A| -> B) -> Option<A> {
+    fn max_by<B: TotalOrd>(&mut self, f: |&A| -> B) -> Option<A> {
         self.fold(None, |max: Option<(A, B)>, x| {
             let x_val = f(&x);
             match max {
@@ -650,7 +650,7 @@ pub trait Iterator<A> {
     /// assert_eq!(*xs.iter().min_by(|x| x.abs()).unwrap(), 0);
     /// ```
     #[inline]
-    fn min_by<B: Ord>(&mut self, f: |&A| -> B) -> Option<A> {
+    fn min_by<B: TotalOrd>(&mut self, f: |&A| -> B) -> Option<A> {
         self.fold(None, |min: Option<(A, B)>, x| {
             let x_val = f(&x);
             match min {
@@ -917,7 +917,7 @@ pub trait OrdIterator<A> {
     fn min_max(&mut self) -> MinMaxResult<A>;
 }
 
-impl<A: Ord, T: Iterator<A>> OrdIterator<A> for T {
+impl<A: TotalOrd, T: Iterator<A>> OrdIterator<A> for T {
     #[inline]
     fn max(&mut self) -> Option<A> {
         self.fold(None, |max, x| {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1069,7 +1069,7 @@ impl MetricMap {
                     if delta.abs() <= noise {
                         LikelyNoise
                     } else {
-                        let pct = delta.abs() / cmp::max(vold.value, f64::EPSILON) * 100.0;
+                        let pct = delta.abs() / vold.value.max(f64::EPSILON) * 100.0;
                         if vold.noise < 0.0 {
                             // When 'noise' is negative, it means we want
                             // to see deltas that go up over time, and can


### PR DESCRIPTION
The `Float` trait provides correct `min` and `max` methods on floating
point types, providing a consistent result regardless of the order the
parameters are passed.

These generic functions do not take the necessary performance hit to
correctly support a partial order, so the true requirement should be
given as a type bound.

Closes #12712
