### PR TITLE
Fix a/an typos

### DIFF
--- a/RELEASES.txt
+++ b/RELEASES.txt
@@ -63,7 +63,7 @@ Version 0.10 (April 2014)
       documentation index page.
     * std: `std::condition` has been removed. All I/O errors are now propagated
       through the `Result` type. In order to assist with error handling, a
-      `try!` macro for unwrapping errors with an early return and an lint for
+      `try!` macro for unwrapping errors with an early return and a lint for
       unused results has been added. See #12039 for more information.
     * std: The `vec` module has been renamed to `slice`.
     * std: A new vector type, `Vec<T>`, has been added in preparation for DST.

--- a/src/doc/guide-lifetimes.md
+++ b/src/doc/guide-lifetimes.md
@@ -263,7 +263,7 @@ process is called *rooting*.
 The previous example demonstrated *rooting*, the process by which the
 compiler ensures that managed boxes remain live for the duration of a
 borrow. Unfortunately, rooting does not work for borrows of owned
-boxes, because it is not possible to have two references to a owned
+boxes, because it is not possible to have two references to an owned
 box.
 
 For owned boxes, therefore, the compiler will only allow a borrow *if
@@ -462,7 +462,7 @@ of a `f64` as if it were a struct with two fields would be a memory
 safety violation.
 
 So, in fact, for every `ref` binding, the compiler will impose the
-same rules as the ones we saw for borrowing the interior of a owned
+same rules as the ones we saw for borrowing the interior of an owned
 box: it must be able to guarantee that the `enum` will not be
 overwritten for the duration of the borrow.  In fact, the compiler
 would accept the example we gave earlier. The example is safe because

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -56,7 +56,7 @@ standard library types, e.g. `Cell` and `RefCell`, that provide inner
 mutability by replacing compile time guarantees with dynamic checks at
 runtime.
 
-An `&mut` reference has a stronger requirement: when a object has an
+An `&mut` reference has a stronger requirement: when an object has an
 `&mut T` pointing into it, then that `&mut` reference must be the only
 such usable path to that object in the whole program. That is, an
 `&mut` cannot alias with any other references.

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -161,7 +161,7 @@ Comments in Rust code follow the general C++ style of line and block-comment for
 with no nesting of block-comment delimiters.
 
 Line comments beginning with exactly _three_ slashes (`///`), and block
-comments beginning with a exactly one repeated asterisk in the block-open
+comments beginning with exactly one repeated asterisk in the block-open
 sequence (`/**`), are interpreted as a special syntax for `doc`
 [attributes](#attributes).  That is, they are equivalent to writing
 `#[doc="..."]` around the body of the comment (this includes the comment
@@ -365,7 +365,7 @@ of integer literal suffix:
     give the literal the corresponding machine type.
 
 The type of an _unsuffixed_ integer literal is determined by type inference.
-If a integer type can be _uniquely_ determined from the surrounding program
+If an integer type can be _uniquely_ determined from the surrounding program
 context, the unsuffixed integer literal has that type.  If the program context
 underconstrains the type, the unsuffixed integer literal's type is `int`; if
 the program context overconstrains the type, it is considered a static type
@@ -2184,7 +2184,7 @@ Supported traits for `deriving` are:
 * `Hash`, to iterate over the bytes in a data type.
 * `Rand`, to create a random instance of a data type.
 * `Default`, to create an empty instance of a data type.
-* `Zero`, to create an zero instance of a numeric data type.
+* `Zero`, to create a zero instance of a numeric data type.
 * `FromPrimitive`, to create an instance from a numeric primitive.
 * `Show`, to format a value using the `{}` formatter.
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2980,7 +2980,7 @@ fn main() {
 }
 ~~~
 
-In general, `use` creates an local alias:
+In general, `use` creates a local alias:
 An alternate path and a possibly different name to access the same item,
 without touching the original, and with both being interchangeable.
 

--- a/src/etc/zsh/_rust
+++ b/src/etc/zsh/_rust
@@ -68,7 +68,7 @@ _rustc_opts_lint=(
     'unsafe-block[usage of an `unsafe` block]'
     'unstable[detects use of #\[unstable\] items (incl. items with no stability attribute)]'
     'unused-imports[imports that are never used]'
-    'unused-must-use[unused result of an type flagged as #\[must_use\]]'
+    'unused-must-use[unused result of a type flagged as #\[must_use\]]'
     "unused-mut[detect mut variables which don't need to be mutable]"
     'unused-result[unused result of an expression in a statement]'
     'unused-unsafe[unnecessary use of an `unsafe` block]'

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1392,7 +1392,7 @@ fn add_upstream_rust_crates(args: &mut Vec<~str>, sess: &Session,
             // If you opted in to dynamic linking and we decided to emit a
             // static output, you should probably be notified of such an event!
             sess.warn("dynamic linking was preferred, but dependencies \
-                       could not all be found in an dylib format.");
+                       could not all be found in a dylib format.");
             sess.warn("linking statically instead, using rlibs");
             add_static_crates(args, sess, tmpdir, deps)
         }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3639,7 +3639,7 @@ pub fn check_enum_variants(ccx: &CrateCtxt,
                     let declty = ty::mk_int_var(ccx.tcx, fcx.infcx().next_int_var_id());
                     check_const_with_ty(&fcx, e.span, e, declty);
                     // check_expr (from check_const pass) doesn't guarantee
-                    // that the expression is in an form that eval_const_expr can
+                    // that the expression is in a form that eval_const_expr can
                     // handle, so we may still get an internal compiler error
 
                     match const_eval::eval_const_expr_partial(ccx.tcx, e) {

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -419,7 +419,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
                 }
             }
             ty::AutoObject(ty::RegionTraitStore(trait_region, _), _, _, _) => {
-                // Determine if we are casting `expr` to an trait
+                // Determine if we are casting `expr` to a trait
                 // instance.  If so, we have to be sure that the type of
                 // the source obeys the trait's region bound.
                 //
@@ -524,7 +524,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
         }
 
         ast::ExprCast(source, _) => {
-            // Determine if we are casting `source` to an trait
+            // Determine if we are casting `source` to a trait
             // instance.  If so, we have to be sure that the type of
             // the source obeys the trait's region bound.
             //

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -813,13 +813,13 @@ impl<E: ::Encoder<S>, S> Encodable<E, S> for Json {
 }
 
 impl Json {
-    /// Encodes a json value into a io::writer.  Uses a single line.
+    /// Encodes a json value into an io::writer.  Uses a single line.
     pub fn to_writer(&self, wr: &mut io::Writer) -> EncodeResult {
         let mut encoder = Encoder::new(wr);
         self.encode(&mut encoder)
     }
 
-    /// Encodes a json value into a io::writer.
+    /// Encodes a json value into an io::writer.
     /// Pretty-prints in a more readable format.
     pub fn to_pretty_writer(&self, wr: &mut io::Writer) -> EncodeResult {
         let mut encoder = PrettyEncoder::new(wr);

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1037,7 +1037,7 @@ pub trait Writer {
         self.write([n])
     }
 
-    /// Write a i8 (1 byte).
+    /// Write an i8 (1 byte).
     fn write_i8(&mut self, n: i8) -> IoResult<()> {
         self.write([n as u8])
     }

--- a/src/libstd/ptr.rs
+++ b/src/libstd/ptr.rs
@@ -131,7 +131,7 @@ pub unsafe fn position<T>(buf: *T, f: |&T| -> bool) -> uint {
     }
 }
 
-/// Create an null pointer.
+/// Create a null pointer.
 ///
 /// # Example
 ///

--- a/src/test/run-pass/shape_intrinsic_tag_then_rec.rs
+++ b/src/test/run-pass/shape_intrinsic_tag_then_rec.rs
@@ -11,7 +11,7 @@
 #![feature(managed_boxes)]
 
 // Exercises a bug in the shape code that was exposed
-// on x86_64: when there is a enum embedded in an
+// on x86_64: when there is an enum embedded in an
 // interior record which is then itself interior to
 // something else, shape calculations were off.
 


### PR DESCRIPTION
Found the first one in the rust reference docs. I was going to submit a PR with one fix, but figured I could look for more... This is the result.
