### PR TITLE
test: Fix android tests

### DIFF
--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // ignore-fast #[feature] doesn't work with check-fast
+// ignore-android
+
 #[feature(asm)];
 
 #[allow(dead_code)];
@@ -32,9 +34,6 @@ pub fn main() {
     }
     assert_eq!(x, 13);
 }
-
-// #[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
-// pub fn main() {}
 
 // At least one error is needed so that compilation fails
 #[static_assert]


### PR DESCRIPTION
This compile-fail test didn't have a main function for architectures other than
x86
