### PR TITLE
Use more Datums in trans.

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -199,7 +199,7 @@ use driver::session::FullDebugInfo;
 use lib::llvm::{llvm, ValueRef, BasicBlockRef};
 use middle::const_eval;
 use middle::borrowck::root_map_key;
-use middle::lang_items::{UniqStrEqFnLangItem, StrEqFnLangItem};
+use middle::lang_items::StrEqFnLangItem;
 use middle::pat_util::*;
 use middle::resolve::DefMap;
 use middle::trans::adt;
@@ -1278,25 +1278,10 @@ fn compare_values<'a>(
                   -> Result<'a> {
     let _icx = push_ctxt("compare_values");
     if ty::type_is_scalar(rhs_t) {
-      let rs = compare_scalar_types(cx, lhs, rhs, rhs_t, ast::BiEq);
-      return rslt(rs.bcx, rs.val);
+        return compare_scalar_types(cx, lhs, rhs, rhs_t, ast::BiEq);
     }
 
     match ty::get(rhs_t).sty {
-        ty::ty_str(ty::vstore_uniq) => {
-            let scratch_lhs = alloca(cx, val_ty(lhs), "__lhs");
-            Store(cx, lhs, scratch_lhs);
-            let scratch_rhs = alloca(cx, val_ty(rhs), "__rhs");
-            Store(cx, rhs, scratch_rhs);
-            let did = langcall(cx, None,
-                               format!("comparison of `{}`", cx.ty_to_str(rhs_t)),
-                               UniqStrEqFnLangItem);
-            let result = callee::trans_lang_call(cx, did, [scratch_lhs, scratch_rhs], None);
-            Result {
-                bcx: result.bcx,
-                val: bool_to_i1(result.bcx, result.val)
-            }
-        }
         ty::ty_str(_) => {
             let did = langcall(cx, None,
                                format!("comparison of `{}`", cx.ty_to_str(rhs_t)),

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1286,7 +1286,12 @@ fn compare_values<'a>(
             let did = langcall(cx, None,
                                format!("comparison of `{}`", cx.ty_to_str(rhs_t)),
                                StrEqFnLangItem);
-            let result = callee::trans_lang_call(cx, did, [lhs, rhs], None);
+            let result = callee::trans_call(cx, None,
+                callee::Fn(callee::trans_fn_ref_with_vtables(cx, did, ExprId(0), [], None)),
+                [lhs, rhs].iter(), |bcx, &val| {
+                    DatumBlock(bcx, Datum(val, rhs_t, RvalueExpr(Rvalue(ByRef))))
+                },
+                None);
             Result {
                 bcx: result.bcx,
                 val: bool_to_i1(result.bcx, result.val)

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -48,15 +48,13 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
     // Now the input operands
     let inputs = ia.inputs.map(|&(ref c, input)| {
         constraints.push((*c).clone());
-
-        let in_datum = unpack_datum!(bcx, expr::trans(bcx, input));
-        unpack_result!(bcx, {
-            callee::trans_arg_datum(bcx,
-                                   expr_ty(bcx, input),
-                                   in_datum,
-                                   cleanup::CustomScope(temp_scope),
-                                   callee::DontAutorefArg)
-        })
+        let input = expr::trans(bcx, input);
+        let input_ty = input.datum.ty;
+        let input = unpack_datum!(bcx, {
+            callee::trans_arg_datum(input, input_ty,
+                                    cleanup::CustomScope(temp_scope))
+        });
+        input.val
     });
 
     // no failure occurred preparing operands, no need to cleanup

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -666,7 +666,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
         let llpersonality = callee::trans_fn_ref(pad_bcx, def_id, ExprId(0));
 
         // The only landing pad clause will be 'cleanup'
-        let llretval = build::LandingPad(pad_bcx, llretty, llpersonality, 1u);
+        let llretval = build::LandingPad(pad_bcx, llretty, llpersonality.val, 1u);
 
         // The landing pad block is a cleanup
         build::SetCleanup(pad_bcx, llretval);

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -711,14 +711,7 @@ pub fn is_null(val: ValueRef) -> bool {
 
 // Used to identify cached monomorphized functions and vtables
 #[deriving(Eq, TotalEq, Hash)]
-pub enum mono_param_id {
-    mono_precise(ty::t, Option<@Vec<mono_id> >),
-    mono_any,
-    mono_repr(uint /* size */,
-              uint /* align */,
-              MonoDataClass,
-              datum::RvalueMode),
-}
+pub struct MonoParamId(ty::t, Option<@Vec<mono_id>>);
 
 #[deriving(Eq, TotalEq, Hash)]
 pub enum MonoDataClass {
@@ -745,7 +738,8 @@ pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
 #[deriving(Eq, TotalEq, Hash)]
 pub struct mono_id_ {
     def: ast::DefId,
-    params: Vec<mono_param_id> }
+    params: Vec<MonoParamId>
+}
 
 pub type mono_id = @mono_id_;
 
@@ -931,16 +925,6 @@ pub fn dummy_substs(tps: Vec<ty::t> ) -> ty::substs {
         self_ty: None,
         tps: tps
     }
-}
-
-pub fn filename_and_line_num_from_span(bcx: &Block, span: Span)
-                                       -> (ValueRef, ValueRef) {
-    let loc = bcx.sess().codemap().lookup_char_pos(span.lo);
-    let filename_cstr = C_cstr(bcx.ccx(),
-                               token::intern_and_get_ident(loc.file.name));
-    let filename = build::PointerCast(bcx, filename_cstr, Type::i8p(bcx.ccx()));
-    let line = C_int(bcx.ccx(), loc.line as int);
-    (filename, line)
 }
 
 // Casts a Rust bool value to an i1.

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -19,10 +19,11 @@ use middle::astencode;
 use middle::resolve;
 use middle::trans::adt;
 use middle::trans::base;
+use middle::trans::base::{decl_crate_map};
 use middle::trans::builder::Builder;
 use middle::trans::common::{C_i32, C_null};
 use middle::trans::common::{mono_id,ExternMap,tydesc_info,BuilderRef_res,Stats};
-use middle::trans::base::{decl_crate_map};
+use middle::trans::datum::{Datum, PodValue, LvalueOrPod};
 use middle::trans::debuginfo;
 use middle::trans::type_::Type;
 use middle::ty;
@@ -45,7 +46,7 @@ pub struct CrateContext {
     tn: TypeNames,
     externs: RefCell<ExternMap>,
     intrinsics: HashMap<&'static str, ValueRef>,
-    item_vals: RefCell<NodeMap<ValueRef>>,
+    item_vals: RefCell<NodeMap<LvalueOrPod>>,
     exp_map2: resolve::ExportMap2,
     reachable: NodeSet,
     item_symbols: RefCell<NodeMap<~str>>,
@@ -65,7 +66,7 @@ pub struct CrateContext {
     // that is generated
     non_inlineable_statics: RefCell<NodeSet>,
     // Cache instances of monomorphized functions
-    monomorphized: RefCell<HashMap<mono_id, ValueRef>>,
+    monomorphized: RefCell<HashMap<mono_id, Datum<PodValue>>>,
     monomorphizing: RefCell<DefIdMap<uint>>,
     // Cache generated vtables
     vtables: RefCell<HashMap<(ty::t, mono_id), ValueRef>>,

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -332,11 +332,10 @@ pub fn trans_uniq_vstore<'a>(bcx: &'a Block<'a>,
                                             Some(lit.span),
                                             "",
                                             StrDupUniqFnLangItem);
-                    let bcx = callee::trans_lang_call(
-                        bcx,
-                        alloc_fn,
-                        [ llptrval, llsizeval ],
-                        Some(expr::SaveIn(lldestval.val))).bcx;
+                    let bcx = callee::trans_lang_call(bcx, alloc_fn, [
+                        pod_value(bcx.tcx(), llptrval, ty::mk_imm_ptr(bcx.tcx(), ty::mk_u8())),
+                        pod_value(bcx.tcx(), llsizeval, ty::mk_uint())
+                    ], Some(expr::SaveIn(lldestval.val))).bcx;
                     return DatumBlock(bcx, lldestval).to_expr_datumblock();
                 }
                 _ => {}


### PR DESCRIPTION
Datums are safer than plain ValueRefs, as they hold a type and a kind (specifying how the value should be handled), and potentially more efficient (e.g. repeated type lookups can be expensive, because of substitutions).
This PR begins the conversion of old code using ValueRefs to Datums.
It also introduces a new Datum kind, PodValue, which can be freely shared, akin to an Lvalue.
