### PR TITLE
RFC: linker placement attribute proposed implementation

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1851,62 +1851,79 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
 
                     // We need the translated value here, because for enums the
                     // LLVM type is not fully determined by the Rust type.
-                    let (v, inlineable) = consts::const_expr(ccx, expr, is_local);
+                    let (v, inlineable, override_reach) = if attr::contains_name(i.attrs.as_slice(),
+                            "unsafe_override_address") {
+                        let (addrconst, _) = consts::const_expr(ccx, expr, is_local);
+                        let llptrty = type_of(ccx, ty).ptr_to().to_ref();
+                        let ptr = unsafe { llvm::LLVMConstIntToPtr(addrconst, llptrty) };
+
+                        (ptr, true, true)
+                    } else {
+                        let (v, i) = consts::const_expr(ccx, expr, is_local);
+
+                        (v, i, false)
+                    };
                     ccx.const_values.borrow_mut().insert(id, v);
                     let mut inlineable = inlineable;
 
-                    unsafe {
-                        let llty = llvm::LLVMTypeOf(v);
-                        let g = sym.with_c_str(|buf| {
-                            llvm::LLVMAddGlobal(ccx.llmod, llty, buf)
-                        });
-
-                        if !ccx.reachable.contains(&id) {
-                            lib::llvm::SetLinkage(g, lib::llvm::InternalLinkage);
-                        }
-
-                        // Apply the `unnamed_addr` attribute if
-                        // requested
-                        if attr::contains_name(i.attrs.as_slice(),
-                                               "address_insignificant") {
-                            if ccx.reachable.contains(&id) {
-                                ccx.sess().span_bug(i.span,
-                                    "insignificant static is reachable");
-                            }
-                            lib::llvm::SetUnnamedAddr(g, true);
-
-                            // This is a curious case where we must make
-                            // all of these statics inlineable. If a
-                            // global is tagged as
-                            // address_insignificant, then LLVM won't
-                            // coalesce globals unless they have an
-                            // internal linkage type. This means that
-                            // external crates cannot use this global.
-                            // This is a problem for things like inner
-                            // statics in generic functions, because the
-                            // function will be inlined into another
-                            // crate and then attempt to link to the
-                            // static in the original crate, only to
-                            // find that it's not there. On the other
-                            // side of inlininig, the crates knows to
-                            // not declare this static as
-                            // available_externally (because it isn't)
-                            inlineable = true;
-                        }
-
-                        if attr::contains_name(i.attrs.as_slice(),
-                                               "thread_local") {
-                            lib::llvm::set_thread_local(g, true);
-                        }
-
-                        if !inlineable {
-                            debug!("{} not inlined", sym);
-                            ccx.non_inlineable_statics.borrow_mut()
-                                                      .insert(id);
-                        }
-
+                    if attr::contains_name(i.attrs.as_slice(), "unsafe_override_address") {
                         ccx.item_symbols.borrow_mut().insert(i.id, sym);
-                        g
+                        foreign = true;
+                        v
+                    } else {
+                        unsafe {
+                            let llty = llvm::LLVMTypeOf(v);
+                            let g = sym.with_c_str(|buf| {
+                                llvm::LLVMAddGlobal(ccx.llmod, llty, buf)
+                            });
+
+                            if override_reach || !ccx.reachable.contains(&id) {
+                                lib::llvm::SetLinkage(g, lib::llvm::InternalLinkage);
+                            }
+
+                            // Apply the `unnamed_addr` attribute if
+                            // requested
+                            if override_reach || attr::contains_name(i.attrs.as_slice(),
+                                                   "address_insignificant") {
+                                if !override_reach && ccx.reachable.contains(&id) {
+                                    ccx.sess().span_bug(i.span,
+                                        "insignificant static is reachable");
+                                }
+                                lib::llvm::SetUnnamedAddr(g, true);
+
+                                // This is a curious case where we must make
+                                // all of these statics inlineable. If a
+                                // global is tagged as
+                                // address_insignificant, then LLVM won't
+                                // coalesce globals unless they have an
+                                // internal linkage type. This means that
+                                // external crates cannot use this global.
+                                // This is a problem for things like inner
+                                // statics in generic functions, because the
+                                // function will be inlined into another
+                                // crate and then attempt to link to the
+                                // static in the original crate, only to
+                                // find that it's not there. On the other
+                                // side of inlininig, the crates knows to
+                                // not declare this static as
+                                // available_externally (because it isn't)
+                                inlineable = true;
+                            }
+
+                            if attr::contains_name(i.attrs.as_slice(),
+                                                   "thread_local") {
+                                lib::llvm::set_thread_local(g, true);
+                            }
+
+                            if !inlineable {
+                                debug!("{} not inlined", sym);
+                                ccx.non_inlineable_statics.borrow_mut()
+                                                          .insert(id);
+                            }
+
+                            ccx.item_symbols.borrow_mut().insert(i.id, sym);
+                            g
+                        }
                     }
                 }
 


### PR DESCRIPTION
This is the implementation of feature in https://github.com/rust-lang/rfcs/pull/44, it allows to use the following code:

``` rust
#[unsafe_override_address]
static t: T = 123;
```

that will create a t pointing to 123 address in memory.

I also have an alternative implementation that uses `&'static T` and requires less patching, not sure which one is better.
