### PR TITLE
Add missing cases to the type_limits lint

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -788,10 +788,10 @@ fn check_type_limits(cx: &Context, e: &ast::Expr) {
     fn is_valid<T:cmp::Ord>(binop: ast::BinOp, v: T,
                             min: T, max: T) -> bool {
         match binop {
-            ast::BiLt => v <= max,
-            ast::BiLe => v < max,
-            ast::BiGt => v >= min,
-            ast::BiGe => v > min,
+            ast::BiLt => v >  min && v <= max,
+            ast::BiLe => v >= min && v <  max,
+            ast::BiGt => v >= min && v <  max,
+            ast::BiGe => v >  min && v <= max,
             ast::BiEq | ast::BiNe => v >= min && v <= max,
             _ => fail!()
         }

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -268,7 +268,7 @@ impl<'a, 'b> Context<'a, 'b> {
     fn verify_arg_type(&mut self, arg: Position, ty: ArgumentType) {
         match arg {
             Exact(arg) => {
-                if arg < 0 || self.args.len() <= arg {
+                if self.args.len() <= arg {
                     let msg = format!("invalid reference to argument `{}` (there \
                                     are {} arguments)", arg, self.args.len());
                     self.ecx.span_err(self.fmtsp, msg);

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -220,9 +220,7 @@ pub fn parse(file: &mut io::Reader,
     if bools_bytes != 0 {
         for i in range(0, bools_bytes) {
             let b = try!(file.read_byte());
-            if b < 0 {
-                return Err("error: expected more bools but hit EOF".to_owned());
-            } else if b == 1 {
+            if b == 1 {
                 bools_map.insert(bnames[i as uint].to_owned(), true);
             }
         }

--- a/src/test/compile-fail/lint-type-limits.rs
+++ b/src/test/compile-fail/lint-type-limits.rs
@@ -29,6 +29,18 @@ fn baz() -> bool {
                 //~^ WARNING literal out of range for its type
 }
 
+fn bleh() {
+    let u = 42u8;
+    let _ = u > 255; //~ ERROR comparison is useless due to type limits
+    let _ = 255 < u; //~ ERROR comparison is useless due to type limits
+    let _ = u < 0; //~ ERROR comparison is useless due to type limits
+    let _ = 0 > u; //~ ERROR comparison is useless due to type limits
+    let _ = u <= 255; //~ ERROR comparison is useless due to type limits
+    let _ = 255 >= u; //~ ERROR comparison is useless due to type limits
+    let _ = u >= 0; //~ ERROR comparison is useless due to type limits
+    let _ = 0 <= u; //~ ERROR comparison is useless due to type limits
+}
+
 fn qux() {
     let mut i = 1i8;
     while 200 != i { //~ ERROR comparison is useless due to type limits


### PR DESCRIPTION
Some cases were not correctly handled by this lint, for instance `let a = 42u8; a < 0` and `let a = 42u8; a > 255`.
It led to the discovery of two useless comparisons, which I removed.
