### PR TITLE
WIP: Fix `ty_trait` variance inference bug

### DIFF
--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -671,8 +671,19 @@ impl<'a> ConstraintContext<'a> {
                                                  substs, variance);
             }
 
-            ty::ty_trait(~ty::TyTrait { def_id, ref substs, .. }) => {
+            ty::ty_trait(~ty::TyTrait { def_id, ref substs, store, mutability, .. }) => {
+                match store {
+                    ty::RegionTraitStore(region) => {
+                        let contra = self.contravariant(variance);
+                        self.add_constraints_from_region(region, contra);
+                    }
+                    ty::UniqTraitStore => {},
+                }
                 let trait_def = ty::lookup_trait_def(self.tcx(), def_id);
+                let variance = match mutability {
+                    ast::MutMutable => self.invariant(variance),
+                    ast::MutImmutable => variance,
+                };
                 self.add_constraints_from_substs(def_id, &trait_def.generics,
                                                  substs, variance);
             }
@@ -778,6 +789,8 @@ impl<'a> ConstraintContext<'a> {
     fn add_constraints_from_region(&mut self,
                                    region: ty::Region,
                                    variance: VarianceTermPtr<'a>) {
+        debug!("add_constraints_from_region(region={}, variance={})",
+                region.repr(self.tcx()), variance.to_str());
         match region {
             ty::ReEarlyBound(param_id, _, _) => {
                 let index = self.inferred_index(param_id);


### PR DESCRIPTION
The lifetime parameter and mutability of a trait reference aren't
accounted for in variance inference pass.

Note: libserialize/json.rs won't be able to compile with this patch.
