### PR TITLE
rustdoc: #13771: Make html links inside paragraphs more readable

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -202,6 +202,10 @@ nav.sub {
     white-space: nowrap;
     text-overflow: ellipsis;
 }
+
+.docblock a { color: #4e8bca; }
+.docblock a:hover { text-decoration: underline; }
+
 .docblock.short p {
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
All links inside docblocks will have their color set to `#4e8bca` (a light blue color to contrast against the black text). This color also offers a visible contrast from the surrounding text if viewed as grayscale, making it suitable for accessability.

Docblock links will also be underlined when hovered over.

Before:
![screen shot 2014-04-27 at 12 47 06 pm](https://cloud.githubusercontent.com/assets/1638690/2812157/00e53a32-ce45-11e3-81e8-7b1dc692f6b7.png)

After (links underlined only on hover, cursor not shown in image):
![screen shot 2014-04-27 at 12 47 48 pm](https://cloud.githubusercontent.com/assets/1638690/2812158/04fa94b4-ce45-11e3-9ead-2344753c251d.png)

Fix #13771 
