### PR TITLE
libsyntax: librustdoc: ignore utf-8 BOM in .rs files

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -463,6 +463,13 @@ impl<'a> SourceCollector<'a> {
         };
         let contents = str::from_utf8_owned(contents).unwrap();
 
+        // Remove the utf-8 BOM if any
+        let contents = if contents.starts_with("\ufeff") {
+            contents.as_slice().slice_from(3)
+        } else {
+            contents.as_slice()
+        };
+
         // Create the intermediate directories
         let mut cur = self.dst.clone();
         let mut root_path = ~"../../";
@@ -482,7 +489,7 @@ impl<'a> SourceCollector<'a> {
             root_path: root_path,
         };
         try!(layout::render(&mut w as &mut Writer, &self.cx.layout,
-                              &page, &(""), &Source(contents.as_slice())));
+                              &page, &(""), &Source(contents)));
         try!(w.flush());
         return Ok(());
     }

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -271,11 +271,20 @@ impl CodeMap {
         }
     }
 
-    pub fn new_filemap(&self, filename: FileName, mut src: ~str) -> Rc<FileMap> {
+    pub fn new_filemap(&self, filename: FileName, src: ~str) -> Rc<FileMap> {
         let mut files = self.files.borrow_mut();
         let start_pos = match files.get().last() {
             None => 0,
             Some(last) => last.deref().start_pos.to_uint() + last.deref().src.len(),
+        };
+
+        // Remove utf-8 BOM if any.
+        // FIXME #12884: no efficient/safe way to remove from the start of a string
+        // and reuse the allocation.
+        let mut src = if src.starts_with("\ufeff") {
+            src.as_slice().slice_from(3).into_owned()
+        } else {
+            src
         };
 
         // Append '\n' in case it's not already there.

--- a/src/test/run-pass/utf8-bom.rs
+++ b/src/test/run-pass/utf8-bom.rs
@@ -1,0 +1,13 @@
+﻿// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This file has utf-8 BOM, it should be compiled normally without error.
+
+pub fn main() {}


### PR DESCRIPTION
Closes #12974
