### PR TITLE
Make Result::{unwrap, unwrap_err} require Show

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -266,7 +266,7 @@ trait def_id_encoder_helpers {
 
 impl<S:serialize::Encoder<E>, E> def_id_encoder_helpers for S {
     fn emit_def_id(&mut self, did: ast::DefId) {
-        did.encode(self).unwrap()
+        did.encode(self).ok().unwrap()
     }
 }
 
@@ -278,13 +278,13 @@ trait def_id_decoder_helpers {
 
 impl<D:serialize::Decoder<E>, E> def_id_decoder_helpers for D {
     fn read_def_id(&mut self, xcx: &ExtendedDecodeContext) -> ast::DefId {
-        let did: ast::DefId = Decodable::decode(self).unwrap();
+        let did: ast::DefId = Decodable::decode(self).ok().unwrap();
         did.tr(xcx)
     }
 
     fn read_def_id_noxcx(&mut self,
                          cdata: @cstore::crate_metadata) -> ast::DefId {
-        let did: ast::DefId = Decodable::decode(self).unwrap();
+        let did: ast::DefId = Decodable::decode(self).ok().unwrap();
         decoder::translate_def_id(cdata, did)
     }
 }

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -496,7 +496,7 @@ impl<T: Send> Sender<T> {
                                 // This send cannot fail because the task is
                                 // asleep (we're looking at it), so the receiver
                                 // can't go away.
-                                (*a.get()).send(t).unwrap();
+                                (*a.get()).send(t).ok().unwrap();
                                 task.wake().map(|t| t.reawaken());
                                 (a, Ok(()))
                             }

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -12,6 +12,7 @@
 
 use clone::Clone;
 use cmp::Eq;
+use std::fmt::Show;
 use iter::{Iterator, FromIterator};
 use option::{None, Option, Some};
 
@@ -174,20 +175,6 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /////////////////////////////////////////////////////////////////////////
-    // Common special cases
-    /////////////////////////////////////////////////////////////////////////
-
-    /// Unwraps a result, yielding the content of an `Ok`.
-    /// Fails if the value is an `Err`.
-    #[inline]
-    pub fn unwrap(self) -> T {
-        match self {
-            Ok(t) => t,
-            Err(_) => fail!("called `Result::unwrap()` on an `Err` value")
-        }
-    }
-
     /// Unwraps a result, yielding the content of an `Ok`.
     /// Else it returns `optb`.
     #[inline]
@@ -207,13 +194,31 @@ impl<T, E> Result<T, E> {
             Err(e) => op(e)
         }
     }
+}
 
+impl<T, E: Show> Result<T, E> {
+    /// Unwraps a result, yielding the content of an `Ok`.
+    ///
+    /// Fails if the value is an `Err`.
+    #[inline]
+    pub fn unwrap(self) -> T {
+        match self {
+            Ok(t) => t,
+            Err(e) =>
+                fail!("called `Result::unwrap()` on an `Err` value: {}", e)
+        }
+    }
+}
+
+impl<T: Show, E> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Err`.
+    ///
     /// Fails if the value is an `Ok`.
     #[inline]
     pub fn unwrap_err(self) -> E {
         match self {
-            Ok(_) => fail!("called `Result::unwrap_err()` on an `Ok` value"),
+            Ok(t) =>
+                fail!("called `Result::unwrap_err()` on an `Ok` value: {}", t),
             Err(e) => e
         }
     }


### PR DESCRIPTION
`foo.ok().unwrap()` and `foo.err().unwrap()` are the fallbacks for types
that aren't `Show`.

Closes #13379
