### PR TITLE
Json doesn't need to depend on IoError to implement Encodable

### DIFF
--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -732,8 +732,8 @@ impl<'a> ::Encoder<io::IoError> for PrettyEncoder<'a> {
     }
 }
 
-impl<E: ::Encoder<io::IoError>> Encodable<E, io::IoError> for Json {
-    fn encode(&self, e: &mut E) -> EncodeResult {
+impl<E: ::Encoder<S>, S> Encodable<E, S> for Json {
+    fn encode(&self, e: &mut E) -> Result<(), S> {
         match *self {
             Number(v) => v.encode(e),
             String(ref v) => v.encode(e),


### PR DESCRIPTION
The implementation of `Encodable<E, S>` for `Json` doesn't need to assume `S` to be `IoError`, only the default encoders for `Json` are depend on it. So this can be parametrize to increase flexiblity. If not, types that implement `Encoder<E>` where `E` is not `IoError` can't be worked with `Json`.
