### PR TITLE
rustdoc: Prune the paths that do not appear in the index.

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -269,6 +269,7 @@ LIB_DOC_DEP_$(1) = $$(CRATEFILE_$(1)) $$(RSINPUTS_$(1))
 endif
 
 $(2) += doc/$(1)/index.html
+doc/$(1)/index.html: CFG_COMPILER_HOST_TRIPLE = $(CFG_TARGET)
 doc/$(1)/index.html: $$(LIB_DOC_DEP_$(1))
 	@$$(call E, rustdoc $$@)
 	$$(Q)$$(RUSTDOC) --cfg dox --cfg stage2 $$<


### PR DESCRIPTION
`allPaths` entries in `search-index.js` are only meaningful when there are `searchIndex` items that refer to them. Pruning unused paths gives a substantial gain in the search index size, especially when both the library docs and compiler docs are generated altogether:

```
 1719473 search-index-old.js
 1503299 search-index.js (13% gain)

  262711 search-index-old.js.gz
  214205 search-index.js.gz (18.5% gain)
```

...where `*.gz` files are gzipped with `gzip -9`. This commit also cleans the `initSearch` JavaScript routine a bit.
