### PR TITLE
std: Extract format string parsing out of libstd

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -52,7 +52,7 @@
 TARGET_CRATES := libc std green rustuv native flate arena glob term semver \
                  uuid serialize sync getopts collections num test time rand \
 		 workcache url log regex graphviz core
-HOST_CRATES := syntax rustc rustdoc fourcc hexfloat regex_macros
+HOST_CRATES := syntax rustc rustdoc fourcc hexfloat regex_macros fmt_macros
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustdoc rustc
 
@@ -61,7 +61,7 @@ DEPS_std := core libc native:rustrt native:compiler-rt native:backtrace
 DEPS_green := std rand native:context_switch
 DEPS_rustuv := std native:uv native:uv_support
 DEPS_native := std
-DEPS_syntax := std term serialize collections log
+DEPS_syntax := std term serialize collections log fmt_macros
 DEPS_rustc := syntax native:rustllvm flate arena serialize sync getopts \
               collections time log
 DEPS_rustdoc := rustc native:hoedown serialize sync getopts collections \
@@ -88,6 +88,7 @@ DEPS_workcache := std serialize collections log
 DEPS_log := std sync
 DEPS_regex := std collections
 DEPS_regex_macros = syntax std regex
+DEPS_fmt_macros = std
 
 TOOL_DEPS_compiletest := test green rustuv getopts
 TOOL_DEPS_rustdoc := rustdoc native

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -8,17 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Parsing of format strings
+//! Macro support for format strings
 //!
 //! These structures are used when parsing format strings for the compiler.
 //! Parsing does not happen at runtime: structures of `std::fmt::rt` are
 //! generated instead.
 
-use prelude::*;
+#![crate_id = "fmt_macros#0.11-pre"]
+#![license = "MIT/ASL2"]
+#![crate_type = "rlib"]
+#![crate_type = "dylib"]
+#![feature(macro_rules, globs)]
+#![experimental]
 
-use char;
-use owned::Box;
-use str;
+use std::char;
+use std::str;
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.
@@ -164,7 +168,7 @@ pub struct PluralArm<'a> {
 /// is specially placed in the `Plural` variant of `Method`.
 ///
 /// http://www.icu-project.org/apiref/icu4c/classicu_1_1PluralRules.html
-#[deriving(Eq, TotalEq, Hash)]
+#[deriving(Eq, TotalEq, Hash, Show)]
 #[allow(missing_doc)]
 pub enum PluralKeyword {
     /// The plural form for zero objects.
@@ -683,7 +687,6 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prelude::*;
 
     fn same(fmt: &'static str, p: &[Piece<'static>]) {
         let mut parser = Parser::new(fmt);

--- a/src/libstd/fmt/rt.rs
+++ b/src/libstd/fmt/rt.rs
@@ -17,8 +17,16 @@
 #![allow(missing_doc)]
 #![doc(hidden)]
 
-use fmt::parse;
 use option::Option;
+
+#[cfg(stage0)]
+pub use fmt::parse::{Alignment, AlignLeft, AlignRight, AlignUnknown};
+#[cfg(stage0)]
+pub use fmt::parse::{PluralKeyword, Zero, One, Two, Few, Many};
+#[cfg(stage0)]
+pub use fmt::parse::{Flag, FlagSignPlus, FlagSignMinus, FlagSignAwareZeroPad};
+#[cfg(stage0)]
+pub use fmt::parse::{FlagAlternate};
 
 pub enum Piece<'a> {
     String(&'a str),
@@ -35,10 +43,18 @@ pub struct Argument<'a> {
 
 pub struct FormatSpec {
     pub fill: char,
-    pub align: parse::Alignment,
+    pub align: Alignment,
     pub flags: uint,
     pub precision: Count,
     pub width: Count,
+}
+
+#[cfg(not(stage0))]
+#[deriving(Eq)]
+pub enum Alignment {
+    AlignLeft,
+    AlignRight,
+    AlignUnknown,
 }
 
 pub enum Count {
@@ -49,14 +65,30 @@ pub enum Position {
     ArgumentNext, ArgumentIs(uint)
 }
 
+#[cfg(not(stage0))]
+pub enum Flag {
+    FlagSignPlus,
+    FlagSignMinus,
+    FlagAlternate,
+    FlagSignAwareZeroPad,
+}
+
 pub enum Method<'a> {
     Plural(Option<uint>, &'a [PluralArm<'a>], &'a [Piece<'a>]),
     Select(&'a [SelectArm<'a>], &'a [Piece<'a>]),
 }
 
 pub enum PluralSelector {
-    Keyword(parse::PluralKeyword),
+    Keyword(PluralKeyword),
     Literal(uint),
+}
+
+pub enum PluralKeyword {
+    Zero,
+    One,
+    Two,
+    Few,
+    Many,
 }
 
 pub struct PluralArm<'a> {

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -18,7 +18,7 @@ use parse::token::InternedString;
 use parse::token;
 use rsparse = parse;
 
-use std::fmt::parse;
+use parse = fmt_macros;
 use collections::{HashMap, HashSet};
 
 #[deriving(Eq)]
@@ -232,7 +232,7 @@ impl<'a, 'b> Context<'a, 'b> {
                             parse::Keyword(name) => {
                                 self.ecx.span_err(self.fmtsp,
                                                   format!("duplicate selector \
-                                                           `{:?}`", name));
+                                                           `{}`", name));
                             }
                             parse::Literal(idx) => {
                                 self.ecx.span_err(self.fmtsp,
@@ -375,19 +375,9 @@ impl<'a, 'b> Context<'a, 'b> {
         return vec!(unnamed, allow_dead_code);
     }
 
-    fn parsepath(&self, s: &str) -> Vec<ast::Ident> {
-        vec!(self.ecx.ident_of("std"), self.ecx.ident_of("fmt"),
-          self.ecx.ident_of("parse"), self.ecx.ident_of(s))
-    }
-
     fn rtpath(&self, s: &str) -> Vec<ast::Ident> {
         vec!(self.ecx.ident_of("std"), self.ecx.ident_of("fmt"),
           self.ecx.ident_of("rt"), self.ecx.ident_of(s))
-    }
-
-    fn ctpath(&self, s: &str) -> Vec<ast::Ident> {
-        vec!(self.ecx.ident_of("std"), self.ecx.ident_of("fmt"),
-          self.ecx.ident_of("parse"), self.ecx.ident_of(s))
     }
 
     fn none(&self) -> @ast::Expr {
@@ -475,7 +465,7 @@ impl<'a, 'b> Context<'a, 'b> {
                             }).collect();
                         let (lr, selarg) = match arm.selector {
                             parse::Keyword(t) => {
-                                let p = self.ctpath(format!("{:?}", t));
+                                let p = self.rtpath(t.to_str());
                                 let p = self.ecx.path_global(sp, p);
                                 (self.rtpath("Keyword"), self.ecx.expr_path(p))
                             }
@@ -564,13 +554,13 @@ impl<'a, 'b> Context<'a, 'b> {
                 let fill = self.ecx.expr_lit(sp, ast::LitChar(fill));
                 let align = match arg.format.align {
                     parse::AlignLeft => {
-                        self.ecx.path_global(sp, self.parsepath("AlignLeft"))
+                        self.ecx.path_global(sp, self.rtpath("AlignLeft"))
                     }
                     parse::AlignRight => {
-                        self.ecx.path_global(sp, self.parsepath("AlignRight"))
+                        self.ecx.path_global(sp, self.rtpath("AlignRight"))
                     }
                     parse::AlignUnknown => {
-                        self.ecx.path_global(sp, self.parsepath("AlignUnknown"))
+                        self.ecx.path_global(sp, self.rtpath("AlignUnknown"))
                     }
                 };
                 let align = self.ecx.expr_path(align);

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -35,6 +35,7 @@ extern crate term;
 extern crate collections;
 #[phase(syntax, link)]
 extern crate log;
+extern crate fmt_macros;
 
 pub mod util {
     pub mod interner;


### PR DESCRIPTION
This code does not belong in libstd, and rather belongs in a dedicated crate. In
the future, the syntax::ext::format module should move to the fmt_macros crate
(hence the name of the crate), but for now the fmt_macros crate will only
contain the format string parser.

The entire fmt_macros crate is marked #[experimental] because it is not meant
for general consumption, only the format!() interface is officially supported,
not the internals.

This is a breaking change for anyone using the internals of std::fmt::parse.
Some of the flags have moved to std::fmt::rt, while the actual parsing support
has all moved to the fmt_macros library.

[breaking-change]
