### PR TITLE
TrieSet should impl Set/MutableSet; add with_capacity to PriorityQueue/SmallIntMap

### DIFF
--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -117,6 +117,11 @@ impl<T:Ord> PriorityQueue<T> {
     /// Create an empty PriorityQueue
     pub fn new() -> PriorityQueue<T> { PriorityQueue{data: ~[],} }
 
+    /// Create an empty PriorityQueue with capacity `capacity`
+    pub fn with_capacity(capacity: uint) -> PriorityQueue<T> {
+        PriorityQueue { data: slice::with_capacity(capacity) }
+    }
+
     /// Create a PriorityQueue from a vector (heapify)
     pub fn from_vec(xs: ~[T]) -> PriorityQueue<T> {
         let mut q = PriorityQueue{data: xs,};

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -112,6 +112,11 @@ impl<V> SmallIntMap<V> {
     /// Create an empty SmallIntMap
     pub fn new() -> SmallIntMap<V> { SmallIntMap{v: ~[]} }
 
+    /// Create an empty SmallIntMap with capacity `capacity`
+    pub fn with_capacity(capacity: uint) -> SmallIntMap<V> {
+        SmallIntMap { v: slice::with_capacity(capacity) }
+    }
+
     pub fn get<'a>(&'a self, key: &uint) -> &'a V {
         self.find(key).expect("key not present")
     }

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -293,31 +293,45 @@ impl Mutable for TrieSet {
     fn clear(&mut self) { self.map.clear() }
 }
 
+impl Set<uint> for TrieSet {
+    #[inline]
+    fn contains(&self, value: &uint) -> bool {
+        self.map.contains_key(value)
+    }
+
+    #[inline]
+    fn is_disjoint(&self, other: &TrieSet) -> bool {
+        self.iter().all(|v| !other.contains(&v))
+    }
+
+    #[inline]
+    fn is_subset(&self, other: &TrieSet) -> bool {
+        self.iter().all(|v| other.contains(&v))
+    }
+
+    #[inline]
+    fn is_superset(&self, other: &TrieSet) -> bool {
+        other.is_subset(self)
+    }
+}
+
+impl MutableSet<uint> for TrieSet {
+    #[inline]
+    fn insert(&mut self, value: uint) -> bool {
+        self.map.insert(value, ())
+    }
+
+    #[inline]
+    fn remove(&mut self, value: &uint) -> bool {
+        self.map.remove(value)
+    }
+}
+
 impl TrieSet {
     /// Create an empty TrieSet
     #[inline]
     pub fn new() -> TrieSet {
         TrieSet{map: TrieMap::new()}
-    }
-
-    /// Return true if the set contains a value
-    #[inline]
-    pub fn contains(&self, value: &uint) -> bool {
-        self.map.contains_key(value)
-    }
-
-    /// Add a value to the set. Return true if the value was not already
-    /// present in the set.
-    #[inline]
-    pub fn insert(&mut self, value: uint) -> bool {
-        self.map.insert(value, ())
-    }
-
-    /// Remove a value from the set. Return true if the value was
-    /// present in the set.
-    #[inline]
-    pub fn remove(&mut self, value: &uint) -> bool {
-        self.map.remove(value)
     }
 
     /// Visit all values in reverse order


### PR DESCRIPTION
Two minor tweaks to collections. This makes `TrieSet` implement `Set` and `MutableSet`. It also allows preinitialization of `PriorityQueue` and `SmallIntMap`.

This is a rebased version of #13061.
