### PR TITLE
rustc: Always name bytecode based on crate ids

### DIFF
--- a/src/test/run-make/o-flag-and-some-bitcode/Makefile
+++ b/src/test/run-make/o-flag-and-some-bitcode/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs -o $(TMPDIR)/libfoo-somehash-0.0.rlib
+	$(RUSTC) main.rs -Zlto

--- a/src/test/run-make/o-flag-and-some-bitcode/foo.rs
+++ b/src/test/run-make/o-flag-and-some-bitcode/foo.rs
@@ -1,0 +1,4 @@
+#![crate_id = "foo"]
+#![crate_type = "rlib"]
+
+pub fn foo() {}

--- a/src/test/run-make/o-flag-and-some-bitcode/main.rs
+++ b/src/test/run-make/o-flag-and-some-bitcode/main.rs
@@ -1,0 +1,4 @@
+extern crate foo;
+
+fn main() {
+}


### PR DESCRIPTION
When performing LTO, bytecode is loaded from an archive by using the crate id's
name. If the -o flag was specified when building the original library, it
previously also mangled the name of the bytecode.

This switches to always using the crate id's name when naming the bytecode file,
ensuring that it can always be loaded at a later date, regardless of -o.

Closes #13317
