### PR TITLE
Add cfg for version based conditional compilation

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -61,7 +61,7 @@ DEPS_std := core libc native:rustrt native:compiler-rt native:backtrace native:j
 DEPS_green := std rand native:context_switch
 DEPS_rustuv := std native:uv native:uv_support
 DEPS_native := std
-DEPS_syntax := std term serialize collections log fmt_macros
+DEPS_syntax := std term serialize collections log fmt_macros semver
 DEPS_rustc := syntax native:rustllvm flate arena serialize sync getopts \
               collections time log
 DEPS_rustdoc := rustc native:hoedown serialize sync getopts collections \

--- a/src/test/compile-fail/cfg-version-multiple-matches.rs
+++ b/src/test/compile-fail/cfg-version-multiple-matches.rs
@@ -1,0 +1,19 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(rust_version=">0.1.0")]
+fn foo() -> int { 1 }
+
+#[cfg(rust_version=">=0.3.0")]
+fn foo() -> int { 2 } //~ ERROR duplicate definition of value `foo`
+
+fn main() {
+    foo();
+}

--- a/src/test/compile-fail/cfg-version-not-matched.rs
+++ b/src/test/compile-fail/cfg-version-not-matched.rs
@@ -1,0 +1,16 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(rust_version="<0.1.0")]
+fn foo() -> int { 1 }
+
+fn main() {
+    foo(); //~ ERROR unresolved name `foo`
+}

--- a/src/test/run-pass/cfg-rust-version.rs
+++ b/src/test/run-pass/cfg-rust-version.rs
@@ -1,0 +1,19 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(rust_version=">0.2.0")]
+fn foo() -> int { 1 }
+
+#[cfg(rust_version="<0.2.0")]
+fn foo() -> int { 0 }
+
+fn main() {
+    assert_eq!(1, foo());
+}


### PR DESCRIPTION
Fixes #3795

This PR implements a cfg that conditionally includes code based on the current version of the Rust compiler.
It uses the syntax proposed in #3795, namely #[cfg(rust_version="X")].  
It accepts the operators <, <=, >, >=, != (just for completeness), and checks for equality if no operator is specified.
