### PR TITLE
Included the log crate because debug! has moved to liblog

### DIFF
--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -12,6 +12,8 @@
 // ignore-fast
 // ignore-android needs extra network permissions
 // exec-env:RUST_LOG=debug
+#[feature(phase)];
+#[phase(syntax, link)] extern crate log;
 
 use std::libc;
 use std::io::net::ip::{Ipv4Addr, SocketAddr};


### PR DESCRIPTION
This test failed to compile due to debug! being moved, which caused a compilation failure during make check.
