### PR TITLE
Add non-utf8 byte to the bytes!() example

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -471,8 +471,9 @@ pub mod builtin {
     /// # Example
     ///
     /// ```
-    /// let rust = bytes!("r", 'u', "st");
+    /// let rust = bytes!("r", 'u', "st", 255);
     /// assert_eq!(rust[1], 'u' as u8);
+    /// assert_eq!(rust[5], 255);
     /// ```
     #[macro_export]
     macro_rules! bytes( ($($e:expr),*) => ({ /* compiler built-in */ }) )


### PR DESCRIPTION
Only an example was needed, as the ability to write uints into the string is
already mentioned.

Fix #7102.
