### PR TITLE
Recommend autoload instead of require

### DIFF
--- a/src/etc/emacs/README.md
+++ b/src/etc/emacs/README.md
@@ -12,11 +12,12 @@ To install manually, check out this repository and add this to your
 
 ```lisp
 (add-to-list 'load-path "/path/to/rust-mode/")
-(require 'rust-mode)
+(autoload 'rust-mode "rust-mode" nil t)
+(add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
 ```
 
-`rust-mode` will automatically be associated with `.rs` files. To enable it
-explicitly, do <kbd>M-x rust-mode</kbd>.
+This associates `rust-mode` with `.rs` files. To enable it explicitly, do
+<kbd>M-x rust-mode</kbd>.
 
 ### `package.el` installation via Marmalade or MELPA
 


### PR DESCRIPTION
Lazy loading with autoload will result in faster startup time for Emacs
users and is generally the recommended approach for major modes.
