### PR TITLE
rustc: put ty_trait and ty_closure behind some indirection, nearly halving the size of ty::sty

### DIFF
--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -280,11 +280,11 @@ fn enc_sty(w: &mut MemWriter, cx: &ctxt, st: &ty::sty) {
             enc_substs(w, cx, substs);
             mywrite!(w, "]");
         }
-        ty::ty_trait(def, ref substs, store, mt, bounds) => {
-            mywrite!(w, "x[{}|", (cx.ds)(def));
+        ty::ty_trait(~ty::TyTrait { def_id, ref substs, store, mutability, bounds }) => {
+            mywrite!(w, "x[{}|", (cx.ds)(def_id));
             enc_substs(w, cx, substs);
             enc_trait_store(w, cx, store);
-            enc_mutability(w, mt);
+            enc_mutability(w, mutability);
             let bounds = ty::ParamBounds {builtin_bounds: bounds,
                                           trait_bounds: Vec::new()};
             enc_bounds(w, cx, &bounds);

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -315,7 +315,7 @@ fn enc_sty(w: &mut MemWriter, cx: &ctxt, st: &ty::sty) {
         ty::ty_unboxed_vec(mt) => { mywrite!(w, "U"); enc_mt(w, cx, mt); }
         ty::ty_closure(ref f) => {
             mywrite!(w, "f");
-            enc_closure_ty(w, cx, f);
+            enc_closure_ty(w, cx, *f);
         }
         ty::ty_bare_fn(ref f) => {
             mywrite!(w, "F");

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -358,7 +358,7 @@ pub fn check_expr(cx: &mut Context, e: &Expr) {
 fn check_trait_cast(cx: &mut Context, source_ty: ty::t, target_ty: ty::t, span: Span) {
     check_cast_for_escaping_regions(cx, source_ty, target_ty, span);
     match ty::get(target_ty).sty {
-        ty::ty_trait(_, _, _, _, bounds) => {
+        ty::ty_trait(~ty::TyTrait { bounds, .. }) => {
             check_trait_cast_bounds(cx, span, source_ty, bounds);
         }
         _ => {}

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -208,21 +208,21 @@ fn with_appropriate_checker(cx: &Context,
 
     let fty = ty::node_id_to_type(cx.tcx, id);
     match ty::get(fty).sty {
-        ty::ty_closure(ty::ClosureTy {
+        ty::ty_closure(~ty::ClosureTy {
             sigil: OwnedSigil,
             bounds: bounds,
             ..
         }) => {
             b(|cx, fv| check_for_uniq(cx, fv, bounds))
         }
-        ty::ty_closure(ty::ClosureTy {
+        ty::ty_closure(~ty::ClosureTy {
             sigil: ManagedSigil,
             ..
         }) => {
             // can't happen
             fail!("internal error: saw closure with managed sigil (@fn)");
         }
-        ty::ty_closure(ty::ClosureTy {
+        ty::ty_closure(~ty::ClosureTy {
             sigil: BorrowedSigil,
             bounds: bounds,
             region: region,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -911,7 +911,7 @@ fn check_heap_type(cx: &Context, span: Span, ty: ty::t) {
                 }
                 ty::ty_uniq(_) | ty::ty_str(ty::vstore_uniq) |
                 ty::ty_vec(_, ty::vstore_uniq) |
-                ty::ty_trait(_, _, ty::UniqTraitStore, _, _) => {
+                ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) => {
                     n_uniq += 1;
                 }
                 ty::ty_closure(ref c) if c.sigil == ast::OwnedSigil => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -173,7 +173,7 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
         ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) |
         ty::ty_vec(_, ty::vstore_uniq) |
         ty::ty_str(ty::vstore_uniq) |
-        ty::ty_closure(ty::ClosureTy {sigil: ast::OwnedSigil, ..}) => {
+        ty::ty_closure(~ty::ClosureTy {sigil: ast::OwnedSigil, ..}) => {
             Some(deref_ptr(OwnedPtr))
         }
 
@@ -189,7 +189,7 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
         }
 
         ty::ty_str(ty::vstore_slice(r)) |
-        ty::ty_closure(ty::ClosureTy {sigil: ast::BorrowedSigil,
+        ty::ty_closure(~ty::ClosureTy {sigil: ast::BorrowedSigil,
                                       region: r, ..}) => {
             Some(deref_ptr(BorrowedPtr(ty::ImmBorrow, r)))
         }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -170,7 +170,7 @@ pub enum deref_kind {
 pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
     match ty::get(t).sty {
         ty::ty_uniq(_) |
-        ty::ty_trait(_, _, ty::UniqTraitStore, _, _) |
+        ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) |
         ty::ty_vec(_, ty::vstore_uniq) |
         ty::ty_str(ty::vstore_uniq) |
         ty::ty_closure(ty::ClosureTy {sigil: ast::OwnedSigil, ..}) => {
@@ -183,7 +183,7 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
             Some(deref_ptr(BorrowedPtr(kind, r)))
         }
 
-        ty::ty_trait(_, _, ty::RegionTraitStore(r), m, _) => {
+        ty::ty_trait(~ty::TyTrait { store: ty::RegionTraitStore(r), mutability: m, .. }) => {
             let kind = ty::BorrowKind::from_mutbl(m);
             Some(deref_ptr(BorrowedPtr(kind, r)))
         }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -269,7 +269,7 @@ pub fn decl_rust_fn(ccx: &CrateContext, has_env: bool,
             // noalias because the actual object pointer is nested.
             ty::ty_uniq(..) | // ty::ty_trait(_, _, ty::UniqTraitStore, _, _) |
             ty::ty_vec(_, ty::vstore_uniq) | ty::ty_str(ty::vstore_uniq) |
-            ty::ty_closure(ty::ClosureTy {sigil: ast::OwnedSigil, ..}) => {
+            ty::ty_closure(~ty::ClosureTy {sigil: ast::OwnedSigil, ..}) => {
                 unsafe {
                     llvm::LLVMAddAttribute(llarg, lib::llvm::NoAliasAttribute as c_uint);
                 }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -2126,7 +2126,9 @@ fn type_metadata(cx: &CrateContext,
         ty::ty_closure(ref closurety) => {
             subroutine_type_metadata(cx, &closurety.sig, usage_site_span)
         },
-        ty::ty_trait(def_id, ref substs, trait_store, mutability, ref bounds) => {
+        ty::ty_trait(~ty::TyTrait { def_id, ref substs,
+                                store: trait_store, mutability,
+                                ref bounds }) => {
             trait_metadata(cx, def_id, t, substs, trait_store, mutability, bounds)
         },
         ty::ty_struct(def_id, ref substs) => {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -310,7 +310,7 @@ fn make_drop_glue<'a>(bcx: &'a Block<'a>, v0: ValueRef, t: ty::t) -> &'a Block<'
                 }
             }
         }
-        ty::ty_trait(_, _, ty::UniqTraitStore, _, _) => {
+        ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) => {
             let lluniquevalue = GEPi(bcx, v0, [0, abi::trt_field_box]);
             // Only drop the value when it is non-null
             with_cond(bcx, IsNotNull(bcx, Load(bcx, lluniquevalue)), |bcx| {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -351,7 +351,7 @@ impl<'a> Reflector<'a> {
             })
           }
 
-          ty::ty_trait(_, _, _, _, _) => {
+          ty::ty_trait(..) => {
               let extra = [
                   self.c_slice(token::intern_and_get_ident(ty_to_str(tcx, t)))
               ];

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -746,7 +746,7 @@ pub enum sty {
     ty_ptr(mt),
     ty_rptr(Region, mt),
     ty_bare_fn(BareFnTy),
-    ty_closure(ClosureTy),
+    ty_closure(~ClosureTy),
     ty_trait(~TyTrait),
     ty_struct(DefId, substs),
     ty_tup(Vec<t>),
@@ -1407,7 +1407,7 @@ pub fn mk_mut_unboxed_vec(cx: &ctxt, ty: t) -> t {
 pub fn mk_tup(cx: &ctxt, ts: Vec<t>) -> t { mk_t(cx, ty_tup(ts)) }
 
 pub fn mk_closure(cx: &ctxt, fty: ClosureTy) -> t {
-    mk_t(cx, ty_closure(fty))
+    mk_t(cx, ty_closure(~fty))
 }
 
 pub fn mk_bare_fn(cx: &ctxt, fty: BareFnTy) -> t {
@@ -2149,7 +2149,7 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
             }
 
             ty_closure(ref c) => {
-                closure_contents(cx, c)
+                closure_contents(cx, *c)
             }
 
             ty_box(typ) => {
@@ -2870,7 +2870,7 @@ pub fn ty_region(tcx: &ctxt,
 pub fn replace_fn_sig(cx: &ctxt, fsty: &sty, new_sig: FnSig) -> t {
     match *fsty {
         ty_bare_fn(ref f) => mk_bare_fn(cx, BareFnTy {sig: new_sig, ..*f}),
-        ty_closure(ref f) => mk_closure(cx, ClosureTy {sig: new_sig, ..*f}),
+        ty_closure(ref f) => mk_closure(cx, ClosureTy {sig: new_sig, ..**f}),
         ref s => {
             cx.sess.bug(
                 format!("ty_fn_sig() called on non-fn type: {:?}", s));
@@ -2888,7 +2888,7 @@ pub fn replace_closure_return_type(tcx: &ctxt, fn_type: t, ret_type: t) -> t {
         ty::ty_closure(ref fty) => {
             ty::mk_closure(tcx, ClosureTy {
                 sig: FnSig {output: ret_type, ..fty.sig.clone()},
-                ..(*fty).clone()
+                ..(**fty).clone()
             })
         }
         _ => {
@@ -3140,7 +3140,7 @@ pub fn adjust_ty(cx: &ctxt,
                 ty::mk_closure(cx, ClosureTy {
                     sigil: BorrowedSigil,
                     region: r,
-                    ..(*fty).clone()
+                    ..(**fty).clone()
                 })
             }
 

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -159,12 +159,14 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_enum(tid, ref substs) => {
             ty::ty_enum(tid, this.fold_substs(substs))
         }
-        ty::ty_trait(did, ref substs, st, mutbl, bounds) => {
-            ty::ty_trait(did,
-                     this.fold_substs(substs),
-                     this.fold_trait_store(st),
-                     mutbl,
-                     bounds)
+        ty::ty_trait(~ty::TyTrait { def_id, ref substs, store, mutability, bounds }) => {
+            ty::ty_trait(~ty::TyTrait{
+                def_id: def_id,
+                substs: this.fold_substs(substs),
+                store: this.fold_trait_store(store),
+                mutability: mutability,
+                bounds: bounds
+            })
         }
         ty::ty_tup(ref ts) => {
             ty::ty_tup(fold_ty_vec(this, ts.as_slice()))

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -175,7 +175,7 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
             ty::ty_bare_fn(this.fold_bare_fn_ty(f))
         }
         ty::ty_closure(ref f) => {
-            ty::ty_closure(this.fold_closure_ty(f))
+            ty::ty_closure(~this.fold_closure_ty(*f))
         }
         ty::ty_rptr(r, ref tm) => {
             ty::ty_rptr(this.fold_region(r),

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1860,7 +1860,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
 
         let fn_sig = match *fn_sty {
             ty::ty_bare_fn(ty::BareFnTy {sig: ref sig, ..}) |
-            ty::ty_closure(ty::ClosureTy {sig: ref sig, ..}) => sig,
+            ty::ty_closure(~ty::ClosureTy {sig: ref sig, ..}) => sig,
             _ => {
                 fcx.type_error_message(call_expr.span, |actual| {
                     format!("expected function but \

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -542,7 +542,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             // explaining how it goes about doing that.
             let target_ty = rcx.resolve_node_type(expr.id);
             match ty::get(target_ty).sty {
-                ty::ty_trait(_, _, ty::RegionTraitStore(trait_region), _, _) => {
+                ty::ty_trait(~ty::TyTrait { store: ty::RegionTraitStore(trait_region), .. }) => {
                     let source_ty = rcx.resolve_expr_type_adjusted(source);
                     constrain_regions_in_type(
                         rcx,

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -610,7 +610,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
     let tcx = rcx.fcx.tcx();
     let function_type = rcx.resolve_node_type(expr.id);
     match ty::get(function_type).sty {
-        ty::ty_closure(ty::ClosureTy {
+        ty::ty_closure(~ty::ClosureTy {
                 sigil: ast::BorrowedSigil, region: region, ..}) => {
             let freevars = freevars::get_freevars(tcx, expr.id);
             if freevars.is_empty() {
@@ -635,7 +635,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
     rcx.set_repeating_scope(repeating_scope);
 
     match ty::get(function_type).sty {
-        ty::ty_closure(ty::ClosureTy {sigil: ast::BorrowedSigil, ..}) => {
+        ty::ty_closure(~ty::ClosureTy {sigil: ast::BorrowedSigil, ..}) => {
             let freevars = freevars::get_freevars(tcx, expr.id);
             propagate_upupvar_borrow_kind(rcx, expr, freevars);
         }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -478,7 +478,7 @@ fn fixup_substs(vcx: &VtableContext,
                          ty::EmptyBuiltinBounds());
     fixup_ty(vcx, span, t, is_early).map(|t_f| {
         match ty::get(t_f).sty {
-          ty::ty_trait(_, ref substs_f, _, _, _) => (*substs_f).clone(),
+          ty::ty_trait(ref inner) => inner.substs.clone(),
           _ => fail!("t_f should be a trait")
         }
     })
@@ -536,8 +536,10 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
     let resolve_object_cast = |src: &ast::Expr, target_ty: ty::t| {
       match ty::get(target_ty).sty {
           // Bounds of type's contents are not checked here, but in kind.rs.
-          ty::ty_trait(target_def_id, ref target_substs, store,
-                       target_mutbl, _bounds) => {
+          ty::ty_trait(~ty::TyTrait {
+              def_id: target_def_id, substs: ref target_substs, store: store,
+              mutability: target_mutbl, bounds: _bounds
+          }) => {
               fn mutability_allowed(a_mutbl: ast::Mutability,
                                     b_mutbl: ast::Mutability) -> bool {
                   a_mutbl == b_mutbl ||

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -106,7 +106,7 @@ fn type_is_defined_in_local_crate(original_type: t) -> bool {
     ty::walk_ty(original_type, |t| {
         match get(t).sty {
             ty_enum(def_id, _) |
-            ty_trait(def_id, _, _, _, _) |
+            ty_trait(~ty::TyTrait { def_id, .. }) |
             ty_struct(def_id, _) => {
                 if def_id.krate == ast::LOCAL_CRATE {
                     found_nominal = true;
@@ -132,7 +132,7 @@ fn get_base_type_def_id(inference_context: &InferCtxt,
             match get(base_type).sty {
                 ty_enum(def_id, _) |
                 ty_struct(def_id, _) |
-                ty_trait(def_id, _, _, _, _) => {
+                ty_trait(~ty::TyTrait { def_id, .. }) => {
                     return Some(def_id);
                 }
                 _ => {

--- a/src/librustc/middle/typeck/infer/coercion.rs
+++ b/src/librustc/middle/typeck/infer/coercion.rs
@@ -119,7 +119,7 @@ impl<'f> Coerce<'f> {
                 });
             }
 
-            ty::ty_closure(ty::ClosureTy {sigil: ast::BorrowedSigil, ..}) => {
+            ty::ty_closure(~ty::ClosureTy {sigil: ast::BorrowedSigil, ..}) => {
                 return self.unpack_actual_value(a, |sty_a| {
                     self.coerce_borrowed_fn(a, sty_a, b)
                 });
@@ -361,7 +361,7 @@ impl<'f> Coerce<'f> {
             ty::ClosureTy {
                 sigil: ast::BorrowedSigil,
                 region: r_borrow,
-                ..fn_ty
+                .. *fn_ty
             });
 
         if_ok!(self.subtype(a_borrowed, b));
@@ -397,7 +397,7 @@ impl<'f> Coerce<'f> {
             let a_closure = ty::mk_closure(self.get_ref().infcx.tcx,
                                            ty::ClosureTy {
                                                 sig: fn_ty_a.sig.clone(),
-                                                ..fn_ty_b
+                                                .. *fn_ty_b
                                            });
             if_ok!(self.subtype(a_closure, b));
             Ok(Some(adj))

--- a/src/librustc/middle/typeck/infer/coercion.rs
+++ b/src/librustc/middle/typeck/infer/coercion.rs
@@ -131,7 +131,9 @@ impl<'f> Coerce<'f> {
                 });
             }
 
-            ty::ty_trait(def_id, ref substs, ty::UniqTraitStore, m, bounds) => {
+            ty::ty_trait(~ty::TyTrait {
+                def_id, ref substs, store: ty::UniqTraitStore, mutability: m, bounds
+            }) => {
                 let result = self.unpack_actual_value(a, |sty_a| {
                     match *sty_a {
                         ty::ty_uniq(..) => {
@@ -148,7 +150,9 @@ impl<'f> Coerce<'f> {
                 }
             }
 
-            ty::ty_trait(def_id, ref substs, ty::RegionTraitStore(region), m, bounds) => {
+            ty::ty_trait(~ty::TyTrait {
+                def_id, ref substs, store: ty::RegionTraitStore(region), mutability: m, bounds
+            }) => {
                 let result = self.unpack_actual_value(a, |sty_a| {
                     match *sty_a {
                         ty::ty_rptr(..) => {
@@ -313,9 +317,9 @@ impl<'f> Coerce<'f> {
         let r_a = self.get_ref().infcx.next_region_var(Coercion(self.get_ref().trace));
 
         let a_borrowed = match *sty_a {
-            ty::ty_trait(did, ref substs, _, _, b) => {
-                ty::mk_trait(tcx, did, substs.clone(),
-                             ty::RegionTraitStore(r_a), b_mutbl, b)
+            ty::ty_trait(~ty::TyTrait { def_id, ref substs, bounds, .. }) => {
+                ty::mk_trait(tcx, def_id, substs.clone(),
+                             ty::RegionTraitStore(r_a), b_mutbl, bounds)
             }
             _ => {
                 return self.subtype(a, b);

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -500,18 +500,18 @@ pub fn super_tys<C:Combine>(this: &C, a: ty::t, b: ty::t) -> cres<ty::t> {
           Ok(ty::mk_enum(tcx, a_id, substs))
       }
 
-      (&ty::ty_trait(a_id, ref a_substs, a_store, a_mutbl, a_bounds),
-       &ty::ty_trait(b_id, ref b_substs, b_store, b_mutbl, b_bounds))
-      if a_id == b_id && a_mutbl == b_mutbl => {
+      (&ty::ty_trait(ref a_),
+       &ty::ty_trait(ref b_))
+      if a_.def_id == b_.def_id && a_.mutability == b_.mutability => {
           debug!("Trying to match traits {:?} and {:?}", a, b);
-          let substs = if_ok!(this.substs(a_id, a_substs, b_substs));
-          let s = if_ok!(this.trait_stores(ty::terr_trait, a_store, b_store));
-          let bounds = if_ok!(this.bounds(a_bounds, b_bounds));
+          let substs = if_ok!(this.substs(a_.def_id, &a_.substs, &b_.substs));
+          let s = if_ok!(this.trait_stores(ty::terr_trait, a_.store, b_.store));
+          let bounds = if_ok!(this.bounds(a_.bounds, b_.bounds));
           Ok(ty::mk_trait(tcx,
-                          a_id,
+                          a_.def_id,
                           substs.clone(),
                           s,
-                          a_mutbl,
+                          a_.mutability,
                           bounds))
       }
 

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -570,7 +570,7 @@ pub fn super_tys<C:Combine>(this: &C, a: ty::t, b: ty::t) -> cres<ty::t> {
       }
 
       (&ty::ty_closure(ref a_fty), &ty::ty_closure(ref b_fty)) => {
-        this.closure_tys(a_fty, b_fty).and_then(|fty| {
+        this.closure_tys(*a_fty, *b_fty).and_then(|fty| {
             Ok(ty::mk_closure(tcx, fty))
         })
       }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -719,7 +719,7 @@ impl<'a> InferCtxt<'a> {
                                   ty::EmptyBuiltinBounds());
         let dummy1 = self.resolve_type_vars_if_possible(dummy0);
         match ty::get(dummy1).sty {
-            ty::ty_trait(ref def_id, ref substs, _, _, _) => {
+            ty::ty_trait(~ty::TyTrait { ref def_id, ref substs, .. }) => {
                 ty::TraitRef {
                     def_id: *def_id,
                     substs: (*substs).clone(),
@@ -976,4 +976,3 @@ impl Repr for RegionVariableOrigin {
         }
     }
 }
-

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -705,7 +705,7 @@ impl<'a> ConstraintContext<'a> {
                 self.add_constraints_from_sig(sig, variance);
             }
 
-            ty::ty_closure(ty::ClosureTy { sig: ref sig, region, .. }) => {
+            ty::ty_closure(~ty::ClosureTy { sig: ref sig, region, .. }) => {
                 let contra = self.contravariant(variance);
                 self.add_constraints_from_region(region, contra);
                 self.add_constraints_from_sig(sig, variance);

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -675,7 +675,7 @@ impl<'a> ConstraintContext<'a> {
                                                  substs, variance);
             }
 
-            ty::ty_trait(def_id, ref substs, _, _, _) => {
+            ty::ty_trait(~ty::TyTrait { def_id, ref substs, .. }) => {
                 let trait_def = ty::lookup_trait_def(self.tcx(), def_id);
                 self.add_constraints_from_substs(def_id, &trait_def.generics,
                                                  substs, variance);

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -453,7 +453,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
         ~"(" + strs.connect(",") + ")"
       }
       ty_closure(ref f) => {
-          closure_to_str(cx, f)
+          closure_to_str(cx, *f)
       }
       ty_bare_fn(ref f) => {
           bare_fn_to_str(cx, f.purity, f.abis, None, &f.sig)

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -484,7 +484,9 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
                       did,
                       false)
       }
-      ty_trait(did, ref substs, s, mutbl, ref bounds) => {
+      ty_trait(~ty::TyTrait {
+          def_id: did, ref substs, store: s, mutability: mutbl, ref bounds
+      }) => {
         let base = ty::item_path_str(cx, did);
         let ty = parameterized(cx, base, &substs.regions,
                                substs.tps.as_slice(), did, true);


### PR DESCRIPTION
These variants occur rarely but inflate the whole enum for the other variants, leaving a lot of wasted space. In total this reduces `ty::sty` from 160 bytes to 96 (on a 64-bit platform).

After this, `ty_struct` and `ty_enum` are the largest variants, with the 80-byte `substs` being the major contributor.
