### PR TITLE
Update GitHub's Rust projects page.

### DIFF
--- a/src/doc/complement-lang-faq.md
+++ b/src/doc/complement-lang-faq.md
@@ -27,7 +27,7 @@ Some examples that demonstrate different aspects of the language:
 
 You may also be interested in browsing [GitHub's Rust][github-rust] page.
 
-[github-rust]: https://github.com/languages/Rust
+[github-rust]: https://github.com/trending?l=rust
 
 ## Does it run on Windows?
 


### PR DESCRIPTION
The old link is broken.
