### PR TITLE
libsyntax: Add `box PAT` to the pattern grammar. RFC #14.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2867,6 +2867,19 @@ impl<'a> Parser<'a> {
             // parse ref pat
             let mutbl = self.parse_mutability();
             pat = self.parse_pat_ident(BindByRef(mutbl));
+        } else if self.eat_keyword(keywords::Box) {
+            // `box PAT`
+            //
+            // FIXME(#13910): Rename to `PatBox` and extend to full DST
+            // support.
+            let sub = self.parse_pat();
+            pat = PatUniq(sub);
+            hi = self.last_span.hi;
+            return @ast::Pat {
+                id: ast::DUMMY_NODE_ID,
+                node: pat,
+                span: mk_sp(lo, hi)
+            }
         } else {
             let can_be_enum_or_struct = self.look_ahead(1, |t| {
                 match *t {

--- a/src/test/run-pass/box-pattern.rs
+++ b/src/test/run-pass/box-pattern.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let box x = box 3;
+    match box 3 {
+        box y => {
+            assert!(x == y);
+            println!("{} {}", x, y);
+        }
+    }
+}
+


### PR DESCRIPTION
r? @alexcrichton
