### PR TITLE
native: Use WNOHANG before signaling

### DIFF
--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -2356,6 +2356,8 @@ pub mod consts {
 
             pub static CLOCK_REALTIME: c_int = 0;
             pub static CLOCK_MONOTONIC: c_int = 1;
+
+            pub static WNOHANG: c_int = 1;
         }
         pub mod posix08 {
         }
@@ -2802,6 +2804,8 @@ pub mod consts {
 
             pub static CLOCK_REALTIME: c_int = 0;
             pub static CLOCK_MONOTONIC: c_int = 4;
+
+            pub static WNOHANG: c_int = 1;
         }
         pub mod posix08 {
         }
@@ -3187,6 +3191,8 @@ pub mod consts {
             pub static PTHREAD_CREATE_JOINABLE: c_int = 1;
             pub static PTHREAD_CREATE_DETACHED: c_int = 2;
             pub static PTHREAD_STACK_MIN: size_t = 8192;
+
+            pub static WNOHANG: c_int = 1;
         }
         pub mod posix08 {
         }


### PR DESCRIPTION
It turns out that on linux, and possibly other platforms, child processes will
continue to accept signals until they have been _reaped_. This means that once
the child has exited, it will succeed to receive signals until waitpid() has
been invoked on it.

This is unfortunate behavior, and differs from what is seen on OSX and windows.
This commit changes the behavior of Process::signal() to be the same across
platforms, and updates the documentation of Process::kill() to note that when
signaling a foreign process it may accept signals until reaped.

Implementation-wise, this invokes waitpid() with WNOHANG before each signal to
the child to ensure that if the child has exited that we will reap it. Other
possibilities include installing a SIGCHLD signal handler, but at this time I
believe that that's too complicated.

Closes #13124
