### PR TITLE
Fail on internal compiler errors in compile-fail

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -89,6 +89,7 @@ fn run_cfail_test(config: &config, props: &TestProps, testfile: &Path) {
     } else {
         check_error_patterns(props, testfile, &proc_res);
     }
+    check_no_compiler_crash(&proc_res);
 }
 
 fn run_rfail_test(config: &config, props: &TestProps, testfile: &Path) {
@@ -502,6 +503,15 @@ fn check_error_patterns(props: &TestProps,
             error(format!("error pattern '{}' not found!", *pattern));
         }
         fatal_ProcRes("multiple error patterns not found".to_owned(), proc_res);
+    }
+}
+
+fn check_no_compiler_crash(proc_res: &ProcRes) {
+    for line in proc_res.stderr.lines() {
+        if line.starts_with("error: internal compiler error:") {
+            fatal_ProcRes("compiler encountered internal error".to_owned(),
+                          proc_res);
+        }
     }
 }
 

--- a/src/test/compile-fail/inherit-struct8.rs
+++ b/src/test/compile-fail/inherit-struct8.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME: #13991
+
+
 // Test struct inheritance.
 #![feature(struct_inherit)]
 

--- a/src/test/compile-fail/issue-9725.rs
+++ b/src/test/compile-fail/issue-9725.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME: #13992
+
 struct A { foo: int }
 
 fn main() {

--- a/src/test/compile-fail/unsupported-cast.rs
+++ b/src/test/compile-fail/unsupported-cast.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME: #13993
 // error-pattern:unsupported cast
 
 extern crate libc;


### PR DESCRIPTION
This change makes internal compile errors in the compile-fail tests failures.

I believe this is the correct behaviour- those tests are intended to assert that the compiler doesn't proceed, not that it explodes.

So far, it fails on 4 tests in my environment, my testcase for #13943 which is what caused me to tackle this, and 3 others:

```
failures:
    [compile-fail] compile-fail/incompatible-tuple.rs # This one is mine and not on master
    [compile-fail] compile-fail/inherit-struct8.rs
    [compile-fail] compile-fail/issue-9725.rs
    [compile-fail] compile-fail/unsupported-cast.rs
```
