### PR TITLE
mk: Use rwildcard to calculate dependent files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -177,10 +177,10 @@ include config.mk
 
 # Just a few macros used everywhere
 include $(CFG_SRC_DIR)mk/util.mk
-# All crates and their dependencies
-include $(CFG_SRC_DIR)mk/crates.mk
 # Reconfiguring when the makefiles or submodules change
 include $(CFG_SRC_DIR)mk/reconfig.mk
+# All crates and their dependencies
+include $(CFG_SRC_DIR)mk/crates.mk
 # Various bits of setup, common macros, and top-level rules
 include $(CFG_SRC_DIR)mk/main.mk
 # C and assembly components that are not LLVM

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -105,8 +105,7 @@ COMPILER_DOC_CRATES := rustc syntax
 # $(1) is the crate to generate variables for
 define RUST_CRATE
 CRATEFILE_$(1) := $$(S)src/lib$(1)/lib.rs
-RSINPUTS_$(1) := $$(wildcard $$(addprefix $(S)src/lib$(1), \
-				*.rs */*.rs */*/*.rs */*/*/*.rs))
+RSINPUTS_$(1) := $$(call rwildcard,$(S)src/lib$(1)/,*.rs)
 RUST_DEPS_$(1) := $$(filter-out native:%,$$(DEPS_$(1)))
 NATIVE_DEPS_$(1) := $$(patsubst native:%,%,$$(filter native:%,$$(DEPS_$(1))))
 endef
@@ -117,8 +116,7 @@ $(foreach crate,$(CRATES),$(eval $(call RUST_CRATE,$(crate))))
 #
 # $(1) is the crate to generate variables for
 define RUST_TOOL
-TOOL_INPUTS_$(1) := $$(wildcard $$(addprefix $$(dir $$(TOOL_SOURCE_$(1))), \
-				*.rs */*.rs */*/*.rs */*/*/*.rs))
+TOOL_INPUTS_$(1) := $$(call rwildcard,$$(dir $$(TOOL_SOURCE_$(1))),*.rs)
 endef
 
 $(foreach crate,$(TOOLS),$(eval $(call RUST_TOOL,$(crate))))


### PR DESCRIPTION
The previous dependency calculation was based on an arbitrary set of asterisks
at an arbitrary depth, but using the recursive version should be much more
robust in figuring out what's dependent.
