### PR TITLE
Fix kate syntax highlighting

### DIFF
--- a/src/etc/kate/rust.xml
+++ b/src/etc/kate/rust.xml
@@ -202,7 +202,7 @@
 			<RegExpr String="[0-9][0-9_]*\.[0-9_]*([eE][+-]?[0-9_]+)?(f32|f64|f)?" attribute="Number" context="#stay"/>
 			<RegExpr String="[0-9][0-9_]*&rustIntSuf;" attribute="Number" context="#stay"/>
 			<Detect2Chars char="#" char1="[" attribute="Attribute" context="Attribute" beginRegion="Attribute"/>
-			<Detect2Chars char="#" char1="!" char2="[" attribute="Attribute" context="Attribute" beginRegion="Attribute"/>
+			<StringDetect String="#![" attribute="Attribute" context="Attribute" beginRegion="Attribute"/>
 			<RegExpr String="&rustIdent;::" attribute="Scope"/>
 			<RegExpr String="&rustIdent;!" attribute="Macro"/>
 			<RegExpr String="&apos;&rustIdent;(?!&apos;)" attribute="Lifetime"/>


### PR DESCRIPTION
This has to be the most pathetic pull request I've ever made, but the `[` in `#![some_attribute]` was not getting highlighted in KATE.
