### PR TITLE
Add the name of the copyright holder and year

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,4 @@
-Copyright (c) 2006-2009 Graydon Hoare
-Copyright (c) 2009-2014 Mozilla Foundation
+Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
The years of copyright and the name of the copyright holder were not
present in the notice.

The Apache license was added to the project in 2012, so 2012 is the
starting year. The copyright holder is the Mozilla Foundation (taken
from the MIT license).
