### PR TITLE
rustc: remove linker_private/linker_private_weak

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -43,21 +43,21 @@ pub enum Visibility {
     ProtectedVisibility = 2,
 }
 
+// This enum omits the obsolete (and no-op) linkage types DLLImportLinkage,
+// DLLExportLinkage, GhostLinkage and LinkOnceODRAutoHideLinkage.
+// LinkerPrivateLinkage and LinkerPrivateWeakLinkage are not included either;
+// they've been removed in upstream LLVM commit r203866.
 pub enum Linkage {
     ExternalLinkage = 0,
     AvailableExternallyLinkage = 1,
     LinkOnceAnyLinkage = 2,
     LinkOnceODRLinkage = 3,
-    LinkOnceODRAutoHideLinkage = 4,
     WeakAnyLinkage = 5,
     WeakODRLinkage = 6,
     AppendingLinkage = 7,
     InternalLinkage = 8,
     PrivateLinkage = 9,
-    DLLImportLinkage = 10,
-    DLLExportLinkage = 11,
     ExternalWeakLinkage = 12,
-    GhostLinkage = 13,
     CommonLinkage = 14,
 }
 

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -59,8 +59,6 @@ pub enum Linkage {
     ExternalWeakLinkage = 12,
     GhostLinkage = 13,
     CommonLinkage = 14,
-    LinkerPrivateLinkage = 15,
-    LinkerPrivateWeakLinkage = 16,
 }
 
 #[deriving(Clone)]

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -121,8 +121,6 @@ pub fn llvm_linkage_by_name(name: &str) -> Option<Linkage> {
         "extern_weak" => Some(lib::llvm::ExternalWeakLinkage),
         "external" => Some(lib::llvm::ExternalLinkage),
         "internal" => Some(lib::llvm::InternalLinkage),
-        "linker_private" => Some(lib::llvm::LinkerPrivateLinkage),
-        "linker_private_weak" => Some(lib::llvm::LinkerPrivateWeakLinkage),
         "linkonce" => Some(lib::llvm::LinkOnceAnyLinkage),
         "linkonce_odr" => Some(lib::llvm::LinkOnceODRLinkage),
         "private" => Some(lib::llvm::PrivateLinkage),


### PR DESCRIPTION
Remove the linker_private and linker_private_weak linkage attributes,
they have been superseded by private and private_weak and have been
removed in upstream LLVM in commit r203866.
