### PR TITLE
Handle CRLF properly in the lexer

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -304,7 +304,7 @@ impl<'a> StringReader<'a> {
                             if !is_line_non_doc_comment(string) {
                                 Some(TokenAndSpan{
                                     tok: token::DOC_COMMENT(str_to_ident(string)),
-                                    sp: codemap::mk_sp(start_bpos, self.pos)
+                                    sp: codemap::mk_sp(start_bpos, self.last_pos)
                                 })
                             } else {
                                 None
@@ -358,7 +358,7 @@ impl<'a> StringReader<'a> {
     fn consume_block_comment(&mut self) -> Option<TokenAndSpan> {
         // block comments starting with "/**" or "/*!" are doc-comments
         let is_doc_comment = self.curr_is('*') || self.curr_is('!');
-        let start_bpos = self.pos - BytePos(if is_doc_comment {3} else {2});
+        let start_bpos = self.last_pos - BytePos(2);
 
         let mut level: int = 1;
         while level > 0 {
@@ -389,7 +389,7 @@ impl<'a> StringReader<'a> {
                 if !is_block_non_doc_comment(string) {
                     Some(TokenAndSpan{
                             tok: token::DOC_COMMENT(str_to_ident(string)),
-                            sp: codemap::mk_sp(start_bpos, self.pos)
+                            sp: codemap::mk_sp(start_bpos, self.last_pos)
                         })
                 } else {
                     None

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -70,10 +70,10 @@ impl<'a> Reader for StringReader<'a> {
         ret_val
     }
     fn fatal(&self, m: &str) -> ! {
-        self.span_diagnostic.span_fatal(self.peek_span, m)
+        self.fatal_span(self.peek_span, m)
     }
     fn err(&self, m: &str) {
-        self.span_diagnostic.span_err(self.peek_span, m)
+        self.err_span(self.peek_span, m)
     }
     fn peek(&self) -> TokenAndSpan {
         // FIXME(pcwalton): Bad copy!
@@ -137,43 +137,52 @@ impl<'a> StringReader<'a> {
         self.curr == Some(c)
     }
 
-    /// Report a lexical error spanning [`from_pos`, `to_pos`)
-    fn fatal_span(&mut self, from_pos: BytePos, to_pos: BytePos, m: &str) -> ! {
-        self.peek_span = codemap::mk_sp(from_pos, to_pos);
-        self.fatal(m);
+    /// Report a fatal lexical error with a given span.
+    pub fn fatal_span(&self, sp: Span, m: &str) -> ! {
+        self.span_diagnostic.span_fatal(sp, m)
     }
 
-    fn err_span(&mut self, from_pos: BytePos, to_pos: BytePos, m: &str) {
-        self.peek_span = codemap::mk_sp(from_pos, to_pos);
-        self.err(m);
+    /// Report a lexical error with a given span.
+    pub fn err_span(&self, sp: Span, m: &str) {
+        self.span_diagnostic.span_err(sp, m)
+    }
+
+    /// Report a fatal error spanning [`from_pos`, `to_pos`).
+    fn fatal_span_(&self, from_pos: BytePos, to_pos: BytePos, m: &str) -> ! {
+        self.fatal_span(codemap::mk_sp(from_pos, to_pos), m)
+    }
+
+    /// Report a lexical error spanning [`from_pos`, `to_pos`).
+    fn err_span_(&self, from_pos: BytePos, to_pos: BytePos, m: &str) {
+        self.err_span(codemap::mk_sp(from_pos, to_pos), m)
     }
 
     /// Report a lexical error spanning [`from_pos`, `to_pos`), appending an
     /// escaped character to the error message
-    fn fatal_span_char(&mut self, from_pos: BytePos, to_pos: BytePos, m: &str, c: char) -> ! {
+    fn fatal_span_char(&self, from_pos: BytePos, to_pos: BytePos, m: &str, c: char) -> ! {
         let mut m = m.to_string();
         m.push_str(": ");
         char::escape_default(c, |c| m.push_char(c));
-        self.fatal_span(from_pos, to_pos, m.as_slice());
+        self.fatal_span_(from_pos, to_pos, m.as_slice());
     }
 
     /// Report a lexical error spanning [`from_pos`, `to_pos`), appending an
     /// escaped character to the error message
-    fn err_span_char(&mut self, from_pos: BytePos, to_pos: BytePos, m: &str, c: char) {
+    fn err_span_char(&self, from_pos: BytePos, to_pos: BytePos, m: &str, c: char) {
         let mut m = m.to_string();
         m.push_str(": ");
         char::escape_default(c, |c| m.push_char(c));
-        self.err_span(from_pos, to_pos, m.as_slice());
+        self.err_span_(from_pos, to_pos, m.as_slice());
     }
 
     /// Report a lexical error spanning [`from_pos`, `to_pos`), appending the
     /// offending string to the error message
-    fn fatal_span_verbose(&mut self, from_pos: BytePos, to_pos: BytePos, mut m: String) -> ! {
+    fn fatal_span_verbose(&self, from_pos: BytePos, to_pos: BytePos, mut m: String) -> ! {
         m.push_str(": ");
         let from = self.byte_offset(from_pos).to_uint();
         let to = self.byte_offset(to_pos).to_uint();
         m.push_str(self.filemap.src.as_slice().slice(from, to));
-        self.fatal_span(from_pos, to_pos, m.as_slice());
+        self.fatal_span_(from_pos, to_pos, m.as_slice());
     }
 
     /// Advance peek_tok and peek_span to refer to the next token, and
@@ -369,7 +378,7 @@ impl<'a> StringReader<'a> {
                     "unterminated block comment"
                 };
                 let last_bpos = self.last_pos;
-                self.fatal_span(start_bpos, last_bpos, msg);
+                self.fatal_span_(start_bpos, last_bpos, msg);
             } else if self.curr_is('/') && self.nextch_is('*') {
                 level += 1;
                 self.bump();
@@ -421,7 +430,7 @@ impl<'a> StringReader<'a> {
                 return Some(rslt);
             } else {
                 let last_bpos = self.last_pos;
-                self.err_span(start_bpos, last_bpos, "scan_exponent: bad fp literal");
+                self.err_span_(start_bpos, last_bpos, "scan_exponent: bad fp literal");
                 rslt.push_str("1"); // arbitrary placeholder exponent
                 return Some(rslt);
             }
@@ -447,9 +456,10 @@ impl<'a> StringReader<'a> {
 
     fn check_float_base(&mut self, start_bpos: BytePos, last_bpos: BytePos, base: uint) {
         match base {
-          16u => self.err_span(start_bpos, last_bpos, "hexadecimal float literal is not supported"),
-          8u => self.err_span(start_bpos, last_bpos, "octal float literal is not supported"),
-          2u => self.err_span(start_bpos, last_bpos, "binary float literal is not supported"),
+          16u => self.err_span_(start_bpos, last_bpos,
+                                "hexadecimal float literal is not supported"),
+          8u => self.err_span_(start_bpos, last_bpos, "octal float literal is not supported"),
+          2u => self.err_span_(start_bpos, last_bpos, "binary float literal is not supported"),
           _ => ()
         }
     }
@@ -509,7 +519,7 @@ impl<'a> StringReader<'a> {
             }
             if num_str.len() == 0u {
                 let last_bpos = self.last_pos;
-                self.err_span(start_bpos, last_bpos, "no valid digits found for number");
+                self.err_span_(start_bpos, last_bpos, "no valid digits found for number");
                 num_str = "1".to_string();
             }
             let parsed = match from_str_radix::<u64>(num_str.as_slice(),
@@ -517,7 +527,7 @@ impl<'a> StringReader<'a> {
                 Some(p) => p,
                 None => {
                     let last_bpos = self.last_pos;
-                    self.err_span(start_bpos, last_bpos, "int literal is too large");
+                    self.err_span_(start_bpos, last_bpos, "int literal is too large");
                     1
                 }
             };
@@ -573,7 +583,7 @@ impl<'a> StringReader<'a> {
                 return token::LIT_FLOAT(str_to_ident(num_str.as_slice()), ast::TyF128);
             }
             let last_bpos = self.last_pos;
-            self.err_span(start_bpos, last_bpos, "expected `f32`, `f64` or `f128` suffix");
+            self.err_span_(start_bpos, last_bpos, "expected `f32`, `f64` or `f128` suffix");
         }
         if is_float {
             let last_bpos = self.last_pos;
@@ -583,7 +593,7 @@ impl<'a> StringReader<'a> {
         } else {
             if num_str.len() == 0u {
                 let last_bpos = self.last_pos;
-                self.err_span(start_bpos, last_bpos, "no valid digits found for number");
+                self.err_span_(start_bpos, last_bpos, "no valid digits found for number");
                 num_str = "1".to_string();
             }
             let parsed = match from_str_radix::<u64>(num_str.as_slice(),
@@ -591,7 +601,7 @@ impl<'a> StringReader<'a> {
                 Some(p) => p,
                 None => {
                     let last_bpos = self.last_pos;
-                    self.err_span(start_bpos, last_bpos, "int literal is too large");
+                    self.err_span_(start_bpos, last_bpos, "int literal is too large");
                     1
                 }
             };
@@ -609,11 +619,11 @@ impl<'a> StringReader<'a> {
         for _ in range(0, n_hex_digits) {
             if self.is_eof() {
                 let last_bpos = self.last_pos;
-                self.fatal_span(start_bpos, last_bpos, "unterminated numeric character escape");
+                self.fatal_span_(start_bpos, last_bpos, "unterminated numeric character escape");
             }
             if self.curr_is(delim) {
                 let last_bpos = self.last_pos;
-                self.err_span(start_bpos, last_bpos, "numeric character escape is too short");
+                self.err_span_(start_bpos, last_bpos, "numeric character escape is too short");
                 break;
             }
             let c = self.curr.unwrap_or('\x00');
@@ -630,7 +640,7 @@ impl<'a> StringReader<'a> {
             Some(x) => x,
             None => {
                 let last_bpos = self.last_pos;
-                self.err_span(start_bpos, last_bpos, "illegal numeric character escape");
+                self.err_span_(start_bpos, last_bpos, "illegal numeric character escape");
                 '?'
             }
         }
@@ -856,16 +866,16 @@ impl<'a> StringReader<'a> {
                 let last_bpos = self.last_pos;
                 if token::is_keyword(token::keywords::Self,
                                      keyword_checking_token) {
-                    self.err_span(start,
-                                  last_bpos,
-                                  "invalid lifetime name: 'self \
-                                   is no longer a special lifetime");
+                    self.err_span_(start,
+                                   last_bpos,
+                                   "invalid lifetime name: 'self \
+                                    is no longer a special lifetime");
                 } else if token::is_any_keyword(keyword_checking_token) &&
                     !token::is_keyword(token::keywords::Static,
                                        keyword_checking_token) {
-                    self.err_span(start,
-                                  last_bpos,
-                                  "invalid lifetime name");
+                    self.err_span_(start,
+                                   last_bpos,
+                                   "invalid lifetime name");
                 }
                 return token::LIFETIME(ident);
             }
@@ -922,8 +932,8 @@ impl<'a> StringReader<'a> {
                 while !self_.curr_is('"') {
                     if self_.is_eof() {
                         let last_pos = self_.last_pos;
-                        self_.fatal_span(start, last_pos,
-                                         "unterminated double quote byte string");
+                        self_.fatal_span_(start, last_pos,
+                                          "unterminated double quote byte string");
                     }
 
                     let ch_start = self_.last_pos;
@@ -947,7 +957,7 @@ impl<'a> StringReader<'a> {
 
                 if self_.is_eof() {
                     let last_pos = self_.last_pos;
-                    self_.fatal_span(start_bpos, last_pos, "unterminated raw string");
+                    self_.fatal_span_(start_bpos, last_pos, "unterminated raw string");
                 } else if !self_.curr_is('"') {
                     let last_pos = self_.last_pos;
                     let ch = self_.curr.unwrap();
@@ -963,7 +973,7 @@ impl<'a> StringReader<'a> {
                     match self_.curr {
                         None => {
                             let last_pos = self_.last_pos;
-                            self_.fatal_span(start_bpos, last_pos, "unterminated raw string")
+                            self_.fatal_span_(start_bpos, last_pos, "unterminated raw string")
                         },
                         Some('"') => {
                             content_end_bpos = self_.last_pos;
@@ -997,7 +1007,7 @@ impl<'a> StringReader<'a> {
             while !self.curr_is('"') {
                 if self.is_eof() {
                     let last_bpos = self.last_pos;
-                    self.fatal_span(start_bpos, last_bpos, "unterminated double quote string");
+                    self.fatal_span_(start_bpos, last_bpos, "unterminated double quote string");
                 }
 
                 let ch_start = self.last_pos;
@@ -1020,7 +1030,7 @@ impl<'a> StringReader<'a> {
 
             if self.is_eof() {
                 let last_bpos = self.last_pos;
-                self.fatal_span(start_bpos, last_bpos, "unterminated raw string");
+                self.fatal_span_(start_bpos, last_bpos, "unterminated raw string");
             } else if !self.curr_is('"') {
                 let last_bpos = self.last_pos;
                 let curr_char = self.curr.unwrap();
@@ -1035,7 +1045,7 @@ impl<'a> StringReader<'a> {
             'outer: loop {
                 if self.is_eof() {
                     let last_bpos = self.last_pos;
-                    self.fatal_span(start_bpos, last_bpos, "unterminated raw string");
+                    self.fatal_span_(start_bpos, last_bpos, "unterminated raw string");
                 }
                 if self.curr_is('"') {
                     content_end_bpos = self.last_pos;

--- a/src/test/compile-fail/lex-bare-cr-string-literal-doc-comment.rs
+++ b/src/test/compile-fail/lex-bare-cr-string-literal-doc-comment.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-cr
+
+/// doc comment with bare CR: ''
+pub fn foo() {}
+//~^^ ERROR: bare CR not allowed in doc-comment
+
+/** block doc comment with bare CR: '' */
+pub fn bar() {}
+//~^^ ERROR: bare CR not allowed in block doc-comment
+
+fn main() {
+    // the following string literal has a bare CR in it
+    let _s = "foobar"; //~ ERROR: bare CR not allowed in string
+
+    // the following string literal has a bare CR in it
+    let _s = r"barfoo"; //~ ERROR: bare CR not allowed in raw string
+
+    // the following string literal has a bare CR in it
+    let _s = "foo\bar"; //~ ERROR: unknown character escape: \r
+}

--- a/src/test/run-pass/.gitattributes
+++ b/src/test/run-pass/.gitattributes
@@ -1,0 +1,1 @@
+lexer-crlf-line-endings-string-literal-doc-comment.rs -text

--- a/src/test/run-pass/lexer-crlf-line-endings-string-literal-doc-comment.rs
+++ b/src/test/run-pass/lexer-crlf-line-endings-string-literal-doc-comment.rs
@@ -1,0 +1,44 @@
+// ignore-tidy-cr ignore-license
+// ignore-tidy-cr (repeated again because of tidy bug)
+// license is ignored because tidy can't handle the CRLF here properly.
+
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// NB: this file needs CRLF line endings. The .gitattributes file in
+// this directory should enforce it.
+
+// ignore-pretty
+
+/// Doc comment that ends in CRLF
+pub fn foo() {}
+
+/** Block doc comment that
+ *  contains CRLF characters
+ */
+pub fn bar() {}
+
+fn main() {
+    let s = "string
+literal";
+    assert_eq!(s, "string\nliteral");
+
+    let s = "literal with \
+             escaped newline";
+    assert_eq!(s, "literal with escaped newline");
+
+    let s = r"string
+literal";
+    assert_eq!(s, "string\nliteral");
+
+    // validate that our source file has CRLF endings
+    let source = include_str!("lexer-crlf-line-endings-string-literal-doc-comment.rs");
+    assert!(source.contains("string\r\nliteral"));
+}


### PR DESCRIPTION
The lexer already ignores CRLF in between tokens, but it doesn't
properly handle carriage returns inside strings and doc comments. Teach
it to treat CRLF as LF inside these tokens, and to disallow carriage
returns that are not followed by linefeeds. This includes handling an
escaped CRLF inside a regular string token the same way it handles an
escaped LF.

This is technically a breaking change, as bare carriage returns are no
longer allowed, and CRLF sequences are now treated as LF inside strings
and doc comments, but it's very unlikely to actually affect any
real-world code.

This change is necessary to have Rust code compile on Windows the same
way it does on Unix. The mozilla/rust repository explicitly sets eol=lf
for Rust source files, but other Rust repositories don't. Notably,
rust-http cannot be compiled on Windows without converting the CRLF line
endings back to LF.

[breaking-change]
