### PR TITLE
std: Bring back half of Add on String

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -351,6 +351,14 @@ impl<'a, S: Str> Equiv<S> for String {
     }
 }
 
+impl<S: Str> Add<S, String> for String {
+    fn add(&self, other: &S) -> String {
+        let mut s = self.to_string();
+        s.push_str(other.as_slice());
+        return s;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::prelude::*;
@@ -466,5 +474,14 @@ mod tests {
         s.clear();
         assert_eq!(s.len(), 0);
         assert_eq!(s.as_slice(), "");
+    }
+
+    #[test]
+    fn test_str_add() {
+        let a = String::from_str("12345");
+        let b = a + "2";
+        let b = b + String::from_str("2");
+        assert_eq!(b.len(), 7);
+        assert_eq!(b.as_slice(), "1234522");
     }
 }


### PR DESCRIPTION
This adds an implementation of Add for String where the rhs is `<S: Str>`. The
other half of adding strings is where the lhs is `<S: Str>`, but coherence and
the libcore separation currently prevent that.
