### PR TITLE
Fix typo "gihub" in libsyntax/crateid.

### DIFF
--- a/src/libsyntax/crateid.rs
+++ b/src/libsyntax/crateid.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,7 +13,7 @@ use std::fmt;
 /// CrateIds identify crates and include the crate name and optionally a path
 /// and version. In the full form, they look like relative URLs. Example:
 /// `github.com/mozilla/rust#std:1.0` would be a package ID with a path of
-/// `gitub.com/mozilla/rust` and a crate name of `std` with a version of
+/// `github.com/mozilla/rust` and a crate name of `std` with a version of
 /// `1.0`. If no crate name is given after the hash, the name is inferred to
 /// be the last component of the path. If no version is given, it is inferred
 /// to be `0.0`.


### PR DESCRIPTION
Example URL in CrateId documentation is:

```
`gihub.com/mozilla/rust`
```

Instead of:

```
`github.com/mozilla/rust`
```

Also update libsyntax/crateid.rs licensing header for 2014.
