### PR TITLE
syntax: Remove AbiSet, use one Abi

### DIFF
--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -90,7 +90,7 @@ fn fold_foreign_mod(cx: &mut Context, nm: &ast::ForeignMod) -> ast::ForeignMod {
         filter_view_item(cx, a).map(|x| cx.fold_view_item(x))
     }).collect();
     ast::ForeignMod {
-        abis: nm.abis,
+        abi: nm.abi,
         view_items: filtered_view_items,
         items: filtered_items
     }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -187,7 +187,7 @@ fn extract_crate_info(e: &Env, i: &ast::ViewItem) -> Option<CrateInfo> {
 fn visit_item(e: &Env, i: &ast::Item) {
     match i.node {
         ast::ItemForeignMod(ref fm) => {
-            if fm.abis.is_rust() || fm.abis.is_intrinsic() {
+            if fm.abi == abi::Rust || fm.abi == abi::RustIntrinsic {
                 return;
             }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -33,7 +33,7 @@ use std::hash::Hash;
 use std::io::MemWriter;
 use std::str;
 use collections::HashMap;
-use syntax::abi::AbiSet;
+use syntax::abi;
 use syntax::ast::*;
 use syntax::ast;
 use syntax::ast_map::{PathElem, PathElems};
@@ -1217,7 +1217,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
                                 nitem: &ForeignItem,
                                 index: @RefCell<Vec<entry<i64>> >,
                                 path: PathElems,
-                                abi: AbiSet) {
+                                abi: abi::Abi) {
     index.borrow_mut().push(entry {
         val: nitem.id as i64,
         pos: ebml_w.writer.tell().unwrap(),
@@ -1231,7 +1231,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         encode_bounds_and_type(ebml_w, ecx,
                                &lookup_item_type(ecx.tcx,local_def(nitem.id)));
         encode_name(ebml_w, nitem.ident.name);
-        if abi.is_intrinsic() {
+        if abi == abi::RustIntrinsic {
             (ecx.encode_inlined_item)(ecx, ebml_w, IIForeignRef(nitem));
         } else {
             encode_symbol(ecx, ebml_w, nitem.id);
@@ -1279,11 +1279,11 @@ fn my_visit_foreign_item(ni: &ForeignItem,
     let mut ebml_w = unsafe {
         ebml_w.unsafe_clone()
     };
-    let abis = ecx.tcx.map.get_foreign_abis(ni.id);
+    let abi = ecx.tcx.map.get_foreign_abi(ni.id);
     ecx.tcx.map.with_path(ni.id, |path| {
         encode_info_for_foreign_item(ecx, &mut ebml_w,
                                      ni, index,
-                                     path, abis);
+                                     path, abi);
     });
 }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -20,7 +20,6 @@ use middle::ty;
 
 use std::str;
 use std::uint;
-use syntax::abi::AbiSet;
 use syntax::abi;
 use syntax::ast;
 use syntax::ast::*;
@@ -460,18 +459,12 @@ fn parse_purity(c: char) -> Purity {
     }
 }
 
-fn parse_abi_set(st: &mut PState) -> AbiSet {
+fn parse_abi_set(st: &mut PState) -> abi::Abi {
     assert_eq!(next(st), '[');
-    let mut abis = AbiSet::empty();
-    while peek(st) != ']' {
-         scan(st, |c| c == ',', |bytes| {
-                 let abi_str = str::from_utf8(bytes).unwrap().to_owned();
-                 let abi = abi::lookup(abi_str).expect(abi_str);
-                 abis.add(abi);
-              });
-    }
-    assert_eq!(next(st), ']');
-    return abis;
+    scan(st, |c| c == ']', |bytes| {
+        let abi_str = str::from_utf8(bytes).unwrap().to_owned();
+        abi::lookup(abi_str).expect(abi_str)
+    })
 }
 
 fn parse_onceness(c: char) -> ast::Onceness {
@@ -505,7 +498,7 @@ fn parse_bare_fn_ty(st: &mut PState, conv: conv_did) -> ty::BareFnTy {
     let sig = parse_sig(st, |x,y| conv(x,y));
     ty::BareFnTy {
         purity: purity,
-        abis: abi,
+        abi: abi,
         sig: sig
     }
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use middle::ty::param_ty;
 use middle::ty;
 
-use syntax::abi::AbiSet;
+use syntax::abi::Abi;
 use syntax::ast;
 use syntax::ast::*;
 use syntax::diagnostic::SpanHandler;
@@ -341,12 +341,9 @@ fn enc_purity(w: &mut MemWriter, p: Purity) {
     }
 }
 
-fn enc_abi_set(w: &mut MemWriter, abis: AbiSet) {
+fn enc_abi(w: &mut MemWriter, abi: Abi) {
     mywrite!(w, "[");
-    abis.each(|abi| {
-        mywrite!(w, "{},", abi.name());
-        true
-    });
+    mywrite!(w, "{}", abi.name());
     mywrite!(w, "]")
 }
 
@@ -359,7 +356,7 @@ fn enc_onceness(w: &mut MemWriter, o: Onceness) {
 
 pub fn enc_bare_fn_ty(w: &mut MemWriter, cx: &ctxt, ft: &ty::BareFnTy) {
     enc_purity(w, ft.purity);
-    enc_abi_set(w, ft.abis);
+    enc_abi(w, ft.abi);
     enc_fn_sig(w, cx, &ft.sig);
 }
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -59,6 +59,7 @@ use std::u32;
 use std::u64;
 use std::u8;
 use collections::SmallIntMap;
+use syntax::abi;
 use syntax::ast_map;
 use syntax::ast_util::IdVisitingOperation;
 use syntax::attr::{AttrMetaMethods, AttributeMethods};
@@ -892,7 +893,7 @@ fn check_item_ctypes(cx: &Context, it: &ast::Item) {
     }
 
     match it.node {
-      ast::ItemForeignMod(ref nmod) if !nmod.abis.is_intrinsic() => {
+      ast::ItemForeignMod(ref nmod) if nmod.abi != abi::RustIntrinsic => {
         for ni in nmod.items.iter() {
             match ni.node {
                 ast::ForeignItemFn(decl, _) => check_foreign_fn(cx, decl),

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -855,8 +855,8 @@ pub fn trans_external_path(ccx: &CrateContext, did: ast::DefId, t: ty::t) -> Val
     let name = csearch::get_symbol(&ccx.sess().cstore, did);
     match ty::get(t).sty {
         ty::ty_bare_fn(ref fn_ty) => {
-            match fn_ty.abis.for_target(ccx.sess().targ_cfg.os,
-                                        ccx.sess().targ_cfg.arch) {
+            match fn_ty.abi.for_target(ccx.sess().targ_cfg.os,
+                                       ccx.sess().targ_cfg.arch) {
                 Some(Rust) | Some(RustIntrinsic) => {
                     get_extern_rust_fn(ccx,
                                        fn_ty.sig.inputs.as_slice(),
@@ -865,7 +865,7 @@ pub fn trans_external_path(ccx: &CrateContext, did: ast::DefId, t: ty::t) -> Val
                                        did)
                 }
                 Some(..) | None => {
-                    let c = foreign::llvm_calling_convention(ccx, fn_ty.abis);
+                    let c = foreign::llvm_calling_convention(ccx, fn_ty.abi);
                     let cconv = c.unwrap_or(lib::llvm::CCallConv);
                     let llty = type_of_fn_from_ty(ccx, t);
                     get_extern_fn(&mut *ccx.externs.borrow_mut(), ccx.llmod,
@@ -1601,7 +1601,7 @@ impl<'a> Visitor<()> for TransItemVisitor<'a> {
 pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
     let _icx = push_ctxt("trans_item");
     match item.node {
-      ast::ItemFn(decl, purity, _abis, ref generics, body) => {
+      ast::ItemFn(decl, purity, _abi, ref generics, body) => {
         if purity == ast::ExternFn  {
             let llfndecl = get_item_val(ccx, item.id);
             foreign::trans_rust_fn_with_foreign_abi(
@@ -1721,7 +1721,7 @@ fn register_fn(ccx: &CrateContext,
                -> ValueRef {
     let f = match ty::get(node_type).sty {
         ty::ty_bare_fn(ref f) => {
-            assert!(f.abis.is_rust() || f.abis.is_intrinsic());
+            assert!(f.abi == Rust || f.abi == RustIntrinsic);
             f
         }
         _ => fail!("expected bare rust fn or an intrinsic")
@@ -1997,8 +1997,8 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
 
             match ni.node {
                 ast::ForeignItemFn(..) => {
-                    let abis = ccx.tcx.map.get_foreign_abis(id);
-                    foreign::register_foreign_item_fn(ccx, abis, ni)
+                    let abi = ccx.tcx.map.get_foreign_abi(id);
+                    foreign::register_foreign_item_fn(ccx, abi, ni)
                 }
                 ast::ForeignItemStatic(..) => {
                     foreign::register_static(ccx, ni)

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -34,6 +34,7 @@ use util::common::indenter;
 use util::ppaux::Repr;
 
 use std::c_str::ToCStr;
+use syntax::abi::Rust;
 use syntax::parse::token;
 use syntax::{ast, ast_map, visit};
 
@@ -393,7 +394,7 @@ pub fn trans_trait_callee_from_llval<'a>(bcx: &'a Block<'a>,
     debug!("(translating trait callee) loading method");
     // Replace the self type (&Self or ~Self) with an opaque pointer.
     let llcallee_ty = match ty::get(callee_ty).sty {
-        ty::ty_bare_fn(ref f) if f.abis.is_rust() => {
+        ty::ty_bare_fn(ref f) if f.abi == Rust => {
             type_of_rust_fn(ccx, true, f.sig.inputs.slice_from(1), f.sig.output)
         }
         _ => {

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -23,6 +23,7 @@ use middle::ty;
 use middle::typeck;
 use util::ppaux::Repr;
 
+use syntax::abi;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::local_def;
@@ -99,7 +100,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
 
     match map_node {
         ast_map::NodeForeignItem(_) => {
-            if !ccx.tcx.map.get_foreign_abis(fn_id.node).is_intrinsic() {
+            if ccx.tcx.map.get_foreign_abi(fn_id.node) != abi::RustIntrinsic {
                 // Foreign externs don't have to be monomorphized.
                 return (get_item_val(ccx, fn_id.node), true);
             }
@@ -150,7 +151,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
 
     let f = match ty::get(mono_ty).sty {
         ty::ty_bare_fn(ref f) => {
-            assert!(f.abis.is_rust() || f.abis.is_intrinsic());
+            assert!(f.abi == abi::Rust || f.abi == abi::RustIntrinsic);
             f
         }
         _ => fail!("expected bare rust fn or an intrinsic")

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -19,6 +19,7 @@ use util::ppaux::Repr;
 
 use middle::trans::type_::Type;
 
+use syntax::abi;
 use syntax::ast;
 use syntax::owned_slice::OwnedSlice;
 
@@ -75,7 +76,7 @@ pub fn type_of_fn_from_ty(cx: &CrateContext, fty: ty::t) -> Type {
             type_of_rust_fn(cx, true, f.sig.inputs.as_slice(), f.sig.output)
         }
         ty::ty_bare_fn(ref f) => {
-            if f.abis.is_rust() || f.abis.is_intrinsic() {
+            if f.abi == abi::Rust || f.abi == abi::RustIntrinsic {
                 type_of_rust_fn(cx,
                                 false,
                                 f.sig.inputs.as_slice(),

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -51,7 +51,7 @@ use syntax::parse::token;
 use syntax::parse::token::InternedString;
 use syntax::{ast, ast_map};
 use syntax::owned_slice::OwnedSlice;
-use syntax::abi::AbiSet;
+use syntax::abi;
 use syntax;
 use collections::enum_set::{EnumSet, CLike};
 
@@ -416,8 +416,8 @@ pub fn type_id(t: t) -> uint { get(t).id }
 #[deriving(Clone, Eq, TotalEq, Hash)]
 pub struct BareFnTy {
     pub purity: ast::Purity,
-    pub abis: AbiSet,
-    pub sig: FnSig
+    pub abi: abi::Abi,
+    pub sig: FnSig,
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash)]
@@ -796,7 +796,7 @@ pub enum type_err {
     terr_mismatch,
     terr_purity_mismatch(expected_found<Purity>),
     terr_onceness_mismatch(expected_found<Onceness>),
-    terr_abi_mismatch(expected_found<AbiSet>),
+    terr_abi_mismatch(expected_found<abi::Abi>),
     terr_mutability,
     terr_sigil_mismatch(expected_found<ast::Sigil>),
     terr_box_mutability,
@@ -1409,7 +1409,7 @@ pub fn mk_ctor_fn(cx: &ctxt,
     mk_bare_fn(cx,
                BareFnTy {
                    purity: ast::ImpureFn,
-                   abis: AbiSet::Rust(),
+                   abi: abi::Rust,
                    sig: FnSig {
                     binder_id: binder_id,
                     inputs: input_args,
@@ -4677,7 +4677,7 @@ pub fn hash_crate_independent(tcx: &ctxt, t: t, svh: &Svh) -> u64 {
             ty_bare_fn(ref b) => {
                 byte!(14);
                 hash!(b.purity);
-                hash!(b.abis);
+                hash!(b.abi);
             }
             ty_closure(ref c) => {
                 byte!(15);

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -48,7 +48,7 @@ pub trait TypeFolder {
                        fty: &ty::BareFnTy)
                        -> ty::BareFnTy {
         ty::BareFnTy { sig: self.fold_sig(&fty.sig),
-                       abis: fty.abis,
+                       abi: fty.abi,
                        purity: fty.purity }
     }
 

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1164,7 +1164,7 @@ impl<'a> LookupContext<'a> {
         let fty = ty::mk_bare_fn(tcx, ty::BareFnTy {
             sig: fn_sig,
             purity: bare_fn_ty.purity,
-            abis: bare_fn_ty.abis.clone(),
+            abi: bare_fn_ty.abi.clone(),
         });
         debug!("after replacing bound regions, fty={}", self.ty_to_str(fty));
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -120,7 +120,7 @@ use std::mem::replace;
 use std::result;
 use std::slice;
 use std::vec::Vec;
-use syntax::abi::AbiSet;
+use syntax::abi;
 use syntax::ast::{Provided, Required};
 use syntax::ast;
 use syntax::ast_util::local_def;
@@ -599,7 +599,7 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
         check_bounds_are_used(ccx, t.span, &generics.ty_params, tpt_ty);
       }
       ast::ItemForeignMod(ref m) => {
-        if m.abis.is_intrinsic() {
+        if m.abi == abi::RustIntrinsic {
             for item in m.items.iter() {
                 check_intrinsic_type(ccx, *item);
             }
@@ -612,7 +612,7 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
 
                 match item.node {
                     ast::ForeignItemFn(ref fn_decl, _) => {
-                        if fn_decl.variadic && !m.abis.is_c() {
+                        if fn_decl.variadic && m.abi != abi::C {
                             ccx.tcx.sess.span_err(
                                 item.span, "variadic function must have C calling convention");
                         }
@@ -4224,7 +4224,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
     };
     let fty = ty::mk_bare_fn(tcx, ty::BareFnTy {
         purity: ast::UnsafeFn,
-        abis: AbiSet::Intrinsic(),
+        abi: abi::RustIntrinsic,
         sig: FnSig {binder_id: it.id,
                     inputs: inputs,
                     output: output,

--- a/src/librustc/middle/typeck/infer/coercion.rs
+++ b/src/librustc/middle/typeck/infer/coercion.rs
@@ -77,6 +77,7 @@ use middle::typeck::infer::to_str::InferStr;
 use middle::typeck::infer::resolve::try_resolve_tvar_shallow;
 use util::common::indenter;
 
+use syntax::abi;
 use syntax::ast::MutImmutable;
 use syntax::ast;
 
@@ -384,7 +385,7 @@ impl<'f> Coerce<'f> {
             debug!("coerce_from_bare_fn(a={}, b={})",
                    a.inf_str(self.get_ref().infcx), b.inf_str(self.get_ref().infcx));
 
-            if !fn_ty_a.abis.is_rust() || fn_ty_a.purity != ast::ImpureFn {
+            if fn_ty_a.abi != abi::Rust || fn_ty_a.purity != ast::ImpureFn {
                 return self.subtype(a, b);
             }
 

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -67,7 +67,7 @@ use std::result;
 use syntax::ast::{Onceness, Purity};
 use syntax::ast;
 use syntax::owned_slice::OwnedSlice;
-use syntax::abi::AbiSet;
+use syntax::abi;
 
 pub trait Combine {
     fn infcx<'a>(&'a self) -> &'a InferCtxt<'a>;
@@ -195,10 +195,10 @@ pub trait Combine {
     fn bare_fn_tys(&self, a: &ty::BareFnTy,
                    b: &ty::BareFnTy) -> cres<ty::BareFnTy> {
         let purity = if_ok!(self.purities(a.purity, b.purity));
-        let abi = if_ok!(self.abis(a.abis, b.abis));
+        let abi = if_ok!(self.abi(a.abi, b.abi));
         let sig = if_ok!(self.fn_sigs(&a.sig, &b.sig));
         Ok(ty::BareFnTy {purity: purity,
-                abis: abi,
+                abi: abi,
                 sig: sig})
     }
 
@@ -248,7 +248,7 @@ pub trait Combine {
 
     fn purities(&self, a: Purity, b: Purity) -> cres<Purity>;
 
-    fn abis(&self, a: AbiSet, b: AbiSet) -> cres<AbiSet> {
+    fn abi(&self, a: abi::Abi, b: abi::Abi) -> cres<abi::Abi> {
         if a == b {
             Ok(a)
         } else {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -358,7 +358,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
             }
             let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
                 purity: ast::ImpureFn,
-                abis: abi::AbiSet::Rust(),
+                abi: abi::Rust,
                 sig: ty::FnSig {
                     binder_id: main_id,
                     inputs: Vec::new(),
@@ -404,7 +404,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
 
             let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
                 purity: ast::ImpureFn,
-                abis: abi::AbiSet::Rust(),
+                abi: abi::Rust,
                 sig: ty::FnSig {
                     binder_id: start_id,
                     inputs: vec!(

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -23,7 +23,7 @@ use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_unboxed_vec, ty_infer};
 use middle::ty;
 use middle::typeck;
 
-use syntax::abi::AbiSet;
+use syntax::abi;
 use syntax::ast_map;
 use syntax::codemap::{Span, Pos};
 use syntax::parse::token;
@@ -253,14 +253,14 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
     }
     fn bare_fn_to_str(cx: &ctxt,
                       purity: ast::Purity,
-                      abis: AbiSet,
+                      abi: abi::Abi,
                       ident: Option<ast::Ident>,
                       sig: &ty::FnSig)
                       -> ~str {
-        let mut s = if abis.is_rust() {
+        let mut s = if abi == abi::Rust {
             ~""
         } else {
-            format!("extern {} ", abis.to_str())
+            format!("extern {} ", abi.to_str())
         };
 
         match purity {
@@ -406,7 +406,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
           closure_to_str(cx, *f)
       }
       ty_bare_fn(ref f) => {
-          bare_fn_to_str(cx, f.purity, f.abis, None, &f.sig)
+          bare_fn_to_str(cx, f.purity, f.abi, None, &f.sig)
       }
       ty_infer(infer_ty) => infer_ty.to_str(),
       ty_err => ~"[type error]",
@@ -813,9 +813,9 @@ impl Repr for ast::Visibility {
 
 impl Repr for ty::BareFnTy {
     fn repr(&self, tcx: &ctxt) -> ~str {
-        format!("BareFnTy \\{purity: {:?}, abis: {}, sig: {}\\}",
+        format!("BareFnTy \\{purity: {:?}, abi: {}, sig: {}\\}",
              self.purity,
-             self.abis.to_str(),
+             self.abi.to_str(),
              self.sig.repr(tcx))
     }
 }
@@ -968,13 +968,13 @@ impl UserString for ast::Ident {
     }
 }
 
-impl Repr for AbiSet {
+impl Repr for abi::Abi {
     fn repr(&self, _tcx: &ctxt) -> ~str {
         self.to_str()
     }
 }
 
-impl UserString for AbiSet {
+impl UserString for abi::Abi {
     fn user_string(&self, _tcx: &ctxt) -> ~str {
         self.to_str()
     }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -975,7 +975,7 @@ impl Clean<BareFunctionDecl> for ast::BareFnTy {
                 type_params: Vec::new(),
             },
             decl: self.decl.clean(),
-            abi: self.abis.to_str(),
+            abi: self.abi.to_str(),
         }
     }
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -11,7 +11,7 @@
 //! Rust AST Visitor. Extracts useful information and massages it into a form
 //! usable for clean
 
-use syntax::abi::AbiSet;
+use syntax::abi;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::ast_map;
@@ -95,7 +95,7 @@ impl<'a> RustdocVisitor<'a> {
     }
 
     pub fn visit_fn(&mut self, item: &ast::Item, fd: &ast::FnDecl,
-                    purity: &ast::Purity, _abi: &AbiSet,
+                    purity: &ast::Purity, _abi: &abi::Abi,
                     gen: &ast::Generics) -> Function {
         debug!("Visiting fn");
         Function {

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -9,12 +9,11 @@
 // except according to those terms.
 
 use std::fmt;
-use std::fmt::Show;
 
 #[deriving(Eq)]
 pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, }
 
-#[deriving(Eq, TotalEq, Hash)]
+#[deriving(Eq, TotalEq, Hash, Encodable, Decodable, Clone)]
 pub enum Abi {
     // NB: This ordering MUST match the AbiDatas array below.
     // (This is ensured by the test indices_are_correct().)
@@ -63,11 +62,6 @@ pub enum AbiArchitecture {
     RustArch,   // Not a real ABI (e.g., intrinsic)
     AllArch,    // An ABI that specifies cross-platform defaults (e.g., "C")
     Archs(u32)  // Multiple architectures (bitset)
-}
-
-#[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
-pub struct AbiSet {
-    bits: u32   // each bit represents one of the abis below
 }
 
 static AbiDatas: &'static [AbiData] = &[
@@ -136,12 +130,20 @@ impl Abi {
         self.data().name
     }
 
-    pub fn for_target(&self, os: Os, arch: Architecture) -> Abi {
-        match (*self, os, arch) {
+    pub fn for_target(&self, os: Os, arch: Architecture) -> Option<Abi> {
+        // If this ABI isn't actually for the specified architecture, then we
+        // short circuit early
+        match self.data().abi_arch {
+            Archs(a) if a & arch.bit() == 0 => return None,
+            Archs(_) | RustArch | AllArch => {}
+        }
+        // Transform this ABI as appropriate for the requested os/arch
+        // combination.
+        Some(match (*self, os, arch) {
             (System, OsWin32, X86) => Stdcall,
             (System, _, _) => C,
             (me, _, _) => me,
-        }
+        })
     }
 }
 
@@ -151,138 +153,9 @@ impl Architecture {
     }
 }
 
-impl AbiSet {
-    pub fn from(abi: Abi) -> AbiSet {
-        AbiSet { bits: (1 << abi.index()) }
-    }
-
-    #[inline]
-    pub fn Rust() -> AbiSet {
-        AbiSet::from(Rust)
-    }
-
-    #[inline]
-    pub fn C() -> AbiSet {
-        AbiSet::from(C)
-    }
-
-    #[inline]
-    pub fn Intrinsic() -> AbiSet {
-        AbiSet::from(RustIntrinsic)
-    }
-
-    pub fn default() -> AbiSet {
-        AbiSet::C()
-    }
-
-    pub fn empty() -> AbiSet {
-        AbiSet { bits: 0 }
-    }
-
-    #[inline]
-    pub fn is_rust(&self) -> bool {
-        self.bits == 1 << Rust.index()
-    }
-
-    #[inline]
-    pub fn is_c(&self) -> bool {
-        self.bits == 1 << C.index()
-    }
-
-    #[inline]
-    pub fn is_intrinsic(&self) -> bool {
-        self.bits == 1 << RustIntrinsic.index()
-    }
-
-    pub fn contains(&self, abi: Abi) -> bool {
-        (self.bits & (1 << abi.index())) != 0
-    }
-
-    pub fn subset_of(&self, other_abi_set: AbiSet) -> bool {
-        (self.bits & other_abi_set.bits) == self.bits
-    }
-
-    pub fn add(&mut self, abi: Abi) {
-        self.bits |= 1 << abi.index();
-    }
-
-    pub fn each(&self, op: |abi: Abi| -> bool) -> bool {
-        each_abi(|abi| !self.contains(abi) || op(abi))
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.bits == 0
-    }
-
-    pub fn for_target(&self, os: Os, arch: Architecture) -> Option<Abi> {
-        // NB---Single platform ABIs come first
-
-        let mut res = None;
-
-        self.each(|abi| {
-            let data = abi.data();
-            match data.abi_arch {
-                Archs(a) if (a & arch.bit()) != 0 => { res = Some(abi); false }
-                Archs(_) => { true }
-                RustArch | AllArch => { res = Some(abi); false }
-            }
-        });
-
-        res.map(|r| r.for_target(os, arch))
-    }
-
-    pub fn check_valid(&self) -> Option<(Abi, Abi)> {
-        let mut abis = Vec::new();
-        self.each(|abi| { abis.push(abi); true });
-
-        for (i, abi) in abis.iter().enumerate() {
-            let data = abi.data();
-            for other_abi in abis.slice(0, i).iter() {
-                let other_data = other_abi.data();
-                debug!("abis=({:?},{:?}) datas=({:?},{:?})",
-                       abi, data.abi_arch,
-                       other_abi, other_data.abi_arch);
-                match (&data.abi_arch, &other_data.abi_arch) {
-                    (&AllArch, &AllArch) => {
-                        // Two cross-architecture ABIs
-                        return Some((*abi, *other_abi));
-                    }
-                    (_, &RustArch) |
-                    (&RustArch, _) => {
-                        // Cannot combine Rust or Rust-Intrinsic with
-                        // anything else.
-                        return Some((*abi, *other_abi));
-                    }
-                    (&Archs(is), &Archs(js)) if (is & js) != 0 => {
-                        // Two ABIs for same architecture
-                        return Some((*abi, *other_abi));
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        return None;
-    }
-}
-
 impl fmt::Show for Abi {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.data().name.fmt(f)
-    }
-}
-
-impl fmt::Show for AbiSet {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f.buf, "\""));
-        let mut first = true;
-        self.each(|abi| {
-            if first { first = false; }
-            else { let _ = write!(f.buf, " "); }
-            let _ = write!(f.buf, "{}", abi.data().name);
-            true
-        });
-        write!(f.buf, "\"")
+        write!(f.buf, "\"{}\"", self.name())
     }
 }
 
@@ -304,95 +177,6 @@ fn lookup_baz() {
     assert!(abi.is_none());
 }
 
-#[cfg(test)]
-fn cannot_combine(n: Abi, m: Abi) {
-    let mut set = AbiSet::empty();
-    set.add(n);
-    set.add(m);
-    match set.check_valid() {
-        Some((a, b)) => {
-            assert!((n == a && m == b) ||
-                         (m == a && n == b));
-        }
-        None => {
-            fail!("invalid match not detected");
-        }
-    }
-}
-
-#[cfg(test)]
-fn can_combine(n: Abi, m: Abi) {
-    let mut set = AbiSet::empty();
-    set.add(n);
-    set.add(m);
-    match set.check_valid() {
-        Some((_, _)) => {
-            fail!("valid match declared invalid");
-        }
-        None => {}
-    }
-}
-
-#[test]
-fn cannot_combine_cdecl_and_stdcall() {
-    cannot_combine(Cdecl, Stdcall);
-}
-
-#[test]
-fn cannot_combine_c_and_rust() {
-    cannot_combine(C, Rust);
-}
-
-#[test]
-fn cannot_combine_rust_and_cdecl() {
-    cannot_combine(Rust, Cdecl);
-}
-
-#[test]
-fn cannot_combine_rust_intrinsic_and_cdecl() {
-    cannot_combine(RustIntrinsic, Cdecl);
-}
-
-#[test]
-fn can_combine_system_and_cdecl() {
-    can_combine(System, Cdecl);
-}
-
-#[test]
-fn can_combine_c_and_stdcall() {
-    can_combine(C, Stdcall);
-}
-
-#[test]
-fn can_combine_aapcs_and_stdcall() {
-    can_combine(Aapcs, Stdcall);
-}
-
-#[test]
-fn abi_to_str_stdcall_aaps() {
-    let mut set = AbiSet::empty();
-    set.add(Aapcs);
-    set.add(Stdcall);
-    assert!(set.to_str() == ~"\"stdcall aapcs\"");
-}
-
-#[test]
-fn abi_to_str_c_aaps() {
-    let mut set = AbiSet::empty();
-    set.add(Aapcs);
-    set.add(C);
-    debug!("set = {}", set.to_str());
-    assert!(set.to_str() == ~"\"aapcs C\"");
-}
-
-#[test]
-fn abi_to_str_rust() {
-    let mut set = AbiSet::empty();
-    set.add(Rust);
-    debug!("set = {}", set.to_str());
-    assert!(set.to_str() == ~"\"Rust\"");
-}
-
 #[test]
 fn indices_are_correct() {
     for (i, abi_data) in AbiDatas.iter().enumerate() {
@@ -407,30 +191,14 @@ fn indices_are_correct() {
     assert_eq!(ArmBits, bits);
 }
 
-#[cfg(test)]
-fn get_arch(abis: &[Abi], os: Os, arch: Architecture) -> Option<Abi> {
-    let mut set = AbiSet::empty();
-    for &abi in abis.iter() {
-        set.add(abi);
-    }
-    set.for_target(os, arch)
-}
-
-#[test]
-fn pick_multiplatform() {
-    assert_eq!(get_arch([C, Cdecl], OsLinux, X86), Some(Cdecl));
-    assert_eq!(get_arch([C, Cdecl], OsLinux, X86_64), Some(Cdecl));
-    assert_eq!(get_arch([C, Cdecl], OsLinux, Arm), Some(C));
-}
-
 #[test]
 fn pick_uniplatform() {
-    assert_eq!(get_arch([Stdcall], OsLinux, X86), Some(Stdcall));
-    assert_eq!(get_arch([Stdcall], OsLinux, Arm), None);
-    assert_eq!(get_arch([System], OsLinux, X86), Some(C));
-    assert_eq!(get_arch([System], OsWin32, X86), Some(Stdcall));
-    assert_eq!(get_arch([System], OsWin32, X86_64), Some(C));
-    assert_eq!(get_arch([System], OsWin32, Arm), Some(C));
-    assert_eq!(get_arch([Stdcall], OsWin32, X86), Some(Stdcall));
-    assert_eq!(get_arch([Stdcall], OsWin32, X86_64), Some(Stdcall));
+    assert_eq!(Stdcall.for_arch(OsLinux, X86), Some(Stdcall));
+    assert_eq!(Stdcall.for_arch(OsLinux, Arm), None);
+    assert_eq!(System.for_arch(OsLinux, X86), Some(C));
+    assert_eq!(System.for_arch(OsWin32, X86), Some(Stdcall));
+    assert_eq!(System.for_arch(OsWin32, X86_64), Some(C));
+    assert_eq!(System.for_arch(OsWin32, Arm), Some(C));
+    assert_eq!(Stdcall.for_arch(OsWin32, X86), Some(Stdcall));
+    assert_eq!(Stdcall.for_arch(OsWin32, X86_64), Some(Stdcall));
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -11,7 +11,7 @@
 // The Rust abstract syntax tree.
 
 use codemap::{Span, Spanned, DUMMY_SP};
-use abi::AbiSet;
+use abi::Abi;
 use ast_util;
 use owned_slice::OwnedSlice;
 use parse::token::{InternedString, special_idents, str_to_ident};
@@ -807,7 +807,7 @@ pub struct ClosureTy {
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct BareFnTy {
     pub purity: Purity,
-    pub abis: AbiSet,
+    pub abi: Abi,
     pub lifetimes: Vec<Lifetime>,
     pub decl: P<FnDecl>
 }
@@ -941,7 +941,7 @@ pub struct Mod {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct ForeignMod {
-    pub abis: AbiSet,
+    pub abi: Abi,
     pub view_items: Vec<ViewItem>,
     pub items: Vec<@ForeignItem>,
 }
@@ -1119,7 +1119,7 @@ pub struct Item {
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub enum Item_ {
     ItemStatic(P<Ty>, Mutability, @Expr),
-    ItemFn(P<FnDecl>, Purity, AbiSet, Generics, P<Block>),
+    ItemFn(P<FnDecl>, Purity, Abi, Generics, P<Block>),
     ItemMod(Mod),
     ItemForeignMod(ForeignMod),
     ItemTy(P<Ty>, Generics),

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use abi::AbiSet;
+use abi;
 use ast::*;
 use ast_util;
 use codemap::Span;
@@ -224,19 +224,19 @@ impl Map {
         }
     }
 
-    pub fn get_foreign_abis(&self, id: NodeId) -> AbiSet {
+    pub fn get_foreign_abi(&self, id: NodeId) -> abi::Abi {
         let parent = self.get_parent(id);
-        let abis = match self.find_entry(parent) {
+        let abi = match self.find_entry(parent) {
             Some(EntryItem(_, i)) => match i.node {
-                ItemForeignMod(ref nm) => Some(nm.abis),
+                ItemForeignMod(ref nm) => Some(nm.abi),
                 _ => None
             },
             // Wrong but OK, because the only inlined foreign items are intrinsics.
-            Some(RootInlinedParent(_)) => Some(AbiSet::Intrinsic()),
+            Some(RootInlinedParent(_)) => Some(abi::RustIntrinsic),
             _ => None
         };
-        match abis {
-            Some(abis) => abis,
+        match abi {
+            Some(abi) => abi,
             None => fail!("expected foreign mod or inlined parent, found {}",
                           self.node_to_str(parent))
         }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use abi::AbiSet;
+use abi;
 use ast::{P, Ident};
 use ast;
 use ast_util;
@@ -826,7 +826,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                   Vec::new(),
                   ast::ItemFn(self.fn_decl(inputs, output),
                               ast::ImpureFn,
-                              AbiSet::Rust(),
+                              abi::Rust,
                               generics,
                               body))
     }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -170,7 +170,7 @@ pub trait Folder {
                 TyBareFn(@BareFnTy {
                     lifetimes: f.lifetimes.iter().map(|l| fold_lifetime(l, self)).collect(),
                     purity: f.purity,
-                    abis: f.abis,
+                    abi: f.abi,
                     decl: self.fold_fn_decl(f.decl)
                 })
             }
@@ -198,7 +198,7 @@ pub trait Folder {
 
     fn fold_foreign_mod(&mut self, nm: &ForeignMod) -> ForeignMod {
         ast::ForeignMod {
-            abis: nm.abis,
+            abi: nm.abi,
             view_items: nm.view_items
                           .iter()
                           .map(|x| self.fold_view_item(x))

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -657,7 +657,7 @@ mod test {
                                 variadic: false
                             }),
                                     ast::ImpureFn,
-                                    abi::AbiSet::Rust(),
+                                    abi::Rust,
                                     ast::Generics{ // no idea on either of these:
                                         lifetimes: Vec::new(),
                                         ty_params: OwnedSlice::empty(),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use abi::AbiSet;
+use abi::Abi;
 use ast::*;
 use ast;
 use codemap::Span;
@@ -29,7 +29,7 @@ use owned_slice::OwnedSlice;
 
 pub enum FnKind<'a> {
     // fn foo() or extern "Abi" fn foo()
-    FkItemFn(Ident, &'a Generics, Purity, AbiSet),
+    FkItemFn(Ident, &'a Generics, Purity, Abi),
 
     // fn foo(&self)
     FkMethod(Ident, &'a Generics, &'a Method),


### PR DESCRIPTION
This change removes the AbiSet from the AST, converting all usage to have just
one Abi value. The current scheme selects a relevant ABI given a list of ABIs
based on the target architecture and how relevant each ABI is to that
architecture.

Instead of this mildly complicated scheme, only one ABI will be allowed in abi
strings, and pseudo-abis will be created for special cases as necessary. For
example the "system" abi exists for stdcall on win32 and C on win64.

Closes #10049
