### PR TITLE
Remove RefCell::{with, with_mut}

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -313,10 +313,10 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     time(time_passes, "looking for entry point", (),
          |_| middle::entry::find_entry_point(&sess, krate, &ast_map));
 
-    sess.macro_registrar_fn.with_mut(|r| *r =
+    *sess.macro_registrar_fn.borrow_mut() =
         time(time_passes, "looking for macro registrar", (), |_|
             syntax::ext::registrar::find_macro_registrar(
-                sess.diagnostic(), krate)));
+                sess.diagnostic(), krate));
 
     let freevars = time(time_passes, "freevar finding", (), |_|
                         freevars::annotate_freevars(def_map, krate));

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -135,11 +135,11 @@ impl CStore {
     }
 
     pub fn reset(&self) {
-        self.metas.with_mut(|s| s.clear());
-        self.extern_mod_crate_map.with_mut(|s| s.clear());
-        self.used_crate_sources.with_mut(|s| s.clear());
-        self.used_libraries.with_mut(|s| s.clear());
-        self.used_link_args.with_mut(|s| s.clear());
+        self.metas.borrow_mut().clear();
+        self.extern_mod_crate_map.borrow_mut().clear();
+        self.used_crate_sources.borrow_mut().clear();
+        self.used_libraries.borrow_mut().clear();
+        self.used_link_args.borrow_mut().clear();
     }
 
     // This method is used when generating the command line to pass through to

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -22,19 +22,17 @@ use ty::Unsafe;
 /// A mutable memory location that admits only `Pod` data.
 pub struct Cell<T> {
     priv value: Unsafe<T>,
-    priv marker1: marker::InvariantType<T>,
-    priv marker2: marker::NoFreeze,
-    priv marker3: marker::NoShare,
+    priv marker1: marker::NoFreeze,
+    priv marker2: marker::NoShare,
 }
 
 impl<T:Pod> Cell<T> {
     /// Creates a new `Cell` containing the given value.
     pub fn new(value: T) -> Cell<T> {
         Cell {
-            value: Unsafe{value: value, marker1: marker::InvariantType::<T>},
-            marker1: marker::InvariantType::<T>,
-            marker2: marker::NoFreeze,
-            marker3: marker::NoShare,
+            value: Unsafe::new(value),
+            marker1: marker::NoFreeze,
+            marker2: marker::NoShare,
         }
     }
 
@@ -75,10 +73,9 @@ impl<T: fmt::Show> fmt::Show for Cell<T> {
 pub struct RefCell<T> {
     priv value: Unsafe<T>,
     priv borrow: BorrowFlag,
-    priv marker1: marker::InvariantType<T>,
-    priv marker2: marker::NoFreeze,
-    priv marker3: marker::NoPod,
-    priv marker4: marker::NoShare,
+    priv marker1: marker::NoFreeze,
+    priv marker2: marker::NoPod,
+    priv marker3: marker::NoShare,
 }
 
 // Values [1, MAX-1] represent the number of `Ref` active
@@ -91,11 +88,10 @@ impl<T> RefCell<T> {
     /// Create a new `RefCell` containing `value`
     pub fn new(value: T) -> RefCell<T> {
         RefCell {
-            marker1: marker::InvariantType::<T>,
-            marker2: marker::NoFreeze,
-            marker3: marker::NoPod,
-            marker4: marker::NoShare,
-            value: Unsafe{value: value, marker1: marker::InvariantType::<T>},
+            marker1: marker::NoFreeze,
+            marker2: marker::NoPod,
+            marker3: marker::NoShare,
+            value: Unsafe::new(value),
             borrow: UNUSED,
         }
     }

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -173,28 +173,6 @@ impl<T> RefCell<T> {
         }
     }
 
-    /// Immutably borrows the wrapped value and applies `blk` to it.
-    ///
-    /// # Failure
-    ///
-    /// Fails if the value is currently mutably borrowed.
-    #[inline]
-    pub fn with<U>(&self, blk: |&T| -> U) -> U {
-        let ptr = self.borrow();
-        blk(ptr.get())
-    }
-
-    /// Mutably borrows the wrapped value and applies `blk` to it.
-    ///
-    /// # Failure
-    ///
-    /// Fails if the value is currently borrowed.
-    #[inline]
-    pub fn with_mut<U>(&self, blk: |&mut T| -> U) -> U {
-        let mut ptr = self.borrow_mut();
-        blk(ptr.get())
-    }
-
     /// Sets the value, replacing what was there.
     ///
     /// # Failure
@@ -370,43 +348,6 @@ mod test {
             let _b2 = x.borrow();
         }
         assert!(x.try_borrow_mut().is_none());
-    }
-
-    #[test]
-    fn with_ok() {
-        let x = RefCell::new(0);
-        assert_eq!(1, x.with(|x| *x+1));
-    }
-
-    #[test]
-    #[should_fail]
-    fn mut_borrow_with() {
-        let x = RefCell::new(0);
-        let _b1 = x.borrow_mut();
-        x.with(|x| *x+1);
-    }
-
-    #[test]
-    fn borrow_with() {
-        let x = RefCell::new(0);
-        let _b1 = x.borrow();
-        assert_eq!(1, x.with(|x| *x+1));
-    }
-
-    #[test]
-    fn with_mut_ok() {
-        let x = RefCell::new(0);
-        x.with_mut(|x| *x += 1);
-        let b = x.borrow();
-        assert_eq!(1, *b.get());
-    }
-
-    #[test]
-    #[should_fail]
-    fn borrow_with_mut() {
-        let x = RefCell::new(0);
-        let _b = x.borrow();
-        x.with_mut(|x| *x += 1);
     }
 
     #[test]

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -87,10 +87,8 @@ mod tests {
     fn test_clone() {
         let x = Gc::new(RefCell::new(5));
         let y = x.clone();
-        x.borrow().with_mut(|inner| {
-            *inner = 20;
-        });
-        assert_eq!(y.borrow().with(|x| *x), 20);
+        *x.borrow().borrow_mut() = 20;
+        assert_eq!(*y.borrow().borrow(), 20);
     }
 
     #[test]

--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -198,10 +198,8 @@ mod tests {
     fn test_clone() {
         let x = Rc::new(RefCell::new(5));
         let y = x.clone();
-        x.deref().with_mut(|inner| {
-            *inner = 20;
-        });
-        assert_eq!(y.deref().with(|v| *v), 20);
+        *x.borrow_mut() = 20;
+        assert_eq!(*y.borrow(), 20);
     }
 
     #[test]


### PR DESCRIPTION
These are superfluous now that we have fixed rvalue lifetimes and Deref.

I'd also like to kill off `get` and `set`, but that'll be a large change so I want to make sure that we actually want to do that first.
