### PR TITLE
Remind the programmer to use () for method calls

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2317,11 +2317,13 @@ fn check_expr_with_unifier(fcx: @FnCtxt,
                 fcx.type_error_message(
                     expr.span,
                     |actual| {
-                        format!("attempted to take value of method `{}` on type `{}` \
-                                 (try writing an anonymous function)",
+                        format!("attempted to take value of method `{}` on type `{}`",
                                 token::get_name(field), actual)
                     },
                     expr_t, None);
+
+                tcx.sess.span_note(expr.span,
+                    "maybe a missing `()` to call it? If not, try an anonymous function.");
             }
 
             None => {

--- a/src/test/compile-fail/method-missing-call.rs
+++ b/src/test/compile-fail/method-missing-call.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests to make sure that parens are needed for method calls without arguments.
+// outputs text to make sure either an anonymous function is provided or
+// open-close '()' parens are given
+
+
+struct Point {
+    x: int,
+    y: int
+}
+impl Point {
+    fn new() -> Point {
+        Point{x:0, y:0}
+    }
+    fn get_x(&self) -> int {
+        self.x
+    }
+}
+
+fn main() {
+    let point: Point = Point::new();
+    let px: int =  point.get_x;//~ ERROR attempted to take value of method `get_x` on type `Point`
+    //~^ NOTE maybe a missing `()` to call it? If not, try an anonymous function.
+}
+


### PR DESCRIPTION
its a common (yet easily fixable) error to just forget parens at the end of getter-like methods without any arguments.

The current error message for that case asks for an anonymous function, this patch adds a note asking for either an anonymous function, or for trailing parens.

This is my first contribution! do i need to do anything else?
