### PR TITLE
std: make vec!() macro handle a trailing comma

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -273,7 +273,8 @@ macro_rules! vec(
         let mut _temp = ::std::vec::Vec::new();
         $(_temp.push($e);)*
         _temp
-    })
+    });
+    ($($e:expr),+,) => (vec!($($e),+))
 )
 
 

--- a/src/test/compile-fail/vec-macro-with-comma-only.rs
+++ b/src/test/compile-fail/vec-macro-with-comma-only.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    vec!(,); //~ ERROR unexpected token
+}

--- a/src/test/run-pass/vec-macro-with-trailing-comma.rs
+++ b/src/test/run-pass/vec-macro-with-trailing-comma.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+pub fn main() {
+    assert_eq!(vec!(1), vec!(1,));
+    assert_eq!(vec!(1, 2, 3), vec!(1, 2, 3,));
+}


### PR DESCRIPTION
Fixes #12910.
