### PR TITLE
rustc: Crawl static initializers for reachability

### DIFF
--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -270,11 +270,12 @@ impl<'a> ReachableContext<'a> {
 
                     // Statics with insignificant addresses are not reachable
                     // because they're inlined specially into all other crates.
-                    ast::ItemStatic(..) => {
+                    ast::ItemStatic(_, _, init) => {
                         if attr::contains_name(item.attrs.as_slice(),
                                                "address_insignificant") {
                             self.reachable_symbols.remove(&search_item);
                         }
+                        visit::walk_expr(self, init, ());
                     }
 
                     // These are normal, nothing reachable about these

--- a/src/test/auxiliary/issue-13620-1.rs
+++ b/src/test/auxiliary/issue-13620-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Foo {
+    pub foo: extern fn()
+}
+
+extern fn the_foo() {}
+
+pub static FOO: Foo = Foo {
+    foo: the_foo
+};

--- a/src/test/auxiliary/issue-13620-2.rs
+++ b/src/test/auxiliary/issue-13620-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate crate1 = "issue-13620-1";
+
+pub static FOO2: crate1::Foo = crate1::FOO;

--- a/src/test/run-pass/issue-13620.rs
+++ b/src/test/run-pass/issue-13620.rs
@@ -1,0 +1,18 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-13620-1.rs
+// aux-build:issue-13620-2.rs
+
+extern crate crate2 = "issue-13620-2";
+
+fn main() {
+    (crate2::FOO2.foo)();
+}


### PR DESCRIPTION
This ensures that private functions exported through static initializers will
actually end up being public in the object file (so other objects can continue
to reference the function).

Closes #13620
