### PR TITLE
Move Bounded trait from num to cmp

### DIFF
--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -28,7 +28,7 @@
 
 use num::{Int, one, zero};
 
-#[cfg(not(test))] use cmp::{Eq, Ord, TotalOrd, Ordering, TotalEq};
+#[cfg(not(test))] use cmp::{Eq, Ord, TotalOrd, Ordering, TotalEq, Bounded};
 #[cfg(not(test))] use ops::{Not, BitAnd, BitOr, BitXor};
 #[cfg(not(test))] use default::Default;
 
@@ -170,6 +170,14 @@ impl Eq for bool {
 
 #[cfg(not(test))]
 impl TotalEq for bool {}
+
+#[cfg(not(test))]
+impl Bounded for bool {
+    #[inline]
+    fn min_value() -> bool { false }
+    #[inline]
+    fn max_value() -> bool { true }
+}
 
 #[cfg(not(test))]
 impl Default for bool {

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -34,7 +34,7 @@ pub use unicode::normalization::decompose_canonical;
 /// Returns the compatibility decomposition of a character.
 pub use unicode::normalization::decompose_compatible;
 
-#[cfg(not(test))] use cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering};
+#[cfg(not(test))] use cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Bounded};
 #[cfg(not(test))] use default::Default;
 
 // UTF-8 ranges and tags for encoding characters
@@ -621,6 +621,14 @@ impl TotalOrd for char {
     fn cmp(&self, other: &char) -> Ordering {
         (*self as u32).cmp(&(*other as u32))
     }
+}
+
+#[cfg(not(test))]
+impl Bounded for char {
+    #[inline]
+    fn min_value() -> char { '\x00' }
+    #[inline]
+    fn max_value() -> char { MAX }
 }
 
 #[cfg(not(test))]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -129,6 +129,15 @@ impl Ord for Ordering {
     fn lt(&self, other: &Ordering) -> bool { (*self as int) < (*other as int) }
 }
 
+/// Types which have upper and lower bounds
+pub trait Bounded {
+    // FIXME (#5527): These should be associated constants
+    /// returns the smallest value this type can represent
+    fn min_value() -> Self;
+    /// returns the largest value this type can represent
+    fn max_value() -> Self;
+}
+
 /// Combine orderings, lexically.
 ///
 /// For example for a type `(int, int)`, two comparisons could be done.
@@ -192,7 +201,7 @@ pub fn max<T: TotalOrd>(v1: T, v2: T) -> T {
 // Implementation of Eq/TotalEq for some primitive types
 #[cfg(not(test))]
 mod impls {
-    use cmp::{Ord, TotalOrd, Eq, TotalEq, Ordering, Equal};
+    use cmp::{Ord, TotalOrd, Eq, TotalEq, Bounded, Ordering, Equal};
 
     impl Eq for () {
         #[inline]
@@ -208,6 +217,12 @@ mod impls {
     impl TotalOrd for () {
         #[inline]
         fn cmp(&self, _other: &()) -> Ordering { Equal }
+    }
+    impl Bounded for () {
+        #[inline]
+        fn min_value() -> () { () }
+        #[inline]
+        fn max_value() -> () { () }
     }
 
     // & pointers

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -14,10 +14,10 @@ use default::Default;
 use intrinsics;
 use mem;
 use num::{FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
-use num::{Zero, One, Bounded, Signed, Num, Primitive, Float};
+use num::{Zero, One, Signed, Num, Primitive, Float};
 use option::Option;
 
-#[cfg(not(test))] use cmp::{Eq, Ord};
+#[cfg(not(test))] use cmp::{Eq, Ord, Bounded};
 #[cfg(not(test))] use ops::{Add, Sub, Mul, Div, Rem, Neg};
 
 pub static RADIX: uint = 2u;
@@ -220,6 +220,7 @@ impl Signed for f32 {
     fn is_negative(&self) -> bool { *self < 0.0 || (1.0 / *self) == NEG_INFINITY }
 }
 
+#[cfg(not(test))]
 impl Bounded for f32 {
     // NOTE: this is the smallest non-infinite f32 value, *not* MIN_VALUE
     #[inline]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -14,10 +14,10 @@ use default::Default;
 use intrinsics;
 use mem;
 use num::{FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
-use num::{Zero, One, Bounded, Signed, Num, Primitive, Float};
+use num::{Zero, One, Signed, Num, Primitive, Float};
 use option::Option;
 
-#[cfg(not(test))] use cmp::{Eq, Ord};
+#[cfg(not(test))] use cmp::{Eq, Ord, Bounded};
 #[cfg(not(test))] use ops::{Add, Sub, Mul, Div, Rem, Neg};
 
 // FIXME(#5527): These constants should be deprecated once associated
@@ -220,6 +220,7 @@ impl Signed for f64 {
     fn is_negative(&self) -> bool { *self < 0.0 || (1.0 / *self) == NEG_INFINITY }
 }
 
+#[cfg(not(test))]
 impl Bounded for f64 {
     // NOTE: this is the smallest non-infinite f32 value, *not* MIN_VALUE
     #[inline]

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Signed, Num, Primitive, Int};
+use num::{Bitwise, Zero, One, Signed, Num, Primitive, Int};
 use num::{CheckedDiv, CheckedAdd, CheckedSub, CheckedMul};
 use option::{Option, Some, None};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitOr, BitAnd, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Signed, Num, Primitive, Int};
+use num::{Bitwise, Zero, One, Signed, Num, Primitive, Int};
 use num::{CheckedDiv, CheckedAdd, CheckedSub, CheckedMul};
 use option::{Option, Some, None};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitOr, BitAnd, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Signed, Num, Primitive, Int};
+use num::{Bitwise, Zero, One, Signed, Num, Primitive, Int};
 use num::{CheckedDiv, CheckedAdd, CheckedSub, CheckedMul};
 use option::{Option, Some, None};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitOr, BitAnd, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Signed, Num, Primitive, Int};
+use num::{Bitwise, Zero, One, Signed, Num, Primitive, Int};
 use num::{CheckedDiv, CheckedAdd, CheckedSub, CheckedMul};
 use option::{Option, Some, None};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitOr, BitAnd, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/int.rs
+++ b/src/libcore/num/int.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Signed, Num, Primitive, Int};
+use num::{Bitwise, Zero, One, Signed, Num, Primitive, Int};
 use num::{CheckedDiv, CheckedAdd, CheckedSub, CheckedMul};
 use option::{Option, Some, None};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitOr, BitAnd, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -214,6 +214,7 @@ impl Not<$T> for $T {
     fn not(&self) -> $T { !*self }
 }
 
+#[cfg(not(test))]
 impl Bounded for $T {
     #[inline]
     fn min_value() -> $T { MIN }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -16,7 +16,7 @@
 #![allow(missing_doc)]
 
 use clone::Clone;
-use cmp::{Eq, Ord};
+use cmp::{Eq, Ord, Bounded};
 use kinds::Copy;
 use mem::size_of;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
@@ -188,14 +188,6 @@ pub fn pow<T: One + Mul<T, T>>(mut base: T, mut exp: uint) -> T {
     }
 }
 
-/// Numbers which have upper and lower bounds
-pub trait Bounded {
-    // FIXME (#5527): These should be associated constants
-    /// returns the smallest finite number this type can represent
-    fn min_value() -> Self;
-    /// returns the largest finite number this type can represent
-    fn max_value() -> Self;
-}
 
 /// Numbers with a fixed binary representation.
 pub trait Bitwise: Bounded

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Unsigned, Num, Int, Primitive};
+use num::{Bitwise, Zero, One, Unsigned, Num, Int, Primitive};
 use num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 use option::{Some, None, Option};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitAnd, BitOr, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Unsigned, Num, Int, Primitive};
+use num::{Bitwise, Zero, One, Unsigned, Num, Int, Primitive};
 use num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 use option::{Some, None, Option};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitAnd, BitOr, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Unsigned, Num, Int, Primitive};
+use num::{Bitwise, Zero, One, Unsigned, Num, Int, Primitive};
 use num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 use option::{Some, None, Option};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitAnd, BitOr, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Unsigned, Num, Int, Primitive};
+use num::{Bitwise, Zero, One, Unsigned, Num, Int, Primitive};
 use num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 use option::{Some, None, Option};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitAnd, BitOr, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/uint.rs
+++ b/src/libcore/num/uint.rs
@@ -12,12 +12,12 @@
 
 use default::Default;
 use intrinsics;
-use num::{Bitwise, Bounded, Zero, One, Unsigned, Num, Int, Primitive};
+use num::{Bitwise, Zero, One, Unsigned, Num, Int, Primitive};
 use num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 use option::{Some, None, Option};
 
 #[cfg(not(test))]
-use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering};
+use cmp::{Eq, Ord, TotalEq, TotalOrd, Less, Greater, Equal, Ordering, Bounded};
 #[cfg(not(test))]
 use ops::{Add, Sub, Mul, Div, Rem, Neg, BitAnd, BitOr, BitXor};
 #[cfg(not(test))]

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -130,6 +130,7 @@ impl Not<$T> for $T {
     fn not(&self) -> $T { !*self }
 }
 
+#[cfg(not(test))]
 impl Bounded for $T {
     #[inline]
     fn min_value() -> $T { MIN }

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -12,7 +12,7 @@
 
 // this is surprisingly complicated to be both generic & correct
 
-use std::num::Bounded;
+use std::cmp::Bounded;
 use Rng;
 use distributions::{Sample, IndependentSample};
 
@@ -164,7 +164,7 @@ mod tests {
     use distributions::{Sample, IndependentSample};
     use {Rng, task_rng};
     use super::Range;
-    use std::num::Bounded;
+    use std::cmp::Bounded;
 
     #[should_fail]
     #[test]

--- a/src/librustc/util/sha2.rs
+++ b/src/librustc/util/sha2.rs
@@ -524,7 +524,7 @@ mod tests {
     extern crate rand;
 
     use super::{Digest, Sha256, FixedBuffer};
-    use std::num::Bounded;
+    use std::cmp::Bounded;
     use self::rand::isaac::IsaacRng;
     use self::rand::Rng;
     use serialize::hex::FromHex;

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -21,7 +21,7 @@ use option::{Option};
 
 pub use core::num::{Num, div_rem, Zero, zero, One, one};
 pub use core::num::{Signed, abs, abs_sub, signum};
-pub use core::num::{Unsigned, pow, Bounded, Bitwise};
+pub use core::num::{Unsigned, pow, Bitwise};
 pub use core::num::{Primitive, Int, Saturating};
 pub use core::num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 pub use core::num::{cast, FromPrimitive, NumCast, ToPrimitive};


### PR DESCRIPTION
Bounded trait is useful also for non-numeric types. I propose to move it to core::cmp.  It makes sense to implement it for any type that implements TotalOrd and has finite number of values.
