### PR TITLE
Fix #12939: reporting of ignored tests in rustdoc

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -268,24 +268,25 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
     extern fn block(_ob: *buf, text: *buf, lang: *buf, opaque: *libc::c_void) {
         unsafe {
             if text.is_null() { return }
-            let (should_fail, no_run, ignore) = if lang.is_null() {
-                (false, false, false)
+            let (should_fail, no_run, ignore, notrust) = if lang.is_null() {
+                (false, false, false, false)
             } else {
                 slice::raw::buf_as_slice((*lang).data,
                                        (*lang).size as uint, |lang| {
                     let s = str::from_utf8(lang).unwrap();
                     (s.contains("should_fail"),
                      s.contains("no_run"),
-                     s.contains("ignore") || s.contains("notrust"))
+                     s.contains("ignore"),
+                     s.contains("notrust"))
                 })
             };
-            if ignore { return }
+            if notrust { return }
             slice::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {
                 let tests = &mut *(opaque as *mut ::test::Collector);
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().map(|l| stripped_filtered_line(l).unwrap_or(l));
                 let text = lines.collect::<~[&str]>().connect("\n");
-                tests.add_test(text, should_fail, no_run);
+                tests.add_test(text, should_fail, no_run, ignore);
             })
         }
     }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -217,7 +217,7 @@ impl Collector {
         }
     }
 
-    pub fn add_test(&mut self, test: ~str, should_fail: bool, no_run: bool) {
+    pub fn add_test(&mut self, test: ~str, should_fail: bool, no_run: bool, should_ignore: bool) {
         let name = if self.use_headers {
             let s = self.current_header.as_ref().map(|s| s.as_slice()).unwrap_or("");
             format!("{}_{}", s, self.cnt)
@@ -232,7 +232,7 @@ impl Collector {
         self.tests.push(testing::TestDescAndFn {
             desc: testing::TestDesc {
                 name: testing::DynTestName(name),
-                ignore: false,
+                ignore: should_ignore,
                 should_fail: false, // compiler failures are test failures
             },
             testfn: testing::DynTestFn(proc() {


### PR DESCRIPTION
librustdoc: instead of skipping ignored tests, pass them to libtest
so it can report them as such.  If a test is marked as `notrust`,
however, it will not show up in the final report.

Fix #12939
