### PR TITLE
mk: Pass exact compile to rustc on cross compiles

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -542,6 +542,8 @@ ifdef CFG_CCACHE_BASEDIR
   export CCACHE_BASEDIR
 endif
 
+FIND_COMPILER = $(word 1,$(1:ccache=))
+
 define CFG_MAKE_TOOLCHAIN
   # Prepend the tools with their prefix if cross compiling
   ifneq ($(CFG_BUILD),$(1))
@@ -549,7 +551,8 @@ define CFG_MAKE_TOOLCHAIN
 	CXX_$(1)=$(CROSS_PREFIX_$(1))$(CXX_$(1))
 	CPP_$(1)=$(CROSS_PREFIX_$(1))$(CPP_$(1))
 	AR_$(1)=$(CROSS_PREFIX_$(1))$(AR_$(1))
-	RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(CXX_$(1)) -C ar=$$(AR_$(1)) $(RUSTC_CROSS_FLAGS_$(1))
+	RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(call FIND_COMPILER,$$(CXX_$(1))) \
+	    -C ar=$$(call FIND_COMPILER,$$(AR_$(1))) $(RUSTC_CROSS_FLAGS_$(1))
 
 	RUSTC_FLAGS_$(1)=$$(RUSTC_CROSS_FLAGS_$(1)) $(RUSTC_FLAGS_$(1))
   endif


### PR DESCRIPTION
Instead of passing through CC which may have things like ccache and other
arguments (when using clang) this commit filters out the necessary arguments
from CC to pass the right linker to rustc.

Closes #13562
