### PR TITLE
fix Option<~ZeroSizeType>

### DIFF
--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -64,12 +64,21 @@ pub unsafe fn realloc_raw(ptr: *mut u8, size: uint) -> *mut u8 {
     }
 }
 
+// The compiler never calls `exchange_free` on ~ZeroSizeType, so zero-size
+// allocations can point to this `static`. It would be incorrect to use a null
+// pointer, due to enums assuming types like unique pointers are never null.
+static EMPTY: () = ();
+
 /// The allocator for unique pointers without contained managed pointers.
 #[cfg(not(test))]
 #[lang="exchange_malloc"]
 #[inline]
-pub unsafe fn exchange_malloc(size: uint) -> *u8 {
-    malloc_raw(size) as *u8
+pub unsafe fn exchange_malloc(size: uint) -> *mut u8 {
+    if size == 0 {
+        &EMPTY as *() as *mut u8
+    } else {
+        malloc_raw(size)
+    }
 }
 
 // FIXME: #7496

--- a/src/test/run-pass/empty-allocation-non-null.rs
+++ b/src/test/run-pass/empty-allocation-non-null.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    assert!(Some(~()).is_some());
+
+    struct Foo;
+    assert!(Some(~Foo).is_some());
+
+    let xs: ~[()] = ~[];
+    assert!(Some(xs).is_some());
+}


### PR DESCRIPTION
1778b6361627c5894bf75ffecf427573af02d390 provided the guarantee of no
`exchange_free` calls for ~ZeroSizeType, so a sentinel can now be used
without overhead.

Closes #11998
