### PR TITLE
syntax: Make ViewItemUse no longer contain multiple view paths.

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -130,16 +130,14 @@ impl<'a> Visitor<()> for Context<'a> {
 
     fn visit_view_item(&mut self, i: &ast::ViewItem, _: ()) {
         match i.node {
-            ast::ViewItemUse(ref paths) => {
-                for path in paths.iter() {
-                    match path.node {
-                        ast::ViewPathGlob(..) => {
-                            self.gate_feature("globs", path.span,
-                                              "glob import statements are \
-                                               experimental and possibly buggy");
-                        }
-                        _ => {}
+            ast::ViewItemUse(ref path) => {
+                match path.node {
+                    ast::ViewPathGlob(..) => {
+                        self.gate_feature("globs", path.span,
+                                          "glob import statements are \
+                                           experimental and possibly buggy");
                     }
+                    _ => {}
                 }
             }
             ast::ViewItemExternCrate(..) => {

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -166,7 +166,7 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
 
         let vp = @codemap::dummy_spanned(ast::ViewPathGlob(prelude_path, ast::DUMMY_NODE_ID));
         let vi2 = ast::ViewItem {
-            node: ast::ViewItemUse(vec!(vp)),
+            node: ast::ViewItemUse(vp),
             attrs: Vec::new(),
             vis: ast::Inherited,
             span: DUMMY_SP,

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -299,9 +299,9 @@ fn mk_std(cx: &TestCtxt) -> ast::ViewItem {
     let id_test = token::str_to_ident("test");
     let (vi, vis) = if cx.is_test_crate {
         (ast::ViewItemUse(
-            vec!(@nospan(ast::ViewPathSimple(id_test,
-                                             path_node(vec!(id_test)),
-                                             ast::DUMMY_NODE_ID)))),
+            @nospan(ast::ViewPathSimple(id_test,
+                                        path_node(vec!(id_test)),
+                                        ast::DUMMY_NODE_ID))),
          ast::Public)
     } else {
         (ast::ViewItemExternCrate(id_test,

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -872,26 +872,24 @@ impl<'a> Visitor<()> for PrivacyVisitor<'a> {
     fn visit_view_item(&mut self, a: &ast::ViewItem, _: ()) {
         match a.node {
             ast::ViewItemExternCrate(..) => {}
-            ast::ViewItemUse(ref uses) => {
-                for vpath in uses.iter() {
-                    match vpath.node {
-                        ast::ViewPathSimple(..) | ast::ViewPathGlob(..) => {}
-                        ast::ViewPathList(_, ref list, _) => {
-                            for pid in list.iter() {
-                                debug!("privacy - list {}", pid.node.id);
-                                let seg = ast::PathSegment {
-                                    identifier: pid.node.name,
-                                    lifetimes: Vec::new(),
-                                    types: OwnedSlice::empty(),
-                                };
-                                let segs = vec!(seg);
-                                let path = ast::Path {
-                                    global: false,
-                                    span: pid.span,
-                                    segments: segs,
-                                };
-                                self.check_path(pid.span, pid.node.id, &path);
-                            }
+            ast::ViewItemUse(ref vpath) => {
+                match vpath.node {
+                    ast::ViewPathSimple(..) | ast::ViewPathGlob(..) => {}
+                    ast::ViewPathList(_, ref list, _) => {
+                        for pid in list.iter() {
+                            debug!("privacy - list {}", pid.node.id);
+                            let seg = ast::PathSegment {
+                                identifier: pid.node.name,
+                                lifetimes: Vec::new(),
+                                types: OwnedSlice::empty(),
+                            };
+                            let segs = vec!(seg);
+                            let path = ast::Path {
+                                global: false,
+                                span: pid.span,
+                                segments: segs,
+                            };
+                            self.check_path(pid.span, pid.node.id, &path);
                         }
                     }
                 }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1085,7 +1085,7 @@ impl Clean<Item> for ast::ViewItem {
 #[deriving(Clone, Encodable, Decodable)]
 pub enum ViewItemInner {
     ExternCrate(~str, Option<~str>, ast::NodeId),
-    Import(Vec<ViewPath>)
+    Import(ViewPath)
 }
 
 impl Clean<ViewItemInner> for ast::ViewItem_ {
@@ -1099,7 +1099,7 @@ impl Clean<ViewItemInner> for ast::ViewItem_ {
                 ExternCrate(i.clean(), string, *id)
             }
             &ast::ViewItemUse(ref vp) => {
-                Import(vp.clean().move_iter().collect())
+                Import(vp.clean())
             }
         }
     }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -32,6 +32,10 @@ use core;
 use doctree;
 use visit_ast;
 
+/// A stable identifier to the particular version of JSON output.
+/// Increment this when the `Crate` and related structures change.
+pub static SCHEMA_VERSION: &'static str = "0.8.2";
+
 pub trait Clean<T> {
     fn clean(&self) -> T;
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1165,12 +1165,10 @@ fn item_module(w: &mut Writer, cx: &Context,
                         try!(write!(w, ";</code></td></tr>"));
                     }
 
-                    clean::Import(ref imports) => {
-                        for import in imports.iter() {
-                            try!(write!(w, "<tr><td><code>{}{}</code></td></tr>",
-                                          VisSpace(myitem.visibility),
-                                          *import));
-                        }
+                    clean::Import(ref import) => {
+                        try!(write!(w, "<tr><td><code>{}{}</code></td></tr>",
+                                      VisSpace(myitem.visibility),
+                                      *import));
                     }
                 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -34,6 +34,9 @@ use std::io::{File, MemWriter};
 use std::str;
 use serialize::{json, Decodable, Encodable};
 
+// reexported from `clean` so it can be easily updated with the mod itself
+pub use clean::SCHEMA_VERSION;
+
 pub mod clean;
 pub mod core;
 pub mod doctree;
@@ -54,8 +57,6 @@ pub mod plugins;
 pub mod visit_ast;
 pub mod test;
 mod flock;
-
-pub static SCHEMA_VERSION: &'static str = "0.8.1";
 
 type Pass = (&'static str,                                      // name
              fn(clean::Crate) -> plugins::PluginResult,         // fn

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -133,14 +133,12 @@ impl<'a> RustdocVisitor<'a> {
             return om.view_items.push(item.clone());
         }
         let item = match item.node {
-            ast::ViewItemUse(ref paths) => {
-                // rustc no longer supports "use foo, bar;"
-                assert_eq!(paths.len(), 1);
-                match self.visit_view_path(*paths.get(0), om) {
+            ast::ViewItemUse(ref vpath) => {
+                match self.visit_view_path(*vpath, om) {
                     None => return,
                     Some(path) => {
                         ast::ViewItem {
-                            node: ast::ViewItemUse(vec!(path)),
+                            node: ast::ViewItemUse(path),
                             .. item.clone()
                         }
                     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1003,7 +1003,7 @@ pub enum ViewItem_ {
     // (containing arbitrary characters) from which to fetch the crate sources
     // For example, extern crate whatever = "github.com/mozilla/rust"
     ViewItemExternCrate(Ident, Option<(InternedString,StrStyle)>, NodeId),
-    ViewItemUse(Vec<@ViewPath> ),
+    ViewItemUse(@ViewPath),
 }
 
 // Meta-data associated with an item

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -407,18 +407,16 @@ impl<'a, O: IdVisitingOperation> Visitor<()> for IdVisitor<'a, O> {
             ViewItemExternCrate(_, _, node_id) => {
                 self.operation.visit_id(node_id)
             }
-            ViewItemUse(ref view_paths) => {
-                for view_path in view_paths.iter() {
-                    match view_path.node {
-                        ViewPathSimple(_, _, node_id) |
-                        ViewPathGlob(_, node_id) => {
-                            self.operation.visit_id(node_id)
-                        }
-                        ViewPathList(_, ref paths, node_id) => {
-                            self.operation.visit_id(node_id);
-                            for path in paths.iter() {
-                                self.operation.visit_id(path.node.id)
-                            }
+            ViewItemUse(ref view_path) => {
+                match view_path.node {
+                    ViewPathSimple(_, _, node_id) |
+                    ViewPathGlob(_, node_id) => {
+                        self.operation.visit_id(node_id)
+                    }
+                    ViewPathList(_, ref paths, node_id) => {
+                        self.operation.visit_id(node_id);
+                        for path in paths.iter() {
+                            self.operation.visit_id(path.node.id)
                         }
                     }
                 }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -246,7 +246,7 @@ pub trait AstBuilder {
                        -> @ast::MetaItem;
 
     fn view_use(&self, sp: Span,
-                vis: ast::Visibility, vp: Vec<@ast::ViewPath> ) -> ast::ViewItem;
+                vis: ast::Visibility, vp: @ast::ViewPath) -> ast::ViewItem;
     fn view_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> ast::ViewItem;
     fn view_use_simple_(&self, sp: Span, vis: ast::Visibility,
                         ident: ast::Ident, path: ast::Path) -> ast::ViewItem;
@@ -949,7 +949,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn view_use(&self, sp: Span,
-                vis: ast::Visibility, vp: Vec<@ast::ViewPath> ) -> ast::ViewItem {
+                vis: ast::Visibility, vp: @ast::ViewPath) -> ast::ViewItem {
         ast::ViewItem {
             node: ast::ViewItemUse(vp),
             attrs: Vec::new(),
@@ -966,10 +966,10 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn view_use_simple_(&self, sp: Span, vis: ast::Visibility,
                         ident: ast::Ident, path: ast::Path) -> ast::ViewItem {
         self.view_use(sp, vis,
-                      vec!(@respan(sp,
-                                ast::ViewPathSimple(ident,
-                                                    path,
-                                                    ast::DUMMY_NODE_ID))))
+                      @respan(sp,
+                           ast::ViewPathSimple(ident,
+                                               path,
+                                               ast::DUMMY_NODE_ID)))
     }
 
     fn view_use_list(&self, sp: Span, vis: ast::Visibility,
@@ -979,17 +979,17 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }).collect();
 
         self.view_use(sp, vis,
-                      vec!(@respan(sp,
-                                ast::ViewPathList(self.path(sp, path),
-                                                  imports,
-                                                  ast::DUMMY_NODE_ID))))
+                      @respan(sp,
+                           ast::ViewPathList(self.path(sp, path),
+                                             imports,
+                                             ast::DUMMY_NODE_ID)))
     }
 
     fn view_use_glob(&self, sp: Span,
                      vis: ast::Visibility, path: Vec<ast::Ident> ) -> ast::ViewItem {
         self.view_use(sp, vis,
-                      vec!(@respan(sp,
-                                ast::ViewPathGlob(self.path(sp, path), ast::DUMMY_NODE_ID))))
+                      @respan(sp,
+                           ast::ViewPathGlob(self.path(sp, path), ast::DUMMY_NODE_ID)))
     }
 }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -28,44 +28,42 @@ pub trait Folder {
         meta_items.iter().map(|x| fold_meta_item_(*x, self)).collect()
     }
 
-    fn fold_view_paths(&mut self, view_paths: &[@ViewPath]) -> Vec<@ViewPath> {
-        view_paths.iter().map(|view_path| {
-            let inner_view_path = match view_path.node {
-                ViewPathSimple(ref ident, ref path, node_id) => {
-                    let id = self.new_id(node_id);
-                    ViewPathSimple(ident.clone(),
-                                   self.fold_path(path),
-                                   id)
-                }
-                ViewPathGlob(ref path, node_id) => {
-                    let id = self.new_id(node_id);
-                    ViewPathGlob(self.fold_path(path), id)
-                }
-                ViewPathList(ref path, ref path_list_idents, node_id) => {
-                    let id = self.new_id(node_id);
-                    ViewPathList(self.fold_path(path),
-                                 path_list_idents.iter().map(|path_list_ident| {
-                                    let id = self.new_id(path_list_ident.node
-                                                                        .id);
-                                    Spanned {
-                                        node: PathListIdent_ {
-                                            name: path_list_ident.node
-                                                                 .name
-                                                                 .clone(),
-                                            id: id,
-                                        },
-                                        span: self.new_span(
-                                            path_list_ident.span)
-                                    }
-                                 }).collect(),
-                                 id)
-                }
-            };
-            @Spanned {
-                node: inner_view_path,
-                span: self.new_span(view_path.span),
+    fn fold_view_path(&mut self, view_path: @ViewPath) -> @ViewPath {
+        let inner_view_path = match view_path.node {
+            ViewPathSimple(ref ident, ref path, node_id) => {
+                let id = self.new_id(node_id);
+                ViewPathSimple(ident.clone(),
+                               self.fold_path(path),
+                               id)
             }
-        }).collect()
+            ViewPathGlob(ref path, node_id) => {
+                let id = self.new_id(node_id);
+                ViewPathGlob(self.fold_path(path), id)
+            }
+            ViewPathList(ref path, ref path_list_idents, node_id) => {
+                let id = self.new_id(node_id);
+                ViewPathList(self.fold_path(path),
+                             path_list_idents.iter().map(|path_list_ident| {
+                                let id = self.new_id(path_list_ident.node
+                                                                    .id);
+                                Spanned {
+                                    node: PathListIdent_ {
+                                        name: path_list_ident.node
+                                                             .name
+                                                             .clone(),
+                                        id: id,
+                                    },
+                                    span: self.new_span(
+                                        path_list_ident.span)
+                                }
+                             }).collect(),
+                             id)
+            }
+        };
+        @Spanned {
+            node: inner_view_path,
+            span: self.new_span(view_path.span),
+        }
     }
 
     fn fold_view_item(&mut self, vi: &ViewItem) -> ViewItem {
@@ -557,8 +555,8 @@ pub fn noop_fold_view_item<T: Folder>(vi: &ViewItem, folder: &mut T)
                               (*string).clone(),
                               folder.new_id(node_id))
         }
-        ViewItemUse(ref view_paths) => {
-            ViewItemUse(folder.fold_view_paths(view_paths.as_slice()))
+        ViewItemUse(ref view_path) => {
+            ViewItemUse(folder.fold_view_path(*view_path))
         }
     };
     ViewItem {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4918,12 +4918,12 @@ impl<'a> Parser<'a> {
     }
 
     // matches view_paths = view_path | view_path , view_paths
-    fn parse_view_paths(&mut self) -> Vec<@ViewPath> {
-        let mut vp = vec!(self.parse_view_path());
+    fn parse_view_paths(&mut self) -> @ViewPath {
+        let vp = self.parse_view_path();
         while self.token == token::COMMA {
             self.bump();
             self.obsolete(self.last_span, ObsoleteMultipleImport);
-            vp.push(self.parse_view_path());
+            let _ = self.parse_view_path();
         }
         return vp;
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1995,11 +1995,6 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_view_paths(&mut self,
-                            vps: &[@ast::ViewPath]) -> IoResult<()> {
-        self.commasep(Inconsistent, vps, |s, &vp| s.print_view_path(vp))
-    }
-
     pub fn print_view_item(&mut self, item: &ast::ViewItem) -> IoResult<()> {
         try!(self.hardbreak_if_not_bol());
         try!(self.maybe_print_comment(item.span.lo));
@@ -2017,9 +2012,9 @@ impl<'a> State<'a> {
                 }
             }
 
-            ast::ViewItemUse(ref vps) => {
+            ast::ViewItemUse(ref vp) => {
                 try!(self.head("use"));
-                try!(self.print_view_paths(vps.as_slice()));
+                try!(self.print_view_path(*vp));
             }
         }
         try!(word(&mut self.s, ";"));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -150,22 +150,20 @@ pub fn walk_view_item<E: Clone, V: Visitor<E>>(visitor: &mut V, vi: &ViewItem, e
         ViewItemExternCrate(name, _, _) => {
             visitor.visit_ident(vi.span, name, env)
         }
-        ViewItemUse(ref paths) => {
-            for vp in paths.iter() {
-                match vp.node {
-                    ViewPathSimple(ident, ref path, id) => {
-                        visitor.visit_ident(vp.span, ident, env.clone());
-                        visitor.visit_path(path, id, env.clone());
+        ViewItemUse(ref vp) => {
+            match vp.node {
+                ViewPathSimple(ident, ref path, id) => {
+                    visitor.visit_ident(vp.span, ident, env.clone());
+                    visitor.visit_path(path, id, env.clone());
+                }
+                ViewPathGlob(ref path, id) => {
+                    visitor.visit_path(path, id, env.clone());
+                }
+                ViewPathList(ref path, ref list, _) => {
+                    for id in list.iter() {
+                        visitor.visit_ident(id.span, id.node.name, env.clone())
                     }
-                    ViewPathGlob(ref path, id) => {
-                        visitor.visit_path(path, id, env.clone());
-                    }
-                    ViewPathList(ref path, ref list, _) => {
-                        for id in list.iter() {
-                            visitor.visit_ident(id.span, id.node.name, env.clone())
-                        }
-                        walk_path(visitor, path, env.clone());
-                    }
+                    walk_path(visitor, path, env.clone());
                 }
             }
         }


### PR DESCRIPTION
It reflected the obsolete syntax `use a, b, c;` and did not make past the parser (though it was a non-fatal error so we can continue). This legacy affected many portions of rustc and rustdoc as well, so this PR cleans them up altogether.

As a side effect of cleanup, we now have `SCHEMA_VERSION` in `rustdoc::clean` (instead of the crate root), so it has a better chance to be updated when `rustdoc::clean` gets updated.
