### PR TITLE
rustc: Remove absolute rpaths

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -358,16 +358,12 @@ CFGFLAG$(1)_T_$(2)_H_$(3) = stage1
 endif
 endif
 
-ifdef CFG_DISABLE_RPATH
 ifeq ($$(OSTYPE_$(3)),apple-darwin)
   RPATH_VAR$(1)_T_$(2)_H_$(3) := \
       DYLD_LIBRARY_PATH="$$$$DYLD_LIBRARY_PATH:$$(CURDIR)/$$(HLIB$(1)_H_$(3))"
 else
   RPATH_VAR$(1)_T_$(2)_H_$(3) := \
       LD_LIBRARY_PATH="$$$$LD_LIBRARY_PATH:$$(CURDIR)/$$(HLIB$(1)_H_$(3))"
-endif
-else
-    RPATH_VAR$(1)_T_$(2)_H_$(3) :=
 endif
 
 STAGE$(1)_T_$(2)_H_$(3) := 						\

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -42,23 +42,14 @@ pub fn get_rpath_flags(sess: &Session, out_filename: &Path) -> Vec<~str> {
     let sysroot = sess.filesearch().sysroot;
     let output = out_filename;
     let libs = sess.cstore.get_used_crates(cstore::RequireDynamic);
-    let libs = libs.move_iter().filter_map(|(_, l)| l.map(|p| p.clone())).collect();
-    // We don't currently rpath extern libraries, but we know
-    // where rustrt is and we know every rust program needs it
-    let libs = slice::append_one(libs, get_sysroot_absolute_rt_lib(sess));
+    let libs = libs.move_iter().filter_map(|(_, l)| {
+        l.map(|p| p.clone())
+    }).collect::<~[_]>();
 
     let rpaths = get_rpaths(os, sysroot, output, libs,
                             sess.opts.target_triple);
     flags.push_all(rpaths_to_flags(rpaths.as_slice()).as_slice());
     flags
-}
-
-fn get_sysroot_absolute_rt_lib(sess: &Session) -> Path {
-    let sysroot = sess.filesearch().sysroot;
-    let r = filesearch::relative_target_lib_path(sysroot, sess.opts.target_triple);
-    let mut p = sysroot.join(&r);
-    p.push(os::dll_filename("rustrt"));
-    p
 }
 
 pub fn rpaths_to_flags(rpaths: &[~str]) -> Vec<~str> {

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -12,9 +12,10 @@
 use driver::session::Session;
 use metadata::cstore;
 use metadata::filesearch;
+use util::fs;
 
 use collections::HashSet;
-use std::{os, slice};
+use std::os;
 use syntax::abi;
 
 fn not_win32(os: abi::Os) -> bool {
@@ -121,9 +122,9 @@ pub fn get_rpath_relative_to_output(os: abi::Os,
         abi::OsWin32 => unreachable!()
     };
 
-    let mut lib = os::make_absolute(lib);
+    let mut lib = fs::realpath(&os::make_absolute(lib)).unwrap();
     lib.pop();
-    let mut output = os::make_absolute(output);
+    let mut output = fs::realpath(&os::make_absolute(output)).unwrap();
     output.pop();
     let relative = lib.path_relative_from(&output);
     let relative = relative.expect("could not create rpath relative to output");

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -127,6 +127,7 @@ pub mod util {
     pub mod ppaux;
     pub mod sha2;
     pub mod nodemap;
+    pub mod fs;
 }
 
 pub mod lib {

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -15,6 +15,8 @@ use std::os;
 use std::io::fs;
 use collections::HashSet;
 
+use myfs = util::fs;
+
 pub enum FileMatch { FileMatches, FileDoesntMatch }
 
 // A module for searching for libraries
@@ -156,17 +158,10 @@ fn make_rustpkg_target_lib_path(sysroot: &Path,
 pub fn get_or_default_sysroot() -> Path {
     // Follow symlinks.  If the resolved path is relative, make it absolute.
     fn canonicalize(path: Option<Path>) -> Option<Path> {
-        path.and_then(|mut path|
-            match fs::readlink(&path) {
-                Ok(canon) => {
-                    if canon.is_absolute() {
-                        Some(canon)
-                    } else {
-                        path.pop();
-                        Some(path.join(canon))
-                    }
-                },
-                Err(..) => Some(path),
+        path.and_then(|path|
+            match myfs::realpath(&path) {
+                Ok(canon) => Some(canon),
+                Err(e) => fail!("failed to get realpath: {}", e),
             })
     }
 

--- a/src/librustc/util/fs.rs
+++ b/src/librustc/util/fs.rs
@@ -1,0 +1,103 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::io::fs;
+use std::os;
+
+/// Returns an absolute path in the filesystem that `path` points to. The
+/// returned path does not contain any symlinks in its hierarchy.
+pub fn realpath(original: &Path) -> io::IoResult<Path> {
+    static MAX_LINKS_FOLLOWED: uint = 256;
+    let original = os::make_absolute(original);
+
+    // Right now lstat on windows doesn't work quite well
+    if cfg!(windows) {
+        return Ok(original)
+    }
+
+    let result = original.root_path();
+    let mut result = result.expect("make_absolute has no root_path");
+    let mut followed = 0;
+
+    for part in original.components() {
+        result.push(part);
+
+        loop {
+            if followed == MAX_LINKS_FOLLOWED {
+                return Err(io::standard_error(io::InvalidInput))
+            }
+
+            match fs::lstat(&result) {
+                Err(..) => break,
+                Ok(ref stat) if stat.kind != io::TypeSymlink => break,
+                Ok(..) => {
+                    followed += 1;
+                    let path = try!(fs::readlink(&result));
+                    result.pop();
+                    result.push(path);
+                }
+            }
+        }
+    }
+
+    return Ok(result);
+}
+
+#[cfg(not(windows), test)]
+mod test {
+    use std::io;
+    use std::io::fs::{File, symlink, mkdir, mkdir_recursive};
+    use super::realpath;
+    use std::io::TempDir;
+
+    #[test]
+    fn realpath_works() {
+        let tmpdir = TempDir::new("rustc-fs").unwrap();
+        let tmpdir = realpath(tmpdir.path()).unwrap();
+        let file = tmpdir.join("test");
+        let dir = tmpdir.join("test2");
+        let link = dir.join("link");
+        let linkdir = tmpdir.join("test3");
+
+        File::create(&file).unwrap();
+        mkdir(&dir, io::UserRWX).unwrap();
+        symlink(&file, &link).unwrap();
+        symlink(&dir, &linkdir).unwrap();
+
+        assert!(realpath(&tmpdir).unwrap() == tmpdir);
+        assert!(realpath(&file).unwrap() == file);
+        assert!(realpath(&link).unwrap() == file);
+        assert!(realpath(&linkdir).unwrap() == dir);
+        assert!(realpath(&linkdir.join("link")).unwrap() == file);
+    }
+
+    #[test]
+    fn realpath_works_tricky() {
+        let tmpdir = TempDir::new("rustc-fs").unwrap();
+        let tmpdir = realpath(tmpdir.path()).unwrap();
+
+        let a = tmpdir.join("a");
+        let b = a.join("b");
+        let c = b.join("c");
+        let d = a.join("d");
+        let e = d.join("e");
+        let f = a.join("f");
+
+        mkdir_recursive(&b, io::UserRWX).unwrap();
+        mkdir_recursive(&d, io::UserRWX).unwrap();
+        File::create(&f).unwrap();
+        symlink(&Path::new("../d/e"), &c).unwrap();
+        symlink(&Path::new("../f"), &e).unwrap();
+
+        assert!(realpath(&c).unwrap() == f);
+        assert!(realpath(&e).unwrap() == f);
+    }
+}


### PR DESCRIPTION
Concerns have been raised about using absolute rpaths in #11746, and this is the
first step towards not relying on rpaths at all. The only current use case for
an absolute rpath is when a non-installed rust builds an executable that then
moves from is built location. The relative rpath back to libstd and absolute
rpath to the installation directory still remain (CFG_PREFIX).

Closes #11746
Rebasing of #12754
