### PR TITLE
Replace 'region' with 'lifetime' in a few transmute function names

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -70,7 +70,7 @@ use std::cast;
 let mut x: u8 = 1;
 
 let ref_1: &mut u8 = &mut x;
-let ref_2: &mut u8 = unsafe { cast::transmute_mut_region(ref_1) };
+let ref_2: &mut u8 = unsafe { cast::transmute_mut_lifetime(ref_1) };
 
 // oops, ref_1 and ref_2 point to the same piece of data (x) and are
 // both usable

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -26,7 +26,7 @@
 
 extern crate collections;
 
-use std::cast::{transmute, transmute_mut, transmute_mut_region};
+use std::cast::{transmute, transmute_mut, transmute_mut_lifetime};
 use std::cast;
 use std::cell::{Cell, RefCell};
 use std::mem;
@@ -186,7 +186,7 @@ impl Arena {
     #[inline]
     fn alloc_copy_inner(&mut self, n_bytes: uint, align: uint) -> *u8 {
         unsafe {
-            let this = transmute_mut_region(self);
+            let this = transmute_mut_lifetime(self);
             let start = round_up(this.copy_head.fill.get(), align);
             let end = start + n_bytes;
             if end > self.chunk_size() {
@@ -233,7 +233,7 @@ impl Arena {
             let after_tydesc;
 
             {
-                let head = transmute_mut_region(&mut self.head);
+                let head = transmute_mut_lifetime(&mut self.head);
 
                 tydesc_start = head.fill.get();
                 after_tydesc = head.fill.get() + mem::size_of::<*TyDesc>();
@@ -245,7 +245,7 @@ impl Arena {
                 return self.alloc_noncopy_grow(n_bytes, align);
             }
 
-            let head = transmute_mut_region(&mut self.head);
+            let head = transmute_mut_lifetime(&mut self.head);
             head.fill.set(round_up(end, mem::pref_align_of::<*TyDesc>()));
 
             //debug!("idx = {}, size = {}, align = {}, fill = {}",

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -630,7 +630,7 @@ impl Scheduler {
         unsafe {
 
             let sched: &mut Scheduler =
-                cast::transmute_mut_region(*next_task.sched.get_mut_ref());
+                cast::transmute_mut_lifetime(*next_task.sched.get_mut_ref());
 
             let current_task: &mut GreenTask = match sched.cleanup_job {
                 Some(CleanupJob { task: ref mut task, .. }) => &mut **task,
@@ -681,8 +681,8 @@ impl Scheduler {
         let next_task_context =
                 &mut next_task.coroutine.get_mut_ref().saved_context;
         unsafe {
-            (cast::transmute_mut_region(current_task_context),
-             cast::transmute_mut_region(next_task_context))
+            (cast::transmute_mut_lifetime(current_task_context),
+             cast::transmute_mut_lifetime(next_task_context))
         }
     }
 

--- a/src/libstd/cast.rs
+++ b/src/libstd/cast.rs
@@ -63,9 +63,9 @@ pub unsafe fn transmute<L, G>(thing: L) -> G {
 #[inline]
 pub unsafe fn transmute_mut<'a,T>(ptr: &'a T) -> &'a mut T { transmute(ptr) }
 
-/// Coerce a reference to have an arbitrary associated region.
+/// Coerce a reference to have an arbitrary associated lifetime.
 #[inline]
-pub unsafe fn transmute_region<'a,'b,T>(ptr: &'a T) -> &'b T {
+pub unsafe fn transmute_lifetime<'a,'b,T>(ptr: &'a T) -> &'b T {
     transmute(ptr)
 }
 
@@ -75,28 +75,28 @@ pub unsafe fn transmute_mut_unsafe<T>(ptr: *T) -> *mut T {
     transmute(ptr)
 }
 
-/// Coerce a mutable reference to have an arbitrary associated region.
+/// Coerce a mutable reference to have an arbitrary associated lifetime.
 #[inline]
-pub unsafe fn transmute_mut_region<'a,'b,T>(ptr: &'a mut T) -> &'b mut T {
+pub unsafe fn transmute_mut_lifetime<'a,'b,T>(ptr: &'a mut T) -> &'b mut T {
     transmute(ptr)
 }
 
 /// Transforms lifetime of the second pointer to match the first.
 #[inline]
 pub unsafe fn copy_lifetime<'a,S,T>(_ptr: &'a S, ptr: &T) -> &'a T {
-    transmute_region(ptr)
+    transmute_lifetime(ptr)
 }
 
 /// Transforms lifetime of the second pointer to match the first.
 #[inline]
 pub unsafe fn copy_mut_lifetime<'a,S,T>(_ptr: &'a mut S, ptr: &mut T) -> &'a mut T {
-    transmute_mut_region(ptr)
+    transmute_mut_lifetime(ptr)
 }
 
 /// Transforms lifetime of the second pointer to match the first.
 #[inline]
 pub unsafe fn copy_lifetime_vec<'a,S,T>(_ptr: &'a [S], ptr: &T) -> &'a T {
-    transmute_region(ptr)
+    transmute_lifetime(ptr)
 }
 
 


### PR DESCRIPTION
Regions were renamed to lifetimes a while back, so these functions should probably be renamed as well.
