### PR TITLE
Remove unused struct

### DIFF
--- a/src/test/run-fail/assert-eq-macro-fail.rs
+++ b/src/test/run-fail/assert-eq-macro-fail.rs
@@ -10,9 +10,6 @@
 
 // error-pattern:assertion failed: `(left == right) && (right == left)` (left: `14`, right: `15`)
 
-#[deriving(Eq)]
-struct Point { x : int }
-
 fn main() {
     assert_eq!(14,15);
 }


### PR DESCRIPTION
Removes the unused Point struct from assert-eq-macro-fail.rs.
