### PR TITLE
In stats.rs port [T] to Vec<T>

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1007,7 +1007,6 @@ pub fn run_test(opts: &TestOpts,
         return;
     }
 
-    #[allow(deprecated_owned_vector)]
     fn run_test_inner(desc: TestDesc,
                       monitor_ch: Sender<MonitorMsg>,
                       nocapture: bool,


### PR DESCRIPTION
It seemed to me, that [T] was deprecated and i am trying to help.
