### PR TITLE
rustc: Don't die on 0-length pattern idents

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1239,7 +1239,7 @@ fn check_pat_uppercase_variable(cx: &Context, p: &ast::Pat) {
                     // last identifier alone is right choice for this lint.
                     let ident = path.segments.last().unwrap().identifier;
                     let s = token::get_ident(ident);
-                    if s.get().char_at(0).is_uppercase() {
+                    if s.get().len() > 0 && s.get().char_at(0).is_uppercase() {
                         cx.span_lint(
                             UppercaseVariables,
                             path.span,

--- a/src/test/run-pass/issue-13775.rs
+++ b/src/test/run-pass/issue-13775.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+    fn bar(&self, int) {}
+}
+
+fn main() {}


### PR DESCRIPTION
These often crop up when using default methods that don't actually bind their
argument names.

Closes #13775
