### PR TITLE
std: override clone_from for Vec.

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -232,4 +232,5 @@ mod std {
     pub use to_str;
     pub use ty;
     pub use unstable;
+    pub use vec;
 }


### PR DESCRIPTION
std: override clone_from for Vec.

A vector can reuse its allocation (and the allocations/resources of any
contained values) when cloning into an already-instantiated vector, so
we might as well do so.
