### PR TITLE
Add git to README.md dependency list because configure requires it

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ documentation.
     * `perl` 5.0 or later
     * GNU `make` 3.81 or later
     * `curl`
+    * `git`
 2. Download and build Rust:
 
     You can either download a [tarball] or build directly from the [repo].


### PR DESCRIPTION
Configure required git be installed so this should be added to the dependencies list.  If it's only required when using git, a note could also be added.
