### PR TITLE
Refactored iter (libstd/option.rs)

### DIFF
--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -211,10 +211,7 @@ impl<T> Option<T> {
     /// Return an iterator over the possibly contained value
     #[inline]
     pub fn iter<'r>(&'r self) -> Item<&'r T> {
-        match *self {
-            Some(ref x) => Item{opt: Some(x)},
-            None => Item{opt: None}
-        }
+        Item{opt: self.as_ref()}
     }
 
     /// Return a mutable iterator over the possibly contained value


### PR DESCRIPTION
Using as_ref() instead of match
