### PR TITLE
update identifier naming warnings to give an example

### DIFF
--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1326,12 +1326,21 @@ fn check_item_non_camel_case_types(cx: &Context, it: &ast::Item) {
         !ident.char_at(0).is_lowercase() && !ident.contains_char('_')
     }
 
+    fn to_camel_case(s: &str) -> String {
+        s.split('_').flat_map(|word| word.chars().enumerate().map(|(i, c)|
+            if i == 0 { c.to_uppercase() }
+            else { c }
+        )).collect()
+    }
+
     fn check_case(cx: &Context, sort: &str, ident: ast::Ident, span: Span) {
+        let s = token::get_ident(ident);
+
         if !is_camel_case(ident) {
             cx.span_lint(
                 NonCamelCaseTypes, span,
-                format!("{} `{}` should have a camel case identifier",
-                    sort, token::get_ident(ident)).as_slice());
+                format!("{} `{}` should have a camel case name such as `{}`",
+                    sort, s, to_camel_case(s.get())).as_slice());
         }
     }
 
@@ -1369,10 +1378,29 @@ fn check_snake_case(cx: &Context, sort: &str, ident: ast::Ident, span: Span) {
         })
     }
 
+    fn to_snake_case(str: &str) -> String {
+        let mut words = vec![];
+        for s in str.split('_') {
+            let mut buf = String::new();
+            if s.is_empty() { continue; }
+            for ch in s.chars() {
+                if !buf.is_empty() && ch.is_uppercase() {
+                    words.push(buf);
+                    buf = String::new();
+                }
+                buf.push_char(ch.to_lowercase());
+            }
+            words.push(buf);
+        }
+        words.connect("_")
+    }
+
+    let s = token::get_ident(ident);
+
     if !is_snake_case(ident) {
         cx.span_lint(NonSnakeCaseFunctions, span,
-                    format!("{} `{}` should have a snake case identifier",
-                            sort, token::get_ident(ident)).as_slice());
+                    format!("{} `{}` should have a snake case name such as `{}`",
+                            sort, s, to_snake_case(s.get())).as_slice());
     }
 }
 
@@ -1386,7 +1414,10 @@ fn check_item_non_uppercase_statics(cx: &Context, it: &ast::Item) {
             // upper/lowercase)
             if s.get().chars().any(|c| c.is_lowercase()) {
                 cx.span_lint(NonUppercaseStatics, it.span,
-                             "static constant should have an uppercase identifier");
+                            format!("static constant `{}` should have an uppercase name \
+                                such as `{}`", s.get(),
+                                s.get().chars().map(|c| c.to_uppercase())
+                                    .collect::<String>().as_slice()).as_slice());
             }
         }
         _ => {}
@@ -1402,7 +1433,10 @@ fn check_pat_non_uppercase_statics(cx: &Context, p: &ast::Pat) {
             let s = token::get_ident(ident);
             if s.get().chars().any(|c| c.is_lowercase()) {
                 cx.span_lint(NonUppercasePatternStatics, path.span,
-                             "static constant in pattern should be all caps");
+                            format!("static constant in pattern `{}` should have an uppercase \
+                                name such as `{}`", s.get(),
+                                s.get().chars().map(|c| c.to_uppercase())
+                                    .collect::<String>().as_slice()).as_slice());
             }
         }
         _ => {}

--- a/src/test/compile-fail/lint-non-camel-case-types.rs
+++ b/src/test/compile-fail/lint-non-camel-case-types.rs
@@ -11,25 +11,25 @@
 #![forbid(non_camel_case_types)]
 #![allow(dead_code)]
 
-struct foo { //~ ERROR type `foo` should have a camel case identifier
+struct foo { //~ ERROR type `foo` should have a camel case name such as `Foo`
     bar: int,
 }
 
-enum foo2 { //~ ERROR type `foo2` should have a camel case identifier
+enum foo2 { //~ ERROR type `foo2` should have a camel case name such as `Foo2`
     Bar
 }
 
-struct foo3 { //~ ERROR type `foo3` should have a camel case identifier
+struct foo3 { //~ ERROR type `foo3` should have a camel case name such as `Foo3`
     bar: int
 }
 
-type foo4 = int; //~ ERROR type `foo4` should have a camel case identifier
+type foo4 = int; //~ ERROR type `foo4` should have a camel case name such as `Foo4`
 
 enum Foo5 {
-    bar //~ ERROR variant `bar` should have a camel case identifier
+    bar //~ ERROR variant `bar` should have a camel case name such as `Bar`
 }
 
-trait foo6 { //~ ERROR trait `foo6` should have a camel case identifier
+trait foo6 { //~ ERROR trait `foo6` should have a camel case name such as `Foo6`
 }
 
 fn main() { }

--- a/src/test/compile-fail/lint-non-snake-case-functions.rs
+++ b/src/test/compile-fail/lint-non-snake-case-functions.rs
@@ -15,25 +15,25 @@ struct Foo;
 
 impl Foo {
     fn Foo_Method() {}
-    //~^ ERROR method `Foo_Method` should have a snake case identifier
+    //~^ ERROR method `Foo_Method` should have a snake case name such as `foo_method`
 
     // Don't allow two underscores in a row
     fn foo__method(&self) {}
-    //~^ ERROR method `foo__method` should have a snake case identifier
+    //~^ ERROR method `foo__method` should have a snake case name such as `foo_method`
 
     pub fn xyZ(&mut self) {}
-    //~^ ERROR method `xyZ` should have a snake case identifier
+    //~^ ERROR method `xyZ` should have a snake case name such as `xy_z`
 }
 
 trait X {
     fn ABC();
-    //~^ ERROR trait method `ABC` should have a snake case identifier
+    //~^ ERROR trait method `ABC` should have a snake case name such as `a_b_c`
 
     fn a_b_C(&self) {}
-    //~^ ERROR trait method `a_b_C` should have a snake case identifier
+    //~^ ERROR trait method `a_b_C` should have a snake case name such as `a_b_c`
 
     fn something__else(&mut self);
-    //~^ ERROR trait method `something__else` should have a snake case identifier
+    //~^ ERROR trait method `something__else` should have a snake case name such as `something_else`
 }
 
 impl X for Foo {
@@ -43,9 +43,9 @@ impl X for Foo {
 }
 
 fn Cookie() {}
-//~^ ERROR function `Cookie` should have a snake case identifier
+//~^ ERROR function `Cookie` should have a snake case name such as `cookie`
 
 pub fn bi_S_Cuit() {}
-//~^ ERROR function `bi_S_Cuit` should have a snake case identifier
+//~^ ERROR function `bi_S_Cuit` should have a snake case name such as `bi_s_cuit`
 
 fn main() { }

--- a/src/test/compile-fail/lint-non-uppercase-statics.rs
+++ b/src/test/compile-fail/lint-non-uppercase-statics.rs
@@ -11,6 +11,6 @@
 #![forbid(non_uppercase_statics)]
 #![allow(dead_code)]
 
-static foo: int = 1; //~ ERROR static constant should have an uppercase identifier
+static foo: int = 1; //~ ERROR static constant `foo` should have an uppercase name such as `FOO`
 
 fn main() { }

--- a/src/test/compile-fail/match-static-const-lc.rs
+++ b/src/test/compile-fail/match-static-const-lc.rs
@@ -18,7 +18,7 @@ pub static a : int = 97;
 fn f() {
     let r = match (0,0) {
         (0, a) => 0,
-        //~^ ERROR static constant in pattern should be all caps
+        //~^ ERROR static constant in pattern `a` should have an uppercase name such as `A`
         (x, y) => 1 + x + y,
     };
     assert!(r == 1);
@@ -32,7 +32,7 @@ fn g() {
     use self::m::aha;
     let r = match (0,0) {
         (0, aha) => 0,
-        //~^ ERROR static constant in pattern should be all caps
+        //~^ ERROR static constant in pattern `aha` should have an uppercase name such as `AHA`
         (x, y)   => 1 + x + y,
     };
     assert!(r == 1);
@@ -46,7 +46,7 @@ fn h() {
     use not_okay = self::n::OKAY;
     let r = match (0,0) {
         (0, not_okay) => 0,
-        //~^ ERROR static constant in pattern should be all caps
+//~^ ERROR static constant in pattern `not_okay` should have an uppercase name such as `NOT_OKAY`
         (x, y)   => 1 + x + y,
     };
     assert!(r == 1);


### PR DESCRIPTION
This updates identifier warnings such as `struct `foo_bar` should have a
camel case identifier` to provide an example.

Closes #14738.
