### PR TITLE
Refactor ty_vec - represent &[T] as &([T])

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -191,7 +191,7 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
                         }
                     }
                 }
-                ty::ty_vec(..) => {
+                ty::ty_vec(..) | ty::ty_rptr(..) => {
                     match *ctor {
                         vec(n) => Some(format!("vectors of length {}", n)),
                         _ => None
@@ -258,50 +258,57 @@ fn is_useful(cx: &MatchCheckCtxt, m: &matrix, v: &[@Pat]) -> useful {
           None => {
             match ty::get(left_ty).sty {
               ty::ty_bool => {
-                match is_useful_specialized(cx, m, v,
-                                            val(const_bool(true)),
-                                            0u, left_ty){
-                  not_useful => {
-                    is_useful_specialized(cx, m, v,
-                                          val(const_bool(false)),
-                                          0u, left_ty)
+                  match is_useful_specialized(cx, m, v,
+                                              val(const_bool(true)),
+                                              0u, left_ty){
+                      not_useful => {
+                          is_useful_specialized(cx, m, v,
+                                                val(const_bool(false)),
+                                                0u, left_ty)
+                      }
+                      ref u => (*u).clone(),
                   }
-                  ref u => (*u).clone(),
-                }
               }
               ty::ty_enum(eid, _) => {
-                for va in (*ty::enum_variants(cx.tcx, eid)).iter() {
-                    match is_useful_specialized(cx, m, v, variant(va.id),
-                                                va.args.len(), left_ty) {
-                      not_useful => (),
-                      ref u => return (*u).clone(),
-                    }
-                }
-                not_useful
-              }
-              ty::ty_vec(_, ty::VstoreFixed(n)) => {
-                is_useful_specialized(cx, m, v, vec(n), n, left_ty)
-              }
-              ty::ty_vec(..) => {
-                let max_len = m.iter().rev().fold(0, |max_len, r| {
-                  match r.get(0).node {
-                    PatVec(ref before, _, ref after) => {
-                      cmp::max(before.len() + after.len(), max_len)
-                    }
-                    _ => max_len
+                  for va in (*ty::enum_variants(cx.tcx, eid)).iter() {
+                      match is_useful_specialized(cx, m, v, variant(va.id),
+                                                  va.args.len(), left_ty) {
+                        not_useful => (),
+                        ref u => return (*u).clone(),
+                      }
                   }
-                });
-                for n in iter::range(0u, max_len + 1) {
-                  match is_useful_specialized(cx, m, v, vec(n), n, left_ty) {
-                    not_useful => (),
-                    ref u => return (*u).clone(),
-                  }
-                }
-                not_useful
+                  not_useful
               }
+              ty::ty_vec(_, Some(n)) => {
+                  is_useful_specialized(cx, m, v, vec(n), n, left_ty)
+              }
+              ty::ty_vec(..) => fail!("impossible case"),
+              ty::ty_rptr(_, ty::mt{ty: ty, ..}) | ty::ty_uniq(ty) => match ty::get(ty).sty {
+                  ty::ty_vec(_, None) => {
+                      let max_len = m.iter().rev().fold(0, |max_len, r| {
+                          match r.get(0).node {
+                              PatVec(ref before, _, ref after) => {
+                                  cmp::max(before.len() + after.len(), max_len)
+                              }
+                              _ => max_len
+                          }
+                      });
+                      for n in iter::range(0u, max_len + 1) {
+                          match is_useful_specialized(cx, m, v, vec(n), n, left_ty) {
+                              not_useful => (),
+                              ref u => return (*u).clone(),
+                          }
+                      }
+                      not_useful
+                  }
+                  _ => {
+                      let arity = ctor_arity(cx, &single, left_ty);
+                      is_useful_specialized(cx, m, v, single, arity, left_ty)
+                  }
+              },
               _ => {
-                let arity = ctor_arity(cx, &single, left_ty);
-                is_useful_specialized(cx, m, v, single, arity, left_ty)
+                  let arity = ctor_arity(cx, &single, left_ty);
+                  is_useful_specialized(cx, m, v, single, arity, left_ty)
               }
             }
           }
@@ -394,17 +401,16 @@ fn is_wild(cx: &MatchCheckCtxt, p: @Pat) -> bool {
 }
 
 fn missing_ctor(cx: &MatchCheckCtxt,
-                    m: &matrix,
-                    left_ty: ty::t)
-                 -> Option<ctor> {
-    match ty::get(left_ty).sty {
-      ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_rptr(..) | ty::ty_tup(_) |
-      ty::ty_struct(..) => {
-        for r in m.iter() {
-            if !is_wild(cx, *r.get(0)) { return None; }
-        }
-        return Some(single);
-      }
+                m: &matrix,
+                left_ty: ty::t)
+                -> Option<ctor> {
+    return match ty::get(left_ty).sty {
+      ty::ty_box(_) | ty::ty_tup(_) |
+      ty::ty_struct(..) => check_matrix_for_wild(cx, m),
+      ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty: ty, ..}) => match ty::get(ty).sty {
+          ty::ty_vec(_, None) => ctor_for_slice(m),
+          _ => check_matrix_for_wild(cx, m),
+      },
       ty::ty_enum(eid, _) => {
         let mut found = Vec::new();
         for r in m.iter() {
@@ -441,7 +447,7 @@ fn missing_ctor(cx: &MatchCheckCtxt,
         else if true_found { Some(val(const_bool(false))) }
         else { Some(val(const_bool(true))) }
       }
-      ty::ty_vec(_, ty::VstoreFixed(n)) => {
+      ty::ty_vec(_, Some(n)) => {
         let mut missing = true;
         let mut wrong = false;
         for r in m.iter() {
@@ -464,8 +470,19 @@ fn missing_ctor(cx: &MatchCheckCtxt,
           _         => None
         }
       }
-      ty::ty_vec(..) => {
+      ty::ty_vec(..) => fail!("impossible case"),
+      _ => Some(single)
+    };
 
+    fn check_matrix_for_wild(cx: &MatchCheckCtxt, m: &matrix) -> Option<ctor> {
+        for r in m.iter() {
+            if !is_wild(cx, *r.get(0)) { return None; }
+        }
+        return Some(single);
+    }
+
+    // For slice and ~[T].
+    fn ctor_for_slice(m: &matrix) -> Option<ctor> {
         // Find the lengths and slices of all vector patterns.
         let mut vec_pat_lens = m.iter().filter_map(|r| {
             match r.get(0).node {
@@ -511,31 +528,37 @@ fn missing_ctor(cx: &MatchCheckCtxt,
           Some(k) => Some(vec(k)),
           None => None
         }
-      }
-      _ => Some(single)
     }
 }
 
 fn ctor_arity(cx: &MatchCheckCtxt, ctor: &ctor, ty: ty::t) -> uint {
-    match ty::get(ty).sty {
-      ty::ty_tup(ref fs) => fs.len(),
-      ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_rptr(..) => 1u,
-      ty::ty_enum(eid, _) => {
-          let id = match *ctor { variant(id) => id,
-          _ => fail!("impossible case") };
-        match ty::enum_variants(cx.tcx, eid).iter().find(|v| v.id == id ) {
-            Some(v) => v.args.len(),
-            None => fail!("impossible case")
-        }
-      }
-      ty::ty_struct(cid, _) => ty::lookup_struct_fields(cx.tcx, cid).len(),
-      ty::ty_vec(..) => {
+    fn vec_ctor_arity(ctor: &ctor) -> uint {
         match *ctor {
-          vec(n) => n,
-          _ => 0u
+            vec(n) => n,
+            _ => 0u
         }
-      }
-      _ => 0u
+    }
+
+    match ty::get(ty).sty {
+        ty::ty_tup(ref fs) => fs.len(),
+        ty::ty_box(_) => 1u,
+        ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty: ty, ..}) => match ty::get(ty).sty {
+            ty::ty_vec(_, None) => vec_ctor_arity(ctor),
+            _ => 1u,
+        },
+        ty::ty_enum(eid, _) => {
+            let id = match *ctor {
+                variant(id) => id,
+                _ => fail!("impossible case")
+            };
+            match ty::enum_variants(cx.tcx, eid).iter().find(|v| v.id == id ) {
+                Some(v) => v.args.len(),
+                None => fail!("impossible case")
+            }
+        }
+        ty::ty_struct(cid, _) => ty::lookup_struct_fields(cx.tcx, cid).len(),
+        ty::ty_vec(_, Some(_)) => vec_ctor_arity(ctor),
+        _ => 0u
     }
 }
 

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -918,7 +918,6 @@ fn check_heap_type(cx: &Context, span: Span, ty: ty::t) {
                     n_box += 1;
                 }
                 ty::ty_uniq(_) | ty::ty_str(ty::VstoreUniq) |
-                ty::ty_vec(_, ty::VstoreUniq) |
                 ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) |
                 ty::ty_closure(~ty::ClosureTy { store: ty::UniqTraitStore, .. }) => {
                     n_uniq += 1;
@@ -1156,10 +1155,13 @@ fn check_unused_result(cx: &Context, s: &ast::Stmt) {
 fn check_deprecated_owned_vector(cx: &Context, e: &ast::Expr) {
     let t = ty::expr_ty(cx.tcx, e);
     match ty::get(t).sty {
-        ty::ty_vec(_, ty::VstoreUniq) => {
-            cx.span_lint(DeprecatedOwnedVector, e.span,
-                         "use of deprecated `~[]` vector; replaced by `std::vec::Vec`")
-        }
+        ty::ty_uniq(t) => match ty::get(t).sty {
+            ty::ty_vec(_, None) => {
+                cx.span_lint(DeprecatedOwnedVector, e.span,
+                             "use of deprecated `~[]` vector; replaced by `std::vec::Vec`")
+            }
+            _ => {}
+        },
         _ => {}
     }
 }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -438,7 +438,8 @@ impl<'a,'b> Clone for ArmData<'a, 'b> {
 struct Match<'a,'b> {
     pats: Vec<@ast::Pat> ,
     data: ArmData<'a,'b>,
-    bound_ptrs: Vec<(Ident, ValueRef)> }
+    bound_ptrs: Vec<(Ident, ValueRef)>
+}
 
 impl<'a,'b> Repr for Match<'a,'b> {
     fn repr(&self, tcx: &ty::ctxt) -> ~str {
@@ -1109,8 +1110,9 @@ fn extract_vec_elems<'a>(
         let slice_begin = tvec::pointer_add_byte(bcx, base, slice_byte_offset);
         let slice_len_offset = C_uint(bcx.ccx(), elem_count - 1u);
         let slice_len = Sub(bcx, len, slice_len_offset);
-        let slice_ty = ty::mk_vec(bcx.tcx(), vt.unit_ty,
-                                  ty::VstoreSlice(ty::ReStatic, ast::MutImmutable));
+        let slice_ty = ty::mk_slice(bcx.tcx(),
+                                    ty::ReStatic,
+                                    ty::mt {ty: vt.unit_ty, mutbl: ast::MutImmutable});
         let scratch = rvalue_scratch_datum(bcx, slice_ty, "");
         Store(bcx, slice_begin,
               GEPi(bcx, scratch.val, [0u, abi::slice_elt_base]));

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -188,7 +188,7 @@ fn decl_fn(llmod: ModuleRef, name: &str, cc: lib::llvm::CallConv,
         // FIXME #6750 ~Trait cannot be directly marked as
         // noalias because the actual object pointer is nested.
         ty::ty_uniq(..) | // ty::ty_trait(_, _, ty::UniqTraitStore, _, _) |
-        ty::ty_vec(_, ty::VstoreUniq) | ty::ty_str(ty::VstoreUniq) => {
+        ty::ty_str(ty::VstoreUniq) => {
             unsafe {
                 llvm::LLVMAddReturnAttribute(llfn, lib::llvm::NoAliasAttribute as c_uint);
             }
@@ -260,7 +260,7 @@ pub fn decl_rust_fn(ccx: &CrateContext, has_env: bool,
             // FIXME #6750 ~Trait cannot be directly marked as
             // noalias because the actual object pointer is nested.
             ty::ty_uniq(..) | // ty::ty_trait(_, _, ty::UniqTraitStore, _, _) |
-            ty::ty_vec(_, ty::VstoreUniq) | ty::ty_str(ty::VstoreUniq) |
+            ty::ty_str(ty::VstoreUniq) |
             ty::ty_closure(~ty::ClosureTy {store: ty::UniqTraitStore, ..}) => {
                 unsafe {
                     llvm::LLVMAddAttribute(llarg, lib::llvm::NoAliasAttribute as c_uint);
@@ -664,8 +664,12 @@ pub fn iter_structural_ty<'r,
               }
           })
       }
-      ty::ty_str(ty::VstoreFixed(n)) |
-      ty::ty_vec(_, ty::VstoreFixed(n)) => {
+      ty::ty_str(ty::VstoreFixed(n)) => {
+        let unit_ty = ty::sequence_element_type(cx.tcx(), t);
+        let (base, len) = tvec::get_fixed_base_and_byte_len(cx, av, unit_ty, n);
+        cx = tvec::iter_vec_raw(cx, base, unit_ty, len, f);
+      }
+      ty::ty_vec(_, Some(n)) => {
         let unit_ty = ty::sequence_element_type(cx.tcx(), t);
         let (base, len) = tvec::get_fixed_base_and_byte_len(cx, av, unit_ty, n);
         cx = tvec::iter_vec_raw(cx, base, unit_ty, len, f);

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -653,7 +653,7 @@ pub fn trans_call_inner<'a>(
         match ty::get(ret_ty).sty {
             // `~` pointer return values never alias because ownership
             // is transferred
-            ty::ty_uniq(..) | ty::ty_vec(_, ty::VstoreUniq) => {
+            ty::ty_uniq(..) => {
                 attrs.push((0, NoAliasAttribute));
             }
             _ => {}

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -711,8 +711,12 @@ pub enum MonoDataClass {
 pub fn mono_data_classify(t: ty::t) -> MonoDataClass {
     match ty::get(t).sty {
         ty::ty_float(_) => MonoFloat,
-        ty::ty_rptr(..) | ty::ty_uniq(..) | ty::ty_box(..) |
-        ty::ty_str(ty::VstoreUniq) | ty::ty_vec(_, ty::VstoreUniq) |
+        ty::ty_rptr(_, mt) => match ty::get(mt.ty).sty {
+            ty::ty_vec(_, None) => MonoBits,
+            _ => MonoNonNull,
+        },
+        ty::ty_uniq(..) | ty::ty_box(..) |
+        ty::ty_str(ty::VstoreUniq) |
         ty::ty_bare_fn(..) => MonoNonNull,
         // Is that everything?  Would closures or slices qualify?
         _ => MonoBits

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -2202,27 +2202,27 @@ fn type_metadata(cx: &CrateContext,
         ty::ty_box(typ) => {
             create_pointer_to_box_metadata(cx, t, typ)
         },
-        ty::ty_vec(ty, ref vstore) => {
-            match *vstore {
-                ty::VstoreFixed(len) => {
-                    fixed_vec_metadata(cx, ty, len, usage_site_span)
-                }
-                ty::VstoreUniq => {
-                    let vec_metadata = vec_metadata(cx, ty, usage_site_span);
+        ty::ty_vec(ref mt, Some(len)) => fixed_vec_metadata(cx, mt.ty, len, usage_site_span),
+        ty::ty_uniq(typ) => {
+            match ty::get(typ).sty {
+                ty::ty_vec(ref mt, None) => {
+                    let vec_metadata = vec_metadata(cx, mt.ty, usage_site_span);
                     pointer_type_metadata(cx, t, vec_metadata)
                 }
-                ty::VstoreSlice(..) => {
-                    vec_slice_metadata(cx, t, ty, usage_site_span)
+                _ => {
+                    let pointee = type_metadata(cx, typ, usage_site_span);
+                    pointer_type_metadata(cx, t, pointee)
                 }
             }
-        },
-        ty::ty_uniq(typ) => {
-            let pointee = type_metadata(cx, typ, usage_site_span);
-            pointer_type_metadata(cx, t, pointee)
         }
         ty::ty_ptr(ref mt) | ty::ty_rptr(_, ref mt) => {
-            let pointee = type_metadata(cx, mt.ty, usage_site_span);
-            pointer_type_metadata(cx, t, pointee)
+            match ty::get(mt.ty).sty {
+                ty::ty_vec(ref mt, None) => vec_slice_metadata(cx, t, mt.ty, usage_site_span),
+                _ => {
+                    let pointee = type_metadata(cx, mt.ty, usage_site_span);
+                    pointer_type_metadata(cx, t, pointee)
+                }
+            }
         },
         ty::ty_bare_fn(ref barefnty) => {
             subroutine_type_metadata(cx, &barefnty.sig, usage_site_span)

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -117,14 +117,17 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
         ty::ty_float(t) => Type::float_from_ty(cx, t),
 
         ty::ty_str(ty::VstoreUniq) |
-        ty::ty_vec(_, ty::VstoreUniq) |
         ty::ty_box(..) |
         ty::ty_uniq(..) |
-        ty::ty_ptr(..) |
-        ty::ty_rptr(..) => Type::i8p(cx),
+        ty::ty_ptr(..) => Type::i8p(cx),
+        ty::ty_rptr(_, mt) => {
+            match ty::get(mt.ty).sty {
+                ty::ty_vec(_, None) => Type::struct_(cx, [Type::i8p(cx), Type::i8p(cx)], false),
+                _ => Type::i8p(cx),
+            }
+        }
 
-        ty::ty_str(ty::VstoreSlice(..)) |
-        ty::ty_vec(_, ty::VstoreSlice(..)) => {
+        ty::ty_str(ty::VstoreSlice(..)) => {
             Type::struct_(cx, [Type::i8p(cx), Type::i8p(cx)], false)
         }
 
@@ -133,8 +136,8 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
         ty::ty_trait(..) => Type::opaque_trait(cx),
 
         ty::ty_str(ty::VstoreFixed(size)) => Type::array(&Type::i8(cx), size as u64),
-        ty::ty_vec(ty, ty::VstoreFixed(size)) => {
-            Type::array(&sizing_type_of(cx, ty), size as u64)
+        ty::ty_vec(mt, Some(size)) => {
+            Type::array(&sizing_type_of(cx, mt.ty), size as u64)
         }
 
         ty::ty_tup(..) | ty::ty_enum(..) => {
@@ -153,7 +156,8 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
             }
         }
 
-        ty::ty_self(_) | ty::ty_infer(..) | ty::ty_param(..) | ty::ty_err(..) => {
+        ty::ty_self(_) | ty::ty_infer(..) | ty::ty_param(..) |
+        ty::ty_err(..) | ty::ty_vec(_, None) => {
             cx.sess().bug(format!("fictitious type {:?} in sizing_type_of()",
                                   ty::get(t).sty))
         }
@@ -215,18 +219,21 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
           Type::at_box(cx, type_of(cx, typ)).ptr_to()
       }
       ty::ty_uniq(typ) => {
-          type_of(cx, typ).ptr_to()
-      }
-      ty::ty_vec(ty, ty::VstoreUniq) => {
-          Type::vec(cx, &type_of(cx, ty)).ptr_to()
+          match ty::get(typ).sty {
+              ty::ty_vec(mt, None) => Type::vec(cx, &type_of(cx, mt.ty)).ptr_to(),
+              _ => type_of(cx, typ).ptr_to(),
+          }
       }
       ty::ty_ptr(ref mt) => type_of(cx, mt.ty).ptr_to(),
-      ty::ty_rptr(_, ref mt) => type_of(cx, mt.ty).ptr_to(),
-
-      ty::ty_vec(ty, ty::VstoreSlice(..)) => {
-          let p_ty = type_of(cx, ty).ptr_to();
-          let u_ty = Type::uint_from_ty(cx, ast::TyU);
-          Type::struct_(cx, [p_ty, u_ty], false)
+      ty::ty_rptr(_, ref mt) => {
+          match ty::get(mt.ty).sty {
+              ty::ty_vec(mt, None) => {
+                  let p_ty = type_of(cx, mt.ty).ptr_to();
+                  let u_ty = Type::uint_from_ty(cx, ast::TyU);
+                  Type::struct_(cx, [p_ty, u_ty], false)
+              }
+              _ => type_of(cx, mt.ty).ptr_to(),
+          }
       }
 
       ty::ty_str(ty::VstoreSlice(..)) => {
@@ -238,8 +245,8 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
           Type::array(&Type::i8(cx), (n + 1u) as u64)
       }
 
-      ty::ty_vec(ty, ty::VstoreFixed(n)) => {
-          Type::array(&type_of(cx, ty), n as u64)
+      ty::ty_vec(ref mt, Some(n)) => {
+          Type::array(&type_of(cx, mt.ty), n as u64)
       }
 
       ty::ty_bare_fn(_) => {
@@ -271,7 +278,9 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
               adt::incomplete_type_of(cx, repr, name)
           }
       }
-      ty::ty_self(..) => cx.sess().unimpl("type_of: ty_self"),
+
+      ty::ty_vec(_, None) => cx.sess().bug("type_of with unszied ty_vec"),
+      ty::ty_self(..) => cx.sess().unimpl("type_of with ty_self"),
       ty::ty_infer(..) => cx.sess().bug("type_of with ty_infer"),
       ty::ty_param(..) => cx.sess().bug("type_of with ty_param"),
       ty::ty_err(..) => cx.sess().bug("type_of with ty_err")

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -130,16 +130,14 @@ pub struct mt {
 }
 
 #[deriving(Clone, Eq, TotalEq, Encodable, Decodable, Hash, Show)]
-/// Describes the "storage mode" of a `[]`, whether it's fixed length or a slice.
-///
-/// Set M to () to disable mutable slices.
-pub enum Vstore<M = ast::Mutability> {
+/// Describes the "storage mode" of a str, whether it's fixed length or a slice.
+pub enum Vstore {
     /// [T, ..N]
     VstoreFixed(uint),
     /// ~[T]
     VstoreUniq,
     /// &[T] and &mut [T]
-    VstoreSlice(Region, M)
+    VstoreSlice(Region)
 }
 
 #[deriving(Clone, Eq, TotalEq, Hash, Encodable, Decodable, Show)]
@@ -735,8 +733,8 @@ pub enum sty {
     ty_enum(DefId, substs),
     ty_box(t),
     ty_uniq(t),
-    ty_str(Vstore<()>),
-    ty_vec(t, Vstore),
+    ty_str(Vstore),
+    ty_vec(mt, Option<uint>),
     ty_ptr(mt),
     ty_rptr(Region, mt),
     ty_bare_fn(BareFnTy),
@@ -813,7 +811,7 @@ pub enum type_err {
     terr_regions_no_overlap(Region, Region),
     terr_regions_insufficiently_polymorphic(BoundRegion, Region),
     terr_regions_overly_polymorphic(BoundRegion, Region),
-    terr_vstores_differ(terr_vstore_kind, expected_found<Vstore<()>>),
+    terr_vstores_differ(terr_vstore_kind, expected_found<Vstore>),
     terr_trait_stores_differ(terr_vstore_kind, expected_found<TraitStore>),
     terr_in_field(@type_err, ast::Ident),
     terr_sorts(expected_found<t>),
@@ -1179,12 +1177,8 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
         return f;
     }
     match &st {
-      &ty_str(VstoreSlice(r, ())) => {
+      &ty_str(VstoreSlice(r)) => {
         flags |= rflags(r);
-      }
-      &ty_vec(ty, VstoreSlice(r, _)) => {
-        flags |= rflags(r);
-        flags |= get(ty).flags;
       }
       &ty_nil | &ty_bool | &ty_char | &ty_int(_) | &ty_float(_) | &ty_uint(_) |
       &ty_str(_) => {}
@@ -1212,10 +1206,10 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
               _ => {}
           }
       }
-      &ty_box(tt) | &ty_uniq(tt) | &ty_vec(tt, _) => {
+      &ty_box(tt) | &ty_uniq(tt) => {
         flags |= get(tt).flags
       }
-      &ty_ptr(ref m) => {
+      &ty_ptr(ref m) | &ty_vec(ref m, _) => {
         flags |= get(m.ty).flags;
       }
       &ty_rptr(r, ref m) => {
@@ -1349,7 +1343,7 @@ pub fn mk_mach_float(tm: ast::FloatTy) -> t {
 #[inline]
 pub fn mk_char() -> t { mk_prim_t(&primitives::TY_CHAR) }
 
-pub fn mk_str(cx: &ctxt, v: Vstore<()>) -> t {
+pub fn mk_str(cx: &ctxt, v: Vstore) -> t {
     mk_t(cx, ty_str(v))
 }
 
@@ -1385,8 +1379,16 @@ pub fn mk_nil_ptr(cx: &ctxt) -> t {
     mk_ptr(cx, mt {ty: mk_nil(), mutbl: ast::MutImmutable})
 }
 
-pub fn mk_vec(cx: &ctxt, ty: t, v: Vstore) -> t {
-    mk_t(cx, ty_vec(ty, v))
+pub fn mk_vec(cx: &ctxt, tm: mt, sz: Option<uint>) -> t {
+    mk_t(cx, ty_vec(tm, sz))
+}
+
+pub fn mk_slice(cx: &ctxt, r: Region, tm: mt) -> t {
+    mk_rptr(cx, r,
+            mt {
+                ty: mk_vec(cx, tm, None),
+                mutbl: tm.mutbl
+            })
 }
 
 pub fn mk_tup(cx: &ctxt, ts: Vec<t>) -> t { mk_t(cx, ty_tup(ts)) }
@@ -1465,8 +1467,8 @@ pub fn maybe_walk_ty(ty: t, f: |t| -> bool) {
         ty_nil | ty_bot | ty_bool | ty_char | ty_int(_) | ty_uint(_) | ty_float(_) |
         ty_str(_) | ty_self(_) |
         ty_infer(_) | ty_param(_) | ty_err => {}
-        ty_box(ty) | ty_uniq(ty) | ty_vec(ty, _) => maybe_walk_ty(ty, f),
-        ty_ptr(ref tm) | ty_rptr(_, ref tm) => {
+        ty_box(ty) | ty_uniq(ty) => maybe_walk_ty(ty, f),
+        ty_ptr(ref tm) | ty_rptr(_, ref tm) | ty_vec(ref tm, _) => {
             maybe_walk_ty(tm.ty, f);
         }
         ty_enum(_, ref substs) | ty_struct(_, ref substs) |
@@ -1601,13 +1603,23 @@ pub fn type_is_self(ty: t) -> bool {
     }
 }
 
+fn type_is_slice(ty:t) -> bool {
+    match get(ty).sty {
+        ty_rptr(_, mt) => match get(mt.ty).sty {
+            ty_vec(_, None) => true,
+            _ => false,
+        },
+        _ => false
+    }
+}
+
 pub fn type_is_structural(ty: t) -> bool {
     match get(ty).sty {
       ty_struct(..) | ty_tup(_) | ty_enum(..) | ty_closure(_) | ty_trait(..) |
-      ty_vec(_, VstoreFixed(_)) | ty_str(VstoreFixed(_)) |
-      ty_vec(_, VstoreSlice(..)) | ty_str(VstoreSlice(..))
+      ty_vec(_, Some(_)) |
+      ty_str(VstoreFixed(_)) | ty_str(VstoreSlice(_))
       => true,
-      _ => false
+      _ => type_is_slice(ty)
     }
 }
 
@@ -1621,7 +1633,12 @@ pub fn type_is_simd(cx: &ctxt, ty: t) -> bool {
 pub fn sequence_element_type(cx: &ctxt, ty: t) -> t {
     match get(ty).sty {
         ty_str(_) => mk_mach_uint(ast::TyU8),
-        ty_vec(ty, _) => ty,
+        ty_vec(mt, _) => mt.ty,
+        ty_ptr(mt{ty: t, ..}) | ty_rptr(_, mt{ty: t, ..}) |
+        ty_box(t) | ty_uniq(t) => match get(t).sty {
+            ty_vec(mt, None) => mt.ty,
+            _ => cx.sess.bug("sequence_element_type called on non-sequence value"),
+        },
         _ => cx.sess.bug("sequence_element_type called on non-sequence value"),
     }
 }
@@ -1655,8 +1672,13 @@ pub fn type_is_boxed(ty: t) -> bool {
 
 pub fn type_is_region_ptr(ty: t) -> bool {
     match get(ty).sty {
-      ty_rptr(_, _) => true,
-      _ => false
+        ty_rptr(_, mt) => match get(mt.ty).sty {
+            // FIXME(nrc, DST) slices weren't regarded as rptrs, so we preserve this
+            // odd behaviour for now. (But ~[] were unique. I have no idea why).
+            ty_vec(_, None) => false,
+            _ => true
+        },
+        _ => false
     }
 }
 
@@ -1669,7 +1691,7 @@ pub fn type_is_unsafe_ptr(ty: t) -> bool {
 
 pub fn type_is_unique(ty: t) -> bool {
     match get(ty).sty {
-        ty_uniq(_) | ty_vec(_, VstoreUniq) | ty_str(VstoreUniq) => true,
+        ty_uniq(_) | ty_str(VstoreUniq) => true,
         _ => false
     }
 }
@@ -1743,8 +1765,7 @@ fn type_needs_unwind_cleanup_(cx: &ctxt, ty: t,
             !needs_unwind_cleanup
           }
           ty_uniq(_) |
-          ty_str(VstoreUniq) |
-          ty_vec(_, VstoreUniq) => {
+          ty_str(VstoreUniq) => {
             // Once we're inside a box, the annihilator will find
             // it and destroy it.
             if !encountered_box {
@@ -2086,19 +2107,11 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
                     borrowed_contents(r, mt.mutbl))
             }
 
-            ty_vec(ty, VstoreUniq) => {
-                tc_ty(cx, ty, cache).owned_pointer()
+            ty_vec(mt, _) => {
+                tc_mt(cx, mt, cache)
             }
 
-            ty_vec(ty, VstoreSlice(r, mutbl)) => {
-                tc_ty(cx, ty, cache).reference(borrowed_contents(r, mutbl))
-            }
-
-            ty_vec(ty, VstoreFixed(_)) => {
-                tc_ty(cx, ty, cache)
-            }
-
-            ty_str(VstoreSlice(r, ())) => {
+            ty_str(VstoreSlice(r)) => {
                 borrowed_contents(r, ast::MutImmutable)
             }
 
@@ -2321,8 +2334,8 @@ pub fn is_instantiable(cx: &ctxt, r_ty: t) -> bool {
             // fixed length vectors need special treatment compared to
             // normal vectors, since they don't necessarily have the
             // possibilty to have length zero.
-            ty_vec(_, VstoreFixed(0)) => false, // don't need no contents
-            ty_vec(ty, VstoreFixed(_)) => type_requires(cx, seen, r_ty, ty),
+            ty_vec(_, Some(0)) => false, // don't need no contents
+            ty_vec(mt, Some(_)) => type_requires(cx, seen, r_ty, mt.ty),
 
             ty_nil |
             ty_bot |
@@ -2338,7 +2351,7 @@ pub fn is_instantiable(cx: &ctxt, r_ty: t) -> bool {
             ty_err |
             ty_param(_) |
             ty_self(_) |
-            ty_vec(_, _) => {
+            ty_vec(_, None) => {
                 false
             }
             ty_box(typ) | ty_uniq(typ) => {
@@ -2459,8 +2472,8 @@ pub fn is_type_representable(cx: &ctxt, sp: Span, ty: t) -> Representability {
             }
             // Fixed-length vectors.
             // FIXME(#11924) Behavior undecided for zero-length vectors.
-            ty_vec(ty, VstoreFixed(_)) => {
-                type_structurally_recursive(cx, sp, seen, ty)
+            ty_vec(mt, Some(_)) => {
+                type_structurally_recursive(cx, sp, seen, mt.ty)
             }
 
             // Push struct and enum def-ids onto `seen` before recursing.
@@ -2604,21 +2617,34 @@ pub fn type_is_c_like_enum(cx: &ctxt, ty: t) -> bool {
 // Some types---notably unsafe ptrs---can only be dereferenced explicitly.
 pub fn deref(t: t, explicit: bool) -> Option<mt> {
     match get(t).sty {
-        ty_box(typ) | ty_uniq(typ) => Some(mt {
-            ty: typ,
-            mutbl: ast::MutImmutable,
-        }),
-        ty_rptr(_, mt) => Some(mt),
+        ty_box(typ) | ty_uniq(typ) => match get(typ).sty {
+            // Don't deref ~[] etc., might need to generalise this to all DST.
+            ty_vec(_, None) => None,
+            _ => Some(mt {
+                ty: typ,
+                mutbl: ast::MutImmutable,
+            }),
+        },
+        ty_rptr(_, mt) => match get(mt.ty).sty {
+            // Don't deref &[], might need to generalise this to all DST.
+            ty_vec(_, None) => None,
+            _ => Some(mt),
+        },
         ty_ptr(mt) if explicit => Some(mt),
         _ => None
     }
 }
 
 // Returns the type of t[i]
-pub fn index(t: t) -> Option<t> {
+pub fn index(t: t) -> Option<mt> {
     match get(t).sty {
-        ty_vec(ty, _) => Some(ty),
-        ty_str(_) => Some(mk_u8()),
+        ty_vec(mt, _) => Some(mt),
+        ty_ptr(mt{ty: t, ..}) | ty_rptr(_, mt{ty: t, ..}) |
+        ty_box(t) | ty_uniq(t) => match get(t).sty {
+            ty_vec(mt, None) => Some(mt),
+            _ => None,
+        },
+        ty_str(_) => Some(mt {ty: mk_u8(), mutbl: ast::MutImmutable}),
         _ => None
     }
 }
@@ -2723,8 +2749,7 @@ pub fn ty_region(tcx: &ctxt,
                  ty: t) -> Region {
     match get(ty).sty {
         ty_rptr(r, _) => r,
-        ty_vec(_, VstoreSlice(r, _)) => r,
-        ty_str(VstoreSlice(r, ())) => r,
+        ty_str(VstoreSlice(r)) => r,
         ref s => {
             tcx.sess.span_bug(
                 span,
@@ -2929,12 +2954,22 @@ pub fn adjust_ty(cx: &ctxt,
                   r: Region, m: ast::Mutability,
                   ty: ty::t) -> ty::t {
         match get(ty).sty {
-            ty_vec(ty, _) => {
-                ty::mk_vec(cx, ty, VstoreSlice(r, m))
+            ty_uniq(t) | ty_ptr(mt{ty: t, ..}) |
+            ty_rptr(_, mt{ty: t, ..}) => match get(t).sty {
+                ty::ty_vec(mt, None) => ty::mk_slice(cx, r, ty::mt {ty: mt.ty, mutbl: m}),
+                ref s => {
+                    cx.sess.span_bug(
+                        span,
+                        format!("borrow-vec associated with bad sty: {:?}",
+                             s));
+                }
+            },
+            ty_vec(mt, Some(_)) => {
+                ty::mk_slice(cx, r, ty::mt {ty: mt.ty, mutbl: m})
             }
 
             ty_str(_) => {
-                ty::mk_str(cx, VstoreSlice(r, ()))
+                ty::mk_str(cx, VstoreSlice(r))
             }
 
             ref s => {
@@ -4152,10 +4187,10 @@ pub fn normalize_ty(cx: &ctxt, t: t) -> t {
             return t_norm;
         }
 
-        fn fold_vstore<M>(&mut self, vstore: Vstore<M>) -> Vstore<M> {
+        fn fold_vstore(&mut self, vstore: Vstore) -> Vstore {
             match vstore {
                 VstoreFixed(..) | VstoreUniq => vstore,
-                VstoreSlice(_, m) => VstoreSlice(ReStatic, m)
+                VstoreSlice(_) => VstoreSlice(ReStatic)
             }
         }
 
@@ -4575,9 +4610,15 @@ pub fn hash_crate_independent(tcx: &ctxt, t: t, svh: &Svh) -> u64 {
             ty_uniq(_) => {
                 byte!(10);
             }
-            ty_vec(_, v) => {
+            ty_vec(m, Some(_)) => {
                 byte!(11);
-                hash!(v);
+                mt(&mut state, m);
+                1u8.hash(&mut state);
+            }
+            ty_vec(m, None) => {
+                byte!(11);
+                mt(&mut state, m);
+                0u8.hash(&mut state);
             }
             ty_ptr(m) => {
                 byte!(12);

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -68,7 +68,7 @@ pub trait TypeFolder {
         r
     }
 
-    fn fold_vstore<M>(&mut self, vstore: ty::Vstore<M>) -> ty::Vstore<M> {
+    fn fold_vstore(&mut self, vstore: ty::Vstore) -> ty::Vstore {
         super_fold_vstore(self, vstore)
     }
 
@@ -147,8 +147,8 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_ptr(ref tm) => {
             ty::ty_ptr(this.fold_mt(tm))
         }
-        ty::ty_vec(ty, vst) => {
-            ty::ty_vec(this.fold_ty(ty), this.fold_vstore(vst))
+        ty::ty_vec(ref tm, sz) => {
+            ty::ty_vec(this.fold_mt(tm), sz)
         }
         ty::ty_enum(tid, ref substs) => {
             ty::ty_enum(tid, this.fold_substs(substs))
@@ -191,13 +191,13 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
     }
 }
 
-pub fn super_fold_vstore<T:TypeFolder, M>(this: &mut T,
-                                          vstore: ty::Vstore<M>)
-                                          -> ty::Vstore<M> {
+pub fn super_fold_vstore<T:TypeFolder>(this: &mut T,
+                                       vstore: ty::Vstore)
+                                       -> ty::Vstore {
     match vstore {
         ty::VstoreFixed(i) => ty::VstoreFixed(i),
         ty::VstoreUniq => ty::VstoreUniq,
-        ty::VstoreSlice(r, m) => ty::VstoreSlice(this.fold_region(r), m),
+        ty::VstoreSlice(r) => ty::VstoreSlice(this.fold_region(r)),
     }
 }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1286,10 +1286,9 @@ pub fn check_lit(fcx: &FnCtxt, lit: &ast::Lit) -> ty::t {
     let tcx = fcx.ccx.tcx;
 
     match lit.node {
-        ast::LitStr(..) => ty::mk_str(tcx, ty::VstoreSlice(ty::ReStatic, ())),
+        ast::LitStr(..) => ty::mk_str(tcx, ty::VstoreSlice(ty::ReStatic)),
         ast::LitBinary(..) => {
-            ty::mk_vec(tcx, ty::mk_u8(),
-                       ty::VstoreSlice(ty::ReStatic, ast::MutImmutable))
+            ty::mk_slice(tcx, ty::ReStatic, ty::mt{ ty: ty::mk_u8(), mutbl: ast::MutImmutable })
         }
         ast::LitChar(_) => ty::mk_char(),
         ast::LitInt(_, t) => ty::mk_mach_int(t),
@@ -2458,7 +2457,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       ast::ExprVstore(ev, vst) => {
         let typ = match ev.node {
           ast::ExprLit(lit) if ast_util::lit_is_str(lit) => {
-            let v = ast_expr_vstore_to_vstore(fcx, ev, vst, ());
+            let v = ast_expr_vstore_to_vstore(fcx, ev, vst);
             ty::mk_str(tcx, v)
           }
           ast::ExprVec(ref args) => {
@@ -2466,7 +2465,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 ast::ExprVstoreMutSlice => ast::MutMutable,
                 _ => ast::MutImmutable,
             };
-            let v = ast_expr_vstore_to_vstore(fcx, ev, vst, mutability);
+            let v = ast_expr_vstore_to_vstore(fcx, ev, vst);
             let mut any_error = false;
             let mut any_bot = false;
             let t: ty::t = fcx.infcx().next_ty_var();
@@ -2485,7 +2484,23 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             } else if any_bot {
                 ty::mk_bot()
             } else {
-                ty::mk_vec(tcx, t, v)
+                match v {
+                    ty::VstoreFixed(sz) => ty::mk_vec(tcx,
+                                                      ty::mt {ty: t, mutbl: mutability},
+                                                      Some(sz)),
+                    ty::VstoreUniq => ty::mk_uniq(tcx,
+                                                  ty::mk_vec(tcx,
+                                                             ty::mt {ty: t, mutbl: mutability},
+                                                             None)), // Sadly, we know the length
+                                                                     // - Some(args.len()) - but
+                                                                     // must thow it away or cause
+                                                                     // confusion further down the
+                                                                     // pipeline. Hopefully we can
+                                                                     // remedy this later.
+                                                                     // See below (x3) too.
+                    ty::VstoreSlice(r) => ty::mk_slice(tcx, r,
+                                                       ty::mt {ty: t, mutbl: mutability}),
+                }
             }
           }
           ast::ExprRepeat(element, count_expr) => {
@@ -2495,7 +2510,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 ast::ExprVstoreMutSlice => ast::MutMutable,
                 _ => ast::MutImmutable,
             };
-            let v = ast_expr_vstore_to_vstore(fcx, ev, vst, mutability);
+            let tt = ast_expr_vstore_to_vstore(fcx, ev, vst);
             let t = fcx.infcx().next_ty_var();
             check_expr_has_type(fcx, element, t);
             let arg_t = fcx.expr_ty(element);
@@ -2504,7 +2519,17 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             } else if ty::type_is_bot(arg_t) {
                 ty::mk_bot()
             } else {
-                ty::mk_vec(tcx, t, v)
+                match tt {
+                    ty::VstoreFixed(sz) => ty::mk_vec(tcx,
+                                                      ty::mt {ty: t, mutbl: mutability},
+                                                      Some(sz)),
+                    ty::VstoreUniq => ty::mk_uniq(tcx,
+                                                  ty::mk_vec(tcx,
+                                                             ty::mt {ty: t, mutbl: mutability},
+                                                             None)),
+                    ty::VstoreSlice(r) => ty::mk_slice(tcx, r,
+                                                       ty::mt {ty: t, mutbl: mutability}),
+                }
             }
           }
           _ =>
@@ -2949,6 +2974,11 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                         fn is_vec(t: ty::t) -> bool {
                             match ty::get(t).sty {
                                 ty::ty_vec(..) => true,
+                                ty::ty_ptr(ty::mt{ty: t, ..}) | ty::ty_rptr(_, ty::mt{ty: t, ..}) |
+                                ty::ty_box(t) | ty::ty_uniq(t) => match ty::get(t).sty {
+                                    ty::ty_vec(_, None) => true,
+                                    _ => false,
+                                },
                                 _ => false
                             }
                         }
@@ -3005,7 +3035,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         for e in args.iter() {
             check_expr_has_type(fcx, *e, t);
         }
-        let typ = ty::mk_vec(tcx, t, ty::VstoreFixed(args.len()));
+        let typ = ty::mk_vec(tcx, ty::mt {ty: t, mutbl: ast::MutImmutable},
+                             Some(args.len()));
         fcx.write_ty(id, typ);
       }
       ast::ExprRepeat(element, count_expr) => {
@@ -3021,7 +3052,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_bot(id);
         }
         else {
-            let t = ty::mk_vec(tcx, t, ty::VstoreFixed(count));
+            let t = ty::mk_vec(tcx, ty::mt {ty: t, mutbl: ast::MutImmutable},
+                               Some(count));
             fcx.write_ty(id, t);
         }
       }
@@ -3089,9 +3121,9 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 autoderef(fcx, expr.span, raw_base_t, Some(base.id),
                           lvalue_pref, |base_t, _| ty::index(base_t));
               match field_ty {
-                  Some(ty) => {
+                  Some(mt) => {
                       check_expr_has_type(fcx, idx, ty::mk_uint());
-                      fcx.write_ty(id, ty);
+                      fcx.write_ty(id, mt.ty);
                       fcx.write_autoderef_adjustment(base.id, autoderefs);
                   }
                   None => {
@@ -3833,33 +3865,32 @@ pub fn type_is_c_like_enum(fcx: &FnCtxt, sp: Span, typ: ty::t) -> bool {
     return ty::type_is_c_like_enum(fcx.ccx.tcx, typ_s);
 }
 
-pub fn ast_expr_vstore_to_vstore<M>(fcx: &FnCtxt,
-                                    e: &ast::Expr,
-                                    v: ast::ExprVstore,
-                                    m: M)
-                                    -> ty::Vstore<M> {
+pub fn ast_expr_vstore_to_vstore(fcx: &FnCtxt,
+                                 e: &ast::Expr,
+                                 v: ast::ExprVstore)
+                                 -> ty::Vstore {
     match v {
         ast::ExprVstoreUniq => ty::VstoreUniq,
         ast::ExprVstoreSlice | ast::ExprVstoreMutSlice => {
             match e.node {
                 ast::ExprLit(..) => {
                     // string literals and *empty slices* live in static memory
-                    ty::VstoreSlice(ty::ReStatic, m)
+                    ty::VstoreSlice(ty::ReStatic)
                 }
                 ast::ExprVec(ref elements) if elements.len() == 0 => {
                     // string literals and *empty slices* live in static memory
-                    ty::VstoreSlice(ty::ReStatic, m)
+                    ty::VstoreSlice(ty::ReStatic)
                 }
                 ast::ExprRepeat(..) |
                 ast::ExprVec(..) => {
                     // vector literals are temporaries on the stack
                     match fcx.tcx().region_maps.temporary_scope(e.id) {
                         Some(scope) => {
-                            ty::VstoreSlice(ty::ReScope(scope), m)
+                            ty::VstoreSlice(ty::ReScope(scope))
                         }
                         None => {
                             // this slice occurs in a static somewhere
-                            ty::VstoreSlice(ty::ReStatic, m)
+                            ty::VstoreSlice(ty::ReStatic)
                         }
                     }
                 }

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -928,11 +928,17 @@ fn constrain_index(rcx: &mut Rcx,
 
     let r_index_expr = ty::ReScope(index_expr.id);
     match ty::get(indexed_ty).sty {
-        ty::ty_str(ty::VstoreSlice(r_ptr, ())) |
-        ty::ty_vec(_, ty::VstoreSlice(r_ptr, _)) => {
+        ty::ty_str(ty::VstoreSlice(r_ptr)) => {
             rcx.fcx.mk_subr(true, infer::IndexSlice(index_expr.span),
                             r_index_expr, r_ptr);
         }
+        ty::ty_rptr(r_ptr, mt) => match ty::get(mt.ty).sty {
+            ty::ty_vec(_, None) => {
+                rcx.fcx.mk_subr(true, infer::IndexSlice(index_expr.span),
+                                r_index_expr, r_ptr);
+            }
+            _ => {}
+        },
 
         _ => {}
     }

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -100,8 +100,7 @@ pub fn relate_nested_regions(tcx: &ty::ctxt,
 
         fn fold_ty(&mut self, ty: ty::t) -> ty::t {
             match ty::get(ty).sty {
-                ty::ty_rptr(r, ty::mt {ty, ..}) |
-                ty::ty_vec(ty, ty::VstoreSlice(r, _)) => {
+                ty::ty_rptr(r, ty::mt {ty, ..}) => {
                     self.relate(r);
                     self.stack.push(r);
                     ty_fold::super_fold_ty(self, ty);

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -717,16 +717,8 @@ impl<'a> ConstraintContext<'a> {
                 self.add_constraints_from_vstore(vstore, variance);
             }
 
-            ty::ty_vec(ty, vstore) => {
-                self.add_constraints_from_vstore(vstore, variance);
-                let mt = ty::mt {
-                    ty: ty,
-                    mutbl: match vstore {
-                        ty::VstoreSlice(_, m) => m,
-                        _ => ast::MutImmutable
-                    }
-                };
-                self.add_constraints_from_mt(&mt, variance);
+            ty::ty_vec(ref mt, _) => {
+                self.add_constraints_from_mt(mt, variance);
             }
 
             ty::ty_uniq(typ) | ty::ty_box(typ) => {
@@ -799,11 +791,11 @@ impl<'a> ConstraintContext<'a> {
 
     /// Adds constraints appropriate for a vector with Vstore `vstore`
     /// appearing in a context with ambient variance `variance`
-    fn add_constraints_from_vstore<M>(&mut self,
-                                      vstore: ty::Vstore<M>,
-                                      variance: VarianceTermPtr<'a>) {
+    fn add_constraints_from_vstore(&mut self,
+                                   vstore: ty::Vstore,
+                                   variance: VarianceTermPtr<'a>) {
         match vstore {
-            ty::VstoreSlice(r, _) => {
+            ty::VstoreSlice(r) => {
                 let contra = self.contravariant(variance);
                 self.add_constraints_from_region(r, contra);
             }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -395,22 +395,22 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
         let bound_str = bounds.repr(cx);
         format!("{}{}{}{}", trait_store_to_str(cx, store), ty, bound_sep, bound_str)
       }
-      ty_vec(ty, vs) => {
-        match vs {
-            ty::VstoreFixed(n) => {
-                format!("[{}, .. {}]", ty_to_str(cx, ty), n)
-            }
-            _ => {
-                format!("{}[{}]", vs.repr(cx), ty_to_str(cx, ty))
-            }
-        }
-      }
       ty_str(vs) => {
         match vs {
             ty::VstoreFixed(n) => format!("str/{}", n),
             ty::VstoreUniq => "~str".to_owned(),
-            ty::VstoreSlice(r, ()) => format!("{}str", region_ptr_to_str(cx, r))
+            ty::VstoreSlice(r) => format!("{}str", region_ptr_to_str(cx, r))
         }
+      }
+      ty_vec(ref mt, sz) => {
+          match sz {
+              Some(n) => {
+                  format!("[{}, .. {}]", mt_to_str(cx, mt), n)
+              }
+              None => {
+                  format!("[{}]", ty_to_str(cx, mt.ty))
+              }
+          }
       }
     }
 }
@@ -853,19 +853,7 @@ impl Repr for ty::Vstore {
         match *self {
             ty::VstoreFixed(n) => format!("{}", n),
             ty::VstoreUniq => "~".to_owned(),
-            ty::VstoreSlice(r, m) => {
-                format!("{}{}", region_ptr_to_str(tcx, r), mutability_to_str(m))
-            }
-        }
-    }
-}
-
-impl Repr for ty::Vstore<()> {
-    fn repr(&self, tcx: &ctxt) -> ~str {
-        match *self {
-            ty::VstoreFixed(n) => format!("{}", n),
-            ty::VstoreUniq => "~".to_owned(),
-            ty::VstoreSlice(r, ()) => region_ptr_to_str(tcx, r)
+            ty::VstoreSlice(r) => region_ptr_to_str(tcx, r)
         }
     }
 }


### PR DESCRIPTION
Refactors all uses of ty_vec and associated things to remove the vstore abstraction (still used for strings, for now). Pointers to vectors are stored as ty_rptr or ty_uniq wrapped around a ty_vec. There are no user-facing changes. Existing behaviour is preserved by special-casing many instances of pointers containing vectors. Hopefully with DST most of these hacks will go away. For now it is useful to leave them hanging around rather than abstracting them into a method or something.

Closes #13554.
