### PR TITLE
rustc: Restrict the scope of a borrow on def_map

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3199,12 +3199,13 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprStruct(ref path, ref fields, base_expr) => {
         // Resolve the path.
-        match tcx.def_map.borrow().find(&id) {
-            Some(&ast::DefStruct(type_def_id)) => {
+        let def = tcx.def_map.borrow().find(&id).map(|i| *i);
+        match def {
+            Some(ast::DefStruct(type_def_id)) => {
                 check_struct_constructor(fcx, id, expr.span, type_def_id,
                                          fields.as_slice(), base_expr);
             }
-            Some(&ast::DefVariant(enum_id, variant_id, _)) => {
+            Some(ast::DefVariant(enum_id, variant_id, _)) => {
                 check_struct_enum_variant(fcx, id, expr.span, enum_id,
                                           variant_id, fields.as_slice());
             }

--- a/src/test/run-pass/issue-13763.rs
+++ b/src/test/run-pass/issue-13763.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::u8;
+
+static NUM: uint = u8::BITS as uint;
+
+struct MyStruct { nums: [uint, ..8] }
+
+
+fn main() {
+    let _s = MyStruct { nums: [0, ..NUM] };
+}


### PR DESCRIPTION
This addresses the ICE from #13763, but it does not allow the test to compile,
due to #13768. An alternate test was checked in in the meantime.

Closes #13763
