### PR TITLE
regex_macros: Fix valgrind errors

### DIFF
--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -247,15 +247,11 @@ fn exec<'t>(which: ::regex::native::MatchKind, input: &'t str,
         fn new(which: MatchKind) -> Threads {
             Threads {
                 which: which,
-                // These unsafe blocks are used for performance reasons, as it
-                // gives us a zero-cost initialization of a sparse set. The
-                // trick is described in more detail here:
-                // http://research.swtch.com/sparse
-                // The idea here is to avoid initializing threads that never
-                // need to be initialized, particularly for larger regexs with
-                // a lot of instructions.
-                queue: unsafe { ::std::mem::uninit() },
-                sparse: unsafe { ::std::mem::uninit() },
+                queue: [Thread {
+                    pc: 0,
+                    captures: [None, ..$num_cap_locs];
+                }, ..$num_insts],
+                sparse: [0, ..$num_insts],
                 size: 0,
             }
         }


### PR DESCRIPTION
While speedier to not perform initialization, these calls to mem::init() are
causing valgrind errors when using compiled macros.

Closes #13969
