### PR TITLE
rustdoc: add stability and source links to the methods; w/ style tweaks

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1064,7 +1064,7 @@ impl Context {
             };
             try!(write!(w, "<a class='source-link' \
                               href='{root}src/{krate}/{path}.html\\#{href}'>\
-                              Source</a>",
+                              [src]</a>",
                           root = self.root_path,
                           krate = self.layout.krate,
                           path = path.connect("/"),

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1183,7 +1183,7 @@ impl Context {
                     VisSpace(myitem.visibility),
                     *myitem.name.get_ref(),
                     s.type_,
-                    Initializer(s.expr, Item { cx: cx, item: myitem }),
+                    Initializer(s.expr, Item { cx: self, item: myitem }),
                     Markdown(blank(myitem.doc_value()))));
                 }
 
@@ -1222,7 +1222,7 @@ impl Context {
                     Markdown(shorter(myitem.doc_value())),
                     class = shortty(myitem),
                     href = item_path(myitem),
-                    title = full_path(cx, myitem)));
+                    title = full_path(self, myitem)));
                 }
             }
         }
@@ -1637,7 +1637,7 @@ impl Context {
 
         fn docmeth(w: &mut Writer, cx: &Context,
                    item: &clean::Item, dox: bool) -> io::IoResult<()> {
-            try!(write!(w, "<div class="method-container">"));
+            try!(write!(w, "<div class='method-container'>"));
             try!(write!(w, "<h4 id='method.{}' class='method'><code>",
                           *item.name.get_ref()));
             try!(cx.render_method(w, item));

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1579,7 +1579,7 @@ impl Context {
                     p.ref0().trait_.is_some()
                 });
                 let traits = traits.collect::<Vec<&(clean::Impl, Option<~str>)>>();
-    
+
                 if non_trait.len() > 0 {
                     try!(write!(w, "<h2 id='methods'>Methods</h2>"));
                     for &(ref i, ref dox) in non_trait.move_iter() {
@@ -1637,6 +1637,7 @@ impl Context {
 
         fn docmeth(w: &mut Writer, cx: &Context,
                    item: &clean::Item, dox: bool) -> io::IoResult<()> {
+            try!(write!(w, "<div class="method-container">"));
             try!(write!(w, "<h4 id='method.{}' class='method'><code>",
                           *item.name.get_ref()));
             try!(cx.render_method(w, item));
@@ -1650,6 +1651,7 @@ impl Context {
                 }
                 Some(..) | None => Ok(())
             }
+            try!(write!(w, "</div>"));
         }
 
         try!(write!(w, "<div class='methods'>"));

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -227,6 +227,12 @@ nav.sub {
     font-size: 90%;
     font-weight: 400;
 }
+.method .source-link {
+    visibility: hidden;
+}
+.method-container:hover .source-link {
+    visibility: visible;
+}
 
 .content table {
     border-spacing: 0 5px;
@@ -369,23 +375,20 @@ a {
 }
 
 .stability {
-    border-radius: 2px;
-    color: #FFF;
+    border-radius: 10px;
     display: inline-block;
-    font-size: 11px;
-    font-weight: 400;
+    font-size: 0;
+    height: 12px;
+    width: 12px;
     margin: 0 8px;
     padding: 0 4px;
-    text-transform: uppercase;
-    vertical-align: 4px;
+    vertical-align: 12px;
 }
 .method .stability {
-    visibility: hidden;
+    height: 10px;
+    width: 10px;
     margin: 0 4px;
-    vertical-align: 1px;
-}
-.method:hover .stability {
-    visibility: visible;
+    vertical-align: 9px;
 }
 
 .stability.Deprecated { background-color: #C8344D; }
@@ -425,11 +428,9 @@ pre.rust .lifetime { color: #B76514; }
     .sidebar {
         display: none;
     }
-
     .content {
         margin-left: 0px;
     }
-
     nav.sub {
         margin: 0 auto;
     }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -89,7 +89,7 @@ h3.impl, h3.method, h4.method {
 h3.impl, h3.method {
     margin-top: 15px;
 }
-h1, h2, h3, h4, section.sidebar, a.source, .search-input, .content table a {
+h1, h2, h3, h4, section.sidebar, .source-link, .search-input, .content table a {
     font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
@@ -222,7 +222,7 @@ nav.sub {
 .docblock h2 { font-size: 1.15em; }
 .docblock h3, .docblock h4, .docblock h5 { font-size: 1em; }
 
-.content .source {
+.content .source-link {
     float: right;
     font-size: 23px;
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -226,9 +226,6 @@ nav.sub {
     float: right;
     font-size: 90%;
     font-weight: 400;
-    border-radius: 3px;
-    padding: 2px 10px;
-    background-color: #ddd;
 }
 
 .content table {
@@ -292,8 +289,8 @@ a {
     color: #000;
     background: transparent;
 }
-p a { color: #4e8bca; }
-p a:hover { text-decoration: underline; }
+.content p a { color: #4e8bca; }
+.content p a:hover { text-decoration: underline; }
 
 .content a.trait, .block a.current.trait { color: #ed9603; }
 .content a.mod, .block a.current.mod { color: #4d76ae; }
@@ -372,24 +369,31 @@ p a:hover { text-decoration: underline; }
 }
 
 .stability {
-    border-left: 6px solid #000;
-    border-radius: 3px;
+    border-radius: 2px;
+    color: #FFF;
+    display: inline-block;
+    font-size: 11px;
     font-weight: 400;
-    padding: 4px 10px;
-    font-size: 90%;
-    font-style: italic;
-    border-bottom: 2px solid #000;
-    padding: 2px 5px;
-    text-transform: lowercase;
-    margin-left: 14px;
+    margin: 0 8px;
+    padding: 0 4px;
+    text-transform: uppercase;
+    vertical-align: 4px;
+}
+.method .stability {
+    visibility: hidden;
+    margin: 0 4px;
+    vertical-align: 1px;
+}
+.method:hover .stability {
+    visibility: visible;
 }
 
-.stability.Deprecated { border-color: #D60027; color: #880017; }
-.stability.Experimental { border-color: #EC5315; color: #a53c0e; }
-.stability.Unstable { border-color: #FFD700; color: #b39800; }
-.stability.Stable { border-color: #AEC516; color: #7c8b10; }
-.stability.Frozen { border-color: #009431; color: #007726; }
-.stability.Locked { border-color: #0084B6; color: #00668c; }
+.stability.Deprecated { background-color: #C8344D; }
+.stability.Experimental { background-color: #E58623; }
+.stability.Unstable { background-color: #F2CF15; }
+.stability.Stable { background-color: #809C10; }
+.stability.Frozen { background-color: #108034; }
+.stability.Locked { background-color: #007DAB; }
 
 :target { background: #FDFFD3; }
 

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -224,7 +224,11 @@ nav.sub {
 
 .content .source-link {
     float: right;
-    font-size: 23px;
+    font-size: 90%;
+    font-weight: 400;
+    border-radius: 3px;
+    padding: 2px 10px;
+    background-color: #ddd;
 }
 
 .content table {
@@ -372,6 +376,10 @@ p a:hover { text-decoration: underline; }
     border-radius: 3px;
     font-weight: 400;
     padding: 4px 10px;
+    font-size: 90%;
+    font-style: italic;
+    border-bottom: 2px solid #000;
+    padding: 2px 5px;
     text-transform: lowercase;
     margin-left: 14px;
 }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -366,10 +366,14 @@ pub fn find_stability<AM: AttrMetaMethods, It: Iterator<AM>>(mut metas: It)
             "locked" => Locked,
             _ => continue // not a stability level
         };
+        let text = match m.value_str() {
+            "" => m.name().get(),
+            desc => desc
+        };
 
         return Some(Stability {
                 level: level,
-                text: m.value_str()
+                text: text
             });
     }
     None

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -367,8 +367,8 @@ pub fn find_stability<AM: AttrMetaMethods, It: Iterator<AM>>(mut metas: It)
             _ => continue // not a stability level
         };
         let text = match m.value_str() {
-            "" => m.name().get(),
-            desc => desc
+            None => Some(m.name()),
+            Some(desc) => Some(desc)
         };
 
         return Some(Stability {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1088,9 +1088,9 @@ impl<'a> Parser<'a> {
                 p.parse_arg_general(false)
             });
 
-            let hi = p.last_span.hi;
             match p.token {
               token::SEMI => {
+                let hi = p.last_span.hi;
                 p.bump();
                 debug!("parse_trait_methods(): parsing required method");
                 // NB: at the moment, visibility annotations on required
@@ -1113,6 +1113,7 @@ impl<'a> Parser<'a> {
                 debug!("parse_trait_methods(): parsing provided method");
                 let (inner_attrs, body) =
                     p.parse_inner_attrs_and_block();
+                let hi = p.last_span.hi;
                 let attrs = attrs.append(inner_attrs.as_slice());
                 Provided(@ast::Method {
                     ident: ident,


### PR DESCRIPTION
- Pull-in changes from #13802, with a rebase
- Fix again link selectors (unrelated to the original PR)
- Show stability attributes with color pellets, add more explicit titles that will appear on hover
- Keep using `[src]` for the source links, don't show them on methods until (method+description) is hovered

Example: http://adrientetar.legtux.org/cached/rust-docs/foo.htm

cc @lifthrasiir. Closes #13802, which fixes #12932.

r? @alexcrichton
