### PR TITLE
lint: add internal mutability lint.

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -89,6 +89,7 @@ pub enum Lint {
     TypeOverflow,
     UnusedUnsafe,
     UnsafeBlock,
+    InternalMutability,
     AttributeUsage,
     UnknownFeatures,
     UnknownCrateType,
@@ -280,6 +281,13 @@ static lint_table: &'static [(&'static str, LintSpec)] = &[
         desc: "usage of an `unsafe` block",
         default: allow
     }),
+
+    ("internal_mutability",
+     LintSpec {
+         lint: InternalMutability,
+         desc: "detect the use of types with internal (non-inherited) mutability",
+         default: allow
+     }),
 
     ("attribute_usage",
      LintSpec {
@@ -1387,6 +1395,25 @@ fn check_unsafe_block(cx: &Context, e: &ast::Expr) {
     }
 }
 
+fn check_internal_mutability(cx: &Context, e: &ast::Expr) {
+    let (name, args) = match e.node {
+        ast::ExprMethodCall(_, _, ref args) => ("method", args),
+        ast::ExprCall(_, ref args) => ("function", args),
+        _ => return
+    };
+
+    for arg in args.iter() {
+        let arg_ty = ty::expr_ty(cx.tcx, *arg);
+        let reaches_unsafe = ty::type_interior_reaches_unsafe(cx.tcx, arg_ty);
+
+        if reaches_unsafe {
+            cx.span_lint(InternalMutability, arg.span,
+                         format_strbuf!("internally mutable type used in {} call",
+                                        name).as_slice())
+        }
+    }
+}
+
 fn check_unused_mut_pat(cx: &Context, pats: &[@ast::Pat]) {
     // collect all mutable pattern and group their NodeIDs by their Identifier to
     // avoid false warnings in match arms with multiple patterns
@@ -1742,6 +1769,7 @@ impl<'a> Visitor<()> for Context<'a> {
         check_unnecessary_parens_expr(self, e);
         check_unused_unsafe(self, e);
         check_unsafe_block(self, e);
+        check_internal_mutability(self, e);
         check_unnecessary_allocation(self, e);
         check_heap_expr(self, e);
 

--- a/src/test/compile-fail/lint-internal-mutability.rs
+++ b/src/test/compile-fail/lint-internal-mutability.rs
@@ -1,0 +1,65 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(internal_mutability)]
+
+use std::cell::{Cell,RefCell};
+use std::ty::Unsafe;
+use std::rc::Rc;
+
+struct Foo {
+    x: Unsafe<uint>
+}
+impl Foo {
+    fn amp_call(&self) {}
+    fn amp_mut_call(&mut self) {}
+    fn call(self) {}
+}
+
+struct Bar;
+
+impl Bar {
+    fn call(&self, _: Cell<uint>, _: &RefCell<uint>, _: &Rc<uint>) {}
+    fn call2(&self, _: &Cell<uint>, _: RefCell<uint>, _: &uint) {}
+}
+
+fn call(_: Cell<uint>, _: &RefCell<uint>, _: &Rc<uint>) {}
+fn call2(_: &Cell<uint>, _: RefCell<uint>, _: &uint) {}
+
+
+fn main() {
+    let a = Cell::new(1);
+    let b1 = RefCell::new(2u);
+    let b2 = b1.clone(); //~ ERROR internally mutable type used in method call
+    let c = Rc::new(3);
+
+    call(a, //~ ERROR internally mutable type used in function call
+         &b1, //~ ERROR internally mutable type used in function call
+         &c); //~ ERROR internally mutable type used in function call
+
+    call2(&a, //~ ERROR internally mutable type used in function call
+          b1, //~ ERROR internally mutable type used in function call
+          &*c);
+
+    let mut foo = Foo { x: Unsafe::new(4) };
+
+    foo.amp_call();//~ ERROR internally mutable type used in method call
+    foo.amp_mut_call();//~ ERROR internally mutable type used in method call
+    foo.call();//~ ERROR internally mutable type used in method call
+
+    Bar.call(a, //~ ERROR internally mutable type used in method call
+             &b2, //~ ERROR internally mutable type used in method call
+             &c); //~ ERROR internally mutable type used in method call
+
+    Bar.call2(&a, //~ ERROR internally mutable type used in method call
+              b2, //~ ERROR internally mutable type used in method call
+              &*c);
+
+}


### PR DESCRIPTION
This picks up any use of types with internal mutability (containing
`Unsafe`) in function/method calls, since these may cause things to be
modified unexpectedly.

This lint is like the "heap memory" lints, in that using internally
mutable types is perfectly valid in many instances, but it is easy to
expose the compiler's internal knowledge for the cases when someone does
wish to keep track of everything being mutated.
