### PR TITLE
fix MIPS target

### DIFF
--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -270,7 +270,7 @@ fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,
 type Registers = [uint, ..32];
 
 #[cfg(target_arch = "mips")]
-fn new_regs() -> Box<Registers> { box [0, .. 32] }
+fn new_regs() -> Box<Registers> { box {[0, .. 32]} }
 
 #[cfg(target_arch = "mips")]
 fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2476,6 +2476,9 @@ pub mod consts {
         }
         pub mod posix08 {
         }
+        #[cfg(target_arch = "arm")]
+        #[cfg(target_arch = "x86")]
+        #[cfg(target_arch = "x86_64")]
         pub mod bsd44 {
             use types::os::arch::c95::c_int;
 
@@ -2513,6 +2516,49 @@ pub mod consts {
             pub static SO_BROADCAST: c_int = 6;
             pub static SO_REUSEADDR: c_int = 2;
             pub static SO_ERROR: c_int = 4;
+
+            pub static SHUT_RD: c_int = 0;
+            pub static SHUT_WR: c_int = 1;
+            pub static SHUT_RDWR: c_int = 2;
+        }
+        #[cfg(target_arch = "mips")]
+        pub mod bsd44 {
+            use types::os::arch::c95::c_int;
+
+            pub static MADV_NORMAL : c_int = 0;
+            pub static MADV_RANDOM : c_int = 1;
+            pub static MADV_SEQUENTIAL : c_int = 2;
+            pub static MADV_WILLNEED : c_int = 3;
+            pub static MADV_DONTNEED : c_int = 4;
+            pub static MADV_REMOVE : c_int = 9;
+            pub static MADV_DONTFORK : c_int = 10;
+            pub static MADV_DOFORK : c_int = 11;
+            pub static MADV_MERGEABLE : c_int = 12;
+            pub static MADV_UNMERGEABLE : c_int = 13;
+            pub static MADV_HWPOISON : c_int = 100;
+
+            pub static AF_UNIX: c_int = 1;
+            pub static AF_INET: c_int = 2;
+            pub static AF_INET6: c_int = 10;
+            pub static SOCK_STREAM: c_int = 2;
+            pub static SOCK_DGRAM: c_int = 1;
+            pub static IPPROTO_TCP: c_int = 6;
+            pub static IPPROTO_IP: c_int = 0;
+            pub static IPPROTO_IPV6: c_int = 41;
+            pub static IP_MULTICAST_TTL: c_int = 33;
+            pub static IP_MULTICAST_LOOP: c_int = 34;
+            pub static IP_TTL: c_int = 2;
+            pub static IP_ADD_MEMBERSHIP: c_int = 35;
+            pub static IP_DROP_MEMBERSHIP: c_int = 36;
+            pub static IPV6_ADD_MEMBERSHIP: c_int = 20;
+            pub static IPV6_DROP_MEMBERSHIP: c_int = 21;
+
+            pub static TCP_NODELAY: c_int = 1;
+            pub static SOL_SOCKET: c_int = 65535;
+            pub static SO_KEEPALIVE: c_int = 8;
+            pub static SO_BROADCAST: c_int = 32;
+            pub static SO_REUSEADDR: c_int = 4;
+            pub static SO_ERROR: c_int = 4103;
 
             pub static SHUT_RD: c_int = 0;
             pub static SHUT_WR: c_int = 1;

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -42,11 +42,12 @@ enum InAddr {
 fn ip_to_inaddr(ip: ip::IpAddr) -> InAddr {
     match ip {
         ip::Ipv4Addr(a, b, c, d) => {
+            let ip = (a as u32 << 24) |
+                     (b as u32 << 16) |
+                     (c as u32 <<  8) |
+                     (d as u32 <<  0);
             InAddr(libc::in_addr {
-                s_addr: (d as u32 << 24) |
-                        (c as u32 << 16) |
-                        (b as u32 <<  8) |
-                        (a as u32 <<  0)
+                s_addr: mem::from_be32(ip)
             })
         }
         ip::Ipv6Addr(a, b, c, d, e, f, g, h) => {
@@ -174,11 +175,11 @@ pub fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
             let storage: &libc::sockaddr_in = unsafe {
                 mem::transmute(storage)
             };
-            let addr = storage.sin_addr.s_addr as u32;
-            let a = (addr >>  0) as u8;
-            let b = (addr >>  8) as u8;
-            let c = (addr >> 16) as u8;
-            let d = (addr >> 24) as u8;
+            let ip = mem::to_be32(storage.sin_addr.s_addr as u32);
+            let a = (ip >> 24) as u8;
+            let b = (ip >> 16) as u8;
+            let c = (ip >>  8) as u8;
+            let d = (ip >>  0) as u8;
             Ok(ip::SocketAddr {
                 ip: ip::Ipv4Addr(a, b, c, d),
                 port: ntohs(storage.sin_port),

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -43,11 +43,11 @@ pub fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
             let storage: &libc::sockaddr_in = unsafe {
                 mem::transmute(storage)
             };
-            let addr = storage.sin_addr.s_addr as u32;
-            let a = (addr >>  0) as u8;
-            let b = (addr >>  8) as u8;
-            let c = (addr >> 16) as u8;
-            let d = (addr >> 24) as u8;
+            let ip = mem::to_be32(storage.sin_addr.s_addr as u32);
+            let a = (ip >> 24) as u8;
+            let b = (ip >> 16) as u8;
+            let c = (ip >>  8) as u8;
+            let d = (ip >>  0) as u8;
             ip::SocketAddr {
                 ip: ip::Ipv4Addr(a, b, c, d),
                 port: ntohs(storage.sin_port),
@@ -82,15 +82,16 @@ fn addr_to_sockaddr(addr: ip::SocketAddr) -> (libc::sockaddr_storage, uint) {
         let mut storage: libc::sockaddr_storage = mem::zeroed();
         let len = match addr.ip {
             ip::Ipv4Addr(a, b, c, d) => {
+                let ip = (a as u32 << 24) |
+                         (b as u32 << 16) |
+                         (c as u32 <<  8) |
+                         (d as u32 <<  0);
                 let storage: &mut libc::sockaddr_in =
                     mem::transmute(&mut storage);
                 (*storage).sin_family = libc::AF_INET as libc::sa_family_t;
                 (*storage).sin_port = htons(addr.port);
                 (*storage).sin_addr = libc::in_addr {
-                    s_addr: (d as u32 << 24) |
-                            (c as u32 << 16) |
-                            (b as u32 <<  8) |
-                            (a as u32 <<  0)
+                    s_addr: mem::from_be32(ip)
                 };
                 mem::size_of::<libc::sockaddr_in>()
             }


### PR DESCRIPTION
Because IPv4 address conversion doesn't consider big-endian target, I add functions to handle that.
These function names may need to be changed, but I can't come up with a good one.
