### PR TITLE
liburl doc: insert missing hyphen

### DIFF
--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -194,7 +194,7 @@ pub fn encode(s: &str) -> ~str {
 }
 
 /**
- * Encodes a URI component by replacing reserved characters with percent
+ * Encodes a URI component by replacing reserved characters with percent-
  * encoded character sequences.
  *
  * This function is compliant with RFC 3986.


### PR DESCRIPTION
"percent-encoded", like in the docs for `encode` above.
