### PR TITLE
Tutorial doc

### DIFF
--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -101,6 +101,8 @@ fn print_message() { println!("I am running in a different task!"); }
 spawn(print_message);
 
 // Print something more profound in a different task using a lambda expression
+// This uses the proc() keyword to assign to spawn a function with no name
+// That function will call println!(...) as requested
 spawn(proc() println!("I am also running in a different task!") );
 ~~~~
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1717,27 +1717,32 @@ environment (sometimes referred to as "capturing" variables in their
 environment). For example, you couldn't write the following:
 
 ~~~~ {.ignore}
-let foo = 10;
+let x = 3;
 
-// `bar` cannot refer to `foo`
-fn bar() -> () { println!("{}", foo); }
+// `fun` cannot refer to `x`
+fn fun() -> () { println!("{}", x); }
 ~~~~
 
 Rust also supports _closures_, functions that can access variables in
-the enclosing scope.  Compare `foo` in these:
+the enclosing scope.  Compare `x` in these:
 
 ~~~~
-fn            bar() -> () { println!("{}", foo) }; // cannot reach enclosing scope
-let closure = |foo| -> () { println!("{}", foo) }; // can reach enclosing scope
+let x = 3;
+
+// `fun` is an invalid definition
+fn  fun       () -> () { println!("{}", x) }; // cannot reach enclosing scope
+let closure = || -> () { println!("{}", x) }; // can reach enclosing scope
+
+fun();      // Still won't work
+closure();  // Prints: 3
 ~~~~
 
 Closures can be utilized in this fashion:
 
 ~~~~
-// Create a nameless function and assign it to `closure`.
-// It's sole argument is a yet unknown `foo` to be supplied
-// by the caller.
-let closure = |foo| -> () { println!("{}", foo) };
+// Create a nameless function and assign it to `closure`. It's sole
+// argument is a yet unknown `x` to be supplied by the caller.
+let closure = |x| -> () { println!("{}", x) };
 
 // Define `call_closure_with_ten` to take one argument and return null `()`.
 // `fun` is a function which takes one `int` argument `|int|` and also returns
@@ -1752,7 +1757,7 @@ call_closure_with_ten(closure);
 This can be simplified by removing null arguments:
 
 ~~~~
-let closure = |foo| println!("{}", foo);
+let closure = |x| println!("{}", x);
 fn call_closure_with_ten(fun: |int|) { fun(10); }
 
 call_closure_with_ten(closure);

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1719,19 +1719,41 @@ environment). For example, you couldn't write the following:
 ~~~~ {.ignore}
 let foo = 10;
 
-fn bar() -> int {
-   return foo; // `bar` cannot refer to `foo`
-}
+// `bar` cannot refer to `foo`
+fn bar() -> () { println!("{}", foo); }
 ~~~~
 
 Rust also supports _closures_, functions that can access variables in
-the enclosing scope.
+the enclosing scope.  Compare `foo` in these:
 
 ~~~~
-fn call_closure_with_ten(b: |int|) { b(10); }
+fn            bar() -> () { println!("{}", foo) }; // cannot reach enclosing scope
+let closure = |foo| -> () { println!("{}", foo) }; // can reach enclosing scope
+~~~~
 
-let captured_var = 20;
-let closure = |arg| println!("captured_var={}, arg={}", captured_var, arg);
+Closures can be utilized in this fashion:
+
+~~~~
+// Create a nameless function and assign it to `closure`.
+// It's sole argument is a yet unknown `foo` to be supplied
+// by the caller.
+let closure = |foo| -> () { println!("{}", foo) };
+
+// Define `call_closure_with_ten` to take one argument and return null `()`.
+// `fun` is a function which takes one `int` argument `|int|` and also returns
+// null `()`.  `|int|` defines the `fun` to be of type _closure_
+fn call_closure_with_ten(fun: |int| -> ()) -> () { fun(10); }
+
+// The caller supplies `10` to the closure
+// which prints out the value
+call_closure_with_ten(closure);
+~~~~
+
+This can be simplified by removing null arguments:
+
+~~~~
+let closure = |foo| println!("{}", foo);
+fn call_closure_with_ten(fun: |int|) { fun(10); }
 
 call_closure_with_ten(closure);
 ~~~~

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1736,7 +1736,7 @@ let closure = || -> () { println!("{}", x) }; // can capture enclosing scope
 
 // `fun_arg` is an invalid definition
 fn  fun_arg       (arg: int) -> () { println!("{}", arg + x) }; // cannot capture enclosing scope
-let closure_arg = |arg: int| -> () { println!("{}", arg + x) }; // Can capture enclosing scope
+let closure_arg = |arg: int| -> () { println!("{}", arg + x) }; // can capture enclosing scope
 //                       ^
 // Requires a type because the implementation needs to know which `+` to use.
 // In the future, the implementation may not need the help.

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1731,11 +1731,11 @@ they try to access `x`:
 let x = 3;
 
 // `fun` is an invalid definition
-fn  fun       () -> () { println!("{}", x) }; // cannot capture enclosing scope
+fn  fun       () -> () { println!("{}", x) }  // cannot capture enclosing scope
 let closure = || -> () { println!("{}", x) }; // can capture enclosing scope
 
 // `fun_arg` is an invalid definition
-fn  fun_arg       (arg: int) -> () { println!("{}", arg + x) }; // cannot capture enclosing scope
+fn  fun_arg       (arg: int) -> () { println!("{}", arg + x) }  // cannot capture enclosing scope
 let closure_arg = |arg: int| -> () { println!("{}", arg + x) }; // can capture enclosing scope
 //                       ^
 // Requires a type because the implementation needs to know which `+` to use.


### PR DESCRIPTION
Improve tutorial discussion of closures, e.g. with respect to type inference and variable capture.

Fix #13621 

---- original description follows

I'd like this pulled to master if possible but if not I'd appreciate comments on what I need to change.  I found the closures difficult to understand as they were so I tried to explain it so I would've had an easier time understanding it.  I think it's better at least, somewhat.

I don't know that everyone liked the `-> ()` I included but I thought explicit is best to aid understanding.  I thought it was much harder to understand than it should have been.

[EDIT] - Clicked too early.
This doesn't `make check` without errors on my Xubuntu on Virtualbox machine.  Not sure why.  I don't think I changed anything problematic.  I'll try `make check` on master tomorrow.

Opened https://github.com/mozilla/rust/issues/13621 regarding this.
