### PR TITLE
More ergonomic multiple-data expressions.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -50,8 +50,9 @@
 ################################################################################
 
 TARGET_CRATES := std extra green rustuv native flate arena glob term semver \
-                 uuid serialize sync getopts collections num test time rand
-HOST_CRATES := syntax rustc rustdoc fourcc hexfloat
+                 uuid serialize sync getopts collections num test time rand \
+		 simd
+HOST_CRATES := syntax rustc rustdoc fourcc hexfloat simd_syntax
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustdoc rustc
 
@@ -81,6 +82,8 @@ DEPS_num := std rand
 DEPS_test := std extra collections getopts serialize term
 DEPS_time := std serialize
 DEPS_rand := std
+DEPS_simd := std simd_syntax
+DEPS_simd_syntax := syntax std
 
 TOOL_DEPS_compiletest := test green rustuv getopts
 TOOL_DEPS_rustdoc := rustdoc native

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -413,6 +413,22 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
           assert_eq!(next(st), ']');
           return ty::mk_struct(st.tcx, did, substs);
       }
+      'S' => {
+          assert_eq!(next(st), '[');
+          let prim_ty = parse_ty(st, |x, y| conv(x, y) );
+          if !ty::type_is_simd_scalar(st.tcx, prim_ty) {
+              error!("invalid type in simd: {}", ::util::ppaux::ty_to_str(st.tcx, prim_ty));
+              fail!();
+          }
+          assert_eq!(next(st), 'x');
+          let count = parse_uint(st);
+          if count == 0 {
+              error!("invalid simd element count: {}", count);
+              fail!();
+          }
+          assert_eq!(next(st), ']');
+          return ty::mk_simd(st.tcx, prim_ty, count);
+      }
       c => { error!("unexpected char in type string: {}", c); fail!();}
     }
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -336,6 +336,11 @@ fn enc_sty(w: &mut MemWriter, cx: @ctxt, st: &ty::sty) {
             enc_substs(w, cx, substs);
             mywrite!(w, "]");
         }
+        ty::ty_simd(t, n) => {
+            mywrite!(w, "S[");
+            enc_ty(w, cx, t);
+            mywrite!(w, "x{}]", n);
+        }
         ty::ty_err => fail!("shouldn't encode error type")
     }
 }

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -597,8 +597,13 @@ impl<'a, O:DataFlowOperator> PropagationContext<'a, O> {
                 self.walk_call(expr.id, [e], in_out, loop_scopes);
             }
 
-            ast::ExprTup(ref exprs) => {
+            ast::ExprTup(ref exprs) | ast::ExprSimd(ref exprs) => {
                 self.walk_exprs(exprs.as_slice(), in_out, loop_scopes);
+            }
+            ast::ExprSwizzle(left, opt_right, ref mask) => {
+                self.walk_expr(left, in_out, loop_scopes);
+                self.walk_opt_expr(opt_right, in_out, loop_scopes);
+                self.walk_exprs(mask.as_slice(), in_out, loop_scopes);
             }
 
             ast::ExprBinary(op, l, r) if ast_util::lazy_binop(op) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -208,7 +208,7 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
         }
 
         ty::ty_vec(_, ty::vstore_fixed(_)) |
-        ty::ty_str(ty::vstore_fixed(_)) => {
+        ty::ty_str(ty::vstore_fixed(_)) | ty::ty_simd(..) => {
             Some(deref_interior(InteriorElement(element_kind(t))))
         }
 
@@ -473,7 +473,8 @@ impl<TYPER:Typer> MemCategorizationContext<TYPER> {
           ast::ExprBlock(..) | ast::ExprLoop(..) | ast::ExprMatch(..) |
           ast::ExprLit(..) | ast::ExprBreak(..) | ast::ExprMac(..) |
           ast::ExprAgain(..) | ast::ExprStruct(..) | ast::ExprRepeat(..) |
-          ast::ExprInlineAsm(..) | ast::ExprBox(..) => {
+          ast::ExprInlineAsm(..) | ast::ExprBox(..) | ast::ExprSwizzle(..) |
+          ast::ExprSimd(..) => {
             Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
           }
 
@@ -814,7 +815,7 @@ impl<TYPER:Typer> MemCategorizationContext<TYPER> {
         //! - `derefs`: the deref number to be used for
         //!   the implicit index deref, if any (see above)
 
-        let element_ty = match ty::index(base_cmt.ty) {
+        let element_ty = match ty::index(self.tcx(), base_cmt.ty) {
           Some(ref mt) => mt.ty,
           None => {
             self.tcx().sess.span_bug(

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -465,8 +465,15 @@ impl VisitContext {
                     }
                 }
             }
+            ExprSwizzle(left_expr, opt_right_expr, _) => {
+                self.consume_expr(left_expr);
+                match opt_right_expr {
+                    Some(r) => self.consume_expr(r),
+                    None => {}
+                }
+            }
 
-            ExprTup(ref exprs) => {
+            ExprTup(ref exprs) | ExprSimd(ref exprs) => {
                 self.consume_exprs(exprs.as_slice());
             }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -680,6 +680,11 @@ pub fn C_bytes(bytes: &[u8]) -> ValueRef {
         return llvm::LLVMConstStringInContext(base::task_llcx(), ptr, bytes.len() as c_uint, True);
     }
 }
+pub fn C_vector(elts: &[ValueRef]) -> ValueRef {
+    unsafe {
+        llvm::LLVMConstVector(elts.as_ptr(), elts.len() as u32)
+    }
+}
 
 pub fn get_param(fndecl: ValueRef, param: uint) -> ValueRef {
     unsafe {

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -25,6 +25,7 @@ use middle::trans::glue;
 use middle::trans::tvec;
 use middle::trans::type_of;
 use middle::trans::write_guard;
+use middle::trans::simd;
 use middle::ty;
 use util::ppaux::{ty_to_str};
 
@@ -529,9 +530,12 @@ impl Datum<Lvalue> {
     }
 
     pub fn get_vec_base_and_len<'a>(&self, bcx: &'a Block<'a>) -> (ValueRef, ValueRef) {
-        //! Converts a vector into the slice pair.
-
-        tvec::get_base_and_len(bcx, self.val, self.ty)
+        //! Converts a vector or a simd into the slice pair.
+        if ty::type_is_simd(bcx.ccx().tcx, self.ty) {
+            simd::get_base_and_len(bcx, self.val, self.ty)
+        } else {
+            tvec::get_base_and_len(bcx, self.val, self.ty)
+        }
     }
 }
 

--- a/src/librustc/middle/trans/mod.rs
+++ b/src/librustc/middle/trans/mod.rs
@@ -46,3 +46,4 @@ pub mod value;
 pub mod basic_block;
 pub mod llrepr;
 pub mod cleanup;
+pub mod simd;

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -278,6 +278,13 @@ impl<'a> Reflector<'a> {
               })
           }
 
+            ty::ty_simd(inner_ty, count) => {
+                let extra = vec_ng::append(vec!(self.c_tydesc(inner_ty),
+                                                self.c_uint(count)),
+                                           self.c_size_and_align(t).as_slice());
+                self.visit("simd", extra.as_slice())
+            }
+
           // FIXME (#2595): visiting all the variants in turn is probably
           // not ideal. It'll work but will get costly on big enums. Maybe
           // let the visitor tell us if it wants to visit only a particular

--- a/src/librustc/middle/trans/simd.rs
+++ b/src/librustc/middle/trans/simd.rs
@@ -1,0 +1,23 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use middle::ty;
+use middle::ty::{simd_size};
+use middle::trans::build::GEPi;
+use middle::trans::common::{Block, C_uint};
+use lib::llvm::ValueRef;
+
+pub fn get_base_and_len(bcx: &Block,
+                        llval: ValueRef,
+                        ty: ty::t)
+                        -> (ValueRef, ValueRef) {
+    (GEPi(bcx, llval, [0, 0]),
+     C_uint(bcx.ccx(), simd_size(bcx.ccx().tcx, ty)))
+}

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -161,6 +161,10 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
             }
         }
 
+        ty::ty_simd(t, n) => {
+            Type::vector(&type_of(cx, t), n as u64)
+        }
+
         ty::ty_self(_) | ty::ty_infer(..) | ty::ty_param(..) | ty::ty_err(..) => {
             cx.tcx.sess.bug(format!("fictitious type {:?} in sizing_type_of()", ty::get(t).sty))
         }
@@ -287,6 +291,9 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
                                         substs.tps.as_slice());
               adt::incomplete_type_of(cx, repr, name)
           }
+      }
+      ty::ty_simd(t, n) => {
+          Type::vector(&type_of(cx, t), n as u64)
       }
       ty::ty_self(..) => cx.tcx.sess.unimpl("type_of: ty_self"),
       ty::ty_infer(..) => cx.tcx.sess.bug("type_of with ty_infer"),

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -189,7 +189,7 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_nil | ty::ty_bot | ty::ty_bool | ty::ty_char |
         ty::ty_int(_) | ty::ty_uint(_) | ty::ty_float(_) |
         ty::ty_err | ty::ty_infer(_) |
-        ty::ty_param(..) | ty::ty_self(_) => {
+        ty::ty_param(..) | ty::ty_self(_) | ty::ty_simd(..) => {
             (*sty).clone()
         }
     }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -838,10 +838,11 @@ impl<'a> LookupContext<'a> {
             ty_bare_fn(..) | ty_box(..) | ty_uniq(..) | ty_rptr(..) |
             ty_infer(IntVar(_)) |
             ty_infer(FloatVar(_)) |
+            ty_infer(MDVar(..)) |
             ty_self(_) | ty_param(..) | ty_nil | ty_bot | ty_bool |
             ty_char | ty_int(..) | ty_uint(..) |
             ty_float(..) | ty_enum(..) | ty_ptr(..) | ty_struct(..) | ty_tup(..) |
-            ty_str(..) | ty_vec(..) | ty_trait(..) | ty_closure(..) => {
+            ty_str(..) | ty_vec(..) | ty_trait(..) | ty_closure(..) | ty_simd(..) => {
                 self.search_for_some_kind_of_autorefd_method(
                     AutoPtr, autoderefs, [MutImmutable, MutMutable],
                     |m,r| ty::mk_rptr(tcx, r, ty::mt {ty:self_ty, mutbl:m}))

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -21,7 +21,7 @@ use middle::ty::get;
 use middle::ty::{ImplContainer, lookup_item_type, subst};
 use middle::ty::{substs, t, ty_bool, ty_char, ty_bot, ty_box, ty_enum, ty_err};
 use middle::ty::{ty_str, ty_vec, ty_float, ty_infer, ty_int, ty_nil};
-use middle::ty::{ty_param, ty_param_bounds_and_ty, ty_ptr};
+use middle::ty::{ty_param, ty_param_bounds_and_ty, ty_ptr, ty_simd};
 use middle::ty::{ty_rptr, ty_self, ty_struct, ty_trait, ty_tup};
 use middle::ty::{ty_uint, ty_uniq, ty_bare_fn, ty_closure};
 use middle::ty::{ty_unboxed_vec, type_is_ty_var};
@@ -85,7 +85,7 @@ fn get_base_type(inference_context: &InferCtxt,
         ty_str(..) | ty_vec(..) | ty_bare_fn(..) | ty_closure(..) | ty_tup(..) |
         ty_infer(..) | ty_param(..) | ty_self(..) |
         ty_unboxed_vec(..) | ty_err | ty_box(_) |
-        ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
+        ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) | ty_simd(..) => {
             debug!("(getting base type) no base type; found {:?}",
                    get(original_type).sty);
             None

--- a/src/librustc/middle/typeck/infer/to_str.rs
+++ b/src/librustc/middle/typeck/infer/to_str.rs
@@ -92,3 +92,8 @@ impl InferStr for ty::TraitRef {
         trait_ref_to_str(cx.tcx, self)
     }
 }
+impl InferStr for ty::MDVarValue {
+    fn inf_str(&self, _cx: &InferCtxt) -> ~str {
+        self.to_str()
+    }
+}

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -309,3 +309,16 @@ impl SimplyUnifiable for ast::FloatTy {
         return ty::terr_float_mismatch(err);
     }
 }
+
+impl UnifyVid<Option<ty::MDVarValue>> for ty::MDVid {
+    fn appropriate_vals_and_bindings<'v>(infcx: &'v InferCtxt)
+        -> &'v RefCell<ValsAndBindings<ty::MDVid, Option<ty::MDVarValue>>> {
+        return &infcx.md_var_bindings;
+    }
+}
+
+impl SimplyUnifiable for ty::MDVarValue {
+    fn to_type_err(err: expected_found<ty::MDVarValue>) -> ty::type_err {
+        return ty::terr_md_mismatch(err);
+    }
+}

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -667,6 +667,9 @@ impl<'a> ConstraintContext<'a> {
                     self.add_constraints_from_ty(subty, variance);
                 }
             }
+            ty::ty_simd(t, _) => {
+                self.add_constraints_from_ty(t, variance);
+            }
 
             ty::ty_enum(def_id, ref substs) |
             ty::ty_struct(def_id, ref substs) => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -16,7 +16,7 @@ use middle::ty::{BrFresh, ctxt};
 use middle::ty::{mt, t, param_ty};
 use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region,
                  ReEmpty};
-use middle::ty::{ty_bool, ty_char, ty_bot, ty_box, ty_struct, ty_enum};
+use middle::ty::{ty_bool, ty_char, ty_bot, ty_box, ty_struct, ty_enum, ty_simd};
 use middle::ty::{ty_err, ty_str, ty_vec, ty_float, ty_bare_fn, ty_closure};
 use middle::ty::{ty_nil, ty_param, ty_ptr, ty_rptr, ty_self, ty_tup};
 use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_unboxed_vec, ty_infer};
@@ -453,6 +453,7 @@ pub fn ty_to_str(cx: ctxt, typ: t) -> ~str {
         let strs = elems.map(|elem| ty_to_str(cx, *elem));
         ~"(" + strs.connect(",") + ")"
       }
+      ty_simd(t, count) => format!("<{:s}, ..{:u}>", ty_to_str(cx, t), count),
       ty_closure(ref f) => {
           closure_to_str(cx, f)
       }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -705,6 +705,7 @@ impl Clean<Type> for ast::Ty {
             TyClosure(ref c) => Closure(~c.clean()),
             TyBareFn(ref barefn) => BareFunction(~barefn.clean()),
             TyBot => Bottom,
+            TySimd(t, ref count) => FixedVector(~t.clean(), count.span.to_str()),
             ref x => fail!("Unimplemented type {:?}", x),
         }
     }

--- a/src/libsimd/lib.rs
+++ b/src/libsimd/lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #[crate_id = "simd#0.10-pre"];
+#[crate_type = "dylib"];
 #[crate_type = "rlib"];
 #[license = "MIT/ASL2"];
 #[comment = "A link-time library to facilitate access to SIMD types & operations"];

--- a/src/libsimd/lib.rs
+++ b/src/libsimd/lib.rs
@@ -1,0 +1,214 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_id = "simd#0.10-pre"];
+#[crate_type = "rlib"];
+#[license = "MIT/ASL2"];
+#[comment = "A link-time library to facilitate access to SIMD types & operations"];
+
+#[feature(macro_registrar, simd, phase, macro_rules)];
+#[allow(experimental)];
+#[experimental];
+
+#[phase(syntax)]
+extern crate simd_syntax;
+
+use std::iter;
+use std::container::Container;
+use std::cast;
+
+pub trait Simd<PrimitiveTy> {
+    fn every(self, value: PrimitiveTy) -> bool;
+    fn any(self, value: PrimitiveTy) -> bool;
+
+    fn iter<'a>(&'a self) -> Items<'a, PrimitiveTy>;
+    fn mut_iter<'a>(&'a mut self) -> MutItems<'a, PrimitiveTy>;
+
+    fn as_slice<'a>(&'a self) -> &'a [PrimitiveTy];
+    fn as_mut_slice<'a>(&'a mut self) -> &'a mut [PrimitiveTy];
+
+    fn len(&self) -> uint;
+}
+pub trait BoolSimd {
+    fn every_true(self) -> bool;
+    fn every_false(self) -> bool;
+    fn any_true(self) -> bool;
+    fn any_false(self) -> bool;
+}
+impl<T: Simd<bool>> BoolSimd for T {
+    #[inline] fn every_true(self) -> bool { self.every(true) }
+    #[inline] fn every_false(self) -> bool { self.every(false) }
+    #[inline] fn any_true(self) -> bool { self.any(true) }
+    #[inline] fn any_false(self) -> bool { self.any(false) }
+}
+
+#[deriving(Eq, Clone)]
+pub struct Items<'a, ElemT> {
+    priv vec: *ElemT,
+    priv pos: uint,
+    priv len: uint,
+}
+#[deriving(Eq, Clone)]
+pub struct MutItems<'a, ElemT> {
+    priv vec: *mut ElemT,
+    priv pos: uint,
+    priv len: uint,
+}
+
+impl<'a, ElemT> iter::Iterator<&'a ElemT> for Items<'a, ElemT> {
+    fn next(&mut self) -> Option<&'a ElemT> {
+        if self.pos >= self.len {
+            None
+        } else {
+            self.pos += 1;
+            Some(unsafe { cast::transmute(self.vec.offset((self.pos - 1) as int)) })
+        }
+    }
+}
+impl<'a, ElemT> iter::Iterator<&'a mut ElemT> for MutItems<'a, ElemT> {
+    fn next(&mut self) -> Option<&'a mut ElemT> {
+        if self.pos >= self.len {
+            None
+        } else {
+            self.pos += 1;
+            Some(unsafe { cast::transmute(self.vec.offset((self.pos - 1) as int)) })
+        }
+    }
+}
+
+macro_rules! _def(
+    ($ident:ident = ($prim:ty, ..$len:expr)) => {
+        def_type_simd!( #[allow(non_camel_case_types)]
+                        pub type $ident = <$prim, ..$len>)
+        impl Simd<$prim> for $ident {
+            #[inline] fn every(self, value: $prim) -> bool {
+                for i in iter::range(0u, $len as uint) {
+                    if self[i] != value {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            #[inline] fn any(self, value: $prim) -> bool {
+                for i in iter::range(0u, $len as uint) {
+                    if self[i] == value {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            fn iter<'a>(&'a self) -> Items<'a, $prim> {
+                Items {
+                    vec: unsafe { cast::transmute(self) },
+                    pos: 0,
+                    len: $len,
+                }
+            }
+            fn mut_iter<'a>(&'a mut self) -> MutItems<'a, $prim> {
+                MutItems {
+                    vec: unsafe { cast::transmute(self) },
+                    pos: 0,
+                    len: $len,
+                }
+            }
+
+            fn as_slice<'a>(&'a self) -> &'a [$prim] {
+                use std::raw::Slice;
+                unsafe {
+                    cast::transmute_copy(&Slice {
+                        data: self as *$ident as *$prim,
+                        len: $len,
+                    })
+                }
+            }
+            fn as_mut_slice<'a>(&'a mut self) -> &'a mut [$prim] {
+                use std::raw::Slice;
+                unsafe {
+                    cast::transmute_copy(&Slice {
+                        data: cast::transmute::<*mut $prim, *$prim>
+                            (self as *mut $ident as *mut $prim),
+                        len: $len,
+                    })
+                }
+            }
+
+            #[inline(always)] fn len(&self) -> uint { $len }
+        }
+    }
+)
+_def!(boolx2  = (bool, ..2 ))
+_def!(boolx4  = (bool, ..4 ))
+_def!(boolx8  = (bool, ..8 ))
+_def!(boolx16 = (bool, ..16))
+_def!(boolx32 = (bool, ..32))
+_def!(boolx64 = (bool, ..64))
+
+_def!(i8x16   = (i8,   ..16))
+_def!(i8x32   = (i8,   ..32))
+_def!(i8x64   = (i8,   ..64))
+_def!(u8x16   = (u8,   ..16))
+_def!(u8x32   = (u8,   ..32))
+_def!(u8x64   = (u8,   ..64))
+
+_def!(i16x8   = (i16,  ..8 ))
+_def!(i16x16  = (i16,  ..16))
+_def!(i16x32  = (i16,  ..32))
+_def!(u16x8   = (u16,  ..8 ))
+_def!(u16x16  = (u16,  ..16))
+_def!(u16x32  = (u16,  ..32))
+
+_def!(i32x4   = (i32,  ..4 ))
+_def!(i32x8   = (i32,  ..8 ))
+_def!(i32x16  = (i32,  ..16))
+_def!(u32x4   = (u32,  ..4 ))
+_def!(u32x8   = (u32,  ..8 ))
+_def!(u32x16  = (u32,  ..16))
+
+_def!(i64x2   = (i64,  ..2 ))
+_def!(i64x4   = (i64,  ..4 ))
+_def!(i64x8   = (i64,  ..8 ))
+_def!(u64x2   = (u64,  ..2 ))
+_def!(u64x4   = (u64,  ..4 ))
+_def!(u64x8   = (u64,  ..8 ))
+
+_def!(f32x4   = (f32,  ..4 ))
+_def!(f32x8   = (f32,  ..8 ))
+_def!(f32x16  = (f32,  ..16))
+_def!(f64x2   = (f64,  ..2 ))
+_def!(f64x4   = (f64,  ..4 ))
+_def!(f64x8   = (f64,  ..8 ))
+
+#[cfg(test)]
+mod test {
+    use super::Simd;
+    #[test]
+    fn as_slice() {
+        let v: super::i32x4 = gather_simd!(1, 2, 3, 4);
+        assert!(v.as_slice() == [1, 2, 3, 4]);
+
+        let v: super::i32x4 = gather_simd!(1, 2, 3, 4);
+        let v = swizzle_simd!(v -> (3, 2, 1, 0));
+        assert!(v.as_slice() == [4, 3, 2, 1]);
+    }
+    #[test]
+    fn as_mut_slice() {
+        let mut v: super::i32x4 = gather_simd!(1, 2, 3, 4);
+        assert!(v.as_slice() == [1, 2, 3, 4]);
+        v.as_mut_slice()[0] = 10;
+        assert!(v.as_slice() == [10, 2, 3, 4]);
+
+        let v: super::i32x4 = gather_simd!(1, 2, 3, 4);
+        let mut v = swizzle_simd!(v -> (3, 2, 1, 0));
+        assert!(v.as_slice() == [4, 3, 2, 1]);
+        v.as_mut_slice()[0] = 10;
+        assert!(v.as_slice() == [10, 3, 2, 1]);
+    }
+}

--- a/src/libsimd_syntax/lib.rs
+++ b/src/libsimd_syntax/lib.rs
@@ -1,0 +1,221 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_id = "simd_syntax#0.10-pre"];
+#[crate_type = "dylib"];
+#[license = "MIT/ASL2"];
+#[comment = "A parse-time library to facilitate access to SIMD types & operations"];
+
+#[feature(macro_registrar, managed_boxes)];
+#[allow(deprecated_owned_vector)];
+
+extern crate syntax;
+
+use syntax::ast::{Expr, ExprSwizzle, ExprSimd, DUMMY_NODE_ID, Name};
+use syntax::ast::{P, Item, TokenTree, Ty, TySimd};
+use syntax::{ast, ast_util};
+use syntax::codemap::{respan, mk_sp};
+use syntax::ext::base::{get_exprs_from_tts, SyntaxExtension, BasicMacroExpander};
+use syntax::ext::base::{ExtCtxt, MacResult, MRExpr, MRItem, NormalTT};
+use syntax::codemap::{Span, Spanned};
+use syntax::parse::{parser, token, tts_to_parser};
+use syntax::parse::token::keywords;
+use syntax::parse::common::{seq_sep_trailing_allowed};
+use syntax::parse::attr::ParserAttr;
+
+use std::option::{Option, Some, None};
+use std::vec_ng::Vec;
+
+#[macro_registrar]
+pub fn macro_registrar(register: |Name, SyntaxExtension|) {
+    register(token::intern("gather_simd"),
+             NormalTT(~BasicMacroExpander {
+                expander: make_simd,
+                span: None,
+            },
+                      None));
+    register(token::intern("def_type_simd"),
+             NormalTT(~BasicMacroExpander {
+                expander: make_def_simd_type,
+                span: None,
+            },
+                      None));
+    register(token::intern("swizzle_simd"),
+             NormalTT(~BasicMacroExpander {
+                expander: make_swizzle,
+                span: None,
+            },
+                      None));
+}
+
+fn make_simd(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> MacResult {
+    let elements = match get_exprs_from_tts(cx, sp, tts) {
+        Some(e) => e,
+        None => {
+            cx.span_err(sp, "SIMD gather with zero elements");
+            return MacResult::dummy_expr(sp);
+        }
+    };
+    MRExpr(@Expr{ id: DUMMY_NODE_ID, span: sp, node: ExprSimd(elements)})
+}
+fn make_def_simd_type(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> MacResult {
+
+    let parse_simd_ty = |cx: &mut ExtCtxt,
+                         parser: &mut parser::Parser,
+                         sep_token: &[token::Token],
+                         require_simd_ty: bool|
+                     -> Option<P<Ty>> {
+        if parser.eat(&token::LT) {
+            let lo = parser.span.lo;
+            let prim = parser.parse_ty(false);
+            parser.expect(&token::COMMA);
+            parser.expect(&token::DOTDOT);
+
+            let count = {
+                let mut lhs = cx.expand_expr(parser.parse_bottom_expr());
+                loop {
+                    if parser.token == token::GT &&
+                        parser.look_ahead(1, |token| {
+                            sep_token.iter().any(|t| t == token )
+                        }) {
+                        break;
+                    } else {
+                        lhs = parser.parse_more_binops(lhs, 0);
+                    }
+                }
+                lhs
+            };
+            parser.expect(&token::GT);
+            parser.bump();
+            Some(P(Ty{ id: DUMMY_NODE_ID,
+                       node: TySimd(prim, count),
+                       span: mk_sp(lo, parser.span.hi),
+                    }))
+        } else if !require_simd_ty {
+            Some(parser.parse_ty(false))
+        } else {
+            cx.span_err(parser.span, "expected a SIMD type");
+            None
+        }
+    };
+
+    let mut parser =
+        tts_to_parser(cx.parse_sess(),
+                      tts.to_owned().move_iter().collect(),
+                      cx.cfg());
+
+    let attrs = {
+        let mut attrs = Vec::new();
+        let mut cont = true;
+        while cont {
+            match parser.token {
+                token::INTERPOLATED(token::NtAttr(attr)) => {
+                    parser.bump();
+                    attrs.push(*attr);
+                }
+                token::POUND => {
+                    let lo = parser.span.lo;
+                    parser.bump();
+                    parser.expect(&token::LBRACKET);
+                    let meta_item = parser.parse_meta_item();
+                    parser.expect(&token::RBRACKET);
+                    let hi = parser.span.hi;
+                    attrs.push(Spanned {
+                            span: mk_sp(lo, hi),
+                            node: ast::Attribute_ {
+                                style: ast::AttrOuter,
+                                value: meta_item,
+                                is_sugared_doc: false,
+                            }
+                        });
+                }
+                _ => cont = false,
+            };
+        }
+        attrs
+    };
+
+    let vis = parser.parse_visibility();
+    let ty_type;
+
+    if parser.eat_keyword(keywords::Type) {
+        ty_type = keywords::Type;
+    } else if parser.eat_keyword(keywords::Struct) {
+        ty_type = keywords::Struct;
+    } else {
+        let token_str = parser.this_token_to_str();
+        parser.span_err(sp,
+                        format!("expected `type` or `struct` but found `{}`",
+                                token_str));
+        return MacResult::dummy_expr(sp);
+    }
+
+    let ident = parser.parse_ident();
+    let opt_inner;
+    match ty_type {
+        keywords::Type => {
+            parser.expect(&token::EQ);
+            opt_inner = parse_simd_ty(cx, &mut parser, [token::SEMI, token::EOF], true);
+            parser.expect(&token::EOF);
+        }
+        keywords::Struct => {
+            parser.expect(&token::LPAREN);
+            opt_inner = parse_simd_ty(cx, &mut parser, [token::RPAREN], true);
+            parser.eat(&token::SEMI);
+            parser.expect(&token::EOF);
+        }
+        _ => unreachable!(),
+    };
+    match opt_inner {
+        Some(inner) => {
+            let item = Item{
+                vis: vis,
+                attrs: attrs,
+                ident: ident,
+                id: ast::DUMMY_NODE_ID,
+                node: match ty_type {
+                    keywords::Struct => ast::ItemStruct(@ast::StructDef {
+                            fields: Vec::from_elem(1,
+                                                   respan(inner.span, ast::StructField_ {
+                                        kind: ast::UnnamedField,
+                                        id: ast::DUMMY_NODE_ID,
+                                        ty: inner,
+                                        attrs: Vec::new(),
+                                    })),
+                            ctor_id: Some(ast::DUMMY_NODE_ID),
+                        }, ast_util::empty_generics()),
+                    keywords::Type => ast::ItemTy(inner, ast_util::empty_generics()),
+                    _ => unreachable!(),
+                },
+                span: sp,
+            };
+            MRItem(@item)
+        }
+        None => MacResult::dummy_expr(sp)
+    }
+}
+fn make_swizzle(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> MacResult {
+    let mut parser = tts_to_parser(cx.parse_sess(),
+                                   tts.to_owned().move_iter().collect(),
+                                   cx.cfg());
+    let left = parser.parse_expr();
+    let opt_right = if parser.eat(&token::DOTDOT) {
+        Some(parser.parse_expr())
+    } else { None };
+    parser.expect(&token::RARROW);
+    let mask = parser.parse_unspanned_seq(&token::LPAREN,
+                                          &token::RPAREN,
+                                          seq_sep_trailing_allowed(token::COMMA),
+                                          |s| {
+            cx.expand_expr(s.parse_expr())
+        });
+
+    MRExpr(@Expr{ id: DUMMY_NODE_ID, span: sp, node: ExprSwizzle(left, opt_right, mask)})
+}

--- a/src/libstd/intrinsics.rs
+++ b/src/libstd/intrinsics.rs
@@ -162,6 +162,12 @@ pub trait TyVisitor {
     fn visit_trait(&mut self, name: &str) -> bool;
     fn visit_param(&mut self, i: uint) -> bool;
     fn visit_self(&mut self) -> bool;
+
+    fn visit_simd(&mut self,
+                  inner_ty: *TyDesc,
+                  count: uint,
+                  size: uint,
+                  align: uint) -> bool;
 }
 
 extern "rust-intrinsic" {

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -441,4 +441,17 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         self.align_to::<&'static u8>();
         true
     }
+
+    fn visit_simd(&mut self,
+                  inner_ty: *TyDesc,
+                  count: uint,
+                  size: uint,
+                  align: uint) -> bool {
+        self.align(align);
+        if ! self.inner.visit_simd(inner_ty, count, size, align) {
+            return false
+        }
+        self.bump(size);
+        true
+    }
 }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -595,6 +595,12 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
 
     fn visit_param(&mut self, _i: uint) -> bool { true }
     fn visit_self(&mut self) -> bool { true }
+
+    fn visit_simd(&mut self,
+                  _inner_ty: *TyDesc,
+                  _count: uint,
+                  _size: uint,
+                  _align: uint) -> bool { true }
 }
 
 pub fn write_repr<T>(writer: &mut io::Writer, object: &T) -> io::IoResult<()> {

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[doc(hidden)];
+//#[doc(hidden)];
+#[allow(missing_doc)];
 
 use prelude::*;
 use libc::uintptr_t;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4046,7 +4046,7 @@ impl Parser {
     }
 
     // parse visiility: PUB, PRIV, or nothing
-    fn parse_visibility(&mut self) -> Visibility {
+    pub fn parse_visibility(&mut self) -> Visibility {
         if self.eat_keyword(keywords::Pub) { Public }
         else if self.eat_keyword(keywords::Priv) { Private }
         else { Inherited }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -506,6 +506,7 @@ pub fn print_type(s: &mut State, ty: &ast::Ty) -> io::IoResult<()> {
         ast::TyInfer => {
             try!(word(&mut s.s, "_"));
         }
+        ast::TySimd(..) => fail!("can't pretty print simd types"),
     }
     end(s)
 }
@@ -1242,6 +1243,25 @@ pub fn print_expr(s: &mut State, expr: &ast::Expr) -> io::IoResult<()> {
             try!(word(&mut s.s, ","));
         }
         try!(pclose(s));
+      }
+      ast::ExprSimd(ref exprs) => {
+        try!(word(&mut s.s, "gather_simd!("));
+        try!(commasep_exprs(s, Inconsistent, exprs.as_slice()));
+        try!(word(&mut s.s, ")"));
+      }
+      ast::ExprSwizzle(left, right_opt, ref mask) => {
+        try!(word(&mut s.s, "swizzle_simd!("));
+        try!(print_expr(s, left));
+        match right_opt {
+            Some(right) => {
+                    try!(word_space(s, "@"));
+                    try!(print_expr(s, right));
+                }
+            None => {}
+        };
+        try!(word(&mut s.s, " -> ("));
+        try!(commasep_exprs(s, Inconsistent, mask.as_slice()));
+        try!(word(&mut s.s, ")"));
       }
       ast::ExprCall(func, ref args) => {
         try!(print_expr(s, func));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -366,6 +366,10 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
         TyTypeof(expression) => {
             visitor.visit_expr(expression, env)
         }
+        TySimd(ty, len) => {
+            visitor.visit_ty(ty, env.clone());
+            visitor.visit_expr(len, env)
+        }
         TyNil | TyBot | TyInfer => {}
     }
 }
@@ -654,6 +658,18 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
         ExprTup(ref subexpressions) => {
             for subexpression in subexpressions.iter() {
                 visitor.visit_expr(*subexpression, env.clone())
+            }
+        }
+        ExprSimd(ref exprs) => {
+            for &e in exprs.iter() {
+                visitor.visit_expr(e, env.clone());
+            }
+        }
+        ExprSwizzle(left_expr, right_expr, ref mask) => {
+            visitor.visit_expr(left_expr, env.clone());
+            walk_expr_opt(visitor, right_expr, env.clone());
+            for &m in mask.iter() {
+                visitor.visit_expr(m, env.clone());
             }
         }
         ExprCall(callee_expression, ref arguments) => {

--- a/src/test/compile-fail/simd-if-cond.rs
+++ b/src/test/compile-fail/simd-if-cond.rs
@@ -1,0 +1,44 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// xfail-stage1
+
+#[feature(simd, phase)];
+#[allow(experimental)];
+#[phase(syntax)]
+extern crate simd_syntax;
+extern crate simd;
+
+#[simd]
+#[deriving(Show)]
+struct RGBA {
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+}
+
+fn main() {
+    // this should be Okay:
+    let r = gather_simd!(0.0f32) == gather_simd!(1.0f32);
+    let _ = if r[0] { Some(true) }
+            else { None };
+
+    if gather_simd!(0.0f32) == gather_simd!(1.0f32) {
+        //~^ ERROR expected `bool` but found `<bool, ..1>` (expected bool but found internal simd)
+    }
+
+    // simd structures should still require impls of the respective cmps.
+    let v1 = RGBA{ r: 0.0f32, g: 0.25f32, b: 0.5f32, a: 0.75f32 };
+    let v2 = RGBA{ r: 0.0f32, g: 0.25f32, b: 0.5f32, a: 0.75f32 };
+    let _ = v1 == v2;
+    //~^ ERROR binary operation `==` cannot be applied to type `RGBA`
+}

--- a/src/test/compile-fail/simd-struct-indexing.rs
+++ b/src/test/compile-fail/simd-struct-indexing.rs
@@ -1,0 +1,40 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+// checks that struct simd types are not implicitly indexable.
+
+#[feature(simd)];
+#[allow(experimental)];
+
+#[simd]
+struct RGBA {
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+}
+
+#[inline(never)]
+fn index(v: &mut RGBA) {
+    v[0] = 10.0f32;
+    //~^ ERROR
+}
+
+
+pub fn main() {
+    let mut v = RGBA {
+        r: 20.0f32,
+        g: 20.0f32,
+        b: 20.0f32,
+        a: 20.0f32,
+    };
+    index(&mut v);
+}

--- a/src/test/compile-fail/simd-swizzle-mask-const-expr.rs
+++ b/src/test/compile-fail/simd-swizzle-mask-const-expr.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(simd)];
+#[feature(simd, phase)];
 
-#[simd]
-struct vec4<T>(T, T, T, T); //~ ERROR SIMD vector cannot be generic
+#[phase(syntax)]
+extern crate simd_syntax;
+extern crate simd;
 
-#[simd]
-struct empty; //~ ERROR SIMD vector cannot be empty
+#[inline(never)] fn get_num() -> i32 { 10 }
 
-#[simd]
-struct i64f64(i64, f64); //~ ERROR SIMD vector should be homogeneous
-
-fn main() {}
+fn main() {
+    let v = gather_simd!(0);
+    let i = get_num();
+    let _ = swizzle_simd!(v -> (i));
+    //~^ ERROR expected constant integer for swizzle mask but found variable
+}

--- a/src/test/compile-fail/simd-swizzle-mask-out-of-bounds.rs
+++ b/src/test/compile-fail/simd-swizzle-mask-out-of-bounds.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(simd, phase)];
+
+#[phase(syntax)]
+extern crate simd_syntax;
+extern crate simd;
+
+fn main() {
+    let v = gather_simd!(0.0f32, 0.0f32, 0.0f32, 0.0f32);
+    let _ = swizzle_simd!(v -> (15));
+    //~^ ERROR invalid mask index in SIMD swizzle: `15`
+    let _ = swizzle_simd!(v -> (0, 0, 0, 0, 10));
+    //~^ ERROR invalid mask index in SIMD swizzle: `10`
+}

--- a/src/test/run-pass/md-gather-infer.rs
+++ b/src/test/run-pass/md-gather-infer.rs
@@ -1,0 +1,28 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(simd, phase)];
+
+#[phase(syntax)]
+extern crate simd_syntax;
+extern crate simd;
+use simd::{f64x8, i64x4};
+
+#[inline(never)] fn i64x4_f(_: i64x4) {}
+#[inline(never)] fn f64x8_f(_: f64x8) {}
+
+pub fn main() {
+    let v = gather_simd!(0, 1, 2, 3);
+    i64x4_f(v);
+
+    let v = gather_simd!(1.0, 2.0, 3.0, 4.0);
+    let v = swizzle_simd!(v -> (3, 2, 1, 0, 0, 1, 2, 3));
+    f64x8_f(v);
+}

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -138,6 +138,12 @@ impl TyVisitor for MyVisitor {
     fn visit_trait(&mut self, _name: &str) -> bool { true }
     fn visit_param(&mut self, _i: uint) -> bool { true }
     fn visit_self(&mut self) -> bool { true }
+
+    fn visit_simd(&mut self,
+                  _inner: *TyDesc,
+                  _count: uint,
+                  _size: uint,
+                  _align: uint) -> bool { true }
 }
 
 fn visit_ty<T>(v: &mut MyVisitor) {

--- a/src/test/run-pass/simd-binop.rs
+++ b/src/test/run-pass/simd-binop.rs
@@ -8,31 +8,211 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(phase, simd)];
 #[allow(experimental)];
 
-use std::unstable::simd::{i32x4, f32x4, u32x4};
+#[phase(syntax)] extern crate simd_syntax;
+extern crate simd;
+extern crate test;
 
-fn test_int(e: i32) -> i32 {
-    let v = i32x4(e, 0i32, 0i32, 0i32);
-    let i32x4(e2, _, _, _) = v * v + v - v;
-    e2
+use simd::{Simd, f64x4, boolx8};
+
+#[inline(never)] fn test_int(e: i32) -> i32 {
+    let v = gather_simd!(e, 0i32, 0i32, 0i32);
+    (v * v + v - v)[0]
 }
 
-fn test_float(e: f32) -> f32 {
-    let v = f32x4(e, 0f32, 0f32, 0f32);
-    let f32x4(e2, _, _, _) = v * v + v - v;
-    e2
+#[inline(never)] fn test_float(e: f32) -> f32 {
+    let v = gather_simd!(e, 0f32, 0f32, 0f32);
+    (v * v + v - v)[0]
 }
 
-pub fn test_shift(e: u32) -> u32 {
-    let v = u32x4(e, 0u32, 0u32, 0u32);
-    let one = u32x4(1u32, 0u32, 0u32, 0u32);
-    let u32x4(e2, _, _, _) = v << one >> one;
-    e2
+#[inline(never)] pub fn test_shift(e: u32) -> u32 {
+    let v = gather_simd!(e, 0u32, 0u32, 0u32);
+    let one = gather_simd!(1u32, 0u32, 0u32, 0u32);
+    (v << one >> one)[0]
+}
+
+#[inline(never)] fn fake_mutate<T>(_: &mut T) {}
+
+#[inline(never)] fn f64x4_actions(lhs: f64x4, rhs: f64x4) -> (boolx8, boolx8, boolx8) {
+    let llhs1 = swizzle_simd!(lhs > rhs .. lhs >= rhs -> (0, 1, 2, 3, 4, 5, 6, 7));
+    let llhs2 = swizzle_simd!(lhs == rhs .. lhs != rhs -> (0, 1, 2, 3, 4, 5, 6, 7));
+    let llhs3 = swizzle_simd!(lhs <= rhs .. lhs < rhs -> (0, 1, 2, 3, 4, 5, 6, 7));
+    let m1 = swizzle_simd!(llhs1 .. llhs2 -> (0, 1, 2, 3, 4, 5,  6,  7,  8,  9, 10, 11));
+    let m2 = swizzle_simd!(llhs2 .. llhs3 -> (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+    (swizzle_simd!(m1 .. m2 -> (0,  1,   2,  3,  4,  5,  6,  7)),
+     swizzle_simd!(m1 .. m2 -> (8,  9,  10, 11, 12, 13, 14, 15)),
+     swizzle_simd!(m1 .. m2 -> (16, 17, 18, 19, 20, 21, 22, 23)))
 }
 
 pub fn main() {
     assert_eq!(test_int(3i32), 9i32);
     assert_eq!(test_float(3f32), 9f32);
     assert_eq!(test_shift(3u32), 3u32);
+
+
+    let mut v1 = gather_simd!(3.1415926535f64, 6.2821853070f64, 0.25f64, 0.25f64);
+    let mut v2 = swizzle_simd!(v1 -> (1, 0, 2, 2));
+    fake_mutate(&mut v1);
+    fake_mutate(&mut v2);
+
+    let (cond0a, cond0b, cond0c) = f64x4_actions(v1, v2);
+    let cond1 = swizzle_simd!(cond0a -> (0,  1,  2,  3));
+    let cond2 = swizzle_simd!(cond0a -> (4,  5,  6,  7));
+    let cond3 = swizzle_simd!(cond0b -> (0,  1,  2,  3));
+    let cond4 = swizzle_simd!(cond0b -> (4,  5,  6,  7));
+    let cond5 = swizzle_simd!(cond0c -> (0,  1,  2,  3));
+    let cond6 = swizzle_simd!(cond0c -> (4,  5,  6,  7));
+
+    fn format_fold_f(string: ~str, (idx, v): (uint, &bool)) -> ~str {
+        string + format!(" {:}:{:}", idx, v)
+    }
+
+    assert!(cond1[0] == false);
+    assert!(cond1[1] == true );
+    assert!(cond1[2] == false);
+    assert!(cond1[3] == false);
+    assert!(cond2[0] == false);
+    assert!(cond2[1] == true );
+    assert!(cond2[2] == true );
+    assert!(cond2[3] == true );
+    assert!(cond3[0] == false);
+    assert!(cond3[1] == false);
+    assert!(cond3[2] == true );
+    assert!(cond3[3] == true );
+    assert!(cond4[0] == true );
+    assert!(cond4[1] == true );
+    assert!(cond4[2] == false);
+    assert!(cond4[3] == false);
+    assert!(cond5[0] == true );
+    assert!(cond5[1] == false);
+    assert!(cond5[2] == true );
+    assert!(cond5[3] == true );
+    assert!(cond6[0] == true );
+    assert!(cond6[1] == false);
+    assert!(cond6[2] == false);
+    assert!(cond6[3] == false);
+
+    // watch out, these are long.
+    let mut v1 = gather_simd!(3i8, 1i8, 4i8, 1i8, 5i8, 9i8, 2i8, 0i8,
+                              6i8, 2i8, 8i8, 2i8, 1i8, 8i8, 5i8, 0i8);
+    let mut v2 = gather_simd!(6i8, 2i8, 8i8, 2i8, 1i8, 8i8, 5i8, 0i8,
+                              3i8, 1i8, 4i8, 1i8, 5i8, 9i8, 2i8, 0i8);
+    fake_mutate(&mut v1);
+    fake_mutate(&mut v2);
+
+    println!("{}", v1.iter().fold(~"v1:", |string, v| string + format!(" {}", v) ));
+    println!("{}", v2.iter().fold(~"v2:", |string, v| string + format!(" {}", v) ));
+
+    let cond1 = v1 >  v2; assert_eq!(cond1.len(), 16);
+    let cond2 = v1 >= v2; assert_eq!(cond2.len(), 16);
+    let cond3 = v1 == v2; assert_eq!(cond3.len(), 16);
+    let cond4 = v1 != v2; assert_eq!(cond4.len(), 16);
+    let cond5 = v1 <= v2; assert_eq!(cond5.len(), 16);
+    let cond6 = v1 <  v2; assert_eq!(cond6.len(), 16);
+
+    println!("{}", cond1.iter().enumerate().fold(~"cond1:", format_fold_f));
+    println!("{}", cond2.iter().enumerate().fold(~"cond2:", format_fold_f));
+    println!("{}", cond3.iter().enumerate().fold(~"cond3:", format_fold_f));
+    println!("{}", cond4.iter().enumerate().fold(~"cond4:", format_fold_f));
+    println!("{}", cond5.iter().enumerate().fold(~"cond5:", format_fold_f));
+    println!("{}", cond6.iter().enumerate().fold(~"cond6:", format_fold_f));
+
+    assert!(cond1[0]  == false &&
+            cond1[1]  == false &&
+            cond1[2]  == false &&
+            cond1[3]  == false &&
+            cond1[4]  == true  &&
+            cond1[5]  == true  &&
+            cond1[6]  == false &&
+            cond1[7]  == false &&
+            cond1[8]  == true  &&
+            cond1[9]  == true  &&
+            cond1[10] == true  &&
+            cond1[11] == true  &&
+            cond1[12] == false &&
+            cond1[13] == false &&
+            cond1[14] == true  &&
+            cond1[15] == false);
+    assert!(cond2[0]  == false &&
+            cond2[1]  == false &&
+            cond2[2]  == false &&
+            cond2[3]  == false &&
+            cond2[4]  == true  &&
+            cond2[5]  == true  &&
+            cond2[6]  == false &&
+            cond2[7]  == true  &&
+            cond2[8]  == true  &&
+            cond2[9]  == true  &&
+            cond2[10] == true  &&
+            cond2[11] == true  &&
+            cond2[12] == false &&
+            cond2[13] == false &&
+            cond2[14] == true  &&
+            cond2[15] == true);
+    assert!(cond3[0]  == false &&
+            cond3[1]  == false &&
+            cond3[2]  == false &&
+            cond3[3]  == false &&
+            cond3[4]  == false &&
+            cond3[5]  == false &&
+            cond3[6]  == false &&
+            cond3[7]  == true  &&
+            cond3[8]  == false &&
+            cond3[9]  == false &&
+            cond3[10] == false &&
+            cond3[11] == false &&
+            cond3[12] == false &&
+            cond3[13] == false &&
+            cond3[14] == false &&
+            cond3[15] == true);
+    assert!(cond4[0]  == true  &&
+            cond4[1]  == true  &&
+            cond4[2]  == true  &&
+            cond4[3]  == true  &&
+            cond4[4]  == true  &&
+            cond4[5]  == true  &&
+            cond4[6]  == true  &&
+            cond4[7]  == false &&
+            cond4[8]  == true  &&
+            cond4[9]  == true  &&
+            cond4[10] == true  &&
+            cond4[11] == true  &&
+            cond4[12] == true  &&
+            cond4[13] == true  &&
+            cond4[14] == true  &&
+            cond4[15] == false);
+    assert!(cond5[0]  == true  &&
+            cond5[1]  == true  &&
+            cond5[2]  == true  &&
+            cond5[3]  == true  &&
+            cond5[4]  == false &&
+            cond5[5]  == false &&
+            cond5[6]  == true  &&
+            cond5[7]  == true  &&
+            cond5[8]  == false &&
+            cond5[9]  == false &&
+            cond5[10] == false &&
+            cond5[11] == false &&
+            cond5[12] == true  &&
+            cond5[13] == true  &&
+            cond5[14] == false &&
+            cond5[15] == true);
+    assert!(cond6[0]  == true  &&
+            cond6[1]  == true  &&
+            cond6[2]  == true  &&
+            cond6[3]  == true  &&
+            cond6[4]  == false &&
+            cond6[5]  == false &&
+            cond6[6]  == true  &&
+            cond6[7]  == false &&
+            cond6[8]  == false &&
+            cond6[9]  == false &&
+            cond6[10] == false &&
+            cond6[11] == false &&
+            cond6[12] == true  &&
+            cond6[13] == true  &&
+            cond6[14] == false &&
+            cond6[15] == false);
 }

--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -10,7 +10,9 @@
 
 // ignore-fast
 
-#[feature(simd)];
+#[feature(simd, phase)];
+#[allow(experimental)];
+#[phase(syntax)] extern crate simd_syntax;
 
 use std::ops;
 
@@ -22,14 +24,16 @@ fn add<T: ops::Add<T, T>>(lhs: T, rhs: T) -> T {
 
 impl ops::Add<f32x4, f32x4> for f32x4 {
     fn add(&self, rhs: &f32x4) -> f32x4 {
-        *self + *rhs
+        let lhs = swizzle_simd!(self -> (0, 1, 2, 3));
+        let rhs = swizzle_simd!(rhs -> (0, 1, 2, 3));
+        let sum = lhs + rhs;
+        f32x4(sum[0], sum[1], sum[2], sum[3])
     }
 }
 
 pub fn main() {
     let lr = f32x4(1.0f32, 2.0f32, 3.0f32, 4.0f32);
 
-    // lame-o
     let f32x4(x, y, z, w) = add(lr, lr);
     assert_eq!(x, 2.0f32);
     assert_eq!(y, 4.0f32);

--- a/src/test/run-pass/simd-index.rs
+++ b/src/test/run-pass/simd-index.rs
@@ -1,0 +1,42 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+// checks that strict simd types are implicitly indexable.
+
+#[feature(simd, phase)];
+#[allow(experimental)];
+
+#[phase(syntax)] extern crate simd_syntax;
+
+def_type_simd!(#[allow(non_camel_case_types)] type f32x4 = <f32, ..4>;)
+def_type_simd!(#[allow(non_camel_case_types)] type i32x4 = <i32, ..4>;)
+
+#[inline(never)]
+fn f32x4_index(v: &mut f32x4) {
+    v[0] = 10.0f32;
+}
+#[inline(never)]
+fn i32x4_index(v: &mut i32x4) {
+    v[0] = 10i32;
+}
+
+
+pub fn main() {
+    let mut v = gather_simd!(20.0f32, 20.0f32, 20.0f32, 20.0f32);
+    f32x4_index(&mut v);
+    //assert!(v[0] == 10.0f32);
+    //assert!(v[1] == 20.0f32);
+
+    let mut v = gather_simd!(15, 15, 15, 15);
+    i32x4_index(&mut v);
+    //assert!(v[0] == 10);
+    //assert!(v[1] == 15);
+}

--- a/src/test/run-pass/simd-struct-swizzle.rs
+++ b/src/test/run-pass/simd-struct-swizzle.rs
@@ -1,0 +1,47 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+// checks that struct simd types can be swizzled.
+
+#[feature(simd, phase)];
+#[allow(experimental)];
+#[phase(syntax)] extern crate simd_syntax;
+extern crate simd;
+
+use simd::f32x4;
+
+#[simd]
+struct RGBA {
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+}
+
+#[inline(never)]
+fn get(v: RGBA) -> f32x4 {
+    swizzle_simd!(v -> (3, 2, 1, 0))
+}
+
+
+pub fn main() {
+    let v1 = RGBA {
+        r: 1.0f32,
+        g: 2.0f32,
+        b: 3.0f32,
+        a: 4.0f32,
+    };
+    let v2 = get(v1);
+    assert_eq!(v1.r, v2[3]);
+    assert_eq!(v1.g, v2[2]);
+    assert_eq!(v1.b, v2[1]);
+    assert_eq!(v1.a, v2[0]);
+}

--- a/src/test/run-pass/simd-swizzle.rs
+++ b/src/test/run-pass/simd-swizzle.rs
@@ -1,0 +1,55 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// xfail-stage1
+
+#[feature(simd, phase)];
+#[allow(experimental)];
+
+#[phase(syntax)]
+extern crate simd_syntax;
+extern crate simd;
+
+use simd::BoolSimd;
+use simd::f32x4;
+
+#[simd]
+struct RGBA {
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+}
+
+static const_expr: i32 = 15 / 3;
+
+fn main() {
+    let v = gather_simd!(1.0, 2.0, 4.0, 8.0);
+    let rev_v = swizzle_simd!(v -> (3, 2, 1, 0));
+    let gather_rev = gather_simd!(8.0, 4.0, 2.0, 1.0);
+    let cond = rev_v == gather_rev;
+    assert!(cond.every_true());
+    assert!((swizzle_simd!(v -> (0, 1, 2, 3,
+                                 3, 2, 1, 0)) ==
+             gather_simd!(1.0, 2.0, 4.0, 8.0,
+                          8.0, 4.0, 2.0, 1.0)).every_true());
+    assert_eq!(swizzle_simd!(v -> (0))[0], 1.0);
+
+    assert_eq!(swizzle_simd!(v -> (const_expr - 2))[0], 8.0);
+
+    let rgba = RGBA{ r: 1.0f32,
+                     g: 2.0f32,
+                     b: 3.0f32,
+                     a: 4.0f32 };
+
+    assert!((swizzle_simd!(rgba -> (3, 2, 1, 0)) ==
+             gather_simd!(4.0, 3.0, 2.0, 1.0)).every_true());
+}


### PR DESCRIPTION
### The gist:

``` rust
#[phase(syntax)] extern crate simd_syntax;
extern crate simd;
use simd::{Simd, i32x8};
// Two new expressions, with inference:
let v = gather_simd!(1, 2, 3, 4);
let w = swizzle_simd!(v -> (3, 2, 1, 0));
let x: i32x8 = swizzle_simd!(v .. w -> (0, 7, 1, 6, 2, 5, 3, 4));
// multiple-data compare:
let cond = (x == gather_simd!(1, 1, 2, 2, 3, 3, 4, 4));
assert!(cond.every_true());

// New type (libsimd defines all the types anyone would realistically need,
// so most users won't need to use this):
def_type_simd!(pub type f32x4 = <f32, ..4>;)
def_type_simd!(pub struct i32x4(<i32, ..4>);)
```

I should emphasize that there are no parse changes in this PR; I choose to expose the ergonomics with a syntax extension so others can use a different syntax than the one provided in libsimd_syntax, hopefully without too much issue.
### Pre-merge FIXME's (off the top of my head):
- Moar tests.
- Documentation.
- Drop single instruction-ness in nomenclature. This feature makes no such guarantee anyway.
- Transition to single expression w/ opcode.
- Remove std::unstable::simd.
- #[deriving] for single-element struct tuples wrapping multiple-data types.

I wouldn't call this ready to be merged; as per the FIXME's I've still got work to do. However, I'd very much like some feedback!
