### PR TITLE
libnative: Convert non-blocking fds to blocking when necessary

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2378,6 +2378,15 @@ pub mod consts {
             pub static CLOCK_MONOTONIC: c_int = 1;
 
             pub static WNOHANG: c_int = 1;
+
+            pub static F_GETFL: c_int = 3;
+            pub static F_SETFL: c_int = 4;
+            #[cfg(target_arch = "mips")]
+            pub static O_NONBLOCK: c_int = 0x0080;
+            #[cfg(target_arch = "arm")]
+            #[cfg(target_arch = "x86")]
+            #[cfg(target_arch = "x86_64")]
+            pub static O_NONBLOCK: c_int = 0o04000;
         }
         pub mod posix08 {
         }
@@ -2828,6 +2837,10 @@ pub mod consts {
             pub static CLOCK_MONOTONIC: c_int = 4;
 
             pub static WNOHANG: c_int = 1;
+
+            pub static F_GETFL: c_int = 3;
+            pub static F_SETFL: c_int = 4;
+            pub static O_NONBLOCK: c_int = 0x0004;
         }
         pub mod posix08 {
         }
@@ -3217,6 +3230,10 @@ pub mod consts {
             pub static PTHREAD_STACK_MIN: size_t = 8192;
 
             pub static WNOHANG: c_int = 1;
+
+            pub static F_GETFL: c_int = 3;
+            pub static F_SETFL: c_int = 4;
+            pub static O_NONBLOCK: c_int = 0x0004;
         }
         pub mod posix08 {
         }

--- a/src/test/run-make/libnative-nonblock/Makefile
+++ b/src/test/run-make/libnative-nonblock/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) write.rs
+	$(CC) -o $(TMPDIR)/mknblock mknblock.c
+	mkfifo $(TMPDIR)/fifo
+	/bin/sh -c "(sleep 1; cat) < $(TMPDIR)/fifo > /dev/null" &
+	/bin/sh -c "($(TMPDIR)/mknblock; $(TMPDIR)/write) > $(TMPDIR)/fifo"

--- a/src/test/run-make/libnative-nonblock/mknblock.c
+++ b/src/test/run-make/libnative-nonblock/mknblock.c
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#include <fcntl.h>
+#include <stdio.h>
+
+int main() {
+    if (fcntl(1, F_SETFL, O_NONBLOCK) == -1) {
+        perror("fcntl");
+        return 1;
+    }
+    return 0;
+}

--- a/src/test/run-make/libnative-nonblock/write.rs
+++ b/src/test/run-make/libnative-nonblock/write.rs
@@ -1,0 +1,33 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::io::IoResult;
+use std::os;
+
+fn run() -> IoResult<()> {
+    let mut out = io::stdio::stdout_raw();
+    for _ in range(0u, 1024) {
+        let mut buf = ['x' as u8, ..1024];
+        buf[1023] = '\n' as u8;
+        try!(out.write(buf));
+    }
+    Ok(())
+}
+
+fn main() {
+    match run() {
+        Err(e) => {
+            (writeln!(&mut io::stderr(), "Error: {}", e)).unwrap();
+            os::set_exit_status(1);
+        }
+        Ok(()) => ()
+    }
+}


### PR DESCRIPTION
When doing a read or write on a file descriptor, if it returns EAGAIN or
EWOULDBLOCK, we need to turn off the O_NONBLOCK flag and try again. This
can happen because TTYs and FIFOs share the file descriptor flags with
other processes.

Fixes #13336.
