### PR TITLE
Rename ast::Purity and ast::Impure Function. Closes #7287

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -28,7 +28,7 @@ use syntax::parse::token;
 pub struct StaticMethodInfo {
     pub ident: ast::Ident,
     pub def_id: ast::DefId,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub vis: ast::Visibility,
 }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -330,11 +330,11 @@ fn item_to_def_like(item: ebml::Doc, did: ast::DefId, cnum: ast::CrateNum)
         MutStatic => DlDef(ast::DefStatic(did, true)),
         Struct    => DlDef(ast::DefStruct(did)),
         UnsafeFn  => DlDef(ast::DefFn(did, ast::UnsafeFn)),
-        Fn        => DlDef(ast::DefFn(did, ast::ImpureFn)),
+        Fn        => DlDef(ast::DefFn(did, ast::NormalFn)),
         ForeignFn => DlDef(ast::DefFn(did, ast::ExternFn)),
         StaticMethod | UnsafeStaticMethod => {
-            let purity = if fam == UnsafeStaticMethod { ast::UnsafeFn } else
-                { ast::ImpureFn };
+            let fn_style = if fam == UnsafeStaticMethod { ast::UnsafeFn } else
+                { ast::NormalFn };
             // def_static_method carries an optional field of its enclosing
             // trait or enclosing impl (if this is an inherent static method).
             // So we need to detect whether this is in a trait or not, which
@@ -348,7 +348,7 @@ fn item_to_def_like(item: ebml::Doc, did: ast::DefId, cnum: ast::CrateNum)
                 ast::FromImpl(item_reqd_and_translated_parent_item(cnum,
                                                                    item))
             };
-            DlDef(ast::DefStaticMethod(did, provenance, purity))
+            DlDef(ast::DefStaticMethod(did, provenance, fn_style))
         }
         Type | ForeignType => DlDef(ast::DefTy(did)),
         Mod => DlDef(ast::DefMod(did)),
@@ -905,17 +905,17 @@ pub fn get_static_methods_if_impl(intr: Rc<IdentInterner>,
         let family = item_family(impl_method_doc);
         match family {
             StaticMethod | UnsafeStaticMethod => {
-                let purity;
+                let fn_style;
                 match item_family(impl_method_doc) {
-                    StaticMethod => purity = ast::ImpureFn,
-                    UnsafeStaticMethod => purity = ast::UnsafeFn,
+                    StaticMethod => fn_style = ast::NormalFn,
+                    UnsafeStaticMethod => fn_style = ast::UnsafeFn,
                     _ => fail!()
                 }
 
                 static_impl_methods.push(StaticMethodInfo {
                     ident: item_name(&*intr, impl_method_doc),
                     def_id: item_def_id(impl_method_doc, cdata),
-                    purity: purity,
+                    fn_style: fn_style,
                     vis: item_visibility(impl_method_doc),
                 });
             }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -758,12 +758,12 @@ fn encode_method_ty_fields(ecx: &EncodeContext,
     encode_method_fty(ecx, ebml_w, &method_ty.fty);
     encode_visibility(ebml_w, method_ty.vis);
     encode_explicit_self(ebml_w, method_ty.explicit_self);
-    let purity = method_ty.fty.purity;
+    let fn_style = method_ty.fty.fn_style;
     match method_ty.explicit_self {
         ast::SelfStatic => {
-            encode_family(ebml_w, purity_static_method_family(purity));
+            encode_family(ebml_w, fn_style_static_method_family(fn_style));
         }
-        _ => encode_family(ebml_w, purity_fn_family(purity))
+        _ => encode_family(ebml_w, style_fn_family(fn_style))
     }
     encode_provided_source(ebml_w, method_ty.provided_source);
 }
@@ -811,18 +811,18 @@ fn encode_info_for_method(ecx: &EncodeContext,
     ebml_w.end_tag();
 }
 
-fn purity_fn_family(p: Purity) -> char {
-    match p {
+fn style_fn_family(s: FnStyle) -> char {
+    match s {
         UnsafeFn => 'u',
-        ImpureFn => 'f',
+        NormalFn => 'f',
         ExternFn => 'e'
     }
 }
 
-fn purity_static_method_family(p: Purity) -> char {
-    match p {
+fn fn_style_static_method_family(s: FnStyle) -> char {
+    match s {
         UnsafeFn => 'U',
-        ImpureFn => 'F',
+        NormalFn => 'F',
         _ => fail!("extern fn can't be static")
     }
 }
@@ -911,11 +911,11 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_visibility(ebml_w, vis);
         ebml_w.end_tag();
       }
-      ItemFn(_, purity, _, ref generics, _) => {
+      ItemFn(_, fn_style, _, ref generics, _) => {
         add_to_index(item, ebml_w, index);
         ebml_w.start_tag(tag_items_data_item);
         encode_def_id(ebml_w, def_id);
-        encode_family(ebml_w, purity_fn_family(purity));
+        encode_family(ebml_w, style_fn_family(fn_style));
         let tps_len = generics.ty_params.len();
         encode_bounds_and_type(ebml_w, ecx, &lookup_item_type(tcx, def_id));
         encode_name(ebml_w, item.ident.name);
@@ -1165,8 +1165,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
             match method_ty.explicit_self {
                 SelfStatic => {
                     encode_family(ebml_w,
-                                  purity_static_method_family(
-                                      method_ty.fty.purity));
+                                  fn_style_static_method_family(
+                                      method_ty.fty.fn_style));
 
                     let tpt = ty::lookup_item_type(tcx, method_def_id);
                     encode_bounds_and_type(ebml_w, ecx, &tpt);
@@ -1174,8 +1174,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
 
                 _ => {
                     encode_family(ebml_w,
-                                  purity_fn_family(
-                                      method_ty.fty.purity));
+                                  style_fn_family(
+                                      method_ty.fty.fn_style));
                 }
             }
 
@@ -1227,7 +1227,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
     encode_def_id(ebml_w, local_def(nitem.id));
     match nitem.node {
       ForeignItemFn(..) => {
-        encode_family(ebml_w, purity_fn_family(ImpureFn));
+        encode_family(ebml_w, style_fn_family(NormalFn));
         encode_bounds_and_type(ebml_w, ecx,
                                &lookup_item_type(ecx.tcx,local_def(nitem.id)));
         encode_name(ebml_w, nitem.ident.name);

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -449,12 +449,12 @@ fn parse_hex(st: &mut PState) -> uint {
     };
 }
 
-fn parse_purity(c: char) -> Purity {
+fn parse_fn_style(c: char) -> FnStyle {
     match c {
         'u' => UnsafeFn,
-        'i' => ImpureFn,
+        'n' => NormalFn,
         'c' => ExternFn,
-        _ => fail!("parse_purity: bad purity {}", c)
+        _ => fail!("parse_fn_style: bad fn_style {}", c)
     }
 }
 
@@ -476,13 +476,13 @@ fn parse_onceness(c: char) -> ast::Onceness {
 
 fn parse_closure_ty(st: &mut PState, conv: conv_did) -> ty::ClosureTy {
     let sigil = parse_sigil(st);
-    let purity = parse_purity(next(st));
+    let fn_style = parse_fn_style(next(st));
     let onceness = parse_onceness(next(st));
     let region = parse_region(st, |x,y| conv(x,y));
     let bounds = parse_bounds(st, |x,y| conv(x,y));
     let sig = parse_sig(st, |x,y| conv(x,y));
     ty::ClosureTy {
-        purity: purity,
+        fn_style: fn_style,
         sigil: sigil,
         onceness: onceness,
         region: region,
@@ -492,11 +492,11 @@ fn parse_closure_ty(st: &mut PState, conv: conv_did) -> ty::ClosureTy {
 }
 
 fn parse_bare_fn_ty(st: &mut PState, conv: conv_did) -> ty::BareFnTy {
-    let purity = parse_purity(next(st));
+    let fn_style = parse_fn_style(next(st));
     let abi = parse_abi_set(st);
     let sig = parse_sig(st, |x,y| conv(x,y));
     ty::BareFnTy {
-        purity: purity,
+        fn_style: fn_style,
         abi: abi,
         sig: sig
     }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -332,9 +332,9 @@ fn enc_sigil(w: &mut MemWriter, sigil: Sigil) {
     }
 }
 
-fn enc_purity(w: &mut MemWriter, p: Purity) {
+fn enc_fn_style(w: &mut MemWriter, p: FnStyle) {
     match p {
-        ImpureFn => mywrite!(w, "i"),
+        NormalFn => mywrite!(w, "n"),
         UnsafeFn => mywrite!(w, "u"),
         ExternFn => mywrite!(w, "c")
     }
@@ -354,14 +354,14 @@ fn enc_onceness(w: &mut MemWriter, o: Onceness) {
 }
 
 pub fn enc_bare_fn_ty(w: &mut MemWriter, cx: &ctxt, ft: &ty::BareFnTy) {
-    enc_purity(w, ft.purity);
+    enc_fn_style(w, ft.fn_style);
     enc_abi(w, ft.abi);
     enc_fn_sig(w, cx, &ft.sig);
 }
 
 fn enc_closure_ty(w: &mut MemWriter, cx: &ctxt, ft: &ty::ClosureTy) {
     enc_sigil(w, ft.sigil);
-    enc_purity(w, ft.purity);
+    enc_fn_style(w, ft.fn_style);
     enc_onceness(w, ft.onceness);
     enc_region(w, cx, ft.region);
     let bounds = ty::ParamBounds {builtin_bounds: ft.bounds,

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -29,8 +29,8 @@ enum UnsafeContext {
 
 fn type_is_unsafe_function(ty: ty::t) -> bool {
     match ty::get(ty).sty {
-        ty::ty_bare_fn(ref f) => f.purity == ast::UnsafeFn,
-        ty::ty_closure(ref f) => f.purity == ast::UnsafeFn,
+        ty::ty_bare_fn(ref f) => f.fn_style == ast::UnsafeFn,
+        ty::ty_closure(ref f) => f.fn_style == ast::UnsafeFn,
         _ => false,
     }
 }
@@ -84,10 +84,10 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
                 block: &ast::Block, span: Span, node_id: ast::NodeId, _:()) {
 
         let (is_item_fn, is_unsafe_fn) = match *fn_kind {
-            visit::FkItemFn(_, _, purity, _) =>
-                (true, purity == ast::UnsafeFn),
+            visit::FkItemFn(_, _, fn_style, _) =>
+                (true, fn_style == ast::UnsafeFn),
             visit::FkMethod(_, _, method) =>
-                (true, method.purity == ast::UnsafeFn),
+                (true, method.fn_style == ast::UnsafeFn),
             _ => (false, false),
         };
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1182,11 +1182,11 @@ impl<'a> Resolver<'a> {
                     (DefStatic(local_def(item.id), mutbl), sp, is_public);
                 parent
             }
-            ItemFn(_, purity, _, _, _) => {
+            ItemFn(_, fn_style, _, _, _) => {
               let (name_bindings, new_parent) =
                 self.add_child(ident, parent, ForbidDuplicateValues, sp);
 
-                let def = DefFn(local_def(item.id), purity);
+                let def = DefFn(local_def(item.id), fn_style);
                 name_bindings.define_value(def, sp, is_public);
                 new_parent
             }
@@ -1313,7 +1313,7 @@ impl<'a> Resolver<'a> {
                                     DefStaticMethod(local_def(method.id),
                                                       FromImpl(local_def(
                                                         item.id)),
-                                                      method.purity)
+                                                      method.fn_style)
                                 }
                                 _ => {
                                     // Non-static methods become
@@ -1364,7 +1364,7 @@ impl<'a> Resolver<'a> {
                             // Static methods become `def_static_method`s.
                             DefStaticMethod(local_def(ty_m.id),
                                               FromTrait(local_def(item.id)),
-                                              ty_m.purity)
+                                              ty_m.fn_style)
                         }
                         _ => {
                             // Non-static methods become `def_method`s.
@@ -1869,7 +1869,7 @@ impl<'a> Resolver<'a> {
                                                        DUMMY_SP);
                                     let def = DefFn(
                                         static_method_info.def_id,
-                                        static_method_info.purity);
+                                        static_method_info.fn_style);
 
                                     method_name_bindings.define_value(
                                         def, DUMMY_SP,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1554,8 +1554,8 @@ impl<'a> Visitor<()> for TransItemVisitor<'a> {
 pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
     let _icx = push_ctxt("trans_item");
     match item.node {
-      ast::ItemFn(decl, purity, _abi, ref generics, body) => {
-        if purity == ast::ExternFn  {
+      ast::ItemFn(decl, fn_style, _abi, ref generics, body) => {
+        if fn_style == ast::ExternFn  {
             let llfndecl = get_item_val(ccx, item.id);
             foreign::trans_rust_fn_with_foreign_abi(
                 ccx, decl, body, item.attrs.as_slice(), llfndecl, item.id);
@@ -1899,8 +1899,8 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
                     }
                 }
 
-                ast::ItemFn(_, purity, _, _, _) => {
-                    let llfn = if purity != ast::ExternFn {
+                ast::ItemFn(_, fn_style, _, _, _) => {
+                    let llfn = if fn_style != ast::ExternFn {
                         register_fn(ccx, i.span, sym, i.id, ty)
                     } else {
                         foreign::register_rust_fn_with_foreign_abi(ccx,

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -615,7 +615,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
 
             let opt_def = cx.tcx().def_map.borrow().find_copy(&e.id);
             match opt_def {
-                Some(ast::DefFn(def_id, _purity)) => {
+                Some(ast::DefFn(def_id, _fn_style)) => {
                     if !ast_util::is_local(def_id) {
                         let ty = csearch::get_type(cx.tcx(), def_id).ty;
                         (base::trans_external_path(cx, def_id, ty), true)

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -211,7 +211,7 @@ impl<'a> Reflector<'a> {
           // FIXME (#2594): fetch constants out of intrinsic
           // FIXME (#4809): visitor should break out bare fns from other fns
           ty::ty_closure(ref fty) => {
-            let pureval = ast_purity_constant(fty.purity);
+            let pureval = ast_fn_style_constant(fty.fn_style);
             let sigilval = ast_sigil_constant(fty.sigil);
             let retval = if ty::type_is_bot(fty.sig.output) {0u} else {1u};
             let extra = vec!(self.c_uint(pureval),
@@ -226,7 +226,7 @@ impl<'a> Reflector<'a> {
           // FIXME (#2594): fetch constants out of intrinsic:: for the
           // numbers.
           ty::ty_bare_fn(ref fty) => {
-            let pureval = ast_purity_constant(fty.purity);
+            let pureval = ast_fn_style_constant(fty.fn_style);
             let sigilval = 0u;
             let retval = if ty::type_is_bot(fty.sig.output) {0u} else {1u};
             let extra = vec!(self.c_uint(pureval),
@@ -399,10 +399,10 @@ pub fn ast_sigil_constant(sigil: ast::Sigil) -> uint {
     }
 }
 
-pub fn ast_purity_constant(purity: ast::Purity) -> uint {
-    match purity {
+pub fn ast_fn_style_constant(fn_style: ast::FnStyle) -> uint {
+    match fn_style {
         ast::UnsafeFn => 1u,
-        ast::ImpureFn => 2u,
+        ast::NormalFn => 2u,
         ast::ExternFn => 3u
     }
 }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -49,7 +49,7 @@ pub trait TypeFolder {
                        -> ty::BareFnTy {
         ty::BareFnTy { sig: self.fold_sig(&fty.sig),
                        abi: fty.abi,
-                       purity: fty.purity }
+                       fn_style: fty.fn_style }
     }
 
     fn fold_closure_ty(&mut self,
@@ -58,7 +58,7 @@ pub trait TypeFolder {
         ty::ClosureTy {
             region: self.fold_region(fty.region),
             sig: self.fold_sig(&fty.sig),
-            purity: fty.purity,
+            fn_style: fty.fn_style,
             sigil: fty.sigil,
             onceness: fty.onceness,
             bounds: fty.bounds,

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -523,7 +523,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                     tcx.sess.span_err(ast_ty.span,
                                       "variadic function must have C calling convention");
                 }
-                ty::mk_bare_fn(tcx, ty_of_bare_fn(this, ast_ty.id, bf.purity,
+                ty::mk_bare_fn(tcx, ty_of_bare_fn(this, ast_ty.id, bf.fn_style,
                                                   bf.abi, bf.decl))
             }
             ast::TyClosure(ref f) => {
@@ -543,7 +543,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                                             rscope,
                                             ast_ty.id,
                                             f.sigil,
-                                            f.purity,
+                                            f.fn_style,
                                             f.onceness,
                                             bounds,
                                             &f.region,
@@ -662,24 +662,24 @@ struct SelfInfo {
 pub fn ty_of_method<AC:AstConv>(
     this: &AC,
     id: ast::NodeId,
-    purity: ast::Purity,
+    fn_style: ast::FnStyle,
     untransformed_self_ty: ty::t,
     explicit_self: ast::ExplicitSelf,
     decl: &ast::FnDecl) -> ty::BareFnTy {
-    ty_of_method_or_bare_fn(this, id, purity, abi::Rust, Some(SelfInfo {
+    ty_of_method_or_bare_fn(this, id, fn_style, abi::Rust, Some(SelfInfo {
         untransformed_self_ty: untransformed_self_ty,
         explicit_self: explicit_self
     }), decl)
 }
 
 pub fn ty_of_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
-                                 purity: ast::Purity, abi: abi::Abi,
+                                 fn_style: ast::FnStyle, abi: abi::Abi,
                                  decl: &ast::FnDecl) -> ty::BareFnTy {
-    ty_of_method_or_bare_fn(this, id, purity, abi, None, decl)
+    ty_of_method_or_bare_fn(this, id, fn_style, abi, None, decl)
 }
 
 fn ty_of_method_or_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
-                                       purity: ast::Purity, abi: abi::Abi,
+                                       fn_style: ast::FnStyle, abi: abi::Abi,
                                        opt_self_info: Option<SelfInfo>,
                                        decl: &ast::FnDecl) -> ty::BareFnTy {
     debug!("ty_of_method_or_bare_fn");
@@ -725,7 +725,7 @@ fn ty_of_method_or_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
     };
 
     return ty::BareFnTy {
-        purity: purity,
+        fn_style: fn_style,
         abi: abi,
         sig: ty::FnSig {
             binder_id: id,
@@ -741,7 +741,7 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope>(
     rscope: &RS,
     id: ast::NodeId,
     sigil: ast::Sigil,
-    purity: ast::Purity,
+    fn_style: ast::FnStyle,
     onceness: ast::Onceness,
     bounds: ty::BuiltinBounds,
     opt_lifetime: &Option<ast::Lifetime>,
@@ -798,7 +798,7 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope>(
     };
 
     ty::ClosureTy {
-        purity: purity,
+        fn_style: fn_style,
         sigil: sigil,
         onceness: onceness,
         region: bound_region,

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1163,7 +1163,7 @@ impl<'a> LookupContext<'a> {
         let transformed_self_ty = *fn_sig.inputs.get(0);
         let fty = ty::mk_bare_fn(tcx, ty::BareFnTy {
             sig: fn_sig,
-            purity: bare_fn_ty.purity,
+            fn_style: bare_fn_ty.fn_style,
             abi: bare_fn_ty.abi.clone(),
         });
         debug!("after replacing bound regions, fty={}", self.ty_to_str(fty));

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -200,14 +200,14 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                 ty_method_of_trait_method(
                                     ccx, trait_id, &trait_ty_generics,
                                     &m.id, &m.ident, &m.explicit_self,
-                                    &m.generics, &m.purity, m.decl)
+                                    &m.generics, &m.fn_style, m.decl)
                             }
 
                             &ast::Provided(ref m) => {
                                 ty_method_of_trait_method(
                                     ccx, trait_id, &trait_ty_generics,
                                     &m.id, &m.ident, &m.explicit_self,
-                                    &m.generics, &m.purity, m.decl)
+                                    &m.generics, &m.fn_style, m.decl)
                             }
                         };
 
@@ -376,11 +376,11 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                  m_ident: &ast::Ident,
                                  m_explicit_self: &ast::ExplicitSelf,
                                  m_generics: &ast::Generics,
-                                 m_purity: &ast::Purity,
+                                 m_fn_style: &ast::FnStyle,
                                  m_decl: &ast::FnDecl) -> ty::Method
     {
         let trait_self_ty = ty::mk_self(this.tcx, local_def(trait_id));
-        let fty = astconv::ty_of_method(this, *m_id, *m_purity, trait_self_ty,
+        let fty = astconv::ty_of_method(this, *m_id, *m_fn_style, trait_self_ty,
                                         *m_explicit_self, m_decl);
         let num_trait_type_params = trait_generics.type_param_defs().len();
         let ty_generics = ty_generics_for_fn_or_method(this, m_generics,
@@ -508,7 +508,7 @@ fn convert_methods(ccx: &CrateCtxt,
                     rcvr_generics: &ast::Generics,
                     rcvr_visibility: ast::Visibility) -> ty::Method
     {
-        let fty = astconv::ty_of_method(ccx, m.id, m.purity,
+        let fty = astconv::ty_of_method(ccx, m.id, m.fn_style,
                                         untransformed_rcvr_ty,
                                         m.explicit_self, m.decl);
 
@@ -818,11 +818,11 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
             tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
-        ast::ItemFn(decl, purity, abi, ref generics, _) => {
+        ast::ItemFn(decl, fn_style, abi, ref generics, _) => {
             let ty_generics = ty_generics_for_fn_or_method(ccx, generics, 0);
             let tofd = astconv::ty_of_bare_fn(ccx,
                                               it.id,
-                                              purity,
+                                              fn_style,
                                               abi,
                                               decl);
             let tpt = ty_param_bounds_and_ty {
@@ -1029,7 +1029,7 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
         ccx.tcx,
         ty::BareFnTy {
             abi: abi,
-            purity: ast::UnsafeFn,
+            fn_style: ast::UnsafeFn,
             sig: ty::FnSig {binder_id: def_id.node,
                             inputs: input_tys,
                             output: output_ty,

--- a/src/librustc/middle/typeck/infer/coercion.rs
+++ b/src/librustc/middle/typeck/infer/coercion.rs
@@ -385,7 +385,7 @@ impl<'f> Coerce<'f> {
             debug!("coerce_from_bare_fn(a={}, b={})",
                    a.inf_str(self.get_ref().infcx), b.inf_str(self.get_ref().infcx));
 
-            if fn_ty_a.abi != abi::Rust || fn_ty_a.purity != ast::ImpureFn {
+            if fn_ty_a.abi != abi::Rust || fn_ty_a.fn_style != ast::NormalFn {
                 return self.subtype(a, b);
             }
 

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -64,7 +64,7 @@ use util::ppaux::Repr;
 
 use std::result;
 
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{Onceness, FnStyle};
 use syntax::ast;
 use syntax::owned_slice::OwnedSlice;
 use syntax::abi;
@@ -194,10 +194,10 @@ pub trait Combine {
 
     fn bare_fn_tys(&self, a: &ty::BareFnTy,
                    b: &ty::BareFnTy) -> cres<ty::BareFnTy> {
-        let purity = if_ok!(self.purities(a.purity, b.purity));
+        let fn_style = if_ok!(self.fn_styles(a.fn_style, b.fn_style));
         let abi = if_ok!(self.abi(a.abi, b.abi));
         let sig = if_ok!(self.fn_sigs(&a.sig, &b.sig));
-        Ok(ty::BareFnTy {purity: purity,
+        Ok(ty::BareFnTy {fn_style: fn_style,
                 abi: abi,
                 sig: sig})
     }
@@ -207,11 +207,11 @@ pub trait Combine {
 
         let p = if_ok!(self.sigils(a.sigil, b.sigil));
         let r = if_ok!(self.contraregions(a.region, b.region));
-        let purity = if_ok!(self.purities(a.purity, b.purity));
+        let fn_style = if_ok!(self.fn_styles(a.fn_style, b.fn_style));
         let onceness = if_ok!(self.oncenesses(a.onceness, b.onceness));
         let bounds = if_ok!(self.bounds(a.bounds, b.bounds));
         let sig = if_ok!(self.fn_sigs(&a.sig, &b.sig));
-        Ok(ty::ClosureTy {purity: purity,
+        Ok(ty::ClosureTy {fn_style: fn_style,
                 sigil: p,
                 onceness: onceness,
                 region: r,
@@ -246,7 +246,7 @@ pub trait Combine {
         }
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity>;
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle>;
 
     fn abi(&self, a: abi::Abi, b: abi::Abi) -> cres<abi::Abi> {
         if a == b {

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1102,10 +1102,10 @@ impl<'a> ErrorReportingHelpers for InferCtxt<'a> {
                                 output: ast::P<ast::Ty>,
                                 item: ast::P<ast::Item>,
                                 generics: ast::Generics) {
-        let (fn_decl, purity, ident) = match item.node {
+        let (fn_decl, fn_style, ident) = match item.node {
             // FIXME: handling method
-            ast::ItemFn(ref fn_decl, ref purity, _, _, _) => {
-                (fn_decl, purity, item.ident)
+            ast::ItemFn(ref fn_decl, ref fn_style, _, _, _) => {
+                (fn_decl, fn_style, item.ident)
             },
             _ => fail!("Expect function or method")
 
@@ -1117,7 +1117,7 @@ impl<'a> ErrorReportingHelpers for InferCtxt<'a> {
             variadic: fn_decl.variadic
         };
         let suggested_fn =
-            pprust::fun_to_str(&fd, *purity, ident, None, &generics);
+            pprust::fun_to_str(&fd, *fn_style, ident, None, &generics);
         let msg = format!("consider using an explicit lifetime \
                            parameter as shown: {}", suggested_fn);
         self.tcx.sess.span_note(item.span, msg);

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -22,8 +22,8 @@ use middle::typeck::infer::{cres, InferCtxt};
 use middle::typeck::infer::{TypeTrace, Subtype};
 use middle::typeck::infer::fold_regions_in_sig;
 use syntax::ast::{Many, Once, MutImmutable, MutMutable};
-use syntax::ast::{ExternFn, ImpureFn, UnsafeFn, NodeId};
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{ExternFn, NormalFn, UnsafeFn, NodeId};
+use syntax::ast::{Onceness, FnStyle};
 use collections::HashMap;
 use util::common::{indenter};
 use util::ppaux::mt_to_str;
@@ -81,10 +81,10 @@ impl<'f> Combine for Glb<'f> {
         Lub(*self.get_ref()).tys(a, b)
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity> {
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle> {
         match (a, b) {
           (ExternFn, _) | (_, ExternFn) => Ok(ExternFn),
-          (ImpureFn, _) | (_, ImpureFn) => Ok(ImpureFn),
+          (NormalFn, _) | (_, NormalFn) => Ok(NormalFn),
           (UnsafeFn, UnsafeFn) => Ok(UnsafeFn)
         }
     }

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -23,8 +23,8 @@ use middle::typeck::infer::fold_regions_in_sig;
 use middle::typeck::infer::{TypeTrace, Subtype};
 use collections::HashMap;
 use syntax::ast::{Many, Once, NodeId};
-use syntax::ast::{ExternFn, ImpureFn, UnsafeFn};
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{ExternFn, NormalFn, UnsafeFn};
+use syntax::ast::{Onceness, FnStyle};
 use util::ppaux::mt_to_str;
 
 pub struct Lub<'f>(pub CombineFields<'f>);  // least-upper-bound: common supertype
@@ -75,10 +75,10 @@ impl<'f> Combine for Lub<'f> {
         Glb(*self.get_ref()).tys(a, b)
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity> {
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle> {
         match (a, b) {
           (UnsafeFn, _) | (_, UnsafeFn) => Ok(UnsafeFn),
-          (ImpureFn, _) | (_, ImpureFn) => Ok(ImpureFn),
+          (NormalFn, _) | (_, NormalFn) => Ok(NormalFn),
           (ExternFn, ExternFn) => Ok(ExternFn),
         }
     }

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -25,7 +25,7 @@ use middle::typeck::infer::{TypeTrace, Subtype};
 use util::common::{indenter};
 use util::ppaux::bound_region_to_str;
 
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{Onceness, FnStyle};
 
 pub struct Sub<'f>(pub CombineFields<'f>);  // "subtype", "subregion" etc
 
@@ -87,9 +87,9 @@ impl<'f> Combine for Sub<'f> {
         }
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity> {
-        self.lub().purities(a, b).compare(b, || {
-            ty::terr_purity_mismatch(expected_found(self, a, b))
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle> {
+        self.lub().fn_styles(a, b).compare(b, || {
+            ty::terr_fn_style_mismatch(expected_found(self, a, b))
         })
     }
 

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -182,7 +182,7 @@ impl Env {
         let inputs = input_tys.map(|t| {mode: ast::expl(ast::by_copy),
                                         ty: *t});
         ty::mk_fn(self.tcx, FnTyBase {
-            meta: FnMeta {purity: ast::ImpureFn,
+            meta: FnMeta {fn_style: ast::NormalFn,
                           proto: ast::ProtoBare,
                           onceness: ast::Many,
                           region: ty::ReStatic,

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -357,7 +357,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
                 _ => ()
             }
             let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
-                purity: ast::ImpureFn,
+                fn_style: ast::NormalFn,
                 abi: abi::Rust,
                 sig: ty::FnSig {
                     binder_id: main_id,
@@ -403,7 +403,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
             }
 
             let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
-                purity: ast::ImpureFn,
+                fn_style: ast::NormalFn,
                 abi: abi::Rust,
                 sig: ty::FnSig {
                     binder_id: start_id,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -252,7 +252,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
         ty_to_str(cx, input)
     }
     fn bare_fn_to_str(cx: &ctxt,
-                      purity: ast::Purity,
+                      fn_style: ast::FnStyle,
                       abi: abi::Abi,
                       ident: Option<ast::Ident>,
                       sig: &ty::FnSig)
@@ -263,10 +263,10 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
             format!("extern {} ", abi.to_str())
         };
 
-        match purity {
-            ast::ImpureFn => {}
+        match fn_style {
+            ast::NormalFn => {}
             _ => {
-                s.push_str(purity.to_str());
+                s.push_str(fn_style.to_str());
                 s.push_char(' ');
             }
         };
@@ -305,10 +305,10 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
             }
         }
 
-        match cty.purity {
-            ast::ImpureFn => {}
+        match cty.fn_style {
+            ast::NormalFn => {}
             _ => {
-                s.push_str(cty.purity.to_str());
+                s.push_str(cty.fn_style.to_str());
                 s.push_char(' ');
             }
         };
@@ -405,7 +405,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
           closure_to_str(cx, *f)
       }
       ty_bare_fn(ref f) => {
-          bare_fn_to_str(cx, f.purity, f.abi, None, &f.sig)
+          bare_fn_to_str(cx, f.fn_style, f.abi, None, &f.sig)
       }
       ty_infer(infer_ty) => infer_ty.to_str(),
       ty_err => ~"[type error]",
@@ -812,8 +812,8 @@ impl Repr for ast::Visibility {
 
 impl Repr for ty::BareFnTy {
     fn repr(&self, tcx: &ctxt) -> ~str {
-        format!("BareFnTy \\{purity: {:?}, abi: {}, sig: {}\\}",
-             self.purity,
+        format!("BareFnTy \\{fn_style: {:?}, abi: {}, sig: {}\\}",
+             self.fn_style,
              self.abi.to_str(),
              self.sig.repr(tcx))
     }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -356,7 +356,7 @@ impl Clean<Generics> for ast::Generics {
 pub struct Method {
     pub generics: Generics,
     pub self_: SelfTy,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub decl: FnDecl,
 }
 
@@ -383,7 +383,7 @@ impl Clean<Item> for ast::Method {
             inner: MethodItem(Method {
                 generics: self.generics.clean(),
                 self_: self.explicit_self.clean(),
-                purity: self.purity.clone(),
+                fn_style: self.fn_style.clone(),
                 decl: decl,
             }),
         }
@@ -392,7 +392,7 @@ impl Clean<Item> for ast::Method {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct TyMethod {
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub decl: FnDecl,
     pub generics: Generics,
     pub self_: SelfTy,
@@ -419,7 +419,7 @@ impl Clean<Item> for ast::TypeMethod {
             id: self.id,
             visibility: None,
             inner: TyMethodItem(TyMethod {
-                purity: self.purity.clone(),
+                fn_style: self.fn_style.clone(),
                 decl: decl,
                 self_: self.explicit_self.clean(),
                 generics: self.generics.clean(),
@@ -451,7 +451,7 @@ impl Clean<SelfTy> for ast::ExplicitSelf {
 pub struct Function {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
 }
 
 impl Clean<Item> for doctree::Function {
@@ -465,7 +465,7 @@ impl Clean<Item> for doctree::Function {
             inner: FunctionItem(Function {
                 decl: self.decl.clean(),
                 generics: self.generics.clean(),
-                purity: self.purity,
+                fn_style: self.fn_style,
             }),
         }
     }
@@ -478,7 +478,7 @@ pub struct ClosureDecl {
     pub lifetimes: Vec<Lifetime>,
     pub decl: FnDecl,
     pub onceness: ast::Onceness,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub bounds: Vec<TyParamBound>,
 }
 
@@ -490,7 +490,7 @@ impl Clean<ClosureDecl> for ast::ClosureTy {
             lifetimes: self.lifetimes.clean().move_iter().collect(),
             decl: self.decl.clean(),
             onceness: self.onceness,
-            purity: self.purity,
+            fn_style: self.fn_style,
             bounds: match self.bounds {
                 Some(ref x) => x.clean().move_iter().collect(),
                 None        => Vec::new()
@@ -960,7 +960,7 @@ impl Clean<Item> for doctree::Typedef {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct BareFunctionDecl {
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub generics: Generics,
     pub decl: FnDecl,
     pub abi: ~str,
@@ -969,7 +969,7 @@ pub struct BareFunctionDecl {
 impl Clean<BareFunctionDecl> for ast::BareFnTy {
     fn clean(&self) -> BareFunctionDecl {
         BareFunctionDecl {
-            purity: self.purity,
+            fn_style: self.fn_style,
             generics: Generics {
                 lifetimes: self.lifetimes.clean().move_iter().collect(),
                 type_params: Vec::new(),
@@ -1164,7 +1164,7 @@ impl Clean<Item> for ast::ForeignItem {
                 ForeignFunctionItem(Function {
                     decl: decl.clean(),
                     generics: generics.clean(),
-                    purity: ast::ExternFn,
+                    fn_style: ast::ExternFn,
                 })
             }
             ast::ForeignItemStatic(ref ty, mutbl) => {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -113,7 +113,7 @@ pub struct Function {
     pub id: NodeId,
     pub name: Ident,
     pub vis: ast::Visibility,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub where: Span,
     pub generics: ast::Generics,
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -29,9 +29,9 @@ use html::render::{cache_key, current_location_key};
 /// Helper to render an optional visibility with a space after it (if the
 /// visibility is preset)
 pub struct VisSpace(pub Option<ast::Visibility>);
-/// Similarly to VisSpace, this structure is used to render a purity with a
+/// Similarly to VisSpace, this structure is used to render a function style with a
 /// space after it.
-pub struct PuritySpace(pub ast::Purity);
+pub struct FnStyleSpace(pub ast::FnStyle);
 /// Wrapper struct for properly emitting a method declaration.
 pub struct Method<'a>(pub &'a clean::SelfTy, pub &'a clean::FnDecl);
 
@@ -41,9 +41,9 @@ impl VisSpace {
     }
 }
 
-impl PuritySpace {
-    pub fn get(&self) -> ast::Purity {
-        let PuritySpace(v) = *self; v
+impl FnStyleSpace {
+    pub fn get(&self) -> ast::FnStyle {
+        let FnStyleSpace(v) = *self; v
     }
 }
 
@@ -343,7 +343,7 @@ impl fmt::Show for clean::Type {
                 };
 
                 write!(f.buf, "{}{}{arrow, select, yes{ -&gt; {ret}} other{}}",
-                       PuritySpace(decl.purity),
+                       FnStyleSpace(decl.fn_style),
                        match decl.sigil {
                            ast::OwnedSigil => format!("proc({})", decl.decl.inputs),
                            ast::BorrowedSigil => format!("{}|{}|", region, decl.decl.inputs),
@@ -355,7 +355,7 @@ impl fmt::Show for clean::Type {
             }
             clean::BareFunction(ref decl) => {
                 write!(f.buf, "{}{}fn{}{}",
-                       PuritySpace(decl.purity),
+                       FnStyleSpace(decl.fn_style),
                        match decl.abi {
                            ref x if "" == *x => ~"",
                            ref x if "\"Rust\"" == *x => ~"",
@@ -472,12 +472,12 @@ impl fmt::Show for VisSpace {
     }
 }
 
-impl fmt::Show for PuritySpace {
+impl fmt::Show for FnStyleSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.get() {
             ast::UnsafeFn => write!(f.buf, "unsafe "),
             ast::ExternFn => write!(f.buf, "extern "),
-            ast::ImpureFn => Ok(())
+            ast::NormalFn => Ok(())
         }
     }
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -51,7 +51,7 @@ use rustc::util::nodemap::NodeSet;
 use clean;
 use doctree;
 use fold::DocFolder;
-use html::format::{VisSpace, Method, PuritySpace};
+use html::format::{VisSpace, Method, FnStyleSpace};
 use html::layout;
 use html::markdown;
 use html::markdown::Markdown;
@@ -1178,10 +1178,10 @@ fn item_module(w: &mut Writer, cx: &Context,
 
 fn item_function(w: &mut Writer, it: &clean::Item,
                  f: &clean::Function) -> fmt::Result {
-    try!(write!(w, "<pre class='rust fn'>{vis}{purity}fn \
+    try!(write!(w, "<pre class='rust fn'>{vis}{fn_style}fn \
                     {name}{generics}{decl}</pre>",
            vis = VisSpace(it.visibility),
-           purity = PuritySpace(f.purity),
+           fn_style = FnStyleSpace(f.fn_style),
            name = it.name.get_ref().as_slice(),
            generics = f.generics,
            decl = f.decl));
@@ -1292,12 +1292,12 @@ fn item_trait(w: &mut Writer, it: &clean::Item,
 }
 
 fn render_method(w: &mut Writer, meth: &clean::Item) -> fmt::Result {
-    fn fun(w: &mut Writer, it: &clean::Item, purity: ast::Purity,
+    fn fun(w: &mut Writer, it: &clean::Item, fn_style: ast::FnStyle,
            g: &clean::Generics, selfty: &clean::SelfTy,
            d: &clean::FnDecl) -> fmt::Result {
         write!(w, "{}fn <a href='\\#{ty}.{name}' class='fnname'>{name}</a>\
                    {generics}{decl}",
-               match purity {
+               match fn_style {
                    ast::UnsafeFn => "unsafe ",
                    _ => "",
                },
@@ -1308,10 +1308,10 @@ fn render_method(w: &mut Writer, meth: &clean::Item) -> fmt::Result {
     }
     match meth.inner {
         clean::TyMethodItem(ref m) => {
-            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl)
+            fun(w, meth, m.fn_style, &m.generics, &m.self_, &m.decl)
         }
         clean::MethodItem(ref m) => {
-            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl)
+            fun(w, meth, m.fn_style, &m.generics, &m.self_, &m.decl)
         }
         _ => unreachable!()
     }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -95,7 +95,7 @@ impl<'a> RustdocVisitor<'a> {
     }
 
     pub fn visit_fn(&mut self, item: &ast::Item, fd: &ast::FnDecl,
-                    purity: &ast::Purity, _abi: &abi::Abi,
+                    fn_style: &ast::FnStyle, _abi: &abi::Abi,
                     gen: &ast::Generics) -> Function {
         debug!("Visiting fn");
         Function {
@@ -106,7 +106,7 @@ impl<'a> RustdocVisitor<'a> {
             name: item.ident,
             where: item.span,
             generics: gen.clone(),
-            purity: *purity,
+            fn_style: *fn_style,
         }
     }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -210,8 +210,8 @@ pub enum MethodProvenance {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub enum Def {
-    DefFn(DefId, Purity),
-    DefStaticMethod(/* method */ DefId, MethodProvenance, Purity),
+    DefFn(DefId, FnStyle),
+    DefStaticMethod(/* method */ DefId, MethodProvenance, FnStyle),
     DefSelfTy(/* trait id */ NodeId),
     DefMod(DefId),
     DefForeignMod(DefId),
@@ -696,7 +696,7 @@ pub struct TypeField {
 pub struct TypeMethod {
     pub ident: Ident,
     pub attrs: Vec<Attribute>,
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub decl: P<FnDecl>,
     pub generics: Generics,
     pub explicit_self: ExplicitSelf,
@@ -794,7 +794,7 @@ pub struct ClosureTy {
     pub sigil: Sigil,
     pub region: Option<Lifetime>,
     pub lifetimes: Vec<Lifetime>,
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub onceness: Onceness,
     pub decl: P<FnDecl>,
     // Optional optvec distinguishes between "fn()" and "fn:()" so we can
@@ -806,7 +806,7 @@ pub struct ClosureTy {
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct BareFnTy {
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub abi: Abi,
     pub lifetimes: Vec<Lifetime>,
     pub decl: P<FnDecl>
@@ -886,16 +886,16 @@ pub struct FnDecl {
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
-pub enum Purity {
+pub enum FnStyle {
     UnsafeFn, // declared with "unsafe fn"
-    ImpureFn, // declared with "fn"
+    NormalFn, // declared with "fn"
     ExternFn, // declared with "extern fn"
 }
 
-impl fmt::Show for Purity {
+impl fmt::Show for FnStyle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ImpureFn => "impure".fmt(f),
+            NormalFn => "normal".fmt(f),
             UnsafeFn => "unsafe".fmt(f),
             ExternFn => "extern".fmt(f),
         }
@@ -925,7 +925,7 @@ pub struct Method {
     pub attrs: Vec<Attribute>,
     pub generics: Generics,
     pub explicit_self: ExplicitSelf,
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub decl: P<FnDecl>,
     pub body: P<Block>,
     pub id: NodeId,
@@ -1119,7 +1119,7 @@ pub struct Item {
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub enum Item_ {
     ItemStatic(P<Ty>, Mutability, @Expr),
-    ItemFn(P<FnDecl>, Purity, Abi, Generics, P<Block>),
+    ItemFn(P<FnDecl>, FnStyle, Abi, Generics, P<Block>),
     ItemMod(Mod),
     ItemForeignMod(ForeignMod),
     ItemTy(P<Ty>, Generics),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -264,7 +264,7 @@ pub fn trait_method_to_ty_method(method: &TraitMethod) -> TypeMethod {
             TypeMethod {
                 ident: m.ident,
                 attrs: m.attrs.clone(),
-                purity: m.purity,
+                fn_style: m.fn_style,
                 decl: m.decl,
                 generics: m.generics.clone(),
                 explicit_self: m.explicit_self,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -825,7 +825,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                   name,
                   Vec::new(),
                   ast::ItemFn(self.fn_decl(inputs, output),
-                              ast::ImpureFn,
+                              ast::NormalFn,
                               abi::Rust,
                               generics,
                               body))

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -619,7 +619,7 @@ impl<'a> MethodDef<'a> {
             attrs: attrs,
             generics: fn_generics,
             explicit_self: explicit_self,
-            purity: ast::ImpureFn,
+            fn_style: ast::NormalFn,
             decl: fn_decl,
             body: body_block,
             id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -158,7 +158,7 @@ pub trait Folder {
             TyClosure(ref f) => {
                 TyClosure(@ClosureTy {
                     sigil: f.sigil,
-                    purity: f.purity,
+                    fn_style: f.fn_style,
                     region: fold_opt_lifetime(&f.region, self),
                     onceness: f.onceness,
                     bounds: fold_opt_bounds(&f.bounds, self),
@@ -169,7 +169,7 @@ pub trait Folder {
             TyBareFn(ref f) => {
                 TyBareFn(@BareFnTy {
                     lifetimes: f.lifetimes.iter().map(|l| fold_lifetime(l, self)).collect(),
-                    purity: f.purity,
+                    fn_style: f.fn_style,
                     abi: f.abi,
                     decl: self.fold_fn_decl(f.decl)
                 })
@@ -549,10 +549,10 @@ pub fn noop_fold_item_underscore<T: Folder>(i: &Item_, folder: &mut T) -> Item_ 
         ItemStatic(t, m, e) => {
             ItemStatic(folder.fold_ty(t), m, folder.fold_expr(e))
         }
-        ItemFn(decl, purity, abi, ref generics, body) => {
+        ItemFn(decl, fn_style, abi, ref generics, body) => {
             ItemFn(
                 folder.fold_fn_decl(decl),
-                purity,
+                fn_style,
                 abi,
                 fold_generics(generics, folder),
                 folder.fold_block(body)
@@ -603,7 +603,7 @@ pub fn noop_fold_type_method<T: Folder>(m: &TypeMethod, fld: &mut T) -> TypeMeth
         id: fld.new_id(m.id), // Needs to be first, for ast_map.
         ident: fld.fold_ident(m.ident),
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, fld)).collect(),
-        purity: m.purity,
+        fn_style: m.fn_style,
         decl: fld.fold_fn_decl(m.decl),
         generics: fold_generics(&m.generics, fld),
         explicit_self: fld.fold_explicit_self(&m.explicit_self),
@@ -680,7 +680,7 @@ pub fn noop_fold_method<T: Folder>(m: &Method, folder: &mut T) -> @Method {
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, folder)).collect(),
         generics: fold_generics(&m.generics, folder),
         explicit_self: folder.fold_explicit_self(&m.explicit_self),
-        purity: m.purity,
+        fn_style: m.fn_style,
         decl: folder.fold_fn_decl(m.decl),
         body: folder.fold_block(m.body),
         span: folder.new_span(m.span),

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -657,7 +657,7 @@ mod test {
                                 cf: ast::Return,
                                 variadic: false
                             }),
-                                    ast::ImpureFn,
+                                    ast::NormalFn,
                                     abi::Rust,
                                     ast::Generics{ // no idea on either of these:
                                         lifetimes: Vec::new(),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -29,7 +29,7 @@ use owned_slice::OwnedSlice;
 
 pub enum FnKind<'a> {
     // fn foo() or extern "Abi" fn foo()
-    FkItemFn(Ident, &'a Generics, Purity, Abi),
+    FkItemFn(Ident, &'a Generics, FnStyle, Abi),
 
     // fn foo(&self)
     FkMethod(Ident, &'a Generics, &'a Method),
@@ -207,8 +207,8 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
             visitor.visit_ty(typ, env.clone());
             visitor.visit_expr(expr, env);
         }
-        ItemFn(declaration, purity, abi, ref generics, body) => {
-            visitor.visit_fn(&FkItemFn(item.ident, generics, purity, abi),
+        ItemFn(declaration, fn_style, abi, ref generics, body) => {
+            visitor.visit_fn(&FkItemFn(item.ident, generics, fn_style, abi),
                              declaration,
                              body,
                              item.span,

--- a/src/test/compile-fail/trait-impl-method-mismatch.rs
+++ b/src/test/compile-fail/trait-impl-method-mismatch.rs
@@ -17,7 +17,7 @@ trait Mumbo {
 impl Mumbo for uint {
     // Cannot have a larger effect than the trait:
     unsafe fn jumbo(&self, x: @uint) { *self + *x; }
-    //~^ ERROR expected impure fn but found unsafe fn
+    //~^ ERROR expected normal fn but found unsafe fn
 }
 
 fn main() {}


### PR DESCRIPTION
Renamed ast::Purity to ast::FnStyle and ast::ImpureFn to ast::NormalFn.
Additionally updated associated variable and function names and test cases.
Fixes #7287
