### PR TITLE
mk: Don't build any docs with --disable-docs.

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -287,6 +287,7 @@ $(foreach crate,$(COMPILER_DOC_CRATES),$(eval $(call DEF_LIB_DOC,$(crate),COMPIL
 ifdef CFG_DISABLE_DOCS
   $(info cfg: disabling doc build (CFG_DISABLE_DOCS))
   DOC_TARGETS :=
+  COMPILER_DOC_TARGETS :=
 endif
 
 docs: $(DOC_TARGETS)


### PR DESCRIPTION
We were still generating compiler docs even with --disable-docs passed.

cc @pnkfelix
