### PR TITLE
Fix repeated module documentation

### DIFF
--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -88,10 +88,7 @@ mod homing;
 mod queue;
 mod rc;
 
-/// The implementation of `rtio` for libuv
 pub mod uvio;
-
-/// C bindings to libuv
 pub mod uvll;
 
 pub mod file;

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! The implementation of `rtio` for libuv
+
 use std::c_str::CString;
 use std::cast;
 use std::io::IoError;

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Simple backtrace functionality (to print on failure)
+
 #![allow(non_camel_case_types)]
 
 use char::Char;

--- a/src/libstd/rt/global_heap.rs
+++ b/src/libstd/rt/global_heap.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+
+//! The global (exchange) heap.
+
 use libc::{c_void, size_t, free, malloc, realloc};
 use ptr::{RawPtr, mut_null};
 use intrinsics::abort;

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -85,44 +85,44 @@ pub mod shouldnt_be_public {
 // Internal macros used by the runtime.
 mod macros;
 
-/// The global (exchange) heap.
+// The global (exchange) heap.
 pub mod global_heap;
 
-/// Implementations of language-critical runtime features like @.
+// Implementations of language-critical runtime features like @.
 pub mod task;
 
-/// The EventLoop and internal synchronous I/O interface.
+// The EventLoop and internal synchronous I/O interface.
 pub mod rtio;
 
-/// The Local trait for types that are accessible via thread-local
-/// or task-local storage.
+// The Local trait for types that are accessible via thread-local
+// or task-local storage.
 pub mod local;
 
-/// Bindings to system threading libraries.
+// Bindings to system threading libraries.
 pub mod thread;
 
-/// The runtime configuration, read from environment variables.
+// The runtime configuration, read from environment variables.
 pub mod env;
 
-/// The local, managed heap
+// The local, managed heap
 pub mod local_heap;
 
-/// The runtime needs to be able to put a pointer into thread-local storage.
+// The runtime needs to be able to put a pointer into thread-local storage.
 mod local_ptr;
 
-/// Bindings to pthread/windows thread-local storage.
+// Bindings to pthread/windows thread-local storage.
 mod thread_local_storage;
 
-/// Stack unwinding
+// Stack unwinding
 pub mod unwind;
 
-/// The interface to libunwind that rust is using.
+// The interface to libunwind that rust is using.
 mod libunwind;
 
-/// Simple backtrace functionality (to print on failure)
+// Simple backtrace functionality (to print on failure)
 pub mod backtrace;
 
-/// Just stuff
+// Just stuff
 mod util;
 
 // Global command line argument storage

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! The EventLoop and internal synchronous I/O interface.
+
 use c_str::CString;
 use cast;
 use comm::{Sender, Receiver};

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Stack unwinding
+
 // Implementation of Rust stack unwinding
 //
 // For background on exception handling and stack unwinding please see

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*
-  Predicates on exprs and stmts that the pretty-printer and parser use
- */
+//! Routines the parser uses to classify AST nodes
+
+// Predicates on exprs and stmts that the pretty-printer and parser use
 
 use ast;
 

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Common routines shared by parser mods
+
 use parse::token;
 
 // SeqSep : a sequence separator (token)

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -28,13 +28,8 @@ pub mod token;
 pub mod comments;
 pub mod attr;
 
-/// Common routines shared by parser mods
 pub mod common;
-
-/// Routines the parser uses to classify AST nodes
 pub mod classify;
-
-/// Reporting obsolete syntax
 pub mod obsolete;
 
 // info about a parsing session.


### PR DESCRIPTION
This is a quick fix for repeated documentation descriptions in certain modules.
Following is a list of the faulty modules I found. I ran `pcregrep -r -M "<p>(.+)\n\1" doc` on the html documentation to help identify them.
- [rustuv::uvio](http://static.rust-lang.org/doc/master/rustuv/uvio/index.html)
- [rustuv::uvll](http://static.rust-lang.org/doc/master/rustuv/uvll/index.html)
- [std::rt::backtrace](http://static.rust-lang.org/doc/master/std/rt/backtrace/index.html)
- [std::rt::env](http://static.rust-lang.org/doc/master/std/rt/env/index.html)
- [std::rt::global_heap](http://static.rust-lang.org/doc/master/std/rt/global_heap/index.html)
- [std::rt::local_heap](http://static.rust-lang.org/doc/master/std/rt/local_heap/index.html)
- [std::rt::rtio](http://static.rust-lang.org/doc/master/std/rt/rtio/index.html)
- [std::rt::task](http://static.rust-lang.org/doc/master/std/rt/task/index.html)
- [std::rt::thread](http://static.rust-lang.org/doc/master/std/rt/thread/index.html)
- [std::rt::unwind](http://static.rust-lang.org/doc/master/std/rt/unwind/index.html)
- [syntax::parse::classify](http://static.rust-lang.org/doc/master/syntax/parse/classify/index.html)
- [syntax::parse::common](http://static.rust-lang.org/doc/master/syntax/parse/common/index.html)

After a little testing, I discovered that moving the documentation inside (`//!`) instead of outside (`///`) modules fixed the immediate problem. I went through the trouble of moving the documentation, and with this commit there are no more repeated descriptions within those faulty modules.

This does not fix the underlying problem though. We should look into why having the documentation outside instead of inside caused the descriptions to be repeated. I will create a separate issue with my findings on the subject if necessary.
In the meantime, this simple fix should be enough.
