### PR TITLE
vim: Fix indentation at global scope after non-semantic ([{/)]}

### DIFF
--- a/src/etc/vim/indent/rust.vim
+++ b/src/etc/vim/indent/rust.vim
@@ -30,7 +30,7 @@ endif
 
 " Come here when loading the script the first time.
 
-function s:get_line_trimmed(lnum)
+function! s:get_line_trimmed(lnum)
 	" Get the line and remove a trailing comment.
 	" Use syntax highlighting attributes when possible.
 	" NOTE: this is not accurate; /* */ or a line continuation could trick it
@@ -58,6 +58,20 @@ function s:get_line_trimmed(lnum)
 		" Sorry, this is not complete, nor fully correct (e.g. string "//").
 		" Such is life.
 		return substitute(line, "\s*//.*$", "", "")
+	endif
+endfunction
+
+function! s:is_string_comment(lnum, col)
+	if has('syntax_items')
+		for id in synstack(a:lnum, a:col)
+			let synname = synIDattr(id, "name")
+			if synname == "rustString" || synname =~ "^rustComment"
+				return 1
+			endif
+		endfor
+	else
+		" without syntax, let's not even try
+		return 0
 	endif
 endfunction
 
@@ -152,8 +166,10 @@ function GetRustIndent(lnum)
 	" column zero)
 
 	call cursor(a:lnum, 1)
-	if searchpair('{\|(', '', '}\|)', 'nbW') == 0
-		if searchpair('\[', '', '\]', 'nbW') == 0
+	if searchpair('{\|(', '', '}\|)', 'nbW'
+				\ 's:is_string_comment(line("."), col("."))') == 0
+		if searchpair('\[', '', '\]', 'nbW',
+					\ 's:is_string_comment(line("."), col("."))') == 0
 			" Global scope, should be zero
 			return 0
 		else


### PR DESCRIPTION
If an unbalanced [ exists in a string or comment, this should not be
considered when calculating the indent at the top level.

Similarly, when testing for ({/}) to see if we're at the top level to
begin with, strings and comments should be skipped.
