### PR TITLE
std: Modernize the local_data api

### DIFF
--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -14,23 +14,21 @@ use syntax::ast;
 use syntax::visit;
 use syntax::visit::Visitor;
 
-use std::local_data;
-
 use time;
 
 pub fn time<T, U>(do_it: bool, what: &str, u: U, f: |U| -> T) -> T {
     local_data_key!(depth: uint);
     if !do_it { return f(u); }
 
-    let old = local_data::get(depth, |d| d.map(|a| *a).unwrap_or(0));
-    local_data::set(depth, old + 1);
+    let old = depth.get().map(|d| *d).unwrap_or(0);
+    depth.replace(Some(old + 1));
 
     let start = time::precise_time_s();
     let rv = f(u);
     let end = time::precise_time_s();
 
     println!("{}time: {:3.3f} s\t{}", "  ".repeat(old), end - start, what);
-    local_data::set(depth, old);
+    depth.replace(Some(old));
 
     rv
 }

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -26,7 +26,6 @@ use rustc::metadata::cstore;
 use rustc::metadata::csearch;
 use rustc::metadata::decoder;
 
-use std::local_data;
 use std::strbuf::StrBuf;
 
 use core;
@@ -77,7 +76,7 @@ pub struct Crate {
 
 impl<'a> Clean<Crate> for visit_ast::RustdocVisitor<'a> {
     fn clean(&self) -> Crate {
-        let cx = local_data::get(super::ctxtkey, |x| *x.unwrap());
+        let cx = super::ctxtkey.get().unwrap();
 
         let mut externs = Vec::new();
         cx.sess().cstore.iter_crate_data(|n, meta| {
@@ -251,7 +250,7 @@ impl Clean<Item> for doctree::Module {
         // determine if we should display the inner contents or
         // the outer `mod` item for the source code.
         let where = {
-            let ctxt = local_data::get(super::ctxtkey, |x| *x.unwrap());
+            let ctxt = super::ctxtkey.get().unwrap();
             let cm = ctxt.sess().codemap();
             let outer = cm.lookup_char_pos(self.where_outer.lo);
             let inner = cm.lookup_char_pos(self.where_inner.lo);
@@ -726,7 +725,7 @@ impl Clean<Type> for ast::Ty {
     fn clean(&self) -> Type {
         use syntax::ast::*;
         debug!("cleaning type `{:?}`", self);
-        let ctxt = local_data::get(super::ctxtkey, |x| *x.unwrap());
+        let ctxt = super::ctxtkey.get().unwrap();
         let codemap = ctxt.sess().codemap();
         debug!("span corresponds to `{}`", codemap.span_to_str(self.span));
         match self.node {
@@ -909,7 +908,7 @@ pub struct Span {
 
 impl Clean<Span> for syntax::codemap::Span {
     fn clean(&self) -> Span {
-        let ctxt = local_data::get(super::ctxtkey, |x| *x.unwrap());
+        let ctxt = super::ctxtkey.get().unwrap();
         let cm = ctxt.sess().codemap();
         let filename = cm.span_to_filename(*self);
         let lo = cm.lookup_char_pos(self.lo);
@@ -1237,7 +1236,7 @@ trait ToSource {
 impl ToSource for syntax::codemap::Span {
     fn to_src(&self) -> ~str {
         debug!("converting span {:?} to snippet", self.clean());
-        let ctxt = local_data::get(super::ctxtkey, |x| x.unwrap().clone());
+        let ctxt = super::ctxtkey.get().unwrap();
         let cm = ctxt.sess().codemap().clone();
         let sn = match cm.span_to_snippet(*self) {
             Some(x) => x,
@@ -1292,7 +1291,7 @@ fn name_from_pat(p: &ast::Pat) -> ~str {
 /// Given a Type, resolve it using the def_map
 fn resolve_type(path: Path, tpbs: Option<Vec<TyParamBound> >,
                 id: ast::NodeId) -> Type {
-    let cx = local_data::get(super::ctxtkey, |x| *x.unwrap());
+    let cx = super::ctxtkey.get().unwrap();
     let tycx = match cx.maybe_typed {
         core::Typed(ref tycx) => tycx,
         // If we're extracting tests, this return value doesn't matter.
@@ -1351,7 +1350,7 @@ fn resolve_use_source(path: Path, id: ast::NodeId) -> ImportSource {
 }
 
 fn resolve_def(id: ast::NodeId) -> Option<ast::DefId> {
-    let cx = local_data::get(super::ctxtkey, |x| *x.unwrap());
+    let cx = super::ctxtkey.get().unwrap();
     match cx.maybe_typed {
         core::Typed(ref tcx) => {
             tcx.def_map.borrow().find(&id).map(|&d| ast_util::def_id_of_def(d))

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -20,7 +20,6 @@ use syntax;
 
 use std::cell::RefCell;
 use std::os;
-use std::local_data;
 use collections::HashSet;
 
 use visit_ast::RustdocVisitor;
@@ -109,7 +108,7 @@ pub fn run_core(libs: HashSet<Path>, cfgs: Vec<~str>, path: &Path)
                 -> (clean::Crate, CrateAnalysis) {
     let (ctxt, analysis) = get_ast_and_resolve(path, libs, cfgs);
     let ctxt = @ctxt;
-    local_data::set(super::ctxtkey, ctxt);
+    super::ctxtkey.replace(Some(ctxt));
 
     let krate = {
         let mut v = RustdocVisitor::new(ctxt, Some(&analysis));

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -28,7 +28,6 @@ extern crate time;
 extern crate log;
 extern crate libc;
 
-use std::local_data;
 use std::io;
 use std::io::{File, MemWriter};
 use std::str;
@@ -276,7 +275,7 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
                        &cr)
     }).unwrap();
     info!("finished with rustc");
-    local_data::set(analysiskey, analysis);
+    analysiskey.replace(Some(analysis));
 
     // Process all of the crate attributes, extracting plugin metadata along
     // with the passes which we are supposed to run.

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -11,7 +11,6 @@
 use collections::HashSet;
 use rustc::util::nodemap::NodeSet;
 use std::cmp;
-use std::local_data;
 use std::strbuf::StrBuf;
 use std::uint;
 use syntax::ast;
@@ -86,13 +85,11 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
 
 /// Strip private items from the point of view of a crate or externally from a
 /// crate, specified by the `xcrate` flag.
-pub fn strip_private(krate: clean::Crate) -> plugins::PluginResult {
+pub fn strip_private(mut krate: clean::Crate) -> plugins::PluginResult {
     // This stripper collects all *retained* nodes.
     let mut retained = HashSet::new();
-    let exported_items = local_data::get(super::analysiskey, |analysis| {
-        analysis.unwrap().exported_items.clone()
-    });
-    let mut krate = krate;
+    let analysis = super::analysiskey.get().unwrap();
+    let exported_items = analysis.exported_items.clone();
 
     // strip all private items
     {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -12,7 +12,6 @@ use std::cell::RefCell;
 use std::char;
 use std::io;
 use std::io::{Process, TempDir};
-use std::local_data;
 use std::os;
 use std::str;
 use std::strbuf::StrBuf;
@@ -75,7 +74,7 @@ pub fn run(input: &str,
         maybe_typed: core::NotTyped(sess),
         src: input_path,
     };
-    local_data::set(super::ctxtkey, ctx);
+    super::ctxtkey.replace(Some(ctx));
 
     let mut v = RustdocVisitor::new(ctx, None);
     v.visit(&ctx.krate);

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -23,16 +23,14 @@ named and annotated. This name is then passed to the functions in this module to
 modify/read the slot specified by the key.
 
 ```rust
-use std::local_data;
-
 local_data_key!(key_int: int)
 local_data_key!(key_vector: ~[int])
 
-local_data::set(key_int, 3);
-local_data::get(key_int, |opt| assert_eq!(opt.map(|x| *x), Some(3)));
+key_int.replace(Some(3));
+assert_eq!(*key_int.get().unwrap(), 3);
 
-local_data::set(key_vector, ~[4]);
-local_data::get(key_vector, |opt| assert_eq!(*opt.unwrap(), ~[4]));
+key_vector.replace(Some(~[4]));
+assert_eq!(*key_vector.get().unwrap(), ~[4]);
 ```
 
 */
@@ -43,9 +41,12 @@ local_data::get(key_vector, |opt| assert_eq!(*opt.unwrap(), ~[4]));
 use cast;
 use iter::{Iterator};
 use kinds::Send;
+use kinds::marker;
 use mem::replace;
+use ops::{Drop, Deref};
 use option::{None, Option, Some};
 use owned::Box;
+use raw;
 use rt::task::{Task, LocalStorage};
 use slice::{ImmutableVector, MutableVector};
 use vec::Vec;
@@ -66,7 +67,7 @@ pub type Key<T> = &'static KeyValue<T>;
 #[allow(missing_doc)]
 pub enum KeyValue<T> { Key }
 
-#[allow(missing_doc)]
+#[doc(hidden)]
 trait LocalData {}
 impl<T: 'static> LocalData for T {}
 
@@ -91,7 +92,7 @@ impl<T: 'static> LocalData for T {}
 // n.b. If TLS is used heavily in future, this could be made more efficient with
 //      a proper map.
 #[doc(hidden)]
-pub type Map = Vec<Option<(*u8, TLSValue, LoanState)>>;
+pub type Map = Vec<Option<(*u8, TLSValue, uint)>>;
 type TLSValue = Box<LocalData:Send>;
 
 // Gets the map from the runtime. Lazily initialises if not done so already.
@@ -111,243 +112,156 @@ unsafe fn get_local_map() -> &mut Map {
             *slot = Some(vec!());
             match *slot {
                 Some(ref mut map_ptr) => { return map_ptr }
-                None => abort()
+                None => unreachable!(),
             }
-        }
-    }
-}
-
-#[deriving(Eq)]
-enum LoanState {
-    NoLoan, ImmLoan, MutLoan
-}
-
-impl LoanState {
-    fn describe(&self) -> &'static str {
-        match *self {
-            NoLoan => "no loan",
-            ImmLoan => "immutable",
-            MutLoan => "mutable"
         }
     }
 }
 
 fn key_to_key_value<T: 'static>(key: Key<T>) -> *u8 {
-    unsafe { cast::transmute(key) }
+    key as *KeyValue<T> as *u8
 }
 
-/// Removes a task-local value from task-local storage. This will return
-/// Some(value) if the key was present in TLS, otherwise it will return None.
+/// An RAII immutable reference to a task-local value.
 ///
-/// A runtime assertion will be triggered it removal of TLS value is attempted
-/// while the value is still loaned out via `get` or `get_mut`.
-pub fn pop<T: 'static>(key: Key<T>) -> Option<T> {
-    let map = unsafe { get_local_map() };
-    let key_value = key_to_key_value(key);
-
-    for entry in map.mut_iter() {
-        match *entry {
-            Some((k, _, loan)) if k == key_value => {
-                if loan != NoLoan {
-                    fail!("TLS value cannot be removed because it is currently \
-                          borrowed as {}", loan.describe());
-                }
-                // Move the data out of the `entry` slot via prelude::replace.
-                // This is guaranteed to succeed because we already matched
-                // on `Some` above.
-                let data = match replace(entry, None) {
-                    Some((_, data, _)) => data,
-                    None => abort()
-                };
-
-                // Move `data` into transmute to get out the memory that it
-                // owns, we must free it manually later.
-                let (_vtable, alloc): (uint, Box<T>) = unsafe {
-                    cast::transmute(data)
-                };
-
-                // Now that we own `alloc`, we can just move out of it as we
-                // would with any other data.
-                return Some(*alloc);
-            }
-            _ => {}
-        }
-    }
-    return None;
+/// The task-local data can be accessed through this value, and when this
+/// structure is dropped it will return the borrow on the data.
+pub struct Ref<T> {
+    ptr: &'static T,
+    key: Key<T>,
+    index: uint,
+    nosend: marker::NoSend,
 }
 
-/// Retrieves a value from TLS. The closure provided is yielded `Some` of a
-/// reference to the value located in TLS if one exists, or `None` if the key
-/// provided is not present in TLS currently.
-///
-/// It is considered a runtime error to attempt to get a value which is already
-/// on loan via the `get_mut` method provided.
-pub fn get<T: 'static, U>(key: Key<T>, f: |Option<&T>| -> U) -> U {
-    get_with(key, ImmLoan, f)
-}
+impl<T: 'static> KeyValue<T> {
+    /// Replaces a value in task local storage.
+    ///
+    /// If this key is already present in TLS, then the previous value is
+    /// replaced with the provided data, and then returned.
+    ///
+    /// # Failure
+    ///
+    /// This function will fail if this key is present in TLS and currently on
+    /// loan with the `get` method.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// local_data_key!(foo: int)
+    ///
+    /// assert_eq!(foo.replace(Some(10)), None);
+    /// assert_eq!(foo.replace(Some(4)), Some(10));
+    /// assert_eq!(foo.replace(None), Some(4));
+    /// ```
+    pub fn replace(&'static self, data: Option<T>) -> Option<T> {
+        let map = unsafe { get_local_map() };
+        let keyval = key_to_key_value(self);
 
-/// Retrieves a mutable value from TLS. The closure provided is yielded `Some`
-/// of a reference to the mutable value located in TLS if one exists, or `None`
-/// if the key provided is not present in TLS currently.
-///
-/// It is considered a runtime error to attempt to get a value which is already
-/// on loan via this or the `get` methods.
-pub fn get_mut<T: 'static, U>(key: Key<T>, f: |Option<&mut T>| -> U) -> U {
-    get_with(key, MutLoan, |x| {
-        match x {
-            None => f(None),
-            // We're violating a lot of compiler guarantees with this
-            // invocation of `transmute`, but we're doing runtime checks to
-            // ensure that it's always valid (only one at a time).
-            //
-            // there is no need to be upset!
-            Some(x) => { f(Some(unsafe { cast::transmute::<&_, &mut _>(x) })) }
-        }
-    })
-}
-
-fn get_with<T:'static,
-            U>(
-            key: Key<T>,
-            state: LoanState,
-            f: |Option<&T>| -> U)
-            -> U {
-    // This function must be extremely careful. Because TLS can store owned
-    // values, and we must have some form of `get` function other than `pop`,
-    // this function has to give a `&` reference back to the caller.
-    //
-    // One option is to return the reference, but this cannot be sound because
-    // the actual lifetime of the object is not known. The slot in TLS could not
-    // be modified until the object goes out of scope, but the TLS code cannot
-    // know when this happens.
-    //
-    // For this reason, the reference is yielded to a specified closure. This
-    // way the TLS code knows exactly what the lifetime of the yielded pointer
-    // is, allowing callers to acquire references to owned data. This is also
-    // sound so long as measures are taken to ensure that while a TLS slot is
-    // loaned out to a caller, it's not modified recursively.
-    let map = unsafe { get_local_map() };
-    let key_value = key_to_key_value(key);
-
-    let pos = map.iter().position(|entry| {
-        match *entry {
-            Some((k, _, _)) if k == key_value => true, _ => false
-        }
-    });
-    match pos {
-        None => { return f(None); }
-        Some(i) => {
-            let ret;
-            let mut return_loan = false;
-            match *map.get_mut(i) {
-                Some((_, ref data, ref mut loan)) => {
-                    match (state, *loan) {
-                        (_, NoLoan) => {
-                            *loan = state;
-                            return_loan = true;
-                        }
-                        (ImmLoan, ImmLoan) => {}
-                        (want, cur) => {
-                            fail!("TLS slot cannot be borrowed as {} because \
-                                    it is already borrowed as {}",
-                                  want.describe(), cur.describe());
-                        }
-                    }
-                    // data was created with `box T as Box<LocalData>`, so we
-                    // extract pointer part of the trait, (as Box<T>), and
-                    // then use compiler coercions to achieve a '&' pointer.
-                    unsafe {
-                        match *cast::transmute::<&TLSValue,
-                                                 &(uint, Box<T>)>(data){
-                            (_vtable, ref alloc) => {
-                                let value: &T = *alloc;
-                                ret = f(Some(value));
-                            }
-                        }
-                    }
-                }
-                _ => abort()
-            }
-
-            // n.b. 'data' and 'loans' are both invalid pointers at the point
-            // 'f' returned because `f` could have appended more TLS items which
-            // in turn relocated the vector. Hence we do another lookup here to
-            // fixup the loans.
-            if return_loan {
-                match *map.get_mut(i) {
-                    Some((_, _, ref mut loan)) => { *loan = NoLoan; }
-                    None => abort()
-                }
-            }
-            return ret;
-        }
-    }
-}
-
-fn abort() -> ! {
-    use intrinsics;
-    unsafe { intrinsics::abort() }
-}
-
-/// Inserts a value into task local storage. If the key is already present in
-/// TLS, then the previous value is removed and replaced with the provided data.
-///
-/// It is considered a runtime error to attempt to set a key which is currently
-/// on loan via the `get` or `get_mut` methods.
-pub fn set<T: 'static>(key: Key<T>, data: T) {
-    let map = unsafe { get_local_map() };
-    let keyval = key_to_key_value(key);
-
-    // When the task-local map is destroyed, all the data needs to be cleaned
-    // up. For this reason we can't do some clever tricks to store 'Box<T>' as
-    // a '*c_void' or something like that. To solve the problem, we cast
-    // everything to a trait (LocalData) which is then stored inside the map.
-    // Upon destruction of the map, all the objects will be destroyed and the
-    // traits have enough information about them to destroy themselves.
-    let data = box data as Box<LocalData:>;
-
-    fn insertion_position(map: &mut Map,
-                          key: *u8) -> Option<uint> {
-        // First see if the map contains this key already
-        let curspot = map.iter().position(|entry| {
-            match *entry {
-                Some((ekey, _, loan)) if key == ekey => {
-                    if loan != NoLoan {
-                        fail!("TLS value cannot be overwritten because it is
-                               already borrowed as {}", loan.describe())
-                    }
-                    true
-                }
-                _ => false,
-            }
+        // When the task-local map is destroyed, all the data needs to be
+        // cleaned up. For this reason we can't do some clever tricks to store
+        // '~T' as a '*c_void' or something like that. To solve the problem, we
+        // cast everything to a trait (LocalData) which is then stored inside
+        // the map.  Upon destruction of the map, all the objects will be
+        // destroyed and the traits have enough information about them to
+        // destroy themselves.
+        //
+        // Additionally, the type of the local data map must ascribe to Send, so
+        // we do the transmute here to add the Send bound back on. This doesn't
+        // actually matter because TLS will always own the data (until its moved
+        // out) and we're not actually sending it to other schedulers or
+        // anything.
+        let newval = data.map(|d| {
+            let d = box d as Box<LocalData>;
+            let d: Box<LocalData:Send> = unsafe { cast::transmute(d) };
+            (keyval, d, 0)
         });
-        // If it doesn't contain the key, just find a slot that's None
-        match curspot {
-            Some(i) => Some(i),
-            None => map.iter().position(|entry| entry.is_none())
+
+        let pos = match self.find(map) {
+            Some((i, _, &0)) => Some(i),
+            Some((_, _, _)) => fail!("TLS value cannot be replaced because it \
+                                      is already borrowed"),
+            None => map.iter().position(|entry| entry.is_none()),
+        };
+
+        match pos {
+            Some(i) => {
+                replace(map.get_mut(i), newval).map(|(_, data, _)| {
+                    // Move `data` into transmute to get out the memory that it
+                    // owns, we must free it manually later.
+                    let t: raw::TraitObject = unsafe { cast::transmute(data) };
+                    let alloc: Box<T> = unsafe { cast::transmute(t.data) };
+
+                    // Now that we own `alloc`, we can just move out of it as we
+                    // would with any other data.
+                    *alloc
+                })
+            }
+            None => {
+                map.push(newval);
+                None
+            }
         }
     }
 
-    // The type of the local data map must ascribe to Send, so we do the
-    // transmute here to add the Send bound back on. This doesn't actually
-    // matter because TLS will always own the data (until its moved out) and
-    // we're not actually sending it to other schedulers or anything.
-    let data: Box<LocalData:Send> = unsafe { cast::transmute(data) };
-    match insertion_position(map, keyval) {
-        Some(i) => { *map.get_mut(i) = Some((keyval, data, NoLoan)); }
-        None => { map.push(Some((keyval, data, NoLoan))); }
+    /// Borrows a value from TLS.
+    ///
+    /// If `None` is returned, then this key is not present in TLS. If `Some` is
+    /// returned, then the returned data is a smart pointer representing a new
+    /// loan on this TLS key. While on loan, this key cannot be altered via the
+    /// `replace` method.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// local_data_key!(key: int)
+    ///
+    /// assert!(key.get().is_none());
+    ///
+    /// key.replace(Some(3));
+    /// assert_eq!(*key.get().unwrap(), 3);
+    /// ```
+    pub fn get(&'static self) -> Option<Ref<T>> {
+        let map = unsafe { get_local_map() };
+
+        self.find(map).map(|(pos, data, loan)| {
+            *loan += 1;
+
+            // data was created with `~T as ~LocalData`, so we extract
+            // pointer part of the trait, (as ~T), and then use
+            // compiler coercions to achieve a '&' pointer.
+            let ptr = unsafe {
+                let data = data as *Box<LocalData:Send> as *raw::TraitObject;
+                &mut *((*data).data as *mut T)
+            };
+            Ref { ptr: ptr, index: pos, nosend: marker::NoSend, key: self }
+        })
+    }
+
+    fn find<'a>(&'static self,
+                map: &'a mut Map) -> Option<(uint, &'a TLSValue, &'a mut uint)>{
+        let key_value = key_to_key_value(self);
+        map.mut_iter().enumerate().filter_map(|(i, entry)| {
+            match *entry {
+                Some((k, ref data, ref mut loan)) if k == key_value => {
+                    Some((i, data, loan))
+                }
+                _ => None
+            }
+        }).next()
     }
 }
 
-/// Modifies a task-local value by temporarily removing it from task-local
-/// storage and then re-inserting if `Some` is returned from the closure.
-///
-/// This function will have the same runtime errors as generated from `pop` and
-/// `set` (the key must not currently be on loan
-pub fn modify<T: 'static>(key: Key<T>, f: |Option<T>| -> Option<T>) {
-    match f(pop(key)) {
-        Some(next) => { set(key, next); }
-        None => {}
+impl<T: 'static> Deref<T> for Ref<T> {
+    fn deref<'a>(&'a self) -> &'a T { self.ptr }
+}
+
+#[unsafe_destructor]
+impl<T: 'static> Drop for Ref<T> {
+    fn drop(&mut self) {
+        let map = unsafe { get_local_map() };
+
+        let (_, _, ref mut loan) = *map.get_mut(self.index).get_mut_ref();
+        *loan -= 1;
     }
 }
 
@@ -362,55 +276,36 @@ mod tests {
     #[test]
     fn test_tls_multitask() {
         static my_key: Key<~str> = &Key;
-        set(my_key, "parent data".to_owned());
+        my_key.replace(Some("parent data".to_owned()));
         task::spawn(proc() {
             // TLS shouldn't carry over.
-            assert!(get(my_key, |k| k.map(|k| (*k).clone())).is_none());
-            set(my_key, "child data".to_owned());
-            assert!(get(my_key, |k| k.map(|k| (*k).clone())).unwrap() ==
-                    "child data".to_owned());
+            assert!(my_key.get().is_none());
+            my_key.replace(Some("child data".to_owned()));
+            assert!(my_key.get().get_ref().as_slice() == "child data");
             // should be cleaned up for us
         });
+
         // Must work multiple times
-        assert!(get(my_key, |k| k.map(|k| (*k).clone())).unwrap() == "parent data".to_owned());
-        assert!(get(my_key, |k| k.map(|k| (*k).clone())).unwrap() == "parent data".to_owned());
-        assert!(get(my_key, |k| k.map(|k| (*k).clone())).unwrap() == "parent data".to_owned());
+        assert!(my_key.get().unwrap().as_slice() == "parent data");
+        assert!(my_key.get().unwrap().as_slice() == "parent data");
+        assert!(my_key.get().unwrap().as_slice() == "parent data");
     }
 
     #[test]
     fn test_tls_overwrite() {
         static my_key: Key<~str> = &Key;
-        set(my_key, "first data".to_owned());
-        set(my_key, "next data".to_owned()); // Shouldn't leak.
-        assert!(get(my_key, |k| k.map(|k| (*k).clone())).unwrap() == "next data".to_owned());
+        my_key.replace(Some("first data".to_owned()));
+        my_key.replace(Some("next data".to_owned())); // Shouldn't leak.
+        assert!(my_key.get().unwrap().as_slice() == "next data");
     }
 
     #[test]
     fn test_tls_pop() {
         static my_key: Key<~str> = &Key;
-        set(my_key, "weasel".to_owned());
-        assert!(pop(my_key).unwrap() == "weasel".to_owned());
+        my_key.replace(Some("weasel".to_owned()));
+        assert!(my_key.replace(None).unwrap() == "weasel".to_owned());
         // Pop must remove the data from the map.
-        assert!(pop(my_key).is_none());
-    }
-
-    #[test]
-    fn test_tls_modify() {
-        static my_key: Key<~str> = &Key;
-        modify(my_key, |data| {
-            match data {
-                Some(ref val) => fail!("unwelcome value: {}", *val),
-                None           => Some("first data".to_owned())
-            }
-        });
-        modify(my_key, |data| {
-            match data.as_ref().map(|s| s.as_slice()) {
-                Some("first data") => Some("next data".to_owned()),
-                Some(ref val)       => fail!("wrong value: {}", *val),
-                None                 => fail!("missing value")
-            }
-        });
-        assert!(pop(my_key).unwrap() == "next data".to_owned());
+        assert!(my_key.replace(None).is_none());
     }
 
     #[test]
@@ -423,7 +318,7 @@ mod tests {
         // a stack smaller than 1 MB.
         static my_key: Key<~str> = &Key;
         task::spawn(proc() {
-            set(my_key, "hax".to_owned());
+            my_key.replace(Some("hax".to_owned()));
         });
     }
 
@@ -433,28 +328,27 @@ mod tests {
         static box_key: Key<@()> = &Key;
         static int_key: Key<int> = &Key;
         task::spawn(proc() {
-            set(str_key, "string data".to_owned());
-            set(box_key, @());
-            set(int_key, 42);
+            str_key.replace(Some("string data".to_owned()));
+            box_key.replace(Some(@()));
+            int_key.replace(Some(42));
         });
     }
 
     #[test]
-    #[allow(dead_code)]
     fn test_tls_overwrite_multiple_types() {
         static str_key: Key<~str> = &Key;
         static box_key: Key<@()> = &Key;
         static int_key: Key<int> = &Key;
         task::spawn(proc() {
-            set(str_key, "string data".to_owned());
-            set(str_key, "string data 2".to_owned());
-            set(box_key, @());
-            set(box_key, @());
-            set(int_key, 42);
+            str_key.replace(Some("string data".to_owned()));
+            str_key.replace(Some("string data 2".to_owned()));
+            box_key.replace(Some(@()));
+            box_key.replace(Some(@()));
+            int_key.replace(Some(42));
             // This could cause a segfault if overwriting-destruction is done
             // with the crazy polymorphic transmute rather than the provided
             // finaliser.
-            set(int_key, 31337);
+            int_key.replace(Some(31337));
         });
     }
 
@@ -464,17 +358,16 @@ mod tests {
         static str_key: Key<~str> = &Key;
         static box_key: Key<@()> = &Key;
         static int_key: Key<int> = &Key;
-        set(str_key, "parent data".to_owned());
-        set(box_key, @());
+        str_key.replace(Some("parent data".to_owned()));
+        box_key.replace(Some(@()));
         task::spawn(proc() {
-            // spawn_linked
-            set(str_key, "string data".to_owned());
-            set(box_key, @());
-            set(int_key, 42);
+            str_key.replace(Some("string data".to_owned()));
+            box_key.replace(Some(@()));
+            int_key.replace(Some(42));
             fail!();
         });
         // Not quite nondeterministic.
-        set(int_key, 31337);
+        int_key.replace(Some(31337));
         fail!();
     }
 
@@ -482,42 +375,24 @@ mod tests {
     fn test_static_pointer() {
         static key: Key<&'static int> = &Key;
         static VALUE: int = 0;
-        let v: &'static int = &VALUE;
-        set(key, v);
+        key.replace(Some(&VALUE));
     }
 
     #[test]
     fn test_owned() {
         static key: Key<Box<int>> = &Key;
-        set(key, box 1);
+        key.replace(Some(box 1));
 
-        get(key, |v| {
-            get(key, |v| {
-                get(key, |v| {
-                    assert_eq!(**v.unwrap(), 1);
-                });
-                assert_eq!(**v.unwrap(), 1);
-            });
-            assert_eq!(**v.unwrap(), 1);
-        });
-        set(key, box 2);
-        get(key, |v| {
-            assert_eq!(**v.unwrap(), 2);
-        })
-    }
-
-    #[test]
-    fn test_get_mut() {
-        static key: Key<int> = &Key;
-        set(key, 1);
-
-        get_mut(key, |v| {
-            *v.unwrap() = 2;
-        });
-
-        get(key, |v| {
-            assert_eq!(*v.unwrap(), 2);
-        })
+        {
+            let k1 = key.get().unwrap();
+            let k2 = key.get().unwrap();
+            let k3 = key.get().unwrap();
+            assert_eq!(**k1, 1);
+            assert_eq!(**k2, 1);
+            assert_eq!(**k3, 1);
+        }
+        key.replace(Some(box 2));
+        assert_eq!(**key.get().unwrap(), 2);
     }
 
     #[test]
@@ -527,56 +402,26 @@ mod tests {
         static key3: Key<int> = &Key;
         static key4: Key<int> = &Key;
         static key5: Key<int> = &Key;
-        set(key1, 1);
-        set(key2, 2);
-        set(key3, 3);
-        set(key4, 4);
-        set(key5, 5);
+        key1.replace(Some(1));
+        key2.replace(Some(2));
+        key3.replace(Some(3));
+        key4.replace(Some(4));
+        key5.replace(Some(5));
 
-        get(key1, |x| assert_eq!(*x.unwrap(), 1));
-        get(key2, |x| assert_eq!(*x.unwrap(), 2));
-        get(key3, |x| assert_eq!(*x.unwrap(), 3));
-        get(key4, |x| assert_eq!(*x.unwrap(), 4));
-        get(key5, |x| assert_eq!(*x.unwrap(), 5));
+        assert_eq!(*key1.get().unwrap(), 1);
+        assert_eq!(*key2.get().unwrap(), 2);
+        assert_eq!(*key3.get().unwrap(), 3);
+        assert_eq!(*key4.get().unwrap(), 4);
+        assert_eq!(*key5.get().unwrap(), 5);
     }
 
     #[test]
     #[should_fail]
     fn test_nested_get_set1() {
         static key: Key<int> = &Key;
-        set(key, 4);
-        get(key, |_| {
-            set(key, 4);
-        })
-    }
+        key.replace(Some(4));
 
-    #[test]
-    #[should_fail]
-    fn test_nested_get_mut2() {
-        static key: Key<int> = &Key;
-        set(key, 4);
-        get(key, |_| {
-            get_mut(key, |_| {})
-        })
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_nested_get_mut3() {
-        static key: Key<int> = &Key;
-        set(key, 4);
-        get_mut(key, |_| {
-            get(key, |_| {})
-        })
-    }
-
-    #[test]
-    #[should_fail]
-    fn test_nested_get_mut4() {
-        static key: Key<int> = &Key;
-        set(key, 4);
-        get_mut(key, |_| {
-            get_mut(key, |_| {})
-        })
+        let _k = key.get();
+        key.replace(Some(4));
     }
 }

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -289,12 +289,10 @@ macro_rules! println(
 /// # Example
 ///
 /// ```
-/// use std::local_data;
-///
 /// local_data_key!(my_integer: int)
 ///
-/// local_data::set(my_integer, 2);
-/// local_data::get(my_integer, |val| println!("{}", val.map(|i| *i)));
+/// my_integer.replace(Some(2));
+/// println!("{}", my_integer.get().map(|a| *a));
 /// ```
 #[macro_export]
 macro_rules! local_data_key(

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -414,13 +414,12 @@ mod test {
 
     #[test]
     fn tls() {
-        use local_data;
         local_data_key!(key: @~str)
-        local_data::set(key, @"data".to_owned());
-        assert!(*local_data::get(key, |k| k.map(|k| *k)).unwrap() == "data".to_owned());
+        key.replace(Some(@"data".to_owned()));
+        assert_eq!(key.get().unwrap().as_slice(), "data");
         local_data_key!(key2: @~str)
-        local_data::set(key2, @"data".to_owned());
-        assert!(*local_data::get(key2, |k| k.map(|k| *k)).unwrap() == "data".to_owned());
+        key2.replace(Some(@"data".to_owned()));
+        assert_eq!(key2.get().unwrap().as_slice(), "data");
     }
 
     #[test]

--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -3112,7 +3112,6 @@ mod tests {
     #[test]
     #[should_fail]
     fn test_from_elem_fail() {
-        use cast;
         use cell::Cell;
         use rc::Rc;
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -19,7 +19,6 @@ use util::interner;
 use serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::cast;
 use std::fmt;
-use std::local_data;
 use std::path::BytesContainer;
 use std::rc::Rc;
 use std::strbuf::StrBuf;
@@ -529,11 +528,11 @@ pub type IdentInterner = StrInterner;
 // FIXME(eddyb) #8726 This should probably use a task-local reference.
 pub fn get_ident_interner() -> Rc<IdentInterner> {
     local_data_key!(key: Rc<::parse::token::IdentInterner>)
-    match local_data::get(key, |k| k.map(|k| k.clone())) {
-        Some(interner) => interner,
+    match key.get() {
+        Some(interner) => interner.clone(),
         None => {
             let interner = Rc::new(mk_fresh_ident_interner());
-            local_data::set(key, interner.clone());
+            key.replace(Some(interner.clone()));
             interner
         }
     }

--- a/src/test/auxiliary/macro_crate_outlive_expansion_phase.rs
+++ b/src/test/auxiliary/macro_crate_outlive_expansion_phase.rs
@@ -15,7 +15,6 @@
 extern crate syntax;
 
 use std::any::Any;
-use std::local_data;
 use syntax::ast::Name;
 use syntax::ext::base::SyntaxExtension;
 
@@ -30,6 +29,6 @@ impl Drop for Foo {
 #[macro_registrar]
 pub fn registrar(_: |Name, SyntaxExtension|) {
     local_data_key!(foo: Box<Any:Send>);
-    local_data::set(foo, box Foo { foo: 10 } as Box<Any:Send>);
+    foo.replace(Some(box Foo { foo: 10 } as Box<Any:Send>));
 }
 

--- a/src/test/compile-fail/core-tls-store-pointer.rs
+++ b/src/test/compile-fail/core-tls-store-pointer.rs
@@ -10,8 +10,6 @@
 
 // Testing that we can't store a reference it task-local storage
 
-use std::local_data;
-
 local_data_key!(key: @&int)
 //~^ ERROR missing lifetime specifier
 

--- a/src/test/compile-fail/macro-local-data-key-priv.rs
+++ b/src/test/compile-fail/macro-local-data-key-priv.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::local_data;
-
 // check that the local data keys are private by default.
 
 mod bar {
@@ -17,6 +15,6 @@ mod bar {
 }
 
 fn main() {
-    local_data::set(bar::baz, -10.0);
+    bar::baz.replace(Some(-10.0));
     //~^ ERROR static `baz` is private
 }

--- a/src/test/run-pass/macro-local-data-key.rs
+++ b/src/test/run-pass/macro-local-data-key.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::local_data;
-
 local_data_key!(foo: int)
 
 mod bar {
@@ -17,12 +15,12 @@ mod bar {
 }
 
 pub fn main() {
-    local_data::get(foo, |x| assert!(x.is_none()));
-    local_data::get(bar::baz, |y| assert!(y.is_none()));
+    assert!(foo.get().is_none());
+    assert!(bar::baz.get().is_none());
 
-    local_data::set(foo, 3);
-    local_data::set(bar::baz, -10.0);
+    foo.replace(Some(3));
+    bar::baz.replace(Some(-10.0));
 
-    local_data::get(foo, |x| assert_eq!(*x.unwrap(), 3));
-    local_data::get(bar::baz, |y| assert_eq!(*y.unwrap(), -10.0));
+    assert_eq!(*foo.get().unwrap(), 3);
+    assert_eq!(*bar::baz.get().unwrap(), -10.0);
 }


### PR DESCRIPTION
This commit brings the local_data api up to modern rust standards with a few key
improvements:
- All functionality is now exposed as a method on the keys themselves. Instead
  of importing std::local_data, you now use "key.set()" and "key.get()".
- All closures have been removed in favor of RAII functionality. This means that
  get() and get_mut() no long require closures, but rather return
  Option<SmartPointer> where the smart pointer takes care of relinquishing the
  borrow and also implements the necessary Deref traits
- The modify() function was removed to cut the local_data interface down to its
  bare essentials (similarly to how RefCell removed set/get).

[breaking-change]
