### PR TITLE
collections: replace all ~[T] with Vec<T>.

### DIFF
--- a/src/libcollections/deque.rs
+++ b/src/libcollections/deque.rs
@@ -44,7 +44,6 @@ pub mod bench {
     extern crate test;
     use self::test::BenchHarness;
     use std::container::MutableMap;
-    use std::slice;
     use rand;
     use rand::Rng;
 
@@ -90,18 +89,18 @@ pub mod bench {
                                                 bh: &mut BenchHarness) {
         // setup
         let mut rng = rand::weak_rng();
-        let mut keys = slice::from_fn(n, |_| rng.gen::<uint>() % n);
+        let mut keys = Vec::from_fn(n, |_| rng.gen::<uint>() % n);
 
         for k in keys.iter() {
             map.insert(*k, 1);
         }
 
-        rng.shuffle(keys);
+        rng.shuffle(keys.as_mut_slice());
 
         // measure
         let mut i = 0;
         bh.iter(|| {
-            map.find(&(keys[i]));
+            map.find(keys.get(i));
             i = (i + 1) % n;
         })
     }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -739,12 +739,12 @@ mod tests {
             check_links(&m);
         }
 
-        let v = ~[1,2,3,4,5];
-        let u = ~[9,8,1,2,3,4,5];
-        let mut m = list_from(v);
-        m.append(list_from(u));
+        let v = vec![1,2,3,4,5];
+        let u = vec![9,8,1,2,3,4,5];
+        let mut m = list_from(v.as_slice());
+        m.append(list_from(u.as_slice()));
         check_links(&m);
-        let sum = v + u;
+        let sum = v.append(u.as_slice());
         assert_eq!(sum.len(), m.len());
         for elt in sum.move_iter() {
             assert_eq!(m.pop_front(), Some(elt))
@@ -763,12 +763,12 @@ mod tests {
             check_links(&m);
         }
 
-        let v = ~[1,2,3,4,5];
-        let u = ~[9,8,1,2,3,4,5];
-        let mut m = list_from(v);
-        m.prepend(list_from(u));
+        let v = vec![1,2,3,4,5];
+        let u = vec![9,8,1,2,3,4,5];
+        let mut m = list_from(v.as_slice());
+        m.prepend(list_from(u.as_slice()));
         check_links(&m);
-        let sum = u + v;
+        let sum = u.append(v.as_slice());
         assert_eq!(sum.len(), m.len());
         for elt in sum.move_iter() {
             assert_eq!(m.pop_front(), Some(elt))
@@ -783,11 +783,11 @@ mod tests {
         n.rotate_forward(); check_links(&n);
         assert_eq!(n.len(), 0);
 
-        let v = ~[1,2,3,4,5];
-        let mut m = list_from(v);
+        let v = vec![1,2,3,4,5];
+        let mut m = list_from(v.as_slice());
         m.rotate_backward(); check_links(&m);
         m.rotate_forward(); check_links(&m);
-        assert_eq!(v.iter().collect::<~[&int]>(), m.iter().collect());
+        assert_eq!(v.iter().collect::<Vec<&int>>(), m.iter().collect());
         m.rotate_forward(); check_links(&m);
         m.rotate_forward(); check_links(&m);
         m.pop_front(); check_links(&m);
@@ -795,7 +795,7 @@ mod tests {
         m.rotate_backward(); check_links(&m);
         m.push_front(9); check_links(&m);
         m.rotate_forward(); check_links(&m);
-        assert_eq!(~[3,9,5,1,2], m.move_iter().collect());
+        assert_eq!(vec![3,9,5,1,2], m.move_iter().collect());
     }
 
     #[test]
@@ -925,7 +925,7 @@ mod tests {
         }
         check_links(&m);
         assert_eq!(m.len(), 3 + len * 2);
-        assert_eq!(m.move_iter().collect::<~[int]>(), ~[-2,0,1,2,3,4,5,6,7,8,9,0,1]);
+        assert_eq!(m.move_iter().collect::<Vec<int>>(), vec![-2,0,1,2,3,4,5,6,7,8,9,0,1]);
     }
 
     #[test]
@@ -936,8 +936,8 @@ mod tests {
         m.merge(n, |a, b| a <= b);
         assert_eq!(m.len(), len);
         check_links(&m);
-        let res = m.move_iter().collect::<~[int]>();
-        assert_eq!(res, ~[-1, 0, 0, 0, 1, 3, 5, 6, 7, 2, 7, 7, 9]);
+        let res = m.move_iter().collect::<Vec<int>>();
+        assert_eq!(res, vec![-1, 0, 0, 0, 1, 3, 5, 6, 7, 2, 7, 7, 9]);
     }
 
     #[test]
@@ -952,7 +952,7 @@ mod tests {
         m.push_back(4);
         m.insert_ordered(3);
         check_links(&m);
-        assert_eq!(~[2,3,4], m.move_iter().collect::<~[int]>());
+        assert_eq!(vec![2,3,4], m.move_iter().collect::<Vec<int>>());
     }
 
     #[test]
@@ -974,7 +974,7 @@ mod tests {
         let n = list_from([1,2,3]);
         spawn(proc() {
             check_links(&n);
-            assert_eq!(~[&1,&2,&3], n.iter().collect::<~[&int]>());
+            assert_eq!(&[&1,&2,&3], n.iter().collect::<Vec<&int>>().as_slice());
         });
     }
 
@@ -1047,7 +1047,7 @@ mod tests {
     #[cfg(test)]
     fn fuzz_test(sz: int) {
         let mut m: DList<int> = DList::new();
-        let mut v = ~[];
+        let mut v = vec![];
         for i in range(0, sz) {
             check_links(&m);
             let r: u8 = rand::random();

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -246,24 +246,24 @@ mod test {
     fn test_iterator() {
         let mut e1: EnumSet<Foo> = EnumSet::empty();
 
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[], elems)
+        let elems: Vec<Foo> = e1.iter().collect();
+        assert!(elems.is_empty())
 
         e1.add(A);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A], elems)
 
         e1.add(C);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A,C], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A,C], elems)
 
         e1.add(C);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A,C], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A,C], elems)
 
         e1.add(B);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A,B,C], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A,B,C], elems)
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -280,15 +280,15 @@ mod test {
         e2.add(C);
 
         let e_union = e1 | e2;
-        let elems: ~[Foo] = e_union.iter().collect();
-        assert_eq!(~[A,B,C], elems)
+        let elems = e_union.iter().collect();
+        assert_eq!(vec![A,B,C], elems)
 
         let e_intersection = e1 & e2;
-        let elems: ~[Foo] = e_intersection.iter().collect();
-        assert_eq!(~[C], elems)
+        let elems = e_intersection.iter().collect();
+        assert_eq!(vec![C], elems)
 
         let e_subtract = e1 - e2;
-        let elems: ~[Foo] = e_subtract.iter().collect();
-        assert_eq!(~[A], elems)
+        let elems = e_subtract.iter().collect();
+        assert_eq!(vec![A], elems)
     }
 }

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -81,7 +81,7 @@ mod table {
     /// You can kind of think of this module/data structure as a safe wrapper
     /// around just the "table" part of the hashtable. It enforces some
     /// invariants at the type level and employs some performance trickery,
-    /// but in general is just a tricked out `~[Option<u64, K, V>]`.
+    /// but in general is just a tricked out `Vec<Option<u64, K, V>>`.
     ///
     /// FIXME(cgaebel):
     ///
@@ -1833,8 +1833,8 @@ mod test_map {
             hm
         };
 
-        let v = hm.move_iter().collect::<~[(char, int)]>();
-        assert!([('a', 1), ('b', 2)] == v || [('b', 2), ('a', 1)] == v);
+        let v = hm.move_iter().collect::<Vec<(char, int)>>();
+        assert!([('a', 1), ('b', 2)] == v.as_slice() || [('b', 2), ('a', 1)] == v.as_slice());
     }
 
     #[test]
@@ -1856,9 +1856,9 @@ mod test_map {
 
     #[test]
     fn test_keys() {
-        let vec = ~[(1, 'a'), (2, 'b'), (3, 'c')];
+        let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map = vec.move_iter().collect::<HashMap<int, char>>();
-        let keys = map.keys().map(|&k| k).collect::<~[int]>();
+        let keys = map.keys().map(|&k| k).collect::<Vec<int>>();
         assert_eq!(keys.len(), 3);
         assert!(keys.contains(&1));
         assert!(keys.contains(&2));
@@ -1867,9 +1867,9 @@ mod test_map {
 
     #[test]
     fn test_values() {
-        let vec = ~[(1, 'a'), (2, 'b'), (3, 'c')];
+        let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map = vec.move_iter().collect::<HashMap<int, char>>();
-        let values = map.values().map(|&v| v).collect::<~[char]>();
+        let values = map.values().map(|&v| v).collect::<Vec<char>>();
         assert_eq!(values.len(), 3);
         assert!(values.contains(&'a'));
         assert!(values.contains(&'b'));
@@ -1942,7 +1942,7 @@ mod test_map {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: HashMap<int, int> = xs.iter().map(|&x| x).collect();
 
@@ -2133,7 +2133,7 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let xs = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let set: HashSet<int> = xs.iter().map(|&x| x).collect();
 
@@ -2153,8 +2153,8 @@ mod test_set {
             hs
         };
 
-        let v = hs.move_iter().collect::<~[char]>();
-        assert!(['a', 'b'] == v || ['b', 'a'] == v);
+        let v = hs.move_iter().collect::<Vec<char>>();
+        assert!(['a', 'b'] == v.as_slice() || ['b', 'a'] == v.as_slice());
     }
 
     #[test]

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -22,6 +22,8 @@
 
 #![feature(macro_rules, managed_boxes, default_type_params, phase)]
 
+#![deny(deprecated_owned_vector)]
+
 extern crate rand;
 
 #[cfg(test)] extern crate test;

--- a/src/libcollections/lru_cache.rs
+++ b/src/libcollections/lru_cache.rs
@@ -294,10 +294,10 @@ mod tests {
 
     #[test]
     fn test_put_update() {
-        let mut cache: LruCache<~str, ~[u8]> = LruCache::new(1);
-        cache.put(~"1", ~[10, 10]);
-        cache.put(~"1", ~[10, 19]);
-        assert_opt_eq(cache.get(&~"1"), ~[10, 19]);
+        let mut cache: LruCache<~str, Vec<u8>> = LruCache::new(1);
+        cache.put(~"1", vec![10, 10]);
+        cache.put(~"1", vec![10, 19]);
+        assert_opt_eq(cache.get(&~"1"), vec![10, 19]);
         assert_eq!(cache.len(), 1);
     }
 

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -17,11 +17,11 @@
 
 use std::iter::{Enumerate, FilterMap, Rev};
 use std::mem::replace;
-use std::slice;
+use std::{vec, slice};
 
 #[allow(missing_doc)]
 pub struct SmallIntMap<T> {
-    v: ~[Option<T>],
+    v: Vec<Option<T>>,
 }
 
 impl<V> Container for SmallIntMap<V> {
@@ -45,7 +45,7 @@ impl<V> Map<uint, V> for SmallIntMap<V> {
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, key: &uint) -> Option<&'a V> {
         if *key < self.v.len() {
-            match self.v[*key] {
+            match *self.v.get(*key) {
               Some(ref value) => Some(value),
               None => None
             }
@@ -59,7 +59,7 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
     /// Return a mutable reference to the value corresponding to the key
     fn find_mut<'a>(&'a mut self, key: &uint) -> Option<&'a mut V> {
         if *key < self.v.len() {
-            match self.v[*key] {
+            match *self.v.get_mut(*key) {
               Some(ref mut value) => Some(value),
               None => None
             }
@@ -77,7 +77,7 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
         if len <= key {
             self.v.grow_fn(key - len + 1, |_| None);
         }
-        self.v[key] = Some(value);
+        *self.v.get_mut(key) = Some(value);
         !exists
     }
 
@@ -104,17 +104,17 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
         if *key >= self.v.len() {
             return None;
         }
-        self.v[*key].take()
+        self.v.get_mut(*key).take()
     }
 }
 
 impl<V> SmallIntMap<V> {
     /// Create an empty SmallIntMap
-    pub fn new() -> SmallIntMap<V> { SmallIntMap{v: ~[]} }
+    pub fn new() -> SmallIntMap<V> { SmallIntMap{v: vec!()} }
 
     /// Create an empty SmallIntMap with capacity `capacity`
     pub fn with_capacity(capacity: uint) -> SmallIntMap<V> {
-        SmallIntMap { v: slice::with_capacity(capacity) }
+        SmallIntMap { v: Vec::with_capacity(capacity) }
     }
 
     pub fn get<'a>(&'a self, key: &uint) -> &'a V {
@@ -158,9 +158,9 @@ impl<V> SmallIntMap<V> {
     /// Empties the hash map, moving all values into the specified closure
     pub fn move_iter(&mut self)
         -> FilterMap<(uint, Option<V>), (uint, V),
-                Enumerate<slice::MoveItems<Option<V>>>>
+                Enumerate<vec::MoveItems<Option<V>>>>
     {
-        let values = replace(&mut self.v, ~[]);
+        let values = replace(&mut self.v, vec!());
         values.move_iter().enumerate().filter_map(|(i, v)| {
             v.map(|v| (i, v))
         })

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -139,7 +139,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// Requires that it be frozen (immutable).
     pub fn iter<'a>(&'a self) -> Entries<'a, K, V> {
         Entries {
-            stack: ~[],
+            stack: vec!(),
             node: deref(&self.root),
             remaining_min: self.length,
             remaining_max: self.length
@@ -156,7 +156,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// map, with the values being mutable.
     pub fn mut_iter<'a>(&'a mut self) -> MutEntries<'a, K, V> {
         MutEntries {
-            stack: ~[],
+            stack: vec!(),
             node: mut_deref(&mut self.root),
             remaining_min: self.length,
             remaining_max: self.length
@@ -173,8 +173,8 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     pub fn move_iter(self) -> MoveEntries<K, V> {
         let TreeMap { root: root, length: length } = self;
         let stk = match root {
-            None => ~[],
-            Some(~tn) => ~[tn]
+            None => vec!(),
+            Some(~tn) => vec!(tn)
         };
         MoveEntries {
             stack: stk,
@@ -222,7 +222,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// `traverse_left`/`traverse_right`/`traverse_complete`.
     fn iter_for_traversal<'a>(&'a self) -> Entries<'a, K, V> {
         Entries {
-            stack: ~[],
+            stack: vec!(),
             node: deref(&self.root),
             remaining_min: 0,
             remaining_max: self.length
@@ -245,7 +245,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// `traverse_left`/`traverse_right`/`traverse_complete`.
     fn mut_iter_for_traversal<'a>(&'a mut self) -> MutEntries<'a, K, V> {
         MutEntries {
-            stack: ~[],
+            stack: vec!(),
             node: mut_deref(&mut self.root),
             remaining_min: 0,
             remaining_max: self.length
@@ -273,7 +273,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
 
 /// Lazy forward iterator over a map
 pub struct Entries<'a, K, V> {
-    stack: ~[&'a TreeNode<K, V>],
+    stack: Vec<&'a TreeNode<K, V>>,
     // See the comment on MutEntries; this is just to allow
     // code-sharing (for this immutable-values iterator it *could* very
     // well be Option<&'a TreeNode<K,V>>).
@@ -290,7 +290,7 @@ pub struct RevEntries<'a, K, V> {
 /// Lazy forward iterator over a map that allows for the mutation of
 /// the values.
 pub struct MutEntries<'a, K, V> {
-    stack: ~[&'a mut TreeNode<K, V>],
+    stack: Vec<&'a mut TreeNode<K, V>>,
     // Unfortunately, we require some unsafe-ness to get around the
     // fact that we would be storing a reference *into* one of the
     // nodes in the stack.
@@ -482,7 +482,7 @@ fn mut_deref<K, V>(x: &mut Option<~TreeNode<K, V>>) -> *mut TreeNode<K, V> {
 
 /// Lazy forward iterator over a map that consumes the map while iterating
 pub struct MoveEntries<K, V> {
-    stack: ~[TreeNode<K, V>],
+    stack: Vec<TreeNode<K, V>>,
     remaining: uint
 }
 
@@ -1143,9 +1143,9 @@ mod test_treemap {
     #[test]
     fn test_rand_int() {
         let mut map: TreeMap<int,int> = TreeMap::new();
-        let mut ctrl = ~[];
+        let mut ctrl = vec![];
 
-        check_equal(ctrl, &map);
+        check_equal(ctrl.as_slice(), &map);
         assert!(map.find(&5).is_none());
 
         let mut rng: rand::IsaacRng = rand::SeedableRng::from_seed(&[42]);
@@ -1158,7 +1158,7 @@ mod test_treemap {
                     assert!(map.insert(k, v));
                     ctrl.push((k, v));
                     check_structure(&map);
-                    check_equal(ctrl, &map);
+                    check_equal(ctrl.as_slice(), &map);
                 }
             }
 
@@ -1167,7 +1167,7 @@ mod test_treemap {
                 let (key, _) = ctrl.remove(r).unwrap();
                 assert!(map.remove(&key));
                 check_structure(&map);
-                check_equal(ctrl, &map);
+                check_equal(ctrl.as_slice(), &map);
             }
         }
     }
@@ -1414,7 +1414,7 @@ mod test_treemap {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: TreeMap<int, int> = xs.iter().map(|&x| x).collect();
 
@@ -1725,7 +1725,7 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let xs = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let set: TreeSet<int> = xs.iter().map(|&x| x).collect();
 

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -774,7 +774,7 @@ mod test_map {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[(1u, 1i), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = vec![(1u, 1i), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: TrieMap<int> = xs.iter().map(|&x| x).collect();
 
@@ -1042,7 +1042,7 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[9u, 8, 7, 6, 5, 4, 3, 2, 1];
+        let xs = vec![9u, 8, 7, 6, 5, 4, 3, 2, 1];
 
         let set: TrieSet = xs.iter().map(|&x| x).collect();
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -117,13 +117,15 @@ macro_rules! assert(
 #[macro_export]
 macro_rules! assert_eq(
     ($given:expr , $expected:expr) => ({
-        let given_val = &($given);
-        let expected_val = &($expected);
-        // check both directions of equality....
-        if !((*given_val == *expected_val) &&
-             (*expected_val == *given_val)) {
-            fail!("assertion failed: `(left == right) && (right == left)` \
-                   (left: `{}`, right: `{}`)", *given_val, *expected_val)
+        match (&($given), &($expected)) {
+            (given_val, expected_val) => {
+                // check both directions of equality....
+                if !((*given_val == *expected_val) &&
+                     (*expected_val == *given_val)) {
+                    fail!("assertion failed: `(left == right) && (right == left)` \
+                           (left: `{}`, right: `{}`)", *given_val, *expected_val)
+                }
+            }
         }
     })
 )


### PR DESCRIPTION
collections: replace all ~[T] with Vec<T>.
