### PR TITLE
Replaced StdRng::new with task_rng

### DIFF
--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -370,14 +370,14 @@ mod bench {
     use self::test::BenchHarness;
     use std::mem::size_of;
     use distributions::IndependentSample;
-    use {StdRng, RAND_BENCH_N};
+    use {RAND_BENCH_N, task_rng};
     use super::Gamma;
 
 
     #[bench]
     fn bench_gamma_large_shape(bh: &mut BenchHarness) {
         let gamma = Gamma::new(10., 1.0);
-        let mut rng = StdRng::new();
+        let mut rng = task_rng();
 
         bh.iter(|| {
             for _ in range(0, RAND_BENCH_N) {
@@ -390,7 +390,7 @@ mod bench {
     #[bench]
     fn bench_gamma_small_shape(bh: &mut BenchHarness) {
         let gamma = Gamma::new(0.1, 1.0);
-        let mut rng = StdRng::new();
+        let mut rng = task_rng();
 
         bh.iter(|| {
             for _ in range(0, RAND_BENCH_N) {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -865,7 +865,7 @@ static RAND_BENCH_N: u64 = 100;
 mod bench {
     extern crate test;
     use self::test::BenchHarness;
-    use {XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng, RAND_BENCH_N};
+    use {XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng, RAND_BENCH_N, task_rng};
     use std::mem::size_of;
 
     #[bench]
@@ -904,6 +904,17 @@ mod bench {
     #[bench]
     fn rand_std(bh: &mut BenchHarness) {
         let mut rng = StdRng::new();
+        bh.iter(|| {
+            for _ in range(0, RAND_BENCH_N) {
+                rng.gen::<uint>();
+            }
+        });
+        bh.bytes = size_of::<uint>() as u64 * RAND_BENCH_N;
+    }
+
+    #[bench]
+    fn rand_task_rng(bh: &mut BenchHarness) {
+        let rng = task_rng();
         bh.iter(|| {
             for _ in range(0, RAND_BENCH_N) {
                 rng.gen::<uint>();


### PR DESCRIPTION
I replaced StdRng::new with task_rng in a few tests and benchmarks (not
in the parts being benchmarked only in the setup). This will make
benchmarks and tests go by slightly faster.

I didn't replace the StdRng::new with task_rng in test/bench/noise.rs
line 44 because the StdRng::new part is being measured by the
benchmark. I think the StdRng::new() part is a nonessential part of the
benchmark though so maybe it should be replaced.
