### PR TITLE
libsyntax: Allow `+` to separate trait bounds.

### DIFF
--- a/src/doc/complement-cheatsheet.md
+++ b/src/doc/complement-cheatsheet.md
@@ -157,7 +157,7 @@ struct FooClosure<'a> {
 }
 
 fn a(a: int, b: uint) -> i32 {
-    (a as uint + b) as i32
+    ((a as uint) + b) as i32
 }
 
 fn main() {

--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -298,7 +298,7 @@ be distributed on the available cores.
 fn partial_sum(start: uint) -> f64 {
     let mut local_sum = 0f64;
     for num in range(start*100000, (start+1)*100000) {
-        local_sum += (num as f64 + 1.0).powf(-2.0);
+        local_sum += ((num as f64) + 1.0).powf(-2.0);
     }
     local_sum
 }

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -220,8 +220,8 @@ pub fn to_digit(c: char, radix: uint) -> Option<uint> {
     }
     let val = match c {
       '0' .. '9' => c as uint - ('0' as uint),
-      'a' .. 'z' => c as uint + 10u - ('a' as uint),
-      'A' .. 'Z' => c as uint + 10u - ('A' as uint),
+      'a' .. 'z' => (c as uint) + 10u - ('a' as uint),
+      'A' .. 'Z' => (c as uint) + 10u - ('A' as uint),
       _ => return None,
     };
     if val < radix { Some(val) }
@@ -280,9 +280,9 @@ pub fn from_digit(num: uint, radix: uint) -> Option<char> {
     if num < radix {
         unsafe {
             if num < 10 {
-                Some(transmute(('0' as uint + num) as u32))
+                Some(transmute((('0' as uint) + num) as u32))
             } else {
-                Some(transmute(('a' as uint + num - 10u) as u32))
+                Some(transmute((('a' as uint) + num - 10u) as u32))
             }
         }
     } else {
@@ -311,8 +311,8 @@ pub fn escape_unicode(c: char, f: |char|) {
     for offset in range_step::<i32>(4 * (pad - 1), -1, -4) {
         unsafe {
             match ((c as i32) >> offset) & 0xf {
-                i @ 0 .. 9 => { f(transmute('0' as i32 + i)); }
-                i => { f(transmute('a' as i32 + (i - 10))); }
+                i @ 0 .. 9 => { f(transmute(('0' as i32) + i)); }
+                i => { f(transmute(('a' as i32) + (i - 10))); }
             }
         }
     }

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -267,7 +267,7 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
                     if i < 0
                     || buf[i as uint] == '-' as u8
                     || buf[i as uint] == '+' as u8 {
-                        for j in range(i as uint + 1, end).rev() {
+                        for j in range((i as uint) + 1, end).rev() {
                             buf[j + 1] = buf[j];
                         }
                         buf[(i + 1) as uint] = value2ascii(1);

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -99,13 +99,13 @@ macro_rules! radix {
     }
 }
 
-radix!(Binary,    2, "0b", x @  0 .. 2 => '0' as u8 + x)
-radix!(Octal,     8, "0o", x @  0 .. 7 => '0' as u8 + x)
-radix!(Decimal,  10, "",   x @  0 .. 9 => '0' as u8 + x)
-radix!(LowerHex, 16, "0x", x @  0 .. 9 => '0' as u8 + x,
-                           x @ 10 ..15 => 'a' as u8 + (x - 10))
-radix!(UpperHex, 16, "0x", x @  0 .. 9 => '0' as u8 + x,
-                           x @ 10 ..15 => 'A' as u8 + (x - 10))
+radix!(Binary,    2, "0b", x @  0 .. 2 => ('0' as u8) + x)
+radix!(Octal,     8, "0o", x @  0 .. 7 => ('0' as u8) + x)
+radix!(Decimal,  10, "",   x @  0 .. 9 => ('0' as u8) + x)
+radix!(LowerHex, 16, "0x", x @  0 .. 9 => ('0' as u8) + x,
+                           x @ 10 ..15 => ('a' as u8) + (x - 10))
+radix!(UpperHex, 16, "0x", x @  0 .. 9 => ('0' as u8) + x,
+                           x @ 10 ..15 => ('A' as u8) + (x - 10))
 
 /// A radix with in the range of `2..36`.
 #[deriving(Clone, Eq)]
@@ -124,8 +124,8 @@ impl GenericRadix for Radix {
     fn base(&self) -> u8 { self.base }
     fn digit(&self, x: u8) -> u8 {
         match x {
-            x @  0 ..9 => '0' as u8 + x,
-            x if x < self.base() => 'a' as u8 + (x - 10),
+            x @  0 ..9 => ('0' as u8) + x,
+            x if x < self.base() => ('a' as u8) + (x - 10),
             x => fail!("number not in the range 0..{}: {}", self.base() - 1, x),
         }
     }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -570,7 +570,7 @@ impl<'a,T> ImmutableVector<'a, T> for &'a [T] {
             let p = self.as_ptr();
             if mem::size_of::<T>() == 0 {
                 Items{ptr: p,
-                      end: (p as uint + self.len()) as *T,
+                      end: ((p as uint) + self.len()) as *T,
                       marker: marker::ContravariantLifetime::<'a>}
             } else {
                 Items{ptr: p,
@@ -1026,7 +1026,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
             let p = self.as_mut_ptr();
             if mem::size_of::<T>() == 0 {
                 MutItems{ptr: p,
-                         end: (p as uint + self.len()) as *mut T,
+                         end: ((p as uint) + self.len()) as *mut T,
                          marker: marker::ContravariantLifetime::<'a>,
                          marker2: marker::NoCopy}
             } else {
@@ -1293,7 +1293,7 @@ macro_rules! iterator {
                             // purposefully don't use 'ptr.offset' because for
                             // vectors with 0-size elements this would return the
                             // same pointer.
-                            transmute(self.ptr as uint + 1)
+                            transmute((self.ptr as uint) + 1)
                         } else {
                             self.ptr.offset(1)
                         };

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -299,5 +299,5 @@ fn align_down(sp: *mut uint) -> *mut uint {
 #[inline]
 pub fn mut_offset<T>(ptr: *mut T, count: int) -> *mut T {
     use std::mem::size_of;
-    (ptr as int + count * (size_of::<T>() as int)) as *mut T
+    ((ptr as int) + count * (size_of::<T>() as int)) as *mut T
 }

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -476,7 +476,7 @@ impl Runtime for GreenTask {
 
         // Don't return the red zone as part of the usable stack of this task,
         // it's essentially an implementation detail.
-        (c.current_stack_segment.start() as uint + stack::RED_ZONE,
+        ((c.current_stack_segment.start() as uint) + stack::RED_ZONE,
          c.current_stack_segment.end() as uint)
     }
 

--- a/src/liblog/directive.rs
+++ b/src/liblog/directive.rs
@@ -24,7 +24,7 @@ pub static LOG_LEVEL_NAMES: [&'static str, ..4] = ["ERROR", "WARN", "INFO",
 fn parse_log_level(level: &str) -> Option<u32> {
     from_str::<u32>(level).or_else(|| {
         let pos = LOG_LEVEL_NAMES.iter().position(|&name| name.eq_ignore_ascii_case(level));
-        pos.map(|p| p as u32 + 1)
+        pos.map(|p| (p as u32) + 1)
     }).map(|p| cmp::min(p, ::MAX_LOG_LEVEL))
 }
 

--- a/src/libnative/io/util.rs
+++ b/src/libnative/io/util.rs
@@ -157,7 +157,7 @@ pub fn await(fd: net::sock_t, deadline: Option<u64>,
                 &tv as *_
             }
         };
-        let n = if cfg!(windows) {1} else {fd as libc::c_int + 1};
+        let n = if cfg!(windows) {1} else {(fd as libc::c_int) + 1};
         let r = unsafe { c::select(n, read, write, ptr::null(), tvp) };
         r
     }) {

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -2129,7 +2129,7 @@ mod bigint_tests {
         check(i64::MAX.to_bigint().unwrap(), i64::MAX);
 
         assert_eq!(
-            (i64::MAX as u64 + 1).to_bigint().unwrap().to_i64(),
+            ((i64::MAX as u64) + 1).to_bigint().unwrap().to_i64(),
             None);
 
         assert_eq!(

--- a/src/libregex/parse/mod.rs
+++ b/src/libregex/parse/mod.rs
@@ -923,7 +923,7 @@ fn combine_ranges(unordered: Vec<(char, char)>) -> Vec<(char, char)> {
     // Returns true iff the two character classes overlap or share a boundary.
     // e.g., ('a', 'g') and ('h', 'm') would return true.
     fn should_merge((a, b): (char, char), (x, y): (char, char)) -> bool {
-        cmp::max(a, x) as u32 <= cmp::min(b, y) as u32 + 1
+        cmp::max(a, x) as u32 <= (cmp::min(b, y) as u32) + 1
     }
 
     // This is currently O(n^2), but I think with sufficient cleverness,

--- a/src/librustc/back/svh.rs
+++ b/src/librustc/back/svh.rs
@@ -101,8 +101,8 @@ impl Svh {
         fn hex(b: u64) -> char {
             let b = (b & 0xf) as u8;
             let b = match b {
-                0 .. 9 => '0' as u8 + b,
-                _ => 'a' as u8 + b - 10,
+                0 .. 9 => ('0' as u8) + b,
+                _ => ('a' as u8) + b - 10,
             };
             b as char
         }

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -92,7 +92,7 @@ impl CStore {
     }
 
     pub fn next_crate_num(&self) -> ast::CrateNum {
-        self.metas.borrow().len() as ast::CrateNum + 1
+        (self.metas.borrow().len() as ast::CrateNum) + 1
     }
 
     pub fn get_crate_data(&self, cnum: ast::CrateNum) -> Rc<crate_metadata> {

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -161,12 +161,14 @@ impl<'a> Parser<'a> {
         fn parse_digit(c: char, radix: u8) -> Option<u8> {
             let c = c as u8;
             // assuming radix is either 10 or 16
-            if c >= '0' as u8 && c <= '9' as u8 {
+            if c >= ('0' as u8) && c <= ('9' as u8) {
                 Some(c - '0' as u8)
-            } else if radix > 10 && c >= 'a' as u8 && c < 'a' as u8 + (radix - 10) {
-                Some(c - 'a' as u8 + 10)
-            } else if radix > 10 && c >= 'A' as u8 && c < 'A' as u8 + (radix - 10) {
-                Some(c - 'A' as u8 + 10)
+            } else if radix > 10 && c >= ('a' as u8) &&
+                    c < ('a' as u8) + (radix - 10) {
+                Some(c - ('a' as u8) + 10)
+            } else if radix > 10 && c >= ('A' as u8) &&
+                    c < ('A' as u8) + (radix - 10) {
+                Some(c - ('A' as u8) + 10)
             } else {
                 None
             }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -200,8 +200,8 @@ pub fn int_to_str_bytes_common<T: Int>(num: T, radix: uint, sign: SignFormat, f:
             current_digit_signed
         };
         buf[cur] = match current_digit.to_u8().unwrap() {
-            i @ 0..9 => '0' as u8 + i,
-            i        => 'a' as u8 + (i - 10),
+            i @ 0..9 => ('0' as u8) + i,
+            i        => ('a' as u8) + (i - 10),
         };
         cur += 1;
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -221,7 +221,7 @@ pub fn env_as_bytes() -> Vec<(~[u8],~[u8])> {
                 raw::buf_as_slice(p, len, |s| {
                     result.push(str::from_utf16_lossy(s).into_bytes());
                 });
-                i += len as int + 1;
+                i += (len as int) + 1;
             }
             FreeEnvironmentStringsW(ch);
             result

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -650,15 +650,15 @@ mod test {
             let s = format!("%\\{1\\}%\\{2\\}%{}%d", op);
             let res = expand(s.as_bytes(), [], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
-            assert_eq!(res.unwrap(), vec!('0' as u8 + bs[0]));
+            assert_eq!(res.unwrap(), vec!(('0' as u8) + bs[0]));
             let s = format!("%\\{1\\}%\\{1\\}%{}%d", op);
             let res = expand(s.as_bytes(), [], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
-            assert_eq!(res.unwrap(), vec!('0' as u8 + bs[1]));
+            assert_eq!(res.unwrap(), vec!(('0' as u8) + bs[1]));
             let s = format!("%\\{2\\}%\\{1\\}%{}%d", op);
             let res = expand(s.as_bytes(), [], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
-            assert_eq!(res.unwrap(), vec!('0' as u8 + bs[2]));
+            assert_eq!(res.unwrap(), vec!(('0' as u8) + bs[2]));
         }
     }
 

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -294,7 +294,7 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
                     string_map.insert(name.to_strbuf(),
                                       Vec::from_slice(
                                           string_table.slice(offset as uint,
-                                          offset as uint + len)))
+                                          (offset as uint) + len)))
                 },
                 None => {
                     return Err("invalid file: missing NUL in \

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -884,7 +884,7 @@ pub fn strftime(format: &str, tm: &Tm) -> StrBuf {
     }
 
     fn iso_week(ch:char, tm: &Tm) -> StrBuf {
-        let mut year: int = tm.tm_year as int + 1900;
+        let mut year: int = (tm.tm_year as int) + 1900;
         let mut days: int = iso_week_days (tm.tm_yday, tm.tm_wday);
 
         if days < 0 {
@@ -964,7 +964,7 @@ pub fn strftime(format: &str, tm: &Tm) -> StrBuf {
             11 => "Dec".to_strbuf(),
             _  => die()
           },
-          'C' => format_strbuf!("{:02d}", (tm.tm_year as int + 1900) / 100),
+          'C' => format_strbuf!("{:02d}", ((tm.tm_year as int) + 1900) / 100),
           'c' => {
             format_strbuf!("{} {} {} {} {}",
                 parse_type('a', tm),
@@ -1048,8 +1048,8 @@ pub fn strftime(format: &str, tm: &Tm) -> StrBuf {
                              (tm.tm_yday - (tm.tm_wday - 1 + 7) % 7 + 7) / 7)
           }
           'w' => (tm.tm_wday as int).to_str().to_strbuf(),
-          'Y' => (tm.tm_year as int + 1900).to_str().to_strbuf(),
-          'y' => format_strbuf!("{:02d}", (tm.tm_year as int + 1900) % 100),
+          'Y' => ((tm.tm_year as int) + 1900).to_str().to_strbuf(),
+          'y' => format_strbuf!("{:02d}", ((tm.tm_year as int) + 1900) % 100),
           'Z' => tm.tm_zone.to_strbuf(),
           'z' => {
             let sign = if tm.tm_gmtoff > 0_i32 { '+' } else { '-' };

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -188,7 +188,7 @@ fn get_id(m: u64) -> u8 {
 fn to_vec(raw_sol: &List<u64>) -> Vec<u8> {
     let mut sol = Vec::from_elem(50, '.' as u8);
     for &m in raw_sol.iter() {
-        let id = '0' as u8 + get_id(m);
+        let id = ('0' as u8) + get_id(m);
         for i in range(0u, 50) {
             if m & 1 << i != 0 {
                 *sol.get_mut(i) = id;

--- a/src/test/run-pass/new-trait-bounds-syntax.rs
+++ b/src/test/run-pass/new-trait-bounds-syntax.rs
@@ -1,0 +1,37 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait MyTrait {
+    fn foo(&self);
+}
+
+struct MyStruct {
+    x: int,
+    y: int,
+}
+
+impl MyTrait for MyStruct {
+    fn foo(&self) {
+        println!("hello world!");
+    }
+}
+
+fn bar(x: &MyTrait + Send + Share) {
+    x.foo();
+}
+
+fn main() {
+    let traity: Box<MyTrait + Send + Share> = box MyStruct {
+        x: 1,
+        y: 2,
+    };
+    bar(traity);
+}
+

--- a/src/test/run-pass/static-impl.rs
+++ b/src/test/run-pass/static-impl.rs
@@ -16,7 +16,7 @@ pub trait plus {
 
 mod a {
     use plus;
-    impl plus for uint { fn plus(&self) -> int { *self as int + 20 } }
+    impl plus for uint { fn plus(&self) -> int { (*self as int) + 20 } }
 }
 
 mod b {
@@ -64,7 +64,7 @@ pub fn main() {
     assert_eq!((vec!(1)).length_().str(), "1".to_strbuf());
     let vect = vec!(3, 4).map_(|a| *a + 4);
     assert_eq!(*vect.get(0), 7);
-    let vect = (vec!(3, 4)).map_::<uint>(|a| *a as uint + 4u);
+    let vect = (vec!(3, 4)).map_::<uint>(|a| (*a as uint) + 4u);
     assert_eq!(*vect.get(0), 7u);
     let mut x = 0u;
     10u.multi(|_n| x += 2u );


### PR DESCRIPTION
This breaks some code that looked like `1 as u32 + 2`, because now `+`
is part of the type grammar. Change it to `(1 as u32) + 2`.

Part of #12778.

[breaking-change]

r? @alexcrichton
