### PR TITLE
librustc: Remove `~"string"` and `&"string"` from the language

### DIFF
--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -220,7 +220,9 @@ impl<'a> Parser<'a> {
                         try!(self.parse_group_opts())
                     } else {
                         self.caps += 1;
-                        self.stack.push(Paren(self.flags, self.caps, ~""))
+                        self.stack.push(Paren(self.flags,
+                                              self.caps,
+                                              "".to_owned()))
                     }
                 }
                 ')' => {
@@ -769,7 +771,7 @@ impl<'a> Parser<'a> {
                     }
                     if self.cur() == ':' {
                         // Save the old flags with the opening paren.
-                        self.stack.push(Paren(self.flags, 0, ~""));
+                        self.stack.push(Paren(self.flags, 0, "".to_owned()));
                     }
                     self.flags = flags;
                     return Ok(())

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1070,16 +1070,16 @@ pub fn build_session_(sopts: session::Options,
 
 pub fn parse_pretty(sess: &Session, name: &str) -> PpMode {
     match name {
-      &"normal" => PpmNormal,
-      &"expanded" => PpmExpanded,
-      &"typed" => PpmTyped,
-      &"expanded,identified" => PpmExpandedIdentified,
-      &"identified" => PpmIdentified,
-      _ => {
-        sess.fatal("argument to `pretty` must be one of `normal`, \
-                    `expanded`, `typed`, `identified`, \
-                    or `expanded,identified`");
-      }
+        "normal" => PpmNormal,
+        "expanded" => PpmExpanded,
+        "typed" => PpmTyped,
+        "expanded,identified" => PpmExpandedIdentified,
+        "identified" => PpmIdentified,
+        _ => {
+            sess.fatal("argument to `pretty` must be one of `normal`, \
+                        `expanded`, `typed`, `identified`, \
+                        or `expanded,identified`");
+        }
     }
 }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -300,7 +300,7 @@ pub fn run_compiler(args: &[~str]) {
         None::<d::PpMode> => {/* continue */ }
     }
 
-    if r.contains(&~"ls") {
+    if r.contains(&("ls".to_owned())) {
         match input {
             d::FileInput(ref ifile) => {
                 let mut stdout = io::stdout();

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1036,7 +1036,7 @@ fn check_crate_attrs_usage(cx: &Context, attrs: &[ast::Attribute]) {
         if !iter.any(|other_attr| { name.equiv(other_attr) }) {
             cx.span_lint(AttributeUsage, attr.span, "unknown crate attribute");
         }
-        if name.equiv(& &"link") {
+        if name.equiv(&("link")) {
             cx.tcx.sess.span_err(attr.span,
                                  "obsolete crate `link` attribute");
             cx.tcx.sess.note("the link attribute has been superceded by the crate_id \

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -189,9 +189,9 @@ impl<'a, 'b> Reflector<'a, 'b> {
           ty::ty_rptr(_, ref mt) => {
               match ty::get(mt.ty).sty {
                   ty::ty_vec(ref mt, None) => {
-                      let (name, extra) = (~"slice", Vec::new());
+                      let (name, extra) = ("slice".to_owned(), Vec::new());
                       let extra = extra.append(self.c_mt(mt).as_slice());
-                      self.visit(~"evec_" + name, extra.as_slice())
+                      self.visit("evec_".to_owned() + name, extra.as_slice())
                   }
                   ty::ty_str => self.visit("estr_slice".to_owned(), &[]),
                   _ => {

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -647,8 +647,8 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
               ty::ty_vec(mt, None) => {
                   fcx.type_error_message(pat.span,
                                          |_| {
-                                          ~"unique vector patterns are no \
-                                            longer supported"
+                                            "unique vector patterns are no \
+                                             longer supported".to_owned()
                                          },
                                          expected,
                                          None);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2566,10 +2566,6 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
     match expr.node {
       ast::ExprVstore(ev, vst) => {
         let typ = match ev.node {
-          ast::ExprLit(lit) if ast_util::lit_is_str(lit) => {
-            ast_expr_vstore_to_ty(fcx, ev, vst, || ty::mt{ ty: ty::mk_str(tcx),
-                                                           mutbl: ast::MutImmutable })
-          }
           ast::ExprVec(ref args) => {
             let mutability = match vst {
                 ast::ExprVstoreMutSlice => ast::MutMutable,
@@ -2622,8 +2618,13 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                             mutbl: mutability})
             }
           }
-          _ =>
-            tcx.sess.span_bug(expr.span, "vstore modifier on non-sequence")
+          ast::ExprLit(_) => {
+            tcx.sess.span_err(expr.span,
+                              "`~\"string\"` has been removed; use `\"string\".to_owned()` \
+                               instead");
+            ty::mk_err()
+          }
+          _ => tcx.sess.span_bug(expr.span, "vstore modifier on non-sequence"),
         };
         fcx.write_ty(ev.id, typ);
         fcx.write_ty(id, typ);

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1740,7 +1740,7 @@ impl<T: Iterator<char>> Builder<T> {
             Some(NumberValue(n)) => { Ok(Number(n)) }
             Some(BooleanValue(b)) => { Ok(Boolean(b)) }
             Some(StringValue(ref mut s)) => {
-                let mut temp = ~"";
+                let mut temp = "".to_owned();
                 swap(s, &mut temp);
                 Ok(String(temp))
             }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -270,22 +270,22 @@ pub fn syntax_expander_table() -> SyntaxEnv {
     }
 
     let mut syntax_expanders = SyntaxEnv::new();
-    syntax_expanders.insert(intern(&"macro_rules"),
+    syntax_expanders.insert(intern("macro_rules"),
                             IdentTT(~BasicIdentMacroExpander {
                                 expander: ext::tt::macro_rules::add_new_extension,
                                 span: None,
                             },
                             None));
-    syntax_expanders.insert(intern(&"fmt"),
+    syntax_expanders.insert(intern("fmt"),
                             builtin_normal_expander(
                                 ext::fmt::expand_syntax_ext));
-    syntax_expanders.insert(intern(&"format_args"),
+    syntax_expanders.insert(intern("format_args"),
                             builtin_normal_expander(
                                 ext::format::expand_args));
-    syntax_expanders.insert(intern(&"env"),
+    syntax_expanders.insert(intern("env"),
                             builtin_normal_expander(
                                     ext::env::expand_env));
-    syntax_expanders.insert(intern(&"option_env"),
+    syntax_expanders.insert(intern("option_env"),
                             builtin_normal_expander(
                                     ext::env::expand_option_env));
     syntax_expanders.insert(intern("bytes"),
@@ -297,63 +297,63 @@ pub fn syntax_expander_table() -> SyntaxEnv {
     syntax_expanders.insert(intern("concat"),
                             builtin_normal_expander(
                                     ext::concat::expand_syntax_ext));
-    syntax_expanders.insert(intern(&"log_syntax"),
+    syntax_expanders.insert(intern("log_syntax"),
                             builtin_normal_expander(
                                     ext::log_syntax::expand_syntax_ext));
-    syntax_expanders.insert(intern(&"deriving"),
+    syntax_expanders.insert(intern("deriving"),
                             ItemDecorator(ext::deriving::expand_meta_deriving));
 
     // Quasi-quoting expanders
-    syntax_expanders.insert(intern(&"quote_tokens"),
+    syntax_expanders.insert(intern("quote_tokens"),
                        builtin_normal_expander(
                             ext::quote::expand_quote_tokens));
-    syntax_expanders.insert(intern(&"quote_expr"),
+    syntax_expanders.insert(intern("quote_expr"),
                        builtin_normal_expander(
                             ext::quote::expand_quote_expr));
-    syntax_expanders.insert(intern(&"quote_ty"),
+    syntax_expanders.insert(intern("quote_ty"),
                        builtin_normal_expander(
                             ext::quote::expand_quote_ty));
-    syntax_expanders.insert(intern(&"quote_item"),
+    syntax_expanders.insert(intern("quote_item"),
                        builtin_normal_expander(
                             ext::quote::expand_quote_item));
-    syntax_expanders.insert(intern(&"quote_pat"),
+    syntax_expanders.insert(intern("quote_pat"),
                        builtin_normal_expander(
                             ext::quote::expand_quote_pat));
-    syntax_expanders.insert(intern(&"quote_stmt"),
+    syntax_expanders.insert(intern("quote_stmt"),
                        builtin_normal_expander(
                             ext::quote::expand_quote_stmt));
 
-    syntax_expanders.insert(intern(&"line"),
+    syntax_expanders.insert(intern("line"),
                             builtin_normal_expander(
                                     ext::source_util::expand_line));
-    syntax_expanders.insert(intern(&"col"),
+    syntax_expanders.insert(intern("col"),
                             builtin_normal_expander(
                                     ext::source_util::expand_col));
-    syntax_expanders.insert(intern(&"file"),
+    syntax_expanders.insert(intern("file"),
                             builtin_normal_expander(
                                     ext::source_util::expand_file));
-    syntax_expanders.insert(intern(&"stringify"),
+    syntax_expanders.insert(intern("stringify"),
                             builtin_normal_expander(
                                     ext::source_util::expand_stringify));
-    syntax_expanders.insert(intern(&"include"),
+    syntax_expanders.insert(intern("include"),
                             builtin_normal_expander(
                                     ext::source_util::expand_include));
-    syntax_expanders.insert(intern(&"include_str"),
+    syntax_expanders.insert(intern("include_str"),
                             builtin_normal_expander(
                                     ext::source_util::expand_include_str));
-    syntax_expanders.insert(intern(&"include_bin"),
+    syntax_expanders.insert(intern("include_bin"),
                             builtin_normal_expander(
                                     ext::source_util::expand_include_bin));
-    syntax_expanders.insert(intern(&"module_path"),
+    syntax_expanders.insert(intern("module_path"),
                             builtin_normal_expander(
                                     ext::source_util::expand_mod));
-    syntax_expanders.insert(intern(&"asm"),
+    syntax_expanders.insert(intern("asm"),
                             builtin_normal_expander(
                                     ext::asm::expand_asm));
-    syntax_expanders.insert(intern(&"cfg"),
+    syntax_expanders.insert(intern("cfg"),
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg));
-    syntax_expanders.insert(intern(&"trace_macros"),
+    syntax_expanders.insert(intern("trace_macros"),
                             builtin_normal_expander(
                                     ext::trace_macros::expand_trace_macros));
     syntax_expanders

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2779,28 +2779,11 @@ impl<'a> Parser<'a> {
             }
           }
           token::BINOP(token::AND) | token::ANDAND => {
-              // parse &pat
-              let lo = self.span.lo;
-              self.expect_and();
-              let sub = self.parse_pat();
-              hi = sub.span.hi;
-              // HACK: parse &"..." as a literal of a borrowed str
-              pat = match sub.node {
-                  PatLit(e) => {
-                      match e.node {
-                        ExprLit(lit) if lit_is_str(lit) => {
-                          let vst = @Expr {
-                              id: ast::DUMMY_NODE_ID,
-                              node: ExprVstore(e, ExprVstoreSlice),
-                              span: mk_sp(lo, hi)
-                          };
-                          PatLit(vst)
-                        }
-                        _ => PatRegion(sub),
-                      }
-                  }
-                  _ => PatRegion(sub),
-            };
+            // parse &pat
+            let lo = self.span.lo;
+            self.expect_and();
+            let sub = self.parse_pat();
+            pat = PatRegion(sub);
             hi = self.last_span.hi;
             return @ast::Pat {
                 id: ast::DUMMY_NODE_ID,

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -534,7 +534,7 @@ impl<T: Writer> ConsoleTestState<T> {
 
     pub fn write_run_start(&mut self, len: uint) -> io::IoResult<()> {
         self.total = len;
-        let noun = if len != 1 { &"tests" } else { &"test" };
+        let noun = if len != 1 { "tests" } else { "test" };
         self.write_plain(format!("\nrunning {} {}\n", len, noun))
     }
 


### PR DESCRIPTION
r? @alexcrichton
