### PR TITLE
Make method Vec::remove() public

### DIFF
--- a/src/libstd/vec_ng.rs
+++ b/src/libstd/vec_ng.rs
@@ -427,7 +427,7 @@ impl<T> Vec<T> {
         }
     }
 
-    fn remove(&mut self, index: uint) -> Option<T> {
+    pub fn remove(&mut self, index: uint) -> Option<T> {
         let len = self.len();
         if index < len {
             unsafe { // infallible


### PR DESCRIPTION
This method is public on `OwnedVector`, it should also be public on `vec_ng`
