### PR TITLE
Start leveraging the Deref/DerefMut traits

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -54,11 +54,11 @@ struct Chunk {
 }
 impl Chunk {
     fn capacity(&self) -> uint {
-        self.data.deref().borrow().get().capacity()
+        self.data.borrow().capacity()
     }
 
     unsafe fn as_ptr(&self) -> *u8 {
-        self.data.deref().borrow().get().as_ptr()
+        self.data.borrow().as_ptr()
     }
 }
 

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -206,12 +206,8 @@ impl<'a> Archive<'a> {
 
         let mut rustpath = filesearch::rust_path();
         rustpath.push(self.sess.filesearch().get_target_lib_path());
-        let addl_lib_search_paths = self.sess
-                                        .opts
-                                        .addl_lib_search_paths
-                                        .borrow();
-        let path = addl_lib_search_paths.get().iter();
-        for path in path.chain(rustpath.iter()) {
+        let search = self.sess.opts.addl_lib_search_paths.borrow();
+        for path in search.iter().chain(rustpath.iter()) {
             debug!("looking for {} inside {}", name, path.display());
             let test = path.join(oslibname.as_slice());
             if test.exists() { return test }

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -27,8 +27,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
     }
 
     // Make sure we actually can run LTO
-    let crate_types = sess.crate_types.borrow();
-    for crate_type in crate_types.get().iter() {
+    for crate_type in sess.crate_types.borrow().iter() {
         match *crate_type {
             session::CrateTypeExecutable | session::CrateTypeStaticlib => {}
             _ => {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -543,8 +543,8 @@ fn write_out_deps(sess: &Session,
     // write Makefile-compatible dependency rules
     let files: Vec<~str> = sess.codemap().files.borrow()
                                .iter().filter_map(|fmap| {
-                                    if fmap.deref().is_real_file() {
-                                        Some(fmap.deref().name.clone())
+                                    if fmap.is_real_file() {
+                                        Some(fmap.name.clone())
                                     } else {
                                         None
                                     }
@@ -682,7 +682,7 @@ pub fn pretty_print_input(sess: Session,
     };
 
     let src_name = source_name(input);
-    let src = sess.codemap().get_filemap(src_name).deref().src.as_bytes().to_owned();
+    let src = sess.codemap().get_filemap(src_name).src.as_bytes().to_owned();
     let mut rdr = MemReader::new(src);
 
     match ppm {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -512,8 +512,7 @@ fn write_out_deps(sess: &Session,
         let file = outputs.path(*output_type);
         match *output_type {
             link::OutputTypeExe => {
-                let crate_types = sess.crate_types.borrow();
-                for output in crate_types.get().iter() {
+                for output in sess.crate_types.borrow().iter() {
                     let p = link::filename_for_input(sess, *output, &id, &file);
                     out_filenames.push(p);
                 }
@@ -542,7 +541,7 @@ fn write_out_deps(sess: &Session,
 
     // Build a list of files used to compile the output and
     // write Makefile-compatible dependency rules
-    let files: Vec<~str> = sess.codemap().files.borrow().get()
+    let files: Vec<~str> = sess.codemap().files.borrow()
                                .iter().filter_map(|fmap| {
                                     if fmap.deref().is_real_file() {
                                         Some(fmap.deref().name.clone())

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -253,11 +253,11 @@ impl Session {
                     sp: Span,
                     msg: ~str) {
         let mut lints = self.lints.borrow_mut();
-        match lints.get().find_mut(&id) {
+        match lints.find_mut(&id) {
             Some(arr) => { arr.push((lint, sp, msg)); return; }
             None => {}
         }
-        lints.get().insert(id, vec!((lint, sp, msg)));
+        lints.insert(id, vec!((lint, sp, msg)));
     }
     pub fn next_node_id(&self) -> ast::NodeId {
         self.reserve_node_ids(1)

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -88,10 +88,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
     }
 
     fn fold_item(&mut self, i: @ast::Item) -> SmallVector<@ast::Item> {
-        {
-            let mut path = self.cx.path.borrow_mut();
-            path.get().push(i.ident);
-        }
+        self.cx.path.borrow_mut().push(i.ident);
         debug!("current path: {}",
                ast_util::path_name_i(self.cx.path.get().as_slice()));
 
@@ -112,10 +109,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
                         ignore: is_ignored(&self.cx, i),
                         should_fail: should_fail(i)
                     };
-                    {
-                        let mut testfns = self.cx.testfns.borrow_mut();
-                        testfns.get().push(test);
-                    }
+                    self.cx.testfns.borrow_mut().push(test);
                     // debug!("have {} test/bench functions",
                     //        cx.testfns.len());
                 }
@@ -123,10 +117,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
         }
 
         let res = fold::noop_fold_item(i, self);
-        {
-            let mut path = self.cx.path.borrow_mut();
-            path.get().pop();
-        }
+        self.cx.path.borrow_mut().pop();
         res
     }
 
@@ -414,12 +405,9 @@ fn is_test_crate(krate: &ast::Crate) -> bool {
 
 fn mk_test_descs(cx: &TestCtxt) -> @ast::Expr {
     let mut descs = Vec::new();
-    {
-        let testfns = cx.testfns.borrow();
-        debug!("building test vector from {} tests", testfns.get().len());
-        for test in testfns.get().iter() {
-            descs.push(mk_test_desc_and_fn_rec(cx, test));
-        }
+    debug!("building test vector from {} tests", cx.testfns.borrow().len());
+    for test in cx.testfns.borrow().iter() {
+        descs.push(mk_test_desc_and_fn_rec(cx, test));
     }
 
     let inner_expr = @ast::Expr {

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1831,13 +1831,11 @@ impl TypeNames {
     }
 
     pub fn associate_type(&self, s: &str, t: &Type) {
-        let mut named_types = self.named_types.borrow_mut();
-        assert!(named_types.get().insert(s.to_owned(), t.to_ref()));
+        assert!(self.named_types.borrow_mut().insert(s.to_owned(), t.to_ref()));
     }
 
     pub fn find_type(&self, s: &str) -> Option<Type> {
-        let named_types = self.named_types.borrow();
-        named_types.get().find_equiv(&s).map(|x| Type::from_ref(*x))
+        self.named_types.borrow().find_equiv(&s).map(|x| Type::from_ref(*x))
     }
 
     pub fn type_to_str(&self, ty: Type) -> ~str {

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1187,8 +1187,7 @@ pub fn translate_def_id(cdata: Cmd, did: ast::DefId) -> ast::DefId {
         return ast::DefId { krate: cdata.cnum, node: did.node };
     }
 
-    let cnum_map = cdata.cnum_map.borrow();
-    match cnum_map.get().find(&did.krate) {
+    match cdata.cnum_map.borrow().find(&did.krate) {
         Some(&n) => {
             ast::DefId {
                 krate: n,

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -36,10 +36,9 @@ impl<'a> FileSearch<'a> {
         let mut visited_dirs = HashSet::new();
         let mut found = false;
 
-        let addl_lib_search_paths = self.addl_lib_search_paths.borrow();
         debug!("filesearch: searching additional lib search paths [{:?}]",
-               addl_lib_search_paths.get().len());
-        for path in addl_lib_search_paths.get().iter() {
+               self.addl_lib_search_paths.borrow().len());
+        for path in self.addl_lib_search_paths.borrow().iter() {
             match f(path) {
                 FileMatches => found = true,
                 FileDoesntMatch => ()

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -382,23 +382,17 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
                                          pos: pos,
                                          len: len };
 
-        let tt_opt = {
-            let rcache = st.tcx.rcache.borrow();
-            rcache.get().find_copy(&key)
-        };
-        match tt_opt {
+        match st.tcx.rcache.borrow().find_copy(&key) {
           Some(tt) => return tt,
-          None => {
-            let mut ps = PState {
-                pos: pos,
-                .. *st
-            };
-            let tt = parse_ty(&mut ps, |x,y| conv(x,y));
-            let mut rcache = st.tcx.rcache.borrow_mut();
-            rcache.get().insert(key, tt);
-            return tt;
-          }
+          None => {}
         }
+        let mut ps = PState {
+            pos: pos,
+            .. *st
+        };
+        let tt = parse_ty(&mut ps, |x,y| conv(x,y));
+        st.tcx.rcache.borrow_mut().insert(key, tt);
+        return tt;
       }
       '"' => {
         let _ = parse_def(st, TypeWithId, |x,y| conv(x,y));

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1045,8 +1045,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         ebml_w.tag(c::tag_table_capture_map, |ebml_w| {
             ebml_w.id(id);
             ebml_w.tag(c::tag_table_val, |ebml_w| {
-                ebml_w.emit_from_vec(cap_vars.deref().as_slice(),
-                                        |ebml_w, cap_var| {
+                ebml_w.emit_from_vec(cap_vars.as_slice(), |ebml_w, cap_var| {
                     cap_var.encode(ebml_w);
                 })
             })

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -958,89 +958,63 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
 
     debug!("Encoding side tables for id {}", id);
 
-    {
-        let def_map = tcx.def_map.borrow();
-        let r = def_map.get().find(&id);
-        for def in r.iter() {
-            ebml_w.tag(c::tag_table_def, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| (*def).encode(ebml_w));
-            })
-        }
+    for def in tcx.def_map.borrow().find(&id).iter() {
+        ebml_w.tag(c::tag_table_def, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| (*def).encode(ebml_w));
+        })
     }
 
-    {
-        let node_types = tcx.node_types.borrow();
-        let r = node_types.get().find(&(id as uint));
-        for &ty in r.iter() {
-            ebml_w.tag(c::tag_table_node_type, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    ebml_w.emit_ty(ecx, *ty);
-                })
+    for &ty in tcx.node_types.borrow().find(&(id as uint)).iter() {
+        ebml_w.tag(c::tag_table_node_type, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                ebml_w.emit_ty(ecx, *ty);
             })
-        }
+        })
     }
 
-    {
-        let node_type_substs = tcx.node_type_substs.borrow();
-        let r = node_type_substs.get().find(&id);
-        for tys in r.iter() {
-            ebml_w.tag(c::tag_table_node_type_subst, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    ebml_w.emit_tys(ecx, tys.as_slice())
-                })
+    for tys in tcx.node_type_substs.borrow().find(&id).iter() {
+        ebml_w.tag(c::tag_table_node_type_subst, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                ebml_w.emit_tys(ecx, tys.as_slice())
             })
-        }
+        })
     }
 
-    {
-        let freevars = tcx.freevars.borrow();
-        let r = freevars.get().find(&id);
-        for &fv in r.iter() {
-            ebml_w.tag(c::tag_table_freevars, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    ebml_w.emit_from_vec(fv.as_slice(), |ebml_w, fv_entry| {
-                        encode_freevar_entry(ebml_w, *fv_entry)
-                    })
+    for &fv in tcx.freevars.borrow().find(&id).iter() {
+        ebml_w.tag(c::tag_table_freevars, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                ebml_w.emit_from_vec(fv.as_slice(), |ebml_w, fv_entry| {
+                    encode_freevar_entry(ebml_w, *fv_entry)
                 })
             })
-        }
+        })
     }
 
     let lid = ast::DefId { krate: ast::LOCAL_CRATE, node: id };
-    {
-        let tcache = tcx.tcache.borrow();
-        let r = tcache.get().find(&lid);
-        for &tpbt in r.iter() {
-            ebml_w.tag(c::tag_table_tcache, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    ebml_w.emit_tpbt(ecx, tpbt.clone());
-                })
+    for &tpbt in tcx.tcache.borrow().find(&lid).iter() {
+        ebml_w.tag(c::tag_table_tcache, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                ebml_w.emit_tpbt(ecx, tpbt.clone());
             })
-        }
+        })
     }
 
-    {
-        let r = {
-            let ty_param_defs = tcx.ty_param_defs.borrow();
-            ty_param_defs.get().find(&id).map(|def| *def)
-        };
-        for type_param_def in r.iter() {
-            ebml_w.tag(c::tag_table_param_defs, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    ebml_w.emit_type_param_def(ecx, type_param_def)
-                })
+    for &type_param_def in tcx.ty_param_defs.borrow().find(&id).iter() {
+        ebml_w.tag(c::tag_table_param_defs, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                ebml_w.emit_type_param_def(ecx, type_param_def)
             })
-        }
+        })
     }
 
     let method_call = MethodCall::expr(id);
-    for &method in maps.method_map.borrow().get().find(&method_call).iter() {
+    for &method in maps.method_map.borrow().find(&method_call).iter() {
         ebml_w.tag(c::tag_table_method_map, |ebml_w| {
             ebml_w.id(id);
             ebml_w.tag(c::tag_table_val, |ebml_w| {
@@ -1049,33 +1023,25 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         })
     }
 
-    {
-        let vtable_map = maps.vtable_map.borrow();
-        let r = vtable_map.get().find(&id);
-        for &dr in r.iter() {
-            ebml_w.tag(c::tag_table_vtable_map, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    encode_vtable_res(ecx, ebml_w, *dr);
-                })
+    for &dr in maps.vtable_map.borrow().find(&id).iter() {
+        ebml_w.tag(c::tag_table_vtable_map, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                encode_vtable_res(ecx, ebml_w, *dr);
             })
-        }
+        })
     }
 
-    {
-        let adjustments = tcx.adjustments.borrow();
-        let r = adjustments.get().find(&id);
-        for adj in r.iter() {
-            ebml_w.tag(c::tag_table_adjustments, |ebml_w| {
-                ebml_w.id(id);
-                ebml_w.tag(c::tag_table_val, |ebml_w| {
-                    ebml_w.emit_auto_adjustment(ecx, **adj);
-                })
+    for adj in tcx.adjustments.borrow().find(&id).iter() {
+        ebml_w.tag(c::tag_table_adjustments, |ebml_w| {
+            ebml_w.id(id);
+            ebml_w.tag(c::tag_table_val, |ebml_w| {
+                ebml_w.emit_auto_adjustment(ecx, **adj);
             })
-        }
+        })
     }
 
-    for &cap_vars in maps.capture_map.borrow().get().find(&id).iter() {
+    for &cap_vars in maps.capture_map.borrow().find(&id).iter() {
         ebml_w.tag(c::tag_table_capture_map, |ebml_w| {
             ebml_w.id(id);
             ebml_w.tag(c::tag_table_val, |ebml_w| {
@@ -1343,71 +1309,54 @@ fn decode_side_tables(xcx: &ExtendedDecodeContext,
                 match value {
                     c::tag_table_def => {
                         let def = decode_def(xcx, val_doc);
-                        let mut def_map = dcx.tcx.def_map.borrow_mut();
-                        def_map.get().insert(id, def);
+                        dcx.tcx.def_map.borrow_mut().insert(id, def);
                     }
                     c::tag_table_node_type => {
                         let ty = val_dsr.read_ty(xcx);
                         debug!("inserting ty for node {:?}: {}",
                                id, ty_to_str(dcx.tcx, ty));
-                        let mut node_types = dcx.tcx.node_types.borrow_mut();
-                        node_types.get().insert(id as uint, ty);
+                        dcx.tcx.node_types.borrow_mut().insert(id as uint, ty);
                     }
                     c::tag_table_node_type_subst => {
                         let tys = val_dsr.read_tys(xcx);
-                        let mut node_type_substs = dcx.tcx
-                                                      .node_type_substs
-                                                      .borrow_mut();
-                        node_type_substs.get().insert(id, tys);
+                        dcx.tcx.node_type_substs.borrow_mut().insert(id, tys);
                     }
                     c::tag_table_freevars => {
                         let fv_info = @val_dsr.read_to_vec(|val_dsr| {
                             @val_dsr.read_freevar_entry(xcx)
                         }).move_iter().collect();
-                        let mut freevars = dcx.tcx.freevars.borrow_mut();
-                        freevars.get().insert(id, fv_info);
+                        dcx.tcx.freevars.borrow_mut().insert(id, fv_info);
                     }
                     c::tag_table_tcache => {
                         let tpbt = val_dsr.read_ty_param_bounds_and_ty(xcx);
                         let lid = ast::DefId { krate: ast::LOCAL_CRATE, node: id };
-                        let mut tcache = dcx.tcx.tcache.borrow_mut();
-                        tcache.get().insert(lid, tpbt);
+                        dcx.tcx.tcache.borrow_mut().insert(lid, tpbt);
                     }
                     c::tag_table_param_defs => {
                         let bounds = val_dsr.read_type_param_def(xcx);
-                        let mut ty_param_defs = dcx.tcx
-                                                   .ty_param_defs
-                                                   .borrow_mut();
-                        ty_param_defs.get().insert(id, bounds);
+                        dcx.tcx.ty_param_defs.borrow_mut().insert(id, bounds);
                     }
                     c::tag_table_method_map => {
                         let method = val_dsr.read_method_callee(xcx);
                         let method_call = MethodCall::expr(id);
-                        dcx.maps.method_map.borrow_mut().get().insert(method_call, method);
+                        dcx.maps.method_map.borrow_mut().insert(method_call, method);
                     }
                     c::tag_table_vtable_map => {
                         let vtable_res =
                             val_dsr.read_vtable_res(xcx.dcx.tcx,
                                                     xcx.dcx.cdata);
-                        let mut vtable_map = dcx.maps.vtable_map.borrow_mut();
-                        vtable_map.get().insert(id, vtable_res);
+                        dcx.maps.vtable_map.borrow_mut().insert(id, vtable_res);
                     }
                     c::tag_table_adjustments => {
                         let adj: @ty::AutoAdjustment = @val_dsr.read_auto_adjustment(xcx);
-                        let mut adjustments = dcx.tcx
-                                                 .adjustments
-                                                 .borrow_mut();
-                        adjustments.get().insert(id, adj);
+                        dcx.tcx.adjustments.borrow_mut().insert(id, adj);
                     }
                     c::tag_table_capture_map => {
                         let cvars =
                                 val_dsr.read_to_vec(|val_dsr| val_dsr.read_capture_var(xcx))
                                        .move_iter()
                                        .collect();
-                        let mut capture_map = dcx.maps
-                                                 .capture_map
-                                                 .borrow_mut();
-                        capture_map.get().insert(id, Rc::new(cvars));
+                        dcx.maps.capture_map.borrow_mut().insert(id, Rc::new(cvars));
                     }
                     _ => {
                         xcx.dcx.tcx.sess.bug(

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -710,7 +710,7 @@ impl<'a> CheckLoanCtxt<'a> {
     fn check_captured_variables(&self,
                                 closure_id: ast::NodeId,
                                 span: Span) {
-        for cap_var in self.bccx.capture_map.get(&closure_id).deref().iter() {
+        for cap_var in self.bccx.capture_map.get(&closure_id).iter() {
             let var_id = ast_util::def_id_of_def(cap_var.def).node;
             let var_path = @LpVar(var_id);
             self.check_if_path_is_moved(closure_id, span,

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -378,11 +378,7 @@ impl<'a> CheckLoanCtxt<'a> {
     pub fn check_assignment(&self, expr: &ast::Expr) {
         // We don't use cat_expr() here because we don't want to treat
         // auto-ref'd parameters in overloaded operators as rvalues.
-        let adj = {
-            let adjustments = self.bccx.tcx.adjustments.borrow();
-            adjustments.get().find_copy(&expr.id)
-        };
-        let cmt = match adj {
+        let cmt = match self.bccx.tcx.adjustments.borrow().find_copy(&expr.id) {
             None => self.bccx.cat_expr_unadjusted(expr),
             Some(adj) => self.bccx.cat_expr_autoderefd(expr, adj)
         };
@@ -452,10 +448,7 @@ impl<'a> CheckLoanCtxt<'a> {
                        cmt.repr(this.tcx()));
                 match cmt.cat {
                     mc::cat_local(id) | mc::cat_arg(id) => {
-                        let mut used_mut_nodes = this.tcx()
-                                                     .used_mut_nodes
-                                                     .borrow_mut();
-                        used_mut_nodes.get().insert(id);
+                        this.tcx().used_mut_nodes.borrow_mut().insert(id);
                         return;
                     }
 
@@ -839,11 +832,11 @@ fn check_loans_in_expr<'a>(this: &mut CheckLoanCtxt<'a>,
         this.check_call(expr, None, expr.span, args.as_slice());
       }
       ast::ExprIndex(_, rval) | ast::ExprBinary(_, _, rval)
-      if method_map.get().contains_key(&MethodCall::expr(expr.id)) => {
+      if method_map.contains_key(&MethodCall::expr(expr.id)) => {
         this.check_call(expr, None, expr.span, [rval]);
       }
       ast::ExprUnary(_, _) | ast::ExprIndex(_, _)
-      if method_map.get().contains_key(&MethodCall::expr(expr.id)) => {
+      if method_map.contains_key(&MethodCall::expr(expr.id)) => {
         this.check_call(expr, None, expr.span, []);
       }
       ast::ExprInlineAsm(ref ia) => {

--- a/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
@@ -47,7 +47,7 @@ pub fn gather_move_from_pat(bccx: &BorrowckCtxt,
 pub fn gather_captures(bccx: &BorrowckCtxt,
                        move_data: &MoveData,
                        closure_expr: &ast::Expr) {
-    for captured_var in bccx.capture_map.get(&closure_expr.id).deref().iter() {
+    for captured_var in bccx.capture_map.get(&closure_expr.id).iter() {
         match captured_var.mode {
             moves::CapMove => {
                 let cmt = bccx.cat_captured_var(closure_expr.id,

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -237,8 +237,7 @@ impl<'a> GuaranteeLifetimeContext<'a> {
         let rm_key = root_map_key {id: cmt_deref.id, derefs: derefs};
         let root_info = RootInfo {scope: root_scope};
 
-        let mut root_map = self.bccx.root_map.borrow_mut();
-        root_map.get().insert(rm_key, root_info);
+        self.bccx.root_map.borrow_mut().insert(rm_key, root_info);
 
         debug!("root_key: {:?} root_info: {:?}", rm_key, root_info);
         Ok(())

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -452,7 +452,7 @@ impl<'a> GatherLoanCtxt<'a> {
 
     fn guarantee_captures(&mut self,
                           closure_expr: &ast::Expr) {
-        for captured_var in self.bccx.capture_map.get(&closure_expr.id).deref().iter() {
+        for captured_var in self.bccx.capture_map.get(&closure_expr.id).iter() {
             match captured_var.mode {
                 moves::CapCopy | moves::CapMove => { continue; }
                 moves::CapRef => { }

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -195,7 +195,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
     this.id_range.add(ex.id);
 
     // If this expression is borrowed, have to ensure it remains valid:
-    for &adjustments in tcx.adjustments.borrow().get().find(&ex.id).iter() {
+    for &adjustments in tcx.adjustments.borrow().find(&ex.id).iter() {
         this.guarantee_adjustments(ex, *adjustments);
     }
 
@@ -255,7 +255,7 @@ fn gather_loans_in_expr(this: &mut GatherLoanCtxt,
 
       ast::ExprIndex(_, arg) |
       ast::ExprBinary(_, _, arg)
-      if method_map.get().contains_key(&MethodCall::expr(ex.id)) => {
+      if method_map.contains_key(&MethodCall::expr(ex.id)) => {
           // Arguments in method calls are always passed by ref.
           //
           // Currently these do not use adjustments, so we have to
@@ -343,7 +343,7 @@ impl<'a> GatherLoanCtxt<'a> {
                                 autoderefs: uint) {
         let method_map = self.bccx.method_map.borrow();
         for i in range(0, autoderefs) {
-            match method_map.get().find(&MethodCall::autoderef(expr.id, i as u32)) {
+            match method_map.find(&MethodCall::autoderef(expr.id, i as u32)) {
                 Some(method) => {
                     // Treat overloaded autoderefs as if an AutoRef adjustment
                     // was applied on the base type, as that is always the case.
@@ -466,8 +466,8 @@ impl<'a> GatherLoanCtxt<'a> {
             // Lookup the kind of borrow the callee requires
             let upvar_id = ty::UpvarId { var_id: var_id,
                                          closure_expr_id: closure_expr.id };
-            let upvar_borrow_map = self.tcx().upvar_borrow_map.borrow();
-            let upvar_borrow = upvar_borrow_map.get().get_copy(&upvar_id);
+            let upvar_borrow = self.tcx().upvar_borrow_map.borrow()
+                                   .get_copy(&upvar_id);
 
             self.guarantee_valid_kind(closure_expr.id,
                                       closure_expr.span,
@@ -750,10 +750,7 @@ impl<'a> GatherLoanCtxt<'a> {
 
         match *loan_path {
             LpVar(local_id) => {
-                let mut used_mut_nodes = self.tcx()
-                                             .used_mut_nodes
-                                             .borrow_mut();
-                used_mut_nodes.get().insert(local_id);
+                self.tcx().used_mut_nodes.borrow_mut().insert(local_id);
             }
             LpExtend(base, mc::McInherited, _) => {
                 self.mark_loan_path_as_mutated(base);

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -574,7 +574,7 @@ impl<'a> BorrowckCtxt<'a> {
                 let (expr_ty, expr_span) = match self.tcx.map.find(move.id) {
                     Some(ast_map::NodeExpr(expr)) => {
                         (ty::expr_ty_adjusted(self.tcx, expr,
-                                              self.method_map.borrow().get()), expr.span)
+                                              &*self.method_map.borrow()), expr.span)
                     }
                     r => self.tcx.sess.bug(format!("MoveExpr({:?}) maps to {:?}, not Expr",
                                                    move.id, r))
@@ -601,7 +601,7 @@ impl<'a> BorrowckCtxt<'a> {
                 let (expr_ty, expr_span) = match self.tcx.map.find(move.id) {
                     Some(ast_map::NodeExpr(expr)) => {
                         (ty::expr_ty_adjusted(self.tcx, expr,
-                                              self.method_map.borrow().get()), expr.span)
+                                              &*self.method_map.borrow()), expr.span)
                     }
                     r => self.tcx.sess.bug(format!("Captured({:?}) maps to {:?}, not Expr",
                                                    move.id, r))
@@ -942,16 +942,15 @@ impl<'a> mc::Typer for TcxTyper<'a> {
     }
 
     fn node_method_ty(&self, method_call: typeck::MethodCall) -> Option<ty::t> {
-        self.method_map.borrow().get().find(&method_call).map(|method| method.ty)
+        self.method_map.borrow().find(&method_call).map(|method| method.ty)
     }
 
     fn adjustment(&mut self, id: ast::NodeId) -> Option<@ty::AutoAdjustment> {
-        let adjustments = self.tcx.adjustments.borrow();
-        adjustments.get().find_copy(&id)
+        self.tcx.adjustments.borrow().find_copy(&id)
     }
 
     fn is_method_call(&mut self, id: ast::NodeId) -> bool {
-        self.method_map.borrow().get().contains_key(&typeck::MethodCall::expr(id))
+        self.method_map.borrow().contains_key(&typeck::MethodCall::expr(id))
     }
 
     fn temporary_scope(&mut self, id: ast::NodeId) -> Option<ast::NodeId> {
@@ -959,7 +958,6 @@ impl<'a> mc::Typer for TcxTyper<'a> {
     }
 
     fn upvar_borrow(&mut self, id: ty::UpvarId) -> ty::UpvarBorrow {
-        let upvar_borrow_map = self.tcx.upvar_borrow_map.borrow();
-        upvar_borrow_map.get().get_copy(&id)
+        self.tcx.upvar_borrow_map.borrow().get_copy(&id)
     }
 }

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -497,8 +497,7 @@ impl<'a> CFGBuilder<'a> {
             }
 
             Some(_) => {
-                let def_map = self.tcx.def_map.borrow();
-                match def_map.get().find(&expr.id) {
+                match self.tcx.def_map.borrow().find(&expr.id) {
                     Some(&ast::DefLabel(loop_id)) => {
                         for l in self.loop_scopes.iter() {
                             if l.loop_id == loop_id {
@@ -522,6 +521,6 @@ impl<'a> CFGBuilder<'a> {
 
     fn is_method_call(&self, expr: &ast::Expr) -> bool {
         let method_call = typeck::MethodCall::expr(expr.id);
-        self.method_map.borrow().get().contains_key(&method_call)
+        self.method_map.borrow().contains_key(&method_call)
     }
 }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -103,7 +103,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr, is_const: bool) {
           ExprLit(lit) if ast_util::lit_is_str(lit) => {}
           ExprBinary(..) | ExprUnary(..) => {
             let method_call = typeck::MethodCall::expr(e.id);
-            if v.method_map.borrow().get().contains_key(&method_call) {
+            if v.method_map.borrow().contains_key(&method_call) {
                 v.tcx.sess.span_err(e.span, "user-defined operators are not \
                                              allowed in constant expressions");
             }
@@ -127,7 +127,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr, is_const: bool) {
                                     "paths in constants may only refer to \
                                      items without type parameters");
             }
-            match v.def_map.borrow().get().find(&e.id) {
+            match v.def_map.borrow().find(&e.id) {
               Some(&DefStatic(..)) |
               Some(&DefFn(_, _)) |
               Some(&DefVariant(_, _, _)) |
@@ -145,7 +145,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr, is_const: bool) {
             }
           }
           ExprCall(callee, _) => {
-            match v.def_map.borrow().get().find(&callee.id) {
+            match v.def_map.borrow().find(&callee.id) {
                 Some(&DefStruct(..)) => {}    // OK.
                 Some(&DefVariant(..)) => {}    // OK.
                 _ => {
@@ -221,8 +221,7 @@ impl<'a> Visitor<()> for CheckItemRecursionVisitor<'a> {
     fn visit_expr(&mut self, e: &Expr, _: ()) {
         match e.node {
             ExprPath(..) => {
-                let def_map = self.def_map.borrow();
-                match def_map.get().find(&e.id) {
+                match self.def_map.borrow().find(&e.id) {
                     Some(&DefStatic(def_id, _)) if
                             ast_util::is_local(def_id) => {
                         self.visit_item(self.ast_map.expect_item(def_id.node), ());

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -121,10 +121,7 @@ fn check_arms(cx: &MatchCheckCtxt, arms: &[Arm]) {
 
             // Check that we do not match against a static NaN (#6804)
             let pat_matches_nan: |&Pat| -> bool = |p| {
-                let opt_def = {
-                    let def_map = cx.tcx.def_map.borrow();
-                    def_map.get().find_copy(&p.id)
-                };
+                let opt_def = cx.tcx.def_map.borrow().find_copy(&p.id);
                 match opt_def {
                     Some(DefStatic(did, false)) => {
                         let const_expr = lookup_const_by_id(cx.tcx, did).unwrap();
@@ -351,10 +348,7 @@ fn pat_ctor_id(cx: &MatchCheckCtxt, p: @Pat) -> Option<ctor> {
     match pat.node {
       PatWild | PatWildMulti => { None }
       PatIdent(_, _, _) | PatEnum(_, _) => {
-        let opt_def = {
-            let def_map = cx.tcx.def_map.borrow();
-            def_map.get().find_copy(&pat.id)
-        };
+        let opt_def = cx.tcx.def_map.borrow().find_copy(&pat.id);
         match opt_def {
           Some(DefVariant(_, id, _)) => Some(variant(id)),
           Some(DefStatic(did, false)) => {
@@ -369,8 +363,7 @@ fn pat_ctor_id(cx: &MatchCheckCtxt, p: @Pat) -> Option<ctor> {
         Some(range(eval_const_expr(cx.tcx, lo), eval_const_expr(cx.tcx, hi)))
       }
       PatStruct(..) => {
-        let def_map = cx.tcx.def_map.borrow();
-        match def_map.get().find(&pat.id) {
+        match cx.tcx.def_map.borrow().find(&pat.id) {
           Some(&DefVariant(_, id, _)) => Some(variant(id)),
           _ => Some(single)
         }
@@ -392,8 +385,7 @@ fn is_wild(cx: &MatchCheckCtxt, p: @Pat) -> bool {
     match pat.node {
       PatWild | PatWildMulti => { true }
       PatIdent(_, _, _) => {
-        let def_map = cx.tcx.def_map.borrow();
-        match def_map.get().find(&pat.id) {
+        match cx.tcx.def_map.borrow().find(&pat.id) {
           Some(&DefVariant(_, _, _)) | Some(&DefStatic(..)) => { false }
           _ => { true }
         }
@@ -575,10 +567,7 @@ fn specialize(cx: &MatchCheckCtxt,
                                     r.tail()))
             }
             PatIdent(_, _, _) => {
-                let opt_def = {
-                    let def_map = cx.tcx.def_map.borrow();
-                    def_map.get().find_copy(&pat_id)
-                };
+                let opt_def = cx.tcx.def_map.borrow().find_copy(&pat_id);
                 match opt_def {
                     Some(DefVariant(_, id, _)) => {
                         if variant(id) == *ctor_id {
@@ -636,11 +625,8 @@ fn specialize(cx: &MatchCheckCtxt,
                 }
             }
             PatEnum(_, args) => {
-                let opt_def = {
-                    let def_map = cx.tcx.def_map.borrow();
-                    def_map.get().get_copy(&pat_id)
-                };
-                match opt_def {
+                let def = cx.tcx.def_map.borrow().get_copy(&pat_id);
+                match def {
                     DefStatic(did, _) => {
                         let const_expr =
                             lookup_const_by_id(cx.tcx, did).unwrap();
@@ -701,11 +687,8 @@ fn specialize(cx: &MatchCheckCtxt,
             }
             PatStruct(_, ref pattern_fields, _) => {
                 // Is this a struct or an enum variant?
-                let opt_def = {
-                    let def_map = cx.tcx.def_map.borrow();
-                    def_map.get().get_copy(&pat_id)
-                };
-                match opt_def {
+                let def = cx.tcx.def_map.borrow().get_copy(&pat_id);
+                match def {
                     DefVariant(_, variant_id, _) => {
                         if variant(variant_id) == *ctor_id {
                             let struct_fields = ty::lookup_struct_fields(cx.tcx, variant_id);
@@ -891,10 +874,7 @@ fn check_fn(cx: &mut MatchCheckCtxt,
 }
 
 fn is_refutable(cx: &MatchCheckCtxt, pat: &Pat) -> bool {
-    let opt_def = {
-        let def_map = cx.tcx.def_map.borrow();
-        def_map.get().find_copy(&pat.id)
-    };
+    let opt_def = cx.tcx.def_map.borrow().find_copy(&pat.id);
     match opt_def {
       Some(DefVariant(enum_id, _, _)) => {
         if ty::enum_variants(cx.tcx, enum_id).len() != 1u {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -83,10 +83,7 @@ pub fn join_all<It: Iterator<constness>>(mut cs: It) -> constness {
 }
 
 pub fn lookup_const(tcx: &ty::ctxt, e: &Expr) -> Option<@Expr> {
-    let opt_def = {
-        let def_map = tcx.def_map.borrow();
-        def_map.get().find_copy(&e.id)
-    };
+    let opt_def = tcx.def_map.borrow().find_copy(&e.id);
     match opt_def {
         Some(ast::DefStatic(def_id, false)) => {
             lookup_const_by_id(tcx, def_id)
@@ -125,7 +122,7 @@ pub fn lookup_variant_by_id(tcx: &ty::ctxt,
             }
         }
     } else {
-        match tcx.extern_const_variants.borrow().get().find(&variant_def) {
+        match tcx.extern_const_variants.borrow().find(&variant_def) {
             Some(&e) => return e,
             None => {}
         }
@@ -145,7 +142,7 @@ pub fn lookup_variant_by_id(tcx: &ty::ctxt,
             },
             _ => None
         };
-        tcx.extern_const_variants.borrow_mut().get().insert(variant_def, e);
+        tcx.extern_const_variants.borrow_mut().insert(variant_def, e);
         return e;
     }
 }
@@ -166,12 +163,9 @@ pub fn lookup_const_by_id(tcx: &ty::ctxt, def_id: ast::DefId)
             }
         }
     } else {
-        {
-            let extern_const_statics = tcx.extern_const_statics.borrow();
-            match extern_const_statics.get().find(&def_id) {
-                Some(&e) => return e,
-                None => {}
-            }
+        match tcx.extern_const_statics.borrow().find(&def_id) {
+            Some(&e) => return e,
+            None => {}
         }
         let maps = astencode::Maps {
             root_map: @RefCell::new(HashMap::new()),
@@ -187,12 +181,8 @@ pub fn lookup_const_by_id(tcx: &ty::ctxt, def_id: ast::DefId)
             },
             _ => None
         };
-        {
-            let mut extern_const_statics = tcx.extern_const_statics
-                                              .borrow_mut();
-            extern_const_statics.get().insert(def_id, e);
-            return e;
-        }
+        tcx.extern_const_statics.borrow_mut().insert(def_id, e);
+        return e;
     }
 }
 

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -490,7 +490,7 @@ pub fn lit_to_const(lit: &Lit) -> const_val {
     match lit.node {
         LitStr(ref s, _) => const_str((*s).clone()),
         LitBinary(ref data) => {
-            const_binary(Rc::new(data.deref().iter().map(|x| *x).collect()))
+            const_binary(Rc::new(data.iter().map(|x| *x).collect()))
         }
         LitChar(n) => const_uint(n as u64),
         LitInt(n, _) => const_int(n),

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -782,8 +782,7 @@ impl<'a, 'b, O:DataFlowOperator> PropagationContext<'a, 'b, O> {
             }
 
             Some(_) => {
-                let def_map = self.tcx().def_map.borrow();
-                match def_map.get().find(&expr.id) {
+                match self.tcx().def_map.borrow().find(&expr.id) {
                     Some(&ast::DefLabel(loop_id)) => {
                         match loop_scopes.iter().position(|l| l.loop_id == loop_id) {
                             Some(i) => i,
@@ -809,7 +808,7 @@ impl<'a, 'b, O:DataFlowOperator> PropagationContext<'a, 'b, O> {
 
     fn is_method_call(&self, expr: &ast::Expr) -> bool {
         let method_call = typeck::MethodCall::expr(expr.id);
-        self.dfcx.method_map.borrow().get().contains_key(&method_call)
+        self.dfcx.method_map.borrow().contains_key(&method_call)
     }
 
     fn reset(&mut self, bits: &mut [uint]) {

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -75,8 +75,7 @@ impl<'a> MarkSymbolVisitor<'a> {
     }
 
     fn lookup_and_handle_definition(&mut self, id: &ast::NodeId) {
-        let def_map = self.tcx.def_map.borrow();
-        let def = match def_map.get().find(id) {
+        let def = match self.tcx.def_map.borrow().find(id) {
             Some(&def) => def,
             None => return
         };
@@ -94,7 +93,7 @@ impl<'a> MarkSymbolVisitor<'a> {
     fn lookup_and_handle_method(&mut self, id: ast::NodeId,
                                 span: codemap::Span) {
         let method_call = typeck::MethodCall::expr(id);
-        match self.method_map.borrow().get().find(&method_call) {
+        match self.method_map.borrow().find(&method_call) {
             Some(method) => {
                 match method.origin {
                     typeck::MethodStatic(def_id) => {
@@ -342,12 +341,10 @@ impl<'a> DeadVisitor<'a> {
         // method of a private type is used, but the type itself is never
         // called directly.
         let def_id = local_def(id);
-        let inherent_impls = self.tcx.inherent_impls.borrow();
-        match inherent_impls.get().find(&def_id) {
+        match self.tcx.inherent_impls.borrow().find(&def_id) {
             None => (),
             Some(ref impl_list) => {
-                let impl_list = impl_list.borrow();
-                for impl_ in impl_list.get().iter() {
+                for impl_ in impl_list.borrow().iter() {
                     for method in impl_.methods.iter() {
                         if self.live_symbols.contains(&method.def_id.node) {
                             return true;

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -56,8 +56,7 @@ impl<'a> EffectCheckVisitor<'a> {
             UnsafeBlock(block_id) => {
                 // OK, but record this.
                 debug!("effect: recording unsafe block as used: {:?}", block_id);
-                let mut used_unsafe = self.tcx.used_unsafe.borrow_mut();
-                let _ = used_unsafe.get().insert(block_id);
+                self.tcx.used_unsafe.borrow_mut().insert(block_id);
             }
             UnsafeFn => {}
         }
@@ -139,7 +138,7 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
         match expr.node {
             ast::ExprMethodCall(_, _, _) => {
                 let method_call = MethodCall::expr(expr.id);
-                let base_type = self.method_map.borrow().get().get(&method_call).ty;
+                let base_type = self.method_map.borrow().get(&method_call).ty;
                 debug!("effect: method call case, base type is {}",
                        ppaux::ty_to_str(self.tcx, base_type));
                 if type_is_unsafe_function(base_type) {

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -51,8 +51,7 @@ impl Visitor<int> for CollectFreevarsVisitor {
             }
             ast::ExprPath(..) => {
                 let mut i = 0;
-                let def_map = self.def_map.borrow();
-                match def_map.get().find(&expr.id) {
+                match self.def_map.borrow().find(&expr.id) {
                     None => fail!("path not found"),
                     Some(&df) => {
                         let mut def = df;
@@ -141,8 +140,7 @@ pub fn annotate_freevars(def_map: resolve::DefMap, krate: &ast::Crate) ->
 }
 
 pub fn get_freevars(tcx: &ty::ctxt, fid: ast::NodeId) -> freevar_info {
-    let freevars = tcx.freevars.borrow();
-    match freevars.get().find(&fid) {
+    match tcx.freevars.borrow().find(&fid) {
         None => fail!("get_freevars: {} has no freevars", fid),
         Some(&d) => return d
     }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -117,18 +117,13 @@ fn check_struct_safe_for_destructor(cx: &mut Context,
 }
 
 fn check_impl_of_trait(cx: &mut Context, it: &Item, trait_ref: &TraitRef, self_type: &Ty) {
-    let def_map = cx.tcx.def_map.borrow();
-    let ast_trait_def = def_map.get()
-                               .find(&trait_ref.ref_id)
-                               .expect("trait ref not in def map!");
-    let trait_def_id = ast_util::def_id_of_def(*ast_trait_def);
-    let trait_def;
-    {
-        let trait_defs = cx.tcx.trait_defs.borrow();
-        trait_def = *trait_defs.get()
-                               .find(&trait_def_id)
-                               .expect("trait def not in trait-defs map!");
-    }
+    let ast_trait_def = *cx.tcx.def_map.borrow()
+                              .find(&trait_ref.ref_id)
+                              .expect("trait ref not in def map!");
+    let trait_def_id = ast_util::def_id_of_def(ast_trait_def);
+    let trait_def = *cx.tcx.trait_defs.borrow()
+                           .find(&trait_def_id)
+                           .expect("trait def not in trait-defs map!");
 
     // If this trait has builtin-kind supertraits, meet them.
     let self_ty: ty::t = ty::node_id_to_type(cx.tcx, it.id);
@@ -147,7 +142,7 @@ fn check_impl_of_trait(cx: &mut Context, it: &Item, trait_ref: &TraitRef, self_t
         match self_type.node {
             TyPath(_, ref bounds, path_node_id) => {
                 assert!(bounds.is_none());
-                let struct_def = def_map.get().get_copy(&path_node_id);
+                let struct_def = cx.tcx.def_map.borrow().get_copy(&path_node_id);
                 let struct_did = ast_util::def_id_of_def(struct_def);
                 check_struct_safe_for_destructor(cx, self_type.span, struct_did);
             }
@@ -266,18 +261,17 @@ pub fn check_expr(cx: &mut Context, e: &Expr) {
     // Handle any kind bounds on type parameters
     {
         let method_map = cx.method_map.borrow();
-        let method = method_map.get().find(&typeck::MethodCall::expr(e.id));
+        let method = method_map.find(&typeck::MethodCall::expr(e.id));
         let node_type_substs = cx.tcx.node_type_substs.borrow();
         let r = match method {
             Some(method) => Some(&method.substs.tps),
-            None => node_type_substs.get().find(&e.id)
+            None => node_type_substs.find(&e.id)
         };
         for ts in r.iter() {
             let def_map = cx.tcx.def_map.borrow();
             let type_param_defs = match e.node {
               ExprPath(_) => {
-                let did = ast_util::def_id_of_def(def_map.get()
-                                                         .get_copy(&e.id));
+                let did = ast_util::def_id_of_def(def_map.get_copy(&e.id));
                 ty::lookup_item_type(cx.tcx, did).generics.type_param_defs.clone()
               }
               _ => {
@@ -334,14 +328,13 @@ pub fn check_expr(cx: &mut Context, e: &Expr) {
     }
 
     // Search for auto-adjustments to find trait coercions.
-    let adjustments = cx.tcx.adjustments.borrow();
-    match adjustments.get().find(&e.id) {
+    match cx.tcx.adjustments.borrow().find(&e.id) {
         Some(adjustment) => {
             match **adjustment {
                 ty::AutoObject(..) => {
                     let source_ty = ty::expr_ty(cx.tcx, e);
                     let target_ty = ty::expr_ty_adjusted(cx.tcx, e,
-                                                         cx.method_map.borrow().get());
+                                                         &*cx.method_map.borrow());
                     check_trait_cast(cx, source_ty, target_ty, e.span);
                 }
                 ty::AutoAddEnv(..) |
@@ -368,10 +361,10 @@ fn check_ty(cx: &mut Context, aty: &Ty) {
     match aty.node {
         TyPath(_, _, id) => {
             let node_type_substs = cx.tcx.node_type_substs.borrow();
-            let r = node_type_substs.get().find(&id);
+            let r = node_type_substs.find(&id);
             for ts in r.iter() {
                 let def_map = cx.tcx.def_map.borrow();
-                let did = ast_util::def_id_of_def(def_map.get().get_copy(&id));
+                let did = ast_util::def_id_of_def(def_map.get_copy(&id));
                 let generics = ty::lookup_item_type(cx.tcx, did).generics;
                 let type_param_defs = generics.type_param_defs();
                 for (&ty, type_param_def) in ts.iter().zip(type_param_defs.iter()) {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -291,7 +291,6 @@ pub fn check_expr(cx: &mut Context, e: &Expr) {
                 }
               }
             };
-            let type_param_defs = type_param_defs.deref();
             if ts.len() != type_param_defs.len() {
                 // Fail earlier to make debugging easier
                 fail!("internal error: in kind::check_expr, length \

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -472,7 +472,7 @@ fn visit_expr(ir: &mut IrMaps, expr: &Expr) {
         // in better error messages than just pointing at the closure
         // construction site.
         let mut call_caps = Vec::new();
-        for cv in ir.capture_map.get(&expr.id).deref().iter() {
+        for cv in ir.capture_map.get(&expr.id).iter() {
             match moves::moved_variable_node_id_from_def(cv.def) {
               Some(rv) => {
                 let cv_ln = ir.add_live_node(FreeVarNode(cv.span));
@@ -979,7 +979,7 @@ impl<'a> Liveness<'a> {
                         this.ir.tcx.sess.span_bug(expr.span, "no registered caps");
                      }
                  };
-                 caps.deref().iter().rev().fold(succ, |succ, cap| {
+                 caps.iter().rev().fold(succ, |succ, cap| {
                      this.init_from_succ(cap.ln, succ);
                      let var = this.variable(cap.var_nid, expr.span);
                      this.acc(cap.ln, var, ACC_READ | ACC_USE);

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -455,7 +455,7 @@ fn visit_expr(ir: &mut IrMaps, expr: &Expr) {
     match expr.node {
       // live nodes required for uses or definitions of variables:
       ExprPath(_) => {
-        let def = ir.tcx.def_map.borrow().get().get_copy(&expr.id);
+        let def = ir.tcx.def_map.borrow().get_copy(&expr.id);
         debug!("expr {}: path that leads to {:?}", expr.id, def);
         if moves::moved_variable_node_id_from_def(def).is_some() {
             ir.add_live_node_for_node(expr.id, ExprNode(expr.span));
@@ -707,7 +707,7 @@ impl<'a> Liveness<'a> {
             Some(_) => {
                 // Refers to a labeled loop. Use the results of resolve
                 // to find with one
-                match self.ir.tcx.def_map.borrow().get().find(&id) {
+                match self.ir.tcx.def_map.borrow().find(&id) {
                     Some(&DefLabel(loop_id)) => loop_id,
                     _ => self.ir.tcx.sess.span_bug(sp, "label on break/loop \
                                                         doesn't refer to a loop")
@@ -1274,7 +1274,7 @@ impl<'a> Liveness<'a> {
 
     fn access_path(&mut self, expr: &Expr, succ: LiveNode, acc: uint)
                    -> LiveNode {
-        let def = self.ir.tcx.def_map.borrow().get().get_copy(&expr.id);
+        let def = self.ir.tcx.def_map.borrow().get_copy(&expr.id);
         match moves::moved_variable_node_id_from_def(def) {
           Some(nid) => {
             let ln = self.live_node(expr.id, expr.span);
@@ -1490,7 +1490,7 @@ impl<'a> Liveness<'a> {
     fn check_lvalue(&mut self, expr: &Expr) {
         match expr.node {
           ExprPath(_) => {
-            match self.ir.tcx.def_map.borrow().get().get_copy(&expr.id) {
+            match self.ir.tcx.def_map.borrow().get_copy(&expr.id) {
               DefLocal(nid, _) => {
                 // Assignment to an immutable variable or argument: only legal
                 // if there is no later assignment. If this local is actually

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -455,8 +455,7 @@ impl<TYPER:Typer> MemCategorizationContext<TYPER> {
           }
 
           ast::ExprPath(_) => {
-            let def_map = self.tcx().def_map.borrow();
-            let def = def_map.get().get_copy(&expr.id);
+            let def = self.tcx().def_map.borrow().get_copy(&expr.id);
             self.cat_def(expr.id, expr.span, expr_ty, def)
           }
 
@@ -1010,8 +1009,7 @@ impl<TYPER:Typer> MemCategorizationContext<TYPER> {
             // variant(..)
           }
           ast::PatEnum(_, Some(ref subpats)) => {
-            let def_map = self.tcx().def_map.borrow();
-            match def_map.get().find(&pat.id) {
+            match self.tcx().def_map.borrow().find(&pat.id) {
                 Some(&ast::DefVariant(enum_did, _, _)) => {
                     // variant(x, y, z)
 
@@ -1202,8 +1200,7 @@ pub fn field_mutbl(tcx: &ty::ctxt,
         }
       }
       ty::ty_enum(..) => {
-        let def_map = tcx.def_map.borrow();
-        match def_map.get().get_copy(&node_id) {
+        match tcx.def_map.borrow().get_copy(&node_id) {
           ast::DefVariant(_, variant_id, _) => {
             let r = ty::lookup_struct_fields(tcx, variant_id);
             for fld in r.iter() {

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -31,8 +31,7 @@ pub fn pat_id_map(dm: resolve::DefMap, pat: &Pat) -> PatIdMap {
 pub fn pat_is_variant_or_struct(dm: resolve::DefMap, pat: &Pat) -> bool {
     match pat.node {
         PatEnum(_, _) | PatIdent(_, _, None) | PatStruct(..) => {
-            let dm = dm.borrow();
-            match dm.get().find(&pat.id) {
+            match dm.borrow().find(&pat.id) {
                 Some(&DefVariant(..)) | Some(&DefStruct(..)) => true,
                 _ => false
             }
@@ -44,8 +43,7 @@ pub fn pat_is_variant_or_struct(dm: resolve::DefMap, pat: &Pat) -> bool {
 pub fn pat_is_const(dm: resolve::DefMap, pat: &Pat) -> bool {
     match pat.node {
         PatIdent(_, _, None) | PatEnum(..) => {
-            let dm = dm.borrow();
-            match dm.get().find(&pat.id) {
+            match dm.borrow().find(&pat.id) {
                 Some(&DefStatic(_, false)) => true,
                 _ => false
             }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -100,7 +100,7 @@ impl<'a> Visitor<()> for ReachableContext<'a> {
 
         match expr.node {
             ast::ExprPath(_) => {
-                let def = match self.tcx.def_map.borrow().get().find(&expr.id) {
+                let def = match self.tcx.def_map.borrow().find(&expr.id) {
                     Some(&def) => def,
                     None => {
                         self.tcx.sess.span_bug(expr.span,
@@ -133,7 +133,7 @@ impl<'a> Visitor<()> for ReachableContext<'a> {
             }
             ast::ExprMethodCall(..) => {
                 let method_call = typeck::MethodCall::expr(expr.id);
-                match self.method_map.borrow().get().get(&method_call).origin {
+                match self.method_map.borrow().get(&method_call).origin {
                     typeck::MethodStatic(def_id) => {
                         if is_local(def_id) {
                             if self.def_id_represents_local_inlined_item(def_id) {
@@ -330,7 +330,7 @@ impl<'a> ReachableContext<'a> {
     // this properly would result in the necessity of computing *type*
     // reachability, which might result in a compile time loss.
     fn mark_destructors_reachable(&mut self) {
-        for (_, destructor_def_id) in self.tcx.destructor_for_type.borrow().get().iter() {
+        for (_, destructor_def_id) in self.tcx.destructor_for_type.borrow().iter() {
             if destructor_def_id.krate == ast::LOCAL_CRATE {
                 self.reachable_symbols.insert(destructor_def_id.node);
             }

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -141,7 +141,7 @@ impl<T:Subst> Subst for Rc<T> {
     fn subst_spanned(&self, tcx: &ty::ctxt,
                      substs: &ty::substs,
                      span: Option<Span>) -> Rc<T> {
-        Rc::new(self.deref().subst_spanned(tcx, substs, span))
+        Rc::new((**self).subst_spanned(tcx, substs, span))
     }
 }
 

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -118,18 +118,14 @@ pub fn represent_node(bcx: &Block, node: ast::NodeId) -> @Repr {
 /// Decides how to represent a given type.
 pub fn represent_type(cx: &CrateContext, t: ty::t) -> @Repr {
     debug!("Representing: {}", ty_to_str(cx.tcx(), t));
-    {
-        let adt_reprs = cx.adt_reprs.borrow();
-        match adt_reprs.get().find(&t) {
-            Some(repr) => return *repr,
-            None => {}
-        }
+    match cx.adt_reprs.borrow().find(&t) {
+        Some(repr) => return *repr,
+        None => {}
     }
 
     let repr = @represent_type_uncached(cx, t);
     debug!("Represented as: {:?}", repr)
-    let mut adt_reprs = cx.adt_reprs.borrow_mut();
-    adt_reprs.get().insert(t, repr);
+    cx.adt_reprs.borrow_mut().insert(t, repr);
     return repr;
 }
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -79,11 +79,11 @@ impl<'a> Builder<'a> {
                 s.push_char('/');
                 s.push_str(category);
 
-                let n = match h.get().find(&s) {
+                let n = match h.find(&s) {
                     Some(&n) => n,
                     _ => 0u
                 };
-                h.get().insert(s, n+1u);
+                h.insert(s, n+1u);
             })
         }
     }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -399,7 +399,7 @@ pub fn trans_fn_ref_with_vtables(
             let ref_ty = match node {
                 ExprId(id) => node_id_type(bcx, id),
                 MethodCall(method_call) => {
-                    let t = bcx.ccx().maps.method_map.borrow().get().get(&method_call).ty;
+                    let t = bcx.ccx().maps.method_map.borrow().get(&method_call).ty;
                     monomorphize_type(bcx, t)
                 }
             };
@@ -482,7 +482,7 @@ pub fn trans_method_call<'a>(
     let _icx = push_ctxt("trans_method_call");
     debug!("trans_method_call(call_ex={})", call_ex.repr(bcx.tcx()));
     let method_call = MethodCall::expr(call_ex.id);
-    let method_ty = bcx.ccx().maps.method_map.borrow().get().get(&method_call).ty;
+    let method_ty = bcx.ccx().maps.method_map.borrow().get(&method_call).ty;
     trans_call_inner(
         bcx,
         Some(common::expr_info(call_ex)),

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -394,11 +394,11 @@ pub fn trans_expr_fn<'a>(
 
     let cap_vars = ccx.maps.capture_map.borrow().get_copy(&id);
     let ClosureResult {llbox, cdata_ty, bcx} =
-        build_closure(bcx, cap_vars.deref().as_slice(), sigil);
+        build_closure(bcx, cap_vars.as_slice(), sigil);
     trans_closure(ccx, decl, body, llfn,
                   bcx.fcx.param_substs, id,
                   [], ty::ty_fn_ret(fty),
-                  |bcx| load_environment(bcx, cdata_ty, cap_vars.deref().as_slice(), sigil));
+                  |bcx| load_environment(bcx, cdata_ty, cap_vars.as_slice(), sigil));
     fill_fn_pair(bcx, dest_addr, llfn, llbox);
 
     bcx

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -317,10 +317,7 @@ fn load_environment<'a>(bcx: &'a Block<'a>, cdata_ty: ty::t,
         }
         let def_id = ast_util::def_id_of_def(cap_var.def);
 
-        {
-            let mut llupvars = bcx.fcx.llupvars.borrow_mut();
-            llupvars.get().insert(def_id.node, upvarptr);
-        }
+        bcx.fcx.llupvars.borrow_mut().insert(def_id.node, upvarptr);
 
         for &env_pointer_alloca in env_pointer_alloca.iter() {
             debuginfo::create_captured_var_metadata(
@@ -395,7 +392,7 @@ pub fn trans_expr_fn<'a>(
     // set an inline hint for all closures
     set_inline_hint(llfn);
 
-    let cap_vars = ccx.maps.capture_map.borrow().get().get_copy(&id);
+    let cap_vars = ccx.maps.capture_map.borrow().get_copy(&id);
     let ClosureResult {llbox, cdata_ty, bcx} =
         build_closure(bcx, cap_vars.deref().as_slice(), sigil);
     trans_closure(ccx, decl, body, llfn,
@@ -423,12 +420,9 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
         }
     };
 
-    {
-        let cache = ccx.closure_bare_wrapper_cache.borrow();
-        match cache.get().find(&fn_ptr) {
-            Some(&llval) => return llval,
-            None => {}
-        }
+    match ccx.closure_bare_wrapper_cache.borrow().find(&fn_ptr) {
+        Some(&llval) => return llval,
+        None => {}
     }
 
     let tcx = ccx.tcx();
@@ -457,10 +451,7 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
         decl_rust_fn(ccx, true, f.sig.inputs.as_slice(), f.sig.output, name)
     };
 
-    {
-        let mut cache = ccx.closure_bare_wrapper_cache.borrow_mut();
-        cache.get().insert(fn_ptr, llfn);
-    }
+    ccx.closure_bare_wrapper_cache.borrow_mut().insert(fn_ptr, llfn);
 
     // This is only used by statics inlined from a different crate.
     if !is_local {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -465,8 +465,7 @@ impl<'a> Block<'a> {
     }
 
     pub fn def(&self, nid: ast::NodeId) -> ast::Def {
-        let def_map = self.tcx().def_map.borrow();
-        match def_map.get().find(&nid) {
+        match self.tcx().def_map.borrow().find(&nid) {
             Some(&v) => v,
             None => {
                 self.tcx().sess.bug(format!(
@@ -584,12 +583,9 @@ pub fn C_u8(ccx: &CrateContext, i: uint) -> ValueRef {
 // our boxed-and-length-annotated strings.
 pub fn C_cstr(cx: &CrateContext, s: InternedString) -> ValueRef {
     unsafe {
-        {
-            let const_cstr_cache = cx.const_cstr_cache.borrow();
-            match const_cstr_cache.get().find(&s) {
-                Some(&llval) => return llval,
-                None => ()
-            }
+        match cx.const_cstr_cache.borrow().find(&s) {
+            Some(&llval) => return llval,
+            None => ()
         }
 
         let sc = llvm::LLVMConstStringInContext(cx.llcx,
@@ -605,8 +601,7 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString) -> ValueRef {
         llvm::LLVMSetGlobalConstant(g, True);
         lib::llvm::SetLinkage(g, lib::llvm::InternalLinkage);
 
-        let mut const_cstr_cache = cx.const_cstr_cache.borrow_mut();
-        const_cstr_cache.get().insert(s, g);
+        cx.const_cstr_cache.borrow_mut().insert(s, g);
         g
     }
 }
@@ -795,7 +790,7 @@ pub fn expr_ty(bcx: &Block, ex: &ast::Expr) -> ty::t {
 
 pub fn expr_ty_adjusted(bcx: &Block, ex: &ast::Expr) -> ty::t {
     let tcx = bcx.tcx();
-    let t = ty::expr_ty_adjusted(tcx, ex, bcx.ccx().maps.method_map.borrow().get());
+    let t = ty::expr_ty_adjusted(tcx, ex, &*bcx.ccx().maps.method_map.borrow());
     monomorphize_type(bcx, t)
 }
 
@@ -814,7 +809,7 @@ pub fn node_id_type_params(bcx: &Block, node: ExprOrMethodCall) -> Vec<ty::t> {
     let params = match node {
         ExprId(id) => ty::node_id_to_type_params(tcx, id),
         MethodCall(method_call) => {
-            bcx.ccx().maps.method_map.borrow().get().get(&method_call).substs.tps.clone()
+            bcx.ccx().maps.method_map.borrow().get(&method_call).substs.tps.clone()
         }
     };
 
@@ -837,7 +832,7 @@ pub fn node_id_type_params(bcx: &Block, node: ExprOrMethodCall) -> Vec<ty::t> {
 pub fn node_vtables(bcx: &Block, id: ast::NodeId)
                  -> Option<typeck::vtable_res> {
     let vtable_map = bcx.ccx().maps.vtable_map.borrow();
-    let raw_vtables = vtable_map.get().find(&id);
+    let raw_vtables = vtable_map.find(&id);
     raw_vtables.map(|vts| resolve_vtables_in_fn_ctxt(bcx.fcx, *vts))
 }
 

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -937,7 +937,7 @@ pub fn filename_and_line_num_from_span(bcx: &Block, span: Span)
                                        -> (ValueRef, ValueRef) {
     let loc = bcx.sess().codemap().lookup_char_pos(span.lo);
     let filename_cstr = C_cstr(bcx.ccx(),
-                               token::intern_and_get_ident(loc.file.deref().name));
+                               token::intern_and_get_ident(loc.file.name));
     let filename = build::PointerCast(bcx, filename_cstr, Type::i8p(bcx.ccx()));
     let line = C_int(bcx.ccx(), loc.line as int);
     (filename, line)

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -84,8 +84,7 @@ pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: ast::Lit)
 pub fn const_ptrcast(cx: &CrateContext, a: ValueRef, t: Type) -> ValueRef {
     unsafe {
         let b = llvm::LLVMConstPointerCast(a, t.ptr_to().to_ref());
-        let mut const_globals = cx.const_globals.borrow_mut();
-        assert!(const_globals.get().insert(b as int, a));
+        assert!(cx.const_globals.borrow_mut().insert(b as int, a));
         b
     }
 }
@@ -118,8 +117,7 @@ fn const_addr_of(cx: &CrateContext, cv: ValueRef) -> ValueRef {
 }
 
 fn const_deref_ptr(cx: &CrateContext, v: ValueRef) -> ValueRef {
-    let const_globals = cx.const_globals.borrow();
-    let v = match const_globals.get().find(&(v as int)) {
+    let v = match cx.const_globals.borrow().find(&(v as int)) {
         Some(&v) => v,
         None => v
     };
@@ -163,10 +161,7 @@ fn const_deref(cx: &CrateContext, v: ValueRef, t: ty::t, explicit: bool)
 
 pub fn get_const_val(cx: &CrateContext,
                      mut def_id: ast::DefId) -> (ValueRef, bool) {
-    let contains_key = {
-        let const_values = cx.const_values.borrow();
-        const_values.get().contains_key(&def_id.node)
-    };
+    let contains_key = cx.const_values.borrow().contains_key(&def_id.node);
     if !ast_util::is_local(def_id) || !contains_key {
         if !ast_util::is_local(def_id) {
             def_id = inline::maybe_instantiate_inline(cx, def_id);
@@ -180,10 +175,8 @@ pub fn get_const_val(cx: &CrateContext,
         }
     }
 
-    let const_values = cx.const_values.borrow();
-    let non_inlineable_statics = cx.non_inlineable_statics.borrow();
-    (const_values.get().get_copy(&def_id.node),
-     !non_inlineable_statics.get().contains(&def_id.node))
+    (cx.const_values.borrow().get_copy(&def_id.node),
+     !cx.non_inlineable_statics.borrow().contains(&def_id.node))
 }
 
 pub fn const_expr(cx: &CrateContext, e: &ast::Expr, is_local: bool) -> (ValueRef, bool) {
@@ -192,12 +185,9 @@ pub fn const_expr(cx: &CrateContext, e: &ast::Expr, is_local: bool) -> (ValueRef
     let mut inlineable = inlineable;
     let ety = ty::expr_ty(cx.tcx(), e);
     let ety_adjusted = ty::expr_ty_adjusted(cx.tcx(), e,
-                                            cx.maps.method_map.borrow().get());
-    let adjustment = {
-        let adjustments = cx.tcx.adjustments.borrow();
-        adjustments.get().find_copy(&e.id)
-    };
-    match adjustment {
+                                            &*cx.maps.method_map.borrow());
+    let opt_adj = cx.tcx.adjustments.borrow().find_copy(&e.id);
+    match opt_adj {
         None => { }
         Some(adj) => {
             match *adj {
@@ -424,7 +414,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
           }
           ast::ExprField(base, field, _) => {
               let bt = ty::expr_ty_adjusted(cx.tcx(), base,
-                                            cx.maps.method_map.borrow().get());
+                                            &*cx.maps.method_map.borrow());
               let brepr = adt::represent_type(cx, bt);
               let (bv, inlineable) = const_expr(cx, base, is_local);
               expr::with_field_tys(cx.tcx(), bt, None, |discr, field_tys| {
@@ -435,7 +425,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
 
           ast::ExprIndex(base, index) => {
               let bt = ty::expr_ty_adjusted(cx.tcx(), base,
-                                            cx.maps.method_map.borrow().get());
+                                            &*cx.maps.method_map.borrow());
               let (bv, inlineable) = const_expr(cx, base, is_local);
               let iv = match const_eval::eval_const_expr(cx.tcx(), index) {
                   const_eval::const_int(i) => i as u64,
@@ -624,11 +614,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
             // Assert that there are no type parameters in this path.
             assert!(pth.segments.iter().all(|seg| seg.types.is_empty()));
 
-            let tcx = cx.tcx();
-            let opt_def = {
-                let def_map = tcx.def_map.borrow();
-                def_map.get().find_copy(&e.id)
-            };
+            let opt_def = cx.tcx().def_map.borrow().find_copy(&e.id);
             match opt_def {
                 Some(ast::DefFn(def_id, _purity)) => {
                     if !ast_util::is_local(def_id) {
@@ -661,11 +647,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
             }
           }
           ast::ExprCall(callee, ref args) => {
-              let tcx = cx.tcx();
-              let opt_def = {
-                  let def_map = tcx.def_map.borrow();
-                  def_map.get().find_copy(&callee.id)
-              };
+              let opt_def = cx.tcx().def_map.borrow().find_copy(&callee.id);
               match opt_def {
                   Some(ast::DefStruct(_)) => {
                       let ety = ty::expr_ty(cx.tcx(), e);
@@ -702,8 +684,7 @@ pub fn trans_const(ccx: &CrateContext, m: ast::Mutability, id: ast::NodeId) {
         let g = base::get_item_val(ccx, id);
         // At this point, get_item_val has already translated the
         // constant's initializer to determine its LLVM type.
-        let const_values = ccx.const_values.borrow();
-        let v = const_values.get().get_copy(&id);
+        let v = ccx.const_values.borrow().get_copy(&id);
         llvm::LLVMSetInitializer(g, v);
         if m != ast::MutMutable {
             llvm::LLVMSetGlobalConstant(g, True);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -77,7 +77,7 @@ pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: ast::Lit)
         ast::LitBool(b) => C_bool(cx, b),
         ast::LitNil => C_nil(cx),
         ast::LitStr(ref s, _) => C_str_slice(cx, (*s).clone()),
-        ast::LitBinary(ref data) => C_binary_slice(cx, data.deref().as_slice()),
+        ast::LitBinary(ref data) => C_binary_slice(cx, data.as_slice()),
     }
 }
 

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -273,8 +273,7 @@ pub fn trans_break_cont<'a>(bcx: &'a Block<'a>,
     let loop_id = match opt_label {
         None => fcx.top_loop_scope(),
         Some(_) => {
-            let def_map = bcx.tcx().def_map.borrow();
-            match def_map.get().find(&expr_id) {
+            match bcx.tcx().def_map.borrow().find(&expr_id) {
                 Some(&ast::DefLabel(loop_id)) => loop_id,
                 ref r => {
                     bcx.tcx().sess.bug(format!("{:?} in def-map for label", r))

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -334,7 +334,7 @@ pub fn trans_fail<'a>(
     let v_fail_str = C_cstr(ccx, fail_str);
     let _icx = push_ctxt("trans_fail_value");
     let loc = bcx.sess().codemap().lookup_char_pos(sp.lo);
-    let v_filename = C_cstr(ccx, token::intern_and_get_ident(loc.file.deref().name));
+    let v_filename = C_cstr(ccx, token::intern_and_get_ident(loc.file.name));
     let v_line = loc.line as int;
     let v_str = PointerCast(bcx, v_fail_str, Type::i8p(ccx));
     let v_filename = PointerCast(bcx, v_filename, Type::i8p(ccx));

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -610,7 +610,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
     }
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     let function_type_metadata = unsafe {
         let fn_signature = get_function_signature(cx, fn_ast_id, fn_decl, param_substs, span);
@@ -930,7 +930,7 @@ fn declare_local(bcx: &Block,
                  span: Span) {
     let cx: &CrateContext = bcx.ccx();
 
-    let filename = span_start(cx, span).file.deref().name.clone();
+    let filename = span_start(cx, span).file.name.clone();
     let file_metadata = file_metadata(cx, filename);
 
     let name = token::get_ident(variable_ident);
@@ -1181,7 +1181,7 @@ fn prepare_struct_metadata(cx: &CrateContext,
 
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, def_id);
 
-    let file_name = span_start(cx, definition_span).file.deref().name.clone();
+    let file_name = span_start(cx, definition_span).file.name.clone();
     let file_metadata = file_metadata(cx, file_name);
 
     let struct_metadata_stub = create_struct_stub(cx,
@@ -1276,7 +1276,7 @@ fn prepare_tuple_metadata(cx: &CrateContext,
     let tuple_llvm_type = type_of::type_of(cx, tuple_type);
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     UnfinishedMetadata {
         cache_id: cache_id_for_type(tuple_type),
@@ -1436,7 +1436,7 @@ fn prepare_enum_metadata(cx: &CrateContext,
 
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, enum_def_id);
     let loc = span_start(cx, definition_span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     // For empty enums there is an early exit. Just describe it as an empty struct with the
     // appropriate type name
@@ -1775,7 +1775,7 @@ fn boxed_type_metadata(cx: &CrateContext,
     ];
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     return composite_type_metadata(
         cx,
@@ -1876,7 +1876,7 @@ fn vec_metadata(cx: &CrateContext,
     assert!(member_descriptions.len() == member_llvm_types.len());
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     composite_type_metadata(
         cx,
@@ -1927,7 +1927,7 @@ fn vec_slice_metadata(cx: &CrateContext,
     assert!(member_descriptions.len() == member_llvm_types.len());
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     return composite_type_metadata(
         cx,
@@ -1953,7 +1953,7 @@ fn subroutine_type_metadata(cx: &CrateContext,
                             span: Span)
                          -> DICompositeType {
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.deref().name);
+    let file_metadata = file_metadata(cx, loc.file.name);
 
     let mut signature_metadata: Vec<DIType> =
         Vec::with_capacity(signature.inputs.len() + 1);
@@ -1999,7 +1999,7 @@ fn trait_metadata(cx: &CrateContext,
 
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, def_id);
 
-    let file_name = span_start(cx, definition_span).file.deref().name.clone();
+    let file_name = span_start(cx, definition_span).file.name.clone();
     let file_metadata = file_metadata(cx, file_name);
 
     let trait_llvm_type = type_of::type_of(cx, trait_type);
@@ -2297,7 +2297,7 @@ fn populate_scope_map(cx: &CrateContext,
                                    &mut HashMap<ast::NodeId, DIScope>|) {
         // Create a new lexical scope and push it onto the stack
         let loc = cx.sess().codemap().lookup_char_pos(scope_span.lo);
-        let file_metadata = file_metadata(cx, loc.file.deref().name);
+        let file_metadata = file_metadata(cx, loc.file.name);
         let parent_scope = scope_stack.last().unwrap().scope_metadata;
 
         let scope_metadata = unsafe {
@@ -2414,7 +2414,7 @@ fn populate_scope_map(cx: &CrateContext,
                     if need_new_scope {
                         // Create a new lexical scope and push it onto the stack
                         let loc = cx.sess().codemap().lookup_char_pos(pat.span.lo);
-                        let file_metadata = file_metadata(cx, loc.file.deref().name);
+                        let file_metadata = file_metadata(cx, loc.file.name);
                         let parent_scope = scope_stack.last().unwrap().scope_metadata;
 
                         let scope_metadata = unsafe {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -294,15 +294,12 @@ pub fn create_local_var_metadata(bcx: &Block, local: &ast::Local) {
     pat_util::pat_bindings(def_map, local.pat, |_, node_id, span, path_ref| {
         let var_ident = ast_util::path_to_ident(path_ref);
 
-        let datum = {
-            let lllocals = bcx.fcx.lllocals.borrow();
-            match lllocals.get().find_copy(&node_id) {
-                Some(datum) => datum,
-                None => {
-                    bcx.sess().span_bug(span,
-                        format!("no entry in lllocals table for {:?}",
-                                node_id));
-                }
+        let datum = match bcx.fcx.lllocals.borrow().find_copy(&node_id) {
+            Some(datum) => datum,
+            None => {
+                bcx.sess().span_bug(span,
+                    format!("no entry in lllocals table for {:?}",
+                            node_id));
             }
         };
 
@@ -436,15 +433,12 @@ pub fn create_argument_metadata(bcx: &Block, arg: &ast::Arg) {
     let scope_metadata = bcx.fcx.debug_context.get_ref(cx, arg.pat.span).fn_metadata;
 
     pat_util::pat_bindings(def_map, arg.pat, |_, node_id, span, path_ref| {
-        let llarg = {
-            let llargs = bcx.fcx.llargs.borrow();
-            match llargs.get().find_copy(&node_id) {
-                Some(v) => v,
-                None => {
-                    bcx.sess().span_bug(span,
-                        format!("no entry in llargs table for {:?}",
-                                node_id));
-                }
+        let llarg = match bcx.fcx.llargs.borrow().find_copy(&node_id) {
+            Some(v) => v,
+            None => {
+                bcx.sess().span_bug(span,
+                    format!("no entry in llargs table for {:?}",
+                            node_id));
             }
         };
 
@@ -686,14 +680,11 @@ pub fn create_function_debug_context(cx: &CrateContext,
     };
 
     let arg_pats = fn_decl.inputs.map(|arg_ref| arg_ref.pat);
-    {
-        let mut scope_map = fn_debug_context.scope_map.borrow_mut();
-        populate_scope_map(cx,
-                           arg_pats.as_slice(),
-                           top_level_block,
-                           fn_metadata,
-                           scope_map.get());
-    }
+    populate_scope_map(cx,
+                       arg_pats.as_slice(),
+                       top_level_block,
+                       fn_metadata,
+                       &mut *fn_debug_context.scope_map.borrow_mut());
 
     // Clear the debug location so we don't assign them in the function prelude
     set_debug_location(cx, UnknownLocation);
@@ -1014,12 +1005,9 @@ fn declare_local(bcx: &Block,
 }
 
 fn file_metadata(cx: &CrateContext, full_path: &str) -> DIFile {
-    {
-        let created_files = debug_context(cx).created_files.borrow();
-        match created_files.get().find_equiv(&full_path) {
-            Some(file_metadata) => return *file_metadata,
-            None => ()
-        }
+    match debug_context(cx).created_files.borrow().find_equiv(&full_path) {
+        Some(file_metadata) => return *file_metadata,
+        None => ()
     }
 
     debug!("file_metadata: {}", full_path);
@@ -1043,7 +1031,7 @@ fn file_metadata(cx: &CrateContext, full_path: &str) -> DIFile {
         });
 
     let mut created_files = debug_context(cx).created_files.borrow_mut();
-    created_files.get().insert(full_path.to_owned(), file_metadata);
+    created_files.insert(full_path.to_owned(), file_metadata);
     return file_metadata;
 }
 
@@ -1053,9 +1041,7 @@ fn scope_metadata(fcx: &FunctionContext,
                   span: Span)
                -> DIScope {
     let scope_map = &fcx.debug_context.get_ref(fcx.ccx, span).scope_map;
-    let scope_map = scope_map.borrow();
-
-    match scope_map.get().find_copy(&node_id) {
+    match scope_map.borrow().find_copy(&node_id) {
         Some(scope_metadata) => scope_metadata,
         None => {
             let node = fcx.ccx.tcx.map.get(node_id);
@@ -1243,10 +1229,8 @@ impl RecursiveTypeDescription {
                 ref member_description_factory
             } => {
                 // Insert the stub into the cache in order to allow recursive references ...
-                {
-                    let mut created_types = debug_context(cx).created_types.borrow_mut();
-                    created_types.get().insert(cache_id, metadata_stub);
-                }
+                debug_context(cx).created_types.borrow_mut()
+                                 .insert(cache_id, metadata_stub);
 
                 // ... then create the member descriptions ...
                 let member_descriptions = member_description_factory.create_member_descriptions(cx);
@@ -1649,12 +1633,12 @@ fn set_members_of_composite_type(cx: &CrateContext,
     {
         let mut composite_types_completed =
             debug_context(cx).composite_types_completed.borrow_mut();
-        if composite_types_completed.get().contains(&composite_type_metadata) {
+        if composite_types_completed.contains(&composite_type_metadata) {
             cx.sess().span_bug(definition_span, "debuginfo::set_members_of_composite_type() - \
                                                  Already completed forward declaration \
                                                  re-encountered.");
         } else {
-            composite_types_completed.get().insert(composite_type_metadata);
+            composite_types_completed.insert(composite_type_metadata);
         }
     }
 
@@ -2035,12 +2019,9 @@ fn type_metadata(cx: &CrateContext,
               -> DIType {
     let cache_id = cache_id_for_type(t);
 
-    {
-        let created_types = debug_context(cx).created_types.borrow();
-        match created_types.get().find(&cache_id) {
-            Some(type_metadata) => return *type_metadata,
-            None => ()
-        }
+    match debug_context(cx).created_types.borrow().find(&cache_id) {
+        Some(type_metadata) => return *type_metadata,
+        None => ()
     }
 
     fn create_pointer_to_box_metadata(cx: &CrateContext,
@@ -2149,8 +2130,7 @@ fn type_metadata(cx: &CrateContext,
         _ => cx.sess().bug(format!("debuginfo: unexpected type in type_metadata: {:?}", sty))
     };
 
-    let mut created_types = debug_context(cx).created_types.borrow_mut();
-    created_types.get().insert(cache_id, type_metadata);
+    debug_context(cx).created_types.borrow_mut().insert(cache_id, type_metadata);
     type_metadata
 }
 
@@ -2250,8 +2230,7 @@ fn fn_should_be_ignored(fcx: &FunctionContext) -> bool {
 }
 
 fn assert_type_for_node_id(cx: &CrateContext, node_id: ast::NodeId, error_span: Span) {
-    let node_types = cx.tcx.node_types.borrow();
-    if !node_types.get().contains_key(&(node_id as uint)) {
+    if !cx.tcx.node_types.borrow().contains_key(&(node_id as uint)) {
         cx.sess().span_bug(error_span, "debuginfo: Could not find type for node id!");
     }
 }
@@ -2781,10 +2760,8 @@ fn namespace_for_item(cx: &CrateContext, def_id: ast::DefId) -> @NamespaceTreeNo
             let name = path_element.name();
             current_key.push(name);
 
-            let existing_node = {
-                let namespace_map = debug_context(cx).namespace_map.borrow();
-                namespace_map.get().find_copy(&current_key)
-            };
+            let existing_node = debug_context(cx).namespace_map.borrow()
+                                                 .find_copy(&current_key);
             let current_node = match existing_node {
                 Some(existing_node) => existing_node,
                 None => {
@@ -2813,11 +2790,8 @@ fn namespace_for_item(cx: &CrateContext, def_id: ast::DefId) -> @NamespaceTreeNo
                         parent: parent_node,
                     };
 
-                    {
-                        let mut namespace_map = debug_context(cx).namespace_map
-                                                                 .borrow_mut();
-                        namespace_map.get().insert(current_key.clone(), node);
-                    }
+                    debug_context(cx).namespace_map.borrow_mut()
+                                     .insert(current_key.clone(), node);
 
                     node
                 }

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -239,16 +239,12 @@ pub fn register_foreign_item_fn(ccx: &CrateContext, abis: AbiSet,
     // Create the LLVM value for the C extern fn
     let llfn_ty = lltype_for_fn_from_foreign_types(ccx, &tys);
 
-    let llfn;
-    {
-        let mut externs = ccx.externs.borrow_mut();
-        llfn = base::get_extern_fn(externs.get(),
+    let llfn = base::get_extern_fn(&mut *ccx.externs.borrow_mut(),
                                    ccx.llmod,
                                    lname.get(),
                                    cc,
                                    llfn_ty,
                                    tys.fn_sig.output);
-    };
     add_argument_attributes(&tys, llfn);
 
     llfn
@@ -470,8 +466,8 @@ pub fn trans_foreign_mod(ccx: &CrateContext, foreign_mod: &ast::ForeignMod) {
         }
 
         let lname = link_name(foreign_item);
-        let mut item_symbols = ccx.item_symbols.borrow_mut();
-        item_symbols.get().insert(foreign_item.id, lname.get().to_owned());
+        ccx.item_symbols.borrow_mut().insert(foreign_item.id,
+                                             lname.get().to_owned());
     }
 }
 

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -128,7 +128,7 @@ pub fn drop_ty_immediate<'a>(bcx: &'a Block<'a>, v: ValueRef, t: ty::t)
 
 pub fn get_drop_glue(ccx: &CrateContext, t: ty::t) -> ValueRef {
     let t = get_drop_glue_type(ccx, t);
-    match ccx.drop_glues.borrow().get().find(&t) {
+    match ccx.drop_glues.borrow().find(&t) {
         Some(&glue) => return glue,
         _ => { }
     }
@@ -136,7 +136,7 @@ pub fn get_drop_glue(ccx: &CrateContext, t: ty::t) -> ValueRef {
     let llfnty = Type::glue_fn(ccx, type_of(ccx, t).ptr_to());
     let glue = declare_generic_glue(ccx, t, llfnty, "drop");
 
-    ccx.drop_glues.borrow_mut().get().insert(t, glue);
+    ccx.drop_glues.borrow_mut().insert(t, glue);
 
     make_generic_glue(ccx, t, glue, make_drop_glue, "drop");
 
@@ -476,8 +476,7 @@ pub fn emit_tydescs(ccx: &CrateContext) {
     // As of this point, allow no more tydescs to be created.
     ccx.finished_tydescs.set(true);
     let glue_fn_ty = Type::generic_glue_fn(ccx).ptr_to();
-    let mut tyds = ccx.tydescs.borrow_mut();
-    for (_, &val) in tyds.get().iter() {
+    for (_, &val) in ccx.tydescs.borrow().iter() {
         let ti = val;
 
         // Each of the glue functions needs to be cast to a generic type

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -102,12 +102,9 @@ pub fn type_of_fn_from_ty(cx: &CrateContext, fty: ty::t) -> Type {
 //     recursive types. For example, enum types rely on this behavior.
 
 pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
-    {
-        let llsizingtypes = cx.llsizingtypes.borrow();
-        match llsizingtypes.get().find_copy(&t) {
-            Some(t) => return t,
-            None => ()
-        }
+    match cx.llsizingtypes.borrow().find_copy(&t) {
+        Some(t) => return t,
+        None => ()
     }
 
     let llsizingty = match ty::get(t).sty {
@@ -165,20 +162,16 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
         }
     };
 
-    let mut llsizingtypes = cx.llsizingtypes.borrow_mut();
-    llsizingtypes.get().insert(t, llsizingty);
+    cx.llsizingtypes.borrow_mut().insert(t, llsizingty);
     llsizingty
 }
 
 // NB: If you update this, be sure to update `sizing_type_of()` as well.
 pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
     // Check the cache.
-    {
-        let lltypes = cx.lltypes.borrow();
-        match lltypes.get().find(&t) {
-            Some(&llty) => return llty,
-            None => ()
-        }
+    match cx.lltypes.borrow().find(&t) {
+        Some(&llty) => return llty,
+        None => ()
     }
 
     debug!("type_of {} {:?}", t.repr(cx.tcx()), t);
@@ -198,8 +191,7 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
                 t_norm.repr(cx.tcx()),
                 t_norm,
                 cx.tn.type_to_str(llty));
-        let mut lltypes = cx.lltypes.borrow_mut();
-        lltypes.get().insert(t, llty);
+        cx.lltypes.borrow_mut().insert(t, llty);
         return llty;
     }
 
@@ -295,10 +287,8 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
             t.repr(cx.tcx()),
             t,
             cx.tn.type_to_str(llty));
-    {
-        let mut lltypes = cx.lltypes.borrow_mut();
-        lltypes.get().insert(t, llty);
-    }
+
+    cx.lltypes.borrow_mut().insert(t, llty);
 
     // If this was an enum or struct, fill in the type now.
     match ty::get(t).sty {

--- a/src/librustc/middle/trans/write_guard.rs
+++ b/src/librustc/middle/trans/write_guard.rs
@@ -34,8 +34,7 @@ pub fn root_and_write_guard<'a, K:KindOps>(datum: &Datum<K>,
     //
     // (Note: root'd values are always boxes)
     let ccx = bcx.ccx();
-    let root_map = ccx.maps.root_map.borrow();
-    match root_map.get().find(&key) {
+    match ccx.maps.root_map.borrow().find(&key) {
         None => bcx,
         Some(&root_info) => root(datum, bcx, span, key, root_info)
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1154,12 +1154,9 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
 
     let key = intern_key { sty: &st };
 
-    {
-        let mut interner = cx.interner.borrow_mut();
-        match interner.get().find(&key) {
-          Some(t) => unsafe { return cast::transmute(&t.sty); },
-          _ => ()
-        }
+    match cx.interner.borrow().find(&key) {
+        Some(t) => unsafe { return cast::transmute(&t.sty); },
+        _ => ()
     }
 
     let mut flags = 0u;
@@ -1255,8 +1252,7 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
         sty: sty_ptr,
     };
 
-    let mut interner = cx.interner.borrow_mut();
-    interner.get().insert(key, t);
+    cx.interner.borrow_mut().insert(key, t);
 
     cx.next_id.set(cx.next_id.get() + 1);
 
@@ -1762,21 +1758,15 @@ pub fn type_needs_drop(cx: &ctxt, ty: t) -> bool {
 // that only contain scalars and shared boxes can avoid unwind
 // cleanups.
 pub fn type_needs_unwind_cleanup(cx: &ctxt, ty: t) -> bool {
-    {
-        let needs_unwind_cleanup_cache = cx.needs_unwind_cleanup_cache
-                                           .borrow();
-        match needs_unwind_cleanup_cache.get().find(&ty) {
-            Some(&result) => return result,
-            None => ()
-        }
+    match cx.needs_unwind_cleanup_cache.borrow().find(&ty) {
+        Some(&result) => return result,
+        None => ()
     }
 
     let mut tycache = HashSet::new();
     let needs_unwind_cleanup =
         type_needs_unwind_cleanup_(cx, ty, &mut tycache, false);
-    let mut needs_unwind_cleanup_cache = cx.needs_unwind_cleanup_cache
-                                           .borrow_mut();
-    needs_unwind_cleanup_cache.get().insert(ty, needs_unwind_cleanup);
+    cx.needs_unwind_cleanup_cache.borrow_mut().insert(ty, needs_unwind_cleanup);
     return needs_unwind_cleanup;
 }
 
@@ -2094,19 +2084,15 @@ pub fn type_interior_is_unsafe(cx: &ctxt, t: ty::t) -> bool {
 pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
     let ty_id = type_id(ty);
 
-    {
-        let tc_cache = cx.tc_cache.borrow();
-        match tc_cache.get().find(&ty_id) {
-            Some(tc) => { return *tc; }
-            None => {}
-        }
+    match cx.tc_cache.borrow().find(&ty_id) {
+        Some(tc) => { return *tc; }
+        None => {}
     }
 
     let mut cache = HashMap::new();
     let result = tc_ty(cx, ty, &mut cache);
 
-    let mut tc_cache = cx.tc_cache.borrow_mut();
-    tc_cache.get().insert(ty_id, result);
+    cx.tc_cache.borrow_mut().insert(ty_id, result);
     return result;
 
     fn tc_ty(cx: &ctxt,
@@ -2139,12 +2125,9 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
             Some(tc) => { return *tc; }
             None => {}
         }
-        {
-            let tc_cache = cx.tc_cache.borrow();
-            match tc_cache.get().find(&ty_id) {    // Must check both caches!
-                Some(tc) => { return *tc; }
-                None => {}
-            }
+        match cx.tc_cache.borrow().find(&ty_id) {    // Must check both caches!
+            Some(tc) => { return *tc; }
+            None => {}
         }
         cache.insert(ty_id, TC::None);
 
@@ -2243,7 +2226,7 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
                 assert_eq!(p.def_id.krate, ast::LOCAL_CRATE);
 
                 let ty_param_defs = cx.ty_param_defs.borrow();
-                let tp_def = ty_param_defs.get().get(&p.def_id.node);
+                let tp_def = ty_param_defs.get(&p.def_id.node);
                 kind_bounds_to_contents(cx,
                                         tp_def.bounds.builtin_bounds,
                                         tp_def.bounds.trait_bounds.as_slice())
@@ -2686,7 +2669,7 @@ pub fn type_is_sized(cx: &ctxt, ty: ty::t) -> bool {
         // FIXME(#6308) add trait, vec, str, etc here.
         ty_param(p) => {
             let ty_param_defs = cx.ty_param_defs.borrow();
-            let param_def = ty_param_defs.get().get(&p.def_id.node);
+            let param_def = ty_param_defs.get(&p.def_id.node);
             if param_def.bounds.builtin_bounds.contains_elem(BoundSized) {
                 return true;
             }
@@ -2746,8 +2729,7 @@ pub fn index(t: t) -> Option<mt> {
 }
 
 pub fn node_id_to_trait_ref(cx: &ctxt, id: ast::NodeId) -> @ty::TraitRef {
-    let trait_refs = cx.trait_refs.borrow();
-    match trait_refs.get().find(&id) {
+    match cx.trait_refs.borrow().find(&id) {
        Some(&t) => t,
        None => cx.sess.bug(
            format!("node_id_to_trait_ref: no trait ref for node `{}`",
@@ -2756,8 +2738,7 @@ pub fn node_id_to_trait_ref(cx: &ctxt, id: ast::NodeId) -> @ty::TraitRef {
 }
 
 pub fn try_node_id_to_type(cx: &ctxt, id: ast::NodeId) -> Option<t> {
-    let node_types = cx.node_types.borrow();
-    node_types.get().find_copy(&(id as uint))
+    cx.node_types.borrow().find_copy(&(id as uint))
 }
 
 pub fn node_id_to_type(cx: &ctxt, id: ast::NodeId) -> t {
@@ -2770,9 +2751,7 @@ pub fn node_id_to_type(cx: &ctxt, id: ast::NodeId) -> t {
 }
 
 pub fn node_id_to_type_opt(cx: &ctxt, id: ast::NodeId) -> Option<t> {
-    let node_types = cx.node_types.borrow();
-    debug!("id: {:?}, node_types: {:?}", id, node_types);
-    match node_types.get().find(&(id as uint)) {
+    match cx.node_types.borrow().find(&(id as uint)) {
        Some(&t) => Some(t),
        None => None
     }
@@ -2780,16 +2759,14 @@ pub fn node_id_to_type_opt(cx: &ctxt, id: ast::NodeId) -> Option<t> {
 
 // FIXME(pcwalton): Makes a copy, bleh. Probably better to not do that.
 pub fn node_id_to_type_params(cx: &ctxt, id: ast::NodeId) -> Vec<t> {
-    let node_type_substs = cx.node_type_substs.borrow();
-    match node_type_substs.get().find(&id) {
+    match cx.node_type_substs.borrow().find(&id) {
       None => return Vec::new(),
       Some(ts) => return (*ts).clone(),
     }
 }
 
 fn node_id_has_type_params(cx: &ctxt, id: ast::NodeId) -> bool {
-    let node_type_substs = cx.node_type_substs.borrow();
-    node_type_substs.get().contains_key(&id)
+    cx.node_type_substs.borrow().contains_key(&id)
 }
 
 pub fn fn_is_variadic(fty: t) -> bool {
@@ -2970,7 +2947,7 @@ pub fn expr_ty_adjusted(cx: &ctxt,
      */
 
     let unadjusted_ty = expr_ty(cx, expr);
-    let adjustment = cx.adjustments.borrow().get().find_copy(&expr.id);
+    let adjustment = cx.adjustments.borrow().find_copy(&expr.id);
     adjust_ty(cx, expr.span, expr.id, unadjusted_ty, adjustment, |method_call| {
         method_map.find(&method_call).map(|method| method.ty)
     })
@@ -3260,8 +3237,7 @@ pub fn method_call_type_param_defs(tcx: &ctxt, origin: typeck::MethodOrigin)
 }
 
 pub fn resolve_expr(tcx: &ctxt, expr: &ast::Expr) -> ast::Def {
-    let def_map = tcx.def_map.borrow();
-    match def_map.get().find(&expr.id) {
+    match tcx.def_map.borrow().find(&expr.id) {
         Some(&def) => def,
         None => {
             tcx.sess.span_bug(expr.span, format!(
@@ -3294,7 +3270,7 @@ pub enum ExprKind {
 pub fn expr_kind(tcx: &ctxt,
                  method_map: MethodMap,
                  expr: &ast::Expr) -> ExprKind {
-    if method_map.borrow().get().contains_key(&MethodCall::expr(expr.id)) {
+    if method_map.borrow().contains_key(&MethodCall::expr(expr.id)) {
         // Overloaded operations are generally calls, and hence they are
         // generated via DPS, but there are two exceptions:
         return match expr.node {
@@ -3377,8 +3353,7 @@ pub fn expr_kind(tcx: &ctxt,
         }
 
         ast::ExprCast(..) => {
-            let node_types = tcx.node_types.borrow();
-            match node_types.get().find(&(expr.id as uint)) {
+            match tcx.node_types.borrow().find(&(expr.id as uint)) {
                 Some(&t) => {
                     if type_is_trait(t) {
                         RvalueDpsExpr
@@ -3426,8 +3401,7 @@ pub fn expr_kind(tcx: &ctxt,
 
         ast::ExprBox(place, _) => {
             // Special case `~T` for now:
-            let def_map = tcx.def_map.borrow();
-            let definition = match def_map.get().find(&place.id) {
+            let definition = match tcx.def_map.borrow().find(&place.id) {
                 Some(&def) => def,
                 None => fail!("no def for place"),
             };
@@ -3709,8 +3683,7 @@ pub fn def_has_ty_params(def: ast::Def) -> bool {
 }
 
 pub fn provided_source(cx: &ctxt, id: ast::DefId) -> Option<ast::DefId> {
-    let provided_method_sources = cx.provided_method_sources.borrow();
-    provided_method_sources.get().find(&id).map(|x| *x)
+    cx.provided_method_sources.borrow().find(&id).map(|x| *x)
 }
 
 pub fn provided_trait_methods(cx: &ctxt, id: ast::DefId) -> Vec<@Method> {
@@ -3747,12 +3720,9 @@ pub fn provided_trait_methods(cx: &ctxt, id: ast::DefId) -> Vec<@Method> {
 
 pub fn trait_supertraits(cx: &ctxt, id: ast::DefId) -> @Vec<@TraitRef> {
     // Check the cache.
-    {
-        let supertraits = cx.supertraits.borrow();
-        match supertraits.get().find(&id) {
-            Some(&trait_refs) => { return trait_refs; }
-            None => {}  // Continue.
-        }
+    match cx.supertraits.borrow().find(&id) {
+        Some(&trait_refs) => { return trait_refs; }
+        None => {}  // Continue.
     }
 
     // Not in the cache. It had better be in the metadata, which means it
@@ -3762,8 +3732,7 @@ pub fn trait_supertraits(cx: &ctxt, id: ast::DefId) -> @Vec<@TraitRef> {
     // Get the supertraits out of the metadata and create the
     // TraitRef for each.
     let result = @csearch::get_supertraits(cx, id);
-    let mut supertraits = cx.supertraits.borrow_mut();
-    supertraits.get().insert(id, result);
+    cx.supertraits.borrow_mut().insert(id, result);
     return result;
 }
 
@@ -3808,42 +3777,38 @@ pub fn trait_method(cx: &ctxt, trait_did: ast::DefId, idx: uint) -> @Method {
 
 
 pub fn trait_methods(cx: &ctxt, trait_did: ast::DefId) -> @Vec<@Method> {
-    let mut trait_methods_cache = cx.trait_methods_cache.borrow_mut();
-    match trait_methods_cache.get().find(&trait_did) {
+    let mut trait_methods = cx.trait_methods_cache.borrow_mut();
+    match trait_methods.find(&trait_did) {
         Some(&methods) => methods,
         None => {
             let def_ids = ty::trait_method_def_ids(cx, trait_did);
             let methods = @def_ids.map(|d| ty::method(cx, *d));
-            trait_methods_cache.get().insert(trait_did, methods);
+            trait_methods.insert(trait_did, methods);
             methods
         }
     }
 }
 
 pub fn method(cx: &ctxt, id: ast::DefId) -> @Method {
-    let mut methods = cx.methods.borrow_mut();
-    lookup_locally_or_in_crate_store("methods", id, methods.get(), || {
+    lookup_locally_or_in_crate_store("methods", id,
+                                     &mut *cx.methods.borrow_mut(), || {
         @csearch::get_method(cx, id)
     })
 }
 
 pub fn trait_method_def_ids(cx: &ctxt, id: ast::DefId) -> @Vec<DefId> {
-    let mut trait_method_def_ids = cx.trait_method_def_ids.borrow_mut();
     lookup_locally_or_in_crate_store("trait_method_def_ids",
                                      id,
-                                     trait_method_def_ids.get(),
+                                     &mut *cx.trait_method_def_ids.borrow_mut(),
                                      || {
         @csearch::get_trait_method_def_ids(&cx.sess.cstore, id)
     })
 }
 
 pub fn impl_trait_ref(cx: &ctxt, id: ast::DefId) -> Option<@TraitRef> {
-    {
-        let mut impl_trait_cache = cx.impl_trait_cache.borrow_mut();
-        match impl_trait_cache.get().find(&id) {
-            Some(&ret) => { return ret; }
-            None => {}
-        }
+    match cx.impl_trait_cache.borrow().find(&id) {
+        Some(&ret) => { return ret; }
+        None => {}
     }
 
     let ret = if id.krate == ast::LOCAL_CRATE {
@@ -3868,17 +3833,15 @@ pub fn impl_trait_ref(cx: &ctxt, id: ast::DefId) -> Option<@TraitRef> {
         csearch::get_impl_trait(cx, id)
     };
 
-    let mut impl_trait_cache = cx.impl_trait_cache.borrow_mut();
-    impl_trait_cache.get().insert(id, ret);
+    cx.impl_trait_cache.borrow_mut().insert(id, ret);
     return ret;
 }
 
 pub fn trait_ref_to_def_id(tcx: &ctxt, tr: &ast::TraitRef) -> ast::DefId {
-    let def_map = tcx.def_map.borrow();
-    let def = def_map.get()
+    let def = *tcx.def_map.borrow()
                      .find(&tr.ref_id)
                      .expect("no def-map entry for trait");
-    ast_util::def_id_of_def(*def)
+    ast_util::def_id_of_def(def)
 }
 
 pub fn try_add_builtin_trait(tcx: &ctxt,
@@ -4021,8 +3984,7 @@ impl DtorKind {
 /* If struct_id names a struct with a dtor, return Some(the dtor's id).
    Otherwise return none. */
 pub fn ty_dtor(cx: &ctxt, struct_id: DefId) -> DtorKind {
-    let destructor_for_type = cx.destructor_for_type.borrow();
-    match destructor_for_type.get().find(&struct_id) {
+    match cx.destructor_for_type.borrow().find(&struct_id) {
         Some(&method_def_id) => {
             let flag = !has_attr(cx, struct_id, "unsafe_no_drop_flag");
 
@@ -4056,12 +4018,9 @@ pub fn type_is_empty(cx: &ctxt, t: t) -> bool {
 }
 
 pub fn enum_variants(cx: &ctxt, id: ast::DefId) -> @Vec<@VariantInfo> {
-    {
-        let enum_var_cache = cx.enum_var_cache.borrow();
-        match enum_var_cache.get().find(&id) {
-            Some(&variants) => return variants,
-            _ => { /* fallthrough */ }
-        }
+    match cx.enum_var_cache.borrow().find(&id) {
+        Some(&variants) => return variants,
+        _ => { /* fallthrough */ }
     }
 
     let result = if ast::LOCAL_CRATE != id.krate {
@@ -4129,11 +4088,8 @@ pub fn enum_variants(cx: &ctxt, id: ast::DefId) -> @Vec<@VariantInfo> {
         }
     };
 
-    {
-        let mut enum_var_cache = cx.enum_var_cache.borrow_mut();
-        enum_var_cache.get().insert(id, result);
-        result
-    }
+    cx.enum_var_cache.borrow_mut().insert(id, result);
+    result
 }
 
 
@@ -4160,25 +4116,23 @@ pub fn enum_variant_with_id(cx: &ctxt,
 pub fn lookup_item_type(cx: &ctxt,
                         did: ast::DefId)
                      -> ty_param_bounds_and_ty {
-    let mut tcache = cx.tcache.borrow_mut();
     lookup_locally_or_in_crate_store(
-        "tcache", did, tcache.get(),
+        "tcache", did, &mut *cx.tcache.borrow_mut(),
         || csearch::get_type(cx, did))
 }
 
 pub fn lookup_impl_vtables(cx: &ctxt,
                            did: ast::DefId)
                      -> typeck::impl_res {
-    let mut impl_vtables = cx.impl_vtables.borrow_mut();
     lookup_locally_or_in_crate_store(
-        "impl_vtables", did, impl_vtables.get(),
+        "impl_vtables", did, &mut *cx.impl_vtables.borrow_mut(),
         || csearch::get_impl_vtables(cx, did) )
 }
 
 /// Given the did of a trait, returns its canonical trait ref.
 pub fn lookup_trait_def(cx: &ctxt, did: ast::DefId) -> @ty::TraitDef {
     let mut trait_defs = cx.trait_defs.borrow_mut();
-    match trait_defs.get().find(&did) {
+    match trait_defs.find(&did) {
         Some(&trait_def) => {
             // The item is in this crate. The caller should have added it to the
             // type cache already
@@ -4187,7 +4141,7 @@ pub fn lookup_trait_def(cx: &ctxt, did: ast::DefId) -> @ty::TraitDef {
         None => {
             assert!(did.krate != ast::LOCAL_CRATE);
             let trait_def = @csearch::get_trait_def(cx, did);
-            trait_defs.get().insert(did, trait_def);
+            trait_defs.insert(did, trait_def);
             return trait_def;
         }
     }
@@ -4255,16 +4209,14 @@ pub fn lookup_field_type(tcx: &ctxt,
     let t = if id.krate == ast::LOCAL_CRATE {
         node_id_to_type(tcx, id.node)
     } else {
-        {
-            let mut tcache = tcx.tcache.borrow_mut();
-            match tcache.get().find(&id) {
-               Some(&ty_param_bounds_and_ty {ty, ..}) => ty,
-               None => {
-                   let tpt = csearch::get_field_type(tcx, struct_id, id);
-                   tcache.get().insert(id, tpt.clone());
-                   tpt.ty
-               }
-            }
+        let mut tcache = tcx.tcache.borrow_mut();
+        match tcache.find(&id) {
+           Some(&ty_param_bounds_and_ty {ty, ..}) => ty,
+           None => {
+               let tpt = csearch::get_field_type(tcx, struct_id, id);
+               tcache.insert(id, tpt.clone());
+               tpt.ty
+           }
         }
     };
     subst(tcx, substs, t)
@@ -4444,23 +4396,14 @@ pub fn normalize_ty(cx: &ctxt, t: t) -> t {
         fn tcx<'a>(&'a self) -> &'a ctxt { let TypeNormalizer(c) = *self; c }
 
         fn fold_ty(&mut self, t: ty::t) -> ty::t {
-            let normalized_opt = {
-                let normalized_cache = self.tcx().normalized_cache.borrow();
-                normalized_cache.get().find_copy(&t)
-            };
-            match normalized_opt {
-                Some(u) => {
-                    return u;
-                }
-                None => {
-                    let t_norm = ty_fold::super_fold_ty(self, t);
-                    let mut normalized_cache = self.tcx()
-                                                   .normalized_cache
-                                                   .borrow_mut();
-                    normalized_cache.get().insert(t, t_norm);
-                    return t_norm;
-                }
+            match self.tcx().normalized_cache.borrow().find_copy(&t) {
+                None => {}
+                Some(u) => return u
             }
+
+            let t_norm = ty_fold::super_fold_ty(self, t);
+            self.tcx().normalized_cache.borrow_mut().insert(t, t_norm);
+            return t_norm;
         }
 
         fn fold_vstore(&mut self, vstore: vstore) -> vstore {
@@ -4636,16 +4579,14 @@ pub fn count_traits_and_supertraits(tcx: &ctxt,
 
 pub fn get_tydesc_ty(tcx: &ctxt) -> Result<t, ~str> {
     tcx.lang_items.require(TyDescStructLangItem).map(|tydesc_lang_item| {
-        let intrinsic_defs = tcx.intrinsic_defs.borrow();
-        intrinsic_defs.get().find_copy(&tydesc_lang_item)
+        tcx.intrinsic_defs.borrow().find_copy(&tydesc_lang_item)
             .expect("Failed to resolve TyDesc")
     })
 }
 
 pub fn get_opaque_ty(tcx: &ctxt) -> Result<t, ~str> {
     tcx.lang_items.require(OpaqueStructLangItem).map(|opaque_lang_item| {
-        let intrinsic_defs = tcx.intrinsic_defs.borrow();
-        intrinsic_defs.get().find_copy(&opaque_lang_item)
+        tcx.intrinsic_defs.borrow().find_copy(&opaque_lang_item)
             .expect("Failed to resolve Opaque")
     })
 }
@@ -4672,9 +4613,8 @@ pub fn visitor_object_ty(tcx: &ctxt,
 }
 
 pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> @ItemVariances {
-    let mut item_variance_map = tcx.item_variance_map.borrow_mut();
     lookup_locally_or_in_crate_store(
-        "item_variance_map", item_id, item_variance_map.get(),
+        "item_variance_map", item_id, &mut *tcx.item_variance_map.borrow_mut(),
         || @csearch::get_item_variances(&tcx.sess.cstore, item_id))
 }
 
@@ -4684,18 +4624,17 @@ fn record_trait_implementation(tcx: &ctxt,
                                implementation: @Impl) {
     let implementation_list;
     let mut trait_impls = tcx.trait_impls.borrow_mut();
-    match trait_impls.get().find(&trait_def_id) {
+    match trait_impls.find(&trait_def_id) {
         None => {
             implementation_list = @RefCell::new(Vec::new());
-            trait_impls.get().insert(trait_def_id, implementation_list);
+            trait_impls.insert(trait_def_id, implementation_list);
         }
         Some(&existing_implementation_list) => {
             implementation_list = existing_implementation_list
         }
     }
 
-    let mut implementation_list = implementation_list.borrow_mut();
-    implementation_list.get().push(implementation);
+    implementation_list.borrow_mut().push(implementation);
 }
 
 /// Populates the type context with all the implementations for the given type
@@ -4705,11 +4644,8 @@ pub fn populate_implementations_for_type_if_necessary(tcx: &ctxt,
     if type_id.krate == LOCAL_CRATE {
         return
     }
-    {
-        let populated_external_types = tcx.populated_external_types.borrow();
-        if populated_external_types.get().contains(&type_id) {
-            return
-        }
+    if tcx.populated_external_types.borrow().contains(&type_id) {
+        return
     }
 
     csearch::each_implementation_for_type(&tcx.sess.cstore, type_id,
@@ -4729,9 +4665,8 @@ pub fn populate_implementations_for_type_if_necessary(tcx: &ctxt,
         // the map. This is a bit unfortunate.
         for method in implementation.methods.iter() {
             for source in method.provided_source.iter() {
-                let mut provided_method_sources =
-                    tcx.provided_method_sources.borrow_mut();
-                provided_method_sources.get().insert(method.def_id, *source);
+                tcx.provided_method_sources.borrow_mut()
+                   .insert(method.def_id, *source);
             }
         }
 
@@ -4739,30 +4674,23 @@ pub fn populate_implementations_for_type_if_necessary(tcx: &ctxt,
         if associated_traits.is_none() {
             let implementation_list;
             let mut inherent_impls = tcx.inherent_impls.borrow_mut();
-            match inherent_impls.get().find(&type_id) {
+            match inherent_impls.find(&type_id) {
                 None => {
                     implementation_list = @RefCell::new(Vec::new());
-                    inherent_impls.get().insert(type_id, implementation_list);
+                    inherent_impls.insert(type_id, implementation_list);
                 }
                 Some(&existing_implementation_list) => {
                     implementation_list = existing_implementation_list;
                 }
             }
-            {
-                let mut implementation_list =
-                    implementation_list.borrow_mut();
-                implementation_list.get().push(implementation);
-            }
+            implementation_list.borrow_mut().push(implementation);
         }
 
         // Store the implementation info.
-        let mut impls = tcx.impls.borrow_mut();
-        impls.get().insert(implementation_def_id, implementation);
+        tcx.impls.borrow_mut().insert(implementation_def_id, implementation);
     });
 
-    let mut populated_external_types = tcx.populated_external_types
-                                          .borrow_mut();
-    populated_external_types.get().insert(type_id);
+    tcx.populated_external_types.borrow_mut().insert(type_id);
 }
 
 /// Populates the type context with all the implementations for the given
@@ -4773,12 +4701,8 @@ pub fn populate_implementations_for_trait_if_necessary(
     if trait_id.krate == LOCAL_CRATE {
         return
     }
-    {
-        let populated_external_traits = tcx.populated_external_traits
-                                           .borrow();
-        if populated_external_traits.get().contains(&trait_id) {
-            return
-        }
+    if tcx.populated_external_traits.borrow().contains(&trait_id) {
+        return
     }
 
     csearch::each_implementation_for_trait(&tcx.sess.cstore, trait_id,
@@ -4792,20 +4716,16 @@ pub fn populate_implementations_for_trait_if_necessary(
         // the map. This is a bit unfortunate.
         for method in implementation.methods.iter() {
             for source in method.provided_source.iter() {
-                let mut provided_method_sources =
-                    tcx.provided_method_sources.borrow_mut();
-                provided_method_sources.get().insert(method.def_id, *source);
+                tcx.provided_method_sources.borrow_mut()
+                   .insert(method.def_id, *source);
             }
         }
 
         // Store the implementation info.
-        let mut impls = tcx.impls.borrow_mut();
-        impls.get().insert(implementation_def_id, implementation);
+        tcx.impls.borrow_mut().insert(implementation_def_id, implementation);
     });
 
-    let mut populated_external_traits = tcx.populated_external_traits
-                                           .borrow_mut();
-    populated_external_traits.get().insert(trait_id);
+    tcx.populated_external_traits.borrow_mut().insert(trait_id);
 }
 
 /// Given the def_id of an impl, return the def_id of the trait it implements.
@@ -4837,12 +4757,7 @@ pub fn trait_of_method(tcx: &ctxt, def_id: ast::DefId)
     if def_id.krate != LOCAL_CRATE {
         return csearch::get_trait_of_method(&tcx.sess.cstore, def_id, tcx);
     }
-    let method;
-    {
-        let methods = tcx.methods.borrow();
-        method = methods.get().find(&def_id).map(|method| *method);
-    }
-    match method {
+    match tcx.methods.borrow().find(&def_id).map(|m| *m) {
         Some(method) => {
             match method.container {
                 TraitContainer(def_id) => Some(def_id),
@@ -4861,14 +4776,10 @@ pub fn trait_of_method(tcx: &ctxt, def_id: ast::DefId)
 /// Otherwise, return `None`.
 pub fn trait_method_of_method(tcx: &ctxt,
                               def_id: ast::DefId) -> Option<ast::DefId> {
-    let method;
-    {
-        let methods = tcx.methods.borrow();
-        match methods.get().find(&def_id) {
-            Some(m) => method = *m,
-            None => return None,
-        }
-    }
+    let method = match tcx.methods.borrow().find(&def_id) {
+        Some(&m) => m,
+        None => return None,
+    };
     let name = method.ident.name;
     match trait_of_method(tcx, def_id) {
         Some(trait_did) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1009,13 +1009,13 @@ pub struct Generics {
 
 impl Generics {
     pub fn has_type_params(&self) -> bool {
-        !self.type_param_defs.deref().is_empty()
+        !self.type_param_defs.is_empty()
     }
     pub fn type_param_defs<'a>(&'a self) -> &'a [TypeParameterDef] {
-        self.type_param_defs.deref().as_slice()
+        self.type_param_defs.as_slice()
     }
     pub fn region_param_defs<'a>(&'a self) -> &'a [RegionParameterDef] {
-        self.region_param_defs.deref().as_slice()
+        self.region_param_defs.as_slice()
     }
 }
 

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -364,8 +364,7 @@ pub fn check_struct_pat(pcx: &pat_ctxt, pat_id: ast::NodeId, span: Span,
     let class_fields = ty::lookup_struct_fields(tcx, struct_id);
 
     // Check to ensure that the struct is the one specified.
-    let def_map = tcx.def_map.borrow();
-    match def_map.get().find(&pat_id) {
+    match tcx.def_map.borrow().find(&pat_id) {
         Some(&ast::DefStruct(supplied_def_id))
                 if supplied_def_id == struct_id => {
             // OK.
@@ -399,8 +398,7 @@ pub fn check_struct_like_enum_variant_pat(pcx: &pat_ctxt,
     let tcx = pcx.fcx.ccx.tcx;
 
     // Find the variant that was specified.
-    let def_map = tcx.def_map.borrow();
-    match def_map.get().find(&pat_id) {
+    match tcx.def_map.borrow().find(&pat_id) {
         Some(&ast::DefVariant(found_enum_id, variant_id, _))
                 if found_enum_id == enum_id => {
             // Get the struct fields from this struct-like enum variant.
@@ -470,9 +468,8 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
       }
       ast::PatEnum(..) |
       ast::PatIdent(..) if pat_is_const(tcx.def_map, pat) => {
-        let def_map = tcx.def_map.borrow();
-        let const_did = ast_util::def_id_of_def(def_map.get()
-                                                       .get_copy(&pat.id));
+        let const_did = ast_util::def_id_of_def(tcx.def_map.borrow()
+                                                   .get_copy(&pat.id));
         let const_tpt = ty::lookup_item_type(tcx, const_did);
         demand::suptype(fcx, pat.span, expected, const_tpt.ty);
         fcx.write_ty(pat.id, const_tpt.ty);
@@ -548,8 +545,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
                                          e, actual)})},
                                          Some(expected), ~"a structure pattern",
                                          None);
-                let def_map = tcx.def_map.borrow();
-                match def_map.get().find(&pat.id) {
+                match tcx.def_map.borrow().find(&pat.id) {
                     Some(&ast::DefStruct(supplied_def_id)) => {
                          check_struct_pat(pcx,
                                           pat.id,

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1110,7 +1110,7 @@ impl<'a> LookupContext<'a> {
         let m_regions =
             self.fcx.infcx().region_vars_for_defs(
                 self.span,
-                candidate.method_ty.generics.region_param_defs.deref().as_slice());
+                candidate.method_ty.generics.region_param_defs.as_slice());
         for &r in m_regions.iter() {
             all_regions.push(r);
         }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -466,8 +466,8 @@ impl<'a> LookupContext<'a> {
         ty::populate_implementations_for_trait_if_necessary(self.tcx(), trait_did);
 
         // Look for explicit implementations.
-        for impl_infos in self.tcx().trait_impls.borrow().get().find(&trait_did).iter() {
-            for impl_info in impl_infos.borrow().get().iter() {
+        for impl_infos in self.tcx().trait_impls.borrow().find(&trait_did).iter() {
+            for impl_info in impl_infos.borrow().iter() {
                 self.push_candidates_from_impl(*impl_info, true);
             }
         }
@@ -641,8 +641,8 @@ impl<'a> LookupContext<'a> {
         // metadata if necessary.
         ty::populate_implementations_for_type_if_necessary(self.tcx(), did);
 
-        for impl_infos in self.tcx().inherent_impls.borrow().get().find(&did).iter() {
-            for impl_info in impl_infos.borrow().get().iter() {
+        for impl_infos in self.tcx().inherent_impls.borrow().find(&did).iter() {
+            for impl_info in impl_infos.borrow().iter() {
                 self.push_candidates_from_impl(*impl_info, false);
             }
         }
@@ -1259,17 +1259,14 @@ impl<'a> LookupContext<'a> {
         let bad;
         match candidate.origin {
             MethodStatic(method_id) => {
-                let destructors = self.tcx().destructors.borrow();
-                bad = destructors.get().contains(&method_id);
+                bad = self.tcx().destructors.borrow().contains(&method_id);
             }
             // FIXME: does this properly enforce this on everything now
             // that self has been merged in? -sully
             MethodParam(MethodParam { trait_id: trait_id, .. }) |
             MethodObject(MethodObject { trait_id: trait_id, .. }) => {
-                let destructor_for_type = self.tcx()
-                                              .destructor_for_type
-                                              .borrow();
-                bad = destructor_for_type.get().contains_key(&trait_id);
+                bad = self.tcx().destructor_for_type.borrow()
+                          .contains_key(&trait_id);
             }
         }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -565,7 +565,7 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
                 fn_tpt.generics.type_param_defs(),
                 [],
                 [],
-                fn_tpt.generics.region_param_defs.deref().as_slice(),
+                fn_tpt.generics.region_param_defs.as_slice(),
                 body.id);
 
         check_bare_fn(ccx, decl, body, it.id, fn_tpt.ty, param_env);
@@ -3698,7 +3698,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
                         nsupplied = num_supplied_regions));
         }
 
-        fcx.infcx().region_vars_for_defs(span, tpt.generics.region_param_defs.deref().as_slice())
+        fcx.infcx().region_vars_for_defs(span, tpt.generics.region_param_defs.as_slice())
     };
     let regions = ty::NonerasedRegions(regions);
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -355,13 +355,11 @@ impl<'a> GatherLocalsVisitor<'a> {
                     // infer the variable's type
                     let var_id = self.fcx.infcx().next_ty_var_id();
                     let var_ty = ty::mk_var(self.fcx.tcx(), var_id);
-                    let mut locals = self.fcx.inh.locals.borrow_mut();
-                    locals.get().insert(nid, var_ty);
+                    self.fcx.inh.locals.borrow_mut().insert(nid, var_ty);
                 }
                 Some(typ) => {
                     // take type that the user specified
-                    let mut locals = self.fcx.inh.locals.borrow_mut();
-                    locals.get().insert(nid, typ);
+                    self.fcx.inh.locals.borrow_mut().insert(nid, typ);
                 }
             }
     }
@@ -375,13 +373,10 @@ impl<'a> Visitor<()> for GatherLocalsVisitor<'a> {
               _ => Some(self.fcx.to_ty(local.ty))
             };
             self.assign(local.id, o_ty);
-            {
-                let locals = self.fcx.inh.locals.borrow();
-                debug!("Local variable {} is assigned type {}",
-                       self.fcx.pat_to_str(local.pat),
-                       self.fcx.infcx().ty_to_str(
-                           locals.get().get_copy(&local.id)));
-            }
+            debug!("Local variable {} is assigned type {}",
+                   self.fcx.pat_to_str(local.pat),
+                   self.fcx.infcx().ty_to_str(
+                       self.fcx.inh.locals.borrow().get_copy(&local.id)));
             visit::walk_local(self, local, ());
 
     }
@@ -391,13 +386,10 @@ impl<'a> Visitor<()> for GatherLocalsVisitor<'a> {
               ast::PatIdent(_, ref path, _)
                   if pat_util::pat_is_binding(self.fcx.ccx.tcx.def_map, p) => {
                 self.assign(p.id, None);
-                {
-                    let locals = self.fcx.inh.locals.borrow();
-                    debug!("Pattern binding {} is assigned to {}",
-                           token::get_ident(path.segments.get(0).identifier),
-                           self.fcx.infcx().ty_to_str(
-                               locals.get().get_copy(&p.id)));
-                }
+                debug!("Pattern binding {} is assigned to {}",
+                       token::get_ident(path.segments.get(0).identifier),
+                       self.fcx.infcx().ty_to_str(
+                           self.fcx.inh.locals.borrow().get_copy(&p.id)));
               }
               _ => {}
             }
@@ -1007,8 +999,7 @@ impl<'a> FnCtxt<'a> {
     }
 
     pub fn local_ty(&self, span: Span, nid: ast::NodeId) -> ty::t {
-        let locals = self.inh.locals.borrow();
-        match locals.get().find(&nid) {
+        match self.inh.locals.borrow().find(&nid) {
             Some(&t) => t,
             None => {
                 self.tcx().sess.span_bug(
@@ -1026,8 +1017,7 @@ impl<'a> FnCtxt<'a> {
     pub fn write_ty(&self, node_id: ast::NodeId, ty: ty::t) {
         debug!("write_ty({}, {}) in fcx {}",
                node_id, ppaux::ty_to_str(self.tcx(), ty), self.tag());
-        let mut node_types = self.inh.node_types.borrow_mut();
-        node_types.get().insert(node_id, ty);
+        self.inh.node_types.borrow_mut().insert(node_id, ty);
     }
 
     pub fn write_substs(&self, node_id: ast::NodeId, substs: ty::substs) {
@@ -1037,8 +1027,7 @@ impl<'a> FnCtxt<'a> {
                    ty::substs_to_str(self.tcx(), &substs),
                    self.tag());
 
-            let mut node_type_substs = self.inh.node_type_substs.borrow_mut();
-            node_type_substs.get().insert(node_id, substs);
+            self.inh.node_type_substs.borrow_mut().insert(node_id, substs);
         }
     }
 
@@ -1067,8 +1056,7 @@ impl<'a> FnCtxt<'a> {
                             node_id: ast::NodeId,
                             adj: @ty::AutoAdjustment) {
         debug!("write_adjustment(node_id={:?}, adj={:?})", node_id, adj);
-        let mut adjustments = self.inh.adjustments.borrow_mut();
-        adjustments.get().insert(node_id, adj);
+        self.inh.adjustments.borrow_mut().insert(node_id, adj);
     }
 
     pub fn write_nil(&self, node_id: ast::NodeId) {
@@ -1090,8 +1078,7 @@ impl<'a> FnCtxt<'a> {
     }
 
     pub fn expr_ty(&self, ex: &ast::Expr) -> ty::t {
-        let node_types = self.inh.node_types.borrow();
-        match node_types.get().find(&ex.id) {
+        match self.inh.node_types.borrow().find(&ex.id) {
             Some(&t) => t,
             None => {
                 self.tcx().sess.bug(format!("no type for expr in fcx {}",
@@ -1101,7 +1088,7 @@ impl<'a> FnCtxt<'a> {
     }
 
     pub fn node_ty(&self, id: ast::NodeId) -> ty::t {
-        match self.inh.node_types.borrow().get().find(&id) {
+        match self.inh.node_types.borrow().find(&id) {
             Some(&t) => t,
             None => {
                 self.tcx().sess.bug(
@@ -1113,7 +1100,7 @@ impl<'a> FnCtxt<'a> {
     }
 
     pub fn node_ty_substs(&self, id: ast::NodeId) -> ty::substs {
-        match self.inh.node_type_substs.borrow().get().find(&id) {
+        match self.inh.node_type_substs.borrow().find(&id) {
             Some(ts) => (*ts).clone(),
             None => {
                 self.tcx().sess.bug(
@@ -1125,7 +1112,7 @@ impl<'a> FnCtxt<'a> {
     }
 
     pub fn method_ty_substs(&self, id: ast::NodeId) -> ty::substs {
-        match self.inh.method_map.borrow().get().find(&MethodCall::expr(id)) {
+        match self.inh.method_map.borrow().find(&MethodCall::expr(id)) {
             Some(method) => method.substs.clone(),
             None => {
                 self.tcx().sess.bug(
@@ -1140,8 +1127,7 @@ impl<'a> FnCtxt<'a> {
                               id: ast::NodeId,
                               f: |&ty::substs| -> bool)
                               -> bool {
-        let node_type_substs = self.inh.node_type_substs.borrow();
-        match node_type_substs.get().find(&id) {
+        match self.inh.node_type_substs.borrow().find(&id) {
             Some(s) => f(s),
             None => true
         }
@@ -1327,7 +1313,7 @@ fn try_overloaded_deref(fcx: &FnCtxt,
             let ref_ty = ty::ty_fn_ret(method.ty);
             match method_call {
                 Some(method_call) => {
-                    fcx.inh.method_map.borrow_mut().get().insert(method_call, method);
+                    fcx.inh.method_map.borrow_mut().insert(method_call, method);
                 }
                 None => {}
             }
@@ -1908,7 +1894,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             Some(method) => {
                 let method_ty = method.ty;
                 let method_call = MethodCall::expr(expr.id);
-                fcx.inh.method_map.borrow_mut().get().insert(method_call, method);
+                fcx.inh.method_map.borrow_mut().insert(method_call, method);
                 method_ty
             }
             None => {
@@ -1998,7 +1984,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 let method_ty = method.ty;
                 // HACK(eddyb) Fully qualified path to work around a resolve bug.
                 let method_call = ::middle::typeck::MethodCall::expr(op_ex.id);
-                fcx.inh.method_map.borrow_mut().get().insert(method_call, method);
+                fcx.inh.method_map.borrow_mut().insert(method_call, method);
                 check_method_argument_types(fcx, op_ex.span,
                                             method_ty, op_ex,
                                             args, DoDerefArgs)
@@ -3131,8 +3117,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprStruct(ref path, ref fields, base_expr) => {
         // Resolve the path.
-        let def_map = tcx.def_map.borrow();
-        match def_map.get().find(&id) {
+        match tcx.def_map.borrow().find(&id) {
             Some(&ast::DefStruct(type_def_id)) => {
                 check_struct_constructor(fcx, id, expr.span, type_def_id,
                                          fields.as_slice(), base_expr);
@@ -3323,8 +3308,8 @@ pub fn check_block_with_expected(fcx: &FnCtxt,
                                  expected: Option<ty::t>) {
     let prev = {
         let mut fcx_ps = fcx.ps.borrow_mut();
-        let purity_state = fcx_ps.get().recurse(blk);
-        replace(fcx_ps.get(), purity_state)
+        let purity_state = fcx_ps.recurse(blk);
+        replace(&mut *fcx_ps, purity_state)
     };
 
     fcx.with_region_lb(blk.id, || {
@@ -3394,10 +3379,7 @@ pub fn check_const(ccx: &CrateCtxt,
     let inh = blank_inherited_fields(ccx);
     let rty = ty::node_id_to_type(ccx.tcx, id);
     let fcx = blank_fn_ctxt(ccx, &inh, rty, e.id);
-    let declty = {
-        let tcache = fcx.ccx.tcx.tcache.borrow();
-        tcache.get().get(&local_def(id)).ty
-    };
+    let declty = fcx.ccx.tcx.tcache.borrow().get(&local_def(id)).ty;
     check_const_with_ty(&fcx, sp, e, declty);
 }
 
@@ -3608,10 +3590,7 @@ pub fn check_enum_variants(ccx: &CrateCtxt,
     let variants = do_check(ccx, vs, id, hint);
 
     // cache so that ty::enum_variants won't repeat this work
-    {
-        let mut enum_var_cache = ccx.tcx.enum_var_cache.borrow_mut();
-        enum_var_cache.get().insert(local_def(id), @variants);
-    }
+    ccx.tcx.enum_var_cache.borrow_mut().insert(local_def(id), @variants);
 
     // Check that it is possible to represent this enum.
     check_representable(ccx.tcx, sp, id, "enum");
@@ -3958,8 +3937,7 @@ pub fn may_break(cx: &ty::ctxt, id: ast::NodeId, b: ast::P<ast::Block>) -> bool 
     (block_query(b, |e| {
         match e.node {
             ast::ExprBreak(Some(_)) => {
-                let def_map = cx.def_map.borrow();
-                match def_map.get().find(&e.id) {
+                match cx.def_map.borrow().find(&e.id) {
                     Some(&ast::DefLabel(loop_id)) if id == loop_id => true,
                     _ => false,
                 }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -666,12 +666,11 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
             debug!("vtable resolution on parameter bounds for method call {}",
                    ex.repr(fcx.tcx()));
             let type_param_defs = ty::method_call_type_param_defs(cx.tcx, method.origin);
-            if has_trait_bounds(type_param_defs.deref().as_slice()) {
+            if has_trait_bounds(type_param_defs.as_slice()) {
                 let substs = fcx.method_ty_substs(ex.id);
                 let vcx = fcx.vtable_context();
                 let vtbls = lookup_vtables(&vcx, ex.span,
-                                           type_param_defs.deref()
-                                                          .as_slice(),
+                                           type_param_defs.as_slice(),
                                            &substs, is_early);
                 if !is_early {
                     insert_vtables(fcx, ex.id, vtbls);
@@ -780,7 +779,7 @@ pub fn resolve_impl(tcx: &ty::ctxt,
 pub fn trans_resolve_method(tcx: &ty::ctxt, id: ast::NodeId,
                             substs: &ty::substs) -> Option<vtable_res> {
     let generics = ty::lookup_item_type(tcx, ast_util::local_def(id)).generics;
-    let type_param_defs = generics.type_param_defs.deref();
+    let type_param_defs = &*generics.type_param_defs;
     if has_trait_bounds(type_param_defs.as_slice()) {
         let vcx = VtableContext {
             infcx: &infer::new_infer_ctxt(tcx),

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -82,8 +82,7 @@ pub fn collect_item_types(ccx: &CrateCtxt, krate: &ast::Crate) {
                               lang_item: ast::DefId) {
         let ty::ty_param_bounds_and_ty { ty: ty, .. } =
             ccx.get_item_ty(lang_item);
-        let mut intrinsic_defs = ccx.tcx.intrinsic_defs.borrow_mut();
-        intrinsic_defs.get().insert(lang_item, ty);
+        ccx.tcx.intrinsic_defs.borrow_mut().insert(lang_item, ty);
     }
 
     match ccx.tcx.lang_items.ty_desc() {
@@ -180,10 +179,7 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
             ty: result_ty
         };
 
-        {
-            let mut tcache = tcx.tcache.borrow_mut();
-            tcache.get().insert(local_def(variant.node.id), tpt);
-        }
+        tcx.tcache.borrow_mut().insert(local_def(variant.node.id), tpt);
 
         write_ty_to_tcx(tcx, variant.node.id, result_ty);
     }
@@ -221,8 +217,8 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                                   &trait_ty_generics);
                         }
 
-                        let mut methods = tcx.methods.borrow_mut();
-                        methods.get().insert(ty_method.def_id, ty_method);
+                        tcx.methods.borrow_mut().insert(ty_method.def_id,
+                                                        ty_method);
                     }
 
                     // Add an entry mapping
@@ -238,13 +234,10 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                     });
 
                     let trait_def_id = local_def(trait_id);
-                    let mut trait_method_def_ids = tcx.trait_method_def_ids
-                                                      .borrow_mut();
-                    trait_method_def_ids.get()
-                                        .insert(trait_def_id,
-                                                @method_def_ids.iter()
-                                                               .map(|x| *x)
-                                                               .collect());
+                    tcx.trait_method_def_ids.borrow_mut()
+                        .insert(trait_def_id, @method_def_ids.iter()
+                                                             .map(|x| *x)
+                                                             .collect());
                 }
                 _ => {} // Ignore things that aren't traits.
             }
@@ -372,8 +365,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                ty.repr(tcx),
                substs.repr(tcx));
 
-        let mut tcache = tcx.tcache.borrow_mut();
-        tcache.get().insert(m.def_id,
+        tcx.tcache.borrow_mut().insert(m.def_id,
                           ty_param_bounds_and_ty {
                               generics: ty::Generics {
                                   type_param_defs: Rc::new(new_type_param_defs),
@@ -423,10 +415,7 @@ pub fn ensure_supertraits(ccx: &CrateCtxt,
 
     // Called only the first time trait_def_of_item is called.
     // Supertraits are ensured at the same time.
-    {
-        let supertraits = tcx.supertraits.borrow();
-        assert!(!supertraits.get().contains_key(&local_def(id)));
-    }
+    assert!(!tcx.supertraits.borrow().contains_key(&local_def(id)));
 
     let self_ty = ty::mk_self(ccx.tcx, local_def(id));
     let mut ty_trait_refs: Vec<@ty::TraitRef> = Vec::new();
@@ -451,8 +440,7 @@ pub fn ensure_supertraits(ccx: &CrateCtxt,
         }
     }
 
-    let mut supertraits = tcx.supertraits.borrow_mut();
-    supertraits.get().insert(local_def(id), @ty_trait_refs);
+    tcx.supertraits.borrow_mut().insert(local_def(id), @ty_trait_refs);
     bounds
 }
 
@@ -462,8 +450,7 @@ pub fn convert_field(ccx: &CrateCtxt,
     let tt = ccx.to_ty(&ExplicitRscope, v.node.ty);
     write_ty_to_tcx(ccx.tcx, v.node.id, tt);
     /* add the field to the tcache */
-    let mut tcache = ccx.tcx.tcache.borrow_mut();
-    tcache.get().insert(local_def(v.node.id),
+    ccx.tcx.tcache.borrow_mut().insert(local_def(v.node.id),
                           ty::ty_param_bounds_and_ty {
                               generics: struct_generics.clone(),
                               ty: tt
@@ -499,32 +486,28 @@ fn convert_methods(ccx: &CrateCtxt,
                 m.ident.repr(ccx.tcx),
                 m.id,
                 fty.repr(ccx.tcx));
-        {
-            let mut tcache = tcx.tcache.borrow_mut();
-            tcache.get().insert(
-                local_def(m.id),
+        tcx.tcache.borrow_mut().insert(
+            local_def(m.id),
 
-                // n.b.: the type of a method is parameterized by both
-                // the parameters on the receiver and those on the method
-                // itself
-                ty_param_bounds_and_ty {
-                    generics: ty::Generics {
-                        type_param_defs: Rc::new(vec::append(
-                            Vec::from_slice(
-                                rcvr_ty_generics.type_param_defs()),
-                            m_ty_generics.type_param_defs())),
-                        region_param_defs: Rc::new(vec::append(
-                                Vec::from_slice(rcvr_ty_generics.region_param_defs()),
-                                m_ty_generics.region_param_defs())),
-                    },
-                    ty: fty
-                });
-        }
+            // n.b.: the type of a method is parameterized by both
+            // the parameters on the receiver and those on the method
+            // itself
+            ty_param_bounds_and_ty {
+                generics: ty::Generics {
+                    type_param_defs: Rc::new(vec::append(
+                        Vec::from_slice(
+                            rcvr_ty_generics.type_param_defs()),
+                        m_ty_generics.type_param_defs())),
+                    region_param_defs: Rc::new(vec::append(
+                            Vec::from_slice(rcvr_ty_generics.region_param_defs()),
+                            m_ty_generics.region_param_defs())),
+                },
+                ty: fty
+            });
 
         write_ty_to_tcx(tcx, m.id, fty);
 
-        let mut methods = tcx.methods.borrow_mut();
-        methods.get().insert(mty.def_id, mty);
+        tcx.methods.borrow_mut().insert(mty.def_id, mty);
     }
 
     fn ty_of_method(ccx: &CrateCtxt,
@@ -605,13 +588,10 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
             let selfty = ccx.to_ty(&ExplicitRscope, selfty);
             write_ty_to_tcx(tcx, it.id, selfty);
 
-            {
-                let mut tcache = tcx.tcache.borrow_mut();
-                tcache.get().insert(local_def(it.id),
-                                    ty_param_bounds_and_ty {
-                                        generics: ty_generics.clone(),
-                                        ty: selfty});
-            }
+            tcx.tcache.borrow_mut().insert(local_def(it.id),
+                                ty_param_bounds_and_ty {
+                                    generics: ty_generics.clone(),
+                                    ty: selfty});
 
             // If there is a trait reference, treat the methods as always public.
             // This is to work around some incorrect behavior in privacy checking:
@@ -670,10 +650,7 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
             let tpt = ty_of_item(ccx, it);
             write_ty_to_tcx(tcx, it.id, tpt.ty);
 
-            {
-                let mut tcache = tcx.tcache.borrow_mut();
-                tcache.get().insert(local_def(it.id), tpt.clone());
-            }
+            tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
 
             convert_struct(ccx, struct_def, tpt, it.id);
         },
@@ -719,32 +696,23 @@ pub fn convert_struct(ccx: &CrateCtxt,
                 // Enum-like.
                 write_ty_to_tcx(tcx, ctor_id, selfty);
 
-                {
-                    let mut tcache = tcx.tcache.borrow_mut();
-                    tcache.get().insert(local_def(ctor_id), tpt);
-                }
+                tcx.tcache.borrow_mut().insert(local_def(ctor_id), tpt);
             } else if struct_def.fields.get(0).node.kind ==
                     ast::UnnamedField {
                 // Tuple-like.
-                let inputs = {
-                    let tcache = tcx.tcache.borrow();
-                    struct_def.fields.map(
-                        |field| tcache.get().get(
-                            &local_def(field.node.id)).ty)
-                };
+                let inputs = struct_def.fields.map(
+                        |field| tcx.tcache.borrow().get(
+                            &local_def(field.node.id)).ty);
                 let ctor_fn_ty = ty::mk_ctor_fn(tcx,
                                                 ctor_id,
                                                 inputs.as_slice(),
                                                 selfty);
                 write_ty_to_tcx(tcx, ctor_id, ctor_fn_ty);
-                {
-                    let mut tcache = tcx.tcache.borrow_mut();
-                    tcache.get().insert(local_def(ctor_id),
-                                      ty_param_bounds_and_ty {
-                        generics: tpt.generics,
-                        ty: ctor_fn_ty
-                    });
-                }
+                tcx.tcache.borrow_mut().insert(local_def(ctor_id),
+                                  ty_param_bounds_and_ty {
+                    generics: tpt.generics,
+                    ty: ctor_fn_ty
+                });
             }
         }
     }
@@ -764,8 +732,7 @@ pub fn convert_foreign(ccx: &CrateCtxt, i: &ast::ForeignItem) {
     let tpt = ty_of_foreign_item(ccx, i, abis);
     write_ty_to_tcx(ccx.tcx, i.id, tpt.ty);
 
-    let mut tcache = ccx.tcx.tcache.borrow_mut();
-    tcache.get().insert(local_def(i.id), tpt);
+    ccx.tcx.tcache.borrow_mut().insert(local_def(i.id), tpt);
 }
 
 pub fn instantiate_trait_ref(ccx: &CrateCtxt,
@@ -787,8 +754,8 @@ pub fn instantiate_trait_ref(ccx: &CrateCtxt,
                 astconv::ast_path_to_trait_ref(
                     ccx, &rscope, trait_did, Some(self_ty), &ast_trait_ref.path);
 
-            let mut trait_refs = ccx.tcx.trait_refs.borrow_mut();
-            trait_refs.get().insert(ast_trait_ref.ref_id, trait_ref);
+            ccx.tcx.trait_refs.borrow_mut().insert(ast_trait_ref.ref_id,
+                                                   trait_ref);
             return trait_ref;
         }
         _ => {
@@ -815,12 +782,9 @@ fn get_trait_def(ccx: &CrateCtxt, trait_id: ast::DefId) -> @ty::TraitDef {
 pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::Item) -> @ty::TraitDef {
     let def_id = local_def(it.id);
     let tcx = ccx.tcx;
-    {
-        let trait_defs = tcx.trait_defs.borrow();
-        match trait_defs.get().find(&def_id) {
-          Some(&def) => return def,
-          _ => {}
-        }
+    match tcx.trait_defs.borrow().find(&def_id) {
+        Some(&def) => return def,
+        _ => {}
     }
 
     match it.node {
@@ -837,8 +801,7 @@ pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::Item) -> @ty::TraitDef {
             let trait_def = @ty::TraitDef {generics: ty_generics,
                                            bounds: bounds,
                                            trait_ref: trait_ref};
-            let mut trait_defs = tcx.trait_defs.borrow_mut();
-            trait_defs.get().insert(def_id, trait_def);
+            tcx.trait_defs.borrow_mut().insert(def_id, trait_def);
             return trait_def;
         }
         ref s => {
@@ -853,20 +816,16 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
                   -> ty::ty_param_bounds_and_ty {
     let def_id = local_def(it.id);
     let tcx = ccx.tcx;
-    {
-        let tcache = tcx.tcache.borrow();
-        match tcache.get().find(&def_id) {
-            Some(tpt) => return tpt.clone(),
-            _ => {}
-        }
+    match tcx.tcache.borrow().find(&def_id) {
+        Some(tpt) => return tpt.clone(),
+        _ => {}
     }
     match it.node {
         ast::ItemStatic(t, _, _) => {
             let typ = ccx.to_ty(&ExplicitRscope, t);
             let tpt = no_params(typ);
 
-            let mut tcache = tcx.tcache.borrow_mut();
-            tcache.get().insert(local_def(it.id), tpt.clone());
+            tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
         ast::ItemFn(decl, purity, abi, ref generics, _) => {
@@ -885,17 +844,13 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
                     it.id,
                     ppaux::ty_to_str(tcx, tpt.ty));
 
-            let mut tcache = ccx.tcx.tcache.borrow_mut();
-            tcache.get().insert(local_def(it.id), tpt.clone());
+            ccx.tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
         ast::ItemTy(t, ref generics) => {
-            {
-                let mut tcache = tcx.tcache.borrow_mut();
-                match tcache.get().find(&local_def(it.id)) {
-                    Some(tpt) => return tpt.clone(),
-                    None => { }
-                }
+            match tcx.tcache.borrow_mut().find(&local_def(it.id)) {
+                Some(tpt) => return tpt.clone(),
+                None => { }
             }
 
             let tpt = {
@@ -906,8 +861,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
                 }
             };
 
-            let mut tcache = tcx.tcache.borrow_mut();
-            tcache.get().insert(local_def(it.id), tpt.clone());
+            tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
         ast::ItemEnum(_, ref generics) => {
@@ -920,8 +874,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
                 ty: t
             };
 
-            let mut tcache = tcx.tcache.borrow_mut();
-            tcache.get().insert(local_def(it.id), tpt.clone());
+            tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
         ast::ItemTrait(..) => {
@@ -938,8 +891,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
                 ty: t
             };
 
-            let mut tcache = tcx.tcache.borrow_mut();
-            tcache.get().insert(local_def(it.id), tpt.clone());
+            tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
         ast::ItemImpl(..) | ast::ItemMod(_) |
@@ -997,7 +949,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
         type_param_defs: Rc::new(ty_params.iter().enumerate().map(|(offset, param)| {
             let existing_def_opt = {
                 let ty_param_defs = ccx.tcx.ty_param_defs.borrow();
-                ty_param_defs.get().find(&param.id).map(|&def| def)
+                ty_param_defs.find(&param.id).map(|&def| def)
             };
             existing_def_opt.unwrap_or_else(|| {
                 let param_ty = ty::param_ty {idx: base_index + offset,
@@ -1011,8 +963,7 @@ pub fn ty_generics(ccx: &CrateCtxt,
                     default: default
                 };
                 debug!("def for param: {}", def.repr(ccx.tcx));
-                let mut ty_param_defs = ccx.tcx.ty_param_defs.borrow_mut();
-                ty_param_defs.get().insert(param.id, def);
+                ccx.tcx.ty_param_defs.borrow_mut().insert(param.id, def);
                 def
             })
         }).collect()),
@@ -1100,8 +1051,7 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
         ty: t_fn
     };
 
-    let mut tcache = ccx.tcx.tcache.borrow_mut();
-    tcache.get().insert(def_id, tpt.clone());
+    ccx.tcx.tcache.borrow_mut().insert(def_id, tpt.clone());
     return tpt;
 }
 

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -338,8 +338,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
         let mut new_type_param_defs = Vec::new();
         let substd_type_param_defs =
             trait_ty_generics.type_param_defs.subst(tcx, &substs);
-        new_type_param_defs.push_all(substd_type_param_defs.deref()
-                                                           .as_slice());
+        new_type_param_defs.push_all(substd_type_param_defs.as_slice());
 
         // add in the "self" type parameter
         let self_trait_def = get_trait_def(ccx, local_def(trait_id));
@@ -356,8 +355,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
 
         // add in the type parameters from the method
         let substd_type_param_defs = m.generics.type_param_defs.subst(tcx, &substs);
-        new_type_param_defs.push_all(substd_type_param_defs.deref()
-                                                           .as_slice());
+        new_type_param_defs.push_all(substd_type_param_defs.as_slice());
 
         debug!("static method {} type_param_defs={} ty={}, substs={}",
                m.def_id.repr(tcx),

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -757,8 +757,7 @@ impl<'a> Rebuilder<'a> {
 
     fn offset_cur_anon(&self) {
         let mut anon = self.cur_anon.get();
-        let inserted_anons = self.inserted_anons.borrow();
-        while inserted_anons.get().contains(&anon) {
+        while self.inserted_anons.borrow().contains(&anon) {
             anon += 1;
         }
         self.cur_anon.set(anon);
@@ -770,8 +769,7 @@ impl<'a> Rebuilder<'a> {
     }
 
     fn track_anon(&self, anon: uint) {
-        let mut inserted_anons = self.inserted_anons.borrow_mut();
-        inserted_anons.get().insert(anon);
+        self.inserted_anons.borrow_mut().insert(anon);
     }
 
     fn rebuild_generics(&self,
@@ -845,8 +843,7 @@ impl<'a> Rebuilder<'a> {
                     ty_queue.push(mut_ty.ty);
                 }
                 ast::TyPath(ref path, _, id) => {
-                    let def_map = self.tcx.def_map.borrow();
-                    let a_def = match def_map.get().find(&id) {
+                    let a_def = match self.tcx.def_map.borrow().find(&id) {
                         None => self.tcx.sess.fatal(format!("unbound path {}",
                                                     pprust::path_to_str(path))),
                         Some(&d) => d
@@ -1258,8 +1255,7 @@ impl LifeGiver {
             if !self.taken.contains(&s) {
                 lifetime = name_to_dummy_lifetime(
                                     token::str_to_ident(s.as_slice()).name);
-                let mut generated = self.generated.borrow_mut();
-                generated.get().push(lifetime);
+                self.generated.borrow_mut().push(lifetime);
                 break;
             }
             self.inc_counter();

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -530,25 +530,21 @@ impl<'a> InferCtxt<'a> {
     }
 
     pub fn start_snapshot(&self) -> Snapshot {
-        let ty_var_bindings = self.ty_var_bindings.borrow();
-        let int_var_bindings = self.int_var_bindings.borrow();
-        let float_var_bindings = self.float_var_bindings.borrow();
         Snapshot {
-            ty_var_bindings_len: ty_var_bindings.get().bindings.len(),
-            int_var_bindings_len: int_var_bindings.get().bindings.len(),
-            float_var_bindings_len: float_var_bindings.get().bindings.len(),
+            ty_var_bindings_len: self.ty_var_bindings.borrow().bindings.len(),
+            int_var_bindings_len: self.int_var_bindings.borrow().bindings.len(),
+            float_var_bindings_len: self.float_var_bindings.borrow().bindings.len(),
             region_vars_snapshot: self.region_vars.start_snapshot(),
         }
     }
 
     pub fn rollback_to(&self, snapshot: &Snapshot) {
         debug!("rollback!");
-        let mut ty_var_bindings = self.ty_var_bindings.borrow_mut();
-        let mut int_var_bindings = self.int_var_bindings.borrow_mut();
-        let mut float_var_bindings = self.float_var_bindings.borrow_mut();
-        rollback_to(ty_var_bindings.get(), snapshot.ty_var_bindings_len);
-        rollback_to(int_var_bindings.get(), snapshot.int_var_bindings_len);
-        rollback_to(float_var_bindings.get(),
+        rollback_to(&mut *self.ty_var_bindings.borrow_mut(),
+                    snapshot.ty_var_bindings_len);
+        rollback_to(&mut *self.int_var_bindings.borrow_mut(),
+                    snapshot.int_var_bindings_len);
+        rollback_to(&mut *self.float_var_bindings.borrow_mut(),
                     snapshot.float_var_bindings_len);
 
         self.region_vars.rollback_to(snapshot.region_vars_snapshot);
@@ -562,10 +558,8 @@ impl<'a> InferCtxt<'a> {
         indent(|| {
             let r = self.try(|| f());
 
-            let mut ty_var_bindings = self.ty_var_bindings.borrow_mut();
-            let mut int_var_bindings = self.int_var_bindings.borrow_mut();
-            ty_var_bindings.get().bindings.truncate(0);
-            int_var_bindings.get().bindings.truncate(0);
+            self.ty_var_bindings.borrow_mut().bindings.truncate(0);
+            self.int_var_bindings.borrow_mut().bindings.truncate(0);
             self.region_vars.commit();
             r
         })
@@ -614,7 +608,7 @@ impl<'a> InferCtxt<'a> {
         self.ty_var_counter.set(id + 1);
         {
             let mut ty_var_bindings = self.ty_var_bindings.borrow_mut();
-            let vals = &mut ty_var_bindings.get().vals;
+            let vals = &mut ty_var_bindings.vals;
             vals.insert(id, Root(Bounds { lb: None, ub: None }, 0u));
         }
         return TyVid(id);
@@ -632,7 +626,7 @@ impl<'a> InferCtxt<'a> {
         let mut int_var_counter = self.int_var_counter.get();
         let mut int_var_bindings = self.int_var_bindings.borrow_mut();
         let result = IntVid(next_simple_var(&mut int_var_counter,
-                                            int_var_bindings.get()));
+                                            &mut *int_var_bindings));
         self.int_var_counter.set(int_var_counter);
         result
     }
@@ -645,7 +639,7 @@ impl<'a> InferCtxt<'a> {
         let mut float_var_counter = self.float_var_counter.get();
         let mut float_var_bindings = self.float_var_bindings.borrow_mut();
         let result = FloatVid(next_simple_var(&mut float_var_counter,
-                                              float_var_bindings.get()));
+                                              &mut *float_var_bindings));
         self.float_var_counter.set(float_var_counter);
         result
     }

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -75,8 +75,7 @@ impl<'a> UnifyInferCtxtMethods for InferCtxt<'a> {
 
         let tcx = self.tcx;
         let vb = UnifyVid::appropriate_vals_and_bindings(self);
-        let mut vb = vb.borrow_mut();
-        return helper(tcx, vb.get(), vid);
+        return helper(tcx, &mut *vb.borrow_mut(), vid);
 
         fn helper<T:Clone, V:Clone+Eq+Vid>(
             tcx: &ty::ctxt,
@@ -123,9 +122,9 @@ impl<'a> UnifyInferCtxtMethods for InferCtxt<'a> {
 
         let vb = UnifyVid::appropriate_vals_and_bindings(self);
         let mut vb = vb.borrow_mut();
-        let old_v = (*vb.get().vals.get(&vid.to_uint())).clone();
-        vb.get().bindings.push((vid.clone(), old_v));
-        vb.get().vals.insert(vid.to_uint(), new_v);
+        let old_v = (*vb.vals.get(&vid.to_uint())).clone();
+        vb.bindings.push((vid.clone(), old_v));
+        vb.vals.insert(vid.to_uint(), new_v);
     }
 
     fn unify<T:Clone + InferStr,

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -252,8 +252,7 @@ pub struct CrateCtxt<'a> {
 pub fn write_ty_to_tcx(tcx: &ty::ctxt, node_id: ast::NodeId, ty: ty::t) {
     debug!("write_ty_to_tcx({}, {})", node_id, ppaux::ty_to_str(tcx, ty));
     assert!(!ty::type_needs_infer(ty));
-    let mut node_types = tcx.node_types.borrow_mut();
-    node_types.get().insert(node_id as uint, ty);
+    tcx.node_types.borrow_mut().insert(node_id as uint, ty);
 }
 pub fn write_substs_to_tcx(tcx: &ty::ctxt,
                            node_id: ast::NodeId,
@@ -263,8 +262,7 @@ pub fn write_substs_to_tcx(tcx: &ty::ctxt,
                substs.map(|t| ppaux::ty_to_str(tcx, *t)));
         assert!(substs.iter().all(|t| !ty::type_needs_infer(*t)));
 
-        let mut node_type_substs = tcx.node_type_substs.borrow_mut();
-        node_type_substs.get().insert(node_id, substs);
+        tcx.node_type_substs.borrow_mut().insert(node_id, substs);
     }
 }
 pub fn write_tpt_to_tcx(tcx: &ty::ctxt,
@@ -277,8 +275,7 @@ pub fn write_tpt_to_tcx(tcx: &ty::ctxt,
 }
 
 pub fn lookup_def_tcx(tcx:&ty::ctxt, sp: Span, id: ast::NodeId) -> ast::Def {
-    let def_map = tcx.def_map.borrow();
-    match def_map.get().find(&id) {
+    match tcx.def_map.borrow().find(&id) {
         Some(&x) => x,
         _ => {
             tcx.sess.span_fatal(sp, "internal error looking up a definition")

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -359,10 +359,7 @@ impl<'a> Visitor<()> for TermsContext<'a> {
                 // "invalid item id" from "item id with no
                 // parameters".
                 if self.num_inferred() == inferreds_on_entry {
-                    let mut item_variance_map = self.tcx
-                                                    .item_variance_map
-                                                    .borrow_mut();
-                    let newly_added = item_variance_map.get().insert(
+                    let newly_added = self.tcx.item_variance_map.borrow_mut().insert(
                         ast_util::local_def(item.id),
                         self.empty_variances);
                     assert!(newly_added);
@@ -944,9 +941,8 @@ impl<'a> SolveContext<'a> {
                 tcx.sess.span_err(tcx.map.span(item_id), found);
             }
 
-            let mut item_variance_map = tcx.item_variance_map.borrow_mut();
-            let newly_added = item_variance_map.get().insert(item_def_id,
-                                                             @item_variances);
+            let newly_added = tcx.item_variance_map.borrow_mut()
+                                 .insert(item_def_id, @item_variances);
             assert!(newly_added);
         }
     }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -459,9 +459,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
       ty_infer(infer_ty) => infer_ty.to_str(),
       ty_err => ~"[type error]",
       ty_param(param_ty {idx: id, def_id: did}) => {
-          let ty_param_defs = cx.ty_param_defs.borrow();
-          let param_def = ty_param_defs.get().find(&did.node);
-          let ident = match param_def {
+          let ident = match cx.ty_param_defs.borrow().find(&did.node) {
               Some(def) => token::get_ident(def.ident).get().to_str(),
               // This should not happen...
               None => format!("BUG[{:?}]", id)

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1181,7 +1181,7 @@ impl ToSource for syntax::codemap::Span {
 fn lit_to_str(lit: &ast::Lit) -> ~str {
     match lit.node {
         ast::LitStr(ref st, _) => st.get().to_owned(),
-        ast::LitBinary(ref data) => format!("{:?}", data.deref().as_slice()),
+        ast::LitBinary(ref data) => format!("{:?}", data.as_slice()),
         ast::LitChar(c) => ~"'" + std::char::from_u32(c).unwrap().to_str() + "'",
         ast::LitInt(i, _t) => i.to_str(),
         ast::LitUint(u, _t) => u.to_str(),

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1229,16 +1229,15 @@ fn resolve_type(path: Path, tpbs: Option<Vec<TyParamBound> >,
         core::NotTyped(_) => return Bool
     };
     debug!("searching for {:?} in defmap", id);
-    let def_map = tycx.def_map.borrow();
-    let d = match def_map.get().find(&id) {
-        Some(k) => k,
+    let d = match tycx.def_map.borrow().find(&id) {
+        Some(&k) => k,
         None => {
             debug!("could not find {:?} in defmap (`{}`)", id, tycx.map.node_to_str(id));
             fail!("Unexpected failure: unresolved id not in defmap (this is a bug!)")
         }
     };
 
-    let (def_id, kind) = match *d {
+    let (def_id, kind) = match d {
         ast::DefFn(i, _) => (i, TypeFunction),
         ast::DefSelfTy(i) => return Self(i),
         ast::DefTy(i) => (i, TypeEnum),
@@ -1285,8 +1284,7 @@ fn resolve_def(id: ast::NodeId) -> Option<ast::DefId> {
     let cx = local_data::get(super::ctxtkey, |x| *x.unwrap());
     match cx.maybe_typed {
         core::Typed(ref tcx) => {
-            let def_map = tcx.def_map.borrow();
-            def_map.get().find(&id).map(|&d| ast_util::def_id_of_def(d))
+            tcx.def_map.borrow().find(&id).map(|&d| ast_util::def_id_of_def(d))
         }
         core::NotTyped(_) => None
     }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -186,7 +186,7 @@ impl<'a> RustdocVisitor<'a> {
             core::Typed(ref tcx) => tcx,
             core::NotTyped(_) => return false
         };
-        let def = ast_util::def_id_of_def(*tcx.def_map.borrow().get().get(&id));
+        let def = ast_util::def_id_of_def(*tcx.def_map.borrow().get(&id));
         if !ast_util::is_local(def) { return false }
         let analysis = match self.analysis {
             Some(analysis) => analysis, None => return false

--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -113,8 +113,7 @@ mod test {
         fn call(&mut self) {
             let task = match *self {
                 MyCallback(ref rc, n) => {
-                    let mut slot = rc.borrow_mut();
-                    match *slot.get() {
+                    match *rc.borrow_mut().deref_mut() {
                         (ref mut task, ref mut val) => {
                             *val = n;
                             match task.take() {
@@ -140,8 +139,7 @@ mod test {
     fn sleep(chan: &Chan) -> uint {
         let task: ~Task = Local::take();
         task.deschedule(1, |task| {
-            let mut slot = chan.borrow_mut();
-            match *slot.get() {
+            match *chan.borrow_mut().deref_mut() {
                 (ref mut slot, _) => {
                     assert!(slot.is_none());
                     *slot = Some(task);
@@ -150,8 +148,7 @@ mod test {
             Ok(())
         });
 
-        let slot = chan.borrow();
-        match *slot.get() { (_, n) => n }
+        match *chan.borrow() { (_, n) => n }
     }
 
     #[test]

--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -113,7 +113,7 @@ mod test {
         fn call(&mut self) {
             let task = match *self {
                 MyCallback(ref rc, n) => {
-                    let mut slot = rc.deref().borrow_mut();
+                    let mut slot = rc.borrow_mut();
                     match *slot.get() {
                         (ref mut task, ref mut val) => {
                             *val = n;
@@ -140,7 +140,7 @@ mod test {
     fn sleep(chan: &Chan) -> uint {
         let task: ~Task = Local::take();
         task.deschedule(1, |task| {
-            let mut slot = chan.deref().borrow_mut();
+            let mut slot = chan.borrow_mut();
             match *slot.get() {
                 (ref mut slot, _) => {
                     assert!(slot.is_none());
@@ -150,7 +150,7 @@ mod test {
             Ok(())
         });
 
-        let slot = chan.deref().borrow();
+        let slot = chan.borrow();
         match *slot.get() { (_, n) => n }
     }
 

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -387,7 +387,7 @@ impl<S:Encoder,T:Encodable<S>> Encodable<S> for @T {
 impl<S:Encoder,T:Encodable<S>> Encodable<S> for Rc<T> {
     #[inline]
     fn encode(&self, s: &mut S) {
-        self.deref().encode(s)
+        (**self).encode(s)
     }
 }
 

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -176,8 +176,7 @@ impl<T> RefCell<T> {
     /// Fails if the value is currently borrowed.
     #[inline]
     pub fn set(&self, value: T) {
-        let mut reference = self.borrow_mut();
-        *reference.get() = value;
+        *self.borrow_mut() = value;
     }
 }
 
@@ -189,23 +188,19 @@ impl<T:Clone> RefCell<T> {
     /// Fails if the value is currently mutably borrowed.
     #[inline]
     pub fn get(&self) -> T {
-        let reference = self.borrow();
-        (*reference.get()).clone()
+        (*self.borrow()).clone()
     }
 }
 
 impl<T: Clone> Clone for RefCell<T> {
     fn clone(&self) -> RefCell<T> {
-        let x = self.borrow();
-        RefCell::new(x.get().clone())
+        RefCell::new(self.get())
     }
 }
 
 impl<T: Eq> Eq for RefCell<T> {
     fn eq(&self, other: &RefCell<T>) -> bool {
-        let a = self.borrow();
-        let b = other.borrow();
-        a.get() == b.get()
+        *self.borrow() == *other.borrow()
     }
 }
 
@@ -219,14 +214,6 @@ impl<'b, T> Drop for Ref<'b, T> {
     fn drop(&mut self) {
         assert!(self.parent.borrow != WRITING && self.parent.borrow != UNUSED);
         unsafe { self.parent.as_mut().borrow -= 1; }
-    }
-}
-
-impl<'b, T> Ref<'b, T> {
-    /// Retrieve an immutable reference to the stored value.
-    #[inline]
-    pub fn get<'a>(&'a self) -> &'a T {
-        unsafe{ &*self.parent.value.get() }
     }
 }
 
@@ -247,14 +234,6 @@ impl<'b, T> Drop for RefMut<'b, T> {
     fn drop(&mut self) {
         assert!(self.parent.borrow == WRITING);
         self.parent.borrow = UNUSED;
-    }
-}
-
-impl<'b, T> RefMut<'b, T> {
-    /// Retrieve a mutable reference to the stored value.
-    #[inline]
-    pub fn get<'a>(&'a mut self) -> &'a mut T {
-        unsafe{ &mut *self.parent.value.get() }
     }
 }
 

--- a/src/libstd/hash/mod.rs
+++ b/src/libstd/hash/mod.rs
@@ -66,7 +66,6 @@
 use container::Container;
 use io::Writer;
 use iter::Iterator;
-use ops::Deref;
 use option::{Option, Some, None};
 use rc::Rc;
 use str::{Str, StrSlice};
@@ -247,7 +246,7 @@ impl<S: Writer, T: Hash<S>> Hash<S> for @T {
 impl<S: Writer, T: Hash<S>> Hash<S> for Rc<T> {
     #[inline]
     fn hash(&self, state: &mut S) {
-        self.deref().hash(state);
+        (**self).hash(state);
     }
 }
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -650,7 +650,7 @@ mod tests {
         #[unsafe_destructor]
         impl ::ops::Drop for R {
            fn drop(&mut self) {
-                let ii = self.i.deref();
+                let ii = &*self.i;
                 ii.set(ii.get() + 1);
             }
         }
@@ -667,7 +667,7 @@ mod tests {
             let opt = Some(x);
             let _y = opt.unwrap();
         }
-        assert_eq!(i.deref().get(), 1);
+        assert_eq!(i.get(), 1);
     }
 
     #[test]

--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -122,24 +122,23 @@ impl<T> Clone for Rc<T> {
 
 impl<T: Eq> Eq for Rc<T> {
     #[inline(always)]
-    fn eq(&self, other: &Rc<T>) -> bool { *self.deref() == *other.deref() }
-
+    fn eq(&self, other: &Rc<T>) -> bool { **self == **other }
     #[inline(always)]
-    fn ne(&self, other: &Rc<T>) -> bool { *self.deref() != *other.deref() }
+    fn ne(&self, other: &Rc<T>) -> bool { **self != **other }
 }
 
 impl<T: Ord> Ord for Rc<T> {
     #[inline(always)]
-    fn lt(&self, other: &Rc<T>) -> bool { *self.deref() < *other.deref() }
+    fn lt(&self, other: &Rc<T>) -> bool { **self < **other }
 
     #[inline(always)]
-    fn le(&self, other: &Rc<T>) -> bool { *self.deref() <= *other.deref() }
+    fn le(&self, other: &Rc<T>) -> bool { **self <= **other }
 
     #[inline(always)]
-    fn gt(&self, other: &Rc<T>) -> bool { *self.deref() > *other.deref() }
+    fn gt(&self, other: &Rc<T>) -> bool { **self > **other }
 
     #[inline(always)]
-    fn ge(&self, other: &Rc<T>) -> bool { *self.deref() >= *other.deref() }
+    fn ge(&self, other: &Rc<T>) -> bool { **self >= **other }
 }
 
 /// Weak reference to a reference-counted box
@@ -236,21 +235,21 @@ mod tests {
     #[test]
     fn test_simple() {
         let x = Rc::new(5);
-        assert_eq!(*x.deref(), 5);
+        assert_eq!(*x, 5);
     }
 
     #[test]
     fn test_simple_clone() {
         let x = Rc::new(5);
         let y = x.clone();
-        assert_eq!(*x.deref(), 5);
-        assert_eq!(*y.deref(), 5);
+        assert_eq!(*x, 5);
+        assert_eq!(*y, 5);
     }
 
     #[test]
     fn test_destructor() {
         let x = Rc::new(~5);
-        assert_eq!(**x.deref(), 5);
+        assert_eq!(**x, 5);
     }
 
     #[test]
@@ -273,7 +272,7 @@ mod tests {
         // see issue #11532
         use gc::Gc;
         let a = Rc::new(RefCell::new(Gc::new(1)));
-        assert!(a.deref().try_borrow_mut().is_some());
+        assert!(a.try_borrow_mut().is_some());
     }
 
     #[test]
@@ -284,7 +283,7 @@ mod tests {
 
         let a = Rc::new(Cycle { x: RefCell::new(None) });
         let b = a.clone().downgrade();
-        *a.deref().x.borrow_mut() = Some(b);
+        *a.x.borrow_mut() = Some(b);
 
         // hopefully we don't double-free (or leak)...
     }

--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -284,7 +284,7 @@ mod tests {
 
         let a = Rc::new(Cycle { x: RefCell::new(None) });
         let b = a.clone().downgrade();
-        *a.deref().x.borrow_mut().get() = Some(b);
+        *a.deref().x.borrow_mut() = Some(b);
 
         // hopefully we don't double-free (or leak)...
     }

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -471,7 +471,7 @@ mod test {
 
         {
             let mut a = a.borrow_mut();
-            a.get().next = Some(b);
+            a.next = Some(b);
         }
     }
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -40,7 +40,7 @@ impl PathElem {
 impl fmt::Show for PathElem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let slot = token::get_name(self.name());
-        write!(f.buf, "{}", slot.get())
+        write!(f.buf, "{}", slot)
     }
 }
 
@@ -190,8 +190,8 @@ pub struct Map {
 impl Map {
     fn find_entry(&self, id: NodeId) -> Option<MapEntry> {
         let map = self.map.borrow();
-        if map.get().len() > id as uint {
-            Some(*map.get().get(id as uint))
+        if map.len() > id as uint {
+            Some(*map.get(id as uint))
         } else {
             None
         }
@@ -395,8 +395,7 @@ pub struct Ctx<'a, F> {
 
 impl<'a, F> Ctx<'a, F> {
     fn insert(&self, id: NodeId, entry: MapEntry) {
-        let mut map = self.map.map.borrow_mut();
-        map.get().grow_set(id as uint, &NotPresent, entry);
+        (*self.map.map.borrow_mut()).grow_set(id as uint, &NotPresent, entry);
     }
 }
 
@@ -540,7 +539,7 @@ pub fn map_crate<F: FoldOps>(krate: Crate, fold_ops: F) -> (Crate, Map) {
         let map = map.map.borrow();
         // This only makes sense for ordered stores; note the
         // enumerate to count the number of entries.
-        let (entries_less_1, _) = map.get().iter().filter(|&x| {
+        let (entries_less_1, _) = (*map).iter().filter(|&x| {
             match *x {
                 NotPresent => false,
                 _ => true
@@ -548,7 +547,7 @@ pub fn map_crate<F: FoldOps>(krate: Crate, fold_ops: F) -> (Crate, Map) {
         }).enumerate().last().expect("AST map was empty after folding?");
 
         let entries = entries_less_1 + 1;
-        let vector_length = map.get().len();
+        let vector_length = (*map).len();
         debug!("The AST map has {} entries with a maximum of {}: occupancy {:.1}%",
               entries, vector_length, (entries as f64 / vector_length as f64) * 100.);
     }

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -84,11 +84,11 @@ pub struct Handler {
 
 impl Handler {
     pub fn fatal(&self, msg: &str) -> ! {
-        self.emit.borrow_mut().get().emit(None, msg, Fatal);
+        self.emit.borrow_mut().emit(None, msg, Fatal);
         fail!(FatalError);
     }
     pub fn err(&self, msg: &str) {
-        self.emit.borrow_mut().get().emit(None, msg, Error);
+        self.emit.borrow_mut().emit(None, msg, Error);
         self.bump_err_count();
     }
     pub fn bump_err_count(&self) {
@@ -113,13 +113,13 @@ impl Handler {
         self.fatal(s);
     }
     pub fn warn(&self, msg: &str) {
-        self.emit.borrow_mut().get().emit(None, msg, Warning);
+        self.emit.borrow_mut().emit(None, msg, Warning);
     }
     pub fn note(&self, msg: &str) {
-        self.emit.borrow_mut().get().emit(None, msg, Note);
+        self.emit.borrow_mut().emit(None, msg, Note);
     }
     pub fn bug(&self, msg: &str) -> ! {
-        self.emit.borrow_mut().get().emit(None, msg, Bug);
+        self.emit.borrow_mut().emit(None, msg, Bug);
         fail!(ExplicitBug);
     }
     pub fn unimpl(&self, msg: &str) -> ! {
@@ -129,11 +129,11 @@ impl Handler {
                 cmsp: Option<(&codemap::CodeMap, Span)>,
                 msg: &str,
                 lvl: Level) {
-        self.emit.borrow_mut().get().emit(cmsp, msg, lvl);
+        self.emit.borrow_mut().emit(cmsp, msg, lvl);
     }
     pub fn custom_emit(&self, cm: &codemap::CodeMap,
                        sp: Span, msg: &str, lvl: Level) {
-        self.emit.borrow_mut().get().custom_emit(cm, sp, msg, lvl);
+        self.emit.borrow_mut().custom_emit(cm, sp, msg, lvl);
     }
 }
 
@@ -301,7 +301,7 @@ fn highlight_lines(err: &mut EmitterWriter,
                    sp: Span,
                    lvl: Level,
                    lines: codemap::FileLines) -> io::IoResult<()> {
-    let fm = lines.file.deref();
+    let fm = &*lines.file;
 
     let mut elided = false;
     let mut display_lines = lines.lines.as_slice();
@@ -374,7 +374,7 @@ fn custom_highlight_lines(w: &mut EmitterWriter,
                           sp: Span,
                           lvl: Level,
                           lines: codemap::FileLines) -> io::IoResult<()> {
-    let fm = lines.file.deref();
+    let fm = &*lines.file;
 
     let lines = lines.lines.as_slice();
     if lines.len() > MAX_LINES {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -628,7 +628,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             vec!(
                 self.expr_str(span, msg),
                 self.expr_str(span,
-                              token::intern_and_get_ident(loc.file.deref().name)),
+                              token::intern_and_get_ident(loc.file.name)),
                 self.expr_uint(span, loc.line)))
     }
 

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -63,11 +63,10 @@ pub fn new_mark(m: Mrk, tail: SyntaxContext) -> SyntaxContext {
 // Extend a syntax context with a given mark and table
 fn new_mark_internal(m: Mrk, tail: SyntaxContext, table: &SCTable) -> SyntaxContext {
     let key = (tail, m);
-    let mut mark_memo = table.mark_memo.borrow_mut();
     let new_ctxt = |_: &(SyntaxContext, Mrk)|
-                   idx_push(table.table.borrow_mut().get(), Mark(m, tail));
+                   idx_push(&mut *table.table.borrow_mut(), Mark(m, tail));
 
-    *mark_memo.get().find_or_insert_with(key, new_ctxt)
+    *table.mark_memo.borrow_mut().find_or_insert_with(key, new_ctxt)
 }
 
 /// Extend a syntax context with a given rename
@@ -82,11 +81,10 @@ fn new_rename_internal(id: Ident,
                        tail: SyntaxContext,
                        table: &SCTable) -> SyntaxContext {
     let key = (tail,id,to);
-    let mut rename_memo = table.rename_memo.borrow_mut();
     let new_ctxt = |_: &(SyntaxContext, Ident, Mrk)|
-                   idx_push(table.table.borrow_mut().get(), Rename(id, to, tail));
+                   idx_push(&mut *table.table.borrow_mut(), Rename(id, to, tail));
 
-    *rename_memo.get().find_or_insert_with(key, new_ctxt)
+    *table.rename_memo.borrow_mut().find_or_insert_with(key, new_ctxt)
 }
 
 /// Fetch the SCTable from TLS, create one if it doesn't yet exist.
@@ -102,7 +100,7 @@ pub fn with_sctable<T>(op: |&SCTable| -> T) -> T {
             }
             Some(ts) => ts.clone()
         };
-        op(table.deref())
+        op(&*table)
     })
 }
 
@@ -119,8 +117,7 @@ fn new_sctable_internal() -> SCTable {
 /// Print out an SCTable for debugging
 pub fn display_sctable(table: &SCTable) {
     error!("SC table:");
-    let table = table.table.borrow();
-    for (idx,val) in table.get().iter().enumerate() {
+    for (idx,val) in table.table.borrow().iter().enumerate() {
         error!("{:4u} : {:?}",idx,val);
     }
 }
@@ -128,9 +125,9 @@ pub fn display_sctable(table: &SCTable) {
 /// Clear the tables from TLD to reclaim memory.
 pub fn clear_tables() {
     with_sctable(|table| {
-        *table.table.borrow_mut().get() = Vec::new();
-        *table.mark_memo.borrow_mut().get() = HashMap::new();
-        *table.rename_memo.borrow_mut().get() = HashMap::new();
+        *table.table.borrow_mut() = Vec::new();
+        *table.mark_memo.borrow_mut() = HashMap::new();
+        *table.rename_memo.borrow_mut() = HashMap::new();
     });
     with_resolve_table_mut(|table| *table = HashMap::new());
 }
@@ -166,7 +163,7 @@ fn with_resolve_table_mut<T>(op: |&mut ResolveTable| -> T) -> T {
             }
             Some(ts) => ts.clone()
         };
-        op(table.deref().borrow_mut().get())
+        op(&mut *table.borrow_mut())
     })
 }
 
@@ -183,7 +180,7 @@ fn resolve_internal(id: Ident,
     }
 
     let resolved = {
-        let result = *table.table.borrow().get().get(id.ctxt as uint);
+        let result = *table.table.borrow().get(id.ctxt as uint);
         match result {
             EmptyCtxt => id.name,
             // ignore marks here:
@@ -227,10 +224,7 @@ fn marksof_internal(ctxt: SyntaxContext,
     let mut result = Vec::new();
     let mut loopvar = ctxt;
     loop {
-        let table_entry = {
-            let table = table.table.borrow();
-            *table.get().get(loopvar as uint)
-        };
+        let table_entry = *table.table.borrow().get(loopvar as uint);
         match table_entry {
             EmptyCtxt => {
                 return result;
@@ -257,7 +251,7 @@ fn marksof_internal(ctxt: SyntaxContext,
 /// FAILS when outside is not a mark.
 pub fn outer_mark(ctxt: SyntaxContext) -> Mrk {
     with_sctable(|sctable| {
-        match *sctable.table.borrow().get().get(ctxt as uint) {
+        match *sctable.table.borrow().get(ctxt as uint) {
             Mark(mrk, _) => mrk,
             _ => fail!("can't retrieve outer mark when outside is not a mark")
         }
@@ -327,7 +321,7 @@ mod tests {
         let mut result = Vec::new();
         loop {
             let table = table.table.borrow();
-            match *table.get().get(sc as uint) {
+            match *table.get(sc as uint) {
                 EmptyCtxt => {return result;},
                 Mark(mrk,tail) => {
                     result.push(M(mrk));
@@ -351,9 +345,9 @@ mod tests {
         assert_eq!(unfold_test_sc(test_sc.clone(),EMPTY_CTXT,&mut t),4);
         {
             let table = t.table.borrow();
-            assert!(*table.get().get(2) == Mark(9,0));
-            assert!(*table.get().get(3) == Rename(id(101,0),14,2));
-            assert!(*table.get().get(4) == Mark(3,3));
+            assert!(*table.get(2) == Mark(9,0));
+            assert!(*table.get(3) == Rename(id(101,0),14,2));
+            assert!(*table.get(4) == Mark(3,3));
         }
         assert_eq!(refold_test_sc(4,&t),test_sc);
     }
@@ -372,8 +366,8 @@ mod tests {
         assert_eq!(unfold_marks(vec!(3,7),EMPTY_CTXT,&mut t),3);
         {
             let table = t.table.borrow();
-            assert!(*table.get().get(2) == Mark(7,0));
-            assert!(*table.get().get(3) == Mark(3,2));
+            assert!(*table.get(2) == Mark(7,0));
+            assert!(*table.get(3) == Mark(3,2));
         }
     }
 

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -57,7 +57,7 @@ pub fn expand_file(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 
     let topmost = topmost_expn_info(cx.backtrace().unwrap());
     let loc = cx.codemap().lookup_char_pos(topmost.call_site.lo);
-    let filename = token::intern_and_get_ident(loc.file.deref().name);
+    let filename = token::intern_and_get_ident(loc.file.name);
     base::MRExpr(cx.expr_str(topmost.call_site, filename))
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -238,23 +238,23 @@ pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> ~str {
 
 impl<'a> State<'a> {
     pub fn ibox(&mut self, u: uint) -> IoResult<()> {
-        self.boxes.borrow_mut().get().push(pp::Inconsistent);
+        self.boxes.borrow_mut().push(pp::Inconsistent);
         pp::ibox(&mut self.s, u)
     }
 
     pub fn end(&mut self) -> IoResult<()> {
-        self.boxes.borrow_mut().get().pop().unwrap();
+        self.boxes.borrow_mut().pop().unwrap();
         pp::end(&mut self.s)
     }
 
     pub fn cbox(&mut self, u: uint) -> IoResult<()> {
-        self.boxes.borrow_mut().get().push(pp::Consistent);
+        self.boxes.borrow_mut().push(pp::Consistent);
         pp::cbox(&mut self.s, u)
     }
 
     // "raw box"
     pub fn rbox(&mut self, u: uint, b: pp::Breaks) -> IoResult<()> {
-        self.boxes.borrow_mut().get().push(b);
+        self.boxes.borrow_mut().push(b);
         pp::rbox(&mut self.s, u, b)
     }
 
@@ -322,7 +322,7 @@ impl<'a> State<'a> {
     }
 
     pub fn in_cbox(&mut self) -> bool {
-        match self.boxes.borrow().get().last() {
+        match self.boxes.borrow().last() {
             Some(&last_box) => last_box == pp::Consistent,
             None => false
         }
@@ -2186,7 +2186,7 @@ impl<'a> State<'a> {
             ast::LitBinary(ref arr) => {
                 try!(self.ibox(indent_unit));
                 try!(word(&mut self.s, "["));
-                try!(self.commasep_cmnt(Inconsistent, arr.deref().as_slice(),
+                try!(self.commasep_cmnt(Inconsistent, arr.as_slice(),
                                         |s, u| word(&mut s.s, format!("{}", *u)),
                                         |_| lit.span));
                 try!(word(&mut self.s, "]"));

--- a/src/test/auxiliary/cci_nested_lib.rs
+++ b/src/test/auxiliary/cci_nested_lib.rs
@@ -24,7 +24,7 @@ pub struct alist<A,B> {
 
 pub fn alist_add<A:'static,B:'static>(lst: &alist<A,B>, k: A, v: B) {
     let mut data = lst.data.borrow_mut();
-    data.get().push(Entry{key:k, value:v});
+    (*data).push(Entry{key:k, value:v});
 }
 
 pub fn alist_get<A:Clone + 'static,
@@ -34,7 +34,7 @@ pub fn alist_get<A:Clone + 'static,
                  -> B {
     let eq_fn = lst.eq_fn;
     let data = lst.data.borrow();
-    for entry in data.get().iter() {
+    for entry in (*data).iter() {
         if eq_fn(entry.key.clone(), k.clone()) {
             return entry.value.clone();
         }

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -42,5 +42,5 @@ fn main()
     let w = v.clone();
     let b = v.deref();
     let mut b = b.borrow_mut();
-    b.get().v.set(w.clone());
+    b.v.set(w.clone());
 }

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -40,7 +40,7 @@ fn main()
     //~^ ERROR cannot pack type `~B`, which does not fulfill `Send`
     let v = Rc::new(RefCell::new(a));
     let w = v.clone();
-    let b = v.deref();
+    let b = &*v;
     let mut b = b.borrow_mut();
     b.v.set(w.clone());
 }

--- a/src/test/compile-fail/mut-cant-alias.rs
+++ b/src/test/compile-fail/mut-cant-alias.rs
@@ -13,6 +13,6 @@ use std::cell::RefCell;
 fn main() {
     let m = RefCell::new(0);
     let mut b = m.borrow_mut();
-    let b1 = b.get();
-    let b2 = b.get(); //~ ERROR cannot borrow
+    let b1 = &mut *b;
+    let b2 = &mut *b; //~ ERROR cannot borrow
 }

--- a/src/test/compile-fail/mut-ptr-cant-outlive-ref.rs
+++ b/src/test/compile-fail/mut-ptr-cant-outlive-ref.rs
@@ -15,6 +15,6 @@ fn main() {
     let p;
     {
         let b = m.borrow();
-        p = b.get(); //~ ERROR `b` does not live long enough
+        p = &*b; //~ ERROR `b` does not live long enough
     }
 }

--- a/src/test/run-pass/format-ref-cell.rs
+++ b/src/test/run-pass/format-ref-cell.rs
@@ -13,6 +13,6 @@ use std::cell::RefCell;
 pub fn main() {
     let name = RefCell::new("rust");
     let what = RefCell::new("rocks");
-    let msg = format!("{name:?} {:?}", what.borrow().get(), name=name.borrow().get());
+    let msg = format!("{name:?} {:?}", &*what.borrow(), name=&*name.borrow());
     assert_eq!(msg, ~"&\"rust\" &\"rocks\"");
 }

--- a/src/test/run-pass/self-re-assign.rs
+++ b/src/test/run-pass/self-re-assign.rs
@@ -20,5 +20,5 @@ pub fn main() {
 
    let mut x = Rc::new(3);
    x = x;
-   assert!(*x.deref() == 3);
+   assert!(*x == 3);
 }

--- a/src/test/run-pass/trait-cast.rs
+++ b/src/test/run-pass/trait-cast.rs
@@ -42,8 +42,8 @@ impl to_str for Tree {
     fn to_str_(&self) -> ~str {
         let Tree(t) = *self;
         let this = t.borrow();
-        let (l, r) = (this.get().left, this.get().right);
-        let val = &this.get().val;
+        let (l, r) = (this.left, this.right);
+        let val = &this.val;
         format!("[{}, {}, {}]", val.to_str_(), l.to_str_(), r.to_str_())
     }
 }
@@ -64,6 +64,6 @@ pub fn main() {
     {
         let Tree(t1_) = t1;
         let mut t1 = t1_.borrow_mut();
-        t1.get().left = Some(t2); // create cycle
+        t1.left = Some(t2); // create cycle
     }
 }

--- a/src/test/run-pass/uniq-cc-generic.rs
+++ b/src/test/run-pass/uniq-cc-generic.rs
@@ -38,6 +38,6 @@ pub fn main() {
     let v = empty_pointy();
     {
         let mut vb = v.borrow_mut();
-        vb.get().a = p(v);
+        vb.a = p(v);
     }
 }

--- a/src/test/run-pass/uniq-cc.rs
+++ b/src/test/run-pass/uniq-cc.rs
@@ -35,6 +35,6 @@ pub fn main() {
     let v = empty_pointy();
     {
         let mut vb = v.borrow_mut();
-        vb.get().a = p(v);
+        vb.a = p(v);
     }
 }


### PR DESCRIPTION
This commit removes the `get()` method from `Ref` and `RefMut` in favor of the `*` operator, and removes all usage of the `deref()` function manually from rustc, favoring using `*` instead.

Some of the code is a little wacky, but that's due to either #13044 or #13042
