### PR TITLE
rustc: test: don't silently ignore bad benches

### DIFF
--- a/src/test/compile-fail/issue-12997-1.rs
+++ b/src/test/compile-fail/issue-12997-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+//! Test that makes sure wrongly-typed bench functions aren't ignored
+
+#[bench]
+fn foo() { } //~ ERROR functions used as benches
+
+#[bench]
+fn bar(x: int, y: int) { } //~ ERROR functions used as benches

--- a/src/test/compile-fail/issue-12997-2.rs
+++ b/src/test/compile-fail/issue-12997-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+//! Test that makes sure wrongly-typed bench functions are rejected
+
+// error-pattern:expected &-ptr but found int
+#[bench]
+fn bar(x: int) { }


### PR DESCRIPTION
This is adequate because when a function has a type that isn't caught here,
that is, it has a single argument, but it _isn't_ `&mut BenchHarness`, it
errors later on with:

```
 error: mismatched types: expected `fn(&mut test::BenchHarness)` but found
`fn(int)` (expected &-ptr but found int)
```

which I consider acceptable.

Closes #12997
