### PR TITLE
Rename .as_mut() to .as_mut_ref() in Option/Result/AnyMutRefExt

### DIFF
--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -215,7 +215,7 @@ impl<T> Deque<T> for DList<T> {
     /// Provide a mutable reference to the front element, or None if the list is empty
     #[inline]
     fn front_mut<'a>(&'a mut self) -> Option<&'a mut T> {
-        self.list_head.as_mut().map(|head| &mut head.value)
+        self.list_head.as_mut_ref().map(|head| &mut head.value)
     }
 
     /// Provide a reference to the back element, or None if the list is empty

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -13,12 +13,14 @@
 //! This module implements the `Any` trait, which enables dynamic typing
 //! of any type, through runtime reflection.
 //!
-//! `Any` itself can be used to get a `TypeId`, and has more features when used as a trait object.
-//! As `&Any` (a borrowed trait object), it has the `is` and `as_ref` methods, to test if the
-//! contained value is of a given type, and to get a reference to the inner value as a type. As
-//! `&mut Any`, there is also the `as_mut` method, for getting a mutable reference to the inner
-//! value. `Box<Any>` adds the `move` method, which will unwrap a `Box<T>` from the object.  See
-//! the extension traits (`*Ext`) for the full details.
+//! `Any` itself can be used to get a `TypeId`, and has more features when used
+//! as a trait object. As `&Any` (a borrowed trait object), it has the `is` and
+//! `as_ref` methods, to test if the contained value is of a given type,
+//! and to get a reference to the inner value as a type. As `&mut Any`, there
+//! is also the `as_mut_ref` method, for getting a mutable reference to the
+//! inner value. `Box<Any>` adds the `move` method, which will unwrap a
+//! `Box<T>` from the object. See the extension traits (`*Ext`) for the full
+//! details.
 
 use mem::{transmute, transmute_copy};
 use option::{Option, Some, None};
@@ -94,12 +96,17 @@ impl<'a> AnyRefExt<'a> for &'a Any {
 pub trait AnyMutRefExt<'a> {
     /// Returns some mutable reference to the boxed value if it is of type `T`, or
     /// `None` if it isn't.
-    fn as_mut<T: 'static>(self) -> Option<&'a mut T>;
+    fn as_mut_ref<T: 'static>(self) -> Option<&'a mut T>;
+
+    /// Deprecated name for `as_mut_ref()`.
+    #[deprecated = "replaced by .as_mut_ref()"]
+    #[inline]
+    fn as_mut<T: 'static>(self) -> Option<&'a mut T> { self.as_mut_ref() }
 }
 
 impl<'a> AnyMutRefExt<'a> for &'a mut Any {
     #[inline]
-    fn as_mut<T: 'static>(self) -> Option<&'a mut T> {
+    fn as_mut_ref<T: 'static>(self) -> Option<&'a mut T> {
         if self.is::<T>() {
             unsafe {
                 // Get the raw representation of the trait object
@@ -184,7 +191,7 @@ mod tests {
         let tmp: &mut uint = b;
         let b_r = tmp as &mut Any;
 
-        match a_r.as_mut::<uint>() {
+        match a_r.as_mut_ref::<uint>() {
             Some(x) => {
                 assert_eq!(*x, 5u);
                 *x = 612;
@@ -192,7 +199,7 @@ mod tests {
             x => fail!("Unexpected value {}", x)
         }
 
-        match b_r.as_mut::<uint>() {
+        match b_r.as_mut_ref::<uint>() {
             Some(x) => {
                 assert_eq!(*x, 7u);
                 *x = 413;
@@ -200,22 +207,22 @@ mod tests {
             x => fail!("Unexpected value {}", x)
         }
 
-        match a_r.as_mut::<Test>() {
+        match a_r.as_mut_ref::<Test>() {
             None => (),
             x => fail!("Unexpected value {}", x)
         }
 
-        match b_r.as_mut::<Test>() {
+        match b_r.as_mut_ref::<Test>() {
             None => (),
             x => fail!("Unexpected value {}", x)
         }
 
-        match a_r.as_mut::<uint>() {
+        match a_r.as_mut_ref::<uint>() {
             Some(&612) => {}
             x => fail!("Unexpected value {}", x)
         }
 
-        match b_r.as_mut::<uint>() {
+        match b_r.as_mut_ref::<uint>() {
             Some(&413) => {}
             x => fail!("Unexpected value {}", x)
         }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1703,7 +1703,7 @@ impl<'a, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for FlatMap<'a, A, T,
                 }
             }
             match self.iter.next().map(|x| (self.f)(x)) {
-                None => return self.backiter.as_mut().and_then(|it| it.next()),
+                None => return self.backiter.as_mut_ref().and_then(|it| it.next()),
                 next => self.frontiter = next,
             }
         }
@@ -1735,7 +1735,7 @@ impl<'a,
                 }
             }
             match self.iter.next_back().map(|x| (self.f)(x)) {
-                None => return self.frontiter.as_mut().and_then(|it| it.next_back()),
+                None => return self.frontiter.as_mut_ref().and_then(|it| it.next_back()),
                 next => self.backiter = next,
             }
         }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -207,8 +207,15 @@ impl<T> Option<T> {
 
     /// Convert from `Option<T>` to `Option<&mut T>`
     #[inline]
-    pub fn as_mut<'r>(&'r mut self) -> Option<&'r mut T> {
+    pub fn as_mut_ref<'r>(&'r mut self) -> Option<&'r mut T> {
         match *self { Some(ref mut x) => Some(x), None => None }
+    }
+
+    /// Deprecated name for `as_mut_ref()`.
+    #[deprecated = "replaced by .as_mut_ref()"]
+    #[inline]
+    pub fn as_mut<'r>(&'r mut self) -> Option<&'r mut T> {
+        self.as_mut_ref()
     }
 
     /// Convert from `Option<T>` to `&[T]` (without copying)
@@ -330,7 +337,7 @@ impl<T> Option<T> {
     /// Returns a mutable iterator over the possibly contained value.
     #[inline]
     pub fn mut_iter<'r>(&'r mut self) -> Item<&'r mut T> {
-        Item{opt: self.as_mut()}
+        Item{opt: self.as_mut_ref()}
     }
 
     /// Returns a consuming iterator over the possibly contained value.

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -391,11 +391,18 @@ impl<T, E> Result<T, E> {
 
     /// Convert from `Result<T, E>` to `Result<&mut T, &mut E>`
     #[inline]
-    pub fn as_mut<'r>(&'r mut self) -> Result<&'r mut T, &'r mut E> {
+    pub fn as_mut_ref<'r>(&'r mut self) -> Result<&'r mut T, &'r mut E> {
         match *self {
             Ok(ref mut x) => Ok(x),
             Err(ref mut x) => Err(x),
         }
+    }
+
+    /// Deprecated name for `as_mut_ref()`.
+    #[deprecated = "replaced by .as_mut_ref()"]
+    #[inline]
+    pub fn as_mut<'r>(&'r mut self) -> Result<&'r mut T, &'r mut E> {
+        self.as_mut_ref()
     }
 
     /////////////////////////////////////////////////////////////////////////

--- a/src/libstd/sync/spsc_queue.rs
+++ b/src/libstd/sync/spsc_queue.rs
@@ -204,7 +204,7 @@ impl<T: Send> Queue<T> {
             let tail = self.tail;
             let next = (*tail).next.load(Acquire);
             if next.is_null() { return None }
-            return (*next).value.as_mut();
+            return (*next).value.as_mut_ref();
         }
     }
 }


### PR DESCRIPTION
For consistency with other naming patterns, rename .as_mut() to
.as_mut_ref().

Leave .as_mut() as a deprecated function.

[breaking-change]
