### PR TITLE
core: Apply stability attributes to ptr mod

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -213,14 +213,14 @@ pub struct Unique<T> {
 impl<T: Send> Unique<T> {
     pub fn new(value: T) -> Unique<T> {
         unsafe {
-            let ptr = malloc(std::mem::size_of::<T>() as size_t) as *mut T;
+            let ptr = malloc(mem::size_of::<T>() as size_t) as *mut T;
             // we *need* valid pointer.
             assert!(!ptr.is_null());
             // `*ptr` is uninitialized, and `*ptr = value` would
             // attempt to destroy it `overwrite` moves a value into
             // this memory without attempting to drop the original
             // value.
-            mem::overwrite(&mut *ptr, value);
+            ptr::write(&mut *ptr, value);
             Unique{ptr: ptr}
         }
     }

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -13,7 +13,8 @@
 #![allow(missing_doc)]
 
 use std::clone::Clone;
-use std::mem::{overwrite, zeroed, replace, swap};
+use std::mem::{zeroed, replace, swap};
+use std::ptr;
 use std::slice;
 
 /// A priority queue implemented with a binary heap
@@ -163,13 +164,13 @@ impl<T: Ord> PriorityQueue<T> {
                 let parent = (pos - 1) >> 1;
                 if new > *self.data.get(parent) {
                     let x = replace(self.data.get_mut(parent), zeroed());
-                    overwrite(self.data.get_mut(pos), x);
+                    ptr::write(self.data.get_mut(pos), x);
                     pos = parent;
                     continue
                 }
                 break
             }
-            overwrite(self.data.get_mut(pos), new);
+            ptr::write(self.data.get_mut(pos), new);
         }
     }
 
@@ -185,12 +186,12 @@ impl<T: Ord> PriorityQueue<T> {
                     child = right;
                 }
                 let x = replace(self.data.get_mut(child), zeroed());
-                overwrite(self.data.get_mut(pos), x);
+                ptr::write(self.data.get_mut(pos), x);
                 pos = child;
                 child = 2 * pos + 1;
             }
 
-            overwrite(self.data.get_mut(pos), new);
+            ptr::write(self.data.get_mut(pos), new);
             self.siftup(start, pos);
         }
     }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -155,16 +155,16 @@ pub unsafe fn uninit<T>() -> T {
 /// contained at the location `dst`. This could leak allocations or resources,
 /// so care must be taken to previously deallocate the value at `dst`.
 #[inline]
-#[stable]
+#[deprecated = "use ptr::write"]
 pub unsafe fn overwrite<T>(dst: *mut T, src: T) {
     intrinsics::move_val_init(&mut *dst, src)
 }
 
 /// Deprecated, use `overwrite` instead
 #[inline]
-#[deprecated = "this function has been renamed to `overwrite`"]
+#[deprecated = "use ptr::write"]
 pub unsafe fn move_val_init<T>(dst: &mut T, src: T) {
-    overwrite(dst, src)
+    ptr::write(dst, src)
 }
 
 /// Convert an u16 to little endian from the target's endianness.

--- a/src/libcore/should_not_exist.rs
+++ b/src/libcore/should_not_exist.rs
@@ -77,7 +77,7 @@ impl<A: Clone> Clone for ~[A] {
             try_finally(
                 &mut i, (),
                 |i, ()| while *i < len {
-                    mem::overwrite(
+                    ptr::write(
                         &mut(*p.offset(*i as int)),
                         self.unsafe_ref(*i).clone());
                     *i += 1;

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1093,7 +1093,7 @@ impl<'a,T> MutableVector<'a, T> for &'a mut [T] {
 
     #[inline]
     unsafe fn init_elem(self, i: uint, val: T) {
-        mem::overwrite(&mut (*self.as_mut_ptr().offset(i as int)), val);
+        ptr::write(&mut (*self.as_mut_ptr().offset(i as int)), val);
     }
 
     #[inline]
@@ -1218,6 +1218,7 @@ pub mod bytes {
 
     impl<'a> MutableByteVector for &'a mut [u8] {
         #[inline]
+        #[allow(experimental)]
         fn set_memory(self, value: u8) {
             unsafe { ptr::set_memory(self.as_mut_ptr(), value, self.len()) };
         }


### PR DESCRIPTION
This time we're not promoting anything directly to 'stable', but instead promoting functions we're happy with to 'unstable'. They'll become stable in another pass later.
- null and mut_null are unstable. Their names may change if the unsafe
  pointer types change.
- copy_memory and copy_overlapping_memory are unstable. We think they
  aren't going to change.
- set_memory and zero_memory are experimental. Both the names and
  the semantics are under question.
- swap and replace are unstable and probably won't change.
- read is unstable, probably won't change
- read_and_zero is experimental. It's necessity is in doubt.
- mem::overwrite is now called ptr::write to match read and is
  unstable. mem::overwrite is now deprecated
- array_each, array_each_with_len, buf_len, and position are
  all deprecated because they use old style iteration and their
  utility is generally under question.

Note that `mem::overwrite`, which was just declared stable last week, is deprecated now in favor of `ptr::write`. Woo!
