### PR TITLE
std: Add experimental networking methods

### DIFF
--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -85,6 +85,29 @@ impl TcpStream {
     pub fn socket_name(&mut self) -> IoResult<SocketAddr> {
         self.obj.socket_name()
     }
+
+    /// Sets the nodelay flag on this connection to the boolean specified
+    #[experimental]
+    pub fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
+        if nodelay {
+            self.obj.nodelay()
+        } else {
+            self.obj.control_congestion()
+        }
+    }
+
+    /// Sets the keepalive timeout to the timeout specified.
+    ///
+    /// If the value specified is `None`, then the keepalive flag is cleared on
+    /// this connection. Otherwise, the keepalive timeout will be set to the
+    /// specified time, in seconds.
+    #[experimental]
+    pub fn set_keepalive(&mut self, delay_in_seconds: Option<uint>) -> IoResult<()> {
+        match delay_in_seconds {
+            Some(i) => self.obj.keepalive(i),
+            None => self.obj.letdie(),
+        }
+    }
 }
 
 impl Clone for TcpStream {

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -16,7 +16,7 @@
 //! datagram protocol.
 
 use clone::Clone;
-use io::net::ip::SocketAddr;
+use io::net::ip::{SocketAddr, IpAddr};
 use io::{Reader, Writer, IoResult};
 use kinds::Send;
 use result::{Ok, Err};
@@ -94,6 +94,52 @@ impl UdpSocket {
     /// Returns the socket address that this socket was created from.
     pub fn socket_name(&mut self) -> IoResult<SocketAddr> {
         self.obj.socket_name()
+    }
+
+    /// Joins a multicast IP address (becomes a member of it)
+    #[experimental]
+    pub fn join_multicast(&mut self, multi: IpAddr) -> IoResult<()> {
+        self.obj.join_multicast(multi)
+    }
+
+    /// Leaves a multicast IP address (drops membership from it)
+    #[experimental]
+    pub fn leave_multicast(&mut self, multi: IpAddr) -> IoResult<()> {
+        self.obj.leave_multicast(multi)
+    }
+
+    /// Set the multicast loop flag to the specified value
+    ///
+    /// This lets multicast packets loop back to local sockets (if enabled)
+    #[experimental]
+    pub fn set_multicast_loop(&mut self, on: bool) -> IoResult<()> {
+        if on {
+            self.obj.loop_multicast_locally()
+        } else {
+            self.obj.dont_loop_multicast_locally()
+        }
+    }
+
+    /// Sets the multicast TTL
+    #[experimental]
+    pub fn set_multicast_ttl(&mut self, ttl: int) -> IoResult<()> {
+        self.obj.multicast_time_to_live(ttl)
+    }
+
+    /// Sets this socket's TTL
+    #[experimental]
+    pub fn set_ttl(&mut self, ttl: int) -> IoResult<()> {
+        self.obj.time_to_live(ttl)
+    }
+
+    /// Sets the broadcast flag on or off
+    #[experimental]
+    pub fn set_broadast(&mut self, broadcast: bool) -> IoResult<()> {
+        if broadcast {
+            self.obj.hear_broadcasts()
+        } else {
+            self.obj.ignore_broadcasts()
+        }
     }
 }
 


### PR DESCRIPTION
The underlying I/O objects implement a good deal of various options here and
there for tuning network sockets and how they perform. Most of this is a relic
of "whatever libuv provides", but these options are genuinely useful.

It is unclear at this time whether these options should be well supported or
not, or whether they have correct names or not. For now, I believe it's better
to expose the functionality than to not, but all new methods are added with
an #[experimental] annotation.
