### PR TITLE
green: Don't return the red zone in stack_bounds()

### DIFF
--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -20,14 +20,15 @@
 
 use std::any::Any;
 use std::cast;
-use std::rt::env;
+use std::raw;
 use std::rt::Runtime;
+use std::rt::env;
 use std::rt::local::Local;
 use std::rt::rtio;
+use std::rt::stack;
 use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::task::TaskOpts;
 use std::unstable::mutex::NativeMutex;
-use std::raw;
 
 use context::Context;
 use coroutine::Coroutine;
@@ -469,7 +470,9 @@ impl Runtime for GreenTask {
         let c = self.coroutine.as_ref()
             .expect("GreenTask.stack_bounds called without a coroutine");
 
-        (c.current_stack_segment.start() as uint,
+        // Don't return the red zone as part of the usable stack of this task,
+        // it's essentially an implementation detail.
+        (c.current_stack_segment.start() as uint + stack::RED_ZONE,
          c.current_stack_segment.end() as uint)
     }
 


### PR DESCRIPTION
This is mostly just an implementation detail, and anyone worried about the stack
bounds doesn't need to be bothered with the red zone because it's not usable
anyway.

Closes #12897
