### PR TITLE
Specialize kinds inference for `Unsafe<T>`

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2214,7 +2214,9 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
         } else if Some(did) == cx.lang_items.no_share_bound() {
             tc | TC::ReachesNoShare
         } else if Some(did) == cx.lang_items.unsafe_type() {
-            tc | TC::InteriorUnsafe
+            // FIXME(#13231): This shouldn't be needed after
+            // opt-in built-in bounds are implemented.
+            (tc | TC::InteriorUnsafe) - TC::Nonsharable
         } else {
             tc
         }

--- a/src/test/compile-fail/typeck-unsafe-always-share.rs
+++ b/src/test/compile-fail/typeck-unsafe-always-share.rs
@@ -1,0 +1,43 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verify that Unsafe is *always* share regardles `T` is share.
+
+// ignore-tidy-linelength
+
+use std::ty::Unsafe;
+use std::kinds::marker;
+
+struct MyShare<T> {
+    u: Unsafe<T>
+}
+
+struct NoShare {
+    m: marker::NoShare
+}
+
+fn test<T: Share>(s: T){
+
+}
+
+fn main() {
+    let us = Unsafe::new(MyShare{u: Unsafe::new(0)});
+    test(us);
+
+    let uns = Unsafe::new(NoShare{m: marker::NoShare});
+    test(uns);
+
+    let ms = MyShare{u: uns};
+    test(ms);
+
+    let ns = NoShare{m: marker::NoShare};
+    test(ns);
+    //~^ ERROR instantiating a type parameter with an incompatible type `NoShare`, which does not fulfill `Share`
+}


### PR DESCRIPTION
This patch adds a special rule for `Unsafe<T>` and makes it `Share`
regardless of whether T is `Share`.

[breaking-change]

Closes #13125

cc @nikomatsakis 
