### PR TITLE
Rename Iterator::len to count

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1545,7 +1545,7 @@ fn disassemble_extract(config: &Config, _props: &TestProps,
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end().unwrap();
     let x = str::from_utf8(x.as_slice()).unwrap();
-    x.lines().len()
+    x.lines().count()
 }
 
 

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -241,17 +241,17 @@ enum Op {Union, Intersect, Assign, Difference}
 /// bv.set(5, true);
 /// bv.set(7, true);
 /// println!("{}", bv.to_str());
-/// println!("total bits set to true: {}", bv.iter().count(|x| x));
+/// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 ///
 /// // flip all values in bitvector, producing non-primes less than 10
 /// bv.negate();
 /// println!("{}", bv.to_str());
-/// println!("total bits set to true: {}", bv.iter().count(|x| x));
+/// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 ///
 /// // reset bitvector to empty
 /// bv.clear();
 /// println!("{}", bv.to_str());
-/// println!("total bits set to true: {}", bv.iter().count(|x| x));
+/// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 /// ```
 #[deriving(Clone)]
 pub struct Bitv {
@@ -461,7 +461,7 @@ impl Bitv {
     /// bv.set(5, true);
     /// bv.set(8, true);
     /// // Count bits set to 1; result should be 5
-    /// println!("{}", bv.iter().count(|x| x));
+    /// println!("{}", bv.iter().filter(|x| *x).count());
     /// ```
     #[inline]
     pub fn iter<'a>(&'a self) -> Bits<'a> {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1131,7 +1131,7 @@ mod tests {
         let v = &[0, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.iter().len() == 128);
+            assert!(m.iter().count() == 128);
         })
     }
     #[bench]
@@ -1139,7 +1139,7 @@ mod tests {
         let v = &[0, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.mut_iter().len() == 128);
+            assert!(m.mut_iter().count() == 128);
         })
     }
     #[bench]
@@ -1147,7 +1147,7 @@ mod tests {
         let v = &[0, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.iter().rev().len() == 128);
+            assert!(m.iter().rev().count() == 128);
         })
     }
     #[bench]
@@ -1155,7 +1155,7 @@ mod tests {
         let v = &[0, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.mut_iter().rev().len() == 128);
+            assert!(m.mut_iter().rev().count() == 128);
         })
     }
 }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2155,7 +2155,7 @@ mod tests {
     #[test]
     fn test_mut_splitator() {
         let mut xs = [0,1,0,2,3,0,0,4,5,0];
-        assert_eq!(xs.mut_split(|x| *x == 0).len(), 6);
+        assert_eq!(xs.mut_split(|x| *x == 0).count(), 6);
         for slice in xs.mut_split(|x| *x == 0) {
             slice.reverse();
         }

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -31,7 +31,7 @@ pub struct SmallIntMap<T> {
 impl<V> Container for SmallIntMap<V> {
     /// Return the number of elements in the map
     fn len(&self) -> uint {
-        self.v.iter().count(|elt| elt.is_some())
+        self.v.iter().filter(|elt| elt.is_some()).count()
     }
 
     /// Return true if there are no elements in the map

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -2181,7 +2181,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars().len(), len));
+        b.iter(|| assert_eq!(s.chars().count(), len));
     }
 
     #[bench]
@@ -2194,7 +2194,7 @@ mod bench {
         Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars().len(), len));
+        b.iter(|| assert_eq!(s.chars().count(), len));
     }
 
     #[bench]
@@ -2202,7 +2202,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars().rev().len(), len));
+        b.iter(|| assert_eq!(s.chars().rev().count(), len));
     }
 
     #[bench]
@@ -2210,7 +2210,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices().len(), len));
+        b.iter(|| assert_eq!(s.char_indices().count(), len));
     }
 
     #[bench]
@@ -2218,14 +2218,14 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices().rev().len(), len));
+        b.iter(|| assert_eq!(s.char_indices().rev().count(), len));
     }
 
     #[bench]
     fn split_unicode_ascii(b: &mut Bencher) {
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
-        b.iter(|| assert_eq!(s.split('V').len(), 3));
+        b.iter(|| assert_eq!(s.split('V').count(), 3));
     }
 
     #[bench]
@@ -2240,16 +2240,16 @@ mod bench {
         }
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
-        b.iter(|| assert_eq!(s.split(NotAscii('V')).len(), 3));
+        b.iter(|| assert_eq!(s.split(NotAscii('V')).count(), 3));
     }
 
 
     #[bench]
     fn split_ascii(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(' ').len(), len));
+        b.iter(|| assert_eq!(s.split(' ').count(), len));
     }
 
     #[bench]
@@ -2264,34 +2264,34 @@ mod bench {
             fn only_ascii(&self) -> bool { false }
         }
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(NotAscii(' ')).len(), len));
+        b.iter(|| assert_eq!(s.split(NotAscii(' ')).count(), len));
     }
 
     #[bench]
     fn split_extern_fn(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
         fn pred(c: char) -> bool { c == ' ' }
 
-        b.iter(|| assert_eq!(s.split(pred).len(), len));
+        b.iter(|| assert_eq!(s.split(pred).count(), len));
     }
 
     #[bench]
     fn split_closure(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(|c: char| c == ' ').len(), len));
+        b.iter(|| assert_eq!(s.split(|c: char| c == ' ').count(), len));
     }
 
     #[bench]
     fn split_slice(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(&[' ']).len(), len));
+        b.iter(|| assert_eq!(s.split(&[' ']).count(), len));
     }
 
     #[bench]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1772,23 +1772,23 @@ mod tests {
         assert_eq!(v.pop(), Some(()));
         assert_eq!(v.pop(), None);
 
-        assert_eq!(v.iter().len(), 0);
+        assert_eq!(v.iter().count(), 0);
         v.push(());
-        assert_eq!(v.iter().len(), 1);
+        assert_eq!(v.iter().count(), 1);
         v.push(());
-        assert_eq!(v.iter().len(), 2);
+        assert_eq!(v.iter().count(), 2);
 
         for &() in v.iter() {}
 
-        assert_eq!(v.mut_iter().len(), 2);
+        assert_eq!(v.mut_iter().count(), 2);
         v.push(());
-        assert_eq!(v.mut_iter().len(), 3);
+        assert_eq!(v.mut_iter().count(), 3);
         v.push(());
-        assert_eq!(v.mut_iter().len(), 4);
+        assert_eq!(v.mut_iter().count(), 4);
 
         for &() in v.mut_iter() {}
         unsafe { v.set_len(0); }
-        assert_eq!(v.mut_iter().len(), 0);
+        assert_eq!(v.mut_iter().count(), 0);
     }
 
     #[test]

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -529,11 +529,11 @@ pub trait Iterator<A> {
     /// ```rust
     /// let a = [1, 2, 3, 4, 5];
     /// let mut it = a.iter();
-    /// assert!(it.len() == 5);
-    /// assert!(it.len() == 0);
+    /// assert!(it.count() == 5);
+    /// assert!(it.count() == 0);
     /// ```
     #[inline]
-    fn len(&mut self) -> uint {
+    fn count(&mut self) -> uint {
         self.fold(0, |cnt, _x| cnt + 1)
     }
 
@@ -589,16 +589,6 @@ pub trait Iterator<A> {
             i += 1;
         }
         None
-    }
-
-    /// Count the number of elements satisfying the specified predicate
-    #[inline]
-    fn count(&mut self, predicate: |A| -> bool) -> uint {
-        let mut i = 0;
-        for x in *self {
-            if predicate(x) { i += 1 }
-        }
-        i
     }
 
     /// Return the element that gives the maximum value from the
@@ -737,6 +727,14 @@ pub trait ExactSize<A> : DoubleEndedIterator<A> {
             }
         }
         None
+    }
+
+    #[inline]
+    /// Return the exact length of the iterator.
+    fn len(&self) -> uint {
+        let (lower, upper) = self.size_hint();
+        assert!(upper == Some(lower));
+        lower
     }
 }
 
@@ -2594,9 +2592,9 @@ mod tests {
     #[test]
     fn test_iterator_len() {
         let v = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        assert_eq!(v.slice(0, 4).iter().len(), 4);
-        assert_eq!(v.slice(0, 10).iter().len(), 10);
-        assert_eq!(v.slice(0, 0).iter().len(), 0);
+        assert_eq!(v.slice(0, 4).iter().count(), 4);
+        assert_eq!(v.slice(0, 10).iter().count(), 10);
+        assert_eq!(v.slice(0, 0).iter().count(), 0);
     }
 
     #[test]
@@ -2712,9 +2710,9 @@ mod tests {
     #[test]
     fn test_count() {
         let xs = &[1, 2, 2, 1, 5, 9, 0, 2];
-        assert_eq!(xs.iter().count(|x| *x == 2), 3);
-        assert_eq!(xs.iter().count(|x| *x == 5), 1);
-        assert_eq!(xs.iter().count(|x| *x == 95), 0);
+        assert_eq!(xs.iter().filter(|x| **x == 2).count(), 3);
+        assert_eq!(xs.iter().filter(|x| **x == 5).count(), 1);
+        assert_eq!(xs.iter().filter(|x| **x == 95).count(), 0);
     }
 
     #[test]
@@ -3044,10 +3042,10 @@ mod tests {
         assert!(range(-10i, -1).collect::<Vec<int>>() ==
                    vec![-10, -9, -8, -7, -6, -5, -4, -3, -2]);
         assert!(range(0i, 5).rev().collect::<Vec<int>>() == vec![4, 3, 2, 1, 0]);
-        assert_eq!(range(200, -5).len(), 0);
-        assert_eq!(range(200, -5).rev().len(), 0);
-        assert_eq!(range(200, 200).len(), 0);
-        assert_eq!(range(200, 200).rev().len(), 0);
+        assert_eq!(range(200, -5).count(), 0);
+        assert_eq!(range(200, -5).rev().count(), 0);
+        assert_eq!(range(200, 200).count(), 0);
+        assert_eq!(range(200, 200).rev().count(), 0);
 
         assert_eq!(range(0i, 100).size_hint(), (100, Some(100)));
         // this test is only meaningful when sizeof uint < sizeof u64
@@ -3062,8 +3060,8 @@ mod tests {
                 vec![0i, 1, 2, 3, 4, 5]);
         assert!(range_inclusive(0i, 5).rev().collect::<Vec<int>>() ==
                 vec![5i, 4, 3, 2, 1, 0]);
-        assert_eq!(range_inclusive(200, -5).len(), 0);
-        assert_eq!(range_inclusive(200, -5).rev().len(), 0);
+        assert_eq!(range_inclusive(200, -5).count(), 0);
+        assert_eq!(range_inclusive(200, -5).rev().count(), 0);
         assert!(range_inclusive(200, 200).collect::<Vec<int>>() == vec![200]);
         assert!(range_inclusive(200, 200).rev().collect::<Vec<int>>() == vec![200]);
     }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -252,7 +252,7 @@ pub mod traits {
     use super::*;
 
     use cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering, Equiv};
-    use iter::{order, Iterator};
+    use iter::order;
     use container::Container;
 
     impl<'a,T:PartialEq> PartialEq for &'a [T] {
@@ -1141,7 +1141,6 @@ impl<'a, T:Clone> MutableCloneableVector<T> for &'a mut [T] {
 /// Unsafe operations
 pub mod raw {
     use mem::transmute;
-    use iter::Iterator;
     use ptr::RawPtr;
     use raw::Slice;
     use option::{None, Option, Some};

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -867,7 +867,6 @@ static TAG_CONT_U8: u8 = 128u8;
 pub mod raw {
     use mem;
     use container::Container;
-    use iter::Iterator;
     use ptr::RawPtr;
     use raw::Slice;
     use slice::{ImmutableVector};
@@ -1725,7 +1724,7 @@ impl<'a> StrSlice<'a> for &'a str {
     fn is_alphanumeric(&self) -> bool { self.chars().all(char::is_alphanumeric) }
 
     #[inline]
-    fn char_len(&self) -> uint { self.chars().len() }
+    fn char_len(&self) -> uint { self.chars().count() }
 
     #[inline]
     fn slice(&self, begin: uint, end: uint) -> &'a str {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -351,7 +351,7 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
 fn encode_path<PI: Iterator<PathElem> + Clone>(ebml_w: &mut Encoder,
                                                mut path: PI) {
     ebml_w.start_tag(tag_path);
-    ebml_w.wr_tagged_u32(tag_path_len, path.clone().len() as u32);
+    ebml_w.wr_tagged_u32(tag_path_len, path.clone().count() as u32);
     for pe in path {
         let tag = match pe {
             ast_map::PathMod(_) => tag_path_elem_mod,

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -82,7 +82,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
         ItemFn(..) => {
             if item.ident.name == ctxt.main_name {
                  ctxt.ast_map.with_path(item.id, |mut path| {
-                        if path.len() == 1 {
+                        if path.count() == 1 {
                             // This is a top-level function so can be 'main'
                             if ctxt.main_fn.is_none() {
                                 ctxt.main_fn = Some((item.id, item.span));

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -191,11 +191,11 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
     };
 
     // Convert the type parameters supplied by the user.
-    let supplied_ty_param_count = path.segments.iter().flat_map(|s| s.types.iter()).len();
+    let supplied_ty_param_count = path.segments.iter().flat_map(|s| s.types.iter()).count();
     let formal_ty_param_count = decl_generics.type_param_defs().len();
     let required_ty_param_count = decl_generics.type_param_defs().iter()
                                                .take_while(|x| x.default.is_none())
-                                               .len();
+                                               .count();
     if supplied_ty_param_count < required_ty_param_count {
         let expected = if required_ty_param_count < formal_ty_param_count {
             "expected at least"
@@ -407,7 +407,7 @@ pub fn ast_ty_to_builtin_ty<AC:AstConv,
                     if path.segments
                            .iter()
                            .flat_map(|s| s.types.iter())
-                           .len() > 1 {
+                           .count() > 1 {
                         this.tcx()
                             .sess
                             .span_err(path.span,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1611,7 +1611,7 @@ fn check_type_parameter_positions_in_path(function_context: &FnCtxt,
             let formal_ty_param_count = generics.type_param_defs().len();
             let required_ty_param_count = generics.type_param_defs().iter()
                                                   .take_while(|x| x.default.is_none())
-                                                  .len();
+                                                  .count();
             let supplied_ty_param_count = trait_segment.types.len();
             if supplied_ty_param_count < required_ty_param_count {
                 let msg = if required_ty_param_count < generics.type_param_defs().len() {
@@ -3872,7 +3872,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
     let ty_param_count = tpt.generics.type_param_defs().len();
     let ty_param_req = tpt.generics.type_param_defs().iter()
                                                    .take_while(|x| x.default.is_none())
-                                                   .len();
+                                                   .count();
     let mut ty_substs_len = 0;
     for segment in pth.segments.iter() {
         ty_substs_len += segment.types.len()

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -454,7 +454,7 @@ pub fn parameterized(cx: &ctxt,
                 Some(default) => ty::subst(cx, &substs, default) == actual,
                 None => false
             }
-        }).len()
+        }).count()
     } else {
         0
     };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2042,7 +2042,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<String, Vec<String>> {
 impl<'a> fmt::Show for Source<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Source(s) = *self;
-        let lines = s.lines().len();
+        let lines = s.lines().count();
         let mut cols = 0;
         let mut tmp = lines;
         while tmp > 0 {

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -32,7 +32,7 @@ pub struct Toc {
 
 impl Toc {
     fn count_entries_with_level(&self, level: u32) -> uint {
-        self.entries.iter().count(|e| e.level == level)
+        self.entries.iter().filter(|e| e.level == level).count()
     }
 }
 

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -13,7 +13,6 @@
 use char;
 use clone::Clone;
 use container::Container;
-use iter::Iterator;
 use num::{NumCast, Zero, One, cast, Int};
 use num::{Float, FPNaN, FPInfinite, ToPrimitive};
 use num;

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -353,17 +353,17 @@ mod test {
     #[test]
     fn test_gen_ascii_str() {
         let mut r = task_rng();
-        assert_eq!(r.gen_ascii_chars().take(0).len(), 0u);
-        assert_eq!(r.gen_ascii_chars().take(10).len(), 10u);
-        assert_eq!(r.gen_ascii_chars().take(16).len(), 16u);
+        assert_eq!(r.gen_ascii_chars().take(0).count(), 0u);
+        assert_eq!(r.gen_ascii_chars().take(10).count(), 10u);
+        assert_eq!(r.gen_ascii_chars().take(16).count(), 16u);
     }
 
     #[test]
     fn test_gen_vec() {
         let mut r = task_rng();
-        assert_eq!(r.gen_iter::<u8>().take(0).len(), 0u);
-        assert_eq!(r.gen_iter::<u8>().take(10).len(), 10u);
-        assert_eq!(r.gen_iter::<f64>().take(16).len(), 16u);
+        assert_eq!(r.gen_iter::<u8>().take(0).count(), 0u);
+        assert_eq!(r.gen_iter::<u8>().take(10).count(), 10u);
+        assert_eq!(r.gen_iter::<f64>().take(16).count(), 16u);
     }
 
     #[test]

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -84,7 +84,7 @@ fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
             if i == 0 {
                 valid = chars.next().is_none();
                 break
-            } else if chars.by_ref().take(i - 1).len() != i - 1 {
+            } else if chars.by_ref().take(i - 1).count() != i - 1 {
                 valid = false;
             }
         }

--- a/src/test/run-pass/issue-13204.rs
+++ b/src/test/run-pass/issue-13204.rs
@@ -14,7 +14,7 @@
 pub trait Foo {
     fn bar<'a, I: Iterator<&'a ()>>(&self, it: I) -> uint {
         let mut xs = it.filter(|_| true);
-        xs.len()
+        xs.count()
     }
 }
 


### PR DESCRIPTION
This commit carries out the request from issue #14678:

> The method `Iterator::len()` is surprising, as all the other uses of
> `len()` do not consume the value. `len()` would make more sense to be
> called `count()`, but that would collide with the current
> `Iterator::count(|T| -> bool) -> unit` method. That method, however, is
> a bit redundant, and can be easily replaced with
> `iter.filter(|x| x < 5).count()`.
> After this change, we could then define the `len()` method
> on `iter::ExactSize`.

Closes #14678.

[breaking-change]
