### PR TITLE
Remove a pile of (mainly) internal `~[]` uses

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -451,7 +451,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
         let options_to_remove = [~"-O", ~"-g", ~"--debuginfo"];
         let new_options = split_maybe_args(options).move_iter()
                                                    .filter(|x| !options_to_remove.contains(x))
-                                                   .collect::<~[~str]>()
+                                                   .collect::<Vec<~str>>()
                                                    .connect(" ");
         Some(new_options)
     }

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -117,13 +117,13 @@ mod tests {
             words.push(r.gen_vec::<u8>(range));
         }
         for _ in range(0, 20) {
-            let mut input = ~[];
+            let mut input = vec![];
             for _ in range(0, 2000) {
                 input.push_all(r.choose(words.as_slice()).as_slice());
             }
             debug!("de/inflate of {} bytes of random word-sequences",
                    input.len());
-            let cmp = deflate_bytes(input).expect("deflation failed");
+            let cmp = deflate_bytes(input.as_slice()).expect("deflation failed");
             let out = inflate_bytes(cmp.as_slice()).expect("inflation failed");
             debug!("{} bytes deflated to {} ({:.1f}% size)",
                    input.len(), cmp.len(),

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -53,7 +53,7 @@
 //!
 //!     let program = args[0].clone();
 //!
-//!     let opts = ~[
+//!     let opts = [
 //!         optopt("o", "", "set output file name", "NAME"),
 //!         optflag("h", "help", "print this help menu")
 //!     ];

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -31,6 +31,8 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://static.rust-lang.org/doc/master")]
 
+#![deny(deprecated_owned_vector)]
+
 use std::cell::Cell;
 use std::{cmp, os, path};
 use std::io::fs;
@@ -225,26 +227,26 @@ impl Pattern {
      */
     pub fn new(pattern: &str) -> Pattern {
 
-        let chars = pattern.chars().collect::<~[_]>();
+        let chars = pattern.chars().collect::<Vec<_>>();
         let mut tokens = Vec::new();
         let mut i = 0;
 
         while i < chars.len() {
-            match chars[i] {
+            match *chars.get(i) {
                 '?' => {
                     tokens.push(AnyChar);
                     i += 1;
                 }
                 '*' => {
                     // *, **, ***, ****, ... are all equivalent
-                    while i < chars.len() && chars[i] == '*' {
+                    while i < chars.len() && *chars.get(i) == '*' {
                         i += 1;
                     }
                     tokens.push(AnySequence);
                 }
                 '[' => {
 
-                    if i <= chars.len() - 4 && chars[i + 1] == '!' {
+                    if i <= chars.len() - 4 && *chars.get(i + 1) == '!' {
                         match chars.slice_from(i + 3).position_elem(&']') {
                             None => (),
                             Some(j) => {
@@ -256,7 +258,7 @@ impl Pattern {
                             }
                         }
                     }
-                    else if i <= chars.len() - 3 && chars[i + 1] != '!' {
+                    else if i <= chars.len() - 3 && *chars.get(i + 1) != '!' {
                         match chars.slice_from(i + 2).position_elem(&']') {
                             None => (),
                             Some(j) => {

--- a/src/libgreen/basic.rs
+++ b/src/libgreen/basic.rs
@@ -27,11 +27,11 @@ pub fn event_loop() -> ~EventLoop:Send {
 }
 
 struct BasicLoop {
-    work: ~[proc():Send],             // pending work
+    work: Vec<proc():Send>,             // pending work
     idle: Option<*mut BasicPausable>, // only one is allowed
-    remotes: ~[(uint, ~Callback:Send)],
+    remotes: Vec<(uint, ~Callback:Send)>,
     next_remote: uint,
-    messages: Exclusive<~[Message]>,
+    messages: Exclusive<Vec<Message>>,
 }
 
 enum Message { RunRemote(uint), RemoveRemote(uint) }
@@ -39,18 +39,18 @@ enum Message { RunRemote(uint), RemoveRemote(uint) }
 impl BasicLoop {
     fn new() -> BasicLoop {
         BasicLoop {
-            work: ~[],
+            work: vec![],
             idle: None,
             next_remote: 0,
-            remotes: ~[],
-            messages: Exclusive::new(~[]),
+            remotes: vec![],
+            messages: Exclusive::new(vec![]),
         }
     }
 
     /// Process everything in the work queue (continually)
     fn work(&mut self) {
         while self.work.len() > 0 {
-            for work in replace(&mut self.work, ~[]).move_iter() {
+            for work in replace(&mut self.work, vec![]).move_iter() {
                 work();
             }
         }
@@ -60,7 +60,7 @@ impl BasicLoop {
         let messages = unsafe {
             self.messages.with(|messages| {
                 if messages.len() > 0 {
-                    Some(replace(messages, ~[]))
+                    Some(replace(messages, vec![]))
                 } else {
                     None
                 }
@@ -165,12 +165,12 @@ impl EventLoop for BasicLoop {
 }
 
 struct BasicRemote {
-    queue: Exclusive<~[Message]>,
+    queue: Exclusive<Vec<Message>>,
     id: uint,
 }
 
 impl BasicRemote {
-    fn new(queue: Exclusive<~[Message]>, id: uint) -> BasicRemote {
+    fn new(queue: Exclusive<Vec<Message>>, id: uint) -> BasicRemote {
         BasicRemote { queue: queue, id: id }
     }
 }

--- a/src/libgreen/stack.rs
+++ b/src/libgreen/stack.rs
@@ -126,13 +126,13 @@ impl Drop for Stack {
 pub struct StackPool {
     // Ideally this would be some datastructure that preserved ordering on
     // Stack.min_size.
-    stacks: ~[Stack],
+    stacks: Vec<Stack>,
 }
 
 impl StackPool {
     pub fn new() -> StackPool {
         StackPool {
-            stacks: ~[],
+            stacks: vec![],
         }
     }
 

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -340,11 +340,11 @@ pub fn mkdir(p: &CString, mode: io::FilePermission) -> IoResult<()> {
     }))
 }
 
-pub fn readdir(p: &CString) -> IoResult<~[Path]> {
+pub fn readdir(p: &CString) -> IoResult<Vec<Path>> {
     use libc::{dirent_t};
     use libc::{opendir, readdir_r, closedir};
 
-    fn prune(root: &CString, dirs: ~[Path]) -> ~[Path] {
+    fn prune(root: &CString, dirs: Vec<Path>) -> Vec<Path> {
         let root = unsafe { CString::new(root.with_ref(|p| p), false) };
         let root = Path::new(root);
 
@@ -365,7 +365,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
     let dir_ptr = p.with_ref(|buf| unsafe { opendir(buf) });
 
     if dir_ptr as uint != 0 {
-        let mut paths = ~[];
+        let mut paths = vec!();
         let mut entry_ptr = 0 as *mut dirent_t;
         while unsafe { readdir_r(dir_ptr, ptr, &mut entry_ptr) == 0 } {
             if entry_ptr.is_null() { break }
@@ -571,4 +571,3 @@ mod tests {
         }
     }
 }
-

--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -323,10 +323,10 @@ pub fn mkdir(p: &CString, _mode: io::FilePermission) -> IoResult<()> {
     })
 }
 
-pub fn readdir(p: &CString) -> IoResult<~[Path]> {
+pub fn readdir(p: &CString) -> IoResult<Vec<Path>> {
     use rt::global_heap::malloc_raw;
 
-    fn prune(root: &CString, dirs: ~[Path]) -> ~[Path] {
+    fn prune(root: &CString, dirs: Vec<Path>) -> Vec<Path> {
         let root = unsafe { CString::new(root.with_ref(|p| p), false) };
         let root = Path::new(root);
 
@@ -346,7 +346,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
         let wfd_ptr = malloc_raw(rust_list_dir_wfd_size() as uint);
         let find_handle = libc::FindFirstFileW(path_ptr, wfd_ptr as libc::HANDLE);
         if find_handle as libc::c_int != libc::INVALID_HANDLE_VALUE {
-            let mut paths = ~[];
+            let mut paths = vec!();
             let mut more_files = 1 as libc::c_int;
             while more_files != 0 {
                 let fp_buf = rust_list_dir_wfd_fp_buf(wfd_ptr as *c_void);

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -217,7 +217,7 @@ impl rtio::IoFactory for IoFactory {
     fn fs_rename(&mut self, path: &CString, to: &CString) -> IoResult<()> {
         file::rename(path, to)
     }
-    fn fs_readdir(&mut self, path: &CString, _flags: c_int) -> IoResult<~[Path]> {
+    fn fs_readdir(&mut self, path: &CString, _flags: c_int) -> IoResult<Vec<Path>> {
         file::readdir(path)
     }
     fn fs_lstat(&mut self, path: &CString) -> IoResult<io::FileStat> {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -102,11 +102,11 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
     // active timers are those which are able to be selected upon (and it's a
     // sorted list, and dead timers are those which have expired, but ownership
     // hasn't yet been transferred back to the timer itself.
-    let mut active: ~[~Inner] = ~[];
-    let mut dead = ~[];
+    let mut active: Vec<~Inner> = vec![];
+    let mut dead = vec![];
 
     // inserts a timer into an array of timers (sorted by firing time)
-    fn insert(t: ~Inner, active: &mut ~[~Inner]) {
+    fn insert(t: ~Inner, active: &mut Vec<~Inner>) {
         match active.iter().position(|tm| tm.target > t.target) {
             Some(pos) => { active.insert(pos, t); }
             None => { active.push(t); }
@@ -114,7 +114,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
     }
 
     // signals the first requests in the queue, possible re-enqueueing it.
-    fn signal(active: &mut ~[~Inner], dead: &mut ~[(uint, ~Inner)]) {
+    fn signal(active: &mut Vec<~Inner>, dead: &mut Vec<(uint, ~Inner)>) {
         let mut timer = match active.shift() {
             Some(timer) => timer, None => return
         };
@@ -137,7 +137,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
             let now = now();
             // If this request has already expired, then signal it and go
             // through another iteration
-            if active[0].target <= now {
+            if active.get(0).target <= now {
                 signal(&mut active, &mut dead);
                 continue;
             }
@@ -145,7 +145,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
             // The actual timeout listed in the requests array is an
             // absolute date, so here we translate the absolute time to a
             // relative time.
-            let tm = active[0].target - now;
+            let tm = active.get(0).target - now;
             timeout.tv_sec = (tm / 1000) as libc::time_t;
             timeout.tv_usec = ((tm % 1000) * 1000) as libc::suseconds_t;
             &timeout as *libc::timeval

--- a/src/libnative/io/timer_win32.rs
+++ b/src/libnative/io/timer_win32.rs
@@ -40,8 +40,8 @@ pub enum Req {
 }
 
 fn helper(input: libc::HANDLE, messages: Receiver<Req>) {
-    let mut objs = ~[input];
-    let mut chans = ~[];
+    let mut objs = vec![input];
+    let mut chans = vec![];
 
     'outer: loop {
         let idx = unsafe {
@@ -78,7 +78,7 @@ fn helper(input: libc::HANDLE, messages: Receiver<Req>) {
             }
         } else {
             let remove = {
-                match &chans[idx as uint - 1] {
+                match chans.get(idx as uint - 1) {
                     &(ref c, oneshot) => !c.try_send(()) || oneshot
                 }
             };

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -190,7 +190,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
                 } else {
                     None
                 })
-                .collect::<~[&ast::Attribute]>();
+                .collect::<Vec<&ast::Attribute>>();
             for m in link_args.iter() {
                 match m.value_str() {
                     Some(linkarg) => e.sess.cstore.add_used_link_args(linkarg.get()),
@@ -205,7 +205,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
                 } else {
                     None
                 })
-                .collect::<~[&ast::Attribute]>();
+                .collect::<Vec<&ast::Attribute>>();
             for m in link_args.iter() {
                 match m.meta_item_list() {
                     Some(items) => {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -133,7 +133,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
             slice::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().filter(|l| stripped_filtered_line(*l).is_none());
-                let text = lines.collect::<~[&str]>().connect("\n");
+                let text = lines.collect::<Vec<&str>>().connect("\n");
 
                 let buf = buf {
                     data: text.as_bytes().as_ptr(),
@@ -186,7 +186,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
                 Some(s) => s.to_lower().into_str(),
                 None => s.to_owned()
             }
-        }).collect::<~[~str]>().connect("-");
+        }).collect::<Vec<~str>>().connect("-");
 
         let opaque = unsafe {&mut *(opaque as *mut my_opaque)};
 
@@ -285,7 +285,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                 let tests = &mut *(opaque as *mut ::test::Collector);
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().map(|l| stripped_filtered_line(l).unwrap_or(l));
-                let text = lines.collect::<~[&str]>().connect("\n");
+                let text = lines.collect::<Vec<&str>>().connect("\n");
                 tests.add_test(text, should_fail, no_run, ignore);
             })
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1205,8 +1205,8 @@ fn item_trait(w: &mut Writer, it: &clean::Item,
                   it.name.get_ref().as_slice(),
                   t.generics,
                   parents));
-    let required = t.methods.iter().filter(|m| m.is_req()).collect::<~[&clean::TraitMethod]>();
-    let provided = t.methods.iter().filter(|m| !m.is_req()).collect::<~[&clean::TraitMethod]>();
+    let required = t.methods.iter().filter(|m| m.is_req()).collect::<Vec<&clean::TraitMethod>>();
+    let provided = t.methods.iter().filter(|m| !m.is_req()).collect::<Vec<&clean::TraitMethod>>();
 
     if t.methods.len() == 0 {
         try!(write!(w, "\\{ \\}"));
@@ -1502,11 +1502,11 @@ fn render_methods(w: &mut Writer, it: &clean::Item) -> fmt::Result {
                 let mut non_trait = v.iter().filter(|p| {
                     p.ref0().trait_.is_none()
                 });
-                let non_trait = non_trait.collect::<~[&(clean::Impl, Option<~str>)]>();
+                let non_trait = non_trait.collect::<Vec<&(clean::Impl, Option<~str>)>>();
                 let mut traits = v.iter().filter(|p| {
                     p.ref0().trait_.is_some()
                 });
-                let traits = traits.collect::<~[&(clean::Impl, Option<~str>)]>();
+                let traits = traits.collect::<Vec<&(clean::Impl, Option<~str>)>>();
 
                 if non_trait.len() > 0 {
                     try!(write!(w, "<h2 id='methods'>Methods</h2>"));

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -161,12 +161,12 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches) -> int 
 }
 
 /// Run any tests/code examples in the markdown file `input`.
-pub fn test(input: &str, libs: HashSet<Path>, mut test_args: ~[~str]) -> int {
+pub fn test(input: &str, libs: HashSet<Path>, mut test_args: Vec<~str>) -> int {
     let input_str = load_or_return!(input, 1, 2);
 
     let mut collector = Collector::new(input.to_owned(), libs, true, true);
     find_testable_code(input_str, &mut collector);
     test_args.unshift(~"rustdoctest");
-    testing::test_main(test_args, collector.tests);
+    testing::test_main(test_args.as_slice(), collector.tests);
     0
 }

--- a/src/librustuv/access.rs
+++ b/src/librustuv/access.rs
@@ -31,7 +31,7 @@ pub struct Guard<'a> {
 }
 
 struct Inner {
-    queue: ~[BlockedTask],
+    queue: Vec<BlockedTask>,
     held: bool,
 }
 
@@ -39,7 +39,7 @@ impl Access {
     pub fn new() -> Access {
         Access {
             inner: UnsafeArc::new(Inner {
-                queue: ~[],
+                queue: vec![],
                 held: false,
             })
         }

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -152,13 +152,13 @@ impl FsRequest {
     }
 
     pub fn readdir(loop_: &Loop, path: &CString, flags: c_int)
-        -> Result<~[Path], UvError>
+        -> Result<Vec<Path>, UvError>
     {
         execute(|req, cb| unsafe {
             uvll::uv_fs_readdir(loop_.handle,
                                 req, path.with_ref(|p| p), flags, cb)
         }).map(|req| unsafe {
-            let mut paths = ~[];
+            let mut paths = vec!();
             let path = CString::new(path.with_ref(|p| p), false);
             let parent = Path::new(path);
             let _ = c_str::from_c_multistring(req.get_ptr() as *libc::c_char,

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -234,7 +234,7 @@ impl IoFactory for UvIoFactory {
         r.map_err(uv_error_to_io_error)
     }
     fn fs_readdir(&mut self, path: &CString, flags: c_int)
-        -> Result<~[Path], IoError>
+        -> Result<Vec<Path>, IoError>
     {
         let r = FsRequest::readdir(&self.loop_, path, flags);
         r.map_err(uv_error_to_io_error)

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -636,7 +636,7 @@ pub mod writer {
     // ebml writing
     pub struct Encoder<'a, W> {
         pub writer: &'a mut W,
-        size_positions: ~[uint],
+        size_positions: Vec<uint>,
     }
 
     fn write_sized_vuint<W: Writer>(w: &mut W, n: uint, size: uint) -> EncodeResult {
@@ -668,10 +668,9 @@ pub mod writer {
     }
 
     pub fn Encoder<'a, W: Writer + Seek>(w: &'a mut W) -> Encoder<'a, W> {
-        let size_positions: ~[uint] = ~[];
         Encoder {
             writer: w,
-            size_positions: size_positions,
+            size_positions: vec!(),
         }
     }
 

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -21,7 +21,7 @@ use option::{Option, Some, None};
 use result::{Ok, Err};
 use io;
 use io::{IoError, IoResult, Reader};
-use slice::{OwnedVector, ImmutableVector};
+use slice::{OwnedVector, ImmutableVector, Vector};
 use ptr::RawPtr;
 
 /// An iterator that reads a single byte on each iteration,
@@ -88,7 +88,7 @@ pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
       8u => f(unsafe { transmute::<i64, [u8, ..8]>(to_le64(n as i64)) }),
       _ => {
 
-        let mut bytes: ~[u8] = ~[];
+        let mut bytes = vec!();
         let mut i = size;
         let mut n = n;
         while i > 0u {
@@ -96,7 +96,7 @@ pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
             n >>= 8_u64;
             i -= 1u;
         }
-        f(bytes)
+        f(bytes.as_slice())
       }
     }
 }
@@ -127,14 +127,14 @@ pub fn u64_to_be_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
       4u => f(unsafe { transmute::<i32, [u8, ..4]>(to_be32(n as i32)) }),
       8u => f(unsafe { transmute::<i64, [u8, ..8]>(to_be64(n as i64)) }),
       _ => {
-        let mut bytes: ~[u8] = ~[];
+        let mut bytes = vec!();
         let mut i = size;
         while i > 0u {
             let shift = ((i - 1u) * 8u) as u64;
             bytes.push((n >> shift) as u8);
             i -= 1u;
         }
-        f(bytes)
+        f(bytes.as_slice())
       }
     }
 }

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -483,7 +483,7 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 /// Will return an error if the provided `from` doesn't exist, the process lacks
 /// permissions to view the contents or if the `path` points at a non-directory
 /// file
-pub fn readdir(path: &Path) -> IoResult<~[Path]> {
+pub fn readdir(path: &Path) -> IoResult<Vec<Path>> {
     LocalIo::maybe_raise(|io| {
         io.fs_readdir(&path.to_c_str(), 0)
     })
@@ -498,7 +498,7 @@ pub fn walk_dir(path: &Path) -> IoResult<Directories> {
 
 /// An iterator which walks over a directory
 pub struct Directories {
-    stack: ~[Path],
+    stack: Vec<Path>,
 }
 
 impl Iterator<Path> for Directories {

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -29,6 +29,7 @@ use option::{Some, None};
 use result::{Ok, Err};
 use rt::rtio::{IoFactory, LocalIo, RtioSignal};
 use slice::{ImmutableVector, OwnedVector};
+use vec::Vec;
 
 /// Signals that can be sent and received
 #[repr(int)]
@@ -80,7 +81,7 @@ pub enum Signum {
 /// ```
 pub struct Listener {
     /// A map from signums to handles to keep the handles in memory
-    handles: ~[(Signum, ~RtioSignal:Send)],
+    handles: Vec<(Signum, ~RtioSignal:Send)>,
     /// This is where all the handles send signums, which are received by
     /// the clients from the receiver.
     tx: Sender<Signum>,
@@ -99,7 +100,7 @@ impl Listener {
         Listener {
             tx: tx,
             rx: rx,
-            handles: ~[],
+            handles: vec!(),
         }
     }
 

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -20,8 +20,9 @@ use option::{Some, None};
 use ptr::RawPtr;
 use unstable::sync::Exclusive;
 use slice::OwnedVector;
+use vec::Vec;
 
-type Queue = Exclusive<~[proc():Send]>;
+type Queue = Exclusive<Vec<proc():Send>>;
 
 // You'll note that these variables are *not* atomic, and this is done on
 // purpose. This module is designed to have init() called *once* in a
@@ -35,7 +36,7 @@ pub fn init() {
     unsafe {
         rtassert!(!RUNNING);
         rtassert!(QUEUE.is_null());
-        let state: ~Queue = ~Exclusive::new(~[]);
+        let state: ~Queue = ~Exclusive::new(vec!());
         QUEUE = cast::transmute(state);
     }
 }
@@ -61,7 +62,7 @@ pub fn run() {
         QUEUE = 0 as *mut Queue;
         let mut vec = None;
         state.with(|arr| {
-            vec = Some(mem::replace(arr, ~[]));
+            vec = Some(mem::replace(arr, vec!()));
         });
         vec.take_unwrap()
     };

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -20,6 +20,7 @@ use path::Path;
 use result::Err;
 use rt::local::Local;
 use rt::task::Task;
+use vec::Vec;
 
 use ai = io::net::addrinfo;
 use io;
@@ -168,7 +169,7 @@ pub trait IoFactory {
     fn fs_rmdir(&mut self, path: &CString) -> IoResult<()>;
     fn fs_rename(&mut self, path: &CString, to: &CString) -> IoResult<()>;
     fn fs_readdir(&mut self, path: &CString, flags: c_int) ->
-        IoResult<~[Path]>;
+        IoResult<Vec<Path>>;
     fn fs_lstat(&mut self, path: &CString) -> IoResult<FileStat>;
     fn fs_chown(&mut self, path: &CString, uid: int, gid: int) ->
         IoResult<()>;

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -242,9 +242,9 @@ impl<'a, 'b> Context<'a, 'b> {
                             }
                         }
                     }
-                    self.verify_pieces(arm.result);
+                    self.verify_pieces(arm.result.as_slice());
                 }
-                self.verify_pieces(*default);
+                self.verify_pieces(default.as_slice());
             }
             parse::Select(ref arms, ref default) => {
                 self.verify_arg_type(pos, String);
@@ -258,9 +258,9 @@ impl<'a, 'b> Context<'a, 'b> {
                         self.ecx.span_err(self.fmtsp,
                                           "empty selector in `select`");
                     }
-                    self.verify_pieces(arm.result);
+                    self.verify_pieces(arm.result.as_slice());
                 }
-                self.verify_pieces(*default);
+                self.verify_pieces(default.as_slice());
             }
         }
         self.nest_level -= 1;

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -170,14 +170,14 @@ impl<'a> Stats for &'a [f64] {
     // FIXME #11059 handle NaN, inf and overflow
     #[allow(deprecated_owned_vector)]
     fn sum(self) -> f64 {
-        let mut partials : ~[f64] = ~[];
+        let mut partials = vec![];
 
         for &mut x in self.iter() {
             let mut j = 0;
             // This inner loop applies `hi`/`lo` summation to each
             // partial so that the list of partial sums remains exact.
             for i in range(0, partials.len()) {
-                let mut y = partials[i];
+                let mut y = *partials.get(i);
                 if num::abs(x) < num::abs(y) {
                     mem::swap(&mut x, &mut y);
                 }
@@ -186,7 +186,7 @@ impl<'a> Stats for &'a [f64] {
                 let hi = x + y;
                 let lo = y - (hi - x);
                 if lo != 0f64 {
-                    partials[j] = lo;
+                    *partials.get_mut(j) = lo;
                     j += 1;
                 }
                 x = hi;
@@ -194,7 +194,7 @@ impl<'a> Stats for &'a [f64] {
             if j >= partials.len() {
                 partials.push(x);
             } else {
-                partials[j] = x;
+                *partials.get_mut(j) = x;
                 partials.truncate(j+1);
             }
         }

--- a/src/libworkcache/lib.rs
+++ b/src/libworkcache/lib.rs
@@ -17,6 +17,7 @@
        html_root_url = "http://static.rust-lang.org/doc/master")]
 #![feature(phase)]
 #![allow(visible_private_types)]
+#![deny(deprecated_owned_vector)]
 
 #[phase(syntax, link)] extern crate log;
 extern crate serialize;
@@ -319,8 +320,8 @@ impl Exec {
     }
 
     // returns pairs of (kind, name)
-    pub fn lookup_discovered_inputs(&self) -> ~[(~str, ~str)] {
-        let mut rs = ~[];
+    pub fn lookup_discovered_inputs(&self) -> Vec<(~str, ~str)> {
+        let mut rs = vec![];
         let WorkMap(ref discovered_inputs) = self.discovered_inputs;
         for (k, v) in discovered_inputs.iter() {
             let KindMap(ref vmap) = *v;
@@ -341,8 +342,8 @@ impl<'a> Prep<'a> {
         }
     }
 
-    pub fn lookup_declared_inputs(&self) -> ~[~str] {
-        let mut rs = ~[];
+    pub fn lookup_declared_inputs(&self) -> Vec<~str> {
+        let mut rs = vec![];
         let WorkMap(ref declared_inputs) = self.declared_inputs;
         for (_, v) in declared_inputs.iter() {
             let KindMap(ref vmap) = *v;

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -76,7 +76,7 @@ fn main() {
                 format!("{}\t trees of depth {}\t check: {}",
                         iterations * 2, depth, chk)
             })
-        }).collect::<~[Future<~str>]>();
+        }).collect::<Vec<Future<~str>>>();
 
     for message in messages.mut_iter() {
         println!("{}", *message.get_ref());


### PR DESCRIPTION
Remove a pile of (mainly) internal `~[]` uses

A few of them are public like the changes in `std::fmt::parse`, but the majority are just implementation details.
