### PR TITLE
docs: Add a not found page

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -30,7 +30,7 @@ DOCS := index intro tutorial guide-ffi guide-macros guide-lifetimes \
 	guide-tasks guide-container guide-pointers guide-testing \
 	guide-runtime complement-bugreport complement-cheatsheet \
 	complement-lang-faq complement-project-faq rust rustdoc \
-	guide-unsafe
+	guide-unsafe not_found
 
 PDF_DOCS := tutorial rust
 

--- a/src/doc/not_found.md
+++ b/src/doc/not_found.md
@@ -1,0 +1,20 @@
+% Not Found
+
+<!-- Completely hide the TOC and the section numbers -->
+<style type="text/css">
+#TOC { display: none; }
+.header-section-number { display: none; }
+li {list-style-type: none; }
+</style>
+
+Looks like you've taken a wrong turn.
+
+Some things that might be helpful to you though:
+
+## Reference
+* [The Rust official site](http://rust-lang.org)
+* [The Rust reference manual](http://static.rust-lang.org/doc/master/rust.html) (* [PDF](http://static.rust-lang.org/doc/master/rust.pdf))
+
+## Docs
+* [The standard library (stable)](http://doc.rust-lang.org/doc/0.10/std/index.html)
+* [The standard library (master)](http://doc.rust-lang.org/doc/master/std/index.html)


### PR DESCRIPTION
I created a stub page for use when the docs 404.

Documentation on how to configure it is available here: http://aws.typepad.com/aws/2011/02/host-your-static-website-on-amazon-s3.html
