### PR TITLE
Make ~[T] no longer a growable vector

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -33,7 +33,6 @@ use std::os;
 use std::str;
 use std::strbuf::StrBuf;
 use std::task;
-use std::slice;
 use test::MetricMap;
 
 pub fn run(config: config, testfile: ~str) {
@@ -509,7 +508,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
                          proc_res: &ProcRes) {
 
     // true if we found the error in question
-    let mut found_flags = slice::from_elem(
+    let mut found_flags = Vec::from_elem(
         expected_errors.len(), false);
 
     if proc_res.status.success() {
@@ -554,13 +553,13 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
     for line in proc_res.stderr.lines() {
         let mut was_expected = false;
         for (i, ee) in expected_errors.iter().enumerate() {
-            if !found_flags[i] {
+            if !*found_flags.get(i) {
                 debug!("prefix={} ee.kind={} ee.msg={} line={}",
                        *prefixes.get(i), ee.kind, ee.msg, line);
                 if prefix_matches(line, *prefixes.get(i)) &&
                     line.contains(ee.kind) &&
                     line.contains(ee.msg) {
-                    found_flags[i] = true;
+                    *found_flags.get_mut(i) = true;
                     was_expected = true;
                     break;
                 }

--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -255,10 +255,9 @@ might look like the example below.
 
 ~~~
 # use std::task::spawn;
-# use std::slice;
 
 // Create a vector of ports, one for each child task
-let rxs = slice::from_fn(3, |init_val| {
+let rxs = Vec::from_fn(3, |init_val| {
     let (tx, rx) = channel();
     spawn(proc() {
         tx.send(some_expensive_computation(init_val));
@@ -304,7 +303,6 @@ be distributed on the available cores.
 
 ~~~
 # extern crate sync;
-# use std::slice;
 fn partial_sum(start: uint) -> f64 {
     let mut local_sum = 0f64;
     for num in range(start*100000, (start+1)*100000) {
@@ -314,7 +312,7 @@ fn partial_sum(start: uint) -> f64 {
 }
 
 fn main() {
-    let mut futures = slice::from_fn(1000, |ind| sync::Future::spawn( proc() { partial_sum(ind) }));
+    let mut futures = Vec::from_fn(1000, |ind| sync::Future::spawn( proc() { partial_sum(ind) }));
 
     let mut final_res = 0f64;
     for ft in futures.mut_iter()  {
@@ -342,15 +340,14 @@ a single large vector of floats. Each task needs the full vector to perform its 
 extern crate rand;
 extern crate sync;
 
-use std::slice;
 use sync::Arc;
 
-fn pnorm(nums: &~[f64], p: uint) -> f64 {
+fn pnorm(nums: &[f64], p: uint) -> f64 {
     nums.iter().fold(0.0, |a,b| a+(*b).powf(&(p as f64)) ).powf(&(1.0 / (p as f64)))
 }
 
 fn main() {
-    let numbers = slice::from_fn(1000000, |_| rand::random::<f64>());
+    let numbers = Vec::from_fn(1000000, |_| rand::random::<f64>());
     let numbers_arc = Arc::new(numbers);
 
     for num in range(1u, 10) {
@@ -358,9 +355,9 @@ fn main() {
         tx.send(numbers_arc.clone());
 
         spawn(proc() {
-            let local_arc : Arc<~[f64]> = rx.recv();
+            let local_arc : Arc<Vec<f64>> = rx.recv();
             let task_numbers = &*local_arc;
-            println!("{}-norm = {}", num, pnorm(task_numbers, num));
+            println!("{}-norm = {}", num, pnorm(task_numbers.as_slice(), num));
         });
     }
 }
@@ -374,9 +371,8 @@ created by the line
 # extern crate sync;
 # extern crate rand;
 # use sync::Arc;
-# use std::slice;
 # fn main() {
-# let numbers = slice::from_fn(1000000, |_| rand::random::<f64>());
+# let numbers = Vec::from_fn(1000000, |_| rand::random::<f64>());
 let numbers_arc=Arc::new(numbers);
 # }
 ~~~
@@ -387,9 +383,8 @@ and a clone of it is sent to each task
 # extern crate sync;
 # extern crate rand;
 # use sync::Arc;
-# use std::slice;
 # fn main() {
-# let numbers=slice::from_fn(1000000, |_| rand::random::<f64>());
+# let numbers=Vec::from_fn(1000000, |_| rand::random::<f64>());
 # let numbers_arc = Arc::new(numbers);
 # let (tx, rx) = channel();
 tx.send(numbers_arc.clone());
@@ -404,13 +399,12 @@ Each task recovers the underlying data by
 # extern crate sync;
 # extern crate rand;
 # use sync::Arc;
-# use std::slice;
 # fn main() {
-# let numbers=slice::from_fn(1000000, |_| rand::random::<f64>());
+# let numbers=Vec::from_fn(1000000, |_| rand::random::<f64>());
 # let numbers_arc=Arc::new(numbers);
 # let (tx, rx) = channel();
 # tx.send(numbers_arc.clone());
-# let local_arc : Arc<~[f64]> = rx.recv();
+# let local_arc : Arc<Vec<f64>> = rx.recv();
 let task_numbers = &*local_arc;
 # }
 ~~~

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1582,12 +1582,12 @@ the elements are mutable if the vector is mutable.
 use std::strbuf::StrBuf;
 
 // A dynamically sized vector (unique vector)
-let mut numbers = ~[1, 2, 3];
+let mut numbers = vec![1, 2, 3];
 numbers.push(4);
 numbers.push(5);
 
 // The type of a unique vector is written as `~[int]`
-let more_numbers: ~[int] = numbers;
+let more_numbers: ~[int] = numbers.move_iter().collect();
 
 // The original `numbers` value can no longer be used, due to move semantics.
 
@@ -1955,8 +1955,8 @@ vector consisting of the result of applying `function` to each element
 of `vector`:
 
 ~~~~
-fn map<T, U>(vector: &[T], function: |v: &T| -> U) -> ~[U] {
-    let mut accumulator = ~[];
+fn map<T, U>(vector: &[T], function: |v: &T| -> U) -> Vec<U> {
+    let mut accumulator = Vec::new();
     for element in vector.iter() {
         accumulator.push(function(element));
     }

--- a/src/libnative/io/addrinfo.rs
+++ b/src/libnative/io/addrinfo.rs
@@ -57,7 +57,7 @@ impl GetAddrInfoRequest {
         }
 
         // Collect all the results we found
-        let mut addrs = ~[];
+        let mut addrs = Vec::new();
         let mut rp = res;
         while rp.is_not_null() {
             unsafe {
@@ -80,7 +80,7 @@ impl GetAddrInfoRequest {
 
         unsafe { freeaddrinfo(res); }
 
-        Ok(addrs)
+        Ok(addrs.move_iter().collect())
     }
 }
 

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -18,7 +18,6 @@ use libc::{c_int, c_void};
 use libc;
 use std::mem;
 use std::rt::rtio;
-use std::slice;
 
 use io::{IoResult, retry, keep_going};
 
@@ -416,7 +415,7 @@ pub fn readlink(p: &CString) -> IoResult<Path> {
     if len == -1 {
         len = 1024; // FIXME: read PATH_MAX from C ffi?
     }
-    let mut buf = slice::with_capacity::<u8>(len as uint);
+    let mut buf: Vec<u8> = Vec::with_capacity(len as uint);
     match retry(|| unsafe {
         libc::readlink(p, buf.as_ptr() as *mut libc::c_char,
                        len as libc::size_t) as libc::c_int

--- a/src/librustc/back/rpath.rs
+++ b/src/librustc/back/rpath.rs
@@ -156,8 +156,6 @@ pub fn minimize_rpaths(rpaths: &[~str]) -> Vec<~str> {
 
 #[cfg(unix, test)]
 mod test {
-    use std::os;
-
     use back::rpath::get_install_prefix_rpath;
     use back::rpath::{minimize_rpaths, rpaths_to_flags, get_rpath_relative_to_output};
     use syntax::abi;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -223,13 +223,13 @@ pub fn describe_codegen_flags() {
 }
 
 pub fn run_compiler(args: &[~str]) {
-    let mut args = args.to_owned();
+    let mut args = Vec::from_slice(args);
     let binary = args.shift().unwrap();
 
     if args.is_empty() { usage(binary); return; }
 
     let matches =
-        &match getopts::getopts(args, d::optgroups().as_slice()) {
+        &match getopts::getopts(args.as_slice(), d::optgroups().as_slice()) {
           Ok(m) => m,
           Err(f) => {
             d::early_error(f.to_err_msg());

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -18,7 +18,6 @@
 
 
 use std::io;
-use std::slice;
 use std::strbuf::StrBuf;
 use std::uint;
 use syntax::ast;
@@ -308,13 +307,13 @@ impl<'a, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, O> {
                 changed: true
             };
 
-            let mut temp = slice::from_elem(self.words_per_id, 0u);
+            let mut temp = Vec::from_elem(self.words_per_id, 0u);
             let mut loop_scopes = Vec::new();
 
             while propcx.changed {
                 propcx.changed = false;
-                propcx.reset(temp);
-                propcx.walk_block(blk, temp, &mut loop_scopes);
+                propcx.reset(temp.as_mut_slice());
+                propcx.walk_block(blk, temp.as_mut_slice(), &mut loop_scopes);
             }
         }
 

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -16,8 +16,6 @@
  * closure.
  */
 
-use std::slice;
-
 use back::abi;
 use driver::session;
 use lib::llvm::{ValueRef, NoAliasAttribute, StructRetAttribute, NoCaptureAttribute};
@@ -221,11 +219,12 @@ fn resolve_default_method_vtables(bcx: &Block,
         Some(vtables) => {
             let num_impl_type_parameters =
                 vtables.len() - num_method_vtables;
-            vtables.tailn(num_impl_type_parameters).to_owned()
+            Vec::from_slice(vtables.tailn(num_impl_type_parameters))
         },
-        None => slice::from_elem(num_method_vtables, @Vec::new())
+        None => Vec::from_elem(num_method_vtables, @Vec::new())
     };
 
+    let method_vtables = method_vtables.as_slice();
     let param_vtables = @((*trait_vtables_fixed).clone().append(method_vtables));
 
     let self_vtables = resolve_param_vtables_under_param_substs(

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -593,11 +593,11 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
                 const_eval::const_uint(i) => i as uint,
                 _ => cx.sess().span_bug(count.span, "count must be integral const expression.")
             };
-            let vs = slice::from_elem(n, const_expr(cx, elem, is_local).val0());
+            let vs = Vec::from_elem(n, const_expr(cx, elem, is_local).val0());
             let v = if vs.iter().any(|vi| val_ty(*vi) != llunitty) {
-                C_struct(cx, vs, false)
+                C_struct(cx, vs.as_slice(), false)
             } else {
-                C_array(llunitty, vs)
+                C_array(llunitty, vs.as_slice())
             };
             (v, true)
           }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -148,7 +148,6 @@ use collections::HashMap;
 use collections::HashSet;
 use libc::{c_uint, c_ulonglong, c_longlong};
 use std::ptr;
-use std::slice;
 use std::strbuf::StrBuf;
 use std::sync::atomics;
 use syntax::codemap::{Span, Pos};
@@ -776,7 +775,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
             return create_DIArray(DIB(cx), []);
         }
 
-        let mut signature = slice::with_capacity(fn_decl.inputs.len() + 1);
+        let mut signature = Vec::with_capacity(fn_decl.inputs.len() + 1);
 
         // Return type -- llvm::DIBuilder wants this at index 0
         match fn_decl.output.node {
@@ -818,7 +817,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
             signature.push(type_metadata(cx, arg_type, codemap::DUMMY_SP));
         }
 
-        return create_DIArray(DIB(cx), signature);
+        return create_DIArray(DIB(cx), signature.as_slice());
     }
 
     fn get_template_parameters(cx: &CrateContext,
@@ -961,7 +960,7 @@ fn compile_unit_metadata(cx: &CrateContext) {
                             // prepend "./" if necessary
                             let dotdot = bytes!("..");
                             let prefix = &[dotdot[0], ::std::path::SEP_BYTE];
-                            let mut path_bytes = p.as_vec().to_owned();
+                            let mut path_bytes = Vec::from_slice(p.as_vec());
 
                             if path_bytes.slice_to(2) != prefix &&
                                path_bytes.slice_to(2) != dotdot {
@@ -969,7 +968,7 @@ fn compile_unit_metadata(cx: &CrateContext) {
                                 path_bytes.insert(1, prefix[1]);
                             }
 
-                            path_bytes.to_c_str()
+                            path_bytes.as_slice().to_c_str()
                         }
                     _ => fallback_path(cx)
                 }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -71,7 +71,6 @@ use util::nodemap::NodeMap;
 use middle::trans::machine::{llsize_of, llsize_of_alloc};
 use middle::trans::type_::Type;
 
-use std::slice;
 use syntax::ast;
 use syntax::codemap;
 use syntax::print::pprust::{expr_to_str};
@@ -969,7 +968,7 @@ fn trans_rec_or_struct<'a>(
     let ty = node_id_type(bcx, id);
     let tcx = bcx.tcx();
     with_field_tys(tcx, ty, Some(id), |discr, field_tys| {
-        let mut need_base = slice::from_elem(field_tys.len(), true);
+        let mut need_base = Vec::from_elem(field_tys.len(), true);
 
         let numbered_fields = fields.iter().map(|field| {
             let opt_pos =
@@ -977,7 +976,7 @@ fn trans_rec_or_struct<'a>(
                                           field_ty.ident.name == field.ident.node.name);
             match opt_pos {
                 Some(i) => {
-                    need_base[i] = false;
+                    *need_base.get_mut(i) = false;
                     (i, field.expr)
                 }
                 None => {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -118,7 +118,6 @@ use std::cell::{Cell, RefCell};
 use collections::HashMap;
 use std::mem::replace;
 use std::result;
-use std::slice;
 use std::vec::Vec;
 use syntax::abi;
 use syntax::ast::{Provided, Required};
@@ -3906,13 +3905,13 @@ pub fn check_bounds_are_used(ccx: &CrateCtxt,
 
     // make a vector of booleans initially false, set to true when used
     if tps.len() == 0u { return; }
-    let mut tps_used = slice::from_elem(tps.len(), false);
+    let mut tps_used = Vec::from_elem(tps.len(), false);
 
     ty::walk_ty(ty, |t| {
             match ty::get(t).sty {
                 ty::ty_param(param_ty {idx, ..}) => {
                     debug!("Found use of ty param \\#{}", idx);
-                    tps_used[idx] = true;
+                    *tps_used.get_mut(idx) = true;
                 }
                 _ => ()
             }

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -26,7 +26,6 @@ use util::ppaux::{Repr};
 
 use std::cell::{Cell, RefCell};
 use std::uint;
-use std::slice;
 use collections::{HashMap, HashSet};
 use syntax::ast;
 
@@ -1004,7 +1003,7 @@ impl<'a> RegionVarBindings<'a> {
         // idea is to report errors that derive from independent
         // regions of the graph, but not those that derive from
         // overlapping locations.
-        let mut dup_vec = slice::from_elem(self.num_vars(), uint::MAX);
+        let mut dup_vec = Vec::from_elem(self.num_vars(), uint::MAX);
 
         let mut opt_graph = None;
 
@@ -1052,11 +1051,13 @@ impl<'a> RegionVarBindings<'a> {
                     match var_data[idx].classification {
                         Expanding => {
                             self.collect_error_for_expanding_node(
-                                graph, var_data, dup_vec, node_vid, errors);
+                                graph, var_data, dup_vec.as_mut_slice(),
+                                node_vid, errors);
                         }
                         Contracting => {
                             self.collect_error_for_contracting_node(
-                                graph, var_data, dup_vec, node_vid, errors);
+                                graph, var_data, dup_vec.as_mut_slice(),
+                                node_vid, errors);
                         }
                     }
                 }

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -525,7 +525,6 @@ mod tests {
 
     use super::{Digest, Sha256, FixedBuffer};
     use std::num::Bounded;
-    use std::slice;
     use self::rand::isaac::IsaacRng;
     use self::rand::Rng;
     use serialize::hex::FromHex;
@@ -600,7 +599,7 @@ mod tests {
     /// correct.
     fn test_digest_1million_random<D: Digest>(digest: &mut D, blocksize: uint, expected: &str) {
         let total_size = 1000000;
-        let buffer = slice::from_elem(blocksize * 2, 'a' as u8);
+        let buffer = Vec::from_elem(blocksize * 2, 'a' as u8);
         let mut rng = IsaacRng::new_unseeded();
         let mut count = 0;
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -38,7 +38,6 @@ use std::fmt;
 use std::io::{fs, File, BufferedWriter, MemWriter, BufferedReader};
 use std::io;
 use std::local_data;
-use std::slice;
 use std::str;
 use std::strbuf::StrBuf;
 
@@ -1047,7 +1046,7 @@ fn item_module(w: &mut Writer, cx: &Context,
                item: &clean::Item, items: &[clean::Item]) -> fmt::Result {
     try!(document(w, item));
     debug!("{:?}", items);
-    let mut indices = slice::from_fn(items.len(), |i| i);
+    let mut indices = Vec::from_fn(items.len(), |i| i);
 
     fn cmp(i1: &clean::Item, i2: &clean::Item, idx1: uint, idx2: uint) -> Ordering {
         if shortty(i1) == shortty(i2) {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -169,8 +169,8 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, should_fail: bool,
 
 fn maketest(s: &str, cratename: &str, loose_feature_gating: bool) -> ~str {
     let mut prog = StrBuf::from_str(r"
-#![deny(warnings)];
-#![allow(unused_variable, dead_assignment, unused_mut, attribute_usage, dead_code)];
+#![deny(warnings)]
+#![allow(unused_variable, dead_assignment, unused_mut, attribute_usage, dead_code)]
 ");
 
     if loose_feature_gating {

--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -138,7 +138,7 @@ pub fn accum_addrinfo(addr: &Addrinfo) -> ~[ai::Info] {
     unsafe {
         let mut addr = addr.handle;
 
-        let mut addrs = ~[];
+        let mut addrs = Vec::new();
         loop {
             let rustaddr = net::sockaddr_to_addr(cast::transmute((*addr).ai_addr),
                                                  (*addr).ai_addrlen as uint);
@@ -180,6 +180,6 @@ pub fn accum_addrinfo(addr: &Addrinfo) -> ~[ai::Info] {
             }
         }
 
-        return addrs;
+        return addrs.move_iter().collect();
     }
 }

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -469,7 +469,6 @@ mod test {
     use libc::{O_CREAT, O_RDWR, O_RDONLY, S_IWUSR, S_IRUSR};
     use std::io;
     use std::str;
-    use std::slice;
     use super::FsRequest;
     use super::super::Loop;
     use super::super::local_loop;
@@ -505,8 +504,8 @@ mod test {
             let fd = result.fd;
 
             // read
-            let mut read_mem = slice::from_elem(1000, 0u8);
-            let result = FsRequest::read(l(), fd, read_mem, 0);
+            let mut read_mem = Vec::from_elem(1000, 0u8);
+            let result = FsRequest::read(l(), fd, read_mem.as_mut_slice(), 0);
             assert!(result.is_ok());
 
             let nread = result.unwrap();

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -79,7 +79,7 @@ impl<'a> ToBase64 for &'a [u8] {
             UrlSafe => URLSAFE_CHARS
         };
 
-        let mut v: ~[u8] = ~[];
+        let mut v = Vec::new();
         let mut i = 0;
         let mut cur_length = 0;
         let len = self.len();
@@ -146,7 +146,7 @@ impl<'a> ToBase64 for &'a [u8] {
         }
 
         unsafe {
-            str::raw::from_utf8_owned(v)
+            str::raw::from_utf8_owned(v.move_iter().collect())
         }
     }
 }
@@ -208,7 +208,7 @@ impl<'a> FromBase64 for &'a str {
      * ```
      */
     fn from_base64(&self) -> Result<~[u8], FromBase64Error> {
-        let mut r = ~[];
+        let mut r = Vec::new();
         let mut buf: u32 = 0;
         let mut modulus = 0;
 
@@ -256,7 +256,7 @@ impl<'a> FromBase64 for &'a str {
             _ => return Err(InvalidBase64Length),
         }
 
-        Ok(r)
+        Ok(r.move_iter().collect())
     }
 }
 
@@ -337,12 +337,12 @@ mod tests {
     #[test]
     fn test_base64_random() {
         use self::rand::{task_rng, random, Rng};
-        use std::slice;
 
         for _ in range(0, 1000) {
             let times = task_rng().gen_range(1u, 100);
-            let v = slice::from_fn(times, |_| random::<u8>());
-            assert_eq!(v.to_base64(STANDARD).from_base64().unwrap(), v);
+            let v = Vec::from_fn(times, |_| random::<u8>());
+            assert_eq!(v.as_slice().to_base64(STANDARD).from_base64().unwrap(),
+                       v.as_slice().to_owned());
         }
     }
 

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -1099,8 +1099,7 @@ mod bench {
 
     #[bench]
     pub fn vuint_at_A_aligned(b: &mut Bencher) {
-        use std::slice;
-        let data = slice::from_fn(4*100, |i| {
+        let data = Vec::from_fn(4*100, |i| {
             match i % 2 {
               0 => 0x80u8,
               _ => i as u8,
@@ -1110,7 +1109,7 @@ mod bench {
         b.iter(|| {
             let mut i = 0;
             while i < data.len() {
-                sum += reader::vuint_at(data, i).unwrap().val;
+                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
                 i += 4;
             }
         });
@@ -1118,8 +1117,7 @@ mod bench {
 
     #[bench]
     pub fn vuint_at_A_unaligned(b: &mut Bencher) {
-        use std::slice;
-        let data = slice::from_fn(4*100+1, |i| {
+        let data = Vec::from_fn(4*100+1, |i| {
             match i % 2 {
               1 => 0x80u8,
               _ => i as u8
@@ -1129,7 +1127,7 @@ mod bench {
         b.iter(|| {
             let mut i = 1;
             while i < data.len() {
-                sum += reader::vuint_at(data, i).unwrap().val;
+                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
                 i += 4;
             }
         });
@@ -1137,8 +1135,7 @@ mod bench {
 
     #[bench]
     pub fn vuint_at_D_aligned(b: &mut Bencher) {
-        use std::slice;
-        let data = slice::from_fn(4*100, |i| {
+        let data = Vec::from_fn(4*100, |i| {
             match i % 4 {
               0 => 0x10u8,
               3 => i as u8,
@@ -1149,7 +1146,7 @@ mod bench {
         b.iter(|| {
             let mut i = 0;
             while i < data.len() {
-                sum += reader::vuint_at(data, i).unwrap().val;
+                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
                 i += 4;
             }
         });
@@ -1157,8 +1154,7 @@ mod bench {
 
     #[bench]
     pub fn vuint_at_D_unaligned(b: &mut Bencher) {
-        use std::slice;
-        let data = slice::from_fn(4*100+1, |i| {
+        let data = Vec::from_fn(4*100+1, |i| {
             match i % 4 {
               1 => 0x10u8,
               0 => i as u8,
@@ -1169,7 +1165,7 @@ mod bench {
         b.iter(|| {
             let mut i = 1;
             while i < data.len() {
-                sum += reader::vuint_at(data, i).unwrap().val;
+                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
                 i += 4;
             }
         });

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -10,7 +10,6 @@
 
 //! Hex binary-to-text encoding
 use std::str;
-use std::slice;
 use std::fmt;
 
 /// A trait for converting a value to hexadecimal encoding
@@ -39,14 +38,14 @@ impl<'a> ToHex for &'a [u8] {
      * ```
      */
     fn to_hex(&self) -> ~str {
-        let mut v = slice::with_capacity(self.len() * 2);
+        let mut v = Vec::with_capacity(self.len() * 2);
         for &byte in self.iter() {
             v.push(CHARS[(byte >> 4) as uint]);
             v.push(CHARS[(byte & 0xf) as uint]);
         }
 
         unsafe {
-            str::raw::from_utf8_owned(v)
+            str::raw::from_utf8_owned(v.move_iter().collect())
         }
     }
 }
@@ -106,7 +105,7 @@ impl<'a> FromHex for &'a str {
      */
     fn from_hex(&self) -> Result<~[u8], FromHexError> {
         // This may be an overestimate if there is any whitespace
-        let mut b = slice::with_capacity(self.len() / 2);
+        let mut b = Vec::with_capacity(self.len() / 2);
         let mut modulus = 0;
         let mut buf = 0u8;
 
@@ -132,7 +131,7 @@ impl<'a> FromHex for &'a str {
         }
 
         match modulus {
-            0 => Ok(b),
+            0 => Ok(b.move_iter().collect()),
             _ => Err(InvalidHexLength),
         }
     }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1230,11 +1230,11 @@ impl<T : Iterator<char>> Parser<T> {
         self.bump();
         self.parse_whitespace();
 
-        let mut values = ~[];
+        let mut values = Vec::new();
 
         if self.ch_is(']') {
             self.bump();
-            return Ok(List(values));
+            return Ok(List(values.move_iter().collect()));
         }
 
         loop {
@@ -1252,7 +1252,7 @@ impl<T : Iterator<char>> Parser<T> {
                 self.bump();
             } else if self.ch_is(']') {
                 self.bump();
-                return Ok(List(values));
+                return Ok(List(values.move_iter().collect()));
             } else {
                 return self.error(~"expected `,` or `]`")
             }
@@ -1332,14 +1332,14 @@ pub fn from_str(s: &str) -> DecodeResult<Json> {
 
 /// A structure to decode JSON to values in rust.
 pub struct Decoder {
-    stack: ~[Json],
+    stack: Vec<Json>,
 }
 
 impl Decoder {
     /// Creates a new decoder instance for decoding the specified JSON value.
     pub fn new(json: Json) -> Decoder {
         Decoder {
-            stack: ~[json]
+            stack: vec!(json),
         }
     }
 }

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -16,7 +16,6 @@ Core encoding and decoding interfaces.
 
 use std::path;
 use std::rc::Rc;
-use std::slice;
 
 pub trait Encoder<E> {
     // Primitive types:
@@ -443,11 +442,15 @@ impl<E, S:Encoder<E>,T:Encodable<S, E>> Encodable<S, E> for ~[T] {
 impl<E, D:Decoder<E>,T:Decodable<D, E>> Decodable<D, E> for ~[T] {
     fn decode(d: &mut D) -> Result<~[T], E> {
         d.read_seq(|d, len| {
-            let mut v: ~[T] = slice::with_capacity(len);
+            let mut v: Vec<T> = Vec::with_capacity(len);
             for i in range(0, len) {
                 v.push(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }
-            Ok(v)
+            println!("-------");
+            println!("{}", v.len());
+            let k = v.move_iter().collect::<~[T]>();
+            println!("{}", k.len());
+            Ok(k)
         })
     }
 }
@@ -594,11 +597,11 @@ pub trait DecoderHelpers<E> {
 impl<E, D:Decoder<E>> DecoderHelpers<E> for D {
     fn read_to_vec<T>(&mut self, f: |&mut D| -> Result<T, E>) -> Result<~[T], E> {
         self.read_seq(|this, len| {
-            let mut v = slice::with_capacity(len);
+            let mut v = Vec::with_capacity(len);
             for i in range(0, len) {
                 v.push(try!(this.read_seq_elt(i, |this| f(this))));
             }
-            Ok(v)
+            Ok(v.move_iter().collect())
         })
     }
 }

--- a/src/libstd/comm/shared.rs
+++ b/src/libstd/comm/shared.rs
@@ -30,7 +30,6 @@ use rt::task::{Task, BlockedTask};
 use rt::thread::Thread;
 use sync::atomics;
 use unstable::mutex::NativeMutex;
-use slice::OwnedVector;
 
 use mpsc = sync::mpsc_queue;
 

--- a/src/libstd/comm/stream.rs
+++ b/src/libstd/comm/stream.rs
@@ -30,7 +30,6 @@ use rt::task::{Task, BlockedTask};
 use rt::thread::Thread;
 use spsc = sync::spsc_queue;
 use sync::atomics;
-use slice::OwnedVector;
 
 static DISCONNECTED: int = int::MIN;
 #[cfg(test)]

--- a/src/libstd/hash/sip.rs
+++ b/src/libstd/hash/sip.rs
@@ -359,13 +359,8 @@ pub fn hash_with_keys<T: Hash<SipState>>(k0: u64, k1: u64, value: &T) -> u64 {
 #[cfg(test)]
 mod tests {
     extern crate test;
-    use io::Writer;
-    use iter::Iterator;
+    use prelude::*;
     use num::ToStrRadix;
-    use option::{Some, None};
-    use str::Str;
-    use strbuf::StrBuf;
-    use slice::{Vector, ImmutableVector, OwnedVector};
     use self::test::Bencher;
 
     use super::super::Hash;
@@ -454,7 +449,7 @@ mod tests {
 
         let k0 = 0x_07_06_05_04_03_02_01_00_u64;
         let k1 = 0x_0f_0e_0d_0c_0b_0a_09_08_u64;
-        let mut buf : ~[u8] = ~[];
+        let mut buf = Vec::new();
         let mut t = 0;
         let mut state_inc = SipState::new_with_keys(k0, k1);
         let mut state_full = SipState::new_with_keys(k0, k1);
@@ -496,7 +491,7 @@ mod tests {
             assert_eq!(vec, out);
 
             state_full.reset();
-            state_full.write(buf);
+            state_full.write(buf.as_slice());
             let f = result_str(state_full.result());
             let i = result_str(state_inc.result());
             let v = to_hex_str(&vecs[t]);

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -17,7 +17,7 @@ use iter::ExactSize;
 use ops::Drop;
 use option::{Some, None, Option};
 use result::{Ok, Err};
-use slice::{OwnedVector, ImmutableVector, MutableVector};
+use slice::{ImmutableVector, MutableVector};
 use slice;
 use vec::Vec;
 
@@ -391,7 +391,7 @@ mod test {
 
     /// A dummy reader intended at testing short-reads propagation.
     pub struct ShortReader {
-        lengths: ~[uint],
+        lengths: Vec<uint>,
     }
 
     impl Reader for ShortReader {
@@ -554,7 +554,7 @@ mod test {
 
     #[test]
     fn test_short_reads() {
-        let inner = ShortReader{lengths: ~[0, 1, 2, 0, 1, 0]};
+        let inner = ShortReader{lengths: vec![0, 1, 2, 0, 1, 0]};
         let mut reader = BufferedReader::new(inner);
         let mut buf = [0, 0];
         assert_eq!(reader.read(buf), Ok(0));

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -21,7 +21,7 @@ use option::{Option, Some, None};
 use result::{Ok, Err};
 use io;
 use io::{IoError, IoResult, Reader};
-use slice::{OwnedVector, ImmutableVector, Vector};
+use slice::{ImmutableVector, Vector};
 use ptr::RawPtr;
 
 /// An iterator that reads a single byte on each iteration,
@@ -503,21 +503,22 @@ mod test {
 #[cfg(test)]
 mod bench {
     extern crate test;
-    use self::test::Bencher;
+
     use container::Container;
+    use prelude::*;
+    use self::test::Bencher;
 
     macro_rules! u64_from_be_bytes_bench_impl(
         ($size:expr, $stride:expr, $start_index:expr) =>
         ({
-            use slice;
             use super::u64_from_be_bytes;
 
-            let data = slice::from_fn($stride*100+$start_index, |i| i as u8);
+            let data = Vec::from_fn($stride*100+$start_index, |i| i as u8);
             let mut sum = 0u64;
             b.iter(|| {
                 let mut i = $start_index;
                 while i < data.len() {
-                    sum += u64_from_be_bytes(data, i, $size);
+                    sum += u64_from_be_bytes(data.as_slice(), i, $size);
                     i += $stride;
                 }
             });

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -17,7 +17,7 @@ use result::{Err, Ok};
 use io;
 use io::{Reader, Writer, Seek, Buffer, IoError, SeekStyle, IoResult};
 use slice;
-use slice::{Vector, ImmutableVector, MutableVector, OwnedCloneableVector};
+use slice::{Vector, ImmutableVector, MutableVector};
 use vec::Vec;
 
 fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -228,11 +228,11 @@ use os;
 use option::{Option, Some, None};
 use path::Path;
 use result::{Ok, Err, Result};
-use str::{StrSlice, OwnedStr};
+use str::StrSlice;
 use str;
 use uint;
 use unstable::finally::try_finally;
-use slice::{Vector, OwnedVector, MutableVector, ImmutableVector, OwnedCloneableVector};
+use slice::{Vector, MutableVector, ImmutableVector};
 use vec::Vec;
 
 // Reexports

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -16,6 +16,7 @@ use fmt;
 use io::IoResult;
 use io;
 use libc;
+use mem;
 use rt::rtio::{RtioProcess, IoFactory, LocalIo};
 
 /// Signal a process to exit, without forcibly killing it. Corresponds to
@@ -416,12 +417,7 @@ impl Drop for Process {
         drop(self.stdin.take());
         drop(self.stdout.take());
         drop(self.stderr.take());
-        loop {
-            match self.extra_io.pop() {
-                Some(_) => (),
-                None => break,
-            }
-        }
+        drop(mem::replace(&mut self.extra_io, ~[]));
 
         self.wait();
     }

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -28,7 +28,7 @@ use mem::drop;
 use option::{Some, None};
 use result::{Ok, Err};
 use rt::rtio::{IoFactory, LocalIo, RtioSignal};
-use slice::{ImmutableVector, OwnedVector};
+use slice::ImmutableVector;
 use vec::Vec;
 
 /// Signals that can be sent and received

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -46,7 +46,7 @@ use kinds::Send;
 use mem::replace;
 use option::{None, Option, Some};
 use rt::task::{Task, LocalStorage};
-use slice::{ImmutableVector, MutableVector, OwnedVector};
+use slice::{ImmutableVector, MutableVector};
 use vec::Vec;
 
 /**

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -277,13 +277,13 @@ impl ToStrRadix for $T {
     /// Convert to a string in a given base.
     #[inline]
     fn to_str_radix(&self, radix: uint) -> ~str {
-        let mut buf: ~[u8] = ~[];
+        let mut buf = Vec::new();
         strconv::int_to_str_bytes_common(*self, radix, strconv::SignNeg, |i| {
             buf.push(i);
         });
         // We know we generated valid utf-8, so we don't need to go through that
         // check.
-        unsafe { str::raw::from_utf8_owned(buf) }
+        unsafe { str::raw::from_utf8_owned(buf.move_iter().collect()) }
     }
 }
 

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1779,12 +1779,11 @@ mod bench {
     extern crate test;
     use self::test::Bencher;
     use num;
-    use slice;
     use prelude::*;
 
     #[bench]
     fn bench_pow_function(b: &mut Bencher) {
-        let v = slice::from_fn(1024, |n| n);
+        let v = Vec::from_fn(1024, |n| n);
         b.iter(|| {v.iter().fold(0, |old, new| num::pow(old, *new));});
     }
 }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -10,19 +10,21 @@
 
 #![allow(missing_doc)]
 
+use char;
 use clone::Clone;
 use container::Container;
-use std::cmp::{Ord, Eq};
-use ops::{Add, Sub, Mul, Div, Rem, Neg};
-use option::{None, Option, Some};
-use char;
-use str::{StrSlice};
-use str;
-use slice::{CloneableVector, ImmutableVector, MutableVector};
-use slice::OwnedVector;
-use num;
+use iter::Iterator;
 use num::{NumCast, Zero, One, cast, Int};
 use num::{Round, Float, FPNaN, FPInfinite, ToPrimitive};
+use num;
+use ops::{Add, Sub, Mul, Div, Rem, Neg};
+use option::{None, Option, Some};
+use slice::OwnedVector;
+use slice::{CloneableVector, ImmutableVector, MutableVector};
+use std::cmp::{Ord, Eq};
+use str::{StrSlice};
+use str;
+use vec::Vec;
 
 /// A flag that specifies whether to use exponential (scientific) notation.
 pub enum ExponentFormat {
@@ -293,7 +295,7 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Float+Round+
     }
 
     let neg = num < _0 || (negative_zero && _1 / num == Float::neg_infinity());
-    let mut buf: ~[u8] = ~[];
+    let mut buf = Vec::new();
     let radix_gen: T   = cast(radix as int).unwrap();
 
     let (num, exp) = match exp_format {
@@ -411,23 +413,23 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Float+Round+
                     // If reached left end of number, have to
                     // insert additional digit:
                     if i < 0
-                    || buf[i as uint] == '-' as u8
-                    || buf[i as uint] == '+' as u8 {
+                    || *buf.get(i as uint) == '-' as u8
+                    || *buf.get(i as uint) == '+' as u8 {
                         buf.insert((i + 1) as uint, value2ascii(1));
                         break;
                     }
 
                     // Skip the '.'
-                    if buf[i as uint] == '.' as u8 { i -= 1; continue; }
+                    if *buf.get(i as uint) == '.' as u8 { i -= 1; continue; }
 
                     // Either increment the digit,
                     // or set to 0 if max and carry the 1.
-                    let current_digit = ascii2value(buf[i as uint]);
+                    let current_digit = ascii2value(*buf.get(i as uint));
                     if current_digit < (radix - 1) {
-                        buf[i as uint] = value2ascii(current_digit+1);
+                        *buf.get_mut(i as uint) = value2ascii(current_digit+1);
                         break;
                     } else {
-                        buf[i as uint] = value2ascii(0);
+                        *buf.get_mut(i as uint) = value2ascii(0);
                         i -= 1;
                     }
                 }
@@ -444,25 +446,25 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Float+Round+
         let mut i = buf_max_i;
 
         // discover trailing zeros of fractional part
-        while i > start_fractional_digits && buf[i] == '0' as u8 {
+        while i > start_fractional_digits && *buf.get(i) == '0' as u8 {
             i -= 1;
         }
 
         // Only attempt to truncate digits if buf has fractional digits
         if i >= start_fractional_digits {
             // If buf ends with '.', cut that too.
-            if buf[i] == '.' as u8 { i -= 1 }
+            if *buf.get(i) == '.' as u8 { i -= 1 }
 
             // only resize buf if we actually remove digits
             if i < buf_max_i {
-                buf = buf.slice(0, i + 1).to_owned();
+                buf = Vec::from_slice(buf.slice(0, i + 1));
             }
         }
     } // If exact and trailing '.', just cut that
     else {
         let max_i = buf.len() - 1;
-        if buf[max_i] == '.' as u8 {
-            buf = buf.slice(0, max_i).to_owned();
+        if *buf.get(max_i) == '.' as u8 {
+            buf = Vec::from_slice(buf.slice(0, max_i));
         }
     }
 
@@ -481,7 +483,7 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Float+Round+
         }
     }
 
-    (buf, false)
+    (buf.move_iter().collect(), false)
 }
 
 /**

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -191,13 +191,13 @@ impl ToStrRadix for $T {
     /// Convert to a string in a given base.
     #[inline]
     fn to_str_radix(&self, radix: uint) -> ~str {
-        let mut buf = ~[];
+        let mut buf = Vec::new();
         strconv::int_to_str_bytes_common(*self, radix, strconv::SignNone, |i| {
             buf.push(i);
         });
         // We know we generated valid utf-8, so we don't need to go through that
         // check.
-        unsafe { str::raw::from_utf8_owned(buf) }
+        unsafe { str::raw::from_utf8_owned(buf.move_iter().collect()) }
     }
 }
 

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -74,7 +74,7 @@ use option::{Option, None, Some};
 use str;
 use str::{MaybeOwned, Str, StrSlice, from_utf8_lossy};
 use strbuf::StrBuf;
-use slice::{OwnedCloneableVector, OwnedVector, Vector};
+use slice::Vector;
 use slice::{ImmutableEqVector, ImmutableVector};
 use vec::Vec;
 

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -21,7 +21,7 @@ use option::{Option, None, Some};
 use str;
 use str::Str;
 use slice::{CloneableVector, RevSplits, Splits, Vector, VectorVector,
-            ImmutableEqVector, OwnedVector, ImmutableVector, OwnedCloneableVector};
+            ImmutableEqVector, OwnedVector, ImmutableVector};
 use vec::Vec;
 
 use super::{BytesContainer, GenericPath, GenericPathUnsafe};

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -21,7 +21,7 @@ use io::Writer;
 use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Rev, Iterator, Map};
 use option::{Option, Some, None};
 use slice::{Vector, OwnedVector, ImmutableVector};
-use str::{CharSplits, OwnedStr, Str, StrVector, StrSlice};
+use str::{CharSplits, Str, StrVector, StrSlice};
 use strbuf::StrBuf;
 use vec::Vec;
 

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -56,7 +56,7 @@ pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
 pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
 pub use slice::{ImmutableEqVector, ImmutableTotalOrdVector, ImmutableCloneableVector};
-pub use slice::{OwnedVector, OwnedCloneableVector, OwnedEqVector};
+pub use slice::{OwnedVector};
 pub use slice::{MutableVector, MutableTotalOrdVector};
 pub use slice::{Vector, VectorVector, CloneableVector, ImmutableVector};
 pub use strbuf::StrBuf;

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -170,10 +170,9 @@ pub fn mut_null<T>() -> *mut T { 0 as *mut T }
 ///
 /// ```
 /// use std::ptr;
-/// use std::slice;
 ///
-/// unsafe fn from_buf_raw<T>(ptr: *T, elts: uint) -> ~[T] {
-///     let mut dst = slice::with_capacity(elts);
+/// unsafe fn from_buf_raw<T>(ptr: *T, elts: uint) -> Vec<T> {
+///     let mut dst = Vec::with_capacity(elts);
 ///     dst.set_len(elts);
 ///     ptr::copy_memory(dst.as_mut_ptr(), ptr, elts);
 ///     dst

--- a/src/libstd/repr.rs
+++ b/src/libstd/repr.rs
@@ -28,7 +28,7 @@ use reflect::{MovePtr, align};
 use result::{Ok, Err};
 use str::StrSlice;
 use to_str::ToStr;
-use slice::{Vector, OwnedVector};
+use slice::Vector;
 use intrinsics::{Disr, Opaque, TyDesc, TyVisitor, get_tydesc, visit_tydesc};
 use raw;
 use vec::Vec;

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -125,13 +125,14 @@ mod imp {
     unsafe fn load_argc_and_argv(argc: int, argv: **u8) -> ~[~[u8]] {
         use c_str::CString;
         use ptr::RawPtr;
-        use {slice, libc};
+        use libc;
         use slice::CloneableVector;
+        use vec::Vec;
 
-        slice::from_fn(argc as uint, |i| {
+        Vec::from_fn(argc as uint, |i| {
             let cs = CString::new(*(argv as **libc::c_char).offset(i as int), false);
             cs.as_bytes_no_nul().to_owned()
-        })
+        }).move_iter().collect()
     }
 
     #[cfg(test)]

--- a/src/libstd/sync/arc.rs
+++ b/src/libstd/sync/arc.rs
@@ -23,12 +23,13 @@
 
 use cast;
 use clone::Clone;
+use iter::Iterator;
 use kinds::Send;
 use ops::Drop;
 use ptr::RawPtr;
 use sync::atomics::{fence, AtomicUint, Relaxed, Acquire, Release};
-use slice;
 use ty::Unsafe;
+use vec::Vec;
 
 /// An atomically reference counted pointer.
 ///
@@ -73,7 +74,8 @@ impl<T: Send> UnsafeArc<T> {
                 ~[] // need to free data here
             } else {
                 let ptr = new_inner(data, num_handles);
-                slice::from_fn(num_handles, |_| UnsafeArc { data: ptr })
+                let v = Vec::from_fn(num_handles, |_| UnsafeArc { data: ptr });
+                v.move_iter().collect()
             }
         }
     }

--- a/src/libstd/sync/deque.rs
+++ b/src/libstd/sync/deque.rs
@@ -61,7 +61,7 @@ use ptr::RawPtr;
 use sync::arc::UnsafeArc;
 use sync::atomics::{AtomicInt, AtomicPtr, SeqCst};
 use unstable::sync::Exclusive;
-use slice::{OwnedVector, ImmutableVector};
+use slice::ImmutableVector;
 use vec::Vec;
 
 // Once the queue is less than 1/K full, then it will be downsized. Note that

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn exclusive_new_arc() {
         unsafe {
-            let mut futures = ~[];
+            let mut futures = Vec::new();
 
             let num_tasks = 10;
             let count = 10;

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -20,7 +20,6 @@ use rsparse = parse;
 
 use std::fmt::parse;
 use collections::{HashMap, HashSet};
-use std::slice;
 
 #[deriving(Eq)]
 enum ArgumentType {
@@ -609,7 +608,7 @@ impl<'a, 'b> Context<'a, 'b> {
     fn to_expr(&self, extra: @ast::Expr) -> @ast::Expr {
         let mut lets = Vec::new();
         let mut locals = Vec::new();
-        let mut names = slice::from_fn(self.name_positions.len(), |_| None);
+        let mut names = Vec::from_fn(self.name_positions.len(), |_| None);
         let mut pats = Vec::new();
         let mut heads = Vec::new();
 
@@ -673,7 +672,7 @@ impl<'a, 'b> Context<'a, 'b> {
             let lname = self.ecx.ident_of(format!("__arg{}", *name));
             pats.push(self.ecx.pat_ident(e.span, lname));
             heads.push(self.ecx.expr_addr_of(e.span, e));
-            names[*self.name_positions.get(name)] =
+            *names.get_mut(*self.name_positions.get(name)) =
                 Some(self.format_arg(e.span,
                                      Named((*name).clone()),
                                      self.ecx.expr_ident(e.span, lname)));

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -16,7 +16,6 @@ use collections::{TrieMap, TreeMap, HashMap, HashSet};
 use std::os;
 use rand::{Rng, IsaacRng, SeedableRng};
 use std::uint;
-use std::slice;
 
 fn timed(label: &str, f: ||) {
     let start = time::precise_time_s();
@@ -99,7 +98,7 @@ fn main() {
         }
     };
 
-    let mut rand = slice::with_capacity(n_keys);
+    let mut rand = Vec::with_capacity(n_keys);
 
     {
         let mut rng: IsaacRng = SeedableRng::from_seed(&[1, 1, 1, 1, 1, 1, 1]);
@@ -130,7 +129,7 @@ fn main() {
     {
         println!(" Random integers:");
         let mut map: TreeMap<uint,uint> = TreeMap::new();
-        vector(&mut map, n_keys, rand);
+        vector(&mut map, n_keys, rand.as_slice());
     }
 
     // FIXME: #9970
@@ -149,7 +148,7 @@ fn main() {
     {
         println!(" Random integers:");
         let mut map: HashMap<uint,uint> = HashMap::new();
-        vector(&mut map, n_keys, rand);
+        vector(&mut map, n_keys, rand.as_slice());
     }
 
     // FIXME: #9970
@@ -168,6 +167,6 @@ fn main() {
     {
         println!(" Random integers:");
         let mut map: TrieMap<uint> = TrieMap::new();
-        vector(&mut map, n_keys, rand);
+        vector(&mut map, n_keys, rand.as_slice());
     }
 }

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::os;
-use std::slice;
 
 fn max(a: i32, b: i32) -> i32 {
     if a > b {
@@ -20,12 +19,16 @@ fn max(a: i32, b: i32) -> i32 {
 }
 
 fn fannkuch_redux(n: i32) -> i32 {
-    let mut perm = slice::from_elem(n as uint, 0i32);
-    let mut perm1 = slice::from_fn(n as uint, |i| i as i32);
-    let mut count = slice::from_elem(n as uint, 0i32);
+    let mut perm = Vec::from_elem(n as uint, 0i32);
+    let mut perm1 = Vec::from_fn(n as uint, |i| i as i32);
+    let mut count = Vec::from_elem(n as uint, 0i32);
     let mut max_flips_count = 0i32;
     let mut perm_count = 0i32;
     let mut checksum = 0i32;
+
+    let perm = perm.as_mut_slice();
+    let perm1 = perm1.as_mut_slice();
+    let count = count.as_mut_slice();
 
     let mut r = n;
     loop {

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -12,7 +12,6 @@ use std::cmp::min;
 use std::io::{stdout, IoResult};
 use std::os;
 use std::slice::bytes::copy_memory;
-use std::slice;
 
 static LINE_LEN: uint = 60;
 static LOOKUP_SIZE: uint = 4 * 1024;
@@ -90,10 +89,10 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
 
     fn make(&mut self, n: uint) -> IoResult<()> {
         let alu_len = self.alu.len();
-        let mut buf = slice::from_elem(alu_len + LINE_LEN, 0u8);
+        let mut buf = Vec::from_elem(alu_len + LINE_LEN, 0u8);
         let alu: &[u8] = self.alu.as_bytes();
 
-        copy_memory(buf, alu);
+        copy_memory(buf.as_mut_slice(), alu);
         let buf_len = buf.len();
         copy_memory(buf.mut_slice(alu_len, buf_len),
                     alu.slice_to(LINE_LEN));

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -14,7 +14,6 @@ use std::from_str::FromStr;
 use std::iter::count;
 use std::cmp::min;
 use std::os;
-use std::slice::from_elem;
 use sync::{Arc, RWLock};
 
 fn A(i: uint, j: uint) -> f64 {

--- a/src/test/compile-fail/lint-deprecated-owned-vector.rs
+++ b/src/test/compile-fail/lint-deprecated-owned-vector.rs
@@ -13,5 +13,4 @@
 fn main() {
     ~[1]; //~ ERROR use of deprecated `~[]`
     //~^ ERROR use of deprecated `~[]`
-    std::slice::with_capacity::<int>(10); //~ ERROR use of deprecated `~[]`
 }

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -29,7 +29,12 @@ use test::B;
 
 // Make sure this import is warned about when at least one of its imported names
 // is unused
-use std::slice::{from_fn, from_elem};   //~ ERROR unused import
+use test2::{foo, bar}; //~ ERROR unused import
+
+mod test2 {
+    pub fn foo() {}
+    pub fn bar() {}
+}
 
 mod test {
     pub trait A { fn a(&self) {} }
@@ -66,5 +71,5 @@ fn main() {
     let mut b = 4;
     swap(&mut a, &mut b);
     test::C.b();
-    let _a = from_elem(0, 0);
+    let _a = foo();
 }

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -36,7 +36,7 @@ fn double() {
 }
 
 fn runtest(me: &str) {
-    let mut env = os::env();
+    let mut env = os::env().move_iter().collect::<Vec<(~str, ~str)>>();
     match env.iter().position(|&(ref s, _)| "RUST_BACKTRACE" == *s) {
         Some(i) => { env.remove(i); }
         None => {}


### PR DESCRIPTION
This is all in preparation for DST. This removes all the growable/shrinkable methods from `~[T]`.
