### PR TITLE
mk: Change windows to install from stage2

### DIFF
--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -20,13 +20,7 @@
 #   PREPARE_TARGETS - the target triples, space separated
 #   PREPARE_DEST_DIR - the directory to put the image
 
-
-# On windows we install from stage3, but on unix only stage2
-ifdef CFG_WINDOWSY_$(CFG_BUILD)
-PREPARE_STAGE=3
-else
 PREPARE_STAGE=2
-endif
 
 DEFAULT_PREPARE_DIR_CMD = umask 022 && mkdir -p
 DEFAULT_PREPARE_BIN_CMD = install -m755


### PR DESCRIPTION
In the past, windows was installed from stage3 to guarantee convergence between
the host and target artifacts, but syntax extensions on all platforms are
currently relying on convergence, so special casing this one platform has become
less relevant over time.

This will also have the added benefit of dealing with #13474 and #13491. These
issues will be closed after next next nightly is confirmed to fix them.
