### PR TITLE
doc: Remove reference to the 'extra' library

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -30,7 +30,6 @@ li {list-style-type: none; }
 
 * [The `arena` allocation library](arena/index.html)
 * [The `collections` library](collections/index.html)
-* [The `extra` library of extra stuff](extra/index.html)
 * [The `flate` compression library](flate/index.html)
 * [The `fourcc` four-character code library](fourcc/index.html)
 * [The `getopts` argument parsing library](getopts/index.html)


### PR DESCRIPTION
Forgot to remove this as part of the previous removal of libextra
