### PR TITLE
syntax: allow stmt/expr macro invocations to be delimited by [].

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -297,20 +297,16 @@ pub fn can_begin_expr(t: &Token) -> bool {
     }
 }
 
-/// what's the opposite delimiter?
-pub fn flip_delimiter(t: &token::Token) -> token::Token {
+/// Returns the matching close delimiter if this is an open delimiter,
+/// otherwise `None`.
+pub fn close_delimiter_for(t: &Token) -> Option<Token> {
     match *t {
-      LPAREN => RPAREN,
-      LBRACE => RBRACE,
-      LBRACKET => RBRACKET,
-      RPAREN => LPAREN,
-      RBRACE => LBRACE,
-      RBRACKET => LBRACKET,
-      _ => fail!()
+        LPAREN   => Some(RPAREN),
+        LBRACE   => Some(RBRACE),
+        LBRACKET => Some(RBRACKET),
+        _        => None
     }
 }
-
-
 
 pub fn is_lit(t: &Token) -> bool {
     match *t {

--- a/src/test/run-pass/vec-macro-with-brackets.rs
+++ b/src/test/run-pass/vec-macro-with-brackets.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(macro_rules)];
+
+macro_rules! vec [
+    ($($e:expr),*) => ({
+        let mut _temp = ::std::vec_ng::Vec::new();
+        $(_temp.push($e);)*
+        _temp
+    })
+]
+
+pub fn main() {
+    let my_vec = vec![1, 2, 3, 4, 5];
+}


### PR DESCRIPTION
this is useful for macros like vec! which construct containers

This is a followup to @huonw's earlier change which allowed `{}` to be used as delimiters. I'm acting at the behest of @eddyb on IRC, who also wanted `vec![a, b, c]`. Is this the sort of change which now requires going through the RFC process?
