### PR TITLE
Fixes #13843 (empty regexes are now valid)

### DIFF
--- a/src/libregex/parse/mod.rs
+++ b/src/libregex/parse/mod.rs
@@ -201,6 +201,9 @@ pub fn parse(s: &str) -> Result<Ast, Error> {
 
 impl<'a> Parser<'a> {
     fn parse(&mut self) -> Result<Ast, Error> {
+        if self.chars.len() == 0 {
+            return Ok(Nothing);
+        }
         loop {
             let c = self.cur();
             match c {

--- a/src/libregex/test/tests.rs
+++ b/src/libregex/test/tests.rs
@@ -28,6 +28,20 @@ fn split() {
     assert_eq!(subs, vec!("cauchy", "plato", "tyler", "binx"));
 }
 
+#[test]
+fn empty_regex_empty_match() {
+    let re = regex!("");
+    let ms = re.find_iter("").collect::<Vec<(uint, uint)>>();
+    assert_eq!(ms, vec![(0, 0)]);
+}
+
+#[test]
+fn empty_regex_nonempty_match() {
+    let re = regex!("");
+    let ms = re.find_iter("abc").collect::<Vec<(uint, uint)>>();
+    assert_eq!(ms, vec![(0, 0), (1, 1), (2, 2), (3, 3)]);
+}
+
 macro_rules! replace(
     ($name:ident, $which:ident, $re:expr,
      $search:expr, $replace:expr, $result:expr) => (


### PR DESCRIPTION
An empty regex is a valid regex that always matches. This behavior
is consistent with at least Go and Python.

A couple regression tests are included.

I'd just assume that an empty regex is an invalid regex and that an error should be returned (I can't think of any reason to use an empty regex?), but it's probably better to be consistent with other regex libraries.
