### PR TITLE
Remove references to obsolete `do` keyword

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -206,13 +206,12 @@ The keywords are the following strings:
 as
 break
 crate
-do
 else enum extern
 false fn for
 if impl in
 let loop
 match mod mut
-priv pub
+priv proc pub
 ref return
 self static struct super
 true trait type
@@ -2558,12 +2557,12 @@ task in a _failing state_.
 
 ~~~~ {.ignore}
 # use std::task;
-# do task::spawn {
+# task::spawn(proc() {
 
 ([1, 2, 3, 4])[0];
 (["a", "b"])[10]; // fails
 
-# }
+# })
 ~~~~
 
 ### Unary operator expressions

--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -165,12 +165,12 @@ that one can still write things like `#[deriving(Eq)]`).
     # // what's actually being documented.
     # fn fib(n: int) { n + 2 }
 
-    do spawn { fib(200); }
+    spawn(proc() { fib(200); })
     ```
     */
     # fn foo() {}
 
-The documentation online would look like `do spawn { fib(200); }`, but when
+The documentation online would look like `spawn(proc() { fib(200); })`, but when
 testing this code, the `fib` function will be included (so it can compile).
 
 ## Running tests (advanced)


### PR DESCRIPTION
Also add the new `proc` keyword to the documentation.
