### PR TITLE
rustdoc: Inline documentation across crates

### DIFF
--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -41,7 +41,9 @@ pub fn recalibrate() {
 # }
 ~~~
 
-Documentation can also be controlled via the `doc` attribute on items.
+Documentation can also be controlled via the `doc` attribute on items. This is
+implicitly done by the compiler when using the above form of doc comments
+(converting the slash-based comments to `#[doc]` attributes).
 
 ~~~
 #[doc = "
@@ -50,6 +52,7 @@ Calculates the factorial of a number.
 Given the input integer `n`, this function will calculate `n!` and return it.
 "]
 pub fn factorial(n: int) -> int { if n < 2 {1} else {n * factorial(n)} }
+# fn main() {}
 ~~~
 
 The `doc` attribute can also be used to control how rustdoc emits documentation
@@ -60,6 +63,7 @@ in some cases.
 // `pub use` reaches across crates, but this behavior can also be disabled.
 #[doc(no_inline)]
 pub use std::option::Option;
+# fn main() {}
 ```
 
 Doc comments are markdown, and are currently parsed with the

--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -41,6 +41,27 @@ pub fn recalibrate() {
 # }
 ~~~
 
+Documentation can also be controlled via the `doc` attribute on items.
+
+~~~
+#[doc = "
+Calculates the factorial of a number.
+
+Given the input integer `n`, this function will calculate `n!` and return it.
+"]
+pub fn factorial(n: int) -> int { if n < 2 {1} else {n * factorial(n)} }
+~~~
+
+The `doc` attribute can also be used to control how rustdoc emits documentation
+in some cases.
+
+```
+// Rustdoc will inline documentation of a `pub use` into this crate when the
+// `pub use` reaches across crates, but this behavior can also be disabled.
+#[doc(no_inline)]
+pub use std::option::Option;
+```
+
 Doc comments are markdown, and are currently parsed with the
 [sundown][sundown] library. rustdoc does not yet do any fanciness such as
 referencing other items inline, like javadoc's `@see`. One exception to this

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -206,6 +206,9 @@ pub static tag_crate_triple: uint = 0x66;
 
 pub static tag_dylib_dependency_formats: uint = 0x67;
 
+pub static tag_method_argument_names: uint = 0x8e;
+pub static tag_method_argument_name: uint = 0x8f;
+
 #[deriving(Clone, Show)]
 pub struct LinkMeta {
     pub crateid: CrateId,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -308,7 +308,7 @@ pub fn get_missing_lang_items(cstore: &cstore::CStore, cnum: ast::CrateNum)
 }
 
 pub fn get_method_arg_names(cstore: &cstore::CStore, did: ast::DefId)
-    -> Vec<StrBuf>
+    -> Vec<String>
 {
     let cdata = cstore.get_crate_data(did.krate);
     decoder::get_method_arg_names(&*cdata, did.node)

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -306,3 +306,10 @@ pub fn get_missing_lang_items(cstore: &cstore::CStore, cnum: ast::CrateNum)
     let cdata = cstore.get_crate_data(cnum);
     decoder::get_missing_lang_items(&*cdata)
 }
+
+pub fn get_method_arg_names(cstore: &cstore::CStore, did: ast::DefId)
+    -> Vec<StrBuf>
+{
+    let cdata = cstore.get_crate_data(did.krate);
+    decoder::get_method_arg_names(&*cdata, did.node)
+}

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1309,3 +1309,18 @@ pub fn get_missing_lang_items(cdata: Cmd)
     });
     return result;
 }
+
+pub fn get_method_arg_names(cdata: Cmd, id: ast::NodeId) -> Vec<StrBuf> {
+    let mut ret = Vec::new();
+    let method_doc = lookup_item(id, cdata.data());
+    match reader::maybe_get_doc(method_doc, tag_method_argument_names) {
+        Some(args_doc) => {
+            reader::tagged_docs(args_doc, tag_method_argument_name, |name_doc| {
+                ret.push(name_doc.as_str_slice().to_strbuf());
+                true
+            });
+        }
+        None => {}
+    }
+    return ret;
+}

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1310,7 +1310,7 @@ pub fn get_missing_lang_items(cdata: Cmd)
     return result;
 }
 
-pub fn get_method_arg_names(cdata: Cmd, id: ast::NodeId) -> Vec<StrBuf> {
+pub fn get_method_arg_names(cdata: Cmd, id: ast::NodeId) -> Vec<String> {
     let mut ret = Vec::new();
     let method_doc = lookup_item(id, cdata.data());
     match reader::maybe_get_doc(method_doc, tag_method_argument_names) {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -536,6 +536,7 @@ fn encode_reexports(ecx: &EncodeContext,
 fn encode_info_for_mod(ecx: &EncodeContext,
                        ebml_w: &mut Encoder,
                        md: &Mod,
+                       attrs: &[Attribute],
                        id: NodeId,
                        path: PathElems,
                        name: Ident,
@@ -584,6 +585,7 @@ fn encode_info_for_mod(ecx: &EncodeContext,
         debug!("(encoding info for module) encoding reexports for {}", id);
         encode_reexports(ecx, ebml_w, id, path);
     }
+    encode_attributes(ebml_w, attrs);
 
     ebml_w.end_tag();
 }
@@ -938,6 +940,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_info_for_mod(ecx,
                             ebml_w,
                             m,
+                            item.attrs.as_slice(),
                             item.id,
                             path,
                             item.ident,
@@ -1337,6 +1340,7 @@ fn encode_info_for_items(ecx: &EncodeContext,
     encode_info_for_mod(ecx,
                         ebml_w,
                         &krate.module,
+                        &[],
                         CRATE_NODE_ID,
                         ast_map::Values([].iter()).chain(None),
                         syntax::parse::token::special_idents::invalid,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -774,6 +774,21 @@ fn encode_info_for_method(ecx: &EncodeContext,
         } else {
             encode_symbol(ecx, ebml_w, m.def_id.node);
         }
+
+        ebml_w.start_tag(tag_method_argument_names);
+        for arg in ast_method.decl.inputs.iter() {
+            ebml_w.start_tag(tag_method_argument_name);
+            match arg.pat.node {
+                ast::PatIdent(_, ref name, _) => {
+                    let name = name.segments.last().unwrap().identifier;
+                    let name = token::get_ident(name);
+                    ebml_w.writer.write(name.get().as_bytes());
+                }
+                _ => {}
+            }
+            ebml_w.end_tag();
+        }
+        ebml_w.end_tag();
     }
 
     ebml_w.end_tag();

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1571,6 +1571,9 @@ fn try_inline(id: ast::NodeId) -> Option<Vec<Item>> {
             ret.extend(build_impls(tcx, did).move_iter());
             build_type(tcx, did)
         }
+        // Assume that the enum type is reexported next to the variant, and
+        // variants don't show up in documentation specially.
+        ast::DefVariant(..) => return Some(Vec::new()),
         _ => return None,
     };
     let fqn = csearch::get_item_path(tcx, did);

--- a/src/librustdoc/clean.rs
+++ b/src/librustdoc/clean.rs
@@ -1961,7 +1961,7 @@ fn build_impl(tcx: &ty::ctxt, did: ast::DefId) -> Item {
     let associated_trait = csearch::get_impl_trait(tcx, did);
     let attrs = load_attrs(tcx, did);
     let ty = ty::lookup_item_type(tcx, did);
-    let methods = tcx.impl_methods.borrow().get(&did).iter().map(|did| {
+    let methods = csearch::get_impl_methods(&tcx.sess.cstore, did).iter().map(|did| {
         let mut item = match ty::method(tcx, *did).clean() {
             Provided(item) => item,
             Required(item) => item,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -1,0 +1,278 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Support for inlining external documentation into the current AST.
+
+use syntax::ast;
+use syntax::ast_util;
+use syntax::attr::AttrMetaMethods;
+
+use rustc::metadata::csearch;
+use rustc::metadata::decoder;
+use rustc::middle::ty;
+
+use core;
+use doctree;
+use clean;
+
+use super::Clean;
+
+/// Attempt to inline the definition of a local node id into this AST.
+///
+/// This function will fetch the definition of the id specified, and if it is
+/// from another crate it will attempt to inline the documentation from the
+/// other crate into this crate.
+///
+/// This is primarily used for `pub use` statements which are, in general,
+/// implementation details. Inlining the documentation should help provide a
+/// better experience when reading the documentation in this use case.
+///
+/// The returned value is `None` if the `id` could not be inlined, and `Some`
+/// of a vector of items if it was successfully expanded.
+pub fn try_inline(id: ast::NodeId) -> Option<Vec<clean::Item>> {
+    let cx = ::ctxtkey.get().unwrap();
+    let tcx = match cx.maybe_typed {
+        core::Typed(ref tycx) => tycx,
+        core::NotTyped(_) => return None,
+    };
+    let def = match tcx.def_map.borrow().find(&id) {
+        Some(def) => *def,
+        None => return None,
+    };
+    let did = ast_util::def_id_of_def(def);
+    if ast_util::is_local(did) { return None }
+    try_inline_def(&**cx, tcx, def)
+}
+
+fn try_inline_def(cx: &core::DocContext,
+                  tcx: &ty::ctxt,
+                  def: ast::Def) -> Option<Vec<clean::Item>> {
+    let mut ret = Vec::new();
+    let did = ast_util::def_id_of_def(def);
+    let inner = match def {
+        ast::DefTrait(did) => {
+            record_extern_fqn(cx, did, clean::TypeTrait);
+            clean::TraitItem(build_external_trait(tcx, did))
+        }
+        ast::DefFn(did, style) => {
+            record_extern_fqn(cx, did, clean::TypeFunction);
+            clean::FunctionItem(build_external_function(tcx, did, style))
+        }
+        ast::DefStruct(did) => {
+            record_extern_fqn(cx, did, clean::TypeStruct);
+            ret.extend(build_impls(tcx, did).move_iter());
+            clean::StructItem(build_struct(tcx, did))
+        }
+        ast::DefTy(did) => {
+            record_extern_fqn(cx, did, clean::TypeEnum);
+            ret.extend(build_impls(tcx, did).move_iter());
+            build_type(tcx, did)
+        }
+        // Assume that the enum type is reexported next to the variant, and
+        // variants don't show up in documentation specially.
+        ast::DefVariant(..) => return Some(Vec::new()),
+        ast::DefMod(did) => {
+            record_extern_fqn(cx, did, clean::TypeModule);
+            clean::ModuleItem(build_module(cx, tcx, did))
+        }
+        _ => return None,
+    };
+    let fqn = csearch::get_item_path(tcx, did);
+    ret.push(clean::Item {
+        source: clean::Span::empty(),
+        name: Some(fqn.last().unwrap().to_str().to_strbuf()),
+        attrs: load_attrs(tcx, did),
+        inner: inner,
+        visibility: Some(ast::Public),
+        def_id: did,
+    });
+    Some(ret)
+}
+
+pub fn load_attrs(tcx: &ty::ctxt, did: ast::DefId) -> Vec<clean::Attribute> {
+    let mut attrs = Vec::new();
+    csearch::get_item_attrs(&tcx.sess.cstore, did, |v| {
+        attrs.extend(v.move_iter().map(|mut a| {
+            // FIXME this isn't quite always true, it's just true about 99% of
+            //       the time when dealing with documentation. For example,
+            //       this would treat doc comments of the form `#[doc = "foo"]`
+            //       incorrectly.
+            if a.name().get() == "doc" && a.value_str().is_some() {
+                a.node.is_sugared_doc = true;
+            }
+            a.clean()
+        }));
+    });
+    attrs
+}
+
+/// Record an external fully qualified name in the external_paths cache.
+///
+/// These names are used later on by HTML rendering to generate things like
+/// source links back to the original item.
+pub fn record_extern_fqn(cx: &core::DocContext,
+                         did: ast::DefId,
+                         kind: clean::TypeKind) {
+    match cx.maybe_typed {
+        core::Typed(ref tcx) => {
+            let fqn = csearch::get_item_path(tcx, did);
+            let fqn = fqn.move_iter().map(|i| i.to_str().to_strbuf()).collect();
+            cx.external_paths.borrow_mut().get_mut_ref().insert(did, (fqn, kind));
+        }
+        core::NotTyped(..) => {}
+    }
+}
+
+pub fn build_external_trait(tcx: &ty::ctxt, did: ast::DefId) -> clean::Trait {
+    let def = ty::lookup_trait_def(tcx, did);
+    let methods = ty::trait_methods(tcx, did);
+    clean::Trait {
+        generics: def.generics.clean(),
+        methods: methods.iter().map(|i| i.clean()).collect(),
+        parents: Vec::new(), // FIXME: this is likely wrong
+    }
+}
+
+fn build_external_function(tcx: &ty::ctxt,
+                           did: ast::DefId,
+                           style: ast::FnStyle) -> clean::Function {
+    let t = ty::lookup_item_type(tcx, did);
+    clean::Function {
+        decl: match ty::get(t.ty).sty {
+            ty::ty_bare_fn(ref f) => (did, &f.sig).clean(),
+            _ => fail!("bad function"),
+        },
+        generics: t.generics.clean(),
+        fn_style: style,
+    }
+}
+
+fn build_struct(tcx: &ty::ctxt, did: ast::DefId) -> clean::Struct {
+    use syntax::parse::token::special_idents::unnamed_field;
+
+    let t = ty::lookup_item_type(tcx, did);
+    let fields = ty::lookup_struct_fields(tcx, did);
+
+    clean::Struct {
+        struct_type: match fields.as_slice() {
+            [] => doctree::Unit,
+            [ref f] if f.name == unnamed_field.name => doctree::Newtype,
+            [ref f, ..] if f.name == unnamed_field.name => doctree::Tuple,
+            _ => doctree::Plain,
+        },
+        generics: t.generics.clean(),
+        fields: fields.iter().map(|f| f.clean()).collect(),
+        fields_stripped: false,
+    }
+}
+
+fn build_type(tcx: &ty::ctxt, did: ast::DefId) -> clean::ItemEnum {
+    let t = ty::lookup_item_type(tcx, did);
+    match ty::get(t.ty).sty {
+        ty::ty_enum(edid, _) => {
+            return clean::EnumItem(clean::Enum {
+                generics: t.generics.clean(),
+                variants_stripped: false,
+                variants: ty::enum_variants(tcx, edid).clean(),
+            })
+        }
+        _ => {}
+    }
+
+    clean::TypedefItem(clean::Typedef {
+        type_: t.ty.clean(),
+        generics: t.generics.clean(),
+    })
+}
+
+fn build_impls(tcx: &ty::ctxt,
+               did: ast::DefId) -> Vec<clean::Item> {
+    ty::populate_implementations_for_type_if_necessary(tcx, did);
+    let mut impls = Vec::new();
+
+    match tcx.inherent_impls.borrow().find(&did) {
+        None => {}
+        Some(i) => {
+            impls.extend(i.borrow().iter().map(|&did| { build_impl(tcx, did) }));
+        }
+    }
+
+    impls
+}
+
+fn build_impl(tcx: &ty::ctxt, did: ast::DefId) -> clean::Item {
+    let associated_trait = csearch::get_impl_trait(tcx, did);
+    let attrs = load_attrs(tcx, did);
+    let ty = ty::lookup_item_type(tcx, did);
+    let methods = csearch::get_impl_methods(&tcx.sess.cstore, did).iter().map(|did| {
+        let mut item = match ty::method(tcx, *did).clean() {
+            clean::Provided(item) => item,
+            clean::Required(item) => item,
+        };
+        item.inner = match item.inner.clone() {
+            clean::TyMethodItem(clean::TyMethod {
+                fn_style, decl, self_, generics
+            }) => {
+                clean::MethodItem(clean::Method {
+                    fn_style: fn_style,
+                    decl: decl,
+                    self_: self_,
+                    generics: generics,
+                })
+            }
+            _ => fail!("not a tymethod"),
+        };
+        item
+    }).collect();
+    clean::Item {
+        inner: clean::ImplItem(clean::Impl {
+            derived: clean::detect_derived(attrs.as_slice()),
+            trait_: associated_trait.clean().map(|bound| {
+                match bound {
+                    clean::TraitBound(ty) => ty,
+                    clean::RegionBound => unreachable!(),
+                }
+            }),
+            for_: ty.ty.clean(),
+            generics: ty.generics.clean(),
+            methods: methods,
+        }),
+        source: clean::Span::empty(),
+        name: None,
+        attrs: attrs,
+        visibility: Some(ast::Inherited),
+        def_id: did,
+    }
+}
+
+fn build_module(cx: &core::DocContext, tcx: &ty::ctxt,
+                did: ast::DefId) -> clean::Module {
+    let mut items = Vec::new();
+
+    // FIXME: this doesn't handle reexports inside the module itself.
+    //        Should they be handled?
+    csearch::each_child_of_item(&tcx.sess.cstore, did, |def, _, _| {
+        match def {
+            decoder::DlDef(def) => {
+                match try_inline_def(cx, tcx, def) {
+                    Some(i) => items.extend(i.move_iter()),
+                    None => {}
+                }
+            }
+            decoder::DlImpl(did) => items.push(build_impl(tcx, did)),
+            decoder::DlField => fail!("unimplemented field"),
+        }
+    });
+
+    clean::Module {
+        items: items,
+        is_crate: false,
+    }
+}

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -150,7 +150,7 @@ fn resolved_path(w: &mut fmt::Formatter, did: ast::DefId, p: &clean::Path,
                  print_all: bool) -> fmt::Result {
     path(w, p, print_all,
         |cache, loc| {
-            if ast_util::is_local(did) {
+            if ast_util::is_local(did) || cache.paths.contains_key(&did) {
                 Some(("../".repeat(loc.len())).to_strbuf())
             } else {
                 match *cache.extern_locations.get(&did.krate) {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -99,7 +99,7 @@ impl fmt::Show for clean::TyParamBound {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             clean::RegionBound => {
-                f.write("::".as_bytes())
+                f.write("'static".as_bytes())
             }
             clean::TraitBound(ref ty) => {
                 write!(f, "{}", *ty)

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -144,6 +144,8 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
     extern fn block(ob: *mut hoedown_buffer, text: *hoedown_buffer,
                     lang: *hoedown_buffer, opaque: *mut libc::c_void) {
         unsafe {
+            if text.is_null() { return }
+
             let opaque = opaque as *mut hoedown_html_renderer_state;
             let my_opaque: &MyOpaque = &*((*opaque).opaque as *MyOpaque);
             slice::raw::buf_as_slice((*text).data, (*text).size as uint, |text| {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -132,7 +132,7 @@ pub struct Cache {
     ///
     /// The values of the map are a list of implementations and documentation
     /// found on that implementation.
-    pub impls: HashMap<ast::NodeId, Vec<(clean::Impl, Option<String>)>>,
+    pub impls: HashMap<ast::DefId, Vec<(clean::Impl, Option<String>)>>,
 
     /// Maintains a mapping of local crate node ids to the fully qualified name
     /// and "short type description" of that node. This is used when generating
@@ -837,10 +837,8 @@ impl DocFolder for Cache {
                 match item {
                     clean::Item{ attrs, inner: clean::ImplItem(i), .. } => {
                         match i.for_ {
-                            clean::ResolvedPath { did, .. }
-                                if ast_util::is_local(did) =>
-                            {
-                                let v = self.impls.find_or_insert_with(did.node, |_| {
+                            clean::ResolvedPath { did, .. } => {
+                                let v = self.impls.find_or_insert_with(did, |_| {
                                     Vec::new()
                                 });
                                 // extract relevant documentation for this impl
@@ -1664,7 +1662,7 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
 }
 
 fn render_methods(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {
-    match cache_key.get().unwrap().impls.find(&it.def_id.node) {
+    match cache_key.get().unwrap().impls.find(&it.def_id) {
         Some(v) => {
             let mut non_trait = v.iter().filter(|p| {
                 p.ref0().trait_.is_none()

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -797,6 +797,7 @@ impl DocFolder for Cache {
                 // not a public item.
                 let id = item.def_id.node;
                 if !self.paths.contains_key(&item.def_id) ||
+                   !ast_util::is_local(item.def_id) ||
                    self.public_items.contains(&id) {
                     self.paths.insert(item.def_id,
                                       (self.stack.clone(), shortty(&item)));

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -675,4 +675,14 @@
     if (window.pending_implementors) {
         window.register_implementors(window.pending_implementors);
     }
+
+
+    var query = window.location.search.substring(1);
+    var vars = query.split('&');
+    for (var i = 0; i < vars.length; i++) {
+        var pair = vars[i].split('=');
+        if (pair[0] == 'gotosrc') {
+            window.location = $('#src-' + pair[1]).attr('href');
+        }
+    }
 }());

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -676,13 +676,9 @@
         window.register_implementors(window.pending_implementors);
     }
 
-
-    var query = window.location.search.substring(1);
-    var vars = query.split('&');
-    for (var i = 0; i < vars.length; i++) {
-        var pair = vars[i].split('=');
-        if (pair[0] == 'gotosrc') {
-            window.location = $('#src-' + pair[1]).attr('href');
-        }
+    // See documentaiton in html/render.rs for what this is doing.
+    var query = getQueryStringParams();
+    if (query['gotosrc']) {
+        window.location = $('#src-' + query['gotosrc']).attr('href');
     }
 }());

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -152,7 +152,8 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             clean::ImplItem(clean::Impl{
                 for_: clean::ResolvedPath{ did, .. }, ..
             }) => {
-                if !self.exported_items.contains(&did.node) {
+                if ast_util::is_local(did) &&
+                   !self.exported_items.contains(&did.node) {
                     return None;
                 }
             }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -16,10 +16,10 @@
 //!
 //! ## Intrinsic types and operations
 //!
-//! The [`ptr`](../core/ptr/index.html) and [`mem`](../core/mem/index.html)
+//! The [`ptr`](ptr/index.html) and [`mem`](mem/index.html)
 //! modules deal with unsafe pointers and memory manipulation.
-//! [`kinds`](../core/kinds/index.html) defines the special built-in traits,
-//! and [`raw`](../core/raw/index.html) the runtime representation of Rust types.
+//! [`kinds`](kinds/index.html) defines the special built-in traits,
+//! and [`raw`](raw/index.html) the runtime representation of Rust types.
 //! These are some of the lowest-level building blocks in Rust.
 //!
 //! ## Math on primitive types and math traits
@@ -31,11 +31,11 @@
 //!
 //! ## Pervasive types
 //!
-//! The [`option`](option/index.html) and [`result`](../core/result/index.html)
+//! The [`option`](option/index.html) and [`result`](result/index.html)
 //! modules define optional and error-handling types, `Option` and `Result`.
-//! [`iter`](../core/iter/index.html) defines Rust's iterator protocol
+//! [`iter`](iter/index.html) defines Rust's iterator protocol
 //! along with a wide variety of iterators.
-//! [`Cell` and `RefCell`](../core/cell/index.html) are for creating types that
+//! [`Cell` and `RefCell`](cell/index.html) are for creating types that
 //! manage their own mutability.
 //!
 //! ## Vectors, slices and strings

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -38,62 +38,62 @@
 //! `drop`, `spawn`, and `channel`.
 
 // Reexported core operators
-#[doc(noinline)] pub use kinds::{Copy, Send, Sized, Share};
-#[doc(noinline)] pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
-#[doc(noinline)] pub use ops::{BitAnd, BitOr, BitXor};
-#[doc(noinline)] pub use ops::{Drop, Deref, DerefMut};
-#[doc(noinline)] pub use ops::{Shl, Shr, Index};
-#[doc(noinline)] pub use option::{Option, Some, None};
-#[doc(noinline)] pub use result::{Result, Ok, Err};
+#[doc(no_inline)] pub use kinds::{Copy, Send, Sized, Share};
+#[doc(no_inline)] pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
+#[doc(no_inline)] pub use ops::{BitAnd, BitOr, BitXor};
+#[doc(no_inline)] pub use ops::{Drop, Deref, DerefMut};
+#[doc(no_inline)] pub use ops::{Shl, Shr, Index};
+#[doc(no_inline)] pub use option::{Option, Some, None};
+#[doc(no_inline)] pub use result::{Result, Ok, Err};
 
 // Reexported functions
-#[doc(noinline)] pub use from_str::from_str;
-#[doc(noinline)] pub use iter::range;
-#[doc(noinline)] pub use mem::drop;
+#[doc(no_inline)] pub use from_str::from_str;
+#[doc(no_inline)] pub use iter::range;
+#[doc(no_inline)] pub use mem::drop;
 
 // Reexported types and traits
 
-#[doc(noinline)] pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
-#[doc(noinline)] pub use ascii::IntoBytes;
-#[doc(noinline)] pub use c_str::ToCStr;
-#[doc(noinline)] pub use char::Char;
-#[doc(noinline)] pub use clone::Clone;
-#[doc(noinline)] pub use cmp::{Eq, Ord, TotalEq, TotalOrd};
-#[doc(noinline)] pub use cmp::{Ordering, Less, Equal, Greater, Equiv};
-#[doc(noinline)] pub use container::{Container, Mutable, Map, MutableMap};
-#[doc(noinline)] pub use container::{Set, MutableSet};
-#[doc(noinline)] pub use iter::{FromIterator, Extendable, ExactSize};
-#[doc(noinline)] pub use iter::{Iterator, DoubleEndedIterator};
-#[doc(noinline)] pub use iter::{RandomAccessIterator, CloneableIterator};
-#[doc(noinline)] pub use iter::{OrdIterator, MutableDoubleEndedIterator};
-#[doc(noinline)] pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};
-#[doc(noinline)] pub use num::{Signed, Unsigned, Primitive, Int, Float};
-#[doc(noinline)] pub use num::{FloatMath, ToPrimitive, FromPrimitive};
-#[doc(noinline)] pub use option::Expect;
-#[doc(noinline)] pub use owned::Box;
-#[doc(noinline)] pub use path::{GenericPath, Path, PosixPath, WindowsPath};
-#[doc(noinline)] pub use ptr::RawPtr;
-#[doc(noinline)] pub use io::{Buffer, Writer, Reader, Seek};
-#[doc(noinline)] pub use str::{Str, StrVector, StrSlice, OwnedStr};
-#[doc(noinline)] pub use str::{IntoMaybeOwned, StrAllocating};
-#[doc(noinline)] pub use to_str::{ToStr, IntoStr};
-#[doc(noinline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
-#[doc(noinline)] pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
-#[doc(noinline)] pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
-#[doc(noinline)] pub use slice::{CloneableVector, ImmutableCloneableVector};
-#[doc(noinline)] pub use slice::{MutableCloneableVector, MutableTotalOrdVector};
-#[doc(noinline)] pub use slice::{ImmutableVector, MutableVector};
-#[doc(noinline)] pub use slice::{ImmutableEqVector, ImmutableTotalOrdVector};
-#[doc(noinline)] pub use slice::{Vector, VectorVector, OwnedVector};
-#[doc(noinline)] pub use slice::MutableVectorAllocating;
-#[doc(noinline)] pub use string::String;
-#[doc(noinline)] pub use vec::Vec;
+#[doc(no_inline)] pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
+#[doc(no_inline)] pub use ascii::IntoBytes;
+#[doc(no_inline)] pub use c_str::ToCStr;
+#[doc(no_inline)] pub use char::Char;
+#[doc(no_inline)] pub use clone::Clone;
+#[doc(no_inline)] pub use cmp::{Eq, Ord, TotalEq, TotalOrd};
+#[doc(no_inline)] pub use cmp::{Ordering, Less, Equal, Greater, Equiv};
+#[doc(no_inline)] pub use container::{Container, Mutable, Map, MutableMap};
+#[doc(no_inline)] pub use container::{Set, MutableSet};
+#[doc(no_inline)] pub use iter::{FromIterator, Extendable, ExactSize};
+#[doc(no_inline)] pub use iter::{Iterator, DoubleEndedIterator};
+#[doc(no_inline)] pub use iter::{RandomAccessIterator, CloneableIterator};
+#[doc(no_inline)] pub use iter::{OrdIterator, MutableDoubleEndedIterator};
+#[doc(no_inline)] pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};
+#[doc(no_inline)] pub use num::{Signed, Unsigned, Primitive, Int, Float};
+#[doc(no_inline)] pub use num::{FloatMath, ToPrimitive, FromPrimitive};
+#[doc(no_inline)] pub use option::Expect;
+#[doc(no_inline)] pub use owned::Box;
+#[doc(no_inline)] pub use path::{GenericPath, Path, PosixPath, WindowsPath};
+#[doc(no_inline)] pub use ptr::RawPtr;
+#[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek};
+#[doc(no_inline)] pub use str::{Str, StrVector, StrSlice, OwnedStr};
+#[doc(no_inline)] pub use str::{IntoMaybeOwned, StrAllocating};
+#[doc(no_inline)] pub use to_str::{ToStr, IntoStr};
+#[doc(no_inline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
+#[doc(no_inline)] pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
+#[doc(no_inline)] pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
+#[doc(no_inline)] pub use slice::{CloneableVector, ImmutableCloneableVector};
+#[doc(no_inline)] pub use slice::{MutableCloneableVector, MutableTotalOrdVector};
+#[doc(no_inline)] pub use slice::{ImmutableVector, MutableVector};
+#[doc(no_inline)] pub use slice::{ImmutableEqVector, ImmutableTotalOrdVector};
+#[doc(no_inline)] pub use slice::{Vector, VectorVector, OwnedVector};
+#[doc(no_inline)] pub use slice::MutableVectorAllocating;
+#[doc(no_inline)] pub use string::String;
+#[doc(no_inline)] pub use vec::Vec;
 
 // Reexported runtime types
-#[doc(noinline)] pub use comm::{sync_channel, channel};
-#[doc(noinline)] pub use comm::{SyncSender, Sender, Receiver};
-#[doc(noinline)] pub use task::spawn;
+#[doc(no_inline)] pub use comm::{sync_channel, channel};
+#[doc(no_inline)] pub use comm::{SyncSender, Sender, Receiver};
+#[doc(no_inline)] pub use task::spawn;
 
 // Reexported statics
 #[cfg(not(test))]
-#[doc(noinline)] pub use gc::GC;
+#[doc(no_inline)] pub use gc::GC;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -38,55 +38,62 @@
 //! `drop`, `spawn`, and `channel`.
 
 // Reexported core operators
-pub use kinds::{Copy, Send, Sized, Share};
-pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
-pub use ops::{BitAnd, BitOr, BitXor};
-pub use ops::{Drop, Deref, DerefMut};
-pub use ops::{Shl, Shr, Index};
-pub use option::{Option, Some, None};
-pub use result::{Result, Ok, Err};
+#[doc(noinline)] pub use kinds::{Copy, Send, Sized, Share};
+#[doc(noinline)] pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};
+#[doc(noinline)] pub use ops::{BitAnd, BitOr, BitXor};
+#[doc(noinline)] pub use ops::{Drop, Deref, DerefMut};
+#[doc(noinline)] pub use ops::{Shl, Shr, Index};
+#[doc(noinline)] pub use option::{Option, Some, None};
+#[doc(noinline)] pub use result::{Result, Ok, Err};
 
 // Reexported functions
-pub use from_str::from_str;
-pub use iter::range;
-pub use mem::drop;
+#[doc(noinline)] pub use from_str::from_str;
+#[doc(noinline)] pub use iter::range;
+#[doc(noinline)] pub use mem::drop;
 
 // Reexported types and traits
 
-pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr, IntoBytes};
-pub use c_str::ToCStr;
-pub use char::Char;
-pub use clone::Clone;
-pub use cmp::{Eq, Ord, TotalEq, TotalOrd, Ordering, Less, Equal, Greater, Equiv};
-pub use container::{Container, Mutable, Map, MutableMap, Set, MutableSet};
-pub use iter::{FromIterator, Extendable};
-pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIterator};
-pub use iter::{OrdIterator, MutableDoubleEndedIterator, ExactSize};
-pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};
-pub use num::{Signed, Unsigned};
-pub use num::{Primitive, Int, Float, FloatMath, ToPrimitive, FromPrimitive};
-pub use option::Expect;
-pub use owned::Box;
-pub use path::{GenericPath, Path, PosixPath, WindowsPath};
-pub use ptr::RawPtr;
-pub use io::{Buffer, Writer, Reader, Seek};
-pub use str::{Str, StrVector, StrSlice, OwnedStr, IntoMaybeOwned};
-pub use str::{StrAllocating};
-pub use to_str::{ToStr, IntoStr};
-pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
-pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
-pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
-pub use slice::{CloneableVector, ImmutableCloneableVector, MutableCloneableVector};
-pub use slice::{ImmutableVector, MutableVector};
-pub use slice::{ImmutableEqVector, ImmutableTotalOrdVector, MutableTotalOrdVector};
-pub use slice::{Vector, VectorVector, OwnedVector, MutableVectorAllocating};
-pub use string::String;
-pub use vec::Vec;
+#[doc(noinline)] pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
+#[doc(noinline)] pub use ascii::IntoBytes;
+#[doc(noinline)] pub use c_str::ToCStr;
+#[doc(noinline)] pub use char::Char;
+#[doc(noinline)] pub use clone::Clone;
+#[doc(noinline)] pub use cmp::{Eq, Ord, TotalEq, TotalOrd};
+#[doc(noinline)] pub use cmp::{Ordering, Less, Equal, Greater, Equiv};
+#[doc(noinline)] pub use container::{Container, Mutable, Map, MutableMap};
+#[doc(noinline)] pub use container::{Set, MutableSet};
+#[doc(noinline)] pub use iter::{FromIterator, Extendable, ExactSize};
+#[doc(noinline)] pub use iter::{Iterator, DoubleEndedIterator};
+#[doc(noinline)] pub use iter::{RandomAccessIterator, CloneableIterator};
+#[doc(noinline)] pub use iter::{OrdIterator, MutableDoubleEndedIterator};
+#[doc(noinline)] pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};
+#[doc(noinline)] pub use num::{Signed, Unsigned, Primitive, Int, Float};
+#[doc(noinline)] pub use num::{FloatMath, ToPrimitive, FromPrimitive};
+#[doc(noinline)] pub use option::Expect;
+#[doc(noinline)] pub use owned::Box;
+#[doc(noinline)] pub use path::{GenericPath, Path, PosixPath, WindowsPath};
+#[doc(noinline)] pub use ptr::RawPtr;
+#[doc(noinline)] pub use io::{Buffer, Writer, Reader, Seek};
+#[doc(noinline)] pub use str::{Str, StrVector, StrSlice, OwnedStr};
+#[doc(noinline)] pub use str::{IntoMaybeOwned, StrAllocating};
+#[doc(noinline)] pub use to_str::{ToStr, IntoStr};
+#[doc(noinline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
+#[doc(noinline)] pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
+#[doc(noinline)] pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
+#[doc(noinline)] pub use slice::{CloneableVector, ImmutableCloneableVector};
+#[doc(noinline)] pub use slice::{MutableCloneableVector, MutableTotalOrdVector};
+#[doc(noinline)] pub use slice::{ImmutableVector, MutableVector};
+#[doc(noinline)] pub use slice::{ImmutableEqVector, ImmutableTotalOrdVector};
+#[doc(noinline)] pub use slice::{Vector, VectorVector, OwnedVector};
+#[doc(noinline)] pub use slice::MutableVectorAllocating;
+#[doc(noinline)] pub use string::String;
+#[doc(noinline)] pub use vec::Vec;
 
 // Reexported runtime types
-pub use comm::{sync_channel, channel, SyncSender, Sender, Receiver};
-pub use task::spawn;
+#[doc(noinline)] pub use comm::{sync_channel, channel};
+#[doc(noinline)] pub use comm::{SyncSender, Sender, Receiver};
+#[doc(noinline)] pub use task::spawn;
 
 // Reexported statics
 #[cfg(not(test))]
-pub use gc::GC;
+#[doc(noinline)] pub use gc::GC;


### PR DESCRIPTION
As part of the libstd facade (cc #13851), rustdoc is taught to inline documentation across crate boundaries through the usage of a `pub use` statement. This is done to allow libstd to maintain the facade that it is a standalone library with a defined public interface (allowing us to shuffle around what's underneath it).

A preview is available at http://people.mozilla.org/~acrichton/doc/std/index.html
