### PR TITLE
std: Explicitly link to libm for freebsd

### DIFF
--- a/src/libstd/rtdeps.rs
+++ b/src/libstd/rtdeps.rs
@@ -38,6 +38,7 @@ extern {}
 #[cfg(target_os = "freebsd")]
 #[link(name = "execinfo")]
 #[link(name = "pthread")]
+#[link(name = "m")]
 extern {}
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Apparently we had forgotten to do this for freebsd, causing possible problems
on FreeBSD 10. The discussion in #12324 has some more details about how it's
missing.
