### PR TITLE
mk: Simplify how prepare.mk, install.mk, and dist.mk deal with stages

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -65,8 +65,6 @@ $(PKG_EXE): rust.iss modpath.iss LICENSE.txt rust-logo.ico \
 dist-prepare-win: PREPARE_HOST=$(CFG_BUILD)
 dist-prepare-win: PREPARE_TARGETS=$(CFG_BUILD)
 dist-prepare-win: PREPARE_DEST_DIR=tmp/dist/win
-# On windows we're using stage3, unlike Unix...
-dist-prepare-win: PREPARE_STAGE=3
 dist-prepare-win: PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-prepare-win: PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
 dist-prepare-win: PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
@@ -135,7 +133,6 @@ ifeq ($(CFG_OSTYPE), apple-darwin)
 dist-prepare-osx: PREPARE_HOST=$(CFG_BUILD)
 dist-prepare-osx: PREPARE_TARGETS=$(CFG_BUILD)
 dist-prepare-osx: PREPARE_DEST_DIR=tmp/dist/pkgroot
-dist-prepare-osx: PREPARE_STAGE=2
 dist-prepare-osx: PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-prepare-osx: PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
 dist-prepare-osx: PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
@@ -165,7 +162,6 @@ dist-tar-bins: $(foreach host,$(CFG_HOST),dist/$(PKG_DIR)-$(host).tar.gz)
 define DEF_INSTALLER
 dist-install-dir-$(1): PREPARE_HOST=$(1)
 dist-install-dir-$(1): PREPARE_TARGETS=$(1)
-dist-install-dir-$(1): PREPARE_STAGE=2
 dist-install-dir-$(1): PREPARE_DEST_DIR=tmp/dist/$$(PKG_DIR)-$(1)
 dist-install-dir-$(1): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-install-dir-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -13,11 +13,10 @@
 # mirror of the installation directory structure.
 
 # The stage we install from
-ISTAGE = 2
+ISTAGE = $(PREPARE_STAGE)
 
 install: PREPARE_HOST=$(CFG_BUILD)
 install: PREPARE_TARGETS=$(CFG_TARGET)
-install: PREPARE_STAGE=$(ISTAGE)
 install: PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 install: PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
 install: PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)


### PR DESCRIPTION
The only stage that can be installed from is 2 everywhere but windows,
3 on windows.

Lightly tested. Not actually tested on Windows, but I did confirm that a _similar_ change fixed the problem on Windows.

Closes #12799
