### PR TITLE
Add compiler flag to force color output

### DIFF
--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -323,7 +323,7 @@ fn parse_crate_attrs(sess: &Session, input: &Input) ->
 }
 
 pub fn early_error(msg: &str) -> ! {
-    let mut emitter = diagnostic::EmitterWriter::stderr();
+    let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto);
     emitter.emit(None, msg, diagnostic::Fatal);
     fail!(diagnostic::FatalError);
 }
@@ -368,7 +368,7 @@ fn monitor(f: proc():Send) {
         Err(value) => {
             // Task failed without emitting a fatal diagnostic
             if !value.is::<diagnostic::FatalError>() {
-                let mut emitter = diagnostic::EmitterWriter::stderr();
+                let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto);
 
                 // a .span_bug or .bug call has already printed what
                 // it wants to print.

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -196,7 +196,7 @@ pub fn build_session(sopts: config::Options,
                      -> Session {
     let codemap = codemap::CodeMap::new();
     let diagnostic_handler =
-        diagnostic::default_handler();
+        diagnostic::default_handler(sopts.color);
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -78,7 +78,7 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<StrBuf>)
 
 
     let codemap = syntax::codemap::CodeMap::new();
-    let diagnostic_handler = syntax::diagnostic::default_handler();
+    let diagnostic_handler = syntax::diagnostic::default_handler(syntax::diagnostic::Auto);
     let span_diagnostic_handler =
         syntax::diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -53,7 +53,7 @@ pub fn run(input: &str,
 
 
     let codemap = CodeMap::new();
-    let diagnostic_handler = diagnostic::default_handler();
+    let diagnostic_handler = diagnostic::default_handler(diagnostic::Auto);
     let span_diagnostic_handler =
     diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -49,6 +49,13 @@ impl RenderSpan {
     }
 }
 
+#[deriving(Clone)]
+pub enum ColorConfig {
+    Auto,
+    Always,
+    Never
+}
+
 pub trait Emitter {
     fn emit(&mut self, cmsp: Option<(&codemap::CodeMap, Span)>,
             msg: &str, lvl: Level);
@@ -176,8 +183,8 @@ pub fn mk_span_handler(handler: Handler, cm: codemap::CodeMap) -> SpanHandler {
     }
 }
 
-pub fn default_handler() -> Handler {
-    mk_handler(box EmitterWriter::stderr())
+pub fn default_handler(color_config: ColorConfig) -> Handler {
+    mk_handler(box EmitterWriter::stderr(color_config))
 }
 
 pub fn mk_handler(e: Box<Emitter:Send>) -> Handler {
@@ -257,9 +264,16 @@ enum Destination {
 }
 
 impl EmitterWriter {
-    pub fn stderr() -> EmitterWriter {
+    pub fn stderr(color_config: ColorConfig) -> EmitterWriter {
         let stderr = io::stderr();
-        if stderr.get_ref().isatty() {
+
+        let use_color = match color_config {
+            Always => true,
+            Never  => false,
+            Auto   => stderr.get_ref().isatty()
+        };
+
+        if use_color {
             let dst = match term::Terminal::new(stderr.unwrap()) {
                 Ok(t) => Terminal(t),
                 Err(..) => Raw(box io::stderr()),

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -13,7 +13,7 @@
 
 use ast;
 use codemap::{Span, CodeMap, FileMap};
-use diagnostic::{SpanHandler, mk_span_handler, default_handler};
+use diagnostic::{SpanHandler, mk_span_handler, default_handler, Auto};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 
@@ -41,7 +41,7 @@ pub struct ParseSess {
 
 pub fn new_parse_sess() -> ParseSess {
     ParseSess {
-        span_diagnostic: mk_span_handler(default_handler(), CodeMap::new()),
+        span_diagnostic: mk_span_handler(default_handler(Auto), CodeMap::new()),
         included_mod_stack: RefCell::new(Vec::new()),
     }
 }


### PR DESCRIPTION
This pull request fixes #12881.

Two caveats:
1. As explained in the commit message, this doesn't include a regression test. If this is unacceptable, please let me know, I'll see what I can do.
2. I'm getting some test failures on make check, all from debuginfo. I suspect this is due to #13680 and  not related to my changes (I have GDB 7.7). This is the list of failed tests:

> [debuginfo-gdb] debuginfo/basic-types-globals.rs
> [debuginfo-gdb] debuginfo/basic-types-mut-globals.rs
> [debuginfo-gdb] debuginfo/basic-types.rs
> [debuginfo-gdb] debuginfo/borrowed-basic.rs
> [debuginfo-gdb] debuginfo/borrowed-managed-basic.rs
> [debuginfo-gdb] debuginfo/borrowed-struct.rs
> [debuginfo-gdb] debuginfo/borrowed-unique-basic.rs
> [debuginfo-gdb] debuginfo/box.rs
> [debuginfo-gdb] debuginfo/by-value-non-immediate-argument.rs
> [debuginfo-gdb] debuginfo/by-value-self-argument-in-trait-impl.rs
> [debuginfo-gdb] debuginfo/closure-in-generic-function.rs
> [debuginfo-gdb] debuginfo/evec-in-struct.rs
> [debuginfo-gdb] debuginfo/function-arg-initialization.rs
> [debuginfo-gdb] debuginfo/function-prologue-stepping-no-split-stack.rs
> [debuginfo-gdb] debuginfo/generic-function.rs
> [debuginfo-gdb] debuginfo/generic-functions-nested.rs
> [debuginfo-gdb] debuginfo/generic-method-on-generic-struct.rs
> [debuginfo-gdb] debuginfo/generic-static-method-on-struct-and-enum.rs
> [debuginfo-gdb] debuginfo/generic-struct.rs
> [debuginfo-gdb] debuginfo/lexical-scope-in-stack-closure.rs
> [debuginfo-gdb] debuginfo/lexical-scope-in-unique-closure.rs
> [debuginfo-gdb] debuginfo/method-on-generic-struct.rs
> [debuginfo-gdb] debuginfo/method-on-tuple-struct.rs
> [debuginfo-gdb] debuginfo/name-shadowing-and-scope-nesting.rs
> [debuginfo-gdb] debuginfo/recursive-struct.rs
> [debuginfo-gdb] debuginfo/self-in-generic-default-method.rs
> [debuginfo-gdb] debuginfo/shadowed-argument.rs
> [debuginfo-gdb] debuginfo/shadowed-variable.rs
> [debuginfo-gdb] debuginfo/simd.rs
> [debuginfo-gdb] debuginfo/simple-lexical-scope.rs
> [debuginfo-gdb] debuginfo/simple-struct.rs
> [debuginfo-gdb] debuginfo/simple-tuple.rs
> [debuginfo-gdb] debuginfo/static-method-on-struct-and-enum.rs
> [debuginfo-gdb] debuginfo/tuple-struct.rs
> [debuginfo-gdb] debuginfo/var-captured-in-nested-closure.rs
> [debuginfo-gdb] debuginfo/var-captured-in-sendable-closure.rs
> [debuginfo-gdb] debuginfo/var-captured-in-stack-closure.rs

I can provide the full output on request.
