### PR TITLE
test: Add an option to not capture output

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -267,7 +267,8 @@ pub fn test_opts(config: &config) -> test::TestOpts {
         ratchet_metrics: config.ratchet_metrics.clone(),
         ratchet_noise_percent: config.ratchet_noise_percent.clone(),
         save_metrics: config.save_metrics.clone(),
-        test_shard: config.test_shard.clone()
+        test_shard: config.test_shard.clone(),
+        nocapture: false,
     }
 }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -955,6 +955,7 @@ fn fatal(err: ~str) -> ! { error(err); fail!(); }
 fn fatal_ProcRes(err: ~str, proc_res: &ProcRes) -> ! {
     print!("\n\
 error: {}\n\
+status: {}\n\
 command: {}\n\
 stdout:\n\
 ------------------------------------------\n\
@@ -965,7 +966,8 @@ stderr:\n\
 {}\n\
 ------------------------------------------\n\
 \n",
-             err, proc_res.cmdline, proc_res.stdout, proc_res.stderr);
+             err, proc_res.status, proc_res.cmdline, proc_res.stdout,
+             proc_res.stderr);
     fail!();
 }
 


### PR DESCRIPTION
A new flag to the test runner, --nocapture, can be passed to instruct that the
output of tests should not be captured by default. The behavior can also be
triggered via a RUST_TEST_NOCAPTURE environment variable being set.

Closes #13374
