### PR TITLE
Check lifetime parameters when resolving impls; use `ty::substs` in trans

### DIFF
--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -128,7 +128,7 @@ pub enum astencode_tag { // Reserves 0x40 -- 0x5f
     tag_table_val = 0x45,
     tag_table_def = 0x46,
     tag_table_node_type = 0x47,
-    tag_table_node_type_subst = 0x48,
+    tag_table_item_subst = 0x48,
     tag_table_freevars = 0x49,
     tag_table_tcache = 0x4a,
     tag_table_param_defs = 0x4b,

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -195,6 +195,17 @@ impl Subst for ty::substs {
     }
 }
 
+impl Subst for ty::ItemSubsts {
+    fn subst_spanned(&self, tcx: &ty::ctxt,
+                     substs: &ty::substs,
+                     span: Option<Span>)
+                     -> ty::ItemSubsts {
+        ty::ItemSubsts {
+            substs: self.substs.subst_spanned(tcx, substs, span)
+        }
+    }
+}
+
 impl Subst for ty::RegionSubsts {
     fn subst_spanned(&self, tcx: &ty::ctxt,
                      substs: &ty::substs,

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -236,7 +236,7 @@ fn trans_struct_drop<'a>(bcx: &'a Block<'a>,
 
     // Find and call the actual destructor
     let dtor_addr = get_res_dtor(bcx.ccx(), dtor_did,
-                                 class_did, substs.tps.as_slice());
+                                 class_did, substs);
 
     // The second argument is the "self" argument for drop
     let params = unsafe {

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -295,7 +295,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             RetVoid(bcx);
         }
         "size_of" => {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llsize_of_real(ccx, lltp_ty) as uint));
         }
@@ -305,7 +305,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             // if the value is non-immediate. Note that, with
             // intrinsics, there are no argument cleanups to
             // concern ourselves with, so we can use an rvalue datum.
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             let mode = appropriate_rvalue_mode(ccx, tp_ty);
             let src = Datum {val: get_param(decl, first_real_arg + 1u),
                              ty: tp_ty,
@@ -314,17 +314,17 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             RetVoid(bcx);
         }
         "min_align_of" => {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_min(ccx, lltp_ty) as uint));
         }
         "pref_align_of"=> {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_pref(ccx, lltp_ty) as uint));
         }
         "get_tydesc" => {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             let static_ti = get_tydesc(ccx, tp_ty);
             glue::lazily_emit_visit_glue(ccx, &*static_ti);
 
@@ -339,7 +339,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
         "type_id" => {
             let hash = ty::hash_crate_independent(
                 ccx.tcx(),
-                *substs.tys.get(0),
+                *substs.substs.tps.get(0),
                 &ccx.link_meta.crate_hash);
             // NB: This needs to be kept in lockstep with the TypeId struct in
             //     libstd/unstable/intrinsics.rs
@@ -354,7 +354,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             }
         }
         "init" => {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             match bcx.fcx.llretptr.get() {
                 Some(ptr) => { Store(bcx, C_null(lltp_ty), ptr); RetVoid(bcx); }
@@ -364,7 +364,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
         }
         "uninit" => {
             // Do nothing, this is effectively a no-op
-            let retty = *substs.tys.get(0);
+            let retty = *substs.substs.tps.get(0);
             if type_is_immediate(ccx, retty) && !return_type_is_void(ccx, retty) {
                 unsafe {
                     Ret(bcx, lib::llvm::llvm::LLVMGetUndef(type_of(ccx, retty).to_ref()));
@@ -377,7 +377,8 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             RetVoid(bcx);
         }
         "transmute" => {
-            let (in_type, out_type) = (*substs.tys.get(0), *substs.tys.get(1));
+            let (in_type, out_type) = (*substs.substs.tps.get(0),
+                                       *substs.substs.tps.get(1));
             let llintype = type_of::type_of(ccx, in_type);
             let llouttype = type_of::type_of(ccx, out_type);
 
@@ -444,11 +445,11 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             }
         }
         "needs_drop" => {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             Ret(bcx, C_bool(ccx, ty::type_needs_drop(ccx.tcx(), tp_ty)));
         }
         "owns_managed" => {
-            let tp_ty = *substs.tys.get(0);
+            let tp_ty = *substs.substs.tps.get(0);
             Ret(bcx, C_bool(ccx, ty::type_contents(ccx.tcx(), tp_ty).owns_managed()));
         }
         "visit_tydesc" => {
@@ -464,14 +465,20 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             let lladdr = InBoundsGEP(bcx, ptr, [offset]);
             Ret(bcx, lladdr);
         }
-        "copy_nonoverlapping_memory" => copy_intrinsic(bcx, false, false, *substs.tys.get(0)),
-        "copy_memory" => copy_intrinsic(bcx, true, false, *substs.tys.get(0)),
-        "set_memory" => memset_intrinsic(bcx, false, *substs.tys.get(0)),
+        "copy_nonoverlapping_memory" => {
+            copy_intrinsic(bcx, false, false, *substs.substs.tps.get(0))
+        }
+        "copy_memory" => {
+            copy_intrinsic(bcx, true, false, *substs.substs.tps.get(0))
+        }
+        "set_memory" => {
+            memset_intrinsic(bcx, false, *substs.substs.tps.get(0))
+        }
 
         "volatile_copy_nonoverlapping_memory" =>
-            copy_intrinsic(bcx, false, true, *substs.tys.get(0)),
-        "volatile_copy_memory" => copy_intrinsic(bcx, true, true, *substs.tys.get(0)),
-        "volatile_set_memory" => memset_intrinsic(bcx, true, *substs.tys.get(0)),
+            copy_intrinsic(bcx, false, true, *substs.substs.tps.get(0)),
+        "volatile_copy_memory" => copy_intrinsic(bcx, true, true, *substs.substs.tps.get(0)),
+        "volatile_set_memory" => memset_intrinsic(bcx, true, *substs.substs.tps.get(0)),
 
         "ctlz8" => count_zeros_intrinsic(bcx, "llvm.ctlz.i8"),
         "ctlz16" => count_zeros_intrinsic(bcx, "llvm.ctlz.i16"),

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -299,7 +299,7 @@ pub fn regionck_expr(fcx: &FnCtxt, e: &ast::Expr) {
         // regionck assumes typeck succeeded
         rcx.visit_expr(e, ());
     }
-    fcx.infcx().resolve_regions();
+    fcx.infcx().resolve_regions_and_report_errors();
 }
 
 pub fn regionck_fn(fcx: &FnCtxt, blk: &ast::Block) {
@@ -309,7 +309,7 @@ pub fn regionck_fn(fcx: &FnCtxt, blk: &ast::Block) {
         // regionck assumes typeck succeeded
         rcx.visit_block(blk, ());
     }
-    fcx.infcx().resolve_regions();
+    fcx.infcx().resolve_regions_and_report_errors();
 }
 
 impl<'a> Visitor<()> for Rcx<'a> {

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -733,7 +733,8 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
 pub fn resolve_impl(tcx: &ty::ctxt,
                     impl_item: &ast::Item,
                     impl_generics: &ty::Generics,
-                    impl_trait_ref: &ty::TraitRef) {
+                    impl_trait_ref: &ty::TraitRef)
+{
     let param_env = ty::construct_parameter_environment(
         tcx,
         None,
@@ -774,6 +775,7 @@ pub fn resolve_impl(tcx: &ty::ctxt,
         lookup_vtables_for_param(&vcx, impl_item.span, None,
                                  &param_bounds, t, false);
 
+    infcx.resolve_regions_and_report_errors();
 
     let res = impl_res {
         trait_vtables: vtbls,

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -15,6 +15,7 @@ use middle::ty_fold::TypeFolder;
 use middle::typeck::astconv::AstConv;
 use middle::typeck::check::{FnCtxt, impl_self_ty};
 use middle::typeck::check::{structurally_resolved_type};
+use middle::typeck::check::writeback;
 use middle::typeck::infer::fixup_err_to_str;
 use middle::typeck::infer::{resolve_and_force_all_but_regions, resolve_type};
 use middle::typeck::infer;
@@ -444,7 +445,7 @@ fn search_for_vtable(vcx: &VtableContext,
         // Finally, we register that we found a matching impl, and
         // record the def ID of the impl as well as the resolved list
         // of type substitutions for the target trait.
-        found.push(vtable_static(impl_did, substs_f.tps.clone(), subres));
+        found.push(vtable_static(impl_did, substs_f, subres));
     }
 
     match found.len() {
@@ -625,7 +626,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
     };
     match ex.node {
       ast::ExprPath(..) => {
-        fcx.opt_node_ty_substs(ex.id, |substs| {
+        fcx.opt_node_ty_substs(ex.id, |item_substs| {
             debug!("vtable resolution on parameter bounds for expr {}",
                    ex.repr(fcx.tcx()));
             let def = cx.tcx.def_map.borrow().get_copy(&ex.id);
@@ -639,7 +640,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
                 let vcx = fcx.vtable_context();
                 let vtbls = lookup_vtables(&vcx, ex.span,
                                            item_ty.generics.type_param_defs(),
-                                           substs, is_early);
+                                           &item_substs.substs, is_early);
                 if !is_early {
                     insert_vtables(fcx, MethodCall::expr(ex.id), vtbls);
                 }
@@ -733,8 +734,10 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
 pub fn resolve_impl(tcx: &ty::ctxt,
                     impl_item: &ast::Item,
                     impl_generics: &ty::Generics,
-                    impl_trait_ref: &ty::TraitRef)
-{
+                    impl_trait_ref: &ty::TraitRef) {
+    debug!("resolve_impl(impl_item.id={})",
+           impl_item.id);
+
     let param_env = ty::construct_parameter_environment(
         tcx,
         None,
@@ -745,6 +748,7 @@ pub fn resolve_impl(tcx: &ty::ctxt,
         impl_item.id);
 
     let impl_trait_ref = impl_trait_ref.subst(tcx, &param_env.free_substs);
+    debug!("impl_trait_ref={}", impl_trait_ref.repr(tcx));
 
     let infcx = &infer::new_infer_ctxt(tcx);
     let vcx = VtableContext { infcx: infcx, param_env: &param_env };
@@ -781,7 +785,12 @@ pub fn resolve_impl(tcx: &ty::ctxt,
         trait_vtables: vtbls,
         self_vtables: self_vtable_res
     };
+    let res = writeback::resolve_impl_res(infcx, impl_item.span, &res);
     let impl_def_id = ast_util::local_def(impl_item.id);
+
+    debug!("impl_vtables for {} are {}",
+           impl_def_id.repr(tcx),
+           res.repr(tcx));
 
     tcx.impl_vtables.borrow_mut().insert(impl_def_id, res);
 }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -644,7 +644,7 @@ impl<'a> InferCtxt<'a> {
         self.region_vars.new_bound(binder_id)
     }
 
-    pub fn resolve_regions(&self) {
+    pub fn resolve_regions_and_report_errors(&self) {
         let errors = self.region_vars.resolve_regions();
         self.report_region_errors(&errors); // see error_reporting.rs
     }

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -184,7 +184,7 @@ pub enum vtable_origin {
       from whence comes the vtable, and tys are the type substs.
       vtable_res is the vtable itself
      */
-    vtable_static(ast::DefId, Vec<ty::t>, vtable_res),
+    vtable_static(ast::DefId, ty::substs, vtable_res),
 
     /*
       Dynamic vtable, comes from a parameter that has a bound on it:
@@ -253,13 +253,16 @@ pub fn write_ty_to_tcx(tcx: &ty::ctxt, node_id: ast::NodeId, ty: ty::t) {
 }
 pub fn write_substs_to_tcx(tcx: &ty::ctxt,
                            node_id: ast::NodeId,
-                           substs: Vec<ty::t> ) {
-    if substs.len() > 0u {
-        debug!("write_substs_to_tcx({}, {:?})", node_id,
-               substs.iter().map(|t| ppaux::ty_to_str(tcx, *t)).collect::<Vec<~str>>());
-        assert!(substs.iter().all(|t| !ty::type_needs_infer(*t)));
+                           item_substs: ty::ItemSubsts) {
+    if !item_substs.is_noop() {
+        debug!("write_substs_to_tcx({}, {})",
+               node_id,
+               item_substs.repr(tcx));
 
-        tcx.node_type_substs.borrow_mut().insert(node_id, substs);
+        assert!(item_substs.substs.tps.iter().
+                all(|t| !ty::type_needs_infer(*t)));
+
+        tcx.item_substs.borrow_mut().insert(node_id, item_substs);
     }
 }
 pub fn lookup_def_tcx(tcx:&ty::ctxt, sp: Span, id: ast::NodeId) -> ast::Def {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -561,6 +561,12 @@ impl Repr for ty::substs {
     }
 }
 
+impl Repr for ty::ItemSubsts {
+    fn repr(&self, tcx: &ctxt) -> ~str {
+        format!("ItemSubsts({})", self.substs.repr(tcx))
+    }
+}
+
 impl Repr for ty::RegionSubsts {
     fn repr(&self, tcx: &ctxt) -> ~str {
         match *self {

--- a/src/test/compile-fail/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs
+++ b/src/test/compile-fail/trait-impl-of-supertrait-has-wrong-lifetime-parameters.rs
@@ -1,0 +1,41 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that when we test the supertrait we ensure consistent use of
+// lifetime parameters. In this case, implementing T2<'a,'b> requires
+// an impl of T1<'a>, but we have an impl of T1<'b>.
+
+trait T1<'x> {
+    fn x(&self) -> &'x int;
+}
+
+trait T2<'x, 'y> : T1<'x> {
+    fn y(&self) -> &'y int;
+}
+
+struct S<'a, 'b> {
+    a: &'a int,
+    b: &'b int
+}
+
+impl<'a,'b> T1<'b> for S<'a, 'b> {
+    fn x(&self) -> &'b int {
+        self.b
+    }
+}
+
+impl<'a,'b> T2<'a, 'b> for S<'a, 'b> { //~ ERROR cannot infer an appropriate lifetime
+    fn y(&self) -> &'b int {
+        self.b
+    }
+}
+
+pub fn main() {
+}


### PR DESCRIPTION
Code to use `ty::substs` in trans. As part of this, uncovered (and fixed) issue #14050.

r? @pcwalton
