### PR TITLE
rustdoc: design fixes and changes

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -471,7 +471,7 @@ Two examples of paths with type arguments:
 # fn f() {
 # fn id<T>(t: T) -> T { t }
 type T = HashMap<int,~str>;  // Type arguments used in a type expression
-let x = id::<int>(10);         // Type arguments used in a call expression
+let x = id::<int>(10);       // Type arguments used in a call expression
 # }
 ~~~~
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -982,7 +982,8 @@ The obvious approach is to define `Cons` as containing an element in the list
 along with the next `List` node. However, this will generate a compiler error.
 
 ~~~ {.ignore}
-// error: illegal recursive enum type; wrap the inner value in a box to make it representable
+// error: illegal recursive enum type; wrap the inner value in a box to make it
+// representable
 enum List {
     Cons(u32, List), // an element (`u32`) and the next node in the list
     Nil
@@ -1054,10 +1055,10 @@ immutable, the whole list is immutable. The memory allocation itself is the
 box, while the owner holds onto a pointer to it:
 
 ~~~ {.notrust}
-          List box             List box           List box            List box
-        +--------------+    +--------------+    +--------------+    +--------------+
-list -> | Cons | 1 | ~ | -> | Cons | 2 | ~ | -> | Cons | 3 | ~ | -> | Nil          |
-        +--------------+    +--------------+    +--------------+    +--------------+
+            List box            List box            List box          List box
+        +--------------+    +--------------+    +--------------+    +----------+
+list -> | Cons | 1 | ~ | -> | Cons | 2 | ~ | -> | Cons | 3 | ~ | -> | Nil      |
+        +--------------+    +--------------+    +--------------+    +----------+
 ~~~
 
 > *Note:* the above diagram shows the logical contents of the enum. The actual
@@ -1197,7 +1198,8 @@ fn eq(xs: &List, ys: &List) -> bool {
         // If we have reached the end of both lists, they are equal.
         (&Nil, &Nil) => true,
         // If the current element in both lists is equal, keep going.
-        (&Cons(x, ~ref next_xs), &Cons(y, ~ref next_ys)) if x == y => eq(next_xs, next_ys),
+        (&Cons(x, ~ref next_xs), &Cons(y, ~ref next_ys))
+                if x == y => eq(next_xs, next_ys),
         // If the current elements are not equal, the lists are not equal.
         _ => false
     }
@@ -1256,7 +1258,7 @@ Using the generic `List<T>` works much like before, thanks to type inference:
 #     Cons(value, ~xs)
 # }
 let mut xs = Nil; // Unknown type! This is a `List<T>`, but `T` can be anything.
-xs = prepend(xs, 10); // The compiler infers the type of `xs` as `List<int>` from this.
+xs = prepend(xs, 10); // Here the compiler infers `xs`'s type as `List<int>`.
 xs = prepend(xs, 15);
 xs = prepend(xs, 20);
 ~~~
@@ -1303,7 +1305,8 @@ fn eq<T: Eq>(xs: &List<T>, ys: &List<T>) -> bool {
         // If we have reached the end of both lists, they are equal.
         (&Nil, &Nil) => true,
         // If the current element in both lists is equal, keep going.
-        (&Cons(ref x, ~ref next_xs), &Cons(ref y, ~ref next_ys)) if x == y => eq(next_xs, next_ys),
+        (&Cons(ref x, ~ref next_xs), &Cons(ref y, ~ref next_ys))
+                if x == y => eq(next_xs, next_ys),
         // If the current elements are not equal, the lists are not equal.
         _ => false
     }
@@ -1331,7 +1334,8 @@ impl<T: Eq> Eq for List<T> {
             // If we have reached the end of both lists, they are equal.
             (&Nil, &Nil) => true,
             // If the current element in both lists is equal, keep going.
-            (&Cons(ref x, ~ref next_xs), &Cons(ref y, ~ref next_ys)) if x == y => next_xs == next_ys,
+            (&Cons(ref x, ~ref next_xs), &Cons(ref y, ~ref next_ys))
+                    if x == y => next_xs == next_ys,
             // If the current elements are not equal, the lists are not equal.
             _ => false
         }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -209,7 +209,7 @@ pub fn render(w: &mut io::Writer, s: &str, print_toc: bool) -> fmt::Result {
         };
 
         // Render the HTML
-        let text = format!(r#"<h{lvl} id="{id}" class='section-link'><a
+        let text = format!(r#"<h{lvl} id="{id}" class='section-header'><a
                            href="\#{id}">{sec_len,plural,=0{}other{{sec} }}{}</a></h{lvl}>"#,
                            s, lvl = level, id = id,
                            sec_len = sec.len(), sec = sec);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1121,7 +1121,7 @@ fn item_module(w: &mut Writer, cx: &Context,
                 clean::MacroItem(..)           => ("macros", "Macros"),
             };
             try!(write!(w,
-                        "<h2 id='{id}' class='section-link'>\
+                        "<h2 id='{id}' class='section-header'>\
                         <a href=\"\\#{id}\">{name}</a></h2>\n<table>",
                         id = short, name = name));
         }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -53,17 +53,25 @@
 body {
     color: #333;
     min-width: 500px;
-    font: 18px "Heuristica", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 1.4;
+    font: 15px/1.4 "Heuristica", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin: 0;
     position: relative;
     padding: 10px 15px 20px 15px;
 }
 
+h1 {
+    font-size: 1.5em;
+}
+h2 {
+    font-size: 1.4em;
+}
+h3 {
+    font-size: 1.3em;
+}
 h1, h2, h3:not(.impl), h4:not(.method) {
     color: black;
     font-weight: 500;
-    margin: 30px 0 15px 0;
+    margin: 20px 0 15px 0;
     padding-bottom: 6px;
 }
 h1.fqn {
@@ -93,7 +101,7 @@ ul ul, ol ul, ul ol, ol ol {
 }
 
 p {
-    margin: 0 0 1em 0;
+    margin: 0 0 .6em 0;
 }
 
 code, pre {
@@ -101,19 +109,15 @@ code, pre {
     white-space: pre-wrap;
 }
 pre {
-    font-size: 15px;
+    background-color: #F5F5F5;
     padding: 14px;
-    padding-right: 0;
-    border-left: 2px solid #eee;
 }
 
 .source pre {
-    border-left: none;
     padding: 20px;
 }
 
 nav.sub {
-    padding-top: 10px;
     font-size: 16px;
     text-transform: uppercase;
 }
@@ -149,7 +153,7 @@ nav.sub {
 }
 
 .block {
-    padding: 10px;
+    padding: 0 10px;
     margin-bottom: 10px;
 }
 .block h2 { 
@@ -170,7 +174,7 @@ nav.sub {
 }
 
 .content {
-    padding: 20px 0;
+    padding: 15px 0;
 }
 
 .content.source pre.rust {
@@ -209,7 +213,6 @@ nav.sub {
 }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
-    margin: 30px 0 15px 0;
     border-bottom: 1px solid #DDD;
 }
 
@@ -389,10 +392,12 @@ pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
 pre.rust .lifetime { color: #B76514; }
 
 .section-header {
+    /* Override parent class attributes. */
     border-bottom: none !important;
     font-size: 1.1em !important;
-    margin: 0 !important;
-    padding: 0 !important;
+    font-weight: 400;
+    margin: 0 0 -5px;
+    padding: 0;
 }
 .section-header:hover a:after {
     content: '\2002\00a7\2002';

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -53,7 +53,7 @@
 body {
     color: #333;
     min-width: 500px;
-    font: 15px/1.4 "Heuristica", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font: 15.5px/1.4 "Heuristica", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin: 0;
     position: relative;
     padding: 10px 15px 20px 15px;
@@ -68,7 +68,7 @@ h2 {
 h3 {
     font-size: 1.3em;
 }
-h1, h2, h3:not(.impl), h4:not(.method) {
+h1, h2, h3:not(.impl):not(.method), h4:not(.method) {
     color: black;
     font-weight: 500;
     margin: 20px 0 15px 0;
@@ -78,15 +78,15 @@ h1.fqn {
     border-bottom: 1px dashed #D5D5D5;
     margin-top: 0;
 }
-h2, h3:not(.impl), h4:not(.method) {
+h2, h3:not(.impl):not(.method), h4:not(.method) {
     border-bottom: 1px solid #DDDDDD;
 }
-h3.impl, h4.method {
+h3.impl, h3.method, h4.method {
     font-weight: 600;
     margin-top: 10px;
     margin-bottom: 10px;
 }
-h3.impl {
+h3.impl, h3.method {
     margin-top: 15px;
 }
 h1, h2, h3, h4, section.sidebar, a.source, .search-input, .content table a {
@@ -211,6 +211,7 @@ nav.sub {
     text-overflow: ellipsis;
     margin: 0;
 }
+.docblock.short code { white-space: nowrap; }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
     border-bottom: 1px solid #DDD;
@@ -366,9 +367,10 @@ a {
 .stability {
     border-left: 6px solid #000;
     border-radius: 3px;
-    padding: 2px 10px;
+    font-weight: 400;
+    padding: 4px 10px;
     text-transform: lowercase;
-    margin-left: 10px;
+    margin-left: 14px;
 }
 
 .stability.Deprecated { border-color: #D60027; color: #880017; }
@@ -395,7 +397,6 @@ pre.rust .lifetime { color: #B76514; }
     /* Override parent class attributes. */
     border-bottom: none !important;
     font-size: 1.1em !important;
-    font-weight: 400;
     margin: 0 0 -5px;
     padding: 0;
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -388,16 +388,17 @@ pre.rust .doccomment { color: #4D4D4C; }
 pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
 pre.rust .lifetime { color: #B76514; }
 
-h1.section-link:hover a:after,
-h2.section-link:hover a:after,
-h3.section-link:hover a:after,
-h4.section-link:hover a:after,
-h5.section-link:hover a:after,
-h6.section-link:hover a:after {
-  content: '\2002\00a7\2002';
+.section-header {
+    border-bottom: none !important;
+    font-size: 1.1em !important;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+.section-header:hover a:after {
+    content: '\2002\00a7\2002';
 }
 
-/** Media Queries **/
+/* Media Queries */
 
 @media (max-width: 700px) {
     .sidebar {


### PR DESCRIPTION
- Closes #13591. Relevant example: http://adrientetar.legtux.org/cached/rust-docs/struct.CChars.htm
  (Had to use `!important` to override CSS selector precedence, namely matching over parent class.)
- Implement changes from #13780 feedback, namely:
  - Changed font-size from 18px to 15px
  - Reintroduced gray background for code samples
  - Tightened up the margins
- Fix point 1 and point 4 of #13804.

Samples:
- [enum.FileType](http://adrientetar.legtux.org/cached/rust-docs/enum.FileType.htm)
- [struct.CChars](http://adrientetar.legtux.org/cached/rust-docs/struct.CChars.htm)
- [std](http://adrientetar.legtux.org/cached/rust-docs/std.htm)
- [std::io](http://adrientetar.legtux.org/cached/rust-docs/io.htm).

r? @brson
