### PR TITLE
Update emacs mode to support new `#![inner(attribute)]` syntax.

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -196,8 +196,8 @@
      ;; Special types
      (,(regexp-opt rust-special-types 'words) . font-lock-type-face)
 
-     ;; Attributes like `#[bar(baz)]`
-     (,(rust-re-grab (concat "#\\[" rust-re-ident "[^]]*\\]"))
+     ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]`
+     (,(rust-re-grab (concat "#\\!?[" rust-re-ident "[^]]*\\]"))
       1 font-lock-preprocessor-face)
 
      ;; Syntax extension invocations like `foo!`, highlight including the !


### PR DESCRIPTION
I'm just blindly augmenting a regexp slightly.
