### PR TITLE
Make `--crate-file-name` obey `--crate-type`

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3920,7 +3920,9 @@ link Rust crates together, and more information about native libraries can be
 found in the [ffi tutorial][ffi].
 
 In one session of compilation, the compiler can generate multiple artifacts
-through the usage of command line flags and the `crate_type` attribute.
+through the usage of either command line flags or the `crate_type` attribute.
+If one or more command line flag is specified, all `crate_type` attributes will
+be ignored in favor of only building the artifacts specified by command line.
 
 * `--crate-type=bin`, `#[crate_type = "bin"]` - A runnable executable will be
   produced.  This requires that there is a `main` function in the crate which
@@ -3963,7 +3965,10 @@ through the usage of command line flags and the `crate_type` attribute.
 
 Note that these outputs are stackable in the sense that if multiple are
 specified, then the compiler will produce each form of output at once without
-having to recompile.
+having to recompile. However, this only applies for outputs specified by the same
+method. If only `crate_type` attributes are specified, then they will all be
+built, but if one or more `--crate-type` command line flag is specified,
+then only those outputs will be built.
 
 With all these different kinds of outputs, if crate A depends on crate B, then
 the compiler could find B in various different forms throughout the system. The

--- a/src/test/run-make/obey-crate-type-flag/Makefile
+++ b/src/test/run-make/obey-crate-type-flag/Makefile
@@ -1,0 +1,13 @@
+-include ../tools.mk
+
+# check that rustc builds all crate_type attributes
+# delete rlib
+# delete whatever dylib is made for this system
+# check that rustc only builds --crate-type flags, ignoring attributes
+# fail if an rlib was built
+all:
+	$(RUSTC) test.rs
+	rm $(TMPDIR)/libtest*.rlib
+	rm $(TMPDIR)/libtest*
+	$(RUSTC) --crate-type dylib test.rs
+	rm $(TMPDIR)/libtest*.rlib && exit 1 || exit 0

--- a/src/test/run-make/obey-crate-type-flag/test.rs
+++ b/src/test/run-make/obey-crate-type-flag/test.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+#![crate_type = "dylib"]
+


### PR DESCRIPTION
Before, the `--crate-file-name` flag only checked crate attributes for
possible crate types. Now, if any type is specified by one or more
`--crate-type` flags, only the filenames for those types will be
emitted, and any types specified by crate attributes will be ignored.
