### PR TITLE
Add `stat` method to `std::io::fs::File` to stat without a Path.

### DIFF
--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -197,6 +197,14 @@ impl rtio::RtioFileStream for FileDesc {
         let _ = self.seek(orig_pos as i64, io::SeekSet);
         return ret;
     }
+
+    fn fstat(&mut self) -> IoResult<io::FileStat> {
+        let mut stat: libc::stat = unsafe { mem::uninit() };
+        match unsafe { libc::fstat(self.fd(), &mut stat) } {
+            0 => Ok(mkstat(&stat)),
+            _ => Err(super::last_error()),
+        }
+    }
 }
 
 impl rtio::RtioPipe for FileDesc {
@@ -469,8 +477,7 @@ pub fn link(src: &CString, dst: &CString) -> IoResult<()> {
     }))
 }
 
-fn mkstat(stat: &libc::stat, path: &CString) -> io::FileStat {
-    let path = unsafe { CString::new(path.with_ref(|p| p), false) };
+fn mkstat(stat: &libc::stat) -> io::FileStat {
     let kind = match (stat.st_mode as c_int) & libc::S_IFMT {
         libc::S_IFREG => io::TypeFile,
         libc::S_IFDIR => io::TypeDirectory,
@@ -481,7 +488,6 @@ fn mkstat(stat: &libc::stat, path: &CString) -> io::FileStat {
     };
 
     io::FileStat {
-        path: Path::new(path),
         size: stat.st_size as u64,
         kind: kind,
         perm: unsafe {
@@ -509,7 +515,7 @@ pub fn stat(p: &CString) -> IoResult<io::FileStat> {
     let mut stat: libc::stat = unsafe { mem::uninit() };
     as_utf16_p(p.as_str().unwrap(), |up| {
         match unsafe { libc::wstat(up, &mut stat) } {
-            0 => Ok(mkstat(&stat, p)),
+            0 => Ok(mkstat(&stat)),
             _ => Err(super::last_error()),
         }
     })

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -228,7 +228,6 @@ use ops::{BitOr, BitAnd, Sub};
 use option::{Option, Some, None};
 use os;
 use owned::Box;
-use path::Path;
 use result::{Ok, Err, Result};
 use slice::{Vector, MutableVector, ImmutableVector};
 use str::{StrSlice, StrAllocating};
@@ -1516,8 +1515,6 @@ pub enum FileType {
 /// ```
 #[deriving(Hash)]
 pub struct FileStat {
-    /// The path that this stat structure is describing
-    pub path: Path,
     /// The size of the file, in bytes
     pub size: u64,
     /// The kind of file this path points to (directory, file, pipe, etc.)

--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -269,6 +269,7 @@ pub trait RtioFileStream {
     fn fsync(&mut self) -> IoResult<()>;
     fn datasync(&mut self) -> IoResult<()>;
     fn truncate(&mut self, offset: i64) -> IoResult<()>;
+    fn fstat(&mut self) -> IoResult<FileStat>;
 }
 
 pub trait RtioProcess {


### PR DESCRIPTION
The `FileStat` struct contained a `path` field, which was filled by the
`stat` and `lstat` function. Since this field isn't in fact returned by
the operating system (it was copied from the paths passed to the
functions) it was removed, as in the `fstat` case we aren't working with
a `Path`, but directly with a fd.

If your code used the `path` field of `FileStat` you will now have to
manually store the path passed to `stat` along with the returned struct.

[breaking-change]
