### PR TITLE
rustc: Disallow autoderef for bottom type `!`

### DIFF
--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -937,7 +937,7 @@ impl<'a> LookupContext<'a> {
             ty_bare_fn(..) | ty_box(..) | ty_uniq(..) | ty_rptr(..) |
             ty_infer(IntVar(_)) |
             ty_infer(FloatVar(_)) |
-            ty_self(_) | ty_param(..) | ty_nil | ty_bot | ty_bool |
+            ty_self(_) | ty_param(..) | ty_nil | ty_bool |
             ty_char | ty_int(..) | ty_uint(..) |
             ty_float(..) | ty_enum(..) | ty_ptr(..) | ty_struct(..) | ty_tup(..) |
             ty_str | ty_vec(..) | ty_trait(..) | ty_closure(..) => {
@@ -946,7 +946,7 @@ impl<'a> LookupContext<'a> {
                     |m,r| ty::mk_rptr(tcx, r, ty::mt {ty:self_ty, mutbl:m}))
             }
 
-            ty_err => None,
+            ty_bot | ty_err => None,
 
             ty_infer(TyVar(_)) => {
                 self.bug(format!("unexpected type: {}",

--- a/src/test/compile-fail/bot-method.rs
+++ b/src/test/compile-fail/bot-method.rs
@@ -1,0 +1,15 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: attempted access of field `foo` on type `!`, but no field with that name was found
+
+fn main() {
+    (fail!("bottom")).foo
+}


### PR DESCRIPTION
Fix issue #13847.
