### PR TITLE
add a line to the example to clarify semantics

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -455,7 +455,7 @@ against each pattern in order until one matches. The matching pattern
 executes its corresponding arm.
 
 ~~~~
-# let my_number = 1;
+let my_number = 1;
 match my_number {
   0     => println!("zero"),
   1 | 2 => println!("one or two"),


### PR DESCRIPTION
This is to clarify that match construct doesn't define a new variable, since I
observed a person reading the Rust tutorial who seemed to incorrectly think
that it did. Fixes https://github.com/mozilla/rust/issues/13571 .
