### PR TITLE
Fix docs for `core::result::Result::map`.

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -432,11 +432,13 @@ impl<T, E> Result<T, E> {
     ///     let line: IoResult<String> = reader.read_line();
     ///     // Convert the string line to a number using `map` and `from_str`
     ///     let val: IoResult<int> = line.map(|line| {
-    ///         from_str::<int>(line.as_slice()).unwrap_or(0)
+    ///         from_str::<int>(line.as_slice().trim_right()).unwrap_or(0)
     ///     });
     ///     // Add the value if there were no errors, otherwise add 0
     ///     sum += val.ok().unwrap_or(0);
     /// }
+    ///
+    /// assert!(sum == 10);
     /// ~~~
     #[inline]
     pub fn map<U>(self, op: |T| -> U) -> Result<U,E> {


### PR DESCRIPTION
`reader.read_line()` includes trailing newline char, which makes
`from_str` always return `None`.
