### PR TITLE
serialize: impl ToJson for all Encodables

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1010,15 +1010,6 @@ fn calc_result(desc: &TestDesc, task_succeeded: bool) -> TestResult {
 }
 
 
-impl ToJson for Metric {
-    fn to_json(&self) -> json::Json {
-        let mut map = ~TreeMap::new();
-        map.insert(~"value", json::Number(self.value));
-        map.insert(~"noise", json::Number(self.noise));
-        json::Object(map)
-    }
-}
-
 impl MetricMap {
 
     pub fn new() -> MetricMap {


### PR DESCRIPTION
I just wanted to submit this at this point to see if something like this would be accepted. If so, I can clean it up some more, such as converting to `Vec<T>`, etc.

The short is that this is now possible:

``` rust
#[deriving(Encodable)]
struct Foo {
  bar: uint
}

foo.to_json(); // => json::Object(TreeMap)
```

fixes #8335
