### PR TITLE
Rename Pod to Copy

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -578,7 +578,7 @@ impl Repr for ty::ParamBounds {
                 ty::BoundStatic => "'static".to_owned(),
                 ty::BoundSend => "Send".to_owned(),
                 ty::BoundSized => "Sized".to_owned(),
-                ty::BoundCopy => "Pod".to_owned(),
+                ty::BoundCopy => "Copy".to_owned(),
                 ty::BoundShare => "Share".to_owned(),
             });
         }
@@ -856,7 +856,7 @@ impl UserString for ty::BuiltinBound {
             ty::BoundStatic => "'static".to_owned(),
             ty::BoundSend => "Send".to_owned(),
             ty::BoundSized => "Sized".to_owned(),
-            ty::BoundCopy => "Pod".to_owned(),
+            ty::BoundCopy => "Copy".to_owned(),
             ty::BoundShare => "Share".to_owned(),
         }
     }

--- a/src/test/compile-fail/error-should-say-copy-not-pod.rs
+++ b/src/test/compile-fail/error-should-say-copy-not-pod.rs
@@ -1,0 +1,17 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that the error message uses the word Copy, not Pod.
+
+fn check_bound<T:Copy>(_: T) {}
+
+fn main() {
+    check_bound("nocopy".to_owned()); //~ ERROR does not fulfill `Copy`
+}


### PR DESCRIPTION
Some error messages still use the word `Pod` instead of `Copy`. Renames
them.
