### PR TITLE
syntax: Tweak parsing lifetime bounds on closures

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3420,8 +3420,21 @@ x = bo(5,7);
 
 ### Closure types
 
-The type of a closure mapping an input of type `A` to an output of type `B` is `|A| -> B`. A closure with no arguments or return values has type `||`.
+~~~~ {.notrust .ebnf .notation}
+closure_type := [ 'unsafe' ] [ '<' lifetime-list '>' ] '|' arg-list '|'
+                [ ':' bound-list ] [ '->' type ]
+procedure_type := 'proc' [ '<' lifetime-list '>' ] '(' arg-list ')'
+                  [ ':' bound-list ] [ '->' type ]
+lifetime-list := lifetime | lifetime ',' lifetime-list
+arg-list := ident ':' type | ident ':' type ',' arg-list
+bound-list := bound | bound '+' bound-list
+bound := path | lifetime
+~~~~
 
+The type of a closure mapping an input of type `A` to an output of type `B` is
+`|A| -> B`. A closure with no arguments or return values has type `||`.
+Similarly, a procedure mapping `A` to `B` is `proc(A) -> B` and a no-argument
+and no-return value closure has type `proc()`.
 
 An example of creating and calling a closure:
 
@@ -3441,6 +3454,30 @@ fn call_closure(c1: ||, c2: |int| -> int) {
 }
 
 call_closure(closure_no_args, closure_args);
+
+```
+
+Unlike closures, procedures may only be invoked once, but own their
+environment, and are allowed to move out of their environment. Procedures are
+allocated on the heap (unlike closures). An example of creating and calling a
+procedure:
+
+```rust
+let string = ~"Hello";
+
+// Creates a new procedure, passing it to the `spawn` function.
+spawn(proc() {
+  println!("{} world!", string);
+});
+
+// the variable `string` has been moved into the previous procedure, so it is
+// no longer usable.
+
+
+// Create an invoke a procedure. Note that the procedure is *moved* when
+// invoked, so it cannot be invoked again.
+let f = proc(n: int) { n + 22 };
+println!("answer: {}", f(20));
 
 ```
 

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -36,8 +36,6 @@ pub enum ObsoleteSyntax {
     ObsoleteEnumWildcard,
     ObsoleteStructWildcard,
     ObsoleteVecDotDotWildcard,
-    ObsoleteBoxedClosure,
-    ObsoleteClosureType,
     ObsoleteMultipleImport,
     ObsoleteManagedPattern,
     ObsoleteManagedString,
@@ -110,16 +108,6 @@ impl<'a> ParserObsoleteMethods for Parser<'a> {
             ObsoleteVecDotDotWildcard => (
                 "vec slice wildcard",
                 "use `..` instead of `.._` for matching slices"
-            ),
-            ObsoleteBoxedClosure => (
-                "managed or owned closure",
-                "managed closures have been removed and owned closures are \
-                 now written `proc()`"
-            ),
-            ObsoleteClosureType => (
-                "closure type",
-                "closures are now written `|A| -> B` rather than `&fn(A) -> \
-                 B`."
             ),
             ObsoleteMultipleImport => (
                 "multiple imports",

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -15,11 +15,11 @@
 
 // returns an infinite iterator of repeated applications of f to x,
 // i.e. [x, f(x), f(f(x)), ...], as haskell iterate function.
-fn iterate<'a, T>(x: T, f: 'a |&T| -> T) -> Iterate<'a, T> {
+fn iterate<'a, T>(x: T, f: |&T|: 'a -> T) -> Iterate<'a, T> {
     Iterate {f: f, next: x}
 }
 struct Iterate<'a, T> {
-    f: 'a |&T| -> T,
+    f: |&T|: 'a -> T,
     next: T
 }
 impl<'a, T> Iterator<T> for Iterate<'a, T> {

--- a/src/test/compile-fail/closure-bounds-static-cant-capture-borrowed.rs
+++ b/src/test/compile-fail/closure-bounds-static-cant-capture-borrowed.rs
@@ -12,8 +12,8 @@ fn bar(blk: ||:'static) {
 }
 
 fn foo(x: &()) {
-    bar(|| {
-        let _ = x; //~ ERROR does not fulfill `'static`
+    bar(|| { //~ ERROR cannot infer an appropriate lifetime
+        let _ = x;
     })
 }
 

--- a/src/test/run-pass/closure-syntax.rs
+++ b/src/test/run-pass/closure-syntax.rs
@@ -1,0 +1,76 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty #13324
+
+#![allow(dead_code)]
+
+fn foo<T>() {}
+
+trait Bar1 {}
+impl Bar1 for proc() {}
+
+trait Bar2 {}
+impl Bar2 for proc(): Send {}
+
+trait Bar3 {}
+impl<'b> Bar3 for <'a>|&'a int|: 'b + Send -> &'a int {}
+
+trait Bar4 {}
+impl Bar4 for proc<'a>(&'a int) -> &'a int {}
+
+struct Foo<'a> {
+    a: ||: 'a,
+    b: ||: 'static,
+    c: <'b>||: 'a,
+    d: ||: 'a + Share,
+    e: <'b>|int|: 'a + Share -> &'b f32,
+    f: proc(),
+    g: proc(): 'static + Share,
+    h: proc<'b>(int): Share -> &'b f32,
+}
+
+fn f<'a>(a: &'a int, f: <'b>|&'b int| -> &'b int) -> &'a int {
+    f(a)
+}
+
+fn g<'a>(a: &'a int, f: proc<'b>(&'b int) -> &'b int) -> &'a int {
+    f(a)
+}
+
+fn bar<'b>() {
+    foo::<||>();
+    foo::<|| -> ()>();
+    foo::<||:>();
+    foo::<||:'b>();
+    foo::<||:'b + Share>();
+    foo::<||:Share>();
+    foo::< <'a>|int, f32, &'a int|:'b + Share -> &'a int>();
+    foo::<proc()>();
+    foo::<proc() -> ()>();
+    foo::<proc():>();
+    foo::<proc():'static>();
+    foo::<proc():Share>();
+    foo::<proc<'a>(int, f32, &'a int):'static + Share -> &'a int>();
+
+    // issue #11209
+    let _: 'b ||; // for comparison
+    let _: <'a> ||;
+
+    let _: Option<||:'b>;
+    // let _: Option<<'a>||>;
+    let _: Option< <'a>||>;
+
+    // issue #11210
+    let _: 'static ||;
+}
+
+pub fn main() {
+}

--- a/src/test/run-pass/const-fn-val.rs
+++ b/src/test/run-pass/const-fn-val.rs
@@ -12,7 +12,7 @@ fn foo() -> int {
     return 0xca7f000d;
 }
 
-struct Bar<'a> { f: 'a || -> int }
+struct Bar<'a> { f: ||: 'a -> int }
 
 static mut b : Bar<'static> = Bar { f: foo };
 

--- a/src/test/run-pass/const-vec-of-fns.rs
+++ b/src/test/run-pass/const-vec-of-fns.rs
@@ -17,7 +17,7 @@
 
 fn f() { }
 static bare_fns: &'static [fn()] = &[f, f];
-struct S<'a>('a ||);
+struct S<'a>(||:'a);
 static mut closures: &'static [S<'static>] = &[S(f), S(f)];
 
 pub fn main() {

--- a/src/test/run-pass/expr-block-fn.rs
+++ b/src/test/run-pass/expr-block-fn.rs
@@ -11,7 +11,7 @@
 
 
 fn test_fn() {
-    type t = 'static || -> int;
+    type t = ||: 'static -> int;
     fn ten() -> int { return 10; }
     let rs: t = ten;
     assert!((rs() == 10));

--- a/src/test/run-pass/expr-block-generic-box1.rs
+++ b/src/test/run-pass/expr-block-generic-box1.rs
@@ -10,7 +10,7 @@
 
 #[feature(managed_boxes)];
 
-type compare<T> = 'static |@T, @T| -> bool;
+type compare<T> = |@T, @T|: 'static -> bool;
 
 fn test_generic<T>(expected: @T, eq: compare<T>) {
     let actual: @T = { expected };

--- a/src/test/run-pass/expr-block-generic-box2.rs
+++ b/src/test/run-pass/expr-block-generic-box2.rs
@@ -12,7 +12,7 @@
 
 // ignore-fast
 
-type compare<'a, T> = 'a |T, T| -> bool;
+type compare<'a, T> = |T, T|: 'a -> bool;
 
 fn test_generic<T:Clone>(expected: T, eq: compare<T>) {
     let actual: T = { expected.clone() };

--- a/src/test/run-pass/expr-block-generic-unique1.rs
+++ b/src/test/run-pass/expr-block-generic-unique1.rs
@@ -10,7 +10,7 @@
 
 
 
-type compare<'a, T> = 'a |~T, ~T| -> bool;
+type compare<'a, T> = |~T, ~T|: 'a -> bool;
 
 fn test_generic<T:Clone>(expected: ~T, eq: compare<T>) {
     let actual: ~T = { expected.clone() };

--- a/src/test/run-pass/expr-block-generic-unique2.rs
+++ b/src/test/run-pass/expr-block-generic-unique2.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast
 
-type compare<'a, T> = 'a |T, T| -> bool;
+type compare<'a, T> = |T, T|: 'a -> bool;
 
 fn test_generic<T:Clone>(expected: T, eq: compare<T>) {
     let actual: T = { expected.clone() };

--- a/src/test/run-pass/expr-block-generic.rs
+++ b/src/test/run-pass/expr-block-generic.rs
@@ -12,7 +12,7 @@
 // ignore-fast
 
 // Tests for standalone blocks as expressions with dynamic type sizes
-type compare<'a, T> = 'a |T, T| -> bool;
+type compare<'a, T> = |T, T|: 'a -> bool;
 
 fn test_generic<T:Clone>(expected: T, eq: compare<T>) {
     let actual: T = { expected.clone() };

--- a/src/test/run-pass/expr-if-generic-box1.rs
+++ b/src/test/run-pass/expr-if-generic-box1.rs
@@ -10,7 +10,7 @@
 
 #[feature(managed_boxes)];
 
-type compare<T> = 'static |@T, @T| -> bool;
+type compare<T> = |@T, @T|: 'static -> bool;
 
 fn test_generic<T>(expected: @T, not_expected: @T, eq: compare<T>) {
     let actual: @T = if true { expected } else { not_expected };

--- a/src/test/run-pass/expr-if-generic-box2.rs
+++ b/src/test/run-pass/expr-if-generic-box2.rs
@@ -12,7 +12,7 @@
 
 // ignore-fast
 
-type compare<T> = 'static |T, T| -> bool;
+type compare<T> = |T, T|: 'static -> bool;
 
 fn test_generic<T:Clone>(expected: T, not_expected: T, eq: compare<T>) {
     let actual: T = if true { expected.clone() } else { not_expected };

--- a/src/test/run-pass/expr-if-generic.rs
+++ b/src/test/run-pass/expr-if-generic.rs
@@ -11,7 +11,7 @@
 // ignore-fast
 
 // Tests for if as expressions with dynamic type sizes
-type compare<T> = 'static |T, T| -> bool;
+type compare<T> = |T, T|: 'static -> bool;
 
 fn test_generic<T:Clone>(expected: T, not_expected: T, eq: compare<T>) {
     let actual: T = if true { expected.clone() } else { not_expected };

--- a/src/test/run-pass/expr-match-generic-box1.rs
+++ b/src/test/run-pass/expr-match-generic-box1.rs
@@ -10,7 +10,7 @@
 
 #[feature(managed_boxes)];
 
-type compare<T> = 'static |@T, @T| -> bool;
+type compare<T> = |@T, @T|: 'static -> bool;
 
 fn test_generic<T>(expected: @T, eq: compare<T>) {
     let actual: @T = match true { true => { expected }, _ => fail!() };

--- a/src/test/run-pass/expr-match-generic-box2.rs
+++ b/src/test/run-pass/expr-match-generic-box2.rs
@@ -12,7 +12,7 @@
 
 // ignore-fast
 
-type compare<T> = 'static |T, T| -> bool;
+type compare<T> = |T, T|: 'static -> bool;
 
 fn test_generic<T:Clone>(expected: T, eq: compare<T>) {
     let actual: T = match true { true => { expected.clone() }, _ => fail!("wat") };

--- a/src/test/run-pass/expr-match-generic-unique1.rs
+++ b/src/test/run-pass/expr-match-generic-unique1.rs
@@ -10,7 +10,7 @@
 
 
 
-type compare<T> = 'static |~T, ~T| -> bool;
+type compare<T> = |~T, ~T|: 'static -> bool;
 
 fn test_generic<T:Clone>(expected: ~T, eq: compare<T>) {
     let actual: ~T = match true {

--- a/src/test/run-pass/expr-match-generic-unique2.rs
+++ b/src/test/run-pass/expr-match-generic-unique2.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast
 
-type compare<'a, T> = 'a |T, T| -> bool;
+type compare<'a, T> = |T, T|: 'a -> bool;
 
 fn test_generic<T:Clone>(expected: T, eq: compare<T>) {
     let actual: T = match true {

--- a/src/test/run-pass/fn-coerce-field.rs
+++ b/src/test/run-pass/fn-coerce-field.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct r<'a> {
-    field: 'a ||
+    field: ||: 'a,
 }
 
 pub fn main() {

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -28,7 +28,7 @@ mod map_reduce {
     use std::str;
     use std::task;
 
-    pub type putter<'a> = 'a |~str, ~str|;
+    pub type putter<'a> = |~str, ~str|: 'a;
 
     pub type mapper = extern fn(~str, putter);
 

--- a/src/test/run-pass/issue-10767.rs
+++ b/src/test/run-pass/issue-10767.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-type Connection = |Vec<u8>|: 'static;
-
-fn f() -> Option<Connection> {
-    let mock_connection: Connection = |_| {};
-    Some(mock_connection)
-}
-
 pub fn main() {
+    fn f() {
+    };
+    let _: ~fn() = ~f;
 }

--- a/src/test/run-pass/issue-3904.rs
+++ b/src/test/run-pass/issue-3904.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type ErrPrinter<'a> = 'a |&str, &str|;
+type ErrPrinter<'a> = |&str, &str|: 'a;
 
 fn example_err(prog: &str, arg: &str) {
     println!("{}: {}", prog, arg)

--- a/src/test/run-pass/issue-6157.rs
+++ b/src/test/run-pass/issue-6157.rs
@@ -10,7 +10,7 @@
 
 pub trait OpInt<'a> { fn call<'a>(&'a self, int, int) -> int; }
 
-impl<'a> OpInt<'a> for 'a |int, int| -> int {
+impl<'a> OpInt<'a> for |int, int|: 'a -> int {
     fn call(&self, a:int, b:int) -> int {
         (*self)(a, b)
     }

--- a/src/test/run-pass/once-move-out-on-stack.rs
+++ b/src/test/run-pass/once-move-out-on-stack.rs
@@ -12,7 +12,7 @@
 
 // ignore-fast
 
-#[feature(once_fns)];
+#![feature(once_fns)]
 extern crate sync;
 use sync::Arc;
 

--- a/src/test/run-pass/regions-copy-closure.rs
+++ b/src/test/run-pass/regions-copy-closure.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct closure_box<'a> {
-    cl: 'a ||,
+    cl: ||: 'a,
 }
 
-fn box_it<'r>(x: 'r ||) -> closure_box<'r> {
+fn box_it<'r>(x: ||: 'r) -> closure_box<'r> {
     closure_box {cl: x}
 }
 

--- a/src/test/run-pass/regions-dependent-autofn.rs
+++ b/src/test/run-pass/regions-dependent-autofn.rs
@@ -11,9 +11,9 @@
 // Test lifetimes are linked properly when we autoslice a vector.
 // Issue #3148.
 
-fn subslice<'r>(v: 'r ||) -> 'r || { v }
+fn subslice<'r>(v: ||: 'r) -> ||: 'r { v }
 
-fn both<'r>(v: 'r ||) -> 'r || {
+fn both<'r>(v: ||: 'r) -> ||: 'r {
     subslice(subslice(v))
 }
 

--- a/src/test/run-pass/regions-static-closure.rs
+++ b/src/test/run-pass/regions-static-closure.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct closure_box<'a> {
-    cl: 'a ||,
+    cl: ||: 'a,
 }
 
-fn box_it<'r>(x: 'r ||) -> closure_box<'r> {
+fn box_it<'r>(x: ||: 'r) -> closure_box<'r> {
     closure_box {cl: x}
 }
 


### PR DESCRIPTION
In summary these are some example transitions this change makes:

```
'a ||       => ||: 'a
proc:Send() => proc():Send
```

The intended syntax for closures is to put the lifetime bound not at the front
but rather in the list of bounds. Currently there is no official support in the
AST for bounds that are not 'static, so this case is currently specially handled
in the parser to desugar to what the AST is expecting. Additionally, this moves
the bounds on procedures to the correct position, which is after the argument
list.

The current grammar for closures and procedures is:

```
procedure := 'proc' [ '<' lifetime-list '>' ] '(' arg-list ')'
                    [ ':' bound-list ] [ '->' type ]
closure := [ 'unsafe' ] ['<' lifetime-list '>' ] '|' arg-list '|'
                    [ ':' bound-list ] [ '->' type ]
lifetime-list := lifetime | lifetime ',' lifetime-list
arg-list := ident ':' type | ident ':' type ',' arg-list
bound-list := bound | bound '+' bound-list
bound := path | lifetime
```

This does not currently handle the << ambiguity in `Option<<'a>||>`, I am
deferring that to a later patch. Additionally, this removes the support for the
obsolete syntaxes of ~fn and &fn.

Closes #10553
Closes #10767 
Closes #11209
Closes #11210
Closes #11211
