### PR TITLE
travis: Prevent timeouts with travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script: |
     if [[ $LLVM_VERSION != '3.4' ]]; then exit 0; fi
   fi &&
   make tidy &&
-  make -j4 rustc-stage1 &&
+  travis_wait make -j4 rustc-stage1 &&
   make check-stage1-std check-stage1-rpass check-stage1-cfail check-stage1-rfail check-stage1-doc
 
 env:


### PR DESCRIPTION
The most frequent failure for our travis builds is running into the timeout
limits when building the compiler itself. Building librustc takes a very long
amount of time, often hitting the 10 minutes with no output threshold that
travis imposes on us.

This commit switches the relevant `make` step to being wrapped in the
`travis_wait` command [1](http://docs.travis-ci.com/user/build-timeouts/). This command will print something once a minute so as
to not time out a build.

This will hopefully enable us to have fewer flaky builds on travis!
