### PR TITLE
Tweak cfg(not(a, b)) and fix building libstd on arm linux

### DIFF
--- a/src/libstd/rt/libunwind.rs
+++ b/src/libstd/rt/libunwind.rs
@@ -98,9 +98,18 @@ extern "C" {
     pub fn _Unwind_Backtrace(trace: _Unwind_Trace_Fn,
                              trace_argument: *libc::c_void)
                 -> _Unwind_Reason_Code;
-    #[cfg(not(target_os = "android"))]
+    #[cfg(stage0, not(target_os = "android"))]
     pub fn _Unwind_GetIP(ctx: *_Unwind_Context) -> libc::uintptr_t;
-    #[cfg(not(target_os = "android"))]
+    #[cfg(stage0, not(target_os = "android"))]
+    pub fn _Unwind_FindEnclosingFunction(pc: *libc::c_void) -> *libc::c_void;
+
+    #[cfg(not(stage0),
+          not(target_os = "android"),
+          not(target_os = "linux", target_arch = "arm"))]
+    pub fn _Unwind_GetIP(ctx: *_Unwind_Context) -> libc::uintptr_t;
+    #[cfg(not(stage0),
+          not(target_os = "android"),
+          not(target_os = "linux", target_arch = "arm"))]
     pub fn _Unwind_FindEnclosingFunction(pc: *libc::c_void) -> *libc::c_void;
 }
 
@@ -108,6 +117,7 @@ extern "C" {
 // of the macro. This is all copy/pasted directly from the header file with the
 // definition of _Unwind_GetIP.
 #[cfg(target_os = "android")]
+#[cfg(target_os = "linux", target_os = "arm")]
 pub unsafe fn _Unwind_GetIP(ctx: *_Unwind_Context) -> libc::uintptr_t {
     #[repr(C)]
     enum _Unwind_VRS_Result {
@@ -151,6 +161,7 @@ pub unsafe fn _Unwind_GetIP(ctx: *_Unwind_Context) -> libc::uintptr_t {
 
 // This function also doesn't exist on android, so make it a no-op
 #[cfg(target_os = "android")]
+#[cfg(target_os = "linux", target_os = "arm")]
 pub unsafe fn _Unwind_FindEnclosingFunction(pc: *libc::c_void) -> *libc::c_void{
     pc
 }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -317,9 +317,9 @@ pub fn test_cfg<AM: AttrMetaMethods, It: Iterator<AM>>
                                 debug!("not!");
                                 // inside #[cfg(not(...))], so these need to all
                                 // not match.
-                                not_cfgs.iter().all(|mi| {
+                                !not_cfgs.iter().all(|mi| {
                                     debug!("cfg(not({}[...]))", mi.name());
-                                    !contains(cfg, *mi)
+                                    contains(cfg, *mi)
                                 })
                             }
                             _ => contains(cfg, *cfg_mi)

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -16,7 +16,7 @@
 fn foo1() -> int { 1 }
 
 // !fooA AND !bar
-#[cfg(not(fooA, bar))]
+#[cfg(not(fooA), not(bar))]
 fn foo2() -> int { 2 }
 
 // fooC OR (fooB AND !bar)
@@ -24,8 +24,16 @@ fn foo2() -> int { 2 }
 #[cfg(fooB, not(bar))]
 fn foo2() -> int { 3 }
 
+// fooA AND bar
+#[cfg(fooA, bar)]
+fn foo3() -> int { 2 }
+
+// !(fooA AND bar)
+#[cfg(not(fooA, bar))]
+fn foo3() -> int { 3 }
 
 pub fn main() {
     assert_eq!(1, foo1());
     assert_eq!(3, foo2());
+    assert_eq!(3, foo3());
 }


### PR DESCRIPTION
The two commits have the details of the two fixes
