### PR TITLE
Change the biguint documentation example to reflect deprecated ~[]

### DIFF
--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -74,7 +74,7 @@ pub mod BigDigit {
 /**
 A big unsigned integer type.
 
-A `BigUint`-typed value `BigUint { data: ~[a, b, c] }` represents a number
+A `BigUint`-typed value `BigUint { data: vec!(a, b, c) }` represents a number
 `(a + b * BigDigit::base + c * BigDigit::base^2)`.
 */
 #[deriving(Clone)]


### PR DESCRIPTION
I updated the documentation in BigUint to reflect the deprecation of ~[] in favor of Vec<>.
