### PR TITLE
Fix many collections implementing PartialEq

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -815,8 +815,6 @@ impl cmp::PartialEq for BitvSet {
         }
         return true;
     }
-
-    fn ne(&self, other: &BitvSet) -> bool { !self.eq(other) }
 }
 
 impl fmt::Show for BitvSet {

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -374,8 +374,8 @@ impl<A: PartialEq> PartialEq for RingBuf<A> {
             self.iter().zip(other.iter()).all(|(a, b)| a == b)
     }
     fn ne(&self, other: &RingBuf<A>) -> bool {
-        self.nelts != other.nelts &&
-            self.iter().zip(other.iter()).all(|(a, b)| a != b)
+        self.nelts != other.nelts ||
+            self.iter().zip(other.iter()).any(|(a, b)| a != b)
     }
 }
 

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -371,10 +371,11 @@ fn raw_index(lo: uint, len: uint, index: uint) -> uint {
 impl<A: PartialEq> PartialEq for RingBuf<A> {
     fn eq(&self, other: &RingBuf<A>) -> bool {
         self.nelts == other.nelts &&
-            self.iter().zip(other.iter()).all(|(a, b)| a.eq(b))
+            self.iter().zip(other.iter()).all(|(a, b)| a == b)
     }
     fn ne(&self, other: &RingBuf<A>) -> bool {
-        !self.eq(other)
+        self.nelts != other.nelts &&
+            self.iter().zip(other.iter()).all(|(a, b)| a != b)
     }
 }
 

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -52,6 +52,10 @@ impl<K: PartialEq + Ord, V: PartialEq> PartialEq for TreeMap<K, V> {
         self.len() == other.len() &&
             self.iter().zip(other.iter()).all(|(a, b)| a == b)
     }
+    fn ne(&self, other: &TreeMap<K, V>) -> bool {
+        self.len() != other.len() &&
+            self.iter().zip(other.iter()).all(|(a, b)| a != b)
+    }
 }
 
 // Lexicographical comparison
@@ -559,6 +563,8 @@ pub struct TreeSet<T> {
 impl<T: PartialEq + Ord> PartialEq for TreeSet<T> {
     #[inline]
     fn eq(&self, other: &TreeSet<T>) -> bool { self.map == other.map }
+    #[inline]
+    fn ne(&self, other: &TreeSet<T>) -> bool { self.map != other.map }
 }
 
 impl<T: PartialOrd + Ord> PartialOrd for TreeSet<T> {

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -53,8 +53,8 @@ impl<K: PartialEq + Ord, V: PartialEq> PartialEq for TreeMap<K, V> {
             self.iter().zip(other.iter()).all(|(a, b)| a == b)
     }
     fn ne(&self, other: &TreeMap<K, V>) -> bool {
-        self.len() != other.len() &&
-            self.iter().zip(other.iter()).all(|(a, b)| a != b)
+        self.len() != other.len() ||
+            self.iter().zip(other.iter()).any(|(a, b)| a != b)
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -199,9 +199,10 @@ impl<T:Copy> Clone for Cell<T> {
 }
 
 impl<T:PartialEq + Copy> PartialEq for Cell<T> {
-    fn eq(&self, other: &Cell<T>) -> bool {
-        self.get() == other.get()
-    }
+    #[inline]
+    fn eq(&self, other: &Cell<T>) -> bool { self.get() == other.get() }
+    #[inline]
+    fn ne(&self, other: &Cell<T>) -> bool { self.get() != other.get() }
 }
 
 /// A mutable memory location with dynamically checked borrow rules

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -404,11 +404,9 @@ impl<T> RawPtr<T> for *mut T {
 #[cfg(not(test))]
 impl<T> PartialEq for *T {
     #[inline]
-    fn eq(&self, other: &*T) -> bool {
-        *self == *other
-    }
+    fn eq(&self, other: &*T) -> bool { *self == *other }
     #[inline]
-    fn ne(&self, other: &*T) -> bool { !self.eq(other) }
+    fn ne(&self, other: &*T) -> bool { *self != *other }
 }
 
 #[cfg(not(test))]
@@ -417,11 +415,9 @@ impl<T> Eq for *T {}
 #[cfg(not(test))]
 impl<T> PartialEq for *mut T {
     #[inline]
-    fn eq(&self, other: &*mut T) -> bool {
-        *self == *other
-    }
+    fn eq(&self, other: &*mut T) -> bool { *self == *other }
     #[inline]
-    fn ne(&self, other: &*mut T) -> bool { !self.eq(other) }
+    fn ne(&self, other: &*mut T) -> bool { *self != *other }
 }
 
 #[cfg(not(test))]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -270,7 +270,7 @@ pub mod traits {
         #[inline]
         fn eq(&self, other: &~[T]) -> bool { self.as_slice() == *other }
         #[inline]
-        fn ne(&self, other: &~[T]) -> bool { !self.eq(other) }
+        fn ne(&self, other: &~[T]) -> bool { self.as_slice() != *other }
     }
 
     impl<'a,T:Eq> Eq for &'a [T] {}

--- a/src/libstd/collections/hashmap.rs
+++ b/src/libstd/collections/hashmap.rs
@@ -1424,7 +1424,7 @@ impl<K: Eq + Hash<S>, V: PartialEq, S, H: Hasher<S>> PartialEq for HashMap<K, V,
         if self.len() != other.len() { return true; }
 
         self.iter()
-          .all(|(key, value)| {
+          .any(|(key, value)| {
             match other.find(key) {
                 None    => true,
                 Some(v) => *value != *v

--- a/src/libstd/collections/hashmap.rs
+++ b/src/libstd/collections/hashmap.rs
@@ -1420,6 +1420,17 @@ impl<K: Eq + Hash<S>, V: PartialEq, S, H: Hasher<S>> PartialEq for HashMap<K, V,
             }
         })
     }
+    fn ne(&self, other: &HashMap<K, V, H>) -> bool {
+        if self.len() != other.len() { return true; }
+
+        self.iter()
+          .all(|(key, value)| {
+            match other.find(key) {
+                None    => true,
+                Some(v) => *value != *v
+            }
+        })
+    }
 }
 
 impl<K: Eq + Hash<S>, V: Eq, S, H: Hasher<S>> Eq for HashMap<K, V, H> {}
@@ -1495,10 +1506,13 @@ pub struct HashSet<T, H = sip::SipHasher> {
 }
 
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> PartialEq for HashSet<T, H> {
+    #[inline]
     fn eq(&self, other: &HashSet<T, H>) -> bool {
-        if self.len() != other.len() { return false; }
-
-        self.iter().all(|key| other.contains(key))
+        self.map == other.map
+    }
+    #[inline]
+    fn ne(&self, other: &HashSet<T, H>) -> bool {
+        self.map != other.map
     }
 }
 

--- a/src/libstd/collections/lru_cache.rs
+++ b/src/libstd/collections/lru_cache.rs
@@ -73,9 +73,10 @@ impl<S, K: Hash<S>> Hash<S> for KeyRef<K> {
 }
 
 impl<K: PartialEq> PartialEq for KeyRef<K> {
-    fn eq(&self, other: &KeyRef<K>) -> bool {
-        unsafe{ (*self.k).eq(&*other.k) }
-    }
+    #[inline]
+    fn eq(&self, other: &KeyRef<K>) -> bool { unsafe { (&*self.k) == (&*other.k) } }
+    #[inline]
+    fn ne(&self, other: &KeyRef<K>) -> bool { unsafe { (&*self.k) != (&*other.k) } }
 }
 
 impl<K: Eq> Eq for KeyRef<K> {}


### PR DESCRIPTION
They now properly check each element with the `eq` and `ne` methods in their
own `eq` and `ne` method, respectively.
