### PR TITLE
rustc: Fix def ids of xcrate-reexported items

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -610,7 +610,7 @@ fn each_child_of_item_or_crate(intr: Rc<IdentInterner>,
                 // Hand off the item to the callback.
                 let def_like = item_to_def_like(child_item_doc,
                                                 child_def_id,
-                                                cdata.cnum);
+                                                child_def_id.krate);
                 // These items have a public visibility because they're part of
                 // a public re-export.
                 callback(def_like, token::str_to_ident(name), ast::Public);

--- a/src/test/auxiliary/issue-13872-1.rs
+++ b/src/test/auxiliary/issue-13872-1.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub enum A { B }

--- a/src/test/auxiliary/issue-13872-2.rs
+++ b/src/test/auxiliary/issue-13872-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo = "issue-13872-1";
+
+pub use foo::B;

--- a/src/test/auxiliary/issue-13872-3.rs
+++ b/src/test/auxiliary/issue-13872-3.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate bar = "issue-13872-2";
+
+use bar::B;
+
+pub fn foo() {
+    match B {
+        B => {}
+    }
+}

--- a/src/test/run-pass/issue-13872.rs
+++ b/src/test/run-pass/issue-13872.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-13872-1.rs
+// aux-build:issue-13872-2.rs
+// aux-build:issue-13872-3.rs
+
+extern crate other = "issue-13872-3";
+
+fn main() {
+    other::foo();
+}


### PR DESCRIPTION
This was just a typo in the decoder using the source crate's number rather than
the destination crate's number of a reexport.

Closes #13872
