### PR TITLE
add min_pos_value constant for floats

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -71,9 +71,11 @@ pub static DIGITS: uint = 6u;
 
 pub static EPSILON: f32 = 1.19209290e-07_f32;
 
-/// Minimum normalized f32 value
-pub static MIN_VALUE: f32 = 1.17549435e-38_f32;
-/// Maximum f32 value
+/// Smallest finite f32 value
+pub static MIN_VALUE: f32 = -3.40282347e+38_f32;
+/// Smallest positive, normalized f32 value
+pub static MIN_POS_VALUE: f32 = 1.17549435e-38_f32;
+/// Largest finite f32 value
 pub static MAX_VALUE: f32 = 3.40282347e+38_f32;
 
 pub static MIN_EXP: int = -125;
@@ -90,8 +92,9 @@ pub static NEG_INFINITY: f32 = -1.0_f32/0.0_f32;
 pub mod consts {
     // FIXME: replace with mathematical constants from cmath.
 
-    // FIXME(#11621): These constants should be deprecated once CTFE is
-    // implemented in favour of calling their respective functions in `Float`.
+    // FIXME(#5527): These constants should be deprecated once associated
+    // constants are implemented in favour of referencing the respective members
+    // of `Float`.
 
     /// Archimedes' constant
     pub static PI: f32 = 3.14159265358979323846264338327950288_f32;
@@ -341,6 +344,9 @@ impl Float for f32 {
 
     #[inline]
     fn max_10_exp(_: Option<f32>) -> int { MAX_10_EXP }
+
+    #[inline]
+    fn min_pos_value(_: Option<f32>) -> f32 { MIN_POS_VALUE }
 
     /// Constructs a floating point number by multiplying `x` by 2 raised to the
     /// power of `exp`

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -73,8 +73,9 @@ mod cmath {
     }
 }
 
-// FIXME(#11621): These constants should be deprecated once CTFE is implemented
-// in favour of calling their respective functions in `Bounded` and `Float`.
+// FIXME(#5527): These constants should be deprecated once associated
+// constants are implemented in favour of referencing the respective
+// members of `Bounded` and `Float`.
 
 pub static RADIX: uint = 2u;
 
@@ -83,9 +84,11 @@ pub static DIGITS: uint = 15u;
 
 pub static EPSILON: f64 = 2.2204460492503131e-16_f64;
 
-/// Minimum normalized f64 value
-pub static MIN_VALUE: f64 = 2.2250738585072014e-308_f64;
-/// Maximum f64 value
+/// Smallest finite f64 value
+pub static MIN_VALUE: f64 = -1.7976931348623157e+308_f64;
+/// Smallest positive, normalized f64 value
+pub static MIN_POS_VALUE: f64 = 2.2250738585072014e-308_f64;
+/// Largest finite f64 value
 pub static MAX_VALUE: f64 = 1.7976931348623157e+308_f64;
 
 pub static MIN_EXP: int = -1021;
@@ -104,8 +107,9 @@ pub static NEG_INFINITY: f64 = -1.0_f64/0.0_f64;
 pub mod consts {
     // FIXME: replace with mathematical constants from cmath.
 
-    // FIXME(#11621): These constants should be deprecated once CTFE is
-    // implemented in favour of calling their respective functions in `Float`.
+    // FIXME(#5527): These constants should be deprecated once associated
+    // constants are implemented in favour of referencing the respective members
+    // of `Float`.
 
     /// Archimedes' constant
     pub static PI: f64 = 3.14159265358979323846264338327950288_f64;
@@ -330,25 +334,28 @@ impl Float for f64 {
     }
 
     #[inline]
-    fn mantissa_digits(_: Option<f64>) -> uint { 53 }
+    fn mantissa_digits(_: Option<f64>) -> uint { MANTISSA_DIGITS }
 
     #[inline]
-    fn digits(_: Option<f64>) -> uint { 15 }
+    fn digits(_: Option<f64>) -> uint { DIGITS }
 
     #[inline]
-    fn epsilon() -> f64 { 2.2204460492503131e-16 }
+    fn epsilon() -> f64 { EPSILON }
 
     #[inline]
-    fn min_exp(_: Option<f64>) -> int { -1021 }
+    fn min_exp(_: Option<f64>) -> int { MIN_EXP }
 
     #[inline]
-    fn max_exp(_: Option<f64>) -> int { 1024 }
+    fn max_exp(_: Option<f64>) -> int { MAX_EXP }
 
     #[inline]
-    fn min_10_exp(_: Option<f64>) -> int { -307 }
+    fn min_10_exp(_: Option<f64>) -> int { MIN_10_EXP }
 
     #[inline]
-    fn max_10_exp(_: Option<f64>) -> int { 308 }
+    fn max_10_exp(_: Option<f64>) -> int { MAX_10_EXP }
+
+    #[inline]
+    fn min_pos_value(_: Option<f64>) -> f64 { MIN_POS_VALUE }
 
     /// Constructs a floating point number by multiplying `x` by 2 raised to the
     /// power of `exp`

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -190,7 +190,9 @@ pub fn pow<T: One + Mul<T, T>>(mut base: T, mut exp: uint) -> T {
 /// Numbers which have upper and lower bounds
 pub trait Bounded {
     // FIXME (#5527): These should be associated constants
+    /// returns the smallest finite number this type can represent
     fn min_value() -> Self;
+    /// returns the largest finite number this type can represent
     fn max_value() -> Self;
 }
 
@@ -356,6 +358,8 @@ pub trait Float: Signed + Primitive {
     /// Returns the category that this number falls into.
     fn classify(self) -> FPCategory;
 
+    // FIXME (#5527): These should be associated constants
+
     /// Returns the number of binary digits of mantissa that this type supports.
     fn mantissa_digits(unused_self: Option<Self>) -> uint;
     /// Returns the number of base-10 digits of precision that this type supports.
@@ -370,6 +374,8 @@ pub trait Float: Signed + Primitive {
     fn min_10_exp(unused_self: Option<Self>) -> int;
     /// Returns the maximum base-10 exponent that this type can represent.
     fn max_10_exp(unused_self: Option<Self>) -> int;
+    /// Returns the smallest normalized positive number that this type can represent.
+    fn min_pos_value(unused_self: Option<Self>) -> Self;
 
     /// Constructs a floating point number created by multiplying `x` by 2
     /// raised to the power of `exp`.
@@ -433,6 +439,8 @@ pub trait Float: Signed + Primitive {
     /// Calculate the length of the hypotenuse of a right-angle triangle given
     /// legs of length `x` and `y`.
     fn hypot(self, other: Self) -> Self;
+
+    // FIXME (#5527): These should be associated constants
 
     /// Archimedes' constant.
     fn pi() -> Self;


### PR DESCRIPTION
Follow-up on issue #13297 and PR #13710.  Instead of following the (confusing) C/C++ approach
of using `MIN_VALUE` for the smallest _positive_ number, we introduce `MIN_POS_VALUE` (and
in the Float trait, `min_pos_value`) to represent this number.

This patch also removes a few remaining redundantly-defined constants that were missed last
time around.
