### PR TITLE
Strip out non-public modules

### DIFF
--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -128,7 +128,8 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                 }
             }
 
-            clean::ViewItemItem(..) => {
+            clean::ViewItemItem(..) |
+            clean::ModuleItem(..) => {
                 if i.visibility != Some(ast::Public) {
                     return None
                 }
@@ -139,9 +140,6 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                     return None;
                 }
             }
-
-            // handled below
-            clean::ModuleItem(..) => {}
 
             // trait impls for private items should be stripped
             clean::ImplItem(clean::Impl{ for_: clean::ResolvedPath{ id: ref for_id, .. }, .. }) => {


### PR DESCRIPTION
Modules don't actually inherit privacy, so anything other than Public should be considered private.

Fixes #12801

cc @cmr
