### PR TITLE
rustc: Ensure closures are "split-stack"

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -709,6 +709,7 @@ pub mod llvm {
         pub fn LLVMSetGC(Fn: ValueRef, Name: *c_char);
         pub fn LLVMAddFunctionAttr(Fn: ValueRef, PA: c_uint);
         pub fn LLVMAddFunctionAttrString(Fn: ValueRef, Name: *c_char);
+        pub fn LLVMRemoveFunctionAttrString(Fn: ValueRef, Name: *c_char);
         pub fn LLVMGetFunctionAttr(Fn: ValueRef) -> c_ulonglong;
 
         pub fn LLVMAddReturnAttribute(Fn: ValueRef, PA: c_uint);

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -199,6 +199,7 @@ fn decl_fn(llmod: ModuleRef, name: &str, cc: lib::llvm::CallConv,
     lib::llvm::SetFunctionCallConv(llfn, cc);
     // Function addresses in Rust are never significant, allowing functions to be merged.
     lib::llvm::SetUnnamedAddr(llfn, true);
+    set_split_stack(llfn);
 
     llfn
 }
@@ -445,8 +446,8 @@ pub fn set_llvm_fn_attrs(attrs: &[ast::Attribute], llfn: ValueRef) {
     }
 
     // Add the no-split-stack attribute if requested
-    if !contains_name(attrs, "no_split_stack") {
-        set_split_stack(llfn);
+    if contains_name(attrs, "no_split_stack") {
+        unset_split_stack(llfn);
     }
 
     if contains_name(attrs, "cold") {
@@ -461,6 +462,12 @@ pub fn set_always_inline(f: ValueRef) {
 pub fn set_split_stack(f: ValueRef) {
     "split-stack".with_c_str(|buf| {
         unsafe { llvm::LLVMAddFunctionAttrString(f, buf); }
+    })
+}
+
+pub fn unset_split_stack(f: ValueRef) {
+    "split-stack".with_c_str(|buf| {
+        unsafe { llvm::LLVMRemoveFunctionAttrString(f, buf); }
     })
 }
 

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -77,6 +77,18 @@ extern "C" void LLVMAddFunctionAttrString(LLVMValueRef fn, const char *Name) {
   unwrap<Function>(fn)->addFnAttr(Name);
 }
 
+extern "C" void LLVMRemoveFunctionAttrString(LLVMValueRef fn, const char *Name) {
+  Function *f = unwrap<Function>(fn);
+  LLVMContext &C = f->getContext();
+  AttrBuilder B;
+  B.addAttribute(Name);
+  AttributeSet to_remove = AttributeSet::get(C, AttributeSet::FunctionIndex, B);
+
+  AttributeSet attrs = f->getAttributes();
+  f->setAttributes(attrs.removeAttributes(f->getContext(),
+                                          AttributeSet::FunctionIndex,
+                                          to_remove));
+}
 
 extern "C" void LLVMAddReturnAttribute(LLVMValueRef Fn, LLVMAttribute PA) {
   Function *A = unwrap<Function>(Fn);


### PR DESCRIPTION
In upgrading LLVM, only rust functions had the "split-stack" attribute added.
This commit changes the addition of LLVM's "split-stack" attribute to _always_
occur and then we remove it sometimes if the "no_split_stack" rust attribute is
present.

Closes #13625
