### PR TITLE
rustuv: Handle short writes in uv_fs_write

### DIFF
--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -426,7 +426,7 @@ pub unsafe fn set_stdio_container_stream(c: *uv_stdio_container_t,
 }
 
 // data access helpers
-pub unsafe fn get_result_from_fs_req(req: *uv_fs_t) -> c_int {
+pub unsafe fn get_result_from_fs_req(req: *uv_fs_t) -> ssize_t {
     rust_uv_get_result_from_fs_req(req)
 }
 pub unsafe fn get_ptr_from_fs_req(req: *uv_fs_t) -> *libc::c_void {
@@ -501,7 +501,7 @@ extern {
     fn rust_uv_get_udp_handle_from_send_req(req: *uv_udp_send_t) -> *uv_udp_t;
 
     fn rust_uv_populate_uv_stat(req_in: *uv_fs_t, stat_out: *uv_stat_t);
-    fn rust_uv_get_result_from_fs_req(req: *uv_fs_t) -> c_int;
+    fn rust_uv_get_result_from_fs_req(req: *uv_fs_t) -> ssize_t;
     fn rust_uv_get_ptr_from_fs_req(req: *uv_fs_t) -> *libc::c_void;
     fn rust_uv_get_path_from_fs_req(req: *uv_fs_t) -> *c_char;
     fn rust_uv_get_loop_from_fs_req(req: *uv_fs_t) -> *uv_loop_t;

--- a/src/rt/rust_uv.c
+++ b/src/rt/rust_uv.c
@@ -97,7 +97,7 @@ rust_uv_req_type_max() {
   return UV_REQ_TYPE_MAX;
 }
 
-int
+ssize_t
 rust_uv_get_result_from_fs_req(uv_fs_t* req) {
   return req->result;
 }


### PR DESCRIPTION
The libuv fs wrappers are very thin wrappers around the syscalls they correspond
to, and a notable worrisome case is the write syscall. This syscall is not
guaranteed to write the entire buffer provided, so we may have to continue
calling uv_fs_write if a short write occurs.

Closes #13130
