### PR TITLE
std: Ignore a flaky std::comm test

### DIFF
--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -1935,5 +1935,5 @@ mod sync_tests {
             assert_eq!(tx.try_send(1), Sent);
         });
         assert_eq!(rx.recv(), 1);
-    })
+    } #[ignore(reason = "flaky on libnative")])
 }


### PR DESCRIPTION
This test relies on the parent to be descheduled before the child sends its
data. This has proved to be unreliable on libnative on the bots. It's a fairly
trivial test regardless, so ignoring it for now won't lose much.
