### PR TITLE
librand: Revise crypto part of document

### DIFF
--- a/src/librand/os.rs
+++ b/src/librand/os.rs
@@ -109,6 +109,7 @@ mod imp {
                                      CRYPT_VERIFYCONTEXT | CRYPT_SILENT)
             };
 
+            // FIXME #13259:
             // It turns out that if we can't acquire a context with the
             // NTE_BAD_SIGNATURE error code, the documentation states:
             //


### PR DESCRIPTION
This patch adds document which explains when to use `OSRng` in
cryptographic context, and explains why we use `/dev/urandom` instead
of `/dev/random`.
