### PR TITLE
rustc: Remove the session building_library flag

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -210,7 +210,6 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                                     -> (ast::Crate, syntax::ast_map::Map) {
     let time_passes = sess.time_passes();
 
-    sess.building_library.set(session::building_library(&sess.opts, &krate));
     *sess.crate_types.borrow_mut() = session::collect_crate_types(sess, krate.attrs.as_slice());
 
     time(time_passes, "gated feature checking", (), |_|
@@ -1046,7 +1045,6 @@ pub fn build_session_(sopts: session::Options,
         entry_type: Cell::new(None),
         macro_registrar_fn: Cell::new(None),
         default_sysroot: default_sysroot,
-        building_library: Cell::new(false),
         local_crate_source_file: local_crate_source_file,
         working_dir: os::getcwd(),
         lints: RefCell::new(NodeMap::new()),

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -25,7 +25,6 @@ use syntax::codemap::Span;
 use syntax::diagnostic;
 use syntax::parse::ParseSess;
 use syntax::{abi, ast, codemap};
-use syntax;
 
 use std::cell::{Cell, RefCell};
 use collections::HashSet;
@@ -185,7 +184,6 @@ pub struct Session {
     pub entry_type: Cell<Option<EntryFnType>>,
     pub macro_registrar_fn: Cell<Option<ast::NodeId>>,
     pub default_sysroot: Option<Path>,
-    pub building_library: Cell<bool>,
     // The name of the root source file of the crate, in the local file system. The path is always
     // expected to be absolute. `None` means that there is no source file.
     pub local_crate_source_file: Option<Path>,
@@ -475,26 +473,6 @@ cgoptions!(
 // Seems out of place, but it uses session, so I'm putting it here
 pub fn expect<T:Clone>(sess: &Session, opt: Option<T>, msg: || -> ~str) -> T {
     diagnostic::expect(sess.diagnostic(), opt, msg)
-}
-
-pub fn building_library(options: &Options, krate: &ast::Crate) -> bool {
-    if options.test { return false }
-    for output in options.crate_types.iter() {
-        match *output {
-            CrateTypeExecutable => {}
-            CrateTypeStaticlib | CrateTypeDylib | CrateTypeRlib => return true
-        }
-    }
-    match syntax::attr::first_attr_value_str_by_name(krate.attrs.as_slice(),
-                                                     "crate_type") {
-        Some(s) => {
-            s.equiv(&("lib")) ||
-            s.equiv(&("rlib")) ||
-            s.equiv(&("dylib")) ||
-            s.equiv(&("staticlib"))
-        }
-        _ => false
-    }
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+use driver::session;
 use driver::session::Session;
 
 use syntax::ast;
@@ -86,7 +86,10 @@ impl<'a> fold::Folder for StandardLibraryInjector<'a> {
             span: DUMMY_SP
         });
 
-        if use_start(&krate) && !self.sess.building_library.get() {
+        let any_exe = self.sess.crate_types.borrow().iter().any(|ty| {
+            *ty == session::CrateTypeExecutable
+        });
+        if use_start(&krate) && any_exe {
             vis.push(ast::ViewItem {
                 node: ast::ViewItemExternCrate(token::str_to_ident("native"),
                                              with_version("native"),

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -125,27 +125,23 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
         // Remove any #[main] from the AST so it doesn't clash with
         // the one we're going to add. Only if compiling an executable.
 
-        fn nomain(cx: &TestCtxt, item: @ast::Item) -> @ast::Item {
-            if !cx.sess.building_library.get() {
-                @ast::Item {
-                    attrs: item.attrs.iter().filter_map(|attr| {
-                        if !attr.name().equiv(&("main")) {
-                            Some(*attr)
-                        } else {
-                            None
-                        }
-                    }).collect(),
-                    .. (*item).clone()
-                }
-            } else {
-                item
+        fn nomain(item: @ast::Item) -> @ast::Item {
+            @ast::Item {
+                attrs: item.attrs.iter().filter_map(|attr| {
+                    if !attr.name().equiv(&("main")) {
+                        Some(*attr)
+                    } else {
+                        None
+                    }
+                }).collect(),
+                .. (*item).clone()
             }
         }
 
         let mod_nomain = ast::Mod {
             inner: m.inner,
             view_items: m.view_items.clone(),
-            items: m.items.iter().map(|i| nomain(&self.cx, *i)).collect(),
+            items: m.items.iter().map(|i| nomain(*i)).collect(),
         };
 
         fold::noop_fold_mod(&mod_nomain, self)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1663,7 +1663,7 @@ fn finish_register_fn(ccx: &CrateContext, sp: Span, sym: ~str, node_id: ast::Nod
         lib::llvm::SetLinkage(llfn, lib::llvm::InternalLinkage);
     }
 
-    if is_entry_fn(ccx.sess(), node_id) && !ccx.sess().building_library.get() {
+    if is_entry_fn(ccx.sess(), node_id) {
         create_entry_wrapper(ccx, sp, llfn);
     }
 }
@@ -2062,7 +2062,10 @@ pub fn crate_ctxt_to_encode_parms<'r>(cx: &'r CrateContext, ie: encoder::EncodeI
 pub fn write_metadata(cx: &CrateContext, krate: &ast::Crate) -> Vec<u8> {
     use flate;
 
-    if !cx.sess().building_library.get() {
+    let any_library = cx.sess().crate_types.borrow().iter().any(|ty| {
+        *ty != session::CrateTypeExecutable
+    });
+    if !any_library {
         return Vec::new()
     }
 

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -409,16 +409,14 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
 
 fn check_for_entry_fn(ccx: &CrateCtxt) {
     let tcx = ccx.tcx;
-    if !tcx.sess.building_library.get() {
-        match *tcx.sess.entry_fn.borrow() {
-          Some((id, sp)) => match tcx.sess.entry_type.get() {
-              Some(session::EntryMain) => check_main_fn_ty(ccx, id, sp),
-              Some(session::EntryStart) => check_start_fn_ty(ccx, id, sp),
-              Some(session::EntryNone) => {}
-              None => tcx.sess.bug("entry function without a type")
-          },
-          None => {}
-        }
+    match *tcx.sess.entry_fn.borrow() {
+        Some((id, sp)) => match tcx.sess.entry_type.get() {
+            Some(session::EntryMain) => check_main_fn_ty(ccx, id, sp),
+            Some(session::EntryStart) => check_start_fn_ty(ccx, id, sp),
+            Some(session::EntryNone) => {}
+            None => tcx.sess.bug("entry function without a type")
+        },
+        None => {}
     }
 }
 

--- a/src/test/run-make/libs-and-bins/Makefile
+++ b/src/test/run-make/libs-and-bins/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	$(call RUN,foo)
+	rm $(TMPDIR)/$(call DYLIB_GLOB,foo)
+

--- a/src/test/run-make/libs-and-bins/foo.rs
+++ b/src/test/run-make/libs-and-bins/foo.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "dylib"]
+#![crate_type = "bin"]
+
+fn main() {}


### PR DESCRIPTION
This has long since not been too relevant since the introduction of many crate
type outputs. This commit removes the flag entirely, adjusting all logic to do
the most reasonable thing when building both a library and an executable.

Closes #13337
