### PR TITLE
rustdoc: Show types for traits across crates

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -653,4 +653,26 @@
     }
 
     window.initSearch = initSearch;
+
+    window.register_implementors = function(imp) {
+        var list = $('#implementors-list');
+        var libs = Object.getOwnPropertyNames(imp);
+        for (var i = 0; i < libs.length; i++) {
+            var structs = Object.getOwnPropertyNames(imp[libs[i]]);
+            for (var j = 0; j < structs.length; j++) {
+                console.log(i, structs[j]);
+                var path = rootPath + imp[libs[i]][structs[j]];
+                var klass = path.contains("type.") ? "type" : "struct";
+                var link = $('<a>').text(structs[j])
+                                   .attr('href', path)
+                                   .attr('class', klass);
+                var code = $('<code>').append(link);
+                var li = $('<li>').append(code);
+                list.append(li);
+            }
+        }
+    };
+    if (window.pending_implementors) {
+        window.register_implementors(window.pending_implementors);
+    }
 }());


### PR DESCRIPTION
Right now, when you look in the "Implementors" section for traits, you only see
implementors within that crate. This commit modifies that section to include
implementors from neighboring crates as well.

For example, the Container trait currently says that it is only implemented by
strings and slices, but it is in fact implemented by nearly all containers.

Implementation-wise, this change generates an "implementors cache" similarly to
the search index where each crate will append implementors to the files. When
the page for a trait is loaded, it will load its specific cache file, rendering
links for all upstream types which implement the trait.
