### PR TITLE
rustc: Run destructors when dest=Ignore

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -936,7 +936,7 @@ pub fn init_local<'a>(bcx: &'a Block<'a>, local: &ast::Local)
         // Handle let _ = e; just like e;
         match local.init {
             Some(init) => {
-              return expr::trans_into(bcx, init, expr::Ignore);
+                return controlflow::trans_stmt_semi(bcx, init)
             }
             None => { return bcx; }
         }

--- a/src/test/run-pass/issue-4734.rs
+++ b/src/test/run-pass/issue-4734.rs
@@ -1,0 +1,44 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ensures that destructors are run for expressions of the form "e;" where
+// `e` is a type which requires a destructor.
+
+#![allow(path_statement)]
+
+struct A { n: int }
+struct B;
+
+static mut NUM_DROPS: uint = 0;
+
+impl Drop for A {
+    fn drop(&mut self) {
+        unsafe { NUM_DROPS += 1; }
+    }
+}
+
+impl Drop for B {
+    fn drop(&mut self) {
+        unsafe { NUM_DROPS += 1; }
+    }
+}
+
+fn main() {
+    assert_eq!(unsafe { NUM_DROPS }, 0);
+    { let _a = A { n: 1 }; }
+    assert_eq!(unsafe { NUM_DROPS }, 1);
+    { A { n: 3 }; }
+    assert_eq!(unsafe { NUM_DROPS }, 2);
+
+    { let _b = B; }
+    assert_eq!(unsafe { NUM_DROPS }, 3);
+    { B; }
+    assert_eq!(unsafe { NUM_DROPS }, 4);
+}

--- a/src/test/run-pass/issue-6892.rs
+++ b/src/test/run-pass/issue-6892.rs
@@ -1,0 +1,52 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ensures that destructors are run for expressions of the form "let _ = e;"
+// where `e` is a type which requires a destructor.
+
+struct Foo;
+struct Bar { x: int }
+struct Baz(int);
+
+static mut NUM_DROPS: uint = 0;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        unsafe { NUM_DROPS += 1; }
+    }
+}
+impl Drop for Bar {
+    fn drop(&mut self) {
+        unsafe { NUM_DROPS += 1; }
+    }
+}
+impl Drop for Baz {
+    fn drop(&mut self) {
+        unsafe { NUM_DROPS += 1; }
+    }
+}
+
+fn main() {
+    assert_eq!(unsafe { NUM_DROPS }, 0);
+    { let _x = Foo; }
+    assert_eq!(unsafe { NUM_DROPS }, 1);
+    { let _x = Bar { x: 21 }; }
+    assert_eq!(unsafe { NUM_DROPS }, 2);
+    { let _x = Baz(21); }
+    assert_eq!(unsafe { NUM_DROPS }, 3);
+
+    assert_eq!(unsafe { NUM_DROPS }, 3);
+    { let _ = Foo; }
+    assert_eq!(unsafe { NUM_DROPS }, 4);
+    { let _ = Bar { x: 21 }; }
+    assert_eq!(unsafe { NUM_DROPS }, 5);
+    { let _ = Baz(21); }
+    assert_eq!(unsafe { NUM_DROPS }, 6);
+}


### PR DESCRIPTION
Previously, if statements of the form "Foo;" or "let _ = Foo;" were encountered
where Foo had a destructor, the destructors were not run. This changes
the relevant locations in trans to check for ty::type_needs_drop and invokes
trans_to_lvalue instead of trans_into.

Closes #4734
Closes #6892
