### PR TITLE
Make ast::Arg usable in quote macros

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -135,6 +135,12 @@ pub mod rt {
         }
     }
 
+    impl ToSource for ast::Arg {
+        fn to_source(&self) -> String {
+            pprust::arg_to_str(self)
+        }
+    }
+
     impl<'a> ToSource for &'a str {
         fn to_source(&self) -> String {
             let lit = dummy_spanned(ast::LitStr(
@@ -264,6 +270,7 @@ pub mod rt {
     impl_to_tokens!(Generics)
     impl_to_tokens!(@ast::Expr)
     impl_to_tokens!(ast::Block)
+    impl_to_tokens!(ast::Arg)
     impl_to_tokens_self!(&'a str)
     impl_to_tokens!(())
     impl_to_tokens!(char)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -242,6 +242,10 @@ pub fn variant_to_str(var: &ast::Variant) -> String {
     to_str(|s| s.print_variant(var))
 }
 
+pub fn arg_to_str(arg: &ast::Arg) -> String {
+    to_str(|s| s.print_arg(arg))
+}
+
 pub fn visibility_qualified(vis: ast::Visibility, s: &str) -> String {
     match vis {
         ast::Public => format!("pub {}", s).to_string(),


### PR DESCRIPTION
The need for this came up while I worked on a procedural macro that parses an argument and adds the same argument to a generated function.
