### PR TITLE
rustc: Enable -f{function,data}-sections

### DIFF
--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -1748,7 +1748,9 @@ pub mod llvm {
                                            Level: CodeGenOptLevel,
                                            EnableSegstk: bool,
                                            UseSoftFP: bool,
-                                           NoFramePointerElim: bool) -> TargetMachineRef;
+                                           NoFramePointerElim: bool,
+                                           FunctionSections: bool,
+                                           DataSections: bool) -> TargetMachineRef;
         pub fn LLVMRustDisposeTargetMachine(T: TargetMachineRef);
         pub fn LLVMRustAddAnalysisPasses(T: TargetMachineRef,
                                          PM: PassManagerRef,

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -69,7 +69,9 @@ LLVMRustCreateTargetMachine(const char *triple,
                             CodeGenOpt::Level OptLevel,
                             bool EnableSegmentedStacks,
                             bool UseSoftFloat,
-                            bool NoFramePointerElim) {
+                            bool NoFramePointerElim,
+                            bool FunctionSections,
+                            bool DataSections) {
     std::string Error;
     Triple Trip(Triple::normalize(triple));
     const llvm::Target *TheTarget = TargetRegistry::lookupTarget(Trip.getTriple(),
@@ -97,6 +99,8 @@ LLVMRustCreateTargetMachine(const char *triple,
                                                        RM,
                                                        CM,
                                                        OptLevel);
+    TM->setDataSections(DataSections);
+    TM->setFunctionSections(FunctionSections);
     return wrap(TM);
 }
 

--- a/src/test/debug-info/basic-types-globals-metadata.rs
+++ b/src/test/debug-info/basic-types-globals-metadata.rs
@@ -66,6 +66,8 @@ static F64: f64 = 3.5;
 
 fn main() {
     _zzz();
+
+    let a = (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64);
 }
 
 fn _zzz() {()}

--- a/src/test/debug-info/basic-types-globals.rs
+++ b/src/test/debug-info/basic-types-globals.rs
@@ -70,6 +70,8 @@ static F64: f64 = 3.5;
 
 fn main() {
     _zzz();
+
+    let a = (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64);
 }
 
 fn _zzz() {()}

--- a/src/test/debug-info/basic-types-metadata.rs
+++ b/src/test/debug-info/basic-types-metadata.rs
@@ -67,6 +67,7 @@ fn main() {
     let f32: f32 = 2.5;
     let f64: f64 = 3.5;
     _zzz();
+    if 1 == 1 { _yyy(); }
 }
 
 fn _zzz() {()}

--- a/src/test/debug-info/c-style-enum.rs
+++ b/src/test/debug-info/c-style-enum.rs
@@ -121,6 +121,10 @@ fn main() {
     };
 
     zzz();
+
+    let a = SINGLE_VARIANT;
+    let a = unsafe { AUTO_ONE };
+    let a = unsafe { MANUAL_ONE };
 }
 
 fn zzz() {()}

--- a/src/test/debug-info/limited-debuginfo.rs
+++ b/src/test/debug-info/limited-debuginfo.rs
@@ -38,6 +38,7 @@ struct Struct {
 
 fn main() {
     some_function(101, 202);
+    some_other_function(1, 2);
 }
 
 


### PR DESCRIPTION
The compiler has previously been producing binaries on the order of 1.8MB for
hello world programs "fn main() {}". This is largely a result of the compilation
model used by compiling entire libraries into a single object file and because
static linking is favored by default.

When linking, linkers will pull in the entire contents of an object file if any
symbol from the object file is used. This means that if any symbol from a rust
library is used, the entire library is pulled in unconditionally, regardless of
whether the library is used or not.

Traditional C/C++ projects do not normally encounter these large executable
problems because their archives (rust's rlibs) are composed of many objects.
Because of this, linkers can eliminate entire objects from being in the final
executable. With rustc, however, the linker does not have the opportunity to
leave out entire object files.

In order to get similar benefits from dead code stripping at link time, this
commit enables the -ffunction-sections and -fdata-sections flags in LLVM, as
well as passing --gc-sections to the linker _by default_. This means that each
function and each global will be placed into its own section, allowing the
linker to GC all unused functions and data symbols.

By enabling these flags, rust is able to generate much smaller binaries default.
On linux, a hello world binary went from 1.8MB to 597K (a 67% reduction in
size). The output size of dynamic libraries remained constant, but the output
size of rlibs increased, as seen below:

```
libarena       -  2.27% bigger
libcollections -  0.64% bigger
libflate       -  0.85% bigger
libfourcc      - 14.67% bigger
libgetopts     -  4.52% bigger
libglob        -  2.74% bigger
libgreen       -  9.68% bigger
libhexfloat    - 13.68% bigger
liblibc        - 10.79% bigger
liblog         - 10.95% bigger
libnative      -  8.34% bigger
libnum         -  2.31% bigger
librand        -  1.71% bigger
libregex       -  6.43% bigger
librustc       -  4.21% bigger
librustdoc     -  8.98% bigger
librustuv      -  4.11% bigger
libsemver      -  2.68% bigger
libserialize   -  1.92% bigger
libstd         -  3.59% bigger
libsync        -  3.96% bigger
libsyntax      -  4.96% bigger
libterm        - 13.96% bigger
libtest        -  6.03% bigger
libtime        -  2.86% bigger
liburl         -  6.59% bigger
libuuid        -  4.70% bigger
libworkcache   -  8.44% bigger
```

This increase in size is a result of encoding many more section names into each
object file (rlib). These increases are moderate enough that this change seems
worthwhile to me, due to the drastic improvements seen in the final artifacts.
The overall increase of the stage2 target folder (not the size of an install)
went from 337MB to 348MB (3% increase).

Additionally, linking is generally slower when executed with all these new
sections plus the --gc-sections flag. The stage0 compiler takes 1.4s to link the
`rustc` binary, where the stage1 compiler takes 1.9s to link the binary. Three
megabytes are shaved off the binary. I found this increase in link time to be
acceptable relative to the benefits of code size gained.

This commit only enables --gc-sections for _executables_, not dynamic libraries.
LLVM does all the heavy lifting when producing an object file for a dynamic
library, so there is little else for the linker to do (remember that we only
have one object file).

I conducted similar experiments by putting a _module's_ functions and data
symbols into its own section (granularity moved to a module level instead of a
function/static level). The size benefits of a hello world were seen to be on
the order of 400K rather than 1.2MB. It seemed that enough benefit was gained
using ffunction-sections that this route was less desirable, despite the lesser
increases in binary rlib size.
