### PR TITLE
Copy-edit a sentence about borrowing references

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1395,7 +1395,7 @@ let mut y = ~5; // mutable
 In contrast with
 owned boxes, where the holder of an owned box is the owner of the pointed-to
 memory, references never imply ownership - they are "borrowed".
-A reference can be borrowed to
+You can borrow a reference to
 any object, and the compiler verifies that it cannot outlive the lifetime of
 the object.
 


### PR DESCRIPTION
This is a very minor edit to the tutorial section on references.

Reading this section for the first time, I stumbled on the phrase "a reference can be borrowed to any object."  Its meaning was clear enough once I got it, but I had to re-read it a couple of times to parse it correctly.  Something about the passive voice plus the way "reference to any object" is split up by the verb phrase.  How about this instead?
