### PR TITLE
Correct overly broad definition of `'static` kind bound.

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3446,8 +3446,9 @@ The kinds are:
     This kind includes scalars and immutable references,
     as well as structural types containing other `Pod` types.
 `'static`
-  : Types of this kind do not contain any references;
-    this can be a useful guarantee for code
+  : Types of this kind do not contain any references (except for
+    references with the `static` lifetime, which are allowed).
+    This can be a useful guarantee for code
     that breaks borrowing assumptions
     using [`unsafe` operations](#unsafe-functions).
 `Drop`


### PR DESCRIPTION
While double-checking my understanding of the meaning of `'static`, I made the following test program:

``` rust
fn foo<X:'static>(_x: X) { }

#[cfg(not(acceptable))]
fn bar() {
    let a = 3;
    let b = &a;
    foo(b);
}

#[cfg(acceptable)]
fn bar() {
    static c : int = 4;;
    let d : &'static int = &c;
    foo(d);
}

fn main() {
    bar();
}
```

Transcript of compiling above program, illustrating that the `--cfg acceptable` variant of `bar` compiles successfully, showing that the`'static` kind bound only disallows non-`static` references, not _all_ references:

```
% rustc --version
/Users/fklock/opt/rust-dbg/bin/rustc 0.10-pre (caf17fe 2014-03-21 02:21:50 -0700)
host: x86_64-apple-darwin
% rustc /tmp/s.rs
/tmp/s.rs:7:5: 7:8 error: instantiating a type parameter with an incompatible type `&int`, which does not fulfill `'static`
/tmp/s.rs:7     foo(b);
                ^~~
error: aborting due to previous error
% rustc --cfg acceptable /tmp/s.rs
% ./s
%
```

(Note that the explicit type annotation on `let d : &'static int` is necessary; it did not suffice for me to just write `let d = &'static c;`. That might be a latent bug, I am not sure yet.)

Anyway, a fix to the documentation seemed prudent.
