### PR TITLE
Remove trivial branches in with_cond

### DIFF
--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -521,11 +521,9 @@ fn trans_index<'a>(bcx: &'a Block<'a>,
     debug!("trans_index: len {}", bcx.val_to_str(len));
 
     let bounds_check = ICmp(bcx, lib::llvm::IntUGE, ix_val, len);
-    let expect = ccx.intrinsics.get_copy(&("llvm.expect.i1"));
-    let expected = Call(bcx, expect, [bounds_check, C_i1(ccx, false)], []);
-    let bcx = with_cond(bcx, expected, |bcx| {
-            controlflow::trans_fail_bounds_check(bcx, index_expr.span, ix_val, len)
-        });
+    let bcx = with_cond_expected(bcx, bounds_check, false, |bcx| {
+        controlflow::trans_fail_bounds_check(bcx, index_expr.span, ix_val, len)
+    });
     let elt = InBoundsGEP(bcx, base, [ix_val]);
     let elt = PointerCast(bcx, elt, vt.llunit_ty.ptr_to());
     DatumBlock(bcx, Datum(elt, vt.unit_ty, LvalueExpr))


### PR DESCRIPTION
Removes branches on constant values when using with_cond, improving the
performance of non-optimized code and (hopefully) improving compile times.

This is a fairly simple front-end optimization.

@cmr if you could see if there is a measurable difference in compile times, that would be awesome
