### PR TITLE
Rename functions in Ascii

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -819,7 +819,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         let i = s.chars();
         let c : Vec<char> = i.map( |c| {
             if c.is_ascii() {
-                c.to_ascii().to_lower().to_char()
+                c.to_ascii().to_lowercase().to_char()
             } else {
                 c
             }

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -553,18 +553,18 @@ fn in_char_specifiers(specifiers: &[CharSpecifier], c: char, options: MatchOptio
                 // FIXME: work with non-ascii chars properly (issue #1347)
                 if !options.case_sensitive && c.is_ascii() && start.is_ascii() && end.is_ascii() {
 
-                    let start = start.to_ascii().to_lower();
-                    let end = end.to_ascii().to_lower();
+                    let start = start.to_ascii().to_lowercase();
+                    let end = end.to_ascii().to_lowercase();
 
-                    let start_up = start.to_upper();
-                    let end_up = end.to_upper();
+                    let start_up = start.to_uppercase();
+                    let end_up = end.to_uppercase();
 
                     // only allow case insensitive matching when
                     // both start and end are within a-z or A-Z
                     if start != start_up && end != end_up {
                         let start = start.to_char();
                         let end = end.to_char();
-                        let c = c.to_ascii().to_lower().to_char();
+                        let c = c.to_ascii().to_lowercase().to_char();
                         if c >= start && c <= end {
                             return true;
                         }

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -39,15 +39,29 @@ impl Ascii {
         self.chr as char
     }
 
+    #[inline]
+    #[allow(missing_doc)]
+    #[deprecated="renamed to `to_lowercase`"]
+    pub fn to_lower(self) -> Ascii {
+        self.to_lowercase()
+    }
+
     /// Convert to lowercase.
     #[inline]
-    pub fn to_lower(self) -> Ascii {
+    pub fn to_lowercase(self) -> Ascii {
         Ascii{chr: ASCII_LOWER_MAP[self.chr as uint]}
+    }
+
+    #[inline]
+    #[allow(missing_doc)]
+    #[deprecated="renamed to `to_uppercase`"]
+    pub fn to_upper(self) -> Ascii {
+        self.to_uppercase()
     }
 
     /// Convert to uppercase.
     #[inline]
-    pub fn to_upper(self) -> Ascii {
+    pub fn to_uppercase(self) -> Ascii {
         Ascii{chr: ASCII_UPPER_MAP[self.chr as uint]}
     }
 
@@ -59,9 +73,16 @@ impl Ascii {
 
     // the following methods are like ctype, and the implementation is inspired by musl
 
+    #[inline]
+    #[allow(missing_doc)]
+    #[deprecated="renamed to `is_alphabetic`"]
+    pub fn is_alpha(&self) -> bool {
+        self.is_alphabetic()
+    }
+
     /// Check if the character is a letter (a-z, A-Z)
     #[inline]
-    pub fn is_alpha(&self) -> bool {
+    pub fn is_alphabetic(&self) -> bool {
         (self.chr >= 0x41 && self.chr <= 0x5A) || (self.chr >= 0x61 && self.chr <= 0x7A)
     }
 
@@ -71,9 +92,16 @@ impl Ascii {
         self.chr >= 0x30 && self.chr <= 0x39
     }
 
+    #[inline]
+    #[allow(missing_doc)]
+    #[deprecated="renamed to `is_alphanumeric`"]
+    pub fn is_alnum(&self) -> bool {
+        self.is_alphanumeric()
+    }
+
     /// Check if the character is a letter or number
     #[inline]
-    pub fn is_alnum(&self) -> bool {
+    pub fn is_alphanumeric(&self) -> bool {
         self.is_alpha() || self.is_digit()
     }
 
@@ -101,15 +129,29 @@ impl Ascii {
         (self.chr - 0x20) < 0x5F
     }
 
+    #[inline]
+    #[allow(missing_doc)]
+    #[deprecated="renamed to `is_lowercase`"]
+    pub fn is_lower(&self) -> bool {
+        self.is_lowercase()
+    }
+
     /// Checks if the character is lowercase
     #[inline]
-    pub fn is_lower(&self) -> bool {
+    pub fn is_lowercase(&self) -> bool {
         (self.chr - 'a' as u8) < 26
+    }
+
+    #[inline]
+    #[allow(missing_doc)]
+    #[deprecated="renamed to `is_uppercase`"]
+    pub fn is_upper(&self) -> bool {
+        self.is_uppercase()
     }
 
     /// Checks if the character is uppercase
     #[inline]
-    pub fn is_upper(&self) -> bool {
+    pub fn is_uppercase(&self) -> bool {
         (self.chr - 'A' as u8) < 26
     }
 


### PR DESCRIPTION
Some functions implemented for the Ascii struct have the same functionality as other functions implemented for the normal chars. For consistency, I think they should have the same name, so I renamed the functions in Ascii to match the names in the Char trait.
- Renamed `to_lower` to `to_lowercase`
- Renamed `to_upper` to `to_uppercase`
- Renamed `is_alpha` to `is_alphabetic`
- Renamed `is_alnum` to `is_alphanumeric`
- Renamed `is_lower` to `is_lowercase`
- Renamed `is_upper` to `is_uppercase`

[breaking-change]
