### PR TITLE
Add num_variants intrinsic for enums and safe wrapper in std::reflect.

### DIFF
--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -323,6 +323,17 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_pref(ccx, lltp_ty) as uint));
         }
+        "num_variants" => {
+            let tp_ty = *substs.tys.get(0);
+            let ref sty = ty::get(tp_ty).sty;
+            let num_variants = match *sty {
+                ty::ty_enum(did, _) => {
+                    ty::enum_variants(ccx.tcx(), did).len()
+                }
+                _ => 0
+            };
+            Ret(bcx, C_uint(ccx, num_variants));
+        }
         "get_tydesc" => {
             let tp_ty = *substs.tys.get(0);
             let static_ti = get_tydesc(ccx, tp_ty);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -4139,6 +4139,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
             }
             "needs_drop" => (1u, Vec::new(), ty::mk_bool()),
             "owns_managed" => (1u, Vec::new(), ty::mk_bool()),
+            "num_variants" => (1u, Vec::new(), ty::mk_uint()),
 
             "get_tydesc" => {
               let tydesc_ty = match ty::get_tydesc_ty(ccx.tcx) {

--- a/src/libstd/intrinsics.rs
+++ b/src/libstd/intrinsics.rs
@@ -280,6 +280,10 @@ extern "rust-intrinsic" {
     pub fn min_align_of<T>() -> uint;
     pub fn pref_align_of<T>() -> uint;
 
+    /// Gets the number of variants in an enum
+    #[cfg(not(stage0))]
+    pub fn num_variants<T>() -> uint;
+
     /// Get a static pointer to a type descriptor.
     pub fn get_tydesc<T>() -> *TyDesc;
 

--- a/src/libstd/reflect.rs
+++ b/src/libstd/reflect.rs
@@ -37,6 +37,14 @@ pub fn align(size: uint, align: uint) -> uint {
     ((size + align) - 1u) & !(align - 1u)
 }
 
+/// Get the number of variants in an enum
+#[cfg(not(stage0))]
+#[inline]
+pub fn num_variants<T>() -> uint {
+    use intrinsics::num_variants;
+    unsafe { num_variants::<T>() }
+}
+
 /// Adaptor to wrap around visitors implementing MovePtr.
 pub struct MovePtrAdaptor<V> {
     inner: V


### PR DESCRIPTION
This adds an intrinsic to query the number of variants in an enum, along with a safe wrapper for it in std::reflect:

``` rust
use std::reflect::num_variants;

enum Shape {
    Triangle,
    Square,
    Circle,
}

fn main() {
    let num_shapes: uint = num_variants::<Shape>();
    println!("{}", num_shapes); // prints 3
}
```

If the type parameter is not an enum, the result is 0.
