### PR TITLE
Fix smallest-hello-world.rs interaction with `puts`

### DIFF
--- a/src/test/run-pass/smallest-hello-world.rs
+++ b/src/test/run-pass/smallest-hello-world.rs
@@ -26,7 +26,7 @@ pub extern fn rust_stack_exhausted() {}
 #[no_split_stack]
 fn main(_: int, _: **u8) -> int {
     unsafe {
-        let (ptr, _): (*u8, uint) = transmute("Hello!");
+        let (ptr, _): (*u8, uint) = transmute("Hello!\0");
         puts(ptr);
     }
     return 0;


### PR DESCRIPTION
It now hands `puts` a zero-terminated string, like it expects.

Fix #13603.
