### PR TITLE
rustc: Use rust strings for failure arguments

### DIFF
--- a/src/libcore/failure.rs
+++ b/src/libcore/failure.rs
@@ -28,13 +28,25 @@
 
 #![allow(dead_code, missing_doc)]
 
-#[cfg(not(test))]
-use str::raw::c_str_to_static_slice;
 use fmt;
+use intrinsics;
+#[cfg(not(test), stage0)]
+use str::raw::c_str_to_static_slice;
 
 #[cold] #[inline(never)] // this is the slow path, always
 #[lang="fail_"]
-#[cfg(not(test))]
+#[cfg(not(test), not(stage0))]
+fn fail_(expr: &'static str, file: &'static str, line: uint) -> ! {
+    format_args!(|args| -> () {
+        begin_unwind(args, file, line);
+    }, "{}", expr);
+
+    unsafe { intrinsics::abort() }
+}
+
+#[cold] #[inline(never)] // this is the slow path, always
+#[lang="fail_"]
+#[cfg(not(test), stage0)]
 fn fail_(expr: *u8, file: *u8, line: uint) -> ! {
     unsafe {
         let expr = c_str_to_static_slice(expr as *i8);
@@ -43,19 +55,30 @@ fn fail_(expr: *u8, file: *u8, line: uint) -> ! {
             begin_unwind(args, file, line);
         }, "{}", expr);
 
-        loop {}
+        intrinsics::abort()
     }
 }
 
 #[cold]
 #[lang="fail_bounds_check"]
-#[cfg(not(test))]
+#[cfg(not(test), not(stage0))]
+fn fail_bounds_check(file: &'static str, line: uint,
+                     index: uint, len: uint) -> ! {
+    format_args!(|args| -> () {
+        begin_unwind(args, file, line);
+    }, "index out of bounds: the len is {} but the index is {}", len, index);
+    unsafe { intrinsics::abort() }
+}
+
+#[cold]
+#[lang="fail_bounds_check"]
+#[cfg(not(test), stage0)]
 fn fail_bounds_check(file: *u8, line: uint, index: uint, len: uint) -> ! {
     let file = unsafe { c_str_to_static_slice(file as *i8) };
     format_args!(|args| -> () {
         begin_unwind(args, file, line);
     }, "index out of bounds: the len is {} but the index is {}", len, index);
-    loop {}
+    unsafe { intrinsics::abort() }
 }
 
 #[cold]

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -596,7 +596,8 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString, null_terminated: bool) -> Va
 pub fn C_str_slice(cx: &CrateContext, s: InternedString) -> ValueRef {
     unsafe {
         let len = s.get().len();
-        let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s, false), Type::i8p(cx).to_ref());
+        let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s, false),
+                                            Type::i8p(cx).to_ref());
         C_struct(cx, [cs, C_uint(cx, len)], false)
     }
 }
@@ -841,19 +842,6 @@ pub fn find_vtable(tcx: &ty::ctxt,
         }
     };
     param_bounds.get(n_bound).clone()
-}
-
-pub fn filename_and_line_num_from_span(bcx: &Block, span: Span)
-                                       -> (ValueRef, ValueRef) {
-    let loc = bcx.sess().codemap().lookup_char_pos(span.lo);
-    let filename_cstr = C_cstr(bcx.ccx(),
-                               token::intern_and_get_ident(loc.file
-                                                              .name
-                                                              .as_slice()),
-                               true);
-    let filename = build::PointerCast(bcx, filename_cstr, Type::i8p(bcx.ccx()));
-    let line = C_int(bcx.ccx(), loc.line as int);
-    (filename, line)
 }
 
 // Casts a Rust bool value to an i1.

--- a/src/test/auxiliary/lang-item-public.rs
+++ b/src/test/auxiliary/lang-item-public.rs
@@ -11,7 +11,7 @@
 #![no_std]
 
 #[lang="fail_"]
-fn fail(_: *i8, _: *i8, _: uint) -> ! { loop {} }
+fn fail(_: &'static str, _: &'static str, _: uint) -> ! { loop {} }
 
 #[lang = "stack_exhausted"]
 extern fn stack_exhausted() {}


### PR DESCRIPTION
This avoids having to perform conversions from `*u8` to `&'static str` which can
suck in a good deal of code.

Closes #14442
