### PR TITLE
rustc: remove ty_unboxed_vec.

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -349,7 +349,6 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
         let mt = parse_mt(st, |x,y| conv(x,y));
         return ty::mk_rptr(st.tcx, r, mt);
       }
-      'U' => return ty::mk_unboxed_vec(st.tcx, parse_mt(st, |x,y| conv(x,y))),
       'V' => {
         let mt = parse_mt(st, |x,y| conv(x,y));
         let v = parse_vstore(st, |x,y| conv(x,y));

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -298,7 +298,6 @@ fn enc_sty(w: &mut MemWriter, cx: &ctxt, st: &ty::sty) {
             mywrite!(w, "v");
             enc_vstore(w, cx, v);
         }
-        ty::ty_unboxed_vec(mt) => { mywrite!(w, "U"); enc_mt(w, cx, mt); }
         ty::ty_closure(ref f) => {
             mywrite!(w, "f");
             enc_closure_ty(w, cx, *f);

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -191,7 +191,7 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
                         }
                     }
                 }
-                ty::ty_unboxed_vec(..) | ty::ty_vec(..) => {
+                ty::ty_vec(..) => {
                     match *ctor {
                         vec(n) => Some(format!("vectors of length {}", n)),
                         _ => None
@@ -282,7 +282,7 @@ fn is_useful(cx: &MatchCheckCtxt, m: &matrix, v: &[@Pat]) -> useful {
               ty::ty_vec(_, ty::vstore_fixed(n)) => {
                 is_useful_specialized(cx, m, v, vec(n), n, left_ty)
               }
-              ty::ty_unboxed_vec(..) | ty::ty_vec(..) => {
+              ty::ty_vec(..) => {
                 let max_len = m.iter().rev().fold(0, |max_len, r| {
                   match r.get(0).node {
                     PatVec(ref before, _, ref after) => {
@@ -464,7 +464,7 @@ fn missing_ctor(cx: &MatchCheckCtxt,
           _         => None
         }
       }
-      ty::ty_unboxed_vec(..) | ty::ty_vec(..) => {
+      ty::ty_vec(..) => {
 
         // Find the lengths and slices of all vector patterns.
         let mut vec_pat_lens = m.iter().filter_map(|r| {
@@ -529,7 +529,7 @@ fn ctor_arity(cx: &MatchCheckCtxt, ctor: &ctor, ty: ty::t) -> uint {
         }
       }
       ty::ty_struct(cid, _) => ty::lookup_struct_fields(cx.tcx, cid).len(),
-      ty::ty_unboxed_vec(..) | ty::ty_vec(..) => {
+      ty::ty_vec(..) => {
         match *ctor {
           vec(n) => n,
           _ => 0u

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1088,7 +1088,8 @@ fn extract_vec_elems<'a>(
     let _icx = push_ctxt("match::extract_vec_elems");
     let vec_datum = match_datum(bcx, val, pat_id);
     let (base, len) = vec_datum.get_vec_base_and_len(bcx);
-    let vt = tvec::vec_types(bcx, node_id_type(bcx, pat_id));
+    let vec_ty = node_id_type(bcx, pat_id);
+    let vt = tvec::vec_types(bcx, ty::sequence_element_type(bcx.tcx(), vec_ty));
 
     let mut elems = Vec::from_fn(elem_count, |i| {
         match slice {
@@ -1681,8 +1682,8 @@ fn compile_submatch_continue<'r,
                 kind = compare;
             },
             vec_len(..) => {
-                let vt = tvec::vec_types(bcx, node_id_type(bcx, pat_id));
-                let (_, len) = tvec::get_base_and_len(bcx, val, vt.vec_ty);
+                let vec_ty = node_id_type(bcx, pat_id);
+                let (_, len) = tvec::get_base_and_len(bcx, val, vec_ty);
                 test_val = len;
                 kind = compare_vec_len;
             }

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -278,7 +278,7 @@ impl<'a> CleanupMethods<'a> for FunctionContext<'a> {
     fn schedule_free_value(&self,
                            cleanup_scope: ScopeId,
                            val: ValueRef,
-                           heap: common::heap) {
+                           heap: Heap) {
         /*!
          * Schedules a call to `free(val)`. Note that this is a shallow
          * operation.
@@ -814,9 +814,14 @@ impl Cleanup for DropValue {
     }
 }
 
+pub enum Heap {
+    HeapManaged,
+    HeapExchange
+}
+
 pub struct FreeValue {
     ptr: ValueRef,
-    heap: common::heap,
+    heap: Heap,
 }
 
 impl Cleanup for FreeValue {
@@ -826,10 +831,10 @@ impl Cleanup for FreeValue {
 
     fn trans<'a>(&self, bcx: &'a Block<'a>) -> &'a Block<'a> {
         match self.heap {
-            common::heap_managed => {
+            HeapManaged => {
                 glue::trans_free(bcx, self.ptr)
             }
-            common::heap_exchange | common::heap_exchange_closure => {
+            HeapExchange => {
                 glue::trans_exchange_free(bcx, self.ptr)
             }
         }
@@ -901,7 +906,7 @@ pub trait CleanupMethods<'a> {
     fn schedule_free_value(&self,
                            cleanup_scope: ScopeId,
                            val: ValueRef,
-                           heap: common::heap);
+                           heap: Heap);
     fn schedule_clean(&self,
                       cleanup_scope: ScopeId,
                       cleanup: ~Cleanup);

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -13,6 +13,7 @@ use back::abi;
 use back::link::mangle_internal_name_by_path_and_seq;
 use driver::session::FullDebugInfo;
 use lib::llvm::ValueRef;
+use middle::lang_items::ClosureExchangeMallocFnLangItem;
 use middle::moves;
 use middle::trans::base::*;
 use middle::trans::build::*;
@@ -20,6 +21,7 @@ use middle::trans::common::*;
 use middle::trans::datum::{Datum, DatumBlock, Expr, Lvalue, rvalue_scratch_datum};
 use middle::trans::debuginfo;
 use middle::trans::expr;
+use middle::trans::machine::llsize_of;
 use middle::trans::type_of::*;
 use middle::trans::type_::Type;
 use middle::ty;
@@ -168,7 +170,10 @@ fn allocate_cbox<'a>(bcx: &'a Block<'a>,
             tcx.sess.bug("trying to trans allocation of @fn")
         }
         ast::OwnedSigil => {
-            malloc_raw(bcx, cdata_ty, heap_exchange_closure)
+            let ty = type_of(bcx.ccx(), cdata_ty);
+            let size = llsize_of(bcx.ccx(), ty);
+            // we treat proc as @ here, which isn't ideal
+            malloc_raw_dyn_managed(bcx, cdata_ty, ClosureExchangeMallocFnLangItem, size)
         }
         ast::BorrowedSigil => {
             let cbox_ty = tuplify_box_ty(tcx, cdata_ty);

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -385,14 +385,6 @@ impl<'a> FunctionContext<'a> {
     }
 }
 
-// Heap selectors. Indicate which heap something should go on.
-#[deriving(Eq)]
-pub enum heap {
-    heap_managed,
-    heap_exchange,
-    heap_exchange_closure
-}
-
 // Basic block context.  We create a block context for each basic block
 // (single-entry, single-exit sequence of instructions) we generate from Rust
 // code.  Each basic block we generate is attached to a function, typically

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -37,6 +37,7 @@ use back::abi;
 use lib::llvm::{ValueRef, llvm};
 use lib;
 use metadata::csearch;
+use middle::lang_items::MallocFnLangItem;
 use middle::trans::_match;
 use middle::trans::adt;
 use middle::trans::asm;
@@ -426,8 +427,7 @@ fn trans_datum_unadjusted<'a>(bcx: &'a Block<'a>,
             // `trans_rvalue_dps_unadjusted`.)
             let box_ty = expr_ty(bcx, expr);
             let contents_ty = expr_ty(bcx, contents);
-            let heap = heap_exchange;
-            return trans_boxed_expr(bcx, box_ty, contents, contents_ty, heap)
+            trans_uniq_expr(bcx, box_ty, contents, contents_ty)
         }
         ast::ExprLit(lit) => trans_immediate_lit(bcx, expr, (*lit).clone()),
         ast::ExprBinary(op, lhs, rhs) => {
@@ -504,7 +504,7 @@ fn trans_index<'a>(bcx: &'a Block<'a>,
         }
     };
 
-    let vt = tvec::vec_types(bcx, base_datum.ty);
+    let vt = tvec::vec_types(bcx, ty::sequence_element_type(bcx.tcx(), base_datum.ty));
     base::maybe_name_value(bcx.ccx(), vt.llunit_size, "unit_sz");
 
     let (base, len) = base_datum.get_vec_base_and_len(bcx);
@@ -1175,10 +1175,10 @@ fn trans_unary<'a>(bcx: &'a Block<'a>,
             immediate_rvalue_bcx(bcx, llneg, un_ty).to_expr_datumblock()
         }
         ast::UnBox => {
-            trans_boxed_expr(bcx, un_ty, sub_expr, expr_ty(bcx, sub_expr), heap_managed)
+            trans_managed_expr(bcx, un_ty, sub_expr, expr_ty(bcx, sub_expr))
         }
         ast::UnUniq => {
-            trans_boxed_expr(bcx, un_ty, sub_expr, expr_ty(bcx, sub_expr), heap_exchange)
+            trans_uniq_expr(bcx, un_ty, sub_expr, expr_ty(bcx, sub_expr))
         }
         ast::UnDeref => {
             let datum = unpack_datum!(bcx, trans(bcx, sub_expr));
@@ -1187,42 +1187,52 @@ fn trans_unary<'a>(bcx: &'a Block<'a>,
     }
 }
 
-fn trans_boxed_expr<'a>(bcx: &'a Block<'a>,
-                        box_ty: ty::t,
-                        contents: &ast::Expr,
-                        contents_ty: ty::t,
-                        heap: heap)
+fn trans_uniq_expr<'a>(bcx: &'a Block<'a>,
+                       box_ty: ty::t,
+                       contents: &ast::Expr,
+                       contents_ty: ty::t)
                         -> DatumBlock<'a, Expr> {
-    let _icx = push_ctxt("trans_boxed_expr");
+    let _icx = push_ctxt("trans_uniq_expr");
     let fcx = bcx.fcx;
-    if heap == heap_exchange {
-        let llty = type_of::type_of(bcx.ccx(), contents_ty);
-        let size = llsize_of(bcx.ccx(), llty);
-        let Result { bcx: bcx, val: val } = malloc_raw_dyn(bcx, contents_ty,
-                                                           heap_exchange, size);
-        // Unique boxes do not allocate for zero-size types. The standard library may assume
-        // that `free` is never called on the pointer returned for `~ZeroSizeType`.
-        if llsize_of_alloc(bcx.ccx(), llty) == 0 {
-            let bcx = trans_into(bcx, contents, SaveIn(val));
-            immediate_rvalue_bcx(bcx, val, box_ty).to_expr_datumblock()
-        } else {
-            let custom_cleanup_scope = fcx.push_custom_cleanup_scope();
-            fcx.schedule_free_value(cleanup::CustomScope(custom_cleanup_scope),
-                                    val, heap_exchange);
-            let bcx = trans_into(bcx, contents, SaveIn(val));
-            fcx.pop_custom_cleanup_scope(custom_cleanup_scope);
-            immediate_rvalue_bcx(bcx, val, box_ty).to_expr_datumblock()
-        }
+    let llty = type_of::type_of(bcx.ccx(), contents_ty);
+    let size = llsize_of(bcx.ccx(), llty);
+    // We need to a make a pointer type because box_ty is ty_bot
+    // if content_ty is, e.g. ~fail!().
+    let real_box_ty = ty::mk_uniq(bcx.tcx(), contents_ty);
+    let Result { bcx, val } = malloc_raw_dyn(bcx, real_box_ty, size);
+    // Unique boxes do not allocate for zero-size types. The standard library may assume
+    // that `free` is never called on the pointer returned for `~ZeroSizeType`.
+    let bcx = if llsize_of_alloc(bcx.ccx(), llty) == 0 {
+        trans_into(bcx, contents, SaveIn(val))
     } else {
-        let base::MallocResult { bcx, smart_ptr: bx, body } =
-            base::malloc_general(bcx, contents_ty, heap);
         let custom_cleanup_scope = fcx.push_custom_cleanup_scope();
         fcx.schedule_free_value(cleanup::CustomScope(custom_cleanup_scope),
-                                bx, heap);
-        let bcx = trans_into(bcx, contents, SaveIn(body));
+                                val, cleanup::HeapExchange);
+        let bcx = trans_into(bcx, contents, SaveIn(val));
         fcx.pop_custom_cleanup_scope(custom_cleanup_scope);
-        immediate_rvalue_bcx(bcx, bx, box_ty).to_expr_datumblock()
-    }
+        bcx
+    };
+    immediate_rvalue_bcx(bcx, val, box_ty).to_expr_datumblock()
+}
+
+fn trans_managed_expr<'a>(bcx: &'a Block<'a>,
+                          box_ty: ty::t,
+                          contents: &ast::Expr,
+                          contents_ty: ty::t)
+                          -> DatumBlock<'a, Expr> {
+    let _icx = push_ctxt("trans_managed_expr");
+    let fcx = bcx.fcx;
+    let ty = type_of::type_of(bcx.ccx(), contents_ty);
+    let Result {bcx, val: bx} = malloc_raw_dyn_managed(bcx, contents_ty, MallocFnLangItem,
+                                                        llsize_of(bcx.ccx(), ty));
+    let body = GEPi(bcx, bx, [0u, abi::box_field_body]);
+
+    let custom_cleanup_scope = fcx.push_custom_cleanup_scope();
+    fcx.schedule_free_value(cleanup::CustomScope(custom_cleanup_scope),
+                            bx, cleanup::HeapManaged);
+    let bcx = trans_into(bcx, contents, SaveIn(body));
+    fcx.pop_custom_cleanup_scope(custom_cleanup_scope);
+    immediate_rvalue_bcx(bcx, bx, box_ty).to_expr_datumblock()
 }
 
 fn trans_addr_of<'a>(bcx: &'a Block<'a>,
@@ -1243,31 +1253,22 @@ fn trans_gc<'a>(mut bcx: &'a Block<'a>,
                 -> &'a Block<'a> {
     let contents_ty = expr_ty(bcx, contents);
     let box_ty = ty::mk_box(bcx.tcx(), contents_ty);
-    let expr_ty = expr_ty(bcx, expr);
 
-    let addr = match dest {
-        Ignore => {
-            return trans_boxed_expr(bcx,
-                                    box_ty,
-                                    contents,
-                                    contents_ty,
-                                    heap_managed).bcx
+    let contents_datum = unpack_datum!(bcx, trans_managed_expr(bcx,
+                                                               box_ty,
+                                                               contents,
+                                                               contents_ty));
+
+    match dest {
+        Ignore => bcx,
+        SaveIn(addr) => {
+            let expr_ty = expr_ty(bcx, expr);
+            let repr = adt::represent_type(bcx.ccx(), expr_ty);
+            adt::trans_start_init(bcx, repr, addr, 0);
+            let field_dest = adt::trans_field_ptr(bcx, repr, addr, 0, 0);
+            contents_datum.store_to(bcx, field_dest)
         }
-        SaveIn(addr) => addr,
-    };
-
-    let repr = adt::represent_type(bcx.ccx(), expr_ty);
-    adt::trans_start_init(bcx, repr, addr, 0);
-    let field_dest = adt::trans_field_ptr(bcx, repr, addr, 0, 0);
-    let contents_datum = unpack_datum!(bcx, trans_boxed_expr(bcx,
-                                                             box_ty,
-                                                             contents,
-                                                             contents_ty,
-                                                             heap_managed));
-    bcx = contents_datum.store_to(bcx, field_dest);
-
-    // Next, wrap it up in the struct.
-    bcx
+    }
 }
 
 // Important to get types for both lhs and rhs, because one might be _|_
@@ -1801,11 +1802,11 @@ fn deref_once<'a>(bcx: &'a Block<'a>,
             RvalueExpr(Rvalue { mode: ByRef }) => {
                 let scope = cleanup::temporary_scope(bcx.tcx(), expr.id);
                 let ptr = Load(bcx, datum.val);
-                bcx.fcx.schedule_free_value(scope, ptr, heap_exchange);
+                bcx.fcx.schedule_free_value(scope, ptr, cleanup::HeapExchange);
             }
             RvalueExpr(Rvalue { mode: ByValue }) => {
                 let scope = cleanup::temporary_scope(bcx.tcx(), expr.id);
-                bcx.fcx.schedule_free_value(scope, datum.val, heap_exchange);
+                bcx.fcx.schedule_free_value(scope, datum.val, cleanup::HeapExchange);
             }
             LvalueExpr => { }
         }

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -163,11 +163,6 @@ impl<'a> Reflector<'a> {
           ty::ty_float(ast::TyF32) => self.leaf("f32"),
           ty::ty_float(ast::TyF64) => self.leaf("f64"),
 
-          ty::ty_unboxed_vec(ref mt) => {
-              let values = self.c_mt(mt);
-              self.visit("vec", values.as_slice())
-          }
-
           // Should rename to str_*/vec_*.
           ty::ty_str(vst) => {
               let (name, extra) = self.vstore_name_and_extra(t, vst);

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -137,10 +137,6 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
             Type::array(&sizing_type_of(cx, mt.ty), size as u64)
         }
 
-        ty::ty_unboxed_vec(mt) => {
-            Type::vec(cx, &sizing_type_of(cx, mt.ty))
-        }
-
         ty::ty_tup(..) | ty::ty_enum(..) => {
             let repr = adt::represent_type(cx, t);
             adt::sizing_type_of(cx, repr)
@@ -223,9 +219,6 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
       }
       ty::ty_vec(ref mt, ty::vstore_uniq) => {
           Type::vec(cx, &type_of(cx, mt.ty)).ptr_to()
-      }
-      ty::ty_unboxed_vec(ref mt) => {
-          Type::vec(cx, &type_of(cx, mt.ty))
       }
       ty::ty_ptr(ref mt) => type_of(cx, mt.ty).ptr_to(),
       ty::ty_rptr(_, ref mt) => type_of(cx, mt.ty).ptr_to(),

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -148,9 +148,6 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_ptr(ref tm) => {
             ty::ty_ptr(this.fold_mt(tm))
         }
-        ty::ty_unboxed_vec(ref tm) => {
-            ty::ty_unboxed_vec(this.fold_mt(tm))
-        }
         ty::ty_vec(ref tm, vst) => {
             ty::ty_vec(this.fold_mt(tm), this.fold_vstore(vst))
         }

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -637,9 +637,6 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
             };
             (mt, region_var)
           }
-          ty::ty_unboxed_vec(mt) => {
-            (mt, default_region_var)
-          },
           _ => {
               for &elt in before.iter() {
                   check_pat(pcx, elt, ty::mk_err());

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -910,7 +910,7 @@ impl<'a> LookupContext<'a> {
 
             ty_err => None,
 
-            ty_unboxed_vec(_) | ty_infer(TyVar(_)) => {
+            ty_infer(TyVar(_)) => {
                 self.bug(format!("unexpected type: {}",
                               self.ty_to_str(self_ty)));
             }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -24,7 +24,7 @@ use middle::ty::{ty_str, ty_vec, ty_float, ty_infer, ty_int, ty_nil};
 use middle::ty::{ty_param, ty_param_bounds_and_ty, ty_ptr};
 use middle::ty::{ty_rptr, ty_self, ty_struct, ty_trait, ty_tup};
 use middle::ty::{ty_uint, ty_uniq, ty_bare_fn, ty_closure};
-use middle::ty::{ty_unboxed_vec, type_is_ty_var};
+use middle::ty::type_is_ty_var;
 use middle::subst::Subst;
 use middle::ty;
 use middle::ty::{Impl, Method};
@@ -81,9 +81,8 @@ fn get_base_type(inference_context: &InferCtxt,
 
         ty_nil | ty_bot | ty_bool | ty_char | ty_int(..) | ty_uint(..) | ty_float(..) |
         ty_str(..) | ty_vec(..) | ty_bare_fn(..) | ty_closure(..) | ty_tup(..) |
-        ty_infer(..) | ty_param(..) | ty_self(..) |
-        ty_unboxed_vec(..) | ty_err | ty_box(_) |
-        ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
+        ty_infer(..) | ty_param(..) | ty_self(..) | ty_err |
+        ty_box(_) | ty_uniq(_) | ty_ptr(_) | ty_rptr(_, _) => {
             debug!("(getting base type) no base type; found {:?}",
                    get(original_type).sty);
             None

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -707,7 +707,7 @@ impl<'a> ConstraintContext<'a> {
                 self.add_constraints_from_sig(sig, variance);
             }
 
-            ty::ty_infer(..) | ty::ty_err | ty::ty_unboxed_vec(..) => {
+            ty::ty_infer(..) | ty::ty_err => {
                 self.tcx().sess.bug(
                     format!("unexpected type encountered in \
                             variance inference: {}",

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -19,7 +19,7 @@ use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region,
 use middle::ty::{ty_bool, ty_char, ty_bot, ty_box, ty_struct, ty_enum};
 use middle::ty::{ty_err, ty_str, ty_vec, ty_float, ty_bare_fn, ty_closure};
 use middle::ty::{ty_nil, ty_param, ty_ptr, ty_rptr, ty_self, ty_tup};
-use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_unboxed_vec, ty_infer};
+use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_infer};
 use middle::ty;
 use middle::typeck;
 
@@ -397,7 +397,6 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
       ty_rptr(r, ref tm) => {
         region_ptr_to_str(cx, r) + mt_to_str(cx, tm)
       }
-      ty_unboxed_vec(ref tm) => { format!("unboxed_vec<{}>", mt_to_str(cx, tm)) }
       ty_tup(ref elems) => {
         let strs: Vec<~str> = elems.iter().map(|elem| ty_to_str(cx, *elem)).collect();
         ~"(" + strs.connect(",") + ")"

--- a/src/libstd/intrinsics.rs
+++ b/src/libstd/intrinsics.rs
@@ -108,8 +108,6 @@ pub trait TyVisitor {
     fn visit_ptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_rptr(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
 
-    fn visit_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
-    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_uniq(&mut self, mtbl: uint, inner: *TyDesc) -> bool;
     fn visit_evec_slice(&mut self, mtbl: uint, inner: *TyDesc) -> bool;

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -18,7 +18,6 @@ Runtime type reflection
 
 use intrinsics::{Disr, Opaque, TyDesc, TyVisitor};
 use mem;
-use raw;
 
 /**
  * Trait for visitor that wishes to reflect on data. To use this, create a
@@ -236,19 +235,6 @@ impl<V:TyVisitor + MovePtr> TyVisitor for MovePtrAdaptor<V> {
         self.align_to::<&'static u8>();
         if ! self.inner.visit_rptr(mtbl, inner) { return false; }
         self.bump_past::<&'static u8>();
-        true
-    }
-
-    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.align_to::<raw::Vec<()>>();
-        if ! self.inner.visit_vec(mtbl, inner) { return false; }
-        true
-    }
-
-    fn visit_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.align_to::<~[u8]>();
-        if ! self.inner.visit_vec(mtbl, inner) { return false; }
-        self.bump_past::<~[u8]>();
         true
     }
 

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -341,15 +341,6 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
         })
     }
 
-    // Type no longer exists, vestigial function.
-    fn visit_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { fail!(); }
-
-    fn visit_unboxed_vec(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
-        self.get::<raw::Vec<()>>(|this, b| {
-            this.write_unboxed_vec_repr(mtbl, b, inner)
-        })
-    }
-
     fn visit_evec_box(&mut self, mtbl: uint, inner: *TyDesc) -> bool {
         self.get::<&raw::Box<raw::Vec<()>>>(|this, b| {
             try!(this, this.writer.write(['@' as u8]));

--- a/src/test/run-pass/reflect-visit-type.rs
+++ b/src/test/run-pass/reflect-visit-type.rs
@@ -73,8 +73,6 @@ impl TyVisitor for MyVisitor {
     fn visit_ptr(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_rptr(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
 
-    fn visit_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
-    fn visit_unboxed_vec(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_box(&mut self, _mtbl: uint, _inner: *TyDesc) -> bool { true }
     fn visit_evec_uniq(&mut self, _mtbl: uint, inner: *TyDesc) -> bool {
         self.types.push(~"[");


### PR DESCRIPTION
Removes the special `ty_unboxed_vec` type from the type system.
It was previously used only during translating `~[T]`/`~str` allocation and drop glue.
