### PR TITLE
rustc: Prevent false positives in crate loading

### DIFF
--- a/src/test/run-make/suspicious-library/Makefile
+++ b/src/test/run-make/suspicious-library/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	touch $(call DYLIB,foo-something-special)
+	touch $(call DYLIB,foo-something-special2)
+	$(RUSTC) bar.rs

--- a/src/test/run-make/suspicious-library/bar.rs
+++ b/src/test/run-make/suspicious-library/bar.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;
+
+fn main() { foo::foo() }

--- a/src/test/run-make/suspicious-library/foo.rs
+++ b/src/test/run-make/suspicious-library/foo.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type = "dylib"];
+
+pub fn foo() {}


### PR DESCRIPTION
Previously, any library of the pattern `lib<name>-<hash>-<version>.so` was

> considered a candidate (rightly so) for loading a crate. Sets are generated for
> each unique `<hash>`, and then from these sets a candidate is selected. If a set
> contained more than one element, then it immediately generated an error saying
> that multiple copies of the same dylib were found.

This is incorrect because each candidate needs to be validated to actually
contain a rust library (valid metadata). This commit alters the logic to filter
each set of candidates for a hash to only libraries which are actually rust
libraries. This means that if multiple false positives are found with the right
name pattern, they're all ignored.

Closes #13010
