### PR TITLE
Add TimeoutReceiver to allow recv()ing with a timeout

### DIFF
--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -958,8 +958,8 @@ impl<T: Send> select::Packet for Receiver<T> {
 }
 
 impl<T: Send> TimeoutReceiver<T> {
+    /// Creates a TimeoutReceiver
     pub fn new(inner: Receiver<T>, timeout: u64) -> TimeoutReceiver<T> {
-        // create a timer object
         let timer = Timer::new().unwrap();
         TimeoutReceiver { inner: inner, timer: timer, timeout: timeout }
     }

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -120,9 +120,9 @@
 //! });
 //! rx.recv();
 //! ```
-//! 
+//!
 //! Reading from a channel with a timeout:
-//! 
+//!
 //! ```
 //! let (tx, rx) = channel();
 //! let mut rx = TimeoutReceiver::new(rx, 10000);
@@ -968,7 +968,7 @@ impl<T: Send> TimeoutReceiver<T> {
     /// timeout has passed
     ///
     /// This method can not fail as opposed to the original Receiver::recv, but
-    /// it returns an Option instead of the raw value. None is returned if the 
+    /// it returns an Option instead of the raw value. None is returned if the
     /// recv timed out.
     pub fn recv(&mut self) -> Option<T> {
         let oneshot = self.timer.oneshot(self.timeout);
@@ -981,7 +981,7 @@ impl<T: Send> TimeoutReceiver<T> {
             inner_rx.add();
         }
         let ret = sel.wait();
-        if ret == inner_rx.id() { 
+        if ret == inner_rx.id() {
             return Some(inner_rx.recv());
         }
 


### PR DESCRIPTION
Not sure if this is the best way to do this, or if there is already a way that I missed, but it comes in very handy when you want to avoid blocking forever.
