### PR TITLE
Update attribute syntax parsing

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -12,6 +12,7 @@
 #[feature(phase)];
 
 #[allow(non_camel_case_types)];
+#[allow(deprecated_owned_vector)]; // NOTE: remove after stage0
 #[deny(warnings)];
 
 extern crate test;

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -24,6 +24,7 @@
       html_root_url = "http://static.rust-lang.org/doc/master")];
 #[allow(missing_doc)];
 #[feature(managed_boxes)];
+#[allow(deprecated_owned_vector)]; // NOTE: remove after stage0
 
 extern crate collections;
 

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -174,6 +174,7 @@
 // NB this does *not* include globs, please keep it that way.
 #[feature(macro_rules, phase)];
 #[allow(visible_private_types)];
+#[allow(deprecated_owned_vector)]; // NOTE: remove after stage0
 
 #[cfg(test)] #[phase(syntax, link)] extern crate log;
 extern crate rand;

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -42,6 +42,7 @@ via `close` and `delete` methods.
 #[feature(macro_rules)];
 #[deny(unused_result, unused_must_use)];
 #[allow(visible_private_types)];
+#[allow(deprecated_owned_vector)]; // NOTE: remove after stage0
 
 #[cfg(test)] extern crate green;
 

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -12,7 +12,7 @@ use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos};
 use diagnostic;
 use parse::lexer::{is_whitespace, with_str_from, Reader};
-use parse::lexer::{StringReader, bump, is_eof, nextch_is, TokenAndSpan};
+use parse::lexer::{StringReader, bump, peek, is_eof, nextch_is, TokenAndSpan};
 use parse::lexer::{is_line_non_doc_comment, is_block_non_doc_comment};
 use parse::lexer;
 use parse::token;
@@ -331,7 +331,11 @@ fn consume_comment(rdr: &StringReader,
     } else if rdr.curr_is('/') && nextch_is(rdr, '*') {
         read_block_comment(rdr, code_to_the_left, comments);
     } else if rdr.curr_is('#') && nextch_is(rdr, '!') {
-        read_shebang_comment(rdr, code_to_the_left, comments);
+        // Make sure the following token is **not** the beginning
+        // of an inner attribute, which starts with the same syntax.
+        if peek(rdr, 2).unwrap() != '[' {
+            read_shebang_comment(rdr, code_to_the_left, comments);
+        }
     } else { fail!(); }
     debug!("<<< consume comment");
 }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -12,7 +12,7 @@ use ast;
 use codemap::{BytePos, CharPos, CodeMap, Pos};
 use diagnostic;
 use parse::lexer::{is_whitespace, with_str_from, Reader};
-use parse::lexer::{StringReader, bump, peek, is_eof, nextch_is, TokenAndSpan};
+use parse::lexer::{StringReader, bump, is_eof, nextch_is, TokenAndSpan};
 use parse::lexer::{is_line_non_doc_comment, is_block_non_doc_comment};
 use parse::lexer;
 use parse::token;
@@ -319,7 +319,9 @@ fn read_block_comment(rdr: &StringReader,
 fn peeking_at_comment(rdr: &StringReader) -> bool {
     return (rdr.curr_is('/') && nextch_is(rdr, '/')) ||
          (rdr.curr_is('/') && nextch_is(rdr, '*')) ||
-         (rdr.curr_is('#') && nextch_is(rdr, '!'));
+         // consider shebangs comments, but not inner attributes
+         (rdr.curr_is('#') && nextch_is(rdr, '!') &&
+          !lexer::nextnextch_is(rdr, '['));
 }
 
 fn consume_comment(rdr: &StringReader,
@@ -331,11 +333,7 @@ fn consume_comment(rdr: &StringReader,
     } else if rdr.curr_is('/') && nextch_is(rdr, '*') {
         read_block_comment(rdr, code_to_the_left, comments);
     } else if rdr.curr_is('#') && nextch_is(rdr, '!') {
-        // Make sure the following token is **not** the beginning
-        // of an inner attribute, which starts with the same syntax.
-        if peek(rdr, 2).unwrap() != '[' {
-            read_shebang_comment(rdr, code_to_the_left, comments);
-        }
+        read_shebang_comment(rdr, code_to_the_left, comments);
     } else { fail!(); }
     debug!("<<< consume comment");
 }

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -271,9 +271,21 @@ pub fn bump(rdr: &StringReader) {
         rdr.curr.set(None);
     }
 }
+
+// EFFECT: Peek 'n' characters ahead.
+pub fn peek(rdr: &StringReader, n: uint) -> Option<char> {
+    let offset = byte_offset(rdr, rdr.pos.get()).to_uint() + (n - 1);
+    if offset < (rdr.filemap.src).len() {
+        Some(rdr.filemap.src.char_at(offset))
+    } else {
+        None
+    }
+}
+
 pub fn is_eof(rdr: &StringReader) -> bool {
     rdr.curr.get().is_none()
 }
+
 pub fn nextch(rdr: &StringReader) -> Option<char> {
     let offset = byte_offset(rdr, rdr.pos.get()).to_uint();
     if offset < rdr.filemap.deref().src.len() {
@@ -370,6 +382,12 @@ fn consume_any_line_comment(rdr: &StringReader)
         }
     } else if rdr.curr_is('#') {
         if nextch_is(rdr, '!') {
+
+            // Parse an inner attribute.
+            if peek(rdr, 2).unwrap() == '[' {
+                return None;
+            }
+
             // I guess this is the only way to figure out if
             // we're at the beginning of the file...
             let cmap = CodeMap::new();

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -18,9 +18,10 @@ use parse::token::{str_to_ident};
 
 use std::cell::{Cell, RefCell};
 use std::char;
-use std::rc::Rc;
 use std::mem::replace;
 use std::num::from_str_radix;
+use std::rc::Rc;
+use std::str;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader};
 
@@ -272,16 +273,6 @@ pub fn bump(rdr: &StringReader) {
     }
 }
 
-// EFFECT: Peek 'n' characters ahead.
-pub fn peek(rdr: &StringReader, n: uint) -> Option<char> {
-    let offset = byte_offset(rdr, rdr.pos.get()).to_uint() + (n - 1);
-    if offset < (rdr.filemap.src).len() {
-        Some(rdr.filemap.src.char_at(offset))
-    } else {
-        None
-    }
-}
-
 pub fn is_eof(rdr: &StringReader) -> bool {
     rdr.curr.get().is_none()
 }
@@ -296,6 +287,21 @@ pub fn nextch(rdr: &StringReader) -> Option<char> {
 }
 pub fn nextch_is(rdr: &StringReader, c: char) -> bool {
     nextch(rdr) == Some(c)
+}
+
+pub fn nextnextch(rdr: &StringReader) -> Option<char> {
+    let offset = byte_offset(rdr, rdr.pos.get()).to_uint();
+    let s = rdr.filemap.deref().src.as_slice();
+    if offset >= s.len() { return None }
+    let str::CharRange { next, .. } = s.char_range_at(offset);
+    if next < s.len() {
+        Some(s.char_at(next))
+    } else {
+        None
+    }
+}
+pub fn nextnextch_is(rdr: &StringReader, c: char) -> bool {
+    nextnextch(rdr) == Some(c)
 }
 
 fn hex_digit_val(c: Option<char>) -> int {
@@ -384,7 +390,7 @@ fn consume_any_line_comment(rdr: &StringReader)
         if nextch_is(rdr, '!') {
 
             // Parse an inner attribute.
-            if peek(rdr, 2).unwrap() == '[' {
+            if nextnextch_is(rdr, '[') {
                 return None;
             }
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -33,6 +33,7 @@
       html_root_url = "http://static.rust-lang.org/doc/master")];
 
 #[feature(asm, macro_rules)];
+#[allow(deprecated_owned_vector)]; // NOTE: remove after stage0
 
 extern crate collections;
 extern crate getopts;

--- a/src/test/compile-fail/attr.rs
+++ b/src/test/compile-fail/attr.rs
@@ -10,5 +10,5 @@
 
 fn main() {}
 
-#![lang(foo)] //~ ERROR An inner attribute was not permitted in this context.
+#![lang(foo)] //~ ERROR an inner attribute is not permitted in this context
 fn foo() {}

--- a/src/test/compile-fail/attr.rs
+++ b/src/test/compile-fail/attr.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}
+
+#![lang(foo)] //~ ERROR An inner attribute was not permitted in this context.
+fn foo() {}

--- a/src/test/compile-fail/column-offset-1-based.rs
+++ b/src/test/compile-fail/column-offset-1-based.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-# //~ ERROR 11:1: 11:2 error: expected item
+# //~ ERROR 11:1: 11:2 error: expected `[` but found `<eof>`

--- a/src/test/compile-fail/issue-1655.rs
+++ b/src/test/compile-fail/issue-1655.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected item
+// error-pattern:expected `[` but found `~`
 mod blade_runner {
     #~[doc(
         brief = "Blade Runner is probably the best movie ever",

--- a/src/test/run-pass/attr-mix-new.rs
+++ b/src/test/run-pass/attr-mix-new.rs
@@ -13,4 +13,4 @@ mod foo {
   #![feature(globs)]
 }
 
-fn main() {}
+pub fn main() {}

--- a/src/test/run-pass/attr-mix-new.rs
+++ b/src/test/run-pass/attr-mix-new.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[foo(bar)]
+mod foo {
+  #![feature(globs)]
+}
+
+fn main() {}

--- a/src/test/run-pass/attr-shebang.rs
+++ b/src/test/run-pass/attr-shebang.rs
@@ -1,4 +1,5 @@
 #![allow(unknown_features)]
 #![feature(bogus)]
-fn main() { }
+pub fn main() { }
 // ignore-license
+// ignore-fast

--- a/src/test/run-pass/attr-shebang.rs
+++ b/src/test/run-pass/attr-shebang.rs
@@ -1,0 +1,4 @@
+#![allow(unknown_features)]
+#![feature(bogus)]
+fn main() { }
+// ignore-license

--- a/src/test/run-pass/attr.rs
+++ b/src/test/run-pass/attr.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[main]
+fn foo() {
+}

--- a/src/test/run-pass/attr.rs
+++ b/src/test/run-pass/attr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-fast
+
 #[main]
 fn foo() {
 }


### PR DESCRIPTION
This will require a snapshot to finish, but these commits update the parser to parse attributes of the form `#![...]`

Thanks to @TheHydroImpulse for all the initial work!

cc #2569
