### PR TITLE
mk: Replace 'oxidize' with 'rustc'. Closes #13781

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -74,7 +74,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4):				    \
 		$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4))	    \
 		$$(TSREQ$(1)_T_$(2)_H_$(3))			    \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
-	@$$(call E, oxidize: $$(@D)/lib$(4))
+	@$$(call E, rustc: $$(@D)/lib$(4))
 	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
 	    $$(dir $$@)$$(call CFG_LIB_GLOB_$(2),$(4)))
 	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
@@ -114,7 +114,7 @@ $$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)):			\
 		    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep))	\
 		$$(TSREQ$(1)_T_$(2)_H_$(3))			\
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
-	@$$(call E, oxidize: $$@)
+	@$$(call E, rustc: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --cfg $(4)
 
 endef

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -372,7 +372,7 @@ $(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)): CFG_COMPILER_HOST_TRIPLE = $(2)
 $(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)):				\
 		$$(CRATEFILE_$(4)) \
 		$$(TESTDEP_$(1)_$(2)_$(3)_$(4))
-	@$$(call E, oxidize: $$@)
+	@$$(call E, rustc: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test	\
 		-L "$$(RT_OUTPUT_DIR_$(2))"		\
 		-L "$$(LLVM_LIBDIR_$(2))"


### PR DESCRIPTION
Using `rustc` instead of e.g. `compile` makes it clear this is a rust build step.
