### PR TITLE
Some de-~[] work in std::io

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -84,8 +84,8 @@ pub fn run(lib_path: &str,
 
             Some(Result {
                 status: status,
-                out: str::from_utf8_owned(output).unwrap(),
-                err: str::from_utf8_owned(error).unwrap()
+                out: str::from_utf8(output.as_slice()).unwrap().to_owned(),
+                err: str::from_utf8(error.as_slice()).unwrap().to_owned()
             })
         },
         Err(..) => None

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -153,7 +153,7 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
         match props.pp_exact { Some(_) => 1, None => 2 };
 
     let src = File::open(testfile).read_to_end().unwrap();
-    let src = str::from_utf8_owned(src).unwrap();
+    let src = str::from_utf8(src.as_slice()).unwrap().to_owned();
     let mut srcs = vec!(src);
 
     let mut round = 0;
@@ -177,7 +177,7 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
         Some(ref file) => {
             let filepath = testfile.dir_path().join(file);
             let s = File::open(&filepath).read_to_end().unwrap();
-            str::from_utf8_owned(s).unwrap()
+            str::from_utf8(s.as_slice()).unwrap().to_owned()
           }
           None => { (*srcs.get(srcs.len() - 2u)).clone() }
         };
@@ -1163,7 +1163,7 @@ fn disassemble_extract(config: &config, _props: &TestProps,
 
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end().unwrap();
-    let x = str::from_utf8_owned(x).unwrap();
+    let x = str::from_utf8(x.as_slice()).unwrap();
     x.lines().len()
 }
 

--- a/src/doc/complement-cheatsheet.md
+++ b/src/doc/complement-cheatsheet.md
@@ -96,7 +96,7 @@ Use the [`lines`](http://static.rust-lang.org/doc/master/std/io/trait.Buffer.htm
 use std::io::BufferedReader;
 # use std::io::MemReader;
 
-# let reader = MemReader::new(~[]);
+# let reader = MemReader::new(vec!());
 
 let mut reader = BufferedReader::new(reader);
 for line in reader.lines() {

--- a/src/librand/reader.rs
+++ b/src/librand/reader.rs
@@ -23,7 +23,7 @@ use Rng;
 /// use rand::{reader, Rng};
 /// use std::io::MemReader;
 ///
-/// let mut rng = reader::ReaderRng::new(MemReader::new(~[1,2,3,4,5,6,7,8]));
+/// let mut rng = reader::ReaderRng::new(MemReader::new(vec!(1,2,3,4,5,6,7,8)));
 /// println!("{:x}", rng.gen::<uint>());
 /// ```
 pub struct ReaderRng<R> {
@@ -80,7 +80,7 @@ mod test {
         // transmute from the target to avoid endianness concerns.
         let v = ~[1u64, 2u64, 3u64];
         let bytes: ~[u8] = unsafe {cast::transmute(v)};
-        let mut rng = ReaderRng::new(MemReader::new(bytes));
+        let mut rng = ReaderRng::new(MemReader::new(bytes.move_iter().collect()));
 
         assert_eq!(rng.next_u64(), 1);
         assert_eq!(rng.next_u64(), 2);
@@ -91,7 +91,7 @@ mod test {
         // transmute from the target to avoid endianness concerns.
         let v = ~[1u32, 2u32, 3u32];
         let bytes: ~[u8] = unsafe {cast::transmute(v)};
-        let mut rng = ReaderRng::new(MemReader::new(bytes));
+        let mut rng = ReaderRng::new(MemReader::new(bytes.move_iter().collect()));
 
         assert_eq!(rng.next_u32(), 1);
         assert_eq!(rng.next_u32(), 2);
@@ -102,7 +102,7 @@ mod test {
         let v = [1u8, 2, 3, 4, 5, 6, 7, 8];
         let mut w = [0u8, .. 8];
 
-        let mut rng = ReaderRng::new(MemReader::new(v.to_owned()));
+        let mut rng = ReaderRng::new(MemReader::new(Vec::from_slice(v)));
         rng.fill_bytes(w);
 
         assert!(v == w);
@@ -111,7 +111,7 @@ mod test {
     #[test]
     #[should_fail]
     fn test_reader_rng_insufficient_bytes() {
-        let mut rng = ReaderRng::new(MemReader::new(~[]));
+        let mut rng = ReaderRng::new(MemReader::new(vec!()));
         let mut v = [0u8, .. 3];
         rng.fill_bytes(v);
     }

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -59,8 +59,10 @@ fn run_ar(sess: &Session, args: &str, cwd: Option<&Path>,
             if !o.status.success() {
                 sess.err(format!("{} {} failed with: {}", ar, args.connect(" "),
                                  o.status));
-                sess.note(format!("stdout ---\n{}", str::from_utf8(o.output).unwrap()));
-                sess.note(format!("stderr ---\n{}", str::from_utf8(o.error).unwrap()));
+                sess.note(format!("stdout ---\n{}",
+                                  str::from_utf8(o.output.as_slice()).unwrap()));
+                sess.note(format!("stderr ---\n{}",
+                                  str::from_utf8(o.error.as_slice()).unwrap()));
                 sess.abort_if_errors();
             }
             o
@@ -129,7 +131,7 @@ impl<'a> Archive<'a> {
     /// Lists all files in an archive
     pub fn files(&self) -> Vec<~str> {
         let output = run_ar(self.sess, "t", None, [&self.dst]);
-        let output = str::from_utf8(output.output).unwrap();
+        let output = str::from_utf8(output.output.as_slice()).unwrap();
         // use lines_any because windows delimits output with `\r\n` instead of
         // just `\n`
         output.lines_any().map(|s| s.to_owned()).collect()

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -337,7 +337,9 @@ pub mod write {
                 if !prog.status.success() {
                     sess.err(format!("linking with `{}` failed: {}", cc, prog.status));
                     sess.note(format!("{} arguments: '{}'", cc, args.connect("' '")));
-                    sess.note(str::from_utf8_owned(prog.error + prog.output).unwrap());
+                    let mut note = prog.error.clone();
+                    note.push_all(prog.output.as_slice());
+                    sess.note(str::from_utf8(note.as_slice()).unwrap().to_owned());
                     sess.abort_if_errors();
                 }
             },
@@ -929,7 +931,8 @@ fn link_rlib<'a>(sess: &'a Session,
             let bc = obj_filename.with_extension("bc");
             let bc_deflated = obj_filename.with_extension("bc.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {
-                fs::File::create(&bc_deflated).write(flate::deflate_bytes(data).as_slice())
+                fs::File::create(&bc_deflated)
+                    .write(flate::deflate_bytes(data.as_slice()).as_slice())
             }) {
                 Ok(()) => {}
                 Err(e) => {
@@ -1025,7 +1028,9 @@ fn link_natively(sess: &Session, dylib: bool, obj_filename: &Path,
             if !prog.status.success() {
                 sess.err(format!("linking with `{}` failed: {}", cc_prog, prog.status));
                 sess.note(format!("{} arguments: '{}'", cc_prog, cc_args.connect("' '")));
-                sess.note(str::from_utf8_owned(prog.error + prog.output).unwrap());
+                let mut output = prog.error.clone();
+                output.push_all(prog.output.as_slice());
+                sess.note(str::from_utf8(output.as_slice()).unwrap().to_owned());
                 sess.abort_if_errors();
             }
         },

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -681,7 +681,7 @@ pub fn pretty_print_input(sess: Session,
     };
 
     let src_name = source_name(input);
-    let src = sess.codemap().get_filemap(src_name).src.as_bytes().to_owned();
+    let src = Vec::from_slice(sess.codemap().get_filemap(src_name).src.as_bytes());
     let mut rdr = MemReader::new(src);
 
     match ppm {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -272,7 +272,7 @@ pub fn run_compiler(args: &[~str]) {
         let ifile = matches.free.get(0).as_slice();
         if ifile == "-" {
             let contents = io::stdin().read_to_end().unwrap();
-            let src = str::from_utf8_owned(contents).unwrap();
+            let src = str::from_utf8(contents.as_slice()).unwrap().to_owned();
             (d::StrInput(src), None)
         } else {
             (d::FileInput(Path::new(ifile)), Some(Path::new(ifile)))

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -741,7 +741,7 @@ impl<'a> Liveness<'a> {
             self.write_vars(wr, ln, |idx| self.users.get(idx).writer);
             write!(wr, "  precedes {}]", self.successors.get(ln.get()).to_str());
         }
-        str::from_utf8_owned(wr.unwrap()).unwrap()
+        str::from_utf8(wr.unwrap().as_slice()).unwrap().to_owned()
     }
 
     fn init_empty(&mut self, ln: LiveNode, succ_ln: LiveNode) {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -34,7 +34,7 @@ pub fn highlight(src: &str, class: Option<&str>) -> ~str {
          lexer::new_string_reader(&sess.span_diagnostic, fm),
          class,
          &mut out).unwrap();
-    str::from_utf8_lossy(out.unwrap()).into_owned()
+    str::from_utf8_lossy(out.unwrap().as_slice()).into_owned()
 }
 
 /// Exhausts the `lexer` writing the output into `out`.

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -487,7 +487,7 @@ impl<'a> SourceCollector<'a> {
                        filename.ends_with("macros>") => return Ok(()),
             Err(e) => return Err(e)
         };
-        let contents = str::from_utf8_owned(contents).unwrap();
+        let contents = str::from_utf8(contents.as_slice()).unwrap();
 
         // Remove the utf-8 BOM if any
         let contents = if contents.starts_with("\ufeff") {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -312,7 +312,7 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
         }
         try!(write!(&mut w, "\\};"));
 
-        str::from_utf8_owned(w.unwrap()).unwrap()
+        str::from_utf8(w.unwrap().as_slice()).unwrap().to_owned()
     };
 
     // Write out the shared files. Note that these are shared among all rustdoc

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -388,7 +388,7 @@ fn json_output(krate: clean::Crate, res: Vec<plugins::PluginJson> ,
             let mut encoder = json::Encoder::new(&mut w as &mut io::Writer);
             krate.encode(&mut encoder).unwrap();
         }
-        str::from_utf8_owned(w.unwrap()).unwrap()
+        str::from_utf8(w.unwrap().as_slice()).unwrap().to_owned()
     };
     let crate_json = match json::from_str(crate_json_str) {
         Ok(j) => j,

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -22,7 +22,7 @@ use test::Collector;
 fn load_string(input: &Path) -> io::IoResult<Option<~str>> {
     let mut f = try!(io::File::open(input));
     let d = try!(f.read_to_end());
-    Ok(str::from_utf8_owned(d))
+    Ok(str::from_utf8(d.as_slice()).map(|s| s.to_owned()))
 }
 macro_rules! load_or_return {
     ($input: expr, $cant_read: expr, $not_utf8: expr) => {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -159,7 +159,8 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, should_fail: bool,
             if should_fail && out.status.success() {
                 fail!("test executable succeeded when it should have failed");
             } else if !should_fail && !out.status.success() {
-                fail!("test executable failed:\n{}", str::from_utf8(out.error));
+                fail!("test executable failed:\n{}",
+                      str::from_utf8(out.error.as_slice()));
             }
         }
     }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1282,8 +1282,8 @@ pub fn from_reader(rdr: &mut io::Reader) -> DecodeResult<Json> {
         Ok(c) => c,
         Err(e) => return Err(IoError(e))
     };
-    let s = match str::from_utf8_owned(contents) {
-        Some(s) => s,
+    let s = match str::from_utf8(contents.as_slice()) {
+        Some(s) => s.to_owned(),
         None => return Err(ParseError(~"contents not utf-8", 0, 0))
     };
     let mut parser = Parser::new(s.chars());

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -309,7 +309,7 @@ impl<'a> Encoder<'a> {
     }
 
     /// Encode the specified struct into a json [u8]
-    pub fn buffer_encode<T:Encodable<Encoder<'a>, io::IoError>>(to_encode_object: &T) -> ~[u8]  {
+    pub fn buffer_encode<T:Encodable<Encoder<'a>, io::IoError>>(to_encode_object: &T) -> Vec<u8>  {
        //Serialize the object in a string using a writer
         let mut m = MemWriter::new();
         {
@@ -322,8 +322,8 @@ impl<'a> Encoder<'a> {
 
     /// Encode the specified struct into a json str
     pub fn str_encode<T:Encodable<Encoder<'a>, io::IoError>>(to_encode_object: &T) -> ~str  {
-        let buff:~[u8] = Encoder::buffer_encode(to_encode_object);
-        str::from_utf8_owned(buff).unwrap()
+        let buff = Encoder::buffer_encode(to_encode_object);
+        str::from_utf8(buff.as_slice()).unwrap().to_owned()
     }
 }
 
@@ -484,7 +484,7 @@ impl<'a> ::Encoder<io::IoError> for Encoder<'a> {
         let mut check_encoder = Encoder::new(&mut buf);
         try!(f(&mut check_encoder));
         let buf = buf.unwrap();
-        let out = from_utf8(buf).unwrap();
+        let out = from_utf8(buf.as_slice()).unwrap();
         let needs_wrapping = out.char_at(0) != '"' &&
             out.char_at_reverse(out.len()) != '"';
         if needs_wrapping { try!(write!(self.wr, "\"")); }
@@ -715,7 +715,7 @@ impl<'a> ::Encoder<io::IoError> for PrettyEncoder<'a> {
         let mut check_encoder = PrettyEncoder::new(&mut buf);
         try!(f(&mut check_encoder));
         let buf = buf.unwrap();
-        let out = from_utf8(buf).unwrap();
+        let out = from_utf8(buf.as_slice()).unwrap();
         let needs_wrapping = out.char_at(0) != '"' &&
             out.char_at_reverse(out.len()) != '"';
         if needs_wrapping { try!(write!(self.wr, "\"")); }
@@ -763,7 +763,7 @@ impl Json {
     pub fn to_pretty_str(&self) -> ~str {
         let mut s = MemWriter::new();
         self.to_pretty_writer(&mut s as &mut io::Writer).unwrap();
-        str::from_utf8_owned(s.unwrap()).unwrap()
+        str::from_utf8(s.unwrap().as_slice()).unwrap().to_owned()
     }
 
      /// If the Json value is an Object, returns the value associated with the provided key.
@@ -1927,7 +1927,7 @@ mod tests {
 
         let mut m = MemWriter::new();
         f(&mut m as &mut io::Writer);
-        str::from_utf8_owned(m.unwrap()).unwrap()
+        str::from_utf8(m.unwrap().as_slice()).unwrap().to_owned()
     }
 
     #[test]
@@ -2528,7 +2528,7 @@ mod tests {
             hm.encode(&mut encoder).unwrap();
         }
         let bytes = mem_buf.unwrap();
-        let json_str = from_utf8(bytes).unwrap();
+        let json_str = from_utf8(bytes.as_slice()).unwrap();
         match from_str(json_str) {
             Err(_) => fail!("Unable to parse json_str: {:?}", json_str),
             _ => {} // it parsed and we are good to go
@@ -2548,7 +2548,7 @@ mod tests {
             hm.encode(&mut encoder).unwrap();
         }
         let bytes = mem_buf.unwrap();
-        let json_str = from_utf8(bytes).unwrap();
+        let json_str = from_utf8(bytes.as_slice()).unwrap();
         match from_str(json_str) {
             Err(_) => fail!("Unable to parse json_str: {:?}", json_str),
             _ => {} // it parsed and we are good to go

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -490,7 +490,7 @@ use repr;
 use result::{Ok, Err};
 use str::StrSlice;
 use str;
-use slice::ImmutableVector;
+use slice::{Vector, ImmutableVector};
 use slice;
 
 pub use self::num::radix;
@@ -795,7 +795,7 @@ pub fn format(args: &Arguments) -> ~str {
 pub unsafe fn format_unsafe(fmt: &[rt::Piece], args: &[Argument]) -> ~str {
     let mut output = MemWriter::new();
     write_unsafe(&mut output as &mut io::Writer, fmt, args).unwrap();
-    return str::from_utf8_owned(output.unwrap()).unwrap();
+    return str::from_utf8(output.unwrap().as_slice()).unwrap().to_owned();
 }
 
 impl<'a> Formatter<'a> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -405,7 +405,7 @@ mod test {
 
     #[test]
     fn test_buffered_reader() {
-        let inner = MemReader::new(~[0, 1, 2, 3, 4]);
+        let inner = MemReader::new(vec!(0, 1, 2, 3, 4));
         let mut reader = BufferedReader::with_capacity(2, inner);
 
         let mut buf = [0, 0, 0];
@@ -502,7 +502,7 @@ mod test {
 
     #[test]
     fn test_read_until() {
-        let inner = MemReader::new(~[0, 1, 2, 1, 0]);
+        let inner = MemReader::new(vec!(0, 1, 2, 1, 0));
         let mut reader = BufferedReader::with_capacity(2, inner);
         assert_eq!(reader.read_until(0), Ok(vec!(0)));
         assert_eq!(reader.read_until(2), Ok(vec!(1, 2)));
@@ -533,7 +533,7 @@ mod test {
 
     #[test]
     fn test_read_line() {
-        let in_buf = MemReader::new(bytes!("a\nb\nc").to_owned());
+        let in_buf = MemReader::new(Vec::from_slice(bytes!("a\nb\nc")));
         let mut reader = BufferedReader::with_capacity(2, in_buf);
         assert_eq!(reader.read_line(), Ok(~"a\n"));
         assert_eq!(reader.read_line(), Ok(~"b\n"));
@@ -543,7 +543,7 @@ mod test {
 
     #[test]
     fn test_lines() {
-        let in_buf = MemReader::new(bytes!("a\nb\nc").to_owned());
+        let in_buf = MemReader::new(Vec::from_slice(bytes!("a\nb\nc")));
         let mut reader = BufferedReader::with_capacity(2, in_buf);
         let mut it = reader.lines();
         assert_eq!(it.next(), Some(Ok(~"a\n")));

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -504,10 +504,10 @@ mod test {
     fn test_read_until() {
         let inner = MemReader::new(~[0, 1, 2, 1, 0]);
         let mut reader = BufferedReader::with_capacity(2, inner);
-        assert_eq!(reader.read_until(0), Ok(~[0]));
-        assert_eq!(reader.read_until(2), Ok(~[1, 2]));
-        assert_eq!(reader.read_until(1), Ok(~[1]));
-        assert_eq!(reader.read_until(8), Ok(~[0]));
+        assert_eq!(reader.read_until(0), Ok(vec!(0)));
+        assert_eq!(reader.read_until(2), Ok(vec!(1, 2)));
+        assert_eq!(reader.read_until(1), Ok(vec!(1)));
+        assert_eq!(reader.read_until(8), Ok(vec!(0)));
         assert!(reader.read_until(9).is_err());
     }
 

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -323,7 +323,7 @@ mod test {
     fn read_bytes() {
         let mut reader = MemReader::new(~[10, 11, 12, 13]);
         let bytes = reader.read_exact(4).unwrap();
-        assert!(bytes == ~[10, 11, 12, 13]);
+        assert!(bytes == vec!(10, 11, 12, 13));
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod test {
             count: 0,
         };
         let bytes = reader.read_exact(4).unwrap();
-        assert!(bytes == ~[10, 11, 12, 13]);
+        assert!(bytes == vec!(10, 11, 12, 13));
     }
 
     #[test]
@@ -344,9 +344,9 @@ mod test {
     #[test]
     fn push_exact() {
         let mut reader = MemReader::new(~[10, 11, 12, 13]);
-        let mut buf = ~[8, 9];
+        let mut buf = vec!(8, 9);
         reader.push_exact(&mut buf, 4).unwrap();
-        assert!(buf == ~[8, 9, 10, 11, 12, 13]);
+        assert!(buf == vec!(8, 9, 10, 11, 12, 13));
     }
 
     #[test]
@@ -354,17 +354,17 @@ mod test {
         let mut reader = PartialReader {
             count: 0,
         };
-        let mut buf = ~[8, 9];
+        let mut buf = vec!(8, 9);
         reader.push_exact(&mut buf, 4).unwrap();
-        assert!(buf == ~[8, 9, 10, 11, 12, 13]);
+        assert!(buf == vec!(8, 9, 10, 11, 12, 13));
     }
 
     #[test]
     fn push_exact_eof() {
         let mut reader = MemReader::new(~[10, 11]);
-        let mut buf = ~[8, 9];
+        let mut buf = vec!(8, 9);
         assert!(reader.push_exact(&mut buf, 4).is_err());
-        assert!(buf == ~[8, 9, 10, 11]);
+        assert!(buf == vec!(8, 9, 10, 11));
     }
 
     #[test]
@@ -372,9 +372,9 @@ mod test {
         let mut reader = ErroringLaterReader {
             count: 0,
         };
-        let mut buf = ~[8, 9];
+        let mut buf = vec!(8, 9);
         assert!(reader.push_exact(&mut buf, 4).is_err());
-        assert!(buf == ~[8, 9, 10]);
+        assert!(buf == vec!(8, 9, 10));
     }
 
     #[test]
@@ -383,7 +383,7 @@ mod test {
             count: 0,
         };
         let buf = reader.read_to_end().unwrap();
-        assert!(buf == ~[10, 11, 12, 13]);
+        assert!(buf == vec!(10, 11, 12, 13));
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod test {
             count: 0,
         };
         let buf = reader.read_to_end().unwrap();
-        assert!(buf == ~[10, 11]);
+        assert!(buf == vec!(10, 11));
     }
 
     #[test]

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -267,7 +267,7 @@ mod test {
 
     #[test]
     fn read_byte() {
-        let mut reader = MemReader::new(~[10]);
+        let mut reader = MemReader::new(vec!(10));
         let byte = reader.read_byte();
         assert!(byte == Ok(10));
     }
@@ -321,7 +321,7 @@ mod test {
 
     #[test]
     fn read_bytes() {
-        let mut reader = MemReader::new(~[10, 11, 12, 13]);
+        let mut reader = MemReader::new(vec!(10, 11, 12, 13));
         let bytes = reader.read_exact(4).unwrap();
         assert!(bytes == vec!(10, 11, 12, 13));
     }
@@ -337,13 +337,13 @@ mod test {
 
     #[test]
     fn read_bytes_eof() {
-        let mut reader = MemReader::new(~[10, 11]);
+        let mut reader = MemReader::new(vec!(10, 11));
         assert!(reader.read_exact(4).is_err());
     }
 
     #[test]
     fn push_exact() {
-        let mut reader = MemReader::new(~[10, 11, 12, 13]);
+        let mut reader = MemReader::new(vec!(10, 11, 12, 13));
         let mut buf = vec!(8, 9);
         reader.push_exact(&mut buf, 4).unwrap();
         assert!(buf == vec!(8, 9, 10, 11, 12, 13));
@@ -361,7 +361,7 @@ mod test {
 
     #[test]
     fn push_exact_eof() {
-        let mut reader = MemReader::new(~[10, 11]);
+        let mut reader = MemReader::new(vec!(10, 11));
         let mut buf = vec!(8, 9);
         assert!(reader.push_exact(&mut buf, 4).is_err());
         assert!(buf == vec!(8, 9, 10, 11));

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1074,7 +1074,7 @@ mod test {
         check!(copy(&input, &output));
 
         assert_eq!(check!(File::open(&output).read_to_end()),
-                   (bytes!("foo")).to_owned());
+                   (Vec::from_slice(bytes!("foo"))));
     })
 
     iotest!(fn copy_file_src_dir() {
@@ -1114,7 +1114,7 @@ mod test {
         }
         assert_eq!(check!(stat(&out)).size, check!(stat(&input)).size);
         assert_eq!(check!(File::open(&out).read_to_end()),
-                   (bytes!("foobar")).to_owned());
+                   (Vec::from_slice(bytes!("foobar"))));
     })
 
     #[cfg(not(windows))] // apparently windows doesn't like symlinks
@@ -1146,7 +1146,7 @@ mod test {
         }
         assert_eq!(check!(stat(&out)).size, check!(stat(&input)).size);
         assert_eq!(check!(File::open(&out).read_to_end()),
-                   (bytes!("foobar")).to_owned());
+                   (Vec::from_slice(bytes!("foobar"))));
 
         // can't link to yourself
         match link(&input, &input) {
@@ -1206,7 +1206,7 @@ mod test {
         check!(file.fsync());
         assert_eq!(check!(stat(&path)).size, 10);
         assert_eq!(check!(File::open(&path).read_to_end()),
-                   (bytes!("foobar", 0, 0, 0, 0)).to_owned());
+                   (Vec::from_slice(bytes!("foobar", 0, 0, 0, 0))));
 
         // Truncate to a smaller length, don't seek, and then write something.
         // Ensure that the intermediate zeroes are all filled in (we're seeked
@@ -1217,7 +1217,7 @@ mod test {
         check!(file.fsync());
         assert_eq!(check!(stat(&path)).size, 9);
         assert_eq!(check!(File::open(&path).read_to_end()),
-                   (bytes!("fo", 0, 0, 0, 0, "wut")).to_owned());
+                   (Vec::from_slice(bytes!("fo", 0, 0, 0, 0, "wut"))));
         drop(file);
     })
 

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -18,6 +18,7 @@ use io;
 use io::{Reader, Writer, Seek, Buffer, IoError, SeekStyle, IoResult};
 use slice;
 use slice::{Vector, ImmutableVector, MutableVector, OwnedCloneableVector};
+use vec::Vec;
 
 fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> {
     // compute offset as signed and clamp to prevent overflow
@@ -49,10 +50,10 @@ fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> 
 /// let mut w = MemWriter::new();
 /// w.write([0, 1, 2]);
 ///
-/// assert_eq!(w.unwrap(), ~[0, 1, 2]);
+/// assert_eq!(w.unwrap(), vec!(0, 1, 2));
 /// ```
 pub struct MemWriter {
-    buf: ~[u8],
+    buf: Vec<u8>,
     pos: uint,
 }
 
@@ -64,7 +65,7 @@ impl MemWriter {
     /// Create a new `MemWriter`, allocating at least `n` bytes for
     /// the internal buffer.
     pub fn with_capacity(n: uint) -> MemWriter {
-        MemWriter { buf: slice::with_capacity(n), pos: 0 }
+        MemWriter { buf: Vec::with_capacity(n), pos: 0 }
     }
 
     /// Acquires an immutable reference to the underlying buffer of this
@@ -75,7 +76,7 @@ impl MemWriter {
     pub fn get_ref<'a>(&'a self) -> &'a [u8] { self.buf.as_slice() }
 
     /// Unwraps this `MemWriter`, returning the underlying buffer
-    pub fn unwrap(self) -> ~[u8] { self.buf }
+    pub fn unwrap(self) -> Vec<u8> { self.buf }
 }
 
 impl Writer for MemWriter {
@@ -127,19 +128,19 @@ impl Seek for MemWriter {
 /// # #[allow(unused_must_use)];
 /// use std::io::MemReader;
 ///
-/// let mut r = MemReader::new(~[0, 1, 2]);
+/// let mut r = MemReader::new(vec!(0, 1, 2));
 ///
 /// assert_eq!(r.read_to_end().unwrap(), vec!(0, 1, 2));
 /// ```
 pub struct MemReader {
-    buf: ~[u8],
+    buf: Vec<u8>,
     pos: uint
 }
 
 impl MemReader {
     /// Creates a new `MemReader` which will read the buffer given. The buffer
     /// can be re-acquired through `unwrap`
-    pub fn new(buf: ~[u8]) -> MemReader {
+    pub fn new(buf: Vec<u8>) -> MemReader {
         MemReader {
             buf: buf,
             pos: 0
@@ -159,7 +160,7 @@ impl MemReader {
     pub fn get_ref<'a>(&'a self) -> &'a [u8] { self.buf.as_slice() }
 
     /// Unwraps this `MemReader`, returning the underlying buffer
-    pub fn unwrap(self) -> ~[u8] { self.buf }
+    pub fn unwrap(self) -> Vec<u8> { self.buf }
 }
 
 impl Reader for MemReader {
@@ -425,7 +426,7 @@ mod test {
 
     #[test]
     fn test_mem_reader() {
-        let mut reader = MemReader::new(~[0, 1, 2, 3, 4, 5, 6, 7]);
+        let mut reader = MemReader::new(vec!(0, 1, 2, 3, 4, 5, 6, 7));
         let mut buf = [];
         assert_eq!(reader.read(buf), Ok(0));
         assert_eq!(reader.tell(), Ok(0));
@@ -440,7 +441,7 @@ mod test {
         assert_eq!(reader.read(buf), Ok(3));
         assert_eq!(buf.slice(0, 3), &[5, 6, 7]);
         assert!(reader.read(buf).is_err());
-        let mut reader = MemReader::new(~[0, 1, 2, 3, 4, 5, 6, 7]);
+        let mut reader = MemReader::new(vec!(0, 1, 2, 3, 4, 5, 6, 7));
         assert_eq!(reader.read_until(3).unwrap(), vec!(0, 1, 2, 3));
         assert_eq!(reader.read_until(3).unwrap(), vec!(4, 5, 6, 7));
         assert!(reader.read(buf).is_err());
@@ -525,7 +526,7 @@ mod test {
         r.seek(10, SeekSet).unwrap();
         assert!(r.read(&mut []).is_err());
 
-        let mut r = MemReader::new(~[10]);
+        let mut r = MemReader::new(vec!(10));
         r.seek(10, SeekSet).unwrap();
         assert!(r.read(&mut []).is_err());
 
@@ -545,7 +546,7 @@ mod test {
         let mut r = BufReader::new(buf);
         assert!(r.seek(-1, SeekSet).is_err());
 
-        let mut r = MemReader::new(~[10]);
+        let mut r = MemReader::new(vec!(10));
         assert!(r.seek(-1, SeekSet).is_err());
 
         let mut r = MemWriter::new();
@@ -558,7 +559,7 @@ mod test {
 
     #[test]
     fn io_fill() {
-        let mut r = MemReader::new(~[1, 2, 3, 4, 5, 6, 7, 8]);
+        let mut r = MemReader::new(vec!(1, 2, 3, 4, 5, 6, 7, 8));
         let mut buf = [0, ..3];
         assert_eq!(r.fill(buf), Ok(()));
         assert_eq!(buf.as_slice(), &[1, 2, 3]);

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -129,7 +129,7 @@ impl Seek for MemWriter {
 ///
 /// let mut r = MemReader::new(~[0, 1, 2]);
 ///
-/// assert_eq!(r.read_to_end().unwrap(), ~[0, 1, 2]);
+/// assert_eq!(r.read_to_end().unwrap(), vec!(0, 1, 2));
 /// ```
 pub struct MemReader {
     buf: ~[u8],
@@ -272,7 +272,7 @@ impl<'a> Seek for BufWriter<'a> {
 /// let mut buf = [0, 1, 2, 3];
 /// let mut r = BufReader::new(buf);
 ///
-/// assert_eq!(r.read_to_end().unwrap(), ~[0, 1, 2, 3]);
+/// assert_eq!(r.read_to_end().unwrap(), vec!(0, 1, 2, 3));
 /// ```
 pub struct BufReader<'a> {
     buf: &'a [u8],
@@ -441,8 +441,8 @@ mod test {
         assert_eq!(buf.slice(0, 3), &[5, 6, 7]);
         assert!(reader.read(buf).is_err());
         let mut reader = MemReader::new(~[0, 1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(reader.read_until(3).unwrap(), ~[0, 1, 2, 3]);
-        assert_eq!(reader.read_until(3).unwrap(), ~[4, 5, 6, 7]);
+        assert_eq!(reader.read_until(3).unwrap(), vec!(0, 1, 2, 3));
+        assert_eq!(reader.read_until(3).unwrap(), vec!(4, 5, 6, 7));
         assert!(reader.read(buf).is_err());
     }
 
@@ -465,8 +465,8 @@ mod test {
         assert_eq!(buf.slice(0, 3), &[5, 6, 7]);
         assert!(reader.read(buf).is_err());
         let mut reader = BufReader::new(in_buf);
-        assert_eq!(reader.read_until(3).unwrap(), ~[0, 1, 2, 3]);
-        assert_eq!(reader.read_until(3).unwrap(), ~[4, 5, 6, 7]);
+        assert_eq!(reader.read_until(3).unwrap(), vec!(0, 1, 2, 3));
+        assert_eq!(reader.read_until(3).unwrap(), vec!(4, 5, 6, 7));
         assert!(reader.read(buf).is_err());
     }
 

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -718,14 +718,14 @@ mod test {
         spawn(proc() {
             let mut a = a;
             let mut c = a.accept().unwrap();
-            assert_eq!(c.read_to_end(), Ok(~[]));
+            assert_eq!(c.read_to_end(), Ok(vec!()));
             c.write([1]).unwrap();
         });
 
         let mut s = TcpStream::connect(addr).unwrap();
         assert!(s.obj.close_write().is_ok());
         assert!(s.write([1]).is_err());
-        assert_eq!(s.read_to_end(), Ok(~[1]));
+        assert_eq!(s.read_to_end(), Ok(vec!(1)));
     })
 }
 

--- a/src/libstd/io/result.rs
+++ b/src/libstd/io/result.rs
@@ -87,7 +87,7 @@ mod test {
         let mut writer: io::IoResult<MemWriter> = Ok(MemWriter::new());
         writer.write([0, 1, 2]).unwrap();
         writer.flush().unwrap();
-        assert_eq!(writer.unwrap().unwrap(), ~[0, 1, 2]);
+        assert_eq!(writer.unwrap().unwrap(), vec!(0, 1, 2));
     }
 
     #[test]
@@ -108,7 +108,7 @@ mod test {
     #[test]
     fn test_option_reader() {
         let mut reader: io::IoResult<MemReader> =
-            Ok(MemReader::new(~[0, 1, 2, 3]));
+            Ok(MemReader::new(vec!(0, 1, 2, 3)));
         let mut buf = [0, 0];
         reader.read(buf).unwrap();
         assert_eq!(buf.as_slice(), &[0, 1]);

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -207,7 +207,7 @@ mod test {
         let mut r = MemReader::new(~[0, 1, 2]);
         {
             let mut r = LimitReader::new(r.by_ref(), 4);
-            assert_eq!(~[0, 1, 2], r.read_to_end().unwrap());
+            assert_eq!(vec!(0, 1, 2), r.read_to_end().unwrap());
         }
     }
 
@@ -216,9 +216,9 @@ mod test {
         let mut r = MemReader::new(~[0, 1, 2]);
         {
             let mut r = LimitReader::new(r.by_ref(), 2);
-            assert_eq!(~[0, 1], r.read_to_end().unwrap());
+            assert_eq!(vec!(0, 1), r.read_to_end().unwrap());
         }
-        assert_eq!(~[2], r.read_to_end().unwrap());
+        assert_eq!(vec!(2), r.read_to_end().unwrap());
     }
 
     #[test]
@@ -228,7 +228,7 @@ mod test {
         assert_eq!(3, r.limit());
         assert_eq!(0, r.read_byte().unwrap());
         assert_eq!(2, r.limit());
-        assert_eq!(~[1, 2], r.read_to_end().unwrap());
+        assert_eq!(vec!(1, 2), r.read_to_end().unwrap());
         assert_eq!(0, r.limit());
     }
 
@@ -288,14 +288,14 @@ mod test {
         let rs = ~[MemReader::new(~[0, 1]), MemReader::new(~[]),
                    MemReader::new(~[2, 3])];
         let mut r = ChainedReader::new(rs.move_iter());
-        assert_eq!(~[0, 1, 2, 3], r.read_to_end().unwrap());
+        assert_eq!(vec!(0, 1, 2, 3), r.read_to_end().unwrap());
     }
 
     #[test]
     fn test_tee_reader() {
         let mut r = TeeReader::new(MemReader::new(~[0, 1, 2]),
                                    MemWriter::new());
-        assert_eq!(~[0, 1, 2], r.read_to_end().unwrap());
+        assert_eq!(vec!(0, 1, 2), r.read_to_end().unwrap());
         let (_, w) = r.unwrap();
         assert_eq!(~[0, 1, 2], w.unwrap());
     }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -85,12 +85,12 @@ impl Reader for NullReader {
 
 /// A `Writer` which multiplexes writes to a set of `Writers`.
 pub struct MultiWriter {
-    writers: ~[~Writer]
+    writers: Vec<~Writer>
 }
 
 impl MultiWriter {
     /// Creates a new `MultiWriter`
-    pub fn new(writers: ~[~Writer]) -> MultiWriter {
+    pub fn new(writers: Vec<~Writer>) -> MultiWriter {
         MultiWriter { writers: writers }
     }
 }
@@ -273,8 +273,8 @@ mod test {
             }
         }
 
-        let mut multi = MultiWriter::new(~[~TestWriter as ~Writer,
-                                           ~TestWriter as ~Writer]);
+        let mut multi = MultiWriter::new(vec!(~TestWriter as ~Writer,
+                                              ~TestWriter as ~Writer));
         multi.write([1, 2, 3]).unwrap();
         assert_eq!(2, unsafe { writes });
         assert_eq!(0, unsafe { flushes });
@@ -285,8 +285,8 @@ mod test {
 
     #[test]
     fn test_chained_reader() {
-        let rs = ~[MemReader::new(vec!(0, 1)), MemReader::new(vec!()),
-                   MemReader::new(vec!(2, 3))];
+        let rs = vec!(MemReader::new(vec!(0, 1)), MemReader::new(vec!()),
+                      MemReader::new(vec!(2, 3)));
         let mut r = ChainedReader::new(rs.move_iter());
         assert_eq!(vec!(0, 1, 2, 3), r.read_to_end().unwrap());
     }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -204,7 +204,7 @@ mod test {
 
     #[test]
     fn test_limit_reader_unlimited() {
-        let mut r = MemReader::new(~[0, 1, 2]);
+        let mut r = MemReader::new(vec!(0, 1, 2));
         {
             let mut r = LimitReader::new(r.by_ref(), 4);
             assert_eq!(vec!(0, 1, 2), r.read_to_end().unwrap());
@@ -213,7 +213,7 @@ mod test {
 
     #[test]
     fn test_limit_reader_limited() {
-        let mut r = MemReader::new(~[0, 1, 2]);
+        let mut r = MemReader::new(vec!(0, 1, 2));
         {
             let mut r = LimitReader::new(r.by_ref(), 2);
             assert_eq!(vec!(0, 1), r.read_to_end().unwrap());
@@ -223,7 +223,7 @@ mod test {
 
     #[test]
     fn test_limit_reader_limit() {
-        let r = MemReader::new(~[0, 1, 2]);
+        let r = MemReader::new(vec!(0, 1, 2));
         let mut r = LimitReader::new(r, 3);
         assert_eq!(3, r.limit());
         assert_eq!(0, r.read_byte().unwrap());
@@ -285,26 +285,26 @@ mod test {
 
     #[test]
     fn test_chained_reader() {
-        let rs = ~[MemReader::new(~[0, 1]), MemReader::new(~[]),
-                   MemReader::new(~[2, 3])];
+        let rs = ~[MemReader::new(vec!(0, 1)), MemReader::new(vec!()),
+                   MemReader::new(vec!(2, 3))];
         let mut r = ChainedReader::new(rs.move_iter());
         assert_eq!(vec!(0, 1, 2, 3), r.read_to_end().unwrap());
     }
 
     #[test]
     fn test_tee_reader() {
-        let mut r = TeeReader::new(MemReader::new(~[0, 1, 2]),
+        let mut r = TeeReader::new(MemReader::new(vec!(0, 1, 2)),
                                    MemWriter::new());
         assert_eq!(vec!(0, 1, 2), r.read_to_end().unwrap());
         let (_, w) = r.unwrap();
-        assert_eq!(~[0, 1, 2], w.unwrap());
+        assert_eq!(vec!(0, 1, 2), w.unwrap());
     }
 
     #[test]
     fn test_copy() {
-        let mut r = MemReader::new(~[0, 1, 2, 3, 4]);
+        let mut r = MemReader::new(vec!(0, 1, 2, 3, 4));
         let mut w = MemWriter::new();
         copy(&mut r, &mut w).unwrap();
-        assert_eq!(~[0, 1, 2, 3, 4], w.unwrap());
+        assert_eq!(vec!(0, 1, 2, 3, 4), w.unwrap());
     }
 }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -28,7 +28,7 @@ use reflect::{MovePtr, align};
 use result::{Ok, Err};
 use str::StrSlice;
 use to_str::ToStr;
-use slice::OwnedVector;
+use slice::{Vector, OwnedVector};
 use intrinsics::{Disr, Opaque, TyDesc, TyVisitor, get_tydesc, visit_tydesc};
 use raw;
 
@@ -617,7 +617,7 @@ pub fn repr_to_str<T>(t: &T) -> ~str {
 
     let mut result = io::MemWriter::new();
     write_repr(&mut result as &mut io::Writer, t).unwrap();
-    str::from_utf8_owned(result.unwrap()).unwrap()
+    str::from_utf8(result.unwrap().as_slice()).unwrap().to_owned()
 }
 
 #[cfg(test)]
@@ -635,7 +635,7 @@ fn test_repr() {
     fn exact_test<T>(t: &T, e:&str) {
         let mut m = io::MemWriter::new();
         write_repr(&mut m as &mut io::Writer, t).unwrap();
-        let s = str::from_utf8_owned(m.unwrap()).unwrap();
+        let s = str::from_utf8(m.unwrap().as_slice()).unwrap().to_owned();
         assert_eq!(s.as_slice(), e);
     }
 

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -756,7 +756,7 @@ mod test {
     macro_rules! t( ($a:expr, $b:expr) => ({
         let mut m = MemWriter::new();
         super::demangle(&mut m, $a).unwrap();
-        assert_eq!(str::from_utf8_owned(m.unwrap()).unwrap(), $b.to_owned());
+        assert_eq!(str::from_utf8(m.unwrap().as_slice()).unwrap().to_owned(), $b.to_owned());
     }) )
 
     #[test]

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -113,13 +113,13 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         }
         Ok(bytes) => bytes,
     };
-    match str::from_utf8_owned(bytes) {
+    match str::from_utf8(bytes.as_slice()) {
         Some(src) => {
             // Add this input file to the code map to make it available as
             // dependency information
             let filename = file.display().to_str();
             let interned = token::intern_and_get_ident(src);
-            cx.codemap().new_filemap(filename, src);
+            cx.codemap().new_filemap(filename, src.to_owned());
 
             base::MRExpr(cx.expr_str(sp, interned))
         }

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -350,7 +350,7 @@ pub fn gather_comments_and_literals(span_diagnostic:
                                     srdr: &mut io::Reader)
                                  -> (Vec<Comment>, Vec<Literal>) {
     let src = srdr.read_to_end().unwrap();
-    let src = str::from_utf8_owned(src).unwrap();
+    let src = str::from_utf8(src.as_slice()).unwrap().to_owned();
     let cm = CodeMap::new();
     let filemap = cm.new_filemap(path, src);
     let mut rdr = lexer::new_low_level_string_reader(span_diagnostic, filemap);

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -228,9 +228,10 @@ pub fn file_to_filemap(sess: &ParseSess, path: &Path, spanopt: Option<Span>)
             unreachable!()
         }
     };
-    match str::from_utf8_owned(bytes) {
+    match str::from_utf8(bytes.as_slice()) {
         Some(s) => {
-            return string_to_filemap(sess, s, path.as_str().unwrap().to_str())
+            return string_to_filemap(sess, s.to_owned(),
+                                     path.as_str().unwrap().to_str())
         }
         None => err(format!("{} is not UTF-8 encoded", path.display())),
     }
@@ -292,7 +293,7 @@ mod test {
         let mut writer = MemWriter::new();
         let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
         let _ = val.encode(&mut encoder);
-        str::from_utf8_owned(writer.unwrap()).unwrap()
+        str::from_utf8(writer.unwrap().as_slice()).unwrap().to_owned()
     }
 
     // produce a codemap::span

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -208,8 +208,8 @@ pub fn parse(file: &mut io::Reader,
 
     // don't read NUL
     let bytes = try!(file.read_exact(names_bytes as uint - 1));
-    let names_str = match str::from_utf8_owned(bytes) {
-        Some(s) => s, None => return Err(~"input not utf-8"),
+    let names_str = match str::from_utf8(bytes.as_slice()) {
+        Some(s) => s.to_owned(), None => return Err(~"input not utf-8"),
     };
 
     let term_names: Vec<~str> = names_str.split('|').map(|s| s.to_owned()).collect();

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -1015,7 +1015,7 @@ mod tests {
             use std::io::MemWriter;
             let mut m = MemWriter::new();
             write_boxplot(&mut m as &mut io::Writer, s, 30).unwrap();
-            let out = str::from_utf8_owned(m.unwrap()).unwrap();
+            let out = str::from_utf8(m.unwrap().as_slice()).unwrap().to_owned();
             assert_eq!(out, expected);
         }
 

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -460,7 +460,7 @@ pub fn query_to_str(query: &Query) -> ~str {
         write!(&mut writer, "{}={}", encode_component(*k),
                encode_component(*v));
     }
-    str::from_utf8_lossy(writer.unwrap()).into_owned()
+    str::from_utf8_lossy(writer.unwrap().as_slice()).into_owned()
 }
 
 /**

--- a/src/libworkcache/lib.rs
+++ b/src/libworkcache/lib.rs
@@ -479,7 +479,7 @@ impl<'a, T:Send +
 fn test() {
     use std::os;
     use std::io::{fs, Process};
-    use std::str::from_utf8_owned;
+    use std::str::from_utf8;
 
     // Create a path to a new file 'filename' in the directory in which
     // this test is running.
@@ -505,7 +505,7 @@ fn test() {
         let pth = pth.clone();
 
         let contents = File::open(&pth).read_to_end().unwrap();
-        let file_content = from_utf8_owned(contents).unwrap();
+        let file_content = from_utf8(contents.as_slice()).unwrap().to_owned();
 
         // FIXME (#9639): This needs to handle non-utf8 paths
         prep.declare_input("file", pth.as_str().unwrap(), file_content);

--- a/src/libworkcache/lib.rs
+++ b/src/libworkcache/lib.rs
@@ -256,7 +256,7 @@ fn json_encode<'a, T:Encodable<json::Encoder<'a>, io::IoError>>(t: &T) -> ~str {
     let mut writer = MemWriter::new();
     let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
     let _ = t.encode(&mut encoder);
-    str::from_utf8_owned(writer.unwrap()).unwrap()
+    str::from_utf8(writer.unwrap().as_slice()).unwrap().to_owned()
 }
 
 // FIXME(#5121)

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -154,7 +154,7 @@ fn main() {
 
     let rdr = if os::getenv("RUST_BENCH").is_some() {
         let foo = include_bin!("shootout-k-nucleotide.data");
-        ~MemReader::new(foo.to_owned()) as ~Reader
+        ~MemReader::new(Vec::from_slice(foo)) as ~Reader
     } else {
         ~stdio::stdin() as ~Reader
     };

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -44,7 +44,7 @@ fn main() {
     };
     let mut data = data.unwrap();
 
-    for seq in data.mut_split(|c| *c == '>' as u8) {
+    for seq in data.as_mut_slice().mut_split(|c| *c == '>' as u8) {
         // skip header and last \n
         let begin = match seq.iter().position(|c| *c == '\n' as u8) {
             None => continue,
@@ -80,5 +80,5 @@ fn main() {
         }
     }
 
-    stdout().write(data).unwrap();
+    stdout().write(data.as_slice()).unwrap();
 }

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -58,7 +58,7 @@ fn main() {
         // rustc is passed to us with --out-dir and -L etc., so we
         // can't exec it directly
         let result = Process::output("sh", [~"-c", rustc + " " + main_file_str]).unwrap();
-        let err = str::from_utf8_lossy(result.error);
+        let err = str::from_utf8_lossy(result.error.as_slice());
 
         // positive test so that this test will be updated when the
         // compiler changes.

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -55,7 +55,7 @@ fn main() {
         // can't exec it directly
         let result = Process::output("sh", [~"-c", rustc + " " + main_file_str]).unwrap();
 
-        let err = str::from_utf8_lossy(result.error);
+        let err = str::from_utf8_lossy(result.error.as_slice());
 
         // the span should end the line (e.g no extra ~'s)
         let expected_span = "^" + "~".repeat(n - 1) + "\n";

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -53,7 +53,7 @@ fn runtest(me: &str) {
     }).unwrap();
     let out = p.wait_with_output();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error).unwrap();
+    let s = str::from_utf8(out.error.as_slice()).unwrap();
     assert!(s.contains("stack backtrace") && s.contains("foo::h"),
             "bad output: {}", s);
 
@@ -65,7 +65,7 @@ fn runtest(me: &str) {
     }).unwrap();
     let out = p.wait_with_output();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error).unwrap();
+    let s = str::from_utf8(out.error.as_slice()).unwrap();
     assert!(!s.contains("stack backtrace") && !s.contains("foo::h"),
             "bad output2: {}", s);
 
@@ -77,7 +77,7 @@ fn runtest(me: &str) {
     }).unwrap();
     let out = p.wait_with_output();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error).unwrap();
+    let s = str::from_utf8(out.error.as_slice()).unwrap();
     assert!(s.contains("stack backtrace") && s.contains("double::h"),
             "bad output3: {}", s);
 
@@ -90,7 +90,7 @@ fn runtest(me: &str) {
     }).unwrap();
     let out = p.wait_with_output();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error).unwrap();
+    let s = str::from_utf8(out.error.as_slice()).unwrap();
     let mut i = 0;
     for _ in range(0, 2) {
         i += s.slice_from(i + 10).find_str("stack backtrace").unwrap() + 10;

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -174,7 +174,7 @@ fn test_write() {
         writeln!(w, "{foo}", foo="bar");
     }
 
-    let s = str::from_utf8_owned(buf.unwrap()).unwrap();
+    let s = str::from_utf8(buf.unwrap().as_slice()).unwrap().to_owned();
     t!(s, "34helloline\nbar\n");
 }
 
@@ -198,7 +198,7 @@ fn test_format_args() {
         format_args!(|args| { fmt::write(w, args); }, "test");
         format_args!(|args| { fmt::write(w, args); }, "{test}", test=3);
     }
-    let s = str::from_utf8_owned(buf.unwrap()).unwrap();
+    let s = str::from_utf8(buf.unwrap().as_slice()).unwrap().to_owned();
     t!(s, "1test3");
 
     let s = format_args!(fmt::format, "hello {}", "world");

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -43,12 +43,12 @@ fn main() {
     } else {
         let silent = Process::output(args[0], [~"silent"]).unwrap();
         assert!(!silent.status.success());
-        let error = str::from_utf8_lossy(silent.error);
+        let error = str::from_utf8_lossy(silent.error.as_slice());
         assert!(error.as_slice().contains("has overflowed its stack"));
 
         let loud = Process::output(args[0], [~"loud"]).unwrap();
         assert!(!loud.status.success());
-        let error = str::from_utf8_lossy(silent.error);
+        let error = str::from_utf8_lossy(silent.error.as_slice());
         assert!(error.as_slice().contains("has overflowed its stack"));
     }
 }


### PR DESCRIPTION
`Reader`, `Writer`, `MemReader`, `MemWriter`, and `MultiWriter` now work with `Vec<u8>` instead of `~[u8]`. This does introduce some extra copies since `from_utf8_owned` isn't usable anymore, but I think that can't be helped until `~str`'s representation changes.
