### PR TITLE
[RFC] num: bitwise reflection methods

### DIFF
--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -39,6 +39,16 @@ impl Bitwise for i16 {
     /// of the number.
     #[inline]
     fn trailing_zeros(&self) -> i16 { unsafe { intrinsics::cttz16(*self) } }
+
+    /// Returns the bitwise reflected representation of the number.
+    fn reflect(&self) -> i16 {
+        let mut r = 0;
+        for i in range(0, 16) {
+            let digit = (*self >> i) & 1;
+            r = r | (digit << (15-i));
+        }
+      return r;
+    }
 }
 
 impl CheckedAdd for i16 {

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -39,6 +39,16 @@ impl Bitwise for i32 {
     /// of the number.
     #[inline]
     fn trailing_zeros(&self) -> i32 { unsafe { intrinsics::cttz32(*self) } }
+
+    /// Returns the bitwise reflected representation of the number.
+    fn reflect(&self) -> i32 {
+        let mut r = 0;
+        for i in range(0, 32) {
+            let digit = (*self >> i) & 1;
+            r = r | (digit << (31-i));
+        }
+      return r;
+    }
 }
 
 impl CheckedAdd for i32 {

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -40,6 +40,16 @@ impl Bitwise for i64 {
     /// Counts the number of trailing zeros.
     #[inline]
     fn trailing_zeros(&self) -> i64 { unsafe { intrinsics::cttz64(*self) } }
+
+    /// Returns the bitwise reflected representation of the number.
+    fn reflect(&self) -> i64 {
+        let mut r = 0;
+        for i in range(0, 64) {
+            let digit = (*self >> i) & 1;
+            r = r | (digit << (63-i));
+        }
+      return r;
+    }
 }
 
 impl CheckedAdd for i64 {

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -39,6 +39,16 @@ impl Bitwise for i8 {
     /// of the number.
     #[inline]
     fn trailing_zeros(&self) -> i8 { unsafe { intrinsics::cttz8(*self) } }
+
+    /// Returns the bitwise reflected representation of the number.
+    fn reflect(&self) -> i8 {
+        let mut r = 0;
+        for i in range(0, 8) {
+            let digit = (*self >> i) & 1;
+            r = r | (digit << (7-i));
+        }
+      return r;
+    }
 }
 
 impl CheckedAdd for i8 {

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -41,6 +41,10 @@ impl Bitwise for int {
     /// of the number.
     #[inline]
     fn trailing_zeros(&self) -> int { (*self as i32).trailing_zeros() as int }
+
+    /// Returns the bitwise reflected representation of the number.
+    #[inline]
+    fn reflect(&self) -> int { (*self as i32).reflect() as int }
 }
 
 #[cfg(target_word_size = "64")]
@@ -58,6 +62,10 @@ impl Bitwise for int {
     /// of the number.
     #[inline]
     fn trailing_zeros(&self) -> int { (*self as i64).trailing_zeros() as int }
+
+    /// Returns the bitwise reflected representation of the number.
+    #[inline]
+    fn reflect(&self) -> int { (*self as i64).reflect() as int }
 }
 
 #[cfg(target_word_size = "32")]

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -375,6 +375,13 @@ mod tests {
     }
 
     #[test]
+    fn test_bitwise_reflect() {
+        assert_eq!((0b01011001 as $T).reflect(), (0b10011010 as $T) << (BITS - 8));
+        assert_eq!((0b01000011 as $T).reflect(), (0b11000010 as $T) << (BITS - 8));
+        assert_eq!((0b11110011 as $T).reflect(), (0b11001111 as $T) << (BITS - 8));
+    }
+
+    #[test]
     fn test_from_str() {
         assert_eq!(from_str::<$T>("0"), Some(0 as $T));
         assert_eq!(from_str::<$T>("3"), Some(3 as $T));

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -271,6 +271,18 @@ pub trait Bitwise: Bounded
     /// assert_eq!(n.trailing_zeros(), 3);
     /// ```
     fn trailing_zeros(&self) -> Self;
+
+    /// Returns the bitwise reflected representation of the number.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::num::Bitwise;
+    ///
+    /// let n = 0b11010001u8;
+    /// assert_eq!(n.reflect(), 0b10001011u8);
+    /// ```
+    fn reflect(&self) -> Self;
 }
 
 /// Specifies the available operations common to all of Rust's core numeric primitives.

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -223,6 +223,11 @@ impl Bitwise for $T {
     fn trailing_zeros(&self) -> $T {
         (*self as $T_SIGNED).trailing_zeros() as $T
     }
+
+    /// Returns the bitwise reflected representation of the number.
+    fn reflect(&self) -> $T {
+        (*self as $T_SIGNED).reflect() as $T
+    }
 }
 
 #[cfg(test)]
@@ -270,6 +275,13 @@ mod tests {
         assert_eq!((0b0101100 as $T).count_zeros(), BITS as $T - 3);
         assert_eq!((0b0100001 as $T).count_zeros(), BITS as $T - 2);
         assert_eq!((0b1111001 as $T).count_zeros(), BITS as $T - 5);
+    }
+
+    #[test]
+    fn test_bitwise_reflect() {
+        assert_eq!((0b01011001 as $T).reflect(), (0b10011010 as $T) << (BITS - 8));
+        assert_eq!((0b01000011 as $T).reflect(), (0b11000010 as $T) << (BITS - 8));
+        assert_eq!((0b11110011 as $T).reflect(), (0b11001111 as $T) << (BITS - 8));
     }
 
     #[test]


### PR DESCRIPTION
A bit-manipulation PR, however I still have some doubts:
- Library. I believe this is a pretty core operation for several algorithms (eg. many checksums), is the "battery-included" philosophy ok for libstd?
- Naming. Is `reflect()` too generic? That's how the operation is usually called, but may be too broad as API and conflict with reflection/introspection.
- Lot's of redundancy here: 8, 16, 32 and 64 variants. I tried implementing it more generically, however:
  - The `Bitwise` trait lacks `One`, `Zero` and `NumCast` for this implementation to work. Maybe they should be added anyway?
  - Is it possible to split `impl Bitwise for i8..i64` in multiple files? Most of it is through instrinsics in each module, but ideally `reflect()` could be directly implemented in uint/int_macros abusing `$T`.

---

Let Bitwise provide a reflect() method for reversed binary
representation. This is a binary primitive used in several algorithms,
eg. CRC checksums.
