### PR TITLE
Add Reader.read_at_least()

### DIFF
--- a/src/librand/reader.rs
+++ b/src/librand/reader.rs
@@ -60,8 +60,8 @@ impl<R: Reader> Rng for ReaderRng<R> {
     }
     fn fill_bytes(&mut self, v: &mut [u8]) {
         if v.len() == 0 { return }
-        match self.reader.fill(v) {
-            Ok(()) => {}
+        match self.reader.read_at_least(v.len(), v) {
+            Ok(_) => {}
             Err(e) => fail!("ReaderRng.fill_bytes error: {}", e)
         }
     }

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -342,39 +342,39 @@ mod test {
     }
 
     #[test]
-    fn push_exact() {
-        let mut reader = MemReader::new(vec!(10, 11, 12, 13));
-        let mut buf = vec!(8, 9);
-        reader.push_exact(&mut buf, 4).unwrap();
-        assert!(buf == vec!(8, 9, 10, 11, 12, 13));
+    fn push_at_least() {
+        let mut reader = MemReader::new(vec![10, 11, 12, 13]);
+        let mut buf = vec![8, 9];
+        assert!(reader.push_at_least(4, 4, &mut buf).is_ok());
+        assert!(buf == vec![8, 9, 10, 11, 12, 13]);
     }
 
     #[test]
-    fn push_exact_partial() {
+    fn push_at_least_partial() {
         let mut reader = PartialReader {
             count: 0,
         };
-        let mut buf = vec!(8, 9);
-        reader.push_exact(&mut buf, 4).unwrap();
-        assert!(buf == vec!(8, 9, 10, 11, 12, 13));
+        let mut buf = vec![8, 9];
+        assert!(reader.push_at_least(4, 4, &mut buf).is_ok());
+        assert!(buf == vec![8, 9, 10, 11, 12, 13]);
     }
 
     #[test]
-    fn push_exact_eof() {
-        let mut reader = MemReader::new(vec!(10, 11));
-        let mut buf = vec!(8, 9);
-        assert!(reader.push_exact(&mut buf, 4).is_err());
-        assert!(buf == vec!(8, 9, 10, 11));
+    fn push_at_least_eof() {
+        let mut reader = MemReader::new(vec![10, 11]);
+        let mut buf = vec![8, 9];
+        assert!(reader.push_at_least(4, 4, &mut buf).is_err());
+        assert!(buf == vec![8, 9, 10, 11]);
     }
 
     #[test]
-    fn push_exact_error() {
+    fn push_at_least_error() {
         let mut reader = ErroringLaterReader {
             count: 0,
         };
-        let mut buf = vec!(8, 9);
-        assert!(reader.push_exact(&mut buf, 4).is_err());
-        assert!(buf == vec!(8, 9, 10));
+        let mut buf = vec![8, 9];
+        assert!(reader.push_at_least(4, 4, &mut buf).is_err());
+        assert!(buf == vec![8, 9, 10]);
     }
 
     #[test]

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -559,16 +559,16 @@ mod test {
     }
 
     #[test]
-    fn io_fill() {
-        let mut r = MemReader::new(vec!(1, 2, 3, 4, 5, 6, 7, 8));
+    fn io_read_at_least() {
+        let mut r = MemReader::new(vec![1, 2, 3, 4, 5, 6, 7, 8]);
         let mut buf = [0, ..3];
-        assert_eq!(r.fill(buf), Ok(()));
+        assert!(r.read_at_least(buf.len(), buf).is_ok());
         assert_eq!(buf.as_slice(), &[1, 2, 3]);
-        assert_eq!(r.fill(buf.mut_slice_to(0)), Ok(()));
+        assert!(r.read_at_least(0, buf.mut_slice_to(0)).is_ok());
         assert_eq!(buf.as_slice(), &[1, 2, 3]);
-        assert_eq!(r.fill(buf), Ok(()));
+        assert!(r.read_at_least(buf.len(), buf).is_ok());
         assert_eq!(buf.as_slice(), &[4, 5, 6]);
-        assert!(r.fill(buf).is_err());
+        assert!(r.read_at_least(buf.len(), buf).is_err());
         assert_eq!(buf.as_slice(), &[7, 8, 6]);
     }
 }


### PR DESCRIPTION
Reader.read_at_least() ensures that at least a given number of bytes
have been read. The most common use-case for this is ensuring at least 1
byte has been read. If the reader returns 0 enough times in a row, a new
error kind NoProgress will be returned instead of looping infinitely.

This change is necessary in order to properly support Readers that
repeatedly return 0, either because they're broken, or because they're
attempting to do a non-blocking read on some resource that never becomes
available.

Also add .push() and .push_at_least() methods. push() is like read() but
the results are appended to the passed Vec.

Remove Reader.fill() and Reader.push_exact() as they end up being thin
wrappers around read_at_least() and push_at_least().

[breaking-change]
