### PR TITLE
Revert "Modules are either public, or private, so private modules should...

### DIFF
--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -128,8 +128,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                 }
             }
 
-            clean::ViewItemItem(..) |
-            clean::ModuleItem(..) => {
+            clean::ViewItemItem(..) => {
                 if i.visibility != Some(ast::Public) {
                     return None
                 }
@@ -140,6 +139,9 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                     return None;
                 }
             }
+
+            // handled below
+            clean::ModuleItem(..) => {}
 
             // trait impls for private items should be stripped
             clean::ImplItem(clean::Impl{ for_: clean::ResolvedPath{ id: ref for_id, .. }, .. }) => {


### PR DESCRIPTION
... be stripped out"

This reverts commit 7180b5de4452095b032e6c77a77d8c6f81c4f6d3.

We don't particularly need this, I've never seen it clutter up the docs, it just seemed nice at the time. Sadly it caused a regression for reexported methods.

Closes #13091
