### PR TITLE
rustc: Add search paths to dylib load paths

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -231,7 +231,7 @@ pub use funcs::bsd43::{shutdown};
 #[cfg(windows)] pub use types::os::arch::extra::{HANDLE, BOOL, LPSECURITY_ATTRIBUTES};
 #[cfg(windows)] pub use types::os::arch::extra::{LPCSTR, WORD, DWORD, BYTE, FILETIME};
 #[cfg(windows)] pub use types::os::arch::extra::{LARGE_INTEGER, LPVOID, LONG};
-#[cfg(windows)] pub use types::os::arch::extra::{time64_t, OVERLAPPED};
+#[cfg(windows)] pub use types::os::arch::extra::{time64_t, OVERLAPPED, LPCWSTR};
 #[cfg(windows)] pub use types::os::arch::extra::{LPOVERLAPPED, SIZE_T, LPDWORD};
 #[cfg(windows)] pub use funcs::c95::string::{wcslen};
 #[cfg(windows)] pub use funcs::posix88::stat_::{wstat, wutime, wchmod, wrmdir};

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -232,6 +232,14 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                  front::config::strip_unconfigured_items(krate));
 
     krate = time(time_passes, "expansion", krate, |krate| {
+        // Windows dlls do not have rpaths, so they don't know how to find their
+        // dependencies. It's up to use to tell the system where to find all the
+        // dependent dlls. Note that this uses cfg!(windows) as opposed to
+        // targ_cfg because syntax extensions are always loaded for the host
+        // compiler, not for the target.
+        if cfg!(windows) {
+            sess.host_filesearch().add_dylib_search_paths();
+        }
         let cfg = syntax::ext::expand::ExpansionConfig {
             loader: loader,
             deriving_hash_type_parameter: sess.features.default_type_params.get(),

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -13,6 +13,7 @@
 use std::cell::RefCell;
 use std::os;
 use std::io::fs;
+use std::unstable::dynamic_lib::DynamicLibrary;
 use collections::HashSet;
 
 use myfs = util::fs;
@@ -131,6 +132,13 @@ impl<'a> FileSearch<'a> {
             addl_lib_search_paths: addl_lib_search_paths,
             triple: triple,
         }
+    }
+
+    pub fn add_dylib_search_paths(&self) {
+        self.for_each_lib_search_path(|lib_search_path| {
+            DynamicLibrary::add_search_path(lib_search_path);
+            FileDoesntMatch
+        })
     }
 }
 

--- a/src/test/auxiliary/syntax-extension-with-dll-deps-1.rs
+++ b/src/test/auxiliary/syntax-extension-with-dll-deps-1.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// force-host
+
+#![crate_type = "dylib"]
+
+pub fn the_answer() -> int {
+    2
+}

--- a/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
+++ b/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
@@ -1,0 +1,38 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "dylib"]
+#![feature(macro_registrar, quote, globs)]
+
+extern crate other = "syntax-extension-with-dll-deps-1";
+extern crate syntax;
+
+use syntax::ast::{Name, TokenTree, Item, MetaItem};
+use syntax::codemap::Span;
+use syntax::ext::base::*;
+use syntax::parse::token;
+
+#[macro_registrar]
+pub fn macro_registrar(register: |Name, SyntaxExtension|) {
+    register(token::intern("foo"),
+        NormalTT(~BasicMacroExpander {
+            expander: expand_foo,
+            span: None,
+        },
+        None));
+}
+
+fn expand_foo(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> ~MacResult {
+    let answer = other::the_answer();
+    MacExpr::new(quote_expr!(cx, $answer))
+}

--- a/src/test/run-pass-fulldeps/syntax-extension-with-dll-deps.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-with-dll-deps.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:syntax-extension-with-dll-deps-1.rs
+// aux-build:syntax-extension-with-dll-deps-2.rs
+// ignore-stage1
+
+#![feature(phase)]
+
+#[phase(syntax)]
+extern crate extension = "syntax-extension-with-dll-deps-2";
+
+fn main() {
+    foo!();
+}


### PR DESCRIPTION
When a syntax extension is loaded by the compiler, the dylib that is opened may
have other dylibs that it depends on. The dynamic linker must be able to find
these libraries on the system or else the library will fail to load.

Currently, unix gets by with the use of rpaths. This relies on the dylib not
moving around too drastically relative to its dependencies. For windows,
however, this is no rpath available, and in theory unix should work without
rpaths as well.

This modifies the compiler to add all -L search directories to the dynamic
linker's set of load paths. This is currently managed through environment
variables for each platform.

Closes #13848
