### PR TITLE
doc: add webfonts there too, style fixes

### DIFF
--- a/src/doc/full-toc.inc
+++ b/src/doc/full-toc.inc
@@ -1,6 +1,11 @@
 <style>
   /* Display the full TOC */
-  #TOC ul ul {
+  nav {
+    column-count: auto;
+    -moz-column-count: auto;
+    -webkit-column-count: auto;
+  }
+  nav ul ul {
     display: block;
     padding-left: 2em;
   }

--- a/src/doc/guide-lifetimes.md
+++ b/src/doc/guide-lifetimes.md
@@ -236,7 +236,7 @@ it. It would violate memory safety for the box that was originally
 assigned to `x` to be garbage-collected, since a non-heap
 pointer *`y`* still points into it.
 
-> ***Note:*** Our current implementation implements the garbage collector
+> *Note:* Our current implementation implements the garbage collector
 > using reference counting and cycle detection.
 
 For this reason, whenever an `&` expression borrows the interior of a
@@ -674,7 +674,7 @@ Named lifetime notation can also be used to control the flow of execution:
 }
 ~~~
 
-> ***Note:*** Labelled breaks are not currently supported within `while` loops.
+> *Note:* Labelled breaks are not currently supported within `while` loops.
 
 Named labels are hygienic and can be used safely within macros.
 See the macros guide section on hygiene for more details.

--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -462,7 +462,7 @@ an `Error` result.
 
 [`Result`]: std/result/index.html
 
-> ***Note:*** A failed task does not currently produce a useful error
+> *Note:* A failed task does not currently produce a useful error
 > value (`try` always returns `Err(())`). In the
 > future, it may be possible for tasks to intercept the value passed to
 > `fail!()`.

--- a/src/doc/po/ja/tutorial.md.po
+++ b/src/doc/po/ja/tutorial.md.po
@@ -196,11 +196,11 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:57
 msgid ""
-"> ***Warning:*** Rust is a language under ongoing development. Notes > about "
+"> *Warning:* Rust is a language under ongoing development. Notes > about "
 "potential changes to the language, implementation > deficiencies, and other "
 "caveats appear offset in blockquotes."
 msgstr ""
-"> ***警告:*** Rust は開発途上の言語です。将来予定されている言語への変更や、実"
+"> *警告:* Rust は開発途上の言語です。将来予定されている言語への変更や、実"
 "装上の不備、その他の注意事項など、 blockquote の段落 (この段落もそうです) に"
 "注意してください。"
 
@@ -287,13 +287,13 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:88
 msgid ""
-"> ***Note:*** Windows users should read the detailed > \"[getting started]"
+"> *Note:* Windows users should read the detailed > \"[getting started]"
 "[wiki-start]\" notes on the wiki. Even when using > the binary installer, "
 "the Windows build requires a MinGW installation, > the precise details of "
 "which are not discussed here. Finally, `rustc` may > need to be [referred to "
 "as `rustc.exe`][bug-3319]. It's a bummer, we > know."
 msgstr ""
-"> ***注意:*** Windows ユーザーは wiki の [getting started][wiki-start] の記事"
+"> *注意:* Windows ユーザーは wiki の [getting started][wiki-start] の記事"
 "を読んでください。 本書では詳細を説明しませんが、インストーラを利用する場合で"
 "も、MinGW のインストールなど、追加の手順が必要です。また、コンパイラは "
 "`rustc` ではなく、 [`rustc.exe` として呼び出す必要がある][bug-3319] かもしれ"
@@ -1254,11 +1254,11 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:504
 msgid ""
-"> ***Note:*** The following code makes use of tuples (`(f64, f64)`) which > "
+"> *Note:* The following code makes use of tuples (`(f64, f64)`) which > "
 "are explained in section 5.3. For now you can think of tuples as a list of > "
 "items."
 msgstr ""
-"> ***注意:*** 以下のコード例では5.3 節で説明されるタプル (`(f64, f64)`) を"
+"> *注意:* 以下のコード例では5.3 節で説明されるタプル (`(f64, f64)`) を"
 "使っています。現時点では、タプルは項目のリストのようなものだとみなしてくださ"
 "い。"
 
@@ -3005,11 +3005,11 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:1774
 msgid ""
-"> ***Note:*** Both the syntax and the semantics will be changing > in small "
+"> *Note:* Both the syntax and the semantics will be changing > in small "
 "ways. At the moment they can be unsound in some > scenarios, particularly "
 "with non-copyable types."
 msgstr ""
-"> ***注意*** コードの文法と意味は将来的に変更されるかもしれません。現時点では"
+"> *注意* コードの文法と意味は将来的に変更されるかもしれません。現時点では"
 "いくつかの状況、特にコピーできない型が関連するケースにおいて望ましくない振る"
 "舞いが起こされる場合があります。"
 
@@ -3660,10 +3660,10 @@ msgstr ""
 #. type: Plain text
 #: src/doc/tutorial.md:2099
 msgid ""
-"> ***Note:*** These two traits were referred to as 'kinds' in earlier > "
+"> *Note:* These two traits were referred to as 'kinds' in earlier > "
 "iterations of the language, and often still are."
 msgstr ""
-"> ***注意*** これら2つのトレイトは、以前は 「種」 (kind) と呼ばれており、現在"
+"> *注意* これら2つのトレイトは、以前は 「種」 (kind) と呼ばれており、現在"
 "でもそう呼ばれる場合があります。"
 
 #. type: Plain text
@@ -4374,9 +4374,9 @@ msgstr ""
 
 #. type: Plain text
 #: src/doc/tutorial.md:2511
-msgid "> ***Note:*** Trait inheritance does not actually work with objects yet"
+msgid "> *Note:* Trait inheritance does not actually work with objects yet"
 msgstr ""
-"> ***注意*** トレイトの継承は、実際にはまだオブジェクトに対しては動作しませ"
+"> *注意* トレイトの継承は、実際にはまだオブジェクトに対しては動作しませ"
 "ん。"
 
 #. type: Plain text

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -10,13 +10,43 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+@font-face {
+    font-family: 'Fira Sans';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Fira Sans'), url("http://rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
+}
+@font-face {
+    font-family: 'Fira Sans';
+    font-style: normal;
+    font-weight: 500;
+    src: local('Fira Sans Medium'), url("http://rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Heuristica Regular'), url("http://rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: italic;
+    font-weight: 400;
+    src: local('Heuristica Italic'), url("http://rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
+}
+@font-face {
+    font-family: 'Heuristica';
+    font-style: normal;
+    font-weight: 700;
+    src: local('Heuristica Bold'), url("http://rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
+}
 /* Global page semantics
    ========================================================================== */
 body {
     margin: 0 auto;
     padding: 0 15px;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 14px;
+    font-family: Heuristica, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 18px;
     color: #333;
     line-height: 1.428571429;
 }
@@ -26,24 +56,36 @@ body {
     }
 }
 
+h1, h2, h3, h4, h5, h6, nav, #versioninfo {
+    font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
 h1, h2, h3, h4, h5, h6 {
     color: black;
-    font-weight: 500;
+    font-weight: 400;
     line-height: 1.1;
 }
 h1, h2, h3 {
     margin-top: 20px;
     margin-bottom: 10px;
 }
+@media (min-width: 1170px) {
+    h1, h2, h3 {
+        margin-top: 30px;
+        margin-bottom: 15px;
+    }
+}
 h4, h5, h6 {
     margin-top: 12px;
     margin-bottom: 10px;
-    padding: .2em .8em;
+    padding: 5px 10px;
+}
+h5, h6 {
     text-decoration: underline;
 }
 
 h1 {
-    font-size: 36px;
+    font-size: 28px;
+    font-weight: 500;
     padding: .1em .4em;
     margin: 0.67em 0;
     border-bottom: 2px solid #ddd;
@@ -52,7 +94,7 @@ h1.title {
     line-height: 1.5em;
 }
 h2 {
-    font-size: 30px;
+    font-size: 26px;
     padding: .2em .5em;
     border-bottom: 1px solid #ddd;
 }
@@ -62,17 +104,34 @@ h3 {
     border-bottom: 1px solid #DDE8FC;
 }
 h4 {
-    font-size: 18px;
+    font-size: 22px;
 }
 h5 {
-    font-size: 16px;
+    font-size: 20px;
 }
 h6 {
-    font-size: 14px;
+    font-size: 18px;
+}
+@media (min-width: 992px) {
+    h1 {
+        font-size: 36px;
+    }
+    h2 {
+        font-size: 30px;
+    }
+    h3 {
+        font-size: 26px;
+    }
 }
 
+nav {
+    column-count: 2;
+    -moz-column-count: 2;
+    -webkit-column-count: 2;
+    font-size: 15px;
+}
 p {
-    margin: 0 0 10px;
+    margin: 0 0 1em 0;
 }
 
 strong {
@@ -85,10 +144,10 @@ em {
 
 footer {
     border-top: 1px solid #ddd;
-    font-size: 12px;
+    font-size: 14.3px;
     font-style: italic;
-    padding-top: 4px;
-    margin-top: 4em;
+    padding-top: 5px;
+    margin-top: 3em;
     margin-bottom: 1em;
 }
 
@@ -130,16 +189,14 @@ pre {
     border-radius: 0.5em;
     white-space: pre-wrap;
     padding: 9.5px;
-    margin: 10px 0;
+    margin: 20px 0;
     font-size: 13px;
     word-break: break-all;
     word-wrap: break-word;
 }
 code {
-    padding: 2px 4px;
-    font-size: 90%;
-    color: #C7254E;
-    background-color: #F9F2F4;
+    padding: 0 2px;
+    color: #8D1A38;
     white-space: nowrap;
 }
 pre code {
@@ -170,7 +227,7 @@ pre.rust .lifetime { color: #B76514; }
     margin: 0.5em;
     font-size: 1.1em;
 }
-@media only screen, handheld and (min-width: 768px) {
+@media handheld, only screen and (min-width: 768px) {
     #versioninfo {
         position: fixed;
         bottom: 0px;
@@ -185,7 +242,7 @@ pre.rust .lifetime { color: #B76514; }
 }
 #versioninfo a.hash {
     color: gray;
-    font-size: 70%;
+    font-size: 80%;
 }
 
 blockquote {
@@ -221,13 +278,13 @@ dd {
     margin-left: 0;
 }
 
-#TOC ul {
+nav ul {
     list-style-type: none;
     padding-left: 0px;
 }
 
 /* Only display one level of hierarchy in the TOC */
-#TOC ul ul {
+nav ul ul {
     display: none;
 }
 

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -14,38 +14,38 @@
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 400;
-    src: local('Fira Sans'), url("http://rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
+    src: local('Fira Sans'), url("http://www.rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
 }
 @font-face {
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 500;
-    src: local('Fira Sans Medium'), url("http://rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
+    src: local('Fira Sans Medium'), url("http://www.rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
 }
 @font-face {
     font-family: 'Heuristica';
     font-style: normal;
     font-weight: 400;
-    src: local('Heuristica Regular'), url("http://rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
+    src: local('Heuristica Regular'), url("http://www.rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
 }
 @font-face {
     font-family: 'Heuristica';
     font-style: italic;
     font-weight: 400;
-    src: local('Heuristica Italic'), url("http://rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
+    src: local('Heuristica Italic'), url("http://www.rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
 }
 @font-face {
     font-family: 'Heuristica';
     font-style: normal;
     font-weight: 700;
-    src: local('Heuristica Bold'), url("http://rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
+    src: local('Heuristica Bold'), url("http://www.rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
 }
 /* Global page semantics
    ========================================================================== */
 body {
     margin: 0 auto;
     padding: 0 15px;
-    font-family: Heuristica, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Heuristica", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 18px;
     color: #333;
     line-height: 1.428571429;
@@ -66,9 +66,16 @@ h1, h2, h3, h4, h5, h6 {
 }
 h1, h2, h3 {
     margin-top: 20px;
-    margin-bottom: 10px;
+    margin-bottom: 15px;
+}
+h1 {
+    margin-bottom: 20px;
 }
 @media (min-width: 1170px) {
+    h1 {
+        margin-top: 40px;
+        margin-bottom: 30px;
+    }
     h1, h2, h3 {
         margin-top: 30px;
         margin-bottom: 15px;
@@ -87,7 +94,6 @@ h1 {
     font-size: 28px;
     font-weight: 500;
     padding: .1em .4em;
-    margin: 0.67em 0;
     border-bottom: 2px solid #ddd;
 }
 h1.title {
@@ -227,7 +233,7 @@ pre.rust .lifetime { color: #B76514; }
     margin: 0.5em;
     font-size: 1.1em;
 }
-@media handheld, only screen and (min-width: 768px) {
+@media only screen and (min-width: 768px) {
     #versioninfo {
         position: fixed;
         bottom: 0px;
@@ -254,21 +260,16 @@ blockquote {
 blockquote p {
     font-size: 17px;
     font-weight: 300;
-    line-height: 1.25;
+    line-height: 1.4;
 }
 blockquote p:last-child {
     margin-bottom: 0;
 }
 
-ul,
-ol {
-    margin-top: 0;
-    margin-bottom: 10px;
+ul, ol {
+    padding-left: 25px;
 }
-ul ul,
-ol ul,
-ul ol,
-ol ol {
+ul ul, ol ul, ul ol, ol ol {
     margin-bottom: 0;
 }
 dl {
@@ -280,6 +281,7 @@ dd {
 
 nav ul {
     list-style-type: none;
+    margin: 0;
     padding-left: 0px;
 }
 

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -96,9 +96,9 @@ The section [Special Unicode Productions](#special-unicode-productions) lists th
 
 ## String table productions
 
-Some rules in the grammar -- notably [unary
+Some rules in the grammar &mdash; notably [unary
 operators](#unary-operator-expressions), [binary
-operators](#binary-operator-expressions), and [keywords](#keywords) --
+operators](#binary-operator-expressions), and [keywords](#keywords) &mdash;
 are given in a simplified form: as a listing of a table of unquoted,
 printable whitespace-separated strings. These cases form a subset of
 the rules regarding the [token](#tokens) rule, and are assumed to be
@@ -645,7 +645,7 @@ The processing of that source file may result in other source files being loaded
 Source files have the extension `.rs`.
 
 A Rust source file describes a module, the name and
-location of which -- in the module tree of the current crate -- are defined
+location of which &mdash; in the module tree of the current crate &mdash; are defined
 from outside the source file: either by an explicit `mod_item` in
 a referencing source file, or by the name of the crate itself.
 
@@ -709,7 +709,7 @@ Some items form an implicit scope for the declaration of sub-items. In other
 words, within a function or module, declarations of items can (in many cases)
 be mixed with the statements, control blocks, and similar artifacts that
 otherwise compose the item body. The meaning of these scoped items is the same
-as if the item was declared outside the scope -- it is still a static item --
+as if the item was declared outside the scope &mdash; it is still a static item &mdash;
 except that the item's *path name* within the module namespace is qualified by
 the name of the enclosing item, or is private to the enclosing item (in the
 case of functions).
@@ -1332,7 +1332,6 @@ Traits are implemented for specific types through separate [implementations](#im
 ~~~~
 # type Surface = int;
 # type BoundingBox = int;
-
 trait Shape {
     fn draw(&self, Surface);
     fn bounding_box(&self) -> BoundingBox;
@@ -1363,7 +1362,6 @@ For example:
 ~~~~
 # type Surface = int;
 # trait Shape { fn draw(&self, Surface); }
-
 fn draw_twice<T: Shape>(surface: Surface, sh: T) {
     sh.draw(surface);
     sh.draw(surface);
@@ -1379,7 +1377,6 @@ to pointers to the trait name, used as a type.
 # trait Shape { }
 # impl Shape for int { }
 # let mycircle = 0;
-
 let myshape: ~Shape = ~mycircle as ~Shape;
 ~~~~
 
@@ -1440,7 +1437,6 @@ Likewise, supertrait methods may also be called on trait objects.
 # impl Shape for int { fn area(&self) -> f64 { 0.0 } }
 # impl Circle for int { fn radius(&self) -> f64 { 0.0 } }
 # let mycircle = 0;
-
 let mycircle: Circle = ~mycircle as ~Circle;
 let nonsense = mycircle.radius() * mycircle.area();
 ~~~~
@@ -1457,7 +1453,6 @@ Implementations are defined with the keyword `impl`.
 # struct BoundingBox {x: f64, y: f64, width: f64, height: f64};
 # trait Shape { fn draw(&self, Surface); fn bounding_box(&self) -> BoundingBox; }
 # fn do_draw_circle(s: Surface, c: Circle) { }
-
 struct Circle {
     radius: f64,
     center: Point,
@@ -1490,7 +1485,6 @@ Implementation parameters are written after the `impl` keyword.
 
 ~~~~
 # trait Seq<T> { }
-
 impl<T> Seq<T> for ~[T] {
    /* ... */
 }
@@ -1730,7 +1724,7 @@ attr : ident [ '=' literal
              | '(' attr_list ')' ] ? ;
 ~~~~
 
-Static entities in Rust -- crates, modules and items -- may have _attributes_
+Static entities in Rust &mdash; crates, modules and items &mdash; may have _attributes_
 applied to them. Attributes in Rust are modeled on Attributes in ECMA-335,
 with the syntax coming from ECMA-334 (C#). An attribute is a general,
 free-form metadatum that is interpreted according to name, convention, and
@@ -2352,8 +2346,8 @@ The declared names may denote new slots or new items.
 #### Item declarations
 
 An _item declaration statement_ has a syntactic form identical to an
-[item](#items) declaration within a module. Declaring an item -- a function,
-enumeration, structure, type, static, trait, implementation or module -- locally
+[item](#items) declaration within a module. Declaring an item &mdash; a function,
+enumeration, structure, type, static, trait, implementation or module &mdash; locally
 within a statement block is simply a way of restricting its scope to a narrow
 region containing all of its uses; it is otherwise identical in meaning to
 declaring the item outside the statement block.
@@ -3382,7 +3376,7 @@ but must be denoted by named reference to an [`enum` item](#enumerations).
 
 ### Recursive types
 
-Nominal types -- [enumerations](#enumerated-types) and [structures](#structure-types) -- may be recursive.
+Nominal types &mdash; [enumerations](#enumerated-types) and [structures](#structure-types) &mdash; may be recursive.
 That is, each `enum` constructor or `struct` field may refer, directly or indirectly, to the enclosing `enum` or `struct` type itself.
 Such recursion has restrictions:
 
@@ -3692,7 +3686,7 @@ entry to each function as the task executes. A stack allocation is reclaimed
 when control leaves the frame containing it.
 
 The _heap_ is a general term that describes two separate sets of boxes:
-managed boxes -- which may be subject to garbage collection -- and owned
+managed boxes &mdash; which may be subject to garbage collection &mdash; and owned
 boxes.  The lifetime of an allocation in the heap depends on the lifetime of
 the box values pointing to it. Since box values may themselves be passed in
 and out of frames, or stored in the heap, heap allocations may outlive the
@@ -3758,7 +3752,7 @@ initialized; this is enforced by the compiler.
 ### Owned boxes
 
 An  _owned box_ is a reference to a heap allocation holding another value, which is constructed
-by the prefix *tilde* sigil `~`
+by the prefix *tilde* sigil `~`.
 
 An example of an owned box type and value:
 
@@ -3793,7 +3787,7 @@ The runtime scheduler maps tasks to a certain number of operating-system threads
 By default, the scheduler chooses the number of threads based on
 the number of concurrent physical CPUs detected at startup.
 It's also possible to override this choice at runtime.
-When the number of tasks exceeds the number of threads -- which is likely --
+When the number of tasks exceeds the number of threads &mdash; which is likely &mdash;
 the scheduler multiplexes the tasks onto threads.^[
 This is an M:N scheduler,
 which is known to give suboptimal results for CPU-bound concurrency problems.
@@ -3832,14 +3826,14 @@ that cause transitions between the states. The lifecycle states of a task are:
 * failing
 * dead
 
-A task begins its lifecycle -- once it has been spawned -- in the *running*
+A task begins its lifecycle &mdash; once it has been spawned &mdash; in the *running*
 state. In this state it executes the statements of its entry function, and any
 functions called by the entry function.
 
 A task may transition from the *running* state to the *blocked*
 state any time it makes a blocking communication call. When the
-call can be completed -- when a message arrives at a sender, or a
-buffer opens to receive a message -- then the blocked task will
+call can be completed &mdash; when a message arrives at a sender, or a
+buffer opens to receive a message &mdash; then the blocked task will
 unblock and transition back to *running*.
 
 A task may transition to the *failing* state at any time, due being

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -51,13 +51,13 @@ fragments of programs that don't compile on their own. To try them
 out, you might have to wrap them in `fn main() { ... }`, and make sure
 they don't contain references to names that aren't actually defined.
 
-> ***Warning:*** Rust is a language under ongoing development. Notes
+> *Warning:* Rust is a language under ongoing development. Notes
 > about potential changes to the language, implementation
 > deficiencies, and other caveats appear offset in blockquotes.
 
 # Getting started
 
-> ***Warning:*** The tarball and installer links are for the most recent
+> *Warning:* The tarball and installer links are for the most recent
 > release, not master. To use master, you **must** build from [git].
 
 The Rust compiler currently must be built from a [tarball] or [git], unless
@@ -79,7 +79,7 @@ Snapshot binaries are currently built and tested on several platforms:
 You may find that other platforms work, but these are our "tier 1"
 supported build environments that are most likely to work.
 
-> ***Note:*** Windows users should read the detailed
+> *Note:* Windows users should read the detailed
 > [Getting started][wiki-start] notes on the wiki. Even when using
 > the binary installer, the Windows build requires a MinGW installation,
 > the precise details of which are not discussed here.
@@ -130,7 +130,7 @@ fn main() {
     println!("hello?");
 }
 ~~~~
-> ***Note:*** An identifier followed by an exclamation point, like
+> *Note:* An identifier followed by an exclamation point, like
 > `println!`, is a macro invocation.  Macros are explained
 > [later](#syntax-extensions); for now just remember to include the
 > exclamation point.
@@ -498,7 +498,7 @@ omitted.
 A powerful application of pattern matching is *destructuring*:
 matching in order to bind names to the contents of data types.
 
-> ***Note:*** The following code makes use of tuples (`(f64, f64)`) which
+> *Note:* The following code makes use of tuples (`(f64, f64)`) which
 > are explained in section 5.3. For now you can think of tuples as a list of
 > items.
 
@@ -781,7 +781,7 @@ fn area(sh: Shape) -> f64 {
 }
 ~~~~
 
-> ***Note:*** This feature of the compiler is currently gated behind the
+> *Note:* This feature of the compiler is currently gated behind the
 > `#[feature(struct_variant)]` directive. More about these directives can be
 > found in the manual.
 
@@ -841,7 +841,6 @@ values can be extracted with pattern matching:
 
 ~~~
 # struct Inches(int);
-
 let length_with_unit = Inches(10);
 let Inches(integer_length) = length_with_unit;
 println!("length is {} inches", integer_length);
@@ -1061,7 +1060,7 @@ list -> | Cons | 1 | ~ | -> | Cons | 2 | ~ | -> | Cons | 3 | ~ | -> | Nil       
         +--------------+    +--------------+    +--------------+    +--------------+
 ~~~
 
-> ***Note:*** the above diagram shows the logical contents of the enum. The actual
+> *Note:* the above diagram shows the logical contents of the enum. The actual
 > memory layout of the enum may vary. For example, for the `List` enum shown
 > above, Rust guarantees that there will be no enum tag field in the actual
 > structure. See the language reference for more details.
@@ -1209,7 +1208,7 @@ let ys = Cons(5, ~Cons(10, ~Nil));
 assert!(eq(&xs, &ys));
 ~~~
 
-> ***Note:*** Rust doesn't guarantee [tail-call](http://en.wikipedia.org/wiki/Tail_call) optimization,
+> *Note:* Rust doesn't guarantee [tail-call](http://en.wikipedia.org/wiki/Tail_call) optimization,
 > but LLVM is able to handle a simple case like this with optimizations enabled.
 
 ## Lists of other types
@@ -1220,7 +1219,7 @@ element type.
 
 The `u32` in the previous definition can be substituted with a type parameter:
 
-> ***Note:*** The following code introduces generics, which are explained in a
+> *Note:* The following code introduces generics, which are explained in a
 > [dedicated section](#generics).
 
 ~~~
@@ -1794,7 +1793,7 @@ spawn(proc() {
 });
 ~~~~
 
-> ***Note:*** If you want to see the output of `debug!` statements, you will need to turn on
+> *Note:* If you want to see the output of `debug!` statements, you will need to turn on
 > `debug!` logging.  To enable `debug!` logging, set the RUST_LOG environment
 > variable to the name of your crate, which, for a file named `foo.rs`, will be
 > `foo` (e.g., with bash, `export RUST_LOG=foo`).
@@ -1816,7 +1815,7 @@ call_twice(closure);
 call_twice(function);
 ~~~~
 
-> ***Note:*** Both the syntax and the semantics will be changing
+> *Note:* Both the syntax and the semantics will be changing
 > in small ways. At the moment they can be unsound in some
 > scenarios, particularly with non-copyable types.
 
@@ -2011,7 +2010,7 @@ a function that returns `Option<T>` instead of `T`.
 fn radius(shape: Shape) -> Option<f64> {
     match shape {
         Circle(_, radius) => Some(radius),
-        Rectangle(..)      => None
+        Rectangle(..)     => None
     }
 }
 ~~~~
@@ -2101,7 +2100,7 @@ references, or types where the only contained references
 have the `'static` lifetime. (For more on named lifetimes and their uses,
 see the [references and lifetimes guide][lifetimes].)
 
-> ***Note:*** These built-in traits were referred to as 'kinds' in earlier
+> *Note:* These built-in traits were referred to as 'kinds' in earlier
 > iterations of the language, and often still are.
 
 Additionally, the `Drop` trait is used to define destructors. This
@@ -2512,7 +2511,7 @@ let mycircle: ~Circle = concrete as ~Circle;
 let nonsense = mycircle.radius() * mycircle.area();
 ~~~
 
-> ***Note:*** Trait inheritance does not actually work with objects yet
+> *Note:* Trait inheritance does not actually work with objects yet
 
 ## Deriving implementations for traits
 
@@ -2966,7 +2965,7 @@ use farm::*;
 # fn main() { cow(); chicken() }
 ~~~
 
-> ***Note:*** This feature of the compiler is currently gated behind the
+> *Note:* This feature of the compiler is currently gated behind the
 > `#[feature(globs)]` directive. More about these directives can be found in
 > the manual.
 

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -32,13 +32,13 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
 r##"<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The {krate} library documentation.">
 
     <title>{title}</title>
 
-    <link href='http://fonts.googleapis.com/css?family=Inconsolata:400,700'
+    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600'
           rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="{root_path}main.css">
 
@@ -54,7 +54,7 @@ r##"<!DOCTYPE html>
 
     <section class="sidebar">
         {logo, select, none{} other{
-            <a href='{root_path}{krate}/index.html'><img src='#' alt='' width='100px' /></a>
+            <a href='{root_path}{krate}/index.html'><img src='#' alt='' width='100'></a>
         }}
 
         {sidebar}
@@ -66,7 +66,7 @@ r##"<!DOCTYPE html>
                 <input class="search-input" name="search"
                        autocomplete="off"
                        placeholder="Search documentation..."
-                       type="search" />
+                       type="search">
             </div>
         </form>
     </nav>
@@ -115,8 +115,7 @@ r##"<!DOCTYPE html>
     <script src="{root_path}main.js"></script>
     <script async src="{root_path}search-index.js"></script>
 </body>
-</html>
-"##,
+</html>"##,
     content   = *t,
     root_path = page.root_path,
     ty        = page.ty,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -976,7 +976,7 @@ impl<'a> fmt::Show for Item<'a> {
                 format!("{}-{}", self.item.source.loline, self.item.source.hiline)
             };
             try!(write!(fmt.buf,
-                          "<a class='source'\
+                          "<a class='source' \
                               href='{root}src/{krate}/{path}.html\\#{href}'>\
                               [src]</a>",
                           root = self.cx.root_path,

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -13,31 +13,31 @@
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 400;
-    src: local('Fira Sans'), url("http://rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
+    src: local('Fira Sans'), url("http://www.rust-lang.org/fonts/FiraSans-Regular.woff") format('woff');
 }
 @font-face {
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 500;
-    src: local('Fira Sans Medium'), url("http://rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
+    src: local('Fira Sans Medium'), url("http://www.rust-lang.org/fonts/FiraSans-Medium.woff") format('woff');
 }
 @font-face {
     font-family: 'Heuristica';
     font-style: normal;
     font-weight: 400;
-    src: local('Heuristica Regular'), url("http://rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
+    src: local('Heuristica Regular'), url("http://www.rust-lang.org/fonts/Heuristica-Regular.woff") format('woff');
 }
 @font-face {
     font-family: 'Heuristica';
     font-style: italic;
     font-weight: 400;
-    src: local('Heuristica Italic'), url("http://rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
+    src: local('Heuristica Italic'), url("http://www.rust-lang.org/fonts/Heuristica-Italic.woff") format('woff');
 }
 @font-face {
     font-family: 'Heuristica';
     font-style: normal;
     font-weight: 700;
-    src: local('Heuristica Bold'), url("http://rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
+    src: local('Heuristica Bold'), url("http://www.rust-lang.org/fonts/Heuristica-Bold.woff") format('woff');
 }
 
 @import "normalize.css";
@@ -58,31 +58,38 @@ body {
     margin: 0;
     position: relative;
     padding: 10px 15px 20px 15px;
-    padding-bottom: 20px;
 }
 
-h1, h2, h3, h4 {
+h1, h2, h3:not(.impl), h4:not(.method) {
     color: black;
     font-weight: 500;
     margin: 30px 0 20px 0;
-    padding-bottom: 15px;
+    padding-bottom: 6px;
 }
 h1.fqn {
     border-bottom: 1px dashed #D5D5D5;
     margin-top: 0;
 }
-h2, h3, h4 {
+h2, h3:not(.impl), h4:not(.method) {
     border-bottom: 1px solid #DDDDDD;
 }
-h2 code, h3 code, h4 code, .block a {
-    font-size: 1.2em;
+h3.impl, h4.method {
+    font-weight: 600;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
-h1, h2, h3, h4, section.sidebar, a.source, .content a, .search-input {
+h3.impl {
+    margin-top: 15px;
+}
+h1, h2, h3, h4, section.sidebar, a.source, .content a.mod, .search-input {
     font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
-ul {
+ol, ul {
     padding-left: 25px;
+}
+ul ul, ol ul, ul ol, ol ol {
+    margin-bottom: 0;
 }
 
 p {
@@ -90,7 +97,7 @@ p {
 }
 
 code, pre {
-    font-family: Menlo, Monaco, Consolas, Inconsolata, "DejaVu Sans Mono", monospace;
+    font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
 }
 pre {
     font-size: 15px;
@@ -194,9 +201,8 @@ nav.sub {
 }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
-    margin-left: 0;
     margin: 40px 0 10px 0;
-    padding-bottom: 10px;
+    padding: 10px 0;
     border-bottom: 1px solid #DDD;
 }
 
@@ -384,7 +390,7 @@ h3.section-link:hover a:after,
 h4.section-link:hover a:after,
 h5.section-link:hover a:after,
 h6.section-link:hover a:after {
-  content: ' § ';
+  content: '\2002\00a7\2002';
 }
 
 /** Media Queries **/


### PR DESCRIPTION
- Use Fira Sans for headlines, Heuristica for the body (Adobe Utopia derivative). Both are licensed under the SIL OFL license. (I didn't include BoldItalic because it is sparingly used.)
- Split TOC into 2 columns for the docs except manual (too tall, too wide to be readable).
- Some fixes to rustdoc, bring styles in coherency with eachother
- A few tweaks

Two examples: [modified tutorial](http://adrientetar.legtux.org/cached/rust-docs/tutorial.htm) and [modified manual](http://adrientetar.legtux.org/cached/rust-docs/manual.htm).

Rustdoc got some fixes, here is [modified `enum.FileType`](http://adrientetar.legtux.org/cached/rust-docs/enum.FileType.htm), [modified `std`](http://adrientetar.legtux.org/cached/rust-docs/std.htm) and [modified `std::io`](http://adrientetar.legtux.org/cached/rust-docs/io.htm).
#13484, #13485 follow-up.

cc @brson
