### PR TITLE
Vec tweaks

### DIFF
--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -447,7 +447,7 @@ impl<T> Vec<T> {
     /// assert_eq!(vec.capacity(), 11);
     /// ```
     pub fn reserve_exact(&mut self, capacity: uint) {
-        if capacity >= self.len {
+        if capacity > self.cap {
             let size = capacity.checked_mul(&size_of::<T>()).expect("capacity overflow");
             self.cap = capacity;
             unsafe {

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -230,9 +230,7 @@ impl<T: Clone> Vec<T> {
     /// ```
     #[inline]
     pub fn push_all(&mut self, other: &[T]) {
-        for element in other.iter() {
-            self.push((*element).clone())
-        }
+        self.extend(other.iter().map(|e| e.clone()));
     }
 
     /// Grows the `Vec` in-place.
@@ -947,9 +945,7 @@ impl<T> Vec<T> {
     /// assert_eq!(vec, vec!(~1, ~2, ~3, ~4));
     /// ```
     pub fn push_all_move(&mut self, other: Vec<T>) {
-        for element in other.move_iter() {
-            self.push(element)
-        }
+        self.extend(other.move_iter());
     }
 
     /// Returns a mutable slice of `self` between `start` and `end`.


### PR DESCRIPTION
- push_all\* operations should reserve capacity before pushing data to avoid unnecessary reallocations
- reserve_exact should never shrink, as specified in documentation
