### PR TITLE
add `Show` impl for Tree{Map,Set} and cleanup

### DIFF
--- a/src/libcollections/hashmap.rs
+++ b/src/libcollections/hashmap.rs
@@ -2004,6 +2004,20 @@ mod test_map {
     }
 
     #[test]
+    fn test_show() {
+        let mut map: HashMap<int, int> = HashMap::new();
+        let empty: HashMap<int, int> = HashMap::new();
+
+        map.insert(1, 2);
+        map.insert(3, 4);
+
+        let map_str = format!("{}", map);
+
+        assert!(map_str == "{1: 2, 3: 4}".to_owned() || map_str == "{3: 4, 1: 2}".to_owned());
+        assert_eq!(format!("{}", empty), "{}".to_owned());
+    }
+
+    #[test]
     fn test_expand() {
         let mut m = HashMap::new();
 

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -12,9 +12,11 @@
 //! trees. The only requirement for the types is that the key implements
 //! `TotalOrd`.
 
-use std::iter;
-use std::iter::{Peekable};
 use std::cmp::Ordering;
+use std::fmt::Show;
+use std::fmt;
+use std::iter::Peekable;
+use std::iter;
 use std::mem::{replace, swap};
 use std::ptr;
 
@@ -65,6 +67,19 @@ fn lt<K: Ord + TotalOrd, V: Ord>(a: &TreeMap<K, V>,
 impl<K: Ord + TotalOrd, V: Ord> Ord for TreeMap<K, V> {
     #[inline]
     fn lt(&self, other: &TreeMap<K, V>) -> bool { lt(self, other) }
+}
+
+impl<K: TotalOrd + Show, V: Show> Show for TreeMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, r"\{"));
+
+        for (i, (k, v)) in self.iter().enumerate() {
+            if i != 0 { try!(write!(f, ", ")); }
+            try!(write!(f, "{}: {}", *k, *v));
+        }
+
+        write!(f, r"\}")
+    }
 }
 
 impl<K: TotalOrd, V> Container for TreeMap<K, V> {
@@ -545,6 +560,19 @@ impl<T: Eq + TotalOrd> Eq for TreeSet<T> {
 impl<T: Ord + TotalOrd> Ord for TreeSet<T> {
     #[inline]
     fn lt(&self, other: &TreeSet<T>) -> bool { self.map < other.map }
+}
+
+impl<T: TotalOrd + Show> Show for TreeSet<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, r"\{"));
+
+        for (i, x) in self.iter().enumerate() {
+            if i != 0 { try!(write!(f, ", ")); }
+            try!(write!(f, "{}", *x));
+        }
+
+        write!(f, r"\}")
+    }
 }
 
 impl<T: TotalOrd> Container for TreeSet<T> {
@@ -1329,6 +1357,20 @@ mod test_treemap {
     }
 
     #[test]
+    fn test_show() {
+        let mut map: TreeMap<int, int> = TreeMap::new();
+        let empty: TreeMap<int, int> = TreeMap::new();
+
+        map.insert(1, 2);
+        map.insert(3, 4);
+
+        let map_str = format!("{}", map);
+
+        assert!(map_str == "{1: 2, 3: 4}".to_owned());
+        assert_eq!(format!("{}", empty), "{}".to_owned());
+    }
+
+    #[test]
     fn test_lazy_iterator() {
         let mut m = TreeMap::new();
         let (x1, y1) = (2, 5);
@@ -1722,5 +1764,19 @@ mod test_set {
         for x in xs.iter() {
             assert!(set.contains(x));
         }
+    }
+
+    #[test]
+    fn test_show() {
+        let mut set: TreeSet<int> = TreeSet::new();
+        let empty: TreeSet<int> = TreeSet::new();
+
+        set.insert(1);
+        set.insert(2);
+
+        let set_str = format!("{}", set);
+
+        assert!(set_str == "{1, 2}".to_owned());
+        assert_eq!(format!("{}", empty), "{}".to_owned());
     }
 }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1434,36 +1434,6 @@ impl<T: Iterator<char>> Parser<T> {
                         },
                     },
                     _ => return self.error(InvalidEscape),
-/*=======
-                    'u' => {
-                        // Parse \u1234.
-                        let mut i = 0u;
-                        let mut n = 0u;
-                        while i < 4u && !self.eof() {
-                            self.bump();
-                            n = match self.ch_or_null() {
-                                c @ '0' .. '9' => n * 16u + (c as uint) - ('0' as uint),
-                                'a' | 'A' => n * 16u + 10u,
-                                'b' | 'B' => n * 16u + 11u,
-                                'c' | 'C' => n * 16u + 12u,
-                                'd' | 'D' => n * 16u + 13u,
-                                'e' | 'E' => n * 16u + 14u,
-                                'f' | 'F' => n * 16u + 15u,
-                                _ => return self.error(UnrecognizedHex)
-                            };
-
-                            i += 1u;
-                        }
-
-                        // Error out if we didn't parse 4 digits.
-                        if i != 4u {
-                            return self.error(NotFourDigit);
-                        }
-
-                        res.push_char(char::from_u32(n as u32).unwrap());
-                    }
-                    _ => return self.error(InvalidEscape),
->>>>>>> Add a streaming parser to serialize::json.*/
                 }
                 escape = false;
             } else if self.ch_is('\\') {


### PR DESCRIPTION
This is a hodge podge of a couple small cleanup commits. It implements `Show` for `TreeMap` and `TreeSet`, and some removal of commented out code.
