### PR TITLE
Allow "moves" out of immutable static (turn into memcpy)

### DIFF
--- a/src/test/compile-fail/cant-move-out-of-mutable-static.rs
+++ b/src/test/compile-fail/cant-move-out-of-mutable-static.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ensure that moves out of mutable static items is disallowed
+
+use std::kinds::marker;
+
+struct Foo {
+    foo: int,
+    nocopy: marker::NoCopy
+}
+
+static mut BAR: Foo = Foo{foo: 5, nocopy: marker::NoCopy};
+
+fn main() {
+    unsafe {
+        let _f = BAR; //~ ERROR: cannot move out of mutable static item
+    }
+}
+

--- a/src/test/compile-fail/std-uncopyable-atomics.rs
+++ b/src/test/compile-fail/std-uncopyable-atomics.rs
@@ -16,11 +16,11 @@ use std::sync::atomics::*;
 use std::ptr;
 
 fn main() {
-    let x = INIT_ATOMIC_BOOL; //~ ERROR cannot move out of static item
+    let x = INIT_ATOMIC_BOOL;
     let x = *&x; //~ ERROR: cannot move out of dereference
-    let x = INIT_ATOMIC_INT; //~ ERROR cannot move out of static item
+    let x = INIT_ATOMIC_INT;
     let x = *&x; //~ ERROR: cannot move out of dereference
-    let x = INIT_ATOMIC_UINT; //~ ERROR cannot move out of static item
+    let x = INIT_ATOMIC_UINT;
     let x = *&x; //~ ERROR: cannot move out of dereference
     let x: AtomicPtr<uint> = AtomicPtr::new(ptr::mut_null());
     let x = *&x; //~ ERROR: cannot move out of dereference

--- a/src/test/run-pass/borrowck-ensure-static-items-moves-copy.rs
+++ b/src/test/run-pass/borrowck-ensure-static-items-moves-copy.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Verifies that static items can't be moved
+// Ensure that moves out of statics don't null the static
 
 use std::kinds::marker;
 
@@ -17,13 +17,21 @@ struct Foo {
     nocopy: marker::NoCopy
 }
 
-static BAR: Foo = Foo{foo: 5, nocopy: marker::NoCopy};
-
-
-fn test(f: Foo) {
-    let _f = Foo{foo: 4, ..f};
+impl Eq for Foo {
+    fn eq(&self, other: &Foo) -> bool {
+        self.foo == other.foo
+    }
 }
 
+impl std::fmt::Show for Foo {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f.buf, "Foo({})", self.foo)
+    }
+}
+
+static BAR: Foo = Foo{foo: 5, nocopy: marker::NoCopy};
+
 fn main() {
-    test(BAR); //~ ERROR cannot move out of static item
+    let x = BAR;
+    assert_eq!(x, BAR);
 }

--- a/src/test/run-pass/borrowck-move-out-of-static-item.rs
+++ b/src/test/run-pass/borrowck-move-out-of-static-item.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Ensure that moves out of static items is forbidden
+// Ensure that moves out of immutable static items is allowed
 
 use std::kinds::marker;
 
@@ -25,5 +25,5 @@ fn test(f: Foo) {
 }
 
 fn main() {
-    test(BAR); //~ ERROR cannot move out of static item
+    test(BAR);
 }


### PR DESCRIPTION
Fixes #13233
