### PR TITLE
Visit type parameter in lifetime suggestion

### DIFF
--- a/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param-2.rs
+++ b/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param-2.rs
@@ -1,0 +1,36 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+use std::iter::{Range,range};
+
+trait Itble<'r, T, I: Iterator<T>> { fn iter(&'r self) -> I; }
+
+impl<'r> Itble<'r, uint, Range<uint>> for (uint, uint) {
+    fn iter(&'r self) -> Range<uint> {
+        let &(min, max) = self;
+        range(min, max)
+    }
+}
+
+fn check<'r, I: Iterator<uint>, T: Itble<'r, uint, I>>(cont: &T) -> bool {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn check<'a, I: Iterator<uint>, T: Itble<'a, uint, I>>(cont: &'a T) -> bool
+    let cont_iter = cont.iter(); //~ ERROR: cannot infer
+    let result = cont_iter.fold(Some(0u16), |state, val| {
+        state.map_or(None, |mask| {
+            let bit = 1 << val;
+            if mask & bit == 0 {Some(mask|bit)} else {None}
+        })
+    });
+    result.is_some()
+}
+
+fn main() {}

--- a/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param.rs
+++ b/src/test/compile-fail/lifetime-inference-give-expl-lifetime-param.rs
@@ -54,5 +54,16 @@ fn bar2<'a, 'b, 'c>(x: &Bar<'a, 'b, 'c>) -> (&int, &int, &int) {
     //~^^ ERROR: cannot infer
 }
 
+struct Cat<'x, T> { cat: &'x int, t: T }
+struct Dog<'y> { dog: &'y int }
+fn cat<'x>(x: Cat<'x, Dog>) -> &int {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn cat<'a, 'x>(x: Cat<'x, Dog<'a>>) -> &'a int
+    x.t.dog //~ ERROR: mismatched types
+}
+
+fn cat2<'x, 'y>(x: Cat<'x, Dog<'y>>) -> &int {
+//~^ NOTE: consider using an explicit lifetime parameter as shown: fn cat2<'a, 'x>(x: Cat<'x, Dog<'a>>) -> &'a int
+    x.t.dog //~ ERROR: mismatched types
+}
 
 fn main() {}


### PR DESCRIPTION
Previously, Rebuilder did not visit type parameters when rebuilding
generics and path, so in some cases the suggestion turns out to be
erroneous.
