### PR TITLE
Provide a note if method lookup fails and there are static definitions with the same name.

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -97,6 +97,7 @@ use middle::typeck::check::method::{AutoderefReceiver};
 use middle::typeck::check::method::{AutoderefReceiverFlag};
 use middle::typeck::check::method::{CheckTraitsAndInherentMethods};
 use middle::typeck::check::method::{DontAutoderefReceiver};
+use middle::typeck::check::method::{IgnoreStaticMethods, ReportStaticMethods};
 use middle::typeck::check::regionmanip::replace_late_bound_regions_in_fn_sig;
 use middle::typeck::check::regionmanip::relate_free_regions;
 use middle::typeck::check::vtable::VtableContext;
@@ -1360,7 +1361,7 @@ fn try_overloaded_deref(fcx: &FnCtxt,
         (PreferMutLvalue, Some(trait_did)) => {
             method::lookup_in_trait(fcx, span, base_expr.map(|x| &*x),
                                     token::intern("deref_mut"), trait_did,
-                                    base_ty, [], DontAutoderefReceiver)
+                                    base_ty, [], DontAutoderefReceiver, IgnoreStaticMethods)
         }
         _ => None
     };
@@ -1370,7 +1371,7 @@ fn try_overloaded_deref(fcx: &FnCtxt,
         (None, Some(trait_did)) => {
             method::lookup_in_trait(fcx, span, base_expr.map(|x| &*x),
                                     token::intern("deref"), trait_did,
-                                    base_ty, [], DontAutoderefReceiver)
+                                    base_ty, [], DontAutoderefReceiver, IgnoreStaticMethods)
         }
         (method, _) => method
     };
@@ -1956,7 +1957,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                          expr_t, tps.as_slice(),
                                          DontDerefArgs,
                                          CheckTraitsAndInherentMethods,
-                                         AutoderefReceiver) {
+                                         AutoderefReceiver, IgnoreStaticMethods) {
             Some(method) => {
                 let method_ty = method.ty;
                 let method_call = MethodCall::expr(expr.id);
@@ -1976,6 +1977,15 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
 
                 // Add error type for the result
                 fcx.write_error(expr.id);
+
+                // Check for potential static matches (missing self parameters)
+                method::lookup(fcx, expr, rcvr,
+                                    method_name.node.name,
+                                    expr_t, tps.as_slice(),
+                                    DontDerefArgs,
+                                    CheckTraitsAndInherentMethods,
+                                    DontAutoderefReceiver, ReportStaticMethods);
+
                 ty::mk_err()
             }
         };
@@ -2040,7 +2050,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         let method = match trait_did {
             Some(trait_did) => {
                 method::lookup_in_trait(fcx, op_ex.span, Some(&*args[0]), opname,
-                                        trait_did, self_t, [], autoderef_receiver)
+                                        trait_did, self_t, [], autoderef_receiver,
+                                        IgnoreStaticMethods)
             }
             None => None
         };
@@ -2348,7 +2359,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                              tps.as_slice(),
                              DontDerefArgs,
                              CheckTraitsAndInherentMethods,
-                             AutoderefReceiver) {
+                             AutoderefReceiver,
+                             IgnoreStaticMethods) {
             Some(_) => {
                 fcx.type_error_message(
                     expr.span,

--- a/src/test/compile-fail/issue-7575.rs
+++ b/src/test/compile-fail/issue-7575.rs
@@ -1,0 +1,80 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait CtxtFn {
+    fn f8(self, uint) -> uint;
+    fn f9(uint) -> uint; //~ NOTE candidate #
+}
+
+trait OtherTrait {
+    fn f9(uint) -> uint; //~ NOTE candidate #
+}
+
+trait UnusedTrait { // This should never show up as a candidate
+    fn f9(uint) -> uint;
+}
+
+impl CtxtFn for uint {
+    fn f8(self, i: uint) -> uint {
+        i * 4u
+    }
+
+    fn f9(i: uint) -> uint {
+        i * 4u
+    }
+}
+
+impl OtherTrait for uint {
+    fn f9(i: uint) -> uint {
+        i * 8u
+    }
+}
+
+struct MyInt(int);
+
+impl MyInt {
+    fn fff(i: int) -> int { //~ NOTE candidate #1 is `MyInt::fff`
+        i
+    }
+}
+
+trait ManyImplTrait {
+    fn is_str() -> bool { //~ NOTE candidate #1 is
+        false
+    }
+}
+
+impl ManyImplTrait for ~str {
+    fn is_str() -> bool {
+        true
+    }
+}
+
+impl ManyImplTrait for uint {}
+impl ManyImplTrait for int {}
+impl ManyImplTrait for char {}
+impl ManyImplTrait for MyInt {}
+
+fn no_param_bound(u: uint, m: MyInt) -> uint {
+    u.f8(42) + u.f9(342) + m.fff(42)
+            //~^ ERROR type `uint` does not implement any method in scope named `f9`
+            //~^^ NOTE found defined static methods, maybe a `self` is missing?
+                        //~^^^ ERROR type `MyInt` does not implement any method in scope named `fff`
+                        //~^^^^ NOTE found defined static methods, maybe a `self` is missing?
+}
+
+fn param_bound<T: ManyImplTrait>(t: T) -> bool {
+    t.is_str()
+    //~^ ERROR type `T` does not implement any method in scope named `is_str`
+    //~^^ NOTE found defined static methods, maybe a `self` is missing?
+}
+
+fn main() {
+}

--- a/src/test/run-pass/issue-7575.rs
+++ b/src/test/run-pass/issue-7575.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+    fn new() -> bool { false }
+}
+
+trait Bar {
+    fn new(&self) -> bool { true }
+}
+
+impl Bar for int {}
+impl Foo for int {}
+
+fn main() {
+    assert!(1i.new());
+}


### PR DESCRIPTION
Closes #7575.

I don't think the change from a contains lookup to an iteration of the HashSet in the resolver should be much of a burden as the set of methods with the same name should be relatively small.
