### PR TITLE
Change std inject attributes to outer attributes

### DIFF
--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -341,7 +341,7 @@ fn mk_test_module(cx: &TestCtxt) -> @ast::Item {
     // This attribute tells resolve to let us call unexported functions
     let resolve_unexported_str = InternedString::new("!resolve_unexported");
     let resolve_unexported_attr =
-        attr::mk_attr(attr::mk_word_item(resolve_unexported_str));
+        attr::mk_attr_inner(attr::mk_word_item(resolve_unexported_str));
 
     let item = ast::Item {
         ident: token::str_to_ident("__test"),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1436,7 +1436,7 @@ fn synthesize_crate_attrs(ecx: &EncodeContext,
     fn synthesize_crateid_attr(ecx: &EncodeContext) -> Attribute {
         assert!(!ecx.link_meta.crateid.name.is_empty());
 
-        attr::mk_attr(
+        attr::mk_attr_inner(
             attr::mk_name_value_item_str(
                 InternedString::new("crate_id"),
                 token::intern_and_get_ident(ecx.link_meta.crateid.to_str())))

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -231,7 +231,7 @@ fn get_extern_rust_fn(ccx: &CrateContext, inputs: &[ty::t], output: ty::t,
 
     let f = decl_rust_fn(ccx, false, inputs, output, name);
     csearch::get_item_attrs(&ccx.sess().cstore, did, |meta_items| {
-        set_llvm_fn_attrs(meta_items.iter().map(|&x| attr::mk_attr(x))
+        set_llvm_fn_attrs(meta_items.iter().map(|&x| attr::mk_attr_outer(x))
                                     .collect::<Vec<_>>().as_slice(), f)
     });
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -126,7 +126,11 @@ impl AttributeMethods for Attribute {
                 InternedString::new("doc"),
                 token::intern_and_get_ident(strip_doc_comment_decoration(
                         comment.get()).as_slice()));
-            mk_attr(meta)
+            if self.node.style == ast::AttrOuter {
+                mk_attr_outer(meta)
+            } else {
+                mk_attr_inner(meta)
+            }
         } else {
             *self
         }
@@ -154,9 +158,19 @@ pub fn mk_word_item(name: InternedString) -> @MetaItem {
     @dummy_spanned(MetaWord(name))
 }
 
-pub fn mk_attr(item: @MetaItem) -> Attribute {
+/// Returns an inner attribute with the given value.
+pub fn mk_attr_inner(item: @MetaItem) -> Attribute {
     dummy_spanned(Attribute_ {
         style: ast::AttrInner,
+        value: item,
+        is_sugared_doc: false,
+    })
+}
+
+/// Returns an outer attribute with the given value.
+pub fn mk_attr_outer(item: @MetaItem) -> Attribute {
+    dummy_spanned(Attribute_ {
+        style: ast::AttrOuter,
         value: item,
         is_sugared_doc: false,
     })


### PR DESCRIPTION
The #[phase(syntax,link)] attribute on `extern crate std` needs to be an
outer attribute so it can pretty-print properly.

Also add `#![no_std]` and `#[feature(phase)]` so compiling the
pretty-printed source will work.
