### PR TITLE
Fix rlib creation. Change the filename of compressed bitcode

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -937,8 +937,9 @@ fn link_rlib<'a>(sess: &'a Session,
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
             let bc = obj_filename.with_extension("bc");
+            let bc_deflated = obj_filename.with_extension("bc.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {
-                fs::File::create(&bc).write(flate::deflate_bytes(data).as_slice())
+                fs::File::create(&bc_deflated).write(flate::deflate_bytes(data).as_slice())
             }) {
                 Ok(()) => {}
                 Err(e) => {
@@ -946,7 +947,8 @@ fn link_rlib<'a>(sess: &'a Session,
                     sess.abort_if_errors()
                 }
             }
-            a.add_file(&bc, false);
+            a.add_file(&bc_deflated, false);
+            remove(sess, &bc_deflated);
             if !sess.opts.cg.save_temps &&
                !sess.opts.output_types.contains(&OutputTypeBitcode) {
                 remove(sess, &bc);

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -52,9 +52,9 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
 
         let archive = ArchiveRO::open(&path).expect("wanted an rlib");
         debug!("reading {}", name);
-        let bc = time(sess.time_passes(), format!("read {}.bc", name), (), |_|
-                      archive.read(format!("{}.bc", name)));
-        let bc = bc.expect("missing bytecode in archive!");
+        let bc = time(sess.time_passes(), format!("read {}.bc.deflate", name), (), |_|
+                      archive.read(format!("{}.bc.deflate", name)));
+        let bc = bc.expect("missing compressed bytecode in archive!");
         let bc = time(sess.time_passes(), format!("inflate {}.bc", name), (), |_|
                       flate::inflate_bytes(bc));
         let ptr = bc.as_slice().as_ptr();

--- a/src/test/run-make/output-type-permutations/Makefile
+++ b/src/test/run-make/output-type-permutations/Makefile
@@ -15,7 +15,6 @@ all:
 	rm $(TMPDIR)/bar
 	$(RUSTC) foo.rs --emit=asm,ir,bc,obj,link --crate-type=staticlib
 	rm $(TMPDIR)/bar.ll
-	rm $(TMPDIR)/bar.bc
 	rm $(TMPDIR)/bar.s
 	rm $(TMPDIR)/bar.o
 	rm $(TMPDIR)/$(call STATICLIB_GLOB,bar)
@@ -37,6 +36,9 @@ all:
 	rm $(TMPDIR)/foo
 	$(RUSTC) foo.rs --crate-type=bin -o $(TMPDIR)/foo
 	rm $(TMPDIR)/foo
+	mv $(TMPDIR)/bar.bc $(TMPDIR)/foo.bc
 	$(RUSTC) foo.rs --emit=bc,link --crate-type=rlib
+	cmp $(TMPDIR)/foo.bc $(TMPDIR)/bar.bc
 	rm $(TMPDIR)/bar.bc
+	rm $(TMPDIR)/foo.bc
 	rm $(TMPDIR)/$(call RLIB_GLOB,bar)


### PR DESCRIPTION
Fixes #12992

I tried to increase the number of deflate's probes. Reduction of 0.5% or 2% is not enough.
