### PR TITLE
Improve pprust-expanded

### DIFF
--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -8,18 +8,49 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::from_str::FromStr;
+use std::fmt;
+
 #[deriving(Clone, Eq)]
-pub enum mode {
-    mode_compile_fail,
-    mode_run_fail,
-    mode_run_pass,
-    mode_pretty,
-    mode_debug_info,
-    mode_codegen
+pub enum Mode {
+    CompileFail,
+    RunFail,
+    RunPass,
+    Pretty,
+    DebugInfo,
+    Codegen
+}
+
+impl FromStr for Mode {
+    fn from_str(s: &str) -> Option<Mode> {
+        match s {
+          "compile-fail" => Some(CompileFail),
+          "run-fail" => Some(RunFail),
+          "run-pass" => Some(RunPass),
+          "pretty" => Some(Pretty),
+          "debug-info" => Some(DebugInfo),
+          "codegen" => Some(Codegen),
+          _ => None,
+        }
+    }
+}
+
+impl fmt::Show for Mode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg = match *self {
+          CompileFail => "compile-fail",
+          RunFail => "run-fail",
+          RunPass => "run-pass",
+          Pretty => "pretty",
+          DebugInfo => "debug-info",
+          Codegen => "codegen",
+        };
+        write!(f.buf, "{}", msg)
+    }
 }
 
 #[deriving(Clone)]
-pub struct config {
+pub struct Config {
     // The library paths required for running the compiler
     pub compile_lib_path: ~str,
 
@@ -48,7 +79,7 @@ pub struct config {
     pub stage_id: ~str,
 
     // The test mode, compile-fail, run-fail, run-pass
-    pub mode: mode,
+    pub mode: Mode,
 
     // Run ignored tests
     pub run_ignored: bool,

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use common::config;
+use common::Config;
 use common;
 use util;
 
@@ -110,11 +110,11 @@ pub fn load_props(testfile: &Path) -> TestProps {
     };
 }
 
-pub fn is_test_ignored(config: &config, testfile: &Path) -> bool {
-    fn ignore_target(config: &config) -> ~str {
+pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
+    fn ignore_target(config: &Config) -> ~str {
         ~"ignore-" + util::get_os(config.target)
     }
-    fn ignore_stage(config: &config) -> ~str {
+    fn ignore_stage(config: &Config) -> ~str {
         ~"ignore-" + config.stage_id.split('-').next().unwrap()
     }
 
@@ -122,7 +122,7 @@ pub fn is_test_ignored(config: &config, testfile: &Path) -> bool {
         if parse_name_directive(ln, "ignore-test") { false }
         else if parse_name_directive(ln, ignore_target(config)) { false }
         else if parse_name_directive(ln, ignore_stage(config)) { false }
-        else if config.mode == common::mode_pretty &&
+        else if config.mode == common::Pretty &&
             parse_name_directive(ln, "ignore-pretty") { false }
         else if config.target != config.host &&
             parse_name_directive(ln, "ignore-cross-compile") { false }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -8,11 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use common::config;
-use common::mode_compile_fail;
-use common::mode_pretty;
-use common::mode_run_fail;
-use common::mode_run_pass;
+use common::Config;
+use common::{CompileFail, Pretty, RunFail, RunPass};
 use errors;
 use header::TestProps;
 use header::load_props;
@@ -36,7 +33,7 @@ use std::task;
 use std::slice;
 use test::MetricMap;
 
-pub fn run(config: config, testfile: ~str) {
+pub fn run(config: Config, testfile: ~str) {
 
     match config.target.as_slice() {
 
@@ -53,7 +50,7 @@ pub fn run(config: config, testfile: ~str) {
     run_metrics(config, testfile, &mut _mm);
 }
 
-pub fn run_metrics(config: config, testfile: ~str, mm: &mut MetricMap) {
+pub fn run_metrics(config: Config, testfile: ~str, mm: &mut MetricMap) {
     if config.verbose {
         // We're going to be dumping a lot of info. Start on a new line.
         print!("\n\n");
@@ -63,16 +60,16 @@ pub fn run_metrics(config: config, testfile: ~str, mm: &mut MetricMap) {
     let props = load_props(&testfile);
     debug!("loaded props");
     match config.mode {
-      mode_compile_fail => run_cfail_test(&config, &props, &testfile),
-      mode_run_fail => run_rfail_test(&config, &props, &testfile),
-      mode_run_pass => run_rpass_test(&config, &props, &testfile),
-      mode_pretty => run_pretty_test(&config, &props, &testfile),
-      mode_debug_info => run_debuginfo_test(&config, &props, &testfile),
-      mode_codegen => run_codegen_test(&config, &props, &testfile, mm)
+      CompileFail => run_cfail_test(&config, &props, &testfile),
+      RunFail => run_rfail_test(&config, &props, &testfile),
+      RunPass => run_rpass_test(&config, &props, &testfile),
+      Pretty => run_pretty_test(&config, &props, &testfile),
+      DebugInfo => run_debuginfo_test(&config, &props, &testfile),
+      Codegen => run_codegen_test(&config, &props, &testfile, mm)
     }
 }
 
-fn run_cfail_test(config: &config, props: &TestProps, testfile: &Path) {
+fn run_cfail_test(config: &Config, props: &TestProps, testfile: &Path) {
     let proc_res = compile_test(config, props, testfile);
 
     if proc_res.status.success() {
@@ -92,7 +89,7 @@ fn run_cfail_test(config: &config, props: &TestProps, testfile: &Path) {
     }
 }
 
-fn run_rfail_test(config: &config, props: &TestProps, testfile: &Path) {
+fn run_rfail_test(config: &Config, props: &TestProps, testfile: &Path) {
     let proc_res = if !config.jit {
         let proc_res = compile_test(config, props, testfile);
 
@@ -125,7 +122,7 @@ fn check_correct_failure_status(proc_res: &ProcRes) {
     }
 }
 
-fn run_rpass_test(config: &config, props: &TestProps, testfile: &Path) {
+fn run_rpass_test(config: &Config, props: &TestProps, testfile: &Path) {
     if !config.jit {
         let mut proc_res = compile_test(config, props, testfile);
 
@@ -145,7 +142,7 @@ fn run_rpass_test(config: &config, props: &TestProps, testfile: &Path) {
     }
 }
 
-fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
+fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
     if props.pp_exact.is_some() {
         logv(config, ~"testing for exact pretty-printing");
     } else { logv(config, ~"testing for converging pretty-printing"); }
@@ -202,12 +199,12 @@ fn run_pretty_test(config: &config, props: &TestProps, testfile: &Path) {
 
     return;
 
-    fn print_source(config: &config, testfile: &Path, src: ~str) -> ProcRes {
+    fn print_source(config: &Config, testfile: &Path, src: ~str) -> ProcRes {
         compose_and_run(config, testfile, make_pp_args(config, testfile),
                         Vec::new(), config.compile_lib_path, Some(src))
     }
 
-    fn make_pp_args(config: &config, _testfile: &Path) -> ProcArgs {
+    fn make_pp_args(config: &Config, _testfile: &Path) -> ProcArgs {
         let args = vec!(~"-", ~"--pretty", ~"normal",
                      ~"--target=" + config.target);
         // FIXME (#9639): This needs to handle non-utf8 paths
@@ -232,13 +229,13 @@ actual:\n\
         }
     }
 
-    fn typecheck_source(config: &config, props: &TestProps,
+    fn typecheck_source(config: &Config, props: &TestProps,
                         testfile: &Path, src: ~str) -> ProcRes {
         let args = make_typecheck_args(config, props, testfile);
         compose_and_run_compiler(config, props, testfile, args, Some(src))
     }
 
-    fn make_typecheck_args(config: &config, props: &TestProps, testfile: &Path) -> ProcArgs {
+    fn make_typecheck_args(config: &Config, props: &TestProps, testfile: &Path) -> ProcArgs {
         let aux_dir = aux_output_dir_name(config, testfile);
         let target = if props.force_host {
             config.host.as_slice()
@@ -259,8 +256,8 @@ actual:\n\
     }
 }
 
-fn run_debuginfo_test(config: &config, props: &TestProps, testfile: &Path) {
-    let mut config = config {
+fn run_debuginfo_test(config: &Config, props: &TestProps, testfile: &Path) {
+    let mut config = Config {
         target_rustcflags: cleanup_debug_info_options(&config.target_rustcflags),
         host_rustcflags: cleanup_debug_info_options(&config.host_rustcflags),
         .. config.clone()
@@ -667,16 +664,16 @@ struct ProcArgs {prog: ~str, args: Vec<~str> }
 
 struct ProcRes {status: ProcessExit, stdout: ~str, stderr: ~str, cmdline: ~str}
 
-fn compile_test(config: &config, props: &TestProps,
+fn compile_test(config: &Config, props: &TestProps,
                 testfile: &Path) -> ProcRes {
     compile_test_(config, props, testfile, [])
 }
 
-fn jit_test(config: &config, props: &TestProps, testfile: &Path) -> ProcRes {
+fn jit_test(config: &Config, props: &TestProps, testfile: &Path) -> ProcRes {
     compile_test_(config, props, testfile, [~"--jit"])
 }
 
-fn compile_test_(config: &config, props: &TestProps,
+fn compile_test_(config: &Config, props: &TestProps,
                  testfile: &Path, extra_args: &[~str]) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
@@ -688,7 +685,7 @@ fn compile_test_(config: &config, props: &TestProps,
     compose_and_run_compiler(config, props, testfile, args, None)
 }
 
-fn exec_compiled_test(config: &config, props: &TestProps,
+fn exec_compiled_test(config: &Config, props: &TestProps,
                       testfile: &Path) -> ProcRes {
 
     let env = props.exec_env.clone();
@@ -709,7 +706,7 @@ fn exec_compiled_test(config: &config, props: &TestProps,
 }
 
 fn compose_and_run_compiler(
-    config: &config,
+    config: &Config,
     props: &TestProps,
     testfile: &Path,
     args: ProcArgs,
@@ -767,7 +764,7 @@ fn ensure_dir(path: &Path) {
     fs::mkdir(path, io::UserRWX).unwrap();
 }
 
-fn compose_and_run(config: &config, testfile: &Path,
+fn compose_and_run(config: &Config, testfile: &Path,
                    ProcArgs{ args, prog }: ProcArgs,
                    procenv: Vec<(~str, ~str)> ,
                    lib_path: &str,
@@ -781,10 +778,10 @@ enum TargetLocation {
     ThisDirectory(Path),
 }
 
-fn make_compile_args(config: &config,
+fn make_compile_args(config: &Config,
                      props: &TestProps,
                      extras: Vec<~str> ,
-                     xform: |&config, &Path| -> TargetLocation,
+                     xform: |&Config, &Path| -> TargetLocation,
                      testfile: &Path)
                      -> ProcArgs {
     let xform_file = xform(config, testfile);
@@ -816,14 +813,14 @@ fn make_compile_args(config: &config,
     return ProcArgs {prog: config.rustc_path.as_str().unwrap().to_owned(), args: args};
 }
 
-fn make_lib_name(config: &config, auxfile: &Path, testfile: &Path) -> Path {
+fn make_lib_name(config: &Config, auxfile: &Path, testfile: &Path) -> Path {
     // what we return here is not particularly important, as it
     // happens; rustc ignores everything except for the directory.
     let auxname = output_testname(auxfile);
     aux_output_dir_name(config, testfile).join(&auxname)
 }
 
-fn make_exe_name(config: &config, testfile: &Path) -> Path {
+fn make_exe_name(config: &Config, testfile: &Path) -> Path {
     let mut f = output_base_name(config, testfile);
     if !os::consts::EXE_SUFFIX.is_empty() {
         match f.filename().map(|s| s + os::consts::EXE_SUFFIX.as_bytes()) {
@@ -834,7 +831,7 @@ fn make_exe_name(config: &config, testfile: &Path) -> Path {
     f
 }
 
-fn make_run_args(config: &config, _props: &TestProps, testfile: &Path) ->
+fn make_run_args(config: &Config, _props: &TestProps, testfile: &Path) ->
    ProcArgs {
     // If we've got another tool to run under (valgrind),
     // then split apart its command
@@ -857,7 +854,7 @@ fn split_maybe_args(argstr: &Option<~str>) -> Vec<~str> {
     }
 }
 
-fn program_output(config: &config, testfile: &Path, lib_path: &str, prog: ~str,
+fn program_output(config: &Config, testfile: &Path, lib_path: &str, prog: ~str,
                   args: Vec<~str> , env: Vec<(~str, ~str)> ,
                   input: Option<~str>) -> ProcRes {
     let cmdline =
@@ -897,23 +894,23 @@ fn lib_path_cmd_prefix(path: &str) -> ~str {
     format!("{}=\"{}\"", util::lib_path_env_var(), util::make_new_path(path))
 }
 
-fn dump_output(config: &config, testfile: &Path, out: &str, err: &str) {
+fn dump_output(config: &Config, testfile: &Path, out: &str, err: &str) {
     dump_output_file(config, testfile, out, "out");
     dump_output_file(config, testfile, err, "err");
     maybe_dump_to_stdout(config, out, err);
 }
 
-fn dump_output_file(config: &config, testfile: &Path,
+fn dump_output_file(config: &Config, testfile: &Path,
                     out: &str, extension: &str) {
     let outfile = make_out_name(config, testfile, extension);
     File::create(&outfile).write(out.as_bytes()).unwrap();
 }
 
-fn make_out_name(config: &config, testfile: &Path, extension: &str) -> Path {
+fn make_out_name(config: &Config, testfile: &Path, extension: &str) -> Path {
     output_base_name(config, testfile).with_extension(extension)
 }
 
-fn aux_output_dir_name(config: &config, testfile: &Path) -> Path {
+fn aux_output_dir_name(config: &Config, testfile: &Path) -> Path {
     let mut f = output_base_name(config, testfile);
     match f.filename().map(|s| s + bytes!(".libaux")) {
         Some(v) => f.set_filename(v),
@@ -926,13 +923,13 @@ fn output_testname(testfile: &Path) -> Path {
     Path::new(testfile.filestem().unwrap())
 }
 
-fn output_base_name(config: &config, testfile: &Path) -> Path {
+fn output_base_name(config: &Config, testfile: &Path) -> Path {
     config.build_base
         .join(&output_testname(testfile))
         .with_extension(config.stage_id.as_slice())
 }
 
-fn maybe_dump_to_stdout(config: &config, out: &str, err: &str) {
+fn maybe_dump_to_stdout(config: &Config, out: &str, err: &str) {
     if config.verbose {
         println!("------{}------------------------------", "stdout");
         println!("{}", out);
@@ -963,7 +960,7 @@ stderr:\n\
     fail!();
 }
 
-fn _arm_exec_compiled_test(config: &config, props: &TestProps,
+fn _arm_exec_compiled_test(config: &Config, props: &TestProps,
                       testfile: &Path, env: Vec<(~str, ~str)> ) -> ProcRes {
 
     let args = make_run_args(config, props, testfile);
@@ -1063,7 +1060,7 @@ fn _arm_exec_compiled_test(config: &config, props: &TestProps,
     }
 }
 
-fn _arm_push_aux_shared_library(config: &config, testfile: &Path) {
+fn _arm_push_aux_shared_library(config: &Config, testfile: &Path) {
     let tdir = aux_output_dir_name(config, testfile);
 
     let dirs = fs::readdir(&tdir).unwrap();
@@ -1086,7 +1083,7 @@ fn _arm_push_aux_shared_library(config: &config, testfile: &Path) {
 
 // codegen tests (vs. clang)
 
-fn make_o_name(config: &config, testfile: &Path) -> Path {
+fn make_o_name(config: &Config, testfile: &Path) -> Path {
     output_base_name(config, testfile).with_extension("o")
 }
 
@@ -1099,7 +1096,7 @@ fn append_suffix_to_stem(p: &Path, suffix: &str) -> Path {
     }
 }
 
-fn compile_test_and_save_bitcode(config: &config, props: &TestProps,
+fn compile_test_and_save_bitcode(config: &Config, props: &TestProps,
                                  testfile: &Path) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
@@ -1112,7 +1109,7 @@ fn compile_test_and_save_bitcode(config: &config, props: &TestProps,
     compose_and_run_compiler(config, props, testfile, args, None)
 }
 
-fn compile_cc_with_clang_and_save_bitcode(config: &config, _props: &TestProps,
+fn compile_cc_with_clang_and_save_bitcode(config: &Config, _props: &TestProps,
                                           testfile: &Path) -> ProcRes {
     let bitcodefile = output_base_name(config, testfile).with_extension("bc");
     let bitcodefile = append_suffix_to_stem(&bitcodefile, "clang");
@@ -1128,7 +1125,7 @@ fn compile_cc_with_clang_and_save_bitcode(config: &config, _props: &TestProps,
     compose_and_run(config, testfile, proc_args, Vec::new(), "", None)
 }
 
-fn extract_function_from_bitcode(config: &config, _props: &TestProps,
+fn extract_function_from_bitcode(config: &Config, _props: &TestProps,
                                  fname: &str, testfile: &Path,
                                  suffix: &str) -> ProcRes {
     let bitcodefile = output_base_name(config, testfile).with_extension("bc");
@@ -1145,7 +1142,7 @@ fn extract_function_from_bitcode(config: &config, _props: &TestProps,
     compose_and_run(config, testfile, proc_args, Vec::new(), "", None)
 }
 
-fn disassemble_extract(config: &config, _props: &TestProps,
+fn disassemble_extract(config: &Config, _props: &TestProps,
                        testfile: &Path, suffix: &str) -> ProcRes {
     let bitcodefile = output_base_name(config, testfile).with_extension("bc");
     let bitcodefile = append_suffix_to_stem(&bitcodefile, suffix);
@@ -1169,7 +1166,7 @@ fn count_extracted_lines(p: &Path) -> uint {
 }
 
 
-fn run_codegen_test(config: &config, props: &TestProps,
+fn run_codegen_test(config: &Config, props: &TestProps,
                     testfile: &Path, mm: &mut MetricMap) {
 
     if config.llvm_bin_path.is_none() {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -157,9 +157,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
     let mut round = 0;
     while round < rounds {
         logv(config, format!("pretty-printing round {}", round));
-        let proc_res = print_source(config,
-                                    testfile,
-                                    (*srcs.get(round)).clone());
+        let proc_res = print_source(config, props, testfile, (*srcs.get(round)).clone(), "normal");
 
         if !proc_res.status.success() {
             fatal_ProcRes(format!("pretty-printing failed in round {}", round),
@@ -197,16 +195,41 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
         fatal_ProcRes(~"pretty-printed source does not typecheck", &proc_res);
     }
 
+    // additionally, run `--pretty expanded` and try to build it.
+    let proc_res = print_source(config, props, testfile, (*srcs.get(round)).clone(), "expanded");
+    if !proc_res.status.success() {
+        fatal_ProcRes(format!("pretty-printing (expanded) failed"), &proc_res);
+    }
+
+    let ProcRes{ stdout: expanded_src, .. } = proc_res;
+    let proc_res = typecheck_source(config, props, testfile, expanded_src);
+    if !proc_res.status.success() {
+        fatal_ProcRes(format!("pretty-printed source (expanded) does not typecheck"), &proc_res);
+    }
+
     return;
 
-    fn print_source(config: &Config, testfile: &Path, src: ~str) -> ProcRes {
-        compose_and_run(config, testfile, make_pp_args(config, testfile),
+    fn print_source(config: &Config,
+                    props: &TestProps,
+                    testfile: &Path,
+                    src: ~str,
+                    pretty_type: &str) -> ProcRes {
+        compose_and_run(config, testfile,
+                        make_pp_args(config, props, testfile, pretty_type.to_owned()),
                         Vec::new(), config.compile_lib_path, Some(src))
     }
 
-    fn make_pp_args(config: &Config, _testfile: &Path) -> ProcArgs {
-        let args = vec!(~"-", ~"--pretty", ~"normal",
-                     ~"--target=" + config.target);
+    fn make_pp_args(config: &Config,
+                    props: &TestProps,
+                    testfile: &Path,
+                    pretty_type: ~str) -> ProcArgs {
+        let aux_dir = aux_output_dir_name(config, testfile);
+        let mut args = vec!(~"-", ~"--pretty", pretty_type,
+                     ~"--target=" + config.target,
+                     ~"-L",
+                     aux_dir.as_str().unwrap().to_owned());
+        args.push_all_move(split_maybe_args(&config.target_rustcflags));
+        args.push_all_move(split_maybe_args(&props.compile_flags));
         // FIXME (#9639): This needs to handle non-utf8 paths
         return ProcArgs {prog: config.rustc_path.as_str().unwrap().to_owned(), args: args};
     }

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use common::config;
+use common::Config;
 
 #[cfg(target_os = "win32")]
 use std::os::getenv;
@@ -51,7 +51,7 @@ pub fn lib_path_env_var() -> ~str { ~"PATH" }
 #[cfg(target_os = "win32")]
 pub fn path_div() -> ~str { ~";" }
 
-pub fn logv(config: &config, s: ~str) {
+pub fn logv(config: &Config, s: ~str) {
     debug!("{}", s);
     if config.verbose { println!("{}", s); }
 }

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -97,6 +97,7 @@ impl<'a> fold::Folder for StandardLibraryInjector<'a> {
             });
         }
 
+        // `extern crate` must be precede `use` items
         vis.push_all_move(krate.module.view_items.clone());
         let new_module = ast::Mod {
             view_items: vis,
@@ -127,8 +128,20 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
         if !no_prelude(krate.attrs.as_slice()) {
             // only add `use std::prelude::*;` if there wasn't a
             // `#![no_implicit_prelude]` at the crate level.
+
+            let mut attrs = krate.attrs.clone();
+
+            // fold_mod() will insert glob path.
+            let globs_attr = attr::mk_attr(attr::mk_list_item(
+                InternedString::new("feature"),
+                vec!(
+                    attr::mk_word_item(InternedString::new("globs")),
+                )));
+            attrs.push(globs_attr);
+
             ast::Crate {
                 module: self.fold_mod(&krate.module),
+                attrs: attrs,
                 ..krate
             }
         } else {
@@ -172,11 +185,20 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
             span: DUMMY_SP,
         };
 
-        let vis = (vec!(vi2)).append(module.view_items.as_slice());
+        let (crates, uses) = module.view_items.partitioned(|x| {
+            match x.node {
+                ast::ViewItemExternCrate(..) => true,
+                _ => false,
+            }
+        });
 
-        // FIXME #2543: Bad copy.
+        // add vi2 after any `extern crate` but before any `use`
+        let mut view_items = crates;
+        view_items.push(vi2);
+        view_items.push_all_move(uses);
+
         let new_module = ast::Mod {
-            view_items: vis,
+            view_items: view_items,
             ..(*module).clone()
         };
         fold::noop_fold_mod(&new_module, self)

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -175,6 +175,21 @@ pub fn mk_sugared_doc_attr(text: InternedString, lo: BytePos, hi: BytePos)
     spanned(lo, hi, attr)
 }
 
+pub fn rename_attr(attr: &Attribute, new_name: &str) -> Attribute {
+    let new_mname = token::intern_and_get_ident(new_name);
+    let meta = attr.meta();
+    let new_item: ast::MetaItem_ = match meta.node {
+        ast::MetaWord(_) => ast::MetaWord(new_mname),
+        ast::MetaList(_, ref v) => ast::MetaList(new_mname, (*v).clone()),
+        ast::MetaNameValue(_, ref l) => ast::MetaNameValue(new_mname, (*l).clone()),
+    };
+
+    dummy_spanned(ast::Attribute_ {
+        value: @dummy_spanned(new_item),
+        .. (attr.node).clone()
+    })
+}
+
 /* Searching */
 /// Check if `needle` occurs in `haystack` by a structural
 /// comparison. This is slightly subtle, and relies on ignoring the

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -156,7 +156,7 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
             //     }
             //   }
 
-            let local_ident = token::gensym_ident("i");
+            let local_ident = token::gensym_ident("__i"); // FIXME #13573
             let next_ident = fld.cx.ident_of("next");
             let none_ident = fld.cx.ident_of("None");
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -947,6 +947,10 @@ impl<'a> State<'a> {
     }
 
     pub fn print_attribute(&mut self, attr: &ast::Attribute) -> IoResult<()> {
+        // skip any attribute which starts with `!`. it's only for internal usage.
+        if attr.name().get().char_at(0) == '!' {
+            return Ok(());
+        }
         try!(self.hardbreak_if_not_bol());
         try!(self.maybe_print_comment(attr.span.lo));
         if attr.node.is_sugared_doc {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1261,11 +1261,6 @@ impl<'a> State<'a> {
                 }
 
                 try!(self.print_mutability(m));
-                // Avoid `& &e` => `&&e`.
-                match (m, &expr.node) {
-                    (ast::MutImmutable, &ast::ExprAddrOf(..)) => try!(space(&mut self.s)),
-                    _ => { }
-                }
 
                 try!(self.print_expr_maybe_paren(expr));
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -247,6 +247,15 @@ pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> ~str {
     }
 }
 
+fn needs_parentheses(expr: &ast::Expr) -> bool {
+    match expr.node {
+        ast::ExprAssign(..) | ast::ExprBinary(..) |
+        ast::ExprFnBlock(..) | ast::ExprProc(..) |
+        ast::ExprAssignOp(..) | ast::ExprCast(..) => true,
+        _ => false,
+    }
+}
+
 impl<'a> State<'a> {
     pub fn ibox(&mut self, u: uint) -> IoResult<()> {
         self.boxes.push(pp::Inconsistent);
@@ -1118,6 +1127,18 @@ impl<'a> State<'a> {
         self.pclose()
     }
 
+    pub fn print_expr_maybe_paren(&mut self, expr: &ast::Expr) -> IoResult<()> {
+        let needs_par = needs_parentheses(expr);
+        if needs_par {
+            try!(self.popen());
+        }
+        try!(self.print_expr(expr));
+        if needs_par {
+            try!(self.pclose());
+        }
+        Ok(())
+    }
+
     pub fn print_expr(&mut self, expr: &ast::Expr) -> IoResult<()> {
         try!(self.maybe_print_comment(expr.span.lo));
         try!(self.ibox(indent_unit));
@@ -1191,7 +1212,7 @@ impl<'a> State<'a> {
                 try!(self.pclose());
             }
             ast::ExprCall(func, ref args) => {
-                try!(self.print_expr(func));
+                try!(self.print_expr_maybe_paren(func));
                 try!(self.print_call_post(args.as_slice()));
             }
             ast::ExprMethodCall(ident, ref tys, ref args) => {
@@ -1215,17 +1236,38 @@ impl<'a> State<'a> {
             }
             ast::ExprUnary(op, expr) => {
                 try!(word(&mut self.s, ast_util::unop_to_str(op)));
-                try!(self.print_expr(expr));
+                try!(self.print_expr_maybe_paren(expr));
             }
             ast::ExprAddrOf(m, expr) => {
                 try!(word(&mut self.s, "&"));
+
+                // `ExprAddrOf(ExprLit("str"))` should be `&&"str"` instead of `&"str"`
+                // since `&"str"` is `ExprVstore(ExprLit("str"))` which has same meaning to
+                // `"str"`.
+                // In many cases adding parentheses (`&("str")`) would help, but it become invalid
+                // if expr is in `PatLit()`.
+                let needs_extra_amp = match expr.node {
+                    ast::ExprLit(lit) => {
+                        match lit.node {
+                            ast::LitStr(..) => true,
+                            _ => false,
+                        }
+                    }
+                    ast::ExprVec(..) => true,
+                    _ => false,
+                };
+                if needs_extra_amp {
+                    try!(word(&mut self.s, "&"));
+                }
+
                 try!(self.print_mutability(m));
                 // Avoid `& &e` => `&&e`.
                 match (m, &expr.node) {
                     (ast::MutImmutable, &ast::ExprAddrOf(..)) => try!(space(&mut self.s)),
                     _ => { }
                 }
-                try!(self.print_expr(expr));
+
+                try!(self.print_expr_maybe_paren(expr));
             }
             ast::ExprLit(lit) => try!(self.print_literal(lit)),
             ast::ExprCast(expr, ty) => {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1493,22 +1493,27 @@ impl<'a> State<'a> {
                 try!(self.popen());
                 try!(self.print_string(a.asm.get(), a.asm_str_style));
                 try!(self.word_space(":"));
-                for &(ref co, o) in a.outputs.iter() {
-                    try!(self.print_string(co.get(), ast::CookedStr));
-                    try!(self.popen());
-                    try!(self.print_expr(o));
-                    try!(self.pclose());
-                    try!(self.word_space(","));
-                }
+
+                try!(self.commasep(Inconsistent, a.outputs.as_slice(), |s, &(ref co, o)| {
+                    try!(s.print_string(co.get(), ast::CookedStr));
+                    try!(s.popen());
+                    try!(s.print_expr(o));
+                    try!(s.pclose());
+                    Ok(())
+                }));
+                try!(space(&mut self.s));
                 try!(self.word_space(":"));
-                for &(ref co, o) in a.inputs.iter() {
-                    try!(self.print_string(co.get(), ast::CookedStr));
-                    try!(self.popen());
-                    try!(self.print_expr(o));
-                    try!(self.pclose());
-                    try!(self.word_space(","));
-                }
+
+                try!(self.commasep(Inconsistent, a.inputs.as_slice(), |s, &(ref co, o)| {
+                    try!(s.print_string(co.get(), ast::CookedStr));
+                    try!(s.popen());
+                    try!(s.print_expr(o));
+                    try!(s.pclose());
+                    Ok(())
+                }));
+                try!(space(&mut self.s));
                 try!(self.word_space(":"));
+
                 try!(self.print_string(a.clobbers.get(), ast::CookedStr));
                 try!(self.pclose());
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -168,7 +168,7 @@ pub fn tt_to_str(tt: &ast::TokenTree) -> ~str {
 }
 
 pub fn tts_to_str(tts: &[ast::TokenTree]) -> ~str {
-    to_str(|s| s.print_tts(&tts))
+    to_str(|s| s.print_tts(tts))
 }
 
 pub fn stmt_to_str(stmt: &ast::Stmt) -> ~str {
@@ -709,7 +709,7 @@ impl<'a> State<'a> {
                 try!(self.print_ident(item.ident));
                 try!(self.cbox(indent_unit));
                 try!(self.popen());
-                try!(self.print_tts(&(tts.as_slice())));
+                try!(self.print_tts(tts.as_slice()));
                 try!(self.pclose());
                 try!(self.end());
             }
@@ -818,7 +818,7 @@ impl<'a> State<'a> {
     /// expression arguments as expressions). It can be done! I think.
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> IoResult<()> {
         match *tt {
-            ast::TTDelim(ref tts) => self.print_tts(&(tts.as_slice())),
+            ast::TTDelim(ref tts) => self.print_tts(tts.as_slice()),
             ast::TTTok(_, ref tk) => {
                 word(&mut self.s, parse::token::to_str(tk))
             }
@@ -843,7 +843,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_tts(&mut self, tts: & &[ast::TokenTree]) -> IoResult<()> {
+    pub fn print_tts(&mut self, tts: &[ast::TokenTree]) -> IoResult<()> {
         try!(self.ibox(0));
         for (i, tt) in tts.iter().enumerate() {
             if i != 0 {
@@ -1104,7 +1104,7 @@ impl<'a> State<'a> {
                 try!(self.print_path(pth, false));
                 try!(word(&mut self.s, "!"));
                 try!(self.popen());
-                try!(self.print_tts(&tts.as_slice()));
+                try!(self.print_tts(tts.as_slice()));
                 self.pclose()
             }
         }

--- a/src/test/run-fail/run-unexported-tests.rs
+++ b/src/test/run-fail/run-unexported-tests.rs
@@ -11,6 +11,7 @@
 // error-pattern:runned an unexported test
 // compile-flags:--test
 // check-stdout
+// ignore-pretty: does not work well with `--test`
 
 mod m {
     pub fn exported() { }

--- a/src/test/run-fail/test-fail.rs
+++ b/src/test/run-fail/test-fail.rs
@@ -11,6 +11,7 @@
 // check-stdout
 // error-pattern:task 'test_foo' failed at
 // compile-flags: --test
+// ignore-pretty: does not work well with `--test`
 
 #[test]
 fn test_foo() {

--- a/src/test/run-fail/test-tasks-invalid-value.rs
+++ b/src/test/run-fail/test-tasks-invalid-value.rs
@@ -14,6 +14,7 @@
 // error-pattern:should be a positive integer
 // compile-flags: --test
 // exec-env:RUST_TEST_TASKS=foo
+// ignore-pretty: does not work well with `--test`
 
 #[test]
 fn do_nothing() {}

--- a/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
+++ b/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // ignore-android
+// ignore-pretty: does not work well with `--test`
+
 #![feature(quote)]
 #![deny(unused_variable)]
 

--- a/src/test/run-pass/assert-eq-macro-success.rs
+++ b/src/test/run-pass/assert-eq-macro-success.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(managed_boxes)]
+
 #[deriving(Eq, Show)]
 struct Point { x : int }
 

--- a/src/test/run-pass/binops.rs
+++ b/src/test/run-pass/binops.rs
@@ -10,6 +10,8 @@
 
 // Binop corner cases
 
+#![feature(managed_boxes)]
+
 fn test_nil() {
     assert_eq!((), ());
     assert!((!(() != ())));

--- a/src/test/run-pass/box-compare.rs
+++ b/src/test/run-pass/box-compare.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+#![feature(managed_boxes)]
 
 pub fn main() {
     assert!((@1 < @3));

--- a/src/test/run-pass/hygienic-labels-in-let.rs
+++ b/src/test/run-pass/hygienic-labels-in-let.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty: pprust doesn't print hygiene output
+
 #![feature(macro_rules)]
 
 macro_rules! loop_x {

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-#![feature(macro_rules)]
+#![feature(macro_rules, managed_boxes)]
 #![deny(warnings)]
 #![allow(unused_must_use)]
 #![allow(deprecated_owned_vector)]

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty: `--pretty expand` creates unnecessary `unsafe` block
 
 #![feature(macro_rules, managed_boxes)]
 #![deny(warnings)]

--- a/src/test/run-pass/nullable-pointer-iotareduction.rs
+++ b/src/test/run-pass/nullable-pointer-iotareduction.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(macro_rules)]
+#![feature(macro_rules, managed_boxes)]
 
 use std::{option, cast};
 

--- a/src/test/run-pass/nullable-pointer-size.rs
+++ b/src/test/run-pass/nullable-pointer-size.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(macro_rules)]
+#![feature(macro_rules, managed_boxes)]
 
 use std::mem;
 

--- a/src/test/run-pass/shebang.rs
+++ b/src/test/run-pass/shebang.rs
@@ -9,6 +9,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pp-exact
+// ignore-pretty: `expand` addes some preludes before shebang
 
 pub fn main() { println!("Hello World"); }

--- a/src/test/run-pass/test-ignore-cfg.rs
+++ b/src/test/run-pass/test-ignore-cfg.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: --test --cfg ignorecfg
+// ignore-pretty: does not work well with `--test`
 
 #[test]
 #[ignore(cfg(ignorecfg))]

--- a/src/test/run-pass/test-runner-hides-main.rs
+++ b/src/test/run-pass/test-runner-hides-main.rs
@@ -10,6 +10,7 @@
 
 // compile-flags:--test
 // ignore-win32 #10872
+// ignore-pretty: does not work well with `--test`
 
 // Building as a test runner means that a synthetic main will be run,
 // not ours


### PR DESCRIPTION
This patchset fixes some bugs regarding pprust-expanded,
and make compiletest run `--pretty expanded` tests.
