### PR TITLE
std: fix Cell's Show instance.

### DIFF
--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -61,9 +61,9 @@ impl<T:Eq + Copy> Eq for Cell<T> {
     }
 }
 
-impl<T: fmt::Show> fmt::Show for Cell<T> {
+impl<T: Copy + fmt::Show> fmt::Show for Cell<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f.buf, r"Cell \{ value: {} \}", unsafe{*&self.value.get()})
+        write!(f.buf, r"Cell \{ value: {} \}", self.get())
     }
 }
 
@@ -263,6 +263,17 @@ mod test {
         let y = Cell::new((30, 40));
         assert_eq!(y, Cell::new((30, 40)));
         assert_eq!(y.get(), (30, 40));
+    }
+
+    #[test]
+    fn cell_has_sensible_show() {
+        use str::StrSlice;
+
+        let x = Cell::new("foo bar");
+        assert!(format!("{}", x).contains(x.get()));
+
+        x.set("baz qux");
+        assert!(format!("{}", x).contains(x.get()));
     }
 
     #[test]


### PR DESCRIPTION
std: fix Cell's Show instance.

Previously it was printing the address of the Unsafe contained in the
Cell (i.e. the address of the Cell itself). This is clearly useless, and
was presumably a mistake due to writing `*&` instead of `&*`.

However, this later expression is likely also incorrect, since it takes
a reference into a Cell while other user code is executing (i.e. the
Show instance for the contained type), hence the contents should just be
copied out.
