### PR TITLE
debuginfo: Unify DWARF representation of enum types

### DIFF
--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -22,7 +22,7 @@
 // gdb-check:$2 = {{TheB, x = 0, y = 1229782938247303441}, {TheB, 0, 286331153, 286331153}}
 
 // gdb-command:print *univariant_ref
-// gdb-check:$3 = {4820353753753434}
+// gdb-check:$3 = {{4820353753753434}}
 
 #![allow(unused_variable)]
 #![feature(struct_variant)]

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -27,7 +27,7 @@
 // gdb-check:$3 = {{Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {Case3, a = 0, b = 1499027801, c = 1499027801}, {Case3, a = 0, b = 6438275382588823897}}
 
 // gdb-command:print univariant
-// gdb-check:$4 = {a = -1}
+// gdb-check:$4 = {{a = -1}}
 
 #![feature(struct_variant)]
 

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -27,7 +27,7 @@
 // gdb-check:$3 = {{Case3, 0, 22873, 22873, 22873, 22873}, {Case3, 0, 1499027801, 1499027801}, {Case3, 0, 6438275382588823897}}
 
 // gdb-command:print univariant
-// gdb-check:$4 = {-1}
+// gdb-check:$4 = {{-1}}
 
 
 // NOTE: This is a copy of the non-generic test case. The `Txx` type parameters have to be

--- a/src/test/debuginfo/managed-enum.rs
+++ b/src/test/debuginfo/managed-enum.rs
@@ -22,7 +22,7 @@
 // gdb-check:$2 = {{TheB, x = 0, y = 1229782938247303441}, {TheB, 0, 286331153, 286331153}}
 
 // gdb-command:print univariant->val
-// gdb-check:$3 = {-9747455}
+// gdb-check:$3 = {{-9747455}}
 
 #![allow(unused_variable)]
 #![feature(struct_variant, managed_boxes)]

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
@@ -16,19 +17,19 @@
 // gdb-command:finish
 
 // gdb-command:print some
-// gdb-check:$1 = (u32 *) 0x12345678
+// gdb-check:$1 = {RUST$ENCODED$ENUM$0$None = {0x12345678}}
 
 // gdb-command:print none
-// gdb-check:$2 = (u32 *) 0x0
+// gdb-check:$2 = {RUST$ENCODED$ENUM$0$None = {0x0}}
 
 // gdb-command:print full
-// gdb-check:$3 = {454545, 0x87654321, 9988}
+// gdb-check:$3 = {RUST$ENCODED$ENUM$1$Empty = {454545, 0x87654321, 9988}}
 
 // gdb-command:print empty->discr
 // gdb-check:$4 = (int *) 0x0
 
 // gdb-command:print droid
-// gdb-check:$5 = {id = 675675, range = 10000001, internals = 0x43218765}
+// gdb-check:$5 = {RUST$ENCODED$ENUM$2$Void = {id = 675675, range = 10000001, internals = 0x43218765}}
 
 // gdb-command:print void_droid->internals
 // gdb-check:$6 = (int *) 0x0

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 
 #![feature(managed_boxes)]
@@ -20,53 +21,53 @@
 
 // gdb-command:print stack_unique.value
 // gdb-check:$1 = 0
-// gdb-command:print stack_unique.next->value
+// gdb-command:print stack_unique.next.RUST$ENCODED$ENUM$0$Empty.val->value
 // gdb-check:$2 = 1
 
 // gdb-command:print unique_unique->value
 // gdb-check:$3 = 2
-// gdb-command:print unique_unique->next->value
+// gdb-command:print unique_unique->next.RUST$ENCODED$ENUM$0$Empty.val->value
 // gdb-check:$4 = 3
 
 // gdb-command:print box_unique->val.value
 // gdb-check:$5 = 4
-// gdb-command:print box_unique->val.next->value
+// gdb-command:print box_unique->val.next.RUST$ENCODED$ENUM$0$Empty.val->value
 // gdb-check:$6 = 5
 
 // gdb-command:print vec_unique[0].value
 // gdb-check:$7 = 6.5
-// gdb-command:print vec_unique[0].next->value
+// gdb-command:print vec_unique[0].next.RUST$ENCODED$ENUM$0$Empty.val->value
 // gdb-check:$8 = 7.5
 
 // gdb-command:print borrowed_unique->value
 // gdb-check:$9 = 8.5
-// gdb-command:print borrowed_unique->next->value
+// gdb-command:print borrowed_unique->next.RUST$ENCODED$ENUM$0$Empty.val->value
 // gdb-check:$10 = 9.5
 
 // MANAGED
 // gdb-command:print stack_managed.value
 // gdb-check:$11 = 10
-// gdb-command:print stack_managed.next.val->value
+// gdb-command:print stack_managed.next.RUST$ENCODED$ENUM$0$Empty.val->val.value
 // gdb-check:$12 = 11
 
 // gdb-command:print unique_managed->value
 // gdb-check:$13 = 12
-// gdb-command:print unique_managed->next.val->value
+// gdb-command:print unique_managed->next.RUST$ENCODED$ENUM$0$Empty.val->val.value
 // gdb-check:$14 = 13
 
 // gdb-command:print box_managed.val->value
 // gdb-check:$15 = 14
-// gdb-command:print box_managed->val->next.val->value
+// gdb-command:print box_managed->val->next.RUST$ENCODED$ENUM$0$Empty.val->val.value
 // gdb-check:$16 = 15
 
 // gdb-command:print vec_managed[0].value
 // gdb-check:$17 = 16.5
-// gdb-command:print vec_managed[0].next.val->value
+// gdb-command:print vec_managed[0].next.RUST$ENCODED$ENUM$0$Empty.val->val.value
 // gdb-check:$18 = 17.5
 
 // gdb-command:print borrowed_managed->value
 // gdb-check:$19 = 18.5
-// gdb-command:print borrowed_managed->next.val->value
+// gdb-command:print borrowed_managed->next.RUST$ENCODED$ENUM$0$Empty.val->val.value
 // gdb-check:$20 = 19.5
 
 // LONG CYCLE
@@ -97,7 +98,7 @@
 // gdb-command:print (*****long_cycle_w_anonymous_types).value
 // gdb-check:$31 = 30
 
-// gdb-command:print (*****((*****long_cycle_w_anonymous_types).next)).value
+// gdb-command:print (*****((*****long_cycle_w_anonymous_types).next.RUST$ENCODED$ENUM$0$Empty.val)).value
 // gdb-check:$32 = 31
 
 // gdb-command:continue

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -24,7 +24,7 @@
 // gdb-check:$2 = {{Case2, 0, {x = 286331153, y = 286331153, z = 4369}}, {Case2, 0, 1229782938247303441, 4369}}
 
 // gdb-command:print univariant
-// gdb-check:$3 = {{x = 123, y = 456, z = 789}}
+// gdb-check:$3 = {{{x = 123, y = 456, z = 789}}}
 
 #![allow(unused_variable)]
 

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -27,7 +27,7 @@
 // gdb-check:$3 = {{Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {Case3, a = 0, b = 1499027801, c = 1499027801}, {Case3, a = 0, b = 6438275382588823897}}
 
 // gdb-command:print univariant
-// gdb-check:$4 = {a = -1}
+// gdb-check:$4 = {{a = -1}}
 
 #![allow(unused_variable)]
 #![feature(struct_variant)]

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -27,7 +27,7 @@
 // gdb-check:$3 = {{Case3, 0, 22873, 22873, 22873, 22873}, {Case3, 0, 1499027801, 1499027801}, {Case3, 0, 6438275382588823897}}
 
 // gdb-command:print univariant
-// gdb-check:$4 = {-1}
+// gdb-check:$4 = {{-1}}
 
 #![allow(unused_variable)]
 

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -22,7 +22,7 @@
 // gdb-check:$2 = {{TheB, x = 0, y = 1229782938247303441}, {TheB, 0, 286331153, 286331153}}
 
 // gdb-command:print *univariant
-// gdb-check:$3 = {123234}
+// gdb-check:$3 = {{123234}}
 
 #![allow(unused_variable)]
 #![feature(struct_variant)]


### PR DESCRIPTION
So far the DWARF information for enums was different for regular enums, univariant enums, Option-like enums, etc. Regular enums were encoded as unions of structs, while the other variants were encoded as bare structs. With the changes in this PR all enums are encoded as unions so that debuggers can reconstruct if something originally was a struct, a univariant enum, or an Option-like enum.  For the latter case, information about the _Null_ variant is encoded into the union field name. This information can then be used by the debugger to print a `None` value actually as `None` instead of `Some(0x0)`.

The changes in this PR should also fix the regression reported in #14385 and #14411, but I want to close these only after I have confirmation from the original reporters that the issues are actually fixed for them.
