### PR TITLE
Removing unused wrapper to libc::close.

### DIFF
--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -56,12 +56,6 @@ use libc::c_char;
 #[cfg(windows)]
 use str::OwnedStr;
 
-/// Delegates to the libc close() function, returning the same return value.
-pub fn close(fd: int) -> int {
-    unsafe {
-        libc::close(fd as c_int) as int
-    }
-}
 
 pub static TMPBUF_SZ : uint = 1000u;
 static BUF_BYTES : uint = 2048u;


### PR DESCRIPTION
It's not used and it passes the test after removing.
And some function inside rust repository reimplement it in severals ways like in: 
`src/libnative/io/helper_thread.rs`:

``` rust
169:    pub fn close(fd: libc::c_int) {
170-        let _fd = FileDesc::new(fd, true);
171-    }
172-}
```

Or directly use `libc::CloseHandler`
`src/libnative/io/helper_thread.rs`:

``` rust
194:    pub fn close(handle: HANDLE) {
195-        assert!(unsafe { CloseHandle(handle) != 0 });
196-    }
```

Or `libc::close`:
`src/librustdoc/flock.rs`:

``` rust
108-            if ret == -1 {
109:                unsafe { libc::close(fd); }
110-                fail!("could not lock `{}`", p.display())
111-            }
```
