### PR TITLE
libc: only provide an rlib.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -102,6 +102,7 @@ TOOL_SOURCE_rustdoc := $(S)src/driver/driver.rs
 TOOL_SOURCE_rustc := $(S)src/driver/driver.rs
 
 ONLY_RLIB_core := 1
+ONLY_RLIB_libc := 1
 ONLY_RLIB_rlibc := 1
 ONLY_RLIB_alloc := 1
 ONLY_RLIB_rand := 1

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -14,7 +14,6 @@
 #![no_std] // we don't need std, and we can't have std, since it doesn't exist
            // yet. std depends on us.
 #![crate_type = "rlib"]
-#![crate_type = "dylib"]
 
 /*!
 * Bindings for the C standard library and other platform libraries
@@ -4435,5 +4434,8 @@ pub mod funcs {
         }
     }
 }
+
+#[doc(hidden)]
+pub fn issue_14344_workaround() {} // FIXME #14344 force linkage to happen correctly
 
 #[test] fn work_on_windows() { } // FIXME #10872 needed for a happy windows

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -254,6 +254,11 @@ mod unicode;
 #[unstable]
 pub mod rt;
 
+#[doc(hidden)]
+pub fn issue_14344_workaround() { // FIXME #14344 force linkage to happen correctly
+    libc::issue_14344_workaround();
+}
+
 // A curious inner-module that's not exported that contains the binding
 // 'std' so that macro-expanded references to std::error and such
 // can be resolved within libstd.


### PR DESCRIPTION
libc: only provide an rlib.

There's absolutely no reason for `libc` to be offered as a dynamic
library.
