### PR TITLE
Remove <no-bounds> on trait objects

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -883,13 +883,7 @@ impl<A:UserString> UserString for Rc<A> {
 
 impl UserString for ty::BuiltinBounds {
     fn user_string(&self, tcx: &ctxt) -> ~str {
-        if self.is_empty() { "<no-bounds>".to_owned() } else {
-            let mut result = Vec::new();
-            for bb in self.iter() {
-                result.push(bb.user_string(tcx));
-            }
-            result.connect("+")
-        }
+        self.iter().map(|bb| bb.user_string(tcx)).collect::<Vec<~str>>().connect("+")
     }
 }
 

--- a/src/test/compile-fail/issue-5153.rs
+++ b/src/test/compile-fail/issue-5153.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: type `&Foo<no-bounds>` does not implement any method in scope named `foo`
+// error-pattern: type `&Foo` does not implement any method in scope named `foo`
 
 trait Foo {
     fn foo(~self);


### PR DESCRIPTION
Printing <no-bounds> on trait objects comes from a time when trait
objects had a non-empty default bounds set. As they no longer have any
default bounds, printing <no-bounds> is just noise.
