### PR TITLE
rustc: fixed regionck for owned trait casts.

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -98,20 +98,20 @@ pub type IdentMacroExpanderFn =
 pub type MacroCrateRegistrationFun =
     fn(|ast::Name, SyntaxExtension|);
 
-pub trait AnyMacro {
+pub trait AnyMacro<'a> {
     fn make_expr(&self) -> @ast::Expr;
     fn make_items(&self) -> SmallVector<@ast::Item>;
     fn make_stmt(&self) -> @ast::Stmt;
 }
 
 
-pub enum MacResult {
+pub enum MacResult<'a> {
     MRExpr(@ast::Expr),
     MRItem(@ast::Item),
-    MRAny(~AnyMacro:),
+    MRAny(~AnyMacro<'a>:),
     MRDef(MacroDef),
 }
-impl MacResult {
+impl<'a> MacResult<'a> {
     /// Create an empty expression MacResult; useful for satisfying
     /// type signatures after emitting a non-fatal error (which stop
     /// compilation well before the validity (or otherwise)) of the
@@ -123,7 +123,7 @@ impl MacResult {
             span: sp,
         }
     }
-    pub fn dummy_expr(sp: codemap::Span) -> MacResult {
+    pub fn dummy_expr(sp: codemap::Span) -> MacResult<'a> {
         MRExpr(MacResult::raw_dummy_expr(sp))
     }
     pub fn dummy_any(sp: codemap::Span) -> MacResult {
@@ -133,7 +133,7 @@ impl MacResult {
 struct DummyMacResult {
     sp: codemap::Span
 }
-impl AnyMacro for DummyMacResult {
+impl<'a> AnyMacro<'a> for DummyMacResult {
     fn make_expr(&self) -> @ast::Expr {
         MacResult::raw_dummy_expr(self.sp)
     }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -57,7 +57,7 @@ impl<'a> ParserAnyMacro<'a> {
     }
 }
 
-impl<'a> AnyMacro for ParserAnyMacro<'a> {
+impl<'a> AnyMacro<'a> for ParserAnyMacro<'a> {
     fn make_expr(&self) -> @ast::Expr {
         let ret = self.parser.borrow_mut().parse_expr();
         self.ensure_complete_parse(true);
@@ -106,7 +106,7 @@ impl MacroExpander for MacroRulesMacroExpander {
 }
 
 // Given `lhses` and `rhses`, this is the new macro we create
-fn generic_extension(cx: &ExtCtxt,
+fn generic_extension<'a>(cx: &'a ExtCtxt,
                      sp: Span,
                      name: Ident,
                      arg: &[ast::TokenTree],

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -24,7 +24,7 @@ use std::str;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader};
 
-pub trait Reader {
+pub trait Reader<'a> {
     fn is_eof(&self) -> bool;
     fn next_token(&mut self) -> TokenAndSpan;
     fn fatal(&self, ~str) -> !;
@@ -89,7 +89,7 @@ pub fn new_low_level_string_reader<'a>(span_diagnostic: &'a SpanHandler,
     r
 }
 
-impl<'a> Reader for StringReader<'a> {
+impl<'a> Reader<'a> for StringReader<'a> {
     fn is_eof(&self) -> bool { is_eof(self) }
     // return the next token. EFFECT: advances the string_reader.
     fn next_token(&mut self) -> TokenAndSpan {
@@ -113,7 +113,7 @@ impl<'a> Reader for StringReader<'a> {
     }
 }
 
-impl<'a> Reader for TtReader<'a> {
+impl<'a> Reader<'a> for TtReader<'a> {
     fn is_eof(&self) -> bool {
         self.cur_tok == token::EOF
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -272,7 +272,7 @@ struct ParsedItemsAndViewItems {
 
 /* ident is handled by common.rs */
 
-pub fn Parser<'a>(sess: &'a ParseSess, cfg: ast::CrateConfig, mut rdr: ~Reader:)
+pub fn Parser<'a>(sess: &'a ParseSess, cfg: ast::CrateConfig, mut rdr: ~Reader<'a>:)
               -> Parser<'a> {
     let tok0 = rdr.next_token();
     let span = tok0.sp;
@@ -324,7 +324,7 @@ pub struct Parser<'a> {
     pub tokens_consumed: uint,
     pub restriction: restriction,
     pub quote_depth: uint, // not (yet) related to the quasiquoter
-    pub reader: ~Reader:,
+    pub reader: ~Reader<'a>:,
     pub interner: Rc<token::IdentInterner>,
     /// The set of seen errors about obsolete syntax. Used to suppress
     /// extra detail when the same error is seen twice

--- a/src/test/compile-fail/regionck-uniq-trait-cast-fail.rs
+++ b/src/test/compile-fail/regionck-uniq-trait-cast-fail.rs
@@ -8,23 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait A<T> {}
-struct B<'a, T>(&'a A<T>);
+// Test that lifetimes can't escape through owned trait casts
 
-trait X<'a> {}
-impl<'a, T> X<'a> for B<'a, T> {}
+trait X {}
+impl<'a> X for &'a X {}
 
-fn f<'a, T, U>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `T`
+fn foo(x: &X) -> ~X: {
+    ~x as ~X:
+    //~^ ERROR lifetime of the source pointer does not outlive lifetime bound of the object type
 }
 
-fn g<'a, T, U>(v: &'a A<U>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `U`
+fn main() {
 }
-
-fn h<'a, T: 'static>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: // ok
-}
-
-fn main() {}
-

--- a/src/test/compile-fail/regionck-uniq-trait-coerce-fail.rs
+++ b/src/test/compile-fail/regionck-uniq-trait-coerce-fail.rs
@@ -8,23 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait A<T> {}
-struct B<'a, T>(&'a A<T>);
+// Test that lifetimes can't escape through owned trait coercions
 
-trait X<'a> {}
-impl<'a, T> X<'a> for B<'a, T> {}
+trait A {}
+impl<'a> A for &'a A {}
 
-fn f<'a, T, U>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `T`
+struct B;
+impl A for B {}
+impl<'a> A for &'a B {}
+
+fn main() {
+    let _tmp = {
+        let bb = B;
+        let pb = ~&bb; //~ ERROR `bb` does not live long enough
+        let aa: ~A: = pb;
+        aa
+    };
 }
-
-fn g<'a, T, U>(v: &'a A<U>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `U`
-}
-
-fn h<'a, T: 'static>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: // ok
-}
-
-fn main() {}
-

--- a/src/test/run-pass/regionck-uniq-trait-cast-pass.rs
+++ b/src/test/run-pass/regionck-uniq-trait-cast-pass.rs
@@ -8,23 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait A<T> {}
-struct B<'a, T>(&'a A<T>);
+// Test that trait lifetime params aren't constrained to static lifetime
+// when casting something to owned trait
 
 trait X<'a> {}
-impl<'a, T> X<'a> for B<'a, T> {}
+impl<'a> X<'a> for &'a X<'a> {}
 
-fn f<'a, T, U>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `T`
+fn foo<'a>(x: &'a X<'a>) -> ~X<'a>: {
+    ~x as ~X<'a>:
 }
 
-fn g<'a, T, U>(v: &'a A<U>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `U`
+pub fn main() {
 }
-
-fn h<'a, T: 'static>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: // ok
-}
-
-fn main() {}
-

--- a/src/test/run-pass/regionck-uniq-trait-coerce-pass.rs
+++ b/src/test/run-pass/regionck-uniq-trait-coerce-pass.rs
@@ -8,23 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait A<T> {}
-struct B<'a, T>(&'a A<T>);
+// Test that trait lifetime params aren't constrained to static lifetime
+// when coercing something to owned trait
 
-trait X<'a> {}
-impl<'a, T> X<'a> for B<'a, T> {}
+trait A<'a> {}
+impl<'a> A<'a> for &'a A<'a> {}
 
-fn f<'a, T, U>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `T`
+struct B;
+impl<'a> A<'a> for B {}
+impl<'a> A<'a> for &'a B {}
+
+pub fn main() {
+    let bb = B;
+    let _tmp = {
+        let pb = ~&bb;
+        let aa: ~A: = pb;
+        aa
+    };
 }
-
-fn g<'a, T, U>(v: &'a A<U>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: //~ ERROR value may contain references; add `'static` bound to `U`
-}
-
-fn h<'a, T: 'static>(v: &'a A<T>) -> ~X<'a>: {
-    ~B(v) as ~X<'a>: // ok
-}
-
-fn main() {}
-


### PR DESCRIPTION
Regionck didn't do any checks for casts/coercions to an owned trait,
which resulted in lifetimes of the source pointer
to be ignored in the result of such cast.

This fix constraints all regions of the source type of the cast/coercion to be superregions
of each region of the target type (if target trait definition has some lifetime params),
or of 'static lifetime (if there're no lifetime params in target trait's definition).

Closes #5723
Closes #9745
Closes #11971
