### PR TITLE
mk: Bundle jemalloc with make dist

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -36,7 +36,7 @@ LICENSE.txt: $(S)COPYRIGHT $(S)LICENSE-APACHE $(S)LICENSE-MIT
 PKG_TAR = dist/$(PKG_NAME).tar.gz
 
 PKG_GITMODULES := $(S)src/libuv $(S)src/llvm $(S)src/gyp $(S)src/compiler-rt \
-		  $(S)src/rt/hoedown
+		  $(S)src/rt/hoedown $(S)src/jemalloc
 PKG_FILES := \
     $(S)COPYRIGHT                              \
     $(S)LICENSE-APACHE                         \


### PR DESCRIPTION
The dist tarball doesn't depend on git, so all git submodules must be included
inside of it.
