### PR TITLE
comm: Impose an artificial bound on channel size 

### DIFF
--- a/src/libstd/comm/stream.rs
+++ b/src/libstd/comm/stream.rs
@@ -132,9 +132,14 @@ impl<T: Send> Packet<T> {
                 }
             }
 
-            // Otherwise we just sent some data on a non-waiting queue, so just
-            // make sure the world is sane and carry on!
-            n => { assert!(n >= 0); UpSuccess }
+            // Otherwise we just sent some data on a non-waiting queue. Be sure
+            // that we're not moving towards exhausting the address space, and
+            // then carry on.
+            n => {
+                assert!(n >= 0);
+                super::assert_sane_bound::<T>(n as uint);
+                UpSuccess
+            }
         }
     }
 


### PR DESCRIPTION
This commit adds an artificial and "very high" bound on the size of an unbounded
asynchronous channel. An unbounded channel runs the risk of memory exhaustions,
resulting in a process abort (currently OOM is not a fail!()). This is often a
disastrous failure mode, so instead this commit attempts to mitigate some of the
worry by imposing a large limit which will theoretically get triggered before
hitting OOM.

This commit also adds an ability to sidestep these assertions by using the
`unchecked_channel` method to create a Sender/Receiver pair. This function is
currently marked as `#[experimental]` due to leaking implementation
abstractions.
