### PR TITLE
Refactored while_some (libstd/option.rs)

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -295,10 +295,13 @@ impl<T> Option<T> {
 
     /// Applies a function zero or more times until the result is `None`.
     #[inline]
-    pub fn while_some(self, blk: |v: T| -> Option<T>) {
+    pub fn while_some(self, f: |v: T| -> Option<T>) {
         let mut opt = self;
-        while opt.is_some() {
-            opt = blk(opt.unwrap());
+        loop {
+            match opt {
+                Some(x) => opt = f(x),
+                None => break
+            }
         }
     }
 


### PR DESCRIPTION
The old 'while' needed to match 2 times for each iteration. With the new 'loop' there is just one match needed.

I have also replaced 'blk' by 'f' to be more consistent with parameter names in other functions that are implemented for Option<T>
