### PR TITLE
deriving should give expn_info

### DIFF
--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -19,6 +19,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
                              mitem: @MetaItem,
                              item: @Item,
                              push: |@Item|) {
+    assert!(span.expn_info.is_some(), "derived trait should have expn_info set");
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -408,6 +408,7 @@ impl<'a> TraitDef<'a> {
                          InternedString::new("automatically_derived")));
         let opt_trait_ref = Some(trait_ref);
         let ident = ast_util::impl_pretty_name(&opt_trait_ref, self_type);
+        assert!(self.span.expn_info.is_some(), "Should have expansion info")
         cx.item(
             self.span,
             ident,
@@ -613,6 +614,7 @@ impl<'a> MethodDef<'a> {
             Vec::new()
         };
 
+        assert!(trait_.span.expn_info.is_some(), "Should have expansion info")
         // Create the method.
         @ast::Method {
             ident: method_ident,


### PR DESCRIPTION
Ensure that all generated code from deriving attributes get an expn_info in their span.
