### PR TITLE
Fix an unnecessary use of `cast::transmute`

### DIFF
--- a/src/libstd/ty.rs
+++ b/src/libstd/ty.rs
@@ -63,7 +63,7 @@ impl<T> Unsafe<T> {
 
     /// Gets a mutable pointer to the wrapped value
     #[inline]
-    pub unsafe fn get(&self) -> *mut T { cast::transmute(&self.value) }
+    pub unsafe fn get(&self) -> *mut T { cast::transmute_mut_unsafe(&self.value) }
 
     /// Unwraps the value
     #[inline]


### PR DESCRIPTION
Fix an unnecessary use of `cast::transmute`

Wherever possible, more specialized variants of said functions should be used,
such as in this case `cast::transmute_mmut_unsafe`.
