### PR TITLE
rustdoc: Fix rendering closures and trait bounds

### DIFF
--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -2601,7 +2601,9 @@ impl<A: Clone> Clone for ~[A] {
 
 impl<'a, T: fmt::Show> fmt::Show for &'a [T] {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f.buf, "["));
+        if f.flags & (1 << (fmt::parse::FlagAlternate as uint)) == 0 {
+            try!(write!(f.buf, "["));
+        }
         let mut is_first = true;
         for x in self.iter() {
             if is_first {
@@ -2611,7 +2613,10 @@ impl<'a, T: fmt::Show> fmt::Show for &'a [T] {
             }
             try!(write!(f.buf, "{}", *x))
         }
-        write!(f.buf, "]")
+        if f.flags & (1 << (fmt::parse::FlagAlternate as uint)) == 0 {
+            try!(write!(f.buf, "]"));
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closures did not have their bounds printed at all, nor their lifetimes. Trait
bounds were also printed in angle brackets rather than after a colon with a '+'
inbetween them.

Note that on the current task::spawn [1] documentation page, there is no mention
of a `Send` bound even though it is crucially important!

[1] - http://static.rust-lang.org/doc/master/std/task/fn.task.html
