### PR TITLE
Allow the use of syntax extensions when cross-compiling

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -526,8 +526,6 @@ endif
 # triples).  The associated message will be printed as a warning
 # during attempts to run those tests.
 
-CTEST_DISABLE_NONSELFHOST_rpass-full = "run-pass-full suite is unavailable when cross-compiling."
-
 define DEF_CTEST_VARS
 
 # All the per-stage build rules you might want to call from the
@@ -573,7 +571,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         $$(CTEST_TESTARGS)
 
 CTEST_DEPS_rpass_$(1)-T-$(2)-H-$(3) = $$(RPASS_TESTS)
-CTEST_DEPS_rpass-full_$(1)-T-$(2)-H-$(3) = $$(RPASS_FULL_TESTS) $$(CSREQ$(1)_T_$(2)_H_$(3))
+CTEST_DEPS_rpass-full_$(1)-T-$(2)-H-$(3) = $$(RPASS_FULL_TESTS) $$(CSREQ$(1)_T_$(3)_H_$(3)) $$(SREQ$(1)_T_$(2)_H_$(3))
 CTEST_DEPS_rfail_$(1)-T-$(2)-H-$(3) = $$(RFAIL_TESTS)
 CTEST_DEPS_cfail_$(1)-T-$(2)-H-$(3) = $$(CFAIL_TESTS)
 CTEST_DEPS_bench_$(1)-T-$(2)-H-$(3) = $$(BENCH_TESTS)

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -184,7 +184,7 @@ impl<'a> Archive<'a> {
         let unixlibname = format!("lib{}.a", name);
 
         let mut rustpath = filesearch::rust_path();
-        rustpath.push(self.sess.filesearch().get_target_lib_path());
+        rustpath.push(self.sess.target_filesearch().get_lib_path());
         let search = self.sess.opts.addl_lib_search_paths.borrow();
         for path in search.iter().chain(rustpath.iter()) {
             debug!("looking for {} inside {}", name, path.display());

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1088,7 +1088,7 @@ fn link_args(sess: &Session,
     // The default library location, we need this to find the runtime.
     // The location of crates will be determined as needed.
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let lib_path = sess.filesearch().get_target_lib_path();
+    let lib_path = sess.target_filesearch().get_lib_path();
     let stage: ~str = "-L".to_owned() + lib_path.as_str().unwrap();
 
     let mut args = vec!(stage);

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -40,7 +40,7 @@ pub fn get_rpath_flags(sess: &Session, out_filename: &Path) -> Vec<~str> {
 
     debug!("preparing the RPATH!");
 
-    let sysroot = sess.filesearch().sysroot;
+    let sysroot = sess.sysroot();
     let output = out_filename;
     let libs = sess.cstore.get_used_crates(cstore::RequireDynamic);
     let libs = libs.move_iter().filter_map(|(_, l)| {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -284,9 +284,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     let time_passes = sess.time_passes();
 
     time(time_passes, "external crate/lib resolution", (), |_|
-         creader::read_crates(&sess, krate,
-                              session::sess_os_to_meta_os(sess.targ_cfg.os),
-                              token::get_ident_interner()));
+         creader::read_crates(&sess, krate));
 
     let lang_items = time(time_passes, "language item collection", (), |_|
                           middle::lang_items::collect_language_items(krate, &sess));
@@ -794,7 +792,7 @@ pub fn build_target_config(sopts: &session::Options) -> session::Config {
     }
 }
 
-pub fn host_triple() -> ~str {
+pub fn host_triple() -> &'static str {
     // Get the host triple out of the build environment. This ensures that our
     // idea of the host triple is the same as for the set of libraries we've
     // actually built.  We can't just take LLVM's host triple because they
@@ -803,7 +801,7 @@ pub fn host_triple() -> ~str {
     // Instead of grabbing the host triple (for the current host), we grab (at
     // compile time) the target triple that this rustc is built with and
     // calling that (at runtime) the host triple.
-    (env!("CFG_COMPILER_HOST_TRIPLE")).to_owned()
+    env!("CFG_COMPILER_HOST_TRIPLE")
 }
 
 pub fn build_session_options(matches: &getopts::Matches) -> session::Options {
@@ -895,7 +893,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> session::Options {
     }
 
     let sysroot_opt = matches.opt_str("sysroot").map(|m| Path::new(m));
-    let target = matches.opt_str("target").unwrap_or(host_triple());
+    let target = matches.opt_str("target").unwrap_or(host_triple().to_owned());
     let opt_level = {
         if (debugging_opts & session::NO_OPT) != 0 {
             No

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -319,15 +319,23 @@ impl Session {
     pub fn show_span(&self) -> bool {
         self.debugging_opt(SHOW_SPAN)
     }
-    pub fn filesearch<'a>(&'a self) -> filesearch::FileSearch<'a> {
-        let sysroot = match self.opts.maybe_sysroot {
-            Some(ref sysroot) => sysroot,
+    pub fn sysroot<'a>(&'a self) -> &'a Path {
+        match self.opts.maybe_sysroot {
+            Some (ref sysroot) => sysroot,
             None => self.default_sysroot.as_ref()
                         .expect("missing sysroot and default_sysroot in Session")
-        };
+        }
+    }
+    pub fn target_filesearch<'a>(&'a self) -> filesearch::FileSearch<'a> {
         filesearch::FileSearch::new(
-            sysroot,
+            self.sysroot(),
             self.opts.target_triple,
+            &self.opts.addl_lib_search_paths)
+    }
+    pub fn host_filesearch<'a>(&'a self) -> filesearch::FileSearch<'a> {
+        filesearch::FileSearch::new(
+            self.sysroot(),
+            host_triple(),
             &self.opts.addl_lib_search_paths)
     }
 }
@@ -343,7 +351,7 @@ pub fn basic_options() -> Options {
         output_types: Vec::new(),
         addl_lib_search_paths: RefCell::new(HashSet::new()),
         maybe_sysroot: None,
-        target_triple: host_triple(),
+        target_triple: host_triple().to_owned(),
         cfg: Vec::new(),
         test: false,
         parse_only: false,

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -200,6 +200,8 @@ pub static tag_macro_registrar_fn: uint = 0x8b;
 pub static tag_exported_macros: uint = 0x8c;
 pub static tag_macro_def: uint = 0x8d;
 
+pub static tag_crate_triple: uint = 0x66;
+
 #[deriving(Clone, Show)]
 pub struct LinkMeta {
     pub crateid: CrateId,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -277,20 +277,6 @@ pub fn get_trait_of_method(cstore: &cstore::CStore,
     decoder::get_trait_of_method(&*cdata, def_id.node, tcx)
 }
 
-pub fn get_macro_registrar_fn(cstore: &cstore::CStore,
-                              crate_num: ast::CrateNum)
-                              -> Option<ast::NodeId> {
-    let cdata = cstore.get_crate_data(crate_num);
-    decoder::get_macro_registrar_fn(&*cdata)
-}
-
-pub fn get_exported_macros(cstore: &cstore::CStore,
-                           crate_num: ast::CrateNum)
-                           -> Vec<~str> {
-    let cdata = cstore.get_crate_data(crate_num);
-    decoder::get_exported_macros(&*cdata)
-}
-
 pub fn get_tuple_struct_definition_if_ctor(cstore: &cstore::CStore,
                                            def_id: ast::DefId)
     -> Option<ast::DefId>

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1126,6 +1126,12 @@ pub fn maybe_get_crate_id(data: &[u8]) -> Option<CrateId> {
     })
 }
 
+pub fn get_crate_triple(data: &[u8]) -> ~str {
+    let cratedoc = reader::Doc(data);
+    let triple_doc = reader::maybe_get_doc(cratedoc, tag_crate_triple);
+    triple_doc.expect("No triple in crate").as_str()
+}
+
 pub fn get_crate_id(data: &[u8]) -> CrateId {
     let cratedoc = reader::Doc(data);
     let hashdoc = reader::get_doc(cratedoc, tag_crate_crateid);
@@ -1231,13 +1237,13 @@ pub fn get_native_libraries(cdata: Cmd) -> Vec<(cstore::NativeLibaryKind, ~str)>
     return result;
 }
 
-pub fn get_macro_registrar_fn(cdata: Cmd) -> Option<ast::NodeId> {
-    reader::maybe_get_doc(reader::Doc(cdata.data()), tag_macro_registrar_fn)
+pub fn get_macro_registrar_fn(data: &[u8]) -> Option<ast::NodeId> {
+    reader::maybe_get_doc(reader::Doc(data), tag_macro_registrar_fn)
         .map(|doc| FromPrimitive::from_u32(reader::doc_as_u32(doc)).unwrap())
 }
 
-pub fn get_exported_macros(cdata: Cmd) -> Vec<~str> {
-    let macros = reader::get_doc(reader::Doc(cdata.data()),
+pub fn get_exported_macros(data: &[u8]) -> Vec<~str> {
+    let macros = reader::get_doc(reader::Doc(data),
                                  tag_exported_macros);
     let mut result = Vec::new();
     reader::tagged_docs(macros, tag_macro_def, |macro_doc| {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1669,6 +1669,12 @@ fn encode_crate_id(ebml_w: &mut Encoder, crate_id: &CrateId) {
     ebml_w.end_tag();
 }
 
+fn encode_crate_triple(ebml_w: &mut Encoder, triple: &str) {
+    ebml_w.start_tag(tag_crate_triple);
+    ebml_w.writer.write(triple.as_bytes());
+    ebml_w.end_tag();
+}
+
 // NB: Increment this as you change the metadata encoding version.
 pub static metadata_encoding_version : &'static [u8] =
     &[0x72, //'r' as u8,
@@ -1738,6 +1744,7 @@ fn encode_metadata_inner(wr: &mut MemWriter, parms: EncodeParams, krate: &Crate)
     let mut ebml_w = writer::Encoder(wr);
 
     encode_crate_id(&mut ebml_w, &ecx.link_meta.crateid);
+    encode_crate_triple(&mut ebml_w, tcx.sess.targ_cfg.target_strs.target_triple);
     encode_hash(&mut ebml_w, &ecx.link_meta.crate_hash);
 
     let mut i = ebml_w.writer.tell().unwrap();

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -30,7 +30,7 @@ pub type pick<'a> = |path: &Path|: 'a -> FileMatch;
 pub struct FileSearch<'a> {
     pub sysroot: &'a Path,
     pub addl_lib_search_paths: &'a RefCell<HashSet<Path>>,
-    pub target_triple: &'a str
+    pub triple: &'a str,
 }
 
 impl<'a> FileSearch<'a> {
@@ -48,22 +48,23 @@ impl<'a> FileSearch<'a> {
             visited_dirs.insert(path.as_vec().to_owned());
         }
 
-        debug!("filesearch: searching target lib path");
+        debug!("filesearch: searching lib path");
         let tlib_path = make_target_lib_path(self.sysroot,
-                                    self.target_triple);
+                                    self.triple);
         if !visited_dirs.contains_equiv(&tlib_path.as_vec()) {
             match f(&tlib_path) {
                 FileMatches => found = true,
                 FileDoesntMatch => ()
             }
         }
+
         visited_dirs.insert(tlib_path.as_vec().to_owned());
         // Try RUST_PATH
         if !found {
             let rustpath = rust_path();
             for path in rustpath.iter() {
-                let tlib_path = make_rustpkg_target_lib_path(
-                    self.sysroot, path, self.target_triple);
+                let tlib_path = make_rustpkg_lib_path(
+                    self.sysroot, path, self.triple);
                 debug!("is {} in visited_dirs? {:?}", tlib_path.display(),
                         visited_dirs.contains_equiv(&tlib_path.as_vec().to_owned()));
 
@@ -82,8 +83,8 @@ impl<'a> FileSearch<'a> {
         }
     }
 
-    pub fn get_target_lib_path(&self) -> Path {
-        make_target_lib_path(self.sysroot, self.target_triple)
+    pub fn get_lib_path(&self) -> Path {
+        make_target_lib_path(self.sysroot, self.triple)
     }
 
     pub fn search(&self, pick: pick) {
@@ -122,13 +123,13 @@ impl<'a> FileSearch<'a> {
     }
 
     pub fn new(sysroot: &'a Path,
-               target_triple: &'a str,
+               triple: &'a str,
                addl_lib_search_paths: &'a RefCell<HashSet<Path>>) -> FileSearch<'a> {
-        debug!("using sysroot = {}", sysroot.display());
+        debug!("using sysroot = {}, triple = {}", sysroot.display(), triple);
         FileSearch {
             sysroot: sysroot,
             addl_lib_search_paths: addl_lib_search_paths,
-            target_triple: target_triple
+            triple: triple,
         }
     }
 }
@@ -147,11 +148,11 @@ fn make_target_lib_path(sysroot: &Path,
     sysroot.join(&relative_target_lib_path(sysroot, target_triple))
 }
 
-fn make_rustpkg_target_lib_path(sysroot: &Path,
-                                dir: &Path,
-                                target_triple: &str) -> Path {
+fn make_rustpkg_lib_path(sysroot: &Path,
+                         dir: &Path,
+                         triple: &str) -> Path {
     let mut p = dir.join(find_libdir(sysroot));
-    p.push(target_triple);
+    p.push(triple);
     p
 }
 

--- a/src/test/compile-fail/macro-crate-unexported-macro.rs
+++ b/src/test/compile-fail/macro-crate-unexported-macro.rs
@@ -11,7 +11,6 @@
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 // ignore-android
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/phase-syntax-doesnt-resolve.rs
+++ b/src/test/compile-fail/phase-syntax-doesnt-resolve.rs
@@ -11,7 +11,6 @@
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 // ignore-android
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-fourcc-bad-len.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-bad-len.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-fourcc-invalid-endian.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-invalid-endian.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-fourcc-non-ascii-str.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-non-ascii-str.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-fourcc-non-literal.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-non-literal.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-fourcc-unsupported-literal.rs
+++ b/src/test/compile-fail/syntax-extension-fourcc-unsupported-literal.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-hexfloat-bad-lits.rs
+++ b/src/test/compile-fail/syntax-extension-hexfloat-bad-lits.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/compile-fail/syntax-extension-hexfloat-bad-types.rs
+++ b/src/test/compile-fail/syntax-extension-hexfloat-bad-types.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/run-pass-fulldeps/issue-13560.rs
+++ b/src/test/run-pass-fulldeps/issue-13560.rs
@@ -12,8 +12,6 @@
 // aux-build:issue-13560-2.rs
 // aux-build:issue-13560-3.rs
 // ignore-stage1
-// ignore-android
-// ignore-cross-compile #12102
 
 // Regression test for issue #13560, the test itself is all in the dependent
 // libraries. The fail which previously failed to compile is the one numbered 3.

--- a/src/test/run-pass-fulldeps/macro-crate-outlive-expansion-phase.rs
+++ b/src/test/run-pass-fulldeps/macro-crate-outlive-expansion-phase.rs
@@ -10,8 +10,6 @@
 
 // aux-build:macro_crate_outlive_expansion_phase.rs
 // ignore-stage1
-// ignore-android
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/run-pass-fulldeps/macro-crate.rs
+++ b/src/test/run-pass-fulldeps/macro-crate.rs
@@ -10,8 +10,6 @@
 
 // aux-build:macro_crate_test.rs
 // ignore-stage1
-// ignore-android
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 

--- a/src/test/run-pass-fulldeps/phase-syntax-link-does-resolve.rs
+++ b/src/test/run-pass-fulldeps/phase-syntax-link-does-resolve.rs
@@ -10,17 +10,10 @@
 
 // aux-build:macro_crate_test.rs
 // ignore-stage1
-// ignore-android
-// force-host
-
-// You'll note that there's lots of directives above. This is a very particular
-// test in which we're both linking to a macro crate and loading macros from it.
-// This implies that both versions are the host architecture, meaning this test
-// must also be compiled with the host arch.
+// ignore-cross-compile
 //
-// because this doesn't work with that test runner, ignore-android because it
-// can't run host binaries, and force-host to make this test build as the host
-// arch.
+// macro_crate_test will not compile on a cross-compiled target because
+// libsyntax is not compiled for it.
 
 #![feature(phase)]
 

--- a/src/test/run-pass-fulldeps/syntax-extension-fourcc.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-fourcc.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile
 
 #![feature(phase)]
 

--- a/src/test/run-pass-fulldeps/syntax-extension-hexfloat.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-hexfloat.rs
@@ -10,7 +10,6 @@
 
 // ignore-stage1
 // ignore-pretty
-// ignore-cross-compile #12102
 
 #![feature(phase)]
 #[phase(syntax)]


### PR DESCRIPTION
This allows the use of syntax extensions when cross-compiling (fixing #12102). It does this by encoding the target triple in the crate metadata and checking it when searching for files. Currently the crate triple must match the host triple when there is a macro_registrar_fn, it must match the target triple when linking, and can match either when only macro_rules! macros are used.

due to carelessness, this is pretty much a duplicate of https://github.com/mozilla/rust/pull/13450.
