### PR TITLE
rustc: feature-gate `concat_idents!`.

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -49,6 +49,8 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("macro_registrar", Active),
     ("log_syntax", Active),
     ("trace_macros", Active),
+    ("concat_idents", Active),
+
     ("simd", Active),
     ("default_type_params", Active),
     ("quote", Active),
@@ -226,6 +228,11 @@ impl<'a> Visitor<()> for Context<'a> {
 
         else if id == token::str_to_ident("trace_macros") {
             self.gate_feature("trace_macros", path.span, "`trace_macros` is not \
+                stable enough for use and is subject to change");
+        }
+
+        else if id == token::str_to_ident("concat_idents") {
+            self.gate_feature("concat_idents", path.span, "`concat_idents` is not \
                 stable enough for use and is subject to change");
         }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -52,7 +52,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://static.rust-lang.org/doc/master")]
 #![feature(macro_rules, globs, asm, managed_boxes, thread_local, link_args,
-           simd, linkage, default_type_params, phase)]
+           simd, linkage, default_type_params, phase, concat_idents)]
 
 // Don't link to std. We are std.
 #![no_std]
@@ -60,6 +60,7 @@
 // #![deny(missing_doc)] // NOTE: uncomment after a stage0 snap
 #![allow(missing_doc)] // NOTE: remove after a stage0 snap
 #![allow(visible_private_types)] // NOTE: remove after a stage0 snap
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 // When testing libstd, bring in libuv as the I/O backend so tests can print
 // things and all of the std::io tests have an I/O interface to run on top

--- a/src/test/compile-fail/gated-concat_idents.rs
+++ b/src/test/compile-fail/gated-concat_idents.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    concat_idents!(a, b); //~ ERROR `concat_idents` is not stable enough
+}

--- a/src/test/compile-fail/macros-nonfatal-errors.rs
+++ b/src/test/compile-fail/macros-nonfatal-errors.rs
@@ -12,7 +12,7 @@
 // immediately, so that we get more errors listed at a time.
 
 #![feature(asm)]
-#![feature(trace_macros)]
+#![feature(trace_macros, concat_idents)]
 
 #[deriving(Default, //~ ERROR
            Rand, //~ ERROR

--- a/src/test/compile-fail/syntax-extension-minor.rs
+++ b/src/test/compile-fail/syntax-extension-minor.rs
@@ -10,6 +10,7 @@
 
 // this now fails (correctly, I claim) because hygiene prevents
 // the assembled identifier from being a reference to the binding.
+#![feature(concat_idents)]
 
 pub fn main() {
     let asdf_fdsa = ~"<.<";


### PR DESCRIPTION
rustc: feature-gate `concat_idents!`.

concat_idents! is not as useful as it could be, due to macros only being
allowed in limited places, and hygiene, so lets feature gate it until we
make a decision about it.

cc #13294
