### PR TITLE
Automatically derived

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -985,7 +985,7 @@ static other_attrs: &'static [&'static str] = &[
     "crate_map", "cfg", "doc", "export_name", "link_section",
     "no_mangle", "static_assert", "unsafe_no_drop_flag", "packed",
     "simd", "repr", "deriving", "unsafe_destructor", "link", "phase",
-    "macro_export", "must_use",
+    "macro_export", "must_use", "automatically_derived",
 
     //mod-level
     "path", "link_name", "link_args", "macro_escape", "no_implicit_prelude",

--- a/src/libstd/cmp.rs
+++ b/src/libstd/cmp.rs
@@ -130,18 +130,6 @@ totalord_impl!(uint)
 
 totalord_impl!(char)
 
-/// Compares (a1, b1) against (a2, b2), where the a values are more significant.
-pub fn cmp2<A:TotalOrd,B:TotalOrd>(
-    a1: &A, b1: &B,
-    a2: &A, b2: &B) -> Ordering
-{
-    match a1.cmp(a2) {
-        Less => Less,
-        Greater => Greater,
-        Equal => b1.cmp(b2)
-    }
-}
-
 /**
 Return `o1` if it is not `Equal`, otherwise `o2`. Simulates the
 lexical ordering on a type `(int, int)`.
@@ -204,14 +192,6 @@ mod test {
         assert_eq!(5.cmp(&5), Equal);
         assert_eq!((-5).cmp(&12), Less);
         assert_eq!(12.cmp(-5), Greater);
-    }
-
-    #[test]
-    fn test_cmp2() {
-        assert_eq!(cmp2(1, 2, 3, 4), Less);
-        assert_eq!(cmp2(3, 2, 3, 4), Less);
-        assert_eq!(cmp2(5, 2, 3, 4), Greater);
-        assert_eq!(cmp2(5, 5, 5, 4), Greater);
     }
 
     #[test]

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -186,7 +186,6 @@ use codemap;
 use codemap::Span;
 use opt_vec;
 use parse::token::InternedString;
-use parse::token;
 
 use std::vec_ng::Vec;
 use std::vec_ng;
@@ -399,19 +398,16 @@ impl<'a> TraitDef<'a> {
             cx.path_all(self.span, false, vec!( type_ident ), self_lifetimes,
                         opt_vec::take_vec(self_ty_params)), None);
 
-        let doc_attr = cx.attribute(
+        let attr = cx.attribute(
             self.span,
-            cx.meta_name_value(self.span,
-                               InternedString::new("doc"),
-                               ast::LitStr(token::intern_and_get_ident(
-                                               "Automatically derived."),
-                                           ast::CookedStr)));
+            cx.meta_word(self.span,
+                         InternedString::new("automatically_derived")));
         let opt_trait_ref = Some(trait_ref);
         let ident = ast_util::impl_pretty_name(&opt_trait_ref, self_type);
         cx.item(
             self.span,
             ident,
-            vec_ng::append(vec!(doc_attr), self.attributes.as_slice()),
+            vec_ng::append(vec!(attr), self.attributes.as_slice()),
             ast::ItemImpl(trait_generics, opt_trait_ref,
                           self_type, methods.map(|x| *x)))
     }


### PR DESCRIPTION
This will enable rustdoc to treat them specially.

I also got rid of `std::cmp::cmp2`, which is isomorphic to the `TotalOrd` impl for 2-tuples and never used.
