### PR TITLE
Documentation sprint: Terminfo documentation strings

### DIFF
--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(missing_doc)];
+//! Terminfo database interface.
 
 use collections::HashMap;
 
-/// A parsed terminfo entry.
+/// A parsed terminfo database entry.
 pub struct TermInfo {
     /// Names for the terminal
     priv names: Vec<~str> ,
@@ -25,7 +25,10 @@ pub struct TermInfo {
 }
 
 pub mod searcher;
+
+/// TermInfo format parsing.
 pub mod parser {
+    //! ncurses-compatible compiled terminfo format parsing (term(5))
     pub mod compiled;
 }
 pub mod parm;

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -38,8 +38,8 @@ enum FormatState {
 }
 
 /// Types of parameters a capability can use
-#[deriving(Clone)]
 #[allow(missing_doc)]
+#[deriving(Clone)]
 pub enum Param {
     String(~str),
     Number(int)

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -10,7 +10,7 @@
 
 #[allow(non_uppercase_statics)];
 
-/// ncurses-compatible compiled terminfo format parsing (term(5))
+//! ncurses-compatible compiled terminfo format parsing (term(5))
 
 use collections::HashMap;
 use std::io;

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/// Implement ncurses-compatible database discovery
-/// Does not support hashed database, only filesystem!
+//! ncurses-compatible database discovery
+//!
+//! Does not support hashed database, only filesystem!
 
 use std::io::File;
 use std::os::getenv;


### PR DESCRIPTION
Rust doc sprint: adding doc strings to the Terminfo library.

This is my very first Rust repository PR, so please do not hold back any formatting, nit-picky commentary. I need it.
