### PR TITLE
fix MIPS target

### DIFF
--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -283,6 +283,8 @@ fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,
     unsafe { *sp = 0; }
 
     regs[4] = arg as uint;
+    regs[5] = procedure.code as uint;
+    regs[6] = procedure.env as uint;
     regs[29] = sp as uint;
     regs[25] = fptr as uint;
     regs[31] = fptr as uint;

--- a/src/librustc/back/mips.rs
+++ b/src/librustc/back/mips.rs
@@ -22,7 +22,7 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
 
         data_layout: match target_os {
           abi::OsMacos => {
-            ~"e-p:32:32:32" +
+            ~"E-p:32:32:32" +
                 "-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64" +
                 "-f32:32:32-f64:64:64" +
                 "-v64:64:64-v128:64:128" +
@@ -30,7 +30,7 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
           }
 
           abi::OsWin32 => {
-            ~"e-p:32:32:32" +
+            ~"E-p:32:32:32" +
                 "-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64" +
                 "-f32:32:32-f64:64:64" +
                 "-v64:64:64-v128:64:128" +
@@ -38,7 +38,7 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
           }
 
           abi::OsLinux => {
-            ~"e-p:32:32:32" +
+            ~"E-p:32:32:32" +
                 "-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64" +
                 "-f32:32:32-f64:64:64" +
                 "-v64:64:64-v128:64:128" +
@@ -46,7 +46,7 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
           }
 
           abi::OsAndroid => {
-            ~"e-p:32:32:32" +
+            ~"E-p:32:32:32" +
                 "-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64" +
                 "-f32:32:32-f64:64:64" +
                 "-v64:64:64-v128:64:128" +
@@ -54,7 +54,7 @@ pub fn get_target_strs(target_triple: ~str, target_os: abi::Os) -> target_strs::
           }
 
           abi::OsFreebsd => {
-            ~"e-p:32:32:32" +
+            ~"E-p:32:32:32" +
                 "-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64" +
                 "-f32:32:32-f64:64:64" +
                 "-v64:64:64-v128:64:128" +

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -2133,7 +2133,7 @@ pub mod consts {
             pub static MAP_SHARED : c_int = 0x0001;
             pub static MAP_PRIVATE : c_int = 0x0002;
             pub static MAP_FIXED : c_int = 0x0010;
-            pub static MAP_ANON : c_int = 0x0020;
+            pub static MAP_ANON : c_int = 0x0800;
 
             pub static MAP_FAILED : *c_void = -1 as *c_void;
 
@@ -2425,20 +2425,19 @@ pub mod consts {
             pub static O_DSYNC : c_int = 16;
             pub static O_SYNC : c_int = 16400;
 
-            pub static PROT_GROWSDOWN : c_int = 0x010000000;
-            pub static PROT_GROWSUP : c_int = 0x020000000;
+            pub static PROT_GROWSDOWN : c_int = 0x01000000;
+            pub static PROT_GROWSUP : c_int = 0x02000000;
 
             pub static MAP_TYPE : c_int = 0x000f;
-            pub static MAP_ANONONYMOUS : c_int = 0x0020;
-            pub static MAP_32BIT : c_int = 0x0040;
-            pub static MAP_GROWSDOWN : c_int = 0x0100;
-            pub static MAP_DENYWRITE : c_int = 0x0800;
-            pub static MAP_EXECUTABLE : c_int = 0x01000;
-            pub static MAP_LOCKED : c_int = 0x02000;
-            pub static MAP_NONRESERVE : c_int = 0x04000;
-            pub static MAP_POPULATE : c_int = 0x08000;
-            pub static MAP_NONBLOCK : c_int = 0x010000;
-            pub static MAP_STACK : c_int = 0x020000;
+            pub static MAP_ANONONYMOUS : c_int = 0x0800;
+            pub static MAP_GROWSDOWN : c_int = 0x01000;
+            pub static MAP_DENYWRITE : c_int = 0x02000;
+            pub static MAP_EXECUTABLE : c_int = 0x04000;
+            pub static MAP_LOCKED : c_int = 0x08000;
+            pub static MAP_NONRESERVE : c_int = 0x0400;
+            pub static MAP_POPULATE : c_int = 0x010000;
+            pub static MAP_NONBLOCK : c_int = 0x020000;
+            pub static MAP_STACK : c_int = 0x040000;
         }
         #[cfg(target_os = "linux")]
         pub mod sysconf {

--- a/src/libstd/rt/libunwind.rs
+++ b/src/libstd/rt/libunwind.rs
@@ -65,6 +65,9 @@ pub static unwinder_private_data_size: int = 2;
 #[cfg(target_arch = "arm")]
 pub static unwinder_private_data_size: int = 20;
 
+#[cfg(target_arch = "mips")]
+pub static unwinder_private_data_size: int = 2;
+
 pub struct _Unwind_Exception {
     exception_class: _Unwind_Exception_Class,
     exception_cleanup: _Unwind_Exception_Cleanup_Fn,

--- a/src/libstd/sync/atomics.rs
+++ b/src/libstd/sync/atomics.rs
@@ -225,6 +225,10 @@ impl AtomicInt {
     }
 }
 
+// temporary workaround
+// it causes link failure on MIPS target
+// libgcc doesn't implement 64-bit atomic operations for MIPS32
+#[cfg(not(target_arch = "mips"))]
 impl AtomicU64 {
     pub fn new(v: u64) -> AtomicU64 {
         AtomicU64 { v:v, nopod: marker::NoPod }

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -324,11 +324,15 @@ mod imp {
         static __SIZEOF_PTHREAD_MUTEX_T: uint = 24 - 8;
         #[cfg(target_arch = "arm")]
         static __SIZEOF_PTHREAD_MUTEX_T: uint = 24 - 8;
+        #[cfg(target_arch = "mips")]
+        static __SIZEOF_PTHREAD_MUTEX_T: uint = 24 - 8;
         #[cfg(target_arch = "x86_64")]
         static __SIZEOF_PTHREAD_COND_T: uint = 48 - 8;
         #[cfg(target_arch = "x86")]
         static __SIZEOF_PTHREAD_COND_T: uint = 48 - 8;
         #[cfg(target_arch = "arm")]
+        static __SIZEOF_PTHREAD_COND_T: uint = 48 - 8;
+        #[cfg(target_arch = "mips")]
         static __SIZEOF_PTHREAD_COND_T: uint = 48 - 8;
 
         pub struct pthread_mutex_t {

--- a/src/rt/arch/mips/morestack.S
+++ b/src/rt/arch/mips/morestack.S
@@ -19,38 +19,21 @@ __morestack:
         .set noreorder
         .set nomacro
 
-        // n.b. most of this is probably unnecessary. I know very little mips
-        //      assembly, and I didn't have anything to test on, so I wasn't
-        //      brave enough to try to trim this down.
+        addiu $29, $29, -4
+        sw $30, 0($29)
 
-        addiu $29, $29, -12
-        sw $31, 8($29)
-        sw $30, 4($29)
-        sw $23, 0($29)
-
-        // 24 = 12 (current) + 12 (previous)
-        .cfi_def_cfa_offset 24
+        // 16 = 4 (current) + 12 (previous)
+        .cfi_def_cfa_offset 16
         .cfi_offset 31, -4
-        .cfi_offset 30, -20
-        .cfi_offset 23, -24
+        .cfi_offset 30, -16
 
-        move $23, $28
         move $30, $29
         .cfi_def_cfa_register 30
 
-        // Save argument registers of the original function
-        addiu $29, $29, -32
-        sw $4, 16($29)
-        sw $5, 20($29)
-        sw $6, 24($29)
-        sw $7, 28($29)
+        // O32 ABI always reserves 16 bytes for arguments
+        addiu $29, $29, -16
 
-        move $4, $14     // Size of stack arguments
-        addu $5, $30, 24 // Address of stack arguments
-        move $6, $15     // The amount of stack needed
-
-        move $28, $23
-        lw $25, %call16(rust_stack_exhausted)($23)
+        lw $25, %call16(rust_stack_exhausted)($28)
         jalr $25
         nop
 


### PR DESCRIPTION
I ignored AtomicU64 methods on MIPS target
because libgcc doesn't implement MIPS32 64-bit atomic operations.
Otherwise it would cause link failure.

By the way, the patched LLVM doesn't have MIPS split stack anymore.
Should I file an issue about that?
