### PR TITLE
There is no variance to infer for generics that occur in non-variance contexts

### DIFF
--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -272,6 +272,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         }
 
         // Ugh -- but this ensures any new variants won't be forgotten
+        ast_map::NodeLifetime(..) |
         ast_map::NodeExpr(..) |
         ast_map::NodeStmt(..) |
         ast_map::NodeArg(..) |

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -198,6 +198,7 @@ use arena::Arena;
 use middle::ty;
 use std::fmt;
 use syntax::ast;
+use syntax::ast_map;
 use syntax::ast_util;
 use syntax::owned_slice::OwnedSlice;
 use syntax::visit;
@@ -517,6 +518,13 @@ impl<'a> Visitor<()> for ConstraintContext<'a> {
     }
 }
 
+/// Is `param_id` a lifetime according to `map`?
+fn is_lifetime(map: &ast_map::Map, param_id: ast::NodeId) -> bool {
+    match map.find(param_id) {
+        Some(ast_map::NodeLifetime(..)) => true, _ => false
+    }
+}
+
 impl<'a> ConstraintContext<'a> {
     fn tcx(&self) -> &'a ty::ctxt {
         self.terms_cx.tcx
@@ -533,8 +541,68 @@ impl<'a> ConstraintContext<'a> {
         }
     }
 
+    fn find_binding_for_lifetime(&self, param_id: ast::NodeId) -> ast::NodeId {
+        let tcx = self.terms_cx.tcx;
+        assert!(is_lifetime(&tcx.map, param_id));
+        match tcx.named_region_map.find(&param_id) {
+            Some(&ast::DefEarlyBoundRegion(_, lifetime_decl_id))
+                => lifetime_decl_id,
+            Some(_) => fail!("should not encounter non early-bound cases"),
+
+            // The lookup should only fail when `param_id` is
+            // itself a lifetime binding: use it as the decl_id.
+            None    => param_id,
+        }
+
+    }
+
+    /// Is `param_id` a type parameter for which we infer variance?
     fn is_to_be_inferred(&self, param_id: ast::NodeId) -> bool {
-        self.terms_cx.inferred_map.contains_key(&param_id)
+        let result = self.terms_cx.inferred_map.contains_key(&param_id);
+
+        // To safe-guard against invalid inferred_map constructions,
+        // double-check if variance is inferred at some use of a type
+        // parameter (by inspecting parent of its binding declaration
+        // to see if it is introduced by a type or by a fn/impl).
+
+        let check_result = |this:&ConstraintContext| -> bool {
+            let tcx = this.terms_cx.tcx;
+            let decl_id = this.find_binding_for_lifetime(param_id);
+            // Currently only called on lifetimes; double-checking that.
+            assert!(is_lifetime(&tcx.map, param_id));
+            let parent_id = tcx.map.get_parent(decl_id);
+            let parent = tcx.map.find(parent_id).unwrap_or_else(
+                || fail!("tcx.map missing entry for id: {}", parent_id));
+
+            let is_inferred;
+            macro_rules! cannot_happen { () => { {
+                fail!("invalid parent: {:s} for {:s}",
+                      tcx.map.node_to_str(parent_id),
+                      tcx.map.node_to_str(param_id));
+            } } }
+
+            match parent {
+                ast_map::NodeItem(p) => {
+                    match p.node {
+                        ast::ItemTy(..) |
+                        ast::ItemEnum(..) |
+                        ast::ItemStruct(..) |
+                        ast::ItemTrait(..)   => is_inferred = true,
+                        ast::ItemFn(..)      => is_inferred = false,
+                        _                    => cannot_happen!(),
+                    }
+                }
+                ast_map::NodeTraitMethod(..) => is_inferred = false,
+                ast_map::NodeMethod(_)       => is_inferred = false,
+                _                            => cannot_happen!(),
+            }
+
+            return is_inferred;
+        };
+
+        assert_eq!(result, check_result(self));
+
+        return result;
     }
 
     fn declared_variance(&self,

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -533,6 +533,10 @@ impl<'a> ConstraintContext<'a> {
         }
     }
 
+    fn is_to_be_inferred(&self, param_id: ast::NodeId) -> bool {
+        self.terms_cx.inferred_map.contains_key(&param_id)
+    }
+
     fn declared_variance(&self,
                          param_def_id: ast::DefId,
                          item_def_id: ast::DefId,
@@ -788,8 +792,10 @@ impl<'a> ConstraintContext<'a> {
                                    variance: VarianceTermPtr<'a>) {
         match region {
             ty::ReEarlyBound(param_id, _, _) => {
-                let index = self.inferred_index(param_id);
-                self.add_constraint(index, variance);
+                if self.is_to_be_inferred(param_id) {
+                    let index = self.inferred_index(param_id);
+                    self.add_constraint(index, variance);
+                }
             }
 
             ty::ReStatic => { }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -183,6 +183,18 @@ pub fn generics_to_str(generics: &ast::Generics) -> ~str {
     to_str(|s| s.print_generics(generics))
 }
 
+pub fn ty_method_to_str(p: &ast::TypeMethod) -> ~str {
+    to_str(|s| s.print_ty_method(p))
+}
+
+pub fn method_to_str(p: &ast::Method) -> ~str {
+    to_str(|s| s.print_method(p))
+}
+
+pub fn fn_block_to_str(p: &ast::FnDecl) -> ~str {
+    to_str(|s| s.print_fn_block_args(p))
+}
+
 pub fn path_to_str(p: &ast::Path) -> ~str {
     to_str(|s| s.print_path(p, false))
 }

--- a/src/test/run-pass/regions-no-variance-from-fn-generics.rs
+++ b/src/test/run-pass/regions-no-variance-from-fn-generics.rs
@@ -1,0 +1,45 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #12856: a lifetime formal binding introduced by a generic fn
+// should not upset the variance inference for actual occurrences of
+// that lifetime in type expressions.
+
+trait HasLife<'a> { }
+
+trait UseLife01 {
+    fn refs<'a, H: HasLife<'a>>(&'a self) -> H;
+}
+
+trait UseLife02 {
+    fn refs<'a, T, H: HasType<&'a T>>(&'a self) -> H;
+}
+
+
+trait HasType<T> { }
+
+trait UseLife03<T> {
+    fn refs<'a, H: HasType<&'a T>>(&'a self) -> H;
+}
+
+
+// (The functions below were not actually a problem observed during
+// fixing of #12856; they just seem like natural tests to put in to
+// cover a couple more points in the testing space)
+
+pub fn top_refs_1<'a, H: HasLife<'a>>(_s: &'a ()) -> H {
+    unimplemented!()
+}
+
+pub fn top_refs_2<'a, T, H: HasType<&'a T>>(_s: &'a ()) -> H {
+    unimplemented!()
+}
+
+pub fn main() {}


### PR DESCRIPTION
Fix #12856.

I wanted to put this up first because I wanted to get feedback about the second commit in the series, commit 8599236.  Its the more invasive part of the patch and is largely just belt-and-suspenders assertion checking; in the commit message I mentioned at least one other approach we could take here.  Or we could drop the belt-and-suspenders and just rely on the guard added in the first patch, commit 8d6a005 (which is really quite trivial on its own).

So any feedback on what would be better is appreciated.

r? @nikomatsakis
