### PR TITLE
std: Un-ignore some float tests on windows

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -1037,7 +1037,7 @@ mod tests {
         assert_eq!(0f32.abs_sub(&INFINITY), 0f32);
     }
 
-    #[test] #[ignore(cfg(windows))] // FIXME #8663
+    #[test]
     fn test_abs_sub_nowin() {
         assert!(NAN.abs_sub(&-1f32).is_nan());
         assert!(1f32.abs_sub(&NAN).is_nan());

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -1041,7 +1041,7 @@ mod tests {
         assert_eq!(0f64.abs_sub(&INFINITY), 0f64);
     }
 
-    #[test] #[ignore(cfg(windows))] // FIXME #8663
+    #[test]
     fn test_abs_sub_nowin() {
         assert!(NAN.abs_sub(&-1f64).is_nan());
         assert!(1f64.abs_sub(&NAN).is_nan());


### PR DESCRIPTION
These were fixed in the upgrade from mingw32 to mingw64.

Closes #8663
