### PR TITLE
rustdoc: Make going back in browser history work after typing a search term

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -605,11 +605,10 @@
                     // cleared to ensure the search is successful.
                     currentResults = null;
                     // Synchronize search bar with query string state and
-                    // perform the search, but don't empty the bar if there's
-                    // nothing there.
-                    if (params.search !== undefined) {
-                        $('.search-input').val(params.search);
-                    }
+                    // perform the search. This will empty the bar if there's
+                    // nothing there, which lets you really go back to a
+                    // previous state with nothing in the bar.
+                    $('.search-input').val(params.search);
                     // Some browsers fire 'onpopstate' for every page load
                     // (Chrome), while others fire the event only when actually
                     // popping a state (Firefox), which is why search() is


### PR DESCRIPTION
Currently, in both chrome and firefox, if I type something in the search box in the reference docs I get immediately the search results. That's great. However, if I want to go back to the doc I was reading and try to press the back button, I am immediately forwarded again to the search results. This is caused by the fact that the search term is (deliberately) left in the search box, and the search() function is called as if I typed the search term again.
I disabled calling the search() function if there's no search term in the URL, and now it seems to work fine.

I hope I'm sending the pull request correctly - I'm not really used to git and github.
