### PR TITLE
Some improvements in collections

### DIFF
--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -410,7 +410,7 @@ impl<T> DList<T> {
     }
 }
 
-impl<T: Ord> DList<T> {
+impl<T: TotalOrd> DList<T> {
     /// Insert `elt` sorted in ascending order
     ///
     /// O(N)

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -22,17 +22,17 @@ pub struct PriorityQueue<T> {
     data: Vec<T>,
 }
 
-impl<T:Ord> Container for PriorityQueue<T> {
+impl<T: TotalOrd> Container for PriorityQueue<T> {
     /// Returns the length of the queue
     fn len(&self) -> uint { self.data.len() }
 }
 
-impl<T:Ord> Mutable for PriorityQueue<T> {
+impl<T: TotalOrd> Mutable for PriorityQueue<T> {
     /// Drop all items from the queue
     fn clear(&mut self) { self.data.truncate(0) }
 }
 
-impl<T:Ord> PriorityQueue<T> {
+impl<T: TotalOrd> PriorityQueue<T> {
     /// An iterator visiting all values in underlying vector, in
     /// arbitrary order.
     pub fn iter<'a>(&'a self) -> Items<'a, T> {
@@ -197,7 +197,7 @@ impl<'a, T> Iterator<&'a T> for Items<'a, T> {
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
-impl<T: Ord> FromIterator<T> for PriorityQueue<T> {
+impl<T: TotalOrd> FromIterator<T> for PriorityQueue<T> {
     fn from_iter<Iter: Iterator<T>>(iter: Iter) -> PriorityQueue<T> {
         let mut q = PriorityQueue::new();
         q.extend(iter);
@@ -205,7 +205,7 @@ impl<T: Ord> FromIterator<T> for PriorityQueue<T> {
     }
 }
 
-impl<T: Ord> Extendable<T> for PriorityQueue<T> {
+impl<T: TotalOrd> Extendable<T> for PriorityQueue<T> {
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         let (lower, _) = iter.size_hint();
 

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -98,12 +98,18 @@ impl<T: TotalOrd> PriorityQueue<T> {
         item
     }
 
+    #[deprecated="renamed to `into_vec`"]
+    fn to_vec(self) -> Vec<T> { self.into_vec() }
+
+    #[deprecated="renamed to `into_sorted_vec`"]
+    fn to_sorted_vec(self) -> Vec<T> { self.into_sorted_vec() }
+
     /// Consume the PriorityQueue and return the underlying vector
-    pub fn to_vec(self) -> Vec<T> { let PriorityQueue{data: v} = self; v }
+    pub fn into_vec(self) -> Vec<T> { let PriorityQueue{data: v} = self; v }
 
     /// Consume the PriorityQueue and return a vector in sorted
     /// (ascending) order
-    pub fn to_sorted_vec(self) -> Vec<T> {
+    pub fn into_sorted_vec(self) -> Vec<T> {
         let mut q = self;
         let mut end = q.len();
         while end > 1 {

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -107,9 +107,11 @@ impl<T: TotalOrd> PriorityQueue<T> {
         }
     }
 
+    #[allow(dead_code)]
     #[deprecated="renamed to `into_vec`"]
     fn to_vec(self) -> Vec<T> { self.into_vec() }
 
+    #[allow(dead_code)]
     #[deprecated="renamed to `into_sorted_vec`"]
     fn to_sorted_vec(self) -> Vec<T> { self.into_sorted_vec() }
 


### PR DESCRIPTION
The breaking changes are:
- Changed `DList::insert_ordered` to use `TotalOrd`, not `Ord`
- Changed `PriorityQueue` to use `TotalOrd`, not `Ord`
- Deprecated `PriorityQueue::maybe_top()` (renamed to replace `PriorityQueue::top()`)
- Deprecated `PriorityQueue::maybe_pop()` (renamed to replace `PriorityQueue::pop()`)
- Deprecated `PriorityQueue::to_vec()` (renamed to `PriorityQueue::into_vec()`)
- Deprecated `PriorityQueue::to_sorted_vec()` (renamed to `PriorityQueue::into_sorted_vec()`)
- Changed `PriorityQueue::replace(...)` to return an `Option<T>` instead of failing when the queue is empty.

[breaking-change]
