### PR TITLE
Move the AST from @T to Gc<T>, improve Gc<T>

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1710,14 +1710,14 @@ having ownership of the box. It allows the creation of cycles, and the individua
 not have a destructor.
 
 ~~~
-use std::gc::Gc;
+use std::gc::GC;
 
 // A fixed-size array allocated in a garbage-collected box
-let x = Gc::new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+let x = box(GC) [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 let y = x; // does not perform a move, unlike with `Rc`
 let z = x;
 
-assert!(*z.borrow() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+assert!(*z == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 ~~~
 
 With shared ownership, mutability cannot be inherited so the boxes are always immutable. However,

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn gc_inside() {
         // see issue #11532
-        use realstd::gc::Gc;
+        use std::gc::GC;
         let a = Rc::new(RefCell::new(box(GC) 1));
         assert!(a.try_borrow_mut().is_some());
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -320,8 +320,8 @@ mod tests {
     #[test]
     fn gc_inside() {
         // see issue #11532
-        use std::gc::Gc;
-        let a = Rc::new(RefCell::new(Gc::new(1)));
+        use realstd::gc::Gc;
+        let a = Rc::new(RefCell::new(box(GC) 1));
         assert!(a.try_borrow_mut().is_some());
     }
 

--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -248,13 +248,6 @@ impl<S: Writer, T: Hash<S>> Hash<S> for Box<T> {
     }
 }
 
-impl<S: Writer, T: Hash<S>> Hash<S> for @T {
-    #[inline]
-    fn hash(&self, state: &mut S) {
-        (**self).hash(state);
-    }
-}
-
 impl<S: Writer, T: Hash<S>> Hash<S> for Rc<T> {
     #[inline]
     fn hash(&self, state: &mut S) {

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -39,12 +39,6 @@ pub trait Clone {
     }
 }
 
-impl<T> Clone for @T {
-    /// Return a shallow copy of the managed box.
-    #[inline]
-    fn clone(&self) -> @T { *self }
-}
-
 impl<'a, T> Clone for &'a T {
     /// Return a shallow copy of the reference.
     #[inline]

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -110,6 +110,7 @@ extern_fn_clone!(A, B, C, D, E, F, G, H)
 mod test {
     use prelude::*;
     use realstd::owned::Box;
+    use realstd::gc::{Gc, GC};
 
     fn realclone<T: ::realstd::clone::Clone>(t: &T) -> T {
         use realstd::clone::Clone;
@@ -130,9 +131,9 @@ mod test {
 
     #[test]
     fn test_managed_clone() {
-        let a = @5i;
-        let b: @int = a.clone();
-        assert_eq!(a, b);
+        let a = box(GC) 5i;
+        let b: Gc<int> = realclone(&a);
+        assert!(a == b);
     }
 
     #[test]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -326,29 +326,6 @@ mod impls {
         fn cmp(&self, other: &&'a mut T) -> Ordering { (**self).cmp(*other) }
     }
     impl<'a, T: Eq> Eq for &'a mut T {}
-
-    // @ pointers
-    impl<T:PartialEq> PartialEq for @T {
-        #[inline]
-        fn eq(&self, other: &@T) -> bool { *(*self) == *(*other) }
-        #[inline]
-        fn ne(&self, other: &@T) -> bool { *(*self) != *(*other) }
-    }
-    impl<T:PartialOrd> PartialOrd for @T {
-        #[inline]
-        fn lt(&self, other: &@T) -> bool { *(*self) < *(*other) }
-        #[inline]
-        fn le(&self, other: &@T) -> bool { *(*self) <= *(*other) }
-        #[inline]
-        fn ge(&self, other: &@T) -> bool { *(*self) >= *(*other) }
-        #[inline]
-        fn gt(&self, other: &@T) -> bool { *(*self) > *(*other) }
-    }
-    impl<T: Ord> Ord for @T {
-        #[inline]
-        fn cmp(&self, other: &@T) -> Ordering { (**self).cmp(*other) }
-    }
-    impl<T: Eq> Eq for @T {}
 }
 
 #[cfg(test)]

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -43,7 +43,3 @@ default_impl!(i64, 0i64)
 
 default_impl!(f32, 0.0f32)
 default_impl!(f64, 0.0f64)
-
-impl<T: Default + 'static> Default for @T {
-    fn default() -> @T { @Default::default() }
-}

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -628,9 +628,6 @@ pub fn argumentuint<'a>(s: &'a uint) -> Argument<'a> {
 
 // Implementations of the core formatting traits
 
-impl<T: Show> Show for @T {
-    fn fmt(&self, f: &mut Formatter) -> Result { secret_show(&**self, f) }
-}
 impl<'a, T: Show> Show for &'a T {
     fn fmt(&self, f: &mut Formatter) -> Result { secret_show(*self, f) }
 }

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -79,7 +79,6 @@ pub trait Repr<T> {
 
 impl<'a, T> Repr<Slice<T>> for &'a [T] {}
 impl<'a> Repr<Slice<u8>> for &'a str {}
-impl<T> Repr<*Box<T>> for @T {}
 impl<T> Repr<*Vec<T>> for ~[T] {}
 
 #[cfg(test)]

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -705,7 +705,7 @@ fn print_flowgraph<W:io::Writer>(analysis: CrateAnalysis,
                                  block: ast::P<ast::Block>,
                                  mut out: W) -> io::IoResult<()> {
     let ty_cx = &analysis.ty_cx;
-    let cfg = cfg::CFG::new(ty_cx, block);
+    let cfg = cfg::CFG::new(ty_cx, &*block);
     let lcfg = LabelledCFG { ast_map: &ty_cx.map,
                              cfg: &cfg,
                              name: format!("block{}", block.id).to_string(), };

--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -12,6 +12,8 @@ use syntax::fold::Folder;
 use syntax::{ast, fold, attr};
 use syntax::codemap;
 
+use std::gc::Gc;
+
 struct Context<'a> {
     in_cfg: |attrs: &[ast::Attribute]|: 'a -> bool,
 }
@@ -36,7 +38,7 @@ impl<'a> fold::Folder for Context<'a> {
     fn fold_item_underscore(&mut self, item: &ast::Item_) -> ast::Item_ {
         fold_item_underscore(self, item)
     }
-    fn fold_expr(&mut self, expr: @ast::Expr) -> @ast::Expr {
+    fn fold_expr(&mut self, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         fold_expr(self, expr)
     }
 }
@@ -60,8 +62,8 @@ fn filter_view_item<'r>(cx: &mut Context, view_item: &'r ast::ViewItem)
 }
 
 fn fold_mod(cx: &mut Context, m: &ast::Mod) -> ast::Mod {
-    let filtered_items: Vec<&@ast::Item> = m.items.iter()
-            .filter(|&a| item_in_cfg(cx, *a))
+    let filtered_items: Vec<&Gc<ast::Item>> = m.items.iter()
+            .filter(|a| item_in_cfg(cx, &***a))
             .collect();
     let flattened_items = filtered_items.move_iter()
             .flat_map(|&x| cx.fold_item(x).move_iter())
@@ -76,9 +78,9 @@ fn fold_mod(cx: &mut Context, m: &ast::Mod) -> ast::Mod {
     }
 }
 
-fn filter_foreign_item(cx: &mut Context, item: @ast::ForeignItem)
-                       -> Option<@ast::ForeignItem> {
-    if foreign_item_in_cfg(cx, item) {
+fn filter_foreign_item(cx: &mut Context, item: Gc<ast::ForeignItem>)
+                       -> Option<Gc<ast::ForeignItem>> {
+    if foreign_item_in_cfg(cx, &*item) {
         Some(item)
     } else {
         None
@@ -103,7 +105,7 @@ fn fold_foreign_mod(cx: &mut Context, nm: &ast::ForeignMod) -> ast::ForeignMod {
 fn fold_item_underscore(cx: &mut Context, item: &ast::Item_) -> ast::Item_ {
     let item = match *item {
         ast::ItemImpl(ref a, ref b, c, ref methods) => {
-            let methods = methods.iter().filter(|m| method_in_cfg(cx, **m))
+            let methods = methods.iter().filter(|m| method_in_cfg(cx, &***m))
                 .map(|x| *x).collect();
             ast::ItemImpl((*a).clone(), (*b).clone(), c, methods)
         }
@@ -114,8 +116,8 @@ fn fold_item_underscore(cx: &mut Context, item: &ast::Item_) -> ast::Item_ {
                                  .collect();
             ast::ItemTrait((*a).clone(), b, (*c).clone(), methods)
         }
-        ast::ItemStruct(def, ref generics) => {
-            ast::ItemStruct(fold_struct(cx, def), generics.clone())
+        ast::ItemStruct(ref def, ref generics) => {
+            ast::ItemStruct(fold_struct(cx, &**def), generics.clone())
         }
         ast::ItemEnum(ref def, ref generics) => {
             let mut variants = def.variants.iter().map(|c| c.clone()).
@@ -125,11 +127,11 @@ fn fold_item_underscore(cx: &mut Context, item: &ast::Item_) -> ast::Item_ {
                 } else {
                     Some(match v.node.kind {
                                 ast::TupleVariantKind(..) => v,
-                                ast::StructVariantKind(def) => {
-                                    let def = fold_struct(cx, def);
-                                    @codemap::Spanned {
+                                ast::StructVariantKind(ref def) => {
+                                    let def = fold_struct(cx, &**def);
+                                    box(GC) codemap::Spanned {
                                         node: ast::Variant_ {
-                                            kind: ast::StructVariantKind(def),
+                                            kind: ast::StructVariantKind(def.clone()),
                                             ..v.node.clone()
                                         },
                                         ..*v
@@ -148,11 +150,11 @@ fn fold_item_underscore(cx: &mut Context, item: &ast::Item_) -> ast::Item_ {
     fold::noop_fold_item_underscore(&item, cx)
 }
 
-fn fold_struct(cx: &mut Context, def: &ast::StructDef) -> @ast::StructDef {
+fn fold_struct(cx: &mut Context, def: &ast::StructDef) -> Gc<ast::StructDef> {
     let mut fields = def.fields.iter().map(|c| c.clone()).filter(|m| {
         (cx.in_cfg)(m.node.attrs.as_slice())
     });
-    @ast::StructDef {
+    box(GC) ast::StructDef {
         fields: fields.collect(),
         ctor_id: def.ctor_id,
         super_struct: def.super_struct.clone(),
@@ -160,12 +162,12 @@ fn fold_struct(cx: &mut Context, def: &ast::StructDef) -> @ast::StructDef {
     }
 }
 
-fn retain_stmt(cx: &mut Context, stmt: @ast::Stmt) -> bool {
+fn retain_stmt(cx: &mut Context, stmt: Gc<ast::Stmt>) -> bool {
     match stmt.node {
       ast::StmtDecl(decl, _) => {
         match decl.node {
-          ast::DeclItem(item) => {
-            item_in_cfg(cx, item)
+          ast::DeclItem(ref item) => {
+            item_in_cfg(cx, &**item)
           }
           _ => true
         }
@@ -175,10 +177,10 @@ fn retain_stmt(cx: &mut Context, stmt: @ast::Stmt) -> bool {
 }
 
 fn fold_block(cx: &mut Context, b: ast::P<ast::Block>) -> ast::P<ast::Block> {
-    let resulting_stmts: Vec<&@ast::Stmt> =
+    let resulting_stmts: Vec<&Gc<ast::Stmt>> =
         b.stmts.iter().filter(|&a| retain_stmt(cx, *a)).collect();
     let resulting_stmts = resulting_stmts.move_iter()
-        .flat_map(|&stmt| cx.fold_stmt(stmt).move_iter())
+        .flat_map(|stmt| cx.fold_stmt(&**stmt).move_iter())
         .collect();
     let filtered_view_items = b.view_items.iter().filter_map(|a| {
         filter_view_item(cx, a).map(|x| cx.fold_view_item(x))
@@ -193,14 +195,14 @@ fn fold_block(cx: &mut Context, b: ast::P<ast::Block>) -> ast::P<ast::Block> {
     })
 }
 
-fn fold_expr(cx: &mut Context, expr: @ast::Expr) -> @ast::Expr {
+fn fold_expr(cx: &mut Context, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
     let expr = match expr.node {
         ast::ExprMatch(ref m, ref arms) => {
             let arms = arms.iter()
                 .filter(|a| (cx.in_cfg)(a.attrs.as_slice()))
                 .map(|a| a.clone())
                 .collect();
-            @ast::Expr {
+            box(GC) ast::Expr {
                 id: expr.id,
                 span: expr.span.clone(),
                 node: ast::ExprMatch(m.clone(), arms),
@@ -236,7 +238,7 @@ fn trait_method_in_cfg(cx: &mut Context, meth: &ast::TraitMethod) -> bool {
 
 // Determine if an item should be translated in the current crate
 // configuration based on the item's attributes
-fn in_cfg(cfg: &[@ast::MetaItem], attrs: &[ast::Attribute]) -> bool {
+fn in_cfg(cfg: &[Gc<ast::MetaItem>], attrs: &[ast::Attribute]) -> bool {
     attr::test_cfg(cfg, attrs.iter().map(|x| *x))
 }
 

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -23,6 +23,7 @@ use syntax::parse::token;
 use syntax::util::small_vector::SmallVector;
 
 use std::mem;
+use std::gc::Gc;
 
 pub static VERSION: &'static str = "0.11.0-pre";
 
@@ -165,12 +166,12 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
         krate
     }
 
-    fn fold_item(&mut self, item: @ast::Item) -> SmallVector<@ast::Item> {
+    fn fold_item(&mut self, item: Gc<ast::Item>) -> SmallVector<Gc<ast::Item>> {
         if !no_prelude(item.attrs.as_slice()) {
             // only recur if there wasn't `#![no_implicit_prelude]`
             // on this item, i.e. this means that the prelude is not
             // implicitly imported though the whole subtree
-            fold::noop_fold_item(item, self)
+            fold::noop_fold_item(&*item, self)
         } else {
             SmallVector::one(item)
         }
@@ -193,7 +194,8 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
                 }),
         };
 
-        let vp = @codemap::dummy_spanned(ast::ViewPathGlob(prelude_path, ast::DUMMY_NODE_ID));
+        let vp = box(GC) codemap::dummy_spanned(ast::ViewPathGlob(prelude_path,
+                                                                  ast::DUMMY_NODE_ID));
         let vi2 = ast::ViewItem {
             node: ast::ViewItemUse(vp),
             attrs: Vec::new(),

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -177,7 +177,7 @@ pub fn get_static_methods_if_impl(cstore: &cstore::CStore,
 
 pub fn get_item_attrs(cstore: &cstore::CStore,
                       def_id: ast::DefId,
-                      f: |Vec<ast::Attribute> |) {
+                      f: |Vec<ast::Attribute>|) {
     let cdata = cstore.get_crate_data(def_id.krate);
     decoder::get_item_attrs(&*cdata, def_id.node, f)
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -28,13 +28,13 @@ use middle::ty;
 use middle::typeck;
 use middle::astencode::vtable_decoder_helpers;
 
-use std::u64;
-use std::hash;
+use std::gc::Gc;
 use std::hash::Hash;
-use std::io;
+use std::hash;
 use std::io::extensions::u64_from_be_bytes;
-use std::option;
+use std::io;
 use std::rc::Rc;
+use std::u64;
 use serialize::ebml::reader;
 use serialize::ebml;
 use serialize::Decodable;
@@ -1010,8 +1010,8 @@ pub fn get_struct_fields(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::NodeId)
     result
 }
 
-fn get_meta_items(md: ebml::Doc) -> Vec<@ast::MetaItem> {
-    let mut items: Vec<@ast::MetaItem> = Vec::new();
+fn get_meta_items(md: ebml::Doc) -> Vec<Gc<ast::MetaItem>> {
+    let mut items: Vec<Gc<ast::MetaItem>> = Vec::new();
     reader::tagged_docs(md, tag_meta_item_word, |meta_item_doc| {
         let nd = reader::get_doc(meta_item_doc, tag_meta_item_name);
         let n = token::intern_and_get_ident(nd.as_str_slice());
@@ -1041,7 +1041,7 @@ fn get_meta_items(md: ebml::Doc) -> Vec<@ast::MetaItem> {
 fn get_attributes(md: ebml::Doc) -> Vec<ast::Attribute> {
     let mut attrs: Vec<ast::Attribute> = Vec::new();
     match reader::maybe_get_doc(md, tag_attributes) {
-      option::Some(attrs_d) => {
+      Some(attrs_d) => {
         reader::tagged_docs(attrs_d, tag_attribute, |attr_doc| {
             let meta_items = get_meta_items(attr_doc);
             // Currently it's only possible to have a single meta item on
@@ -1061,7 +1061,7 @@ fn get_attributes(md: ebml::Doc) -> Vec<ast::Attribute> {
             true
         });
       }
-      option::None => ()
+      None => ()
     }
     return attrs;
 }

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -894,4 +894,3 @@ impl<'a> CheckLoanCtxt<'a> {
         }
     }
 }
-

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -486,8 +486,8 @@ struct StaticInitializerCtxt<'a> {
 impl<'a> visit::Visitor<()> for StaticInitializerCtxt<'a> {
     fn visit_expr(&mut self, ex: &Expr, _: ()) {
         match ex.node {
-            ast::ExprAddrOf(mutbl, base) => {
-                let base_cmt = self.bccx.cat_expr(base);
+            ast::ExprAddrOf(mutbl, ref base) => {
+                let base_cmt = self.bccx.cat_expr(&**base);
                 let borrow_kind = ty::BorrowKind::from_mutbl(mutbl);
                 // Check that we don't allow borrows of unsafe static items.
                 if check_aliasability(self.bccx, ex.span, euv::AddrOf,

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -106,7 +106,7 @@ fn borrowck_item(this: &mut BorrowckCtxt, item: &ast::Item) {
     // flow dependent conditions.
     match item.node {
         ast::ItemStatic(_, _, ex) => {
-            gather_loans::gather_loans_in_static_initializer(this, ex);
+            gather_loans::gather_loans_in_static_initializer(this, &*ex);
         }
         _ => {
             visit::walk_item(this, item, ());
@@ -480,7 +480,7 @@ impl<'a> BorrowckCtxt<'a> {
             move_data::MoveExpr => {
                 let (expr_ty, expr_span) = match self.tcx.map.find(move.id) {
                     Some(ast_map::NodeExpr(expr)) => {
-                        (ty::expr_ty_adjusted(self.tcx, expr), expr.span)
+                        (ty::expr_ty_adjusted(self.tcx, &*expr), expr.span)
                     }
                     r => {
                         self.tcx.sess.bug(format!("MoveExpr({:?}) maps to \
@@ -512,7 +512,7 @@ impl<'a> BorrowckCtxt<'a> {
             move_data::Captured => {
                 let (expr_ty, expr_span) = match self.tcx.map.find(move.id) {
                     Some(ast_map::NodeExpr(expr)) => {
-                        (ty::expr_ty_adjusted(self.tcx, expr), expr.span)
+                        (ty::expr_ty_adjusted(self.tcx, &*expr), expr.span)
                     }
                     r => {
                         self.tcx.sess.bug(format!("Captured({:?}) maps to \

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -17,6 +17,8 @@ use syntax::ast;
 use syntax::ast_util;
 use util::nodemap::NodeMap;
 
+use std::gc::Gc;
+
 struct CFGBuilder<'a> {
     tcx: &'a ty::ctxt,
     exit_map: NodeMap<CFGIndex>,
@@ -66,23 +68,23 @@ fn add_initial_dummy_node(g: &mut CFGGraph) -> CFGIndex {
 impl<'a> CFGBuilder<'a> {
     fn block(&mut self, blk: &ast::Block, pred: CFGIndex) -> CFGIndex {
         let mut stmts_exit = pred;
-        for &stmt in blk.stmts.iter() {
-            stmts_exit = self.stmt(stmt, stmts_exit);
+        for stmt in blk.stmts.iter() {
+            stmts_exit = self.stmt(stmt.clone(), stmts_exit);
         }
 
-        let expr_exit = self.opt_expr(blk.expr, stmts_exit);
+        let expr_exit = self.opt_expr(blk.expr.clone(), stmts_exit);
 
         self.add_node(blk.id, [expr_exit])
     }
 
-    fn stmt(&mut self, stmt: @ast::Stmt, pred: CFGIndex) -> CFGIndex {
+    fn stmt(&mut self, stmt: Gc<ast::Stmt>, pred: CFGIndex) -> CFGIndex {
         match stmt.node {
-            ast::StmtDecl(decl, _) => {
-                self.decl(decl, pred)
+            ast::StmtDecl(ref decl, _) => {
+                self.decl(&**decl, pred)
             }
 
-            ast::StmtExpr(expr, _) | ast::StmtSemi(expr, _) => {
-                self.expr(expr, pred)
+            ast::StmtExpr(ref expr, _) | ast::StmtSemi(ref expr, _) => {
+                self.expr(expr.clone(), pred)
             }
 
             ast::StmtMac(..) => {
@@ -91,11 +93,11 @@ impl<'a> CFGBuilder<'a> {
         }
     }
 
-    fn decl(&mut self, decl: @ast::Decl, pred: CFGIndex) -> CFGIndex {
+    fn decl(&mut self, decl: &ast::Decl, pred: CFGIndex) -> CFGIndex {
         match decl.node {
-            ast::DeclLocal(local) => {
-                let init_exit = self.opt_expr(local.init, pred);
-                self.pat(local.pat, init_exit)
+            ast::DeclLocal(ref local) => {
+                let init_exit = self.opt_expr(local.init.clone(), pred);
+                self.pat(&*local.pat, init_exit)
             }
 
             ast::DeclItem(_) => {
@@ -104,7 +106,7 @@ impl<'a> CFGBuilder<'a> {
         }
     }
 
-    fn pat(&mut self, pat: @ast::Pat, pred: CFGIndex) -> CFGIndex {
+    fn pat(&mut self, pat: &ast::Pat, pred: CFGIndex) -> CFGIndex {
         match pat.node {
             ast::PatIdent(_, _, None) |
             ast::PatEnum(_, None) |
@@ -114,23 +116,23 @@ impl<'a> CFGBuilder<'a> {
                 self.add_node(pat.id, [pred])
             }
 
-            ast::PatBox(subpat) |
-            ast::PatRegion(subpat) |
-            ast::PatIdent(_, _, Some(subpat)) => {
-                let subpat_exit = self.pat(subpat, pred);
+            ast::PatBox(ref subpat) |
+            ast::PatRegion(ref subpat) |
+            ast::PatIdent(_, _, Some(ref subpat)) => {
+                let subpat_exit = self.pat(&**subpat, pred);
                 self.add_node(pat.id, [subpat_exit])
             }
 
             ast::PatEnum(_, Some(ref subpats)) |
             ast::PatTup(ref subpats) => {
                 let pats_exit =
-                    self.pats_all(subpats.iter().map(|p| *p), pred);
+                    self.pats_all(subpats.iter().map(|p| p.clone()), pred);
                 self.add_node(pat.id, [pats_exit])
             }
 
             ast::PatStruct(_, ref subpats, _) => {
                 let pats_exit =
-                    self.pats_all(subpats.iter().map(|f| f.pat), pred);
+                    self.pats_all(subpats.iter().map(|f| f.pat.clone()), pred);
                 self.add_node(pat.id, [pats_exit])
             }
 
@@ -150,39 +152,39 @@ impl<'a> CFGBuilder<'a> {
         }
     }
 
-    fn pats_all<I: Iterator<@ast::Pat>>(&mut self,
+    fn pats_all<I: Iterator<Gc<ast::Pat>>>(&mut self,
                                         pats: I,
                                         pred: CFGIndex) -> CFGIndex {
         //! Handles case where all of the patterns must match.
         let mut pats = pats;
-        pats.fold(pred, |pred, pat| self.pat(pat, pred))
+        pats.fold(pred, |pred, pat| self.pat(&*pat, pred))
     }
 
     fn pats_any(&mut self,
-                pats: &[@ast::Pat],
+                pats: &[Gc<ast::Pat>],
                 pred: CFGIndex) -> CFGIndex {
         //! Handles case where just one of the patterns must match.
 
         if pats.len() == 1 {
-            self.pat(pats[0], pred)
+            self.pat(&*pats[0], pred)
         } else {
             let collect = self.add_dummy_node([]);
             for &pat in pats.iter() {
-                let pat_exit = self.pat(pat, pred);
+                let pat_exit = self.pat(&*pat, pred);
                 self.add_contained_edge(pat_exit, collect);
             }
             collect
         }
     }
 
-    fn expr(&mut self, expr: @ast::Expr, pred: CFGIndex) -> CFGIndex {
+    fn expr(&mut self, expr: Gc<ast::Expr>, pred: CFGIndex) -> CFGIndex {
         match expr.node {
-            ast::ExprBlock(blk) => {
-                let blk_exit = self.block(blk, pred);
+            ast::ExprBlock(ref blk) => {
+                let blk_exit = self.block(&**blk, pred);
                 self.add_node(expr.id, [blk_exit])
             }
 
-            ast::ExprIf(cond, then, None) => {
+            ast::ExprIf(ref cond, ref then, None) => {
                 //
                 //     [pred]
                 //       |
@@ -197,12 +199,12 @@ impl<'a> CFGBuilder<'a> {
                 //    v 3   v 4
                 //   [..expr..]
                 //
-                let cond_exit = self.expr(cond, pred);                // 1
-                let then_exit = self.block(then, cond_exit);          // 2
-                self.add_node(expr.id, [cond_exit, then_exit])        // 3,4
+                let cond_exit = self.expr(cond.clone(), pred);           // 1
+                let then_exit = self.block(&**then, cond_exit);          // 2
+                self.add_node(expr.id, [cond_exit, then_exit])           // 3,4
             }
 
-            ast::ExprIf(cond, then, Some(otherwise)) => {
+            ast::ExprIf(ref cond, ref then, Some(ref otherwise)) => {
                 //
                 //     [pred]
                 //       |
@@ -217,13 +219,13 @@ impl<'a> CFGBuilder<'a> {
                 //    v 4   v 5
                 //   [..expr..]
                 //
-                let cond_exit = self.expr(cond, pred);                // 1
-                let then_exit = self.block(then, cond_exit);          // 2
-                let else_exit = self.expr(otherwise, cond_exit);      // 3
-                self.add_node(expr.id, [then_exit, else_exit])        // 4, 5
+                let cond_exit = self.expr(cond.clone(), pred);           // 1
+                let then_exit = self.block(&**then, cond_exit);          // 2
+                let else_exit = self.expr(otherwise.clone(), cond_exit); // 3
+                self.add_node(expr.id, [then_exit, else_exit])           // 4, 5
             }
 
-            ast::ExprWhile(cond, body) => {
+            ast::ExprWhile(ref cond, ref body) => {
                 //
                 //         [pred]
                 //           |
@@ -242,22 +244,22 @@ impl<'a> CFGBuilder<'a> {
                 // may cause additional edges.
 
                 // Is the condition considered part of the loop?
-                let loopback = self.add_dummy_node([pred]);           // 1
-                let cond_exit = self.expr(cond, loopback);            // 2
-                let expr_exit = self.add_node(expr.id, [cond_exit]);  // 3
+                let loopback = self.add_dummy_node([pred]);              // 1
+                let cond_exit = self.expr(cond.clone(), loopback);       // 2
+                let expr_exit = self.add_node(expr.id, [cond_exit]);     // 3
                 self.loop_scopes.push(LoopScope {
                     loop_id: expr.id,
                     continue_index: loopback,
                     break_index: expr_exit
                 });
-                let body_exit = self.block(body, cond_exit);          // 4
-                self.add_contained_edge(body_exit, loopback);         // 5
+                let body_exit = self.block(&**body, cond_exit);          // 4
+                self.add_contained_edge(body_exit, loopback);            // 5
                 expr_exit
             }
 
             ast::ExprForLoop(..) => fail!("non-desugared expr_for_loop"),
 
-            ast::ExprLoop(body, _) => {
+            ast::ExprLoop(ref body, _) => {
                 //
                 //     [pred]
                 //       |
@@ -272,20 +274,20 @@ impl<'a> CFGBuilder<'a> {
                 // Note that `break` and `loop` statements
                 // may cause additional edges.
 
-                let loopback = self.add_dummy_node([pred]);           // 1
-                let expr_exit = self.add_node(expr.id, []);           // 2
+                let loopback = self.add_dummy_node([pred]);              // 1
+                let expr_exit = self.add_node(expr.id, []);              // 2
                 self.loop_scopes.push(LoopScope {
                     loop_id: expr.id,
                     continue_index: loopback,
                     break_index: expr_exit,
                 });
-                let body_exit = self.block(body, loopback);           // 3
-                self.add_contained_edge(body_exit, loopback);         // 4
+                let body_exit = self.block(&**body, loopback);           // 3
+                self.add_contained_edge(body_exit, loopback);            // 4
                 self.loop_scopes.pop();
                 expr_exit
             }
 
-            ast::ExprMatch(discr, ref arms) => {
+            ast::ExprMatch(ref discr, ref arms) => {
                 //
                 //     [pred]
                 //       |
@@ -309,21 +311,21 @@ impl<'a> CFGBuilder<'a> {
                 //     v 5  v    v
                 //   [....expr....]
                 //
-                let discr_exit = self.expr(discr, pred);                 // 1
+                let discr_exit = self.expr(discr.clone(), pred);         // 1
 
                 let expr_exit = self.add_node(expr.id, []);
                 let mut guard_exit = discr_exit;
                 for arm in arms.iter() {
-                    guard_exit = self.opt_expr(arm.guard, guard_exit); // 2
+                    guard_exit = self.opt_expr(arm.guard, guard_exit);   // 2
                     let pats_exit = self.pats_any(arm.pats.as_slice(),
-                                                  guard_exit); // 3
-                    let body_exit = self.expr(arm.body, pats_exit);      // 4
+                                                  guard_exit);           // 3
+                    let body_exit = self.expr(arm.body.clone(), pats_exit); // 4
                     self.add_contained_edge(body_exit, expr_exit);       // 5
                 }
                 expr_exit
             }
 
-            ast::ExprBinary(op, l, r) if ast_util::lazy_binop(op) => {
+            ast::ExprBinary(op, ref l, ref r) if ast_util::lazy_binop(op) => {
                 //
                 //     [pred]
                 //       |
@@ -338,13 +340,13 @@ impl<'a> CFGBuilder<'a> {
                 //    v 3  v 4
                 //   [..exit..]
                 //
-                let l_exit = self.expr(l, pred);                         // 1
-                let r_exit = self.expr(r, l_exit);                       // 2
+                let l_exit = self.expr(l.clone(), pred);                  // 1
+                let r_exit = self.expr(r.clone(), l_exit);               // 2
                 self.add_node(expr.id, [l_exit, r_exit])                 // 3,4
             }
 
-            ast::ExprRet(v) => {
-                let v_exit = self.opt_expr(v, pred);
+            ast::ExprRet(ref v) => {
+                let v_exit = self.opt_expr(v.clone(), pred);
                 let b = self.add_node(expr.id, [v_exit]);
                 self.add_returning_edge(expr, b);
                 self.add_node(ast::DUMMY_NODE_ID, [])
@@ -370,21 +372,21 @@ impl<'a> CFGBuilder<'a> {
                 self.straightline(expr, pred, elems.as_slice())
             }
 
-            ast::ExprCall(func, ref args) => {
-                self.call(expr, pred, func, args.as_slice())
+            ast::ExprCall(ref func, ref args) => {
+                self.call(expr, pred, func.clone(), args.as_slice())
             }
 
             ast::ExprMethodCall(_, _, ref args) => {
                 self.call(expr, pred, *args.get(0), args.slice_from(1))
             }
 
-            ast::ExprIndex(l, r) |
-            ast::ExprBinary(_, l, r) if self.is_method_call(expr) => {
-                self.call(expr, pred, l, [r])
+            ast::ExprIndex(ref l, ref r) |
+            ast::ExprBinary(_, ref l, ref r) if self.is_method_call(&*expr) => {
+                self.call(expr, pred, l.clone(), [r.clone()])
             }
 
-            ast::ExprUnary(_, e) if self.is_method_call(expr) => {
-                self.call(expr, pred, e, [])
+            ast::ExprUnary(_, ref e) if self.is_method_call(&*expr) => {
+                self.call(expr, pred, e.clone(), [])
             }
 
             ast::ExprTup(ref exprs) => {
@@ -393,7 +395,7 @@ impl<'a> CFGBuilder<'a> {
 
             ast::ExprStruct(_, ref fields, base) => {
                 let base_exit = self.opt_expr(base, pred);
-                let field_exprs: Vec<@ast::Expr> =
+                let field_exprs: Vec<Gc<ast::Expr>> =
                     fields.iter().map(|f| f.expr).collect();
                 self.straightline(expr, base_exit, field_exprs.as_slice())
             }
@@ -437,16 +439,16 @@ impl<'a> CFGBuilder<'a> {
     }
 
     fn call(&mut self,
-            call_expr: @ast::Expr,
+            call_expr: Gc<ast::Expr>,
             pred: CFGIndex,
-            func_or_rcvr: @ast::Expr,
-            args: &[@ast::Expr]) -> CFGIndex {
+            func_or_rcvr: Gc<ast::Expr>,
+            args: &[Gc<ast::Expr>]) -> CFGIndex {
         let func_or_rcvr_exit = self.expr(func_or_rcvr, pred);
         self.straightline(call_expr, func_or_rcvr_exit, args)
     }
 
     fn exprs(&mut self,
-             exprs: &[@ast::Expr],
+             exprs: &[Gc<ast::Expr>],
              pred: CFGIndex) -> CFGIndex {
         //! Constructs graph for `exprs` evaluated in order
 
@@ -454,7 +456,7 @@ impl<'a> CFGBuilder<'a> {
     }
 
     fn opt_expr(&mut self,
-                opt_expr: Option<@ast::Expr>,
+                opt_expr: Option<Gc<ast::Expr>>,
                 pred: CFGIndex) -> CFGIndex {
         //! Constructs graph for `opt_expr` evaluated, if Some
 
@@ -462,9 +464,9 @@ impl<'a> CFGBuilder<'a> {
     }
 
     fn straightline(&mut self,
-                    expr: @ast::Expr,
+                    expr: Gc<ast::Expr>,
                     pred: CFGIndex,
-                    subexprs: &[@ast::Expr]) -> CFGIndex {
+                    subexprs: &[Gc<ast::Expr>]) -> CFGIndex {
         //! Handles case of an expression that evaluates `subexprs` in order
 
         let subexprs_exit = self.exprs(subexprs, pred);
@@ -496,7 +498,7 @@ impl<'a> CFGBuilder<'a> {
     }
 
     fn add_exiting_edge(&mut self,
-                        from_expr: @ast::Expr,
+                        from_expr: Gc<ast::Expr>,
                         from_index: CFGIndex,
                         to_loop: LoopScope,
                         to_index: CFGIndex) {
@@ -511,7 +513,7 @@ impl<'a> CFGBuilder<'a> {
     }
 
     fn add_returning_edge(&mut self,
-                          _from_expr: @ast::Expr,
+                          _from_expr: Gc<ast::Expr>,
                           from_index: CFGIndex) {
         let mut data = CFGEdgeData {
             exiting_scopes: vec!(),
@@ -523,7 +525,7 @@ impl<'a> CFGBuilder<'a> {
     }
 
     fn find_scope(&self,
-                  expr: @ast::Expr,
+                  expr: Gc<ast::Expr>,
                   label: Option<ast::Ident>) -> LoopScope {
         match label {
             None => {

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -45,13 +45,13 @@ pub fn check_crate(krate: &Crate, tcx: &ty::ctxt) {
 fn check_item(v: &mut CheckCrateVisitor, it: &Item, _is_const: bool) {
     match it.node {
         ItemStatic(_, _, ex) => {
-            v.visit_expr(ex, true);
+            v.visit_expr(&*ex, true);
             check_item_recursion(&v.tcx.sess, &v.tcx.map, &v.tcx.def_map, it);
         }
         ItemEnum(ref enum_definition, _) => {
             for var in (*enum_definition).variants.iter() {
                 for ex in var.node.disr_expr.iter() {
-                    v.visit_expr(*ex, true);
+                    v.visit_expr(&**ex, true);
                 }
             }
         }
@@ -73,10 +73,10 @@ fn check_pat(v: &mut CheckCrateVisitor, p: &Pat, _is_const: bool) {
     }
     match p.node {
       // Let through plain ~-string literals here
-      PatLit(a) => if !is_str(a) { v.visit_expr(a, true); },
-      PatRange(a, b) => {
-        if !is_str(a) { v.visit_expr(a, true); }
-        if !is_str(b) { v.visit_expr(b, true); }
+      PatLit(ref a) => if !is_str(&**a) { v.visit_expr(&**a, true); },
+      PatRange(ref a, ref b) => {
+        if !is_str(&**a) { v.visit_expr(&**a, true); }
+        if !is_str(&**b) { v.visit_expr(&**b, true); }
       }
       _ => visit::walk_pat(v, p, false)
     }
@@ -245,7 +245,7 @@ impl<'a> Visitor<()> for CheckItemRecursionVisitor<'a> {
                 match self.def_map.borrow().find(&e.id) {
                     Some(&DefStatic(def_id, _)) if
                             ast_util::is_local(def_id) => {
-                        self.visit_item(self.ast_map.expect_item(def_id.node), ());
+                        self.visit_item(&*self.ast_map.expect_item(def_id.node), ());
                     }
                     _ => ()
                 }

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -35,15 +35,15 @@ impl<'a> Visitor<Context> for CheckLoopVisitor<'a> {
 
     fn visit_expr(&mut self, e: &ast::Expr, cx:Context) {
         match e.node {
-            ast::ExprWhile(e, b) => {
-                self.visit_expr(e, cx);
-                self.visit_block(b, Loop);
+            ast::ExprWhile(ref e, ref b) => {
+                self.visit_expr(&**e, cx);
+                self.visit_block(&**b, Loop);
             }
-            ast::ExprLoop(b, _) => {
-                self.visit_block(b, Loop);
+            ast::ExprLoop(ref b, _) => {
+                self.visit_block(&**b, Loop);
             }
-            ast::ExprFnBlock(_, b) | ast::ExprProc(_, b) => {
-                self.visit_block(b, Closure);
+            ast::ExprFnBlock(_, ref b) | ast::ExprProc(_, ref b) => {
+                self.visit_block(&**b, Closure);
             }
             ast::ExprBreak(_) => self.require_loop("break", cx, e.span),
             ast::ExprAgain(_) => self.require_loop("continue", cx, e.span),

--- a/src/librustc/middle/check_static.rs
+++ b/src/librustc/middle/check_static.rs
@@ -77,13 +77,14 @@ impl<'a> Visitor<bool> for CheckStaticVisitor<'a> {
     fn visit_item(&mut self, i: &ast::Item, _is_const: bool) {
         debug!("visit_item(item={})", pprust::item_to_str(i));
         match i.node {
-            ast::ItemStatic(_, mutability, expr) => {
+            ast::ItemStatic(_, mutability, ref expr) => {
                 match mutability {
                     ast::MutImmutable => {
-                        self.visit_expr(expr, true);
+                        self.visit_expr(&**expr, true);
                     }
                     ast::MutMutable => {
-                        self.report_error(expr.span, safe_type_for_static_mut(self.tcx, expr));
+                        let safe = safe_type_for_static_mut(self.tcx, &**expr);
+                        self.report_error(expr.span, safe);
                     }
                 }
             }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -184,25 +184,25 @@ impl<'a> MarkSymbolVisitor<'a> {
                             }
                         });
                         self.live_symbols.extend(live_fields.map(|f| f.node.id));
-                        visit::walk_item(self, item, ());
+                        visit::walk_item(self, &*item, ());
                     }
                     ast::ItemFn(..)
                     | ast::ItemTy(..)
                     | ast::ItemEnum(..)
                     | ast::ItemStatic(..) => {
-                        visit::walk_item(self, item, ());
+                        visit::walk_item(self, &*item, ());
                     }
                     _ => ()
                 }
             }
             ast_map::NodeTraitMethod(trait_method) => {
-                visit::walk_trait_method(self, trait_method, ());
+                visit::walk_trait_method(self, &*trait_method, ());
             }
             ast_map::NodeMethod(method) => {
-                visit::walk_block(self, method.body, ());
+                visit::walk_block(self, &*method.body, ());
             }
             ast_map::NodeForeignItem(foreign_item) => {
-                visit::walk_foreign_item(self, foreign_item, ());
+                visit::walk_foreign_item(self, &*foreign_item, ());
             }
             _ => ()
         }
@@ -217,7 +217,7 @@ impl<'a> Visitor<()> for MarkSymbolVisitor<'a> {
                 self.lookup_and_handle_method(expr.id, expr.span);
             }
             ast::ExprField(ref lhs, ref ident, _) => {
-                self.handle_field_access(*lhs, ident);
+                self.handle_field_access(&**lhs, ident);
             }
             _ => ()
         }
@@ -479,7 +479,7 @@ impl<'a> Visitor<()> for DeadVisitor<'a> {
     // Overwrite so that we don't warn the trait method itself.
     fn visit_trait_method(&mut self, trait_method: &ast::TraitMethod, _: ()) {
         match *trait_method {
-            ast::Provided(method) => visit::walk_block(self, method.body, ()),
+            ast::Provided(ref method) => visit::walk_block(self, &*method.body, ()),
             ast::Required(_) => ()
         }
     }

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -11,6 +11,8 @@
 use syntax::ast;
 use syntax::ast_util::local_def;
 
+use std::gc::Gc;
+
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum Def {
     DefFn(ast::DefId, ast::FnStyle),
@@ -29,7 +31,7 @@ pub enum Def {
     DefBinding(ast::NodeId, ast::BindingMode),
     DefUse(ast::DefId),
     DefUpvar(ast::NodeId,  // id of closed over var
-             @Def,     // closed over def
+             Gc<Def>,     // closed over def
              ast::NodeId,  // expr node that creates the closure
              ast::NodeId), // id for the block/body of the closure expr
 

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -62,7 +62,7 @@ impl<'a> EffectCheckVisitor<'a> {
         }
     }
 
-    fn check_str_index(&mut self, e: @ast::Expr) {
+    fn check_str_index(&mut self, e: &ast::Expr) {
         let base_type = match e.node {
             ast::ExprIndex(base, _) => ty::node_id_to_type(self.tcx, base.id),
             _ => return
@@ -173,11 +173,11 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
                     _ => {}
                 }
             }
-            ast::ExprAssign(base, _) | ast::ExprAssignOp(_, base, _) => {
-                self.check_str_index(base);
+            ast::ExprAssign(ref base, _) | ast::ExprAssignOp(_, ref base, _) => {
+                self.check_str_index(&**base);
             }
-            ast::ExprAddrOf(ast::MutMutable, base) => {
-                self.check_str_index(base);
+            ast::ExprAddrOf(ast::MutMutable, ref base) => {
+                self.check_str_index(&**base);
             }
             ast::ExprInlineAsm(..) => {
                 self.require_unsafe(expr.span, "use of inline assembly")

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -25,6 +25,8 @@ use syntax::ast;
 use syntax::codemap::{Span};
 use util::ppaux::Repr;
 
+use std::gc::Gc;
+
 ///////////////////////////////////////////////////////////////////////////
 // The Delegate trait
 
@@ -157,7 +159,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                 ty::ReScope(body.id), // Args live only as long as the fn body.
                 arg_ty);
 
-            self.walk_pat(arg_cmt, arg.pat);
+            self.walk_pat(arg_cmt, arg.pat.clone());
         }
     }
 
@@ -173,9 +175,9 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         self.delegate.consume(consume_id, consume_span, cmt, mode);
     }
 
-    fn consume_exprs(&mut self, exprs: &Vec<@ast::Expr>) {
-        for &expr in exprs.iter() {
-            self.consume_expr(expr);
+    fn consume_exprs(&mut self, exprs: &Vec<Gc<ast::Expr>>) {
+        for expr in exprs.iter() {
+            self.consume_expr(&**expr);
         }
     }
 
@@ -186,7 +188,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         self.delegate_consume(expr.id, expr.span, cmt);
 
         match expr.node {
-            ast::ExprParen(subexpr) => {
+            ast::ExprParen(ref subexpr) => {
                 // Argh but is ExprParen horrible. So, if we consume
                 // `(x)`, that generally is also consuming `x`, UNLESS
                 // there are adjustments on the `(x)` expression
@@ -194,7 +196,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                 if self.typer.adjustments().borrow().contains_key(&expr.id) {
                     self.walk_expr(expr);
                 } else {
-                    self.consume_expr(subexpr);
+                    self.consume_expr(&**subexpr);
                 }
             }
 
@@ -240,31 +242,31 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         self.walk_adjustment(expr);
 
         match expr.node {
-            ast::ExprParen(subexpr) => {
-                self.walk_expr(subexpr)
+            ast::ExprParen(ref subexpr) => {
+                self.walk_expr(&**subexpr)
             }
 
             ast::ExprPath(..) => { }
 
-            ast::ExprUnary(ast::UnDeref, base) => {      // *base
-                if !self.walk_overloaded_operator(expr, base, []) {
-                    self.select_from_expr(base);
+            ast::ExprUnary(ast::UnDeref, ref base) => {      // *base
+                if !self.walk_overloaded_operator(expr, &**base, []) {
+                    self.select_from_expr(&**base);
                 }
             }
 
-            ast::ExprField(base, _, _) => {         // base.f
-                self.select_from_expr(base);
+            ast::ExprField(ref base, _, _) => {         // base.f
+                self.select_from_expr(&**base);
             }
 
-            ast::ExprIndex(lhs, rhs) => {           // lhs[rhs]
-                if !self.walk_overloaded_operator(expr, lhs, [rhs]) {
-                    self.select_from_expr(lhs);
-                    self.consume_expr(rhs);
+            ast::ExprIndex(ref lhs, ref rhs) => {           // lhs[rhs]
+                if !self.walk_overloaded_operator(expr, &**lhs, [rhs.clone()]) {
+                    self.select_from_expr(&**lhs);
+                    self.consume_expr(&**rhs);
                 }
             }
 
-            ast::ExprCall(callee, ref args) => {    // callee(args)
-                self.walk_callee(expr, callee);
+            ast::ExprCall(ref callee, ref args) => {    // callee(args)
+                self.walk_callee(expr, &**callee);
                 self.consume_exprs(args);
             }
 
@@ -272,27 +274,27 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                 self.consume_exprs(args);
             }
 
-            ast::ExprStruct(_, ref fields, opt_with) => {
-                self.walk_struct_expr(expr, fields, opt_with);
+            ast::ExprStruct(_, ref fields, ref opt_with) => {
+                self.walk_struct_expr(expr, fields, opt_with.clone());
             }
 
             ast::ExprTup(ref exprs) => {
                 self.consume_exprs(exprs);
             }
 
-            ast::ExprIf(cond_expr, then_blk, opt_else_expr) => {
-                self.consume_expr(cond_expr);
-                self.walk_block(then_blk);
+            ast::ExprIf(ref cond_expr, ref then_blk, ref opt_else_expr) => {
+                self.consume_expr(&**cond_expr);
+                self.walk_block(&**then_blk);
                 for else_expr in opt_else_expr.iter() {
-                    self.consume_expr(*else_expr);
+                    self.consume_expr(&**else_expr);
                 }
             }
 
-            ast::ExprMatch(discr, ref arms) => {
+            ast::ExprMatch(ref discr, ref arms) => {
                 // treatment of the discriminant is handled while
                 // walking the arms:
-                self.walk_expr(discr);
-                let discr_cmt = return_if_err!(self.mc.cat_expr(discr));
+                self.walk_expr(&**discr);
+                let discr_cmt = return_if_err!(self.mc.cat_expr(&**discr));
                 for arm in arms.iter() {
                     self.walk_arm(discr_cmt.clone(), arm);
                 }
@@ -302,26 +304,26 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                 self.consume_exprs(exprs);
             }
 
-            ast::ExprAddrOf(m, base) => {   // &base
+            ast::ExprAddrOf(m, ref base) => {   // &base
                 // make sure that the thing we are pointing out stays valid
                 // for the lifetime `scope_r` of the resulting ptr:
                 let expr_ty = ty::expr_ty(self.tcx(), expr);
                 if !ty::type_is_bot(expr_ty) {
                     let r = ty::ty_region(self.tcx(), expr.span, expr_ty);
                     let bk = ty::BorrowKind::from_mutbl(m);
-                    self.borrow_expr(base, r, bk, AddrOf);
+                    self.borrow_expr(&**base, r, bk, AddrOf);
                 } else {
-                    self.walk_expr(base);
+                    self.walk_expr(&**base);
                 }
             }
 
             ast::ExprInlineAsm(ref ia) => {
-                for &(_, input) in ia.inputs.iter() {
-                    self.consume_expr(input);
+                for &(_, ref input) in ia.inputs.iter() {
+                    self.consume_expr(&**input);
                 }
 
-                for &(_, output) in ia.outputs.iter() {
-                    self.mutate_expr(expr, output, JustWrite);
+                for &(_, ref output) in ia.outputs.iter() {
+                    self.mutate_expr(expr, &**output, JustWrite);
                 }
             }
 
@@ -329,59 +331,59 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
             ast::ExprAgain(..) |
             ast::ExprLit(..) => {}
 
-            ast::ExprLoop(blk, _) => {
-                self.walk_block(blk);
+            ast::ExprLoop(ref blk, _) => {
+                self.walk_block(&**blk);
             }
 
-            ast::ExprWhile(cond_expr, blk) => {
-                self.consume_expr(cond_expr);
-                self.walk_block(blk);
+            ast::ExprWhile(ref cond_expr, ref blk) => {
+                self.consume_expr(&**cond_expr);
+                self.walk_block(&**blk);
             }
 
             ast::ExprForLoop(..) => fail!("non-desugared expr_for_loop"),
 
-            ast::ExprUnary(_, lhs) => {
-                if !self.walk_overloaded_operator(expr, lhs, []) {
-                    self.consume_expr(lhs);
+            ast::ExprUnary(_, ref lhs) => {
+                if !self.walk_overloaded_operator(expr, &**lhs, []) {
+                    self.consume_expr(&**lhs);
                 }
             }
 
-            ast::ExprBinary(_, lhs, rhs) => {
-                if !self.walk_overloaded_operator(expr, lhs, [rhs]) {
-                    self.consume_expr(lhs);
-                    self.consume_expr(rhs);
+            ast::ExprBinary(_, ref lhs, ref rhs) => {
+                if !self.walk_overloaded_operator(expr, &**lhs, [rhs.clone()]) {
+                    self.consume_expr(&**lhs);
+                    self.consume_expr(&**rhs);
                 }
             }
 
-            ast::ExprBlock(blk) => {
-                self.walk_block(blk);
+            ast::ExprBlock(ref blk) => {
+                self.walk_block(&**blk);
             }
 
             ast::ExprRet(ref opt_expr) => {
                 for expr in opt_expr.iter() {
-                    self.consume_expr(*expr);
+                    self.consume_expr(&**expr);
                 }
             }
 
-            ast::ExprAssign(lhs, rhs) => {
-                self.mutate_expr(expr, lhs, JustWrite);
-                self.consume_expr(rhs);
+            ast::ExprAssign(ref lhs, ref rhs) => {
+                self.mutate_expr(expr, &**lhs, JustWrite);
+                self.consume_expr(&**rhs);
             }
 
-            ast::ExprCast(base, _) => {
-                self.consume_expr(base);
+            ast::ExprCast(ref base, _) => {
+                self.consume_expr(&**base);
             }
 
-            ast::ExprAssignOp(_, lhs, rhs) => {
+            ast::ExprAssignOp(_, ref lhs, ref rhs) => {
                 // This will have to change if/when we support
                 // overloaded operators for `+=` and so forth.
-                self.mutate_expr(expr, lhs, WriteAndRead);
-                self.consume_expr(rhs);
+                self.mutate_expr(expr, &**lhs, WriteAndRead);
+                self.consume_expr(&**rhs);
             }
 
-            ast::ExprRepeat(base, count) => {
-                self.consume_expr(base);
-                self.consume_expr(count);
+            ast::ExprRepeat(ref base, ref count) => {
+                self.consume_expr(&**base);
+                self.consume_expr(&**count);
             }
 
             ast::ExprFnBlock(..) |
@@ -389,13 +391,13 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                 self.walk_captures(expr)
             }
 
-            ast::ExprVstore(base, _) => {
-                self.consume_expr(base);
+            ast::ExprVstore(ref base, _) => {
+                self.consume_expr(&**base);
             }
 
-            ast::ExprBox(place, base) => {
-                self.consume_expr(place);
-                self.consume_expr(base);
+            ast::ExprBox(ref place, ref base) => {
+                self.consume_expr(&**place);
+                self.consume_expr(&**base);
             }
 
             ast::ExprMac(..) => {
@@ -448,10 +450,10 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
 
     fn walk_stmt(&mut self, stmt: &ast::Stmt) {
         match stmt.node {
-            ast::StmtDecl(decl, _) => {
+            ast::StmtDecl(ref decl, _) => {
                 match decl.node {
-                    ast::DeclLocal(local) => {
-                        self.walk_local(local);
+                    ast::DeclLocal(ref local) => {
+                        self.walk_local(local.clone());
                     }
 
                     ast::DeclItem(_) => {
@@ -461,9 +463,9 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                 }
             }
 
-            ast::StmtExpr(expr, _) |
-            ast::StmtSemi(expr, _) => {
-                self.consume_expr(expr);
+            ast::StmtExpr(ref expr, _) |
+            ast::StmtSemi(ref expr, _) => {
+                self.consume_expr(&**expr);
             }
 
             ast::StmtMac(..) => {
@@ -472,22 +474,23 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         }
     }
 
-    fn walk_local(&mut self, local: @ast::Local) {
+    fn walk_local(&mut self, local: Gc<ast::Local>) {
         match local.init {
             None => {
                 let delegate = &mut self.delegate;
-                pat_util::pat_bindings(&self.typer.tcx().def_map, local.pat, |_, id, span, _| {
+                pat_util::pat_bindings(&self.typer.tcx().def_map, &*local.pat,
+                                       |_, id, span, _| {
                     delegate.decl_without_init(id, span);
                 })
             }
 
-            Some(expr) => {
+            Some(ref expr) => {
                 // Variable declarations with
                 // initializers are considered
                 // "assigns", which is handled by
                 // `walk_pat`:
-                self.walk_expr(expr);
-                let init_cmt = return_if_err!(self.mc.cat_expr(expr));
+                self.walk_expr(&**expr);
+                let init_cmt = return_if_err!(self.mc.cat_expr(&**expr));
                 self.walk_pat(init_cmt, local.pat);
             }
         }
@@ -502,29 +505,29 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         debug!("walk_block(blk.id={:?})", blk.id);
 
         for stmt in blk.stmts.iter() {
-            self.walk_stmt(*stmt);
+            self.walk_stmt(&**stmt);
         }
 
         for tail_expr in blk.expr.iter() {
-            self.consume_expr(*tail_expr);
+            self.consume_expr(&**tail_expr);
         }
     }
 
     fn walk_struct_expr(&mut self,
                         _expr: &ast::Expr,
                         fields: &Vec<ast::Field>,
-                        opt_with: Option<@ast::Expr>) {
+                        opt_with: Option<Gc<ast::Expr>>) {
         // Consume the expressions supplying values for each field.
         for field in fields.iter() {
-            self.consume_expr(field.expr);
+            self.consume_expr(&*field.expr);
         }
 
         let with_expr = match opt_with {
-            Some(w) => { w }
+            Some(ref w) => { w.clone() }
             None => { return; }
         };
 
-        let with_cmt = return_if_err!(self.mc.cat_expr(with_expr));
+        let with_cmt = return_if_err!(self.mc.cat_expr(&*with_expr));
 
         // Select just those fields of the `with`
         // expression that will actually be used
@@ -542,7 +545,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         // Consume those fields of the with expression that are needed.
         for with_field in with_fields.iter() {
             if !contains_field_named(with_field, fields) {
-                let cmt_field = self.mc.cat_field(with_expr,
+                let cmt_field = self.mc.cat_field(&*with_expr,
                                                   with_cmt.clone(),
                                                   with_field.ident,
                                                   with_field.mt.ty);
@@ -673,7 +676,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
     fn walk_overloaded_operator(&mut self,
                                 expr: &ast::Expr,
                                 receiver: &ast::Expr,
-                                args: &[@ast::Expr])
+                                args: &[Gc<ast::Expr>])
                                 -> bool
     {
         if !self.typer.is_method_call(expr.id) {
@@ -689,8 +692,8 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         let r = ty::ReScope(expr.id);
         let bk = ty::ImmBorrow;
 
-        for &arg in args.iter() {
-            self.borrow_expr(arg, r, bk, OverloadedOperator);
+        for arg in args.iter() {
+            self.borrow_expr(&**arg, r, bk, OverloadedOperator);
         }
         return true;
     }
@@ -701,13 +704,13 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         }
 
         for guard in arm.guard.iter() {
-            self.consume_expr(*guard);
+            self.consume_expr(&**guard);
         }
 
-        self.consume_expr(arm.body);
+        self.consume_expr(&*arm.body);
     }
 
-    fn walk_pat(&mut self, cmt_discr: mc::cmt, pat: @ast::Pat) {
+    fn walk_pat(&mut self, cmt_discr: mc::cmt, pat: Gc<ast::Pat>) {
         debug!("walk_pat cmt_discr={} pat={}", cmt_discr.repr(self.tcx()),
                pat.repr(self.tcx()));
         let mc = &self.mc;
@@ -715,7 +718,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         let tcx = typer.tcx();
         let def_map = &self.typer.tcx().def_map;
         let delegate = &mut self.delegate;
-        return_if_err!(mc.cat_pattern(cmt_discr, pat, |mc, cmt_pat, pat| {
+        return_if_err!(mc.cat_pattern(cmt_discr, &*pat, |mc, cmt_pat, pat| {
             if pat_util::pat_is_binding(def_map, pat) {
                 let tcx = typer.tcx();
 
@@ -765,7 +768,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                         // matched.
 
                         let (slice_cmt, slice_mutbl, slice_r) = {
-                            match mc.cat_slice_pattern(cmt_pat, slice_pat) {
+                            match mc.cat_slice_pattern(cmt_pat, &*slice_pat) {
                                 Ok(v) => v,
                                 Err(()) => {
                                     tcx.sess.span_bug(slice_pat.span,

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -155,8 +155,8 @@ fn check_impl_of_trait(cx: &mut Context, it: &Item, trait_ref: &TraitRef, self_t
 fn check_item(cx: &mut Context, item: &Item) {
     if !attr::contains_name(item.attrs.as_slice(), "unsafe_destructor") {
         match item.node {
-            ItemImpl(_, Some(ref trait_ref), self_type, _) => {
-                check_impl_of_trait(cx, item, trait_ref, self_type);
+            ItemImpl(_, Some(ref trait_ref), ref self_type, _) => {
+                check_impl_of_trait(cx, item, trait_ref, &**self_type);
             }
             _ => {}
         }
@@ -292,19 +292,19 @@ pub fn check_expr(cx: &mut Context, e: &Expr) {
     }
 
     match e.node {
-        ExprUnary(UnBox, interior) => {
-            let interior_type = ty::expr_ty(cx.tcx, interior);
+        ExprUnary(UnBox, ref interior) => {
+            let interior_type = ty::expr_ty(cx.tcx, &**interior);
             let _ = check_static(cx.tcx, interior_type, interior.span);
         }
-        ExprCast(source, _) => {
-            let source_ty = ty::expr_ty(cx.tcx, source);
+        ExprCast(ref source, _) => {
+            let source_ty = ty::expr_ty(cx.tcx, &**source);
             let target_ty = ty::expr_ty(cx.tcx, e);
             check_trait_cast(cx, source_ty, target_ty, source.span);
         }
-        ExprRepeat(element, count_expr) => {
-            let count = ty::eval_repeat_count(cx.tcx, count_expr);
+        ExprRepeat(ref element, ref count_expr) => {
+            let count = ty::eval_repeat_count(cx.tcx, &**count_expr);
             if count > 1 {
-                let element_ty = ty::expr_ty(cx.tcx, element);
+                let element_ty = ty::expr_ty(cx.tcx, &**element);
                 check_copy(cx, element_ty, element.span,
                            "repeated element will be copied");
             }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -110,9 +110,10 @@ use middle::pat_util;
 use middle::ty;
 use util::nodemap::NodeMap;
 
-use std::mem::transmute;
 use std::fmt;
+use std::gc::Gc;
 use std::io;
+use std::mem::transmute;
 use std::rc::Rc;
 use std::str;
 use std::uint;
@@ -364,7 +365,7 @@ fn visit_fn(ir: &mut IrMaps,
 
     for arg in decl.inputs.iter() {
         pat_util::pat_bindings(&ir.tcx.def_map,
-                               arg.pat,
+                               &*arg.pat,
                                |_bm, arg_id, _x, path| {
             debug!("adding argument {}", arg_id);
             let ident = ast_util::path_to_ident(path);
@@ -397,7 +398,7 @@ fn visit_fn(ir: &mut IrMaps,
 }
 
 fn visit_local(ir: &mut IrMaps, local: &Local) {
-    pat_util::pat_bindings(&ir.tcx.def_map, local.pat, |_, p_id, sp, path| {
+    pat_util::pat_bindings(&ir.tcx.def_map, &*local.pat, |_, p_id, sp, path| {
         debug!("adding local variable {}", p_id);
         let name = ast_util::path_to_ident(path);
         ir.add_live_node_for_node(p_id, VarDefNode(sp));
@@ -411,7 +412,7 @@ fn visit_local(ir: &mut IrMaps, local: &Local) {
 
 fn visit_arm(ir: &mut IrMaps, arm: &Arm) {
     for pat in arm.pats.iter() {
-        pat_util::pat_bindings(&ir.tcx.def_map, *pat, |bm, p_id, sp, path| {
+        pat_util::pat_bindings(&ir.tcx.def_map, &**pat, |bm, p_id, sp, path| {
             debug!("adding local variable {} from match with bm {:?}",
                    p_id, bm);
             let name = ast_util::path_to_ident(path);
@@ -588,22 +589,22 @@ impl<'a> Liveness<'a> {
     }
 
     fn arm_pats_bindings(&mut self,
-                         pats: &[@Pat],
+                         pats: &[Gc<Pat>],
                          f: |&mut Liveness<'a>, LiveNode, Variable, Span, NodeId|) {
         // only consider the first pattern; any later patterns must have
         // the same bindings, and we also consider the first pattern to be
         // the "authoritative" set of ids
         if !pats.is_empty() {
-            self.pat_bindings(pats[0], f)
+            self.pat_bindings(&*pats[0], f)
         }
     }
 
-    fn define_bindings_in_pat(&mut self, pat: @Pat, succ: LiveNode)
+    fn define_bindings_in_pat(&mut self, pat: Gc<Pat>, succ: LiveNode)
                               -> LiveNode {
         self.define_bindings_in_arm_pats([pat], succ)
     }
 
-    fn define_bindings_in_arm_pats(&mut self, pats: &[@Pat], succ: LiveNode)
+    fn define_bindings_in_arm_pats(&mut self, pats: &[Gc<Pat>], succ: LiveNode)
                                    -> LiveNode {
         let mut succ = succ;
         self.arm_pats_bindings(pats, |this, ln, var, _sp, _id| {
@@ -858,19 +859,19 @@ impl<'a> Liveness<'a> {
                                -> LiveNode {
         let succ = self.propagate_through_opt_expr(blk.expr, succ);
         blk.stmts.iter().rev().fold(succ, |succ, stmt| {
-            self.propagate_through_stmt(*stmt, succ)
+            self.propagate_through_stmt(&**stmt, succ)
         })
     }
 
     fn propagate_through_stmt(&mut self, stmt: &Stmt, succ: LiveNode)
                               -> LiveNode {
         match stmt.node {
-            StmtDecl(decl, _) => {
-                self.propagate_through_decl(decl, succ)
+            StmtDecl(ref decl, _) => {
+                self.propagate_through_decl(&**decl, succ)
             }
 
-            StmtExpr(expr, _) | StmtSemi(expr, _) => {
-                self.propagate_through_expr(expr, succ)
+            StmtExpr(ref expr, _) | StmtSemi(ref expr, _) => {
+                self.propagate_through_expr(&**expr, succ)
             }
 
             StmtMac(..) => {
@@ -883,7 +884,7 @@ impl<'a> Liveness<'a> {
                               -> LiveNode {
         match decl.node {
             DeclLocal(ref local) => {
-                self.propagate_through_local(*local, succ)
+                self.propagate_through_local(&**local, succ)
             }
             DeclItem(_) => succ,
         }
@@ -909,19 +910,19 @@ impl<'a> Liveness<'a> {
         self.define_bindings_in_pat(local.pat, succ)
     }
 
-    fn propagate_through_exprs(&mut self, exprs: &[@Expr], succ: LiveNode)
+    fn propagate_through_exprs(&mut self, exprs: &[Gc<Expr>], succ: LiveNode)
                                -> LiveNode {
         exprs.iter().rev().fold(succ, |succ, expr| {
-            self.propagate_through_expr(*expr, succ)
+            self.propagate_through_expr(&**expr, succ)
         })
     }
 
     fn propagate_through_opt_expr(&mut self,
-                                  opt_expr: Option<@Expr>,
+                                  opt_expr: Option<Gc<Expr>>,
                                   succ: LiveNode)
                                   -> LiveNode {
         opt_expr.iter().fold(succ, |succ, expr| {
-            self.propagate_through_expr(*expr, succ)
+            self.propagate_through_expr(&**expr, succ)
         })
     }
 
@@ -936,11 +937,11 @@ impl<'a> Liveness<'a> {
               self.access_path(expr, succ, ACC_READ | ACC_USE)
           }
 
-          ExprField(e, _, _) => {
-              self.propagate_through_expr(e, succ)
+          ExprField(ref e, _, _) => {
+              self.propagate_through_expr(&**e, succ)
           }
 
-          ExprFnBlock(_, blk) | ExprProc(_, blk) => {
+          ExprFnBlock(_, ref blk) | ExprProc(_, ref blk) => {
               debug!("{} is an ExprFnBlock or ExprProc", expr_to_str(expr));
 
               /*
@@ -967,7 +968,7 @@ impl<'a> Liveness<'a> {
               })
           }
 
-          ExprIf(cond, then, els) => {
+          ExprIf(ref cond, ref then, ref els) => {
             //
             //     (cond)
             //       |
@@ -981,27 +982,27 @@ impl<'a> Liveness<'a> {
             //    v     v
             //   (  succ  )
             //
-            let else_ln = self.propagate_through_opt_expr(els, succ);
-            let then_ln = self.propagate_through_block(then, succ);
+            let else_ln = self.propagate_through_opt_expr(els.clone(), succ);
+            let then_ln = self.propagate_through_block(&**then, succ);
             let ln = self.live_node(expr.id, expr.span);
             self.init_from_succ(ln, else_ln);
             self.merge_from_succ(ln, then_ln, false);
-            self.propagate_through_expr(cond, ln)
+            self.propagate_through_expr(&**cond, ln)
           }
 
-          ExprWhile(cond, blk) => {
-            self.propagate_through_loop(expr, Some(cond), blk, succ)
+          ExprWhile(ref cond, ref blk) => {
+            self.propagate_through_loop(expr, Some(cond.clone()), &**blk, succ)
           }
 
           ExprForLoop(..) => fail!("non-desugared expr_for_loop"),
 
           // Note that labels have been resolved, so we don't need to look
           // at the label ident
-          ExprLoop(blk, _) => {
-            self.propagate_through_loop(expr, None, blk, succ)
+          ExprLoop(ref blk, _) => {
+            self.propagate_through_loop(expr, None, &**blk, succ)
           }
 
-          ExprMatch(e, ref arms) => {
+          ExprMatch(ref e, ref arms) => {
             //
             //      (e)
             //       |
@@ -1021,7 +1022,7 @@ impl<'a> Liveness<'a> {
             let mut first_merge = true;
             for arm in arms.iter() {
                 let body_succ =
-                    self.propagate_through_expr(arm.body, succ);
+                    self.propagate_through_expr(&*arm.body, succ);
                 let guard_succ =
                     self.propagate_through_opt_expr(arm.guard, body_succ);
                 let arm_succ =
@@ -1030,7 +1031,7 @@ impl<'a> Liveness<'a> {
                 self.merge_from_succ(ln, arm_succ, first_merge);
                 first_merge = false;
             };
-            self.propagate_through_expr(e, ln)
+            self.propagate_through_expr(&**e, ln)
           }
 
           ExprRet(o_e) => {
@@ -1066,49 +1067,49 @@ impl<'a> Liveness<'a> {
               }
           }
 
-          ExprAssign(l, r) => {
+          ExprAssign(ref l, ref r) => {
             // see comment on lvalues in
             // propagate_through_lvalue_components()
-            let succ = self.write_lvalue(l, succ, ACC_WRITE);
-            let succ = self.propagate_through_lvalue_components(l, succ);
-            self.propagate_through_expr(r, succ)
+            let succ = self.write_lvalue(&**l, succ, ACC_WRITE);
+            let succ = self.propagate_through_lvalue_components(&**l, succ);
+            self.propagate_through_expr(&**r, succ)
           }
 
-          ExprAssignOp(_, l, r) => {
+          ExprAssignOp(_, ref l, ref r) => {
             // see comment on lvalues in
             // propagate_through_lvalue_components()
-            let succ = self.write_lvalue(l, succ, ACC_WRITE|ACC_READ);
-            let succ = self.propagate_through_expr(r, succ);
-            self.propagate_through_lvalue_components(l, succ)
+            let succ = self.write_lvalue(&**l, succ, ACC_WRITE|ACC_READ);
+            let succ = self.propagate_through_expr(&**r, succ);
+            self.propagate_through_lvalue_components(&**l, succ)
           }
 
           // Uninteresting cases: just propagate in rev exec order
 
-          ExprVstore(expr, _) => {
-            self.propagate_through_expr(expr, succ)
+          ExprVstore(ref expr, _) => {
+            self.propagate_through_expr(&**expr, succ)
           }
 
           ExprVec(ref exprs) => {
             self.propagate_through_exprs(exprs.as_slice(), succ)
           }
 
-          ExprRepeat(element, count) => {
-            let succ = self.propagate_through_expr(count, succ);
-            self.propagate_through_expr(element, succ)
+          ExprRepeat(ref element, ref count) => {
+            let succ = self.propagate_through_expr(&**count, succ);
+            self.propagate_through_expr(&**element, succ)
           }
 
-          ExprStruct(_, ref fields, with_expr) => {
-            let succ = self.propagate_through_opt_expr(with_expr, succ);
+          ExprStruct(_, ref fields, ref with_expr) => {
+            let succ = self.propagate_through_opt_expr(with_expr.clone(), succ);
             fields.iter().rev().fold(succ, |succ, field| {
-                self.propagate_through_expr(field.expr, succ)
+                self.propagate_through_expr(&*field.expr, succ)
             })
           }
 
-          ExprCall(f, ref args) => {
+          ExprCall(ref f, ref args) => {
             // calling a fn with bot return type means that the fn
             // will fail, and hence the successors can be ignored
             let is_bot = !self.ir.tcx.is_method_call(expr.id) && {
-                let t_ret = ty::ty_fn_ret(ty::expr_ty(self.ir.tcx, f));
+                let t_ret = ty::ty_fn_ret(ty::expr_ty(self.ir.tcx, &**f));
                 ty::type_is_bot(t_ret)
             };
             let succ = if is_bot {
@@ -1117,7 +1118,7 @@ impl<'a> Liveness<'a> {
                 succ
             };
             let succ = self.propagate_through_exprs(args.as_slice(), succ);
-            self.propagate_through_expr(f, succ)
+            self.propagate_through_expr(&**f, succ)
           }
 
           ExprMethodCall(_, _, ref args) => {
@@ -1133,39 +1134,39 @@ impl<'a> Liveness<'a> {
             self.propagate_through_exprs(exprs.as_slice(), succ)
           }
 
-          ExprBinary(op, l, r) if ast_util::lazy_binop(op) => {
-            let r_succ = self.propagate_through_expr(r, succ);
+          ExprBinary(op, ref l, ref r) if ast_util::lazy_binop(op) => {
+            let r_succ = self.propagate_through_expr(&**r, succ);
 
             let ln = self.live_node(expr.id, expr.span);
             self.init_from_succ(ln, succ);
             self.merge_from_succ(ln, r_succ, false);
 
-            self.propagate_through_expr(l, ln)
+            self.propagate_through_expr(&**l, ln)
           }
 
-          ExprIndex(l, r) |
-          ExprBinary(_, l, r) |
-          ExprBox(l, r) => {
-            self.propagate_through_exprs([l, r], succ)
+          ExprIndex(ref l, ref r) |
+          ExprBinary(_, ref l, ref r) |
+          ExprBox(ref l, ref r) => {
+            self.propagate_through_exprs([l.clone(), r.clone()], succ)
           }
 
-          ExprAddrOf(_, e) |
-          ExprCast(e, _) |
-          ExprUnary(_, e) |
-          ExprParen(e) => {
-            self.propagate_through_expr(e, succ)
+          ExprAddrOf(_, ref e) |
+          ExprCast(ref e, _) |
+          ExprUnary(_, ref e) |
+          ExprParen(ref e) => {
+            self.propagate_through_expr(&**e, succ)
           }
 
           ExprInlineAsm(ref ia) => {
-            let succ = ia.outputs.iter().rev().fold(succ, |succ, &(_, expr)| {
+            let succ = ia.outputs.iter().rev().fold(succ, |succ, &(_, ref expr)| {
                 // see comment on lvalues in
                 // propagate_through_lvalue_components()
-                let succ = self.write_lvalue(expr, succ, ACC_WRITE);
-                self.propagate_through_lvalue_components(expr, succ)
+                let succ = self.write_lvalue(&**expr, succ, ACC_WRITE);
+                self.propagate_through_lvalue_components(&**expr, succ)
             });
             // Inputs are executed first. Propagate last because of rev order
-            ia.inputs.iter().rev().fold(succ, |succ, &(_, expr)| {
-                self.propagate_through_expr(expr, succ)
+            ia.inputs.iter().rev().fold(succ, |succ, &(_, ref expr)| {
+                self.propagate_through_expr(&**expr, succ)
             })
           }
 
@@ -1173,8 +1174,8 @@ impl<'a> Liveness<'a> {
             succ
           }
 
-          ExprBlock(blk) => {
-            self.propagate_through_block(blk, succ)
+          ExprBlock(ref blk) => {
+            self.propagate_through_block(&**blk, succ)
           }
 
           ExprMac(..) => {
@@ -1238,7 +1239,7 @@ impl<'a> Liveness<'a> {
 
         match expr.node {
             ExprPath(_) => succ,
-            ExprField(e, _, _) => self.propagate_through_expr(e, succ),
+            ExprField(ref e, _, _) => self.propagate_through_expr(&**e, succ),
             _ => self.propagate_through_expr(expr, succ)
         }
     }
@@ -1276,7 +1277,7 @@ impl<'a> Liveness<'a> {
 
     fn propagate_through_loop(&mut self,
                               expr: &Expr,
-                              cond: Option<@Expr>,
+                              cond: Option<Gc<Expr>>,
                               body: &Block,
                               succ: LiveNode)
                               -> LiveNode {
@@ -1353,10 +1354,10 @@ impl<'a> Liveness<'a> {
 fn check_local(this: &mut Liveness, local: &Local) {
     match local.init {
         Some(_) => {
-            this.warn_about_unused_or_dead_vars_in_pat(local.pat);
+            this.warn_about_unused_or_dead_vars_in_pat(&*local.pat);
         },
         None => {
-            this.pat_bindings(local.pat, |this, ln, var, sp, id| {
+            this.pat_bindings(&*local.pat, |this, ln, var, sp, id| {
                 this.warn_about_unused(sp, id, ln, var);
             })
         }
@@ -1374,28 +1375,28 @@ fn check_arm(this: &mut Liveness, arm: &Arm) {
 
 fn check_expr(this: &mut Liveness, expr: &Expr) {
     match expr.node {
-      ExprAssign(l, r) => {
-        this.check_lvalue(l);
-        this.visit_expr(r, ());
+      ExprAssign(ref l, ref r) => {
+        this.check_lvalue(&**l);
+        this.visit_expr(&**r, ());
 
         visit::walk_expr(this, expr, ());
       }
 
-      ExprAssignOp(_, l, _) => {
-        this.check_lvalue(l);
+      ExprAssignOp(_, ref l, _) => {
+        this.check_lvalue(&**l);
 
         visit::walk_expr(this, expr, ());
       }
 
       ExprInlineAsm(ref ia) => {
-        for &(_, input) in ia.inputs.iter() {
-          this.visit_expr(input, ());
+        for &(_, ref input) in ia.inputs.iter() {
+          this.visit_expr(&**input, ());
         }
 
         // Output operands must be lvalues
-        for &(_, out) in ia.outputs.iter() {
-          this.check_lvalue(out);
-          this.visit_expr(out, ());
+        for &(_, ref out) in ia.outputs.iter() {
+          this.check_lvalue(&**out);
+          this.visit_expr(&**out, ());
         }
 
         visit::walk_expr(this, expr, ());
@@ -1448,8 +1449,8 @@ impl<'a> Liveness<'a> {
                 let ends_with_stmt = match body.expr {
                     None if body.stmts.len() > 0 =>
                         match body.stmts.last().unwrap().node {
-                            StmtSemi(e, _) => {
-                                let t_stmt = ty::expr_ty(self.ir.tcx, e);
+                            StmtSemi(ref e, _) => {
+                                let t_stmt = ty::expr_ty(self.ir.tcx, &**e);
                                 ty::get(t_stmt).sty == ty::get(t_ret).sty
                             },
                             _ => false
@@ -1519,7 +1520,7 @@ impl<'a> Liveness<'a> {
     fn warn_about_unused_args(&self, decl: &FnDecl, entry_ln: LiveNode) {
         for arg in decl.inputs.iter() {
             pat_util::pat_bindings(&self.ir.tcx.def_map,
-                                   arg.pat,
+                                   &*arg.pat,
                                    |_bm, p_id, sp, path| {
                 let var = self.variable(p_id, sp);
                 // Ignore unused self.

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -70,7 +70,7 @@ fn method_might_be_inlined(tcx: &ty::ctxt, method: &ast::Method,
         {
             match tcx.map.find(impl_src.node) {
                 Some(ast_map::NodeItem(item)) => {
-                    item_might_be_inlined(item)
+                    item_might_be_inlined(&*item)
                 }
                 Some(..) | None => {
                     tcx.sess.span_bug(method.span, "impl did is not an item")
@@ -184,7 +184,7 @@ impl<'a> ReachableContext<'a> {
         match self.tcx.map.find(node_id) {
             Some(ast_map::NodeItem(item)) => {
                 match item.node {
-                    ast::ItemFn(..) => item_might_be_inlined(item),
+                    ast::ItemFn(..) => item_might_be_inlined(&*item),
                     _ => false,
                 }
             }
@@ -273,20 +273,20 @@ impl<'a> ReachableContext<'a> {
         match *node {
             ast_map::NodeItem(item) => {
                 match item.node {
-                    ast::ItemFn(_, _, _, _, search_block) => {
-                        if item_might_be_inlined(item) {
-                            visit::walk_block(self, search_block, ())
+                    ast::ItemFn(_, _, _, _, ref search_block) => {
+                        if item_might_be_inlined(&*item) {
+                            visit::walk_block(self, &**search_block, ())
                         }
                     }
 
                     // Statics with insignificant addresses are not reachable
                     // because they're inlined specially into all other crates.
-                    ast::ItemStatic(_, _, init) => {
+                    ast::ItemStatic(_, _, ref init) => {
                         if attr::contains_name(item.attrs.as_slice(),
                                                "address_insignificant") {
                             self.reachable_symbols.remove(&search_item);
                         }
-                        visit::walk_expr(self, init, ());
+                        visit::walk_expr(self, &**init, ());
                     }
 
                     // These are normal, nothing reachable about these
@@ -310,14 +310,14 @@ impl<'a> ReachableContext<'a> {
                         // Keep going, nothing to get exported
                     }
                     ast::Provided(ref method) => {
-                        visit::walk_block(self, method.body, ())
+                        visit::walk_block(self, &*method.body, ())
                     }
                 }
             }
             ast_map::NodeMethod(method) => {
                 let did = self.tcx.map.get_parent_did(search_item);
-                if method_might_be_inlined(self.tcx, method, did) {
-                    visit::walk_block(self, method.body, ())
+                if method_might_be_inlined(self.tcx, &*method, did) {
+                    visit::walk_block(self, &*method.body, ())
                 }
             }
             // Nothing to recurse on for these

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -37,23 +37,23 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
     let temp_scope = fcx.push_custom_cleanup_scope();
 
     // Prepare the output operands
-    let outputs = ia.outputs.iter().map(|&(ref c, out)| {
+    let outputs = ia.outputs.iter().map(|&(ref c, ref out)| {
         constraints.push((*c).clone());
 
-        let out_datum = unpack_datum!(bcx, expr::trans(bcx, out));
+        let out_datum = unpack_datum!(bcx, expr::trans(bcx, &**out));
         output_types.push(type_of::type_of(bcx.ccx(), out_datum.ty));
         out_datum.val
 
     }).collect::<Vec<_>>();
 
     // Now the input operands
-    let inputs = ia.inputs.iter().map(|&(ref c, input)| {
+    let inputs = ia.inputs.iter().map(|&(ref c, ref input)| {
         constraints.push((*c).clone());
 
-        let in_datum = unpack_datum!(bcx, expr::trans(bcx, input));
+        let in_datum = unpack_datum!(bcx, expr::trans(bcx, &**input));
         unpack_result!(bcx, {
             callee::trans_arg_datum(bcx,
-                                   expr_ty(bcx, input),
+                                   expr_ty(bcx, &**input),
                                    in_datum,
                                    cleanup::CustomScope(temp_scope),
                                    callee::DontAutorefArg)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -81,6 +81,7 @@ use std::c_str::ToCStr;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::{i8, i16, i32, i64};
+use std::gc::Gc;
 use syntax::abi::{X86, X86_64, Arm, Mips, Rust, RustIntrinsic};
 use syntax::ast_util::{local_def, is_local};
 use syntax::attr::AttrMetaMethods;
@@ -977,8 +978,8 @@ pub fn init_local<'a>(bcx: &'a Block<'a>, local: &ast::Local)
     if ignore_lhs(bcx, local) {
         // Handle let _ = e; just like e;
         match local.init {
-            Some(init) => {
-                return controlflow::trans_stmt_semi(bcx, init)
+            Some(ref init) => {
+                return controlflow::trans_stmt_semi(bcx, &**init)
             }
             None => { return bcx; }
         }
@@ -1537,14 +1538,14 @@ fn trans_enum_variant_or_tuple_like_struct(ccx: &CrateContext,
 fn trans_enum_def(ccx: &CrateContext, enum_definition: &ast::EnumDef,
                   sp: Span, id: ast::NodeId, vi: &[Rc<ty::VariantInfo>],
                   i: &mut uint) {
-    for &variant in enum_definition.variants.iter() {
+    for variant in enum_definition.variants.iter() {
         let disr_val = vi[*i].disr_val;
         *i += 1;
 
         match variant.node.kind {
             ast::TupleVariantKind(ref args) if args.len() > 0 => {
                 let llfn = get_item_val(ccx, variant.node.id);
-                trans_enum_variant(ccx, id, variant, args.as_slice(),
+                trans_enum_variant(ccx, id, &**variant, args.as_slice(),
                                    disr_val, &param_substs::empty(), llfn);
             }
             ast::TupleVariantKind(_) => {
@@ -1621,16 +1622,16 @@ impl<'a> Visitor<()> for TransItemVisitor<'a> {
 pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
     let _icx = push_ctxt("trans_item");
     match item.node {
-      ast::ItemFn(decl, _fn_style, abi, ref generics, body) => {
+      ast::ItemFn(ref decl, _fn_style, abi, ref generics, ref body) => {
         if abi != Rust  {
             let llfndecl = get_item_val(ccx, item.id);
             foreign::trans_rust_fn_with_foreign_abi(
-                ccx, decl, body, item.attrs.as_slice(), llfndecl, item.id);
+                ccx, &**decl, &**body, item.attrs.as_slice(), llfndecl, item.id);
         } else if !generics.is_type_parameterized() {
             let llfn = get_item_val(ccx, item.id);
             trans_fn(ccx,
-                     decl,
-                     body,
+                     &**decl,
+                     &**body,
                      llfn,
                      &param_substs::empty(),
                      item.id,
@@ -1639,7 +1640,7 @@ pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
             // Be sure to travel more than just one layer deep to catch nested
             // items in blocks and such.
             let mut v = TransItemVisitor{ ccx: ccx };
-            v.visit_block(body, ());
+            v.visit_block(&**body, ());
         }
       }
       ast::ItemImpl(ref generics, _, _, ref ms) => {
@@ -1655,10 +1656,10 @@ pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
             trans_enum_def(ccx, enum_definition, item.span, item.id, vi.as_slice(), &mut i);
         }
       }
-      ast::ItemStatic(_, m, expr) => {
+      ast::ItemStatic(_, m, ref expr) => {
           // Recurse on the expression to catch items in blocks
           let mut v = TransItemVisitor{ ccx: ccx };
-          v.visit_expr(expr, ());
+          v.visit_expr(&**expr, ());
           consts::trans_const(ccx, m, item.id);
           // Do static_assert checking. It can't really be done much earlier
           // because we need to get the value of the bool out of LLVM
@@ -1697,7 +1698,7 @@ pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
     }
 }
 
-pub fn trans_struct_def(ccx: &CrateContext, struct_def: @ast::StructDef) {
+pub fn trans_struct_def(ccx: &CrateContext, struct_def: Gc<ast::StructDef>) {
     // If this is a tuple-like struct, translate the constructor.
     match struct_def.ctor_id {
         // We only need to translate a constructor if there are fields;
@@ -1719,7 +1720,7 @@ pub fn trans_struct_def(ccx: &CrateContext, struct_def: @ast::StructDef) {
 pub fn trans_mod(ccx: &CrateContext, m: &ast::Mod) {
     let _icx = push_ctxt("trans_mod");
     for item in m.items.iter() {
-        trans_item(ccx, *item);
+        trans_item(ccx, &**item);
     }
 }
 
@@ -2003,7 +2004,7 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
             let sym = exported_name(ccx, id, ty, i.attrs.as_slice());
 
             let v = match i.node {
-                ast::ItemStatic(_, _, expr) => {
+                ast::ItemStatic(_, _, ref expr) => {
                     // If this static came from an external crate, then
                     // we need to get the symbol from csearch instead of
                     // using the current crate's name/version
@@ -2022,7 +2023,7 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
 
                     // We need the translated value here, because for enums the
                     // LLVM type is not fully determined by the Rust type.
-                    let (v, inlineable) = consts::const_expr(ccx, expr, is_local);
+                    let (v, inlineable) = consts::const_expr(ccx, &**expr, is_local);
                     ccx.const_values.borrow_mut().insert(id, v);
                     let mut inlineable = inlineable;
 
@@ -2118,13 +2119,13 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
                                    get_item_val()");
                 }
                 ast::Provided(m) => {
-                    register_method(ccx, id, m)
+                    register_method(ccx, id, &*m)
                 }
             }
         }
 
         ast_map::NodeMethod(m) => {
-            register_method(ccx, id, m)
+            register_method(ccx, id, &*m)
         }
 
         ast_map::NodeForeignItem(ni) => {
@@ -2134,13 +2135,13 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
                 ast::ForeignItemFn(..) => {
                     let abi = ccx.tcx.map.get_foreign_abi(id);
                     let ty = ty::node_id_to_type(ccx.tcx(), ni.id);
-                    let name = foreign::link_name(ni);
+                    let name = foreign::link_name(&*ni);
                     foreign::register_foreign_item_fn(ccx, abi, ty,
                                                       name.get().as_slice(),
                                                       Some(ni.span))
                 }
                 ast::ForeignItemStatic(..) => {
-                    foreign::register_static(ccx, ni)
+                    foreign::register_static(ccx, &*ni)
                 }
             }
         }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -77,6 +77,8 @@ use syntax::ast;
 use syntax::codemap;
 use syntax::print::pprust::{expr_to_str};
 
+use std::gc::Gc;
+
 // Destinations
 
 // These are passed around by the code generating functions to track the
@@ -380,22 +382,22 @@ fn trans_datum_unadjusted<'a>(bcx: &'a Block<'a>,
     let _icx = push_ctxt("trans_datum_unadjusted");
 
     match expr.node {
-        ast::ExprParen(e) => {
-            trans(bcx, e)
+        ast::ExprParen(ref e) => {
+            trans(bcx, &**e)
         }
         ast::ExprPath(_) => {
             trans_def(bcx, expr, bcx.def(expr.id))
         }
-        ast::ExprField(base, ident, _) => {
-            trans_rec_field(bcx, base, ident)
+        ast::ExprField(ref base, ident, _) => {
+            trans_rec_field(bcx, &**base, ident)
         }
-        ast::ExprIndex(base, idx) => {
-            trans_index(bcx, expr, base, idx)
+        ast::ExprIndex(ref base, ref idx) => {
+            trans_index(bcx, expr, &**base, &**idx)
         }
-        ast::ExprVstore(contents, ast::ExprVstoreUniq) => {
+        ast::ExprVstore(ref contents, ast::ExprVstoreUniq) => {
             fcx.push_ast_cleanup_scope(contents.id);
             let datum = unpack_datum!(
-                bcx, tvec::trans_uniq_vstore(bcx, expr, contents));
+                bcx, tvec::trans_uniq_vstore(bcx, expr, &**contents));
             bcx = fcx.pop_and_trans_ast_cleanup_scope(bcx, contents.id);
             DatumBlock::new(bcx, datum)
         }
@@ -414,19 +416,19 @@ fn trans_datum_unadjusted<'a>(bcx: &'a Block<'a>,
                                          "expected unique or managed box")
             }
         }
-        ast::ExprLit(lit) => trans_immediate_lit(bcx, expr, (*lit).clone()),
-        ast::ExprBinary(op, lhs, rhs) => {
-            trans_binary(bcx, expr, op, lhs, rhs)
+        ast::ExprLit(ref lit) => trans_immediate_lit(bcx, expr, (**lit).clone()),
+        ast::ExprBinary(op, ref lhs, ref rhs) => {
+            trans_binary(bcx, expr, op, &**lhs, &**rhs)
         }
-        ast::ExprUnary(op, x) => {
-            trans_unary(bcx, expr, op, x)
+        ast::ExprUnary(op, ref x) => {
+            trans_unary(bcx, expr, op, &**x)
         }
-        ast::ExprAddrOf(_, x) => {
-            trans_addr_of(bcx, expr, x)
+        ast::ExprAddrOf(_, ref x) => {
+            trans_addr_of(bcx, expr, &**x)
         }
-        ast::ExprCast(val, _) => {
+        ast::ExprCast(ref val, _) => {
             // Datum output mode means this is a scalar cast:
-            trans_imm_cast(bcx, val, expr.id)
+            trans_imm_cast(bcx, &**val, expr.id)
         }
         _ => {
             bcx.tcx().sess.span_bug(
@@ -589,8 +591,8 @@ fn trans_rvalue_stmt_unadjusted<'a>(bcx: &'a Block<'a>,
     }
 
     match expr.node {
-        ast::ExprParen(e) => {
-            trans_into(bcx, e, Ignore)
+        ast::ExprParen(ref e) => {
+            trans_into(bcx, &**e, Ignore)
         }
         ast::ExprBreak(label_opt) => {
             controlflow::trans_break(bcx, expr.id, label_opt)
@@ -601,15 +603,15 @@ fn trans_rvalue_stmt_unadjusted<'a>(bcx: &'a Block<'a>,
         ast::ExprRet(ex) => {
             controlflow::trans_ret(bcx, ex)
         }
-        ast::ExprWhile(cond, body) => {
-            controlflow::trans_while(bcx, expr.id, cond, body)
+        ast::ExprWhile(ref cond, ref body) => {
+            controlflow::trans_while(bcx, expr.id, &**cond, &**body)
         }
-        ast::ExprLoop(body, _) => {
-            controlflow::trans_loop(bcx, expr.id, body)
+        ast::ExprLoop(ref body, _) => {
+            controlflow::trans_loop(bcx, expr.id, &**body)
         }
-        ast::ExprAssign(dst, src) => {
-            let src_datum = unpack_datum!(bcx, trans(bcx, src));
-            let dst_datum = unpack_datum!(bcx, trans_to_lvalue(bcx, dst, "assign"));
+        ast::ExprAssign(ref dst, ref src) => {
+            let src_datum = unpack_datum!(bcx, trans(bcx, &**src));
+            let dst_datum = unpack_datum!(bcx, trans_to_lvalue(bcx, &**dst, "assign"));
 
             if ty::type_needs_drop(bcx.tcx(), dst_datum.ty) {
                 // If there are destructors involved, make sure we
@@ -636,8 +638,8 @@ fn trans_rvalue_stmt_unadjusted<'a>(bcx: &'a Block<'a>,
                 src_datum.store_to(bcx, dst_datum.val)
             }
         }
-        ast::ExprAssignOp(op, dst, src) => {
-            trans_assign_op(bcx, expr, op, dst, src)
+        ast::ExprAssignOp(op, ref dst, ref src) => {
+            trans_assign_op(bcx, expr, op, &**dst, src.clone())
         }
         ast::ExprInlineAsm(ref a) => {
             asm::trans_inline_asm(bcx, a)
@@ -662,20 +664,20 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
     let fcx = bcx.fcx;
 
     match expr.node {
-        ast::ExprParen(e) => {
-            trans_into(bcx, e, dest)
+        ast::ExprParen(ref e) => {
+            trans_into(bcx, &**e, dest)
         }
         ast::ExprPath(_) => {
             trans_def_dps_unadjusted(bcx, expr, bcx.def(expr.id), dest)
         }
-        ast::ExprIf(cond, thn, els) => {
-            controlflow::trans_if(bcx, expr.id, cond, thn, els, dest)
+        ast::ExprIf(ref cond, ref thn, els) => {
+            controlflow::trans_if(bcx, expr.id, &**cond, thn.clone(), els, dest)
         }
-        ast::ExprMatch(discr, ref arms) => {
-            _match::trans_match(bcx, expr, discr, arms.as_slice(), dest)
+        ast::ExprMatch(ref discr, ref arms) => {
+            _match::trans_match(bcx, expr, &**discr, arms.as_slice(), dest)
         }
-        ast::ExprBlock(blk) => {
-            controlflow::trans_block(bcx, blk, dest)
+        ast::ExprBlock(ref blk) => {
+            controlflow::trans_block(bcx, &**blk, dest)
         }
         ast::ExprStruct(_, ref fields, base) => {
             trans_rec_or_struct(bcx,
@@ -687,7 +689,7 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
         }
         ast::ExprTup(ref args) => {
             let repr = adt::represent_type(bcx.ccx(), expr_ty(bcx, expr));
-            let numbered_fields: Vec<(uint, @ast::Expr)> =
+            let numbered_fields: Vec<(uint, Gc<ast::Expr>)> =
                 args.iter().enumerate().map(|(i, arg)| (i, *arg)).collect();
             trans_adt(bcx, &*repr, 0, numbered_fields.as_slice(), None, dest)
         }
@@ -705,26 +707,26 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
                 }
             }
         }
-        ast::ExprVstore(contents, ast::ExprVstoreSlice) |
-        ast::ExprVstore(contents, ast::ExprVstoreMutSlice) => {
+        ast::ExprVstore(ref contents, ast::ExprVstoreSlice) |
+        ast::ExprVstore(ref contents, ast::ExprVstoreMutSlice) => {
             fcx.push_ast_cleanup_scope(contents.id);
-            bcx = tvec::trans_slice_vstore(bcx, expr, contents, dest);
+            bcx = tvec::trans_slice_vstore(bcx, expr, &**contents, dest);
             fcx.pop_and_trans_ast_cleanup_scope(bcx, contents.id)
         }
         ast::ExprVec(..) | ast::ExprRepeat(..) => {
             tvec::trans_fixed_vstore(bcx, expr, expr, dest)
         }
-        ast::ExprFnBlock(decl, body) |
-        ast::ExprProc(decl, body) => {
+        ast::ExprFnBlock(ref decl, ref body) |
+        ast::ExprProc(ref decl, ref body) => {
             let expr_ty = expr_ty(bcx, expr);
             let store = ty::ty_closure_store(expr_ty);
             debug!("translating block function {} with type {}",
                    expr_to_str(expr), expr_ty.repr(tcx));
-            closure::trans_expr_fn(bcx, store, decl, body, expr.id, dest)
+            closure::trans_expr_fn(bcx, store, &**decl, &**body, expr.id, dest)
         }
-        ast::ExprCall(f, ref args) => {
+        ast::ExprCall(ref f, ref args) => {
             if bcx.tcx().is_method_call(expr.id) {
-                let callee_datum = unpack_datum!(bcx, trans(bcx, f));
+                let callee_datum = unpack_datum!(bcx, trans(bcx, &**f));
                 trans_overloaded_call(bcx,
                                       expr,
                                       callee_datum,
@@ -733,7 +735,7 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
             } else {
                 callee::trans_call(bcx,
                                    expr,
-                                   f,
+                                   &**f,
                                    callee::ArgExprs(args.as_slice()),
                                    dest)
             }
@@ -741,35 +743,35 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
         ast::ExprMethodCall(_, _, ref args) => {
             callee::trans_method_call(bcx,
                                       expr,
-                                      *args.get(0),
+                                      &**args.get(0),
                                       callee::ArgExprs(args.as_slice()),
                                       dest)
         }
-        ast::ExprBinary(_, lhs, rhs) => {
+        ast::ExprBinary(_, ref lhs, ref rhs) => {
             // if not overloaded, would be RvalueDatumExpr
-            let lhs = unpack_datum!(bcx, trans(bcx, lhs));
-            let rhs_datum = unpack_datum!(bcx, trans(bcx, rhs));
+            let lhs = unpack_datum!(bcx, trans(bcx, &**lhs));
+            let rhs_datum = unpack_datum!(bcx, trans(bcx, &**rhs));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id), lhs,
                                 Some((rhs_datum, rhs.id)), Some(dest)).bcx
         }
-        ast::ExprUnary(_, subexpr) => {
+        ast::ExprUnary(_, ref subexpr) => {
             // if not overloaded, would be RvalueDatumExpr
-            let arg = unpack_datum!(bcx, trans(bcx, subexpr));
+            let arg = unpack_datum!(bcx, trans(bcx, &**subexpr));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id),
                                 arg, None, Some(dest)).bcx
         }
-        ast::ExprIndex(base, idx) => {
+        ast::ExprIndex(ref base, ref idx) => {
             // if not overloaded, would be RvalueDatumExpr
-            let base = unpack_datum!(bcx, trans(bcx, base));
-            let idx_datum = unpack_datum!(bcx, trans(bcx, idx));
+            let base = unpack_datum!(bcx, trans(bcx, &**base));
+            let idx_datum = unpack_datum!(bcx, trans(bcx, &**idx));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id), base,
                                 Some((idx_datum, idx.id)), Some(dest)).bcx
         }
-        ast::ExprCast(val, _) => {
+        ast::ExprCast(ref val, _) => {
             // DPS output mode means this is a trait cast:
             match ty::get(node_id_type(bcx, expr.id)).sty {
                 ty::ty_trait(..) => {
-                    let datum = unpack_datum!(bcx, trans(bcx, val));
+                    let datum = unpack_datum!(bcx, trans(bcx, &**val));
                     meth::trans_trait_cast(bcx, datum, expr.id, dest)
                 }
                 _ => {
@@ -778,8 +780,8 @@ fn trans_rvalue_dps_unadjusted<'a>(bcx: &'a Block<'a>,
                 }
             }
         }
-        ast::ExprAssignOp(op, dst, src) => {
-            trans_assign_op(bcx, expr, op, dst, src)
+        ast::ExprAssignOp(op, ref dst, ref src) => {
+            trans_assign_op(bcx, expr, op, &**dst, src.clone())
         }
         _ => {
             bcx.tcx().sess.span_bug(
@@ -978,7 +980,7 @@ pub fn with_field_tys<R>(tcx: &ty::ctxt,
 fn trans_rec_or_struct<'a>(
                        bcx: &'a Block<'a>,
                        fields: &[ast::Field],
-                       base: Option<@ast::Expr>,
+                       base: Option<Gc<ast::Expr>>,
                        expr_span: codemap::Span,
                        id: ast::NodeId,
                        dest: Dest)
@@ -1040,7 +1042,7 @@ fn trans_rec_or_struct<'a>(
  */
 struct StructBaseInfo {
     /// The base expression; will be evaluated after all explicit fields.
-    expr: @ast::Expr,
+    expr: Gc<ast::Expr>,
     /// The indices of fields to copy paired with their types.
     fields: Vec<(uint, ty::t)> }
 
@@ -1058,7 +1060,7 @@ fn trans_adt<'a>(
              bcx: &'a Block<'a>,
              repr: &adt::Repr,
              discr: ty::Disr,
-             fields: &[(uint, @ast::Expr)],
+             fields: &[(uint, Gc<ast::Expr>)],
              optbase: Option<StructBaseInfo>,
              dest: Dest)
              -> &'a Block<'a> {
@@ -1067,12 +1069,12 @@ fn trans_adt<'a>(
     let mut bcx = bcx;
     let addr = match dest {
         Ignore => {
-            for &(_i, e) in fields.iter() {
-                bcx = trans_into(bcx, e, Ignore);
+            for &(_i, ref e) in fields.iter() {
+                bcx = trans_into(bcx, &**e, Ignore);
             }
             for sbi in optbase.iter() {
                 // FIXME #7261: this moves entire base, not just certain fields
-                bcx = trans_into(bcx, sbi.expr, Ignore);
+                bcx = trans_into(bcx, &*sbi.expr, Ignore);
             }
             return bcx;
         }
@@ -1085,10 +1087,10 @@ fn trans_adt<'a>(
 
     adt::trans_start_init(bcx, repr, addr, discr);
 
-    for &(i, e) in fields.iter() {
+    for &(i, ref e) in fields.iter() {
         let dest = adt::trans_field_ptr(bcx, repr, addr, discr, i);
-        let e_ty = expr_ty_adjusted(bcx, e);
-        bcx = trans_into(bcx, e, SaveIn(dest));
+        let e_ty = expr_ty_adjusted(bcx, &**e);
+        bcx = trans_into(bcx, &**e, SaveIn(dest));
         fcx.schedule_drop_mem(cleanup::CustomScope(custom_cleanup_scope),
                               dest, e_ty);
     }
@@ -1096,7 +1098,7 @@ fn trans_adt<'a>(
     for base in optbase.iter() {
         // FIXME #6573: is it sound to use the destination's repr on the base?
         // And, would it ever be reasonable to be here with discr != 0?
-        let base_datum = unpack_datum!(bcx, trans_to_lvalue(bcx, base.expr, "base"));
+        let base_datum = unpack_datum!(bcx, trans_to_lvalue(bcx, &*base.expr, "base"));
         for &(i, t) in base.fields.iter() {
             let datum = base_datum.get_element(
                 t,
@@ -1458,16 +1460,16 @@ fn trans_overloaded_call<'a>(
                          mut bcx: &'a Block<'a>,
                          expr: &ast::Expr,
                          callee: Datum<Expr>,
-                         args: &[@ast::Expr],
+                         args: &[Gc<ast::Expr>],
                          dest: Option<Dest>)
                          -> &'a Block<'a> {
     // Evaluate and tuple the arguments.
     let tuple_type = ty::mk_tup(bcx.tcx(),
                                 args.iter()
-                                    .map(|e| expr_ty(bcx, *e))
+                                    .map(|e| expr_ty(bcx, &**e))
                                     .collect());
     let repr = adt::represent_type(bcx.ccx(), tuple_type);
-    let numbered_fields: Vec<(uint, @ast::Expr)> =
+    let numbered_fields: Vec<(uint, Gc<ast::Expr>)> =
         args.iter().enumerate().map(|(i, arg)| (i, *arg)).collect();
     let argument_scope = bcx.fcx.push_custom_cleanup_scope();
     let tuple_datum =
@@ -1679,7 +1681,7 @@ fn trans_assign_op<'a>(
                    expr: &ast::Expr,
                    op: ast::BinOp,
                    dst: &ast::Expr,
-                   src: @ast::Expr)
+                   src: Gc<ast::Expr>)
                    -> &'a Block<'a> {
     let _icx = push_ctxt("trans_assign_op");
     let mut bcx = bcx;
@@ -1696,7 +1698,7 @@ fn trans_assign_op<'a>(
     let dst = Load(bcx, dst_datum.val);
 
     // Evaluate RHS
-    let rhs_datum = unpack_datum!(bcx, trans(bcx, src));
+    let rhs_datum = unpack_datum!(bcx, trans(bcx, &*src));
     let rhs_ty = rhs_datum.ty;
     let rhs = rhs_datum.to_llscalarish(bcx);
 

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -443,8 +443,8 @@ pub fn trans_native_call<'a>(
 
 pub fn trans_foreign_mod(ccx: &CrateContext, foreign_mod: &ast::ForeignMod) {
     let _icx = push_ctxt("foreign::trans_foreign_mod");
-    for &foreign_item in foreign_mod.items.iter() {
-        let lname = link_name(foreign_item);
+    for foreign_item in foreign_mod.items.iter() {
+        let lname = link_name(&**foreign_item);
 
         match foreign_item.node {
             ast::ForeignItemFn(..) => {

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -51,7 +51,7 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             ccx.external_srcs.borrow_mut().insert(item.id, fn_id);
 
             ccx.stats.n_inlines.set(ccx.stats.n_inlines.get() + 1);
-            trans_item(ccx, item);
+            trans_item(ccx, &*item);
 
             // We're bringing an external global into this crate, but we don't
             // want to create two copies of the global. If we do this, then if
@@ -107,7 +107,7 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             _ => ccx.sess().bug("maybe_instantiate_inline: item has a \
                                  non-enum, non-struct parent")
           }
-          trans_item(ccx, item);
+          trans_item(ccx, &*item);
           local_def(my_id)
         }
         csearch::found_parent(_, _) => {
@@ -131,7 +131,7 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
 
           if num_type_params == 0 {
               let llfn = get_item_val(ccx, mth.id);
-              trans_fn(ccx, mth.decl, mth.body, llfn,
+              trans_fn(ccx, &*mth.decl, &*mth.body, llfn,
                        &param_substs::empty(), mth.id, []);
           }
           local_def(mth.id)

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -35,6 +35,7 @@ use util::common::indenter;
 use util::ppaux::Repr;
 
 use std::c_str::ToCStr;
+use std::gc::Gc;
 use syntax::abi::Rust;
 use syntax::parse::token;
 use syntax::{ast, ast_map, visit};
@@ -47,7 +48,7 @@ see `trans::base::lval_static_fn()` or `trans::base::monomorphic_fn()`.
 */
 pub fn trans_impl(ccx: &CrateContext,
                   name: ast::Ident,
-                  methods: &[@ast::Method],
+                  methods: &[Gc<ast::Method>],
                   generics: &ast::Generics,
                   id: ast::NodeId) {
     let _icx = push_ctxt("meth::trans_impl");
@@ -60,18 +61,18 @@ pub fn trans_impl(ccx: &CrateContext,
     if !generics.ty_params.is_empty() {
         let mut v = TransItemVisitor{ ccx: ccx };
         for method in methods.iter() {
-            visit::walk_method_helper(&mut v, *method, ());
+            visit::walk_method_helper(&mut v, &**method, ());
         }
         return;
     }
     for method in methods.iter() {
         if method.generics.ty_params.len() == 0u {
             let llfn = get_item_val(ccx, method.id);
-            trans_fn(ccx, method.decl, method.body,
+            trans_fn(ccx, &*method.decl, &*method.body,
                      llfn, &param_substs::empty(), method.id, []);
         } else {
             let mut v = TransItemVisitor{ ccx: ccx };
-            visit::walk_method_helper(&mut v, *method, ());
+            visit::walk_method_helper(&mut v, &**method, ());
         }
     }
 }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -201,12 +201,12 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         ast_map::NodeItem(i) => {
             match *i {
               ast::Item {
-                  node: ast::ItemFn(decl, _, _, _, body),
+                  node: ast::ItemFn(ref decl, _, _, _, ref body),
                   ..
               } => {
                   let d = mk_lldecl();
                   set_llvm_fn_attrs(i.attrs.as_slice(), d);
-                  trans_fn(ccx, decl, body, d, &psubsts, fn_id.node, []);
+                  trans_fn(ccx, &**decl, &**body, d, &psubsts, fn_id.node, []);
                   d
               }
               _ => {
@@ -215,12 +215,12 @@ pub fn monomorphic_fn(ccx: &CrateContext,
             }
         }
         ast_map::NodeForeignItem(i) => {
-            let simple = intrinsic::get_simple_intrinsic(ccx, i);
+            let simple = intrinsic::get_simple_intrinsic(ccx, &*i);
             match simple {
                 Some(decl) => decl,
                 None => {
                     let d = mk_lldecl();
-                    intrinsic::trans_intrinsic(ccx, d, i, &psubsts, ref_id);
+                    intrinsic::trans_intrinsic(ccx, d, &*i, &psubsts, ref_id);
                     d
                 }
             }
@@ -235,7 +235,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                 ast::TupleVariantKind(ref args) => {
                     trans_enum_variant(ccx,
                                        parent,
-                                       v,
+                                       &*v,
                                        args.as_slice(),
                                        this_tv.disr_val,
                                        &psubsts,
@@ -249,7 +249,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         ast_map::NodeMethod(mth) => {
             let d = mk_lldecl();
             set_llvm_fn_attrs(mth.attrs.as_slice(), d);
-            trans_fn(ccx, mth.decl, mth.body, d, &psubsts, mth.id, []);
+            trans_fn(ccx, &*mth.decl, &*mth.body, d, &psubsts, mth.id, []);
             d
         }
         ast_map::NodeTraitMethod(method) => {
@@ -257,7 +257,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                 ast::Provided(mth) => {
                     let d = mk_lldecl();
                     set_llvm_fn_attrs(mth.attrs.as_slice(), d);
-                    trans_fn(ccx, mth.decl, mth.body, d, &psubsts, mth.id, []);
+                    trans_fn(ccx, &*mth.decl, &*mth.body, d, &psubsts, mth.id, []);
                     d
                 }
                 _ => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -42,6 +42,7 @@ use std::cmp;
 use std::fmt::Show;
 use std::fmt;
 use std::hash::{Hash, sip, Writer};
+use std::gc::Gc;
 use std::iter::AdditiveIterator;
 use std::mem;
 use std::ops;
@@ -348,8 +349,8 @@ pub struct ctxt {
 
     /// These two caches are used by const_eval when decoding external statics
     /// and variants that are found.
-    pub extern_const_statics: RefCell<DefIdMap<Option<@ast::Expr>>>,
-    pub extern_const_variants: RefCell<DefIdMap<Option<@ast::Expr>>>,
+    pub extern_const_statics: RefCell<DefIdMap<Option<Gc<ast::Expr>>>>,
+    pub extern_const_variants: RefCell<DefIdMap<Option<Gc<ast::Expr>>>>,
 
     pub method_map: typeck::MethodMap,
     pub vtable_map: typeck::vtable_map,
@@ -3122,7 +3123,7 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
             }
         }
 
-        ast::ExprParen(e) => expr_kind(tcx, e),
+        ast::ExprParen(ref e) => expr_kind(tcx, &**e),
 
         ast::ExprMac(..) => {
             tcx.sess.span_bug(
@@ -3181,7 +3182,7 @@ pub fn ty_sort_str(cx: &ctxt, t: t) -> String {
         }
 
         ty_enum(id, _) => format!("enum {}", item_path_str(cx, id)),
-        ty_box(_) => "@-ptr".to_string(),
+        ty_box(_) => "Gc-ptr".to_string(),
         ty_uniq(_) => "box".to_string(),
         ty_vec(_, _) => "vector".to_string(),
         ty_ptr(_) => "*-ptr".to_string(),
@@ -3740,7 +3741,7 @@ pub fn enum_variants(cx: &ctxt, id: ast::DefId) -> Rc<Vec<Rc<VariantInfo>>> {
                             };
 
                             match variant.node.disr_expr {
-                                Some(e) => match const_eval::eval_const_expr_partial(cx, e) {
+                                Some(ref e) => match const_eval::eval_const_expr_partial(cx, &**e) {
                                     Ok(const_eval::const_int(val)) => {
                                         discriminant = val as Disr
                                     }
@@ -3763,7 +3764,7 @@ pub fn enum_variants(cx: &ctxt, id: ast::DefId) -> Rc<Vec<Rc<VariantInfo>>> {
                             };
 
                             last_discriminant = Some(discriminant);
-                            Rc::new(VariantInfo::from_ast_variant(cx, variant,
+                            Rc::new(VariantInfo::from_ast_variant(cx, &*variant,
                                                                   discriminant))
                         }).collect())
                     }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -230,7 +230,7 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
     }
 
     let tps = path.segments.iter().flat_map(|s| s.types.iter())
-                            .map(|&a_t| ast_ty_to_ty(this, rscope, a_t))
+                            .map(|a_t| ast_ty_to_ty(this, rscope, &**a_t))
                             .collect();
 
     let mut substs = subst::Substs {
@@ -451,12 +451,12 @@ pub fn ast_ty_to_builtin_ty<AC:AstConv,
                                               supplied to `Box<T>`");
                     Some(ty::mk_err())
                 }
-                ast::DefTy(did) | ast::DefStruct(did)
+                def::DefTy(did) | def::DefStruct(did)
                         if Some(did) == this.tcx().lang_items.gc() => {
                     if path.segments
                            .iter()
                            .flat_map(|s| s.types.iter())
-                           .len() > 1 {
+                           .count() > 1 {
                         this.tcx()
                             .sess
                             .span_err(path.span,
@@ -532,12 +532,12 @@ pub fn trait_ref_for_unboxed_function<AC:AstConv,
                         .inputs
                         .iter()
                         .map(|input| {
-                            ast_ty_to_ty(this, rscope, input.ty)
+                            ast_ty_to_ty(this, rscope, &*input.ty)
                         }).collect::<Vec<_>>();
     let input_tuple = ty::mk_tup(this.tcx(), input_types);
     let output_type = ast_ty_to_ty(this,
                                    rscope,
-                                   unboxed_function.decl.output);
+                                   &*unboxed_function.decl.output);
     let substs = subst::Substs {
         self_ty: None,
         tps: vec!(input_tuple, output_type),
@@ -564,8 +564,8 @@ fn mk_pointer<AC:AstConv,
     debug!("mk_pointer(ptr_ty={:?})", ptr_ty);
 
     match a_seq_ty.ty.node {
-        ast::TyVec(ty) => {
-            let mut mt = ast_ty_to_mt(this, rscope, ty);
+        ast::TyVec(ref ty) => {
+            let mut mt = ast_ty_to_mt(this, rscope, &**ty);
             if a_seq_ty.mutbl == ast::MutMutable {
                 mt.mutbl = ast::MutMutable;
             }
@@ -590,7 +590,7 @@ fn mk_pointer<AC:AstConv,
                 substs
             } = trait_ref_for_unboxed_function(this,
                                                rscope,
-                                               *unboxed_function);
+                                               &**unboxed_function);
             return ty::mk_trait(this.tcx(),
                                 def_id,
                                 substs,
@@ -650,7 +650,7 @@ fn mk_pointer<AC:AstConv,
         _ => {}
     }
 
-    constr(ast_ty_to_ty(this, rscope, a_seq_ty.ty))
+    constr(ast_ty_to_ty(this, rscope, &*a_seq_ty.ty))
 }
 
 // Parses the programmer's textual representation of a type into our
@@ -690,12 +690,12 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
             ast::TyVec(ty) => {
                 tcx.sess.span_err(ast_ty.span, "bare `[]` is not a type");
                 // return /something/ so they can at least get more errors
-                let vec_ty = ty::mk_vec(tcx, ast_ty_to_mt(this, rscope, ty), None);
+                let vec_ty = ty::mk_vec(tcx, ast_ty_to_mt(this, rscope, &*ty), None);
                 ty::mk_uniq(tcx, vec_ty)
             }
             ast::TyPtr(ref mt) => {
                 ty::mk_ptr(tcx, ty::mt {
-                    ty: ast_ty_to_ty(this, rscope, mt.ty),
+                    ty: ast_ty_to_ty(this, rscope, &*mt.ty),
                     mutbl: mt.mutbl
                 })
             }
@@ -707,7 +707,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
             }
             ast::TyTup(ref fields) => {
                 let flds = fields.iter()
-                                 .map(|&t| ast_ty_to_ty(this, rscope, t))
+                                 .map(|t| ast_ty_to_ty(this, rscope, &**t))
                                  .collect();
                 ty::mk_tup(tcx, flds)
             }
@@ -717,7 +717,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                                       "variadic function must have C calling convention");
                 }
                 ty::mk_bare_fn(tcx, ty_of_bare_fn(this, ast_ty.id, bf.fn_style,
-                                                  bf.abi, bf.decl))
+                                                  bf.abi, &*bf.decl))
             }
             ast::TyClosure(ref f, ref region) => {
 
@@ -741,7 +741,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                                             f.onceness,
                                             bounds,
                                             store,
-                                            f.decl,
+                                            &*f.decl,
                                             None);
                 ty::mk_closure(tcx, fn_decl)
             }
@@ -759,7 +759,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                                             f.onceness,
                                             bounds,
                                             ty::UniqTraitStore,
-                                            f.decl,
+                                            &*f.decl,
                                             None);
                 ty::mk_closure(tcx, fn_decl)
             }
@@ -830,14 +830,14 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                 }
             }
             ast::TyFixedLengthVec(ty, e) => {
-                match const_eval::eval_const_expr_partial(tcx, e) {
+                match const_eval::eval_const_expr_partial(tcx, &*e) {
                     Ok(ref r) => {
                         match *r {
                             const_eval::const_int(i) =>
-                                ty::mk_vec(tcx, ast_ty_to_mt(this, rscope, ty),
+                                ty::mk_vec(tcx, ast_ty_to_mt(this, rscope, &*ty),
                                            Some(i as uint)),
                             const_eval::const_uint(i) =>
-                                ty::mk_vec(tcx, ast_ty_to_mt(this, rscope, ty),
+                                ty::mk_vec(tcx, ast_ty_to_mt(this, rscope, &*ty),
                                            Some(i as uint)),
                             _ => {
                                 tcx.sess.span_fatal(
@@ -876,7 +876,7 @@ pub fn ty_of_arg<AC: AstConv, RS: RegionScope>(this: &AC, rscope: &RS, a: &ast::
     match a.ty.node {
         ast::TyInfer if expected_ty.is_some() => expected_ty.unwrap(),
         ast::TyInfer => this.ty_infer(a.ty.span),
-        _ => ast_ty_to_ty(this, rscope, a.ty),
+        _ => ast_ty_to_ty(this, rscope, &*a.ty),
     }
 }
 
@@ -947,7 +947,7 @@ fn ty_of_method_or_bare_fn<AC:AstConv>(this: &AC, id: ast::NodeId,
 
     let output_ty = match decl.output.node {
         ast::TyInfer => this.ty_infer(decl.output.span),
-        _ => ast_ty_to_ty(this, &rb, decl.output)
+        _ => ast_ty_to_ty(this, &rb, &*decl.output)
     };
 
     return ty::BareFnTy {
@@ -996,7 +996,7 @@ pub fn ty_of_closure<AC:AstConv>(
     let output_ty = match decl.output.node {
         ast::TyInfer if expected_ret_ty.is_some() => expected_ret_ty.unwrap(),
         ast::TyInfer => this.ty_infer(decl.output.span),
-        _ => ast_ty_to_ty(this, &rb, decl.output)
+        _ => ast_ty_to_ty(this, &rb, &*decl.output)
     };
 
     ty::ClosureTy {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -79,8 +79,6 @@ type parameter).
 
 use middle::const_eval;
 use middle::def;
-use middle::lang_items::{ExchangeHeapLangItem, GcLangItem};
-use middle::lang_items::{ManagedHeapLangItem};
 use middle::lint::UnreachableCode;
 use middle::pat_util::pat_id_map;
 use middle::pat_util;
@@ -121,7 +119,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::mem::replace;
 use std::rc::Rc;
-use std::vec::Vec;
+use std::gc::Gc;
 use syntax::abi;
 use syntax::ast::{Provided, Required};
 use syntax::ast;
@@ -382,11 +380,11 @@ impl<'a> Visitor<()> for GatherLocalsVisitor<'a> {
     fn visit_local(&mut self, local: &ast::Local, _: ()) {
         let o_ty = match local.ty.node {
             ast::TyInfer => None,
-            _ => Some(self.fcx.to_ty(local.ty))
+            _ => Some(self.fcx.to_ty(&*local.ty))
         };
         self.assign(local.id, o_ty);
         debug!("Local variable {} is assigned type {}",
-               self.fcx.pat_to_str(local.pat),
+               self.fcx.pat_to_str(&*local.pat),
                self.fcx.infcx().ty_to_str(
                    self.fcx.inh.locals.borrow().get_copy(&local.id)));
         visit::walk_local(self, local, ());
@@ -478,7 +476,7 @@ fn check_fn<'a>(ccx: &'a CrateCtxt<'a>,
         for (arg_ty, input) in arg_tys.iter().zip(decl.inputs.iter()) {
             // Create type variables for each argument.
             pat_util::pat_bindings(&tcx.def_map,
-                                   input.pat,
+                                   &*input.pat,
                                    |_bm, pat_id, _sp, _path| {
                                        visit.assign(pat_id, None);
                                    });
@@ -486,9 +484,9 @@ fn check_fn<'a>(ccx: &'a CrateCtxt<'a>,
             // Check the pattern.
             let pcx = pat_ctxt {
                 fcx: &fcx,
-                map: pat_id_map(&tcx.def_map, input.pat),
+                map: pat_id_map(&tcx.def_map, &*input.pat),
             };
-            _match::check_pat(&pcx, input.pat, *arg_ty);
+            _match::check_pat(&pcx, &*input.pat, *arg_ty);
         }
 
         visit.visit_block(body, ());
@@ -499,11 +497,11 @@ fn check_fn<'a>(ccx: &'a CrateCtxt<'a>,
     // We unify the tail expr's type with the
     // function result type, if there is a tail expr.
     match body.expr {
-        Some(tail_expr) => {
+        Some(ref tail_expr) => {
             // Special case: we print a special error if there appears
             // to be do-block/for-loop confusion
             demand::suptype_with_fn(&fcx, tail_expr.span, false,
-                fcx.ret_ty, fcx.expr_ty(tail_expr),
+                fcx.ret_ty, fcx.expr_ty(&**tail_expr),
                 |sp, e, a, s| {
                     fcx.report_mismatched_return_types(sp, e, a, s);
                 });
@@ -626,7 +624,7 @@ pub fn check_item_sized(ccx: &CrateCtxt, it: &ast::Item) {
                                       enum_definition.variants.as_slice());
         }
         ast::ItemStruct(..) => {
-            check_fields_sized(ccx.tcx, ccx.tcx.map.expect_struct(it.id));
+            check_fields_sized(ccx.tcx, &*ccx.tcx.map.expect_struct(it.id));
         }
         _ => {}
     }
@@ -639,14 +637,14 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
     let _indenter = indenter();
 
     match it.node {
-      ast::ItemStatic(_, _, e) => check_const(ccx, it.span, e, it.id),
+      ast::ItemStatic(_, _, ref e) => check_const(ccx, it.span, &**e, it.id),
       ast::ItemEnum(ref enum_definition, _) => {
         check_enum_variants(ccx,
                             it.span,
                             enum_definition.variants.as_slice(),
                             it.id);
       }
-      ast::ItemFn(decl, _, _, _, body) => {
+      ast::ItemFn(ref decl, _, _, _, ref body) => {
         let fn_tpt = ty::lookup_item_type(ccx.tcx, ast_util::local_def(it.id));
 
         let param_env = ty::construct_parameter_environment(
@@ -658,14 +656,14 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
                 fn_tpt.generics.region_param_defs.as_slice(),
                 body.id);
 
-        check_bare_fn(ccx, decl, body, it.id, fn_tpt.ty, param_env);
+        check_bare_fn(ccx, &**decl, &**body, it.id, fn_tpt.ty, param_env);
       }
       ast::ItemImpl(_, ref opt_trait_ref, _, ref ms) => {
         debug!("ItemImpl {} with id {}", token::get_ident(it.ident), it.id);
 
         let impl_tpt = ty::lookup_item_type(ccx.tcx, ast_util::local_def(it.id));
         for m in ms.iter() {
-            check_method_body(ccx, &impl_tpt.generics, None, *m);
+            check_method_body(ccx, &impl_tpt.generics, None, &**m);
         }
 
         match *opt_trait_ref {
@@ -694,7 +692,7 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
                 }
                 Provided(m) => {
                     check_method_body(ccx, &trait_def.generics,
-                                      Some(trait_def.trait_ref.clone()), m);
+                                      Some(trait_def.trait_ref.clone()), &*m);
                 }
             }
         }
@@ -709,7 +707,7 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
       ast::ItemForeignMod(ref m) => {
         if m.abi == abi::RustIntrinsic {
             for item in m.items.iter() {
-                check_intrinsic_type(ccx, *item);
+                check_intrinsic_type(ccx, &**item);
             }
         } else {
             for item in m.items.iter() {
@@ -770,7 +768,7 @@ fn check_method_body(ccx: &CrateCtxt,
 
     let fty = ty::node_id_to_type(ccx.tcx, method.id);
 
-    check_bare_fn(ccx, method.decl, method.body, method.id, fty, param_env);
+    check_bare_fn(ccx, &*method.decl, &*method.body, method.id, fty, param_env);
 }
 
 fn check_impl_methods_against_trait(ccx: &CrateCtxt,
@@ -778,7 +776,7 @@ fn check_impl_methods_against_trait(ccx: &CrateCtxt,
                                     impl_generics: &ty::Generics,
                                     ast_trait_ref: &ast::TraitRef,
                                     impl_trait_ref: &ty::TraitRef,
-                                    impl_methods: &[@ast::Method]) {
+                                    impl_methods: &[Gc<ast::Method>]) {
     // Locate trait methods
     let tcx = ccx.tcx;
     let trait_methods = ty::trait_methods(tcx, impl_trait_ref.def_id);
@@ -1356,9 +1354,9 @@ pub fn autoderef<T>(fcx: &FnCtxt, sp: Span, base_ty: ty::t,
 /// Attempts to resolve a call expression as an overloaded call.
 fn try_overloaded_call(fcx: &FnCtxt,
                        call_expression: &ast::Expr,
-                       callee: @ast::Expr,
+                       callee: Gc<ast::Expr>,
                        callee_type: ty::t,
-                       args: &[@ast::Expr])
+                       args: &[Gc<ast::Expr>])
                        -> bool {
     // Try `FnOnce`, then `FnMut`, then `Fn`.
     for &(maybe_function_trait, method_name) in [
@@ -1454,7 +1452,7 @@ fn check_method_argument_types(fcx: &FnCtxt,
                                sp: Span,
                                method_fn_ty: ty::t,
                                callee_expr: &ast::Expr,
-                               args: &[@ast::Expr],
+                               args: &[Gc<ast::Expr>],
                                deref_args: DerefArgs,
                                tuple_arguments: TupleArgumentsFlag)
                                -> ty::t {
@@ -1501,7 +1499,7 @@ fn check_argument_types(fcx: &FnCtxt,
                         sp: Span,
                         fn_inputs: &[ty::t],
                         callee_expr: &ast::Expr,
-                        args: &[@ast::Expr],
+                        args: &[Gc<ast::Expr>],
                         deref_args: DerefArgs,
                         variadic: bool,
                         tuple_arguments: TupleArgumentsFlag) {
@@ -1654,7 +1652,7 @@ fn check_argument_types(fcx: &FnCtxt,
                     DontDerefArgs => {}
                 }
 
-                check_expr_coercable_to_type(fcx, *arg, formal_ty);
+                check_expr_coercable_to_type(fcx, &**arg, formal_ty);
 
             }
         }
@@ -1664,11 +1662,12 @@ fn check_argument_types(fcx: &FnCtxt,
     // arguments which we skipped above.
     if variadic {
         for arg in args.iter().skip(expected_arg_count) {
-            check_expr(fcx, *arg);
+            check_expr(fcx, &**arg);
 
             // There are a few types which get autopromoted when passed via varargs
             // in C but we just error out instead and require explicit casts.
-            let arg_ty = structurally_resolved_type(fcx, arg.span, fcx.expr_ty(*arg));
+            let arg_ty = structurally_resolved_type(fcx, arg.span,
+                                                    fcx.expr_ty(&**arg));
             match ty::get(arg_ty).sty {
                 ty::ty_float(ast::TyF32) => {
                     fcx.type_error_message(arg.span,
@@ -2040,7 +2039,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
     fn check_call(fcx: &FnCtxt,
                   call_expr: &ast::Expr,
                   f: &ast::Expr,
-                  args: &[@ast::Expr]) {
+                  args: &[Gc<ast::Expr>]) {
         // Store the type of `f` as the type of the callee
         let fn_ty = fcx.expr_ty(f);
 
@@ -2091,21 +2090,21 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
     fn check_method_call(fcx: &FnCtxt,
                          expr: &ast::Expr,
                          method_name: ast::SpannedIdent,
-                         args: &[@ast::Expr],
+                         args: &[Gc<ast::Expr>],
                          tps: &[ast::P<ast::Ty>]) {
-        let rcvr = args[0];
+        let rcvr = args[0].clone();
         // We can't know if we need &mut self before we look up the method,
         // so treat the receiver as mutable just in case - only explicit
         // overloaded dereferences care about the distinction.
-        check_expr_with_lvalue_pref(fcx, rcvr, PreferMutLvalue);
+        check_expr_with_lvalue_pref(fcx, &*rcvr, PreferMutLvalue);
 
         // no need to check for bot/err -- callee does that
         let expr_t = structurally_resolved_type(fcx,
                                                 expr.span,
-                                                fcx.expr_ty(rcvr));
+                                                fcx.expr_ty(&*rcvr));
 
-        let tps = tps.iter().map(|&ast_ty| fcx.to_ty(ast_ty)).collect::<Vec<_>>();
-        let fn_ty = match method::lookup(fcx, expr, rcvr,
+        let tps = tps.iter().map(|ast_ty| fcx.to_ty(&**ast_ty)).collect::<Vec<_>>();
+        let fn_ty = match method::lookup(fcx, expr, &*rcvr,
                                          method_name.node.name,
                                          expr_t, tps.as_slice(),
                                          DontDerefArgs,
@@ -2136,7 +2135,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 // Check for potential static matches (missing self parameters)
                 method::lookup(fcx,
                                expr,
-                               rcvr,
+                               &*rcvr,
                                method_name.node.name,
                                expr_t,
                                tps.as_slice(),
@@ -2166,18 +2165,18 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
     fn check_then_else(fcx: &FnCtxt,
                        cond_expr: &ast::Expr,
                        then_blk: &ast::Block,
-                       opt_else_expr: Option<@ast::Expr>,
+                       opt_else_expr: Option<Gc<ast::Expr>>,
                        id: ast::NodeId,
                        sp: Span,
                        expected: Option<ty::t>) {
         check_expr_has_type(fcx, cond_expr, ty::mk_bool());
 
         let branches_ty = match opt_else_expr {
-            Some(else_expr) => {
+            Some(ref else_expr) => {
                 check_block_with_expected(fcx, then_blk, expected);
                 let then_ty = fcx.node_ty(then_blk.id);
-                check_expr_with_opt_hint(fcx, else_expr, expected);
-                let else_ty = fcx.expr_ty(else_expr);
+                check_expr_with_opt_hint(fcx, &**else_expr, expected);
+                let else_ty = fcx.expr_ty(&**else_expr);
                 infer::common_supertype(fcx.infcx(),
                                         infer::IfExpression(sp),
                                         true,
@@ -2207,7 +2206,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                         self_t: ty::t,
                         opname: ast::Name,
                         trait_did: Option<ast::DefId>,
-                        args: &[@ast::Expr],
+                        args: &[Gc<ast::Expr>],
                         autoderef_receiver: AutoderefReceiverFlag,
                         unbound_method: ||) -> ty::t {
         let method = match trait_did {
@@ -2253,8 +2252,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
     fn check_binop(fcx: &FnCtxt,
                    expr: &ast::Expr,
                    op: ast::BinOp,
-                   lhs: @ast::Expr,
-                   rhs: @ast::Expr,
+                   lhs: Gc<ast::Expr>,
+                   rhs: Gc<ast::Expr>,
                    is_binop_assignment: IsBinopAssignment) {
         let tcx = fcx.ccx.tcx;
 
@@ -2262,16 +2261,16 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             BinopAssignment => PreferMutLvalue,
             SimpleBinop => NoPreference
         };
-        check_expr_with_lvalue_pref(fcx, lhs, lvalue_pref);
+        check_expr_with_lvalue_pref(fcx, &*lhs, lvalue_pref);
 
         // Callee does bot / err checking
         let lhs_t = structurally_resolved_type(fcx, lhs.span,
-                                               fcx.expr_ty(lhs));
+                                               fcx.expr_ty(&*lhs));
 
         if ty::type_is_integral(lhs_t) && ast_util::is_shift_binop(op) {
             // Shift is a special case: rhs can be any integral type
-            check_expr(fcx, rhs);
-            let rhs_t = fcx.expr_ty(rhs);
+            check_expr(fcx, &*rhs);
+            let rhs_t = fcx.expr_ty(&*rhs);
             require_integral(fcx, rhs.span, rhs_t);
             fcx.write_ty(expr.id, lhs_t);
             return;
@@ -2280,7 +2279,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         if ty::is_binopable(tcx, lhs_t, op) {
             let tvar = fcx.infcx().next_ty_var();
             demand::suptype(fcx, expr.span, tvar, lhs_t);
-            check_expr_has_type(fcx, rhs, tvar);
+            check_expr_has_type(fcx, &*rhs, tvar);
 
             let result_t = match op {
                 ast::BiEq | ast::BiNe | ast::BiLt | ast::BiLe | ast::BiGe |
@@ -2345,7 +2344,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                    },
                                    lhs_t,
                                    None);
-            check_expr(fcx, rhs);
+            check_expr(fcx, &*rhs);
             ty::mk_err()
         };
 
@@ -2357,10 +2356,10 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
 
     fn check_user_binop(fcx: &FnCtxt,
                         ex: &ast::Expr,
-                        lhs_expr: @ast::Expr,
+                        lhs_expr: Gc<ast::Expr>,
                         lhs_resolved_t: ty::t,
                         op: ast::BinOp,
-                        rhs: @ast::Expr) -> ty::t {
+                        rhs: Gc<ast::Expr>) -> ty::t {
         let tcx = fcx.ccx.tcx;
         let lang = &tcx.lang_items;
         let (name, trait_did) = match op {
@@ -2381,7 +2380,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             ast::BiEq => ("eq", lang.eq_trait()),
             ast::BiNe => ("ne", lang.eq_trait()),
             ast::BiAnd | ast::BiOr => {
-                check_expr(fcx, rhs);
+                check_expr(fcx, &*rhs);
                 return ty::mk_err();
             }
         };
@@ -2400,7 +2399,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                        mname: &str,
                        trait_did: Option<ast::DefId>,
                        ex: &ast::Expr,
-                       rhs_expr: @ast::Expr,
+                       rhs_expr: Gc<ast::Expr>,
                        rhs_t: ty::t) -> ty::t {
        lookup_op_method(fcx, ex, rhs_t, token::intern(mname),
                         trait_did, [rhs_expr], DontAutoderefReceiver, || {
@@ -2513,7 +2512,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         };
 
         check_fn(fcx.ccx, inherited_style, &fty_sig,
-                 decl, id, body, fcx.inh);
+                 &*decl, id, &*body, fcx.inh);
     }
 
 
@@ -2549,7 +2548,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             None => {}
         }
 
-        let tps: Vec<ty::t> = tys.iter().map(|&ty| fcx.to_ty(ty)).collect();
+        let tps: Vec<ty::t> = tys.iter().map(|ty| fcx.to_ty(&**ty)).collect();
         match method::lookup(fcx,
                              expr,
                              base,
@@ -2647,7 +2646,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             // an error, so we can continue typechecking
             check_expr_coercable_to_type(
                     fcx,
-                    field.expr,
+                    &*field.expr,
                     expected_field_type);
         }
 
@@ -2688,7 +2687,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                 span: codemap::Span,
                                 class_id: ast::DefId,
                                 fields: &[ast::Field],
-                                base_expr: Option<@ast::Expr>) {
+                                base_expr: Option<Gc<ast::Expr>>) {
         let tcx = fcx.ccx.tcx;
 
         // Look up the number of type parameters and the raw type, and
@@ -2728,7 +2727,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         match base_expr {
             None => {}
             Some(base_expr) => {
-                check_expr_has_type(fcx, base_expr, struct_type);
+                check_expr_has_type(fcx, &*base_expr, struct_type);
                 if ty::type_is_bot(fcx.node_ty(base_expr.id)) {
                     struct_type = ty::mk_bot();
                 }
@@ -2793,8 +2792,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                     let mut any_bot = false;
                     let t: ty::t = fcx.infcx().next_ty_var();
                     for e in args.iter() {
-                        check_expr_has_type(fcx, *e, t);
-                        let arg_t = fcx.expr_ty(*e);
+                        check_expr_has_type(fcx, &**e, t);
+                        let arg_t = fcx.expr_ty(&**e);
                         if ty::type_is_error(arg_t) {
                             any_error = true;
                         }
@@ -2807,29 +2806,29 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                     } else if any_bot {
                         ty::mk_bot()
                     } else {
-                        ast_expr_vstore_to_ty(fcx, ev, vst, ||
+                        ast_expr_vstore_to_ty(fcx, &*ev, vst, ||
                             ty::mt{ ty: ty::mk_vec(tcx,
                                                    ty::mt {ty: t, mutbl: mutability},
                                                    None),
                                                    mutbl: mutability })
                     }
                 }
-                ast::ExprRepeat(element, count_expr) => {
-                    check_expr_with_hint(fcx, count_expr, ty::mk_uint());
-                    let _ = ty::eval_repeat_count(fcx, count_expr);
+                ast::ExprRepeat(ref element, ref count_expr) => {
+                    check_expr_with_hint(fcx, &**count_expr, ty::mk_uint());
+                    let _ = ty::eval_repeat_count(fcx, &**count_expr);
                     let mutability = match vst {
                         ast::ExprVstoreMutSlice => ast::MutMutable,
                         _ => ast::MutImmutable,
                     };
                     let t = fcx.infcx().next_ty_var();
-                    check_expr_has_type(fcx, element, t);
-                    let arg_t = fcx.expr_ty(element);
+                    check_expr_has_type(fcx, &**element, t);
+                    let arg_t = fcx.expr_ty(&**element);
                     if ty::type_is_error(arg_t) {
                         ty::mk_err()
                     } else if ty::type_is_bot(arg_t) {
                         ty::mk_bot()
                     } else {
-                        ast_expr_vstore_to_ty(fcx, ev, vst, ||
+                        ast_expr_vstore_to_ty(fcx, &*ev, vst, ||
                             ty::mt{ ty: ty::mk_vec(tcx,
                                                    ty::mt {ty: t, mutbl: mutability},
                                                    None),
@@ -2851,9 +2850,9 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_ty(id, typ);
         }
 
-      ast::ExprBox(place, subexpr) => {
-          check_expr(fcx, place);
-          check_expr(fcx, subexpr);
+      ast::ExprBox(ref place, ref subexpr) => {
+          check_expr(fcx, &**place);
+          check_expr(fcx, &**subexpr);
 
           let mut checked = false;
           match place.node {
@@ -2883,15 +2882,15 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
           }
       }
 
-      ast::ExprLit(lit) => {
-        let typ = check_lit(fcx, lit);
+      ast::ExprLit(ref lit) => {
+        let typ = check_lit(fcx, &**lit);
         fcx.write_ty(id, typ);
       }
-      ast::ExprBinary(op, lhs, rhs) => {
-        check_binop(fcx, expr, op, lhs, rhs, SimpleBinop);
+      ast::ExprBinary(op, ref lhs, ref rhs) => {
+        check_binop(fcx, expr, op, lhs.clone(), rhs.clone(), SimpleBinop);
 
-        let lhs_ty = fcx.expr_ty(lhs);
-        let rhs_ty = fcx.expr_ty(rhs);
+        let lhs_ty = fcx.expr_ty(&**lhs);
+        let rhs_ty = fcx.expr_ty(&**rhs);
         if ty::type_is_error(lhs_ty) ||
             ty::type_is_error(rhs_ty) {
             fcx.write_error(id);
@@ -2901,15 +2900,15 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_bot(id);
         }
       }
-      ast::ExprAssignOp(op, lhs, rhs) => {
-        check_binop(fcx, expr, op, lhs, rhs, BinopAssignment);
+      ast::ExprAssignOp(op, ref lhs, ref rhs) => {
+        check_binop(fcx, expr, op, lhs.clone(), rhs.clone(), BinopAssignment);
 
-        let lhs_t = fcx.expr_ty(lhs);
+        let lhs_t = fcx.expr_ty(&**lhs);
         let result_t = fcx.expr_ty(expr);
         demand::suptype(fcx, expr.span, result_t, lhs_t);
 
         let tcx = fcx.tcx();
-        if !ty::expr_is_lval(tcx, lhs) {
+        if !ty::expr_is_lval(tcx, &**lhs) {
             tcx.sess.span_err(lhs.span, "illegal left-hand side expression");
         }
 
@@ -2921,7 +2920,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_nil(expr.id);
         }
       }
-      ast::ExprUnary(unop, oprnd) => {
+      ast::ExprUnary(unop, ref oprnd) => {
         let exp_inner = unpack_expected(fcx, expected, |sty| {
             match unop {
                 ast::UnBox | ast::UnUniq => match *sty {
@@ -2936,8 +2935,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             ast::UnDeref => lvalue_pref,
             _ => NoPreference
         };
-        check_expr_with_opt_hint_and_lvalue_pref(fcx, oprnd, exp_inner, lvalue_pref);
-        let mut oprnd_t = fcx.expr_ty(oprnd);
+        check_expr_with_opt_hint_and_lvalue_pref(fcx, &**oprnd, exp_inner, lvalue_pref);
+        let mut oprnd_t = fcx.expr_ty(&**oprnd);
         if !ty::type_is_error(oprnd_t) && !ty::type_is_bot(oprnd_t) {
             match unop {
                 ast::UnBox => {
@@ -2952,7 +2951,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                         Some(mt) => mt.ty,
                         None => match try_overloaded_deref(fcx, expr.span,
                                                            Some(MethodCall::expr(expr.id)),
-                                                           Some(&*oprnd), oprnd_t, lvalue_pref) {
+                                                           Some(&**oprnd), oprnd_t, lvalue_pref) {
                             Some(mt) => mt.ty,
                             None => {
                                 let is_newtype = match ty::get(oprnd_t).sty {
@@ -2987,7 +2986,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                          ty::get(oprnd_t).sty == ty::ty_bool) {
                         oprnd_t = check_user_unop(fcx, "!", "not",
                                                   tcx.lang_items.not_trait(),
-                                                  expr, oprnd, oprnd_t);
+                                                  expr, oprnd.clone(), oprnd_t);
                     }
                 }
                 ast::UnNeg => {
@@ -2997,14 +2996,14 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                          ty::type_is_fp(oprnd_t)) {
                         oprnd_t = check_user_unop(fcx, "-", "neg",
                                                   tcx.lang_items.neg_trait(),
-                                                  expr, oprnd, oprnd_t);
+                                                  expr, oprnd.clone(), oprnd_t);
                     }
                 }
             }
         }
         fcx.write_ty(id, oprnd_t);
       }
-      ast::ExprAddrOf(mutbl, oprnd) => {
+      ast::ExprAddrOf(mutbl, ref oprnd) => {
           let hint = unpack_expected(
               fcx, expected,
               |sty| match *sty { ty::ty_rptr(_, ref mt) => Some(mt.ty),
@@ -3013,7 +3012,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             ast::MutMutable => PreferMutLvalue,
             ast::MutImmutable => NoPreference
         };
-        check_expr_with_opt_hint_and_lvalue_pref(fcx, oprnd, hint, lvalue_pref);
+        check_expr_with_opt_hint_and_lvalue_pref(fcx, &**oprnd, hint, lvalue_pref);
 
         // Note: at this point, we cannot say what the best lifetime
         // is to use for resulting pointer.  We want to use the
@@ -3031,7 +3030,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         let region = fcx.infcx().next_region_var(
             infer::AddrOfRegion(expr.span));
 
-        let tm = ty::mt { ty: fcx.expr_ty(oprnd), mutbl: mutbl };
+        let tm = ty::mt { ty: fcx.expr_ty(&**oprnd), mutbl: mutbl };
         let oprnd_t = if ty::type_is_error(tm.ty) {
             ty::mk_err()
         } else if ty::type_is_bot(tm.ty) {
@@ -3050,20 +3049,20 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         instantiate_path(fcx, pth, tpt, defn, expr.span, expr.id);
       }
       ast::ExprInlineAsm(ref ia) => {
-          for &(_, input) in ia.inputs.iter() {
-              check_expr(fcx, input);
+          for &(_, ref input) in ia.inputs.iter() {
+              check_expr(fcx, &**input);
           }
-          for &(_, out) in ia.outputs.iter() {
-              check_expr(fcx, out);
+          for &(_, ref out) in ia.outputs.iter() {
+              check_expr(fcx, &**out);
           }
           fcx.write_nil(id);
       }
       ast::ExprMac(_) => tcx.sess.bug("unexpanded macro"),
       ast::ExprBreak(_) => { fcx.write_bot(id); }
       ast::ExprAgain(_) => { fcx.write_bot(id); }
-      ast::ExprRet(expr_opt) => {
+      ast::ExprRet(ref expr_opt) => {
         let ret_ty = fcx.ret_ty;
-        match expr_opt {
+        match *expr_opt {
           None => match fcx.mk_eqty(false, infer::Misc(expr.span),
                                     ret_ty, ty::mk_nil()) {
             Ok(_) => { /* fall through */ }
@@ -3073,27 +3072,27 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                     "`return;` in function returning non-nil");
             }
           },
-          Some(e) => {
-              check_expr_has_type(fcx, e, ret_ty);
+          Some(ref e) => {
+              check_expr_has_type(fcx, &**e, ret_ty);
           }
         }
         fcx.write_bot(id);
       }
-      ast::ExprParen(a) => {
-        check_expr_with_opt_hint_and_lvalue_pref(fcx, a, expected, lvalue_pref);
-        fcx.write_ty(id, fcx.expr_ty(a));
+      ast::ExprParen(ref a) => {
+        check_expr_with_opt_hint_and_lvalue_pref(fcx, &**a, expected, lvalue_pref);
+        fcx.write_ty(id, fcx.expr_ty(&**a));
       }
-      ast::ExprAssign(lhs, rhs) => {
-        check_expr_with_lvalue_pref(fcx, lhs, PreferMutLvalue);
+      ast::ExprAssign(ref lhs, ref rhs) => {
+        check_expr_with_lvalue_pref(fcx, &**lhs, PreferMutLvalue);
 
         let tcx = fcx.tcx();
-        if !ty::expr_is_lval(tcx, lhs) {
+        if !ty::expr_is_lval(tcx, &**lhs) {
             tcx.sess.span_err(lhs.span, "illegal left-hand side expression");
         }
 
-        let lhs_ty = fcx.expr_ty(lhs);
-        check_expr_has_type(fcx, rhs, lhs_ty);
-        let rhs_ty = fcx.expr_ty(rhs);
+        let lhs_ty = fcx.expr_ty(&**lhs);
+        check_expr_has_type(fcx, &**rhs, lhs_ty);
+        let rhs_ty = fcx.expr_ty(&**rhs);
 
         if ty::type_is_error(lhs_ty) || ty::type_is_error(rhs_ty) {
             fcx.write_error(id);
@@ -3103,14 +3102,14 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_nil(id);
         }
       }
-      ast::ExprIf(cond, then_blk, opt_else_expr) => {
-        check_then_else(fcx, cond, then_blk, opt_else_expr,
+      ast::ExprIf(ref cond, ref then_blk, ref opt_else_expr) => {
+        check_then_else(fcx, &**cond, &**then_blk, opt_else_expr.clone(),
                         id, expr.span, expected);
       }
-      ast::ExprWhile(cond, body) => {
-        check_expr_has_type(fcx, cond, ty::mk_bool());
-        check_block_no_value(fcx, body);
-        let cond_ty = fcx.expr_ty(cond);
+      ast::ExprWhile(ref cond, ref body) => {
+        check_expr_has_type(fcx, &**cond, ty::mk_bool());
+        check_block_no_value(fcx, &**body);
+        let cond_ty = fcx.expr_ty(&**cond);
         let body_ty = fcx.node_ty(body.id);
         if ty::type_is_error(cond_ty) || ty::type_is_error(body_ty) {
             fcx.write_error(id);
@@ -3124,19 +3123,19 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprForLoop(..) =>
           fail!("non-desugared expr_for_loop"),
-      ast::ExprLoop(body, _) => {
-        check_block_no_value(fcx, (body));
-        if !may_break(tcx, expr.id, body) {
+      ast::ExprLoop(ref body, _) => {
+        check_block_no_value(fcx, &**body);
+        if !may_break(tcx, expr.id, body.clone()) {
             fcx.write_bot(id);
         }
         else {
             fcx.write_nil(id);
         }
       }
-      ast::ExprMatch(discrim, ref arms) => {
-        _match::check_match(fcx, expr, discrim, arms.as_slice());
+      ast::ExprMatch(ref discrim, ref arms) => {
+        _match::check_match(fcx, expr, &**discrim, arms.as_slice());
       }
-      ast::ExprFnBlock(decl, body) => {
+      ast::ExprFnBlock(ref decl, ref body) => {
         let region = astconv::opt_ast_region_to_region(fcx,
                                                        fcx.infcx(),
                                                        expr.span,
@@ -3144,34 +3143,34 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         check_expr_fn(fcx,
                       expr,
                       ty::RegionTraitStore(region, ast::MutMutable),
-                      decl,
-                      body,
+                      &**decl,
+                      body.clone(),
                       expected);
       }
-      ast::ExprProc(decl, body) => {
+      ast::ExprProc(ref decl, ref body) => {
         check_expr_fn(fcx,
                       expr,
                       ty::UniqTraitStore,
-                      decl,
-                      body,
+                      &**decl,
+                      body.clone(),
                       expected);
       }
-      ast::ExprBlock(b) => {
-        check_block_with_expected(fcx, b, expected);
+      ast::ExprBlock(ref b) => {
+        check_block_with_expected(fcx, &**b, expected);
         fcx.write_ty(id, fcx.node_ty(b.id));
       }
-      ast::ExprCall(f, ref args) => {
+      ast::ExprCall(ref f, ref args) => {
           // Index expressions need to be handled separately, to inform them
           // that they appear in call position.
-          check_expr(fcx, f);
-          let f_ty = fcx.expr_ty(f);
+          check_expr(fcx, &**f);
+          let f_ty = fcx.expr_ty(&**f);
 
-          if !try_overloaded_call(fcx, expr, f, f_ty, args.as_slice()) {
-              check_call(fcx, expr, f, args.as_slice());
+          if !try_overloaded_call(fcx, expr, f.clone(), f_ty, args.as_slice()) {
+              check_call(fcx, expr, &**f, args.as_slice());
               let (args_bot, args_err) = args.iter().fold((false, false),
                  |(rest_bot, rest_err), a| {
                      // is this not working?
-                     let a_ty = fcx.expr_ty(*a);
+                     let a_ty = fcx.expr_ty(&**a);
                      (rest_bot || ty::type_is_bot(a_ty),
                       rest_err || ty::type_is_error(a_ty))});
               if ty::type_is_error(f_ty) || args_err {
@@ -3184,7 +3183,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprMethodCall(ident, ref tps, ref args) => {
         check_method_call(fcx, expr, ident, args.as_slice(), tps.as_slice());
-        let mut arg_tys = args.iter().map(|a| fcx.expr_ty(*a));
+        let mut arg_tys = args.iter().map(|a| fcx.expr_ty(&**a));
         let (args_bot, args_err) = arg_tys.fold((false, false),
              |(rest_bot, rest_err), a| {
               (rest_bot || ty::type_is_bot(a),
@@ -3195,10 +3194,10 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_bot(id);
         }
       }
-      ast::ExprCast(e, t) => {
-        check_expr(fcx, e);
-        let t_1 = fcx.to_ty(t);
-        let t_e = fcx.expr_ty(e);
+      ast::ExprCast(ref e, ref t) => {
+        check_expr(fcx, &**e);
+        let t_1 = fcx.to_ty(&**t);
+        let t_e = fcx.expr_ty(&**e);
 
         debug!("t_1={}", fcx.infcx().ty_to_str(t_1));
         debug!("t_e={}", fcx.infcx().ty_to_str(t_e));
@@ -3297,7 +3296,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                 /* this case is allowed */
                             }
                             _ => {
-                                demand::coerce(fcx, e.span, t_1, e);
+                                demand::coerce(fcx, e.span, t_1, &**e);
                             }
                         }
                     } else if !(type_is_scalar(fcx,expr.span,t_e)
@@ -3321,18 +3320,18 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       ast::ExprVec(ref args) => {
         let t: ty::t = fcx.infcx().next_ty_var();
         for e in args.iter() {
-            check_expr_has_type(fcx, *e, t);
+            check_expr_has_type(fcx, &**e, t);
         }
         let typ = ty::mk_vec(tcx, ty::mt {ty: t, mutbl: ast::MutImmutable},
                              Some(args.len()));
         fcx.write_ty(id, typ);
       }
-      ast::ExprRepeat(element, count_expr) => {
-        check_expr_with_hint(fcx, count_expr, ty::mk_uint());
-        let count = ty::eval_repeat_count(fcx, count_expr);
+      ast::ExprRepeat(ref element, ref count_expr) => {
+        check_expr_with_hint(fcx, &**count_expr, ty::mk_uint());
+        let count = ty::eval_repeat_count(fcx, &**count_expr);
         let t: ty::t = fcx.infcx().next_ty_var();
-        check_expr_has_type(fcx, element, t);
-        let element_ty = fcx.expr_ty(element);
+        check_expr_has_type(fcx, &**element, t);
+        let element_ty = fcx.expr_ty(&**element);
         if ty::type_is_error(element_ty) {
             fcx.write_error(id);
         }
@@ -3360,8 +3359,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                 Some(ref fs) if i < fs.len() => Some(*fs.get(i)),
                 _ => None
             };
-            check_expr_with_opt_hint(fcx, *e, opt_hint);
-            let t = fcx.expr_ty(*e);
+            check_expr_with_opt_hint(fcx, &**e, opt_hint);
+            let t = fcx.expr_ty(&**e);
             err_field = err_field || ty::type_is_error(t);
             bot_field = bot_field || ty::type_is_bot(t);
             t
@@ -3393,14 +3392,14 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             }
         }
       }
-      ast::ExprField(base, field, ref tys) => {
-        check_field(fcx, expr, lvalue_pref, base, field.name, tys.as_slice());
+      ast::ExprField(ref base, ref field, ref tys) => {
+        check_field(fcx, expr, lvalue_pref, &**base, field.name, tys.as_slice());
       }
-      ast::ExprIndex(base, idx) => {
-          check_expr_with_lvalue_pref(fcx, base, lvalue_pref);
-          check_expr(fcx, idx);
-          let raw_base_t = fcx.expr_ty(base);
-          let idx_t = fcx.expr_ty(idx);
+      ast::ExprIndex(ref base, ref idx) => {
+          check_expr_with_lvalue_pref(fcx, &**base, lvalue_pref);
+          check_expr(fcx, &**idx);
+          let raw_base_t = fcx.expr_ty(&**base);
+          let idx_t = fcx.expr_ty(&**idx);
           if ty::type_is_error(raw_base_t) || ty::type_is_bot(raw_base_t) {
               fcx.write_ty(id, raw_base_t);
           } else if ty::type_is_error(idx_t) || ty::type_is_bot(idx_t) {
@@ -3411,7 +3410,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                           lvalue_pref, |base_t, _| ty::index(base_t));
               match field_ty {
                   Some(mt) => {
-                      check_expr_has_type(fcx, idx, ty::mk_uint());
+                      check_expr_has_type(fcx, &**idx, ty::mk_uint());
                       fcx.write_ty(id, mt.ty);
                       fcx.write_autoderef_adjustment(base.id, autoderefs);
                   }
@@ -3424,7 +3423,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                                     resolved,
                                                     token::intern("index"),
                                                     tcx.lang_items.index_trait(),
-                                                    [base, idx],
+                                                    [base.clone(), idx.clone()],
                                                     AutoderefReceiver,
                                                     || {
                         fcx.type_error_message(expr.span,
@@ -3488,9 +3487,9 @@ pub fn check_decl_local(fcx: &FnCtxt, local: &ast::Local)  {
     fcx.write_ty(local.id, t);
 
     match local.init {
-        Some(init) => {
-            check_decl_initializer(fcx, local.id, init);
-            let init_ty = fcx.expr_ty(init);
+        Some(ref init) => {
+            check_decl_initializer(fcx, local.id, &**init);
+            let init_ty = fcx.expr_ty(&**init);
             if ty::type_is_error(init_ty) || ty::type_is_bot(init_ty) {
                 fcx.write_ty(local.id, init_ty);
             }
@@ -3500,9 +3499,9 @@ pub fn check_decl_local(fcx: &FnCtxt, local: &ast::Local)  {
 
     let pcx = pat_ctxt {
         fcx: fcx,
-        map: pat_id_map(&tcx.def_map, local.pat),
+        map: pat_id_map(&tcx.def_map, &*local.pat),
     };
-    _match::check_pat(&pcx, local.pat, t);
+    _match::check_pat(&pcx, &*local.pat, t);
     let pat_ty = fcx.node_ty(local.pat.id);
     if ty::type_is_error(pat_ty) || ty::type_is_bot(pat_ty) {
         fcx.write_ty(local.id, pat_ty);
@@ -3518,7 +3517,7 @@ pub fn check_stmt(fcx: &FnCtxt, stmt: &ast::Stmt)  {
         node_id = id;
         match decl.node {
           ast::DeclLocal(ref l) => {
-              check_decl_local(fcx, *l);
+              check_decl_local(fcx, &**l);
               let l_t = fcx.node_ty(l.id);
               saw_bot = saw_bot || ty::type_is_bot(l_t);
               saw_err = saw_err || ty::type_is_error(l_t);
@@ -3526,18 +3525,18 @@ pub fn check_stmt(fcx: &FnCtxt, stmt: &ast::Stmt)  {
           ast::DeclItem(_) => {/* ignore for now */ }
         }
       }
-      ast::StmtExpr(expr, id) => {
+      ast::StmtExpr(ref expr, id) => {
         node_id = id;
         // Check with expected type of ()
-        check_expr_has_type(fcx, expr, ty::mk_nil());
-        let expr_ty = fcx.expr_ty(expr);
+        check_expr_has_type(fcx, &**expr, ty::mk_nil());
+        let expr_ty = fcx.expr_ty(&**expr);
         saw_bot = saw_bot || ty::type_is_bot(expr_ty);
         saw_err = saw_err || ty::type_is_error(expr_ty);
       }
-      ast::StmtSemi(expr, id) => {
+      ast::StmtSemi(ref expr, id) => {
         node_id = id;
-        check_expr(fcx, expr);
-        let expr_ty = fcx.expr_ty(expr);
+        check_expr(fcx, &**expr);
+        let expr_ty = fcx.expr_ty(&**expr);
         saw_bot |= ty::type_is_bot(expr_ty);
         saw_err |= ty::type_is_error(expr_ty);
       }
@@ -3584,8 +3583,8 @@ pub fn check_block_with_expected(fcx: &FnCtxt,
         let mut any_bot = false;
         let mut any_err = false;
         for s in blk.stmts.iter() {
-            check_stmt(fcx, *s);
-            let s_id = ast_util::stmt_id(*s);
+            check_stmt(fcx, &**s);
+            let s_id = ast_util::stmt_id(&**s);
             let s_ty = fcx.node_ty(s_id);
             if last_was_bot && !warned && match s.node {
                   ast::StmtDecl(decl, _) => {
@@ -3632,8 +3631,8 @@ pub fn check_block_with_expected(fcx: &FnCtxt,
                              e.span,
                              "unreachable expression".to_string());
             }
-            check_expr_with_opt_hint(fcx, e, expected);
-              let ety = fcx.expr_ty(e);
+            check_expr_with_opt_hint(fcx, &*e, expected);
+              let ety = fcx.expr_ty(&*e);
               fcx.write_ty(blk.id, ety);
               if any_err {
                   fcx.write_error(blk.id);
@@ -3793,7 +3792,7 @@ pub fn check_enum_variants_sized(ccx: &CrateCtxt,
                     }
                 }
             },
-            ast::StructVariantKind(struct_def) => check_fields_sized(ccx.tcx, struct_def),
+            ast::StructVariantKind(struct_def) => check_fields_sized(ccx.tcx, &*struct_def),
             _ => {}
         }
     }
@@ -3853,17 +3852,17 @@ pub fn check_enum_variants(ccx: &CrateCtxt,
 
             match v.node.disr_expr {
                 Some(e) => {
-                    debug!("disr expr, checking {}", pprust::expr_to_str(e));
+                    debug!("disr expr, checking {}", pprust::expr_to_str(&*e));
 
                     let inh = blank_inherited_fields(ccx);
                     let fcx = blank_fn_ctxt(ccx, &inh, rty, e.id);
                     let declty = ty::mk_int_var(ccx.tcx, fcx.infcx().next_int_var_id());
-                    check_const_with_ty(&fcx, e.span, e, declty);
+                    check_const_with_ty(&fcx, e.span, &*e, declty);
                     // check_expr (from check_const pass) doesn't guarantee
                     // that the expression is in a form that eval_const_expr can
                     // handle, so we may still get an internal compiler error
 
-                    match const_eval::eval_const_expr_partial(ccx.tcx, e) {
+                    match const_eval::eval_const_expr_partial(ccx.tcx, &*e) {
                         Ok(const_eval::const_int(val)) => current_disr_val = val as Disr,
                         Ok(const_eval::const_uint(val)) => current_disr_val = val as Disr,
                         Ok(_) => {
@@ -3898,7 +3897,7 @@ pub fn check_enum_variants(ccx: &CrateCtxt,
             }
             disr_vals.push(current_disr_val);
 
-            let variant_info = Rc::new(VariantInfo::from_ast_variant(ccx.tcx, v,
+            let variant_info = Rc::new(VariantInfo::from_ast_variant(ccx.tcx, &*v,
                                                                      current_disr_val));
             prev_disr_val = Some(current_disr_val);
 
@@ -4096,7 +4095,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
         let mut pushed = false;
         for (i, ty) in pth.segments.iter()
                                    .flat_map(|segment| segment.types.iter())
-                                   .map(|&ast_type| fcx.to_ty(ast_type))
+                                   .map(|ast_type| fcx.to_ty(&**ast_type))
                                    .enumerate() {
             match self_parameter_index {
                 Some(index) if index == i => {
@@ -4264,7 +4263,7 @@ pub fn ast_expr_vstore_to_ty(fcx: &FnCtxt,
 pub fn may_break(cx: &ty::ctxt, id: ast::NodeId, b: ast::P<ast::Block>) -> bool {
     // First: is there an unlabeled break immediately
     // inside the loop?
-    (loop_query(b, |e| {
+    (loop_query(&*b, |e| {
         match *e {
             ast::ExprBreak(_) => true,
             _ => false

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -666,10 +666,10 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
           None => {}
         }
       }
-      ast::ExprCast(src, _) => {
+      ast::ExprCast(ref src, _) => {
           debug!("vtable resolution on expr {}", ex.repr(fcx.tcx()));
           let target_ty = fcx.expr_ty(ex);
-          resolve_object_cast(src, target_ty);
+          resolve_object_cast(&**src, target_ty);
       }
       _ => ()
     }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -53,10 +53,10 @@ pub fn resolve_type_vars_in_fn(fcx: &FnCtxt,
     let mut wbcx = WritebackCx::new(fcx);
     wbcx.visit_block(blk, ());
     for arg in decl.inputs.iter() {
-        wbcx.visit_pat(arg.pat, ());
+        wbcx.visit_pat(&*arg.pat, ());
 
         // Privacy needs the type for the whole pattern, not just each binding
-        if !pat_util::pat_is_binding(&fcx.tcx().def_map, arg.pat) {
+        if !pat_util::pat_is_binding(&fcx.tcx().def_map, &*arg.pat) {
             wbcx.visit_node_id(ResolvingPattern(arg.pat.span),
                                arg.pat.id);
         }

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -211,8 +211,8 @@ impl<'a> visit::Visitor<()> for PrivilegedScopeVisitor<'a> {
                 // Then visit the module items.
                 visit::walk_mod(self, module_, ());
             }
-            ItemImpl(_, None, ast_ty, _) => {
-                if !self.cc.ast_type_is_defined_in_local_crate(ast_ty) {
+            ItemImpl(_, None, ref ast_ty, _) => {
+                if !self.cc.ast_type_is_defined_in_local_crate(&**ast_ty) {
                     // This is an error.
                     let session = &self.cc.crate_context.tcx.sess;
                     session.span_err(item.span,

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -129,6 +129,14 @@ fn type_is_defined_in_local_crate(tcx: &ty::ctxt, original_type: t) -> bool {
                     _ => {}
                 }
             }
+            ty_box(..) => {
+                match tcx.lang_items.gc() {
+                    Some(did) if did.krate == ast::LOCAL_CRATE => {
+                        found_nominal = true;
+                    }
+                    _ => {}
+                }
+            }
 
             _ => { }
         }

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1140,7 +1140,7 @@ impl<'a> Rebuilder<'a> {
                 }
                 ref other => other.clone()
             };
-            @ast::Ty { id: from.id, node: new_node, span: from.span }
+            box(GC) ast::Ty { id: from.id, node: new_node, span: from.span }
         }
 
         let new_ty_node = match to.node {
@@ -1155,7 +1155,7 @@ impl<'a> Rebuilder<'a> {
             }
             _ => fail!("expect ast::TyRptr or ast::TyPath")
         };
-        let new_ty = @ast::Ty {
+        let new_ty = box(GC) ast::Ty {
             id: to.id,
             node: new_ty_node,
             span: to.span

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -479,13 +479,13 @@ impl<'a> Visitor<()> for ConstraintContext<'a> {
                 // `ty::VariantInfo::from_ast_variant()` ourselves
                 // here, mainly so as to mask the differences between
                 // struct-like enums and so forth.
-                for &ast_variant in enum_definition.variants.iter() {
+                for ast_variant in enum_definition.variants.iter() {
                     let variant =
                         ty::VariantInfo::from_ast_variant(tcx,
-                                                          ast_variant,
+                                                          &**ast_variant,
                                                           /*discriminant*/ 0);
-                    for &arg_ty in variant.args.iter() {
-                        self.add_constraints_from_ty(arg_ty, self.covariant);
+                    for arg_ty in variant.args.iter() {
+                        self.add_constraints_from_ty(*arg_ty, self.covariant);
                     }
                 }
             }

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -102,6 +102,6 @@ pub fn block_query(b: ast::P<ast::Block>, p: |&ast::Expr| -> bool) -> bool {
         p: p,
         flag: false,
     };
-    visit::walk_block(&mut v, b, ());
+    visit::walk_block(&mut v, &*b, ());
     return v.flag;
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -25,7 +25,7 @@ use middle::ty;
 use middle::typeck;
 
 use std::rc::Rc;
-use std::string::String;
+use std::gc::Gc;
 use syntax::abi;
 use syntax::ast_map;
 use syntax::codemap::{Span, Pos};

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -510,7 +510,7 @@ impl<T:Repr> Repr for Rc<T> {
     }
 }
 
-impl<T:Repr> Repr for @T {
+impl<T:Repr + 'static> Repr for Gc<T> {
     fn repr(&self, tcx: &ctxt) -> String {
         (&**self).repr(tcx)
     }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -95,7 +95,7 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>)
     let mut cfg = build_configuration(&sess);
     for cfg_ in cfgs.move_iter() {
         let cfg_ = token::intern_and_get_ident(cfg_.as_slice());
-        cfg.push(@dummy_spanned(ast::MetaWord(cfg_)));
+        cfg.push(box(GC) dummy_spanned(ast::MetaWord(cfg_)));
     }
 
     let krate = phase_1_parse_input(&sess, cfg, &input);
@@ -128,11 +128,11 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>)
 pub fn run_core(libs: HashSet<Path>, cfgs: Vec<String>, path: &Path)
                 -> (clean::Crate, CrateAnalysis) {
     let (ctxt, analysis) = get_ast_and_resolve(path, libs, cfgs);
-    let ctxt = @ctxt;
+    let ctxt = box(GC) ctxt;
     super::ctxtkey.replace(Some(ctxt));
 
     let krate = {
-        let mut v = RustdocVisitor::new(ctxt, Some(&analysis));
+        let mut v = RustdocVisitor::new(&*ctxt, Some(&analysis));
         v.visit(&ctxt.krate);
         v.clean()
     };

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -16,6 +16,8 @@ use syntax::codemap::Span;
 use syntax::ast;
 use syntax::ast::{Ident, NodeId};
 
+use std::gc::Gc;
+
 pub struct Module {
     pub name: Option<Ident>,
     pub attrs: Vec<ast::Attribute>,
@@ -133,7 +135,7 @@ pub struct Typedef {
 pub struct Static {
     pub type_: ast::P<ast::Ty>,
     pub mutability: ast::Mutability,
-    pub expr: @ast::Expr,
+    pub expr: Gc<ast::Expr>,
     pub name: Ident,
     pub attrs: Vec<ast::Attribute>,
     pub vis: ast::Visibility,
@@ -156,7 +158,7 @@ pub struct Impl {
     pub generics: ast::Generics,
     pub trait_: Option<ast::TraitRef>,
     pub for_: ast::P<ast::Ty>,
-    pub methods: Vec<@ast::Method>,
+    pub methods: Vec<Gc<ast::Method>>,
     pub attrs: Vec<ast::Attribute>,
     pub where: Span,
     pub vis: ast::Visibility,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -37,6 +37,7 @@ extern crate log;
 use std::io;
 use std::io::{File, MemWriter};
 use std::str;
+use std::gc::Gc;
 use serialize::{json, Decodable, Encodable};
 
 // reexported from `clean` so it can be easily updated with the mod itself
@@ -85,7 +86,7 @@ static DEFAULT_PASSES: &'static [&'static str] = &[
     "unindent-comments",
 ];
 
-local_data_key!(pub ctxtkey: @core::DocContext)
+local_data_key!(pub ctxtkey: Gc<core::DocContext>)
 local_data_key!(pub analysiskey: core::CrateAnalysis)
 
 type Output = (clean::Crate, Vec<plugins::PluginJson> );

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -64,13 +64,13 @@ pub fn run(input: &str,
     let mut cfg = config::build_configuration(&sess);
     cfg.extend(cfgs.move_iter().map(|cfg_| {
         let cfg_ = token::intern_and_get_ident(cfg_.as_slice());
-        @dummy_spanned(ast::MetaWord(cfg_))
+        box(GC) dummy_spanned(ast::MetaWord(cfg_))
     }));
     let krate = driver::phase_1_parse_input(&sess, cfg, &input);
     let (krate, _) = driver::phase_2_configure_and_expand(&sess, krate,
                                                           &from_str("rustdoc-test").unwrap());
 
-    let ctx = @core::DocContext {
+    let ctx = box(GC) core::DocContext {
         krate: krate,
         maybe_typed: core::NotTyped(sess),
         src: input_path,
@@ -82,7 +82,7 @@ pub fn run(input: &str,
     };
     super::ctxtkey.replace(Some(ctx));
 
-    let mut v = RustdocVisitor::new(ctx, None);
+    let mut v = RustdocVisitor::new(&*ctx, None);
     v.visit(&ctx.krate);
     let krate = v.clean();
     let (krate, _) = passes::unindent_comments(krate);

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -16,6 +16,7 @@ Core encoding and decoding interfaces.
 
 use std::path;
 use std::rc::Rc;
+use std::gc::Gc;
 
 pub trait Encoder<E> {
     // Primitive types:
@@ -387,7 +388,7 @@ impl<E, D:Decoder<E>,T:Decodable<D, E>> Decodable<D, E> for Box<T> {
     }
 }
 
-impl<E, S:Encoder<E>,T:Encodable<S, E>> Encodable<S, E> for @T {
+impl<E, S:Encoder<E>,T:'static + Encodable<S, E>> Encodable<S, E> for Gc<T> {
     fn encode(&self, s: &mut S) -> Result<(), E> {
         (**self).encode(s)
     }
@@ -407,9 +408,9 @@ impl<E, D:Decoder<E>,T:Decodable<D, E>> Decodable<D, E> for Rc<T> {
     }
 }
 
-impl<E, D:Decoder<E>,T:Decodable<D, E> + 'static> Decodable<D, E> for @T {
-    fn decode(d: &mut D) -> Result<@T, E> {
-        Ok(@try!(Decodable::decode(d)))
+impl<E, D:Decoder<E>,T:Decodable<D, E> + 'static> Decodable<D, E> for Gc<T> {
+    fn decode(d: &mut D) -> Result<Gc<T>, E> {
+        Ok(box(GC) try!(Decodable::decode(d)))
     }
 }
 

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -18,52 +18,33 @@ collector is task-local so `Gc<T>` is not sendable.
 
 #![allow(experimental)]
 
-use kinds::marker;
 use clone::Clone;
+use cmp::{TotalOrd, Ord, Ordering, TotalEq, Eq};
+use default::Default;
+use fmt;
+use hash::Hash;
+use io::Writer;
+use kinds::marker;
+use ops::Deref;
+use raw;
 
 /// Immutable garbage-collected pointer type
 #[lang="gc"]
-#[cfg(not(test))]
 #[experimental = "Gc is currently based on reference-counting and will not collect cycles until \
                   task annihilation. For now, cycles need to be broken manually by using `Rc<T>` \
                   with a non-owning `Weak<T>` pointer. A tracing garbage collector is planned."]
 pub struct Gc<T> {
+    #[cfg(stage0)]
     ptr: @T,
+    #[cfg(not(stage0))]
+    ptr: *T,
     marker: marker::NoSend,
 }
 
-#[cfg(test)]
-pub struct Gc<T> {
-    ptr: @T,
-    marker: marker::NoSend,
-}
-
-impl<T: 'static> Gc<T> {
-    /// Construct a new garbage-collected box
-    #[inline]
-    pub fn new(value: T) -> Gc<T> {
-        Gc { ptr: @value, marker: marker::NoSend }
-    }
-
-    /// Borrow the value contained in the garbage-collected box
-    #[inline]
-    pub fn borrow<'r>(&'r self) -> &'r T {
-        &*self.ptr
-    }
-
-    /// Determine if two garbage-collected boxes point to the same object
-    #[inline]
-    pub fn ptr_eq(&self, other: &Gc<T>) -> bool {
-        self.borrow() as *T == other.borrow() as *T
-    }
-}
-
-impl<T> Clone for Gc<T> {
+impl<T: 'static> Clone for Gc<T> {
     /// Clone the pointer only
     #[inline]
-    fn clone(&self) -> Gc<T> {
-        Gc{ ptr: self.ptr, marker: marker::NoSend }
-    }
+    fn clone(&self) -> Gc<T> { *self }
 }
 
 /// An value that represents the task-local managed heap.
@@ -73,8 +54,54 @@ impl<T> Clone for Gc<T> {
 #[cfg(not(test))]
 pub static GC: () = ();
 
-#[cfg(test)]
-pub static GC: () = ();
+impl<T: Eq + 'static> Eq for Gc<T> {
+    #[inline]
+    fn eq(&self, other: &Gc<T>) -> bool { *(*self) == *(*other) }
+    #[inline]
+    fn ne(&self, other: &Gc<T>) -> bool { *(*self) != *(*other) }
+}
+impl<T: Ord + 'static> Ord for Gc<T> {
+    #[inline]
+    fn lt(&self, other: &Gc<T>) -> bool { *(*self) < *(*other) }
+    #[inline]
+    fn le(&self, other: &Gc<T>) -> bool { *(*self) <= *(*other) }
+    #[inline]
+    fn ge(&self, other: &Gc<T>) -> bool { *(*self) >= *(*other) }
+    #[inline]
+    fn gt(&self, other: &Gc<T>) -> bool { *(*self) > *(*other) }
+}
+impl<T: TotalOrd + 'static> TotalOrd for Gc<T> {
+    #[inline]
+    fn cmp(&self, other: &Gc<T>) -> Ordering { (**self).cmp(&**other) }
+}
+impl<T: TotalEq + 'static> TotalEq for Gc<T> {}
+
+impl<T: 'static> Deref<T> for Gc<T> {
+    #[cfg(stage0)]
+    fn deref<'a>(&'a self) -> &'a T { &*self.ptr }
+    #[cfg(not(stage0))]
+    fn deref<'a>(&'a self) -> &'a T { &**self }
+}
+
+impl<T: Default + 'static> Default for Gc<T> {
+    fn default() -> Gc<T> {
+        box(GC) Default::default()
+    }
+}
+
+impl<T: 'static> raw::Repr<*raw::Box<T>> for Gc<T> {}
+
+impl<S: Writer, T: Hash<S> + 'static> Hash<S> for Gc<T> {
+    fn hash(&self, s: &mut S) {
+        (**self).hash(s)
+    }
+}
+
+impl<T: 'static + fmt::Show> fmt::Show for Gc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -135,6 +135,8 @@ extern crate rustrt;
 #[cfg(test)] pub use realstd::ops;
 #[cfg(test)] pub use realstd::cmp;
 #[cfg(test)] pub use realstd::ty;
+#[cfg(test)] pub use realstd::owned;
+#[cfg(test)] pub use realstd::gc;
 
 
 // NB: These reexports are in the order they should be listed in rustdoc
@@ -219,6 +221,7 @@ pub mod rand;
 
 pub mod ascii;
 
+#[cfg(not(test))]
 pub mod gc;
 
 /* Common traits */

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -21,15 +21,16 @@ use std::fmt;
 use std::fmt::Show;
 use std::option::Option;
 use std::rc::Rc;
+use std::gc::Gc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
 /// A pointer abstraction. FIXME(eddyb) #10676 use Rc<T> in the future.
-pub type P<T> = @T;
+pub type P<T> = Gc<T>;
 
 #[allow(non_snake_case_functions)]
 /// Construct a P<T> from a T value.
 pub fn P<T: 'static>(value: T) -> P<T> {
-    @value
+    box(GC) value
 }
 
 // FIXME #6993: in librustc, uses of "ident" should be replaced
@@ -217,7 +218,7 @@ pub enum DefRegion {
 
 // The set of MetaItems that define the compilation environment of the crate,
 // used to drive conditional compilation
-pub type CrateConfig = Vec<@MetaItem> ;
+pub type CrateConfig = Vec<Gc<MetaItem>>;
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Crate {
@@ -232,7 +233,7 @@ pub type MetaItem = Spanned<MetaItem_>;
 #[deriving(Clone, Encodable, Decodable, Eq, Hash)]
 pub enum MetaItem_ {
     MetaWord(InternedString),
-    MetaList(InternedString, Vec<@MetaItem> ),
+    MetaList(InternedString, Vec<Gc<MetaItem>>),
     MetaNameValue(InternedString, Lit),
 }
 
@@ -264,8 +265,8 @@ impl PartialEq for MetaItem_ {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Block {
     pub view_items: Vec<ViewItem>,
-    pub stmts: Vec<@Stmt>,
-    pub expr: Option<@Expr>,
+    pub stmts: Vec<Gc<Stmt>>,
+    pub expr: Option<Gc<Expr>>,
     pub id: NodeId,
     pub rules: BlockCheckMode,
     pub span: Span,
@@ -281,7 +282,7 @@ pub struct Pat {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct FieldPat {
     pub ident: Ident,
-    pub pat: @Pat,
+    pub pat: Gc<Pat>,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
@@ -301,18 +302,18 @@ pub enum Pat_ {
     // which it is. The resolver determines this, and
     // records this pattern's NodeId in an auxiliary
     // set (of "pat_idents that refer to nullary enums")
-    PatIdent(BindingMode, Path, Option<@Pat>),
-    PatEnum(Path, Option<Vec<@Pat> >), /* "none" means a * pattern where
+    PatIdent(BindingMode, Path, Option<Gc<Pat>>),
+    PatEnum(Path, Option<Vec<Gc<Pat>>>), /* "none" means a * pattern where
                                      * we don't bind the fields to names */
-    PatStruct(Path, Vec<FieldPat> , bool),
-    PatTup(Vec<@Pat> ),
-    PatBox(@Pat),
-    PatRegion(@Pat), // reference pattern
-    PatLit(@Expr),
-    PatRange(@Expr, @Expr),
+    PatStruct(Path, Vec<FieldPat>, bool),
+    PatTup(Vec<Gc<Pat>>),
+    PatBox(Gc<Pat>),
+    PatRegion(Gc<Pat>), // reference pattern
+    PatLit(Gc<Expr>),
+    PatRange(Gc<Expr>, Gc<Expr>),
     // [a, b, ..i, y, z] is represented as
     // PatVec(~[a, b], Some(i), ~[y, z])
-    PatVec(Vec<@Pat> , Option<@Pat>, Vec<@Pat> ),
+    PatVec(Vec<Gc<Pat>>, Option<Gc<Pat>>, Vec<Gc<Pat>>),
     PatMac(Mac),
 }
 
@@ -365,13 +366,13 @@ pub type Stmt = Spanned<Stmt_>;
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum Stmt_ {
     // could be an item or a local (let) binding:
-    StmtDecl(@Decl, NodeId),
+    StmtDecl(Gc<Decl>, NodeId),
 
     // expr without trailing semi-colon (must have unit type):
-    StmtExpr(@Expr, NodeId),
+    StmtExpr(Gc<Expr>, NodeId),
 
     // expr with trailing semi-colon (may have any type):
-    StmtSemi(@Expr, NodeId),
+    StmtSemi(Gc<Expr>, NodeId),
 
     // bool: is there a trailing sem-colon?
     StmtMac(Mac, bool),
@@ -391,8 +392,8 @@ pub enum LocalSource {
 #[deriving(PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Local {
     pub ty: P<Ty>,
-    pub pat: @Pat,
-    pub init: Option<@Expr>,
+    pub pat: Gc<Pat>,
+    pub init: Option<Gc<Expr>>,
     pub id: NodeId,
     pub span: Span,
     pub source: LocalSource,
@@ -403,23 +404,23 @@ pub type Decl = Spanned<Decl_>;
 #[deriving(PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum Decl_ {
     // a local (let) binding:
-    DeclLocal(@Local),
+    DeclLocal(Gc<Local>),
     // an item binding:
-    DeclItem(@Item),
+    DeclItem(Gc<Item>),
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Arm {
     pub attrs: Vec<Attribute>,
-    pub pats: Vec<@Pat>,
-    pub guard: Option<@Expr>,
-    pub body: @Expr,
+    pub pats: Vec<Gc<Pat>>,
+    pub guard: Option<Gc<Expr>>,
+    pub body: Gc<Expr>,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Field {
     pub ident: SpannedIdent,
-    pub expr: @Expr,
+    pub expr: Gc<Expr>,
     pub span: Span,
 }
 
@@ -446,56 +447,56 @@ pub struct Expr {
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum Expr_ {
-    ExprVstore(@Expr, ExprVstore),
+    ExprVstore(Gc<Expr>, ExprVstore),
     // First expr is the place; second expr is the value.
-    ExprBox(@Expr, @Expr),
-    ExprVec(Vec<@Expr>),
-    ExprCall(@Expr, Vec<@Expr>),
-    ExprMethodCall(SpannedIdent, Vec<P<Ty>>, Vec<@Expr>),
-    ExprTup(Vec<@Expr>),
-    ExprBinary(BinOp, @Expr, @Expr),
-    ExprUnary(UnOp, @Expr),
-    ExprLit(@Lit),
-    ExprCast(@Expr, P<Ty>),
-    ExprIf(@Expr, P<Block>, Option<@Expr>),
-    ExprWhile(@Expr, P<Block>),
+    ExprBox(Gc<Expr>, Gc<Expr>),
+    ExprVec(Vec<Gc<Expr>>),
+    ExprCall(Gc<Expr>, Vec<Gc<Expr>>),
+    ExprMethodCall(SpannedIdent, Vec<P<Ty>>, Vec<Gc<Expr>>),
+    ExprTup(Vec<Gc<Expr>>),
+    ExprBinary(BinOp, Gc<Expr>, Gc<Expr>),
+    ExprUnary(UnOp, Gc<Expr>),
+    ExprLit(Gc<Lit>),
+    ExprCast(Gc<Expr>, P<Ty>),
+    ExprIf(Gc<Expr>, P<Block>, Option<Gc<Expr>>),
+    ExprWhile(Gc<Expr>, P<Block>),
     // FIXME #6993: change to Option<Name>
-    ExprForLoop(@Pat, @Expr, P<Block>, Option<Ident>),
+    ExprForLoop(Gc<Pat>, Gc<Expr>, P<Block>, Option<Ident>),
     // Conditionless loop (can be exited with break, cont, or ret)
     // FIXME #6993: change to Option<Name>
     ExprLoop(P<Block>, Option<Ident>),
-    ExprMatch(@Expr, Vec<Arm>),
+    ExprMatch(Gc<Expr>, Vec<Arm>),
     ExprFnBlock(P<FnDecl>, P<Block>),
     ExprProc(P<FnDecl>, P<Block>),
     ExprBlock(P<Block>),
 
-    ExprAssign(@Expr, @Expr),
-    ExprAssignOp(BinOp, @Expr, @Expr),
-    ExprField(@Expr, Ident, Vec<P<Ty>>),
-    ExprIndex(@Expr, @Expr),
+    ExprAssign(Gc<Expr>, Gc<Expr>),
+    ExprAssignOp(BinOp, Gc<Expr>, Gc<Expr>),
+    ExprField(Gc<Expr>, Ident, Vec<P<Ty>>),
+    ExprIndex(Gc<Expr>, Gc<Expr>),
 
     /// Expression that looks like a "name". For example,
     /// `std::slice::from_elem::<uint>` is an ExprPath that's the "name" part
     /// of a function call.
     ExprPath(Path),
 
-    ExprAddrOf(Mutability, @Expr),
+    ExprAddrOf(Mutability, Gc<Expr>),
     ExprBreak(Option<Ident>),
     ExprAgain(Option<Ident>),
-    ExprRet(Option<@Expr>),
+    ExprRet(Option<Gc<Expr>>),
 
     ExprInlineAsm(InlineAsm),
 
     ExprMac(Mac),
 
     // A struct literal expression.
-    ExprStruct(Path, Vec<Field> , Option<@Expr> /* base */),
+    ExprStruct(Path, Vec<Field> , Option<Gc<Expr>> /* base */),
 
     // A vector literal constructed from one repeated element.
-    ExprRepeat(@Expr /* element */, @Expr /* count */),
+    ExprRepeat(Gc<Expr> /* element */, Gc<Expr> /* count */),
 
     // No-op: used solely so we can pretty-print faithfully
-    ExprParen(@Expr)
+    ExprParen(Gc<Expr>)
 }
 
 // When the main rust parser encounters a syntax-extension invocation, it
@@ -667,7 +668,7 @@ pub struct TypeMethod {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum TraitMethod {
     Required(TypeMethod),
-    Provided(@Method),
+    Provided(Gc<Method>),
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
@@ -782,16 +783,16 @@ pub enum Ty_ {
     TyBox(P<Ty>),
     TyUniq(P<Ty>),
     TyVec(P<Ty>),
-    TyFixedLengthVec(P<Ty>, @Expr),
+    TyFixedLengthVec(P<Ty>, Gc<Expr>),
     TyPtr(MutTy),
     TyRptr(Option<Lifetime>, MutTy),
-    TyClosure(@ClosureTy, Option<Lifetime>),
-    TyProc(@ClosureTy),
-    TyBareFn(@BareFnTy),
-    TyUnboxedFn(@UnboxedFnTy),
+    TyClosure(Gc<ClosureTy>, Option<Lifetime>),
+    TyProc(Gc<ClosureTy>),
+    TyBareFn(Gc<BareFnTy>),
+    TyUnboxedFn(Gc<UnboxedFnTy>),
     TyTup(Vec<P<Ty>> ),
     TyPath(Path, Option<OwnedSlice<TyParamBound>>, NodeId), // for #7264; see above
-    TyTypeof(@Expr),
+    TyTypeof(Gc<Expr>),
     // TyInfer means the type should be inferred instead of it having been
     // specified. This can appear anywhere in a type.
     TyInfer,
@@ -808,8 +809,8 @@ pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
     pub clobbers: InternedString,
-    pub inputs: Vec<(InternedString, @Expr)>,
-    pub outputs: Vec<(InternedString, @Expr)>,
+    pub inputs: Vec<(InternedString, Gc<Expr>)>,
+    pub outputs: Vec<(InternedString, Gc<Expr>)>,
     pub volatile: bool,
     pub alignstack: bool,
     pub dialect: AsmDialect
@@ -818,7 +819,7 @@ pub struct InlineAsm {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Arg {
     pub ty: P<Ty>,
-    pub pat: @Pat,
+    pub pat: Gc<Pat>,
     pub id: NodeId,
 }
 
@@ -832,7 +833,7 @@ impl Arg {
                 node: TyInfer,
                 span: DUMMY_SP,
             }),
-            pat: @Pat {
+            pat: box(GC) Pat {
                 id: DUMMY_NODE_ID,
                 node: PatIdent(BindByValue(mutability), path, None),
                 span: span
@@ -903,14 +904,14 @@ pub struct Mod {
     /// to the last token in the external file.
     pub inner: Span,
     pub view_items: Vec<ViewItem>,
-    pub items: Vec<@Item>,
+    pub items: Vec<Gc<Item>>,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct ForeignMod {
     pub abi: Abi,
     pub view_items: Vec<ViewItem>,
-    pub items: Vec<@ForeignItem>,
+    pub items: Vec<Gc<ForeignItem>>,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
@@ -922,7 +923,7 @@ pub struct VariantArg {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum VariantKind {
     TupleVariantKind(Vec<VariantArg>),
-    StructVariantKind(@StructDef),
+    StructVariantKind(Gc<StructDef>),
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
@@ -936,7 +937,7 @@ pub struct Variant_ {
     pub attrs: Vec<Attribute>,
     pub kind: VariantKind,
     pub id: NodeId,
-    pub disr_expr: Option<@Expr>,
+    pub disr_expr: Option<Gc<Expr>>,
     pub vis: Visibility,
 }
 
@@ -984,7 +985,7 @@ pub enum ViewItem_ {
     // (containing arbitrary characters) from which to fetch the crate sources
     // For example, extern crate whatever = "github.com/mozilla/rust"
     ViewItemExternCrate(Ident, Option<(InternedString,StrStyle)>, NodeId),
-    ViewItemUse(@ViewPath),
+    ViewItemUse(Gc<ViewPath>),
 }
 
 // Meta-data associated with an item
@@ -1007,7 +1008,7 @@ pub struct AttrId(pub uint);
 pub struct Attribute_ {
     pub id: AttrId,
     pub style: AttrStyle,
-    pub value: @MetaItem,
+    pub value: Gc<MetaItem>,
     pub is_sugared_doc: bool,
 }
 
@@ -1105,18 +1106,18 @@ pub struct Item {
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum Item_ {
-    ItemStatic(P<Ty>, Mutability, @Expr),
+    ItemStatic(P<Ty>, Mutability, Gc<Expr>),
     ItemFn(P<FnDecl>, FnStyle, Abi, Generics, P<Block>),
     ItemMod(Mod),
     ItemForeignMod(ForeignMod),
     ItemTy(P<Ty>, Generics),
     ItemEnum(EnumDef, Generics),
-    ItemStruct(@StructDef, Generics),
+    ItemStruct(Gc<StructDef>, Generics),
     ItemTrait(Generics, Sized, Vec<TraitRef> , Vec<TraitMethod> ),
     ItemImpl(Generics,
              Option<TraitRef>, // (optional) trait this impl implements
              P<Ty>, // self
-             Vec<@Method> ),
+             Vec<Gc<Method>>),
     // a macro invocation (which includes macro definition)
     ItemMac(Mac),
 }
@@ -1142,9 +1143,9 @@ pub enum ForeignItem_ {
 // that we trans.
 #[deriving(PartialEq, Eq, Encodable, Decodable, Hash)]
 pub enum InlinedItem {
-    IIItem(@Item),
-    IIMethod(DefId /* impl id */, bool /* is provided */, @Method),
-    IIForeign(@ForeignItem),
+    IIItem(Gc<Item>),
+    IIMethod(DefId /* impl id */, bool /* is provided */, Gc<Method>),
+    IIForeign(Gc<ForeignItem>),
 }
 
 #[cfg(test)]

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -23,8 +23,8 @@ source code snippets, etc.
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 use std::cell::RefCell;
+use std::gc::Gc;
 use std::rc::Rc;
-use std::string::String;
 
 pub trait Pos {
     fn from_uint(n: uint) -> Self;
@@ -91,7 +91,7 @@ pub struct Span {
     pub hi: BytePos,
     /// Information about where the macro came from, if this piece of
     /// code was created by a macro expansion.
-    pub expn_info: Option<@ExpnInfo>
+    pub expn_info: Option<Gc<ExpnInfo>>
 }
 
 pub static DUMMY_SP: Span = Span { lo: BytePos(0), hi: BytePos(0), expn_info: None };

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -20,7 +20,6 @@ use parse;
 use parse::token::InternedString;
 use parse::token;
 
-
 enum State {
     Asm,
     Outputs,
@@ -214,7 +213,7 @@ pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                                                  out));
     }
 
-    MacExpr::new(@ast::Expr {
+    MacExpr::new(box(GC) ast::Expr {
         id: ast::DUMMY_NODE_ID,
         node: ast::ExprInlineAsm(ast::InlineAsm {
             asm: token::intern_and_get_ident(asm.get()),

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -20,6 +20,7 @@ use parse::token::{InternedString, intern, str_to_ident};
 use util::small_vector::SmallVector;
 
 use std::collections::HashMap;
+use std::gc::Gc;
 
 // new-style macro! tt code:
 //
@@ -35,10 +36,10 @@ pub struct MacroDef {
 }
 
 pub type ItemDecorator =
-    fn(&mut ExtCtxt, Span, @ast::MetaItem, @ast::Item, |@ast::Item|);
+    fn(&mut ExtCtxt, Span, Gc<ast::MetaItem>, Gc<ast::Item>, |Gc<ast::Item>|);
 
 pub type ItemModifier =
-    fn(&mut ExtCtxt, Span, @ast::MetaItem, @ast::Item) -> @ast::Item;
+    fn(&mut ExtCtxt, Span, Gc<ast::MetaItem>, Gc<ast::Item>) -> Gc<ast::Item>;
 
 pub struct BasicMacroExpander {
     pub expander: MacroExpanderFn,
@@ -104,11 +105,11 @@ pub trait MacResult {
         None
     }
     /// Create an expression.
-    fn make_expr(&self) -> Option<@ast::Expr> {
+    fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         None
     }
     /// Create zero or more items.
-    fn make_items(&self) -> Option<SmallVector<@ast::Item>> {
+    fn make_items(&self) -> Option<SmallVector<Gc<ast::Item>>> {
         None
     }
     /// Create a pattern.
@@ -120,23 +121,23 @@ pub trait MacResult {
     ///
     /// By default this attempts to create an expression statement,
     /// returning None if that fails.
-    fn make_stmt(&self) -> Option<@ast::Stmt> {
+    fn make_stmt(&self) -> Option<Gc<ast::Stmt>> {
         self.make_expr()
-            .map(|e| @codemap::respan(e.span, ast::StmtExpr(e, ast::DUMMY_NODE_ID)))
+            .map(|e| box(GC) codemap::respan(e.span, ast::StmtExpr(e, ast::DUMMY_NODE_ID)))
     }
 }
 
 /// A convenience type for macros that return a single expression.
 pub struct MacExpr {
-    e: @ast::Expr
+    e: Gc<ast::Expr>,
 }
 impl MacExpr {
-    pub fn new(e: @ast::Expr) -> Box<MacResult> {
+    pub fn new(e: Gc<ast::Expr>) -> Box<MacResult> {
         box MacExpr { e: e } as Box<MacResult>
     }
 }
 impl MacResult for MacExpr {
-    fn make_expr(&self) -> Option<@ast::Expr> {
+    fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         Some(self.e)
     }
 }
@@ -156,22 +157,22 @@ impl MacResult for MacPat {
 }
 /// A convenience type for macros that return a single item.
 pub struct MacItem {
-    i: @ast::Item
+    i: Gc<ast::Item>
 }
 impl MacItem {
-    pub fn new(i: @ast::Item) -> Box<MacResult> {
+    pub fn new(i: Gc<ast::Item>) -> Box<MacResult> {
         box MacItem { i: i } as Box<MacResult>
     }
 }
 impl MacResult for MacItem {
-    fn make_items(&self) -> Option<SmallVector<@ast::Item>> {
+    fn make_items(&self) -> Option<SmallVector<Gc<ast::Item>>> {
         Some(SmallVector::one(self.i))
     }
-    fn make_stmt(&self) -> Option<@ast::Stmt> {
-        Some(@codemap::respan(
+    fn make_stmt(&self) -> Option<Gc<ast::Stmt>> {
+        Some(box(GC) codemap::respan(
             self.i.span,
             ast::StmtDecl(
-                @codemap::respan(self.i.span, ast::DeclItem(self.i)),
+                box(GC) codemap::respan(self.i.span, ast::DeclItem(self.i)),
                 ast::DUMMY_NODE_ID)))
     }
 }
@@ -202,10 +203,10 @@ impl DummyResult {
     }
 
     /// A plain dummy expression.
-    pub fn raw_expr(sp: Span) -> @ast::Expr {
-        @ast::Expr {
+    pub fn raw_expr(sp: Span) -> Gc<ast::Expr> {
+        box(GC) ast::Expr {
             id: ast::DUMMY_NODE_ID,
-            node: ast::ExprLit(@codemap::respan(sp, ast::LitNil)),
+            node: ast::ExprLit(box(GC) codemap::respan(sp, ast::LitNil)),
             span: sp,
         }
     }
@@ -221,21 +222,21 @@ impl DummyResult {
 }
 
 impl MacResult for DummyResult {
-    fn make_expr(&self) -> Option<@ast::Expr> {
+    fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         Some(DummyResult::raw_expr(self.span))
     }
-    fn make_pat(&self) -> Option<@ast::Pat> {
+    fn make_pat(&self) -> Option<Gc<ast::Pat>> {
         Some(DummyResult::raw_pat(self.span))
     }
-    fn make_items(&self) -> Option<SmallVector<@ast::Item>> {
+    fn make_items(&self) -> Option<SmallVector<Gc<ast::Item>>> {
         if self.expr_only {
             None
         } else {
             Some(SmallVector::zero())
         }
     }
-    fn make_stmt(&self) -> Option<@ast::Stmt> {
-        Some(@codemap::respan(self.span,
+    fn make_stmt(&self) -> Option<Gc<ast::Stmt>> {
+        Some(box(GC) codemap::respan(self.span,
                               ast::StmtExpr(DummyResult::raw_expr(self.span),
                                             ast::DUMMY_NODE_ID)))
     }
@@ -397,7 +398,7 @@ pub fn syntax_expander_table() -> SyntaxEnv {
 pub struct ExtCtxt<'a> {
     pub parse_sess: &'a parse::ParseSess,
     pub cfg: ast::CrateConfig,
-    pub backtrace: Option<@ExpnInfo>,
+    pub backtrace: Option<Gc<ExpnInfo>>,
     pub ecfg: expand::ExpansionConfig,
 
     pub mod_path: Vec<ast::Ident> ,
@@ -417,7 +418,7 @@ impl<'a> ExtCtxt<'a> {
         }
     }
 
-    pub fn expand_expr(&mut self, mut e: @ast::Expr) -> @ast::Expr {
+    pub fn expand_expr(&mut self, mut e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         loop {
             match e.node {
                 ast::ExprMac(..) => {
@@ -442,7 +443,7 @@ impl<'a> ExtCtxt<'a> {
         }
     }
     pub fn print_backtrace(&self) { }
-    pub fn backtrace(&self) -> Option<@ExpnInfo> { self.backtrace }
+    pub fn backtrace(&self) -> Option<Gc<ExpnInfo>> { self.backtrace }
     pub fn mod_push(&mut self, i: ast::Ident) { self.mod_path.push(i); }
     pub fn mod_pop(&mut self) { self.mod_path.pop().unwrap(); }
     pub fn mod_path(&self) -> Vec<ast::Ident> {
@@ -455,9 +456,9 @@ impl<'a> ExtCtxt<'a> {
         match ei {
             ExpnInfo {call_site: cs, callee: ref callee} => {
                 self.backtrace =
-                    Some(@ExpnInfo {
+                    Some(box(GC) ExpnInfo {
                         call_site: Span {lo: cs.lo, hi: cs.hi,
-                                         expn_info: self.backtrace},
+                                         expn_info: self.backtrace.clone()},
                         callee: (*callee).clone()
                     });
             }
@@ -528,7 +529,7 @@ impl<'a> ExtCtxt<'a> {
 /// Extract a string literal from the macro expanded version of `expr`,
 /// emitting `err_msg` if `expr` is not a string literal. This does not stop
 /// compilation on error, merely emits a non-fatal error and returns None.
-pub fn expr_to_str(cx: &mut ExtCtxt, expr: @ast::Expr, err_msg: &str)
+pub fn expr_to_str(cx: &mut ExtCtxt, expr: Gc<ast::Expr>, err_msg: &str)
                    -> Option<(InternedString, ast::StrStyle)> {
     // we want to be able to handle e.g. concat("foo", "bar")
     let expr = cx.expand_expr(expr);
@@ -584,7 +585,7 @@ pub fn get_single_str_from_tts(cx: &ExtCtxt,
 /// parsing error, emit a non-fatal error and return None.
 pub fn get_exprs_from_tts(cx: &mut ExtCtxt,
                           sp: Span,
-                          tts: &[ast::TokenTree]) -> Option<Vec<@ast::Expr> > {
+                          tts: &[ast::TokenTree]) -> Option<Vec<Gc<ast::Expr>>> {
     let mut p = parse::new_parser_from_tts(cx.parse_sess(),
                                            cx.cfg(),
                                            tts.iter()

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -113,7 +113,7 @@ pub trait MacResult {
         None
     }
     /// Create a pattern.
-    fn make_pat(&self) -> Option<@ast::Pat> {
+    fn make_pat(&self) -> Option<Gc<ast::Pat>> {
         None
     }
 
@@ -143,15 +143,15 @@ impl MacResult for MacExpr {
 }
 /// A convenience type for macros that return a single pattern.
 pub struct MacPat {
-    p: @ast::Pat
+    p: Gc<ast::Pat>,
 }
 impl MacPat {
-    pub fn new(p: @ast::Pat) -> Box<MacResult> {
+    pub fn new(p: Gc<ast::Pat>) -> Box<MacResult> {
         box MacPat { p: p } as Box<MacResult>
     }
 }
 impl MacResult for MacPat {
-    fn make_pat(&self) -> Option<@ast::Pat> {
+    fn make_pat(&self) -> Option<Gc<ast::Pat>> {
         Some(self.p)
     }
 }
@@ -212,8 +212,8 @@ impl DummyResult {
     }
 
     /// A plain dummy pattern.
-    pub fn raw_pat(sp: Span) -> @ast::Pat {
-        @ast::Pat {
+    pub fn raw_pat(sp: Span) -> Gc<ast::Pat> {
+        box(GC) ast::Pat {
             id: ast::DUMMY_NODE_ID,
             node: ast::PatWild,
             span: sp,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -21,6 +21,8 @@ use parse::token::special_idents;
 use parse::token::InternedString;
 use parse::token;
 
+use std::gc::Gc;
+
 // Transitional reexports so qquote can find the paths it is looking for
 mod syntax {
     pub use ext;
@@ -73,115 +75,129 @@ pub trait AstBuilder {
     fn lifetime(&self, span: Span, ident: ast::Name) -> ast::Lifetime;
 
     // statements
-    fn stmt_expr(&self, expr: @ast::Expr) -> @ast::Stmt;
-    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident, ex: @ast::Expr) -> @ast::Stmt;
+    fn stmt_expr(&self, expr: Gc<ast::Expr>) -> Gc<ast::Stmt>;
+    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
+                ex: Gc<ast::Expr>) -> Gc<ast::Stmt>;
     fn stmt_let_typed(&self,
                       sp: Span,
                       mutbl: bool,
                       ident: ast::Ident,
                       typ: P<ast::Ty>,
-                      ex: @ast::Expr)
-                      -> @ast::Stmt;
+                      ex: Gc<ast::Expr>)
+                      -> Gc<ast::Stmt>;
 
     // blocks
-    fn block(&self, span: Span, stmts: Vec<@ast::Stmt> , expr: Option<@ast::Expr>) -> P<ast::Block>;
-    fn block_expr(&self, expr: @ast::Expr) -> P<ast::Block>;
+    fn block(&self, span: Span, stmts: Vec<Gc<ast::Stmt>>,
+             expr: Option<Gc<ast::Expr>>) -> P<ast::Block>;
+    fn block_expr(&self, expr: Gc<ast::Expr>) -> P<ast::Block>;
     fn block_all(&self, span: Span,
                  view_items: Vec<ast::ViewItem> ,
-                 stmts: Vec<@ast::Stmt> ,
-                 expr: Option<@ast::Expr>) -> P<ast::Block>;
+                 stmts: Vec<Gc<ast::Stmt>> ,
+                 expr: Option<Gc<ast::Expr>>) -> P<ast::Block>;
 
     // expressions
-    fn expr(&self, span: Span, node: ast::Expr_) -> @ast::Expr;
-    fn expr_path(&self, path: ast::Path) -> @ast::Expr;
-    fn expr_ident(&self, span: Span, id: ast::Ident) -> @ast::Expr;
+    fn expr(&self, span: Span, node: ast::Expr_) -> Gc<ast::Expr>;
+    fn expr_path(&self, path: ast::Path) -> Gc<ast::Expr>;
+    fn expr_ident(&self, span: Span, id: ast::Ident) -> Gc<ast::Expr>;
 
-    fn expr_self(&self, span: Span) -> @ast::Expr;
+    fn expr_self(&self, span: Span) -> Gc<ast::Expr>;
     fn expr_binary(&self, sp: Span, op: ast::BinOp,
-                   lhs: @ast::Expr, rhs: @ast::Expr) -> @ast::Expr;
-    fn expr_deref(&self, sp: Span, e: @ast::Expr) -> @ast::Expr;
-    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: @ast::Expr) -> @ast::Expr;
+                   lhs: Gc<ast::Expr>, rhs: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_deref(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: Gc<ast::Expr>) -> Gc<ast::Expr>;
 
-    fn expr_managed(&self, sp: Span, e: @ast::Expr) -> @ast::Expr;
-    fn expr_addr_of(&self, sp: Span, e: @ast::Expr) -> @ast::Expr;
-    fn expr_mut_addr_of(&self, sp: Span, e: @ast::Expr) -> @ast::Expr;
-    fn expr_field_access(&self, span: Span, expr: @ast::Expr, ident: ast::Ident) -> @ast::Expr;
-    fn expr_call(&self, span: Span, expr: @ast::Expr, args: Vec<@ast::Expr> ) -> @ast::Expr;
-    fn expr_call_ident(&self, span: Span, id: ast::Ident, args: Vec<@ast::Expr> ) -> @ast::Expr;
+    fn expr_managed(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_addr_of(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_mut_addr_of(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_field_access(&self, span: Span, expr: Gc<ast::Expr>,
+                         ident: ast::Ident) -> Gc<ast::Expr>;
+    fn expr_call(&self, span: Span, expr: Gc<ast::Expr>,
+                 args: Vec<Gc<ast::Expr>>) -> Gc<ast::Expr>;
+    fn expr_call_ident(&self, span: Span, id: ast::Ident,
+                       args: Vec<Gc<ast::Expr>>) -> Gc<ast::Expr>;
     fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident> ,
-                        args: Vec<@ast::Expr> ) -> @ast::Expr;
+                        args: Vec<Gc<ast::Expr>>) -> Gc<ast::Expr>;
     fn expr_method_call(&self, span: Span,
-                        expr: @ast::Expr, ident: ast::Ident,
-                        args: Vec<@ast::Expr> ) -> @ast::Expr;
-    fn expr_block(&self, b: P<ast::Block>) -> @ast::Expr;
-    fn expr_cast(&self, sp: Span, expr: @ast::Expr, ty: P<ast::Ty>) -> @ast::Expr;
+                        expr: Gc<ast::Expr>, ident: ast::Ident,
+                        args: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr>;
+    fn expr_block(&self, b: P<ast::Block>) -> Gc<ast::Expr>;
+    fn expr_cast(&self, sp: Span, expr: Gc<ast::Expr>,
+                 ty: P<ast::Ty>) -> Gc<ast::Expr>;
 
-    fn field_imm(&self, span: Span, name: Ident, e: @ast::Expr) -> ast::Field;
-    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field> ) -> @ast::Expr;
-    fn expr_struct_ident(&self, span: Span, id: ast::Ident, fields: Vec<ast::Field> ) -> @ast::Expr;
+    fn field_imm(&self, span: Span, name: Ident, e: Gc<ast::Expr>) -> ast::Field;
+    fn expr_struct(&self, span: Span, path: ast::Path,
+                   fields: Vec<ast::Field> ) -> Gc<ast::Expr>;
+    fn expr_struct_ident(&self, span: Span, id: ast::Ident,
+                         fields: Vec<ast::Field> ) -> Gc<ast::Expr>;
 
-    fn expr_lit(&self, sp: Span, lit: ast::Lit_) -> @ast::Expr;
+    fn expr_lit(&self, sp: Span, lit: ast::Lit_) -> Gc<ast::Expr>;
 
-    fn expr_uint(&self, span: Span, i: uint) -> @ast::Expr;
-    fn expr_int(&self, sp: Span, i: int) -> @ast::Expr;
-    fn expr_u8(&self, sp: Span, u: u8) -> @ast::Expr;
-    fn expr_bool(&self, sp: Span, value: bool) -> @ast::Expr;
+    fn expr_uint(&self, span: Span, i: uint) -> Gc<ast::Expr>;
+    fn expr_int(&self, sp: Span, i: int) -> Gc<ast::Expr>;
+    fn expr_u8(&self, sp: Span, u: u8) -> Gc<ast::Expr>;
+    fn expr_bool(&self, sp: Span, value: bool) -> Gc<ast::Expr>;
 
-    fn expr_vstore(&self, sp: Span, expr: @ast::Expr, vst: ast::ExprVstore) -> @ast::Expr;
-    fn expr_vec(&self, sp: Span, exprs: Vec<@ast::Expr> ) -> @ast::Expr;
-    fn expr_vec_ng(&self, sp: Span) -> @ast::Expr;
-    fn expr_vec_slice(&self, sp: Span, exprs: Vec<@ast::Expr> ) -> @ast::Expr;
-    fn expr_str(&self, sp: Span, s: InternedString) -> @ast::Expr;
-    fn expr_str_uniq(&self, sp: Span, s: InternedString) -> @ast::Expr;
+    fn expr_vstore(&self, sp: Span, expr: Gc<ast::Expr>, vst: ast::ExprVstore) -> Gc<ast::Expr>;
+    fn expr_vec(&self, sp: Span, exprs: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr>;
+    fn expr_vec_ng(&self, sp: Span) -> Gc<ast::Expr>;
+    fn expr_vec_slice(&self, sp: Span, exprs: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr>;
+    fn expr_str(&self, sp: Span, s: InternedString) -> Gc<ast::Expr>;
+    fn expr_str_uniq(&self, sp: Span, s: InternedString) -> Gc<ast::Expr>;
 
-    fn expr_some(&self, sp: Span, expr: @ast::Expr) -> @ast::Expr;
-    fn expr_none(&self, sp: Span) -> @ast::Expr;
+    fn expr_some(&self, sp: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_none(&self, sp: Span) -> Gc<ast::Expr>;
 
-    fn expr_fail(&self, span: Span, msg: InternedString) -> @ast::Expr;
-    fn expr_unreachable(&self, span: Span) -> @ast::Expr;
+    fn expr_fail(&self, span: Span, msg: InternedString) -> Gc<ast::Expr>;
+    fn expr_unreachable(&self, span: Span) -> Gc<ast::Expr>;
 
-    fn expr_ok(&self, span: Span, expr: @ast::Expr) -> @ast::Expr;
-    fn expr_err(&self, span: Span, expr: @ast::Expr) -> @ast::Expr;
-    fn expr_try(&self, span: Span, head: @ast::Expr) -> @ast::Expr;
+    fn expr_ok(&self, span: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_err(&self, span: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn expr_try(&self, span: Span, head: Gc<ast::Expr>) -> Gc<ast::Expr>;
 
-    fn pat(&self, span: Span, pat: ast::Pat_) -> @ast::Pat;
-    fn pat_wild(&self, span: Span) -> @ast::Pat;
-    fn pat_lit(&self, span: Span, expr: @ast::Expr) -> @ast::Pat;
-    fn pat_ident(&self, span: Span, ident: ast::Ident) -> @ast::Pat;
+    fn pat(&self, span: Span, pat: ast::Pat_) -> Gc<ast::Pat>;
+    fn pat_wild(&self, span: Span) -> Gc<ast::Pat>;
+    fn pat_lit(&self, span: Span, expr: Gc<ast::Expr>) -> Gc<ast::Pat>;
+    fn pat_ident(&self, span: Span, ident: ast::Ident) -> Gc<ast::Pat>;
 
     fn pat_ident_binding_mode(&self,
                               span: Span,
                               ident: ast::Ident,
-                              bm: ast::BindingMode) -> @ast::Pat;
-    fn pat_enum(&self, span: Span, path: ast::Path, subpats: Vec<@ast::Pat> ) -> @ast::Pat;
+                              bm: ast::BindingMode) -> Gc<ast::Pat>;
+    fn pat_enum(&self, span: Span, path: ast::Path,
+                subpats: Vec<Gc<ast::Pat>>) -> Gc<ast::Pat>;
     fn pat_struct(&self, span: Span,
-                  path: ast::Path, field_pats: Vec<ast::FieldPat> ) -> @ast::Pat;
+                  path: ast::Path, field_pats: Vec<ast::FieldPat> ) -> Gc<ast::Pat>;
 
-    fn arm(&self, span: Span, pats: Vec<@ast::Pat> , expr: @ast::Expr) -> ast::Arm;
+    fn arm(&self, span: Span, pats: Vec<Gc<ast::Pat>> , expr: Gc<ast::Expr>) -> ast::Arm;
     fn arm_unreachable(&self, span: Span) -> ast::Arm;
 
-    fn expr_match(&self, span: Span, arg: @ast::Expr, arms: Vec<ast::Arm> ) -> @ast::Expr;
+    fn expr_match(&self, span: Span, arg: Gc<ast::Expr>, arms: Vec<ast::Arm> ) -> Gc<ast::Expr>;
     fn expr_if(&self, span: Span,
-               cond: @ast::Expr, then: @ast::Expr, els: Option<@ast::Expr>) -> @ast::Expr;
+               cond: Gc<ast::Expr>, then: Gc<ast::Expr>,
+               els: Option<Gc<ast::Expr>>) -> Gc<ast::Expr>;
 
     fn lambda_fn_decl(&self, span: Span,
-                      fn_decl: P<ast::FnDecl>, blk: P<ast::Block>) -> @ast::Expr;
+                      fn_decl: P<ast::FnDecl>, blk: P<ast::Block>) -> Gc<ast::Expr>;
 
-    fn lambda(&self, span: Span, ids: Vec<ast::Ident> , blk: P<ast::Block>) -> @ast::Expr;
-    fn lambda0(&self, span: Span, blk: P<ast::Block>) -> @ast::Expr;
-    fn lambda1(&self, span: Span, blk: P<ast::Block>, ident: ast::Ident) -> @ast::Expr;
+    fn lambda(&self, span: Span, ids: Vec<ast::Ident> , blk: P<ast::Block>) -> Gc<ast::Expr>;
+    fn lambda0(&self, span: Span, blk: P<ast::Block>) -> Gc<ast::Expr>;
+    fn lambda1(&self, span: Span, blk: P<ast::Block>, ident: ast::Ident) -> Gc<ast::Expr>;
 
-    fn lambda_expr(&self, span: Span, ids: Vec<ast::Ident> , blk: @ast::Expr) -> @ast::Expr;
-    fn lambda_expr_0(&self, span: Span, expr: @ast::Expr) -> @ast::Expr;
-    fn lambda_expr_1(&self, span: Span, expr: @ast::Expr, ident: ast::Ident) -> @ast::Expr;
+    fn lambda_expr(&self, span: Span, ids: Vec<ast::Ident> , blk: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn lambda_expr_0(&self, span: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr>;
+    fn lambda_expr_1(&self, span: Span, expr: Gc<ast::Expr>, ident: ast::Ident) -> Gc<ast::Expr>;
 
-    fn lambda_stmts(&self, span: Span, ids: Vec<ast::Ident> , blk: Vec<@ast::Stmt> ) -> @ast::Expr;
-    fn lambda_stmts_0(&self, span: Span, stmts: Vec<@ast::Stmt> ) -> @ast::Expr;
-    fn lambda_stmts_1(&self, span: Span, stmts: Vec<@ast::Stmt> , ident: ast::Ident) -> @ast::Expr;
+    fn lambda_stmts(&self, span: Span, ids: Vec<ast::Ident>,
+                    blk: Vec<Gc<ast::Stmt>>) -> Gc<ast::Expr>;
+    fn lambda_stmts_0(&self, span: Span,
+                      stmts: Vec<Gc<ast::Stmt>>) -> Gc<ast::Expr>;
+    fn lambda_stmts_1(&self, span: Span,
+                      stmts: Vec<Gc<ast::Stmt>>, ident: ast::Ident) -> Gc<ast::Expr>;
 
     // items
     fn item(&self, span: Span,
-            name: Ident, attrs: Vec<ast::Attribute> , node: ast::Item_) -> @ast::Item;
+            name: Ident, attrs: Vec<ast::Attribute>,
+            node: ast::Item_) -> Gc<ast::Item>;
 
     fn arg(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> ast::Arg;
     // FIXME unused self
@@ -193,56 +209,59 @@ pub trait AstBuilder {
                     inputs: Vec<ast::Arg> ,
                     output: P<ast::Ty>,
                     generics: Generics,
-                    body: P<ast::Block>) -> @ast::Item;
+                    body: P<ast::Block>) -> Gc<ast::Item>;
     fn item_fn(&self,
                span: Span,
                name: Ident,
                inputs: Vec<ast::Arg> ,
                output: P<ast::Ty>,
-               body: P<ast::Block>) -> @ast::Item;
+               body: P<ast::Block>) -> Gc<ast::Item>;
 
     fn variant(&self, span: Span, name: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant;
     fn item_enum_poly(&self,
                       span: Span,
                       name: Ident,
                       enum_definition: ast::EnumDef,
-                      generics: Generics) -> @ast::Item;
-    fn item_enum(&self, span: Span, name: Ident, enum_def: ast::EnumDef) -> @ast::Item;
+                      generics: Generics) -> Gc<ast::Item>;
+    fn item_enum(&self, span: Span, name: Ident,
+                 enum_def: ast::EnumDef) -> Gc<ast::Item>;
 
     fn item_struct_poly(&self,
                         span: Span,
                         name: Ident,
                         struct_def: ast::StructDef,
-                        generics: Generics) -> @ast::Item;
-    fn item_struct(&self, span: Span, name: Ident, struct_def: ast::StructDef) -> @ast::Item;
+                        generics: Generics) -> Gc<ast::Item>;
+    fn item_struct(&self, span: Span, name: Ident,
+                   struct_def: ast::StructDef) -> Gc<ast::Item>;
 
     fn item_mod(&self, span: Span, inner_span: Span,
-                name: Ident, attrs: Vec<ast::Attribute> ,
-                vi: Vec<ast::ViewItem> , items: Vec<@ast::Item> ) -> @ast::Item;
+                name: Ident, attrs: Vec<ast::Attribute>,
+                vi: Vec<ast::ViewItem>,
+                items: Vec<Gc<ast::Item>>) -> Gc<ast::Item>;
 
     fn item_ty_poly(&self,
                     span: Span,
                     name: Ident,
                     ty: P<ast::Ty>,
-                    generics: Generics) -> @ast::Item;
-    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> @ast::Item;
+                    generics: Generics) -> Gc<ast::Item>;
+    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> Gc<ast::Item>;
 
-    fn attribute(&self, sp: Span, mi: @ast::MetaItem) -> ast::Attribute;
+    fn attribute(&self, sp: Span, mi: Gc<ast::MetaItem>) -> ast::Attribute;
 
-    fn meta_word(&self, sp: Span, w: InternedString) -> @ast::MetaItem;
+    fn meta_word(&self, sp: Span, w: InternedString) -> Gc<ast::MetaItem>;
     fn meta_list(&self,
                  sp: Span,
                  name: InternedString,
-                 mis: Vec<@ast::MetaItem> )
-                 -> @ast::MetaItem;
+                 mis: Vec<Gc<ast::MetaItem>>)
+                 -> Gc<ast::MetaItem>;
     fn meta_name_value(&self,
                        sp: Span,
                        name: InternedString,
                        value: ast::Lit_)
-                       -> @ast::MetaItem;
+                       -> Gc<ast::MetaItem>;
 
     fn view_use(&self, sp: Span,
-                vis: ast::Visibility, vp: @ast::ViewPath) -> ast::ViewItem;
+                vis: ast::Visibility, vp: Gc<ast::ViewPath>) -> ast::ViewItem;
     fn view_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> ast::ViewItem;
     fn view_use_simple_(&self, sp: Span, vis: ast::Visibility,
                         ident: ast::Ident, path: ast::Path) -> ast::ViewItem;
@@ -418,17 +437,18 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         ast::Lifetime { id: ast::DUMMY_NODE_ID, span: span, name: name }
     }
 
-    fn stmt_expr(&self, expr: @ast::Expr) -> @ast::Stmt {
-        @respan(expr.span, ast::StmtSemi(expr, ast::DUMMY_NODE_ID))
+    fn stmt_expr(&self, expr: Gc<ast::Expr>) -> Gc<ast::Stmt> {
+        box(GC) respan(expr.span, ast::StmtSemi(expr, ast::DUMMY_NODE_ID))
     }
 
-    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident, ex: @ast::Expr) -> @ast::Stmt {
+    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
+                ex: Gc<ast::Expr>) -> Gc<ast::Stmt> {
         let pat = if mutbl {
             self.pat_ident_binding_mode(sp, ident, ast::BindByValue(ast::MutMutable))
         } else {
             self.pat_ident(sp, ident)
         };
-        let local = @ast::Local {
+        let local = box(GC) ast::Local {
             ty: self.ty_infer(sp),
             pat: pat,
             init: Some(ex),
@@ -437,7 +457,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             source: ast::LocalLet,
         };
         let decl = respan(sp, ast::DeclLocal(local));
-        @respan(sp, ast::StmtDecl(@decl, ast::DUMMY_NODE_ID))
+        box(GC) respan(sp, ast::StmtDecl(box(GC) decl, ast::DUMMY_NODE_ID))
     }
 
     fn stmt_let_typed(&self,
@@ -445,14 +465,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                       mutbl: bool,
                       ident: ast::Ident,
                       typ: P<ast::Ty>,
-                      ex: @ast::Expr)
-                      -> @ast::Stmt {
+                      ex: Gc<ast::Expr>)
+                      -> Gc<ast::Stmt> {
         let pat = if mutbl {
             self.pat_ident_binding_mode(sp, ident, ast::BindByValue(ast::MutMutable))
         } else {
             self.pat_ident(sp, ident)
         };
-        let local = @ast::Local {
+        let local = box(GC) ast::Local {
             ty: typ,
             pat: pat,
             init: Some(ex),
@@ -461,21 +481,22 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             source: ast::LocalLet,
         };
         let decl = respan(sp, ast::DeclLocal(local));
-        @respan(sp, ast::StmtDecl(@decl, ast::DUMMY_NODE_ID))
+        box(GC) respan(sp, ast::StmtDecl(box(GC) decl, ast::DUMMY_NODE_ID))
     }
 
-    fn block(&self, span: Span, stmts: Vec<@ast::Stmt> , expr: Option<@Expr>) -> P<ast::Block> {
+    fn block(&self, span: Span, stmts: Vec<Gc<ast::Stmt>>,
+             expr: Option<Gc<Expr>>) -> P<ast::Block> {
         self.block_all(span, Vec::new(), stmts, expr)
     }
 
-    fn block_expr(&self, expr: @ast::Expr) -> P<ast::Block> {
+    fn block_expr(&self, expr: Gc<ast::Expr>) -> P<ast::Block> {
         self.block_all(expr.span, Vec::new(), Vec::new(), Some(expr))
     }
     fn block_all(&self,
                  span: Span,
                  view_items: Vec<ast::ViewItem> ,
-                 stmts: Vec<@ast::Stmt> ,
-                 expr: Option<@ast::Expr>) -> P<ast::Block> {
+                 stmts: Vec<Gc<ast::Stmt>>,
+                 expr: Option<Gc<ast::Expr>>) -> P<ast::Block> {
             P(ast::Block {
                view_items: view_items,
                stmts: stmts,
@@ -486,107 +507,109 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             })
     }
 
-    fn expr(&self, span: Span, node: ast::Expr_) -> @ast::Expr {
-        @ast::Expr {
+    fn expr(&self, span: Span, node: ast::Expr_) -> Gc<ast::Expr> {
+        box(GC) ast::Expr {
             id: ast::DUMMY_NODE_ID,
             node: node,
             span: span,
         }
     }
 
-    fn expr_path(&self, path: ast::Path) -> @ast::Expr {
+    fn expr_path(&self, path: ast::Path) -> Gc<ast::Expr> {
         self.expr(path.span, ast::ExprPath(path))
     }
 
-    fn expr_ident(&self, span: Span, id: ast::Ident) -> @ast::Expr {
+    fn expr_ident(&self, span: Span, id: ast::Ident) -> Gc<ast::Expr> {
         self.expr_path(self.path_ident(span, id))
     }
-    fn expr_self(&self, span: Span) -> @ast::Expr {
+    fn expr_self(&self, span: Span) -> Gc<ast::Expr> {
         self.expr_ident(span, special_idents::self_)
     }
 
     fn expr_binary(&self, sp: Span, op: ast::BinOp,
-                   lhs: @ast::Expr, rhs: @ast::Expr) -> @ast::Expr {
+                   lhs: Gc<ast::Expr>, rhs: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprBinary(op, lhs, rhs))
     }
 
-    fn expr_deref(&self, sp: Span, e: @ast::Expr) -> @ast::Expr {
+    fn expr_deref(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr_unary(sp, ast::UnDeref, e)
     }
-    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: @ast::Expr) -> @ast::Expr {
+    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprUnary(op, e))
     }
 
-    fn expr_managed(&self, sp: Span, e: @ast::Expr) -> @ast::Expr {
+    fn expr_managed(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr_unary(sp, ast::UnBox, e)
     }
 
-    fn expr_field_access(&self, sp: Span, expr: @ast::Expr, ident: ast::Ident) -> @ast::Expr {
+    fn expr_field_access(&self, sp: Span, expr: Gc<ast::Expr>, ident: ast::Ident) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprField(expr, ident, Vec::new()))
     }
-    fn expr_addr_of(&self, sp: Span, e: @ast::Expr) -> @ast::Expr {
+    fn expr_addr_of(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprAddrOf(ast::MutImmutable, e))
     }
-    fn expr_mut_addr_of(&self, sp: Span, e: @ast::Expr) -> @ast::Expr {
+    fn expr_mut_addr_of(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprAddrOf(ast::MutMutable, e))
     }
 
-    fn expr_call(&self, span: Span, expr: @ast::Expr, args: Vec<@ast::Expr> ) -> @ast::Expr {
+    fn expr_call(&self, span: Span, expr: Gc<ast::Expr>,
+                 args: Vec<Gc<ast::Expr>>) -> Gc<ast::Expr> {
         self.expr(span, ast::ExprCall(expr, args))
     }
-    fn expr_call_ident(&self, span: Span, id: ast::Ident, args: Vec<@ast::Expr> ) -> @ast::Expr {
+    fn expr_call_ident(&self, span: Span, id: ast::Ident,
+                       args: Vec<Gc<ast::Expr>>) -> Gc<ast::Expr> {
         self.expr(span, ast::ExprCall(self.expr_ident(span, id), args))
     }
     fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident> ,
-                      args: Vec<@ast::Expr> ) -> @ast::Expr {
+                      args: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr> {
         let pathexpr = self.expr_path(self.path_global(sp, fn_path));
         self.expr_call(sp, pathexpr, args)
     }
     fn expr_method_call(&self, span: Span,
-                        expr: @ast::Expr,
+                        expr: Gc<ast::Expr>,
                         ident: ast::Ident,
-                        mut args: Vec<@ast::Expr> ) -> @ast::Expr {
+                        mut args: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr> {
         let id = Spanned { node: ident, span: span };
         args.unshift(expr);
         self.expr(span, ast::ExprMethodCall(id, Vec::new(), args))
     }
-    fn expr_block(&self, b: P<ast::Block>) -> @ast::Expr {
+    fn expr_block(&self, b: P<ast::Block>) -> Gc<ast::Expr> {
         self.expr(b.span, ast::ExprBlock(b))
     }
-    fn field_imm(&self, span: Span, name: Ident, e: @ast::Expr) -> ast::Field {
+    fn field_imm(&self, span: Span, name: Ident, e: Gc<ast::Expr>) -> ast::Field {
         ast::Field { ident: respan(span, name), expr: e, span: span }
     }
-    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field> ) -> @ast::Expr {
+    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field> ) -> Gc<ast::Expr> {
         self.expr(span, ast::ExprStruct(path, fields, None))
     }
     fn expr_struct_ident(&self, span: Span,
-                         id: ast::Ident, fields: Vec<ast::Field> ) -> @ast::Expr {
+                         id: ast::Ident, fields: Vec<ast::Field> ) -> Gc<ast::Expr> {
         self.expr_struct(span, self.path_ident(span, id), fields)
     }
 
-    fn expr_lit(&self, sp: Span, lit: ast::Lit_) -> @ast::Expr {
-        self.expr(sp, ast::ExprLit(@respan(sp, lit)))
+    fn expr_lit(&self, sp: Span, lit: ast::Lit_) -> Gc<ast::Expr> {
+        self.expr(sp, ast::ExprLit(box(GC) respan(sp, lit)))
     }
-    fn expr_uint(&self, span: Span, i: uint) -> @ast::Expr {
+    fn expr_uint(&self, span: Span, i: uint) -> Gc<ast::Expr> {
         self.expr_lit(span, ast::LitUint(i as u64, ast::TyU))
     }
-    fn expr_int(&self, sp: Span, i: int) -> @ast::Expr {
+    fn expr_int(&self, sp: Span, i: int) -> Gc<ast::Expr> {
         self.expr_lit(sp, ast::LitInt(i as i64, ast::TyI))
     }
-    fn expr_u8(&self, sp: Span, u: u8) -> @ast::Expr {
+    fn expr_u8(&self, sp: Span, u: u8) -> Gc<ast::Expr> {
         self.expr_lit(sp, ast::LitUint(u as u64, ast::TyU8))
     }
-    fn expr_bool(&self, sp: Span, value: bool) -> @ast::Expr {
+    fn expr_bool(&self, sp: Span, value: bool) -> Gc<ast::Expr> {
         self.expr_lit(sp, ast::LitBool(value))
     }
 
-    fn expr_vstore(&self, sp: Span, expr: @ast::Expr, vst: ast::ExprVstore) -> @ast::Expr {
+    fn expr_vstore(&self, sp: Span, expr: Gc<ast::Expr>, vst: ast::ExprVstore) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprVstore(expr, vst))
     }
-    fn expr_vec(&self, sp: Span, exprs: Vec<@ast::Expr> ) -> @ast::Expr {
+    fn expr_vec(&self, sp: Span, exprs: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprVec(exprs))
     }
-    fn expr_vec_ng(&self, sp: Span) -> @ast::Expr {
+    fn expr_vec_ng(&self, sp: Span) -> Gc<ast::Expr> {
         self.expr_call_global(sp,
                               vec!(self.ident_of("std"),
                                    self.ident_of("vec"),
@@ -594,23 +617,23 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                    self.ident_of("new")),
                               Vec::new())
     }
-    fn expr_vec_slice(&self, sp: Span, exprs: Vec<@ast::Expr> ) -> @ast::Expr {
+    fn expr_vec_slice(&self, sp: Span, exprs: Vec<Gc<ast::Expr>> ) -> Gc<ast::Expr> {
         self.expr_vstore(sp, self.expr_vec(sp, exprs), ast::ExprVstoreSlice)
     }
-    fn expr_str(&self, sp: Span, s: InternedString) -> @ast::Expr {
+    fn expr_str(&self, sp: Span, s: InternedString) -> Gc<ast::Expr> {
         self.expr_lit(sp, ast::LitStr(s, ast::CookedStr))
     }
-    fn expr_str_uniq(&self, sp: Span, s: InternedString) -> @ast::Expr {
+    fn expr_str_uniq(&self, sp: Span, s: InternedString) -> Gc<ast::Expr> {
         self.expr_vstore(sp, self.expr_str(sp, s), ast::ExprVstoreUniq)
     }
 
 
-    fn expr_cast(&self, sp: Span, expr: @ast::Expr, ty: P<ast::Ty>) -> @ast::Expr {
+    fn expr_cast(&self, sp: Span, expr: Gc<ast::Expr>, ty: P<ast::Ty>) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprCast(expr, ty))
     }
 
 
-    fn expr_some(&self, sp: Span, expr: @ast::Expr) -> @ast::Expr {
+    fn expr_some(&self, sp: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         let some = vec!(
             self.ident_of("std"),
             self.ident_of("option"),
@@ -618,7 +641,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.expr_call_global(sp, some, vec!(expr))
     }
 
-    fn expr_none(&self, sp: Span) -> @ast::Expr {
+    fn expr_none(&self, sp: Span) -> Gc<ast::Expr> {
         let none = self.path_global(sp, vec!(
             self.ident_of("std"),
             self.ident_of("option"),
@@ -626,7 +649,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.expr_path(none)
     }
 
-    fn expr_fail(&self, span: Span, msg: InternedString) -> @ast::Expr {
+    fn expr_fail(&self, span: Span, msg: InternedString) -> Gc<ast::Expr> {
         let loc = self.codemap().lookup_char_pos(span.lo);
         self.expr_call_global(
             span,
@@ -643,13 +666,13 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 self.expr_uint(span, loc.line)))
     }
 
-    fn expr_unreachable(&self, span: Span) -> @ast::Expr {
+    fn expr_unreachable(&self, span: Span) -> Gc<ast::Expr> {
         self.expr_fail(span,
                        InternedString::new(
                            "internal error: entered unreachable code"))
     }
 
-    fn expr_ok(&self, sp: Span, expr: @ast::Expr) -> @ast::Expr {
+    fn expr_ok(&self, sp: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         let ok = vec!(
             self.ident_of("std"),
             self.ident_of("result"),
@@ -657,7 +680,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.expr_call_global(sp, ok, vec!(expr))
     }
 
-    fn expr_err(&self, sp: Span, expr: @ast::Expr) -> @ast::Expr {
+    fn expr_err(&self, sp: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         let err = vec!(
             self.ident_of("std"),
             self.ident_of("result"),
@@ -665,7 +688,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.expr_call_global(sp, err, vec!(expr))
     }
 
-    fn expr_try(&self, sp: Span, head: @ast::Expr) -> @ast::Expr {
+    fn expr_try(&self, sp: Span, head: Gc<ast::Expr>) -> Gc<ast::Expr> {
         let ok = self.ident_of("Ok");
         let ok_path = self.path_ident(sp, ok);
         let err = self.ident_of("Err");
@@ -694,38 +717,38 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
 
-    fn pat(&self, span: Span, pat: ast::Pat_) -> @ast::Pat {
-        @ast::Pat { id: ast::DUMMY_NODE_ID, node: pat, span: span }
+    fn pat(&self, span: Span, pat: ast::Pat_) -> Gc<ast::Pat> {
+        box(GC) ast::Pat { id: ast::DUMMY_NODE_ID, node: pat, span: span }
     }
-    fn pat_wild(&self, span: Span) -> @ast::Pat {
+    fn pat_wild(&self, span: Span) -> Gc<ast::Pat> {
         self.pat(span, ast::PatWild)
     }
-    fn pat_lit(&self, span: Span, expr: @ast::Expr) -> @ast::Pat {
+    fn pat_lit(&self, span: Span, expr: Gc<ast::Expr>) -> Gc<ast::Pat> {
         self.pat(span, ast::PatLit(expr))
     }
-    fn pat_ident(&self, span: Span, ident: ast::Ident) -> @ast::Pat {
+    fn pat_ident(&self, span: Span, ident: ast::Ident) -> Gc<ast::Pat> {
         self.pat_ident_binding_mode(span, ident, ast::BindByValue(ast::MutImmutable))
     }
 
     fn pat_ident_binding_mode(&self,
                               span: Span,
                               ident: ast::Ident,
-                              bm: ast::BindingMode) -> @ast::Pat {
+                              bm: ast::BindingMode) -> Gc<ast::Pat> {
         let path = self.path_ident(span, ident);
         let pat = ast::PatIdent(bm, path, None);
         self.pat(span, pat)
     }
-    fn pat_enum(&self, span: Span, path: ast::Path, subpats: Vec<@ast::Pat> ) -> @ast::Pat {
+    fn pat_enum(&self, span: Span, path: ast::Path, subpats: Vec<Gc<ast::Pat>> ) -> Gc<ast::Pat> {
         let pat = ast::PatEnum(path, Some(subpats));
         self.pat(span, pat)
     }
     fn pat_struct(&self, span: Span,
-                  path: ast::Path, field_pats: Vec<ast::FieldPat> ) -> @ast::Pat {
+                  path: ast::Path, field_pats: Vec<ast::FieldPat> ) -> Gc<ast::Pat> {
         let pat = ast::PatStruct(path, field_pats, false);
         self.pat(span, pat)
     }
 
-    fn arm(&self, _span: Span, pats: Vec<@ast::Pat> , expr: @ast::Expr) -> ast::Arm {
+    fn arm(&self, _span: Span, pats: Vec<Gc<ast::Pat>> , expr: Gc<ast::Expr>) -> ast::Arm {
         ast::Arm {
             attrs: vec!(),
             pats: pats,
@@ -738,56 +761,60 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.arm(span, vec!(self.pat_wild(span)), self.expr_unreachable(span))
     }
 
-    fn expr_match(&self, span: Span, arg: @ast::Expr, arms: Vec<ast::Arm> ) -> @Expr {
+    fn expr_match(&self, span: Span, arg: Gc<ast::Expr>,
+                  arms: Vec<ast::Arm>) -> Gc<Expr> {
         self.expr(span, ast::ExprMatch(arg, arms))
     }
 
     fn expr_if(&self, span: Span,
-               cond: @ast::Expr, then: @ast::Expr, els: Option<@ast::Expr>) -> @ast::Expr {
+               cond: Gc<ast::Expr>, then: Gc<ast::Expr>,
+               els: Option<Gc<ast::Expr>>) -> Gc<ast::Expr> {
         let els = els.map(|x| self.expr_block(self.block_expr(x)));
         self.expr(span, ast::ExprIf(cond, self.block_expr(then), els))
     }
 
     fn lambda_fn_decl(&self, span: Span,
-                      fn_decl: P<ast::FnDecl>, blk: P<ast::Block>) -> @ast::Expr {
+                      fn_decl: P<ast::FnDecl>, blk: P<ast::Block>) -> Gc<ast::Expr> {
         self.expr(span, ast::ExprFnBlock(fn_decl, blk))
     }
-    fn lambda(&self, span: Span, ids: Vec<ast::Ident> , blk: P<ast::Block>) -> @ast::Expr {
+    fn lambda(&self, span: Span, ids: Vec<ast::Ident> , blk: P<ast::Block>) -> Gc<ast::Expr> {
         let fn_decl = self.fn_decl(
             ids.iter().map(|id| self.arg(span, *id, self.ty_infer(span))).collect(),
             self.ty_infer(span));
 
         self.expr(span, ast::ExprFnBlock(fn_decl, blk))
     }
-    fn lambda0(&self, span: Span, blk: P<ast::Block>) -> @ast::Expr {
+    fn lambda0(&self, span: Span, blk: P<ast::Block>) -> Gc<ast::Expr> {
         self.lambda(span, Vec::new(), blk)
     }
 
-    fn lambda1(&self, span: Span, blk: P<ast::Block>, ident: ast::Ident) -> @ast::Expr {
+    fn lambda1(&self, span: Span, blk: P<ast::Block>, ident: ast::Ident) -> Gc<ast::Expr> {
         self.lambda(span, vec!(ident), blk)
     }
 
-    fn lambda_expr(&self, span: Span, ids: Vec<ast::Ident> , expr: @ast::Expr) -> @ast::Expr {
+    fn lambda_expr(&self, span: Span, ids: Vec<ast::Ident> , expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.lambda(span, ids, self.block_expr(expr))
     }
-    fn lambda_expr_0(&self, span: Span, expr: @ast::Expr) -> @ast::Expr {
+    fn lambda_expr_0(&self, span: Span, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.lambda0(span, self.block_expr(expr))
     }
-    fn lambda_expr_1(&self, span: Span, expr: @ast::Expr, ident: ast::Ident) -> @ast::Expr {
+    fn lambda_expr_1(&self, span: Span, expr: Gc<ast::Expr>, ident: ast::Ident) -> Gc<ast::Expr> {
         self.lambda1(span, self.block_expr(expr), ident)
     }
 
     fn lambda_stmts(&self,
                     span: Span,
                     ids: Vec<ast::Ident>,
-                    stmts: Vec<@ast::Stmt>)
-                    -> @ast::Expr {
+                    stmts: Vec<Gc<ast::Stmt>>)
+                    -> Gc<ast::Expr> {
         self.lambda(span, ids, self.block(span, stmts, None))
     }
-    fn lambda_stmts_0(&self, span: Span, stmts: Vec<@ast::Stmt> ) -> @ast::Expr {
+    fn lambda_stmts_0(&self, span: Span,
+                      stmts: Vec<Gc<ast::Stmt>>) -> Gc<ast::Expr> {
         self.lambda0(span, self.block(span, stmts, None))
     }
-    fn lambda_stmts_1(&self, span: Span, stmts: Vec<@ast::Stmt> , ident: ast::Ident) -> @ast::Expr {
+    fn lambda_stmts_1(&self, span: Span, stmts: Vec<Gc<ast::Stmt>>,
+                      ident: ast::Ident) -> Gc<ast::Expr> {
         self.lambda1(span, self.block(span, stmts, None), ident)
     }
 
@@ -811,10 +838,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn item(&self, span: Span,
-            name: Ident, attrs: Vec<ast::Attribute> , node: ast::Item_) -> @ast::Item {
+            name: Ident, attrs: Vec<ast::Attribute>,
+            node: ast::Item_) -> Gc<ast::Item> {
         // FIXME: Would be nice if our generated code didn't violate
         // Rust coding conventions
-        @ast::Item { ident: name,
+        box(GC) ast::Item { ident: name,
                     attrs: attrs,
                     id: ast::DUMMY_NODE_ID,
                     node: node,
@@ -828,7 +856,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                     inputs: Vec<ast::Arg> ,
                     output: P<ast::Ty>,
                     generics: Generics,
-                    body: P<ast::Block>) -> @ast::Item {
+                    body: P<ast::Block>) -> Gc<ast::Item> {
         self.item(span,
                   name,
                   Vec::new(),
@@ -845,7 +873,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                inputs: Vec<ast::Arg> ,
                output: P<ast::Ty>,
                body: P<ast::Block>
-              ) -> @ast::Item {
+              ) -> Gc<ast::Item> {
         self.item_fn_poly(
             span,
             name,
@@ -873,18 +901,18 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
 
     fn item_enum_poly(&self, span: Span, name: Ident,
                       enum_definition: ast::EnumDef,
-                      generics: Generics) -> @ast::Item {
+                      generics: Generics) -> Gc<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemEnum(enum_definition, generics))
     }
 
     fn item_enum(&self, span: Span, name: Ident,
-                 enum_definition: ast::EnumDef) -> @ast::Item {
+                 enum_definition: ast::EnumDef) -> Gc<ast::Item> {
         self.item_enum_poly(span, name, enum_definition,
                             ast_util::empty_generics())
     }
 
     fn item_struct(&self, span: Span, name: Ident,
-                   struct_def: ast::StructDef) -> @ast::Item {
+                   struct_def: ast::StructDef) -> Gc<ast::Item> {
         self.item_struct_poly(
             span,
             name,
@@ -894,14 +922,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn item_struct_poly(&self, span: Span, name: Ident,
-        struct_def: ast::StructDef, generics: Generics) -> @ast::Item {
-        self.item(span, name, Vec::new(), ast::ItemStruct(@struct_def, generics))
+        struct_def: ast::StructDef, generics: Generics) -> Gc<ast::Item> {
+        self.item(span, name, Vec::new(), ast::ItemStruct(box(GC) struct_def, generics))
     }
 
     fn item_mod(&self, span: Span, inner_span: Span, name: Ident,
                 attrs: Vec<ast::Attribute> ,
                 vi: Vec<ast::ViewItem> ,
-                items: Vec<@ast::Item> ) -> @ast::Item {
+                items: Vec<Gc<ast::Item>>) -> Gc<ast::Item> {
         self.item(
             span,
             name,
@@ -915,15 +943,15 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn item_ty_poly(&self, span: Span, name: Ident, ty: P<ast::Ty>,
-                    generics: Generics) -> @ast::Item {
+                    generics: Generics) -> Gc<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemTy(ty, generics))
     }
 
-    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> @ast::Item {
+    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> Gc<ast::Item> {
         self.item_ty_poly(span, name, ty, ast_util::empty_generics())
     }
 
-    fn attribute(&self, sp: Span, mi: @ast::MetaItem) -> ast::Attribute {
+    fn attribute(&self, sp: Span, mi: Gc<ast::MetaItem>) -> ast::Attribute {
         respan(sp, ast::Attribute_ {
             id: attr::mk_attr_id(),
             style: ast::AttrOuter,
@@ -932,26 +960,26 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn meta_word(&self, sp: Span, w: InternedString) -> @ast::MetaItem {
-        @respan(sp, ast::MetaWord(w))
+    fn meta_word(&self, sp: Span, w: InternedString) -> Gc<ast::MetaItem> {
+        box(GC) respan(sp, ast::MetaWord(w))
     }
     fn meta_list(&self,
                  sp: Span,
                  name: InternedString,
-                 mis: Vec<@ast::MetaItem> )
-                 -> @ast::MetaItem {
-        @respan(sp, ast::MetaList(name, mis))
+                 mis: Vec<Gc<ast::MetaItem>> )
+                 -> Gc<ast::MetaItem> {
+        box(GC) respan(sp, ast::MetaList(name, mis))
     }
     fn meta_name_value(&self,
                        sp: Span,
                        name: InternedString,
                        value: ast::Lit_)
-                       -> @ast::MetaItem {
-        @respan(sp, ast::MetaNameValue(name, respan(sp, value)))
+                       -> Gc<ast::MetaItem> {
+        box(GC) respan(sp, ast::MetaNameValue(name, respan(sp, value)))
     }
 
     fn view_use(&self, sp: Span,
-                vis: ast::Visibility, vp: @ast::ViewPath) -> ast::ViewItem {
+                vis: ast::Visibility, vp: Gc<ast::ViewPath>) -> ast::ViewItem {
         ast::ViewItem {
             node: ast::ViewItemUse(vp),
             attrs: Vec::new(),
@@ -968,7 +996,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn view_use_simple_(&self, sp: Span, vis: ast::Visibility,
                         ident: ast::Ident, path: ast::Path) -> ast::ViewItem {
         self.view_use(sp, vis,
-                      @respan(sp,
+                      box(GC) respan(sp,
                            ast::ViewPathSimple(ident,
                                                path,
                                                ast::DUMMY_NODE_ID)))
@@ -981,7 +1009,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }).collect();
 
         self.view_use(sp, vis,
-                      @respan(sp,
+                      box(GC) respan(sp,
                            ast::ViewPathList(self.path(sp, path),
                                              imports,
                                              ast::DUMMY_NODE_ID)))
@@ -990,7 +1018,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn view_use_glob(&self, sp: Span,
                      vis: ast::Visibility, path: Vec<ast::Ident> ) -> ast::ViewItem {
         self.view_use(sp, vis,
-                      @respan(sp,
+                      box(GC) respan(sp,
                            ast::ViewPathGlob(self.path(sp, path), ast::DUMMY_NODE_ID)))
     }
 }
@@ -1013,8 +1041,8 @@ pub trait Duplicate {
     fn duplicate(&self, cx: &ExtCtxt) -> Self;
 }
 
-impl Duplicate for @ast::Expr {
-    fn duplicate(&self, _: &ExtCtxt) -> @ast::Expr {
+impl Duplicate for Gc<ast::Expr> {
+    fn duplicate(&self, _: &ExtCtxt) -> Gc<ast::Expr> {
         let mut folder = Duplicator;
         folder.fold_expr(*self)
     }

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -44,7 +44,7 @@ pub fn expand_syntax_ext(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     }
     let res = str_to_ident(res_str.as_slice());
 
-    let e = @ast::Expr {
+    let e = box(GC) ast::Expr {
         id: ast::DUMMY_NODE_ID,
         node: ast::ExprPath(
             ast::Path {

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -14,11 +14,13 @@ use ext::base::ExtCtxt;
 use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_bound(cx: &mut ExtCtxt,
                              span: Span,
-                             mitem: @MetaItem,
-                             item: @Item,
-                             push: |@Item|) {
+                             mitem: Gc<MetaItem>,
+                             item: Gc<Item>,
+                             push: |Gc<Item>|) {
 
     let name = match mitem.node {
         MetaWord(ref tname) => {

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -16,11 +16,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_clone(cx: &mut ExtCtxt,
                              span: Span,
-                             mitem: @MetaItem,
-                             item: @Item,
-                             push: |@Item|) {
+                             mitem: Gc<MetaItem>,
+                             item: Gc<Item>,
+                             push: |Gc<Item>|) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
@@ -51,7 +53,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
 fn cs_clone(
     name: &str,
     cx: &mut ExtCtxt, trait_span: Span,
-    substr: &Substructure) -> @Expr {
+    substr: &Substructure) -> Gc<Expr> {
     let clone_ident = substr.method_ident;
     let ctor_ident;
     let all_fields;

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -16,18 +16,20 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_eq(cx: &mut ExtCtxt,
                           span: Span,
-                          mitem: @MetaItem,
-                          item: @Item,
-                          push: |@Item|) {
+                          mitem: Gc<MetaItem>,
+                          item: Gc<Item>,
+                          push: |Gc<Item>|) {
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
-    fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+    fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> Gc<Expr> {
         cs_and(|cx, span, _, _| cx.expr_bool(span, false),
                                  cx, span, substr)
     }
-    fn cs_ne(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+    fn cs_ne(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> Gc<Expr> {
         cs_or(|cx, span, _, _| cx.expr_bool(span, true),
               cx, span, substr)
     }

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -17,11 +17,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_ord(cx: &mut ExtCtxt,
                            span: Span,
-                           mitem: @MetaItem,
-                           item: @Item,
-                           push: |@Item|) {
+                           mitem: Gc<MetaItem>,
+                           item: Gc<Item>,
+                           push: |Gc<Item>|) {
     macro_rules! md (
         ($name:expr, $op:expr, $equal:expr) => { {
             let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -58,7 +60,8 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt,
 }
 
 /// Strict inequality.
-fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt, span: Span,
+         substr: &Substructure) -> Gc<Expr> {
     let op = if less {ast::BiLt} else {ast::BiGt};
     cs_fold(
         false, // need foldr,

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -16,12 +16,15 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_totaleq(cx: &mut ExtCtxt,
                                span: Span,
-                               mitem: @MetaItem,
-                               item: @Item,
-                               push: |@Item|) {
-    fn cs_total_eq_assert(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> @Expr {
+                               mitem: Gc<MetaItem>,
+                               item: Gc<Item>,
+                               push: |Gc<Item>|) {
+    fn cs_total_eq_assert(cx: &mut ExtCtxt, span: Span,
+                          substr: &Substructure) -> Gc<Expr> {
         cs_same_method(|cx, span, exprs| {
             // create `a.<method>(); b.<method>(); c.<method>(); ...`
             // (where method is `assert_receiver_is_total_eq`)

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -18,12 +18,13 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 use std::cmp::{Ordering, Equal, Less, Greater};
+use std::gc::Gc;
 
 pub fn expand_deriving_totalord(cx: &mut ExtCtxt,
                                 span: Span,
-                                mitem: @MetaItem,
-                                item: @Item,
-                                push: |@Item|) {
+                                mitem: Gc<MetaItem>,
+                                item: Gc<Item>,
+                                push: |Gc<Item>|) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
@@ -65,7 +66,7 @@ pub fn ordering_const(cx: &mut ExtCtxt, span: Span, cnst: Ordering) -> ast::Path
 }
 
 pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
-              substr: &Substructure) -> @Expr {
+              substr: &Substructure) -> Gc<Expr> {
     let test_id = cx.ident_of("__test");
     let equals_path = ordering_const(cx, span, Equal);
 

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -23,11 +23,13 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use parse::token;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
                                  span: Span,
-                                 mitem: @MetaItem,
-                                 item: @Item,
-                                 push: |@Item|) {
+                                 mitem: Gc<MetaItem>,
+                                 item: Gc<Item>,
+                                 push: |Gc<Item>|) {
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
@@ -64,7 +66,7 @@ pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
 }
 
 fn decodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
-                          substr: &Substructure) -> @Expr {
+                          substr: &Substructure) -> Gc<Expr> {
     let decoder = substr.nonself_args[0];
     let recurse = vec!(cx.ident_of("serialize"),
                     cx.ident_of("Decodable"),
@@ -159,8 +161,8 @@ fn decode_static_fields(cx: &mut ExtCtxt,
                         trait_span: Span,
                         outer_pat_ident: Ident,
                         fields: &StaticFields,
-                        getarg: |&mut ExtCtxt, Span, InternedString, uint| -> @Expr)
-                        -> @Expr {
+                        getarg: |&mut ExtCtxt, Span, InternedString, uint| -> Gc<Expr>)
+                        -> Gc<Expr> {
     match *fields {
         Unnamed(ref fields) => {
             if fields.is_empty() {

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -16,11 +16,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_default(cx: &mut ExtCtxt,
                             span: Span,
-                            mitem: @MetaItem,
-                            item: @Item,
-                            push: |@Item|) {
+                            mitem: Gc<MetaItem>,
+                            item: Gc<Item>,
+                            push: |Gc<Item>|) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
@@ -46,7 +48,8 @@ pub fn expand_deriving_default(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
+fn default_substructure(cx: &mut ExtCtxt, trait_span: Span,
+                        substr: &Substructure) -> Gc<Expr> {
     let default_ident = vec!(
         cx.ident_of("std"),
         cx.ident_of("default"),

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -91,11 +91,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
                                  span: Span,
-                                 mitem: @MetaItem,
-                                 item: @Item,
-                                 push: |@Item|) {
+                                 mitem: Gc<MetaItem>,
+                                 item: Gc<Item>,
+                                 push: |Gc<Item>|) {
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
@@ -134,7 +136,7 @@ pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
 }
 
 fn encodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
-                          substr: &Substructure) -> @Expr {
+                          substr: &Substructure) -> Gc<Expr> {
     let encoder = substr.nonself_args[0];
     // throw an underscore in front to suppress unused variable warnings
     let blkarg = cx.ident_of("_e");

--- a/src/libsyntax/ext/deriving/generic/ty.rs
+++ b/src/libsyntax/ext/deriving/generic/ty.rs
@@ -20,6 +20,7 @@ use ext::build::AstBuilder;
 use codemap::{Span,respan};
 use owned_slice::OwnedSlice;
 
+use std::gc::Gc;
 
 /// The types of pointers
 pub enum PtrTy<'a> {
@@ -81,7 +82,7 @@ impl<'a> Path<'a> {
 /// A type. Supports pointers (except for *), Self, and literals
 pub enum Ty<'a> {
     Self,
-    // &/Box/@ Ty
+    // &/Box/ Ty
     Ptr(Box<Ty<'a>>, PtrTy<'a>),
     // mod::mod::Type<[lifetime], [Params...]>, including a plain type
     // parameter, and things like `int`
@@ -244,7 +245,7 @@ impl<'a> LifetimeBounds<'a> {
 
 
 pub fn get_explicit_self(cx: &ExtCtxt, span: Span, self_ptr: &Option<PtrTy>)
-    -> (@Expr, ast::ExplicitSelf) {
+    -> (Gc<Expr>, ast::ExplicitSelf) {
     let self_path = cx.expr_self(span);
     match *self_ptr {
         None => {

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -17,11 +17,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_hash(cx: &mut ExtCtxt,
                             span: Span,
-                            mitem: @MetaItem,
-                            item: @Item,
-                            push: |@Item|) {
+                            mitem: Gc<MetaItem>,
+                            item: Gc<Item>,
+                            push: |Gc<Item>|) {
 
     let (path, generics, args) = if cx.ecfg.deriving_hash_type_parameter {
         (Path::new_(vec!("std", "hash", "Hash"), None,
@@ -64,7 +66,8 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
     hash_trait_def.expand(cx, mitem, item, push);
 }
 
-fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
+fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span,
+                     substr: &Substructure) -> Gc<Expr> {
     let state_expr = match substr.nonself_args {
         [state_expr] => state_expr,
         _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(Hash)`")

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -22,6 +22,8 @@ use ast::{Item, MetaItem, MetaList, MetaNameValue, MetaWord};
 use ext::base::ExtCtxt;
 use codemap::Span;
 
+use std::gc::Gc;
+
 pub mod bounds;
 pub mod clone;
 pub mod encodable;
@@ -47,9 +49,9 @@ pub mod generic;
 
 pub fn expand_meta_deriving(cx: &mut ExtCtxt,
                             _span: Span,
-                            mitem: @MetaItem,
-                            item: @Item,
-                            push: |@Item|) {
+                            mitem: Gc<MetaItem>,
+                            item: Gc<Item>,
+                            push: |Gc<Item>|) {
     match mitem.node {
         MetaNameValue(_, ref l) => {
             cx.span_err(l.span, "unexpected value in `deriving`");

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -17,11 +17,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
                                       span: Span,
-                                      mitem: @MetaItem,
-                                      item: @Item,
-                                      push: |@Item|) {
+                                      mitem: Gc<MetaItem>,
+                                      item: Gc<Item>,
+                                      push: |Gc<Item>|) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
@@ -70,7 +72,8 @@ pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
+fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span,
+           substr: &Substructure) -> Gc<Expr> {
     let n = match substr.nonself_args {
         [n] => n,
         _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(FromPrimitive)`")

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -16,11 +16,13 @@ use ext::build::{AstBuilder};
 use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_rand(cx: &mut ExtCtxt,
                             span: Span,
-                            mitem: @MetaItem,
-                            item: @Item,
-                            push: |@Item|) {
+                            mitem: Gc<MetaItem>,
+                            item: Gc<Item>,
+                            push: |Gc<Item>|) {
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
@@ -53,7 +55,8 @@ pub fn expand_deriving_rand(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn rand_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
+fn rand_substructure(cx: &mut ExtCtxt, trait_span: Span,
+                     substr: &Substructure) -> Gc<Expr> {
     let rng = match substr.nonself_args {
         [rng] => vec!( rng ),
         _ => cx.bug("Incorrect number of arguments to `rand` in `deriving(Rand)`")
@@ -134,8 +137,8 @@ fn rand_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
                   trait_span: Span,
                   ctor_ident: Ident,
                   summary: &StaticFields,
-                  rand_call: |&mut ExtCtxt, Span| -> @Expr)
-                  -> @Expr {
+                  rand_call: |&mut ExtCtxt, Span| -> Gc<Expr>)
+                  -> Gc<Expr> {
         match *summary {
             Unnamed(ref fields) => {
                 if fields.is_empty() {

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -20,12 +20,13 @@ use parse::token;
 
 use std::collections::HashMap;
 use std::string::String;
+use std::gc::Gc;
 
 pub fn expand_deriving_show(cx: &mut ExtCtxt,
                             span: Span,
-                            mitem: @MetaItem,
-                            item: @Item,
-                            push: |@Item|) {
+                            mitem: Gc<MetaItem>,
+                            item: Gc<Item>,
+                            push: |Gc<Item>|) {
     // &mut ::std::fmt::Formatter
     let fmtr = Ptr(box Literal(Path::new(vec!("std", "fmt", "Formatter"))),
                    Borrowed(None, ast::MutMutable));
@@ -57,7 +58,7 @@ pub fn expand_deriving_show(cx: &mut ExtCtxt,
 // we construct a format string and then defer to std::fmt, since that
 // knows what's up with formatting at so on.
 fn show_substructure(cx: &mut ExtCtxt, span: Span,
-                     substr: &Substructure) -> @Expr {
+                     substr: &Substructure) -> Gc<Expr> {
     // build `<name>`, `<name>({}, {}, ...)` or `<name> { <field>: {},
     // <field>: {}, ... }` based on the "shape".
     //

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -16,11 +16,13 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
+use std::gc::Gc;
+
 pub fn expand_deriving_zero(cx: &mut ExtCtxt,
                             span: Span,
-                            mitem: @MetaItem,
-                            item: @Item,
-                            push: |@Item|) {
+                            mitem: Gc<MetaItem>,
+                            item: Gc<Item>,
+                            push: |Gc<Item>|) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
@@ -63,7 +65,8 @@ pub fn expand_deriving_zero(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn zero_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> @Expr {
+fn zero_substructure(cx: &mut ExtCtxt, trait_span: Span,
+                     substr: &Substructure) -> Gc<Expr> {
     let zero_ident = vec!(
         cx.ident_of("std"),
         cx.ident_of("num"),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -174,7 +174,7 @@ pub fn expand_expr(e: Gc<ast::Expr>, fld: &mut MacroExpander) -> Gc<ast::Expr> {
             let value_ident = token::gensym_ident("__value");
             // this is careful to use src_pat.span so that error
             // messages point exact at that.
-            let local = @ast::Local {
+            let local = box(GC) ast::Local {
                 ty: fld.cx.ty_infer(src_pat.span),
                 pat: src_pat,
                 init: Some(fld.cx.expr_ident(src_pat.span, value_ident)),
@@ -183,7 +183,8 @@ pub fn expand_expr(e: Gc<ast::Expr>, fld: &mut MacroExpander) -> Gc<ast::Expr> {
                 source: ast::LocalFor
             };
             let local = codemap::respan(src_pat.span, ast::DeclLocal(local));
-            let local = @codemap::respan(span, ast::StmtDecl(@local, ast::DUMMY_NODE_ID));
+            let local = box(GC) codemap::respan(span, ast::StmtDecl(box(GC) local,
+                                                            ast::DUMMY_NODE_ID));
 
             // { let ...; <src_loop_block> }
             let block = fld.cx.block(span, vec![local],
@@ -749,7 +750,7 @@ pub fn expand_block_elts(b: &Block, fld: &mut MacroExpander) -> P<Block> {
     })
 }
 
-pub fn expand_pat(p: @ast::Pat, fld: &mut MacroExpander) -> @ast::Pat {
+pub fn expand_pat(p: Gc<ast::Pat>, fld: &mut MacroExpander) -> Gc<ast::Pat> {
     let (pth, tts) = match p.node {
         PatMac(ref mac) => {
             match mac.node {
@@ -819,7 +820,7 @@ pub fn expand_pat(p: @ast::Pat, fld: &mut MacroExpander) -> @ast::Pat {
         fld.fold_pat(marked_after).node.clone();
     fld.cx.bt_pop();
 
-    @ast::Pat {
+    box(GC) ast::Pat {
         id: ast::DUMMY_NODE_ID,
         node: fully_expanded,
         span: p.span,
@@ -983,7 +984,7 @@ fn mark_expr(expr: Gc<ast::Expr>, m: Mrk) -> Gc<ast::Expr> {
 }
 
 // apply a given mark to the given pattern. Used following the expansion of a macro.
-fn mark_pat(pat: @ast::Pat, m: Mrk) -> @ast::Pat {
+fn mark_pat(pat: Gc<ast::Pat>, m: Mrk) -> Gc<ast::Pat> {
     new_mark_folder(m).fold_pat(pat)
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -29,7 +29,9 @@ use visit;
 use visit::Visitor;
 use util::small_vector::SmallVector;
 
-pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
+use std::gc::Gc;
+
+pub fn expand_expr(e: Gc<ast::Expr>, fld: &mut MacroExpander) -> Gc<ast::Expr> {
     match e.node {
         // expr_mac should really be expr_ext or something; it's the
         // entry-point for all syntax extensions.
@@ -115,7 +117,7 @@ pub fn expand_expr(e: @ast::Expr, fld: &mut MacroExpander) -> @ast::Expr {
                         fld.fold_expr(marked_after).node.clone();
                     fld.cx.bt_pop();
 
-                    @ast::Expr {
+                    box(GC) ast::Expr {
                         id: ast::DUMMY_NODE_ID,
                         node: fully_expanded,
                         span: e.span,
@@ -256,7 +258,7 @@ fn expand_loop_block(loop_block: P<Block>,
             // in a block enclosed by loop head.
             fld.extsbox.push_frame();
             fld.extsbox.info().pending_renames.push(rename);
-            let expanded_block = expand_block_elts(loop_block, fld);
+            let expanded_block = expand_block_elts(&*loop_block, fld);
             fld.extsbox.pop_frame();
 
             (expanded_block, Some(renamed_ident))
@@ -277,8 +279,8 @@ macro_rules! with_exts_frame (
 )
 
 // When we enter a module, record it, for the sake of `module!`
-pub fn expand_item(it: @ast::Item, fld: &mut MacroExpander)
-                   -> SmallVector<@ast::Item> {
+pub fn expand_item(it: Gc<ast::Item>, fld: &mut MacroExpander)
+                   -> SmallVector<Gc<ast::Item>> {
     let it = expand_item_modifiers(it, fld);
 
     let mut decorator_items = SmallVector::zero();
@@ -301,7 +303,7 @@ pub fn expand_item(it: @ast::Item, fld: &mut MacroExpander)
 
                 // we'd ideally decorator_items.push_all(expand_item(item, fld)),
                 // but that double-mut-borrows fld
-                let mut items: SmallVector<@ast::Item> = SmallVector::zero();
+                let mut items: SmallVector<Gc<ast::Item>> = SmallVector::zero();
                 dec_fn(fld.cx, attr.span, attr.node.value, it,
                        |item| items.push(item));
                 decorator_items.extend(items.move_iter()
@@ -320,17 +322,17 @@ pub fn expand_item(it: @ast::Item, fld: &mut MacroExpander)
             let macro_escape = contains_macro_escape(new_attrs.as_slice());
             let result = with_exts_frame!(fld.extsbox,
                                           macro_escape,
-                                          noop_fold_item(it, fld));
+                                          noop_fold_item(&*it, fld));
             fld.cx.mod_pop();
             result
         },
         _ => {
-            let it = @ast::Item {
+            let it = box(GC) ast::Item {
                 attrs: new_attrs,
                 ..(*it).clone()
 
             };
-            noop_fold_item(it, fld)
+            noop_fold_item(&*it, fld)
         }
     };
 
@@ -338,8 +340,8 @@ pub fn expand_item(it: @ast::Item, fld: &mut MacroExpander)
     new_items
 }
 
-fn expand_item_modifiers(mut it: @ast::Item, fld: &mut MacroExpander)
-                         -> @ast::Item {
+fn expand_item_modifiers(mut it: Gc<ast::Item>, fld: &mut MacroExpander)
+                         -> Gc<ast::Item> {
     let (modifiers, attrs) = it.attrs.partitioned(|attr| {
         match fld.extsbox.find(&intern(attr.name().get())) {
             Some(&ItemModifier(_)) => true,
@@ -347,7 +349,7 @@ fn expand_item_modifiers(mut it: @ast::Item, fld: &mut MacroExpander)
         }
     });
 
-    it = @ast::Item {
+    it = box(GC) ast::Item {
         attrs: attrs,
         ..(*it).clone()
     };
@@ -388,8 +390,8 @@ pub fn contains_macro_escape(attrs: &[ast::Attribute]) -> bool {
 
 // Support for item-position macro invocations, exactly the same
 // logic as for expression-position macro invocations.
-pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
-                       -> SmallVector<@ast::Item> {
+pub fn expand_item_mac(it: Gc<ast::Item>, fld: &mut MacroExpander)
+                       -> SmallVector<Gc<ast::Item>> {
     let (pth, tts) = match it.node {
         ItemMac(codemap::Spanned {
             node: MacInvocTT(ref pth, ref tts, _),
@@ -494,7 +496,7 @@ pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
 }
 
 // expand a stmt
-pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<@Stmt> {
+pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<Gc<Stmt>> {
     // why the copying here and not in expand_expr?
     // looks like classic changed-in-only-one-place
     let (pth, tts, semi) = match s.node {
@@ -550,7 +552,7 @@ pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<@Stmt> {
                 }
             };
 
-            mark_stmt(expanded,fm)
+            mark_stmt(&*expanded,fm)
         }
 
         _ => {
@@ -561,20 +563,20 @@ pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<@Stmt> {
     };
 
     // Keep going, outside-in.
-    let fully_expanded = fld.fold_stmt(marked_after);
+    let fully_expanded = fld.fold_stmt(&*marked_after);
     if fully_expanded.is_empty() {
         fld.cx.span_err(pth.span, "macro didn't expand to a statement");
         return SmallVector::zero();
     }
     fld.cx.bt_pop();
-    let fully_expanded: SmallVector<@Stmt> = fully_expanded.move_iter()
-            .map(|s| @Spanned { span: s.span, node: s.node.clone() })
+    let fully_expanded: SmallVector<Gc<Stmt>> = fully_expanded.move_iter()
+            .map(|s| box(GC) Spanned { span: s.span, node: s.node.clone() })
             .collect();
 
     fully_expanded.move_iter().map(|s| {
         match s.node {
             StmtExpr(e, stmt_id) if semi => {
-                @Spanned {
+                box(GC) Spanned {
                     span: s.span,
                     node: StmtSemi(e, stmt_id)
                 }
@@ -587,7 +589,7 @@ pub fn expand_stmt(s: &Stmt, fld: &mut MacroExpander) -> SmallVector<@Stmt> {
 // expand a non-macro stmt. this is essentially the fallthrough for
 // expand_stmt, above.
 fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
-                         -> SmallVector<@Stmt> {
+                         -> SmallVector<Gc<Stmt>> {
     // is it a let?
     match s.node {
         StmtDecl(decl, node_id) => {
@@ -612,7 +614,7 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
                     // names, as well... but that should be okay, as long as
                     // the new names are gensyms for the old ones.
                     let mut name_finder = new_name_finder(Vec::new());
-                    name_finder.visit_pat(expanded_pat,());
+                    name_finder.visit_pat(&*expanded_pat,());
                     // generate fresh names, push them to a new pending list
                     let mut new_pending_renames = Vec::new();
                     for ident in name_finder.ident_accumulator.iter() {
@@ -631,7 +633,7 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
                     // also, don't forget to expand the init:
                     let new_init_opt = init.map(|e| fld.fold_expr(e));
                     let rewritten_local =
-                        @Local {
+                        box(GC) Local {
                             ty: local.ty,
                             pat: rewritten_pat,
                             init: new_init_opt,
@@ -639,8 +641,8 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
                             span: span,
                             source: source
                         };
-                    SmallVector::one(@Spanned {
-                        node: StmtDecl(@Spanned {
+                    SmallVector::one(box(GC) Spanned {
+                        node: StmtDecl(box(GC) Spanned {
                                 node: DeclLocal(rewritten_local),
                                 span: stmt_span
                             },
@@ -687,7 +689,7 @@ impl Visitor<()> for NewNameFinderContext {
                 }
                 // visit optional subpattern of pat_ident:
                 for subpat in inner.iter() {
-                    self.visit_pat(*subpat, ())
+                    self.visit_pat(&**subpat, ())
                 }
             }
             // use the default traversal for non-pat_idents
@@ -725,9 +727,9 @@ pub fn expand_block_elts(b: &Block, fld: &mut MacroExpander) -> P<Block> {
             let renamed_stmt = {
                 let pending_renames = &mut fld.extsbox.info().pending_renames;
                 let mut rename_fld = renames_to_fold(pending_renames);
-                rename_fld.fold_stmt(*x).expect_one("rename_fold didn't return one value")
+                rename_fld.fold_stmt(&**x).expect_one("rename_fold didn't return one value")
             };
-            fld.fold_stmt(renamed_stmt).move_iter()
+            fld.fold_stmt(&*renamed_stmt).move_iter()
         }).collect();
     let new_expr = b.expr.map(|x| {
         let expr = {
@@ -863,24 +865,24 @@ pub struct MacroExpander<'a, 'b> {
 }
 
 impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
-    fn fold_expr(&mut self, expr: @ast::Expr) -> @ast::Expr {
+    fn fold_expr(&mut self, expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
         expand_expr(expr, self)
     }
 
-    fn fold_pat(&mut self, pat: @ast::Pat) -> @ast::Pat {
+    fn fold_pat(&mut self, pat: Gc<ast::Pat>) -> Gc<ast::Pat> {
         expand_pat(pat, self)
     }
 
-    fn fold_item(&mut self, item: @ast::Item) -> SmallVector<@ast::Item> {
+    fn fold_item(&mut self, item: Gc<ast::Item>) -> SmallVector<Gc<ast::Item>> {
         expand_item(item, self)
     }
 
-    fn fold_stmt(&mut self, stmt: &ast::Stmt) -> SmallVector<@ast::Stmt> {
+    fn fold_stmt(&mut self, stmt: &ast::Stmt) -> SmallVector<Gc<ast::Stmt>> {
         expand_stmt(stmt, self)
     }
 
     fn fold_block(&mut self, block: P<Block>) -> P<Block> {
-        expand_block(block, self)
+        expand_block(&*block, self)
     }
 
     fn new_span(&mut self, span: Span) -> Span {
@@ -976,7 +978,7 @@ fn mark_tts(tts: &[TokenTree], m: Mrk) -> Vec<TokenTree> {
 }
 
 // apply a given mark to the given expr. Used following the expansion of a macro.
-fn mark_expr(expr: @ast::Expr, m: Mrk) -> @ast::Expr {
+fn mark_expr(expr: Gc<ast::Expr>, m: Mrk) -> Gc<ast::Expr> {
     new_mark_folder(m).fold_expr(expr)
 }
 
@@ -986,17 +988,17 @@ fn mark_pat(pat: @ast::Pat, m: Mrk) -> @ast::Pat {
 }
 
 // apply a given mark to the given stmt. Used following the expansion of a macro.
-fn mark_stmt(expr: &ast::Stmt, m: Mrk) -> @ast::Stmt {
+fn mark_stmt(expr: &ast::Stmt, m: Mrk) -> Gc<ast::Stmt> {
     new_mark_folder(m).fold_stmt(expr)
             .expect_one("marking a stmt didn't return a stmt")
 }
 
 // apply a given mark to the given item. Used following the expansion of a macro.
-fn mark_item(expr: @ast::Item, m: Mrk) -> SmallVector<@ast::Item> {
+fn mark_item(expr: Gc<ast::Item>, m: Mrk) -> SmallVector<Gc<ast::Item>> {
     new_mark_folder(m).fold_item(expr)
 }
 
-fn original_span(cx: &ExtCtxt) -> @codemap::ExpnInfo {
+fn original_span(cx: &ExtCtxt) -> Gc<codemap::ExpnInfo> {
     let mut relevant_info = cx.backtrace();
     let mut einfo = relevant_info.unwrap();
     loop {
@@ -1134,7 +1136,7 @@ mod test {
             node: Attribute_ {
                 id: attr::mk_attr_id(),
                 style: AttrOuter,
-                value: @Spanned {
+                value: box(GC) Spanned {
                     node: MetaWord(token::intern_and_get_ident(s)),
                     span: codemap::DUMMY_SP,
                 },

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -17,6 +17,7 @@ use parse::token::*;
 use parse::token;
 use parse;
 
+use std::gc::Gc;
 
 /**
 *
@@ -49,6 +50,8 @@ pub mod rt {
 
     pub use parse::new_parser_from_tts;
     pub use codemap::{BytePos, Span, dummy_spanned};
+
+    use std::gc::Gc;
 
     pub trait ToTokens {
         fn to_tokens(&self, _cx: &ExtCtxt) -> Vec<TokenTree> ;
@@ -85,13 +88,13 @@ pub mod rt {
         }
     }
 
-    impl ToSource for @ast::Item {
+    impl ToSource for Gc<ast::Item> {
         fn to_source(&self) -> String {
             pprust::item_to_str(*self)
         }
     }
 
-    impl<'a> ToSource for &'a [@ast::Item] {
+    impl<'a> ToSource for &'a [Gc<ast::Item>] {
         fn to_source(&self) -> String {
             self.iter()
                 .map(|i| i.to_source())
@@ -123,7 +126,7 @@ pub mod rt {
         }
     }
 
-    impl ToSource for @ast::Expr {
+    impl ToSource for Gc<ast::Expr> {
         fn to_source(&self) -> String {
             pprust::expr_to_str(*self)
         }
@@ -263,12 +266,12 @@ pub mod rt {
     )
 
     impl_to_tokens!(ast::Ident)
-    impl_to_tokens!(@ast::Item)
-    impl_to_tokens_self!(&'a [@ast::Item])
+    impl_to_tokens!(Gc<ast::Item>)
+    impl_to_tokens_self!(&'a [Gc<ast::Item>])
     impl_to_tokens!(ast::Ty)
     impl_to_tokens_self!(&'a [ast::Ty])
     impl_to_tokens!(Generics)
-    impl_to_tokens!(@ast::Expr)
+    impl_to_tokens!(Gc<ast::Expr>)
     impl_to_tokens!(ast::Block)
     impl_to_tokens!(ast::Arg)
     impl_to_tokens_self!(&'a str)
@@ -287,15 +290,15 @@ pub mod rt {
     impl_to_tokens!(u64)
 
     pub trait ExtParseUtils {
-        fn parse_item(&self, s: String) -> @ast::Item;
-        fn parse_expr(&self, s: String) -> @ast::Expr;
-        fn parse_stmt(&self, s: String) -> @ast::Stmt;
+        fn parse_item(&self, s: String) -> Gc<ast::Item>;
+        fn parse_expr(&self, s: String) -> Gc<ast::Expr>;
+        fn parse_stmt(&self, s: String) -> Gc<ast::Stmt>;
         fn parse_tts(&self, s: String) -> Vec<ast::TokenTree> ;
     }
 
     impl<'a> ExtParseUtils for ExtCtxt<'a> {
 
-        fn parse_item(&self, s: String) -> @ast::Item {
+        fn parse_item(&self, s: String) -> Gc<ast::Item> {
             let res = parse::parse_item_from_source_str(
                 "<quote expansion>".to_string(),
                 s,
@@ -310,7 +313,7 @@ pub mod rt {
             }
         }
 
-        fn parse_stmt(&self, s: String) -> @ast::Stmt {
+        fn parse_stmt(&self, s: String) -> Gc<ast::Stmt> {
             parse::parse_stmt_from_source_str("<quote expansion>".to_string(),
                                               s,
                                               self.cfg(),
@@ -318,7 +321,7 @@ pub mod rt {
                                               self.parse_sess())
         }
 
-        fn parse_expr(&self, s: String) -> @ast::Expr {
+        fn parse_expr(&self, s: String) -> Gc<ast::Expr> {
             parse::parse_expr_from_source_str("<quote expansion>".to_string(),
                                               s,
                                               self.cfg(),
@@ -400,7 +403,7 @@ fn id_ext(str: &str) -> ast::Ident {
 }
 
 // Lift an ident to the expr that evaluates to that ident.
-fn mk_ident(cx: &ExtCtxt, sp: Span, ident: ast::Ident) -> @ast::Expr {
+fn mk_ident(cx: &ExtCtxt, sp: Span, ident: ast::Ident) -> Gc<ast::Expr> {
     let e_str = cx.expr_str(sp, token::get_ident(ident));
     cx.expr_method_call(sp,
                         cx.expr_ident(sp, id_ext("ext_cx")),
@@ -408,17 +411,17 @@ fn mk_ident(cx: &ExtCtxt, sp: Span, ident: ast::Ident) -> @ast::Expr {
                         vec!(e_str))
 }
 
-fn mk_ast_path(cx: &ExtCtxt, sp: Span, name: &str) -> @ast::Expr {
+fn mk_ast_path(cx: &ExtCtxt, sp: Span, name: &str) -> Gc<ast::Expr> {
     let idents = vec!(id_ext("syntax"), id_ext("ast"), id_ext(name));
     cx.expr_path(cx.path_global(sp, idents))
 }
 
-fn mk_token_path(cx: &ExtCtxt, sp: Span, name: &str) -> @ast::Expr {
+fn mk_token_path(cx: &ExtCtxt, sp: Span, name: &str) -> Gc<ast::Expr> {
     let idents = vec!(id_ext("syntax"), id_ext("parse"), id_ext("token"), id_ext(name));
     cx.expr_path(cx.path_global(sp, idents))
 }
 
-fn mk_binop(cx: &ExtCtxt, sp: Span, bop: token::BinOp) -> @ast::Expr {
+fn mk_binop(cx: &ExtCtxt, sp: Span, bop: token::BinOp) -> Gc<ast::Expr> {
     let name = match bop {
         PLUS => "PLUS",
         MINUS => "MINUS",
@@ -434,7 +437,7 @@ fn mk_binop(cx: &ExtCtxt, sp: Span, bop: token::BinOp) -> @ast::Expr {
     mk_token_path(cx, sp, name)
 }
 
-fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> @ast::Expr {
+fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> Gc<ast::Expr> {
 
     match *tok {
         BINOP(binop) => {
@@ -565,7 +568,8 @@ fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> @ast::Expr {
     mk_token_path(cx, sp, name)
 }
 
-fn mk_tt(cx: &ExtCtxt, sp: Span, tt: &ast::TokenTree) -> Vec<@ast::Stmt> {
+
+fn mk_tt(cx: &ExtCtxt, sp: Span, tt: &ast::TokenTree) -> Vec<Gc<ast::Stmt>> {
     match *tt {
         ast::TTTok(sp, ref tok) => {
             let e_sp = cx.expr_ident(sp, id_ext("_sp"));
@@ -605,7 +609,7 @@ fn mk_tt(cx: &ExtCtxt, sp: Span, tt: &ast::TokenTree) -> Vec<@ast::Stmt> {
 }
 
 fn mk_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-    -> Vec<@ast::Stmt> {
+    -> Vec<Gc<ast::Stmt>> {
     let mut ss = Vec::new();
     for tt in tts.iter() {
         ss.push_all_move(mk_tt(cx, sp, tt));
@@ -614,7 +618,7 @@ fn mk_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 }
 
 fn expand_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
-              -> (@ast::Expr, @ast::Expr) {
+              -> (Gc<ast::Expr>, Gc<ast::Expr>) {
     // NB: It appears that the main parser loses its mind if we consider
     // $foo as a TTNonterminal during the main parse, so we have to re-parse
     // under quote_depth > 0. This is silly and should go away; the _guess_ is
@@ -686,8 +690,8 @@ fn expand_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 
 fn expand_wrapper(cx: &ExtCtxt,
                   sp: Span,
-                  cx_expr: @ast::Expr,
-                  expr: @ast::Expr) -> @ast::Expr {
+                  cx_expr: Gc<ast::Expr>,
+                  expr: Gc<ast::Expr>) -> Gc<ast::Expr> {
     let uses = [
         &["syntax", "ext", "quote", "rt"],
     ].iter().map(|path| {
@@ -703,8 +707,8 @@ fn expand_wrapper(cx: &ExtCtxt,
 fn expand_parse_call(cx: &ExtCtxt,
                      sp: Span,
                      parse_method: &str,
-                     arg_exprs: Vec<@ast::Expr> ,
-                     tts: &[ast::TokenTree]) -> @ast::Expr {
+                     arg_exprs: Vec<Gc<ast::Expr>>,
+                     tts: &[ast::TokenTree]) -> Gc<ast::Expr> {
     let (cx_expr, tts_expr) = expand_tts(cx, sp, tts);
 
     let cfg_call = || cx.expr_method_call(

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -90,7 +90,7 @@ pub mod rt {
 
     impl ToSource for Gc<ast::Item> {
         fn to_source(&self) -> String {
-            pprust::item_to_str(*self)
+            pprust::item_to_str(&**self)
         }
     }
 
@@ -128,7 +128,7 @@ pub mod rt {
 
     impl ToSource for Gc<ast::Expr> {
         fn to_source(&self) -> String {
-            pprust::expr_to_str(*self)
+            pprust::expr_to_str(&**self)
         }
     }
 

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -19,6 +19,7 @@ use parse;
 use parse::token;
 use print::pprust;
 
+use std::gc::Gc;
 use std::io::File;
 use std::rc::Rc;
 use std::str;
@@ -163,7 +164,7 @@ pub fn expand_include_bin(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 }
 
 // recur along an ExpnInfo chain to find the original expression
-fn topmost_expn_info(expn_info: @codemap::ExpnInfo) -> @codemap::ExpnInfo {
+fn topmost_expn_info(expn_info: Gc<codemap::ExpnInfo>) -> Gc<codemap::ExpnInfo> {
     match *expn_info {
         ExpnInfo { call_site: ref call_site, .. } => {
             match call_site.expn_info {

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -452,7 +452,7 @@ pub fn parse_nt(p: &mut Parser, name: &str) -> Nonterminal {
       "meta" => token::NtMeta(p.parse_meta_item()),
       "tt" => {
         p.quote_depth += 1u; //but in theory, non-quoted tts might be useful
-        let res = token::NtTT(@p.parse_token_tree());
+        let res = token::NtTT(box(GC) p.parse_token_tree());
         p.quote_depth -= 1u;
         res
       }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -29,6 +29,7 @@ use util::small_vector::SmallVector;
 
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::gc::Gc;
 
 struct ParserAnyMacro<'a> {
     parser: RefCell<Parser<'a>>,
@@ -58,17 +59,17 @@ impl<'a> ParserAnyMacro<'a> {
 }
 
 impl<'a> MacResult for ParserAnyMacro<'a> {
-    fn make_expr(&self) -> Option<@ast::Expr> {
+    fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         let ret = self.parser.borrow_mut().parse_expr();
         self.ensure_complete_parse(true);
         Some(ret)
     }
-    fn make_pat(&self) -> Option<@ast::Pat> {
+    fn make_pat(&self) -> Option<Gc<ast::Pat>> {
         let ret = self.parser.borrow_mut().parse_pat();
         self.ensure_complete_parse(false);
         Some(ret)
     }
-    fn make_items(&self) -> Option<SmallVector<@ast::Item>> {
+    fn make_items(&self) -> Option<SmallVector<Gc<ast::Item>>> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();
@@ -81,7 +82,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
         self.ensure_complete_parse(false);
         Some(ret)
     }
-    fn make_stmt(&self) -> Option<@ast::Stmt> {
+    fn make_stmt(&self) -> Option<Gc<ast::Stmt>> {
         let attrs = self.parser.borrow_mut().parse_outer_attributes();
         let ret = self.parser.borrow_mut().parse_stmt(attrs);
         self.ensure_complete_parse(true);

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -187,8 +187,8 @@ pub trait Folder {
                 })
             }
             TyUnboxedFn(ref f) => {
-                TyUnboxedFn(@UnboxedFnTy {
-                    decl: self.fold_fn_decl(f.decl),
+                TyUnboxedFn(box(GC) UnboxedFnTy {
+                    decl: self.fold_fn_decl(&*f.decl),
                 })
             }
             TyTup(ref tys) => TyTup(tys.iter().map(|&ty| self.fold_ty(ty)).collect()),
@@ -449,7 +449,7 @@ fn fold_ty_param_bound<T: Folder>(tpb: &TyParamBound, fld: &mut T)
         StaticRegionTyParamBound => StaticRegionTyParamBound,
         UnboxedFnTyParamBound(ref unboxed_function_type) => {
             UnboxedFnTyParamBound(UnboxedFnTy {
-                decl: fld.fold_fn_decl(unboxed_function_type.decl),
+                decl: fld.fold_fn_decl(&*unboxed_function_type.decl),
             })
         }
         OtherRegionTyParamBound(s) => OtherRegionTyParamBound(s)

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -17,6 +17,7 @@ use owned_slice::OwnedSlice;
 use util::small_vector::SmallVector;
 
 use std::rc::Rc;
+use std::gc::Gc;
 
 // We may eventually want to be able to fold over type parameters, too.
 pub trait Folder {
@@ -24,11 +25,11 @@ pub trait Folder {
         noop_fold_crate(c, self)
     }
 
-    fn fold_meta_items(&mut self, meta_items: &[@MetaItem]) -> Vec<@MetaItem> {
+    fn fold_meta_items(&mut self, meta_items: &[Gc<MetaItem>]) -> Vec<Gc<MetaItem>> {
         meta_items.iter().map(|x| fold_meta_item_(*x, self)).collect()
     }
 
-    fn fold_view_path(&mut self, view_path: @ViewPath) -> @ViewPath {
+    fn fold_view_path(&mut self, view_path: Gc<ViewPath>) -> Gc<ViewPath> {
         let inner_view_path = match view_path.node {
             ViewPathSimple(ref ident, ref path, node_id) => {
                 let id = self.new_id(node_id);
@@ -60,7 +61,7 @@ pub trait Folder {
                              id)
             }
         };
-        @Spanned {
+        box(GC) Spanned {
             node: inner_view_path,
             span: self.new_span(view_path.span),
         }
@@ -70,12 +71,12 @@ pub trait Folder {
         noop_fold_view_item(vi, self)
     }
 
-    fn fold_foreign_item(&mut self, ni: @ForeignItem) -> @ForeignItem {
-        noop_fold_foreign_item(ni, self)
+    fn fold_foreign_item(&mut self, ni: Gc<ForeignItem>) -> Gc<ForeignItem> {
+        noop_fold_foreign_item(&*ni, self)
     }
 
-    fn fold_item(&mut self, i: @Item) -> SmallVector<@Item> {
-        noop_fold_item(i, self)
+    fn fold_item(&mut self, i: Gc<Item>) -> SmallVector<Gc<Item>> {
+        noop_fold_item(&*i, self)
     }
 
     fn fold_struct_field(&mut self, sf: &StructField) -> StructField {
@@ -103,15 +104,15 @@ pub trait Folder {
         noop_fold_type_method(m, self)
     }
 
-    fn fold_method(&mut self, m: @Method) -> @Method {
-        noop_fold_method(m, self)
+    fn fold_method(&mut self, m: Gc<Method>) -> Gc<Method>  {
+        noop_fold_method(&*m, self)
     }
 
     fn fold_block(&mut self, b: P<Block>) -> P<Block> {
         noop_fold_block(b, self)
     }
 
-    fn fold_stmt(&mut self, s: &Stmt) -> SmallVector<@Stmt> {
+    fn fold_stmt(&mut self, s: &Stmt) -> SmallVector<Gc<Stmt>> {
         noop_fold_stmt(s, self)
     }
 
@@ -124,11 +125,11 @@ pub trait Folder {
         }
     }
 
-    fn fold_pat(&mut self, p: @Pat) -> @Pat {
+    fn fold_pat(&mut self, p: Gc<Pat>) -> Gc<Pat> {
         noop_fold_pat(p, self)
     }
 
-    fn fold_decl(&mut self, d: @Decl) -> SmallVector<@Decl> {
+    fn fold_decl(&mut self, d: Gc<Decl>) -> SmallVector<Gc<Decl>> {
         let node = match d.node {
             DeclLocal(ref l) => SmallVector::one(DeclLocal(self.fold_local(*l))),
             DeclItem(it) => {
@@ -137,14 +138,14 @@ pub trait Folder {
         };
 
         node.move_iter().map(|node| {
-            @Spanned {
+            box(GC) Spanned {
                 node: node,
                 span: self.new_span(d.span),
             }
         }).collect()
     }
 
-    fn fold_expr(&mut self, e: @Expr) -> @Expr {
+    fn fold_expr(&mut self, e: Gc<Expr>) -> Gc<Expr> {
         noop_fold_expr(e, self)
     }
 
@@ -160,29 +161,29 @@ pub trait Folder {
                 TyRptr(fold_opt_lifetime(region, self), fold_mt(mt, self))
             }
             TyClosure(ref f, ref region) => {
-                TyClosure(@ClosureTy {
+                TyClosure(box(GC) ClosureTy {
                     fn_style: f.fn_style,
                     onceness: f.onceness,
                     bounds: fold_opt_bounds(&f.bounds, self),
-                    decl: self.fold_fn_decl(f.decl),
+                    decl: self.fold_fn_decl(&*f.decl),
                     lifetimes: f.lifetimes.iter().map(|l| self.fold_lifetime(l)).collect(),
                 }, fold_opt_lifetime(region, self))
             }
             TyProc(ref f) => {
-                TyProc(@ClosureTy {
+                TyProc(box(GC) ClosureTy {
                     fn_style: f.fn_style,
                     onceness: f.onceness,
                     bounds: fold_opt_bounds(&f.bounds, self),
-                    decl: self.fold_fn_decl(f.decl),
+                    decl: self.fold_fn_decl(&*f.decl),
                     lifetimes: f.lifetimes.iter().map(|l| self.fold_lifetime(l)).collect(),
                 })
             }
             TyBareFn(ref f) => {
-                TyBareFn(@BareFnTy {
+                TyBareFn(box(GC) BareFnTy {
                     lifetimes: f.lifetimes.iter().map(|l| self.fold_lifetime(l)).collect(),
                     fn_style: f.fn_style,
                     abi: f.abi,
-                    decl: self.fold_fn_decl(f.decl)
+                    decl: self.fold_fn_decl(&*f.decl)
                 })
             }
             TyUnboxedFn(ref f) => {
@@ -236,7 +237,7 @@ pub trait Folder {
                     fold_variant_arg_(x, self)).collect())
             }
             StructVariantKind(ref struct_def) => {
-                kind = StructVariantKind(@ast::StructDef {
+                kind = StructVariantKind(box(GC) ast::StructDef {
                     fields: struct_def.fields.iter()
                         .map(|f| self.fold_struct_field(f)).collect(),
                     ctor_id: struct_def.ctor_id.map(|c| self.new_id(c)),
@@ -285,9 +286,9 @@ pub trait Folder {
         }
     }
 
-    fn fold_local(&mut self, l: @Local) -> @Local {
+    fn fold_local(&mut self, l: Gc<Local>) -> Gc<Local> {
         let id = self.new_id(l.id); // Needs to be first, for ast_map.
-        @Local {
+        box(GC) Local {
             id: id,
             ty: self.fold_ty(l.ty),
             pat: self.fold_pat(l.pat),
@@ -310,7 +311,8 @@ pub trait Folder {
         }
     }
 
-    fn map_exprs(&self, f: |@Expr| -> @Expr, es: &[@Expr]) -> Vec<@Expr> {
+    fn map_exprs(&self, f: |Gc<Expr>| -> Gc<Expr>,
+                 es: &[Gc<Expr>]) -> Vec<Gc<Expr>> {
         es.iter().map(|x| f(*x)).collect()
     }
 
@@ -346,8 +348,8 @@ pub trait Folder {
 /* some little folds that probably aren't useful to have in Folder itself*/
 
 //used in noop_fold_item and noop_fold_crate and noop_fold_crate_directive
-fn fold_meta_item_<T: Folder>(mi: @MetaItem, fld: &mut T) -> @MetaItem {
-    @Spanned {
+fn fold_meta_item_<T: Folder>(mi: Gc<MetaItem>, fld: &mut T) -> Gc<MetaItem> {
+    box(GC) Spanned {
         node:
             match mi.node {
                 MetaWord(ref id) => MetaWord((*id).clone()),
@@ -495,8 +497,9 @@ pub fn fold_generics<T: Folder>(generics: &Generics, fld: &mut T) -> Generics {
               lifetimes: fold_lifetimes(&generics.lifetimes, fld)}
 }
 
-fn fold_struct_def<T: Folder>(struct_def: @StructDef, fld: &mut T) -> @StructDef {
-    @ast::StructDef {
+fn fold_struct_def<T: Folder>(struct_def: Gc<StructDef>,
+                              fld: &mut T) -> Gc<StructDef> {
+    box(GC) ast::StructDef {
         fields: struct_def.fields.iter().map(|f| fold_struct_field(f, fld)).collect(),
         ctor_id: struct_def.ctor_id.map(|cid| fld.new_id(cid)),
         super_struct: match struct_def.super_struct {
@@ -583,7 +586,7 @@ pub fn noop_fold_view_item<T: Folder>(vi: &ViewItem, folder: &mut T)
 pub fn noop_fold_block<T: Folder>(b: P<Block>, folder: &mut T) -> P<Block> {
     let id = folder.new_id(b.id); // Needs to be first, for ast_map.
     let view_items = b.view_items.iter().map(|x| folder.fold_view_item(x)).collect();
-    let stmts = b.stmts.iter().flat_map(|s| folder.fold_stmt(*s).move_iter()).collect();
+    let stmts = b.stmts.iter().flat_map(|s| folder.fold_stmt(&**s).move_iter()).collect();
     P(Block {
         id: id,
         view_items: view_items,
@@ -601,7 +604,7 @@ pub fn noop_fold_item_underscore<T: Folder>(i: &Item_, folder: &mut T) -> Item_ 
         }
         ItemFn(decl, fn_style, abi, ref generics, body) => {
             ItemFn(
-                folder.fold_fn_decl(decl),
+                folder.fold_fn_decl(&*decl),
                 fn_style,
                 abi,
                 fold_generics(generics, folder),
@@ -617,7 +620,7 @@ pub fn noop_fold_item_underscore<T: Folder>(i: &Item_, folder: &mut T) -> Item_ 
             ItemEnum(
                 ast::EnumDef {
                     variants: enum_definition.variants.iter().map(|&x| {
-                        folder.fold_variant(x)
+                        folder.fold_variant(&*x)
                     }).collect(),
                 },
                 fold_generics(generics, folder))
@@ -656,7 +659,7 @@ pub fn noop_fold_type_method<T: Folder>(m: &TypeMethod, fld: &mut T) -> TypeMeth
         ident: fld.fold_ident(m.ident),
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, fld)).collect(),
         fn_style: m.fn_style,
-        decl: fld.fold_fn_decl(m.decl),
+        decl: fld.fold_fn_decl(&*m.decl),
         generics: fold_generics(&m.generics, fld),
         explicit_self: fld.fold_explicit_self(&m.explicit_self),
         span: fld.new_span(m.span),
@@ -683,18 +686,19 @@ pub fn noop_fold_crate<T: Folder>(c: Crate, folder: &mut T) -> Crate {
     }
 }
 
-pub fn noop_fold_item<T: Folder>(i: &Item, folder: &mut T) -> SmallVector<@Item> {
+pub fn noop_fold_item<T: Folder>(i: &Item,
+                                 folder: &mut T) -> SmallVector<Gc<Item>> {
     let id = folder.new_id(i.id); // Needs to be first, for ast_map.
     let node = folder.fold_item_underscore(&i.node);
     let ident = match node {
         // The node may have changed, recompute the "pretty" impl name.
         ItemImpl(_, ref maybe_trait, ty, _) => {
-            ast_util::impl_pretty_name(maybe_trait, ty)
+            ast_util::impl_pretty_name(maybe_trait, &*ty)
         }
         _ => i.ident
     };
 
-    SmallVector::one(@Item {
+    SmallVector::one(box(GC) Item {
         id: id,
         ident: folder.fold_ident(ident),
         attrs: i.attrs.iter().map(|e| fold_attribute_(*e, folder)).collect(),
@@ -704,9 +708,10 @@ pub fn noop_fold_item<T: Folder>(i: &Item, folder: &mut T) -> SmallVector<@Item>
     })
 }
 
-pub fn noop_fold_foreign_item<T: Folder>(ni: &ForeignItem, folder: &mut T) -> @ForeignItem {
+pub fn noop_fold_foreign_item<T: Folder>(ni: &ForeignItem,
+                                         folder: &mut T) -> Gc<ForeignItem> {
     let id = folder.new_id(ni.id); // Needs to be first, for ast_map.
-    @ForeignItem {
+    box(GC) ForeignItem {
         id: id,
         ident: folder.fold_ident(ni.ident),
         attrs: ni.attrs.iter().map(|x| fold_attribute_(*x, folder)).collect(),
@@ -728,23 +733,23 @@ pub fn noop_fold_foreign_item<T: Folder>(ni: &ForeignItem, folder: &mut T) -> @F
     }
 }
 
-pub fn noop_fold_method<T: Folder>(m: &Method, folder: &mut T) -> @Method {
+pub fn noop_fold_method<T: Folder>(m: &Method, folder: &mut T) -> Gc<Method> {
     let id = folder.new_id(m.id); // Needs to be first, for ast_map.
-    @Method {
+    box(GC) Method {
         id: id,
         ident: folder.fold_ident(m.ident),
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, folder)).collect(),
         generics: fold_generics(&m.generics, folder),
         explicit_self: folder.fold_explicit_self(&m.explicit_self),
         fn_style: m.fn_style,
-        decl: folder.fold_fn_decl(m.decl),
+        decl: folder.fold_fn_decl(&*m.decl),
         body: folder.fold_block(m.body),
         span: folder.new_span(m.span),
         vis: m.vis
     }
 }
 
-pub fn noop_fold_pat<T: Folder>(p: @Pat, folder: &mut T) -> @Pat {
+pub fn noop_fold_pat<T: Folder>(p: Gc<Pat>, folder: &mut T) -> Gc<Pat> {
     let id = folder.new_id(p.id);
     let node = match p.node {
         PatWild => PatWild,
@@ -783,14 +788,14 @@ pub fn noop_fold_pat<T: Folder>(p: @Pat, folder: &mut T) -> @Pat {
         PatMac(ref mac) => PatMac(folder.fold_mac(mac)),
     };
 
-    @Pat {
+    box(GC) Pat {
         id: id,
         span: folder.new_span(p.span),
         node: node,
     }
 }
 
-pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
+pub fn noop_fold_expr<T: Folder>(e: Gc<Expr>, folder: &mut T) -> Gc<Expr> {
     let id = folder.new_id(e.id);
     let node = match e.node {
         ExprVstore(e, v) => {
@@ -851,13 +856,15 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
             ExprMatch(folder.fold_expr(expr),
                       arms.iter().map(|x| folder.fold_arm(x)).collect())
         }
-        ExprFnBlock(decl, body) => {
-            ExprFnBlock(folder.fold_fn_decl(decl), folder.fold_block(body))
+        ExprFnBlock(ref decl, ref body) => {
+            ExprFnBlock(folder.fold_fn_decl(&**decl),
+                        folder.fold_block(body.clone()))
         }
-        ExprProc(decl, body) => {
-            ExprProc(folder.fold_fn_decl(decl), folder.fold_block(body))
+        ExprProc(ref decl, ref body) => {
+            ExprProc(folder.fold_fn_decl(&**decl),
+                     folder.fold_block(body.clone()))
         }
-        ExprBlock(blk) => ExprBlock(folder.fold_block(blk)),
+        ExprBlock(ref blk) => ExprBlock(folder.fold_block(blk.clone())),
         ExprAssign(el, er) => {
             ExprAssign(folder.fold_expr(el), folder.fold_expr(er))
         }
@@ -900,14 +907,15 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
         ExprParen(ex) => ExprParen(folder.fold_expr(ex))
     };
 
-    @Expr {
+    box(GC) Expr {
         id: id,
         node: node,
         span: folder.new_span(e.span),
     }
 }
 
-pub fn noop_fold_stmt<T: Folder>(s: &Stmt, folder: &mut T) -> SmallVector<@Stmt> {
+pub fn noop_fold_stmt<T: Folder>(s: &Stmt,
+                                 folder: &mut T) -> SmallVector<Gc<Stmt>> {
     let nodes = match s.node {
         StmtDecl(d, id) => {
             let id = folder.new_id(id);
@@ -926,7 +934,7 @@ pub fn noop_fold_stmt<T: Folder>(s: &Stmt, folder: &mut T) -> SmallVector<@Stmt>
         StmtMac(ref mac, semi) => SmallVector::one(StmtMac(folder.fold_mac(mac), semi))
     };
 
-    nodes.move_iter().map(|node| @Spanned {
+    nodes.move_iter().map(|node| box(GC) Spanned {
         node: node,
         span: folder.new_span(s.span),
     }).collect()

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -13,6 +13,7 @@
 // Predicates on exprs and stmts that the pretty-printer and parser use
 
 use ast;
+use std::gc::Gc;
 
 // does this expression require a semicolon to be treated
 // as a statement? The negation of this: 'can this expression
@@ -21,7 +22,7 @@ use ast;
 // 'if true {...} else {...}
 //  |x| 5 '
 // isn't parsed as (if true {...} else {...} | x) | 5
-pub fn expr_requires_semi_to_be_stmt(e: @ast::Expr) -> bool {
+pub fn expr_requires_semi_to_be_stmt(e: Gc<ast::Expr>) -> bool {
     match e.node {
         ast::ExprIf(..)
         | ast::ExprMatch(..)
@@ -33,7 +34,7 @@ pub fn expr_requires_semi_to_be_stmt(e: @ast::Expr) -> bool {
     }
 }
 
-pub fn expr_is_simple_block(e: @ast::Expr) -> bool {
+pub fn expr_is_simple_block(e: Gc<ast::Expr>) -> bool {
     match e.node {
         ast::ExprBlock(block) => block.rules == ast::DefaultBlock,
       _ => false

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -22,6 +22,8 @@ use codemap::{Span, respan};
 use parse::parser;
 use parse::token;
 
+use std::gc::Gc;
+
 /// The specific types of unsupported syntax
 #[deriving(PartialEq, Eq, Hash)]
 pub enum ObsoleteSyntax {
@@ -35,7 +37,7 @@ pub trait ParserObsoleteMethods {
     fn obsolete(&mut self, sp: Span, kind: ObsoleteSyntax);
     // Reports an obsolete syntax non-fatal error, and returns
     // a placeholder expression
-    fn obsolete_expr(&mut self, sp: Span, kind: ObsoleteSyntax) -> @Expr;
+    fn obsolete_expr(&mut self, sp: Span, kind: ObsoleteSyntax) -> Gc<Expr>;
     fn report(&mut self,
               sp: Span,
               kind: ObsoleteSyntax,
@@ -68,9 +70,9 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
 
     // Reports an obsolete syntax non-fatal error, and returns
     // a placeholder expression
-    fn obsolete_expr(&mut self, sp: Span, kind: ObsoleteSyntax) -> @Expr {
+    fn obsolete_expr(&mut self, sp: Span, kind: ObsoleteSyntax) -> Gc<Expr> {
         self.obsolete(sp, kind);
-        self.mk_expr(sp.lo, sp.hi, ExprLit(@respan(sp, LitNil)))
+        self.mk_expr(sp.lo, sp.hi, ExprLit(box(GC) respan(sp, LitNil)))
     }
 
     fn report(&mut self,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -79,7 +79,7 @@ use owned_slice::OwnedSlice;
 use std::collections::HashSet;
 use std::mem::replace;
 use std::rc::Rc;
-use std::string::String;
+use std::gc::Gc;
 
 #[allow(non_camel_case_types)]
 #[deriving(PartialEq)]
@@ -119,9 +119,9 @@ pub struct PathAndBounds {
 enum ItemOrViewItem {
     // Indicates a failure to parse any kind of item. The attributes are
     // returned.
-    IoviNone(Vec<Attribute> ),
-    IoviItem(@Item),
-    IoviForeignItem(@ForeignItem),
+    IoviNone(Vec<Attribute>),
+    IoviItem(Gc<Item>),
+    IoviForeignItem(Gc<ForeignItem>),
     IoviViewItem(ViewItem)
 }
 
@@ -275,9 +275,9 @@ fn maybe_append(lhs: Vec<Attribute> , rhs: Option<Vec<Attribute> >)
 
 
 struct ParsedItemsAndViewItems {
-    attrs_remaining: Vec<Attribute> ,
-    view_items: Vec<ViewItem> ,
-    items: Vec<@Item> ,
+    attrs_remaining: Vec<Attribute>,
+    view_items: Vec<ViewItem>,
+    items: Vec<@Item>,
     foreign_items: Vec<@ForeignItem>
 }
 
@@ -454,7 +454,8 @@ impl<'a> Parser<'a> {
     // Commit to parsing a complete expression `e` expected to be
     // followed by some token from the set edible + inedible.  Recover
     // from anticipated input errors, discarding erroneous characters.
-    pub fn commit_expr(&mut self, e: @Expr, edible: &[token::Token], inedible: &[token::Token]) {
+    pub fn commit_expr(&mut self, e: Gc<Expr>, edible: &[token::Token],
+                       inedible: &[token::Token]) {
         debug!("commit_expr {:?}", e);
         match e.node {
             ExprPath(..) => {
@@ -469,14 +470,15 @@ impl<'a> Parser<'a> {
         self.expect_one_of(edible, inedible)
     }
 
-    pub fn commit_expr_expecting(&mut self, e: @Expr, edible: token::Token) {
+    pub fn commit_expr_expecting(&mut self, e: Gc<Expr>, edible: token::Token) {
         self.commit_expr(e, &[edible], &[])
     }
 
     // Commit to parsing a complete statement `s`, which expects to be
     // followed by some token from the set edible + inedible.  Check
     // for recoverable input errors, discarding erroneous characters.
-    pub fn commit_stmt(&mut self, s: @Stmt, edible: &[token::Token], inedible: &[token::Token]) {
+    pub fn commit_stmt(&mut self, s: Gc<Stmt>, edible: &[token::Token],
+                       inedible: &[token::Token]) {
         debug!("commit_stmt {:?}", s);
         let _s = s; // unused, but future checks might want to inspect `s`.
         if self.last_token.as_ref().map_or(false, |t| is_ident_or_path(*t)) {
@@ -488,7 +490,7 @@ impl<'a> Parser<'a> {
         self.expect_one_of(edible, inedible)
     }
 
-    pub fn commit_stmt_expecting(&mut self, s: @Stmt, edible: token::Token) {
+    pub fn commit_stmt_expecting(&mut self, s: Gc<Stmt>, edible: token::Token) {
         self.commit_stmt(s, &[edible], &[])
     }
 
@@ -980,7 +982,7 @@ impl<'a> Parser<'a> {
 
         self.expect_keyword(keywords::Fn);
         let (decl, lifetimes) = self.parse_ty_fn_decl(true);
-        return TyBareFn(@BareFnTy {
+        return TyBareFn(box(GC) BareFnTy {
             abi: abi,
             fn_style: fn_style,
             lifetimes: lifetimes,
@@ -1021,7 +1023,7 @@ impl<'a> Parser<'a> {
             cf: ret_style,
             variadic: variadic
         });
-        TyProc(@ClosureTy {
+        TyProc(box(GC) ClosureTy {
             fn_style: NormalFn,
             onceness: Once,
             bounds: bounds,
@@ -1092,11 +1094,11 @@ impl<'a> Parser<'a> {
         });
 
         if is_unboxed {
-            TyUnboxedFn(@UnboxedFnTy {
+            TyUnboxedFn(box(GC) UnboxedFnTy {
                 decl: decl,
             })
         } else {
-            TyClosure(@ClosureTy {
+            TyClosure(box(GC) ClosureTy {
                 fn_style: fn_style,
                 onceness: onceness,
                 bounds: bounds,
@@ -1192,7 +1194,7 @@ impl<'a> Parser<'a> {
                 let (inner_attrs, body) =
                     p.parse_inner_attrs_and_block();
                 let attrs = attrs.append(inner_attrs.as_slice());
-                Provided(@ast::Method {
+                Provided(box(GC) ast::Method {
                     ident: ident,
                     attrs: attrs,
                     generics: generics,
@@ -1465,7 +1467,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn maybe_parse_fixed_vstore(&mut self) -> Option<@ast::Expr> {
+    pub fn maybe_parse_fixed_vstore(&mut self) -> Option<Gc<ast::Expr>> {
         if self.token == token::COMMA &&
                 self.look_ahead(1, |t| *t == token::DOTDOT) {
             self.bump();
@@ -1516,12 +1518,12 @@ impl<'a> Parser<'a> {
     }
 
     // matches '-' lit | lit
-    pub fn parse_literal_maybe_minus(&mut self) -> @Expr {
+    pub fn parse_literal_maybe_minus(&mut self) -> Gc<Expr> {
         let minus_lo = self.span.lo;
         let minus_present = self.eat(&token::BINOP(token::MINUS));
 
         let lo = self.span.lo;
-        let literal = @self.parse_lit();
+        let literal = box(GC) self.parse_lit();
         let hi = self.span.hi;
         let expr = self.mk_expr(lo, hi, ExprLit(literal));
 
@@ -1723,62 +1725,65 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn mk_expr(&mut self, lo: BytePos, hi: BytePos, node: Expr_) -> @Expr {
-        @Expr {
+    pub fn mk_expr(&mut self, lo: BytePos, hi: BytePos, node: Expr_) -> Gc<Expr> {
+        box(GC) Expr {
             id: ast::DUMMY_NODE_ID,
             node: node,
             span: mk_sp(lo, hi),
         }
     }
 
-    pub fn mk_unary(&mut self, unop: ast::UnOp, expr: @Expr) -> ast::Expr_ {
+    pub fn mk_unary(&mut self, unop: ast::UnOp, expr: Gc<Expr>) -> ast::Expr_ {
         ExprUnary(unop, expr)
     }
 
-    pub fn mk_binary(&mut self, binop: ast::BinOp, lhs: @Expr, rhs: @Expr) -> ast::Expr_ {
+    pub fn mk_binary(&mut self, binop: ast::BinOp,
+                     lhs: Gc<Expr>, rhs: Gc<Expr>) -> ast::Expr_ {
         ExprBinary(binop, lhs, rhs)
     }
 
-    pub fn mk_call(&mut self, f: @Expr, args: Vec<@Expr> ) -> ast::Expr_ {
+    pub fn mk_call(&mut self, f: Gc<Expr>, args: Vec<Gc<Expr>>) -> ast::Expr_ {
         ExprCall(f, args)
     }
 
     fn mk_method_call(&mut self,
                       ident: ast::SpannedIdent,
                       tps: Vec<P<Ty>>,
-                      args: Vec<@Expr>)
+                      args: Vec<Gc<Expr>>)
                       -> ast::Expr_ {
         ExprMethodCall(ident, tps, args)
     }
 
-    pub fn mk_index(&mut self, expr: @Expr, idx: @Expr) -> ast::Expr_ {
+    pub fn mk_index(&mut self, expr: Gc<Expr>, idx: Gc<Expr>) -> ast::Expr_ {
         ExprIndex(expr, idx)
     }
 
-    pub fn mk_field(&mut self, expr: @Expr, ident: Ident, tys: Vec<P<Ty>> ) -> ast::Expr_ {
+    pub fn mk_field(&mut self, expr: Gc<Expr>, ident: Ident,
+                    tys: Vec<P<Ty>>) -> ast::Expr_ {
         ExprField(expr, ident, tys)
     }
 
-    pub fn mk_assign_op(&mut self, binop: ast::BinOp, lhs: @Expr, rhs: @Expr) -> ast::Expr_ {
+    pub fn mk_assign_op(&mut self, binop: ast::BinOp,
+                        lhs: Gc<Expr>, rhs: Gc<Expr>) -> ast::Expr_ {
         ExprAssignOp(binop, lhs, rhs)
     }
 
-    pub fn mk_mac_expr(&mut self, lo: BytePos, hi: BytePos, m: Mac_) -> @Expr {
-        @Expr {
+    pub fn mk_mac_expr(&mut self, lo: BytePos, hi: BytePos, m: Mac_) -> Gc<Expr> {
+        box(GC) Expr {
             id: ast::DUMMY_NODE_ID,
             node: ExprMac(codemap::Spanned {node: m, span: mk_sp(lo, hi)}),
             span: mk_sp(lo, hi),
         }
     }
 
-    pub fn mk_lit_u32(&mut self, i: u32) -> @Expr {
+    pub fn mk_lit_u32(&mut self, i: u32) -> Gc<Expr> {
         let span = &self.span;
-        let lv_lit = @codemap::Spanned {
+        let lv_lit = box(GC) codemap::Spanned {
             node: LitUint(i as u64, TyU32),
             span: *span
         };
 
-        @Expr {
+        box(GC) Expr {
             id: ast::DUMMY_NODE_ID,
             node: ExprLit(lv_lit),
             span: *span,
@@ -1788,7 +1793,7 @@ impl<'a> Parser<'a> {
     // at the bottom (top?) of the precedence hierarchy,
     // parse things like parenthesized exprs,
     // macros, return, etc.
-    pub fn parse_bottom_expr(&mut self) -> @Expr {
+    pub fn parse_bottom_expr(&mut self) -> Gc<Expr> {
         maybe_whole_expr!(self);
 
         let lo = self.span.lo;
@@ -1804,7 +1809,7 @@ impl<'a> Parser<'a> {
             if self.token == token::RPAREN {
                 hi = self.span.hi;
                 self.bump();
-                let lit = @spanned(lo, hi, LitNil);
+                let lit = box(GC) spanned(lo, hi, LitNil);
                 return self.mk_expr(lo, hi, ExprLit(lit));
             }
             let mut es = vec!(self.parse_expr());
@@ -1991,7 +1996,7 @@ impl<'a> Parser<'a> {
             // other literal expression
             let lit = self.parse_lit();
             hi = lit.span.hi;
-            ex = ExprLit(@lit);
+            ex = ExprLit(box(GC) lit);
         }
 
         return self.mk_expr(lo, hi, ex);
@@ -1999,19 +2004,19 @@ impl<'a> Parser<'a> {
 
     // parse a block or unsafe block
     pub fn parse_block_expr(&mut self, lo: BytePos, blk_mode: BlockCheckMode)
-                            -> @Expr {
+                            -> Gc<Expr> {
         self.expect(&token::LBRACE);
         let blk = self.parse_block_tail(lo, blk_mode);
         return self.mk_expr(blk.span.lo, blk.span.hi, ExprBlock(blk));
     }
 
     // parse a.b or a(13) or a[4] or just a
-    pub fn parse_dot_or_call_expr(&mut self) -> @Expr {
+    pub fn parse_dot_or_call_expr(&mut self) -> Gc<Expr> {
         let b = self.parse_bottom_expr();
         self.parse_dot_or_call_expr_with(b)
     }
 
-    pub fn parse_dot_or_call_expr_with(&mut self, e0: @Expr) -> @Expr {
+    pub fn parse_dot_or_call_expr_with(&mut self, e0: Gc<Expr>) -> Gc<Expr> {
         let mut e = e0;
         let lo = e.span.lo;
         let mut hi;
@@ -2282,7 +2287,7 @@ impl<'a> Parser<'a> {
     }
 
     // parse a prefix-operator expr
-    pub fn parse_prefix_expr(&mut self) -> @Expr {
+    pub fn parse_prefix_expr(&mut self) -> Gc<Expr> {
         let lo = self.span.lo;
         let hi;
 
@@ -2384,13 +2389,14 @@ impl<'a> Parser<'a> {
     }
 
     // parse an expression of binops
-    pub fn parse_binops(&mut self) -> @Expr {
+    pub fn parse_binops(&mut self) -> Gc<Expr> {
         let prefix_expr = self.parse_prefix_expr();
         self.parse_more_binops(prefix_expr, 0)
     }
 
     // parse an expression of binops of at least min_prec precedence
-    pub fn parse_more_binops(&mut self, lhs: @Expr, min_prec: uint) -> @Expr {
+    pub fn parse_more_binops(&mut self, lhs: Gc<Expr>,
+                             min_prec: uint) -> Gc<Expr> {
         if self.expr_is_complete(lhs) { return lhs; }
 
         // Prevent dynamic borrow errors later on by limiting the
@@ -2439,7 +2445,7 @@ impl<'a> Parser<'a> {
     // parse an assignment expression....
     // actually, this seems to be the main entry point for
     // parsing an arbitrary expression.
-    pub fn parse_assign_expr(&mut self) -> @Expr {
+    pub fn parse_assign_expr(&mut self) -> Gc<Expr> {
         let lo = self.span.lo;
         let lhs = self.parse_binops();
         match self.token {
@@ -2473,11 +2479,11 @@ impl<'a> Parser<'a> {
     }
 
     // parse an 'if' expression ('if' token already eaten)
-    pub fn parse_if_expr(&mut self) -> @Expr {
+    pub fn parse_if_expr(&mut self) -> Gc<Expr> {
         let lo = self.last_span.lo;
         let cond = self.parse_expr();
         let thn = self.parse_block();
-        let mut els: Option<@Expr> = None;
+        let mut els: Option<Gc<Expr>> = None;
         let mut hi = thn.span.hi;
         if self.eat_keyword(keywords::Else) {
             let elexpr = self.parse_else_expr();
@@ -2488,7 +2494,7 @@ impl<'a> Parser<'a> {
     }
 
     // `|args| { ... }` or `{ ...}` like in `do` expressions
-    pub fn parse_lambda_block_expr(&mut self) -> @Expr {
+    pub fn parse_lambda_block_expr(&mut self) -> Gc<Expr> {
         self.parse_lambda_expr_(
             |p| {
                 match p.token {
@@ -2517,7 +2523,7 @@ impl<'a> Parser<'a> {
     }
 
     // `|args| expr`
-    pub fn parse_lambda_expr(&mut self) -> @Expr {
+    pub fn parse_lambda_expr(&mut self) -> Gc<Expr> {
         self.parse_lambda_expr_(|p| p.parse_fn_block_decl(),
                                 |p| p.parse_expr())
     }
@@ -2527,8 +2533,8 @@ impl<'a> Parser<'a> {
     // and in parsing a block expr as e.g. in for...
     pub fn parse_lambda_expr_(&mut self,
                               parse_decl: |&mut Parser| -> P<FnDecl>,
-                              parse_body: |&mut Parser| -> @Expr)
-                              -> @Expr {
+                              parse_body: |&mut Parser| -> Gc<Expr>)
+                              -> Gc<Expr> {
         let lo = self.span.lo;
         let decl = parse_decl(self);
         let body = parse_body(self);
@@ -2544,7 +2550,7 @@ impl<'a> Parser<'a> {
         return self.mk_expr(lo, body.span.hi, ExprFnBlock(decl, fakeblock));
     }
 
-    pub fn parse_else_expr(&mut self) -> @Expr {
+    pub fn parse_else_expr(&mut self) -> Gc<Expr> {
         if self.eat_keyword(keywords::If) {
             return self.parse_if_expr();
         } else {
@@ -2554,7 +2560,7 @@ impl<'a> Parser<'a> {
     }
 
     // parse a 'for' .. 'in' expression ('for' token already eaten)
-    pub fn parse_for_expr(&mut self, opt_ident: Option<ast::Ident>) -> @Expr {
+    pub fn parse_for_expr(&mut self, opt_ident: Option<ast::Ident>) -> Gc<Expr> {
         // Parse: `for <src_pat> in <src_expr> <src_loop_block>`
 
         let lo = self.last_span.lo;
@@ -2567,7 +2573,7 @@ impl<'a> Parser<'a> {
         self.mk_expr(lo, hi, ExprForLoop(pat, expr, loop_block, opt_ident))
     }
 
-    pub fn parse_while_expr(&mut self) -> @Expr {
+    pub fn parse_while_expr(&mut self) -> Gc<Expr> {
         let lo = self.last_span.lo;
         let cond = self.parse_expr();
         let body = self.parse_block();
@@ -2575,7 +2581,7 @@ impl<'a> Parser<'a> {
         return self.mk_expr(lo, hi, ExprWhile(cond, body));
     }
 
-    pub fn parse_loop_expr(&mut self, opt_ident: Option<ast::Ident>) -> @Expr {
+    pub fn parse_loop_expr(&mut self, opt_ident: Option<ast::Ident>) -> Gc<Expr> {
         let lo = self.last_span.lo;
         let body = self.parse_block();
         let hi = body.span.hi;
@@ -2590,7 +2596,7 @@ impl<'a> Parser<'a> {
          || self.look_ahead(1, |t| *t == token::DOTDOT))
     }
 
-    fn parse_match_expr(&mut self) -> @Expr {
+    fn parse_match_expr(&mut self) -> Gc<Expr> {
         let lo = self.last_span.lo;
         let discriminant = self.parse_expr();
         self.commit_expr_expecting(discriminant, token::LBRACE);
@@ -2628,12 +2634,12 @@ impl<'a> Parser<'a> {
     }
 
     // parse an expression
-    pub fn parse_expr(&mut self) -> @Expr {
+    pub fn parse_expr(&mut self) -> Gc<Expr> {
         return self.parse_expr_res(UNRESTRICTED);
     }
 
     // parse an expression, subject to the given restriction
-    fn parse_expr_res(&mut self, r: restriction) -> @Expr {
+    fn parse_expr_res(&mut self, r: restriction) -> Gc<Expr> {
         let old = self.restriction;
         self.restriction = r;
         let e = self.parse_assign_expr();
@@ -2642,7 +2648,7 @@ impl<'a> Parser<'a> {
     }
 
     // parse the RHS of a local variable declaration (e.g. '= 14;')
-    fn parse_initializer(&mut self) -> Option<@Expr> {
+    fn parse_initializer(&mut self) -> Option<Gc<Expr>> {
         if self.token == token::EQ {
             self.bump();
             Some(self.parse_expr())
@@ -2652,7 +2658,7 @@ impl<'a> Parser<'a> {
     }
 
     // parse patterns, separated by '|' s
-    fn parse_pats(&mut self) -> Vec<@Pat> {
+    fn parse_pats(&mut self) -> Vec<Gc<Pat>> {
         let mut pats = Vec::new();
         loop {
             pats.push(self.parse_pat());
@@ -2663,7 +2669,7 @@ impl<'a> Parser<'a> {
 
     fn parse_pat_vec_elements(
         &mut self,
-    ) -> (Vec<@Pat> , Option<@Pat>, Vec<@Pat> ) {
+    ) -> (Vec<Gc<Pat>> , Option<Gc<Pat>>, Vec<Gc<Pat>> ) {
         let mut before = Vec::new();
         let mut slice = None;
         let mut after = Vec::new();
@@ -2685,7 +2691,7 @@ impl<'a> Parser<'a> {
 
             if is_slice {
                 if self.token == token::COMMA || self.token == token::RBRACKET {
-                    slice = Some(@ast::Pat {
+                    slice = Some(box(GC) ast::Pat {
                         id: ast::DUMMY_NODE_ID,
                         node: PatWildMulti,
                         span: self.span,
@@ -2764,7 +2770,7 @@ impl<'a> Parser<'a> {
             } else {
                 let fieldpath = ast_util::ident_to_path(self.last_span,
                                                         fieldname);
-                @ast::Pat {
+                box(GC) ast::Pat {
                     id: ast::DUMMY_NODE_ID,
                     node: PatIdent(bind_type, fieldpath, None),
                     span: self.last_span
@@ -2776,7 +2782,7 @@ impl<'a> Parser<'a> {
     }
 
     // parse a pattern.
-    pub fn parse_pat(&mut self) -> @Pat {
+    pub fn parse_pat(&mut self) -> Gc<Pat> {
         maybe_whole!(self, NtPat);
 
         let lo = self.span.lo;
@@ -2788,7 +2794,7 @@ impl<'a> Parser<'a> {
             self.bump();
             pat = PatWild;
             hi = self.last_span.hi;
-            return @ast::Pat {
+            return box(GC) ast::Pat {
                 id: ast::DUMMY_NODE_ID,
                 node: pat,
                 span: mk_sp(lo, hi)
@@ -2801,7 +2807,7 @@ impl<'a> Parser<'a> {
             pat = PatBox(sub);
             hi = self.last_span.hi;
             self.obsolete(self.last_span, ObsoleteOwnedPattern);
-            return @ast::Pat {
+            return box(GC) ast::Pat {
                 id: ast::DUMMY_NODE_ID,
                 node: pat,
                 span: mk_sp(lo, hi)
@@ -2814,7 +2820,7 @@ impl<'a> Parser<'a> {
             let sub = self.parse_pat();
             pat = PatRegion(sub);
             hi = self.last_span.hi;
-            return @ast::Pat {
+            return box(GC) ast::Pat {
                 id: ast::DUMMY_NODE_ID,
                 node: pat,
                 span: mk_sp(lo, hi)
@@ -2826,7 +2832,7 @@ impl<'a> Parser<'a> {
             if self.token == token::RPAREN {
                 hi = self.span.hi;
                 self.bump();
-                let lit = @codemap::Spanned {
+                let lit = box(GC) codemap::Spanned {
                     node: LitNil,
                     span: mk_sp(lo, hi)};
                 let expr = self.mk_expr(lo, hi, ExprLit(lit));
@@ -2845,7 +2851,7 @@ impl<'a> Parser<'a> {
                 pat = PatTup(fields);
             }
             hi = self.last_span.hi;
-            return @ast::Pat {
+            return box(GC) ast::Pat {
                 id: ast::DUMMY_NODE_ID,
                 node: pat,
                 span: mk_sp(lo, hi)
@@ -2860,7 +2866,7 @@ impl<'a> Parser<'a> {
             self.expect(&token::RBRACKET);
             pat = ast::PatVec(before, slice, after);
             hi = self.last_span.hi;
-            return @ast::Pat {
+            return box(GC) ast::Pat {
                 id: ast::DUMMY_NODE_ID,
                 node: pat,
                 span: mk_sp(lo, hi)
@@ -2904,7 +2910,7 @@ impl<'a> Parser<'a> {
             let sub = self.parse_pat();
             pat = PatBox(sub);
             hi = self.last_span.hi;
-            return @ast::Pat {
+            return box(GC) ast::Pat {
                 id: ast::DUMMY_NODE_ID,
                 node: pat,
                 span: mk_sp(lo, hi)
@@ -2960,7 +2966,7 @@ impl<'a> Parser<'a> {
                         pat = PatStruct(enum_path, fields, etc);
                     }
                     _ => {
-                        let mut args: Vec<@Pat> = Vec::new();
+                        let mut args: Vec<Gc<Pat>> = Vec::new();
                         match self.token {
                           token::LPAREN => {
                             let is_dotdot = self.look_ahead(1, |t| {
@@ -3003,7 +3009,7 @@ impl<'a> Parser<'a> {
             }
         }
         hi = self.last_span.hi;
-        @ast::Pat {
+        box(GC) ast::Pat {
             id: ast::DUMMY_NODE_ID,
             node: pat,
             span: mk_sp(lo, hi),
@@ -3044,7 +3050,7 @@ impl<'a> Parser<'a> {
     }
 
     // parse a local variable declaration
-    fn parse_local(&mut self) -> @Local {
+    fn parse_local(&mut self) -> Gc<Local> {
         let lo = self.span.lo;
         let pat = self.parse_pat();
 
@@ -3055,7 +3061,7 @@ impl<'a> Parser<'a> {
         });
         if self.eat(&token::COLON) { ty = self.parse_ty(false); }
         let init = self.parse_initializer();
-        @ast::Local {
+        box(GC) ast::Local {
             ty: ty,
             pat: pat,
             init: init,
@@ -3066,10 +3072,10 @@ impl<'a> Parser<'a> {
     }
 
     // parse a "let" stmt
-    fn parse_let(&mut self) -> @Decl {
+    fn parse_let(&mut self) -> Gc<Decl> {
         let lo = self.span.lo;
         let local = self.parse_local();
-        return @spanned(lo, self.last_span.hi, DeclLocal(local));
+        box(GC) spanned(lo, self.last_span.hi, DeclLocal(local))
     }
 
     // parse a structure field
@@ -3092,7 +3098,7 @@ impl<'a> Parser<'a> {
 
     // parse a statement. may include decl.
     // precondition: any attributes are parsed already
-    pub fn parse_stmt(&mut self, item_attrs: Vec<Attribute> ) -> @Stmt {
+    pub fn parse_stmt(&mut self, item_attrs: Vec<Attribute>) -> Gc<Stmt> {
         maybe_whole!(self, NtStmt);
 
         fn check_expected_item(p: &mut Parser, found_attrs: bool) {
@@ -3107,7 +3113,7 @@ impl<'a> Parser<'a> {
             check_expected_item(self, !item_attrs.is_empty());
             self.expect_keyword(keywords::Let);
             let decl = self.parse_let();
-            return @spanned(lo, decl.span.hi, StmtDecl(decl, ast::DUMMY_NODE_ID));
+            return box(GC) spanned(lo, decl.span.hi, StmtDecl(decl, ast::DUMMY_NODE_ID));
         } else if is_ident(&self.token)
             && !token::is_any_keyword(&self.token)
             && self.look_ahead(1, |t| *t == token::NOT) {
@@ -3166,12 +3172,12 @@ impl<'a> Parser<'a> {
             let hi = self.span.hi;
 
             if id == token::special_idents::invalid {
-                return @spanned(lo, hi, StmtMac(
+                return box(GC) spanned(lo, hi, StmtMac(
                     spanned(lo, hi, MacInvocTT(pth, tts, EMPTY_CTXT)), false));
             } else {
                 // if it has a special ident, it's definitely an item
-                return @spanned(lo, hi, StmtDecl(
-                    @spanned(lo, hi, DeclItem(
+                return box(GC) spanned(lo, hi, StmtDecl(
+                    box(GC) spanned(lo, hi, DeclItem(
                         self.mk_item(
                             lo, hi, id /*id is good here*/,
                             ItemMac(spanned(lo, hi, MacInvocTT(pth, tts, EMPTY_CTXT))),
@@ -3184,8 +3190,8 @@ impl<'a> Parser<'a> {
             match self.parse_item_or_view_item(item_attrs, false) {
                 IoviItem(i) => {
                     let hi = i.span.hi;
-                    let decl = @spanned(lo, hi, DeclItem(i));
-                    return @spanned(lo, hi, StmtDecl(decl, ast::DUMMY_NODE_ID));
+                    let decl = box(GC) spanned(lo, hi, DeclItem(i));
+                    return box(GC) spanned(lo, hi, StmtDecl(decl, ast::DUMMY_NODE_ID));
                 }
                 IoviViewItem(vi) => {
                     self.span_fatal(vi.span,
@@ -3201,12 +3207,12 @@ impl<'a> Parser<'a> {
 
             // Remainder are line-expr stmts.
             let e = self.parse_expr_res(RESTRICT_STMT_EXPR);
-            return @spanned(lo, e.span.hi, StmtExpr(e, ast::DUMMY_NODE_ID));
+            return box(GC) spanned(lo, e.span.hi, StmtExpr(e, ast::DUMMY_NODE_ID));
         }
     }
 
     // is this expression a successfully-parsed statement?
-    fn expr_is_complete(&mut self, e: @Expr) -> bool {
+    fn expr_is_complete(&mut self, e: Gc<Expr>) -> bool {
         return self.restriction == RESTRICT_STMT_EXPR &&
             !classify::expr_requires_semi_to_be_stmt(e);
     }
@@ -3258,8 +3264,8 @@ impl<'a> Parser<'a> {
                                             false, false);
 
         for item in items.iter() {
-            let decl = @spanned(item.span.lo, item.span.hi, DeclItem(*item));
-            stmts.push(@spanned(item.span.lo, item.span.hi,
+            let decl = box(GC) spanned(item.span.lo, item.span.hi, DeclItem(*item));
+            stmts.push(box(GC) spanned(item.span.lo, item.span.hi,
                                 StmtDecl(decl, ast::DUMMY_NODE_ID)));
         }
 
@@ -3286,7 +3292,7 @@ impl<'a> Parser<'a> {
                     match stmt.node {
                         StmtExpr(e, stmt_id) => {
                             // expression without semicolon
-                            if classify::stmt_ends_with_semi(stmt) {
+                            if classify::stmt_ends_with_semi(&*stmt) {
                                 // Just check for errors and recover; do not eat semicolon yet.
                                 self.commit_stmt(stmt, &[], &[token::SEMI, token::RBRACE]);
                             }
@@ -3299,7 +3305,7 @@ impl<'a> Parser<'a> {
                                         hi: self.last_span.hi,
                                         expn_info: stmt.span.expn_info,
                                     };
-                                    stmts.push(@codemap::Spanned {
+                                    stmts.push(box(GC) codemap::Spanned {
                                         node: StmtSemi(e, stmt_id),
                                         span: span_with_semi,
                                     });
@@ -3317,7 +3323,7 @@ impl<'a> Parser<'a> {
                             match self.token {
                                 token::SEMI => {
                                     self.bump();
-                                    stmts.push(@codemap::Spanned {
+                                    stmts.push(box(GC) codemap::Spanned {
                                         node: StmtMac((*m).clone(), true),
                                         span: stmt.span,
                                     });
@@ -3336,9 +3342,9 @@ impl<'a> Parser<'a> {
                             }
                         }
                         _ => { // all other kinds of statements:
-                            stmts.push(stmt);
+                            stmts.push(stmt.clone());
 
-                            if classify::stmt_ends_with_semi(stmt) {
+                            if classify::stmt_ends_with_semi(&*stmt) {
                                 self.commit_stmt_expecting(stmt, token::SEMI);
                             }
                         }
@@ -3827,8 +3833,8 @@ impl<'a> Parser<'a> {
 
     fn mk_item(&mut self, lo: BytePos, hi: BytePos, ident: Ident,
                node: Item_, vis: Visibility,
-               attrs: Vec<Attribute> ) -> @Item {
-        @Item {
+               attrs: Vec<Attribute>) -> Gc<Item> {
+        box(GC) Item {
             ident: ident,
             attrs: attrs,
             id: ast::DUMMY_NODE_ID,
@@ -3847,7 +3853,8 @@ impl<'a> Parser<'a> {
     }
 
     // parse a method in a trait impl, starting with `attrs` attributes.
-    fn parse_method(&mut self, already_parsed_attrs: Option<Vec<Attribute> >) -> @Method {
+    fn parse_method(&mut self,
+                    already_parsed_attrs: Option<Vec<Attribute>>) -> Gc<Method> {
         let next_attrs = self.parse_outer_attributes();
         let attrs = match already_parsed_attrs {
             Some(mut a) => { a.push_all_move(next_attrs); a }
@@ -3867,7 +3874,7 @@ impl<'a> Parser<'a> {
         let (inner_attrs, body) = self.parse_inner_attrs_and_block();
         let hi = body.span.hi;
         let attrs = attrs.append(inner_attrs.as_slice());
-        @ast::Method {
+        box(GC) ast::Method {
             ident: ident,
             attrs: attrs,
             generics: generics,
@@ -3950,7 +3957,7 @@ impl<'a> Parser<'a> {
             method_attrs = None;
         }
 
-        let ident = ast_util::impl_pretty_name(&opt_trait, ty);
+        let ident = ast_util::impl_pretty_name(&opt_trait, &*ty);
 
         (ident, ItemImpl(generics, opt_trait, ty, meths), Some(inner_attrs))
     }
@@ -4041,7 +4048,7 @@ impl<'a> Parser<'a> {
         let _ = ast::DUMMY_NODE_ID;  // FIXME: Workaround for crazy bug.
         let new_id = ast::DUMMY_NODE_ID;
         (class_name,
-         ItemStruct(@ast::StructDef {
+         ItemStruct(box(GC) ast::StructDef {
              fields: fields,
              ctor_id: if is_tuple_like { Some(new_id) } else { None },
              super_struct: super_struct,
@@ -4121,7 +4128,7 @@ impl<'a> Parser<'a> {
             items: starting_items,
             ..
         } = self.parse_items_and_view_items(first_item_attrs, true, true);
-        let mut items: Vec<@Item> = starting_items;
+        let mut items: Vec<Gc<Item>> = starting_items;
         let attrs_remaining_len = attrs_remaining.len();
 
         // don't think this other loop is even necessary....
@@ -4322,7 +4329,7 @@ impl<'a> Parser<'a> {
 
     // parse a function declaration from a foreign module
     fn parse_item_foreign_fn(&mut self, vis: ast::Visibility,
-                             attrs: Vec<Attribute> ) -> @ForeignItem {
+                             attrs: Vec<Attribute>) -> Gc<ForeignItem> {
         let lo = self.span.lo;
         self.expect_keyword(keywords::Fn);
 
@@ -4330,17 +4337,17 @@ impl<'a> Parser<'a> {
         let decl = self.parse_fn_decl(true);
         let hi = self.span.hi;
         self.expect(&token::SEMI);
-        @ast::ForeignItem { ident: ident,
-                            attrs: attrs,
-                            node: ForeignItemFn(decl, generics),
-                            id: ast::DUMMY_NODE_ID,
-                            span: mk_sp(lo, hi),
-                            vis: vis }
+        box(GC) ast::ForeignItem { ident: ident,
+                                   attrs: attrs,
+                                   node: ForeignItemFn(decl, generics),
+                                   id: ast::DUMMY_NODE_ID,
+                                   span: mk_sp(lo, hi),
+                                   vis: vis }
     }
 
     // parse a static item from a foreign module
     fn parse_item_foreign_static(&mut self, vis: ast::Visibility,
-                                 attrs: Vec<Attribute> ) -> @ForeignItem {
+                                 attrs: Vec<Attribute> ) -> Gc<ForeignItem> {
         let lo = self.span.lo;
 
         self.expect_keyword(keywords::Static);
@@ -4351,7 +4358,7 @@ impl<'a> Parser<'a> {
         let ty = self.parse_ty(false);
         let hi = self.span.hi;
         self.expect(&token::SEMI);
-        @ast::ForeignItem {
+        box(GC) ast::ForeignItem {
             ident: ident,
             attrs: attrs,
             node: ForeignItemStatic(ty, mutbl),
@@ -4483,14 +4490,14 @@ impl<'a> Parser<'a> {
 
     // parse a structure-like enum variant definition
     // this should probably be renamed or refactored...
-    fn parse_struct_def(&mut self) -> @StructDef {
+    fn parse_struct_def(&mut self) -> Gc<StructDef> {
         let mut fields: Vec<StructField> = Vec::new();
         while self.token != token::RBRACE {
             fields.push(self.parse_struct_decl_field());
         }
         self.bump();
 
-        return @ast::StructDef {
+        return box(GC) ast::StructDef {
             fields: fields,
             ctor_id: None,
             super_struct: None,
@@ -4617,7 +4624,7 @@ impl<'a> Parser<'a> {
             INTERPOLATED(token::NtItem(item)) => {
                 self.bump();
                 let new_attrs = attrs.append(item.attrs.as_slice());
-                return IoviItem(@Item {
+                return IoviItem(box(GC) Item {
                     attrs: new_attrs,
                     ..(*item).clone()
                 });
@@ -4892,7 +4899,7 @@ impl<'a> Parser<'a> {
         return IoviNone(attrs);
     }
 
-    pub fn parse_item(&mut self, attrs: Vec<Attribute> ) -> Option<@Item> {
+    pub fn parse_item(&mut self, attrs: Vec<Attribute> ) -> Option<Gc<Item>> {
         match self.parse_item_or_view_item(attrs, true) {
             IoviNone(_) => None,
             IoviViewItem(_) =>
@@ -4914,7 +4921,7 @@ impl<'a> Parser<'a> {
     // | MOD? non_global_path MOD_SEP LBRACE ident_seq RBRACE
     // | MOD? non_global_path MOD_SEP STAR
     // | MOD? non_global_path
-    fn parse_view_path(&mut self) -> @ViewPath {
+    fn parse_view_path(&mut self) -> Gc<ViewPath> {
         let lo = self.span.lo;
 
         if self.token == token::LBRACE {
@@ -4928,7 +4935,7 @@ impl<'a> Parser<'a> {
                 global: false,
                 segments: Vec::new()
             };
-            return @spanned(lo, self.span.hi,
+            return box(GC) spanned(lo, self.span.hi,
                             ViewPathList(path, idents, ast::DUMMY_NODE_ID));
         }
 
@@ -4956,7 +4963,7 @@ impl<'a> Parser<'a> {
                     }
                 }).collect()
             };
-            return @spanned(lo, self.span.hi,
+            return box(GC) spanned(lo, self.span.hi,
                             ViewPathSimple(first_ident, path,
                                            ast::DUMMY_NODE_ID));
           }
@@ -4991,7 +4998,7 @@ impl<'a> Parser<'a> {
                             }
                         }).collect()
                     };
-                    return @spanned(lo, self.span.hi,
+                    return box(GC) spanned(lo, self.span.hi,
                                     ViewPathList(path, idents, ast::DUMMY_NODE_ID));
                   }
 
@@ -5009,7 +5016,7 @@ impl<'a> Parser<'a> {
                             }
                         }).collect()
                     };
-                    return @spanned(lo, self.span.hi,
+                    return box(GC) spanned(lo, self.span.hi,
                                     ViewPathGlob(path, ast::DUMMY_NODE_ID));
                   }
 
@@ -5031,7 +5038,7 @@ impl<'a> Parser<'a> {
                 }
             }).collect()
         };
-        return @spanned(lo,
+        return box(GC) spanned(lo,
                         self.last_span.hi,
                         ViewPathSimple(last, path, ast::DUMMY_NODE_ID));
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -277,8 +277,8 @@ fn maybe_append(lhs: Vec<Attribute> , rhs: Option<Vec<Attribute> >)
 struct ParsedItemsAndViewItems {
     attrs_remaining: Vec<Attribute>,
     view_items: Vec<ViewItem>,
-    items: Vec<@Item>,
-    foreign_items: Vec<@ForeignItem>
+    items: Vec<Gc<Item>>,
+    foreign_items: Vec<Gc<ForeignItem>>
 }
 
 /* ident is handled by common.rs */

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -18,10 +18,10 @@ use util::interner;
 
 use serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::fmt;
-use std::path::BytesContainer;
+use std::gc::Gc;
 use std::mem;
+use std::path::BytesContainer;
 use std::rc::Rc;
-use std::string::String;
 
 #[allow(non_camel_case_types)]
 #[deriving(Clone, Encodable, Decodable, PartialEq, Eq, Hash, Show)]
@@ -105,16 +105,16 @@ pub enum Token {
 #[deriving(Clone, Encodable, Decodable, PartialEq, Eq, Hash)]
 /// For interpolation during macro expansion.
 pub enum Nonterminal {
-    NtItem(@ast::Item),
+    NtItem(Gc<ast::Item>),
     NtBlock(P<ast::Block>),
-    NtStmt(@ast::Stmt),
-    NtPat( @ast::Pat),
-    NtExpr(@ast::Expr),
+    NtStmt(Gc<ast::Stmt>),
+    NtPat( Gc<ast::Pat>),
+    NtExpr(Gc<ast::Expr>),
     NtTy(  P<ast::Ty>),
     NtIdent(Box<ast::Ident>, bool),
-    NtMeta(@ast::MetaItem), // stuff inside brackets for attributes
+    NtMeta(Gc<ast::MetaItem>), // stuff inside brackets for attributes
     NtPath(Box<ast::Path>),
-    NtTT(  @ast::TokenTree), // needs @ed to break a circularity
+    NtTT(  Gc<ast::TokenTree>), // needs @ed to break a circularity
     NtMatchers(Vec<ast::Matcher> )
 }
 
@@ -241,8 +241,8 @@ pub fn to_str(t: &Token) -> String {
       EOF => "<eof>".to_string(),
       INTERPOLATED(ref nt) => {
         match nt {
-            &NtExpr(e) => ::print::pprust::expr_to_str(e),
-            &NtMeta(e) => ::print::pprust::meta_item_to_str(e),
+            &NtExpr(ref e) => ::print::pprust::expr_to_str(&**e),
+            &NtMeta(ref e) => ::print::pprust::meta_item_to_str(&**e),
             _ => {
                 let mut s = "an interpolated ".to_string();
                 match *nt {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1968,7 +1968,7 @@ impl<'a> State<'a> {
                                          &None,
                                          ast::NormalFn,
                                          ast::Many,
-                                         unboxed_function_type.decl,
+                                         &*unboxed_function_type.decl,
                                          None,
                                          &None,
                                          None,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -26,11 +26,11 @@ use print::pp::{break_offset, word, space, zerobreak, hardbreak};
 use print::pp::{Breaks, Consistent, Inconsistent, eof};
 use print::pp;
 
+use std::gc::Gc;
 use std::io::{IoResult, MemWriter};
 use std::io;
 use std::mem;
 use std::str;
-use std::string::String;
 
 pub enum AnnNode<'a> {
     NodeBlock(&'a ast::Block),
@@ -421,8 +421,8 @@ impl<'a> State<'a> {
     }
 
     pub fn commasep_exprs(&mut self, b: Breaks,
-                          exprs: &[@ast::Expr]) -> IoResult<()> {
-        self.commasep_cmnt(b, exprs, |s, &e| s.print_expr(e), |e| e.span)
+                          exprs: &[Gc<ast::Expr>]) -> IoResult<()> {
+        self.commasep_cmnt(b, exprs, |s, e| s.print_expr(&**e), |e| e.span)
     }
 
     pub fn print_mod(&mut self, _mod: &ast::Mod,
@@ -432,7 +432,7 @@ impl<'a> State<'a> {
             try!(self.print_view_item(vitem));
         }
         for item in _mod.items.iter() {
-            try!(self.print_item(*item));
+            try!(self.print_item(&**item));
         }
         Ok(())
     }
@@ -444,7 +444,7 @@ impl<'a> State<'a> {
             try!(self.print_view_item(vitem));
         }
         for item in nmod.items.iter() {
-            try!(self.print_foreign_item(*item));
+            try!(self.print_foreign_item(&**item));
         }
         Ok(())
     }
@@ -464,17 +464,17 @@ impl<'a> State<'a> {
         match ty.node {
             ast::TyNil => try!(word(&mut self.s, "()")),
             ast::TyBot => try!(word(&mut self.s, "!")),
-            ast::TyBox(ty) => {
+            ast::TyBox(ref ty) => {
                 try!(word(&mut self.s, "@"));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
             }
-            ast::TyUniq(ty) => {
+            ast::TyUniq(ref ty) => {
                 try!(word(&mut self.s, "~"));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
             }
-            ast::TyVec(ty) => {
+            ast::TyVec(ref ty) => {
                 try!(word(&mut self.s, "["));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
                 try!(word(&mut self.s, "]"));
             }
             ast::TyPtr(ref mt) => {
@@ -505,7 +505,7 @@ impl<'a> State<'a> {
                                       &None,
                                       f.fn_style,
                                       ast::Many,
-                                      f.decl,
+                                      &*f.decl,
                                       None,
                                       &None,
                                       Some(&generics),
@@ -522,14 +522,14 @@ impl<'a> State<'a> {
                                       region,
                                       f.fn_style,
                                       f.onceness,
-                                      f.decl,
+                                      &*f.decl,
                                       None,
                                       &f.bounds,
                                       Some(&generics),
                                       None,
                                       false));
             }
-            ast::TyProc(f) => {
+            ast::TyProc(ref f) => {
                 let generics = ast::Generics {
                     lifetimes: f.lifetimes.clone(),
                     ty_params: OwnedSlice::empty()
@@ -539,7 +539,7 @@ impl<'a> State<'a> {
                                       &None,
                                       f.fn_style,
                                       f.onceness,
-                                      f.decl,
+                                      &*f.decl,
                                       None,
                                       &f.bounds,
                                       Some(&generics),
@@ -552,7 +552,7 @@ impl<'a> State<'a> {
                                       &None,
                                       ast::NormalFn,
                                       ast::Many,
-                                      f.decl,
+                                      &*f.decl,
                                       None,
                                       &None,
                                       None,
@@ -562,16 +562,16 @@ impl<'a> State<'a> {
             ast::TyPath(ref path, ref bounds, _) => {
                 try!(self.print_bounded_path(path, bounds));
             }
-            ast::TyFixedLengthVec(ty, v) => {
+            ast::TyFixedLengthVec(ref ty, ref v) => {
                 try!(word(&mut self.s, "["));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
                 try!(word(&mut self.s, ", .."));
-                try!(self.print_expr(v));
+                try!(self.print_expr(&**v));
                 try!(word(&mut self.s, "]"));
             }
-            ast::TyTypeof(e) => {
+            ast::TyTypeof(ref e) => {
                 try!(word(&mut self.s, "typeof("));
-                try!(self.print_expr(e));
+                try!(self.print_expr(&**e));
                 try!(word(&mut self.s, ")"));
             }
             ast::TyInfer => {
@@ -582,7 +582,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_type_ref(&mut self, ty: &P<ast::Ty>) -> IoResult<()> {
-        self.print_type(*ty)
+        self.print_type(&**ty)
     }
 
     pub fn print_foreign_item(&mut self,
@@ -591,14 +591,14 @@ impl<'a> State<'a> {
         try!(self.maybe_print_comment(item.span.lo));
         try!(self.print_outer_attributes(item.attrs.as_slice()));
         match item.node {
-            ast::ForeignItemFn(decl, ref generics) => {
-                try!(self.print_fn(decl, None, abi::Rust, item.ident, generics,
-                None, item.vis));
+            ast::ForeignItemFn(ref decl, ref generics) => {
+                try!(self.print_fn(&**decl, None, abi::Rust, item.ident, generics,
+                                   None, item.vis));
                 try!(self.end()); // end head-ibox
                 try!(word(&mut self.s, ";"));
                 self.end() // end the outer fn box
             }
-            ast::ForeignItemStatic(t, m) => {
+            ast::ForeignItemStatic(ref t, m) => {
                 try!(self.head(visibility_qualified(item.vis,
                                                     "static").as_slice()));
                 if m {
@@ -606,7 +606,7 @@ impl<'a> State<'a> {
                 }
                 try!(self.print_ident(item.ident));
                 try!(self.word_space(":"));
-                try!(self.print_type(t));
+                try!(self.print_type(&**t));
                 try!(word(&mut self.s, ";"));
                 try!(self.end()); // end the head-ibox
                 self.end() // end the outer cbox
@@ -620,7 +620,7 @@ impl<'a> State<'a> {
         try!(self.print_outer_attributes(item.attrs.as_slice()));
         try!(self.ann.pre(self, NodeItem(item)));
         match item.node {
-            ast::ItemStatic(ty, m, expr) => {
+            ast::ItemStatic(ref ty, m, ref expr) => {
                 try!(self.head(visibility_qualified(item.vis,
                                                     "static").as_slice()));
                 if m == ast::MutMutable {
@@ -628,18 +628,18 @@ impl<'a> State<'a> {
                 }
                 try!(self.print_ident(item.ident));
                 try!(self.word_space(":"));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
                 try!(space(&mut self.s));
                 try!(self.end()); // end the head-ibox
 
                 try!(self.word_space("="));
-                try!(self.print_expr(expr));
+                try!(self.print_expr(&**expr));
                 try!(word(&mut self.s, ";"));
                 try!(self.end()); // end the outer cbox
             }
-            ast::ItemFn(decl, fn_style, abi, ref typarams, body) => {
+            ast::ItemFn(ref decl, fn_style, abi, ref typarams, ref body) => {
                 try!(self.print_fn(
-                    decl,
+                    &**decl,
                     Some(fn_style),
                     abi,
                     item.ident,
@@ -648,7 +648,7 @@ impl<'a> State<'a> {
                     item.vis
                 ));
                 try!(word(&mut self.s, " "));
-                try!(self.print_block_with_attrs(body, item.attrs.as_slice()));
+                try!(self.print_block_with_attrs(&**body, item.attrs.as_slice()));
             }
             ast::ItemMod(ref _mod) => {
                 try!(self.head(visibility_qualified(item.vis,
@@ -666,7 +666,7 @@ impl<'a> State<'a> {
                 try!(self.print_foreign_mod(nmod, item.attrs.as_slice()));
                 try!(self.bclose(item.span));
             }
-            ast::ItemTy(ty, ref params) => {
+            ast::ItemTy(ref ty, ref params) => {
                 try!(self.ibox(indent_unit));
                 try!(self.ibox(0u));
                 try!(self.word_nbsp(visibility_qualified(item.vis,
@@ -677,7 +677,7 @@ impl<'a> State<'a> {
 
                 try!(space(&mut self.s));
                 try!(self.word_space("="));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
                 try!(word(&mut self.s, ";"));
                 try!(self.end()); // end the outer ibox
             }
@@ -690,16 +690,17 @@ impl<'a> State<'a> {
                     item.vis
                 ));
             }
-            ast::ItemStruct(struct_def, ref generics) => {
+            ast::ItemStruct(ref struct_def, ref generics) => {
                 if struct_def.is_virtual {
                     try!(self.word_space("virtual"));
                 }
                 try!(self.head(visibility_qualified(item.vis,
                                                     "struct").as_slice()));
-                try!(self.print_struct(struct_def, generics, item.ident, item.span));
+                try!(self.print_struct(&**struct_def, generics, item.ident,
+                                       item.span));
             }
 
-            ast::ItemImpl(ref generics, ref opt_trait, ty, ref methods) => {
+            ast::ItemImpl(ref generics, ref opt_trait, ref ty, ref methods) => {
                 try!(self.head(visibility_qualified(item.vis,
                                                     "impl").as_slice()));
                 if generics.is_parameterized() {
@@ -716,13 +717,13 @@ impl<'a> State<'a> {
                     &None => {}
                 }
 
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
 
                 try!(space(&mut self.s));
                 try!(self.bopen());
                 try!(self.print_inner_attributes(item.attrs.as_slice()));
                 for meth in methods.iter() {
-                    try!(self.print_method(*meth));
+                    try!(self.print_method(&**meth));
                 }
                 try!(self.bclose(item.span));
             }
@@ -788,12 +789,12 @@ impl<'a> State<'a> {
                           variants: &[P<ast::Variant>],
                           span: codemap::Span) -> IoResult<()> {
         try!(self.bopen());
-        for &v in variants.iter() {
+        for v in variants.iter() {
             try!(self.space_if_not_bol());
             try!(self.maybe_print_comment(v.span.lo));
             try!(self.print_outer_attributes(v.node.attrs.as_slice()));
             try!(self.ibox(indent_unit));
-            try!(self.print_variant(v));
+            try!(self.print_variant(&**v));
             try!(word(&mut self.s, ","));
             try!(self.end());
             try!(self.maybe_print_trailing_comment(v.span, None));
@@ -816,9 +817,9 @@ impl<'a> State<'a> {
         try!(self.print_ident(ident));
         try!(self.print_generics(generics));
         match struct_def.super_struct {
-            Some(t) => {
+            Some(ref t) => {
                 try!(self.word_space(":"));
-                try!(self.print_type(t));
+                try!(self.print_type(&**t));
             },
             None => {},
         }
@@ -833,7 +834,7 @@ impl<'a> State<'a> {
                             ast::UnnamedField(vis) => {
                                 try!(s.print_visibility(vis));
                                 try!(s.maybe_print_comment(field.span.lo));
-                                s.print_type(field.node.ty)
+                                s.print_type(&*field.node.ty)
                             }
                         }
                     }
@@ -858,7 +859,7 @@ impl<'a> State<'a> {
                         try!(self.print_visibility(visibility));
                         try!(self.print_ident(ident));
                         try!(self.word_nbsp(":"));
-                        try!(self.print_type(field.node.ty));
+                        try!(self.print_type(&*field.node.ty));
                         try!(word(&mut self.s, ","));
                     }
                 }
@@ -929,21 +930,21 @@ impl<'a> State<'a> {
                     try!(self.popen());
                     try!(self.commasep(Consistent,
                                        args.as_slice(),
-                                       |s, arg| s.print_type(arg.ty)));
+                                       |s, arg| s.print_type(&*arg.ty)));
                     try!(self.pclose());
                 }
             }
-            ast::StructVariantKind(struct_def) => {
+            ast::StructVariantKind(ref struct_def) => {
                 try!(self.head(""));
                 let generics = ast_util::empty_generics();
-                try!(self.print_struct(struct_def, &generics, v.node.name, v.span));
+                try!(self.print_struct(&**struct_def, &generics, v.node.name, v.span));
             }
         }
         match v.node.disr_expr {
-            Some(d) => {
+            Some(ref d) => {
                 try!(space(&mut self.s));
                 try!(self.word_space("="));
-                self.print_expr(d)
+                self.print_expr(&**d)
             }
             _ => Ok(())
         }
@@ -958,7 +959,7 @@ impl<'a> State<'a> {
                               &None,
                               m.fn_style,
                               ast::Many,
-                              m.decl,
+                              &*m.decl,
                               Some(m.ident),
                               &None,
                               Some(&m.generics),
@@ -971,7 +972,7 @@ impl<'a> State<'a> {
                               m: &ast::TraitMethod) -> IoResult<()> {
         match *m {
             Required(ref ty_m) => self.print_ty_method(ty_m),
-            Provided(m) => self.print_method(m)
+            Provided(ref m) => self.print_method(&**m)
         }
     }
 
@@ -979,11 +980,11 @@ impl<'a> State<'a> {
         try!(self.hardbreak_if_not_bol());
         try!(self.maybe_print_comment(meth.span.lo));
         try!(self.print_outer_attributes(meth.attrs.as_slice()));
-        try!(self.print_fn(meth.decl, Some(meth.fn_style), abi::Rust,
+        try!(self.print_fn(&*meth.decl, Some(meth.fn_style), abi::Rust,
                         meth.ident, &meth.generics, Some(meth.explicit_self.node),
                         meth.vis));
         try!(word(&mut self.s, " "));
-        self.print_block_with_attrs(meth.body, meth.attrs.as_slice())
+        self.print_block_with_attrs(&*meth.body, meth.attrs.as_slice())
     }
 
     pub fn print_outer_attributes(&mut self,
@@ -1032,7 +1033,7 @@ impl<'a> State<'a> {
                 ast::AttrInner => try!(word(&mut self.s, "#![")),
                 ast::AttrOuter => try!(word(&mut self.s, "#[")),
             }
-            try!(self.print_meta_item(attr.meta()));
+            try!(self.print_meta_item(&*attr.meta()));
             word(&mut self.s, "]")
         }
     }
@@ -1041,16 +1042,16 @@ impl<'a> State<'a> {
     pub fn print_stmt(&mut self, st: &ast::Stmt) -> IoResult<()> {
         try!(self.maybe_print_comment(st.span.lo));
         match st.node {
-            ast::StmtDecl(decl, _) => {
-                try!(self.print_decl(decl));
+            ast::StmtDecl(ref decl, _) => {
+                try!(self.print_decl(&**decl));
             }
-            ast::StmtExpr(expr, _) => {
+            ast::StmtExpr(ref expr, _) => {
                 try!(self.space_if_not_bol());
-                try!(self.print_expr(expr));
+                try!(self.print_expr(&**expr));
             }
-            ast::StmtSemi(expr, _) => {
+            ast::StmtSemi(ref expr, _) => {
                 try!(self.space_if_not_bol());
-                try!(self.print_expr(expr));
+                try!(self.print_expr(&**expr));
                 try!(word(&mut self.s, ";"));
             }
             ast::StmtMac(ref mac, semi) => {
@@ -1105,12 +1106,12 @@ impl<'a> State<'a> {
             try!(self.print_view_item(vi));
         }
         for st in blk.stmts.iter() {
-            try!(self.print_stmt(*st));
+            try!(self.print_stmt(&**st));
         }
         match blk.expr {
-            Some(expr) => {
+            Some(ref expr) => {
                 try!(self.space_if_not_bol());
-                try!(self.print_expr(expr));
+                try!(self.print_expr(&**expr));
                 try!(self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi)));
             }
             _ => ()
@@ -1119,26 +1120,26 @@ impl<'a> State<'a> {
         self.ann.post(self, NodeBlock(blk))
     }
 
-    fn print_else(&mut self, els: Option<@ast::Expr>) -> IoResult<()> {
+    fn print_else(&mut self, els: Option<Gc<ast::Expr>>) -> IoResult<()> {
         match els {
             Some(_else) => {
                 match _else.node {
                     // "another else-if"
-                    ast::ExprIf(i, t, e) => {
+                    ast::ExprIf(ref i, ref t, e) => {
                         try!(self.cbox(indent_unit - 1u));
                         try!(self.ibox(0u));
                         try!(word(&mut self.s, " else if "));
-                        try!(self.print_expr(i));
+                        try!(self.print_expr(&**i));
                         try!(space(&mut self.s));
-                        try!(self.print_block(t));
+                        try!(self.print_block(&**t));
                         self.print_else(e)
                     }
                     // "final else"
-                    ast::ExprBlock(b) => {
+                    ast::ExprBlock(ref b) => {
                         try!(self.cbox(indent_unit - 1u));
                         try!(self.ibox(0u));
                         try!(word(&mut self.s, " else "));
-                        self.print_block(b)
+                        self.print_block(&**b)
                     }
                     // BLEAH, constraints would be great here
                     _ => {
@@ -1151,7 +1152,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block,
-                    elseopt: Option<@ast::Expr>, chk: bool) -> IoResult<()> {
+                    elseopt: Option<Gc<ast::Expr>>, chk: bool) -> IoResult<()> {
         try!(self.head("if"));
         if chk { try!(self.word_nbsp("check")); }
         try!(self.print_expr(test));
@@ -1184,7 +1185,7 @@ impl<'a> State<'a> {
         }
     }
 
-    fn print_call_post(&mut self, args: &[@ast::Expr]) -> IoResult<()> {
+    fn print_call_post(&mut self, args: &[Gc<ast::Expr>]) -> IoResult<()> {
         try!(self.popen());
         try!(self.commasep_exprs(Inconsistent, args));
         self.pclose()
@@ -1207,16 +1208,16 @@ impl<'a> State<'a> {
         try!(self.ibox(indent_unit));
         try!(self.ann.pre(self, NodeExpr(expr)));
         match expr.node {
-            ast::ExprVstore(e, v) => {
+            ast::ExprVstore(ref e, v) => {
                 try!(self.print_expr_vstore(v));
-                try!(self.print_expr(e));
+                try!(self.print_expr(&**e));
             },
-            ast::ExprBox(p, e) => {
+            ast::ExprBox(ref p, ref e) => {
                 try!(word(&mut self.s, "box"));
                 try!(word(&mut self.s, "("));
-                try!(self.print_expr(p));
+                try!(self.print_expr(&**p));
                 try!(self.word_space(")"));
-                try!(self.print_expr(e));
+                try!(self.print_expr(&**e));
             }
             ast::ExprVec(ref exprs) => {
                 try!(self.ibox(indent_unit));
@@ -1226,13 +1227,13 @@ impl<'a> State<'a> {
                 try!(self.end());
             }
 
-            ast::ExprRepeat(element, count) => {
+            ast::ExprRepeat(ref element, ref count) => {
                 try!(self.ibox(indent_unit));
                 try!(word(&mut self.s, "["));
-                try!(self.print_expr(element));
+                try!(self.print_expr(&**element));
                 try!(word(&mut self.s, ","));
                 try!(word(&mut self.s, ".."));
-                try!(self.print_expr(count));
+                try!(self.print_expr(&**count));
                 try!(word(&mut self.s, "]"));
                 try!(self.end());
             }
@@ -1247,19 +1248,19 @@ impl<'a> State<'a> {
                         try!(s.ibox(indent_unit));
                         try!(s.print_ident(field.ident.node));
                         try!(s.word_space(":"));
-                        try!(s.print_expr(field.expr));
+                        try!(s.print_expr(&*field.expr));
                         s.end()
                     },
                     |f| f.span));
                 match wth {
-                    Some(expr) => {
+                    Some(ref expr) => {
                         try!(self.ibox(indent_unit));
                         if !fields.is_empty() {
                             try!(word(&mut self.s, ","));
                             try!(space(&mut self.s));
                         }
                         try!(word(&mut self.s, ".."));
-                        try!(self.print_expr(expr));
+                        try!(self.print_expr(&**expr));
                         try!(self.end());
                     }
                     _ => try!(word(&mut self.s, ","))
@@ -1274,13 +1275,13 @@ impl<'a> State<'a> {
                 }
                 try!(self.pclose());
             }
-            ast::ExprCall(func, ref args) => {
-                try!(self.print_expr_maybe_paren(func));
+            ast::ExprCall(ref func, ref args) => {
+                try!(self.print_expr_maybe_paren(&**func));
                 try!(self.print_call_post(args.as_slice()));
             }
             ast::ExprMethodCall(ident, ref tys, ref args) => {
                 let base_args = args.slice_from(1);
-                try!(self.print_expr(*args.get(0)));
+                try!(self.print_expr(&**args.get(0)));
                 try!(word(&mut self.s, "."));
                 try!(self.print_ident(ident.node));
                 if tys.len() > 0u {
@@ -1291,52 +1292,52 @@ impl<'a> State<'a> {
                 }
                 try!(self.print_call_post(base_args));
             }
-            ast::ExprBinary(op, lhs, rhs) => {
-                try!(self.print_expr(lhs));
+            ast::ExprBinary(op, ref lhs, ref rhs) => {
+                try!(self.print_expr(&**lhs));
                 try!(space(&mut self.s));
                 try!(self.word_space(ast_util::binop_to_str(op)));
-                try!(self.print_expr(rhs));
+                try!(self.print_expr(&**rhs));
             }
-            ast::ExprUnary(op, expr) => {
+            ast::ExprUnary(op, ref expr) => {
                 try!(word(&mut self.s, ast_util::unop_to_str(op)));
-                try!(self.print_expr_maybe_paren(expr));
+                try!(self.print_expr_maybe_paren(&**expr));
             }
-            ast::ExprAddrOf(m, expr) => {
+            ast::ExprAddrOf(m, ref expr) => {
                 try!(word(&mut self.s, "&"));
                 try!(self.print_mutability(m));
-                try!(self.print_expr_maybe_paren(expr));
+                try!(self.print_expr_maybe_paren(&**expr));
             }
-            ast::ExprLit(lit) => try!(self.print_literal(lit)),
-            ast::ExprCast(expr, ty) => {
-                try!(self.print_expr(expr));
+            ast::ExprLit(ref lit) => try!(self.print_literal(&**lit)),
+            ast::ExprCast(ref expr, ref ty) => {
+                try!(self.print_expr(&**expr));
                 try!(space(&mut self.s));
                 try!(self.word_space("as"));
-                try!(self.print_type(ty));
+                try!(self.print_type(&**ty));
             }
-            ast::ExprIf(test, blk, elseopt) => {
-                try!(self.print_if(test, blk, elseopt, false));
+            ast::ExprIf(ref test, ref blk, elseopt) => {
+                try!(self.print_if(&**test, &**blk, elseopt, false));
             }
-            ast::ExprWhile(test, blk) => {
+            ast::ExprWhile(ref test, ref blk) => {
                 try!(self.head("while"));
-                try!(self.print_expr(test));
+                try!(self.print_expr(&**test));
                 try!(space(&mut self.s));
-                try!(self.print_block(blk));
+                try!(self.print_block(&**blk));
             }
-            ast::ExprForLoop(pat, iter, blk, opt_ident) => {
+            ast::ExprForLoop(ref pat, ref iter, ref blk, opt_ident) => {
                 for ident in opt_ident.iter() {
                     try!(word(&mut self.s, "'"));
                     try!(self.print_ident(*ident));
                     try!(self.word_space(":"));
                 }
                 try!(self.head("for"));
-                try!(self.print_pat(pat));
+                try!(self.print_pat(&**pat));
                 try!(space(&mut self.s));
                 try!(self.word_space("in"));
-                try!(self.print_expr(iter));
+                try!(self.print_expr(&**iter));
                 try!(space(&mut self.s));
-                try!(self.print_block(blk));
+                try!(self.print_block(&**blk));
             }
-            ast::ExprLoop(blk, opt_ident) => {
+            ast::ExprLoop(ref blk, opt_ident) => {
                 for ident in opt_ident.iter() {
                     try!(word(&mut self.s, "'"));
                     try!(self.print_ident(*ident));
@@ -1344,13 +1345,13 @@ impl<'a> State<'a> {
                 }
                 try!(self.head("loop"));
                 try!(space(&mut self.s));
-                try!(self.print_block(blk));
+                try!(self.print_block(&**blk));
             }
-            ast::ExprMatch(expr, ref arms) => {
+            ast::ExprMatch(ref expr, ref arms) => {
                 try!(self.cbox(indent_unit));
                 try!(self.ibox(4));
                 try!(self.word_nbsp("match"));
-                try!(self.print_expr(expr));
+                try!(self.print_expr(&**expr));
                 try!(space(&mut self.s));
                 try!(self.bopen());
                 let len = arms.len();
@@ -1371,13 +1372,13 @@ impl<'a> State<'a> {
                             try!(space(&mut self.s));
                             try!(self.word_space("|"));
                         }
-                        try!(self.print_pat(*p));
+                        try!(self.print_pat(&**p));
                     }
                     try!(space(&mut self.s));
                     match arm.guard {
-                        Some(e) => {
+                        Some(ref e) => {
                             try!(self.word_space("if"));
-                            try!(self.print_expr(e));
+                            try!(self.print_expr(&**e));
                             try!(space(&mut self.s));
                         }
                         None => ()
@@ -1385,16 +1386,17 @@ impl<'a> State<'a> {
                     try!(self.word_space("=>"));
 
                     match arm.body.node {
-                        ast::ExprBlock(blk) => {
+                        ast::ExprBlock(ref blk) => {
                             // the block will close the pattern's ibox
-                            try!(self.print_block_unclosed_indent(blk, indent_unit));
+                            try!(self.print_block_unclosed_indent(&**blk,
+                                                                  indent_unit));
                         }
                         _ => {
                             try!(self.end()); // close the ibox for the pattern
-                            try!(self.print_expr(arm.body));
+                            try!(self.print_expr(&*arm.body));
                         }
                     }
-                    if !expr_is_simple_block(expr)
+                    if !expr_is_simple_block(expr.clone())
                         && i < len - 1 {
                         try!(word(&mut self.s, ","));
                     }
@@ -1402,27 +1404,27 @@ impl<'a> State<'a> {
                 }
                 try!(self.bclose_(expr.span, indent_unit));
             }
-            ast::ExprFnBlock(decl, body) => {
+            ast::ExprFnBlock(ref decl, ref body) => {
                 // in do/for blocks we don't want to show an empty
                 // argument list, but at this point we don't know which
                 // we are inside.
                 //
                 // if !decl.inputs.is_empty() {
-                try!(self.print_fn_block_args(decl));
+                try!(self.print_fn_block_args(&**decl));
                 try!(space(&mut self.s));
                 // }
 
                 if !body.stmts.is_empty() || !body.expr.is_some() {
-                    try!(self.print_block_unclosed(body));
+                    try!(self.print_block_unclosed(&**body));
                 } else {
                     // we extract the block, so as not to create another set of boxes
                     match body.expr.unwrap().node {
-                        ast::ExprBlock(blk) => {
-                            try!(self.print_block_unclosed(blk));
+                        ast::ExprBlock(ref blk) => {
+                            try!(self.print_block_unclosed(&**blk));
                         }
                         _ => {
                             // this is a bare expression
-                            try!(self.print_expr(body.expr.unwrap()));
+                            try!(self.print_expr(&*body.expr.unwrap()));
                             try!(self.end()); // need to close a box
                         }
                     }
@@ -1432,25 +1434,25 @@ impl<'a> State<'a> {
                 // empty box to satisfy the close.
                 try!(self.ibox(0));
             }
-            ast::ExprProc(decl, body) => {
+            ast::ExprProc(ref decl, ref body) => {
                 // in do/for blocks we don't want to show an empty
                 // argument list, but at this point we don't know which
                 // we are inside.
                 //
                 // if !decl.inputs.is_empty() {
-                try!(self.print_proc_args(decl));
+                try!(self.print_proc_args(&**decl));
                 try!(space(&mut self.s));
                 // }
                 assert!(body.stmts.is_empty());
                 assert!(body.expr.is_some());
                 // we extract the block, so as not to create another set of boxes
                 match body.expr.unwrap().node {
-                    ast::ExprBlock(blk) => {
-                        try!(self.print_block_unclosed(blk));
+                    ast::ExprBlock(ref blk) => {
+                        try!(self.print_block_unclosed(&**blk));
                     }
                     _ => {
                         // this is a bare expression
-                        try!(self.print_expr(body.expr.unwrap()));
+                        try!(self.print_expr(&*body.expr.unwrap()));
                         try!(self.end()); // need to close a box
                     }
                 }
@@ -1459,28 +1461,28 @@ impl<'a> State<'a> {
                 // empty box to satisfy the close.
                 try!(self.ibox(0));
             }
-            ast::ExprBlock(blk) => {
+            ast::ExprBlock(ref blk) => {
                 // containing cbox, will be closed by print-block at }
                 try!(self.cbox(indent_unit));
                 // head-box, will be closed by print-block after {
                 try!(self.ibox(0u));
-                try!(self.print_block(blk));
+                try!(self.print_block(&**blk));
             }
-            ast::ExprAssign(lhs, rhs) => {
-                try!(self.print_expr(lhs));
+            ast::ExprAssign(ref lhs, ref rhs) => {
+                try!(self.print_expr(&**lhs));
                 try!(space(&mut self.s));
                 try!(self.word_space("="));
-                try!(self.print_expr(rhs));
+                try!(self.print_expr(&**rhs));
             }
-            ast::ExprAssignOp(op, lhs, rhs) => {
-                try!(self.print_expr(lhs));
+            ast::ExprAssignOp(op, ref lhs, ref rhs) => {
+                try!(self.print_expr(&**lhs));
                 try!(space(&mut self.s));
                 try!(word(&mut self.s, ast_util::binop_to_str(op)));
                 try!(self.word_space("="));
-                try!(self.print_expr(rhs));
+                try!(self.print_expr(&**rhs));
             }
-            ast::ExprField(expr, id, ref tys) => {
-                try!(self.print_expr(expr));
+            ast::ExprField(ref expr, id, ref tys) => {
+                try!(self.print_expr(&**expr));
                 try!(word(&mut self.s, "."));
                 try!(self.print_ident(id));
                 if tys.len() > 0u {
@@ -1491,10 +1493,10 @@ impl<'a> State<'a> {
                     try!(word(&mut self.s, ">"));
                 }
             }
-            ast::ExprIndex(expr, index) => {
-                try!(self.print_expr(expr));
+            ast::ExprIndex(ref expr, ref index) => {
+                try!(self.print_expr(&**expr));
                 try!(word(&mut self.s, "["));
-                try!(self.print_expr(index));
+                try!(self.print_expr(&**index));
                 try!(word(&mut self.s, "]"));
             }
             ast::ExprPath(ref path) => try!(self.print_path(path, true)),
@@ -1516,12 +1518,12 @@ impl<'a> State<'a> {
                     try!(space(&mut self.s))
                 }
             }
-            ast::ExprRet(result) => {
+            ast::ExprRet(ref result) => {
                 try!(word(&mut self.s, "return"));
-                match result {
-                    Some(expr) => {
+                match *result {
+                    Some(ref expr) => {
                         try!(word(&mut self.s, " "));
-                        try!(self.print_expr(expr));
+                        try!(self.print_expr(&**expr));
                     }
                     _ => ()
                 }
@@ -1536,20 +1538,22 @@ impl<'a> State<'a> {
                 try!(self.print_string(a.asm.get(), a.asm_str_style));
                 try!(self.word_space(":"));
 
-                try!(self.commasep(Inconsistent, a.outputs.as_slice(), |s, &(ref co, o)| {
+                try!(self.commasep(Inconsistent, a.outputs.as_slice(),
+                                   |s, &(ref co, ref o)| {
                     try!(s.print_string(co.get(), ast::CookedStr));
                     try!(s.popen());
-                    try!(s.print_expr(o));
+                    try!(s.print_expr(&**o));
                     try!(s.pclose());
                     Ok(())
                 }));
                 try!(space(&mut self.s));
                 try!(self.word_space(":"));
 
-                try!(self.commasep(Inconsistent, a.inputs.as_slice(), |s, &(ref co, o)| {
+                try!(self.commasep(Inconsistent, a.inputs.as_slice(),
+                                   |s, &(ref co, ref o)| {
                     try!(s.print_string(co.get(), ast::CookedStr));
                     try!(s.popen());
-                    try!(s.print_expr(o));
+                    try!(s.print_expr(&**o));
                     try!(s.pclose());
                     Ok(())
                 }));
@@ -1560,9 +1564,9 @@ impl<'a> State<'a> {
                 try!(self.pclose());
             }
             ast::ExprMac(ref m) => try!(self.print_mac(m)),
-            ast::ExprParen(e) => {
+            ast::ExprParen(ref e) => {
                 try!(self.popen());
-                try!(self.print_expr(e));
+                try!(self.print_expr(&**e));
                 try!(self.pclose());
             }
         }
@@ -1571,12 +1575,12 @@ impl<'a> State<'a> {
     }
 
     pub fn print_local_decl(&mut self, loc: &ast::Local) -> IoResult<()> {
-        try!(self.print_pat(loc.pat));
+        try!(self.print_pat(&*loc.pat));
         match loc.ty.node {
             ast::TyInfer => Ok(()),
             _ => {
                 try!(self.word_space(":"));
-                self.print_type(loc.ty)
+                self.print_type(&*loc.ty)
             }
         }
     }
@@ -1584,25 +1588,25 @@ impl<'a> State<'a> {
     pub fn print_decl(&mut self, decl: &ast::Decl) -> IoResult<()> {
         try!(self.maybe_print_comment(decl.span.lo));
         match decl.node {
-            ast::DeclLocal(loc) => {
+            ast::DeclLocal(ref loc) => {
                 try!(self.space_if_not_bol());
                 try!(self.ibox(indent_unit));
                 try!(self.word_nbsp("let"));
 
                 try!(self.ibox(indent_unit));
-                try!(self.print_local_decl(loc));
+                try!(self.print_local_decl(&**loc));
                 try!(self.end());
                 match loc.init {
-                    Some(init) => {
+                    Some(ref init) => {
                         try!(self.nbsp());
                         try!(self.word_space("="));
-                        try!(self.print_expr(init));
+                        try!(self.print_expr(&**init));
                     }
                     _ => {}
                 }
                 self.end()
             }
-            ast::DeclItem(item) => self.print_item(item)
+            ast::DeclItem(ref item) => self.print_item(&**item)
         }
     }
 
@@ -1709,9 +1713,9 @@ impl<'a> State<'a> {
                 }
                 try!(self.print_path(path, true));
                 match sub {
-                    Some(p) => {
+                    Some(ref p) => {
                         try!(word(&mut self.s, "@"));
-                        try!(self.print_pat(p));
+                        try!(self.print_pat(&**p));
                     }
                     None => ()
                 }
@@ -1724,7 +1728,7 @@ impl<'a> State<'a> {
                         if !args.is_empty() {
                             try!(self.popen());
                             try!(self.commasep(Inconsistent, args.as_slice(),
-                                              |s, &p| s.print_pat(p)));
+                                              |s, p| s.print_pat(&**p)));
                             try!(self.pclose());
                         }
                     }
@@ -1739,7 +1743,7 @@ impl<'a> State<'a> {
                         try!(s.cbox(indent_unit));
                         try!(s.print_ident(f.ident));
                         try!(s.word_space(":"));
-                        try!(s.print_pat(f.pat));
+                        try!(s.print_pat(&*f.pat));
                         s.end()
                     },
                     |f| f.pat.span));
@@ -1753,46 +1757,46 @@ impl<'a> State<'a> {
                 try!(self.popen());
                 try!(self.commasep(Inconsistent,
                                    elts.as_slice(),
-                                   |s, &p| s.print_pat(p)));
+                                   |s, p| s.print_pat(&**p)));
                 if elts.len() == 1 {
                     try!(word(&mut self.s, ","));
                 }
                 try!(self.pclose());
             }
-            ast::PatBox(inner) => {
+            ast::PatBox(ref inner) => {
                 try!(word(&mut self.s, "box "));
-                try!(self.print_pat(inner));
+                try!(self.print_pat(&**inner));
             }
-            ast::PatRegion(inner) => {
+            ast::PatRegion(ref inner) => {
                 try!(word(&mut self.s, "&"));
-                try!(self.print_pat(inner));
+                try!(self.print_pat(&**inner));
             }
-            ast::PatLit(e) => try!(self.print_expr(e)),
-            ast::PatRange(begin, end) => {
-                try!(self.print_expr(begin));
+            ast::PatLit(ref e) => try!(self.print_expr(&**e)),
+            ast::PatRange(ref begin, ref end) => {
+                try!(self.print_expr(&**begin));
                 try!(space(&mut self.s));
                 try!(word(&mut self.s, ".."));
-                try!(self.print_expr(end));
+                try!(self.print_expr(&**end));
             }
             ast::PatVec(ref before, slice, ref after) => {
                 try!(word(&mut self.s, "["));
                 try!(self.commasep(Inconsistent,
                                    before.as_slice(),
-                                   |s, &p| s.print_pat(p)));
-                for &p in slice.iter() {
+                                   |s, p| s.print_pat(&**p)));
+                for p in slice.iter() {
                     if !before.is_empty() { try!(self.word_space(",")); }
-                    match *p {
+                    match **p {
                         ast::Pat { node: ast::PatWildMulti, .. } => {
                             // this case is handled by print_pat
                         }
                         _ => try!(word(&mut self.s, "..")),
                     }
-                    try!(self.print_pat(p));
+                    try!(self.print_pat(&**p));
                     if !after.is_empty() { try!(self.word_space(",")); }
                 }
                 try!(self.commasep(Inconsistent,
                                    after.as_slice(),
-                                   |s, &p| s.print_pat(p)));
+                                   |s, p| s.print_pat(&**p)));
                 try!(word(&mut self.s, "]"));
             }
             ast::PatMac(ref m) => try!(self.print_mac(m)),
@@ -1888,7 +1892,7 @@ impl<'a> State<'a> {
             _ => {
                 try!(self.space_if_not_bol());
                 try!(self.word_space("->"));
-                self.print_type(decl.output)
+                self.print_type(&*decl.output)
             }
         }
     }
@@ -1904,7 +1908,7 @@ impl<'a> State<'a> {
             _ => {
                 try!(self.space_if_not_bol());
                 try!(self.word_space("->"));
-                try!(self.print_type(decl.output));
+                try!(self.print_type(&*decl.output));
             }
         }
 
@@ -1922,7 +1926,7 @@ impl<'a> State<'a> {
             _ => {
                 try!(self.space_if_not_bol());
                 try!(self.word_space("->"));
-                try!(self.print_type(decl.output));
+                try!(self.print_type(&*decl.output));
             }
         }
 
@@ -2014,10 +2018,10 @@ impl<'a> State<'a> {
                         try!(s.print_ident(param.ident));
                         try!(s.print_bounds(&None, &param.bounds, false));
                         match param.default {
-                            Some(default) => {
+                            Some(ref default) => {
                                 try!(space(&mut s.s));
                                 try!(s.word_space("="));
-                                s.print_type(default)
+                                s.print_type(&**default)
                             }
                             _ => Ok(())
                         }
@@ -2045,7 +2049,7 @@ impl<'a> State<'a> {
                 try!(self.popen());
                 try!(self.commasep(Consistent,
                                    items.as_slice(),
-                                   |s, &i| s.print_meta_item(i)));
+                                   |s, i| s.print_meta_item(&**i)));
                 try!(self.pclose());
             }
         }
@@ -2103,7 +2107,7 @@ impl<'a> State<'a> {
 
             ast::ViewItemUse(ref vp) => {
                 try!(self.head("use"));
-                try!(self.print_view_path(*vp));
+                try!(self.print_view_path(&**vp));
             }
         }
         try!(word(&mut self.s, ";"));
@@ -2121,13 +2125,13 @@ impl<'a> State<'a> {
 
     pub fn print_mt(&mut self, mt: &ast::MutTy) -> IoResult<()> {
         try!(self.print_mutability(mt.mutbl));
-        self.print_type(mt.ty)
+        self.print_type(&*mt.ty)
     }
 
     pub fn print_arg(&mut self, input: &ast::Arg) -> IoResult<()> {
         try!(self.ibox(indent_unit));
         match input.ty.node {
-            ast::TyInfer => try!(self.print_pat(input.pat)),
+            ast::TyInfer => try!(self.print_pat(&*input.pat)),
             _ => {
                 match input.pat.node {
                     ast::PatIdent(_, ref path, _) if
@@ -2137,12 +2141,12 @@ impl<'a> State<'a> {
                         // Do nothing.
                     }
                     _ => {
-                        try!(self.print_pat(input.pat));
+                        try!(self.print_pat(&*input.pat));
                         try!(word(&mut self.s, ":"));
                         try!(space(&mut self.s));
                     }
                 }
-                try!(self.print_type(input.ty));
+                try!(self.print_type(&*input.ty));
             }
         }
         self.end()
@@ -2229,7 +2233,7 @@ impl<'a> State<'a> {
                 if decl.cf == ast::NoReturn {
                     try!(self.word_nbsp("!"));
                 } else {
-                    try!(self.print_type(decl.output));
+                    try!(self.print_type(&*decl.output));
                 }
                 try!(self.end());
             }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -15,6 +15,8 @@ use codemap::Span;
 use parse;
 use owned_slice::OwnedSlice;
 
+use std::gc::Gc;
+
 // Context-passing AST walker. Each overridden visit method has full control
 // over what happens with its node, it can do its own traversal of the node's
 // children (potentially passing in different contexts to each), call
@@ -135,9 +137,9 @@ pub fn walk_inlined_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                   item: &ast::InlinedItem,
                                                   env: E) {
     match *item {
-        IIItem(i) => visitor.visit_item(i, env),
-        IIForeign(i) => visitor.visit_foreign_item(i, env),
-        IIMethod(_, _, m) => walk_method_helper(visitor, m, env),
+        IIItem(i) => visitor.visit_item(&*i, env),
+        IIForeign(i) => visitor.visit_foreign_item(&*i, env),
+        IIMethod(_, _, m) => walk_method_helper(visitor, &*m, env),
     }
 }
 
@@ -155,7 +157,7 @@ pub fn walk_mod<E: Clone, V: Visitor<E>>(visitor: &mut V, module: &Mod, env: E) 
     }
 
     for item in module.items.iter() {
-        visitor.visit_item(*item, env.clone())
+        visitor.visit_item(&**item, env.clone())
     }
 }
 
@@ -188,11 +190,11 @@ pub fn walk_view_item<E: Clone, V: Visitor<E>>(visitor: &mut V, vi: &ViewItem, e
 }
 
 pub fn walk_local<E: Clone, V: Visitor<E>>(visitor: &mut V, local: &Local, env: E) {
-    visitor.visit_pat(local.pat, env.clone());
-    visitor.visit_ty(local.ty, env.clone());
+    visitor.visit_pat(&*local.pat, env.clone());
+    visitor.visit_ty(&*local.ty, env.clone());
     match local.init {
         None => {}
-        Some(initializer) => visitor.visit_expr(initializer, env),
+        Some(initializer) => visitor.visit_expr(&*initializer, env),
     }
 }
 
@@ -219,13 +221,13 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
     visitor.visit_ident(item.span, item.ident, env.clone());
     match item.node {
         ItemStatic(typ, _, expr) => {
-            visitor.visit_ty(typ, env.clone());
-            visitor.visit_expr(expr, env.clone());
+            visitor.visit_ty(&*typ, env.clone());
+            visitor.visit_expr(&*expr, env);
         }
         ItemFn(declaration, fn_style, abi, ref generics, body) => {
             visitor.visit_fn(&FkItemFn(item.ident, generics, fn_style, abi),
-                             declaration,
-                             body,
+                             &*declaration,
+                             &*body,
                              item.span,
                              item.id,
                              env.clone())
@@ -238,12 +240,12 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
                 visitor.visit_view_item(view_item, env.clone())
             }
             for foreign_item in foreign_module.items.iter() {
-                visitor.visit_foreign_item(*foreign_item, env.clone())
+                visitor.visit_foreign_item(&**foreign_item, env.clone())
             }
         }
         ItemTy(typ, ref type_parameters) => {
-            visitor.visit_ty(typ, env.clone());
-            visitor.visit_generics(type_parameters, env.clone())
+            visitor.visit_ty(&*typ, env.clone());
+            visitor.visit_generics(type_parameters, env)
         }
         ItemEnum(ref enum_definition, ref type_parameters) => {
             visitor.visit_generics(type_parameters, env.clone());
@@ -259,14 +261,14 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
                                                                    trait_reference, env.clone()),
                 None => ()
             }
-            visitor.visit_ty(typ, env.clone());
+            visitor.visit_ty(&*typ, env.clone());
             for method in methods.iter() {
-                walk_method_helper(visitor, *method, env.clone())
+                walk_method_helper(visitor, &**method, env.clone())
             }
         }
-        ItemStruct(struct_definition, ref generics) => {
+        ItemStruct(ref struct_definition, ref generics) => {
             visitor.visit_generics(generics, env.clone());
-            visitor.visit_struct_def(struct_definition,
+            visitor.visit_struct_def(&**struct_definition,
                                      item.ident,
                                      generics,
                                      item.id,
@@ -295,7 +297,7 @@ pub fn walk_enum_def<E: Clone, V:Visitor<E>>(visitor: &mut V,
                                              generics: &Generics,
                                              env: E) {
     for &variant in enum_definition.variants.iter() {
-        visitor.visit_variant(variant, generics, env.clone());
+        visitor.visit_variant(&*variant, generics, env.clone());
     }
 }
 
@@ -308,11 +310,11 @@ pub fn walk_variant<E: Clone, V: Visitor<E>>(visitor: &mut V,
     match variant.node.kind {
         TupleVariantKind(ref variant_arguments) => {
             for variant_argument in variant_arguments.iter() {
-                visitor.visit_ty(variant_argument.ty, env.clone())
+                visitor.visit_ty(&*variant_argument.ty, env.clone())
             }
         }
-        StructVariantKind(struct_definition) => {
-            visitor.visit_struct_def(struct_definition,
+        StructVariantKind(ref struct_definition) => {
+            visitor.visit_struct_def(&**struct_definition,
                                      variant.node.name,
                                      generics,
                                      variant.node.id,
@@ -320,7 +322,7 @@ pub fn walk_variant<E: Clone, V: Visitor<E>>(visitor: &mut V,
         }
     }
     match variant.node.disr_expr {
-        Some(expr) => visitor.visit_expr(expr, env.clone()),
+        Some(ref expr) => visitor.visit_expr(&**expr, env.clone()),
         None => ()
     }
     for attr in variant.node.attrs.iter() {
@@ -335,25 +337,25 @@ pub fn skip_ty<E, V: Visitor<E>>(_: &mut V, _: &Ty, _: E) {
 pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
     match typ.node {
         TyUniq(ty) | TyVec(ty) | TyBox(ty) => {
-            visitor.visit_ty(ty, env)
+            visitor.visit_ty(&*ty, env)
         }
         TyPtr(ref mutable_type) => {
-            visitor.visit_ty(mutable_type.ty, env)
+            visitor.visit_ty(&*mutable_type.ty, env)
         }
         TyRptr(ref lifetime, ref mutable_type) => {
             visitor.visit_opt_lifetime_ref(typ.span, lifetime, env.clone());
-            visitor.visit_ty(mutable_type.ty, env)
+            visitor.visit_ty(&*mutable_type.ty, env)
         }
         TyTup(ref tuple_element_types) => {
             for &tuple_element_type in tuple_element_types.iter() {
-                visitor.visit_ty(tuple_element_type, env.clone())
+                visitor.visit_ty(&*tuple_element_type, env.clone())
             }
         }
         TyClosure(ref function_declaration, ref region) => {
             for argument in function_declaration.decl.inputs.iter() {
-                visitor.visit_ty(argument.ty, env.clone())
+                visitor.visit_ty(&*argument.ty, env.clone())
             }
-            visitor.visit_ty(function_declaration.decl.output, env.clone());
+            visitor.visit_ty(&*function_declaration.decl.output, env.clone());
             for bounds in function_declaration.bounds.iter() {
                 walk_ty_param_bounds(visitor, bounds, env.clone())
             }
@@ -366,9 +368,9 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
         }
         TyProc(ref function_declaration) => {
             for argument in function_declaration.decl.inputs.iter() {
-                visitor.visit_ty(argument.ty, env.clone())
+                visitor.visit_ty(&*argument.ty, env.clone())
             }
-            visitor.visit_ty(function_declaration.decl.output, env.clone());
+            visitor.visit_ty(&*function_declaration.decl.output, env.clone());
             for bounds in function_declaration.bounds.iter() {
                 walk_ty_param_bounds(visitor, bounds, env.clone())
             }
@@ -377,9 +379,9 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
         }
         TyBareFn(ref function_declaration) => {
             for argument in function_declaration.decl.inputs.iter() {
-                visitor.visit_ty(argument.ty, env.clone())
+                visitor.visit_ty(&*argument.ty, env.clone())
             }
-            visitor.visit_ty(function_declaration.decl.output, env.clone());
+            visitor.visit_ty(&*function_declaration.decl.output, env.clone());
             walk_lifetime_decls(visitor, &function_declaration.lifetimes,
                                 env.clone());
         }
@@ -395,12 +397,12 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
                 walk_ty_param_bounds(visitor, bounds, env.clone())
             }
         }
-        TyFixedLengthVec(ty, expression) => {
-            visitor.visit_ty(ty, env.clone());
-            visitor.visit_expr(expression, env)
+        TyFixedLengthVec(ref ty, ref expression) => {
+            visitor.visit_ty(&**ty, env.clone());
+            visitor.visit_expr(&**expression, env)
         }
-        TyTypeof(expression) => {
-            visitor.visit_expr(expression, env)
+        TyTypeof(ref expression) => {
+            visitor.visit_expr(&**expression, env)
         }
         TyNil | TyBot | TyInfer => {}
     }
@@ -418,8 +420,8 @@ pub fn walk_path<E: Clone, V: Visitor<E>>(visitor: &mut V, path: &Path, env: E) 
     for segment in path.segments.iter() {
         visitor.visit_ident(path.span, segment.identifier, env.clone());
 
-        for &typ in segment.types.iter() {
-            visitor.visit_ty(typ, env.clone());
+        for typ in segment.types.iter() {
+            visitor.visit_ty(&**typ, env.clone());
         }
         for lifetime in segment.lifetimes.iter() {
             visitor.visit_lifetime_ref(lifetime, env.clone());
@@ -433,47 +435,47 @@ pub fn walk_pat<E: Clone, V: Visitor<E>>(visitor: &mut V, pattern: &Pat, env: E)
             visitor.visit_path(path, pattern.id, env.clone());
             for children in children.iter() {
                 for child in children.iter() {
-                    visitor.visit_pat(*child, env.clone())
+                    visitor.visit_pat(&**child, env.clone())
                 }
             }
         }
         PatStruct(ref path, ref fields, _) => {
             visitor.visit_path(path, pattern.id, env.clone());
             for field in fields.iter() {
-                visitor.visit_pat(field.pat, env.clone())
+                visitor.visit_pat(&*field.pat, env.clone())
             }
         }
         PatTup(ref tuple_elements) => {
             for tuple_element in tuple_elements.iter() {
-                visitor.visit_pat(*tuple_element, env.clone())
+                visitor.visit_pat(&**tuple_element, env.clone())
             }
         }
-        PatBox(subpattern) |
-        PatRegion(subpattern) => {
-            visitor.visit_pat(subpattern, env)
+        PatBox(ref subpattern) |
+        PatRegion(ref subpattern) => {
+            visitor.visit_pat(&**subpattern, env)
         }
         PatIdent(_, ref path, ref optional_subpattern) => {
             visitor.visit_path(path, pattern.id, env.clone());
             match *optional_subpattern {
                 None => {}
-                Some(subpattern) => visitor.visit_pat(subpattern, env),
+                Some(ref subpattern) => visitor.visit_pat(&**subpattern, env),
             }
         }
-        PatLit(expression) => visitor.visit_expr(expression, env),
-        PatRange(lower_bound, upper_bound) => {
-            visitor.visit_expr(lower_bound, env.clone());
-            visitor.visit_expr(upper_bound, env)
+        PatLit(ref expression) => visitor.visit_expr(&**expression, env),
+        PatRange(ref lower_bound, ref upper_bound) => {
+            visitor.visit_expr(&**lower_bound, env.clone());
+            visitor.visit_expr(&**upper_bound, env)
         }
         PatWild | PatWildMulti => (),
         PatVec(ref prepattern, ref slice_pattern, ref postpatterns) => {
             for prepattern in prepattern.iter() {
-                visitor.visit_pat(*prepattern, env.clone())
+                visitor.visit_pat(&**prepattern, env.clone())
             }
             for slice_pattern in slice_pattern.iter() {
-                visitor.visit_pat(*slice_pattern, env.clone())
+                visitor.visit_pat(&**slice_pattern, env.clone())
             }
             for postpattern in postpatterns.iter() {
-                visitor.visit_pat(*postpattern, env.clone())
+                visitor.visit_pat(&**postpattern, env.clone())
             }
         }
         PatMac(ref macro) => visitor.visit_mac(macro, env),
@@ -486,8 +488,8 @@ pub fn walk_foreign_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
     visitor.visit_ident(foreign_item.span, foreign_item.ident, env.clone());
 
     match foreign_item.node {
-        ForeignItemFn(function_declaration, ref generics) => {
-            walk_fn_decl(visitor, function_declaration, env.clone());
+        ForeignItemFn(ref function_declaration, ref generics) => {
+            walk_fn_decl(visitor, &**function_declaration, env.clone());
             visitor.visit_generics(generics, env.clone())
         }
         ForeignItemStatic(typ, _) => visitor.visit_ty(typ, env.clone()),
@@ -525,7 +527,7 @@ pub fn walk_generics<E: Clone, V: Visitor<E>>(visitor: &mut V,
     for type_parameter in generics.ty_params.iter() {
         walk_ty_param_bounds(visitor, &type_parameter.bounds, env.clone());
         match type_parameter.default {
-            Some(ty) => visitor.visit_ty(ty, env.clone()),
+            Some(ref ty) => visitor.visit_ty(&**ty, env.clone()),
             None => {}
         }
     }
@@ -536,10 +538,10 @@ pub fn walk_fn_decl<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                              function_declaration: &FnDecl,
                                              env: E) {
     for argument in function_declaration.inputs.iter() {
-        visitor.visit_pat(argument.pat, env.clone());
-        visitor.visit_ty(argument.ty, env.clone())
+        visitor.visit_pat(&*argument.pat, env.clone());
+        visitor.visit_ty(&*argument.ty, env.clone())
     }
-    visitor.visit_ty(function_declaration.output, env)
+    visitor.visit_ty(&*function_declaration.output, env)
 }
 
 // Note: there is no visit_method() method in the visitor, instead override
@@ -551,8 +553,8 @@ pub fn walk_method_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                    env: E) {
     visitor.visit_ident(method.span, method.ident, env.clone());
     visitor.visit_fn(&FkMethod(method.ident, &method.generics, method),
-                     method.decl,
-                     method.body,
+                     &*method.decl,
+                     &*method.body,
                      method.span,
                      method.id,
                      env.clone());
@@ -590,7 +592,7 @@ pub fn walk_ty_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
     visitor.visit_ident(method_type.span, method_type.ident, env.clone());
     visitor.visit_explicit_self(&method_type.explicit_self, env.clone());
     for argument_type in method_type.decl.inputs.iter() {
-        visitor.visit_ty(argument_type.ty, env.clone())
+        visitor.visit_ty(&*argument_type.ty, env.clone())
     }
     visitor.visit_generics(&method_type.generics, env.clone());
     visitor.visit_ty(method_type.decl.output, env.clone());
@@ -606,7 +608,7 @@ pub fn walk_trait_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
         Required(ref method_type) => {
             visitor.visit_ty_method(method_type, env)
         }
-        Provided(method) => walk_method_helper(visitor, method, env),
+        Provided(ref method) => walk_method_helper(visitor, &**method, env),
     }
 }
 
@@ -614,7 +616,7 @@ pub fn walk_struct_def<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                 struct_definition: &StructDef,
                                                 env: E) {
     match struct_definition.super_struct {
-        Some(t) => visitor.visit_ty(t, env.clone()),
+        Some(ref t) => visitor.visit_ty(&**t, env.clone()),
         None => {},
     }
     for field in struct_definition.fields.iter() {
@@ -644,16 +646,16 @@ pub fn walk_block<E: Clone, V: Visitor<E>>(visitor: &mut V, block: &Block, env: 
         visitor.visit_view_item(view_item, env.clone())
     }
     for statement in block.stmts.iter() {
-        visitor.visit_stmt(*statement, env.clone())
+        visitor.visit_stmt(&**statement, env.clone())
     }
     walk_expr_opt(visitor, block.expr, env)
 }
 
 pub fn walk_stmt<E: Clone, V: Visitor<E>>(visitor: &mut V, statement: &Stmt, env: E) {
     match statement.node {
-        StmtDecl(declaration, _) => visitor.visit_decl(declaration, env),
-        StmtExpr(expression, _) | StmtSemi(expression, _) => {
-            visitor.visit_expr(expression, env)
+        StmtDecl(ref declaration, _) => visitor.visit_decl(&**declaration, env),
+        StmtExpr(ref expression, _) | StmtSemi(ref expression, _) => {
+            visitor.visit_expr(&**expression, env)
         }
         StmtMac(ref macro, _) => visitor.visit_mac(macro, env),
     }
@@ -661,25 +663,25 @@ pub fn walk_stmt<E: Clone, V: Visitor<E>>(visitor: &mut V, statement: &Stmt, env
 
 pub fn walk_decl<E: Clone, V: Visitor<E>>(visitor: &mut V, declaration: &Decl, env: E) {
     match declaration.node {
-        DeclLocal(ref local) => visitor.visit_local(*local, env),
-        DeclItem(item) => visitor.visit_item(item, env),
+        DeclLocal(ref local) => visitor.visit_local(&**local, env),
+        DeclItem(ref item) => visitor.visit_item(&**item, env),
     }
 }
 
 pub fn walk_expr_opt<E: Clone, V: Visitor<E>>(visitor: &mut V,
-                                              optional_expression: Option<@Expr>,
+                                              optional_expression: Option<Gc<Expr>>,
                                               env: E) {
     match optional_expression {
         None => {}
-        Some(expression) => visitor.visit_expr(expression, env),
+        Some(ref expression) => visitor.visit_expr(&**expression, env),
     }
 }
 
 pub fn walk_exprs<E: Clone, V: Visitor<E>>(visitor: &mut V,
-                                           expressions: &[@Expr],
+                                           expressions: &[Gc<Expr>],
                                            env: E) {
     for expression in expressions.iter() {
-        visitor.visit_expr(*expression, env.clone())
+        visitor.visit_expr(&**expression, env.clone())
     }
 }
 
@@ -689,111 +691,111 @@ pub fn walk_mac<E, V: Visitor<E>>(_: &mut V, _: &Mac, _: E) {
 
 pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, env: E) {
     match expression.node {
-        ExprVstore(subexpression, _) => {
-            visitor.visit_expr(subexpression, env.clone())
+        ExprVstore(ref subexpression, _) => {
+            visitor.visit_expr(&**subexpression, env.clone())
         }
-        ExprBox(place, subexpression) => {
-            visitor.visit_expr(place, env.clone());
-            visitor.visit_expr(subexpression, env.clone())
+        ExprBox(ref place, ref subexpression) => {
+            visitor.visit_expr(&**place, env.clone());
+            visitor.visit_expr(&**subexpression, env.clone())
         }
         ExprVec(ref subexpressions) => {
             walk_exprs(visitor, subexpressions.as_slice(), env.clone())
         }
-        ExprRepeat(element, count) => {
-            visitor.visit_expr(element, env.clone());
-            visitor.visit_expr(count, env.clone())
+        ExprRepeat(ref element, ref count) => {
+            visitor.visit_expr(&**element, env.clone());
+            visitor.visit_expr(&**count, env.clone())
         }
         ExprStruct(ref path, ref fields, optional_base) => {
             visitor.visit_path(path, expression.id, env.clone());
             for field in fields.iter() {
-                visitor.visit_expr(field.expr, env.clone())
+                visitor.visit_expr(&*field.expr, env.clone())
             }
             walk_expr_opt(visitor, optional_base, env.clone())
         }
         ExprTup(ref subexpressions) => {
             for subexpression in subexpressions.iter() {
-                visitor.visit_expr(*subexpression, env.clone())
+                visitor.visit_expr(&**subexpression, env.clone())
             }
         }
-        ExprCall(callee_expression, ref arguments) => {
+        ExprCall(ref callee_expression, ref arguments) => {
             for argument in arguments.iter() {
-                visitor.visit_expr(*argument, env.clone())
+                visitor.visit_expr(&**argument, env.clone())
             }
-            visitor.visit_expr(callee_expression, env.clone())
+            visitor.visit_expr(&**callee_expression, env.clone())
         }
         ExprMethodCall(_, ref types, ref arguments) => {
             walk_exprs(visitor, arguments.as_slice(), env.clone());
-            for &typ in types.iter() {
-                visitor.visit_ty(typ, env.clone())
+            for typ in types.iter() {
+                visitor.visit_ty(&**typ, env.clone())
             }
         }
-        ExprBinary(_, left_expression, right_expression) => {
-            visitor.visit_expr(left_expression, env.clone());
-            visitor.visit_expr(right_expression, env.clone())
+        ExprBinary(_, ref left_expression, ref right_expression) => {
+            visitor.visit_expr(&**left_expression, env.clone());
+            visitor.visit_expr(&**right_expression, env.clone())
         }
-        ExprAddrOf(_, subexpression) | ExprUnary(_, subexpression) => {
-            visitor.visit_expr(subexpression, env.clone())
+        ExprAddrOf(_, ref subexpression) | ExprUnary(_, ref subexpression) => {
+            visitor.visit_expr(&**subexpression, env.clone())
         }
         ExprLit(_) => {}
-        ExprCast(subexpression, typ) => {
-            visitor.visit_expr(subexpression, env.clone());
-            visitor.visit_ty(typ, env.clone())
+        ExprCast(ref subexpression, ref typ) => {
+            visitor.visit_expr(&**subexpression, env.clone());
+            visitor.visit_ty(&**typ, env.clone())
         }
-        ExprIf(head_expression, if_block, optional_else) => {
-            visitor.visit_expr(head_expression, env.clone());
-            visitor.visit_block(if_block, env.clone());
+        ExprIf(ref head_expression, ref if_block, optional_else) => {
+            visitor.visit_expr(&**head_expression, env.clone());
+            visitor.visit_block(&**if_block, env.clone());
             walk_expr_opt(visitor, optional_else, env.clone())
         }
-        ExprWhile(subexpression, block) => {
-            visitor.visit_expr(subexpression, env.clone());
-            visitor.visit_block(block, env.clone())
+        ExprWhile(ref subexpression, ref block) => {
+            visitor.visit_expr(&**subexpression, env.clone());
+            visitor.visit_block(&**block, env.clone())
         }
-        ExprForLoop(pattern, subexpression, block, _) => {
-            visitor.visit_pat(pattern, env.clone());
-            visitor.visit_expr(subexpression, env.clone());
-            visitor.visit_block(block, env.clone())
+        ExprForLoop(ref pattern, ref subexpression, ref block, _) => {
+            visitor.visit_pat(&**pattern, env.clone());
+            visitor.visit_expr(&**subexpression, env.clone());
+            visitor.visit_block(&**block, env.clone())
         }
-        ExprLoop(block, _) => visitor.visit_block(block, env.clone()),
-        ExprMatch(subexpression, ref arms) => {
-            visitor.visit_expr(subexpression, env.clone());
+        ExprLoop(ref block, _) => visitor.visit_block(&**block, env.clone()),
+        ExprMatch(ref subexpression, ref arms) => {
+            visitor.visit_expr(&**subexpression, env.clone());
             for arm in arms.iter() {
                 visitor.visit_arm(arm, env.clone())
             }
         }
-        ExprFnBlock(function_declaration, body) => {
+        ExprFnBlock(ref function_declaration, ref body) => {
             visitor.visit_fn(&FkFnBlock,
-                             function_declaration,
-                             body,
+                             &**function_declaration,
+                             &**body,
                              expression.span,
                              expression.id,
                              env.clone())
         }
-        ExprProc(function_declaration, body) => {
+        ExprProc(ref function_declaration, ref body) => {
             visitor.visit_fn(&FkFnBlock,
-                             function_declaration,
-                             body,
+                             &**function_declaration,
+                             &**body,
                              expression.span,
                              expression.id,
                              env.clone())
         }
-        ExprBlock(block) => visitor.visit_block(block, env.clone()),
-        ExprAssign(left_hand_expression, right_hand_expression) => {
-            visitor.visit_expr(right_hand_expression, env.clone());
-            visitor.visit_expr(left_hand_expression, env.clone())
+        ExprBlock(ref block) => visitor.visit_block(&**block, env.clone()),
+        ExprAssign(ref left_hand_expression, ref right_hand_expression) => {
+            visitor.visit_expr(&**right_hand_expression, env.clone());
+            visitor.visit_expr(&**left_hand_expression, env.clone())
         }
-        ExprAssignOp(_, left_expression, right_expression) => {
-            visitor.visit_expr(right_expression, env.clone());
-            visitor.visit_expr(left_expression, env.clone())
+        ExprAssignOp(_, ref left_expression, ref right_expression) => {
+            visitor.visit_expr(&**right_expression, env.clone());
+            visitor.visit_expr(&**left_expression, env.clone())
         }
-        ExprField(subexpression, _, ref types) => {
-            visitor.visit_expr(subexpression, env.clone());
-            for &typ in types.iter() {
-                visitor.visit_ty(typ, env.clone())
+        ExprField(ref subexpression, _, ref types) => {
+            visitor.visit_expr(&**subexpression, env.clone());
+            for typ in types.iter() {
+                visitor.visit_ty(&**typ, env.clone())
             }
         }
-        ExprIndex(main_expression, index_expression) => {
-            visitor.visit_expr(main_expression, env.clone());
-            visitor.visit_expr(index_expression, env.clone())
+        ExprIndex(ref main_expression, ref index_expression) => {
+            visitor.visit_expr(&**main_expression, env.clone());
+            visitor.visit_expr(&**index_expression, env.clone())
         }
         ExprPath(ref path) => {
             visitor.visit_path(path, expression.id, env.clone())
@@ -803,15 +805,15 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
             walk_expr_opt(visitor, optional_expression, env.clone())
         }
         ExprMac(ref macro) => visitor.visit_mac(macro, env.clone()),
-        ExprParen(subexpression) => {
-            visitor.visit_expr(subexpression, env.clone())
+        ExprParen(ref subexpression) => {
+            visitor.visit_expr(&**subexpression, env.clone())
         }
         ExprInlineAsm(ref assembler) => {
-            for &(_, input) in assembler.inputs.iter() {
-                visitor.visit_expr(input, env.clone())
+            for &(_, ref input) in assembler.inputs.iter() {
+                visitor.visit_expr(&**input, env.clone())
             }
-            for &(_, output) in assembler.outputs.iter() {
-                visitor.visit_expr(output, env.clone())
+            for &(_, ref output) in assembler.outputs.iter() {
+                visitor.visit_expr(&**output, env.clone())
             }
         }
     }
@@ -821,7 +823,7 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
 
 pub fn walk_arm<E: Clone, V: Visitor<E>>(visitor: &mut V, arm: &Arm, env: E) {
     for pattern in arm.pats.iter() {
-        visitor.visit_pat(*pattern, env.clone())
+        visitor.visit_pat(&**pattern, env.clone())
     }
     walk_expr_opt(visitor, arm.guard, env.clone());
     visitor.visit_expr(arm.body, env.clone());

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -220,9 +220,9 @@ pub fn walk_trait_ref_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
 pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) {
     visitor.visit_ident(item.span, item.ident, env.clone());
     match item.node {
-        ItemStatic(typ, _, expr) => {
-            visitor.visit_ty(&*typ, env.clone());
-            visitor.visit_expr(&*expr, env);
+        ItemStatic(ref typ, _, ref expr) => {
+            visitor.visit_ty(&**typ, env.clone());
+            visitor.visit_expr(&**expr, env.clone());
         }
         ItemFn(declaration, fn_style, abi, ref generics, body) => {
             visitor.visit_fn(&FkItemFn(item.ident, generics, fn_style, abi),
@@ -243,9 +243,9 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
                 visitor.visit_foreign_item(&**foreign_item, env.clone())
             }
         }
-        ItemTy(typ, ref type_parameters) => {
-            visitor.visit_ty(&*typ, env.clone());
-            visitor.visit_generics(type_parameters, env)
+        ItemTy(ref typ, ref type_parameters) => {
+            visitor.visit_ty(&**typ, env.clone());
+            visitor.visit_generics(type_parameters, env.clone())
         }
         ItemEnum(ref enum_definition, ref type_parameters) => {
             visitor.visit_generics(type_parameters, env.clone());
@@ -387,9 +387,9 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
         }
         TyUnboxedFn(ref function_declaration) => {
             for argument in function_declaration.decl.inputs.iter() {
-                visitor.visit_ty(argument.ty, env.clone())
+                visitor.visit_ty(&*argument.ty, env.clone())
             }
-            visitor.visit_ty(function_declaration.decl.output, env.clone());
+            visitor.visit_ty(&*function_declaration.decl.output, env.clone());
         }
         TyPath(ref path, ref bounds, id) => {
             visitor.visit_path(path, id, env.clone());
@@ -492,7 +492,7 @@ pub fn walk_foreign_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
             walk_fn_decl(visitor, &**function_declaration, env.clone());
             visitor.visit_generics(generics, env.clone())
         }
-        ForeignItemStatic(typ, _) => visitor.visit_ty(typ, env.clone()),
+        ForeignItemStatic(ref typ, _) => visitor.visit_ty(&**typ, env.clone()),
     }
 
     for attr in foreign_item.attrs.iter() {
@@ -511,9 +511,9 @@ pub fn walk_ty_param_bounds<E: Clone, V: Visitor<E>>(visitor: &mut V,
             StaticRegionTyParamBound => {}
             UnboxedFnTyParamBound(ref function_declaration) => {
                 for argument in function_declaration.decl.inputs.iter() {
-                    visitor.visit_ty(argument.ty, env.clone())
+                    visitor.visit_ty(&*argument.ty, env.clone())
                 }
-                visitor.visit_ty(function_declaration.decl.output,
+                visitor.visit_ty(&*function_declaration.decl.output,
                                  env.clone());
             }
             OtherRegionTyParamBound(..) => {}
@@ -595,7 +595,7 @@ pub fn walk_ty_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
         visitor.visit_ty(&*argument_type.ty, env.clone())
     }
     visitor.visit_generics(&method_type.generics, env.clone());
-    visitor.visit_ty(method_type.decl.output, env.clone());
+    visitor.visit_ty(&*method_type.decl.output, env.clone());
     for attr in method_type.attrs.iter() {
         visitor.visit_attribute(attr, env.clone());
     }
@@ -634,7 +634,7 @@ pub fn walk_struct_field<E: Clone, V: Visitor<E>>(visitor: &mut V,
         _ => {}
     }
 
-    visitor.visit_ty(struct_field.node.ty, env.clone());
+    visitor.visit_ty(&*struct_field.node.ty, env.clone());
 
     for attr in struct_field.node.attrs.iter() {
         visitor.visit_attribute(attr, env.clone());
@@ -826,7 +826,7 @@ pub fn walk_arm<E: Clone, V: Visitor<E>>(visitor: &mut V, arm: &Arm, env: E) {
         visitor.visit_pat(&**pattern, env.clone())
     }
     walk_expr_opt(visitor, arm.guard, env.clone());
-    visitor.visit_expr(arm.body, env.clone());
+    visitor.visit_expr(&*arm.body, env.clone());
     for attr in arm.attrs.iter() {
         visitor.visit_attribute(attr, env.clone());
     }

--- a/src/test/compile-fail/terr-sorts.rs
+++ b/src/test/compile-fail/terr-sorts.rs
@@ -19,7 +19,7 @@ type bar = @foo;
 
 fn want_foo(f: foo) {}
 fn have_bar(b: bar) {
-    want_foo(b); //~ ERROR (expected struct foo but found @-ptr)
+    want_foo(b); //~ ERROR (expected struct foo but found Gc-ptr)
 }
 
 fn main() {}

--- a/src/test/run-pass/generic-recursive-tag.rs
+++ b/src/test/run-pass/generic-recursive-tag.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty FIXME(#14193)
+
 #![feature(managed_boxes)]
 
 enum list<T> { cons(@T, @list<T>), nil, }

--- a/src/test/run-pass/trait-cast.rs
+++ b/src/test/run-pass/trait-cast.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty FIXME(#14193)
+
 #![feature(managed_boxes)]
 
 // Test cyclic detector when using trait instances.

--- a/src/test/run-pass/uniq-cc-generic.rs
+++ b/src/test/run-pass/uniq-cc-generic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty FIXME(#14193)
+
 #![feature(managed_boxes)]
 
 use std::cell::RefCell;


### PR DESCRIPTION
This commit removes `@T` from the compiler by moving the AST to using `Gc<T>`. This also starts treating `Gc<T>` as `@T` in the same way that `Box<T>` is the same as `~T` in the compiler.

After this hits a snapshot, the `@T` syntax should be able to be removed completely.
