### PR TITLE
Add next_permutation and prev_permutation onto MutableTotalOrdVector<T>.

### DIFF
--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -1838,11 +1838,102 @@ pub trait MutableTotalOrdVector<T> {
     /// assert!(v == [-5, -3, 1, 2, 4]);
     /// ```
     fn sort(self);
+
+    /// Mutates the slice to the next lexicographic permutation.
+    ///
+    /// Returns `true` if successful, `false` if the slice is at the last-ordered permutation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut v = &mut [0, 1, 2];
+    /// v.next_permutation();
+    /// assert_eq!(v, &mut [0, 2, 1]);
+    /// v.next_permutation();
+    /// assert_eq!(v, &mut [1, 0, 2]);
+    /// ```
+    fn next_permutation(self) -> bool;
+
+    /// Mutates the slice to the previous lexicographic permutation.
+    ///
+    /// Returns `true` if successful, `false` if the slice is at the first-ordered permutation.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut v = &mut [1, 0, 2];
+    /// v.prev_permutation();
+    /// assert_eq!(v, &mut [0, 2, 1]);
+    /// v.prev_permutation();
+    /// assert_eq!(v, &mut [0, 1, 2]);
+    /// ```
+    fn prev_permutation(self) -> bool;
 }
+
 impl<'a, T: TotalOrd> MutableTotalOrdVector<T> for &'a mut [T] {
     #[inline]
     fn sort(self) {
         self.sort_by(|a,b| a.cmp(b))
+    }
+
+    fn next_permutation(self) -> bool {
+        // These cases only have 1 permutation each, so we can't do anything.
+        if self.len() < 2 { return false; }
+
+        // Step 1: Identify the longest, rightmost weakly decreasing part of the vector
+        let mut i = self.len() - 1;
+        while i > 0 && self[i-1] >= self[i] {
+            i -= 1;
+        }
+
+        // If that is the entire vector, this is the last-ordered permutation.
+        if i == 0 {
+            return false;
+        }
+
+        // Step 2: Find the rightmost element larger than the pivot (i-1)
+        let mut j = self.len() - 1;
+        while j >= i && self[j] <= self[i-1]  {
+            j -= 1;
+        }
+
+        // Step 3: Swap that element with the pivot
+        self.swap(j, i-1);
+
+        // Step 4: Reverse the (previously) weakly decreasing part
+        self.mut_slice_from(i).reverse();
+
+        true
+    }
+
+    fn prev_permutation(self) -> bool {
+        // These cases only have 1 permutation each, so we can't do anything.
+        if self.len() < 2 { return false; }
+
+        // Step 1: Identify the longest, rightmost weakly increasing part of the vector
+        let mut i = self.len() - 1;
+        while i > 0 && self[i-1] <= self[i] {
+            i -= 1;
+        }
+
+        // If that is the entire vector, this is the first-ordered permutation.
+        if i == 0 {
+            return false;
+        }
+
+        // Step 2: Reverse the weakly increasing part
+        self.mut_slice_from(i).reverse();
+
+        // Step 3: Find the rightmost element equal to or bigger than the pivot (i-1)
+        let mut j = self.len() - 1;
+        while j >= i && self[j-1] < self[i-1]  {
+            j -= 1;
+        }
+
+        // Step 4: Swap that element with the pivot
+        self.swap(i-1, j);
+
+        true
     }
 }
 
@@ -3689,6 +3780,75 @@ mod tests {
 
         let y: &mut [int] = [];
         assert!(y.mut_last().is_none());
+    }
+
+    #[test]
+    fn test_lexicographic_permutations() {
+        let v : &mut[int] = &mut[1, 2, 3, 4, 5];
+        assert!(v.prev_permutation() == false);
+        assert!(v.next_permutation());
+        assert_eq!(v, &mut[1, 2, 3, 5, 4]);
+        assert!(v.prev_permutation());
+        assert_eq!(v, &mut[1, 2, 3, 4, 5]);
+        assert!(v.next_permutation());
+        assert!(v.next_permutation());
+        assert_eq!(v, &mut[1, 2, 4, 3, 5]);
+        assert!(v.next_permutation());
+        assert_eq!(v, &mut[1, 2, 4, 5, 3]);
+
+        let v : &mut[int] = &mut[1, 0, 0, 0];
+        assert!(v.next_permutation() == false);
+        assert!(v.prev_permutation());
+        assert_eq!(v, &mut[0, 1, 0, 0]);
+        assert!(v.prev_permutation());
+        assert_eq!(v, &mut[0, 0, 1, 0]);
+        assert!(v.prev_permutation());
+        assert_eq!(v, &mut[0, 0, 0, 1]);
+        assert!(v.prev_permutation() == false);
+    }
+
+    #[test]
+    fn test_lexicographic_permutations_empty_and_short() {
+        let empty : &mut[int] = &mut[];
+        assert!(empty.next_permutation() == false);
+        assert_eq!(empty, &mut[]);
+        assert!(empty.prev_permutation() == false);
+        assert_eq!(empty, &mut[]);
+
+        let one_elem : &mut[int] = &mut[4];
+        assert!(one_elem.prev_permutation() == false);
+        assert_eq!(one_elem, &mut[4]);
+        assert!(one_elem.next_permutation() == false);
+        assert_eq!(one_elem, &mut[4]);
+
+        let two_elem : &mut[int] = &mut[1, 2];
+        assert!(two_elem.prev_permutation() == false);
+        assert_eq!(two_elem, &mut[1, 2]);
+        assert!(two_elem.next_permutation());
+        assert_eq!(two_elem, &mut[2, 1]);
+        assert!(two_elem.next_permutation() == false);
+        assert_eq!(two_elem, &mut[2, 1]);
+        assert!(two_elem.prev_permutation());
+        assert_eq!(two_elem, &mut[1, 2]);
+        assert!(two_elem.prev_permutation() == false);
+        assert_eq!(two_elem, &mut[1, 2]);
+    }
+
+    #[test]
+    fn test_lexicographic_permutations_owned() {
+        let mut empty : ~[int] = ~[];
+        assert!(empty.prev_permutation() == false);
+        assert!(empty.next_permutation() == false);
+        assert_eq!(empty, ~[]);
+
+        let mut v : ~[int] = ~[1, 2, 3];
+        assert!(v.prev_permutation() == false);
+        assert!(v.next_permutation());
+        assert_eq!(v, ~[1, 3, 2]);
+        assert!(v.next_permutation());
+        assert_eq!(v, ~[2, 1, 3]);
+        assert!(v.prev_permutation());
+        assert_eq!(v, ~[1, 3, 2]);
     }
 }
 


### PR DESCRIPTION
Okay, so first out, I'm no sure if this is okay as a pull request (without prior discussion or an RFC). However, considering that

> Pull requests will be treated as "review requests"

and the fact that the community is supposed to be friendly to strangers and beginners, I figured not too much could go wrong; worst case, the pull request is not accepted, right? :-)
I looked at the existing RFCs, but all of them felt bigger in scope than simply adding a few function (causing no backwards incompatibility).

Anyway. This adds two methods to mutable vectors (`MutableTotalOrdVector<T>`): next_permutation() and prev_permutation().
They mutate the vector to the next/previous lexicographic permutation, _in place_.  
The existing permutation functionality, [ImmutableCloneableVector::permutations()](http://static.rust-lang.org/doc/master/std/slice/trait.ImmutableCloneableVector.html#tymethod.permutations), uses iterators and clones the entire vector _each iteration_, resulting in bad performance. For even a 10-element vector, that causes 10! = 3628800 calls to clone(), on the entire 10-element vector.
It also uses a swapping algorithm which does not generate lexicographic permutations; if you want lexicographical permutations, as far as I can tell, Rust currently cannot provide that.

So does Rust need this? I don't know. I wanted to use it, and realized it didn't exist, so I created it. Others may disagree about the necessity, of course.

Sample benchmarks:

```
test bench_iterated_permutations_one_iter           ... bench:       721 ns/iter (+/- 212)
test bench_lexicographic_permutations_one_iter      ... bench:        14 ns/iter (+/- 1)
test bench_iterated_permutations_bulk               ... bench:   2449743 ns/iter (+/- 328460)
test bench_lexicographic_permutations_bulk          ... bench:     69704 ns/iter (+/- 2235)
```

51x faster per single iteration (one permutation per benchmark iteration), 35x faster to loop through all 5040 permutations of range(0,7) per benchmark iteration.

One possible (style-ish) issue with this code is the return types: they return `true` if successful, and `false` if the vector was already at the first/last permutation. This makes looping rather easy, but I'm not sure if it's considered "pretty", so to speak. However, since iterators are much too expensive, at least if returning a cloned vector each iteration is the only way to make them work, I found no better way to solve this, and at least IMHO it looks fine.
Also, I'm not sure if the comments inside the actual functions is considered excessive or not, but that is of course easily changed, if that would be the case.  

BTW, I have ran more tests than actually submitted; the full suite would be excessive to submit, but can be viewed [here](https://github.com/exscape/Rust/blob/c70a5869fbe255a817abeaee4d19407c31ae1974/permutation-tests.rs) (please excuse the messy code).
