### PR TITLE
Made the `clone_from` implementation for `~T` reuse the `T` itself if possible

### DIFF
--- a/src/libstd/clone.rs
+++ b/src/libstd/clone.rs
@@ -45,8 +45,9 @@ impl<T: Clone> Clone for ~T {
     fn clone(&self) -> ~T { ~(**self).clone() }
 
     /// Perform copy-assignment from `source` by reusing the existing allocation.
+    #[inline]
     fn clone_from(&mut self, source: &~T) {
-        **self = (**source).clone()
+        (**self).clone_from(&(**source));
     }
 }
 


### PR DESCRIPTION
...by also calling `clone_from` on it.

In general, `Clone` implementors that overwrite `clone_from`
should try to to use it recursively for substructures.
