### PR TITLE
Get rid of the android-cross-path flag to rustc.

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -138,9 +138,6 @@ A space-separated list of arguments to pass through to LLVM.
 If specified, the compiler will save more files (.bc, .o, .no-opt.bc) generated
 throughout compilation in the output directory.
 .TP
-\fBandroid-cross-path\fR=path/to/ndk/bin
-Directory to find the Android NDK cross-compilation tools
-.TP
 \fBno-rpath\fR
 If specified, then the rpath value for dynamic libraries will not be set in
 either dynamic library or executable outputs.

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -307,7 +307,7 @@ CFG_LDPATH_arm-linux-androideabi :=
 CFG_RUN_arm-linux-androideabi=
 CFG_RUN_TARG_arm-linux-androideabi=
 RUSTC_FLAGS_arm-linux-androideabi :=
-RUSTC_CROSS_FLAGS_arm-linux-androideabi :=-C android-cross-path=$(CFG_ANDROID_CROSS_PATH)
+RUSTC_CROSS_FLAGS_arm-linux-androideabi :=
 
 # arm-unknown-linux-gnueabihf configuration
 CROSS_PREFIX_arm-unknown-linux-gnueabihf=arm-linux-gnueabihf-

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -601,6 +601,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
         --stage-id stage$(1)-$(2)							\
         --target $(2)                                       \
         --host $(3)                                       \
+        --android-cross-path=$(CFG_ANDROID_CROSS_PATH)    \
         --adb-path=$(CFG_ADB)                          \
         --adb-test-dir=$(CFG_ADB_TEST_DIR)                  \
         --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3))" \

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -126,6 +126,9 @@ pub struct Config {
     // Host triple for the compiler being invoked
     pub host: ~str,
 
+    // Path to the android tools
+    pub android_cross_path: Path,
+
     // Extra parameter to run adb on arm-linux-androideabi
     pub adb_path: ~str,
 

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -79,6 +79,7 @@ pub fn parse_config(args: Vec<~str> ) -> Config {
           optflag("", "jit", "run tests under the JIT"),
           optopt("", "target", "the target to build for", "TARGET"),
           optopt("", "host", "the host to build for", "HOST"),
+          optopt("", "android-cross-path", "Android NDK standalone path", "PATH"),
           optopt("", "adb-path", "path to the android debugger", "PATH"),
           optopt("", "adb-test-dir", "path to tests for the android debugger", "PATH"),
           optopt("", "lldb-python-dir", "directory containing LLDB's python module", "PATH"),
@@ -142,6 +143,7 @@ pub fn parse_config(args: Vec<~str> ) -> Config {
         jit: matches.opt_present("jit"),
         target: opt_str2(matches.opt_str("target")).to_str(),
         host: opt_str2(matches.opt_str("host")).to_str(),
+        android_cross_path: opt_path(matches, "android-cross-path"),
         adb_path: opt_str2(matches.opt_str("adb-path")).to_str(),
         adb_test_dir:
             opt_str2(matches.opt_str("adb-test-dir")).to_str(),
@@ -173,6 +175,7 @@ pub fn log_config(config: &Config) {
     logv(c, format!("jit: {}", config.jit));
     logv(c, format!("target: {}", config.target));
     logv(c, format!("host: {}", config.host));
+    logv(c, format!("android-cross-path: {}", config.android_cross_path.display()));
     logv(c, format!("adb_path: {}", config.adb_path));
     logv(c, format!("adb_test_dir: {}", config.adb_test_dir));
     logv(c, format!("adb_device_status: {}", config.adb_device_status));

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -347,18 +347,10 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                 break;
             }
 
-            let args = split_maybe_args(&config.target_rustcflags);
-            let mut tool_path = StrBuf::new();
-            for arg in args.iter() {
-                if arg.contains("android-cross-path=") {
-                    tool_path = StrBuf::from_str(arg.replace("android-cross-path=", ""));
-                    break;
-                }
-            }
-
-            if tool_path.is_empty() {
-                fatal("cannot found android cross path".to_owned());
-            }
+            let tool_path = match config.android_cross_path.as_str() {
+                Some(x) => x.to_strbuf(),
+                None => fatal("cannot find android cross path".to_owned())
+            };
 
             let debugger_script = make_out_name(config, testfile, "debugger.script");
             // FIXME (#9639): This needs to handle non-utf8 paths

--- a/src/etc/zsh/_rust
+++ b/src/etc/zsh/_rust
@@ -5,7 +5,6 @@ local -a _rustc_opts_switches _rustc_opts_lint _rustc_opts_debug
 typeset -A opt_args
 
 _rustc_opts_switches=(
-    --android-cross-path'[The path to the Android NDK]'
     --ar'[Program to use for managing archives instead of the default.]'
     -c'[Compile and assemble, but do not link]'
     --cfg'[Configure the compilation environment]'

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -757,40 +757,15 @@ pub fn get_cc_prog(sess: &Session) -> StrBuf {
     // instead of hard-coded gcc.
     // For win32, there is no cc command, so we add a condition to make it use gcc.
     match sess.targ_cfg.os {
-        abi::OsWin32 => return "gcc".to_strbuf(),
-        _ => {},
-    }
-
-    get_system_tool(sess, "cc")
+        abi::OsWin32 => "gcc",
+        _ => "cc",
+    }.to_strbuf()
 }
 
 pub fn get_ar_prog(sess: &Session) -> StrBuf {
     match sess.opts.cg.ar {
-        Some(ref ar) => return (*ar).clone(),
-        None => {}
-    }
-
-    get_system_tool(sess, "ar")
-}
-
-fn get_system_tool(sess: &Session, tool: &str) -> StrBuf {
-    match sess.targ_cfg.os {
-        abi::OsAndroid => match sess.opts.cg.android_cross_path {
-            Some(ref path) => {
-                let tool_str = match tool {
-                    "cc" => "gcc",
-                    _ => tool
-                };
-                format_strbuf!("{}/bin/arm-linux-androideabi-{}",
-                               *path,
-                               tool_str)
-            }
-            None => {
-                sess.fatal(format!("need Android NDK path for the '{}' tool \
-                                    (-C android-cross-path)", tool))
-            }
-        },
-        _ => tool.to_strbuf(),
+        Some(ref ar) => (*ar).clone(),
+        None => "ar".to_strbuf()
     }
 }
 

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -294,8 +294,6 @@ cgoptions!(
         "a list of arguments to pass to llvm (space separated)"),
     save_temps: bool = (false, parse_bool,
         "save all temporary output files during compilation"),
-    android_cross_path: Option<StrBuf> = (None, parse_opt_string,
-        "the path to the Android NDK"),
     no_rpath: bool = (false, parse_bool,
         "disables setting the rpath in libs/exes"),
     no_prepopulate_passes: bool = (false, parse_bool,


### PR DESCRIPTION
It's a bit odd to single out just android when we don't do this for any other cross compiling targets. Android builds will still work since we just pass the full path for gcc and ar with `-C linker` and `-C ar`.

I did add the flag to compiletest though so it can find gdb. Though, i'm pretty sure we don't run debuginfo tests on android anyways right now.

[breaking-change]
