### PR TITLE
[WIP] Start adding support for opt-in built-in traits

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -57,6 +57,8 @@ pub struct Arc<T> {
     _ptr: *mut ArcInner<T>,
 }
 
+impl<T> Share for Arc<T> {}
+
 /// A weak pointer to an `Arc`.
 ///
 /// Weak pointers will not keep the data inside of the `Arc` alive, and can be
@@ -68,11 +70,15 @@ pub struct Weak<T> {
     _ptr: *mut ArcInner<T>,
 }
 
+impl<T: Share> Share for Weak<T> {}
+
 struct ArcInner<T> {
     strong: atomics::AtomicUint,
     weak: atomics::AtomicUint,
     data: T,
 }
+
+impl<T: Share> Share for ArcInner<T> {}
 
 impl<T: Share + Send> Arc<T> {
     /// Create an atomically reference counted wrapper.

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -57,7 +57,7 @@ pub struct Arc<T> {
     _ptr: *mut ArcInner<T>,
 }
 
-impl<T> Share for Arc<T> {}
+impl<T: Share> Share for Arc<T> {}
 
 /// A weak pointer to an `Arc`.
 ///

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -196,6 +196,7 @@ mod std {
     pub use core::fmt;      // necessary for fail!()
     pub use core::option;   // necessary for fail!()
     pub use core::clone;    // deriving(Clone)
+    pub use core::kinds;    // deriving(Share,Send,Copy)
     pub use core::cmp;      // deriving(Eq, Ord, etc.)
     pub use hash;           // deriving(Hash)
 }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1,3 +1,4 @@
+
 // Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -25,7 +26,7 @@ use str::{CharRange, StrAllocating};
 use vec::Vec;
 
 /// A growable string stored as a UTF-8 encoded buffer.
-#[deriving(Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[deriving(Clone, PartialEq, PartialOrd, Eq, Ord, Share)]
 pub struct String {
     vec: Vec<u8>,
 }

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -43,13 +43,15 @@ use vec::Vec;
 // These would be convenient since the methods work like `each`
 
 #[allow(missing_doc)]
-#[deriving(Clone)]
+#[deriving(Clone, Share)]
 pub struct TreeMap<K, V> {
     root: Option<Box<TreeNode<K, V>>>,
     length: uint
 }
 
 impl<K: PartialEq + Ord, V: PartialEq> PartialEq for TreeMap<K, V> {
+
+impl<K: Eq + TotalOrd, V: Eq> Eq for TreeMap<K, V> {
     fn eq(&self, other: &TreeMap<K, V>) -> bool {
         self.len() == other.len() &&
             self.iter().zip(other.iter()).all(|(a, b)| a == b)

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -50,8 +50,6 @@ pub struct TreeMap<K, V> {
 }
 
 impl<K: PartialEq + Ord, V: PartialEq> PartialEq for TreeMap<K, V> {
-
-impl<K: Eq + TotalOrd, V: Eq> Eq for TreeMap<K, V> {
     fn eq(&self, other: &TreeMap<K, V>) -> bool {
         self.len() == other.len() &&
             self.iter().zip(other.iter()).all(|(a, b)| a == b)

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -51,14 +51,15 @@ use slice::{Items, MutItems};
 /// vec.push(4);
 /// assert_eq!(vec, vec!(1, 2, 3, 4));
 /// ```
-#[deriving(Share,Send,Copy)]
-#[allow(raw_pointer_deriving)]
 #[unsafe_no_drop_flag]
 pub struct Vec<T> {
     len: uint,
     cap: uint,
     ptr: *mut T
 }
+
+impl <T: Send> Send for Vec<T> {}
+impl <T: Share> Share for Vec<T> {}
 
 impl<T> Vec<T> {
     /// Constructs a new, empty `Vec`.

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -51,6 +51,8 @@ use slice::{Items, MutItems};
 /// vec.push(4);
 /// assert_eq!(vec, vec!(1, 2, 3, 4));
 /// ```
+#[deriving(Share,Send,Copy)]
+#[allow(raw_pointer_deriving)]
 #[unsafe_no_drop_flag]
 pub struct Vec<T> {
     len: uint,

--- a/src/libcore/atomics.rs
+++ b/src/libcore/atomics.rs
@@ -15,24 +15,28 @@ use std::kinds::marker;
 use ty::Unsafe;
 
 /// An atomic boolean type.
+#[deriving(Share)]
 pub struct AtomicBool {
     v: Unsafe<uint>,
     nocopy: marker::NoCopy
 }
 
 /// A signed atomic integer type, supporting basic atomic arithmetic operations
+#[deriving(Share)]
 pub struct AtomicInt {
     v: Unsafe<int>,
     nocopy: marker::NoCopy
 }
 
 /// An unsigned atomic integer type, supporting basic atomic arithmetic operations
+#[deriving(Share)]
 pub struct AtomicUint {
     v: Unsafe<uint>,
     nocopy: marker::NoCopy
 }
 
 /// An unsafe atomic pointer. Only supports basic atomic operations
+#[deriving(Share)]
 pub struct AtomicPtr<T> {
     p: Unsafe<uint>,
     nocopy: marker::NoCopy

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -14,6 +14,9 @@
 
 #![doc(primitive = "bool")]
 
+#[cfg(not(stage0))]
+use kinds::{Send, Share, Copy};
+
 use num::{Int, one, zero};
 
 /////////////////////////////////////////////////////////////////////////////
@@ -34,6 +37,19 @@ use num::{Int, one, zero};
 pub fn to_bit<N: Int>(p: bool) -> N {
     if p { one() } else { zero() }
 }
+
+/////////////////////////////////////////////////////////////////////////////
+// Trait impls on `bool`
+/////////////////////////////////////////////////////////////////////////////
+
+#[cfg(not(stage0))]
+impl Send for bool { }
+
+#[cfg(not(stage0))]
+impl Share for bool { }
+
+#[cfg(not(stage0))]
+impl Copy for bool { }
 
 #[cfg(test)]
 mod tests {

--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -26,6 +26,9 @@ pub trait Send {
     // empty.
 }
 
+#[cfg(not(stage0))]
+impl<T:Send> Send for *T { }
+
 /// Types with a constant size known at compile-time.
 #[lang="sized"]
 pub trait Sized {
@@ -37,6 +40,13 @@ pub trait Sized {
 pub trait Copy {
     // Empty.
 }
+
+#[cfg(not(stage0))]
+impl<T> Copy for *T { }
+
+#[cfg(not(stage0))]
+impl<'a, T> Copy for &'a T { }
+
 
 /// Types that can be safely shared between tasks when aliased.
 ///
@@ -87,6 +97,15 @@ pub trait Copy {
 pub trait Share {
     // Empty
 }
+
+#[cfg(not(stage0))]
+impl<T:Share> Share for *T { }
+
+#[cfg(not(stage0))]
+impl<'a,T:Share> Share for &'a T { }
+
+#[cfg(not(stage0))]
+impl<'a,T:Share> Share for &'a mut T { }
 
 /// Marker types are special types that are used with unsafe code to
 /// inform the compiler of special constraints. Marker types should

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -10,7 +10,12 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
+<<<<<<< HEAD
 #![doc(primitive = "i16")]
+=======
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+>>>>>>> core: Move impls to libcore
 
 int_module!(i16, 16)
 

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -10,12 +10,10 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
-<<<<<<< HEAD
 #![doc(primitive = "i16")]
-=======
+
 #[cfg(not(stage0))]
 use kinds::{Share, Send, Copy};
->>>>>>> core: Move impls to libcore
 
 int_module!(i16, 16)
 

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "i32")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 int_module!(i32, 32)
 

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "i64")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 int_module!(i64, 64)
 

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "i8")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 int_module!(i8, 8)
 

--- a/src/libcore/num/int.rs
+++ b/src/libcore/num/int.rs
@@ -12,6 +12,9 @@
 
 #![doc(primitive = "int")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 #[cfg(target_word_size = "32")] int_module!(int, 32)
 #[cfg(target_word_size = "64")] int_module!(int, 64)
 

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -28,6 +28,15 @@ pub static MIN: $T = (-1 as $T) << (BITS - 1);
 // calling the `Bounded::max_value` function.
 pub static MAX: $T = !MIN;
 
+#[cfg(not(stage0))]
+impl Send for $T { }
+
+#[cfg(not(stage0))]
+impl Share for $T { }
+
+#[cfg(not(stage0))]
+impl Copy for $T { }
+
 #[cfg(test)]
 mod tests {
     use prelude::*;

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -12,4 +12,7 @@
 
 #![doc(primitive = "u16")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 uint_module!(u16, i16, 16)

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "u32")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 uint_module!(u32, i32, 32)
 

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "u64")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 uint_module!(u64, i64, 64)
 

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "u8")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 uint_module!(u8, i8, 8)
 

--- a/src/libcore/num/uint.rs
+++ b/src/libcore/num/uint.rs
@@ -12,5 +12,8 @@
 
 #![doc(primitive = "uint")]
 
+#[cfg(not(stage0))]
+use kinds::{Share, Send, Copy};
+
 uint_module!(uint, int, ::int::BITS)
 

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -19,6 +19,15 @@ pub static BYTES : uint = ($bits / 8);
 pub static MIN: $T = 0 as $T;
 pub static MAX: $T = 0 as $T - 1 as $T;
 
+#[cfg(not(stage0))]
+impl Send for $T { }
+
+#[cfg(not(stage0))]
+impl Share for $T { }
+
+#[cfg(not(stage0))]
+impl Copy for $T { }
+
 #[cfg(test)]
 mod tests {
     use prelude::*;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -21,7 +21,6 @@ use cmp;
 use cmp::{PartialEq, Eq};
 use collections::Collection;
 use default::Default;
-use kinds::{Share, Send, Copy};
 use iter::{Filter, Map, Iterator};
 use iter::{DoubleEndedIterator, ExactSize};
 use iter::range;
@@ -35,10 +34,6 @@ use uint;
 /*
 Section: Creating a string
 */
-
-impl Share for ~str {}
-impl Send for ~str {}
-impl Copy for ~str {}
 
 /// Converts a vector to a string slice without performing any allocations.
 ///

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -21,6 +21,7 @@ use cmp;
 use cmp::{PartialEq, Eq};
 use collections::Collection;
 use default::Default;
+use kinds::{Share, Send, Copy};
 use iter::{Filter, Map, Iterator};
 use iter::{DoubleEndedIterator, ExactSize};
 use iter::range;
@@ -34,6 +35,10 @@ use uint;
 /*
 Section: Creating a string
 */
+
+impl Share for ~str {}
+impl Send for ~str {}
+impl Copy for ~str {}
 
 /// Converts a vector to a string slice without performing any allocations.
 ///

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -64,6 +64,7 @@
 use clone::Clone;
 #[cfg(not(test))] use cmp::*;
 #[cfg(not(test))] use default::Default;
+use kinds::{Copy, Send, Share};
 
 // macro for implementing n-ary tuple functions and operations
 macro_rules! tuple_impls {
@@ -81,6 +82,10 @@ macro_rules! tuple_impls {
                 $(fn $refN<'a>(&'a self) -> &'a $T;)+
                 $(fn $mutN<'a>(&'a mut self) -> &'a mut $T;)+
             }
+
+            impl<$($T:Copy),+> Copy for ($($T,)+) {}
+            impl<$($T:Send),+> Send for ($($T,)+) {}
+            impl<$($T:Share),+> Share for ($($T,)+) {}
 
             impl<$($T),+> $Tuple<$($T),+> for ($($T,)+) {
                 $(

--- a/src/libcore/ty.rs
+++ b/src/libcore/ty.rs
@@ -53,7 +53,7 @@ pub struct Unsafe<T> {
     pub marker1: marker::InvariantType<T>
 }
 
-impl <T:Share> Share for Unsafe<T> {}
+impl <T> Share for Unsafe<T> {}
 
 impl<T> Unsafe<T> {
 

--- a/src/libcore/ty.rs
+++ b/src/libcore/ty.rs
@@ -10,7 +10,7 @@
 
 //! Types dealing with unsafe actions.
 
-use kinds::marker;
+use kinds::{Share,marker};
 
 /// Unsafe type that wraps a type T and indicates unsafe interior operations on the
 /// wrapped type. Types with an `Unsafe<T>` field are considered to have an *unsafe
@@ -52,6 +52,8 @@ pub struct Unsafe<T> {
     /// Invariance marker
     pub marker1: marker::InvariantType<T>
 }
+
+impl <T:Share> Share for Unsafe<T> {}
 
 impl<T> Unsafe<T> {
 

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -23,6 +23,7 @@ use io::util;
 
 pub type fd_t = libc::c_int;
 
+#[deriving(Share)]
 struct Inner {
     fd: fd_t,
     close_on_drop: bool,

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -252,6 +252,7 @@ pub struct TcpStream {
     write_deadline: u64,
 }
 
+#[deriving(Share)]
 struct Inner {
     fd: sock_t,
 

--- a/src/libnative/io/pipe_unix.rs
+++ b/src/libnative/io/pipe_unix.rs
@@ -56,6 +56,7 @@ fn addr_to_sockaddr_un(addr: &CString) -> IoResult<(libc::sockaddr_storage, uint
     return Ok((storage, len));
 }
 
+#[deriving(Share)]
 struct Inner {
     fd: fd_t,
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3485,7 +3485,7 @@ pub fn type_fulfills_trait(cx: &ctxt, ty: ty::t, trait_ref: Rc<TraitRef>) -> boo
                 type_fulfills_trait(cx, typ, trait_ref.clone())
             })
         }
-        ty_param(param_ty{def_id: did, ..}) => {
+        ty_param(ParamTy{def_id: did, ..}) => {
             // NOTE(flaper87): This will likely change. It's still unsure
             // what will happen w/ the BuiltinBounds but I'm leaning towards
             // completely getting rid of them.
@@ -3502,11 +3502,9 @@ pub fn type_fulfills_trait(cx: &ctxt, ty: ty::t, trait_ref: Rc<TraitRef>) -> boo
 
             let target_trait_ref = Rc::new(ty::TraitRef {
                 def_id: trait_ref.def_id,
-                substs: subst::Substs {
-                    tps: trait_ref.substs.tps.clone(),
-                    regions: trait_ref.substs.regions.clone(),
-                    self_ty: Some(ty)
-                }
+                substs: subst::Substs::new_trait(Vec::new(),
+                                                 Vec::new(),
+                                                 ty)
             });
 
             typeck::check::vtable::ty_trait_vtable(cx, ty, target_trait_ref).is_some()

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3502,7 +3502,7 @@ pub fn type_fulfills_trait(cx: &ctxt, ty: ty::t, trait_ref: Rc<TraitRef>) -> boo
 
             let target_trait_ref = Rc::new(ty::TraitRef {
                 def_id: trait_ref.def_id,
-                substs: ty::substs {
+                substs: subst::Substs {
                     tps: trait_ref.substs.tps.clone(),
                     regions: trait_ref.substs.regions.clone(),
                     self_ty: Some(ty)
@@ -3545,10 +3545,7 @@ pub fn trait_ref_supertraits(cx: &ctxt, trait_ref: &ty::TraitRef) -> Vec<Rc<Trai
 }
 
 pub fn is_built_in_trait(cx: &ctxt, trait_ref: &ty::TraitRef) -> bool {
-    match cx.lang_items.to_builtin_kind(trait_ref.def_id) {
-        Some(_) => true,
-        None => false
-    }
+    cx.lang_items.to_builtin_kind(trait_ref.def_id).is_some()
 }
 
 fn lookup_locally_or_in_crate_store<V:Clone>(

--- a/src/librustc/middle/typeck/check/bounds.rs
+++ b/src/librustc/middle/typeck/check/bounds.rs
@@ -1,0 +1,104 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+/// Bounds Checkers
+/// This runs after the type checker and enforces that built-in trait
+/// implementations are fulfilled by the type they are implemented on.
+/// For a `struct` to fulfill a built-in trait B, all its fields types
+/// must have implement such trait.
+
+use middle::ty;
+use middle::typeck::{CrateCtxt};
+use util::ppaux;
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::visit::Visitor;
+use syntax::visit;
+use syntax::print::pprust;
+
+
+struct BoundContext<'a> {
+    tcx: &'a ty::ctxt
+}
+
+impl<'a> BoundContext<'a> {
+    fn report_error(&self, i: &ast::Item, note_span: Span, msg: &str) {
+        self.tcx.sess.span_err(i.span,
+                               format!("cannot implement a built-in trait \
+                                        on a type that doesn't fulfill such trait."));
+
+        self.tcx.sess.span_note(note_span, msg);
+    }
+}
+
+impl<'a> Visitor<()> for BoundContext<'a> {
+
+    fn visit_item(&mut self, i: &ast::Item, _: ()) {
+        match i.node {
+            ast::ItemImpl(_, Some(ref trait_ref), _, _) => {
+                let tref = ty::node_id_to_trait_ref(self.tcx, trait_ref.ref_id);
+                if !ty::is_built_in_trait(self.tcx, &*tref) {
+                    return
+                }
+
+                debug!("built-in trait implementation found: item={}",
+                       pprust::item_to_str(i))
+
+                // `nty` is `Type` in `impl Trait for Type`
+                let nty = ty::node_id_to_type(self.tcx, i.id);
+                match ty::get(nty).sty {
+                    ty::ty_struct(did, ref substs) => {
+                        let fields = ty::lookup_struct_fields(self.tcx, did);
+                        let span = self.tcx.map.span(did.node);
+
+                        for field in fields.iter() {
+                            let fty = ty::lookup_field_type(self.tcx, did, field.id, substs);
+                            if !ty::type_fulfills_trait(self.tcx, fty, tref.clone()) {
+                                self.report_error(i, span,
+                                                  format!("field with type {} does not fulfill {}",
+                                                          ppaux::ty_to_str(self.tcx, fty),
+                                                          ppaux::trait_ref_to_str(self.tcx,
+                                                                                  &*tref)));
+                            }
+                        }
+
+                    }
+                    ty::ty_enum(did, ref substs) => {
+                        let variants = ty::substd_enum_variants(self.tcx, did, substs);
+                        for variant in variants.iter() {
+                            let span = self.tcx.map.span(variant.id.node);
+                            for arg in variant.args.iter() {
+                                if !ty::type_fulfills_trait(self.tcx, *arg, tref.clone()) {
+                                    self.report_error(i, span,
+                                          format!("variant arg with type {} does not fulfill {}",
+                                                  ppaux::ty_to_str(self.tcx, *arg),
+                                                  ppaux::trait_ref_to_str(self.tcx,
+                                                                          &*tref)));
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        self.tcx.sess.span_err(i.span, "cannot implement built-in traits \
+                                                        on types that are not struct / enum");
+                        //check_type_fulfills_trait(self.tcx, i, nty, tref);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn check_bounds(ccx: &CrateCtxt, krate: &ast::Crate) {
+    let mut visitor = BoundContext {tcx: ccx.tcx};
+    visit::walk_crate(&mut visitor, krate, ());
+}

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -136,6 +136,7 @@ use syntax::visit;
 use syntax::visit::Visitor;
 use syntax;
 
+pub mod bounds;
 pub mod _match;
 pub mod vtable;
 pub mod writeback;

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -869,8 +869,8 @@ pub fn ty_trait_vtable(tcx: &ty::ctxt,
 
     let vcx = VtableContext {
         infcx: &infer::new_infer_ctxt(tcx),
-        param_env: &ty::construct_parameter_environment(tcx, None,
-                                                        [], [], [], [], trait_ref.def_id.node)
+        param_env: &ty::construct_parameter_environment(tcx, &ty::Generics::empty(),
+                                                        trait_ref.def_id.node)
     };
 
     lookup_vtable(&vcx, codemap::DUMMY_SP, ty, trait_ref, false)

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -33,6 +33,7 @@ use std::rc::Rc;
 use std::collections::HashSet;
 use syntax::ast;
 use syntax::ast_util;
+use syntax::codemap;
 use syntax::codemap::Span;
 use syntax::print::pprust::expr_to_str;
 use syntax::visit;
@@ -855,6 +856,24 @@ pub fn trans_resolve_method(tcx: &ty::ctxt, id: ast::NodeId,
                    &generics.types,
                    substs,
                    false)
+}
+
+
+/// Resolve vtables for an `ty::t` after typeck has finished.
+/// This is used by the built-in trait impl checker to verify
+/// that a type `T` implements a built-in trait `B`.
+pub fn ty_trait_vtable(tcx: &ty::ctxt,
+                       ty: ty::t,
+                       trait_ref: Rc<ty::TraitRef>) -> Option<vtable_origin> {
+
+
+    let vcx = VtableContext {
+        infcx: &infer::new_infer_ctxt(tcx),
+        param_env: &ty::construct_parameter_environment(tcx, None,
+                                                        [], [], [], [], trait_ref.def_id.node)
+    };
+
+    lookup_vtable(&vcx, codemap::DUMMY_SP, ty, trait_ref, false)
 }
 
 impl<'a, 'b> visit::Visitor<()> for &'a FnCtxt<'b> {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1077,6 +1077,11 @@ fn ty_generics(ccx: &CrateCtxt,
                     let ty = ty::mk_param(ccx.tcx, param_ty.space,
                                           param_ty.idx, param_ty.def_id);
                     let trait_ref = instantiate_trait_ref(ccx, b, ty);
+
+                    // FIXME(flaper87): Eventually, we'll get rid of the builtin
+                    // bounds EnumSet. When that happens, this will need to be
+                    // changed in order to treat built-in bounds just like every
+                    // other bound.
                     if !ty::try_add_builtin_trait(
                             ccx.tcx, trait_ref.def_id,
                             &mut param_bounds.builtin_bounds) {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -483,6 +483,9 @@ pub fn check_crate(tcx: &ty::ctxt,
     time(time_passes, "type checking", (), |_|
         check::check_item_types(&ccx, krate));
 
+    time(time_passes, "bound checking", (), |_|
+        check::bounds::check_bounds(&ccx, krate));
+
     check_for_entry_fn(&ccx);
     tcx.sess.abort_if_errors();
 }

--- a/src/librustrt/exclusive.rs
+++ b/src/librustrt/exclusive.rs
@@ -21,6 +21,7 @@ use mutex;
 ///
 /// > **Note**: This type is not recommended for general use. The mutex provided
 /// >           as part of `libsync` should almost always be favored.
+#[deriving(Share)]
 pub struct Exclusive<T> {
     lock: mutex::NativeMutex,
     data: Unsafe<T>,

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -164,5 +164,5 @@ pub mod shouldnt_be_public {
 
 #[cfg(not(test))]
 mod std {
-    pub use core::{fmt, option, cmp};
+    pub use core::{fmt, option, cmp, kinds};
 }

--- a/src/librustuv/queue.rs
+++ b/src/librustuv/queue.rs
@@ -37,6 +37,8 @@ enum Message {
     Decrement,
 }
 
+#[deriving(Share)]
+#[allow(raw_pointer_deriving)]
 struct State {
     handle: *uvll::uv_async_t,
     lock: NativeMutex, // see comments in async_cb for why this is needed
@@ -51,6 +53,8 @@ pub struct QueuePool {
 }
 
 /// This type is used to send messages back to the original event loop.
+#[deriving(Share)]
+#[allow(raw_pointer_deriving)]
 pub struct Queue {
     queue: Arc<State>,
 }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -243,7 +243,7 @@ use std::vec::Vec;
 use Encodable;
 
 /// Represents a json value
-#[deriving(Clone, PartialEq)]
+#[deriving(Clone, PartialEq, Share)]
 pub enum Json {
     Number(f64),
     String(String),

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -267,6 +267,7 @@ mod std {
     pub use clone;
     pub use cmp;
     pub use hash;
+    pub use kinds;
 
     pub use comm; // used for select!()
     pub use fmt; // used for any formatting strings

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -13,6 +13,16 @@
 
 macro_rules! int_module (($T:ty) => (
 
+#[cfg(not(stage0))]
+impl Send for $T { }
+
+#[cfg(not(stage0))]
+impl Share for $T { }
+
+#[cfg(not(stage0))]
+impl Copy for $T { }
+
+
 // String conversion functions and impl str -> num
 
 /// Parse a byte slice as a number in the given base

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -13,16 +13,6 @@
 
 macro_rules! int_module (($T:ty) => (
 
-#[cfg(not(stage0))]
-impl Send for $T { }
-
-#[cfg(not(stage0))]
-impl Share for $T { }
-
-#[cfg(not(stage0))]
-impl Copy for $T { }
-
-
 // String conversion functions and impl str -> num
 
 /// Parse a byte slice as a number in the given base

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -14,6 +14,15 @@
 
 macro_rules! uint_module (($T:ty) => (
 
+#[cfg(not(stage0))]
+impl Send for $T { }
+
+#[cfg(not(stage0))]
+impl Share for $T { }
+
+#[cfg(not(stage0))]
+impl Copy for $T { }
+
 // String conversion functions and impl str -> num
 
 /// Parse a byte slice as a number in the given base

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -14,15 +14,6 @@
 
 macro_rules! uint_module (($T:ty) => (
 
-#[cfg(not(stage0))]
-impl Send for $T { }
-
-#[cfg(not(stage0))]
-impl Share for $T { }
-
-#[cfg(not(stage0))]
-impl Copy for $T { }
-
 // String conversion functions and impl str -> num
 
 /// Parse a byte slice as a number in the given base

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -35,7 +35,7 @@ pub type StrComponents<'a> = Map<'a, &'a [u8], Option<&'a str>,
                                        Components<'a>>;
 
 /// Represents a POSIX file path
-#[deriving(Clone)]
+#[deriving(Clone,Share)]
 pub struct Path {
     repr: Vec<u8>, // assumed to never be empty or contain NULs
     sepidx: Option<uint> // index of the final separator in repr

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -73,7 +73,7 @@ pub type Components<'a> = Map<'a, Option<&'a str>, &'a [u8],
 //
 // The only error condition imposed here is valid utf-8. All other invalid paths are simply
 // preserved by the data structure; let the Windows API error out on them.
-#[deriving(Clone)]
+#[deriving(Clone,Share)]
 pub struct Path {
     repr: String, // assumed to never be empty
     prefix: Option<PathPrefix>,

--- a/src/libsync/deque.rs
+++ b/src/libsync/deque.rs
@@ -74,6 +74,7 @@ static K: int = 4;
 // The size in question is 1 << MIN_BITS
 static MIN_BITS: int = 7;
 
+#[deriving(Share)]
 struct Deque<T> {
     bottom: AtomicInt,
     top: AtomicInt,

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -76,5 +76,5 @@ mod lock;
 
 #[cfg(not(test))]
 mod std {
-    pub use core::{fmt, option, cmp, clone};
+    pub use core::{fmt, option, cmp, clone, kinds};
 }

--- a/src/libsync/lock.rs
+++ b/src/libsync/lock.rs
@@ -278,6 +278,8 @@ pub struct RWLock<T> {
     data: Unsafe<T>,
 }
 
+impl<T: Share> Share for RWLock<T> {}
+
 /// A guard which is created by locking an rwlock in write mode. Through this
 /// guard the underlying data can be accessed.
 pub struct RWLockWriteGuard<'a, T> {

--- a/src/libsync/mpmc_bounded_queue.rs
+++ b/src/libsync/mpmc_bounded_queue.rs
@@ -44,6 +44,7 @@ struct Node<T> {
     value: Option<T>,
 }
 
+#[deriving(Share)]
 struct State<T> {
     pad0: [u8, ..64],
     buffer: Vec<Unsafe<Node<T>>>,
@@ -55,6 +56,7 @@ struct State<T> {
     pad3: [u8, ..64],
 }
 
+#[deriving(Share)]
 pub struct Queue<T> {
     state: Arc<State<T>>,
 }

--- a/src/libsync/mpsc_queue.rs
+++ b/src/libsync/mpsc_queue.rs
@@ -69,6 +69,8 @@ struct Node<T> {
 /// The multi-producer single-consumer structure. This is not cloneable, but it
 /// may be safely shared so long as it is guaranteed that there is only one
 /// popper at a time (many pushers are allowed).
+#[deriving(Share)]
+#[allow(raw_pointer_deriving)]
 pub struct Queue<T> {
     head: AtomicPtr<Node<T>>,
     tail: Unsafe<*mut Node<T>>,

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -36,6 +36,7 @@ fn init() -> arc_destruct<context_res> {
     arc(context_res())
 }
 
+#[deriving(Share)]
 struct context_res {
     ctx : int,
 }

--- a/src/test/compile-fail/builtin-superkinds-double-superkind.rs
+++ b/src/test/compile-fail/builtin-superkinds-double-superkind.rs
@@ -13,10 +13,10 @@
 
 trait Foo : Send+Share { }
 
-impl <T: Share> Foo for (T,) { } //~ ERROR cannot implement this trait
+impl <T:Share> Foo for (T,) { } //~ ERROR cannot implement this trait
 
-impl <T: Send> Foo for (T,T) { } //~ ERROR cannot implement this trait
+impl <T:Send> Foo for (T,T) { } //~ ERROR cannot implement this trait
 
-impl <T: Send+Share> Foo for (T,T,T) { } // (ok)
+impl <T:Send+Share> Foo for (T,T,T) { } // (ok)
 
 fn main() { }

--- a/src/test/compile-fail/builtin-superkinds-in-metadata.rs
+++ b/src/test/compile-fail/builtin-superkinds-in-metadata.rs
@@ -19,6 +19,8 @@ use trait_superkinds_in_metadata::{RequiresRequiresShareAndSend, RequiresShare};
 
 struct X<T>(T);
 
+impl<T:Share> Share for X<T> {}
+
 impl <T:Share> RequiresShare for X<T> { }
 
 impl <T:Share> RequiresRequiresShareAndSend for X<T> { } //~ ERROR cannot implement this trait

--- a/src/test/compile-fail/typeck-bounds-share-impls.rs
+++ b/src/test/compile-fail/typeck-bounds-share-impls.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // Verify that `Share` bounds are correctly enforced.
 
 struct MyStruct;
@@ -20,7 +21,7 @@ struct NotShareStruct<'a> {
 }
 
 impl<'a> Share for NotShareStruct<'a> {}
-//~^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait.
+//~^ ERROR cannot implement the trait `core::kinds::Share` on type `NotShareStruct<a>` because the field with type `MyStruct` doesn't fulfill such trait.
 
 enum Foo {
     Var(MyStruct)

--- a/src/test/compile-fail/typeck-bounds-share-impls.rs
+++ b/src/test/compile-fail/typeck-bounds-share-impls.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verify that `Share` bounds are correctly enforced.
+
+struct MyStruct;
+
+struct NotShareStruct<'a> {
+    a: *MyStruct, // *-pointers are share if T is share
+    //b: &'a MyStruct, // &-pointers are share if T is share
+    //c: &'a mut MyStruct, // &mut-pointers are share if T is share
+    d: MyStruct
+}
+
+impl<'a> Share for NotShareStruct<'a> {}
+//~^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait.
+
+enum Foo {
+    Var(MyStruct)
+}
+
+fn share<T:Share>(_: T) {}
+
+fn main() {
+    share(Var(MyStruct));
+    // FIXME(flaper87): This still doesn't typeck
+    //ERROR type parameter with an incompatible type
+}

--- a/src/test/compile-fail/typeck-bounds-type-impl.rs
+++ b/src/test/compile-fail/typeck-bounds-type-impl.rs
@@ -1,0 +1,101 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Verify that built-in trait implementations are enforced recursively on
+// a type.
+
+#![feature(struct_inherit)]
+
+trait DummyTrait {}
+
+struct ShareStruct;
+
+impl DummyTrait for ShareStruct {}
+impl Share for ShareStruct {}
+
+struct SendShareStruct {
+    a: ShareStruct
+}
+
+impl DummyTrait for SendShareStruct {}
+impl Share for SendShareStruct {}
+
+impl Send for SendShareStruct {}
+//~^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
+
+enum ShareEnum {}
+impl Share for ShareEnum {}
+
+enum ShareSendEnum {}
+impl Share for ShareSendEnum {}
+impl Send for ShareSendEnum {}
+
+enum SendShareEnum {
+    MyShareEnumVariant(ShareEnum),
+    MyShareStructVariant(ShareStruct),
+    MyShareSendEnumVariant(ShareEnum, ShareSendEnum)
+}
+
+impl Share for SendShareEnum {}
+impl Send for SendShareEnum {}
+//~^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^^^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
+
+virtual struct Base {
+    a: ShareStruct
+}
+
+struct InheritedShareStruct: Base;
+
+impl Share for InheritedShareStruct {}
+impl Send for InheritedShareStruct {}
+//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+
+#[deriving(Send)]
+//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+struct SendShareStruct2 {
+    a: ShareStruct
+}
+
+
+type MyType = ||:'static -> ShareStruct;
+
+impl Share for MyType {}
+//~^ ERROR cannot implement built-in traits on types that are not struct / enum
+
+
+struct ProcNoShareStruct {
+    a: proc()
+}
+
+impl Share for ProcNoShareStruct {}
+//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+
+struct ProcShareStruct {
+    a: proc():Share
+}
+
+impl Share for ProcShareStruct {}
+
+struct ClosureShareStruct {
+    a: ||:'static+Share
+}
+
+impl Share for ClosureShareStruct {}
+
+struct ClosureNotShareStruct {
+    a: ||:'static
+}
+
+impl Share for ClosureNotShareStruct {}
+//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+
+fn main() {}

--- a/src/test/compile-fail/typeck-bounds-type-impl.rs
+++ b/src/test/compile-fail/typeck-bounds-type-impl.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
+
 // Verify that built-in trait implementations are enforced recursively on
 // a type.
 
@@ -28,7 +30,7 @@ impl DummyTrait for SendShareStruct {}
 impl Share for SendShareStruct {}
 
 impl Send for SendShareStruct {}
-//~^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^ ERROR cannot implement the trait `core::kinds::Send` on type `SendShareStruct` because the field with type `ShareStruct` doesn't fulfill such trait.
 
 enum ShareEnum {}
 impl Share for ShareEnum {}
@@ -45,9 +47,9 @@ enum SendShareEnum {
 
 impl Share for SendShareEnum {}
 impl Send for SendShareEnum {}
-//~^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
-//~^^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
-//~^^^ ERROR cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^ ERROR cannot implement the trait `core::kinds::Send` on type `SendShareEnum` because variant arg with type `ShareEnum` doesn't fulfill such trait.
+//~^^ ERROR cannot implement the trait `core::kinds::Send` on type `SendShareEnum` because variant arg with type `ShareStruct` doesn't fulfill such trait.
+//~^^^ ERROR cannot implement the trait `core::kinds::Send` on type `SendShareEnum` because variant arg with type `ShareEnum` doesn't fulfill such trait.
 
 virtual struct Base {
     a: ShareStruct
@@ -57,10 +59,10 @@ struct InheritedShareStruct: Base;
 
 impl Share for InheritedShareStruct {}
 impl Send for InheritedShareStruct {}
-//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^ ERROR cannot implement the trait `core::kinds::Send` on type `InheritedShareStruct` because the field with type `ShareStruct` doesn't fulfill such trait.
 
 #[deriving(Send)]
-//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^ ERROR cannot implement the trait `core::kinds::Send` on type `SendShareStruct2` because the field with type `ShareStruct` doesn't fulfill such trait.
 struct SendShareStruct2 {
     a: ShareStruct
 }
@@ -69,15 +71,14 @@ struct SendShareStruct2 {
 type MyType = ||:'static -> ShareStruct;
 
 impl Share for MyType {}
-//~^ ERROR cannot implement built-in traits on types that are not struct / enum
-
+//~^ ERROR can only implement built-in trait `core::kinds::Share` on a struct or enum
 
 struct ProcNoShareStruct {
     a: proc()
 }
 
 impl Share for ProcNoShareStruct {}
-//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^ ERROR cannot implement the trait `core::kinds::Share` on type `ProcNoShareStruct` because the field with type `proc()` doesn't fulfill such trait.
 
 struct ProcShareStruct {
     a: proc():Share
@@ -96,6 +97,6 @@ struct ClosureNotShareStruct {
 }
 
 impl Share for ClosureNotShareStruct {}
-//~^ Error cannot implement a built-in trait on a type that doesn't fulfill such trait
+//~^ ERROR cannot implement the trait `core::kinds::Share` on type `ClosureNotShareStruct` because the field with type `'static ||:'static` doesn't fulfill such trait.
 
 fn main() {}

--- a/src/test/compile-fail/typeck-unsafe-always-share.rs
+++ b/src/test/compile-fail/typeck-unsafe-always-share.rs
@@ -19,6 +19,8 @@ struct MyShare<T> {
     u: Unsafe<T>
 }
 
+impl<T:Share> Share for MyShare<T> {}
+
 struct NoShare {
     m: marker::NoShare
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
@@ -20,6 +20,7 @@ use trait_superkinds_in_metadata::{RequiresRequiresShareAndSend, RequiresShare};
 #[deriving(PartialEq)]
 struct X<T>(T);
 
+impl <T:Share> Share for X<T> {}
 impl <T: Share> RequiresShare for X<T> { }
 impl <T: Share+Send> RequiresRequiresShareAndSend for X<T> { }
 

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -19,6 +19,8 @@ use trait_superkinds_in_metadata::{RequiresCopy};
 
 struct X<T>(T);
 
+impl <T:Share> Share for X<T> {}
+
 impl <T:Share> RequiresShare for X<T> { }
 
 impl <T:Share+Send> RequiresRequiresShareAndSend for X<T> { }

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -15,23 +15,27 @@
 use std::sync::Arc;
 use std::task;
 
+#[deriving(Share)]
 trait Pet {
     fn name(&self, blk: |&str|);
     fn num_legs(&self) -> uint;
     fn of_good_pedigree(&self) -> bool;
 }
 
+#[deriving(Share)]
 struct Catte {
     num_whiskers: uint,
     name: String,
 }
 
+#[deriving(Share)]
 struct Dogge {
     bark_decibels: uint,
     tricks_known: uint,
     name: String,
 }
 
+#[deriving(Share)]
 struct Goldfyshe {
     swim_speed: uint,
     name: String,

--- a/src/test/run-pass/typeck-bounds-type-impl.rs
+++ b/src/test/run-pass/typeck-bounds-type-impl.rs
@@ -8,24 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test
+// Checks for built-in traits implementation
 
-// Tests that an `&` pointer to something inherently mutable is itself
-// to be considered mutable.
+#[deriving(Share, Send, Copy)]
+struct Struct;
 
-use std::kinds::marker;
-
-enum Foo { A(marker::NoShare) }
-
-trait Test {}
-
-impl<'a> Test for &'a Foo {}
-
-fn bar<T: Test+Share>(_: T) {}
-
-fn main() {
-    let x = A(marker::NoShare);
-    bar(&x);
-    //FIXME(flaper87): Not yet
-    // ERROR type parameter with an incompatible type
+#[deriving(Share, Send, Copy)]
+struct SendShareStruct2 {
+    a: Struct
 }
+
+struct ManualImpl;
+
+impl Share for ManualImpl {}
+
+fn main() {}


### PR DESCRIPTION
This is the first PR adding actual logic for this RFC.

It's still a work in progress but I'd like to start getting feedback from the community. 

The PR consists in:
- Adding a bounds checker visitor. As of now, this visitor 'only' checks trait implementations. When a trait implementation for a built-in trait is found, it iterates over the implementation type and checks whether it fulfills the trait.
- Adding a function that gets the trait impl vtables for a type. 
- Implementing the `Share` trait for the types requiring it. Note that the implementations added are the ones required to make rust compile. There may definitely be missing implementations for this trait.
- Implementing all the built-in traits for the built-in types

There are still some issues I'm working on. For instance, some fields in the `typeck-bounds-share-impls` are commented out because I hit a compiler bug if they're not. The compiler bug is not really clear to me but I'm working with Niko on figuring what's going on there.

(sorry for taking so long to post this)

cc @nikomatsakis @pcwalton 

cc #13231
[breaking-change]
[RFC#3]
