### PR TITLE
libtest: Only colorize output if stdout is a tty

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -868,7 +868,9 @@ fn should_sort_failures_before_printing_them() {
     assert!(apos < bpos);
 }
 
-fn use_color() -> bool { return get_concurrency() == 1; }
+fn use_color() -> bool {
+    get_concurrency() == 1 && io::stdout().get_ref().isatty()
+}
 
 #[deriving(Clone)]
 enum TestEvent {


### PR DESCRIPTION
Fixes #14570.
