### PR TITLE
Fix outgoing link to snappy in the FFI guide

### DIFF
--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -2,11 +2,11 @@
 
 # Introduction
 
-This guide will use the [snappy](https://code.google.com/p/snappy/)
+This guide will use the [snappy](https://github.com/google/snappy)
 compression/decompression library as an introduction to writing bindings for
 foreign code. Rust is currently unable to call directly into a C++ library, but
 snappy includes a C interface (documented in
-[`snappy-c.h`](https://code.google.com/p/snappy/source/browse/trunk/snappy-c.h)).
+[`snappy-c.h`](https://github.com/google/snappy/blob/master/snappy-c.h)).
 
 The following is a minimal example of calling a foreign function which will
 compile if snappy is installed:


### PR DESCRIPTION
Google have migrated snappy to GitHub.
