### PR TITLE
vec: convert `append` and `append_one` to methods

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -11,7 +11,6 @@
 use std::os;
 use std::str;
 use std::io::process::{ProcessExit, Process, ProcessConfig, ProcessOutput};
-use std::vec;
 
 #[cfg(target_os = "win32")]
 fn target_env(lib_path: &str, prog: &str) -> Vec<(~str,~str)> {
@@ -66,8 +65,7 @@ pub fn run(lib_path: &str,
            env: Vec<(~str, ~str)> ,
            input: Option<~str>) -> Option<Result> {
 
-    let env = vec::append(env.clone(),
-                             target_env(lib_path, prog).as_slice());
+    let env = env.clone().append(target_env(lib_path, prog).as_slice());
     let mut opt_process = Process::configure(ProcessConfig {
         program: prog,
         args: args,
@@ -98,8 +96,7 @@ pub fn run_background(lib_path: &str,
            env: Vec<(~str, ~str)> ,
            input: Option<~str>) -> Option<Process> {
 
-    let env = vec::append(env.clone(),
-                             target_env(lib_path, prog).as_slice());
+    let env = env.clone().append(target_env(lib_path, prog).as_slice());
     let opt_process = Process::configure(ProcessConfig {
         program: prog,
         args: args,

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -33,7 +33,6 @@ use std::os;
 use std::str;
 use std::task;
 use std::slice;
-use std::vec;
 use test::MetricMap;
 
 pub fn run(config: config, testfile: ~str) {
@@ -683,7 +682,7 @@ fn compile_test_(config: &config, props: &TestProps,
     let link_args = vec!(~"-L", aux_dir.as_str().unwrap().to_owned());
     let args = make_compile_args(config,
                                  props,
-                                 vec::append(link_args, extra_args),
+                                 link_args.append(extra_args),
                                  |a, b| ThisFile(make_exe_name(a, b)), testfile);
     compose_and_run_compiler(config, props, testfile, args, None)
 }
@@ -734,8 +733,7 @@ fn compose_and_run_compiler(
         let aux_args =
             make_compile_args(config,
                               &aux_props,
-                              vec::append(crate_type,
-                                             extra_link_args.as_slice()),
+                              crate_type.append(extra_link_args.as_slice()),
                               |a,b| {
                                   let f = make_lib_name(a, b, testfile);
                                   ThisDirectory(f.dir_path())
@@ -1108,8 +1106,7 @@ fn compile_test_and_save_bitcode(config: &config, props: &TestProps,
     let llvm_args = vec!(~"--emit=obj", ~"--crate-type=lib", ~"-C", ~"save-temps");
     let args = make_compile_args(config,
                                  props,
-                                 vec::append(link_args,
-                                                llvm_args.as_slice()),
+                                 link_args.append(llvm_args.as_slice()),
                                  |a, b| ThisFile(make_o_name(a, b)), testfile);
     compose_and_run_compiler(config, props, testfile, args, None)
 }

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -28,7 +28,6 @@ use rand::Rng;
 use std::str;
 use std::uint;
 use std::{i64, u64};
-use std::vec;
 
 /**
 A `BigDigit` is a `BigUint`'s composing element.
@@ -747,8 +746,7 @@ impl BigUint {
     fn shl_unit(&self, n_unit: uint) -> BigUint {
         if n_unit == 0 || self.is_zero() { return (*self).clone(); }
 
-        return BigUint::new(vec::append(Vec::from_elem(n_unit, ZERO_BIG_DIGIT),
-                                           self.data.as_slice()));
+        BigUint::new(Vec::from_elem(n_unit, ZERO_BIG_DIGIT).append(self.data.as_slice()))
     }
 
     #[inline]

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -37,7 +37,6 @@ use std::io::fs;
 use std::io::MemReader;
 use std::mem::drop;
 use std::os;
-use std::vec;
 use getopts::{optopt, optmulti, optflag, optflagopt};
 use getopts;
 use syntax::ast;
@@ -137,8 +136,7 @@ pub fn build_configuration(sess: &Session) -> ast::CrateConfig {
     } else {
         InternedString::new("nogc")
     });
-    return vec::append(user_cfg.move_iter().collect(),
-                          default_cfg.as_slice());
+    user_cfg.move_iter().collect::<Vec<_>>().append(default_cfg.as_slice())
 }
 
 // Convert strings provided as --cfg [cfgspec] into a crate_cfg
@@ -836,9 +834,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> session::Options {
 
         let level_short = level_name.slice_chars(0, 1);
         let level_short = level_short.to_ascii().to_upper().into_str();
-        let flags = vec::append(matches.opt_strs(level_short)
-                                          .move_iter()
-                                          .collect(),
+        let flags = matches.opt_strs(level_short).move_iter().collect::<Vec<_>>().append(
                                    matches.opt_strs(level_name).as_slice());
         for lint_name in flags.iter() {
             let lint_name = lint_name.replace("-", "_");

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -11,7 +11,6 @@
 
 use driver::session::Session;
 
-use std::vec;
 use syntax::ast;
 use syntax::attr;
 use syntax::codemap::DUMMY_SP;
@@ -173,7 +172,7 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
             span: DUMMY_SP,
         };
 
-        let vis = vec::append(vec!(vi2), module.view_items.as_slice());
+        let vis = (vec!(vi2)).append(module.view_items.as_slice());
 
         // FIXME #2543: Bad copy.
         let new_module = ast::Mod {

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -272,7 +272,7 @@ fn should_fail(i: @ast::Item) -> bool {
 fn add_test_module(cx: &TestCtxt, m: &ast::Mod) -> ast::Mod {
     let testmod = mk_test_module(cx);
     ast::Mod {
-        items: vec::append_one(m.items.clone(), testmod),
+        items: m.items.clone().append_one(testmod),
         ..(*m).clone()
     }
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -54,7 +54,6 @@ use std::io;
 use std::os;
 use std::str;
 use std::task;
-use std::vec;
 use syntax::ast;
 use syntax::diagnostic::Emitter;
 use syntax::diagnostic;
@@ -239,9 +238,7 @@ pub fn run_compiler(args: &[~str]) {
         return;
     }
 
-    let lint_flags = vec::append(matches.opt_strs("W")
-                                           .move_iter()
-                                           .collect(),
+    let lint_flags = matches.opt_strs("W").move_iter().collect::<Vec<_>>().append(
                                     matches.opt_strs("warn").as_slice());
     if lint_flags.iter().any(|x| x == &~"help") {
         describe_warnings();

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -20,7 +20,6 @@ use middle::typeck;
 
 use reader = serialize::ebml::reader;
 use std::rc::Rc;
-use std::vec;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::diagnostic::expect;
@@ -93,8 +92,7 @@ pub fn get_item_path(tcx: &ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> 
 
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
-    vec::append(vec!(ast_map::PathMod(token::intern(cdata.name))),
-                   path.as_slice())
+    (vec!(ast_map::PathMod(token::intern(cdata.name)))).append(path.as_slice())
 }
 
 pub enum found_ast {

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -12,7 +12,6 @@
  * Computes the restrictions that result from a borrow.
  */
 
-use std::vec;
 use middle::borrowck::*;
 use mc = middle::mem_categorization;
 use middle::ty;
@@ -173,11 +172,7 @@ impl<'a> RestrictionsContext<'a> {
             Safe => Safe,
             SafeIf(base_lp, base_vec) => {
                 let lp = @LpExtend(base_lp, mc, elem);
-                SafeIf(lp, vec::append_one(base_vec,
-                                              Restriction {
-                                                  loan_path: lp,
-                                                  set: restrictions
-                                              }))
+                SafeIf(lp, base_vec.append_one(Restriction { loan_path: lp, set: restrictions }))
             }
         }
     }

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -21,7 +21,6 @@ use util::ppaux::ty_to_str;
 
 use std::cmp;
 use std::iter;
-use std::vec;
 use syntax::ast::*;
 use syntax::ast_util::{unguarded_pat, walk_pat};
 use syntax::codemap::{DUMMY_SP, Span};
@@ -560,11 +559,10 @@ fn specialize(cx: &MatchCheckCtxt,
         Pat{id: pat_id, node: n, span: pat_span} =>
             match n {
             PatWild => {
-                Some(vec::append(Vec::from_elem(arity, wild()), r.tail()))
+                Some(Vec::from_elem(arity, wild()).append(r.tail()))
             }
             PatWildMulti => {
-                Some(vec::append(Vec::from_elem(arity, wild_multi()),
-                                    r.tail()))
+                Some(Vec::from_elem(arity, wild_multi()).append(r.tail()))
             }
             PatIdent(_, _, _) => {
                 let opt_def = cx.tcx.def_map.borrow().find_copy(&pat_id);
@@ -615,12 +613,7 @@ fn specialize(cx: &MatchCheckCtxt,
                         }
                     }
                     _ => {
-                        Some(
-                            vec::append(
-                                Vec::from_elem(arity, wild()),
-                                r.tail()
-                            )
-                        )
+                        Some(Vec::from_elem(arity, wild()).append(r.tail()))
                     }
                 }
             }
@@ -667,7 +660,7 @@ fn specialize(cx: &MatchCheckCtxt,
                             Some(args) => args.iter().map(|x| *x).collect(),
                             None => Vec::from_elem(arity, wild())
                         };
-                        Some(vec::append(args, r.tail()))
+                        Some(args.append(r.tail()))
                     }
                     DefVariant(_, _, _) => None,
 
@@ -680,7 +673,7 @@ fn specialize(cx: &MatchCheckCtxt,
                             }
                             None => new_args = Vec::from_elem(arity, wild())
                         }
-                        Some(vec::append(new_args, r.tail()))
+                        Some(new_args.append(r.tail()))
                     }
                     _ => None
                 }
@@ -697,8 +690,8 @@ fn specialize(cx: &MatchCheckCtxt,
                                     Some(f) => f.pat,
                                     _ => wild()
                                 }
-                            }).collect();
-                            Some(vec::append(args, r.tail()))
+                            }).collect::<Vec<_>>();
+                            Some(args.append(r.tail()))
                         } else {
                             None
                         }
@@ -728,16 +721,16 @@ fn specialize(cx: &MatchCheckCtxt,
                                 Some(f) => f.pat,
                                 _ => wild()
                             }
-                        }).collect();
-                        Some(vec::append(args, r.tail()))
+                        }).collect::<Vec<_>>();
+                        Some(args.append(r.tail()))
                     }
                 }
             }
             PatTup(args) => {
-                Some(vec::append(args.iter().map(|x| *x).collect(), r.tail()))
+                Some(args.iter().map(|x| *x).collect::<Vec<_>>().append(r.tail()))
             }
             PatUniq(a) | PatRegion(a) => {
-                Some(vec::append(vec!(a), r.tail()))
+                Some((vec!(a)).append(r.tail()))
             }
             PatLit(expr) => {
                 let e_v = eval_const_expr(cx.tcx, expr);

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -57,7 +57,6 @@ use middle::trans::type_::Type;
 use middle::trans::type_of;
 use middle::ty;
 use middle::ty::Disr;
-use std::vec;
 use syntax::abi::{X86, X86_64, Arm, Mips};
 use syntax::ast;
 use syntax::attr;
@@ -220,9 +219,7 @@ fn represent_type_uncached(cx: &CrateContext, t: ty::t) -> Repr {
             let ity = range_to_inttype(cx, hint, &bounds);
             return General(ity, cases.iter().map(|c| {
                 let discr = vec!(ty_of_inttype(ity));
-                mk_struct(cx,
-                          vec::append(discr, c.tys.as_slice()).as_slice(),
-                          false)
+                mk_struct(cx, discr.append(c.tys.as_slice()).as_slice(), false)
             }).collect())
         }
         _ => cx.sess().bug("adt::represent_type called on non-ADT type")
@@ -753,12 +750,8 @@ pub fn trans_const(ccx: &CrateContext, r: &Repr, discr: Disr,
             let lldiscr = C_integral(ll_inttype(ccx, ity), discr as u64, true);
             let contents = build_const_struct(ccx,
                                               case,
-                                              vec::append(
-                                                  vec!(lldiscr),
-                                                  vals).as_slice());
-            C_struct(ccx, vec::append(
-                        contents,
-                        &[padding(ccx, max_sz - case.size)]).as_slice(),
+                                              (vec!(lldiscr)).append(vals).as_slice());
+            C_struct(ccx, contents.append([padding(ccx, max_sz - case.size)]).as_slice(),
                      false)
         }
         Univariant(ref st, _dro) => {

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -49,7 +49,6 @@ use util::ppaux::Repr;
 
 use middle::trans::type_::Type;
 
-use std::vec;
 use syntax::ast;
 use syntax::abi::AbiSet;
 use syntax::ast_map;
@@ -227,8 +226,7 @@ fn resolve_default_method_vtables(bcx: &Block,
         None => slice::from_elem(num_method_vtables, @Vec::new())
     };
 
-    let param_vtables = @(vec::append((*trait_vtables_fixed).clone(),
-                                          method_vtables));
+    let param_vtables = @((*trait_vtables_fixed).clone().append(method_vtables));
 
     let self_vtables = resolve_param_vtables_under_param_substs(
         bcx.tcx(), param_substs, impl_res.self_vtables);

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -36,7 +36,6 @@ use std::c_str::ToCStr;
 use std::libc::c_uint;
 use std::slice;
 use std::vec::Vec;
-use std::vec;
 use syntax::{ast, ast_util};
 
 pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: ast::Lit)
@@ -295,7 +294,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
         exprs.iter().map(|&e| const_expr(cx, e, is_local))
              .fold((Vec::new(), true),
                    |(l, all_inlineable), (val, inlineable)| {
-                (vec::append_one(l, val), all_inlineable && inlineable)
+                (l.append_one(val), all_inlineable && inlineable)
              })
     };
     unsafe {

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -34,7 +34,6 @@ use util::common::indenter;
 use util::ppaux::Repr;
 
 use std::c_str::ToCStr;
-use std::vec;
 use syntax::parse::token;
 use syntax::{ast, ast_map, visit};
 
@@ -319,8 +318,7 @@ fn combine_impl_and_methods_tps(bcx: &Block,
     let node_substs = node_id_type_params(bcx, node);
     debug!("rcvr_substs={:?}", rcvr_substs.repr(ccx.tcx()));
     let ty_substs
-        = vec::append(Vec::from_slice(rcvr_substs),
-                         node_substs.tailn(node_substs.len() - n_m_tps));
+        = Vec::from_slice(rcvr_substs).append(node_substs.tailn(node_substs.len() - n_m_tps));
     debug!("n_m_tps={:?}", n_m_tps);
     debug!("node_substs={:?}", node_substs.repr(ccx.tcx()));
     debug!("ty_substs={:?}", ty_substs.repr(ccx.tcx()));
@@ -338,8 +336,8 @@ fn combine_impl_and_methods_tps(bcx: &Block,
         None => @Vec::from_elem(node_substs.len(), @Vec::new())
     };
     let vtables
-        = @vec::append(Vec::from_slice(rcvr_origins.as_slice()),
-                          r_m_origins.tailn(r_m_origins.len() - n_m_tps));
+        = @Vec::from_slice(rcvr_origins.as_slice())
+                           .append(r_m_origins.tailn(r_m_origins.len() - n_m_tps));
 
     (ty_substs, vtables)
 }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -27,7 +27,6 @@ use util::ppaux::ty_to_str;
 
 use arena::TypedArena;
 use std::libc::c_uint;
-use std::vec;
 use syntax::ast::DefId;
 use syntax::ast;
 use syntax::ast_map;
@@ -132,9 +131,7 @@ impl<'a> Reflector<'a> {
                                  -> (~str, Vec<ValueRef> ) {
         match vstore {
             ty::vstore_fixed(n) => {
-                let extra = vec::append(vec!(self.c_uint(n)),
-                                           self.c_size_and_align(t)
-                                               .as_slice());
+                let extra = (vec!(self.c_uint(n))).append(self.c_size_and_align(t).as_slice());
                 (~"fixed", extra)
             }
             ty::vstore_slice(_) => (~"slice", Vec::new()),
@@ -182,7 +179,7 @@ impl<'a> Reflector<'a> {
           }
           ty::ty_vec(ref mt, vst) => {
               let (name, extra) = self.vstore_name_and_extra(t, vst);
-              let extra = vec::append(extra, self.c_mt(mt).as_slice());
+              let extra = extra.append(self.c_mt(mt).as_slice());
               self.visit(~"evec_" + name, extra.as_slice())
           }
           // Should remove mt from box and uniq.
@@ -210,8 +207,8 @@ impl<'a> Reflector<'a> {
           }
 
           ty::ty_tup(ref tys) => {
-              let extra = vec::append(vec!(self.c_uint(tys.len())),
-                                         self.c_size_and_align(t).as_slice());
+              let extra = (vec!(self.c_uint(tys.len())))
+                          .append(self.c_size_and_align(t).as_slice());
               self.bracketed("tup", extra.as_slice(), |this| {
                   for (i, t) in tys.iter().enumerate() {
                       let extra = vec!(this.c_uint(i), this.c_tydesc(*t));
@@ -258,19 +255,19 @@ impl<'a> Reflector<'a> {
                       special_idents::unnamed_field.name;
               }
 
-              let extra = vec::append(vec!(
+              let extra = (vec!(
                   self.c_slice(token::intern_and_get_ident(ty_to_str(tcx,
                                                                      t))),
                   self.c_bool(named_fields),
                   self.c_uint(fields.len())
-              ), self.c_size_and_align(t).as_slice());
+              )).append(self.c_size_and_align(t).as_slice());
               self.bracketed("class", extra.as_slice(), |this| {
                   for (i, field) in fields.iter().enumerate() {
-                      let extra = vec::append(vec!(
+                      let extra = (vec!(
                         this.c_uint(i),
                         this.c_slice(token::get_ident(field.ident)),
                         this.c_bool(named_fields)
-                      ), this.c_mt(&field.mt).as_slice());
+                      )).append(this.c_mt(&field.mt).as_slice());
                       this.visit("class_field", extra.as_slice());
                   }
               })
@@ -319,10 +316,8 @@ impl<'a> Reflector<'a> {
                 llfdecl
             };
 
-            let enum_args = vec::append(vec!(self.c_uint(variants.len()),
-                                                make_get_disr()),
-                                           self.c_size_and_align(t)
-                                               .as_slice());
+            let enum_args = (vec!(self.c_uint(variants.len()), make_get_disr()))
+                            .append(self.c_size_and_align(t).as_slice());
             self.bracketed("enum", enum_args.as_slice(), |this| {
                 for (i, v) in variants.iter().enumerate() {
                     let name = token::get_ident(v.name);

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -40,7 +40,6 @@ use std::fmt;
 use std::hash::{Hash, sip};
 use std::ops;
 use std::rc::Rc;
-use std::vec;
 use collections::{HashMap, HashSet};
 use syntax::ast::*;
 use syntax::ast_util::{is_local, lit_is_str};
@@ -2880,7 +2879,7 @@ pub fn replace_closure_return_type(tcx: &ctxt, fn_type: t, ret_type: t) -> t {
 
 // Returns a vec of all the input and output types of fty.
 pub fn tys_in_fn_sig(sig: &FnSig) -> Vec<t> {
-    vec::append_one(sig.inputs.iter().map(|a| *a).collect(), sig.output)
+    sig.inputs.iter().map(|a| *a).collect::<Vec<_>>().append_one(sig.output)
 }
 
 // Type accessors for AST nodes
@@ -3213,11 +3212,8 @@ pub fn method_call_type_param_defs(tcx: &ctxt, origin: typeck::MethodOrigin)
             // trait itself.  This ought to be harmonized.
             let trait_type_param_defs =
                 lookup_trait_def(tcx, trt_id).generics.type_param_defs();
-            Rc::new(vec::append(
-                Vec::from_slice(trait_type_param_defs),
-                ty::trait_method(tcx,
-                                 trt_id,
-                                 n_mth).generics.type_param_defs()))
+            Rc::new(Vec::from_slice(trait_type_param_defs).append(
+                        ty::trait_method(tcx, trt_id, n_mth).generics.type_param_defs()))
         }
     }
 }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -97,7 +97,6 @@ use util::ppaux::Repr;
 
 use collections::HashSet;
 use std::result;
-use std::vec;
 use syntax::ast::{DefId, SelfValue, SelfRegion};
 use syntax::ast::{SelfUniq, SelfStatic};
 use syntax::ast::{MutMutable, MutImmutable};
@@ -1122,8 +1121,7 @@ impl<'a> LookupContext<'a> {
         // Construct the full set of type parameters for the method,
         // which is equal to the class tps + the method tps.
         let all_substs = substs {
-            tps: vec::append(candidate.rcvr_substs.tps.clone(),
-                                m_substs.as_slice()),
+            tps: candidate.rcvr_substs.tps.clone().append(m_substs.as_slice()),
             regions: NonerasedRegions(OwnedSlice::from_vec(all_regions)),
             self_ty: candidate.rcvr_substs.self_ty,
         };

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -120,7 +120,6 @@ use std::mem::replace;
 use std::result;
 use std::slice;
 use std::vec::Vec;
-use std::vec;
 use syntax::abi::AbiSet;
 use syntax::ast::{Provided, Required};
 use syntax::ast;
@@ -903,7 +902,7 @@ fn compare_impl_method(tcx: &ty::ctxt,
                 bound_region: ty::BrNamed(l.def_id, l.name)})).
         collect();
     let dummy_substs = ty::substs {
-        tps: vec::append(dummy_impl_tps, dummy_method_tps.as_slice()),
+        tps: dummy_impl_tps.append(dummy_method_tps.as_slice()),
         regions: ty::NonerasedRegions(dummy_impl_regions),
         self_ty: None };
 
@@ -930,7 +929,7 @@ fn compare_impl_method(tcx: &ty::ctxt,
                      self_ty: self_ty } = trait_substs.subst(tcx, &dummy_substs);
         let substs = substs {
             regions: trait_regions,
-            tps: vec::append(trait_tps, dummy_method_tps.as_slice()),
+            tps: trait_tps.append(dummy_method_tps.as_slice()),
             self_ty: self_ty,
         };
         debug!("trait_fty (pre-subst): {} substs={}",

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -48,7 +48,6 @@ use syntax::visit;
 use collections::HashSet;
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::vec;
 
 struct UniversalQuantificationResult {
     monotype: t,
@@ -345,9 +344,7 @@ impl<'a> CoherenceChecker<'a> {
             // construct the polytype for the method based on the method_ty
             let new_generics = ty::Generics {
                 type_param_defs:
-                    Rc::new(vec::append(
-                        Vec::from_slice(impl_poly_type.generics
-                                                      .type_param_defs()),
+                    Rc::new(Vec::from_slice(impl_poly_type.generics.type_param_defs()).append(
                             new_method_ty.generics.type_param_defs())),
                 region_param_defs:
                     impl_poly_type.generics.region_param_defs.clone()

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -46,7 +46,6 @@ use util::ppaux;
 use util::ppaux::Repr;
 
 use std::rc::Rc;
-use std::vec;
 use collections::HashSet;
 
 use syntax::abi::AbiSet;
@@ -320,8 +319,7 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
         let substs = substs {
             regions: ty::NonerasedRegions(rps_from_trait),
             self_ty: Some(self_param),
-            tps: vec::append(non_shifted_trait_tps,
-                                shifted_method_tps.as_slice())
+            tps: non_shifted_trait_tps.append(shifted_method_tps.as_slice())
         };
 
         // create the type of `foo`, applying the substitution above
@@ -490,13 +488,10 @@ fn convert_methods(ccx: &CrateCtxt,
             // itself
             ty_param_bounds_and_ty {
                 generics: ty::Generics {
-                    type_param_defs: Rc::new(vec::append(
-                        Vec::from_slice(
-                            rcvr_ty_generics.type_param_defs()),
-                        m_ty_generics.type_param_defs())),
-                    region_param_defs: Rc::new(vec::append(
-                            Vec::from_slice(rcvr_ty_generics.region_param_defs()),
-                            m_ty_generics.region_param_defs())),
+                    type_param_defs: Rc::new(Vec::from_slice(rcvr_ty_generics.type_param_defs())
+                                             .append(m_ty_generics.type_param_defs())),
+                    region_param_defs: Rc::new(Vec::from_slice(rcvr_ty_generics.region_param_defs())
+                                               .append(m_ty_generics.region_param_defs())),
                 },
                 ty: fty
             });

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -166,6 +166,22 @@ impl<T> Vec<T> {
 }
 
 impl<T: Clone> Vec<T> {
+    /// Iterates over the `second` vector, copying each element and appending it to
+    /// the `first`. Afterwards, the `first` is then returned for use again.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let vec = vec!(1, 2);
+    /// let vec = vec.append([3, 4]);
+    /// assert_eq!(vec, vec!(1, 2, 3, 4));
+    /// ```
+    #[inline]
+    pub fn append(mut self, second: &[T]) -> Vec<T> {
+        self.push_all(second);
+        self
+    }
+
     /// Constructs a `Vec` by cloning elements of a slice.
     ///
     /// # Example
@@ -516,6 +532,22 @@ impl<T> Vec<T> {
             move_val_init(&mut *end, value);
             self.len += 1;
         }
+    }
+
+    /// Appends one element to the vector provided. The vector itself is then
+    /// returned for use again.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let vec = vec!(1, 2);
+    /// let vec = vec.append_one(3);
+    /// assert_eq!(vec, vec!(1, 2, 3));
+    /// ```
+    #[inline]
+    pub fn append_one(mut self, x: T) -> Vec<T> {
+        self.push(x);
+        self
     }
 
     /// Shorten a vector, dropping excess elements.
@@ -1246,38 +1278,6 @@ impl<T> Vector<T> for Vec<T> {
         let slice = Slice { data: self.ptr as *T, len: self.len };
         unsafe { transmute(slice) }
     }
-}
-
-/// Iterates over the `second` vector, copying each element and appending it to
-/// the `first`. Afterwards, the `first` is then returned for use again.
-///
-/// # Example
-///
-/// ```rust
-/// let vec = vec!(1, 2);
-/// let vec = std::vec::append(vec, [3, 4]);
-/// assert_eq!(vec, vec!(1, 2, 3, 4));
-/// ```
-#[inline]
-pub fn append<T:Clone>(mut first: Vec<T>, second: &[T]) -> Vec<T> {
-    first.push_all(second);
-    first
-}
-
-/// Appends one element to the vector provided. The vector itself is then
-/// returned for use again.
-///
-/// # Example
-///
-/// ```rust
-/// let vec = vec!(1, 2);
-/// let vec = std::vec::append_one(vec, 3);
-/// assert_eq!(vec, vec!(1, 2, 3));
-/// ```
-#[inline]
-pub fn append_one<T>(mut lhs: Vec<T>, x: T) -> Vec<T> {
-    lhs.push(x);
-    lhs
 }
 
 #[unsafe_destructor]

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -187,8 +187,6 @@ use codemap::Span;
 use owned_slice::OwnedSlice;
 use parse::token::InternedString;
 
-use std::vec;
-
 pub use self::ty::*;
 mod ty;
 
@@ -411,7 +409,7 @@ impl<'a> TraitDef<'a> {
         cx.item(
             self.span,
             ident,
-            vec::append(vec!(attr), self.attributes.as_slice()),
+            (vec!(attr)).append(self.attributes.as_slice()),
             ast::ItemImpl(trait_generics, opt_trait_ref,
                           self_type, methods))
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -81,7 +81,6 @@ use collections::HashSet;
 use std::kinds::marker;
 use std::mem::replace;
 use std::rc::Rc;
-use std::vec;
 
 #[allow(non_camel_case_types)]
 #[deriving(Eq)]
@@ -262,7 +261,7 @@ fn maybe_append(lhs: Vec<Attribute> , rhs: Option<Vec<Attribute> >)
              -> Vec<Attribute> {
     match rhs {
         None => lhs,
-        Some(ref attrs) => vec::append(lhs, attrs.as_slice())
+        Some(ref attrs) => lhs.append(attrs.as_slice())
     }
 }
 
@@ -398,10 +397,7 @@ impl<'a> Parser<'a> {
         } else if inedible.contains(&self.token) {
             // leave it in the input
         } else {
-            let expected = vec::append(edible.iter()
-                                                .map(|x| (*x).clone())
-                                                .collect(),
-                                          inedible);
+            let expected = edible.iter().map(|x| (*x).clone()).collect::<Vec<_>>().append(inedible);
             let expect = tokens_to_str(expected.as_slice());
             let actual = self.this_token_to_str();
             self.fatal(
@@ -440,10 +436,8 @@ impl<'a> Parser<'a> {
         match e.node {
             ExprPath(..) => {
                 // might be unit-struct construction; check for recoverableinput error.
-                let expected = vec::append(edible.iter()
-                                                    .map(|x| (*x).clone())
-                                                    .collect(),
-                                              inedible);
+                let expected = edible.iter().map(|x| (*x).clone()).collect::<Vec<_>>()
+                              .append(inedible);
                 self.check_for_erroneous_unit_struct_expecting(
                     expected.as_slice());
             }
@@ -463,10 +457,8 @@ impl<'a> Parser<'a> {
         debug!("commit_stmt {:?}", s);
         let _s = s; // unused, but future checks might want to inspect `s`.
         if self.last_token.as_ref().map_or(false, |t| is_ident_or_path(*t)) {
-            let expected = vec::append(edible.iter()
-                                                .map(|x| (*x).clone())
-                                                .collect(),
-                                          inedible.as_slice());
+            let expected = edible.iter().map(|x| (*x).clone()).collect::<Vec<_>>()
+                           .append(inedible.as_slice());
             self.check_for_erroneous_unit_struct_expecting(
                 expected.as_slice());
         }
@@ -1107,7 +1099,7 @@ impl<'a> Parser<'a> {
                 debug!("parse_trait_methods(): parsing provided method");
                 let (inner_attrs, body) =
                     p.parse_inner_attrs_and_block();
-                let attrs = vec::append(attrs, inner_attrs.as_slice());
+                let attrs = attrs.append(inner_attrs.as_slice());
                 Provided(@ast::Method {
                     ident: ident,
                     attrs: attrs,
@@ -3816,7 +3808,7 @@ impl<'a> Parser<'a> {
 
         let (inner_attrs, body) = self.parse_inner_attrs_and_block();
         let hi = body.span.hi;
-        let attrs = vec::append(attrs, inner_attrs.as_slice());
+        let attrs = attrs.append(inner_attrs.as_slice());
         @ast::Method {
             ident: ident,
             attrs: attrs,
@@ -4048,8 +4040,7 @@ impl<'a> Parser<'a> {
         while self.token != term {
             let mut attrs = self.parse_outer_attributes();
             if first {
-                attrs = vec::append(attrs_remaining.clone(),
-                                       attrs.as_slice());
+                attrs = attrs_remaining.clone().append(attrs.as_slice());
                 first = false;
             }
             debug!("parse_mod_items: parse_item_or_view_item(attrs={:?})",
@@ -4192,7 +4183,7 @@ impl<'a> Parser<'a> {
                                      &path,
                                      id_sp);
         let (inner, next) = p0.parse_inner_attrs_and_next();
-        let mod_attrs = vec::append(outer_attrs, inner.as_slice());
+        let mod_attrs = outer_attrs.append(inner.as_slice());
         let first_item_outer_attrs = next;
         let m0 = p0.parse_mod_items(token::EOF, first_item_outer_attrs);
         self.sess.included_mod_stack.borrow_mut().pop();
@@ -4512,7 +4503,7 @@ impl<'a> Parser<'a> {
         match self.token {
             INTERPOLATED(token::NtItem(item)) => {
                 self.bump();
-                let new_attrs = vec::append(attrs, item.attrs.as_slice());
+                let new_attrs = attrs.append(item.attrs.as_slice());
                 return IoviItem(@Item {
                     attrs: new_attrs,
                     ..(*item).clone()
@@ -4940,9 +4931,7 @@ impl<'a> Parser<'a> {
                                   mut extern_mod_allowed: bool,
                                   macros_allowed: bool)
                                   -> ParsedItemsAndViewItems {
-        let mut attrs = vec::append(first_item_attrs,
-                                       self.parse_outer_attributes()
-                                           .as_slice());
+        let mut attrs = first_item_attrs.append(self.parse_outer_attributes().as_slice());
         // First, parse view items.
         let mut view_items : Vec<ast::ViewItem> = Vec::new();
         let mut items = Vec::new();
@@ -5022,9 +5011,7 @@ impl<'a> Parser<'a> {
     fn parse_foreign_items(&mut self, first_item_attrs: Vec<Attribute> ,
                            macros_allowed: bool)
         -> ParsedItemsAndViewItems {
-        let mut attrs = vec::append(first_item_attrs,
-                                       self.parse_outer_attributes()
-                                           .as_slice());
+        let mut attrs = first_item_attrs.append(self.parse_outer_attributes().as_slice());
         let mut foreign_items = Vec::new();
         loop {
             match self.parse_foreign_item(attrs, macros_allowed) {

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -598,10 +598,8 @@ mod test {
             assert!(res.is_err(),
                     "Op {} succeeded incorrectly with 0 stack entries", *cap);
             let p = if *cap == "%s" || *cap == "%l" { String(~"foo") } else { Number(97) };
-            let res = expand(vec::append(bytes!("%p1").iter()
-                                                         .map(|x| *x)
-                                                         .collect(),
-                                            cap.as_bytes()).as_slice(),
+            let res = expand(bytes!("%p1").iter().map(|x| *x).collect::<Vec<_>>()
+                             .append(cap.as_bytes()).as_slice(),
                              [p],
                              vars);
             assert!(res.is_ok(),
@@ -612,18 +610,14 @@ mod test {
             let res = expand(cap.as_bytes(), [], vars);
             assert!(res.is_err(),
                     "Binop {} succeeded incorrectly with 0 stack entries", *cap);
-            let res = expand(vec::append(bytes!("%{1}").iter()
-                                                          .map(|x| *x)
-                                                          .collect(),
-                                             cap.as_bytes()).as_slice(),
+            let res = expand(bytes!("%{1}").iter().map(|x| *x).collect::<Vec<_>>()
+                             .append(cap.as_bytes()).as_slice(),
                               [],
                               vars);
             assert!(res.is_err(),
                     "Binop {} succeeded incorrectly with 1 stack entry", *cap);
-            let res = expand(vec::append(bytes!("%{1}%{2}").iter()
-                                                              .map(|x| *x)
-                                                              .collect(),
-                                            cap.as_bytes()).as_slice(),
+            let res = expand(bytes!("%{1}%{2}").iter().map(|x| *x).collect::<Vec<_>>()
+                             .append(cap.as_bytes()).as_slice(),
                              [],
                              vars);
             assert!(res.is_ok(),

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -92,7 +92,7 @@ fn vec_plus() {
         if r.gen() {
             v.push_all_move(rv);
         } else {
-            v = vec::append(rv.clone(), v.as_slice());
+            v = rv.clone().append(v.as_slice());
         }
         i += 1;
     }
@@ -106,10 +106,10 @@ fn vec_append() {
     while i < 1500 {
         let rv = Vec::from_elem(r.gen_range(0u, i + 1), i);
         if r.gen() {
-            v = vec::append(v.clone(), rv.as_slice());
+            v = v.clone().append(rv.as_slice());
         }
         else {
-            v = vec::append(rv.clone(), v.as_slice());
+            v = rv.clone().append(v.as_slice());
         }
         i += 1;
     }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -126,8 +126,7 @@ fn make_sequence_processor(sz: uint,
       line = from_parent.recv();
       if line == Vec::new() { break; }
 
-       carry = windows_with_carry(vec::append(carry,
-                                                 line.as_slice()).as_slice(),
+       carry = windows_with_carry(carry.append(line.as_slice()).as_slice(),
                                   sz,
                                   |window| {
          update_freq(&mut freqs, window);

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -97,8 +97,7 @@ fn recurse_or_fail(depth: int, st: Option<State>) {
                 unique: ~Cons((), @*st.unique),
                 tuple: (@Cons((), st.tuple.ref0().clone()),
                         ~Cons((), @*st.tuple.ref1().clone())),
-                vec: vec::append(st.vec.clone(),
-                     &[@Cons((), *st.vec.last().unwrap())]),
+                vec: st.vec.clone().append(&[@Cons((), *st.vec.last().unwrap())]),
                 res: r(@Cons((), st.res._l))
             }
           }

--- a/src/test/run-fail/unwind-misc-1.rs
+++ b/src/test/run-fail/unwind-misc-1.rs
@@ -24,7 +24,7 @@ fn main() {
     for _i in range(0u, 10u) {
         arr.push(@~"key stuff");
         map.insert(arr.clone(),
-                   vec::append(arr.clone(), &[@~"value stuff"]));
+                   arr.clone().append([@~"value stuff"]));
         if arr.len() == 5 {
             fail!();
         }

--- a/src/test/run-pass/vec-concat.rs
+++ b/src/test/run-pass/vec-concat.rs
@@ -13,7 +13,7 @@ use std::vec;
 pub fn main() {
     let a: Vec<int> = vec!(1, 2, 3, 4, 5);
     let b: Vec<int> = vec!(6, 7, 8, 9, 0);
-    let v: Vec<int> = vec::append(a, b.as_slice());
+    let v: Vec<int> = a.append(b.as_slice());
     println!("{}", *v.get(9));
     assert_eq!(*v.get(0), 1);
     assert_eq!(*v.get(7), 8);


### PR DESCRIPTION
These were only free functions on `~[T]` because taking self by-value
used to be broken.
