### PR TITLE
Allow $foo:block nonterminals in expression position

### DIFF
--- a/src/test/run-pass/macro-block-nonterminal.rs
+++ b/src/test/run-pass/macro-block-nonterminal.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+macro_rules! do_block{
+    ($val:block) => {$val}
+}
+
+fn main() {
+    let s;
+    do_block!({ s = "it works!"; });
+    assert_eq!(s, "it works!");
+}


### PR DESCRIPTION
Fixes #13678.
