### PR TITLE
rustdoc: add webfonts and tweak the styles accordingly

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -51,7 +51,7 @@ r##"<!DOCTYPE html>
 
     <section class="sidebar">
         {logo, select, none{} other{
-            <a href='{root_path}{krate}/index.html'><img src='#' alt=''/></a>
+            <a href='{root_path}{krate}/index.html'><img src='#' alt='' width='100px' /></a>
         }}
 
         {sidebar}

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -33,9 +33,12 @@ r##"<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="The {krate} library documentation.">
+
     <title>{title}</title>
 
-    <link href='http://fonts.googleapis.com/css?family=Oswald:700|Inconsolata:400,700'
+    <link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700'
           rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="{root_path}main.css">
 
@@ -59,7 +62,6 @@ r##"<!DOCTYPE html>
 
     <nav class="sub">
         <form class="search-form js-only">
-            <button class="do-search">Search</button>
             <div class="search-container">
                 <input class="search-input" name="search"
                        autocomplete="off"

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -934,28 +934,8 @@ impl<'a> fmt::Show for Item<'a> {
             None => {}
         }
 
-        if self.cx.include_sources {
-            let mut path = Vec::new();
-            clean_srcpath(self.item.source.filename.as_bytes(), |component| {
-                path.push(component.to_owned());
-            });
-            let href = if self.item.source.loline == self.item.source.hiline {
-                format!("{}", self.item.source.loline)
-            } else {
-                format!("{}-{}", self.item.source.loline, self.item.source.hiline)
-            };
-            try!(write!(fmt.buf,
-                          "<a class='source'
-                              href='{root}src/{krate}/{path}.html\\#{href}'>\
-                              [src]</a>",
-                          root = self.cx.root_path,
-                          krate = self.cx.layout.krate,
-                          path = path.connect("/"),
-                          href = href));
-        }
-
         // Write the breadcrumb trail header for the top
-        try!(write!(fmt.buf, "<h1 class='fqn'>"));
+        try!(write!(fmt.buf, "\n<h1 class='fqn'>"));
         match self.item.inner {
             clean::ModuleItem(ref m) => if m.is_crate {
                     try!(write!(fmt.buf, "Crate "));
@@ -978,8 +958,29 @@ impl<'a> fmt::Show for Item<'a> {
             try!(write!(fmt.buf, "<a href='{}index.html'>{}</a>::",
                           trail, component.as_slice()));
         }
-        try!(write!(fmt.buf, "<a class='{}' href=''>{}</a></h1>",
+        try!(write!(fmt.buf, "<a class='{}' href=''>{}</a>",
                       shortty(self.item), self.item.name.get_ref().as_slice()));
+
+        if self.cx.include_sources {
+            let mut path = Vec::new();
+            clean_srcpath(self.item.source.filename.as_bytes(), |component| {
+                path.push(component.to_owned());
+            });
+            let href = if self.item.source.loline == self.item.source.hiline {
+                format!("{}", self.item.source.loline)
+            } else {
+                format!("{}-{}", self.item.source.loline, self.item.source.hiline)
+            };
+            try!(write!(fmt.buf,
+                          "<a class='source'\
+                              href='{root}src/{krate}/{path}.html\\#{href}'>\
+                              [src]</a>",
+                          root = self.cx.root_path,
+                          krate = self.cx.layout.krate,
+                          path = path.connect("/"),
+                          href = href));
+        }
+        try!(write!(fmt.buf, "</h1>\n"));
 
         match self.item.inner {
             clean::ModuleItem(ref m) => {

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -9,6 +9,37 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+@font-face {
+    font-family: 'Fira Sans';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Fira Sans'), url("http://rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
+}
+@font-face {
+    font-family: 'Fira Sans';
+    font-style: normal;
+    font-weight: 500;
+    src: local('Fira Sans Medium'), url("http://rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Heuristica Regular'), url("http://rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: italic;
+    font-weight: 400;
+    src: local('Heuristica Italic'), url("http://rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: normal;
+    font-weight: 700;
+    src: local('Heuristica Bold'), url("http://rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
+}
+
 @import "normalize.css";
 
 * {
@@ -21,13 +52,12 @@
 
 body {
     color: #333;
-    min-height: 100%;
     min-width: 500px;
-    height: 100%;
-    font: 15px "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 150%;
+    font: 18px "Heuristica", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 1.4;
+    margin: 0;
     position: relative;
-    height: auto;
+    padding: 10px 15px 20px 15px;
     padding-bottom: 20px;
 }
 
@@ -44,13 +74,23 @@ h1.fqn {
 h2, h3, h4 {
     border-bottom: 1px solid #DDDDDD;
 }
-h2 code, h3 code, h4 code {
-
+h2 code, h3 code, h4 code, .block a {
     font-size: 1.2em;
+}
+h1, h2, h3, h4, section.sidebar, a.source, .content a, .search-input {
+    font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+ul {
+    padding-left: 25px;
+}
+
+p {
+    margin: 0 0 1em 0;
 }
 
 code, pre {
-    font-family: "Inconsolata", Menlo, Monaco, Consolas, "DejaVu Sans Mono", monospace;
+    font-family: Menlo, Monaco, Consolas, Inconsolata, "DejaVu Sans Mono", monospace;
 }
 pre {
     font-size: 15px;
@@ -92,8 +132,6 @@ nav.sub {
     color: #333;
 }
 
-.sidebar .block, pre { background: #fff; }
-
 .block {
     padding: 10px;
     margin-bottom: 10px;
@@ -111,11 +149,12 @@ nav.sub {
     padding-left: 5px;
     padding-bottom: 6px;
     font-size: 14px;
+    font-weight: 300;
     transition: border 500ms ease-out;
 }
 
 .content {
-    padding: 20px 40px;
+    padding: 20px 0;
 }
 
 .content pre { padding: 20px; }
@@ -165,10 +204,9 @@ nav.sub {
 .docblock h2 { font-size: 1.15em; }
 .docblock h3, .docblock h4, .docblock h5 { font-size: 1em; }
 
-.content .source { 
+.content .source {
     float: right;
-    font-weight: 500;
-    padding: 9px 15px;
+    font-size: 23px;
 }
 
 .content table {
@@ -224,7 +262,7 @@ nav.sum { text-align: right; }
 nav.sub form { display: inline; }
 
 nav, .content {
-    margin-left: 220px;
+    margin-left: 230px;
 }
 
 a {
@@ -254,18 +292,18 @@ a {
     margin-top: 5px;
     padding: 10px 16px;
     font-size: 17px;
-    font-weight: 300;
     box-shadow: 0 0 0 1px #e0e0e0, 0 0 0 2px transparent;
-    transition: background-color 50ms linear;
-    transition: border 500ms ease-out;
-    transition: box-shadow 500ms ease-out;
+    transition: border-color 300ms ease;
+    transition: border-radius 300ms ease-in-out;
+    transition: box-shadow 300ms ease-in-out;
 }
 
 .search-input:focus {
     border-color: #66afe9;
+    border-radius: 2px;
     border: 0;
     outline: 0;
-    box-shadow: 0 0 0 1px #078dd8, 0 0 0 2px #078dd8;
+    box-shadow: 0 0 8px #078dd8;
 }
 
 .search-results .desc {
@@ -327,7 +365,7 @@ a {
 
 :target { background: #FDFFD3; }
 
-pre.rust, pre.line-numbers { background-color: #FDFDFD; }
+pre.rust, pre.line-numbers { background-color: #F5F5F5; }
 
 /* Code highlighting */
 pre.rust .kw { color: #8959A8; }
@@ -361,7 +399,6 @@ h6.section-link:hover a:after {
     }
 
     nav.sub {
-        width: 85.5%;
         margin: 0 auto;
     }
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -30,20 +30,26 @@ body {
     padding-bottom: 20px;
 }
 
-h1, .sidebar .location {
-    font: 700 22px "Oswald", Arial, sans-serif;
-}
-h2, h3, h4 {
-    font: 700 16px "Oswald", Arial, sans-serif;
-    text-transform: uppercase;
-}
 h2 code, h3 code, h4 code {
     text-transform: none;
     font-size: 1.2em;
 }
 
+h1 {
+    font: 600 26px "Helvetica Neue", Arial, sans-serif !important;
+    margin: 20px 0;
+}
+
+h2, h3, h4 {
+    font: 500 20px "Helvetica Neue", Arial, sans-serif;
+    margin: 40px 0 20px 0;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #DDDDDD;
+}
+
 code, pre, h1.fqn {
     font-family: "Inconsolata", Menlo, Monaco, Consolas, "DejaVu Sans Mono", monospace;
+    font-weight: normal;
 }
 code, pre {
     color: #333;
@@ -54,6 +60,8 @@ pre {
 h1.fqn {
     font-size: 26px;
     font-weight: normal;
+    padding-bottom: 15px;
+    border-bottom: 1px dashed #D5D5D5;
 }
 
 nav {
@@ -81,7 +89,6 @@ nav.sub {
 .js-only, .hidden { display: none; }
 
 .sidebar {
-    background: #e9e9e9;
     padding: 10px;
 }
 .sidebar img {
@@ -89,34 +96,59 @@ nav.sub {
     display: block;
 }
 
-.sidebar .location { margin-bottom: 10px; }
+.sidebar .location {
+    font-size: 17px;
+    margin: 30px 0 20px 0;
+    background: #e1e1e1;
+    text-align: center;
+    color: #333;
+}
+
+.sidebar .location a {
+    color: #333;
+}
+
 .sidebar .block, pre { background: #fff; }
-.sidebar .block, pre, .content { border-bottom: 2px solid black; }
-.trait { border-color: #fcae2b !important; }
-.mod { border-color: #809fc7 !important; }
-.enum { border-color: #93bc99 !important; }
-.struct { border-color: #e53700 !important; }
-.fn { border-color: #a2777f !important; }
 
 .block {
     padding: 10px;
     margin-bottom: 10px;
 }
-.block h2 { margin-top: 0; }
+.block h2 { 
+    margin-top: 0;
+    text-align: center;
+}
+
 .block a {
     display: inline-block;
-    width: 100%;
     text-overflow: ellipsis;
     overflow: hidden;
     line-height: 15px;
+    margin: 0 0 0 45px;
+    padding-bottom: 4px;
+    border-bottom: 2px solid #fff;
+    font-size: 14px;
+
+    transition: border 500ms ease-out;
+    -webkit-transition: border 500ms ease-out;
+    -moz-transition: border 500ms ease-out;
+    -o-transition: border 500ms ease-out;
+}
+
+body p {
+    font-size: 15px;
+    line-height: 1.6;
 }
 
 .content {
-    background: #f3f3f3;
     padding: 20px 20px 20px 40px;
 }
-.content h1 { margin-top: 0; }
-.content h1, .content h2 { margin-left: -20px; }
+
+.content h1 { 
+    margin-top: 0;
+    font-weight: 400 !important;
+}
+
 .content pre { padding: 20px; }
 .content.source pre.rust {
     white-space: pre;
@@ -155,12 +187,31 @@ nav.sub {
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
     margin-left: 0;
+    margin: 40px 0 10px 0;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #eee;
 }
+
 .docblock h1 { font-size: 1.1em; }
 .docblock h2 { font-size: 1.05em; }
 .docblock h3, .docblock h4, .docblock h5 { font-size: 1em; }
 
-.content .source { float: right; }
+.docblock h3 {
+    font-size: 1.3em;
+}
+
+.docblock h2 {
+    font-size: 1.5em;
+}
+
+.content .source { 
+    float: right;
+    font-size: 14px;
+    font-weight: 400;
+    padding: 9px 15px;
+    color: #333;
+}
+
 .content table {
     border-spacing: 0 5px;
     border-collapse: separate;
@@ -224,7 +275,7 @@ a {
     background: transparent;
 }
 
-.content a, .block a.current { font-weight: bold; }
+.content a, .block a.current { font-weight: 400; }
 
 .content a.trait, .block a.current.trait { color: #ed9603; }
 .content a.mod, .block a.current.mod { color: #4d76ae; }
@@ -235,16 +286,59 @@ a {
 
 .search-container {
     padding-right: 10px;
-    overflow: hidden;
 }
 .search-input {
     border: 2px solid #e9e9e9;
     border-radius: 2px;
-    width: 100%;
+    width: 85%;
+    box-sizing: content-box;
+    outline: none;
+    border: none;
+    background: none;
+    font-family: "Helvetica Neue";
+    color: #000;
+    margin-top: 5px;
+    padding: 10px 20px;
+    font-weight: 300;
+    border-radius: 1px;
+    box-shadow: 0 0 0 1px #e0e0e0, 0 0 0 2px transparent;
+    color: #555555;
+    padding: 10px 16px;
+    line-height: 1.4;
+    font-size: 17px;
+    background-color: white;
+    -webkit-transition: background-color 50ms linear;
+    transition: background-color 50ms linear;
+    transition: border 500ms ease-out;
+    -webkit-transition: border 500ms ease-out;
+    -moz-transition: border 500ms ease-out;
+    -o-transition: border 500ms ease-out;
+    transition: box-shadow 500ms ease-out;
+    -webkit-transition: box-shadow 500ms ease-out;
+    -moz-transition: box-shadow 500ms ease-out;
+    -o-transition: box-shadow 500ms ease-out;
 }
+
+.search-input:focus {
+    border-color: #66afe9;
+    border: 0;
+    outline: 0;
+    box-shadow: 0 0 0 1px #078dd8, 0 0 0 2px #078dd8;
+}
+
 .do-search {
     float: right;
-    width: 62px;
+    outline: none;
+    border: none;
+    font-family: Helvetica Neue;
+    font-weight: 200;
+    color: #fff;
+    padding: 14px 25px;
+    margin-top: 3px;
+    font-size: 16px;
+    margin-right: 15px;
+    text-align: center;
+    background: #6F5E59;
 }
 .search-results .desc {
     white-space: nowrap;
@@ -288,13 +382,16 @@ a {
 }
 
 .stability {
-    border-left: 5px solid #000;
+    border-left: 6px solid #000;
     border-radius: 3px;
-    padding: 0 3px;
-    float: right;
+    padding: 8px 3px;
     background: #fff;
     text-transform: lowercase;
+    display: block;
+    padding-left: 10px;
+    margin-bottom: 20px;
 }
+
 .stability.Deprecated { border-color: #D60027; color: #880017; }
 .stability.Experimental { border-color: #EC5315; color: #a53c0e; }
 .stability.Unstable { border-color: #FFD700; color: #b39800; }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -20,54 +20,42 @@
 /* General structure and fonts */
 
 body {
+    color: #333;
     min-height: 100%;
     min-width: 500px;
     height: 100%;
-    font: 13px "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 165%;
+    font: 15px "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 150%;
     position: relative;
     height: auto;
     padding-bottom: 20px;
 }
 
+h1, h2, h3, h4 {
+    color: black;
+    font-weight: 500;
+    margin: 30px 0 20px 0;
+    padding-bottom: 15px;
+}
+h1.fqn {
+    border-bottom: 1px dashed #D5D5D5;
+    margin-top: 0;
+}
+h2, h3, h4 {
+    border-bottom: 1px solid #DDDDDD;
+}
 h2 code, h3 code, h4 code {
-    text-transform: none;
+
     font-size: 1.2em;
 }
 
-h1 {
-    font: 600 26px "Helvetica Neue", Arial, sans-serif !important;
-    margin: 20px 0;
-}
-
-h2, h3, h4 {
-    font: 500 20px "Helvetica Neue", Arial, sans-serif;
-    margin: 40px 0 20px 0;
-    padding-bottom: 15px;
-    border-bottom: 1px solid #DDDDDD;
-}
-
-code, pre, h1.fqn {
-    font-family: "Inconsolata", Menlo, Monaco, Consolas, "DejaVu Sans Mono", monospace;
-    font-weight: normal;
-}
 code, pre {
-    color: #333;
+    font-family: "Inconsolata", Menlo, Monaco, Consolas, "DejaVu Sans Mono", monospace;
 }
 pre {
     font-size: 15px;
 }
-h1.fqn {
-    font-size: 26px;
-    font-weight: normal;
-    padding-bottom: 15px;
-    border-bottom: 1px dashed #D5D5D5;
-}
 
-nav {
-    font: 700 26px "Oswald", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    text-transform: uppercase;
-}
 nav.sub {
     padding-top: 10px;
     font-size: 16px;
@@ -104,10 +92,6 @@ nav.sub {
     color: #333;
 }
 
-.sidebar .location a {
-    color: #333;
-}
-
 .sidebar .block, pre { background: #fff; }
 
 .block {
@@ -124,26 +108,14 @@ nav.sub {
     text-overflow: ellipsis;
     overflow: hidden;
     line-height: 15px;
-    margin: 0 0 0 45px;
-    padding-bottom: 4px;
-    border-bottom: 2px solid #fff;
+    padding-left: 5px;
+    padding-bottom: 6px;
     font-size: 14px;
-
     transition: border 500ms ease-out;
 }
 
-body p {
-    font-size: 15px;
-    line-height: 1.6;
-}
-
 .content {
-    padding: 20px 20px 20px 40px;
-}
-
-.content h1 { 
-    margin-top: 0;
-    font-weight: 400 !important;
+    padding: 20px 40px;
 }
 
 .content pre { padding: 20px; }
@@ -186,27 +158,17 @@ body p {
     margin-left: 0;
     margin: 40px 0 10px 0;
     padding-bottom: 10px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #DDD;
 }
 
-.docblock h1 { font-size: 1.1em; }
-.docblock h2 { font-size: 1.05em; }
+.docblock h1 { font-size: 1.3em; }
+.docblock h2 { font-size: 1.15em; }
 .docblock h3, .docblock h4, .docblock h5 { font-size: 1em; }
-
-.docblock h3 {
-    font-size: 1.3em;
-}
-
-.docblock h2 {
-    font-size: 1.5em;
-}
 
 .content .source { 
     float: right;
-    font-size: 14px;
-    font-weight: 400;
+    font-weight: 500;
     padding: 9px 15px;
-    color: #333;
 }
 
 .content table {
@@ -263,7 +225,6 @@ nav.sub form { display: inline; }
 
 nav, .content {
     margin-left: 220px;
-    margin-right: 20px;
 }
 
 a {
@@ -272,8 +233,6 @@ a {
     background: transparent;
 }
 
-.content a, .block a.current { font-weight: 400; }
-
 .content a.trait, .block a.current.trait { color: #ed9603; }
 .content a.mod, .block a.current.mod { color: #4d76ae; }
 .content a.enum, .block a.current.enum { color: #5e9766; }
@@ -281,31 +240,22 @@ a {
 .content a.fn, .block a.current.fn { color: #8c6067; }
 .content .fnname { color: #8c6067; }
 
-.search-container {
-    width: 60%;
-    margin-left: 50px;
-}
-
 .search-input {
-    border: 2px solid #e9e9e9;
-    border-radius: 2px;
-    width: 95%;
-    box-sizing: content-box;
+    width: 100%;
+    /* Override Normalize.css: we have margins and do
+     not want to overflow - the `moz` attribute is necessary
+     until Firefox 29, too early to drop at this point */
+    -moz-box-sizing: border-box !important;
+    box-sizing: border-box !important;
     outline: none;
     border: none;
-    background-color: white;
-    font-family: "Helvetica Neue";
-    color: #000;
-    margin-top: 5px;
-    padding: 10px 20px;
-    font-weight: 300;
     border-radius: 1px;
-    box-shadow: 0 0 0 1px #e0e0e0, 0 0 0 2px transparent;
-    color: #555555;
+    color: #555;
+    margin-top: 5px;
     padding: 10px 16px;
-    line-height: 1.4;
     font-size: 17px;
-
+    font-weight: 300;
+    box-shadow: 0 0 0 1px #e0e0e0, 0 0 0 2px transparent;
     transition: background-color 50ms linear;
     transition: border 500ms ease-out;
     transition: box-shadow 500ms ease-out;
@@ -316,21 +266,6 @@ a {
     border: 0;
     outline: 0;
     box-shadow: 0 0 0 1px #078dd8, 0 0 0 2px #078dd8;
-}
-
-.do-search {
-    display: none;
-    outline: none;
-    border: none;
-    font-family: Helvetica Neue;
-    font-weight: 200;
-    color: #fff;
-    padding: 14px 25px;
-    margin-top: 3px;
-    font-size: 16px;
-    text-align: center;
-    background: #5B6672;
-    margin-left: 10px;
 }
 
 .search-results .desc {
@@ -377,11 +312,9 @@ a {
 .stability {
     border-left: 6px solid #000;
     border-radius: 3px;
-    padding: 8px 3px;
-    background: #fff;
+    padding: 8px 3px 8px 10px;
     text-transform: lowercase;
     display: block;
-    padding-left: 10px;
     margin-bottom: 20px;
 }
 
@@ -418,14 +351,6 @@ h6.section-link:hover a:after {
 
 /** Media Queries **/
 
-@media (max-width: 620px) {
-  .search-container {
-    display: block;
-    width: 100%;
-    margin-left: 0px;
-  }
-}
-
 @media (max-width: 700px) {
     .sidebar {
         display: none;
@@ -436,7 +361,7 @@ h6.section-link:hover a:after {
     }
 
     nav.sub {
-        width: 80%;
+        width: 85.5%;
         margin: 0 auto;
     }
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -130,9 +130,6 @@ nav.sub {
     font-size: 14px;
 
     transition: border 500ms ease-out;
-    -webkit-transition: border 500ms ease-out;
-    -moz-transition: border 500ms ease-out;
-    -o-transition: border 500ms ease-out;
 }
 
 body p {
@@ -285,16 +282,18 @@ a {
 .content .fnname { color: #8c6067; }
 
 .search-container {
-    padding-right: 10px;
+    width: 60%;
+    margin-left: 50px;
 }
+
 .search-input {
     border: 2px solid #e9e9e9;
     border-radius: 2px;
-    width: 85%;
+    width: 95%;
     box-sizing: content-box;
     outline: none;
     border: none;
-    background: none;
+    background-color: white;
     font-family: "Helvetica Neue";
     color: #000;
     margin-top: 5px;
@@ -306,17 +305,10 @@ a {
     padding: 10px 16px;
     line-height: 1.4;
     font-size: 17px;
-    background-color: white;
-    -webkit-transition: background-color 50ms linear;
+
     transition: background-color 50ms linear;
     transition: border 500ms ease-out;
-    -webkit-transition: border 500ms ease-out;
-    -moz-transition: border 500ms ease-out;
-    -o-transition: border 500ms ease-out;
     transition: box-shadow 500ms ease-out;
-    -webkit-transition: box-shadow 500ms ease-out;
-    -moz-transition: box-shadow 500ms ease-out;
-    -o-transition: box-shadow 500ms ease-out;
 }
 
 .search-input:focus {
@@ -327,7 +319,7 @@ a {
 }
 
 .do-search {
-    float: right;
+    display: none;
     outline: none;
     border: none;
     font-family: Helvetica Neue;
@@ -336,10 +328,11 @@ a {
     padding: 14px 25px;
     margin-top: 3px;
     font-size: 16px;
-    margin-right: 15px;
     text-align: center;
-    background: #6F5E59;
+    background: #5B6672;
+    margin-left: 10px;
 }
+
 .search-results .desc {
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -421,4 +414,29 @@ h4.section-link:hover a:after,
 h5.section-link:hover a:after,
 h6.section-link:hover a:after {
   content: ' § ';
+}
+
+/** Media Queries **/
+
+@media (max-width: 620px) {
+  .search-container {
+    display: block;
+    width: 100%;
+    margin-left: 0px;
+  }
+}
+
+@media (max-width: 700px) {
+    .sidebar {
+        display: none;
+    }
+
+    .content {
+        margin-left: 0px;
+    }
+
+    nav.sub {
+        width: 80%;
+        margin: 0 auto;
+    }
 }


### PR DESCRIPTION
- Cherry-pick from #12996
- Use Fira Sans for headlines and sidebar (Light), Heuristica for the body (Adobe Utopia derivative). Both are licensed under the SIL OFL license.
- A few tweaks

Two examples: [modified `std`](http://adrientetar.legtux.org/cached/rust-docs/std.htm) and [modified `std::io`](http://adrientetar.legtux.org/cached/rust-docs/io.htm).

cc #13484
**Blocked on graydon/rust-www#25 (for hosting of the fonts), that's showcased [here](http://adrientetar.github.io/rust-www/).**

cc @brson, @TheHydroImpulse
