### PR TITLE
syntax: unify all MacResult's into a single trait.

### DIFF
--- a/src/libfourcc/lib.rs
+++ b/src/libfourcc/lib.rs
@@ -57,7 +57,7 @@ use syntax::ast::Name;
 use syntax::attr::contains;
 use syntax::codemap::{Span, mk_sp};
 use syntax::ext::base;
-use syntax::ext::base::{SyntaxExtension, BasicMacroExpander, NormalTT, ExtCtxt, MRExpr};
+use syntax::ext::base::{SyntaxExtension, BasicMacroExpander, NormalTT, ExtCtxt, MacExpr};
 use syntax::ext::build::AstBuilder;
 use syntax::parse;
 use syntax::parse::token;
@@ -73,7 +73,7 @@ pub fn macro_registrar(register: |Name, SyntaxExtension|) {
         None));
 }
 
-pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> base::MacResult {
+pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> ~base::MacResult {
     let (expr, endian) = parse_tts(cx, tts);
 
     let little = match endian {
@@ -101,12 +101,12 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> 
             }
             _ => {
                 cx.span_err(expr.span, "unsupported literal in fourcc!");
-                return MRExpr(cx.expr_lit(sp, ast::LitUint(0u64, ast::TyU32)));
+                return base::DummyResult::expr(sp)
             }
         },
         _ => {
             cx.span_err(expr.span, "non-literal in fourcc!");
-            return MRExpr(cx.expr_lit(sp, ast::LitUint(0u64, ast::TyU32)));
+            return base::DummyResult::expr(sp)
         }
     };
 
@@ -126,7 +126,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> 
         };
     }
     let e = cx.expr_lit(sp, ast::LitUint(val as u64, ast::TyU32));
-    MRExpr(e)
+    MacExpr::new(e)
 }
 
 struct Ident {

--- a/src/libhexfloat/lib.rs
+++ b/src/libhexfloat/lib.rs
@@ -53,7 +53,7 @@ use syntax::ast;
 use syntax::ast::Name;
 use syntax::codemap::{Span, mk_sp};
 use syntax::ext::base;
-use syntax::ext::base::{SyntaxExtension, BasicMacroExpander, NormalTT, ExtCtxt, MRExpr};
+use syntax::ext::base::{SyntaxExtension, BasicMacroExpander, NormalTT, ExtCtxt, MacExpr};
 use syntax::ext::build::AstBuilder;
 use syntax::parse;
 use syntax::parse::token;
@@ -97,7 +97,7 @@ fn hex_float_lit_err(s: &str) -> Option<(uint, ~str)> {
     }
 }
 
-pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> base::MacResult {
+pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> ~base::MacResult {
     let (expr, ty_lit) = parse_tts(cx, tts);
 
     let ty = match ty_lit {
@@ -121,12 +121,12 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> 
             }
             _ => {
                 cx.span_err(expr.span, "unsupported literal in hexfloat!");
-                return base::MacResult::dummy_expr(sp);
+                return base::DummyResult::expr(sp);
             }
         },
         _ => {
             cx.span_err(expr.span, "non-literal in hexfloat!");
-            return base::MacResult::dummy_expr(sp);
+            return base::DummyResult::expr(sp);
         }
     };
 
@@ -137,7 +137,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> 
                 let pos = expr.span.lo + syntax::codemap::Pos::from_uint(err_pos + 1);
                 let span = syntax::codemap::mk_sp(pos,pos);
                 cx.span_err(span, format!("invalid hex float literal in hexfloat!: {}", err_str));
-                return base::MacResult::dummy_expr(sp);
+                return base::DummyResult::expr(sp);
             }
             _ => ()
         }
@@ -147,7 +147,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> 
         None => ast::LitFloatUnsuffixed(s),
         Some (ty) => ast::LitFloat(s, ty)
     };
-    MRExpr(cx.expr_lit(sp, lit))
+    MacExpr::new(cx.expr_lit(sp, lit))
 }
 
 struct Ident {

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -45,7 +45,7 @@ impl State {
 static OPTIONS: &'static [&'static str] = &["volatile", "alignstack", "intel"];
 
 pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-               -> base::MacResult {
+               -> ~base::MacResult {
     let mut p = parse::new_parser_from_tts(cx.parse_sess(),
                                            cx.cfg(),
                                            tts.iter()
@@ -72,7 +72,7 @@ pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                                                    "inline assembly must be a string literal.") {
                     Some((s, st)) => (s, st),
                     // let compilation continue
-                    None => return MacResult::dummy_expr(sp),
+                    None => return DummyResult::expr(sp),
                 };
                 asm = s;
                 asm_str_style = Some(style);
@@ -210,7 +210,7 @@ pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         inputs.push((token::intern_and_get_ident(i.to_str()), out));
     }
 
-    MRExpr(@ast::Expr {
+    MacExpr::new(@ast::Expr {
         id: ast::DUMMY_NODE_ID,
         node: ast::ExprInlineAsm(ast::InlineAsm {
             asm: token::intern_and_get_ident(asm.get()),

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -18,10 +18,10 @@ use ext::build::AstBuilder;
 
 use std::char;
 
-pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> base::MacResult {
+pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> ~base::MacResult {
     // Gather all argument expressions
     let exprs = match get_exprs_from_tts(cx, sp, tts) {
-        None => return MacResult::dummy_expr(sp),
+        None => return DummyResult::expr(sp),
         Some(e) => e,
     };
     let mut bytes = Vec::new();
@@ -74,5 +74,5 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> 
     }
 
     let e = cx.expr_vec_slice(sp, bytes);
-    MRExpr(e)
+    MacExpr::new(e)
 }

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -26,7 +26,7 @@ use parse::token::InternedString;
 use parse::token;
 use parse;
 
-pub fn expand_cfg(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> base::MacResult {
+pub fn expand_cfg(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> ~base::MacResult {
     let mut p = parse::new_parser_from_tts(cx.parse_sess(),
                                            cx.cfg(),
                                            tts.iter()
@@ -47,5 +47,5 @@ pub fn expand_cfg(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]) -> base::M
     let matches_cfg = attr::test_cfg(cx.cfg().as_slice(),
                                      in_cfg.iter().map(|&x| x));
     let e = cx.expr_bool(sp, matches_cfg);
-    MRExpr(e)
+    MacExpr::new(e)
 }

--- a/src/libsyntax/ext/concat.rs
+++ b/src/libsyntax/ext/concat.rs
@@ -19,10 +19,10 @@ use std::strbuf::StrBuf;
 
 pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
                          sp: codemap::Span,
-                         tts: &[ast::TokenTree]) -> base::MacResult {
+                         tts: &[ast::TokenTree]) -> ~base::MacResult {
     let es = match base::get_exprs_from_tts(cx, sp, tts) {
         Some(e) => e,
-        None => return base::MacResult::dummy_expr(sp)
+        None => return base::DummyResult::expr(sp)
     };
     let mut accumulator = StrBuf::new();
     for e in es.move_iter() {
@@ -57,7 +57,7 @@ pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
             }
         }
     }
-    base::MRExpr(cx.expr_str(
+    base::MacExpr::new(cx.expr_str(
             sp,
             token::intern_and_get_ident(accumulator.into_owned())))
 }

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -19,7 +19,7 @@ use parse::token::{str_to_ident};
 use std::strbuf::StrBuf;
 
 pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     let mut res_str = StrBuf::new();
     for (i, e) in tts.iter().enumerate() {
         if i & 1 == 1 {
@@ -27,7 +27,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                 ast::TTTok(_, token::COMMA) => (),
                 _ => {
                     cx.span_err(sp, "concat_idents! expecting comma.");
-                    return MacResult::dummy_expr(sp);
+                    return DummyResult::expr(sp);
                 }
             }
         } else {
@@ -37,7 +37,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                 }
                 _ => {
                     cx.span_err(sp, "concat_idents! requires ident args.");
-                    return MacResult::dummy_expr(sp);
+                    return DummyResult::expr(sp);
                 }
             }
         }
@@ -61,5 +61,5 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         ),
         span: sp,
     };
-    MRExpr(e)
+    MacExpr::new(e)
 }

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -24,9 +24,9 @@ use parse::token;
 use std::os;
 
 pub fn expand_option_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     let var = match get_single_str_from_tts(cx, sp, tts, "option_env!") {
-        None => return MacResult::dummy_expr(sp),
+        None => return DummyResult::expr(sp),
         Some(v) => v
     };
 
@@ -56,24 +56,24 @@ pub fn expand_option_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                                           s))))
       }
     };
-    MRExpr(e)
+    MacExpr::new(e)
 }
 
 pub fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     let exprs = match get_exprs_from_tts(cx, sp, tts) {
         Some(ref exprs) if exprs.len() == 0 => {
             cx.span_err(sp, "env! takes 1 or 2 arguments");
-            return MacResult::dummy_expr(sp);
+            return DummyResult::expr(sp);
         }
-        None => return MacResult::dummy_expr(sp),
+        None => return DummyResult::expr(sp),
         Some(exprs) => exprs
     };
 
     let var = match expr_to_str(cx,
                                 *exprs.get(0),
                                 "expected string literal") {
-        None => return MacResult::dummy_expr(sp),
+        None => return DummyResult::expr(sp),
         Some((v, _style)) => v
     };
     let msg = match exprs.len() {
@@ -84,13 +84,13 @@ pub fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         }
         2 => {
             match expr_to_str(cx, *exprs.get(1), "expected string literal") {
-                None => return MacResult::dummy_expr(sp),
+                None => return DummyResult::expr(sp),
                 Some((s, _style)) => s
             }
         }
         _ => {
             cx.span_err(sp, "env! takes 1 or 2 arguments");
-            return MacResult::dummy_expr(sp);
+            return DummyResult::expr(sp);
         }
     };
 
@@ -101,5 +101,5 @@ pub fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         }
         Some(s) => cx.expr_str(sp, token::intern_and_get_ident(s))
     };
-    MRExpr(e)
+    MacExpr::new(e)
 }

--- a/src/libsyntax/ext/fmt.rs
+++ b/src/libsyntax/ext/fmt.rs
@@ -16,11 +16,11 @@ use ext::base;
 use ext::build::AstBuilder;
 
 pub fn expand_syntax_ext(ecx: &mut base::ExtCtxt, sp: Span,
-                         _tts: &[ast::TokenTree]) -> base::MacResult {
+                         _tts: &[ast::TokenTree]) -> ~base::MacResult {
     ecx.span_err(sp, "`fmt!` is deprecated, use `format!` instead");
     ecx.parse_sess.span_diagnostic.span_note(sp,
         "see http://static.rust-lang.org/doc/master/std/fmt/index.html \
          for documentation");
 
-    base::MRExpr(ecx.expr_uint(sp, 2))
+    base::MacExpr::new(ecx.expr_uint(sp, 2))
 }

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -806,14 +806,14 @@ impl<'a, 'b> Context<'a, 'b> {
 }
 
 pub fn expand_args(ecx: &mut ExtCtxt, sp: Span,
-                   tts: &[ast::TokenTree]) -> base::MacResult {
+                   tts: &[ast::TokenTree]) -> ~base::MacResult {
 
     match parse_args(ecx, sp, tts) {
         (extra, Some((efmt, args, order, names))) => {
-            MRExpr(expand_preparsed_format_args(ecx, sp, extra, efmt, args,
+            MacExpr::new(expand_preparsed_format_args(ecx, sp, extra, efmt, args,
                                                 order, names))
         }
-        (_, None) => MRExpr(ecx.expr_uint(sp, 2))
+        (_, None) => MacExpr::new(ecx.expr_uint(sp, 2))
     }
 }
 
@@ -845,7 +845,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt, sp: Span,
                                 efmt,
                                 "format argument must be a string literal.") {
         Some((fmt, _)) => fmt,
-        None => return MacResult::raw_dummy_expr(sp)
+        None => return DummyResult::raw_expr(sp)
     };
 
     let mut parser = parse::Parser::new(fmt.get());
@@ -863,7 +863,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt, sp: Span,
     match parser.errors.shift() {
         Some(error) => {
             cx.ecx.span_err(efmt.span, "invalid format string: " + error);
-            return MacResult::raw_dummy_expr(sp);
+            return DummyResult::raw_expr(sp);
         }
         None => {}
     }

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -18,12 +18,12 @@ use std::rc::Rc;
 pub fn expand_syntax_ext(cx: &mut base::ExtCtxt,
                          sp: codemap::Span,
                          tt: &[ast::TokenTree])
-                      -> base::MacResult {
+                      -> ~base::MacResult {
 
     cx.print_backtrace();
     println!("{}", print::pprust::tt_to_str(&ast::TTDelim(
                 Rc::new(tt.iter().map(|x| (*x).clone()).collect()))));
 
     // any so that `log_syntax` can be invoked as an expression and item.
-    base::MacResult::dummy_any(sp)
+    base::DummyResult::any(sp)
 }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -289,53 +289,53 @@ pub mod rt {
 
 pub fn expand_quote_tokens(cx: &mut ExtCtxt,
                            sp: Span,
-                           tts: &[ast::TokenTree]) -> base::MacResult {
+                           tts: &[ast::TokenTree]) -> ~base::MacResult {
     let (cx_expr, expr) = expand_tts(cx, sp, tts);
     let expanded = expand_wrapper(cx, sp, cx_expr, expr);
-    base::MRExpr(expanded)
+    base::MacExpr::new(expanded)
 }
 
 pub fn expand_quote_expr(cx: &mut ExtCtxt,
                          sp: Span,
-                         tts: &[ast::TokenTree]) -> base::MacResult {
+                         tts: &[ast::TokenTree]) -> ~base::MacResult {
     let expanded = expand_parse_call(cx, sp, "parse_expr", Vec::new(), tts);
-    base::MRExpr(expanded)
+    base::MacExpr::new(expanded)
 }
 
 pub fn expand_quote_item(cx: &mut ExtCtxt,
                          sp: Span,
-                         tts: &[ast::TokenTree]) -> base::MacResult {
+                         tts: &[ast::TokenTree]) -> ~base::MacResult {
     let e_attrs = cx.expr_vec_ng(sp);
     let expanded = expand_parse_call(cx, sp, "parse_item",
                                     vec!(e_attrs), tts);
-    base::MRExpr(expanded)
+    base::MacExpr::new(expanded)
 }
 
 pub fn expand_quote_pat(cx: &mut ExtCtxt,
                         sp: Span,
-                        tts: &[ast::TokenTree]) -> base::MacResult {
+                        tts: &[ast::TokenTree]) -> ~base::MacResult {
     let e_refutable = cx.expr_lit(sp, ast::LitBool(true));
     let expanded = expand_parse_call(cx, sp, "parse_pat",
                                     vec!(e_refutable), tts);
-    base::MRExpr(expanded)
+    base::MacExpr::new(expanded)
 }
 
 pub fn expand_quote_ty(cx: &mut ExtCtxt,
                        sp: Span,
-                       tts: &[ast::TokenTree]) -> base::MacResult {
+                       tts: &[ast::TokenTree]) -> ~base::MacResult {
     let e_param_colons = cx.expr_lit(sp, ast::LitBool(false));
     let expanded = expand_parse_call(cx, sp, "parse_ty",
                                      vec!(e_param_colons), tts);
-    base::MRExpr(expanded)
+    base::MacExpr::new(expanded)
 }
 
 pub fn expand_quote_stmt(cx: &mut ExtCtxt,
                          sp: Span,
-                         tts: &[ast::TokenTree]) -> base::MacResult {
+                         tts: &[ast::TokenTree]) -> ~base::MacResult {
     let e_attrs = cx.expr_vec_ng(sp);
     let expanded = expand_parse_call(cx, sp, "parse_stmt",
                                     vec!(e_attrs), tts);
-    base::MRExpr(expanded)
+    base::MacExpr::new(expanded)
 }
 
 fn ids_ext(strs: Vec<~str> ) -> Vec<ast::Ident> {

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -29,63 +29,63 @@ use std::str;
 
 /* line!(): expands to the current line number */
 pub fn expand_line(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     base::check_zero_tts(cx, sp, tts, "line!");
 
     let topmost = topmost_expn_info(cx.backtrace().unwrap());
     let loc = cx.codemap().lookup_char_pos(topmost.call_site.lo);
 
-    base::MRExpr(cx.expr_uint(topmost.call_site, loc.line))
+    base::MacExpr::new(cx.expr_uint(topmost.call_site, loc.line))
 }
 
 /* col!(): expands to the current column number */
 pub fn expand_col(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     base::check_zero_tts(cx, sp, tts, "col!");
 
     let topmost = topmost_expn_info(cx.backtrace().unwrap());
     let loc = cx.codemap().lookup_char_pos(topmost.call_site.lo);
-    base::MRExpr(cx.expr_uint(topmost.call_site, loc.col.to_uint()))
+    base::MacExpr::new(cx.expr_uint(topmost.call_site, loc.col.to_uint()))
 }
 
 /* file!(): expands to the current filename */
 /* The filemap (`loc.file`) contains a bunch more information we could spit
  * out if we wanted. */
 pub fn expand_file(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     base::check_zero_tts(cx, sp, tts, "file!");
 
     let topmost = topmost_expn_info(cx.backtrace().unwrap());
     let loc = cx.codemap().lookup_char_pos(topmost.call_site.lo);
     let filename = token::intern_and_get_ident(loc.file.name);
-    base::MRExpr(cx.expr_str(topmost.call_site, filename))
+    base::MacExpr::new(cx.expr_str(topmost.call_site, filename))
 }
 
 pub fn expand_stringify(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     let s = pprust::tts_to_str(tts);
-    base::MRExpr(cx.expr_str(sp, token::intern_and_get_ident(s)))
+    base::MacExpr::new(cx.expr_str(sp, token::intern_and_get_ident(s)))
 }
 
 pub fn expand_mod(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     base::check_zero_tts(cx, sp, tts, "module_path!");
     let string = cx.mod_path()
                    .iter()
                    .map(|x| token::get_ident(*x).get().to_str())
                    .collect::<Vec<~str>>()
                    .connect("::");
-    base::MRExpr(cx.expr_str(sp, token::intern_and_get_ident(string)))
+    base::MacExpr::new(cx.expr_str(sp, token::intern_and_get_ident(string)))
 }
 
 // include! : parse the given file as an expr
 // This is generally a bad idea because it's going to behave
 // unhygienically.
 pub fn expand_include(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     let file = match get_single_str_from_tts(cx, sp, tts, "include!") {
         Some(f) => f,
-        None => return MacResult::dummy_expr(sp),
+        None => return DummyResult::expr(sp),
     };
     // The file will be added to the code map by the parser
     let mut p =
@@ -95,21 +95,21 @@ pub fn expand_include(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                                                       sp,
                                                       &Path::new(file)),
                                         sp);
-    base::MRExpr(p.parse_expr())
+    base::MacExpr::new(p.parse_expr())
 }
 
 // include_str! : read the given file, insert it as a literal string expr
 pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> base::MacResult {
+    -> ~base::MacResult {
     let file = match get_single_str_from_tts(cx, sp, tts, "include_str!") {
         Some(f) => f,
-        None => return MacResult::dummy_expr(sp)
+        None => return DummyResult::expr(sp)
     };
     let file = res_rel_file(cx, sp, &Path::new(file));
     let bytes = match File::open(&file).read_to_end() {
         Err(e) => {
             cx.span_err(sp, format!("couldn't read {}: {}", file.display(), e));
-            return MacResult::dummy_expr(sp);
+            return DummyResult::expr(sp);
         }
         Ok(bytes) => bytes,
     };
@@ -121,31 +121,31 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             let interned = token::intern_and_get_ident(src);
             cx.codemap().new_filemap(filename, src.to_owned());
 
-            base::MRExpr(cx.expr_str(sp, interned))
+            base::MacExpr::new(cx.expr_str(sp, interned))
         }
         None => {
             cx.span_err(sp, format!("{} wasn't a utf-8 file", file.display()));
-            return MacResult::dummy_expr(sp);
+            return DummyResult::expr(sp);
         }
     }
 }
 
 pub fn expand_include_bin(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-        -> base::MacResult
+        -> ~base::MacResult
 {
     let file = match get_single_str_from_tts(cx, sp, tts, "include_bin!") {
         Some(f) => f,
-        None => return MacResult::dummy_expr(sp)
+        None => return DummyResult::expr(sp)
     };
     let file = res_rel_file(cx, sp, &Path::new(file));
     match File::open(&file).read_to_end() {
         Err(e) => {
             cx.span_err(sp, format!("couldn't read {}: {}", file.display(), e));
-            return MacResult::dummy_expr(sp);
+            return DummyResult::expr(sp);
         }
         Ok(bytes) => {
             let bytes = bytes.iter().map(|x| *x).collect();
-            base::MRExpr(cx.expr_lit(sp, ast::LitBinary(Rc::new(bytes))))
+            base::MacExpr::new(cx.expr_lit(sp, ast::LitBinary(Rc::new(bytes))))
         }
     }
 }

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -17,7 +17,7 @@ use parse::token::{keywords, is_keyword};
 pub fn expand_trace_macros(cx: &mut ExtCtxt,
                            sp: Span,
                            tt: &[ast::TokenTree])
-                        -> base::MacResult {
+                        -> ~base::MacResult {
     match tt {
         [ast::TTTok(_, ref tok)] if is_keyword(keywords::True, tok) => {
             cx.set_trace_macros(true);
@@ -28,5 +28,5 @@ pub fn expand_trace_macros(cx: &mut ExtCtxt,
         _ => cx.span_err(sp, "trace_macros! accepts only `true` or `false`"),
     }
 
-    base::MacResult::dummy_any(sp)
+    base::DummyResult::any(sp)
 }

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -35,11 +35,11 @@ pub fn macro_registrar(register: |Name, SyntaxExtension|) {
     register(token::intern("into_foo"), ItemModifier(expand_into_foo));
 }
 
-fn expand_make_a_1(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> MacResult {
+fn expand_make_a_1(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> ~MacResult {
     if !tts.is_empty() {
         cx.span_fatal(sp, "make_a_1 takes no arguments");
     }
-    MRExpr(quote_expr!(cx, 1i))
+    MacExpr::new(quote_expr!(cx, 1i))
 }
 
 fn expand_into_foo(cx: &mut ExtCtxt, sp: Span, attr: @MetaItem, it: @Item)


### PR DESCRIPTION
There's now one unified way to return things from a macro, instead of
being able to choose the `AnyMacro` trait or the `MRItem`/`MRExpr`
variants of the `MacResult` enum. This does simplify the logic handling
the expansions, but the biggest value of this is it makes macros in (for
example) type position easier to implement, as there's this single thing
to modify.

By my measurements (using `-Z time-passes` on libstd and librustc etc.),
this appears to have little-to-no impact on expansion speed. There are
presumably larger costs than the small number of extra allocations and
virtual calls this adds (notably, all `macro_rules!`-defined macros have
not changed in behaviour, since they had to use the `AnyMacro` trait
anyway).

---

Summary of changes for dynamic syntax extension maintainers:
- `MacResult` is now a trait, and is returned as `~MacResult`
- `MRExpr` & `MRItem` are now `MacExpr::new` and `MacItem:new` respectively (which return `~MacResult`s)
- `MacResult::dummy_...` is `DummyResult::any` or `DummyResult::expr`
