### PR TITLE
Added missing values in std::io::standard_error()

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1408,7 +1408,21 @@ pub fn standard_error(kind: IoErrorKind) -> IoError {
         EndOfFile => "end of file",
         IoUnavailable => "I/O is unavailable",
         InvalidInput => "invalid input",
-        _ => fail!()
+        OtherIoError => "unknown I/O error",
+        FileNotFound => "file not found",
+        PermissionDenied => "permission denied",
+        ConnectionFailed => "connection failed",
+        Closed => "stream is closed",
+        ConnectionRefused => "connection refused",
+        ConnectionReset => "connection reset",
+        ConnectionAborted => "connection aborted",
+        NotConnected => "not connected",
+        BrokenPipe => "broken pipe",
+        PathAlreadyExists => "file exists",
+        PathDoesntExist => "no such file",
+        MismatchedFileTypeForOperation => "mismatched file type",
+        ResourceUnavailable => "resource unavailable",
+        TimedOut => "operation timed out"
     };
     IoError {
         kind: kind,


### PR DESCRIPTION
Hello,

With the latest version of Rust, calling to the function [`std::io::standard_error()`](http://static.rust-lang.org/doc/master/std/io/fn.standard_error.html) succeeds only if the value of the argument is `EndOfFile`, `IoUnavailable` or `InvalidInput`. If the function is called with another value as argument, it fails without message.

Here is a piece of code that reproduces the problem:

``` rust
use std::io::{standard_error,EndOfFile,FileNotFound,PermissionDenied};

fn main() {
     println!("Error 1: {}", standard_error(EndOfFile)); // does not fail
     println!("Error 2: {}", standard_error(FileNotFound)); // fails
     println!("Error 3: {}", standard_error(PermissionDenied)); //fails
}
```

This was because the `IoErrorKind` passed as argument wasn't matched against all the possible values.

I added the missing branches in the `match` statement inside the function, and i removed the call to the `fail!()` macro. I rebuilt the crate with the latest `rustc` version and it seems to works.
