### PR TITLE
doc: add webfonts and tweak the styles accordingly

### DIFF
--- a/src/doc/full-toc.inc
+++ b/src/doc/full-toc.inc
@@ -1,6 +1,11 @@
 <style>
   /* Display the full TOC */
-  #TOC ul ul {
+  nav {
+    column-count: auto;
+    -moz-column-count: auto;
+    -webkit-column-count: auto;
+  }
+  nav ul ul {
     display: block;
     padding-left: 2em;
   }

--- a/src/doc/guide-lifetimes.md
+++ b/src/doc/guide-lifetimes.md
@@ -236,7 +236,7 @@ it. It would violate memory safety for the box that was originally
 assigned to `x` to be garbage-collected, since a non-heap
 pointer *`y`* still points into it.
 
-> ***Note:*** Our current implementation implements the garbage collector
+> *Note:* Our current implementation implements the garbage collector
 > using reference counting and cycle detection.
 
 For this reason, whenever an `&` expression borrows the interior of a
@@ -674,7 +674,7 @@ Named lifetime notation can also be used to control the flow of execution:
 }
 ~~~
 
-> ***Note:*** Labelled breaks are not currently supported within `while` loops.
+> *Note:* Labelled breaks are not currently supported within `while` loops.
 
 Named labels are hygienic and can be used safely within macros.
 See the macros guide section on hygiene for more details.

--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -462,7 +462,7 @@ an `Error` result.
 
 [`Result`]: std/result/index.html
 
-> ***Note:*** A failed task does not currently produce a useful error
+> *Note:* A failed task does not currently produce a useful error
 > value (`try` always returns `Err(())`). In the
 > future, it may be possible for tasks to intercept the value passed to
 > `fail!()`.

--- a/src/doc/po/ja/tutorial.md.po
+++ b/src/doc/po/ja/tutorial.md.po
@@ -196,11 +196,11 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:57
 msgid ""
-"> ***Warning:*** Rust is a language under ongoing development. Notes > about "
+"> *Warning:* Rust is a language under ongoing development. Notes > about "
 "potential changes to the language, implementation > deficiencies, and other "
 "caveats appear offset in blockquotes."
 msgstr ""
-"> ***警告:*** Rust は開発途上の言語です。将来予定されている言語への変更や、実"
+"> *警告:* Rust は開発途上の言語です。将来予定されている言語への変更や、実"
 "装上の不備、その他の注意事項など、 blockquote の段落 (この段落もそうです) に"
 "注意してください。"
 
@@ -287,13 +287,13 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:88
 msgid ""
-"> ***Note:*** Windows users should read the detailed > \"[getting started]"
+"> *Note:* Windows users should read the detailed > \"[getting started]"
 "[wiki-start]\" notes on the wiki. Even when using > the binary installer, "
 "the Windows build requires a MinGW installation, > the precise details of "
 "which are not discussed here. Finally, `rustc` may > need to be [referred to "
 "as `rustc.exe`][bug-3319]. It's a bummer, we > know."
 msgstr ""
-"> ***注意:*** Windows ユーザーは wiki の [getting started][wiki-start] の記事"
+"> *注意:* Windows ユーザーは wiki の [getting started][wiki-start] の記事"
 "を読んでください。 本書では詳細を説明しませんが、インストーラを利用する場合で"
 "も、MinGW のインストールなど、追加の手順が必要です。また、コンパイラは "
 "`rustc` ではなく、 [`rustc.exe` として呼び出す必要がある][bug-3319] かもしれ"
@@ -1254,11 +1254,11 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:504
 msgid ""
-"> ***Note:*** The following code makes use of tuples (`(f64, f64)`) which > "
+"> *Note:* The following code makes use of tuples (`(f64, f64)`) which > "
 "are explained in section 5.3. For now you can think of tuples as a list of > "
 "items."
 msgstr ""
-"> ***注意:*** 以下のコード例では5.3 節で説明されるタプル (`(f64, f64)`) を"
+"> *注意:* 以下のコード例では5.3 節で説明されるタプル (`(f64, f64)`) を"
 "使っています。現時点では、タプルは項目のリストのようなものだとみなしてくださ"
 "い。"
 
@@ -3005,11 +3005,11 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:1774
 msgid ""
-"> ***Note:*** Both the syntax and the semantics will be changing > in small "
+"> *Note:* Both the syntax and the semantics will be changing > in small "
 "ways. At the moment they can be unsound in some > scenarios, particularly "
 "with non-copyable types."
 msgstr ""
-"> ***注意*** コードの文法と意味は将来的に変更されるかもしれません。現時点では"
+"> *注意* コードの文法と意味は将来的に変更されるかもしれません。現時点では"
 "いくつかの状況、特にコピーできない型が関連するケースにおいて望ましくない振る"
 "舞いが起こされる場合があります。"
 
@@ -3660,10 +3660,10 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:2099
 msgid ""
-"> ***Note:*** These two traits were referred to as 'kinds' in earlier > "
+"> *Note:* These two traits were referred to as 'kinds' in earlier > "
 "iterations of the language, and often still are."
 msgstr ""
-"> ***注意*** これら2つのトレイトは、以前は 「種」 (kind) と呼ばれており、現在"
+"> *注意* これら2つのトレイトは、以前は 「種」 (kind) と呼ばれており、現在"
 "でもそう呼ばれる場合があります。"
 
 #. type: Plain text
@@ -4374,9 +4374,9 @@ msgstr ""
 
 #. type: Plain text
 #: src/doc/tutorial.md:2511
-msgid "> ***Note:*** Trait inheritance does not actually work with objects yet"
+msgid "> *Note:* Trait inheritance does not actually work with objects yet"
 msgstr ""
-"> ***注意*** トレイトの継承は、実際にはまだオブジェクトに対しては動作しませ"
+"> *注意* トレイトの継承は、実際にはまだオブジェクトに対しては動作しませ"
 "ん。"
 
 #. type: Plain text

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -10,13 +10,43 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+@font-face {
+    font-family: 'Fira Sans';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Fira Sans'), url("http://rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
+}
+@font-face {
+    font-family: 'Fira Sans';
+    font-style: normal;
+    font-weight: 500;
+    src: local('Fira Sans Medium'), url("http://rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Heuristica Regular'), url("http://rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: italic;
+    font-weight: 400;
+    src: local('Heuristica Italic'), url("http://rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: normal;
+    font-weight: 700;
+    src: local('Heuristica Bold'), url("http://rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
+}
 /* Global page semantics
    ========================================================================== */
 body {
     margin: 0 auto;
     padding: 0 15px;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 14px;
+    font-family: Heuristica, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
     color: #333;
     line-height: 1.428571429;
 }
@@ -26,24 +56,36 @@ body {
     }
 }
 
+h1, h2, h3, h4, h5, h6, nav, div#versioninfo {
+    font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
 h1, h2, h3, h4, h5, h6 {
     color: black;
-    font-weight: 500;
+    font-weight: 400;
     line-height: 1.1;
 }
 h1, h2, h3 {
     margin-top: 20px;
     margin-bottom: 10px;
 }
+@media (min-width: 1170px) {
+    h1, h2, h3 {
+        margin-top: 30px;
+        margin-bottom: 15px;
+    }
+}
 h4, h5, h6 {
     margin-top: 12px;
     margin-bottom: 10px;
-    padding: .2em .8em;
+    padding: 5px 10px;
+}
+h5, h6 {
     text-decoration: underline;
 }
 
 h1 {
-    font-size: 36px;
+    font-size: 28px;
+    font-weight: 500;
     padding: .1em .4em;
     margin: 0.67em 0;
     border-bottom: 2px solid #ddd;
@@ -52,7 +94,7 @@ h1.title {
     line-height: 1.5em;
 }
 h2 {
-    font-size: 30px;
+    font-size: 26px;
     padding: .2em .5em;
     border-bottom: 1px solid #ddd;
 }
@@ -62,15 +104,32 @@ h3 {
     border-bottom: 1px solid #DDE8FC;
 }
 h4 {
-    font-size: 18px;
+    font-size: 22px;
 }
 h5 {
-    font-size: 16px;
+    font-size: 20px;
 }
 h6 {
-    font-size: 14px;
+    font-size: 18px;
+}
+@media (min-width: 992px) {
+    h1 {
+        font-size: 36px;
+    }
+    h2 {
+        font-size: 30px;
+    }
+    h3 {
+        font-size: 26px;
+    }
 }
 
+nav {
+    column-count: 2;
+    -moz-column-count: 2;
+    -webkit-column-count: 2;
+    font-size: 15px;
+}
 p {
     margin: 0 0 10px;
 }
@@ -85,10 +144,10 @@ em {
 
 footer {
     border-top: 1px solid #ddd;
-    font-size: 12px;
+    font-size: 14.3px;
     font-style: italic;
-    padding-top: 4px;
-    margin-top: 4em;
+    padding-top: 5px;
+    margin-top: 3em;
     margin-bottom: 1em;
 }
 
@@ -130,16 +189,14 @@ pre {
     border-radius: 0.5em;
     white-space: pre-wrap;
     padding: 9.5px;
-    margin: 10px 0;
+    margin: 15px 0;
     font-size: 13px;
     word-break: break-all;
     word-wrap: break-word;
 }
 code {
-    padding: 2px 4px;
-    font-size: 90%;
-    color: #C7254E;
-    background-color: #F9F2F4;
+    padding: 0 2px;
+    color: #8D1A38;
     white-space: nowrap;
 }
 pre code {
@@ -170,7 +227,7 @@ pre.rust .lifetime { color: #B76514; }
     margin: 0.5em;
     font-size: 1.1em;
 }
-@media only screen, handheld and (min-width: 768px) {
+@media handheld, only screen and (min-width: 768px) {
     #versioninfo {
         position: fixed;
         bottom: 0px;
@@ -185,7 +242,7 @@ pre.rust .lifetime { color: #B76514; }
 }
 #versioninfo a.hash {
     color: gray;
-    font-size: 70%;
+    font-size: 80%;
 }
 
 blockquote {
@@ -221,13 +278,13 @@ dd {
     margin-left: 0;
 }
 
-#TOC ul {
+nav ul {
     list-style-type: none;
     padding-left: 0px;
 }
 
 /* Only display one level of hierarchy in the TOC */
-#TOC ul ul {
+nav ul ul {
     display: none;
 }
 

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1332,7 +1332,6 @@ Traits are implemented for specific types through separate [implementations](#im
 ~~~~
 # type Surface = int;
 # type BoundingBox = int;
-
 trait Shape {
     fn draw(&self, Surface);
     fn bounding_box(&self) -> BoundingBox;
@@ -1363,7 +1362,6 @@ For example:
 ~~~~
 # type Surface = int;
 # trait Shape { fn draw(&self, Surface); }
-
 fn draw_twice<T: Shape>(surface: Surface, sh: T) {
     sh.draw(surface);
     sh.draw(surface);
@@ -1379,7 +1377,6 @@ to pointers to the trait name, used as a type.
 # trait Shape { }
 # impl Shape for int { }
 # let mycircle = 0;
-
 let myshape: ~Shape = ~mycircle as ~Shape;
 ~~~~
 
@@ -1440,7 +1437,6 @@ Likewise, supertrait methods may also be called on trait objects.
 # impl Shape for int { fn area(&self) -> f64 { 0.0 } }
 # impl Circle for int { fn radius(&self) -> f64 { 0.0 } }
 # let mycircle = 0;
-
 let mycircle: Circle = ~mycircle as ~Circle;
 let nonsense = mycircle.radius() * mycircle.area();
 ~~~~
@@ -1457,7 +1453,6 @@ Implementations are defined with the keyword `impl`.
 # struct BoundingBox {x: f64, y: f64, width: f64, height: f64};
 # trait Shape { fn draw(&self, Surface); fn bounding_box(&self) -> BoundingBox; }
 # fn do_draw_circle(s: Surface, c: Circle) { }
-
 struct Circle {
     radius: f64,
     center: Point,
@@ -1490,7 +1485,6 @@ Implementation parameters are written after the `impl` keyword.
 
 ~~~~
 # trait Seq<T> { }
-
 impl<T> Seq<T> for ~[T] {
    /* ... */
 }
@@ -3758,7 +3752,7 @@ initialized; this is enforced by the compiler.
 ### Owned boxes
 
 An  _owned box_ is a reference to a heap allocation holding another value, which is constructed
-by the prefix *tilde* sigil `~`
+by the prefix *tilde* sigil `~`.
 
 An example of an owned box type and value:
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -51,13 +51,13 @@ fragments of programs that don't compile on their own. To try them
 out, you might have to wrap them in `fn main() { ... }`, and make sure
 they don't contain references to names that aren't actually defined.
 
-> ***Warning:*** Rust is a language under ongoing development. Notes
+> *Warning:* Rust is a language under ongoing development. Notes
 > about potential changes to the language, implementation
 > deficiencies, and other caveats appear offset in blockquotes.
 
 # Getting started
 
-> ***Warning:*** The tarball and installer links are for the most recent
+> *Warning:* The tarball and installer links are for the most recent
 > release, not master. To use master, you **must** build from [git].
 
 The Rust compiler currently must be built from a [tarball] or [git], unless
@@ -79,7 +79,7 @@ Snapshot binaries are currently built and tested on several platforms:
 You may find that other platforms work, but these are our "tier 1"
 supported build environments that are most likely to work.
 
-> ***Note:*** Windows users should read the detailed
+> *Note:* Windows users should read the detailed
 > [Getting started][wiki-start] notes on the wiki. Even when using
 > the binary installer, the Windows build requires a MinGW installation,
 > the precise details of which are not discussed here.
@@ -130,7 +130,7 @@ fn main() {
     println!("hello?");
 }
 ~~~~
-> ***Note:*** An identifier followed by an exclamation point, like
+> *Note:* An identifier followed by an exclamation point, like
 > `println!`, is a macro invocation.  Macros are explained
 > [later](#syntax-extensions); for now just remember to include the
 > exclamation point.
@@ -358,7 +358,7 @@ The unit type, written `()`, has a single value, also written `()`.
 ## Operators
 
 Rust's set of operators contains very few surprises. Arithmetic is done with
-`*`, `/`, `%`, `+`, and `-` (multiply, quotient, remainder, add, and subtract). `-` is
+`*`, `/`, `%`, `+`, and `−` (multiply, quotient, remainder, add, and subtract). `−` is
 also a unary prefix operator that negates numbers. As in C, the bitwise operators
 `>>`, `<<`, `&`, `|`, and `^` are also supported.
 
@@ -498,7 +498,7 @@ omitted.
 A powerful application of pattern matching is *destructuring*:
 matching in order to bind names to the contents of data types.
 
-> ***Note:*** The following code makes use of tuples (`(f64, f64)`) which
+> *Note:* The following code makes use of tuples (`(f64, f64)`) which
 > are explained in section 5.3. For now you can think of tuples as a list of
 > items.
 
@@ -781,7 +781,7 @@ fn area(sh: Shape) -> f64 {
 }
 ~~~~
 
-> ***Note:*** This feature of the compiler is currently gated behind the
+> *Note:* This feature of the compiler is currently gated behind the
 > `#[feature(struct_variant)]` directive. More about these directives can be
 > found in the manual.
 
@@ -1061,7 +1061,7 @@ list -> | Cons | 1 | ~ | -> | Cons | 2 | ~ | -> | Cons | 3 | ~ | -> | Nil       
         +--------------+    +--------------+    +--------------+    +--------------+
 ~~~
 
-> ***Note:*** the above diagram shows the logical contents of the enum. The actual
+> *Note:* the above diagram shows the logical contents of the enum. The actual
 > memory layout of the enum may vary. For example, for the `List` enum shown
 > above, Rust guarantees that there will be no enum tag field in the actual
 > structure. See the language reference for more details.
@@ -1209,7 +1209,7 @@ let ys = Cons(5, ~Cons(10, ~Nil));
 assert!(eq(&xs, &ys));
 ~~~
 
-> ***Note:*** Rust doesn't guarantee [tail-call](http://en.wikipedia.org/wiki/Tail_call) optimization,
+> *Note:* Rust doesn't guarantee [tail-call](http://en.wikipedia.org/wiki/Tail_call) optimization,
 > but LLVM is able to handle a simple case like this with optimizations enabled.
 
 ## Lists of other types
@@ -1220,7 +1220,7 @@ element type.
 
 The `u32` in the previous definition can be substituted with a type parameter:
 
-> ***Note:*** The following code introduces generics, which are explained in a
+> *Note:* The following code introduces generics, which are explained in a
 > [dedicated section](#generics).
 
 ~~~
@@ -1794,7 +1794,7 @@ spawn(proc() {
 });
 ~~~~
 
-> ***Note:*** If you want to see the output of `debug!` statements, you will need to turn on
+> *Note:* If you want to see the output of `debug!` statements, you will need to turn on
 > `debug!` logging.  To enable `debug!` logging, set the RUST_LOG environment
 > variable to the name of your crate, which, for a file named `foo.rs`, will be
 > `foo` (e.g., with bash, `export RUST_LOG=foo`).
@@ -1816,7 +1816,7 @@ call_twice(closure);
 call_twice(function);
 ~~~~
 
-> ***Note:*** Both the syntax and the semantics will be changing
+> *Note:* Both the syntax and the semantics will be changing
 > in small ways. At the moment they can be unsound in some
 > scenarios, particularly with non-copyable types.
 
@@ -2101,7 +2101,7 @@ references, or types where the only contained references
 have the `'static` lifetime. (For more on named lifetimes and their uses,
 see the [references and lifetimes guide][lifetimes].)
 
-> ***Note:*** These built-in traits were referred to as 'kinds' in earlier
+> *Note:* These built-in traits were referred to as 'kinds' in earlier
 > iterations of the language, and often still are.
 
 Additionally, the `Drop` trait is used to define destructors. This
@@ -2512,7 +2512,7 @@ let mycircle: ~Circle = concrete as ~Circle;
 let nonsense = mycircle.radius() * mycircle.area();
 ~~~
 
-> ***Note:*** Trait inheritance does not actually work with objects yet
+> *Note:* Trait inheritance does not actually work with objects yet
 
 ## Deriving implementations for traits
 
@@ -2966,7 +2966,7 @@ use farm::*;
 # fn main() { cow(); chicken() }
 ~~~
 
-> ***Note:*** This feature of the compiler is currently gated behind the
+> *Note:* This feature of the compiler is currently gated behind the
 > `#[feature(globs)]` directive. More about these directives can be found in
 > the manual.
 


### PR DESCRIPTION
- Use Fira Sans for headlines, Heuristica for the body (Adobe Utopia derivative). Both are licensed under the SIL OFL license. (I didn't include BoldItalic because it is sparingly used.)
- Split TOC into 2 columns for the docs except manual (too tall, too wide to be readable).
- A few tweaks

Two examples: [modified tutorial](http://adrientetar.legtux.org/cached/rust-docs/tutorial.htm) and [modified manual](http://adrientetar.legtux.org/cached/rust-docs/manual.htm).

**Blocked on graydon/rust-www#25 (for hosting of the fonts), that's showcased [here](http://adrientetar.github.io/rust-www/).**

cc @brson
