### PR TITLE
stop asking LLVM to null-terminate strings

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -581,7 +581,7 @@ pub fn C_u8(ccx: &CrateContext, i: uint) -> ValueRef {
 
 // This is a 'c-like' raw string, which differs from
 // our boxed-and-length-annotated strings.
-pub fn C_cstr(cx: &CrateContext, s: InternedString) -> ValueRef {
+pub fn C_cstr(cx: &CrateContext, s: InternedString, null_terminated: bool) -> ValueRef {
     unsafe {
         match cx.const_cstr_cache.borrow().find(&s) {
             Some(&llval) => return llval,
@@ -591,7 +591,7 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString) -> ValueRef {
         let sc = llvm::LLVMConstStringInContext(cx.llcx,
                                                 s.get().as_ptr() as *c_char,
                                                 s.get().len() as c_uint,
-                                                False);
+                                                !null_terminated as Bool);
 
         let gsym = token::gensym("str");
         let g = format!("str{}", gsym).with_c_str(|buf| {
@@ -611,7 +611,7 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString) -> ValueRef {
 pub fn C_str_slice(cx: &CrateContext, s: InternedString) -> ValueRef {
     unsafe {
         let len = s.get().len();
-        let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s), Type::i8p(cx).to_ref());
+        let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s, false), Type::i8p(cx).to_ref());
         C_struct(cx, [cs, C_uint(cx, len)], false)
     }
 }
@@ -940,7 +940,7 @@ pub fn filename_and_line_num_from_span(bcx: &Block, span: Span)
                                        -> (ValueRef, ValueRef) {
     let loc = bcx.sess().codemap().lookup_char_pos(span.lo);
     let filename_cstr = C_cstr(bcx.ccx(),
-                               token::intern_and_get_ident(loc.file.name));
+                               token::intern_and_get_ident(loc.file.name), true);
     let filename = build::PointerCast(bcx, filename_cstr, Type::i8p(bcx.ccx()));
     let line = C_int(bcx.ccx(), loc.line as int);
     (filename, line)

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -331,10 +331,10 @@ pub fn trans_fail<'a>(
                   fail_str: InternedString)
                   -> &'a Block<'a> {
     let ccx = bcx.ccx();
-    let v_fail_str = C_cstr(ccx, fail_str);
+    let v_fail_str = C_cstr(ccx, fail_str, true);
     let _icx = push_ctxt("trans_fail_value");
     let loc = bcx.sess().codemap().lookup_char_pos(sp.lo);
-    let v_filename = C_cstr(ccx, token::intern_and_get_ident(loc.file.name));
+    let v_filename = C_cstr(ccx, token::intern_and_get_ident(loc.file.name), true);
     let v_line = loc.line as int;
     let v_str = PointerCast(bcx, v_fail_str, Type::i8p(ccx));
     let v_filename = PointerCast(bcx, v_filename, Type::i8p(ccx));

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -2129,7 +2129,7 @@ fn type_metadata(cx: &CrateContext,
             let i8_t = ty::mk_i8();
             match *vstore {
                 ty::vstore_fixed(len) => {
-                    fixed_vec_metadata(cx, i8_t, len + 1, usage_site_span)
+                    fixed_vec_metadata(cx, i8_t, len, usage_site_span)
                 },
                 ty::vstore_uniq  => {
                     let vec_metadata = vec_metadata(cx, i8_t, usage_site_span);

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -62,7 +62,7 @@ impl<'a> Reflector<'a> {
         let str_ty = ty::mk_str(bcx.tcx(), str_vstore);
         let scratch = rvalue_scratch_datum(bcx, str_ty, "");
         let len = C_uint(bcx.ccx(), s.get().len());
-        let c_str = PointerCast(bcx, C_cstr(bcx.ccx(), s), Type::i8p(bcx.ccx()));
+        let c_str = PointerCast(bcx, C_cstr(bcx.ccx(), s, false), Type::i8p(bcx.ccx()));
         Store(bcx, c_str, GEPi(bcx, scratch.val, [ 0, 0 ]));
         Store(bcx, len, GEPi(bcx, scratch.val, [ 0, 1 ]));
         scratch.val

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -289,7 +289,7 @@ pub fn trans_lit_str<'a>(
             unsafe {
                 let bytes = str_lit.get().len();
                 let llbytes = C_uint(bcx.ccx(), bytes);
-                let llcstr = C_cstr(bcx.ccx(), str_lit);
+                let llcstr = C_cstr(bcx.ccx(), str_lit, false);
                 let llcstr = llvm::LLVMConstPointerCast(llcstr, Type::i8p(bcx.ccx()).to_ref());
                 Store(bcx, llcstr,
                       GEPi(bcx, lldest, [0u, abi::slice_elt_base]));
@@ -319,7 +319,7 @@ pub fn trans_uniq_vstore<'a>(bcx: &'a Block<'a>,
         ast::ExprLit(lit) => {
             match lit.node {
                 ast::LitStr(ref s, _) => {
-                    let llptrval = C_cstr(bcx.ccx(), (*s).clone());
+                    let llptrval = C_cstr(bcx.ccx(), (*s).clone(), false);
                     let llptrval = PointerCast(bcx,
                                                llptrval,
                                                Type::i8p(bcx.ccx()));
@@ -393,7 +393,7 @@ pub fn write_content<'a>(
                         SaveIn(lldest) => {
                             let bytes = s.get().len();
                             let llbytes = C_uint(bcx.ccx(), bytes);
-                            let llcstr = C_cstr(bcx.ccx(), (*s).clone());
+                            let llcstr = C_cstr(bcx.ccx(), (*s).clone(), false);
                             base::call_memcpy(bcx,
                                               lldest,
                                               llcstr,

--- a/src/test/debug-info/include_string.rs
+++ b/src/test/debug-info/include_string.rs
@@ -14,12 +14,12 @@
 // debugger:rbreak zzz
 // debugger:run
 // debugger:finish
-// debugger:print string1
-// check:$1 = [...]"some text to include in another file as string 1", length = 48}
-// debugger:print string2
-// check:$2 = [...]"some text to include in another file as string 2", length = 48}
-// debugger:print string3
-// check:$3 = [...]"some text to include in another file as string 3", length = 48}
+// debugger:print string1.length
+// check:$1 = 48
+// debugger:print string2.length
+// check:$2 = 48
+// debugger:print string3.length
+// check:$3 = 48
 // debugger:continue
 
 #[allow(unused_variable)];


### PR DESCRIPTION
This was missed when dropping the null-termination from our string
types. An explicit null byte can still be placed anywhere in a string if
desired, but there's no reason to stick one at the end of every string
constant.
