### PR TITLE
Spelling & minor span fix

### DIFF
--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -659,7 +659,7 @@ static INITIAL_LOAD_FACTOR: Fraction = (9, 10);
 /// on creation by default, this means the ordering of the keys is
 /// randomized, but makes the tables more resistant to
 /// denial-of-service attacks (Hash DoS). This behaviour can be
-/// overriden with one of the constructors.
+/// overridden with one of the constructors.
 ///
 /// It is required that the keys implement the `Eq` and `Hash` traits, although
 /// this can frequently be achieved by using `#[deriving(Eq, Hash)]`.

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Sharable mutable containers.
+//! Shareable mutable containers.
 //!
 //! Values of the `Cell` and `RefCell` types may be mutated through
 //! shared references (i.e. the common `&T` type), whereas most Rust
@@ -41,7 +41,7 @@
 //! preventing crash bugs. Because of that, inherited mutability is
 //! preferred, and interior mutability is something of a last
 //! resort. Since cell types enable mutation where it would otherwise
-//! be disallowed though, there are occassions when interior
+//! be disallowed though, there are occasions when interior
 //! mutability might be appropriate, or even *must* be used, e.g.
 //!
 //! * Introducing inherited mutability roots to shared types.

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -76,7 +76,7 @@ pub trait FormatWriter {
     /// This function will return an instance of `FormatError` on error.
     fn write(&mut self, bytes: &[u8]) -> Result;
 
-    /// Glue for usage of the `write!` macro with implementors of this trait.
+    /// Glue for usage of the `write!` macro with implementers of this trait.
     ///
     /// This method should generally not be invoked manually, but rather through
     /// the `write!` macro itself.

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -872,10 +872,12 @@ pub trait OrdIterator<A> {
     /// `min_max` finds the minimum and maximum elements in the iterator.
     ///
     /// The return type `MinMaxResult` is an enum of three variants:
+    ///
     /// - `NoElements` if the iterator is empty.
     /// - `OneElement(x)` if the iterator has exactly one element.
-    /// - `MinMax(x, y)` is returned otherwise, where `x <= y`. Two values are equal if and only if
-    /// there is more than one element in the iterator and all elements are equal.
+    /// - `MinMax(x, y)` is returned otherwise, where `x <= y`. Two
+    ///    values are equal if and only if there is more than one
+    ///    element in the iterator and all elements are equal.
     ///
     /// On an iterator of length `n`, `min_max` does `1.5 * n` comparisons,
     /// and so faster than calling `min` and `max separately which does `2 * n` comparisons.

--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -266,7 +266,7 @@ pub mod marker {
     #[deriving(Eq,Clone)]
     pub struct NoCopy;
 
-    /// A type which is considered "not sharable", meaning that
+    /// A type which is considered "not shareable", meaning that
     /// its contents are not threadsafe, hence they cannot be
     /// shared between tasks.
     #[lang="no_share_bound"]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -252,7 +252,7 @@
 //! The suitability of `fail!` as an error handling mechanism is
 //! limited by Rust's lack of any way to "catch" and resume execution
 //! from a thrown exception. Therefore using failure for error
-//! handling requires encapsulating fallable code in a task. Calling
+//! handling requires encapsulating fallible code in a task. Calling
 //! the `fail!` macro, or invoking `fail!` indirectly should be
 //! avoided as an error reporting strategy. Failure is only for
 //! unrecoverable errors and a failing task is typically the sign of

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -190,7 +190,7 @@ pub enum Fail_ {
     UnrecognizedOption(StrBuf),
     /// A required option is not present.
     OptionMissing(StrBuf),
-    /// A single occurence option is being used multiple times.
+    /// A single occurrence option is being used multiple times.
     OptionDuplicated(StrBuf),
     /// There's an argument being passed to a non-argument option.
     UnexpectedArgument(StrBuf),

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -395,7 +395,7 @@ pub trait Labeller<'a,N,E> {
     fn graph_id(&'a self) -> Id<'a>;
 
     /// Maps `n` to a unique identifier with respect to `self`. The
-    /// implementor is responsible for ensuring that the returned name
+    /// implementer is responsible for ensuring that the returned name
     /// is a valid DOT identifier.
     fn node_id(&'a self, n: &N) -> Id<'a>;
 
@@ -457,7 +457,7 @@ pub type Edges<'a,E> = MaybeOwnedVector<'a,E>;
 /// that is bound by the self lifetime `'a`.
 ///
 /// The `nodes` and `edges` method each return instantiations of
-/// `MaybeOwnedVector` to leave implementors the freedom to create
+/// `MaybeOwnedVector` to leave implementers the freedom to create
 /// entirely new vectors or to pass back slices into internally owned
 /// vectors.
 pub trait GraphWalk<'a, N, E> {

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -31,7 +31,7 @@ use std::slice;
 /// Some clients will have a pre-allocated vector ready to hand off in
 /// a slice; others will want to create the set on the fly and hand
 /// off ownership, via either `Growable` or `FixedLen` depending on
-/// which kind of vector they have constucted.  (The `FixedLen`
+/// which kind of vector they have constructed.  (The `FixedLen`
 /// variant is provided for interoperability with `std::slice` methods
 /// that return `~[T]`.)
 pub enum MaybeOwnedVector<'a,T> {

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -125,7 +125,7 @@
 //! }
 //! ```
 //!
-//! > **Note**: This `main` funciton in this example does *not* have I/O
+//! > **Note**: This `main` function in this example does *not* have I/O
 //! >           support. The basic event loop does not provide any support
 //!
 //! # Starting with I/O support in libgreen

--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -23,7 +23,7 @@
 //!
 //! Whenever the call to select() times out, then a channel receives a message.
 //! Whenever the call returns that the file descriptor has information, then the
-//! channel from timers is drained, enqueueing all incoming requests.
+//! channel from timers is drained, enqueuing all incoming requests.
 //!
 //! The actual implementation of the helper thread is a sorted array of
 //! timers in terms of target firing date. The target is the absolute time at
@@ -42,7 +42,7 @@
 //! thread. Whenever the timer is modified, it first takes ownership back from
 //! the worker thread in order to modify the same data structure. This has the
 //! side effect of "cancelling" the previous requests while allowing a
-//! re-enqueueing later on.
+//! re-enqueuing later on.
 //!
 //! Note that all time units in this file are in *milliseconds*.
 

--- a/src/librustc/middle/borrowck/doc.rs
+++ b/src/librustc/middle/borrowck/doc.rs
@@ -424,7 +424,7 @@ the pointer itself `LV` goes out of scope:
 ```
 
 The scope of a managed referent is also the scope of the pointer.  This
-is a conservative approximation, since there may be other aliases fo
+is a conservative approximation, since there may be other aliases for
 that same managed box that would cause it to live longer:
 
 ```notrust
@@ -536,7 +536,7 @@ The final rules govern the computation of *restrictions*, meaning that
 we compute the set of actions that will be illegal for the life of the
 loan. The predicate is written `RESTRICTIONS(LV, LT, ACTIONS) =
 RESTRICTION*`, which can be read "in order to prevent `ACTIONS` from
-occuring on `LV`, the restrictions `RESTRICTION*` must be respected
+occurring on `LV`, the restrictions `RESTRICTION*` must be respected
 for the lifetime of the loan".
 
 Note that there is an initial set of restrictions: these restrictions
@@ -551,7 +551,7 @@ are computed based on the kind of borrow:
 The reasoning here is that a mutable borrow must be the only writer,
 therefore it prevents other writes (`MUTATE`), mutable borrows
 (`CLAIM`), and immutable borrows (`FREEZE`). An immutable borrow
-permits other immutable borows but forbids writes and mutable borows.
+permits other immutable borrows but forbids writes and mutable borows.
 Finally, a const borrow just wants to be sure that the value is not
 moved out from under it, so no actions are forbidden.
 

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -73,7 +73,7 @@ pub struct CrateContext {
     /// came from)
     pub external_srcs: RefCell<NodeMap<ast::DefId>>,
     /// A set of static items which cannot be inlined into other crates. This
-    /// will pevent in IIItem() structures from being encoded into the metadata
+    /// will prevent in IIItem() structures from being encoded into the metadata
     /// that is generated
     pub non_inlineable_statics: RefCell<NodeSet>,
     /// Cache instances of monomorphized functions

--- a/src/librustc/middle/typeck/infer/doc.rs
+++ b/src/librustc/middle/typeck/infer/doc.rs
@@ -244,7 +244,7 @@ yet, that's what we're trying to find!  In our code, we opt to unify
 
 # Implementation details
 
-We make use of a trait-like impementation strategy to consolidate
+We make use of a trait-like implementation strategy to consolidate
 duplicated code between subtypes, GLB, and LUB computations.  See the
 section on "Type Combining" below for details.
 

--- a/src/librustuv/timeout.rs
+++ b/src/librustuv/timeout.rs
@@ -21,7 +21,7 @@ use uvio::UvIoFactory;
 use {Loop, UvError, uv_error_to_io_error, Request, wakeup};
 use {UvHandle, wait_until_woken_after};
 
-/// Managment of a timeout when gaining access to a portion of a duplex stream.
+/// Management of a timeout when gaining access to a portion of a duplex stream.
 pub struct AccessTimeout {
     state: TimeoutState,
     timer: Option<Box<TimerWatcher>>,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -402,7 +402,7 @@ pub enum IoErrorKind {
     PermissionDenied,
     /// A network connection failed for some reason not specified in this list.
     ConnectionFailed,
-    /// The network operation failed because the network connection was cloesd.
+    /// The network operation failed because the network connection was closed.
     Closed,
     /// The connection was refused by the remote server.
     ConnectionRefused,
@@ -469,7 +469,7 @@ pub trait Reader {
     /// inspected for in the error's `kind` field. Also note that reading 0
     /// bytes is not considered an error in all circumstances
     ///
-    /// # Implementaton Note
+    /// # Implementation Note
     ///
     /// When implementing this method on a new Reader, you are strongly encouraged
     /// not to return 0 if you can avoid it.
@@ -938,9 +938,9 @@ fn extend_sign(val: u64, nbytes: uint) -> i64 {
 
 /// A trait for objects which are byte-oriented streams. Writers are defined by
 /// one method, `write`. This function will block until the provided buffer of
-/// bytes has been entirely written, and it will return any failurs which occur.
+/// bytes has been entirely written, and it will return any failures which occur.
 ///
-/// Another commonly overriden method is the `flush` method for writers such as
+/// Another commonly overridden method is the `flush` method for writers such as
 /// buffered writers.
 ///
 /// Writers are intended to be composable with one another. Many objects

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -123,7 +123,7 @@ impl Command {
     /// * Inherit the current process's environment
     /// * Inherit the current process's working directory
     /// * A readable pipe for stdin (file descriptor 0)
-    /// * A writeable pipe for stdour and stderr (file descriptors 1 and 2)
+    /// * A writeable pipe for stdout and stderr (file descriptors 1 and 2)
     ///
     /// Builder methods are provided to change these defaults and
     /// otherwise configure the process.

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -92,7 +92,7 @@ fn src<T>(fd: libc::c_int, readable: bool, f: |StdSource| -> T) -> T {
 /// provided unbuffered access to stdin.
 ///
 /// Care should be taken when creating multiple handles to the stdin of a
-/// process. Beause this is a buffered reader by default, it's possible for
+/// process. Because this is a buffered reader by default, it's possible for
 /// pending input to be unconsumed in one reader and unavailable to other
 /// readers. It is recommended that only one handle at a time is created for the
 /// stdin of a process.

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -52,7 +52,7 @@ use rt::rtio::{IoFactory, LocalIo, RtioTimer};
 /// # }
 /// ```
 ///
-/// If only sleeping is necessary, then a convenience api is provided through
+/// If only sleeping is necessary, then a convenience API is provided through
 /// the `io::timer` module.
 ///
 /// ```

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use ast;
-use codemap::{spanned, Spanned, mk_sp};
+use codemap::{spanned, Spanned, mk_sp, Span};
 use parse::common::*; //resolve bug?
 use parse::token;
 use parse::parser::Parser;
@@ -129,10 +129,10 @@ impl<'a> ParserAttr for Parser<'a> {
                     self.parse_attribute(true)
                 }
                 token::DOC_COMMENT(s) => {
+                    // we need to get the position of this token before we bump.
+                    let Span { lo, hi, .. } = self.span;
                     self.bump();
-                    ::attr::mk_sugared_doc_attr(self.id_to_interned_str(s),
-                                                self.span.lo,
-                                                self.span.hi)
+                    ::attr::mk_sugared_doc_attr(self.id_to_interned_str(s), lo, hi)
                 }
                 _ => {
                     break;

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -11,7 +11,7 @@
 //! Terminal formatting library.
 //!
 //! This crate provides the `Terminal` trait, which abstracts over an [ANSI
-//! Termina][ansi] to provide color printing, among other things. There are two implementations,
+//! Terminal][ansi] to provide color printing, among other things. There are two implementations,
 //! the `TerminfoTerminal`, which uses control characters from a
 //! [terminfo][ti] database, and `WinConsole`, which uses the [Win32 Console
 //! API][win].


### PR DESCRIPTION
The span on a inner doc-comment would point to the next token, e.g. the span for the `a` line points to the `b` line, and the span of `b` points to the `fn`.

``` rust
//! a
//! b

fn bar() {}
```
