### PR TITLE
Add workaround for archive reading bug in LLDB.

### DIFF
--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -109,7 +109,7 @@ impl<'a> Archive<'a> {
     pub fn add_rlib(&mut self, rlib: &Path, name: &str,
                     lto: bool) -> io::IoResult<()> {
         let object = format!("{}.o", name);
-        let bytecode = format!("{}.bc.deflate", name);
+        let bytecode = format!("{}.bytecode.deflate", name);
         let mut ignore = vec!(bytecode.as_slice(), METADATA_FILENAME);
         if lto {
             ignore.push(object.as_slice());

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -958,8 +958,12 @@ fn link_rlib<'a>(sess: &'a Session,
 
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
+            // Note that we make sure that the bytecode filename in the archive is always at least
+            // 16 bytes long by adding a 16 byte extension to it. This is to work around a bug in
+            // LLDB that would cause it to crash if the name of a file in an archive was exactly
+            // 16 bytes.
             let bc = obj_filename.with_extension("bc");
-            let bc_deflated = obj_filename.with_extension("bc.deflate");
+            let bc_deflated = obj_filename.with_extension("bytecode.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {
                 fs::File::create(&bc_deflated)
                     .write(match flate::deflate_bytes(data.as_slice()) {

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -55,10 +55,10 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         let archive = ArchiveRO::open(&path).expect("wanted an rlib");
         debug!("reading {}", name);
         let bc = time(sess.time_passes(),
-                      format!("read {}.bc.deflate", name).as_slice(),
+                      format!("read {}.bytecode.deflate", name).as_slice(),
                       (),
                       |_| {
-                          archive.read(format!("{}.bc.deflate",
+                          archive.read(format!("{}.bytecode.deflate",
                                                name).as_slice())
                       });
         let bc = bc.expect("missing compressed bytecode in archive!");


### PR DESCRIPTION
LLDB contains a bug that makes it crash if an archive it reads contains a file the name of which is exactly 16 bytes long. This bug recently has made it impossible to debug Rust applications with LLDB because some standard libraries triggered it indirectly:
For rlibs, rustc includes the LLVM bytecode in the archive, giving it the extension ".bc.deflate". For liballoc (for example) this results in the 16 character filename "alloc.bc.deflate", which is bad.

This commit replaces the ".bc.deflate" suffix with ".bytecode.deflate" which itself is already longer than 16 bytes, thus making sure that the bug won't be run into anymore.

The bug could still be run into with 14 character filenames because then the .o files will trigger it. However, this is much more rare and working around it would introduce more complexity than necessary at the moment. It can always be done later on, if the need arises.

Fixes #14356.

Q: Should we try to stay backwards compatible by looking for _xxx.bc.deflate_ if _xxx.bytecode.deflate_ is not found?
