### PR TITLE
Rolling up PRs in the queue

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -269,6 +269,7 @@ LIB_DOC_DEP_$(1) = $$(CRATEFILE_$(1)) $$(RSINPUTS_$(1))
 endif
 
 $(2) += doc/$(1)/index.html
+doc/$(1)/index.html: CFG_COMPILER_HOST_TRIPLE = $(CFG_TARGET)
 doc/$(1)/index.html: $$(LIB_DOC_DEP_$(1))
 	@$$(call E, rustdoc $$@)
 	$$(Q)$$(RUSTDOC) --cfg dox --cfg stage2 $$<

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -358,16 +358,12 @@ CFGFLAG$(1)_T_$(2)_H_$(3) = stage1
 endif
 endif
 
-ifdef CFG_DISABLE_RPATH
 ifeq ($$(OSTYPE_$(3)),apple-darwin)
   RPATH_VAR$(1)_T_$(2)_H_$(3) := \
       DYLD_LIBRARY_PATH="$$$$DYLD_LIBRARY_PATH:$$(CURDIR)/$$(HLIB$(1)_H_$(3))"
 else
   RPATH_VAR$(1)_T_$(2)_H_$(3) := \
       LD_LIBRARY_PATH="$$$$LD_LIBRARY_PATH:$$(CURDIR)/$$(HLIB$(1)_H_$(3))"
-endif
-else
-    RPATH_VAR$(1)_T_$(2)_H_$(3) :=
 endif
 
 STAGE$(1)_T_$(2)_H_$(3) := 						\

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -451,7 +451,7 @@ fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
         let options_to_remove = [~"-O", ~"-g", ~"--debuginfo"];
         let new_options = split_maybe_args(options).move_iter()
                                                    .filter(|x| !options_to_remove.contains(x))
-                                                   .collect::<~[~str]>()
+                                                   .collect::<Vec<~str>>()
                                                    .connect(" ");
         Some(new_options)
     }

--- a/src/libcollections/deque.rs
+++ b/src/libcollections/deque.rs
@@ -44,7 +44,6 @@ pub mod bench {
     extern crate test;
     use self::test::BenchHarness;
     use std::container::MutableMap;
-    use std::slice;
     use rand;
     use rand::Rng;
 
@@ -90,18 +89,18 @@ pub mod bench {
                                                 bh: &mut BenchHarness) {
         // setup
         let mut rng = rand::weak_rng();
-        let mut keys = slice::from_fn(n, |_| rng.gen::<uint>() % n);
+        let mut keys = Vec::from_fn(n, |_| rng.gen::<uint>() % n);
 
         for k in keys.iter() {
             map.insert(*k, 1);
         }
 
-        rng.shuffle(keys);
+        rng.shuffle(keys.as_mut_slice());
 
         // measure
         let mut i = 0;
         bh.iter(|| {
-            map.find(&(keys[i]));
+            map.find(keys.get(i));
             i = (i + 1) % n;
         })
     }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -739,12 +739,12 @@ mod tests {
             check_links(&m);
         }
 
-        let v = ~[1,2,3,4,5];
-        let u = ~[9,8,1,2,3,4,5];
-        let mut m = list_from(v);
-        m.append(list_from(u));
+        let v = vec![1,2,3,4,5];
+        let u = vec![9,8,1,2,3,4,5];
+        let mut m = list_from(v.as_slice());
+        m.append(list_from(u.as_slice()));
         check_links(&m);
-        let sum = v + u;
+        let sum = v.append(u.as_slice());
         assert_eq!(sum.len(), m.len());
         for elt in sum.move_iter() {
             assert_eq!(m.pop_front(), Some(elt))
@@ -763,12 +763,12 @@ mod tests {
             check_links(&m);
         }
 
-        let v = ~[1,2,3,4,5];
-        let u = ~[9,8,1,2,3,4,5];
-        let mut m = list_from(v);
-        m.prepend(list_from(u));
+        let v = vec![1,2,3,4,5];
+        let u = vec![9,8,1,2,3,4,5];
+        let mut m = list_from(v.as_slice());
+        m.prepend(list_from(u.as_slice()));
         check_links(&m);
-        let sum = u + v;
+        let sum = u.append(v.as_slice());
         assert_eq!(sum.len(), m.len());
         for elt in sum.move_iter() {
             assert_eq!(m.pop_front(), Some(elt))
@@ -783,11 +783,11 @@ mod tests {
         n.rotate_forward(); check_links(&n);
         assert_eq!(n.len(), 0);
 
-        let v = ~[1,2,3,4,5];
-        let mut m = list_from(v);
+        let v = vec![1,2,3,4,5];
+        let mut m = list_from(v.as_slice());
         m.rotate_backward(); check_links(&m);
         m.rotate_forward(); check_links(&m);
-        assert_eq!(v.iter().collect::<~[&int]>(), m.iter().collect());
+        assert_eq!(v.iter().collect::<Vec<&int>>(), m.iter().collect());
         m.rotate_forward(); check_links(&m);
         m.rotate_forward(); check_links(&m);
         m.pop_front(); check_links(&m);
@@ -795,7 +795,7 @@ mod tests {
         m.rotate_backward(); check_links(&m);
         m.push_front(9); check_links(&m);
         m.rotate_forward(); check_links(&m);
-        assert_eq!(~[3,9,5,1,2], m.move_iter().collect());
+        assert_eq!(vec![3,9,5,1,2], m.move_iter().collect());
     }
 
     #[test]
@@ -925,7 +925,7 @@ mod tests {
         }
         check_links(&m);
         assert_eq!(m.len(), 3 + len * 2);
-        assert_eq!(m.move_iter().collect::<~[int]>(), ~[-2,0,1,2,3,4,5,6,7,8,9,0,1]);
+        assert_eq!(m.move_iter().collect::<Vec<int>>(), vec![-2,0,1,2,3,4,5,6,7,8,9,0,1]);
     }
 
     #[test]
@@ -936,8 +936,8 @@ mod tests {
         m.merge(n, |a, b| a <= b);
         assert_eq!(m.len(), len);
         check_links(&m);
-        let res = m.move_iter().collect::<~[int]>();
-        assert_eq!(res, ~[-1, 0, 0, 0, 1, 3, 5, 6, 7, 2, 7, 7, 9]);
+        let res = m.move_iter().collect::<Vec<int>>();
+        assert_eq!(res, vec![-1, 0, 0, 0, 1, 3, 5, 6, 7, 2, 7, 7, 9]);
     }
 
     #[test]
@@ -952,7 +952,7 @@ mod tests {
         m.push_back(4);
         m.insert_ordered(3);
         check_links(&m);
-        assert_eq!(~[2,3,4], m.move_iter().collect::<~[int]>());
+        assert_eq!(vec![2,3,4], m.move_iter().collect::<Vec<int>>());
     }
 
     #[test]
@@ -974,7 +974,7 @@ mod tests {
         let n = list_from([1,2,3]);
         spawn(proc() {
             check_links(&n);
-            assert_eq!(~[&1,&2,&3], n.iter().collect::<~[&int]>());
+            assert_eq!(&[&1,&2,&3], n.iter().collect::<Vec<&int>>().as_slice());
         });
     }
 
@@ -1047,7 +1047,7 @@ mod tests {
     #[cfg(test)]
     fn fuzz_test(sz: int) {
         let mut m: DList<int> = DList::new();
-        let mut v = ~[];
+        let mut v = vec![];
         for i in range(0, sz) {
             check_links(&m);
             let r: u8 = rand::random();

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -246,24 +246,24 @@ mod test {
     fn test_iterator() {
         let mut e1: EnumSet<Foo> = EnumSet::empty();
 
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[], elems)
+        let elems: Vec<Foo> = e1.iter().collect();
+        assert!(elems.is_empty())
 
         e1.add(A);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A], elems)
 
         e1.add(C);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A,C], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A,C], elems)
 
         e1.add(C);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A,C], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A,C], elems)
 
         e1.add(B);
-        let elems: ~[Foo] = e1.iter().collect();
-        assert_eq!(~[A,B,C], elems)
+        let elems = e1.iter().collect();
+        assert_eq!(vec![A,B,C], elems)
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -280,15 +280,15 @@ mod test {
         e2.add(C);
 
         let e_union = e1 | e2;
-        let elems: ~[Foo] = e_union.iter().collect();
-        assert_eq!(~[A,B,C], elems)
+        let elems = e_union.iter().collect();
+        assert_eq!(vec![A,B,C], elems)
 
         let e_intersection = e1 & e2;
-        let elems: ~[Foo] = e_intersection.iter().collect();
-        assert_eq!(~[C], elems)
+        let elems = e_intersection.iter().collect();
+        assert_eq!(vec![C], elems)
 
         let e_subtract = e1 - e2;
-        let elems: ~[Foo] = e_subtract.iter().collect();
-        assert_eq!(~[A], elems)
+        let elems = e_subtract.iter().collect();
+        assert_eq!(vec![A], elems)
     }
 }

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -81,7 +81,7 @@ mod table {
     /// You can kind of think of this module/data structure as a safe wrapper
     /// around just the "table" part of the hashtable. It enforces some
     /// invariants at the type level and employs some performance trickery,
-    /// but in general is just a tricked out `~[Option<u64, K, V>]`.
+    /// but in general is just a tricked out `Vec<Option<u64, K, V>>`.
     ///
     /// FIXME(cgaebel):
     ///
@@ -1833,8 +1833,8 @@ mod test_map {
             hm
         };
 
-        let v = hm.move_iter().collect::<~[(char, int)]>();
-        assert!([('a', 1), ('b', 2)] == v || [('b', 2), ('a', 1)] == v);
+        let v = hm.move_iter().collect::<Vec<(char, int)>>();
+        assert!([('a', 1), ('b', 2)] == v.as_slice() || [('b', 2), ('a', 1)] == v.as_slice());
     }
 
     #[test]
@@ -1856,9 +1856,9 @@ mod test_map {
 
     #[test]
     fn test_keys() {
-        let vec = ~[(1, 'a'), (2, 'b'), (3, 'c')];
+        let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map = vec.move_iter().collect::<HashMap<int, char>>();
-        let keys = map.keys().map(|&k| k).collect::<~[int]>();
+        let keys = map.keys().map(|&k| k).collect::<Vec<int>>();
         assert_eq!(keys.len(), 3);
         assert!(keys.contains(&1));
         assert!(keys.contains(&2));
@@ -1867,9 +1867,9 @@ mod test_map {
 
     #[test]
     fn test_values() {
-        let vec = ~[(1, 'a'), (2, 'b'), (3, 'c')];
+        let vec = vec![(1, 'a'), (2, 'b'), (3, 'c')];
         let map = vec.move_iter().collect::<HashMap<int, char>>();
-        let values = map.values().map(|&v| v).collect::<~[char]>();
+        let values = map.values().map(|&v| v).collect::<Vec<char>>();
         assert_eq!(values.len(), 3);
         assert!(values.contains(&'a'));
         assert!(values.contains(&'b'));
@@ -1942,7 +1942,7 @@ mod test_map {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: HashMap<int, int> = xs.iter().map(|&x| x).collect();
 
@@ -2133,7 +2133,7 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let xs = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let set: HashSet<int> = xs.iter().map(|&x| x).collect();
 
@@ -2153,8 +2153,8 @@ mod test_set {
             hs
         };
 
-        let v = hs.move_iter().collect::<~[char]>();
-        assert!(['a', 'b'] == v || ['b', 'a'] == v);
+        let v = hs.move_iter().collect::<Vec<char>>();
+        assert!(['a', 'b'] == v.as_slice() || ['b', 'a'] == v.as_slice());
     }
 
     #[test]

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -22,6 +22,8 @@
 
 #![feature(macro_rules, managed_boxes, default_type_params, phase)]
 
+#![deny(deprecated_owned_vector)]
+
 extern crate rand;
 
 #[cfg(test)] extern crate test;

--- a/src/libcollections/lru_cache.rs
+++ b/src/libcollections/lru_cache.rs
@@ -294,10 +294,10 @@ mod tests {
 
     #[test]
     fn test_put_update() {
-        let mut cache: LruCache<~str, ~[u8]> = LruCache::new(1);
-        cache.put(~"1", ~[10, 10]);
-        cache.put(~"1", ~[10, 19]);
-        assert_opt_eq(cache.get(&~"1"), ~[10, 19]);
+        let mut cache: LruCache<~str, Vec<u8>> = LruCache::new(1);
+        cache.put(~"1", vec![10, 10]);
+        cache.put(~"1", vec![10, 19]);
+        assert_opt_eq(cache.get(&~"1"), vec![10, 19]);
         assert_eq!(cache.len(), 1);
     }
 

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -17,11 +17,11 @@
 
 use std::iter::{Enumerate, FilterMap, Rev};
 use std::mem::replace;
-use std::slice;
+use std::{vec, slice};
 
 #[allow(missing_doc)]
 pub struct SmallIntMap<T> {
-    v: ~[Option<T>],
+    v: Vec<Option<T>>,
 }
 
 impl<V> Container for SmallIntMap<V> {
@@ -45,7 +45,7 @@ impl<V> Map<uint, V> for SmallIntMap<V> {
     /// Return a reference to the value corresponding to the key
     fn find<'a>(&'a self, key: &uint) -> Option<&'a V> {
         if *key < self.v.len() {
-            match self.v[*key] {
+            match *self.v.get(*key) {
               Some(ref value) => Some(value),
               None => None
             }
@@ -59,7 +59,7 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
     /// Return a mutable reference to the value corresponding to the key
     fn find_mut<'a>(&'a mut self, key: &uint) -> Option<&'a mut V> {
         if *key < self.v.len() {
-            match self.v[*key] {
+            match *self.v.get_mut(*key) {
               Some(ref mut value) => Some(value),
               None => None
             }
@@ -77,7 +77,7 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
         if len <= key {
             self.v.grow_fn(key - len + 1, |_| None);
         }
-        self.v[key] = Some(value);
+        *self.v.get_mut(key) = Some(value);
         !exists
     }
 
@@ -104,17 +104,17 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
         if *key >= self.v.len() {
             return None;
         }
-        self.v[*key].take()
+        self.v.get_mut(*key).take()
     }
 }
 
 impl<V> SmallIntMap<V> {
     /// Create an empty SmallIntMap
-    pub fn new() -> SmallIntMap<V> { SmallIntMap{v: ~[]} }
+    pub fn new() -> SmallIntMap<V> { SmallIntMap{v: vec!()} }
 
     /// Create an empty SmallIntMap with capacity `capacity`
     pub fn with_capacity(capacity: uint) -> SmallIntMap<V> {
-        SmallIntMap { v: slice::with_capacity(capacity) }
+        SmallIntMap { v: Vec::with_capacity(capacity) }
     }
 
     pub fn get<'a>(&'a self, key: &uint) -> &'a V {
@@ -158,9 +158,9 @@ impl<V> SmallIntMap<V> {
     /// Empties the hash map, moving all values into the specified closure
     pub fn move_iter(&mut self)
         -> FilterMap<(uint, Option<V>), (uint, V),
-                Enumerate<slice::MoveItems<Option<V>>>>
+                Enumerate<vec::MoveItems<Option<V>>>>
     {
-        let values = replace(&mut self.v, ~[]);
+        let values = replace(&mut self.v, vec!());
         values.move_iter().enumerate().filter_map(|(i, v)| {
             v.map(|v| (i, v))
         })

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -139,7 +139,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// Requires that it be frozen (immutable).
     pub fn iter<'a>(&'a self) -> Entries<'a, K, V> {
         Entries {
-            stack: ~[],
+            stack: vec!(),
             node: deref(&self.root),
             remaining_min: self.length,
             remaining_max: self.length
@@ -156,7 +156,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// map, with the values being mutable.
     pub fn mut_iter<'a>(&'a mut self) -> MutEntries<'a, K, V> {
         MutEntries {
-            stack: ~[],
+            stack: vec!(),
             node: mut_deref(&mut self.root),
             remaining_min: self.length,
             remaining_max: self.length
@@ -173,8 +173,8 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     pub fn move_iter(self) -> MoveEntries<K, V> {
         let TreeMap { root: root, length: length } = self;
         let stk = match root {
-            None => ~[],
-            Some(~tn) => ~[tn]
+            None => vec!(),
+            Some(~tn) => vec!(tn)
         };
         MoveEntries {
             stack: stk,
@@ -222,7 +222,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// `traverse_left`/`traverse_right`/`traverse_complete`.
     fn iter_for_traversal<'a>(&'a self) -> Entries<'a, K, V> {
         Entries {
-            stack: ~[],
+            stack: vec!(),
             node: deref(&self.root),
             remaining_min: 0,
             remaining_max: self.length
@@ -245,7 +245,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
     /// `traverse_left`/`traverse_right`/`traverse_complete`.
     fn mut_iter_for_traversal<'a>(&'a mut self) -> MutEntries<'a, K, V> {
         MutEntries {
-            stack: ~[],
+            stack: vec!(),
             node: mut_deref(&mut self.root),
             remaining_min: 0,
             remaining_max: self.length
@@ -273,7 +273,7 @@ impl<K: TotalOrd, V> TreeMap<K, V> {
 
 /// Lazy forward iterator over a map
 pub struct Entries<'a, K, V> {
-    stack: ~[&'a TreeNode<K, V>],
+    stack: Vec<&'a TreeNode<K, V>>,
     // See the comment on MutEntries; this is just to allow
     // code-sharing (for this immutable-values iterator it *could* very
     // well be Option<&'a TreeNode<K,V>>).
@@ -290,7 +290,7 @@ pub struct RevEntries<'a, K, V> {
 /// Lazy forward iterator over a map that allows for the mutation of
 /// the values.
 pub struct MutEntries<'a, K, V> {
-    stack: ~[&'a mut TreeNode<K, V>],
+    stack: Vec<&'a mut TreeNode<K, V>>,
     // Unfortunately, we require some unsafe-ness to get around the
     // fact that we would be storing a reference *into* one of the
     // nodes in the stack.
@@ -482,7 +482,7 @@ fn mut_deref<K, V>(x: &mut Option<~TreeNode<K, V>>) -> *mut TreeNode<K, V> {
 
 /// Lazy forward iterator over a map that consumes the map while iterating
 pub struct MoveEntries<K, V> {
-    stack: ~[TreeNode<K, V>],
+    stack: Vec<TreeNode<K, V>>,
     remaining: uint
 }
 
@@ -1143,9 +1143,9 @@ mod test_treemap {
     #[test]
     fn test_rand_int() {
         let mut map: TreeMap<int,int> = TreeMap::new();
-        let mut ctrl = ~[];
+        let mut ctrl = vec![];
 
-        check_equal(ctrl, &map);
+        check_equal(ctrl.as_slice(), &map);
         assert!(map.find(&5).is_none());
 
         let mut rng: rand::IsaacRng = rand::SeedableRng::from_seed(&[42]);
@@ -1158,7 +1158,7 @@ mod test_treemap {
                     assert!(map.insert(k, v));
                     ctrl.push((k, v));
                     check_structure(&map);
-                    check_equal(ctrl, &map);
+                    check_equal(ctrl.as_slice(), &map);
                 }
             }
 
@@ -1167,7 +1167,7 @@ mod test_treemap {
                 let (key, _) = ctrl.remove(r).unwrap();
                 assert!(map.remove(&key));
                 check_structure(&map);
-                check_equal(ctrl, &map);
+                check_equal(ctrl.as_slice(), &map);
             }
         }
     }
@@ -1414,7 +1414,7 @@ mod test_treemap {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: TreeMap<int, int> = xs.iter().map(|&x| x).collect();
 
@@ -1725,7 +1725,7 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let xs = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let set: TreeSet<int> = xs.iter().map(|&x| x).collect();
 

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -774,7 +774,7 @@ mod test_map {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[(1u, 1i), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = vec![(1u, 1i), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: TrieMap<int> = xs.iter().map(|&x| x).collect();
 
@@ -1042,7 +1042,7 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = ~[9u, 8, 7, 6, 5, 4, 3, 2, 1];
+        let xs = vec![9u, 8, 7, 6, 5, 4, 3, 2, 1];
 
         let set: TrieSet = xs.iter().map(|&x| x).collect();
 

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -117,13 +117,13 @@ mod tests {
             words.push(r.gen_vec::<u8>(range));
         }
         for _ in range(0, 20) {
-            let mut input = ~[];
+            let mut input = vec![];
             for _ in range(0, 2000) {
                 input.push_all(r.choose(words.as_slice()).as_slice());
             }
             debug!("de/inflate of {} bytes of random word-sequences",
                    input.len());
-            let cmp = deflate_bytes(input).expect("deflation failed");
+            let cmp = deflate_bytes(input.as_slice()).expect("deflation failed");
             let out = inflate_bytes(cmp.as_slice()).expect("inflation failed");
             debug!("{} bytes deflated to {} ({:.1f}% size)",
                    input.len(), cmp.len(),

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -53,7 +53,7 @@
 //!
 //!     let program = args[0].clone();
 //!
-//!     let opts = ~[
+//!     let opts = [
 //!         optopt("o", "", "set output file name", "NAME"),
 //!         optflag("h", "help", "print this help menu")
 //!     ];

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -31,6 +31,8 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://static.rust-lang.org/doc/master")]
 
+#![deny(deprecated_owned_vector)]
+
 use std::cell::Cell;
 use std::{cmp, os, path};
 use std::io::fs;
@@ -245,26 +247,26 @@ impl Pattern {
      */
     pub fn new(pattern: &str) -> Pattern {
 
-        let chars = pattern.chars().collect::<~[_]>();
+        let chars = pattern.chars().collect::<Vec<_>>();
         let mut tokens = Vec::new();
         let mut i = 0;
 
         while i < chars.len() {
-            match chars[i] {
+            match *chars.get(i) {
                 '?' => {
                     tokens.push(AnyChar);
                     i += 1;
                 }
                 '*' => {
                     // *, **, ***, ****, ... are all equivalent
-                    while i < chars.len() && chars[i] == '*' {
+                    while i < chars.len() && *chars.get(i) == '*' {
                         i += 1;
                     }
                     tokens.push(AnySequence);
                 }
                 '[' => {
 
-                    if i <= chars.len() - 4 && chars[i + 1] == '!' {
+                    if i <= chars.len() - 4 && *chars.get(i + 1) == '!' {
                         match chars.slice_from(i + 3).position_elem(&']') {
                             None => (),
                             Some(j) => {
@@ -276,7 +278,7 @@ impl Pattern {
                             }
                         }
                     }
-                    else if i <= chars.len() - 3 && chars[i + 1] != '!' {
+                    else if i <= chars.len() - 3 && *chars.get(i + 1) != '!' {
                         match chars.slice_from(i + 2).position_elem(&']') {
                             None => (),
                             Some(j) => {

--- a/src/libgreen/basic.rs
+++ b/src/libgreen/basic.rs
@@ -27,11 +27,11 @@ pub fn event_loop() -> ~EventLoop:Send {
 }
 
 struct BasicLoop {
-    work: ~[proc():Send],             // pending work
+    work: Vec<proc():Send>,             // pending work
     idle: Option<*mut BasicPausable>, // only one is allowed
-    remotes: ~[(uint, ~Callback:Send)],
+    remotes: Vec<(uint, ~Callback:Send)>,
     next_remote: uint,
-    messages: Exclusive<~[Message]>,
+    messages: Exclusive<Vec<Message>>,
 }
 
 enum Message { RunRemote(uint), RemoveRemote(uint) }
@@ -39,18 +39,18 @@ enum Message { RunRemote(uint), RemoveRemote(uint) }
 impl BasicLoop {
     fn new() -> BasicLoop {
         BasicLoop {
-            work: ~[],
+            work: vec![],
             idle: None,
             next_remote: 0,
-            remotes: ~[],
-            messages: Exclusive::new(~[]),
+            remotes: vec![],
+            messages: Exclusive::new(vec![]),
         }
     }
 
     /// Process everything in the work queue (continually)
     fn work(&mut self) {
         while self.work.len() > 0 {
-            for work in replace(&mut self.work, ~[]).move_iter() {
+            for work in replace(&mut self.work, vec![]).move_iter() {
                 work();
             }
         }
@@ -60,7 +60,7 @@ impl BasicLoop {
         let messages = unsafe {
             self.messages.with(|messages| {
                 if messages.len() > 0 {
-                    Some(replace(messages, ~[]))
+                    Some(replace(messages, vec![]))
                 } else {
                     None
                 }
@@ -165,12 +165,12 @@ impl EventLoop for BasicLoop {
 }
 
 struct BasicRemote {
-    queue: Exclusive<~[Message]>,
+    queue: Exclusive<Vec<Message>>,
     id: uint,
 }
 
 impl BasicRemote {
-    fn new(queue: Exclusive<~[Message]>, id: uint) -> BasicRemote {
+    fn new(queue: Exclusive<Vec<Message>>, id: uint) -> BasicRemote {
         BasicRemote { queue: queue, id: id }
     }
 }

--- a/src/libgreen/stack.rs
+++ b/src/libgreen/stack.rs
@@ -126,13 +126,13 @@ impl Drop for Stack {
 pub struct StackPool {
     // Ideally this would be some datastructure that preserved ordering on
     // Stack.min_size.
-    stacks: ~[Stack],
+    stacks: Vec<Stack>,
 }
 
 impl StackPool {
     pub fn new() -> StackPool {
         StackPool {
-            stacks: ~[],
+            stacks: vec![],
         }
     }
 

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -146,7 +146,7 @@ pub use types::os::arch::c95::{c_ushort, clock_t, ptrdiff_t};
 pub use types::os::arch::c95::{size_t, time_t};
 pub use types::os::arch::c99::{c_longlong, c_ulonglong, intptr_t};
 pub use types::os::arch::c99::{uintptr_t};
-pub use types::os::arch::posix88::{dev_t, dirent_t, ino_t, mode_t};
+pub use types::os::arch::posix88::{dev_t, ino_t, mode_t};
 pub use types::os::arch::posix88::{off_t, pid_t, ssize_t};
 
 pub use consts::os::c95::{_IOFBF, _IOLBF, _IONBF, BUFSIZ, EOF};

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -340,11 +340,11 @@ pub fn mkdir(p: &CString, mode: io::FilePermission) -> IoResult<()> {
     }))
 }
 
-pub fn readdir(p: &CString) -> IoResult<~[Path]> {
+pub fn readdir(p: &CString) -> IoResult<Vec<Path>> {
     use libc::{dirent_t};
     use libc::{opendir, readdir_r, closedir};
 
-    fn prune(root: &CString, dirs: ~[Path]) -> ~[Path] {
+    fn prune(root: &CString, dirs: Vec<Path>) -> Vec<Path> {
         let root = unsafe { CString::new(root.with_ref(|p| p), false) };
         let root = Path::new(root);
 
@@ -365,7 +365,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
     let dir_ptr = p.with_ref(|buf| unsafe { opendir(buf) });
 
     if dir_ptr as uint != 0 {
-        let mut paths = ~[];
+        let mut paths = vec!();
         let mut entry_ptr = 0 as *mut dirent_t;
         while unsafe { readdir_r(dir_ptr, ptr, &mut entry_ptr) == 0 } {
             if entry_ptr.is_null() { break }
@@ -571,4 +571,3 @@ mod tests {
         }
     }
 }
-

--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -324,7 +324,7 @@ pub fn mkdir(p: &CString, _mode: io::FilePermission) -> IoResult<()> {
 }
 
 pub fn readdir(p: &CString) -> IoResult<Vec<Path>> {
-    use rt::global_heap::malloc_raw;
+    use std::rt::global_heap::malloc_raw;
 
     fn prune(root: &CString, dirs: Vec<Path>) -> Vec<Path> {
         let root = unsafe { CString::new(root.with_ref(|p| p), false) };

--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -323,10 +323,10 @@ pub fn mkdir(p: &CString, _mode: io::FilePermission) -> IoResult<()> {
     })
 }
 
-pub fn readdir(p: &CString) -> IoResult<~[Path]> {
+pub fn readdir(p: &CString) -> IoResult<Vec<Path>> {
     use rt::global_heap::malloc_raw;
 
-    fn prune(root: &CString, dirs: ~[Path]) -> ~[Path] {
+    fn prune(root: &CString, dirs: Vec<Path>) -> Vec<Path> {
         let root = unsafe { CString::new(root.with_ref(|p| p), false) };
         let root = Path::new(root);
 
@@ -346,7 +346,7 @@ pub fn readdir(p: &CString) -> IoResult<~[Path]> {
         let wfd_ptr = malloc_raw(rust_list_dir_wfd_size() as uint);
         let find_handle = libc::FindFirstFileW(path_ptr, wfd_ptr as libc::HANDLE);
         if find_handle as libc::c_int != libc::INVALID_HANDLE_VALUE {
-            let mut paths = ~[];
+            let mut paths = vec!();
             let mut more_files = 1 as libc::c_int;
             while more_files != 0 {
                 let fp_buf = rust_list_dir_wfd_fp_buf(wfd_ptr as *c_void);

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -217,7 +217,7 @@ impl rtio::IoFactory for IoFactory {
     fn fs_rename(&mut self, path: &CString, to: &CString) -> IoResult<()> {
         file::rename(path, to)
     }
-    fn fs_readdir(&mut self, path: &CString, _flags: c_int) -> IoResult<~[Path]> {
+    fn fs_readdir(&mut self, path: &CString, _flags: c_int) -> IoResult<Vec<Path>> {
         file::readdir(path)
     }
     fn fs_lstat(&mut self, path: &CString) -> IoResult<io::FileStat> {

--- a/src/libnative/io/timer_other.rs
+++ b/src/libnative/io/timer_other.rs
@@ -102,11 +102,11 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
     // active timers are those which are able to be selected upon (and it's a
     // sorted list, and dead timers are those which have expired, but ownership
     // hasn't yet been transferred back to the timer itself.
-    let mut active: ~[~Inner] = ~[];
-    let mut dead = ~[];
+    let mut active: Vec<~Inner> = vec![];
+    let mut dead = vec![];
 
     // inserts a timer into an array of timers (sorted by firing time)
-    fn insert(t: ~Inner, active: &mut ~[~Inner]) {
+    fn insert(t: ~Inner, active: &mut Vec<~Inner>) {
         match active.iter().position(|tm| tm.target > t.target) {
             Some(pos) => { active.insert(pos, t); }
             None => { active.push(t); }
@@ -114,7 +114,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
     }
 
     // signals the first requests in the queue, possible re-enqueueing it.
-    fn signal(active: &mut ~[~Inner], dead: &mut ~[(uint, ~Inner)]) {
+    fn signal(active: &mut Vec<~Inner>, dead: &mut Vec<(uint, ~Inner)>) {
         let mut timer = match active.shift() {
             Some(timer) => timer, None => return
         };
@@ -137,7 +137,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
             let now = now();
             // If this request has already expired, then signal it and go
             // through another iteration
-            if active[0].target <= now {
+            if active.get(0).target <= now {
                 signal(&mut active, &mut dead);
                 continue;
             }
@@ -145,7 +145,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>) {
             // The actual timeout listed in the requests array is an
             // absolute date, so here we translate the absolute time to a
             // relative time.
-            let tm = active[0].target - now;
+            let tm = active.get(0).target - now;
             timeout.tv_sec = (tm / 1000) as libc::time_t;
             timeout.tv_usec = ((tm % 1000) * 1000) as libc::suseconds_t;
             &timeout as *libc::timeval

--- a/src/libnative/io/timer_win32.rs
+++ b/src/libnative/io/timer_win32.rs
@@ -40,8 +40,8 @@ pub enum Req {
 }
 
 fn helper(input: libc::HANDLE, messages: Receiver<Req>) {
-    let mut objs = ~[input];
-    let mut chans = ~[];
+    let mut objs = vec![input];
+    let mut chans = vec![];
 
     'outer: loop {
         let idx = unsafe {
@@ -78,7 +78,7 @@ fn helper(input: libc::HANDLE, messages: Receiver<Req>) {
             }
         } else {
             let remove = {
-                match &chans[idx as uint - 1] {
+                match chans.get(idx as uint - 1) {
                     &(ref c, oneshot) => !c.try_send(()) || oneshot
                 }
             };

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -42,23 +42,14 @@ pub fn get_rpath_flags(sess: &Session, out_filename: &Path) -> Vec<~str> {
     let sysroot = sess.filesearch().sysroot;
     let output = out_filename;
     let libs = sess.cstore.get_used_crates(cstore::RequireDynamic);
-    let libs = libs.move_iter().filter_map(|(_, l)| l.map(|p| p.clone())).collect();
-    // We don't currently rpath extern libraries, but we know
-    // where rustrt is and we know every rust program needs it
-    let libs = slice::append_one(libs, get_sysroot_absolute_rt_lib(sess));
+    let libs = libs.move_iter().filter_map(|(_, l)| {
+        l.map(|p| p.clone())
+    }).collect::<~[_]>();
 
     let rpaths = get_rpaths(os, sysroot, output, libs,
                             sess.opts.target_triple);
     flags.push_all(rpaths_to_flags(rpaths.as_slice()).as_slice());
     flags
-}
-
-fn get_sysroot_absolute_rt_lib(sess: &Session) -> Path {
-    let sysroot = sess.filesearch().sysroot;
-    let r = filesearch::relative_target_lib_path(sysroot, sess.opts.target_triple);
-    let mut p = sysroot.join(&r);
-    p.push(os::dll_filename("rustrt"));
-    p
 }
 
 pub fn rpaths_to_flags(rpaths: &[~str]) -> Vec<~str> {

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -12,9 +12,10 @@
 use driver::session::Session;
 use metadata::cstore;
 use metadata::filesearch;
+use util::fs;
 
 use collections::HashSet;
-use std::{os, slice};
+use std::os;
 use syntax::abi;
 
 fn not_win32(os: abi::Os) -> bool {
@@ -121,9 +122,9 @@ pub fn get_rpath_relative_to_output(os: abi::Os,
         abi::OsWin32 => unreachable!()
     };
 
-    let mut lib = os::make_absolute(lib);
+    let mut lib = fs::realpath(&os::make_absolute(lib)).unwrap();
     lib.pop();
-    let mut output = os::make_absolute(output);
+    let mut output = fs::realpath(&os::make_absolute(output)).unwrap();
     output.pop();
     let relative = lib.path_relative_from(&output);
     let relative = relative.expect("could not create rpath relative to output");

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -664,7 +664,8 @@ impl pprust::PpAnn for TypedAnnotation {
 pub fn pretty_print_input(sess: Session,
                           cfg: ast::CrateConfig,
                           input: &Input,
-                          ppm: PpMode) {
+                          ppm: PpMode,
+                          ofile: Option<Path>) {
     let krate = phase_1_parse_input(&sess, cfg, input);
     let id = link::find_crate_id(krate.attrs.as_slice(), input.filestem());
 
@@ -682,6 +683,17 @@ pub fn pretty_print_input(sess: Session,
     let src = Vec::from_slice(sess.codemap().get_filemap(src_name).src.as_bytes());
     let mut rdr = MemReader::new(src);
 
+    let out = match ofile {
+        None => ~io::stdout() as ~Writer,
+        Some(p) => {
+            let r = io::File::create(&p);
+            match r {
+                Ok(w) => ~w as ~Writer,
+                Err(e) => fail!("print-print failed to open {} due to {}",
+                                p.display(), e),
+            }
+        }
+    };
     match ppm {
         PpmIdentified | PpmExpandedIdentified => {
             pprust::print_crate(sess.codemap(),
@@ -689,7 +701,7 @@ pub fn pretty_print_input(sess: Session,
                                 &krate,
                                 src_name,
                                 &mut rdr,
-                                ~io::stdout(),
+                                out,
                                 &IdentifiedAnnotation,
                                 is_expanded)
         }
@@ -704,7 +716,7 @@ pub fn pretty_print_input(sess: Session,
                                 &krate,
                                 src_name,
                                 &mut rdr,
-                                ~io::stdout(),
+                                out,
                                 &annotation,
                                 is_expanded)
         }
@@ -714,7 +726,7 @@ pub fn pretty_print_input(sess: Session,
                                 &krate,
                                 src_name,
                                 &mut rdr,
-                                ~io::stdout(),
+                                out,
                                 &pprust::NoAnn,
                                 is_expanded)
         }

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -297,20 +297,22 @@ mod __test {
 
 fn mk_std(cx: &TestCtxt) -> ast::ViewItem {
     let id_test = token::str_to_ident("test");
-    let vi = if cx.is_test_crate {
-        ast::ViewItemUse(
+    let (vi, vis) = if cx.is_test_crate {
+        (ast::ViewItemUse(
             vec!(@nospan(ast::ViewPathSimple(id_test,
                                              path_node(vec!(id_test)),
-                                             ast::DUMMY_NODE_ID))))
+                                             ast::DUMMY_NODE_ID)))),
+         ast::Public)
     } else {
-        ast::ViewItemExternCrate(id_test,
+        (ast::ViewItemExternCrate(id_test,
                                with_version("test"),
-                               ast::DUMMY_NODE_ID)
+                               ast::DUMMY_NODE_ID),
+         ast::Inherited)
     };
     ast::ViewItem {
         node: vi,
         attrs: Vec::new(),
-        vis: ast::Inherited,
+        vis: vis,
         span: DUMMY_SP
     }
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -127,6 +127,7 @@ pub mod util {
     pub mod ppaux;
     pub mod sha2;
     pub mod nodemap;
+    pub mod fs;
 }
 
 pub mod lib {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -293,7 +293,7 @@ pub fn run_compiler(args: &[~str]) {
     });
     match pretty {
         Some::<d::PpMode>(ppm) => {
-            d::pretty_print_input(sess, cfg, &input, ppm);
+            d::pretty_print_input(sess, cfg, &input, ppm, ofile);
             return;
         }
         None::<d::PpMode> => {/* continue */ }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -190,7 +190,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
                 } else {
                     None
                 })
-                .collect::<~[&ast::Attribute]>();
+                .collect::<Vec<&ast::Attribute>>();
             for m in link_args.iter() {
                 match m.value_str() {
                     Some(linkarg) => e.sess.cstore.add_used_link_args(linkarg.get()),
@@ -205,7 +205,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
                 } else {
                     None
                 })
-                .collect::<~[&ast::Attribute]>();
+                .collect::<Vec<&ast::Attribute>>();
             for m in link_args.iter() {
                 match m.meta_item_list() {
                     Some(items) => {

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -28,7 +28,7 @@ use syntax::parse::token;
 pub struct StaticMethodInfo {
     pub ident: ast::Ident,
     pub def_id: ast::DefId,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub vis: ast::Visibility,
 }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -330,11 +330,11 @@ fn item_to_def_like(item: ebml::Doc, did: ast::DefId, cnum: ast::CrateNum)
         MutStatic => DlDef(ast::DefStatic(did, true)),
         Struct    => DlDef(ast::DefStruct(did)),
         UnsafeFn  => DlDef(ast::DefFn(did, ast::UnsafeFn)),
-        Fn        => DlDef(ast::DefFn(did, ast::ImpureFn)),
+        Fn        => DlDef(ast::DefFn(did, ast::NormalFn)),
         ForeignFn => DlDef(ast::DefFn(did, ast::ExternFn)),
         StaticMethod | UnsafeStaticMethod => {
-            let purity = if fam == UnsafeStaticMethod { ast::UnsafeFn } else
-                { ast::ImpureFn };
+            let fn_style = if fam == UnsafeStaticMethod { ast::UnsafeFn } else
+                { ast::NormalFn };
             // def_static_method carries an optional field of its enclosing
             // trait or enclosing impl (if this is an inherent static method).
             // So we need to detect whether this is in a trait or not, which
@@ -348,7 +348,7 @@ fn item_to_def_like(item: ebml::Doc, did: ast::DefId, cnum: ast::CrateNum)
                 ast::FromImpl(item_reqd_and_translated_parent_item(cnum,
                                                                    item))
             };
-            DlDef(ast::DefStaticMethod(did, provenance, purity))
+            DlDef(ast::DefStaticMethod(did, provenance, fn_style))
         }
         Type | ForeignType => DlDef(ast::DefTy(did)),
         Mod => DlDef(ast::DefMod(did)),
@@ -905,17 +905,17 @@ pub fn get_static_methods_if_impl(intr: Rc<IdentInterner>,
         let family = item_family(impl_method_doc);
         match family {
             StaticMethod | UnsafeStaticMethod => {
-                let purity;
+                let fn_style;
                 match item_family(impl_method_doc) {
-                    StaticMethod => purity = ast::ImpureFn,
-                    UnsafeStaticMethod => purity = ast::UnsafeFn,
+                    StaticMethod => fn_style = ast::NormalFn,
+                    UnsafeStaticMethod => fn_style = ast::UnsafeFn,
                     _ => fail!()
                 }
 
                 static_impl_methods.push(StaticMethodInfo {
                     ident: item_name(&*intr, impl_method_doc),
                     def_id: item_def_id(impl_method_doc, cdata),
-                    purity: purity,
+                    fn_style: fn_style,
                     vis: item_visibility(impl_method_doc),
                 });
             }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -758,12 +758,12 @@ fn encode_method_ty_fields(ecx: &EncodeContext,
     encode_method_fty(ecx, ebml_w, &method_ty.fty);
     encode_visibility(ebml_w, method_ty.vis);
     encode_explicit_self(ebml_w, method_ty.explicit_self);
-    let purity = method_ty.fty.purity;
+    let fn_style = method_ty.fty.fn_style;
     match method_ty.explicit_self {
         ast::SelfStatic => {
-            encode_family(ebml_w, purity_static_method_family(purity));
+            encode_family(ebml_w, fn_style_static_method_family(fn_style));
         }
-        _ => encode_family(ebml_w, purity_fn_family(purity))
+        _ => encode_family(ebml_w, style_fn_family(fn_style))
     }
     encode_provided_source(ebml_w, method_ty.provided_source);
 }
@@ -811,18 +811,18 @@ fn encode_info_for_method(ecx: &EncodeContext,
     ebml_w.end_tag();
 }
 
-fn purity_fn_family(p: Purity) -> char {
-    match p {
+fn style_fn_family(s: FnStyle) -> char {
+    match s {
         UnsafeFn => 'u',
-        ImpureFn => 'f',
+        NormalFn => 'f',
         ExternFn => 'e'
     }
 }
 
-fn purity_static_method_family(p: Purity) -> char {
-    match p {
+fn fn_style_static_method_family(s: FnStyle) -> char {
+    match s {
         UnsafeFn => 'U',
-        ImpureFn => 'F',
+        NormalFn => 'F',
         _ => fail!("extern fn can't be static")
     }
 }
@@ -911,11 +911,11 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_visibility(ebml_w, vis);
         ebml_w.end_tag();
       }
-      ItemFn(_, purity, _, ref generics, _) => {
+      ItemFn(_, fn_style, _, ref generics, _) => {
         add_to_index(item, ebml_w, index);
         ebml_w.start_tag(tag_items_data_item);
         encode_def_id(ebml_w, def_id);
-        encode_family(ebml_w, purity_fn_family(purity));
+        encode_family(ebml_w, style_fn_family(fn_style));
         let tps_len = generics.ty_params.len();
         encode_bounds_and_type(ebml_w, ecx, &lookup_item_type(tcx, def_id));
         encode_name(ebml_w, item.ident.name);
@@ -1165,8 +1165,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
             match method_ty.explicit_self {
                 SelfStatic => {
                     encode_family(ebml_w,
-                                  purity_static_method_family(
-                                      method_ty.fty.purity));
+                                  fn_style_static_method_family(
+                                      method_ty.fty.fn_style));
 
                     let tpt = ty::lookup_item_type(tcx, method_def_id);
                     encode_bounds_and_type(ebml_w, ecx, &tpt);
@@ -1174,8 +1174,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
 
                 _ => {
                     encode_family(ebml_w,
-                                  purity_fn_family(
-                                      method_ty.fty.purity));
+                                  style_fn_family(
+                                      method_ty.fty.fn_style));
                 }
             }
 
@@ -1227,7 +1227,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
     encode_def_id(ebml_w, local_def(nitem.id));
     match nitem.node {
       ForeignItemFn(..) => {
-        encode_family(ebml_w, purity_fn_family(ImpureFn));
+        encode_family(ebml_w, style_fn_family(NormalFn));
         encode_bounds_and_type(ebml_w, ecx,
                                &lookup_item_type(ecx.tcx,local_def(nitem.id)));
         encode_name(ebml_w, nitem.ident.name);

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -15,6 +15,8 @@ use std::os;
 use std::io::fs;
 use collections::HashSet;
 
+use myfs = util::fs;
+
 pub enum FileMatch { FileMatches, FileDoesntMatch }
 
 // A module for searching for libraries
@@ -156,17 +158,10 @@ fn make_rustpkg_target_lib_path(sysroot: &Path,
 pub fn get_or_default_sysroot() -> Path {
     // Follow symlinks.  If the resolved path is relative, make it absolute.
     fn canonicalize(path: Option<Path>) -> Option<Path> {
-        path.and_then(|mut path|
-            match fs::readlink(&path) {
-                Ok(canon) => {
-                    if canon.is_absolute() {
-                        Some(canon)
-                    } else {
-                        path.pop();
-                        Some(path.join(canon))
-                    }
-                },
-                Err(..) => Some(path),
+        path.and_then(|path|
+            match myfs::realpath(&path) {
+                Ok(canon) => Some(canon),
+                Err(e) => fail!("failed to get realpath: {}", e),
             })
     }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -449,12 +449,12 @@ fn parse_hex(st: &mut PState) -> uint {
     };
 }
 
-fn parse_purity(c: char) -> Purity {
+fn parse_fn_style(c: char) -> FnStyle {
     match c {
         'u' => UnsafeFn,
-        'i' => ImpureFn,
+        'n' => NormalFn,
         'c' => ExternFn,
-        _ => fail!("parse_purity: bad purity {}", c)
+        _ => fail!("parse_fn_style: bad fn_style {}", c)
     }
 }
 
@@ -476,13 +476,13 @@ fn parse_onceness(c: char) -> ast::Onceness {
 
 fn parse_closure_ty(st: &mut PState, conv: conv_did) -> ty::ClosureTy {
     let sigil = parse_sigil(st);
-    let purity = parse_purity(next(st));
+    let fn_style = parse_fn_style(next(st));
     let onceness = parse_onceness(next(st));
     let region = parse_region(st, |x,y| conv(x,y));
     let bounds = parse_bounds(st, |x,y| conv(x,y));
     let sig = parse_sig(st, |x,y| conv(x,y));
     ty::ClosureTy {
-        purity: purity,
+        fn_style: fn_style,
         sigil: sigil,
         onceness: onceness,
         region: region,
@@ -492,11 +492,11 @@ fn parse_closure_ty(st: &mut PState, conv: conv_did) -> ty::ClosureTy {
 }
 
 fn parse_bare_fn_ty(st: &mut PState, conv: conv_did) -> ty::BareFnTy {
-    let purity = parse_purity(next(st));
+    let fn_style = parse_fn_style(next(st));
     let abi = parse_abi_set(st);
     let sig = parse_sig(st, |x,y| conv(x,y));
     ty::BareFnTy {
-        purity: purity,
+        fn_style: fn_style,
         abi: abi,
         sig: sig
     }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -332,9 +332,9 @@ fn enc_sigil(w: &mut MemWriter, sigil: Sigil) {
     }
 }
 
-fn enc_purity(w: &mut MemWriter, p: Purity) {
+fn enc_fn_style(w: &mut MemWriter, p: FnStyle) {
     match p {
-        ImpureFn => mywrite!(w, "i"),
+        NormalFn => mywrite!(w, "n"),
         UnsafeFn => mywrite!(w, "u"),
         ExternFn => mywrite!(w, "c")
     }
@@ -354,14 +354,14 @@ fn enc_onceness(w: &mut MemWriter, o: Onceness) {
 }
 
 pub fn enc_bare_fn_ty(w: &mut MemWriter, cx: &ctxt, ft: &ty::BareFnTy) {
-    enc_purity(w, ft.purity);
+    enc_fn_style(w, ft.fn_style);
     enc_abi(w, ft.abi);
     enc_fn_sig(w, cx, &ft.sig);
 }
 
 fn enc_closure_ty(w: &mut MemWriter, cx: &ctxt, ft: &ty::ClosureTy) {
     enc_sigil(w, ft.sigil);
-    enc_purity(w, ft.purity);
+    enc_fn_style(w, ft.fn_style);
     enc_onceness(w, ft.onceness);
     enc_region(w, cx, ft.region);
     let bounds = ty::ParamBounds {builtin_bounds: ft.bounds,

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -29,8 +29,8 @@ enum UnsafeContext {
 
 fn type_is_unsafe_function(ty: ty::t) -> bool {
     match ty::get(ty).sty {
-        ty::ty_bare_fn(ref f) => f.purity == ast::UnsafeFn,
-        ty::ty_closure(ref f) => f.purity == ast::UnsafeFn,
+        ty::ty_bare_fn(ref f) => f.fn_style == ast::UnsafeFn,
+        ty::ty_closure(ref f) => f.fn_style == ast::UnsafeFn,
         _ => false,
     }
 }
@@ -84,10 +84,10 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
                 block: &ast::Block, span: Span, node_id: ast::NodeId, _:()) {
 
         let (is_item_fn, is_unsafe_fn) = match *fn_kind {
-            visit::FkItemFn(_, _, purity, _) =>
-                (true, purity == ast::UnsafeFn),
+            visit::FkItemFn(_, _, fn_style, _) =>
+                (true, fn_style == ast::UnsafeFn),
             visit::FkMethod(_, _, method) =>
-                (true, method.purity == ast::UnsafeFn),
+                (true, method.fn_style == ast::UnsafeFn),
             _ => (false, false),
         };
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1063,7 +1063,7 @@ fn check_attrs_usage(cx: &Context, attrs: &[ast::Attribute]) {
             if name.equiv(crate_attr) {
                 let msg = match attr.node.style {
                     ast::AttrOuter => "crate-level attribute should be an inner attribute: \
-                                       add semicolon at end",
+                                       add an exclamation mark: #![foo]",
                     ast::AttrInner => "crate-level attribute should be in the root module",
                 };
                 cx.span_lint(AttributeUsage, attr.span, msg);

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1982,6 +1982,7 @@ impl<'a> Resolver<'a> {
                         // the source of this name is different now
                         resolution.type_id.set(id);
                         resolution.value_id.set(id);
+                        resolution.is_public.set(is_public);
                     }
                     None => {
                         debug!("(building import directive) creating new");

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -144,6 +144,12 @@ impl NamespaceResult {
             _ => false
         }
     }
+    fn is_unbound(&self) -> bool {
+        match *self {
+            UnboundResult => true,
+            _ => false
+        }
+    }
 }
 
 enum NameDefinition {
@@ -2449,8 +2455,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        if import_resolution.value_target.borrow().is_none() &&
-           import_resolution.type_target.borrow().is_none() {
+        if value_result.is_unbound() && type_result.is_unbound() {
             let msg = format!("unresolved import: there is no \
                                `{}` in `{}`",
                               token::get_ident(source),

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1182,11 +1182,11 @@ impl<'a> Resolver<'a> {
                     (DefStatic(local_def(item.id), mutbl), sp, is_public);
                 parent
             }
-            ItemFn(_, purity, _, _, _) => {
+            ItemFn(_, fn_style, _, _, _) => {
               let (name_bindings, new_parent) =
                 self.add_child(ident, parent, ForbidDuplicateValues, sp);
 
-                let def = DefFn(local_def(item.id), purity);
+                let def = DefFn(local_def(item.id), fn_style);
                 name_bindings.define_value(def, sp, is_public);
                 new_parent
             }
@@ -1313,7 +1313,7 @@ impl<'a> Resolver<'a> {
                                     DefStaticMethod(local_def(method.id),
                                                       FromImpl(local_def(
                                                         item.id)),
-                                                      method.purity)
+                                                      method.fn_style)
                                 }
                                 _ => {
                                     // Non-static methods become
@@ -1364,7 +1364,7 @@ impl<'a> Resolver<'a> {
                             // Static methods become `def_static_method`s.
                             DefStaticMethod(local_def(ty_m.id),
                                               FromTrait(local_def(item.id)),
-                                              ty_m.purity)
+                                              ty_m.fn_style)
                         }
                         _ => {
                             // Non-static methods become `def_method`s.
@@ -1869,7 +1869,7 @@ impl<'a> Resolver<'a> {
                                                        DUMMY_SP);
                                     let def = DefFn(
                                         static_method_info.def_id,
-                                        static_method_info.purity);
+                                        static_method_info.fn_style);
 
                                     method_name_bindings.define_value(
                                         def, DUMMY_SP,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1554,8 +1554,8 @@ impl<'a> Visitor<()> for TransItemVisitor<'a> {
 pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
     let _icx = push_ctxt("trans_item");
     match item.node {
-      ast::ItemFn(decl, purity, _abi, ref generics, body) => {
-        if purity == ast::ExternFn  {
+      ast::ItemFn(decl, fn_style, _abi, ref generics, body) => {
+        if fn_style == ast::ExternFn  {
             let llfndecl = get_item_val(ccx, item.id);
             foreign::trans_rust_fn_with_foreign_abi(
                 ccx, decl, body, item.attrs.as_slice(), llfndecl, item.id);
@@ -1899,8 +1899,8 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
                     }
                 }
 
-                ast::ItemFn(_, purity, _, _, _) => {
-                    let llfn = if purity != ast::ExternFn {
+                ast::ItemFn(_, fn_style, _, _, _) => {
+                    let llfn = if fn_style != ast::ExternFn {
                         register_fn(ccx, i.span, sym, i.id, ty)
                     } else {
                         foreign::register_rust_fn_with_foreign_abi(ccx,

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -615,7 +615,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
 
             let opt_def = cx.tcx().def_map.borrow().find_copy(&e.id);
             match opt_def {
-                Some(ast::DefFn(def_id, _purity)) => {
+                Some(ast::DefFn(def_id, _fn_style)) => {
                     if !ast_util::is_local(def_id) {
                         let ty = csearch::get_type(cx.tcx(), def_id).ty;
                         (base::trans_external_path(cx, def_id, ty), true)

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -293,6 +293,13 @@ pub fn create_global_var_metadata(cx: &CrateContext,
         return;
     }
 
+    // Don't create debuginfo for globals inlined from other crates. The other crate should already
+    // contain debuginfo for it. More importantly, the global might not even exist in un-inlined
+    // form anywhere which would lead to a linker errors.
+    if cx.external_srcs.borrow().contains_key(&node_id) {
+        return;
+    }
+
     let var_item = cx.tcx.map.get(node_id);
 
     let (ident, span) = match var_item {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -130,6 +130,7 @@ use driver::session::{FullDebugInfo, LimitedDebugInfo, NoDebugInfo};
 use lib::llvm::llvm;
 use lib::llvm::{ModuleRef, ContextRef, ValueRef};
 use lib::llvm::debuginfo::*;
+use metadata::csearch;
 use middle::trans::adt;
 use middle::trans::common::*;
 use middle::trans::datum::{Datum, Lvalue};
@@ -178,6 +179,7 @@ pub struct CrateDebugContext {
     current_debug_location: Cell<DebugLocation>,
     created_files: RefCell<HashMap<~str, DIFile>>,
     created_types: RefCell<HashMap<uint, DIType>>,
+    created_enum_disr_types: RefCell<HashMap<ast::DefId, DIType>>,
     namespace_map: RefCell<HashMap<Vec<ast::Name> , @NamespaceTreeNode>>,
     // This collection is used to assert that composite types (structs, enums, ...) have their
     // members only set once:
@@ -196,6 +198,7 @@ impl CrateDebugContext {
             current_debug_location: Cell::new(UnknownLocation),
             created_files: RefCell::new(HashMap::new()),
             created_types: RefCell::new(HashMap::new()),
+            created_enum_disr_types: RefCell::new(HashMap::new()),
             namespace_map: RefCell::new(HashMap::new()),
             composite_types_completed: RefCell::new(HashSet::new()),
         };
@@ -1542,24 +1545,45 @@ fn prepare_enum_metadata(cx: &CrateContext,
         .collect();
 
     let discriminant_type_metadata = |inttype| {
-        let discriminant_llvm_type = adt::ll_inttype(cx, inttype);
-        let (discriminant_size, discriminant_align) = size_and_align_of(cx, discriminant_llvm_type);
-        let discriminant_base_type_metadata = type_metadata(cx, adt::ty_of_inttype(inttype),
-                                                            codemap::DUMMY_SP);
-        enum_name.with_c_str(|enum_name| {
-            unsafe {
-                llvm::LLVMDIBuilderCreateEnumerationType(
-                    DIB(cx),
-                    containing_scope,
-                    enum_name,
-                    file_metadata,
-                    loc.line as c_uint,
-                    bytes_to_bits(discriminant_size),
-                    bytes_to_bits(discriminant_align),
-                    create_DIArray(DIB(cx), enumerators_metadata.as_slice()),
-                    discriminant_base_type_metadata)
+        // We can reuse the type of the discriminant for all monomorphized instances of an enum
+        // because it doesn't depend on any type parameters. The def_id, uniquely identifying the
+        // enum's polytype acts as key in this cache.
+        let cached_discriminant_type_metadata = debug_context(cx).created_enum_disr_types
+                                                                 .borrow()
+                                                                 .find_copy(&enum_def_id);
+        match cached_discriminant_type_metadata {
+            Some(discriminant_type_metadata) => discriminant_type_metadata,
+            None => {
+                let discriminant_llvm_type = adt::ll_inttype(cx, inttype);
+                let (discriminant_size, discriminant_align) =
+                    size_and_align_of(cx, discriminant_llvm_type);
+                let discriminant_base_type_metadata = type_metadata(cx,
+                                                                    adt::ty_of_inttype(inttype),
+                                                                    codemap::DUMMY_SP);
+                let discriminant_name = get_enum_discriminant_name(cx, enum_def_id);
+
+                let discriminant_type_metadata = discriminant_name.get().with_c_str(|name| {
+                    unsafe {
+                        llvm::LLVMDIBuilderCreateEnumerationType(
+                            DIB(cx),
+                            containing_scope,
+                            name,
+                            file_metadata,
+                            loc.line as c_uint,
+                            bytes_to_bits(discriminant_size),
+                            bytes_to_bits(discriminant_align),
+                            create_DIArray(DIB(cx), enumerators_metadata.as_slice()),
+                            discriminant_base_type_metadata)
+                    }
+                });
+
+                debug_context(cx).created_enum_disr_types
+                                 .borrow_mut()
+                                 .insert(enum_def_id, discriminant_type_metadata);
+
+                discriminant_type_metadata
             }
-        })
+        }
     };
 
     let type_rep = adt::represent_type(cx, enum_type);
@@ -1648,6 +1672,16 @@ fn prepare_enum_metadata(cx: &CrateContext,
             }
         }
     };
+
+    fn get_enum_discriminant_name(cx: &CrateContext, def_id: ast::DefId) -> token::InternedString {
+        let name = if def_id.krate == ast::LOCAL_CRATE {
+            cx.tcx.map.get_path_elem(def_id.node).name()
+        } else {
+            csearch::get_item_path(&cx.tcx, def_id).last().unwrap().name()
+        };
+
+        token::get_name(name)
+    }
 }
 
 enum MemberOffset {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -211,7 +211,7 @@ impl<'a> Reflector<'a> {
           // FIXME (#2594): fetch constants out of intrinsic
           // FIXME (#4809): visitor should break out bare fns from other fns
           ty::ty_closure(ref fty) => {
-            let pureval = ast_purity_constant(fty.purity);
+            let pureval = ast_fn_style_constant(fty.fn_style);
             let sigilval = ast_sigil_constant(fty.sigil);
             let retval = if ty::type_is_bot(fty.sig.output) {0u} else {1u};
             let extra = vec!(self.c_uint(pureval),
@@ -226,7 +226,7 @@ impl<'a> Reflector<'a> {
           // FIXME (#2594): fetch constants out of intrinsic:: for the
           // numbers.
           ty::ty_bare_fn(ref fty) => {
-            let pureval = ast_purity_constant(fty.purity);
+            let pureval = ast_fn_style_constant(fty.fn_style);
             let sigilval = 0u;
             let retval = if ty::type_is_bot(fty.sig.output) {0u} else {1u};
             let extra = vec!(self.c_uint(pureval),
@@ -399,10 +399,10 @@ pub fn ast_sigil_constant(sigil: ast::Sigil) -> uint {
     }
 }
 
-pub fn ast_purity_constant(purity: ast::Purity) -> uint {
-    match purity {
+pub fn ast_fn_style_constant(fn_style: ast::FnStyle) -> uint {
+    match fn_style {
         ast::UnsafeFn => 1u,
-        ast::ImpureFn => 2u,
+        ast::NormalFn => 2u,
         ast::ExternFn => 3u
     }
 }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -49,7 +49,7 @@ pub trait TypeFolder {
                        -> ty::BareFnTy {
         ty::BareFnTy { sig: self.fold_sig(&fty.sig),
                        abi: fty.abi,
-                       purity: fty.purity }
+                       fn_style: fty.fn_style }
     }
 
     fn fold_closure_ty(&mut self,
@@ -58,7 +58,7 @@ pub trait TypeFolder {
         ty::ClosureTy {
             region: self.fold_region(fty.region),
             sig: self.fold_sig(&fty.sig),
-            purity: fty.purity,
+            fn_style: fty.fn_style,
             sigil: fty.sigil,
             onceness: fty.onceness,
             bounds: fty.bounds,

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -572,9 +572,8 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                         let path_str = path_to_str(path);
                         tcx.sess.span_err(
                             ast_ty.span,
-                            format!("reference to trait `{}` where a type is expected; \
-                                    try `@{}`, `~{}`, or `&{}`",
-                                    path_str, path_str, path_str, path_str));
+                            format!("reference to trait `{name}` where a type is expected; \
+                                    try `~{name}` or `&{name}`", name=path_str));
                         ty::mk_err()
                     }
                     ast::DefTy(did) | ast::DefStruct(did) => {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -523,7 +523,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                     tcx.sess.span_err(ast_ty.span,
                                       "variadic function must have C calling convention");
                 }
-                ty::mk_bare_fn(tcx, ty_of_bare_fn(this, ast_ty.id, bf.purity,
+                ty::mk_bare_fn(tcx, ty_of_bare_fn(this, ast_ty.id, bf.fn_style,
                                                   bf.abi, bf.decl))
             }
             ast::TyClosure(ref f) => {
@@ -543,7 +543,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                                             rscope,
                                             ast_ty.id,
                                             f.sigil,
-                                            f.purity,
+                                            f.fn_style,
                                             f.onceness,
                                             bounds,
                                             &f.region,
@@ -661,24 +661,24 @@ struct SelfInfo {
 pub fn ty_of_method<AC:AstConv>(
     this: &AC,
     id: ast::NodeId,
-    purity: ast::Purity,
+    fn_style: ast::FnStyle,
     untransformed_self_ty: ty::t,
     explicit_self: ast::ExplicitSelf,
     decl: &ast::FnDecl) -> ty::BareFnTy {
-    ty_of_method_or_bare_fn(this, id, purity, abi::Rust, Some(SelfInfo {
+    ty_of_method_or_bare_fn(this, id, fn_style, abi::Rust, Some(SelfInfo {
         untransformed_self_ty: untransformed_self_ty,
         explicit_self: explicit_self
     }), decl)
 }
 
 pub fn ty_of_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
-                                 purity: ast::Purity, abi: abi::Abi,
+                                 fn_style: ast::FnStyle, abi: abi::Abi,
                                  decl: &ast::FnDecl) -> ty::BareFnTy {
-    ty_of_method_or_bare_fn(this, id, purity, abi, None, decl)
+    ty_of_method_or_bare_fn(this, id, fn_style, abi, None, decl)
 }
 
 fn ty_of_method_or_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
-                                       purity: ast::Purity, abi: abi::Abi,
+                                       fn_style: ast::FnStyle, abi: abi::Abi,
                                        opt_self_info: Option<SelfInfo>,
                                        decl: &ast::FnDecl) -> ty::BareFnTy {
     debug!("ty_of_method_or_bare_fn");
@@ -724,7 +724,7 @@ fn ty_of_method_or_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
     };
 
     return ty::BareFnTy {
-        purity: purity,
+        fn_style: fn_style,
         abi: abi,
         sig: ty::FnSig {
             binder_id: id,
@@ -740,7 +740,7 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope>(
     rscope: &RS,
     id: ast::NodeId,
     sigil: ast::Sigil,
-    purity: ast::Purity,
+    fn_style: ast::FnStyle,
     onceness: ast::Onceness,
     bounds: ty::BuiltinBounds,
     opt_lifetime: &Option<ast::Lifetime>,
@@ -797,7 +797,7 @@ pub fn ty_of_closure<AC:AstConv,RS:RegionScope>(
     };
 
     ty::ClosureTy {
-        purity: purity,
+        fn_style: fn_style,
         sigil: sigil,
         onceness: onceness,
         region: bound_region,

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1163,7 +1163,7 @@ impl<'a> LookupContext<'a> {
         let transformed_self_ty = *fn_sig.inputs.get(0);
         let fty = ty::mk_bare_fn(tcx, ty::BareFnTy {
             sig: fn_sig,
-            purity: bare_fn_ty.purity,
+            fn_style: bare_fn_ty.fn_style,
             abi: bare_fn_ty.abi.clone(),
         });
         debug!("after replacing bound regions, fty={}", self.ty_to_str(fty));

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -200,14 +200,14 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                 ty_method_of_trait_method(
                                     ccx, trait_id, &trait_ty_generics,
                                     &m.id, &m.ident, &m.explicit_self,
-                                    &m.generics, &m.purity, m.decl)
+                                    &m.generics, &m.fn_style, m.decl)
                             }
 
                             &ast::Provided(ref m) => {
                                 ty_method_of_trait_method(
                                     ccx, trait_id, &trait_ty_generics,
                                     &m.id, &m.ident, &m.explicit_self,
-                                    &m.generics, &m.purity, m.decl)
+                                    &m.generics, &m.fn_style, m.decl)
                             }
                         };
 
@@ -376,11 +376,11 @@ pub fn ensure_trait_methods(ccx: &CrateCtxt, trait_id: ast::NodeId) {
                                  m_ident: &ast::Ident,
                                  m_explicit_self: &ast::ExplicitSelf,
                                  m_generics: &ast::Generics,
-                                 m_purity: &ast::Purity,
+                                 m_fn_style: &ast::FnStyle,
                                  m_decl: &ast::FnDecl) -> ty::Method
     {
         let trait_self_ty = ty::mk_self(this.tcx, local_def(trait_id));
-        let fty = astconv::ty_of_method(this, *m_id, *m_purity, trait_self_ty,
+        let fty = astconv::ty_of_method(this, *m_id, *m_fn_style, trait_self_ty,
                                         *m_explicit_self, m_decl);
         let num_trait_type_params = trait_generics.type_param_defs().len();
         let ty_generics = ty_generics_for_fn_or_method(this, m_generics,
@@ -508,7 +508,7 @@ fn convert_methods(ccx: &CrateCtxt,
                     rcvr_generics: &ast::Generics,
                     rcvr_visibility: ast::Visibility) -> ty::Method
     {
-        let fty = astconv::ty_of_method(ccx, m.id, m.purity,
+        let fty = astconv::ty_of_method(ccx, m.id, m.fn_style,
                                         untransformed_rcvr_ty,
                                         m.explicit_self, m.decl);
 
@@ -818,11 +818,11 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
             tcx.tcache.borrow_mut().insert(local_def(it.id), tpt.clone());
             return tpt;
         }
-        ast::ItemFn(decl, purity, abi, ref generics, _) => {
+        ast::ItemFn(decl, fn_style, abi, ref generics, _) => {
             let ty_generics = ty_generics_for_fn_or_method(ccx, generics, 0);
             let tofd = astconv::ty_of_bare_fn(ccx,
                                               it.id,
-                                              purity,
+                                              fn_style,
                                               abi,
                                               decl);
             let tpt = ty_param_bounds_and_ty {
@@ -1029,7 +1029,7 @@ pub fn ty_of_foreign_fn_decl(ccx: &CrateCtxt,
         ccx.tcx,
         ty::BareFnTy {
             abi: abi,
-            purity: ast::UnsafeFn,
+            fn_style: ast::UnsafeFn,
             sig: ty::FnSig {binder_id: def_id.node,
                             inputs: input_tys,
                             output: output_ty,

--- a/src/librustc/middle/typeck/infer/coercion.rs
+++ b/src/librustc/middle/typeck/infer/coercion.rs
@@ -385,7 +385,7 @@ impl<'f> Coerce<'f> {
             debug!("coerce_from_bare_fn(a={}, b={})",
                    a.inf_str(self.get_ref().infcx), b.inf_str(self.get_ref().infcx));
 
-            if fn_ty_a.abi != abi::Rust || fn_ty_a.purity != ast::ImpureFn {
+            if fn_ty_a.abi != abi::Rust || fn_ty_a.fn_style != ast::NormalFn {
                 return self.subtype(a, b);
             }
 

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -64,7 +64,7 @@ use util::ppaux::Repr;
 
 use std::result;
 
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{Onceness, FnStyle};
 use syntax::ast;
 use syntax::owned_slice::OwnedSlice;
 use syntax::abi;
@@ -194,10 +194,10 @@ pub trait Combine {
 
     fn bare_fn_tys(&self, a: &ty::BareFnTy,
                    b: &ty::BareFnTy) -> cres<ty::BareFnTy> {
-        let purity = if_ok!(self.purities(a.purity, b.purity));
+        let fn_style = if_ok!(self.fn_styles(a.fn_style, b.fn_style));
         let abi = if_ok!(self.abi(a.abi, b.abi));
         let sig = if_ok!(self.fn_sigs(&a.sig, &b.sig));
-        Ok(ty::BareFnTy {purity: purity,
+        Ok(ty::BareFnTy {fn_style: fn_style,
                 abi: abi,
                 sig: sig})
     }
@@ -207,11 +207,11 @@ pub trait Combine {
 
         let p = if_ok!(self.sigils(a.sigil, b.sigil));
         let r = if_ok!(self.contraregions(a.region, b.region));
-        let purity = if_ok!(self.purities(a.purity, b.purity));
+        let fn_style = if_ok!(self.fn_styles(a.fn_style, b.fn_style));
         let onceness = if_ok!(self.oncenesses(a.onceness, b.onceness));
         let bounds = if_ok!(self.bounds(a.bounds, b.bounds));
         let sig = if_ok!(self.fn_sigs(&a.sig, &b.sig));
-        Ok(ty::ClosureTy {purity: purity,
+        Ok(ty::ClosureTy {fn_style: fn_style,
                 sigil: p,
                 onceness: onceness,
                 region: r,
@@ -246,7 +246,7 @@ pub trait Combine {
         }
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity>;
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle>;
 
     fn abi(&self, a: abi::Abi, b: abi::Abi) -> cres<abi::Abi> {
         if a == b {

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1102,10 +1102,10 @@ impl<'a> ErrorReportingHelpers for InferCtxt<'a> {
                                 output: ast::P<ast::Ty>,
                                 item: ast::P<ast::Item>,
                                 generics: ast::Generics) {
-        let (fn_decl, purity, ident) = match item.node {
+        let (fn_decl, fn_style, ident) = match item.node {
             // FIXME: handling method
-            ast::ItemFn(ref fn_decl, ref purity, _, _, _) => {
-                (fn_decl, purity, item.ident)
+            ast::ItemFn(ref fn_decl, ref fn_style, _, _, _) => {
+                (fn_decl, fn_style, item.ident)
             },
             _ => fail!("Expect function or method")
 
@@ -1117,7 +1117,7 @@ impl<'a> ErrorReportingHelpers for InferCtxt<'a> {
             variadic: fn_decl.variadic
         };
         let suggested_fn =
-            pprust::fun_to_str(&fd, *purity, ident, None, &generics);
+            pprust::fun_to_str(&fd, *fn_style, ident, None, &generics);
         let msg = format!("consider using an explicit lifetime \
                            parameter as shown: {}", suggested_fn);
         self.tcx.sess.span_note(item.span, msg);

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -22,8 +22,8 @@ use middle::typeck::infer::{cres, InferCtxt};
 use middle::typeck::infer::{TypeTrace, Subtype};
 use middle::typeck::infer::fold_regions_in_sig;
 use syntax::ast::{Many, Once, MutImmutable, MutMutable};
-use syntax::ast::{ExternFn, ImpureFn, UnsafeFn, NodeId};
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{ExternFn, NormalFn, UnsafeFn, NodeId};
+use syntax::ast::{Onceness, FnStyle};
 use collections::HashMap;
 use util::common::{indenter};
 use util::ppaux::mt_to_str;
@@ -81,10 +81,10 @@ impl<'f> Combine for Glb<'f> {
         Lub(*self.get_ref()).tys(a, b)
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity> {
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle> {
         match (a, b) {
           (ExternFn, _) | (_, ExternFn) => Ok(ExternFn),
-          (ImpureFn, _) | (_, ImpureFn) => Ok(ImpureFn),
+          (NormalFn, _) | (_, NormalFn) => Ok(NormalFn),
           (UnsafeFn, UnsafeFn) => Ok(UnsafeFn)
         }
     }

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -23,8 +23,8 @@ use middle::typeck::infer::fold_regions_in_sig;
 use middle::typeck::infer::{TypeTrace, Subtype};
 use collections::HashMap;
 use syntax::ast::{Many, Once, NodeId};
-use syntax::ast::{ExternFn, ImpureFn, UnsafeFn};
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{ExternFn, NormalFn, UnsafeFn};
+use syntax::ast::{Onceness, FnStyle};
 use util::ppaux::mt_to_str;
 
 pub struct Lub<'f>(pub CombineFields<'f>);  // least-upper-bound: common supertype
@@ -75,10 +75,10 @@ impl<'f> Combine for Lub<'f> {
         Glb(*self.get_ref()).tys(a, b)
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity> {
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle> {
         match (a, b) {
           (UnsafeFn, _) | (_, UnsafeFn) => Ok(UnsafeFn),
-          (ImpureFn, _) | (_, ImpureFn) => Ok(ImpureFn),
+          (NormalFn, _) | (_, NormalFn) => Ok(NormalFn),
           (ExternFn, ExternFn) => Ok(ExternFn),
         }
     }

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -25,7 +25,7 @@ use middle::typeck::infer::{TypeTrace, Subtype};
 use util::common::{indenter};
 use util::ppaux::bound_region_to_str;
 
-use syntax::ast::{Onceness, Purity};
+use syntax::ast::{Onceness, FnStyle};
 
 pub struct Sub<'f>(pub CombineFields<'f>);  // "subtype", "subregion" etc
 
@@ -87,9 +87,9 @@ impl<'f> Combine for Sub<'f> {
         }
     }
 
-    fn purities(&self, a: Purity, b: Purity) -> cres<Purity> {
-        self.lub().purities(a, b).compare(b, || {
-            ty::terr_purity_mismatch(expected_found(self, a, b))
+    fn fn_styles(&self, a: FnStyle, b: FnStyle) -> cres<FnStyle> {
+        self.lub().fn_styles(a, b).compare(b, || {
+            ty::terr_fn_style_mismatch(expected_found(self, a, b))
         })
     }
 

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -182,7 +182,7 @@ impl Env {
         let inputs = input_tys.map(|t| {mode: ast::expl(ast::by_copy),
                                         ty: *t});
         ty::mk_fn(self.tcx, FnTyBase {
-            meta: FnMeta {purity: ast::ImpureFn,
+            meta: FnMeta {fn_style: ast::NormalFn,
                           proto: ast::ProtoBare,
                           onceness: ast::Many,
                           region: ty::ReStatic,

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -357,7 +357,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
                 _ => ()
             }
             let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
-                purity: ast::ImpureFn,
+                fn_style: ast::NormalFn,
                 abi: abi::Rust,
                 sig: ty::FnSig {
                     binder_id: main_id,
@@ -403,7 +403,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
             }
 
             let se_ty = ty::mk_bare_fn(tcx, ty::BareFnTy {
-                purity: ast::ImpureFn,
+                fn_style: ast::NormalFn,
                 abi: abi::Rust,
                 sig: ty::FnSig {
                     binder_id: start_id,

--- a/src/librustc/util/fs.rs
+++ b/src/librustc/util/fs.rs
@@ -1,0 +1,103 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::io::fs;
+use std::os;
+
+/// Returns an absolute path in the filesystem that `path` points to. The
+/// returned path does not contain any symlinks in its hierarchy.
+pub fn realpath(original: &Path) -> io::IoResult<Path> {
+    static MAX_LINKS_FOLLOWED: uint = 256;
+    let original = os::make_absolute(original);
+
+    // Right now lstat on windows doesn't work quite well
+    if cfg!(windows) {
+        return Ok(original)
+    }
+
+    let result = original.root_path();
+    let mut result = result.expect("make_absolute has no root_path");
+    let mut followed = 0;
+
+    for part in original.components() {
+        result.push(part);
+
+        loop {
+            if followed == MAX_LINKS_FOLLOWED {
+                return Err(io::standard_error(io::InvalidInput))
+            }
+
+            match fs::lstat(&result) {
+                Err(..) => break,
+                Ok(ref stat) if stat.kind != io::TypeSymlink => break,
+                Ok(..) => {
+                    followed += 1;
+                    let path = try!(fs::readlink(&result));
+                    result.pop();
+                    result.push(path);
+                }
+            }
+        }
+    }
+
+    return Ok(result);
+}
+
+#[cfg(not(windows), test)]
+mod test {
+    use std::io;
+    use std::io::fs::{File, symlink, mkdir, mkdir_recursive};
+    use super::realpath;
+    use std::io::TempDir;
+
+    #[test]
+    fn realpath_works() {
+        let tmpdir = TempDir::new("rustc-fs").unwrap();
+        let tmpdir = realpath(tmpdir.path()).unwrap();
+        let file = tmpdir.join("test");
+        let dir = tmpdir.join("test2");
+        let link = dir.join("link");
+        let linkdir = tmpdir.join("test3");
+
+        File::create(&file).unwrap();
+        mkdir(&dir, io::UserRWX).unwrap();
+        symlink(&file, &link).unwrap();
+        symlink(&dir, &linkdir).unwrap();
+
+        assert!(realpath(&tmpdir).unwrap() == tmpdir);
+        assert!(realpath(&file).unwrap() == file);
+        assert!(realpath(&link).unwrap() == file);
+        assert!(realpath(&linkdir).unwrap() == dir);
+        assert!(realpath(&linkdir.join("link")).unwrap() == file);
+    }
+
+    #[test]
+    fn realpath_works_tricky() {
+        let tmpdir = TempDir::new("rustc-fs").unwrap();
+        let tmpdir = realpath(tmpdir.path()).unwrap();
+
+        let a = tmpdir.join("a");
+        let b = a.join("b");
+        let c = b.join("c");
+        let d = a.join("d");
+        let e = d.join("e");
+        let f = a.join("f");
+
+        mkdir_recursive(&b, io::UserRWX).unwrap();
+        mkdir_recursive(&d, io::UserRWX).unwrap();
+        File::create(&f).unwrap();
+        symlink(&Path::new("../d/e"), &c).unwrap();
+        symlink(&Path::new("../f"), &e).unwrap();
+
+        assert!(realpath(&c).unwrap() == f);
+        assert!(realpath(&e).unwrap() == f);
+    }
+}

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -252,7 +252,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
         ty_to_str(cx, input)
     }
     fn bare_fn_to_str(cx: &ctxt,
-                      purity: ast::Purity,
+                      fn_style: ast::FnStyle,
                       abi: abi::Abi,
                       ident: Option<ast::Ident>,
                       sig: &ty::FnSig)
@@ -263,10 +263,10 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
             format!("extern {} ", abi.to_str())
         };
 
-        match purity {
-            ast::ImpureFn => {}
+        match fn_style {
+            ast::NormalFn => {}
             _ => {
-                s.push_str(purity.to_str());
+                s.push_str(fn_style.to_str());
                 s.push_char(' ');
             }
         };
@@ -305,10 +305,10 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
             }
         }
 
-        match cty.purity {
-            ast::ImpureFn => {}
+        match cty.fn_style {
+            ast::NormalFn => {}
             _ => {
-                s.push_str(cty.purity.to_str());
+                s.push_str(cty.fn_style.to_str());
                 s.push_char(' ');
             }
         };
@@ -405,7 +405,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
           closure_to_str(cx, *f)
       }
       ty_bare_fn(ref f) => {
-          bare_fn_to_str(cx, f.purity, f.abi, None, &f.sig)
+          bare_fn_to_str(cx, f.fn_style, f.abi, None, &f.sig)
       }
       ty_infer(infer_ty) => infer_ty.to_str(),
       ty_err => ~"[type error]",
@@ -812,8 +812,8 @@ impl Repr for ast::Visibility {
 
 impl Repr for ty::BareFnTy {
     fn repr(&self, tcx: &ctxt) -> ~str {
-        format!("BareFnTy \\{purity: {:?}, abi: {}, sig: {}\\}",
-             self.purity,
+        format!("BareFnTy \\{fn_style: {:?}, abi: {}, sig: {}\\}",
+             self.fn_style,
              self.abi.to_str(),
              self.sig.repr(tcx))
     }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -356,7 +356,7 @@ impl Clean<Generics> for ast::Generics {
 pub struct Method {
     pub generics: Generics,
     pub self_: SelfTy,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub decl: FnDecl,
 }
 
@@ -383,7 +383,7 @@ impl Clean<Item> for ast::Method {
             inner: MethodItem(Method {
                 generics: self.generics.clean(),
                 self_: self.explicit_self.clean(),
-                purity: self.purity.clone(),
+                fn_style: self.fn_style.clone(),
                 decl: decl,
             }),
         }
@@ -392,7 +392,7 @@ impl Clean<Item> for ast::Method {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct TyMethod {
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub decl: FnDecl,
     pub generics: Generics,
     pub self_: SelfTy,
@@ -419,7 +419,7 @@ impl Clean<Item> for ast::TypeMethod {
             id: self.id,
             visibility: None,
             inner: TyMethodItem(TyMethod {
-                purity: self.purity.clone(),
+                fn_style: self.fn_style.clone(),
                 decl: decl,
                 self_: self.explicit_self.clean(),
                 generics: self.generics.clean(),
@@ -451,7 +451,7 @@ impl Clean<SelfTy> for ast::ExplicitSelf {
 pub struct Function {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
 }
 
 impl Clean<Item> for doctree::Function {
@@ -465,7 +465,7 @@ impl Clean<Item> for doctree::Function {
             inner: FunctionItem(Function {
                 decl: self.decl.clean(),
                 generics: self.generics.clean(),
-                purity: self.purity,
+                fn_style: self.fn_style,
             }),
         }
     }
@@ -478,7 +478,7 @@ pub struct ClosureDecl {
     pub lifetimes: Vec<Lifetime>,
     pub decl: FnDecl,
     pub onceness: ast::Onceness,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub bounds: Vec<TyParamBound>,
 }
 
@@ -490,7 +490,7 @@ impl Clean<ClosureDecl> for ast::ClosureTy {
             lifetimes: self.lifetimes.clean().move_iter().collect(),
             decl: self.decl.clean(),
             onceness: self.onceness,
-            purity: self.purity,
+            fn_style: self.fn_style,
             bounds: match self.bounds {
                 Some(ref x) => x.clean().move_iter().collect(),
                 None        => Vec::new()
@@ -960,7 +960,7 @@ impl Clean<Item> for doctree::Typedef {
 
 #[deriving(Clone, Encodable, Decodable)]
 pub struct BareFunctionDecl {
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub generics: Generics,
     pub decl: FnDecl,
     pub abi: ~str,
@@ -969,7 +969,7 @@ pub struct BareFunctionDecl {
 impl Clean<BareFunctionDecl> for ast::BareFnTy {
     fn clean(&self) -> BareFunctionDecl {
         BareFunctionDecl {
-            purity: self.purity,
+            fn_style: self.fn_style,
             generics: Generics {
                 lifetimes: self.lifetimes.clean().move_iter().collect(),
                 type_params: Vec::new(),
@@ -1164,7 +1164,7 @@ impl Clean<Item> for ast::ForeignItem {
                 ForeignFunctionItem(Function {
                     decl: decl.clean(),
                     generics: generics.clean(),
-                    purity: ast::ExternFn,
+                    fn_style: ast::ExternFn,
                 })
             }
             ast::ForeignItemStatic(ref ty, mutbl) => {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -113,7 +113,7 @@ pub struct Function {
     pub id: NodeId,
     pub name: Ident,
     pub vis: ast::Visibility,
-    pub purity: ast::Purity,
+    pub fn_style: ast::FnStyle,
     pub where: Span,
     pub generics: ast::Generics,
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -29,9 +29,9 @@ use html::render::{cache_key, current_location_key};
 /// Helper to render an optional visibility with a space after it (if the
 /// visibility is preset)
 pub struct VisSpace(pub Option<ast::Visibility>);
-/// Similarly to VisSpace, this structure is used to render a purity with a
+/// Similarly to VisSpace, this structure is used to render a function style with a
 /// space after it.
-pub struct PuritySpace(pub ast::Purity);
+pub struct FnStyleSpace(pub ast::FnStyle);
 /// Wrapper struct for properly emitting a method declaration.
 pub struct Method<'a>(pub &'a clean::SelfTy, pub &'a clean::FnDecl);
 
@@ -41,9 +41,9 @@ impl VisSpace {
     }
 }
 
-impl PuritySpace {
-    pub fn get(&self) -> ast::Purity {
-        let PuritySpace(v) = *self; v
+impl FnStyleSpace {
+    pub fn get(&self) -> ast::FnStyle {
+        let FnStyleSpace(v) = *self; v
     }
 }
 
@@ -343,7 +343,7 @@ impl fmt::Show for clean::Type {
                 };
 
                 write!(f.buf, "{}{}{arrow, select, yes{ -&gt; {ret}} other{}}",
-                       PuritySpace(decl.purity),
+                       FnStyleSpace(decl.fn_style),
                        match decl.sigil {
                            ast::OwnedSigil => format!("proc({})", decl.decl.inputs),
                            ast::BorrowedSigil => format!("{}|{}|", region, decl.decl.inputs),
@@ -355,7 +355,7 @@ impl fmt::Show for clean::Type {
             }
             clean::BareFunction(ref decl) => {
                 write!(f.buf, "{}{}fn{}{}",
-                       PuritySpace(decl.purity),
+                       FnStyleSpace(decl.fn_style),
                        match decl.abi {
                            ref x if "" == *x => ~"",
                            ref x if "\"Rust\"" == *x => ~"",
@@ -472,12 +472,12 @@ impl fmt::Show for VisSpace {
     }
 }
 
-impl fmt::Show for PuritySpace {
+impl fmt::Show for FnStyleSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.get() {
             ast::UnsafeFn => write!(f.buf, "unsafe "),
             ast::ExternFn => write!(f.buf, "extern "),
-            ast::ImpureFn => Ok(())
+            ast::NormalFn => Ok(())
         }
     }
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -133,7 +133,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
             slice::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().filter(|l| stripped_filtered_line(*l).is_none());
-                let text = lines.collect::<~[&str]>().connect("\n");
+                let text = lines.collect::<Vec<&str>>().connect("\n");
 
                 let buf = buf {
                     data: text.as_bytes().as_ptr(),
@@ -186,7 +186,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
                 Some(s) => s.to_lower().into_str(),
                 None => s.to_owned()
             }
-        }).collect::<~[~str]>().connect("-");
+        }).collect::<Vec<~str>>().connect("-");
 
         let opaque = unsafe {&mut *(opaque as *mut my_opaque)};
 
@@ -285,7 +285,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                 let tests = &mut *(opaque as *mut ::test::Collector);
                 let text = str::from_utf8(text).unwrap();
                 let mut lines = text.lines().map(|l| stripped_filtered_line(l).unwrap_or(l));
-                let text = lines.collect::<~[&str]>().connect("\n");
+                let text = lines.collect::<Vec<&str>>().connect("\n");
                 tests.add_test(text, should_fail, no_run, ignore);
             })
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1205,8 +1205,8 @@ fn item_trait(w: &mut Writer, it: &clean::Item,
                   it.name.get_ref().as_slice(),
                   t.generics,
                   parents));
-    let required = t.methods.iter().filter(|m| m.is_req()).collect::<~[&clean::TraitMethod]>();
-    let provided = t.methods.iter().filter(|m| !m.is_req()).collect::<~[&clean::TraitMethod]>();
+    let required = t.methods.iter().filter(|m| m.is_req()).collect::<Vec<&clean::TraitMethod>>();
+    let provided = t.methods.iter().filter(|m| !m.is_req()).collect::<Vec<&clean::TraitMethod>>();
 
     if t.methods.len() == 0 {
         try!(write!(w, "\\{ \\}"));
@@ -1502,11 +1502,11 @@ fn render_methods(w: &mut Writer, it: &clean::Item) -> fmt::Result {
                 let mut non_trait = v.iter().filter(|p| {
                     p.ref0().trait_.is_none()
                 });
-                let non_trait = non_trait.collect::<~[&(clean::Impl, Option<~str>)]>();
+                let non_trait = non_trait.collect::<Vec<&(clean::Impl, Option<~str>)>>();
                 let mut traits = v.iter().filter(|p| {
                     p.ref0().trait_.is_some()
                 });
-                let traits = traits.collect::<~[&(clean::Impl, Option<~str>)]>();
+                let traits = traits.collect::<Vec<&(clean::Impl, Option<~str>)>>();
 
                 if non_trait.len() > 0 {
                     try!(write!(w, "<h2 id='methods'>Methods</h2>"));

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -51,7 +51,7 @@ use rustc::util::nodemap::NodeSet;
 use clean;
 use doctree;
 use fold::DocFolder;
-use html::format::{VisSpace, Method, PuritySpace};
+use html::format::{VisSpace, Method, FnStyleSpace};
 use html::layout;
 use html::markdown;
 use html::markdown::Markdown;
@@ -1191,10 +1191,10 @@ fn item_module(w: &mut Writer, cx: &Context,
 
 fn item_function(w: &mut Writer, it: &clean::Item,
                  f: &clean::Function) -> fmt::Result {
-    try!(write!(w, "<pre class='rust fn'>{vis}{purity}fn \
+    try!(write!(w, "<pre class='rust fn'>{vis}{fn_style}fn \
                     {name}{generics}{decl}</pre>",
            vis = VisSpace(it.visibility),
-           purity = PuritySpace(f.purity),
+           fn_style = FnStyleSpace(f.fn_style),
            name = it.name.get_ref().as_slice(),
            generics = f.generics,
            decl = f.decl));
@@ -1305,12 +1305,12 @@ fn item_trait(w: &mut Writer, it: &clean::Item,
 }
 
 fn render_method(w: &mut Writer, meth: &clean::Item) -> fmt::Result {
-    fn fun(w: &mut Writer, it: &clean::Item, purity: ast::Purity,
+    fn fun(w: &mut Writer, it: &clean::Item, fn_style: ast::FnStyle,
            g: &clean::Generics, selfty: &clean::SelfTy,
            d: &clean::FnDecl) -> fmt::Result {
         write!(w, "{}fn <a href='\\#{ty}.{name}' class='fnname'>{name}</a>\
                    {generics}{decl}",
-               match purity {
+               match fn_style {
                    ast::UnsafeFn => "unsafe ",
                    _ => "",
                },
@@ -1321,10 +1321,10 @@ fn render_method(w: &mut Writer, meth: &clean::Item) -> fmt::Result {
     }
     match meth.inner {
         clean::TyMethodItem(ref m) => {
-            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl)
+            fun(w, meth, m.fn_style, &m.generics, &m.self_, &m.decl)
         }
         clean::MethodItem(ref m) => {
-            fun(w, meth, m.purity, &m.generics, &m.self_, &m.decl)
+            fun(w, meth, m.fn_style, &m.generics, &m.self_, &m.decl)
         }
         _ => unreachable!()
     }

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -161,12 +161,12 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches) -> int 
 }
 
 /// Run any tests/code examples in the markdown file `input`.
-pub fn test(input: &str, libs: HashSet<Path>, mut test_args: ~[~str]) -> int {
+pub fn test(input: &str, libs: HashSet<Path>, mut test_args: Vec<~str>) -> int {
     let input_str = load_or_return!(input, 1, 2);
 
     let mut collector = Collector::new(input.to_owned(), libs, true, true);
     find_testable_code(input_str, &mut collector);
     test_args.unshift(~"rustdoctest");
-    testing::test_main(test_args, collector.tests);
+    testing::test_main(test_args.as_slice(), collector.tests);
     0
 }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -95,7 +95,7 @@ impl<'a> RustdocVisitor<'a> {
     }
 
     pub fn visit_fn(&mut self, item: &ast::Item, fd: &ast::FnDecl,
-                    purity: &ast::Purity, _abi: &abi::Abi,
+                    fn_style: &ast::FnStyle, _abi: &abi::Abi,
                     gen: &ast::Generics) -> Function {
         debug!("Visiting fn");
         Function {
@@ -106,7 +106,7 @@ impl<'a> RustdocVisitor<'a> {
             name: item.ident,
             where: item.span,
             generics: gen.clone(),
-            purity: *purity,
+            fn_style: *fn_style,
         }
     }
 

--- a/src/librustuv/access.rs
+++ b/src/librustuv/access.rs
@@ -31,7 +31,7 @@ pub struct Guard<'a> {
 }
 
 struct Inner {
-    queue: ~[BlockedTask],
+    queue: Vec<BlockedTask>,
     held: bool,
 }
 
@@ -39,7 +39,7 @@ impl Access {
     pub fn new() -> Access {
         Access {
             inner: UnsafeArc::new(Inner {
-                queue: ~[],
+                queue: vec![],
                 held: false,
             })
         }

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -152,13 +152,13 @@ impl FsRequest {
     }
 
     pub fn readdir(loop_: &Loop, path: &CString, flags: c_int)
-        -> Result<~[Path], UvError>
+        -> Result<Vec<Path>, UvError>
     {
         execute(|req, cb| unsafe {
             uvll::uv_fs_readdir(loop_.handle,
                                 req, path.with_ref(|p| p), flags, cb)
         }).map(|req| unsafe {
-            let mut paths = ~[];
+            let mut paths = vec!();
             let path = CString::new(path.with_ref(|p| p), false);
             let parent = Path::new(path);
             let _ = c_str::from_c_multistring(req.get_ptr() as *libc::c_char,

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -234,7 +234,7 @@ impl IoFactory for UvIoFactory {
         r.map_err(uv_error_to_io_error)
     }
     fn fs_readdir(&mut self, path: &CString, flags: c_int)
-        -> Result<~[Path], IoError>
+        -> Result<Vec<Path>, IoError>
     {
         let r = FsRequest::readdir(&self.loop_, path, flags);
         r.map_err(uv_error_to_io_error)

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -636,7 +636,7 @@ pub mod writer {
     // ebml writing
     pub struct Encoder<'a, W> {
         pub writer: &'a mut W,
-        size_positions: ~[uint],
+        size_positions: Vec<uint>,
     }
 
     fn write_sized_vuint<W: Writer>(w: &mut W, n: uint, size: uint) -> EncodeResult {
@@ -668,10 +668,9 @@ pub mod writer {
     }
 
     pub fn Encoder<'a, W: Writer + Seek>(w: &'a mut W) -> Encoder<'a, W> {
-        let size_positions: ~[uint] = ~[];
         Encoder {
             writer: w,
-            size_positions: size_positions,
+            size_positions: vec!(),
         }
     }
 

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -21,7 +21,7 @@ use option::{Option, Some, None};
 use result::{Ok, Err};
 use io;
 use io::{IoError, IoResult, Reader};
-use slice::{OwnedVector, ImmutableVector};
+use slice::{OwnedVector, ImmutableVector, Vector};
 use ptr::RawPtr;
 
 /// An iterator that reads a single byte on each iteration,
@@ -88,7 +88,7 @@ pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
       8u => f(unsafe { transmute::<i64, [u8, ..8]>(to_le64(n as i64)) }),
       _ => {
 
-        let mut bytes: ~[u8] = ~[];
+        let mut bytes = vec!();
         let mut i = size;
         let mut n = n;
         while i > 0u {
@@ -96,7 +96,7 @@ pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
             n >>= 8_u64;
             i -= 1u;
         }
-        f(bytes)
+        f(bytes.as_slice())
       }
     }
 }
@@ -127,14 +127,14 @@ pub fn u64_to_be_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
       4u => f(unsafe { transmute::<i32, [u8, ..4]>(to_be32(n as i32)) }),
       8u => f(unsafe { transmute::<i64, [u8, ..8]>(to_be64(n as i64)) }),
       _ => {
-        let mut bytes: ~[u8] = ~[];
+        let mut bytes = vec!();
         let mut i = size;
         while i > 0u {
             let shift = ((i - 1u) * 8u) as u64;
             bytes.push((n >> shift) as u8);
             i -= 1u;
         }
-        f(bytes)
+        f(bytes.as_slice())
       }
     }
 }

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -483,7 +483,7 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 /// Will return an error if the provided `from` doesn't exist, the process lacks
 /// permissions to view the contents or if the `path` points at a non-directory
 /// file
-pub fn readdir(path: &Path) -> IoResult<~[Path]> {
+pub fn readdir(path: &Path) -> IoResult<Vec<Path>> {
     LocalIo::maybe_raise(|io| {
         io.fs_readdir(&path.to_c_str(), 0)
     })
@@ -498,7 +498,7 @@ pub fn walk_dir(path: &Path) -> IoResult<Directories> {
 
 /// An iterator which walks over a directory
 pub struct Directories {
-    stack: ~[Path],
+    stack: Vec<Path>,
 }
 
 impl Iterator<Path> for Directories {

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -29,6 +29,7 @@ use option::{Some, None};
 use result::{Ok, Err};
 use rt::rtio::{IoFactory, LocalIo, RtioSignal};
 use slice::{ImmutableVector, OwnedVector};
+use vec::Vec;
 
 /// Signals that can be sent and received
 #[repr(int)]
@@ -80,7 +81,7 @@ pub enum Signum {
 /// ```
 pub struct Listener {
     /// A map from signums to handles to keep the handles in memory
-    handles: ~[(Signum, ~RtioSignal:Send)],
+    handles: Vec<(Signum, ~RtioSignal:Send)>,
     /// This is where all the handles send signums, which are received by
     /// the clients from the receiver.
     tx: Sender<Signum>,
@@ -99,7 +100,7 @@ impl Listener {
         Listener {
             tx: tx,
             rx: rx,
-            handles: ~[],
+            handles: vec!(),
         }
     }
 

--- a/src/libstd/io/test.rs
+++ b/src/libstd/io/test.rs
@@ -39,7 +39,6 @@ macro_rules! iotest (
             use io::process::*;
             use unstable::running_on_valgrind;
             use str;
-            use util;
 
             fn f() $b
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -117,13 +117,15 @@ macro_rules! assert(
 #[macro_export]
 macro_rules! assert_eq(
     ($given:expr , $expected:expr) => ({
-        let given_val = &($given);
-        let expected_val = &($expected);
-        // check both directions of equality....
-        if !((*given_val == *expected_val) &&
-             (*expected_val == *given_val)) {
-            fail!("assertion failed: `(left == right) && (right == left)` \
-                   (left: `{}`, right: `{}`)", *given_val, *expected_val)
+        match (&($given), &($expected)) {
+            (given_val, expected_val) => {
+                // check both directions of equality....
+                if !((*given_val == *expected_val) &&
+                     (*expected_val == *given_val)) {
+                    fail!("assertion failed: `(left == right) && (right == left)` \
+                           (left: `{}`, right: `{}`)", *given_val, *expected_val)
+                }
+            }
         }
     })
 )

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -20,8 +20,9 @@ use option::{Some, None};
 use ptr::RawPtr;
 use unstable::sync::Exclusive;
 use slice::OwnedVector;
+use vec::Vec;
 
-type Queue = Exclusive<~[proc():Send]>;
+type Queue = Exclusive<Vec<proc():Send>>;
 
 // You'll note that these variables are *not* atomic, and this is done on
 // purpose. This module is designed to have init() called *once* in a
@@ -35,7 +36,7 @@ pub fn init() {
     unsafe {
         rtassert!(!RUNNING);
         rtassert!(QUEUE.is_null());
-        let state: ~Queue = ~Exclusive::new(~[]);
+        let state: ~Queue = ~Exclusive::new(vec!());
         QUEUE = cast::transmute(state);
     }
 }
@@ -61,7 +62,7 @@ pub fn run() {
         QUEUE = 0 as *mut Queue;
         let mut vec = None;
         state.with(|arr| {
-            vec = Some(mem::replace(arr, ~[]));
+            vec = Some(mem::replace(arr, vec!()));
         });
         vec.take_unwrap()
     };

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -20,6 +20,7 @@ use path::Path;
 use result::Err;
 use rt::local::Local;
 use rt::task::Task;
+use vec::Vec;
 
 use ai = io::net::addrinfo;
 use io;
@@ -168,7 +169,7 @@ pub trait IoFactory {
     fn fs_rmdir(&mut self, path: &CString) -> IoResult<()>;
     fn fs_rename(&mut self, path: &CString, to: &CString) -> IoResult<()>;
     fn fs_readdir(&mut self, path: &CString, flags: c_int) ->
-        IoResult<~[Path]>;
+        IoResult<Vec<Path>>;
     fn fs_lstat(&mut self, path: &CString) -> IoResult<FileStat>;
     fn fs_chown(&mut self, path: &CString, uid: int, gid: int) ->
         IoResult<()>;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -210,8 +210,8 @@ pub enum MethodProvenance {
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub enum Def {
-    DefFn(DefId, Purity),
-    DefStaticMethod(/* method */ DefId, MethodProvenance, Purity),
+    DefFn(DefId, FnStyle),
+    DefStaticMethod(/* method */ DefId, MethodProvenance, FnStyle),
     DefSelfTy(/* trait id */ NodeId),
     DefMod(DefId),
     DefForeignMod(DefId),
@@ -696,7 +696,7 @@ pub struct TypeField {
 pub struct TypeMethod {
     pub ident: Ident,
     pub attrs: Vec<Attribute>,
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub decl: P<FnDecl>,
     pub generics: Generics,
     pub explicit_self: ExplicitSelf,
@@ -794,7 +794,7 @@ pub struct ClosureTy {
     pub sigil: Sigil,
     pub region: Option<Lifetime>,
     pub lifetimes: Vec<Lifetime>,
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub onceness: Onceness,
     pub decl: P<FnDecl>,
     // Optional optvec distinguishes between "fn()" and "fn:()" so we can
@@ -806,7 +806,7 @@ pub struct ClosureTy {
 
 #[deriving(Eq, TotalEq, Encodable, Decodable, Hash)]
 pub struct BareFnTy {
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub abi: Abi,
     pub lifetimes: Vec<Lifetime>,
     pub decl: P<FnDecl>
@@ -886,16 +886,16 @@ pub struct FnDecl {
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
-pub enum Purity {
+pub enum FnStyle {
     UnsafeFn, // declared with "unsafe fn"
-    ImpureFn, // declared with "fn"
+    NormalFn, // declared with "fn"
     ExternFn, // declared with "extern fn"
 }
 
-impl fmt::Show for Purity {
+impl fmt::Show for FnStyle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            ImpureFn => "impure".fmt(f),
+            NormalFn => "normal".fmt(f),
             UnsafeFn => "unsafe".fmt(f),
             ExternFn => "extern".fmt(f),
         }
@@ -925,7 +925,7 @@ pub struct Method {
     pub attrs: Vec<Attribute>,
     pub generics: Generics,
     pub explicit_self: ExplicitSelf,
-    pub purity: Purity,
+    pub fn_style: FnStyle,
     pub decl: P<FnDecl>,
     pub body: P<Block>,
     pub id: NodeId,
@@ -1119,7 +1119,7 @@ pub struct Item {
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash)]
 pub enum Item_ {
     ItemStatic(P<Ty>, Mutability, @Expr),
-    ItemFn(P<FnDecl>, Purity, Abi, Generics, P<Block>),
+    ItemFn(P<FnDecl>, FnStyle, Abi, Generics, P<Block>),
     ItemMod(Mod),
     ItemForeignMod(ForeignMod),
     ItemTy(P<Ty>, Generics),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -264,7 +264,7 @@ pub fn trait_method_to_ty_method(method: &TraitMethod) -> TypeMethod {
             TypeMethod {
                 ident: m.ident,
                 attrs: m.attrs.clone(),
-                purity: m.purity,
+                fn_style: m.fn_style,
                 decl: m.decl,
                 generics: m.generics.clone(),
                 explicit_self: m.explicit_self,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -825,7 +825,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                   name,
                   Vec::new(),
                   ast::ItemFn(self.fn_decl(inputs, output),
-                              ast::ImpureFn,
+                              ast::NormalFn,
                               abi::Rust,
                               generics,
                               body))

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -619,7 +619,7 @@ impl<'a> MethodDef<'a> {
             attrs: attrs,
             generics: fn_generics,
             explicit_self: explicit_self,
-            purity: ast::ImpureFn,
+            fn_style: ast::NormalFn,
             decl: fn_decl,
             body: body_block,
             id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -242,9 +242,9 @@ impl<'a, 'b> Context<'a, 'b> {
                             }
                         }
                     }
-                    self.verify_pieces(arm.result);
+                    self.verify_pieces(arm.result.as_slice());
                 }
-                self.verify_pieces(*default);
+                self.verify_pieces(default.as_slice());
             }
             parse::Select(ref arms, ref default) => {
                 self.verify_arg_type(pos, String);
@@ -258,9 +258,9 @@ impl<'a, 'b> Context<'a, 'b> {
                         self.ecx.span_err(self.fmtsp,
                                           "empty selector in `select`");
                     }
-                    self.verify_pieces(arm.result);
+                    self.verify_pieces(arm.result.as_slice());
                 }
-                self.verify_pieces(*default);
+                self.verify_pieces(default.as_slice());
             }
         }
         self.nest_level -= 1;

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -158,7 +158,7 @@ pub trait Folder {
             TyClosure(ref f) => {
                 TyClosure(@ClosureTy {
                     sigil: f.sigil,
-                    purity: f.purity,
+                    fn_style: f.fn_style,
                     region: fold_opt_lifetime(&f.region, self),
                     onceness: f.onceness,
                     bounds: fold_opt_bounds(&f.bounds, self),
@@ -169,7 +169,7 @@ pub trait Folder {
             TyBareFn(ref f) => {
                 TyBareFn(@BareFnTy {
                     lifetimes: f.lifetimes.iter().map(|l| fold_lifetime(l, self)).collect(),
-                    purity: f.purity,
+                    fn_style: f.fn_style,
                     abi: f.abi,
                     decl: self.fold_fn_decl(f.decl)
                 })
@@ -549,10 +549,10 @@ pub fn noop_fold_item_underscore<T: Folder>(i: &Item_, folder: &mut T) -> Item_ 
         ItemStatic(t, m, e) => {
             ItemStatic(folder.fold_ty(t), m, folder.fold_expr(e))
         }
-        ItemFn(decl, purity, abi, ref generics, body) => {
+        ItemFn(decl, fn_style, abi, ref generics, body) => {
             ItemFn(
                 folder.fold_fn_decl(decl),
-                purity,
+                fn_style,
                 abi,
                 fold_generics(generics, folder),
                 folder.fold_block(body)
@@ -603,7 +603,7 @@ pub fn noop_fold_type_method<T: Folder>(m: &TypeMethod, fld: &mut T) -> TypeMeth
         id: fld.new_id(m.id), // Needs to be first, for ast_map.
         ident: fld.fold_ident(m.ident),
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, fld)).collect(),
-        purity: m.purity,
+        fn_style: m.fn_style,
         decl: fld.fold_fn_decl(m.decl),
         generics: fold_generics(&m.generics, fld),
         explicit_self: fld.fold_explicit_self(&m.explicit_self),
@@ -680,7 +680,7 @@ pub fn noop_fold_method<T: Folder>(m: &Method, folder: &mut T) -> @Method {
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, folder)).collect(),
         generics: fold_generics(&m.generics, folder),
         explicit_self: folder.fold_explicit_self(&m.explicit_self),
-        purity: m.purity,
+        fn_style: m.fn_style,
         decl: folder.fold_fn_decl(m.decl),
         body: folder.fold_block(m.body),
         span: folder.new_span(m.span),

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -657,7 +657,7 @@ mod test {
                                 cf: ast::Return,
                                 variadic: false
                             }),
-                                    ast::ImpureFn,
+                                    ast::NormalFn,
                                     abi::Rust,
                                     ast::Generics{ // no idea on either of these:
                                         lifetimes: Vec::new(),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -29,7 +29,7 @@ use owned_slice::OwnedSlice;
 
 pub enum FnKind<'a> {
     // fn foo() or extern "Abi" fn foo()
-    FkItemFn(Ident, &'a Generics, Purity, Abi),
+    FkItemFn(Ident, &'a Generics, FnStyle, Abi),
 
     // fn foo(&self)
     FkMethod(Ident, &'a Generics, &'a Method),
@@ -207,8 +207,8 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
             visitor.visit_ty(typ, env.clone());
             visitor.visit_expr(expr, env);
         }
-        ItemFn(declaration, purity, abi, ref generics, body) => {
-            visitor.visit_fn(&FkItemFn(item.ident, generics, purity, abi),
+        ItemFn(declaration, fn_style, abi, ref generics, body) => {
+            visitor.visit_fn(&FkItemFn(item.ident, generics, fn_style, abi),
                              declaration,
                              body,
                              item.span,

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -170,14 +170,14 @@ impl<'a> Stats for &'a [f64] {
     // FIXME #11059 handle NaN, inf and overflow
     #[allow(deprecated_owned_vector)]
     fn sum(self) -> f64 {
-        let mut partials : ~[f64] = ~[];
+        let mut partials = vec![];
 
         for &mut x in self.iter() {
             let mut j = 0;
             // This inner loop applies `hi`/`lo` summation to each
             // partial so that the list of partial sums remains exact.
             for i in range(0, partials.len()) {
-                let mut y = partials[i];
+                let mut y = *partials.get(i);
                 if num::abs(x) < num::abs(y) {
                     mem::swap(&mut x, &mut y);
                 }
@@ -186,7 +186,7 @@ impl<'a> Stats for &'a [f64] {
                 let hi = x + y;
                 let lo = y - (hi - x);
                 if lo != 0f64 {
-                    partials[j] = lo;
+                    *partials.get_mut(j) = lo;
                     j += 1;
                 }
                 x = hi;
@@ -194,7 +194,7 @@ impl<'a> Stats for &'a [f64] {
             if j >= partials.len() {
                 partials.push(x);
             } else {
-                partials[j] = x;
+                *partials.get_mut(j) = x;
                 partials.truncate(j+1);
             }
         }

--- a/src/libworkcache/lib.rs
+++ b/src/libworkcache/lib.rs
@@ -17,6 +17,7 @@
        html_root_url = "http://static.rust-lang.org/doc/master")]
 #![feature(phase)]
 #![allow(visible_private_types)]
+#![deny(deprecated_owned_vector)]
 
 #[phase(syntax, link)] extern crate log;
 extern crate serialize;
@@ -319,8 +320,8 @@ impl Exec {
     }
 
     // returns pairs of (kind, name)
-    pub fn lookup_discovered_inputs(&self) -> ~[(~str, ~str)] {
-        let mut rs = ~[];
+    pub fn lookup_discovered_inputs(&self) -> Vec<(~str, ~str)> {
+        let mut rs = vec![];
         let WorkMap(ref discovered_inputs) = self.discovered_inputs;
         for (k, v) in discovered_inputs.iter() {
             let KindMap(ref vmap) = *v;
@@ -341,8 +342,8 @@ impl<'a> Prep<'a> {
         }
     }
 
-    pub fn lookup_declared_inputs(&self) -> ~[~str] {
-        let mut rs = ~[];
+    pub fn lookup_declared_inputs(&self) -> Vec<~str> {
+        let mut rs = vec![];
         let WorkMap(ref declared_inputs) = self.declared_inputs;
         for (_, v) in declared_inputs.iter() {
             let KindMap(ref vmap) = *v;

--- a/src/test/auxiliary/issue-12612-1.rs
+++ b/src/test/auxiliary/issue-12612-1.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod bar {
+    pub fn foo() {}
+}

--- a/src/test/auxiliary/issue-12612-2.rs
+++ b/src/test/auxiliary/issue-12612-2.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn baz() {}

--- a/src/test/auxiliary/issue13213aux.rs
+++ b/src/test/auxiliary/issue13213aux.rs
@@ -1,0 +1,27 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+// compile-flags:-g
+
+pub use private::P;
+
+pub struct S {
+    p: P,
+}
+
+mod private {
+    pub struct P {
+        p: i32,
+    }
+    pub static THREE: P = P { p: 3 };
+}
+
+pub static A: S = S { p: private::THREE };

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -76,7 +76,7 @@ fn main() {
                 format!("{}\t trees of depth {}\t check: {}",
                         iterations * 2, depth, chk)
             })
-        }).collect::<~[Future<~str>]>();
+        }).collect::<Vec<Future<~str>>>();
 
     for message in messages.mut_iter() {
         println!("{}", *message.get_ref());

--- a/src/test/compile-fail/issue-12612.rs
+++ b/src/test/compile-fail/issue-12612.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12612-1.rs
+
+extern crate foo = "issue-12612-1";
+
+use foo::bar;
+
+mod test {
+    use bar::foo;
+    //~^ ERROR: unresolved import
+    //~^^ ERROR: failed to resolve import
+}
+
+fn main() {}
+

--- a/src/test/compile-fail/issue-13404.rs
+++ b/src/test/compile-fail/issue-13404.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use a::f;
+use b::f;
+//~^ ERROR: unresolved import
+//~^^ ERROR: failed to resolve import
+
+mod a { pub fn f() {} }
+mod b { }
+
+fn main() {
+    f();
+}

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -11,13 +11,15 @@
 trait A {}
 
 struct Struct {
-    r: A //~ ERROR reference to trait `A` where a type is expected
+    r: A //~ ERROR reference to trait `A` where a type is expected; try `~A` or `&A`
 }
 
-fn new_struct(r: A) -> Struct { //~ ERROR reference to trait `A` where a type is expected
+fn new_struct(r: A) -> Struct {
+    //~^ ERROR reference to trait `A` where a type is expected; try `~A` or `&A`
     Struct { r: r }
 }
 
 trait Curve {}
-enum E {X(Curve)} //~ ERROR reference to trait `Curve` where a type is expected
+enum E {X(Curve)}
+//~^ ERROR reference to trait `Curve` where a type is expected; try `~Curve` or `&Curve`
 fn main() {}

--- a/src/test/compile-fail/issue-7663.rs
+++ b/src/test/compile-fail/issue-7663.rs
@@ -1,0 +1,56 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(globs)]
+#![deny(unused_imports)]
+#![allow(dead_code)]
+
+mod test1 {
+
+    mod foo { pub fn p() -> int { 1 } }
+    mod bar { pub fn p() -> int { 2 } }
+
+    pub mod baz {
+        use test1::foo::*; //~ ERROR: unused import
+        use test1::bar::*;
+
+        pub fn my_main() { assert!(p() == 2); }
+    }
+}
+
+mod test2 {
+
+    mod foo { pub fn p() -> int { 1 } }
+    mod bar { pub fn p() -> int { 2 } }
+
+    pub mod baz {
+        use test2::foo::p; //~ ERROR: unused import
+        use test2::bar::p;
+
+        pub fn my_main() { assert!(p() == 2); }
+    }
+}
+
+mod test3 {
+
+    mod foo { pub fn p() -> int { 1 } }
+    mod bar { pub fn p() -> int { 2 } }
+
+    pub mod baz {
+        use test3::foo::*; //~ ERROR: unused import
+        use test3::bar::p;
+
+        pub fn my_main() { assert!(p() == 2); }
+    }
+}
+
+fn main() {
+}
+

--- a/src/test/compile-fail/regions-trait-2.rs
+++ b/src/test/compile-fail/regions-trait-2.rs
@@ -29,7 +29,7 @@ fn make_gc() -> @get_ctxt  {
     let ctxt = ctxt { v: 22u };
     let hc = has_ctxt { c: &ctxt };
     return @hc as @get_ctxt;
-    //^~ ERROR source contains reference
+    //~^ ERROR source contains reference
 }
 
 fn main() {

--- a/src/test/compile-fail/resolve-priv-shadowing-pub.rs
+++ b/src/test/compile-fail/resolve-priv-shadowing-pub.rs
@@ -1,0 +1,33 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod a {
+    pub fn foobar() -> int { 1 }
+}
+
+mod b {
+    pub fn foobar() -> int { 2 }
+}
+
+mod c {
+    // Technically the second use shadows the first, but in theory it should
+    // only be shadowed for this module. The implementation of resolve currently
+    // doesn't implement this, so this test is ensuring that using "c::foobar"
+    // is *not* getting b::foobar. Today it's an error, but perhaps one day it
+    // can correctly get a::foobar instead.
+    pub use a::foobar;
+    use b::foobar;
+}
+
+fn main() {
+    assert_eq!(c::foobar(), 1);
+    //~^ ERROR: unresolved name `c::foobar`
+}
+

--- a/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
+++ b/src/test/compile-fail/trait-bounds-not-on-bare-trait.rs
@@ -13,7 +13,8 @@ trait Foo {
 
 // This should emit the less confusing error, not the more confusing one.
 
-fn foo(_x: Foo:Send) { //~ERROR reference to trait `Foo` where a type is expected
+fn foo(_x: Foo:Send) {
+    //~^ERROR reference to trait `Foo` where a type is expected; try `~Foo` or `&Foo`
 }
 
 fn main() { }

--- a/src/test/compile-fail/trait-impl-method-mismatch.rs
+++ b/src/test/compile-fail/trait-impl-method-mismatch.rs
@@ -17,7 +17,7 @@ trait Mumbo {
 impl Mumbo for uint {
     // Cannot have a larger effect than the trait:
     unsafe fn jumbo(&self, x: @uint) { *self + *x; }
-    //~^ ERROR expected impure fn but found unsafe fn
+    //~^ ERROR expected normal fn but found unsafe fn
 }
 
 fn main() {}

--- a/src/test/debug-info/issue13213.rs
+++ b/src/test/debug-info/issue13213.rs
@@ -1,0 +1,26 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-android: FIXME(#10381)
+
+// aux-build:issue13213aux.rs
+extern crate issue13213aux;
+
+// compile-flags:-g
+
+// This tests make sure that we get no linker error when using a completely inlined static. Some
+// statics that are marked with AvailableExternallyLinkage in the importing crate, may actually not
+// be available because they have been optimized out from the exporting crate.
+fn main() {
+    let b: issue13213aux::S = issue13213aux::A;
+    zzz();
+}
+
+fn zzz() {()}

--- a/src/test/run-make/pretty-print-to-file/Makefile
+++ b/src/test/run-make/pretty-print-to-file/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -o $(TMPDIR)/input.out --pretty=normal input.rs
+	diff -u $(TMPDIR)/input.out input.pp

--- a/src/test/run-make/pretty-print-to-file/input.pp
+++ b/src/test/run-make/pretty-print-to-file/input.pp
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#[crate_type = "lib"]
+pub fn foo() -> i32 { 45 }

--- a/src/test/run-make/pretty-print-to-file/input.rs
+++ b/src/test/run-make/pretty-print-to-file/input.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type="lib"]
+
+pub fn
+foo() -> i32
+{ 45 }

--- a/src/test/run-pass/issue-11881.rs
+++ b/src/test/run-pass/issue-11881.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate ser = "serialize";
+extern crate serialize;
 
-use serialize = self::ser;
- //necessary for deriving(Encodable)
-use ser::{Encodable, Encoder};
-use ser::json;
-use ser::ebml::writer;
+use serialize::{Encodable, Encoder};
+use serialize::json;
+use serialize::ebml::writer;
 use std::io::MemWriter;
 use std::str::from_utf8_owned;
 

--- a/src/test/run-pass/issue-12612.rs
+++ b/src/test/run-pass/issue-12612.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12612-1.rs
+// aux-build:issue-12612-2.rs
+
+extern crate foo = "issue-12612-1";
+extern crate bar = "issue-12612-2";
+
+use foo::bar;
+
+mod test {
+    use bar::baz;
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-7663.rs
+++ b/src/test/run-pass/issue-7663.rs
@@ -1,0 +1,57 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(globs)]
+#![allow(unused_imports, dead_code)]
+
+mod test1 {
+
+    mod foo { pub fn p() -> int { 1 } }
+    mod bar { pub fn p() -> int { 2 } }
+
+    pub mod baz {
+        use test1::foo::*;
+        use test1::bar::*;
+
+        pub fn my_main() { assert!(p() == 2); }
+    }
+}
+
+mod test2 {
+
+    mod foo { pub fn p() -> int { 1 } }
+    mod bar { pub fn p() -> int { 2 } }
+
+    pub mod baz {
+        use test2::foo::p;
+        use test2::bar::p;
+
+        pub fn my_main() { assert!(p() == 2); }
+    }
+}
+
+mod test3 {
+
+    mod foo { pub fn p() -> int { 1 } }
+    mod bar { pub fn p() -> int { 2 } }
+
+    pub mod baz {
+        use test3::foo::*;
+        use test3::bar::p;
+
+        pub fn my_main() { assert!(p() == 2); }
+    }
+}
+
+fn main() {
+    test1::baz::my_main();
+    test2::baz::my_main();
+    test3::baz::my_main();
+}


### PR DESCRIPTION
Closes #13441 (debuginfo: Fixes and improvements for #12840, #12886, and #13213)
Closes #13433 (Remove references to @Trait from a compiler error message)
Closes #13430 (Fix outdated lint warning about inner attribute)
Closes #13425 (Remove a pile of (mainly) internal `~[]` uses)
Closes #13419 (Stop using transmute_mut in RefCell)
Closes #13417 (Remove an unnecessary file `src/libnative/io/p`.)
Closes #13409 (Closing assorted resolve bugs)
Closes #13406 (Generalized the pretty-print entry points to support `-o <file>`.)
Closes #13403 (test: Add a test for #7663)
Closes #13402 (rustdoc: Prune the paths that do not appear in the index.)
Closes #13396 (rustc: Remove absolute rpaths)
Closes #13371 (Rename ast::Purity and ast::Impure Function. Closes #7287)
Closes #13350 (collections: replace all ~[T] with Vec<T>.)
