### PR TITLE
re-export `Vec` in the collections crate

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -27,6 +27,7 @@ extern crate rand;
 
 #[cfg(test)] extern crate test;
 
+pub use std::vec::Vec;
 pub use bitv::Bitv;
 pub use btree::BTree;
 pub use deque::Deque;


### PR DESCRIPTION
Closes #12542
