### PR TITLE
url: encode small bytes correctly.

### DIFF
--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -164,10 +164,10 @@ fn encode_inner(s: &str, full_url: bool) -> String {
                     out.push_char(ch);
                   }
 
-                  _ => out.push_str(format!("%{:X}", ch as uint).as_slice())
+                  _ => out.push_str(format!("%{:02X}", ch as uint).as_slice())
                 }
             } else {
-                out.push_str(format!("%{:X}", ch as uint).as_slice());
+                out.push_str(format!("%{:02X}", ch as uint).as_slice());
             }
           }
         }
@@ -1181,6 +1181,8 @@ mod tests {
         assert_eq!(encode("@"), "@".to_string());
         assert_eq!(encode("["), "[".to_string());
         assert_eq!(encode("]"), "]".to_string());
+        assert_eq!(encode("\0"), "%00".to_string());
+        assert_eq!(encode("\n"), "%0A".to_string());
     }
 
     #[test]
@@ -1210,6 +1212,8 @@ mod tests {
         assert_eq!(encode_component("@"), "%40".to_string());
         assert_eq!(encode_component("["), "%5B".to_string());
         assert_eq!(encode_component("]"), "%5D".to_string());
+        assert_eq!(encode_component("\0"), "%00".to_string());
+        assert_eq!(encode_component("\n"), "%0A".to_string());
     }
 
     #[test]


### PR DESCRIPTION
url: encode small bytes correctly.

Previously, bytes less than 16 would be encoded as %X, rather than %XX,
since the output width was left to be automatic.
