### PR TITLE
rustc: Remove f{32,64} % from the language

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4125,6 +4125,7 @@ pub fn is_binopable(cx: &ctxt, ty: t, op: ast::BinOp) -> bool {
     static opcat_eq: int = 5;
     static opcat_bit: int = 6;
     static opcat_logic: int = 7;
+    static opcat_mod: int = 8;
 
     fn opcat(op: ast::BinOp) -> int {
         match op {
@@ -4132,7 +4133,7 @@ pub fn is_binopable(cx: &ctxt, ty: t, op: ast::BinOp) -> bool {
           ast::BiSub => opcat_sub,
           ast::BiMul => opcat_mult,
           ast::BiDiv => opcat_mult,
-          ast::BiRem => opcat_mult,
+          ast::BiRem => opcat_mod,
           ast::BiAnd => opcat_logic,
           ast::BiOr => opcat_logic,
           ast::BiBitXor => opcat_bit,
@@ -4168,14 +4169,14 @@ pub fn is_binopable(cx: &ctxt, ty: t, op: ast::BinOp) -> bool {
     static f: bool = false;
 
     let tbl = [
-    //           +, -, *, shift, rel, ==, bit, logic
-    /*other*/   [f, f, f, f,     f,   f,  f,   f],
-    /*bool*/    [f, f, f, f,     t,   t,  t,   t],
-    /*char*/    [f, f, f, f,     t,   t,  f,   f],
-    /*int*/     [t, t, t, t,     t,   t,  t,   f],
-    /*float*/   [t, t, t, f,     t,   t,  f,   f],
-    /*bot*/     [t, t, t, t,     t,   t,  t,   t],
-    /*raw ptr*/ [f, f, f, f,     t,   t,  f,   f]];
+    //           +, -, *, shift, rel, ==, bit, logic, mod
+    /*other*/   [f, f, f, f,     f,   f,  f,   f,     f],
+    /*bool*/    [f, f, f, f,     t,   t,  t,   t,     f],
+    /*char*/    [f, f, f, f,     t,   t,  f,   f,     f],
+    /*int*/     [t, t, t, t,     t,   t,  t,   f,     t],
+    /*float*/   [t, t, t, f,     t,   t,  f,   f,     f],
+    /*bot*/     [t, t, t, t,     t,   t,  t,   t,     t],
+    /*raw ptr*/ [f, f, f, f,     t,   t,  f,   f,     f]];
 
     return tbl[tycat(cx, ty) as uint ][opcat(op) as uint];
 }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -41,6 +41,7 @@ mod cmath {
         pub fn frexpf(n: c_float, value: &mut c_int) -> c_float;
         pub fn fmaxf(a: c_float, b: c_float) -> c_float;
         pub fn fminf(a: c_float, b: c_float) -> c_float;
+        pub fn fmodf(a: c_float, b: c_float) -> c_float;
         pub fn nextafterf(x: c_float, y: c_float) -> c_float;
         pub fn hypotf(x: c_float, y: c_float) -> c_float;
         pub fn ldexpf(x: c_float, n: c_int) -> c_float;
@@ -201,7 +202,9 @@ impl Div<f32,f32> for f32 {
 #[cfg(not(test))]
 impl Rem<f32,f32> for f32 {
     #[inline]
-    fn rem(&self, other: &f32) -> f32 { *self % *other }
+    fn rem(&self, other: &f32) -> f32 {
+        unsafe { cmath::fmodf(*self, *other) }
+    }
 }
 
 #[cfg(not(test))]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -40,6 +40,7 @@ mod cmath {
         pub fn fdim(a: c_double, b: c_double) -> c_double;
         pub fn fmax(a: c_double, b: c_double) -> c_double;
         pub fn fmin(a: c_double, b: c_double) -> c_double;
+        pub fn fmod(a: c_double, b: c_double) -> c_double;
         pub fn nextafter(x: c_double, y: c_double) -> c_double;
         pub fn frexp(n: c_double, value: &mut c_int) -> c_double;
         pub fn hypot(x: c_double, y: c_double) -> c_double;
@@ -210,7 +211,9 @@ impl Div<f64,f64> for f64 {
 #[cfg(not(test))]
 impl Rem<f64,f64> for f64 {
     #[inline]
-    fn rem(&self, other: &f64) -> f64 { *self % *other }
+    fn rem(&self, other: &f64) -> f64 {
+        unsafe { cmath::fmod(*self, *other) }
+    }
 }
 #[cfg(not(test))]
 impl Neg<f64> for f64 {


### PR DESCRIPTION
This commit removes the compiler support for floating point modulus operations,
as well as from the language. An implementation for this operator is now
required to be provided by libraries.

Floating point modulus is rarely used, doesn't exist in C, and is always lowered
to an fmod library call by LLVM, and LLVM is considering removing support
entirely.

Closes #12278
