### PR TITLE
rustdoc: List macros in the sidebar

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1720,6 +1720,7 @@ impl<'a> fmt::Show for Sidebar<'a> {
         try!(block(fmt.buf, "enum", "Enums", it, cx));
         try!(block(fmt.buf, "trait", "Traits", it, cx));
         try!(block(fmt.buf, "fn", "Functions", it, cx));
+        try!(block(fmt.buf, "macro", "Macros", it, cx));
         Ok(())
     }
 }


### PR DESCRIPTION
Fix #14078.
