### PR TITLE
Add stdlib docs to the Linux binary tarball.

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -215,7 +215,7 @@ dist-install-dir-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
 dist-install-dir-$(1): PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
 dist-install-dir-$(1): PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
 dist-install-dir-$(1): PREPARE_CLEAN=true
-dist-install-dir-$(1): prepare-base-dir-$(1)
+dist-install-dir-$(1): prepare-base-dir-$(1) docs compiler-docs
 	$$(Q)(cd $$(PREPARE_DEST_DIR)/ && find . -type f | sed 's/^\.\///') \
       > tmp/dist/manifest-$(1).in
 	$$(Q)mv tmp/dist/manifest-$(1).in $$(PREPARE_DEST_DIR)/$$(CFG_LIBDIR_RELATIVE)/rustlib/manifest.in
@@ -224,6 +224,7 @@ dist-install-dir-$(1): prepare-base-dir-$(1)
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)LICENSE-APACHE $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)LICENSE-MIT $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)README.md $$(PREPARE_DEST_DIR)
+	$$(Q)cp -r doc $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_BIN_CMD) $$(S)src/etc/install.sh $$(PREPARE_DEST_DIR)
 
 dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)


### PR DESCRIPTION
Add stdlib docs to the Linux binary tarball.

These are not installed anywhere, but are included under `./doc` for
those who want an offline copy with their nightlies. This increases the
size of the (compressed) tarball from 76 to 83 MB.

I don't know if it's sane (or possible) to do something similar for the windows .exe/OSX .pkg things.
