### PR TITLE
mk: Depend on regex_macros for tests appropriately

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -349,6 +349,16 @@ TESTDEP_$(1)_$(2)_$(3)_$(4) = $$(SREQ$(1)_T_$(2)_H_$(3)) \
 			    $$(foreach crate,$$(TARGET_CRATES),\
 				$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(crate)) \
 				$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4))
+
+# The regex crate depends on the regex_macros crate during testing, but it
+# notably depend on the *host* regex_macros crate, not the target version.
+# Additionally, this is not a dependency in stage1, only in stage2.
+ifeq ($(4),regex)
+ifneq ($(1),1)
+TESTDEP_$(1)_$(2)_$(3)_$(4) += $$(TLIB$(1)_T_$(3)_H_$(3))/stamp.regex_macros
+endif
+endif
+
 else
 TESTDEP_$(1)_$(2)_$(3)_$(4) = $$(RSINPUTS_$(4))
 endif


### PR DESCRIPTION
There is currently not much precedent for target crates requiring syntax
extensions to compile their test versions. This dependency is possible, but
can't be encoded through the normal means of DEPS_regex because it is a
test-only dependency and it must be a _host_ dependency (it's a syntax
extension).

Closes #13844
