### PR TITLE
New codegen option "no-split-stack"

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -313,6 +313,8 @@ cgoptions!(
         "use an external assembler rather than LLVM's integrated one"),
     relocation_model: StrBuf = ("pic".to_strbuf(), parse_string,
          "choose the relocation model to use (llc -relocation-model for details)"),
+    no_split_stack: bool = (false, parse_bool,
+        "disable segmented stack support"),
 )
 
 pub fn build_codegen_options(matches: &getopts::Matches) -> CodegenOptions

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -176,7 +176,8 @@ fn describe_debug_flags() {
 fn describe_codegen_flags() {
     println!("\nAvailable codegen options:\n");
     let mut cg = config::basic_codegen_options();
-    for &(name, parser, desc) in config::CG_OPTIONS.iter() {
+    for &(name, parser, desc, is_public) in config::CG_OPTIONS.iter() {
+        if !is_public { continue }
         // we invoke the parser function on `None` to see if this option needs
         // an argument or not.
         let (width, extra) = if parser(&mut cg, None) {

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -680,7 +680,7 @@ impl<'a> CleanupHelperMethods<'a> for FunctionContext<'a> {
                     Some(llpersonality) => llpersonality,
                     None => {
                         let fty = Type::variadic_func(&[], &Type::i32(self.ccx));
-                        let f = base::decl_cdecl_fn(self.ccx.llmod,
+                        let f = base::decl_cdecl_fn(self.ccx,
                                                     "rust_eh_personality",
                                                     fty,
                                                     ty::mk_i32());

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -279,14 +279,14 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     macro_rules! ifn (
         ($name:expr fn() -> $ret:expr) => (
             if *key == $name {
-                let f = base::decl_cdecl_fn(ccx.llmod, $name, Type::func([], &$ret), ty::mk_nil());
+                let f = base::decl_cdecl_fn(ccx, $name, Type::func([], &$ret), ty::mk_nil());
                 ccx.intrinsics.borrow_mut().insert($name, f.clone());
                 return Some(f);
             }
         );
         ($name:expr fn($($arg:expr),*) -> $ret:expr) => (
             if *key == $name {
-                let f = base::decl_cdecl_fn(ccx.llmod, $name,
+                let f = base::decl_cdecl_fn(ccx, $name,
                                   Type::func([$($arg),*], &$ret), ty::mk_nil());
                 ccx.intrinsics.borrow_mut().insert($name, f.clone());
                 return Some(f);
@@ -418,7 +418,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
                 // The `if key == $name` is already in ifn!
                 ifn!($name fn($($arg),*) -> $ret);
             } else if *key == $name {
-                let f = base::decl_cdecl_fn(ccx.llmod, stringify!($cname),
+                let f = base::decl_cdecl_fn(ccx, stringify!($cname),
                                       Type::func([$($arg),*], &$ret),
                                       ty::mk_nil());
                 ccx.intrinsics.borrow_mut().insert($name, f.clone());

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -228,7 +228,7 @@ pub fn register_foreign_item_fn(ccx: &CrateContext, abi: Abi, fty: ty::t,
     let llfn_ty = lltype_for_fn_from_foreign_types(ccx, &tys);
 
     let llfn = base::get_extern_fn(&mut *ccx.externs.borrow_mut(),
-                                   ccx.llmod,
+                                   ccx,
                                    name,
                                    cc,
                                    llfn_ty,

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -459,7 +459,7 @@ fn declare_generic_glue(ccx: &CrateContext, t: ty::t, llfnty: Type,
         t,
         format!("glue_{}", name).as_slice());
     debug!("{} is for type {}", fn_nm, ppaux::ty_to_str(ccx.tcx(), t));
-    let llfn = decl_cdecl_fn(ccx.llmod,
+    let llfn = decl_cdecl_fn(ccx,
                              fn_nm.as_slice(),
                              llfnty,
                              ty::mk_nil());


### PR DESCRIPTION
Allows to compile for archs which do not have (or have limited) segmented stack support like embedded/iOS

CLI usage:
rustc -C no-split-stack test.rs
