### PR TITLE
Various modifications to debug and/or fix `make check-stage1`

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -357,12 +357,18 @@ endef
 define SREQ_CMDS
 
 ifeq ($$(OSTYPE_$(3)),apple-darwin)
-  RPATH_VAR$(1)_T_$(2)_H_$(3) := \
+  HOST_RPATH_VAR$(1)_T_$(2)_H_$(3) := \
       DYLD_LIBRARY_PATH="$$$$DYLD_LIBRARY_PATH:$$(CURDIR)/$$(HLIB$(1)_H_$(3))"
+  TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3) := \
+      DYLD_LIBRARY_PATH="$$$$DYLD_LIBRARY_PATH:$$(CURDIR)/$$(TLIB1_T_$(2)_H_$(CFG_BUILD))"
 else
-  RPATH_VAR$(1)_T_$(2)_H_$(3) := \
+  HOST_RPATH_VAR$(1)_T_$(2)_H_$(3) := \
       LD_LIBRARY_PATH="$$$$LD_LIBRARY_PATH:$$(CURDIR)/$$(HLIB$(1)_H_$(3))"
+  TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3) := \
+      LD_LIBRARY_PATH="$$$$LD_LIBRARY_PATH:$$(CURDIR)/$$(TLIB1_T_$(2)_H_$(CFG_BUILD))"
 endif
+
+RPATH_VAR$(1)_T_$(2)_H_$(3) := $$(HOST_RPATH_VAR$(1)_T_$(2)_H_$(3))
 
 # Pass --cfg stage0 only for the build->host part of stage0;
 # if you're building a cross config, the host->* parts are
@@ -379,13 +385,7 @@ ifeq ($(1),0)
 ifneq ($(strip $(CFG_BUILD)),$(strip $(3)))
 CFGFLAG$(1)_T_$(2)_H_$(3) = stage1
 
-ifeq ($$(OSTYPE_$(3)),apple-darwin)
-  RPATH_VAR$(1)_T_$(2)_H_$(3) := \
-      DYLD_LIBRARY_PATH="$$$$DYLD_LIBRARY_PATH:$$(CURDIR)/$$(TLIB1_T_$(2)_H_$(CFG_BUILD))"
-else
-  RPATH_VAR$(1)_T_$(2)_H_$(3) := \
-      LD_LIBRARY_PATH="$$$$LD_LIBRARY_PATH:$$(CURDIR)/$$(TLIB1_T_$(2)_H_$(CFG_BUILD))"
-endif
+RPATH_VAR$(1)_T_$(2)_H_$(3) := $$(TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3))
 endif
 endif
 

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -134,7 +134,7 @@ endif
 # worry about the distribution of one file (with its native dynamic
 # dependencies)
 RUSTFLAGS_STAGE0 += -C prefer-dynamic
-RUSTFLAGS_STAGE1 += -C prefer-dynamic
+RUSTFLAGS_STAGE1 += -C prefer-dynamic --install-prefix $(CFG_BUILD_DIR)/$(CFG_HOST)/stage1
 
 # platform-specific auto-configuration
 include $(CFG_SRC_DIR)mk/platform.mk

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -909,7 +909,8 @@ $(3)/test/run-make/%-$(1)-T-$(2)-H-$(3).ok: \
 	    $$(HBIN$(1)_H_$(3))/rustdoc$$(X_$(3)) \
 	    "$$(TESTNAME)" \
 	    "$$(HOST_RPATH_VAR$(1)_T_$(2)_H_$(3))" \
-	    "$$(TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3))"
+	    "$$(TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3))" \
+	    RUST_BUILD_STAGE=$(1)
 	@touch $$@
 else
 # FIXME #11094 - The above rule doesn't work right for multiple targets

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -908,7 +908,8 @@ $(3)/test/run-make/%-$(1)-T-$(2)-H-$(3).ok: \
 	    "$$(CC_$(3)) $$(CFG_GCCISH_CFLAGS_$(3))" \
 	    $$(HBIN$(1)_H_$(3))/rustdoc$$(X_$(3)) \
 	    "$$(TESTNAME)" \
-	    "$$(RPATH_VAR$(1)_T_$(2)_H_$(3))"
+	    "$$(HOST_RPATH_VAR$(1)_T_$(2)_H_$(3))" \
+	    "$$(TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3))"
 	@touch $$@
 else
 # FIXME #11094 - The above rule doesn't work right for multiple targets

--- a/src/etc/maketest.py
+++ b/src/etc/maketest.py
@@ -23,9 +23,11 @@ os.putenv('TMPDIR', os.path.abspath(sys.argv[4]))
 os.putenv('CC', sys.argv[5])
 os.putenv('RUSTDOC', os.path.abspath(sys.argv[6]))
 filt = sys.argv[7]
-ldpath = sys.argv[8]
-if ldpath != '':
-    os.putenv(ldpath.split('=')[0], ldpath.split('=')[1])
+os.putenv('HOST_RPATH_ENV', sys.argv[8]);
+host_ldpath = sys.argv[8]
+#if host_ldpath != '':
+#    os.putenv(host_ldpath.split('=')[0], host_ldpath.split('=')[1])
+os.putenv('TARGET_RPATH_ENV', sys.argv[9]);
 
 if not filt in sys.argv[1]:
     sys.exit(0)

--- a/src/etc/maketest.py
+++ b/src/etc/maketest.py
@@ -28,6 +28,9 @@ host_ldpath = sys.argv[8]
 #if host_ldpath != '':
 #    os.putenv(host_ldpath.split('=')[0], host_ldpath.split('=')[1])
 os.putenv('TARGET_RPATH_ENV', sys.argv[9]);
+rust_build_stage = sys.argv[10];
+if rust_build_stage != '':
+    os.putenv('RUST_BUILD_STAGE', rust_build_stage.split('=')[1])
 
 if not filt in sys.argv[1]:
     sys.exit(0)

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -899,6 +899,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> session::Options {
     }
 
     let sysroot_opt = matches.opt_str("sysroot").map(|m| Path::new(m));
+    let install_prefix_opt = matches.opt_str("install-prefix").map(|m| Path::new(m));
     let target = matches.opt_str("target").unwrap_or(host_triple().to_owned());
     let opt_level = {
         if (debugging_opts & session::NO_OPT) != 0 {
@@ -978,6 +979,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> session::Options {
         write_dependency_info: write_dependency_info,
         print_metas: print_metas,
         cg: cg,
+        maybe_install_prefix_override: install_prefix_opt,
     }
 }
 
@@ -1118,6 +1120,9 @@ pub fn optgroups() -> Vec<getopts::OptGroup> {
              "Output dependency info to <filename> after compiling, \
               in a format suitable for use by Makefiles", "FILENAME"),
   optopt("", "sysroot", "Override the system root", "PATH"),
+  optopt("", "install-prefix", format!("Override the install prefix ({:s})",
+                                       option_env!("CFG_PREFIX").unwrap_or(
+                                           "unset")), "PATH"),
   optflag("", "test", "Build a test harness"),
   optopt("", "target", "Target triple cpu-manufacturer-kernel[-os]
                         to compile for (see chapter 3.4 of http://www.sourceware.org/autobook/

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -154,6 +154,8 @@ pub struct Options {
     /// Crate id-related things to maybe print. It's (crate_id, crate_name, crate_file_name).
     pub print_metas: (bool, bool, bool),
     pub cg: CodegenOptions,
+    /// If set, use path as install prefix; otherwise use `env!("CFG_PREFIX")`
+    pub maybe_install_prefix_override: Option<Path>,
 }
 
 // The type of entry function, so
@@ -338,6 +340,15 @@ impl Session {
             host_triple(),
             &self.opts.addl_lib_search_paths)
     }
+
+    pub fn install_prefix<'a>(&'a self) -> Path {
+        Path::new(self.opts.maybe_install_prefix_override.clone()
+                  .or(option_env!("CFG_PREFIX").map(Path::new))
+                  .unwrap_or_else(|| {
+                      fail!("built without CFG_PREFIX set; \
+                             set install prefix via command line.")
+                  }))
+    }
 }
 
 /// Some reasonable defaults
@@ -361,6 +372,7 @@ pub fn basic_options() -> Options {
         write_dependency_info: (false, None),
         print_metas: (false, false, false),
         cg: basic_codegen_options(),
+        maybe_install_prefix_override: None,
     }
 }
 

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -17,7 +17,7 @@ use back::svh::Svh;
 use driver::session::Session;
 use driver::{driver, session};
 use metadata::cstore;
-use metadata::cstore::CStore;
+use metadata::cstore::{CStore, CrateSource};
 use metadata::decoder;
 use metadata::loader;
 use metadata::loader::CratePaths;
@@ -68,10 +68,15 @@ impl<'a> visit::Visitor<()> for Env<'a> {
 
 fn dump_crates(cstore: &CStore) {
     debug!("resolved crates:");
-    cstore.iter_crate_data(|_, data| {
+    cstore.iter_crate_data_origins(|_, data, opt_source| {
         debug!("crate_id: {}", data.crate_id());
         debug!("  cnum: {}", data.cnum);
         debug!("  hash: {}", data.hash());
+        opt_source.map(|cs| {
+            let CrateSource { dylib, rlib, cnum: _ } = cs;
+            dylib.map(|dl| debug!("  dylib: {}", dl.display()));
+            rlib.map(|rl|  debug!("   rlib: {}", rl.display()));
+        });
     })
 }
 

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -114,6 +114,17 @@ impl CStore {
         }
     }
 
+    /// Like `iter_crate_data`, but passes source paths (if available) as well.
+    pub fn iter_crate_data_origins(&self, i: |ast::CrateNum,
+                                              &crate_metadata,
+                                              Option<CrateSource>|) {
+        for (&k, v) in self.metas.borrow().iter() {
+            let origin = self.get_used_crate_source(k);
+            origin.as_ref().map(|cs| { assert!(k == cs.cnum); });
+            i(k, &**v, origin);
+        }
+    }
+
     pub fn add_used_crate_source(&self, src: CrateSource) {
         let mut used_crate_sources = self.used_crate_sources.borrow_mut();
         if !used_crate_sources.contains(&src) {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -515,6 +515,9 @@ fn load_extern_macros(krate: &ast::ViewItem, fld: &mut MacroExpander) {
         None => return
     };
 
+    debug!("load_extern_macros: mapped crate {} to path {} and registrar {:s}",
+           crate_name, path.display(), registrar);
+
     let lib = match DynamicLibrary::open(Some(&path)) {
         Ok(lib) => lib,
         // this is fatal: there are almost certainly macros we need

--- a/src/test/run-make/bootstrap-from-c-with-green/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-green/Makefile
@@ -3,7 +3,7 @@
 all:
 	$(RUSTC) lib.rs
 	ln -nsf $(call DYLIB,boot-*) $(call DYLIB,boot)
-	$(CC) main.c -o $(call RUN,main) -lboot
+	$(CC) main.c -o $(call RUN_BINFILE,main) -lboot
 	$(call RUN,main)
 	rm $(call DYLIB,boot)
 	$(call FAIL,main)

--- a/src/test/run-make/bootstrap-from-c-with-native/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-native/Makefile
@@ -3,7 +3,7 @@
 all:
 	$(RUSTC) lib.rs
 	ln -nsf $(call DYLIB,boot-*) $(call DYLIB,boot)
-	$(CC) main.c -o $(call RUN,main) -lboot
+	$(CC) main.c -o $(call RUN_BINFILE,main) -lboot
 	$(call RUN,main)
 	rm $(call DYLIB,boot)
 	$(call FAIL,main)

--- a/src/test/run-make/c-link-to-rust-dylib/Makefile
+++ b/src/test/run-make/c-link-to-rust-dylib/Makefile
@@ -3,7 +3,7 @@
 all:
 	$(RUSTC) foo.rs
 	ln -s $(call DYLIB,foo-*) $(call DYLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) -Wl,-rpath,$(TMPDIR)
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) -Wl,-rpath,$(TMPDIR)
 	$(call RUN,bar)
 	rm $(call DYLIB,foo)
 	$(call FAIL,bar)

--- a/src/test/run-make/c-link-to-rust-staticlib/Makefile
+++ b/src/test/run-make/c-link-to-rust-staticlib/Makefile
@@ -9,7 +9,7 @@ ifneq ($(shell uname),FreeBSD)
 all:
 	$(RUSTC) foo.rs
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(EXTRAFLAGS) -lstdc++
 	$(call RUN,bar)
 	rm $(call STATICLIB,foo*)
 	$(call RUN,bar)

--- a/src/test/run-make/lto-smoke-c/Makefile
+++ b/src/test/run-make/lto-smoke-c/Makefile
@@ -15,5 +15,5 @@ CC := $(CC:-g=)
 all:
 	$(RUSTC) foo.rs -Z lto
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(EXTRAFLAGS) -lstdc++
 	$(call RUN,bar)

--- a/src/test/run-make/lto-syntax-extension/Makefile
+++ b/src/test/run-make/lto-syntax-extension/Makefile
@@ -1,6 +1,19 @@
 -include ../tools.mk
 
-all:
+# This test attempts to use syntax extensions, which are known to be
+# incompatible with stage1 at the moment.
+
+ifeq ($(RUST_BUILD_STAGE),"1")
+DOTEST=
+endif
+ifeq ($(RUST_BUILD_STAGE),"2")
+DOTEST=dotest
+endif
+
+all: $(DOTEST)
+
+dotest:
+	env
 	$(RUSTC) lib.rs
 	$(RUSTC) main.rs -Z lto
 	$(call RUN,main)

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -10,7 +10,7 @@ RUN_BINFILE = $(TMPDIR)/$(1)
 # This the basic way we will invoke the generated binary.  It sets the
 # LD_LIBRARY_PATH environment variable before running the binary.
 RUN = $(TARGET_RPATH_ENV) $(RUN_BINFILE)
-FAILS = $(TARGET_RPATH_ENV) ( $(RUN_BINFILE) && exit 1 || exit 0 )
+FAILS = $(TARGET_RPATH_ENV) $(RUN_BINFILE) && exit 1 || exit 0
 
 RLIB_GLOB = lib$(1)*.rlib
 STATICLIB = $(TMPDIR)/lib$(1).a

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -4,8 +4,13 @@ export DYLD_LIBRARY_PATH:=$(TMPDIR):$(DYLD_LIBRARY_PATH)
 RUSTC := $(RUSTC) --out-dir $(TMPDIR) -L $(TMPDIR)
 CC := $(CC) -L $(TMPDIR)
 
-RUN = $(TMPDIR)/$(1)
-FAILS = $(TMPDIR)/$(1) && exit 1 || exit 0
+# This is the name of the binary we will generate and run; use this
+# e.g. for `$(CC) -o $(RUN_BINFILE)`.
+RUN_BINFILE = $(TMPDIR)/$(1)
+# This the basic way we will invoke the generated binary.  It sets the
+# LD_LIBRARY_PATH environment variable before running the binary.
+RUN = $(TARGET_RPATH_ENV) $(RUN_BINFILE)
+FAILS = $(TARGET_RPATH_ENV) ( $(RUN_BINFILE) && exit 1 || exit 0 )
 
 RLIB_GLOB = lib$(1)*.rlib
 STATICLIB = $(TMPDIR)/lib$(1).a

--- a/src/test/run-make/unicode-input/Makefile
+++ b/src/test/run-make/unicode-input/Makefile
@@ -1,6 +1,19 @@
 -include ../tools.mk
 
-all:
+# This test attempts to run rustc itself from the compiled binary; but
+# that means that you need to set the LD_LIBRARY_PATH for rustc itself
+# while running muliple_files, and that won't work for stage1.
+
+ifeq ($(RUST_BUILD_STAGE),"1")
+DOTEST=
+endif
+ifeq ($(RUST_BUILD_STAGE),"2")
+DOTEST=dotest
+endif
+
+all: $(DOTEST)
+
+dotest:
 	# check that we don't ICE on unicode input, issue #11178
 	$(RUSTC) multiple_files.rs
 	$(call RUN,multiple_files)  "$(RUSTC)" "$(TMPDIR)"


### PR DESCRIPTION
This is a series of modifications to help me debug some `run-make` test failures.

They mainly either:
- add instrumentation to aid debugging of linkage errors,
- introduce the ability to override internal settings within rustc, or
- fine tune some things in the Makefile where we are telling binaries to use a host-oriented path for finding dynamic libraries, when it should be feeding the binaries a _target-oriented_ path for dynamic libraries.

r? @alexcrichton
