### PR TITLE
Remove RUST_LOG="::help" from the docs

### DIFF
--- a/src/doc/complement-lang-faq.md
+++ b/src/doc/complement-lang-faq.md
@@ -141,8 +141,14 @@ export RUST_LOG=hello
 ./hello
 ```
 
-**Long answer** RUST_LOG takes a 'logging spec' that consists of a comma-separated list of paths, where a path consists of the crate name and sequence of module names, each separated by double-colons. For standalone .rs files the crate is implicitly named after the source file, so in the above example we were setting RUST_LOG to the name of the hello crate. Multiple paths can be combined to control the exact logging you want to see. For example, when debugging linking in the compiler you might set `RUST_LOG=rustc::metadata::creader,rustc::util::filesearch,rustc::back::rpath`
-
-If you aren't sure which paths you need, try setting RUST_LOG to `::help` and running your program. This will print a list of paths available for logging. For a full description see [the language reference][1].
+**Long answer** RUST_LOG takes a 'logging spec' that consists of a
+comma-separated list of paths, where a path consists of the crate name and
+sequence of module names, each separated by double-colons. For standalone .rs
+files the crate is implicitly named after the source file, so in the above
+example we were setting RUST_LOG to the name of the hello crate. Multiple paths
+can be combined to control the exact logging you want to see. For example, when
+debugging linking in the compiler you might set
+`RUST_LOG=rustc::metadata::creader,rustc::util::filesearch,rustc::back::rpath`
+For a full description see [the language reference][1].
 
 [1]:http://doc.rust-lang.org/doc/master/rust.html#logging-system

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -4051,10 +4051,6 @@ crate name the crate is given a default name that matches the source file,
 with the extension removed. In that case, to turn on logging for a program
 compiled from, e.g. `helloworld.rs`, `RUST_LOG` should be set to `helloworld`.
 
-As a convenience, the logging spec can also be set to a special pseudo-crate,
-`::help`. In this case, when the application starts, the runtime will
-simply output a list of loaded modules containing log expressions, then exit.
-
 #### Logging Expressions
 
 Rust provides several macros to log information. Here's a simple Rust program


### PR DESCRIPTION
This feature is no longer present in the current version, it was removed along
with the crate map.
