### PR TITLE
Doc: `static mut` is unsafe too

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1036,6 +1036,7 @@ Unsafe operations are those that potentially violate the memory-safety guarantee
 The following language level features cannot be used in the safe subset of Rust:
 
   - Dereferencing a [raw pointer](#pointer-types).
+  - Reading or writing a [mutable static variable](#mutable-statics).
   - Calling an unsafe function (including an intrinsic or foreign function).
 
 ##### Unsafe functions


### PR DESCRIPTION
According to the corresponding section, accessing a mutable static variable requires `unsafe` too, and I believe it counts as as language level feature. Add it to the relevant list in the Unsafety section.
