### PR TITLE
mk: Run doc tests with --cfg dox

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -818,7 +818,7 @@ endif
 ifeq ($(2),$$(CFG_BUILD))
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)): $$(CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4))
 	@$$(call E, run doc-crate-$(4) [$(2)])
-	$$(Q)$$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --test \
+	$$(Q)$$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --test --cfg dox \
 	    	$$(CRATEFILE_$(4)) --test-args "$$(TESTARGS)" && touch $$@
 else
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)):

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -465,7 +465,7 @@ pub mod builtin {
     /// ```
     /// let rust = bytes!("r", 'u', "st", 255);
     /// assert_eq!(rust[1], 'u' as u8);
-    /// assert_eq!(rust[5], 255);
+    /// assert_eq!(rust[4], 255);
     /// ```
     #[macro_export]
     macro_rules! bytes( ($($e:expr),*) => ({ /* compiler built-in */ }) )
@@ -482,10 +482,14 @@ pub mod builtin {
     /// # Example
     ///
     /// ```
+    /// #![feature(concat_idents)]
+    ///
+    /// # fn main() {
     /// fn foobar() -> int { 23 }
     ///
     /// let f = concat_idents!(foo, bar);
     /// println!("{}", f());
+    /// # }
     /// ```
     #[macro_export]
     macro_rules! concat_idents( ($($e:ident),*) => ({ /* compiler built-in */ }) )


### PR DESCRIPTION
There were a few examples in the macros::builtin module that weren't being run
because they were being #[cfg]'d out.

Closes #14697
