### PR TITLE
Remove Rng.choose(), rename Rng.choose_option() to .choose()

### DIFF
--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -125,7 +125,7 @@ mod tests {
         for _ in range(0, 20) {
             let mut input = vec![];
             for _ in range(0, 2000) {
-                input.push_all(r.choose(words.as_slice()).as_slice());
+                input.push_all(r.choose(words.as_slice()).unwrap().as_slice());
             }
             debug!("de/inflate of {} bytes of random word-sequences",
                    input.len());


### PR DESCRIPTION
Rng.choose() is used so rarely that it doesn't necessitate having two
methods, especially since the failing, non-option variant also requires
Clone.

[breaking-change]
