### PR TITLE
Check bounds when looking up type parameters

### DIFF
--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -242,16 +242,17 @@ fn lookup_vtable(vcx: &VtableContext,
     // bounds to see if they include the trait we are looking for.
     let vtable_opt = match ty::get(ty).sty {
         ty::ty_param(param_ty {idx: n, ..}) => {
-            let type_param_bounds: &[@ty::TraitRef] =
-                vcx.param_env
-                   .type_param_bounds
-                   .get(n)
-                   .trait_bounds
-                   .as_slice();
-            lookup_vtable_from_bounds(vcx, span,
-                                      type_param_bounds,
-                                      param_numbered(n),
-                                      trait_ref)
+            let env_bounds = &vcx.param_env.type_param_bounds;
+            if env_bounds.len() > n {
+                let type_param_bounds: &[@ty::TraitRef] =
+                    env_bounds.get(n).trait_bounds.as_slice();
+                lookup_vtable_from_bounds(vcx, span,
+                                          type_param_bounds,
+                                          param_numbered(n),
+                                          trait_ref)
+            } else {
+                None
+            }
         }
 
         ty::ty_self(_) => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -393,8 +393,9 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
       ty_param(param_ty {idx: id, def_id: did}) => {
           let ident = match cx.ty_param_defs.borrow().find(&did.node) {
               Some(def) => token::get_ident(def.ident).get().to_str(),
-              // This should not happen...
-              None => format!("BUG[{:?}]", id)
+              // This can only happen when a type mismatch error happens and
+              // the actual type has more type parameters than the expected one.
+              None => format!("<generic \\#{}>", id)
           };
           if !cx.sess.verbose() {
               ident

--- a/src/test/compile-fail/issue-13466.rs
+++ b/src/test/compile-fail/issue-13466.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #13466
+
+pub fn main() {
+    // The expected arm type `Option<T>` has one type parameter, while
+    // the actual arm `Result<T, E>` has two. typeck should not be
+    // tricked into looking up a non-existing second type parameter.
+    let _x: uint = match Some(1u) {
+    //~^ ERROR mismatched types: expected `uint` but found `<generic #0>`
+        Ok(u) => u, //~ ERROR  mismatched types: expected `std::option::Option<uint>`
+        Err(e) => fail!(e)  //~ ERROR mismatched types: expected `std::option::Option<uint>`
+    };
+}


### PR DESCRIPTION
A mismatched type with more type parameters than the expected one causes
`typeck` looking up out of the bound of type parameter vector, which
leads to ICE.

Closes #13466
