### PR TITLE
Removed deprecated functions `map` and `flat_map` for vectors and slices.

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1764,7 +1764,10 @@ access local variables in the enclosing scope.
 
 ~~~~
 let mut max = 0;
-[1, 2, 3].map(|x| if *x > max { max = *x });
+let f = |x: int| if x > max { max = x };
+for x in [1, 2, 3].iter() {
+    f(*x);
+}
 ~~~~
 
 Stack closures are very efficient because their environment is

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -597,7 +597,7 @@ fn with_argv<T>(prog: &str, args: &[~str], cb: proc:(**libc::c_char) -> T) -> T 
     // Next, convert each of the byte strings into a pointer. This is
     // technically unsafe as the caller could leak these pointers out of our
     // scope.
-    let mut ptrs = tmps.map(|tmp| tmp.with_ref(|buf| buf));
+    let mut ptrs: Vec<_> = tmps.iter().map(|tmp| tmp.with_ref(|buf| buf)).collect();
 
     // Finally, make sure we add a null pointer.
     ptrs.push(ptr::null());
@@ -622,7 +622,9 @@ fn with_envp<T>(env: Option<~[(~str, ~str)]>, cb: proc:(*c_void) -> T) -> T {
             }
 
             // Once again, this is unsafe.
-            let mut ptrs = tmps.map(|tmp| tmp.with_ref(|buf| buf));
+            let mut ptrs: Vec<*libc::c_char> = tmps.iter()
+                                                   .map(|tmp| tmp.with_ref(|buf| buf))
+                                                   .collect();
             ptrs.push(ptr::null());
 
             cb(ptrs.as_ptr() as *c_void)

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -69,8 +69,8 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
     }
 
     // Internalize everything but the reachable symbols of the current module
-    let cstrs = reachable.map(|s| s.to_c_str());
-    let arr = cstrs.map(|c| c.with_ref(|p| p));
+    let cstrs: Vec<::std::c_str::CString> = reachable.iter().map(|s| s.to_c_str()).collect();
+    let arr: Vec<*i8> = cstrs.iter().map(|c| c.with_ref(|p| p)).collect();
     let ptr = arr.as_ptr();
     unsafe {
         llvm::LLVMRustRunRestrictionPass(llmod, ptr as **libc::c_char,

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -943,9 +943,9 @@ pub fn build_session_options(matches: &getopts::Matches) -> session::Options {
         NoDebugInfo
     };
 
-    let addl_lib_search_paths = matches.opt_strs("L").map(|s| {
+    let addl_lib_search_paths = matches.opt_strs("L").iter().map(|s| {
         Path::new(s.as_slice())
-    }).move_iter().collect();
+    }).collect();
 
     let cfg = parse_cfgspecs(matches.opt_strs("cfg").move_iter().collect());
     let test = matches.opt_present("test");

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1861,7 +1861,7 @@ impl TypeNames {
     }
 
     pub fn types_to_str(&self, tys: &[Type]) -> ~str {
-        let strs = tys.map(|t| self.type_to_str(*t));
+        let strs: Vec<~str> = tys.iter().map(|t| self.type_to_str(*t)).collect();
         format!("[{}]", strs.connect(","))
     }
 

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -200,9 +200,9 @@ pub fn get_rust_path() -> Option<~str> {
 pub fn rust_path() -> Vec<Path> {
     let mut env_rust_path: Vec<Path> = match get_rust_path() {
         Some(env_path) => {
-            let env_path_components: Vec<&str> =
-                env_path.split_str(PATH_ENTRY_SEPARATOR).collect();
-            env_path_components.map(|&s| Path::new(s))
+            let env_path_components =
+                env_path.split_str(PATH_ENTRY_SEPARATOR);
+            env_path_components.map(|s| Path::new(s)).collect()
         }
         None => Vec::new()
     };

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -163,7 +163,7 @@ fn raw_pat(p: @Pat) -> @Pat {
 
 fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
     assert!((!pats.is_empty()));
-    let ext = match is_useful(cx, &pats.map(|p| vec!(*p)), [wild()]) {
+    let ext = match is_useful(cx, &pats.iter().map(|p| vec!(*p)).collect(), [wild()]) {
         not_useful => {
             // This is good, wildcard pattern isn't reachable
             return;
@@ -692,12 +692,12 @@ fn specialize(cx: &MatchCheckCtxt,
                     DefVariant(_, variant_id, _) => {
                         if variant(variant_id) == *ctor_id {
                             let struct_fields = ty::lookup_struct_fields(cx.tcx, variant_id);
-                            let args = struct_fields.map(|sf| {
+                            let args = struct_fields.iter().map(|sf| {
                                 match pattern_fields.iter().find(|f| f.ident.name == sf.name) {
                                     Some(f) => f.pat,
                                     _ => wild()
                                 }
-                            });
+                            }).collect();
                             Some(vec::append(args, r.tail()))
                         } else {
                             None

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4707,18 +4707,20 @@ impl<'a> Resolver<'a> {
                                         path: &Path,
                                         namespace: Namespace)
                                         -> Option<(Def, LastPrivate)> {
-        let module_path_idents = path.segments.init().map(|ps| ps.identifier);
+        let module_path_idents = path.segments.init().iter()
+                                                     .map(|ps| ps.identifier)
+                                                     .collect::<Vec<_>>();
 
         let containing_module;
         let last_private;
         match self.resolve_module_path(self.current_module,
-                                       module_path_idents,
+                                       module_path_idents.as_slice(),
                                        UseLexicalScope,
                                        path.span,
                                        PathSearch) {
             Failed => {
                 let msg = format!("use of undeclared module `{}`",
-                                  self.idents_to_str(module_path_idents));
+                                  self.idents_to_str(module_path_idents.as_slice()));
                 self.resolve_error(path.span, msg);
                 return None;
             }
@@ -4772,21 +4774,23 @@ impl<'a> Resolver<'a> {
                                    path: &Path,
                                    namespace: Namespace)
                                        -> Option<(Def, LastPrivate)> {
-        let module_path_idents = path.segments.init().map(|ps| ps.identifier);
+        let module_path_idents = path.segments.init().iter()
+                                                     .map(|ps| ps.identifier)
+                                                     .collect::<Vec<_>>();
 
         let root_module = self.graph_root.get_module();
 
         let containing_module;
         let last_private;
         match self.resolve_module_path_from_root(root_module,
-                                                 module_path_idents,
+                                                 module_path_idents.as_slice(),
                                                  0,
                                                  path.span,
                                                  PathSearch,
                                                  LastMod(AllPublic)) {
             Failed => {
                 let msg = format!("use of undeclared module `::{}`",
-                                  self.idents_to_str(module_path_idents));
+                                  self.idents_to_str(module_path_idents.as_slice()));
                 self.resolve_error(path.span, msg);
                 return None;
             }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -216,7 +216,7 @@ impl<'a> LifetimeContext<'a> {
                referenced_idents={:?} \
                early_count={}",
                n,
-               referenced_idents.map(lifetime_show),
+               referenced_idents.iter().map(lifetime_show).collect::<Vec<token::InternedString>>(),
                early_count);
         if referenced_idents.is_empty() {
             let scope1 = LateScope(n, &generics.lifetimes, scope);

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -134,7 +134,7 @@ impl<T:Subst> Subst for Vec<T> {
     fn subst_spanned(&self, tcx: &ty::ctxt,
                      substs: &ty::substs,
                      span: Option<Span>) -> Vec<T> {
-        self.map(|t| t.subst_spanned(tcx, substs, span))
+        self.iter().map(|t| t.subst_spanned(tcx, substs, span)).collect()
     }
 }
 impl<T:Subst> Subst for Rc<T> {
@@ -189,7 +189,7 @@ impl Subst for ty::substs {
         ty::substs {
             regions: self.regions.subst_spanned(tcx, substs, span),
             self_ty: self.self_ty.map(|typ| typ.subst_spanned(tcx, substs, span)),
-            tps: self.tps.map(|typ| typ.subst_spanned(tcx, substs, span))
+            tps: self.tps.iter().map(|typ| typ.subst_spanned(tcx, substs, span)).collect()
         }
     }
 }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1578,10 +1578,10 @@ fn compile_submatch_continue<'r,
             let pat_ty = node_id_type(bcx, pat_id);
             let pat_repr = adt::represent_type(bcx.ccx(), pat_ty);
             expr::with_field_tys(tcx, pat_ty, Some(pat_id), |discr, field_tys| {
-                let rec_vals = rec_fields.map(|field_name| {
+                let rec_vals = rec_fields.iter().map(|field_name| {
                         let ix = ty::field_idx_strict(tcx, field_name.name, field_tys);
                         adt::trans_field_ptr(bcx, pat_repr, val, discr, ix)
-                        });
+                        }).collect();
                 compile_submatch(
                         bcx,
                         enter_rec_or_struct(bcx,

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -121,7 +121,7 @@ pub fn Invoke(cx: &Block,
     terminate(cx, "Invoke");
     debug!("Invoke({} with arguments ({}))",
            cx.val_to_str(fn_),
-           args.map(|a| cx.val_to_str(*a)).connect(", "));
+           args.iter().map(|a| cx.val_to_str(*a)).collect::<Vec<~str>>().connect(", "));
     B(cx).invoke(fn_, args, then, catch, attributes)
 }
 

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -780,13 +780,13 @@ impl<'a> Builder<'a> {
         let alignstack = if alignstack { lib::llvm::True }
                          else          { lib::llvm::False };
 
-        let argtys = inputs.map(|v| {
+        let argtys = inputs.iter().map(|v| {
             debug!("Asm Input Type: {:?}", self.ccx.tn.val_to_str(*v));
             val_ty(*v)
-        });
+        }).collect::<Vec<_>>();
 
         debug!("Asm Output Type: {:?}", self.ccx.tn.type_to_str(output));
-        let fty = Type::func(argtys, &output);
+        let fty = Type::func(argtys.as_slice(), &output);
         unsafe {
             let v = llvm::LLVMInlineAsm(
                 fty.to_ref(), asm, cons, volatile, alignstack, dia as c_uint);
@@ -800,7 +800,10 @@ impl<'a> Builder<'a> {
 
         debug!("Call {} with args ({})",
                self.ccx.tn.val_to_str(llfn),
-               args.map(|&v| self.ccx.tn.val_to_str(v)).connect(", "));
+               args.iter()
+                   .map(|&v| self.ccx.tn.val_to_str(v))
+                   .collect::<Vec<~str>>()
+                   .connect(", "));
 
         unsafe {
             let v = llvm::LLVMBuildCall(self.llbuilder, llfn, args.as_ptr(),

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -816,7 +816,10 @@ pub fn node_id_type_params(bcx: &Block, node: ExprOrMethodCall) -> Vec<ty::t> {
     if !params.iter().all(|t| !ty::type_needs_infer(*t)) {
         bcx.sess().bug(
             format!("type parameters for node {:?} include inference types: {}",
-                 node, params.map(|t| bcx.ty_to_str(*t)).connect(",")));
+                 node, params.iter()
+                             .map(|t| bcx.ty_to_str(*t))
+                             .collect::<Vec<~str>>()
+                             .connect(",")));
     }
 
     match bcx.fcx.param_substs {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -994,7 +994,7 @@ fn trans_rec_or_struct<'a>(
     with_field_tys(tcx, ty, Some(id), |discr, field_tys| {
         let mut need_base = slice::from_elem(field_tys.len(), true);
 
-        let numbered_fields = fields.map(|field| {
+        let numbered_fields = fields.iter().map(|field| {
             let opt_pos =
                 field_tys.iter().position(|field_ty|
                                           field_ty.ident.name == field.ident.node.name);
@@ -1008,7 +1008,7 @@ fn trans_rec_or_struct<'a>(
                                       "Couldn't find field in struct type")
                 }
             }
-        });
+        }).collect::<Vec<_>>();
         let optbase = match base {
             Some(base_expr) => {
                 let mut leftovers = Vec::new();
@@ -1029,7 +1029,7 @@ fn trans_rec_or_struct<'a>(
         };
 
         let repr = adt::represent_type(bcx.ccx(), ty);
-        trans_adt(bcx, repr, discr, numbered_fields, optbase, dest)
+        trans_adt(bcx, repr, discr, numbered_fields.as_slice(), optbase, dest)
     })
 }
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -851,7 +851,7 @@ fn foreign_types_for_fn_ty(ccx: &CrateContext,
            ty.repr(ccx.tcx()),
            ccx.tn.types_to_str(llsig.llarg_tys.as_slice()),
            ccx.tn.type_to_str(llsig.llret_ty),
-           ccx.tn.types_to_str(fn_ty.arg_tys.map(|t| t.ty).as_slice()),
+           ccx.tn.types_to_str(fn_ty.arg_tys.iter().map(|t| t.ty).collect::<Vec<_>>().as_slice()),
            ccx.tn.type_to_str(fn_ty.ret_ty.ty),
            ret_def);
 

--- a/src/librustc/middle/trans/llrepr.rs
+++ b/src/librustc/middle/trans/llrepr.rs
@@ -18,7 +18,7 @@ pub trait LlvmRepr {
 
 impl<'a, T:LlvmRepr> LlvmRepr for &'a [T] {
     fn llrepr(&self, ccx: &CrateContext) -> ~str {
-        let reprs = self.map(|t| t.llrepr(ccx));
+        let reprs: Vec<~str> = self.iter().map(|t| t.llrepr(ccx)).collect();
         format!("[{}]", reprs.connect(","))
     }
 }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -541,7 +541,7 @@ fn emit_vtable_methods(bcx: &Block,
     ty::populate_implementations_for_trait_if_necessary(bcx.tcx(), trt_id);
 
     let trait_method_def_ids = ty::trait_method_def_ids(tcx, trt_id);
-    trait_method_def_ids.map(|method_def_id| {
+    trait_method_def_ids.iter().map(|method_def_id| {
         let ident = ty::method(tcx, *method_def_id).ident;
         // The substitutions we have are on the impl, so we grab
         // the method type from the impl to substitute into.
@@ -558,7 +558,7 @@ fn emit_vtable_methods(bcx: &Block,
         } else {
             trans_fn_ref_with_vtables(bcx, m_id, ExprId(0), substs, Some(vtables))
         }
-    })
+    }).collect()
 }
 
 pub fn trans_trait_cast<'a>(bcx: &'a Block<'a>,

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -298,7 +298,7 @@ pub fn make_mono_id(ccx: &CrateContext,
                vts.repr(ccx.tcx()), substs.tys.repr(ccx.tcx()));
         let vts_iter = substs.self_vtables.iter().chain(vts.iter());
         vts_iter.zip(substs_iter).map(|(vtable, subst)| {
-            let v = vtable.map(|vt| meth::vtable_id(ccx, vt));
+            let v = vtable.iter().map(|vt| meth::vtable_id(ccx, vt)).collect::<Vec<_>>();
             (*subst, if !v.is_empty() { Some(@v) } else { None })
         }).collect()
       }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1408,14 +1408,14 @@ pub fn mk_ctor_fn(cx: &ctxt,
                   binder_id: ast::NodeId,
                   input_tys: &[ty::t],
                   output: ty::t) -> t {
-    let input_args = input_tys.map(|t| *t);
+    let input_args = input_tys.iter().map(|t| *t).collect();
     mk_bare_fn(cx,
                BareFnTy {
                    purity: ast::ImpureFn,
                    abis: AbiSet::Rust(),
                    sig: FnSig {
                     binder_id: binder_id,
-                    inputs: Vec::from_slice(input_args),
+                    inputs: input_args,
                     output: output,
                     variadic: false
                    }
@@ -2880,7 +2880,7 @@ pub fn replace_closure_return_type(tcx: &ctxt, fn_type: t, ret_type: t) -> t {
 
 // Returns a vec of all the input and output types of fty.
 pub fn tys_in_fn_sig(sig: &FnSig) -> Vec<t> {
-    vec::append_one(sig.inputs.map(|a| *a), sig.output)
+    vec::append_one(sig.inputs.iter().map(|a| *a).collect(), sig.output)
 }
 
 // Type accessors for AST nodes
@@ -3432,7 +3432,7 @@ pub fn field_idx_strict(tcx: &ctxt, name: ast::Name, fields: &[field])
     tcx.sess.bug(format!(
         "no field named `{}` found in the list of fields `{:?}`",
         token::get_name(name),
-        fields.map(|f| token::get_ident(f.ident).get().to_str())));
+        fields.iter().map(|f| token::get_ident(f.ident).get().to_str()).collect::<Vec<~str>>()));
 }
 
 pub fn method_idx(id: ast::Ident, meths: &[@Method]) -> Option<uint> {
@@ -3724,8 +3724,8 @@ pub fn trait_supertraits(cx: &ctxt, id: ast::DefId) -> @Vec<@TraitRef> {
 
 pub fn trait_ref_supertraits(cx: &ctxt, trait_ref: &ty::TraitRef) -> Vec<@TraitRef> {
     let supertrait_refs = trait_supertraits(cx, trait_ref.def_id);
-    supertrait_refs.map(
-        |supertrait_ref| supertrait_ref.subst(cx, &trait_ref.substs))
+    supertrait_refs.iter().map(
+        |supertrait_ref| supertrait_ref.subst(cx, &trait_ref.substs)).collect()
 }
 
 fn lookup_locally_or_in_crate_store<V:Clone>(
@@ -3768,7 +3768,7 @@ pub fn trait_methods(cx: &ctxt, trait_did: ast::DefId) -> @Vec<@Method> {
         Some(&methods) => methods,
         None => {
             let def_ids = ty::trait_method_def_ids(cx, trait_did);
-            let methods = @def_ids.map(|d| ty::method(cx, *d));
+            let methods = @def_ids.iter().map(|d| ty::method(cx, *d)).collect();
             trait_methods.insert(trait_did, methods);
             methods
         }
@@ -3876,7 +3876,7 @@ impl VariantInfo {
         match ast_variant.node.kind {
             ast::TupleVariantKind(ref args) => {
                 let arg_tys = if args.len() > 0 {
-                    ty_fn_args(ctor_ty).map(|a| *a)
+                    ty_fn_args(ctor_ty).iter().map(|a| *a).collect()
                 } else {
                     Vec::new()
                 };
@@ -3897,7 +3897,7 @@ impl VariantInfo {
 
                 assert!(fields.len() > 0);
 
-                let arg_tys = ty_fn_args(ctor_ty).map(|a| *a);
+                let arg_tys = ty_fn_args(ctor_ty).iter().map(|a| *a).collect();
                 let arg_names = fields.iter().map(|field| {
                     match field.node.kind {
                         NamedField(ident, _) => ident,
@@ -4280,7 +4280,7 @@ fn struct_field_tys(fields: &[StructField]) -> Vec<field_ty> {
 // this. Takes a list of substs with which to instantiate field types.
 pub fn struct_fields(cx: &ctxt, did: ast::DefId, substs: &substs)
                      -> Vec<field> {
-    lookup_struct_fields(cx, did).map(|f| {
+    lookup_struct_fields(cx, did).iter().map(|f| {
        field {
             // FIXME #6993: change type of field to Name and get rid of new()
             ident: ast::Ident::new(f.name),
@@ -4289,7 +4289,7 @@ pub fn struct_fields(cx: &ctxt, did: ast::DefId, substs: &substs)
                 mutbl: MutImmutable
             }
         }
-    })
+    }).collect()
 }
 
 pub fn is_binopable(cx: &ctxt, ty: t, op: ast::BinOp) -> bool {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -167,8 +167,8 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
     let expected_num_region_params = decl_generics.region_param_defs().len();
     let supplied_num_region_params = path.segments.last().unwrap().lifetimes.len();
     let regions = if expected_num_region_params == supplied_num_region_params {
-        path.segments.last().unwrap().lifetimes.map(
-            |l| ast_region_to_region(this.tcx(), l))
+        path.segments.last().unwrap().lifetimes.iter().map(
+            |l| ast_region_to_region(this.tcx(), l)).collect::<Vec<_>>()
     } else {
         let anon_regions =
             rscope.anon_regions(path.span, expected_num_region_params);

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -147,7 +147,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
                         let vinfo =
                             ty::enum_variant_with_id(tcx, enm, var);
                         let var_tpt = ty::lookup_item_type(tcx, var);
-                        vinfo.args.map(|t| {
+                        vinfo.args.iter().map(|t| {
                             if var_tpt.generics.type_param_defs().len() ==
                                 expected_substs.tps.len()
                             {
@@ -157,7 +157,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
                                 *t // In this case, an error was already signaled
                                     // anyway
                             }
-                        })
+                        }).collect()
                     };
 
                     kind_name = "variant";
@@ -209,7 +209,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
             // Get the expected types of the arguments.
             let class_fields = ty::struct_fields(
                 tcx, struct_def_id, expected_substs);
-            arg_types = class_fields.map(|field| field.mt.ty);
+            arg_types = class_fields.iter().map(|field| field.mt.ty).collect();
 
             kind_name = "structure";
         }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -659,7 +659,10 @@ impl<'a> LookupContext<'a> {
         debug!("push_candidates_from_impl: {} {} {}",
                token::get_name(self.m_name),
                impl_info.ident.repr(self.tcx()),
-               impl_info.methods.map(|m| m.ident).repr(self.tcx()));
+               impl_info.methods.iter()
+                                .map(|m| m.ident)
+                                .collect::<Vec<ast::Ident>>()
+                                .repr(self.tcx()));
 
         let idx = {
             match impl_info.methods

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -449,7 +449,7 @@ fn check_fn<'a>(ccx: &'a CrateCtxt<'a>,
     let ret_ty = fn_sig.output;
 
     debug!("check_fn(arg_tys={:?}, ret_ty={:?})",
-           arg_tys.map(|&a| ppaux::ty_to_str(tcx, a)),
+           arg_tys.iter().map(|&a| ppaux::ty_to_str(tcx, a)).collect::<Vec<~str>>(),
            ppaux::ty_to_str(tcx, ret_ty));
 
     // Create the function context.  This is either derived from scratch or,
@@ -1717,7 +1717,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         };
 
         debug!("check_argument_types: formal_tys={:?}",
-               formal_tys.map(|t| fcx.infcx().ty_to_str(*t)));
+               formal_tys.iter().map(|t| fcx.infcx().ty_to_str(*t)).collect::<Vec<~str>>());
 
         // Check the arguments.
         // We do this in a pretty awful way: first we typecheck any arguments
@@ -1886,10 +1886,10 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                                 expr.span,
                                                 fcx.expr_ty(rcvr));
 
-        let tps = tps.map(|&ast_ty| fcx.to_ty(ast_ty));
+        let tps = tps.iter().map(|&ast_ty| fcx.to_ty(ast_ty)).collect::<Vec<_>>();
         let fn_ty = match method::lookup(fcx, expr, rcvr,
                                          method_name.name,
-                                         expr_t, tps,
+                                         expr_t, tps.as_slice(),
                                          DontDerefArgs,
                                          CheckTraitsAndInherentMethods,
                                          AutoderefReceiver) {
@@ -2235,7 +2235,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         let fty = if error_happened {
             fty_sig = FnSig {
                 binder_id: ast::CRATE_NODE_ID,
-                inputs: fn_ty.sig.inputs.map(|_| ty::mk_err()),
+                inputs: fn_ty.sig.inputs.iter().map(|_| ty::mk_err()).collect(),
                 output: ty::mk_err(),
                 variadic: false
             };
@@ -2938,11 +2938,11 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprMethodCall(ident, ref tps, ref args) => {
         check_method_call(fcx, expr, ident, args.as_slice(), tps.as_slice());
-        let arg_tys = args.map(|a| fcx.expr_ty(*a));
-        let (args_bot, args_err) = arg_tys.iter().fold((false, false),
+        let mut arg_tys = args.iter().map(|a| fcx.expr_ty(*a));
+        let (args_bot, args_err) = arg_tys.fold((false, false),
              |(rest_bot, rest_err), a| {
-              (rest_bot || ty::type_is_bot(*a),
-               rest_err || ty::type_is_error(*a))});
+              (rest_bot || ty::type_is_bot(a),
+               rest_err || ty::type_is_error(a))});
         if args_err {
             fcx.write_error(id);
         } else if args_bot {
@@ -3686,8 +3686,8 @@ pub fn instantiate_path(fcx: &FnCtxt,
     let num_expected_regions = tpt.generics.region_param_defs().len();
     let num_supplied_regions = pth.segments.last().unwrap().lifetimes.len();
     let regions = if num_expected_regions == num_supplied_regions {
-        OwnedSlice::from_vec(pth.segments.last().unwrap().lifetimes.map(
-            |l| ast_region_to_region(fcx.tcx(), l)))
+        OwnedSlice::from_vec(pth.segments.last().unwrap().lifetimes.iter().map(
+            |l| ast_region_to_region(fcx.tcx(), l)).collect())
     } else {
         if num_supplied_regions != 0 {
             fcx.ccx.tcx.sess.span_err(

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -113,7 +113,7 @@ fn resolve_vtable_map_entry(fcx: &FnCtxt, sp: Span, vtable_key: MethodCall) {
 
     fn resolve_origins(fcx: &FnCtxt, sp: Span,
                        vtbls: vtable_res) -> vtable_res {
-        @vtbls.map(|os| @os.map(|origin| {
+        @vtbls.iter().map(|os| @os.iter().map(|origin| {
             match origin {
                 &vtable_static(def_id, ref tys, origins) => {
                     let r_tys = resolve_type_vars_in_types(fcx,
@@ -126,7 +126,7 @@ fn resolve_vtable_map_entry(fcx: &FnCtxt, sp: Span, vtable_key: MethodCall) {
                     vtable_param(n, b)
                 }
             }
-        }))
+        }).collect()).collect()
     }
 }
 

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -152,7 +152,7 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
         let result_ty = match variant.node.kind {
             ast::TupleVariantKind(ref args) if args.len() > 0 => {
                 let rs = ExplicitRscope;
-                let input_tys = args.map(|va| ccx.to_ty(&rs, va.ty));
+                let input_tys: Vec<_> = args.iter().map(|va| ccx.to_ty(&rs, va.ty)).collect();
                 ty::mk_ctor_fn(tcx, scope, input_tys.as_slice(), enum_ty)
             }
 
@@ -168,8 +168,8 @@ pub fn get_enum_variant_types(ccx: &CrateCtxt,
 
                 convert_struct(ccx, struct_def, tpt, variant.node.id);
 
-                let input_tys = struct_def.fields.map(
-                    |f| ty::node_id_to_type(ccx.tcx, f.node.id));
+                let input_tys: Vec<_> = struct_def.fields.iter().map(
+                    |f| ty::node_id_to_type(ccx.tcx, f.node.id)).collect();
                 ty::mk_ctor_fn(tcx, scope, input_tys.as_slice(), enum_ty)
             }
         };
@@ -222,7 +222,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                     }
 
                     // Add an entry mapping
-                    let method_def_ids = @ms.map(|m| {
+                    let method_def_ids = @ms.iter().map(|m| {
                         match m {
                             &ast::Required(ref ty_method) => {
                                 local_def(ty_method.id)
@@ -231,13 +231,11 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                 local_def(method.id)
                             }
                         }
-                    });
+                    }).collect();
 
                     let trait_def_id = local_def(trait_id);
                     tcx.trait_method_def_ids.borrow_mut()
-                        .insert(trait_def_id, @method_def_ids.iter()
-                                                             .map(|x| *x)
-                                                             .collect());
+                        .insert(trait_def_id, method_def_ids);
                 }
                 _ => {} // Ignore things that aren't traits.
             }
@@ -697,9 +695,9 @@ pub fn convert_struct(ccx: &CrateCtxt,
                 tcx.tcache.borrow_mut().insert(local_def(ctor_id), tpt);
             } else if struct_def.fields.get(0).node.kind.is_unnamed() {
                 // Tuple-like.
-                let inputs = struct_def.fields.map(
+                let inputs: Vec<_> = struct_def.fields.iter().map(
                         |field| tcx.tcache.borrow().get(
-                            &local_def(field.node.id)).ty);
+                            &local_def(field.node.id)).ty).collect();
                 let ctor_fn_ty = ty::mk_ctor_fn(tcx,
                                                 ctor_id,
                                                 inputs.as_slice(),

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -683,7 +683,7 @@ impl<'a> InferCtxt<'a> {
     }
 
     pub fn tys_to_str(&self, ts: &[ty::t]) -> ~str {
-        let tstrs = ts.map(|t| self.ty_to_str(*t));
+        let tstrs: Vec<~str> = ts.iter().map(|t| self.ty_to_str(*t)).collect();
         format!("({})", tstrs.connect(", "))
     }
 

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -1164,8 +1164,14 @@ impl<'a> RegionVarBindings<'a> {
             format!("collect_error_for_expanding_node() could not find error \
                   for var {:?}, lower_bounds={}, upper_bounds={}",
                  node_idx,
-                 lower_bounds.map(|x| x.region).repr(self.tcx),
-                 upper_bounds.map(|x| x.region).repr(self.tcx)));
+                 lower_bounds.iter()
+                             .map(|x| x.region)
+                             .collect::<Vec<ty::Region>>()
+                             .repr(self.tcx),
+                 upper_bounds.iter()
+                             .map(|x| x.region)
+                             .collect::<Vec<ty::Region>>()
+                             .repr(self.tcx)));
     }
 
     fn collect_error_for_contracting_node(
@@ -1209,7 +1215,10 @@ impl<'a> RegionVarBindings<'a> {
             format!("collect_error_for_contracting_node() could not find error \
                   for var {:?}, upper_bounds={}",
                  node_idx,
-                 upper_bounds.map(|x| x.region).repr(self.tcx)));
+                 upper_bounds.iter()
+                             .map(|x| x.region)
+                             .collect::<Vec<ty::Region>>()
+                             .repr(self.tcx)));
     }
 
     fn collect_concrete_regions(&self,

--- a/src/librustc/middle/typeck/infer/to_str.rs
+++ b/src/librustc/middle/typeck/infer/to_str.rs
@@ -32,7 +32,7 @@ impl InferStr for ty::t {
 impl InferStr for FnSig {
     fn inf_str(&self, cx: &InferCtxt) -> ~str {
         format!("({}) -> {}",
-             self.inputs.map(|a| a.inf_str(cx)).connect(", "),
+             self.inputs.iter().map(|a| a.inf_str(cx)).collect::<Vec<~str>>().connect(", "),
              self.output.inf_str(cx))
     }
 }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -258,7 +258,7 @@ pub fn write_substs_to_tcx(tcx: &ty::ctxt,
                            substs: Vec<ty::t> ) {
     if substs.len() > 0u {
         debug!("write_substs_to_tcx({}, {:?})", node_id,
-               substs.map(|t| ppaux::ty_to_str(tcx, *t)));
+               substs.iter().map(|t| ppaux::ty_to_str(tcx, *t)).collect::<Vec<~str>>());
         assert!(substs.iter().all(|t| !ty::type_needs_infer(*t)));
 
         tcx.node_type_substs.borrow_mut().insert(node_id, substs);

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -67,7 +67,7 @@ pub fn indenter() -> _indenter {
 pub fn field_expr(f: ast::Field) -> @ast::Expr { return f.expr; }
 
 pub fn field_exprs(fields: Vec<ast::Field> ) -> Vec<@ast::Expr> {
-    fields.map(|f| f.expr)
+    fields.move_iter().map(|f| f.expr).collect()
 }
 
 struct LoopQueryVisitor<'a> {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -276,7 +276,7 @@ pub fn vstore_ty_to_str(cx: &ctxt, mt: &mt, vs: ty::vstore) -> ~str {
 }
 
 pub fn vec_map_to_str<T>(ts: &[T], f: |t: &T| -> ~str) -> ~str {
-    let tstrs = ts.map(f);
+    let tstrs = ts.iter().map(f).collect::<Vec<~str>>();
     format!("[{}]", tstrs.connect(", "))
 }
 
@@ -405,7 +405,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
                        ket: char,
                        sig: &ty::FnSig) {
         s.push_char(bra);
-        let strs = sig.inputs.map(|a| fn_input_to_str(cx, *a));
+        let strs: Vec<~str> = sig.inputs.iter().map(|a| fn_input_to_str(cx, *a)).collect();
         s.push_str(strs.connect(", "));
         if sig.variadic {
             s.push_str(", ...");
@@ -447,7 +447,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
       }
       ty_unboxed_vec(ref tm) => { format!("unboxed_vec<{}>", mt_to_str(cx, tm)) }
       ty_tup(ref elems) => {
-        let strs = elems.map(|elem| ty_to_str(cx, *elem));
+        let strs: Vec<~str> = elems.iter().map(|elem| ty_to_str(cx, *elem)).collect();
         ~"(" + strs.connect(",") + ")"
       }
       ty_closure(ref f) => {

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -314,14 +314,14 @@ pub fn unindent(s: &str) -> ~str {
 
     if lines.len() >= 1 {
         let mut unindented = vec!( lines.get(0).trim() );
-        unindented.push_all(lines.tail().map(|&line| {
+        unindented.push_all(lines.tail().iter().map(|&line| {
             if line.is_whitespace() {
                 line
             } else {
                 assert!(line.len() >= min_indent);
                 line.slice_from(min_indent)
             }
-        }));
+        }).collect::<Vec<_>>().as_slice());
         unindented.connect("\n")
     } else {
         s.to_owned()

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1706,7 +1706,7 @@ impl<A:ToJson,B:ToJson,C:ToJson> ToJson for (A, B, C) {
 }
 
 impl<A:ToJson> ToJson for ~[A] {
-    fn to_json(&self) -> Json { List(self.map(|elt| elt.to_json())) }
+    fn to_json(&self) -> Json { List(self.iter().map(|elt| elt.to_json()).collect()) }
 }
 
 impl<A:ToJson> ToJson for TreeMap<~str, A> {

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -285,12 +285,12 @@ impl<'a> AsciiStr for &'a [Ascii] {
 
     #[inline]
     fn to_lower(&self) -> ~[Ascii] {
-        self.map(|a| a.to_lower())
+        self.iter().map(|a| a.to_lower()).collect()
     }
 
     #[inline]
     fn to_upper(&self) -> ~[Ascii] {
-        self.map(|a| a.to_upper())
+        self.iter().map(|a| a.to_upper()).collect()
     }
 
     #[inline]

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -19,11 +19,12 @@ getaddrinfo()
 
 #![allow(missing_doc)]
 
+use iter::Iterator;
 use io::IoResult;
 use io::net::ip::{SocketAddr, IpAddr};
 use option::{Option, Some, None};
 use rt::rtio::{IoFactory, LocalIo};
-use slice::ImmutableVector;
+use slice::OwnedVector;
 
 /// Hints to the types of sockets that are desired when looking up hosts
 pub enum SocketType {
@@ -73,7 +74,7 @@ pub struct Info {
 /// Easy name resolution. Given a hostname, returns the list of IP addresses for
 /// that hostname.
 pub fn get_host_addresses(host: &str) -> IoResult<~[IpAddr]> {
-    lookup(Some(host), None, None).map(|a| a.map(|i| i.address.ip))
+    lookup(Some(host), None, None).map(|a| a.move_iter().map(|i| i.address.ip).collect())
 }
 
 /// Full-fleged resolution. This function will perform a synchronous call to

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -902,13 +902,6 @@ impl<T> Vec<T> {
         }
     }
 
-    ///Apply a function to each element of a vector and return the results.
-    #[inline]
-    #[deprecated="Use `xs.iter().map(closure)` instead."]
-    pub fn map<U>(&self, f: |t: &T| -> U) -> Vec<U> {
-        self.iter().map(f).collect()
-    }
-
     /// Takes ownership of the vector `other`, moving all elements into
     /// the current vector. This does not copy any elements, and it is
     /// illegal to use the `other` vector after calling this method

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -25,9 +25,9 @@ use std::u32;
 
 pub fn path_name_i(idents: &[Ident]) -> ~str {
     // FIXME: Bad copies (#2543 -- same for everything else that says "bad")
-    idents.map(|i| {
+    idents.iter().map(|i| {
         token::get_ident(*i).get().to_str()
-    }).connect("::")
+    }).collect::<Vec<~str>>().connect("::")
 }
 
 // totally scary function: ignores all but the last element, should have
@@ -717,13 +717,15 @@ mod test {
     }
 
     #[test] fn idents_name_eq_test() {
-        assert!(segments_name_eq([Ident{name:3,ctxt:4},
-                                   Ident{name:78,ctxt:82}].map(ident_to_segment),
-                                 [Ident{name:3,ctxt:104},
-                                   Ident{name:78,ctxt:182}].map(ident_to_segment)));
-        assert!(!segments_name_eq([Ident{name:3,ctxt:4},
-                                    Ident{name:78,ctxt:82}].map(ident_to_segment),
-                                  [Ident{name:3,ctxt:104},
-                                    Ident{name:77,ctxt:182}].map(ident_to_segment)));
+        assert!(segments_name_eq(
+            [Ident{name:3,ctxt:4}, Ident{name:78,ctxt:82}]
+                .iter().map(ident_to_segment).collect::<Vec<PathSegment>>().as_slice(),
+            [Ident{name:3,ctxt:104}, Ident{name:78,ctxt:182}]
+                .iter().map(ident_to_segment).collect::<Vec<PathSegment>>().as_slice()));
+        assert!(!segments_name_eq(
+            [Ident{name:3,ctxt:4}, Ident{name:78,ctxt:82}]
+                .iter().map(ident_to_segment).collect::<Vec<PathSegment>>().as_slice(),
+            [Ident{name:3,ctxt:104}, Ident{name:77,ctxt:182}]
+                .iter().map(ident_to_segment).collect::<Vec<PathSegment>>().as_slice()));
     }
 }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -746,7 +746,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
     fn lambda(&self, span: Span, ids: Vec<ast::Ident> , blk: P<ast::Block>) -> @ast::Expr {
         let fn_decl = self.fn_decl(
-            ids.map(|id| self.arg(span, *id, self.ty_infer(span))),
+            ids.iter().map(|id| self.arg(span, *id, self.ty_infer(span))).collect(),
             self.ty_infer(span));
 
         self.expr(span, ast::ExprFnBlock(fn_decl, blk))
@@ -966,16 +966,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
 
     fn view_use_list(&self, sp: Span, vis: ast::Visibility,
                      path: Vec<ast::Ident> , imports: &[ast::Ident]) -> ast::ViewItem {
-        let imports = imports.map(|id| {
+        let imports = imports.iter().map(|id| {
             respan(sp, ast::PathListIdent_ { name: *id, id: ast::DUMMY_NODE_ID })
-        });
+        }).collect();
 
         self.view_use(sp, vis,
                       vec!(@respan(sp,
                                 ast::ViewPathList(self.path(sp, path),
-                                                  imports.iter()
-                                                         .map(|x| *x)
-                                                         .collect(),
+                                                  imports,
                                                   ast::DUMMY_NODE_ID))))
     }
 

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -71,11 +71,11 @@ fn cs_clone(
 
     if all_fields.len() >= 1 && all_fields.get(0).name.is_none() {
         // enum-like
-        let subcalls = all_fields.map(subcall);
+        let subcalls = all_fields.iter().map(subcall).collect();
         cx.expr_call_ident(trait_span, ctor_ident, subcalls)
     } else {
         // struct-like
-        let fields = all_fields.map(|field| {
+        let fields = all_fields.iter().map(|field| {
             let ident = match field.name {
                 Some(i) => i,
                 None => cx.span_bug(trait_span,
@@ -83,7 +83,7 @@ fn cs_clone(
                                             name))
             };
             cx.field_imm(field.span, ident, subcall(field))
-        });
+        }).collect::<Vec<_>>();
 
         if fields.is_empty() {
             // no fields, so construct like `None`

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -56,14 +56,14 @@ fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructur
                     if fields.is_empty() {
                         cx.expr_ident(trait_span, substr.type_ident)
                     } else {
-                        let exprs = fields.map(|sp| default_call(*sp));
+                        let exprs = fields.iter().map(|sp| default_call(*sp)).collect();
                         cx.expr_call_ident(trait_span, substr.type_ident, exprs)
                     }
                 }
                 Named(ref fields) => {
-                    let default_fields = fields.map(|&(ident, span)| {
+                    let default_fields = fields.iter().map(|&(ident, span)| {
                         cx.field_imm(span, ident, default_call(span))
-                    });
+                    }).collect();
                     cx.expr_struct_ident(trait_span, substr.type_ident, default_fields)
                 }
             }

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -136,15 +136,15 @@ fn rand_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
                 if fields.is_empty() {
                     cx.expr_ident(trait_span, ctor_ident)
                 } else {
-                    let exprs = fields.map(|span| rand_call(cx, *span));
+                    let exprs = fields.iter().map(|span| rand_call(cx, *span)).collect();
                     cx.expr_call_ident(trait_span, ctor_ident, exprs)
                 }
             }
             Named(ref fields) => {
-                let rand_fields = fields.map(|&(ident, span)| {
+                let rand_fields = fields.iter().map(|&(ident, span)| {
                     let e = rand_call(cx, span);
                     cx.field_imm(span, ident, e)
-                });
+                }).collect();
                 cx.expr_struct_ident(trait_span, ctor_ident, rand_fields)
             }
         }

--- a/src/libsyntax/ext/deriving/ty.rs
+++ b/src/libsyntax/ext/deriving/ty.rs
@@ -69,9 +69,9 @@ impl<'a> Path<'a> {
                    self_ty: Ident,
                    self_generics: &Generics)
                    -> ast::Path {
-        let idents = self.path.map(|s| cx.ident_of(*s) );
+        let idents = self.path.iter().map(|s| cx.ident_of(*s)).collect();
         let lt = mk_lifetimes(cx, span, &self.lifetime);
-        let tys = self.params.map(|t| t.to_ty(cx, span, self_ty, self_generics));
+        let tys = self.params.iter().map(|t| t.to_ty(cx, span, self_ty, self_generics)).collect();
 
         cx.path_all(span, self.global, idents, lt, tys)
     }
@@ -150,7 +150,9 @@ impl<'a> Ty<'a> {
                 let ty = if fields.is_empty() {
                     ast::TyNil
                 } else {
-                    ast::TyTup(fields.map(|f| f.to_ty(cx, span, self_ty, self_generics)))
+                    ast::TyTup(fields.iter()
+                                     .map(|f| f.to_ty(cx, span, self_ty, self_generics))
+                                     .collect())
                 };
 
                 cx.ty(span, ty)
@@ -219,10 +221,10 @@ impl<'a> LifetimeBounds<'a> {
                        self_ty: Ident,
                        self_generics: &Generics)
                        -> Generics {
-        let lifetimes = self.lifetimes.map(|lt| {
+        let lifetimes = self.lifetimes.iter().map(|lt| {
             cx.lifetime(span, cx.ident_of(*lt).name)
-        });
-        let ty_params = self.bounds.map(|t| {
+        }).collect();
+        let ty_params = self.bounds.iter().map(|t| {
             match t {
                 &(ref name, ref bounds) => {
                     mk_ty_param(cx,
@@ -233,7 +235,7 @@ impl<'a> LifetimeBounds<'a> {
                                 self_generics)
                 }
             }
-        });
+        }).collect();
         mk_generics(lifetimes, ty_params)
     }
 }

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -73,14 +73,14 @@ fn zero_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
                     if fields.is_empty() {
                         cx.expr_ident(trait_span, substr.type_ident)
                     } else {
-                        let exprs = fields.map(|sp| zero_call(*sp));
+                        let exprs = fields.iter().map(|sp| zero_call(*sp)).collect();
                         cx.expr_call_ident(trait_span, substr.type_ident, exprs)
                     }
                 }
                 Named(ref fields) => {
-                    let zero_fields = fields.map(|&(ident, span)| {
+                    let zero_fields = fields.iter().map(|&(ident, span)| {
                         cx.field_imm(span, ident, zero_call(span))
-                    });
+                    }).collect();
                     cx.expr_struct_ident(trait_span, substr.type_ident, zero_fields)
                 }
             }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -776,7 +776,7 @@ pub fn expand_block(blk: &Block, fld: &mut MacroExpander) -> P<Block> {
 
 // expand the elements of a block.
 pub fn expand_block_elts(b: &Block, fld: &mut MacroExpander) -> P<Block> {
-    let new_view_items = b.view_items.map(|x| fld.fold_view_item(x));
+    let new_view_items = b.view_items.iter().map(|x| fld.fold_view_item(x)).collect();
     let new_stmts =
         b.stmts.iter().flat_map(|x| {
             let renamed_stmt = {

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -83,7 +83,7 @@ pub mod rt {
 
     impl<'a> ToSource for &'a [@ast::Item] {
         fn to_source(&self) -> ~str {
-            self.map(|i| i.to_source()).connect("\n\n")
+            self.iter().map(|i| i.to_source()).collect::<Vec<~str>>().connect("\n\n")
         }
     }
 
@@ -95,7 +95,7 @@ pub mod rt {
 
     impl<'a> ToSource for &'a [ast::Ty] {
         fn to_source(&self) -> ~str {
-            self.map(|i| i.to_source()).connect(", ")
+            self.iter().map(|i| i.to_source()).collect::<Vec<~str>>().connect(", ")
         }
     }
 
@@ -339,7 +339,7 @@ pub fn expand_quote_stmt(cx: &mut ExtCtxt,
 }
 
 fn ids_ext(strs: Vec<~str> ) -> Vec<ast::Ident> {
-    strs.map(|str| str_to_ident(*str))
+    strs.iter().map(|str| str_to_ident(*str)).collect()
 }
 
 fn id_ext(str: &str) -> ast::Ident {

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -71,7 +71,9 @@ pub fn expand_mod(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     -> base::MacResult {
     base::check_zero_tts(cx, sp, tts, "module_path!");
     let string = cx.mod_path()
+                   .iter()
                    .map(|x| token::get_ident(*x).get().to_str())
+                   .collect::<Vec<~str>>()
                    .connect("::");
     base::MRExpr(cx.expr_str(sp, token::intern_and_get_ident(string)))
 }

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -373,7 +373,7 @@ pub fn parse(sess: &ParseSess,
         } else {
             if (bb_eis.len() > 0u && next_eis.len() > 0u)
                 || bb_eis.len() > 1u {
-                let nts = bb_eis.map(|ei| {
+                let nts = bb_eis.iter().map(|ei| {
                     match ei.elts.get(ei.idx).node {
                       MatchNonterminal(bind, name, _) => {
                         format!("{} ('{}')",
@@ -381,7 +381,7 @@ pub fn parse(sess: &ParseSess,
                                 token::get_ident(bind))
                       }
                       _ => fail!()
-                    } }).connect(" or ");
+                    } }).collect::<Vec<~str>>().connect(" or ");
                 return Error(sp, format!(
                     "local ambiguity: multiple parsing options: \
                      built-in NTs {} or {} other options.",

--- a/src/libsyntax/parse/comments.rs
+++ b/src/libsyntax/parse/comments.rs
@@ -104,7 +104,7 @@ pub fn strip_doc_comment_decoration(comment: &str) -> ~str {
         }
 
         if can_trim {
-            lines.map(|line| line.slice(i + 1, line.len()).to_owned())
+            lines.iter().map(|line| line.slice(i + 1, line.len()).to_owned()).collect()
         } else {
             lines
         }

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -70,7 +70,7 @@ pub fn string_to_pat(source_str: ~str) -> @ast::Pat {
 
 // convert a vector of strings to a vector of ast::Ident's
 pub fn strs_to_idents(ids: Vec<&str> ) -> Vec<ast::Ident> {
-    ids.map(|u| token::str_to_ident(*u))
+    ids.iter().map(|u| token::str_to_ident(*u)).collect()
 }
 
 // does the given string match the pattern? whitespace in the first string

--- a/src/test/auxiliary/issue_2723_a.rs
+++ b/src/test/auxiliary/issue_2723_a.rs
@@ -10,5 +10,5 @@
 
 
 pub unsafe fn f(xs: Vec<int> ) {
-    xs.map(|_x| { unsafe fn q() { fail!(); } });
+    xs.iter().map(|_x| { unsafe fn q() { fail!(); } }).collect::<Vec<()>>();
 }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -99,7 +99,9 @@ impl AsciiArt {
 impl fmt::Show for AsciiArt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Convert each line into a string.
-        let lines = self.lines.map(|line| str::from_chars(line.as_slice()));
+        let lines = self.lines.iter()
+                              .map(|line| str::from_chars(line.as_slice()))
+                              .collect::<Vec<~str>>();
 
         // Concatenate the lines together using a new-line.
         write!(f.buf, "{}", lines.connect("\n"))


### PR DESCRIPTION
They required unnecessary temporaries, are replaced with iterators, and would conflict with a possible future `Iterable` trait.
