### PR TITLE
Add lint check for negating uint literals and variables.

### DIFF
--- a/src/libnative/io/timer_win32.rs
+++ b/src/libnative/io/timer_win32.rs
@@ -137,7 +137,7 @@ impl rtio::RtioTimer for Timer {
 
         // there are 10^6 nanoseconds in a millisecond, and the parameter is in
         // 100ns intervals, so we multiply by 10^4.
-        let due = -(msecs * 10000) as libc::LARGE_INTEGER;
+        let due = -(msecs as i64 * 10000) as libc::LARGE_INTEGER;
         assert_eq!(unsafe {
             imp::SetWaitableTimer(self.obj, &due, 0, ptr::null(),
                                   ptr::mut_null(), 0)
@@ -151,7 +151,7 @@ impl rtio::RtioTimer for Timer {
         let (tx, rx) = channel();
 
         // see above for the calculation
-        let due = -(msecs * 10000) as libc::LARGE_INTEGER;
+        let due = -(msecs as i64 * 10000) as libc::LARGE_INTEGER;
         assert_eq!(unsafe {
             imp::SetWaitableTimer(self.obj, &due, 0, ptr::null(),
                                   ptr::mut_null(), 0)
@@ -167,7 +167,7 @@ impl rtio::RtioTimer for Timer {
         let (tx, rx) = channel();
 
         // see above for the calculation
-        let due = -(msecs * 10000) as libc::LARGE_INTEGER;
+        let due = -(msecs as i64 * 10000) as libc::LARGE_INTEGER;
         assert_eq!(unsafe {
             imp::SetWaitableTimer(self.obj, &due, msecs as libc::LONG,
                                   ptr::null(), ptr::mut_null(), 0)

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
+#![allow(unsigned_negate)]
 
 use metadata::csearch;
 use middle::astencode;

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -43,6 +43,8 @@
  *   taken to it, implementing them for Rust seems difficult.
  */
 
+#![allow(unsigned_negate)]
+
 use std::container::Map;
 use libc::c_ulonglong;
 use std::num::{Bitwise};

--- a/src/libstd/fmt/num.rs
+++ b/src/libstd/fmt/num.rs
@@ -12,6 +12,8 @@
 
 // FIXME: #6220 Implement floating point formatting
 
+#![allow(unsigned_negate)]
+
 use container::Container;
 use fmt;
 use iter::{Iterator, DoubleEndedIterator};

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for 32-bits floats (`f32` type)
 
 #![allow(missing_doc)]
+#![allow(unsigned_negate)]
 
 use prelude::*;
 

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
 #![allow(non_uppercase_statics)]
+#![allow(unsigned_negate)]
 
 use prelude::*;
 

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
 #![allow(non_uppercase_statics)]
+#![allow(unsigned_negate)]
 
 use prelude::*;
 

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
 #![allow(non_uppercase_statics)]
+#![allow(unsigned_negate)]
 
 use prelude::*;
 

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
 #![allow(non_uppercase_statics)]
+#![allow(unsigned_negate)]
 
 use prelude::*;
 

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
 #![allow(non_uppercase_statics)]
+#![allow(unsigned_negate)]
 
 use prelude::*;
 

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -10,6 +10,7 @@
 
 #![macro_escape]
 #![doc(hidden)]
+#![allow(unsigned_negate)]
 
 macro_rules! uint_module (($T:ty, $T_SIGNED:ty, $bits:expr) => (
 

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -15,6 +15,7 @@
 //! which are not used for scheduling in any way.
 
 #![allow(non_camel_case_types)]
+#![allow(unsigned_negate)]
 
 use cast;
 use kinds::Send;

--- a/src/test/compile-fail/lint-type-limits.rs
+++ b/src/test/compile-fail/lint-type-limits.rs
@@ -36,3 +36,14 @@ fn qux() {
         i += 1;
     }
 }
+
+fn quy() {
+    let i = -23u; //~ WARNING negation of unsigned int literal may be unintentional
+                  //~^ WARNING unused variable
+}
+
+fn quz() {
+    let i = 23u;
+    let j = -i;   //~ WARNING negation of unsigned int variable may be unintentional
+                  //~^ WARNING unused variable
+}


### PR DESCRIPTION
See #11273 and #13318
