### PR TITLE
Disallow trailing parentheses for nullary enum variants

### DIFF
--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -198,7 +198,7 @@ fn resolve_internal(id: Ident,
                     resolvedthis
                 }
             }
-            IllegalCtxt() => fail!("expected resolvable context, got IllegalCtxt")
+            IllegalCtxt => fail!("expected resolvable context, got IllegalCtxt")
         }
     };
     resolve_table.insert(key, resolved);

--- a/src/test/compile-fail/enums-pats-not-idents.rs
+++ b/src/test/compile-fail/enums-pats-not-idents.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,5 +12,5 @@
 
 fn main() {
     // a bug in the parser is allowing this:
-    let a() = 13;
+    let a(1) = 13;
 }

--- a/src/test/compile-fail/issue-12560-1.rs
+++ b/src/test/compile-fail/issue-12560-1.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// For style and consistency reasons, non-parametrized enum variants must
+// be used simply as `ident` instead of `ident ()`.
+// This test-case covers enum declaration.
+
+enum Foo {
+    Bar(), //~ ERROR nullary enum variants are written with no trailing `( )`
+    Baz(), //~ ERROR nullary enum variants are written with no trailing `( )`
+    Bazar
+}
+
+fn main() {
+    println!("{}", match Bar { Bar => 1, Baz => 2, Bazar => 3 })
+}

--- a/src/test/compile-fail/issue-12560-2.rs
+++ b/src/test/compile-fail/issue-12560-2.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// For style and consistency reasons, non-parametrized enum variants must
+// be used simply as `ident` instead of `ident ()`.
+// This test-case covers enum matching.
+
+enum Foo {
+    Bar,
+    Baz,
+    Bazar
+}
+
+fn main() {
+    println!("{}", match Bar {
+        Bar() => 1, //~ ERROR nullary enum variants are written with no trailing `( )`
+        Baz() => 2, //~ ERROR nullary enum variants are written with no trailing `( )`
+        Bazar => 3
+    })
+}

--- a/src/test/compile-fail/issue-5927.rs
+++ b/src/test/compile-fail/issue-5927.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -14,7 +14,7 @@
 
 fn main() {
     let z = match 3 {
-        x() => x
+        x(1) => x(1)
     };
     assert_eq!(z,3);
 }


### PR DESCRIPTION
Fix for #12560
