### PR TITLE
Fixed formatter use documentation.

### DIFF
--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -196,10 +196,10 @@ struct Vector2D {
 
 impl fmt::Show for Vector2D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // The `f` value implements the `Writer` trait, which is what the
+        // The `f.buf` value implements the `Writer` trait, which is what the
         // write! macro is expecting. Note that this formatting ignores the
         // various flags provided to format strings.
-        write!(f, "({}, {})", self.x, self.y)
+        write!(f.buf, "({}, {})", self.x, self.y)
     }
 }
 


### PR DESCRIPTION
I changed the documentation examples where `write!( f, ... )` is used to `write!( f.buf, ... )` since `io::Formatter` doesn't actually implement `io::Writer`, but `Formatter.buf` does.
