### PR TITLE
std: Change hash to reexport its own Writer

### DIFF
--- a/src/libstd/hash/mod.rs
+++ b/src/libstd/hash/mod.rs
@@ -65,7 +65,6 @@
 
 use container::Container;
 use intrinsics::TypeId;
-use io::Writer;
 use iter::Iterator;
 use option::{Option, Some, None};
 use owned::Box;
@@ -77,6 +76,8 @@ use vec::Vec;
 
 /// Reexport the `sip::hash` function as our default hasher.
 pub use hash = self::sip::hash;
+
+pub use Writer = io::Writer;
 
 pub mod sip;
 

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -27,7 +27,8 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
                     vec!(box Literal(Path::new_local("__S"))), true),
          LifetimeBounds {
              lifetimes: Vec::new(),
-             bounds: vec!(("__S", ast::StaticSize, vec!(Path::new(vec!("std", "io", "Writer"))))),
+             bounds: vec!(("__S", ast::StaticSize,
+                           vec!(Path::new(vec!("std", "hash", "Writer"))))),
          },
          Path::new_local("__S"))
     } else {


### PR DESCRIPTION
One of the long-term goals of the libstd facade is to move the collections
library underneath the standard library. This would imply that libcollections
today would invert its dependency with libstd.

One of the primary blockers for doing this is the HashMap collection. Of its two
major dependencies, hashing and randomness, this commit is the first step in
dealing with hashing.

When moving the hash module beneath libstd, it must break its primary dependence
on the io::Writer trait (used as the hashing state). The proposed strategy for
breaking this dependence is taking a similar path as core::fmt, which is to have
the hash module define its own "writer trait". This trait would be similar to
std::io::Writer, except that it would not return errors and it would have fewer
convenience methods.

The Hash trait today has its type parameter behind a feature gate (default type
parameters), so this pending change will likely break no code which hasn't opted
in to the feature gate. The SipState struct will lose its implementation of
io::Writer, but it will regain similar methods for dealing with writing data.

This change specifically prepares for the hash migration by modifying
deriving(Hash) to use the std::hash::Writer bound instead of the std::io::Writer
bound. This bound is currently wired to std::io::Writer, but after a snapshot it
will have no need to be wired to the io writer trait.
