### PR TITLE
rustdoc: Fill in external trait methods

### DIFF
--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -19,7 +19,7 @@ pub trait DocFolder {
 
     /// don't override!
     fn fold_item_recur(&mut self, item: Item) -> Option<Item> {
-        let Item { attrs, name, source, visibility, id, inner } = item;
+        let Item { attrs, name, source, visibility, def_id, inner } = item;
         let inner = inner;
         let inner = match inner {
             StructItem(mut i) => {
@@ -83,7 +83,7 @@ pub trait DocFolder {
         };
 
         Some(Item { attrs: attrs, name: name, source: source, inner: inner,
-                    visibility: visibility, id: id })
+                    visibility: visibility, def_id: def_id })
     }
 
     fn fold_mod(&mut self, m: Module) -> Module {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -284,11 +284,15 @@ fn tybounds(w: &mut fmt::Formatter,
 impl fmt::Show for clean::Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            clean::TyParamBinder(id) | clean::Generic(id) => {
+            clean::TyParamBinder(id) => {
                 let m = cache_key.get().unwrap();
-                f.write(m.typarams.get(&id).as_bytes())
+                f.write(m.typarams.get(&ast_util::local_def(id)).as_bytes())
             }
-            clean::ResolvedPath{ did, ref typarams, ref path} => {
+            clean::Generic(did) => {
+                let m = cache_key.get().unwrap();
+                f.write(m.typarams.get(&did).as_bytes())
+            }
+            clean::ResolvedPath{ did, ref typarams, ref path } => {
                 try!(resolved_path(f, did, path, false));
                 tybounds(f, typarams)
             }

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -35,7 +35,7 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
             fn fold_item(&mut self, i: Item) -> Option<Item> {
                 if i.is_hidden_from_doc() {
                     debug!("found one in strip_hidden; removing");
-                    self.stripped.insert(i.id);
+                    self.stripped.insert(i.def_id.node);
 
                     // use a dedicated hidden item for given item type if any
                     match i.inner {
@@ -124,7 +124,8 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             clean::TraitItem(..) | clean::FunctionItem(..) |
             clean::VariantItem(..) | clean::MethodItem(..) |
             clean::ForeignFunctionItem(..) | clean::ForeignStaticItem(..) => {
-                if !self.exported_items.contains(&i.id) {
+                if ast_util::is_local(i.def_id) &&
+                   !self.exported_items.contains(&i.def_id.node) {
                     return None;
                 }
             }
@@ -173,7 +174,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
         };
 
         let i = if fastreturn {
-            self.retained.insert(i.id);
+            self.retained.insert(i.def_id.node);
             return Some(i);
         } else {
             self.fold_item_recur(i)
@@ -188,7 +189,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                            i.doc_value().is_none() => None,
                     clean::ImplItem(ref i) if i.methods.len() == 0 => None,
                     _ => {
-                        self.retained.insert(i.id);
+                        self.retained.insert(i.def_id.node);
                         Some(i)
                     }
                 }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -76,6 +76,8 @@ pub fn run(input: &str,
         maybe_typed: core::NotTyped(sess),
         src: input_path,
         external_paths: RefCell::new(Some(HashMap::new())),
+        external_traits: RefCell::new(None),
+        external_typarams: RefCell::new(None),
     };
     super::ctxtkey.replace(Some(ctx));
 


### PR DESCRIPTION
This commit alters rustdoc to crawl the metadata of upstream libraries in order
to fill in default methods for traits implemented in downstream crates. This,
for example, documents the `insert` function on hash maps.

This is a fairly lossy extraction from the metadata. Documentation and
attributes are lost, but they aren't used anyway. Unfortunately, argument names
are also lost because they are not present in the metadata. Source links are
also lost because the spans are not serialized.

While not perfect, it appears that presenting this documentation through rustdoc
is much better than nothing, so I wanted to land this to allow iteration on it
later on.
