### PR TITLE
rustdoc: Fix hiding of private fields

### DIFF
--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -128,15 +128,9 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                 }
             }
 
-            clean::ViewItemItem(..) => {
+            clean::ViewItemItem(..) | clean::StructFieldItem(..) => {
                 if i.visibility != Some(ast::Public) {
                     return None
-                }
-            }
-
-            clean::StructFieldItem(..) => {
-                if i.visibility == Some(ast::Private) {
-                    return None;
                 }
             }
 


### PR DESCRIPTION
The calculation for whether a field is public or private was tweaked in #13184,
but I forgot to update rustdoc.

Closes #13310
