### PR TITLE
syntax: Don't parameterize the the pretty printer

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -596,7 +596,7 @@ struct IdentifiedAnnotation;
 
 impl pprust::PpAnn for IdentifiedAnnotation {
     fn pre(&self,
-           s: &mut pprust::State<IdentifiedAnnotation>,
+           s: &mut pprust::State,
            node: pprust::AnnNode) -> io::IoResult<()> {
         match node {
             pprust::NodeExpr(_) => s.popen(),
@@ -604,7 +604,7 @@ impl pprust::PpAnn for IdentifiedAnnotation {
         }
     }
     fn post(&self,
-            s: &mut pprust::State<IdentifiedAnnotation>,
+            s: &mut pprust::State,
             node: pprust::AnnNode) -> io::IoResult<()> {
         match node {
             pprust::NodeItem(item) => {
@@ -634,7 +634,7 @@ struct TypedAnnotation {
 
 impl pprust::PpAnn for TypedAnnotation {
     fn pre(&self,
-           s: &mut pprust::State<TypedAnnotation>,
+           s: &mut pprust::State,
            node: pprust::AnnNode) -> io::IoResult<()> {
         match node {
             pprust::NodeExpr(_) => s.popen(),
@@ -642,7 +642,7 @@ impl pprust::PpAnn for TypedAnnotation {
         }
     }
     fn post(&self,
-            s: &mut pprust::State<TypedAnnotation>,
+            s: &mut pprust::State,
             node: pprust::AnnNode) -> io::IoResult<()> {
         let tcx = &self.analysis.ty_cx;
         match node {

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -85,7 +85,7 @@ struct LoopScope<'a> {
 
 impl<'a, O:DataFlowOperator> pprust::PpAnn for DataFlowContext<'a, O> {
     fn pre(&self,
-           ps: &mut pprust::State<DataFlowContext<'a, O>>,
+           ps: &mut pprust::State,
            node: pprust::AnnNode) -> io::IoResult<()> {
         let id = match node {
             pprust::NodeExpr(expr) => expr.id,

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -880,8 +880,8 @@ mod test {
     use super::*;
 
     // this version doesn't care about getting comments or docstrings in.
-    fn fake_print_crate<A: pprust::PpAnn>(s: &mut pprust::State<A>,
-                                          krate: &ast::Crate) -> io::IoResult<()> {
+    fn fake_print_crate(s: &mut pprust::State,
+                        krate: &ast::Crate) -> io::IoResult<()> {
         s.print_mod(&krate.module, krate.attrs.as_slice())
     }
 


### PR DESCRIPTION
The pretty printer constitues an enormous amount of code, there's no reason for
it to be generic. This just least to a huge amount of metadata which isn't
necessary. Instead, this change migrates the pretty printer to using a trait
object instead.

Closes #12985
