### PR TITLE
mk: Stop building OS X .pkg as part of 'make dist'

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -108,7 +108,7 @@ distcheck: dist
 
 else
 
-dist: $(PKG_TAR) $(PKG_OSX)
+dist: $(PKG_TAR)
 
 distcheck: $(PKG_TAR)
 	$(Q)rm -Rf dist


### PR DESCRIPTION
This doesn't work quite right yet (we need to build packages for all hosts)
and I'm not ready to turn on new dist artifacts yet, but I want to start doing
dry runs for 0.10, so I'm turning this off for now.
