### PR TITLE
rustc: Pass -dead_strip on OSX

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1150,6 +1150,18 @@ fn link_args(sess: &Session,
            sess.opts.optimize == session::Aggressive {
             args.push("-Wl,-O1".to_owned());
         }
+    } else if sess.targ_cfg.os == abi::OsMacos {
+        // The dead_strip option to the linker specifies that functions and data
+        // unreachable by the entry point will be removed. This is quite useful
+        // with Rust's compilation model of compiling libraries at a time into
+        // one object file. For example, this brings hello world from 1.7MB to
+        // 458K.
+        //
+        // Note that this is done for both executables and dynamic libraries. We
+        // won't get much benefit from dylibs because LLVM will have already
+        // stripped away as much as it could. This has not been seen to impact
+        // link times negatively.
+        args.push("-Wl,-dead_strip".to_owned());
     }
 
     if sess.targ_cfg.os == abi::OsWin32 {


### PR DESCRIPTION
This flag to the linker asks it to strip away all dead code during linking, as
well as dead data. This reduces the size of hello world from 1.7MB to 458K on my
system (70% reduction).

I have not seen this impact link times negatively, and I have seen this pass
'make check' successfully. I am slightly wary of adding this option, but the
benefits are so huge tha I think we should work hard to work around any issues
rather than avoid using the flag entirely.
