### PR TITLE
Add a Reader::fill() method

### DIFF
--- a/src/librand/reader.rs
+++ b/src/librand/reader.rs
@@ -60,10 +60,8 @@ impl<R: Reader> Rng for ReaderRng<R> {
     }
     fn fill_bytes(&mut self, v: &mut [u8]) {
         if v.len() == 0 { return }
-        match self.reader.read(v) {
-            Ok(n) if n == v.len() => return,
-            Ok(n) => fail!("ReaderRng.fill_bytes could not fill buffer: \
-                            read {} out of {} bytes.", n, v.len()),
+        match self.reader.fill(v) {
+            Ok(()) => {}
             Err(e) => fail!("ReaderRng.fill_bytes error: {}", e)
         }
     }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -87,7 +87,7 @@ impl<R: Reader> BufferedReader<R> {
 }
 
 impl<R: Reader> Buffer for BufferedReader<R> {
-    fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> {
+    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos == self.cap {
             self.cap = try!(self.inner.read(self.buf));
             self.pos = 0;
@@ -104,7 +104,7 @@ impl<R: Reader> Buffer for BufferedReader<R> {
 impl<R: Reader> Reader for BufferedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         let nread = {
-            let available = try!(self.fill());
+            let available = try!(self.fill_buf());
             let nread = cmp::min(available.len(), buf.len());
             slice::bytes::copy_memory(buf, available.slice_to(nread));
             nread
@@ -336,7 +336,7 @@ impl<S: Stream> BufferedStream<S> {
 }
 
 impl<S: Stream> Buffer for BufferedStream<S> {
-    fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> { self.inner.fill() }
+    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> { self.inner.fill_buf() }
     fn consume(&mut self, amt: uint) { self.inner.consume(amt) }
 }
 

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -190,7 +190,7 @@ impl Seek for MemReader {
 }
 
 impl Buffer for MemReader {
-    fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> {
+    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos < self.buf.len() {
             Ok(self.buf.slice_from(self.pos))
         } else {
@@ -322,7 +322,7 @@ impl<'a> Seek for BufReader<'a> {
 }
 
 impl<'a> Buffer for BufReader<'a> {
-    fn fill<'a>(&'a mut self) -> IoResult<&'a [u8]> {
+    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos < self.buf.len() {
             Ok(self.buf.slice_from(self.pos))
         } else {
@@ -554,5 +554,19 @@ mod test {
         let mut buf = [0];
         let mut r = BufWriter::new(buf);
         assert!(r.seek(-1, SeekSet).is_err());
+    }
+
+    #[test]
+    fn io_fill() {
+        let mut r = MemReader::new(~[1, 2, 3, 4, 5, 6, 7, 8]);
+        let mut buf = [0, ..3];
+        assert_eq!(r.fill(buf), Ok(()));
+        assert_eq!(buf.as_slice(), &[1, 2, 3]);
+        assert_eq!(r.fill(buf.mut_slice_to(0)), Ok(()));
+        assert_eq!(buf.as_slice(), &[1, 2, 3]);
+        assert_eq!(r.fill(buf), Ok(()));
+        assert_eq!(buf.as_slice(), &[4, 5, 6]);
+        assert!(r.fill(buf).is_err());
+        assert_eq!(buf.as_slice(), &[7, 8, 6]);
     }
 }


### PR DESCRIPTION
This method can be used to fill a byte slice of data entirely, and it's considered an error if any error happens before its entirely filled.
