### PR TITLE
Remove FIXME referring to a closed issue (#3654)

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2012-2014 Mozilla Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/test/run-pass/reexport-star.rs
+++ b/src/test/run-pass/reexport-star.rs
@@ -12,8 +12,6 @@
 
 #![feature(globs)]
 
-// FIXME #3654
-
 mod a {
     pub fn f() {}
     pub fn g() {}


### PR DESCRIPTION
Issue #3654 had already been fixed and closed, but the FIXME comment has
not been removed. This commit removes the FIXME comment.
