### PR TITLE
Refactor ty_str to use a ~(str) representation.

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -138,23 +138,6 @@ pub fn parse_substs_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: 
     parse_substs(&mut st, conv)
 }
 
-fn parse_vstore(st: &mut PState, conv: conv_did) -> ty::Vstore {
-    assert_eq!(next(st), '/');
-
-    let c = peek(st);
-    if '0' <= c && c <= '9' {
-        let n = parse_uint(st);
-        assert_eq!(next(st), '|');
-        return ty::VstoreFixed(n);
-    }
-
-    match next(st) {
-        '~' => ty::VstoreUniq,
-        '&' => ty::VstoreSlice(parse_region(st, conv)),
-        c => st.tcx.sess.bug(format!("parse_vstore(): bad input '{}'", c))
-    }
-}
-
 fn parse_size(st: &mut PState) -> Option<uint> {
     assert_eq!(next(st), '/');
 
@@ -361,8 +344,8 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
         return ty::mk_vec(st.tcx, mt, sz);
       }
       'v' => {
-        let v = parse_vstore(st, |x,y| conv(x,y));
-        return ty::mk_str(st.tcx, v);
+        let sz = parse_size(st);
+        return ty::mk_str(st.tcx, sz);
       }
       'T' => {
         assert_eq!(next(st), '[');

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -177,21 +177,6 @@ fn enc_bound_region(w: &mut MemWriter, cx: &ctxt, br: ty::BoundRegion) {
     }
 }
 
-pub fn enc_vstore(w: &mut MemWriter, cx: &ctxt,
-                  v: ty::Vstore,
-                  enc_mut: |&mut MemWriter|) {
-    mywrite!(w, "/");
-    match v {
-        ty::VstoreFixed(u) => mywrite!(w, "{}|", u),
-        ty::VstoreUniq => mywrite!(w, "~"),
-        ty::VstoreSlice(r) => {
-            mywrite!(w, "&");
-            enc_region(w, cx, r);
-            enc_mut(w);
-        }
-    }
-}
-
 pub fn enc_trait_ref(w: &mut MemWriter, cx: &ctxt, s: &ty::TraitRef) {
     mywrite!(w, "{}|", (cx.ds)(s.def_id));
     enc_substs(w, cx, &s.substs);
@@ -275,9 +260,13 @@ fn enc_sty(w: &mut MemWriter, cx: &ctxt, st: &ty::sty) {
                 None => mywrite!(w, "|"),
             }
         }
-        ty::ty_str(v) => {
+        ty::ty_str(sz) => {
             mywrite!(w, "v");
-            enc_vstore(w, cx, v, |_| {});
+            mywrite!(w, "/");
+            match sz {
+                Some(n) => mywrite!(w, "{}|", n),
+                None => mywrite!(w, "|"),
+            }
         }
         ty::ty_closure(ref f) => {
             mywrite!(w, "f");

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -405,6 +405,7 @@ fn missing_ctor(cx: &MatchCheckCtxt,
       ty::ty_struct(..) => check_matrix_for_wild(cx, m),
       ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty: ty, ..}) => match ty::get(ty).sty {
           ty::ty_vec(_, None) => ctor_for_slice(m),
+          ty::ty_str(None) => Some(single),
           _ => check_matrix_for_wild(cx, m),
       },
       ty::ty_enum(eid, _) => {

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -68,6 +68,13 @@ impl<'a> EffectCheckVisitor<'a> {
         debug!("effect: checking index with base type {}",
                 ppaux::ty_to_str(self.tcx, base_type));
         match ty::get(base_type).sty {
+            ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => match ty::get(ty).sty {
+                ty::ty_str(None) => {
+                    self.tcx.sess.span_err(e.span,
+                        "modification of string types is not allowed");
+                }
+                _ => {}
+            },
             ty::ty_str(..) => {
                 self.tcx.sess.span_err(e.span,
                     "modification of string types is not allowed");

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -911,7 +911,7 @@ fn check_heap_type(cx: &Context, span: Span, ty: ty::t) {
                 ty::ty_box(_) => {
                     n_box += 1;
                 }
-                ty::ty_uniq(_) | ty::ty_str(ty::VstoreUniq) |
+                ty::ty_uniq(_) |
                 ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) |
                 ty::ty_closure(~ty::ClosureTy { store: ty::UniqTraitStore, .. }) => {
                     n_uniq += 1;

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -174,7 +174,6 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
     match ty::get(t).sty {
         ty::ty_uniq(_) |
         ty::ty_trait(~ty::TyTrait { store: ty::UniqTraitStore, .. }) |
-        ty::ty_str(ty::VstoreUniq) |
         ty::ty_closure(~ty::ClosureTy {store: ty::UniqTraitStore, ..}) => {
             Some(deref_ptr(OwnedPtr))
         }
@@ -188,7 +187,6 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
             Some(deref_ptr(BorrowedPtr(kind, r)))
         }
 
-        ty::ty_str(ty::VstoreSlice(r)) |
         ty::ty_closure(~ty::ClosureTy {store: ty::RegionTraitStore(r, _), ..}) => {
             Some(deref_ptr(BorrowedPtr(ty::ImmBorrow, r)))
         }
@@ -207,7 +205,7 @@ pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
         }
 
         ty::ty_vec(_, Some(_)) |
-        ty::ty_str(ty::VstoreFixed(_)) => {
+        ty::ty_str(Some(_)) => {
             Some(deref_interior(InteriorElement(element_kind(t))))
         }
 
@@ -1306,6 +1304,7 @@ fn element_kind(t: ty::t) -> ElementKind {
         ty::ty_rptr(_, ty::mt{ty:ty, ..}) |
         ty::ty_uniq(ty) => match ty::get(ty).sty {
             ty::ty_vec(_, None) => VecElement,
+            ty::ty_str(None) => StrElement,
             _ => OtherElement
         },
         ty::ty_vec(..) => VecElement,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1293,40 +1293,51 @@ fn compare_values<'a>(
                   rhs: ValueRef,
                   rhs_t: ty::t)
                   -> Result<'a> {
+    fn compare_str<'a>(cx: &'a Block<'a>,
+                       lhs: ValueRef,
+                       rhs: ValueRef,
+                       rhs_t: ty::t)
+                       -> Result<'a> {
+        let did = langcall(cx, None,
+                           format!("comparison of `{}`", cx.ty_to_str(rhs_t)),
+                           StrEqFnLangItem);
+        let result = callee::trans_lang_call(cx, did, [lhs, rhs], None);
+        Result {
+            bcx: result.bcx,
+            val: bool_to_i1(result.bcx, result.val)
+        }
+    }
+
     let _icx = push_ctxt("compare_values");
     if ty::type_is_scalar(rhs_t) {
-      let rs = compare_scalar_types(cx, lhs, rhs, rhs_t, ast::BiEq);
-      return rslt(rs.bcx, rs.val);
+        let rs = compare_scalar_types(cx, lhs, rhs, rhs_t, ast::BiEq);
+        return rslt(rs.bcx, rs.val);
     }
 
     match ty::get(rhs_t).sty {
-        ty::ty_str(ty::VstoreUniq) => {
-            let scratch_lhs = alloca(cx, val_ty(lhs), "__lhs");
-            Store(cx, lhs, scratch_lhs);
-            let scratch_rhs = alloca(cx, val_ty(rhs), "__rhs");
-            Store(cx, rhs, scratch_rhs);
-            let did = langcall(cx, None,
-                               format!("comparison of `{}`", cx.ty_to_str(rhs_t)),
-                               UniqStrEqFnLangItem);
-            let result = callee::trans_lang_call(cx, did, [scratch_lhs, scratch_rhs], None);
-            Result {
-                bcx: result.bcx,
-                val: bool_to_i1(result.bcx, result.val)
+        ty::ty_uniq(t) => match ty::get(t).sty {
+            ty::ty_str(None) => {
+                let scratch_lhs = alloca(cx, val_ty(lhs), "__lhs");
+                Store(cx, lhs, scratch_lhs);
+                let scratch_rhs = alloca(cx, val_ty(rhs), "__rhs");
+                Store(cx, rhs, scratch_rhs);
+                let did = langcall(cx, None,
+                                   format!("comparison of `{}`", cx.ty_to_str(rhs_t)),
+                                   UniqStrEqFnLangItem);
+                let result = callee::trans_lang_call(cx, did, [scratch_lhs, scratch_rhs], None);
+                Result {
+                    bcx: result.bcx,
+                    val: bool_to_i1(result.bcx, result.val)
+                }
             }
-        }
-        ty::ty_str(_) => {
-            let did = langcall(cx, None,
-                               format!("comparison of `{}`", cx.ty_to_str(rhs_t)),
-                               StrEqFnLangItem);
-            let result = callee::trans_lang_call(cx, did, [lhs, rhs], None);
-            Result {
-                bcx: result.bcx,
-                val: bool_to_i1(result.bcx, result.val)
-            }
-        }
-        _ => {
-            cx.sess().bug("only scalars and strings supported in compare_values");
-        }
+            _ => cx.sess().bug("only scalars and strings supported in compare_values"),
+        },
+        ty::ty_rptr(_, mt) => match ty::get(mt.ty).sty {
+            ty::ty_str(None) => compare_str(cx, lhs, rhs, rhs_t),
+            _ => cx.sess().bug("only scalars and strings supported in compare_values"),
+        },
+        ty::ty_str(Some(_)) => compare_str(cx, lhs, rhs, rhs_t),
+        _ => cx.sess().bug("only scalars and strings supported in compare_values"),
     }
 }
 

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -270,11 +270,10 @@ impl Case {
         self.tys.iter().position(|&ty| {
             match ty::get(ty).sty {
                 ty::ty_rptr(_, mt) => match ty::get(mt.ty).sty {
-                    ty::ty_vec(_, None) => false,
+                    ty::ty_vec(_, None) | ty::ty_str(None)=> false,
                     _ => true,
                 },
                 ty::ty_uniq(..) | ty::ty_box(..) |
-                ty::ty_str(ty::VstoreUniq) |
                 ty::ty_bare_fn(..) => true,
                 // Is that everything?  Would closures or slices qualify?
                 _ => false

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -188,8 +188,8 @@ fn decl_fn(llmod: ModuleRef, name: &str, cc: lib::llvm::CallConv,
         // `~` pointer return values never alias because ownership is transferred
         // FIXME #6750 ~Trait cannot be directly marked as
         // noalias because the actual object pointer is nested.
-        ty::ty_uniq(..) | // ty::ty_trait(_, _, ty::UniqTraitStore, _, _) |
-        ty::ty_str(ty::VstoreUniq) => {
+        ty::ty_uniq(..) // | ty::ty_trait(_, _, ty::UniqTraitStore, _, _)
+         => {
             unsafe {
                 llvm::LLVMAddReturnAttribute(llfn, lib::llvm::NoAliasAttribute as c_uint);
             }
@@ -261,7 +261,6 @@ pub fn decl_rust_fn(ccx: &CrateContext, has_env: bool,
             // FIXME #6750 ~Trait cannot be directly marked as
             // noalias because the actual object pointer is nested.
             ty::ty_uniq(..) | // ty::ty_trait(_, _, ty::UniqTraitStore, _, _) |
-            ty::ty_str(ty::VstoreUniq) |
             ty::ty_closure(~ty::ClosureTy {store: ty::UniqTraitStore, ..}) => {
                 unsafe {
                     llvm::LLVMAddAttribute(llarg, lib::llvm::NoAliasAttribute as c_uint);
@@ -665,7 +664,7 @@ pub fn iter_structural_ty<'r,
               }
           })
       }
-      ty::ty_str(ty::VstoreFixed(n)) => {
+      ty::ty_str(Some(n)) => {
         let unit_ty = ty::sequence_element_type(cx.tcx(), t);
         let (base, len) = tvec::get_fixed_base_and_byte_len(cx, av, unit_ty, n);
         cx = tvec::iter_vec_raw(cx, base, unit_ty, len, f);

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -659,9 +659,10 @@ pub fn trans_call_inner<'a>(
         match ty::get(ret_ty).sty {
             // `~` pointer return values never alias because ownership
             // is transferred
-            ty::ty_uniq(..) => {
-                attrs.push((0, NoAliasAttribute));
-            }
+            ty::ty_uniq(ty) => match ty::get(ty).sty {
+                ty::ty_str(None) => {}
+                _ => attrs.push((0, NoAliasAttribute)),
+            },
             _ => {}
         }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -141,7 +141,7 @@ fn const_deref(cx: &CrateContext, v: ValueRef, t: ty::t, explicit: bool)
             let dv = match ty::get(t).sty {
                 ty::ty_ptr(mt) | ty::ty_rptr(_, mt) => {
                     match ty::get(mt.ty).sty {
-                        ty::ty_vec(_, None) => cx.sess().bug("unexpected slice"),
+                        ty::ty_vec(_, None) | ty::ty_str(None) => cx.sess().bug("unexpected slice"),
                         _ => const_deref_ptr(cx, v),
                     }
                 }
@@ -432,13 +432,9 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
                                           "index is not an integer-constant expression")
               };
               let (arr, len) = match ty::get(bt).sty {
-                  ty::ty_str(ty::VstoreSlice(..)) => {
-                    let e1 = const_get_elt(cx, bv, [0]);
-                    (const_deref_ptr(cx, e1), const_get_elt(cx, bv, [1]))
-                  },
                   ty::ty_vec(_, Some(u)) => (bv, C_uint(cx, u)),
                   ty::ty_rptr(_, mt) => match ty::get(mt.ty).sty {
-                      ty::ty_vec(_, None) => {
+                      ty::ty_vec(_, None) | ty::ty_str(None) => {
                           let e1 = const_get_elt(cx, bv, [0]);
                           (const_deref_ptr(cx, e1), const_get_elt(cx, bv, [1]))
                       },
@@ -451,7 +447,17 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
 
               let len = llvm::LLVMConstIntGetZExtValue(len) as u64;
               let len = match ty::get(bt).sty {
-                  ty::ty_str(..) => {assert!(len > 0); len - 1},
+                  ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => match ty::get(ty).sty {
+                      ty::ty_str(None) => {
+                          assert!(len > 0);
+                          len - 1
+                      }
+                      _ => len
+                  },
+                  ty::ty_str(Some(_)) => {
+                      assert!(len > 0);
+                      len - 1
+                  },
                   _ => len
               };
               if iv >= len {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1507,7 +1507,7 @@ pub fn cast_type_kind(t: ty::t) -> cast_kind {
         ty::ty_float(..)   => cast_float,
         ty::ty_ptr(..)     => cast_pointer,
         ty::ty_rptr(_, mt) => match ty::get(mt.ty).sty{
-            ty::ty_vec(_, None) => cast_other,
+            ty::ty_vec(_, None) | ty::ty_str(None) => cast_other,
             _ => cast_pointer,
         },
         ty::ty_bare_fn(..) => cast_pointer,
@@ -1717,7 +1717,8 @@ fn deref_once<'a>(bcx: &'a Block<'a>,
     let r = match ty::get(datum.ty).sty {
         ty::ty_uniq(content_ty) => {
             match ty::get(content_ty).sty {
-                ty::ty_vec(_, None) => bcx.tcx().sess.span_bug(expr.span, "unexpected ~[T]"),
+                ty::ty_vec(_, None) | ty::ty_str(None)
+                    => bcx.tcx().sess.span_bug(expr.span, "unexpected ~[T]"),
                 _ => deref_owned_pointer(bcx, expr, datum, content_ty),
             }
         }
@@ -1734,7 +1735,8 @@ fn deref_once<'a>(bcx: &'a Block<'a>,
         ty::ty_ptr(ty::mt { ty: content_ty, .. }) |
         ty::ty_rptr(_, ty::mt { ty: content_ty, .. }) => {
             match ty::get(content_ty).sty {
-                ty::ty_vec(_, None) => bcx.tcx().sess.span_bug(expr.span, "unexpected &[T]"),
+                ty::ty_vec(_, None) | ty::ty_str(None)
+                    => bcx.tcx().sess.span_bug(expr.span, "unexpected &[T]"),
                 _ => {
                     assert!(!ty::type_needs_drop(bcx.tcx(), datum.ty));
 

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -68,10 +68,6 @@ pub trait TypeFolder {
         r
     }
 
-    fn fold_vstore(&mut self, vstore: ty::Vstore) -> ty::Vstore {
-        super_fold_vstore(self, vstore)
-    }
-
     fn fold_trait_store(&mut self, s: ty::TraitStore) -> ty::TraitStore {
         super_fold_trait_store(self, s)
     }
@@ -179,8 +175,8 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
             ty::ty_struct(did,
                           this.fold_substs(substs))
         }
-        ty::ty_str(vst) => {
-            ty::ty_str(this.fold_vstore(vst))
+        ty::ty_str(sz) => {
+            ty::ty_str(sz)
         }
         ty::ty_nil | ty::ty_bot | ty::ty_bool | ty::ty_char |
         ty::ty_int(_) | ty::ty_uint(_) | ty::ty_float(_) |
@@ -188,16 +184,6 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_param(..) | ty::ty_self(_) => {
             (*sty).clone()
         }
-    }
-}
-
-pub fn super_fold_vstore<T:TypeFolder>(this: &mut T,
-                                       vstore: ty::Vstore)
-                                       -> ty::Vstore {
-    match vstore {
-        ty::VstoreFixed(i) => ty::VstoreFixed(i),
-        ty::VstoreUniq => ty::VstoreUniq,
-        ty::VstoreSlice(r) => ty::VstoreSlice(this.fold_region(r)),
     }
 }
 

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -939,12 +939,8 @@ fn constrain_index(rcx: &mut Rcx,
 
     let r_index_expr = ty::ReScope(index_expr.id);
     match ty::get(indexed_ty).sty {
-        ty::ty_str(ty::VstoreSlice(r_ptr)) => {
-            rcx.fcx.mk_subr(true, infer::IndexSlice(index_expr.span),
-                            r_index_expr, r_ptr);
-        }
         ty::ty_rptr(r_ptr, mt) => match ty::get(mt.ty).sty {
-            ty::ty_vec(_, None) => {
+            ty::ty_vec(_, None) | ty::ty_str(None)=> {
                 rcx.fcx.mk_subr(true, infer::IndexSlice(index_expr.span),
                                 r_index_expr, r_ptr);
             }

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -706,7 +706,7 @@ impl<'a> ConstraintContext<'a> {
         match ty::get(ty).sty {
             ty::ty_nil | ty::ty_bot | ty::ty_bool |
             ty::ty_char | ty::ty_int(_) | ty::ty_uint(_) |
-            ty::ty_float(_) => {
+            ty::ty_float(_) | ty::ty_str(_) => {
                 /* leaf type -- noop */
             }
 
@@ -714,10 +714,6 @@ impl<'a> ConstraintContext<'a> {
                 let contra = self.contravariant(variance);
                 self.add_constraints_from_region(region, contra);
                 self.add_constraints_from_mt(mt, variance);
-            }
-
-            ty::ty_str(vstore) => {
-                self.add_constraints_from_vstore(vstore, variance);
             }
 
             ty::ty_vec(ref mt, _) => {
@@ -792,20 +788,6 @@ impl<'a> ConstraintContext<'a> {
         }
     }
 
-    /// Adds constraints appropriate for a vector with Vstore `vstore`
-    /// appearing in a context with ambient variance `variance`
-    fn add_constraints_from_vstore(&mut self,
-                                   vstore: ty::Vstore,
-                                   variance: VarianceTermPtr<'a>) {
-        match vstore {
-            ty::VstoreSlice(r) => {
-                let contra = self.contravariant(variance);
-                self.add_constraints_from_region(r, contra);
-            }
-
-            ty::VstoreFixed(_) | ty::VstoreUniq => {}
-        }
-    }
 
     /// Adds constraints appropriate for a nominal type (enum, struct,
     /// object, etc) appearing in a context with ambient variance `variance`

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -395,21 +395,16 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
         let bound_str = bounds.repr(cx);
         format!("{}{}{}{}", trait_store_to_str(cx, store), ty, bound_sep, bound_str)
       }
-      ty_str(vs) => {
-        match vs {
-            ty::VstoreFixed(n) => format!("str/{}", n),
-            ty::VstoreUniq => "~str".to_owned(),
-            ty::VstoreSlice(r) => format!("{}str", region_ptr_to_str(cx, r))
+      ty_str(sz) => {
+        match sz {
+            Some(n) => format!("str/{}", n),
+            None => "str".to_owned(),
         }
       }
       ty_vec(ref mt, sz) => {
           match sz {
-              Some(n) => {
-                  format!("[{}, .. {}]", mt_to_str(cx, mt), n)
-              }
-              None => {
-                  format!("[{}]", ty_to_str(cx, mt.ty))
-              }
+              Some(n) => format!("[{}, .. {}]", mt_to_str(cx, mt), n),
+              None => format!("[{}]", ty_to_str(cx, mt.ty)),
           }
       }
     }
@@ -851,16 +846,6 @@ impl Repr for ty::RegionVid {
 impl Repr for ty::TraitStore {
     fn repr(&self, tcx: &ctxt) -> ~str {
         trait_store_to_str(tcx, *self)
-    }
-}
-
-impl Repr for ty::Vstore {
-    fn repr(&self, tcx: &ctxt) -> ~str {
-        match *self {
-            ty::VstoreFixed(n) => format!("{}", n),
-            ty::VstoreUniq => "~".to_owned(),
-            ty::VstoreSlice(r) => region_ptr_to_str(tcx, r)
-        }
     }
 }
 

--- a/src/test/compile-fail/estr-subtyping.rs
+++ b/src/test/compile-fail/estr-subtyping.rs
@@ -17,7 +17,7 @@ fn has_uniq(x: ~str) {
 }
 
 fn has_slice(x: &str) {
-   wants_uniq(x); //~ ERROR str storage differs: expected `~` but found `&`
+   wants_uniq(x); //~ ERROR mismatched types: expected `~str` but found `&str` (expected ~-ptr but f
    wants_slice(x);
 }
 

--- a/src/test/compile-fail/ifmt-bad-select.rs
+++ b/src/test/compile-fail/ifmt-bad-select.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     format!("{0, select, other{}}", 2);
-    //~^ ERROR: expected &str but found integral
+    //~^ ERROR: mismatched types: expected `&&str` but found `&<generic integer #0>` (expected &-ptr
 }


### PR DESCRIPTION
Similar to my recent changes to ~[T]/&[T], these changes remove the vstore abstraction and represent str types as ~(str) and &(str). The Option<uint> in ty_str is the length of the string, None if the string is dynamically sized.
