### PR TITLE
iter: remove `to_owned_vec`

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -452,7 +452,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
         let options_to_remove = [~"-O", ~"-g", ~"--debuginfo"];
         let new_options = split_maybe_args(options).move_iter()
                                                    .filter(|x| !options_to_remove.contains(x))
-                                                   .to_owned_vec()
+                                                   .collect::<~[~str]>()
                                                    .connect(" ");
         Some(new_options)
     }

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -223,7 +223,7 @@ impl Pattern {
      */
     pub fn new(pattern: &str) -> Pattern {
 
-        let chars = pattern.chars().to_owned_vec();
+        let chars = pattern.chars().collect::<~[_]>();
         let mut tokens = Vec::new();
         let mut i = 0;
 

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -826,7 +826,7 @@ mod test {
         let max_val = 100;
 
         let mut r = task_rng();
-        let vals = range(min_val, max_val).to_owned_vec();
+        let vals = range(min_val, max_val).collect::<~[int]>();
         let small_sample = r.sample(vals.iter(), 5);
         let large_sample = r.sample(vals.iter(), vals.len() + 5);
 

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -197,7 +197,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
                 } else {
                     None
                 })
-                .to_owned_vec();
+                .collect::<~[&ast::Attribute]>();
             for m in link_args.iter() {
                 match m.value_str() {
                     Some(linkarg) => e.sess.cstore.add_used_link_args(linkarg.get()),
@@ -212,7 +212,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
                 } else {
                     None
                 })
-                .to_owned_vec();
+                .collect::<~[&ast::Attribute]>();
             for m in link_args.iter() {
                 match m.meta_item_list() {
                     Some(items) => {

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -236,7 +236,7 @@ fn get_extern_rust_fn(ccx: &CrateContext, inputs: &[ty::t], output: ty::t,
 
     let f = decl_rust_fn(ccx, false, inputs, output, name);
     csearch::get_item_attrs(&ccx.sess().cstore, did, |meta_items| {
-        set_llvm_fn_attrs(meta_items.iter().map(|&x| attr::mk_attr(x)).to_owned_vec(), f)
+        set_llvm_fn_attrs(meta_items.iter().map(|&x| attr::mk_attr(x)).collect::<~[_]>(), f)
     });
 
     ccx.externs.borrow_mut().insert(name.to_owned(), f);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -538,7 +538,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
               };
 
               expr::with_field_tys(tcx, ety, Some(e.id), |discr, field_tys| {
-                  let cs = field_tys.iter().enumerate()
+                  let (cs, inlineable) = slice::unzip(field_tys.iter().enumerate()
                       .map(|(ix, &field_ty)| {
                       match fs.iter().find(|f| field_ty.ident.name == f.ident.node.name) {
                           Some(f) => const_expr(cx, (*f).expr, is_local),
@@ -552,8 +552,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
                               }
                           }
                       }
-                  }).to_owned_vec();
-                  let (cs, inlineable) = slice::unzip(cs.move_iter());
+                  }));
                   (adt::trans_const(cx, repr, discr, cs),
                    inlineable.iter().fold(true, |a, &b| a && b))
               })

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -133,7 +133,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
             slice::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().filter(|l| stripped_filtered_line(*l).is_none());
-                let text = lines.to_owned_vec().connect("\n");
+                let text = lines.collect::<~[&str]>().connect("\n");
 
                 let buf = buf {
                     data: text.as_bytes().as_ptr(),
@@ -186,7 +186,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
                 Some(s) => s.to_lower().into_str(),
                 None => s.to_owned()
             }
-        }).to_owned_vec().connect("-");
+        }).collect::<~[~str]>().connect("-");
 
         let opaque = unsafe {&mut *(opaque as *mut my_opaque)};
 
@@ -284,7 +284,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                 let tests = &mut *(opaque as *mut ::test::Collector);
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().map(|l| stripped_filtered_line(l).unwrap_or(l));
-                let text = lines.to_owned_vec().connect("\n");
+                let text = lines.collect::<~[&str]>().connect("\n");
                 tests.add_test(text, should_fail, no_run);
             })
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1205,8 +1205,8 @@ fn item_trait(w: &mut Writer, it: &clean::Item,
                   it.name.get_ref().as_slice(),
                   t.generics,
                   parents));
-    let required = t.methods.iter().filter(|m| m.is_req()).to_owned_vec();
-    let provided = t.methods.iter().filter(|m| !m.is_req()).to_owned_vec();
+    let required = t.methods.iter().filter(|m| m.is_req()).collect::<~[&clean::TraitMethod]>();
+    let provided = t.methods.iter().filter(|m| !m.is_req()).collect::<~[&clean::TraitMethod]>();
 
     if t.methods.len() == 0 {
         try!(write!(w, "\\{ \\}"));
@@ -1502,11 +1502,11 @@ fn render_methods(w: &mut Writer, it: &clean::Item) -> fmt::Result {
                 let mut non_trait = v.iter().filter(|p| {
                     p.ref0().trait_.is_none()
                 });
-                let non_trait = non_trait.to_owned_vec();
+                let non_trait = non_trait.collect::<~[&(clean::Impl, Option<~str>)]>();
                 let mut traits = v.iter().filter(|p| {
                     p.ref0().trait_.is_some()
                 });
-                let traits = traits.to_owned_vec();
+                let traits = traits.collect::<~[&(clean::Impl, Option<~str>)]>();
 
                 if non_trait.len() > 0 {
                     try!(write!(w, "<h2 id='methods'>Methods</h2>"));

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -400,7 +400,7 @@ unsafe fn str_map_bytes(string: ~str, map: &'static [u8]) -> ~str {
 
 #[inline]
 unsafe fn str_copy_map_bytes(string: &str, map: &'static [u8]) -> ~str {
-    let bytes = string.bytes().map(|b| map[b]).to_owned_vec();
+    let bytes = string.bytes().map(|b| map[b]).collect::<~[_]>();
 
     str::raw::from_utf8_owned(bytes)
 }

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -463,21 +463,6 @@ pub trait Iterator<A> {
         FromIterator::from_iterator(self)
     }
 
-    /// Loops through the entire iterator, collecting all of the elements into
-    /// a unique vector. This is simply collect() specialized for vectors.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// let a = [1, 2, 3, 4, 5];
-    /// let b: ~[int] = a.iter().map(|&x| x).to_owned_vec();
-    /// assert!(a == b);
-    /// ```
-    #[inline]
-    fn to_owned_vec(&mut self) -> ~[A] {
-        self.collect()
-    }
-
     /// Loops through `n` iterations, returning the `n`th element of the
     /// iterator.
     ///

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -1177,13 +1177,13 @@ mod tests {
             (s: $path:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let comps = path.components().to_owned_vec();
+                    let comps = path.components().collect::<~[&[u8]]>();
                     let exp: &[&str] = $exp;
-                    let exps = exp.iter().map(|x| x.as_bytes()).to_owned_vec();
+                    let exps = exp.iter().map(|x| x.as_bytes()).collect::<~[&[u8]]>();
                     assert!(comps == exps, "components: Expected {:?}, found {:?}",
                             comps, exps);
-                    let comps = path.rev_components().to_owned_vec();
-                    let exps = exps.move_rev_iter().to_owned_vec();
+                    let comps = path.rev_components().collect::<~[&[u8]]>();
+                    let exps = exps.move_rev_iter().collect::<~[&[u8]]>();
                     assert!(comps == exps, "rev_components: Expected {:?}, found {:?}",
                             comps, exps);
                 }
@@ -1191,12 +1191,12 @@ mod tests {
             (v: [$($arg:expr),+], [$([$($exp:expr),*]),*]) => (
                 {
                     let path = Path::new(b!($($arg),+));
-                    let comps = path.components().to_owned_vec();
+                    let comps = path.components().collect::<~[&[u8]]>();
                     let exp: &[&[u8]] = [$(b!($($exp),*)),*];
                     assert!(comps.as_slice() == exp, "components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
-                    let comps = path.rev_components().to_owned_vec();
-                    let exp = exp.rev_iter().map(|&x|x).to_owned_vec();
+                    let comps = path.rev_components().collect::<~[&[u8]]>();
+                    let exp = exp.rev_iter().map(|&x|x).collect::<~[&[u8]]>();
                     assert!(comps.as_slice() == exp,
                             "rev_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
@@ -1226,13 +1226,13 @@ mod tests {
             (v: [$($arg:expr),+], $exp:expr) => (
                 {
                     let path = Path::new(b!($($arg),+));
-                    let comps = path.str_components().to_owned_vec();
+                    let comps = path.str_components().collect::<~[Option<&str>]>();
                     let exp: &[Option<&str>] = $exp;
                     assert!(comps.as_slice() == exp,
                             "str_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
-                    let comps = path.rev_str_components().to_owned_vec();
-                    let exp = exp.rev_iter().map(|&x|x).to_owned_vec();
+                    let comps = path.rev_str_components().collect::<~[Option<&str>]>();
+                    let exp = exp.rev_iter().map(|&x|x).collect::<~[Option<&str>]>();
                     assert!(comps.as_slice() == exp,
                             "rev_str_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -2224,13 +2224,15 @@ mod tests {
             (s: $path:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let comps = path.str_components().map(|x|x.unwrap()).to_owned_vec();
+                    let comps = path.str_components().map(|x|x.unwrap())
+                                .collect::<~[&str]>();
                     let exp: &[&str] = $exp;
                     assert!(comps.as_slice() == exp,
                             "str_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
-                    let comps = path.rev_str_components().map(|x|x.unwrap()).to_owned_vec();
-                    let exp = exp.rev_iter().map(|&x|x).to_owned_vec();
+                    let comps = path.rev_str_components().map(|x|x.unwrap())
+                                .collect::<~[&str]>();
+                    let exp = exp.rev_iter().map(|&x|x).collect::<~[&str]>();
                     assert!(comps.as_slice() == exp,
                             "rev_str_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
@@ -2239,13 +2241,14 @@ mod tests {
             (v: [$($arg:expr),+], $exp:expr) => (
                 {
                     let path = Path::new(b!($($arg),+));
-                    let comps = path.str_components().map(|x|x.unwrap()).to_owned_vec();
+                    let comps = path.str_components().map(|x|x.unwrap()).collect::<~[&str]>();
                     let exp: &[&str] = $exp;
                     assert!(comps.as_slice() == exp,
                             "str_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
-                    let comps = path.rev_str_components().map(|x|x.unwrap()).to_owned_vec();
-                    let exp = exp.rev_iter().map(|&x|x).to_owned_vec();
+                    let comps = path.rev_str_components().map(|x|x.unwrap())
+                                .collect::<~[&str]>();
+                    let exp = exp.rev_iter().map(|&x|x).collect::<~[&str]>();
                     assert!(comps.as_slice() == exp,
                             "rev_str_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
@@ -2299,12 +2302,12 @@ mod tests {
             (s: $path:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let comps = path.components().to_owned_vec();
+                    let comps = path.components().collect::<~[&[u8]]>();
                     let exp: &[&[u8]] = $exp;
                     assert!(comps.as_slice() == exp, "components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);
-                    let comps = path.rev_components().to_owned_vec();
-                    let exp = exp.rev_iter().map(|&x|x).to_owned_vec();
+                    let comps = path.rev_components().collect::<~[&[u8]]>();
+                    let exp = exp.rev_iter().map(|&x|x).collect::<~[&[u8]]>();
                     assert!(comps.as_slice() == exp,
                             "rev_components: Expected {:?}, found {:?}",
                             comps.as_slice(), exp);

--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -436,7 +436,7 @@ impl ElementSwaps {
             emit_reset: true,
             sdir: range(0, length)
                     .map(|i| SizeDirection{ size: i, dir: Neg })
-                    .to_owned_vec()
+                    .collect::<~[_]>()
         }
     }
 }
@@ -3539,7 +3539,7 @@ mod tests {
                         let n = task_rng().gen::<uint>() % 10;
                         counts[n] += 1;
                         (n, counts[n])
-                    }).to_owned_vec();
+                    }).collect::<~[(uint, int)]>();
 
                 // only sort on the first element, so an unstable sort
                 // may mix up the counts.
@@ -4207,7 +4207,7 @@ mod tests {
         assert_eq!(xs.capacity(), 128);
         xs.shrink_to_fit();
         assert_eq!(xs.capacity(), 100);
-        assert_eq!(xs, range(0, 100).to_owned_vec());
+        assert_eq!(xs, range(0, 100).collect::<~[_]>());
     }
 
     #[test]

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -937,7 +937,7 @@ impl<'a> Iterator<UTF16Item> for UTF16Items<'a> {
 ///          0x0073, 0xDD1E, 0x0069, 0x0063,
 ///          0xD834];
 ///
-/// assert_eq!(str::utf16_items(v).to_owned_vec(),
+/// assert_eq!(str::utf16_items(v).collect::<~[_]>(),
 ///            ~[ScalarValue('𝄞'),
 ///              ScalarValue('m'), ScalarValue('u'), ScalarValue('s'),
 ///              LoneSurrogate(0xDD1E),

--- a/src/libstd/sync/deque.rs
+++ b/src/libstd/sync/deque.rs
@@ -494,7 +494,7 @@ mod tests {
                     }
                 }
             })
-        }).to_owned_vec();
+        }).collect::<~[Thread<()>]>();
 
         while remaining.load(SeqCst) > 0 {
             match w.pop() {
@@ -525,7 +525,7 @@ mod tests {
             Thread::start(proc() {
                 stampede(w, s, 4, 10000);
             })
-        }).to_owned_vec();
+        }).collect::<~[Thread<()>]>();
 
         for thread in threads.move_iter() {
             thread.join();
@@ -556,7 +556,7 @@ mod tests {
                     }
                 }
             })
-        }).to_owned_vec();
+        }).collect::<~[Thread<()>]>();
 
         let mut rng = rand::task_rng();
         let mut expected = 0;

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -76,7 +76,7 @@ fn main() {
                 format!("{}\t trees of depth {}\t check: {}",
                         iterations * 2, depth, chk)
             })
-        }).to_owned_vec();
+        }).collect::<~[Future<~str>]>();
 
     for message in messages.mut_iter() {
         println!("{}", *message.get_ref());

--- a/src/test/run-pass/send_str_treemap.rs
+++ b/src/test/run-pass/send_str_treemap.rs
@@ -62,7 +62,7 @@ pub fn main() {
 
     assert!(map.pop(&Slice("foo")).is_some());
     assert_eq!(map.move_iter().map(|(k, v)| k.to_str() + v.to_str())
-                              .to_owned_vec()
+                              .collect::<~[~str]>()
                               .concat(),
                ~"abc50bcd51cde52def53");
 }

--- a/src/test/run-pass/trait-to-str.rs
+++ b/src/test/run-pass/trait-to-str.rs
@@ -21,7 +21,7 @@ impl to_str for int {
 
 impl<T:to_str> to_str for Vec<T> {
     fn to_string(&self) -> ~str {
-        format!("[{}]", self.iter().map(|e| e.to_string()).to_owned_vec().connect(", "))
+        format!("[{}]", self.iter().map(|e| e.to_string()).collect::<~[~str]>().connect(", "))
     }
 }
 


### PR DESCRIPTION
This has been rendered obsolete by partial type hints. Since the `~[T]`
type is in the process of being removed, it needs to go away.
