### PR TITLE
Added lint for #[deriving] structs and enums with unsafe pointers

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -384,6 +384,7 @@ pub struct t_box_ {
 // alive, and using ty::get is unsafe when the ctxt is no longer alive.
 enum t_opaque {}
 
+#[allow(raw_pointer_deriving)]
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct t { priv inner: *t_opaque }
 

--- a/src/test/compile-fail/lint-raw-ptr-deriving.rs
+++ b/src/test/compile-fail/lint-raw-ptr-deriving.rs
@@ -1,0 +1,35 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[feature(struct_variant)];
+#[allow(dead_code)];
+#[deny(raw_pointer_deriving)];
+
+#[deriving(Clone)]
+struct Foo {
+    x: *int //~ ERROR use of `#[deriving]` with a raw pointer
+}
+
+#[deriving(Clone)]
+struct Bar(*mut int); //~ ERROR use of `#[deriving]` with a raw pointer
+
+#[deriving(Clone)]
+enum Baz {
+    A(*int), //~ ERROR use of `#[deriving]` with a raw pointer
+    B { x: *mut int } //~ ERROR use of `#[deriving]` with a raw pointer
+}
+
+#[deriving(Clone)]
+struct Buzz {
+    x: (*int, //~ ERROR use of `#[deriving]` with a raw pointer
+        *uint) //~ ERROR use of `#[deriving]` with a raw pointer
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #13032 
