### PR TITLE
docs: Add win64 calling convention, update doc

### DIFF
--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -493,6 +493,7 @@ are:
 * `rust-intrinsic`
 * `system`
 * `C`
+* `win64`
 
 Most of the abis in this list are self-explanatory, but the `system` abi may
 seem a little odd. This constraint selects whatever the appropriate ABI is for


### PR DESCRIPTION
Wikipedia suggests that windows on x64 has it's own calling convention (Supported by the fact that we implement it)

source: http://en.wikipedia.org/wiki/X86_calling_conventions#x86-64_calling_conventions
