### PR TITLE
Reopening of #13739: rustdoc: Inline reexported items if possible.

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -154,7 +154,7 @@ fn resolved_path(w: &mut io::Writer, id: ast::NodeId, p: &clean::Path,
         |cache| {
             match cache.paths.find(&id) {
                 None => None,
-                Some(&(ref fqp, shortty)) => Some((fqp.clone(), shortty))
+                Some(info) => Some((info.fqp.clone(), info.ty))
             }
         })
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -213,6 +213,10 @@ nav.sub {
     margin: 0;
 }
 .docblock.short code { white-space: nowrap; }
+.docblock.short .reexported {
+    color: #888;
+    font-size: 90%;
+}
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
     border-bottom: 1px solid #DDD;


### PR DESCRIPTION
Mostly fixes #13045. See #13739 for the screenshots and detailed discussion; the main change remains same. I completely forgot to rebase in spite of #13777 (which also alters the very same files) being merged...
