### PR TITLE
Remove some minor functionality from the bool module

### DIFF
--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -24,32 +24,10 @@
 //! * `TotalEq`
 //! * `Default`
 //!
-//! A `to_bit` conversion function.
 
-use num::{Int, one, zero};
-
-#[cfg(not(test))] use cmp::{Eq, Ord, TotalOrd, Ordering, TotalEq};
+#[cfg(not(test))] use cmp::{Eq, Ord, TotalOrd, Ordering, TotalEq, Less, Equal, Greater};
 #[cfg(not(test))] use ops::{Not};
 #[cfg(not(test))] use default::Default;
-
-/////////////////////////////////////////////////////////////////////////////
-// Freestanding functions
-/////////////////////////////////////////////////////////////////////////////
-
-/// Convert a `bool` to an integer.
-///
-/// # Examples
-///
-/// ```rust
-/// use std::bool;
-///
-/// assert_eq!(bool::to_bit::<u8>(true), 1u8);
-/// assert_eq!(bool::to_bit::<u8>(false), 0u8);
-/// ```
-#[inline]
-pub fn to_bit<N: Int>(p: bool) -> N {
-    if p { one() } else { zero() }
-}
 
 /////////////////////////////////////////////////////////////////////////////
 // Trait impls on `bool`
@@ -73,7 +51,7 @@ impl Not<bool> for bool {
 impl Ord for bool {
     #[inline]
     fn lt(&self, other: &bool) -> bool {
-        to_bit::<u8>(*self) < to_bit(*other)
+        *self == false && *other != false
     }
 }
 
@@ -81,7 +59,13 @@ impl Ord for bool {
 impl TotalOrd for bool {
     #[inline]
     fn cmp(&self, other: &bool) -> Ordering {
-        to_bit::<u8>(*self).cmp(&to_bit(*other))
+        if *self == *other {
+            Equal
+        } else if *self == false {
+            Less
+        } else {
+            Greater
+        }
     }
 }
 
@@ -114,13 +98,6 @@ impl Default for bool {
 #[cfg(test)]
 mod tests {
     use realstd::prelude::*;
-    use super::to_bit;
-
-    #[test]
-    fn test_to_bit() {
-        assert_eq!(to_bit::<u8>(true), 1u8);
-        assert_eq!(to_bit::<u8>(false), 0u8);
-    }
 
     #[test]
     fn test_eq() {

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -29,7 +29,7 @@
 use num::{Int, one, zero};
 
 #[cfg(not(test))] use cmp::{Eq, Ord, TotalOrd, Ordering, TotalEq};
-#[cfg(not(test))] use ops::{Not, BitAnd, BitOr, BitXor};
+#[cfg(not(test))] use ops::{Not};
 #[cfg(not(test))] use default::Default;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -67,71 +67,6 @@ impl Not<bool> for bool {
     /// ```
     #[inline]
     fn not(&self) -> bool { !*self }
-}
-
-#[cfg(not(test))]
-impl BitAnd<bool, bool> for bool {
-    /// Conjunction of two boolean values.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// assert_eq!(false.bitand(&false), false);
-    /// assert_eq!(true.bitand(&false), false);
-    /// assert_eq!(false.bitand(&true), false);
-    /// assert_eq!(true.bitand(&true), true);
-    ///
-    /// assert_eq!(false & false, false);
-    /// assert_eq!(true & false, false);
-    /// assert_eq!(false & true, false);
-    /// assert_eq!(true & true, true);
-    /// ```
-    #[inline]
-    fn bitand(&self, b: &bool) -> bool { *self & *b }
-}
-
-#[cfg(not(test))]
-impl BitOr<bool, bool> for bool {
-    /// Disjunction of two boolean values.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// assert_eq!(false.bitor(&false), false);
-    /// assert_eq!(true.bitor(&false), true);
-    /// assert_eq!(false.bitor(&true), true);
-    /// assert_eq!(true.bitor(&true), true);
-    ///
-    /// assert_eq!(false | false, false);
-    /// assert_eq!(true | false, true);
-    /// assert_eq!(false | true, true);
-    /// assert_eq!(true | true, true);
-    /// ```
-    #[inline]
-    fn bitor(&self, b: &bool) -> bool { *self | *b }
-}
-
-#[cfg(not(test))]
-impl BitXor<bool, bool> for bool {
-    /// An 'exclusive or' of two boolean values.
-    ///
-    /// 'exclusive or' is identical to `or(and(a, not(b)), and(not(a), b))`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// assert_eq!(false.bitxor(&false), false);
-    /// assert_eq!(true.bitxor(&false), true);
-    /// assert_eq!(false.bitxor(&true), true);
-    /// assert_eq!(true.bitxor(&true), false);
-    ///
-    /// assert_eq!(false ^ false, false);
-    /// assert_eq!(true ^ false, true);
-    /// assert_eq!(false ^ true, true);
-    /// assert_eq!(true ^ true, false);
-    /// ```
-    #[inline]
-    fn bitxor(&self, b: &bool) -> bool { *self ^ *b }
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
`to_bit` isn't worth having, and overloading bitwise operators as logical operators is morally wrong.
