### PR TITLE
std: Rename {push,read}_bytes to {push,read}_exact

### DIFF
--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -283,7 +283,7 @@ mod test {
     #[test]
     fn read_bytes() {
         let mut reader = MemReader::new(~[10, 11, 12, 13]);
-        let bytes = reader.read_bytes(4).unwrap();
+        let bytes = reader.read_exact(4).unwrap();
         assert!(bytes == ~[10, 11, 12, 13]);
     }
 
@@ -292,49 +292,49 @@ mod test {
         let mut reader = PartialReader {
             count: 0,
         };
-        let bytes = reader.read_bytes(4).unwrap();
+        let bytes = reader.read_exact(4).unwrap();
         assert!(bytes == ~[10, 11, 12, 13]);
     }
 
     #[test]
     fn read_bytes_eof() {
         let mut reader = MemReader::new(~[10, 11]);
-        assert!(reader.read_bytes(4).is_err());
+        assert!(reader.read_exact(4).is_err());
     }
 
     #[test]
-    fn push_bytes() {
+    fn push_exact() {
         let mut reader = MemReader::new(~[10, 11, 12, 13]);
         let mut buf = ~[8, 9];
-        reader.push_bytes(&mut buf, 4).unwrap();
+        reader.push_exact(&mut buf, 4).unwrap();
         assert!(buf == ~[8, 9, 10, 11, 12, 13]);
     }
 
     #[test]
-    fn push_bytes_partial() {
+    fn push_exact_partial() {
         let mut reader = PartialReader {
             count: 0,
         };
         let mut buf = ~[8, 9];
-        reader.push_bytes(&mut buf, 4).unwrap();
+        reader.push_exact(&mut buf, 4).unwrap();
         assert!(buf == ~[8, 9, 10, 11, 12, 13]);
     }
 
     #[test]
-    fn push_bytes_eof() {
+    fn push_exact_eof() {
         let mut reader = MemReader::new(~[10, 11]);
         let mut buf = ~[8, 9];
-        assert!(reader.push_bytes(&mut buf, 4).is_err());
+        assert!(reader.push_exact(&mut buf, 4).is_err());
         assert!(buf == ~[8, 9, 10, 11]);
     }
 
     #[test]
-    fn push_bytes_error() {
+    fn push_exact_error() {
         let mut reader = ErroringLaterReader {
             count: 0,
         };
         let mut buf = ~[8, 9];
-        assert!(reader.push_bytes(&mut buf, 4).is_err());
+        assert!(reader.push_exact(&mut buf, 4).is_err());
         assert!(buf == ~[8, 9, 10]);
     }
 

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -208,7 +208,7 @@ pub fn parse(file: &mut io::Reader,
     }
 
     // don't read NUL
-    let bytes = try!(file.read_bytes(names_bytes as uint - 1));
+    let bytes = try!(file.read_exact(names_bytes as uint - 1));
     let names_str = match str::from_utf8_owned(bytes) {
         Some(s) => s, None => return Err(~"input not utf-8"),
     };
@@ -251,7 +251,7 @@ pub fn parse(file: &mut io::Reader,
             string_offsets.push(try!(file.read_le_u16()));
         }
 
-        let string_table = try!(file.read_bytes(string_table_bytes as uint));
+        let string_table = try!(file.read_exact(string_table_bytes as uint));
 
         if string_table.len() != string_table_bytes as uint {
             return Err(~"error: hit EOF before end of string table");


### PR DESCRIPTION
These methods can be mistaken for general "read some bytes" utilities when
they're actually only meant for reading an exact number of bytes. By renaming
them it's much clearer about what they're doing without having to read the
documentation.

Closes #12892
