### PR TITLE
Fix lifetime error to print `'a` instead of `&'a`

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -145,7 +145,7 @@ pub fn explain_region_and_span(cx: &ctxt, region: ty::Region)
 }
 
 pub fn bound_region_ptr_to_str(cx: &ctxt, br: BoundRegion) -> StrBuf {
-    bound_region_to_str(cx, "&", true, br)
+    bound_region_to_str(cx, "", false, br)
 }
 
 pub fn bound_region_to_str(cx: &ctxt,

--- a/src/test/compile-fail/issue-10291.rs
+++ b/src/test/compile-fail/issue-10291.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn test<'x>(x: &'x int) { //~ NOTE the lifetime 'x as defined
+    drop::< <'z>|&'z int| -> &'z int>(|z| {
+        //~^ ERROR mismatched types
+        //~^^ ERROR cannot infer an appropriate lifetime
+        x
+    });
+}
+
+fn main() {}


### PR DESCRIPTION
This changes certain error messages about lifetimes so that they display lifetimes without an `&`.

Fixes #10291.
