### PR TITLE
rustc: Fix shadowing private import with reexport

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2050,7 +2050,8 @@ impl<'a> Resolver<'a> {
         while module.resolved_import_count.get() < import_count {
             let import_index = module.resolved_import_count.get();
             let import_directive = imports.get(import_index);
-            match self.resolve_import_for_module(module.clone(), import_directive) {
+            match self.resolve_import_for_module(module.clone(),
+                                                 import_directive) {
                 Failed => {
                     // We presumably emitted an error. Continue.
                     let msg = format!("failed to resolve import `{}`",
@@ -2402,6 +2403,7 @@ impl<'a> Resolver<'a> {
                 import_resolution.value_target = Some(Target::new(target_module.clone(),
                                                                   name_bindings.clone()));
                 import_resolution.value_id = directive.id;
+                import_resolution.is_public = directive.is_public;
                 value_used_public = name_bindings.defined_in_public_namespace(ValueNS);
             }
             UnboundResult => { /* Continue. */ }
@@ -2416,6 +2418,7 @@ impl<'a> Resolver<'a> {
                 import_resolution.type_target =
                     Some(Target::new(target_module.clone(), name_bindings.clone()));
                 import_resolution.type_id = directive.id;
+                import_resolution.is_public = directive.is_public;
                 type_used_public = name_bindings.defined_in_public_namespace(TypeNS);
             }
             UnboundResult => { /* Continue. */ }

--- a/src/test/run-pass/issue-14082.rs
+++ b/src/test/run-pass/issue-14082.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(globs)]
+#![allow(unused_imports, dead_code)]
+
+use foo::GC;
+
+mod foo {
+    use d::*;
+    pub use m::GC; // this should shadow d::GC
+}
+
+mod m {
+    pub struct GC;
+}
+
+mod d {
+    pub struct GC;
+}
+
+fn main() {}


### PR DESCRIPTION
The reexport didn't switch the privacy, so the reexport was actually considered
private, erroneously failing to resolve imports later on.

Closes #14082
