### PR TITLE
This is a Windows specific fix in libc. According to MSDN, the GUID

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1221,8 +1221,8 @@ pub mod types {
 
                 pub struct GUID {
                     pub Data1: DWORD,
-                    pub Data2: DWORD,
-                    pub Data3: DWORD,
+                    pub Data2: WORD,
+                    pub Data3: WORD,
                     pub Data4: [BYTE, ..8],
                 }
 


### PR DESCRIPTION
structure's Data2 and Data3 members expect WORD types instead of DWORD. I
discovered this discrepancy while experimenting with some bindings to
Microsoft's OLE2 api. The discrepancy was corrupting the contents of the
string returned by UuidToString after I used known GUIDs to test the
accuracy of the function binding. I didn't add test cases because it would
mean adding a dependency to my rather incomplete binding library. However,
the fix produces expected string values when tested.
