### PR TITLE
Fix missing_doc lint

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -343,7 +343,7 @@ pub fn phase_3_run_analysis_passes(sess: Session,
     });
 
     time(time_passes, "lint checking", (), |_|
-         lint::check_crate(&ty_cx, &exported_items, krate));
+         lint::check_crate(&ty_cx, &public_items, krate));
 
     CrateAnalysis {
         exp_map2: exp_map2,

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -451,8 +451,8 @@ struct Context<'a> {
     cur: SmallIntMap<(Level, LintSource)>,
     // context we're checking in (used to access fields like sess)
     tcx: &'a ty::ctxt,
-    // Items exported by the crate; used by the missing_doc lint.
-    exported_items: &'a privacy::ExportedItems,
+    // Public items in the crate; used by the missing_doc lint.
+    public_items: &'a privacy::ExportedItems,
     // The id of the current `ast::StructDef` being walked.
     cur_struct_def_id: ast::NodeId,
     // Whether some ancestor of the current node was marked
@@ -1556,7 +1556,7 @@ fn check_missing_doc_attrs(cx: &Context,
     // Only check publicly-visible items, using the result from the privacy pass. It's an option so
     // the crate root can also use this function (it doesn't have a NodeId).
     match id {
-        Some(ref id) if !cx.exported_items.contains(id) => return,
+        Some(ref id) if !cx.public_items.contains(id) => return,
         _ => ()
     }
 
@@ -1921,13 +1921,13 @@ impl<'a> IdVisitingOperation for Context<'a> {
 }
 
 pub fn check_crate(tcx: &ty::ctxt,
-                   exported_items: &privacy::ExportedItems,
+                   public_items: &privacy::PublicItems,
                    krate: &ast::Crate) {
     let mut cx = Context {
         dict: get_lint_dict(),
         cur: SmallIntMap::new(),
         tcx: tcx,
-        exported_items: exported_items,
+        public_items: public_items,
         cur_struct_def_id: -1,
         is_doc_hidden: false,
         lint_stack: Vec::new(),

--- a/src/test/run-pass/issue-11592.rs
+++ b/src/test/run-pass/issue-11592.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![deny(missing_doc)]
+//! as
+
+trait Foo {
+    fn bar();
+}
+
+fn main() {}


### PR DESCRIPTION
Some items including traits are exported even when they aren't public,
so the missing_doc lint used to warn for private traits.

Closes #11592
