### PR TITLE
rustdoc: Create anchor pages for primitive types

### DIFF
--- a/src/doc/complement-cheatsheet.md
+++ b/src/doc/complement-cheatsheet.md
@@ -4,7 +4,7 @@
 
 **Int to string**
 
-Use [`ToStr`](../std/to_str/trait.ToStr.html).
+Use [`ToStr`](std/to_str/trait.ToStr.html).
 
 ~~~
 let x: int = 42;
@@ -13,8 +13,8 @@ let y: String = x.to_str().to_string();
 
 **String to int**
 
-Use [`FromStr`](../std/from_str/trait.FromStr.html), and its helper function,
-[`from_str`](../std/from_str/fn.from_str.html).
+Use [`FromStr`](std/from_str/trait.FromStr.html), and its helper function,
+[`from_str`](std/from_str/fn.from_str.html).
 
 ~~~
 let x: Option<int> = from_str("42");
@@ -35,8 +35,8 @@ let y: String = format!("{:X}", x);   // uppercase hexadecimal
 
 **String to int, in non-base-10**
 
-Use [`FromStrRadix`](../std/num/trait.FromStrRadix.html), and its helper
-function, [`from_str_radix`](../std/num/fn.from_str_radix.html).
+Use [`FromStrRadix`](std/num/trait.FromStrRadix.html), and its helper
+function, [`from_str_radix`](std/num/fn.from_str_radix.html).
 
 ~~~
 use std::num;
@@ -48,7 +48,7 @@ let y: i64 = x.unwrap();
 **Vector of Bytes to String**
 
 To return a Borrowed String Slice (&str) use the str helper function
-[`from_utf8`](../std/str/fn.from_utf8.html).
+[`from_utf8`](std/str/fn.from_utf8.html).
 
 ~~~
 use std::str;
@@ -58,7 +58,7 @@ let x: &str = str::from_utf8(bytes).unwrap();
 ~~~
 
 To return an Owned String use the str helper function
-[`from_utf8_owned`](../std/str/fn.from_utf8_owned.html).
+[`from_utf8_owned`](std/str/fn.from_utf8_owned.html).
 
 ~~~
 use std::str;
@@ -68,8 +68,8 @@ let x: Option<String> =
 let y: String = x.unwrap();
 ~~~
 
-To return a [`MaybeOwned`](../std/str/enum.MaybeOwned.html) use the str helper
-function [`from_utf8_lossy`](../std/str/fn.from_utf8_owned.html).
+To return a [`MaybeOwned`](std/str/type.MaybeOwned.html) use the str helper
+function [`from_utf8_lossy`](std/str/fn.from_utf8_owned.html).
 This function also replaces non-valid utf-8 sequences with U+FFFD replacement
 character.
 
@@ -85,11 +85,11 @@ let y = str::from_utf8_lossy(x);
 ## How do I read from a file?
 
 Use
-[`File::open`](../std/io/fs/struct.File.html#method.open)
+[`File::open`](std/io/fs/struct.File.html#method.open)
 to create a
-[`File`](../std/io/fs/struct.File.html)
+[`File`](std/io/fs/struct.File.html)
 struct, which implements the
-[`Reader`](../std/io/trait.Reader.html)
+[`Reader`](std/io/trait.Reader.html)
 trait.
 
 ~~~ {.ignore}
@@ -103,7 +103,8 @@ let reader : File = File::open(&path).unwrap_or_else(on_error);
 
 ## How do I iterate over the lines in a file?
 
-Use the [`lines`](../std/io/trait.Buffer.html#method.lines) method on a [`BufferedReader`](../std/io/buffered/struct.BufferedReader.html).
+Use the [`lines`](std/io/trait.Buffer.html#method.lines) method on a
+[`BufferedReader`](std/io/struct.BufferedReader.html).
 
 ~~~
 use std::io::BufferedReader;
@@ -121,7 +122,7 @@ for line in reader.lines() {
 
 ## How do I search for a substring?
 
-Use the [`find_str`](../std/str/trait.StrSlice.html#tymethod.find_str) method.
+Use the [`find_str`](std/str/trait.StrSlice.html#tymethod.find_str) method.
 
 ~~~
 let str = "Hello, this is some random string";
@@ -132,7 +133,7 @@ let index: Option<uint> = str.find_str("rand");
 
 ## How do I get the length of a vector?
 
-The [`Container`](../std/container/trait.Container.html) trait provides the `len` method.
+The [`Container`](std/container/trait.Container.html) trait provides the `len` method.
 
 ~~~
 let u: Vec<u32> = vec![0, 1, 2];
@@ -144,7 +145,7 @@ println!("u: {}, v: {}, w: {}", u.len(), v.len(), w.len()); // 3, 4, 5
 
 ## How do I iterate over a vector?
 
-Use the [`iter`](../std/vec/trait.ImmutableVector.html#tymethod.iter) method.
+Use the [`iter`](std/slice/trait.ImmutableVector.html#tymethod.iter) method.
 
 ~~~
 let values: Vec<int> = vec![1, 2, 3, 4, 5];
@@ -153,9 +154,9 @@ for value in values.iter() {  // value: &int
 }
 ~~~
 
-(See also [`mut_iter`](../std/vec/trait.MutableVector.html#tymethod.mut_iter)
+(See also [`mut_iter`](std/slice/trait.MutableVector.html#tymethod.mut_iter)
 which yields `&mut int` and
-[`move_iter`](../std/vec/trait.OwnedVector.html#tymethod.move_iter) which yields
+[`move_iter`](std/slice/trait.OwnedVector.html#tymethod.move_iter) which yields
 `int` while consuming the `values` vector.)
 
 # Type system

--- a/src/doc/complement-lang-faq.md
+++ b/src/doc/complement-lang-faq.md
@@ -21,7 +21,7 @@ Some examples that demonstrate different aspects of the language:
 * The extra library's [json] module. Enums and pattern matching
 
 [sprocketnes]: https://github.com/pcwalton/sprocketnes
-[hash]: https://github.com/mozilla/rust/blob/master/src/libstd/hash.rs
+[hash]: https://github.com/mozilla/rust/blob/master/src/libstd/hash/mod.rs
 [HashMap]: https://github.com/mozilla/rust/blob/master/src/libcollections/hashmap.rs
 [json]: https://github.com/mozilla/rust/blob/master/src/libserialize/json.rs
 
@@ -149,6 +149,6 @@ example we were setting RUST_LOG to the name of the hello crate. Multiple paths
 can be combined to control the exact logging you want to see. For example, when
 debugging linking in the compiler you might set
 `RUST_LOG=rustc::metadata::creader,rustc::util::filesearch,rustc::back::rpath`
-For a full description see [the language reference][1].
+For a full description see [the logging crate][1].
 
-[1]:http://doc.rust-lang.org/doc/master/rust.html#logging-system
+[1]:log/index.html

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -499,9 +499,9 @@ shouldn't get triggered.
 
 The second of these two functions, `eh_personality`, is used by the failure
 mechanisms of the compiler. This is often mapped to GCC's personality function
-(see the [libstd implementation](../std/rt/unwind/) for more information), but
-crates which do not trigger failure can be assured that this function is never
-called.
+(see the [libstd implementation](std/rt/unwind/index.html) for more
+information), but crates which do not trigger failure can be assured that this
+function is never called.
 
 ## Using libcore
 
@@ -511,7 +511,8 @@ called.
 With the above techniques, we've got a bare-metal executable running some Rust
 code. There is a good deal of functionality provided by the standard library,
 however, that is necessary to be productive in Rust. If the standard library is
-not sufficient, then [libcore](../core/) is designed to be used instead.
+not sufficient, then [libcore](../core/index.html) is designed to be used
+instead.
 
 The core library has very few dependencies and is much more portable than the
 standard library itself. Additionally, the core library has most of the

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -511,7 +511,7 @@ function is never called.
 With the above techniques, we've got a bare-metal executable running some Rust
 code. There is a good deal of functionality provided by the standard library,
 however, that is necessary to be productive in Rust. If the standard library is
-not sufficient, then [libcore](../core/index.html) is designed to be used
+not sufficient, then [libcore](core/index.html) is designed to be used
 instead.
 
 The core library has very few dependencies and is much more portable than the

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -97,6 +97,7 @@ pub mod arc;
 pub mod rc;
 
 #[cfg(not(test))]
+#[doc(hidden)]
 mod std {
     pub use core::fmt;
     pub use core::option;

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -12,6 +12,8 @@
 //!
 //! A `to_bit` conversion function.
 
+#![doc(primitive = "bool")]
+
 use num::{Int, one, zero};
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -24,6 +24,7 @@
 //! and, as such, should be performed via the `from_u32` function..
 
 #![allow(non_snake_case_functions)]
+#![doc(primitive = "char")]
 
 use mem::transmute;
 use option::{None, Option, Some};

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -134,10 +134,12 @@ pub mod fmt;
 //        crate.
 mod should_not_exist;
 
+#[doc(hidden)]
 mod core {
     pub use failure;
 }
 
+#[doc(hidden)]
 mod std {
     pub use clone;
     pub use cmp;

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for 32-bits floats (`f32` type)
 
+#![doc(primitive = "f32")]
+
 use intrinsics;
 use mem;
 use num::{FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for 64-bits floats (`f64` type)
 
+#![doc(primitive = "f64")]
+
 use intrinsics;
 use mem;
 use num::{FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
+#![doc(primitive = "i16")]
+
 int_module!(i16, 16)
 

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for signed 32-bits integers (`i32` type)
 
+#![doc(primitive = "i32")]
+
 int_module!(i32, 32)
 

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for signed 64-bits integers (`i64` type)
 
+#![doc(primitive = "i64")]
+
 int_module!(i64, 64)
 

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for signed 8-bits integers (`i8` type)
 
+#![doc(primitive = "i8")]
+
 int_module!(i8, 8)
 

--- a/src/libcore/num/int.rs
+++ b/src/libcore/num/int.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for architecture-sized signed integers (`int` type)
 
+#![doc(primitive = "int")]
+
 #[cfg(target_word_size = "32")] int_module!(int, 32)
 #[cfg(target_word_size = "64")] int_module!(int, 64)
 

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -10,4 +10,6 @@
 
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
+#![doc(primitive = "u16")]
+
 uint_module!(u16, i16, 16)

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
+#![doc(primitive = "u32")]
+
 uint_module!(u32, i32, 32)
 

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
+#![doc(primitive = "u64")]
+
 uint_module!(u64, i64, 64)
 

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
+#![doc(primitive = "u8")]
+
 uint_module!(u8, i8, 8)
 

--- a/src/libcore/num/uint.rs
+++ b/src/libcore/num/uint.rs
@@ -10,5 +10,7 @@
 
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
+#![doc(primitive = "uint")]
+
 uint_module!(uint, int, ::int::BITS)
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -234,8 +234,8 @@
 //! similar and complementary: they are often employed to indicate a
 //! lack of a return value; and they are trivially converted between
 //! each other, so `Result`s are often handled by first converting to
-//! `Option` with the [`ok`](enum.Result.html#method.ok) and
-//! [`err`](enum.Result.html#method.ok) methods.
+//! `Option` with the [`ok`](type.Result.html#method.ok) and
+//! [`err`](type.Result.html#method.ok) methods.
 //!
 //! Whereas `Option` only indicates the lack of a value, `Result` is
 //! specifically for error reporting, and carries with it an error

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -12,6 +12,8 @@
 //!
 //! For more details `std::slice`.
 
+#![doc(primitive = "slice")]
+
 use mem::transmute;
 use clone::Clone;
 use container::Container;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -12,6 +12,8 @@
 //!
 //! For more details, see std::str
 
+#![doc(primitive = "str")]
+
 use mem;
 use char;
 use clone::Clone;

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -59,6 +59,8 @@
 //! assert_eq!(d, (0u32, 0.0f32));
 //! ```
 
+#![doc(primitive = "tuple")]
+
 use clone::Clone;
 #[cfg(not(test))] use cmp::*;
 #[cfg(not(test))] use default::Default;

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -67,12 +67,12 @@ fn try_inline_def(cx: &core::DocContext,
         }
         ast::DefStruct(did) => {
             record_extern_fqn(cx, did, clean::TypeStruct);
-            ret.extend(build_impls(tcx, did).move_iter());
+            ret.extend(build_impls(cx, tcx, did).move_iter());
             clean::StructItem(build_struct(tcx, did))
         }
         ast::DefTy(did) => {
             record_extern_fqn(cx, did, clean::TypeEnum);
-            ret.extend(build_impls(tcx, did).move_iter());
+            ret.extend(build_impls(cx, tcx, did).move_iter());
             build_type(tcx, did)
         }
         // Assume that the enum type is reexported next to the variant, and
@@ -193,7 +193,8 @@ fn build_type(tcx: &ty::ctxt, did: ast::DefId) -> clean::ItemEnum {
     })
 }
 
-fn build_impls(tcx: &ty::ctxt,
+fn build_impls(cx: &core::DocContext,
+               tcx: &ty::ctxt,
                did: ast::DefId) -> Vec<clean::Item> {
     ty::populate_implementations_for_type_if_necessary(tcx, did);
     let mut impls = Vec::new();
@@ -202,6 +203,38 @@ fn build_impls(tcx: &ty::ctxt,
         None => {}
         Some(i) => {
             impls.extend(i.borrow().iter().map(|&did| { build_impl(tcx, did) }));
+        }
+    }
+
+    // If this is the first time we've inlined something from this crate, then
+    // we inline *all* impls from the crate into this crate. Note that there's
+    // currently no way for us to filter this based on type, and we likely need
+    // many impls for a variety of reasons.
+    //
+    // Primarily, the impls will be used to populate the documentation for this
+    // type being inlined, but impls can also be used when generating
+    // documentation for primitives (no way to find those specifically).
+    if cx.populated_crate_impls.borrow_mut().insert(did.krate) {
+        csearch::each_top_level_item_of_crate(&tcx.sess.cstore,
+                                              did.krate,
+                                              |def, _, _| {
+            populate_impls(tcx, def, &mut impls)
+        });
+
+        fn populate_impls(tcx: &ty::ctxt,
+                          def: decoder::DefLike,
+                          impls: &mut Vec<clean::Item>) {
+            match def {
+                decoder::DlImpl(did) => impls.push(build_impl(tcx, did)),
+                decoder::DlDef(ast::DefMod(did)) => {
+                    csearch::each_child_of_item(&tcx.sess.cstore,
+                                                did,
+                                                |def, _, _| {
+                        populate_impls(tcx, def, impls)
+                    })
+                }
+                _ => {}
+            }
         }
     }
 
@@ -268,7 +301,8 @@ fn build_module(cx: &core::DocContext, tcx: &ty::ctxt,
                     None => {}
                 }
             }
-            decoder::DlImpl(did) => items.push(build_impl(tcx, did)),
+            // All impls were inlined above
+            decoder::DlImpl(..) => {}
             decoder::DlField => fail!("unimplemented field"),
         }
     });

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -259,7 +259,8 @@ fn build_module(cx: &core::DocContext, tcx: &ty::ctxt,
 
     // FIXME: this doesn't handle reexports inside the module itself.
     //        Should they be handled?
-    csearch::each_child_of_item(&tcx.sess.cstore, did, |def, _, _| {
+    csearch::each_child_of_item(&tcx.sess.cstore, did, |def, _, vis| {
+        if vis != ast::Public { return }
         match def {
             decoder::DlDef(def) => {
                 match try_inline_def(cx, tcx, def) {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -62,6 +62,11 @@ fn try_inline_def(cx: &core::DocContext,
             clean::TraitItem(build_external_trait(tcx, did))
         }
         ast::DefFn(did, style) => {
+            // If this function is a tuple struct constructor, we just skip it
+            if csearch::get_tuple_struct_definition_if_ctor(&tcx.sess.cstore,
+                                                            did).is_some() {
+                return None
+            }
             record_extern_fqn(cx, did, clean::TypeFunction);
             clean::FunctionItem(build_external_function(tcx, did, style))
         }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1028,7 +1028,7 @@ pub enum Type {
     // region, raw, other boxes, mutable
 }
 
-#[deriving(Clone, Encodable, Decodable, Eq, TotalEq, Hash)]
+#[deriving(Clone, Encodable, Decodable, PartialEq, TotalEq, Hash)]
 pub enum Primitive {
     Int, I8, I16, I32, I64,
     Uint, U8, U16, U32, U64,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -519,9 +519,9 @@ impl Clean<Option<Lifetime>> for ty::Region {
             ty::ReStatic => Some(Lifetime("static".to_string())),
             ty::ReLateBound(_, ty::BrNamed(_, name)) =>
                 Some(Lifetime(token::get_name(name).get().to_string())),
+            ty::ReEarlyBound(_, _, name) => Some(Lifetime(name.clean())),
 
             ty::ReLateBound(..) |
-            ty::ReEarlyBound(..) |
             ty::ReFree(..) |
             ty::ReScope(..) |
             ty::ReInfer(..) |

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -42,6 +42,7 @@ pub struct DocContext {
     pub external_traits: RefCell<Option<HashMap<ast::DefId, clean::Trait>>>,
     pub external_typarams: RefCell<Option<HashMap<ast::DefId, String>>>,
     pub inlined: RefCell<Option<HashSet<ast::DefId>>>,
+    pub populated_crate_impls: RefCell<HashSet<ast::CrateNum>>,
 }
 
 impl DocContext {
@@ -114,6 +115,7 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>)
         external_typarams: RefCell::new(Some(HashMap::new())),
         external_paths: RefCell::new(Some(HashMap::new())),
         inlined: RefCell::new(Some(HashSet::new())),
+        populated_crate_impls: RefCell::new(HashSet::new()),
     }, CrateAnalysis {
         exported_items: exported_items,
         public_items: public_items,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -424,14 +424,8 @@ impl fmt::Show for clean::Type {
                        decl.decl)
             }
             clean::Tuple(ref typs) => {
-                try!(f.write("(".as_bytes()));
-                for (i, typ) in typs.iter().enumerate() {
-                    if i > 0 {
-                        try!(f.write(", ".as_bytes()))
-                    }
-                    try!(write!(f, "{}", *typ));
-                }
-                f.write(")".as_bytes())
+                primitive_link(f, clean::PrimitiveTuple,
+                               format!("({:#})", typs).as_slice())
             }
             clean::Vector(ref t) => {
                 primitive_link(f, clean::Slice, format!("[{}]", **t).as_slice())

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -263,6 +263,47 @@ fn path(w: &mut fmt::Formatter, path: &clean::Path, print_all: bool,
     Ok(())
 }
 
+fn primitive_link(f: &mut fmt::Formatter,
+                  prim: clean::Primitive,
+                  name: &str) -> fmt::Result {
+    let m = cache_key.get().unwrap();
+    let mut needs_termination = false;
+    match m.primitive_locations.find(&prim) {
+        Some(&ast::LOCAL_CRATE) => {
+            let loc = current_location_key.get().unwrap();
+            let len = if loc.len() == 0 {0} else {loc.len() - 1};
+            try!(write!(f, "<a href='{}primitive.{}.html'>",
+                        "../".repeat(len),
+                        prim.to_url_str()));
+            needs_termination = true;
+        }
+        Some(&cnum) => {
+            let loc = match *m.extern_locations.get(&cnum) {
+                render::Remote(ref s) => Some(s.to_string()),
+                render::Local => {
+                    let loc = current_location_key.get().unwrap();
+                    Some(("../".repeat(loc.len())).to_string())
+                }
+                render::Unknown => None,
+            };
+            match loc {
+                Some(s) => {
+                    try!(write!(f, "<a href='{}/primitive.{}.html'>",
+                                s, prim.to_url_str()));
+                    needs_termination = true;
+                }
+                None => {}
+            }
+        }
+        None => {}
+    }
+    try!(write!(f, "{}", name));
+    if needs_termination {
+        try!(write!(f, "</a>"));
+    }
+    Ok(())
+}
+
 /// Helper to render type parameters
 fn tybounds(w: &mut fmt::Formatter,
             typarams: &Option<Vec<clean::TyParamBound> >) -> fmt::Result {
@@ -297,27 +338,7 @@ impl fmt::Show for clean::Type {
                 tybounds(f, typarams)
             }
             clean::Self(..) => f.write("Self".as_bytes()),
-            clean::Primitive(prim) => {
-                let s = match prim {
-                    ast::TyInt(ast::TyI) => "int",
-                    ast::TyInt(ast::TyI8) => "i8",
-                    ast::TyInt(ast::TyI16) => "i16",
-                    ast::TyInt(ast::TyI32) => "i32",
-                    ast::TyInt(ast::TyI64) => "i64",
-                    ast::TyUint(ast::TyU) => "uint",
-                    ast::TyUint(ast::TyU8) => "u8",
-                    ast::TyUint(ast::TyU16) => "u16",
-                    ast::TyUint(ast::TyU32) => "u32",
-                    ast::TyUint(ast::TyU64) => "u64",
-                    ast::TyFloat(ast::TyF32) => "f32",
-                    ast::TyFloat(ast::TyF64) => "f64",
-                    ast::TyFloat(ast::TyF128) => "f128",
-                    ast::TyStr => "str",
-                    ast::TyBool => "bool",
-                    ast::TyChar => "char",
-                };
-                f.write(s.as_bytes())
-            }
+            clean::Primitive(prim) => primitive_link(f, prim, prim.to_str()),
             clean::Closure(ref decl, ref region) => {
                 write!(f, "{style}{lifetimes}|{args}|{bounds}\
                            {arrow, select, yes{ -&gt; {ret}} other{}}",
@@ -329,7 +350,7 @@ impl fmt::Show for clean::Type {
                        },
                        args = decl.decl.inputs,
                        arrow = match decl.decl.output {
-                           clean::Unit => "no",
+                           clean::Primitive(clean::Nil) => "no",
                            _ => "yes",
                        },
                        ret = decl.decl.output,
@@ -379,7 +400,10 @@ impl fmt::Show for clean::Type {
                                ": {}",
                                m.collect::<Vec<String>>().connect(" + "))
                        },
-                       arrow = match decl.decl.output { clean::Unit => "no", _ => "yes" },
+                       arrow = match decl.decl.output {
+                           clean::Primitive(clean::Nil) => "no",
+                           _ => "yes",
+                       },
                        ret = decl.decl.output)
             }
             clean::BareFunction(ref decl) => {
@@ -403,13 +427,13 @@ impl fmt::Show for clean::Type {
                 }
                 f.write(")".as_bytes())
             }
-            clean::Vector(ref t) => write!(f, "[{}]", **t),
-            clean::FixedVector(ref t, ref s) => {
-                write!(f, "[{}, ..{}]", **t, *s)
+            clean::Vector(ref t) => {
+                primitive_link(f, clean::Slice, format!("[{}]", **t).as_slice())
             }
-            clean::String => f.write("str".as_bytes()),
-            clean::Bool => f.write("bool".as_bytes()),
-            clean::Unit => f.write("()".as_bytes()),
+            clean::FixedVector(ref t, ref s) => {
+                primitive_link(f, clean::Slice,
+                               format!("[{}, ..{}]", **t, *s).as_slice())
+            }
             clean::Bottom => f.write("!".as_bytes()),
             clean::Unique(ref t) => write!(f, "~{}", **t),
             clean::Managed(ref t) => write!(f, "@{}", **t),
@@ -454,7 +478,10 @@ impl fmt::Show for clean::FnDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({args}){arrow, select, yes{ -&gt; {ret}} other{}}",
                args = self.inputs,
-               arrow = match self.output { clean::Unit => "no", _ => "yes" },
+               arrow = match self.output {
+                   clean::Primitive(clean::Nil) => "no",
+                   _ => "yes"
+               },
                ret = self.output)
     }
 }
@@ -490,7 +517,10 @@ impl<'a> fmt::Show for Method<'a> {
         write!(f,
                "({args}){arrow, select, yes{ -&gt; {ret}} other{}}",
                args = args,
-               arrow = match d.output { clean::Unit => "no", _ => "yes" },
+               arrow = match d.output {
+                   clean::Primitive(clean::Nil) => "no",
+                   _ => "yes"
+               },
                ret = d.output)
     }
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -278,18 +278,24 @@ fn primitive_link(f: &mut fmt::Formatter,
             needs_termination = true;
         }
         Some(&cnum) => {
+            let path = m.paths.get(&ast::DefId {
+                krate: cnum,
+                node: ast::CRATE_NODE_ID,
+            });
             let loc = match *m.extern_locations.get(&cnum) {
                 render::Remote(ref s) => Some(s.to_string()),
                 render::Local => {
                     let loc = current_location_key.get().unwrap();
-                    Some(("../".repeat(loc.len())).to_string())
+                    Some("../".repeat(loc.len()))
                 }
                 render::Unknown => None,
             };
             match loc {
-                Some(s) => {
-                    try!(write!(f, "<a href='{}/primitive.{}.html'>",
-                                s, prim.to_url_str()));
+                Some(root) => {
+                    try!(write!(f, "<a href='{}{}/primitive.{}.html'>",
+                                root,
+                                path.ref0().as_slice().head().unwrap(),
+                                prim.to_url_str()));
                     needs_termination = true;
                 }
                 None => {}

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -37,6 +37,7 @@ pub enum ItemType {
     ForeignFunction = 13,
     ForeignStatic   = 14,
     Macro           = 15,
+    Primitive       = 16,
 }
 
 impl ItemType {
@@ -58,6 +59,7 @@ impl ItemType {
             ForeignFunction => "ffi",
             ForeignStatic   => "ffs",
             Macro           => "macro",
+            Primitive       => "primitive",
         }
     }
 }
@@ -92,6 +94,7 @@ pub fn shortty(item: &clean::Item) -> ItemType {
         clean::ForeignFunctionItem(..) => ForeignFunction,
         clean::ForeignStaticItem(..)   => ForeignStatic,
         clean::MacroItem(..)           => Macro,
+        clean::PrimitiveItem(..)       => Primitive,
     }
 }
 

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -130,3 +130,17 @@ r##"<!DOCTYPE html>
 fn nonestr<'a>(s: &'a str) -> &'a str {
     if s == "" { "none" } else { s }
 }
+
+pub fn redirect(dst: &mut io::Writer, url: &str) -> io::IoResult<()> {
+    write!(dst,
+r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0;URL={url}">
+</head>
+<body>
+</body>
+</html>"##,
+    url = url,
+    )
+}

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1380,8 +1380,13 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                         if s.len() == 0 { return Ok(()); }
                         try!(write!(f, "<code> = </code>"));
                         if s.contains("\n") {
-                            write!(f, "<a href='{}'>[definition]</a>",
-                                   item.href())
+                            match item.href() {
+                                Some(url) => {
+                                    write!(f, "<a href='{}'>[definition]</a>",
+                                           url)
+                                }
+                                None => Ok(()),
+                            }
                         } else {
                             write!(f, "<code>{}</code>", s.as_slice())
                         }
@@ -1547,8 +1552,8 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     }
     try!(write!(w, "</ul>"));
     try!(write!(w, r#"<script type="text/javascript" async
-                              src="{root_path}/implementors/{path}/\
-                                   {ty}.{name}.js"></script>"#,
+                              src="{root_path}/implementors/{path}/{ty}.{name}.js">
+                      </script>"#,
                 root_path = Vec::from_elem(cx.current.len(), "..").connect("/"),
                 path = if ast_util::is_local(it.def_id) {
                     cx.current.connect("/")

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -229,6 +229,8 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
     };
     try!(mkdir(&cx.dst));
 
+    // Crawl the crate attributes looking for attributes which control how we're
+    // going to emit HTML
     match krate.module.as_ref().map(|m| m.doc_list().unwrap_or(&[])) {
         Some(attrs) => {
             for attr in attrs.iter() {
@@ -297,19 +299,37 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
     cache.stack.push(krate.name.clone());
     krate = cache.fold_crate(krate);
 
+
+    for &(n, ref e) in krate.externs.iter() {
+        cache.extern_locations.insert(n, extern_location(e, &cx.dst));
+        let did = ast::DefId { krate: n, node: ast::CRATE_NODE_ID };
+        cache.paths.insert(did, (vec![e.name.to_string()], item_type::Module));
+    }
+
+    let index = try!(build_index(&krate, &mut cache));
+    try!(write_shared(&cx, &krate, &cache, index));
+    let krate = try!(render_sources(&mut cx, krate));
+
+    // And finally render the whole crate's documentation
+    cx.krate(krate, cache)
+}
+
+fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> {
+    // Build the search index from the collected metadata
     let mut nodeid_to_pathid = HashMap::new();
     let mut pathid_to_nodeid = Vec::new();
     {
-        let Cache { search_index: ref mut index,
-                    orphan_methods: ref meths, paths: ref mut paths, ..} = cache;
+        let Cache { ref mut search_index,
+                    ref orphan_methods,
+                    ref mut paths, .. } = *cache;
 
         // Attach all orphan methods to the type's definition if the type
         // has since been learned.
-        for &(pid, ref item) in meths.iter() {
+        for &(pid, ref item) in orphan_methods.iter() {
             let did = ast_util::local_def(pid);
             match paths.find(&did) {
                 Some(&(ref fqp, _)) => {
-                    index.push(IndexItem {
+                    search_index.push(IndexItem {
                         ty: shortty(item),
                         name: item.name.clone().unwrap(),
                         path: fqp.slice_to(fqp.len() - 1).connect("::")
@@ -324,7 +344,7 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
 
         // Reduce `NodeId` in paths into smaller sequential numbers,
         // and prune the paths that do not appear in the index.
-        for item in index.iter() {
+        for item in search_index.iter() {
             match item.parent {
                 Some(nodeid) => {
                     if !nodeid_to_pathid.contains_key(&nodeid) {
@@ -339,189 +359,182 @@ pub fn run(mut krate: clean::Crate, dst: Path) -> io::IoResult<()> {
         assert_eq!(nodeid_to_pathid.len(), pathid_to_nodeid.len());
     }
 
-    // Publish the search index
-    let index = {
-        let mut w = MemWriter::new();
-        try!(write!(&mut w, r#"searchIndex['{}'] = \{"items":["#, krate.name));
+    // Collect the index into a string
+    let mut w = MemWriter::new();
+    try!(write!(&mut w, r#"searchIndex['{}'] = \{"items":["#, krate.name));
 
-        let mut lastpath = "".to_string();
-        for (i, item) in cache.search_index.iter().enumerate() {
-            // Omit the path if it is same to that of the prior item.
-            let path;
-            if lastpath.as_slice() == item.path.as_slice() {
-                path = "";
-            } else {
-                lastpath = item.path.to_string();
-                path = item.path.as_slice();
-            };
+    let mut lastpath = "".to_string();
+    for (i, item) in cache.search_index.iter().enumerate() {
+        // Omit the path if it is same to that of the prior item.
+        let path;
+        if lastpath.as_slice() == item.path.as_slice() {
+            path = "";
+        } else {
+            lastpath = item.path.to_string();
+            path = item.path.as_slice();
+        };
 
-            if i > 0 {
-                try!(write!(&mut w, ","));
-            }
-            try!(write!(&mut w, r#"[{:u},"{}","{}",{}"#,
-                        item.ty, item.name, path,
-                        item.desc.to_json().to_str()));
-            match item.parent {
-                Some(nodeid) => {
-                    let pathid = *nodeid_to_pathid.find(&nodeid).unwrap();
-                    try!(write!(&mut w, ",{}", pathid));
-                }
-                None => {}
-            }
-            try!(write!(&mut w, "]"));
+        if i > 0 {
+            try!(write!(&mut w, ","));
         }
-
-        try!(write!(&mut w, r#"],"paths":["#));
-
-        for (i, &did) in pathid_to_nodeid.iter().enumerate() {
-            let &(ref fqp, short) = cache.paths.find(&did).unwrap();
-            if i > 0 {
-                try!(write!(&mut w, ","));
+        try!(write!(&mut w, r#"[{:u},"{}","{}",{}"#,
+                    item.ty, item.name, path,
+                    item.desc.to_json().to_str()));
+        match item.parent {
+            Some(nodeid) => {
+                let pathid = *nodeid_to_pathid.find(&nodeid).unwrap();
+                try!(write!(&mut w, ",{}", pathid));
             }
-            try!(write!(&mut w, r#"[{:u},"{}"]"#,
-                        short, *fqp.last().unwrap()));
+            None => {}
         }
+        try!(write!(&mut w, "]"));
+    }
 
-        try!(write!(&mut w, r"]\};"));
+    try!(write!(&mut w, r#"],"paths":["#));
 
-        str::from_utf8(w.unwrap().as_slice()).unwrap().to_string()
-    };
+    for (i, &did) in pathid_to_nodeid.iter().enumerate() {
+        let &(ref fqp, short) = cache.paths.find(&did).unwrap();
+        if i > 0 {
+            try!(write!(&mut w, ","));
+        }
+        try!(write!(&mut w, r#"[{:u},"{}"]"#,
+                    short, *fqp.last().unwrap()));
+    }
 
+    try!(write!(&mut w, r"]\};"));
+
+    Ok(str::from_utf8(w.unwrap().as_slice()).unwrap().to_string())
+}
+
+fn write_shared(cx: &Context,
+                krate: &clean::Crate,
+                cache: &Cache,
+                search_index: String) -> io::IoResult<()> {
     // Write out the shared files. Note that these are shared among all rustdoc
     // docs placed in the output directory, so this needs to be a synchronized
     // operation with respect to all other rustdocs running around.
-    {
-        try!(mkdir(&cx.dst));
-        let _lock = ::flock::Lock::new(&cx.dst.join(".lock"));
+    try!(mkdir(&cx.dst));
+    let _lock = ::flock::Lock::new(&cx.dst.join(".lock"));
 
-        // Add all the static files. These may already exist, but we just
-        // overwrite them anyway to make sure that they're fresh and up-to-date.
-        try!(write(cx.dst.join("jquery.js"),
-                   include_bin!("static/jquery-2.1.0.min.js")));
-        try!(write(cx.dst.join("main.js"), include_bin!("static/main.js")));
-        try!(write(cx.dst.join("main.css"), include_bin!("static/main.css")));
-        try!(write(cx.dst.join("normalize.css"),
-                   include_bin!("static/normalize.css")));
-        try!(write(cx.dst.join("FiraSans-Regular.woff"),
-                   include_bin!("static/FiraSans-Regular.woff")));
-        try!(write(cx.dst.join("FiraSans-Medium.woff"),
-                   include_bin!("static/FiraSans-Medium.woff")));
-        try!(write(cx.dst.join("Heuristica-Regular.woff"),
-                   include_bin!("static/Heuristica-Regular.woff")));
-        try!(write(cx.dst.join("Heuristica-Italic.woff"),
-                   include_bin!("static/Heuristica-Italic.woff")));
-        try!(write(cx.dst.join("Heuristica-Bold.woff"),
-                   include_bin!("static/Heuristica-Bold.woff")));
+    // Add all the static files. These may already exist, but we just
+    // overwrite them anyway to make sure that they're fresh and up-to-date.
+    try!(write(cx.dst.join("jquery.js"),
+               include_bin!("static/jquery-2.1.0.min.js")));
+    try!(write(cx.dst.join("main.js"), include_bin!("static/main.js")));
+    try!(write(cx.dst.join("main.css"), include_bin!("static/main.css")));
+    try!(write(cx.dst.join("normalize.css"),
+               include_bin!("static/normalize.css")));
+    try!(write(cx.dst.join("FiraSans-Regular.woff"),
+               include_bin!("static/FiraSans-Regular.woff")));
+    try!(write(cx.dst.join("FiraSans-Medium.woff"),
+               include_bin!("static/FiraSans-Medium.woff")));
+    try!(write(cx.dst.join("Heuristica-Regular.woff"),
+               include_bin!("static/Heuristica-Regular.woff")));
+    try!(write(cx.dst.join("Heuristica-Italic.woff"),
+               include_bin!("static/Heuristica-Italic.woff")));
+    try!(write(cx.dst.join("Heuristica-Bold.woff"),
+               include_bin!("static/Heuristica-Bold.woff")));
 
-        fn collect(path: &Path, krate: &str,
-                   key: &str) -> io::IoResult<Vec<String>> {
-            let mut ret = Vec::new();
-            if path.exists() {
-                for line in BufferedReader::new(File::open(path)).lines() {
-                    let line = try!(line);
-                    if !line.as_slice().starts_with(key) {
-                        continue
-                    }
-                    if line.as_slice().starts_with(
-                            format!("{}['{}']", key, krate).as_slice()) {
-                        continue
-                    }
-                    ret.push(line.to_string());
+    fn collect(path: &Path, krate: &str,
+               key: &str) -> io::IoResult<Vec<String>> {
+        let mut ret = Vec::new();
+        if path.exists() {
+            for line in BufferedReader::new(File::open(path)).lines() {
+                let line = try!(line);
+                if !line.as_slice().starts_with(key) {
+                    continue
                 }
-            }
-            return Ok(ret);
-        }
-
-        // Update the search index
-        let dst = cx.dst.join("search-index.js");
-        let all_indexes = try!(collect(&dst, krate.name.as_slice(),
-                                       "searchIndex"));
-        let mut w = try!(File::create(&dst));
-        try!(writeln!(&mut w, r"var searchIndex = \{\};"));
-        try!(writeln!(&mut w, "{}", index));
-        for index in all_indexes.iter() {
-            try!(writeln!(&mut w, "{}", *index));
-        }
-        try!(writeln!(&mut w, "initSearch(searchIndex);"));
-
-        // Update the list of all implementors for traits
-        let dst = cx.dst.join("implementors");
-        try!(mkdir(&dst));
-        for (&did, imps) in cache.implementors.iter() {
-            if ast_util::is_local(did) { continue }
-            let &(ref remote_path, remote_item_type) = cache.paths.get(&did);
-
-            let mut mydst = dst.clone();
-            for part in remote_path.slice_to(remote_path.len() - 1).iter() {
-                mydst.push(part.as_slice());
-                try!(mkdir(&mydst));
-            }
-            mydst.push(format!("{}.{}.js",
-                               remote_item_type.to_static_str(),
-                               *remote_path.get(remote_path.len() - 1)));
-            let all_implementors = try!(collect(&mydst, krate.name.as_slice(),
-                                                "implementors"));
-
-            try!(mkdir(&mydst.dir_path()));
-            let mut f = BufferedWriter::new(try!(File::create(&mydst)));
-            try!(writeln!(&mut f, r"(function() \{var implementors = \{\};"));
-
-            for implementor in all_implementors.iter() {
-                try!(writeln!(&mut f, "{}", *implementor));
-            }
-
-            try!(write!(&mut f, r"implementors['{}'] = \{", krate.name));
-            for imp in imps.iter() {
-                let &(ref path, item_type) = match *imp {
-                    PathType(clean::ResolvedPath { did, .. }) => {
-                        cache.paths.get(&did)
-                    }
-                    PathType(..) | OtherType(..) => continue,
-                };
-                try!(write!(&mut f, r#"{}:"#, *path.get(path.len() - 1)));
-                try!(write!(&mut f, r#""{}"#,
-                            path.slice_to(path.len() - 1).connect("/")));
-                try!(write!(&mut f, r#"/{}.{}.html","#,
-                            item_type.to_static_str(),
-                            *path.get(path.len() - 1)));
-            }
-            try!(writeln!(&mut f, r"\};"));
-            try!(writeln!(&mut f, "{}", r"
-                if (window.register_implementors) {
-                    window.register_implementors(implementors);
-                } else {
-                    window.pending_implementors = implementors;
+                if line.as_slice().starts_with(
+                        format!("{}['{}']", key, krate).as_slice()) {
+                    continue
                 }
-            "));
-            try!(writeln!(&mut f, r"\})()"));
+                ret.push(line.to_string());
+            }
         }
+        return Ok(ret);
     }
 
-    // Render all source files (this may turn into a giant no-op)
-    {
-        info!("emitting source files");
-        let dst = cx.dst.join("src");
-        try!(mkdir(&dst));
-        let dst = dst.join(krate.name.as_slice());
-        try!(mkdir(&dst));
-        let mut folder = SourceCollector {
-            dst: dst,
-            seen: HashSet::new(),
-            cx: &mut cx,
-        };
-        // skip all invalid spans
-        folder.seen.insert("".to_string());
-        krate = folder.fold_crate(krate);
+    // Update the search index
+    let dst = cx.dst.join("search-index.js");
+    let all_indexes = try!(collect(&dst, krate.name.as_slice(),
+                                   "searchIndex"));
+    let mut w = try!(File::create(&dst));
+    try!(writeln!(&mut w, r"var searchIndex = \{\};"));
+    try!(writeln!(&mut w, "{}", search_index));
+    for index in all_indexes.iter() {
+        try!(writeln!(&mut w, "{}", *index));
     }
+    try!(writeln!(&mut w, "initSearch(searchIndex);"));
 
-    for &(n, ref e) in krate.externs.iter() {
-        cache.extern_locations.insert(n, extern_location(e, &cx.dst));
-        let did = ast::DefId { krate: n, node: ast::CRATE_NODE_ID };
-        cache.paths.insert(did, (vec![e.name.to_string()], item_type::Module));
+    // Update the list of all implementors for traits
+    let dst = cx.dst.join("implementors");
+    try!(mkdir(&dst));
+    for (&did, imps) in cache.implementors.iter() {
+        if ast_util::is_local(did) { continue }
+        let &(ref remote_path, remote_item_type) = cache.paths.get(&did);
+
+        let mut mydst = dst.clone();
+        for part in remote_path.slice_to(remote_path.len() - 1).iter() {
+            mydst.push(part.as_slice());
+            try!(mkdir(&mydst));
+        }
+        mydst.push(format!("{}.{}.js",
+                           remote_item_type.to_static_str(),
+                           *remote_path.get(remote_path.len() - 1)));
+        let all_implementors = try!(collect(&mydst, krate.name.as_slice(),
+                                            "implementors"));
+
+        try!(mkdir(&mydst.dir_path()));
+        let mut f = BufferedWriter::new(try!(File::create(&mydst)));
+        try!(writeln!(&mut f, r"(function() \{var implementors = \{\};"));
+
+        for implementor in all_implementors.iter() {
+            try!(writeln!(&mut f, "{}", *implementor));
+        }
+
+        try!(write!(&mut f, r"implementors['{}'] = \{", krate.name));
+        for imp in imps.iter() {
+            let &(ref path, item_type) = match *imp {
+                PathType(clean::ResolvedPath { did, .. }) => {
+                    cache.paths.get(&did)
+                }
+                PathType(..) | OtherType(..) => continue,
+            };
+            try!(write!(&mut f, r#"{}:"#, *path.get(path.len() - 1)));
+            try!(write!(&mut f, r#""{}"#,
+                        path.slice_to(path.len() - 1).connect("/")));
+            try!(write!(&mut f, r#"/{}.{}.html","#,
+                        item_type.to_static_str(),
+                        *path.get(path.len() - 1)));
+        }
+        try!(writeln!(&mut f, r"\};"));
+        try!(writeln!(&mut f, "{}", r"
+            if (window.register_implementors) {
+                window.register_implementors(implementors);
+            } else {
+                window.pending_implementors = implementors;
+            }
+        "));
+        try!(writeln!(&mut f, r"\})()"));
     }
+    Ok(())
+}
 
-    // And finally render the whole crate's documentation
-    cx.krate(krate, cache)
+fn render_sources(cx: &mut Context,
+                  krate: clean::Crate) -> io::IoResult<clean::Crate> {
+    info!("emitting source files");
+    let dst = cx.dst.join("src");
+    try!(mkdir(&dst));
+    let dst = dst.join(krate.name.as_slice());
+    try!(mkdir(&dst));
+    let mut folder = SourceCollector {
+        dst: dst,
+        seen: HashSet::new(),
+        cx: cx,
+    };
+    // skip all invalid spans
+    folder.seen.insert("".to_string());
+    Ok(folder.fold_crate(krate))
 }
 
 /// Writes the entire contents of a string to a destination, not attempting to

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -527,7 +527,8 @@
                          "variant",
                          "ffi",
                          "ffs",
-                         "macro"];
+                         "macro",
+                         "primitive"];
 
         function itemTypeFromName(typename) {
             for (var i = 0; i < itemTypes.length; ++i) {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -658,15 +658,13 @@
         var list = $('#implementors-list');
         var libs = Object.getOwnPropertyNames(imp);
         for (var i = 0; i < libs.length; i++) {
-            var structs = Object.getOwnPropertyNames(imp[libs[i]]);
+            if (libs[i] == currentCrate) continue;
+            var structs = imp[libs[i]];
             for (var j = 0; j < structs.length; j++) {
-                console.log(i, structs[j]);
-                var path = rootPath + imp[libs[i]][structs[j]];
-                var klass = path.contains("type.") ? "type" : "struct";
-                var link = $('<a>').text(structs[j])
-                                   .attr('href', path)
-                                   .attr('class', klass);
-                var code = $('<code>').append(link);
+                var code = $('<code>').append(structs[j]);
+                $.each(code.find('a'), function(idx, a) {
+                    $(a).attr('href', rootPath + $(a).attr('href'));
+                });
                 var li = $('<li>').append(code);
                 list.append(li);
             }

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -67,10 +67,21 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
             fn fold_item(&mut self, i: Item) -> Option<Item> {
                 match i.inner {
                     clean::ImplItem(clean::Impl{
-                        for_: clean::ResolvedPath{ did, .. }, ..
+                        for_: clean::ResolvedPath{ did, .. },
+                        ref trait_, ..
                     }) => {
+                        // Impls for stripped don't need to exist
                         if self.stripped.contains(&did.node) {
                             return None;
+                        }
+                        // Impls of stripped traits also don't need to exist
+                        match *trait_ {
+                            Some(clean::ResolvedPath { did, .. }) => {
+                                if self.stripped.contains(&did.node) {
+                                    return None
+                                }
+                            }
+                            _ => {}
                         }
                     }
                     _ => {}
@@ -161,6 +172,9 @@ impl<'a> fold::DocFolder for Stripper<'a> {
 
             // tymethods/macros have no control over privacy
             clean::MacroItem(..) | clean::TyMethodItem(..) => {}
+
+            // Primitives are never stripped
+            clean::PrimitiveItem(..) => {}
         }
 
         let fastreturn = match i.inner {

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -70,7 +70,7 @@ pub fn strip_hidden(krate: clean::Crate) -> plugins::PluginResult {
                         for_: clean::ResolvedPath{ did, .. },
                         ref trait_, ..
                     }) => {
-                        // Impls for stripped don't need to exist
+                        // Impls for stripped types don't need to exist
                         if self.stripped.contains(&did.node) {
                             return None;
                         }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -79,6 +79,7 @@ pub fn run(input: &str,
         external_traits: RefCell::new(None),
         external_typarams: RefCell::new(None),
         inlined: RefCell::new(None),
+        populated_crate_impls: RefCell::new(HashSet::new()),
     };
     super::ctxtkey.replace(Some(ctx));
 

--- a/src/librustuv/homing.rs
+++ b/src/librustuv/homing.rs
@@ -82,6 +82,7 @@ pub fn local_id() -> uint {
     }
 }
 
+#[doc(hidden)]
 pub trait HomingIO {
     fn home<'r>(&'r mut self) -> &'r mut HomeHandle;
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -12,6 +12,7 @@
 
 #![allow(missing_doc)]
 #![allow(unsigned_negate)]
+#![doc(primitive = "f32")]
 
 use prelude::*;
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -11,6 +11,7 @@
 //! Operations and constants for 64-bits floats (`f64` type)
 
 #![allow(missing_doc)]
+#![doc(primitive = "f64")]
 
 use prelude::*;
 

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
+#![doc(primitive = "i16")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for signed 32-bits integers (`i32` type)
 
+#![doc(primitive = "i32")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for signed 64-bits integers (`i64` type)
 
+#![doc(primitive = "i64")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for signed 8-bits integers (`i8` type)
 
+#![doc(primitive = "i8")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for architecture-sized signed integers (`int` type)
 
+#![doc(primitive = "int")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
+#![doc(primitive = "u16")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
+#![doc(primitive = "u32")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
+#![doc(primitive = "u64")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
+#![doc(primitive = "u8")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -10,6 +10,8 @@
 
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
+#![doc(primitive = "uint")]
+
 use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;

--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -97,6 +97,8 @@ There are a number of free functions that create or take vectors, for example:
 
 */
 
+#![doc(primitive = "slice")]
+
 use mem::transmute;
 use clone::Clone;
 use cmp::{TotalOrd, Ordering, Less, Greater};

--- a/src/libstd/str.rs
+++ b/src/libstd/str.rs
@@ -65,6 +65,8 @@ is the same as `&[u8]`.
 
 */
 
+#![doc(primitive = "str")]
+
 use char::Char;
 use char;
 use clone::Clone;

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -288,7 +288,7 @@ pub enum SubstructureFields<'a> {
 
     /**
     non-matching variants of the enum, [(variant index, ast::Variant,
-    [field span, field ident, fields])] (i.e. all fields for self are in the
+    [field span, field ident, fields])] \(i.e. all fields for self are in the
     first tuple, for other1 are in the second tuple, etc.)
     */
     EnumNonMatching(&'a [(uint, P<ast::Variant>, Vec<(Span, Option<Ident>, @Expr)> )]),


### PR DESCRIPTION
This is currently rebased on top of #14478, but that's just to preemptively avoid rebase conflicts and to provide a better preview. This can land independently of that PR.

This change crates a dedicated page in rustdoc for primitive types to outline everything you can do with them (at least in a basic way).
- Preview - http://people.mozilla.org/~acrichton/doc/
- Exhibit A - http://people.mozilla.org/~acrichton/doc/std/#primitives
- Exhibit B - http://people.mozilla.org/~acrichton/doc/std/primitive.str.html
- Exhibit C - http://people.mozilla.org/~acrichton/doc/std/primitive.slice.html

Please don't hesitate to be nitpickity, it's easy to overlook a thing here or there!
