### PR TITLE
native: Ignore SIGPIPE by default

### DIFF
--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -266,6 +266,8 @@ pub mod types {
                 }
 
                 pub enum timezone {}
+
+                pub type sighandler_t = size_t;
             }
             pub mod bsd44 {
                 use libc::types::os::arch::c95::{c_char, c_int, c_uint};
@@ -637,6 +639,8 @@ pub mod types {
                 }
 
                 pub enum timezone {}
+
+                pub type sighandler_t = size_t;
             }
             pub mod bsd44 {
                 use libc::types::os::arch::c95::{c_char, c_int, c_uint};
@@ -1206,6 +1210,8 @@ pub mod types {
                 }
 
                 pub enum timezone {}
+
+                pub type sighandler_t = size_t;
             }
 
             pub mod bsd44 {
@@ -2292,6 +2298,8 @@ pub mod consts {
             use libc::types::os::arch::c95::{c_int, size_t};
 
             pub static SIGTRAP : c_int = 5;
+            pub static SIGPIPE: c_int = 13;
+            pub static SIG_IGN: size_t = 1;
 
             pub static GLOB_ERR      : c_int = 1 << 0;
             pub static GLOB_MARK     : c_int = 1 << 1;
@@ -2741,6 +2749,8 @@ pub mod consts {
             use libc::types::os::arch::c95::{c_int, size_t};
 
             pub static SIGTRAP : c_int = 5;
+            pub static SIGPIPE: c_int = 13;
+            pub static SIG_IGN: size_t = 1;
 
             pub static GLOB_APPEND   : c_int = 0x0001;
             pub static GLOB_DOOFFS   : c_int = 0x0002;
@@ -3136,6 +3146,8 @@ pub mod consts {
             use libc::types::os::arch::c95::{c_int, size_t};
 
             pub static SIGTRAP : c_int = 5;
+            pub static SIGPIPE: c_int = 13;
+            pub static SIG_IGN: size_t = 1;
 
             pub static GLOB_APPEND   : c_int = 0x0001;
             pub static GLOB_DOOFFS   : c_int = 0x0002;
@@ -3835,6 +3847,24 @@ pub mod funcs {
                 pub fn symlink(path1: *c_char, path2: *c_char) -> c_int;
 
                 pub fn ftruncate(fd: c_int, length: off_t) -> c_int;
+            }
+        }
+
+        pub mod signal {
+            use libc::types::os::arch::c95::c_int;
+            use libc::types::os::common::posix01::sighandler_t;
+
+            #[cfg(not(target_os = "android"))]
+            extern {
+                pub fn signal(signum: c_int,
+                              handler: sighandler_t) -> sighandler_t;
+            }
+
+            #[cfg(target_os = "android")]
+            extern {
+                #[link_name = "bsd_signal"]
+                pub fn signal(signum: c_int,
+                              handler: sighandler_t) -> sighandler_t;
             }
         }
 

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -1,0 +1,36 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-fast
+
+// Be sure that when a SIGPIPE would have been received that the entire process
+// doesn't die in a ball of fire, but rather it's gracefully handled.
+
+use std::os;
+use std::io::{PipeStream, Process};
+
+fn test() {
+    let os::Pipe { input, out } = os::pipe();
+    let input = PipeStream::open(input);
+    let mut out = PipeStream::open(out);
+    drop(input);
+
+    let _ = out.write([1]);
+}
+
+fn main() {
+    let args = os::args();
+    if args.len() > 1 && args[1].as_slice() == "test" {
+        return test();
+    }
+
+    let mut p = Process::new(args[0], [~"test"]).unwrap();
+    assert!(p.wait().success());
+}


### PR DESCRIPTION
Some unix platforms will send a SIGPIPE signal instead of returning EPIPE from a
syscall by default. The native runtime doesn't install a SIGPIPE handler,
causing the program to die immediately in this case. This brings the behavior in
line with libgreen by ignoring SIGPIPE and propagating EPIPE upwards to the
application in the form of an IoError.

Closes #13123
