### PR TITLE
rustdoc: Fix search links to enums/typedefs

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -514,9 +514,9 @@
         // `rustdoc::html::item_type::ItemType` type in Rust.
         var itemTypes = ["mod",
                          "struct",
-                         "enum",
+                         "type",
                          "fn",
-                         "typedef",
+                         "type",
                          "static",
                          "trait",
                          "impl",


### PR DESCRIPTION
When the values in html::item_type were updated, the JS definitions were
accidentally not updated as well.

Closes #14095
