### PR TITLE
doc: Remove out-of-place debug! note

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1793,11 +1793,6 @@ spawn(proc() {
 });
 ~~~~
 
-> *Note:* If you want to see the output of `debug!` statements, you will need to turn on
-> `debug!` logging.  To enable `debug!` logging, set the RUST_LOG environment
-> variable to the name of your crate, which, for a file named `foo.rs`, will be
-> `foo` (e.g., with bash, `export RUST_LOG=foo`).
-
 ## Closure compatibility
 
 Rust closures have a convenient subtyping property: you can pass any kind of


### PR DESCRIPTION
As of cc6ec8df, the Owned closures example uses println! instead of
debug!, making a note about seeing debug seem out-of-place in this
section.

Since debug! is not used elsewhere in the tutorial, remove the note
entirely.
