### PR TITLE
Squash test ~[] warning

### DIFF
--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -329,6 +329,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::Item {
     // with our list of tests
     let mainfn = (quote_item!(&cx.ext_cx,
         pub fn main() {
+            #[allow(deprecated_owned_vector)];
             #[main];
             test::test_main_static(::std::os::args(), TESTS);
         }


### PR DESCRIPTION
The use of `std::os::args` creates a deprecated_owned_vector warning
with a bogus span.
