### PR TITLE
Remove ~[] from librand, rename Rng.shuffle_mut to .shuffle

### DIFF
--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -112,7 +112,7 @@ mod tests {
         for _ in range(0, 20) {
             let mut input = ~[];
             for _ in range(0, 2000) {
-                input.push_all(r.choose(words.as_slice()));
+                input.push_all(r.choose(words.as_slice()).as_slice());
             }
             debug!("de/inflate of {} bytes of random word-sequences",
                    input.len());

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -441,7 +441,6 @@ impl<'a> SeedableRng<&'a [u64]> for Isaac64Rng {
 mod test {
     use super::{IsaacRng, Isaac64Rng};
     use {Rng, SeedableRng, task_rng};
-    use std::slice;
 
     #[test]
     fn test_rng_32_rand_seeded() {
@@ -479,7 +478,7 @@ mod test {
         let mut r: IsaacRng = SeedableRng::from_seed(s.as_slice());
         let string1 = r.gen_ascii_str(100);
 
-        r.reseed(s);
+        r.reseed(s.as_slice());
 
         let string2 = r.gen_ascii_str(100);
         assert_eq!(string1, string2);
@@ -490,7 +489,7 @@ mod test {
         let mut r: Isaac64Rng = SeedableRng::from_seed(s.as_slice());
         let string1 = r.gen_ascii_str(100);
 
-        r.reseed(s);
+        r.reseed(s.as_slice());
 
         let string2 = r.gen_ascii_str(100);
         assert_eq!(string1, string2);
@@ -501,43 +500,43 @@ mod test {
         let seed = &[1, 23, 456, 7890, 12345];
         let mut ra: IsaacRng = SeedableRng::from_seed(seed);
         // Regression test that isaac is actually using the above vector
-        let v = slice::from_fn(10, |_| ra.next_u32());
+        let v = Vec::from_fn(10, |_| ra.next_u32());
         assert_eq!(v,
-                   ~[2558573138, 873787463, 263499565, 2103644246, 3595684709,
-                     4203127393, 264982119, 2765226902, 2737944514, 3900253796]);
+                   vec!(2558573138, 873787463, 263499565, 2103644246, 3595684709,
+                        4203127393, 264982119, 2765226902, 2737944514, 3900253796));
 
         let seed = &[12345, 67890, 54321, 9876];
         let mut rb: IsaacRng = SeedableRng::from_seed(seed);
         // skip forward to the 10000th number
         for _ in range(0, 10000) { rb.next_u32(); }
 
-        let v = slice::from_fn(10, |_| rb.next_u32());
+        let v = Vec::from_fn(10, |_| rb.next_u32());
         assert_eq!(v,
-                   ~[3676831399, 3183332890, 2834741178, 3854698763, 2717568474,
-                     1576568959, 3507990155, 179069555, 141456972, 2478885421]);
+                   vec!(3676831399, 3183332890, 2834741178, 3854698763, 2717568474,
+                        1576568959, 3507990155, 179069555, 141456972, 2478885421));
     }
     #[test]
     fn test_rng_64_true_values() {
         let seed = &[1, 23, 456, 7890, 12345];
         let mut ra: Isaac64Rng = SeedableRng::from_seed(seed);
         // Regression test that isaac is actually using the above vector
-        let v = slice::from_fn(10, |_| ra.next_u64());
+        let v = Vec::from_fn(10, |_| ra.next_u64());
         assert_eq!(v,
-                   ~[547121783600835980, 14377643087320773276, 17351601304698403469,
-                     1238879483818134882, 11952566807690396487, 13970131091560099343,
-                     4469761996653280935, 15552757044682284409, 6860251611068737823,
-                     13722198873481261842]);
+                   vec!(547121783600835980, 14377643087320773276, 17351601304698403469,
+                        1238879483818134882, 11952566807690396487, 13970131091560099343,
+                        4469761996653280935, 15552757044682284409, 6860251611068737823,
+                        13722198873481261842));
 
         let seed = &[12345, 67890, 54321, 9876];
         let mut rb: Isaac64Rng = SeedableRng::from_seed(seed);
         // skip forward to the 10000th number
         for _ in range(0, 10000) { rb.next_u64(); }
 
-        let v = slice::from_fn(10, |_| rb.next_u64());
+        let v = Vec::from_fn(10, |_| rb.next_u64());
         assert_eq!(v,
-                   ~[18143823860592706164, 8491801882678285927, 2699425367717515619,
-                     17196852593171130876, 2606123525235546165, 15790932315217671084,
-                     596345674630742204, 9947027391921273664, 11788097613744130851,
-                     10391409374914919106]);
+                   vec!(18143823860592706164, 8491801882678285927, 2699425367717515619,
+                        17196852593171130876, 2606123525235546165, 15790932315217671084,
+                        596345674630742204, 9947027391921273664, 11788097613744130851,
+                        10391409374914919106));
     }
 }

--- a/src/librand/os.rs
+++ b/src/librand/os.rs
@@ -204,7 +204,7 @@ mod test {
     #[test]
     fn test_os_rng_tasks() {
 
-        let mut txs = ~[];
+        let mut txs = vec!();
         for _ in range(0, 20) {
             let (tx, rx) = channel();
             txs.push(tx);

--- a/src/librand/reader.rs
+++ b/src/librand/reader.rs
@@ -68,6 +68,7 @@ impl<R: Reader> Rng for ReaderRng<R> {
 }
 
 #[cfg(test)]
+#[allow(deprecated_owned_vector)]
 mod test {
     use super::ReaderRng;
     use std::io::MemReader;

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -205,8 +205,8 @@ mod test {
     #[test]
     fn test_rng_fill_bytes() {
         use task_rng;
-        let mut v = ~[0u8, .. fill_bytes_v_len];
-        task_rng().fill_bytes(v);
+        let mut v = Vec::from_elem(fill_bytes_v_len, 0u8);
+        task_rng().fill_bytes(v.as_mut_slice());
 
         // Sanity test: if we've gotten here, `fill_bytes` has not infinitely
         // recursed.

--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -3442,19 +3442,21 @@ mod tests {
 
     #[test]
     fn test_sort() {
+        use realstd::slice::Vector;
+        use realstd::clone::Clone;
         for len in range(4u, 25) {
             for _ in range(0, 100) {
                 let mut v = task_rng().gen_vec::<uint>(len);
                 let mut v1 = v.clone();
 
-                v.sort();
-                assert!(v.windows(2).all(|w| w[0] <= w[1]));
+                v.as_mut_slice().sort();
+                assert!(v.as_slice().windows(2).all(|w| w[0] <= w[1]));
 
-                v1.sort_by(|a, b| a.cmp(b));
-                assert!(v1.windows(2).all(|w| w[0] <= w[1]));
+                v1.as_mut_slice().sort_by(|a, b| a.cmp(b));
+                assert!(v1.as_slice().windows(2).all(|w| w[0] <= w[1]));
 
-                v1.sort_by(|a, b| b.cmp(a));
-                assert!(v1.windows(2).all(|w| w[0] >= w[1]));
+                v1.as_mut_slice().sort_by(|a, b| b.cmp(a));
+                assert!(v1.as_slice().windows(2).all(|w| w[0] >= w[1]));
             }
         }
 
@@ -4487,8 +4489,8 @@ mod bench {
     fn sort_random_small(bh: &mut BenchHarness) {
         let mut rng = weak_rng();
         bh.iter(|| {
-            let mut v: ~[u64] = rng.gen_vec(5);
-            v.sort();
+            let mut v = rng.gen_vec::<u64>(5);
+            v.as_mut_slice().sort();
         });
         bh.bytes = 5 * mem::size_of::<u64>() as u64;
     }
@@ -4497,8 +4499,8 @@ mod bench {
     fn sort_random_medium(bh: &mut BenchHarness) {
         let mut rng = weak_rng();
         bh.iter(|| {
-            let mut v: ~[u64] = rng.gen_vec(100);
-            v.sort();
+            let mut v = rng.gen_vec::<u64>(100);
+            v.as_mut_slice().sort();
         });
         bh.bytes = 100 * mem::size_of::<u64>() as u64;
     }
@@ -4507,8 +4509,8 @@ mod bench {
     fn sort_random_large(bh: &mut BenchHarness) {
         let mut rng = weak_rng();
         bh.iter(|| {
-            let mut v: ~[u64] = rng.gen_vec(10000);
-            v.sort();
+            let mut v = rng.gen_vec::<u64>(10000);
+            v.as_mut_slice().sort();
         });
         bh.bytes = 10000 * mem::size_of::<u64>() as u64;
     }
@@ -4528,7 +4530,7 @@ mod bench {
     fn sort_big_random_small(bh: &mut BenchHarness) {
         let mut rng = weak_rng();
         bh.iter(|| {
-            let mut v: ~[BigSortable] = rng.gen_vec(5);
+            let mut v = rng.gen_vec::<BigSortable>(5);
             v.sort();
         });
         bh.bytes = 5 * mem::size_of::<BigSortable>() as u64;
@@ -4538,7 +4540,7 @@ mod bench {
     fn sort_big_random_medium(bh: &mut BenchHarness) {
         let mut rng = weak_rng();
         bh.iter(|| {
-            let mut v: ~[BigSortable] = rng.gen_vec(100);
+            let mut v = rng.gen_vec::<BigSortable>(100);
             v.sort();
         });
         bh.bytes = 100 * mem::size_of::<BigSortable>() as u64;
@@ -4548,7 +4550,7 @@ mod bench {
     fn sort_big_random_large(bh: &mut BenchHarness) {
         let mut rng = weak_rng();
         bh.iter(|| {
-            let mut v: ~[BigSortable] = rng.gen_vec(10000);
+            let mut v = rng.gen_vec::<BigSortable>(10000);
             v.sort();
         });
         bh.bytes = 10000 * mem::size_of::<BigSortable>() as u64;

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -196,7 +196,7 @@ impl Uuid {
     pub fn new_v4() -> Uuid {
         let ub = rand::task_rng().gen_vec(16);
         let mut uuid = Uuid{ bytes: [0, .. 16] };
-        slice::bytes::copy_memory(uuid.bytes, ub);
+        slice::bytes::copy_memory(uuid.bytes, ub.as_slice());
         uuid.set_variant(VariantRFC4122);
         uuid.set_version(Version4Random);
         uuid
@@ -510,7 +510,7 @@ impl rand::Rand for Uuid {
     fn rand<R: rand::Rng>(rng: &mut R) -> Uuid {
         let ub = rng.gen_vec(16);
         let mut uuid = Uuid{ bytes: [0, .. 16] };
-        slice::bytes::copy_memory(uuid.bytes, ub);
+        slice::bytes::copy_memory(uuid.bytes, ub.as_slice());
         uuid.set_variant(VariantRFC4122);
         uuid.set_version(Version4Random);
         uuid

--- a/src/test/run-pass/vector-sort-failure-safe.rs
+++ b/src/test/run-pass/vector-sort-failure-safe.rs
@@ -52,7 +52,7 @@ pub fn main() {
             // work out the total number of comparisons required to sort
             // this array...
             let mut count = 0;
-            main.clone().sort_by(|a, b| { count += 1; a.cmp(b) });
+            main.clone().as_mut_slice().sort_by(|a, b| { count += 1; a.cmp(b) });
 
             // ... and then fail on each and every single one.
             for fail_countdown in range(0, count) {
@@ -67,7 +67,7 @@ pub fn main() {
                 task::try(proc() {
                         let mut v = v;
                         let mut fail_countdown = fail_countdown;
-                        v.sort_by(|a, b| {
+                        v.as_mut_slice().sort_by(|a, b| {
                                 if fail_countdown == 0 {
                                     fail!()
                                 }


### PR DESCRIPTION
Remove ~[] from librand, rename Rng.shuffle_mut to .shuffle.

See commits.
