### PR TITLE
Add trait std::vec::IntoVec

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -94,6 +94,7 @@ syn keyword rustTrait ImmutableEqVector ImmutableTotalOrdVector ImmutableCloneab
 syn keyword rustTrait OwnedVector OwnedCloneableVector OwnedEqVector
 syn keyword rustTrait MutableVector MutableTotalOrdVector
 syn keyword rustTrait Vector VectorVector CloneableVector ImmutableVector
+syn keyword rustTrait Vec IntoVec
 
 "syn keyword rustFunction stream
 syn keyword rustTrait Sender Receiver

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -186,9 +186,6 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// Returns the path as a byte vector
     fn as_vec<'a>(&'a self) -> &'a [u8];
 
-    /// Converts the Path into an owned byte vector
-    fn into_vec(self) -> Vec<u8>;
-
     /// Returns an object that implements `Show` for printing paths
     ///
     /// This will print the equivalent of `to_display_str()` when used with a {} format parameter.

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -22,7 +22,7 @@ use str;
 use str::Str;
 use slice::{CloneableVector, RevSplits, Splits, Vector, VectorVector,
             ImmutableEqVector, OwnedVector, ImmutableVector};
-use vec::Vec;
+use vec::{Vec,IntoVec};
 
 use super::{BytesContainer, GenericPath, GenericPathUnsafe};
 
@@ -181,10 +181,6 @@ impl GenericPath for Path {
         self.repr.as_slice()
     }
 
-    fn into_vec(self) -> Vec<u8> {
-        self.repr
-    }
-
     fn dirname<'a>(&'a self) -> &'a [u8] {
         match self.sepidx {
             None if bytes!("..") == self.repr.as_slice() => self.repr.as_slice(),
@@ -319,6 +315,13 @@ impl GenericPath for Path {
             }
         }
         true
+    }
+}
+
+impl IntoVec<u8> for Path {
+    #[inline]
+    fn into_vec(self) -> Vec<u8> {
+        self.repr
     }
 }
 

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -23,7 +23,7 @@ use option::{Option, Some, None};
 use slice::{Vector, OwnedVector, ImmutableVector};
 use str::{CharSplits, Str, StrVector, StrSlice};
 use strbuf::StrBuf;
-use vec::Vec;
+use vec::{Vec,IntoVec};
 
 use super::{contains_nul, BytesContainer, GenericPath, GenericPathUnsafe};
 
@@ -333,11 +333,6 @@ impl GenericPath for Path {
     }
 
     #[inline]
-    fn into_vec(self) -> Vec<u8> {
-        Vec::from_slice(self.repr.as_bytes())
-    }
-
-    #[inline]
     fn dirname<'a>(&'a self) -> &'a [u8] {
         self.dirname_str().unwrap().as_bytes()
     }
@@ -587,6 +582,13 @@ impl GenericPath for Path {
             }
         }
         true
+    }
+}
+
+impl IntoVec<u8> for Path {
+    #[inline]
+    fn into_vec(self) -> Vec<u8> {
+        Vec::from_slice(self.repr.as_bytes())
     }
 }
 

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -60,7 +60,7 @@ pub use slice::{OwnedVector};
 pub use slice::{MutableVector, MutableTotalOrdVector};
 pub use slice::{Vector, VectorVector, CloneableVector, ImmutableVector};
 pub use strbuf::StrBuf;
-pub use vec::Vec;
+pub use vec::{Vec,IntoVec};
 
 // Reexported runtime types
 pub use comm::{sync_channel, channel, SyncSender, Sender, Receiver};

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -54,17 +54,6 @@ impl<T> OwnedSlice<T> {
         }
     }
 
-    #[inline(never)]
-    pub fn into_vec(self) -> Vec<T> {
-        // null is ok, because len == 0 in that case, as required by Vec.
-        unsafe {
-            let ret = Vec::from_raw_parts(self.len, self.len, self.data);
-            // the vector owns the allocation now
-            cast::forget(self);
-            ret
-        }
-    }
-
     pub fn as_slice<'a>(&'a self) -> &'a [T] {
         static PTR_MARKER: u8 = 0;
         let ptr = if self.data.is_null() {
@@ -92,6 +81,19 @@ impl<T> OwnedSlice<T> {
 
     pub fn map<U>(&self, f: |&T| -> U) -> OwnedSlice<U> {
         self.iter().map(f).collect()
+    }
+}
+
+impl<T> IntoVec<T> for OwnedSlice<T> {
+    fn into_vec(self) -> Vec<T> {
+        #![inline(never)]
+        // null is ok, because len == 0 in that case, as required by Vec.
+        unsafe {
+            let ret = Vec::from_raw_parts(self.len, self.len, self.data);
+            // the vector owns the allocation now
+            cast::forget(self);
+            ret
+        }
     }
 }
 


### PR DESCRIPTION
std::vec::IntoVec provides the .into_vec() method, similar to
std::slice::CloneableVector. It does not provide .to_vec(), because that
requires Clone, and can instead just be provided on individual types
separately.
