### PR TITLE
Generalized the pretty-print entry points to support `-o <file>`.

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -293,7 +293,7 @@ pub fn run_compiler(args: &[~str]) {
     });
     match pretty {
         Some::<d::PpMode>(ppm) => {
-            d::pretty_print_input(sess, cfg, &input, ppm);
+            d::pretty_print_input(sess, cfg, &input, ppm, ofile);
             return;
         }
         None::<d::PpMode> => {/* continue */ }

--- a/src/test/run-make/pretty-print-to-file/Makefile
+++ b/src/test/run-make/pretty-print-to-file/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -o $(TMPDIR)/input.out --pretty=normal input.rs
+	diff -u $(TMPDIR)/input.out input.pp

--- a/src/test/run-make/pretty-print-to-file/input.pp
+++ b/src/test/run-make/pretty-print-to-file/input.pp
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[crate_type = "lib"]
+pub fn foo() -> i32 { 45 }

--- a/src/test/run-make/pretty-print-to-file/input.rs
+++ b/src/test/run-make/pretty-print-to-file/input.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type="lib"]
+
+pub fn
+foo() -> i32
+{ 45 }


### PR DESCRIPTION
This is laying ground-work for the control-flow graph `--pretty` format that I want to land next.
