### PR TITLE
rustc: buffer the output writer for -Z ast-json[-noexpand].

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -186,7 +186,7 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
     });
 
     if sess.opts.debugging_opts & session::AST_JSON_NOEXPAND != 0 {
-        let mut stdout = io::stdout();
+        let mut stdout = io::BufferedWriter::new(io::stdout());
         let mut json = json::PrettyEncoder::new(&mut stdout);
         krate.encode(&mut json);
     }
@@ -261,7 +261,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
          front::assign_node_ids_and_map::assign_node_ids_and_map(sess, krate));
 
     if sess.opts.debugging_opts & session::AST_JSON != 0 {
-        let mut stdout = io::stdout();
+        let mut stdout = io::BufferedWriter::new(io::stdout());
         let mut json = json::PrettyEncoder::new(&mut stdout);
         krate.encode(&mut json);
     }


### PR DESCRIPTION
rustc: buffer the output writer for -Z ast-json[-noexpand].

This takes the time for `rustc libstd/lib.rs -Z ast-json-noexpand > file.json` from 9.0s to 3.5s (~0.5s spent parsing etc.) and `-Z ast-json` from 11s to 5s (~1.5s spent parsing and expanding).
