### PR TITLE
rustc: move the check_loop pass earlier.

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -323,6 +323,9 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     let region_map = time(time_passes, "region resolution", (), |_|
                           middle::region::resolve_crate(&sess, krate));
 
+    time(time_passes, "loop checking", (), |_|
+         middle::check_loop::check_crate(&sess, krate));
+
     let ty_cx = ty::mk_ctxt(sess, def_map, named_region_map, ast_map,
                             freevars, region_map, lang_items);
 
@@ -347,9 +350,6 @@ pub fn phase_3_run_analysis_passes(sess: Session,
 
     time(time_passes, "effect checking", (), |_|
          middle::effect::check_crate(&ty_cx, method_map, krate));
-
-    time(time_passes, "loop checking", (), |_|
-         middle::check_loop::check_crate(&ty_cx, krate));
 
     let middle::moves::MoveMaps {moves_map, moved_variables_set,
                                  capture_map} =

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use middle::ty;
+use driver::session::Session;
 
 use syntax::ast;
 use syntax::codemap::Span;
@@ -21,11 +21,11 @@ enum Context {
 }
 
 struct CheckLoopVisitor<'a> {
-    tcx: &'a ty::ctxt,
+    sess: &'a Session,
 }
 
-pub fn check_crate(tcx: &ty::ctxt, krate: &ast::Crate) {
-    visit::walk_crate(&mut CheckLoopVisitor { tcx: tcx }, krate, Normal)
+pub fn check_crate(sess: &Session, krate: &ast::Crate) {
+    visit::walk_crate(&mut CheckLoopVisitor { sess: sess }, krate, Normal)
 }
 
 impl<'a> Visitor<Context> for CheckLoopVisitor<'a> {
@@ -57,12 +57,10 @@ impl<'a> CheckLoopVisitor<'a> {
         match cx {
             Loop => {}
             Closure => {
-                self.tcx.sess.span_err(span, format!("`{}` inside of a closure",
-                                                     name));
+                self.sess.span_err(span, format!("`{}` inside of a closure", name));
             }
             Normal => {
-                self.tcx.sess.span_err(span, format!("`{}` outside of loop",
-                                                     name));
+                self.sess.span_err(span, format!("`{}` outside of loop", name));
             }
         }
     }

--- a/src/test/compile-fail/break-outside-loop.rs
+++ b/src/test/compile-fail/break-outside-loop.rs
@@ -30,4 +30,6 @@ fn main() {
     }
 
     let rs: Foo = Foo{t: pth};
+
+    let unconstrained = break; //~ ERROR: `break` outside of loop
 }


### PR DESCRIPTION
rustc: move the check_loop pass earlier.

This pass is purely AST based, and by running it earlier we emit more
useful error messages, e.g. type inference fails in the case of 
`let r = break;` with few constraints on `r`, but it's more useful to be told that
the `break` is outside the loop (rather than a type error) when it is.

Closes #13292.
