### PR TITLE
install: Removed lib dir assumptions, closes #13810

### DIFF
--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -384,7 +384,7 @@ while read p; do
     need_ok "failed to update manifest"
 
 # The manifest lists all files to install
-done < "${CFG_SRC_DIR}/lib/rustlib/manifest.in"
+done < "${CFG_SRC_DIR}/${CFG_LIBDIR#$CFG_PREFIX}/rustlib/manifest.in"
 
 # Sanity check: can we run the installed binaries?
 if [ -z "${CFG_DISABLE_VERIFY}" ]


### PR DESCRIPTION
I see that `CFG_LIBDIR` and `CFG_LIBDIR_RELATIVE` are already exported somewhere by the time `install.sh` is run when doing `make install`. Why aren't `CFG_MANDIR` and `CFG_MANDIR_RELATIVE` exported? I'm guessing that none of these variables can be relied on for binary distribution situations? Is this why line 228 assumes `lib` if no `--libdir` option is given?

My solution relies on `CFG_PREFIX` being the prefix to `CFG_LIBDIR` and `CFG_MANDIR` and that the relative portion of the path will match in both the source and destination. Is this a valid assumption?

I tested `make install` on both mingw32 and Linux. Are there any other targets I should run when making changes to `install.sh`?
