### PR TITLE
rustdoc: fix overly broad selectors

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -207,9 +207,6 @@ nav.sub {
     text-overflow: ellipsis;
 }
 
-.docblock a { color: #4e8bca; }
-.docblock a:hover { text-decoration: underline; }
-
 .docblock.short p {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -291,6 +288,8 @@ a {
     color: #000;
     background: transparent;
 }
+p a { color: #4e8bca; }
+p a:hover { text-decoration: underline; }
 
 .content a.trait, .block a.current.trait { color: #ed9603; }
 .content a.mod, .block a.current.mod { color: #4d76ae; }
@@ -397,7 +396,7 @@ pre.rust .doccomment { color: #4D4D4C; }
 pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
 pre.rust .lifetime { color: #B76514; }
 
-.section-header {
+.methods .section-header {
     /* Override parent class attributes. */
     border-bottom: none !important;
     font-size: 1.1em !important;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! # The Rust prelude
+//! The Rust prelude
 //!
 //! Because `std` is required by most serious Rust software, it is
 //! imported at the topmost level of every crate by default, as if the


### PR DESCRIPTION
Two selector fixes for rustdoc:
- links colored in blue (#13807) was also affecting headers, which are anchored to their respective ids
- the header unstyling from #13776 was being applied to all headers also

Additionally, remove a stray title in the documentation. This makes the crate title of prelude appear as header instead of an inline paragraph of text (all others work normally and do not have that header tag).

The design is unchanged from my previous template (e.g. [here](http://adrientetar.legtux.org/cached/rust-docs/struct.CChars.htm)), however it is now properly applied.  
The last fix remaining is to enable webfonts service from `static.rust-lang.org`, this is #13593.

r? @alexcrichton, @brson
