### PR TITLE
rustc: Prevent repeated moves out of proc upvars

### DIFF
--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -274,12 +274,13 @@ pub fn opt_loan_path(cmt: mc::cmt) -> Option<@LoanPath> {
     match cmt.cat {
         mc::cat_rvalue(..) |
         mc::cat_static_item |
-        mc::cat_copied_upvar(_) => {
+        mc::cat_copied_upvar(mc::CopiedUpvar { onceness: ast::Many, .. }) => {
             None
         }
 
         mc::cat_local(id) |
         mc::cat_arg(id) |
+        mc::cat_copied_upvar(mc::CopiedUpvar { upvar_id: id, .. }) |
         mc::cat_upvar(ty::UpvarId {var_id: id, ..}, _) => {
             Some(@LpVar(id))
         }

--- a/src/test/compile-fail/issue-10398.rs
+++ b/src/test/compile-fail/issue-10398.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 fn main() {
-    let r = {
-        let x = ~42;
-        let f = proc() &x; //~ ERROR: `x` does not live long enough
-        f()
+    let x = ~1;
+    let f: proc() = proc() {
+        let _a = x;
+        drop(x);
+        //~^ ERROR: use of moved value: `x`
     };
-
-    drop(r);
+    f();
 }

--- a/src/test/compile-fail/issue-12041.rs
+++ b/src/test/compile-fail/issue-12041.rs
@@ -9,11 +9,13 @@
 // except according to those terms.
 
 fn main() {
-    let r = {
-        let x = ~42;
-        let f = proc() &x; //~ ERROR: `x` does not live long enough
-        f()
-    };
-
-    drop(r);
+    let (tx, rx) = channel();
+    spawn(proc() {
+        loop {
+            let tx = tx;
+            //~^ ERROR: use of moved value: `tx`
+            tx.send(1);
+        }
+    });
 }
+

--- a/src/test/compile-fail/issue-12127.rs
+++ b/src/test/compile-fail/issue-12127.rs
@@ -9,11 +9,10 @@
 // except according to those terms.
 
 fn main() {
-    let r = {
-        let x = ~42;
-        let f = proc() &x; //~ ERROR: `x` does not live long enough
-        f()
-    };
-
-    drop(r);
+    let f = proc() {};
+    (proc() {
+        f();
+        f();
+        //~^ ERROR: use of moved value: `f`
+    })()
 }


### PR DESCRIPTION
This fixes the categorization of the upvars of procs (represented internally
as once fns) to consider usage to require a loan. In doing so, upvars are no
longer allowed to be moved out of repeatedly in loops and such.

Closes #10398
Closes #12041
Closes #12127
