### PR TITLE
Avoid 16-byte filenames in rlibs

### DIFF
--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -109,7 +109,7 @@ impl<'a> Archive<'a> {
     pub fn add_rlib(&mut self, rlib: &Path, name: &str,
                     lto: bool) -> io::IoResult<()> {
         let object = format!("{}.o", name);
-        let bytecode = format!("{}.bc.deflate", name);
+        let bytecode = format!("{}.bytecode.deflate", name);
         let mut ignore = vec!(bytecode.as_slice(), METADATA_FILENAME);
         if lto {
             ignore.push(object.as_slice());

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -166,6 +166,15 @@ impl<'a> Archive<'a> {
             if filename.contains(".SYMDEF") { continue }
 
             let filename = format!("r-{}-{}", name, filename);
+            // LLDB (as mentioned in back::link) crashes on filenames of exactly
+            // 16 bytes in length. If we're including an object file with
+            // exactly 16-bytes of characters, give it some prefix so that it's
+            // not 16 bytes.
+            let filename = if filename.len() == 16 {
+                format!("lldb-fix-{}", filename)
+            } else {
+                filename
+            };
             let new_filename = file.with_filename(filename);
             try!(fs::rename(file, &new_filename));
             inputs.push(new_filename);

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -958,8 +958,12 @@ fn link_rlib<'a>(sess: &'a Session,
 
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
+            // Note that we make sure that the bytecode filename in the archive is always at least
+            // 16 bytes long by adding a 16 byte extension to it. This is to work around a bug in
+            // LLDB that would cause it to crash if the name of a file in an archive was exactly
+            // 16 bytes.
             let bc = obj_filename.with_extension("bc");
-            let bc_deflated = obj_filename.with_extension("bc.deflate");
+            let bc_deflated = obj_filename.with_extension("bytecode.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {
                 fs::File::create(&bc_deflated)
                     .write(match flate::deflate_bytes(data.as_slice()) {

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -958,10 +958,11 @@ fn link_rlib<'a>(sess: &'a Session,
 
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
-            // Note that we make sure that the bytecode filename in the archive is always at least
-            // 16 bytes long by adding a 16 byte extension to it. This is to work around a bug in
-            // LLDB that would cause it to crash if the name of a file in an archive was exactly
-            // 16 bytes.
+            //
+            // Note that we make sure that the bytecode filename in the archive
+            // is never exactly 16 bytes long by adding a 16 byte extension to
+            // it. This is to work around a bug in LLDB that would cause it to
+            // crash if the name of a file in an archive was exactly 16 bytes.
             let bc = obj_filename.with_extension("bc");
             let bc_deflated = obj_filename.with_extension("bytecode.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -55,10 +55,10 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         let archive = ArchiveRO::open(&path).expect("wanted an rlib");
         debug!("reading {}", name);
         let bc = time(sess.time_passes(),
-                      format!("read {}.bc.deflate", name).as_slice(),
+                      format!("read {}.bytecode.deflate", name).as_slice(),
                       (),
                       |_| {
-                          archive.read(format!("{}.bc.deflate",
+                          archive.read(format!("{}.bytecode.deflate",
                                                name).as_slice())
                       });
         let bc = bc.expect("missing compressed bytecode in archive!");


### PR DESCRIPTION
Continuation of #14672 with an extra case handled (objects from native libraries).

cc #14356
