### PR TITLE
librustc: Improve error message for incompatible trait method signatures...

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -923,7 +923,7 @@ fn compare_impl_method(tcx: &ty::ctxt,
         result::Err(ref terr) => {
             tcx.sess.span_err(
                 impl_m_span,
-                format!("method `{}` has an incompatible type: {}",
+                format!("method `{}` has an incompatible type for trait: {}",
                         token::get_ident(trait_m.ident),
                         ty::type_err_to_str(tcx, terr)));
             ty::note_and_explain_type_err(tcx, terr);

--- a/src/test/compile-fail/wrong-mul-method-signature.rs
+++ b/src/test/compile-fail/wrong-mul-method-signature.rs
@@ -13,14 +13,29 @@
 // (In this case the mul method should take &f64 and not f64)
 // See: #11450
 
+struct Vec1 {
+    x: f64
+}
+
+// Expecting ref in input signature
+impl Mul<f64, Vec1> for Vec1 {
+    fn mul(&self, s: f64) -> Vec1 {
+    //~^ ERROR: method `mul` has an incompatible type for trait: expected &-ptr but found f64
+        Vec1 {
+            x: self.x * s
+        }
+    }
+}
+
 struct Vec2 {
     x: f64,
     y: f64
 }
 
+// Wrong type parameter ordering
 impl Mul<Vec2, f64> for Vec2 {
     fn mul(&self, s: f64) -> Vec2 {
-    //~^ ERROR: method `mul` has an incompatible type: expected &-ptr but found f64
+    //~^ ERROR: method `mul` has an incompatible type for trait: expected &-ptr but found f64
         Vec2 {
             x: self.x * s,
             y: self.y * s
@@ -28,6 +43,22 @@ impl Mul<Vec2, f64> for Vec2 {
     }
 }
 
+struct Vec3 {
+    x: f64,
+    y: f64,
+    z: f64
+}
+
+// Unexpected return type
+impl Mul<f64, i32> for Vec3 {
+    fn mul(&self, s: &f64) -> f64 {
+    //~^ ERROR: method `mul` has an incompatible type for trait: expected i32 but found f64
+        *s
+    }
+}
+
 pub fn main() {
+    Vec1 { x: 1.0 } * 2.0;
     Vec2 { x: 1.0, y: 2.0 } * 2.0;
+    Vec3 { x: 1.0, y: 2.0, z: 3.0 } * 2.0;
 }


### PR DESCRIPTION
This can be a frustrating error message, ideally we should print the signature mismatch, but hinting that it's a trait incompatibility helps tracking root cause. Also beefed up the testcases for this.

Ideally we would print the signature mismatch in the error helper?
