### PR TITLE
De-realstd os::args

### DIFF
--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -859,7 +859,7 @@ mod test {
     })
 
     iotest!(fn file_test_io_seek_shakedown() {
-        use std::str;          // 01234567890123
+        use str;          // 01234567890123
         let initial_msg =   "qwer-asdf-zxcv";
         let chunk_one: &str = "qwer";
         let chunk_two: &str = "asdf";
@@ -947,7 +947,7 @@ mod test {
     })
 
     iotest!(fn file_test_directoryinfo_readdir() {
-        use std::str;
+        use str;
         let tmpdir = tmpdir();
         let dir = &tmpdir.join("di_readdir");
         check!(mkdir(dir, io::UserRWX));

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -14,7 +14,7 @@
 
 use prelude::*;
 
-use std::str;
+use str;
 use fmt;
 use io::IoResult;
 use io;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -266,24 +266,21 @@ pub mod rt;
 // can be resolved within libstd.
 #[doc(hidden)]
 mod std {
+    // mods used for deriving
     pub use clone;
     pub use cmp;
-    pub use comm;
-    pub use fmt;
     pub use hash;
-    pub use io;
-    pub use kinds;
-    pub use local_data;
-    pub use option;
-    pub use os;
-    pub use rt;
-    pub use str;
-    pub use to_str;
-    pub use ty;
-    pub use unstable;
-    pub use vec;
 
+    pub use comm; // used for select!()
+    pub use fmt; // used for any formatting strings
+    pub use io; // used for println!()
+    pub use local_data; // used for local_data_key!()
+    pub use option; // used for bitflags!()
+    pub use rt; // used for fail!()
+    pub use vec; // used for vec![]
+
+    // The test runner calls ::std::os::args() but really wants realstd
+    #[cfg(test)] pub use os = realstd::os;
     // The test runner requires std::slice::Vector, so re-export std::slice just for it.
     #[cfg(test)] pub use slice;
-    #[cfg(test)] pub use string;
 }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -918,15 +918,8 @@ extern "system" {
 ///
 /// The arguments are interpreted as utf-8, with invalid bytes replaced with \uFFFD.
 /// See `str::from_utf8_lossy` for details.
-#[cfg(not(test))]
 pub fn args() -> Vec<String> {
     real_args()
-}
-
-#[cfg(test)]
-#[allow(missing_doc)]
-pub fn args() -> ::realstd::vec::Vec<::realstd::string::String> {
-    ::realstd::os::args()
 }
 
 /// Returns the arguments which this program was started with (normally passed
@@ -1507,7 +1500,7 @@ mod tests {
     use prelude::*;
     use c_str::ToCStr;
     use option;
-    use os::{env, getcwd, getenv, make_absolute, args};
+    use os::{env, getcwd, getenv, make_absolute};
     use os::{setenv, unsetenv};
     use os;
     use rand::Rng;
@@ -1516,12 +1509,6 @@ mod tests {
     #[test]
     pub fn last_os_error() {
         debug!("{}", os::last_os_error());
-    }
-
-    #[test]
-    pub fn test_args() {
-        let a = args();
-        assert!(a.len() >= 1);
     }
 
     fn make_rand_name() -> String {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1328,7 +1328,7 @@ impl Drop for MemoryMap {
 
 #[cfg(target_os = "linux")]
 pub mod consts {
-    pub use std::os::arch_consts::ARCH;
+    pub use os::arch_consts::ARCH;
 
     pub static FAMILY: &'static str = "unix";
 
@@ -1359,7 +1359,7 @@ pub mod consts {
 
 #[cfg(target_os = "macos")]
 pub mod consts {
-    pub use std::os::arch_consts::ARCH;
+    pub use os::arch_consts::ARCH;
 
     pub static FAMILY: &'static str = "unix";
 
@@ -1390,7 +1390,7 @@ pub mod consts {
 
 #[cfg(target_os = "freebsd")]
 pub mod consts {
-    pub use std::os::arch_consts::ARCH;
+    pub use os::arch_consts::ARCH;
 
     pub static FAMILY: &'static str = "unix";
 
@@ -1421,7 +1421,7 @@ pub mod consts {
 
 #[cfg(target_os = "android")]
 pub mod consts {
-    pub use std::os::arch_consts::ARCH;
+    pub use os::arch_consts::ARCH;
 
     pub static FAMILY: &'static str = "unix";
 
@@ -1452,7 +1452,7 @@ pub mod consts {
 
 #[cfg(target_os = "win32")]
 pub mod consts {
-    pub use std::os::arch_consts::ARCH;
+    pub use os::arch_consts::ARCH;
 
     pub static FAMILY: &'static str = "windows";
 

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -22,47 +22,23 @@
 
 use option::Option;
 use vec::Vec;
-#[cfg(test)] use option::{Some, None};
-#[cfg(test)] use realstd;
-#[cfg(test)] use realargs = realstd::rt::args;
 
 /// One-time global initialization.
-#[cfg(not(test))]
 pub unsafe fn init(argc: int, argv: **u8) { imp::init(argc, argv) }
-#[cfg(test)]
-pub unsafe fn init(argc: int, argv: **u8) { realargs::init(argc, argv) }
 
 /// One-time global cleanup.
-#[cfg(not(test))] pub unsafe fn cleanup() { imp::cleanup() }
-#[cfg(test)]      pub unsafe fn cleanup() { realargs::cleanup() }
+pub unsafe fn cleanup() { imp::cleanup() }
 
 /// Take the global arguments from global storage.
-#[cfg(not(test))] pub fn take() -> Option<Vec<Vec<u8>>> { imp::take() }
-#[cfg(test)]      pub fn take() -> Option<Vec<Vec<u8>>> {
-    match realargs::take() {
-        realstd::option::Some(v) => Some(unsafe{ ::mem::transmute(v) }),
-        realstd::option::None => None,
-    }
-}
+pub fn take() -> Option<Vec<Vec<u8>>> { imp::take() }
 
 /// Give the global arguments to global storage.
 ///
 /// It is an error if the arguments already exist.
-#[cfg(not(test))] pub fn put(args: Vec<Vec<u8>>) { imp::put(args) }
-#[cfg(test)]      pub fn put(args: Vec<Vec<u8>>) {
-    realargs::put(unsafe {
-        ::mem::transmute(args)
-    })
-}
+pub fn put(args: Vec<Vec<u8>>) { imp::put(args) }
 
 /// Make a clone of the global arguments.
-#[cfg(not(test))] pub fn clone() -> Option<Vec<Vec<u8>>> { imp::clone() }
-#[cfg(test)]      pub fn clone() -> Option<Vec<Vec<u8>>> {
-    match realargs::clone() {
-        realstd::option::Some(v) => Some(unsafe { ::mem::transmute(v) }),
-        realstd::option::None => None,
-    }
-}
+pub fn clone() -> Option<Vec<Vec<u8>>> { imp::clone() }
 
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "android")]
@@ -75,18 +51,16 @@ mod imp {
     use unstable::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
     use mem;
     use vec::Vec;
-    #[cfg(not(test))] use ptr::RawPtr;
+    use ptr::RawPtr;
 
     static mut global_args_ptr: uint = 0;
     static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
 
-    #[cfg(not(test))]
     pub unsafe fn init(argc: int, argv: **u8) {
         let args = load_argc_and_argv(argc, argv);
         put(args);
     }
 
-    #[cfg(not(test))]
     pub unsafe fn cleanup() {
         rtassert!(take().is_some());
         lock.destroy();
@@ -127,7 +101,6 @@ mod imp {
     }
 
     // Copied from `os`.
-    #[cfg(not(test))]
     unsafe fn load_argc_and_argv(argc: int, argv: **u8) -> Vec<Vec<u8>> {
         use c_str::CString;
         use ptr::RawPtr;
@@ -173,8 +146,8 @@ mod imp {
     }
 }
 
-#[cfg(target_os = "macos", not(test))]
-#[cfg(target_os = "win32", not(test))]
+#[cfg(target_os = "macos")]
+#[cfg(target_os = "win32")]
 mod imp {
     use option::Option;
     use vec::Vec;


### PR DESCRIPTION
Clean up the re-exports of various modules in `std::std`, and remove the
`realstd` stuff from `std::rt::args`.
