### PR TITLE
Made 'make install' include libs for additional targets

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -203,19 +203,17 @@ distcheck-osx: dist-osx
 # Unix binary installer tarballs
 ######################################################################
 
-define DEF_INSTALLER
+define DEF_PREPARE_DIST_DIR
 
-$$(eval $$(call DEF_PREPARE,dir-$(1)))
-
-dist-install-dir-$(1): PREPARE_HOST=$(1)
-dist-install-dir-$(1): PREPARE_TARGETS=$(1)
-dist-install-dir-$(1): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)
-dist-install-dir-$(1): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
-dist-install-dir-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
-dist-install-dir-$(1): PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
-dist-install-dir-$(1): PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
-dist-install-dir-$(1): PREPARE_CLEAN=true
-dist-install-dir-$(1): prepare-base-dir-$(1) docs compiler-docs
+dist-install-dir-$(1)$(3): PREPARE_HOST=$(1)
+dist-install-dir-$(1)$(3): PREPARE_TARGETS=$(2)
+dist-install-dir-$(1)$(3): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)
+dist-install-dir-$(1)$(3): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
+dist-install-dir-$(1)$(3): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
+dist-install-dir-$(1)$(3): PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
+dist-install-dir-$(1)$(3): PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
+dist-install-dir-$(1)$(3): PREPARE_CLEAN=true
+dist-install-dir-$(1)$(3): prepare-base-dir-$(1) docs compiler-docs
 	$$(Q)(cd $$(PREPARE_DEST_DIR)/ && find . -type f | sed 's/^\.\///') \
       > tmp/dist/manifest-$(1).in
 	$$(Q)mv tmp/dist/manifest-$(1).in $$(PREPARE_DEST_DIR)/$$(CFG_LIBDIR_RELATIVE)/rustlib/manifest.in
@@ -226,6 +224,16 @@ dist-install-dir-$(1): prepare-base-dir-$(1) docs compiler-docs
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)README.md $$(PREPARE_DEST_DIR)
 	$$(Q)cp -r doc $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_BIN_CMD) $$(S)src/etc/install.sh $$(PREPARE_DEST_DIR)
+
+endef
+
+define DEF_INSTALLER
+
+$$(eval $$(call DEF_PREPARE,dir-$(1)))
+
+$$(eval $$(call DEF_PREPARE_DIST_DIR,$(1),$(1),))
+
+$$(eval $$(call DEF_PREPARE_DIST_DIR,$(1),$(CFG_TARGET),-with-target-libs))
 
 dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)
 	@$(call E, build: $$@)

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -14,12 +14,12 @@ else
 MAYBE_DISABLE_VERIFY=
 endif
 
-install: dist-install-dir-$(CFG_BUILD)
+install: dist-install-dir-$(CFG_BUILD)-with-target-libs
 	$(Q)sh tmp/dist/$(PKG_NAME)-$(CFG_BUILD)/install.sh --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)" "$(MAYBE_DISABLE_VERIFY)"
 # Remove tmp files while we can because they may have been created under sudo
 	$(Q)rm -R tmp/dist
 
-uninstall: dist-install-dir-$(CFG_BUILD)
+uninstall: dist-install-dir-$(CFG_BUILD)-with-target-libs
 	$(Q)sh tmp/dist/$(PKG_NAME)-$(CFG_BUILD)/install.sh --uninstall --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)"
 # Remove tmp files while we can because they may have been created under sudo
 	$(Q)rm -R tmp/dist


### PR DESCRIPTION
'make install' didn't actually install libs for additional targets, which resulted in installed rustc being unable to cross-compile with an error saying 'unable to find crate std'.
