### PR TITLE
Add an `Iterator::batch` transformer and explicit size hints for `FromIterator` and `Extend`

### DIFF
--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -582,7 +582,7 @@ impl<A> DoubleEndedIterator<A> for MoveItems<A> {
 }
 
 impl<A> FromIterator<A> for DList<A> {
-    fn from_iter<T: Iterator<A>>(iterator: T) -> DList<A> {
+    fn from_iter_with_capacity<T: Iterator<A>>(iterator: T, _cap: uint) -> DList<A> {
         let mut ret = DList::new();
         ret.extend(iterator);
         ret
@@ -590,7 +590,7 @@ impl<A> FromIterator<A> for DList<A> {
 }
 
 impl<A> Extendable<A> for DList<A> {
-    fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
+    fn extend_with_capacity<T: Iterator<A>>(&mut self, mut iterator: T, _extra: uint) {
         for elt in iterator { self.push_back(elt); }
     }
 }

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -1082,6 +1082,17 @@ impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
         }
     }
 
+    /// Reserve space for an additional `n` elements in the hash table.
+    pub fn reserve_additional(&mut self, extra: uint) {
+        let len = self.len();
+        if self.minimum_capacity - len < extra {
+            match len.checked_add(&extra) {
+                None => fail!("HashMap::reserve_additional: `uint` overflow"),
+                Some(new_cap) => self.reserve(new_cap)
+            }
+        }
+    }
+
     /// Resizes the internal vectors to a new capacity. It's your responsibility to:
     ///   1) Make sure the new capacity is enough for all the elements, accounting
     ///      for the load factor.
@@ -1552,6 +1563,11 @@ impl<T: TotalEq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// Reserve space for at least `n` elements in the hash table.
     pub fn reserve(&mut self, n: uint) {
         self.map.reserve(n)
+    }
+
+    /// Reserve space for an additional `n` elements in the hash table.
+    pub fn reserve_additional(&mut self, n: uint) {
+        self.map.reserve_additional(n)
     }
 
     /// Returns true if the hash set contains a value equivalent to the

--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -1465,16 +1465,16 @@ pub type Values<'a, K, V> =
     iter::Map<'static, (&'a K, &'a V), &'a V, Entries<'a, K, V>>;
 
 impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S> + Default> FromIterator<(K, V)> for HashMap<K, V, H> {
-    fn from_iter<T: Iterator<(K, V)>>(iter: T) -> HashMap<K, V, H> {
-        let (lower, _) = iter.size_hint();
-        let mut map = HashMap::with_capacity_and_hasher(lower, Default::default());
+    fn from_iter_with_capacity<T: Iterator<(K, V)>>(iter: T, cap: uint) -> HashMap<K, V, H> {
+        let mut map = HashMap::with_capacity_and_hasher(cap, Default::default());
         map.extend(iter);
         map
     }
 }
 
 impl<K: TotalEq + Hash<S>, V, S, H: Hasher<S> + Default> Extendable<(K, V)> for HashMap<K, V, H> {
-    fn extend<T: Iterator<(K, V)>>(&mut self, mut iter: T) {
+    fn extend_with_capacity<T: Iterator<(K, V)>>(&mut self, mut iter: T, extra: uint) {
+        self.reserve_additional(extra);
         for (k, v) in iter {
             self.insert(k, v);
         }
@@ -1633,16 +1633,16 @@ impl<T: TotalEq + Hash<S> + fmt::Show, S, H: Hasher<S>> fmt::Show for HashSet<T,
 }
 
 impl<T: TotalEq + Hash<S>, S, H: Hasher<S> + Default> FromIterator<T> for HashSet<T, H> {
-    fn from_iter<I: Iterator<T>>(iter: I) -> HashSet<T, H> {
-        let (lower, _) = iter.size_hint();
-        let mut set = HashSet::with_capacity_and_hasher(lower, Default::default());
+    fn from_iter_with_capacity<I: Iterator<T>>(iter: I, cap: uint) -> HashSet<T, H> {
+        let mut set = HashSet::with_capacity_and_hasher(cap, Default::default());
         set.extend(iter);
         set
     }
 }
 
 impl<T: TotalEq + Hash<S>, S, H: Hasher<S> + Default> Extendable<T> for HashSet<T, H> {
-    fn extend<I: Iterator<T>>(&mut self, mut iter: I) {
+    fn extend_with_capacity<I: Iterator<T>>(&mut self, mut iter: I, extra: uint) {
+        self.reserve_additional(extra);
         for k in iter {
             self.insert(k);
         }

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -204,20 +204,16 @@ impl<'a, T> Iterator<&'a T> for Items<'a, T> {
 }
 
 impl<T: Ord> FromIterator<T> for PriorityQueue<T> {
-    fn from_iter<Iter: Iterator<T>>(iter: Iter) -> PriorityQueue<T> {
-        let mut q = PriorityQueue::new();
+    fn from_iter_with_capacity<Iter: Iterator<T>>(iter: Iter, cap: uint) -> PriorityQueue<T> {
+        let mut q = PriorityQueue::with_capacity(cap);
         q.extend(iter);
         q
     }
 }
 
 impl<T: Ord> Extendable<T> for PriorityQueue<T> {
-    fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
-        let (lower, _) = iter.size_hint();
-
-        let len = self.capacity();
-        self.reserve(len + lower);
-
+    fn extend_with_capacity<Iter: Iterator<T>>(&mut self, mut iter: Iter, extra: uint) {
+        self.reserve_additional(extra);
         for elem in iter {
             self.push(elem);
         }

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -60,6 +60,12 @@ impl<T:Ord> PriorityQueue<T> {
         self.data.reserve(n)
     }
 
+    /// Reserve capacity for an additional n elements in the PriorityQueue.
+    /// Do nothing if the capacity is already sufficient.
+    pub fn reserve_additional(&mut self, n: uint) {
+        self.data.reserve_additional(n)
+    }
+
     /// Pop the greatest item from the queue - fails if empty
     pub fn pop(&mut self) -> T {
         let mut item = self.data.pop().unwrap();

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -185,6 +185,20 @@ impl<T> RingBuf<T> {
         self.elts.reserve(n);
     }
 
+    /// Reserve capacity for an additional `n` elements in the given RingBuf,
+    /// over-allocating in case the caller needs to reserve additional
+    /// space.
+    ///
+    /// Do nothing if `self`'s capacity is already equal to or greater
+    /// than the requested capacity.
+    ///
+    /// # Arguments
+    ///
+    /// * n - The number of elements to reserve space for
+    pub fn reserve_additional(&mut self, n: uint) {
+        self.elts.reserve_additional(n);
+    }
+
     /// Front-to-back iterator.
     pub fn iter<'a>(&'a self) -> Items<'a, T> {
         Items{index: 0, rindex: self.nelts, lo: self.lo, elts: self.elts.as_slice()}

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -399,16 +399,16 @@ impl<A: Eq> Eq for RingBuf<A> {
 }
 
 impl<A> FromIterator<A> for RingBuf<A> {
-    fn from_iter<T: Iterator<A>>(iterator: T) -> RingBuf<A> {
-        let (lower, _) = iterator.size_hint();
-        let mut deq = RingBuf::with_capacity(lower);
+    fn from_iter_with_capacity<T: Iterator<A>>(iterator: T, cap: uint) -> RingBuf<A> {
+        let mut deq = RingBuf::with_capacity(cap);
         deq.extend(iterator);
         deq
     }
 }
 
 impl<A> Extendable<A> for RingBuf<A> {
-    fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
+    fn extend_with_capacity<T: Iterator<A>>(&mut self, mut iterator: T, extra: uint) {
+        self.reserve_additional(extra);
         for elt in iterator {
             self.push_back(elt);
         }

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -925,7 +925,7 @@ fn remove<K: TotalOrd, V>(node: &mut Option<Box<TreeNode<K, V>>>,
 }
 
 impl<K: TotalOrd, V> FromIterator<(K, V)> for TreeMap<K, V> {
-    fn from_iter<T: Iterator<(K, V)>>(iter: T) -> TreeMap<K, V> {
+    fn from_iter_with_capacity<T: Iterator<(K, V)>>(iter: T, _cap: uint) -> TreeMap<K, V> {
         let mut map = TreeMap::new();
         map.extend(iter);
         map
@@ -934,7 +934,7 @@ impl<K: TotalOrd, V> FromIterator<(K, V)> for TreeMap<K, V> {
 
 impl<K: TotalOrd, V> Extendable<(K, V)> for TreeMap<K, V> {
     #[inline]
-    fn extend<T: Iterator<(K, V)>>(&mut self, mut iter: T) {
+    fn extend_with_capacity<T: Iterator<(K, V)>>(&mut self, mut iter: T, _extra: uint) {
         for (k, v) in iter {
             self.insert(k, v);
         }
@@ -942,7 +942,7 @@ impl<K: TotalOrd, V> Extendable<(K, V)> for TreeMap<K, V> {
 }
 
 impl<T: TotalOrd> FromIterator<T> for TreeSet<T> {
-    fn from_iter<Iter: Iterator<T>>(iter: Iter) -> TreeSet<T> {
+    fn from_iter_with_capacity<Iter: Iterator<T>>(iter: Iter, _cap: uint) -> TreeSet<T> {
         let mut set = TreeSet::new();
         set.extend(iter);
         set
@@ -951,7 +951,7 @@ impl<T: TotalOrd> FromIterator<T> for TreeSet<T> {
 
 impl<T: TotalOrd> Extendable<T> for TreeSet<T> {
     #[inline]
-    fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
+    fn extend_with_capacity<Iter: Iterator<T>>(&mut self, mut iter: Iter, _extra: uint) {
         for elem in iter {
             self.insert(elem);
         }

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -261,7 +261,7 @@ impl<T> TrieMap<T> {
 }
 
 impl<T> FromIterator<(uint, T)> for TrieMap<T> {
-    fn from_iter<Iter: Iterator<(uint, T)>>(iter: Iter) -> TrieMap<T> {
+    fn from_iter_with_capacity<Iter: Iterator<(uint, T)>>(iter: Iter, _cap: uint) -> TrieMap<T> {
         let mut map = TrieMap::new();
         map.extend(iter);
         map
@@ -269,7 +269,7 @@ impl<T> FromIterator<(uint, T)> for TrieMap<T> {
 }
 
 impl<T> Extendable<(uint, T)> for TrieMap<T> {
-    fn extend<Iter: Iterator<(uint, T)>>(&mut self, mut iter: Iter) {
+    fn extend_with_capacity<Iter: Iterator<(uint, T)>>(&mut self, mut iter: Iter, _extra: uint) {
         for (k, v) in iter {
             self.insert(k, v);
         }
@@ -360,7 +360,7 @@ impl TrieSet {
 }
 
 impl FromIterator<uint> for TrieSet {
-    fn from_iter<Iter: Iterator<uint>>(iter: Iter) -> TrieSet {
+    fn from_iter_with_capacity<Iter: Iterator<uint>>(iter: Iter, _cap: uint) -> TrieSet {
         let mut set = TrieSet::new();
         set.extend(iter);
         set
@@ -368,7 +368,7 @@ impl FromIterator<uint> for TrieSet {
 }
 
 impl Extendable<uint> for TrieSet {
-    fn extend<Iter: Iterator<uint>>(&mut self, mut iter: Iter) {
+    fn extend_with_capacity<Iter: Iterator<uint>>(&mut self, mut iter: Iter, _extra: uint) {
         for elem in iter {
             self.insert(elem);
         }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2416,8 +2416,8 @@ mod tests {
     use uint;
 
     impl<T> FromIterator<T> for Vec<T> {
-        fn from_iter_with_capacity<I: Iterator<T>>(mut iterator: I, _cap: uint) -> Vec<T> {
-            let mut v = Vec::new();
+        fn from_iter_with_capacity<I: Iterator<T>>(mut iterator: I, cap: uint) -> Vec<T> {
+            let mut v = Vec::with_capacity(cap);
             for e in iterator {
                 v.push(e);
             }

--- a/src/libcore/should_not_exist.rs
+++ b/src/libcore/should_not_exist.rs
@@ -97,9 +97,8 @@ impl Clone for ~str {
 
 impl FromIterator<char> for ~str {
     #[inline]
-    fn from_iter<T: Iterator<char>>(mut iterator: T) -> ~str {
-        let (lower, _) = iterator.size_hint();
-        let mut cap = if lower == 0 {16} else {lower};
+    fn from_iter_with_capacity<T: Iterator<char>>(mut iterator: T, cap: uint) -> ~str {
+        let mut cap = if cap == 0 {16} else {cap};
         let mut len = 0;
         let mut tmp = [0u8, ..4];
 

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -91,10 +91,10 @@ impl<'b,T> slice::Vector<T> for MaybeOwnedVector<'b,T> {
 }
 
 impl<'a,T> FromIterator<T> for MaybeOwnedVector<'a,T> {
-    fn from_iter<I:Iterator<T>>(iterator: I) -> MaybeOwnedVector<T> {
+    fn from_iter_with_capacity<I:Iterator<T>>(iterator: I, cap: uint) -> MaybeOwnedVector<T> {
         // If we are building from scratch, might as well build the
         // most flexible variant.
-        Growable(FromIterator::from_iter(iterator))
+        Growable(FromIterator::from_iter_with_capacity(iterator, cap))
     }
 }
 

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1428,36 +1428,6 @@ impl<T: Iterator<char>> Parser<T> {
                         },
                     },
                     _ => return self.error(InvalidEscape),
-/*=======
-                    'u' => {
-                        // Parse \u1234.
-                        let mut i = 0u;
-                        let mut n = 0u;
-                        while i < 4u && !self.eof() {
-                            self.bump();
-                            n = match self.ch_or_null() {
-                                c @ '0' .. '9' => n * 16u + (c as uint) - ('0' as uint),
-                                'a' | 'A' => n * 16u + 10u,
-                                'b' | 'B' => n * 16u + 11u,
-                                'c' | 'C' => n * 16u + 12u,
-                                'd' | 'D' => n * 16u + 13u,
-                                'e' | 'E' => n * 16u + 14u,
-                                'f' | 'F' => n * 16u + 15u,
-                                _ => return self.error(UnrecognizedHex)
-                            };
-
-                            i += 1u;
-                        }
-
-                        // Error out if we didn't parse 4 digits.
-                        if i != 4u {
-                            return self.error(NotFourDigit);
-                        }
-
-                        res.push_char(char::from_u32(n as u32).unwrap());
-                    }
-                    _ => return self.error(InvalidEscape),
->>>>>>> Add a streaming parser to serialize::json.*/
                 }
                 escape = false;
             } else if self.ch_is('\\') {

--- a/src/libstd/strbuf.rs
+++ b/src/libstd/strbuf.rs
@@ -288,15 +288,16 @@ impl Mutable for StrBuf {
 }
 
 impl FromIterator<char> for StrBuf {
-    fn from_iter<I:Iterator<char>>(iterator: I) -> StrBuf {
-        let mut buf = StrBuf::new();
+    fn from_iter_with_capacity<I:Iterator<char>>(iterator: I, cap: uint) -> StrBuf {
+        let mut buf = StrBuf::with_capacity(cap);
         buf.extend(iterator);
         buf
     }
 }
 
 impl Extendable<char> for StrBuf {
-    fn extend<I:Iterator<char>>(&mut self, mut iterator: I) {
+    fn extend_with_capacity<I:Iterator<char>>(&mut self, mut iterator: I, extra: uint) {
+        self.reserve_additional(extra);
         for ch in iterator {
             self.push_char(ch)
         }

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -354,9 +354,8 @@ impl<T:Clone> Clone for Vec<T> {
 }
 
 impl<T> FromIterator<T> for Vec<T> {
-    fn from_iter<I:Iterator<T>>(mut iterator: I) -> Vec<T> {
-        let (lower, _) = iterator.size_hint();
-        let mut vector = Vec::with_capacity(lower);
+    fn from_iter_with_capacity<I:Iterator<T>>(mut iterator: I, cap: uint) -> Vec<T> {
+        let mut vector = Vec::with_capacity(cap);
         for element in iterator {
             vector.push(element)
         }
@@ -365,9 +364,8 @@ impl<T> FromIterator<T> for Vec<T> {
 }
 
 impl<T> Extendable<T> for Vec<T> {
-    fn extend<I: Iterator<T>>(&mut self, mut iterator: I) {
-        let (lower, _) = iterator.size_hint();
-        self.reserve_additional(lower);
+    fn extend_with_capacity<I: Iterator<T>>(&mut self, mut iterator: I, extra: uint) {
+        self.reserve_additional(extra);
         for element in iterator {
             self.push(element)
         }

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -126,8 +126,8 @@ impl<T> Container for OwnedSlice<T> {
 }
 
 impl<T> FromIterator<T> for OwnedSlice<T> {
-    fn from_iter<I: Iterator<T>>(mut iter: I) -> OwnedSlice<T> {
-        OwnedSlice::from_vec(iter.collect())
+    fn from_iter_with_capacity<I: Iterator<T>>(mut iter: I, cap: uint) -> OwnedSlice<T> {
+        OwnedSlice::from_vec(iter.collect_with_capacity(cap))
     }
 }
 

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -34,7 +34,7 @@ impl<T> Container for SmallVector<T> {
 }
 
 impl<T> FromIterator<T> for SmallVector<T> {
-    fn from_iter<I: Iterator<T>>(iter: I) -> SmallVector<T> {
+    fn from_iter_with_capacity<I: Iterator<T>>(iter: I, _cap: uint) -> SmallVector<T> {
         let mut v = SmallVector::zero();
         v.extend(iter);
         v
@@ -42,7 +42,7 @@ impl<T> FromIterator<T> for SmallVector<T> {
 }
 
 impl<T> Extendable<T> for SmallVector<T> {
-    fn extend<I: Iterator<T>>(&mut self, mut iter: I) {
+    fn extend_with_capacity<I: Iterator<T>>(&mut self, mut iter: I, _extra: uint) {
         for val in iter {
             self.push(val);
         }


### PR DESCRIPTION
This pull request is focused on adding a `Iterator::batch` transformer. `batch` allows you to batch up multiple values from a stream into one value. For example, this can be used for transforming a stream of a monotonically increasing infinite iterator like `count(0, 1)` into a stream of `vec!(0, 1, 2)`, `vec!(3, 4, 5)`, and etc. It can also be seen as a low level transformer primitive that could be used to implement a variety of iterator transformers, as you could use it to implement `map`, `filter`, `reduce`, and more.

Along the way this also adds support for passing an explicit size hints to `.collect()`, `.from_iter()` and `.extend()` in the form of `.collect_with_capacity()`, `.from_iter_with_capacity()` and `.extend_with_capacity()`. Iterator size hints and `.collect()` calls are generally conservative in the size of collections they preallocate. For example, a filter call like `let xs: Vec<int> = range(1, 5).filter(|x| x != 3).collect()` would initially allocate a zero-sized `Vec<T>` because the `.filter()` gives a lower bound of `0`, and `collect` always uses the lower bounds. There is no way for the user to inform `.collect()` to preallocate space for 4 items. Similarly, there isn't a way to overallocate a collection with `.collect()`. These new methods allow the user to have better control over the memory allocation while still using generic methods.

I have to admit though, I'm not sure if it's better to create methods like `.collect_with_capacity()`, or if we should rename `.size_hint()` to `.size_bounds()`, provide a new `Iterator.size_hint()` that may be outside the bounds of the values, and a `.sized_by()` transformer that lets a user to provide a different hint than the lower bounds.

Finally, it also adds some `.reserve_additional` methods on some collections, and cleans up some dead code.
