### PR TITLE
green: Fix missing Send bounds on procedures

### DIFF
--- a/src/libgreen/basic.rs
+++ b/src/libgreen/basic.rs
@@ -243,7 +243,7 @@ mod test {
         })
     }
 
-    fn run(f: proc()) {
+    fn run(f: proc():Send) {
         let mut pool = pool();
         pool.spawn(TaskOpts::new(), f);
         pool.shutdown();

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -46,7 +46,7 @@ impl Context {
     /// FIXME: this is basically an awful the interface. The main reason for
     ///        this is to reduce the number of allocations made when a green
     ///        task is spawned as much as possible
-    pub fn new(init: InitFn, arg: uint, start: proc(),
+    pub fn new(init: InitFn, arg: uint, start: proc():Send,
                stack: &mut Stack) -> Context {
 
         let sp: *uint = stack.end();

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -289,7 +289,7 @@ macro_rules! green_start( ($f:ident) => (
 /// error.
 pub fn start(argc: int, argv: **u8,
              event_loop_factory: fn() -> ~rtio::EventLoop:Send,
-             main: proc()) -> int {
+             main: proc():Send) -> int {
     rt::init(argc, argv);
     let mut main = Some(main);
     let mut ret = None;
@@ -310,7 +310,7 @@ pub fn start(argc: int, argv: **u8,
 /// This function will not return until all schedulers in the associated pool
 /// have returned.
 pub fn run(event_loop_factory: fn() -> ~rtio::EventLoop:Send,
-           main: proc()) -> int {
+           main: proc():Send) -> int {
     // Create a scheduler pool and spawn the main task into this pool. We will
     // get notified over a channel when the main task exits.
     let mut cfg = PoolConfig::new();
@@ -445,7 +445,7 @@ impl SchedPool {
     /// This is useful to create a task which can then be sent to a specific
     /// scheduler created by `spawn_sched` (and possibly pin it to that
     /// scheduler).
-    pub fn task(&mut self, opts: TaskOpts, f: proc()) -> ~GreenTask {
+    pub fn task(&mut self, opts: TaskOpts, f: proc():Send) -> ~GreenTask {
         GreenTask::configure(&mut self.stack_pool, opts, f)
     }
 
@@ -455,7 +455,7 @@ impl SchedPool {
     /// New tasks are spawned in a round-robin fashion to the schedulers in this
     /// pool, but tasks can certainly migrate among schedulers once they're in
     /// the pool.
-    pub fn spawn(&mut self, opts: TaskOpts, f: proc()) {
+    pub fn spawn(&mut self, opts: TaskOpts, f: proc():Send) {
         let task = self.task(opts, f);
 
         // Figure out someone to send this task to

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -1027,7 +1027,7 @@ mod test {
         })
     }
 
-    fn run(f: proc()) {
+    fn run(f: proc():Send) {
         let mut pool = pool();
         pool.spawn(TaskOpts::new(), f);
         pool.shutdown();

--- a/src/libgreen/simple.rs
+++ b/src/libgreen/simple.rs
@@ -72,7 +72,7 @@ impl Runtime for SimpleTask {
     // feet and running.
     fn yield_now(~self, _cur_task: ~Task) { fail!() }
     fn maybe_yield(~self, _cur_task: ~Task) { fail!() }
-    fn spawn_sibling(~self, _cur_task: ~Task, _opts: TaskOpts, _f: proc()) {
+    fn spawn_sibling(~self, _cur_task: ~Task, _opts: TaskOpts, _f: proc():Send) {
         fail!()
     }
     fn local_io<'a>(&'a mut self) -> Option<rtio::LocalIo<'a>> { None }

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -129,7 +129,7 @@ impl GreenTask {
     /// and will not have any contained Task structure.
     pub fn new(stack_pool: &mut StackPool,
                stack_size: Option<uint>,
-               start: proc()) -> ~GreenTask {
+               start: proc():Send) -> ~GreenTask {
         GreenTask::new_homed(stack_pool, stack_size, AnySched, start)
     }
 
@@ -137,7 +137,7 @@ impl GreenTask {
     pub fn new_homed(stack_pool: &mut StackPool,
                      stack_size: Option<uint>,
                      home: Home,
-                     start: proc()) -> ~GreenTask {
+                     start: proc():Send) -> ~GreenTask {
         // Allocate ourselves a GreenTask structure
         let mut ops = GreenTask::new_typed(None, TypeGreen(Some(home)));
 
@@ -175,7 +175,7 @@ impl GreenTask {
     /// new stack for this task.
     pub fn configure(pool: &mut StackPool,
                      opts: TaskOpts,
-                     f: proc()) -> ~GreenTask {
+                     f: proc():Send) -> ~GreenTask {
         let TaskOpts {
             notify_chan, name, stack_size,
             stderr, stdout,
@@ -443,7 +443,7 @@ impl Runtime for GreenTask {
         }
     }
 
-    fn spawn_sibling(mut ~self, cur_task: ~Task, opts: TaskOpts, f: proc()) {
+    fn spawn_sibling(mut ~self, cur_task: ~Task, opts: TaskOpts, f: proc():Send) {
         self.put_task(cur_task);
 
         // Spawns a task into the current scheduler. We allocate the new task's
@@ -490,7 +490,7 @@ mod tests {
     use super::super::{PoolConfig, SchedPool};
     use super::GreenTask;
 
-    fn spawn_opts(opts: TaskOpts, f: proc()) {
+    fn spawn_opts(opts: TaskOpts, f: proc():Send) {
         let mut pool = SchedPool::new(PoolConfig {
             threads: 1,
             event_loop_factory: ::rustuv::event_loop,


### PR DESCRIPTION
These were mistakenly not updated as part of the removal of the Send bound by
default on procedures.

cc #13629
