### PR TITLE
libc: Deglob reexports. #11870

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -79,73 +79,23 @@
 #[cfg(test)] extern crate test;
 #[cfg(test)] extern crate native;
 
-// Initial glob-exports mean that all the contents of all the modules
-// wind up exported, if you're interested in writing platform-specific code.
-
-pub use types::common::c95::*;
-pub use types::common::c99::*;
-pub use types::common::posix88::*;
-pub use types::common::posix01::*;
-pub use types::common::posix08::*;
-pub use types::common::bsd44::*;
-pub use types::os::common::posix01::*;
-pub use types::os::common::bsd44::*;
-pub use types::os::arch::c95::*;
-pub use types::os::arch::c99::*;
-pub use types::os::arch::posix88::*;
-pub use types::os::arch::posix01::*;
-pub use types::os::arch::posix08::*;
-pub use types::os::arch::bsd44::*;
-pub use types::os::arch::extra::*;
-
-pub use consts::os::c95::*;
-pub use consts::os::c99::*;
-pub use consts::os::posix88::*;
-pub use consts::os::posix01::*;
-pub use consts::os::posix08::*;
-pub use consts::os::bsd44::*;
-pub use consts::os::extra::*;
-pub use consts::os::sysconf::*;
-
-pub use funcs::c95::ctype::*;
-pub use funcs::c95::stdio::*;
-pub use funcs::c95::stdlib::*;
-pub use funcs::c95::string::*;
-
-pub use funcs::posix88::stat_::*;
-pub use funcs::posix88::stdio::*;
-pub use funcs::posix88::fcntl::*;
-pub use funcs::posix88::dirent::*;
-pub use funcs::posix88::unistd::*;
-pub use funcs::posix88::mman::*;
-
-pub use funcs::posix01::stat_::*;
-pub use funcs::posix01::unistd::*;
-pub use funcs::posix01::glob::*;
-pub use funcs::posix01::mman::*;
-pub use funcs::posix08::unistd::*;
-
-pub use funcs::bsd43::*;
-pub use funcs::bsd44::*;
-pub use funcs::extra::*;
-
-#[cfg(target_os = "win32")]
-pub use funcs::extra::kernel32::*;
-#[cfg(target_os = "win32")]
-pub use funcs::extra::msvcrt::*;
-
 // Explicit export lists for the intersection (provided here) mean that
 // you can write more-platform-agnostic code if you stick to just these
 // symbols.
 
 pub use types::common::c95::{FILE, c_void, fpos_t};
+pub use types::common::c99::{int8_t, int16_t, int32_t, int64_t};
+pub use types::common::c99::{uint8_t, uint16_t, uint32_t, uint64_t};
 pub use types::common::posix88::{DIR, dirent_t};
-pub use types::os::arch::c95::{c_char, c_double, c_float, c_int};
+pub use types::os::common::bsd44::{addrinfo, in_addr, in6_addr, sockaddr_storage};
+pub use types::os::common::bsd44::{ip_mreq, ip6_mreq, sockaddr, sockaddr_un};
+pub use types::os::common::bsd44::{sa_family_t, sockaddr_in, sockaddr_in6, socklen_t};
+pub use types::os::arch::c95::{c_char, c_double, c_float, c_int, c_uint};
 pub use types::os::arch::c95::{c_long, c_short, c_uchar, c_ulong};
 pub use types::os::arch::c95::{c_ushort, clock_t, ptrdiff_t};
 pub use types::os::arch::c95::{size_t, time_t};
-pub use types::os::arch::c99::{c_longlong, c_ulonglong, intptr_t};
-pub use types::os::arch::c99::{uintptr_t};
+pub use types::os::arch::c99::{c_longlong, c_ulonglong};
+pub use types::os::arch::c99::{intptr_t, uintptr_t};
 pub use types::os::arch::posix88::{dev_t, ino_t, mode_t};
 pub use types::os::arch::posix88::{off_t, pid_t, ssize_t};
 
@@ -159,8 +109,15 @@ pub use consts::os::posix88::{O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 pub use consts::os::posix88::{R_OK, S_IEXEC, S_IFBLK, S_IFCHR};
 pub use consts::os::posix88::{S_IFDIR, S_IFIFO, S_IFMT, S_IFREG, S_IFLNK};
 pub use consts::os::posix88::{S_IREAD, S_IRUSR, S_IRWXU, S_IWUSR};
-pub use consts::os::posix88::{STDERR_FILENO, STDIN_FILENO};
+pub use consts::os::posix88::{STDERR_FILENO, STDIN_FILENO, S_IXUSR};
 pub use consts::os::posix88::{STDOUT_FILENO, W_OK, X_OK};
+pub use consts::os::bsd44::{AF_INET, AF_INET6, SOCK_STREAM, SOCK_DGRAM};
+pub use consts::os::bsd44::{IPPROTO_IP, IPPROTO_IPV6, IPPROTO_TCP, TCP_NODELAY};
+pub use consts::os::bsd44::{SOL_SOCKET, SO_KEEPALIVE};
+pub use consts::os::bsd44::{SO_REUSEADDR, SO_BROADCAST, SHUT_WR, IP_MULTICAST_LOOP};
+pub use consts::os::bsd44::{IP_ADD_MEMBERSHIP, IP_DROP_MEMBERSHIP};
+pub use consts::os::bsd44::{IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP};
+pub use consts::os::bsd44::{IP_MULTICAST_TTL, IP_TTL};
 
 pub use funcs::c95::ctype::{isalnum, isalpha, iscntrl, isdigit};
 pub use funcs::c95::ctype::{islower, isprint, ispunct, isspace};
@@ -169,7 +126,7 @@ pub use funcs::c95::ctype::{isupper, isxdigit, tolower, toupper};
 pub use funcs::c95::stdio::{fclose, feof, ferror, fflush, fgetc};
 pub use funcs::c95::stdio::{fgetpos, fgets, fopen, fputc, fputs};
 pub use funcs::c95::stdio::{fread, freopen, fseek, fsetpos, ftell};
-pub use funcs::c95::stdio::{fwrite, perror, puts, remove, rewind};
+pub use funcs::c95::stdio::{fwrite, perror, puts, remove, rename, rewind};
 pub use funcs::c95::stdio::{setbuf, setvbuf, tmpfile, ungetc};
 
 pub use funcs::c95::stdlib::{abs, atof, atoi, calloc, exit, _exit};
@@ -191,6 +148,135 @@ pub use funcs::posix88::unistd::{access, chdir, close, dup, dup2};
 pub use funcs::posix88::unistd::{execv, execve, execvp, getcwd};
 pub use funcs::posix88::unistd::{getpid, isatty, lseek, pipe, read};
 pub use funcs::posix88::unistd::{rmdir, unlink, write};
+
+pub use funcs::bsd43::{socket, setsockopt, bind, send, recv, recvfrom};
+pub use funcs::bsd43::{listen, sendto, accept, connect, getpeername, getsockname};
+pub use funcs::bsd43::{shutdown};
+
+// But we also reexport most everything
+// if you're interested in writing platform-specific code.
+
+// FIXME: This is a mess, but the design of this entire module needs to be
+// reconsidered, so I'm not inclined to do better right now. As part of
+// #11870 I removed all the pub globs here, leaving explicit reexports
+// of everything that is actually used in-tree.
+//
+// So the following exports don't follow any particular plan.
+
+#[cfg(unix)] pub use consts::os::sysconf::{_SC_PAGESIZE};
+#[cfg(unix)] pub use consts::os::posix88::{PROT_READ, PROT_WRITE, PROT_EXEC};
+#[cfg(unix)] pub use consts::os::posix88::{MAP_FIXED, MAP_FILE, MAP_ANON, MAP_PRIVATE, MAP_FAILED};
+#[cfg(unix)] pub use consts::os::posix88::{EACCES, EBADF, EINVAL, ENODEV, ENOMEM};
+#[cfg(unix)] pub use consts::os::posix88::{ECONNREFUSED, ECONNRESET, EPERM, EPIPE};
+#[cfg(unix)] pub use consts::os::posix88::{ENOTCONN, ECONNABORTED, EADDRNOTAVAIL, EINTR};
+#[cfg(unix)] pub use consts::os::posix88::{EADDRINUSE, ENOENT, EISDIR, EAGAIN, EWOULDBLOCK};
+#[cfg(unix)] pub use consts::os::posix88::{ECANCELED, SIGINT};
+#[cfg(unix)] pub use consts::os::posix88::{SIGTERM, SIGKILL, SIGPIPE, PROT_NONE};
+#[cfg(unix)] pub use consts::os::posix01::{SIG_IGN, WNOHANG};
+#[cfg(unix)] pub use consts::os::bsd44::{AF_UNIX};
+
+#[cfg(unix)] pub use types::os::common::posix01::{pthread_t, timespec, timezone, timeval};
+
+#[cfg(unix)] pub use types::os::arch::c95::{suseconds_t};
+#[cfg(unix)] pub use types::os::arch::posix88::{uid_t, gid_t};
+#[cfg(unix)] pub use types::os::arch::posix01::{pthread_attr_t};
+#[cfg(unix)] pub use types::os::arch::posix01::{stat, utimbuf};
+#[cfg(unix)] pub use funcs::posix88::unistd::{sysconf, setgid, setsid, setuid, pread, pwrite};
+#[cfg(unix)] pub use funcs::posix88::unistd::{getgid, getuid};
+#[cfg(unix)] pub use funcs::posix88::unistd::{_PC_NAME_MAX, utime, nanosleep, pathconf, link};
+#[cfg(unix)] pub use funcs::posix88::unistd::{chown};
+#[cfg(unix)] pub use funcs::posix88::mman::{mmap, munmap, mprotect};
+#[cfg(unix)] pub use funcs::posix88::dirent::{opendir, readdir_r, closedir};
+#[cfg(unix)] pub use funcs::posix88::fcntl::{fcntl};
+#[cfg(unix)] pub use funcs::posix01::stat_::{lstat};
+#[cfg(unix)] pub use funcs::posix01::unistd::{fsync, ftruncate};
+#[cfg(unix)] pub use funcs::posix01::unistd::{readlink, symlink};
+
+#[cfg(windows)] pub use consts::os::c95::{WSAECONNREFUSED, WSAECONNRESET, WSAEACCES};
+#[cfg(windows)] pub use consts::os::c95::{WSAEWOULDBLOCK, WSAENOTCONN, WSAECONNABORTED};
+#[cfg(windows)] pub use consts::os::c95::{WSAEADDRNOTAVAIL, WSAEADDRINUSE, WSAEINTR};
+#[cfg(windows)] pub use consts::os::extra::{ERROR_INSUFFICIENT_BUFFER};
+#[cfg(windows)] pub use consts::os::extra::{O_BINARY, O_NOINHERIT, PAGE_NOACCESS};
+#[cfg(windows)] pub use consts::os::extra::{PAGE_READONLY, PAGE_READWRITE, PAGE_EXECUTE};
+#[cfg(windows)] pub use consts::os::extra::{PAGE_EXECUTE_READ, PAGE_EXECUTE_READWRITE};
+#[cfg(windows)] pub use consts::os::extra::{MEM_COMMIT, MEM_RESERVE, MEM_RELEASE};
+#[cfg(windows)] pub use consts::os::extra::{FILE_MAP_READ, FILE_MAP_WRITE, FILE_MAP_EXECUTE};
+#[cfg(windows)] pub use consts::os::extra::{ERROR_ALREADY_EXISTS, ERROR_NO_DATA};
+#[cfg(windows)] pub use consts::os::extra::{ERROR_FILE_NOT_FOUND, ERROR_INVALID_NAME};
+#[cfg(windows)] pub use consts::os::extra::{ERROR_BROKEN_PIPE, ERROR_INVALID_FUNCTION};
+#[cfg(windows)] pub use consts::os::extra::{TRUE, FALSE, INFINITE};
+#[cfg(windows)] pub use consts::os::extra::{PROCESS_TERMINATE, PROCESS_QUERY_INFORMATION};
+#[cfg(windows)] pub use consts::os::extra::{STILL_ACTIVE, DETACHED_PROCESS};
+#[cfg(windows)] pub use consts::os::extra::{CREATE_NEW_PROCESS_GROUP};
+#[cfg(windows)] pub use consts::os::extra::{FILE_BEGIN, FILE_END, FILE_CURRENT};
+#[cfg(windows)] pub use consts::os::extra::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+#[cfg(windows)] pub use consts::os::extra::{FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_SHARE_DELETE};
+#[cfg(windows)] pub use consts::os::extra::{TRUNCATE_EXISTING, CREATE_ALWAYS, OPEN_EXISTING};
+#[cfg(windows)] pub use consts::os::extra::{CREATE_NEW, FILE_APPEND_DATA, FILE_WRITE_DATA};
+#[cfg(windows)] pub use consts::os::extra::{OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL};
+#[cfg(windows)] pub use consts::os::extra::{FILE_FLAG_BACKUP_SEMANTICS, INVALID_HANDLE_VALUE};
+#[cfg(windows)] pub use consts::os::extra::{MOVEFILE_REPLACE_EXISTING};
+#[cfg(windows)] pub use consts::os::extra::{GENERIC_READ, GENERIC_WRITE};
+#[cfg(windows)] pub use consts::os::extra::{VOLUME_NAME_DOS, FILE_ATTRIBUTE_NORMAL};
+#[cfg(windows)] pub use consts::os::extra::{PIPE_ACCESS_DUPLEX, FILE_FLAG_FIRST_PIPE_INSTANCE};
+#[cfg(windows)] pub use consts::os::extra::{FILE_FLAG_OVERLAPPED, PIPE_TYPE_BYTE};
+#[cfg(windows)] pub use consts::os::extra::{PIPE_READMODE_BYTE, PIPE_WAIT};
+#[cfg(windows)] pub use consts::os::extra::{PIPE_UNLIMITED_INSTANCES, ERROR_ACCESS_DENIED};
+#[cfg(windows)] pub use consts::os::extra::{FILE_WRITE_ATTRIBUTES, FILE_READ_ATTRIBUTES};
+#[cfg(windows)] pub use consts::os::extra::{ERROR_PIPE_BUSY, ERROR_IO_PENDING};
+#[cfg(windows)] pub use consts::os::extra::{ERROR_PIPE_CONNECTED};
+#[cfg(windows)] pub use types::os::common::bsd44::{SOCKET};
+#[cfg(windows)] pub use types::os::common::posix01::{stat, utimbuf};
+#[cfg(windows)] pub use types::os::arch::extra::{HANDLE, BOOL, LPSECURITY_ATTRIBUTES};
+#[cfg(windows)] pub use types::os::arch::extra::{LPCSTR, WORD, DWORD, BYTE, FILETIME};
+#[cfg(windows)] pub use types::os::arch::extra::{LARGE_INTEGER, LPVOID, LONG};
+#[cfg(windows)] pub use types::os::arch::extra::{time64_t, OVERLAPPED};
+#[cfg(windows)] pub use types::os::arch::extra::{LPOVERLAPPED, SIZE_T, LPDWORD};
+#[cfg(windows)] pub use funcs::c95::string::{wcslen};
+#[cfg(windows)] pub use funcs::posix88::stat_::{wstat, wutime, wchmod, wrmdir};
+#[cfg(windows)] pub use funcs::bsd43::{closesocket};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetCurrentDirectoryW, GetLastError};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetEnvironmentVariableW, SetEnvironmentVariableW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetModuleFileNameW, SetCurrentDirectoryW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetSystemInfo, VirtualAlloc, VirtualFree};
+#[cfg(windows)] pub use funcs::extra::kernel32::{CreateFileMappingW, MapViewOfFile};
+#[cfg(windows)] pub use funcs::extra::kernel32::{UnmapViewOfFile, CloseHandle};
+#[cfg(windows)] pub use funcs::extra::kernel32::{WaitForSingleObject, GetSystemTimeAsFileTime};
+#[cfg(windows)] pub use funcs::extra::kernel32::{QueryPerformanceCounter};
+#[cfg(windows)] pub use funcs::extra::kernel32::{WaitForSingleObject, QueryPerformanceFrequency};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetExitCodeProcess, TerminateProcess};
+#[cfg(windows)] pub use funcs::extra::kernel32::{ReadFile, WriteFile, SetFilePointerEx};
+#[cfg(windows)] pub use funcs::extra::kernel32::{FlushFileBuffers, SetEndOfFile, CreateFileW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{CreateDirectoryW, FindFirstFileW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{FindNextFileW, FindClose, DeleteFileW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetFinalPathNameByHandleW, CreateSymbolicLinkW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{CreateHardLinkW, CreateEventW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{FlushFileBuffers, CreateNamedPipeW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{SetNamedPipeHandleState, WaitNamedPipeW};
+#[cfg(windows)] pub use funcs::extra::kernel32::{GetOverlappedResult, ConnectNamedPipe};
+#[cfg(windows)] pub use funcs::extra::kernel32::{DisconnectNamedPipe, OpenProcess};
+#[cfg(windows)] pub use funcs::extra::kernel32::{MoveFileExW, VirtualProtect};
+#[cfg(windows)] pub use funcs::extra::msvcrt::{get_osfhandle, open_osfhandle};
+
+#[cfg(target_os = "linux")] #[cfg(target_os = "android")] #[cfg(target_os = "freebsd")]
+pub use consts::os::posix01::{CLOCK_REALTIME, CLOCK_MONOTONIC};
+
+#[cfg(target_os = "linux")] #[cfg(target_os = "android")]
+pub use funcs::posix01::unistd::{fdatasync};
+
+#[cfg(unix, not(target_os = "freebsd"))]
+pub use consts::os::extra::{MAP_STACK};
+
+#[cfg(target_os = "freebsd")]
+pub use consts::os::bsd44::{TCP_KEEPIDLE};
+
+#[cfg(target_os = "macos")]
+pub use consts::os::bsd44::{TCP_KEEPALIVE};
+#[cfg(target_os = "macos")]
+pub use consts::os::extra::{F_FULLFSYNC};
+#[cfg(target_os = "macos")]
+pub use types::os::arch::extra::{mach_timebase_info};
+
 
 #[cfg(not(windows))]
 #[link(name = "c")]
@@ -3028,7 +3114,6 @@ pub mod consts {
             pub static MAP_PRIVATE : c_int = 0x0002;
             pub static MAP_FIXED : c_int = 0x0010;
             pub static MAP_ANON : c_int = 0x1000;
-            pub static MAP_STACK : c_int = 0;
 
             pub static MAP_FAILED : *c_void = -1 as *c_void;
 
@@ -3274,6 +3359,7 @@ pub mod consts {
             pub static MAP_HASSEMAPHORE : c_int = 0x0200;
             pub static MAP_NOCACHE : c_int = 0x0400;
             pub static MAP_JIT : c_int = 0x0800;
+            pub static MAP_STACK : c_int = 0;
         }
         pub mod sysconf {
             use types::os::arch::c95::c_int;


### PR DESCRIPTION
Them removes all the glob reexports from liblibc. I did it by removing them all, and then adding back per-platform explicit reexports until everything built again.

I realize this isn't the best strategy for determining an API, but this is the lowest-impact change that solves the problem, plus I'm dissatisfied with the design of this library for other reasons and think it needs to be reconsidered from top to bottom (later).

Progress on #11870.
