### PR TITLE
remove the word managed from the trait explanation

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1402,7 +1402,7 @@ to pointers to the trait name, used as a type.
 let myshape: Box<Shape> = box mycircle as Box<Shape>;
 ~~~~
 
-The resulting value is a managed box containing the value that was cast,
+The resulting value is a box containing the value that was cast,
 along with information that identifies the methods of the implementation that was used.
 Values with a trait type can have [methods called](#method-call-expressions) on them,
 for any method in the trait,


### PR DESCRIPTION
Hi,

I believe the word "managed" doesn't make sense here anymore. It's just a box.
