### PR TITLE
Fix Vim indent regressions from #13600.

### DIFF
--- a/src/etc/vim/indent/rust.vim
+++ b/src/etc/vim/indent/rust.vim
@@ -105,7 +105,7 @@ function GetRustIndent(lnum)
 	if prevline[len(prevline) - 1] == ","
 				\ && s:get_line_trimmed(a:lnum) !~ "^\\s*[\\[\\]{}]"
 				\ && prevline !~ "^\\s*fn\\s"
-				\ && prevline !~ "\\([^\\(\\)]\+,$"
+				\ && prevline !~ "([^()]\\+,$"
 		" Oh ho! The previous line ended in a comma! I bet cindent will try to
 		" take this too far... For now, let's normally use the previous line's
 		" indent.


### PR DESCRIPTION
The change in #13600 was incorrect, containing a bad regular expression;
inside an indent function, errors are silently ignored (and the `~=`
operation will return 0), so it just always failed, causing the cases
that were supposed to be caught to not be caught and making things like
the `match` example shown above or struct field definitions regress.

I have fixed the regular expression to what it should have been. This is
still imperfect, of course, not handling cases like where the first
argument to a function is a function call (`foo(bar(),`), but it'll do
for now.

---

I have a general request to make of reviewers about any changes made to `src/etc/vim`: **please tell me**. As a general rule I want to review them. (I’ll make an exception for changes the prelude; it needs fixing from time to time when some people don’t update the syntax file, anyway.)

cc @brandonw
