### PR TITLE
Update libuv

### DIFF
--- a/src/librustuv/async.rs
+++ b/src/librustuv/async.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::cast;
-use libc::c_int;
 use std::rt::rtio::{Callback, RemoteCallback};
 use std::unstable::sync::Exclusive;
 
@@ -54,8 +53,7 @@ impl UvHandle<uvll::uv_async_t> for AsyncWatcher {
     }
 }
 
-extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {
-    assert!(status == 0);
+extern fn async_cb(handle: *uvll::uv_async_t) {
     let payload: &mut Payload = unsafe {
         cast::transmute(uvll::get_data_for_uv_handle(handle))
     };

--- a/src/librustuv/idle.rs
+++ b/src/librustuv/idle.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::cast;
-use libc::{c_int, c_void};
+use libc::c_void;
 
 use uvll;
 use super::{Loop, UvHandle};
@@ -46,8 +46,7 @@ impl IdleWatcher {
             assert_eq!(uvll::uv_idle_start(handle, onetime_cb), 0)
         }
 
-        extern fn onetime_cb(handle: *uvll::uv_idle_t, status: c_int) {
-            assert_eq!(status, 0);
+        extern fn onetime_cb(handle: *uvll::uv_idle_t) {
             unsafe {
                 let data = uvll::get_data_for_uv_handle(handle);
                 let f: ~proc() = cast::transmute(data);
@@ -82,8 +81,7 @@ impl UvHandle<uvll::uv_idle_t> for IdleWatcher {
     fn uv_handle(&self) -> *uvll::uv_idle_t { self.handle }
 }
 
-extern fn idle_cb(handle: *uvll::uv_idle_t, status: c_int) {
-    assert_eq!(status, 0);
+extern fn idle_cb(handle: *uvll::uv_idle_t) {
     let idle: &mut IdleWatcher = unsafe { UvHandle::from_uv_handle(&handle) };
     idle.callback.call();
 }

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -255,10 +255,9 @@ impl TcpWatcher {
             n => Err(UvError(n))
         };
 
-        extern fn timer_cb(handle: *uvll::uv_timer_t, status: c_int) {
+        extern fn timer_cb(handle: *uvll::uv_timer_t) {
             // Don't close the corresponding tcp request, just wake up the task
             // and let RAII take care of the pending watcher.
-            assert_eq!(status, 0);
             let cx: &mut Ctx = unsafe {
                 &mut *(uvll::get_data_for_uv_handle(handle) as *mut Ctx)
             };
@@ -599,8 +598,7 @@ impl rtio::RtioTcpAcceptor for TcpAcceptor {
         self.timeout_tx = Some(tx);
         self.timeout_rx = Some(rx);
 
-        extern fn timer_cb(timer: *uvll::uv_timer_t, status: c_int) {
-            assert_eq!(status, 0);
+        extern fn timer_cb(timer: *uvll::uv_timer_t) {
             let acceptor: &mut TcpAcceptor = unsafe {
                 &mut *(uvll::get_data_for_uv_handle(timer) as *mut TcpAcceptor)
             };

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -21,7 +21,7 @@
 #![allow(dead_code)]
 
 use std::cast;
-use libc::{c_void, c_int};
+use libc::c_void;
 use std::rt::task::BlockedTask;
 use std::unstable::mutex::NativeMutex;
 use std::sync::arc::UnsafeArc;
@@ -55,8 +55,7 @@ pub struct Queue {
     queue: UnsafeArc<State>,
 }
 
-extern fn async_cb(handle: *uvll::uv_async_t, status: c_int) {
-    assert_eq!(status, 0);
+extern fn async_cb(handle: *uvll::uv_async_t) {
     let pool: &mut QueuePool = unsafe {
         cast::transmute(uvll::get_data_for_uv_handle(handle))
     };

--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use libc::c_int;
 use std::mem;
 use std::rt::rtio::RtioTimer;
 use std::rt::task::BlockedTask;
@@ -137,9 +136,8 @@ impl RtioTimer for TimerWatcher {
     }
 }
 
-extern fn timer_cb(handle: *uvll::uv_timer_t, status: c_int) {
+extern fn timer_cb(handle: *uvll::uv_timer_t) {
     let _f = ForbidSwitch::new("timer callback can't switch");
-    assert_eq!(status, 0);
     let timer: &mut TimerWatcher = unsafe { UvHandle::from_uv_handle(&handle) };
 
     match timer.action.take_unwrap() {

--- a/src/librustuv/tty.rs
+++ b/src/librustuv/tty.rs
@@ -40,7 +40,7 @@ impl TtyWatcher {
         // - https://github.com/joyent/libuv/issues/982
         // - https://github.com/joyent/libuv/issues/988
         let guess = unsafe { uvll::guess_handle(fd) };
-        if readable && guess != uvll::UV_TTY as libc::c_int {
+        if guess != uvll::UV_TTY as libc::c_int {
             return Err(UvError(uvll::EBADF));
         }
 

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -23,7 +23,7 @@ use libc::{O_CREAT, O_APPEND, O_TRUNC, O_RDWR, O_RDONLY, O_WRONLY, S_IRUSR,
 use libc;
 use std::path::Path;
 use std::rt::rtio;
-use std::rt::rtio::IoFactory;
+use std::rt::rtio::{IoFactory, EventLoop};
 use ai = std::io::net::addrinfo;
 
 #[cfg(test)] use std::unstable::run_in_bare_thread;
@@ -69,14 +69,20 @@ impl Drop for UvEventLoop {
         // the loop is free'd (use-after-free). We also must free the uv handle
         // after the loop has been closed because during the closing of the loop
         // the handle is required to be used apparently.
+        //
+        // Lastly, after we've closed the pool of handles we pump the event loop
+        // one last time to run any closing callbacks to make sure the loop
+        // shuts down cleanly.
         let handle = self.uvio.handle_pool.get_ref().handle();
         drop(self.uvio.handle_pool.take());
+        self.run();
+
         self.uvio.loop_.close();
         unsafe { uvll::free_handle(handle) }
     }
 }
 
-impl rtio::EventLoop for UvEventLoop {
+impl EventLoop for UvEventLoop {
     fn run(&mut self) {
         self.uvio.loop_.run();
     }
@@ -110,7 +116,6 @@ impl rtio::EventLoop for UvEventLoop {
 
 #[test]
 fn test_callback_run_once() {
-    use std::rt::rtio::EventLoop;
     run_in_bare_thread(proc() {
         let mut event_loop = UvEventLoop::new();
         let mut count = 0;

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -212,8 +212,7 @@ impl uv_stat_t {
     }
 }
 
-pub type uv_idle_cb = extern "C" fn(handle: *uv_idle_t,
-                                    status: c_int);
+pub type uv_idle_cb = extern "C" fn(handle: *uv_idle_t);
 pub type uv_alloc_cb = extern "C" fn(stream: *uv_stream_t,
                                      suggested_size: size_t,
                                      buf: *mut uv_buf_t);
@@ -230,14 +229,12 @@ pub type uv_udp_recv_cb = extern "C" fn(handle: *uv_udp_t,
 pub type uv_close_cb = extern "C" fn(handle: *uv_handle_t);
 pub type uv_walk_cb = extern "C" fn(handle: *uv_handle_t,
                                     arg: *c_void);
-pub type uv_async_cb = extern "C" fn(handle: *uv_async_t,
-                                     status: c_int);
+pub type uv_async_cb = extern "C" fn(handle: *uv_async_t);
 pub type uv_connect_cb = extern "C" fn(handle: *uv_connect_t,
                                        status: c_int);
 pub type uv_connection_cb = extern "C" fn(handle: *uv_connection_t,
                                           status: c_int);
-pub type uv_timer_cb = extern "C" fn(handle: *uv_timer_t,
-                                     status: c_int);
+pub type uv_timer_cb = extern "C" fn(handle: *uv_timer_t);
 pub type uv_write_cb = extern "C" fn(handle: *uv_write_t,
                                      status: c_int);
 pub type uv_getaddrinfo_cb = extern "C" fn(req: *uv_getaddrinfo_t,
@@ -597,10 +594,12 @@ extern {
                       flags: c_int, mode: c_int, cb: uv_fs_cb) -> c_int;
     pub fn uv_fs_unlink(loop_ptr: *uv_loop_t, req: *uv_fs_t, path: *c_char,
                         cb: uv_fs_cb) -> c_int;
-    pub fn uv_fs_write(l: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
-                       len: size_t, offset: i64, cb: uv_fs_cb) -> c_int;
-    pub fn uv_fs_read(l: *uv_loop_t, req: *uv_fs_t, fd: c_int, buf: *c_void,
-                      len: size_t, offset: i64, cb: uv_fs_cb) -> c_int;
+    pub fn uv_fs_write(l: *uv_loop_t, req: *uv_fs_t, fd: c_int,
+                       bufs: *uv_buf_t, nbufs: c_uint,
+                       offset: i64, cb: uv_fs_cb) -> c_int;
+    pub fn uv_fs_read(l: *uv_loop_t, req: *uv_fs_t, fd: c_int,
+                      bufs: *uv_buf_t, nbufs: c_uint,
+                      offset: i64, cb: uv_fs_cb) -> c_int;
     pub fn uv_fs_close(l: *uv_loop_t, req: *uv_fs_t, fd: c_int,
                        cb: uv_fs_cb) -> c_int;
     pub fn uv_fs_stat(l: *uv_loop_t, req: *uv_fs_t, path: *c_char,

--- a/src/libstd/hash/sip.rs
+++ b/src/libstd/hash/sip.rs
@@ -364,7 +364,7 @@ mod tests {
     use option::{Some, None};
     use str::{Str,StrSlice};
     use strbuf::StrBuf;
-    use slice::{Vector, ImmutableVector, OwnedVector};
+    use slice::{Vector, ImmutableVector};
     use self::test::Bencher;
 
     use super::super::Hash;

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -67,9 +67,9 @@ mod imp {
     use clone::Clone;
     use option::{Option, Some, None};
     use iter::Iterator;
-    use str::StrSlice;
     use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     use mem;
+    #[cfg(not(test))] use str::StrSlice;
     #[cfg(not(test))] use ptr::RawPtr;
 
     static mut global_args_ptr: uint = 0;

--- a/src/rt/libuv-auto-clean-trigger
+++ b/src/rt/libuv-auto-clean-trigger
@@ -1,2 +1,2 @@
 # Change the contents of this file to force a full rebuild of libuv
-2014-02-16
+2014-04-18


### PR DESCRIPTION
This update brings a few months of changes, but primarily a fix for the
following situation.

When creating a handle to stdin, libuv used to set the stdin handle to
nonblocking mode. This would end up affect this stdin handle across all
processes that shared it, which mean that stdin become nonblocking for everyone
using the same stdin. On linux, this also affected _stdout_ because stdin/stdout
roughly point at the same thing.

This problem became apparent when running the test suite manually on a local
computer. The stdtest suite (running with libgreen) would set stdout to
nonblocking mode (as described above), and then the next test suite would always
fail for a printing failure (because stdout was returning EAGAIN).

This has been fixed upstream, joyent/libuv@342e8c, and this update pulls in this
fix. This also brings us in line with a recently upstreamed libuv patch.

Closes #12827
Closes #13336
Closes #13355
