### PR TITLE
Let travis check docs for stage1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script: |
   fi &&
   make tidy &&
   make -j4 rustc-stage1 &&
-  make check-stage1-std check-stage1-rpass check-stage1-cfail check-stage1-rfail
+  make check-stage1-std check-stage1-rpass check-stage1-cfail check-stage1-rfail check-stage1-doc
 
 env:
   global:


### PR DESCRIPTION
This should prevent lot of doc errors in Rust's buildbot and it shouldn't take long to run on travis. We could probably limit it to `std` but I preferred to just check all docs in this phase too.

@alexcrichton r?
