### PR TITLE
Derive TotalEq for std::intrinsics::TypeId

### DIFF
--- a/src/libstd/intrinsics.rs
+++ b/src/libstd/intrinsics.rs
@@ -451,7 +451,7 @@ extern "rust-intrinsic" {
 /// `TypeId` represents a globally unique identifier for a type
 #[lang="type_id"] // This needs to be kept in lockstep with the code in trans/intrinsic.rs and
                   // middle/lang_items.rs
-#[deriving(Eq, Hash, Show)]
+#[deriving(Eq, Hash, Show, TotalEq)]
 #[cfg(not(test))]
 pub struct TypeId {
     priv t: u64,


### PR DESCRIPTION
HashMap and HashSet require keys to implement TotalEq. This makes it possible to use TypeId as a HashMap key again.

Question for reviewers: assuming we want to support `HashMap<TypeId, whatever>`, would it make sense to add a relevant test? If so, should it go to libcollections or libstd?
