### PR TITLE
docs: using named lifetime syntax for controlling flow of execution.

### DIFF
--- a/src/doc/guide-lifetimes.md
+++ b/src/doc/guide-lifetimes.md
@@ -559,9 +559,14 @@ points at a static constant).
 
 # Named lifetimes
 
-Let's look at named lifetimes in more detail. Named lifetimes allow
-for grouping of parameters by lifetime. For example, consider this
-function:
+Lifetimes can be named and referenced. For example, the special lifetime 
+`'static`, which does not go out of scope, can be used to create global
+variables and communicate between tasks (see the manual for usecases).
+
+## Parameter Lifetimes
+
+Named lifetimes allow for grouping of parameters by lifetime. 
+For example, consider this function:
 
 ~~~
 # struct Point {x: f64, y: f64}; // as before
@@ -654,6 +659,20 @@ fn select<'r, T>(shape: &Shape, threshold: f64,
 ~~~
 
 This is equivalent to the previous definition.
+
+## Labeled Control Structures
+
+Named lifetime notation can also be used to control the flow of execution:
+
+~~~
+'h: for i in range(0,10) {
+    'g: loop {
+        if i % 2 == 0 { continue 'h; }
+        if i == 9 { break 'h; }
+        break 'g;
+    }
+}
+~~~
 
 # Conclusion
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2103,7 +2103,8 @@ a `&T` pointer. `MutexArc` is an example of a *sharable* type with internal muta
 These are types that do not contain any data whose lifetime is bound to
 a particular stack frame. These are types that do not contain any
 references, or types where the only contained references
-have the `'static` lifetime.
+have the `'static` lifetime. (For more on named lifetimes and their uses, 
+see the [references and lifetimes guide][lifetimes].)
 
 > ***Note:*** These two traits were referred to as 'kinds' in earlier
 > iterations of the language, and often still are.


### PR DESCRIPTION
- Based on tip given by Leo Testard in mailing list:
  https://mail.mozilla.org/pipermail/rust-dev/2014-March/009145.html
- cross-reference named lifetimes in tutorial -> lifetimes guide
