### PR TITLE
Remove an unnecessary .move_iter().collect()

### DIFF
--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -142,7 +142,7 @@ pub mod win32 {
     }
 
     pub fn as_utf16_p<T>(s: &str, f: |*u16| -> T) -> T {
-        let mut t = s.to_utf16().move_iter().collect::<Vec<u16>>();
+        let mut t = s.to_utf16();
         // Null terminate before passing on.
         t.push(0u16);
         f(t.as_ptr())


### PR DESCRIPTION
Well, at least it looks unnecessary. This is completely untested. I’m leaving that job to bors, if that’s ok.
