### PR TITLE
Get `make check-stage1` working again

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -793,8 +793,27 @@ else
 CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4) = $$(RSINPUTS_$(4))
 endif
 
+# (Issues #13732, #13983, #14000) The doc for the regex crate includes
+# uses of the `regex!` macro from the regex_macros crate.  There is
+# normally a dependence injected that makes the target's regex depend
+# upon the host's regex_macros (see #13845), but that dependency
+# injection is currently skipped for stage1 as a special case.
+#
+# Therefore, as a further special case, this conditional skips
+# attempting to run the doc tests for the regex crate atop stage1,
+# (since there is no regex_macros crate for the stage1 rustc to load).
+#
+# (Another approach for solving this would be to inject the desired
+# dependence for stage1 as well, by setting things up to generate a
+# regex_macros crate that was compatible with the stage1 rustc and
+# thus re-enable our ability to run this test.)
+ifeq (stage$(1)-crate-$(4),stage1-crate-regex)
+check-stage$(1)-T-$(2)-H-$(3)-doc-crate-$(4)-exec:
+	@$$(call E, skipping doc-crate-$(4) as it uses macros and cannot run at stage$(1))
+else
 check-stage$(1)-T-$(2)-H-$(3)-doc-crate-$(4)-exec: \
 	$$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4))
+endif
 
 ifeq ($(2),$$(CFG_BUILD))
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)): $$(CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4))
@@ -951,7 +970,10 @@ $(3)/test/run-make/%-$(1)-T-$(2)-H-$(3).ok: \
 	    "$$(CC_$(3)) $$(CFG_GCCISH_CFLAGS_$(3))" \
 	    $$(HBIN$(1)_H_$(3))/rustdoc$$(X_$(3)) \
 	    "$$(TESTNAME)" \
-	    "$$(RPATH_VAR$(1)_T_$(2)_H_$(3))"
+	    $$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3)) \
+	    "$$(LD_LIBRARY_PATH_ENV_HOSTDIR$(1)_T_$(2)_H_$(3))" \
+	    "$$(LD_LIBRARY_PATH_ENV_TARGETDIR$(1)_T_$(2)_H_$(3))" \
+	    $(1)
 	@touch $$@
 else
 # FIXME #11094 - The above rule doesn't work right for multiple targets

--- a/src/etc/maketest.py
+++ b/src/etc/maketest.py
@@ -30,6 +30,10 @@ def putenv(name, value):
         value = normalize_path(value)
     os.putenv(name, value)
 
+def convert_path_spec(name, value):
+    if os.name == 'nt' and name != 'PATH':
+        value = ":".join(normalize_path(v) for v in value.split(";"))
+    return value
 
 make = sys.argv[2]
 putenv('RUSTC', os.path.abspath(sys.argv[3]))
@@ -37,13 +41,10 @@ putenv('TMPDIR', os.path.abspath(sys.argv[4]))
 putenv('CC', sys.argv[5])
 putenv('RUSTDOC', os.path.abspath(sys.argv[6]))
 filt = sys.argv[7]
-ldpath = sys.argv[8]
-if ldpath != '':
-    name = ldpath.split('=')[0]
-    value = ldpath.split('=')[1]
-    if os.name == 'nt' and name != 'PATH':
-        value = ":".join(normalize_path(v) for v in value.split(";"))
-    os.putenv(name, value)
+putenv('LD_LIB_PATH_ENVVAR', sys.argv[8]);
+putenv('HOST_RPATH_DIR', os.path.abspath(sys.argv[9]));
+putenv('TARGET_RPATH_DIR', os.path.abspath(sys.argv[10]));
+putenv('RUST_BUILD_STAGE', sys.argv[11])
 
 if not filt in sys.argv[1]:
     sys.exit(0)

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -17,7 +17,7 @@ use back::svh::Svh;
 use driver::session::Session;
 use driver::{driver, config};
 use metadata::cstore;
-use metadata::cstore::CStore;
+use metadata::cstore::{CStore, CrateSource};
 use metadata::decoder;
 use metadata::loader;
 use metadata::loader::CratePaths;
@@ -68,10 +68,15 @@ impl<'a> visit::Visitor<()> for Env<'a> {
 
 fn dump_crates(cstore: &CStore) {
     debug!("resolved crates:");
-    cstore.iter_crate_data(|_, data| {
+    cstore.iter_crate_data_origins(|_, data, opt_source| {
         debug!("crate_id: {}", data.crate_id());
         debug!("  cnum: {}", data.cnum);
         debug!("  hash: {}", data.hash());
+        opt_source.map(|cs| {
+            let CrateSource { dylib, rlib, cnum: _ } = cs;
+            dylib.map(|dl| debug!("  dylib: {}", dl.display()));
+            rlib.map(|rl|  debug!("   rlib: {}", rl.display()));
+        });
     })
 }
 

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -114,6 +114,17 @@ impl CStore {
         }
     }
 
+    /// Like `iter_crate_data`, but passes source paths (if available) as well.
+    pub fn iter_crate_data_origins(&self, i: |ast::CrateNum,
+                                              &crate_metadata,
+                                              Option<CrateSource>|) {
+        for (&k, v) in self.metas.borrow().iter() {
+            let origin = self.get_used_crate_source(k);
+            origin.as_ref().map(|cs| { assert!(k == cs.cnum); });
+            i(k, &**v, origin);
+        }
+    }
+
     pub fn add_used_crate_source(&self, src: CrateSource) {
         let mut used_crate_sources = self.used_crate_sources.borrow_mut();
         if !used_crate_sources.contains(&src) {

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -136,7 +136,7 @@ impl<'a> FileSearch<'a> {
 
     pub fn add_dylib_search_paths(&self) {
         self.for_each_lib_search_path(|lib_search_path| {
-            DynamicLibrary::add_search_path(lib_search_path);
+            DynamicLibrary::prepend_search_path(lib_search_path);
             FileDoesntMatch
         })
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -284,7 +284,7 @@ fn rust_input(cratefile: &str, matches: &getopts::Matches) -> Output {
         core::run_core(libs.move_iter().map(|x| x.clone()).collect(),
                        cfgs.move_iter().map(|x| x.to_strbuf()).collect(),
                        &cr)
-    }).unwrap();
+    }).map_err(|boxed_any|format!("{:?}", boxed_any)).unwrap();
     info!("finished with rustc");
     analysiskey.replace(Some(analysis));
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -524,6 +524,9 @@ fn load_extern_macros(krate: &ast::ViewItem, fld: &mut MacroExpander) {
         None => return
     };
 
+    debug!("load_extern_macros: mapped crate {} to path {} and registrar {:s}",
+           crate_name, path.display(), registrar);
+
     let lib = match DynamicLibrary::open(Some(&path)) {
         Ok(lib) => lib,
         // this is fatal: there are almost certainly macros we need

--- a/src/test/run-make/bootstrap-from-c-with-green/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-green/Makefile
@@ -1,9 +1,13 @@
 -include ../tools.mk
 
+HOST_LIB_DIR=$(TMPDIR)/../../../stage$(RUST_BUILD_STAGE)/lib
+# This overrides the LD_LIBRARY_PATH for RUN
+TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
+
 all:
 	$(RUSTC) lib.rs
 	ln -nsf $(call DYLIB,boot-*) $(call DYLIB,boot)
-	$(CC) main.c -o $(call RUN,main) -lboot
+	$(CC) main.c -o $(call RUN_BINFILE,main) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -lboot
 	$(call RUN,main)
-	rm $(call DYLIB,boot)
+	$(call REMOVE_DYLIBS,boot)
 	$(call FAIL,main)

--- a/src/test/run-make/bootstrap-from-c-with-native/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-native/Makefile
@@ -1,9 +1,13 @@
 -include ../tools.mk
 
+HOST_LIB_DIR=$(TMPDIR)/../../../stage$(RUST_BUILD_STAGE)/lib
+# This overrides the LD_LIBRARY_PATH for RUN
+TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
+
 all:
 	$(RUSTC) lib.rs
 	ln -nsf $(call DYLIB,boot-*) $(call DYLIB,boot)
-	$(CC) main.c -o $(call RUN,main) -lboot
+	$(CC) main.c -o $(call RUN_BINFILE,main) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -lboot
 	$(call RUN,main)
-	rm $(call DYLIB,boot)
+	$(call REMOVE_DYLIBS,boot)
 	$(call FAIL,main)

--- a/src/test/run-make/c-dynamic-dylib/Makefile
+++ b/src/test/run-make/c-dynamic-dylib/Makefile
@@ -9,6 +9,6 @@ all: $(call DYLIB,cfoo)
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs
 	$(call RUN,bar)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,cfoo)
+	$(call REMOVE_DYLIBS,cfoo)
 	$(call FAIL,bar)
 endif

--- a/src/test/run-make/c-dynamic-rlib/Makefile
+++ b/src/test/run-make/c-dynamic-rlib/Makefile
@@ -1,5 +1,8 @@
 -include ../tools.mk
 
+# This overrides the LD_LIBRARY_PATH for RUN
+TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
+
 # This hits an assertion in the linker on older versions of osx apparently
 ifeq ($(shell uname),Darwin)
 all:
@@ -8,7 +11,7 @@ else
 all: $(call DYLIB,cfoo)
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs
-	LD_LIBRARY_PATH=$(TMPDIR) $(call RUN,bar)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,cfoo)
+	$(call RUN,bar)
+	$(call REMOVE_DYLIBS,cfoo)
 	$(call FAIL,bar)
 endif

--- a/src/test/run-make/c-link-to-rust-dylib/Makefile
+++ b/src/test/run-make/c-link-to-rust-dylib/Makefile
@@ -1,9 +1,11 @@
 -include ../tools.mk
 
+HOST_LIB_DIR=$(TMPDIR)/../../../stage$(RUST_BUILD_STAGE)/lib
+
 all:
 	$(RUSTC) foo.rs
 	ln -s $(call DYLIB,foo-*) $(call DYLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) -Wl,-rpath,$(TMPDIR)
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -Wl,-rpath,$(TMPDIR)
 	$(call RUN,bar)
-	rm $(call DYLIB,foo)
+	$(call REMOVE_DYLIBS,foo)
 	$(call FAIL,bar)

--- a/src/test/run-make/c-link-to-rust-staticlib/Makefile
+++ b/src/test/run-make/c-link-to-rust-staticlib/Makefile
@@ -11,7 +11,7 @@ ifneq ($(shell uname),FreeBSD)
 all:
 	$(RUSTC) foo.rs
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(EXTRAFLAGS) -lstdc++
 	$(call RUN,bar)
 	rm $(call STATICLIB,foo*)
 	$(call RUN,bar)

--- a/src/test/run-make/c-static-dylib/Makefile
+++ b/src/test/run-make/c-static-dylib/Makefile
@@ -5,5 +5,5 @@ all: $(call STATICLIB,cfoo)
 	$(RUSTC) bar.rs
 	rm $(TMPDIR)/$(call STATICLIB_GLOB,cfoo)
 	$(call RUN,bar)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,foo)
+	$(call REMOVE_DYLIBS,foo)
 	$(call FAIL,bar)

--- a/src/test/run-make/c-static-rlib/Makefile
+++ b/src/test/run-make/c-static-rlib/Makefile
@@ -3,6 +3,6 @@
 all: $(call STATICLIB,cfoo)
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs
-	rm $(TMPDIR)/$(call RLIB_GLOB,foo)
+	$(call REMOVE_RLIBS,foo)
 	rm $(TMPDIR)/$(call STATICLIB_GLOB,cfoo)
 	$(call RUN,bar)

--- a/src/test/run-make/dylib-chain/Makefile
+++ b/src/test/run-make/dylib-chain/Makefile
@@ -6,7 +6,7 @@ all:
 	$(RUSTC) m3.rs
 	$(RUSTC) m4.rs
 	$(call RUN,m4)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,m1)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,m2)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,m3)
+	$(call REMOVE_DYLIBS,m1)
+	$(call REMOVE_DYLIBS,m2)
+	$(call REMOVE_DYLIBS,m3)
 	$(call FAIL,m4)

--- a/src/test/run-make/extern-fn-reachable/Makefile
+++ b/src/test/run-make/extern-fn-reachable/Makefile
@@ -1,5 +1,8 @@
 -include ../tools.mk
 
+# This overrides the LD_LIBRARY_PATH for RUN
+TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
+
 all:
 	$(RUSTC) dylib.rs -o $(TMPDIR)/libdylib.so
 	$(RUSTC) main.rs

--- a/src/test/run-make/lto-smoke-c/Makefile
+++ b/src/test/run-make/lto-smoke-c/Makefile
@@ -19,5 +19,5 @@ CC := $(CC:-g=)
 all:
 	$(RUSTC) foo.rs -Z lto
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN,bar) $(EXTRAFLAGS) -lstdc++
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(EXTRAFLAGS) -lstdc++
 	$(call RUN,bar)

--- a/src/test/run-make/lto-syntax-extension/Makefile
+++ b/src/test/run-make/lto-syntax-extension/Makefile
@@ -1,6 +1,18 @@
 -include ../tools.mk
 
-all:
+# This test attempts to use syntax extensions, which are known to be
+# incompatible with stage1 at the moment.
+
+ifeq ($(RUST_BUILD_STAGE),1)
+DOTEST=
+else
+DOTEST=dotest
+endif
+
+all: $(DOTEST)
+
+dotest:
+	env
 	$(RUSTC) lib.rs
 	$(RUSTC) main.rs -Z lto
 	$(call RUN,main)

--- a/src/test/run-make/missing-crate-dependency/Makefile
+++ b/src/test/run-make/missing-crate-dependency/Makefile
@@ -3,7 +3,7 @@
 all: 
 	$(RUSTC) --crate-type=rlib crateA.rs
 	$(RUSTC) --crate-type=rlib crateB.rs
-	rm $(TMPDIR)/$(call RLIB_GLOB,crateA)
+	$(call REMOVE_RLIBS,crateA)
 	# Ensure crateC fails to compile since dependency crateA is missing
 	$(RUSTC) crateC.rs 2>&1 | \
 		grep "error: can't find crate for \`crateA\` which \`crateB\` depends on"

--- a/src/test/run-make/mixing-libs/Makefile
+++ b/src/test/run-make/mixing-libs/Makefile
@@ -5,5 +5,5 @@ all:
 	$(RUSTC) dylib.rs
 	$(RUSTC) rlib.rs --crate-type=dylib
 	$(RUSTC) dylib.rs
-	rm $(call DYLIB,rlib-*)
+	$(call REMOVE_DYLIBS,rlib)
 	$(RUSTC) prog.rs && exit 1 || exit 0

--- a/src/test/run-make/obey-crate-type-flag/Makefile
+++ b/src/test/run-make/obey-crate-type-flag/Makefile
@@ -7,7 +7,7 @@
 # fail if an rlib was built
 all:
 	$(RUSTC) test.rs
-	rm $(TMPDIR)/$(call RLIB_GLOB,test)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,test)
+	$(call REMOVE_RLIBS,test)
+	$(call REMOVE_DYLIBS,test)
 	$(RUSTC) --crate-type dylib test.rs
-	rm $(TMPDIR)/$(call RLIB_GLOB,test) && exit 1 || exit 0
+	$(call REMOVE_RLIBS,test) && exit 1 || exit 0

--- a/src/test/run-make/output-type-permutations/Makefile
+++ b/src/test/run-make/output-type-permutations/Makefile
@@ -2,8 +2,8 @@
 
 all:
 	$(RUSTC) foo.rs --crate-type=rlib,dylib,staticlib
-	rm $(TMPDIR)/$(call RLIB_GLOB,bar)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,bar)
+	$(call REMOVE_RLIBS,bar)
+	$(call REMOVE_DYLIBS,bar)
 	rm $(TMPDIR)/$(call STATICLIB_GLOB,bar)
 	$(RUSTC) foo.rs --crate-type=bin
 	rm $(TMPDIR)/$(call BIN,bar)
@@ -41,4 +41,4 @@ all:
 	cmp $(TMPDIR)/foo.bc $(TMPDIR)/bar.bc
 	rm $(TMPDIR)/bar.bc
 	rm $(TMPDIR)/foo.bc
-	rm $(TMPDIR)/$(call RLIB_GLOB,bar)
+	$(call REMOVE_RLIBS,bar)

--- a/src/test/run-make/prefer-dylib/Makefile
+++ b/src/test/run-make/prefer-dylib/Makefile
@@ -5,4 +5,4 @@ all:
 	$(RUSTC) foo.rs -C prefer-dynamic
 	$(call RUN,foo)
 	rm $(TMPDIR)/*bar*
-	$(call FAILS,foo)
+	$(call FAIL,foo)

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -4,8 +4,20 @@ export DYLD_LIBRARY_PATH:=$(TMPDIR):$(DYLD_LIBRARY_PATH)
 RUSTC := $(RUSTC) --out-dir $(TMPDIR) -L $(TMPDIR)
 CC := $(CC) -L $(TMPDIR)
 
-RUN = $(TMPDIR)/$(1)
-FAILS = $(TMPDIR)/$(1) && exit 1 || exit 0
+# These deliberately use `=` and not `:=` so that client makefiles can
+# augment HOST_RPATH_DIR / TARGET_RPATH_DIR.
+HOST_RPATH_ENV = \
+    $(LD_LIB_PATH_ENVVAR)=$$$(LD_LIB_PATH_ENVVAR):$(HOST_RPATH_DIR)
+TARGET_RPATH_ENV = \
+    $(LD_LIB_PATH_ENVVAR)=$$$(LD_LIB_PATH_ENVVAR):$(TARGET_RPATH_DIR)
+
+# This is the name of the binary we will generate and run; use this
+# e.g. for `$(CC) -o $(RUN_BINFILE)`.
+RUN_BINFILE = $(TMPDIR)/$(1)
+
+# RUN and FAIL are basic way we will invoke the generated binary.  On
+# non-windows platforms, they set the LD_LIBRARY_PATH environment
+# variable before running the binary.
 
 RLIB_GLOB = lib$(1)*.rlib
 STATICLIB = $(TMPDIR)/lib$(1).a
@@ -18,19 +30,31 @@ IS_WINDOWS=1
 endif
 
 ifeq ($(UNAME),Darwin)
+RUN = $(TARGET_RPATH_ENV) $(RUN_BINFILE)
+FAIL = $(TARGET_RPATH_ENV) $(RUN_BINFILE) && exit 1 || exit 0
 DYLIB_GLOB = lib$(1)*.dylib
 DYLIB = $(TMPDIR)/lib$(1).dylib
+RPATH_LINK_SEARCH =
 else
 ifdef IS_WINDOWS
+RUN = PATH="$(PATH):$(TARGET_RPATH_DIR)" $(RUN_BINFILE)
+FAIL = PATH="$(PATH):$(TARGET_RPATH_DIR)" $(RUN_BINFILE) && exit 1 || exit 0
 DYLIB_GLOB = $(1)*.dll
 DYLIB = $(TMPDIR)/$(1).dll
 BIN = $(1).exe
-export PATH := $(PATH):$(LD_LIBRARY_PATH)
+RPATH_LINK_SEARCH =
+RUSTC := PATH="$(PATH):$(LD_LIBRARY_PATH)" $(RUSTC)
 else
+RUN = $(TARGET_RPATH_ENV) $(RUN_BINFILE)
+FAIL = $(TARGET_RPATH_ENV) $(RUN_BINFILE) && exit 1 || exit 0
 DYLIB_GLOB = lib$(1)*.so
 DYLIB = $(TMPDIR)/lib$(1).so
+RPATH_LINK_SEARCH = -Wl,-rpath-link=$(1)
 endif
 endif
+
+REMOVE_DYLIBS     = rm $(TMPDIR)/$(call DYLIB_GLOB,$(1))
+REMOVE_RLIBS      = rm $(TMPDIR)/$(call RLIB_GLOB,$(1))
 
 %.a: %.o
 	ar crus $@ $<

--- a/src/test/run-make/unicode-input/Makefile
+++ b/src/test/run-make/unicode-input/Makefile
@@ -1,9 +1,21 @@
 -include ../tools.mk
 
+# This test attempts to run rustc itself from the compiled binary; but
+# that means that you need to set the LD_LIBRARY_PATH for rustc itself
+# while running multiple_files, and that won't work for stage1.
+
 # FIXME ignore windows
 ifndef IS_WINDOWS
+ifeq ($(RUST_BUILD_STAGE),1)
+DOTEST=
+else
+DOTEST=dotest
+endif
+endif
 
-all:
+all: $(DOTEST)
+
+dotest:
 	# check that we don't ICE on unicode input, issue #11178
 	$(RUSTC) multiple_files.rs
 	$(call RUN,multiple_files)  "$(RUSTC)" "$(TMPDIR)"
@@ -12,8 +24,3 @@ all:
 	# correct length. issue #8706
 	$(RUSTC) span_length.rs
 	$(call RUN,span_length) "$(RUSTC)" "$(TMPDIR)"
-
-else
-all:
-
-endif


### PR DESCRIPTION
Fix #13732.

This is a revised, much less hacky form of PR #13753

The changes here:
- add instrumentation to aid debugging of linkage errors,
- fine tune some things in the Makefile where we are telling binaries to use a host-oriented path for finding dynamic libraries, when it should be feeding the binaries a target-oriented path for dynamic libraries.
- pass along the current stage number to run-make tests, and
- skip certain tests when running atop stage1.

Fix #13746 as well.
