### PR TITLE
Rolling up PRs in the queue

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -43,7 +43,9 @@ L10N_LANGS := ja
 
 # The options are passed to the documentation generators.
 RUSTDOC_HTML_OPTS_NO_CSS = --markdown-before-content=doc/version_info.html \
-	--markdown-in-header=doc/favicon.inc --markdown-after-content=doc/footer.inc
+	--markdown-in-header=doc/favicon.inc \
+	--markdown-after-content=doc/footer.inc \
+	--markdown-playground-url='http://play.rust-lang.org/'
 
 RUSTDOC_HTML_OPTS = $(RUSTDOC_HTML_OPTS_NO_CSS) --markdown-css rust.css
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -818,7 +818,7 @@ endif
 ifeq ($(2),$$(CFG_BUILD))
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)): $$(CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4))
 	@$$(call E, run doc-crate-$(4) [$(2)])
-	$$(Q)$$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --test \
+	$$(Q)$$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --test --cfg dox \
 	    	$$(CRATEFILE_$(4)) --test-args "$$(TESTARGS)" && touch $$@
 else
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)):

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1545,7 +1545,7 @@ fn disassemble_extract(config: &Config, _props: &TestProps,
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end().unwrap();
     let x = str::from_utf8(x.as_slice()).unwrap();
-    x.lines().len()
+    x.lines().count()
 }
 
 

--- a/src/doc/footer.inc
+++ b/src/doc/footer.inc
@@ -5,3 +5,5 @@ or the <a href="http://opensource.org/licenses/MIT">MIT license</a>, at your opt
 </p><p>
 This file may not be copied, modified, or distributed except according to those terms.
 </p></footer>
+<script type="text/javascript" src="jquery.js"></script>
+<script type="text/javascript" src="playpen.js"></script>

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -523,6 +523,7 @@ vectors provided from C, using idiomatic Rust practices.
 
 ```
 #![no_std]
+#![feature(globs)]
 
 # extern crate libc;
 extern crate core;

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -313,6 +313,19 @@ table th {
     padding: 5px;
 }
 
+/* Code snippets */
+
+.rusttest { display: none; }
+pre.rust { position: relative; }
+pre.rust a { transform: scaleX(-1); }
+.test-arrow {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 10px;
+    font-size: 150%;
+}
+
 @media (min-width: 1170px) {
     pre {
         font-size: 15px;

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1260,6 +1260,8 @@ a = Cat;
 Enumeration constructors can have either named or unnamed fields:
 
 ~~~~
+# #![feature(struct_variant)]
+# fn main() {
 enum Animal {
     Dog (String, f64),
     Cat { name: String, weight: f64 }
@@ -1267,6 +1269,7 @@ enum Animal {
 
 let mut a: Animal = Dog("Cocoa".to_string(), 37.2);
 a = Cat { name: "Spotty".to_string(), weight: 2.7 };
+# }
 ~~~~
 
 In this example, `Cat` is a _struct-like enum variant_,

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -774,6 +774,7 @@ fn point_from_direction(dir: Direction) -> Point {
 Enum variants may also be structs. For example:
 
 ~~~~
+# #![feature(struct_variant)]
 use std::f64;
 # struct Point { x: f64, y: f64 }
 # fn square(x: f64) -> f64 { x * x }
@@ -789,6 +790,7 @@ fn area(sh: Shape) -> f64 {
         }
     }
 }
+# fn main() {}
 ~~~~
 
 > *Note:* This feature of the compiler is currently gated behind the
@@ -3046,6 +3048,7 @@ use farm::{chicken, cow};
 2. Import everything in a module with a wildcard:
 
 ~~~
+# #![feature(globs)]
 use farm::*;
 # mod farm {
 #     pub fn cow() { println!("Bat-chicken? What a stupid name!") }

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -241,17 +241,17 @@ enum Op {Union, Intersect, Assign, Difference}
 /// bv.set(5, true);
 /// bv.set(7, true);
 /// println!("{}", bv.to_str());
-/// println!("total bits set to true: {}", bv.iter().count(|x| x));
+/// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 ///
 /// // flip all values in bitvector, producing non-primes less than 10
 /// bv.negate();
 /// println!("{}", bv.to_str());
-/// println!("total bits set to true: {}", bv.iter().count(|x| x));
+/// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 ///
 /// // reset bitvector to empty
 /// bv.clear();
 /// println!("{}", bv.to_str());
-/// println!("total bits set to true: {}", bv.iter().count(|x| x));
+/// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 /// ```
 #[deriving(Clone)]
 pub struct Bitv {
@@ -461,7 +461,7 @@ impl Bitv {
     /// bv.set(5, true);
     /// bv.set(8, true);
     /// // Count bits set to 1; result should be 5
-    /// println!("{}", bv.iter().count(|x| x));
+    /// println!("{}", bv.iter().filter(|x| *x).count());
     /// ```
     #[inline]
     pub fn iter<'a>(&'a self) -> Bits<'a> {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1131,7 +1131,7 @@ mod tests {
         let v = &[0, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.iter().len() == 128);
+            assert!(m.iter().count() == 128);
         })
     }
     #[bench]
@@ -1139,7 +1139,7 @@ mod tests {
         let v = &[0, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.mut_iter().len() == 128);
+            assert!(m.mut_iter().count() == 128);
         })
     }
     #[bench]
@@ -1147,7 +1147,7 @@ mod tests {
         let v = &[0, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.iter().rev().len() == 128);
+            assert!(m.iter().rev().count() == 128);
         })
     }
     #[bench]
@@ -1155,7 +1155,7 @@ mod tests {
         let v = &[0, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
-            assert!(m.mut_iter().rev().len() == 128);
+            assert!(m.mut_iter().rev().count() == 128);
         })
     }
 }

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -17,7 +17,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(macro_rules, managed_boxes, default_type_params, phase, globs)]
 #![no_std]

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2155,7 +2155,7 @@ mod tests {
     #[test]
     fn test_mut_splitator() {
         let mut xs = [0,1,0,2,3,0,0,4,5,0];
-        assert_eq!(xs.mut_split(|x| *x == 0).len(), 6);
+        assert_eq!(xs.mut_split(|x| *x == 0).count(), 6);
         for slice in xs.mut_split(|x| *x == 0) {
             slice.reverse();
         }

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -31,7 +31,7 @@ pub struct SmallIntMap<T> {
 impl<V> Container for SmallIntMap<V> {
     /// Return the number of elements in the map
     fn len(&self) -> uint {
-        self.v.iter().count(|elt| elt.is_some())
+        self.v.iter().filter(|elt| elt.is_some()).count()
     }
 
     /// Return true if there are no elements in the map

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -2181,7 +2181,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars().len(), len));
+        b.iter(|| assert_eq!(s.chars().count(), len));
     }
 
     #[bench]
@@ -2194,7 +2194,7 @@ mod bench {
         Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars().len(), len));
+        b.iter(|| assert_eq!(s.chars().count(), len));
     }
 
     #[bench]
@@ -2202,7 +2202,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.chars().rev().len(), len));
+        b.iter(|| assert_eq!(s.chars().rev().count(), len));
     }
 
     #[bench]
@@ -2210,7 +2210,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices().len(), len));
+        b.iter(|| assert_eq!(s.char_indices().count(), len));
     }
 
     #[bench]
@@ -2218,14 +2218,14 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices().rev().len(), len));
+        b.iter(|| assert_eq!(s.char_indices().rev().count(), len));
     }
 
     #[bench]
     fn split_unicode_ascii(b: &mut Bencher) {
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
-        b.iter(|| assert_eq!(s.split('V').len(), 3));
+        b.iter(|| assert_eq!(s.split('V').count(), 3));
     }
 
     #[bench]
@@ -2240,16 +2240,16 @@ mod bench {
         }
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
-        b.iter(|| assert_eq!(s.split(NotAscii('V')).len(), 3));
+        b.iter(|| assert_eq!(s.split(NotAscii('V')).count(), 3));
     }
 
 
     #[bench]
     fn split_ascii(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(' ').len(), len));
+        b.iter(|| assert_eq!(s.split(' ').count(), len));
     }
 
     #[bench]
@@ -2264,34 +2264,34 @@ mod bench {
             fn only_ascii(&self) -> bool { false }
         }
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(NotAscii(' ')).len(), len));
+        b.iter(|| assert_eq!(s.split(NotAscii(' ')).count(), len));
     }
 
     #[bench]
     fn split_extern_fn(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
         fn pred(c: char) -> bool { c == ' ' }
 
-        b.iter(|| assert_eq!(s.split(pred).len(), len));
+        b.iter(|| assert_eq!(s.split(pred).count(), len));
     }
 
     #[bench]
     fn split_closure(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(|c: char| c == ' ').len(), len));
+        b.iter(|| assert_eq!(s.split(|c: char| c == ' ').count(), len));
     }
 
     #[bench]
     fn split_slice(b: &mut Bencher) {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
-        let len = s.split(' ').len();
+        let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(&[' ']).len(), len));
+        b.iter(|| assert_eq!(s.split(&[' ']).count(), len));
     }
 
     #[bench]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1772,23 +1772,23 @@ mod tests {
         assert_eq!(v.pop(), Some(()));
         assert_eq!(v.pop(), None);
 
-        assert_eq!(v.iter().len(), 0);
+        assert_eq!(v.iter().count(), 0);
         v.push(());
-        assert_eq!(v.iter().len(), 1);
+        assert_eq!(v.iter().count(), 1);
         v.push(());
-        assert_eq!(v.iter().len(), 2);
+        assert_eq!(v.iter().count(), 2);
 
         for &() in v.iter() {}
 
-        assert_eq!(v.mut_iter().len(), 2);
+        assert_eq!(v.mut_iter().count(), 2);
         v.push(());
-        assert_eq!(v.mut_iter().len(), 3);
+        assert_eq!(v.mut_iter().count(), 3);
         v.push(());
-        assert_eq!(v.mut_iter().len(), 4);
+        assert_eq!(v.mut_iter().count(), 4);
 
         for &() in v.mut_iter() {}
         unsafe { v.set_len(0); }
-        assert_eq!(v.mut_iter().len(), 0);
+        assert_eq!(v.mut_iter().count(), 0);
     }
 
     #[test]

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -529,11 +529,11 @@ pub trait Iterator<A> {
     /// ```rust
     /// let a = [1, 2, 3, 4, 5];
     /// let mut it = a.iter();
-    /// assert!(it.len() == 5);
-    /// assert!(it.len() == 0);
+    /// assert!(it.count() == 5);
+    /// assert!(it.count() == 0);
     /// ```
     #[inline]
-    fn len(&mut self) -> uint {
+    fn count(&mut self) -> uint {
         self.fold(0, |cnt, _x| cnt + 1)
     }
 
@@ -589,16 +589,6 @@ pub trait Iterator<A> {
             i += 1;
         }
         None
-    }
-
-    /// Count the number of elements satisfying the specified predicate
-    #[inline]
-    fn count(&mut self, predicate: |A| -> bool) -> uint {
-        let mut i = 0;
-        for x in *self {
-            if predicate(x) { i += 1 }
-        }
-        i
     }
 
     /// Return the element that gives the maximum value from the
@@ -737,6 +727,14 @@ pub trait ExactSize<A> : DoubleEndedIterator<A> {
             }
         }
         None
+    }
+
+    #[inline]
+    /// Return the exact length of the iterator.
+    fn len(&self) -> uint {
+        let (lower, upper) = self.size_hint();
+        assert!(upper == Some(lower));
+        lower
     }
 }
 
@@ -2594,9 +2592,9 @@ mod tests {
     #[test]
     fn test_iterator_len() {
         let v = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        assert_eq!(v.slice(0, 4).iter().len(), 4);
-        assert_eq!(v.slice(0, 10).iter().len(), 10);
-        assert_eq!(v.slice(0, 0).iter().len(), 0);
+        assert_eq!(v.slice(0, 4).iter().count(), 4);
+        assert_eq!(v.slice(0, 10).iter().count(), 10);
+        assert_eq!(v.slice(0, 0).iter().count(), 0);
     }
 
     #[test]
@@ -2712,9 +2710,9 @@ mod tests {
     #[test]
     fn test_count() {
         let xs = &[1, 2, 2, 1, 5, 9, 0, 2];
-        assert_eq!(xs.iter().count(|x| *x == 2), 3);
-        assert_eq!(xs.iter().count(|x| *x == 5), 1);
-        assert_eq!(xs.iter().count(|x| *x == 95), 0);
+        assert_eq!(xs.iter().filter(|x| **x == 2).count(), 3);
+        assert_eq!(xs.iter().filter(|x| **x == 5).count(), 1);
+        assert_eq!(xs.iter().filter(|x| **x == 95).count(), 0);
     }
 
     #[test]
@@ -3044,10 +3042,10 @@ mod tests {
         assert!(range(-10i, -1).collect::<Vec<int>>() ==
                    vec![-10, -9, -8, -7, -6, -5, -4, -3, -2]);
         assert!(range(0i, 5).rev().collect::<Vec<int>>() == vec![4, 3, 2, 1, 0]);
-        assert_eq!(range(200, -5).len(), 0);
-        assert_eq!(range(200, -5).rev().len(), 0);
-        assert_eq!(range(200, 200).len(), 0);
-        assert_eq!(range(200, 200).rev().len(), 0);
+        assert_eq!(range(200, -5).count(), 0);
+        assert_eq!(range(200, -5).rev().count(), 0);
+        assert_eq!(range(200, 200).count(), 0);
+        assert_eq!(range(200, 200).rev().count(), 0);
 
         assert_eq!(range(0i, 100).size_hint(), (100, Some(100)));
         // this test is only meaningful when sizeof uint < sizeof u64
@@ -3062,8 +3060,8 @@ mod tests {
                 vec![0i, 1, 2, 3, 4, 5]);
         assert!(range_inclusive(0i, 5).rev().collect::<Vec<int>>() ==
                 vec![5i, 4, 3, 2, 1, 0]);
-        assert_eq!(range_inclusive(200, -5).len(), 0);
-        assert_eq!(range_inclusive(200, -5).rev().len(), 0);
+        assert_eq!(range_inclusive(200, -5).count(), 0);
+        assert_eq!(range_inclusive(200, -5).rev().count(), 0);
         assert!(range_inclusive(200, 200).collect::<Vec<int>>() == vec![200]);
         assert!(range_inclusive(200, 200).rev().collect::<Vec<int>>() == vec![200]);
     }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -50,7 +50,8 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![no_std]
 #![feature(globs, macro_rules, managed_boxes, phase, simd)]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -252,7 +252,7 @@ pub mod traits {
     use super::*;
 
     use cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering, Equiv};
-    use iter::{order, Iterator};
+    use iter::order;
     use container::Container;
 
     impl<'a,T:PartialEq> PartialEq for &'a [T] {
@@ -1141,7 +1141,6 @@ impl<'a, T:Clone> MutableCloneableVector<T> for &'a mut [T] {
 /// Unsafe operations
 pub mod raw {
     use mem::transmute;
-    use iter::Iterator;
     use ptr::RawPtr;
     use raw::Slice;
     use option::{None, Option, Some};

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -867,7 +867,6 @@ static TAG_CONT_U8: u8 = 128u8;
 pub mod raw {
     use mem;
     use container::Container;
-    use iter::Iterator;
     use ptr::RawPtr;
     use raw::Slice;
     use slice::{ImmutableVector};
@@ -1725,7 +1724,7 @@ impl<'a> StrSlice<'a> for &'a str {
     fn is_alphanumeric(&self) -> bool { self.chars().all(char::is_alphanumeric) }
 
     #[inline]
-    fn char_len(&self) -> uint { self.chars().len() }
+    fn char_len(&self) -> uint { self.chars().count() }
 
     #[inline]
     fn slice(&self, begin: uint, end: uint) -> &'a str {

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -84,7 +84,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![feature(globs, phase)]
 #![deny(missing_doc)]
 #![deny(deprecated_owned_vector)]

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -29,8 +29,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
-
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![deny(deprecated_owned_vector)]
 
 use std::cell::Cell;

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -203,7 +203,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 // NB this does *not* include globs, please keep it that way.
 #![feature(macro_rules, phase)]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -111,7 +111,8 @@ if logging is disabled, none of the components of the log will be executed.
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(macro_rules)]
 #![deny(missing_doc, deprecated_owned_vector)]

--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -50,7 +50,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![deny(deprecated_owned_vector)]
 

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -21,7 +21,8 @@
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(macro_rules, phase, globs)]
 #![no_std]

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -360,7 +360,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(macro_rules, phase)]
 #![deny(missing_doc, deprecated_owned_vector)]

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -109,7 +109,7 @@ impl<'a> Archive<'a> {
     pub fn add_rlib(&mut self, rlib: &Path, name: &str,
                     lto: bool) -> io::IoResult<()> {
         let object = format!("{}.o", name);
-        let bytecode = format!("{}.bc.deflate", name);
+        let bytecode = format!("{}.bytecode.deflate", name);
         let mut ignore = vec!(bytecode.as_slice(), METADATA_FILENAME);
         if lto {
             ignore.push(object.as_slice());

--- a/src/librustc/back/archive.rs
+++ b/src/librustc/back/archive.rs
@@ -166,6 +166,15 @@ impl<'a> Archive<'a> {
             if filename.contains(".SYMDEF") { continue }
 
             let filename = format!("r-{}-{}", name, filename);
+            // LLDB (as mentioned in back::link) crashes on filenames of exactly
+            // 16 bytes in length. If we're including an object file with
+            // exactly 16-bytes of characters, give it some prefix so that it's
+            // not 16 bytes.
+            let filename = if filename.len() == 16 {
+                format!("lldb-fix-{}", filename)
+            } else {
+                filename
+            };
             let new_filename = file.with_filename(filename);
             try!(fs::rename(file, &new_filename));
             inputs.push(new_filename);

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -958,8 +958,12 @@ fn link_rlib<'a>(sess: &'a Session,
 
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
+            // Note that we make sure that the bytecode filename in the archive is always at least
+            // 16 bytes long by adding a 16 byte extension to it. This is to work around a bug in
+            // LLDB that would cause it to crash if the name of a file in an archive was exactly
+            // 16 bytes.
             let bc = obj_filename.with_extension("bc");
-            let bc_deflated = obj_filename.with_extension("bc.deflate");
+            let bc_deflated = obj_filename.with_extension("bytecode.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {
                 fs::File::create(&bc_deflated)
                     .write(match flate::deflate_bytes(data.as_slice()) {

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -958,10 +958,11 @@ fn link_rlib<'a>(sess: &'a Session,
 
             // For LTO purposes, the bytecode of this library is also inserted
             // into the archive.
-            // Note that we make sure that the bytecode filename in the archive is always at least
-            // 16 bytes long by adding a 16 byte extension to it. This is to work around a bug in
-            // LLDB that would cause it to crash if the name of a file in an archive was exactly
-            // 16 bytes.
+            //
+            // Note that we make sure that the bytecode filename in the archive
+            // is never exactly 16 bytes long by adding a 16 byte extension to
+            // it. This is to work around a bug in LLDB that would cause it to
+            // crash if the name of a file in an archive was exactly 16 bytes.
             let bc = obj_filename.with_extension("bc");
             let bc_deflated = obj_filename.with_extension("bytecode.deflate");
             match fs::File::open(&bc).read_to_end().and_then(|data| {

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -55,10 +55,10 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         let archive = ArchiveRO::open(&path).expect("wanted an rlib");
         debug!("reading {}", name);
         let bc = time(sess.time_passes(),
-                      format!("read {}.bc.deflate", name).as_slice(),
+                      format!("read {}.bytecode.deflate", name).as_slice(),
                       (),
                       |_| {
-                          archive.read(format!("{}.bc.deflate",
+                          archive.read(format!("{}.bytecode.deflate",
                                                name).as_slice())
                       });
         let bc = bc.expect("missing compressed bytecode in archive!");

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -209,6 +209,9 @@ pub static tag_dylib_dependency_formats: uint = 0x67;
 pub static tag_method_argument_names: uint = 0x8e;
 pub static tag_method_argument_name: uint = 0x8f;
 
+pub static tag_reachable_extern_fns: uint = 0x90;
+pub static tag_reachable_extern_fn_id: uint = 0x91;
+
 #[deriving(Clone, Show)]
 pub struct LinkMeta {
     pub crateid: CrateId,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -314,3 +314,10 @@ pub fn get_method_arg_names(cstore: &cstore::CStore, did: ast::DefId)
     let cdata = cstore.get_crate_data(did.krate);
     decoder::get_method_arg_names(&*cdata, did.node)
 }
+
+pub fn get_reachable_extern_fns(cstore: &cstore::CStore, cnum: ast::CrateNum)
+    -> Vec<ast::DefId>
+{
+    let cdata = cstore.get_crate_data(cnum);
+    decoder::get_reachable_extern_fns(&*cdata)
+}

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1325,3 +1325,17 @@ pub fn get_method_arg_names(cdata: Cmd, id: ast::NodeId) -> Vec<String> {
     }
     return ret;
 }
+
+pub fn get_reachable_extern_fns(cdata: Cmd) -> Vec<ast::DefId> {
+    let mut ret = Vec::new();
+    let items = reader::get_doc(ebml::Doc::new(cdata.data()),
+                                tag_reachable_extern_fns);
+    reader::tagged_docs(items, tag_reachable_extern_fn_id, |doc| {
+        ret.push(ast::DefId {
+            krate: cdata.cnum,
+            node: reader::doc_as_u32(doc),
+        });
+        true
+    });
+    return ret;
+}

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -351,7 +351,7 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
 fn encode_path<PI: Iterator<PathElem> + Clone>(ebml_w: &mut Encoder,
                                                mut path: PI) {
     ebml_w.start_tag(tag_path);
-    ebml_w.wr_tagged_u32(tag_path_len, path.clone().len() as u32);
+    ebml_w.wr_tagged_u32(tag_path_len, path.clone().count() as u32);
     for pe in path {
         let tag = match pe {
             ast_map::PathMod(_) => tag_path_elem_mod,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1196,6 +1196,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
                 &Required(ref tm) => {
                     encode_attributes(ebml_w, tm.attrs.as_slice());
                     encode_method_sort(ebml_w, 'r');
+                    encode_method_argument_names(ebml_w, &*tm.decl);
                 }
 
                 &Provided(m) => {
@@ -1210,6 +1211,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
                     encode_method_sort(ebml_w, 'p');
                     encode_inlined_item(ecx, ebml_w,
                                         IIMethodRef(def_id, true, m));
+                    encode_method_argument_names(ebml_w, &*m.decl);
                 }
             }
 

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -82,7 +82,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
         ItemFn(..) => {
             if item.ident.name == ctxt.main_name {
                  ctxt.ast_map.with_path(item.id, |mut path| {
-                        if path.len() == 1 {
+                        if path.count() == 1 {
                             // This is a top-level function so can be 'main'
                             if ctxt.main_fn.is_none() {
                                 ctxt.main_fn = Some((item.id, item.span));

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1297,8 +1297,8 @@ fn trans_eager_binop<'a>(
             FDiv(bcx, lhs, rhs)
         } else {
             // Only zero-check integers; fp /0 is NaN
-            bcx = base::fail_if_zero(bcx, binop_expr.span,
-                                     op, rhs, rhs_t);
+            bcx = base::fail_if_zero_or_overflows(bcx, binop_expr.span,
+                                                  op, lhs, rhs, rhs_t);
             if is_signed {
                 SDiv(bcx, lhs, rhs)
             } else {
@@ -1311,8 +1311,8 @@ fn trans_eager_binop<'a>(
             FRem(bcx, lhs, rhs)
         } else {
             // Only zero-check integers; fp %0 is NaN
-            bcx = base::fail_if_zero(bcx, binop_expr.span,
-                                     op, rhs, rhs_t);
+            bcx = base::fail_if_zero_or_overflows(bcx, binop_expr.span,
+                                                  op, lhs, rhs, rhs_t);
             if is_signed {
                 SRem(bcx, lhs, rhs)
             } else {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -191,11 +191,11 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
     };
 
     // Convert the type parameters supplied by the user.
-    let supplied_ty_param_count = path.segments.iter().flat_map(|s| s.types.iter()).len();
+    let supplied_ty_param_count = path.segments.iter().flat_map(|s| s.types.iter()).count();
     let formal_ty_param_count = decl_generics.type_param_defs().len();
     let required_ty_param_count = decl_generics.type_param_defs().iter()
                                                .take_while(|x| x.default.is_none())
-                                               .len();
+                                               .count();
     if supplied_ty_param_count < required_ty_param_count {
         let expected = if required_ty_param_count < formal_ty_param_count {
             "expected at least"
@@ -407,7 +407,7 @@ pub fn ast_ty_to_builtin_ty<AC:AstConv,
                     if path.segments
                            .iter()
                            .flat_map(|s| s.types.iter())
-                           .len() > 1 {
+                           .count() > 1 {
                         this.tcx()
                             .sess
                             .span_err(path.span,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1615,7 +1615,7 @@ fn check_type_parameter_positions_in_path(function_context: &FnCtxt,
             let formal_ty_param_count = generics.type_param_defs().len();
             let required_ty_param_count = generics.type_param_defs().iter()
                                                   .take_while(|x| x.default.is_none())
-                                                  .len();
+                                                  .count();
             let supplied_ty_param_count = trait_segment.types.len();
             if supplied_ty_param_count < required_ty_param_count {
                 let msg = if required_ty_param_count < generics.type_param_defs().len() {
@@ -3876,7 +3876,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
     let ty_param_count = tpt.generics.type_param_defs().len();
     let ty_param_req = tpt.generics.type_param_defs().iter()
                                                    .take_while(|x| x.default.is_none())
-                                                   .len();
+                                                   .count();
     let mut ty_substs_len = 0;
     for segment in pth.segments.iter() {
         ty_substs_len += segment.types.len()

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -432,7 +432,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
                 // function check_cast_for_escaping_regions() in kind.rs
                 // explaining how it goes about doing that.
 
-                let source_ty = rcx.fcx.expr_ty(expr);
+                let source_ty = rcx.resolve_node_type(expr.id);
                 constrain_regions_in_type(rcx, trait_region,
                                             infer::RelateObjectBound(expr.span), source_ty);
             }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -260,7 +260,14 @@ impl<'cx> WritebackCx<'cx> {
                         })
                     }
 
-                    adjustment => adjustment
+                    ty::AutoObject(trait_store, bb, def_id, substs) => {
+                        ty::AutoObject(
+                            self.resolve(&trait_store, reason),
+                            self.resolve(&bb, reason),
+                            def_id,
+                            self.resolve(&substs, reason)
+                        )
+                    }
                 };
                 debug!("Adjustments for node {}: {:?}", id, resolved_adjustment);
                 self.tcx().adjustments.borrow_mut().insert(

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -456,7 +456,7 @@ pub fn parameterized(cx: &ctxt,
                 Some(default) => default.subst(cx, &substs) == actual,
                 None => false
             }
-        }).len()
+        }).count()
     } else {
         0
     };

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -88,6 +88,10 @@ fn try_inline_def(cx: &core::DocContext,
             record_extern_fqn(cx, did, clean::TypeModule);
             clean::ModuleItem(build_module(cx, tcx, did))
         }
+        ast::DefStatic(did, mtbl) => {
+            record_extern_fqn(cx, did, clean::TypeStatic);
+            clean::StaticItem(build_static(tcx, did, mtbl))
+        }
         _ => return None,
     };
     let fqn = csearch::get_item_path(tcx, did);
@@ -341,5 +345,15 @@ fn build_module(cx: &core::DocContext, tcx: &ty::ctxt,
     clean::Module {
         items: items,
         is_crate: false,
+    }
+}
+
+fn build_static(tcx: &ty::ctxt,
+                did: ast::DefId,
+                mutable: bool) -> clean::Static {
+    clean::Static {
+        type_: ty::lookup_item_type(tcx, did).ty.clean(),
+        mutability: if mutable {clean::Mutable} else {clean::Immutable},
+        expr: "\n\n\n".to_string(), // trigger the "[definition]" links
     }
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -88,7 +88,7 @@ fn try_inline_def(cx: &core::DocContext,
             record_extern_fqn(cx, did, clean::TypeModule);
             clean::ModuleItem(build_module(cx, tcx, did))
         }
-        ast::DefStatic(did, mtbl) => {
+        def::DefStatic(did, mtbl) => {
             record_extern_fqn(cx, did, clean::TypeStatic);
             clean::StaticItem(build_static(tcx, did, mtbl))
         }

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -25,7 +25,7 @@ use html::escape::Escape;
 use t = syntax::parse::token;
 
 /// Highlights some source code, returning the HTML output.
-pub fn highlight(src: &str, class: Option<&str>) -> String {
+pub fn highlight(src: &str, class: Option<&str>, id: Option<&str>) -> String {
     debug!("highlighting: ================\n{}\n==============", src);
     let sess = parse::new_parse_sess();
     let fm = parse::string_to_filemap(&sess,
@@ -36,6 +36,7 @@ pub fn highlight(src: &str, class: Option<&str>) -> String {
     doit(&sess,
          lexer::StringReader::new(&sess.span_diagnostic, fm),
          class,
+         id,
          &mut out).unwrap();
     str::from_utf8_lossy(out.unwrap().as_slice()).to_string()
 }
@@ -47,11 +48,17 @@ pub fn highlight(src: &str, class: Option<&str>) -> String {
 /// it's used. All source code emission is done as slices from the source map,
 /// not from the tokens themselves, in order to stay true to the original
 /// source.
-fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader, class: Option<&str>,
+fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
+        class: Option<&str>, id: Option<&str>,
         out: &mut Writer) -> io::IoResult<()> {
     use syntax::parse::lexer::Reader;
 
-    try!(write!(out, "<pre class='rust {}'>\n", class.unwrap_or("")));
+    try!(write!(out, "<pre "));
+    match id {
+        Some(id) => try!(write!(out, "id='{}' ", id)),
+        None => {}
+    }
+    try!(write!(out, "class='rust {}'>\n", class.unwrap_or("")));
     let mut last = BytePos(0);
     let mut is_attribute = false;
     let mut is_macro = false;

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -16,6 +16,7 @@ pub struct Layout {
     pub logo: String,
     pub favicon: String,
     pub krate: String,
+    pub playground_url: String,
 }
 
 pub struct Page<'a> {
@@ -108,11 +109,13 @@ r##"<!DOCTYPE html>
     </div>
 
     <script>
-        var rootPath = "{root_path}";
-        var currentCrate = "{krate}";
+        window.rootPath = "{root_path}";
+        window.currentCrate = "{krate}";
+        window.playgroundUrl = "{play_url}";
     </script>
     <script src="{root_path}jquery.js"></script>
     <script src="{root_path}main.js"></script>
+    {play_js}
     <script async src="{root_path}search-index.js"></script>
 </body>
 </html>"##,
@@ -124,6 +127,12 @@ r##"<!DOCTYPE html>
     favicon   = nonestr(layout.favicon.as_slice()),
     sidebar   = *sidebar,
     krate     = layout.krate,
+    play_url  = layout.playground_url,
+    play_js   = if layout.playground_url.len() == 0 {
+        "".to_string()
+    } else {
+        format!(r#"<script src="{}playpen.js"></script>"#, page.root_path)
+    },
     )
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2043,7 +2043,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<String, Vec<String>> {
 impl<'a> fmt::Show for Source<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Source(s) = *self;
-        let lines = s.lines().len();
+        let lines = s.lines().count();
         let mut cols = 0;
         let mut tmp = lines;
         while tmp > 0 {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -51,7 +51,7 @@ use rustc::util::nodemap::NodeSet;
 use clean;
 use doctree;
 use fold::DocFolder;
-use html::format::{VisSpace, Method, FnStyleSpace};
+use html::format::{VisSpace, Method, FnStyleSpace, MutableSpace};
 use html::highlight;
 use html::item_type::{ItemType, shortty};
 use html::item_type;
@@ -1441,11 +1441,12 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
 
                 try!(write!(w, "
                     <tr>
-                        <td><code>{}static {}: {}</code>{}</td>
+                        <td><code>{}static {}{}: {}</code>{}</td>
                         <td class='docblock'>{}&nbsp;</td>
                     </tr>
                 ",
                 VisSpace(myitem.visibility),
+                MutableSpace(s.mutability),
                 *myitem.name.get_ref(),
                 s.type_,
                 Initializer(s.expr.as_slice(), Item { cx: cx, item: myitem }),

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -156,7 +156,7 @@ nav.sub {
     padding: 0 10px;
     margin-bottom: 10px;
 }
-.block h2 { 
+.block h2 {
     margin-top: 0;
     text-align: center;
 }
@@ -395,6 +395,17 @@ pre.rust .comment { color: #8E908C; }
 pre.rust .doccomment { color: #4D4D4C; }
 pre.rust .macro, pre.rust .macro-nonterminal { color: #3E999F; }
 pre.rust .lifetime { color: #B76514; }
+
+.rusttest { display: none; }
+pre.rust { position: relative; }
+pre.rust a { transform: scaleX(-1); }
+.test-arrow {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    right: 10px;
+    font-size: 150%;
+}
 
 .methods .section-header {
     /* Override parent class attributes. */

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -678,7 +678,7 @@
         window.register_implementors(window.pending_implementors);
     }
 
-    // See documentaiton in html/render.rs for what this is doing.
+    // See documentation in html/render.rs for what this is doing.
     var query = getQueryStringParams();
     if (query['gotosrc']) {
         window.location = $('#src-' + query['gotosrc']).attr('href');

--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/*jslint browser: true, es5: true */
+/*globals $: true, rootPath: true */
+
+(function() {
+    if (window.playgroundUrl) {
+        $('pre.rust').hover(function() {
+            var id = '#' + $(this).attr('id').replace('rendered', 'raw');
+            var a = $('<a>').text('⇱').attr('class', 'test-arrow');
+            var code = $(id).text();
+            a.attr('href', window.playgroundUrl + '?code=' +
+                           encodeURIComponent(code));
+            a.attr('target', '_blank');
+            $(this).append(a);
+        }, function() {
+            $(this).find('a').remove();
+        });
+    }
+}());
+

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -32,7 +32,7 @@ pub struct Toc {
 
 impl Toc {
     fn count_entries_with_level(&self, level: u32) -> uint {
-        self.entries.iter().count(|e| e.level == level)
+        self.entries.iter().filter(|e| e.level == level).count()
     }
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -126,7 +126,9 @@ pub fn opts() -> Vec<getopts::OptGroup> {
         optmulti("", "markdown-after-content",
                  "files to include inline between the content and </body> of a rendered \
                  Markdown file",
-                 "FILES")
+                 "FILES"),
+        optopt("", "markdown-playground-url",
+               "URL to send code snippets to", "URL")
     )
 }
 

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -173,7 +173,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches) -> int 
 pub fn test(input: &str, libs: HashSet<Path>, mut test_args: Vec<String>) -> int {
     let input_str = load_or_return!(input, 1, 2);
 
-    let mut collector = Collector::new(input.to_string(), libs, true, true);
+    let mut collector = Collector::new(input.to_string(), libs, true);
     find_testable_code(input_str.as_slice(), &mut collector);
     test_args.unshift("rustdoctest".to_string());
     testing::test_main(test_args.as_slice(), collector.tests);

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -16,6 +16,7 @@ use getopts;
 use testing;
 
 use html::escape::Escape;
+use html::markdown;
 use html::markdown::{MarkdownWithToc, find_testable_code, reset_headers};
 use test::Collector;
 
@@ -84,6 +85,11 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches) -> int 
     }
 
     let input_str = load_or_return!(input, 1, 2);
+    let playground = matches.opt_str("markdown-playground-url");
+    if playground.is_some() {
+        markdown::playground_krate.replace(Some(None));
+    }
+    let playground = playground.unwrap_or("".to_string());
 
     let (in_header, before_content, after_content) =
         match (load_external_files(matches.opt_strs("markdown-in-header")
@@ -148,6 +154,9 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches) -> int 
     {before_content}
     <h1 class="title">{title}</h1>
     {text}
+    <script type="text/javascript">
+        window.playgroundUrl = "{playground}";
+    </script>
     {after_content}
 </body>
 </html>"#,
@@ -156,7 +165,9 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches) -> int 
         in_header = in_header,
         before_content = before_content,
         text = MarkdownWithToc(text),
-        after_content = after_content);
+        after_content = after_content,
+        playground = playground,
+        );
 
     match err {
         Err(e) => {

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -20,7 +20,8 @@ Core encoding and decoding interfaces.
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![feature(macro_rules, managed_boxes, default_type_params, phase)]
 
 // test harness access

--- a/src/libstd/collections/hashmap.rs
+++ b/src/libstd/collections/hashmap.rs
@@ -684,8 +684,8 @@ impl DefaultResizePolicy {
 /// denial-of-service attacks (Hash DoS). This behaviour can be
 /// overridden with one of the constructors.
 ///
-/// It is required that the keys implement the `PartialEq` and `Hash` traits, although
-/// this can frequently be achieved by using `#[deriving(PartialEq, Hash)]`.
+/// It is required that the keys implement the `Eq` and `Hash` traits, although
+/// this can frequently be achieved by using `#[deriving(Eq, Hash)]`.
 ///
 /// Relevant papers/articles:
 ///
@@ -1422,6 +1422,8 @@ impl<K: Eq + Hash<S>, V: PartialEq, S, H: Hasher<S>> PartialEq for HashMap<K, V,
     }
 }
 
+impl<K: Eq + Hash<S>, V: Eq, S, H: Hasher<S>> Eq for HashMap<K, V, H> {}
+
 impl<K: Eq + Hash<S> + Show, V: Show, S, H: Hasher<S>> Show for HashMap<K, V, H> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, r"\{"));
@@ -1486,7 +1488,7 @@ pub type SetMoveItems<K> =
 
 /// An implementation of a hash set using the underlying representation of a
 /// HashMap where the value is (). As with the `HashMap` type, a `HashSet`
-/// requires that the elements implement the `PartialEq` and `Hash` traits.
+/// requires that the elements implement the `Eq` and `Hash` traits.
 #[deriving(Clone)]
 pub struct HashSet<T, H = sip::SipHasher> {
     map: HashMap<T, (), H>
@@ -1499,6 +1501,8 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> PartialEq for HashSet<T, H> {
         self.iter().all(|key| other.contains(key))
     }
 }
+
+impl<T: Eq + Hash<S>, S, H: Hasher<S>> Eq for HashSet<T, H> {}
 
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> Container for HashSet<T, H> {
     fn len(&self) -> uint { self.map.len() }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -101,7 +101,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![feature(macro_rules, globs, asm, managed_boxes, thread_local, link_args,
            linkage, default_type_params, phase, concat_idents, quad_precision_float)]
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -465,7 +465,7 @@ pub mod builtin {
     /// ```
     /// let rust = bytes!("r", 'u', "st", 255);
     /// assert_eq!(rust[1], 'u' as u8);
-    /// assert_eq!(rust[5], 255);
+    /// assert_eq!(rust[4], 255);
     /// ```
     #[macro_export]
     macro_rules! bytes( ($($e:expr),*) => ({ /* compiler built-in */ }) )
@@ -482,10 +482,14 @@ pub mod builtin {
     /// # Example
     ///
     /// ```
+    /// #![feature(concat_idents)]
+    ///
+    /// # fn main() {
     /// fn foobar() -> int { 23 }
     ///
     /// let f = concat_idents!(foo, bar);
     /// println!("{}", f());
+    /// # }
     /// ```
     #[macro_export]
     macro_rules! concat_idents( ($($e:ident),*) => ({ /* compiler built-in */ }) )

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -212,7 +212,7 @@ macro_rules! unimplemented(
     () => (fail!("not yet implemented"))
 )
 
-/// Use the syntax described in `std::fmt` to create a value of type `~str`.
+/// Use the syntax described in `std::fmt` to create a value of type `String`.
 /// See `std::fmt` for more information.
 ///
 /// # Example

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -13,7 +13,6 @@
 use char;
 use clone::Clone;
 use container::Container;
-use iter::Iterator;
 use num::{NumCast, Zero, One, cast, Int};
 use num::{Float, FPNaN, FPInfinite, ToPrimitive};
 use num;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -56,12 +56,6 @@ use libc::c_char;
 #[cfg(windows)]
 use str::OwnedStr;
 
-/// Delegates to the libc close() function, returning the same return value.
-pub fn close(fd: int) -> int {
-    unsafe {
-        libc::close(fd as c_int) as int
-    }
-}
 
 pub static TMPBUF_SZ : uint = 1000u;
 static BUF_BYTES : uint = 2048u;

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -353,17 +353,17 @@ mod test {
     #[test]
     fn test_gen_ascii_str() {
         let mut r = task_rng();
-        assert_eq!(r.gen_ascii_chars().take(0).len(), 0u);
-        assert_eq!(r.gen_ascii_chars().take(10).len(), 10u);
-        assert_eq!(r.gen_ascii_chars().take(16).len(), 16u);
+        assert_eq!(r.gen_ascii_chars().take(0).count(), 0u);
+        assert_eq!(r.gen_ascii_chars().take(10).count(), 10u);
+        assert_eq!(r.gen_ascii_chars().take(16).count(), 16u);
     }
 
     #[test]
     fn test_gen_vec() {
         let mut r = task_rng();
-        assert_eq!(r.gen_iter::<u8>().take(0).len(), 0u);
-        assert_eq!(r.gen_iter::<u8>().take(10).len(), 10u);
-        assert_eq!(r.gen_iter::<f64>().take(16).len(), 16u);
+        assert_eq!(r.gen_iter::<u8>().take(0).count(), 0u);
+        assert_eq!(r.gen_iter::<u8>().take(10).count(), 10u);
+        assert_eq!(r.gen_iter::<f64>().take(16).count(), 16u);
     }
 
     #[test]

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -505,7 +505,6 @@ mod imp {
     use c_str::CString;
     use container::Container;
     use io::{IoResult, Writer};
-    use iter::Iterator;
     use libc;
     use mem;
     use ops::Drop;

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -84,7 +84,7 @@ fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
             if i == 0 {
                 valid = chars.next().is_none();
                 break
-            } else if chars.by_ref().take(i - 1).len() != i - 1 {
+            } else if chars.by_ref().take(i - 1).count() != i - 1 {
                 valid = false;
             }
         }

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -18,7 +18,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![feature(phase)]
 #![deny(deprecated_owned_vector)]
 

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -45,7 +45,8 @@
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(macro_rules, phase)]
 

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -17,7 +17,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![feature(phase)]
 #![deny(deprecated_owned_vector)]
 

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -161,10 +161,10 @@ fn encode_inner(s: &str, full_url: bool) -> String {
                     out.push_char(ch);
                   }
 
-                  _ => out.push_str(format!("%{:X}", ch as uint).as_slice())
+                  _ => out.push_str(format!("%{:02X}", ch as uint).as_slice())
                 }
             } else {
-                out.push_str(format!("%{:X}", ch as uint).as_slice());
+                out.push_str(format!("%{:02X}", ch as uint).as_slice());
             }
           }
         }
@@ -1178,6 +1178,8 @@ mod tests {
         assert_eq!(encode("@"), "@".to_string());
         assert_eq!(encode("["), "[".to_string());
         assert_eq!(encode("]"), "]".to_string());
+        assert_eq!(encode("\0"), "%00".to_string());
+        assert_eq!(encode("\n"), "%0A".to_string());
     }
 
     #[test]
@@ -1207,6 +1209,8 @@ mod tests {
         assert_eq!(encode_component("@"), "%40".to_string());
         assert_eq!(encode_component("["), "%5B".to_string());
         assert_eq!(encode_component("]"), "%5D".to_string());
+        assert_eq!(encode_component("\0"), "%00".to_string());
+        assert_eq!(encode_component("\n"), "%0A".to_string());
     }
 
     #[test]

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -16,7 +16,8 @@
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 #![feature(default_type_params)]
 
 use std::collections::HashMap;

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -60,7 +60,8 @@ Examples of string representations:
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/")]
+       html_root_url = "http://doc.rust-lang.org/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(default_type_params)]
 

--- a/src/test/run-make/issue-14500/Makefile
+++ b/src/test/run-make/issue-14500/Makefile
@@ -1,0 +1,14 @@
+-include ../tools.mk
+
+# Test to make sure that reachable extern fns are always available in final
+# productcs, including when LTO is used. In this test, the `foo` crate has a
+# reahable symbol, and is a dependency of the `bar` crate. When the `bar` crate
+# is compiled with LTO, it shouldn't strip the symbol from `foo`, and that's the
+# only way that `foo.c` will successfully compile.
+
+all:
+	$(RUSTC) foo.rs --crate-type=rlib
+	$(RUSTC) bar.rs --crate-type=staticlib -Zlto -L. -o $(TMPDIR)/libbar.a
+	$(CC) foo.c -lbar -o $(call RUN_BINFILE,foo) $(EXTRACFLAGS)
+	$(call RUN,foo)
+

--- a/src/test/run-make/issue-14500/bar.rs
+++ b/src/test/run-make/issue-14500/bar.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;

--- a/src/test/run-make/issue-14500/foo.c
+++ b/src/test/run-make/issue-14500/foo.c
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern void foo();
+
+int main() {
+    foo();
+    return 0;
+}

--- a/src/test/run-make/issue-14500/foo.rs
+++ b/src/test/run-make/issue-14500/foo.rs
@@ -1,0 +1,12 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_mangle]
+pub extern fn foo() {}

--- a/src/test/run-make/lto-smoke-c/Makefile
+++ b/src/test/run-make/lto-smoke-c/Makefile
@@ -1,23 +1,10 @@
 -include ../tools.mk
 
-ifdef IS_WINDOWS
-	EXTRAFLAGS :=
-else
-ifeq ($(shell uname),Darwin)
-else
-ifeq ($(shell uname),FreeBSD)
-	EXTRAFLAGS := -lm -lpthread -lgcc_s
-else
-	EXTRAFLAGS := -lm -lrt -ldl -lpthread
-endif
-endif
-endif
-
 # Apparently older versions of GCC segfault if -g is passed...
 CC := $(CC:-g=)
 
 all:
 	$(RUSTC) foo.rs -Z lto
 	ln -s $(call STATICLIB,foo-*) $(call STATICLIB,foo)
-	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(EXTRAFLAGS) -lstdc++
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(EXTRACFLAGS) -lstdc++
 	$(call RUN,bar)

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -53,6 +53,20 @@ RPATH_LINK_SEARCH = -Wl,-rpath-link=$(1)
 endif
 endif
 
+# Extra flags needed to compile a working executable with the standard library
+ifdef IS_WINDOWS
+	EXTRACFLAGS :=
+else
+ifeq ($(shell uname),Darwin)
+else
+ifeq ($(shell uname),FreeBSD)
+	EXTRACFLAGS := -lm -lpthread -lgcc_s
+else
+	EXTRACFLAGS := -lm -lrt -ldl -lpthread
+endif
+endif
+endif
+
 REMOVE_DYLIBS     = rm $(TMPDIR)/$(call DYLIB_GLOB,$(1))
 REMOVE_RLIBS      = rm $(TMPDIR)/$(call RLIB_GLOB,$(1))
 

--- a/src/test/run-pass/issue-11612.rs
+++ b/src/test/run-pass/issue-11612.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #11612
+// We weren't updating the auto adjustments with all the resolved
+// type information after type check.
+
+trait A {}
+
+struct B<'a, T> {
+    f: &'a T
+}
+
+impl<'a, T> A for B<'a, T> {}
+
+fn foo(_: &A) {}
+
+fn bar<G>(b: &B<G>) {
+    foo(b);       // Coercion should work
+    foo(b as &A); // Explicit cast should work as well
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-13204.rs
+++ b/src/test/run-pass/issue-13204.rs
@@ -14,7 +14,7 @@
 pub trait Foo {
     fn bar<'a, I: Iterator<&'a ()>>(&self, it: I) -> uint {
         let mut xs = it.filter(|_| true);
-        xs.len()
+        xs.count()
     }
 }
 

--- a/src/test/run-pass/issue-8460.rs
+++ b/src/test/run-pass/issue-8460.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{int, i8, i16, i32, i64};
+use std::task;
+
+fn main() {
+    assert!(task::try(proc() int::MIN / -1).is_err());
+    assert!(task::try(proc() i8::MIN / -1).is_err());
+    assert!(task::try(proc() i16::MIN / -1).is_err());
+    assert!(task::try(proc() i32::MIN / -1).is_err());
+    assert!(task::try(proc() i64::MIN / -1).is_err());
+    assert!(task::try(proc() 1i / 0).is_err());
+    assert!(task::try(proc() 1i8 / 0).is_err());
+    assert!(task::try(proc() 1i16 / 0).is_err());
+    assert!(task::try(proc() 1i32 / 0).is_err());
+    assert!(task::try(proc() 1i64 / 0).is_err());
+    assert!(task::try(proc() int::MIN % -1).is_err());
+    assert!(task::try(proc() i8::MIN % -1).is_err());
+    assert!(task::try(proc() i16::MIN % -1).is_err());
+    assert!(task::try(proc() i32::MIN % -1).is_err());
+    assert!(task::try(proc() i64::MIN % -1).is_err());
+    assert!(task::try(proc() 1i % 0).is_err());
+    assert!(task::try(proc() 1i8 % 0).is_err());
+    assert!(task::try(proc() 1i16 % 0).is_err());
+    assert!(task::try(proc() 1i32 % 0).is_err());
+    assert!(task::try(proc() 1i64 % 0).is_err());
+}


### PR DESCRIPTION
Closes #14675 (rustc: Encode argument names for traits)
Closes #14681 (rustc: Avoid UB with signed division/remainder)
Closes #14682 (librustc: Update AutoObject adjustment in writeback.)
Closes #14683 (Avoid 16-byte filenames in rlibs)
Closes #14687 (rustdoc: Inline static documentation across crates)
Closes #14689 (Remove reference to ~str in documentation)
Closes #14692 (Rename Iterator::len to count)
Closes #14693 (Implement Eq for HashSet and HashMap)
Closes #14699 (url: encode small bytes correctly.)
Closes #14700 (rustdoc: Submit examples to play.rust-lang.org)
Closes #14701 (mk: Run doc tests with --cfg dox)
Closes #14710 (rustc: Preserve reachable extern fns with LTO)
Closes #14711 (Removing unused wrapper to libc::close.)
