### PR TITLE
librustc: Improve error message for missing feature attributes.

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -96,7 +96,7 @@ impl<'a> Context<'a> {
     fn gate_feature(&self, feature: &str, span: Span, explain: &str) {
         if !self.has_feature(feature) {
             self.sess.span_err(span, explain);
-            self.sess.span_note(span, format!("add \\#[feature({})] to the \
+            self.sess.span_note(span, format!("add \\#![feature({})] to the \
                                                   crate attributes to enable",
                                                  feature));
         }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3714,7 +3714,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
             && !fcx.tcx().sess.features.default_type_params.get() {
             fcx.tcx().sess.span_err(pth.span, "default type parameters are \
                                                experimental and possibly buggy");
-            fcx.tcx().sess.span_note(pth.span, "add #[feature(default_type_params)] \
+            fcx.tcx().sess.span_note(pth.span, "add #![feature(default_type_params)] \
                                                 to the crate attributes to enable");
         }
 


### PR DESCRIPTION
The current error message is misleading, it asks users to add `#[feature(..)]` which ends up being treated as an outer attribute, which then has no error unless `attribute_usage` lint is enforced. The code will still fail and the user might not understand why.
