### PR TITLE
Removed rev_iter in favor of DoubleEndedIterator

### DIFF
--- a/src/doc/guide-container.md
+++ b/src/doc/guide-container.md
@@ -120,12 +120,13 @@ differently.
 Containers implement iteration over the contained elements by returning an
 iterator object. For example, vector slices several iterators available:
 
-* `iter()` and `rev_iter()`, for immutable references to the elements
-* `mut_iter()` and `mut_rev_iter()`, for mutable references to the elements
-* `move_iter()` and `move_rev_iter()`, to move the elements out by-value
+* `iter()` for immutable references to the elements
+* `mut_iter()` for mutable references to the elements
+* `move_iter()` to move the elements out by-value
 
 A typical mutable container will implement at least `iter()`, `mut_iter()` and
-`move_iter()` along with the reverse variants if it maintains an order.
+`move_iter()`. If it maintains an order, the returned iterators will be
+`DoubleEndedIterator`s, which are described below.
 
 ### Freezing
 
@@ -265,7 +266,7 @@ Iterators offer generic conversion to containers with the `collect` adaptor:
 
 ~~~
 let xs = [0, 1, 1, 2, 3, 5, 8];
-let ys = xs.rev_iter().skip(1).map(|&x| x * 2).collect::<~[int]>();
+let ys = xs.iter().rev().skip(1).map(|&x| x * 2).collect::<~[int]>();
 assert_eq!(ys, ~[10, 6, 4, 2, 2, 0]);
 ~~~
 
@@ -357,9 +358,6 @@ for &x in it.rev() {
     println!("{}", x)
 }
 ~~~
-
-The `rev_iter` and `mut_rev_iter` methods on vectors just return an inverted
-version of the standard immutable and mutable vector iterators.
 
 The `chain`, `map`, `filter`, `filter_map` and `inspect` adaptors are
 `DoubleEndedIterator` implementations if the underlying iterators are.

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -425,6 +425,7 @@ impl Bitv {
     }
 
     #[inline]
+    #[deprecated = "replaced by .iter().rev()"]
     pub fn rev_iter<'a>(&'a self) -> Rev<Bits<'a>> {
         self.iter().rev()
     }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -370,8 +370,8 @@ impl<T> DList<T> {
         Items{nelem: self.len(), head: &self.list_head, tail: self.list_tail}
     }
 
-    /// Provide a reverse iterator
     #[inline]
+    #[deprecated = "replaced by .iter().rev()"]
     pub fn rev_iter<'a>(&'a self) -> Rev<Items<'a, T>> {
         self.iter().rev()
     }
@@ -390,8 +390,9 @@ impl<T> DList<T> {
             list: self
         }
     }
-    /// Provide a reverse iterator with mutable references
+
     #[inline]
+    #[deprecated = "replaced by .mut_iter().rev()"]
     pub fn mut_rev_iter<'a>(&'a mut self) -> Rev<MutItems<'a, T>> {
         self.mut_iter().rev()
     }
@@ -403,8 +404,8 @@ impl<T> DList<T> {
         MoveItems{list: self}
     }
 
-    /// Consume the list into an iterator yielding elements by value, in reverse
     #[inline]
+    #[deprecated = "replaced by .move_iter().rev()"]
     pub fn move_rev_iter(self) -> Rev<MoveItems<T>> {
         self.move_iter().rev()
     }
@@ -849,13 +850,13 @@ mod tests {
     #[test]
     fn test_rev_iter() {
         let m = generate_test();
-        for (i, elt) in m.rev_iter().enumerate() {
+        for (i, elt) in m.iter().rev().enumerate() {
             assert_eq!((6 - i) as int, *elt);
         }
         let mut n = DList::new();
-        assert_eq!(n.rev_iter().next(), None);
+        assert_eq!(n.iter().rev().next(), None);
         n.push_front(4);
-        let mut it = n.rev_iter();
+        let mut it = n.iter().rev();
         assert_eq!(it.size_hint(), (1, Some(1)));
         assert_eq!(it.next().unwrap(), &4);
         assert_eq!(it.size_hint(), (0, Some(0)));
@@ -958,13 +959,13 @@ mod tests {
     #[test]
     fn test_mut_rev_iter() {
         let mut m = generate_test();
-        for (i, elt) in m.mut_rev_iter().enumerate() {
+        for (i, elt) in m.mut_iter().rev().enumerate() {
             assert_eq!((6-i) as int, *elt);
         }
         let mut n = DList::new();
-        assert!(n.mut_rev_iter().next().is_none());
+        assert!(n.mut_iter().rev().next().is_none());
         n.push_front(4);
-        let mut it = n.mut_rev_iter();
+        let mut it = n.mut_iter().rev();
         assert!(it.next().is_some());
         assert!(it.next().is_none());
     }
@@ -1164,7 +1165,7 @@ mod tests {
         let v = &[0, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.rev_iter().len() == 128);
+            assert!(m.iter().rev().len() == 128);
         })
     }
     #[bench]
@@ -1172,7 +1173,7 @@ mod tests {
         let v = &[0, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.mut_rev_iter().len() == 128);
+            assert!(m.mut_iter().rev().len() == 128);
         })
     }
 }

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -382,7 +382,7 @@ mod tests {
     fn test_from_iter() {
         let xs = vec!(9u, 8, 7, 6, 5, 4, 3, 2, 1);
 
-        let mut q: PriorityQueue<uint> = xs.as_slice().rev_iter().map(|&x| x).collect();
+        let mut q: PriorityQueue<uint> = xs.as_slice().iter().rev().map(|&x| x).collect();
 
         for &x in xs.iter() {
             assert_eq!(q.pop(), x);

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -190,7 +190,7 @@ impl<T> RingBuf<T> {
         Items{index: 0, rindex: self.nelts, lo: self.lo, elts: self.elts.as_slice()}
     }
 
-    /// Back-to-front iterator.
+    #[deprecated = "replaced by .iter().rev()"]
     pub fn rev_iter<'a>(&'a self) -> Rev<Items<'a, T>> {
         self.iter().rev()
     }
@@ -221,7 +221,7 @@ impl<T> RingBuf<T> {
         }
     }
 
-    /// Back-to-front iterator which returns mutable values.
+    #[deprecated = "replaced by .mut_iter().rev()"]
     pub fn mut_rev_iter<'a>(&'a mut self) -> Rev<MutItems<'a, T>> {
         self.mut_iter().rev()
     }
@@ -702,23 +702,23 @@ mod tests {
     #[test]
     fn test_rev_iter() {
         let mut d = RingBuf::new();
-        assert_eq!(d.rev_iter().next(), None);
+        assert_eq!(d.iter().rev().next(), None);
 
         for i in range(0, 5) {
             d.push_back(i);
         }
-        assert_eq!(d.rev_iter().collect::<Vec<&int>>().as_slice(), &[&4,&3,&2,&1,&0]);
+        assert_eq!(d.iter().rev().collect::<Vec<&int>>().as_slice(), &[&4,&3,&2,&1,&0]);
 
         for i in range(6, 9) {
             d.push_front(i);
         }
-        assert_eq!(d.rev_iter().collect::<Vec<&int>>().as_slice(), &[&4,&3,&2,&1,&0,&6,&7,&8]);
+        assert_eq!(d.iter().rev().collect::<Vec<&int>>().as_slice(), &[&4,&3,&2,&1,&0,&6,&7,&8]);
     }
 
     #[test]
     fn test_mut_rev_iter_wrap() {
         let mut d = RingBuf::with_capacity(3);
-        assert!(d.mut_rev_iter().next().is_none());
+        assert!(d.mut_iter().rev().next().is_none());
 
         d.push_back(1);
         d.push_back(2);
@@ -726,7 +726,7 @@ mod tests {
         assert_eq!(d.pop_front(), Some(1));
         d.push_back(4);
 
-        assert_eq!(d.mut_rev_iter().map(|x| *x).collect::<Vec<int>>(),
+        assert_eq!(d.mut_iter().rev().map(|x| *x).collect::<Vec<int>>(),
                    vec!(4, 3, 2));
     }
 
@@ -756,19 +756,19 @@ mod tests {
     #[test]
     fn test_mut_rev_iter() {
         let mut d = RingBuf::new();
-        assert!(d.mut_rev_iter().next().is_none());
+        assert!(d.mut_iter().rev().next().is_none());
 
         for i in range(0u, 3) {
             d.push_front(i);
         }
 
-        for (i, elt) in d.mut_rev_iter().enumerate() {
+        for (i, elt) in d.mut_iter().rev().enumerate() {
             assert_eq!(*elt, i);
             *elt = i;
         }
 
         {
-            let mut it = d.mut_rev_iter();
+            let mut it = d.mut_iter().rev();
             assert_eq!(*it.next().unwrap(), 0);
             assert_eq!(*it.next().unwrap(), 1);
             assert_eq!(*it.next().unwrap(), 2);

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -142,16 +142,13 @@ impl<V> SmallIntMap<V> {
         }
     }
 
-    /// An iterator visiting all key-value pairs in descending order by the keys.
-    /// Iterator element type is (uint, &'r V)
-    pub fn rev_iter<'r>(&'r self) -> RevEntries<'r, V> {
+    #[deprecated = "replaced by .iter().rev()"]
+    pub fn rev_iter<'r>(&'r self) -> Rev<Entries<'r, V>> {
         self.iter().rev()
     }
 
-    /// An iterator visiting all key-value pairs in descending order by the keys,
-    /// with mutable references to the values
-    /// Iterator element type is (uint, &'r mut V)
-    pub fn mut_rev_iter<'r>(&'r mut self) -> RevMutEntries <'r, V> {
+    #[deprecated = "replaced by .mut_iter().rev()"]
+    pub fn mut_rev_iter<'r>(&'r mut self) -> Rev<MutEntries<'r, V>> {
         self.mut_iter().rev()
     }
 
@@ -246,6 +243,7 @@ pub struct Entries<'a, T> {
 
 iterator!(impl Entries -> (uint, &'a T), get_ref)
 double_ended_iterator!(impl Entries -> (uint, &'a T), get_ref)
+#[deprecated = "replaced by Rev<Entries<'a, T>>"]
 pub type RevEntries<'a, T> = Rev<Entries<'a, T>>;
 
 pub struct MutEntries<'a, T> {
@@ -256,6 +254,7 @@ pub struct MutEntries<'a, T> {
 
 iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
 double_ended_iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
+#[deprecated = "replaced by Rev<MutEntries<'a, T>"]
 pub type RevMutEntries<'a, T> = Rev<MutEntries<'a, T>>;
 
 #[cfg(test)]
@@ -387,9 +386,9 @@ mod test_map {
         assert!(m.insert(10, 11));
 
         assert_eq!(m.iter().size_hint(), (0, Some(11)));
-        assert_eq!(m.rev_iter().size_hint(), (0, Some(11)));
+        assert_eq!(m.iter().rev().size_hint(), (0, Some(11)));
         assert_eq!(m.mut_iter().size_hint(), (0, Some(11)));
-        assert_eq!(m.mut_rev_iter().size_hint(), (0, Some(11)));
+        assert_eq!(m.mut_iter().rev().size_hint(), (0, Some(11)));
     }
 
     #[test]
@@ -425,7 +424,7 @@ mod test_map {
         assert!(m.insert(6, 10));
         assert!(m.insert(10, 11));
 
-        let mut it = m.rev_iter();
+        let mut it = m.iter().rev();
         assert_eq!(it.next().unwrap(), (10, &11));
         assert_eq!(it.next().unwrap(), (6, &10));
         assert_eq!(it.next().unwrap(), (3, &5));
@@ -444,7 +443,7 @@ mod test_map {
         assert!(m.insert(6, 10));
         assert!(m.insert(10, 11));
 
-        for (k, v) in m.mut_rev_iter() {
+        for (k, v) in m.mut_iter().rev() {
             *v += k as int;
         }
 

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -395,7 +395,7 @@ impl<T> TrieNode<T> {
 
 impl<T> TrieNode<T> {
     fn each_reverse<'a>(&'a self, f: |&uint, &'a T| -> bool) -> bool {
-        for elt in self.children.rev_iter() {
+        for elt in self.children.iter().rev() {
             match *elt {
                 Internal(ref x) => if !x.each_reverse(|i,t| f(i,t)) { return false },
                 External(k, ref v) => if !f(&k, v) { return false },

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -439,7 +439,7 @@ impl Integer for BigUint {
             let bn = *b.data.last().unwrap();
             let mut d = Vec::with_capacity(an.len());
             let mut carry = 0;
-            for elt in an.rev_iter() {
+            for elt in an.iter().rev() {
                 let ai = BigDigit::to_uint(carry, *elt);
                 let di = ai / (bn as uint);
                 assert!(di < BigDigit::base);
@@ -668,7 +668,7 @@ impl ToStrRadix for BigUint {
         fn fill_concat(v: &[BigDigit], radix: uint, l: uint) -> ~str {
             if v.is_empty() { return "0".to_owned() }
             let mut s = StrBuf::with_capacity(v.len() * l);
-            for n in v.rev_iter() {
+            for n in v.iter().rev() {
                 let ss = (*n as uint).to_str_radix(radix);
                 s.push_str("0".repeat(l - ss.len()));
                 s.push_str(ss);
@@ -2187,7 +2187,7 @@ mod bigint_tests {
     fn test_cmp() {
         let vs = [ &[2 as BigDigit], &[1, 1], &[2, 1], &[1, 1, 1] ];
         let mut nums = Vec::new();
-        for s in vs.rev_iter() {
+        for s in vs.iter().rev() {
             nums.push(BigInt::from_slice(Minus, *s));
         }
         nums.push(Zero::zero());

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -927,7 +927,7 @@ impl<'a> Liveness<'a> {
 
     fn propagate_through_exprs(&mut self, exprs: &[@Expr], succ: LiveNode)
                                -> LiveNode {
-        exprs.rev_iter().fold(succ, |succ, expr| {
+        exprs.iter().rev().fold(succ, |succ, expr| {
             self.propagate_through_expr(*expr, succ)
         })
     }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -94,7 +94,7 @@ fn lookup_vtables(vcx: &VtableContext,
     let mut result: Vec<vtable_param_res> =
         substs.tps.iter()
         .rev()
-        .zip(type_param_defs.rev_iter())
+        .zip(type_param_defs.iter().rev())
         .map(|(ty, def)|
             lookup_vtables_for_param(vcx, span, Some(substs),
                                      &*def.bounds, *ty, is_early))

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -304,7 +304,7 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
         None => {}
     }
     if default_passes {
-        for name in DEFAULT_PASSES.rev_iter() {
+        for name in DEFAULT_PASSES.iter().rev() {
             passes.unshift(name.to_owned());
         }
     }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1446,7 +1446,7 @@ impl ::Decoder<Error> for Decoder {
                 };
                 match o.pop(&"fields".to_owned()) {
                     Some(List(l)) => {
-                        for field in l.move_rev_iter() {
+                        for field in l.move_iter().rev() {
                             self.stack.push(field.clone());
                         }
                     },
@@ -1557,7 +1557,7 @@ impl ::Decoder<Error> for Decoder {
         debug!("read_seq()");
         let list = try!(expect!(self.pop(), List));
         let len = list.len();
-        for v in list.move_rev_iter() {
+        for v in list.move_iter().rev() {
             self.stack.push(v);
         }
         f(self, len)

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -16,11 +16,11 @@ use clone::Clone;
 use cmp::{Eq, TotalEq};
 use from_str::FromStr;
 use io::Writer;
-use iter::{AdditiveIterator, Extendable, Iterator, Map};
+use iter::{DoubleEndedIterator, Rev, AdditiveIterator, Extendable, Iterator, Map};
 use option::{Option, None, Some};
 use str;
 use str::Str;
-use slice::{CloneableVector, RevSplits, Splits, Vector, VectorVector,
+use slice::{CloneableVector, Splits, Vector, VectorVector,
             ImmutableEqVector, OwnedVector, ImmutableVector};
 use vec::Vec;
 
@@ -29,14 +29,13 @@ use super::{BytesContainer, GenericPath, GenericPathUnsafe};
 /// Iterator that yields successive components of a Path as &[u8]
 pub type Components<'a> = Splits<'a, u8>;
 /// Iterator that yields components of a Path in reverse as &[u8]
-pub type RevComponents<'a> = RevSplits<'a, u8>;
+pub type RevComponents<'a> = Rev<Components<'a>>;
 
 /// Iterator that yields successive components of a Path as Option<&str>
 pub type StrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
                                        Components<'a>>;
 /// Iterator that yields components of a Path in reverse as Option<&str>
-pub type RevStrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
-                                          RevComponents<'a>>;
+pub type RevStrComponents<'a> = Rev<StrComponents<'a>>;
 
 /// Represents a POSIX file path
 #[deriving(Clone)]
@@ -397,15 +396,7 @@ impl Path {
     /// Returns an iterator that yields each component of the path in reverse.
     /// See components() for details.
     pub fn rev_components<'a>(&'a self) -> RevComponents<'a> {
-        let v = if *self.repr.get(0) == SEP_BYTE {
-            self.repr.slice_from(1)
-        } else { self.repr.as_slice() };
-        let mut ret = v.rsplit(is_sep_byte);
-        if v.is_empty() {
-            // consume the empty "" component
-            ret.next();
-        }
-        ret
+        self.components().rev()
     }
 
     /// Returns an iterator that yields each component of the path as Option<&str>.
@@ -417,7 +408,7 @@ impl Path {
     /// Returns an iterator that yields each component of the path in reverse as Option<&str>.
     /// See components() for details.
     pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
-        self.rev_components().map(str::from_utf8)
+        self.str_components().rev()
     }
 }
 

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -29,12 +29,14 @@ use super::{BytesContainer, GenericPath, GenericPathUnsafe};
 /// Iterator that yields successive components of a Path as &[u8]
 pub type Components<'a> = Splits<'a, u8>;
 /// Iterator that yields components of a Path in reverse as &[u8]
+#[deprecated = "replaced by Rev<Components<'a>>"]
 pub type RevComponents<'a> = Rev<Components<'a>>;
 
 /// Iterator that yields successive components of a Path as Option<&str>
 pub type StrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
                                        Components<'a>>;
 /// Iterator that yields components of a Path in reverse as Option<&str>
+#[deprecated = "replaced by Rev<StrComponents<'a>>"]
 pub type RevStrComponents<'a> = Rev<StrComponents<'a>>;
 
 /// Represents a POSIX file path
@@ -307,8 +309,8 @@ impl GenericPath for Path {
 
     fn ends_with_path(&self, child: &Path) -> bool {
         if !child.is_relative() { return false; }
-        let mut selfit = self.rev_components();
-        let mut childit = child.rev_components();
+        let mut selfit = self.components().rev();
+        let mut childit = child.components().rev();
         loop {
             match (selfit.next(), childit.next()) {
                 (Some(a), Some(b)) => if a != b { return false; },
@@ -395,7 +397,8 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse.
     /// See components() for details.
-    pub fn rev_components<'a>(&'a self) -> RevComponents<'a> {
+    #[deprecated = "replaced by .components().rev()"]
+    pub fn rev_components<'a>(&'a self) -> Rev<Components<'a>> {
         self.components().rev()
     }
 
@@ -407,7 +410,8 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse as Option<&str>.
     /// See components() for details.
-    pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
+    #[deprecated = "replaced by .str_components().rev()"]
+    pub fn rev_str_components<'a>(&'a self) -> Rev<StrComponents<'a>> {
         self.str_components().rev()
     }
 }
@@ -1183,7 +1187,7 @@ mod tests {
                     let exps = exp.iter().map(|x| x.as_bytes()).collect::<Vec<&[u8]>>();
                     assert!(comps == exps, "components: Expected {:?}, found {:?}",
                             comps, exps);
-                    let comps = path.rev_components().collect::<Vec<&[u8]>>();
+                    let comps = path.components().rev().collect::<Vec<&[u8]>>();
                     let exps = exps.move_iter().rev().collect::<Vec<&[u8]>>();
                     assert!(comps == exps, "rev_components: Expected {:?}, found {:?}",
                             comps, exps);
@@ -1195,8 +1199,8 @@ mod tests {
                     let comps = path.components().collect::<Vec<&[u8]>>();
                     let exp: &[&[u8]] = [$(b!($($exp),*)),*];
                     assert_eq!(comps.as_slice(), exp);
-                    let comps = path.rev_components().collect::<Vec<&[u8]>>();
-                    let exp = exp.rev_iter().map(|&x|x).collect::<Vec<&[u8]>>();
+                    let comps = path.components().rev().collect::<Vec<&[u8]>>();
+                    let exp = exp.iter().rev().map(|&x|x).collect::<Vec<&[u8]>>();
                     assert_eq!(comps, exp)
                 }
             )
@@ -1227,8 +1231,8 @@ mod tests {
                     let comps = path.str_components().collect::<Vec<Option<&str>>>();
                     let exp: &[Option<&str>] = $exp;
                     assert_eq!(comps.as_slice(), exp);
-                    let comps = path.rev_str_components().collect::<Vec<Option<&str>>>();
-                    let exp = exp.rev_iter().map(|&x|x).collect::<Vec<Option<&str>>>();
+                    let comps = path.str_components().rev().collect::<Vec<Option<&str>>>();
+                    let exp = exp.iter().rev().map(|&x|x).collect::<Vec<Option<&str>>>();
                     assert_eq!(comps, exp);
                 }
             )

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -37,15 +37,13 @@ pub type StrComponents<'a> = Map<'a, &'a str, Option<&'a str>,
 ///
 /// Each component is yielded as Option<&str> for compatibility with PosixPath, but
 /// every component in WindowsPath is guaranteed to be Some.
-pub type RevStrComponents<'a> = Rev<Map<'a, &'a str, Option<&'a str>,
-                                                 CharSplits<'a, char>>>;
+pub type RevStrComponents<'a> = Rev<StrComponents<'a>>;
 
 /// Iterator that yields successive components of a Path as &[u8]
 pub type Components<'a> = Map<'a, Option<&'a str>, &'a [u8],
                                     StrComponents<'a>>;
 /// Iterator that yields components of a Path in reverse as &[u8]
-pub type RevComponents<'a> = Map<'a, Option<&'a str>, &'a [u8],
-                                       RevStrComponents<'a>>;
+pub type RevComponents<'a> = Rev<Components<'a>>;
 
 /// Represents a Windows path
 // Notes for Windows path impl:
@@ -650,11 +648,7 @@ impl Path {
     /// Returns an iterator that yields each component of the path in reverse as a &[u8].
     /// See str_components() for details.
     pub fn rev_components<'a>(&'a self) -> RevComponents<'a> {
-        fn convert<'a>(x: Option<&'a str>) -> &'a [u8] {
-            #![inline]
-            x.unwrap().as_bytes()
-        }
-        self.rev_str_components().map(convert)
+        self.components().rev()
     }
 
     fn equiv_prefix(&self, other: &Path) -> bool {

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -37,12 +37,14 @@ pub type StrComponents<'a> = Map<'a, &'a str, Option<&'a str>,
 ///
 /// Each component is yielded as Option<&str> for compatibility with PosixPath, but
 /// every component in WindowsPath is guaranteed to be Some.
+#[deprecated = "replaced by Rev<StrComponents<'a>>"]
 pub type RevStrComponents<'a> = Rev<StrComponents<'a>>;
 
 /// Iterator that yields successive components of a Path as &[u8]
 pub type Components<'a> = Map<'a, Option<&'a str>, &'a [u8],
                                     StrComponents<'a>>;
 /// Iterator that yields components of a Path in reverse as &[u8]
+#[deprecated = "replaced by Rev<Components<'a>>"]
 pub type RevComponents<'a> = Rev<Components<'a>>;
 
 /// Represents a Windows path
@@ -631,7 +633,8 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse as an Option<&str>
     /// See str_components() for details.
-    pub fn rev_str_components<'a>(&'a self) -> RevStrComponents<'a> {
+    #[deprecated = "replaced by .str_components().rev()"]
+    pub fn rev_str_components<'a>(&'a self) -> Rev<StrComponents<'a>> {
         self.str_components().rev()
     }
 
@@ -647,7 +650,8 @@ impl Path {
 
     /// Returns an iterator that yields each component of the path in reverse as a &[u8].
     /// See str_components() for details.
-    pub fn rev_components<'a>(&'a self) -> RevComponents<'a> {
+    #[deprecated = "replaced by .components().rev()"]
+    pub fn rev_components<'a>(&'a self) -> Rev<Components<'a>> {
         self.components().rev()
     }
 
@@ -2233,9 +2237,9 @@ mod tests {
                                 .collect::<Vec<&str>>();
                     let exp: &[&str] = $exp;
                     assert_eq!(comps.as_slice(), exp);
-                    let comps = path.rev_str_components().map(|x|x.unwrap())
+                    let comps = path.str_components().rev().map(|x|x.unwrap())
                                 .collect::<Vec<&str>>();
-                    let exp = exp.rev_iter().map(|&x|x).collect::<Vec<&str>>();
+                    let exp = exp.iter().rev().map(|&x|x).collect::<Vec<&str>>();
                     assert_eq!(comps, exp);
                 }
             );
@@ -2245,9 +2249,9 @@ mod tests {
                     let comps = path.str_components().map(|x|x.unwrap()).collect::<Vec<&str>>();
                     let exp: &[&str] = $exp;
                     assert_eq!(comps.as_slice(), exp);
-                    let comps = path.rev_str_components().map(|x|x.unwrap())
+                    let comps = path.str_components().rev().map(|x|x.unwrap())
                                 .collect::<Vec<&str>>();
-                    let exp = exp.rev_iter().map(|&x|x).collect::<Vec<&str>>();
+                    let exp = exp.iter().rev().map(|&x|x).collect::<Vec<&str>>();
                     assert_eq!(comps, exp);
                 }
             )
@@ -2302,8 +2306,8 @@ mod tests {
                     let comps = path.components().collect::<Vec<&[u8]>>();
                     let exp: &[&[u8]] = $exp;
                     assert_eq!(comps.as_slice(), exp);
-                    let comps = path.rev_components().collect::<Vec<&[u8]>>();
-                    let exp = exp.rev_iter().map(|&x|x).collect::<Vec<&[u8]>>();
+                    let comps = path.components().rev().collect::<Vec<&[u8]>>();
+                    let exp = exp.iter().rev().map(|&x|x).collect::<Vec<&[u8]>>();
                     assert_eq!(comps, exp);
                 }
             )

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -343,12 +343,10 @@ impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsets<'a> {
     }
 }
 
-/// External iterator for a string's characters in reverse order.
-/// Use with the `std::iter` module.
+#[deprecated = "replaced by Rev<Chars<'a>>"]
 pub type RevChars<'a> = Rev<Chars<'a>>;
 
-/// External iterator for a string's characters and their byte offsets in reverse order.
-/// Use with the `std::iter` module.
+#[deprecated = "replaced by Rev<CharOffsets<'a>>"]
 pub type RevCharOffsets<'a> = Rev<CharOffsets<'a>>;
 
 /// External iterator for a string's bytes.
@@ -356,8 +354,7 @@ pub type RevCharOffsets<'a> = Rev<CharOffsets<'a>>;
 pub type Bytes<'a> =
     Map<'a, &'a u8, u8, slice::Items<'a, u8>>;
 
-/// External iterator for a string's bytes in reverse order.
-/// Use with the `std::iter` module.
+#[deprecated = "replaced by Rev<Bytes<'a>>"]
 pub type RevBytes<'a> = Rev<Bytes<'a>>;
 
 /// An iterator over the substrings of a string, separated by `sep`.
@@ -372,8 +369,7 @@ pub struct CharSplits<'a, Sep> {
     finished: bool,
 }
 
-/// An iterator over the substrings of a string, separated by `sep`,
-/// starting from the back of the string.
+#[deprecated = "replaced by Rev<CharSplits<'a, Sep>>"]
 pub type RevCharSplits<'a, Sep> = Rev<CharSplits<'a, Sep>>;
 
 /// An iterator over the substrings of a string, separated by `sep`,
@@ -462,7 +458,7 @@ for CharSplits<'a, Sep> {
                 }
             }
         } else {
-            for (idx, ch) in self.string.char_indices_rev() {
+            for (idx, ch) in self.string.char_indices().rev() {
                 if self.sep.matches(ch) {
                     next_split = Some((idx, self.string.char_range_at(idx).next));
                     break;
@@ -1626,21 +1622,23 @@ pub trait StrSlice<'a> {
     /// ```
     fn chars(&self) -> Chars<'a>;
 
-    /// An iterator over the characters of `self`, in reverse order.
-    fn chars_rev(&self) -> RevChars<'a>;
+    /// Do not use this - it is deprecated.
+    #[deprecated = "replaced by .chars().rev()"]
+    fn chars_rev(&self) -> Rev<Chars<'a>>;
 
     /// An iterator over the bytes of `self`
     fn bytes(&self) -> Bytes<'a>;
 
-    /// An iterator over the bytes of `self`, in reverse order
-    fn bytes_rev(&self) -> RevBytes<'a>;
+    /// Do not use this - it is deprecated.
+    #[deprecated = "replaced by .bytes().rev()"]
+    fn bytes_rev(&self) -> Rev<Bytes<'a>>;
 
     /// An iterator over the characters of `self` and their byte offsets.
     fn char_indices(&self) -> CharOffsets<'a>;
 
-    /// An iterator over the characters of `self` and their byte offsets,
-    /// in reverse order.
-    fn char_indices_rev(&self) -> RevCharOffsets<'a>;
+    /// Do not use this - it is deprecated.
+    #[deprecated = "replaced by .char_indices().rev()"]
+    fn char_indices_rev(&self) -> Rev<CharOffsets<'a>>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`.
@@ -1691,25 +1689,21 @@ pub trait StrSlice<'a> {
     ///
     /// let v: ~[&str] = "A..B..".split_terminator('.').collect();
     /// assert_eq!(v, ~["A", "", "B", ""]);
+    ///
+    /// let v: ~[&str] = "Mary had a little lamb".split(' ').rev().collect();
+    /// assert_eq!(v, ~["lamb", "little", "a", "had", "Mary"]);
+    ///
+    /// let v: ~[&str] = "abc1def2ghi".split(|c: char| c.is_digit()).rev().collect();
+    /// assert_eq!(v, ~["ghi", "def", "abc"]);
+    ///
+    /// let v: ~[&str] = "lionXXtigerXleopard".split('X').rev().collect();
+    /// assert_eq!(v, ~["leopard", "tiger", "", "lion"]);
     /// ```
     fn split_terminator<Sep: CharEq>(&self, sep: Sep) -> CharSplits<'a, Sep>;
 
-    /// An iterator over substrings of `self`, separated by characters
-    /// matched by `sep`, in reverse order.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// let v: ~[&str] = "Mary had a little lamb".rsplit(' ').collect();
-    /// assert_eq!(v, ~["lamb", "little", "a", "had", "Mary"]);
-    ///
-    /// let v: ~[&str] = "abc1def2ghi".rsplit(|c: char| c.is_digit()).collect();
-    /// assert_eq!(v, ~["ghi", "def", "abc"]);
-    ///
-    /// let v: ~[&str] = "lionXXtigerXleopard".rsplit('X').collect();
-    /// assert_eq!(v, ~["leopard", "tiger", "", "lion"]);
-    /// ```
-    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> RevCharSplits<'a, Sep>;
+    /// Do not use this - it is deprecated.
+    #[deprecated = "replaced by .split(sep).rev()"]
+    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> Rev<CharSplits<'a, Sep>>;
 
     /// An iterator over substrings of `self`, separated by characters
     /// matched by `sep`, starting from the end of the string.
@@ -2281,7 +2275,8 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn chars_rev(&self) -> RevChars<'a> {
+    #[deprecated = "replaced by .chars().rev()"]
+    fn chars_rev(&self) -> Rev<Chars<'a>> {
         self.chars().rev()
     }
 
@@ -2291,7 +2286,8 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn bytes_rev(&self) -> RevBytes<'a> {
+    #[deprecated = "replaced by .bytes().rev()"]
+    fn bytes_rev(&self) -> Rev<Bytes<'a>> {
         self.bytes().rev()
     }
 
@@ -2301,7 +2297,8 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn char_indices_rev(&self) -> RevCharOffsets<'a> {
+    #[deprecated = "replaced by .char_indices().rev()"]
+    fn char_indices_rev(&self) -> Rev<CharOffsets<'a>> {
         self.char_indices().rev()
     }
 
@@ -2336,7 +2333,8 @@ impl<'a> StrSlice<'a> for &'a str {
     }
 
     #[inline]
-    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> RevCharSplits<'a, Sep> {
+    #[deprecated = "replaced by .split(sep).rev()"]
+    fn rsplit<Sep: CharEq>(&self, sep: Sep) -> Rev<CharSplits<'a, Sep>> {
         self.split(sep).rev()
     }
 
@@ -2656,7 +2654,7 @@ impl<'a> StrSlice<'a> for &'a str {
         if search.only_ascii() {
             self.bytes().rposition(|b| search.matches(b as char))
         } else {
-            for (index, c) in self.char_indices_rev() {
+            for (index, c) in self.char_indices().rev() {
                 if search.matches(c) { return Some(index); }
             }
             None
@@ -3573,7 +3571,7 @@ mod tests {
         let s = "ศไทย中华Việt Nam".to_owned();
         let v = ~['ศ','ไ','ท','ย','中','华','V','i','ệ','t',' ','N','a','m'];
         let mut pos = s.len();
-        for ch in v.rev_iter() {
+        for ch in v.iter().rev() {
             assert!(s.char_at_reverse(pos) == *ch);
             pos -= from_char(*ch).len();
         }
@@ -3673,7 +3671,7 @@ mod tests {
         let v = ~['m', 'a', 'N', ' ', 't', 'ệ','i','V','华','中','ย','ท','ไ','ศ'];
 
         let mut pos = 0;
-        let mut it = s.chars_rev();
+        let mut it = s.chars().rev();
 
         for c in it {
             assert_eq!(c, v[pos]);
@@ -3716,7 +3714,7 @@ mod tests {
         ];
         let mut pos = v.len();
 
-        for b in s.bytes_rev() {
+        for b in s.bytes().rev() {
             pos -= 1;
             assert_eq!(b, v[pos]);
         }
@@ -3748,7 +3746,7 @@ mod tests {
         let v = ['m', 'a', 'N', ' ', 't', 'ệ','i','V','华','中','ย','ท','ไ','ศ'];
 
         let mut pos = 0;
-        let mut it = s.char_indices_rev();
+        let mut it = s.char_indices().rev();
 
         for c in it {
             assert_eq!(c, (p[pos], v[pos]));
@@ -3765,14 +3763,14 @@ mod tests {
         let split: ~[&str] = data.split(' ').collect();
         assert_eq!( split, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit(' ').collect();
+        let mut rsplit: ~[&str] = data.split(' ').rev().collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
         let split: ~[&str] = data.split(|c: char| c == ' ').collect();
         assert_eq!( split, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit(|c: char| c == ' ').collect();
+        let mut rsplit: ~[&str] = data.split(|c: char| c == ' ').rev().collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nMäry", "häd", "ä", "little", "lämb\nLittle", "lämb\n"]);
 
@@ -3780,14 +3778,14 @@ mod tests {
         let split: ~[&str] = data.split('ä').collect();
         assert_eq!( split, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit('ä').collect();
+        let mut rsplit: ~[&str] = data.split('ä').rev().collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
 
         let split: ~[&str] = data.split(|c: char| c == 'ä').collect();
         assert_eq!( split, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
 
-        let mut rsplit: ~[&str] = data.rsplit(|c: char| c == 'ä').collect();
+        let mut rsplit: ~[&str] = data.split(|c: char| c == 'ä').rev().collect();
         rsplit.reverse();
         assert_eq!(rsplit, ~["\nM", "ry h", "d ", " little l", "mb\nLittle l", "mb\n"]);
     }
@@ -4103,7 +4101,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars_rev().len(), len));
+        b.iter(|| assert_eq!(s.chars().rev().len(), len));
     }
 
     #[bench]
@@ -4119,7 +4117,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices_rev().len(), len));
+        b.iter(|| assert_eq!(s.char_indices().rev().len(), len));
     }
 
     #[bench]

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -205,7 +205,8 @@ pub fn first_attr_value_str_by_name(attrs: &[Attribute], name: &str)
 
 pub fn last_meta_item_value_str_by_name(items: &[@MetaItem], name: &str)
                                      -> Option<InternedString> {
-    items.rev_iter()
+    items.iter()
+         .rev()
          .find(|mi| mi.name().equiv(&name))
          .and_then(|i| i.value_str())
 }


### PR DESCRIPTION
In the process, `Splits` got changed to be more like `CharSplits` in `str` to present the DEI interface.

Note that `treemap` still has a `rev_iter` function because it seems like it would be a significant interface change to expose a DEI - the iterator would have to gain an extra pointer, the completion checks would be more complicated, and it isn't easy to check that such an implementation is correct due to the use of unsafety to subvert the aliasing properties of `&mut`.

This fixes #9391.
