### PR TITLE
librustc: Make sure to add argument attributes to extern fns from non-local crates.

### DIFF
--- a/src/test/run-make/extern-fn-with-union/Makefile
+++ b/src/test/run-make/extern-fn-with-union/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+all:
+	$(CC) -std=c99 test.c -c -o $(TMPDIR)/test.o
+	$(AR) rcs $(TMPDIR)/libtest.a $(TMPDIR)/test.o
+	$(RUSTC) testcrate.rs -L $(TMPDIR)
+	$(RUSTC) test.rs -L $(TMPDIR)
+	$(call RUN,test) || exit 1

--- a/src/test/run-make/extern-fn-with-union/test.c
+++ b/src/test/run-make/extern-fn-with-union/test.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdint.h>
+
+typedef union TestUnion {
+    uint64_t bits;
+} TestUnion;
+
+uint64_t give_back(TestUnion tu) {
+    return tu.bits;
+}

--- a/src/test/run-make/extern-fn-with-union/test.rs
+++ b/src/test/run-make/extern-fn-with-union/test.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate testcrate;
+
+use std::mem;
+
+#[link(name = "test", kind = "static")]
+extern {
+    fn give_back(tu: testcrate::TestUnion) -> u64;
+}
+
+fn main() {
+    let magic: u64 = 0xDEADBEEF;
+
+    // Let's test calling it cross crate
+    let back = unsafe {
+        testcrate::give_back(mem::transmute(magic))
+    };
+    assert_eq!(magic, back);
+
+    // And just within this crate
+    let back = unsafe {
+        give_back(mem::transmute(magic))
+    };
+    assert_eq!(magic, back);
+}

--- a/src/test/run-make/extern-fn-with-union/testcrate.rs
+++ b/src/test/run-make/extern-fn-with-union/testcrate.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+
+pub struct TestUnion {
+    val: u64
+}
+
+#[link(name = "test", kind = "static")]
+extern {
+    pub fn give_back(tu: TestUnion) -> u64;
+}


### PR DESCRIPTION
We were correctly determining the attributes needed for the parameters for extern fns, but when that extern fn was from another crate we never bothered to pass that information along to LLVM. (i.e never called `foreign::add_argument_attributes`).

I've just changed both local and non-local (crate) extern fn's to be dealt with together (through `foreign::register_foreign_item_fn`) so we don't run into something like again.

Fixes #14177.
