### PR TITLE
configure: Accept LLVM 3.4.X during configuration

### DIFF
--- a/configure
+++ b/configure
@@ -610,7 +610,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[2-5]svn|3.[2-5])
+        (3.[2-5]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)


### PR DESCRIPTION
The previous regex was a bit to strict, rejecting versions such as 3.4.1 which
is apparently the version which travis is currently installing, causing all
travis builds to fail.
