### PR TITLE
[WIP] middle/check_const: CheckItemRecursion should only recurse into NodeItems

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -245,7 +245,10 @@ impl<'a> Visitor<()> for CheckItemRecursionVisitor<'a> {
                 match self.def_map.borrow().find(&e.id) {
                     Some(&DefStatic(def_id, _)) if
                             ast_util::is_local(def_id) => {
-                        self.visit_item(self.ast_map.expect_item(def_id.node), ());
+                        match self.ast_map.get(def_id.node) {
+                            ast_map::NodeItem(item) => self.visit_item(item, ()),
+                            _ => {}
+                        }
                     }
                     _ => ()
                 }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1987,6 +1987,7 @@ fn exported_name(ccx: &CrateContext, id: ast::NodeId,
 
 pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
     debug!("get_item_val(id=`{:?}`)", id);
+    debug!("get_item_val {}", ast_map::node_id_to_str(&ccx.tcx.map, id));
 
     match ccx.item_vals.borrow().find_copy(&id) {
         Some(v) => return v,

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -179,6 +179,12 @@ pub fn get_const_val(cx: &CrateContext,
                         trans_const(cx, ast::MutImmutable, def_id.node),
                     _ => {}
                 },
+            ast_map::NodeForeignItem(ref item) =>
+                match item.node {
+                    ast::ForeignItemStatic(_, false) =>
+                        trans_const(cx, ast::MutImmutable, def_id.node),
+                    _ => {}
+                },
             _ => {}
         }
     }

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -17,7 +17,6 @@ use lib::llvm::{IntEQ, IntNE, IntUGT, IntUGE, IntULT, IntULE, IntSGT, IntSGE, In
 
 use metadata::csearch;
 use middle::const_eval;
-use middle::def;
 use middle::trans::adt;
 use middle::trans::base;
 use middle::trans::base::push_ctxt;
@@ -632,7 +631,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
 
             let opt_def = cx.tcx().def_map.borrow().find_copy(&e.id);
             match opt_def {
-                Some(def::DefFn(def_id, _fn_style)) => {
+                Some(ast::DefFn(def_id, _fn_style)) => {
                     if !ast_util::is_local(def_id) {
                         let ty = csearch::get_type(cx.tcx(), def_id).ty;
                         (base::trans_external_path(cx, def_id, ty), true)
@@ -644,7 +643,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
                 Some(def::DefStatic(def_id, false)) => {
                     get_const_val(cx, def_id)
                 }
-                Some(def::DefVariant(enum_did, variant_did, _)) => {
+                Some(ast::DefVariant(enum_did, variant_did, _)) => {
                     let ety = ty::expr_ty(cx.tcx(), e);
                     let repr = adt::represent_type(cx, ety);
                     let vinfo = ty::enum_variant_with_id(cx.tcx(),
@@ -652,7 +651,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
                                                          variant_did);
                     (adt::trans_const(cx, &*repr, vinfo.disr_val, []), true)
                 }
-                Some(def::DefStruct(_)) => {
+                Some(ast::DefStruct(_)) => {
                     let ety = ty::expr_ty(cx.tcx(), e);
                     let llty = type_of::type_of(cx, ety);
                     (C_null(llty), true)
@@ -665,14 +664,14 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
           ast::ExprCall(callee, ref args) => {
               let opt_def = cx.tcx().def_map.borrow().find_copy(&callee.id);
               match opt_def {
-                  Some(def::DefStruct(_)) => {
+                  Some(ast::DefStruct(_)) => {
                       let ety = ty::expr_ty(cx.tcx(), e);
                       let repr = adt::represent_type(cx, ety);
                       let (arg_vals, inlineable) = map_list(args.as_slice());
                       (adt::trans_const(cx, &*repr, 0, arg_vals.as_slice()),
                        inlineable)
                   }
-                  Some(def::DefVariant(enum_did, variant_did, _)) => {
+                  Some(ast::DefVariant(enum_did, variant_did, _)) => {
                       let ety = ty::expr_ty(cx.tcx(), e);
                       let repr = adt::represent_type(cx, ety);
                       let vinfo = ty::enum_variant_with_id(cx.tcx(),

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -37,7 +37,7 @@ use std::c_str::ToCStr;
 use std::vec;
 use std::vec::Vec;
 use libc::c_uint;
-use syntax::{ast, ast_util};
+use syntax::{ast, ast_util, ast_map};
 
 pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: ast::Lit)
     -> ValueRef {
@@ -172,10 +172,13 @@ pub fn get_const_val(cx: &CrateContext,
             def_id = inline::maybe_instantiate_inline(cx, def_id);
         }
 
-        match cx.tcx.map.expect_item(def_id.node).node {
-            ast::ItemStatic(_, ast::MutImmutable, _) => {
-                trans_const(cx, ast::MutImmutable, def_id.node);
-            }
+        match cx.tcx.map.get(def_id.node) {
+            ast_map::NodeItem(ref item) =>
+                match item.node {
+                    ast::ItemStatic(_, ast::MutImmutable, _) =>
+                        trans_const(cx, ast::MutImmutable, def_id.node),
+                    _ => {}
+                },
             _ => {}
         }
     }

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -179,14 +179,19 @@ pub fn get_const_val(cx: &CrateContext,
                         trans_const(cx, ast::MutImmutable, def_id.node),
                     _ => {}
                 },
-            ast_map::NodeForeignItem(ref item) =>
+            /*ast_map::NodeForeignItem(ref item) =>
                 match item.node {
                     ast::ForeignItemStatic(_, false) =>
                         trans_const(cx, ast::MutImmutable, def_id.node),
                     _ => {}
-                },
+                }, */
             _ => {}
         }
+    }
+    if !cx.const_values.borrow().contains_key(&def_id.node) {
+        debug!("get_const_value {}: value={}",
+               ast_map::node_id_to_str(&cx.tcx.map, def_id.node),
+               cx.item_symbols.borrow().find(&def_id.node));
     }
 
     (cx.const_values.borrow().get_copy(&def_id.node),

--- a/src/libsyntax/ast_map.rs
+++ b/src/libsyntax/ast_map.rs
@@ -663,7 +663,7 @@ pub fn map_decoded_item<F: FoldOps>(map: &Map,
     ii
 }
 
-fn node_id_to_str(map: &Map, id: NodeId) -> String {
+pub fn node_id_to_str(map: &Map, id: NodeId) -> String {
     match map.find(id) {
         Some(NodeItem(item)) => {
             let path_str = map.path_to_str_with_ident(id, item.ident);

--- a/src/test/auxiliary/static-extern-ref-2.rs
+++ b/src/test/auxiliary/static-extern-ref-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:static-extern-ref-2.rs
+
+extern crate libc;
+use libc::c_uint;
+
+#[no_mangle]
+pub static test_extern: c_uint = 5;

--- a/src/test/run-pass/static-extern-ref.rs
+++ b/src/test/run-pass/static-extern-ref.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:static-extern-ref-2.rs
+
+/*
+ * Ensure that parse accepts references to extern static variables.
+ */
+
+extern crate bar = "static-extern-ref-2";
+extern crate libc;
+
+use libc::c_uint;
+
+pub static test: &'static c_uint = &test_extern;
+
+extern {
+    pub static test_extern: c_uint;
+}
+
+fn main() {}


### PR DESCRIPTION
_Note:_ This used to be #13950. Unfortunately due to poor branch management practices on my part, I had to close it in favor of this issue.

This fixes a bug in `libsyntax` which would crash on ASTs containing references to foreign externs. Previously the included test would fail with,

```
rustc' failed at 'expected item, found foreign item test_extern::test_extern (id=13)', /opt/exp/rust/src/libsyntax/ast_map.rs:264
```
