### PR TITLE
After a hash mismatch error, emit file-system paths of crates involved.

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -232,6 +232,9 @@ impl Session {
     pub fn span_end_note(&self, sp: Span, msg: &str) {
         self.diagnostic().span_end_note(sp, msg)
     }
+    pub fn fileline_note(&self, sp: Span, msg: &str) {
+        self.diagnostic().fileline_note(sp, msg)
+    }
     pub fn note(&self, msg: &str) {
         self.diagnostic().handler().note(msg)
     }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -21,6 +21,7 @@ use metadata::cstore;
 use metadata::decoder;
 use metadata::loader;
 use metadata::loader::Os;
+use metadata::loader::CratePaths;
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -141,7 +142,7 @@ fn visit_view_item(e: &mut Env, i: &ast::ViewItem) {
 
     match extract_crate_info(e, i) {
         Some(info) => {
-            let cnum = resolve_crate(e, None, info.ident, &info.crate_id, None,
+            let cnum = resolve_crate(e, &None, info.ident, &info.crate_id, None,
                                      i.span);
             e.sess.cstore.add_extern_mod_stmt_cnum(info.id, cnum);
         }
@@ -278,13 +279,13 @@ fn existing_match(e: &Env, crate_id: &CrateId,
     None
 }
 
-fn resolve_crate(e: &mut Env,
-                 root_ident: Option<&str>,
-                 ident: &str,
-                 crate_id: &CrateId,
-                 hash: Option<&Svh>,
-                 span: Span)
-              -> ast::CrateNum {
+fn resolve_crate<'a>(e: &mut Env,
+                     root: &Option<CratePaths>,
+                     ident: &str,
+                     crate_id: &CrateId,
+                     hash: Option<&Svh>,
+                     span: Span)
+                     -> ast::CrateNum {
     match existing_match(e, crate_id, hash) {
         None => {
             let id_hash = link::crate_id_hash(crate_id);
@@ -297,11 +298,11 @@ fn resolve_crate(e: &mut Env,
                 hash: hash.map(|a| &*a),
                 os: e.os,
                 intr: e.intr.clone(),
-                rejected_via_hash: false,
+                rejected_via_hash: None,
             };
             let loader::Library {
                 dylib, rlib, metadata
-            } = load_ctxt.load_library_crate(root_ident);
+            } = load_ctxt.load_library_crate(root);
 
             let crate_id = decoder::get_crate_id(metadata.as_slice());
             let hash = decoder::get_crate_hash(metadata.as_slice());
@@ -316,15 +317,22 @@ fn resolve_crate(e: &mut Env,
             });
             e.next_crate_num += 1;
 
-            // Maintain a reference to the top most crate.
-            let root_crate = match root_ident {
-                Some(c) => c,
-                None => load_ctxt.ident.clone()
+            // Stash paths for top-most crate locally if necessary.
+            let crate_paths = if root.is_none() {
+                Some(CratePaths {
+                    ident: load_ctxt.ident.to_owned(),
+                    dylib: dylib.clone(),
+                    rlib:  rlib.clone(),
+                })
+            } else {
+                None
             };
+            // Maintain a reference to the top most crate.
+            let root = if root.is_some() { root } else { &crate_paths };
 
             // Now resolve the crates referenced by this crate
             let cnum_map = resolve_crate_deps(e,
-            Some(root_crate),
+            root,
             metadata.as_slice(),
             span);
 
@@ -349,7 +357,7 @@ fn resolve_crate(e: &mut Env,
 
 // Go through the crate metadata and load any crates that it references
 fn resolve_crate_deps(e: &mut Env,
-                      root_ident: Option<&str>,
+                      root: &Option<CratePaths>,
                       cdata: &[u8], span : Span)
                    -> cstore::cnum_map {
     debug!("resolving deps of external crate");
@@ -360,7 +368,7 @@ fn resolve_crate_deps(e: &mut Env,
     for dep in r.iter() {
         let extrn_cnum = dep.cnum;
         debug!("resolving dep crate {} hash: `{}`", dep.crate_id, dep.hash);
-        let local_cnum = resolve_crate(e, root_ident,
+        let local_cnum = resolve_crate(e, root,
                                        dep.crate_id.name.as_slice(),
                                        &dep.crate_id,
                                        Some(&dep.hash),
@@ -393,7 +401,7 @@ impl<'a> Loader<'a> {
 impl<'a> CrateLoader for Loader<'a> {
     fn load_crate(&mut self, krate: &ast::ViewItem) -> MacroCrate {
         let info = extract_crate_info(&self.env, krate).unwrap();
-        let cnum = resolve_crate(&mut self.env, None, info.ident,
+        let cnum = resolve_crate(&mut self.env, &None, info.ident,
                                  &info.crate_id, None, krate.span);
         let library = self.env.sess.cstore.get_used_crate_source(cnum).unwrap();
         MacroCrate {

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -298,7 +298,7 @@ fn resolve_crate<'a>(e: &mut Env,
                 hash: hash.map(|a| &*a),
                 os: e.os,
                 intr: e.intr.clone(),
-                rejected_via_hash: None,
+                rejected_via_hash: vec!(),
             };
             let loader::Library {
                 dylib, rlib, metadata

--- a/src/test/run-make/many-crates-but-no-match/Makefile
+++ b/src/test/run-make/many-crates-but-no-match/Makefile
@@ -1,0 +1,34 @@
+-include ../tools.mk
+
+# Modelled after compile-fail/changing-crates test, but this one puts
+# more than one (mismatching) candidate crate into the search path,
+# which did not appear directly expressible in compile-fail/aux-build
+# infrastructure.
+#
+# Note that we move the built libraries into target direcrtories rather than
+# use the `--out-dir` option because the `../tools.mk` file already bakes a
+# use of `--out-dir` into the definition of $(RUSTC).
+
+A1=$(TMPDIR)/a1
+A2=$(TMPDIR)/a2
+A3=$(TMPDIR)/a3
+
+# A hack to match distinct lines of output from a single run.
+LOG=$(TMPDIR)/log.txt
+
+all: 
+	mkdir -p $(A1) $(A2) $(A3)
+	$(RUSTC) --crate-type=rlib crateA1.rs
+	mv $(TMPDIR)/$(call RLIB_GLOB,crateA) $(A1)
+	$(RUSTC) --crate-type=rlib -L$(A1) crateB.rs
+	$(RUSTC) --crate-type=rlib crateA2.rs
+	mv $(TMPDIR)/$(call RLIB_GLOB,crateA) $(A2)
+	$(RUSTC) --crate-type=rlib crateA3.rs
+	mv $(TMPDIR)/$(call RLIB_GLOB,crateA) $(A3)
+	# Ensure crateC fails to compile since A1 is "missing" and A2/A3 hashes do not match
+	$(RUSTC) -L$(A2) -L$(A3) crateC.rs >$(LOG) 2>&1 || true
+	grep "error: found possibly newer version of crate \`crateA\` which \`crateB\` depends on" $(LOG)
+	grep "note: perhaps this crate needs to be recompiled?" $(LOG)
+	grep "note: crate \`crateA\` path #1:" $(LOG)
+	grep "note: crate \`crateA\` path #2:" $(LOG)
+	grep "note: crate \`crateB\` path #1:" $(LOG)

--- a/src/test/run-make/many-crates-but-no-match/crateA1.rs
+++ b/src/test/run-make/many-crates-but-no-match/crateA1.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_id="crateA"]
+
+// Base crate
+pub fn func<T>() {}

--- a/src/test/run-make/many-crates-but-no-match/crateA2.rs
+++ b/src/test/run-make/many-crates-but-no-match/crateA2.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_id="crateA"]
+
+// Base crate
+pub fn func<T>() { println!("hello"); }

--- a/src/test/run-make/many-crates-but-no-match/crateA3.rs
+++ b/src/test/run-make/many-crates-but-no-match/crateA3.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_id="crateA"]
+
+// Base crate
+pub fn foo<T>() { println!("world!"); }

--- a/src/test/run-make/many-crates-but-no-match/crateB.rs
+++ b/src/test/run-make/many-crates-but-no-match/crateB.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate crateA;

--- a/src/test/run-make/many-crates-but-no-match/crateC.rs
+++ b/src/test/run-make/many-crates-but-no-match/crateC.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate crateB;
+
+fn main() {}


### PR DESCRIPTION
Fix #13266.

There is a little bit of acrobatics in the definition of `crate_paths`
to avoid calling `clone()` on the dylib/rlib unless we actually are
going to need them.

The other oddity is that I have replaced the `root_ident: Option<&str>`
parameter with a `root: &Option<CratePaths>`, which may surprise one
who was expecting to see something like: `root: Option<&CratePaths>`.
I went with the approach here because I could not come up with code for
the alternative that was acceptable to the borrow checker.
