### PR TITLE
Minor libsyntax @ and cell cleanup.

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -23,6 +23,7 @@ use metadata::loader;
 use metadata::loader::Os;
 
 use std::cell::RefCell;
+use std::rc::Rc;
 use collections::HashMap;
 use syntax::ast;
 use syntax::abi;
@@ -41,7 +42,7 @@ use syntax::visit;
 pub fn read_crates(sess: &Session,
                    krate: &ast::Crate,
                    os: loader::Os,
-                   intr: @IdentInterner) {
+                   intr: Rc<IdentInterner>) {
     let mut e = Env {
         sess: sess,
         os: os,
@@ -114,7 +115,7 @@ struct Env<'a> {
     os: loader::Os,
     crate_cache: @RefCell<Vec<cache_entry>>,
     next_crate_num: ast::CrateNum,
-    intr: @IdentInterner
+    intr: Rc<IdentInterner>
 }
 
 fn visit_crate(e: &Env, c: &ast::Crate) {
@@ -295,7 +296,7 @@ fn resolve_crate(e: &mut Env,
                 id_hash: id_hash,
                 hash: hash.map(|a| &*a),
                 os: e.os,
-                intr: e.intr,
+                intr: e.intr.clone(),
                 rejected_via_hash: false,
             };
             let loader::Library {

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -63,7 +63,7 @@ pub fn each_child_of_item(cstore: &cstore::CStore,
     let get_crate_data: decoder::GetCrateDataCb = |cnum| {
         cstore.get_crate_data(cnum)
     };
-    decoder::each_child_of_item(cstore.intr,
+    decoder::each_child_of_item(cstore.intr.clone(),
                                 crate_data,
                                 def_id.node,
                                 get_crate_data,
@@ -80,7 +80,7 @@ pub fn each_top_level_item_of_crate(cstore: &cstore::CStore,
     let get_crate_data: decoder::GetCrateDataCb = |cnum| {
         cstore.get_crate_data(cnum)
     };
-    decoder::each_top_level_item_of_crate(cstore.intr,
+    decoder::each_top_level_item_of_crate(cstore.intr.clone(),
                                           crate_data,
                                           get_crate_data,
                                           callback)
@@ -118,19 +118,19 @@ pub fn get_enum_variants(tcx: &ty::ctxt, def: ast::DefId)
                       -> Vec<@ty::VariantInfo> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
-    return decoder::get_enum_variants(cstore.intr, cdata, def.node, tcx)
+    return decoder::get_enum_variants(cstore.intr.clone(), cdata, def.node, tcx)
 }
 
 /// Returns information about the given implementation.
 pub fn get_impl(tcx: &ty::ctxt, impl_def_id: ast::DefId)
                 -> ty::Impl {
     let cdata = tcx.sess.cstore.get_crate_data(impl_def_id.krate);
-    decoder::get_impl(tcx.sess.cstore.intr, cdata, impl_def_id.node, tcx)
+    decoder::get_impl(tcx.sess.cstore.intr.clone(), cdata, impl_def_id.node, tcx)
 }
 
 pub fn get_method(tcx: &ty::ctxt, def: ast::DefId) -> ty::Method {
     let cdata = tcx.sess.cstore.get_crate_data(def.krate);
-    decoder::get_method(tcx.sess.cstore.intr, cdata, def.node, tcx)
+    decoder::get_method(tcx.sess.cstore.intr.clone(), cdata, def.node, tcx)
 }
 
 pub fn get_method_name_and_explicit_self(cstore: &cstore::CStore,
@@ -138,7 +138,7 @@ pub fn get_method_name_and_explicit_self(cstore: &cstore::CStore,
                                      -> (ast::Ident, ast::ExplicitSelf_)
 {
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_method_name_and_explicit_self(cstore.intr, cdata, def.node)
+    decoder::get_method_name_and_explicit_self(cstore.intr.clone(), cdata, def.node)
 }
 
 pub fn get_trait_method_def_ids(cstore: &cstore::CStore,
@@ -158,7 +158,7 @@ pub fn get_provided_trait_methods(tcx: &ty::ctxt,
                                -> Vec<@ty::Method> {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_provided_trait_methods(cstore.intr, cdata, def.node, tcx)
+    decoder::get_provided_trait_methods(cstore.intr.clone(), cdata, def.node, tcx)
 }
 
 pub fn get_supertraits(tcx: &ty::ctxt, def: ast::DefId) -> Vec<@ty::TraitRef> {
@@ -177,7 +177,7 @@ pub fn get_static_methods_if_impl(cstore: &cstore::CStore,
                                   def: ast::DefId)
                                -> Option<Vec<StaticMethodInfo> > {
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_static_methods_if_impl(cstore.intr, cdata, def.node)
+    decoder::get_static_methods_if_impl(cstore.intr.clone(), cdata, def.node)
 }
 
 pub fn get_item_attrs(cstore: &cstore::CStore,
@@ -191,7 +191,7 @@ pub fn get_struct_fields(cstore: &cstore::CStore,
                          def: ast::DefId)
                       -> Vec<ty::field_ty> {
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_struct_fields(cstore.intr, cdata, def.node)
+    decoder::get_struct_fields(cstore.intr.clone(), cdata, def.node)
 }
 
 pub fn get_type(tcx: &ty::ctxt,
@@ -251,7 +251,7 @@ pub fn get_impl_method(cstore: &cstore::CStore,
                        mname: ast::Ident)
                     -> Option<ast::DefId> {
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_impl_method(cstore.intr, cdata, def.node, mname)
+    decoder::get_impl_method(cstore.intr.clone(), cdata, def.node, mname)
 }
 
 pub fn get_item_visibility(cstore: &cstore::CStore,

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -19,6 +19,7 @@ use metadata::loader;
 
 use std::cell::RefCell;
 use std::c_vec::CVec;
+use std::rc::Rc;
 use collections::HashMap;
 use syntax::ast;
 use syntax::parse::token::IdentInterner;
@@ -70,14 +71,14 @@ pub struct CStore {
     priv used_crate_sources: RefCell<Vec<CrateSource> >,
     priv used_libraries: RefCell<Vec<(~str, NativeLibaryKind)> >,
     priv used_link_args: RefCell<Vec<~str> >,
-    intr: @IdentInterner
+    intr: Rc<IdentInterner>
 }
 
 // Map from NodeId's of local extern crate statements to crate numbers
 type extern_mod_crate_map = HashMap<ast::NodeId, ast::CrateNum>;
 
 impl CStore {
-    pub fn new(intr: @IdentInterner) -> CStore {
+    pub fn new(intr: Rc<IdentInterner>) -> CStore {
         CStore {
             metas: RefCell::new(HashMap::new()),
             extern_mod_crate_map: RefCell::new(HashMap::new()),

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -29,6 +29,7 @@ use std::cast;
 use std::cmp;
 use std::io;
 use std::os::consts::{macos, freebsd, linux, android, win32};
+use std::rc::Rc;
 use std::str;
 use std::slice;
 
@@ -52,7 +53,7 @@ pub struct Context<'a> {
     id_hash: &'a str,
     hash: Option<&'a Svh>,
     os: Os,
-    intr: @IdentInterner,
+    intr: Rc<IdentInterner>,
     rejected_via_hash: bool,
 }
 

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -44,7 +44,7 @@ pub fn highlight(src: &str, class: Option<&str>) -> ~str {
 /// it's used. All source code emission is done as slices from the source map,
 /// not from the tokens themselves, in order to stay true to the original
 /// source.
-fn doit(sess: &parse::ParseSess, lexer: lexer::StringReader, class: Option<&str>,
+fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader, class: Option<&str>,
         out: &mut Writer) -> io::IoResult<()> {
     use syntax::parse::lexer::Reader;
 
@@ -55,7 +55,7 @@ fn doit(sess: &parse::ParseSess, lexer: lexer::StringReader, class: Option<&str>
     let mut is_macro_nonterminal = false;
     loop {
         let next = lexer.next_token();
-        let test = if next.tok == t::EOF {lexer.pos.get()} else {next.sp.lo};
+        let test = if next.tok == t::EOF {lexer.pos} else {next.sp.lo};
 
         // The lexer consumes all whitespace and non-doc-comments when iterating
         // between tokens. If this token isn't directly adjacent to our last

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -581,14 +581,16 @@ pub enum TokenTree {
     TTTok(Span, ::parse::token::Token),
     // a delimited sequence (the delimiters appear as the first
     // and last elements of the vector)
-    TTDelim(@Vec<TokenTree> ),
+    // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
+    TTDelim(Rc<Vec<TokenTree>>),
 
     // These only make sense for right-hand-sides of MBE macros:
 
     // a kleene-style repetition sequence with a span, a TTForest,
     // an optional separator, and a boolean where true indicates
     // zero or more (..), and false indicates one or more (+).
-    TTSeq(Span, @Vec<TokenTree> , Option<::parse::token::Token>, bool),
+    // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
+    TTSeq(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, bool),
 
     // a syntactic variable that will be filled in by macro expansion.
     TTNonterminal(Span, Ident)

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -13,6 +13,8 @@ use codemap;
 use ext::base;
 use print;
 
+use std::rc::Rc;
+
 pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
                          sp: codemap::Span,
                          tt: &[ast::TokenTree])
@@ -20,7 +22,7 @@ pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
 
     cx.print_backtrace();
     println!("{}", print::pprust::tt_to_str(&ast::TTDelim(
-                @tt.iter().map(|x| (*x).clone()).collect())));
+                Rc::new(tt.iter().map(|x| (*x).clone()).collect()))));
 
     // any so that `log_syntax` can be invoked as an expression and item.
     base::MacResult::dummy_any(sp)

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -204,11 +204,11 @@ pub enum ParseResult {
     Error(codemap::Span, ~str)
 }
 
-pub fn parse_or_else<R: Reader>(sess: &ParseSess,
-                                cfg: ast::CrateConfig,
-                                rdr: R,
-                                ms: Vec<Matcher> )
-                                -> HashMap<Ident, @NamedMatch> {
+pub fn parse_or_else(sess: &ParseSess,
+                     cfg: ast::CrateConfig,
+                     rdr: TtReader,
+                     ms: Vec<Matcher> )
+                     -> HashMap<Ident, @NamedMatch> {
     match parse(sess, cfg, rdr, ms.as_slice()) {
         Success(m) => m,
         Failure(sp, str) => sess.span_diagnostic.span_fatal(sp, str),
@@ -226,11 +226,11 @@ pub fn token_name_eq(t1 : &Token, t2 : &Token) -> bool {
     }
 }
 
-pub fn parse<R: Reader>(sess: &ParseSess,
-                        cfg: ast::CrateConfig,
-                        rdr: R,
-                        ms: &[Matcher])
-                        -> ParseResult {
+pub fn parse(sess: &ParseSess,
+             cfg: ast::CrateConfig,
+             mut rdr: TtReader,
+             ms: &[Matcher])
+             -> ParseResult {
     let mut cur_eis = Vec::new();
     cur_eis.push(initial_matcher_pos(ms.iter()
                                        .map(|x| (*x).clone())
@@ -395,7 +395,7 @@ pub fn parse<R: Reader>(sess: &ParseSess,
                 }
                 rdr.next_token();
             } else /* bb_eis.len() == 1 */ {
-                let mut rust_parser = Parser(sess, cfg.clone(), rdr.dup());
+                let mut rust_parser = Parser(sess, cfg.clone(), ~rdr.clone());
 
                 let mut ei = bb_eis.pop().unwrap();
                 match ei.elts.get(ei.idx).node {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -86,8 +86,8 @@ impl<'a> AnyMacro for ParserAnyMacro<'a> {
 
 struct MacroRulesMacroExpander {
     name: Ident,
-    lhses: @Vec<@NamedMatch> ,
-    rhses: @Vec<@NamedMatch> ,
+    lhses: Vec<Rc<NamedMatch>>,
+    rhses: Vec<Rc<NamedMatch>>,
 }
 
 impl MacroExpander for MacroRulesMacroExpander {
@@ -110,8 +110,8 @@ fn generic_extension(cx: &ExtCtxt,
                      sp: Span,
                      name: Ident,
                      arg: &[ast::TokenTree],
-                     lhses: &[@NamedMatch],
-                     rhses: &[@NamedMatch])
+                     lhses: &[Rc<NamedMatch>],
+                     rhses: &[Rc<NamedMatch>])
                      -> MacResult {
     if cx.trace_macros() {
         println!("{}! \\{ {} \\}",
@@ -221,12 +221,12 @@ pub fn add_new_extension(cx: &mut ExtCtxt,
 
     // Extract the arguments:
     let lhses = match **argument_map.get(&lhs_nm) {
-        MatchedSeq(ref s, _) => /* FIXME (#2543) */ @(*s).clone(),
+        MatchedSeq(ref s, _) => /* FIXME (#2543) */ (*s).clone(),
         _ => cx.span_bug(sp, "wrong-structured lhs")
     };
 
     let rhses = match **argument_map.get(&rhs_nm) {
-        MatchedSeq(ref s, _) => /* FIXME (#2543) */ @(*s).clone(),
+        MatchedSeq(ref s, _) => /* FIXME (#2543) */ (*s).clone(),
         _ => cx.span_bug(sp, "wrong-structured rhs")
     };
 

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -28,6 +28,7 @@ use print;
 use util::small_vector::SmallVector;
 
 use std::cell::RefCell;
+use std::rc::Rc;
 
 struct ParserAnyMacro<'a> {
     parser: RefCell<Parser<'a>>,
@@ -115,9 +116,9 @@ fn generic_extension(cx: &ExtCtxt,
     if cx.trace_macros() {
         println!("{}! \\{ {} \\}",
                  token::get_ident(name),
-                 print::pprust::tt_to_str(&TTDelim(@arg.iter()
-                                                       .map(|x| (*x).clone())
-                                                       .collect())));
+                 print::pprust::tt_to_str(&TTDelim(Rc::new(arg.iter()
+                                                              .map(|x| (*x).clone())
+                                                              .collect()))));
     }
 
     // Which arm's failure should we report? (the one furthest along)

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -17,12 +17,13 @@ use parse::token::{EOF, INTERPOLATED, IDENT, Token, NtIdent};
 use parse::token;
 use parse::lexer::TokenAndSpan;
 
+use std::rc::Rc;
 use collections::HashMap;
 
 ///an unzipping of `TokenTree`s
 #[deriving(Clone)]
 struct TtFrame {
-    forest: @Vec<ast::TokenTree>,
+    forest: Rc<Vec<ast::TokenTree>>,
     idx: uint,
     dotdotdoted: bool,
     sep: Option<Token>,
@@ -52,7 +53,7 @@ pub fn new_tt_reader<'a>(sp_diag: &'a SpanHandler,
     let mut r = TtReader {
         sp_diag: sp_diag,
         stack: vec!(TtFrame {
-            forest: @src,
+            forest: Rc::new(src),
             idx: 0,
             dotdotdoted: false,
             sep: None,
@@ -212,7 +213,7 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
             }
             TTSeq(sp, tts, sep, zerok) => {
                 // FIXME(pcwalton): Bad copy.
-                match lockstep_iter_size(&TTSeq(sp, tts, sep.clone(), zerok), r) {
+                match lockstep_iter_size(&TTSeq(sp, tts.clone(), sep.clone(), zerok), r) {
                     LisUnconstrained => {
                         r.sp_diag.span_fatal(
                             sp.clone(), /* blame macro writer */

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -17,29 +17,29 @@ use parse::token::{EOF, INTERPOLATED, IDENT, Token, NtIdent};
 use parse::token;
 use parse::lexer::TokenAndSpan;
 
-use std::cell::{Cell, RefCell};
 use collections::HashMap;
 
 ///an unzipping of `TokenTree`s
+#[deriving(Clone)]
 struct TtFrame {
-    forest: @Vec<ast::TokenTree> ,
-    idx: Cell<uint>,
+    forest: @Vec<ast::TokenTree>,
+    idx: uint,
     dotdotdoted: bool,
     sep: Option<Token>,
-    up: Option<@TtFrame>,
 }
 
+#[deriving(Clone)]
 pub struct TtReader<'a> {
     sp_diag: &'a SpanHandler,
     // the unzipped tree:
-    priv stack: RefCell<@TtFrame>,
+    priv stack: Vec<TtFrame>,
     /* for MBE-style macro transcription */
-    priv interpolations: RefCell<HashMap<Ident, @NamedMatch>>,
-    priv repeat_idx: RefCell<Vec<uint> >,
-    priv repeat_len: RefCell<Vec<uint> >,
+    priv interpolations: HashMap<Ident, @NamedMatch>,
+    priv repeat_idx: Vec<uint>,
+    priv repeat_len: Vec<uint>,
     /* cached: */
-    cur_tok: RefCell<Token>,
-    cur_span: RefCell<Span>,
+    cur_tok: Token,
+    cur_span: Span,
 }
 
 /** This can do Macro-By-Example transcription. On the other hand, if
@@ -49,58 +49,30 @@ pub fn new_tt_reader<'a>(sp_diag: &'a SpanHandler,
                          interp: Option<HashMap<Ident, @NamedMatch>>,
                          src: Vec<ast::TokenTree> )
                          -> TtReader<'a> {
-    let r = TtReader {
+    let mut r = TtReader {
         sp_diag: sp_diag,
-        stack: RefCell::new(@TtFrame {
+        stack: vec!(TtFrame {
             forest: @src,
-            idx: Cell::new(0u),
+            idx: 0,
             dotdotdoted: false,
             sep: None,
-            up: None
         }),
         interpolations: match interp { /* just a convienience */
-            None => RefCell::new(HashMap::new()),
-            Some(x) => RefCell::new(x),
+            None => HashMap::new(),
+            Some(x) => x,
         },
-        repeat_idx: RefCell::new(Vec::new()),
-        repeat_len: RefCell::new(Vec::new()),
+        repeat_idx: Vec::new(),
+        repeat_len: Vec::new(),
         /* dummy values, never read: */
-        cur_tok: RefCell::new(EOF),
-        cur_span: RefCell::new(DUMMY_SP),
+        cur_tok: EOF,
+        cur_span: DUMMY_SP,
     };
-    tt_next_token(&r); /* get cur_tok and cur_span set up */
+    tt_next_token(&mut r); /* get cur_tok and cur_span set up */
     r
 }
 
-fn dup_tt_frame(f: @TtFrame) -> @TtFrame {
-    @TtFrame {
-        forest: @(*f.forest).clone(),
-        idx: f.idx.clone(),
-        dotdotdoted: f.dotdotdoted,
-        sep: f.sep.clone(),
-        up: match f.up {
-            Some(up_frame) => Some(dup_tt_frame(up_frame)),
-            None => None
-        }
-    }
-}
-
-pub fn dup_tt_reader<'a>(r: &TtReader<'a>) -> TtReader<'a> {
-    TtReader {
-        sp_diag: r.sp_diag,
-        stack: RefCell::new(dup_tt_frame(r.stack.get())),
-        repeat_idx: r.repeat_idx.clone(),
-        repeat_len: r.repeat_len.clone(),
-        cur_tok: r.cur_tok.clone(),
-        cur_span: r.cur_span.clone(),
-        interpolations: r.interpolations.clone(),
-    }
-}
-
-
-fn lookup_cur_matched_by_matched(r: &TtReader, start: @NamedMatch)
-                                 -> @NamedMatch {
-    fn red(ad: @NamedMatch, idx: &uint) -> @NamedMatch {
+fn lookup_cur_matched_by_matched(r: &TtReader, start: @NamedMatch) -> @NamedMatch {
+    r.repeat_idx.iter().fold(start, |ad, idx| {
         match *ad {
             MatchedNonterminal(_) => {
                 // end of the line; duplicate henceforth
@@ -108,16 +80,15 @@ fn lookup_cur_matched_by_matched(r: &TtReader, start: @NamedMatch)
             }
             MatchedSeq(ref ads, _) => *ads.get(*idx)
         }
-    }
-    r.repeat_idx.borrow().iter().fold(start, red)
+    })
 }
 
 fn lookup_cur_matched(r: &TtReader, name: Ident) -> @NamedMatch {
-    let matched_opt = r.interpolations.borrow().find_copy(&name);
+    let matched_opt = r.interpolations.find_copy(&name);
     match matched_opt {
         Some(s) => lookup_cur_matched_by_matched(r, s),
         None => {
-            r.sp_diag.span_fatal(r.cur_span.get(),
+            r.sp_diag.span_fatal(r.cur_span,
                                  format!("unknown macro variable `{}`",
                                          token::get_ident(name)));
         }
@@ -167,143 +138,140 @@ fn lockstep_iter_size(t: &TokenTree, r: &TtReader) -> LockstepIterSize {
 
 // return the next token from the TtReader.
 // EFFECT: advances the reader's token field
-pub fn tt_next_token(r: &TtReader) -> TokenAndSpan {
+pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
     // FIXME(pcwalton): Bad copy?
     let ret_val = TokenAndSpan {
-        tok: r.cur_tok.get(),
-        sp: r.cur_span.get(),
+        tok: r.cur_tok.clone(),
+        sp: r.cur_span.clone(),
     };
     loop {
-        if r.stack.borrow().idx.get() < r.stack.borrow().forest.len() {
-            break;
-        }
+        let should_pop = match r.stack.last() {
+            None => {
+                assert_eq!(ret_val.tok, EOF);
+                return ret_val;
+            }
+            Some(frame) => {
+                if frame.idx < frame.forest.len() {
+                    break;
+                }
+                !frame.dotdotdoted ||
+                    *r.repeat_idx.last().unwrap() == *r.repeat_len.last().unwrap() - 1
+            }
+        };
 
         /* done with this set; pop or repeat? */
-        if !r.stack.get().dotdotdoted || {
-                *r.repeat_idx.borrow().last().unwrap() ==
-                *r.repeat_len.borrow().last().unwrap() - 1
-            } {
-
-            match r.stack.get().up {
-              None => {
-                r.cur_tok.set(EOF);
-                return ret_val;
-              }
-              Some(tt_f) => {
-                if r.stack.get().dotdotdoted {
-                    r.repeat_idx.borrow_mut().pop().unwrap();
-                    r.repeat_len.borrow_mut().pop().unwrap();
+        if should_pop {
+            let prev = r.stack.pop().unwrap();
+            match r.stack.mut_last() {
+                None => {
+                    r.cur_tok = EOF;
+                    return ret_val;
                 }
-
-                r.stack.set(tt_f);
-                r.stack.get().idx.set(r.stack.get().idx.get() + 1u);
-              }
+                Some(frame) => {
+                    frame.idx += 1;
+                }
             }
-
+            if prev.dotdotdoted {
+                r.repeat_idx.pop();
+                r.repeat_len.pop();
+            }
         } else { /* repeat */
-            r.stack.get().idx.set(0u);
-            {
-                let mut repeat_idx = r.repeat_idx.borrow_mut();
-                let last_repeat_idx = repeat_idx.len() - 1u;
-                *repeat_idx.get_mut(last_repeat_idx) += 1u;
-            }
-            match r.stack.get().sep.clone() {
-              Some(tk) => {
-                r.cur_tok.set(tk); /* repeat same span, I guess */
-                return ret_val;
-              }
-              None => ()
+            *r.repeat_idx.mut_last().unwrap() += 1u;
+            r.stack.mut_last().unwrap().idx = 0;
+            match r.stack.last().unwrap().sep.clone() {
+                Some(tk) => {
+                    r.cur_tok = tk; /* repeat same span, I guess */
+                    return ret_val;
+                }
+                None => {}
             }
         }
     }
     loop { /* because it's easiest, this handles `TTDelim` not starting
-    with a `TTTok`, even though it won't happen */
-        // FIXME(pcwalton): Bad copy.
-        match (*r.stack.get().forest.get(r.stack.get().idx.get())).clone() {
-          TTDelim(tts) => {
-            r.stack.set(@TtFrame {
-                forest: tts,
-                idx: Cell::new(0u),
-                dotdotdoted: false,
-                sep: None,
-                up: Some(r.stack.get())
-            });
-            // if this could be 0-length, we'd need to potentially recur here
-          }
-          TTTok(sp, tok) => {
-            r.cur_span.set(sp);
-            r.cur_tok.set(tok);
-            r.stack.get().idx.set(r.stack.get().idx.get() + 1u);
-            return ret_val;
-          }
-          TTSeq(sp, tts, sep, zerok) => {
+              with a `TTTok`, even though it won't happen */
+        let t = {
+            let frame = r.stack.last().unwrap();
             // FIXME(pcwalton): Bad copy.
-            let t = TTSeq(sp, tts, sep.clone(), zerok);
-            match lockstep_iter_size(&t, r) {
-              LisUnconstrained => {
-                r.sp_diag.span_fatal(
-                    sp, /* blame macro writer */
-                      "attempted to repeat an expression \
-                       containing no syntax \
-                       variables matched as repeating at this depth");
-                  }
-                  LisContradiction(ref msg) => {
-                      /* FIXME #2887 blame macro invoker instead*/
-                      r.sp_diag.span_fatal(sp, (*msg));
-                  }
-                  LisConstraint(len, _) => {
-                    if len == 0 {
-                      if !zerok {
-                        r.sp_diag.span_fatal(sp, /* FIXME #2887 blame invoker
-                        */
-                                             "this must repeat at least \
-                                              once");
-                          }
-
-                    r.stack.get().idx.set(r.stack.get().idx.get() + 1u);
-                    return tt_next_token(r);
-                } else {
-                    r.repeat_len.borrow_mut().push(len);
-                    r.repeat_idx.borrow_mut().push(0u);
-                    r.stack.set(@TtFrame {
-                        forest: tts,
-                        idx: Cell::new(0u),
-                        dotdotdoted: true,
-                        sep: sep,
-                        up: Some(r.stack.get())
-                    });
-                }
-              }
+            (*frame.forest.get(frame.idx)).clone()
+        };
+        match t {
+            TTDelim(tts) => {
+                r.stack.push(TtFrame {
+                    forest: tts,
+                    idx: 0,
+                    dotdotdoted: false,
+                    sep: None
+                });
+                // if this could be 0-length, we'd need to potentially recur here
             }
-          }
-          // FIXME #2887: think about span stuff here
-          TTNonterminal(sp, ident) => {
-            match *lookup_cur_matched(r, ident) {
-              /* sidestep the interpolation tricks for ident because
-              (a) idents can be in lots of places, so it'd be a pain
-              (b) we actually can, since it's a token. */
-              MatchedNonterminal(NtIdent(~sn,b)) => {
-                r.cur_span.set(sp);
-                r.cur_tok.set(IDENT(sn,b));
-                r.stack.get().idx.set(r.stack.get().idx.get() + 1u);
+            TTTok(sp, tok) => {
+                r.cur_span = sp;
+                r.cur_tok = tok;
+                r.stack.mut_last().unwrap().idx += 1;
                 return ret_val;
-              }
-              MatchedNonterminal(ref other_whole_nt) => {
+            }
+            TTSeq(sp, tts, sep, zerok) => {
                 // FIXME(pcwalton): Bad copy.
-                r.cur_span.set(sp);
-                r.cur_tok.set(INTERPOLATED((*other_whole_nt).clone()));
-                r.stack.get().idx.set(r.stack.get().idx.get() + 1u);
-                return ret_val;
-              }
-              MatchedSeq(..) => {
-                r.sp_diag.span_fatal(
-                    r.cur_span.get(), /* blame the macro writer */
-                    format!("variable '{}' is still repeating at this depth",
-                            token::get_ident(ident)));
-              }
+                match lockstep_iter_size(&TTSeq(sp, tts, sep.clone(), zerok), r) {
+                    LisUnconstrained => {
+                        r.sp_diag.span_fatal(
+                            sp.clone(), /* blame macro writer */
+                            "attempted to repeat an expression \
+                             containing no syntax \
+                             variables matched as repeating at this depth");
+                        }
+                        LisContradiction(ref msg) => {
+                            // FIXME #2887 blame macro invoker instead
+                            r.sp_diag.span_fatal(sp.clone(), *msg);
+                        }
+                    LisConstraint(len, _) => {
+                        if len == 0 {
+                            if !zerok {
+                                // FIXME #2887 blame invoker
+                                r.sp_diag.span_fatal(sp.clone(),
+                                                     "this must repeat at least once");
+                            }
+
+                            r.stack.mut_last().unwrap().idx += 1;
+                            return tt_next_token(r);
+                        }
+                        r.repeat_len.push(len);
+                        r.repeat_idx.push(0);
+                        r.stack.push(TtFrame {
+                            forest: tts,
+                            idx: 0,
+                            dotdotdoted: true,
+                            sep: sep.clone()
+                        });
+                    }
+                }
             }
-          }
+            // FIXME #2887: think about span stuff here
+            TTNonterminal(sp, ident) => {
+                r.stack.mut_last().unwrap().idx += 1;
+                match *lookup_cur_matched(r, ident) {
+                    /* sidestep the interpolation tricks for ident because
+                       (a) idents can be in lots of places, so it'd be a pain
+                       (b) we actually can, since it's a token. */
+                    MatchedNonterminal(NtIdent(~sn,b)) => {
+                        r.cur_span = sp;
+                        r.cur_tok = IDENT(sn,b);
+                        return ret_val;
+                    }
+                    MatchedNonterminal(ref other_whole_nt) => {
+                        // FIXME(pcwalton): Bad copy.
+                        r.cur_span = sp;
+                        r.cur_tok = INTERPOLATED((*other_whole_nt).clone());
+                        return ret_val;
+                    }
+                    MatchedSeq(..) => {
+                        r.sp_diag.span_fatal(
+                            r.cur_span, /* blame the macro writer */
+                            format!("variable '{}' is still repeating at this depth",
+                                    token::get_ident(ident)));
+                    }
+                }
+            }
         }
     }
-
 }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -366,13 +366,13 @@ mod test {
             [ast::TTTok(_,_),
              ast::TTTok(_,token::NOT),
              ast::TTTok(_,_),
-             ast::TTDelim(delim_elts)] => {
+             ast::TTDelim(ref delim_elts)] => {
                 let delim_elts: &[ast::TokenTree] = delim_elts.as_slice();
                 match delim_elts {
                     [ast::TTTok(_,token::LPAREN),
-                     ast::TTDelim(first_set),
+                     ast::TTDelim(ref first_set),
                      ast::TTTok(_,token::FAT_ARROW),
-                     ast::TTDelim(second_set),
+                     ast::TTDelim(ref second_set),
                      ast::TTTok(_,token::RPAREN)] => {
                         let first_set: &[ast::TokenTree] =
                             first_set.as_slice();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -329,7 +329,7 @@ pub struct Parser<'a> {
     restriction: restriction,
     quote_depth: uint, // not (yet) related to the quasiquoter
     reader: ~Reader:,
-    interner: @token::IdentInterner,
+    interner: Rc<token::IdentInterner>,
     /// The set of seen errors about obsolete syntax. Used to suppress
     /// extra detail when the same error is seen twice
     obsolete_set: HashSet<ObsoleteSyntax>,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -274,7 +274,7 @@ struct ParsedItemsAndViewItems {
 
 /* ident is handled by common.rs */
 
-pub fn Parser<'a>(sess: &'a ParseSess, cfg: ast::CrateConfig, rdr: ~Reader:)
+pub fn Parser<'a>(sess: &'a ParseSess, cfg: ast::CrateConfig, mut rdr: ~Reader:)
               -> Parser<'a> {
     let tok0 = rdr.next_token();
     let span = tok0.sp;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -80,6 +80,7 @@ use owned_slice::OwnedSlice;
 use collections::HashSet;
 use std::kinds::marker;
 use std::mem::replace;
+use std::rc::Rc;
 use std::vec;
 
 #[allow(non_camel_case_types)]
@@ -2101,7 +2102,7 @@ impl<'a> Parser<'a> {
                     let seq = match seq {
                         Spanned { node, .. } => node,
                     };
-                    TTSeq(mk_sp(sp.lo, p.span.hi), @seq, s, z)
+                    TTSeq(mk_sp(sp.lo, p.span.hi), Rc::new(seq), s, z)
                 } else {
                     TTNonterminal(sp, p.parse_ident())
                 }
@@ -2144,7 +2145,7 @@ impl<'a> Parser<'a> {
                 result.push(parse_any_tt_tok(self));
                 self.open_braces.pop().unwrap();
 
-                TTDelim(@result)
+                TTDelim(Rc::new(result))
             }
             _ => parse_non_delim_tt_tok(self)
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -26,7 +26,6 @@ use print::pp::{Breaks, Consistent, Inconsistent, eof};
 use print::pp;
 
 use std::cast;
-use std::cell::RefCell;
 use std::char;
 use std::str;
 use std::io;
@@ -61,7 +60,7 @@ pub struct State<'a> {
     comments: Option<Vec<comments::Comment> >,
     literals: Option<Vec<comments::Literal> >,
     cur_cmnt_and_lit: CurrentCommentAndLiteral,
-    boxes: RefCell<Vec<pp::Breaks> >,
+    boxes: Vec<pp::Breaks>,
     ann: &'a PpAnn
 }
 
@@ -82,7 +81,7 @@ pub fn rust_printer_annotated<'a>(writer: ~io::Writer,
             cur_cmnt: 0,
             cur_lit: 0
         },
-        boxes: RefCell::new(Vec::new()),
+        boxes: Vec::new(),
         ann: ann
     }
 }
@@ -124,7 +123,7 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
             cur_cmnt: 0,
             cur_lit: 0
         },
-        boxes: RefCell::new(Vec::new()),
+        boxes: Vec::new(),
         ann: ann
     };
     try!(s.print_mod(&krate.module, krate.attrs.as_slice()));
@@ -238,23 +237,23 @@ pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> ~str {
 
 impl<'a> State<'a> {
     pub fn ibox(&mut self, u: uint) -> IoResult<()> {
-        self.boxes.borrow_mut().push(pp::Inconsistent);
+        self.boxes.push(pp::Inconsistent);
         pp::ibox(&mut self.s, u)
     }
 
     pub fn end(&mut self) -> IoResult<()> {
-        self.boxes.borrow_mut().pop().unwrap();
+        self.boxes.pop().unwrap();
         pp::end(&mut self.s)
     }
 
     pub fn cbox(&mut self, u: uint) -> IoResult<()> {
-        self.boxes.borrow_mut().push(pp::Consistent);
+        self.boxes.push(pp::Consistent);
         pp::cbox(&mut self.s, u)
     }
 
     // "raw box"
     pub fn rbox(&mut self, u: uint, b: pp::Breaks) -> IoResult<()> {
-        self.boxes.borrow_mut().push(b);
+        self.boxes.push(b);
         pp::rbox(&mut self.s, u, b)
     }
 
@@ -321,8 +320,8 @@ impl<'a> State<'a> {
         self.s.last_token().is_eof() || self.s.last_token().is_hardbreak_tok()
     }
 
-    pub fn in_cbox(&mut self) -> bool {
-        match self.boxes.borrow().last() {
+    pub fn in_cbox(&self) -> bool {
+        match self.boxes.last() {
             Some(&last_box) => last_box == pp::Consistent,
             None => false
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -31,8 +31,8 @@ use std::char;
 use std::str;
 use std::io;
 use std::io::{IoResult, MemWriter};
+use std::rc::Rc;
 
-// The &mut State is stored here to prevent recursive type.
 pub enum AnnNode<'a> {
     NodeBlock(&'a ast::Block),
     NodeItem(&'a ast::Item),
@@ -57,7 +57,7 @@ pub struct CurrentCommentAndLiteral {
 pub struct State<'a> {
     s: pp::Printer,
     cm: Option<&'a CodeMap>,
-    intr: @token::IdentInterner,
+    intr: Rc<token::IdentInterner>,
     comments: Option<Vec<comments::Comment> >,
     literals: Option<Vec<comments::Literal> >,
     cur_cmnt_and_lit: CurrentCommentAndLiteral,


### PR DESCRIPTION
Removes all Cell's/RefCell's from lexer::Reader implementations and a couple @.
