### PR TITLE
Cleanup old issue references

### DIFF
--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -406,11 +406,11 @@ impl Integer for BigUint {
                 let mut d0 = d0;
                 let mut prod = b * d0;
                 while prod > m {
-                    // FIXME(#6050): overloaded operators force moves with generic types
+                    // FIXME(#5992): assignment operator overloads
                     // d0 -= d_unit
                     d0   = d0 - d_unit;
-                    // FIXME(#6050): overloaded operators force moves with generic types
-                    // prod = prod - b_unit;
+                    // FIXME(#5992): assignment operator overloads
+                    // prod -= b_unit;
                     prod = prod - b_unit
                 }
                 if d0.is_zero() {
@@ -418,10 +418,10 @@ impl Integer for BigUint {
                     continue;
                 }
                 n = 1;
-                // FIXME(#6102): Assignment operator for BigInt causes ICE
+                // FIXME(#5992): assignment operator overloads
                 // d += d0;
                 d = d + d0;
-                // FIXME(#6102): Assignment operator for BigInt causes ICE
+                // FIXME(#5992): assignment operator overloads
                 // m -= prod;
                 m = m - prod;
             }
@@ -724,8 +724,7 @@ impl BigUint {
                     let d: Option<BigUint> = FromPrimitive::from_uint(d);
                     match d {
                         Some(d) => {
-                            // FIXME(#6102): Assignment operator for BigInt
-                            // causes ICE:
+                            // FIXME(#5992): assignment operator overloads
                             // n += d * power;
                             n = n + d * power;
                         }
@@ -738,7 +737,7 @@ impl BigUint {
                 return Some(n);
             }
             end -= unit_len;
-            // FIXME(#6050): overloaded operators force moves with generic types
+            // FIXME(#5992): assignment operator overloads
             // power *= base_num;
             power = power * base_num;
         }
@@ -2068,7 +2067,7 @@ mod biguint_tests {
         fn factor(n: uint) -> BigUint {
             let mut f: BigUint = One::one();
             for i in range(2, n + 1) {
-                // FIXME(#6102): Assignment operator for BigInt causes ICE
+                // FIXME(#5992): assignment operator overloads
                 // f *= FromPrimitive::from_uint(i);
                 f = f * FromPrimitive::from_uint(i).unwrap();
             }

--- a/src/libnum/rational.rs
+++ b/src/libnum/rational.rs
@@ -87,10 +87,10 @@ impl<T: Clone + Integer + Ord>
     fn reduce(&mut self) {
         let g : T = self.numer.gcd(&self.denom);
 
-        // FIXME(#6050): overloaded operators force moves with generic types
+        // FIXME(#5992): assignment operator overloads
         // self.numer /= g;
         self.numer = self.numer / g;
-        // FIXME(#6050): overloaded operators force moves with generic types
+        // FIXME(#5992): assignment operator overloads
         // self.denom /= g;
         self.denom = self.denom / g;
 

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -91,7 +91,7 @@ impl<'a> Archive<'a> {
     pub fn read(&self, file: &str) -> Vec<u8> {
         // Apparently if "ar p" is used on windows, it generates a corrupt file
         // which has bad headers and LLVM will immediately choke on it
-        if cfg!(windows) && cfg!(windows) { // FIXME(#10734) double-and
+        if cfg!(windows) {
             let loc = TempDir::new("rsar").unwrap();
             let archive = os::make_absolute(&self.dst);
             run_ar(self.sess, "x", Some(loc.path()), [&archive,


### PR DESCRIPTION
Cleanup old issue references. One of these workarounds no longer need to be used anymore and the others are out of date.
