### PR TITLE
Add support for different relocation models

### DIFF
--- a/src/etc/zsh/_rust
+++ b/src/etc/zsh/_rust
@@ -36,6 +36,7 @@ _rustc_opts_switches=(
     --target'[Target triple cpu-manufacturer-kernel\[-os\] to compile]'
     --target-cpu'[Select target processor (llc -mcpu=help for details)]'
     --target-feature'[Target specific attributes (llc -mattr=help for details)]'
+    --relocation-model'[Relocation model (llc --help for details)]'
     {-v,--version}'[Print version info and exit]'
 )
 _rustc_opts_lint=(

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -455,6 +455,8 @@ cgoptions!(
         "prefer dynamic linking to static linking"),
     no_integrated_as: bool = (false, parse_bool,
         "use an external assembler rather than LLVM's integrated one"),
+    relocation_model: ~str = (~"pic", parse_string,
+         "choose the relocation model to use (llc -relocation-model for details)"),
 )
 
 // Seems out of place, but it uses session, so I'm putting it here

--- a/src/test/run-make/relocation-model/Makefile
+++ b/src/test/run-make/relocation-model/Makefile
@@ -1,0 +1,15 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -C relocation-model=dynamic-no-pic foo.rs
+	$(call RUN,foo)
+
+	$(RUSTC) -C relocation-model=default foo.rs
+	$(call RUN,foo)
+
+	$(RUSTC) -C relocation-model=static foo.rs
+	$(call RUN,foo)
+
+	$(RUSTC) -C relocation-model=default --crate-type=dylib foo.rs
+	$(RUSTC) -C relocation-model=static --crate-type=dylib foo.rs
+	$(RUSTC) -C relocation-model=dynamic-no-pic --crate-type=dylib foo.rs

--- a/src/test/run-make/relocation-model/foo.rs
+++ b/src/test/run-make/relocation-model/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {}


### PR DESCRIPTION
Rust currently defaults to `RelocPIC` regardless. This patch adds a new
codegen option that allows choosing different relocation-model. The
available models are:

```
- default (Use the target-specific default model)
- static
- pic
- no-pic
```

For a more detailed information use `llc --help`
