### PR TITLE
rustc: Account for typedefs in privacy

### DIFF
--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -297,6 +297,23 @@ impl<'a> Visitor<()> for EmbargoVisitor<'a> {
                 }
             }
 
+            ast::ItemTy(ref ty, _) if public_first => {
+                match ty.node {
+                    ast::TyPath(_, _, id) => {
+                        match self.tcx.def_map.borrow().get_copy(&id) {
+                            ast::DefPrimTy(..) => {},
+                            def => {
+                                let did = def_id_of_def(def);
+                                if is_local(did) {
+                                    self.exported_items.insert(did.node);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
             _ => {}
         }
 

--- a/src/test/auxiliary/issue-14421.rs
+++ b/src/test/auxiliary/issue-14421.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+#![deny(warnings)]
+
+pub use src::aliases::B;
+pub use src::hidden_core::make;
+
+mod src {
+    pub mod aliases {
+        use super::hidden_core::A;
+        pub type B = A<f32>;
+    }
+
+    pub mod hidden_core {
+        use super::aliases::B;
+
+        pub struct A<T>;
+
+        pub fn make() -> B { A }
+
+        impl<T> A<T> {
+            pub fn foo(&mut self) { println!("called foo"); }
+        }
+    }
+}

--- a/src/test/auxiliary/issue-14422.rs
+++ b/src/test/auxiliary/issue-14422.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+#![deny(warnings)]
+
+pub use src::aliases::B;
+pub use src::hidden_core::make;
+
+mod src {
+    pub mod aliases {
+        use super::hidden_core::A;
+        pub type B = A;
+    }
+
+    pub mod hidden_core {
+        use super::aliases::B;
+
+        pub struct A;
+
+        pub fn make() -> B { A }
+
+        impl A {
+            pub fn foo(&mut self) { println!("called foo"); }
+        }
+    }
+}

--- a/src/test/run-pass/issue-14421.rs
+++ b/src/test/run-pass/issue-14421.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-14421.rs
+
+extern crate bug_lib = "issue-14421";
+
+use bug_lib::B;
+use bug_lib::make;
+
+pub fn main() {
+    let mut an_A: B = make();
+    an_A.foo();
+}
+

--- a/src/test/run-pass/issue-14422.rs
+++ b/src/test/run-pass/issue-14422.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-14422.rs
+
+extern crate bug_lib = "issue-14422";
+
+use bug_lib::B;
+use bug_lib::make;
+
+pub fn main() {
+    let mut an_A: B = make();
+    an_A.foo();
+}


### PR DESCRIPTION
This ensures that a public typedef to a private item is ensured to be public in
terms of linkage. This affects both the visibility of the library's symbols as
well as other lints based on privacy (dead_code for example).

Closes #14421
Closes #14422
