### PR TITLE
libsyntax: Remove uses of `~str` from libsyntax, and fix fallout

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -536,7 +536,7 @@ pub fn crate_id_hash(crate_id: &CrateId) -> ~str {
     // the crate id in the hash because lookups are only done by (name/vers),
     // not by path.
     let mut s = Sha256::new();
-    s.input_str(crate_id.short_name_with_version());
+    s.input_str(crate_id.short_name_with_version().as_slice());
     truncated_hash_result(&mut s).slice_to(8).to_owned()
 }
 
@@ -566,7 +566,7 @@ fn symbol_hash(tcx: &ty::ctxt,
     // to be independent of one another in the crate.
 
     symbol_hasher.reset();
-    symbol_hasher.input_str(link_meta.crateid.name);
+    symbol_hasher.input_str(link_meta.crateid.name.as_slice());
     symbol_hasher.input_str("-");
     symbol_hasher.input_str(link_meta.crate_hash.as_str());
     symbol_hasher.input_str("-");

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -143,8 +143,8 @@ pub fn build_configuration(sess: &Session) -> ast::CrateConfig {
 fn parse_cfgspecs(cfgspecs: Vec<~str> )
                   -> ast::CrateConfig {
     cfgspecs.move_iter().map(|s| {
-        parse::parse_meta_from_source_str("cfgspec".to_str(),
-                                          s,
+        parse::parse_meta_from_source_str("cfgspec".to_strbuf(),
+                                          s.to_strbuf(),
                                           Vec::new(),
                                           &parse::new_parse_sess())
     }).collect::<ast::CrateConfig>()
@@ -175,8 +175,8 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
                 parse::parse_crate_from_file(&(*file), cfg.clone(), &sess.parse_sess)
             }
             StrInput(ref src) => {
-                parse::parse_crate_from_source_str(anon_src(),
-                                                   (*src).clone(),
+                parse::parse_crate_from_source_str(anon_src().to_strbuf(),
+                                                   src.to_strbuf(),
                                                    cfg.clone(),
                                                    &sess.parse_sess)
             }
@@ -528,7 +528,7 @@ fn write_out_deps(sess: &Session,
         // write Makefile-compatible dependency rules
         let files: Vec<~str> = sess.codemap().files.borrow()
                                    .iter().filter(|fmap| fmap.is_real_file())
-                                   .map(|fmap| fmap.name.clone())
+                                   .map(|fmap| fmap.name.to_owned())
                                    .collect();
         let mut file = try!(io::File::create(&deps_filename));
         for path in out_filenames.iter() {
@@ -604,20 +604,20 @@ impl pprust::PpAnn for IdentifiedAnnotation {
         match node {
             pprust::NodeItem(item) => {
                 try!(pp::space(&mut s.s));
-                s.synth_comment(item.id.to_str())
+                s.synth_comment(item.id.to_str().to_strbuf())
             }
             pprust::NodeBlock(blk) => {
                 try!(pp::space(&mut s.s));
-                s.synth_comment("block ".to_owned() + blk.id.to_str())
+                s.synth_comment((format!("block {}", blk.id)).to_strbuf())
             }
             pprust::NodeExpr(expr) => {
                 try!(pp::space(&mut s.s));
-                try!(s.synth_comment(expr.id.to_str()));
+                try!(s.synth_comment(expr.id.to_str().to_strbuf()));
                 s.pclose()
             }
             pprust::NodePat(pat) => {
                 try!(pp::space(&mut s.s));
-                s.synth_comment("pat ".to_owned() + pat.id.to_str())
+                s.synth_comment((format!("pat {}", pat.id)).to_strbuf())
             }
         }
     }
@@ -692,7 +692,7 @@ pub fn pretty_print_input(sess: Session,
             pprust::print_crate(sess.codemap(),
                                 sess.diagnostic(),
                                 &krate,
-                                src_name,
+                                src_name.to_strbuf(),
                                 &mut rdr,
                                 out,
                                 &IdentifiedAnnotation,
@@ -707,7 +707,7 @@ pub fn pretty_print_input(sess: Session,
             pprust::print_crate(annotation.analysis.ty_cx.sess.codemap(),
                                 annotation.analysis.ty_cx.sess.diagnostic(),
                                 &krate,
-                                src_name,
+                                src_name.to_strbuf(),
                                 &mut rdr,
                                 out,
                                 &annotation,
@@ -717,7 +717,7 @@ pub fn pretty_print_input(sess: Session,
             pprust::print_crate(sess.codemap(),
                                 sess.diagnostic(),
                                 &krate,
-                                src_name,
+                                src_name.to_strbuf(),
                                 &mut rdr,
                                 out,
                                 &pprust::NoAnn,

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -471,7 +471,8 @@ cgoptions!(
 )
 
 // Seems out of place, but it uses session, so I'm putting it here
-pub fn expect<T:Clone>(sess: &Session, opt: Option<T>, msg: || -> ~str) -> T {
+pub fn expect<T:Clone>(sess: &Session, opt: Option<T>, msg: || -> StrBuf)
+              -> T {
     diagnostic::expect(sess.diagnostic(), opt, msg)
 }
 

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -168,7 +168,7 @@ fn generate_test_harness(sess: &Session, krate: ast::Crate)
     cx.ext_cx.bt_push(ExpnInfo {
         call_site: DUMMY_SP,
         callee: NameAndSpan {
-            name: "test".to_owned(),
+            name: "test".to_strbuf(),
             format: MacroAttribute,
             span: None
         }
@@ -398,7 +398,7 @@ fn mk_tests(cx: &TestCtxt) -> @ast::Item {
 
 fn is_test_crate(krate: &ast::Crate) -> bool {
     match attr::find_crateid(krate.attrs.as_slice()) {
-        Some(ref s) if "test" == s.name => true,
+        Some(ref s) if "test" == s.name.as_slice() => true,
         _ => false
     }
 }
@@ -427,7 +427,7 @@ fn mk_test_desc_and_fn_rec(cx: &TestCtxt, test: &Test) -> @ast::Expr {
 
     let name_lit: ast::Lit =
         nospan(ast::LitStr(token::intern_and_get_ident(
-                    ast_util::path_name_i(path.as_slice())),
+                    ast_util::path_name_i(path.as_slice()).as_slice()),
                     ast::CookedStr));
 
     let name_expr = @ast::Expr {

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -352,10 +352,11 @@ fn parse_crate_attrs(sess: &session::Session, input: &d::Input) ->
                                                &sess.parse_sess)
         }
         d::StrInput(ref src) => {
-            parse::parse_crate_attrs_from_source_str(d::anon_src(),
-                                                     (*src).clone(),
-                                                     Vec::new(),
-                                                     &sess.parse_sess)
+            parse::parse_crate_attrs_from_source_str(
+                d::anon_src().to_strbuf(),
+                src.to_strbuf(),
+                Vec::new(),
+                &sess.parse_sess)
         }
     };
     result.move_iter().collect()

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -428,11 +428,11 @@ impl<'a> CrateLoader for Loader<'a> {
         };
         let macros = decoder::get_exported_macros(library.metadata.as_slice());
         let registrar = decoder::get_macro_registrar_fn(library.metadata.as_slice()).map(|id| {
-            decoder::get_symbol(library.metadata.as_slice(), id)
+            decoder::get_symbol(library.metadata.as_slice(), id).to_strbuf()
         });
         let mc = MacroCrate {
             lib: library.dylib.clone(),
-            macros: macros.move_iter().collect(),
+            macros: macros.move_iter().map(|x| x.to_strbuf()).collect(),
             registrar_symbol: registrar,
         };
         if should_link {

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -207,12 +207,17 @@ pub fn get_field_type(tcx: &ty::ctxt, class_id: ast::DefId,
     let all_items = reader::get_doc(reader::Doc(cdata.data()), tag_items);
     let class_doc = expect(tcx.sess.diagnostic(),
                            decoder::maybe_find_item(class_id.node, all_items),
-                           || format!("get_field_type: class ID {:?} not found",
-                                   class_id) );
+                           || {
+        (format!("get_field_type: class ID {:?} not found",
+                 class_id)).to_strbuf()
+    });
     let the_field = expect(tcx.sess.diagnostic(),
         decoder::maybe_find_item(def.node, class_doc),
-        || format!("get_field_type: in class {:?}, field ID {:?} not found",
-                 class_id, def) );
+        || {
+            (format!("get_field_type: in class {:?}, field ID {:?} not found",
+                    class_id,
+                    def)).to_strbuf()
+        });
     let ty = decoder::item_type(def, the_field, tcx, &*cdata);
     ty::ty_param_bounds_and_ty {
         generics: ty::Generics {type_param_defs: Rc::new(Vec::new()),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1563,7 +1563,7 @@ impl<'a, 'b, 'c> Visitor<()> for MacroDefVisitor<'a, 'b, 'c> {
                 let def = self.ecx.tcx.sess.codemap().span_to_snippet(item.span)
                     .expect("Unable to find source for macro");
                 self.ebml_w.start_tag(tag_macro_def);
-                self.ebml_w.wr_str(def);
+                self.ebml_w.wr_str(def.as_slice());
                 self.ebml_w.end_tag();
             }
             _ => {}

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -112,8 +112,8 @@ impl<'a, O:DataFlowOperator> pprust::PpAnn for DataFlowContext<'a, O> {
                 "".to_owned()
             };
 
-            try!(ps.synth_comment(format!("id {}: {}{}{}", id, entry_str,
-                                          gens_str, kills_str)));
+            try!(ps.synth_comment((format!("id {}: {}{}{}", id, entry_str,
+                                          gens_str, kills_str)).to_strbuf()));
             try!(pp::space(&mut ps.s));
         }
         Ok(())

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -569,7 +569,7 @@ fn check_sized(tcx: &ty::ctxt, ty: ty::t, name: ~str, sp: Span) {
 fn check_pat(cx: &mut Context, pat: &Pat) {
     let var_name = match pat.node {
         PatWild => Some("_".to_owned()),
-        PatIdent(_, ref path, _) => Some(path_to_str(path)),
+        PatIdent(_, ref path, _) => Some(path_to_str(path).to_owned()),
         _ => None
     };
 

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -357,7 +357,7 @@ enum FieldName {
 impl<'a> PrivacyVisitor<'a> {
     // used when debugging
     fn nodestr(&self, id: ast::NodeId) -> ~str {
-        self.tcx.map.node_to_str(id)
+        self.tcx.map.node_to_str(id).to_owned()
     }
 
     // Determines whether the given definition is public from the point of view

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -3167,12 +3167,12 @@ impl<'a> Resolver<'a> {
                          .codemap()
                          .span_to_snippet(imports.get(index).span)
                          .unwrap();
-            if sn.contains("::") {
+            if sn.as_slice().contains("::") {
                 self.resolve_error(imports.get(index).span,
                                    "unresolved import");
             } else {
                 let err = format!("unresolved import (maybe you meant `{}::*`?)",
-                               sn.slice(0, sn.len()));
+                                  sn.as_slice().slice(0, sn.len()));
                 self.resolve_error(imports.get(index).span, err);
             }
         }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1145,7 +1145,11 @@ pub fn new_fn_ctxt<'a>(ccx: &'a CrateContext,
     for p in param_substs.iter() { p.validate(); }
 
     debug!("new_fn_ctxt(path={}, id={}, param_substs={})",
-           if id == -1 { "".to_owned() } else { ccx.tcx.map.path_to_str(id) },
+           if id == -1 {
+               "".to_owned()
+           } else {
+               ccx.tcx.map.path_to_str(id).to_owned()
+           },
            id, param_substs.map(|s| s.repr(ccx.tcx())));
 
     let substd_output_type = match param_substs {
@@ -1458,7 +1462,7 @@ pub fn trans_fn(ccx: &CrateContext,
                 param_substs: Option<&param_substs>,
                 id: ast::NodeId,
                 attrs: &[ast::Attribute]) {
-    let _s = StatRecorder::new(ccx, ccx.tcx.map.path_to_str(id));
+    let _s = StatRecorder::new(ccx, ccx.tcx.map.path_to_str(id).to_owned());
     debug!("trans_fn(param_substs={})", param_substs.map(|s| s.repr(ccx.tcx())));
     let _icx = push_ctxt("trans_fn");
     let output_type = ty::ty_fn_ret(ty::node_id_to_type(ccx.tcx(), id));
@@ -2161,9 +2165,10 @@ pub fn trans_crate(krate: ast::Crate,
     // crashes if the module identifer is same as other symbols
     // such as a function name in the module.
     // 1. http://llvm.org/bugs/show_bug.cgi?id=11479
-    let llmod_id = link_meta.crateid.name + ".rs";
+    let mut llmod_id = link_meta.crateid.name.clone();
+    llmod_id.push_str(".rs");
 
-    let ccx = CrateContext::new(llmod_id, tcx, exp_map2,
+    let ccx = CrateContext::new(llmod_id.as_slice(), tcx, exp_map2,
                                 Sha256::new(), link_meta, reachable);
     {
         let _icx = push_ctxt("text");

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -364,7 +364,7 @@ pub fn trans_fn_ref_with_vtables(
         let map_node = session::expect(
             ccx.sess(),
             tcx.map.find(def_id.node),
-            || format!("local item should be in ast map"));
+            || "local item should be in ast map".to_strbuf());
 
         match map_node {
             ast_map::NodeForeignItem(_) => {

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -426,7 +426,7 @@ impl<'a> Block<'a> {
     }
 
     pub fn node_id_to_str(&self, id: ast::NodeId) -> ~str {
-        self.tcx().map.node_to_str(id)
+        self.tcx().map.node_to_str(id).to_owned()
     }
 
     pub fn expr_to_str(&self, e: &ast::Expr) -> ~str {
@@ -839,7 +839,10 @@ pub fn filename_and_line_num_from_span(bcx: &Block, span: Span)
                                        -> (ValueRef, ValueRef) {
     let loc = bcx.sess().codemap().lookup_char_pos(span.lo);
     let filename_cstr = C_cstr(bcx.ccx(),
-                               token::intern_and_get_ident(loc.file.name), true);
+                               token::intern_and_get_ident(loc.file
+                                                              .name
+                                                              .as_slice()),
+                               true);
     let filename = build::PointerCast(bcx, filename_cstr, Type::i8p(bcx.ccx()));
     let line = C_int(bcx.ccx(), loc.line as int);
     (filename, line)

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -345,7 +345,11 @@ pub fn trans_fail<'a>(
     let v_fail_str = C_cstr(ccx, fail_str, true);
     let _icx = push_ctxt("trans_fail_value");
     let loc = bcx.sess().codemap().lookup_char_pos(sp.lo);
-    let v_filename = C_cstr(ccx, token::intern_and_get_ident(loc.file.name), true);
+    let v_filename = C_cstr(ccx,
+                            token::intern_and_get_ident(loc.file
+                                                           .name
+                                                           .as_slice()),
+                            true);
     let v_line = loc.line as int;
     let v_str = PointerCast(bcx, v_fail_str, Type::i8p(ccx));
     let v_filename = PointerCast(bcx, v_filename, Type::i8p(ccx));

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -330,7 +330,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
     };
 
     let filename = span_start(cx, span).file.name.clone();
-    let file_metadata = file_metadata(cx, filename);
+    let file_metadata = file_metadata(cx, filename.as_slice());
 
     let is_local_to_unit = is_node_local_to_unit(cx, node_id);
     let loc = span_start(cx, span);
@@ -700,7 +700,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
     }
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     let function_type_metadata = unsafe {
         let fn_signature = get_function_signature(cx, fn_ast_id, fn_decl, param_substs, span);
@@ -1011,7 +1011,7 @@ fn compile_unit_metadata(cx: &CrateContext) {
     });
 
     fn fallback_path(cx: &CrateContext) -> CString {
-        cx.link_meta.crateid.name.to_c_str()
+        cx.link_meta.crateid.name.as_slice().to_c_str()
     }
 }
 
@@ -1025,7 +1025,7 @@ fn declare_local(bcx: &Block,
     let cx: &CrateContext = bcx.ccx();
 
     let filename = span_start(cx, span).file.name.clone();
-    let file_metadata = file_metadata(cx, filename);
+    let file_metadata = file_metadata(cx, filename.as_slice());
 
     let name = token::get_ident(variable_ident);
     let loc = span_start(cx, span);
@@ -1277,7 +1277,7 @@ fn prepare_struct_metadata(cx: &CrateContext,
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, def_id);
 
     let file_name = span_start(cx, definition_span).file.name.clone();
-    let file_metadata = file_metadata(cx, file_name);
+    let file_metadata = file_metadata(cx, file_name.as_slice());
 
     let struct_metadata_stub = create_struct_stub(cx,
                                                   struct_llvm_type,
@@ -1371,7 +1371,7 @@ fn prepare_tuple_metadata(cx: &CrateContext,
     let tuple_llvm_type = type_of::type_of(cx, tuple_type);
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     UnfinishedMetadata {
         cache_id: cache_id_for_type(tuple_type),
@@ -1533,7 +1533,7 @@ fn prepare_enum_metadata(cx: &CrateContext,
 
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, enum_def_id);
     let loc = span_start(cx, definition_span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     // For empty enums there is an early exit. Just describe it as an empty struct with the
     // appropriate type name
@@ -1903,7 +1903,7 @@ fn boxed_type_metadata(cx: &CrateContext,
     ];
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     return composite_type_metadata(
         cx,
@@ -2004,7 +2004,7 @@ fn vec_metadata(cx: &CrateContext,
     assert!(member_descriptions.len() == member_llvm_types.len());
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     composite_type_metadata(
         cx,
@@ -2055,7 +2055,7 @@ fn vec_slice_metadata(cx: &CrateContext,
     assert!(member_descriptions.len() == member_llvm_types.len());
 
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     return composite_type_metadata(
         cx,
@@ -2081,7 +2081,7 @@ fn subroutine_type_metadata(cx: &CrateContext,
                             span: Span)
                          -> DICompositeType {
     let loc = span_start(cx, span);
-    let file_metadata = file_metadata(cx, loc.file.name);
+    let file_metadata = file_metadata(cx, loc.file.name.as_slice());
 
     let mut signature_metadata: Vec<DIType> =
         Vec::with_capacity(signature.inputs.len() + 1);
@@ -2126,7 +2126,7 @@ fn trait_metadata(cx: &CrateContext,
     let (containing_scope, definition_span) = get_namespace_and_span_for_item(cx, def_id);
 
     let file_name = span_start(cx, definition_span).file.name.clone();
-    let file_metadata = file_metadata(cx, file_name);
+    let file_metadata = file_metadata(cx, file_name.as_slice());
 
     let trait_llvm_type = type_of::type_of(cx, trait_type);
 
@@ -2420,7 +2420,7 @@ fn populate_scope_map(cx: &CrateContext,
                                    &mut HashMap<ast::NodeId, DIScope>|) {
         // Create a new lexical scope and push it onto the stack
         let loc = cx.sess().codemap().lookup_char_pos(scope_span.lo);
-        let file_metadata = file_metadata(cx, loc.file.name);
+        let file_metadata = file_metadata(cx, loc.file.name.as_slice());
         let parent_scope = scope_stack.last().unwrap().scope_metadata;
 
         let scope_metadata = unsafe {
@@ -2538,7 +2538,10 @@ fn populate_scope_map(cx: &CrateContext,
                     if need_new_scope {
                         // Create a new lexical scope and push it onto the stack
                         let loc = cx.sess().codemap().lookup_char_pos(pat.span.lo);
-                        let file_metadata = file_metadata(cx, loc.file.name);
+                        let file_metadata = file_metadata(cx,
+                                                          loc.file
+                                                             .name
+                                                             .as_slice());
                         let parent_scope = scope_stack.last().unwrap().scope_metadata;
 
                         let scope_metadata = unsafe {
@@ -2860,7 +2863,10 @@ fn namespace_for_item(cx: &CrateContext, def_id: ast::DefId) -> Rc<NamespaceTree
     ty::with_path(cx.tcx(), def_id, |path| {
         // prepend crate name if not already present
         let krate = if def_id.krate == ast::LOCAL_CRATE {
-            let crate_namespace_ident = token::str_to_ident(cx.link_meta.crateid.name);
+            let crate_namespace_ident = token::str_to_ident(cx.link_meta
+                                                              .crateid
+                                                              .name
+                                                              .as_slice());
             Some(ast_map::PathMod(crate_namespace_ident.name))
         } else {
             None

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -109,9 +109,11 @@ pub fn monomorphic_fn(ccx: &CrateContext,
     let map_node = session::expect(
         ccx.sess(),
         ccx.tcx.map.find(fn_id.node),
-        || format!("while monomorphizing {:?}, couldn't find it in the \
-                    item map (may have attempted to monomorphize an item \
-                    defined in a different crate?)", fn_id));
+        || {
+            (format!("while monomorphizing {:?}, couldn't find it in the \
+                      item map (may have attempted to monomorphize an item \
+                      defined in a different crate?)", fn_id)).to_strbuf()
+        });
 
     match map_node {
         ast_map::NodeForeignItem(_) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3709,7 +3709,7 @@ pub fn substd_enum_variants(cx: &ctxt,
 }
 
 pub fn item_path_str(cx: &ctxt, id: ast::DefId) -> ~str {
-    with_path(cx, id, |path| ast_map::path_to_str(path))
+    with_path(cx, id, |path| ast_map::path_to_str(path)).to_owned()
 }
 
 pub enum DtorKind {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -341,9 +341,9 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> ~str {
       ty_bot => "!".to_owned(),
       ty_bool => "bool".to_owned(),
       ty_char => "char".to_owned(),
-      ty_int(t) => ast_util::int_ty_to_str(t, None),
-      ty_uint(t) => ast_util::uint_ty_to_str(t, None),
-      ty_float(t) => ast_util::float_ty_to_str(t),
+      ty_int(t) => ast_util::int_ty_to_str(t, None).to_owned(),
+      ty_uint(t) => ast_util::uint_ty_to_str(t, None).to_owned(),
+      ty_float(t) => ast_util::float_ty_to_str(t).to_owned(),
       ty_box(typ) => "@".to_owned() + ty_to_str(cx, typ),
       ty_uniq(typ) => "~".to_owned() + ty_to_str(cx, typ),
       ty_ptr(ref tm) => "*".to_owned() + mt_to_str(cx, tm),
@@ -870,7 +870,7 @@ impl Repr for ty::BuiltinBounds {
 
 impl Repr for Span {
     fn repr(&self, tcx: &ctxt) -> ~str {
-        tcx.sess.codemap().span_to_str(*self)
+        tcx.sess.codemap().span_to_str(*self).to_owned()
     }
 }
 

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -92,7 +92,7 @@ impl<'a> Clean<Crate> for visit_ast::RustdocVisitor<'a> {
         let id = link::find_crate_id(self.attrs.as_slice(),
                                      t_outputs.out_filestem);
         Crate {
-            name: id.name,
+            name: id.name.to_owned(),
             module: Some(self.module.clean()),
             externs: externs,
         }
@@ -1239,7 +1239,7 @@ impl ToSource for syntax::codemap::Span {
         let ctxt = super::ctxtkey.get().unwrap();
         let cm = ctxt.sess().codemap().clone();
         let sn = match cm.span_to_snippet(*self) {
-            Some(x) => x,
+            Some(x) => x.to_owned(),
             None    => "".to_owned()
         };
         debug!("got snippet {}", sn);

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -27,7 +27,9 @@ use t = syntax::parse::token;
 /// Highlights some source code, returning the HTML output.
 pub fn highlight(src: &str, class: Option<&str>) -> ~str {
     let sess = parse::new_parse_sess();
-    let fm = parse::string_to_filemap(&sess, src.to_owned(), "<stdin>".to_owned());
+    let fm = parse::string_to_filemap(&sess,
+                                      src.to_strbuf(),
+                                      "<stdin>".to_strbuf());
 
     let mut out = io::MemWriter::new();
     doit(&sess,
@@ -70,11 +72,11 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader, class: Option<&
                 hi: test,
                 expn_info: None,
             }).unwrap();
-            if snip.contains("/") {
+            if snip.as_slice().contains("/") {
                 try!(write!(out, "<span class='comment'>{}</span>",
-                              Escape(snip)));
+                              Escape(snip.as_slice())));
             } else {
-                try!(write!(out, "{}", Escape(snip)));
+                try!(write!(out, "{}", Escape(snip.as_slice())));
             }
         }
         last = next.sp.hi;
@@ -171,10 +173,10 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader, class: Option<&
         // stringifying this token
         let snip = sess.span_diagnostic.cm.span_to_snippet(next.sp).unwrap();
         if klass == "" {
-            try!(write!(out, "{}", Escape(snip)));
+            try!(write!(out, "{}", Escape(snip.as_slice())));
         } else {
             try!(write!(out, "<span class='{}'>{}</span>", klass,
-                          Escape(snip)));
+                          Escape(snip.as_slice())));
         }
     }
 

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -79,7 +79,7 @@ impl<'a, T: Copy> Iterator<T> for Values<'a, T> {
 /// The type of the iterator used by with_path.
 pub type PathElems<'a, 'b> = iter::Chain<Values<'a, PathElem>, LinkedPath<'b>>;
 
-pub fn path_to_str<PI: Iterator<PathElem>>(mut path: PI) -> ~str {
+pub fn path_to_str<PI: Iterator<PathElem>>(mut path: PI) -> StrBuf {
     let itr = token::get_ident_interner();
 
     path.fold(StrBuf::new(), |mut s, e| {
@@ -89,7 +89,7 @@ pub fn path_to_str<PI: Iterator<PathElem>>(mut path: PI) -> ~str {
         }
         s.push_str(e.as_slice());
         s
-    }).into_owned()
+    }).to_strbuf()
 }
 
 #[deriving(Clone)]
@@ -322,11 +322,11 @@ impl Map {
         self.with_path_next(id, None, f)
     }
 
-    pub fn path_to_str(&self, id: NodeId) -> ~str {
+    pub fn path_to_str(&self, id: NodeId) -> StrBuf {
         self.with_path(id, |path| path_to_str(path))
     }
 
-    fn path_to_str_with_ident(&self, id: NodeId, i: Ident) -> ~str {
+    fn path_to_str_with_ident(&self, id: NodeId, i: Ident) -> StrBuf {
         self.with_path(id, |path| {
             path_to_str(path.chain(Some(PathName(i.name)).move_iter()))
         })
@@ -405,7 +405,7 @@ impl Map {
         }
     }
 
-    pub fn node_to_str(&self, id: NodeId) -> ~str {
+    pub fn node_to_str(&self, id: NodeId) -> StrBuf {
         node_id_to_str(self, id)
     }
 }
@@ -650,7 +650,7 @@ pub fn map_decoded_item<F: FoldOps>(map: &Map,
     ii
 }
 
-fn node_id_to_str(map: &Map, id: NodeId) -> ~str {
+fn node_id_to_str(map: &Map, id: NodeId) -> StrBuf {
     match map.find(id) {
         Some(NodeItem(item)) => {
             let path_str = map.path_to_str_with_ident(id, item.ident);
@@ -666,51 +666,58 @@ fn node_id_to_str(map: &Map, id: NodeId) -> ~str {
                 ItemImpl(..) => "impl",
                 ItemMac(..) => "macro"
             };
-            format!("{} {} (id={})", item_str, path_str, id)
+            (format!("{} {} (id={})", item_str, path_str, id)).to_strbuf()
         }
         Some(NodeForeignItem(item)) => {
             let path_str = map.path_to_str_with_ident(id, item.ident);
-            format!("foreign item {} (id={})", path_str, id)
+            (format!("foreign item {} (id={})", path_str, id)).to_strbuf()
         }
         Some(NodeMethod(m)) => {
-            format!("method {} in {} (id={})",
+            (format!("method {} in {} (id={})",
                     token::get_ident(m.ident),
-                    map.path_to_str(id), id)
+                    map.path_to_str(id), id)).to_strbuf()
         }
         Some(NodeTraitMethod(ref tm)) => {
             let m = ast_util::trait_method_to_ty_method(&**tm);
-            format!("method {} in {} (id={})",
+            (format!("method {} in {} (id={})",
                     token::get_ident(m.ident),
-                    map.path_to_str(id), id)
+                    map.path_to_str(id), id)).to_strbuf()
         }
         Some(NodeVariant(ref variant)) => {
-            format!("variant {} in {} (id={})",
+            (format!("variant {} in {} (id={})",
                     token::get_ident(variant.node.name),
-                    map.path_to_str(id), id)
+                    map.path_to_str(id), id)).to_strbuf()
         }
         Some(NodeExpr(expr)) => {
-            format!("expr {} (id={})", pprust::expr_to_str(expr), id)
+            (format!("expr {} (id={})",
+                    pprust::expr_to_str(expr), id)).to_strbuf()
         }
         Some(NodeStmt(stmt)) => {
-            format!("stmt {} (id={})", pprust::stmt_to_str(stmt), id)
+            (format!("stmt {} (id={})",
+                    pprust::stmt_to_str(stmt), id)).to_strbuf()
         }
         Some(NodeArg(pat)) => {
-            format!("arg {} (id={})", pprust::pat_to_str(pat), id)
+            (format!("arg {} (id={})",
+                    pprust::pat_to_str(pat), id)).to_strbuf()
         }
         Some(NodeLocal(pat)) => {
-            format!("local {} (id={})", pprust::pat_to_str(pat), id)
+            (format!("local {} (id={})",
+                    pprust::pat_to_str(pat), id)).to_strbuf()
         }
         Some(NodeBlock(block)) => {
-            format!("block {} (id={})", pprust::block_to_str(block), id)
+            (format!("block {} (id={})",
+                    pprust::block_to_str(block), id)).to_strbuf()
         }
         Some(NodeStructCtor(_)) => {
-            format!("struct_ctor {} (id={})", map.path_to_str(id), id)
+            (format!("struct_ctor {} (id={})",
+                    map.path_to_str(id), id)).to_strbuf()
         }
         Some(NodeLifetime(ref l)) => {
-            format!("lifetime {} (id={})", pprust::lifetime_to_str(*l), id)
+            (format!("lifetime {} (id={})",
+                    pprust::lifetime_to_str(*l), id)).to_strbuf()
         }
         None => {
-            format!("unknown node (id={})", id)
+            (format!("unknown node (id={})", id)).to_strbuf()
         }
     }
 }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -24,11 +24,11 @@ use std::cmp;
 use std::strbuf::StrBuf;
 use std::u32;
 
-pub fn path_name_i(idents: &[Ident]) -> ~str {
+pub fn path_name_i(idents: &[Ident]) -> StrBuf {
     // FIXME: Bad copies (#2543 -- same for everything else that says "bad")
     idents.iter().map(|i| {
-        token::get_ident(*i).get().to_str()
-    }).collect::<Vec<~str>>().connect("::")
+        token::get_ident(*i).get().to_strbuf()
+    }).collect::<Vec<StrBuf>>().connect("::").to_strbuf()
 }
 
 // totally scary function: ignores all but the last element, should have
@@ -134,7 +134,7 @@ pub fn is_path(e: @Expr) -> bool {
 
 // Get a string representation of a signed int type, with its value.
 // We want to avoid "45int" and "-3int" in favor of "45" and "-3"
-pub fn int_ty_to_str(t: IntTy, val: Option<i64>) -> ~str {
+pub fn int_ty_to_str(t: IntTy, val: Option<i64>) -> StrBuf {
     let s = match t {
         TyI if val.is_some() => "",
         TyI => "int",
@@ -145,8 +145,8 @@ pub fn int_ty_to_str(t: IntTy, val: Option<i64>) -> ~str {
     };
 
     match val {
-        Some(n) => format!("{}{}", n, s),
-        None => s.to_owned()
+        Some(n) => format!("{}{}", n, s).to_strbuf(),
+        None => s.to_strbuf()
     }
 }
 
@@ -161,7 +161,7 @@ pub fn int_ty_max(t: IntTy) -> u64 {
 
 // Get a string representation of an unsigned int type, with its value.
 // We want to avoid "42uint" in favor of "42u"
-pub fn uint_ty_to_str(t: UintTy, val: Option<u64>) -> ~str {
+pub fn uint_ty_to_str(t: UintTy, val: Option<u64>) -> StrBuf {
     let s = match t {
         TyU if val.is_some() => "u",
         TyU => "uint",
@@ -172,8 +172,8 @@ pub fn uint_ty_to_str(t: UintTy, val: Option<u64>) -> ~str {
     };
 
     match val {
-        Some(n) => format!("{}{}", n, s),
-        None => s.to_owned()
+        Some(n) => format!("{}{}", n, s).to_strbuf(),
+        None => s.to_strbuf()
     }
 }
 
@@ -186,8 +186,12 @@ pub fn uint_ty_max(t: UintTy) -> u64 {
     }
 }
 
-pub fn float_ty_to_str(t: FloatTy) -> ~str {
-    match t { TyF32 => "f32".to_owned(), TyF64 => "f64".to_owned(), TyF128 => "f128".to_owned() }
+pub fn float_ty_to_str(t: FloatTy) -> StrBuf {
+    match t {
+        TyF32 => "f32".to_strbuf(),
+        TyF64 => "f64".to_strbuf(),
+        TyF128 => "f128".to_strbuf(),
+    }
 }
 
 pub fn is_call_expr(e: @Expr) -> bool {
@@ -252,11 +256,11 @@ pub fn unguarded_pat(a: &Arm) -> Option<Vec<@Pat> > {
 /// listed as `__extensions__::method_name::hash`, with no indication
 /// of the type).
 pub fn impl_pretty_name(trait_ref: &Option<TraitRef>, ty: &Ty) -> Ident {
-    let mut pretty = StrBuf::from_owned_str(pprust::ty_to_str(ty));
+    let mut pretty = pprust::ty_to_str(ty);
     match *trait_ref {
         Some(ref trait_ref) => {
             pretty.push_char('.');
-            pretty.push_str(pprust::path_to_str(&trait_ref.path));
+            pretty.push_str(pprust::path_to_str(&trait_ref.path).as_slice());
         }
         None => {}
     }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -125,7 +125,7 @@ impl AttributeMethods for Attribute {
             let meta = mk_name_value_item_str(
                 InternedString::new("doc"),
                 token::intern_and_get_ident(strip_doc_comment_decoration(
-                        comment.get())));
+                        comment.get()).as_slice()));
             mk_attr(meta)
         } else {
             *self

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -30,7 +30,7 @@ use collections::HashMap;
 // ast::MacInvocTT.
 
 pub struct MacroDef {
-    pub name: ~str,
+    pub name: StrBuf,
     pub ext: SyntaxExtension
 }
 
@@ -361,8 +361,8 @@ pub fn syntax_expander_table() -> SyntaxEnv {
 
 pub struct MacroCrate {
     pub lib: Option<Path>,
-    pub macros: Vec<~str>,
-    pub registrar_symbol: Option<~str>,
+    pub macros: Vec<StrBuf>,
+    pub registrar_symbol: Option<StrBuf>,
 }
 
 pub trait CrateLoader {
@@ -425,7 +425,7 @@ impl<'a> ExtCtxt<'a> {
     pub fn mod_pop(&mut self) { self.mod_path.pop().unwrap(); }
     pub fn mod_path(&self) -> Vec<ast::Ident> {
         let mut v = Vec::new();
-        v.push(token::str_to_ident(self.ecfg.crate_id.name));
+        v.push(token::str_to_ident(self.ecfg.crate_id.name.as_slice()));
         v.extend(self.mod_path.iter().map(|a| *a));
         return v;
     }
@@ -540,14 +540,14 @@ pub fn get_single_str_from_tts(cx: &ExtCtxt,
                                sp: Span,
                                tts: &[ast::TokenTree],
                                name: &str)
-                               -> Option<~str> {
+                               -> Option<StrBuf> {
     if tts.len() != 1 {
         cx.span_err(sp, format!("{} takes 1 argument.", name));
     } else {
         match tts[0] {
             ast::TTTok(_, token::LIT_STR(ident))
             | ast::TTTok(_, token::LIT_STR_RAW(ident, _)) => {
-                return Some(token::get_ident(ident).get().to_str())
+                return Some(token::get_ident(ident).get().to_strbuf())
             }
             _ => cx.span_err(sp, format!("{} requires a string.", name)),
         }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -639,7 +639,9 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             vec!(
                 self.expr_str(span, msg),
                 self.expr_str(span,
-                              token::intern_and_get_ident(loc.file.name)),
+                              token::intern_and_get_ident(loc.file
+                                                             .name
+                                                             .as_slice())),
                 self.expr_uint(span, loc.line)))
     }
 

--- a/src/libsyntax/ext/deriving/generic.rs
+++ b/src/libsyntax/ext/deriving/generic.rs
@@ -987,7 +987,7 @@ impl<'a> TraitDef<'a> {
         to_set.expn_info = Some(@codemap::ExpnInfo {
             call_site: to_set,
             callee: codemap::NameAndSpan {
-                name: format!("deriving({})", trait_name),
+                name: format!("deriving({})", trait_name).to_strbuf(),
                 format: codemap::MacroAttribute,
                 span: Some(self.span)
             }

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -30,7 +30,7 @@ pub fn expand_option_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         Some(v) => v
     };
 
-    let e = match os::getenv(var) {
+    let e = match os::getenv(var.as_slice()) {
       None => {
           cx.expr_path(cx.path_all(sp,
                                    true,

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -55,7 +55,7 @@ pub mod rt {
 
     trait ToSource : ToTokens {
         // Takes a thing and generates a string containing rust code for it.
-        pub fn to_source() -> ~str;
+        pub fn to_source() -> StrBuf;
 
         // If you can make source, you can definitely make tokens.
         pub fn to_tokens(cx: &ExtCtxt) -> ~[TokenTree] {
@@ -67,59 +67,67 @@ pub mod rt {
 
     pub trait ToSource {
         // Takes a thing and generates a string containing rust code for it.
-        fn to_source(&self) -> ~str;
+        fn to_source(&self) -> StrBuf;
     }
 
     impl ToSource for ast::Ident {
-        fn to_source(&self) -> ~str {
-            get_ident(*self).get().to_str()
+        fn to_source(&self) -> StrBuf {
+            get_ident(*self).get().to_strbuf()
         }
     }
 
     impl ToSource for @ast::Item {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             pprust::item_to_str(*self)
         }
     }
 
     impl<'a> ToSource for &'a [@ast::Item] {
-        fn to_source(&self) -> ~str {
-            self.iter().map(|i| i.to_source()).collect::<Vec<~str>>().connect("\n\n")
+        fn to_source(&self) -> StrBuf {
+            self.iter()
+                .map(|i| i.to_source())
+                .collect::<Vec<StrBuf>>()
+                .connect("\n\n")
+                .to_strbuf()
         }
     }
 
     impl ToSource for ast::Ty {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             pprust::ty_to_str(self)
         }
     }
 
     impl<'a> ToSource for &'a [ast::Ty] {
-        fn to_source(&self) -> ~str {
-            self.iter().map(|i| i.to_source()).collect::<Vec<~str>>().connect(", ")
+        fn to_source(&self) -> StrBuf {
+            self.iter()
+                .map(|i| i.to_source())
+                .collect::<Vec<StrBuf>>()
+                .connect(", ")
+                .to_strbuf()
         }
     }
 
     impl ToSource for Generics {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             pprust::generics_to_str(self)
         }
     }
 
     impl ToSource for @ast::Expr {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             pprust::expr_to_str(*self)
         }
     }
 
     impl ToSource for ast::Block {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             pprust::block_to_str(self)
         }
     }
 
     impl<'a> ToSource for &'a str {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitStr(
                     token::intern_and_get_ident(*self), ast::CookedStr));
             pprust::lit_to_str(&lit)
@@ -127,41 +135,41 @@ pub mod rt {
     }
 
     impl ToSource for () {
-        fn to_source(&self) -> ~str {
-            "()".to_owned()
+        fn to_source(&self) -> StrBuf {
+            "()".to_strbuf()
         }
     }
 
     impl ToSource for bool {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitBool(*self));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for char {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitChar(*self));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for int {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitInt(*self as i64, ast::TyI));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for i8 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitInt(*self as i64, ast::TyI8));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for i16 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitInt(*self as i64, ast::TyI16));
             pprust::lit_to_str(&lit)
         }
@@ -169,49 +177,49 @@ pub mod rt {
 
 
     impl ToSource for i32 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitInt(*self as i64, ast::TyI32));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for i64 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitInt(*self as i64, ast::TyI64));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for uint {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitUint(*self as u64, ast::TyU));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for u8 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitUint(*self as u64, ast::TyU8));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for u16 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitUint(*self as u64, ast::TyU16));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for u32 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitUint(*self as u64, ast::TyU32));
             pprust::lit_to_str(&lit)
         }
     }
 
     impl ToSource for u64 {
-        fn to_source(&self) -> ~str {
+        fn to_source(&self) -> StrBuf {
             let lit = dummy_spanned(ast::LitUint(*self as u64, ast::TyU64));
             pprust::lit_to_str(&lit)
         }
@@ -263,17 +271,17 @@ pub mod rt {
     impl_to_tokens!(u64)
 
     pub trait ExtParseUtils {
-        fn parse_item(&self, s: ~str) -> @ast::Item;
-        fn parse_expr(&self, s: ~str) -> @ast::Expr;
-        fn parse_stmt(&self, s: ~str) -> @ast::Stmt;
-        fn parse_tts(&self, s: ~str) -> Vec<ast::TokenTree> ;
+        fn parse_item(&self, s: StrBuf) -> @ast::Item;
+        fn parse_expr(&self, s: StrBuf) -> @ast::Expr;
+        fn parse_stmt(&self, s: StrBuf) -> @ast::Stmt;
+        fn parse_tts(&self, s: StrBuf) -> Vec<ast::TokenTree> ;
     }
 
     impl<'a> ExtParseUtils for ExtCtxt<'a> {
 
-        fn parse_item(&self, s: ~str) -> @ast::Item {
+        fn parse_item(&self, s: StrBuf) -> @ast::Item {
             let res = parse::parse_item_from_source_str(
-                "<quote expansion>".to_str(),
+                "<quote expansion>".to_strbuf(),
                 s,
                 self.cfg(),
                 self.parse_sess());
@@ -286,23 +294,23 @@ pub mod rt {
             }
         }
 
-        fn parse_stmt(&self, s: ~str) -> @ast::Stmt {
-            parse::parse_stmt_from_source_str("<quote expansion>".to_str(),
+        fn parse_stmt(&self, s: StrBuf) -> @ast::Stmt {
+            parse::parse_stmt_from_source_str("<quote expansion>".to_strbuf(),
                                               s,
                                               self.cfg(),
                                               Vec::new(),
                                               self.parse_sess())
         }
 
-        fn parse_expr(&self, s: ~str) -> @ast::Expr {
-            parse::parse_expr_from_source_str("<quote expansion>".to_str(),
+        fn parse_expr(&self, s: StrBuf) -> @ast::Expr {
+            parse::parse_expr_from_source_str("<quote expansion>".to_strbuf(),
                                               s,
                                               self.cfg(),
                                               self.parse_sess())
         }
 
-        fn parse_tts(&self, s: ~str) -> Vec<ast::TokenTree> {
-            parse::parse_tts_from_source_str("<quote expansion>".to_str(),
+        fn parse_tts(&self, s: StrBuf) -> Vec<ast::TokenTree> {
+            parse::parse_tts_from_source_str("<quote expansion>".to_strbuf(),
                                              s,
                                              self.cfg(),
                                              self.parse_sess())
@@ -367,8 +375,8 @@ pub fn expand_quote_stmt(cx: &mut ExtCtxt,
     base::MacExpr::new(expanded)
 }
 
-fn ids_ext(strs: Vec<~str> ) -> Vec<ast::Ident> {
-    strs.iter().map(|str| str_to_ident(*str)).collect()
+fn ids_ext(strs: Vec<StrBuf> ) -> Vec<ast::Ident> {
+    strs.iter().map(|str| str_to_ident((*str).as_slice())).collect()
 }
 
 fn id_ext(str: &str) -> ast::Ident {
@@ -678,11 +686,11 @@ fn expand_wrapper(cx: &ExtCtxt,
                   sp: Span,
                   cx_expr: @ast::Expr,
                   expr: @ast::Expr) -> @ast::Expr {
-    let uses = vec!( cx.view_use_glob(sp, ast::Inherited,
-                                   ids_ext(vec!("syntax".to_owned(),
-                                             "ext".to_owned(),
-                                             "quote".to_owned(),
-                                             "rt".to_owned()))) );
+    let uses = vec![ cx.view_use_glob(sp, ast::Inherited,
+                                   ids_ext(vec!["syntax".to_strbuf(),
+                                                "ext".to_strbuf(),
+                                                "quote".to_strbuf(),
+                                                "rt".to_strbuf()])) ];
 
     let stmt_let_ext_cx = cx.stmt_let(sp, false, id_ext("ext_cx"), cx_expr);
 

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -132,7 +132,7 @@ fn generic_extension(cx: &ExtCtxt,
 
     // Which arm's failure should we report? (the one furthest along)
     let mut best_fail_spot = DUMMY_SP;
-    let mut best_fail_msg = "internal error: ran no matchers".to_owned();
+    let mut best_fail_msg = "internal error: ran no matchers".to_strbuf();
 
     for (i, lhs) in lhses.iter().enumerate() { // try each arm's matchers
         match **lhs {
@@ -177,13 +177,13 @@ fn generic_extension(cx: &ExtCtxt,
                 best_fail_spot = sp;
                 best_fail_msg = (*msg).clone();
               },
-              Error(sp, ref msg) => cx.span_fatal(sp, (*msg))
+              Error(sp, ref msg) => cx.span_fatal(sp, msg.as_slice())
             }
           }
           _ => cx.bug("non-matcher found in parsed lhses")
         }
     }
-    cx.span_fatal(best_fail_spot, best_fail_msg);
+    cx.span_fatal(best_fail_spot, best_fail_msg.as_slice());
 }
 
 // this procedure performs the expansion of the
@@ -247,7 +247,7 @@ pub fn add_new_extension(cx: &mut ExtCtxt,
 
     box MacroRulesDefiner {
         def: RefCell::new(Some(MacroDef {
-            name: token::get_ident(name).to_str(),
+            name: token::get_ident(name).to_str().to_strbuf(),
             ext: NormalTT(exp, Some(sp))
         }))
     } as Box<MacResult>

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -100,7 +100,7 @@ fn lookup_cur_matched(r: &TtReader, name: Ident) -> Rc<NamedMatch> {
 enum LockstepIterSize {
     LisUnconstrained,
     LisConstraint(uint, Ident),
-    LisContradiction(~str),
+    LisContradiction(StrBuf),
 }
 
 fn lis_merge(lhs: LockstepIterSize, rhs: LockstepIterSize) -> LockstepIterSize {
@@ -116,7 +116,7 @@ fn lis_merge(lhs: LockstepIterSize, rhs: LockstepIterSize) -> LockstepIterSize {
                 let r_n = token::get_ident(r_id);
                 LisContradiction(format!("inconsistent lockstep iteration: \
                                           '{}' has {} items, but '{}' has {}",
-                                          l_n, l_len, r_n, r_len))
+                                          l_n, l_len, r_n, r_len).to_strbuf())
             }
         }
     }
@@ -223,7 +223,7 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                         }
                         LisContradiction(ref msg) => {
                             // FIXME #2887 blame macro invoker instead
-                            r.sp_diag.span_fatal(sp.clone(), *msg);
+                            r.sp_diag.span_fatal(sp.clone(), msg.as_slice());
                         }
                     LisConstraint(len, _) => {
                         if len == 0 {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -949,7 +949,7 @@ mod test {
                 let pred_val = $pred;
                 let a_val = $a;
                 let b_val = $b;
-                if !(pred_val(a_val,b_val)) {
+                if !(pred_val(a_val.as_slice(),b_val.as_slice())) {
                     fail!("expected args satisfying {}, got {:?} and {:?}",
                           $predname, a_val, b_val);
                 }
@@ -961,12 +961,13 @@ mod test {
     #[test] fn ident_transformation () {
         let mut zz_fold = ToZzIdentFolder;
         let ast = string_to_crate(
-            "#[a] mod b {fn c (d : e, f : g) {h!(i,j,k);l;m}}".to_owned());
+            "#[a] mod b {fn c (d : e, f : g) {h!(i,j,k);l;m}}".to_strbuf());
         let folded_crate = zz_fold.fold_crate(ast);
-        assert_pred!(matches_codepattern,
-                     "matches_codepattern",
-                     pprust::to_str(|s| fake_print_crate(s, &folded_crate)),
-                     "#[a]mod zz{fn zz(zz:zz,zz:zz){zz!(zz,zz,zz);zz;zz}}".to_owned());
+        assert_pred!(
+            matches_codepattern,
+            "matches_codepattern",
+            pprust::to_str(|s| fake_print_crate(s, &folded_crate)),
+            "#[a]mod zz{fn zz(zz:zz,zz:zz){zz!(zz,zz,zz);zz;zz}}".to_strbuf());
     }
 
     // even inside macro defs....
@@ -974,11 +975,12 @@ mod test {
         let mut zz_fold = ToZzIdentFolder;
         let ast = string_to_crate(
             "macro_rules! a {(b $c:expr $(d $e:token)f+ => \
-             (g $(d $d $e)+))} ".to_owned());
+             (g $(d $d $e)+))} ".to_strbuf());
         let folded_crate = zz_fold.fold_crate(ast);
-        assert_pred!(matches_codepattern,
-                     "matches_codepattern",
-                     pprust::to_str(|s| fake_print_crate(s, &folded_crate)),
-                     "zz!zz((zz$zz:zz$(zz $zz:zz)zz+=>(zz$(zz$zz$zz)+)))".to_owned());
+        assert_pred!(
+            matches_codepattern,
+            "matches_codepattern",
+            pprust::to_str(|s| fake_print_crate(s, &folded_crate)),
+            "zz!zz((zz$zz:zz$(zz $zz:zz)zz+=>(zz$(zz$zz$zz)+)))".to_strbuf());
     }
 }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -77,8 +77,8 @@ pub fn parse_crate_attrs_from_file(
     inner
 }
 
-pub fn parse_crate_from_source_str(name: ~str,
-                                   source: ~str,
+pub fn parse_crate_from_source_str(name: StrBuf,
+                                   source: StrBuf,
                                    cfg: ast::CrateConfig,
                                    sess: &ParseSess)
                                    -> ast::Crate {
@@ -89,8 +89,8 @@ pub fn parse_crate_from_source_str(name: ~str,
     maybe_aborted(p.parse_crate_mod(),p)
 }
 
-pub fn parse_crate_attrs_from_source_str(name: ~str,
-                                         source: ~str,
+pub fn parse_crate_attrs_from_source_str(name: StrBuf,
+                                         source: StrBuf,
                                          cfg: ast::CrateConfig,
                                          sess: &ParseSess)
                                          -> Vec<ast::Attribute> {
@@ -102,8 +102,8 @@ pub fn parse_crate_attrs_from_source_str(name: ~str,
     inner
 }
 
-pub fn parse_expr_from_source_str(name: ~str,
-                                  source: ~str,
+pub fn parse_expr_from_source_str(name: StrBuf,
+                                  source: StrBuf,
                                   cfg: ast::CrateConfig,
                                   sess: &ParseSess)
                                   -> @ast::Expr {
@@ -111,8 +111,8 @@ pub fn parse_expr_from_source_str(name: ~str,
     maybe_aborted(p.parse_expr(), p)
 }
 
-pub fn parse_item_from_source_str(name: ~str,
-                                  source: ~str,
+pub fn parse_item_from_source_str(name: StrBuf,
+                                  source: StrBuf,
                                   cfg: ast::CrateConfig,
                                   sess: &ParseSess)
                                   -> Option<@ast::Item> {
@@ -121,8 +121,8 @@ pub fn parse_item_from_source_str(name: ~str,
     maybe_aborted(p.parse_item(attrs),p)
 }
 
-pub fn parse_meta_from_source_str(name: ~str,
-                                  source: ~str,
+pub fn parse_meta_from_source_str(name: StrBuf,
+                                  source: StrBuf,
                                   cfg: ast::CrateConfig,
                                   sess: &ParseSess)
                                   -> @ast::MetaItem {
@@ -130,8 +130,8 @@ pub fn parse_meta_from_source_str(name: ~str,
     maybe_aborted(p.parse_meta_item(),p)
 }
 
-pub fn parse_stmt_from_source_str(name: ~str,
-                                  source: ~str,
+pub fn parse_stmt_from_source_str(name: StrBuf,
+                                  source: StrBuf,
                                   cfg: ast::CrateConfig,
                                   attrs: Vec<ast::Attribute> ,
                                   sess: &ParseSess)
@@ -145,8 +145,8 @@ pub fn parse_stmt_from_source_str(name: ~str,
     maybe_aborted(p.parse_stmt(attrs),p)
 }
 
-pub fn parse_tts_from_source_str(name: ~str,
-                                 source: ~str,
+pub fn parse_tts_from_source_str(name: StrBuf,
+                                 source: StrBuf,
                                  cfg: ast::CrateConfig,
                                  sess: &ParseSess)
                                  -> Vec<ast::TokenTree> {
@@ -164,8 +164,8 @@ pub fn parse_tts_from_source_str(name: ~str,
 // Create a new parser from a source string
 pub fn new_parser_from_source_str<'a>(sess: &'a ParseSess,
                                       cfg: ast::CrateConfig,
-                                      name: ~str,
-                                      source: ~str)
+                                      name: StrBuf,
+                                      source: StrBuf)
                                       -> Parser<'a> {
     filemap_to_parser(sess, string_to_filemap(sess, source, name), cfg)
 }
@@ -225,8 +225,8 @@ pub fn file_to_filemap(sess: &ParseSess, path: &Path, spanopt: Option<Span>)
     };
     match str::from_utf8(bytes.as_slice()) {
         Some(s) => {
-            return string_to_filemap(sess, s.to_owned(),
-                                     path.as_str().unwrap().to_str())
+            return string_to_filemap(sess, s.to_strbuf(),
+                                     path.as_str().unwrap().to_strbuf())
         }
         None => err(format!("{} is not UTF-8 encoded", path.display())),
     }
@@ -235,7 +235,7 @@ pub fn file_to_filemap(sess: &ParseSess, path: &Path, spanopt: Option<Span>)
 
 // given a session and a string, add the string to
 // the session's codemap and return the new filemap
-pub fn string_to_filemap(sess: &ParseSess, source: ~str, path: ~str)
+pub fn string_to_filemap(sess: &ParseSess, source: StrBuf, path: StrBuf)
                          -> Rc<FileMap> {
     sess.span_diagnostic.cm.new_filemap(path, source)
 }
@@ -284,11 +284,11 @@ mod test {
     use util::parser_testing::{string_to_expr, string_to_item};
     use util::parser_testing::string_to_stmt;
 
-    fn to_json_str<'a, E: Encodable<json::Encoder<'a>, io::IoError>>(val: &E) -> ~str {
+    fn to_json_str<'a, E: Encodable<json::Encoder<'a>, io::IoError>>(val: &E) -> StrBuf {
         let mut writer = MemWriter::new();
         let mut encoder = json::Encoder::new(&mut writer as &mut io::Writer);
         let _ = val.encode(&mut encoder);
-        str::from_utf8(writer.unwrap().as_slice()).unwrap().to_owned()
+        str::from_utf8(writer.unwrap().as_slice()).unwrap().to_strbuf()
     }
 
     // produce a codemap::span
@@ -297,7 +297,7 @@ mod test {
     }
 
     #[test] fn path_exprs_1() {
-        assert!(string_to_expr("a".to_owned()) ==
+        assert!(string_to_expr("a".to_strbuf()) ==
                    @ast::Expr{
                     id: ast::DUMMY_NODE_ID,
                     node: ast::ExprPath(ast::Path {
@@ -316,7 +316,7 @@ mod test {
     }
 
     #[test] fn path_exprs_2 () {
-        assert!(string_to_expr("::a::b".to_owned()) ==
+        assert!(string_to_expr("::a::b".to_strbuf()) ==
                    @ast::Expr {
                     id: ast::DUMMY_NODE_ID,
                     node: ast::ExprPath(ast::Path {
@@ -341,12 +341,12 @@ mod test {
 
     #[should_fail]
     #[test] fn bad_path_expr_1() {
-        string_to_expr("::abc::def::return".to_owned());
+        string_to_expr("::abc::def::return".to_strbuf());
     }
 
     // check the token-tree-ization of macros
     #[test] fn string_to_tts_macro () {
-        let tts = string_to_tts("macro_rules! zip (($a)=>($a))".to_owned());
+        let tts = string_to_tts("macro_rules! zip (($a)=>($a))".to_strbuf());
         let tts: &[ast::TokenTree] = tts.as_slice();
         match tts {
             [ast::TTTok(_,_),
@@ -399,7 +399,7 @@ mod test {
     }
 
     #[test] fn string_to_tts_1 () {
-        let tts = string_to_tts("fn a (b : int) { b; }".to_owned());
+        let tts = string_to_tts("fn a (b : int) { b; }".to_strbuf());
         assert_eq!(to_json_str(&tts),
         "[\
     {\
@@ -523,12 +523,12 @@ mod test {
             ]\
         ]\
     }\
-]".to_owned()
+]".to_strbuf()
         );
     }
 
     #[test] fn ret_expr() {
-        assert!(string_to_expr("return d".to_owned()) ==
+        assert!(string_to_expr("return d".to_strbuf()) ==
                    @ast::Expr{
                     id: ast::DUMMY_NODE_ID,
                     node:ast::ExprRet(Some(@ast::Expr{
@@ -551,7 +551,7 @@ mod test {
     }
 
     #[test] fn parse_stmt_1 () {
-        assert!(string_to_stmt("b;".to_owned()) ==
+        assert!(string_to_stmt("b;".to_strbuf()) ==
                    @Spanned{
                        node: ast::StmtExpr(@ast::Expr {
                            id: ast::DUMMY_NODE_ID,
@@ -578,7 +578,7 @@ mod test {
 
     #[test] fn parse_ident_pat () {
         let sess = new_parse_sess();
-        let mut parser = string_to_parser(&sess, "b".to_owned());
+        let mut parser = string_to_parser(&sess, "b".to_strbuf());
         assert!(parser.parse_pat() ==
                    @ast::Pat{id: ast::DUMMY_NODE_ID,
                              node: ast::PatIdent(
@@ -602,7 +602,7 @@ mod test {
     // check the contents of the tt manually:
     #[test] fn parse_fundecl () {
         // this test depends on the intern order of "fn" and "int"
-        assert!(string_to_item("fn a (b : int) { b; }".to_owned()) ==
+        assert!(string_to_item("fn a (b : int) { b; }".to_strbuf()) ==
                   Some(
                       @ast::Item{ident:str_to_ident("a"),
                             attrs:Vec::new(),
@@ -694,13 +694,13 @@ mod test {
 
     #[test] fn parse_exprs () {
         // just make sure that they parse....
-        string_to_expr("3 + 4".to_owned());
-        string_to_expr("a::z.froob(b,@(987+3))".to_owned());
+        string_to_expr("3 + 4".to_strbuf());
+        string_to_expr("a::z.froob(b,@(987+3))".to_strbuf());
     }
 
     #[test] fn attrs_fix_bug () {
         string_to_item("pub fn mk_file_writer(path: &Path, flags: &[FileFlag])
-                   -> Result<@Writer, ~str> {
+                   -> Result<@Writer, StrBuf> {
     #[cfg(windows)]
     fn wb() -> c_int {
       (O_WRONLY | libc::consts::os::extra::O_BINARY) as c_int
@@ -710,7 +710,7 @@ mod test {
     fn wb() -> c_int { O_WRONLY as c_int }
 
     let mut fflags: c_int = wb();
-}".to_owned());
+}".to_strbuf());
     }
 
 }

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -123,7 +123,7 @@ impl<'a> ParserObsoleteMethods for Parser<'a> {
             ),
             ObsoleteManagedString => (
                 "managed string",
-                "use `Rc<~str>` instead of a managed string"
+                "use `Rc<StrBuf>` instead of a managed string"
             ),
             ObsoleteManagedVec => (
                 "managed vector",

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -137,58 +137,62 @@ impl fmt::Show for Nonterminal {
     }
 }
 
-pub fn binop_to_str(o: BinOp) -> ~str {
+pub fn binop_to_str(o: BinOp) -> StrBuf {
     match o {
-      PLUS => "+".to_owned(),
-      MINUS => "-".to_owned(),
-      STAR => "*".to_owned(),
-      SLASH => "/".to_owned(),
-      PERCENT => "%".to_owned(),
-      CARET => "^".to_owned(),
-      AND => "&".to_owned(),
-      OR => "|".to_owned(),
-      SHL => "<<".to_owned(),
-      SHR => ">>".to_owned()
+      PLUS => "+".to_strbuf(),
+      MINUS => "-".to_strbuf(),
+      STAR => "*".to_strbuf(),
+      SLASH => "/".to_strbuf(),
+      PERCENT => "%".to_strbuf(),
+      CARET => "^".to_strbuf(),
+      AND => "&".to_strbuf(),
+      OR => "|".to_strbuf(),
+      SHL => "<<".to_strbuf(),
+      SHR => ">>".to_strbuf()
     }
 }
 
-pub fn to_str(t: &Token) -> ~str {
+pub fn to_str(t: &Token) -> StrBuf {
     match *t {
-      EQ => "=".to_owned(),
-      LT => "<".to_owned(),
-      LE => "<=".to_owned(),
-      EQEQ => "==".to_owned(),
-      NE => "!=".to_owned(),
-      GE => ">=".to_owned(),
-      GT => ">".to_owned(),
-      NOT => "!".to_owned(),
-      TILDE => "~".to_owned(),
-      OROR => "||".to_owned(),
-      ANDAND => "&&".to_owned(),
+      EQ => "=".to_strbuf(),
+      LT => "<".to_strbuf(),
+      LE => "<=".to_strbuf(),
+      EQEQ => "==".to_strbuf(),
+      NE => "!=".to_strbuf(),
+      GE => ">=".to_strbuf(),
+      GT => ">".to_strbuf(),
+      NOT => "!".to_strbuf(),
+      TILDE => "~".to_strbuf(),
+      OROR => "||".to_strbuf(),
+      ANDAND => "&&".to_strbuf(),
       BINOP(op) => binop_to_str(op),
-      BINOPEQ(op) => binop_to_str(op) + "=",
+      BINOPEQ(op) => {
+          let mut s = binop_to_str(op);
+          s.push_str("=");
+          s
+      }
 
       /* Structural symbols */
-      AT => "@".to_owned(),
-      DOT => ".".to_owned(),
-      DOTDOT => "..".to_owned(),
-      DOTDOTDOT => "...".to_owned(),
-      COMMA => ",".to_owned(),
-      SEMI => ";".to_owned(),
-      COLON => ":".to_owned(),
-      MOD_SEP => "::".to_owned(),
-      RARROW => "->".to_owned(),
-      LARROW => "<-".to_owned(),
-      DARROW => "<->".to_owned(),
-      FAT_ARROW => "=>".to_owned(),
-      LPAREN => "(".to_owned(),
-      RPAREN => ")".to_owned(),
-      LBRACKET => "[".to_owned(),
-      RBRACKET => "]".to_owned(),
-      LBRACE => "{".to_owned(),
-      RBRACE => "}".to_owned(),
-      POUND => "#".to_owned(),
-      DOLLAR => "$".to_owned(),
+      AT => "@".to_strbuf(),
+      DOT => ".".to_strbuf(),
+      DOTDOT => "..".to_strbuf(),
+      DOTDOTDOT => "...".to_strbuf(),
+      COMMA => ",".to_strbuf(),
+      SEMI => ";".to_strbuf(),
+      COLON => ":".to_strbuf(),
+      MOD_SEP => "::".to_strbuf(),
+      RARROW => "->".to_strbuf(),
+      LARROW => "<-".to_strbuf(),
+      DARROW => "<->".to_strbuf(),
+      FAT_ARROW => "=>".to_strbuf(),
+      LPAREN => "(".to_strbuf(),
+      RPAREN => ")".to_strbuf(),
+      LBRACKET => "[".to_strbuf(),
+      RBRACKET => "]".to_strbuf(),
+      LBRACE => "{".to_strbuf(),
+      RBRACE => "}".to_strbuf(),
+      POUND => "#".to_strbuf(),
+      DOLLAR => "$".to_strbuf(),
 
       /* Literals */
       LIT_CHAR(c) => {
@@ -197,63 +201,64 @@ pub fn to_str(t: &Token) -> ~str {
               res.push_char(c);
           });
           res.push_char('\'');
-          res.into_owned()
+          res
       }
       LIT_INT(i, t) => ast_util::int_ty_to_str(t, Some(i)),
       LIT_UINT(u, t) => ast_util::uint_ty_to_str(t, Some(u)),
-      LIT_INT_UNSUFFIXED(i) => { i.to_str() }
+      LIT_INT_UNSUFFIXED(i) => { i.to_str().to_strbuf() }
       LIT_FLOAT(s, t) => {
         let mut body = StrBuf::from_str(get_ident(s).get());
         if body.as_slice().ends_with(".") {
             body.push_char('0');  // `10.f` is not a float literal
         }
-        body.push_str(ast_util::float_ty_to_str(t));
-        body.into_owned()
+        body.push_str(ast_util::float_ty_to_str(t).as_slice());
+        body
       }
       LIT_FLOAT_UNSUFFIXED(s) => {
         let mut body = StrBuf::from_str(get_ident(s).get());
         if body.as_slice().ends_with(".") {
             body.push_char('0');  // `10.f` is not a float literal
         }
-        body.into_owned()
+        body
       }
       LIT_STR(s) => {
-          format!("\"{}\"", get_ident(s).get().escape_default())
+          (format!("\"{}\"", get_ident(s).get().escape_default())).to_strbuf()
       }
       LIT_STR_RAW(s, n) => {
-          format!("r{delim}\"{string}\"{delim}",
-                  delim="#".repeat(n), string=get_ident(s))
+          (format!("r{delim}\"{string}\"{delim}",
+                  delim="#".repeat(n), string=get_ident(s))).to_strbuf()
       }
 
       /* Name components */
-      IDENT(s, _) => get_ident(s).get().to_str(),
+      IDENT(s, _) => get_ident(s).get().to_strbuf(),
       LIFETIME(s) => {
-          format!("'{}", get_ident(s))
+          (format!("'{}", get_ident(s))).to_strbuf()
       }
-      UNDERSCORE => "_".to_owned(),
+      UNDERSCORE => "_".to_strbuf(),
 
       /* Other */
-      DOC_COMMENT(s) => get_ident(s).get().to_str(),
-      EOF => "<eof>".to_owned(),
+      DOC_COMMENT(s) => get_ident(s).get().to_strbuf(),
+      EOF => "<eof>".to_strbuf(),
       INTERPOLATED(ref nt) => {
         match nt {
             &NtExpr(e) => ::print::pprust::expr_to_str(e),
             &NtMeta(e) => ::print::pprust::meta_item_to_str(e),
             _ => {
-                "an interpolated ".to_owned() +
-                    match *nt {
-                        NtItem(..) => "item".to_owned(),
-                        NtBlock(..) => "block".to_owned(),
-                        NtStmt(..) => "statement".to_owned(),
-                        NtPat(..) => "pattern".to_owned(),
-                        NtMeta(..) => fail!("should have been handled"),
-                        NtExpr(..) => fail!("should have been handled above"),
-                        NtTy(..) => "type".to_owned(),
-                        NtIdent(..) => "identifier".to_owned(),
-                        NtPath(..) => "path".to_owned(),
-                        NtTT(..) => "tt".to_owned(),
-                        NtMatchers(..) => "matcher sequence".to_owned()
-                    }
+                let mut s = "an interpolated ".to_strbuf();
+                match *nt {
+                    NtItem(..) => s.push_str("item"),
+                    NtBlock(..) => s.push_str("block"),
+                    NtStmt(..) => s.push_str("statement"),
+                    NtPat(..) => s.push_str("pattern"),
+                    NtMeta(..) => fail!("should have been handled"),
+                    NtExpr(..) => fail!("should have been handled above"),
+                    NtTy(..) => s.push_str("type"),
+                    NtIdent(..) => s.push_str("identifier"),
+                    NtPath(..) => s.push_str("path"),
+                    NtTT(..) => s.push_str("tt"),
+                    NtMatchers(..) => s.push_str("matcher sequence")
+                };
+                s
             }
         }
       }

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -84,7 +84,7 @@ pub struct BeginToken {
 
 #[deriving(Clone)]
 pub enum Token {
-    String(~str, int),
+    String(StrBuf, int),
     Break(BreakToken),
     Begin(BeginToken),
     End,
@@ -109,13 +109,13 @@ impl Token {
     }
 }
 
-pub fn tok_str(t: Token) -> ~str {
+pub fn tok_str(t: Token) -> StrBuf {
     match t {
-        String(s, len) => return format!("STR({},{})", s, len),
-        Break(_) => return "BREAK".to_owned(),
-        Begin(_) => return "BEGIN".to_owned(),
-        End => return "END".to_owned(),
-        Eof => return "EOF".to_owned()
+        String(s, len) => return format!("STR({},{})", s, len).to_strbuf(),
+        Break(_) => return "BREAK".to_strbuf(),
+        Begin(_) => return "BEGIN".to_strbuf(),
+        End => return "END".to_strbuf(),
+        Eof => return "EOF".to_strbuf()
     }
 }
 
@@ -124,7 +124,7 @@ pub fn buf_str(toks: Vec<Token>,
                left: uint,
                right: uint,
                lim: uint)
-               -> ~str {
+               -> StrBuf {
     let n = toks.len();
     assert_eq!(n, szs.len());
     let mut i = left;
@@ -140,7 +140,7 @@ pub fn buf_str(toks: Vec<Token>,
         i %= n;
     }
     s.push_char(']');
-    return s.into_owned();
+    return s.into_strbuf();
 }
 
 pub enum PrintStackBreak {
@@ -585,7 +585,7 @@ impl Printer {
             assert_eq!(l, len);
             // assert!(l <= space);
             self.space -= len;
-            self.print_str(s)
+            self.print_str(s.as_slice())
           }
           Eof => {
             // Eof should never get here.
@@ -625,15 +625,15 @@ pub fn end(p: &mut Printer) -> io::IoResult<()> { p.pretty_print(End) }
 pub fn eof(p: &mut Printer) -> io::IoResult<()> { p.pretty_print(Eof) }
 
 pub fn word(p: &mut Printer, wrd: &str) -> io::IoResult<()> {
-    p.pretty_print(String(/* bad */ wrd.to_str(), wrd.len() as int))
+    p.pretty_print(String(/* bad */ wrd.to_strbuf(), wrd.len() as int))
 }
 
 pub fn huge_word(p: &mut Printer, wrd: &str) -> io::IoResult<()> {
-    p.pretty_print(String(/* bad */ wrd.to_str(), SIZE_INFINITY))
+    p.pretty_print(String(/* bad */ wrd.to_strbuf(), SIZE_INFINITY))
 }
 
 pub fn zero_word(p: &mut Printer, wrd: &str) -> io::IoResult<()> {
-    p.pretty_print(String(/* bad */ wrd.to_str(), 0))
+    p.pretty_print(String(/* bad */ wrd.to_strbuf(), 0))
 }
 
 pub fn spaces(p: &mut Printer, n: uint) -> io::IoResult<()> {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -97,7 +97,7 @@ pub static default_columns: uint = 78u;
 pub fn print_crate<'a>(cm: &'a CodeMap,
                        span_diagnostic: &diagnostic::SpanHandler,
                        krate: &ast::Crate,
-                       filename: ~str,
+                       filename: StrBuf,
                        input: &mut io::Reader,
                        out: Box<io::Writer>,
                        ann: &'a PpAnn,
@@ -132,7 +132,7 @@ pub fn print_crate<'a>(cm: &'a CodeMap,
     eof(&mut s.s)
 }
 
-pub fn to_str(f: |&mut State| -> IoResult<()>) -> ~str {
+pub fn to_str(f: |&mut State| -> IoResult<()>) -> StrBuf {
     let mut s = rust_printer(box MemWriter::new());
     f(&mut s).unwrap();
     eof(&mut s.s).unwrap();
@@ -143,65 +143,65 @@ pub fn to_str(f: |&mut State| -> IoResult<()>) -> ~str {
         let (_, wr): (uint, Box<MemWriter>) = cast::transmute_copy(&s.s.out);
         let result = str::from_utf8_owned(wr.get_ref().to_owned()).unwrap();
         cast::forget(wr);
-        result
+        result.to_strbuf()
     }
 }
 
-pub fn ty_to_str(ty: &ast::Ty) -> ~str {
+pub fn ty_to_str(ty: &ast::Ty) -> StrBuf {
     to_str(|s| s.print_type(ty))
 }
 
-pub fn pat_to_str(pat: &ast::Pat) -> ~str {
+pub fn pat_to_str(pat: &ast::Pat) -> StrBuf {
     to_str(|s| s.print_pat(pat))
 }
 
-pub fn expr_to_str(e: &ast::Expr) -> ~str {
+pub fn expr_to_str(e: &ast::Expr) -> StrBuf {
     to_str(|s| s.print_expr(e))
 }
 
-pub fn lifetime_to_str(e: &ast::Lifetime) -> ~str {
+pub fn lifetime_to_str(e: &ast::Lifetime) -> StrBuf {
     to_str(|s| s.print_lifetime(e))
 }
 
-pub fn tt_to_str(tt: &ast::TokenTree) -> ~str {
+pub fn tt_to_str(tt: &ast::TokenTree) -> StrBuf {
     to_str(|s| s.print_tt(tt))
 }
 
-pub fn tts_to_str(tts: &[ast::TokenTree]) -> ~str {
+pub fn tts_to_str(tts: &[ast::TokenTree]) -> StrBuf {
     to_str(|s| s.print_tts(&tts))
 }
 
-pub fn stmt_to_str(stmt: &ast::Stmt) -> ~str {
+pub fn stmt_to_str(stmt: &ast::Stmt) -> StrBuf {
     to_str(|s| s.print_stmt(stmt))
 }
 
-pub fn item_to_str(i: &ast::Item) -> ~str {
+pub fn item_to_str(i: &ast::Item) -> StrBuf {
     to_str(|s| s.print_item(i))
 }
 
-pub fn generics_to_str(generics: &ast::Generics) -> ~str {
+pub fn generics_to_str(generics: &ast::Generics) -> StrBuf {
     to_str(|s| s.print_generics(generics))
 }
 
-pub fn ty_method_to_str(p: &ast::TypeMethod) -> ~str {
+pub fn ty_method_to_str(p: &ast::TypeMethod) -> StrBuf {
     to_str(|s| s.print_ty_method(p))
 }
 
-pub fn method_to_str(p: &ast::Method) -> ~str {
+pub fn method_to_str(p: &ast::Method) -> StrBuf {
     to_str(|s| s.print_method(p))
 }
 
-pub fn fn_block_to_str(p: &ast::FnDecl) -> ~str {
+pub fn fn_block_to_str(p: &ast::FnDecl) -> StrBuf {
     to_str(|s| s.print_fn_block_args(p))
 }
 
-pub fn path_to_str(p: &ast::Path) -> ~str {
+pub fn path_to_str(p: &ast::Path) -> StrBuf {
     to_str(|s| s.print_path(p, false))
 }
 
 pub fn fun_to_str(decl: &ast::FnDecl, fn_style: ast::FnStyle, name: ast::Ident,
                   opt_explicit_self: Option<ast::ExplicitSelf_>,
-                  generics: &ast::Generics) -> ~str {
+                  generics: &ast::Generics) -> StrBuf {
     to_str(|s| {
         try!(s.print_fn(decl, Some(fn_style), abi::Rust,
                         name, generics, opt_explicit_self, ast::Inherited));
@@ -210,7 +210,7 @@ pub fn fun_to_str(decl: &ast::FnDecl, fn_style: ast::FnStyle, name: ast::Ident,
     })
 }
 
-pub fn block_to_str(blk: &ast::Block) -> ~str {
+pub fn block_to_str(blk: &ast::Block) -> StrBuf {
     to_str(|s| {
         // containing cbox, will be closed by print-block at }
         try!(s.cbox(indent_unit));
@@ -220,30 +220,30 @@ pub fn block_to_str(blk: &ast::Block) -> ~str {
     })
 }
 
-pub fn meta_item_to_str(mi: &ast::MetaItem) -> ~str {
+pub fn meta_item_to_str(mi: &ast::MetaItem) -> StrBuf {
     to_str(|s| s.print_meta_item(mi))
 }
 
-pub fn attribute_to_str(attr: &ast::Attribute) -> ~str {
+pub fn attribute_to_str(attr: &ast::Attribute) -> StrBuf {
     to_str(|s| s.print_attribute(attr))
 }
 
-pub fn lit_to_str(l: &ast::Lit) -> ~str {
+pub fn lit_to_str(l: &ast::Lit) -> StrBuf {
     to_str(|s| s.print_literal(l))
 }
 
-pub fn explicit_self_to_str(explicit_self: ast::ExplicitSelf_) -> ~str {
+pub fn explicit_self_to_str(explicit_self: ast::ExplicitSelf_) -> StrBuf {
     to_str(|s| s.print_explicit_self(explicit_self, ast::MutImmutable).map(|_| {}))
 }
 
-pub fn variant_to_str(var: &ast::Variant) -> ~str {
+pub fn variant_to_str(var: &ast::Variant) -> StrBuf {
     to_str(|s| s.print_variant(var))
 }
 
-pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> ~str {
+pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> StrBuf {
     match vis {
-        ast::Public => format!("pub {}", s),
-        ast::Inherited => s.to_owned()
+        ast::Public => format!("pub {}", s).to_strbuf(),
+        ast::Inherited => s.to_strbuf()
     }
 }
 
@@ -366,10 +366,10 @@ impl<'a> State<'a> {
 
     // Synthesizes a comment that was not textually present in the original source
     // file.
-    pub fn synth_comment(&mut self, text: ~str) -> IoResult<()> {
+    pub fn synth_comment(&mut self, text: StrBuf) -> IoResult<()> {
         try!(word(&mut self.s, "/*"));
         try!(space(&mut self.s));
-        try!(word(&mut self.s, text));
+        try!(word(&mut self.s, text.as_slice()));
         try!(space(&mut self.s));
         word(&mut self.s, "*/")
     }
@@ -552,7 +552,8 @@ impl<'a> State<'a> {
                 self.end() // end the outer fn box
             }
             ast::ForeignItemStatic(t, m) => {
-                try!(self.head(visibility_qualified(item.vis, "static")));
+                try!(self.head(visibility_qualified(item.vis,
+                                                    "static").as_slice()));
                 if m {
                     try!(self.word_space("mut"));
                 }
@@ -573,7 +574,8 @@ impl<'a> State<'a> {
         try!(self.ann.pre(self, NodeItem(item)));
         match item.node {
             ast::ItemStatic(ty, m, expr) => {
-                try!(self.head(visibility_qualified(item.vis, "static")));
+                try!(self.head(visibility_qualified(item.vis,
+                                                    "static").as_slice()));
                 if m == ast::MutMutable {
                     try!(self.word_space("mut"));
                 }
@@ -602,7 +604,8 @@ impl<'a> State<'a> {
                 try!(self.print_block_with_attrs(body, item.attrs.as_slice()));
             }
             ast::ItemMod(ref _mod) => {
-                try!(self.head(visibility_qualified(item.vis, "mod")));
+                try!(self.head(visibility_qualified(item.vis,
+                                                    "mod").as_slice()));
                 try!(self.print_ident(item.ident));
                 try!(self.nbsp());
                 try!(self.bopen());
@@ -619,7 +622,8 @@ impl<'a> State<'a> {
             ast::ItemTy(ty, ref params) => {
                 try!(self.ibox(indent_unit));
                 try!(self.ibox(0u));
-                try!(self.word_nbsp(visibility_qualified(item.vis, "type")));
+                try!(self.word_nbsp(visibility_qualified(item.vis,
+                                                         "type").as_slice()));
                 try!(self.print_ident(item.ident));
                 try!(self.print_generics(params));
                 try!(self.end()); // end the inner ibox
@@ -643,12 +647,14 @@ impl<'a> State<'a> {
                 if struct_def.is_virtual {
                     try!(self.word_space("virtual"));
                 }
-                try!(self.head(visibility_qualified(item.vis, "struct")));
+                try!(self.head(visibility_qualified(item.vis,
+                                                    "struct").as_slice()));
                 try!(self.print_struct(struct_def, generics, item.ident, item.span));
             }
 
             ast::ItemImpl(ref generics, ref opt_trait, ty, ref methods) => {
-                try!(self.head(visibility_qualified(item.vis, "impl")));
+                try!(self.head(visibility_qualified(item.vis,
+                                                    "impl").as_slice()));
                 if generics.is_parameterized() {
                     try!(self.print_generics(generics));
                     try!(space(&mut self.s));
@@ -674,7 +680,8 @@ impl<'a> State<'a> {
                 try!(self.bclose(item.span));
             }
             ast::ItemTrait(ref generics, ref sized, ref traits, ref methods) => {
-                try!(self.head(visibility_qualified(item.vis, "trait")));
+                try!(self.head(visibility_qualified(item.vis,
+                                                    "trait").as_slice()));
                 try!(self.print_ident(item.ident));
                 try!(self.print_generics(generics));
                 if *sized == ast::DynSize {
@@ -723,7 +730,7 @@ impl<'a> State<'a> {
                           generics: &ast::Generics, ident: ast::Ident,
                           span: codemap::Span,
                           visibility: ast::Visibility) -> IoResult<()> {
-        try!(self.head(visibility_qualified(visibility, "enum")));
+        try!(self.head(visibility_qualified(visibility, "enum").as_slice()));
         try!(self.print_ident(ident));
         try!(self.print_generics(generics));
         try!(space(&mut self.s));
@@ -825,7 +832,7 @@ impl<'a> State<'a> {
         match *tt {
             ast::TTDelim(ref tts) => self.print_tts(&(tts.as_slice())),
             ast::TTTok(_, ref tk) => {
-                word(&mut self.s, parse::token::to_str(tk))
+                word(&mut self.s, parse::token::to_str(tk).as_slice())
             }
             ast::TTSeq(_, ref tts, ref sep, zerok) => {
                 try!(word(&mut self.s, "$("));
@@ -835,7 +842,8 @@ impl<'a> State<'a> {
                 try!(word(&mut self.s, ")"));
                 match *sep {
                     Some(ref tk) => {
-                        try!(word(&mut self.s, parse::token::to_str(tk)));
+                        try!(word(&mut self.s,
+                                  parse::token::to_str(tk).as_slice()));
                     }
                     None => ()
                 }
@@ -2189,7 +2197,7 @@ impl<'a> State<'a> {
         try!(self.maybe_print_comment(lit.span.lo));
         match self.next_lit(lit.span.lo) {
             Some(ref ltrl) => {
-                return word(&mut self.s, (*ltrl).lit);
+                return word(&mut self.s, (*ltrl).lit.as_slice());
             }
             _ => ()
         }
@@ -2202,16 +2210,19 @@ impl<'a> State<'a> {
                 word(&mut self.s, res.into_owned())
             }
             ast::LitInt(i, t) => {
-                word(&mut self.s, ast_util::int_ty_to_str(t, Some(i)))
+                word(&mut self.s,
+                     ast_util::int_ty_to_str(t, Some(i)).as_slice())
             }
             ast::LitUint(u, t) => {
-                word(&mut self.s, ast_util::uint_ty_to_str(t, Some(u)))
+                word(&mut self.s,
+                     ast_util::uint_ty_to_str(t, Some(u)).as_slice())
             }
             ast::LitIntUnsuffixed(i) => {
                 word(&mut self.s, format!("{}", i))
             }
             ast::LitFloat(ref f, t) => {
-                word(&mut self.s, f.get() + ast_util::float_ty_to_str(t))
+                word(&mut self.s,
+                     f.get() + ast_util::float_ty_to_str(t).as_slice())
             }
             ast::LitFloatUnsuffixed(ref f) => word(&mut self.s, f.get()),
             ast::LitNil => word(&mut self.s, "()"),
@@ -2266,7 +2277,7 @@ impl<'a> State<'a> {
             comments::Mixed => {
                 assert_eq!(cmnt.lines.len(), 1u);
                 try!(zerobreak(&mut self.s));
-                try!(word(&mut self.s, *cmnt.lines.get(0)));
+                try!(word(&mut self.s, cmnt.lines.get(0).as_slice()));
                 zerobreak(&mut self.s)
             }
             comments::Isolated => {
@@ -2275,7 +2286,7 @@ impl<'a> State<'a> {
                     // Don't print empty lines because they will end up as trailing
                     // whitespace
                     if !line.is_empty() {
-                        try!(word(&mut self.s, *line));
+                        try!(word(&mut self.s, line.as_slice()));
                     }
                     try!(hardbreak(&mut self.s));
                 }
@@ -2284,13 +2295,13 @@ impl<'a> State<'a> {
             comments::Trailing => {
                 try!(word(&mut self.s, " "));
                 if cmnt.lines.len() == 1u {
-                    try!(word(&mut self.s, *cmnt.lines.get(0)));
+                    try!(word(&mut self.s, cmnt.lines.get(0).as_slice()));
                     hardbreak(&mut self.s)
                 } else {
                     try!(self.ibox(0u));
                     for line in cmnt.lines.iter() {
                         if !line.is_empty() {
-                            try!(word(&mut self.s, *line));
+                            try!(word(&mut self.s, line.as_slice()));
                         }
                         try!(hardbreak(&mut self.s));
                     }
@@ -2300,7 +2311,7 @@ impl<'a> State<'a> {
             comments::BlankLine => {
                 // We need to do at least one, possibly two hardbreaks.
                 let is_semi = match self.s.last_token() {
-                    pp::String(s, _) => ";" == s,
+                    pp::String(s, _) => ";" == s.as_slice(),
                     _ => false
                 };
                 if is_semi || self.is_begin() || self.is_end() {
@@ -2371,8 +2382,9 @@ impl<'a> State<'a> {
                                 opt_fn_style: Option<ast::FnStyle>,
                                 abi: abi::Abi,
                                 vis: ast::Visibility) -> IoResult<()> {
-        try!(word(&mut self.s, visibility_qualified(vis, "")));
+        try!(word(&mut self.s, visibility_qualified(vis, "").as_slice()));
         try!(self.print_opt_fn_style(opt_fn_style));
+
         if abi != abi::Rust {
             try!(self.word_nbsp("extern"));
             try!(self.word_nbsp(abi.to_str()));
@@ -2420,7 +2432,7 @@ mod test {
         let generics = ast_util::empty_generics();
         assert_eq!(&fun_to_str(&decl, ast::NormalFn, abba_ident,
                                None, &generics),
-                   &"fn abba()".to_owned());
+                   &"fn abba()".to_strbuf());
     }
 
     #[test]
@@ -2438,6 +2450,6 @@ mod test {
         });
 
         let varstr = variant_to_str(&var);
-        assert_eq!(&varstr,&"pub principal_skinner".to_owned());
+        assert_eq!(&varstr,&"pub principal_skinner".to_strbuf());
     }
 }

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -92,7 +92,7 @@ impl<T: TotalEq + Hash + Clone + 'static> Interner<T> {
 
 #[deriving(Clone, Eq, Hash, Ord)]
 pub struct RcStr {
-    string: Rc<~str>,
+    string: Rc<StrBuf>,
 }
 
 impl TotalEq for RcStr {}
@@ -106,7 +106,7 @@ impl TotalOrd for RcStr {
 impl Str for RcStr {
     #[inline]
     fn as_slice<'a>(&'a self) -> &'a str {
-        let s: &'a str = *self.string;
+        let s: &'a str = self.string.as_slice();
         s
     }
 }
@@ -121,7 +121,7 @@ impl fmt::Show for RcStr {
 impl RcStr {
     pub fn new(string: &str) -> RcStr {
         RcStr {
-            string: Rc::new(string.to_owned()),
+            string: Rc::new(string.to_strbuf()),
         }
     }
 }

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -16,17 +16,21 @@ use parse::parser::Parser;
 use parse::token;
 
 // map a string to tts, using a made-up filename:
-pub fn string_to_tts(source_str: ~str) -> Vec<ast::TokenTree> {
+pub fn string_to_tts(source_str: StrBuf) -> Vec<ast::TokenTree> {
     let ps = new_parse_sess();
-    filemap_to_tts(&ps, string_to_filemap(&ps, source_str,"bogofile".to_owned()))
+    filemap_to_tts(&ps,
+                   string_to_filemap(&ps, source_str, "bogofile".to_strbuf()))
 }
 
 // map string to parser (via tts)
-pub fn string_to_parser<'a>(ps: &'a ParseSess, source_str: ~str) -> Parser<'a> {
-    new_parser_from_source_str(ps, Vec::new(), "bogofile".to_owned(), source_str)
+pub fn string_to_parser<'a>(ps: &'a ParseSess, source_str: StrBuf) -> Parser<'a> {
+    new_parser_from_source_str(ps,
+                               Vec::new(),
+                               "bogofile".to_strbuf(),
+                               source_str)
 }
 
-fn with_error_checking_parse<T>(s: ~str, f: |&mut Parser| -> T) -> T {
+fn with_error_checking_parse<T>(s: StrBuf, f: |&mut Parser| -> T) -> T {
     let ps = new_parse_sess();
     let mut p = string_to_parser(&ps, s);
     let x = f(&mut p);
@@ -35,28 +39,28 @@ fn with_error_checking_parse<T>(s: ~str, f: |&mut Parser| -> T) -> T {
 }
 
 // parse a string, return a crate.
-pub fn string_to_crate (source_str : ~str) -> ast::Crate {
+pub fn string_to_crate (source_str : StrBuf) -> ast::Crate {
     with_error_checking_parse(source_str, |p| {
         p.parse_crate_mod()
     })
 }
 
 // parse a string, return an expr
-pub fn string_to_expr (source_str : ~str) -> @ast::Expr {
+pub fn string_to_expr (source_str : StrBuf) -> @ast::Expr {
     with_error_checking_parse(source_str, |p| {
         p.parse_expr()
     })
 }
 
 // parse a string, return an item
-pub fn string_to_item (source_str : ~str) -> Option<@ast::Item> {
+pub fn string_to_item (source_str : StrBuf) -> Option<@ast::Item> {
     with_error_checking_parse(source_str, |p| {
         p.parse_item(Vec::new())
     })
 }
 
 // parse a string, return a stmt
-pub fn string_to_stmt(source_str : ~str) -> @ast::Stmt {
+pub fn string_to_stmt(source_str : StrBuf) -> @ast::Stmt {
     with_error_checking_parse(source_str, |p| {
         p.parse_stmt(Vec::new())
     })
@@ -64,7 +68,7 @@ pub fn string_to_stmt(source_str : ~str) -> @ast::Stmt {
 
 // parse a string, return a pat. Uses "irrefutable"... which doesn't
 // (currently) affect parsing.
-pub fn string_to_pat(source_str: ~str) -> @ast::Pat {
+pub fn string_to_pat(source_str: StrBuf) -> @ast::Pat {
     string_to_parser(&new_parse_sess(), source_str).parse_pat()
 }
 


### PR DESCRIPTION
r? @brson
