### PR TITLE
Fixed comment and refactored functions (libstd/option.rs)

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -211,19 +211,13 @@ impl<T> Option<T> {
     /// Return an iterator over the possibly contained value
     #[inline]
     pub fn iter<'r>(&'r self) -> Item<&'r T> {
-        match *self {
-            Some(ref x) => Item{opt: Some(x)},
-            None => Item{opt: None}
-        }
+        Item{opt: self.as_ref()}
     }
 
     /// Return a mutable iterator over the possibly contained value
     #[inline]
     pub fn mut_iter<'r>(&'r mut self) -> Item<&'r mut T> {
-        match *self {
-            Some(ref mut x) => Item{opt: Some(x)},
-            None => Item{opt: None}
-        }
+        Item{opt: self.as_mut()}
     }
 
     /// Return a consuming iterator over the possibly contained value

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -104,7 +104,7 @@ impl<T> Option<T> {
         }
     }
 
-    /// Convert from `Option<T>` to `&[T]` (without copying)
+    /// Convert from `Option<T>` to `&mut [T]` (without copying)
     #[inline]
     pub fn as_mut_slice<'r>(&'r mut self) -> &'r mut [T] {
         match *self {


### PR DESCRIPTION
The old comment of as_mut_slice() did not describe the function correctly. The new one does.

Also refactored option::iter() and option::mut_iter() to use as_ref() and as_mut() instead of match.
