### PR TITLE
Remove RefCell::get and RefCell::set

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -212,9 +212,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     let time_passes = sess.time_passes();
 
     sess.building_library.set(session::building_library(&sess.opts, &krate));
-    sess.crate_types.set(session::collect_crate_types(sess,
-                                                      krate.attrs
-                                                           .as_slice()));
+    *sess.crate_types.borrow_mut() = session::collect_crate_types(sess, krate.attrs.as_slice());
 
     time(time_passes, "gated feature checking", (), |_|
          front::feature_gate::check_crate(sess, &krate));

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -90,7 +90,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
     fn fold_item(&mut self, i: @ast::Item) -> SmallVector<@ast::Item> {
         self.cx.path.borrow_mut().push(i.ident);
         debug!("current path: {}",
-               ast_util::path_name_i(self.cx.path.get().as_slice()));
+               ast_util::path_name_i(self.cx.path.borrow().as_slice()));
 
         if is_test_fn(&self.cx, i) || is_bench_fn(&self.cx, i) {
             match i.node {
@@ -104,7 +104,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
                     debug!("this is a test function");
                     let test = Test {
                         span: i.span,
-                        path: self.cx.path.get(),
+                        path: self.cx.path.borrow().clone(),
                         bench: is_bench_fn(&self.cx, i),
                         ignore: is_ignored(&self.cx, i),
                         should_fail: should_fail(i)

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1345,7 +1345,7 @@ fn encode_info_for_items(ecx: &EncodeContext,
     }
 
     ebml_w.end_tag();
-    return /*bad*/(*index).get();
+    return /*bad*/index.borrow().clone();
 }
 
 
@@ -1365,7 +1365,7 @@ fn create_index<T:Clone + Hash + 'static>(
 
     let mut buckets_frozen = Vec::new();
     for bucket in buckets.iter() {
-        buckets_frozen.push(@/*bad*/(**bucket).get());
+        buckets_frozen.push(@/*bad*/bucket.borrow().clone());
     }
     return buckets_frozen;
 }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -270,7 +270,7 @@ fn create_and_seed_worklist(tcx: &ty::ctxt,
     }
 
     // Seed entry point
-    match tcx.sess.entry_fn.get() {
+    match *tcx.sess.entry_fn.borrow() {
         Some((id, _)) => worklist.push(id),
         None => ()
     }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -123,13 +123,13 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
 
 fn configure_main(this: &mut EntryContext) {
     if this.start_fn.is_some() {
-        this.session.entry_fn.set(this.start_fn);
+        *this.session.entry_fn.borrow_mut() = this.start_fn;
         this.session.entry_type.set(Some(session::EntryStart));
     } else if this.attr_main_fn.is_some() {
-        this.session.entry_fn.set(this.attr_main_fn);
+        *this.session.entry_fn.borrow_mut() = this.attr_main_fn;
         this.session.entry_type.set(Some(session::EntryMain));
     } else if this.main_fn.is_some() {
-        this.session.entry_fn.set(this.main_fn);
+        *this.session.entry_fn.borrow_mut() = this.main_fn;
         this.session.entry_type.set(Some(session::EntryMain));
     } else {
         if !this.session.building_library.get() {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -385,6 +385,10 @@ struct ImportResolution {
     type_id: Cell<NodeId>,
 }
 
+fn get<T: Clone>(cell: &RefCell<T>) -> T {
+    cell.borrow().clone()
+}
+
 impl ImportResolution {
     fn new(id: NodeId, is_public: bool) -> ImportResolution {
         ImportResolution {
@@ -400,8 +404,8 @@ impl ImportResolution {
     fn target_for_namespace(&self, namespace: Namespace)
                                 -> Option<Target> {
         match namespace {
-            TypeNS      => return self.type_target.get(),
-            ValueNS     => return self.value_target.get(),
+            TypeNS      => return self.type_target.borrow().clone(),
+            ValueNS     => return self.value_target.borrow().clone(),
         }
     }
 
@@ -546,7 +550,8 @@ impl NameBindings {
         // Merges the module with the existing type def or creates a new one.
         let module_ = @Module::new(parent_link, def_id, kind, external,
                                        is_public);
-        match self.type_def.get() {
+        let type_def = self.type_def.borrow().clone();
+        match type_def {
             None => {
                 self.type_def.set(Some(TypeNsDef {
                     is_public: is_public,
@@ -574,7 +579,8 @@ impl NameBindings {
                        external: bool,
                        is_public: bool,
                        _sp: Span) {
-        match self.type_def.get() {
+        let type_def = self.type_def.borrow().clone();
+        match type_def {
             None => {
                 let module = @Module::new(parent_link, def_id, kind,
                                               external, is_public);
@@ -609,7 +615,8 @@ impl NameBindings {
     /// Records a type definition.
     fn define_type(&self, def: Def, sp: Span, is_public: bool) {
         // Merges the type with the existing type def or creates a new one.
-        match self.type_def.get() {
+        let type_def = self.type_def.borrow().clone();
+        match type_def {
             None => {
                 self.type_def.set(Some(TypeNsDef {
                     module_def: None,
@@ -662,17 +669,17 @@ impl NameBindings {
 
     fn defined_in_namespace(&self, namespace: Namespace) -> bool {
         match namespace {
-            TypeNS   => return self.type_def.get().is_some(),
-            ValueNS  => return self.value_def.get().is_some()
+            TypeNS   => return self.type_def.borrow().is_some(),
+            ValueNS  => return self.value_def.borrow().is_some()
         }
     }
 
     fn defined_in_public_namespace(&self, namespace: Namespace) -> bool {
         match namespace {
-            TypeNS => match self.type_def.get() {
+            TypeNS => match *self.type_def.borrow() {
                 Some(def) => def.is_public, None => false
             },
-            ValueNS => match self.value_def.get() {
+            ValueNS => match *self.value_def.borrow() {
                 Some(def) => def.is_public, None => false
             }
         }
@@ -681,7 +688,7 @@ impl NameBindings {
     fn def_for_namespace(&self, namespace: Namespace) -> Option<Def> {
         match namespace {
             TypeNS => {
-                match self.type_def.get() {
+                match *self.type_def.borrow() {
                     None => None,
                     Some(type_def) => {
                         match type_def.type_def {
@@ -702,7 +709,7 @@ impl NameBindings {
                 }
             }
             ValueNS => {
-                match self.value_def.get() {
+                match *self.value_def.borrow() {
                     None => None,
                     Some(value_def) => Some(value_def.def)
                 }
@@ -714,13 +721,13 @@ impl NameBindings {
         if self.defined_in_namespace(namespace) {
             match namespace {
                 TypeNS  => {
-                    match self.type_def.get() {
+                    match *self.type_def.borrow() {
                         None => None,
                         Some(type_def) => type_def.type_span
                     }
                 }
                 ValueNS => {
-                    match self.value_def.get() {
+                    match *self.value_def.borrow() {
                         None => None,
                         Some(value_def) => value_def.value_span
                     }
@@ -1620,7 +1627,8 @@ impl<'a> Resolver<'a> {
         match def {
           DefMod(def_id) | DefForeignMod(def_id) | DefStruct(def_id) |
           DefTy(def_id) => {
-            match child_name_bindings.type_def.get() {
+            let type_def = child_name_bindings.type_def.borrow().clone();
+            match type_def {
               Some(TypeNsDef { module_def: Some(module_def), .. }) => {
                 debug!("(building reduced graph for external crate) \
                         already created module");
@@ -1812,7 +1820,8 @@ impl<'a> Resolver<'a> {
                                 // Process the static methods. First,
                                 // create the module.
                                 let type_module;
-                                match child_name_bindings.type_def.get() {
+                                let type_def = child_name_bindings.type_def.borrow().clone();
+                                match type_def {
                                     Some(TypeNsDef {
                                         module_def: Some(module_def),
                                         ..
@@ -2421,7 +2430,7 @@ impl<'a> Resolver<'a> {
         match type_result {
             BoundResult(target_module, name_bindings) => {
                 debug!("(resolving single import) found type target: {:?}",
-                       {name_bindings.type_def.get().unwrap().type_def});
+                       { name_bindings.type_def.borrow().clone().unwrap().type_def });
                 import_resolution.type_target.set(
                     Some(Target::new(target_module, name_bindings)));
                 import_resolution.type_id.set(directive.id);
@@ -2433,8 +2442,8 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        if import_resolution.value_target.get().is_none() &&
-           import_resolution.type_target.get().is_none() {
+        if import_resolution.value_target.borrow().is_none() &&
+           import_resolution.type_target.borrow().is_none() {
             let msg = format!("unresolved import: there is no \
                                `{}` in `{}`",
                               token::get_ident(source),
@@ -2452,7 +2461,7 @@ impl<'a> Resolver<'a> {
         // record what this import resolves to for later uses in documentation,
         // this may resolve to either a value or a type, but for documentation
         // purposes it's good enough to just favor one over the other.
-        let value_private = match import_resolution.value_target.get() {
+        let value_private = match *import_resolution.value_target.borrow() {
             Some(target) => {
                 let def = target.bindings.def_for_namespace(ValueNS).unwrap();
                 self.def_map.borrow_mut().insert(directive.id, def);
@@ -2463,7 +2472,7 @@ impl<'a> Resolver<'a> {
             // _exists is false.
             None => None,
         };
-        let type_private = match import_resolution.type_target.get() {
+        let type_private = match *import_resolution.type_target.borrow() {
             Some(target) => {
                 let def = target.bindings.def_for_namespace(TypeNS).unwrap();
                 self.def_map.borrow_mut().insert(directive.id, def);
@@ -2513,7 +2522,7 @@ impl<'a> Resolver<'a> {
         for (ident, target_import_resolution) in import_resolutions.iter() {
             debug!("(resolving glob import) writing module resolution \
                     {:?} into `{}`",
-                   target_import_resolution.type_target.get().is_none(),
+                   target_import_resolution.type_target.borrow().is_none(),
                    self.module_to_str(module_));
 
             if !target_import_resolution.is_public.get() {
@@ -2529,9 +2538,9 @@ impl<'a> Resolver<'a> {
                     let new_import_resolution =
                         @ImportResolution::new(id, is_public);
                     new_import_resolution.value_target.set(
-                        target_import_resolution.value_target.get());
+                        get(&target_import_resolution.value_target));
                     new_import_resolution.type_target.set(
-                        target_import_resolution.type_target.get());
+                        get(&target_import_resolution.type_target));
 
                     import_resolutions.insert
                         (*ident, new_import_resolution);
@@ -2540,7 +2549,7 @@ impl<'a> Resolver<'a> {
                     // Merge the two import resolutions at a finer-grained
                     // level.
 
-                    match target_import_resolution.value_target.get() {
+                    match *target_import_resolution.value_target.borrow() {
                         None => {
                             // Continue.
                         }
@@ -2549,7 +2558,7 @@ impl<'a> Resolver<'a> {
                                 Some(value_target));
                         }
                     }
-                    match target_import_resolution.type_target.get() {
+                    match *target_import_resolution.type_target.borrow() {
                         None => {
                             // Continue.
                         }
@@ -2692,7 +2701,7 @@ impl<'a> Resolver<'a> {
                 Success((target, used_proxy)) => {
                     // Check to see whether there are type bindings, and, if
                     // so, whether there is a module within.
-                    match target.bindings.type_def.get() {
+                    match *target.bindings.type_def.borrow() {
                         Some(type_def) => {
                             match type_def.module_def {
                                 None => {
@@ -3004,7 +3013,7 @@ impl<'a> Resolver<'a> {
         match resolve_result {
             Success((target, _)) => {
                 let bindings = &*target.bindings;
-                match bindings.type_def.get() {
+                match *bindings.type_def.borrow() {
                     Some(type_def) => {
                         match type_def.module_def {
                             None => {
@@ -4526,8 +4535,8 @@ impl<'a> Resolver<'a> {
                 debug!("(resolve bare identifier pattern) succeeded in \
                          finding {} at {:?}",
                         token::get_ident(name),
-                        target.bindings.value_def.get());
-                match target.bindings.value_def.get() {
+                        target.bindings.value_def.borrow());
+                match *target.bindings.value_def.borrow() {
                     None => {
                         fail!("resolved name in the value namespace to a \
                               set of name bindings with no def?!");

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1128,7 +1128,7 @@ pub fn make_return_pointer(fcx: &FunctionContext, output_type: ty::t)
             llvm::LLVMGetParam(fcx.llfn, 0)
         } else {
             let lloutputtype = type_of::type_of(fcx.ccx, output_type);
-            let bcx = fcx.entry_bcx.get().unwrap();
+            let bcx = fcx.entry_bcx.borrow().clone().unwrap();
             Alloca(bcx, lloutputtype, "__make_return_pointer")
         }
     }
@@ -1399,7 +1399,7 @@ pub fn trans_closure(ccx: &CrateContext,
 
     // Create the first basic block in the function and keep a handle on it to
     //  pass to finish_fn later.
-    let bcx_top = fcx.entry_bcx.get().unwrap();
+    let bcx_top = fcx.entry_bcx.borrow().clone().unwrap();
     let mut bcx = bcx_top;
     let block_ty = node_id_type(bcx, body.id);
 
@@ -1547,7 +1547,7 @@ fn trans_enum_variant_or_tuple_like_struct(ccx: &CrateContext,
 
     let arg_datums = create_datums_for_fn_args(&fcx, arg_tys.as_slice());
 
-    let bcx = fcx.entry_bcx.get().unwrap();
+    let bcx = fcx.entry_bcx.borrow().clone().unwrap();
 
     if !type_is_zero_size(fcx.ccx, result_ty) {
         let repr = adt::represent_type(ccx, result_ty);
@@ -1752,7 +1752,7 @@ pub fn register_fn_llvmty(ccx: &CrateContext,
 }
 
 pub fn is_entry_fn(sess: &Session, node_id: ast::NodeId) -> bool {
-    match sess.entry_fn.get() {
+    match *sess.entry_fn.borrow() {
         Some((entry_id, _)) => node_id == entry_id,
         None => false
     }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1209,7 +1209,7 @@ pub fn init_function<'a>(
                      param_substs: Option<@param_substs>) {
     let entry_bcx = fcx.new_temp_block("entry-block");
 
-    fcx.entry_bcx.set(Some(entry_bcx));
+    *fcx.entry_bcx.borrow_mut() = Some(entry_bcx);
 
     // Use a dummy instruction as the insertion point for all allocas.
     // This is later removed in FunctionContext::cleanup.

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -464,7 +464,7 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
     let arena = TypedArena::new();
     let fcx = new_fn_ctxt(ccx, llfn, -1, true, f.sig.output, None, None, &arena);
     init_function(&fcx, true, f.sig.output, None);
-    let bcx = fcx.entry_bcx.get().unwrap();
+    let bcx = fcx.entry_bcx.borrow().clone().unwrap();
 
     let args = create_datums_for_fn_args(&fcx,
                                          ty::ty_fn_args(closure_ty)

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -322,7 +322,7 @@ impl<'a> FunctionContext<'a> {
                                                      .unwrap());
         }
         // Remove the cycle between fcx and bcx, so memory can be freed
-        self.entry_bcx.set(None);
+        *self.entry_bcx.borrow_mut() = None;
     }
 
     pub fn get_llreturn(&self) -> BasicBlockRef {

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -463,7 +463,7 @@ fn make_generic_glue(ccx: &CrateContext,
     // llfn is expected be declared to take a parameter of the appropriate
     // type, so we don't need to explicitly cast the function parameter.
 
-    let bcx = fcx.entry_bcx.get().unwrap();
+    let bcx = fcx.entry_bcx.borrow().clone().unwrap();
     let llrawptr0 = unsafe { llvm::LLVMGetParam(llfn, fcx.arg_pos(0) as c_uint) };
     let bcx = helper(bcx, llrawptr0, t);
     finish_fn(&fcx, bcx);

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -199,7 +199,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
 
     set_always_inline(fcx.llfn);
 
-    let mut bcx = fcx.entry_bcx.get().unwrap();
+    let mut bcx = fcx.entry_bcx.borrow().clone().unwrap();
     let first_real_arg = fcx.arg_pos(0u);
 
     let name = token::get_ident(item.ident);

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -300,7 +300,7 @@ impl<'a> Reflector<'a> {
                     //
                     llvm::LLVMGetParam(llfdecl, fcx.arg_pos(0u) as c_uint)
                 };
-                let bcx = fcx.entry_bcx.get().unwrap();
+                let bcx = fcx.entry_bcx.borrow().clone().unwrap();
                 let arg = BitCast(bcx, arg, llptrty);
                 let ret = adt::trans_get_discr(bcx, repr, arg, Some(Type::i64(ccx)));
                 Store(bcx, ret, fcx.llretptr.get().unwrap());

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3333,7 +3333,7 @@ pub fn check_block_with_expected(fcx: &FnCtxt,
         };
     });
 
-    fcx.ps.set(prev);
+    *fcx.ps.borrow_mut() = prev;
 }
 
 pub fn check_const(ccx: &CrateCtxt,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2209,8 +2209,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         fcx.write_ty(expr.id, fty);
 
         let (inherited_purity, id) =
-            ty::determine_inherited_purity((fcx.ps.get().purity,
-                                            fcx.ps.get().def),
+            ty::determine_inherited_purity((fcx.ps.borrow().purity,
+                                            fcx.ps.borrow().def),
                                            (purity, expr.id),
                                            sigil);
 

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -398,7 +398,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
            expr.repr(rcx.fcx.tcx()), rcx.repeating_scope);
 
     let method_call = MethodCall::expr(expr.id);
-    let has_method_map = rcx.fcx.inh.method_map.get().contains_key(&method_call);
+    let has_method_map = rcx.fcx.inh.method_map.borrow().contains_key(&method_call);
 
     // Check any autoderefs or autorefs that appear.
     for &adjustment in rcx.fcx.inh.adjustments.borrow().find(&expr.id).iter() {
@@ -498,7 +498,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
         ast::ExprUnary(ast::UnDeref, base) => {
             // For *a, the lifetime of a must enclose the deref
             let method_call = MethodCall::expr(expr.id);
-            let base_ty = match rcx.fcx.inh.method_map.get().find(&method_call) {
+            let base_ty = match rcx.fcx.inh.method_map.borrow().find(&method_call) {
                 Some(method) => {
                     constrain_call(rcx, None, expr, Some(base), [], true);
                     ty::ty_fn_ret(method.ty)
@@ -852,7 +852,7 @@ fn constrain_autoderefs(rcx: &mut Rcx,
                i, derefs);
 
         let method_call = MethodCall::autoderef(deref_expr.id, i as u32);
-        derefd_ty = match rcx.fcx.inh.method_map.get().find(&method_call) {
+        derefd_ty = match rcx.fcx.inh.method_map.borrow().find(&method_call) {
             Some(method) => {
                 // Treat overloaded autoderefs as if an AutoRef adjustment
                 // was applied on the base type, as that is always the case.

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1286,6 +1286,6 @@ impl LifeGiver {
     }
 
     fn get_generated_lifetimes(&self) -> Vec<ast::Lifetime> {
-        self.generated.get()
+        self.generated.borrow().clone()
     }
 }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -431,7 +431,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
 fn check_for_entry_fn(ccx: &CrateCtxt) {
     let tcx = ccx.tcx;
     if !tcx.sess.building_library.get() {
-        match tcx.sess.entry_fn.get() {
+        match *tcx.sess.entry_fn.borrow() {
           Some((id, sp)) => match tcx.sess.entry_type.get() {
               Some(session::EntryMain) => check_main_fn_ty(ccx, id, sp),
               Some(session::EntryStart) => check_start_fn_ty(ccx, id, sp),

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -176,21 +176,9 @@ impl<T> RefCell<T> {
     }
 }
 
-impl<T:Clone> RefCell<T> {
-    /// Returns a copy of the contained value.
-    ///
-    /// # Failure
-    ///
-    /// Fails if the value is currently mutably borrowed.
-    #[inline]
-    pub fn get(&self) -> T {
-        (*self.borrow()).clone()
-    }
-}
-
 impl<T: Clone> Clone for RefCell<T> {
     fn clone(&self) -> RefCell<T> {
-        RefCell::new(self.get())
+        RefCell::new(self.borrow().clone())
     }
 }
 
@@ -216,7 +204,7 @@ impl<'b, T> Drop for Ref<'b, T> {
 impl<'b, T> Deref<T> for Ref<'b, T> {
     #[inline]
     fn deref<'a>(&'a self) -> &'a T {
-        unsafe{ &*self.parent.value.get() }
+        unsafe { &*self.parent.value.get() }
     }
 }
 
@@ -236,14 +224,14 @@ impl<'b, T> Drop for RefMut<'b, T> {
 impl<'b, T> Deref<T> for RefMut<'b, T> {
     #[inline]
     fn deref<'a>(&'a self) -> &'a T {
-        unsafe{ &*self.parent.value.get() }
+        unsafe { &*self.parent.value.get() }
     }
 }
 
 impl<'b, T> DerefMut<T> for RefMut<'b, T> {
     #[inline]
     fn deref_mut<'a>(&'a mut self) -> &'a mut T {
-        unsafe{ &mut *self.parent.value.get() }
+        unsafe { &mut *self.parent.value.get() }
     }
 }
 

--- a/src/libstd/cell.rs
+++ b/src/libstd/cell.rs
@@ -164,16 +164,6 @@ impl<T> RefCell<T> {
             None => fail!("RefCell<T> already borrowed")
         }
     }
-
-    /// Sets the value, replacing what was there.
-    ///
-    /// # Failure
-    ///
-    /// Fails if the value is currently borrowed.
-    #[inline]
-    pub fn set(&self, value: T) {
-        *self.borrow_mut() = value;
-    }
 }
 
 impl<T: Clone> Clone for RefCell<T> {

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -652,7 +652,7 @@ mod tests {
            fn drop(&mut self) {
                 let ii = &*self.i;
                 let i = ii.borrow().clone();
-                ii.set(i + 1);
+                *ii.borrow_mut() = i + 1;
             }
         }
 

--- a/src/libstd/option.rs
+++ b/src/libstd/option.rs
@@ -651,7 +651,8 @@ mod tests {
         impl ::ops::Drop for R {
            fn drop(&mut self) {
                 let ii = &*self.i;
-                ii.set(ii.get() + 1);
+                let i = ii.borrow().clone();
+                ii.set(i + 1);
             }
         }
 
@@ -667,7 +668,7 @@ mod tests {
             let opt = Some(x);
             let _y = opt.unwrap();
         }
-        assert_eq!(i.get(), 1);
+        assert_eq!(*i.borrow(), 1);
     }
 
     #[test]

--- a/src/test/auxiliary/issue-2631-a.rs
+++ b/src/test/auxiliary/issue-2631-a.rs
@@ -21,5 +21,5 @@ pub type header_map = HashMap<~str, @RefCell<Vec<@~str>>>;
 
 // the unused ty param is necessary so this gets monomorphized
 pub fn request<T>(req: &header_map) {
-  let _x = (**((**req.get(&~"METHOD")).clone()).get().get(0)).clone();
+  let _x = (**((**req.get(&~"METHOD")).clone()).borrow().clone().get(0)).clone();
 }

--- a/src/test/run-pass/cycle-collection.rs
+++ b/src/test/run-pass/cycle-collection.rs
@@ -19,7 +19,7 @@ enum taggy {
 
 fn f() {
     let a_box = @RefCell::new(nil);
-    a_box.set(cons(a_box));
+    *a_box.borrow_mut() = cons(a_box);
 }
 
 pub fn main() {

--- a/src/test/run-pass/issue-980.rs
+++ b/src/test/run-pass/issue-980.rs
@@ -23,7 +23,7 @@ struct Pointy {
 
 pub fn main() {
     let m = @RefCell::new(Pointy { x : no_pointy });
-    m.set(Pointy {
+    *m.borrow_mut() = Pointy {
         x: yes_pointy(m)
-    });
+    };
 }

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -17,6 +17,9 @@ use std::os;
 use std::str;
 
 // lifted from the test module
+// Inlining to avoid llvm turning the recursive functions into tail calls,
+// which doesn't consume stack.
+#[inline(always)]
 pub fn black_box<T>(dummy: T) { unsafe { asm!("" : : "r"(&dummy)) } }
 
 fn silent_recurse() {


### PR DESCRIPTION
`RefCell::get` can be a bit surprising, because it actually clones the wrapped value. This removes `RefCell::get` and replaces all the users with `RefCell::borrow()` when it can, and `RefCell::borrow().clone()` when it can't. It removes `RefCell::set` for consistency. This closes #13182.

It also fixes an infinite loop in a test when debugging is on.
