### PR TITLE
rustc: Accept PartialOrd/PartialOrdEq for Eq/Ord

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -37,6 +37,9 @@
 //! assert!(SketchyNum {num: 25} != SketchyNum {num: 57});
 //! ```
 
+pub use PartialEq = cmp::Eq;
+pub use PartialOrd = cmp::Ord;
+
 /// Trait for values that can be compared for equality and inequality.
 ///
 /// This trait allows partial equality, where types can be unordered instead of

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -53,7 +53,7 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
-        path: Path::new(vec!("std", "cmp", "Eq")),
+        path: Path::new(vec!("std", "cmp", "PartialEq")),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -43,7 +43,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
-        path: Path::new(vec!("std", "cmp", "Ord")),
+        path: Path::new(vec!("std", "cmp", "PartialOrd")),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -77,9 +77,10 @@ pub fn expand_meta_deriving(cx: &mut ExtCtxt,
                             "Encodable" => expand!(encodable::expand_deriving_encodable),
                             "Decodable" => expand!(decodable::expand_deriving_decodable),
 
-                            "Eq" => expand!(eq::expand_deriving_eq),
+                            // NOTE this needs treatment after a stage0 snap
+                            "PartialEq" | "Eq" => expand!(eq::expand_deriving_eq),
                             "TotalEq" => expand!(totaleq::expand_deriving_totaleq),
-                            "Ord" => expand!(ord::expand_deriving_ord),
+                            "PartialOrd" | "Ord" => expand!(ord::expand_deriving_ord),
                             "TotalOrd" => expand!(totalord::expand_deriving_totalord),
 
                             "Rand" => expand!(rand::expand_deriving_rand),


### PR DESCRIPTION
This is a transitionary step towards completing #12517. This change modifies the
compiler to accept Partial{Ord,Eq} as deriving modes which will currently expand
to implementations of PartialOrd and PartialEq (synonyms for Eq/Ord).

After a snapshot, all of deriving(Eq, Ord) will be removed, and after a snapshot
of that, TotalEq/TotalOrd will be renamed to Eq/Ord.
