### PR TITLE
Initial support for emitting DWARF for static variables

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -277,6 +277,7 @@ pub mod debuginfo {
     pub type DIDerivedType = DIType;
     pub type DICompositeType = DIDerivedType;
     pub type DIVariable = DIDescriptor;
+    pub type DIGlobalVariable = DIDescriptor;
     pub type DIArray = DIDescriptor;
     pub type DISubrange = DIDescriptor;
 
@@ -1588,6 +1589,18 @@ pub mod llvm {
                                                Line: c_uint,
                                                Col: c_uint)
                                                -> DILexicalBlock;
+
+        pub fn LLVMDIBuilderCreateStaticVariable(Builder: DIBuilderRef,
+                                                 Context: DIDescriptor,
+                                                 Name: *c_char,
+                                                 LinkageName: *c_char,
+                                                 File: DIFile,
+                                                 LineNo: c_uint,
+                                                 Ty: DIType,
+                                                 isLocalToUnit: bool,
+                                                 Val: ValueRef,
+                                                 Decl: ValueRef)
+                                                 -> DIGlobalVariable;
 
         pub fn LLVMDIBuilderCreateLocalVariable(Builder: DIBuilderRef,
                                                 Tag: c_uint,

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -28,6 +28,7 @@ use middle::trans::inline;
 use middle::trans::machine;
 use middle::trans::type_::Type;
 use middle::trans::type_of;
+use middle::trans::debuginfo;
 use middle::ty;
 use util::ppaux::{Repr, ty_to_str};
 
@@ -688,5 +689,6 @@ pub fn trans_const(ccx: &CrateContext, m: ast::Mutability, id: ast::NodeId) {
         if m != ast::MutMutable {
             llvm::LLVMSetGlobalConstant(g, True);
         }
+        debuginfo::create_global_var_metadata(ccx, id, g);
     }
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -323,6 +323,28 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateLexicalBlock(
         unwrapDI<DIFile>(File), Line, Col));
 }
 
+extern "C" LLVMValueRef LLVMDIBuilderCreateStaticVariable(
+    DIBuilderRef Builder,
+    LLVMValueRef Context,
+    const char* Name,
+    const char* LinkageName,
+    LLVMValueRef File,
+    unsigned LineNo,
+    LLVMValueRef Ty,
+    bool isLocalToUnit,
+    LLVMValueRef Val,
+    LLVMValueRef Decl = NULL) {
+    return wrap(Builder->createStaticVariable(unwrapDI<DIDescriptor>(Context),
+        Name,
+        LinkageName,
+        unwrapDI<DIFile>(File),
+        LineNo,
+        unwrapDI<DIType>(Ty),
+        isLocalToUnit,
+        unwrap(Val),
+        unwrapDI<MDNode*>(Decl)));
+}
+
 extern "C" LLVMValueRef LLVMDIBuilderCreateLocalVariable(
     DIBuilderRef Builder,
     unsigned Tag,

--- a/src/rustllvm/rustllvm.def.in
+++ b/src/rustllvm/rustllvm.def.in
@@ -586,6 +586,7 @@ LLVMDIBuilderCreate
 LLVMDIBuilderDispose
 LLVMDIBuilderFinalize
 LLVMDIBuilderCreateCompileUnit
+LLVMDIBuilderCreateStaticVariable
 LLVMDIBuilderCreateLocalVariable
 LLVMDIBuilderCreateFunction
 LLVMDIBuilderCreateFile

--- a/src/test/debug-info/basic-types-globals-metadata.rs
+++ b/src/test/debug-info/basic-types-globals-metadata.rs
@@ -1,0 +1,68 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-android: FIXME(#10381)
+
+// compile-flags:-g
+// debugger:rbreak zzz
+// debugger:run
+// debugger:finish
+// debugger:whatis 'basic-types-globals-metadata::B'
+// check:type = bool
+// debugger:whatis 'basic-types-globals-metadata::I'
+// check:type = int
+// debugger:whatis 'basic-types-globals-metadata::C'
+// check:type = char
+// debugger:whatis 'basic-types-globals-metadata::I8'
+// check:type = i8
+// debugger:whatis 'basic-types-globals-metadata::I16'
+// check:type = i16
+// debugger:whatis 'basic-types-globals-metadata::I32'
+// check:type = i32
+// debugger:whatis 'basic-types-globals-metadata::I64'
+// check:type = i64
+// debugger:whatis 'basic-types-globals-metadata::U'
+// check:type = uint
+// debugger:whatis 'basic-types-globals-metadata::U8'
+// check:type = u8
+// debugger:whatis 'basic-types-globals-metadata::U16'
+// check:type = u16
+// debugger:whatis 'basic-types-globals-metadata::U32'
+// check:type = u32
+// debugger:whatis 'basic-types-globals-metadata::U64'
+// check:type = u64
+// debugger:whatis 'basic-types-globals-metadata::F32'
+// check:type = f32
+// debugger:whatis 'basic-types-globals-metadata::F64'
+// check:type = f64
+// debugger:continue
+
+#[allow(unused_variable)];
+
+static B: bool = false;
+static I: int = -1;
+static C: char = 'a';
+static I8: i8 = 68;
+static I16: i16 = -16;
+static I32: i32 = -32;
+static I64: i64 = -64;
+static U: uint = 1;
+static U8: u8 = 100;
+static U16: u16 = 16;
+static U32: u32 = 32;
+static U64: u64 = 64;
+static F32: f32 = 2.5;
+static F64: f64 = 3.5;
+
+fn main() {
+    _zzz();
+}
+
+fn _zzz() {()}

--- a/src/test/debug-info/basic-types-globals.rs
+++ b/src/test/debug-info/basic-types-globals.rs
@@ -1,0 +1,74 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Caveats - gdb prints any 8-bit value (meaning rust I8 and u8 values)
+// as its numerical value along with its associated ASCII char, there
+// doesn't seem to be any way around this. Also, gdb doesn't know
+// about UTF-32 character encoding and will print a rust char as only
+// its numerical value.
+
+// ignore-android: FIXME(#10381)
+
+// compile-flags:-g
+// debugger:rbreak zzz
+// debugger:run
+// debugger:finish
+// debugger:print 'basic-types-globals::B'
+// check:$1 = false
+// debugger:print 'basic-types-globals::I'
+// check:$2 = -1
+// debugger:print 'basic-types-globals::C'
+// check:$3 = 97
+// debugger:print/d 'basic-types-globals::I8'
+// check:$4 = 68
+// debugger:print 'basic-types-globals::I16'
+// check:$5 = -16
+// debugger:print 'basic-types-globals::I32'
+// check:$6 = -32
+// debugger:print 'basic-types-globals::I64'
+// check:$7 = -64
+// debugger:print 'basic-types-globals::U'
+// check:$8 = 1
+// debugger:print/d 'basic-types-globals::U8'
+// check:$9 = 100
+// debugger:print 'basic-types-globals::U16'
+// check:$10 = 16
+// debugger:print 'basic-types-globals::U32'
+// check:$11 = 32
+// debugger:print 'basic-types-globals::U64'
+// check:$12 = 64
+// debugger:print 'basic-types-globals::F32'
+// check:$13 = 2.5
+// debugger:print 'basic-types-globals::F64'
+// check:$14 = 3.5
+// debugger:continue
+
+#[allow(unused_variable)];
+
+static B: bool = false;
+static I: int = -1;
+static C: char = 'a';
+static I8: i8 = 68;
+static I16: i16 = -16;
+static I32: i32 = -32;
+static I64: i64 = -64;
+static U: uint = 1;
+static U8: u8 = 100;
+static U16: u16 = 16;
+static U32: u32 = 32;
+static U64: u64 = 64;
+static F32: f32 = 2.5;
+static F64: f64 = 3.5;
+
+fn main() {
+    _zzz();
+}
+
+fn _zzz() {()}

--- a/src/test/debug-info/basic-types-metadata.rs
+++ b/src/test/debug-info/basic-types-metadata.rs
@@ -46,8 +46,7 @@
 // check:type = f64
 // debugger:info functions _yyy
 // check:[...]![...]_yyy([...])([...]);
-// debugger:detach
-// debugger:quit
+// debugger:continue
 
 #[allow(unused_variable)];
 

--- a/src/test/debug-info/basic-types-mut-globals.rs
+++ b/src/test/debug-info/basic-types-mut-globals.rs
@@ -1,0 +1,128 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Caveats - gdb prints any 8-bit value (meaning rust I8 and u8 values)
+// as its numerical value along with its associated ASCII char, there
+// doesn't seem to be any way around this. Also, gdb doesn't know
+// about UTF-32 character encoding and will print a rust char as only
+// its numerical value.
+
+// ignore-android: FIXME(#10381)
+
+// compile-flags:-g
+// debugger:rbreak zzz
+// debugger:run
+// debugger:finish
+
+// Check initializers
+// debugger:print 'basic-types-mut-globals::B'
+// check:$1 = false
+// debugger:print 'basic-types-mut-globals::I'
+// check:$2 = -1
+// debugger:print 'basic-types-mut-globals::C'
+// check:$3 = 97
+// debugger:print/d 'basic-types-mut-globals::I8'
+// check:$4 = 68
+// debugger:print 'basic-types-mut-globals::I16'
+// check:$5 = -16
+// debugger:print 'basic-types-mut-globals::I32'
+// check:$6 = -32
+// debugger:print 'basic-types-mut-globals::I64'
+// check:$7 = -64
+// debugger:print 'basic-types-mut-globals::U'
+// check:$8 = 1
+// debugger:print/d 'basic-types-mut-globals::U8'
+// check:$9 = 100
+// debugger:print 'basic-types-mut-globals::U16'
+// check:$10 = 16
+// debugger:print 'basic-types-mut-globals::U32'
+// check:$11 = 32
+// debugger:print 'basic-types-mut-globals::U64'
+// check:$12 = 64
+// debugger:print 'basic-types-mut-globals::F32'
+// check:$13 = 2.5
+// debugger:print 'basic-types-mut-globals::F64'
+// check:$14 = 3.5
+// debugger:continue
+
+// Check new values
+// debugger:print 'basic-types-mut-globals'::B
+// check:$15 = true
+// debugger:print 'basic-types-mut-globals'::I
+// check:$16 = 2
+// debugger:print 'basic-types-mut-globals'::C
+// check:$17 = 102
+// debugger:print/d 'basic-types-mut-globals'::I8
+// check:$18 = 78
+// debugger:print 'basic-types-mut-globals'::I16
+// check:$19 = -26
+// debugger:print 'basic-types-mut-globals'::I32
+// check:$20 = -12
+// debugger:print 'basic-types-mut-globals'::I64
+// check:$21 = -54
+// debugger:print 'basic-types-mut-globals'::U
+// check:$22 = 5
+// debugger:print/d 'basic-types-mut-globals'::U8
+// check:$23 = 20
+// debugger:print 'basic-types-mut-globals'::U16
+// check:$24 = 32
+// debugger:print 'basic-types-mut-globals'::U32
+// check:$25 = 16
+// debugger:print 'basic-types-mut-globals'::U64
+// check:$26 = 128
+// debugger:print 'basic-types-mut-globals'::F32
+// check:$27 = 5.75
+// debugger:print 'basic-types-mut-globals'::F64
+// check:$28 = 9.25
+
+// debugger:detach
+// debugger:quit
+
+#[allow(unused_variable)];
+
+static mut B: bool = false;
+static mut I: int = -1;
+static mut C: char = 'a';
+static mut I8: i8 = 68;
+static mut I16: i16 = -16;
+static mut I32: i32 = -32;
+static mut I64: i64 = -64;
+static mut U: uint = 1;
+static mut U8: u8 = 100;
+static mut U16: u16 = 16;
+static mut U32: u32 = 32;
+static mut U64: u64 = 64;
+static mut F32: f32 = 2.5;
+static mut F64: f64 = 3.5;
+
+fn main() {
+    _zzz();
+
+    unsafe {
+        B = true;
+        I = 2;
+        C = 'f';
+        I8 = 78;
+        I16 = -26;
+        I32 = -12;
+        I64 = -54;
+        U = 5;
+        U8 = 20;
+        U16 = 32;
+        U32 = 16;
+        U64 = 128;
+        F32 = 5.75;
+        F64 = 9.25;
+    }
+
+    _zzz();
+}
+
+fn _zzz() {()}

--- a/src/test/debug-info/c-style-enum.rs
+++ b/src/test/debug-info/c-style-enum.rs
@@ -12,29 +12,63 @@
 
 // compile-flags:-g
 // debugger:rbreak zzz
+
+// debugger:print 'c-style-enum::SINGLE_VARIANT'
+// check:$1 = TheOnlyVariant
+
+// debugger:print 'c-style-enum::AUTO_ONE'
+// check:$2 = One
+
+// debugger:print 'c-style-enum::AUTO_TWO'
+// check:$3 = One
+
+// debugger:print 'c-style-enum::AUTO_THREE'
+// check:$4 = One
+
+// debugger:print 'c-style-enum::MANUAL_ONE'
+// check:$5 = OneHundred
+
+// debugger:print 'c-style-enum::MANUAL_TWO'
+// check:$6 = OneHundred
+
+// debugger:print 'c-style-enum::MANUAL_THREE'
+// check:$7 = OneHundred
+
 // debugger:run
 // debugger:finish
 
 // debugger:print auto_one
-// check:$1 = One
+// check:$8 = One
 
 // debugger:print auto_two
-// check:$2 = Two
+// check:$9 = Two
 
 // debugger:print auto_three
-// check:$3 = Three
+// check:$10 = Three
 
 // debugger:print manual_one_hundred
-// check:$4 = OneHundred
+// check:$11 = OneHundred
 
 // debugger:print manual_one_thousand
-// check:$5 = OneThousand
+// check:$12 = OneThousand
 
 // debugger:print manual_one_million
-// check:$6 = OneMillion
+// check:$13 = OneMillion
 
 // debugger:print single_variant
-// check:$7 = TheOnlyVariant
+// check:$14 = TheOnlyVariant
+
+// debugger:print 'c-style-enum::AUTO_TWO'
+// check:$15 = Two
+
+// debugger:print 'c-style-enum::AUTO_THREE'
+// check:$16 = Three
+
+// debugger:print 'c-style-enum::MANUAL_TWO'
+// check:$17 = OneThousand
+
+// debugger:print 'c-style-enum::MANUAL_THREE'
+// check:$18 = OneMillion
 
 #[allow(unused_variable)];
 
@@ -54,6 +88,16 @@ enum SingleVariant {
     TheOnlyVariant
 }
 
+static SINGLE_VARIANT: SingleVariant = TheOnlyVariant;
+
+static mut AUTO_ONE: AutoDiscriminant = One;
+static mut AUTO_TWO: AutoDiscriminant = One;
+static mut AUTO_THREE: AutoDiscriminant = One;
+
+static mut MANUAL_ONE: ManualDiscriminant = OneHundred;
+static mut MANUAL_TWO: ManualDiscriminant = OneHundred;
+static mut MANUAL_THREE: ManualDiscriminant = OneHundred;
+
 fn main() {
 
     let auto_one = One;
@@ -65,6 +109,14 @@ fn main() {
     let manual_one_million = OneMillion;
 
     let single_variant = TheOnlyVariant;
+
+    unsafe {
+        AUTO_TWO = Two;
+        AUTO_THREE = Three;
+
+        MANUAL_TWO = OneThousand;
+        MANUAL_THREE = OneMillion;
+    };
 
     zzz();
 }

--- a/src/test/debug-info/lexical-scopes-in-block-expression.rs
+++ b/src/test/debug-info/lexical-scopes-in-block-expression.rs
@@ -15,29 +15,26 @@
 // debugger:rbreak zzz
 // debugger:run
 
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$1 = 0
+
 // STRUCT EXPRESSION
 // debugger:finish
 // debugger:print val
-// check:$1 = -1
+// check:$2 = -1
 // debugger:print ten
-// check:$2 = 10
+// check:$3 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$3 = 11
-// debugger:print ten
-// check:$4 = 10
-// debugger:continue
-
-// debugger:finish
-// debugger:print val
-// check:$5 = -1
+// check:$4 = 11
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$5 = 1
 // debugger:print ten
 // check:$6 = 10
 // debugger:continue
 
-// FUNCTION CALL
 // debugger:finish
 // debugger:print val
 // check:$7 = -1
@@ -45,57 +42,55 @@
 // check:$8 = 10
 // debugger:continue
 
+// FUNCTION CALL
 // debugger:finish
 // debugger:print val
-// check:$9 = 12
+// check:$9 = -1
 // debugger:print ten
 // check:$10 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$11 = -1
+// check:$11 = 12
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$12 = 2
 // debugger:print ten
-// check:$12 = 10
+// check:$13 = 10
+// debugger:continue
+
+// debugger:finish
+// debugger:print val
+// check:$14 = -1
+// debugger:print ten
+// check:$15 = 10
 // debugger:continue
 
 // TUPLE EXPRESSION
 // debugger:finish
 // debugger:print val
-// check:$13 = -1
+// check:$16 = -1
 // debugger:print ten
-// check:$14 = 10
+// check:$17 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$15 = 13
-// debugger:print ten
-// check:$16 = 10
-// debugger:continue
-
-// debugger:finish
-// debugger:print val
-// check:$17 = -1
-// debugger:print ten
-// check:$18 = 10
-// debugger:continue
-
-// VEC EXPRESSION
-// debugger:finish
-// debugger:print val
-// check:$19 = -1
+// check:$18 = 13
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$19 = 3
 // debugger:print ten
 // check:$20 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$21 = 14
+// check:$21 = -1
 // debugger:print ten
 // check:$22 = 10
 // debugger:continue
 
+// VEC EXPRESSION
 // debugger:finish
 // debugger:print val
 // check:$23 = -1
@@ -103,39 +98,35 @@
 // check:$24 = 10
 // debugger:continue
 
+// debugger:finish
+// debugger:print val
+// check:$25 = 14
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$26 = 4
+// debugger:print ten
+// check:$27 = 10
+// debugger:continue
+
+// debugger:finish
+// debugger:print val
+// check:$28 = -1
+// debugger:print ten
+// check:$29 = 10
+// debugger:continue
+
 // REPEAT VEC EXPRESSION
 // debugger:finish
 // debugger:print val
-// check:$25 = -1
+// check:$30 = -1
 // debugger:print ten
-// check:$26 = 10
+// check:$31 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$27 = 15
-// debugger:print ten
-// check:$28 = 10
-// debugger:continue
-
-// debugger:finish
-// debugger:print val
-// check:$29 = -1
-// debugger:print ten
-// check:$30 = 10
-// debugger:continue
-
-// ASSIGNMENT EXPRESSION
-// debugger:finish
-// debugger:print val
-// check:$31 = -1
-// debugger:print ten
-// check:$32 = 10
-// debugger:continue
-
-// debugger:finish
-// debugger:print val
-// check:$33 = 16
+// check:$32 = 15
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$33 = 5
 // debugger:print ten
 // check:$34 = 10
 // debugger:continue
@@ -147,8 +138,7 @@
 // check:$36 = 10
 // debugger:continue
 
-
-// ARITHMETIC EXPRESSION
+// ASSIGNMENT EXPRESSION
 // debugger:finish
 // debugger:print val
 // check:$37 = -1
@@ -158,39 +148,73 @@
 
 // debugger:finish
 // debugger:print val
-// check:$39 = 17
+// check:$39 = 16
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$40 = 6
 // debugger:print ten
-// check:$40 = 10
+// check:$41 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$41 = -1
+// check:$42 = -1
 // debugger:print ten
-// check:$42 = 10
+// check:$43 = 10
+// debugger:continue
+
+
+// ARITHMETIC EXPRESSION
+// debugger:finish
+// debugger:print val
+// check:$44 = -1
+// debugger:print ten
+// check:$45 = 10
+// debugger:continue
+
+// debugger:finish
+// debugger:print val
+// check:$46 = 17
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$47 = 7
+// debugger:print ten
+// check:$48 = 10
+// debugger:continue
+
+// debugger:finish
+// debugger:print val
+// check:$49 = -1
+// debugger:print ten
+// check:$50 = 10
 // debugger:continue
 
 // INDEX EXPRESSION
 // debugger:finish
 // debugger:print val
-// check:$43 = -1
+// check:$51 = -1
 // debugger:print ten
-// check:$44 = 10
+// check:$52 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$45 = 18
+// check:$53 = 18
+// debugger:print 'lexical-scopes-in-block-expression::MUT_INT'
+// check:$54 = 8
 // debugger:print ten
-// check:$46 = 10
+// check:$55 = 10
 // debugger:continue
 
 // debugger:finish
 // debugger:print val
-// check:$47 = -1
+// check:$56 = -1
 // debugger:print ten
-// check:$48 = 10
+// check:$57 = 10
 // debugger:continue
+
+#[allow(unused_variable)];
+#[allow(dead_assignment)];
+
+static mut MUT_INT: int = 0;
 
 struct Point {
     x: int,
@@ -213,6 +237,7 @@ fn main() {
             sentinel();
 
             let val = ten + 1;
+            unsafe {MUT_INT = 1;};
 
             zzz();
             sentinel();
@@ -231,6 +256,7 @@ fn main() {
         sentinel();
 
         let val = ten + 2;
+        unsafe {MUT_INT = 2;};
 
         zzz();
         sentinel();
@@ -248,6 +274,7 @@ fn main() {
         sentinel();
 
         let val = ten + 3;
+        unsafe {MUT_INT = 3;};
 
         zzz();
         sentinel();
@@ -264,6 +291,7 @@ fn main() {
         sentinel();
 
         let val = ten + 4;
+        unsafe {MUT_INT = 4;};
 
         zzz();
         sentinel();
@@ -280,6 +308,7 @@ fn main() {
         sentinel();
 
         let val = ten + 5;
+        unsafe {MUT_INT = 5;};
 
         zzz();
         sentinel();
@@ -297,6 +326,7 @@ fn main() {
         sentinel();
 
         let val = ten + 6;
+        unsafe {MUT_INT = 6;};
 
         zzz();
         sentinel();
@@ -313,6 +343,7 @@ fn main() {
         sentinel();
 
         let val = ten + 7;
+        unsafe {MUT_INT = 7;};
 
         zzz();
         sentinel();
@@ -330,6 +361,7 @@ fn main() {
         sentinel();
 
         let val = ten + 8;
+        unsafe {MUT_INT = 8;};
 
         zzz();
         sentinel();

--- a/src/test/debug-info/simple-struct.rs
+++ b/src/test/debug-info/simple-struct.rs
@@ -13,28 +13,66 @@
 // compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
+
+// debugger:print 'simple-struct::NO_PADDING_16'
+// check:$1 = {x = 1000, y = -1001}
+
+// debugger:print 'simple-struct::NO_PADDING_32'
+// check:$2 = {x = 1, y = 2, z = 3}
+
+// debugger:print 'simple-struct::NO_PADDING_64'
+// check:$3 = {x = 4, y = 5, z = 6}
+
+// debugger:print 'simple-struct::NO_PADDING_163264'
+// check:$4 = {a = 7, b = 8, c = 9, d = 10}
+
+// debugger:print 'simple-struct::INTERNAL_PADDING'
+// check:$5 = {x = 11, y = 12}
+
+// debugger:print 'simple-struct::PADDING_AT_END'
+// check:$6 = {x = 13, y = 14}
+
 // debugger:run
 // debugger:finish
 
 // debugger:print no_padding16
-// check:$1 = {x = 10000, y = -10001}
+// check:$7 = {x = 10000, y = -10001}
 
 // debugger:print no_padding32
-// check:$2 = {x = -10002, y = -10003.5, z = 10004}
+// check:$8 = {x = -10002, y = -10003.5, z = 10004}
 
 // debugger:print no_padding64
-// check:$3 = {x = -10005.5, y = 10006, z = 10007}
+// check:$9 = {x = -10005.5, y = 10006, z = 10007}
 
 // debugger:print no_padding163264
-// check:$4 = {a = -10008, b = 10009, c = 10010, d = 10011}
+// check:$10 = {a = -10008, b = 10009, c = 10010, d = 10011}
 
 // debugger:print internal_padding
-// check:$5 = {x = 10012, y = -10013}
+// check:$11 = {x = 10012, y = -10013}
 
 // debugger:print padding_at_end
-// check:$6 = {x = -10014, y = 10015}
+// check:$12 = {x = -10014, y = 10015}
+
+// debugger:print 'simple-struct::NO_PADDING_16'
+// check:$13 = {x = 100, y = -101}
+
+// debugger:print 'simple-struct::NO_PADDING_32'
+// check:$14 = {x = -15, y = -16, z = 17}
+
+// debugger:print 'simple-struct::NO_PADDING_64'
+// check:$15 = {x = -18, y = 19, z = 20}
+
+// debugger:print 'simple-struct::NO_PADDING_163264'
+// check:$16 = {a = -21, b = 22, c = 23, d = 24}
+
+// debugger:print 'simple-struct::INTERNAL_PADDING'
+// check:$17 = {x = 25, y = -26}
+
+// debugger:print 'simple-struct::PADDING_AT_END'
+// check:$18 = {x = -27, y = 28}
 
 #[allow(unused_variable)];
+#[allow(dead_code)];
 
 struct NoPadding16 {
     x: u16,
@@ -70,6 +108,40 @@ struct PaddingAtEnd {
     y: u16
 }
 
+static mut NO_PADDING_16: NoPadding16 = NoPadding16 {
+    x: 1000,
+    y: -1001
+};
+
+static mut NO_PADDING_32: NoPadding32 = NoPadding32 {
+    x: 1,
+    y: 2.0,
+    z: 3
+};
+
+static mut NO_PADDING_64: NoPadding64 = NoPadding64 {
+    x: 4.0,
+    y: 5,
+    z: 6
+};
+
+static mut NO_PADDING_163264: NoPadding163264 = NoPadding163264 {
+    a: 7,
+    b: 8,
+    c: 9,
+    d: 10
+};
+
+static mut INTERNAL_PADDING: InternalPadding = InternalPadding {
+    x: 11,
+    y: 12
+};
+
+static mut PADDING_AT_END: PaddingAtEnd = PaddingAtEnd {
+    x: 13,
+    y: 14
+};
+
 fn main() {
     let no_padding16 = NoPadding16 { x: 10000, y: -10001 };
     let no_padding32 = NoPadding32 { x: -10002, y: -10003.5, z: 10004 };
@@ -78,6 +150,30 @@ fn main() {
 
     let internal_padding = InternalPadding { x: 10012, y: -10013 };
     let padding_at_end = PaddingAtEnd { x: -10014, y: 10015 };
+
+    unsafe {
+        NO_PADDING_16.x = 100;
+        NO_PADDING_16.y = -101;
+
+        NO_PADDING_32.x = -15;
+        NO_PADDING_32.y = -16.0;
+        NO_PADDING_32.z = 17;
+
+        NO_PADDING_64.x = -18.0;
+        NO_PADDING_64.y = 19;
+        NO_PADDING_64.z = 20;
+
+        NO_PADDING_163264.a = -21;
+        NO_PADDING_163264.b = 22;
+        NO_PADDING_163264.c = 23;
+        NO_PADDING_163264.d = 24;
+
+        INTERNAL_PADDING.x = 25;
+        INTERNAL_PADDING.y = -26;
+
+        PADDING_AT_END.x = -27;
+        PADDING_AT_END.y = 28;
+    }
 
     zzz();
 }

--- a/src/test/debug-info/simple-tuple.rs
+++ b/src/test/debug-info/simple-tuple.rs
@@ -13,27 +13,74 @@
 // compile-flags:-g
 // debugger:set print pretty off
 // debugger:rbreak zzz
+
+// debugger:print/d 'simple-tuple::NO_PADDING_8'
+// check:$1 = {-50, 50}
+// debugger:print 'simple-tuple::NO_PADDING_16'
+// check:$2 = {-1, 2, 3}
+// debugger:print 'simple-tuple::NO_PADDING_32'
+// check:$3 = {4, 5, 6}
+// debugger:print 'simple-tuple::NO_PADDING_64'
+// check:$4 = {7, 8, 9}
+
+// debugger:print 'simple-tuple::INTERNAL_PADDING_1'
+// check:$5 = {10, 11}
+// debugger:print 'simple-tuple::INTERNAL_PADDING_2'
+// check:$6 = {12, 13, 14, 15}
+
+// debugger:print 'simple-tuple::PADDING_AT_END'
+// check:$7 = {16, 17}
+
 // debugger:run
 // debugger:finish
 
 // debugger:print/d noPadding8
-// check:$1 = {-100, 100}
+// check:$8 = {-100, 100}
 // debugger:print noPadding16
-// check:$2 = {0, 1, 2}
+// check:$9 = {0, 1, 2}
 // debugger:print noPadding32
-// check:$3 = {3, 4.5, 5}
+// check:$10 = {3, 4.5, 5}
 // debugger:print noPadding64
-// check:$4 = {6, 7.5, 8}
+// check:$11 = {6, 7.5, 8}
 
 // debugger:print internalPadding1
-// check:$5 = {9, 10}
+// check:$12 = {9, 10}
 // debugger:print internalPadding2
-// check:$6 = {11, 12, 13, 14}
+// check:$13 = {11, 12, 13, 14}
 
 // debugger:print paddingAtEnd
-// check:$7 = {15, 16}
+// check:$14 = {15, 16}
+
+// debugger:print/d 'simple-tuple::NO_PADDING_8'
+// check:$15 = {-127, 127}
+// debugger:print 'simple-tuple::NO_PADDING_16'
+// check:$16 = {-10, 10, 9}
+// debugger:print 'simple-tuple::NO_PADDING_32'
+// check:$17 = {14, 15, 16}
+// debugger:print 'simple-tuple::NO_PADDING_64'
+// check:$18 = {17, 18, 19}
+
+// debugger:print 'simple-tuple::INTERNAL_PADDING_1'
+// check:$19 = {110, 111}
+// debugger:print 'simple-tuple::INTERNAL_PADDING_2'
+// check:$20 = {112, 113, 114, 115}
+
+// debugger:print 'simple-tuple::PADDING_AT_END'
+// check:$21 = {116, 117}
 
 #[allow(unused_variable)];
+#[allow(dead_code)];
+
+static mut NO_PADDING_8: (i8, u8) = (-50, 50);
+static mut NO_PADDING_16: (i16, i16, u16) = (-1, 2, 3);
+
+static mut NO_PADDING_32: (i32, f32, u32) = (4, 5.0, 6);
+static mut NO_PADDING_64: (i64, f64, u64) = (7, 8.0, 9);
+
+static mut INTERNAL_PADDING_1: (i16, i32) = (10, 11);
+static mut INTERNAL_PADDING_2: (i16, i32, u32, u64) = (12, 13, 14, 15);
+
+static mut PADDING_AT_END: (i32, i16) = (16, 17);
 
 fn main() {
     let noPadding8: (i8, u8) = (-100, 100);
@@ -45,6 +92,19 @@ fn main() {
     let internalPadding2: (i16, i32, u32, u64) = (11, 12, 13, 14);
 
     let paddingAtEnd: (i32, i16) = (15, 16);
+
+    unsafe {
+        NO_PADDING_8 = (-127, 127);
+        NO_PADDING_16 = (-10, 10, 9);
+
+        NO_PADDING_32 = (14, 15.0, 16);
+        NO_PADDING_64 = (17, 18.0, 19);
+
+        INTERNAL_PADDING_1 = (110, 111);
+        INTERNAL_PADDING_2 = (112, 113, 114, 115);
+
+        PADDING_AT_END = (116, 117);
+    }
 
     zzz();
 }

--- a/src/test/debug-info/vec-slices.rs
+++ b/src/test/debug-info/vec-slices.rs
@@ -47,6 +47,11 @@
 // debugger:print padded_struct.data_ptr[1]
 // check:$13 = {x = 13, y = 14, z = 15}
 
+// debugger:print 'vec-slices::MUT_VECT_SLICE'.length
+// check:$14 = 2
+// debugger:print *((int64_t[2]*)('vec-slices::MUT_VECT_SLICE'.data_ptr))
+// check:$15 = {64, 65}
+
 #[allow(unused_variable)];
 
 struct AStruct {
@@ -54,6 +59,9 @@ struct AStruct {
     y: i32,
     z: i16
 }
+
+static VECT_SLICE: &'static [i64] = &[64, 65];
+static mut MUT_VECT_SLICE: &'static [i64] = &[32];
 
 fn main() {
     let empty: &[i64] = &[];
@@ -67,6 +75,10 @@ fn main() {
         AStruct { x: 10, y: 11, z: 12 },
         AStruct { x: 13, y: 14, z: 15 }
     ];
+
+    unsafe {
+        MUT_VECT_SLICE = VECT_SLICE;
+    }
 
     zzz();
 }

--- a/src/test/debug-info/vec.rs
+++ b/src/test/debug-info/vec.rs
@@ -17,11 +17,21 @@
 // debugger:finish
 // debugger:print a
 // check:$1 = {1, 2, 3}
+// debugger:print vec::VECT
+// check:$2 = {4, 5, 6}
 
 #[allow(unused_variable)];
 
+static mut VECT: [i32, ..3] = [1, 2, 3];
+
 fn main() {
     let a = [1, 2, 3];
+
+    unsafe {
+        VECT[0] = 4;
+        VECT[1] = 5;
+        VECT[2] = 6;
+    }
 
     zzz();
 }


### PR DESCRIPTION
Only supports crate level statics. No debug info is generated for function level statics. Closes #9227.

As discussed at the end of the comments for #9227, I took an initial stab at adding support for function level statics and decided it would be enough work to warrant being split into a separate issue.

See #13144 for the new issue describing the need to add support for function level static variables.
