### PR TITLE
[WIP] Allow macros in identifier position

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -273,6 +273,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
 
     // Discard MTWT tables that aren't required past resolution.
     syntax::ext::mtwt::clear_tables();
+    syntax::ast::clear_macro_idents();
 
     let named_region_map = time(time_passes, "lifetime resolution", (),
                                 |_| middle::resolve_lifetime::krate(&sess, krate));

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -61,6 +61,10 @@ fn get_macro_idents() -> Ref<RefCell<Vec<Mac>>> {
     }
 }
 
+pub fn clear_macro_idents() {
+    key_macro_idents.replace(None);
+}
+
 impl Ident {
     /// Construct an identifier with the given name and an empty context:
     pub fn new(name: Name) -> Ident { Ident {name: name, ctxt: EMPTY_CTXT}}

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -19,6 +19,8 @@ use parse::token;
 
 use std::fmt;
 use std::fmt::Show;
+use std::cell::RefCell;
+use std::local_data::Ref;
 use std::option::Option;
 use std::rc::Rc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
@@ -44,9 +46,48 @@ pub struct Ident {
     pub ctxt: SyntaxContext
 }
 
+pub static MACRO_CTXT: SyntaxContext = 0xffffffffu32;
+
+local_data_key!(key_macro_idents: RefCell<Vec<Mac>>)
+
+fn get_macro_idents() -> Ref<RefCell<Vec<Mac>>> {
+    match key_macro_idents.get() {
+        Some(x) => x,
+        None => {
+            let x = RefCell::new(Vec::new());
+            key_macro_idents.replace(Some(x));
+            get_macro_idents()
+        }
+    }
+}
+
 impl Ident {
     /// Construct an identifier with the given name and an empty context:
     pub fn new(name: Name) -> Ident { Ident {name: name, ctxt: EMPTY_CTXT}}
+
+    pub fn new_macro_ident(a: Mac) -> Ident {
+        let r = get_macro_idents();
+        let mut macro_idents = r.borrow_mut();
+        macro_idents.push(a);
+        let idx: Name = macro_idents.len() as u32 - 1;
+        Ident {name: idx, ctxt: MACRO_CTXT}
+    }
+
+    pub fn get_macro_ident(&self) -> Option<Mac> {
+        match self.ctxt {
+            MACRO_CTXT => {
+                let r = get_macro_idents();
+                let mut macro_idents = r.borrow_mut();
+                let i = self.name as uint;
+                if i < macro_idents.len() {
+                    Some(macro_idents.get(i).clone())
+                } else {
+                    None
+                }
+            },
+            _ => None
+        }
+    }
 }
 
 impl Eq for Ident {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -114,6 +114,10 @@ pub trait MacResult {
     fn make_items(&self) -> Option<SmallVector<@ast::Item>> {
         None
     }
+    /// Create an identifier
+    fn make_ident(&self) -> Option<ast::Ident> {
+        None
+    }
 
     /// Create a statement.
     ///

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -229,7 +229,7 @@ fn expand_loop_block(loop_block: P<Block>,
             // and be renamed incorrectly.
             let mut rename_list = vec!(rename);
             let mut rename_fld = renames_to_fold(&mut rename_list);
-            let renamed_ident = rename_fld.fold_ident(label);
+            let renamed_ident = fold_ident_or_macro(label, &mut rename_fld);
 
             // The rename *must* be added to the enclosed syntax context for
             // `break` or `continue` to pick up because by definition they are

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -363,6 +363,57 @@ pub fn contains_macro_escape(attrs: &[ast::Attribute]) -> bool {
     attr::contains_name(attrs, "macro_escape")
 }
 
+fn expand_ident(ident: Ident, fld: &mut MacroExpander) -> Ident {
+    match ident.get_macro_ident() {
+        None => ident,
+        Some(mac) => {
+            let MacInvocTT(ref pth, ref tts, _) = mac.node;
+            let extname = pth.segments.get(0).identifier;
+            let extnamestr = token::get_ident(extname);
+            match fld.extsbox.find(&extname.name) {
+                None => {
+                    fld.cx.span_err(pth.span, format!("macro undefined: '{}'", extnamestr));
+                    parse::token::special_idents::invalid
+                }
+
+                Some(&NormalTT(ref expandfun, exp_span)) => {
+                    fld.cx.bt_push(ExpnInfo {
+                        call_site: mac.span,
+                        callee: NameAndSpan {
+                            name: extnamestr.get().to_strbuf(),
+                            format: MacroBang,
+                            span: exp_span,
+                        }
+                    });
+                    let fm = fresh_mark();
+                    // mark before expansion:
+                    let marked_tts = mark_tts(tts.as_slice(), fm);
+
+                    // TODO: Read expand_expr to see whether we want
+                    // original_span(fld.cx) or mac.span
+                    let mac_span = original_span(fld.cx);
+
+                    match expandfun.expand(fld.cx,
+                                                          mac_span.call_site,
+                                                          marked_tts.as_slice()).make_ident() {
+                        Some(ident) => ident,
+                        None => {
+                            fld.cx.span_err(pth.span,
+                                            format!("non-ident macro in ident pos: {}",
+                                                    extnamestr));
+                            parse::token::special_idents::invalid
+                        }
+                    }
+                }
+                _ => {
+                    debug!("FIXME");
+                    parse::token::special_idents::invalid
+                }
+            }
+        }
+    }
+}
+
 // Support for item-position macro invocations, exactly the same
 // logic as for expression-position macro invocations.
 pub fn expand_item_mac(it: @ast::Item, fld: &mut MacroExpander)
@@ -812,12 +863,17 @@ pub struct IdentRenamer<'a> {
 
 impl<'a> Folder for IdentRenamer<'a> {
     fn fold_ident(&mut self, id: Ident) -> Ident {
-        let new_ctxt = self.renames.iter().fold(id.ctxt, |ctxt, &(from, to)| {
-            mtwt::new_rename(from, to, ctxt)
-        });
-        Ident {
-            name: id.name,
-            ctxt: new_ctxt,
+        match id.get_macro_ident() {
+            Some(_mac) => id,
+            None => {
+                let new_ctxt = self.renames.iter().fold(id.ctxt, |ctxt, &(from, to)| {
+                    mtwt::new_rename(from, to, ctxt)
+                });
+                Ident {
+                    name: id.name,
+                    ctxt: new_ctxt,
+                }
+            }
         }
     }
 }
@@ -847,6 +903,10 @@ pub struct MacroExpander<'a, 'b> {
 impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
     fn fold_expr(&mut self, expr: @ast::Expr) -> @ast::Expr {
         expand_expr(expr, self)
+    }
+
+    fn fold_ident(&mut self, ident: ast::Ident) -> ast::Ident {
+        expand_ident(ident, self)
     }
 
     fn fold_item(&mut self, item: @ast::Item) -> SmallVector<@ast::Item> {
@@ -903,9 +963,13 @@ struct Marker { mark: Mrk }
 
 impl Folder for Marker {
     fn fold_ident(&mut self, id: Ident) -> Ident {
-        ast::Ident {
-            name: id.name,
-            ctxt: mtwt::new_mark(self.mark, id.ctxt)
+        match id.get_macro_ident() {
+            Some(_mac) => id,
+            None =>
+                ast::Ident {
+                    name: id.name,
+                    ctxt: mtwt::new_mark(self.mark, id.ctxt)
+                }
         }
     }
     fn fold_mac(&mut self, m: &ast::Mac) -> ast::Mac {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -394,8 +394,8 @@ fn expand_ident(ident: Ident, fld: &mut MacroExpander) -> Ident {
                     let mac_span = original_span(fld.cx);
 
                     match expandfun.expand(fld.cx,
-                                                          mac_span.call_site,
-                                                          marked_tts.as_slice()).make_ident() {
+                                           mac_span.call_site,
+                                           marked_tts.as_slice()).make_ident() {
                         Some(ident) => ident,
                         None => {
                             fld.cx.span_err(pth.span,

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -685,7 +685,7 @@ pub fn noop_fold_item<T: Folder>(i: &Item, folder: &mut T) -> SmallVector<@Item>
         ItemImpl(_, ref maybe_trait, ty, _) => {
             ast_util::impl_pretty_name(maybe_trait, ty)
         }
-        _ => fold_ident_or_macro(i.ident, folder)
+        _ => i.ident
     };
 
     SmallVector::one(@Item {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -678,7 +678,10 @@ pub fn noop_fold_item<T: Folder>(i: &Item, folder: &mut T) -> SmallVector<@Item>
         ItemImpl(_, ref maybe_trait, ty, _) => {
             ast_util::impl_pretty_name(maybe_trait, ty)
         }
-        _ => i.ident
+        _ => match i.ident.get_macro_ident() {
+            Some(mac) => ast::Ident::new_macro_ident(folder.fold_mac(&mac)),
+            None      => i.ident,
+        }
     };
 
     SmallVector::one(@Item {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -413,7 +413,7 @@ pub fn fold_tts<T: Folder>(tts: &[TokenTree], fld: &mut T) -> Vec<TokenTree> {
     }).collect()
 }
 
-fn fold_ident_or_macro<T: Folder>(i: Ident, folder: &mut T) -> Ident {
+pub fn fold_ident_or_macro<T: Folder>(i: Ident, folder: &mut T) -> Ident {
     match i.get_macro_ident() {
         Some(mac) => ast::Ident::new_macro_ident(folder.fold_mac(&mac)),
         None      => folder.fold_ident(i)

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -273,7 +273,7 @@ pub trait Folder {
             span: self.new_span(p.span),
             global: p.global,
             segments: p.segments.iter().map(|segment| ast::PathSegment {
-                identifier: self.fold_ident(segment.identifier),
+                identifier: fold_ident_or_macro(segment.identifier, self),
                 lifetimes: segment.lifetimes.iter().map(|l| self.fold_lifetime(l)).collect(),
                 types: segment.types.iter().map(|&typ| self.fold_ty(typ)).collect(),
             }).collect()
@@ -408,18 +408,25 @@ pub fn fold_tts<T: Folder>(tts: &[TokenTree], fld: &mut T) -> Vec<TokenTree> {
                   sep.as_ref().map(|tok|maybe_fold_ident(tok,fld)),
                   is_optional),
             TTNonterminal(sp,ref ident) =>
-            TTNonterminal(sp,fld.fold_ident(*ident))
+            TTNonterminal(sp,fold_ident_or_macro(*ident, fld))
         }
     }).collect()
+}
+
+fn fold_ident_or_macro<T: Folder>(i: Ident, folder: &mut T) -> Ident {
+    match i.get_macro_ident() {
+        Some(mac) => ast::Ident::new_macro_ident(folder.fold_mac(&mac)),
+        None      => folder.fold_ident(i)
+    }
 }
 
 // apply ident folder if it's an ident, otherwise leave it alone
 fn maybe_fold_ident<T: Folder>(t: &token::Token, fld: &mut T) -> token::Token {
     match *t {
         token::IDENT(id, followed_by_colons) => {
-            token::IDENT(fld.fold_ident(id), followed_by_colons)
+            token::IDENT(fold_ident_or_macro(id, fld), followed_by_colons)
         }
-        token::LIFETIME(id) => token::LIFETIME(fld.fold_ident(id)),
+        token::LIFETIME(id) => token::LIFETIME(fold_ident_or_macro(id, fld)),
         _ => (*t).clone()
     }
 }
@@ -518,7 +525,7 @@ fn fold_struct_field<T: Folder>(f: &StructField, fld: &mut T) -> StructField {
 
 fn fold_field_<T: Folder>(field: Field, folder: &mut T) -> Field {
     ast::Field {
-        ident: respan(field.ident.span, folder.fold_ident(field.ident.node)),
+        ident: respan(field.ident.span, fold_ident_or_macro(field.ident.node, folder)),
         expr: folder.fold_expr(field.expr),
         span: folder.new_span(field.span),
     }
@@ -641,7 +648,7 @@ pub fn noop_fold_type_method<T: Folder>(m: &TypeMethod, fld: &mut T) -> TypeMeth
     let id = fld.new_id(m.id); // Needs to be first, for ast_map.
     TypeMethod {
         id: id,
-        ident: fld.fold_ident(m.ident),
+        ident: fold_ident_or_macro(m.ident, fld),
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, fld)).collect(),
         fn_style: m.fn_style,
         decl: fld.fold_fn_decl(m.decl),
@@ -678,15 +685,12 @@ pub fn noop_fold_item<T: Folder>(i: &Item, folder: &mut T) -> SmallVector<@Item>
         ItemImpl(_, ref maybe_trait, ty, _) => {
             ast_util::impl_pretty_name(maybe_trait, ty)
         }
-        _ => match i.ident.get_macro_ident() {
-            Some(mac) => ast::Ident::new_macro_ident(folder.fold_mac(&mac)),
-            None      => i.ident,
-        }
+        _ => fold_ident_or_macro(i.ident, folder)
     };
 
     SmallVector::one(@Item {
         id: id,
-        ident: folder.fold_ident(ident),
+        ident: fold_ident_or_macro(ident, folder),
         attrs: i.attrs.iter().map(|e| fold_attribute_(*e, folder)).collect(),
         node: node,
         vis: i.vis,
@@ -698,7 +702,7 @@ pub fn noop_fold_foreign_item<T: Folder>(ni: &ForeignItem, folder: &mut T) -> @F
     let id = folder.new_id(ni.id); // Needs to be first, for ast_map.
     @ForeignItem {
         id: id,
-        ident: folder.fold_ident(ni.ident),
+        ident: fold_ident_or_macro(ni.ident, folder),
         attrs: ni.attrs.iter().map(|x| fold_attribute_(*x, folder)).collect(),
         node: match ni.node {
             ForeignItemFn(ref fdec, ref generics) => {
@@ -722,7 +726,7 @@ pub fn noop_fold_method<T: Folder>(m: &Method, folder: &mut T) -> @Method {
     let id = folder.new_id(m.id); // Needs to be first, for ast_map.
     @Method {
         id: id,
-        ident: folder.fold_ident(m.ident),
+        ident: fold_ident_or_macro(m.ident, folder),
         attrs: m.attrs.iter().map(|a| fold_attribute_(*a, folder)).collect(),
         generics: fold_generics(&m.generics, folder),
         explicit_self: folder.fold_explicit_self(&m.explicit_self),
@@ -801,7 +805,7 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
         }
         ExprMethodCall(i, ref tps, ref args) => {
             ExprMethodCall(
-                respan(i.span, folder.fold_ident(i.node)),
+                respan(i.span, fold_ident_or_macro(i.node, folder)),
                 tps.iter().map(|&x| folder.fold_ty(x)).collect(),
                 args.iter().map(|&x| folder.fold_expr(x)).collect())
         }
@@ -830,11 +834,11 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
             ExprForLoop(folder.fold_pat(pat),
                         folder.fold_expr(iter),
                         folder.fold_block(body),
-                        maybe_ident.map(|i| folder.fold_ident(i)))
+                        maybe_ident.map(|i| fold_ident_or_macro(i, folder)))
         }
         ExprLoop(body, opt_ident) => {
             ExprLoop(folder.fold_block(body),
-                     opt_ident.map(|x| folder.fold_ident(x)))
+                     opt_ident.map(|x| fold_ident_or_macro(x, folder)))
         }
         ExprMatch(expr, ref arms) => {
             ExprMatch(folder.fold_expr(expr),
@@ -857,15 +861,15 @@ pub fn noop_fold_expr<T: Folder>(e: @Expr, folder: &mut T) -> @Expr {
         }
         ExprField(el, id, ref tys) => {
             ExprField(folder.fold_expr(el),
-                      folder.fold_ident(id),
+                      fold_ident_or_macro(id, folder),
                       tys.iter().map(|&x| folder.fold_ty(x)).collect())
         }
         ExprIndex(el, er) => {
             ExprIndex(folder.fold_expr(el), folder.fold_expr(er))
         }
         ExprPath(ref pth) => ExprPath(folder.fold_path(pth)),
-        ExprBreak(opt_ident) => ExprBreak(opt_ident.map(|x| folder.fold_ident(x))),
-        ExprAgain(opt_ident) => ExprAgain(opt_ident.map(|x| folder.fold_ident(x))),
+        ExprBreak(opt_ident) => ExprBreak(opt_ident.map(|x| fold_ident_or_macro(x, folder))),
+        ExprAgain(opt_ident) => ExprAgain(opt_ident.map(|x| fold_ident_or_macro(x, folder))),
         ExprRet(ref e) => {
             ExprRet(e.map(|x| folder.fold_expr(x)))
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2020,6 +2020,21 @@ impl<'a> Parser<'a> {
             // expr.f
             if self.eat(&token::DOT) {
                 match self.token {
+                  token::LPAREN => {
+                      let es = self.parse_unspanned_seq(
+                          &token::LPAREN,
+                          &token::RPAREN,
+                          seq_sep_none(),
+                          |p| p.parse_ident_or_macro()
+                      );
+                      if es.len() == 1 {
+                          let i = *es.get(0);
+                          let field = self.mk_field(e, i, Vec::new());
+                          e = self.mk_expr(self.span.lo, self.span.hi, field)
+                      } else {
+                          fail!("uh oh");
+                      }
+                  }
                   token::IDENT(i, _) => {
                     let dot = self.last_span.hi;
                     hi = self.span.hi;

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -158,12 +158,12 @@ pub fn walk_mod<E: Clone, V: Visitor<E>>(visitor: &mut V, module: &Mod, env: E) 
 pub fn walk_view_item<E: Clone, V: Visitor<E>>(visitor: &mut V, vi: &ViewItem, env: E) {
     match vi.node {
         ViewItemExternCrate(name, _, _) => {
-            visitor.visit_ident(vi.span, name, env)
+            walk_ident(visitor, vi.span, name, env)
         }
         ViewItemUse(ref vp) => {
             match vp.node {
                 ViewPathSimple(ident, ref path, id) => {
-                    visitor.visit_ident(vp.span, ident, env.clone());
+                    walk_ident(visitor, vp.span, ident, env.clone());
                     visitor.visit_path(path, id, env.clone());
                 }
                 ViewPathGlob(ref path, id) => {
@@ -171,7 +171,7 @@ pub fn walk_view_item<E: Clone, V: Visitor<E>>(visitor: &mut V, vi: &ViewItem, e
                 }
                 ViewPathList(ref path, ref list, _) => {
                     for id in list.iter() {
-                        visitor.visit_ident(id.span, id.node.name, env.clone())
+                        walk_ident(visitor, id.span, id.node.name, env.clone())
                     }
                     walk_path(visitor, path, env.clone());
                 }
@@ -208,11 +208,18 @@ pub fn walk_trait_ref_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
     visitor.visit_path(&trait_ref.path, trait_ref.ref_id, env)
 }
 
-pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) {
-    match item.ident.get_macro_ident() {
+pub fn walk_ident<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                           span: Span,
+                                           ident: Ident,
+                                           env: E) {
+    match ident.get_macro_ident() {
         Some(mac) => visitor.visit_mac(&mac, env.clone()),
-        None      => visitor.visit_ident(item.span, item.ident, env.clone()),
+        None      => visitor.visit_ident(span, ident, env.clone()),
     }
+}
+
+pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) {
+    walk_ident(visitor, item.span, item.ident, env.clone());
     match item.node {
         ItemStatic(typ, _, expr) => {
             visitor.visit_ty(typ, env.clone());
@@ -296,7 +303,7 @@ pub fn walk_variant<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                              variant: &Variant,
                                              generics: &Generics,
                                              env: E) {
-    visitor.visit_ident(variant.span, variant.node.name, env.clone());
+    walk_ident(visitor, variant.span, variant.node.name, env.clone());
 
     match variant.node.kind {
         TupleVariantKind(ref variant_arguments) => {
@@ -400,7 +407,7 @@ fn walk_lifetime_decls<E: Clone, V: Visitor<E>>(visitor: &mut V,
 
 pub fn walk_path<E: Clone, V: Visitor<E>>(visitor: &mut V, path: &Path, env: E) {
     for segment in path.segments.iter() {
-        visitor.visit_ident(path.span, segment.identifier, env.clone());
+        walk_ident(visitor, path.span, segment.identifier, env.clone());
 
         for &typ in segment.types.iter() {
             visitor.visit_ty(typ, env.clone());
@@ -466,7 +473,7 @@ pub fn walk_pat<E: Clone, V: Visitor<E>>(visitor: &mut V, pattern: &Pat, env: E)
 pub fn walk_foreign_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                   foreign_item: &ForeignItem,
                                                   env: E) {
-    visitor.visit_ident(foreign_item.span, foreign_item.ident, env.clone());
+    walk_ident(visitor, foreign_item.span, foreign_item.ident, env.clone());
 
     match foreign_item.node {
         ForeignItemFn(function_declaration, ref generics) => {
@@ -521,7 +528,7 @@ pub fn walk_fn_decl<E: Clone, V: Visitor<E>>(visitor: &mut V,
 pub fn walk_method_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                    method: &Method,
                                                    env: E) {
-    visitor.visit_ident(method.span, method.ident, env.clone());
+    walk_ident(visitor, method.span, method.ident, env.clone());
     visitor.visit_fn(&FkMethod(method.ident, &method.generics, method),
                      method.decl,
                      method.body,
@@ -556,7 +563,7 @@ pub fn walk_fn<E: Clone, V: Visitor<E>>(visitor: &mut V,
 pub fn walk_ty_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                method_type: &TypeMethod,
                                                env: E) {
-    visitor.visit_ident(method_type.span, method_type.ident, env.clone());
+    walk_ident(visitor, method_type.span, method_type.ident, env.clone());
     visitor.visit_explicit_self(&method_type.explicit_self, env.clone());
     for argument_type in method_type.decl.inputs.iter() {
         visitor.visit_ty(argument_type.ty, env.clone())
@@ -593,7 +600,7 @@ pub fn walk_struct_field<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                   env: E) {
     match struct_field.node.kind {
         NamedField(name, _) => {
-            visitor.visit_ident(struct_field.span, name, env.clone())
+            walk_ident(visitor, struct_field.span, name, env.clone())
         }
         _ => {}
     }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -209,7 +209,10 @@ pub fn walk_trait_ref_helper<E: Clone, V: Visitor<E>>(visitor: &mut V,
 }
 
 pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) {
-    visitor.visit_ident(item.span, item.ident, env.clone());
+    match item.ident.get_macro_ident() {
+        Some(mac) => visitor.visit_mac(&mac, env.clone()),
+        None      => visitor.visit_ident(item.span, item.ident, env.clone()),
+    }
     match item.node {
         ItemStatic(typ, _, expr) => {
             visitor.visit_ty(typ, env.clone());


### PR DESCRIPTION
This allows macros to be used in identifier position of items, making `concat_idents!` far more useful. This is very much a work in progress.
