### PR TITLE
Remove -Z no-opt flag, allow --opt-level override, and add -O<n> flag

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -165,7 +165,6 @@ debugging_opts!(
         SHOW_SPAN,
         COUNT_TYPE_SIZES,
         META_STATS,
-        NO_OPT,
         GC,
         PRINT_LINK_ARGS,
         PRINT_LLVM_PASSES,
@@ -196,7 +195,6 @@ pub fn debugging_opts_map() -> Vec<(&'static str, &'static str, u64)> {
      ("count-type-sizes", "count the sizes of aggregate types",
       COUNT_TYPE_SIZES),
      ("meta-stats", "gather metadata statistics", META_STATS),
-     ("no-opt", "do not optimize, even if -O is passed", NO_OPT),
      ("print-link-args", "Print the arguments passed to the linker",
       PRINT_LINK_ARGS),
      ("gc", "Garbage collect shared data (experimental)", GC),
@@ -653,7 +651,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         None => driver::host_triple().to_strbuf(),
     };
     let opt_level = {
-        if (debugging_opts & NO_OPT) != 0 {
+        if debugging_opts != 0 {
             No
         } else if matches.opt_present("O") {
             if matches.opt_present("opt-level") {

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -653,14 +653,9 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let opt_level = {
         if debugging_opts != 0 {
             No
-        } else if (matches.opt_count("O") == 1) && (matches.opt_strs("O").len() == 0) {
-            // FIXME: This is hack to support -O defaulting to -O2 if it is the only -O or
-            // --opt-level arg. Consider removing -O or moving it to another flag. If this
-            // is done then change type of -O flag to optmulti.
-            Default
         } else if matches.opt_present("O") {
             match matches.opt_strs("O").last().as_ref().map(|s| s.as_slice()) {
-                None      |
+                None => Default, // This provides support for -O defaulting to -O2.
                 Some("0") => No,
                 Some("1") => Less,
                 Some("2") => Default,

--- a/src/test/run-pass/capture_nil.rs
+++ b/src/test/run-pass/capture_nil.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-Z no-opt
+// compile-flags:-O0
 
 // This test has to be setup just so to trigger
 // the condition which was causing us a crash.


### PR DESCRIPTION
Remove the `-Z no-opt` flag from rustc, fix #13649.

Also fix #7493 and in the process add `-O<n>` flag in the same vein as gcc, clang, and ghc.

The additional flag `-O<n>` flag may not be desired, but doing it this way unifies the two optimisation flags and results in clearer code.

Backwards compatibility is kept as the `-O` flag still defaults to optimisation level 2. However this only works when no other `-O<n>` or `--opt-level` arguments are passed to rustc (is this bad?).
