### PR TITLE
std: Add trait ToCU16Str

### DIFF
--- a/src/libnative/io/c_win32.rs
+++ b/src/libnative/io/c_win32.rs
@@ -69,7 +69,7 @@ extern "system" {
 pub mod compat {
     use std::intrinsics::{atomic_store_relaxed, transmute};
     use libc::types::os::arch::extra::{LPCWSTR, HMODULE, LPCSTR, LPVOID};
-    use std::os::win32::as_utf16_p;
+    use std::c_str::ToCU16Str;
 
     extern "system" {
         fn GetModuleHandleW(lpModuleName: LPCWSTR) -> HMODULE;
@@ -80,7 +80,7 @@ pub mod compat {
     // This way, calling a function in this compatibility layer (after it's loaded) shouldn't
     // be any slower than a regular DLL call.
     unsafe fn store_func<T: Copy>(ptr: *mut T, module: &str, symbol: &str, fallback: T) {
-        as_utf16_p(module, |module| {
+        module.with_c_u16_str(|module| {
             symbol.with_c_str(|symbol| {
                 let handle = GetModuleHandleW(module);
                 let func: Option<T> = transmute(GetProcAddress(handle, symbol));

--- a/src/librustdoc/flock.rs
+++ b/src/librustdoc/flock.rs
@@ -135,7 +135,7 @@ mod imp {
 mod imp {
     use libc;
     use std::mem;
-    use std::os::win32::as_utf16_p;
+    use std::c_str::ToCU16Str;
     use std::os;
     use std::ptr;
 
@@ -161,7 +161,7 @@ mod imp {
 
     impl Lock {
         pub fn new(p: &Path) -> Lock {
-            let handle = as_utf16_p(p.as_str().unwrap(), |p| unsafe {
+            let handle = p.as_str().unwrap().with_c_u16_str(|p| unsafe {
                 libc::CreateFileW(p,
                                   libc::FILE_GENERIC_READ |
                                     libc::FILE_GENERIC_WRITE,

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -136,7 +136,8 @@ pub mod win32 {
                     // closure returned invalid UTF-16, rather than
                     // set `res` to None and continue.
                     let s = str::from_utf16(sub)
-                        .expect("fill_utf16_buf_and_decode: closure created invalid UTF-16");
+                        .expect("fill_utf16_buf_and_decode: closure created invalid UTF-16")
+                        .into_owned();
                     res = option::Some(s)
                 }
             }
@@ -210,7 +211,7 @@ pub fn env_as_bytes() -> Vec<(~[u8],~[u8])> {
                 let p = &*ch.offset(i);
                 let len = ptr::position(p, |c| *c == 0);
                 raw::buf_as_slice(p, len, |s| {
-                    result.push(str::from_utf16_lossy(s).into_bytes());
+                    result.push(str::from_utf16_lossy(s).into_owned().into_bytes());
                 });
                 i += len as int + 1;
             }
@@ -863,7 +864,7 @@ fn real_args() -> Vec<~str> {
         let opt_s = slice::raw::buf_as_slice(ptr, len, |buf| {
             str::from_utf16(str::truncate_utf16_at_nul(buf))
         });
-        opt_s.expect("CommandLineToArgvW returned invalid UTF-16")
+        opt_s.expect("CommandLineToArgvW returned invalid UTF-16").into_owned()
     });
 
     unsafe {

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -347,7 +347,7 @@ Section: Misc
 /// v[4] = 0xD800;
 /// assert_eq!(str::from_utf16(v), None);
 /// ```
-pub fn from_utf16(v: &[u16]) -> Option<~str> {
+pub fn from_utf16(v: &[u16]) -> Option<StrBuf> {
     let mut s = StrBuf::with_capacity(v.len() / 2);
     for c in utf16_items(v) {
         match c {
@@ -355,7 +355,7 @@ pub fn from_utf16(v: &[u16]) -> Option<~str> {
             LoneSurrogate(_) => return None
         }
     }
-    Some(s.into_owned())
+    Some(s.into_strbuf())
 }
 
 /// Decode a UTF-16 encoded vector `v` into a string, replacing
@@ -373,7 +373,7 @@ pub fn from_utf16(v: &[u16]) -> Option<~str> {
 /// assert_eq!(str::from_utf16_lossy(v),
 ///            "𝄞mus\uFFFDic\uFFFD".to_owned());
 /// ```
-pub fn from_utf16_lossy(v: &[u16]) -> ~str {
+pub fn from_utf16_lossy(v: &[u16]) -> StrBuf {
     utf16_items(v).map(|c| c.to_char_lossy()).collect()
 }
 
@@ -1658,8 +1658,9 @@ mod tests {
             assert!(is_utf16(u.as_slice()));
             assert_eq!(s.to_utf16(), u);
 
-            assert_eq!(from_utf16(u.as_slice()).unwrap(), s);
+            let s = s.to_strbuf();
             assert_eq!(from_utf16_lossy(u.as_slice()), s);
+            assert_eq!(from_utf16(u.as_slice()).unwrap(), s);
 
             assert_eq!(from_utf16(s.to_utf16().as_slice()).unwrap(), s);
             assert_eq!(from_utf16(u.as_slice()).unwrap().to_utf16(), u);
@@ -1685,15 +1686,16 @@ mod tests {
     fn test_utf16_lossy() {
         // completely positive cases tested above.
         // lead + eof
-        assert_eq!(from_utf16_lossy([0xD800]), "\uFFFD".to_owned());
+        assert_eq!(from_utf16_lossy([0xD800]), "\uFFFD".to_strbuf());
         // lead + lead
-        assert_eq!(from_utf16_lossy([0xD800, 0xD800]), "\uFFFD\uFFFD".to_owned());
+        assert_eq!(from_utf16_lossy([0xD800, 0xD800]), "\uFFFD\uFFFD".to_strbuf());
 
         // isolated trail
-        assert_eq!(from_utf16_lossy([0x0061, 0xDC00]), "a\uFFFD".to_owned());
+        assert_eq!(from_utf16_lossy([0x0061, 0xDC00]), "a\uFFFD".to_strbuf());
 
         // general
-        assert_eq!(from_utf16_lossy([0xD800, 0xd801, 0xdc8b, 0xD800]), "\uFFFD𐒋\uFFFD".to_owned());
+        assert_eq!(from_utf16_lossy([0xD800, 0xd801, 0xdc8b, 0xD800]),
+                   "\uFFFD𐒋\uFFFD".to_strbuf());
     }
 
     #[test]

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -236,13 +236,13 @@ pub mod dl {
     use ptr;
     use result::{Ok, Err, Result};
     use str;
-    use c_str::ToCStr;
+    use c_str::{ToCStr, ToCU16Str};
 
     pub unsafe fn open_external<T: ToCStr>(filename: T) -> *u8 {
         // Windows expects Unicode data
         let filename_cstr = filename.to_c_str();
         let filename_str = str::from_utf8(filename_cstr.as_bytes_no_nul()).unwrap();
-        os::win32::as_utf16_p(filename_str, |raw_name| {
+        filename_str.with_c_u16_str(|raw_name| {
             LoadLibraryW(raw_name as *libc::c_void) as *u8
         })
     }


### PR DESCRIPTION
First patch adds `ToCU16Str` for UTF-16 ffi.
It also removes `std::os::win32::{as_utf16_p, as_mut_utf16_p}`.

Second patch changes return type of `from_utf16{,_lossy}` to `StrBuf`.

[breaking-change]
