### PR TITLE
std: slice.get(i) shouldn't do bounds check twice

### DIFF
--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -975,7 +975,11 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
 
     #[inline]
     fn get(&self, index: uint) -> Option<&'a T> {
-        if index < self.len() { Some(&self[index]) } else { None }
+        if index < self.len() {
+            Some(unsafe { self.unsafe_ref(index) })
+        } else {
+            None
+        }
     }
 
     #[inline]


### PR DESCRIPTION
The `get` function already checks that `i` is within bounds, so skip the
second one and use `unsafe_ref`.
