### PR TITLE
Remove a warning when built with  --disable-manage-submodules

### DIFF
--- a/configure
+++ b/configure
@@ -1136,7 +1136,7 @@ do
         CXXFLAGS=$LLVM_CXXFLAGS
         LDFLAGS=$LLVM_LDFLAGS
 
-        if [ "$CFG_DISABLE_LIBCPP" != 1 ] && [ "$CFG_USING_CLANG" == 1 ]; then
+        if [ -z "$CFG_DISABLE_LIBCPP" ] && [ -n "$CFG_USING_CLANG" ]; then
             LLVM_OPTS="$LLVM_OPTS --enable-libcpp"
         fi
 


### PR DESCRIPTION
 Remove a warning (./configure: 1140: [: unexpected operator) when built with --disable-manage-submodules
