### PR TITLE
Combine lifetime parameters when instantiating default methods

### DIFF
--- a/src/test/run-pass/issue-13204.rs
+++ b/src/test/run-pass/issue-13204.rs
@@ -1,0 +1,32 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that when instantiating trait default methods, typeck handles
+// lifetime parameters defined on the method bound correctly.
+
+pub trait Foo {
+    fn bar<'a, I: Iterator<&'a ()>>(&self, it: I) -> uint {
+        let mut xs = it.filter(|_| true);
+        xs.len()
+    }
+}
+
+pub struct Baz;
+
+impl Foo for Baz {
+    // When instantiating `Foo::bar` for `Baz` here, typeck used to
+    // ICE due to the lifetime parameter of `bar`.
+}
+
+fn main() {
+    let x = Baz;
+    let y = vec!((), (), ());
+    assert_eq!(x.bar(y.iter()), 3);
+}


### PR DESCRIPTION
When instantiating trait default methods for certain implementation,
`typeck` correctly combined type parameters from trait bound with those
from method bound, but didn't do so for lifetime parameters. Applies
the same logic to lifetime parameters.

Closes #13204
