### PR TITLE
Workaround for Windows denormal bug in float_to_str_bytes_common

### DIFF
--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -308,8 +308,34 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+Eq+Ord+Float+
                     ExpBin => (num.abs().log2().floor(), cast::<f64, T>(2.0f64).unwrap()),
                     ExpNone => unreachable!()
                 };
+                let iexp = cast::<T, i32>(exp).unwrap();
 
-                (num / exp_base.powf(exp), cast::<T, i32>(exp).unwrap())
+                // For subnormal floats, powi and powf behave differently
+                // depending on the platform/compiler.  For example, consider:
+                //
+                //     2f64.pow(-1074) [where pow = powf or powi]
+                //
+                // - On Mingw (vanilla), powf returns zero whereas powi
+                //   returns a subnormal.
+                //
+                // - On Mingw-w64, both powi and powf return subnormals.
+                //
+                // - On Linux, powi returns zero whereas powf returns a
+                //   subnormal.
+                //
+                // This workaround accounts for the difference in behavior and
+                // fixes part of issue #13439.
+                #[cfg(windows)]
+                fn pow<T: Float>(exp_base: T, _: T, iexp: i32) -> T {
+                    exp_base.powi(iexp)
+                }
+
+                #[cfg(not(windows))]
+                fn pow<T: Float>(exp_base: T, exp: T, _: i32) -> T {
+                    exp_base.powf(exp)
+                }
+
+                (num / pow(exp_base, exp, iexp), iexp)
             }
         }
     };


### PR DESCRIPTION
On Windows (MinGW32), `2.0f64.powf(-1074.0)` returns zero instead of a denormal number, which screws up everything later on in `float_to_str_bytes_common`.  Changing it to use `powi` works around the problem but breaks the build on Linux (and presumably other systems).

Fixes #13439.
