### PR TITLE
libstd: Remove `~str` from all `libstd` modules except `fmt` and `str`.

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -157,9 +157,14 @@ fn iter_header(testfile: &Path, it: |&str| -> bool) -> bool {
         // module or function. This doesn't seem to be an optimization
         // with a warm page cache. Maybe with a cold one.
         let ln = ln.unwrap();
-        if ln.starts_with("fn") || ln.starts_with("mod") {
+        if ln.as_slice().starts_with("fn") ||
+                ln.as_slice().starts_with("mod") {
             return true;
-        } else { if !(it(ln.trim())) { return false; } }
+        } else {
+            if !(it(ln.as_slice().trim())) {
+                return false;
+            }
+        }
     }
     return true;
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -619,18 +619,18 @@ fn parse_debugger_commands(file_path: &Path, debugger_prefix: &str)
     for line in reader.lines() {
         match line {
             Ok(line) => {
-                if line.contains("#break") {
+                if line.as_slice().contains("#break") {
                     breakpoint_lines.push(counter);
                 }
 
                 header::parse_name_value_directive(
-                        line,
+                        line.as_slice(),
                         command_directive.to_strbuf()).map(|cmd| {
                     commands.push(cmd)
                 });
 
                 header::parse_name_value_directive(
-                        line,
+                        line.as_slice(),
                         check_directive.to_strbuf()).map(|cmd| {
                     check_lines.push(cmd)
                 });

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -302,8 +302,10 @@ pub fn mod_enabled(level: u32, module: &str) -> bool {
     enabled(level, module, unsafe { (*DIRECTIVES).iter() })
 }
 
-fn enabled(level: u32, module: &str,
-           iter: slice::Items<directive::LogDirective>) -> bool {
+fn enabled(level: u32,
+           module: &str,
+           iter: slice::Items<directive::LogDirective>)
+           -> bool {
     // Search for the longest match, the vector is assumed to be pre-sorted.
     for directive in iter.rev() {
         match directive.name {
@@ -322,7 +324,7 @@ fn enabled(level: u32, module: &str,
 /// `Once` primitive (and this function is called from that primitive).
 fn init() {
     let mut directives = match os::getenv("RUST_LOG") {
-        Some(spec) => directive::parse_logging_spec(spec),
+        Some(spec) => directive::parse_logging_spec(spec.as_slice()),
         None => Vec::new(),
     };
 

--- a/src/libnative/io/addrinfo.rs
+++ b/src/libnative/io/addrinfo.rs
@@ -104,9 +104,10 @@ fn get_error(_: c_int) -> IoError {
 #[cfg(not(windows))]
 fn get_error(s: c_int) -> IoError {
     use std::io;
-    use std::str::raw::from_c_str;
 
-    let err_str = unsafe { from_c_str(gai_strerror(s)) };
+    let err_str = unsafe {
+        CString::new(gai_strerror(s), false).as_str().unwrap().to_strbuf()
+    };
     IoError {
         kind: io::OtherIoError,
         desc: "unable to resolve host",

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -604,7 +604,7 @@ impl_to_biguint!(u32,  FromPrimitive::from_u32)
 impl_to_biguint!(u64,  FromPrimitive::from_u64)
 
 impl ToStrRadix for BigUint {
-    fn to_str_radix(&self, radix: uint) -> ~str {
+    fn to_str_radix(&self, radix: uint) -> StrBuf {
         assert!(1 < radix && radix <= 16);
         let (base, max_len) = get_radix_base(radix);
         if base == BigDigit::base {
@@ -627,15 +627,17 @@ impl ToStrRadix for BigUint {
             return result;
         }
 
-        fn fill_concat(v: &[BigDigit], radix: uint, l: uint) -> ~str {
-            if v.is_empty() { return "0".to_owned() }
+        fn fill_concat(v: &[BigDigit], radix: uint, l: uint) -> StrBuf {
+            if v.is_empty() {
+                return "0".to_strbuf()
+            }
             let mut s = StrBuf::with_capacity(v.len() * l);
             for n in v.iter().rev() {
                 let ss = (*n as uint).to_str_radix(radix);
                 s.push_str("0".repeat(l - ss.len()));
-                s.push_str(ss);
+                s.push_str(ss.as_slice());
             }
-            s.as_slice().trim_left_chars('0').to_owned()
+            s.as_slice().trim_left_chars('0').to_strbuf()
         }
     }
 }
@@ -1209,11 +1211,11 @@ impl_to_bigint!(u64,  FromPrimitive::from_u64)
 
 impl ToStrRadix for BigInt {
     #[inline]
-    fn to_str_radix(&self, radix: uint) -> ~str {
+    fn to_str_radix(&self, radix: uint) -> StrBuf {
         match self.sign {
             Plus  => self.data.to_str_radix(radix),
-            Zero  => "0".to_owned(),
-            Minus => "-".to_owned() + self.data.to_str_radix(radix)
+            Zero  => "0".to_strbuf(),
+            Minus => format_strbuf!("-{}", self.data.to_str_radix(radix)),
         }
     }
 }

--- a/src/libnum/complex.rs
+++ b/src/libnum/complex.rs
@@ -179,11 +179,15 @@ impl<T: fmt::Show + Num + Ord> fmt::Show for Complex<T> {
 }
 
 impl<T: ToStrRadix + Num + Ord> ToStrRadix for Complex<T> {
-    fn to_str_radix(&self, radix: uint) -> ~str {
+    fn to_str_radix(&self, radix: uint) -> StrBuf {
         if self.im < Zero::zero() {
-            format!("{}-{}i", self.re.to_str_radix(radix), (-self.im).to_str_radix(radix))
+            format_strbuf!("{}-{}i",
+                           self.re.to_str_radix(radix),
+                           (-self.im).to_str_radix(radix))
         } else {
-            format!("{}+{}i", self.re.to_str_radix(radix), self.im.to_str_radix(radix))
+            format_strbuf!("{}+{}i",
+                           self.re.to_str_radix(radix),
+                           self.im.to_str_radix(radix))
         }
     }
 }

--- a/src/libnum/rational.rs
+++ b/src/libnum/rational.rs
@@ -281,8 +281,10 @@ impl<T: fmt::Show> fmt::Show for Ratio<T> {
 }
 impl<T: ToStrRadix> ToStrRadix for Ratio<T> {
     /// Renders as `numer/denom` where the numbers are in base `radix`.
-    fn to_str_radix(&self, radix: uint) -> ~str {
-        format!("{}/{}", self.numer.to_str_radix(radix), self.denom.to_str_radix(radix))
+    fn to_str_radix(&self, radix: uint) -> StrBuf {
+        format_strbuf!("{}/{}",
+                       self.numer.to_str_radix(radix),
+                       self.denom.to_str_radix(radix))
     }
 }
 

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -85,7 +85,7 @@ fn native(cx: &mut ExtCtxt, sp: codemap::Span, tts: &[ast::TokenTree])
     let re = match Regex::new(regex.to_owned()) {
         Ok(re) => re,
         Err(err) => {
-            cx.span_err(sp, err.to_str());
+            cx.span_err(sp, err.to_str().as_slice());
             return DummyResult::any(sp)
         }
     };

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -158,7 +158,7 @@ impl<'a> Archive<'a> {
             if skip.iter().any(|s| *s == filename) { continue }
             if filename.contains(".SYMDEF") { continue }
 
-            let filename = format!("r-{}-{}", name, filename);
+            let filename = format_strbuf!("r-{}-{}", name, filename);
             let new_filename = file.with_filename(filename);
             try!(fs::rename(file, &new_filename));
             inputs.push(new_filename);
@@ -178,8 +178,8 @@ impl<'a> Archive<'a> {
         };
         // On Windows, static libraries sometimes show up as libfoo.a and other
         // times show up as foo.lib
-        let oslibname = format!("{}{}.{}", osprefix, name, osext);
-        let unixlibname = format!("lib{}.a", name);
+        let oslibname = format_strbuf!("{}{}.{}", osprefix, name, osext);
+        let unixlibname = format_strbuf!("lib{}.a", name);
 
         let mut rustpath = filesearch::rust_path();
         rustpath.push(self.sess.target_filesearch().get_lib_path());

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -815,7 +815,7 @@ pub fn filename_for_input(sess: &Session, crate_type: config::CrateType,
     let libname = output_lib_filename(id);
     match crate_type {
         config::CrateTypeRlib => {
-            out_filename.with_filename(format!("lib{}.rlib", libname))
+            out_filename.with_filename(format_strbuf!("lib{}.rlib", libname))
         }
         config::CrateTypeDylib => {
             let (prefix, suffix) = match sess.targ_cfg.os {
@@ -825,10 +825,13 @@ pub fn filename_for_input(sess: &Session, crate_type: config::CrateType,
                 abi::OsAndroid => (loader::ANDROID_DLL_PREFIX, loader::ANDROID_DLL_SUFFIX),
                 abi::OsFreebsd => (loader::FREEBSD_DLL_PREFIX, loader::FREEBSD_DLL_SUFFIX),
             };
-            out_filename.with_filename(format!("{}{}{}", prefix, libname, suffix))
+            out_filename.with_filename(format_strbuf!("{}{}{}",
+                                                      prefix,
+                                                      libname,
+                                                      suffix))
         }
         config::CrateTypeStaticlib => {
-            out_filename.with_filename(format!("lib{}.a", libname))
+            out_filename.with_filename(format_strbuf!("lib{}.a", libname))
         }
         config::CrateTypeExecutable => out_filename.clone(),
     }

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -589,10 +589,12 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
 
         let level_short = level_name.slice_chars(0, 1);
         let level_short = level_short.to_ascii().to_upper().into_str();
-        let flags = matches.opt_strs(level_short).move_iter().collect::<Vec<_>>().append(
-                                   matches.opt_strs(level_name).as_slice());
+        let flags = matches.opt_strs(level_short.as_slice())
+                           .move_iter()
+                           .collect::<Vec<_>>()
+                           .append(matches.opt_strs(level_name).as_slice());
         for lint_name in flags.iter() {
-            let lint_name = lint_name.replace("-", "_");
+            let lint_name = lint_name.replace("-", "_").into_strbuf();
             match lint_dict.find_equiv(&lint_name) {
               None => {
                 early_error(format!("unknown {} flag: {}",

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -693,7 +693,8 @@ fn print_flowgraph<W:io::Writer>(analysis: CrateAnalysis,
             let m = "graphviz::render failed";
             io::IoError {
                 detail: Some(match orig_detail {
-                    None => m.into_owned(), Some(d) => format!("{}: {}", m, d)
+                    None => m.into_strbuf(),
+                    Some(d) => format_strbuf!("{}: {}", m, d)
                 }),
                 ..ioerr
             }

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -327,7 +327,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::Item {
         pub fn main() {
             #![main]
             use std::slice::Vector;
-            test::test_main_static_x(::std::os::args().as_slice(), TESTS);
+            test::test_main_static(::std::os::args().as_slice(), TESTS);
         }
     )).unwrap();
 

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -156,7 +156,7 @@ fn extract_crate_info(e: &Env, i: &ast::ViewItem) -> Option<CrateInfo> {
                         Some(id) => id
                     }
                 }
-                None => from_str(ident.get().to_str()).unwrap()
+                None => from_str(ident.get().to_str().as_slice()).unwrap()
             };
             Some(CrateInfo {
                 ident: ident.get().to_strbuf(),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1439,7 +1439,10 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
         attr::mk_attr(
             attr::mk_name_value_item_str(
                 InternedString::new("crate_id"),
-                token::intern_and_get_ident(ecx.link_meta.crateid.to_str())))
+                token::intern_and_get_ident(ecx.link_meta
+                                               .crateid
+                                               .to_str()
+                                               .as_slice())))
     }
 
     let mut attrs = Vec::new();

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -734,7 +734,7 @@ impl<'a> BorrowckCtxt<'a> {
                     }
                     mc::PositionalField(idx) => {
                         out.push_char('#'); // invent a notation here
-                        out.push_str(idx.to_str());
+                        out.push_str(idx.to_str().as_slice());
                     }
                 }
             }

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -164,8 +164,8 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
             match ty::get(ty).sty {
                 ty::ty_bool => {
                     match *ctor {
-                        val(const_bool(true)) => Some("true".to_owned()),
-                        val(const_bool(false)) => Some("false".to_owned()),
+                        val(const_bool(true)) => Some("true".to_strbuf()),
+                        val(const_bool(false)) => Some("false".to_strbuf()),
                         _ => None
                     }
                 }
@@ -177,7 +177,11 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
                     let variants = ty::enum_variants(cx.tcx, id);
 
                     match variants.iter().find(|v| v.id == vid) {
-                        Some(v) => Some(token::get_ident(v.name).get().to_str()),
+                        Some(v) => {
+                            Some(token::get_ident(v.name).get()
+                                                         .to_str()
+                                                         .into_strbuf())
+                        }
                         None => {
                             fail!("check_exhaustive: bad variant in ctor")
                         }
@@ -185,7 +189,9 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
                 }
                 ty::ty_vec(..) | ty::ty_rptr(..) => {
                     match *ctor {
-                        vec(n) => Some(format!("vectors of length {}", n)),
+                        vec(n) => {
+                            Some(format_strbuf!("vectors of length {}", n))
+                        }
                         _ => None
                     }
                 }
@@ -193,11 +199,11 @@ fn check_exhaustive(cx: &MatchCheckCtxt, sp: Span, pats: Vec<@Pat> ) {
             }
         }
     };
-    let msg = "non-exhaustive patterns".to_owned() + match ext {
-        Some(ref s) => format!(": {} not covered",  *s),
-        None => "".to_owned()
-    };
-    cx.tcx.sess.span_err(sp, msg);
+    let msg = format_strbuf!("non-exhaustive patterns{}", match ext {
+        Some(ref s) => format_strbuf!(": {} not covered", *s),
+        None => "".to_strbuf()
+    });
+    cx.tcx.sess.span_err(sp, msg.as_slice());
 }
 
 type matrix = Vec<Vec<@Pat> > ;

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -506,15 +506,21 @@ impl<'a> Context<'a> {
         let mut note = None;
         let msg = match src {
             Default => {
-                format!("{}, \\#[{}({})] on by default", msg,
-                    level_to_str(level), self.lint_to_str(lint))
+                format_strbuf!("{}, \\#[{}({})] on by default",
+                               msg,
+                               level_to_str(level),
+                               self.lint_to_str(lint))
             },
             CommandLine => {
-                format!("{} [-{} {}]", msg,
-                    match level {
-                        warn => 'W', deny => 'D', forbid => 'F',
-                        allow => fail!()
-                    }, self.lint_to_str(lint).replace("_", "-"))
+                format_strbuf!("{} [-{} {}]",
+                               msg,
+                               match level {
+                                warn => 'W',
+                                deny => 'D',
+                                forbid => 'F',
+                                allow => fail!()
+                               },
+                               self.lint_to_str(lint).replace("_", "-"))
             },
             Node(src) => {
                 note = Some(src);
@@ -522,8 +528,8 @@ impl<'a> Context<'a> {
             }
         };
         match level {
-            warn =>          { self.tcx.sess.span_warn(span, msg); }
-            deny | forbid => { self.tcx.sess.span_err(span, msg);  }
+            warn => self.tcx.sess.span_warn(span, msg.as_slice()),
+            deny | forbid => self.tcx.sess.span_err(span, msg.as_slice()),
             allow => fail!(),
         }
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -738,8 +738,11 @@ pub fn iter_structural_ty<'r,
 
                   for variant in (*variants).iter() {
                       let variant_cx =
-                          fcx.new_temp_block("enum-iter-variant-".to_owned() +
-                                             variant.disr_val.to_str());
+                          fcx.new_temp_block(
+                              format_strbuf!("enum-iter-variant-{}",
+                                             variant.disr_val
+                                                    .to_str()
+                                                    .as_slice()).as_slice());
                       match adt::trans_case(cx, &*repr, variant.disr_val) {
                           _match::single_result(r) => {
                               AddCase(llswitch, r.val, variant_cx.llbb)

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -340,7 +340,8 @@ pub fn create_global_var_metadata(cx: &CrateContext,
 
     let namespace_node = namespace_for_item(cx, ast_util::local_def(node_id));
     let var_name = token::get_ident(ident).get().to_str();
-    let linkage_name = namespace_node.mangled_name_of_contained_item(var_name);
+    let linkage_name =
+        namespace_node.mangled_name_of_contained_item(var_name.as_slice());
     let var_scope = namespace_node.scope;
 
     var_name.as_slice().with_c_str(|var_name| {
@@ -1481,14 +1482,17 @@ fn describe_enum_variant(cx: &CrateContext,
     // Get the argument names from the enum variant info
     let mut arg_names: Vec<_> = match variant_info.arg_names {
         Some(ref names) => {
-            names.iter().map(|ident| token::get_ident(*ident).get().to_str()).collect()
+            names.iter()
+                 .map(|ident| {
+                     token::get_ident(*ident).get().to_str().into_strbuf()
+                 }).collect()
         }
-        None => variant_info.args.iter().map(|_| "".to_owned()).collect()
+        None => variant_info.args.iter().map(|_| "".to_strbuf()).collect()
     };
 
     // If this is not a univariant enum, there is also the (unnamed) discriminant field
     if discriminant_type_metadata.is_some() {
-        arg_names.insert(0, "".to_owned());
+        arg_names.insert(0, "".to_strbuf());
     }
 
     // Build an array of (field name, field type) pairs to be captured in the factory closure.

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -255,7 +255,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> StrBuf {
         match fn_style {
             ast::NormalFn => {}
             _ => {
-                s.push_str(fn_style.to_str());
+                s.push_str(fn_style.to_str().as_slice());
                 s.push_char(' ');
             }
         };
@@ -292,7 +292,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> StrBuf {
         match cty.fn_style {
             ast::NormalFn => {}
             _ => {
-                s.push_str(cty.fn_style.to_str());
+                s.push_str(cty.fn_style.to_str().as_slice());
                 s.push_char(' ');
             }
         };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -399,12 +399,16 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
         // Update the search index
         let dst = cx.dst.join("search-index.js");
         let mut all_indexes = Vec::new();
-        all_indexes.push(index);
+        all_indexes.push(index.to_strbuf());
         if dst.exists() {
             for line in BufferedReader::new(File::open(&dst)).lines() {
                 let line = try!(line);
-                if !line.starts_with("searchIndex") { continue }
-                if line.starts_with(format!("searchIndex['{}']", krate.name)) {
+                if !line.as_slice().starts_with("searchIndex") {
+                    continue
+                }
+                if line.as_slice()
+                       .starts_with(format_strbuf!("searchIndex['{}']",
+                                                   krate.name).as_slice()) {
                     continue
                 }
                 all_indexes.push(line);

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -386,7 +386,7 @@ impl fmt::Show for UvError {
 #[test]
 fn error_smoke_test() {
     let err: UvError = UvError(uvll::EOF);
-    assert_eq!(err.to_str(), "EOF: end of file".to_owned());
+    assert_eq!(err.to_str(), "EOF: end of file".to_strbuf());
 }
 
 pub fn uv_error_to_io_error(uverr: UvError) -> IoError {

--- a/src/libserialize/ebml.rs
+++ b/src/libserialize/ebml.rs
@@ -663,7 +663,7 @@ pub mod writer {
             _ => Err(io::IoError {
                 kind: io::OtherIoError,
                 desc: "int too big",
-                detail: Some(format!("{}", n))
+                detail: Some(format_strbuf!("{}", n))
             })
         }
     }
@@ -676,7 +676,7 @@ pub mod writer {
         Err(io::IoError {
             kind: io::OtherIoError,
             desc: "int too big",
-            detail: Some(format!("{}", n))
+            detail: Some(format_strbuf!("{}", n))
         })
     }
 

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -16,10 +16,9 @@ use iter::Iterator;
 use mem;
 use option::{Option, Some, None};
 use slice::{ImmutableVector, MutableVector, Vector};
-use str::OwnedStr;
-use str::Str;
-use str::{StrAllocating, StrSlice};
+use str::{OwnedStr, Str, StrAllocating, StrSlice};
 use str;
+use strbuf::StrBuf;
 use to_str::{IntoStr};
 use vec::Vec;
 
@@ -249,7 +248,7 @@ impl OwnedAsciiCast for ~[u8] {
     }
 }
 
-impl OwnedAsciiCast for ~str {
+impl OwnedAsciiCast for StrBuf {
     #[inline]
     fn is_ascii(&self) -> bool {
         self.as_slice().is_ascii()
@@ -257,7 +256,7 @@ impl OwnedAsciiCast for ~str {
 
     #[inline]
     unsafe fn into_ascii_nocheck(self) -> Vec<Ascii> {
-        let v: ~[u8] = mem::transmute(self);
+        let v: Vec<u8> = mem::transmute(self);
         v.into_ascii_nocheck()
     }
 }
@@ -314,17 +313,18 @@ impl<'a> AsciiStr for &'a [Ascii] {
 
 impl IntoStr for ~[Ascii] {
     #[inline]
-    fn into_str(self) -> ~str {
-        unsafe { mem::transmute(self) }
+    fn into_str(self) -> StrBuf {
+        let vector: Vec<Ascii> = self.as_slice().iter().map(|x| *x).collect();
+        vector.into_str()
     }
 }
 
 impl IntoStr for Vec<Ascii> {
     #[inline]
-    fn into_str(self) -> ~str {
+    fn into_str(self) -> StrBuf {
         unsafe {
             let s: &str = mem::transmute(self.as_slice());
-            s.to_owned()
+            s.to_strbuf()
         }
     }
 }
@@ -346,12 +346,12 @@ pub trait OwnedStrAsciiExt {
     /// Convert the string to ASCII upper case:
     /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
     /// but non-ASCII letters are unchanged.
-    fn into_ascii_upper(self) -> ~str;
+    fn into_ascii_upper(self) -> StrBuf;
 
     /// Convert the string to ASCII lower case:
     /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
     /// but non-ASCII letters are unchanged.
-    fn into_ascii_lower(self) -> ~str;
+    fn into_ascii_lower(self) -> StrBuf;
 }
 
 /// Extension methods for ASCII-subset only operations on string slices
@@ -359,12 +359,12 @@ pub trait StrAsciiExt {
     /// Makes a copy of the string in ASCII upper case:
     /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
     /// but non-ASCII letters are unchanged.
-    fn to_ascii_upper(&self) -> ~str;
+    fn to_ascii_upper(&self) -> StrBuf;
 
     /// Makes a copy of the string in ASCII lower case:
     /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
     /// but non-ASCII letters are unchanged.
-    fn to_ascii_lower(&self) -> ~str;
+    fn to_ascii_lower(&self) -> StrBuf;
 
     /// Check that two strings are an ASCII case-insensitive match.
     /// Same as `to_ascii_lower(a) == to_ascii_lower(b)`,
@@ -374,12 +374,12 @@ pub trait StrAsciiExt {
 
 impl<'a> StrAsciiExt for &'a str {
     #[inline]
-    fn to_ascii_upper(&self) -> ~str {
+    fn to_ascii_upper(&self) -> StrBuf {
         unsafe { str_copy_map_bytes(*self, ASCII_UPPER_MAP) }
     }
 
     #[inline]
-    fn to_ascii_lower(&self) -> ~str {
+    fn to_ascii_lower(&self) -> StrBuf {
         unsafe { str_copy_map_bytes(*self, ASCII_LOWER_MAP) }
     }
 
@@ -394,36 +394,36 @@ impl<'a> StrAsciiExt for &'a str {
     }
 }
 
-impl OwnedStrAsciiExt for ~str {
+impl OwnedStrAsciiExt for StrBuf {
     #[inline]
-    fn into_ascii_upper(self) -> ~str {
+    fn into_ascii_upper(self) -> StrBuf {
         unsafe { str_map_bytes(self, ASCII_UPPER_MAP) }
     }
 
     #[inline]
-    fn into_ascii_lower(self) -> ~str {
+    fn into_ascii_lower(self) -> StrBuf {
         unsafe { str_map_bytes(self, ASCII_LOWER_MAP) }
     }
 }
 
 #[inline]
-unsafe fn str_map_bytes(string: ~str, map: &'static [u8]) -> ~str {
+unsafe fn str_map_bytes(string: StrBuf, map: &'static [u8]) -> StrBuf {
     let mut bytes = string.into_bytes();
 
     for b in bytes.mut_iter() {
         *b = map[*b as uint];
     }
 
-    str::raw::from_utf8_owned(bytes)
+    str::from_utf8(bytes.as_slice()).unwrap().to_strbuf()
 }
 
 #[inline]
-unsafe fn str_copy_map_bytes(string: &str, map: &'static [u8]) -> ~str {
+unsafe fn str_copy_map_bytes(string: &str, map: &'static [u8]) -> StrBuf {
     let mut s = string.to_owned();
     for b in str::raw::as_owned_vec(&mut s).mut_iter() {
         *b = map[*b as uint];
     }
-    s
+    s.into_strbuf()
 }
 
 static ASCII_LOWER_MAP: &'static [u8] = &[
@@ -552,15 +552,17 @@ mod tests {
         assert_eq!("( ;".to_ascii(),                 v2ascii!([40, 32, 59]));
         // FIXME: #5475 borrowchk error, owned vectors do not live long enough
         // if chained-from directly
-        let v = box [40u8, 32u8, 59u8]; assert_eq!(v.to_ascii(), v2ascii!([40, 32, 59]));
-        let v = "( ;".to_owned();              assert_eq!(v.to_ascii(), v2ascii!([40, 32, 59]));
+        let v = box [40u8, 32u8, 59u8];
+        assert_eq!(v.to_ascii(), v2ascii!([40, 32, 59]));
+        let v = "( ;".to_strbuf();
+        assert_eq!(v.as_slice().to_ascii(), v2ascii!([40, 32, 59]));
 
-        assert_eq!("abCDef&?#".to_ascii().to_lower().into_str(), "abcdef&?#".to_owned());
-        assert_eq!("abCDef&?#".to_ascii().to_upper().into_str(), "ABCDEF&?#".to_owned());
+        assert_eq!("abCDef&?#".to_ascii().to_lower().into_str(), "abcdef&?#".to_strbuf());
+        assert_eq!("abCDef&?#".to_ascii().to_upper().into_str(), "ABCDEF&?#".to_strbuf());
 
-        assert_eq!("".to_ascii().to_lower().into_str(), "".to_owned());
-        assert_eq!("YMCA".to_ascii().to_lower().into_str(), "ymca".to_owned());
-        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_str(), "ABCDEFXYZ:.;".to_owned());
+        assert_eq!("".to_ascii().to_lower().into_str(), "".to_strbuf());
+        assert_eq!("YMCA".to_ascii().to_lower().into_str(), "ymca".to_strbuf());
+        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_str(), "ABCDEFXYZ:.;".to_strbuf());
 
         assert!("aBcDeF&?#".to_ascii().eq_ignore_case("AbCdEf&?#".to_ascii()));
 
@@ -572,16 +574,16 @@ mod tests {
 
     #[test]
     fn test_ascii_vec_ng() {
-        assert_eq!("abCDef&?#".to_ascii().to_lower().into_str(), "abcdef&?#".to_owned());
-        assert_eq!("abCDef&?#".to_ascii().to_upper().into_str(), "ABCDEF&?#".to_owned());
-        assert_eq!("".to_ascii().to_lower().into_str(), "".to_owned());
-        assert_eq!("YMCA".to_ascii().to_lower().into_str(), "ymca".to_owned());
-        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_str(), "ABCDEFXYZ:.;".to_owned());
+        assert_eq!("abCDef&?#".to_ascii().to_lower().into_str(), "abcdef&?#".to_strbuf());
+        assert_eq!("abCDef&?#".to_ascii().to_upper().into_str(), "ABCDEF&?#".to_strbuf());
+        assert_eq!("".to_ascii().to_lower().into_str(), "".to_strbuf());
+        assert_eq!("YMCA".to_ascii().to_lower().into_str(), "ymca".to_strbuf());
+        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_str(), "ABCDEFXYZ:.;".to_strbuf());
     }
 
     #[test]
     fn test_owned_ascii_vec() {
-        assert_eq!(("( ;".to_owned()).into_ascii(), vec2ascii![40, 32, 59]);
+        assert_eq!(("( ;".to_strbuf()).into_ascii(), vec2ascii![40, 32, 59]);
         assert_eq!((box [40u8, 32u8, 59u8]).into_ascii(), vec2ascii![40, 32, 59]);
     }
 
@@ -593,8 +595,8 @@ mod tests {
 
     #[test]
     fn test_ascii_into_str() {
-        assert_eq!(vec2ascii![40, 32, 59].into_str(), "( ;".to_owned());
-        assert_eq!(vec2ascii!(40, 32, 59).into_str(), "( ;".to_owned());
+        assert_eq!(vec2ascii![40, 32, 59].into_str(), "( ;".to_strbuf());
+        assert_eq!(vec2ascii!(40, 32, 59).into_str(), "( ;".to_strbuf());
     }
 
     #[test]
@@ -641,70 +643,70 @@ mod tests {
         assert_eq!((vec![40u8, 32u8, 59u8]).into_ascii_opt(), Some(vec2ascii![40, 32, 59]));
         assert_eq!((vec![127u8, 128u8, 255u8]).into_ascii_opt(), None);
 
-        assert_eq!(("( ;".to_owned()).into_ascii_opt(), Some(vec2ascii![40, 32, 59]));
-        assert_eq!(("zoä华".to_owned()).into_ascii_opt(), None);
+        assert_eq!(("( ;".to_strbuf()).into_ascii_opt(), Some(vec2ascii![40, 32, 59]));
+        assert_eq!(("zoä华".to_strbuf()).into_ascii_opt(), None);
     }
 
     #[test]
     fn test_to_ascii_upper() {
-        assert_eq!("url()URL()uRl()ürl".to_ascii_upper(), "URL()URL()URL()üRL".to_owned());
-        assert_eq!("hıKß".to_ascii_upper(), "HıKß".to_owned());
+        assert_eq!("url()URL()uRl()ürl".to_ascii_upper(), "URL()URL()URL()üRL".to_strbuf());
+        assert_eq!("hıKß".to_ascii_upper(), "HıKß".to_strbuf());
 
         let mut i = 0;
         while i <= 500 {
             let upper = if 'a' as u32 <= i && i <= 'z' as u32 { i + 'A' as u32 - 'a' as u32 }
                         else { i };
             assert_eq!(from_char(from_u32(i).unwrap()).to_ascii_upper(),
-                       from_char(from_u32(upper).unwrap()))
+                       from_char(from_u32(upper).unwrap()).to_strbuf())
             i += 1;
         }
     }
 
     #[test]
     fn test_to_ascii_lower() {
-        assert_eq!("url()URL()uRl()Ürl".to_ascii_lower(), "url()url()url()Ürl".to_owned());
+        assert_eq!("url()URL()uRl()Ürl".to_ascii_lower(), "url()url()url()Ürl".to_strbuf());
         // Dotted capital I, Kelvin sign, Sharp S.
-        assert_eq!("HİKß".to_ascii_lower(), "hİKß".to_owned());
+        assert_eq!("HİKß".to_ascii_lower(), "hİKß".to_strbuf());
 
         let mut i = 0;
         while i <= 500 {
             let lower = if 'A' as u32 <= i && i <= 'Z' as u32 { i + 'a' as u32 - 'A' as u32 }
                         else { i };
             assert_eq!(from_char(from_u32(i).unwrap()).to_ascii_lower(),
-                       from_char(from_u32(lower).unwrap()))
+                       from_char(from_u32(lower).unwrap()).to_strbuf())
             i += 1;
         }
     }
 
     #[test]
     fn test_into_ascii_upper() {
-        assert_eq!(("url()URL()uRl()ürl".to_owned()).into_ascii_upper(),
-                   "URL()URL()URL()üRL".to_owned());
-        assert_eq!(("hıKß".to_owned()).into_ascii_upper(), "HıKß".to_owned());
+        assert_eq!(("url()URL()uRl()ürl".to_strbuf()).into_ascii_upper(),
+                   "URL()URL()URL()üRL".to_strbuf());
+        assert_eq!(("hıKß".to_strbuf()).into_ascii_upper(), "HıKß".to_strbuf());
 
         let mut i = 0;
         while i <= 500 {
             let upper = if 'a' as u32 <= i && i <= 'z' as u32 { i + 'A' as u32 - 'a' as u32 }
                         else { i };
-            assert_eq!(from_char(from_u32(i).unwrap()).into_ascii_upper(),
-                       from_char(from_u32(upper).unwrap()))
+            assert_eq!(from_char(from_u32(i).unwrap()).to_strbuf().into_ascii_upper(),
+                       from_char(from_u32(upper).unwrap()).to_strbuf())
             i += 1;
         }
     }
 
     #[test]
     fn test_into_ascii_lower() {
-        assert_eq!(("url()URL()uRl()Ürl".to_owned()).into_ascii_lower(),
-                   "url()url()url()Ürl".to_owned());
+        assert_eq!(("url()URL()uRl()Ürl".to_strbuf()).into_ascii_lower(),
+                   "url()url()url()Ürl".to_strbuf());
         // Dotted capital I, Kelvin sign, Sharp S.
-        assert_eq!(("HİKß".to_owned()).into_ascii_lower(), "hİKß".to_owned());
+        assert_eq!(("HİKß".to_strbuf()).into_ascii_lower(), "hİKß".to_strbuf());
 
         let mut i = 0;
         while i <= 500 {
             let lower = if 'A' as u32 <= i && i <= 'Z' as u32 { i + 'a' as u32 - 'A' as u32 }
                         else { i };
-            assert_eq!(from_char(from_u32(i).unwrap()).into_ascii_lower(),
-                       from_char(from_u32(lower).unwrap()))
+            assert_eq!(from_char(from_u32(i).unwrap()).to_strbuf().into_ascii_lower(),
+                       from_char(from_u32(lower).unwrap()).to_strbuf())
             i += 1;
         }
     }
@@ -724,8 +726,11 @@ mod tests {
             let c = i;
             let lower = if 'A' as u32 <= c && c <= 'Z' as u32 { c + 'a' as u32 - 'A' as u32 }
                         else { c };
-            assert!(from_char(from_u32(i).unwrap()).
-                eq_ignore_ascii_case(from_char(from_u32(lower).unwrap())));
+            assert!(from_char(from_u32(i).unwrap()).as_slice()
+                                                   .eq_ignore_ascii_case(
+                                                       from_char(
+                                                           from_u32(lower)
+                                                            .unwrap())));
             i += 1;
         }
     }
@@ -733,12 +738,12 @@ mod tests {
     #[test]
     fn test_to_str() {
         let s = Ascii{ chr: 't' as u8 }.to_str();
-        assert_eq!(s, "t".to_owned());
+        assert_eq!(s, "t".to_strbuf());
     }
 
     #[test]
     fn test_show() {
         let c = Ascii { chr: 't' as u8 };
-        assert_eq!(format!("{}", c), "t".to_owned());
+        assert_eq!(format_strbuf!("{}", c), "t".to_strbuf());
     }
 }

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -985,7 +985,7 @@ mod test {
 
     pub fn stress_factor() -> uint {
         match os::getenv("RUST_TEST_STRESS") {
-            Some(val) => from_str::<uint>(val).unwrap(),
+            Some(val) => from_str::<uint>(val.as_slice()).unwrap(),
             None => 1,
         }
     }
@@ -1518,7 +1518,7 @@ mod sync_tests {
 
     pub fn stress_factor() -> uint {
         match os::getenv("RUST_TEST_STRESS") {
-            Some(val) => from_str::<uint>(val).unwrap(),
+            Some(val) => from_str::<uint>(val.as_slice()).unwrap(),
             None => 1,
         }
     }

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -488,7 +488,7 @@ use io;
 use option::None;
 use repr;
 use result::{Ok, Err};
-use str::{StrAllocating};
+use str::{Str, StrAllocating};
 use str;
 use strbuf::StrBuf;
 use slice::Vector;
@@ -572,7 +572,7 @@ impl<T> Poly for T {
             // this allocation of a new string
             _ => {
                 let s = repr::repr_to_str(self);
-                f.pad(s)
+                f.pad(s.as_slice())
             }
         }
     }

--- a/src/libstd/hash/mod.rs
+++ b/src/libstd/hash/mod.rs
@@ -23,7 +23,7 @@
  * #[deriving(Hash)]
  * struct Person {
  *     id: uint,
- *     name: ~str,
+ *     name: StrBuf,
  *     phone: u64,
  * }
  *
@@ -43,7 +43,7 @@
  *
  * struct Person {
  *     id: uint,
- *     name: ~str,
+ *     name: StrBuf,
  *     phone: u64,
  * }
  *
@@ -142,13 +142,6 @@ impl<'a, S: Writer> Hash<S> for &'a str {
     fn hash(&self, state: &mut S) {
         state.write(self.as_bytes());
         state.write_u8(0xFF);
-    }
-}
-
-impl<S: Writer> Hash<S> for ~str {
-    #[inline]
-    fn hash(&self, state: &mut S) {
-        self.as_slice().hash(state);
     }
 }
 

--- a/src/libstd/hash/sip.rs
+++ b/src/libstd/hash/sip.rs
@@ -458,12 +458,12 @@ mod tests {
         let mut state_inc = SipState::new_with_keys(k0, k1);
         let mut state_full = SipState::new_with_keys(k0, k1);
 
-        fn to_hex_str(r: &[u8, ..8]) -> ~str {
+        fn to_hex_str(r: &[u8, ..8]) -> StrBuf {
             let mut s = StrBuf::new();
             for b in r.iter() {
-                s.push_str((*b as uint).to_str_radix(16u));
+                s.push_str((*b as uint).to_str_radix(16u).as_slice());
             }
-            s.into_owned()
+            s
         }
 
         fn result_bytes(h: u64) -> ~[u8] {
@@ -478,13 +478,13 @@ mod tests {
             ]
         }
 
-        fn result_str(h: u64) -> ~str {
+        fn result_str(h: u64) -> StrBuf {
             let r = result_bytes(h);
             let mut s = StrBuf::new();
             for b in r.iter() {
-                s.push_str((*b as uint).to_str_radix(16u));
+                s.push_str((*b as uint).to_str_radix(16u).as_slice());
             }
-            s.into_owned()
+            s
         }
 
         while t < 64 {
@@ -636,7 +636,6 @@ officia deserunt mollit anim id est laborum.";
     struct Compound {
         x: u8,
         y: u64,
-        z: ~str,
     }
 
     #[bench]
@@ -644,7 +643,6 @@ officia deserunt mollit anim id est laborum.";
         let compound = Compound {
             x: 1,
             y: 2,
-            z: "foobarbaz".to_owned(),
         };
         b.iter(|| {
             assert_eq!(hash(&compound), 15783192367317361799);

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -537,9 +537,9 @@ mod test {
     fn test_read_line() {
         let in_buf = MemReader::new(Vec::from_slice(bytes!("a\nb\nc")));
         let mut reader = BufferedReader::with_capacity(2, in_buf);
-        assert_eq!(reader.read_line(), Ok("a\n".to_owned()));
-        assert_eq!(reader.read_line(), Ok("b\n".to_owned()));
-        assert_eq!(reader.read_line(), Ok("c".to_owned()));
+        assert_eq!(reader.read_line(), Ok("a\n".to_strbuf()));
+        assert_eq!(reader.read_line(), Ok("b\n".to_strbuf()));
+        assert_eq!(reader.read_line(), Ok("c".to_strbuf()));
         assert!(reader.read_line().is_err());
     }
 
@@ -548,9 +548,9 @@ mod test {
         let in_buf = MemReader::new(Vec::from_slice(bytes!("a\nb\nc")));
         let mut reader = BufferedReader::with_capacity(2, in_buf);
         let mut it = reader.lines();
-        assert_eq!(it.next(), Some(Ok("a\n".to_owned())));
-        assert_eq!(it.next(), Some(Ok("b\n".to_owned())));
-        assert_eq!(it.next(), Some(Ok("c".to_owned())));
+        assert_eq!(it.next(), Some(Ok("a\n".to_strbuf())));
+        assert_eq!(it.next(), Some(Ok("b\n".to_strbuf())));
+        assert_eq!(it.next(), Some(Ok("c".to_strbuf())));
         assert_eq!(it.next(), None);
     }
 

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -745,7 +745,8 @@ mod test {
     pub fn tmpdir() -> TempDir {
         use os;
         use rand;
-        let ret = os::tmpdir().join(format!("rust-{}", rand::random::<u32>()));
+        let ret = os::tmpdir().join(
+            format_strbuf!("rust-{}", rand::random::<u32>()));
         check!(io::fs::mkdir(&ret, io::UserRWX));
         TempDir(ret)
     }
@@ -952,9 +953,10 @@ mod test {
         check!(mkdir(dir, io::UserRWX));
         let prefix = "foo";
         for n in range(0,3) {
-            let f = dir.join(format!("{}.txt", n));
+            let f = dir.join(format_strbuf!("{}.txt", n));
             let mut w = check!(File::create(&f));
-            let msg_str = (prefix + n.to_str().to_owned()).to_owned();
+            let msg_str =
+                (prefix + n.to_str().into_owned()).to_owned();
             let msg = msg_str.as_bytes();
             check!(w.write(msg));
         }
@@ -1039,7 +1041,7 @@ mod test {
         let tmpdir = tmpdir();
 
         let mut dirpath = tmpdir.path().clone();
-        dirpath.push(format!("test-가一ー你好"));
+        dirpath.push(format_strbuf!("test-가一ー你好"));
         check!(mkdir(&dirpath, io::UserRWX));
         assert!(dirpath.is_dir());
 
@@ -1056,7 +1058,7 @@ mod test {
 
         let tmpdir = tmpdir();
         let unicode = tmpdir.path();
-        let unicode = unicode.join(format!("test-각丁ー再见"));
+        let unicode = unicode.join(format_strbuf!("test-각丁ー再见"));
         check!(mkdir(&unicode, io::UserRWX));
         assert!(unicode.exists());
         assert!(!Path::new("test/unicode-bogus-path-각丁ー再见").exists());

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -497,7 +497,7 @@ mod test {
         writer.write_line("testing").unwrap();
         writer.write_str("testing").unwrap();
         let mut r = BufReader::new(writer.get_ref());
-        assert_eq!(r.read_to_str().unwrap(), "testingtesting\ntesting".to_owned());
+        assert_eq!(r.read_to_str().unwrap(), "testingtesting\ntesting".to_strbuf());
     }
 
     #[test]
@@ -507,7 +507,7 @@ mod test {
         writer.write_char('\n').unwrap();
         writer.write_char('ệ').unwrap();
         let mut r = BufReader::new(writer.get_ref());
-        assert_eq!(r.read_to_str().unwrap(), "a\nệ".to_owned());
+        assert_eq!(r.read_to_str().unwrap(), "a\nệ".to_strbuf());
     }
 
     #[test]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -76,7 +76,7 @@ Some examples of obvious things you might want to do
 
     let path = Path::new("message.txt");
     let mut file = BufferedReader::new(File::open(&path));
-    let lines: Vec<~str> = file.lines().map(|x| x.unwrap()).collect();
+    let lines: Vec<StrBuf> = file.lines().map(|x| x.unwrap()).collect();
     ```
 
 * Make a simple TCP client connection and request
@@ -228,6 +228,7 @@ use result::{Ok, Err, Result};
 use slice::{Vector, MutableVector, ImmutableVector};
 use str::{StrSlice, StrAllocating};
 use str;
+use strbuf::StrBuf;
 use uint;
 use vec::Vec;
 
@@ -292,7 +293,7 @@ pub struct IoError {
     /// A human-readable description about the error
     pub desc: &'static str,
     /// Detailed information about this error, not always available
-    pub detail: Option<~str>
+    pub detail: Option<StrBuf>
 }
 
 impl IoError {
@@ -364,7 +365,11 @@ impl IoError {
         IoError {
             kind: kind,
             desc: desc,
-            detail: if detail {Some(os::error_string(errno))} else {None},
+            detail: if detail {
+                Some(os::error_string(errno))
+            } else {
+                None
+            },
         }
     }
 
@@ -490,8 +495,10 @@ pub trait Reader {
     /// bytes are read.
     fn read_at_least(&mut self, min: uint, buf: &mut [u8]) -> IoResult<uint> {
         if min > buf.len() {
-            return Err(IoError { detail: Some("the buffer is too short".to_owned()),
-                                 ..standard_error(InvalidInput) });
+            return Err(IoError {
+                detail: Some("the buffer is too short".to_strbuf()),
+                ..standard_error(InvalidInput)
+            });
         }
         let mut read = 0;
         while read < min {
@@ -556,8 +563,10 @@ pub trait Reader {
     /// bytes are read.
     fn push_at_least(&mut self, min: uint, len: uint, buf: &mut Vec<u8>) -> IoResult<uint> {
         if min > len {
-            return Err(IoError { detail: Some("the buffer is too short".to_owned()),
-                                 ..standard_error(InvalidInput) });
+            return Err(IoError {
+                detail: Some("the buffer is too short".to_strbuf()),
+                ..standard_error(InvalidInput)
+            });
         }
 
         let start_len = buf.len();
@@ -623,10 +632,10 @@ pub trait Reader {
     /// This function returns all of the same errors as `read_to_end` with an
     /// additional error if the reader's contents are not a valid sequence of
     /// UTF-8 bytes.
-    fn read_to_str(&mut self) -> IoResult<~str> {
+    fn read_to_str(&mut self) -> IoResult<StrBuf> {
         self.read_to_end().and_then(|s| {
             match str::from_utf8(s.as_slice()) {
-                Some(s) => Ok(s.to_owned()),
+                Some(s) => Ok(s.to_strbuf()),
                 None => Err(standard_error(InvalidInput)),
             }
         })
@@ -1235,8 +1244,8 @@ pub struct Lines<'r, T> {
     buffer: &'r mut T,
 }
 
-impl<'r, T: Buffer> Iterator<IoResult<~str>> for Lines<'r, T> {
-    fn next(&mut self) -> Option<IoResult<~str>> {
+impl<'r, T: Buffer> Iterator<IoResult<StrBuf>> for Lines<'r, T> {
+    fn next(&mut self) -> Option<IoResult<StrBuf>> {
         match self.buffer.read_line() {
             Ok(x) => Some(Ok(x)),
             Err(IoError { kind: EndOfFile, ..}) => None,
@@ -1321,10 +1330,10 @@ pub trait Buffer: Reader {
     ///
     /// Additionally, this function can fail if the line of input read is not a
     /// valid UTF-8 sequence of bytes.
-    fn read_line(&mut self) -> IoResult<~str> {
+    fn read_line(&mut self) -> IoResult<StrBuf> {
         self.read_until('\n' as u8).and_then(|line|
             match str::from_utf8(line.as_slice()) {
-                Some(s) => Ok(s.to_owned()),
+                Some(s) => Ok(s.to_strbuf()),
                 None => Err(standard_error(InvalidInput)),
             }
         )

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -445,8 +445,8 @@ mod test {
     #[test]
     fn ipv6_addr_to_str() {
         let a1 = Ipv6Addr(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x280);
-        assert!(a1.to_str() == "::ffff:192.0.2.128".to_owned() ||
-                a1.to_str() == "::FFFF:192.0.2.128".to_owned());
-        assert_eq!(Ipv6Addr(8, 9, 10, 11, 12, 13, 14, 15).to_str(), "8:9:a:b:c:d:e:f".to_owned());
+        assert!(a1.to_str() == "::ffff:192.0.2.128".to_strbuf() ||
+                a1.to_str() == "::FFFF:192.0.2.128".to_strbuf());
+        assert_eq!(Ipv6Addr(8, 9, 10, 11, 12, 13, 14, 15).to_str(), "8:9:a:b:c:d:e:f".to_strbuf());
     }
 }

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -434,7 +434,7 @@ mod test {
         let socket_addr = next_test_ip4();
         let ip_str = socket_addr.ip.to_str();
         let port = socket_addr.port;
-        let listener = TcpListener::bind(ip_str, port);
+        let listener = TcpListener::bind(ip_str.as_slice(), port);
         let mut acceptor = listener.listen();
 
         spawn(proc() {
@@ -452,7 +452,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut stream = TcpStream::connect("localhost", addr.port);
@@ -469,7 +469,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut stream = TcpStream::connect("127.0.0.1", addr.port);
@@ -486,7 +486,7 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut stream = TcpStream::connect("::1", addr.port);
@@ -503,10 +503,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect(ip_str, port);
+            let mut stream = TcpStream::connect(ip_str.as_slice(), port);
             stream.write([99]).unwrap();
         });
 
@@ -520,10 +520,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect(ip_str, port);
+            let mut stream = TcpStream::connect(ip_str.as_slice(), port);
             stream.write([99]).unwrap();
         });
 
@@ -537,10 +537,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str, port);
+            let _stream = TcpStream::connect(ip_str.as_slice(), port);
             // Close
         });
 
@@ -554,10 +554,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str, port);
+            let _stream = TcpStream::connect(ip_str.as_slice(), port);
             // Close
         });
 
@@ -571,10 +571,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str, port);
+            let _stream = TcpStream::connect(ip_str.as_slice(), port);
             // Close
         });
 
@@ -596,10 +596,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str, port);
+            let _stream = TcpStream::connect(ip_str.as_slice(), port);
             // Close
         });
 
@@ -621,10 +621,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str, port);
+            let _stream = TcpStream::connect(ip_str.as_slice(), port);
             // Close
         });
 
@@ -648,10 +648,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str, port);
+            let _stream = TcpStream::connect(ip_str.as_slice(), port);
             // Close
         });
 
@@ -676,11 +676,11 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         let max = 10u;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             for _ in range(0, max) {
-                let mut stream = TcpStream::connect(ip_str, port);
+                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
                 stream.write([99]).unwrap();
             }
         });
@@ -697,11 +697,11 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         let max = 10u;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             for _ in range(0, max) {
-                let mut stream = TcpStream::connect(ip_str, port);
+                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
                 stream.write([99]).unwrap();
             }
         });
@@ -718,7 +718,7 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         static MAX: int = 10;
-        let acceptor = TcpListener::bind(ip_str, port).listen();
+        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -743,7 +743,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str, port);
+                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -757,7 +757,7 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         static MAX: int = 10;
-        let acceptor = TcpListener::bind(ip_str, port).listen();
+        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -782,7 +782,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str, port);
+                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -796,7 +796,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let acceptor = TcpListener::bind(ip_str, port).listen();
+        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -821,7 +821,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str, port);
+                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -835,7 +835,7 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let acceptor = TcpListener::bind(ip_str, port).listen();
+        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -860,7 +860,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str, port);
+                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -872,7 +872,7 @@ mod test {
     pub fn socket_name(addr: SocketAddr) {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut listener = TcpListener::bind(ip_str, port).unwrap();
+        let mut listener = TcpListener::bind(ip_str.as_slice(), port).unwrap();
 
         // Make sure socket_name gives
         // us the socket we binded to.
@@ -884,13 +884,13 @@ mod test {
     pub fn peer_name(addr: SocketAddr) {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let acceptor = TcpListener::bind(ip_str, port).listen();
+        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
         spawn(proc() {
             let mut acceptor = acceptor;
             acceptor.accept().unwrap();
         });
 
-        let stream = TcpStream::connect(ip_str, port);
+        let stream = TcpStream::connect(ip_str.as_slice(), port);
 
         assert!(stream.is_ok());
         let mut stream = stream.unwrap();
@@ -920,7 +920,7 @@ mod test {
         let (tx, rx) = channel();
         spawn(proc() {
             let ip_str = addr.ip.to_str();
-            let mut srv = TcpListener::bind(ip_str, port).listen().unwrap();
+            let mut srv = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
             tx.send(());
             let mut cl = srv.accept().unwrap();
             cl.write([10]).unwrap();
@@ -931,7 +931,7 @@ mod test {
 
         rx.recv();
         let ip_str = addr.ip.to_str();
-        let mut c = TcpStream::connect(ip_str, port).unwrap();
+        let mut c = TcpStream::connect(ip_str.as_slice(), port).unwrap();
         let mut b = [0, ..10];
         assert_eq!(c.read(b), Ok(1));
         c.write([1]).unwrap();
@@ -942,9 +942,9 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let listener = TcpListener::bind(ip_str, port).unwrap().listen();
+        let listener = TcpListener::bind(ip_str.as_slice(), port).unwrap().listen();
         assert!(listener.is_ok());
-        match TcpListener::bind(ip_str, port).listen() {
+        match TcpListener::bind(ip_str.as_slice(), port).listen() {
             Ok(..) => fail!(),
             Err(e) => {
                 assert!(e.kind == ConnectionRefused || e.kind == OtherIoError);
@@ -960,14 +960,14 @@ mod test {
         spawn(proc() {
             let ip_str = addr.ip.to_str();
             rx.recv();
-            let _stream = TcpStream::connect(ip_str, port).unwrap();
+            let _stream = TcpStream::connect(ip_str.as_slice(), port).unwrap();
             // Close
             rx.recv();
         });
 
         {
             let ip_str = addr.ip.to_str();
-            let mut acceptor = TcpListener::bind(ip_str, port).listen();
+            let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
             tx.send(());
             {
                 let _stream = acceptor.accept().unwrap();
@@ -976,17 +976,17 @@ mod test {
             }
             // Close listener
         }
-        let _listener = TcpListener::bind(addr.ip.to_str(), port);
+        let _listener = TcpListener::bind(addr.ip.to_str().as_slice(), port);
     })
 
     iotest!(fn tcp_clone_smoke() {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port);
+            let mut s = TcpStream::connect(ip_str.as_slice(), port);
             let mut buf = [0, 0];
             assert_eq!(s.read(buf), Ok(1));
             assert_eq!(buf[0], 1);
@@ -1014,12 +1014,12 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
         let (tx1, rx) = channel();
         let tx2 = tx1.clone();
 
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port);
+            let mut s = TcpStream::connect(ip_str.as_slice(), port);
             s.write([1]).unwrap();
             rx.recv();
             s.write([2]).unwrap();
@@ -1048,10 +1048,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str, port).listen();
+        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
 
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port);
+            let mut s = TcpStream::connect(ip_str.as_slice(), port);
             let mut buf = [0, 1];
             s.read(buf).unwrap();
             s.read(buf).unwrap();
@@ -1077,7 +1077,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let a = TcpListener::bind(ip_str, port).unwrap().listen();
+        let a = TcpListener::bind(ip_str.as_slice(), port).unwrap().listen();
         spawn(proc() {
             let mut a = a;
             let mut c = a.accept().unwrap();
@@ -1085,7 +1085,7 @@ mod test {
             c.write([1]).unwrap();
         });
 
-        let mut s = TcpStream::connect(ip_str, port).unwrap();
+        let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
         assert!(s.obj.close_write().is_ok());
         assert!(s.write([1]).is_err());
         assert_eq!(s.read_to_end(), Ok(vec!(1)));
@@ -1095,7 +1095,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str, port).unwrap().listen().unwrap();
+        let mut a = TcpListener::bind(ip_str.as_slice(), port).unwrap().listen().unwrap();
 
         a.set_timeout(Some(10));
 
@@ -1114,7 +1114,8 @@ mod test {
         if !cfg!(target_os = "freebsd") {
             let (tx, rx) = channel();
             spawn(proc() {
-                tx.send(TcpStream::connect(addr.ip.to_str(), port).unwrap());
+                tx.send(TcpStream::connect(addr.ip.to_str().as_slice(),
+                                           port).unwrap());
             });
             let _l = rx.recv();
             for i in range(0, 1001) {
@@ -1131,7 +1132,8 @@ mod test {
         // Unset the timeout and make sure that this always blocks.
         a.set_timeout(None);
         spawn(proc() {
-            drop(TcpStream::connect(addr.ip.to_str(), port).unwrap());
+            drop(TcpStream::connect(addr.ip.to_str().as_slice(),
+                                    port).unwrap());
         });
         a.accept().unwrap();
     })
@@ -1140,7 +1142,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let a = TcpListener::bind(ip_str, port).listen().unwrap();
+        let a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
         let (_tx, rx) = channel::<()>();
         spawn(proc() {
             let mut a = a;
@@ -1149,7 +1151,7 @@ mod test {
         });
 
         let mut b = [0];
-        let mut s = TcpStream::connect(ip_str, port).unwrap();
+        let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
         let mut s2 = s.clone();
 
         // closing should prevent reads/writes
@@ -1178,7 +1180,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let a = TcpListener::bind(ip_str, port).listen().unwrap();
+        let a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
         let (_tx, rx) = channel::<()>();
         spawn(proc() {
             let mut a = a;
@@ -1186,7 +1188,7 @@ mod test {
             let _ = rx.recv_opt();
         });
 
-        let mut s = TcpStream::connect(ip_str, port).unwrap();
+        let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
         let s2 = s.clone();
         let (tx, rx) = channel();
         spawn(proc() {
@@ -1205,10 +1207,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str, port).listen().unwrap();
+        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port).unwrap();
+            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
             rx.recv();
             assert!(s.write([0]).is_ok());
             let _ = rx.recv_opt();
@@ -1239,10 +1241,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str, port).listen().unwrap();
+        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port).unwrap();
+            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
             rx.recv();
             let mut amt = 0;
             while amt < 100 * 128 * 1024 {
@@ -1269,10 +1271,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str, port).listen().unwrap();
+        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port).unwrap();
+            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
             rx.recv();
             assert!(s.write([0]).is_ok());
             let _ = rx.recv_opt();
@@ -1298,10 +1300,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str, port).listen().unwrap();
+        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str, port).unwrap();
+            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
             rx.recv();
             assert_eq!(s.write([0]), Ok(()));
             let _ = rx.recv_opt();

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -583,11 +583,11 @@ mod tests {
         }
     })
 
-    pub fn read_all(input: &mut Reader) -> ~str {
+    pub fn read_all(input: &mut Reader) -> StrBuf {
         input.read_to_str().unwrap()
     }
 
-    pub fn run_output(cmd: Command) -> ~str {
+    pub fn run_output(cmd: Command) -> StrBuf {
         let p = cmd.spawn();
         assert!(p.is_ok());
         let mut p = p.unwrap();
@@ -601,7 +601,7 @@ mod tests {
     iotest!(fn stdout_works() {
         let mut cmd = Command::new("echo");
         cmd.arg("foobar").stdout(CreatePipe(false, true));
-        assert_eq!(run_output(cmd), "foobar\n".to_owned());
+        assert_eq!(run_output(cmd), "foobar\n".to_strbuf());
     })
 
     #[cfg(unix, not(target_os="android"))]
@@ -610,7 +610,7 @@ mod tests {
         cmd.arg("-c").arg("pwd")
            .cwd(&Path::new("/"))
            .stdout(CreatePipe(false, true));
-        assert_eq!(run_output(cmd), "/\n".to_owned());
+        assert_eq!(run_output(cmd), "/\n".to_strbuf());
     })
 
     #[cfg(unix, not(target_os="android"))]
@@ -624,7 +624,7 @@ mod tests {
         drop(p.stdin.take());
         let out = read_all(p.stdout.get_mut_ref() as &mut Reader);
         assert!(p.wait().unwrap().success());
-        assert_eq!(out, "foobar\n".to_owned());
+        assert_eq!(out, "foobar\n".to_strbuf());
     })
 
     #[cfg(not(target_os="android"))]
@@ -682,7 +682,7 @@ mod tests {
         let output_str = str::from_utf8(output.as_slice()).unwrap();
 
         assert!(status.success());
-        assert_eq!(output_str.trim().to_owned(), "hello".to_owned());
+        assert_eq!(output_str.trim().to_strbuf(), "hello".to_strbuf());
         // FIXME #7224
         if !running_on_valgrind() {
             assert_eq!(error, Vec::new());
@@ -719,7 +719,7 @@ mod tests {
         let output_str = str::from_utf8(output.as_slice()).unwrap();
 
         assert!(status.success());
-        assert_eq!(output_str.trim().to_owned(), "hello".to_owned());
+        assert_eq!(output_str.trim().to_strbuf(), "hello".to_strbuf());
         // FIXME #7224
         if !running_on_valgrind() {
             assert_eq!(error, Vec::new());
@@ -749,9 +749,9 @@ mod tests {
         let prog = pwd_cmd().spawn().unwrap();
 
         let output = str::from_utf8(prog.wait_with_output().unwrap()
-                                        .output.as_slice()).unwrap().to_owned();
+                                        .output.as_slice()).unwrap().to_strbuf();
         let parent_dir = os::getcwd();
-        let child_dir = Path::new(output.trim());
+        let child_dir = Path::new(output.as_slice().trim());
 
         let parent_stat = parent_dir.stat().unwrap();
         let child_stat = child_dir.stat().unwrap();
@@ -768,8 +768,8 @@ mod tests {
         let prog = pwd_cmd().cwd(&parent_dir).spawn().unwrap();
 
         let output = str::from_utf8(prog.wait_with_output().unwrap()
-                                        .output.as_slice()).unwrap().to_owned();
-        let child_dir = Path::new(output.trim());
+                                        .output.as_slice()).unwrap().to_strbuf();
+        let child_dir = Path::new(output.as_slice().trim().into_strbuf());
 
         let parent_stat = parent_dir.stat().unwrap();
         let child_stat = child_dir.stat().unwrap();
@@ -803,12 +803,13 @@ mod tests {
 
         let prog = env_cmd().spawn().unwrap();
         let output = str::from_utf8(prog.wait_with_output().unwrap()
-                                        .output.as_slice()).unwrap().to_owned();
+                                        .output.as_slice()).unwrap().to_strbuf();
 
         let r = os::env();
         for &(ref k, ref v) in r.iter() {
             // don't check windows magical empty-named variables
-            assert!(k.is_empty() || output.contains(format!("{}={}", *k, *v)));
+            assert!(k.is_empty() ||
+                    output.as_slice().contains(format!("{}={}", *k, *v)));
         }
     })
     #[cfg(target_os="android")]
@@ -819,12 +820,12 @@ mod tests {
         let mut prog = env_cmd().spawn().unwrap();
         let output = str::from_utf8(prog.wait_with_output()
                                         .unwrap().output.as_slice())
-                                   .unwrap().to_owned();
+                                   .unwrap().to_strbuf();
 
         let r = os::env();
         for &(ref k, ref v) in r.iter() {
             // don't check android RANDOM variables
-            if *k != "RANDOM".to_owned() {
+            if *k != "RANDOM".to_strbuf() {
                 assert!(output.contains(format!("{}={}", *k, *v)) ||
                         output.contains(format!("{}=\'{}\'", *k, *v)));
             }
@@ -835,9 +836,9 @@ mod tests {
         let new_env = box [("RUN_TEST_NEW_ENV", "123")];
         let prog = env_cmd().env(new_env).spawn().unwrap();
         let result = prog.wait_with_output().unwrap();
-        let output = str::from_utf8_lossy(result.output.as_slice()).into_owned();
+        let output = str::from_utf8_lossy(result.output.as_slice()).into_strbuf();
 
-        assert!(output.contains("RUN_TEST_NEW_ENV=123"),
+        assert!(output.as_slice().contains("RUN_TEST_NEW_ENV=123"),
                 "didn't find RUN_TEST_NEW_ENV inside of:\n\n{}", output);
     })
 

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -399,7 +399,7 @@ mod tests {
             set_stdout(box w);
             println!("hello!");
         });
-        assert_eq!(r.read_to_str().unwrap(), "hello!\n".to_owned());
+        assert_eq!(r.read_to_str().unwrap(), "hello!\n".to_strbuf());
     })
 
     iotest!(fn capture_stderr() {
@@ -412,6 +412,6 @@ mod tests {
             fail!("my special message");
         });
         let s = r.read_to_str().unwrap();
-        assert!(s.contains("my special message"));
+        assert!(s.as_slice().contains("my special message"));
     })
 }

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -42,10 +42,11 @@ impl TempDir {
         static mut CNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
 
         for _ in range(0u, 1000) {
-            let filename = format!("rs-{}-{}-{}",
-                                   unsafe { libc::getpid() },
-                                   unsafe { CNT.fetch_add(1, atomics::SeqCst) },
-                                   suffix);
+            let filename =
+                format_strbuf!("rs-{}-{}-{}",
+                               unsafe { libc::getpid() },
+                               unsafe { CNT.fetch_add(1, atomics::SeqCst) },
+                               suffix);
             let p = tmpdir.join(filename);
             match fs::mkdir(&p, io::UserRWX) {
                 Err(..) => {}

--- a/src/libstd/io/test.rs
+++ b/src/libstd/io/test.rs
@@ -67,14 +67,14 @@ pub fn next_test_unix() -> Path {
     // base port and pid are an attempt to be unique between multiple
     // test-runners of different configurations running on one
     // buildbot, the count is to be unique within this executable.
-    let string = format!("rust-test-unix-path-{}-{}-{}",
-                         base_port(),
-                         unsafe {libc::getpid()},
-                         unsafe {COUNT.fetch_add(1, Relaxed)});
+    let string = format_strbuf!("rust-test-unix-path-{}-{}-{}",
+                                base_port(),
+                                unsafe {libc::getpid()},
+                                unsafe {COUNT.fetch_add(1, Relaxed)});
     if cfg!(unix) {
         os::tmpdir().join(string)
     } else {
-        Path::new(r"\\.\pipe\" + string)
+        Path::new(format_strbuf!("{}{}", r"\\.\pipe\", string))
     }
 }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -283,4 +283,5 @@ mod std {
 
     // The test runner requires std::slice::Vector, so re-export std::slice just for it.
     #[cfg(test)] pub use slice;
+    #[cfg(test)] pub use strbuf;
 }

--- a/src/libstd/local_data.rs
+++ b/src/libstd/local_data.rs
@@ -274,12 +274,12 @@ mod tests {
 
     #[test]
     fn test_tls_multitask() {
-        static my_key: Key<~str> = &Key;
-        my_key.replace(Some("parent data".to_owned()));
+        static my_key: Key<StrBuf> = &Key;
+        my_key.replace(Some("parent data".to_strbuf()));
         task::spawn(proc() {
             // TLS shouldn't carry over.
             assert!(my_key.get().is_none());
-            my_key.replace(Some("child data".to_owned()));
+            my_key.replace(Some("child data".to_strbuf()));
             assert!(my_key.get().get_ref().as_slice() == "child data");
             // should be cleaned up for us
         });
@@ -292,17 +292,17 @@ mod tests {
 
     #[test]
     fn test_tls_overwrite() {
-        static my_key: Key<~str> = &Key;
-        my_key.replace(Some("first data".to_owned()));
-        my_key.replace(Some("next data".to_owned())); // Shouldn't leak.
+        static my_key: Key<StrBuf> = &Key;
+        my_key.replace(Some("first data".to_strbuf()));
+        my_key.replace(Some("next data".to_strbuf())); // Shouldn't leak.
         assert!(my_key.get().unwrap().as_slice() == "next data");
     }
 
     #[test]
     fn test_tls_pop() {
-        static my_key: Key<~str> = &Key;
-        my_key.replace(Some("weasel".to_owned()));
-        assert!(my_key.replace(None).unwrap() == "weasel".to_owned());
+        static my_key: Key<StrBuf> = &Key;
+        my_key.replace(Some("weasel".to_strbuf()));
+        assert!(my_key.replace(None).unwrap() == "weasel".to_strbuf());
         // Pop must remove the data from the map.
         assert!(my_key.replace(None).is_none());
     }
@@ -315,19 +315,19 @@ mod tests {
         // to get recorded as something within a rust stack segment. Then a
         // subsequent upcall (esp. for logging, think vsnprintf) would run on
         // a stack smaller than 1 MB.
-        static my_key: Key<~str> = &Key;
+        static my_key: Key<StrBuf> = &Key;
         task::spawn(proc() {
-            my_key.replace(Some("hax".to_owned()));
+            my_key.replace(Some("hax".to_strbuf()));
         });
     }
 
     #[test]
     fn test_tls_multiple_types() {
-        static str_key: Key<~str> = &Key;
+        static str_key: Key<StrBuf> = &Key;
         static box_key: Key<@()> = &Key;
         static int_key: Key<int> = &Key;
         task::spawn(proc() {
-            str_key.replace(Some("string data".to_owned()));
+            str_key.replace(Some("string data".to_strbuf()));
             box_key.replace(Some(@()));
             int_key.replace(Some(42));
         });
@@ -335,12 +335,12 @@ mod tests {
 
     #[test]
     fn test_tls_overwrite_multiple_types() {
-        static str_key: Key<~str> = &Key;
+        static str_key: Key<StrBuf> = &Key;
         static box_key: Key<@()> = &Key;
         static int_key: Key<int> = &Key;
         task::spawn(proc() {
-            str_key.replace(Some("string data".to_owned()));
-            str_key.replace(Some("string data 2".to_owned()));
+            str_key.replace(Some("string data".to_strbuf()));
+            str_key.replace(Some("string data 2".to_strbuf()));
             box_key.replace(Some(@()));
             box_key.replace(Some(@()));
             int_key.replace(Some(42));
@@ -354,13 +354,13 @@ mod tests {
     #[test]
     #[should_fail]
     fn test_tls_cleanup_on_failure() {
-        static str_key: Key<~str> = &Key;
+        static str_key: Key<StrBuf> = &Key;
         static box_key: Key<@()> = &Key;
         static int_key: Key<int> = &Key;
-        str_key.replace(Some("parent data".to_owned()));
+        str_key.replace(Some("parent data".to_strbuf()));
         box_key.replace(Some(@()));
         task::spawn(proc() {
-            str_key.replace(Some("string data".to_owned()));
+            str_key.replace(Some("string data".to_strbuf()));
             box_key.replace(Some(@()));
             int_key.replace(Some(42));
             fail!();

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -20,6 +20,7 @@ use intrinsics;
 use libc::c_int;
 use num::strconv;
 use num;
+use strbuf::StrBuf;
 
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON, MIN_VALUE};
 pub use core::f32::{MIN_POS_VALUE, MAX_VALUE, MIN_EXP, MAX_EXP, MIN_10_EXP};
@@ -242,7 +243,7 @@ impl FloatMath for f32 {
 ///
 /// * num - The float value
 #[inline]
-pub fn to_str(num: f32) -> ~str {
+pub fn to_str(num: f32) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
     r
@@ -254,7 +255,7 @@ pub fn to_str(num: f32) -> ~str {
 ///
 /// * num - The float value
 #[inline]
-pub fn to_str_hex(num: f32) -> ~str {
+pub fn to_str_hex(num: f32) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 16u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
     r
@@ -268,7 +269,7 @@ pub fn to_str_hex(num: f32) -> ~str {
 /// * num - The float value
 /// * radix - The base to use
 #[inline]
-pub fn to_str_radix_special(num: f32, rdx: uint) -> (~str, bool) {
+pub fn to_str_radix_special(num: f32, rdx: uint) -> (StrBuf, bool) {
     strconv::float_to_str_common(num, rdx, true,
                            strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false)
 }
@@ -281,7 +282,7 @@ pub fn to_str_radix_special(num: f32, rdx: uint) -> (~str, bool) {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
-pub fn to_str_exact(num: f32, dig: uint) -> ~str {
+pub fn to_str_exact(num: f32, dig: uint) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpNone, false);
     r
@@ -295,7 +296,7 @@ pub fn to_str_exact(num: f32, dig: uint) -> ~str {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
-pub fn to_str_digits(num: f32, dig: uint) -> ~str {
+pub fn to_str_digits(num: f32, dig: uint) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpNone, false);
     r
@@ -310,7 +311,7 @@ pub fn to_str_digits(num: f32, dig: uint) -> ~str {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
-pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> ~str {
+pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpDec, upper);
     r
@@ -325,7 +326,7 @@ pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> ~str {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
-pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> ~str {
+pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpDec, upper);
     r
@@ -345,7 +346,7 @@ impl num::ToStrRadix for f32 {
     /// possible misinterpretation of the result at higher bases. If those values
     /// are expected, use `to_str_radix_special()` instead.
     #[inline]
-    fn to_str_radix(&self, rdx: uint) -> ~str {
+    fn to_str_radix(&self, rdx: uint) -> StrBuf {
         let (r, special) = strconv::float_to_str_common(
             *self, rdx, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
         if special { fail!("number has a special value, \

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -19,6 +19,7 @@ use intrinsics;
 use libc::c_int;
 use num::strconv;
 use num;
+use strbuf::StrBuf;
 
 pub use core::f64::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON, MIN_VALUE};
 pub use core::f64::{MIN_POS_VALUE, MAX_VALUE, MIN_EXP, MAX_EXP, MIN_10_EXP};
@@ -250,7 +251,7 @@ impl FloatMath for f64 {
 ///
 /// * num - The float value
 #[inline]
-pub fn to_str(num: f64) -> ~str {
+pub fn to_str(num: f64) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
     r
@@ -262,7 +263,7 @@ pub fn to_str(num: f64) -> ~str {
 ///
 /// * num - The float value
 #[inline]
-pub fn to_str_hex(num: f64) -> ~str {
+pub fn to_str_hex(num: f64) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 16u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
     r
@@ -276,7 +277,7 @@ pub fn to_str_hex(num: f64) -> ~str {
 /// * num - The float value
 /// * radix - The base to use
 #[inline]
-pub fn to_str_radix_special(num: f64, rdx: uint) -> (~str, bool) {
+pub fn to_str_radix_special(num: f64, rdx: uint) -> (StrBuf, bool) {
     strconv::float_to_str_common(num, rdx, true,
                            strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false)
 }
@@ -289,7 +290,7 @@ pub fn to_str_radix_special(num: f64, rdx: uint) -> (~str, bool) {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
-pub fn to_str_exact(num: f64, dig: uint) -> ~str {
+pub fn to_str_exact(num: f64, dig: uint) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpNone, false);
     r
@@ -303,7 +304,7 @@ pub fn to_str_exact(num: f64, dig: uint) -> ~str {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
-pub fn to_str_digits(num: f64, dig: uint) -> ~str {
+pub fn to_str_digits(num: f64, dig: uint) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpNone, false);
     r
@@ -318,7 +319,7 @@ pub fn to_str_digits(num: f64, dig: uint) -> ~str {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
-pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> ~str {
+pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpDec, upper);
     r
@@ -333,7 +334,7 @@ pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> ~str {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
-pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> ~str {
+pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> StrBuf {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpDec, upper);
     r
@@ -353,7 +354,7 @@ impl num::ToStrRadix for f64 {
     /// possible misinterpretation of the result at higher bases. If those values
     /// are expected, use `to_str_radix_special()` instead.
     #[inline]
-    fn to_str_radix(&self, rdx: uint) -> ~str {
+    fn to_str_radix(&self, rdx: uint) -> StrBuf {
         let (r, special) = strconv::float_to_str_common(
             *self, rdx, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
         if special { fail!("number has a special value, \

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::i16::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::i32::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::i64::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::i8::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::int::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -77,8 +77,8 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
 impl ToStrRadix for $T {
     /// Convert to a string in a given base.
     #[inline]
-    fn to_str_radix(&self, radix: uint) -> ~str {
-        format!("{}", ::fmt::radix(*self, radix as u8))
+    fn to_str_radix(&self, radix: uint) -> StrBuf {
+        format_strbuf!("{}", ::fmt::radix(*self, radix as u8))
     }
 }
 
@@ -136,39 +136,39 @@ mod tests {
 
     #[test]
     fn test_to_str() {
-        assert_eq!((0 as $T).to_str_radix(10u), "0".to_owned());
-        assert_eq!((1 as $T).to_str_radix(10u), "1".to_owned());
-        assert_eq!((-1 as $T).to_str_radix(10u), "-1".to_owned());
-        assert_eq!((127 as $T).to_str_radix(16u), "7f".to_owned());
-        assert_eq!((100 as $T).to_str_radix(10u), "100".to_owned());
+        assert_eq!((0 as $T).to_str_radix(10u), "0".to_strbuf());
+        assert_eq!((1 as $T).to_str_radix(10u), "1".to_strbuf());
+        assert_eq!((-1 as $T).to_str_radix(10u), "-1".to_strbuf());
+        assert_eq!((127 as $T).to_str_radix(16u), "7f".to_strbuf());
+        assert_eq!((100 as $T).to_str_radix(10u), "100".to_strbuf());
 
     }
 
     #[test]
     fn test_int_to_str_overflow() {
         let mut i8_val: i8 = 127_i8;
-        assert_eq!(i8_val.to_str(), "127".to_owned());
+        assert_eq!(i8_val.to_str(), "127".to_strbuf());
 
         i8_val += 1 as i8;
-        assert_eq!(i8_val.to_str(), "-128".to_owned());
+        assert_eq!(i8_val.to_str(), "-128".to_strbuf());
 
         let mut i16_val: i16 = 32_767_i16;
-        assert_eq!(i16_val.to_str(), "32767".to_owned());
+        assert_eq!(i16_val.to_str(), "32767".to_strbuf());
 
         i16_val += 1 as i16;
-        assert_eq!(i16_val.to_str(), "-32768".to_owned());
+        assert_eq!(i16_val.to_str(), "-32768".to_strbuf());
 
         let mut i32_val: i32 = 2_147_483_647_i32;
-        assert_eq!(i32_val.to_str(), "2147483647".to_owned());
+        assert_eq!(i32_val.to_str(), "2147483647".to_strbuf());
 
         i32_val += 1 as i32;
-        assert_eq!(i32_val.to_str(), "-2147483648".to_owned());
+        assert_eq!(i32_val.to_str(), "-2147483648".to_strbuf());
 
         let mut i64_val: i64 = 9_223_372_036_854_775_807_i64;
-        assert_eq!(i64_val.to_str(), "9223372036854775807".to_owned());
+        assert_eq!(i64_val.to_str(), "9223372036854775807".to_strbuf());
 
         i64_val += 1 as i64;
-        assert_eq!(i64_val.to_str(), "-9223372036854775808".to_owned());
+        assert_eq!(i64_val.to_str(), "-9223372036854775808".to_strbuf());
     }
 
     #[test]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -15,7 +15,8 @@
 
 #![allow(missing_doc)]
 
-use option::{Option};
+use option::Option;
+use strbuf::StrBuf;
 
 #[cfg(test)] use fmt::Show;
 
@@ -111,7 +112,7 @@ pub trait FloatMath: Float {
 
 /// A generic trait for converting a value to a string with a radix (base)
 pub trait ToStrRadix {
-    fn to_str_radix(&self, radix: uint) -> ~str;
+    fn to_str_radix(&self, radix: uint) -> StrBuf;
 }
 
 /// A generic trait for converting a string with a radix (base) to a value

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -19,9 +19,9 @@ use num::{Float, FPNaN, FPInfinite, ToPrimitive};
 use num;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 use option::{None, Option, Some};
-use slice::{CloneableVector, ImmutableVector, MutableVector};
+use slice::{ImmutableVector, MutableVector};
 use std::cmp::{Ord, Eq};
-use str::{StrAllocating, StrSlice};
+use str::StrSlice;
 use strbuf::StrBuf;
 use vec::Vec;
 
@@ -496,10 +496,10 @@ pub fn float_to_str_common<T:NumCast+Zero+One+Eq+Ord+NumStrConv+Float+
                              Div<T,T>+Neg<T>+Rem<T,T>+Mul<T,T>>(
         num: T, radix: uint, negative_zero: bool,
         sign: SignFormat, digits: SignificantDigits, exp_format: ExponentFormat, exp_capital: bool
-        ) -> (~str, bool) {
+        ) -> (StrBuf, bool) {
     let (bytes, special) = float_to_str_bytes_common(num, radix,
                                negative_zero, sign, digits, exp_format, exp_capital);
-    (StrBuf::from_utf8(bytes).unwrap().into_owned(), special)
+    (StrBuf::from_utf8(bytes).unwrap(), special)
 }
 
 // Some constants for from_str_bytes_common's input validation,

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::u16::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::u32::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::u64::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::u8::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -15,6 +15,7 @@ use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
 use slice::ImmutableVector;
+use strbuf::StrBuf;
 
 pub use core::uint::{BITS, BYTES, MIN, MAX};
 

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -78,8 +78,8 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
 impl ToStrRadix for $T {
     /// Convert to a string in a given base.
     #[inline]
-    fn to_str_radix(&self, radix: uint) -> ~str {
-        format!("{}", ::fmt::radix(*self, radix as u8))
+    fn to_str_radix(&self, radix: uint) -> StrBuf {
+        format_strbuf!("{}", ::fmt::radix(*self, radix as u8))
     }
 }
 
@@ -94,13 +94,13 @@ mod tests {
 
     #[test]
     pub fn test_to_str() {
-        assert_eq!((0 as $T).to_str_radix(10u), "0".to_owned());
-        assert_eq!((1 as $T).to_str_radix(10u), "1".to_owned());
-        assert_eq!((2 as $T).to_str_radix(10u), "2".to_owned());
-        assert_eq!((11 as $T).to_str_radix(10u), "11".to_owned());
-        assert_eq!((11 as $T).to_str_radix(16u), "b".to_owned());
-        assert_eq!((255 as $T).to_str_radix(16u), "ff".to_owned());
-        assert_eq!((0xff as $T).to_str_radix(10u), "255".to_owned());
+        assert_eq!((0 as $T).to_str_radix(10u), "0".to_strbuf());
+        assert_eq!((1 as $T).to_str_radix(10u), "1".to_strbuf());
+        assert_eq!((2 as $T).to_str_radix(10u), "2".to_strbuf());
+        assert_eq!((11 as $T).to_str_radix(10u), "11".to_strbuf());
+        assert_eq!((11 as $T).to_str_radix(16u), "b".to_strbuf());
+        assert_eq!((255 as $T).to_str_radix(16u), "ff".to_strbuf());
+        assert_eq!((0xff as $T).to_str_radix(10u), "255".to_strbuf());
     }
 
     #[test]
@@ -133,28 +133,28 @@ mod tests {
     #[test]
     fn test_uint_to_str_overflow() {
         let mut u8_val: u8 = 255_u8;
-        assert_eq!(u8_val.to_str(), "255".to_owned());
+        assert_eq!(u8_val.to_str(), "255".to_strbuf());
 
         u8_val += 1 as u8;
-        assert_eq!(u8_val.to_str(), "0".to_owned());
+        assert_eq!(u8_val.to_str(), "0".to_strbuf());
 
         let mut u16_val: u16 = 65_535_u16;
-        assert_eq!(u16_val.to_str(), "65535".to_owned());
+        assert_eq!(u16_val.to_str(), "65535".to_strbuf());
 
         u16_val += 1 as u16;
-        assert_eq!(u16_val.to_str(), "0".to_owned());
+        assert_eq!(u16_val.to_str(), "0".to_strbuf());
 
         let mut u32_val: u32 = 4_294_967_295_u32;
-        assert_eq!(u32_val.to_str(), "4294967295".to_owned());
+        assert_eq!(u32_val.to_str(), "4294967295".to_strbuf());
 
         u32_val += 1 as u32;
-        assert_eq!(u32_val.to_str(), "0".to_owned());
+        assert_eq!(u32_val.to_str(), "0".to_strbuf());
 
         let mut u64_val: u64 = 18_446_744_073_709_551_615_u64;
-        assert_eq!(u64_val.to_str(), "18446744073709551615".to_owned());
+        assert_eq!(u64_val.to_str(), "18446744073709551615".to_strbuf());
 
         u64_val += 1 as u64;
-        assert_eq!(u64_val.to_str(), "0".to_owned());
+        assert_eq!(u64_val.to_str(), "0".to_strbuf());
     }
 
     #[test]

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -519,26 +519,10 @@ impl<'a> BytesContainer for &'a str {
     fn is_str(_: Option<&'a str>) -> bool { true }
 }
 
-impl BytesContainer for ~str {
-    #[inline]
-    fn container_as_bytes<'a>(&'a self) -> &'a [u8] {
-        self.as_bytes()
-    }
-    #[inline]
-    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
-        Some(self.as_slice())
-    }
-    #[inline]
-    fn is_str(_: Option<~str>) -> bool { true }
-}
 impl BytesContainer for StrBuf {
     #[inline]
     fn container_as_bytes<'a>(&'a self) -> &'a [u8] {
         self.as_bytes()
-    }
-    #[inline]
-    fn container_into_owned_bytes(self) -> Vec<u8> {
-        self.into_bytes()
     }
     #[inline]
     fn container_as_str<'a>(&'a self) -> Option<&'a str> {

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -781,7 +781,7 @@ mod tests {
         t!(s: "a/b/c", ["d", "e"], "a/b/c/d/e");
         t!(s: "a/b/c", ["d", "/e"], "/e");
         t!(s: "a/b/c", ["d", "/e", "f"], "/e/f");
-        t!(s: "a/b/c", ["d".to_owned(), "e".to_owned()], "a/b/c/d/e");
+        t!(s: "a/b/c", ["d".to_strbuf(), "e".to_strbuf()], "a/b/c/d/e");
         t!(v: b!("a/b/c"), [b!("d"), b!("e")], b!("a/b/c/d/e"));
         t!(v: b!("a/b/c"), [b!("d"), b!("/e"), b!("f")], b!("/e/f"));
         t!(v: b!("a/b/c"), [Vec::from_slice(b!("d")), Vec::from_slice(b!("e"))], b!("a/b/c/d/e"));
@@ -886,7 +886,7 @@ mod tests {
         t!(s: "a/b/c", ["d", "e"], "a/b/c/d/e");
         t!(s: "a/b/c", ["..", "d"], "a/b/d");
         t!(s: "a/b/c", ["d", "/e", "f"], "/e/f");
-        t!(s: "a/b/c", ["d".to_owned(), "e".to_owned()], "a/b/c/d/e");
+        t!(s: "a/b/c", ["d".to_strbuf(), "e".to_strbuf()], "a/b/c/d/e");
         t!(v: b!("a/b/c"), [b!("d"), b!("e")], b!("a/b/c/d/e"));
         t!(v: b!("a/b/c"), [Vec::from_slice(b!("d")), Vec::from_slice(b!("e"))], b!("a/b/c/d/e"));
     }

--- a/src/libstd/rt/env.rs
+++ b/src/libstd/rt/env.rs
@@ -13,6 +13,7 @@
 use from_str::from_str;
 use option::{Some, None, Expect};
 use os;
+use str::Str;
 
 // Note that these are all accessed without any synchronization.
 // They are expected to be initialized once then left alone.
@@ -25,15 +26,19 @@ static mut DEBUG_BORROW: bool = false;
 pub fn init() {
     unsafe {
         match os::getenv("RUST_MIN_STACK") {
-            Some(s) => match from_str(s) {
+            Some(s) => match from_str(s.as_slice()) {
                 Some(i) => MIN_STACK = i,
                 None => ()
             },
             None => ()
         }
         match os::getenv("RUST_MAX_CACHED_STACKS") {
-            Some(max) => MAX_CACHED_STACKS = from_str(max).expect("expected positive integer in \
-                                                                   RUST_MAX_CACHED_STACKS"),
+            Some(max) => {
+                MAX_CACHED_STACKS =
+                    from_str(max.as_slice()).expect("expected positive \
+                                                     integer in \
+                                                     RUST_MAX_CACHED_STACKS")
+            }
             None => ()
         }
         match os::getenv("RUST_DEBUG_BORROW") {

--- a/src/libstd/rt/task.rs
+++ b/src/libstd/rt/task.rs
@@ -419,11 +419,11 @@ mod test {
 
     #[test]
     fn tls() {
-        local_data_key!(key: @~str)
-        key.replace(Some(@"data".to_owned()));
+        local_data_key!(key: @StrBuf)
+        key.replace(Some(@"data".to_strbuf()));
         assert_eq!(key.get().unwrap().as_slice(), "data");
-        local_data_key!(key2: @~str)
-        key2.replace(Some(@"data".to_owned()));
+        local_data_key!(key2: @StrBuf)
+        key2.replace(Some(@"data".to_strbuf()));
         assert_eq!(key2.get().unwrap().as_slice(), "data");
     }
 

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -71,6 +71,7 @@ use rt::backtrace;
 use rt::local::Local;
 use rt::task::Task;
 use str::Str;
+use strbuf::StrBuf;
 use task::TaskResult;
 
 use uw = rt::libunwind;
@@ -315,7 +316,7 @@ pub fn begin_unwind_fmt(msg: &fmt::Arguments, file: &'static str, line: uint) ->
     // required with the current scheme, and (b) we don't handle
     // failure + OOM properly anyway (see comment in begin_unwind
     // below).
-    begin_unwind_inner(box fmt::format(msg), file, line)
+    begin_unwind_inner(box fmt::format_strbuf(msg), file, line)
 }
 
 /// This is the entry point of unwinding for fail!() and assert!().
@@ -350,7 +351,7 @@ fn begin_unwind_inner(msg: Box<Any:Send>,
     {
         let msg_s = match msg.as_ref::<&'static str>() {
             Some(s) => *s,
-            None => match msg.as_ref::<~str>() {
+            None => match msg.as_ref::<StrBuf>() {
                 Some(s) => s.as_slice(),
                 None => "Box<Any>",
             }

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -18,7 +18,7 @@ use libc;
 use option::{Some, None, Option};
 use os;
 use result::Ok;
-use str::StrSlice;
+use str::{Str, StrSlice};
 use unstable::running_on_valgrind;
 use slice::ImmutableVector;
 
@@ -72,7 +72,7 @@ pub fn limit_thread_creation_due_to_osx_and_valgrind() -> bool {
 pub fn default_sched_threads() -> uint {
     match os::getenv("RUST_THREADS") {
         Some(nstr) => {
-            let opt_n: Option<uint> = FromStr::from_str(nstr);
+            let opt_n: Option<uint> = FromStr::from_str(nstr.as_slice());
             match opt_n {
                 Some(n) if n > 0 => n,
                 _ => rtabort!("`RUST_THREADS` is `{}`, should be a positive integer", nstr)

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -569,7 +569,9 @@ impl<'a> IntoMaybeOwned<'a> for ~str {
 
 impl<'a> IntoMaybeOwned<'a> for StrBuf {
     #[inline]
-    fn into_maybe_owned(self) -> MaybeOwned<'a> { Owned(self.into_owned()) }
+    fn into_maybe_owned(self) -> MaybeOwned<'a> {
+        Owned(self.into_owned())
+    }
 }
 
 impl<'a> IntoMaybeOwned<'a> for &'a str {
@@ -657,7 +659,7 @@ impl<'a, H: Writer> ::hash::Hash<H> for MaybeOwned<'a> {
     fn hash(&self, hasher: &mut H) {
         match *self {
             Slice(s) => s.hash(hasher),
-            Owned(ref s) => s.hash(hasher),
+            Owned(ref s) => s.as_slice().hash(hasher),
         }
     }
 }
@@ -1085,7 +1087,7 @@ mod tests {
     #[test]
     fn test_concat() {
         fn t(v: &[~str], s: &str) {
-            assert_eq!(v.concat(), s.to_str());
+            assert_eq!(v.concat(), s.to_str().into_owned());
         }
         t(["you".to_owned(), "know".to_owned(), "I'm".to_owned(),
           "no".to_owned(), "good".to_owned()], "youknowI'mnogood");
@@ -1097,7 +1099,7 @@ mod tests {
     #[test]
     fn test_connect() {
         fn t(v: &[~str], sep: &str, s: &str) {
-            assert_eq!(v.connect(sep), s.to_str());
+            assert_eq!(v.connect(sep), s.to_str().into_owned());
         }
         t(["you".to_owned(), "know".to_owned(), "I'm".to_owned(),
            "no".to_owned(), "good".to_owned()],
@@ -1110,7 +1112,7 @@ mod tests {
     #[test]
     fn test_concat_slices() {
         fn t(v: &[&str], s: &str) {
-            assert_eq!(v.concat(), s.to_str());
+            assert_eq!(v.concat(), s.to_str().into_owned());
         }
         t(["you", "know", "I'm", "no", "good"], "youknowI'mnogood");
         let v: &[&str] = [];
@@ -1121,7 +1123,7 @@ mod tests {
     #[test]
     fn test_connect_slices() {
         fn t(v: &[&str], sep: &str, s: &str) {
-            assert_eq!(v.connect(sep), s.to_str());
+            assert_eq!(v.connect(sep), s.to_str().into_owned());
         }
         t(["you", "know", "I'm", "no", "good"],
           " ", "you know I'm no good");
@@ -2176,16 +2178,16 @@ mod tests {
         let s = Slice("abcde");
         assert_eq!(s.len(), 5);
         assert_eq!(s.as_slice(), "abcde");
-        assert_eq!(s.to_str(), "abcde".to_owned());
-        assert_eq!(format!("{}", s), "abcde".to_owned());
+        assert_eq!(s.to_str(), "abcde".to_strbuf());
+        assert_eq!(format_strbuf!("{}", s), "abcde".to_strbuf());
         assert!(s.lt(&Owned("bcdef".to_owned())));
         assert_eq!(Slice(""), Default::default());
 
         let o = Owned("abcde".to_owned());
         assert_eq!(o.len(), 5);
         assert_eq!(o.as_slice(), "abcde");
-        assert_eq!(o.to_str(), "abcde".to_owned());
-        assert_eq!(format!("{}", o), "abcde".to_owned());
+        assert_eq!(o.to_str(), "abcde".to_strbuf());
+        assert_eq!(format_strbuf!("{}", o), "abcde".to_strbuf());
         assert!(o.lt(&Slice("bcdef")));
         assert_eq!(Owned("".to_owned()), Default::default());
 

--- a/src/libstd/strbuf.rs
+++ b/src/libstd/strbuf.rs
@@ -12,6 +12,7 @@
 
 use c_vec::CVec;
 use char::Char;
+use cmp::Equiv;
 use container::{Container, Mutable};
 use fmt;
 use io::Writer;
@@ -334,6 +335,13 @@ impl<H:Writer> ::hash::Hash<H> for StrBuf {
     #[inline]
     fn hash(&self, hasher: &mut H) {
         self.as_slice().hash(hasher)
+    }
+}
+
+impl<'a, S: Str> Equiv<S> for StrBuf {
+    #[inline]
+    fn equiv(&self, other: &S) -> bool {
+        self.as_slice() == other.as_slice()
     }
 }
 

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -51,6 +51,7 @@ use str::{Str, SendStr, IntoMaybeOwned};
 #[cfg(test)] use owned::AnyOwnExt;
 #[cfg(test)] use result;
 #[cfg(test)] use str::StrAllocating;
+#[cfg(test)] use strbuf::StrBuf;
 
 /// Indicates the manner in which a task exited.
 ///
@@ -496,12 +497,12 @@ fn test_try_fail_message_static_str() {
 #[test]
 fn test_try_fail_message_owned_str() {
     match try(proc() {
-        fail!("owned string".to_owned());
+        fail!("owned string".to_strbuf());
     }) {
         Err(e) => {
-            type T = ~str;
+            type T = StrBuf;
             assert!(e.is::<T>());
-            assert_eq!(*e.move::<T>().unwrap(), "owned string".to_owned());
+            assert_eq!(*e.move::<T>().unwrap(), "owned string".to_strbuf());
         }
         Ok(()) => fail!()
     }

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -15,21 +15,24 @@ The `ToStr` trait for converting to strings
 */
 
 use fmt;
+use strbuf::StrBuf;
 
 /// A generic trait for converting a value to a string
 pub trait ToStr {
     /// Converts the value of `self` to an owned string
-    fn to_str(&self) -> ~str;
+    fn to_str(&self) -> StrBuf;
 }
 
 /// Trait for converting a type to a string, consuming it in the process.
 pub trait IntoStr {
     /// Consume and convert to a string.
-    fn into_str(self) -> ~str;
+    fn into_str(self) -> StrBuf;
 }
 
 impl<T: fmt::Show> ToStr for T {
-    fn to_str(&self) -> ~str { format!("{}", *self) }
+    fn to_str(&self) -> StrBuf {
+        format_strbuf!("{}", *self)
+    }
 }
 
 #[cfg(test)]
@@ -39,23 +42,23 @@ mod tests {
 
     #[test]
     fn test_simple_types() {
-        assert_eq!(1i.to_str(), "1".to_owned());
-        assert_eq!((-1i).to_str(), "-1".to_owned());
-        assert_eq!(200u.to_str(), "200".to_owned());
-        assert_eq!(2u8.to_str(), "2".to_owned());
-        assert_eq!(true.to_str(), "true".to_owned());
-        assert_eq!(false.to_str(), "false".to_owned());
-        assert_eq!(().to_str(), "()".to_owned());
-        assert_eq!(("hi".to_owned()).to_str(), "hi".to_owned());
+        assert_eq!(1i.to_str(), "1".to_strbuf());
+        assert_eq!((-1i).to_str(), "-1".to_strbuf());
+        assert_eq!(200u.to_str(), "200".to_strbuf());
+        assert_eq!(2u8.to_str(), "2".to_strbuf());
+        assert_eq!(true.to_str(), "true".to_strbuf());
+        assert_eq!(false.to_str(), "false".to_strbuf());
+        assert_eq!(().to_str(), "()".to_strbuf());
+        assert_eq!(("hi".to_strbuf()).to_str(), "hi".to_strbuf());
     }
 
     #[test]
     fn test_vectors() {
         let x: ~[int] = box [];
-        assert_eq!(x.to_str(), "[]".to_owned());
-        assert_eq!((box [1]).to_str(), "[1]".to_owned());
-        assert_eq!((box [1, 2, 3]).to_str(), "[1, 2, 3]".to_owned());
+        assert_eq!(x.to_str(), "[]".to_strbuf());
+        assert_eq!((box [1]).to_str(), "[1]".to_strbuf());
+        assert_eq!((box [1, 2, 3]).to_str(), "[1, 2, 3]".to_strbuf());
         assert!((box [box [], box [1], box [1, 1]]).to_str() ==
-               "[[], [1], [1, 1]]".to_owned());
+               "[[], [1], [1, 1]]".to_strbuf());
     }
 }

--- a/src/libstd/unstable/dynamic_lib.rs
+++ b/src/libstd/unstable/dynamic_lib.rs
@@ -27,6 +27,7 @@ use path;
 use result::*;
 use slice::Vector;
 use str;
+use strbuf::StrBuf;
 use vec::Vec;
 
 pub struct DynamicLibrary { handle: *u8}
@@ -56,7 +57,7 @@ impl DynamicLibrary {
     /// Lazily open a dynamic library. When passed None it gives a
     /// handle to the calling process
     pub fn open<T: ToCStr>(filename: Option<T>)
-                        -> Result<DynamicLibrary, ~str> {
+                        -> Result<DynamicLibrary, StrBuf> {
         unsafe {
             let mut filename = filename;
             let maybe_library = dl::check_for_errors_in(|| {
@@ -95,7 +96,7 @@ impl DynamicLibrary {
     }
 
     /// Access the value at the symbol of the dynamic library
-    pub unsafe fn symbol<T>(&self, symbol: &str) -> Result<T, ~str> {
+    pub unsafe fn symbol<T>(&self, symbol: &str) -> Result<T, StrBuf> {
         // This function should have a lifetime constraint of 'a on
         // T but that feature is still unimplemented
 
@@ -168,11 +169,12 @@ mod test {
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
 pub mod dl {
-    use c_str::ToCStr;
+    use c_str::{CString, ToCStr};
     use libc;
     use ptr;
-    use str;
     use result::*;
+    use str::StrAllocating;
+    use strbuf::StrBuf;
 
     pub unsafe fn open_external<T: ToCStr>(filename: T) -> *u8 {
         filename.with_c_str(|raw_name| {
@@ -184,7 +186,7 @@ pub mod dl {
         dlopen(ptr::null(), Lazy as libc::c_int) as *u8
     }
 
-    pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, ~str> {
+    pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, StrBuf> {
         use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
         static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
         unsafe {
@@ -199,7 +201,9 @@ pub mod dl {
             let ret = if ptr::null() == last_error {
                 Ok(result)
             } else {
-                Err(str::raw::from_c_str(last_error))
+                Err(CString::new(last_error, false).as_str()
+                                                   .unwrap()
+                                                   .to_strbuf())
             };
 
             ret
@@ -253,7 +257,7 @@ pub mod dl {
         handle as *u8
     }
 
-    pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, ~str> {
+    pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, StrBuf> {
         unsafe {
             SetLastError(0);
 

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -671,7 +671,7 @@ impl<T> Vec<T> {
     /// ```rust
     /// let v = vec!("a".to_owned(), "b".to_owned());
     /// for s in v.move_iter() {
-    ///     // s has type ~str, not &~str
+    ///     // s has type StrBuf, not &StrBuf
     ///     println!("{}", s);
     /// }
     /// ```
@@ -1847,9 +1847,9 @@ mod tests {
         let b: ~[u8] = FromVec::from_vec(a);
         assert_eq!(b.as_slice(), &[]);
 
-        let a = vec!["one".to_owned(), "two".to_owned()];
-        let b: ~[~str] = FromVec::from_vec(a);
-        assert_eq!(b.as_slice(), &["one".to_owned(), "two".to_owned()]);
+        let a = vec!["one".to_strbuf(), "two".to_strbuf()];
+        let b: ~[StrBuf] = FromVec::from_vec(a);
+        assert_eq!(b.as_slice(), &["one".to_strbuf(), "two".to_strbuf()]);
 
         struct Foo {
             x: uint,

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -208,7 +208,8 @@ pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     // Append an input operand, with the form of ("0", expr)
     // that links to an output operand.
     for &(i, out) in read_write_operands.iter() {
-        inputs.push((token::intern_and_get_ident(i.to_str()), out));
+        inputs.push((token::intern_and_get_ident(i.to_str().as_slice()),
+                                                 out));
     }
 
     MacExpr::new(@ast::Expr {

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -53,7 +53,7 @@ pub fn expand_option_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                                    cx.ident_of("Some")),
                               vec!(cx.expr_str(sp,
                                                token::intern_and_get_ident(
-                                          s))))
+                                          s.as_slice()))))
       }
     };
     MacExpr::new(e)
@@ -99,7 +99,7 @@ pub fn expand_env(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             cx.span_err(sp, msg.get());
             cx.expr_uint(sp, 0)
         }
-        Some(s) => cx.expr_str(sp, token::intern_and_get_ident(s))
+        Some(s) => cx.expr_str(sp, token::intern_and_get_ident(s.as_slice()))
     };
     MacExpr::new(e)
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -529,7 +529,7 @@ fn load_extern_macros(krate: &ast::ViewItem, fld: &mut MacroExpander) {
         // this is fatal: there are almost certainly macros we need
         // inside this crate, so continue would spew "macro undefined"
         // errors
-        Err(err) => fld.cx.span_fatal(krate.span, err)
+        Err(err) => fld.cx.span_fatal(krate.span, err.as_slice())
     };
 
     unsafe {
@@ -537,7 +537,7 @@ fn load_extern_macros(krate: &ast::ViewItem, fld: &mut MacroExpander) {
             match lib.symbol(registrar.as_slice()) {
                 Ok(registrar) => registrar,
                 // again fatal if we can't register macros
-                Err(err) => fld.cx.span_fatal(krate.span, err)
+                Err(err) => fld.cx.span_fatal(krate.span, err.as_slice())
             };
         registrar(|name, extension| {
             let extension = match extension {

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -480,7 +480,7 @@ impl<'a, 'b> Context<'a, 'b> {
                             }).collect();
                         let (lr, selarg) = match arm.selector {
                             parse::Keyword(t) => {
-                                let p = self.rtpath(t.to_str());
+                                let p = self.rtpath(t.to_str().as_slice());
                                 let p = self.ecx.path_global(sp, p);
                                 (self.rtpath("Keyword"), self.ecx.expr_path(p))
                             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -623,7 +623,7 @@ impl<'a> State<'a> {
             }
             ast::ItemForeignMod(ref nmod) => {
                 try!(self.head("extern"));
-                try!(self.word_nbsp(nmod.abi.to_str()));
+                try!(self.word_nbsp(nmod.abi.to_str().as_slice()));
                 try!(self.bopen());
                 try!(self.print_foreign_mod(nmod, item.attrs.as_slice()));
                 try!(self.bclose(item.span));
@@ -2389,7 +2389,7 @@ impl<'a> State<'a> {
             Some(abi::Rust) => Ok(()),
             Some(abi) => {
                 try!(self.word_nbsp("extern"));
-                self.word_nbsp(abi.to_str())
+                self.word_nbsp(abi.to_str().as_slice())
             }
             None => Ok(())
         }
@@ -2400,7 +2400,7 @@ impl<'a> State<'a> {
         match opt_abi {
             Some(abi) => {
                 try!(self.word_nbsp("extern"));
-                self.word_nbsp(abi.to_str())
+                self.word_nbsp(abi.to_str().as_slice())
             }
             None => Ok(())
         }
@@ -2416,7 +2416,7 @@ impl<'a> State<'a> {
 
         if abi != abi::Rust {
             try!(self.word_nbsp("extern"));
-            try!(self.word_nbsp(abi.to_str()));
+            try!(self.word_nbsp(abi.to_str().as_slice()));
         }
 
         word(&mut self.s, "fn")

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -36,11 +36,11 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
                 dirs_to_search.push(homedir.unwrap().join(".terminfo"))
             }
             match getenv("TERMINFO_DIRS") {
-                Some(dirs) => for i in dirs.split(':') {
+                Some(dirs) => for i in dirs.as_slice().split(':') {
                     if i == "" {
                         dirs_to_search.push(Path::new("/usr/share/terminfo"));
                     } else {
-                        dirs_to_search.push(Path::new(i.to_owned()));
+                        dirs_to_search.push(Path::new(i.to_strbuf()));
                     }
                 },
                 // Found nothing in TERMINFO_DIRS, use the default paths:

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -921,7 +921,7 @@ fn get_concurrency() -> uint {
     use std::rt;
     match os::getenv("RUST_TEST_TASKS") {
         Some(s) => {
-            let opt_n: Option<uint> = FromStr::from_str(s);
+            let opt_n: Option<uint> = FromStr::from_str(s.as_slice());
             match opt_n {
                 Some(n) if n > 0 => n,
                 _ => fail!("RUST_TEST_TASKS is `{}`, should be a positive integer.", s)

--- a/src/test/run-fail/assert-macro-owned.rs
+++ b/src/test/run-fail/assert-macro-owned.rs
@@ -11,5 +11,5 @@
 // error-pattern:failed at 'test-assert-owned'
 
 fn main() {
-    assert!(false, "test-assert-owned".to_owned());
+    assert!(false, "test-assert-owned".to_strbuf());
 }

--- a/src/test/run-fail/explicit-fail-msg.rs
+++ b/src/test/run-fail/explicit-fail-msg.rs
@@ -15,5 +15,5 @@
 fn main() {
     let mut a = 1;
     if 1 == 1 { a = 2; }
-    fail!("woooo".to_owned() + "o");
+    fail!(format_strbuf!("woooo{}", "o"));
 }

--- a/src/test/run-fail/unwind-misc-1.rs
+++ b/src/test/run-fail/unwind-misc-1.rs
@@ -22,9 +22,9 @@ fn main() {
     let mut map = collections::HashMap::new();
     let mut arr = Vec::new();
     for _i in range(0u, 10u) {
-        arr.push(@"key stuff".to_owned());
+        arr.push(@"key stuff".to_strbuf());
         map.insert(arr.clone(),
-                   arr.clone().append([@"value stuff".to_owned()]));
+                   arr.clone().append([@"value stuff".to_strbuf()]));
         if arr.len() == 5 {
             fail!();
         }

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -92,6 +92,6 @@ fn main() {
     } else if args.len() >= 2 && args[1].as_slice() == "double-fail" {
         double();
     } else {
-        runtest(args[0]);
+        runtest(args[0].as_slice());
     }
 }

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -46,6 +46,6 @@ fn main() {
         info!("info");
     });
     let s = r.read_to_str().unwrap();
-    assert!(s.contains("info"));
-    assert!(!s.contains("debug"));
+    assert!(s.as_slice().contains("info"));
+    assert!(!s.as_slice().contains("debug"));
 }

--- a/src/test/run-pass/cleanup-shortcircuit.rs
+++ b/src/test/run-pass/cleanup-shortcircuit.rs
@@ -32,7 +32,7 @@ pub fn main() {
     // expression was never evaluated, we wound up trying to clean
     // uninitialized memory.
 
-    if args.len() >= 2 && args[1] == "signal".to_owned() {
+    if args.len() >= 2 && args[1].as_slice() == "signal" {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }
     }

--- a/src/test/run-pass/deriving-show-2.rs
+++ b/src/test/run-pass/deriving-show-2.rs
@@ -41,15 +41,15 @@ impl fmt::Show for Custom {
 }
 
 pub fn main() {
-    assert_eq!(B1.to_str(), "B1".to_owned());
-    assert_eq!(B2.to_str(), "B2".to_owned());
-    assert_eq!(C1(3).to_str(), "C1(3)".to_owned());
-    assert_eq!(C2(B2).to_str(), "C2(B2)".to_owned());
-    assert_eq!(D1{ a: 2 }.to_str(), "D1 { a: 2 }".to_owned());
-    assert_eq!(E.to_str(), "E".to_owned());
-    assert_eq!(F(3).to_str(), "F(3)".to_owned());
-    assert_eq!(G(3, 4).to_str(), "G(3, 4)".to_owned());
-    assert_eq!(G(3, 4).to_str(), "G(3, 4)".to_owned());
-    assert_eq!(I{ a: 2, b: 4 }.to_str(), "I { a: 2, b: 4 }".to_owned());
-    assert_eq!(J(Custom).to_str(), "J(yay)".to_owned());
+    assert_eq!(B1.to_str(), "B1".to_strbuf());
+    assert_eq!(B2.to_str(), "B2".to_strbuf());
+    assert_eq!(C1(3).to_str(), "C1(3)".to_strbuf());
+    assert_eq!(C2(B2).to_str(), "C2(B2)".to_strbuf());
+    assert_eq!(D1{ a: 2 }.to_str(), "D1 { a: 2 }".to_strbuf());
+    assert_eq!(E.to_str(), "E".to_strbuf());
+    assert_eq!(F(3).to_str(), "F(3)".to_strbuf());
+    assert_eq!(G(3, 4).to_str(), "G(3, 4)".to_strbuf());
+    assert_eq!(G(3, 4).to_str(), "G(3, 4)".to_strbuf());
+    assert_eq!(I{ a: 2, b: 4 }.to_str(), "I { a: 2, b: 4 }".to_strbuf());
+    assert_eq!(J(Custom).to_str(), "J(yay)".to_strbuf());
 }

--- a/src/test/run-pass/exec-env.rs
+++ b/src/test/run-pass/exec-env.rs
@@ -13,5 +13,5 @@
 use std::os;
 
 pub fn main() {
-    assert_eq!(os::getenv("TEST_EXEC_ENV"), Some("22".to_owned()));
+    assert_eq!(os::getenv("TEST_EXEC_ENV"), Some("22".to_strbuf()));
 }

--- a/src/test/run-pass/exponential-notation.rs
+++ b/src/test/run-pass/exponential-notation.rs
@@ -13,7 +13,7 @@
 use s = std::num::strconv;
 use to_str = std::num::strconv::float_to_str_common;
 
-macro_rules! t(($a:expr, $b:expr) => { { let (r, _) = $a; assert_eq!(r, $b.to_owned()) } })
+macro_rules! t(($a:expr, $b:expr) => { { let (r, _) = $a; assert_eq!(r, $b.to_strbuf()) } })
 
 pub fn main() {
     // Basic usage

--- a/src/test/run-pass/fixed_length_vec_glue.rs
+++ b/src/test/run-pass/fixed_length_vec_glue.rs
@@ -17,5 +17,5 @@ pub fn main() {
     let arr = [1,2,3];
     let struc = Struc {a: 13u8, b: arr, c: 42};
     let s = repr::repr_to_str(&struc);
-    assert_eq!(s, "Struc{a: 13u8, b: [1, 2, 3], c: 42}".to_owned());
+    assert_eq!(s, "Struc{a: 13u8, b: [1, 2, 3], c: 42}".to_strbuf());
 }

--- a/src/test/run-pass/issue-3559.rs
+++ b/src/test/run-pass/issue-3559.rs
@@ -22,8 +22,8 @@ fn check_strs(actual: &str, expected: &str) -> bool {
 
 pub fn main() {
     let mut table = HashMap::new();
-    table.insert("one".to_owned(), 1);
-    table.insert("two".to_owned(), 2);
-    assert!(check_strs(table.to_str(), "{one: 1, two: 2}") ||
-            check_strs(table.to_str(), "{two: 2, one: 1}"));
+    table.insert("one".to_strbuf(), 1);
+    table.insert("two".to_strbuf(), 2);
+    assert!(check_strs(table.to_str().as_slice(), "{one: 1, two: 2}") ||
+            check_strs(table.to_str().as_slice(), "{two: 2, one: 1}"));
 }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -159,7 +159,7 @@ pub fn check_strs(actual: &str, expected: &str) -> bool {
 
 fn test_ascii_art_ctor() {
     let art = AsciiArt(3, 3, '*');
-    assert!(check_strs(art.to_str(), "...\n...\n..."));
+    assert!(check_strs(art.to_str().as_slice(), "...\n...\n..."));
 }
 
 
@@ -168,7 +168,7 @@ fn test_add_pt() {
     art.add_pt(0, 0);
     art.add_pt(0, -10);
     art.add_pt(1, 2);
-    assert!(check_strs(art.to_str(), "*..\n...\n.*."));
+    assert!(check_strs(art.to_str().as_slice(), "*..\n...\n.*."));
 }
 
 
@@ -176,7 +176,7 @@ fn test_shapes() {
     let mut art = AsciiArt(4, 4, '*');
     art.add_rect(Rect {top_left: Point {x: 0, y: 0}, size: Size {width: 4, height: 4}});
     art.add_point(Point {x: 2, y: 2});
-    assert!(check_strs(art.to_str(), "****\n*..*\n*.**\n****"));
+    assert!(check_strs(art.to_str().as_slice(), "****\n*..*\n*.**\n****"));
 }
 
 pub fn main() {

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -36,12 +36,13 @@ fn main() {
     let blah       = "\u03c0\u042f\u97f3\u00e6\u221e";
 
     let child_name = "child";
-    let child_dir  = "process-spawn-with-unicode-params-" + blah;
+    let child_dir  = format_strbuf!("process-spawn-with-unicode-params-{}",
+                                    blah);
 
     // parameters sent to child / expected to be received from parent
     let arg = blah;
     let cwd = my_dir.join(Path::new(child_dir.clone()));
-    let env = ("RUST_TEST_PROC_SPAWN_UNICODE".to_owned(), blah.to_owned());
+    let env = ("RUST_TEST_PROC_SPAWN_UNICODE".to_strbuf(), blah.to_strbuf());
 
     // am I the parent or the child?
     if my_args.len() == 1 {             // parent

--- a/src/test/run-pass/send_str_hashmap.rs
+++ b/src/test/run-pass/send_str_hashmap.rs
@@ -54,18 +54,8 @@ pub fn main() {
     assert_eq!(map.find_equiv(&("cde")), Some(&c));
     assert_eq!(map.find_equiv(&("def")), Some(&d));
 
-    assert_eq!(map.find_equiv(&("abc".to_owned())), Some(&a));
-    assert_eq!(map.find_equiv(&("bcd".to_owned())), Some(&b));
-    assert_eq!(map.find_equiv(&("cde".to_owned())), Some(&c));
-    assert_eq!(map.find_equiv(&("def".to_owned())), Some(&d));
-
     assert_eq!(map.find_equiv(&Slice("abc")), Some(&a));
     assert_eq!(map.find_equiv(&Slice("bcd")), Some(&b));
     assert_eq!(map.find_equiv(&Slice("cde")), Some(&c));
     assert_eq!(map.find_equiv(&Slice("def")), Some(&d));
-
-    assert_eq!(map.find_equiv(&Owned("abc".to_owned())), Some(&a));
-    assert_eq!(map.find_equiv(&Owned("bcd".to_owned())), Some(&b));
-    assert_eq!(map.find_equiv(&Owned("cde".to_owned())), Some(&c));
-    assert_eq!(map.find_equiv(&Owned("def".to_owned())), Some(&d));
 }

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -26,7 +26,7 @@ use std::io::process::{Command, ExitSignal, ExitStatus};
 pub fn main() {
     let args = os::args();
     let args = args.as_slice();
-    if args.len() >= 2 && args[1] == "signal".to_owned() {
+    if args.len() >= 2 && args[1].as_slice() == "signal" {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }
     } else {

--- a/src/test/run-pass/tcp-connect-timeouts.rs
+++ b/src/test/run-pass/tcp-connect-timeouts.rs
@@ -63,7 +63,7 @@ iotest!(fn eventual_timeout() {
     let (tx1, rx1) = channel();
     let (_tx2, rx2) = channel::<()>();
     native::task::spawn(proc() {
-        let _l = TcpListener::bind(host, port).unwrap().listen();
+        let _l = TcpListener::bind(host.as_slice(), port).unwrap().listen();
         tx1.send(());
         let _ = rx2.recv_opt();
     });
@@ -84,7 +84,7 @@ iotest!(fn timeout_success() {
     let addr = next_test_ip4();
     let host = addr.ip.to_str();
     let port = addr.port;
-    let _l = TcpListener::bind(host, port).unwrap().listen();
+    let _l = TcpListener::bind(host.as_slice(), port).unwrap().listen();
 
     assert!(TcpStream::connect_timeout(addr, 1000).is_ok());
 })

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -64,7 +64,7 @@ fn main() {
         builder.spawn(proc() {
             let host = addr.ip.to_str();
             let port = addr.port;
-            match TcpStream::connect(host, port) {
+            match TcpStream::connect(host.as_slice(), port) {
                 Ok(stream) => {
                     let mut stream = stream;
                     stream.write([1]);

--- a/src/test/run-pass/test-ignore-cfg.rs
+++ b/src/test/run-pass/test-ignore-cfg.rs
@@ -27,10 +27,10 @@ fn checktests() {
     let tests = __test::TESTS;
 
     assert!(
-        tests.iter().any(|t| t.desc.name.to_str() == "shouldignore".to_owned() &&
+        tests.iter().any(|t| t.desc.name.to_str().as_slice() == "shouldignore" &&
                          t.desc.ignore));
 
     assert!(
-        tests.iter().any(|t| t.desc.name.to_str() == "shouldnotignore".to_owned() &&
+        tests.iter().any(|t| t.desc.name.to_str().as_slice() == "shouldnotignore" &&
                          !t.desc.ignore));
 }

--- a/src/test/run-pass/vec-to_str.rs
+++ b/src/test/run-pass/vec-to_str.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 pub fn main() {
-    assert_eq!((vec!(0, 1)).to_str(), "[0, 1]".to_owned());
-    assert_eq!((&[1, 2]).to_str(), "[1, 2]".to_owned());
+    assert_eq!((vec!(0, 1)).to_str(), "[0, 1]".to_strbuf());
+    assert_eq!((&[1, 2]).to_str(), "[1, 2]".to_strbuf());
 
     let foo = vec!(3, 4);
     let bar = &[4, 5];
 
-    assert_eq!(foo.to_str(), "[3, 4]".to_owned());
-    assert_eq!(bar.to_str(), "[4, 5]".to_owned());
+    assert_eq!(foo.to_str(), "[3, 4]".to_strbuf());
+    assert_eq!(bar.to_str(), "[4, 5]".to_strbuf());
 }


### PR DESCRIPTION
r? @alexcrichton
