### PR TITLE
rustdoc: Update the "Additional tutorials" link

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -33,7 +33,7 @@ pleasant high-level features include:
 This is an introductory tutorial for the Rust programming language. It
 covers the fundamentals of the language, including the syntax, the
 type system and memory model, generics, and modules. [Additional
-tutorials](#what-next) cover specific language features in greater
+tutorials](#what-next?) cover specific language features in greater
 depth.
 
 This tutorial assumes that the reader is already familiar with one or


### PR DESCRIPTION
This pr updates the "Additional tutorials" link in the scope section to match the "What next?" link in the table of contents.
