### PR TITLE
rustdoc: Hyperlink cross-crate reexports

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -17,14 +17,13 @@ This document does not serve as a tutorial introduction to the
 language. Background familiarity with the language is assumed. A separate
 [tutorial] document is available to help acquire such background familiarity.
 
-This document also does not serve as a reference to the [standard] or [extra]
-libraries included in the language distribution. Those libraries are
+This document also does not serve as a reference to the [standard]
+library included in the language distribution. Those libraries are
 documented separately by extracting documentation attributes from their
 source code.
 
 [tutorial]: tutorial.html
 [standard]: std/index.html
-[extra]: extra/index.html
 
 ## Disclaimer
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -24,7 +24,7 @@
 //!
 //! Functions return `Result` whenever errors are expected and
 //! recoverable. In the `std` crate `Result` is most prominently used
-//! for [I/O](../io/index.html).
+//! for [I/O](../../std/io/index.html).
 //!
 //! A simple function returning `Result` might be
 //! defined and used like so:

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -44,9 +44,9 @@ impl ItemType {
         match *self {
             Module          => "mod",
             Struct          => "struct",
-            Enum            => "enum",
+            Enum            => "type",
             Function        => "fn",
-            Typedef         => "typedef",
+            Typedef         => "type",
             Static          => "static",
             Trait           => "trait",
             Impl            => "impl",

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -43,6 +43,7 @@ use std::strbuf::StrBuf;
 use sync::Arc;
 use serialize::json::ToJson;
 use syntax::ast;
+use syntax::ast_util;
 use syntax::attr;
 use syntax::parse::token::InternedString;
 use rustc::util::nodemap::NodeSet;
@@ -50,13 +51,13 @@ use rustc::util::nodemap::NodeSet;
 use clean;
 use doctree;
 use fold::DocFolder;
-use html::item_type;
-use html::item_type::{ItemType, shortty};
 use html::format::{VisSpace, Method, FnStyleSpace};
-use html::layout;
-use html::markdown;
-use html::markdown::Markdown;
 use html::highlight;
+use html::item_type::{ItemType, shortty};
+use html::item_type;
+use html::layout;
+use html::markdown::Markdown;
+use html::markdown;
 
 /// Major driving force in all rustdoc rendering. This contains information
 /// about where in the tree-like hierarchy rendering is occurring and controls
@@ -138,7 +139,7 @@ pub struct Cache {
     /// URLs when a type is being linked to. External paths are not located in
     /// this map because the `External` type itself has all the information
     /// necessary.
-    pub paths: HashMap<ast::NodeId, (Vec<~str> , ItemType)>,
+    pub paths: HashMap<ast::DefId, (Vec<~str>, ItemType)>,
 
     /// This map contains information about all known traits of this crate.
     /// Implementations of a crate should inherit the documentation of the
@@ -242,12 +243,26 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
     }
 
     // Crawl the crate to build various caches used for the output
-    let public_items = ::analysiskey.get().map(|a| a.public_items.clone());
-    let public_items = public_items.unwrap_or(NodeSet::new());
+    let analysis = ::analysiskey.get();
+    let public_items = analysis.as_ref().map(|a| a.public_items.clone());
+    let paths = analysis.as_ref().map(|a| {
+        let paths = a.external_paths.borrow_mut().take_unwrap();
+        paths.move_iter().map(|(k, (v, t))| {
+            (k, (v, match t {
+                clean::TypeStruct => item_type::Struct,
+                clean::TypeEnum => item_type::Enum,
+                clean::TypeFunction => item_type::Function,
+                clean::TypeTrait => item_type::Trait,
+                clean::TypeModule => item_type::Module,
+                clean::TypeStatic => item_type::Static,
+                clean::TypeVariant => item_type::Variant,
+            }))
+        }).collect()
+    }).unwrap_or(HashMap::new());
     let mut cache = Cache {
         impls: HashMap::new(),
         typarams: HashMap::new(),
-        paths: HashMap::new(),
+        paths: paths,
         traits: HashMap::new(),
         implementors: HashMap::new(),
         stack: Vec::new(),
@@ -255,7 +270,7 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
         search_index: Vec::new(),
         extern_locations: HashMap::new(),
         privmod: false,
-        public_items: public_items,
+        public_items: public_items.unwrap_or(NodeSet::new()),
         orphan_methods: Vec::new(),
     };
     cache.stack.push(krate.name.clone());
@@ -269,15 +284,16 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
 
         // Attach all orphan methods to the type's definition if the type
         // has since been learned.
-        for &(ref pid, ref item) in meths.iter() {
-            match paths.find(pid) {
+        for &(pid, ref item) in meths.iter() {
+            let did = ast_util::local_def(pid);
+            match paths.find(&did) {
                 Some(&(ref fqp, _)) => {
                     index.push(IndexItem {
                         ty: shortty(item),
                         name: item.name.clone().unwrap(),
                         path: fqp.slice_to(fqp.len() - 1).connect("::"),
                         desc: shorter(item.doc_value()).to_owned(),
-                        parent: Some(*pid),
+                        parent: Some(pid),
                     });
                 },
                 None => {}
@@ -336,7 +352,8 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
         try!(write!(&mut w, r#"],"paths":["#));
 
         for (i, &nodeid) in pathid_to_nodeid.iter().enumerate() {
-            let &(ref fqp, short) = cache.paths.find(&nodeid).unwrap();
+            let def = ast_util::local_def(nodeid);
+            let &(ref fqp, short) = cache.paths.find(&def).unwrap();
             if i > 0 {
                 try!(write!(&mut w, ","));
             }
@@ -414,6 +431,8 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
 
     for &(n, ref e) in krate.externs.iter() {
         cache.extern_locations.insert(n, extern_location(e, &cx.dst));
+        let did = ast::DefId { krate: n, node: ast::CRATE_NODE_ID };
+        cache.paths.insert(did, (Vec::new(), item_type::Module));
     }
 
     // And finally render the whole crate's documentation
@@ -605,7 +624,12 @@ impl DocFolder for Cache {
         match item.inner {
             clean::ImplItem(ref i) => {
                 match i.trait_ {
-                    Some(clean::ResolvedPath{ id, .. }) => {
+                    // FIXME: this is_local() check seems to be losing
+                    // information
+                    Some(clean::ResolvedPath{ did, .. })
+                        if ast_util::is_local(did) =>
+                    {
+                        let id = did.node;
                         let v = self.implementors.find_or_insert_with(id, |_|{
                             Vec::new()
                         });
@@ -642,7 +666,8 @@ impl DocFolder for Cache {
                             (None, None)
                         } else {
                             let last = self.parent_stack.last().unwrap();
-                            let path = match self.paths.find(last) {
+                            let did = ast_util::local_def(*last);
+                            let path = match self.paths.find(&did) {
                                 Some(&(_, item_type::Trait)) =>
                                     Some(self.stack.slice_to(self.stack.len() - 1)),
                                 // The current stack not necessarily has correlation for
@@ -698,10 +723,11 @@ impl DocFolder for Cache {
                 // a reexported item doesn't show up in the `public_items` map,
                 // so we can skip inserting into the paths map if there was
                 // already an entry present and we're not a public item.
-                if !self.paths.contains_key(&item.id) ||
+                let did = ast_util::local_def(item.id);
+                if !self.paths.contains_key(&did) ||
                    self.public_items.contains(&item.id) {
-                    self.paths.insert(item.id,
-                                      (self.stack.clone(), shortty(&item)));
+                    self.paths.insert(did, (self.stack.clone(),
+                                            shortty(&item)));
                 }
             }
             // link variants to their parent enum because pages aren't emitted
@@ -709,7 +735,8 @@ impl DocFolder for Cache {
             clean::VariantItem(..) => {
                 let mut stack = self.stack.clone();
                 stack.pop();
-                self.paths.insert(item.id, (stack, item_type::Enum));
+                self.paths.insert(ast_util::local_def(item.id),
+                                  (stack, item_type::Enum));
             }
             _ => {}
         }
@@ -721,8 +748,13 @@ impl DocFolder for Cache {
             }
             clean::ImplItem(ref i) => {
                 match i.for_ {
-                    clean::ResolvedPath{ id, .. } => {
-                        self.parent_stack.push(id); true
+                    clean::ResolvedPath{ did, .. } => {
+                        if ast_util::is_local(did) {
+                            self.parent_stack.push(did.node);
+                            true
+                        } else {
+                            false
+                        }
                     }
                     _ => false
                 }
@@ -737,8 +769,10 @@ impl DocFolder for Cache {
                 match item {
                     clean::Item{ attrs, inner: clean::ImplItem(i), .. } => {
                         match i.for_ {
-                            clean::ResolvedPath { id, .. } => {
-                                let v = self.impls.find_or_insert_with(id, |_| {
+                            clean::ResolvedPath { did, .. }
+                                if ast_util::is_local(did) =>
+                            {
+                                let v = self.impls.find_or_insert_with(did.node, |_| {
                                     Vec::new()
                                 });
                                 // extract relevant documentation for this impl
@@ -1595,7 +1629,7 @@ fn render_impl(w: &mut Writer, i: &clean::Impl,
         Some(ref ty) => {
             try!(write!(w, "{} for ", *ty));
             match *ty {
-                clean::ResolvedPath { id, .. } => Some(id),
+                clean::ResolvedPath { did, .. } => Some(did),
                 _ => None,
             }
         }
@@ -1634,9 +1668,10 @@ fn render_impl(w: &mut Writer, i: &clean::Impl,
     // default methods which weren't overridden in the implementation block.
     match trait_id {
         None => {}
-        Some(id) => {
+        // FIXME: this should work for non-local traits
+        Some(did) if ast_util::is_local(did) => {
             try!({
-                match cache_key.get().unwrap().traits.find(&id) {
+                match cache_key.get().unwrap().traits.find(&did.node) {
                     Some(t) => {
                         for method in t.methods.iter() {
                             let n = method.item().name.clone();
@@ -1653,6 +1688,7 @@ fn render_impl(w: &mut Writer, i: &clean::Impl,
                 Ok(())
             })
         }
+        Some(..) => {}
     }
     try!(write!(w, "</div>"));
     Ok(())

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -65,9 +65,10 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
         impl<'a> fold::DocFolder for ImplStripper<'a> {
             fn fold_item(&mut self, i: Item) -> Option<Item> {
                 match i.inner {
-                    clean::ImplItem(clean::Impl{ for_: clean::ResolvedPath{ id: for_id, .. },
-                                                 .. }) => {
-                        if self.stripped.contains(&for_id) {
+                    clean::ImplItem(clean::Impl{
+                        for_: clean::ResolvedPath{ did, .. }, ..
+                    }) => {
+                        if self.stripped.contains(&did.node) {
                             return None;
                         }
                     }
@@ -146,8 +147,10 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             clean::ModuleItem(..) => {}
 
             // trait impls for private items should be stripped
-            clean::ImplItem(clean::Impl{ for_: clean::ResolvedPath{ id: ref for_id, .. }, .. }) => {
-                if !self.exported_items.contains(for_id) {
+            clean::ImplItem(clean::Impl{
+                for_: clean::ResolvedPath{ did, .. }, ..
+            }) => {
+                if !self.exported_items.contains(&did.node) {
                     return None;
                 }
             }
@@ -201,9 +204,9 @@ impl<'a> fold::DocFolder for ImplStripper<'a> {
         match i.inner {
             clean::ImplItem(ref imp) => {
                 match imp.trait_ {
-                    Some(clean::ResolvedPath{ id, .. }) => {
+                    Some(clean::ResolvedPath{ did, .. }) => {
                         let ImplStripper(s) = *self;
-                        if !s.contains(&id) {
+                        if !s.contains(&did.node) {
                             return None;
                         }
                     }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -16,7 +16,7 @@ use std::os;
 use std::str;
 use std::strbuf::StrBuf;
 
-use collections::HashSet;
+use collections::{HashSet, HashMap};
 use testing;
 use rustc::back::link;
 use rustc::driver::driver;
@@ -73,6 +73,7 @@ pub fn run(input: &str,
         krate: krate,
         maybe_typed: core::NotTyped(sess),
         src: input_path,
+        external_paths: RefCell::new(Some(HashMap::new())),
     };
     super::ctxtkey.replace(Some(ctx));
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -16,11 +16,11 @@
 //!
 //! ## Intrinsic types and operations
 //!
-//! The [`ptr`](ptr/index.html), [`mem`](mem/index.html),
-//! and [`cast`](cast/index.html) modules deal with unsafe pointers,
+//! The [`ptr`](../core/ptr/index.html), [`mem`](../core/mem/index.html),
+//! and [`cast`](../core/cast/index.html) modules deal with unsafe pointers,
 //! memory manipulation, and coercion.
-//! [`kinds`](kinds/index.html) defines the special built-in traits,
-//! and [`raw`](raw/index.html) the runtime representation of Rust types.
+//! [`kinds`](../core/kinds/index.html) defines the special built-in traits,
+//! and [`raw`](../core/raw/index.html) the runtime representation of Rust types.
 //! These are some of the lowest-level building blocks of Rust
 //! abstractions.
 //!
@@ -35,9 +35,9 @@
 //!
 //! The [`option`](option/index.html) and [`result`](result/index.html)
 //! modules define optional and error-handling types, `Option` and `Result`.
-//! [`iter`](iter/index.html) defines Rust's iterator protocol
+//! [`iter`](../core/iter/index.html) defines Rust's iterator protocol
 //! along with a wide variety of iterators.
-//! [`Cell` and `RefCell`](cell/index.html) are for creating types that
+//! [`Cell` and `RefCell`](../core/cell/index.html) are for creating types that
 //! manage their own mutability.
 //!
 //! ## Vectors, slices and strings

--- a/src/libstd/result.rs
+++ b/src/libstd/result.rs
@@ -226,8 +226,8 @@
 //! similar and complementary: they are often employed to indicate a
 //! lack of a return value; and they are trivially converted between
 //! each other, so `Result`s are often handled by first converting to
-//! `Option` with the [`ok`](enum.Result.html#method.ok) and
-//! [`err`](enum.Result.html#method.ok) methods.
+//! `Option` with the [`ok`](../../core/result/enum.Result.html#method.ok) and
+//! [`err`](../../core/result/enum.Result.html#method.ok) methods.
 //!
 //! Whereas `Option` only indicates the lack of a value, `Result` is
 //! specifically for error reporting, and carries with it an error


### PR DESCRIPTION
This should improve the libcore experience quite a bit when looking at the
libstd documentation.
