### PR TITLE
std: Improve non-task-based usage

### DIFF
--- a/src/libstd/rt/rtio.rs
+++ b/src/libstd/rt/rtio.rs
@@ -171,7 +171,10 @@ impl<'a> LocalIo<'a> {
         //
         // In order to get around this, we just transmute a copy out of the task
         // in order to have what is likely a static lifetime (bad).
-        let mut t: Box<Task> = Local::take();
+        let mut t: Box<Task> = match Local::try_take() {
+            Some(t) => t,
+            None => return None,
+        };
         let ret = t.local_io().map(|t| {
             unsafe { mem::transmute_copy(&t) }
         });

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -176,7 +176,10 @@ impl TaskBuilder {
             Some(gen) => gen(f),
             None => f
         };
-        let t: Box<Task> = Local::take();
+        let t: Box<Task> = match Local::try_take() {
+            Some(t) => t,
+            None => fail!("need a local task to spawn a new task"),
+        };
         t.spawn_sibling(self.opts, f);
     }
 

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -1,0 +1,59 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate native;
+
+use std::io::process::{Command, ProcessOutput};
+use std::os;
+use std::str;
+use std::rt::unwind::try;
+
+local_data_key!(foo: int)
+
+#[start]
+fn start(argc: int, argv: **u8) -> int {
+    if argc > 1 {
+        unsafe {
+            match **argv.offset(1) {
+                1 => {}
+                2 => println!("foo"),
+                3 => assert!(try(|| {}).is_ok()),
+                4 => assert!(try(|| fail!()).is_err()),
+                5 => assert!(try(|| spawn(proc() {})).is_err()),
+                6 => assert!(Command::new("test").spawn().is_err()),
+                7 => assert!(foo.get().is_some()),
+                8 => assert!(try(|| { foo.replace(Some(3)); }).is_err()),
+                _ => fail!()
+            }
+        }
+        return 0
+    }
+
+    native::start(argc, argv, main)
+}
+
+fn main() {
+    let args = os::args();
+    let me = args.get(0).as_slice();
+
+    pass(Command::new(me).arg(&[1u8]).output().unwrap());
+    pass(Command::new(me).arg(&[2u8]).output().unwrap());
+    pass(Command::new(me).arg(&[3u8]).output().unwrap());
+    pass(Command::new(me).arg(&[4u8]).output().unwrap());
+    pass(Command::new(me).arg(&[5u8]).output().unwrap());
+    pass(Command::new(me).arg(&[6u8]).output().unwrap());
+}
+
+fn pass(output: ProcessOutput) {
+    if !output.status.success() {
+        println!("{}", str::from_utf8(output.output.as_slice()));
+        println!("{}", str::from_utf8(output.error.as_slice()));
+    }
+}


### PR DESCRIPTION
A few notable improvements were implemented to cut down on the number of aborts
triggered by the standard library when a local task is not found.
- Primarily, the unwinding functionality was restructured to support an unsafe
  top-level function, `try`. This function invokes a closure, capturing any
  failure which occurs inside of it. The purpose of this function is to be as
  lightweight of a "try block" as possible for rust, intended for use when the
  runtime is difficult to set up.
  
  This function is _not_ meant to be used by normal rust code, nor should it be
  consider for use with normal rust code.
- When invoking spawn(), a `fail!()` is triggered rather than an abort.
- When invoking LocalIo::borrow(), which is transitively called by all I/O
  constructors, None is returned rather than aborting to indicate that there is
  no local I/O implementation.

A test case was also added showing the variety of things that you can do without
a runtime or task set up now. In general, this is just a refactoring to abort
less quickly in the standard library when a local task is not found.
