### PR TITLE
Ignore /build even if it’s a symlink, but only at top-level.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ config.stamp
 .DS_Store
 src/etc/dl
 .settings/
-build/
+/build
 i686-pc-mingw32/
 src/librustc/lib/llvmdeps.rs
 *.pot


### PR DESCRIPTION
CC @alexcrichton
Closes #14545
