### PR TITLE
Fix a test that was missed in the liblog PR

### DIFF
--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -13,6 +13,10 @@
 // ignore-android needs extra network permissions
 // exec-env:RUST_LOG=debug
 
+#[feature(phase)];
+#[phase(syntax, link)]
+extern crate log;
+
 use std::libc;
 use std::io::net::ip::{Ipv4Addr, SocketAddr};
 use std::io::net::tcp::{TcpListener, TcpStream};


### PR DESCRIPTION
The same test was missed in chan/port renaming PR #12815 and was fixed in #12880:

> This was missed because it is skipped on linux and windows, and the mac bots were moving at the time the PR landed.

It seems the same happened to the liblog PR.
