### PR TITLE
core: Stabilize the mem module

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -216,9 +216,9 @@ impl<T: Send> Unique<T> {
             // we *need* valid pointer.
             assert!(!ptr.is_null());
             // `*ptr` is uninitialized, and `*ptr = value` would attempt to destroy it
-            // move_val_init moves a value into this memory without
+            // `overwrite` moves a value into this memory without
             // attempting to drop the original value.
-            mem::move_val_init(&mut *ptr, value);
+            mem::overwrite(&mut *ptr, value);
             Unique{ptr: ptr}
         }
     }

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -13,7 +13,7 @@
 #![allow(missing_doc)]
 
 use std::clone::Clone;
-use std::mem::{move_val_init, init, replace, swap};
+use std::mem::{overwrite, zeroed, replace, swap};
 use std::slice;
 
 /// A priority queue implemented with a binary heap
@@ -157,26 +157,26 @@ impl<T: TotalOrd> PriorityQueue<T> {
     // compared to using swaps, which involves twice as many moves.
     fn siftup(&mut self, start: uint, mut pos: uint) {
         unsafe {
-            let new = replace(self.data.get_mut(pos), init());
+            let new = replace(self.data.get_mut(pos), zeroed());
 
             while pos > start {
                 let parent = (pos - 1) >> 1;
                 if new > *self.data.get(parent) {
-                    let x = replace(self.data.get_mut(parent), init());
-                    move_val_init(self.data.get_mut(pos), x);
+                    let x = replace(self.data.get_mut(parent), zeroed());
+                    overwrite(self.data.get_mut(pos), x);
                     pos = parent;
                     continue
                 }
                 break
             }
-            move_val_init(self.data.get_mut(pos), new);
+            overwrite(self.data.get_mut(pos), new);
         }
     }
 
     fn siftdown_range(&mut self, mut pos: uint, end: uint) {
         unsafe {
             let start = pos;
-            let new = replace(self.data.get_mut(pos), init());
+            let new = replace(self.data.get_mut(pos), zeroed());
 
             let mut child = 2 * pos + 1;
             while child < end {
@@ -184,13 +184,13 @@ impl<T: TotalOrd> PriorityQueue<T> {
                 if right < end && !(*self.data.get(child) > *self.data.get(right)) {
                     child = right;
                 }
-                let x = replace(self.data.get_mut(child), init());
-                move_val_init(self.data.get_mut(pos), x);
+                let x = replace(self.data.get_mut(child), zeroed());
+                overwrite(self.data.get_mut(pos), x);
                 pos = child;
                 child = 2 * pos + 1;
             }
 
-            move_val_init(self.data.get_mut(pos), new);
+            overwrite(self.data.get_mut(pos), new);
             self.siftup(start, pos);
         }
     }

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -10,7 +10,7 @@
 
 //! Ordered containers with integer keys, implemented as radix tries (`TrieSet` and `TrieMap` types)
 
-use std::mem::init;
+use std::mem::zeroed;
 use std::mem;
 use std::slice::{Items, MutItems};
 use std::slice;
@@ -522,7 +522,8 @@ macro_rules! iterator_impl {
                     remaining_max: 0,
                     length: 0,
                     // ick :( ... at least the compiler will tell us if we screwed up.
-                    stack: [init(), init(), init(), init(), init(), init(), init(), init()]
+                    stack: [zeroed(), zeroed(), zeroed(), zeroed(), zeroed(),
+                            zeroed(), zeroed(), zeroed()]
                 }
             }
 
@@ -532,8 +533,10 @@ macro_rules! iterator_impl {
                     remaining_min: 0,
                     remaining_max: 0,
                     length: 0,
-                    stack: [init(), init(), init(), init(), init(), init(), init(), init(),
-                            init(), init(), init(), init(), init(), init(), init(), init()]
+                    stack: [zeroed(), zeroed(), zeroed(), zeroed(),
+                            zeroed(), zeroed(), zeroed(), zeroed(),
+                            zeroed(), zeroed(), zeroed(), zeroed(),
+                            zeroed(), zeroed(), zeroed(), zeroed()]
                 }
             }
         }

--- a/src/libcore/should_not_exist.rs
+++ b/src/libcore/should_not_exist.rs
@@ -171,15 +171,17 @@ impl<A: Clone> Clone for ~[A] {
         unsafe {
             let ret = alloc(size) as *mut Vec<A>;
 
-            (*ret).fill = len * mem::nonzero_size_of::<A>();
-            (*ret).alloc = len * mem::nonzero_size_of::<A>();
+            let a_size = mem::size_of::<A>();
+            let a_size = if a_size == 0 {1} else {a_size};
+            (*ret).fill = len * a_size;
+            (*ret).alloc = len * a_size;
 
             let mut i = 0;
             let p = &mut (*ret).data as *mut _ as *mut A;
             try_finally(
                 &mut i, (),
                 |i, ()| while *i < len {
-                    mem::move_val_init(
+                    mem::overwrite(
                         &mut(*p.offset(*i as int)),
                         self.unsafe_ref(*i).clone());
                     *i += 1;

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1122,7 +1122,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     unsafe fn init_elem(self, i: uint, val: T) {
-        mem::move_val_init(&mut (*self.as_mut_ptr().offset(i as int)), val);
+        mem::overwrite(&mut (*self.as_mut_ptr().offset(i as int)), val);
     }
 
     #[inline]
@@ -1306,7 +1306,8 @@ macro_rules! iterator {
             #[inline]
             fn size_hint(&self) -> (uint, Option<uint>) {
                 let diff = (self.end as uint) - (self.ptr as uint);
-                let exact = diff / mem::nonzero_size_of::<T>();
+                let size = mem::size_of::<T>();
+                let exact = diff / (if size == 0 {1} else {size});
                 (exact, Some(exact))
             }
         }

--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -118,7 +118,7 @@ impl rtio::RtioFileStream for FileDesc {
 
     fn pread(&mut self, buf: &mut [u8], offset: u64) -> Result<int, IoError> {
         let mut read = 0;
-        let mut overlap: libc::OVERLAPPED = unsafe { mem::init() };
+        let mut overlap: libc::OVERLAPPED = unsafe { mem::zeroed() };
         overlap.Offset = offset as libc::DWORD;
         overlap.OffsetHigh = (offset >> 32) as libc::DWORD;
         let ret = unsafe {
@@ -135,7 +135,7 @@ impl rtio::RtioFileStream for FileDesc {
     fn pwrite(&mut self, buf: &[u8], mut offset: u64) -> Result<(), IoError> {
         let mut cur = buf.as_ptr();
         let mut remaining = buf.len();
-        let mut overlap: libc::OVERLAPPED = unsafe { mem::init() };
+        let mut overlap: libc::OVERLAPPED = unsafe { mem::zeroed() };
         while remaining > 0 {
             overlap.Offset = offset as libc::DWORD;
             overlap.OffsetHigh = (offset >> 32) as libc::DWORD;

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -68,7 +68,7 @@ fn ip_to_inaddr(ip: ip::IpAddr) -> InAddr {
 
 fn addr_to_sockaddr(addr: ip::SocketAddr) -> (libc::sockaddr_storage, uint) {
     unsafe {
-        let storage: libc::sockaddr_storage = mem::init();
+        let storage: libc::sockaddr_storage = mem::zeroed();
         let len = match ip_to_inaddr(addr.ip) {
             InAddr(inaddr) => {
                 let storage: *mut libc::sockaddr_in = mem::transmute(&storage);
@@ -120,7 +120,7 @@ fn setsockopt<T>(fd: sock_t, opt: libc::c_int, val: libc::c_int,
 pub fn getsockopt<T: Copy>(fd: sock_t, opt: libc::c_int,
                            val: libc::c_int) -> IoResult<T> {
     unsafe {
-        let mut slot: T = mem::init();
+        let mut slot: T = mem::zeroed();
         let mut len = mem::size_of::<T>() as libc::socklen_t;
         let ret = c::getsockopt(fd, opt, val,
                                 &mut slot as *mut _ as *mut _,
@@ -152,7 +152,7 @@ fn sockname(fd: sock_t,
                                          *mut libc::socklen_t) -> libc::c_int)
     -> IoResult<ip::SocketAddr>
 {
-    let mut storage: libc::sockaddr_storage = unsafe { mem::init() };
+    let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
     let mut len = mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
     unsafe {
         let storage = &mut storage as *mut libc::sockaddr_storage;
@@ -221,7 +221,7 @@ pub fn init() {
 
         let _guard = LOCK.lock();
         if !INITIALIZED {
-            let mut data: c::WSADATA = mem::init();
+            let mut data: c::WSADATA = mem::zeroed();
             let ret = c::WSAStartup(0x202,      // version 2.2
                                     &mut data);
             assert_eq!(ret, 0);
@@ -497,7 +497,7 @@ impl TcpAcceptor {
             try!(util::await(self.fd(), Some(self.deadline), util::Readable));
         }
         unsafe {
-            let mut storage: libc::sockaddr_storage = mem::init();
+            let mut storage: libc::sockaddr_storage = mem::zeroed();
             let storagep = &mut storage as *mut libc::sockaddr_storage;
             let size = mem::size_of::<libc::sockaddr_storage>();
             let mut size = size as libc::socklen_t;
@@ -622,7 +622,7 @@ impl rtio::RtioSocket for UdpSocket {
 impl rtio::RtioUdpSocket for UdpSocket {
     fn recvfrom(&mut self, buf: &mut [u8]) -> IoResult<(uint, ip::SocketAddr)> {
         let fd = self.fd();
-        let mut storage: libc::sockaddr_storage = unsafe { mem::init() };
+        let mut storage: libc::sockaddr_storage = unsafe { mem::zeroed() };
         let storagep = &mut storage as *mut _ as *mut libc::sockaddr;
         let mut addrlen: libc::socklen_t =
                 mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;

--- a/src/libnative/io/pipe_win32.rs
+++ b/src/libnative/io/pipe_win32.rs
@@ -86,8 +86,8 @@
 
 use libc;
 use std::c_str::CString;
-use std::intrinsics;
 use std::io;
+use std::mem;
 use std::os::win32::as_utf16_p;
 use std::os;
 use std::ptr;
@@ -345,7 +345,7 @@ impl rtio::RtioPipe for UnixStream {
         }
 
         let mut bytes_read = 0;
-        let mut overlapped: libc::OVERLAPPED = unsafe { intrinsics::init() };
+        let mut overlapped: libc::OVERLAPPED = unsafe { mem::zeroed() };
         overlapped.hEvent = self.read.get_ref().handle();
 
         // Pre-flight check to see if the reading half has been closed. This
@@ -417,7 +417,7 @@ impl rtio::RtioPipe for UnixStream {
         }
 
         let mut offset = 0;
-        let mut overlapped: libc::OVERLAPPED = unsafe { intrinsics::init() };
+        let mut overlapped: libc::OVERLAPPED = unsafe { mem::zeroed() };
         overlapped.hEvent = self.write.get_ref().handle();
 
         while offset < buf.len() {
@@ -633,7 +633,7 @@ impl UnixAcceptor {
         // someone on the other end connects. This function can "fail" if a
         // client connects after we created the pipe but before we got down
         // here. Thanks windows.
-        let mut overlapped: libc::OVERLAPPED = unsafe { intrinsics::init() };
+        let mut overlapped: libc::OVERLAPPED = unsafe { mem::zeroed() };
         overlapped.hEvent = self.event.handle();
         if unsafe { libc::ConnectNamedPipe(handle, &mut overlapped) == 0 } {
             let mut err = unsafe { libc::GetLastError() };

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -896,8 +896,8 @@ fn waitpid(pid: pid_t, deadline: u64) -> IoResult<p::ProcessExit> {
     // self-pipe plus the old handler registered (return value of sigaction).
     fn register_sigchld() -> (libc::c_int, c::sigaction) {
         unsafe {
-            let mut old: c::sigaction = mem::init();
-            let mut new: c::sigaction = mem::init();
+            let mut old: c::sigaction = mem::zeroed();
+            let mut new: c::sigaction = mem::zeroed();
             new.sa_handler = sigchld_handler;
             new.sa_flags = c::SA_NOCLDSTOP;
             assert_eq!(c::sigaction(c::SIGCHLD, &new, &mut old), 0);
@@ -916,7 +916,7 @@ fn waitpid(pid: pid_t, deadline: u64) -> IoResult<p::ProcessExit> {
                       messages: Receiver<Req>,
                       (read_fd, old): (libc::c_int, c::sigaction)) {
         util::set_nonblocking(input, true).unwrap();
-        let mut set: c::fd_set = unsafe { mem::init() };
+        let mut set: c::fd_set = unsafe { mem::zeroed() };
         let mut tv: libc::timeval;
         let mut active = Vec::<(libc::pid_t, Sender<p::ProcessExit>, u64)>::new();
         let max = cmp::max(input, read_fd) + 1;

--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -87,17 +87,17 @@ pub enum Req {
 // returns the current time (in milliseconds)
 pub fn now() -> u64 {
     unsafe {
-        let mut now: libc::timeval = mem::init();
+        let mut now: libc::timeval = mem::zeroed();
         assert_eq!(c::gettimeofday(&mut now, ptr::null()), 0);
         return (now.tv_sec as u64) * 1000 + (now.tv_usec as u64) / 1000;
     }
 }
 
 fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
-    let mut set: c::fd_set = unsafe { mem::init() };
+    let mut set: c::fd_set = unsafe { mem::zeroed() };
 
     let mut fd = FileDesc::new(input, true);
-    let mut timeout: libc::timeval = unsafe { mem::init() };
+    let mut timeout: libc::timeval = unsafe { mem::zeroed() };
 
     // active timers are those which are able to be selected upon (and it's a
     // sorted list, and dead timers are those which have expired, but ownership

--- a/src/libnative/io/util.rs
+++ b/src/libnative/io/util.rs
@@ -89,7 +89,7 @@ pub fn connect_timeout(fd: net::sock_t,
         // to use select() with a timeout.
         -1 if os::errno() as int == INPROGRESS as int ||
               os::errno() as int == WOULDBLOCK as int => {
-            let mut set: c::fd_set = unsafe { mem::init() };
+            let mut set: c::fd_set = unsafe { mem::zeroed() };
             c::fd_set(&mut set, fd);
             match await(fd, &mut set, timeout_ms) {
                 0 => Err(timeout("connection timed out")),
@@ -137,13 +137,13 @@ pub fn connect_timeout(fd: net::sock_t,
 
 pub fn await(fd: net::sock_t, deadline: Option<u64>,
              status: SocketStatus) -> IoResult<()> {
-    let mut set: c::fd_set = unsafe { mem::init() };
+    let mut set: c::fd_set = unsafe { mem::zeroed() };
     c::fd_set(&mut set, fd);
     let (read, write) = match status {
         Readable => (&set as *_, ptr::null()),
         Writable => (ptr::null(), &set as *_),
     };
-    let mut tv: libc::timeval = unsafe { mem::init() };
+    let mut tv: libc::timeval = unsafe { mem::zeroed() };
 
     match retry(|| {
         let now = ::io::timer::now();

--- a/src/librustdoc/flock.rs
+++ b/src/librustdoc/flock.rs
@@ -176,7 +176,7 @@ mod imp {
             if handle as uint == libc::INVALID_HANDLE_VALUE as uint {
                 fail!("create file error: {}", os::last_os_error());
             }
-            let mut overlapped: libc::OVERLAPPED = unsafe { mem::init() };
+            let mut overlapped: libc::OVERLAPPED = unsafe { mem::zeroed() };
             let ret = unsafe {
                 LockFileEx(handle, LOCKFILE_EXCLUSIVE_LOCK, 0, 100, 0,
                            &mut overlapped)
@@ -192,7 +192,7 @@ mod imp {
 
     impl Drop for Lock {
         fn drop(&mut self) {
-            let mut overlapped: libc::OVERLAPPED = unsafe { mem::init() };
+            let mut overlapped: libc::OVERLAPPED = unsafe { mem::zeroed() };
             unsafe {
                 UnlockFileEx(self.handle, 0, 100, 0, &mut overlapped);
                 libc::CloseHandle(self.handle);

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -79,7 +79,7 @@ pub fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
 
 fn addr_to_sockaddr(addr: ip::SocketAddr) -> (libc::sockaddr_storage, uint) {
     unsafe {
-        let mut storage: libc::sockaddr_storage = mem::init();
+        let mut storage: libc::sockaddr_storage = mem::zeroed();
         let len = match addr.ip {
             ip::Ipv4Addr(a, b, c, d) => {
                 let storage: &mut libc::sockaddr_in =
@@ -133,7 +133,7 @@ fn socket_name(sk: SocketNameKind,
     };
 
     // Allocate a sockaddr_storage since we don't know if it's ipv4 or ipv6
-    let mut sockaddr: libc::sockaddr_storage = unsafe { mem::init() };
+    let mut sockaddr: libc::sockaddr_storage = unsafe { mem::zeroed() };
     let mut namelen = mem::size_of::<libc::sockaddr_storage>() as c_int;
 
     let sockaddr_p = &mut sockaddr as *mut libc::sockaddr_storage;

--- a/src/libstd/unstable/mutex.rs
+++ b/src/libstd/unstable/mutex.rs
@@ -390,8 +390,8 @@ mod imp {
     impl Mutex {
         pub unsafe fn new() -> Mutex {
             let m = Mutex {
-                lock: Unsafe::new(mem::init()),
-                cond: Unsafe::new(mem::init()),
+                lock: Unsafe::new(mem::zeroed()),
+                cond: Unsafe::new(mem::zeroed()),
             };
 
             pthread_mutex_init(m.lock.get(), 0 as *libc::c_void);

--- a/src/test/run-pass/type-use-i1-versus-i8.rs
+++ b/src/test/run-pass/type-use-i1-versus-i8.rs
@@ -14,6 +14,6 @@ pub fn main() {
     unsafe {
         let mut x: bool = false;
         // this line breaks it
-        mem::move_val_init(&mut x, false);
+        mem::overwrite(&mut x, false);
     }
 }


### PR DESCRIPTION
Excluding the functions inherited from the cast module last week (with marked
stability levels), these functions received the following treatment.
- size_of - this method has become #[stable]
- nonzero_size_of/nonzero_size_of_val - these methods have been removed
- min_align_of - this method is now #[stable]
- pref_align_of - this method has been renamed without the
  `pref_` prefix, and it is the "default alignment" now. This decision is in line
  with what clang does (see url linked in comment on function). This function
  is now #[stable].
- init - renamed to zeroed and marked #[stable]
- uninit - marked #[stable]
- move_val_init - renamed to overwrite and marked #[stable]
- {from,to}_{be,le}{16,32,64} - all functions marked #[stable]
- swap/replace/drop - marked #[stable]
- size_of_val/min_align_of_val/align_of_val - these functions are marked
  #[unstable], but will continue to exist in some form. Concerns have been
  raised about their `_val` prefix.
