### PR TITLE
Hide trait rc::RcBoxPtr from docs

### DIFF
--- a/src/libstd/rc.rs
+++ b/src/libstd/rc.rs
@@ -192,7 +192,7 @@ impl<T> Clone for Weak<T> {
     }
 }
 
-#[allow(missing_doc)]
+#[doc(hidden)]
 trait RcBoxPtr<T> {
     fn inner<'a>(&'a self) -> &'a RcBox<T>;
 


### PR DESCRIPTION
It is for internal use only and should not appear in docs.
