### PR TITLE
term: Don't run the code example, just compile it

### DIFF
--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ## Example
 //!
-//! ```rust
+//! ```no_run
 //! extern crate term;
 //!
 //! fn main() {


### PR DESCRIPTION
This is blocking a snapshot because apparently the test fails on the bots.
