### PR TITLE
Change AUTHORS section in the man pages

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -182,8 +182,7 @@ rustdoc
 See <\fBhttps://github.com/mozilla/rust/issues\fR> for issues.
 
 .SH "AUTHOR"
-See \fBAUTHORS.txt\fR in the rust source distribution. Graydon Hoare
-<\fIgraydon@mozilla.com\fR> is the project leader.
+See \fBAUTHORS.txt\fR in the Rust source distribution.
 
 .SH "COPYRIGHT"
 This work is dual-licensed under Apache 2.0 and MIT terms.  See \fBCOPYRIGHT\fR

--- a/man/rustdoc.1
+++ b/man/rustdoc.1
@@ -90,8 +90,7 @@ rustc
 See <\fBhttps://github.com/mozilla/rust/issues\fR> for issues.
 
 .SH "AUTHOR"
-See \fBAUTHORS.txt\fR in the rust source distribution. Graydon Hoare
-<\fIgraydon@mozilla.com\fR> is the project leader.
+See \fBAUTHORS.txt\fR in the Rust source distribution.
 
 .SH "COPYRIGHT"
 This work is dual-licensed under Apache 2.0 and MIT terms.  See \fBCOPYRIGHT\fR


### PR DESCRIPTION
The man pages no longer contain Graydon Hoare as the project lead.

Fix #13509.
