### PR TITLE
Implement HashMap.find_with_or_insert_with()

### DIFF
--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -1295,8 +1295,7 @@ impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///         },
     ///         // if the key doesn't exist in the map yet, add it in
     ///         // the obvious way.
-    ///         |_k, v| vec![v],
-    ///     );
+    ///         |_k, v| vec![v]);
     /// }
     ///
     /// assert_eq!(map.len(), 3);

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -1299,9 +1299,10 @@ impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///     );
     /// }
     ///
-    /// for (k, v) in map.iter() {
-    ///     println!("{} -> {}", *k, *v);
-    /// }
+    /// assert_eq!(map.len(), 3);
+    /// assert_eq!(map.get(&"a key"), &vec!["value", "new value"]);
+    /// assert_eq!(map.get(&"b key"), &vec!["new value"]);
+    /// assert_eq!(map.get(&"z key"), &vec!["new value", "value"]);
     /// ```
     pub fn find_with_or_insert_with<'a, A>(&'a mut self,
                                            k: K,

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -1275,15 +1275,14 @@ impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// use collections::HashMap;
     ///
     /// // map some strings to vectors of strings
-    /// let mut map = HashMap::<StrBuf, Vec<StrBuf>>::new();
-    /// map.insert(StrBuf::from_str("a key"), vec![StrBuf::from_str("value")]);
-    /// map.insert(StrBuf::from_str("z key"), vec![StrBuf::from_str("value")]);
+    /// let mut map = HashMap::new();
+    /// map.insert("a key", vec!["value"]);
+    /// map.insert("z key", vec!["value"]);
     ///
-    /// let new = vec![StrBuf::from_str("a key"),
-    ///                StrBuf::from_str("b key"),
-    ///                StrBuf::from_str("z key")];
+    /// let new = vec!["a key", "b key", "z key"];
+    ///
     /// for k in new.move_iter() {
-    ///     map.mangle(k, StrBuf::from_str("new value"),
+    ///     map.mangle(k, "new value",
     ///                // if the key doesn't exist in the map yet, add it in
     ///                // the obvious way.
     ///                |_k, v| vec![v],
@@ -1299,7 +1298,7 @@ impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// }
     ///
     /// for (k, v) in map.iter() {
-    ///     println!("{} -> {:?}", *k, *v);
+    ///     println!("{} -> {}", *k, *v);
     /// }
     /// ```
     pub fn mangle<'a, A>(&'a mut self,


### PR DESCRIPTION
This used to be called `mangle` and was removed when the Robin Hood hash map came along, but it is a useful thing to have in certain situations (I just hit it with my Teepee header representation), so I want it back.

The method is renamed to `find_with_or_insert_with`, also with the parameters swapped to make sense—find and then insert, not insert and then find.

/cc @cgaebel
