### PR TITLE
rustdoc: Only link to local inlined foreign items

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -85,6 +85,7 @@ fn try_inline_def(cx: &core::DocContext,
         _ => return None,
     };
     let fqn = csearch::get_item_path(tcx, did);
+    cx.inlined.borrow_mut().get_mut_ref().insert(did);
     ret.push(clean::Item {
         source: clean::Span::empty(),
         name: Some(fqn.last().unwrap().to_str().to_string()),

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -41,6 +41,7 @@ pub struct DocContext {
     pub external_paths: ExternalPaths,
     pub external_traits: RefCell<Option<HashMap<ast::DefId, clean::Trait>>>,
     pub external_typarams: RefCell<Option<HashMap<ast::DefId, String>>>,
+    pub inlined: RefCell<Option<HashSet<ast::DefId>>>,
 }
 
 impl DocContext {
@@ -58,6 +59,7 @@ pub struct CrateAnalysis {
     pub external_paths: ExternalPaths,
     pub external_traits: RefCell<Option<HashMap<ast::DefId, clean::Trait>>>,
     pub external_typarams: RefCell<Option<HashMap<ast::DefId, String>>>,
+    pub inlined: RefCell<Option<HashSet<ast::DefId>>>,
 }
 
 /// Parses, resolves, and typechecks the given crate
@@ -111,12 +113,14 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>)
         external_traits: RefCell::new(Some(HashMap::new())),
         external_typarams: RefCell::new(Some(HashMap::new())),
         external_paths: RefCell::new(Some(HashMap::new())),
+        inlined: RefCell::new(Some(HashSet::new())),
     }, CrateAnalysis {
         exported_items: exported_items,
         public_items: public_items,
         external_paths: RefCell::new(None),
         external_traits: RefCell::new(None),
         external_typarams: RefCell::new(None),
+        inlined: RefCell::new(None),
     })
 }
 
@@ -138,5 +142,7 @@ pub fn run_core(libs: HashSet<Path>, cfgs: Vec<String>, path: &Path)
     *analysis.external_traits.borrow_mut() = map;
     let map = ctxt.external_typarams.borrow_mut().take();
     *analysis.external_typarams.borrow_mut() = map;
+    let map = ctxt.inlined.borrow_mut().take();
+    *analysis.inlined.borrow_mut() = map;
     (krate, analysis)
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -150,7 +150,7 @@ fn resolved_path(w: &mut fmt::Formatter, did: ast::DefId, p: &clean::Path,
                  print_all: bool) -> fmt::Result {
     path(w, p, print_all,
         |cache, loc| {
-            if ast_util::is_local(did) || cache.paths.contains_key(&did) {
+            if ast_util::is_local(did) || cache.inlined.contains(&did) {
                 Some(("../".repeat(loc.len())).to_string())
             } else {
                 match *cache.extern_locations.get(&did.krate) {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -159,6 +159,9 @@ pub struct Cache {
     /// Cache of where external crate documentation can be found.
     pub extern_locations: HashMap<ast::CrateNum, ExternalLocation>,
 
+    /// Set of definitions which have been inlined from external crates.
+    pub inlined: HashSet<ast::DefId>,
+
     // Private fields only used when initially crawling a crate to build a cache
 
     stack: Vec<String>,
@@ -287,6 +290,9 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
         typarams: analysis.as_ref().map(|a| {
             a.external_typarams.borrow_mut().take_unwrap()
         }).unwrap_or(HashMap::new()),
+        inlined: analysis.as_ref().map(|a| {
+            a.inlined.borrow_mut().take_unwrap()
+        }).unwrap_or(HashSet::new()),
     };
     cache.stack.push(krate.name.clone());
     krate = cache.fold_crate(krate);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -78,6 +78,7 @@ pub fn run(input: &str,
         external_paths: RefCell::new(Some(HashMap::new())),
         external_traits: RefCell::new(None),
         external_typarams: RefCell::new(None),
+        inlined: RefCell::new(None),
     };
     super::ctxtkey.replace(Some(ctx));
 


### PR DESCRIPTION
This commit alters rustdoc to keep a hash set of known inlined items which is a
whitelist for generating URLs to.

Closes #14438
