### PR TITLE
Add log crate to fix test on Mac OS X

### DIFF
--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -13,6 +13,9 @@
 // ignore-android needs extra network permissions
 // exec-env:RUST_LOG=debug
 
+#[feature(phase)];
+#[phase(syntax, link)] extern crate log;
+
 use std::libc;
 use std::io::net::ip::{Ipv4Addr, SocketAddr};
 use std::io::net::tcp::{TcpListener, TcpStream};


### PR DESCRIPTION
To follow mozilla/rust#12791 and fix `make check` on Mac OS X, I added `extern crate log;` into the crashed test code.
