### PR TITLE
syntax: Fix span on illegal ABI errors

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4537,7 +4537,7 @@ impl<'a> Parser<'a> {
                     Some(abi) => Some(abi),
                     None => {
                         self.span_err(
-                            self.span,
+                            self.last_span,
                             format!("illegal ABI: expected one of [{}], \
                                      found `{}`",
                                     abi::all_names().connect(", "),

--- a/src/test/compile-fail/issue-8537.rs
+++ b/src/test/compile-fail/issue-8537.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub extern
+  "invalid-abi" //~ ERROR illegal ABI
+fn foo() {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #8537
Fixes #14499 (duplicate of #8537)

Old:

``` rust
test.rs:2   pub extern "xxxxx" fn add(x: int, y: int) -> int {
                               ^~
```

New:

``` rust
test.rs:2   pub extern "xxxxx" fn add(x: int, y: int) -> int {
                       ^~~~~~~
```
