### PR TITLE
Move the mutex module out of std::unstable and straight into libstd.

### DIFF
--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -14,7 +14,7 @@ use std::rt::rtio::{RemoteCallback, PausableIdleCallback, Callback, EventLoop};
 use std::rt::task::BlockedTask;
 use std::rt::task::Task;
 use std::sync::deque;
-use std::unstable::mutex::NativeMutex;
+use std::rt::mutex::NativeMutex;
 use std::raw;
 
 use rand::{XorShiftRng, Rng, Rand};
@@ -1474,7 +1474,7 @@ mod test {
 
     #[test]
     fn test_spawn_sched_blocking() {
-        use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+        use std::rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
         static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
         // Testing that a task in one scheduler can block in foreign code

--- a/src/libgreen/simple.rs
+++ b/src/libgreen/simple.rs
@@ -18,7 +18,7 @@ use std::rt::local::Local;
 use std::rt::rtio;
 use std::rt::task::{Task, BlockedTask};
 use std::task::TaskOpts;
-use std::unstable::mutex::NativeMutex;
+use std::rt::mutex::NativeMutex;
 
 struct SimpleTask {
     lock: NativeMutex,

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -28,7 +28,7 @@ use std::rt::rtio;
 use std::rt::stack;
 use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::task::TaskOpts;
-use std::unstable::mutex::NativeMutex;
+use std::rt::mutex::NativeMutex;
 
 use context::Context;
 use coroutine::Coroutine;

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -14,7 +14,8 @@ use std::io::net::ip;
 use std::io;
 use std::mem;
 use std::rt::rtio;
-use std::unstable::mutex;
+use std::sync::arc::UnsafeArc;
+use std::rt::mutex;
 
 use super::{IoResult, retry, keep_going};
 use super::c;
@@ -215,7 +216,7 @@ pub fn init() {}
 pub fn init() {
 
     unsafe {
-        use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+        use std::rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
         static mut INITIALIZED: bool = false;
         static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
 

--- a/src/libnative/io/pipe_unix.rs
+++ b/src/libnative/io/pipe_unix.rs
@@ -15,7 +15,8 @@ use std::intrinsics;
 use std::io;
 use std::mem;
 use std::rt::rtio;
-use std::unstable::mutex;
+use std::sync::arc::UnsafeArc;
+use std::rt::mutex;
 
 use super::{IoResult, retry};
 use super::net;

--- a/src/libnative/io/pipe_win32.rs
+++ b/src/libnative/io/pipe_win32.rs
@@ -94,7 +94,7 @@ use std::os;
 use std::ptr;
 use std::rt::rtio;
 use std::sync::atomics;
-use std::unstable::mutex;
+use std::rt::mutex;
 
 use super::IoResult;
 use super::c;

--- a/src/libnative/io/timer_helper.rs
+++ b/src/libnative/io/timer_helper.rs
@@ -1,0 +1,149 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation of the helper thread for the timer module
+//!
+//! This module contains the management necessary for the timer worker thread.
+//! This thread is responsible for performing the send()s on channels for timers
+//! that are using channels instead of a blocking call.
+//!
+//! The timer thread is lazily initialized, and it's shut down via the
+//! `shutdown` function provided. It must be maintained as an invariant that
+//! `shutdown` is only called when the entire program is finished. No new timers
+//! can be created in the future and there must be no active timers at that
+//! time.
+
+use std::mem;
+use std::rt::bookkeeping;
+use std::rt;
+use std::rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+
+use io::timer::{Req, Shutdown};
+use task;
+
+// You'll note that these variables are *not* protected by a lock. These
+// variables are initialized with a Once before any Timer is created and are
+// only torn down after everything else has exited. This means that these
+// variables are read-only during use (after initialization) and both of which
+// are safe to use concurrently.
+static mut HELPER_CHAN: *mut Sender<Req> = 0 as *mut Sender<Req>;
+static mut HELPER_SIGNAL: imp::signal = 0 as imp::signal;
+
+static mut TIMER_HELPER_EXIT: StaticNativeMutex = NATIVE_MUTEX_INIT;
+
+pub fn boot(helper: fn(imp::signal, Receiver<Req>)) {
+    static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
+    static mut INITIALIZED: bool = false;
+
+    unsafe {
+        let mut _guard = LOCK.lock();
+        if !INITIALIZED {
+            let (tx, rx) = channel();
+            // promote this to a shared channel
+            drop(tx.clone());
+            HELPER_CHAN = mem::transmute(box tx);
+            let (receive, send) = imp::new();
+            HELPER_SIGNAL = send;
+
+            task::spawn(proc() {
+                bookkeeping::decrement();
+                helper(receive, rx);
+                TIMER_HELPER_EXIT.lock().signal()
+            });
+
+            rt::at_exit(proc() { shutdown() });
+            INITIALIZED = true;
+        }
+    }
+}
+
+pub fn send(req: Req) {
+    unsafe {
+        assert!(!HELPER_CHAN.is_null());
+        (*HELPER_CHAN).send(req);
+        imp::signal(HELPER_SIGNAL);
+    }
+}
+
+fn shutdown() {
+    // Request a shutdown, and then wait for the task to exit
+    unsafe {
+        let guard = TIMER_HELPER_EXIT.lock();
+        send(Shutdown);
+        guard.wait();
+        drop(guard);
+        TIMER_HELPER_EXIT.destroy();
+    }
+
+
+    // Clean up after ther helper thread
+    unsafe {
+        imp::close(HELPER_SIGNAL);
+        let _chan: Box<Sender<Req>> = mem::transmute(HELPER_CHAN);
+        HELPER_CHAN = 0 as *mut Sender<Req>;
+        HELPER_SIGNAL = 0 as imp::signal;
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use libc;
+    use std::os;
+
+    use io::file::FileDesc;
+
+    pub type signal = libc::c_int;
+
+    pub fn new() -> (signal, signal) {
+        let pipe = os::pipe();
+        (pipe.input, pipe.out)
+    }
+
+    pub fn signal(fd: libc::c_int) {
+        FileDesc::new(fd, false).inner_write([0]).unwrap();
+    }
+
+    pub fn close(fd: libc::c_int) {
+        let _fd = FileDesc::new(fd, true);
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use libc::{BOOL, LPCSTR, HANDLE, LPSECURITY_ATTRIBUTES, CloseHandle};
+    use std::ptr;
+    use libc;
+
+    pub type signal = HANDLE;
+
+    pub fn new() -> (HANDLE, HANDLE) {
+        unsafe {
+            let handle = CreateEventA(ptr::mut_null(), libc::FALSE, libc::FALSE,
+                                      ptr::null());
+            (handle, handle)
+        }
+    }
+
+    pub fn signal(handle: HANDLE) {
+        assert!(unsafe { SetEvent(handle) != 0 });
+    }
+
+    pub fn close(handle: HANDLE) {
+        assert!(unsafe { CloseHandle(handle) != 0 });
+    }
+
+    extern "system" {
+        fn CreateEventA(lpSecurityAttributes: LPSECURITY_ATTRIBUTES,
+                        bManualReset: BOOL,
+                        bInitialState: BOOL,
+                        lpName: LPCSTR) -> HANDLE;
+        fn SetEvent(hEvent: HANDLE) -> BOOL;
+    }
+}

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -25,7 +25,7 @@ use std::rt::task::{Task, BlockedTask, SendMessage};
 use std::rt::thread::Thread;
 use std::rt;
 use std::task::TaskOpts;
-use std::unstable::mutex::NativeMutex;
+use std::rt::mutex::NativeMutex;
 
 use io;
 use task;

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -24,7 +24,8 @@ use alloc::arc::Arc;
 use libc::c_void;
 use std::mem;
 use std::rt::task::BlockedTask;
-use std::unstable::mutex::NativeMutex;
+use std::sync::arc::UnsafeArc;
+use std::rt::mutex::NativeMutex;
 use mpsc = std::sync::mpsc_queue;
 
 use async::AsyncWatcher;

--- a/src/libstd/comm/shared.rs
+++ b/src/libstd/comm/shared.rs
@@ -30,7 +30,7 @@ use rt::local::Local;
 use rt::task::{Task, BlockedTask};
 use rt::thread::Thread;
 use sync::atomics;
-use unstable::mutex::NativeMutex;
+use rt::mutex::NativeMutex;
 
 use mpsc = sync::mpsc_queue;
 

--- a/src/libstd/comm/sync.rs
+++ b/src/libstd/comm/sync.rs
@@ -46,7 +46,7 @@ use rt::local::Local;
 use rt::task::{Task, BlockedTask};
 use sync::atomics;
 use ty::Unsafe;
-use unstable::mutex::{NativeMutex, LockGuard};
+use rt::mutex::{NativeMutex, LockGuard};
 use vec::Vec;
 
 pub struct Packet<T> {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -161,7 +161,7 @@ Accessing environment variables is not generally threadsafe.
 Serialize access through a global lock.
 */
 fn with_env_lock<T>(f: || -> T) -> T {
-    use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+    use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
 
     static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
 

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -48,7 +48,7 @@ mod imp {
     use iter::Iterator;
     use option::{Option, Some, None};
     use owned::Box;
-    use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+    use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     use mem;
     use vec::Vec;
     use ptr::RawPtr;

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -242,7 +242,7 @@ mod imp {
     use mem;
     use option::{Some, None, Option};
     use result::{Ok, Err};
-    use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+    use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     use uw = rt::libunwind;
 
     struct Context<'a> {
@@ -515,7 +515,7 @@ mod imp {
     use str::StrSlice;
     use unstable::dynamic_lib::DynamicLibrary;
     use intrinsics;
-    use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+    use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     use slice::ImmutableVector;
 
     extern "system" {

--- a/src/libstd/rt/bookkeeping.rs
+++ b/src/libstd/rt/bookkeeping.rs
@@ -22,7 +22,7 @@
 #![doc(hidden)]
 
 use sync::atomics;
-use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
 
 static mut TASK_COUNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
 static mut TASK_LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -92,8 +92,9 @@ pub mod shouldnt_be_public {
 // Internal macros used by the runtime.
 mod macros;
 
-/// Implementations of language-critical runtime features like @.
 pub mod task;
+
+pub mod mutex;
 
 // The EventLoop and internal synchronous I/O interface.
 pub mod rtio;

--- a/src/libstd/rt/mutex.rs
+++ b/src/libstd/rt/mutex.rs
@@ -33,7 +33,7 @@
 //! # Example
 //!
 //! ```rust
-//! use std::unstable::mutex::{NativeMutex, StaticNativeMutex, NATIVE_MUTEX_INIT};
+//! use std::rt::mutex::{NativeMutex, StaticNativeMutex, NATIVE_MUTEX_INIT};
 //!
 //! // Use a statically initialized mutex
 //! static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
@@ -109,7 +109,7 @@ impl StaticNativeMutex {
     /// # Example
     ///
     /// ```rust
-    /// use std::unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+    /// use std::rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     /// static mut LOCK: StaticNativeMutex = NATIVE_MUTEX_INIT;
     /// unsafe {
     ///     let _guard = LOCK.lock();
@@ -183,7 +183,7 @@ impl NativeMutex {
     ///
     /// # Example
     /// ```rust
-    /// use std::unstable::mutex::NativeMutex;
+    /// use std::rt::mutex::NativeMutex;
     /// unsafe {
     ///     let mut lock = NativeMutex::new();
     ///

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -223,8 +223,8 @@ pub mod dl {
         dlopen(ptr::null(), Lazy as libc::c_int) as *u8
     }
 
-    pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, String> {
-        use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+    pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, ~str> {
+        use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
         static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
         unsafe {
             // dlerror isn't thread safe, so we need to lock around this entire

--- a/src/libstd/unstable/mod.rs
+++ b/src/libstd/unstable/mod.rs
@@ -13,5 +13,4 @@
 pub mod dynamic_lib;
 
 pub mod sync;
-pub mod mutex;
 

--- a/src/libstd/unstable/sync.rs
+++ b/src/libstd/unstable/sync.rs
@@ -13,7 +13,8 @@ use alloc::arc::Arc;
 use clone::Clone;
 use kinds::Send;
 use ty::Unsafe;
-use unstable::mutex::NativeMutex;
+use sync::arc::UnsafeArc;
+use rt::mutex::NativeMutex;
 
 struct ExData<T> {
     lock: NativeMutex,

--- a/src/libsync/mutex.rs
+++ b/src/libsync/mutex.rs
@@ -64,7 +64,7 @@ use std::rt::task::{BlockedTask, Task};
 use std::rt::thread::Thread;
 use std::sync::atomics;
 use std::ty::Unsafe;
-use std::unstable::mutex;
+use std::rt::mutex;
 
 use q = mpsc_intrusive;
 


### PR DESCRIPTION
This is not a breaking change as mutex is re-exported in std::unstable
to make a transition easier. `std::mutex` is also marked as unstable.

This change is related to #1457 and comment
https://github.com/mozilla/rust/issues/1457#issuecomment-40523194
