### PR TITLE
Rename things in std::ascii for consistency

### DIFF
--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::io::{BufferedReader, File};
+use std::ascii::StrAsciiExt;
 use regex::Regex;
 
 pub struct ExpectedError {
@@ -31,7 +32,7 @@ pub fn load_errors(re: &Regex, testfile: &Path) -> Vec<ExpectedError> {
 fn parse_expected(line_num: uint, line: &str, re: &Regex) -> Option<ExpectedError> {
     re.captures(line).and_then(|caps| {
         let adjusts = caps.name("adjusts").len();
-        let kind = caps.name("kind").to_ascii().to_lower().into_str().to_string();
+        let kind = caps.name("kind").to_ascii_lowercase();
         let msg = caps.name("msg").trim().to_string();
 
         debug!("line={} kind={} msg={}", line_num, kind, msg);

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -802,21 +802,8 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
     }).collect::<Vec<String> >();
 
     #[cfg(target_os = "win32")]
-    fn to_lower( s : &str ) -> String {
-        let i = s.chars();
-        let c : Vec<char> = i.map( |c| {
-            if c.is_ascii() {
-                c.to_ascii().to_lowercase().to_char()
-            } else {
-                c
-            }
-        } ).collect();
-        str::from_chars(c.as_slice()).to_string()
-    }
-
-    #[cfg(target_os = "win32")]
     fn prefix_matches( line : &str, prefix : &str ) -> bool {
-        to_lower(line).as_slice().starts_with(to_lower(prefix).as_slice())
+        line.len() >= prefix.len() && line.slice_to(prefix.len()).eq_ignore_ascii_case(prefix)
     }
 
     #[cfg(target_os = "linux")]

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -78,7 +78,8 @@ syn keyword   rustEnumVariant Ok Err
 "syn keyword rustFunction drop
 
 " Types and traits {{{3
-syn keyword rustTrait Ascii AsciiCast OwnedAsciiCast AsciiStr IntoBytes
+syn keyword rustTrait Ascii ToAscii IntoAscii AsciiStr
+syn keyword rustTrait AsciiSlice AsciiVec IntoBytes
 syn keyword rustTrait ToCStr
 syn keyword rustTrait Char
 syn keyword rustTrait Clone

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1257,17 +1257,18 @@ macro_rules! iterator {
                     if self.ptr == self.end {
                         None
                     } else {
-                        let old = self.ptr;
-                        self.ptr = if mem::size_of::<T>() == 0 {
+                        if mem::size_of::<T>() == 0 {
                             // purposefully don't use 'ptr.offset' because for
                             // vectors with 0-size elements this would return the
                             // same pointer.
-                            transmute(self.ptr as uint + 1)
+                            self.ptr = transmute(self.ptr as uint + 1);
+                            Some(transmute(1u)) // Use a non-NULL pointer value
                         } else {
-                            self.ptr.offset(1)
-                        };
+                            let old = self.ptr;
+                            self.ptr = self.ptr.offset(1);
 
-                        Some(transmute(old))
+                            Some(transmute(old))
+                        }
                     }
                 }
             }
@@ -1289,13 +1290,14 @@ macro_rules! iterator {
                     if self.end == self.ptr {
                         None
                     } else {
-                        self.end = if mem::size_of::<T>() == 0 {
-                            // See above for why 'ptr.offset' isn't used
-                            transmute(self.end as uint - 1)
+                        if mem::size_of::<T>() == 0 {
+                            // See above for why `ptr.offset` isn't used
+                            self.end = transmute(self.end as uint - 1);
+                            Some(transmute(1u)) // Use a non-NULL pointer value
                         } else {
-                            self.end.offset(-1)
-                        };
-                        Some(transmute(self.end))
+                            self.end = self.end.offset(-1);
+                            Some(transmute(self.end))
+                        }
                     }
                 }
             }
@@ -1314,7 +1316,11 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
     fn idx(&mut self, index: uint) -> Option<&'a T> {
         unsafe {
             if index < self.indexable() {
-                transmute(self.ptr.offset(index as int))
+                if mem::size_of::<T>() == 0 {
+                    Some(transmute(1u)) // Use a non-NULL pointer value
+                } else {
+                    Some(transmute(self.ptr.offset(index as int)))
+                }
             } else {
                 None
             }

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -36,6 +36,7 @@ use getopts::{optopt, optmulti, optflag, optflagopt};
 use getopts;
 use lib::llvm::llvm;
 use std::cell::{RefCell};
+use std::ascii::StrAsciiExt;
 
 
 pub struct Config {
@@ -596,7 +597,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         let level_name = lint::level_to_str(*level);
 
         let level_short = level_name.slice_chars(0, 1);
-        let level_short = level_short.to_ascii().to_upper().into_str();
+        let level_short = level_short.to_ascii_uppercase();
         let flags = matches.opt_strs(level_short.as_slice())
                            .move_iter()
                            .collect::<Vec<_>>()

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -207,7 +207,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
         // Transform the contents of the header into a hyphenated string
         let id = (s.as_slice().words().map(|s| {
             match s.to_ascii_opt() {
-                Some(s) => s.to_lower().into_str().to_string(),
+                Some(s) => s.to_lowercase().into_str(),
                 None => s.to_string()
             }
         }).collect::<Vec<String>>().connect("-")).to_string();

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -336,11 +336,25 @@ impl<'a> AsciiStr for &'a [Ascii] {
 pub trait AsciiSlice {
     /// Converts the receiver to a vector representation of a lowercase ASCII
     /// string.
-    fn to_lower(&self) -> Vec<Ascii>;
+    fn to_lowercase(&self) -> Vec<Ascii>;
+
+    #[allow(missing_doc)]
+    #[deprecated = "replaced by .to_lowercase()"]
+    #[inline]
+    fn to_lower(&self) -> Vec<Ascii> {
+        self.to_lowercase()
+    }
 
     /// Converts the receiver to a vector representation of an uppercase ASCII
     /// string.
-    fn to_upper(&self) -> Vec<Ascii>;
+    fn to_uppercase(&self) -> Vec<Ascii>;
+
+    #[allow(missing_doc)]
+    #[deprecated = "replaced by .to_uppercase()"]
+    #[inline]
+    fn to_upper(&self) -> Vec<Ascii> {
+        self.to_uppercase()
+    }
 
     /// Compares two ASCII strings ignoring case.
     fn eq_ignore_case(self, other: &[Ascii]) -> bool;
@@ -348,13 +362,13 @@ pub trait AsciiSlice {
 
 impl<'a> AsciiSlice for &'a [Ascii] {
     #[inline]
-    fn to_lower(&self) -> Vec<Ascii> {
-        self.iter().map(|a| a.to_lower()).collect()
+    fn to_lowercase(&self) -> Vec<Ascii> {
+        self.iter().map(|a| a.to_lowercase()).collect()
     }
 
     #[inline]
-    fn to_upper(&self) -> Vec<Ascii> {
-        self.iter().map(|a| a.to_upper()).collect()
+    fn to_uppercase(&self) -> Vec<Ascii> {
+        self.iter().map(|a| a.to_uppercase()).collect()
     }
 
     #[inline]
@@ -367,28 +381,28 @@ impl<'a> AsciiSlice for &'a [Ascii] {
 pub trait AsciiVec {
     /// Converts the receiver to a vector representation of a lowercase ASCII
     /// string.
-    fn into_lower(self) -> Vec<Ascii>;
+    fn into_lowercase(self) -> Vec<Ascii>;
 
     /// Converts the receiver to a vector representation of an uppercase ASCII
     /// string.
-    fn into_upper(self) -> Vec<Ascii>;
+    fn into_uppercase(self) -> Vec<Ascii>;
 }
 
 impl AsciiVec for Vec<Ascii> {
     #[inline]
-    fn into_lower(self) -> Vec<Ascii> {
+    fn into_lowercase(self) -> Vec<Ascii> {
         let mut v = self;
         for b in v.mut_iter() {
-            *b = b.to_lower()
+            *b = b.to_lowercase()
         }
         v
     }
 
     #[inline]
-    fn into_upper(self) -> Vec<Ascii> {
+    fn into_uppercase(self) -> Vec<Ascii> {
         let mut v = self;
         for b in v.mut_iter() {
-            *b = b.to_upper()
+            *b = b.to_uppercase()
         }
         v
     }
@@ -431,13 +445,27 @@ pub trait StringAsciiExt {
     ///
     /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
     /// but non-ASCII letters are unchanged.
-    fn into_ascii_upper(self) -> String;
+    fn into_ascii_uppercase(self) -> String;
+
+    #[allow(missing_doc)]
+    #[deprecated = "replaced by .into_ascii_uppercase"]
+    #[inline]
+    fn into_ascii_upper(self) -> String {
+        self.into_ascii_uppercase()
+    }
 
     /// Convert the string to ASCII lower case.
     ///
     /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
     /// but non-ASCII letters are unchanged.
-    fn into_ascii_lower(self) -> String;
+    fn into_ascii_lowercase(self) -> String;
+
+    #[allow(missing_doc)]
+    #[deprecated = "replaced by .into_ascii_lowercase"]
+    #[inline]
+    fn into_ascii_lower(self) -> String {
+        self.into_ascii_lowercase()
+    }
 }
 
 /// Extension methods for ASCII-subset only operations on string slices
@@ -446,29 +474,43 @@ pub trait StrAsciiExt {
     ///
     /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
     /// but non-ASCII letters are unchanged.
-    fn to_ascii_upper(&self) -> String;
+    fn to_ascii_uppercase(&self) -> String;
+
+    #[allow(missing_doc)]
+    #[deprecated = "replaced by .to_ascii_uppercase()"]
+    #[inline]
+    fn to_ascii_upper(&self) -> String {
+        self.to_ascii_uppercase()
+    }
 
     /// Makes a copy of the string in ASCII lower case.
     ///
     /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
     /// but non-ASCII letters are unchanged.
-    fn to_ascii_lower(&self) -> String;
+    fn to_ascii_lowercase(&self) -> String;
+
+    #[allow(missing_doc)]
+    #[deprecated = "replaced by .to_ascii_lowercase()"]
+    #[inline]
+    fn to_ascii_lower(&self) -> String {
+        self.to_ascii_lowercase()
+    }
 
     /// Check that two strings are an ASCII case-insensitive match.
     ///
-    /// Same as `to_ascii_lower(a) == to_ascii_lower(b)`,
+    /// Same as `to_ascii_lowercase(a) == to_ascii_lowercase(b)`,
     /// but without allocating and copying temporary strings.
     fn eq_ignore_ascii_case(&self, other: &str) -> bool;
 }
 
 impl<'a> StrAsciiExt for &'a str {
     #[inline]
-    fn to_ascii_upper(&self) -> String {
+    fn to_ascii_uppercase(&self) -> String {
         unsafe { str_map_bytes(self.to_owned(), ASCII_UPPER_MAP) }
     }
 
     #[inline]
-    fn to_ascii_lower(&self) -> String {
+    fn to_ascii_lowercase(&self) -> String {
         unsafe { str_map_bytes(self.to_owned(), ASCII_LOWER_MAP) }
     }
 
@@ -485,12 +527,12 @@ impl<'a> StrAsciiExt for &'a str {
 
 impl StringAsciiExt for String {
     #[inline]
-    fn into_ascii_upper(self) -> String {
+    fn into_ascii_uppercase(self) -> String {
         unsafe { str_map_bytes(self, ASCII_UPPER_MAP) }
     }
 
     #[inline]
-    fn into_ascii_lower(self) -> String {
+    fn into_ascii_lowercase(self) -> String {
         unsafe { str_map_bytes(self, ASCII_LOWER_MAP) }
     }
 }
@@ -599,15 +641,15 @@ mod tests {
         assert_eq!('A'.to_ascii().to_char(), 'A');
         assert_eq!('A'.to_ascii().to_byte(), 65u8);
 
-        assert_eq!('A'.to_ascii().to_lower().to_char(), 'a');
-        assert_eq!('Z'.to_ascii().to_lower().to_char(), 'z');
-        assert_eq!('a'.to_ascii().to_upper().to_char(), 'A');
-        assert_eq!('z'.to_ascii().to_upper().to_char(), 'Z');
+        assert_eq!('A'.to_ascii().to_lowercase().to_char(), 'a');
+        assert_eq!('Z'.to_ascii().to_lowercase().to_char(), 'z');
+        assert_eq!('a'.to_ascii().to_uppercase().to_char(), 'A');
+        assert_eq!('z'.to_ascii().to_uppercase().to_char(), 'Z');
 
-        assert_eq!('@'.to_ascii().to_lower().to_char(), '@');
-        assert_eq!('['.to_ascii().to_lower().to_char(), '[');
-        assert_eq!('`'.to_ascii().to_upper().to_char(), '`');
-        assert_eq!('{'.to_ascii().to_upper().to_char(), '{');
+        assert_eq!('@'.to_ascii().to_lowercase().to_char(), '@');
+        assert_eq!('['.to_ascii().to_lowercase().to_char(), '[');
+        assert_eq!('`'.to_ascii().to_uppercase().to_char(), '`');
+        assert_eq!('{'.to_ascii().to_uppercase().to_char(), '{');
 
         assert!('0'.to_ascii().is_digit());
         assert!('9'.to_ascii().is_digit());
@@ -631,12 +673,13 @@ mod tests {
         assert_eq!(v.to_ascii(), v2ascii!([40, 32, 59]));
         assert_eq!("( ;".to_string().as_slice().to_ascii(), v2ascii!([40, 32, 59]));
 
-        assert_eq!("abCDef&?#".to_ascii().to_lower().into_str(), "abcdef&?#".to_string());
-        assert_eq!("abCDef&?#".to_ascii().to_upper().into_str(), "ABCDEF&?#".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_lowercase().into_str(), "abcdef&?#".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_uppercase().into_str(), "ABCDEF&?#".to_string());
 
-        assert_eq!("".to_ascii().to_lower().into_str(), "".to_string());
-        assert_eq!("YMCA".to_ascii().to_lower().into_str(), "ymca".to_string());
-        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_str(), "ABCDEFXYZ:.;".to_string());
+        assert_eq!("".to_ascii().into_lowercase().into_str(), "".to_string());
+        assert_eq!("YMCA".to_ascii().into_lowercase().into_str(), "ymca".to_string());
+        assert_eq!("abcDEFxyz:.;".to_ascii().into_uppercase().into_str(),
+                   "ABCDEFXYZ:.;".to_string());
 
         assert!("aBcDeF&?#".to_ascii().eq_ignore_case("AbCdEf&?#".to_ascii()));
 
@@ -648,11 +691,11 @@ mod tests {
 
     #[test]
     fn test_ascii_vec_ng() {
-        assert_eq!("abCDef&?#".to_ascii().to_lower().into_str(), "abcdef&?#".to_string());
-        assert_eq!("abCDef&?#".to_ascii().to_upper().into_str(), "ABCDEF&?#".to_string());
-        assert_eq!("".to_ascii().to_lower().into_str(), "".to_string());
-        assert_eq!("YMCA".to_ascii().to_lower().into_str(), "ymca".to_string());
-        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_str(), "ABCDEFXYZ:.;".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_lowercase().into_str(), "abcdef&?#".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_uppercase().into_str(), "ABCDEF&?#".to_string());
+        assert_eq!("".to_ascii().to_lowercase().into_str(), "".to_string());
+        assert_eq!("YMCA".to_ascii().to_lowercase().into_str(), "ymca".to_string());
+        assert_eq!("abcDEFxyz:.;".to_ascii().to_uppercase().into_str(), "ABCDEFXYZ:.;".to_string());
     }
 
     #[test]
@@ -722,64 +765,64 @@ mod tests {
     }
 
     #[test]
-    fn test_to_ascii_upper() {
-        assert_eq!("url()URL()uRl()ürl".to_ascii_upper(), "URL()URL()URL()üRL".to_string());
-        assert_eq!("hıKß".to_ascii_upper(), "HıKß".to_string());
+    fn test_to_ascii_uppercase() {
+        assert_eq!("url()URL()uRl()ürl".to_ascii_uppercase(), "URL()URL()URL()üRL".to_string());
+        assert_eq!("hıKß".to_ascii_uppercase(), "HıKß".to_string());
 
         let mut i = 0;
         while i <= 500 {
             let upper = if 'a' as u32 <= i && i <= 'z' as u32 { i + 'A' as u32 - 'a' as u32 }
                         else { i };
-            assert_eq!(from_char(from_u32(i).unwrap()).as_slice().to_ascii_upper(),
+            assert_eq!(from_char(from_u32(i).unwrap()).as_slice().to_ascii_uppercase(),
                        from_char(from_u32(upper).unwrap()).to_string())
             i += 1;
         }
     }
 
     #[test]
-    fn test_to_ascii_lower() {
-        assert_eq!("url()URL()uRl()Ürl".to_ascii_lower(), "url()url()url()Ürl".to_string());
+    fn test_to_ascii_lowercase() {
+        assert_eq!("url()URL()uRl()Ürl".to_ascii_lowercase(), "url()url()url()Ürl".to_string());
         // Dotted capital I, Kelvin sign, Sharp S.
-        assert_eq!("HİKß".to_ascii_lower(), "hİKß".to_string());
+        assert_eq!("HİKß".to_ascii_lowercase(), "hİKß".to_string());
 
         let mut i = 0;
         while i <= 500 {
             let lower = if 'A' as u32 <= i && i <= 'Z' as u32 { i + 'a' as u32 - 'A' as u32 }
                         else { i };
-            assert_eq!(from_char(from_u32(i).unwrap()).as_slice().to_ascii_lower(),
+            assert_eq!(from_char(from_u32(i).unwrap()).as_slice().to_ascii_lowercase(),
                        from_char(from_u32(lower).unwrap()).to_string())
             i += 1;
         }
     }
 
     #[test]
-    fn test_into_ascii_upper() {
-        assert_eq!(("url()URL()uRl()ürl".to_string()).into_ascii_upper(),
+    fn test_into_ascii_uppercase() {
+        assert_eq!(("url()URL()uRl()ürl".to_string()).into_ascii_uppercase(),
                    "URL()URL()URL()üRL".to_string());
-        assert_eq!(("hıKß".to_string()).into_ascii_upper(), "HıKß".to_string());
+        assert_eq!(("hıKß".to_string()).into_ascii_uppercase(), "HıKß".to_string());
 
         let mut i = 0;
         while i <= 500 {
             let upper = if 'a' as u32 <= i && i <= 'z' as u32 { i + 'A' as u32 - 'a' as u32 }
                         else { i };
-            assert_eq!(from_char(from_u32(i).unwrap()).to_string().into_ascii_upper(),
+            assert_eq!(from_char(from_u32(i).unwrap()).to_string().into_ascii_uppercase(),
                        from_char(from_u32(upper).unwrap()).to_string())
             i += 1;
         }
     }
 
     #[test]
-    fn test_into_ascii_lower() {
-        assert_eq!(("url()URL()uRl()Ürl".to_string()).into_ascii_lower(),
+    fn test_into_ascii_lowercase() {
+        assert_eq!(("url()URL()uRl()Ürl".to_string()).into_ascii_lowercase(),
                    "url()url()url()Ürl".to_string());
         // Dotted capital I, Kelvin sign, Sharp S.
-        assert_eq!(("HİKß".to_string()).into_ascii_lower(), "hİKß".to_string());
+        assert_eq!(("HİKß".to_string()).into_ascii_lowercase(), "hİKß".to_string());
 
         let mut i = 0;
         while i <= 500 {
             let lower = if 'A' as u32 <= i && i <= 'Z' as u32 { i + 'a' as u32 - 'A' as u32 }
                         else { i };
-            assert_eq!(from_char(from_u32(i).unwrap()).to_string().into_ascii_lower(),
+            assert_eq!(from_char(from_u32(i).unwrap()).to_string().into_ascii_lowercase(),
                        from_char(from_u32(lower).unwrap()).to_string())
             i += 1;
         }

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -676,9 +676,9 @@ mod tests {
         assert_eq!("abCDef&?#".to_ascii().to_lowercase().into_str(), "abcdef&?#".to_string());
         assert_eq!("abCDef&?#".to_ascii().to_uppercase().into_str(), "ABCDEF&?#".to_string());
 
-        assert_eq!("".to_ascii().into_lowercase().into_str(), "".to_string());
-        assert_eq!("YMCA".to_ascii().into_lowercase().into_str(), "ymca".to_string());
-        assert_eq!("abcDEFxyz:.;".to_ascii().into_uppercase().into_str(),
+        assert_eq!("".to_ascii().to_lowercase().into_str(), "".to_string());
+        assert_eq!("YMCA".to_ascii().to_lowercase().into_str(), "ymca".to_string());
+        assert_eq!("abcDEFxyz:.;".to_ascii().to_uppercase().into_str(),
                    "ABCDEFXYZ:.;".to_string());
 
         assert!("aBcDeF&?#".to_ascii().eq_ignore_case("AbCdEf&?#".to_ascii()));

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -10,7 +10,7 @@
 
 //! Windows file path handling
 
-use ascii::AsciiCast;
+use ascii::ToAscii;
 use c_str::{CString, ToCStr};
 use clone::Clone;
 use cmp::{Eq, TotalEq};

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -247,8 +247,8 @@ impl GenericPathUnsafe for Path {
             // path is assumed to have a prefix of Some(DiskPrefix)
             let repr = me.repr.as_slice();
             match me.prefix {
-                Some(DiskPrefix) => repr[0] == path[0].to_ascii().to_upper().to_byte(),
-                Some(VerbatimDiskPrefix) => repr[4] == path[0].to_ascii().to_upper().to_byte(),
+                Some(DiskPrefix) => repr[0] == path[0].to_ascii().to_uppercase().to_byte(),
+                Some(VerbatimDiskPrefix) => repr[4] == path[0].to_ascii().to_uppercase().to_byte(),
                 _ => false
             }
         }
@@ -740,7 +740,7 @@ impl Path {
                                     let v = s.as_mut_vec();
                                     *v.get_mut(0) = v.get(0)
                                                      .to_ascii()
-                                                     .to_upper()
+                                                     .to_uppercase()
                                                      .to_byte();
                                 }
                                 if is_abs {
@@ -756,7 +756,7 @@ impl Path {
                                 let mut s = String::from_str(s.slice_to(len));
                                 unsafe {
                                     let v = s.as_mut_vec();
-                                    *v.get_mut(4) = v.get(4).to_ascii().to_upper().to_byte();
+                                    *v.get_mut(4) = v.get(4).to_ascii().to_uppercase().to_byte();
                                 }
                                 Some(s)
                             }
@@ -777,12 +777,12 @@ impl Path {
                         let mut s = String::with_capacity(n);
                         match prefix {
                             Some(DiskPrefix) => {
-                                s.push_char(prefix_[0].to_ascii().to_upper().to_char());
+                                s.push_char(prefix_[0].to_ascii().to_uppercase().to_char());
                                 s.push_char(':');
                             }
                             Some(VerbatimDiskPrefix) => {
                                 s.push_str(prefix_.slice_to(4));
-                                s.push_char(prefix_[4].to_ascii().to_upper().to_char());
+                                s.push_char(prefix_[4].to_ascii().to_uppercase().to_char());
                                 s.push_str(prefix_.slice_from(5));
                             }
                             Some(UNCPrefix(a,b)) => {

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -53,8 +53,8 @@
 
 // Reexported types and traits
 
-#[doc(no_inline)] pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
-#[doc(no_inline)] pub use ascii::IntoBytes;
+#[doc(no_inline)] pub use ascii::{Ascii, ToAscii, IntoAscii, AsciiStr};
+#[doc(no_inline)] pub use ascii::{AsciiSlice, AsciiVec, IntoBytes};
 #[doc(no_inline)] pub use c_str::ToCStr;
 #[doc(no_inline)] pub use char::Char;
 #[doc(no_inline)] pub use clone::Clone;

--- a/src/libstd/string.rs
+++ b/src/libstd/string.rs
@@ -366,6 +366,21 @@ impl FromStr for String {
     }
 }
 
+/// Unsafe operations
+pub mod raw {
+    use super::String;
+    use vec::Vec;
+
+    /// Returns the vector as a string buffer without copying,
+    /// without checking if it contains valid UTF-8.
+    #[inline]
+    pub unsafe fn from_utf8(vec: Vec<u8>) -> String {
+        String {
+            vec: vec
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate test;

--- a/src/libstd/vec.rs
+++ b/src/libstd/vec.rs
@@ -1184,15 +1184,7 @@ impl<T> Vec<T> {
     /// would also make any pointers to it invalid.
     #[inline]
     pub fn as_ptr(&self) -> *T {
-        // If we have a 0-sized vector, then the base pointer should not be NULL
-        // because an iterator over the slice will attempt to yield the base
-        // pointer as the first element in the vector, but this will end up
-        // being Some(NULL) which is optimized to None.
-        if mem::size_of::<T>() == 0 {
-            1 as *T
-        } else {
-            self.ptr as *T
-        }
+        self.ptr as *T
     }
 
     /// Returns a mutable unsafe pointer to the vector's buffer.
@@ -1204,12 +1196,7 @@ impl<T> Vec<T> {
     /// would also make any pointers to it invalid.
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T {
-        // see above for the 0-size check
-        if mem::size_of::<T>() == 0 {
-            1 as *mut T
-        } else {
-            self.ptr
-        }
+        self.ptr
     }
 
     /// Retains only the elements specified by the predicate.

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -522,12 +522,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                     }
                 }
                 FormatHEX => {
-                    s = s.as_slice()
-                         .to_ascii()
-                         .to_upper()
-                         .into_bytes()
-                         .move_iter()
-                         .collect();
+                    s = s.as_slice().to_ascii().to_uppercase().into_bytes();
                     if flags.alternate {
                         let s_ = replace(&mut s, vec!('0' as u8, 'X' as u8));
                         s.push_all_move(s_);

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -63,7 +63,7 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
        buffer.push_str(format!("{} {:0.3f}\n",
                                k.as_slice()
                                .to_ascii()
-                               .to_upper()
+                               .to_uppercase()
                                .into_str(), v).as_slice());
    }
 

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -257,7 +257,7 @@ fn get_sequence<R: Buffer>(r: &mut R, key: &str) -> Vec<u8> {
         res.push_all(l.as_slice().trim().as_bytes());
     }
     for b in res.mut_iter() {
-        *b = b.to_ascii().to_upper().to_byte();
+        *b = b.to_ascii().to_uppercase().to_byte();
     }
     res
 }

--- a/src/test/run-pass/issue-10683.rs
+++ b/src/test/run-pass/issue-10683.rs
@@ -13,7 +13,7 @@ use std::ascii::StrAsciiExt;
 static NAME: &'static str = "hello world";
 
 fn main() {
-    match NAME.to_ascii_lower().as_slice() {
+    match NAME.to_ascii_lowercase().as_slice() {
         "foo" => {}
         _ => {}
     }


### PR DESCRIPTION
Tweak the names of various things in `std::ascii` to be more descriptive and consistent.

Also fix `Vec.ptr()` to always return the correct pointer even for zero-sized types; handle the issues with iteration over zero-sized types in the iterators instead.

[breaking-change]
