### PR TITLE
Use defaults from formal type parameters in type inference, as fallbacks.

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -684,7 +684,7 @@ impl<'a> AstConv for Context<'a>{
     }
 
     fn ty_infer(&self, _span: Span) -> ty::t {
-        infer::new_infer_ctxt(self.tcx).next_ty_var()
+        infer::new_infer_ctxt(self.tcx).next_ty_var(None)
     }
 }
 

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -32,7 +32,7 @@ pub fn check_match(fcx: &FnCtxt,
                    arms: &[ast::Arm]) {
     let tcx = fcx.ccx.tcx;
 
-    let discrim_ty = fcx.infcx().next_ty_var();
+    let discrim_ty = fcx.infcx().next_ty_var(None);
     check_expr_has_type(fcx, discrim, discrim_ty);
 
     // Typecheck the patterns first, so that we get types for all the

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1095,24 +1095,22 @@ impl<'a> LookupContext<'a> {
         // If they were not explicitly supplied, just construct fresh
         // variables.
         let num_supplied_tps = self.supplied_tps.len();
-        let num_method_tps = candidate.method_ty.generics.type_param_defs().len();
-        let m_substs = {
-            if num_supplied_tps == 0u {
-                self.fcx.infcx().next_ty_vars(num_method_tps)
-            } else if num_method_tps == 0u {
-                tcx.sess.span_err(
-                    self.span,
-                    "this method does not take type parameters");
-                self.fcx.infcx().next_ty_vars(num_method_tps)
-            } else if num_supplied_tps != num_method_tps {
-                tcx.sess.span_err(
-                    self.span,
-                    "incorrect number of type \
-                     parameters given for this method");
-                self.fcx.infcx().next_ty_vars(num_method_tps)
-            } else {
-                Vec::from_slice(self.supplied_tps)
-            }
+        let method_tps = candidate.method_ty.generics.type_param_defs();
+        let m_substs = if num_supplied_tps == 0u {
+            self.fcx.infcx().next_ty_vars(method_tps)
+        } else if method_tps.len() == 0u {
+            tcx.sess.span_err(
+                self.span,
+                "this method does not take type parameters");
+            self.fcx.infcx().next_ty_vars(method_tps)
+        } else if num_supplied_tps != method_tps.len() {
+            tcx.sess.span_err(
+                self.span,
+                "incorrect number of type \
+                 parameters given for this method");
+            self.fcx.infcx().next_ty_vars(method_tps)
+        } else {
+            Vec::from_slice(self.supplied_tps)
         };
 
         // Determine values for the early-bound lifetime parameters.

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -370,7 +370,7 @@ impl<'a> GatherLocalsVisitor<'a> {
         match ty_opt {
             None => {
                 // infer the variable's type
-                let var_ty = self.fcx.infcx().next_ty_var();
+                let var_ty = self.fcx.infcx().next_ty_var(None);
                 self.fcx.inh.locals.borrow_mut().insert(nid, var_ty);
             }
             Some(typ) => {
@@ -1050,7 +1050,7 @@ impl<'a> AstConv for FnCtxt<'a> {
     }
 
     fn ty_infer(&self, _span: Span) -> ty::t {
-        self.infcx().next_ty_var()
+        self.infcx().next_ty_var(None)
     }
 }
 
@@ -2092,7 +2092,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         }
 
         if ty::is_binopable(tcx, lhs_t, op) {
-            let tvar = fcx.infcx().next_ty_var();
+            let tvar = fcx.infcx().next_ty_var(None);
             demand::suptype(fcx, expr.span, tvar, lhs_t);
             check_expr_has_type(fcx, rhs, tvar);
 
@@ -2570,7 +2570,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             let v = ast_expr_vstore_to_vstore(fcx, ev, vst);
             let mut any_error = false;
             let mut any_bot = false;
-            let t: ty::t = fcx.infcx().next_ty_var();
+            let t = fcx.infcx().next_ty_var(None);
             for e in args.iter() {
                 check_expr_has_type(fcx, *e, t);
                 let arg_t = fcx.expr_ty(*e);
@@ -2613,7 +2613,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 _ => ast::MutImmutable,
             };
             let tt = ast_expr_vstore_to_vstore(fcx, ev, vst);
-            let t = fcx.infcx().next_ty_var();
+            let t = fcx.infcx().next_ty_var(None);
             check_expr_has_type(fcx, element, t);
             let arg_t = fcx.expr_ty(element);
             if ty::type_is_error(arg_t) {
@@ -3133,7 +3133,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         }
       }
       ast::ExprVec(ref args) => {
-        let t: ty::t = fcx.infcx().next_ty_var();
+        let t: ty::t = fcx.infcx().next_ty_var(None);
         for e in args.iter() {
             check_expr_has_type(fcx, *e, t);
         }
@@ -3144,7 +3144,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       ast::ExprRepeat(element, count_expr) => {
         check_expr_with_hint(fcx, count_expr, ty::mk_uint());
         let count = ty::eval_repeat_count(fcx, count_expr);
-        let t: ty::t = fcx.infcx().next_ty_var();
+        let t: ty::t = fcx.infcx().next_ty_var(None);
         check_expr_has_type(fcx, element, t);
         let element_ty = fcx.expr_ty(element);
         if ty::type_is_error(element_ty) {
@@ -3882,7 +3882,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
                                    .enumerate() {
             match self_parameter_index {
                 Some(index) if index == i => {
-                    tps.push(fcx.infcx().next_ty_var());
+                    tps.push(fcx.infcx().next_ty_var(None));
                     pushed = true;
                 }
                 _ => {}
@@ -3906,7 +3906,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
         for (i, default) in defaults.skip(ty_substs_len).enumerate() {
             match self_parameter_index {
                 Some(index) if index == i + ty_substs_len => {
-                    substs.tps.push(fcx.infcx().next_ty_var());
+                    substs.tps.push(fcx.infcx().next_ty_var(None));
                     pushed = true;
                 }
                 _ => {}
@@ -3925,7 +3925,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
 
         // If the self parameter goes at the end, insert it there.
         if !pushed && self_parameter_index.is_some() {
-            substs.tps.push(fcx.infcx().next_ty_var())
+            substs.tps.push(fcx.infcx().next_ty_var(None))
         }
 
         assert_eq!(substs.tps.len(), ty_param_count)

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -480,13 +480,10 @@ impl<'a> CoherenceChecker<'a> {
                 infer::BoundRegionInCoherence(d.name)))
             .collect();
 
-        let bounds_count = polytype.generics.type_param_defs().len();
-        let type_parameters = self.inference_context.next_ty_vars(bounds_count);
-
         let substitutions = substs {
             regions: ty::NonerasedRegions(region_parameters),
             self_ty: None,
-            tps: type_parameters
+            tps: self.inference_context.next_ty_vars(polytype.generics.type_param_defs())
         };
         let monotype = subst(self.crate_context.tcx,
                              &substitutions,

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -15,11 +15,8 @@ use middle::ty;
 use middle::typeck::infer::then;
 use middle::typeck::infer::combine::*;
 use middle::typeck::infer::lattice::*;
-use middle::typeck::infer::lub::Lub;
-use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::InferStr;
-use middle::typeck::infer::{cres, InferCtxt};
-use middle::typeck::infer::{TypeTrace, Subtype};
+use middle::typeck::infer::{cres, Subtype};
 use middle::typeck::infer::fold_regions_in_sig;
 use syntax::ast::{Many, Once, MutImmutable, MutMutable};
 use syntax::ast::{ExternFn, NormalFn, UnsafeFn, NodeId};
@@ -30,19 +27,9 @@ use util::ppaux::mt_to_str;
 
 pub struct Glb<'f>(pub CombineFields<'f>);  // "greatest lower bound" (common subtype)
 
-impl<'f> Glb<'f> {
-    pub fn get_ref<'a>(&'a self) -> &'a CombineFields<'f> { let Glb(ref v) = *self; v }
-}
-
-impl<'f> Combine for Glb<'f> {
-    fn infcx<'a>(&'a self) -> &'a InferCtxt<'a> { self.get_ref().infcx }
-    fn tag(&self) -> ~str { "glb".to_owned() }
-    fn a_is_expected(&self) -> bool { self.get_ref().a_is_expected }
-    fn trace(&self) -> TypeTrace { self.get_ref().trace.clone() }
-
-    fn sub<'a>(&'a self) -> Sub<'a> { Sub(self.get_ref().clone()) }
-    fn lub<'a>(&'a self) -> Lub<'a> { Lub(self.get_ref().clone()) }
-    fn glb<'a>(&'a self) -> Glb<'a> { Glb(self.get_ref().clone()) }
+impl<'f> Combine<'f> for Glb<'f> {
+    fn get_ref<'a>(&'a self) -> &'a CombineFields<'f> { let Glb(ref v) = *self; v }
+    fn tag(&self) -> &'static str { "glb" }
 
     fn mts(&self, a: &ty::mt, b: &ty::mt) -> cres<ty::mt> {
         let tcx = self.get_ref().infcx.tcx;

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -364,10 +364,10 @@ impl<'f> TyLatticeDir for Glb<'f> {
     }
 }
 
-pub fn super_lattice_tys<L:LatticeDir+TyLatticeDir+Combine>(this: &L,
-                                                            a: ty::t,
-                                                            b: ty::t)
-                                                            -> cres<ty::t> {
+pub fn super_lattice_tys<'f, L:LatticeDir+TyLatticeDir+Combine<'f>>(this: &L,
+                                                                    a: ty::t,
+                                                                    b: ty::t)
+                                                                    -> cres<ty::t> {
     debug!("{}.lattice_tys({}, {})", this.tag(),
            a.inf_str(this.infcx()),
            b.inf_str(this.infcx()));
@@ -430,7 +430,7 @@ pub enum LatticeVarResult<V,T> {
  *   the variables and return the unified variable, in which case the
  *   result is a variable.  This is indicated with a `VarResult`
  *   return. */
-pub fn lattice_vars<L:LatticeDir + Combine,
+pub fn lattice_vars<'f, L:LatticeDir + Combine<'f>,
                     T:Clone + InferStr + LatticeValue,
                     V:Clone + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
     this: &L,                           // defines whether we want LUB or GLB
@@ -476,7 +476,7 @@ pub fn lattice_vars<L:LatticeDir + Combine,
     })
 }
 
-pub fn lattice_var_and_t<L:LatticeDir + Combine,
+pub fn lattice_var_and_t<'f, L:LatticeDir + Combine<'f>,
                          T:Clone + InferStr + LatticeValue,
                          V:Clone + Eq + ToStr + Vid + UnifyVid<Bounds<T>>>(
     this: &L,
@@ -521,9 +521,9 @@ pub fn lattice_var_and_t<L:LatticeDir + Combine,
 // Random utility functions used by LUB/GLB when computing LUB/GLB of
 // fn types
 
-pub fn var_ids<T:Combine>(this: &T,
-                          map: &HashMap<ty::BoundRegion, ty::Region>)
-                          -> Vec<RegionVid> {
+pub fn var_ids<'f, T: Combine<'f>>(this: &T,
+                                   map: &HashMap<ty::BoundRegion, ty::Region>)
+                                   -> Vec<RegionVid> {
     map.iter().map(|(_, r)| match *r {
             ty::ReInfer(ty::ReVar(r)) => { r }
             r => {

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -14,13 +14,10 @@ use middle::ty::RegionVid;
 use middle::ty;
 use middle::typeck::infer::then;
 use middle::typeck::infer::combine::*;
-use middle::typeck::infer::glb::Glb;
 use middle::typeck::infer::lattice::*;
-use middle::typeck::infer::sub::Sub;
 use middle::typeck::infer::to_str::InferStr;
-use middle::typeck::infer::{cres, InferCtxt};
+use middle::typeck::infer::{cres, Subtype};
 use middle::typeck::infer::fold_regions_in_sig;
-use middle::typeck::infer::{TypeTrace, Subtype};
 use collections::HashMap;
 use syntax::ast::{Many, Once, NodeId};
 use syntax::ast::{ExternFn, NormalFn, UnsafeFn};
@@ -29,19 +26,9 @@ use util::ppaux::mt_to_str;
 
 pub struct Lub<'f>(pub CombineFields<'f>);  // least-upper-bound: common supertype
 
-impl<'f> Lub<'f> {
-    pub fn get_ref<'a>(&'a self) -> &'a CombineFields<'f> { let Lub(ref v) = *self; v }
-}
-
-impl<'f> Combine for Lub<'f> {
-    fn infcx<'a>(&'a self) -> &'a InferCtxt<'a> { self.get_ref().infcx }
-    fn tag(&self) -> ~str { "lub".to_owned() }
-    fn a_is_expected(&self) -> bool { self.get_ref().a_is_expected }
-    fn trace(&self) -> TypeTrace { self.get_ref().trace.clone() }
-
-    fn sub<'a>(&'a self) -> Sub<'a> { Sub(self.get_ref().clone()) }
-    fn lub<'a>(&'a self) -> Lub<'a> { Lub(self.get_ref().clone()) }
-    fn glb<'a>(&'a self) -> Glb<'a> { Glb(self.get_ref().clone()) }
+impl<'f> Combine<'f> for Lub<'f> {
+    fn get_ref<'a>(&'a self) -> &'a CombineFields<'f> { let Lub(ref v) = *self; v }
+    fn tag(&self) -> &'static str { "lub" }
 
     fn mts(&self, a: &ty::mt, b: &ty::mt) -> cres<ty::mt> {
         let tcx = self.get_ref().infcx.tcx;

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -66,7 +66,8 @@ pub type Bound<T> = Option<T>;
 #[deriving(Clone)]
 pub struct Bounds<T> {
     lb: Bound<T>,
-    ub: Bound<T>
+    ub: Bound<T>,
+    fallback: Bound<T>
 }
 
 pub type cres<T> = Result<T,ty::type_err>; // "combine result"
@@ -590,19 +591,22 @@ fn next_simple_var<V:Clone,T:Clone>(counter: &mut uint,
 }
 
 impl<'a> InferCtxt<'a> {
-    pub fn next_ty_var(&self) -> ty::t {
+    pub fn next_ty_var(&self, fallback: Option<ty::t>) -> ty::t {
         let id = self.ty_var_counter.get();
         self.ty_var_counter.set(id + 1);
         self.ty_var_bindings.borrow_mut().vals.insert(id, Root(Bounds {
             lb: None,
-            ub: None
+            ub: None,
+            fallback: fallback
         }, 0u));
 
         ty::mk_var(self.tcx, TyVid(id))
     }
 
     pub fn next_ty_vars(&self, ty_params: &[ty::TypeParameterDef]) -> Vec<ty::t> {
-        ty_params.iter().map(|_| self.next_ty_var()).collect()
+        ty_params.iter().map(|ty_param| {
+            self.next_ty_var(ty_param.default)
+        }).collect()
     }
 
     pub fn next_int_var_id(&self) -> IntVid {

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -590,23 +590,19 @@ fn next_simple_var<V:Clone,T:Clone>(counter: &mut uint,
 }
 
 impl<'a> InferCtxt<'a> {
-    pub fn next_ty_var_id(&self) -> TyVid {
+    pub fn next_ty_var(&self) -> ty::t {
         let id = self.ty_var_counter.get();
         self.ty_var_counter.set(id + 1);
-        {
-            let mut ty_var_bindings = self.ty_var_bindings.borrow_mut();
-            let vals = &mut ty_var_bindings.vals;
-            vals.insert(id, Root(Bounds { lb: None, ub: None }, 0u));
-        }
-        return TyVid(id);
+        self.ty_var_bindings.borrow_mut().vals.insert(id, Root(Bounds {
+            lb: None,
+            ub: None
+        }, 0u));
+
+        ty::mk_var(self.tcx, TyVid(id))
     }
 
-    pub fn next_ty_var(&self) -> ty::t {
-        ty::mk_var(self.tcx, self.next_ty_var_id())
-    }
-
-    pub fn next_ty_vars(&self, n: uint) -> Vec<ty::t> {
-        Vec::from_fn(n, |_i| self.next_ty_var())
+    pub fn next_ty_vars(&self, ty_params: &[ty::TypeParameterDef]) -> Vec<ty::t> {
+        ty_params.iter().map(|_| self.next_ty_var()).collect()
     }
 
     pub fn next_int_var_id(&self) -> IntVid {

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -220,11 +220,14 @@ impl<'a> ResolveState<'a> {
             let bounds = nde.possible_types;
 
             let t1 = match bounds {
-              Bounds { ub:_, lb:Some(t) } if !type_is_bot(t)
+              Bounds { ub:_, lb:Some(t), .. } if !type_is_bot(t)
                 => self.resolve_type(t),
-              Bounds { ub:Some(t), lb:_ } => self.resolve_type(t),
-              Bounds { ub:_, lb:Some(t) } => self.resolve_type(t),
-              Bounds { ub:None, lb:None } => {
+              Bounds { ub:Some(t), lb:_, .. } => self.resolve_type(t),
+              Bounds { ub:_, lb:Some(t), .. } => self.resolve_type(t),
+              Bounds { ub:None, lb:None, fallback: Some(t) } if self.should(force_tvar) => {
+                  self.resolve_type(t)
+              }
+              Bounds { ub:None, lb:None, .. } => {
                 if self.should(force_tvar) {
                     self.err = Some(unresolved_ty(vid));
                 }

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -14,14 +14,10 @@ use middle::ty;
 use middle::ty::TyVar;
 use middle::typeck::check::regionmanip::replace_late_bound_regions_in_fn_sig;
 use middle::typeck::infer::combine::*;
-use middle::typeck::infer::{cres, CresCompare};
-use middle::typeck::infer::glb::Glb;
-use middle::typeck::infer::InferCtxt;
+use middle::typeck::infer::{cres, CresCompare, Subtype};
 use middle::typeck::infer::lattice::CombineFieldsLatticeMethods;
-use middle::typeck::infer::lub::Lub;
 use middle::typeck::infer::then;
 use middle::typeck::infer::to_str::InferStr;
-use middle::typeck::infer::{TypeTrace, Subtype};
 use util::common::{indenter};
 use util::ppaux::bound_region_to_str;
 
@@ -29,19 +25,9 @@ use syntax::ast::{Onceness, FnStyle};
 
 pub struct Sub<'f>(pub CombineFields<'f>);  // "subtype", "subregion" etc
 
-impl<'f> Sub<'f> {
-    pub fn get_ref<'a>(&'a self) -> &'a CombineFields<'f> { let Sub(ref v) = *self; v }
-}
-
-impl<'f> Combine for Sub<'f> {
-    fn infcx<'a>(&'a self) -> &'a InferCtxt<'a> { self.get_ref().infcx }
-    fn tag(&self) -> ~str { "sub".to_owned() }
-    fn a_is_expected(&self) -> bool { self.get_ref().a_is_expected }
-    fn trace(&self) -> TypeTrace { self.get_ref().trace.clone() }
-
-    fn sub<'a>(&'a self) -> Sub<'a> { Sub(self.get_ref().clone()) }
-    fn lub<'a>(&'a self) -> Lub<'a> { Lub(self.get_ref().clone()) }
-    fn glb<'a>(&'a self) -> Glb<'a> { Glb(self.get_ref().clone()) }
+impl<'f> Combine<'f> for Sub<'f> {
+    fn get_ref<'a>(&'a self) -> &'a CombineFields<'f> { let Sub(ref v) = *self; v }
+    fn tag(&self) -> &'static str { "sub" }
 
     fn contratys(&self, a: ty::t, b: ty::t) -> cres<ty::t> {
         let opp = CombineFields {


### PR DESCRIPTION
This enables more powerful uses of default type params, while maintaining backwards compatibility.

``` rust
// A simple function example.
fn foo<T: Default = uint>() -> T {Default::default()}
println!("{}", foo());

// Making constructors generic over type params, falling back to a default.
// This allows making, e.g. containers parametric over an allocator without
// affecting existing code bases and without using different constructors.
#[deriving(Default)]
struct Heap;
struct Vec<T, A = Heap>(A);
impl<T, A: Default = Heap> Vec<T, A> {
    fn new() -> Vec<T, A> {
        Vec(Default::default())
    }
    fn push(&self, _: T) {}
}

// error: mismatched types: expected `main::Vec<<generic #1>>` but found `()`
let () = Vec::new(); // ^^ the error message omits A, it was inferred to Heap

let v = Vec::new();
v.push(5u); 
// error: mismatched types: expected `main::Vec<uint>` but found `()`
let () = v; // ^^ fully inferred type (again omitting A)

let v: Vec<_, char> = Vec::new();
v.push(5u);
// error: mismatched types: expected `main::Vec<uint, char>` but found `()`
let () = v; // ^^ overriding the defaults still works
```

**Disclaimer**: the current implementation is only a proof of concept, missing substitution (for `<T, U = (T, T)>`) and any form of lifetime environment (for `<'a, T = &'a int>`).

Also, I somehow managed to break overriding the defaults (the last example doesn't actually compile).
It seems odd given that fallbacls should only be used when `force_tvar` is set, and that shouldn't happen for `let v: Vec<_, char> = Vec::new();` (otherwise our inference would be unusable).
cc @nikomatsakis
