### PR TITLE
Added run_flags directive to `compiletest`

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -17,6 +17,8 @@ pub struct TestProps {
     pub error_patterns: Vec<~str> ,
     // Extra flags to pass to the compiler
     pub compile_flags: Option<~str>,
+    // Extra flags to pass when the compiled code is run (such as --bench)
+    pub run_flags: Option<~str>,
     // If present, the name of a file that this test should match when
     // pretty-printed
     pub pp_exact: Option<Path>,
@@ -42,6 +44,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut aux_builds = Vec::new();
     let mut exec_env = Vec::new();
     let mut compile_flags = None;
+    let mut run_flags = None;
     let mut pp_exact = None;
     let mut debugger_cmds = Vec::new();
     let mut check_lines = Vec::new();
@@ -56,6 +59,10 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         if compile_flags.is_none() {
             compile_flags = parse_compile_flags(ln);
+        }
+
+        if run_flags.is_none() {
+            run_flags = parse_run_flags(ln);
         }
 
         if pp_exact.is_none() {
@@ -96,9 +103,11 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         true
     });
-    return TestProps {
+
+    TestProps {
         error_patterns: error_patterns,
         compile_flags: compile_flags,
+        run_flags: run_flags,
         pp_exact: pp_exact,
         aux_builds: aux_builds,
         exec_env: exec_env,
@@ -107,7 +116,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         force_host: force_host,
         check_stdout: check_stdout,
         no_prefer_dynamic: no_prefer_dynamic,
-    };
+    }
 }
 
 pub fn is_test_ignored(config: &config, testfile: &Path) -> bool {
@@ -158,6 +167,10 @@ fn parse_aux_build(line: &str) -> Option<~str> {
 
 fn parse_compile_flags(line: &str) -> Option<~str> {
     parse_name_value_directive(line, ~"compile-flags")
+}
+
+fn parse_run_flags(line: &str) -> Option<~str> {
+    parse_name_value_directive(line, ~"run-flags")
 }
 
 fn parse_debugger_cmd(line: &str) -> Option<~str> {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -834,14 +834,19 @@ fn make_exe_name(config: &config, testfile: &Path) -> Path {
     f
 }
 
-fn make_run_args(config: &config, _props: &TestProps, testfile: &Path) ->
+fn make_run_args(config: &config, props: &TestProps, testfile: &Path) ->
    ProcArgs {
     // If we've got another tool to run under (valgrind),
     // then split apart its command
     let mut args = split_maybe_args(&config.runtool);
     let exe_file = make_exe_name(config, testfile);
+
     // FIXME (#9639): This needs to handle non-utf8 paths
     args.push(exe_file.as_str().unwrap().to_owned());
+
+    // Add the arguments in the run_flags directive
+    args.push_all_move(split_maybe_args(&props.run_flags));
+
     let prog = args.shift().unwrap();
     return ProcArgs {prog: prog, args: args};
 }


### PR DESCRIPTION
Now it is possible to specify run-flags in tests. For example, by using `run-flags: --bench` the Bencher is run.
