### PR TITLE
Private struct fields by default

### DIFF
--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -21,87 +21,87 @@ pub enum mode {
 #[deriving(Clone)]
 pub struct config {
     // The library paths required for running the compiler
-    compile_lib_path: ~str,
+    pub compile_lib_path: ~str,
 
     // The library paths required for running compiled programs
-    run_lib_path: ~str,
+    pub run_lib_path: ~str,
 
     // The rustc executable
-    rustc_path: Path,
+    pub rustc_path: Path,
 
     // The clang executable
-    clang_path: Option<Path>,
+    pub clang_path: Option<Path>,
 
     // The llvm binaries path
-    llvm_bin_path: Option<Path>,
+    pub llvm_bin_path: Option<Path>,
 
     // The directory containing the tests to run
-    src_base: Path,
+    pub src_base: Path,
 
     // The directory where programs should be built
-    build_base: Path,
+    pub build_base: Path,
 
     // Directory for auxiliary libraries
-    aux_base: Path,
+    pub aux_base: Path,
 
     // The name of the stage being built (stage1, etc)
-    stage_id: ~str,
+    pub stage_id: ~str,
 
     // The test mode, compile-fail, run-fail, run-pass
-    mode: mode,
+    pub mode: mode,
 
     // Run ignored tests
-    run_ignored: bool,
+    pub run_ignored: bool,
 
     // Only run tests that match this filter
-    filter: Option<~str>,
+    pub filter: Option<~str>,
 
     // Write out a parseable log of tests that were run
-    logfile: Option<Path>,
+    pub logfile: Option<Path>,
 
     // Write out a json file containing any metrics of the run
-    save_metrics: Option<Path>,
+    pub save_metrics: Option<Path>,
 
     // Write and ratchet a metrics file
-    ratchet_metrics: Option<Path>,
+    pub ratchet_metrics: Option<Path>,
 
     // Percent change in metrics to consider noise
-    ratchet_noise_percent: Option<f64>,
+    pub ratchet_noise_percent: Option<f64>,
 
-    // "Shard" of the testsuite to run: this has the form of
+    // "Shard" of the testsuite to pub run: this has the form of
     // two numbers (a,b), and causes only those tests with
     // positional order equal to a mod b to run.
-    test_shard: Option<(uint,uint)>,
+    pub test_shard: Option<(uint,uint)>,
 
     // A command line to prefix program execution with,
     // for running under valgrind
-    runtool: Option<~str>,
+    pub runtool: Option<~str>,
 
     // Flags to pass to the compiler when building for the host
-    host_rustcflags: Option<~str>,
+    pub host_rustcflags: Option<~str>,
 
     // Flags to pass to the compiler when building for the target
-    target_rustcflags: Option<~str>,
+    pub target_rustcflags: Option<~str>,
 
     // Run tests using the JIT
-    jit: bool,
+    pub jit: bool,
 
     // Target system to be tested
-    target: ~str,
+    pub target: ~str,
 
     // Host triple for the compiler being invoked
-    host: ~str,
+    pub host: ~str,
 
     // Extra parameter to run adb on arm-linux-androideabi
-    adb_path: ~str,
+    pub adb_path: ~str,
 
     // Extra parameter to run test sute on arm-linux-androideabi
-    adb_test_dir: ~str,
+    pub adb_test_dir: ~str,
 
     // status whether android device available or not
-    adb_device_status: bool,
+    pub adb_device_status: bool,
 
     // Explain what's going on
-    verbose: bool
+    pub verbose: bool
 
 }

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -10,7 +10,11 @@
 
 use std::io::{BufferedReader, File};
 
-pub struct ExpectedError { line: uint, kind: ~str, msg: ~str }
+pub struct ExpectedError {
+    pub line: uint,
+    pub kind: ~str,
+    pub msg: ~str,
+}
 
 // Load any test directives embedded in the file
 pub fn load_errors(testfile: &Path) -> Vec<ExpectedError> {

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -14,26 +14,26 @@ use util;
 
 pub struct TestProps {
     // Lines that should be expected, in order, on standard out
-    error_patterns: Vec<~str> ,
+    pub error_patterns: Vec<~str> ,
     // Extra flags to pass to the compiler
-    compile_flags: Option<~str>,
+    pub compile_flags: Option<~str>,
     // If present, the name of a file that this test should match when
     // pretty-printed
-    pp_exact: Option<Path>,
+    pub pp_exact: Option<Path>,
     // Modules from aux directory that should be compiled
-    aux_builds: Vec<~str> ,
+    pub aux_builds: Vec<~str> ,
     // Environment settings to use during execution
-    exec_env: Vec<(~str,~str)> ,
+    pub exec_env: Vec<(~str,~str)> ,
     // Commands to be given to the debugger, when testing debug info
-    debugger_cmds: Vec<~str> ,
+    pub debugger_cmds: Vec<~str> ,
     // Lines to check if they appear in the expected debugger output
-    check_lines: Vec<~str> ,
+    pub check_lines: Vec<~str> ,
     // Flag to force a crate to be built with the host architecture
-    force_host: bool,
+    pub force_host: bool,
     // Check stdout for error-pattern output as well as stderr
-    check_stdout: bool,
+    pub check_stdout: bool,
     // Don't force a --crate-type=dylib flag on the command line
-    no_prefer_dynamic: bool,
+    pub no_prefer_dynamic: bool,
 }
 
 // Load any test directives embedded in the file

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -57,7 +57,7 @@ fn target_env(lib_path: &str, prog: &str) -> Vec<(~str,~str)> {
     return env;
 }
 
-pub struct Result {status: ProcessExit, out: ~str, err: ~str}
+pub struct Result {pub status: ProcessExit, pub out: ~str, pub err: ~str}
 
 pub fn run(lib_path: &str,
            prog: &str,

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -200,7 +200,7 @@ use std::ptr;
 // Unique<T> has the same semantics as ~T
 pub struct Unique<T> {
     // It contains a single raw, mutable pointer to the object in question.
-    priv ptr: *mut T
+    ptr: *mut T
 }
 
 // Implement methods for creating and using the values in the box.

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1527,12 +1527,9 @@ of an item to see whether it should be allowed or not. This is where privacy
 warnings are generated, or otherwise "you used a private item of another module
 and weren't allowed to."
 
-By default, everything in rust is *private*, with two exceptions. The first
-exception is that struct fields are public by default (but the struct itself is
-still private by default), and the remaining exception is that enum variants in
-a `pub` enum are the default visibility of the enum container itself.. You are
-allowed to alter this default visibility with the `pub` keyword (or `priv`
-keyword for struct fields and enum variants). When an item is declared as `pub`,
+By default, everything in rust is *private*, with one exception. Enum variants
+in a `pub` enum are also public by default. You are allowed to alter this
+default visibility with the `priv` keyword. When an item is declared as `pub`,
 it can be thought of as being accessible to the outside world. For example:
 
 ~~~~
@@ -1542,7 +1539,7 @@ struct Foo;
 
 // Declare a public struct with a private field
 pub struct Bar {
-    priv field: int
+    field: int
 }
 
 // Declare a public enum with public and private variants
@@ -2354,7 +2351,7 @@ The following are examples of structure expressions:
 ~~~~
 # struct Point { x: f64, y: f64 }
 # struct TuplePoint(f64, f64);
-# mod game { pub struct User<'a> { name: &'a str, age: uint, score: uint } }
+# mod game { pub struct User<'a> { pub name: &'a str, pub age: uint, pub score: uint } }
 # struct Cookie; fn some_fn<T>(t: T) {}
 Point {x: 10.0, y: 20.0};
 TuplePoint(10.0, 20.0);
@@ -3140,7 +3137,7 @@ The types `char` and `str` hold textual data.
 A value of type `char` is a [Unicode scalar value](
 http://www.unicode.org/glossary/#unicode_scalar_value)
 (ie. a code point that is not a surrogate),
-represented as a 32-bit unsigned word in the 0x0000 to 0xD7FF 
+represented as a 32-bit unsigned word in the 0x0000 to 0xD7FF
 or 0xE000 to 0x10FFFF range.
 A `[char]` vector is effectively an UCS-4 / UTF-32 string.
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2657,8 +2657,8 @@ Rust doesn't support encapsulation: both struct fields and methods can
 be private. But this encapsulation is at the module level, not the
 struct level.
 
-For convenience, fields are _public_ by default, and can be made _private_ with
-the `priv` keyword:
+Fields are _private_ by default, and can be made _public_ with
+the `pub` keyword:
 
 ~~~
 mod farm {
@@ -2667,8 +2667,8 @@ mod farm {
 # impl Human { pub fn rest(&self) { } }
 # pub fn make_me_a_farm() -> Farm { Farm { chickens: ~[], farmer: Human(0) } }
     pub struct Farm {
-        priv chickens: ~[Chicken],
-        farmer: Human
+        chickens: ~[Chicken],
+        pub farmer: Human
     }
 
     impl Farm {

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -25,6 +25,8 @@
 #![allow(missing_doc)]
 #![feature(managed_boxes)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+
 extern crate collections;
 
 use std::cast::{transmute, transmute_mut, transmute_mut_region};
@@ -83,9 +85,9 @@ pub struct Arena {
     // The head is separated out from the list as a unbenchmarked
     // microoptimization, to avoid needing to case on the list to
     // access the head.
-    priv head: Chunk,
-    priv copy_head: Chunk,
-    priv chunks: RefCell<Vec<Chunk>>,
+    head: Chunk,
+    copy_head: Chunk,
+    chunks: RefCell<Vec<Chunk>>,
 }
 
 impl Arena {
@@ -333,14 +335,14 @@ fn test_arena_destructors_fail() {
 /// run again for these objects.
 pub struct TypedArena<T> {
     /// A pointer to the next object to be allocated.
-    priv ptr: *T,
+    ptr: *T,
 
     /// A pointer to the end of the allocated area. When this pointer is
     /// reached, a new chunk is allocated.
-    priv end: *T,
+    end: *T,
 
     /// A pointer to the first arena segment.
-    priv first: Option<~TypedArenaChunk<T>>,
+    first: Option<~TypedArenaChunk<T>>,
 }
 
 struct TypedArenaChunk<T> {

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -227,9 +227,9 @@ enum Op {Union, Intersect, Assign, Difference}
 #[deriving(Clone)]
 pub struct Bitv {
     /// Internal representation of the bit vector (small or large)
-    priv rep: BitvVariant,
+    rep: BitvVariant,
     /// The number of valid bits in the internal representation
-    priv nbits: uint
+    nbits: uint
 }
 
 fn die() -> ! {
@@ -587,9 +587,9 @@ fn iterate_bits(base: uint, bits: uint, f: |uint| -> bool) -> bool {
 
 /// An iterator for `Bitv`.
 pub struct Bits<'a> {
-    priv bitv: &'a Bitv,
-    priv next_idx: uint,
-    priv end_idx: uint,
+    bitv: &'a Bitv,
+    next_idx: uint,
+    end_idx: uint,
 }
 
 impl<'a> Iterator<bool> for Bits<'a> {
@@ -648,12 +648,12 @@ impl<'a> RandomAccessIterator<bool> for Bits<'a> {
 /// as a `uint`.
 #[deriving(Clone)]
 pub struct BitvSet {
-    priv size: uint,
+    size: uint,
 
     // In theory this is a `Bitv` instead of always a `BigBitv`, but knowing that
     // there's an array of storage makes our lives a whole lot easier when
     // performing union/intersection/etc operations
-    priv bitv: BigBitv
+    bitv: BigBitv
 }
 
 impl BitvSet {
@@ -912,8 +912,8 @@ impl BitvSet {
 }
 
 pub struct BitPositions<'a> {
-    priv set: &'a BitvSet,
-    priv next_idx: uint
+    set: &'a BitvSet,
+    next_idx: uint
 }
 
 impl<'a> Iterator<uint> for BitPositions<'a> {

--- a/src/libcollections/btree.rs
+++ b/src/libcollections/btree.rs
@@ -23,10 +23,10 @@ use std::fmt::Show;
 
 #[allow(missing_doc)]
 pub struct BTree<K, V> {
-    priv root: Node<K, V>,
-    priv len: uint,
-    priv lower_bound: uint,
-    priv upper_bound: uint
+    root: Node<K, V>,
+    len: uint,
+    lower_bound: uint,
+    upper_bound: uint
 }
 
 impl<K: TotalOrd, V> BTree<K, V> {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -32,9 +32,9 @@ use deque::Deque;
 
 /// A doubly-linked list.
 pub struct DList<T> {
-    priv length: uint,
-    priv list_head: Link<T>,
-    priv list_tail: Rawlink<Node<T>>,
+    length: uint,
+    list_head: Link<T>,
+    list_tail: Rawlink<Node<T>>,
 }
 
 type Link<T> = Option<~Node<T>>;
@@ -48,9 +48,9 @@ struct Node<T> {
 
 /// Double-ended DList iterator
 pub struct Items<'a, T> {
-    priv head: &'a Link<T>,
-    priv tail: Rawlink<Node<T>>,
-    priv nelem: uint,
+    head: &'a Link<T>,
+    tail: Rawlink<Node<T>>,
+    nelem: uint,
 }
 
 // FIXME #11820: the &'a Option<> of the Link stops clone working.
@@ -60,16 +60,16 @@ impl<'a, T> Clone for Items<'a, T> {
 
 /// Double-ended mutable DList iterator
 pub struct MutItems<'a, T> {
-    priv list: &'a mut DList<T>,
-    priv head: Rawlink<Node<T>>,
-    priv tail: Rawlink<Node<T>>,
-    priv nelem: uint,
+    list: &'a mut DList<T>,
+    head: Rawlink<Node<T>>,
+    tail: Rawlink<Node<T>>,
+    nelem: uint,
 }
 
 /// DList consuming iterator
 #[deriving(Clone)]
 pub struct MoveItems<T> {
-    priv list: DList<T>
+    list: DList<T>
 }
 
 /// Rawlink is a type like Option<T> but for holding a raw pointer

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -20,7 +20,7 @@ use std::num::Bitwise;
 pub struct EnumSet<E> {
     // We must maintain the invariant that no bits are set
     // for which no variant exists
-    priv bits: uint
+    bits: uint
 }
 
 /// An interface for casting C-like enum to uint and back.
@@ -102,8 +102,8 @@ impl<E:CLike> BitAnd<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
 
 /// An iterator over an EnumSet
 pub struct Items<E> {
-    priv index: uint,
-    priv bits: uint,
+    index: uint,
+    bits: uint,
 }
 
 impl<E:CLike> Items<E> {

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -100,25 +100,25 @@ mod table {
     /// this and going "what? of course there are debug-only asserts!", then
     /// please make this use them!
     pub struct RawTable<K, V> {
-        priv capacity: uint,
-        priv size:     uint,
-        priv hashes:   *mut u64,
-        priv keys:     *mut K,
-        priv vals:     *mut V,
+        capacity: uint,
+        size:     uint,
+        hashes:   *mut u64,
+        keys:     *mut K,
+        vals:     *mut V,
     }
 
     /// Represents an index into a `RawTable` with no key or value in it.
     pub struct EmptyIndex {
-        priv idx:   int,
-        priv nocopy: marker::NoCopy,
+        idx:   int,
+        nocopy: marker::NoCopy,
     }
 
     /// Represents an index into a `RawTable` with a key, value, and hash
     /// in it.
     pub struct FullIndex {
-        priv idx:   int,
-        priv hash:  SafeHash,
-        priv nocopy: marker::NoCopy,
+        idx:   int,
+        hash:  SafeHash,
+        nocopy: marker::NoCopy,
     }
 
     impl FullIndex {
@@ -142,7 +142,7 @@ mod table {
     /// A hash that is not zero, since we use that to represent empty buckets.
     #[deriving(Eq)]
     pub struct SafeHash {
-        priv hash: u64,
+        hash: u64,
     }
 
     impl SafeHash {
@@ -376,18 +376,18 @@ mod table {
     }
 
     pub struct Entries<'a, K, V> {
-        priv table: &'a RawTable<K, V>,
-        priv idx: uint,
+        table: &'a RawTable<K, V>,
+        idx: uint,
     }
 
     pub struct MutEntries<'a, K, V> {
-        priv table: &'a mut RawTable<K, V>,
-        priv idx: uint,
+        table: &'a mut RawTable<K, V>,
+        idx: uint,
     }
 
     pub struct MoveEntries<K, V> {
-        priv table: RawTable<K, V>,
-        priv idx: uint,
+        table: RawTable<K, V>,
+        idx: uint,
     }
 
     impl<'a, K, V> Iterator<(&'a K, &'a V)> for Entries<'a, K, V> {
@@ -675,19 +675,19 @@ static INITIAL_LOAD_FACTOR: Fraction = (9, 10);
 #[deriving(Clone)]
 pub struct HashMap<K, V, H = sip::SipHasher> {
     // All hashes are keyed on these values, to prevent hash collision attacks.
-    priv hasher: H,
+    hasher: H,
 
     // When size == grow_at, we double the capacity.
-    priv grow_at: uint,
+    grow_at: uint,
 
     // The capacity must never drop below this.
-    priv minimum_capacity: uint,
+    minimum_capacity: uint,
 
-    priv table: table::RawTable<K, V>,
+    table: table::RawTable<K, V>,
 
     // We keep this at the end since it's 4-bytes, unlike everything else
     // in this struct. Might as well save a word of padding!
-    priv load_factor: Fraction,
+    load_factor: Fraction,
 }
 
 /// Get the number of elements which will force the capacity to grow.
@@ -1385,7 +1385,7 @@ pub type SetMoveItems<K> =
 /// requires that the elements implement the `Eq` and `Hash` traits.
 #[deriving(Clone)]
 pub struct HashSet<T, H = sip::SipHasher> {
-    priv map: HashMap<T, (), H>
+    map: HashMap<T, (), H>
 }
 
 impl<T: TotalEq + Hash<S>, S, H: Hasher<S>> Eq for HashSet<T, H> {

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -22,6 +22,8 @@
 
 #![feature(macro_rules, managed_boxes, default_type_params, phase)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+
 extern crate rand;
 
 #[cfg(test)] extern crate test;

--- a/src/libcollections/lru_cache.rs
+++ b/src/libcollections/lru_cache.rs
@@ -56,10 +56,10 @@ struct LruEntry<K, V> {
 
 /// An LRU Cache.
 pub struct LruCache<K, V> {
-    priv map: HashMap<KeyRef<K>, ~LruEntry<K, V>>,
-    priv max_size: uint,
-    priv head: *mut LruEntry<K, V>,
-    priv tail: *mut LruEntry<K, V>,
+    map: HashMap<KeyRef<K>, ~LruEntry<K, V>>,
+    max_size: uint,
+    head: *mut LruEntry<K, V>,
+    tail: *mut LruEntry<K, V>,
 }
 
 impl<S, K: Hash<S>> Hash<S> for KeyRef<K> {

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -19,7 +19,7 @@ use std::slice;
 /// A priority queue implemented with a binary heap
 #[deriving(Clone)]
 pub struct PriorityQueue<T> {
-    priv data: ~[T],
+    data: ~[T],
 }
 
 impl<T:Ord> Container for PriorityQueue<T> {
@@ -181,7 +181,7 @@ impl<T:Ord> PriorityQueue<T> {
 
 /// PriorityQueue iterator
 pub struct Items <'a, T> {
-    priv iter: slice::Items<'a, T>,
+    iter: slice::Items<'a, T>,
 }
 
 impl<'a, T> Iterator<&'a T> for Items<'a, T> {

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -25,9 +25,9 @@ static MINIMUM_CAPACITY: uint = 2u;
 /// RingBuf is a circular buffer that implements Deque.
 #[deriving(Clone)]
 pub struct RingBuf<T> {
-    priv nelts: uint,
-    priv lo: uint,
-    priv elts: ~[Option<T>]
+    nelts: uint,
+    lo: uint,
+    elts: ~[Option<T>]
 }
 
 impl<T> Container for RingBuf<T> {
@@ -230,10 +230,10 @@ impl<T> RingBuf<T> {
 
 /// RingBuf iterator
 pub struct Items<'a, T> {
-    priv lo: uint,
-    priv index: uint,
-    priv rindex: uint,
-    priv elts: &'a [Option<T>],
+    lo: uint,
+    index: uint,
+    rindex: uint,
+    elts: &'a [Option<T>],
 }
 
 impl<'a, T> Iterator<&'a T> for Items<'a, T> {
@@ -285,9 +285,9 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
 
 /// RingBuf mutable iterator
 pub struct MutItems<'a, T> {
-    priv remaining1: &'a mut [Option<T>],
-    priv remaining2: &'a mut [Option<T>],
-    priv nelts: uint,
+    remaining1: &'a mut [Option<T>],
+    remaining2: &'a mut [Option<T>],
+    nelts: uint,
 }
 
 impl<'a, T> Iterator<&'a mut T> for MutItems<'a, T> {

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -21,7 +21,7 @@ use std::slice;
 
 #[allow(missing_doc)]
 pub struct SmallIntMap<T> {
-    priv v: ~[Option<T>],
+    v: ~[Option<T>],
 }
 
 impl<V> Container for SmallIntMap<V> {
@@ -234,9 +234,9 @@ macro_rules! double_ended_iterator {
 }
 
 pub struct Entries<'a, T> {
-    priv front: uint,
-    priv back: uint,
-    priv iter: slice::Items<'a, Option<T>>
+    front: uint,
+    back: uint,
+    iter: slice::Items<'a, Option<T>>
 }
 
 iterator!(impl Entries -> (uint, &'a T), get_ref)
@@ -244,9 +244,9 @@ double_ended_iterator!(impl Entries -> (uint, &'a T), get_ref)
 pub type RevEntries<'a, T> = Rev<Entries<'a, T>>;
 
 pub struct MutEntries<'a, T> {
-    priv front: uint,
-    priv back: uint,
-    priv iter: slice::MutItems<'a, Option<T>>
+    front: uint,
+    back: uint,
+    iter: slice::MutItems<'a, Option<T>>
 }
 
 iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -36,8 +36,8 @@ use std::ptr;
 #[allow(missing_doc)]
 #[deriving(Clone)]
 pub struct TreeMap<K, V> {
-    priv root: Option<~TreeNode<K, V>>,
-    priv length: uint
+    root: Option<~TreeNode<K, V>>,
+    length: uint
 }
 
 impl<K: Eq + TotalOrd, V: Eq> Eq for TreeMap<K, V> {
@@ -273,24 +273,24 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
 
 /// Lazy forward iterator over a map
 pub struct Entries<'a, K, V> {
-    priv stack: ~[&'a TreeNode<K, V>],
+    stack: ~[&'a TreeNode<K, V>],
     // See the comment on MutEntries; this is just to allow
     // code-sharing (for this immutable-values iterator it *could* very
     // well be Option<&'a TreeNode<K,V>>).
-    priv node: *TreeNode<K, V>,
-    priv remaining_min: uint,
-    priv remaining_max: uint
+    node: *TreeNode<K, V>,
+    remaining_min: uint,
+    remaining_max: uint
 }
 
 /// Lazy backward iterator over a map
 pub struct RevEntries<'a, K, V> {
-    priv iter: Entries<'a, K, V>,
+    iter: Entries<'a, K, V>,
 }
 
 /// Lazy forward iterator over a map that allows for the mutation of
 /// the values.
 pub struct MutEntries<'a, K, V> {
-    priv stack: ~[&'a mut TreeNode<K, V>],
+    stack: ~[&'a mut TreeNode<K, V>],
     // Unfortunately, we require some unsafe-ness to get around the
     // fact that we would be storing a reference *into* one of the
     // nodes in the stack.
@@ -310,14 +310,14 @@ pub struct MutEntries<'a, K, V> {
     // it under control.
     //
     // (This field can legitimately be null.)
-    priv node: *mut TreeNode<K, V>,
-    priv remaining_min: uint,
-    priv remaining_max: uint
+    node: *mut TreeNode<K, V>,
+    remaining_min: uint,
+    remaining_max: uint
 }
 
 /// Lazy backward iterator over a map
 pub struct RevMutEntries<'a, K, V> {
-    priv iter: MutEntries<'a, K, V>,
+    iter: MutEntries<'a, K, V>,
 }
 
 
@@ -482,8 +482,8 @@ fn mut_deref<K, V>(x: &mut Option<~TreeNode<K, V>>) -> *mut TreeNode<K, V> {
 
 /// Lazy forward iterator over a map that consumes the map while iterating
 pub struct MoveEntries<K, V> {
-    priv stack: ~[TreeNode<K, V>],
-    priv remaining: uint
+    stack: ~[TreeNode<K, V>],
+    remaining: uint
 }
 
 impl<K, V> Iterator<(K, V)> for MoveEntries<K,V> {
@@ -551,7 +551,7 @@ impl<'a, T> Iterator<&'a T> for RevSetItems<'a, T> {
 /// `TotalOrd` trait.
 #[deriving(Clone)]
 pub struct TreeSet<T> {
-    priv map: TreeMap<T, ()>
+    map: TreeMap<T, ()>
 }
 
 impl<T: Eq + TotalOrd> Eq for TreeSet<T> {
@@ -703,36 +703,36 @@ impl<T: TotalOrd> TreeSet<T> {
 
 /// Lazy forward iterator over a set
 pub struct SetItems<'a, T> {
-    priv iter: Entries<'a, T, ()>
+    iter: Entries<'a, T, ()>
 }
 
 /// Lazy backward iterator over a set
 pub struct RevSetItems<'a, T> {
-    priv iter: RevEntries<'a, T, ()>
+    iter: RevEntries<'a, T, ()>
 }
 
 /// Lazy iterator producing elements in the set difference (in-order)
 pub struct DifferenceItems<'a, T> {
-    priv a: Peekable<&'a T, SetItems<'a, T>>,
-    priv b: Peekable<&'a T, SetItems<'a, T>>,
+    a: Peekable<&'a T, SetItems<'a, T>>,
+    b: Peekable<&'a T, SetItems<'a, T>>,
 }
 
 /// Lazy iterator producing elements in the set symmetric difference (in-order)
 pub struct SymDifferenceItems<'a, T> {
-    priv a: Peekable<&'a T, SetItems<'a, T>>,
-    priv b: Peekable<&'a T, SetItems<'a, T>>,
+    a: Peekable<&'a T, SetItems<'a, T>>,
+    b: Peekable<&'a T, SetItems<'a, T>>,
 }
 
 /// Lazy iterator producing elements in the set intersection (in-order)
 pub struct IntersectionItems<'a, T> {
-    priv a: Peekable<&'a T, SetItems<'a, T>>,
-    priv b: Peekable<&'a T, SetItems<'a, T>>,
+    a: Peekable<&'a T, SetItems<'a, T>>,
+    b: Peekable<&'a T, SetItems<'a, T>>,
 }
 
 /// Lazy iterator producing elements in the set intersection (in-order)
 pub struct UnionItems<'a, T> {
-    priv a: Peekable<&'a T, SetItems<'a, T>>,
-    priv b: Peekable<&'a T, SetItems<'a, T>>,
+    a: Peekable<&'a T, SetItems<'a, T>>,
+    b: Peekable<&'a T, SetItems<'a, T>>,
 }
 
 /// Compare `x` and `y`, but return `short` if x is None and `long` if y is None

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -30,8 +30,8 @@ enum Child<T> {
 
 #[allow(missing_doc)]
 pub struct TrieMap<T> {
-    priv root: TrieNode<T>,
-    priv length: uint
+    root: TrieNode<T>,
+    length: uint
 }
 
 impl<T> Container for TrieMap<T> {
@@ -278,7 +278,7 @@ impl<T> Extendable<(uint, T)> for TrieMap<T> {
 
 #[allow(missing_doc)]
 pub struct TrieSet {
-    priv map: TrieMap<()>
+    map: TrieMap<()>
 }
 
 impl Container for TrieSet {
@@ -474,19 +474,19 @@ fn remove<T>(count: &mut uint, child: &mut Child<T>, key: uint,
 
 /// Forward iterator over a map
 pub struct Entries<'a, T> {
-    priv stack: [slice::Items<'a, Child<T>>, .. NUM_CHUNKS],
-    priv length: uint,
-    priv remaining_min: uint,
-    priv remaining_max: uint
+    stack: [slice::Items<'a, Child<T>>, .. NUM_CHUNKS],
+    length: uint,
+    remaining_min: uint,
+    remaining_max: uint
 }
 
 /// Forward iterator over the key-value pairs of a map, with the
 /// values being mutable.
 pub struct MutEntries<'a, T> {
-    priv stack: [slice::MutItems<'a, Child<T>>, .. NUM_CHUNKS],
-    priv length: uint,
-    priv remaining_min: uint,
-    priv remaining_max: uint
+    stack: [slice::MutItems<'a, Child<T>>, .. NUM_CHUNKS],
+    length: uint,
+    remaining_min: uint,
+    remaining_max: uint
 }
 
 // FIXME #5846: see `addr!` above.
@@ -605,7 +605,7 @@ iterator_impl! { MutEntries, iter = mut_iter, mutability = mut }
 
 /// Forward iterator over a set
 pub struct SetItems<'a> {
-    priv iter: Entries<'a, ()>
+    iter: Entries<'a, ()>
 }
 
 impl<'a> Iterator<uint> for SetItems<'a> {

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -87,6 +87,8 @@
 #![deny(missing_doc)]
 #![deny(deprecated_owned_vector)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+
 #[cfg(test)] #[phase(syntax, link)] extern crate log;
 
 use std::cmp::Eq;
@@ -130,13 +132,13 @@ pub enum Occur {
 #[deriving(Clone, Eq)]
 pub struct Opt {
     /// Name of the option
-    name: Name,
+    pub name: Name,
     /// Whether it has an argument
-    hasarg: HasArg,
+    pub hasarg: HasArg,
     /// How often it can occur
-    occur: Occur,
+    pub occur: Occur,
     /// Which options it aliases
-    priv aliases: Vec<Opt> ,
+    pub aliases: Vec<Opt> ,
 }
 
 /// One group of options, e.g., both -h and --help, along with
@@ -144,17 +146,17 @@ pub struct Opt {
 #[deriving(Clone, Eq)]
 pub struct OptGroup {
     /// Short Name of the `OptGroup`
-    short_name: ~str,
+    pub short_name: ~str,
     /// Long Name of the `OptGroup`
-    long_name: ~str,
+    pub long_name: ~str,
     /// Hint
-    hint: ~str,
+    pub hint: ~str,
     /// Description
-    desc: ~str,
+    pub desc: ~str,
     /// Whether it has an argument
-    hasarg: HasArg,
+    pub hasarg: HasArg,
     /// How often it can occur
-    occur: Occur
+    pub occur: Occur
 }
 
 /// Describes wether an option is given at all or has a value.
@@ -169,11 +171,12 @@ enum Optval {
 #[deriving(Clone, Eq)]
 pub struct Matches {
     /// Options that matched
-    priv opts: Vec<Opt> ,
+    opts: Vec<Opt> ,
     /// Values of the Options that matched
-    priv vals: Vec<Vec<Optval> > ,
+    vals: Vec<Vec<Optval> > ,
     /// Free string fragments
-    free: Vec<~str> }
+    pub free: Vec<~str>,
+}
 
 /// The type returned when the command line does not conform to the
 /// expected format. Call the `to_err_msg` method to retrieve the

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -41,10 +41,11 @@ use std::path::is_sep;
  * pattern - see the `glob` function for more details.
  */
 pub struct Paths {
-    priv root: Path,
-    priv dir_patterns: Vec<Pattern> ,
-    priv options: MatchOptions,
-    priv todo: Vec<(Path,uint)> }
+    root: Path,
+    dir_patterns: Vec<Pattern>,
+    options: MatchOptions,
+    todo: Vec<(Path,uint)>,
+}
 
 ///
 /// Return an iterator that produces all the Paths that match the given pattern,
@@ -176,7 +177,8 @@ fn list_dir_sorted(path: &Path) -> Vec<Path> {
  */
 #[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, Hash, Default)]
 pub struct Pattern {
-    priv tokens: Vec<PatternToken> }
+    tokens: Vec<PatternToken>,
+}
 
 #[deriving(Clone, Eq, TotalEq, Ord, TotalOrd, Hash)]
 enum PatternToken {
@@ -513,13 +515,13 @@ pub struct MatchOptions {
      * currently only considers upper/lower case relationships between ASCII characters,
      * but in future this might be extended to work with Unicode.
      */
-    priv case_sensitive: bool,
+    case_sensitive: bool,
 
     /**
      * If this is true then path-component separator characters (e.g. `/` on Posix)
      * must be matched by a literal `/`, rather than by `*` or `?` or `[...]`
      */
-    priv require_literal_separator: bool,
+    require_literal_separator: bool,
 
     /**
      * If this is true then paths that contain components that start with a `.` will
@@ -527,7 +529,7 @@ pub struct MatchOptions {
      * will not match. This is useful because such files are conventionally considered
      * hidden on Unix systems and it might be desirable to skip them when listing files.
      */
-    priv require_literal_leading_dot: bool
+    require_literal_leading_dot: bool
 }
 
 impl MatchOptions {

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -22,9 +22,9 @@ use std::raw;
 // then misalign the regs again.
 pub struct Context {
     /// Hold the registers while the task or scheduler is suspended
-    priv regs: ~Registers,
+    regs: ~Registers,
     /// Lower bound and upper bound for the stack
-    priv stack_bounds: Option<(uint, uint)>,
+    stack_bounds: Option<(uint, uint)>,
 }
 
 pub type InitFn = extern "C" fn(uint, *(), *()) -> !;

--- a/src/libgreen/coroutine.rs
+++ b/src/libgreen/coroutine.rs
@@ -22,10 +22,10 @@ pub struct Coroutine {
     ///
     /// Servo needs this to be public in order to tell SpiderMonkey
     /// about the stack bounds.
-    current_stack_segment: Stack,
+    pub current_stack_segment: Stack,
 
     /// Always valid if the task is alive and not running.
-    saved_context: Context
+    pub saved_context: Context
 }
 
 impl Coroutine {

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -296,10 +296,10 @@ pub fn run(event_loop_factory: fn() -> ~rtio::EventLoop:Send,
 /// Configuration of how an M:N pool of schedulers is spawned.
 pub struct PoolConfig {
     /// The number of schedulers (OS threads) to spawn into this M:N pool.
-    threads: uint,
+    pub threads: uint,
     /// A factory function used to create new event loops. If this is not
     /// specified then the default event loop factory is used.
-    event_loop_factory: fn() -> ~rtio::EventLoop:Send,
+    pub event_loop_factory: fn() -> ~rtio::EventLoop:Send,
 }
 
 impl PoolConfig {
@@ -316,17 +316,17 @@ impl PoolConfig {
 /// A structure representing a handle to a pool of schedulers. This handle is
 /// used to keep the pool alive and also reap the status from the pool.
 pub struct SchedPool {
-    priv id: uint,
-    priv threads: ~[Thread<()>],
-    priv handles: ~[SchedHandle],
-    priv stealers: ~[deque::Stealer<~task::GreenTask>],
-    priv next_friend: uint,
-    priv stack_pool: StackPool,
-    priv deque_pool: deque::BufferPool<~task::GreenTask>,
-    priv sleepers: SleeperList,
-    priv factory: fn() -> ~rtio::EventLoop:Send,
-    priv task_state: TaskState,
-    priv tasks_done: Receiver<()>,
+    id: uint,
+    threads: ~[Thread<()>],
+    handles: ~[SchedHandle],
+    stealers: ~[deque::Stealer<~task::GreenTask>],
+    next_friend: uint,
+    stack_pool: StackPool,
+    deque_pool: deque::BufferPool<~task::GreenTask>,
+    sleepers: SleeperList,
+    factory: fn() -> ~rtio::EventLoop:Send,
+    task_state: TaskState,
+    tasks_done: Receiver<()>,
 }
 
 /// This is an internal state shared among a pool of schedulers. This is used to

--- a/src/libgreen/message_queue.rs
+++ b/src/libgreen/message_queue.rs
@@ -23,11 +23,11 @@ pub fn queue<T: Send>() -> (Consumer<T>, Producer<T>) {
 }
 
 pub struct Producer<T> {
-    priv inner: UnsafeArc<mpsc::Queue<T>>,
+    inner: UnsafeArc<mpsc::Queue<T>>,
 }
 
 pub struct Consumer<T> {
-    priv inner: UnsafeArc<mpsc::Queue<T>>,
+    inner: UnsafeArc<mpsc::Queue<T>>,
 }
 
 impl<T: Send> Consumer<T> {

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -39,7 +39,12 @@ pub struct Scheduler {
     /// ID number of the pool that this scheduler is a member of. When
     /// reawakening green tasks, this is used to ensure that tasks aren't
     /// reawoken on the wrong pool of schedulers.
-    pool_id: uint,
+    pub pool_id: uint,
+    /// The pool of stacks that this scheduler has cached
+    pub stack_pool: StackPool,
+    /// Bookkeeping for the number of tasks which are currently running around
+    /// inside this pool of schedulers
+    pub task_state: TaskState,
     /// There are N work queues, one per scheduler.
     work_queue: deque::Worker<~GreenTask>,
     /// Work queues for the other schedulers. These are created by
@@ -64,7 +69,6 @@ pub struct Scheduler {
     /// A flag to indicate we've received the shutdown message and should
     /// no longer try to go to sleep, but exit instead.
     no_sleep: bool,
-    stack_pool: StackPool,
     /// The scheduler runs on a special task. When it is not running
     /// it is stored here instead of the work queue.
     sched_task: Option<~GreenTask>,
@@ -87,9 +91,6 @@ pub struct Scheduler {
     /// A flag to tell the scheduler loop it needs to do some stealing
     /// in order to introduce randomness as part of a yield
     steal_for_yield: bool,
-    /// Bookkeeping for the number of tasks which are currently running around
-    /// inside this pool of schedulers
-    task_state: TaskState,
 
     // n.b. currently destructors of an object are run in top-to-bottom in order
     //      of field declaration. Due to its nature, the pausable idle callback
@@ -99,7 +100,7 @@ pub struct Scheduler {
     //      destroyed before it's actually destroyed.
 
     /// The event loop used to drive the scheduler and perform I/O
-    event_loop: ~EventLoop:Send,
+    pub event_loop: ~EventLoop:Send,
 }
 
 /// An indication of how hard to work on a given operation, the difference
@@ -893,9 +894,9 @@ pub enum SchedMessage {
 }
 
 pub struct SchedHandle {
-    priv remote: ~RemoteCallback:Send,
-    priv queue: msgq::Producer<SchedMessage>,
-    sched_id: uint
+    remote: ~RemoteCallback:Send,
+    queue: msgq::Producer<SchedMessage>,
+    pub sched_id: uint
 }
 
 impl SchedHandle {

--- a/src/libgreen/sleeper_list.rs
+++ b/src/libgreen/sleeper_list.rs
@@ -16,7 +16,7 @@ use std::sync::mpmc_bounded_queue::Queue;
 use sched::SchedHandle;
 
 pub struct SleeperList {
-    priv q: Queue<SchedHandle>,
+    q: Queue<SchedHandle>,
 }
 
 impl SleeperList {

--- a/src/libgreen/stack.rs
+++ b/src/libgreen/stack.rs
@@ -15,9 +15,9 @@ use std::libc;
 
 /// A task's stack. The name "Stack" is a vestige of segmented stacks.
 pub struct Stack {
-    priv buf: MemoryMap,
-    priv min_size: uint,
-    priv valgrind_id: libc::c_uint,
+    buf: MemoryMap,
+    min_size: uint,
+    valgrind_id: libc::c_uint,
 }
 
 // Try to use MAP_STACK on platforms that support it (it's what we're doing
@@ -126,7 +126,7 @@ impl Drop for Stack {
 pub struct StackPool {
     // Ideally this would be some datastructure that preserved ordering on
     // Stack.min_size.
-    priv stacks: ~[Stack],
+    stacks: ~[Stack],
 }
 
 impl StackPool {

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -42,32 +42,32 @@ pub struct GreenTask {
     /// context and the stack that this task owns. This field is optional to
     /// relinquish ownership back to a scheduler to recycle stacks at a later
     /// date.
-    coroutine: Option<Coroutine>,
+    pub coroutine: Option<Coroutine>,
 
     /// Optional handle back into the home sched pool of this task. This field
     /// is lazily initialized.
-    handle: Option<SchedHandle>,
+    pub handle: Option<SchedHandle>,
 
     /// Slot for maintaining ownership of a scheduler. If a task is running,
     /// this value will be Some(sched) where the task is running on "sched".
-    sched: Option<~Scheduler>,
+    pub sched: Option<~Scheduler>,
 
     /// Temporary ownership slot of a std::rt::task::Task object. This is used
     /// to squirrel that libstd task away while we're performing green task
     /// operations.
-    task: Option<~Task>,
+    pub task: Option<~Task>,
 
     /// Dictates whether this is a sched task or a normal green task
-    task_type: TaskType,
+    pub task_type: TaskType,
 
     /// Home pool that this task was spawned into. This field is lazily
     /// initialized until when the task is initially scheduled, and is used to
     /// make sure that tasks are always woken up in the correct pool of
     /// schedulers.
-    pool_id: uint,
+    pub pool_id: uint,
 
     // See the comments in the scheduler about why this is necessary
-    nasty_deschedule_lock: NativeMutex,
+    pub nasty_deschedule_lock: NativeMutex,
 }
 
 pub enum TaskType {

--- a/src/liblog/directive.rs
+++ b/src/liblog/directive.rs
@@ -12,8 +12,8 @@ use std::cmp;
 
 #[deriving(Show, Clone)]
 pub struct LogDirective {
-    name: Option<~str>,
-    level: u32,
+    pub name: Option<~str>,
+    pub level: u32,
 }
 
 static LOG_LEVEL_NAMES: [&'static str, ..4] = ["error", "warn", "info",

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -30,7 +30,7 @@ struct Inner {
 }
 
 pub struct FileDesc {
-    priv inner: UnsafeArc<Inner>
+    inner: UnsafeArc<Inner>
 }
 
 impl FileDesc {
@@ -216,8 +216,8 @@ impl Drop for Inner {
 }
 
 pub struct CFile {
-    priv file: *libc::FILE,
-    priv fd: FileDesc,
+    file: *libc::FILE,
+    fd: FileDesc,
 }
 
 impl CFile {

--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -34,7 +34,7 @@ struct Inner {
 }
 
 pub struct FileDesc {
-    priv inner: UnsafeArc<Inner>
+    inner: UnsafeArc<Inner>
 }
 
 impl FileDesc {

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -215,7 +215,7 @@ fn keep_going(data: &[u8], f: |*u8, uint| -> i64) -> i64 {
 /// Implementation of rt::rtio's IoFactory trait to generate handles to the
 /// native I/O functionality.
 pub struct IoFactory {
-    priv cannot_construct_outside_of_this_module: ()
+    cannot_construct_outside_of_this_module: ()
 }
 
 impl IoFactory {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -237,7 +237,7 @@ pub fn init() {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct TcpStream {
-    priv inner: UnsafeArc<Inner>,
+    inner: UnsafeArc<Inner>,
 }
 
 struct Inner {
@@ -373,7 +373,7 @@ impl Drop for Inner {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct TcpListener {
-    priv inner: UnsafeArc<Inner>,
+    inner: UnsafeArc<Inner>,
 }
 
 impl TcpListener {
@@ -430,7 +430,7 @@ impl rtio::RtioSocket for TcpListener {
 }
 
 pub struct TcpAcceptor {
-    priv listener: TcpListener,
+    listener: TcpListener,
 }
 
 impl TcpAcceptor {
@@ -474,7 +474,7 @@ impl rtio::RtioTcpAcceptor for TcpAcceptor {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct UdpSocket {
-    priv inner: UnsafeArc<Inner>,
+    inner: UnsafeArc<Inner>,
 }
 
 impl UdpSocket {

--- a/src/libnative/io/pipe_unix.rs
+++ b/src/libnative/io/pipe_unix.rs
@@ -106,7 +106,7 @@ fn bind(addr: &CString, ty: libc::c_int) -> IoResult<Inner> {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct UnixStream {
-    priv inner: UnsafeArc<Inner>,
+    inner: UnsafeArc<Inner>,
 }
 
 impl UnixStream {
@@ -160,7 +160,7 @@ impl rtio::RtioPipe for UnixStream {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct UnixDatagram {
-    priv inner: UnsafeArc<Inner>,
+    inner: UnsafeArc<Inner>,
 }
 
 impl UnixDatagram {
@@ -231,7 +231,7 @@ impl UnixDatagram {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct UnixListener {
-    priv inner: Inner,
+    inner: Inner,
 }
 
 impl UnixListener {
@@ -256,7 +256,7 @@ impl rtio::RtioUnixListener for UnixListener {
 }
 
 pub struct UnixAcceptor {
-    priv listener: UnixListener,
+    listener: UnixListener,
 }
 
 impl UnixAcceptor {

--- a/src/libnative/io/pipe_win32.rs
+++ b/src/libnative/io/pipe_win32.rs
@@ -154,9 +154,9 @@ unsafe fn pipe(name: *u16, init: bool) -> libc::HANDLE {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct UnixStream {
-    priv inner: UnsafeArc<Inner>,
-    priv write: Option<Event>,
-    priv read: Option<Event>,
+    inner: UnsafeArc<Inner>,
+    write: Option<Event>,
+    read: Option<Event>,
 }
 
 impl UnixStream {
@@ -349,8 +349,8 @@ impl rtio::RtioPipe for UnixStream {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct UnixListener {
-    priv handle: libc::HANDLE,
-    priv name: CString,
+    handle: libc::HANDLE,
+    name: CString,
 }
 
 impl UnixListener {
@@ -389,8 +389,8 @@ impl rtio::RtioUnixListener for UnixListener {
 }
 
 pub struct UnixAcceptor {
-    priv listener: UnixListener,
-    priv event: Event,
+    listener: UnixListener,
+    event: Event,
 }
 
 impl UnixAcceptor {

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -31,15 +31,15 @@ use super::file;
  */
 pub struct Process {
     /// The unique id of the process (this should never be negative).
-    priv pid: pid_t,
+    pid: pid_t,
 
     /// A handle to the process - on unix this will always be NULL, but on
     /// windows it will be a HANDLE to the process, which will prevent the
     /// pid being re-used until the handle is closed.
-    priv handle: *(),
+    handle: *(),
 
     /// None until finish() is called.
-    priv exit_code: Option<p::ProcessExit>,
+    exit_code: Option<p::ProcessExit>,
 }
 
 impl Process {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -59,8 +59,8 @@ use io::IoResult;
 use io::timer_helper;
 
 pub struct Timer {
-    priv id: uint,
-    priv inner: Option<~Inner>,
+    id: uint,
+    inner: Option<~Inner>,
 }
 
 struct Inner {

--- a/src/libnative/io/timer_timerfd.rs
+++ b/src/libnative/io/timer_timerfd.rs
@@ -40,8 +40,8 @@ use io::IoResult;
 use io::timer_helper;
 
 pub struct Timer {
-    priv fd: FileDesc,
-    priv on_worker: bool,
+    fd: FileDesc,
+    on_worker: bool,
 }
 
 #[allow(visible_private_types)]
@@ -285,24 +285,24 @@ mod imp {
     #[cfg(target_arch = "x86_64")]
     #[packed]
     pub struct epoll_event {
-        events: u32,
-        data: i64,
+        pub events: u32,
+        pub data: i64,
     }
 
     #[cfg(not(target_arch = "x86_64"))]
     pub struct epoll_event {
-        events: u32,
-        data: i64,
+        pub events: u32,
+        pub data: i64,
     }
 
     pub struct timespec {
-        tv_sec: libc::time_t,
-        tv_nsec: libc::c_long,
+        pub tv_sec: libc::time_t,
+        pub tv_nsec: libc::c_long,
     }
 
     pub struct itimerspec {
-        it_interval: timespec,
-        it_value: timespec,
+        pub it_interval: timespec,
+        pub it_value: timespec,
     }
 
     extern {

--- a/src/libnative/io/timer_win32.rs
+++ b/src/libnative/io/timer_win32.rs
@@ -29,8 +29,8 @@ use io::timer_helper;
 use io::IoResult;
 
 pub struct Timer {
-    priv obj: libc::HANDLE,
-    priv on_worker: bool,
+    obj: libc::HANDLE,
+    on_worker: bool,
 }
 
 pub enum Req {

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -51,6 +51,8 @@
 #![deny(unused_result, unused_must_use)]
 #![allow(non_camel_case_types)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the
 //    answer is that you don't need them)

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -86,7 +86,7 @@ A `BigUint`-typed value `BigUint { data: ~[a, b, c] }` represents a number
 */
 #[deriving(Clone)]
 pub struct BigUint {
-    priv data: Vec<BigDigit>
+    data: Vec<BigDigit>
 }
 
 impl Eq for BigUint {
@@ -863,8 +863,8 @@ impl Neg<Sign> for Sign {
 /// A big signed integer type.
 #[deriving(Clone)]
 pub struct BigInt {
-    priv sign: Sign,
-    priv data: BigUint
+    sign: Sign,
+    data: BigUint
 }
 
 impl Eq for BigInt {

--- a/src/libnum/rational.rs
+++ b/src/libnum/rational.rs
@@ -22,8 +22,8 @@ use bigint::{BigInt, BigUint, Sign, Plus, Minus};
 #[deriving(Clone)]
 #[allow(missing_doc)]
 pub struct Ratio<T> {
-    priv numer: T,
-    priv denom: T
+    numer: T,
+    denom: T
 }
 
 /// Alias for a `Ratio` of machine-sized integers.

--- a/src/librand/distributions/exponential.rs
+++ b/src/librand/distributions/exponential.rs
@@ -66,7 +66,7 @@ impl Rand for Exp1 {
 /// ```
 pub struct Exp {
     /// `lambda` stored as `1/lambda`, since this is what we scale by.
-    priv lambda_inverse: f64
+    lambda_inverse: f64
 }
 
 impl Exp {

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -236,11 +236,11 @@ impl IndependentSample<f64> for ChiSquared {
 /// println!("{} is from an F(2, 32) distribution", v)
 /// ```
 pub struct FisherF {
-    priv numer: ChiSquared,
-    priv denom: ChiSquared,
+    numer: ChiSquared,
+    denom: ChiSquared,
     // denom_dof / numer_dof so that this can just be a straight
     // multiplication, rather than a division.
-    priv dof_ratio: f64,
+    dof_ratio: f64,
 }
 
 impl FisherF {
@@ -279,8 +279,8 @@ impl IndependentSample<f64> for FisherF {
 /// println!("{} is from a t(11) distribution", v)
 /// ```
 pub struct StudentT {
-    priv chi: ChiSquared,
-    priv dof: f64
+    chi: ChiSquared,
+    dof: f64
 }
 
 impl StudentT {

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -71,9 +71,9 @@ impl<Sup: Rand> IndependentSample<Sup> for RandSample<Sup> {
 /// A value with a particular weight for use with `WeightedChoice`.
 pub struct Weighted<T> {
     /// The numerical weight of this item
-    weight: uint,
+    pub weight: uint,
     /// The actual item which is being weighted
-    item: T,
+    pub item: T,
 }
 
 /// A distribution that selects from a finite collection of weighted items.
@@ -101,8 +101,8 @@ pub struct Weighted<T> {
 /// }
 /// ```
 pub struct WeightedChoice<T> {
-    priv items: ~[Weighted<T>],
-    priv weight_range: Range<uint>
+    pub items: ~[Weighted<T>],
+    pub weight_range: Range<uint>
 }
 
 impl<T: Clone> WeightedChoice<T> {

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -82,8 +82,8 @@ impl Rand for StandardNormal {
 /// println!("{} is from a N(2, 9) distribution", v)
 /// ```
 pub struct Normal {
-    priv mean: f64,
-    priv std_dev: f64
+    mean: f64,
+    std_dev: f64,
 }
 
 impl Normal {
@@ -124,7 +124,7 @@ impl IndependentSample<f64> for Normal {
 /// println!("{} is from an ln N(2, 9) distribution", v)
 /// ```
 pub struct LogNormal {
-    priv norm: Normal
+    norm: Normal
 }
 
 impl LogNormal {

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -46,9 +46,9 @@ use distributions::{Sample, IndependentSample};
 /// }
 /// ```
 pub struct Range<X> {
-    priv low: X,
-    priv range: X,
-    priv accept_zone: X
+    low: X,
+    range: X,
+    accept_zone: X
 }
 
 impl<X: SampleRange + Ord> Range<X> {

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -28,12 +28,12 @@ static RAND_SIZE: u32 = 1 << RAND_SIZE_LEN;
 /// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
 /// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
 pub struct IsaacRng {
-    priv cnt: u32,
-    priv rsl: [u32, .. RAND_SIZE],
-    priv mem: [u32, .. RAND_SIZE],
-    priv a: u32,
-    priv b: u32,
-    priv c: u32
+    cnt: u32,
+    rsl: [u32, .. RAND_SIZE],
+    mem: [u32, .. RAND_SIZE],
+    a: u32,
+    b: u32,
+    c: u32
 }
 static EMPTY: IsaacRng = IsaacRng {
     cnt: 0,
@@ -231,12 +231,12 @@ static RAND_SIZE_64: uint = 1 << RAND_SIZE_64_LEN;
 /// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
 /// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
 pub struct Isaac64Rng {
-    priv cnt: uint,
-    priv rsl: [u64, .. RAND_SIZE_64],
-    priv mem: [u64, .. RAND_SIZE_64],
-    priv a: u64,
-    priv b: u64,
-    priv c: u64,
+    cnt: uint,
+    rsl: [u64, .. RAND_SIZE_64],
+    mem: [u64, .. RAND_SIZE_64],
+    a: u64,
+    b: u64,
+    c: u64,
 }
 
 static EMPTY_64: Isaac64Rng = Isaac64Rng {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -72,6 +72,8 @@ println!("{:?}", tuple_ptr)
 
 #![feature(macro_rules, managed_boxes, phase)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+
 #[cfg(test)]
 #[phase(syntax, link)] extern crate log;
 
@@ -407,12 +409,12 @@ pub fn rng() -> StdRng {
 /// The standard RNG. This is designed to be efficient on the current
 /// platform.
 #[cfg(not(target_word_size="64"))]
-pub struct StdRng { priv rng: IsaacRng }
+pub struct StdRng { rng: IsaacRng }
 
 /// The standard RNG. This is designed to be efficient on the current
 /// platform.
 #[cfg(target_word_size="64")]
-pub struct StdRng { priv rng: Isaac64Rng }
+pub struct StdRng { rng: Isaac64Rng }
 
 impl StdRng {
     /// Create a randomly seeded instance of `StdRng`.
@@ -489,10 +491,10 @@ pub fn weak_rng() -> XorShiftRng {
 /// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
 /// Statistical Software*. Vol. 8 (Issue 14).
 pub struct XorShiftRng {
-    priv x: u32,
-    priv y: u32,
-    priv z: u32,
-    priv w: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    w: u32,
 }
 
 impl Rng for XorShiftRng {
@@ -573,8 +575,8 @@ pub struct TaskRng {
     // The use of unsafe code here is OK if the invariants above are
     // satisfied; and it allows us to avoid (unnecessarily) using a
     // GC'd or RC'd pointer.
-    priv rng: *mut TaskRngInner,
-    priv marker: marker::NoSend,
+    rng: *mut TaskRngInner,
+    marker: marker::NoSend,
 }
 
 // used to make space in TLS for a random number generator

--- a/src/librand/os.rs
+++ b/src/librand/os.rs
@@ -30,7 +30,7 @@ mod imp {
     /// This does not block.
     #[cfg(unix)]
     pub struct OSRng {
-        priv inner: ReaderRng<File>
+        inner: ReaderRng<File>
     }
 
     impl OSRng {
@@ -77,7 +77,7 @@ mod imp {
     ///
     /// This does not block.
     pub struct OSRng {
-        priv hcryptprov: HCRYPTPROV
+        hcryptprov: HCRYPTPROV
     }
 
     static PROV_RSA_FULL: DWORD = 1;

--- a/src/librand/reader.rs
+++ b/src/librand/reader.rs
@@ -27,7 +27,7 @@ use Rng;
 /// println!("{:x}", rng.gen::<uint>());
 /// ```
 pub struct ReaderRng<R> {
-    priv reader: R
+    reader: R
 }
 
 impl<R: Reader> ReaderRng<R> {

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -21,11 +21,11 @@ static DEFAULT_GENERATION_THRESHOLD: uint = 32 * 1024;
 /// A wrapper around any RNG which reseeds the underlying RNG after it
 /// has generated a certain number of random bytes.
 pub struct ReseedingRng<R, Rsdr> {
-    priv rng: R,
-    priv generation_threshold: uint,
-    priv bytes_generated: uint,
+    rng: R,
+    generation_threshold: uint,
+    bytes_generated: uint,
     /// Controls the behaviour when reseeding the RNG.
-    reseeder: Rsdr
+    pub reseeder: Rsdr,
 }
 
 impl<R: Rng, Rsdr: Reseeder<R>> ReseedingRng<R, Rsdr> {

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -28,12 +28,12 @@ use syntax::abi;
 pub static METADATA_FILENAME: &'static str = "rust.metadata.bin";
 
 pub struct Archive<'a> {
-    priv sess: &'a Session,
-    priv dst: Path,
+    sess: &'a Session,
+    dst: Path,
 }
 
 pub struct ArchiveRO {
-    priv ptr: ArchiveRef,
+    ptr: ArchiveRef,
 }
 
 fn run_ar(sess: &Session, args: &str, cwd: Option<&Path>,

--- a/src/librustc/back/svh.rs
+++ b/src/librustc/back/svh.rs
@@ -54,7 +54,7 @@ use syntax::ast;
 
 #[deriving(Clone, Eq)]
 pub struct Svh {
-    priv hash: ~str,
+    hash: ~str,
 }
 
 impl Svh {

--- a/src/librustc/back/target_strs.rs
+++ b/src/librustc/back/target_strs.rs
@@ -11,9 +11,9 @@
 #![allow(non_camel_case_types)]
 
 pub struct t {
-    module_asm: ~str,
-    meta_sect_name: ~str,
-    data_layout: ~str,
-    target_triple: ~str,
-    cc_args: Vec<~str> ,
+    pub module_asm: ~str,
+    pub meta_sect_name: ~str,
+    pub data_layout: ~str,
+    pub target_triple: ~str,
+    pub cc_args: Vec<~str> ,
 }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -270,12 +270,12 @@ pub fn phase_2_configure_and_expand(sess: &Session,
 }
 
 pub struct CrateAnalysis {
-    exp_map2: middle::resolve::ExportMap2,
-    exported_items: middle::privacy::ExportedItems,
-    public_items: middle::privacy::PublicItems,
-    ty_cx: ty::ctxt,
-    maps: astencode::Maps,
-    reachable: NodeSet,
+    pub exp_map2: middle::resolve::ExportMap2,
+    pub exported_items: middle::privacy::ExportedItems,
+    pub public_items: middle::privacy::PublicItems,
+    pub ty_cx: ty::ctxt,
+    pub maps: astencode::Maps,
+    pub reachable: NodeSet,
 }
 
 /// Run the resolution, typechecking, region checking and other
@@ -409,12 +409,12 @@ pub fn phase_3_run_analysis_passes(sess: Session,
 }
 
 pub struct CrateTranslation {
-    context: ContextRef,
-    module: ModuleRef,
-    metadata_module: ModuleRef,
-    link: LinkMeta,
-    metadata: Vec<u8> ,
-    reachable: Vec<~str> ,
+    pub context: ContextRef,
+    pub module: ModuleRef,
+    pub metadata_module: ModuleRef,
+    pub link: LinkMeta,
+    pub metadata: Vec<u8>,
+    pub reachable: Vec<~str>,
 }
 
 /// Run the translation phase to LLVM, after which the AST and analysis can
@@ -1124,9 +1124,9 @@ pub fn optgroups() -> Vec<getopts::OptGroup> {
 }
 
 pub struct OutputFilenames {
-    out_directory: Path,
-    out_filestem: ~str,
-    single_output_file: Option<Path>,
+    pub out_directory: Path,
+    pub out_filestem: ~str,
+    pub single_output_file: Option<Path>,
 }
 
 impl OutputFilenames {

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -31,11 +31,11 @@ use std::cell::{Cell, RefCell};
 use collections::HashSet;
 
 pub struct Config {
-    os: abi::Os,
-    arch: abi::Architecture,
-    target_strs: target_strs::t,
-    int_type: IntTy,
-    uint_type: UintTy,
+    pub os: abi::Os,
+    pub arch: abi::Architecture,
+    pub target_strs: target_strs::t,
+    pub int_type: IntTy,
+    pub uint_type: UintTy,
 }
 
 macro_rules! debugging_opts(
@@ -124,34 +124,34 @@ pub enum DebugInfoLevel {
 pub struct Options {
     // The crate config requested for the session, which may be combined
     // with additional crate configurations during the compile process
-    crate_types: Vec<CrateType> ,
+    pub crate_types: Vec<CrateType> ,
 
-    gc: bool,
-    optimize: OptLevel,
-    debuginfo: DebugInfoLevel,
-    lint_opts: Vec<(lint::Lint, lint::level)> ,
-    output_types: Vec<back::link::OutputType> ,
+    pub gc: bool,
+    pub optimize: OptLevel,
+    pub debuginfo: DebugInfoLevel,
+    pub lint_opts: Vec<(lint::Lint, lint::level)> ,
+    pub output_types: Vec<back::link::OutputType> ,
     // This was mutable for rustpkg, which updates search paths based on the
     // parsed code. It remains mutable in case its replacements wants to use
     // this.
-    addl_lib_search_paths: RefCell<HashSet<Path>>,
-    maybe_sysroot: Option<Path>,
-    target_triple: ~str,
+    pub addl_lib_search_paths: RefCell<HashSet<Path>>,
+    pub maybe_sysroot: Option<Path>,
+    pub target_triple: ~str,
     // User-specified cfg meta items. The compiler itself will add additional
     // items to the crate config, and during parsing the entire crate config
     // will be added to the crate AST node.  This should not be used for
     // anything except building the full crate config prior to parsing.
-    cfg: ast::CrateConfig,
-    test: bool,
-    parse_only: bool,
-    no_trans: bool,
-    no_analysis: bool,
-    debugging_opts: u64,
+    pub cfg: ast::CrateConfig,
+    pub test: bool,
+    pub parse_only: bool,
+    pub no_trans: bool,
+    pub no_analysis: bool,
+    pub debugging_opts: u64,
     /// Whether to write dependency files. It's (enabled, optional filename).
-    write_dependency_info: (bool, Option<Path>),
+    pub write_dependency_info: (bool, Option<Path>),
     /// Crate id-related things to maybe print. It's (crate_id, crate_name, crate_file_name).
-    print_metas: (bool, bool, bool),
-    cg: CodegenOptions,
+    pub print_metas: (bool, bool, bool),
+    pub cg: CodegenOptions,
 }
 
 // The type of entry function, so
@@ -174,28 +174,28 @@ pub enum CrateType {
 }
 
 pub struct Session {
-    targ_cfg: Config,
-    opts: Options,
-    cstore: metadata::cstore::CStore,
-    parse_sess: ParseSess,
+    pub targ_cfg: Config,
+    pub opts: Options,
+    pub cstore: metadata::cstore::CStore,
+    pub parse_sess: ParseSess,
     // For a library crate, this is always none
-    entry_fn: RefCell<Option<(NodeId, codemap::Span)>>,
-    entry_type: Cell<Option<EntryFnType>>,
-    macro_registrar_fn: RefCell<Option<ast::DefId>>,
-    default_sysroot: Option<Path>,
-    building_library: Cell<bool>,
+    pub entry_fn: RefCell<Option<(NodeId, codemap::Span)>>,
+    pub entry_type: Cell<Option<EntryFnType>>,
+    pub macro_registrar_fn: RefCell<Option<ast::DefId>>,
+    pub default_sysroot: Option<Path>,
+    pub building_library: Cell<bool>,
     // The name of the root source file of the crate, in the local file system. The path is always
     // expected to be absolute. `None` means that there is no source file.
-    local_crate_source_file: Option<Path>,
-    working_dir: Path,
-    lints: RefCell<NodeMap<Vec<(lint::Lint, codemap::Span, ~str)>>>,
-    node_id: Cell<ast::NodeId>,
-    crate_types: RefCell<Vec<CrateType>>,
-    features: front::feature_gate::Features,
+    pub local_crate_source_file: Option<Path>,
+    pub working_dir: Path,
+    pub lints: RefCell<NodeMap<Vec<(lint::Lint, codemap::Span, ~str)>>>,
+    pub node_id: Cell<ast::NodeId>,
+    pub crate_types: RefCell<Vec<CrateType>>,
+    pub features: front::feature_gate::Features,
 
     /// The maximum recursion limit for potentially infinitely recursive
     /// operations such as auto-dereference and monomorphization.
-    recursion_limit: Cell<uint>,
+    pub recursion_limit: Cell<uint>,
 }
 
 impl Session {
@@ -365,7 +365,7 @@ macro_rules! cgoptions(
     ($($opt:ident : $t:ty = ($init:expr, $parse:ident, $desc:expr)),* ,) =>
 (
     #[deriving(Clone)]
-    pub struct CodegenOptions { $($opt: $t),* }
+    pub struct CodegenOptions { $(pub $opt: $t),* }
 
     pub fn basic_codegen_options() -> CodegenOptions {
         CodegenOptions { $($opt: $init),* }

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -74,7 +74,7 @@ enum Status {
 
 /// A set of features to be used by later passes.
 pub struct Features {
-    default_type_params: Cell<bool>
+    pub default_type_params: Cell<bool>
 }
 
 impl Features {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -31,6 +31,9 @@ This API is completely unstable and subject to change.
 #![feature(macro_rules, globs, struct_variant, managed_boxes, quote,
            default_type_params, phase)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+#![allow(unrecognized_lint)] // NOTE: remove after a stage0 snap
+
 extern crate flate;
 extern crate arena;
 extern crate syntax;

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1878,7 +1878,7 @@ impl TypeNames {
 /* Memory-managed interface to target data. */
 
 pub struct target_data_res {
-    td: TargetDataRef,
+    pub td: TargetDataRef,
 }
 
 impl Drop for target_data_res {
@@ -1896,7 +1896,7 @@ pub fn target_data_res(td: TargetDataRef) -> target_data_res {
 }
 
 pub struct TargetData {
-    lltd: TargetDataRef,
+    pub lltd: TargetDataRef,
     dtor: @target_data_res
 }
 
@@ -1914,7 +1914,7 @@ pub fn mk_target_data(string_rep: &str) -> TargetData {
 /* Memory-managed interface to pass managers. */
 
 pub struct pass_manager_res {
-    pm: PassManagerRef,
+    pub pm: PassManagerRef,
 }
 
 impl Drop for pass_manager_res {
@@ -1932,7 +1932,7 @@ pub fn pass_manager_res(pm: PassManagerRef) -> pass_manager_res {
 }
 
 pub struct PassManager {
-    llpm: PassManagerRef,
+    pub llpm: PassManagerRef,
     dtor: @pass_manager_res
 }
 
@@ -1950,7 +1950,7 @@ pub fn mk_pass_manager() -> PassManager {
 /* Memory-managed interface to object files. */
 
 pub struct ObjectFile {
-    llof: ObjectFileRef,
+    pub llof: ObjectFileRef,
 }
 
 impl ObjectFile {
@@ -1981,7 +1981,7 @@ impl Drop for ObjectFile {
 /* Memory-managed interface to section iterators. */
 
 pub struct section_iter_res {
-    si: SectionIteratorRef,
+    pub si: SectionIteratorRef,
 }
 
 impl Drop for section_iter_res {
@@ -1999,7 +1999,7 @@ pub fn section_iter_res(si: SectionIteratorRef) -> section_iter_res {
 }
 
 pub struct SectionIter {
-    llsi: SectionIteratorRef,
+    pub llsi: SectionIteratorRef,
     dtor: @section_iter_res
 }
 

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -210,6 +210,6 @@ pub static tag_macro_def: uint = 0x65;
 
 #[deriving(Clone, Show)]
 pub struct LinkMeta {
-    crateid: CrateId,
-    crate_hash: Svh,
+    pub crateid: CrateId,
+    pub crate_hash: Svh,
 }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -371,7 +371,7 @@ fn resolve_crate_deps(e: &mut Env,
 }
 
 pub struct Loader<'a> {
-    priv env: Env<'a>,
+    env: Env<'a>,
 }
 
 impl<'a> Loader<'a> {

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -26,10 +26,10 @@ use syntax::diagnostic::expect;
 use syntax::parse::token;
 
 pub struct StaticMethodInfo {
-    ident: ast::Ident,
-    def_id: ast::DefId,
-    purity: ast::Purity,
-    vis: ast::Visibility,
+    pub ident: ast::Ident,
+    pub def_id: ast::DefId,
+    pub purity: ast::Purity,
+    pub vis: ast::Visibility,
 }
 
 pub fn get_symbol(cstore: &cstore::CStore, def: ast::DefId) -> ~str {

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -37,10 +37,10 @@ pub enum MetadataBlob {
 }
 
 pub struct crate_metadata {
-    name: ~str,
-    data: MetadataBlob,
-    cnum_map: cnum_map,
-    cnum: ast::CrateNum
+    pub name: ~str,
+    pub data: MetadataBlob,
+    pub cnum_map: cnum_map,
+    pub cnum: ast::CrateNum,
 }
 
 #[deriving(Eq)]
@@ -60,18 +60,18 @@ pub enum NativeLibaryKind {
 // must be non-None.
 #[deriving(Eq, Clone)]
 pub struct CrateSource {
-    dylib: Option<Path>,
-    rlib: Option<Path>,
-    cnum: ast::CrateNum,
+    pub dylib: Option<Path>,
+    pub rlib: Option<Path>,
+    pub cnum: ast::CrateNum,
 }
 
 pub struct CStore {
-    priv metas: RefCell<HashMap<ast::CrateNum, @crate_metadata>>,
-    priv extern_mod_crate_map: RefCell<extern_mod_crate_map>,
-    priv used_crate_sources: RefCell<Vec<CrateSource> >,
-    priv used_libraries: RefCell<Vec<(~str, NativeLibaryKind)> >,
-    priv used_link_args: RefCell<Vec<~str> >,
-    intr: Rc<IdentInterner>
+    metas: RefCell<HashMap<ast::CrateNum, @crate_metadata>>,
+    extern_mod_crate_map: RefCell<extern_mod_crate_map>,
+    used_crate_sources: RefCell<Vec<CrateSource>>,
+    used_libraries: RefCell<Vec<(~str, NativeLibaryKind)>>,
+    used_link_args: RefCell<Vec<~str>>,
+    pub intr: Rc<IdentInterner>,
 }
 
 // Map from NodeId's of local extern crate statements to crate numbers

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1108,9 +1108,9 @@ pub fn get_crate_attributes(data: &[u8]) -> Vec<ast::Attribute> {
 
 #[deriving(Clone)]
 pub struct CrateDep {
-    cnum: ast::CrateNum,
-    crate_id: CrateId,
-    hash: Svh,
+    pub cnum: ast::CrateNum,
+    pub crate_id: CrateId,
+    pub hash: Svh,
 }
 
 pub fn get_crate_deps(data: &[u8]) -> Vec<CrateDep> {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -69,14 +69,14 @@ pub type EncodeInlinedItem<'a> = 'a |ecx: &EncodeContext,
                                      ii: InlinedItemRef|;
 
 pub struct EncodeParams<'a> {
-    diag: &'a SpanHandler,
-    tcx: &'a ty::ctxt,
-    reexports2: middle::resolve::ExportMap2,
-    item_symbols: &'a RefCell<NodeMap<~str>>,
-    non_inlineable_statics: &'a RefCell<NodeSet>,
-    link_meta: &'a LinkMeta,
-    cstore: &'a cstore::CStore,
-    encode_inlined_item: EncodeInlinedItem<'a>,
+    pub diag: &'a SpanHandler,
+    pub tcx: &'a ty::ctxt,
+    pub reexports2: middle::resolve::ExportMap2,
+    pub item_symbols: &'a RefCell<NodeMap<~str>>,
+    pub non_inlineable_statics: &'a RefCell<NodeSet>,
+    pub link_meta: &'a LinkMeta,
+    pub cstore: &'a cstore::CStore,
+    pub encode_inlined_item: EncodeInlinedItem<'a>,
 }
 
 pub struct Stats {
@@ -96,16 +96,16 @@ pub struct Stats {
 }
 
 pub struct EncodeContext<'a> {
-    diag: &'a SpanHandler,
-    tcx: &'a ty::ctxt,
-    stats: @Stats,
-    reexports2: middle::resolve::ExportMap2,
-    item_symbols: &'a RefCell<NodeMap<~str>>,
-    non_inlineable_statics: &'a RefCell<NodeSet>,
-    link_meta: &'a LinkMeta,
-    cstore: &'a cstore::CStore,
-    encode_inlined_item: EncodeInlinedItem<'a>,
-    type_abbrevs: abbrev_map,
+    pub diag: &'a SpanHandler,
+    pub tcx: &'a ty::ctxt,
+    pub stats: @Stats,
+    pub reexports2: middle::resolve::ExportMap2,
+    pub item_symbols: &'a RefCell<NodeMap<~str>>,
+    pub non_inlineable_statics: &'a RefCell<NodeSet>,
+    pub link_meta: &'a LinkMeta,
+    pub cstore: &'a cstore::CStore,
+    pub encode_inlined_item: EncodeInlinedItem<'a>,
+    pub type_abbrevs: abbrev_map,
 }
 
 fn encode_name(ebml_w: &mut Encoder, name: Name) {

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -26,9 +26,9 @@ pub enum FileMatch { FileMatches, FileDoesntMatch }
 pub type pick<'a> = 'a |path: &Path| -> FileMatch;
 
 pub struct FileSearch<'a> {
-    sysroot: &'a Path,
-    addl_lib_search_paths: &'a RefCell<HashSet<Path>>,
-    target_triple: &'a str
+    pub sysroot: &'a Path,
+    pub addl_lib_search_paths: &'a RefCell<HashSet<Path>>,
+    pub target_triple: &'a str
 }
 
 impl<'a> FileSearch<'a> {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -46,27 +46,27 @@ pub enum Os {
 }
 
 pub struct Context<'a> {
-    sess: &'a Session,
-    span: Span,
-    ident: &'a str,
-    crate_id: &'a CrateId,
-    id_hash: &'a str,
-    hash: Option<&'a Svh>,
-    os: Os,
-    intr: Rc<IdentInterner>,
-    rejected_via_hash: bool,
+    pub sess: &'a Session,
+    pub span: Span,
+    pub ident: &'a str,
+    pub crate_id: &'a CrateId,
+    pub id_hash: &'a str,
+    pub hash: Option<&'a Svh>,
+    pub os: Os,
+    pub intr: Rc<IdentInterner>,
+    pub rejected_via_hash: bool,
 }
 
 pub struct Library {
-    dylib: Option<Path>,
-    rlib: Option<Path>,
-    metadata: MetadataBlob,
+    pub dylib: Option<Path>,
+    pub rlib: Option<Path>,
+    pub metadata: MetadataBlob,
 }
 
 pub struct ArchiveMetadata {
-    priv archive: ArchiveRO,
+    archive: ArchiveRO,
     // See comments in ArchiveMetadata::new for why this is static
-    priv data: &'static [u8],
+    data: &'static [u8],
 }
 
 // FIXME(#11857) this should be a "real" realpath

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -34,12 +34,12 @@ macro_rules! mywrite( ($wr:expr, $($arg:tt)*) => (
 ) )
 
 pub struct ctxt<'a> {
-    diag: &'a SpanHandler,
+    pub diag: &'a SpanHandler,
     // Def -> str Callback:
-    ds: fn(DefId) -> ~str,
+    pub ds: fn(DefId) -> ~str,
     // The type context.
-    tcx: &'a ty::ctxt,
-    abbrevs: abbrev_ctxt
+    pub tcx: &'a ty::ctxt,
+    pub abbrevs: abbrev_ctxt
 }
 
 // Compact string representation for ty.t values. API ty_str & parse_from_str.

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -53,10 +53,10 @@ use writer = serialize::ebml::writer;
 
 // Auxiliary maps of things to be encoded
 pub struct Maps {
-    root_map: middle::borrowck::root_map,
-    method_map: middle::typeck::MethodMap,
-    vtable_map: middle::typeck::vtable_map,
-    capture_map: RefCell<middle::moves::CaptureMap>,
+    pub root_map: middle::borrowck::root_map,
+    pub method_map: middle::typeck::MethodMap,
+    pub vtable_map: middle::typeck::vtable_map,
+    pub capture_map: RefCell<middle::moves::CaptureMap>,
 }
 
 struct DecodeContext<'a> {

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -207,8 +207,8 @@ pub struct BorrowStats {
 // is T, which is not a box.
 #[deriving(Eq, TotalEq, Hash)]
 pub struct root_map_key {
-    id: ast::NodeId,
-    derefs: uint
+    pub id: ast::NodeId,
+    pub derefs: uint
 }
 
 pub type BckResult<T> = Result<T, BckError>;
@@ -378,7 +378,7 @@ impl Repr for RestrictionSet {
 // uncovered after a certain number of auto-derefs.
 
 pub struct RootInfo {
-    scope: ast::NodeId,
+    pub scope: ast::NodeId,
 }
 
 pub type root_map = @RefCell<HashMap<root_map_key, RootInfo>>;

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -30,37 +30,37 @@ use util::ppaux::Repr;
 
 pub struct MoveData {
     /// Move paths. See section "Move paths" in `doc.rs`.
-    paths: RefCell<Vec<MovePath>>,
+    pub paths: RefCell<Vec<MovePath>>,
 
     /// Cache of loan path to move path index, for easy lookup.
-    path_map: RefCell<HashMap<@LoanPath, MovePathIndex>>,
+    pub path_map: RefCell<HashMap<@LoanPath, MovePathIndex>>,
 
     /// Each move or uninitialized variable gets an entry here.
-    moves: RefCell<Vec<Move>>,
+    pub moves: RefCell<Vec<Move>>,
 
     /// Assignments to a variable, like `x = foo`. These are assigned
     /// bits for dataflow, since we must track them to ensure that
     /// immutable variables are assigned at most once along each path.
-    var_assignments: RefCell<Vec<Assignment>>,
+    pub var_assignments: RefCell<Vec<Assignment>>,
 
     /// Assignments to a path, like `x.f = foo`. These are not
     /// assigned dataflow bits, but we track them because they still
     /// kill move bits.
-    path_assignments: RefCell<Vec<Assignment>>,
+    pub path_assignments: RefCell<Vec<Assignment>>,
 
     /// Assignments to a variable or path, like `x = foo`, but not `x += foo`.
-    assignee_ids: RefCell<HashSet<ast::NodeId>>,
+    pub assignee_ids: RefCell<HashSet<ast::NodeId>>,
 }
 
 pub struct FlowedMoveData<'a> {
-    move_data: MoveData,
+    pub move_data: MoveData,
 
-    dfcx_moves: MoveDataFlow<'a>,
+    pub dfcx_moves: MoveDataFlow<'a>,
 
     // We could (and maybe should, for efficiency) combine both move
     // and assign data flow into one, but this way it's easier to
     // distinguish the bits that correspond to moves and assignments.
-    dfcx_assign: AssignDataFlow<'a>
+    pub dfcx_assign: AssignDataFlow<'a>
 }
 
 /// Index into `MoveData.paths`, used like a pointer
@@ -97,21 +97,21 @@ static InvalidMoveIndex: MoveIndex =
 
 pub struct MovePath {
     /// Loan path corresponding to this move path
-    loan_path: @LoanPath,
+    pub loan_path: @LoanPath,
 
     /// Parent pointer, `InvalidMovePathIndex` if root
-    parent: MovePathIndex,
+    pub parent: MovePathIndex,
 
     /// Head of linked list of moves to this path,
     /// `InvalidMoveIndex` if not moved
-    first_move: MoveIndex,
+    pub first_move: MoveIndex,
 
     /// First node in linked list of children, `InvalidMovePathIndex` if leaf
-    first_child: MovePathIndex,
+    pub first_child: MovePathIndex,
 
     /// Next node in linked list of parent's children (siblings),
     /// `InvalidMovePathIndex` if none.
-    next_sibling: MovePathIndex,
+    pub next_sibling: MovePathIndex,
 }
 
 pub enum MoveKind {
@@ -123,27 +123,27 @@ pub enum MoveKind {
 
 pub struct Move {
     /// Path being moved.
-    path: MovePathIndex,
+    pub path: MovePathIndex,
 
     /// id of node that is doing the move.
-    id: ast::NodeId,
+    pub id: ast::NodeId,
 
     /// Kind of move, for error messages.
-    kind: MoveKind,
+    pub kind: MoveKind,
 
     /// Next node in linked list of moves from `path`, or `InvalidMoveIndex`
-    next_move: MoveIndex
+    pub next_move: MoveIndex
 }
 
 pub struct Assignment {
     /// Path being assigned.
-    path: MovePathIndex,
+    pub path: MovePathIndex,
 
     /// id where assignment occurs
-    id: ast::NodeId,
+    pub id: ast::NodeId,
 
     /// span of node where assignment occurs
-    span: Span,
+    pub span: Span,
 }
 
 pub struct MoveDataFlowOperator;

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -31,21 +31,21 @@ use util::nodemap::NodeMap;
 
 #[deriving(Clone)]
 pub struct DataFlowContext<'a, O> {
-    priv tcx: &'a ty::ctxt,
-    priv method_map: typeck::MethodMap,
+    tcx: &'a ty::ctxt,
+    method_map: typeck::MethodMap,
 
     /// the data flow operator
-    priv oper: O,
+    oper: O,
 
     /// number of bits to propagate per id
-    priv bits_per_id: uint,
+    bits_per_id: uint,
 
     /// number of words we will use to store bits_per_id.
     /// equal to bits_per_id/uint::BITS rounded up.
-    priv words_per_id: uint,
+    words_per_id: uint,
 
     // mapping from node to bitset index.
-    priv nodeid_to_bitset: NodeMap<uint>,
+    nodeid_to_bitset: NodeMap<uint>,
 
     // Bit sets per id.  The following three fields (`gens`, `kills`,
     // and `on_entry`) all have the same structure. For each id in
@@ -54,14 +54,15 @@ pub struct DataFlowContext<'a, O> {
     // the full vector (see the method `compute_id_range()`).
 
     /// bits generated as we exit the scope `id`. Updated by `add_gen()`.
-    priv gens: Vec<uint> ,
+    gens: Vec<uint>,
 
     /// bits killed as we exit the scope `id`. Updated by `add_kill()`.
-    priv kills: Vec<uint> ,
+    kills: Vec<uint>,
 
     /// bits that are valid on entry to the scope `id`. Updated by
     /// `propagate()`.
-    priv on_entry: Vec<uint> }
+    on_entry: Vec<uint>,
+}
 
 /// Parameterization for the precise form of data flow that is used.
 pub trait DataFlowOperator {

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -26,8 +26,8 @@ use syntax::visit::Visitor;
 // (The def_upvar will already have been stripped).
 #[deriving(Encodable, Decodable)]
 pub struct freevar_entry {
-    def: ast::Def, //< The variable being accessed free.
-    span: Span     //< First span where it is accessed (there can be multiple)
+    pub def: ast::Def, //< The variable being accessed free.
+    pub span: Span     //< First span where it is accessed (there can be multiple)
 }
 pub type freevar_info = @Vec<@freevar_entry> ;
 pub type freevar_map = NodeMap<freevar_info>;

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -37,20 +37,20 @@ be indexed by the direction (see the type `Direction`).
 use std::uint;
 
 pub struct Graph<N,E> {
-    priv nodes: Vec<Node<N>> ,
-    priv edges: Vec<Edge<E>> ,
+    nodes: Vec<Node<N>> ,
+    edges: Vec<Edge<E>> ,
 }
 
 pub struct Node<N> {
-    priv first_edge: [EdgeIndex, ..2], // see module comment
-    data: N,
+    first_edge: [EdgeIndex, ..2], // see module comment
+    pub data: N,
 }
 
 pub struct Edge<E> {
-    priv next_edge: [EdgeIndex, ..2], // see module comment
-    priv source: NodeIndex,
-    priv target: NodeIndex,
-    data: E,
+    next_edge: [EdgeIndex, ..2], // see module comment
+    source: NodeIndex,
+    target: NodeIndex,
+    pub data: E,
 }
 
 #[deriving(Eq)]
@@ -62,7 +62,7 @@ pub struct EdgeIndex(uint);
 pub static InvalidEdgeIndex: EdgeIndex = EdgeIndex(uint::MAX);
 
 // Use a private field here to guarantee no more instances are created:
-pub struct Direction { priv repr: uint }
+pub struct Direction { repr: uint }
 pub static Outgoing: Direction = Direction { repr: 0 };
 pub static Incoming: Direction = Direction { repr: 1 };
 

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -47,7 +47,7 @@ pub enum LangItem {
 }
 
 pub struct LanguageItems {
-    items: Vec<Option<ast::DefId>> ,
+    pub items: Vec<Option<ast::DefId>> ,
 }
 
 impl LanguageItems {

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1506,7 +1506,7 @@ fn check_missing_doc_ty_method(cx: &Context, tm: &ast::TypeMethod) {
 
 fn check_missing_doc_struct_field(cx: &Context, sf: &ast::StructField) {
     match sf.node.kind {
-        ast::NamedField(_, vis) if vis != ast::Private =>
+        ast::NamedField(_, vis) if vis == ast::Public =>
             check_missing_doc_attrs(cx,
                                     Some(cx.cur_struct_def_id),
                                     sf.node.attrs.as_slice(),

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -135,9 +135,9 @@ pub enum level {
 
 #[deriving(Clone, Eq, Ord, TotalEq, TotalOrd)]
 pub struct LintSpec {
-    default: level,
-    lint: Lint,
-    desc: &'static str,
+    pub default: level,
+    pub lint: Lint,
+    pub desc: &'static str,
 }
 
 pub type LintDict = HashMap<&'static str, LintSpec>;

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -90,8 +90,8 @@ pub enum categorization {
 
 #[deriving(Eq)]
 pub struct CopiedUpvar {
-    upvar_id: ast::NodeId,
-    onceness: ast::Onceness,
+    pub upvar_id: ast::NodeId,
+    pub onceness: ast::Onceness,
 }
 
 // different kinds of pointers:
@@ -147,11 +147,11 @@ pub enum MutabilityCategory {
 // fashion. For more details, see the method `cat_pattern`
 #[deriving(Eq)]
 pub struct cmt_ {
-    id: ast::NodeId,          // id of expr/pat producing this value
-    span: Span,                // span of same expr/pat
-    cat: categorization,       // categorization of expr
-    mutbl: MutabilityCategory, // mutability of expr as lvalue
-    ty: ty::t                  // type of the expr (*see WARNING above*)
+    pub id: ast::NodeId,          // id of expr/pat producing this value
+    pub span: Span,                // span of same expr/pat
+    pub cat: categorization,       // categorization of expr
+    pub mutbl: MutabilityCategory, // mutability of expr as lvalue
+    pub ty: ty::t                  // type of the expr (*see WARNING above*)
 }
 
 pub type cmt = @cmt_;
@@ -242,7 +242,7 @@ impl ast_node for ast::Pat {
 }
 
 pub struct MemCategorizationContext<TYPER> {
-    typer: TYPER
+    pub typer: TYPER
 }
 
 pub type McResult<T> = Result<T, ()>;

--- a/src/librustc/middle/moves.rs
+++ b/src/librustc/middle/moves.rs
@@ -153,9 +153,9 @@ pub enum CaptureMode {
 
 #[deriving(Encodable, Decodable)]
 pub struct CaptureVar {
-    def: Def,         // Variable being accessed free
-    span: Span,       // Location of an access to this variable
-    mode: CaptureMode // How variable is being accessed
+    pub def: Def,         // Variable being accessed free
+    pub span: Span,       // Location of an access to this variable
+    pub mode: CaptureMode // How variable is being accessed
 }
 
 pub type CaptureMap = NodeMap<Rc<Vec<CaptureVar>>>;
@@ -163,15 +163,15 @@ pub type CaptureMap = NodeMap<Rc<Vec<CaptureVar>>>;
 /** See the section Output on the module comment for explanation. */
 #[deriving(Clone)]
 pub struct MoveMaps {
-    moves_map: NodeSet,
+    pub moves_map: NodeSet,
     /**
      * Set of variable node-ids that are moved.
      *
-     * Note: The `moves_map` stores expression ids that are moves,
+     * pub Note: The `moves_map` stores expression ids that are moves,
      * whereas this set stores the ids of the variables that are
      * moved at some point */
-    moved_variables_set: NodeSet,
-    capture_map: CaptureMap
+    pub moved_variables_set: NodeSet,
+    pub capture_map: CaptureMap
 }
 
 #[deriving(Clone)]

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -75,11 +75,11 @@ The region maps encode information about region relationships.
   for dynamic checks and/or arbitrary amounts of stack space.
 */
 pub struct RegionMaps {
-    priv scope_map: RefCell<NodeMap<ast::NodeId>>,
-    priv var_map: RefCell<NodeMap<ast::NodeId>>,
-    priv free_region_map: RefCell<HashMap<FreeRegion, Vec<FreeRegion> >>,
-    priv rvalue_scopes: RefCell<NodeMap<ast::NodeId>>,
-    priv terminating_scopes: RefCell<HashSet<ast::NodeId>>,
+    scope_map: RefCell<NodeMap<ast::NodeId>>,
+    var_map: RefCell<NodeMap<ast::NodeId>>,
+    free_region_map: RefCell<HashMap<FreeRegion, Vec<FreeRegion> >>,
+    rvalue_scopes: RefCell<NodeMap<ast::NodeId>>,
+    terminating_scopes: RefCell<HashSet<ast::NodeId>>,
 }
 
 #[deriving(Clone)]

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -55,8 +55,8 @@ pub type TraitMap = NodeMap<Vec<DefId> >;
 pub type ExportMap2 = @RefCell<NodeMap<Vec<Export2> >>;
 
 pub struct Export2 {
-    name: ~str,        // The name of the target.
-    def_id: DefId,     // The definition of the target.
+    pub name: ~str,        // The name of the target.
+    pub def_id: DefId,     // The definition of the target.
 }
 
 // This set contains all exported definitions from external crates. The set does
@@ -73,10 +73,10 @@ pub enum LastPrivate {
     // and whether the import is in fact used for each.
     // If the Option<PrivateDep> fields are None, it means there is no defintion
     // in that namespace.
-    LastImport{value_priv: Option<PrivateDep>,
-               value_used: ImportUse,
-               type_priv: Option<PrivateDep>,
-               type_used: ImportUse},
+    LastImport{pub value_priv: Option<PrivateDep>,
+               pub value_used: ImportUse,
+               pub type_priv: Option<PrivateDep>,
+               pub type_used: ImportUse},
 }
 
 pub enum PrivateDep {
@@ -5408,11 +5408,11 @@ impl<'a> Resolver<'a> {
 }
 
 pub struct CrateMap {
-    def_map: DefMap,
-    exp_map2: ExportMap2,
-    trait_map: TraitMap,
-    external_exports: ExternalExports,
-    last_private_map: LastPrivateMap,
+    pub def_map: DefMap,
+    pub exp_map2: ExportMap2,
+    pub trait_map: TraitMap,
+    pub external_exports: ExternalExports,
+    pub last_private_map: LastPrivateMap,
 }
 
 /// Entry point to crate resolution.

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -82,7 +82,7 @@ pub enum Repr {
      * General-case enums: for each case there is a struct, and they
      * all start with a field for the discriminant.
      */
-    General(IntType, Vec<Struct> ),
+    General(IntType, Vec<Struct>),
     /**
      * Two cases distinguished by a nullable pointer: the case with discriminant
      * `nndiscr` is represented by the struct `nonnull`, where the `ptrfield`th
@@ -94,16 +94,21 @@ pub enum Repr {
      * is represented such that `None` is a null pointer and `Some` is the
      * identity function.
      */
-    NullablePointer{ nonnull: Struct, nndiscr: Disr, ptrfield: uint,
-                     nullfields: Vec<ty::t> }
+    NullablePointer {
+        pub nonnull: Struct,
+        pub nndiscr: Disr,
+        pub ptrfield: uint,
+        pub nullfields: Vec<ty::t>,
+    }
 }
 
 /// For structs, and struct-like parts of anything fancier.
 pub struct Struct {
-    size: u64,
-    align: u64,
-    packed: bool,
-    fields: Vec<ty::t> }
+    pub size: u64,
+    pub align: u64,
+    pub packed: bool,
+    pub fields: Vec<ty::t>,
+}
 
 /**
  * Convenience for `represent_type`.  There should probably be more or

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -413,9 +413,9 @@ pub fn malloc_raw<'a>(bcx: &'a Block<'a>, t: ty::t, heap: heap)
 }
 
 pub struct MallocResult<'a> {
-    bcx: &'a Block<'a>,
-    smart_ptr: ValueRef,
-    body: ValueRef
+    pub bcx: &'a Block<'a>,
+    pub smart_ptr: ValueRef,
+    pub body: ValueRef
 }
 
 // malloc_general_dyn: usefully wraps malloc_raw_dyn; allocates a smart
@@ -1647,7 +1647,7 @@ pub fn trans_enum_def(ccx: &CrateContext, enum_definition: &ast::EnumDef,
 }
 
 pub struct TransItemVisitor<'a> {
-    ccx: &'a CrateContext,
+    pub ccx: &'a CrateContext,
 }
 
 impl<'a> Visitor<()> for TransItemVisitor<'a> {

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -23,8 +23,8 @@ use std::libc::{c_uint, c_ulonglong, c_char};
 use syntax::codemap::Span;
 
 pub struct Builder<'a> {
-    llbuilder: BuilderRef,
-    ccx: &'a CrateContext,
+    pub llbuilder: BuilderRef,
+    pub ccx: &'a CrateContext,
 }
 
 // This is a really awful way to get a zero-length c-string, but better (and a

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -35,15 +35,15 @@ pub enum ArgKind {
 /// This is borrowed from clang's ABIInfo.h
 #[deriving(Clone)]
 pub struct ArgType {
-    kind: ArgKind,
+    pub kind: ArgKind,
     /// Original LLVM type
-    ty: Type,
+    pub ty: Type,
     /// Coerced LLVM Type
-    cast: option::Option<Type>,
+    pub cast: option::Option<Type>,
     /// Dummy argument, which is emitted before the real argument
-    pad: option::Option<Type>,
+    pub pad: option::Option<Type>,
     /// LLVM attribute of argument
-    attr: option::Option<Attribute>
+    pub attr: option::Option<Attribute>
 }
 
 impl ArgType {
@@ -99,10 +99,10 @@ impl ArgType {
 /// comments are reverse-engineered and may be inaccurate. -NDM
 pub struct FnType {
     /// The LLVM types of each argument.
-    arg_tys: Vec<ArgType> ,
+    pub arg_tys: Vec<ArgType> ,
 
     /// LLVM return type.
-    ret_ty: ArgType,
+    pub ret_ty: ArgType,
 }
 
 pub fn compute_abi_info(ccx: &CrateContext,

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -54,8 +54,8 @@ use syntax::abi::AbiSet;
 use syntax::ast_map;
 
 pub struct MethodData {
-    llfn: ValueRef,
-    llself: ValueRef,
+    pub llfn: ValueRef,
+    pub llself: ValueRef,
 }
 
 pub enum CalleeData {
@@ -70,8 +70,8 @@ pub enum CalleeData {
 }
 
 pub struct Callee<'a> {
-    bcx: &'a Block<'a>,
-    data: CalleeData
+    pub bcx: &'a Block<'a>,
+    pub data: CalleeData
 }
 
 fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -42,7 +42,7 @@ pub struct CleanupScope<'a> {
 }
 
 pub struct CustomScopeIndex {
-    priv index: uint
+    index: uint
 }
 
 pub static EXIT_BREAK: uint = 0;

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -111,12 +111,12 @@ pub fn gensym_name(name: &str) -> PathElem {
 }
 
 pub struct tydesc_info {
-    ty: ty::t,
-    tydesc: ValueRef,
-    size: ValueRef,
-    align: ValueRef,
-    name: ValueRef,
-    visit_glue: Cell<Option<ValueRef>>,
+    pub ty: ty::t,
+    pub tydesc: ValueRef,
+    pub size: ValueRef,
+    pub align: ValueRef,
+    pub name: ValueRef,
+    pub visit_glue: Cell<Option<ValueRef>>,
 }
 
 /*
@@ -146,8 +146,8 @@ pub struct tydesc_info {
  */
 
 pub struct NodeInfo {
-    id: ast::NodeId,
-    span: Span,
+    pub id: ast::NodeId,
+    pub span: Span,
 }
 
 pub fn expr_info(expr: &ast::Expr) -> NodeInfo {
@@ -155,22 +155,22 @@ pub fn expr_info(expr: &ast::Expr) -> NodeInfo {
 }
 
 pub struct Stats {
-    n_static_tydescs: Cell<uint>,
-    n_glues_created: Cell<uint>,
-    n_null_glues: Cell<uint>,
-    n_real_glues: Cell<uint>,
-    n_fns: Cell<uint>,
-    n_monos: Cell<uint>,
-    n_inlines: Cell<uint>,
-    n_closures: Cell<uint>,
-    n_llvm_insns: Cell<uint>,
-    llvm_insns: RefCell<HashMap<~str, uint>>,
+    pub n_static_tydescs: Cell<uint>,
+    pub n_glues_created: Cell<uint>,
+    pub n_null_glues: Cell<uint>,
+    pub n_real_glues: Cell<uint>,
+    pub n_fns: Cell<uint>,
+    pub n_monos: Cell<uint>,
+    pub n_inlines: Cell<uint>,
+    pub n_closures: Cell<uint>,
+    pub n_llvm_insns: Cell<uint>,
+    pub llvm_insns: RefCell<HashMap<~str, uint>>,
     // (ident, time-in-ms, llvm-instructions)
-    fn_stats: RefCell<Vec<(~str, uint, uint)> >,
+    pub fn_stats: RefCell<Vec<(~str, uint, uint)> >,
 }
 
 pub struct BuilderRef_res {
-    b: BuilderRef,
+    pub b: BuilderRef,
 }
 
 impl Drop for BuilderRef_res {
@@ -192,10 +192,10 @@ pub type ExternMap = HashMap<~str, ValueRef>;
 // Here `self_ty` is the real type of the self parameter to this method. It
 // will only be set in the case of default methods.
 pub struct param_substs {
-    tys: Vec<ty::t> ,
-    self_ty: Option<ty::t>,
-    vtables: Option<typeck::vtable_res>,
-    self_vtables: Option<typeck::vtable_param_res>
+    pub tys: Vec<ty::t> ,
+    pub self_ty: Option<ty::t>,
+    pub vtables: Option<typeck::vtable_res>,
+    pub self_vtables: Option<typeck::vtable_param_res>
 }
 
 impl param_substs {
@@ -228,69 +228,69 @@ pub struct FunctionContext<'a> {
     // address of the first instruction in the sequence of
     // instructions for this function that will go in the .text
     // section of the executable we're generating.
-    llfn: ValueRef,
+    pub llfn: ValueRef,
 
     // The environment argument in a closure.
-    llenv: Option<ValueRef>,
+    pub llenv: Option<ValueRef>,
 
     // The place to store the return value. If the return type is immediate,
     // this is an alloca in the function. Otherwise, it's the hidden first
     // parameter to the function. After function construction, this should
     // always be Some.
-    llretptr: Cell<Option<ValueRef>>,
+    pub llretptr: Cell<Option<ValueRef>>,
 
-    entry_bcx: RefCell<Option<&'a Block<'a>>>,
+    pub entry_bcx: RefCell<Option<&'a Block<'a>>>,
 
-    // These elements: "hoisted basic blocks" containing
+    // These pub elements: "hoisted basic blocks" containing
     // administrative activities that have to happen in only one place in
     // the function, due to LLVM's quirks.
     // A marker for the place where we want to insert the function's static
     // allocas, so that LLVM will coalesce them into a single alloca call.
-    alloca_insert_pt: Cell<Option<ValueRef>>,
-    llreturn: Cell<Option<BasicBlockRef>>,
+    pub alloca_insert_pt: Cell<Option<ValueRef>>,
+    pub llreturn: Cell<Option<BasicBlockRef>>,
 
     // The a value alloca'd for calls to upcalls.rust_personality. Used when
     // outputting the resume instruction.
-    personality: Cell<Option<ValueRef>>,
+    pub personality: Cell<Option<ValueRef>>,
 
     // True if the caller expects this fn to use the out pointer to
     // return. Either way, your code should write into llretptr, but if
     // this value is false, llretptr will be a local alloca.
-    caller_expects_out_pointer: bool,
+    pub caller_expects_out_pointer: bool,
 
     // Maps arguments to allocas created for them in llallocas.
-    llargs: RefCell<NodeMap<LvalueDatum>>,
+    pub llargs: RefCell<NodeMap<LvalueDatum>>,
 
     // Maps the def_ids for local variables to the allocas created for
     // them in llallocas.
-    lllocals: RefCell<NodeMap<LvalueDatum>>,
+    pub lllocals: RefCell<NodeMap<LvalueDatum>>,
 
     // Same as above, but for closure upvars
-    llupvars: RefCell<NodeMap<ValueRef>>,
+    pub llupvars: RefCell<NodeMap<ValueRef>>,
 
     // The NodeId of the function, or -1 if it doesn't correspond to
     // a user-defined function.
-    id: ast::NodeId,
+    pub id: ast::NodeId,
 
     // If this function is being monomorphized, this contains the type
     // substitutions used.
-    param_substs: Option<@param_substs>,
+    pub param_substs: Option<@param_substs>,
 
     // The source span and nesting context where this function comes from, for
     // error reporting and symbol generation.
-    span: Option<Span>,
+    pub span: Option<Span>,
 
     // The arena that blocks are allocated from.
-    block_arena: &'a TypedArena<Block<'a>>,
+    pub block_arena: &'a TypedArena<Block<'a>>,
 
     // This function's enclosing crate context.
-    ccx: &'a CrateContext,
+    pub ccx: &'a CrateContext,
 
     // Used and maintained by the debuginfo module.
-    debug_context: debuginfo::FunctionDebugContext,
+    pub debug_context: debuginfo::FunctionDebugContext,
 
     // Cleanup scopes.
-    scopes: RefCell<Vec<cleanup::CleanupScope<'a>> >,
+    pub scopes: RefCell<Vec<cleanup::CleanupScope<'a>> >,
 }
 
 impl<'a> FunctionContext<'a> {
@@ -405,20 +405,20 @@ pub struct Block<'a> {
     // block to the function pointed to by llfn.  We insert
     // instructions into that block by way of this block context.
     // The block pointing to this one in the function's digraph.
-    llbb: BasicBlockRef,
-    terminated: Cell<bool>,
-    unreachable: Cell<bool>,
+    pub llbb: BasicBlockRef,
+    pub terminated: Cell<bool>,
+    pub unreachable: Cell<bool>,
 
     // Is this block part of a landing pad?
-    is_lpad: bool,
+    pub is_lpad: bool,
 
     // AST node-id associated with this block, if any. Used for
     // debugging purposes only.
-    opt_node_id: Option<ast::NodeId>,
+    pub opt_node_id: Option<ast::NodeId>,
 
     // The function context for the function to which this block is
     // attached.
-    fcx: &'a FunctionContext<'a>,
+    pub fcx: &'a FunctionContext<'a>,
 }
 
 impl<'a> Block<'a> {
@@ -493,8 +493,8 @@ impl<'a> Block<'a> {
 }
 
 pub struct Result<'a> {
-    bcx: &'a Block<'a>,
-    val: ValueRef
+    pub bcx: &'a Block<'a>,
+    pub val: ValueRef
 }
 
 pub fn rslt<'a>(bcx: &'a Block<'a>, val: ValueRef) -> Result<'a> {
@@ -744,8 +744,8 @@ pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
 
 #[deriving(Eq, TotalEq, Hash)]
 pub struct mono_id_ {
-    def: ast::DefId,
-    params: Vec<mono_param_id> }
+    pub def: ast::DefId,
+    pub params: Vec<mono_param_id> }
 
 pub type mono_id = @mono_id_;
 

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -37,39 +37,39 @@ use syntax::ast;
 use syntax::parse::token::InternedString;
 
 pub struct CrateContext {
-    llmod: ModuleRef,
-    llcx: ContextRef,
-    metadata_llmod: ModuleRef,
-    td: TargetData,
-    tn: TypeNames,
-    externs: RefCell<ExternMap>,
-    intrinsics: HashMap<&'static str, ValueRef>,
-    item_vals: RefCell<NodeMap<ValueRef>>,
-    exp_map2: resolve::ExportMap2,
-    reachable: NodeSet,
-    item_symbols: RefCell<NodeMap<~str>>,
-    link_meta: LinkMeta,
-    drop_glues: RefCell<HashMap<ty::t, ValueRef>>,
-    tydescs: RefCell<HashMap<ty::t, @tydesc_info>>,
+    pub llmod: ModuleRef,
+    pub llcx: ContextRef,
+    pub metadata_llmod: ModuleRef,
+    pub td: TargetData,
+    pub tn: TypeNames,
+    pub externs: RefCell<ExternMap>,
+    pub intrinsics: HashMap<&'static str, ValueRef>,
+    pub item_vals: RefCell<NodeMap<ValueRef>>,
+    pub exp_map2: resolve::ExportMap2,
+    pub reachable: NodeSet,
+    pub item_symbols: RefCell<NodeMap<~str>>,
+    pub link_meta: LinkMeta,
+    pub drop_glues: RefCell<HashMap<ty::t, ValueRef>>,
+    pub tydescs: RefCell<HashMap<ty::t, @tydesc_info>>,
     // Set when running emit_tydescs to enforce that no more tydescs are
     // created.
-    finished_tydescs: Cell<bool>,
+    pub finished_tydescs: Cell<bool>,
     // Track mapping of external ids to local items imported for inlining
-    external: RefCell<DefIdMap<Option<ast::NodeId>>>,
+    pub external: RefCell<DefIdMap<Option<ast::NodeId>>>,
     // Backwards version of the `external` map (inlined items to where they
     // came from)
-    external_srcs: RefCell<NodeMap<ast::DefId>>,
+    pub external_srcs: RefCell<NodeMap<ast::DefId>>,
     // A set of static items which cannot be inlined into other crates. This
     // will pevent in IIItem() structures from being encoded into the metadata
     // that is generated
-    non_inlineable_statics: RefCell<NodeSet>,
+    pub non_inlineable_statics: RefCell<NodeSet>,
     // Cache instances of monomorphized functions
-    monomorphized: RefCell<HashMap<mono_id, ValueRef>>,
-    monomorphizing: RefCell<DefIdMap<uint>>,
+    pub monomorphized: RefCell<HashMap<mono_id, ValueRef>>,
+    pub monomorphizing: RefCell<DefIdMap<uint>>,
     // Cache generated vtables
-    vtables: RefCell<HashMap<(ty::t, mono_id), ValueRef>>,
+    pub vtables: RefCell<HashMap<(ty::t, mono_id), ValueRef>>,
     // Cache of constant strings,
-    const_cstr_cache: RefCell<HashMap<InternedString, ValueRef>>,
+    pub const_cstr_cache: RefCell<HashMap<InternedString, ValueRef>>,
 
     // Reverse-direction for const ptrs cast from globals.
     // Key is an int, cast from a ValueRef holding a *T,
@@ -79,36 +79,36 @@ pub struct CrateContext {
     // when we ptrcast, and we have to ptrcast during translation
     // of a [T] const because we form a slice, a [*T,int] pair, not
     // a pointer to an LLVM array type.
-    const_globals: RefCell<HashMap<int, ValueRef>>,
+    pub const_globals: RefCell<HashMap<int, ValueRef>>,
 
     // Cache of emitted const values
-    const_values: RefCell<NodeMap<ValueRef>>,
+    pub const_values: RefCell<NodeMap<ValueRef>>,
 
     // Cache of external const values
-    extern_const_values: RefCell<DefIdMap<ValueRef>>,
+    pub extern_const_values: RefCell<DefIdMap<ValueRef>>,
 
-    impl_method_cache: RefCell<HashMap<(ast::DefId, ast::Name), ast::DefId>>,
+    pub impl_method_cache: RefCell<HashMap<(ast::DefId, ast::Name), ast::DefId>>,
 
     // Cache of closure wrappers for bare fn's.
-    closure_bare_wrapper_cache: RefCell<HashMap<ValueRef, ValueRef>>,
+    pub closure_bare_wrapper_cache: RefCell<HashMap<ValueRef, ValueRef>>,
 
-    lltypes: RefCell<HashMap<ty::t, Type>>,
-    llsizingtypes: RefCell<HashMap<ty::t, Type>>,
-    adt_reprs: RefCell<HashMap<ty::t, @adt::Repr>>,
-    symbol_hasher: RefCell<Sha256>,
-    type_hashcodes: RefCell<HashMap<ty::t, ~str>>,
-    all_llvm_symbols: RefCell<HashSet<~str>>,
-    tcx: ty::ctxt,
-    maps: astencode::Maps,
-    stats: @Stats,
-    int_type: Type,
-    opaque_vec_type: Type,
-    builder: BuilderRef_res,
+    pub lltypes: RefCell<HashMap<ty::t, Type>>,
+    pub llsizingtypes: RefCell<HashMap<ty::t, Type>>,
+    pub adt_reprs: RefCell<HashMap<ty::t, @adt::Repr>>,
+    pub symbol_hasher: RefCell<Sha256>,
+    pub type_hashcodes: RefCell<HashMap<ty::t, ~str>>,
+    pub all_llvm_symbols: RefCell<HashSet<~str>>,
+    pub tcx: ty::ctxt,
+    pub maps: astencode::Maps,
+    pub stats: @Stats,
+    pub int_type: Type,
+    pub opaque_vec_type: Type,
+    pub builder: BuilderRef_res,
     // Set when at least one function uses GC. Needed so that
     // decl_gc_metadata knows whether to link to the module metadata, which
     // is not emitted by LLVM's GC pass when no functions use GC.
-    uses_gc: bool,
-    dbg_cx: Option<debuginfo::CrateDebugContext>,
+    pub uses_gc: bool,
+    pub dbg_cx: Option<debuginfo::CrateDebugContext>,
 }
 
 impl CrateContext {

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -41,18 +41,18 @@ use syntax::codemap::Span;
 pub struct Datum<K> {
     /// The llvm value.  This is either a pointer to the Rust value or
     /// the value itself, depending on `kind` below.
-    val: ValueRef,
+    pub val: ValueRef,
 
     /// The rust type of the value.
-    ty: ty::t,
+    pub ty: ty::t,
 
     /// Indicates whether this is by-ref or by-value.
-    kind: K,
+    pub kind: K,
 }
 
 pub struct DatumBlock<'a, K> {
-    bcx: &'a Block<'a>,
-    datum: Datum<K>,
+    pub bcx: &'a Block<'a>,
+    pub datum: Datum<K>,
 }
 
 pub enum Expr {
@@ -70,7 +70,7 @@ pub enum Expr {
 pub struct Lvalue;
 
 pub struct Rvalue {
-    mode: RvalueMode
+    pub mode: RvalueMode
 }
 
 pub fn Rvalue(m: RvalueMode) -> Rvalue {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -173,15 +173,15 @@ static DW_ATE_unsigned_char: c_uint = 0x08;
 
 /// A context object for maintaining all state needed by the debuginfo module.
 pub struct CrateDebugContext {
-    priv llcontext: ContextRef,
-    priv builder: DIBuilderRef,
-    priv current_debug_location: Cell<DebugLocation>,
-    priv created_files: RefCell<HashMap<~str, DIFile>>,
-    priv created_types: RefCell<HashMap<uint, DIType>>,
-    priv namespace_map: RefCell<HashMap<Vec<ast::Name> , @NamespaceTreeNode>>,
+    llcontext: ContextRef,
+    builder: DIBuilderRef,
+    current_debug_location: Cell<DebugLocation>,
+    created_files: RefCell<HashMap<~str, DIFile>>,
+    created_types: RefCell<HashMap<uint, DIType>>,
+    namespace_map: RefCell<HashMap<Vec<ast::Name> , @NamespaceTreeNode>>,
     // This collection is used to assert that composite types (structs, enums, ...) have their
     // members only set once:
-    priv composite_types_completed: RefCell<HashSet<DIType>>,
+    composite_types_completed: RefCell<HashSet<DIType>>,
 }
 
 impl CrateDebugContext {

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -143,11 +143,11 @@ pub fn make_drop_glue_unboxed<'a>(
 }
 
 pub struct VecTypes {
-    vec_ty: ty::t,
-    unit_ty: ty::t,
-    llunit_ty: Type,
-    llunit_size: ValueRef,
-    llunit_alloc_size: u64
+    pub vec_ty: ty::t,
+    pub unit_ty: ty::t,
+    pub llunit_ty: Type,
+    pub llunit_size: ValueRef,
+    pub llunit_alloc_size: u64
 }
 
 impl VecTypes {

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -26,7 +26,7 @@ use std::libc::{c_uint};
 
 #[deriving(Clone, Eq, Show)]
 pub struct Type {
-    priv rf: TypeRef
+    rf: TypeRef
 }
 
 macro_rules! ty (

--- a/src/librustc/middle/trans/value.rs
+++ b/src/librustc/middle/trans/value.rs
@@ -152,7 +152,7 @@ impl Use {
 
 /// Iterator for the users of a value
 pub struct Users {
-    priv next: Option<Use>
+    next: Option<Use>
 }
 
 impl Iterator<Value> for Users {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -63,8 +63,8 @@ pub static INITIAL_DISCRIMINANT_VALUE: Disr = 0;
 
 #[deriving(Eq, TotalEq, Hash)]
 pub struct field {
-    ident: ast::Ident,
-    mt: mt
+    pub ident: ast::Ident,
+    pub mt: mt
 }
 
 #[deriving(Clone)]
@@ -75,16 +75,16 @@ pub enum MethodContainer {
 
 #[deriving(Clone)]
 pub struct Method {
-    ident: ast::Ident,
-    generics: ty::Generics,
-    fty: BareFnTy,
-    explicit_self: ast::ExplicitSelf_,
-    vis: ast::Visibility,
-    def_id: ast::DefId,
-    container: MethodContainer,
+    pub ident: ast::Ident,
+    pub generics: ty::Generics,
+    pub fty: BareFnTy,
+    pub explicit_self: ast::ExplicitSelf_,
+    pub vis: ast::Visibility,
+    pub def_id: ast::DefId,
+    pub container: MethodContainer,
 
     // If this method is provided, we need to know where it came from
-    provided_source: Option<ast::DefId>
+    pub provided_source: Option<ast::DefId>
 }
 
 impl Method {
@@ -118,14 +118,15 @@ impl Method {
 }
 
 pub struct Impl {
-    did: DefId,
-    ident: Ident,
-    methods: Vec<@Method> }
+    pub did: DefId,
+    pub ident: Ident,
+    pub methods: Vec<@Method>,
+}
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct mt {
-    ty: t,
-    mutbl: ast::Mutability,
+    pub ty: t,
+    pub mutbl: ast::Mutability,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash, Show)]
@@ -142,18 +143,18 @@ pub enum TraitStore {
 }
 
 pub struct field_ty {
-    name: Name,
-    id: DefId,
-    vis: ast::Visibility,
+    pub name: Name,
+    pub id: DefId,
+    pub vis: ast::Visibility,
 }
 
 // Contains information needed to resolve types and (in the future) look up
 // the types of AST nodes.
 #[deriving(Eq, TotalEq, Hash)]
 pub struct creader_cache_key {
-    cnum: CrateNum,
-    pos: uint,
-    len: uint
+    pub cnum: CrateNum,
+    pub pos: uint,
+    pub len: uint
 }
 
 pub type creader_cache = RefCell<HashMap<creader_cache_key, t>>;
@@ -191,9 +192,9 @@ pub enum ast_ty_to_ty_cache_entry {
 
 #[deriving(Clone, Eq, Decodable, Encodable)]
 pub struct ItemVariances {
-    self_param: Option<Variance>,
-    type_params: OwnedSlice<Variance>,
-    region_params: OwnedSlice<Variance>
+    pub self_param: Option<Variance>,
+    pub type_params: OwnedSlice<Variance>,
+    pub region_params: OwnedSlice<Variance>
 }
 
 #[deriving(Clone, Eq, Decodable, Encodable, Show)]
@@ -216,8 +217,8 @@ pub enum AutoAdjustment {
 
 #[deriving(Decodable, Encodable)]
 pub struct AutoDerefRef {
-    autoderefs: uint,
-    autoref: Option<AutoRef>
+    pub autoderefs: uint,
+    pub autoref: Option<AutoRef>
 }
 
 #[deriving(Decodable, Encodable, Eq, Show)]
@@ -247,112 +248,112 @@ pub enum AutoRef {
 pub struct ctxt {
     // Specifically use a speedy hash algorithm for this hash map, it's used
     // quite often.
-    interner: RefCell<FnvHashMap<intern_key, ~t_box_>>,
-    next_id: Cell<uint>,
-    sess: Session,
-    def_map: resolve::DefMap,
+    pub interner: RefCell<FnvHashMap<intern_key, ~t_box_>>,
+    pub next_id: Cell<uint>,
+    pub sess: Session,
+    pub def_map: resolve::DefMap,
 
-    named_region_map: resolve_lifetime::NamedRegionMap,
+    pub named_region_map: resolve_lifetime::NamedRegionMap,
 
-    region_maps: middle::region::RegionMaps,
+    pub region_maps: middle::region::RegionMaps,
 
     // Stores the types for various nodes in the AST.  Note that this table
     // is not guaranteed to be populated until after typeck.  See
     // typeck::check::fn_ctxt for details.
-    node_types: node_type_table,
+    pub node_types: node_type_table,
 
     // Stores the type parameters which were substituted to obtain the type
     // of this node.  This only applies to nodes that refer to entities
     // parameterized by type parameters, such as generic fns, types, or
     // other items.
-    node_type_substs: RefCell<NodeMap<Vec<t>>>,
+    pub node_type_substs: RefCell<NodeMap<Vec<t>>>,
 
     // Maps from a method to the method "descriptor"
-    methods: RefCell<DefIdMap<@Method>>,
+    pub methods: RefCell<DefIdMap<@Method>>,
 
     // Maps from a trait def-id to a list of the def-ids of its methods
-    trait_method_def_ids: RefCell<DefIdMap<@Vec<DefId> >>,
+    pub trait_method_def_ids: RefCell<DefIdMap<@Vec<DefId> >>,
 
     // A cache for the trait_methods() routine
-    trait_methods_cache: RefCell<DefIdMap<@Vec<@Method> >>,
+    pub trait_methods_cache: RefCell<DefIdMap<@Vec<@Method> >>,
 
-    impl_trait_cache: RefCell<DefIdMap<Option<@ty::TraitRef>>>,
+    pub impl_trait_cache: RefCell<DefIdMap<Option<@ty::TraitRef>>>,
 
-    trait_refs: RefCell<NodeMap<@TraitRef>>,
-    trait_defs: RefCell<DefIdMap<@TraitDef>>,
+    pub trait_refs: RefCell<NodeMap<@TraitRef>>,
+    pub trait_defs: RefCell<DefIdMap<@TraitDef>>,
 
-    map: ast_map::Map,
-    intrinsic_defs: RefCell<DefIdMap<t>>,
-    freevars: RefCell<freevars::freevar_map>,
-    tcache: type_cache,
-    rcache: creader_cache,
-    short_names_cache: RefCell<HashMap<t, ~str>>,
-    needs_unwind_cleanup_cache: RefCell<HashMap<t, bool>>,
-    tc_cache: RefCell<HashMap<uint, TypeContents>>,
-    ast_ty_to_ty_cache: RefCell<NodeMap<ast_ty_to_ty_cache_entry>>,
-    enum_var_cache: RefCell<DefIdMap<@Vec<@VariantInfo> >>,
-    ty_param_defs: RefCell<NodeMap<TypeParameterDef>>,
-    adjustments: RefCell<NodeMap<@AutoAdjustment>>,
-    normalized_cache: RefCell<HashMap<t, t>>,
-    lang_items: @middle::lang_items::LanguageItems,
+    pub map: ast_map::Map,
+    pub intrinsic_defs: RefCell<DefIdMap<t>>,
+    pub freevars: RefCell<freevars::freevar_map>,
+    pub tcache: type_cache,
+    pub rcache: creader_cache,
+    pub short_names_cache: RefCell<HashMap<t, ~str>>,
+    pub needs_unwind_cleanup_cache: RefCell<HashMap<t, bool>>,
+    pub tc_cache: RefCell<HashMap<uint, TypeContents>>,
+    pub ast_ty_to_ty_cache: RefCell<NodeMap<ast_ty_to_ty_cache_entry>>,
+    pub enum_var_cache: RefCell<DefIdMap<@Vec<@VariantInfo> >>,
+    pub ty_param_defs: RefCell<NodeMap<TypeParameterDef>>,
+    pub adjustments: RefCell<NodeMap<@AutoAdjustment>>,
+    pub normalized_cache: RefCell<HashMap<t, t>>,
+    pub lang_items: @middle::lang_items::LanguageItems,
     // A mapping of fake provided method def_ids to the default implementation
-    provided_method_sources: RefCell<DefIdMap<ast::DefId>>,
-    supertraits: RefCell<DefIdMap<@Vec<@TraitRef> >>,
+    pub provided_method_sources: RefCell<DefIdMap<ast::DefId>>,
+    pub supertraits: RefCell<DefIdMap<@Vec<@TraitRef> >>,
 
     // Maps from def-id of a type or region parameter to its
     // (inferred) variance.
-    item_variance_map: RefCell<DefIdMap<@ItemVariances>>,
+    pub item_variance_map: RefCell<DefIdMap<@ItemVariances>>,
 
     // A mapping from the def ID of an enum or struct type to the def ID
     // of the method that implements its destructor. If the type is not
     // present in this map, it does not have a destructor. This map is
     // populated during the coherence phase of typechecking.
-    destructor_for_type: RefCell<DefIdMap<ast::DefId>>,
+    pub destructor_for_type: RefCell<DefIdMap<ast::DefId>>,
 
     // A method will be in this list if and only if it is a destructor.
-    destructors: RefCell<DefIdSet>,
+    pub destructors: RefCell<DefIdSet>,
 
     // Maps a trait onto a list of impls of that trait.
-    trait_impls: RefCell<DefIdMap<@RefCell<Vec<@Impl> >>>,
+    pub trait_impls: RefCell<DefIdMap<@RefCell<Vec<@Impl> >>>,
 
     // Maps a def_id of a type to a list of its inherent impls.
     // Contains implementations of methods that are inherent to a type.
     // Methods in these implementations don't need to be exported.
-    inherent_impls: RefCell<DefIdMap<@RefCell<Vec<@Impl> >>>,
+    pub inherent_impls: RefCell<DefIdMap<@RefCell<Vec<@Impl> >>>,
 
     // Maps a def_id of an impl to an Impl structure.
     // Note that this contains all of the impls that we know about,
     // including ones in other crates. It's not clear that this is the best
     // way to do it.
-    impls: RefCell<DefIdMap<@Impl>>,
+    pub impls: RefCell<DefIdMap<@Impl>>,
 
     // Set of used unsafe nodes (functions or blocks). Unsafe nodes not
     // present in this set can be warned about.
-    used_unsafe: RefCell<NodeSet>,
+    pub used_unsafe: RefCell<NodeSet>,
 
     // Set of nodes which mark locals as mutable which end up getting used at
     // some point. Local variable definitions not in this set can be warned
     // about.
-    used_mut_nodes: RefCell<NodeSet>,
+    pub used_mut_nodes: RefCell<NodeSet>,
 
     // vtable resolution information for impl declarations
-    impl_vtables: typeck::impl_vtable_map,
+    pub impl_vtables: typeck::impl_vtable_map,
 
     // The set of external nominal types whose implementations have been read.
     // This is used for lazy resolution of methods.
-    populated_external_types: RefCell<DefIdSet>,
+    pub populated_external_types: RefCell<DefIdSet>,
 
     // The set of external traits whose implementations have been read. This
     // is used for lazy resolution of traits.
-    populated_external_traits: RefCell<DefIdSet>,
+    pub populated_external_traits: RefCell<DefIdSet>,
 
     // Borrows
-    upvar_borrow_map: RefCell<UpvarBorrowMap>,
+    pub upvar_borrow_map: RefCell<UpvarBorrowMap>,
 
     // These two caches are used by const_eval when decoding external statics
     // and variants that are found.
-    extern_const_statics: RefCell<DefIdMap<Option<@ast::Expr>>>,
-    extern_const_variants: RefCell<DefIdMap<Option<@ast::Expr>>>,
+    pub extern_const_statics: RefCell<DefIdMap<Option<@ast::Expr>>>,
+    pub extern_const_variants: RefCell<DefIdMap<Option<@ast::Expr>>>,
 }
 
 pub enum tbox_flag {
@@ -363,7 +364,7 @@ pub enum tbox_flag {
     has_ty_err = 16,
     has_ty_bot = 32,
 
-    // a meta-flag: subst may be required if the type has parameters, a self
+    // a meta-pub flag: subst may be required if the type has parameters, a self
     // type, or references bound regions
     needs_subst = 1 | 2 | 8
 }
@@ -371,9 +372,9 @@ pub enum tbox_flag {
 pub type t_box = &'static t_box_;
 
 pub struct t_box_ {
-    sty: sty,
-    id: uint,
-    flags: uint,
+    pub sty: sty,
+    pub id: uint,
+    pub flags: uint,
 }
 
 // To reduce refcounting cost, we're representing types as unsafe pointers
@@ -385,7 +386,7 @@ enum t_opaque {}
 
 #[allow(raw_pointer_deriving)]
 #[deriving(Clone, Eq, TotalEq, Hash)]
-pub struct t { priv inner: *t_opaque }
+pub struct t { inner: *t_opaque }
 
 impl fmt::Show for t {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -417,19 +418,19 @@ pub fn type_id(t: t) -> uint { get(t).id }
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct BareFnTy {
-    purity: ast::Purity,
-    abis: AbiSet,
-    sig: FnSig
+    pub purity: ast::Purity,
+    pub abis: AbiSet,
+    pub sig: FnSig
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct ClosureTy {
-    purity: ast::Purity,
-    sigil: ast::Sigil,
-    onceness: ast::Onceness,
-    region: Region,
-    bounds: BuiltinBounds,
-    sig: FnSig,
+    pub purity: ast::Purity,
+    pub sigil: ast::Sigil,
+    pub onceness: ast::Onceness,
+    pub region: Region,
+    pub bounds: BuiltinBounds,
+    pub sig: FnSig,
 }
 
 /**
@@ -446,16 +447,16 @@ pub struct ClosureTy {
  */
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct FnSig {
-    binder_id: ast::NodeId,
-    inputs: Vec<t>,
-    output: t,
-    variadic: bool
+    pub binder_id: ast::NodeId,
+    pub inputs: Vec<t>,
+    pub output: t,
+    pub variadic: bool
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct param_ty {
-    idx: uint,
-    def_id: DefId
+    pub idx: uint,
+    pub def_id: DefId
 }
 
 /// Representation of regions:
@@ -502,8 +503,8 @@ pub enum Region {
  */
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct UpvarId {
-    var_id: ast::NodeId,
-    closure_expr_id: ast::NodeId,
+    pub var_id: ast::NodeId,
+    pub closure_expr_id: ast::NodeId,
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
@@ -603,8 +604,8 @@ pub enum BorrowKind {
  */
 #[deriving(Eq, Clone)]
 pub struct UpvarBorrow {
-    kind: BorrowKind,
-    region: ty::Region,
+    pub kind: BorrowKind,
+    pub region: ty::Region,
 }
 
 pub type UpvarBorrowMap = HashMap<UpvarId, UpvarBorrow>;
@@ -621,8 +622,8 @@ impl Region {
 
 #[deriving(Clone, Eq, Ord, TotalEq, TotalOrd, Hash, Encodable, Decodable, Show)]
 pub struct FreeRegion {
-    scope_id: NodeId,
-    bound_region: BoundRegion
+    pub scope_id: NodeId,
+    pub bound_region: BoundRegion
 }
 
 #[deriving(Clone, Eq, Ord, TotalEq, TotalOrd, Hash, Encodable, Decodable, Show)]
@@ -669,9 +670,9 @@ pub enum RegionSubsts {
  *   always substituted away to the implementing type for a trait. */
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct substs {
-    self_ty: Option<ty::t>,
-    tps: Vec<t>,
-    regions: RegionSubsts,
+    pub self_ty: Option<ty::t>,
+    pub tps: Vec<t>,
+    pub regions: RegionSubsts,
 }
 
 mod primitives {
@@ -759,17 +760,17 @@ pub enum sty {
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct TyTrait {
-    def_id: DefId,
-    substs: substs,
-    store: TraitStore,
-    mutability: ast::Mutability,
-    bounds: BuiltinBounds
+    pub def_id: DefId,
+    pub substs: substs,
+    pub store: TraitStore,
+    pub mutability: ast::Mutability,
+    pub bounds: BuiltinBounds
 }
 
 #[deriving(Eq, TotalEq, Hash)]
 pub struct TraitRef {
-    def_id: DefId,
-    substs: substs
+    pub def_id: DefId,
+    pub substs: substs
 }
 
 #[deriving(Clone, Eq)]
@@ -788,8 +789,8 @@ pub enum terr_vstore_kind {
 
 #[deriving(Clone, Show)]
 pub struct expected_found<T> {
-    expected: T,
-    found: T
+    pub expected: T,
+    pub found: T
 }
 
 // Data structures used in type unification
@@ -830,8 +831,8 @@ pub enum type_err {
 
 #[deriving(Eq, TotalEq, Hash)]
 pub struct ParamBounds {
-    builtin_bounds: BuiltinBounds,
-    trait_bounds: Vec<@TraitRef> }
+    pub builtin_bounds: BuiltinBounds,
+    pub trait_bounds: Vec<@TraitRef> }
 
 pub type BuiltinBounds = EnumSet<BuiltinBound>;
 
@@ -878,7 +879,7 @@ pub struct FloatVid(uint);
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct RegionVid {
-    id: uint
+    pub id: uint
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
@@ -983,16 +984,16 @@ impl fmt::Show for IntVarValue {
 
 #[deriving(Clone)]
 pub struct TypeParameterDef {
-    ident: ast::Ident,
-    def_id: ast::DefId,
-    bounds: @ParamBounds,
-    default: Option<ty::t>
+    pub ident: ast::Ident,
+    pub def_id: ast::DefId,
+    pub bounds: @ParamBounds,
+    pub default: Option<ty::t>
 }
 
 #[deriving(Encodable, Decodable, Clone)]
 pub struct RegionParameterDef {
-    name: ast::Name,
-    def_id: ast::DefId,
+    pub name: ast::Name,
+    pub def_id: ast::DefId,
 }
 
 /// Information about the type/lifetime parameters associated with an item.
@@ -1000,11 +1001,11 @@ pub struct RegionParameterDef {
 #[deriving(Clone)]
 pub struct Generics {
     /// List of type parameters declared on the item.
-    type_param_defs: Rc<Vec<TypeParameterDef> >,
+    pub type_param_defs: Rc<Vec<TypeParameterDef>>,
 
     /// List of region parameters declared on the item.
     /// For a fn or method, only includes *early-bound* lifetimes.
-    region_param_defs: Rc<Vec<RegionParameterDef> >,
+    pub region_param_defs: Rc<Vec<RegionParameterDef>>,
 }
 
 impl Generics {
@@ -1037,13 +1038,13 @@ pub struct ParameterEnvironment {
     /// In general, this means converting from bound parameters to
     /// free parameters. Since we currently represent bound/free type
     /// parameters in the same way, this only has an affect on regions.
-    free_substs: ty::substs,
+    pub free_substs: ty::substs,
 
     /// Bound on the Self parameter
-    self_param_bound: Option<@TraitRef>,
+    pub self_param_bound: Option<@TraitRef>,
 
     /// Bounds on each numbered type parameter
-    type_param_bounds: Vec<ParamBounds> ,
+    pub type_param_bounds: Vec<ParamBounds> ,
 }
 
 /// A polytype.
@@ -1058,20 +1059,20 @@ pub struct ParameterEnvironment {
 ///   region `&self` or to (unsubstituted) ty_param types
 #[deriving(Clone)]
 pub struct ty_param_bounds_and_ty {
-    generics: Generics,
-    ty: t
+    pub generics: Generics,
+    pub ty: t
 }
 
 /// As `ty_param_bounds_and_ty` but for a trait ref.
 pub struct TraitDef {
-    generics: Generics,
-    bounds: BuiltinBounds,
-    trait_ref: @ty::TraitRef,
+    pub generics: Generics,
+    pub bounds: BuiltinBounds,
+    pub trait_ref: @ty::TraitRef,
 }
 
 pub struct ty_param_substs_and_ty {
-    substs: ty::substs,
-    ty: ty::t
+    pub substs: ty::substs,
+    pub ty: ty::t
 }
 
 pub type type_cache = RefCell<DefIdMap<ty_param_bounds_and_ty>>;
@@ -1841,7 +1842,7 @@ fn type_needs_unwind_cleanup_(cx: &ctxt, ty: t,
  * a type than to think about what is *not* contained within a type.
  */
 pub struct TypeContents {
-    bits: u64
+    pub bits: u64
 }
 
 macro_rules! def_type_content_sets(
@@ -3175,8 +3176,8 @@ impl AutoRef {
 }
 
 pub struct ParamsTy {
-    params: Vec<t>,
-    ty: t
+    pub params: Vec<t>,
+    pub ty: t
 }
 
 pub fn expr_ty_params_and_ty(cx: &ctxt,
@@ -3850,13 +3851,13 @@ pub fn ty_to_def_id(ty: t) -> Option<ast::DefId> {
 // Enum information
 #[deriving(Clone)]
 pub struct VariantInfo {
-    args: Vec<t>,
-    arg_names: Option<Vec<ast::Ident> >,
-    ctor_ty: t,
-    name: ast::Ident,
-    id: ast::DefId,
-    disr_val: Disr,
-    vis: Visibility
+    pub args: Vec<t>,
+    pub arg_names: Option<Vec<ast::Ident> >,
+    pub ctor_ty: t,
+    pub name: ast::Ident,
+    pub id: ast::DefId,
+    pub disr_val: Disr,
+    pub vis: Visibility
 }
 
 impl VariantInfo {

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -219,8 +219,8 @@ pub fn super_fold_trait_store<T:TypeFolder>(this: &mut T,
 // Some sample folders
 
 pub struct BottomUpFolder<'a> {
-    tcx: &'a ty::ctxt,
-    fldop: 'a |ty::t| -> ty::t,
+    pub tcx: &'a ty::ctxt,
+    pub fldop: 'a |ty::t| -> ty::t,
 }
 
 impl<'a> TypeFolder for BottomUpFolder<'a> {

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -103,8 +103,8 @@ pub fn check_match(fcx: &FnCtxt,
 }
 
 pub struct pat_ctxt<'a> {
-    fcx: &'a FnCtxt<'a>,
-    map: PatIdMap,
+    pub fcx: &'a FnCtxt<'a>,
+    pub map: PatIdMap,
 }
 
 pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -178,9 +178,9 @@ pub enum FnKind {
 
 #[deriving(Clone)]
 pub struct PurityState {
-    def: ast::NodeId,
-    purity: ast::Purity,
-    priv from_fn: bool
+    pub def: ast::NodeId,
+    pub purity: ast::Purity,
+    from_fn: bool
 }
 
 impl PurityState {

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -65,8 +65,8 @@ use syntax::visit::Visitor;
 /// A vtable context includes an inference context, a crate context, and a
 /// callback function to call in case of type error.
 pub struct VtableContext<'a> {
-    infcx: &'a infer::InferCtxt<'a>,
-    param_env: &'a ty::ParameterEnvironment,
+    pub infcx: &'a infer::InferCtxt<'a>,
+    pub param_env: &'a ty::ParameterEnvironment,
 }
 
 impl<'a> VtableContext<'a> {

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -331,9 +331,9 @@ pub trait Combine {
 }
 
 pub struct CombineFields<'a> {
-    infcx: &'a InferCtxt<'a>,
-    a_is_expected: bool,
-    trace: TypeTrace,
+    pub infcx: &'a InferCtxt<'a>,
+    pub a_is_expected: bool,
+    pub trace: TypeTrace,
 }
 
 pub fn expected_found<C:Combine,T>(

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -75,26 +75,26 @@ pub type fres<T> = Result<T, fixup_err>; // "fixup result"
 pub type CoerceResult = cres<Option<@ty::AutoAdjustment>>;
 
 pub struct InferCtxt<'a> {
-    tcx: &'a ty::ctxt,
+    pub tcx: &'a ty::ctxt,
 
     // We instantiate ValsAndBindings with bounds<ty::t> because the
     // types that might instantiate a general type variable have an
     // order, represented by its upper and lower bounds.
-    ty_var_bindings: RefCell<ValsAndBindings<ty::TyVid, Bounds<ty::t>>>,
-    ty_var_counter: Cell<uint>,
+    pub ty_var_bindings: RefCell<ValsAndBindings<ty::TyVid, Bounds<ty::t>>>,
+    pub ty_var_counter: Cell<uint>,
 
     // Map from integral variable to the kind of integer it represents
-    int_var_bindings: RefCell<ValsAndBindings<ty::IntVid,
+    pub int_var_bindings: RefCell<ValsAndBindings<ty::IntVid,
                                               Option<IntVarValue>>>,
-    int_var_counter: Cell<uint>,
+    pub int_var_counter: Cell<uint>,
 
     // Map from floating variable to the kind of float it represents
-    float_var_bindings: RefCell<ValsAndBindings<ty::FloatVid,
+    pub float_var_bindings: RefCell<ValsAndBindings<ty::FloatVid,
                                                 Option<ast::FloatTy>>>,
-    float_var_counter: Cell<uint>,
+    pub float_var_counter: Cell<uint>,
 
     // For region variables.
-    region_vars: RegionVarBindings<'a>,
+    pub region_vars: RegionVarBindings<'a>,
 }
 
 /// Why did we require that the two types be related?

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -104,8 +104,8 @@ pub enum RegionResolutionError {
 /// 'a and 'b together inside a SameRegions struct
 #[deriving(Clone)]
 pub struct SameRegions {
-    scope_id: ast::NodeId,
-    regions: Vec<BoundRegion>
+    pub scope_id: ast::NodeId,
+    pub regions: Vec<BoundRegion>
 }
 
 impl SameRegions {

--- a/src/librustc/middle/typeck/infer/unify.rs
+++ b/src/librustc/middle/typeck/infer/unify.rs
@@ -26,14 +26,14 @@ pub enum VarValue<V, T> {
 }
 
 pub struct ValsAndBindings<V, T> {
-    vals: SmallIntMap<VarValue<V, T>>,
-    bindings: Vec<(V, VarValue<V, T>)> ,
+    pub vals: SmallIntMap<VarValue<V, T>>,
+    pub bindings: Vec<(V, VarValue<V, T>)> ,
 }
 
 pub struct Node<V, T> {
-    root: V,
-    possible_types: T,
-    rank: uint,
+    pub root: V,
+    pub possible_types: T,
+    pub rank: uint,
 }
 
 pub trait UnifyVid<T> {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -108,49 +108,49 @@ pub enum MethodOrigin {
 #[deriving(Clone, Encodable, Decodable)]
 pub struct MethodParam {
     // the trait containing the method to be invoked
-    trait_id: ast::DefId,
+    pub trait_id: ast::DefId,
 
     // index of the method to be invoked amongst the trait's methods
-    method_num: uint,
+    pub method_num: uint,
 
     // index of the type parameter (from those that are in scope) that is
     // the type of the receiver
-    param_num: param_index,
+    pub param_num: param_index,
 
     // index of the bound for this type parameter which specifies the trait
-    bound_num: uint,
+    pub bound_num: uint,
 }
 
 // details for a method invoked with a receiver whose type is an object
 #[deriving(Clone, Encodable, Decodable)]
 pub struct MethodObject {
     // the (super)trait containing the method to be invoked
-    trait_id: ast::DefId,
+    pub trait_id: ast::DefId,
 
     // the actual base trait id of the object
-    object_trait_id: ast::DefId,
+    pub object_trait_id: ast::DefId,
 
     // index of the method to be invoked amongst the trait's methods
-    method_num: uint,
+    pub method_num: uint,
 
     // index into the actual runtime vtable.
     // the vtable is formed by concatenating together the method lists of
     // the base object trait and all supertraits;  this is the index into
     // that vtable
-    real_index: uint,
+    pub real_index: uint,
 }
 
 #[deriving(Clone)]
 pub struct MethodCallee {
-    origin: MethodOrigin,
-    ty: ty::t,
-    substs: ty::substs
+    pub origin: MethodOrigin,
+    pub ty: ty::t,
+    pub substs: ty::substs
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash, Show)]
 pub struct MethodCall {
-    expr_id: ast::NodeId,
-    autoderef: u32
+    pub expr_id: ast::NodeId,
+    pub autoderef: u32
 }
 
 impl MethodCall {
@@ -224,9 +224,9 @@ pub type vtable_map = @RefCell<FnvHashMap<MethodCall, vtable_res>>;
 #[deriving(Clone)]
 pub struct impl_res {
     // resolutions for any bounded params on the trait definition
-    trait_vtables: vtable_res,
+    pub trait_vtables: vtable_res,
     // resolutions for the trait /itself/ (and for supertraits)
-    self_vtables: vtable_param_res
+    pub self_vtables: vtable_param_res
 }
 
 impl Repr for impl_res {

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -473,7 +473,7 @@ impl Engine256 {
 
 /// The SHA-256 hash algorithm
 pub struct Sha256 {
-    priv engine: Engine256
+    engine: Engine256
 }
 
 impl Sha256 {

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -64,9 +64,9 @@ impl<T: Clean<U>, U> Clean<Vec<U>> for syntax::owned_slice::OwnedSlice<T> {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Crate {
-    name: ~str,
-    module: Option<Item>,
-    externs: Vec<(ast::CrateNum, ExternalCrate)> ,
+    pub name: ~str,
+    pub module: Option<Item>,
+    pub externs: Vec<(ast::CrateNum, ExternalCrate)>,
 }
 
 impl<'a> Clean<Crate> for visit_ast::RustdocVisitor<'a> {
@@ -92,8 +92,8 @@ impl<'a> Clean<Crate> for visit_ast::RustdocVisitor<'a> {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct ExternalCrate {
-    name: ~str,
-    attrs: Vec<Attribute> ,
+    pub name: ~str,
+    pub attrs: Vec<Attribute>,
 }
 
 impl Clean<ExternalCrate> for cstore::crate_metadata {
@@ -113,13 +113,13 @@ impl Clean<ExternalCrate> for cstore::crate_metadata {
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Item {
     /// Stringified span
-    source: Span,
+    pub source: Span,
     /// Not everything has a name. E.g., impls
-    name: Option<~str>,
-    attrs: Vec<Attribute> ,
-    inner: ItemEnum,
-    visibility: Option<Visibility>,
-    id: ast::NodeId,
+    pub name: Option<~str>,
+    pub attrs: Vec<Attribute> ,
+    pub inner: ItemEnum,
+    pub visibility: Option<Visibility>,
+    pub id: ast::NodeId,
 }
 
 impl Item {
@@ -192,8 +192,8 @@ pub enum ItemEnum {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Module {
-    items: Vec<Item> ,
-    is_crate: bool,
+    pub items: Vec<Item>,
+    pub is_crate: bool,
 }
 
 impl Clean<Item> for doctree::Module {
@@ -289,9 +289,10 @@ impl<'a> attr::AttrMetaMethods for &'a Attribute {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct TyParam {
-    name: ~str,
-    id: ast::NodeId,
-    bounds: Vec<TyParamBound> }
+    pub name: ~str,
+    pub id: ast::NodeId,
+    pub bounds: Vec<TyParamBound>,
+}
 
 impl Clean<TyParam> for ast::TyParam {
     fn clean(&self) -> TyParam {
@@ -338,8 +339,9 @@ impl Clean<Lifetime> for ast::Lifetime {
 // maybe use a Generic enum and use ~[Generic]?
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Generics {
-    lifetimes: Vec<Lifetime> ,
-    type_params: Vec<TyParam> }
+    pub lifetimes: Vec<Lifetime>,
+    pub type_params: Vec<TyParam>,
+}
 
 impl Clean<Generics> for ast::Generics {
     fn clean(&self) -> Generics {
@@ -352,10 +354,10 @@ impl Clean<Generics> for ast::Generics {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Method {
-    generics: Generics,
-    self_: SelfTy,
-    purity: ast::Purity,
-    decl: FnDecl,
+    pub generics: Generics,
+    pub self_: SelfTy,
+    pub purity: ast::Purity,
+    pub decl: FnDecl,
 }
 
 impl Clean<Item> for ast::Method {
@@ -390,10 +392,10 @@ impl Clean<Item> for ast::Method {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct TyMethod {
-    purity: ast::Purity,
-    decl: FnDecl,
-    generics: Generics,
-    self_: SelfTy,
+    pub purity: ast::Purity,
+    pub decl: FnDecl,
+    pub generics: Generics,
+    pub self_: SelfTy,
 }
 
 impl Clean<Item> for ast::TypeMethod {
@@ -447,9 +449,9 @@ impl Clean<SelfTy> for ast::ExplicitSelf {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Function {
-    decl: FnDecl,
-    generics: Generics,
-    purity: ast::Purity,
+    pub decl: FnDecl,
+    pub generics: Generics,
+    pub purity: ast::Purity,
 }
 
 impl Clean<Item> for doctree::Function {
@@ -471,13 +473,14 @@ impl Clean<Item> for doctree::Function {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct ClosureDecl {
-    sigil: ast::Sigil,
-    region: Option<Lifetime>,
-    lifetimes: Vec<Lifetime> ,
-    decl: FnDecl,
-    onceness: ast::Onceness,
-    purity: ast::Purity,
-    bounds: Vec<TyParamBound> }
+    pub sigil: ast::Sigil,
+    pub region: Option<Lifetime>,
+    pub lifetimes: Vec<Lifetime>,
+    pub decl: FnDecl,
+    pub onceness: ast::Onceness,
+    pub purity: ast::Purity,
+    pub bounds: Vec<TyParamBound>,
+}
 
 impl Clean<ClosureDecl> for ast::ClosureTy {
     fn clean(&self) -> ClosureDecl {
@@ -498,14 +501,15 @@ impl Clean<ClosureDecl> for ast::ClosureTy {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct FnDecl {
-    inputs: Arguments,
-    output: Type,
-    cf: RetStyle,
-    attrs: Vec<Attribute> }
+    pub inputs: Arguments,
+    pub output: Type,
+    pub cf: RetStyle,
+    pub attrs: Vec<Attribute>,
+}
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Arguments {
-    values: Vec<Argument> ,
+    pub values: Vec<Argument>,
 }
 
 impl Clean<FnDecl> for ast::FnDecl {
@@ -523,9 +527,9 @@ impl Clean<FnDecl> for ast::FnDecl {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Argument {
-    type_: Type,
-    name: ~str,
-    id: ast::NodeId
+    pub type_: Type,
+    pub name: ~str,
+    pub id: ast::NodeId,
 }
 
 impl Clean<Argument> for ast::Arg {
@@ -555,9 +559,9 @@ impl Clean<RetStyle> for ast::RetStyle {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Trait {
-    methods: Vec<TraitMethod> ,
-    generics: Generics,
-    parents: Vec<Type> ,
+    pub methods: Vec<TraitMethod>,
+    pub generics: Generics,
+    pub parents: Vec<Type>,
 }
 
 impl Clean<Item> for doctree::Trait {
@@ -626,17 +630,17 @@ impl Clean<TraitMethod> for ast::TraitMethod {
 pub enum Type {
     /// structs/enums/traits (anything that'd be an ast::TyPath)
     ResolvedPath {
-        path: Path,
-        typarams: Option<Vec<TyParamBound> >,
-        id: ast::NodeId,
+        pub path: Path,
+        pub typarams: Option<Vec<TyParamBound>>,
+        pub id: ast::NodeId,
     },
     /// Same as above, but only external variants
     ExternalPath {
-        path: Path,
-        typarams: Option<Vec<TyParamBound> >,
-        fqn: Vec<~str> ,
-        kind: TypeKind,
-        krate: ast::CrateNum,
+        pub path: Path,
+        pub typarams: Option<Vec<TyParamBound>>,
+        pub fqn: Vec<~str>,
+        pub kind: TypeKind,
+        pub krate: ast::CrateNum,
     },
     // I have no idea how to usefully use this.
     TyParamBinder(ast::NodeId),
@@ -662,7 +666,11 @@ pub enum Type {
     Unique(~Type),
     Managed(~Type),
     RawPointer(Mutability, ~Type),
-    BorrowedRef { lifetime: Option<Lifetime>, mutability: Mutability, type_: ~Type},
+    BorrowedRef {
+        pub lifetime: Option<Lifetime>,
+        pub mutability: Mutability,
+        pub type_: ~Type,
+    },
     // region, raw, other boxes, mutable
 }
 
@@ -707,7 +715,7 @@ impl Clean<Type> for ast::Ty {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct StructField {
-    type_: Type,
+    pub type_: Type,
 }
 
 impl Clean<Item> for ast::StructField {
@@ -739,10 +747,10 @@ impl Clean<Option<Visibility>> for ast::Visibility {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Struct {
-    struct_type: doctree::StructType,
-    generics: Generics,
-    fields: Vec<Item> ,
-    fields_stripped: bool,
+    pub struct_type: doctree::StructType,
+    pub generics: Generics,
+    pub fields: Vec<Item>,
+    pub fields_stripped: bool,
 }
 
 impl Clean<Item> for doctree::Struct {
@@ -768,9 +776,9 @@ impl Clean<Item> for doctree::Struct {
 /// only as a variant in an enum.
 #[deriving(Clone, Encodable, Decodable)]
 pub struct VariantStruct {
-    struct_type: doctree::StructType,
-    fields: Vec<Item> ,
-    fields_stripped: bool,
+    pub struct_type: doctree::StructType,
+    pub fields: Vec<Item>,
+    pub fields_stripped: bool,
 }
 
 impl Clean<VariantStruct> for syntax::ast::StructDef {
@@ -785,9 +793,9 @@ impl Clean<VariantStruct> for syntax::ast::StructDef {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Enum {
-    variants: Vec<Item> ,
-    generics: Generics,
-    variants_stripped: bool,
+    pub variants: Vec<Item>,
+    pub generics: Generics,
+    pub variants_stripped: bool,
 }
 
 impl Clean<Item> for doctree::Enum {
@@ -809,7 +817,7 @@ impl Clean<Item> for doctree::Enum {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Variant {
-    kind: VariantKind,
+    pub kind: VariantKind,
 }
 
 impl Clean<Item> for doctree::Variant {
@@ -851,11 +859,11 @@ impl Clean<VariantKind> for ast::VariantKind {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Span {
-    filename: ~str,
-    loline: uint,
-    locol: uint,
-    hiline: uint,
-    hicol: uint,
+    pub filename: ~str,
+    pub loline: uint,
+    pub locol: uint,
+    pub hiline: uint,
+    pub hicol: uint,
 }
 
 impl Clean<Span> for syntax::codemap::Span {
@@ -876,8 +884,8 @@ impl Clean<Span> for syntax::codemap::Span {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Path {
-    global: bool,
-    segments: Vec<PathSegment> ,
+    pub global: bool,
+    pub segments: Vec<PathSegment>,
 }
 
 impl Clean<Path> for ast::Path {
@@ -891,9 +899,9 @@ impl Clean<Path> for ast::Path {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct PathSegment {
-    name: ~str,
-    lifetimes: Vec<Lifetime> ,
-    types: Vec<Type> ,
+    pub name: ~str,
+    pub lifetimes: Vec<Lifetime>,
+    pub types: Vec<Type>,
 }
 
 impl Clean<PathSegment> for ast::PathSegment {
@@ -930,8 +938,8 @@ impl Clean<~str> for ast::Ident {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Typedef {
-    type_: Type,
-    generics: Generics,
+    pub type_: Type,
+    pub generics: Generics,
 }
 
 impl Clean<Item> for doctree::Typedef {
@@ -952,10 +960,10 @@ impl Clean<Item> for doctree::Typedef {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct BareFunctionDecl {
-    purity: ast::Purity,
-    generics: Generics,
-    decl: FnDecl,
-    abi: ~str
+    pub purity: ast::Purity,
+    pub generics: Generics,
+    pub decl: FnDecl,
+    pub abi: ~str,
 }
 
 impl Clean<BareFunctionDecl> for ast::BareFnTy {
@@ -974,12 +982,12 @@ impl Clean<BareFunctionDecl> for ast::BareFnTy {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Static {
-    type_: Type,
-    mutability: Mutability,
+    pub type_: Type,
+    pub mutability: Mutability,
     /// It's useful to have the value of a static documented, but I have no
     /// desire to represent expressions (that'd basically be all of the AST,
     /// which is huge!). So, have a string.
-    expr: ~str,
+    pub expr: ~str,
 }
 
 impl Clean<Item> for doctree::Static {
@@ -1017,11 +1025,11 @@ impl Clean<Mutability> for ast::Mutability {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Impl {
-    generics: Generics,
-    trait_: Option<Type>,
-    for_: Type,
-    methods: Vec<Item>,
-    derived: bool,
+    pub generics: Generics,
+    pub trait_: Option<Type>,
+    pub for_: Type,
+    pub methods: Vec<Item>,
+    pub derived: bool,
 }
 
 impl Clean<Item> for doctree::Impl {
@@ -1056,7 +1064,7 @@ impl Clean<Item> for doctree::Impl {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct ViewItem {
-    inner: ViewItemInner
+    pub inner: ViewItemInner,
 }
 
 impl Clean<Item> for ast::ViewItem {
@@ -1109,8 +1117,8 @@ pub enum ViewPath {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct ImportSource {
-    path: Path,
-    did: Option<ast::DefId>,
+    pub path: Path,
+    pub did: Option<ast::DefId>,
 }
 
 impl Clean<ViewPath> for ast::ViewPath {
@@ -1130,8 +1138,8 @@ impl Clean<ViewPath> for ast::ViewPath {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct ViewListIdent {
-    name: ~str,
-    source: Option<ast::DefId>,
+    pub name: ~str,
+    pub source: Option<ast::DefId>,
 }
 
 impl Clean<ViewListIdent> for ast::PathListIdent {
@@ -1311,7 +1319,7 @@ fn resolve_def(id: ast::NodeId) -> Option<ast::DefId> {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Macro {
-    source: ~str,
+    pub source: ~str,
 }
 
 impl Clean<Item> for doctree::Macro {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -32,8 +32,8 @@ pub enum MaybeTyped {
 }
 
 pub struct DocContext {
-    krate: ast::Crate,
-    maybe_typed: MaybeTyped
+    pub krate: ast::Crate,
+    pub maybe_typed: MaybeTyped
 }
 
 impl DocContext {
@@ -46,8 +46,8 @@ impl DocContext {
 }
 
 pub struct CrateAnalysis {
-    exported_items: privacy::ExportedItems,
-    public_items: privacy::PublicItems,
+    pub exported_items: privacy::ExportedItems,
+    pub public_items: privacy::PublicItems,
 }
 
 /// Parses, resolves, and typechecks the given crate

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -17,23 +17,23 @@ use syntax::ast;
 use syntax::ast::{Ident, NodeId};
 
 pub struct Module {
-    name: Option<Ident>,
-    attrs: Vec<ast::Attribute> ,
-    where: Span,
-    structs: Vec<Struct> ,
-    enums: Vec<Enum> ,
-    fns: Vec<Function> ,
-    mods: Vec<Module> ,
-    id: NodeId,
-    typedefs: Vec<Typedef> ,
-    statics: Vec<Static> ,
-    traits: Vec<Trait> ,
-    vis: ast::Visibility,
-    impls: Vec<Impl> ,
-    foreigns: Vec<ast::ForeignMod> ,
-    view_items: Vec<ast::ViewItem> ,
-    macros: Vec<Macro> ,
-    is_crate: bool,
+    pub name: Option<Ident>,
+    pub attrs: Vec<ast::Attribute>,
+    pub where: Span,
+    pub structs: Vec<Struct>,
+    pub enums: Vec<Enum>,
+    pub fns: Vec<Function>,
+    pub mods: Vec<Module>,
+    pub id: NodeId,
+    pub typedefs: Vec<Typedef>,
+    pub statics: Vec<Static>,
+    pub traits: Vec<Trait>,
+    pub vis: ast::Visibility,
+    pub impls: Vec<Impl>,
+    pub foreigns: Vec<ast::ForeignMod>,
+    pub view_items: Vec<ast::ViewItem>,
+    pub macros: Vec<Macro>,
+    pub is_crate: bool,
 }
 
 impl Module {
@@ -78,94 +78,94 @@ pub enum TypeBound {
 }
 
 pub struct Struct {
-    vis: ast::Visibility,
-    id: NodeId,
-    struct_type: StructType,
-    name: Ident,
-    generics: ast::Generics,
-    attrs: Vec<ast::Attribute> ,
-    fields: Vec<ast::StructField> ,
-    where: Span,
+    pub vis: ast::Visibility,
+    pub id: NodeId,
+    pub struct_type: StructType,
+    pub name: Ident,
+    pub generics: ast::Generics,
+    pub attrs: Vec<ast::Attribute>,
+    pub fields: Vec<ast::StructField>,
+    pub where: Span,
 }
 
 pub struct Enum {
-    vis: ast::Visibility,
-    variants: Vec<Variant> ,
-    generics: ast::Generics,
-    attrs: Vec<ast::Attribute> ,
-    id: NodeId,
-    where: Span,
-    name: Ident,
+    pub vis: ast::Visibility,
+    pub variants: Vec<Variant>,
+    pub generics: ast::Generics,
+    pub attrs: Vec<ast::Attribute>,
+    pub id: NodeId,
+    pub where: Span,
+    pub name: Ident,
 }
 
 pub struct Variant {
-    name: Ident,
-    attrs: Vec<ast::Attribute> ,
-    kind: ast::VariantKind,
-    id: ast::NodeId,
-    vis: ast::Visibility,
-    where: Span,
+    pub name: Ident,
+    pub attrs: Vec<ast::Attribute>,
+    pub kind: ast::VariantKind,
+    pub id: ast::NodeId,
+    pub vis: ast::Visibility,
+    pub where: Span,
 }
 
 pub struct Function {
-    decl: ast::FnDecl,
-    attrs: Vec<ast::Attribute> ,
-    id: NodeId,
-    name: Ident,
-    vis: ast::Visibility,
-    purity: ast::Purity,
-    where: Span,
-    generics: ast::Generics,
+    pub decl: ast::FnDecl,
+    pub attrs: Vec<ast::Attribute>,
+    pub id: NodeId,
+    pub name: Ident,
+    pub vis: ast::Visibility,
+    pub purity: ast::Purity,
+    pub where: Span,
+    pub generics: ast::Generics,
 }
 
 pub struct Typedef {
-    ty: ast::P<ast::Ty>,
-    gen: ast::Generics,
-    name: Ident,
-    id: ast::NodeId,
-    attrs: Vec<ast::Attribute> ,
-    where: Span,
-    vis: ast::Visibility,
+    pub ty: ast::P<ast::Ty>,
+    pub gen: ast::Generics,
+    pub name: Ident,
+    pub id: ast::NodeId,
+    pub attrs: Vec<ast::Attribute>,
+    pub where: Span,
+    pub vis: ast::Visibility,
 }
 
 pub struct Static {
-    type_: ast::P<ast::Ty>,
-    mutability: ast::Mutability,
-    expr: @ast::Expr,
-    name: Ident,
-    attrs: Vec<ast::Attribute> ,
-    vis: ast::Visibility,
-    id: ast::NodeId,
-    where: Span,
+    pub type_: ast::P<ast::Ty>,
+    pub mutability: ast::Mutability,
+    pub expr: @ast::Expr,
+    pub name: Ident,
+    pub attrs: Vec<ast::Attribute>,
+    pub vis: ast::Visibility,
+    pub id: ast::NodeId,
+    pub where: Span,
 }
 
 pub struct Trait {
-    name: Ident,
-    methods: Vec<ast::TraitMethod> , //should be TraitMethod
-    generics: ast::Generics,
-    parents: Vec<ast::TraitRef> ,
-    attrs: Vec<ast::Attribute> ,
-    id: ast::NodeId,
-    where: Span,
-    vis: ast::Visibility,
+    pub name: Ident,
+    pub methods: Vec<ast::TraitMethod>, //should be TraitMethod
+    pub generics: ast::Generics,
+    pub parents: Vec<ast::TraitRef>,
+    pub attrs: Vec<ast::Attribute>,
+    pub id: ast::NodeId,
+    pub where: Span,
+    pub vis: ast::Visibility,
 }
 
 pub struct Impl {
-    generics: ast::Generics,
-    trait_: Option<ast::TraitRef>,
-    for_: ast::P<ast::Ty>,
-    methods: Vec<@ast::Method> ,
-    attrs: Vec<ast::Attribute> ,
-    where: Span,
-    vis: ast::Visibility,
-    id: ast::NodeId,
+    pub generics: ast::Generics,
+    pub trait_: Option<ast::TraitRef>,
+    pub for_: ast::P<ast::Ty>,
+    pub methods: Vec<@ast::Method>,
+    pub attrs: Vec<ast::Attribute>,
+    pub where: Span,
+    pub vis: ast::Visibility,
+    pub id: ast::NodeId,
 }
 
 pub struct Macro {
-    name: Ident,
-    id: ast::NodeId,
-    attrs: Vec<ast::Attribute> ,
-    where: Span,
+    pub name: Ident,
+    pub id: ast::NodeId,
+    pub attrs: Vec<ast::Attribute>,
+    pub where: Span,
 }
 
 pub fn struct_type_from_def(sd: &ast::StructDef) -> StructType {

--- a/src/librustdoc/flock.rs
+++ b/src/librustdoc/flock.rs
@@ -27,14 +27,14 @@ mod imp {
         use std::libc;
 
         pub struct flock {
-            l_type: libc::c_short,
-            l_whence: libc::c_short,
-            l_start: libc::off_t,
-            l_len: libc::off_t,
-            l_pid: libc::pid_t,
+            pub l_type: libc::c_short,
+            pub l_whence: libc::c_short,
+            pub l_start: libc::off_t,
+            pub l_len: libc::off_t,
+            pub l_pid: libc::pid_t,
 
             // not actually here, but brings in line with freebsd
-            l_sysid: libc::c_int,
+            pub l_sysid: libc::c_int,
         }
 
         pub static F_WRLCK: libc::c_short = 1;
@@ -48,12 +48,12 @@ mod imp {
         use std::libc;
 
         pub struct flock {
-            l_start: libc::off_t,
-            l_len: libc::off_t,
-            l_pid: libc::pid_t,
-            l_type: libc::c_short,
-            l_whence: libc::c_short,
-            l_sysid: libc::c_int,
+            pub l_start: libc::off_t,
+            pub l_len: libc::off_t,
+            pub l_pid: libc::pid_t,
+            pub l_type: libc::c_short,
+            pub l_whence: libc::c_short,
+            pub l_sysid: libc::c_int,
         }
 
         pub static F_UNLCK: libc::c_short = 2;
@@ -67,14 +67,14 @@ mod imp {
         use std::libc;
 
         pub struct flock {
-            l_start: libc::off_t,
-            l_len: libc::off_t,
-            l_pid: libc::pid_t,
-            l_type: libc::c_short,
-            l_whence: libc::c_short,
+            pub l_start: libc::off_t,
+            pub l_len: libc::off_t,
+            pub l_pid: libc::pid_t,
+            pub l_type: libc::c_short,
+            pub l_whence: libc::c_short,
 
             // not actually here, but brings in line with freebsd
-            l_sysid: libc::c_int,
+            pub l_sysid: libc::c_int,
         }
 
         pub static F_UNLCK: libc::c_short = 2;
@@ -84,7 +84,7 @@ mod imp {
     }
 
     pub struct Lock {
-        priv fd: libc::c_int,
+        fd: libc::c_int,
     }
 
     impl Lock {
@@ -155,7 +155,7 @@ mod imp {
     }
 
     pub struct Lock {
-        priv handle: libc::HANDLE,
+        handle: libc::HANDLE,
     }
 
     impl Lock {

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -13,15 +13,15 @@ use std::io;
 
 #[deriving(Clone)]
 pub struct Layout {
-    logo: ~str,
-    favicon: ~str,
-    krate: ~str,
+    pub logo: ~str,
+    pub favicon: ~str,
+    pub krate: ~str,
 }
 
 pub struct Page<'a> {
-    title: &'a str,
-    ty: &'a str,
-    root_path: &'a str,
+    pub title: &'a str,
+    pub ty: &'a str,
+    pub root_path: &'a str,
 }
 
 pub fn render<T: fmt::Show, S: fmt::Show>(

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -68,26 +68,26 @@ use html::highlight;
 pub struct Context {
     /// Current hierarchy of components leading down to what's currently being
     /// rendered
-    current: Vec<~str> ,
+    pub current: Vec<~str> ,
     /// String representation of how to get back to the root path of the 'doc/'
     /// folder in terms of a relative URL.
-    root_path: ~str,
+    pub root_path: ~str,
     /// The current destination folder of where HTML artifacts should be placed.
     /// This changes as the context descends into the module hierarchy.
-    dst: Path,
+    pub dst: Path,
     /// This describes the layout of each page, and is not modified after
     /// creation of the context (contains info like the favicon)
-    layout: layout::Layout,
+    pub layout: layout::Layout,
     /// This map is a list of what should be displayed on the sidebar of the
     /// current page. The key is the section header (traits, modules,
     /// functions), and the value is the list of containers belonging to this
     /// header. This map will change depending on the surrounding context of the
     /// page.
-    sidebar: HashMap<~str, Vec<~str> >,
+    pub sidebar: HashMap<~str, Vec<~str> >,
     /// This flag indicates whether [src] links should be generated or not. If
     /// the source files are present in the html rendering, then this will be
     /// `true`.
-    include_sources: bool,
+    pub include_sources: bool,
 }
 
 /// Indicates where an external crate can be found.
@@ -122,7 +122,7 @@ pub struct Cache {
     /// Mapping of typaram ids to the name of the type parameter. This is used
     /// when pretty-printing a type (so pretty printing doesn't have to
     /// painfully maintain a context like this)
-    typarams: HashMap<ast::NodeId, ~str>,
+    pub typarams: HashMap<ast::NodeId, ~str>,
 
     /// Maps a type id to all known implementations for that type. This is only
     /// recognized for intra-crate `ResolvedPath` types, and is used to print
@@ -130,43 +130,43 @@ pub struct Cache {
     ///
     /// The values of the map are a list of implementations and documentation
     /// found on that implementation.
-    impls: HashMap<ast::NodeId, Vec<(clean::Impl, Option<~str>)> >,
+    pub impls: HashMap<ast::NodeId, Vec<(clean::Impl, Option<~str>)> >,
 
     /// Maintains a mapping of local crate node ids to the fully qualified name
     /// and "short type description" of that node. This is used when generating
     /// URLs when a type is being linked to. External paths are not located in
     /// this map because the `External` type itself has all the information
     /// necessary.
-    paths: HashMap<ast::NodeId, (Vec<~str> , &'static str)>,
+    pub paths: HashMap<ast::NodeId, (Vec<~str> , &'static str)>,
 
     /// This map contains information about all known traits of this crate.
     /// Implementations of a crate should inherit the documentation of the
     /// parent trait if no extra documentation is specified, and default methods
     /// should show up in documentation about trait implementations.
-    traits: HashMap<ast::NodeId, clean::Trait>,
+    pub traits: HashMap<ast::NodeId, clean::Trait>,
 
     /// When rendering traits, it's often useful to be able to list all
     /// implementors of the trait, and this mapping is exactly, that: a mapping
     /// of trait ids to the list of known implementors of the trait
-    implementors: HashMap<ast::NodeId, Vec<Implementor> >,
+    pub implementors: HashMap<ast::NodeId, Vec<Implementor> >,
 
     /// Cache of where external crate documentation can be found.
-    extern_locations: HashMap<ast::CrateNum, ExternalLocation>,
+    pub extern_locations: HashMap<ast::CrateNum, ExternalLocation>,
 
     // Private fields only used when initially crawling a crate to build a cache
 
-    priv stack: Vec<~str> ,
-    priv parent_stack: Vec<ast::NodeId> ,
-    priv search_index: Vec<IndexItem> ,
-    priv privmod: bool,
-    priv public_items: NodeSet,
+    stack: Vec<~str> ,
+    parent_stack: Vec<ast::NodeId> ,
+    search_index: Vec<IndexItem> ,
+    privmod: bool,
+    public_items: NodeSet,
 
     // In rare case where a structure is defined in one module but implemented
     // in another, if the implementing module is parsed before defining module,
     // then the fully qualified name of the structure isn't presented in `paths`
     // yet when its implementation methods are being indexed. Caches such methods
     // and their parent id here and indexes them at the end of crate parsing.
-    priv orphan_methods: Vec<(ast::NodeId, clean::Item)>,
+    orphan_methods: Vec<(ast::NodeId, clean::Item)>,
 }
 
 /// Helper struct to render all source code to HTML pages

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -26,7 +26,7 @@ pub struct Toc {
     /// # Main
     /// ### A
     /// ## B
-    priv entries: Vec<TocEntry>
+    entries: Vec<TocEntry>
 }
 
 impl Toc {
@@ -37,17 +37,17 @@ impl Toc {
 
 #[deriving(Eq)]
 pub struct TocEntry {
-    priv level: u32,
-    priv sec_number: ~str,
-    priv name: ~str,
-    priv id: ~str,
-    priv children: Toc,
+    level: u32,
+    sec_number: ~str,
+    name: ~str,
+    id: ~str,
+    children: Toc,
 }
 
 /// Progressive construction of a table of contents.
 #[deriving(Eq)]
 pub struct TocBuilder {
-    priv top_level: Toc,
+    top_level: Toc,
     /// The current heirachy of parent headings, the levels are
     /// strictly increasing (i.e. chain[0].level < chain[1].level <
     /// ...) with each entry being the most recent occurance of a
@@ -56,7 +56,7 @@ pub struct TocBuilder {
     /// the most recent one).
     ///
     /// We also have `chain[0].level <= top_level.entries[last]`.
-    priv chain: Vec<TocEntry>
+    chain: Vec<TocEntry>
 }
 
 impl TocBuilder {

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -19,10 +19,10 @@ pub type PluginCallback = fn (clean::Crate) -> PluginResult;
 
 /// Manages loading and running of plugins
 pub struct PluginManager {
-    priv dylibs: Vec<dl::DynamicLibrary> ,
-    priv callbacks: Vec<PluginCallback> ,
+    dylibs: Vec<dl::DynamicLibrary> ,
+    callbacks: Vec<PluginCallback> ,
     /// The directory plugins will be loaded from
-    prefix: Path,
+    pub prefix: Path,
 }
 
 impl PluginManager {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -190,15 +190,15 @@ fn maketest(s: &str, cratename: &str, loose_feature_gating: bool) -> ~str {
 }
 
 pub struct Collector {
-    tests: Vec<testing::TestDescAndFn>,
-    priv names: Vec<~str>,
-    priv libs: HashSet<Path>,
-    priv cnt: uint,
-    priv use_headers: bool,
-    priv current_header: Option<~str>,
-    priv cratename: ~str,
+    pub tests: Vec<testing::TestDescAndFn>,
+    names: Vec<~str>,
+    libs: HashSet<Path>,
+    cnt: uint,
+    use_headers: bool,
+    current_header: Option<~str>,
+    cratename: ~str,
 
-    priv loose_feature_gating: bool
+    loose_feature_gating: bool
 }
 
 impl Collector {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -21,10 +21,10 @@ use core;
 use doctree::*;
 
 pub struct RustdocVisitor<'a> {
-    module: Module,
-    attrs: Vec<ast::Attribute> ,
-    cx: &'a core::DocContext,
-    analysis: Option<&'a core::CrateAnalysis>,
+    pub module: Module,
+    pub attrs: Vec<ast::Attribute>,
+    pub cx: &'a core::DocContext,
+    pub analysis: Option<&'a core::CrateAnalysis>,
 }
 
 impl<'a> RustdocVisitor<'a> {

--- a/src/librustuv/access.rs
+++ b/src/librustuv/access.rs
@@ -22,12 +22,12 @@ use std::rt::local::Local;
 use homing::HomingMissile;
 
 pub struct Access {
-    priv inner: UnsafeArc<Inner>,
+    inner: UnsafeArc<Inner>,
 }
 
 pub struct Guard<'a> {
-    priv access: &'a mut Access,
-    priv missile: Option<HomingMissile>,
+    access: &'a mut Access,
+    missile: Option<HomingMissile>,
 }
 
 struct Inner {

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -26,14 +26,14 @@ use uvll;
 
 pub struct FsRequest {
     req: *uvll::uv_fs_t,
-    priv fired: bool,
+    fired: bool,
 }
 
 pub struct FileWatcher {
-    priv loop_: Loop,
-    priv fd: c_int,
-    priv close: rtio::CloseBehavior,
-    priv home: HomeHandle,
+    loop_: Loop,
+    fd: c_int,
+    close: rtio::CloseBehavior,
+    home: HomeHandle,
 }
 
 impl FsRequest {

--- a/src/librustuv/homing.rs
+++ b/src/librustuv/homing.rs
@@ -48,8 +48,8 @@ use queue::{Queue, QueuePool};
 /// Handles are clone-able in order to derive new handles from existing handles
 /// (very useful for when accepting a socket from a server).
 pub struct HomeHandle {
-    priv queue: Queue,
-    priv id: uint,
+    queue: Queue,
+    id: uint,
 }
 
 impl HomeHandle {
@@ -126,7 +126,7 @@ pub trait HomingIO {
 /// task back to its appropriate home (if applicable). The field is used to
 /// assert that we are where we think we are.
 pub struct HomingMissile {
-    priv io_home: uint,
+    io_home: uint,
 }
 
 impl HomingMissile {

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -197,8 +197,8 @@ pub trait UvHandle<T> {
 }
 
 pub struct ForbidSwitch {
-    priv msg: &'static str,
-    priv io: uint,
+    msg: &'static str,
+    io: uint,
 }
 
 impl ForbidSwitch {
@@ -261,8 +261,8 @@ fn wakeup(slot: &mut Option<BlockedTask>) {
 }
 
 pub struct Request {
-    handle: *uvll::uv_req_t,
-    priv defused: bool,
+    pub handle: *uvll::uv_req_t,
+    defused: bool,
 }
 
 impl Request {
@@ -313,7 +313,7 @@ impl Drop for Request {
 /// with dtors may not be destructured, but tuple structs can,
 /// but the results are not correct.
 pub struct Loop {
-    priv handle: *uvll::uv_loop_t
+    handle: *uvll::uv_loop_t
 }
 
 impl Loop {

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -153,22 +153,22 @@ pub struct TcpWatcher {
     handle: *uvll::uv_tcp_t,
     stream: StreamWatcher,
     home: HomeHandle,
-    priv refcount: Refcount,
+    refcount: Refcount,
 
     // libuv can't support concurrent reads and concurrent writes of the same
     // stream object, so we use these access guards in order to arbitrate among
     // multiple concurrent reads and writes. Note that libuv *can* read and
     // write simultaneously, it just can't read and read simultaneously.
-    priv read_access: Access,
-    priv write_access: Access,
+    read_access: Access,
+    write_access: Access,
 }
 
 pub struct TcpListener {
     home: HomeHandle,
     handle: *uvll::uv_pipe_t,
-    priv closing_task: Option<BlockedTask>,
-    priv outgoing: Sender<Result<~rtio::RtioTcpStream:Send, IoError>>,
-    priv incoming: Receiver<Result<~rtio::RtioTcpStream:Send, IoError>>,
+    closing_task: Option<BlockedTask>,
+    outgoing: Sender<Result<~rtio::RtioTcpStream:Send, IoError>>,
+    incoming: Receiver<Result<~rtio::RtioTcpStream:Send, IoError>>,
 }
 
 pub struct TcpAcceptor {
@@ -476,9 +476,9 @@ pub struct UdpWatcher {
     home: HomeHandle,
 
     // See above for what these fields are
-    priv refcount: Refcount,
-    priv read_access: Access,
-    priv write_access: Access,
+    refcount: Refcount,
+    read_access: Access,
+    write_access: Access,
 }
 
 impl UdpWatcher {

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -26,19 +26,19 @@ use uvll;
 pub struct PipeWatcher {
     stream: StreamWatcher,
     home: HomeHandle,
-    priv defused: bool,
-    priv refcount: Refcount,
+    defused: bool,
+    refcount: Refcount,
 
     // see comments in TcpWatcher for why these exist
-    priv write_access: Access,
-    priv read_access: Access,
+    write_access: Access,
+    read_access: Access,
 }
 
 pub struct PipeListener {
     home: HomeHandle,
     pipe: *uvll::uv_pipe_t,
-    priv outgoing: Sender<Result<~RtioPipe:Send, IoError>>,
-    priv incoming: Receiver<Result<~RtioPipe:Send, IoError>>,
+    outgoing: Sender<Result<~RtioPipe:Send, IoError>>,
+    incoming: Receiver<Result<~RtioPipe:Send, IoError>>,
 }
 
 pub struct PipeAcceptor {

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -46,13 +46,13 @@ struct State {
 /// This structure is intended to be stored next to the event loop, and it is
 /// used to create new `Queue` structures.
 pub struct QueuePool {
-    priv queue: UnsafeArc<State>,
-    priv refcnt: uint,
+    queue: UnsafeArc<State>,
+    refcnt: uint,
 }
 
 /// This type is used to send messages back to the original event loop.
 pub struct Queue {
-    priv queue: UnsafeArc<State>,
+    queue: UnsafeArc<State>,
 }
 
 extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {

--- a/src/librustuv/rc.rs
+++ b/src/librustuv/rc.rs
@@ -19,7 +19,7 @@
 use std::sync::arc::UnsafeArc;
 
 pub struct Refcount {
-    priv rc: UnsafeArc<uint>,
+    rc: UnsafeArc<uint>,
 }
 
 impl Refcount {

--- a/src/librustuv/stream.rs
+++ b/src/librustuv/stream.rs
@@ -23,13 +23,13 @@ use uvll;
 // uv_stream_t instance, and all I/O operations assume that it's already located
 // on the appropriate scheduler.
 pub struct StreamWatcher {
-    handle: *uvll::uv_stream_t,
+    pub handle: *uvll::uv_stream_t,
 
     // Cache the last used uv_write_t so we don't have to allocate a new one on
     // every call to uv_write(). Ideally this would be a stack-allocated
     // structure, but currently we don't have mappings for all the structures
     // defined in libuv, so we're foced to malloc this.
-    priv last_write_req: Option<Request>,
+    last_write_req: Option<Request>,
 }
 
 struct ReadContext {

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -46,7 +46,7 @@ use uvll;
 
 // Obviously an Event Loop is always home.
 pub struct UvEventLoop {
-    priv uvio: UvIoFactory
+    uvio: UvIoFactory
 }
 
 impl UvEventLoop {
@@ -124,8 +124,8 @@ fn test_callback_run_once() {
 }
 
 pub struct UvIoFactory {
-    loop_: Loop,
-    priv handle_pool: Option<~QueuePool>,
+    pub loop_: Loop,
+    handle_pool: Option<~QueuePool>,
 }
 
 impl UvIoFactory {

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -100,15 +100,15 @@ pub type uv_buf_len_t = libc::c_ulong;
 // see libuv/include/uv-unix.h
 #[cfg(unix)]
 pub struct uv_buf_t {
-    base: *u8,
-    len: uv_buf_len_t,
+    pub base: *u8,
+    pub len: uv_buf_len_t,
 }
 
 // see libuv/include/uv-win.h
 #[cfg(windows)]
 pub struct uv_buf_t {
-    len: uv_buf_len_t,
-    base: *u8,
+    pub len: uv_buf_len_t,
+    pub base: *u8,
 }
 
 #[repr(C)]
@@ -119,23 +119,23 @@ pub enum uv_run_mode {
 }
 
 pub struct uv_process_options_t {
-    exit_cb: uv_exit_cb,
-    file: *libc::c_char,
-    args: **libc::c_char,
-    env: **libc::c_char,
-    cwd: *libc::c_char,
-    flags: libc::c_uint,
-    stdio_count: libc::c_int,
-    stdio: *uv_stdio_container_t,
-    uid: uv_uid_t,
-    gid: uv_gid_t,
+    pub exit_cb: uv_exit_cb,
+    pub file: *libc::c_char,
+    pub args: **libc::c_char,
+    pub env: **libc::c_char,
+    pub cwd: *libc::c_char,
+    pub flags: libc::c_uint,
+    pub stdio_count: libc::c_int,
+    pub stdio: *uv_stdio_container_t,
+    pub uid: uv_uid_t,
+    pub gid: uv_gid_t,
 }
 
 // These fields are private because they must be interfaced with through the
 // functions below.
 pub struct uv_stdio_container_t {
-    priv flags: libc::c_int,
-    priv stream: *uv_stream_t,
+    flags: libc::c_int,
+    stream: *uv_stream_t,
 }
 
 pub type uv_handle_t = c_void;
@@ -160,27 +160,27 @@ pub type uv_signal_t = c_void;
 pub type uv_shutdown_t = c_void;
 
 pub struct uv_timespec_t {
-    tv_sec: libc::c_long,
-    tv_nsec: libc::c_long
+    pub tv_sec: libc::c_long,
+    pub tv_nsec: libc::c_long
 }
 
 pub struct uv_stat_t {
-    st_dev: libc::uint64_t,
-    st_mode: libc::uint64_t,
-    st_nlink: libc::uint64_t,
-    st_uid: libc::uint64_t,
-    st_gid: libc::uint64_t,
-    st_rdev: libc::uint64_t,
-    st_ino: libc::uint64_t,
-    st_size: libc::uint64_t,
-    st_blksize: libc::uint64_t,
-    st_blocks: libc::uint64_t,
-    st_flags: libc::uint64_t,
-    st_gen: libc::uint64_t,
-    st_atim: uv_timespec_t,
-    st_mtim: uv_timespec_t,
-    st_ctim: uv_timespec_t,
-    st_birthtim: uv_timespec_t
+    pub st_dev: libc::uint64_t,
+    pub st_mode: libc::uint64_t,
+    pub st_nlink: libc::uint64_t,
+    pub st_uid: libc::uint64_t,
+    pub st_gid: libc::uint64_t,
+    pub st_rdev: libc::uint64_t,
+    pub st_ino: libc::uint64_t,
+    pub st_size: libc::uint64_t,
+    pub st_blksize: libc::uint64_t,
+    pub st_blocks: libc::uint64_t,
+    pub st_flags: libc::uint64_t,
+    pub st_gen: libc::uint64_t,
+    pub st_atim: uv_timespec_t,
+    pub st_mtim: uv_timespec_t,
+    pub st_ctim: uv_timespec_t,
+    pub st_birthtim: uv_timespec_t
 }
 
 impl uv_stat_t {

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -20,9 +20,9 @@ use std::str;
 // Common data structures
 #[deriving(Clone)]
 pub struct Doc<'a> {
-    data: &'a [u8],
-    start: uint,
-    end: uint,
+    pub data: &'a [u8],
+    pub start: uint,
+    pub end: uint,
 }
 
 impl<'doc> Doc<'doc> {
@@ -40,8 +40,8 @@ impl<'doc> Doc<'doc> {
 }
 
 pub struct TaggedDoc<'a> {
-    priv tag: uint,
-    doc: Doc<'a>,
+    tag: uint,
+    pub doc: Doc<'a>,
 }
 
 pub enum EbmlEncoderTag {
@@ -117,8 +117,8 @@ pub mod reader {
     )
 
     pub struct Res {
-        val: uint,
-        next: uint
+        pub val: uint,
+        pub next: uint
     }
 
     #[inline(never)]
@@ -291,8 +291,8 @@ pub mod reader {
     pub fn doc_as_i64(d: Doc) -> i64 { doc_as_u64(d) as i64 }
 
     pub struct Decoder<'a> {
-        priv parent: Doc<'a>,
-        priv pos: uint,
+        parent: Doc<'a>,
+        pos: uint,
     }
 
     pub fn Decoder<'a>(d: Doc<'a>) -> Decoder<'a> {
@@ -635,8 +635,8 @@ pub mod writer {
 
     // ebml writing
     pub struct Encoder<'a, W> {
-        writer: &'a mut W,
-        priv size_positions: ~[uint],
+        pub writer: &'a mut W,
+        size_positions: ~[uint],
     }
 
     fn write_sized_vuint<W: Writer>(w: &mut W, n: uint, size: uint) -> EncodeResult {

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -298,7 +298,7 @@ fn spaces(n: uint) -> ~str {
 
 /// A structure for implementing serialization to JSON.
 pub struct Encoder<'a> {
-    priv wr: &'a mut io::Writer,
+    wr: &'a mut io::Writer,
 }
 
 impl<'a> Encoder<'a> {
@@ -504,8 +504,8 @@ impl<'a> ::Encoder<io::IoError> for Encoder<'a> {
 /// Another encoder for JSON, but prints out human-readable JSON instead of
 /// compact data
 pub struct PrettyEncoder<'a> {
-    priv wr: &'a mut io::Writer,
-    priv indent: uint,
+    wr: &'a mut io::Writer,
+    indent: uint,
 }
 
 impl<'a> PrettyEncoder<'a> {
@@ -899,10 +899,10 @@ impl Json {
 }
 
 pub struct Parser<T> {
-    priv rdr: T,
-    priv ch: Option<char>,
-    priv line: uint,
-    priv col: uint,
+    rdr: T,
+    ch: Option<char>,
+    line: uint,
+    col: uint,
 }
 
 impl<T: Iterator<char>> Parser<T> {
@@ -1298,7 +1298,7 @@ pub fn from_str(s: &str) -> DecodeResult<Json> {
 
 /// A structure to decode JSON to values in rust.
 pub struct Decoder {
-    priv stack: ~[Json],
+    stack: ~[Json],
 }
 
 impl Decoder {

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -25,7 +25,7 @@ use option::{Option, Some, None};
 
 /// Datatype to hold one ascii character. It wraps a `u8`, with the highest bit always zero.
 #[deriving(Clone, Eq, Ord, TotalOrd, TotalEq, Hash)]
-pub struct Ascii { priv chr: u8 }
+pub struct Ascii { chr: u8 }
 
 impl Ascii {
     /// Converts an ascii character into a `u8`.

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -86,8 +86,8 @@ use raw::Slice;
 /// This structure wraps a `*libc::c_char`, and will automatically free the
 /// memory it is pointing to when it goes out of scope.
 pub struct CString {
-    priv buf: *libc::c_char,
-    priv owns_buffer_: bool,
+    buf: *libc::c_char,
+    owns_buffer_: bool,
 }
 
 impl Clone for CString {
@@ -373,8 +373,8 @@ fn check_for_null(v: &[u8], buf: *mut libc::c_char) {
 ///
 /// Use with the `std::iter` module.
 pub struct CChars<'a> {
-    priv ptr: *libc::c_char,
-    priv marker: marker::ContravariantLifetime<'a>,
+    ptr: *libc::c_char,
+    marker: marker::ContravariantLifetime<'a>,
 }
 
 impl<'a> Iterator<libc::c_char> for CChars<'a> {

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -44,9 +44,9 @@ use raw;
 
 /// The type representing a foreign chunk of memory
 pub struct CVec<T> {
-    priv base: *mut T,
-    priv len: uint,
-    priv dtor: Option<proc:Send()>,
+    base: *mut T,
+    len: uint,
+    dtor: Option<proc:Send()>,
 }
 
 #[unsafe_destructor]

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -21,8 +21,8 @@ use ty::Unsafe;
 
 /// A mutable memory location that admits only `Copy` data.
 pub struct Cell<T> {
-    priv value: Unsafe<T>,
-    priv noshare: marker::NoShare,
+    value: Unsafe<T>,
+    noshare: marker::NoShare,
 }
 
 impl<T:Copy> Cell<T> {
@@ -69,10 +69,10 @@ impl<T: fmt::Show> fmt::Show for Cell<T> {
 
 /// A mutable memory location with dynamically checked borrow rules
 pub struct RefCell<T> {
-    priv value: Unsafe<T>,
-    priv borrow: BorrowFlag,
-    priv nocopy: marker::NoCopy,
-    priv noshare: marker::NoShare,
+    value: Unsafe<T>,
+    borrow: BorrowFlag,
+    nocopy: marker::NoCopy,
+    noshare: marker::NoShare,
 }
 
 // Values [1, MAX-1] represent the number of `Ref` active
@@ -202,7 +202,7 @@ impl<T: Eq> Eq for RefCell<T> {
 
 /// Wraps a borrowed reference to a value in a `RefCell` box.
 pub struct Ref<'b, T> {
-    priv parent: &'b RefCell<T>
+    parent: &'b RefCell<T>
 }
 
 #[unsafe_destructor]
@@ -222,7 +222,7 @@ impl<'b, T> Deref<T> for Ref<'b, T> {
 
 /// Wraps a mutable borrowed reference to a value in a `RefCell` box.
 pub struct RefMut<'b, T> {
-    priv parent: &'b mut RefCell<T>
+    parent: &'b mut RefCell<T>
 }
 
 #[unsafe_destructor]

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -289,34 +289,34 @@ static RESCHED_FREQ: int = 256;
 /// The receiving-half of Rust's channel type. This half can only be owned by
 /// one task
 pub struct Receiver<T> {
-    priv inner: Flavor<T>,
-    priv receives: Cell<uint>,
+    inner: Flavor<T>,
+    receives: Cell<uint>,
     // can't share in an arc
-    priv marker: marker::NoShare,
+    marker: marker::NoShare,
 }
 
 /// An iterator over messages on a receiver, this iterator will block
 /// whenever `next` is called, waiting for a new message, and `None` will be
 /// returned when the corresponding channel has hung up.
 pub struct Messages<'a, T> {
-    priv rx: &'a Receiver<T>
+    rx: &'a Receiver<T>
 }
 
 /// The sending-half of Rust's asynchronous channel type. This half can only be
 /// owned by one task, but it can be cloned to send to other tasks.
 pub struct Sender<T> {
-    priv inner: Flavor<T>,
-    priv sends: Cell<uint>,
+    inner: Flavor<T>,
+    sends: Cell<uint>,
     // can't share in an arc
-    priv marker: marker::NoShare,
+    marker: marker::NoShare,
 }
 
 /// The sending-half of Rust's synchronous channel type. This half can only be
 /// owned by one task, but it can be cloned to send to other tasks.
 pub struct SyncSender<T> {
-    priv inner: UnsafeArc<sync::Packet<T>>,
+    inner: UnsafeArc<sync::Packet<T>>,
     // can't share in an arc
-    priv marker: marker::NoShare,
+    marker: marker::NoShare,
 }
 
 /// This enumeration is the list of the possible reasons that try_recv could not

--- a/src/libstd/comm/select.rs
+++ b/src/libstd/comm/select.rs
@@ -62,10 +62,10 @@ use uint;
 /// The "receiver set" of the select interface. This structure is used to manage
 /// a set of receivers which are being selected over.
 pub struct Select {
-    priv head: *mut Handle<'static, ()>,
-    priv tail: *mut Handle<'static, ()>,
-    priv next_id: Cell<uint>,
-    priv marker1: marker::NoSend,
+    head: *mut Handle<'static, ()>,
+    tail: *mut Handle<'static, ()>,
+    next_id: Cell<uint>,
+    marker1: marker::NoSend,
 }
 
 /// A handle to a receiver which is currently a member of a `Select` set of
@@ -74,16 +74,16 @@ pub struct Select {
 pub struct Handle<'rx, T> {
     /// The ID of this handle, used to compare against the return value of
     /// `Select::wait()`
-    priv id: uint,
-    priv selector: &'rx Select,
-    priv next: *mut Handle<'static, ()>,
-    priv prev: *mut Handle<'static, ()>,
-    priv added: bool,
-    priv packet: &'rx Packet,
+    id: uint,
+    selector: &'rx Select,
+    next: *mut Handle<'static, ()>,
+    prev: *mut Handle<'static, ()>,
+    added: bool,
+    packet: &'rx Packet,
 
     // due to our fun transmutes, we be sure to place this at the end. (nothing
     // previous relies on T)
-    priv rx: &'rx Receiver<T>,
+    rx: &'rx Receiver<T>,
 }
 
 struct Packets { cur: *mut Handle<'static, ()> }

--- a/src/libstd/fmt/mod.rs
+++ b/src/libstd/fmt/mod.rs
@@ -508,20 +508,20 @@ pub type Result = io::IoResult<()>;
 /// traits.
 pub struct Formatter<'a> {
     /// Flags for formatting (packed version of rt::Flag)
-    flags: uint,
+    pub flags: uint,
     /// Character used as 'fill' whenever there is alignment
-    fill: char,
+    pub fill: char,
     /// Boolean indication of whether the output should be left-aligned
-    align: parse::Alignment,
+    pub align: parse::Alignment,
     /// Optionally specified integer width that the output should be
-    width: Option<uint>,
+    pub width: Option<uint>,
     /// Optionally specified precision for numeric types
-    precision: Option<uint>,
+    pub precision: Option<uint>,
 
     /// Output buffer.
-    buf: &'a mut io::Writer,
-    priv curarg: slice::Items<'a, Argument<'a>>,
-    priv args: &'a [Argument<'a>],
+    pub buf: &'a mut io::Writer,
+    curarg: slice::Items<'a, Argument<'a>>,
+    args: &'a [Argument<'a>],
 }
 
 /// This struct represents the generic "argument" which is taken by the Xprintf
@@ -529,8 +529,8 @@ pub struct Formatter<'a> {
 /// compile time it is ensured that the function and the value have the correct
 /// types, and then this struct is used to canonicalize arguments to one type.
 pub struct Argument<'a> {
-    priv formatter: extern "Rust" fn(&any::Void, &mut Formatter) -> Result,
-    priv value: &'a any::Void,
+    formatter: extern "Rust" fn(&any::Void, &mut Formatter) -> Result,
+    value: &'a any::Void,
 }
 
 impl<'a> Arguments<'a> {
@@ -555,8 +555,8 @@ impl<'a> Arguments<'a> {
 /// string at compile-time so usage of the `write` and `format` functions can
 /// be safely performed.
 pub struct Arguments<'a> {
-    priv fmt: &'a [rt::Piece<'a>],
-    priv args: &'a [Argument<'a>],
+    fmt: &'a [rt::Piece<'a>],
+    args: &'a [Argument<'a>],
 }
 
 /// When a format is not otherwise specified, types are formatted by ascribing

--- a/src/libstd/fmt/num.rs
+++ b/src/libstd/fmt/num.rs
@@ -108,7 +108,7 @@ radix!(UpperHex, 16, "0x", x @  0 .. 9 => '0' as u8 + x,
 /// A radix with in the range of `2..36`.
 #[deriving(Clone, Eq)]
 pub struct Radix {
-    priv base: u8,
+    base: u8,
 }
 
 impl Radix {

--- a/src/libstd/fmt/parse.rs
+++ b/src/libstd/fmt/parse.rs
@@ -37,30 +37,30 @@ pub enum Piece<'a> {
 #[deriving(Eq)]
 pub struct Argument<'a> {
     /// Where to find this argument
-    position: Position<'a>,
+    pub position: Position<'a>,
     /// How to format the argument
-    format: FormatSpec<'a>,
+    pub format: FormatSpec<'a>,
     /// If not `None`, what method to invoke on the argument
-    method: Option<~Method<'a>>
+    pub method: Option<~Method<'a>>
 }
 
 /// Specification for the formatting of an argument in the format string.
 #[deriving(Eq)]
 pub struct FormatSpec<'a> {
     /// Optionally specified character to fill alignment with
-    fill: Option<char>,
+    pub fill: Option<char>,
     /// Optionally specified alignment
-    align: Alignment,
+    pub align: Alignment,
     /// Packed version of various flags provided
-    flags: uint,
+    pub flags: uint,
     /// The integer precision to use
-    precision: Count<'a>,
+    pub precision: Count<'a>,
     /// The string width requested for the resulting format
-    width: Count<'a>,
+    pub width: Count<'a>,
     /// The descriptor string representing the name of the format desired for
     /// this argument, this can be empty or any number of characters, although
     /// it is required to be one word.
-    ty: &'a str
+    pub ty: &'a str
 }
 
 /// Enum describing where an argument for a format can be located.
@@ -154,9 +154,9 @@ pub enum PluralSelector {
 pub struct PluralArm<'a> {
     /// A selector can either be specified by a keyword or with an integer
     /// literal.
-    selector: PluralSelector,
+    pub selector: PluralSelector,
     /// Array of pieces which are the format of this arm
-    result: ~[Piece<'a>],
+    pub result: ~[Piece<'a>],
 }
 
 /// Enum of the 5 CLDR plural keywords. There is one more, "other", but that
@@ -182,9 +182,9 @@ pub enum PluralKeyword {
 #[deriving(Eq)]
 pub struct SelectArm<'a> {
     /// String selector which guards this arm
-    selector: &'a str,
+    pub selector: &'a str,
     /// Array of pieces which are the format of this arm
-    result: ~[Piece<'a>],
+    pub result: ~[Piece<'a>],
 }
 
 /// The parser structure for interpreting the input format string. This is
@@ -194,11 +194,11 @@ pub struct SelectArm<'a> {
 /// This is a recursive-descent parser for the sake of simplicity, and if
 /// necessary there's probably lots of room for improvement performance-wise.
 pub struct Parser<'a> {
-    priv input: &'a str,
-    priv cur: str::CharOffsets<'a>,
-    priv depth: uint,
+    input: &'a str,
+    cur: str::CharOffsets<'a>,
+    depth: uint,
     /// Error messages accumulated during parsing
-    errors: ~[~str],
+    pub errors: ~[~str],
 }
 
 impl<'a> Iterator<Piece<'a>> for Parser<'a> {

--- a/src/libstd/fmt/rt.rs
+++ b/src/libstd/fmt/rt.rs
@@ -28,17 +28,17 @@ pub enum Piece<'a> {
 }
 
 pub struct Argument<'a> {
-    position: Position,
-    format: FormatSpec,
-    method: Option<&'a Method<'a>>
+    pub position: Position,
+    pub format: FormatSpec,
+    pub method: Option<&'a Method<'a>>
 }
 
 pub struct FormatSpec {
-    fill: char,
-    align: parse::Alignment,
-    flags: uint,
-    precision: Count,
-    width: Count,
+    pub fill: char,
+    pub align: parse::Alignment,
+    pub flags: uint,
+    pub precision: Count,
+    pub width: Count,
 }
 
 pub enum Count {
@@ -60,11 +60,11 @@ pub enum PluralSelector {
 }
 
 pub struct PluralArm<'a> {
-    selector: PluralSelector,
-    result: &'a [Piece<'a>],
+    pub selector: PluralSelector,
+    pub result: &'a [Piece<'a>],
 }
 
 pub struct SelectArm<'a> {
-    selector: &'a str,
-    result: &'a [Piece<'a>],
+    pub selector: &'a str,
+    pub result: &'a [Piece<'a>],
 }

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -29,14 +29,14 @@ use managed;
                   task annihilation. For now, cycles need to be broken manually by using `Rc<T>` \
                   with a non-owning `Weak<T>` pointer. A tracing garbage collector is planned."]
 pub struct Gc<T> {
-    priv ptr: @T,
-    priv marker: marker::NoSend,
+    ptr: @T,
+    marker: marker::NoSend,
 }
 
 #[cfg(test)]
 pub struct Gc<T> {
-    priv ptr: @T,
-    priv marker: marker::NoSend,
+    ptr: @T,
+    marker: marker::NoSend,
 }
 
 impl<T: 'static> Gc<T> {

--- a/src/libstd/hash/sip.rs
+++ b/src/libstd/hash/sip.rs
@@ -36,15 +36,15 @@ use super::{Hash, Hasher};
 
 /// `SipState` computes a SipHash 2-4 hash over a stream of bytes.
 pub struct SipState {
-    priv k0: u64,
-    priv k1: u64,
-    priv length: uint, // how many bytes we've processed
-    priv v0: u64,      // hash state
-    priv v1: u64,
-    priv v2: u64,
-    priv v3: u64,
-    priv tail: [u8, ..8], // unprocessed bytes
-    priv ntail: uint,  // how many bytes in tail are valid
+    k0: u64,
+    k1: u64,
+    length: uint, // how many bytes we've processed
+    v0: u64,      // hash state
+    v1: u64,
+    v2: u64,
+    v3: u64,
+    tail: [u8, ..8], // unprocessed bytes
+    ntail: uint,  // how many bytes in tail are valid
 }
 
 // sadly, these macro definitions can't appear later,
@@ -231,8 +231,8 @@ impl Default for SipState {
 /// `SipHasher` computes the SipHash algorithm from a stream of bytes.
 #[deriving(Clone)]
 pub struct SipHasher {
-    priv k0: u64,
-    priv k1: u64,
+    k0: u64,
+    k1: u64,
 }
 
 impl SipHasher {

--- a/src/libstd/intrinsics.rs
+++ b/src/libstd/intrinsics.rs
@@ -53,19 +53,19 @@ pub type GlueFn = extern "Rust" fn(*i8);
 #[cfg(not(test))]
 pub struct TyDesc {
     // sizeof(T)
-    size: uint,
+    pub size: uint,
 
     // alignof(T)
-    align: uint,
+    pub align: uint,
 
     // Called when a value of type `T` is no longer needed
-    drop_glue: GlueFn,
+    pub drop_glue: GlueFn,
 
     // Called by reflection visitor to visit a value of type `T`
-    visit_glue: GlueFn,
+    pub visit_glue: GlueFn,
 
     // Name corresponding to the type
-    name: &'static str
+    pub name: &'static str,
 }
 
 #[lang="opaque"]
@@ -454,7 +454,7 @@ extern "rust-intrinsic" {
 #[deriving(Eq, Hash, Show, TotalEq)]
 #[cfg(not(test))]
 pub struct TypeId {
-    priv t: u64,
+    t: u64,
 }
 
 #[cfg(not(test))]

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -43,10 +43,10 @@ use vec::Vec;
 /// }
 /// ```
 pub struct BufferedReader<R> {
-    priv inner: R,
-    priv buf: Vec<u8>,
-    priv pos: uint,
-    priv cap: uint,
+    inner: R,
+    buf: Vec<u8>,
+    pos: uint,
+    cap: uint,
 }
 
 impl<R: Reader> BufferedReader<R> {
@@ -135,9 +135,9 @@ impl<R: Reader> Reader for BufferedReader<R> {
 /// writer.flush();
 /// ```
 pub struct BufferedWriter<W> {
-    priv inner: Option<W>,
-    priv buf: Vec<u8>,
-    priv pos: uint
+    inner: Option<W>,
+    buf: Vec<u8>,
+    pos: uint
 }
 
 impl<W: Writer> BufferedWriter<W> {
@@ -220,7 +220,7 @@ impl<W: Writer> Drop for BufferedWriter<W> {
 ///
 /// This writer will be flushed when it is dropped.
 pub struct LineBufferedWriter<W> {
-    priv inner: BufferedWriter<W>,
+    inner: BufferedWriter<W>,
 }
 
 impl<W: Writer> LineBufferedWriter<W> {
@@ -303,7 +303,7 @@ impl<W: Reader> Reader for InternalBufferedWriter<W> {
 /// }
 /// ```
 pub struct BufferedStream<S> {
-    priv inner: BufferedReader<InternalBufferedWriter<S>>
+    inner: BufferedReader<InternalBufferedWriter<S>>
 }
 
 impl<S: Stream> BufferedStream<S> {
@@ -391,7 +391,7 @@ mod test {
 
     /// A dummy reader intended at testing short-reads propagation.
     pub struct ShortReader {
-        priv lengths: ~[uint],
+        lengths: ~[uint],
     }
 
     impl Reader for ShortReader {

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -36,10 +36,10 @@ use slice::{bytes, CloneableVector, MutableVector, ImmutableVector};
 /// }
 /// ```
 pub struct ChanReader {
-    priv buf: Option<~[u8]>,  // A buffer of bytes received but not consumed.
-    priv pos: uint,           // How many of the buffered bytes have already be consumed.
-    priv rx: Receiver<~[u8]>,   // The rx to pull data from.
-    priv closed: bool,        // Whether the pipe this rx connects to has been closed.
+    buf: Option<~[u8]>,  // A buffer of bytes received but not consumed.
+    pos: uint,           // How many of the buffered bytes have already be consumed.
+    rx: Receiver<~[u8]>,   // The rx to pull data from.
+    closed: bool,        // Whether the pipe this rx connects to has been closed.
 }
 
 impl ChanReader {
@@ -98,7 +98,7 @@ impl Reader for ChanReader {
 /// writer.write("hello, world".as_bytes());
 /// ```
 pub struct ChanWriter {
-    priv tx: Sender<~[u8]>,
+    tx: Sender<~[u8]>,
 }
 
 impl ChanWriter {

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -38,7 +38,7 @@ use ptr::RawPtr;
 /// Any error other than `EndOfFile` that is produced by the underlying Reader
 /// is returned by the iterator and should be handled by the caller.
 pub struct Bytes<'r, T> {
-    priv reader: &'r mut T,
+    reader: &'r mut T,
 }
 
 impl<'r, R: Reader> Bytes<'r, R> {

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -78,9 +78,9 @@ use vec::Vec;
 /// configured at creation time, via the `FileAccess` parameter to
 /// `File::open_mode()`.
 pub struct File {
-    priv fd: ~RtioFileStream:Send,
-    priv path: Path,
-    priv last_nread: int,
+    fd: ~RtioFileStream:Send,
+    path: Path,
+    last_nread: int,
 }
 
 impl File {
@@ -498,7 +498,7 @@ pub fn walk_dir(path: &Path) -> IoResult<Directories> {
 
 /// An iterator which walks over a directory
 pub struct Directories {
-    priv stack: ~[Path],
+    stack: ~[Path],
 }
 
 impl Iterator<Path> for Directories {

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -52,8 +52,8 @@ fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> 
 /// assert_eq!(w.unwrap(), ~[0, 1, 2]);
 /// ```
 pub struct MemWriter {
-    priv buf: ~[u8],
-    priv pos: uint,
+    buf: ~[u8],
+    pos: uint,
 }
 
 impl MemWriter {
@@ -132,8 +132,8 @@ impl Seek for MemWriter {
 /// assert_eq!(r.read_to_end().unwrap(), ~[0, 1, 2]);
 /// ```
 pub struct MemReader {
-    priv buf: ~[u8],
-    priv pos: uint
+    buf: ~[u8],
+    pos: uint
 }
 
 impl MemReader {
@@ -219,8 +219,8 @@ impl Buffer for MemReader {
 /// assert!(buf == [0, 1, 2, 0]);
 /// ```
 pub struct BufWriter<'a> {
-    priv buf: &'a mut [u8],
-    priv pos: uint
+    buf: &'a mut [u8],
+    pos: uint
 }
 
 impl<'a> BufWriter<'a> {
@@ -275,8 +275,8 @@ impl<'a> Seek for BufWriter<'a> {
 /// assert_eq!(r.read_to_end().unwrap(), ~[0, 1, 2, 3]);
 /// ```
 pub struct BufReader<'a> {
-    priv buf: &'a [u8],
-    priv pos: uint
+    buf: &'a [u8],
+    pos: uint
 }
 
 impl<'a> BufReader<'a> {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -283,11 +283,11 @@ pub type IoResult<T> = Result<T, IoError>;
 pub struct IoError {
     /// An enumeration which can be matched against for determining the flavor
     /// of error.
-    kind: IoErrorKind,
+    pub kind: IoErrorKind,
     /// A human-readable description about the error
-    desc: &'static str,
+    pub desc: &'static str,
     /// Detailed information about this error, not always available
-    detail: Option<~str>
+    pub detail: Option<~str>
 }
 
 impl fmt::Show for IoError {
@@ -1023,7 +1023,7 @@ impl<T: Reader + Writer> Stream for T {}
 /// Any error other than `EndOfFile` that is produced by the underlying Reader
 /// is returned by the iterator and should be handled by the caller.
 pub struct Lines<'r, T> {
-    priv buffer: &'r mut T,
+    buffer: &'r mut T,
 }
 
 impl<'r, T: Buffer> Iterator<IoResult<~str>> for Lines<'r, T> {
@@ -1050,7 +1050,7 @@ impl<'r, T: Buffer> Iterator<IoResult<~str>> for Lines<'r, T> {
 /// Any error other than `EndOfFile` that is produced by the underlying Reader
 /// is returned by the iterator and should be handled by the caller.
 pub struct Chars<'r, T> {
-    priv buffer: &'r mut T
+    buffer: &'r mut T
 }
 
 impl<'r, T: Buffer> Iterator<IoResult<char>> for Chars<'r, T> {
@@ -1290,7 +1290,7 @@ pub trait Acceptor<T> {
 /// connection attempt was successful.  A successful connection will be wrapped
 /// in `Ok`. A failed connection is represented as an `Err`.
 pub struct IncomingConnections<'a, A> {
-    priv inc: &'a mut A,
+    inc: &'a mut A,
 }
 
 impl<'a, T, A: Acceptor<T>> Iterator<IoResult<T>> for IncomingConnections<'a, A> {
@@ -1389,13 +1389,13 @@ pub enum FileType {
 #[deriving(Hash)]
 pub struct FileStat {
     /// The path that this stat structure is describing
-    path: Path,
+    pub path: Path,
     /// The size of the file, in bytes
-    size: u64,
+    pub size: u64,
     /// The kind of file this path points to (directory, file, pipe, etc.)
-    kind: FileType,
+    pub kind: FileType,
     /// The file permissions currently on the file
-    perm: FilePermission,
+    pub perm: FilePermission,
 
     // FIXME(#10301): These time fields are pretty useless without an actual
     //                time representation, what are the milliseconds relative
@@ -1403,13 +1403,13 @@ pub struct FileStat {
 
     /// The time that the file was created at, in platform-dependent
     /// milliseconds
-    created: u64,
+    pub created: u64,
     /// The time that this file was last modified, in platform-dependent
     /// milliseconds
-    modified: u64,
+    pub modified: u64,
     /// The time that this file was last accessed, in platform-dependent
     /// milliseconds
-    accessed: u64,
+    pub accessed: u64,
 
     /// Information returned by stat() which is not guaranteed to be
     /// platform-independent. This information may be useful on some platforms,
@@ -1419,7 +1419,7 @@ pub struct FileStat {
     /// Usage of this field is discouraged, but if access is desired then the
     /// fields are located here.
     #[unstable]
-    unstable: UnstableFileStat,
+    pub unstable: UnstableFileStat,
 }
 
 /// This structure represents all of the possible information which can be
@@ -1430,25 +1430,25 @@ pub struct FileStat {
 #[deriving(Hash)]
 pub struct UnstableFileStat {
     /// The ID of the device containing the file.
-    device: u64,
+    pub device: u64,
     /// The file serial number.
-    inode: u64,
+    pub inode: u64,
     /// The device ID.
-    rdev: u64,
+    pub rdev: u64,
     /// The number of hard links to this file.
-    nlink: u64,
+    pub nlink: u64,
     /// The user ID of the file.
-    uid: u64,
+    pub uid: u64,
     /// The group ID of the file.
-    gid: u64,
+    pub gid: u64,
     /// The optimal block size for I/O.
-    blksize: u64,
+    pub blksize: u64,
     /// The blocks allocated for this file.
-    blocks: u64,
+    pub blocks: u64,
     /// User-defined flags for the file.
-    flags: u64,
+    pub flags: u64,
     /// The file generation number.
-    gen: u64,
+    pub gen: u64,
 }
 
 /// A set of permissions for a file or directory is represented by a set of

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -57,18 +57,18 @@ pub enum Protocol {
 /// For details on these fields, see their corresponding definitions via
 /// `man -s 3 getaddrinfo`
 pub struct Hint {
-    family: uint,
-    socktype: Option<SocketType>,
-    protocol: Option<Protocol>,
-    flags: uint,
+    pub family: uint,
+    pub socktype: Option<SocketType>,
+    pub protocol: Option<Protocol>,
+    pub flags: uint,
 }
 
 pub struct Info {
-    address: SocketAddr,
-    family: uint,
-    socktype: Option<SocketType>,
-    protocol: Option<Protocol>,
-    flags: uint,
+    pub address: SocketAddr,
+    pub family: uint,
+    pub socktype: Option<SocketType>,
+    pub protocol: Option<Protocol>,
+    pub flags: uint,
 }
 
 /// Easy name resolution. Given a hostname, returns the list of IP addresses for

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -58,8 +58,8 @@ impl fmt::Show for IpAddr {
 
 #[deriving(Eq, TotalEq, Clone, Hash)]
 pub struct SocketAddr {
-    ip: IpAddr,
-    port: Port,
+    pub ip: IpAddr,
+    pub port: Port,
 }
 
 impl fmt::Show for SocketAddr {

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -17,8 +17,6 @@
 //! A TCP connection implements the `Reader` and `Writer` traits, while the TCP
 //! listener (socket server) implements the `Listener` and `Acceptor` traits.
 
-#![deny(missing_doc)]
-
 use clone::Clone;
 use io::IoResult;
 use io::net::ip::SocketAddr;
@@ -46,7 +44,7 @@ use rt::rtio::{RtioTcpAcceptor, RtioTcpStream};
 /// drop(stream); // close the connection
 /// ```
 pub struct TcpStream {
-    priv obj: ~RtioTcpStream:Send
+    obj: ~RtioTcpStream:Send
 }
 
 impl TcpStream {
@@ -128,7 +126,7 @@ impl Writer for TcpStream {
 /// # }
 /// ```
 pub struct TcpListener {
-    priv obj: ~RtioTcpListener:Send
+    obj: ~RtioTcpListener:Send
 }
 
 impl TcpListener {
@@ -161,7 +159,7 @@ impl Listener<TcpStream, TcpAcceptor> for TcpListener {
 /// a `TcpListener`'s `listen` method, and this object can be used to accept new
 /// `TcpStream` instances.
 pub struct TcpAcceptor {
-    priv obj: ~RtioTcpAcceptor:Send
+    obj: ~RtioTcpAcceptor:Send
 }
 
 impl Acceptor<TcpStream> for TcpAcceptor {

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -54,7 +54,7 @@ use rt::rtio::{RtioSocket, RtioUdpSocket, IoFactory, LocalIo};
 /// drop(socket); // close the socket
 /// ```
 pub struct UdpSocket {
-    priv obj: ~RtioUdpSocket:Send
+    obj: ~RtioUdpSocket:Send
 }
 
 impl UdpSocket {
@@ -115,8 +115,8 @@ impl Clone for UdpSocket {
 /// A type that allows convenient usage of a UDP stream connected to one
 /// address via the `Reader` and `Writer` traits.
 pub struct UdpStream {
-    priv socket: UdpSocket,
-    priv connected_to: SocketAddr
+    socket: UdpSocket,
+    connected_to: SocketAddr
 }
 
 impl UdpStream {

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -36,7 +36,7 @@ use rt::rtio::{RtioUnixAcceptor, RtioPipe};
 
 /// A stream which communicates over a named pipe.
 pub struct UnixStream {
-    priv obj: PipeStream,
+    obj: PipeStream,
 }
 
 impl UnixStream {
@@ -83,7 +83,7 @@ impl Writer for UnixStream {
 /// A value that can listen for incoming named pipe connection requests.
 pub struct UnixListener {
     /// The internal, opaque runtime Unix listener.
-    priv obj: ~RtioUnixListener:Send,
+    obj: ~RtioUnixListener:Send,
 }
 
 impl UnixListener {
@@ -125,7 +125,7 @@ impl Listener<UnixStream, UnixAcceptor> for UnixListener {
 /// A value that can accept named pipe connections, returned from `listen()`.
 pub struct UnixAcceptor {
     /// The internal, opaque runtime Unix acceptor.
-    priv obj: ~RtioUnixAcceptor:Send,
+    obj: ~RtioUnixAcceptor:Send,
 }
 
 impl Acceptor<UnixStream> for UnixAcceptor {

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -23,7 +23,7 @@ use rt::rtio::{RtioPipe, LocalIo};
 /// A synchronous, in-memory pipe.
 pub struct PipeStream {
     /// The internal, opaque runtime pipe object.
-    priv obj: ~RtioPipe:Send,
+    obj: ~RtioPipe:Send,
 }
 
 impl PipeStream {

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -10,8 +10,6 @@
 
 //! Bindings for executing child processes
 
-#![deny(missing_doc)]
-
 use prelude::*;
 
 use fmt;
@@ -53,23 +51,23 @@ use rt::rtio::{RtioProcess, IoFactory, LocalIo};
 /// assert!(child.wait().success());
 /// ```
 pub struct Process {
-    priv handle: ~RtioProcess:Send,
+    handle: ~RtioProcess:Send,
 
     /// Handle to the child's stdin, if the `stdin` field of this process's
     /// `ProcessConfig` was `CreatePipe`. By default, this handle is `Some`.
-    stdin: Option<io::PipeStream>,
+    pub stdin: Option<io::PipeStream>,
 
     /// Handle to the child's stdout, if the `stdout` field of this process's
     /// `ProcessConfig` was `CreatePipe`. By default, this handle is `Some`.
-    stdout: Option<io::PipeStream>,
+    pub stdout: Option<io::PipeStream>,
 
     /// Handle to the child's stderr, if the `stderr` field of this process's
     /// `ProcessConfig` was `CreatePipe`. By default, this handle is `Some`.
-    stderr: Option<io::PipeStream>,
+    pub stderr: Option<io::PipeStream>,
 
     /// Extra I/O handles as configured by the original `ProcessConfig` when
     /// this process was created. This is by default empty.
-    extra_io: ~[Option<io::PipeStream>],
+    pub extra_io: ~[Option<io::PipeStream>],
 }
 
 /// This configuration describes how a new process should be spawned. A blank
@@ -88,33 +86,33 @@ pub struct Process {
 /// ```
 pub struct ProcessConfig<'a> {
     /// Path to the program to run
-    program: &'a str,
+    pub program: &'a str,
 
     /// Arguments to pass to the program (doesn't include the program itself)
-    args: &'a [~str],
+    pub args: &'a [~str],
 
     /// Optional environment to specify for the program. If this is None, then
     /// it will inherit the current process's environment.
-    env: Option<&'a [(~str, ~str)]>,
+    pub env: Option<&'a [(~str, ~str)]>,
 
     /// Optional working directory for the new process. If this is None, then
     /// the current directory of the running process is inherited.
-    cwd: Option<&'a Path>,
+    pub cwd: Option<&'a Path>,
 
     /// Configuration for the child process's stdin handle (file descriptor 0).
     /// This field defaults to `CreatePipe(true, false)` so the input can be
     /// written to.
-    stdin: StdioContainer,
+    pub stdin: StdioContainer,
 
     /// Configuration for the child process's stdout handle (file descriptor 1).
     /// This field defaults to `CreatePipe(false, true)` so the output can be
     /// collected.
-    stdout: StdioContainer,
+    pub stdout: StdioContainer,
 
     /// Configuration for the child process's stdout handle (file descriptor 2).
     /// This field defaults to `CreatePipe(false, true)` so the output can be
     /// collected.
-    stderr: StdioContainer,
+    pub stderr: StdioContainer,
 
     /// Any number of streams/file descriptors/pipes may be attached to this
     /// process. This list enumerates the file descriptors and such for the
@@ -122,31 +120,31 @@ pub struct ProcessConfig<'a> {
     /// 3 and go to the length of this array. The first three file descriptors
     /// (stdin/stdout/stderr) are configured with the `stdin`, `stdout`, and
     /// `stderr` fields.
-    extra_io: &'a [StdioContainer],
+    pub extra_io: &'a [StdioContainer],
 
     /// Sets the child process's user id. This translates to a `setuid` call in
     /// the child process. Setting this value on windows will cause the spawn to
     /// fail. Failure in the `setuid` call on unix will also cause the spawn to
     /// fail.
-    uid: Option<uint>,
+    pub uid: Option<uint>,
 
     /// Similar to `uid`, but sets the group id of the child process. This has
     /// the same semantics as the `uid` field.
-    gid: Option<uint>,
+    pub gid: Option<uint>,
 
     /// If true, the child process is spawned in a detached state. On unix, this
     /// means that the child is the leader of a new process group.
-    detach: bool,
+    pub detach: bool,
 }
 
 /// The output of a finished process.
 pub struct ProcessOutput {
     /// The status (exit code) of the process.
-    status: ProcessExit,
+    pub status: ProcessExit,
     /// The data that the process wrote to stdout.
-    output: ~[u8],
+    pub output: ~[u8],
     /// The data that the process wrote to stderr.
-    error: ~[u8],
+    pub error: ~[u8],
 }
 
 /// Describes what to do with a standard io stream for a child process.

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -81,15 +81,15 @@ pub enum Signum {
 /// ```
 pub struct Listener {
     /// A map from signums to handles to keep the handles in memory
-    priv handles: ~[(Signum, ~RtioSignal)],
+    handles: ~[(Signum, ~RtioSignal)],
     /// This is where all the handles send signums, which are received by
     /// the clients from the receiver.
-    priv tx: Sender<Signum>,
+    tx: Sender<Signum>,
 
     /// Clients of Listener can `recv()` on this receiver. This is exposed to
     /// allow selection over it as well as manipulation of the receiver
     /// directly.
-    rx: Receiver<Signum>,
+    pub rx: Receiver<Signum>,
 }
 
 impl Listener {

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -293,7 +293,7 @@ pub fn println_args(fmt: &fmt::Arguments) {
 
 /// Representation of a reader of a standard input stream
 pub struct StdReader {
-    priv inner: StdSource
+    inner: StdSource
 }
 
 impl Reader for StdReader {
@@ -322,7 +322,7 @@ impl Reader for StdReader {
 
 /// Representation of a writer to a standard output stream
 pub struct StdWriter {
-    priv inner: StdSource
+    inner: StdSource
 }
 
 impl StdWriter {

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -24,7 +24,7 @@ use sync::atomics;
 /// A wrapper for a path to temporary directory implementing automatic
 /// scope-based deletion.
 pub struct TempDir {
-    priv path: Option<Path>
+    path: Option<Path>
 }
 
 impl TempDir {

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -63,7 +63,7 @@ use rt::rtio::{IoFactory, LocalIo, RtioTimer};
 /// # }
 /// ```
 pub struct Timer {
-    priv obj: ~RtioTimer:Send,
+    obj: ~RtioTimer:Send,
 }
 
 /// Sleep the current task for `msecs` milliseconds.

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -17,8 +17,8 @@ use slice::bytes::MutableByteVector;
 
 /// Wraps a `Reader`, limiting the number of bytes that can be read from it.
 pub struct LimitReader<R> {
-    priv limit: uint,
-    priv inner: R
+    limit: uint,
+    inner: R
 }
 
 impl<R: Reader> LimitReader<R> {
@@ -85,7 +85,7 @@ impl Reader for NullReader {
 
 /// A `Writer` which multiplexes writes to a set of `Writers`.
 pub struct MultiWriter {
-    priv writers: ~[~Writer]
+    writers: ~[~Writer]
 }
 
 impl MultiWriter {
@@ -118,8 +118,8 @@ impl Writer for MultiWriter {
 /// A `Reader` which chains input from multiple `Readers`, reading each to
 /// completion before moving onto the next.
 pub struct ChainedReader<I, R> {
-    priv readers: I,
-    priv cur_reader: Option<R>,
+    readers: I,
+    cur_reader: Option<R>,
 }
 
 impl<R: Reader, I: Iterator<R>> ChainedReader<I, R> {
@@ -156,8 +156,8 @@ impl<R: Reader, I: Iterator<R>> Reader for ChainedReader<I, R> {
 /// A `Reader` which forwards input from another `Reader`, passing it along to
 /// a `Writer` as well. Similar to the `tee(1)` command.
 pub struct TeeReader<R, W> {
-    priv reader: R,
-    priv writer: W
+    reader: R,
+    writer: W,
 }
 
 impl<R: Reader, W: Writer> TeeReader<R, W> {

--- a/src/libstd/iter.rs
+++ b/src/libstd/iter.rs
@@ -751,7 +751,7 @@ impl<A, B, T: ExactSize<A>, U: ExactSize<B>> ExactSize<(A, B)> for Zip<T, U> {}
 /// An double-ended iterator with the direction inverted
 #[deriving(Clone)]
 pub struct Rev<T> {
-    priv iter: T
+    iter: T
 }
 
 impl<A, T: DoubleEndedIterator<A>> Iterator<A> for Rev<T> {
@@ -778,7 +778,7 @@ impl<A, T: DoubleEndedIterator<A> + RandomAccessIterator<A>> RandomAccessIterato
 
 /// A mutable reference to an iterator
 pub struct ByRef<'a, T> {
-    priv iter: &'a mut T
+    iter: &'a mut T
 }
 
 impl<'a, A, T: Iterator<A>> Iterator<A> for ByRef<'a, T> {
@@ -1036,8 +1036,8 @@ impl<A, T: Clone + Iterator<A>> CloneableIterator for T {
 /// An iterator that repeats endlessly
 #[deriving(Clone)]
 pub struct Cycle<T> {
-    priv orig: T,
-    priv iter: T,
+    orig: T,
+    iter: T,
 }
 
 impl<A, T: Clone + Iterator<A>> Iterator<A> for Cycle<T> {
@@ -1087,9 +1087,9 @@ impl<A, T: Clone + RandomAccessIterator<A>> RandomAccessIterator<A> for Cycle<T>
 /// An iterator which strings two iterators together
 #[deriving(Clone)]
 pub struct Chain<T, U> {
-    priv a: T,
-    priv b: U,
-    priv flag: bool
+    a: T,
+    b: U,
+    flag: bool
 }
 
 impl<A, T: Iterator<A>, U: Iterator<A>> Iterator<A> for Chain<T, U> {
@@ -1156,8 +1156,8 @@ for Chain<T, U> {
 /// An iterator which iterates two other iterators simultaneously
 #[deriving(Clone)]
 pub struct Zip<T, U> {
-    priv a: T,
-    priv b: U
+    a: T,
+    b: U
 }
 
 impl<A, B, T: Iterator<A>, U: Iterator<B>> Iterator<(A, B)> for Zip<T, U> {
@@ -1234,8 +1234,8 @@ RandomAccessIterator<(A, B)> for Zip<T, U> {
 
 /// An iterator which maps the values of `iter` with `f`
 pub struct Map<'a, A, B, T> {
-    priv iter: T,
-    priv f: 'a |A| -> B
+    iter: T,
+    f: 'a |A| -> B
 }
 
 impl<'a, A, B, T> Map<'a, A, B, T> {
@@ -1283,8 +1283,8 @@ impl<'a, A, B, T: RandomAccessIterator<A>> RandomAccessIterator<B> for Map<'a, A
 
 /// An iterator which filters the elements of `iter` with `predicate`
 pub struct Filter<'a, A, T> {
-    priv iter: T,
-    priv predicate: 'a |&A| -> bool
+    iter: T,
+    predicate: 'a |&A| -> bool
 }
 
 impl<'a, A, T: Iterator<A>> Iterator<A> for Filter<'a, A, T> {
@@ -1327,8 +1327,8 @@ impl<'a, A, T: DoubleEndedIterator<A>> DoubleEndedIterator<A> for Filter<'a, A, 
 
 /// An iterator which uses `f` to both filter and map elements from `iter`
 pub struct FilterMap<'a, A, B, T> {
-    priv iter: T,
-    priv f: 'a |A| -> Option<B>
+    iter: T,
+    f: 'a |A| -> Option<B>
 }
 
 impl<'a, A, B, T: Iterator<A>> Iterator<B> for FilterMap<'a, A, B, T> {
@@ -1371,8 +1371,8 @@ for FilterMap<'a, A, B, T> {
 /// An iterator which yields the current count and the element during iteration
 #[deriving(Clone)]
 pub struct Enumerate<T> {
-    priv iter: T,
-    priv count: uint
+    iter: T,
+    count: uint
 }
 
 impl<A, T: Iterator<A>> Iterator<(uint, A)> for Enumerate<T> {
@@ -1425,8 +1425,8 @@ impl<A, T: RandomAccessIterator<A>> RandomAccessIterator<(uint, A)> for Enumerat
 
 /// An iterator with a `peek()` that returns an optional reference to the next element.
 pub struct Peekable<A, T> {
-    priv iter: T,
-    priv peeked: Option<A>,
+    iter: T,
+    peeked: Option<A>,
 }
 
 impl<A, T: Iterator<A>> Iterator<A> for Peekable<A, T> {
@@ -1475,9 +1475,9 @@ impl<'a, A, T: Iterator<A>> Peekable<A, T> {
 
 /// An iterator which rejects elements while `predicate` is true
 pub struct SkipWhile<'a, A, T> {
-    priv iter: T,
-    priv flag: bool,
-    priv predicate: 'a |&A| -> bool
+    iter: T,
+    flag: bool,
+    predicate: 'a |&A| -> bool
 }
 
 impl<'a, A, T: Iterator<A>> Iterator<A> for SkipWhile<'a, A, T> {
@@ -1513,9 +1513,9 @@ impl<'a, A, T: Iterator<A>> Iterator<A> for SkipWhile<'a, A, T> {
 
 /// An iterator which only accepts elements while `predicate` is true
 pub struct TakeWhile<'a, A, T> {
-    priv iter: T,
-    priv flag: bool,
-    priv predicate: 'a |&A| -> bool
+    iter: T,
+    flag: bool,
+    predicate: 'a |&A| -> bool
 }
 
 impl<'a, A, T: Iterator<A>> Iterator<A> for TakeWhile<'a, A, T> {
@@ -1548,8 +1548,8 @@ impl<'a, A, T: Iterator<A>> Iterator<A> for TakeWhile<'a, A, T> {
 /// An iterator which skips over `n` elements of `iter`.
 #[deriving(Clone)]
 pub struct Skip<T> {
-    priv iter: T,
-    priv n: uint
+    iter: T,
+    n: uint
 }
 
 impl<A, T: Iterator<A>> Iterator<A> for Skip<T> {
@@ -1612,8 +1612,8 @@ impl<A, T: RandomAccessIterator<A>> RandomAccessIterator<A> for Skip<T> {
 /// An iterator which only iterates over the first `n` iterations of `iter`.
 #[deriving(Clone)]
 pub struct Take<T> {
-    priv iter: T,
-    priv n: uint
+    iter: T,
+    n: uint
 }
 
 impl<A, T: Iterator<A>> Iterator<A> for Take<T> {
@@ -1661,11 +1661,11 @@ impl<A, T: RandomAccessIterator<A>> RandomAccessIterator<A> for Take<T> {
 
 /// An iterator to maintain state while iterating another iterator
 pub struct Scan<'a, A, B, T, St> {
-    priv iter: T,
-    priv f: 'a |&mut St, A| -> Option<B>,
+    iter: T,
+    f: 'a |&mut St, A| -> Option<B>,
 
     /// The current internal state to be passed to the closure next.
-    state: St
+    pub state: St,
 }
 
 impl<'a, A, B, T: Iterator<A>, St> Iterator<B> for Scan<'a, A, B, T, St> {
@@ -1685,10 +1685,10 @@ impl<'a, A, B, T: Iterator<A>, St> Iterator<B> for Scan<'a, A, B, T, St> {
 /// and yields the elements of the produced iterators
 ///
 pub struct FlatMap<'a, A, T, U> {
-    priv iter: T,
-    priv f: 'a |A| -> U,
-    priv frontiter: Option<U>,
-    priv backiter: Option<U>,
+    iter: T,
+    f: 'a |A| -> U,
+    frontiter: Option<U>,
+    backiter: Option<U>,
 }
 
 impl<'a, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for FlatMap<'a, A, T, U> {
@@ -1744,8 +1744,8 @@ impl<'a,
 /// yields `None` once.
 #[deriving(Clone)]
 pub struct Fuse<T> {
-    priv iter: T,
-    priv done: bool
+    iter: T,
+    done: bool
 }
 
 impl<A, T: Iterator<A>> Iterator<A> for Fuse<T> {
@@ -1816,8 +1816,8 @@ impl<T> Fuse<T> {
 /// An iterator that calls a function with a reference to each
 /// element before yielding it.
 pub struct Inspect<'a, A, T> {
-    priv iter: T,
-    priv f: 'a |&A|
+    iter: T,
+    f: 'a |&A|
 }
 
 impl<'a, A, T> Inspect<'a, A, T> {
@@ -1869,9 +1869,9 @@ for Inspect<'a, A, T> {
 
 /// An iterator which just modifies the contained state throughout iteration.
 pub struct Unfold<'a, A, St> {
-    priv f: 'a |&mut St| -> Option<A>,
+    f: 'a |&mut St| -> Option<A>,
     /// Internal state that will be yielded on the next iteration
-    state: St
+    pub state: St,
 }
 
 impl<'a, A, St> Unfold<'a, A, St> {
@@ -1905,9 +1905,9 @@ impl<'a, A, St> Iterator<A> for Unfold<'a, A, St> {
 #[deriving(Clone)]
 pub struct Counter<A> {
     /// The current state the counter is at (next value to be yielded)
-    priv state: A,
+    state: A,
     /// The amount that this iterator is stepping by
-    priv step: A
+    step: A,
 }
 
 /// Creates a new counter with the specified start/step
@@ -1933,9 +1933,9 @@ impl<A: Add<A, A> + Clone> Iterator<A> for Counter<A> {
 /// An iterator over the range [start, stop)
 #[deriving(Clone)]
 pub struct Range<A> {
-    priv state: A,
-    priv stop: A,
-    priv one: A
+    state: A,
+    stop: A,
+    one: A
 }
 
 /// Return an iterator over the range [start, stop)
@@ -2007,8 +2007,8 @@ impl<A: Int + Ord + Clone + ToPrimitive> DoubleEndedIterator<A> for Range<A> {
 /// An iterator over the range [start, stop]
 #[deriving(Clone)]
 pub struct RangeInclusive<A> {
-    priv range: Range<A>,
-    priv done: bool
+    range: Range<A>,
+    done: bool,
 }
 
 /// Return an iterator over the range [start, stop]
@@ -2070,10 +2070,10 @@ impl<A: Sub<A, A> + Int + Ord + Clone + ToPrimitive> DoubleEndedIterator<A>
 /// An iterator over the range [start, stop) by `step`. It handles overflow by stopping.
 #[deriving(Clone)]
 pub struct RangeStep<A> {
-    priv state: A,
-    priv stop: A,
-    priv step: A,
-    priv rev: bool
+    state: A,
+    stop: A,
+    step: A,
+    rev: bool,
 }
 
 /// Return an iterator over the range [start, stop) by `step`. It handles overflow by stopping.
@@ -2102,11 +2102,11 @@ impl<A: CheckedAdd + Ord + Clone> Iterator<A> for RangeStep<A> {
 /// An iterator over the range [start, stop] by `step`. It handles overflow by stopping.
 #[deriving(Clone)]
 pub struct RangeStepInclusive<A> {
-    priv state: A,
-    priv stop: A,
-    priv step: A,
-    priv rev: bool,
-    priv done: bool
+    state: A,
+    stop: A,
+    step: A,
+    rev: bool,
+    done: bool,
 }
 
 /// Return an iterator over the range [start, stop] by `step`. It handles overflow by stopping.
@@ -2137,7 +2137,7 @@ impl<A: CheckedAdd + Ord + Clone + Eq> Iterator<A> for RangeStepInclusive<A> {
 /// An iterator that repeats an element endlessly
 #[deriving(Clone)]
 pub struct Repeat<A> {
-    priv element: A
+    element: A
 }
 
 impl<A: Clone> Repeat<A> {

--- a/src/libstd/kinds.rs
+++ b/src/libstd/kinds.rs
@@ -193,7 +193,7 @@ pub mod marker {
     /// "interior" mutability:
     ///
     /// ```
-    /// pub struct Cell<T> { priv value: T }
+    /// pub struct Cell<T> { value: T }
     /// # fn main() {}
     /// ```
     ///

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -57,7 +57,9 @@
 // Don't link to std. We are std.
 #![no_std]
 
-#![deny(missing_doc)]
+// #![deny(missing_doc)] // NOTE: uncomment after a stage0 snap
+#![allow(missing_doc)] // NOTE: remove after a stage0 snap
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
 
 // When testing libstd, bring in libuv as the I/O backend so tests can print
 // things and all of the std::io tests have an I/O interface to run on top

--- a/src/libstd/libc.rs
+++ b/src/libstd/libc.rs
@@ -244,25 +244,25 @@ pub mod types {
                 pub type pthread_t = c_ulong;
 
                 pub struct glob_t {
-                    gl_pathc: size_t,
-                    gl_pathv: **c_char,
-                    gl_offs:  size_t,
+                    pub gl_pathc: size_t,
+                    pub gl_pathv: **c_char,
+                    pub gl_offs:  size_t,
 
-                    __unused1: *c_void,
-                    __unused2: *c_void,
-                    __unused3: *c_void,
-                    __unused4: *c_void,
-                    __unused5: *c_void,
+                    pub __unused1: *c_void,
+                    pub __unused2: *c_void,
+                    pub __unused3: *c_void,
+                    pub __unused4: *c_void,
+                    pub __unused5: *c_void,
                 }
 
                 pub struct timeval {
-                    tv_sec: time_t,
-                    tv_usec: suseconds_t,
+                    pub tv_sec: time_t,
+                    pub tv_usec: suseconds_t,
                 }
 
                 pub struct timespec {
-                    tv_sec: time_t,
-                    tv_nsec: c_long,
+                    pub tv_sec: time_t,
+                    pub tv_nsec: c_long,
                 }
 
                 pub enum timezone {}
@@ -277,54 +277,54 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 pub struct sockaddr {
-                    sa_family: sa_family_t,
-                    sa_data: [u8, ..14],
+                    pub sa_family: sa_family_t,
+                    pub sa_data: [u8, ..14],
                 }
                 pub struct sockaddr_storage {
-                    ss_family: sa_family_t,
-                    __ss_align: i64,
-                    __ss_pad2: [u8, ..112],
+                    pub ss_family: sa_family_t,
+                    pub __ss_align: i64,
+                    pub __ss_pad2: [u8, ..112],
                 }
                 pub struct sockaddr_in {
-                    sin_family: sa_family_t,
-                    sin_port: in_port_t,
-                    sin_addr: in_addr,
-                    sin_zero: [u8, ..8],
+                    pub sin_family: sa_family_t,
+                    pub sin_port: in_port_t,
+                    pub sin_addr: in_addr,
+                    pub sin_zero: [u8, ..8],
                 }
                 pub struct in_addr {
-                    s_addr: in_addr_t,
+                    pub s_addr: in_addr_t,
                 }
                 pub struct sockaddr_in6 {
-                    sin6_family: sa_family_t,
-                    sin6_port: in_port_t,
-                    sin6_flowinfo: u32,
-                    sin6_addr: in6_addr,
-                    sin6_scope_id: u32,
+                    pub sin6_family: sa_family_t,
+                    pub sin6_port: in_port_t,
+                    pub sin6_flowinfo: u32,
+                    pub sin6_addr: in6_addr,
+                    pub sin6_scope_id: u32,
                 }
                 pub struct in6_addr {
-                    s6_addr: [u16, ..8]
+                    pub s6_addr: [u16, ..8]
                 }
                 pub struct ip_mreq {
-                    imr_multiaddr: in_addr,
-                    imr_interface: in_addr,
+                    pub imr_multiaddr: in_addr,
+                    pub imr_interface: in_addr,
                 }
                 pub struct ip6_mreq {
-                    ipv6mr_multiaddr: in6_addr,
-                    ipv6mr_interface: c_uint,
+                    pub ipv6mr_multiaddr: in6_addr,
+                    pub ipv6mr_interface: c_uint,
                 }
                 pub struct addrinfo {
-                    ai_flags: c_int,
-                    ai_family: c_int,
-                    ai_socktype: c_int,
-                    ai_protocol: c_int,
-                    ai_addrlen: socklen_t,
-                    ai_addr: *sockaddr,
-                    ai_canonname: *c_char,
-                    ai_next: *addrinfo
+                    pub ai_flags: c_int,
+                    pub ai_family: c_int,
+                    pub ai_socktype: c_int,
+                    pub ai_protocol: c_int,
+                    pub ai_addrlen: socklen_t,
+                    pub ai_addr: *sockaddr,
+                    pub ai_canonname: *c_char,
+                    pub ai_next: *addrinfo,
                 }
                 pub struct sockaddr_un {
-                    sun_family: sa_family_t,
-                    sun_path: [c_char, ..108]
+                    pub sun_family: sa_family_t,
+                    pub sun_path: [c_char, ..108]
                 }
             }
         }
@@ -395,35 +395,35 @@ pub mod types {
                 pub type blkcnt_t = i32;
 
                 pub struct stat {
-                    st_dev: dev_t,
-                    __pad1: c_short,
-                    st_ino: ino_t,
-                    st_mode: mode_t,
-                    st_nlink: nlink_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: dev_t,
-                    __pad2: c_short,
-                    st_size: off_t,
-                    st_blksize: blksize_t,
-                    st_blocks: blkcnt_t,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    __unused4: c_long,
-                    __unused5: c_long,
+                    pub st_dev: dev_t,
+                    pub __pad1: c_short,
+                    pub st_ino: ino_t,
+                    pub st_mode: mode_t,
+                    pub st_nlink: nlink_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: dev_t,
+                    pub __pad2: c_short,
+                    pub st_size: off_t,
+                    pub st_blksize: blksize_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub __unused4: c_long,
+                    pub __unused5: c_long,
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub struct pthread_attr_t {
-                    __size: [u32, ..9]
+                    pub __size: [u32, ..9]
                 }
             }
             #[cfg(target_arch = "arm")]
@@ -437,34 +437,34 @@ pub mod types {
                 pub type blkcnt_t = u32;
 
                 pub struct stat {
-                    st_dev: c_ulonglong,
-                    __pad0: [c_uchar, ..4],
-                    __st_ino: ino_t,
-                    st_mode: c_uint,
-                    st_nlink: c_uint,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: c_ulonglong,
-                    __pad3: [c_uchar, ..4],
-                    st_size: c_longlong,
-                    st_blksize: blksize_t,
-                    st_blocks: c_ulonglong,
-                    st_atime: time_t,
-                    st_atime_nsec: c_ulong,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_ulong,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_ulong,
-                    st_ino: c_ulonglong
+                    pub st_dev: c_ulonglong,
+                    pub __pad0: [c_uchar, ..4],
+                    pub __st_ino: ino_t,
+                    pub st_mode: c_uint,
+                    pub st_nlink: c_uint,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: c_ulonglong,
+                    pub __pad3: [c_uchar, ..4],
+                    pub st_size: c_longlong,
+                    pub st_blksize: blksize_t,
+                    pub st_blocks: c_ulonglong,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_ulong,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_ulong,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_ulong,
+                    pub st_ino: c_ulonglong,
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub struct pthread_attr_t {
-                    __size: [u32, ..9]
+                    pub __size: [u32, ..9]
                 }
             }
             #[cfg(target_arch = "mips")]
@@ -479,35 +479,35 @@ pub mod types {
                 pub type blkcnt_t = i32;
 
                 pub struct stat {
-                    st_dev: c_ulong,
-                    st_pad1: [c_long, ..3],
-                    st_ino: ino_t,
-                    st_mode: mode_t,
-                    st_nlink: nlink_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: c_ulong,
-                    st_pad2: [c_long, ..2],
-                    st_size: off_t,
-                    st_pad3: c_long,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    st_blksize: blksize_t,
-                    st_blocks: blkcnt_t,
-                    st_pad5: [c_long, ..14],
+                    pub st_dev: c_ulong,
+                    pub st_pad1: [c_long, ..3],
+                    pub st_ino: ino_t,
+                    pub st_mode: mode_t,
+                    pub st_nlink: nlink_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: c_ulong,
+                    pub st_pad2: [c_long, ..2],
+                    pub st_size: off_t,
+                    pub st_pad3: c_long,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub st_blksize: blksize_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_pad5: [c_long, ..14],
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub struct pthread_attr_t {
-                    __size: [u32, ..9]
+                    pub __size: [u32, ..9]
                 }
             }
             pub mod posix08 {}
@@ -563,33 +563,33 @@ pub mod types {
                 pub type blksize_t = i64;
                 pub type blkcnt_t = i64;
                 pub struct stat {
-                    st_dev: dev_t,
-                    st_ino: ino_t,
-                    st_nlink: nlink_t,
-                    st_mode: mode_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    __pad0: c_int,
-                    st_rdev: dev_t,
-                    st_size: off_t,
-                    st_blksize: blksize_t,
-                    st_blocks: blkcnt_t,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    __unused: [c_long, ..3],
+                    pub st_dev: dev_t,
+                    pub st_ino: ino_t,
+                    pub st_nlink: nlink_t,
+                    pub st_mode: mode_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub __pad0: c_int,
+                    pub st_rdev: dev_t,
+                    pub st_size: off_t,
+                    pub st_blksize: blksize_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub __unused: [c_long, ..3],
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub struct pthread_attr_t {
-                    __size: [u64, ..7]
+                    pub __size: [u64, ..7]
                 }
             }
             pub mod posix08 {
@@ -613,29 +613,29 @@ pub mod types {
                 pub type pthread_t = uintptr_t;
 
                 pub struct glob_t {
-                    gl_pathc:  size_t,
-                    __unused1: size_t,
-                    gl_offs:   size_t,
-                    __unused2: c_int,
-                    gl_pathv:  **c_char,
+                    pub gl_pathc:  size_t,
+                    pub __unused1: size_t,
+                    pub gl_offs:   size_t,
+                    pub __unused2: c_int,
+                    pub gl_pathv:  **c_char,
 
-                    __unused3: *c_void,
+                    pub __unused3: *c_void,
 
-                    __unused4: *c_void,
-                    __unused5: *c_void,
-                    __unused6: *c_void,
-                    __unused7: *c_void,
-                    __unused8: *c_void,
+                    pub __unused4: *c_void,
+                    pub __unused5: *c_void,
+                    pub __unused6: *c_void,
+                    pub __unused7: *c_void,
+                    pub __unused8: *c_void,
                 }
 
                 pub struct timeval {
-                    tv_sec: time_t,
-                    tv_usec: suseconds_t,
+                    pub tv_sec: time_t,
+                    pub tv_usec: suseconds_t,
                 }
 
                 pub struct timespec {
-                    tv_sec: time_t,
-                    tv_nsec: c_long,
+                    pub tv_sec: time_t,
+                    pub tv_nsec: c_long,
                 }
 
                 pub enum timezone {}
@@ -650,60 +650,60 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 pub struct sockaddr {
-                    sa_len: u8,
-                    sa_family: sa_family_t,
-                    sa_data: [u8, ..14],
+                    pub sa_len: u8,
+                    pub sa_family: sa_family_t,
+                    pub sa_data: [u8, ..14],
                 }
                 pub struct sockaddr_storage {
-                    ss_len: u8,
-                    ss_family: sa_family_t,
-                    __ss_pad1: [u8, ..6],
-                    __ss_align: i64,
-                    __ss_pad2: [u8, ..112],
+                    pub ss_len: u8,
+                    pub ss_family: sa_family_t,
+                    pub __ss_pad1: [u8, ..6],
+                    pub __ss_align: i64,
+                    pub __ss_pad2: [u8, ..112],
                 }
                 pub struct sockaddr_in {
-                    sin_len: u8,
-                    sin_family: sa_family_t,
-                    sin_port: in_port_t,
-                    sin_addr: in_addr,
-                    sin_zero: [u8, ..8],
+                    pub sin_len: u8,
+                    pub sin_family: sa_family_t,
+                    pub sin_port: in_port_t,
+                    pub sin_addr: in_addr,
+                    pub sin_zero: [u8, ..8],
                 }
                 pub struct in_addr {
-                    s_addr: in_addr_t,
+                    pub s_addr: in_addr_t,
                 }
                 pub struct sockaddr_in6 {
-                    sin6_len: u8,
-                    sin6_family: sa_family_t,
-                    sin6_port: in_port_t,
-                    sin6_flowinfo: u32,
-                    sin6_addr: in6_addr,
-                    sin6_scope_id: u32,
+                    pub sin6_len: u8,
+                    pub sin6_family: sa_family_t,
+                    pub sin6_port: in_port_t,
+                    pub sin6_flowinfo: u32,
+                    pub sin6_addr: in6_addr,
+                    pub sin6_scope_id: u32,
                 }
                 pub struct in6_addr {
-                    s6_addr: [u16, ..8]
+                    pub s6_addr: [u16, ..8]
                 }
                 pub struct ip_mreq {
-                    imr_multiaddr: in_addr,
-                    imr_interface: in_addr,
+                    pub imr_multiaddr: in_addr,
+                    pub imr_interface: in_addr,
                 }
                 pub struct ip6_mreq {
-                    ipv6mr_multiaddr: in6_addr,
-                    ipv6mr_interface: c_uint,
+                    pub ipv6mr_multiaddr: in6_addr,
+                    pub ipv6mr_interface: c_uint,
                 }
                 pub struct addrinfo {
-                    ai_flags: c_int,
-                    ai_family: c_int,
-                    ai_socktype: c_int,
-                    ai_protocol: c_int,
-                    ai_addrlen: socklen_t,
-                    ai_canonname: *c_char,
-                    ai_addr: *sockaddr,
-                    ai_next: *addrinfo
+                    pub ai_flags: c_int,
+                    pub ai_family: c_int,
+                    pub ai_socktype: c_int,
+                    pub ai_protocol: c_int,
+                    pub ai_addrlen: socklen_t,
+                    pub ai_canonname: *c_char,
+                    pub ai_addr: *sockaddr,
+                    pub ai_next: *addrinfo,
                 }
                 pub struct sockaddr_un {
-                    sun_len: u8,
-                    sun_family: sa_family_t,
-                    sun_path: [c_char, ..104]
+                    pub sun_len: u8,
+                    pub sun_family: sa_family_t,
+                    pub sun_path: [c_char, ..104]
                 }
             }
         }
@@ -759,33 +759,33 @@ pub mod types {
                 pub type blkcnt_t = i64;
                 pub type fflags_t = u32;
                 pub struct stat {
-                    st_dev: dev_t,
-                    st_ino: ino_t,
-                    st_mode: mode_t,
-                    st_nlink: nlink_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: dev_t,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    st_size: off_t,
-                    st_blocks: blkcnt_t,
-                    st_blksize: blksize_t,
-                    st_flags: fflags_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
-                    st_birthtime: time_t,
-                    st_birthtime_nsec: c_long,
-                    __unused: [uint8_t, ..2],
+                    pub st_dev: dev_t,
+                    pub st_ino: ino_t,
+                    pub st_mode: mode_t,
+                    pub st_nlink: nlink_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: dev_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub st_size: off_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_blksize: blksize_t,
+                    pub st_flags: fflags_t,
+                    pub st_gen: uint32_t,
+                    pub st_lspare: int32_t,
+                    pub st_birthtime: time_t,
+                    pub st_birthtime_nsec: c_long,
+                    pub __unused: [uint8_t, ..2],
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub type pthread_attr_t = *c_void;
@@ -809,36 +809,36 @@ pub mod types {
                 use libc::types::os::arch::posix88::{dev_t, ino_t};
                 use libc::types::os::arch::posix88::mode_t;
 
-                // Note: this is the struct called stat64 in win32. Not stat,
+                // pub Note: this is the struct called stat64 in win32. Not stat,
                 // nor stati64.
                 pub struct stat {
-                    st_dev: dev_t,
-                    st_ino: ino_t,
-                    st_mode: mode_t,
-                    st_nlink: c_short,
-                    st_uid: c_short,
-                    st_gid: c_short,
-                    st_rdev: dev_t,
-                    st_size: int64,
-                    st_atime: time64_t,
-                    st_mtime: time64_t,
-                    st_ctime: time64_t,
+                    pub st_dev: dev_t,
+                    pub st_ino: ino_t,
+                    pub st_mode: mode_t,
+                    pub st_nlink: c_short,
+                    pub st_uid: c_short,
+                    pub st_gid: c_short,
+                    pub st_rdev: dev_t,
+                    pub st_size: int64,
+                    pub st_atime: time64_t,
+                    pub st_mtime: time64_t,
+                    pub st_ctime: time64_t,
                 }
 
                 // note that this is called utimbuf64 in win32
                 pub struct utimbuf {
-                    actime: time64_t,
-                    modtime: time64_t,
+                    pub actime: time64_t,
+                    pub modtime: time64_t,
                 }
 
                 pub struct timeval {
-                    tv_sec: time_t,
-                    tv_usec: suseconds_t,
+                    pub tv_sec: time_t,
+                    pub tv_usec: suseconds_t,
                 }
 
                 pub struct timespec {
-                    tv_sec: time_t,
-                    tv_nsec: c_long,
+                    pub tv_sec: time_t,
+                    pub tv_nsec: c_long,
                 }
 
                 pub enum timezone {}
@@ -853,54 +853,54 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 pub struct sockaddr {
-                    sa_family: sa_family_t,
-                    sa_data: [u8, ..14],
+                    pub sa_family: sa_family_t,
+                    pub sa_data: [u8, ..14],
                 }
                 pub struct sockaddr_storage {
-                    ss_family: sa_family_t,
-                    __ss_align: i64,
-                    __ss_pad2: [u8, ..112],
+                    pub ss_family: sa_family_t,
+                    pub __ss_align: i64,
+                    pub __ss_pad2: [u8, ..112],
                 }
                 pub struct sockaddr_in {
-                    sin_family: sa_family_t,
-                    sin_port: in_port_t,
-                    sin_addr: in_addr,
-                    sin_zero: [u8, ..8],
+                    pub sin_family: sa_family_t,
+                    pub sin_port: in_port_t,
+                    pub sin_addr: in_addr,
+                    pub sin_zero: [u8, ..8],
                 }
                 pub struct in_addr {
-                    s_addr: in_addr_t,
+                    pub s_addr: in_addr_t,
                 }
                 pub struct sockaddr_in6 {
-                    sin6_family: sa_family_t,
-                    sin6_port: in_port_t,
-                    sin6_flowinfo: u32,
-                    sin6_addr: in6_addr,
-                    sin6_scope_id: u32,
+                    pub sin6_family: sa_family_t,
+                    pub sin6_port: in_port_t,
+                    pub sin6_flowinfo: u32,
+                    pub sin6_addr: in6_addr,
+                    pub sin6_scope_id: u32,
                 }
                 pub struct in6_addr {
-                    s6_addr: [u16, ..8]
+                    pub s6_addr: [u16, ..8]
                 }
                 pub struct ip_mreq {
-                    imr_multiaddr: in_addr,
-                    imr_interface: in_addr,
+                    pub imr_multiaddr: in_addr,
+                    pub imr_interface: in_addr,
                 }
                 pub struct ip6_mreq {
-                    ipv6mr_multiaddr: in6_addr,
-                    ipv6mr_interface: c_uint,
+                    pub ipv6mr_multiaddr: in6_addr,
+                    pub ipv6mr_interface: c_uint,
                 }
                 pub struct addrinfo {
-                    ai_flags: c_int,
-                    ai_family: c_int,
-                    ai_socktype: c_int,
-                    ai_protocol: c_int,
-                    ai_addrlen: size_t,
-                    ai_canonname: *c_char,
-                    ai_addr: *sockaddr,
-                    ai_next: *addrinfo
+                    pub ai_flags: c_int,
+                    pub ai_family: c_int,
+                    pub ai_socktype: c_int,
+                    pub ai_protocol: c_int,
+                    pub ai_addrlen: size_t,
+                    pub ai_canonname: *c_char,
+                    pub ai_addr: *sockaddr,
+                    pub ai_next: *addrinfo,
                 }
                 pub struct sockaddr_un {
-                    sun_family: sa_family_t,
-                    sun_path: [c_char, ..108]
+                    pub sun_family: sa_family_t,
+                    pub sun_path: [c_char, ..108]
                 }
             }
         }
@@ -1038,47 +1038,47 @@ pub mod types {
                 pub type int64 = i64;
 
                 pub struct STARTUPINFO {
-                    cb: DWORD,
-                    lpReserved: LPWSTR,
-                    lpDesktop: LPWSTR,
-                    lpTitle: LPWSTR,
-                    dwX: DWORD,
-                    dwY: DWORD,
-                    dwXSize: DWORD,
-                    dwYSize: DWORD,
-                    dwXCountChars: DWORD,
-                    dwYCountCharts: DWORD,
-                    dwFillAttribute: DWORD,
-                    dwFlags: DWORD,
-                    wShowWindow: WORD,
-                    cbReserved2: WORD,
-                    lpReserved2: LPBYTE,
-                    hStdInput: HANDLE,
-                    hStdOutput: HANDLE,
-                    hStdError: HANDLE
+                    pub cb: DWORD,
+                    pub lpReserved: LPWSTR,
+                    pub lpDesktop: LPWSTR,
+                    pub lpTitle: LPWSTR,
+                    pub dwX: DWORD,
+                    pub dwY: DWORD,
+                    pub dwXSize: DWORD,
+                    pub dwYSize: DWORD,
+                    pub dwXCountChars: DWORD,
+                    pub dwYCountCharts: DWORD,
+                    pub dwFillAttribute: DWORD,
+                    pub dwFlags: DWORD,
+                    pub wShowWindow: WORD,
+                    pub cbReserved2: WORD,
+                    pub lpReserved2: LPBYTE,
+                    pub hStdInput: HANDLE,
+                    pub hStdOutput: HANDLE,
+                    pub hStdError: HANDLE,
                 }
                 pub type LPSTARTUPINFO = *mut STARTUPINFO;
 
                 pub struct PROCESS_INFORMATION {
-                    hProcess: HANDLE,
-                    hThread: HANDLE,
-                    dwProcessId: DWORD,
-                    dwThreadId: DWORD
+                    pub hProcess: HANDLE,
+                    pub hThread: HANDLE,
+                    pub dwProcessId: DWORD,
+                    pub dwThreadId: DWORD,
                 }
                 pub type LPPROCESS_INFORMATION = *mut PROCESS_INFORMATION;
 
                 pub struct SYSTEM_INFO {
-                    wProcessorArchitecture: WORD,
-                    wReserved: WORD,
-                    dwPageSize: DWORD,
-                    lpMinimumApplicationAddress: LPVOID,
-                    lpMaximumApplicationAddress: LPVOID,
-                    dwActiveProcessorMask: DWORD,
-                    dwNumberOfProcessors: DWORD,
-                    dwProcessorType: DWORD,
-                    dwAllocationGranularity: DWORD,
-                    wProcessorLevel: WORD,
-                    wProcessorRevision: WORD
+                    pub wProcessorArchitecture: WORD,
+                    pub wReserved: WORD,
+                    pub dwPageSize: DWORD,
+                    pub lpMinimumApplicationAddress: LPVOID,
+                    pub lpMaximumApplicationAddress: LPVOID,
+                    pub dwActiveProcessorMask: DWORD,
+                    pub dwNumberOfProcessors: DWORD,
+                    pub dwProcessorType: DWORD,
+                    pub dwAllocationGranularity: DWORD,
+                    pub wProcessorLevel: WORD,
+                    pub wProcessorRevision: WORD,
                 }
                 pub type LPSYSTEM_INFO = *mut SYSTEM_INFO;
 
@@ -1101,68 +1101,68 @@ pub mod types {
                 }
 
                 pub struct MEMORY_BASIC_INFORMATION {
-                    BaseAddress: LPVOID,
-                    AllocationBase: LPVOID,
-                    AllocationProtect: DWORD,
-                    RegionSize: SIZE_T,
-                    State: DWORD,
-                    Protect: DWORD,
-                    Type: DWORD
+                    pub BaseAddress: LPVOID,
+                    pub AllocationBase: LPVOID,
+                    pub AllocationProtect: DWORD,
+                    pub RegionSize: SIZE_T,
+                    pub State: DWORD,
+                    pub Protect: DWORD,
+                    pub Type: DWORD,
                 }
                 pub type LPMEMORY_BASIC_INFORMATION = *mut MEMORY_BASIC_INFORMATION;
 
                 pub struct OVERLAPPED {
-                    Internal: *c_ulong,
-                    InternalHigh: *c_ulong,
-                    Offset: DWORD,
-                    OffsetHigh: DWORD,
-                    hEvent: HANDLE,
+                    pub Internal: *c_ulong,
+                    pub InternalHigh: *c_ulong,
+                    pub Offset: DWORD,
+                    pub OffsetHigh: DWORD,
+                    pub hEvent: HANDLE,
                 }
 
                 pub type LPOVERLAPPED = *mut OVERLAPPED;
 
                 pub struct FILETIME {
-                    dwLowDateTime: DWORD,
-                    dwHighDateTime: DWORD,
+                    pub dwLowDateTime: DWORD,
+                    pub dwHighDateTime: DWORD,
                 }
 
                 pub type LPFILETIME = *mut FILETIME;
 
                 pub struct GUID {
-                    Data1: DWORD,
-                    Data2: DWORD,
-                    Data3: DWORD,
-                    Data4: [BYTE, ..8],
+                    pub Data1: DWORD,
+                    pub Data2: DWORD,
+                    pub Data3: DWORD,
+                    pub Data4: [BYTE, ..8],
                 }
 
                 pub struct WSAPROTOCOLCHAIN {
-                    ChainLen: c_int,
-                    ChainEntries: [DWORD, ..MAX_PROTOCOL_CHAIN],
+                    pub ChainLen: c_int,
+                    pub ChainEntries: [DWORD, ..MAX_PROTOCOL_CHAIN],
                 }
 
                 pub type LPWSAPROTOCOLCHAIN = *mut WSAPROTOCOLCHAIN;
 
                 pub struct WSAPROTOCOL_INFO {
-                    dwServiceFlags1: DWORD,
-                    dwServiceFlags2: DWORD,
-                    dwServiceFlags3: DWORD,
-                    dwServiceFlags4: DWORD,
-                    dwProviderFlags: DWORD,
-                    ProviderId: GUID,
-                    dwCatalogEntryId: DWORD,
-                    ProtocolChain: WSAPROTOCOLCHAIN,
-                    iVersion: c_int,
-                    iAddressFamily: c_int,
-                    iMaxSockAddr: c_int,
-                    iMinSockAddr: c_int,
-                    iSocketType: c_int,
-                    iProtocol: c_int,
-                    iProtocolMaxOffset: c_int,
-                    iNetworkByteOrder: c_int,
-                    iSecurityScheme: c_int,
-                    dwMessageSize: DWORD,
-                    dwProviderReserved: DWORD,
-                    szProtocol: [u8, ..WSAPROTOCOL_LEN+1],
+                    pub dwServiceFlags1: DWORD,
+                    pub dwServiceFlags2: DWORD,
+                    pub dwServiceFlags3: DWORD,
+                    pub dwServiceFlags4: DWORD,
+                    pub dwProviderFlags: DWORD,
+                    pub ProviderId: GUID,
+                    pub dwCatalogEntryId: DWORD,
+                    pub ProtocolChain: WSAPROTOCOLCHAIN,
+                    pub iVersion: c_int,
+                    pub iAddressFamily: c_int,
+                    pub iMaxSockAddr: c_int,
+                    pub iMinSockAddr: c_int,
+                    pub iSocketType: c_int,
+                    pub iProtocol: c_int,
+                    pub iProtocolMaxOffset: c_int,
+                    pub iNetworkByteOrder: c_int,
+                    pub iSecurityScheme: c_int,
+                    pub dwMessageSize: DWORD,
+                    pub dwProviderReserved: DWORD,
+                    pub szProtocol: [u8, ..WSAPROTOCOL_LEN+1],
                 }
 
                 pub type LPWSAPROTOCOL_INFO = *mut WSAPROTOCOL_INFO;
@@ -1184,29 +1184,29 @@ pub mod types {
                 pub type pthread_t = uintptr_t;
 
                 pub struct glob_t {
-                    gl_pathc:  size_t,
-                    __unused1: c_int,
-                    gl_offs:   size_t,
-                    __unused2: c_int,
-                    gl_pathv:  **c_char,
+                    pub gl_pathc:  size_t,
+                    pub __unused1: c_int,
+                    pub gl_offs:   size_t,
+                    pub __unused2: c_int,
+                    pub gl_pathv:  **c_char,
 
-                    __unused3: *c_void,
+                    pub __unused3: *c_void,
 
-                    __unused4: *c_void,
-                    __unused5: *c_void,
-                    __unused6: *c_void,
-                    __unused7: *c_void,
-                    __unused8: *c_void,
+                    pub __unused4: *c_void,
+                    pub __unused5: *c_void,
+                    pub __unused6: *c_void,
+                    pub __unused7: *c_void,
+                    pub __unused8: *c_void,
                 }
 
                 pub struct timeval {
-                    tv_sec: time_t,
-                    tv_usec: suseconds_t,
+                    pub tv_sec: time_t,
+                    pub tv_usec: suseconds_t,
                 }
 
                 pub struct timespec {
-                    tv_sec: time_t,
-                    tv_nsec: c_long,
+                    pub tv_sec: time_t,
+                    pub tv_nsec: c_long,
                 }
 
                 pub enum timezone {}
@@ -1222,60 +1222,60 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 pub struct sockaddr {
-                    sa_len: u8,
-                    sa_family: sa_family_t,
-                    sa_data: [u8, ..14],
+                    pub sa_len: u8,
+                    pub sa_family: sa_family_t,
+                    pub sa_data: [u8, ..14],
                 }
                 pub struct sockaddr_storage {
-                    ss_len: u8,
-                    ss_family: sa_family_t,
-                    __ss_pad1: [u8, ..6],
-                    __ss_align: i64,
-                    __ss_pad2: [u8, ..112],
+                    pub ss_len: u8,
+                    pub ss_family: sa_family_t,
+                    pub __ss_pad1: [u8, ..6],
+                    pub __ss_align: i64,
+                    pub __ss_pad2: [u8, ..112],
                 }
                 pub struct sockaddr_in {
-                    sin_len: u8,
-                    sin_family: sa_family_t,
-                    sin_port: in_port_t,
-                    sin_addr: in_addr,
-                    sin_zero: [u8, ..8],
+                    pub sin_len: u8,
+                    pub sin_family: sa_family_t,
+                    pub sin_port: in_port_t,
+                    pub sin_addr: in_addr,
+                    pub sin_zero: [u8, ..8],
                 }
                 pub struct in_addr {
-                    s_addr: in_addr_t,
+                    pub s_addr: in_addr_t,
                 }
                 pub struct sockaddr_in6 {
-                    sin6_len: u8,
-                    sin6_family: sa_family_t,
-                    sin6_port: in_port_t,
-                    sin6_flowinfo: u32,
-                    sin6_addr: in6_addr,
-                    sin6_scope_id: u32,
+                    pub sin6_len: u8,
+                    pub sin6_family: sa_family_t,
+                    pub sin6_port: in_port_t,
+                    pub sin6_flowinfo: u32,
+                    pub sin6_addr: in6_addr,
+                    pub sin6_scope_id: u32,
                 }
                 pub struct in6_addr {
-                    s6_addr: [u16, ..8]
+                    pub s6_addr: [u16, ..8]
                 }
                 pub struct ip_mreq {
-                    imr_multiaddr: in_addr,
-                    imr_interface: in_addr,
+                    pub imr_multiaddr: in_addr,
+                    pub imr_interface: in_addr,
                 }
                 pub struct ip6_mreq {
-                    ipv6mr_multiaddr: in6_addr,
-                    ipv6mr_interface: c_uint,
+                    pub ipv6mr_multiaddr: in6_addr,
+                    pub ipv6mr_interface: c_uint,
                 }
                 pub struct addrinfo {
-                    ai_flags: c_int,
-                    ai_family: c_int,
-                    ai_socktype: c_int,
-                    ai_protocol: c_int,
-                    ai_addrlen: socklen_t,
-                    ai_canonname: *c_char,
-                    ai_addr: *sockaddr,
-                    ai_next: *addrinfo
+                    pub ai_flags: c_int,
+                    pub ai_family: c_int,
+                    pub ai_socktype: c_int,
+                    pub ai_protocol: c_int,
+                    pub ai_addrlen: socklen_t,
+                    pub ai_canonname: *c_char,
+                    pub ai_addr: *sockaddr,
+                    pub ai_next: *addrinfo,
                 }
                 pub struct sockaddr_un {
-                    sun_len: u8,
-                    sun_family: sa_family_t,
-                    sun_path: [c_char, ..104]
+                    pub sun_len: u8,
+                    pub sun_family: sa_family_t,
+                    pub sun_path: [c_char, ..104]
                 }
             }
         }
@@ -1330,38 +1330,38 @@ pub mod types {
                 pub type blkcnt_t = i32;
 
                 pub struct stat {
-                    st_dev: dev_t,
-                    st_mode: mode_t,
-                    st_nlink: nlink_t,
-                    st_ino: ino_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: dev_t,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    st_birthtime: time_t,
-                    st_birthtime_nsec: c_long,
-                    st_size: off_t,
-                    st_blocks: blkcnt_t,
-                    st_blksize: blksize_t,
-                    st_flags: uint32_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
-                    st_qspare: [int64_t, ..2],
+                    pub st_dev: dev_t,
+                    pub st_mode: mode_t,
+                    pub st_nlink: nlink_t,
+                    pub st_ino: ino_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: dev_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub st_birthtime: time_t,
+                    pub st_birthtime_nsec: c_long,
+                    pub st_size: off_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_blksize: blksize_t,
+                    pub st_flags: uint32_t,
+                    pub st_gen: uint32_t,
+                    pub st_lspare: int32_t,
+                    pub st_qspare: [int64_t, ..2],
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub struct pthread_attr_t {
-                    __sig: c_long,
-                    __opaque: [c_char, ..36]
+                    pub __sig: c_long,
+                    pub __opaque: [c_char, ..36]
                 }
             }
             pub mod posix08 {
@@ -1370,8 +1370,8 @@ pub mod types {
             }
             pub mod extra {
                 pub struct mach_timebase_info {
-                    numer: u32,
-                    denom: u32,
+                    pub numer: u32,
+                    pub denom: u32,
                 }
 
                 pub type mach_timebase_info_data_t = mach_timebase_info;
@@ -1428,38 +1428,38 @@ pub mod types {
                 pub type blkcnt_t = i32;
 
                 pub struct stat {
-                    st_dev: dev_t,
-                    st_mode: mode_t,
-                    st_nlink: nlink_t,
-                    st_ino: ino_t,
-                    st_uid: uid_t,
-                    st_gid: gid_t,
-                    st_rdev: dev_t,
-                    st_atime: time_t,
-                    st_atime_nsec: c_long,
-                    st_mtime: time_t,
-                    st_mtime_nsec: c_long,
-                    st_ctime: time_t,
-                    st_ctime_nsec: c_long,
-                    st_birthtime: time_t,
-                    st_birthtime_nsec: c_long,
-                    st_size: off_t,
-                    st_blocks: blkcnt_t,
-                    st_blksize: blksize_t,
-                    st_flags: uint32_t,
-                    st_gen: uint32_t,
-                    st_lspare: int32_t,
-                    st_qspare: [int64_t, ..2],
+                    pub st_dev: dev_t,
+                    pub st_mode: mode_t,
+                    pub st_nlink: nlink_t,
+                    pub st_ino: ino_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: dev_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub st_birthtime: time_t,
+                    pub st_birthtime_nsec: c_long,
+                    pub st_size: off_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_blksize: blksize_t,
+                    pub st_flags: uint32_t,
+                    pub st_gen: uint32_t,
+                    pub st_lspare: int32_t,
+                    pub st_qspare: [int64_t, ..2],
                 }
 
                 pub struct utimbuf {
-                    actime: time_t,
-                    modtime: time_t,
+                    pub actime: time_t,
+                    pub modtime: time_t,
                 }
 
                 pub struct pthread_attr_t {
-                    __sig: c_long,
-                    __opaque: [c_char, ..56]
+                    pub __sig: c_long,
+                    pub __opaque: [c_char, ..56]
                 }
             }
             pub mod posix08 {
@@ -1468,8 +1468,8 @@ pub mod types {
             }
             pub mod extra {
                 pub struct mach_timebase_info {
-                    numer: u32,
-                    denom: u32,
+                    pub numer: u32,
+                    pub denom: u32,
                 }
 
                 pub type mach_timebase_info_data_t = mach_timebase_info;

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -535,7 +535,7 @@ impl<T> Default for Option<T> {
 /// methods on `Option`.
 #[deriving(Clone)]
 pub struct Item<A> {
-    priv opt: Option<A>
+    opt: Option<A>
 }
 
 impl<A> Iterator<A> for Item<A> {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -370,10 +370,10 @@ pub fn unsetenv(n: &str) {
 pub struct Pipe {
     /// A file descriptor representing the reading end of the pipe. Data written
     /// on the `out` file descriptor can be read from this file descriptor.
-    input: c_int,
+    pub input: c_int,
     /// A file descriptor representing the write end of the pipe. Data written
     /// to this file descriptor can be read from the `input` file descriptor.
-    out: c_int,
+    pub out: c_int,
 }
 
 /// Creates a new low-level OS in-memory pipe.
@@ -946,11 +946,11 @@ pub fn page_size() -> uint {
 /// let it leave scope by accident if you want it to stick around.
 pub struct MemoryMap {
     /// Pointer to the memory created or modified by this map.
-    data: *mut u8,
+    pub data: *mut u8,
     /// Number of bytes this map applies to
-    len: uint,
+    pub len: uint,
     /// Type of mapping
-    kind: MemoryMapKind
+    pub kind: MemoryMapKind,
 }
 
 /// Type of memory map

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -488,8 +488,8 @@ pub trait GenericPathUnsafe {
 
 /// Helper struct for printing paths with format!()
 pub struct Display<'a, P> {
-    priv path: &'a P,
-    priv filename: bool
+    path: &'a P,
+    filename: bool
 }
 
 impl<'a, P: GenericPath> fmt::Show for Display<'a, P> {

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -40,8 +40,8 @@ pub type RevStrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
 /// Represents a POSIX file path
 #[deriving(Clone)]
 pub struct Path {
-    priv repr: ~[u8], // assumed to never be empty or contain NULs
-    priv sepidx: Option<uint> // index of the final separator in repr
+    repr: ~[u8], // assumed to never be empty or contain NULs
+    sepidx: Option<uint> // index of the final separator in repr
 }
 
 /// The standard path separator character

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -81,9 +81,9 @@ pub type RevComponents<'a> = Map<'a, Option<&'a str>, &'a [u8],
 // preserved by the data structure; let the Windows API error out on them.
 #[deriving(Clone)]
 pub struct Path {
-    priv repr: ~str, // assumed to never be empty
-    priv prefix: Option<PathPrefix>,
-    priv sepidx: Option<uint> // index of the final separator in the non-prefix portion of repr
+    repr: ~str, // assumed to never be empty
+    prefix: Option<PathPrefix>,
+    sepidx: Option<uint> // index of the final separator in the non-prefix portion of repr
 }
 
 impl Eq for Path {

--- a/src/libstd/raw.rs
+++ b/src/libstd/raw.rs
@@ -21,18 +21,18 @@ use cast;
 
 /// The representation of a Rust managed box
 pub struct Box<T> {
-    ref_count: uint,
-    drop_glue: fn(ptr: *mut u8),
-    prev: *mut Box<T>,
-    next: *mut Box<T>,
-    data: T
+    pub ref_count: uint,
+    pub drop_glue: fn(ptr: *mut u8),
+    pub prev: *mut Box<T>,
+    pub next: *mut Box<T>,
+    pub data: T,
 }
 
 /// The representation of a Rust vector
 pub struct Vec<T> {
-    fill: uint,
-    alloc: uint,
-    data: T
+    pub fill: uint,
+    pub alloc: uint,
+    pub data: T,
 }
 
 /// The representation of a Rust string
@@ -40,20 +40,20 @@ pub type String = Vec<u8>;
 
 /// The representation of a Rust slice
 pub struct Slice<T> {
-    data: *T,
-    len: uint
+    pub data: *T,
+    pub len: uint,
 }
 
 /// The representation of a Rust closure
 pub struct Closure {
-    code: *(),
-    env: *(),
+    pub code: *(),
+    pub env: *(),
 }
 
 /// The representation of a Rust procedure (`proc()`)
 pub struct Procedure {
-    code: *(),
-    env: *(),
+    pub code: *(),
+    pub env: *(),
 }
 
 /// The representation of a Rust trait object.
@@ -61,8 +61,8 @@ pub struct Procedure {
 /// This struct does not have a `Repr` implementation
 /// because there is no way to refer to all trait objects generically.
 pub struct TraitObject {
-    vtable: *(),
-    data: *(),
+    pub vtable: *(),
+    pub data: *(),
 }
 
 /// This trait is meant to map equivalences between raw structs and their

--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -43,9 +43,9 @@ struct RcBox<T> {
 /// Immutable reference counted pointer type
 #[unsafe_no_drop_flag]
 pub struct Rc<T> {
-    priv ptr: *mut RcBox<T>,
-    priv nosend: marker::NoSend,
-    priv noshare: marker::NoShare
+    ptr: *mut RcBox<T>,
+    nosend: marker::NoSend,
+    noshare: marker::NoShare
 }
 
 impl<T> Rc<T> {
@@ -151,9 +151,9 @@ impl<T: TotalOrd> TotalOrd for Rc<T> {
 /// Weak reference to a reference-counted box
 #[unsafe_no_drop_flag]
 pub struct Weak<T> {
-    priv ptr: *mut RcBox<T>,
-    priv nosend: marker::NoSend,
-    priv noshare: marker::NoShare
+    ptr: *mut RcBox<T>,
+    nosend: marker::NoSend,
+    noshare: marker::NoShare
 }
 
 impl<T> Weak<T> {

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -40,7 +40,7 @@ pub fn align(size: uint, align: uint) -> uint {
 
 /// Adaptor to wrap around visitors implementing MovePtr.
 pub struct MovePtrAdaptor<V> {
-    priv inner: V
+    inner: V
 }
 pub fn MovePtrAdaptor<V:TyVisitor + MovePtr>(v: V) -> MovePtrAdaptor<V> {
     MovePtrAdaptor { inner: v }

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -101,11 +101,11 @@ enum VariantState {
 }
 
 pub struct ReprVisitor<'a> {
-    priv ptr: *u8,
-    priv ptr_stk: ~[*u8],
-    priv var_stk: ~[VariantState],
-    priv writer: &'a mut io::Writer,
-    priv last_err: Option<io::IoError>,
+    ptr: *u8,
+    ptr_stk: ~[*u8],
+    var_stk: ~[VariantState],
+    writer: &'a mut io::Writer,
+    last_err: Option<io::IoError>,
 }
 
 pub fn ReprVisitor<'a>(ptr: *u8,

--- a/src/libstd/rt/libunwind.rs
+++ b/src/libstd/rt/libunwind.rs
@@ -17,8 +17,7 @@ use libc;
 
 #[cfg(not(target_arch = "arm"))]
 #[repr(C)]
-pub enum _Unwind_Action
-{
+pub enum _Unwind_Action {
     _UA_SEARCH_PHASE = 1,
     _UA_CLEANUP_PHASE = 2,
     _UA_HANDLER_FRAME = 4,
@@ -28,14 +27,13 @@ pub enum _Unwind_Action
 
 #[cfg(target_arch = "arm")]
 #[repr(C)]
-pub enum _Unwind_State
-{
-  _US_VIRTUAL_UNWIND_FRAME = 0,
-  _US_UNWIND_FRAME_STARTING = 1,
-  _US_UNWIND_FRAME_RESUME = 2,
-  _US_ACTION_MASK = 3,
-  _US_FORCE_UNWIND = 8,
-  _US_END_OF_STACK = 16
+pub enum _Unwind_State {
+    _US_VIRTUAL_UNWIND_FRAME = 0,
+    _US_UNWIND_FRAME_STARTING = 1,
+    _US_UNWIND_FRAME_RESUME = 2,
+    _US_ACTION_MASK = 3,
+    _US_FORCE_UNWIND = 8,
+    _US_END_OF_STACK = 16
 }
 
 #[repr(C)]
@@ -69,9 +67,9 @@ pub static unwinder_private_data_size: int = 20;
 pub static unwinder_private_data_size: int = 2;
 
 pub struct _Unwind_Exception {
-    exception_class: _Unwind_Exception_Class,
-    exception_cleanup: _Unwind_Exception_Cleanup_Fn,
-    private: [_Unwind_Word, ..unwinder_private_data_size],
+    pub exception_class: _Unwind_Exception_Class,
+    pub exception_cleanup: _Unwind_Exception_Cleanup_Fn,
+    pub private: [_Unwind_Word, ..unwinder_private_data_size],
 }
 
 pub enum _Unwind_Context {}

--- a/src/libstd/rt/local_heap.rs
+++ b/src/libstd/rt/local_heap.rs
@@ -33,14 +33,14 @@ static MAGIC: u32 = 0xbadc0ffe;
 pub type Box = raw::Box<()>;
 
 pub struct MemoryRegion {
-    priv allocations: Vec<*AllocHeader>,
-    priv live_allocations: uint,
+    allocations: Vec<*AllocHeader>,
+    live_allocations: uint,
 }
 
 pub struct LocalHeap {
-    priv memory_region: MemoryRegion,
+    memory_region: MemoryRegion,
 
-    priv live_allocs: *mut raw::Box<()>,
+    live_allocs: *mut raw::Box<()>,
 }
 
 impl LocalHeap {

--- a/src/libstd/rt/local_ptr.rs
+++ b/src/libstd/rt/local_ptr.rs
@@ -31,7 +31,7 @@ pub use self::compiled::*;
 /// Encapsulates a borrowed value. When this value goes out of scope, the
 /// pointer is returned.
 pub struct Borrowed<T> {
-    priv val: *(),
+    val: *(),
 }
 
 #[unsafe_destructor]

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -61,11 +61,11 @@ pub trait RemoteCallback {
 /// libuv (it does translation to windows under the hood).
 pub struct FileOpenConfig {
     /// Path to file to be opened
-    path: Path,
+    pub path: Path,
     /// Flags for file access mode (as per open(2))
-    flags: int,
+    pub flags: int,
     /// File creation mode, ignored unless O_CREAT is passed as part of flags
-    priv mode: int
+    pub mode: int
 }
 
 /// Description of what to do when a file handle is closed
@@ -83,7 +83,7 @@ pub enum CloseBehavior {
 }
 
 pub struct LocalIo<'a> {
-    priv factory: &'a mut IoFactory,
+    factory: &'a mut IoFactory,
 }
 
 #[unsafe_destructor]

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -43,18 +43,18 @@ use unstable::finally::Finally;
 /// in the struct. This contains a pointer to another struct that holds
 /// the type-specific state.
 pub struct Task {
-    heap: LocalHeap,
-    gc: GarbageCollector,
-    storage: LocalStorage,
-    unwinder: Unwinder,
-    death: Death,
-    destroyed: bool,
-    name: Option<SendStr>,
+    pub heap: LocalHeap,
+    pub gc: GarbageCollector,
+    pub storage: LocalStorage,
+    pub unwinder: Unwinder,
+    pub death: Death,
+    pub destroyed: bool,
+    pub name: Option<SendStr>,
 
-    stdout: Option<~Writer:Send>,
-    stderr: Option<~Writer:Send>,
+    pub stdout: Option<~Writer:Send>,
+    pub stderr: Option<~Writer:Send>,
 
-    priv imp: Option<~Runtime:Send>,
+    imp: Option<~Runtime:Send>,
 }
 
 pub struct GarbageCollector;
@@ -77,11 +77,11 @@ pub enum DeathAction {
 
 /// Per-task state related to task death, killing, failure, etc.
 pub struct Death {
-    on_exit: Option<DeathAction>,
+    pub on_exit: Option<DeathAction>,
 }
 
 pub struct BlockedTasks {
-    priv inner: UnsafeArc<AtomicUint>,
+    inner: UnsafeArc<AtomicUint>,
 }
 
 impl Task {

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -28,9 +28,9 @@ type StartFn = extern "C" fn(*libc::c_void) -> imp::rust_thread_return;
 /// This struct represents a native thread's state. This is used to join on an
 /// existing thread created in the join-able state.
 pub struct Thread<T> {
-    priv native: imp::rust_thread,
-    priv joined: bool,
-    priv packet: ~Option<T>,
+    native: imp::rust_thread,
+    joined: bool,
+    packet: ~Option<T>,
 }
 
 static DEFAULT_STACK_SIZE: uint = 1024 * 1024;

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -75,8 +75,8 @@ use intrinsics;
 use uw = rt::libunwind;
 
 pub struct Unwinder {
-    priv unwinding: bool,
-    priv cause: Option<~Any:Send>
+    unwinding: bool,
+    cause: Option<~Any:Send>
 }
 
 impl Unwinder {

--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -233,10 +233,10 @@ pub fn mut_ref_slice<'a, A>(s: &'a mut A) -> &'a mut [A] {
 /// An iterator over the slices of a vector separated by elements that
 /// match a predicate function.
 pub struct Splits<'a, T> {
-    priv v: &'a [T],
-    priv n: uint,
-    priv pred: 'a |t: &T| -> bool,
-    priv finished: bool
+    v: &'a [T],
+    n: uint,
+    pred: 'a |t: &T| -> bool,
+    finished: bool
 }
 
 impl<'a, T> Iterator<&'a [T]> for Splits<'a, T> {
@@ -282,10 +282,10 @@ impl<'a, T> Iterator<&'a [T]> for Splits<'a, T> {
 /// An iterator over the slices of a vector separated by elements that
 /// match a predicate function, from back to front.
 pub struct RevSplits<'a, T> {
-    priv v: &'a [T],
-    priv n: uint,
-    priv pred: 'a |t: &T| -> bool,
-    priv finished: bool
+    v: &'a [T],
+    n: uint,
+    pred: 'a |t: &T| -> bool,
+    finished: bool
 }
 
 impl<'a, T> Iterator<&'a [T]> for RevSplits<'a, T> {
@@ -411,9 +411,9 @@ pub fn unzip<T, U, V: Iterator<(T, U)>>(mut iter: V) -> (~[T], ~[U]) {
 /// The last generated swap is always (0, 1), and it returns the
 /// sequence to its initial order.
 pub struct ElementSwaps {
-    priv sdir: ~[SizeDirection],
+    sdir: ~[SizeDirection],
     /// If true, emit the last swap that returns the sequence to initial state
-    priv emit_reset: bool,
+    emit_reset: bool,
 }
 
 impl ElementSwaps {
@@ -486,8 +486,8 @@ impl Iterator<(uint, uint)> for ElementSwaps {
 ///
 /// Generates even and odd permutations alternately.
 pub struct Permutations<T> {
-    priv swaps: ElementSwaps,
-    priv v: ~[T],
+    swaps: ElementSwaps,
+    v: ~[T],
 }
 
 impl<T: Clone> Iterator<~[T]> for Permutations<T> {
@@ -508,8 +508,8 @@ impl<T: Clone> Iterator<~[T]> for Permutations<T> {
 /// a vector.
 #[deriving(Clone)]
 pub struct Windows<'a, T> {
-    priv v: &'a [T],
-    priv size: uint
+    v: &'a [T],
+    size: uint
 }
 
 impl<'a, T> Iterator<&'a [T]> for Windows<'a, T> {
@@ -542,8 +542,8 @@ impl<'a, T> Iterator<&'a [T]> for Windows<'a, T> {
 /// the last slice of the iteration will be the remainder.
 #[deriving(Clone)]
 pub struct Chunks<'a, T> {
-    priv v: &'a [T],
-    priv size: uint
+    v: &'a [T],
+    size: uint
 }
 
 impl<'a, T> Iterator<&'a [T]> for Chunks<'a, T> {
@@ -2632,17 +2632,17 @@ impl<A> Default for ~[A] {
 
 /// Immutable slice iterator
 pub struct Items<'a, T> {
-    priv ptr: *T,
-    priv end: *T,
-    priv marker: marker::ContravariantLifetime<'a>
+    ptr: *T,
+    end: *T,
+    marker: marker::ContravariantLifetime<'a>
 }
 
 /// Mutable slice iterator
 pub struct MutItems<'a, T> {
-    priv ptr: *mut T,
-    priv end: *mut T,
-    priv marker: marker::ContravariantLifetime<'a>,
-    priv marker2: marker::NoCopy
+    ptr: *mut T,
+    end: *mut T,
+    marker: marker::ContravariantLifetime<'a>,
+    marker2: marker::NoCopy
 }
 
 macro_rules! iterator {
@@ -2735,9 +2735,9 @@ pub type RevMutItems<'a, T> = Rev<MutItems<'a, T>>;
 /// An iterator over the subslices of the vector which are separated
 /// by elements that match `pred`.
 pub struct MutSplits<'a, T> {
-    priv v: &'a mut [T],
-    priv pred: 'a |t: &T| -> bool,
-    priv finished: bool
+    v: &'a mut [T],
+    pred: 'a |t: &T| -> bool,
+    finished: bool
 }
 
 impl<'a, T> Iterator<&'a mut [T]> for MutSplits<'a, T> {
@@ -2800,8 +2800,8 @@ impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutSplits<'a, T> {
 /// the vector len is not evenly divided by the chunk size, the last slice of the iteration will be
 /// the remainder.
 pub struct MutChunks<'a, T> {
-    priv v: &'a mut [T],
-    priv chunk_size: uint
+    v: &'a mut [T],
+    chunk_size: uint
 }
 
 impl<'a, T> Iterator<&'a mut [T]> for MutChunks<'a, T> {
@@ -2849,8 +2849,8 @@ impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutChunks<'a, T> {
 
 /// An iterator that moves out of a vector.
 pub struct MoveItems<T> {
-    priv allocation: *mut u8, // the block of memory allocated for the vector
-    priv iter: Items<'static, T>
+    allocation: *mut u8, // the block of memory allocated for the vector
+    iter: Items<'static, T>
 }
 
 impl<T> Iterator<T> for MoveItems<T> {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -275,7 +275,7 @@ Section: Iterators
 #[deriving(Clone)]
 pub struct Chars<'a> {
     /// The slice remaining to be iterated
-    priv string: &'a str,
+    string: &'a str,
 }
 
 impl<'a> Iterator<char> for Chars<'a> {
@@ -320,8 +320,8 @@ impl<'a> DoubleEndedIterator<char> for Chars<'a> {
 #[deriving(Clone)]
 pub struct CharOffsets<'a> {
     /// The original string to be iterated
-    priv string: &'a str,
-    priv iter: Chars<'a>,
+    string: &'a str,
+    iter: Chars<'a>,
 }
 
 impl<'a> Iterator<(uint, char)> for CharOffsets<'a> {
@@ -371,12 +371,12 @@ pub type RevBytes<'a> = Rev<Bytes<'a>>;
 #[deriving(Clone)]
 pub struct CharSplits<'a, Sep> {
     /// The slice remaining to be iterated
-    priv string: &'a str,
-    priv sep: Sep,
+    string: &'a str,
+    sep: Sep,
     /// Whether an empty string at the end is allowed
-    priv allow_trailing_empty: bool,
-    priv only_ascii: bool,
-    priv finished: bool,
+    allow_trailing_empty: bool,
+    only_ascii: bool,
+    finished: bool,
 }
 
 /// An iterator over the substrings of a string, separated by `sep`,
@@ -387,10 +387,10 @@ pub type RevCharSplits<'a, Sep> = Rev<CharSplits<'a, Sep>>;
 /// splitting at most `count` times.
 #[deriving(Clone)]
 pub struct CharSplitsN<'a, Sep> {
-    priv iter: CharSplits<'a, Sep>,
+    iter: CharSplits<'a, Sep>,
     /// The number of splits remaining
-    priv count: uint,
-    priv invert: bool,
+    count: uint,
+    invert: bool,
 }
 
 /// An iterator over the words of a string, separated by a sequence of whitespace
@@ -503,18 +503,18 @@ impl<'a, Sep: CharEq> Iterator<&'a str> for CharSplitsN<'a, Sep> {
 /// substring within a larger string
 #[deriving(Clone)]
 pub struct MatchIndices<'a> {
-    priv haystack: &'a str,
-    priv needle: &'a str,
-    priv position: uint,
+    haystack: &'a str,
+    needle: &'a str,
+    position: uint,
 }
 
 /// An iterator over the substrings of a string separated by a given
 /// search string
 #[deriving(Clone)]
 pub struct StrSplits<'a> {
-    priv it: MatchIndices<'a>,
-    priv last_end: uint,
-    priv finished: bool
+    it: MatchIndices<'a>,
+    last_end: uint,
+    finished: bool
 }
 
 impl<'a> Iterator<(uint, uint)> for MatchIndices<'a> {
@@ -597,10 +597,10 @@ enum NormalizationForm {
 /// Use with the `std::iter` module.
 #[deriving(Clone)]
 pub struct Normalizations<'a> {
-    priv kind: NormalizationForm,
-    priv iter: Chars<'a>,
-    priv buffer: ~[(char, u8)],
-    priv sorted: bool
+    kind: NormalizationForm,
+    iter: Chars<'a>,
+    buffer: ~[(char, u8)],
+    sorted: bool
 }
 
 impl<'a> Iterator<char> for Normalizations<'a> {
@@ -856,7 +856,7 @@ pub fn is_utf16(v: &[u16]) -> bool {
 /// of `u16`s.
 #[deriving(Clone)]
 pub struct UTF16Items<'a> {
-    priv iter: slice::Items<'a, u16>
+    iter: slice::Items<'a, u16>
 }
 /// The possibilities for values decoded from a `u16` stream.
 #[deriving(Eq, TotalEq, Clone, Show)]
@@ -1061,9 +1061,9 @@ pub fn utf8_char_width(b: u8) -> uint {
 /// for iterating over the UTF-8 bytes of a string.
 pub struct CharRange {
     /// Current `char`
-    ch: char,
+    pub ch: char,
     /// Index of the first byte of the next `char`
-    next: uint
+    pub next: uint,
 }
 
 // Return the initial codepoint accumulator for the first byte.

--- a/src/libstd/sync/arc.rs
+++ b/src/libstd/sync/arc.rs
@@ -35,7 +35,7 @@ use ty::Unsafe;
 /// Enforces no shared-memory safety.
 #[unsafe_no_drop_flag]
 pub struct UnsafeArc<T> {
-    priv data: *mut ArcData<T>,
+    data: *mut ArcData<T>,
 }
 
 struct ArcData<T> {

--- a/src/libstd/sync/atomics.rs
+++ b/src/libstd/sync/atomics.rs
@@ -116,26 +116,26 @@ use ty::Unsafe;
 
 /// An atomic boolean type.
 pub struct AtomicBool {
-    priv v: Unsafe<uint>,
-    priv nocopy: marker::NoCopy
+    v: Unsafe<uint>,
+    nocopy: marker::NoCopy
 }
 
 /// A signed atomic integer type, supporting basic atomic arithmetic operations
 pub struct AtomicInt {
-    priv v: Unsafe<int>,
-    priv nocopy: marker::NoCopy
+    v: Unsafe<int>,
+    nocopy: marker::NoCopy
 }
 
 /// An unsigned atomic integer type, supporting basic atomic arithmetic operations
 pub struct AtomicUint {
-    priv v: Unsafe<uint>,
-    priv nocopy: marker::NoCopy
+    v: Unsafe<uint>,
+    nocopy: marker::NoCopy
 }
 
 /// An unsafe atomic pointer. Only supports basic atomic operations
 pub struct AtomicPtr<T> {
-    priv p: Unsafe<uint>,
-    priv nocopy: marker::NoCopy
+    p: Unsafe<uint>,
+    nocopy: marker::NoCopy
 }
 
 /// An atomic, nullable unique pointer
@@ -144,7 +144,7 @@ pub struct AtomicPtr<T> {
 /// owned heap objects across tasks.
 #[unsafe_no_drop_flag]
 pub struct AtomicOption<T> {
-    priv p: Unsafe<uint>,
+    p: Unsafe<uint>,
 }
 
 /// Atomic memory orderings

--- a/src/libstd/sync/deque.rs
+++ b/src/libstd/sync/deque.rs
@@ -86,14 +86,14 @@ struct Deque<T> {
 ///
 /// There may only be one worker per deque.
 pub struct Worker<T> {
-    priv deque: UnsafeArc<Deque<T>>,
+    deque: UnsafeArc<Deque<T>>,
 }
 
 /// The stealing half of the work-stealing deque. Stealers have access to the
 /// opposite end of the deque from the worker, and they only have access to the
 /// `steal` method.
 pub struct Stealer<T> {
-    priv deque: UnsafeArc<Deque<T>>,
+    deque: UnsafeArc<Deque<T>>,
 }
 
 /// When stealing some data, this is an enumeration of the possible outcomes.
@@ -116,7 +116,7 @@ pub enum Stolen<T> {
 /// will only use this structure when allocating a new buffer or deallocating a
 /// previous one.
 pub struct BufferPool<T> {
-    priv pool: Exclusive<~[~Buffer<T>]>,
+    pool: Exclusive<~[~Buffer<T>]>,
 }
 
 /// An internal buffer used by the chase-lev deque. This structure is actually

--- a/src/libstd/sync/mpmc_bounded_queue.rs
+++ b/src/libstd/sync/mpmc_bounded_queue.rs
@@ -54,7 +54,7 @@ struct State<T> {
 }
 
 pub struct Queue<T> {
-    priv state: UnsafeArc<State<T>>,
+    state: UnsafeArc<State<T>>,
 }
 
 impl<T: Send> State<T> {

--- a/src/libstd/sync/mpsc_queue.rs
+++ b/src/libstd/sync/mpsc_queue.rs
@@ -67,8 +67,8 @@ struct Node<T> {
 /// may be safely shared so long as it is guaranteed that there is only one
 /// popper at a time (many pushers are allowed).
 pub struct Queue<T> {
-    priv head: AtomicPtr<Node<T>>,
-    priv tail: *mut Node<T>,
+    head: AtomicPtr<Node<T>>,
+    tail: *mut Node<T>,
 }
 
 impl<T> Node<T> {

--- a/src/libstd/sync/spsc_queue.rs
+++ b/src/libstd/sync/spsc_queue.rs
@@ -55,19 +55,19 @@ struct Node<T> {
 /// time.
 pub struct Queue<T> {
     // consumer fields
-    priv tail: *mut Node<T>, // where to pop from
-    priv tail_prev: AtomicPtr<Node<T>>, // where to pop from
+    tail: *mut Node<T>, // where to pop from
+    tail_prev: AtomicPtr<Node<T>>, // where to pop from
 
     // producer fields
-    priv head: *mut Node<T>,      // where to push to
-    priv first: *mut Node<T>,     // where to get new nodes from
-    priv tail_copy: *mut Node<T>, // between first/tail
+    head: *mut Node<T>,      // where to push to
+    first: *mut Node<T>,     // where to get new nodes from
+    tail_copy: *mut Node<T>, // between first/tail
 
     // Cache maintenance fields. Additions and subtractions are stored
     // separately in order to allow them to use nonatomic addition/subtraction.
-    priv cache_bound: uint,
-    priv cache_additions: AtomicUint,
-    priv cache_subtractions: AtomicUint,
+    cache_bound: uint,
+    cache_additions: AtomicUint,
+    cache_subtractions: AtomicUint,
 }
 
 impl<T: Send> Node<T> {

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -60,15 +60,15 @@ pub type TaskResult = Result<(), ~Any:Send>;
 /// Task configuration options
 pub struct TaskOpts {
     /// Enable lifecycle notifications on the given channel
-    notify_chan: Option<Sender<TaskResult>>,
+    pub notify_chan: Option<Sender<TaskResult>>,
     /// A name for the task-to-be, for identification in failure messages
-    name: Option<SendStr>,
+    pub name: Option<SendStr>,
     /// The size of the stack for the spawned task
-    stack_size: Option<uint>,
+    pub stack_size: Option<uint>,
     /// Task-local stdout
-    stdout: Option<~Writer:Send>,
+    pub stdout: Option<~Writer:Send>,
     /// Task-local stderr
-    stderr: Option<~Writer:Send>,
+    pub stderr: Option<~Writer:Send>,
 }
 
 /**
@@ -85,9 +85,9 @@ pub struct TaskOpts {
 // the run function move them in.
 pub struct TaskBuilder {
     /// Options to spawn the new task with
-    opts: TaskOpts,
-    priv gen_body: Option<proc:Send(v: proc:Send()) -> proc:Send()>,
-    priv nocopy: Option<marker::NoCopy>,
+    pub opts: TaskOpts,
+    gen_body: Option<proc:Send(v: proc:Send()) -> proc:Send()>,
+    nocopy: Option<marker::NoCopy>,
 }
 
 /**

--- a/src/libstd/ty.rs
+++ b/src/libstd/ty.rs
@@ -48,10 +48,10 @@ use kinds::marker;
 #[lang="unsafe"]
 pub struct Unsafe<T> {
     /// Wrapped value
-    value: T,
+    pub value: T,
 
     /// Invariance marker
-    marker1: marker::InvariantType<T>
+    pub marker1: marker::InvariantType<T>
 }
 
 impl<T> Unsafe<T> {

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -22,7 +22,7 @@ use ops::*;
 use option::*;
 use result::*;
 
-pub struct DynamicLibrary { priv handle: *u8}
+pub struct DynamicLibrary { handle: *u8}
 
 impl Drop for DynamicLibrary {
     fn drop(&mut self) {

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -67,7 +67,7 @@ use ops::Drop;
 /// Prefer the `NativeMutex` type where possible, since that does not
 /// require manual deallocation.
 pub struct StaticNativeMutex {
-    priv inner: imp::Mutex,
+    inner: imp::Mutex,
 }
 
 /// A native mutex with a destructor for clean-up.
@@ -75,7 +75,7 @@ pub struct StaticNativeMutex {
 /// See `StaticNativeMutex` for a version that is suitable for storing in
 /// statics.
 pub struct NativeMutex {
-    priv inner: StaticNativeMutex
+    inner: StaticNativeMutex
 }
 
 /// Automatically unlocks the mutex that it was created from on
@@ -86,7 +86,7 @@ pub struct NativeMutex {
 /// then.
 #[must_use]
 pub struct LockGuard<'a> {
-    priv lock: &'a StaticNativeMutex
+    lock: &'a StaticNativeMutex
 }
 
 pub static NATIVE_MUTEX_INIT: StaticNativeMutex = StaticNativeMutex {
@@ -372,8 +372,8 @@ mod imp {
     }
 
     pub struct Mutex {
-        priv lock: Unsafe<pthread_mutex_t>,
-        priv cond: Unsafe<pthread_cond_t>,
+        lock: Unsafe<pthread_mutex_t>,
+        cond: Unsafe<pthread_cond_t>,
     }
 
     pub static MUTEX_INIT: Mutex = Mutex {
@@ -447,8 +447,8 @@ mod imp {
 
     pub struct Mutex {
         // pointers for the lock/cond handles, atomically updated
-        priv lock: atomics::AtomicUint,
-        priv cond: atomics::AtomicUint,
+        lock: atomics::AtomicUint,
+        cond: atomics::AtomicUint,
     }
 
     pub static MUTEX_INIT: Mutex = Mutex {

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -30,7 +30,7 @@ struct ExData<T> {
  * need to block or deschedule while accessing shared state, use extra::sync::RWArc.
  */
 pub struct Exclusive<T> {
-    priv x: UnsafeArc<ExData<T>>
+    x: UnsafeArc<ExData<T>>
 }
 
 impl<T:Send> Clone for Exclusive<T> {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -56,9 +56,9 @@ use slice::{MutableTotalOrdVector, Vector};
 /// ```
 #[unsafe_no_drop_flag]
 pub struct Vec<T> {
-    priv len: uint,
-    priv cap: uint,
-    priv ptr: *mut T
+    len: uint,
+    cap: uint,
+    ptr: *mut T
 }
 
 impl<T> Vec<T> {
@@ -1308,8 +1308,8 @@ impl<T:fmt::Show> fmt::Show for Vec<T> {
 
 /// An iterator that moves out of a vector.
 pub struct MoveItems<T> {
-    priv allocation: *mut c_void, // the block of memory allocated for the vector
-    priv iter: Items<'static, T>
+    allocation: *mut c_void, // the block of memory allocated for the vector
+    iter: Items<'static, T>
 }
 
 impl<T> Iterator<T> for MoveItems<T> {

--- a/src/libsync/arc.rs
+++ b/src/libsync/arc.rs
@@ -46,7 +46,7 @@ use std::sync::atomics;
 /// ```
 #[unsafe_no_drop_flag]
 pub struct Arc<T> {
-    priv x: *mut ArcInner<T>,
+    x: *mut ArcInner<T>,
 }
 
 /// A weak pointer to an `Arc`.
@@ -55,7 +55,7 @@ pub struct Arc<T> {
 /// used to break cycles between `Arc` pointers.
 #[unsafe_no_drop_flag]
 pub struct Weak<T> {
-    priv x: *mut ArcInner<T>,
+    x: *mut ArcInner<T>,
 }
 
 struct ArcInner<T> {

--- a/src/libsync/comm.rs
+++ b/src/libsync/comm.rs
@@ -20,8 +20,8 @@ use std::comm;
 
 /// An extension of `pipes::stream` that allows both sending and receiving.
 pub struct DuplexStream<S, R> {
-    priv tx: Sender<S>,
-    priv rx: Receiver<R>,
+    tx: Sender<S>,
+    rx: Receiver<R>,
 }
 
 /// Creates a bidirectional stream.

--- a/src/libsync/future.rs
+++ b/src/libsync/future.rs
@@ -30,7 +30,7 @@ use std::mem::replace;
 
 /// A type encapsulating the result of a computation which may not be complete
 pub struct Future<A> {
-    priv state: FutureState<A>,
+    state: FutureState<A>,
 }
 
 enum FutureState<A> {

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -20,7 +20,11 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://static.rust-lang.org/doc/master")]
 #![feature(phase)]
-#![deny(missing_doc, deprecated_owned_vector)]
+#![deny(deprecated_owned_vector)]
+
+// #![deny(missing_doc)] // NOTE: uncomment after a stage0 snap
+#![allow(missing_doc)] // NOTE: remove after a stage0 snap
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
 
 #[cfg(test)]
 #[phase(syntax, link)] extern crate log;

--- a/src/libsync/lock.rs
+++ b/src/libsync/lock.rs
@@ -79,12 +79,12 @@ impl<'b> Inner<'b> {
 /// A condition variable, a mechanism for unlock-and-descheduling and
 /// signaling, for use with the lock types.
 pub struct Condvar<'a> {
-    priv name: &'static str,
+    name: &'static str,
     // n.b. Inner must be after PoisonOnFail because we must set the poison flag
     //      *inside* the mutex, and struct fields are destroyed top-to-bottom
     //      (destroy the lock guard last).
-    priv poison: PoisonOnFail<'a>,
-    priv inner: Inner<'a>,
+    poison: PoisonOnFail<'a>,
+    inner: Inner<'a>,
 }
 
 impl<'a> Condvar<'a> {
@@ -166,18 +166,18 @@ impl<'a> Condvar<'a> {
 /// }
 /// ```
 pub struct Mutex<T> {
-    priv lock: raw::Mutex,
-    priv failed: Unsafe<bool>,
-    priv data: Unsafe<T>,
+    lock: raw::Mutex,
+    failed: Unsafe<bool>,
+    data: Unsafe<T>,
 }
 
 /// An guard which is created by locking a mutex. Through this guard the
 /// underlying data can be accessed.
 pub struct MutexGuard<'a, T> {
-    priv data: &'a mut T,
+    data: &'a mut T,
     /// Inner condition variable connected to the locked mutex that this guard
     /// was created from. This can be used for atomic-unlock-and-deschedule.
-    cond: Condvar<'a>,
+    pub cond: Condvar<'a>,
 }
 
 impl<T: Send> Mutex<T> {
@@ -265,25 +265,25 @@ impl<'a, T> DerefMut<T> for MutexGuard<'a, T> {
 /// println!("{}", *val);
 /// ```
 pub struct RWLock<T> {
-    priv lock: raw::RWLock,
-    priv failed: Unsafe<bool>,
-    priv data: Unsafe<T>,
+    lock: raw::RWLock,
+    failed: Unsafe<bool>,
+    data: Unsafe<T>,
 }
 
 /// A guard which is created by locking an rwlock in write mode. Through this
 /// guard the underlying data can be accessed.
 pub struct RWLockWriteGuard<'a, T> {
-    priv data: &'a mut T,
+    data: &'a mut T,
     /// Inner condition variable that can be used to sleep on the write mode of
     /// this rwlock.
-    cond: Condvar<'a>,
+    pub cond: Condvar<'a>,
 }
 
 /// A guard which is created by locking an rwlock in read mode. Through this
 /// guard the underlying data can be accessed.
 pub struct RWLockReadGuard<'a, T> {
-    priv data: &'a T,
-    priv guard: raw::RWLockReadGuard<'a>,
+    data: &'a T,
+    guard: raw::RWLockReadGuard<'a>,
 }
 
 impl<T: Send + Share> RWLock<T> {
@@ -397,8 +397,8 @@ impl<'a, T> DerefMut<T> for RWLockWriteGuard<'a, T> {
 /// }
 /// ```
 pub struct Barrier {
-    priv lock: Mutex<BarrierState>,
-    priv num_tasks: uint,
+    lock: Mutex<BarrierState>,
+    num_tasks: uint,
 }
 
 // The inner state of a double barrier

--- a/src/libsync/mpsc_intrusive.rs
+++ b/src/libsync/mpsc_intrusive.rs
@@ -41,18 +41,18 @@ use std::ty::Unsafe;
 // initialization.
 
 pub struct Node<T> {
-    next: atomics::AtomicUint,
-    data: T,
+    pub next: atomics::AtomicUint,
+    pub data: T,
 }
 
 pub struct DummyNode {
-    next: atomics::AtomicUint,
+    pub next: atomics::AtomicUint,
 }
 
 pub struct Queue<T> {
-    head: atomics::AtomicUint,
-    tail: Unsafe<*mut Node<T>>,
-    stub: DummyNode,
+    pub head: atomics::AtomicUint,
+    pub tail: Unsafe<*mut Node<T>>,
+    pub stub: DummyNode,
 }
 
 impl<T: Send> Queue<T> {

--- a/src/libsync/mutex.rs
+++ b/src/libsync/mutex.rs
@@ -94,7 +94,7 @@ pub static NATIVE_BLOCKED: uint = 1 << 2;
 /// drop(guard); // unlock the lock
 /// ```
 pub struct Mutex {
-    priv lock: StaticMutex,
+    lock: StaticMutex,
 }
 
 #[deriving(Eq, Show)]
@@ -128,28 +128,28 @@ enum Flavor {
 /// ```
 pub struct StaticMutex {
     /// Current set of flags on this mutex
-    priv state: atomics::AtomicUint,
+    state: atomics::AtomicUint,
     /// an OS mutex used by native threads
-    priv lock: mutex::StaticNativeMutex,
+    lock: mutex::StaticNativeMutex,
 
     /// Type of locking operation currently on this mutex
-    priv flavor: Unsafe<Flavor>,
+    flavor: Unsafe<Flavor>,
     /// uint-cast of the green thread waiting for this mutex
-    priv green_blocker: Unsafe<uint>,
+    green_blocker: Unsafe<uint>,
     /// uint-cast of the native thread waiting for this mutex
-    priv native_blocker: Unsafe<uint>,
+    native_blocker: Unsafe<uint>,
 
     /// A concurrent mpsc queue used by green threads, along with a count used
     /// to figure out when to dequeue and enqueue.
-    priv q: q::Queue<uint>,
-    priv green_cnt: atomics::AtomicUint,
+    q: q::Queue<uint>,
+    green_cnt: atomics::AtomicUint,
 }
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
 #[must_use]
 pub struct Guard<'a> {
-    priv lock: &'a StaticMutex,
+    lock: &'a StaticMutex,
 }
 
 /// Static initialization of a mutex. This constant can be used to initialize

--- a/src/libsync/one.rs
+++ b/src/libsync/one.rs
@@ -41,9 +41,9 @@ use mutex::{StaticMutex, MUTEX_INIT};
 /// }
 /// ```
 pub struct Once {
-    priv mutex: StaticMutex,
-    priv cnt: atomics::AtomicInt,
-    priv lock_cnt: atomics::AtomicInt,
+    mutex: StaticMutex,
+    cnt: atomics::AtomicInt,
+    lock_cnt: atomics::AtomicInt,
 }
 
 /// Initialization value for static `Once` values.

--- a/src/libsync/task_pool.rs
+++ b/src/libsync/task_pool.rs
@@ -21,8 +21,8 @@ enum Msg<T> {
 }
 
 pub struct TaskPool<T> {
-    priv channels: Vec<Sender<Msg<T>>>,
-    priv next_index: uint,
+    channels: Vec<Sender<Msg<T>>>,
+    next_index: uint,
 }
 
 #[unsafe_destructor]

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -67,7 +67,7 @@ pub enum AbiArchitecture {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct AbiSet {
-    priv bits: u32   // each bit represents one of the abis below
+    bits: u32   // each bit represents one of the abis below
 }
 
 static AbiDatas: &'static [AbiData] = &[

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -40,8 +40,8 @@ pub fn P<T: 'static>(value: T) -> P<T> {
 // That Work Together"
 #[deriving(Clone, Hash, Ord, TotalEq, TotalOrd, Show)]
 pub struct Ident {
-    name: Name,
-    ctxt: SyntaxContext
+    pub name: Name,
+    pub ctxt: SyntaxContext
 }
 
 impl Ident {
@@ -115,9 +115,9 @@ pub type FnIdent = Option<Ident>;
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Lifetime {
-    id: NodeId,
-    span: Span,
-    name: Name
+    pub id: NodeId,
+    pub span: Span,
+    pub name: Name
 }
 
 // a "Path" is essentially Rust's notion of a name;
@@ -126,12 +126,12 @@ pub struct Lifetime {
 // of supporting information.
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Path {
-    span: Span,
+    pub span: Span,
     /// A `::foo` path, is relative to the crate root rather than current
     /// module (like paths in an import).
-    global: bool,
+    pub global: bool,
     /// The segments in the path: the things separated by `::`.
-    segments: Vec<PathSegment> ,
+    pub segments: Vec<PathSegment> ,
 }
 
 /// A segment of a path: an identifier, an optional lifetime, and a set of
@@ -139,11 +139,11 @@ pub struct Path {
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct PathSegment {
     /// The identifier portion of this path segment.
-    identifier: Ident,
+    pub identifier: Ident,
     /// The lifetime parameters for this path segment.
-    lifetimes: Vec<Lifetime>,
+    pub lifetimes: Vec<Lifetime>,
     /// The type parameters for this path segment, if present.
-    types: OwnedSlice<P<Ty>>,
+    pub types: OwnedSlice<P<Ty>>,
 }
 
 pub type CrateNum = u32;
@@ -152,8 +152,8 @@ pub type NodeId = u32;
 
 #[deriving(Clone, TotalEq, TotalOrd, Ord, Eq, Encodable, Decodable, Hash, Show)]
 pub struct DefId {
-    krate: CrateNum,
-    node: NodeId,
+    pub krate: CrateNum,
+    pub node: NodeId,
 }
 
 /// Item definitions in the currently-compiled crate would have the CrateNum
@@ -178,16 +178,16 @@ pub enum TyParamBound {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct TyParam {
-    ident: Ident,
-    id: NodeId,
-    bounds: OwnedSlice<TyParamBound>,
-    default: Option<P<Ty>>
+    pub ident: Ident,
+    pub id: NodeId,
+    pub bounds: OwnedSlice<TyParamBound>,
+    pub default: Option<P<Ty>>
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Generics {
-    lifetimes: Vec<Lifetime>,
-    ty_params: OwnedSlice<TyParam>,
+    pub lifetimes: Vec<Lifetime>,
+    pub ty_params: OwnedSlice<TyParam>,
 }
 
 impl Generics {
@@ -259,10 +259,10 @@ pub type CrateConfig = Vec<@MetaItem> ;
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Crate {
-    module: Mod,
-    attrs: Vec<Attribute> ,
-    config: CrateConfig,
-    span: Span,
+    pub module: Mod,
+    pub attrs: Vec<Attribute>,
+    pub config: CrateConfig,
+    pub span: Span,
 }
 
 pub type MetaItem = Spanned<MetaItem_>;
@@ -301,25 +301,25 @@ impl Eq for MetaItem_ {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Block {
-    view_items: Vec<ViewItem> ,
-    stmts: Vec<@Stmt> ,
-    expr: Option<@Expr>,
-    id: NodeId,
-    rules: BlockCheckMode,
-    span: Span,
+    pub view_items: Vec<ViewItem>,
+    pub stmts: Vec<@Stmt>,
+    pub expr: Option<@Expr>,
+    pub id: NodeId,
+    pub rules: BlockCheckMode,
+    pub span: Span,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Pat {
-    id: NodeId,
-    node: Pat_,
-    span: Span,
+    pub id: NodeId,
+    pub node: Pat_,
+    pub span: Span,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct FieldPat {
-    ident: Ident,
-    pat: @Pat,
+    pub ident: Ident,
+    pub pat: @Pat,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -436,11 +436,11 @@ pub enum Stmt_ {
 /// Local represents a `let` statement, e.g., `let <pat>:<ty> = <expr>;`
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Local {
-    ty: P<Ty>,
-    pat: @Pat,
-    init: Option<@Expr>,
-    id: NodeId,
-    span: Span,
+    pub ty: P<Ty>,
+    pub pat: @Pat,
+    pub init: Option<@Expr>,
+    pub id: NodeId,
+    pub span: Span,
 }
 
 pub type Decl = Spanned<Decl_>;
@@ -455,16 +455,16 @@ pub enum Decl_ {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Arm {
-    pats: Vec<@Pat> ,
-    guard: Option<@Expr>,
-    body: @Expr,
+    pub pats: Vec<@Pat>,
+    pub guard: Option<@Expr>,
+    pub body: @Expr,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Field {
-    ident: SpannedIdent,
-    expr: @Expr,
-    span: Span,
+    pub ident: SpannedIdent,
+    pub expr: @Expr,
+    pub span: Span,
 }
 
 pub type SpannedIdent = Spanned<Ident>;
@@ -483,9 +483,9 @@ pub enum UnsafeSource {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Expr {
-    id: NodeId,
-    node: Expr_,
-    span: Span,
+    pub id: NodeId,
+    pub node: Expr_,
+    pub span: Span,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -681,27 +681,27 @@ pub enum Lit_ {
 // type structure in middle/ty.rs as well.
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct MutTy {
-    ty: P<Ty>,
-    mutbl: Mutability,
+    pub ty: P<Ty>,
+    pub mutbl: Mutability,
 }
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct TypeField {
-    ident: Ident,
-    mt: MutTy,
-    span: Span,
+    pub ident: Ident,
+    pub mt: MutTy,
+    pub span: Span,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct TypeMethod {
-    ident: Ident,
-    attrs: Vec<Attribute> ,
-    purity: Purity,
-    decl: P<FnDecl>,
-    generics: Generics,
-    explicit_self: ExplicitSelf,
-    id: NodeId,
-    span: Span,
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub purity: Purity,
+    pub decl: P<FnDecl>,
+    pub generics: Generics,
+    pub explicit_self: ExplicitSelf,
+    pub id: NodeId,
+    pub span: Span,
 }
 
 // A trait method is either required (meaning it doesn't have an
@@ -758,9 +758,9 @@ impl fmt::Show for FloatTy {
 // NB Eq method appears below.
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Ty {
-    id: NodeId,
-    node: Ty_,
-    span: Span,
+    pub id: NodeId,
+    pub node: Ty_,
+    pub span: Span,
 }
 
 // Not represented directly in the AST, referred to by name through a ty_path.
@@ -791,25 +791,25 @@ impl fmt::Show for Onceness {
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct ClosureTy {
-    sigil: Sigil,
-    region: Option<Lifetime>,
-    lifetimes: Vec<Lifetime>,
-    purity: Purity,
-    onceness: Onceness,
-    decl: P<FnDecl>,
+    pub sigil: Sigil,
+    pub region: Option<Lifetime>,
+    pub lifetimes: Vec<Lifetime>,
+    pub purity: Purity,
+    pub onceness: Onceness,
+    pub decl: P<FnDecl>,
     // Optional optvec distinguishes between "fn()" and "fn:()" so we can
     // implement issue #7264. None means "fn()", which means infer a default
     // bound based on pointer sigil during typeck. Some(Empty) means "fn:()",
     // which means use no bounds (e.g., not even Owned on a ~fn()).
-    bounds: Option<OwnedSlice<TyParamBound>>,
+    pub bounds: Option<OwnedSlice<TyParamBound>>,
 }
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct BareFnTy {
-    purity: Purity,
-    abis: AbiSet,
-    lifetimes: Vec<Lifetime>,
-    decl: P<FnDecl>
+    pub purity: Purity,
+    pub abis: AbiSet,
+    pub lifetimes: Vec<Lifetime>,
+    pub decl: P<FnDecl>
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -840,21 +840,21 @@ pub enum AsmDialect {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct InlineAsm {
-    asm: InternedString,
-    asm_str_style: StrStyle,
-    clobbers: InternedString,
-    inputs: Vec<(InternedString, @Expr)> ,
-    outputs: Vec<(InternedString, @Expr)> ,
-    volatile: bool,
-    alignstack: bool,
-    dialect: AsmDialect
+    pub asm: InternedString,
+    pub asm_str_style: StrStyle,
+    pub clobbers: InternedString,
+    pub inputs: Vec<(InternedString, @Expr)>,
+    pub outputs: Vec<(InternedString, @Expr)>,
+    pub volatile: bool,
+    pub alignstack: bool,
+    pub dialect: AsmDialect
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Arg {
-    ty: P<Ty>,
-    pat: @Pat,
-    id: NodeId,
+    pub ty: P<Ty>,
+    pub pat: @Pat,
+    pub id: NodeId,
 }
 
 impl Arg {
@@ -879,10 +879,10 @@ impl Arg {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct FnDecl {
-    inputs: Vec<Arg> ,
-    output: P<Ty>,
-    cf: RetStyle,
-    variadic: bool
+    pub inputs: Vec<Arg>,
+    pub output: P<Ty>,
+    pub cf: RetStyle,
+    pub variadic: bool
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -921,64 +921,64 @@ pub type ExplicitSelf = Spanned<ExplicitSelf_>;
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Method {
-    ident: Ident,
-    attrs: Vec<Attribute> ,
-    generics: Generics,
-    explicit_self: ExplicitSelf,
-    purity: Purity,
-    decl: P<FnDecl>,
-    body: P<Block>,
-    id: NodeId,
-    span: Span,
-    vis: Visibility,
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub generics: Generics,
+    pub explicit_self: ExplicitSelf,
+    pub purity: Purity,
+    pub decl: P<FnDecl>,
+    pub body: P<Block>,
+    pub id: NodeId,
+    pub span: Span,
+    pub vis: Visibility,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Mod {
-    view_items: Vec<ViewItem> ,
-    items: Vec<@Item> ,
+    pub view_items: Vec<ViewItem> ,
+    pub items: Vec<@Item> ,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct ForeignMod {
-    abis: AbiSet,
-    view_items: Vec<ViewItem> ,
-    items: Vec<@ForeignItem> ,
+    pub abis: AbiSet,
+    pub view_items: Vec<ViewItem>,
+    pub items: Vec<@ForeignItem>,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct VariantArg {
-    ty: P<Ty>,
-    id: NodeId,
+    pub ty: P<Ty>,
+    pub id: NodeId,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub enum VariantKind {
-    TupleVariantKind(Vec<VariantArg> ),
+    TupleVariantKind(Vec<VariantArg>),
     StructVariantKind(@StructDef),
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct EnumDef {
-    variants: Vec<P<Variant>> ,
+    pub variants: Vec<P<Variant>>,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Variant_ {
-    name: Ident,
-    attrs: Vec<Attribute> ,
-    kind: VariantKind,
-    id: NodeId,
-    disr_expr: Option<@Expr>,
-    vis: Visibility,
+    pub name: Ident,
+    pub attrs: Vec<Attribute>,
+    pub kind: VariantKind,
+    pub id: NodeId,
+    pub disr_expr: Option<@Expr>,
+    pub vis: Visibility,
 }
 
 pub type Variant = Spanned<Variant_>;
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct PathListIdent_ {
-    name: Ident,
-    id: NodeId,
+    pub name: Ident,
+    pub id: NodeId,
 }
 
 pub type PathListIdent = Spanned<PathListIdent_>;
@@ -1004,10 +1004,10 @@ pub enum ViewPath_ {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct ViewItem {
-    node: ViewItem_,
-    attrs: Vec<Attribute> ,
-    vis: Visibility,
-    span: Span,
+    pub node: ViewItem_,
+    pub attrs: Vec<Attribute>,
+    pub vis: Visibility,
+    pub span: Span,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -1035,9 +1035,9 @@ pub enum AttrStyle {
 // doc-comments are promoted to attributes that have is_sugared_doc = true
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Attribute_ {
-    style: AttrStyle,
-    value: @MetaItem,
-    is_sugared_doc: bool,
+    pub style: AttrStyle,
+    pub value: @MetaItem,
+    pub is_sugared_doc: bool,
 }
 
 /*
@@ -1049,8 +1049,8 @@ pub struct Attribute_ {
  */
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct TraitRef {
-    path: Path,
-    ref_id: NodeId,
+    pub path: Path,
+    pub ref_id: NodeId,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -1071,10 +1071,10 @@ impl Visibility {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct StructField_ {
-    kind: StructFieldKind,
-    id: NodeId,
-    ty: P<Ty>,
-    attrs: Vec<Attribute> ,
+    pub kind: StructFieldKind,
+    pub id: NodeId,
+    pub ty: P<Ty>,
+    pub attrs: Vec<Attribute>,
 }
 
 pub type StructField = Spanned<StructField_>;
@@ -1096,10 +1096,10 @@ impl StructFieldKind {
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct StructDef {
-    fields: Vec<StructField> , /* fields, not including ctor */
+    pub fields: Vec<StructField>, /* fields, not including ctor */
     /* ID of the constructor. This is only used for tuple- or enum-like
      * structs. */
-    ctor_id: Option<NodeId>
+    pub ctor_id: Option<NodeId>
 }
 
 /*
@@ -1108,12 +1108,12 @@ pub struct StructDef {
  */
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Item {
-    ident: Ident,
-    attrs: Vec<Attribute> ,
-    id: NodeId,
-    node: Item_,
-    vis: Visibility,
-    span: Span,
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub id: NodeId,
+    pub node: Item_,
+    pub vis: Visibility,
+    pub span: Span,
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
@@ -1136,12 +1136,12 @@ pub enum Item_ {
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct ForeignItem {
-    ident: Ident,
-    attrs: Vec<Attribute> ,
-    node: ForeignItem_,
-    id: NodeId,
-    span: Span,
-    vis: Visibility,
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub node: ForeignItem_,
+    pub id: NodeId,
+    pub span: Span,
+    pub vis: Visibility,
 }
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -184,7 +184,7 @@ pub struct Map {
     ///
     /// Also, indexing is pretty quick when you've got a vector and
     /// plain old integers.
-    priv map: RefCell<Vec<MapEntry> >
+    map: RefCell<Vec<MapEntry> >
 }
 
 impl Map {

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -325,8 +325,8 @@ pub fn empty_generics() -> Generics {
 
 #[deriving(Encodable, Decodable)]
 pub struct IdRange {
-    min: NodeId,
-    max: NodeId,
+    pub min: NodeId,
+    pub max: NodeId,
 }
 
 impl IdRange {
@@ -352,9 +352,9 @@ pub trait IdVisitingOperation {
 }
 
 pub struct IdVisitor<'a, O> {
-    operation: &'a O,
-    pass_through_items: bool,
-    visited_outermost: bool,
+    pub operation: &'a O,
+    pub pass_through_items: bool,
+    pub visited_outermost: bool,
 }
 
 impl<'a, O: IdVisitingOperation> IdVisitor<'a, O> {

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -337,8 +337,8 @@ pub fn test_cfg<AM: AttrMetaMethods, It: Iterator<AM>>
 
 /// Represents the #[deprecated="foo"] (etc) attributes.
 pub struct Stability {
-    level: StabilityLevel,
-    text: Option<InternedString>
+    pub level: StabilityLevel,
+    pub text: Option<InternedString>
 }
 
 /// The available stability levels.

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -86,19 +86,19 @@ to the original source.
 */
 #[deriving(Clone, Show, Hash)]
 pub struct Span {
-    lo: BytePos,
-    hi: BytePos,
+    pub lo: BytePos,
+    pub hi: BytePos,
     /// Information about where the macro came from, if this piece of
     /// code was created by a macro expansion.
-    expn_info: Option<@ExpnInfo>
+    pub expn_info: Option<@ExpnInfo>
 }
 
 pub static DUMMY_SP: Span = Span { lo: BytePos(0), hi: BytePos(0), expn_info: None };
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct Spanned<T> {
-    node: T,
-    span: Span,
+    pub node: T,
+    pub span: Span,
 }
 
 impl Eq for Span {
@@ -143,26 +143,26 @@ pub fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
 /// A source code location used for error reporting
 pub struct Loc {
     /// Information about the original source
-    file: Rc<FileMap>,
+    pub file: Rc<FileMap>,
     /// The (1-based) line number
-    line: uint,
+    pub line: uint,
     /// The (0-based) column offset
-    col: CharPos
+    pub col: CharPos
 }
 
 /// A source code location used as the result of lookup_char_pos_adj
 // Actually, *none* of the clients use the filename *or* file field;
 // perhaps they should just be removed.
 pub struct LocWithOpt {
-    filename: FileName,
-    line: uint,
-    col: CharPos,
-    file: Option<Rc<FileMap>>,
+    pub filename: FileName,
+    pub line: uint,
+    pub col: CharPos,
+    pub file: Option<Rc<FileMap>>,
 }
 
 // used to be structural records. Better names, anyone?
-pub struct FileMapAndLine {fm: Rc<FileMap>, line: uint}
-pub struct FileMapAndBytePos {fm: Rc<FileMap>, pos: BytePos}
+pub struct FileMapAndLine { pub fm: Rc<FileMap>, pub line: uint }
+pub struct FileMapAndBytePos { pub fm: Rc<FileMap>, pub pos: BytePos }
 
 /// The syntax with which a macro was invoked.
 #[deriving(Clone, Hash, Show)]
@@ -177,13 +177,13 @@ pub enum MacroFormat {
 pub struct NameAndSpan {
     /// The name of the macro that was invoked to create the thing
     /// with this Span.
-    name: ~str,
+    pub name: ~str,
     /// The format with which the macro was invoked.
-    format: MacroFormat,
+    pub format: MacroFormat,
     /// The span of the macro definition itself. The macro may not
     /// have a sensible definition span (e.g. something defined
     /// completely inside libsyntax) in which case this is None.
-    span: Option<Span>
+    pub span: Option<Span>
 }
 
 /// Extra information for tracking macro expansion of spans
@@ -198,29 +198,29 @@ pub struct ExpnInfo {
     /// the expansion would point to the `bar!` invocation; that
     /// call_site span would have its own ExpnInfo, with the call_site
     /// pointing to the `foo!` invocation.
-    call_site: Span,
+    pub call_site: Span,
     /// Information about the macro and its definition.
     ///
     /// The `callee` of the inner expression in the `call_site`
     /// example would point to the `macro_rules! bar { ... }` and that
     /// of the `bar!()` invocation would point to the `macro_rules!
     /// foo { ... }`.
-    callee: NameAndSpan
+    pub callee: NameAndSpan
 }
 
 pub type FileName = ~str;
 
 pub struct FileLines {
-    file: Rc<FileMap>,
-    lines: Vec<uint>
+    pub file: Rc<FileMap>,
+    pub lines: Vec<uint>
 }
 
 /// Identifies an offset of a multi-byte character in a FileMap
 pub struct MultiByteChar {
     /// The absolute offset of the character in the CodeMap
-    pos: BytePos,
+    pub pos: BytePos,
     /// The number of bytes, >=2
-    bytes: uint,
+    pub bytes: uint,
 }
 
 /// A single source in the CodeMap
@@ -228,15 +228,15 @@ pub struct FileMap {
     /// The name of the file that the source came from, source that doesn't
     /// originate from files has names between angle brackets by convention,
     /// e.g. `<anon>`
-    name: FileName,
+    pub name: FileName,
     /// The complete source code
-    src: ~str,
+    pub src: ~str,
     /// The start position of this source in the CodeMap
-    start_pos: BytePos,
+    pub start_pos: BytePos,
     /// Locations of lines beginnings in the source code
-    lines: RefCell<Vec<BytePos> >,
+    pub lines: RefCell<Vec<BytePos> >,
     /// Locations of multi-byte characters in the source code
-    multibyte_chars: RefCell<Vec<MultiByteChar> >,
+    pub multibyte_chars: RefCell<Vec<MultiByteChar> >,
 }
 
 impl FileMap {
@@ -284,7 +284,7 @@ impl FileMap {
 }
 
 pub struct CodeMap {
-    files: RefCell<Vec<Rc<FileMap>>>
+    pub files: RefCell<Vec<Rc<FileMap>>>
 }
 
 impl CodeMap {

--- a/src/libsyntax/crateid.rs
+++ b/src/libsyntax/crateid.rs
@@ -24,11 +24,11 @@ use std::from_str::FromStr;
 pub struct CrateId {
     /// A path which represents the codes origin. By convention this is the
     /// URL, without `http://` or `https://` prefix, to the crate's repository
-    path: ~str,
+    pub path: ~str,
     /// The name of the crate.
-    name: ~str,
+    pub name: ~str,
     /// The version of the crate.
-    version: Option<~str>,
+    pub version: Option<~str>,
 }
 
 impl fmt::Show for CrateId {

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -40,8 +40,8 @@ pub struct ExplicitBug;
 // accepts span information for source-location
 // reporting.
 pub struct SpanHandler {
-    handler: Handler,
-    cm: codemap::CodeMap,
+    pub handler: Handler,
+    pub cm: codemap::CodeMap,
 }
 
 impl SpanHandler {
@@ -216,7 +216,7 @@ fn print_diagnostic(dst: &mut EmitterWriter,
 }
 
 pub struct EmitterWriter {
-    priv dst: Destination,
+    dst: Destination,
 }
 
 enum Destination {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -30,8 +30,8 @@ use collections::HashMap;
 // ast::MacInvocTT.
 
 pub struct MacroDef {
-    name: ~str,
-    ext: SyntaxExtension
+    pub name: ~str,
+    pub ext: SyntaxExtension
 }
 
 pub type ItemDecorator =
@@ -41,8 +41,8 @@ pub type ItemModifier =
     fn(&mut ExtCtxt, Span, @ast::MetaItem, @ast::Item) -> @ast::Item;
 
 pub struct BasicMacroExpander {
-    expander: MacroExpanderFn,
-    span: Option<Span>
+    pub expander: MacroExpanderFn,
+    pub span: Option<Span>
 }
 
 pub trait MacroExpander {
@@ -68,8 +68,8 @@ impl MacroExpander for BasicMacroExpander {
 }
 
 pub struct BasicIdentMacroExpander {
-    expander: IdentMacroExpanderFn,
-    span: Option<Span>
+    pub expander: IdentMacroExpanderFn,
+    pub span: Option<Span>
 }
 
 pub trait IdentMacroExpander {
@@ -172,9 +172,9 @@ pub enum SyntaxExtension {
 
 pub struct BlockInfo {
     // should macros escape from this scope?
-    macros_escape: bool,
+    pub macros_escape: bool,
     // what are the pending renames?
-    pending_renames: RenameList,
+    pub pending_renames: RenameList,
 }
 
 impl BlockInfo {
@@ -292,8 +292,8 @@ pub fn syntax_expander_table() -> SyntaxEnv {
 }
 
 pub struct MacroCrate {
-    lib: Option<Path>,
-    cnum: ast::CrateNum,
+    pub lib: Option<Path>,
+    pub cnum: ast::CrateNum,
 }
 
 pub trait CrateLoader {
@@ -306,13 +306,13 @@ pub trait CrateLoader {
 // when a macro expansion occurs, the resulting nodes have the backtrace()
 // -> expn_info of their expansion context stored into their span.
 pub struct ExtCtxt<'a> {
-    parse_sess: &'a parse::ParseSess,
-    cfg: ast::CrateConfig,
-    backtrace: Option<@ExpnInfo>,
-    ecfg: expand::ExpansionConfig<'a>,
+    pub parse_sess: &'a parse::ParseSess,
+    pub cfg: ast::CrateConfig,
+    pub backtrace: Option<@ExpnInfo>,
+    pub ecfg: expand::ExpansionConfig<'a>,
 
-    mod_path: Vec<ast::Ident> ,
-    trace_mac: bool
+    pub mod_path: Vec<ast::Ident> ,
+    pub trace_mac: bool,
 }
 
 impl<'a> ExtCtxt<'a> {
@@ -532,7 +532,7 @@ struct MapChainFrame {
 
 // Only generic to make it easy to test
 pub struct SyntaxEnv {
-    priv chain: Vec<MapChainFrame> ,
+    chain: Vec<MapChainFrame> ,
 }
 
 impl SyntaxEnv {

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -192,75 +192,77 @@ mod ty;
 
 pub struct TraitDef<'a> {
     /// The span for the current #[deriving(Foo)] header.
-    span: Span,
+    pub span: Span,
 
-    attributes: Vec<ast::Attribute> ,
+    pub attributes: Vec<ast::Attribute>,
 
     /// Path of the trait, including any type parameters
-    path: Path<'a>,
+    pub path: Path<'a>,
 
     /// Additional bounds required of any type parameters of the type,
     /// other than the current trait
-    additional_bounds: Vec<Ty<'a>> ,
+    pub additional_bounds: Vec<Ty<'a>>,
 
     /// Any extra lifetimes and/or bounds, e.g. `D: serialize::Decoder`
-    generics: LifetimeBounds<'a>,
+    pub generics: LifetimeBounds<'a>,
 
-    methods: Vec<MethodDef<'a>> }
+    pub methods: Vec<MethodDef<'a>>,
+}
 
 
 pub struct MethodDef<'a> {
     /// name of the method
-    name: &'a str,
+    pub name: &'a str,
     /// List of generics, e.g. `R: rand::Rng`
-    generics: LifetimeBounds<'a>,
+    pub generics: LifetimeBounds<'a>,
 
     /// Whether there is a self argument (outer Option) i.e. whether
     /// this is a static function, and whether it is a pointer (inner
     /// Option)
-    explicit_self: Option<Option<PtrTy<'a>>>,
+    pub explicit_self: Option<Option<PtrTy<'a>>>,
 
     /// Arguments other than the self argument
-    args: Vec<Ty<'a>> ,
+    pub args: Vec<Ty<'a>>,
 
     /// Return type
-    ret_ty: Ty<'a>,
+    pub ret_ty: Ty<'a>,
 
     /// Whether to mark this as #[inline]
-    inline: bool,
+    pub inline: bool,
 
     /// if the value of the nonmatching enums is independent of the
     /// actual enum variants, i.e. can use _ => .. match.
-    const_nonmatching: bool,
+    pub const_nonmatching: bool,
 
-    combine_substructure: CombineSubstructureFunc<'a>
+    pub combine_substructure: CombineSubstructureFunc<'a>,
 }
 
 /// All the data about the data structure/method being derived upon.
 pub struct Substructure<'a> {
     /// ident of self
-    type_ident: Ident,
+    pub type_ident: Ident,
     /// ident of the method
-    method_ident: Ident,
+    pub method_ident: Ident,
     /// dereferenced access to any Self or Ptr(Self, _) arguments
-    self_args: &'a [@Expr],
+    pub self_args: &'a [@Expr],
     /// verbatim access to any other arguments
-    nonself_args: &'a [@Expr],
-    fields: &'a SubstructureFields<'a>
+    pub nonself_args: &'a [@Expr],
+    pub fields: &'a SubstructureFields<'a>
 }
 
 /// Summary of the relevant parts of a struct/enum field.
 pub struct FieldInfo {
-    span: Span,
+    pub span: Span,
     /// None for tuple structs/normal enum variants, Some for normal
     /// structs/struct enum variants.
-    name: Option<Ident>,
+    pub name: Option<Ident>,
     /// The expression corresponding to this field of `self`
     /// (specifically, a reference to it).
-    self_: @Expr,
+    pub self_: @Expr,
     /// The expressions corresponding to references to this field in
     /// the other Self arguments.
-    other: Vec<@Expr> }
+    pub other: Vec<@Expr>,
+}
 
 /// Fields for a static method
 pub enum StaticFields {

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -29,10 +29,10 @@ pub enum PtrTy<'a> {
 /// A path, e.g. `::std::option::Option::<int>` (global). Has support
 /// for type parameters and a lifetime.
 pub struct Path<'a> {
-    path: Vec<&'a str> ,
-    lifetime: Option<&'a str>,
-    params: Vec<~Ty<'a>> ,
-    global: bool
+    pub path: Vec<&'a str> ,
+    pub lifetime: Option<&'a str>,
+    pub params: Vec<~Ty<'a>> ,
+    pub global: bool,
 }
 
 impl<'a> Path<'a> {
@@ -205,8 +205,8 @@ fn mk_generics(lifetimes: Vec<ast::Lifetime> ,  ty_params: Vec<ast::TyParam> ) -
 
 /// Lifetimes and bounds on type parameters
 pub struct LifetimeBounds<'a> {
-    lifetimes: Vec<&'a str>,
-    bounds: Vec<(&'a str, Vec<Path<'a>>)>,
+    pub lifetimes: Vec<&'a str>,
+    pub bounds: Vec<(&'a str, Vec<Path<'a>>)>,
 }
 
 impl<'a> LifetimeBounds<'a> {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -838,8 +838,8 @@ pub fn new_span(cx: &ExtCtxt, sp: Span) -> Span {
 }
 
 pub struct MacroExpander<'a, 'b> {
-    extsbox: SyntaxEnv,
-    cx: &'a mut ExtCtxt<'b>,
+    pub extsbox: SyntaxEnv,
+    pub cx: &'a mut ExtCtxt<'b>,
 }
 
 impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
@@ -869,9 +869,9 @@ impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
 }
 
 pub struct ExpansionConfig<'a> {
-    loader: &'a mut CrateLoader,
-    deriving_hash_type_parameter: bool,
-    crate_id: CrateId,
+    pub loader: &'a mut CrateLoader,
+    pub deriving_hash_type_parameter: bool,
+    pub crate_id: CrateId,
 }
 
 pub fn expand_crate(parse_sess: &parse::ParseSess,

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -31,16 +31,16 @@ struct TtFrame {
 
 #[deriving(Clone)]
 pub struct TtReader<'a> {
-    sp_diag: &'a SpanHandler,
+    pub sp_diag: &'a SpanHandler,
     // the unzipped tree:
-    priv stack: Vec<TtFrame>,
+    stack: Vec<TtFrame>,
     /* for MBE-style macro transcription */
-    priv interpolations: HashMap<Ident, Rc<NamedMatch>>,
-    priv repeat_idx: Vec<uint>,
-    priv repeat_len: Vec<uint>,
+    interpolations: HashMap<Ident, Rc<NamedMatch>>,
+    repeat_idx: Vec<uint>,
+    repeat_len: Vec<uint>,
     /* cached: */
-    cur_tok: Token,
-    cur_span: Span,
+    pub cur_tok: Token,
+    pub cur_span: Span,
 }
 
 /** This can do Macro-By-Example transcription. On the other hand, if

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -30,6 +30,8 @@ This API is completely unstable and subject to change.
            quote)]
 #![allow(deprecated)]
 
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+
 extern crate serialize;
 extern crate term;
 extern crate collections;

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -18,8 +18,8 @@ use serialize::{Encodable, Decodable, Encoder, Decoder};
 #[unsafe_no_drop_flag] // data is set to null on destruction
 pub struct OwnedSlice<T> {
     /// null iff len == 0
-    priv data: *mut T,
-    priv len: uint,
+    data: *mut T,
+    len: uint,
 }
 
 #[unsafe_destructor]

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -31,9 +31,9 @@ pub enum CommentStyle {
 
 #[deriving(Clone)]
 pub struct Comment {
-    style: CommentStyle,
-    lines: Vec<~str> ,
-    pos: BytePos
+    pub style: CommentStyle,
+    pub lines: Vec<~str>,
+    pub pos: BytePos,
 }
 
 pub fn is_doc_comment(s: &str) -> bool {
@@ -338,8 +338,8 @@ fn consume_comment(rdr: &mut StringReader,
 
 #[deriving(Clone)]
 pub struct Literal {
-    lit: ~str,
-    pos: BytePos
+    pub lit: ~str,
+    pub pos: BytePos,
 }
 
 // it appears this function is called only from pprust... that's

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -13,8 +13,8 @@ use parse::token;
 // SeqSep : a sequence separator (token)
 // and whether a trailing separator is allowed.
 pub struct SeqSep {
-    sep: Option<token::Token>,
-    trailing_sep_allowed: bool
+    pub sep: Option<token::Token>,
+    pub trailing_sep_allowed: bool
 }
 
 pub fn seq_sep_trailing_disallowed(t: token::Token) -> SeqSep {

--- a/src/libsyntax/parse/lexer.rs
+++ b/src/libsyntax/parse/lexer.rs
@@ -34,24 +34,24 @@ pub trait Reader {
 
 #[deriving(Clone, Eq, Show)]
 pub struct TokenAndSpan {
-    tok: token::Token,
-    sp: Span,
+    pub tok: token::Token,
+    pub sp: Span,
 }
 
 pub struct StringReader<'a> {
-    span_diagnostic: &'a SpanHandler,
+    pub span_diagnostic: &'a SpanHandler,
     // The absolute offset within the codemap of the next character to read
-    pos: BytePos,
+    pub pos: BytePos,
     // The absolute offset within the codemap of the last character read(curr)
-    last_pos: BytePos,
+    pub last_pos: BytePos,
     // The column of the next character to read
-    col: CharPos,
+    pub col: CharPos,
     // The last character to be read
-    curr: Option<char>,
-    filemap: Rc<codemap::FileMap>,
+    pub curr: Option<char>,
+    pub filemap: Rc<codemap::FileMap>,
     /* cached: */
-    peek_tok: token::Token,
-    peek_span: Span,
+    pub peek_tok: token::Token,
+    pub peek_span: Span,
 }
 
 impl<'a> StringReader<'a> {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -39,7 +39,7 @@ pub mod obsolete;
 
 // info about a parsing session.
 pub struct ParseSess {
-    span_diagnostic: SpanHandler, // better be the same as the one in the reader!
+    pub span_diagnostic: SpanHandler, // better be the same as the one in the reader!
     /// Used to determine and report recursive mod inclusions
     included_mod_stack: RefCell<Vec<Path>>,
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -78,7 +78,6 @@ use parse::{new_sub_parser_from_file, ParseSess};
 use owned_slice::OwnedSlice;
 
 use collections::HashSet;
-use std::kinds::marker;
 use std::mem::replace;
 use std::rc::Rc;
 
@@ -113,8 +112,8 @@ pub enum PathParsingMode {
 
 /// A path paired with optional type bounds.
 pub struct PathAndBounds {
-    path: ast::Path,
-    bounds: Option<OwnedSlice<TyParamBound>>,
+    pub path: ast::Path,
+    pub bounds: Option<OwnedSlice<TyParamBound>>,
 }
 
 enum ItemOrViewItem {
@@ -306,38 +305,35 @@ pub fn Parser<'a>(sess: &'a ParseSess, cfg: ast::CrateConfig, mut rdr: ~Reader:)
         obsolete_set: HashSet::new(),
         mod_path_stack: Vec::new(),
         open_braces: Vec::new(),
-        nocopy: marker::NoCopy
     }
 }
 
 pub struct Parser<'a> {
-    sess: &'a ParseSess,
-    cfg: CrateConfig,
+    pub sess: &'a ParseSess,
     // the current token:
-    token: token::Token,
+    pub token: token::Token,
     // the span of the current token:
-    span: Span,
+    pub span: Span,
     // the span of the prior token:
-    last_span: Span,
+    pub last_span: Span,
+    pub cfg: CrateConfig,
     // the previous token or None (only stashed sometimes).
-    last_token: Option<~token::Token>,
-    buffer: [TokenAndSpan, ..4],
-    buffer_start: int,
-    buffer_end: int,
-    tokens_consumed: uint,
-    restriction: restriction,
-    quote_depth: uint, // not (yet) related to the quasiquoter
-    reader: ~Reader:,
-    interner: Rc<token::IdentInterner>,
+    pub last_token: Option<~token::Token>,
+    pub buffer: [TokenAndSpan, ..4],
+    pub buffer_start: int,
+    pub buffer_end: int,
+    pub tokens_consumed: uint,
+    pub restriction: restriction,
+    pub quote_depth: uint, // not (yet) related to the quasiquoter
+    pub reader: ~Reader:,
+    pub interner: Rc<token::IdentInterner>,
     /// The set of seen errors about obsolete syntax. Used to suppress
     /// extra detail when the same error is seen twice
-    obsolete_set: HashSet<ObsoleteSyntax>,
+    pub obsolete_set: HashSet<ObsoleteSyntax>,
     /// Used to determine the path to externally loaded source files
-    mod_path_stack: Vec<InternedString> ,
+    pub mod_path_stack: Vec<InternedString>,
     /// Stack of spans of open delimiters. Used for error message.
-    open_braces: Vec<Span> ,
-    /* do not copy the parser; its state is tied to outside state */
-    priv nocopy: marker::NoCopy
+    pub open_braces: Vec<Span>,
 }
 
 fn is_plain_ident_or_underscore(t: &token::Token) -> bool {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -556,7 +556,7 @@ pub fn get_ident_interner() -> Rc<IdentInterner> {
 /// somehow.
 #[deriving(Clone, Eq, Hash, Ord, TotalEq, TotalOrd)]
 pub struct InternedString {
-    priv string: RcStr,
+    string: RcStr,
 }
 
 impl InternedString {

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -257,7 +257,7 @@ pub fn mk_printer(out: ~io::Writer, linewidth: uint) -> Printer {
  * called 'print'.
  */
 pub struct Printer {
-    out: ~io::Writer,
+    pub out: ~io::Writer,
     buf_len: uint,
     margin: int, // width of lines we're constrained to
     space: int, // number of spaces left on line

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -54,7 +54,7 @@ pub struct CurrentCommentAndLiteral {
 }
 
 pub struct State<'a> {
-    s: pp::Printer,
+    pub s: pp::Printer,
     cm: Option<&'a CodeMap>,
     intr: Rc<token::IdentInterner>,
     comments: Option<Vec<comments::Comment> >,

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -23,8 +23,8 @@ use std::hash::Hash;
 use std::rc::Rc;
 
 pub struct Interner<T> {
-    priv map: RefCell<HashMap<T, Name>>,
-    priv vect: RefCell<Vec<T> >,
+    map: RefCell<HashMap<T, Name>>,
+    vect: RefCell<Vec<T> >,
 }
 
 // when traits can extend traits, we should extend index<Name,T> to get []
@@ -92,7 +92,7 @@ impl<T: TotalEq + Hash + Clone + 'static> Interner<T> {
 
 #[deriving(Clone, Eq, Hash, Ord)]
 pub struct RcStr {
-    priv string: Rc<~str>,
+    string: Rc<~str>,
 }
 
 impl TotalEq for RcStr {}
@@ -134,8 +134,8 @@ impl RcStr {
 // A StrInterner differs from Interner<String> in that it accepts
 // &str rather than RcStr, resulting in less allocation.
 pub struct StrInterner {
-    priv map: RefCell<HashMap<RcStr, Name>>,
-    priv vect: RefCell<Vec<RcStr> >,
+    map: RefCell<HashMap<RcStr, Name>>,
+    vect: RefCell<Vec<RcStr> >,
 }
 
 // when traits can extend traits, we should extend index<Name,T> to get []

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -20,7 +20,10 @@
        html_root_url = "http://static.rust-lang.org/doc/master")]
 
 #![feature(macro_rules)]
-#![deny(missing_doc)]
+
+// #![deny(missing_doc)] // NOTE: uncomment after a stage0 snap
+#![allow(missing_doc)] // NOTE: remove after a stage0 snap
+#![allow(visible_private_types)] // NOTE: remove after a stage0 snap
 
 extern crate collections;
 
@@ -111,9 +114,9 @@ fn cap_for_attr(attr: attr::Attr) -> &'static str {
 /// A Terminal that knows how many colors it supports, with a reference to its
 /// parsed TermInfo database record.
 pub struct Terminal<T> {
-    priv num_colors: u16,
-    priv out: T,
-    priv ti: ~TermInfo
+    num_colors: u16,
+    out: T,
+    ti: ~TermInfo
 }
 
 impl<T: Writer> Terminal<T> {

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -15,13 +15,13 @@ use collections::HashMap;
 /// A parsed terminfo database entry.
 pub struct TermInfo {
     /// Names for the terminal
-    priv names: Vec<~str> ,
+    pub names: Vec<~str> ,
     /// Map of capability name to boolean value
-    priv bools: HashMap<~str, bool>,
+    pub bools: HashMap<~str, bool>,
     /// Map of capability name to numeric value
-    numbers: HashMap<~str, u16>,
+    pub numbers: HashMap<~str, u16>,
     /// Map of capability name to raw (unexpanded) string
-    strings: HashMap<~str, Vec<u8> >
+    pub strings: HashMap<~str, Vec<u8> >
 }
 
 pub mod searcher;

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -48,9 +48,9 @@ pub enum Param {
 /// Container for static and dynamic variable arrays
 pub struct Variables {
     /// Static variables A-Z
-    priv sta: [Param, ..26],
+    sta: [Param, ..26],
     /// Dynamic variables a-z
-    priv dyn: [Param, ..26]
+    dyn: [Param, ..26]
 }
 
 impl Variables {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -147,30 +147,30 @@ impl TestFn {
 /// set-up & tear-down before running a piece of code repeatedly via a
 /// call to `iter`.
 pub struct BenchHarness {
-    priv iterations: u64,
-    priv ns_start: u64,
-    priv ns_end: u64,
-    bytes: u64
+    iterations: u64,
+    ns_start: u64,
+    ns_end: u64,
+    pub bytes: u64,
 }
 
 // The definition of a single test. A test runner will run a list of
 // these.
 #[deriving(Clone)]
 pub struct TestDesc {
-    name: TestName,
-    ignore: bool,
-    should_fail: bool
+    pub name: TestName,
+    pub ignore: bool,
+    pub should_fail: bool,
 }
 
 pub struct TestDescAndFn {
-    desc: TestDesc,
-    testfn: TestFn,
+    pub desc: TestDesc,
+    pub testfn: TestFn,
 }
 
 #[deriving(Clone, Encodable, Decodable, Eq, Show)]
 pub struct Metric {
-    priv value: f64,
-    priv noise: f64
+    value: f64,
+    noise: f64
 }
 
 impl Metric {
@@ -242,15 +242,15 @@ pub fn test_main_static(args: &[~str], tests: &[TestDescAndFn]) {
 }
 
 pub struct TestOpts {
-    filter: Option<~str>,
-    run_ignored: bool,
-    run_tests: bool,
-    run_benchmarks: bool,
-    ratchet_metrics: Option<Path>,
-    ratchet_noise_percent: Option<f64>,
-    save_metrics: Option<Path>,
-    test_shard: Option<(uint,uint)>,
-    logfile: Option<Path>
+    pub filter: Option<~str>,
+    pub run_ignored: bool,
+    pub run_tests: bool,
+    pub run_benchmarks: bool,
+    pub ratchet_metrics: Option<Path>,
+    pub ratchet_noise_percent: Option<f64>,
+    pub save_metrics: Option<Path>,
+    pub test_shard: Option<(uint,uint)>,
+    pub logfile: Option<Path>
 }
 
 /// Result of parsing the options.
@@ -375,8 +375,8 @@ pub fn opt_shard(maybestr: Option<~str>) -> Option<(uint,uint)> {
 
 #[deriving(Clone, Eq)]
 pub struct BenchSamples {
-    priv ns_iter_summ: stats::Summary,
-    priv mb_s: uint
+    ns_iter_summ: stats::Summary,
+    mb_s: uint,
 }
 
 #[deriving(Clone, Eq)]

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -130,18 +130,18 @@ pub trait Stats {
 #[deriving(Clone, Eq)]
 #[allow(missing_doc)]
 pub struct Summary {
-    sum: f64,
-    min: f64,
-    max: f64,
-    mean: f64,
-    median: f64,
-    var: f64,
-    std_dev: f64,
-    std_dev_pct: f64,
-    median_abs_dev: f64,
-    median_abs_dev_pct: f64,
-    quartiles: (f64,f64,f64),
-    iqr: f64,
+    pub sum: f64,
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub median: f64,
+    pub var: f64,
+    pub std_dev: f64,
+    pub std_dev_pct: f64,
+    pub median_abs_dev: f64,
+    pub median_abs_dev_pct: f64,
+    pub quartiles: (f64,f64,f64),
+    pub iqr: f64,
 }
 
 impl Summary {

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -51,40 +51,40 @@ use collections::HashMap;
 #[deriving(Clone, Eq, TotalEq)]
 pub struct Url {
     /// The scheme part of a URL, such as `https` in the above example.
-    scheme: ~str,
+    pub scheme: ~str,
     /// A URL subcomponent for user authentication.  `username` in the above example.
-    user: Option<UserInfo>,
+    pub user: Option<UserInfo>,
     /// A domain name or IP address.  For example, `example.com`.
-    host: ~str,
+    pub host: ~str,
     /// A TCP port number, for example `8080`.
-    port: Option<~str>,
+    pub port: Option<~str>,
     /// The path component of a URL, for example `/foo/bar`.
-    path: ~str,
+    pub path: ~str,
     /// The query component of a URL.  `vec!((~"baz", ~"qux"))` represents the
     /// fragment `baz=qux` in the above example.
-    query: Query,
+    pub query: Query,
     /// The fragment component, such as `quz`.  Doesn't include the leading `#` character.
-    fragment: Option<~str>
+    pub fragment: Option<~str>
 }
 
 #[deriving(Clone, Eq)]
 pub struct Path {
     /// The path component of a URL, for example `/foo/bar`.
-    path: ~str,
+    pub path: ~str,
     /// The query component of a URL.  `vec!((~"baz", ~"qux"))` represents the
     /// fragment `baz=qux` in the above example.
-    query: Query,
+    pub query: Query,
     /// The fragment component, such as `quz`.  Doesn't include the leading `#` character.
-    fragment: Option<~str>
+    pub fragment: Option<~str>
 }
 
 /// An optional subcomponent of a URI authority component.
 #[deriving(Clone, Eq, TotalEq)]
 pub struct UserInfo {
     /// The user name.
-    user: ~str,
+    pub user: ~str,
     /// Password or other scheme-specific authentication information.
-    pass: Option<~str>
+    pub pass: Option<~str>
 }
 
 /// Represents the query component of a URI.

--- a/src/libworkcache/lib.rs
+++ b/src/libworkcache/lib.rs
@@ -140,9 +140,9 @@ impl WorkMap {
 }
 
 pub struct Database {
-    priv db_filename: Path,
-    priv db_cache: TreeMap<~str, ~str>,
-    db_dirty: bool
+    db_filename: Path,
+    db_cache: TreeMap<~str, ~str>,
+    pub db_dirty: bool,
 }
 
 impl Database {
@@ -225,26 +225,26 @@ pub type FreshnessMap = TreeMap<~str,extern fn(&str,&str)->bool>;
 
 #[deriving(Clone)]
 pub struct Context {
-    db: Arc<RWLock<Database>>,
-    priv cfg: Arc<json::Object>,
+    pub db: Arc<RWLock<Database>>,
+    cfg: Arc<json::Object>,
     /// Map from kinds (source, exe, url, etc.) to a freshness function.
     /// The freshness function takes a name (e.g. file path) and value
     /// (e.g. hash of file contents) and determines whether it's up-to-date.
     /// For example, in the file case, this would read the file off disk,
     /// hash it, and return the result of comparing the given hash and the
     /// read hash for equality.
-    priv freshness: Arc<FreshnessMap>
+    freshness: Arc<FreshnessMap>
 }
 
 pub struct Prep<'a> {
-    priv ctxt: &'a Context,
-    priv fn_name: &'a str,
-    priv declared_inputs: WorkMap,
+    ctxt: &'a Context,
+    fn_name: &'a str,
+    declared_inputs: WorkMap,
 }
 
 pub struct Exec {
-    priv discovered_inputs: WorkMap,
-    priv discovered_outputs: WorkMap
+    discovered_inputs: WorkMap,
+    discovered_outputs: WorkMap
 }
 
 enum Work<'a, T> {

--- a/src/test/auxiliary/anon_trait_static_method_lib.rs
+++ b/src/test/auxiliary/anon_trait_static_method_lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 pub struct Foo {
-    x: int
+    pub x: int
 }
 
 impl Foo {

--- a/src/test/auxiliary/cci_class.rs
+++ b/src/test/auxiliary/cci_class.rs
@@ -10,9 +10,9 @@
 
 pub mod kitties {
     pub struct cat {
-      priv meows : uint,
+      meows : uint,
 
-      how_hungry : int,
+      pub how_hungry : int,
     }
 
     pub fn cat(in_x : uint, in_y : int) -> cat  {

--- a/src/test/auxiliary/cci_class_2.rs
+++ b/src/test/auxiliary/cci_class_2.rs
@@ -10,9 +10,9 @@
 
 pub mod kitties {
     pub struct cat {
-      priv meows : uint,
+      meows : uint,
 
-      how_hungry : int,
+      pub how_hungry : int,
 
     }
 

--- a/src/test/auxiliary/cci_class_3.rs
+++ b/src/test/auxiliary/cci_class_3.rs
@@ -10,9 +10,9 @@
 
 pub mod kitties {
     pub struct cat {
-        priv meows : uint,
+        meows : uint,
 
-        how_hungry : int,
+        pub how_hungry : int,
     }
 
     impl cat {

--- a/src/test/auxiliary/cci_class_4.rs
+++ b/src/test/auxiliary/cci_class_4.rs
@@ -10,10 +10,10 @@
 
 pub mod kitties {
     pub struct cat {
-        priv meows : uint,
+        meows : uint,
 
-        how_hungry : int,
-        name : ~str,
+        pub how_hungry : int,
+        pub name : ~str,
     }
 
     impl cat {

--- a/src/test/auxiliary/cci_class_5.rs
+++ b/src/test/auxiliary/cci_class_5.rs
@@ -10,8 +10,8 @@
 
 pub mod kitties {
     pub struct cat {
-        priv meows : uint,
-        how_hungry : int,
+        meows : uint,
+        pub how_hungry : int,
     }
 
     impl cat {

--- a/src/test/auxiliary/cci_class_6.rs
+++ b/src/test/auxiliary/cci_class_6.rs
@@ -11,10 +11,10 @@
 pub mod kitties {
 
     pub struct cat<U> {
-        priv info : Vec<U> ,
-        priv meows : uint,
+        info : Vec<U> ,
+        meows : uint,
 
-        how_hungry : int,
+        pub how_hungry : int,
     }
 
     impl<U> cat<U> {

--- a/src/test/auxiliary/cci_class_cast.rs
+++ b/src/test/auxiliary/cci_class_cast.rs
@@ -12,9 +12,9 @@ pub mod kitty {
     use std::fmt;
 
     pub struct cat {
-      priv meows : uint,
-      how_hungry : int,
-      name : ~str,
+      meows : uint,
+      pub how_hungry : int,
+      pub name : ~str,
     }
 
     impl fmt::Show for cat {

--- a/src/test/auxiliary/crateresolve5-1.rs
+++ b/src/test/auxiliary/crateresolve5-1.rs
@@ -12,7 +12,7 @@
 
 #[crate_type = "lib"];
 
-pub struct NameVal { name: ~str, val: int }
+pub struct NameVal { pub name: ~str, pub val: int }
 
 pub fn struct_nameval() -> NameVal {
     NameVal { name: ~"crateresolve5", val: 10 }

--- a/src/test/auxiliary/crateresolve5-2.rs
+++ b/src/test/auxiliary/crateresolve5-2.rs
@@ -12,7 +12,7 @@
 
 #[crate_type = "lib"];
 
-pub struct NameVal { name: ~str, val: int }
+pub struct NameVal { pub name: ~str, pub val: int }
 pub fn struct_nameval() -> NameVal {
     NameVal { name: ~"crateresolve5", val: 10 }
 }

--- a/src/test/auxiliary/explicit_self_xcrate.rs
+++ b/src/test/auxiliary/explicit_self_xcrate.rs
@@ -14,7 +14,7 @@ pub trait Foo {
 }
 
 pub struct Bar {
-    x: ~str
+    pub x: ~str
 }
 
 impl Foo for Bar {

--- a/src/test/auxiliary/impl_privacy_xc_1.rs
+++ b/src/test/auxiliary/impl_privacy_xc_1.rs
@@ -11,7 +11,7 @@
 #[crate_type = "lib"];
 
 pub struct Fish {
-    x: int
+    pub x: int
 }
 
 impl Fish {

--- a/src/test/auxiliary/impl_privacy_xc_2.rs
+++ b/src/test/auxiliary/impl_privacy_xc_2.rs
@@ -11,7 +11,7 @@
 #[crate_type = "lib"];
 
 pub struct Fish {
-    x: int
+    pub x: int
 }
 
 mod unexported {

--- a/src/test/auxiliary/issue-8044.rs
+++ b/src/test/auxiliary/issue-8044.rs
@@ -11,11 +11,11 @@
 #[feature(struct_variant)];
 
 pub struct BTree<V> {
-    node: TreeItem<V>,
+    pub node: TreeItem<V>,
 }
 
 pub enum TreeItem<V> {
-    TreeLeaf { value: V },
+    TreeLeaf { pub value: V },
 }
 
 pub fn leaf<V>(value: V) -> TreeItem<V> {

--- a/src/test/auxiliary/issue2378b.rs
+++ b/src/test/auxiliary/issue2378b.rs
@@ -14,7 +14,7 @@ extern crate issue2378a;
 
 use issue2378a::maybe;
 
-pub struct two_maybes<T> {a: maybe<T>, b: maybe<T>}
+pub struct two_maybes<T> {pub a: maybe<T>, pub b: maybe<T>}
 
 impl<T:Clone> Index<uint,(T,T)> for two_maybes<T> {
     fn index(&self, idx: &uint) -> (T, T) {

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -116,18 +116,18 @@ pub trait Trait {
 impl Trait for MethodTester {}
 
 #[deprecated]
-pub struct DeprecatedStruct { i: int }
+pub struct DeprecatedStruct { pub i: int }
 #[experimental]
-pub struct ExperimentalStruct { i: int }
+pub struct ExperimentalStruct { pub i: int }
 #[unstable]
-pub struct UnstableStruct { i: int }
-pub struct UnmarkedStruct { i: int }
+pub struct UnstableStruct { pub i: int }
+pub struct UnmarkedStruct { pub i: int }
 #[stable]
-pub struct StableStruct { i: int }
+pub struct StableStruct { pub i: int }
 #[frozen]
-pub struct FrozenStruct { i: int }
+pub struct FrozenStruct { pub i: int }
 #[locked]
-pub struct LockedStruct { i: int }
+pub struct LockedStruct { pub i: int }
 
 #[deprecated]
 pub struct DeprecatedUnitStruct;

--- a/src/test/auxiliary/overloaded_autoderef_xc.rs
+++ b/src/test/auxiliary/overloaded_autoderef_xc.rs
@@ -11,7 +11,7 @@
 use std::ops::Deref;
 
 struct DerefWithHelper<H, T> {
-    helper: H
+    pub helper: H
 }
 
 trait Helper<T> {

--- a/src/test/auxiliary/pub_use_xcrate1.rs
+++ b/src/test/auxiliary/pub_use_xcrate1.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 pub struct Foo {
-    name: int
+    pub name: int
 }

--- a/src/test/auxiliary/struct-field-privacy.rs
+++ b/src/test/auxiliary/struct-field-privacy.rs
@@ -14,6 +14,6 @@ struct A {
 }
 
 pub struct B {
-    a: int,
-    priv b: int,
+    pub a: int,
+    b: int,
 }

--- a/src/test/auxiliary/struct_destructuring_cross_crate.rs
+++ b/src/test/auxiliary/struct_destructuring_cross_crate.rs
@@ -11,6 +11,6 @@
 #[crate_type="lib"];
 
 pub struct S {
-    x: int,
-    y: int
+    pub x: int,
+    pub y: int,
 }

--- a/src/test/auxiliary/struct_variant_xc_aux.rs
+++ b/src/test/auxiliary/struct_variant_xc_aux.rs
@@ -14,5 +14,5 @@
 #![feature(struct_variant)]
 
 pub enum Enum {
-    Variant { arg: u8 }
+    Variant { pub arg: u8 }
 }

--- a/src/test/auxiliary/trait_default_method_xc_aux.rs
+++ b/src/test/auxiliary/trait_default_method_xc_aux.rs
@@ -10,7 +10,7 @@
 
 #[crate_id="trait_default_method_xc_aux"];
 
-pub struct Something { x: int }
+pub struct Something { pub x: int }
 
 pub trait A {
     fn f(&self) -> int;

--- a/src/test/auxiliary/trait_default_method_xc_aux_2.rs
+++ b/src/test/auxiliary/trait_default_method_xc_aux_2.rs
@@ -13,7 +13,7 @@
 extern crate aux = "trait_default_method_xc_aux";
 use aux::A;
 
-pub struct a_struct { x: int }
+pub struct a_struct { pub x: int }
 
 impl A for a_struct {
     fn f(&self) -> int { 10 }

--- a/src/test/auxiliary/trait_inheritance_auto_xc_2_aux.rs
+++ b/src/test/auxiliary/trait_inheritance_auto_xc_2_aux.rs
@@ -12,7 +12,7 @@ pub trait Foo { fn f(&self) -> int; }
 pub trait Bar { fn g(&self) -> int; }
 pub trait Baz { fn h(&self) -> int; }
 
-pub struct A { x: int }
+pub struct A { pub x: int }
 
 impl Foo for A { fn f(&self) -> int { 10 } }
 impl Bar for A { fn g(&self) -> int { 20 } }

--- a/src/test/auxiliary/trait_inheritance_cross_trait_call_xc_aux.rs
+++ b/src/test/auxiliary/trait_inheritance_cross_trait_call_xc_aux.rs
@@ -14,7 +14,7 @@ pub trait Foo {
 }
 
 pub struct A {
-    x: int
+    pub x: int
 }
 
 impl Foo for A {

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -15,7 +15,7 @@ pub trait MyNum : Add<Self,Self> + Sub<Self,Self> + Mul<Self,Self> + Eq {
 
 #[deriving(Show)]
 pub struct MyInt {
-    val: int
+    pub val: int
 }
 
 impl Add<MyInt, MyInt> for MyInt {

--- a/src/test/auxiliary/xc_private_method_lib.rs
+++ b/src/test/auxiliary/xc_private_method_lib.rs
@@ -11,7 +11,7 @@
 #[crate_type="lib"];
 
 pub struct Struct {
-    x: int
+    pub x: int
 }
 
 impl Struct {

--- a/src/test/compile-fail/issue-3763.rs
+++ b/src/test/compile-fail/issue-3763.rs
@@ -12,7 +12,7 @@
 
 mod my_mod {
     pub struct MyStruct {
-        priv priv_field: int
+        priv_field: int
     }
     pub fn MyStruct () -> MyStruct {
         MyStruct {priv_field: 4}

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -24,14 +24,14 @@ struct Foo {
 }
 
 pub struct PubFoo { //~ ERROR: missing documentation
-    a: int,      //~ ERROR: missing documentation
-    priv b: int,
+    pub a: int,      //~ ERROR: missing documentation
+    b: int,
 }
 
 #[allow(missing_doc)]
 pub struct PubFoo2 {
-    a: int,
-    c: int,
+    pub a: int,
+    pub c: int,
 }
 
 mod module_no_dox {}
@@ -106,8 +106,8 @@ enum Baz {
 
 pub enum PubBaz { //~ ERROR: missing documentation
     PubBazA { //~ ERROR: missing documentation
-        a: int, //~ ERROR: missing documentation
-        priv b: int
+        pub a: int, //~ ERROR: missing documentation
+        b: int
     },
 
     priv PubBazB
@@ -118,8 +118,8 @@ pub enum PubBaz2 {
     /// dox
     PubBaz2A {
         /// dox
-        a: int,
-        priv b: int
+        pub a: int,
+        b: int
     },
     priv PubBaz2B
 }
@@ -127,8 +127,8 @@ pub enum PubBaz2 {
 #[allow(missing_doc)]
 pub enum PubBaz3 {
     PubBaz3A {
-        a: int,
-        priv b: int
+        pub a: int,
+        b: int
     },
     priv PubBaz3B
 }

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -40,8 +40,8 @@ mod test {
 }
 
 mod foo {
-    pub struct Point{x: int, y: int}
-    pub struct Square{p: Point, h: uint, w: uint}
+    pub struct Point{pub x: int, pub y: int}
+    pub struct Square{pub p: Point, pub h: uint, pub w: uint}
 }
 
 mod bar {

--- a/src/test/compile-fail/lint-visible-private-types.rs
+++ b/src/test/compile-fail/lint-visible-private-types.rs
@@ -46,8 +46,8 @@ fn y(_: Private<int>) {}
 
 
 pub struct Foo {
-    x: Private<int>, //~ ERROR private type in exported type signature
-    priv y: Private<int>
+    pub x: Private<int>, //~ ERROR private type in exported type signature
+    y: Private<int>
 }
 
 struct Bar {
@@ -57,8 +57,8 @@ struct Bar {
 pub enum Baz {
     Baz1(Private<int>), //~ ERROR private type in exported type signature
     Baz2 {
-        x: Private<int>, //~ ERROR private type in exported type signature
-        priv y: Private<int>
+        pub x: Private<int>, //~ ERROR private type in exported type signature
+        y: Private<int>
     },
 
     priv Baz3(Private<int>),

--- a/src/test/compile-fail/private-impl-method.rs
+++ b/src/test/compile-fail/private-impl-method.rs
@@ -10,7 +10,7 @@
 
 mod a {
     pub struct Foo {
-        x: int
+        pub x: int
     }
 
     impl Foo {

--- a/src/test/compile-fail/private-struct-field-ctor.rs
+++ b/src/test/compile-fail/private-struct-field-ctor.rs
@@ -10,7 +10,7 @@
 
 mod a {
     pub struct Foo {
-        priv x: int
+        x: int
     }
 }
 

--- a/src/test/compile-fail/private-struct-field-pattern.rs
+++ b/src/test/compile-fail/private-struct-field-pattern.rs
@@ -12,7 +12,7 @@ use a::Foo;
 
 mod a {
     pub struct Foo {
-        priv x: int
+        x: int
     }
 
     pub fn make() -> Foo {

--- a/src/test/compile-fail/private-struct-field.rs
+++ b/src/test/compile-fail/private-struct-field.rs
@@ -10,7 +10,7 @@
 
 mod cat {
     pub struct Cat {
-        priv meows: uint
+        meows: uint
     }
 
     pub fn new_cat() -> Cat {

--- a/src/test/compile-fail/struct-field-privacy.rs
+++ b/src/test/compile-fail/struct-field-privacy.rs
@@ -20,12 +20,10 @@ mod inner {
     struct A {
         a: int,
         pub b: int,
-        priv c: int, //~ ERROR: unnecessary `priv` visibility
     }
     pub struct B {
-        a: int,
-        priv b: int,
-        pub c: int,
+        pub a: int,
+        b: int,
     }
 }
 
@@ -36,10 +34,8 @@ fn test(a: A, b: inner::A, c: inner::B, d: xc::A, e: xc::B) {
     a.a;
     b.a; //~ ERROR: field `a` is private
     b.b;
-    b.c; //~ ERROR: field `c` is private
     c.a;
     c.b; //~ ERROR: field `b` is private
-    c.c;
 
     d.a; //~ ERROR: field `a` is private
     d.b;

--- a/src/test/run-pass/issue-3847.rs
+++ b/src/test/run-pass/issue-3847.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 mod buildings {
-    pub struct Tower { height: uint }
+    pub struct Tower { pub height: uint }
 }
 
 pub fn main() {

--- a/src/test/run-pass/issue-4830.rs
+++ b/src/test/run-pass/issue-4830.rs
@@ -10,7 +10,7 @@
 
 pub struct Scheduler {
     /// The event loop used to drive the scheduler and perform I/O
-    priv event_loop: ~int
+    event_loop: ~int
 }
 
 pub fn main() { }

--- a/src/test/run-pass/module-qualified-struct-destructure.rs
+++ b/src/test/run-pass/module-qualified-struct-destructure.rs
@@ -10,8 +10,8 @@
 
 mod m {
     pub struct S {
-        x: int,
-        y: int
+        pub x: int,
+        pub y: int
     }
 }
 

--- a/src/test/run-pass/overloaded-autoderef-order.rs
+++ b/src/test/run-pass/overloaded-autoderef-order.rs
@@ -29,8 +29,8 @@ impl<X, Y> Deref<Y> for DerefWrapper<X, Y> {
 
 mod priv_test {
     pub struct DerefWrapperHideX<X, Y> {
-        priv x: X,
-        y: Y
+        x: X,
+        pub y: Y
     }
 
     impl<X, Y> DerefWrapperHideX<X, Y> {

--- a/src/test/run-pass/trait-default-method-xc.rs
+++ b/src/test/run-pass/trait-default-method-xc.rs
@@ -24,7 +24,7 @@ fn welp<T>(i: int, _x: &T) -> int {
 }
 
 mod stuff {
-    pub struct thing { x: int }
+    pub struct thing { pub x: int }
 }
 
 impl A for stuff::thing {


### PR DESCRIPTION
This is an implementation of a portion of [RFC #4](https://github.com/rust-lang/rfcs/blob/master/active/0004-private-fields.md). This PR makes named struct fields private by default (as opposed to inherited by default).

The only real meaty change is the first commit to `rustc`, all other commits are just fallout of that change.

Summary of changes made:
- Named fields are private by default _everywhere_
- The `priv` keyword is now default-deny on named fields (done in a "lint" pass in privacy)

Changes yet to be done (before the RFC is closed)
- Change tuple structs to have private fields by default
- Remove `priv` enum variants
- Make `priv` a reserved keyword
