### PR TITLE
Fix inner attribute syntax from `#[foo];` to `#![foo]`

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -294,7 +294,7 @@ asm!(assembly template
    );
 ```
 
-Any use of `asm` is feature gated (requires `#[feature(asm)];` on the
+Any use of `asm` is feature gated (requires `#![feature(asm)]` on the
 crate to allow) and of course requires an `unsafe` block.
 
 > **Note**: the examples here are given in x86/x86-64 assembly, but all
@@ -306,7 +306,7 @@ The `assembly template` is the only required parameter and must be a
 literal string (i.e `""`)
 
 ```
-#[feature(asm)];
+#![feature(asm)]
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]
@@ -334,7 +334,7 @@ Output operands, input operands, clobbers and options are all optional
 but you must add the right number of `:` if you skip them:
 
 ```
-# #[feature(asm)];
+# #![feature(asm)]
 # #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
 # fn main() { unsafe {
 asm!("xor %eax, %eax"
@@ -348,7 +348,7 @@ asm!("xor %eax, %eax"
 Whitespace also doesn't matter:
 
 ```
-# #[feature(asm)];
+# #![feature(asm)]
 # #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
 # fn main() { unsafe {
 asm!("xor %eax, %eax" ::: "eax");
@@ -362,7 +362,7 @@ Input and output operands follow the same format: `:
 expressions must be mutable lvalues:
 
 ```
-# #[feature(asm)];
+# #![feature(asm)]
 # #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
 fn add(a: int, b: int) -> int {
     let mut c = 0;
@@ -390,7 +390,7 @@ compiler not to assume any values loaded into those registers will
 stay valid.
 
 ```
-# #[feature(asm)];
+# #![feature(asm)]
 # #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
 # fn main() { unsafe {
 // Put the value 0x200 in eax

--- a/src/doc/po/ja/rust.md.po
+++ b/src/doc/po/ja/rust.md.po
@@ -1,5 +1,5 @@
 # Japanese translations for Rust package
-# Copyright (C) 2013 The Rust Project Developers
+# Copyright (C) 2013-2014 The Rust Project Developers
 # This file is distributed under the same license as the Rust package.
 # Automatically generated, 2013.
 #
@@ -886,7 +886,7 @@ msgstr ""
 #: src/doc/rust.md:2008
 #, fuzzy
 #| msgid "~~~~ use std::task::spawn;"
-msgid "~~~~ {.ignore} #[warn(unstable)];"
+msgid "~~~~ {.ignore} #![warn(unstable)]"
 msgstr ""
 "~~~~\n"
 "use std::task::spawn;"

--- a/src/etc/combine-tests.py
+++ b/src/etc/combine-tests.py
@@ -54,7 +54,7 @@ c.write(
 #[crate_id=\"run_pass_stage2#0.1\"];
 #[crate_id=\"run_pass_stage2#0.1\"];
 #[feature(globs, macro_rules, struct_variant, managed_boxes)];
-#[allow(warnings)];
+#![allow(warnings)]
 extern crate collections;
 """
 )

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,7 +15,7 @@ Utilities for program-wide and customizable logging
 ## Example
 
 ```
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)] extern crate log;
 
 fn main() {

--- a/src/liblog/macros.rs
+++ b/src/liblog/macros.rs
@@ -21,7 +21,7 @@
 /// # Example
 ///
 /// ```
-/// #[feature(phase)];
+/// #![feature(phase)]
 /// #[phase(syntax, link)] extern crate log;
 ///
 /// # fn main() {
@@ -45,7 +45,7 @@ macro_rules! log(
 /// # Example
 ///
 /// ```
-/// #[feature(phase)];
+/// #![feature(phase)]
 /// #[phase(syntax, link)] extern crate log;
 ///
 /// # fn main() {
@@ -63,7 +63,7 @@ macro_rules! error(
 /// # Example
 ///
 /// ```
-/// #[feature(phase)];
+/// #![feature(phase)]
 /// #[phase(syntax, link)] extern crate log;
 ///
 /// # fn main() {
@@ -81,7 +81,7 @@ macro_rules! warn(
 /// # Example
 ///
 /// ```
-/// #[feature(phase)];
+/// #![feature(phase)]
 /// #[phase(syntax, link)] extern crate log;
 ///
 /// # fn main() {
@@ -101,7 +101,7 @@ macro_rules! info(
 /// # Example
 ///
 /// ```
-/// #[feature(phase)];
+/// #![feature(phase)]
 /// #[phase(syntax, link)] extern crate log;
 ///
 /// # fn main() {
@@ -118,7 +118,7 @@ macro_rules! debug(
 /// # Example
 ///
 /// ```
-/// #[feature(phase)];
+/// #![feature(phase)]
 /// #[phase(syntax, link)] extern crate log;
 ///
 /// # fn main() {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/auxiliary/issue_2316_b.rs
+++ b/src/test/auxiliary/issue_2316_b.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[allow(unused_imports)];
-#[feature(globs)];
+#![feature(globs)]
 
 extern crate issue_2316_a;
 

--- a/src/test/auxiliary/logging_right_crate.rs
+++ b/src/test/auxiliary/logging_right_crate.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)] extern crate log;
 
 pub fn foo<T>() {

--- a/src/test/compile-fail/import-glob-0.rs
+++ b/src/test/compile-fail/import-glob-0.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // error-pattern: unresolved name
 
-#[feature(globs)];
+#![feature(globs)]
 
 use module_of_many_things::*;
 

--- a/src/test/compile-fail/import-glob-circular.rs
+++ b/src/test/compile-fail/import-glob-circular.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // error-pattern: unresolved
 
-#[feature(globs)];
+#![feature(globs)]
 
 mod circ1 {
     pub use circ2::f2;

--- a/src/test/compile-fail/name-clash-nullary.rs
+++ b/src/test/compile-fail/name-clash-nullary.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 
 // error-pattern:declaration of `None` shadows
 use std::option::*;

--- a/src/test/compile-fail/qquote-1.rs
+++ b/src/test/compile-fail/qquote-1.rs
@@ -10,7 +10,7 @@
 
 // ignore-test Can't use syntax crate here
 
-#[feature(quote)];
+#![feature(quote)]
 
 extern crate syntax;
 

--- a/src/test/compile-fail/qquote-2.rs
+++ b/src/test/compile-fail/qquote-2.rs
@@ -10,7 +10,7 @@
 
 // ignore-test Can't use syntax crate here
 
-#[feature(quote)];
+#![feature(quote)]
 
 extern crate syntax;
 

--- a/src/test/debug-info/simd.rs
+++ b/src/test/debug-info/simd.rs
@@ -40,7 +40,7 @@
 
 // debugger:continue
 
-#[allow(experimental)];
+#![allow(experimental)]
 #[allow(unused_variable)];
 
 use std::unstable::simd::{i8x16, i16x8,i32x4,i64x2,u8x16,u16x8,u32x4,u64x2,f32x4,f64x2};

--- a/src/test/pretty/raw-str-nonexpr.rs
+++ b/src/test/pretty/raw-str-nonexpr.rs
@@ -11,7 +11,7 @@
 // ignore-fast #[feature] doesn't work with check-fast
 // pp-exact
 
-#[feature(asm)];
+#![feature(asm)]
 
 #[cfg = r#"just parse this"#]
 extern crate blah = r##"blah"##;

--- a/src/test/run-fail/glob-use-std.rs
+++ b/src/test/run-fail/glob-use-std.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,7 +11,7 @@
 // Issue #7580
 
 // error-pattern:fail works
-#[feature(globs)];
+#![feature(globs)]
 
 use std::*;
 

--- a/src/test/run-fail/rt-set-exit-status-fail.rs
+++ b/src/test/run-fail/rt-set-exit-status-fail.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // error-pattern:whatever
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)] extern crate log;
 use std::os;
 

--- a/src/test/run-fail/rt-set-exit-status-fail2.rs
+++ b/src/test/run-fail/rt-set-exit-status-fail2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // error-pattern:whatever
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)] extern crate log;
 use std::os;
 use std::task;

--- a/src/test/run-fail/rt-set-exit-status.rs
+++ b/src/test/run-fail/rt-set-exit-status.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // error-pattern:whatever
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)] extern crate log;
 use std::os;
 

--- a/src/test/run-pass-fulldeps/macro-crate-outlive-expansion-phase.rs
+++ b/src/test/run-pass-fulldeps/macro-crate-outlive-expansion-phase.rs
@@ -14,7 +14,7 @@
 // ignore-android
 // ignore-cross-compile #12102
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax)]
 extern crate macro_crate_outlive_expansion_phase;

--- a/src/test/run-pass-fulldeps/macro-crate.rs
+++ b/src/test/run-pass-fulldeps/macro-crate.rs
@@ -14,7 +14,7 @@
 // ignore-android
 // ignore-cross-compile #12102
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax)]
 extern crate macro_crate_test;

--- a/src/test/run-pass-fulldeps/phase-syntax-link-does-resolve.rs
+++ b/src/test/run-pass-fulldeps/phase-syntax-link-does-resolve.rs
@@ -24,7 +24,7 @@
 // can't run host binaries, and force-host to make this test build as the host
 // arch.
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax, link)]
 extern crate macro_crate_test;

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -11,7 +11,7 @@
 // ignore-pretty
 // ignore-test
 
-#[feature(quote)];
+#![feature(quote)]
 
 extern crate syntax;
 

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -10,7 +10,7 @@
 
 // ignore-test
 
-#[feature(quote)];
+#![feature(quote)]
 #[feature(managed_boxes)];
 
 extern crate syntax;

--- a/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
+++ b/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast
 // ignore-android
-#[feature(quote)];
+#![feature(quote)]
 #[deny(unused_variable)];
 
 extern crate syntax;

--- a/src/test/run-pass-fulldeps/syntax-extension-fourcc.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-fourcc.rs
@@ -13,7 +13,7 @@
 // ignore-pretty
 // ignore-cross-compile
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax)]
 extern crate fourcc;

--- a/src/test/run-pass-fulldeps/syntax-extension-hexfloat.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-hexfloat.rs
@@ -13,7 +13,7 @@
 // ignore-cross-compile #12102
 // ignore-fast
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax)]
 extern crate hexfloat;
 

--- a/src/test/run-pass/asm-concat-src.rs
+++ b/src/test/run-pass/asm-concat-src.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-fast #[feature] doesn't work with check-fast
-#[feature(asm)];
+#![feature(asm)]
 
 pub fn main() {
     unsafe { asm!(concat!("", "")) };

--- a/src/test/run-pass/asm-in-out-operand.rs
+++ b/src/test/run-pass/asm-in-out-operand.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-fast #[feature] doesn't work with check-fast
-#[feature(asm)];
+#![feature(asm)]
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]

--- a/src/test/run-pass/asm-out-assign.rs
+++ b/src/test/run-pass/asm-out-assign.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-fast #[feature] doesn't work with check-fast
-#[feature(asm)];
+#![feature(asm)]
 
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -12,7 +12,7 @@
 // ignore-android (FIXME #11419)
 // exec-env:RUST_LOG=info
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax, link)]
 extern crate log;

--- a/src/test/run-pass/conditional-debug-macro-off.rs
+++ b/src/test/run-pass/conditional-debug-macro-off.rs
@@ -12,7 +12,7 @@
 // compile-flags: --cfg ndebug
 // exec-env:RUST_LOG=conditional-debug-macro-off=4
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/test/run-pass/export-glob-imports-target.rs
+++ b/src/test/run-pass/export-glob-imports-target.rs
@@ -15,7 +15,7 @@
 
 // Modified to not use export since it's going away. --pcw
 
-#[feature(globs)];
+#![feature(globs)]
 
 mod foo {
     use foo::bar::*;

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -11,7 +11,7 @@
 // ignore-fast: check-fast screws up repr paths
 
 #[feature(macro_rules)];
-#[deny(warnings)];
+#![deny(warnings)]
 #[allow(unused_must_use)];
 #[allow(deprecated_owned_vector)];
 

--- a/src/test/run-pass/import-glob-0.rs
+++ b/src/test/run-pass/import-glob-0.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 
 use module_of_many_things::*;
 use dug::too::greedily::and::too::deep::*;

--- a/src/test/run-pass/import-glob-crate.rs
+++ b/src/test/run-pass/import-glob-crate.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 #[allow(dead_assignment)];
 
 use std::mem::*;

--- a/src/test/run-pass/import-in-block.rs
+++ b/src/test/run-pass/import-in-block.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 
 pub fn main() {
     use std::mem::replace;

--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 
 mod rusti {
     extern "rust-intrinsic" {

--- a/src/test/run-pass/issue-2526-a.rs
+++ b/src/test/run-pass/issue-2526-a.rs
@@ -11,7 +11,7 @@
 // ignore-fast
 // aux-build:issue-2526.rs
 
-#[feature(globs)];
+#![feature(globs)]
 #[allow(unused_imports)];
 
 extern crate issue_2526;

--- a/src/test/run-pass/item-attributes.rs
+++ b/src/test/run-pass/item-attributes.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -160,7 +160,7 @@ mod test_foreign_items {
         use std::libc;
 
         extern {
-            #[attr];
+            #![attr]
 
             #[attr]
             fn rust_get_test_int() -> libc::intptr_t;

--- a/src/test/run-pass/linkage1.rs
+++ b/src/test/run-pass/linkage1.rs
@@ -14,7 +14,7 @@
 // ignore-macos
 // aux-build:linkage1.rs
 
-#[feature(linkage)];
+#![feature(linkage)]
 
 extern crate other = "linkage1";
 

--- a/src/test/run-pass/logging-enabled-debug.rs
+++ b/src/test/run-pass/logging-enabled-debug.rs
@@ -12,7 +12,7 @@
 // compile-flags:--cfg ndebug
 // exec-env:RUST_LOG=logging-enabled-debug=debug
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/test/run-pass/logging-enabled.rs
+++ b/src/test/run-pass/logging-enabled.rs
@@ -11,7 +11,7 @@
 // ignore-fast
 // exec-env:RUST_LOG=logging-enabled=info
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/test/run-pass/macro-crate-def-only.rs
+++ b/src/test/run-pass/macro-crate-def-only.rs
@@ -11,7 +11,7 @@
 // aux-build:macro_crate_def_only.rs
 // ignore-fast
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax)]
 extern crate macro_crate_def_only;

--- a/src/test/run-pass/macro-export-inner-module.rs
+++ b/src/test/run-pass/macro-export-inner-module.rs
@@ -12,7 +12,7 @@
 //ignore-stage1
 //ignore-fast
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax)]
 extern crate macro_export_inner_module;

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast
 
-#[feature(asm)];
+#![feature(asm)]
 
 use std::io::Process;
 use std::os;

--- a/src/test/run-pass/phase-use-ignored.rs
+++ b/src/test/run-pass/phase-use-ignored.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast
 
-#[feature(phase)];
+#![feature(phase)]
 
 #[phase(syntax)]
 use std::mem;

--- a/src/test/run-pass/privacy-ns.rs
+++ b/src/test/run-pass/privacy-ns.rs
@@ -13,7 +13,7 @@
 // Check we do the correct privacy checks when we import a name and there is an
 // item with that name in both the value and type namespaces.
 
-#[feature(globs)];
+#![feature(globs)]
 #[allow(dead_code)];
 #[allow(unused_imports)];
 

--- a/src/test/run-pass/reexport-star.rs
+++ b/src/test/run-pass/reexport-star.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 
 // FIXME #3654
 

--- a/src/test/run-pass/simd-binop.rs
+++ b/src/test/run-pass/simd-binop.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[allow(experimental)];
+#![allow(experimental)]
 
 use std::unstable::simd::{i32x4, f32x4, u32x4};
 

--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast
 
-#[feature(simd)];
+#![feature(simd)]
 
 use std::ops;
 

--- a/src/test/run-pass/simd-issue-10604.rs
+++ b/src/test/run-pass/simd-issue-10604.rs
@@ -10,8 +10,8 @@
 
 // ignore-fast
 
-#[allow(experimental)];
-#[feature(simd)];
+#![allow(experimental)]
+#![feature(simd)]
 
 pub fn main() {
     let _o = None::<std::unstable::simd::i32x4>;

--- a/src/test/run-pass/simd-type.rs
+++ b/src/test/run-pass/simd-type.rs
@@ -10,7 +10,7 @@
 
 // ignore-fast feature doesn't work
 
-#[feature(simd)];
+#![feature(simd)]
 
 #[simd]
 struct RGBA {

--- a/src/test/run-pass/tag-exports.rs
+++ b/src/test/run-pass/tag-exports.rs
@@ -10,7 +10,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[feature(globs)];
+#![feature(globs)]
 
 use alder::*;
 

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -13,7 +13,7 @@
 // ignore-android needs extra network permissions
 // exec-env:RUST_LOG=debug
 
-#[feature(phase)];
+#![feature(phase)]
 #[phase(syntax, link)]
 extern crate log;
 

--- a/src/test/run-pass/warn-ctypes-inhibit.rs
+++ b/src/test/run-pass/warn-ctypes-inhibit.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // compile-flags:-D ctypes
 
-#[allow(ctypes)];
+#![allow(ctypes)]
 
 mod libc {
     extern {


### PR DESCRIPTION
From the 0.10 changelog:
- The inner attribute syntax has changed from `#[foo];` to `#![foo]`.

I've run the tests, but I've got results I do not understand:
https://tim.siosm.fr/downloads/rust_tests_master.log (run on f819c21)
https://tim.siosm.fr/downloads/rust_tests_patched.log (run on f819c21 + patch; I've made a rebase since but did not rerun the checks)
