### PR TITLE
native: Always open a file with Open/Write modes

### DIFF
--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -274,7 +274,7 @@ pub fn open(path: &CString, fm: io::FileMode, fa: io::FileAccess)
         (io::Truncate, io::Read) => libc::TRUNCATE_EXISTING,
         (io::Truncate, _) => libc::CREATE_ALWAYS,
         (io::Open, io::Read) => libc::OPEN_EXISTING,
-        (io::Open, _) => libc::CREATE_NEW,
+        (io::Open, _) => libc::OPEN_ALWAYS,
         (io::Append, io::Read) => {
             dwDesiredAccess |= libc::FILE_APPEND_DATA;
             libc::OPEN_EXISTING

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1255,11 +1255,31 @@ mod test {
         match File::open_mode(&tmpdir.join("a"), io::Open, io::Read) {
             Ok(..) => fail!(), Err(..) => {}
         }
+
+        // Perform each one twice to make sure that it succeeds the second time
+        // (where the file exists)
         check!(File::open_mode(&tmpdir.join("b"), io::Open, io::Write));
+        assert!(tmpdir.join("b").exists());
+        check!(File::open_mode(&tmpdir.join("b"), io::Open, io::Write));
+
         check!(File::open_mode(&tmpdir.join("c"), io::Open, io::ReadWrite));
+        assert!(tmpdir.join("c").exists());
+        check!(File::open_mode(&tmpdir.join("c"), io::Open, io::ReadWrite));
+
         check!(File::open_mode(&tmpdir.join("d"), io::Append, io::Write));
+        assert!(tmpdir.join("d").exists());
+        check!(File::open_mode(&tmpdir.join("d"), io::Append, io::Write));
+
         check!(File::open_mode(&tmpdir.join("e"), io::Append, io::ReadWrite));
+        assert!(tmpdir.join("e").exists());
+        check!(File::open_mode(&tmpdir.join("e"), io::Append, io::ReadWrite));
+
         check!(File::open_mode(&tmpdir.join("f"), io::Truncate, io::Write));
+        assert!(tmpdir.join("f").exists());
+        check!(File::open_mode(&tmpdir.join("f"), io::Truncate, io::Write));
+
+        check!(File::open_mode(&tmpdir.join("g"), io::Truncate, io::ReadWrite));
+        assert!(tmpdir.join("g").exists());
         check!(File::open_mode(&tmpdir.join("g"), io::Truncate, io::ReadWrite));
 
         check!(File::create(&tmpdir.join("h")).write("foo".as_bytes()));


### PR DESCRIPTION
Previously, windows was using the CREATE_NEW flag which fails if the file
previously existed, which differed from the unix semantics. This alters the
opening to use the OPEN_ALWAYS flag to mirror the unix semantics.

Closes #13861
