### PR TITLE
rustc: Add some support for mixing rlibs and dylibs

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -24,6 +24,7 @@ use metadata::cstore::CStore;
 use metadata::creader::Loader;
 use metadata;
 use middle::{trans, freevars, kind, ty, typeck, lint, reachable};
+use middle::dependency_format;
 use middle;
 use util::common::time;
 use util::ppaux;
@@ -383,7 +384,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
         ty_cx: ty_cx,
         exported_items: exported_items,
         public_items: public_items,
-        reachable: reachable_map
+        reachable: reachable_map,
     }
 }
 
@@ -394,6 +395,7 @@ pub struct CrateTranslation {
     pub link: LinkMeta,
     pub metadata: Vec<u8>,
     pub reachable: Vec<~str>,
+    pub crate_formats: dependency_format::Dependencies,
 }
 
 /// Run the translation phase to LLVM, after which the AST and analysis can
@@ -401,11 +403,14 @@ pub struct CrateTranslation {
 pub fn phase_4_translate_to_llvm(krate: ast::Crate,
                                  analysis: CrateAnalysis,
                                  outputs: &OutputFilenames) -> (ty::ctxt, CrateTranslation) {
-    // Option dance to work around the lack of stack once closures.
     let time_passes = analysis.ty_cx.sess.time_passes();
-    let mut analysis = Some(analysis);
-    time(time_passes, "translation", krate, |krate|
-         trans::base::trans_crate(krate, analysis.take_unwrap(), outputs))
+
+    time(time_passes, "resolving dependency formats", (), |_|
+         dependency_format::calculate(&analysis.ty_cx));
+
+    // Option dance to work around the lack of stack once closures.
+    time(time_passes, "translation", (krate, analysis), |(krate, analysis)|
+         trans::base::trans_crate(krate, analysis, outputs))
 }
 
 /// Run LLVM itself, producing a bitcode file, assembly file or object file

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -126,7 +126,7 @@ pub enum DebugInfoLevel {
 pub struct Options {
     // The crate config requested for the session, which may be combined
     // with additional crate configurations during the compile process
-    pub crate_types: Vec<CrateType> ,
+    pub crate_types: Vec<CrateType>,
 
     pub gc: bool,
     pub optimize: OptLevel,
@@ -167,7 +167,7 @@ pub enum EntryFnType {
     EntryNone,
 }
 
-#[deriving(Eq, Ord, Clone, TotalOrd, TotalEq)]
+#[deriving(Eq, Ord, Clone, TotalOrd, TotalEq, Hash)]
 pub enum CrateType {
     CrateTypeExecutable,
     CrateTypeDylib,

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -93,6 +93,7 @@ pub mod middle {
     pub mod cfg;
     pub mod dead;
     pub mod expr_use_visitor;
+    pub mod dependency_format;
 }
 
 pub mod front {

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -203,6 +203,8 @@ pub static tag_macro_def: uint = 0x8d;
 
 pub static tag_crate_triple: uint = 0x66;
 
+pub static tag_dylib_dependency_formats: uint = 0x67;
+
 #[deriving(Clone, Show)]
 pub struct LinkMeta {
     pub crateid: CrateId,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -284,3 +284,11 @@ pub fn get_tuple_struct_definition_if_ctor(cstore: &cstore::CStore,
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_tuple_struct_definition_if_ctor(&*cdata, def_id.node)
 }
+
+pub fn get_dylib_dependency_formats(cstore: &cstore::CStore,
+                                    cnum: ast::CrateNum)
+    -> Vec<(ast::CrateNum, cstore::LinkagePreference)>
+{
+    let cdata = cstore.get_crate_data(cnum);
+    decoder::get_dylib_dependency_formats(&*cdata)
+}

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -45,7 +45,7 @@ pub struct crate_metadata {
     pub span: Span,
 }
 
-#[deriving(Eq)]
+#[deriving(Show, Eq, Clone)]
 pub enum LinkagePreference {
     RequireDynamic,
     RequireStatic,

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -1,0 +1,229 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Resolution of mixing rlibs and dylibs
+//!
+//! When producing a final artifact, such as a dynamic library, the compiler has
+//! a choice between linking an rlib or linking a dylib of all upstream
+//! dependencies. The linking phase must guarantee, however, that a library only
+//! show up once in the object file. For example, it is illegal for library A to
+//! be statically linked to B and C in separate dylibs, and then link B and C
+//! into a crate D (because library A appears twice).
+//!
+//! The job of this module is to calculate what format each upstream crate
+//! should be used when linking each output type requested in this session. This
+//! generally follows this set of rules:
+//!
+//!     1. Each library must appear exactly once in the output.
+//!     2. Each rlib contains only one library (it's just an object file)
+//!     3. Each dylib can contain more than one library (due to static linking),
+//!        and can also bring in many dynamic dependencies.
+//!
+//! With these constraints in mind, it's generally a very difficult problem to
+//! find a solution that's not "all rlibs" or "all dylibs". I have suspicions
+//! that NP-ness may come into the picture here...
+//!
+//! The current selection algorithm below looks mostly similar to:
+//!
+//!     1. If static linking is required, then require all upstream dependencies
+//!        to be available as rlibs. If not, generate an error.
+//!     2. If static linking is requested (generating an executable), then
+//!        attempt to use all upstream dependencies as rlibs. If any are not
+//!        found, bail out and continue to step 3.
+//!     3. Static linking has failed, at least one library must be dynamically
+//!        linked. Apply a heuristic by greedily maximizing the number of
+//!        dynamically linked libraries.
+//!     4. Each upstream dependency available as a dynamic library is
+//!        registered. The dependencies all propagate, adding to a map. It is
+//!        possible for a dylib to add a static library as a dependency, but it
+//!        is illegal for two dylibs to add the same static library as a
+//!        dependency. The same dylib can be added twice. Additionally, it is
+//!        illegal to add a static dependency when it was previously found as a
+//!        dylib (and vice versa)
+//!     5. After all dynamic dependencies have been traversed, re-traverse the
+//!        remaining dependencies and add them statically (if they haven't been
+//!        added already).
+//!
+//! While not perfect, this algorithm should help support use-cases such as leaf
+//! dependencies being static while the larger tree of inner dependencies are
+//! all dynamic. This isn't currently very well battle tested, so it will likely
+//! fall short in some use cases.
+//!
+//! Currently, there is no way to specify the preference of linkage with a
+//! particular library (other than a global dynamic/static switch).
+//! Additionally, the algorithm is geared towards finding *any* solution rather
+//! than finding a number of solutions (there are normally quite a few).
+
+use collections::HashMap;
+use syntax::ast;
+
+use driver::session;
+use metadata::cstore;
+use metadata::csearch;
+use middle::ty;
+
+/// A list of dependencies for a certain crate type.
+///
+/// The length of this vector is the same as the number of external crates used.
+/// The value is None if the crate does not need to be linked (it was found
+/// statically in another dylib), or Some(kind) if it needs to be linked as
+/// `kind` (either static or dynamic).
+pub type DependencyList = Vec<Option<cstore::LinkagePreference>>;
+
+/// A mapping of all required dependencies for a particular flavor of output.
+///
+/// This is local to the tcx, and is generally relevant to one session.
+pub type Dependencies = HashMap<session::CrateType, DependencyList>;
+
+pub fn calculate(tcx: &ty::ctxt) {
+    let mut fmts = tcx.dependency_formats.borrow_mut();
+    for &ty in tcx.sess.crate_types.borrow().iter() {
+        fmts.insert(ty, calculate_type(&tcx.sess, ty));
+    }
+    tcx.sess.abort_if_errors();
+}
+
+fn calculate_type(sess: &session::Session,
+                  ty: session::CrateType) -> DependencyList {
+    match ty {
+        // If the global prefer_dynamic switch is turned off, first attempt
+        // static linkage (this can fail).
+        session::CrateTypeExecutable if !sess.opts.cg.prefer_dynamic => {
+            match attempt_static(sess) {
+                Some(v) => return v,
+                None => {}
+            }
+        }
+
+        // No linkage happens with rlibs, we just needed the metadata (which we
+        // got long ago), so don't bother with anything.
+        session::CrateTypeRlib => return Vec::new(),
+
+        // Staticlibs must have all static dependencies. If any fail to be
+        // found, we generate some nice pretty errors.
+        session::CrateTypeStaticlib => {
+            match attempt_static(sess) {
+                Some(v) => return v,
+                None => {}
+            }
+            sess.cstore.iter_crate_data(|cnum, data| {
+                let src = sess.cstore.get_used_crate_source(cnum).unwrap();
+                if src.rlib.is_some() { return }
+                sess.err(format!("dependency `{}` not found in rlib format",
+                                 data.name));
+            });
+            return Vec::new();
+        }
+
+        // Everything else falls through below
+        session::CrateTypeExecutable | session::CrateTypeDylib => {},
+    }
+
+    let mut formats = HashMap::new();
+
+    // Sweep all crates for found dylibs. Add all dylibs, as well as their
+    // dependencies, ensuring there are no conflicts. The only valid case for a
+    // dependency to be relied upon twice is for both cases to rely on a dylib.
+    sess.cstore.iter_crate_data(|cnum, data| {
+        let src = sess.cstore.get_used_crate_source(cnum).unwrap();
+        if src.dylib.is_some() {
+            add_library(sess, cnum, cstore::RequireDynamic, &mut formats);
+            debug!("adding dylib: {}", data.name);
+            let deps = csearch::get_dylib_dependency_formats(&sess.cstore, cnum);
+            for &(depnum, style) in deps.iter() {
+                add_library(sess, depnum, style, &mut formats);
+                debug!("adding {}: {}", style,
+                       sess.cstore.get_crate_data(depnum).name.clone());
+            }
+        }
+    });
+
+    // Collect what we've got so far in the return vector.
+    let mut ret = range(1, sess.cstore.next_crate_num()).map(|i| {
+        match formats.find(&i).map(|v| *v) {
+            v @ Some(cstore::RequireDynamic) => v,
+            _ => None,
+        }
+    }).collect::<Vec<_>>();
+
+    // Run through the dependency list again, and add any missing libraries as
+    // static libraries.
+    sess.cstore.iter_crate_data(|cnum, data| {
+        let src = sess.cstore.get_used_crate_source(cnum).unwrap();
+        if src.dylib.is_none() && !formats.contains_key(&cnum) {
+            assert!(src.rlib.is_some());
+            add_library(sess, cnum, cstore::RequireStatic, &mut formats);
+            *ret.get_mut(cnum as uint - 1) = Some(cstore::RequireStatic);
+            debug!("adding staticlib: {}", data.name);
+        }
+    });
+
+    // When dylib B links to dylib A, then when using B we must also link to A.
+    // It could be the case, however, that the rlib for A is present (hence we
+    // found metadata), but the dylib for A has since been removed.
+    //
+    // For situations like this, we perform one last pass over the dependencies,
+    // making sure that everything is available in the requested format.
+    for (cnum, kind) in ret.iter().enumerate() {
+        let cnum = cnum as ast::CrateNum;
+        let src = sess.cstore.get_used_crate_source(cnum + 1).unwrap();
+        match *kind {
+            None => continue,
+            Some(cstore::RequireStatic) if src.rlib.is_some() => continue,
+            Some(cstore::RequireDynamic) if src.dylib.is_some() => continue,
+            Some(kind) => {
+                let data = sess.cstore.get_crate_data(cnum + 1);
+                sess.err(format!("crate `{}` required to be available in {}, \
+                                  but it was not available in this form",
+                                 data.name,
+                                 match kind {
+                                     cstore::RequireStatic => "rlib",
+                                     cstore::RequireDynamic => "dylib",
+                                 }));
+            }
+        }
+    }
+
+    return ret;
+}
+
+fn add_library(sess: &session::Session,
+               cnum: ast::CrateNum,
+               link: cstore::LinkagePreference,
+               m: &mut HashMap<ast::CrateNum, cstore::LinkagePreference>) {
+    match m.find(&cnum) {
+        Some(&link2) => {
+            // If the linkages differ, then we'd have two copies of the library
+            // if we continued linking. If the linkages are both static, then we
+            // would also have two copies of the library (static from two
+            // different locations).
+            //
+            // This error is probably a little obscure, but I imagine that it
+            // can be refined over time.
+            if link2 != link || link == cstore::RequireStatic {
+                let data = sess.cstore.get_crate_data(cnum);
+                sess.err(format!("cannot satisfy dependencies so `{}` only \
+                                  shows up once", data.name));
+                sess.note("having upstream crates all available in one format \
+                           will likely make this go away");
+            }
+        }
+        None => { m.insert(cnum, link); }
+    }
+}
+
+fn attempt_static(sess: &session::Session) -> Option<DependencyList> {
+    let crates = sess.cstore.get_used_crates(cstore::RequireStatic);
+    if crates.iter().all(|&(_, ref p)| p.is_some()) {
+        Some(crates.move_iter().map(|_| Some(cstore::RequireStatic)).collect())
+    } else {
+        None
+    }
+}

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2194,6 +2194,7 @@ pub fn trans_crate(krate: ast::Crate,
     reachable.push("rust_eh_personality_catch".to_owned()); // referenced from rt/rust_try.ll
 
     let metadata_module = ccx.metadata_llmod;
+    let formats = ccx.tcx.dependency_formats.borrow().clone();
 
     (ccx.tcx, CrateTranslation {
         context: llcx,
@@ -2202,5 +2203,6 @@ pub fn trans_crate(krate: ast::Crate,
         metadata_module: metadata_module,
         metadata: metadata,
         reachable: reachable,
+        crate_formats: formats,
     })
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -15,6 +15,7 @@ use driver::session::Session;
 use metadata::csearch;
 use mc = middle::mem_categorization;
 use middle::const_eval;
+use middle::dependency_format;
 use middle::lang_items::{ExchangeHeapLangItem, OpaqueStructLangItem};
 use middle::lang_items::{TyDescStructLangItem, TyVisitorTraitLangItem};
 use middle::freevars;
@@ -349,6 +350,8 @@ pub struct ctxt {
 
     pub method_map: typeck::MethodMap,
     pub vtable_map: typeck::vtable_map,
+
+    pub dependency_formats: RefCell<dependency_format::Dependencies>,
 }
 
 pub enum tbox_flag {
@@ -1123,6 +1126,7 @@ pub fn mk_ctxt(s: Session,
         extern_const_variants: RefCell::new(DefIdMap::new()),
         method_map: RefCell::new(FnvHashMap::new()),
         vtable_map: RefCell::new(FnvHashMap::new()),
+        dependency_formats: RefCell::new(HashMap::new()),
     }
 }
 

--- a/src/test/auxiliary/issue-12133-dylib2.rs
+++ b/src/test/auxiliary/issue-12133-dylib2.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "dylib"]
+
+extern crate a = "issue-12133-rlib";
+extern crate b = "issue-12133-dylib";
+

--- a/src/test/run-make/mixing-formats/Makefile
+++ b/src/test/run-make/mixing-formats/Makefile
@@ -1,0 +1,74 @@
+-include ../tools.mk
+
+# Testing various mixings of rlibs and dylibs. Makes sure that it's possible to
+# link an rlib to a dylib. The dependency tree among the file looks like:
+#
+#				foo
+#			      /     \
+#			    bar1   bar2
+#			   /    \ /
+#			 baz    baz2
+#
+# This is generally testing the permutations of the foo/bar1/bar2 layer against
+# the baz/baz2 layer
+
+all:
+	# Building just baz
+	$(RUSTC) --crate-type=rlib  foo.rs
+	$(RUSTC) --crate-type=dylib bar1.rs
+	$(RUSTC) --crate-type=dylib,rlib baz.rs
+	$(RUSTC) --crate-type=bin baz.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=rlib  bar1.rs
+	$(RUSTC) --crate-type=dylib,rlib baz.rs
+	$(RUSTC) --crate-type=bin baz.rs
+	rm $(TMPDIR)/*
+	# Building baz2
+	$(RUSTC) --crate-type=rlib  foo.rs
+	$(RUSTC) --crate-type=dylib bar1.rs
+	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib baz2.rs && exit 1 || exit 0
+	$(RUSTC) --crate-type=bin baz2.rs && exit 1 || exit 0
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=rlib  foo.rs
+	$(RUSTC) --crate-type=rlib  bar1.rs
+	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=rlib  foo.rs
+	$(RUSTC) --crate-type=dylib bar1.rs
+	$(RUSTC) --crate-type=rlib  bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=rlib  foo.rs
+	$(RUSTC) --crate-type=rlib  bar1.rs
+	$(RUSTC) --crate-type=rlib  bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=rlib  bar1.rs
+	$(RUSTC) --crate-type=rlib  bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=dylib bar1.rs
+	$(RUSTC) --crate-type=rlib  bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=rlib  bar1.rs
+	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=dylib bar1.rs
+	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=bin baz2.rs

--- a/src/test/run-make/mixing-formats/bar1.rs
+++ b/src/test/run-make/mixing-formats/bar1.rs
@@ -8,13 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue-12133-rlib.rs
-// aux-build:issue-12133-dylib.rs
-// no-prefer-dynamic
-
-// error-pattern: dylib output requested, but some depenencies could not
-
-#![crate_type = "dylib"]
-
-extern crate a = "issue-12133-rlib";
-extern crate b = "issue-12133-dylib";
+extern crate foo;

--- a/src/test/run-make/mixing-formats/bar2.rs
+++ b/src/test/run-make/mixing-formats/bar2.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;

--- a/src/test/run-make/mixing-formats/baz.rs
+++ b/src/test/run-make/mixing-formats/baz.rs
@@ -8,12 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// aux-build:issue-12133-rlib.rs
-// aux-build:issue-12133-dylib.rs
-
-// error-pattern: dynamic linking is preferred, but dependencies were not found
-
-extern crate a = "issue-12133-rlib";
-extern crate b = "issue-12133-dylib";
+extern crate bar1;
 
 fn main() {}

--- a/src/test/run-make/mixing-formats/baz2.rs
+++ b/src/test/run-make/mixing-formats/baz2.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate bar1;
+extern crate bar2;
+
+fn main() {}
+

--- a/src/test/run-make/mixing-formats/foo.rs
+++ b/src/test/run-make/mixing-formats/foo.rs
@@ -1,0 +1,9 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.

--- a/src/test/run-make/mixing-libs/Makefile
+++ b/src/test/run-make/mixing-libs/Makefile
@@ -2,7 +2,7 @@
 
 all:
 	$(RUSTC) rlib.rs
-	$(RUSTC) dylib.rs && exit 1 || exit 0
+	$(RUSTC) dylib.rs
 	$(RUSTC) rlib.rs --crate-type=dylib
 	$(RUSTC) dylib.rs
 	rm $(call DYLIB,rlib-*)

--- a/src/test/run-pass/issue-12133-1.rs
+++ b/src/test/run-pass/issue-12133-1.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12133-rlib.rs
+// aux-build:issue-12133-dylib.rs
+
+extern crate a = "issue-12133-rlib";
+extern crate b = "issue-12133-dylib";
+
+fn main() {}

--- a/src/test/run-pass/issue-12133-2.rs
+++ b/src/test/run-pass/issue-12133-2.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-12133-rlib.rs
+// aux-build:issue-12133-dylib.rs
+// no-prefer-dynamic
+
+extern crate a = "issue-12133-rlib";
+extern crate b = "issue-12133-dylib";
+
+fn main() {}

--- a/src/test/run-pass/issue-12133-3.rs
+++ b/src/test/run-pass/issue-12133-3.rs
@@ -10,11 +10,8 @@
 
 // aux-build:issue-12133-rlib.rs
 // aux-build:issue-12133-dylib.rs
-// no-prefer-dynamic
+// aux-build:issue-12133-dylib2.rs
 
-// error-pattern: dependencies were not all found in either dylib or rlib format
-
-extern crate a = "issue-12133-rlib";
-extern crate b = "issue-12133-dylib";
+extern crate other = "issue-12133-dylib2";
 
 fn main() {}


### PR DESCRIPTION
Currently, rustc requires that a linkage be a product of 100% rlibs or 100%
dylibs. This is to satisfy the requirement that each object appear at most once
in the final output products. This is a bit limiting, and the upcoming libcore
library cannot exist as a dylib, so these rules must change.

The goal of this commit is to enable _some_ use cases for mixing rlibs and
dylibs, primarily libcore's use case. It is not targeted at allowing an
exhaustive number of linkage flavors.

There is a new dependency_format module in rustc which calculates what format
each upstream library should be linked as in each output type of the current
unit of compilation. The module itself contains many gory details about what's
going on here.

cc #10729
