### PR TITLE
Fix rustdoc field visibility checks

### DIFF
--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -135,7 +135,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             }
 
             clean::StructFieldItem(..) => {
-                if i.visibility == Some(ast::Private) {
+                if i.visibility != Some(ast::Public) {
                     return None;
                 }
             }


### PR DESCRIPTION
Fields are now default-private, not default-public
