### PR TITLE
Fix call order to be the same as definition order

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1883,8 +1883,8 @@ impl Shape {
 
 let s = Circle(Point { x: 1.0, y: 2.0 }, 3.0);
 
-(~s).draw_owned();
 (&s).draw_reference();
+(~s).draw_owned();
 s.draw_value();
 ~~~
 


### PR DESCRIPTION
Feels strange to have the order be arbitrary here. Order them the same.
