### PR TITLE
ICE: index is out of bounds

### DIFF
--- a/src/test/compile-fail/incompatible-tuple.rs
+++ b/src/test/compile-fail/incompatible-tuple.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let e: Result<int, int> = Ok(42);
+    match e {
+        Some(x) => x.unwrap(), //~ ERROR: mismatched types
+        Err(y) => {}
+    }
+}


### PR DESCRIPTION
Full error:

```
error: internal compiler error: unexpected failure
note: the compiler hit an unexpected failure path. this is a bug.
note: we would appreciate a bug report: http://static.rust-lang.org/doc/master/complement-bugreport.html
note: run with `RUST_BACKTRACE=1` for a backtrace
task 'rustc' failed at 'index out of bounds: the len is 0 but the index is 0', /Users/richo/code/ext/rust/src/librustc/lib.rs:1
stack backtrace:
   1:        0x10e056454 - rt::backtrace::imp::write::h83295a134654bcb25Ea::v0.11.pre
   2:        0x10dfaa9de - rt::unwind::begin_unwind_inner::hc38c28c2cd3ae771bfa::v0.11.pre
   3:        0x10dfaa168 - rt::unwind::begin_unwind::h2730927107001630441::v0.11.pre
   4:        0x10e055f19 - rt::unwind::begin_unwind_raw::h306590fe88d36375kca::v0.11.pre
   5:        0x10dfa93de - rt::unwind::fail_::hd63985b95168120aY99::v0.11.pre
   6:        0x10e055f62 - rt::unwind::fail_bounds_check::closure.40451
   7:        0x10dfab4ee - rt::unwind::fail_bounds_check::h26f221f8cf2bcc37laa::v0.11.pre
   8:        0x10b5e6689 - middle::typeck::check::method::LookupContext<'a>::push_bound_candidates::closure.65727
   9:        0x10b5e4c0a - middle::typeck::check::autoderef::h13135548454059641069::v0.11.pre
  10:        0x10b5e17a3 - middle::typeck::check::method::LookupContext<'a>::push_bound_candidates::hb51fd0fa2d0bb0cbP84::v0.11.pre
  11:        0x10b5e1a61 - middle::typeck::check::method::lookup_in_trait::h812eab9d072e657dtR4::v0.11.pre
  12:        0x10b5e2736 - middle::typeck::check::try_overloaded_deref::h14b178c47821eb9d3T8::v0.11.pre
  13:        0x10b5e4d34 - middle::typeck::check::autoderef::h13135548454059641069::v0.11.pre
  14:        0x10b5dffdb - middle::typeck::check::method::lookup::h959563854274ea31sK4::v0.11.pre
  15:        0x10b621953 - middle::typeck::check::check_expr_with_unifier::h38c3cedd0d5855f2fo9::v0.11.pre
  16:        0x10b57791e - middle::typeck::check::_match::check_match::h200da26bbf4c03bdVbZ::v0.11.pre
  17:        0x10b622313 - middle::typeck::check::check_expr_with_unifier::h38c3cedd0d5855f2fo9::v0.11.pre
  18:        0x10b60079c - middle::typeck::check::check_block_with_expected::h278a16eaf6104785sLb::v0.11.pre
  19:        0x10b5fbb09 - middle::typeck::check::check_fn::hf8fb603f939ec40btd7::v0.11.pre
  20:        0x10b5fb33a - middle::typeck::check::check_bare_fn::h31db39b42163c378k36::v0.11.pre
  21:        0x10b5f354e - middle::typeck::check::check_item::h9aec93d2daba64f8Hz7::v0.11.pre
  22:        0x10b5fb0bd - middle::typeck::check::check_item_types::h15c7ff25086978eaC26::v0.11.pre
  23:        0x10b73da0f - util::common::time::h5306111628350992853::v0.11.pre
  24:        0x10b73c93d - middle::typeck::check_crate::h32079f61ae4627d9Czu::v0.11.pre
  25:        0x10bb45a11 - driver::driver::phase_3_run_analysis_passes::hec78e69f36698c2dmsf::v0.11.pre
  26:        0x10bb4b462 - driver::driver::compile_input::hf2bc71d67063a45exRf::v0.11.pre
  27:        0x10bb71ab7 - run_compiler::h6e7451d32e4a45f8bln::v0.11.pre
  28:        0x10bb89a0d - main_args::closure.91252
  29:        0x10bb87da2 - monitor::closure.91127
  30:        0x10bb8298b - task::TaskBuilder::try::closure.90893
  31:        0x10dc6d06c - task::spawn_opts::closure.7136
  32:        0x10e04c458 - rt::task::Task::run::closure.40348
  33:        0x10e05b66c - rust_try
  34:        0x10e04c2d7 - rt::task::Task::run::h831eee15d405de45L57::v0.11.pre
  35:        0x10dc6ceef - task::spawn_opts::closure.7108
  36:        0x10e054e26 - rt::thread::thread_start::h6c71e4c659c05bcaYK8::v0.11.pre
  37:     0x7fff92226899 - _pthread_body
  38:     0x7fff9222672a - _pthread_struct_init
```

The code I was compiling is:

``` rust
#![crate_id = "charge"]

extern crate stripe;
extern crate http;

use std::io;

fn input(prompt: ~str) -> ~str {
    let output = io::stdout();
    let reader = io::stdin();

    output.write(prompt.as_bytes());

    match reader.read_line() {
        Some(line) => line.unwrap(),
        Err(err) => fail!("Error: {}", err)
    }
}

fn main() {
    let cc_no = input("CC no: ");
    println!("You entered: {}", cc_no);
}
```

The ICE only happens when I call `unwrap` on `line`. Otherwise it just explodes because of my inconsistent types.
