### PR TITLE
Remove deprecated owned vector from iterator example.

### DIFF
--- a/src/doc/guide-container.md
+++ b/src/doc/guide-container.md
@@ -396,7 +396,7 @@ underlying iterators are.
 
 ~~~
 let xs = [1, 2, 3, 4, 5];
-let ys = ~[7, 9, 11];
+let ys = [7, 9, 11];
 let mut it = xs.iter().chain(ys.iter());
 println!("{}", it.idx(0)); // prints `Some(1)`
 println!("{}", it.idx(5)); // prints `Some(7)`


### PR DESCRIPTION
The last example in the containers and iterators guide had a superfluous owned vector in it. Everything works fine without it, so I removed it to avoid confusion.
