### PR TITLE
rustc: Use the "real" realpath function

### DIFF
--- a/src/test/run-make/libs-through-symlinks/Makefile
+++ b/src/test/run-make/libs-through-symlinks/Makefile
@@ -1,0 +1,14 @@
+-include ../tools.mk
+
+ifdef IS_WINDOWS
+all:
+else
+
+NAME := $(shell $(RUSTC) --crate-file-name foo.rs)
+
+all:
+	mkdir -p $(TMPDIR)/outdir
+	$(RUSTC) foo.rs -o $(TMPDIR)/outdir/$(NAME)
+	ln -nsf outdir/$(NAME) $(TMPDIR)
+	RUST_LOG=rustc::metadata::loader $(RUSTC) bar.rs
+endif

--- a/src/test/run-make/libs-through-symlinks/bar.rs
+++ b/src/test/run-make/libs-through-symlinks/bar.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;
+
+fn main() {}

--- a/src/test/run-make/libs-through-symlinks/foo.rs
+++ b/src/test/run-make/libs-through-symlinks/foo.rs
@@ -1,0 +1,12 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+#![crate_id = "foo"]


### PR DESCRIPTION
The logic of the custom realpath function in metadata::loader was incorrect, but
the logic in util::fs was correct.

Closes #13890
