### PR TITLE
Add syntax extension ary![expr, ..N]

### DIFF
--- a/src/libsyntax/ext/ary.rs
+++ b/src/libsyntax/ext/ary.rs
@@ -1,0 +1,50 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation of the ary![] macro
+
+use ast;
+use codemap::Span;
+use ext::base;
+use ext::base::{ExtCtxt, MacExpr, MacResult, DummyResult};
+use ext::build::AstBuilder;
+use parse;
+use parse::token;
+
+pub fn expand_ary(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+                 -> Box<base::MacResult> {
+    let mut p = parse::new_parser_from_tts(cx.parse_sess(), cx.cfg(), Vec::from_slice(tts));
+    let val_expr = p.parse_expr();
+    p.expect(&token::COMMA);
+    p.expect(&token::DOTDOT);
+    // negative literals should not be a fatal error
+    if p.eat(&token::BINOP(token::MINUS)) {
+        p.span_err(p.last_span, "expected positive integral literal");
+        return DummyResult::expr(sp);
+    }
+    let lit = p.parse_lit();
+    let count = match lit.node {
+        ast::LitInt(i, _) | ast::LitIntUnsuffixed(i) if i > 0 => i as u64,
+        ast::LitUint(u, _) if u > 0 => u,
+        _ => {
+            p.span_err(lit.span, "expected positive integral literal");
+            return DummyResult::expr(sp);
+        }
+    };
+    let count = match count.to_uint() {
+        None => {
+            p.span_err(lit.span, "integral literal out of range");
+            return DummyResult::expr(sp);
+        }
+        Some(x) => x
+    };
+    let exprs = Vec::from_fn(count, |_| val_expr.clone());
+    MacExpr::new(cx.expr_vec(sp, exprs))
+}

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -359,6 +359,9 @@ pub fn syntax_expander_table() -> SyntaxEnv {
     syntax_expanders.insert(intern("trace_macros"),
                             builtin_normal_expander(
                                     ext::trace_macros::expand_trace_macros));
+    syntax_expanders.insert(intern("ary"),
+                            builtin_normal_expander(
+                                    ext::ary::expand_ary));
     syntax_expanders
 }
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -98,6 +98,7 @@ pub mod ext {
     pub mod concat_idents;
     pub mod log_syntax;
     pub mod source_util;
+    pub mod ary;
 
     pub mod trace_macros;
 }

--- a/src/test/compile-fail/syntax-extension-ary-non-literal.rs
+++ b/src/test/compile-fail/syntax-extension-ary-non-literal.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let count = 4u;
+    let v = ary![3i, ..count]; //~ ERROR unexpected token: `count`
+}

--- a/src/test/compile-fail/syntax-extension-ary-non-positive-integral.rs
+++ b/src/test/compile-fail/syntax-extension-ary-non-positive-integral.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = ary![42i, ..-5]; //~ ERROR expected positive integral literal
+    let b = ary![42i, ..0i32]; //~ ERROR expected positive integral literal
+    let c = ary![42i, ..0u]; //~ ERROR expected positive integral literal
+}

--- a/src/test/run-pass/syntax-extension-ary.rs
+++ b/src/test/run-pass/syntax-extension-ary.rs
@@ -1,0 +1,58 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = ary![42i, ..1];
+    assert_eq!(a.as_slice(), [42i].as_slice());
+    assert_eq!(a.as_slice(), [42i, ..1].as_slice());
+
+    let b = ary![42i, ..10];
+    assert_eq!(b.as_slice(), [42i, ..10].as_slice());
+
+    let c = ary![None::<Vec<u8>>, ..10];
+    assert_eq!(c.len(), 10);
+    assert_eq!(c.as_slice(), Vec::from_elem(10, None::<Vec<u8>>).as_slice());
+
+    #[deriving(Eq)]
+    // non-Copy, non-Clone
+    struct Foo {
+        x: uint,
+        nocopy: ::std::kinds::marker::NoCopy
+    }
+
+    impl Foo {
+        fn new(x: uint) -> Foo {
+            Foo {
+                x: x,
+                nocopy: ::std::kinds::marker::NoCopy
+            }
+        }
+    }
+
+    let d = ary![Foo::new(42), ..10];
+    assert_eq!(d.len(), 10);
+    assert!(d.as_slice() == Vec::from_fn(10, |_| Foo::new(42)).as_slice());
+
+    let mut it = range(0, 4);
+    let e = ary![it.next(), ..8];
+    assert_eq!(e.as_slice(), &[Some(0), Some(1), Some(2), Some(3), None, None, None, None]);
+
+    let f = ary![format!("{}", 42i), ..4];
+    assert_eq!(f.len(), 4);
+    for s in f.iter() {
+        assert_eq!(s.as_slice(), "42");
+    }
+
+    let g = ary![vec![1u,2,3], ..4];
+    assert_eq!(g.len(), 4);
+    for v in g.iter() {
+        assert_eq!(v.as_slice(), &[1u,2,3]);
+    }
+}


### PR DESCRIPTION
`ary![expr, ..N]` expands to an array by repeating `expr` N times. This is
in contrast to `[expr, ..N]` which Copies `expr` N times.

Sample usage:

```
let x = ary![None::<Vec<u8>>, ..10];
```

The one limitation is the count needs to be an integral literal, it
cannot be a static or a compile-time expression.

Related to #5244, but is more flexible.
