### PR TITLE
fast_rsqrt for f32 and f64 types

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -460,9 +460,9 @@ impl Float for f32 {
     /// Newton's method to approximate the value.
     /// Originally seen in Quake arena
     fn fast_rsqrt(self) -> f32 {
-        let mut i:  i32 = 0;
-        let mut x2: f32 = 0.0;
-        let mut y:  f32 = 0.0;
+        let mut i:  i32;
+        let mut x2: f32;
+        let mut y:  f32;
 
         y  = self;
         x2 = y * 0.5;

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -466,8 +466,8 @@ impl Float for f32 {
 
         y  = self;
         x2 = y * 0.5;
-        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit level hacking
-        i = 0x5f3759df - ( i >> 1 );
+        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit
+        i = 0x5f3759df - ( i >> 1 );                      // level hacking
         y = unsafe{std::cast::transmute::<i32, f32>(i)};
         y = y * (1.5 - (x2 * y * y));
         y

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -456,6 +456,23 @@ impl Float for f32 {
     #[inline]
     fn rsqrt(self) -> f32 { self.sqrt().recip() }
 
+    /// The reciprocal of the square root of a number, quickly using
+    /// Newton's method to approximate the value.
+    /// Originally seen in Quake arena
+    fn fast_rsqrt(self) -> f32 {
+        let mut i:  i32 = 0;
+        let mut x2: f32 = 0.0;
+        let mut y:  f32 = 0.0;
+
+        y  = self;
+        x2 = y * 0.5;
+        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit level hacking
+        i = 0x5f3759df - ( i >> 1 );
+        y = unsafe{std::cast::transmute::<i32, f32>(i)};
+        y = y * (1.5 - (x2 * y * y));
+        y
+    }
+
     #[inline]
     fn cbrt(self) -> f32 {
         unsafe { cmath::cbrtf(self) }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -466,9 +466,9 @@ impl Float for f32 {
 
         y  = self;
         x2 = y * 0.5;
-        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit
+        i = unsafe{cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit
         i = 0x5f3759df - ( i >> 1 );                      // level hacking
-        y = unsafe{std::cast::transmute::<i32, f32>(i)};
+        y = unsafe{cast::transmute::<i32, f32>(i)};
         y = y * (1.5 - (x2 * y * y));
         y
     }

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -464,6 +464,28 @@ impl Float for f64 {
     #[inline]
     fn rsqrt(self) -> f64 { self.sqrt().recip() }
 
+    /// The reciprocal of the square root of a number, quickly using
+    /// Newton's method to approximate the value.  For f64 values,
+    /// the calculations are still done with 32 bit precision due to
+    /// the math not working the same way in higher bit types.  If you're
+    /// calculating the "fast" inverse square root, however, this should
+    /// not be a major problem
+    /// Originally seen in Quake arena
+    fn fast_rsqrt(self) -> f64 {
+        let mut i:  i32 = 0;
+        let mut x2: f32 = 0.0;
+        let mut y:  f32 = 0.0;
+
+        y  = self as f32;
+        x2 = y * 0.5;
+        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit level hacking
+        i = 0x5f3759df - ( i >> 1 );
+        y = unsafe{std::cast::transmute::<i32, f32>(i)};
+        y = y * (1.5 - (x2 * y * y));
+        y as f64
+    }
+
+
     #[inline]
     fn cbrt(self) -> f64 {
         unsafe { cmath::cbrt(self) }

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -478,8 +478,8 @@ impl Float for f64 {
 
         y  = self as f32;
         x2 = y * 0.5;
-        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit level hacking
-        i = 0x5f3759df - ( i >> 1 );
+        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit
+        i = 0x5f3759df - ( i >> 1 );                      // level hacking
         y = unsafe{std::cast::transmute::<i32, f32>(i)};
         y = y * (1.5 - (x2 * y * y));
         y as f64

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -472,9 +472,9 @@ impl Float for f64 {
     /// not be a major problem
     /// Originally seen in Quake arena
     fn fast_rsqrt(self) -> f64 {
-        let mut i:  i32 = 0;
-        let mut x2: f32 = 0.0;
-        let mut y:  f32 = 0.0;
+        let mut i:  i32;
+        let mut x2: f32;
+        let mut y:  f32;
 
         y  = self as f32;
         x2 = y * 0.5;

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -478,9 +478,9 @@ impl Float for f64 {
 
         y  = self as f32;
         x2 = y * 0.5;
-        i = unsafe{std::cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit
+        i = unsafe{cast::transmute::<f32, i32>(y)};  // stark lack of evil floating point bit
         i = 0x5f3759df - ( i >> 1 );                      // level hacking
-        y = unsafe{std::cast::transmute::<i32, f32>(i)};
+        y = unsafe{cast::transmute::<i32, f32>(i)};
         y = y * (1.5 - (x2 * y * y));
         y as f64
     }

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -428,6 +428,8 @@ pub trait Float: Signed + Primitive {
     fn sqrt(self) -> Self;
     /// Take the reciprocal (inverse) square root of a number, `1/sqrt(x)`.
     fn rsqrt(self) -> Self;
+    /// Take the fast reciprocal (inverse) square root of a number, `1/sqrt(x)`
+    fn fast_rsqrt(self) -> Self;
     /// Take the cubic root of a number.
     fn cbrt(self) -> Self;
     /// Calculate the length of the hypotenuse of a right-angle triangle given


### PR DESCRIPTION
Useful for applications that need to be as fast as possible, this function allows for faster inverse square root computation than the current rsqrt function.  Both are necessary, and serve different purposes.
