### PR TITLE
Point out which struct's field is private

### DIFF
--- a/src/test/auxiliary/privacy-struct-variant.rs
+++ b/src/test/auxiliary/privacy-struct-variant.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod cat {
-    pub struct Cat {
-        meows: uint
-    }
+#![feature(struct_variant)]
 
-    pub fn new_cat() -> Cat {
-        Cat { meows: 52 }
+pub enum Foo {
+    Bar {
+        baz: int
     }
-}
-
-fn main() {
-    let nyan = cat::new_cat();
-    assert!(nyan.meows == 52);    //~ ERROR field `meows` of struct `cat::Cat` is private
 }

--- a/src/test/compile-fail/issue-3763.rs
+++ b/src/test/compile-fail/issue-3763.rs
@@ -24,11 +24,15 @@ mod my_mod {
 
 fn main() {
     let my_struct = my_mod::MyStruct();
-    let _woohoo = (&my_struct).priv_field; //~ ERROR field `priv_field` is private
-    let _woohoo = (~my_struct).priv_field; //~ ERROR field `priv_field` is private
-    let _woohoo = (@my_struct).priv_field; //~ ERROR field `priv_field` is private
+    let _woohoo = (&my_struct).priv_field;
+    //~^ ERROR field `priv_field` of struct `my_mod::MyStruct` is private
+    let _woohoo = (~my_struct).priv_field;
+    //~^ ERROR field `priv_field` of struct `my_mod::MyStruct` is private
+    let _woohoo = (@my_struct).priv_field;
+    //~^ ERROR field `priv_field` of struct `my_mod::MyStruct` is private
     (&my_struct).happyfun();               //~ ERROR method `happyfun` is private
     (~my_struct).happyfun();               //~ ERROR method `happyfun` is private
     (@my_struct).happyfun();               //~ ERROR method `happyfun` is private
-    let nope = my_struct.priv_field;       //~ ERROR field `priv_field` is private
+    let nope = my_struct.priv_field;
+    //~^ ERROR field `priv_field` of struct `my_mod::MyStruct` is private
 }

--- a/src/test/compile-fail/privacy-struct-variant.rs
+++ b/src/test/compile-fail/privacy-struct-variant.rs
@@ -1,0 +1,48 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:privacy-struct-variant.rs
+
+#![feature(struct_variant)]
+
+extern crate other = "privacy-struct-variant";
+
+mod a {
+    pub enum Foo {
+        Bar {
+            baz: int
+        }
+    }
+
+    fn test() {
+        let foo = Bar { baz: 42 };
+
+        let Bar { baz: _ } = foo;
+        match foo { Bar { baz: _ } => {} }
+    }
+}
+
+fn main() {
+    let foo = a::Bar { baz: 42 };
+    //~^ ERROR: field `baz` of variant `Bar` of enum `a::Foo` is private
+
+    let a::Bar { baz: _ } = foo;
+    //~^ ERROR: field `baz` of variant `Bar` of enum `a::Foo` is private
+    match foo { a::Bar { baz: _ } => {} }
+    //~^ ERROR: field `baz` of variant `Bar` of enum `a::Foo` is private
+    //
+    let foo = other::Bar { baz: 42 };
+    //~^ ERROR: field `baz` of variant `Bar` of enum `privacy-struct-variant::Foo` is private
+
+    let other::Bar { baz: _ } = foo;
+    //~^ ERROR: field `baz` of variant `Bar` of enum `privacy-struct-variant::Foo` is private
+    match foo { other::Bar { baz: _ } => {} }
+    //~^ ERROR: field `baz` of variant `Bar` of enum `privacy-struct-variant::Foo` is private
+}

--- a/src/test/compile-fail/privacy5.rs
+++ b/src/test/compile-fail/privacy5.rs
@@ -64,25 +64,25 @@ fn this_crate() {
     let c = a::C(2, 3); //~ ERROR: cannot invoke tuple struct constructor
     let d = a::D(4);
 
-    let a::A(()) = a; //~ ERROR: field #1 is private
+    let a::A(()) = a; //~ ERROR: field #1 of struct `a::A` is private
     let a::A(_) = a;
-    match a { a::A(()) => {} } //~ ERROR: field #1 is private
+    match a { a::A(()) => {} } //~ ERROR: field #1 of struct `a::A` is private
     match a { a::A(_) => {} }
 
     let a::B(_) = b;
-    let a::B(_b) = b; //~ ERROR: field #1 is private
+    let a::B(_b) = b; //~ ERROR: field #1 of struct `a::B` is private
     match b { a::B(_) => {} }
-    match b { a::B(_b) => {} } //~ ERROR: field #1 is private
-    match b { a::B(1) => {} a::B(_) => {} } //~ ERROR: field #1 is private
+    match b { a::B(_b) => {} } //~ ERROR: field #1 of struct `a::B` is private
+    match b { a::B(1) => {} a::B(_) => {} } //~ ERROR: field #1 of struct `a::B` is private
 
     let a::C(_, _) = c;
     let a::C(_a, _) = c;
-    let a::C(_, _b) = c; //~ ERROR: field #2 is private
-    let a::C(_a, _b) = c; //~ ERROR: field #2 is private
+    let a::C(_, _b) = c; //~ ERROR: field #2 of struct `a::C` is private
+    let a::C(_a, _b) = c; //~ ERROR: field #2 of struct `a::C` is private
     match c { a::C(_, _) => {} }
     match c { a::C(_a, _) => {} }
-    match c { a::C(_, _b) => {} } //~ ERROR: field #2 is private
-    match c { a::C(_a, _b) => {} } //~ ERROR: field #2 is private
+    match c { a::C(_, _b) => {} } //~ ERROR: field #2 of struct `a::C` is private
+    match c { a::C(_a, _b) => {} } //~ ERROR: field #2 of struct `a::C` is private
 
     let a::D(_) = d;
     let a::D(_d) = d;
@@ -102,25 +102,30 @@ fn xcrate() {
     let c = other::C(2, 3); //~ ERROR: cannot invoke tuple struct constructor
     let d = other::D(4);
 
-    let other::A(()) = a; //~ ERROR: field #1 is private
+    let other::A(()) = a; //~ ERROR: field #1 of struct `privacy-tuple-struct::A` is private
     let other::A(_) = a;
-    match a { other::A(()) => {} } //~ ERROR: field #1 is private
+    match a { other::A(()) => {} }
+    //~^ ERROR: field #1 of struct `privacy-tuple-struct::A` is private
     match a { other::A(_) => {} }
 
     let other::B(_) = b;
-    let other::B(_b) = b; //~ ERROR: field #1 is private
+    let other::B(_b) = b; //~ ERROR: field #1 of struct `privacy-tuple-struct::B` is private
     match b { other::B(_) => {} }
-    match b { other::B(_b) => {} } //~ ERROR: field #1 is private
-    match b { other::B(1) => {} other::B(_) => {} } //~ ERROR: field #1 is private
+    match b { other::B(_b) => {} }
+    //~^ ERROR: field #1 of struct `privacy-tuple-struct::B` is private
+    match b { other::B(1) => {} other::B(_) => {} }
+    //~^ ERROR: field #1 of struct `privacy-tuple-struct::B` is private
 
     let other::C(_, _) = c;
     let other::C(_a, _) = c;
-    let other::C(_, _b) = c; //~ ERROR: field #2 is private
-    let other::C(_a, _b) = c; //~ ERROR: field #2 is private
+    let other::C(_, _b) = c; //~ ERROR: field #2 of struct `privacy-tuple-struct::C` is private
+    let other::C(_a, _b) = c; //~ ERROR: field #2 of struct `privacy-tuple-struct::C` is private
     match c { other::C(_, _) => {} }
     match c { other::C(_a, _) => {} }
-    match c { other::C(_, _b) => {} } //~ ERROR: field #2 is private
-    match c { other::C(_a, _b) => {} } //~ ERROR: field #2 is private
+    match c { other::C(_, _b) => {} }
+    //~^ ERROR: field #2 of struct `privacy-tuple-struct::C` is private
+    match c { other::C(_a, _b) => {} }
+    //~^ ERROR: field #2 of struct `privacy-tuple-struct::C` is private
 
     let other::D(_) = d;
     let other::D(_d) = d;

--- a/src/test/compile-fail/private-struct-field-cross-crate.rs
+++ b/src/test/compile-fail/private-struct-field-cross-crate.rs
@@ -14,5 +14,6 @@ use cci_class::kitties::cat;
 
 fn main() {
   let nyan : cat = cat(52u, 99);
-  assert!((nyan.meows == 52u));   //~ ERROR field `meows` is private
+  assert!((nyan.meows == 52u));
+  //~^ ERROR field `meows` of struct `cci_class::kitties::cat` is private
 }

--- a/src/test/compile-fail/private-struct-field-ctor.rs
+++ b/src/test/compile-fail/private-struct-field-ctor.rs
@@ -15,5 +15,5 @@ mod a {
 }
 
 fn main() {
-    let s = a::Foo { x: 1 };    //~ ERROR field `x` is private
+    let s = a::Foo { x: 1 };    //~ ERROR field `x` of struct `a::Foo` is private
 }

--- a/src/test/compile-fail/private-struct-field-pattern.rs
+++ b/src/test/compile-fail/private-struct-field-pattern.rs
@@ -22,6 +22,6 @@ mod a {
 
 fn main() {
     match a::make() {
-        Foo { x: _ } => {}  //~ ERROR field `x` is private
+        Foo { x: _ } => {}  //~ ERROR field `x` of struct `a::Foo` is private
     }
 }

--- a/src/test/compile-fail/struct-field-privacy.rs
+++ b/src/test/compile-fail/struct-field-privacy.rs
@@ -32,16 +32,16 @@ fn test(a: A, b: inner::A, c: inner::B, d: xc::A, e: xc::B) {
     //~^^ ERROR: struct `A` is private
 
     a.a;
-    b.a; //~ ERROR: field `a` is private
+    b.a; //~ ERROR: field `a` of struct `inner::A` is private
     b.b;
     c.a;
-    c.b; //~ ERROR: field `b` is private
+    c.b; //~ ERROR: field `b` of struct `inner::B` is private
 
-    d.a; //~ ERROR: field `a` is private
+    d.a; //~ ERROR: field `a` of struct `struct-field-privacy::A` is private
     d.b;
 
     e.a;
-    e.b; //~ ERROR: field `b` is private
+    e.b; //~ ERROR: field `b` of struct `struct-field-privacy::B` is private
 }
 
 fn main() {}


### PR DESCRIPTION
In the error message for when a private field is used, include the name of the struct, or if it's a struct-like enum variant, the names of the variant and the enum.

This fixes #13341.
