### PR TITLE
rustc: Don't link in syntax extensions

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -310,10 +310,10 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     time(time_passes, "looking for entry point", (),
          |_| middle::entry::find_entry_point(&sess, krate, &ast_map));
 
-    *sess.macro_registrar_fn.borrow_mut() =
+    sess.macro_registrar_fn.set(
         time(time_passes, "looking for macro registrar", (), |_|
             syntax::ext::registrar::find_macro_registrar(
-                sess.diagnostic(), krate));
+                sess.diagnostic(), krate)));
 
     let freevars = time(time_passes, "freevar finding", (), |_|
                         freevars::annotate_freevars(def_map, krate));
@@ -1054,7 +1054,7 @@ pub fn build_session_(sopts: session::Options,
         // For a library crate, this is always none
         entry_fn: RefCell::new(None),
         entry_type: Cell::new(None),
-        macro_registrar_fn: RefCell::new(None),
+        macro_registrar_fn: Cell::new(None),
         default_sysroot: default_sysroot,
         building_library: Cell::new(false),
         local_crate_source_file: local_crate_source_file,

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -181,7 +181,7 @@ pub struct Session {
     // For a library crate, this is always none
     pub entry_fn: RefCell<Option<(NodeId, codemap::Span)>>,
     pub entry_type: Cell<Option<EntryFnType>>,
-    pub macro_registrar_fn: RefCell<Option<ast::DefId>>,
+    pub macro_registrar_fn: Cell<Option<ast::NodeId>>,
     pub default_sysroot: Option<Path>,
     pub building_library: Cell<bool>,
     // The name of the root source file of the crate, in the local file system. The path is always

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -279,7 +279,7 @@ pub fn get_trait_of_method(cstore: &cstore::CStore,
 
 pub fn get_macro_registrar_fn(cstore: &cstore::CStore,
                               crate_num: ast::CrateNum)
-                              -> Option<ast::DefId> {
+                              -> Option<ast::NodeId> {
     let cdata = cstore.get_crate_data(crate_num);
     decoder::get_macro_registrar_fn(cdata)
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1235,9 +1235,9 @@ pub fn get_native_libraries(cdata: Cmd) -> Vec<(cstore::NativeLibaryKind, ~str)>
     return result;
 }
 
-pub fn get_macro_registrar_fn(cdata: Cmd) -> Option<ast::DefId> {
+pub fn get_macro_registrar_fn(cdata: Cmd) -> Option<ast::NodeId> {
     reader::maybe_get_doc(reader::Doc(cdata.data()), tag_macro_registrar_fn)
-        .map(|doc| item_def_id(doc, cdata))
+        .map(|doc| FromPrimitive::from_u32(reader::doc_as_u32(doc)).unwrap())
 }
 
 pub fn get_exported_macros(cdata: Cmd) -> Vec<~str> {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1565,12 +1565,8 @@ fn encode_native_libraries(ecx: &EncodeContext, ebml_w: &mut Encoder) {
 }
 
 fn encode_macro_registrar_fn(ecx: &EncodeContext, ebml_w: &mut Encoder) {
-    match *ecx.tcx.sess.macro_registrar_fn.borrow() {
-        Some(did) => {
-            ebml_w.start_tag(tag_macro_registrar_fn);
-            encode_def_id(ebml_w, did);
-            ebml_w.end_tag();
-        }
+    match ecx.tcx.sess.macro_registrar_fn.get() {
+        Some(id) => { ebml_w.wr_tagged_u32(tag_macro_registrar_fn, id); }
         None => {}
     }
 }

--- a/src/libsyntax/ext/registrar.rs
+++ b/src/libsyntax/ext/registrar.rs
@@ -36,7 +36,7 @@ impl Visitor<()> for MacroRegistrarContext {
 }
 
 pub fn find_macro_registrar(diagnostic: &diagnostic::SpanHandler,
-                            krate: &ast::Crate) -> Option<ast::DefId> {
+                            krate: &ast::Crate) -> Option<ast::NodeId> {
     let mut ctx = MacroRegistrarContext { registrars: Vec::new() };
     visit::walk_crate(&mut ctx, krate, ());
 
@@ -44,10 +44,7 @@ pub fn find_macro_registrar(diagnostic: &diagnostic::SpanHandler,
         0 => None,
         1 => {
             let (node_id, _) = ctx.registrars.pop().unwrap();
-            Some(ast::DefId {
-                krate: ast::LOCAL_CRATE,
-                node: node_id
-            })
+            Some(node_id)
         },
         _ => {
             diagnostic.handler().err("multiple macro registration functions found");

--- a/src/test/run-make/lto-syntax-extension/Makefile
+++ b/src/test/run-make/lto-syntax-extension/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) lib.rs
+	$(RUSTC) main.rs -Z lto
+	$(call RUN,main)

--- a/src/test/run-make/lto-syntax-extension/lib.rs
+++ b/src/test/run-make/lto-syntax-extension/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[crate_type = "rlib"];

--- a/src/test/run-make/lto-syntax-extension/main.rs
+++ b/src/test/run-make/lto-syntax-extension/main.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(phase)]
+
+extern crate lib;
+#[phase(syntax)] extern crate fourcc;
+
+fn main() {
+    fourcc!("1234");
+}


### PR DESCRIPTION
This bug was introduced in #13384 by accident, and this commit continues the
work of #13384 by finishing support for loading a syntax extension crate without
registering it with the local cstore.

Closes #13495
