### PR TITLE
Move task::task() to TaskBuilder::new()

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -55,7 +55,7 @@ use std::cmp;
 use std::io;
 use std::os;
 use std::str;
-use std::task;
+use std::task::TaskBuilder;
 use syntax::ast;
 use syntax::diagnostic::Emitter;
 use syntax::diagnostic;
@@ -374,7 +374,7 @@ pub fn monitor(f: proc():Send) {
     #[cfg(not(rtopt))]
     static STACK_SIZE: uint = 20000000; // 20MB
 
-    let mut task_builder = task::task().named("rustc");
+    let mut task_builder = TaskBuilder::new().named("rustc");
 
     // FIXME: Hacks on hacks. If the env is trying to override the stack size
     // then *don't* set it explicitly.

--- a/src/libsync/lock.rs
+++ b/src/libsync/lock.rs
@@ -445,6 +445,7 @@ impl Barrier {
 mod tests {
     use std::comm::Empty;
     use std::task;
+    use std::task::TaskBuilder;
 
     use arc::Arc;
     use super::{Mutex, Barrier, RWLock};
@@ -614,7 +615,7 @@ mod tests {
         let mut children = Vec::new();
         for _ in range(0, 5) {
             let arc3 = arc.clone();
-            let mut builder = task::task();
+            let mut builder = TaskBuilder::new();
             children.push(builder.future_result());
             builder.spawn(proc() {
                 let lock = arc3.read();

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -60,7 +60,7 @@ use std::io;
 use std::os;
 use std::str;
 use std::strbuf::StrBuf;
-use std::task;
+use std::task::TaskBuilder;
 
 // to be used by rustc to compile tests in libtest
 pub mod test {
@@ -961,7 +961,7 @@ pub fn run_test(force_ignore: bool,
             let mut reader = ChanReader::new(rx);
             let stdout = ChanWriter::new(tx.clone());
             let stderr = ChanWriter::new(tx);
-            let mut task = task::task().named(match desc.name {
+            let mut task = TaskBuilder::new().named(match desc.name {
                 DynTestName(ref name) => name.clone().into_maybe_owned(),
                 StaticTestName(name) => name.into_maybe_owned(),
             });

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -23,6 +23,7 @@ extern crate time;
 use std::comm;
 use std::os;
 use std::task;
+use std::task::TaskBuilder;
 use std::uint;
 
 fn move_out<T>(_x: T) {}
@@ -62,7 +63,7 @@ fn run(args: &[~str]) {
     let mut worker_results = Vec::new();
     for _ in range(0u, workers) {
         let to_child = to_child.clone();
-        let mut builder = task::task();
+        let mut builder = TaskBuilder::new();
         worker_results.push(builder.future_result());
         builder.spawn(proc() {
             for _ in range(0u, size / workers) {

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -18,6 +18,7 @@ extern crate time;
 
 use std::os;
 use std::task;
+use std::task::TaskBuilder;
 use std::uint;
 
 fn move_out<T>(_x: T) {}
@@ -56,7 +57,7 @@ fn run(args: &[~str]) {
     let mut worker_results = Vec::new();
     let from_parent = if workers == 1 {
         let (to_child, from_parent) = channel();
-        let mut builder = task::task();
+        let mut builder = TaskBuilder::new();
         worker_results.push(builder.future_result());
         builder.spawn(proc() {
             for _ in range(0u, size / workers) {
@@ -70,7 +71,7 @@ fn run(args: &[~str]) {
         let (to_child, from_parent) = channel();
         for _ in range(0u, workers) {
             let to_child = to_child.clone();
-            let mut builder = task::task();
+            let mut builder = TaskBuilder::new();
             worker_results.push(builder.future_result());
             builder.spawn(proc() {
                 for _ in range(0u, size / workers) {

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -24,6 +24,7 @@ extern crate time;
 use std::os;
 use std::result::{Ok, Err};
 use std::task;
+use std::task::TaskBuilder;
 use std::uint;
 
 fn fib(n: int) -> int {
@@ -77,7 +78,7 @@ fn stress_task(id: int) {
 fn stress(num_tasks: int) {
     let mut results = Vec::new();
     for i in range(0, num_tasks) {
-        let mut builder = task::task();
+        let mut builder = TaskBuilder::new();
         results.push(builder.future_result());
         builder.spawn(proc() {
             stress_task(i);

--- a/src/test/run-fail/fail-task-name-owned.rs
+++ b/src/test/run-fail/fail-task-name-owned.rs
@@ -10,10 +10,10 @@
 
 // error-pattern:task 'owned name' failed at 'test'
 
-use std::task;
+use std::task::TaskBuilder;
 
 fn main() {
-    task::task().named("owned name".to_owned()).try(proc() {
+    TaskBuilder::new().named("owned name".to_owned()).try(proc() {
         fail!("test");
         1
     }).unwrap()

--- a/src/test/run-fail/fail-task-name-send-str.rs
+++ b/src/test/run-fail/fail-task-name-send-str.rs
@@ -11,7 +11,7 @@
 // error-pattern:task 'send name' failed at 'test'
 
 fn main() {
-    ::std::task::task().named("send name".into_maybe_owned()).try(proc() {
+    ::std::task::TaskBuilder::new().named("send name".into_maybe_owned()).try(proc() {
         fail!("test");
         3
     }).unwrap()

--- a/src/test/run-fail/fail-task-name-static.rs
+++ b/src/test/run-fail/fail-task-name-static.rs
@@ -11,7 +11,7 @@
 // error-pattern:task 'static name' failed at 'test'
 
 fn main() {
-    ::std::task::task().named("static name").try(proc() {
+    ::std::task::TaskBuilder::new().named("static name").try(proc() {
         fail!("test");
     }).unwrap()
 }

--- a/src/test/run-pass/issue-2190-1.rs
+++ b/src/test/run-pass/issue-2190-1.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::task;
+use std::task::TaskBuilder;
 
 static generations: uint = 1024+256+128+49;
 
 fn spawn(f: proc():Send) {
-    let mut t = task::task();
+    let mut t = TaskBuilder::new();
     t.opts.stack_size = Some(32 * 1024);
     t.spawn(f);
 }

--- a/src/test/run-pass/spawning-with-debug.rs
+++ b/src/test/run-pass/spawning-with-debug.rs
@@ -13,9 +13,9 @@
 
 // regression test for issue #10405, make sure we don't call println! too soon.
 
-use std::task;
+use std::task::TaskBuilder;
 
 pub fn main() {
-    let mut t = task::task();
+    let mut t = TaskBuilder::new();
     t.spawn(proc() ());
 }

--- a/src/test/run-pass/task-comm-12.rs
+++ b/src/test/run-pass/task-comm-12.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::task;
+use std::task::TaskBuilder;
 
 pub fn main() { test00(); }
 
@@ -16,7 +17,7 @@ fn start(_task_number: int) { println!("Started / Finished task."); }
 
 fn test00() {
     let i: int = 0;
-    let mut builder = task::task();
+    let mut builder = TaskBuilder::new();
     let mut result = builder.future_result();
     builder.spawn(proc() {
         start(i)

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-use std::task;
+use std::task::TaskBuilder;
 
 pub fn main() { println!("===== WITHOUT THREADS ====="); test00(); }
 
@@ -38,7 +38,7 @@ fn test00() {
     let mut results = Vec::new();
     while i < number_of_tasks {
         let tx = tx.clone();
-        let mut builder = task::task();
+        let mut builder = TaskBuilder::new();
         results.push(builder.future_result());
         builder.spawn({
             let i = i;

--- a/src/test/run-pass/task-comm-9.rs
+++ b/src/test/run-pass/task-comm-9.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-use std::task;
+use std::task::TaskBuilder;
 
 pub fn main() { test00(); }
 
@@ -24,7 +24,7 @@ fn test00() {
     let (tx, rx) = channel();
     let number_of_messages: int = 10;
 
-    let mut builder = task::task();
+    let mut builder = TaskBuilder::new();
     let result = builder.future_result();
     builder.spawn(proc() {
         test00_start(&tx, number_of_messages);

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -22,7 +22,7 @@ extern crate rustuv;
 use std::io::net::ip::{Ipv4Addr, SocketAddr};
 use std::io::net::tcp::{TcpListener, TcpStream};
 use std::io::{Acceptor, Listener};
-use std::task;
+use std::task::TaskBuilder;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
@@ -61,7 +61,7 @@ fn main() {
     let (tx, rx) = channel();
     for _ in range(0, 1000) {
         let tx = tx.clone();
-        let mut builder = task::task();
+        let mut builder = TaskBuilder::new();
         builder.opts.stack_size = Some(32 * 1024);
         builder.spawn(proc() {
             match TcpStream::connect(addr) {

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 use std::task;
+use std::task::TaskBuilder;
 
 pub fn main() {
-    let mut builder = task::task();
+    let mut builder = TaskBuilder::new();
     let mut result = builder.future_result();
     builder.spawn(child);
     println!("1");

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 use std::task;
+use std::task::TaskBuilder;
 
 pub fn main() {
-    let mut builder = task::task();
+    let mut builder = TaskBuilder::new();
     let mut result = builder.future_result();
     builder.spawn(child);
     println!("1");


### PR DESCRIPTION
The constructor for `TaskBuilder` is being changed to an associated
function called `new` for consistency with the rest of the standard
library.

Closes #13666

[breaking-change]
