### PR TITLE
Made libflate functions return Options instead of outright failing

### DIFF
--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -56,7 +56,10 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
                       archive.read(format!("{}.bc.deflate", name)));
         let bc = bc.expect("missing compressed bytecode in archive!");
         let bc = time(sess.time_passes(), format!("inflate {}.bc", name), (), |_|
-                      flate::inflate_bytes(bc));
+                      match flate::inflate_bytes(bc) {
+                          Some(bc) => bc,
+                          None => sess.fatal(format!("failed to decompress bc of `{}`", name))
+                      });
         let ptr = bc.as_slice().as_ptr();
         debug!("linking {}", name);
         time(sess.time_passes(), format!("ll link {}", name), (), |()| unsafe {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -494,14 +494,17 @@ fn get_metadata_section_imp(os: Os, filename: &Path) -> Result<MetadataBlob, ~st
                 let version_ok = slice::raw::buf_as_slice(cvbuf, minsz,
                     |buf0| buf0 == encoder::metadata_encoding_version);
                 if !version_ok { return Err(format!("incompatible metadata version found: '{}'",
-                                                    filename.display()));}
+                                                    filename.display())); }
 
                 let cvbuf1 = cvbuf.offset(vlen as int);
                 debug!("inflating {} bytes of compressed metadata",
                        csz - vlen);
                 slice::raw::buf_as_slice(cvbuf1, csz-vlen, |bytes| {
-                    let inflated = flate::inflate_bytes(bytes);
-                    found = Ok(MetadataVec(inflated));
+                    match flate::inflate_bytes(bytes) {
+                        Some(inflated) => found = Ok(MetadataVec(inflated)),
+                        None => found = Err(format!("failed to decompress metadata for: '{}'",
+                                                    filename.display()))
+                    }
                 });
                 if found.is_ok() {
                     return found;


### PR DESCRIPTION
This should make the library slightly more pleasant to use, and make the compiler errors related to corrupt rlibs more sensible (i.e not failing on an assert)

In addition, Github seems to think I'm a completely different person
