### PR TITLE
Fix ICE / LLVM error with tuple struct matches using (..)

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1120,7 +1120,7 @@ fn any_tuple_struct_pat(bcx: &Block, m: &[Match], col: uint) -> bool {
     m.iter().any(|br| {
         let pat = *br.pats.get(col);
         match pat.node {
-            ast::PatEnum(_, Some(_)) => {
+            ast::PatEnum(_, _) => {
                 match bcx.tcx().def_map.borrow().find(&pat.id) {
                     Some(&ast::DefFn(..)) |
                     Some(&ast::DefStruct(..)) => true,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -810,6 +810,9 @@ fn enter_tuple_struct<'a, 'b>(
             ast::PatEnum(_, Some(ref elts)) => {
                 Some(elts.iter().map(|x| (*x)).collect())
             }
+            ast::PatEnum(_, None) => {
+                Some(Vec::from_elem(n_elts, dummy))
+            }
             _ => {
                 assert_is_binding_or_wild(bcx, p);
                 Some(Vec::from_elem(n_elts, dummy))

--- a/src/test/run-pass/issue-14308.rs
+++ b/src/test/run-pass/issue-14308.rs
@@ -1,0 +1,32 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A(int);
+struct B;
+
+fn main() {
+    let x = match A(3) {
+        A(..) => 1
+    };
+    assert_eq!(x, 1);
+    let x = match A(4) {
+        A(1) => 1,
+        A(..) => 2
+    };
+    assert_eq!(x, 2);
+
+    // This next test uses a (..) wildcard match on a nullary struct.
+    // There's no particularly good reason to support this, but it's currently allowed,
+    // and this makes sure it doesn't ICE or break LLVM.
+    let x = match B {
+        B(..) => 3
+    };
+    assert_eq!(x, 3);
+}


### PR DESCRIPTION
Fixes #14308.
