### PR TITLE
Update rustc manpage with missing options

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -1,6 +1,6 @@
 .TH RUSTC "1" "March 2014" "rustc 0.11-pre" "User Commands"
 .SH NAME
-rustc \- rust compiler
+rustc \- The Rust compiler
 .SH SYNOPSIS
 .B rustc
 [\fIOPTIONS\fR] \fIINPUT\fR
@@ -33,8 +33,16 @@ List the symbols defined by a library crate
 \fB\-\-no\-trans\fR
 Run all passes except translation; no output
 .TP
-\fB\-g\fR, \fB\-\-debuginfo\fR
+\fB\-\-no\-analysis\fR
+Parse and expand the source, but run no analysis and produce no output
+.TP
+\fB\-g\fR
 Emit DWARF debug information into object files generated.
+.TP
+\fB\-\-debuginfo\fR LEVEL
+Emit DWARF debug info to the objects created: 0 = no debug info, 1 =
+line-tables only (for stacktraces and breakpoints), 2 = full debug
+info with variable and type information (same as -g).
 .TP
 \fB\-O\fR
 Equivalent to \fI\-\-opt\-level=2\fR
@@ -57,6 +65,10 @@ Pretty-print the input instead of compiling; valid types are: normal
 (un-annotated source), expanded (crates expanded), typed (crates
 expanded, with type annotations), or identified (fully parenthesized,
 AST nodes and blocks with IDs)
+.TP
+\fB\-\-dep-info\fR [FILENAME]
+Output dependency info to <filename> after compiling, in o format suitable
+for use by Makefiles.
 .TP
 \fB\-\-sysroot\fR PATH
 Override the system root
@@ -151,15 +163,14 @@ level.
 Generates software floating point library calls instead of hardware
 instructions.
 .TP
-\fBgen-crate-map\fR
-Forces generate of a toplevel crate map. May be required for logging to work
-when rust is embedded into another application.
-.TP
 \fBprefer-dynamic\fR
 Prefers dynamic linking to static linking.
 .TP
 \fBno-integrated-as\fR
 Force usage of an external assembler rather than LLVM's integrated one.
+.TP
+\fBrelocation-model\fR=[pic,static,dynamic-no-pic]
+The relocation model to use. (default: pic)
 
 .SH "EXAMPLES"
 To build an executable from a source file with a main function:

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1103,7 +1103,8 @@ pub fn optgroups() -> Vec<getopts::OptGroup> {
          1 = line-tables only (for stacktraces and breakpoints),
          2 = full debug info with variable and type information (same as -g)", "LEVEL"),
   optflag("", "no-trans", "Run all passes except translation; no output"),
-  optflag("", "no-analysis", "Parse and expand the output, but run no analysis or produce output"),
+  optflag("", "no-analysis",
+          "Parse and expand the source, but run no analysis and produce no output"),
   optflag("O", "", "Equivalent to --opt-level=2"),
   optopt("o", "", "Write output to <filename>", "FILENAME"),
   optopt("", "opt-level", "Optimize with possible levels 0-3", "LEVEL"),
@@ -1116,7 +1117,9 @@ pub fn optgroups() -> Vec<getopts::OptGroup> {
               typed (crates expanded, with type annotations),
               or identified (fully parenthesized,
               AST nodes and blocks with IDs)", "TYPE"),
-  optflagopt("", "dep-info", "Output dependency info to <filename> after compiling", "FILENAME"),
+  optflagopt("", "dep-info",
+             "Output dependency info to <filename> after compiling, \
+              in a format suitable for use by Makefiles", "FILENAME"),
   optopt("", "sysroot", "Override the system root", "PATH"),
   optflag("", "test", "Build a test harness"),
   optopt("", "target", "Target triple cpu-manufacturer-kernel[-os]


### PR DESCRIPTION
--no-analysis, --dep-info, -C relocation-model, remove --gen-crate-map
