### PR TITLE
Remove some `pub use` glob usage

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -904,7 +904,7 @@ An example of re-exporting:
 ~~~~
 # fn main() { }
 mod quux {
-    pub use quux::foo::*;
+    pub use quux::foo::{bar, baz};
 
     pub mod foo {
         pub fn bar() { }
@@ -913,10 +913,10 @@ mod quux {
 }
 ~~~~
 
-In this example, the module `quux` re-exports all of the public names defined in `foo`.
+In this example, the module `quux` re-exports two public names defined in `foo`.
 
 Also note that the paths contained in `use` items are relative to the crate root.
-So, in the previous example, the `use` refers to `quux::foo::*`, and not simply to `foo::*`.
+So, in the previous example, the `use` refers to `quux::foo::{bar, baz}`, and not simply to `foo::{bar, baz}`.
 This also means that top-level module declarations should be at the crate root if direct usage
 of the declared modules within `use` items is desired.  It is also possible to use `self` and `super`
 at the beginning of a `use` item to refer to the current and direct parent modules respectively.

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -20,6 +20,7 @@
        html_root_url = "http://doc.rust-lang.org/")]
 
 #![feature(macro_registrar, managed_boxes, quote)]
+#![allow(unused_imports)] // `quote_expr!` adds some `use` globs which may be unused
 
 extern crate regex;
 extern crate syntax;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -9,16 +9,16 @@
 // except according to those terms.
 
 use abi;
-use ast::{P, Ident};
+use ast::{P, Ident, Generics, NodeId, Expr};
 use ast;
 use ast_util;
 use attr;
 use codemap::{Span, respan, Spanned, DUMMY_SP};
 use ext::base::ExtCtxt;
-use ext::quote::rt::*;
 use fold::Folder;
 use owned_slice::OwnedSlice;
 use parse::token::special_idents;
+use parse::token::InternedString;
 use parse::token;
 
 pub struct Field {

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -12,6 +12,7 @@ use ast::{MetaItem, MetaWord, Item};
 use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 
 pub fn expand_deriving_bound(cx: &mut ExtCtxt,
                              span: Span,

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -13,6 +13,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_clone(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -13,6 +13,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_eq(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -14,6 +14,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_ord(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -13,6 +13,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_totaleq(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -14,6 +14,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 use std::cmp::{Ordering, Equal, Less, Greater};

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -19,6 +19,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use parse::token;
 

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -13,6 +13,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_default(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -88,6 +88,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token;
 
 pub fn expand_deriving_encodable(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -191,8 +191,9 @@ use codemap::Span;
 use owned_slice::OwnedSlice;
 use parse::token::InternedString;
 
-pub use self::ty::*;
-mod ty;
+use self::ty::*;
+
+pub mod ty;
 
 pub struct TraitDef<'a> {
     /// The span for the current #[deriving(Foo)] header.

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -14,6 +14,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_hash(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -14,6 +14,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -14,6 +14,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::{AstBuilder};
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 
 pub fn expand_deriving_rand(cx: &mut ExtCtxt,
                             span: Span,

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -15,6 +15,7 @@ use ext::format;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token;
 
 use collections::HashMap;

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -13,6 +13,7 @@ use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::build::AstBuilder;
 use ext::deriving::generic::*;
+use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 
 pub fn expand_deriving_zero(cx: &mut ExtCtxt,

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -36,8 +36,17 @@ pub mod rt {
     use parse;
     use print::pprust;
 
-    pub use ast::*;
-    pub use parse::token::*;
+    #[cfg(not(stage0))]
+    use ast::{TokenTree, Generics, Expr};
+
+    // NOTE remove this after snapshot
+    // (stage0 quasiquoter needs this)
+    #[cfg(stage0)]
+    pub use ast::{Generics, TokenTree, TTTok};
+    #[cfg(stage0)]
+    pub use parse::token::{IDENT, SEMI, LBRACE, RBRACE, LIFETIME, COLON, AND, BINOP, EQ,
+                           LBRACKET, RBRACKET, LPAREN, RPAREN, POUND, NOT, MOD_SEP, DOT, COMMA};
+
     pub use parse::new_parser_from_tts;
     pub use codemap::{BytePos, Span, dummy_spanned};
 
@@ -72,7 +81,7 @@ pub mod rt {
 
     impl ToSource for ast::Ident {
         fn to_source(&self) -> String {
-            get_ident(*self).get().to_string()
+            token::get_ident(*self).get().to_string()
         }
     }
 
@@ -685,11 +694,14 @@ fn expand_wrapper(cx: &ExtCtxt,
                   sp: Span,
                   cx_expr: @ast::Expr,
                   expr: @ast::Expr) -> @ast::Expr {
-    let uses = vec![ cx.view_use_glob(sp, ast::Inherited,
-                                   ids_ext(vec!["syntax".to_string(),
-                                                "ext".to_string(),
-                                                "quote".to_string(),
-                                                "rt".to_string()])) ];
+    let uses = [
+        &["syntax", "ast"],
+        &["syntax", "parse", "token"],
+        &["syntax", "ext", "quote", "rt"],
+    ].iter().map(|path| {
+        let path = path.iter().map(|s| s.to_string()).collect();
+        cx.view_use_glob(sp, ast::Inherited, ids_ext(path))
+    }).collect();
 
     let stmt_let_ext_cx = cx.stmt_let(sp, false, id_ext("ext_cx"), cx_expr);
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -48,6 +48,7 @@ pub mod util {
 pub mod syntax {
     pub use ext;
     pub use parse;
+    pub use ast;
 }
 
 pub mod owned_slice;


### PR DESCRIPTION
This patchset removes `pub use` usage except for `test/`.
cc #11870
