### PR TITLE
Fixing a mismatched square bracket typo in src/libstd/slice.rs

### DIFF
--- a/src/libstd/slice.rs
+++ b/src/libstd/slice.rs
@@ -38,7 +38,7 @@ These traits include `ImmutableVector`, and `MutableVector` for the `&mut [T]`
 case.
 
 An example is the method `.slice(a, b)` that returns an immutable "view" into
-a vector or a vector slice from the index interval `[a, b)`:
+a vector or a vector slice from the index interval `[a, b]`:
 
 ```rust
 let numbers = [0, 1, 2];


### PR DESCRIPTION
Fixing a small typo in the documentation for `src/libstd/slice.rs`
