### PR TITLE
Use defvar for rust-top-item-beg-re instead

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -380,11 +380,11 @@ idomenu (imenu with `ido-mode') for best mileage.")
 ;;; Defun Motions
 
 ;;; Start of a Rust item
-(setq rust-top-item-beg-re
-      (concat "^\\s-*\\(?:priv\\|pub\\)?\\s-*"
-              (regexp-opt
-               '("enum" "struct" "type" "mod" "use" "fn" "static" "impl"
-                 "extern" "impl" "static" "trait"))))
+(defvar rust-top-item-beg-re
+  (concat "^\\s-*\\(?:priv\\|pub\\)?\\s-*"
+          (regexp-opt
+           '("enum" "struct" "type" "mod" "use" "fn" "static" "impl"
+             "extern" "impl" "static" "trait"))))
 
 (defun rust-beginning-of-defun (&optional arg)
   "Move backward to the beginning of the current defun.


### PR DESCRIPTION
Since rust-top-item-beg-re hasn't been defined yet, using defvar instead of
setq is more appropriate here (and also silences compilation warnings).
