### PR TITLE
Implement ToJson for Vec<T>

### DIFF
--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2233,6 +2233,10 @@ impl<A:ToJson> ToJson for ~[A] {
     fn to_json(&self) -> Json { List(self.iter().map(|elt| elt.to_json()).collect()) }
 }
 
+impl<A:ToJson> ToJson for Vec<A> {
+    fn to_json(&self) -> Json { List(self.iter().map(|elt| elt.to_json()).collect()) }
+}
+
 impl<A:ToJson> ToJson for TreeMap<~str, A> {
     fn to_json(&self) -> Json {
         let mut d = TreeMap::new();


### PR DESCRIPTION
Now that ~[T] is obsolete, we need to allow to_json() to work for
vectors.
