### PR TITLE
core: Finish stabilizing the `mem` module.

### DIFF
--- a/src/libcollections/lru_cache.rs
+++ b/src/libcollections/lru_cache.rs
@@ -92,7 +92,7 @@ impl<K: Hash + TotalEq, V> LruCache<K, V> {
         let cache = LruCache {
             map: HashMap::new(),
             max_size: capacity,
-            head: unsafe{ mem::transmute(box mem::uninit::<LruEntry<K, V>>()) },
+            head: unsafe{ mem::transmute(box mem::uninitialized::<LruEntry<K, V>>()) },
         };
         unsafe {
             (*cache.head).next = cache.head;

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -26,7 +26,7 @@ pub fn size_of<T>() -> uint {
 
 /// Returns the size of the type that `_val` points to in bytes.
 #[inline]
-#[unstable = "the name of this function may change slightly before stabilizing"]
+#[stable]
 pub fn size_of_val<T>(_val: &T) -> uint {
     size_of::<T>()
 }
@@ -64,7 +64,7 @@ pub fn min_align_of<T>() -> uint {
 /// Returns the ABI-required minimum alignment of the type of the value that
 /// `_val` points to
 #[inline]
-#[unstable = "the name of this function may change slightly before stabilizing"]
+#[stable]
 pub fn min_align_of_val<T>(_val: &T) -> uint {
     min_align_of::<T>()
 }
@@ -90,7 +90,7 @@ pub fn align_of<T>() -> uint {
 /// as trait objects (in the future), returning the alignment for an arbitrary
 /// value at runtime.
 #[inline]
-#[unstable = "the name of this function may change slightly before stabilizing"]
+#[stable]
 pub fn align_of_val<T>(_val: &T) -> uint {
     align_of::<T>()
 }
@@ -117,7 +117,7 @@ pub fn pref_align_of_val<T>(val: &T) -> uint { align_of_val(val) }
 ///
 /// This is useful for FFI functions sometimes, but should generally be avoided.
 #[inline]
-#[unstable = "the name of this function is subject to change"]
+#[stable]
 pub unsafe fn zeroed<T>() -> T {
     intrinsics::init()
 }
@@ -136,7 +136,14 @@ pub unsafe fn init<T>() -> T { zeroed() }
 ///
 /// This is useful for FFI functions sometimes, but should generally be avoided.
 #[inline]
-#[unstable = "the name of this function is subject to change"]
+#[stable]
+pub unsafe fn uninitialized<T>() -> T {
+    intrinsics::uninit()
+}
+
+/// Deprecated, use `uninitialized` instead.
+#[inline]
+#[deprecated = "this function has been renamed to `uninitialized`"]
 pub unsafe fn uninit<T>() -> T {
     intrinsics::uninit()
 }
@@ -148,7 +155,7 @@ pub unsafe fn uninit<T>() -> T {
 /// contained at the location `dst`. This could leak allocations or resources,
 /// so care must be taken to previously deallocate the value at `dst`.
 #[inline]
-#[unstable = "the name of this function is subject to change"]
+#[stable]
 pub unsafe fn overwrite<T>(dst: *mut T, src: T) {
     intrinsics::move_val_init(&mut *dst, src)
 }
@@ -315,7 +322,7 @@ pub fn from_be64(x: u64) -> u64 { x }
 pub fn swap<T>(x: &mut T, y: &mut T) {
     unsafe {
         // Give ourselves some scratch space to work with
-        let mut t: T = uninit();
+        let mut t: T = uninitialized();
 
         // Perform the swap, `&mut` pointers never alias
         ptr::copy_nonoverlapping_memory(&mut t, &*x, 1);

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -201,7 +201,7 @@ pub unsafe fn copy_memory<T>(dst: *mut T, src: *T, count: uint) {
 /// fn swap<T>(x: &mut T, y: &mut T) {
 ///     unsafe {
 ///         // Give ourselves some scratch space to work with
-///         let mut t: T = mem::uninit();
+///         let mut t: T = mem::uninitialized();
 ///
 ///         // Perform the swap, `&mut` pointers never alias
 ///         ptr::copy_nonoverlapping_memory(&mut t, &*x, 1);
@@ -244,7 +244,7 @@ pub unsafe fn zero_memory<T>(dst: *mut T, count: uint) {
 #[inline]
 pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
     // Give ourselves some scratch space to work with
-    let mut tmp: T = mem::uninit();
+    let mut tmp: T = mem::uninitialized();
     let t: *mut T = &mut tmp;
 
     // Perform the swap
@@ -268,7 +268,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 /// Reads the value from `*src` and returns it.
 #[inline(always)]
 pub unsafe fn read<T>(src: *T) -> T {
-    let mut tmp: T = mem::uninit();
+    let mut tmp: T = mem::uninitialized();
     copy_nonoverlapping_memory(&mut tmp, src, 1);
     tmp
 }

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -164,7 +164,7 @@ impl rtio::RtioFileStream for FileDesc {
     }
 
     fn fstat(&mut self) -> IoResult<io::FileStat> {
-        let mut stat: libc::stat = unsafe { mem::uninit() };
+        let mut stat: libc::stat = unsafe { mem::zeroed() };
         match retry(|| unsafe { libc::fstat(self.fd(), &mut stat) }) {
             0 => Ok(mkstat(&stat)),
             _ => Err(super::last_error()),
@@ -509,7 +509,7 @@ fn mkstat(stat: &libc::stat) -> io::FileStat {
 }
 
 pub fn stat(p: &CString) -> IoResult<io::FileStat> {
-    let mut stat: libc::stat = unsafe { mem::uninit() };
+    let mut stat: libc::stat = unsafe { mem::zeroed() };
     match retry(|| unsafe { libc::stat(p.with_ref(|p| p), &mut stat) }) {
         0 => Ok(mkstat(&stat)),
         _ => Err(super::last_error()),
@@ -517,7 +517,7 @@ pub fn stat(p: &CString) -> IoResult<io::FileStat> {
 }
 
 pub fn lstat(p: &CString) -> IoResult<io::FileStat> {
-    let mut stat: libc::stat = unsafe { mem::uninit() };
+    let mut stat: libc::stat = unsafe { mem::zeroed() };
     match retry(|| unsafe { libc::lstat(p.with_ref(|p| p), &mut stat) }) {
         0 => Ok(mkstat(&stat)),
         _ => Err(super::last_error()),

--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -195,7 +195,7 @@ impl rtio::RtioFileStream for FileDesc {
     }
 
     fn fstat(&mut self) -> IoResult<io::FileStat> {
-        let mut stat: libc::stat = unsafe { mem::uninit() };
+        let mut stat: libc::stat = unsafe { mem::zeroed() };
         match unsafe { libc::fstat(self.fd(), &mut stat) } {
             0 => Ok(mkstat(&stat)),
             _ => Err(super::last_error()),
@@ -510,7 +510,7 @@ fn mkstat(stat: &libc::stat) -> io::FileStat {
 }
 
 pub fn stat(p: &CString) -> IoResult<io::FileStat> {
-    let mut stat: libc::stat = unsafe { mem::uninit() };
+    let mut stat: libc::stat = unsafe { mem::zeroed() };
     as_utf16_p(p.as_str().unwrap(), |up| {
         match unsafe { libc::wstat(up, &mut stat) } {
             0 => Ok(mkstat(&stat)),

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -254,8 +254,8 @@ fn exec<'t>(which: ::regex::native::MatchKind, input: &'t str,
                 // The idea here is to avoid initializing threads that never
                 // need to be initialized, particularly for larger regexs with
                 // a lot of instructions.
-                queue: unsafe { ::std::mem::uninit() },
-                sparse: unsafe { ::std::mem::uninit() },
+                queue: unsafe { ::std::mem::uninitialized() },
+                sparse: unsafe { ::std::mem::uninitialized() },
                 size: 0,
             }
         }

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -377,7 +377,7 @@ impl<'a> ToCStr for &'a [u8] {
 // Unsafe function that handles possibly copying the &[u8] into a stack array.
 unsafe fn with_c_str<T>(v: &[u8], checked: bool, f: |*libc::c_char| -> T) -> T {
     if v.len() < BUF_LEN {
-        let mut buf: [u8, .. BUF_LEN] = mem::uninit();
+        let mut buf: [u8, .. BUF_LEN] = mem::uninitialized();
         slice::bytes::copy_memory(buf, v);
         buf[v.len()] = 0;
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -969,7 +969,7 @@ pub fn page_size() -> uint {
 pub fn page_size() -> uint {
     use mem;
     unsafe {
-        let mut info = mem::uninit();
+        let mut info = mem::zeroed();
         libc::GetSystemInfo(&mut info);
 
         return info.dwPageSize as uint;
@@ -1288,7 +1288,7 @@ impl MemoryMap {
     pub fn granularity() -> uint {
         use mem;
         unsafe {
-            let mut info = mem::uninit();
+            let mut info = mem::zeroed();
             libc::GetSystemInfo(&mut info);
 
             return info.dwAllocationGranularity as uint;

--- a/src/libstd/rt/thread.rs
+++ b/src/libstd/rt/thread.rs
@@ -227,8 +227,8 @@ mod imp {
     pub type rust_thread_return = *u8;
 
     pub unsafe fn create(stack: uint, p: Box<proc():Send>) -> rust_thread {
-        let mut native: libc::pthread_t = mem::uninit();
-        let mut attr: libc::pthread_attr_t = mem::uninit();
+        let mut native: libc::pthread_t = mem::zeroed();
+        let mut attr: libc::pthread_attr_t = mem::zeroed();
         assert_eq!(pthread_attr_init(&mut attr), 0);
         assert_eq!(pthread_attr_setdetachstate(&mut attr,
                                                PTHREAD_CREATE_JOINABLE), 0);

--- a/src/test/run-pass/issue-10714.rs
+++ b/src/test/run-pass/issue-10714.rs
@@ -10,5 +10,5 @@
 
 enum v {}
 pub fn main() {
-    let y: v = unsafe { ::std::mem::uninit() };
+    let y: v = unsafe { ::std::mem::uninitialized() };
 }

--- a/src/test/run-pass/uninit-empty-types.rs
+++ b/src/test/run-pass/uninit-empty-types.rs
@@ -17,7 +17,7 @@ struct Foo;
 
 pub fn main() {
     unsafe {
-        let _x: Foo = mem::uninit();
-        let _x: [Foo, ..2] = mem::uninit();
+        let _x: Foo = mem::uninitialized();
+        let _x: [Foo, ..2] = mem::uninitialized();
     }
 }


### PR DESCRIPTION
- All of the *_val functions have gone from #[unstable] to #[stable]
- The overwrite and zeroed functions have gone from #[unstable] to #[stable]
- The uninit function is now deprecated, replaced by its stable counterpart,
  uninitialized

[breaking-change]
