### PR TITLE
Improve error message for range in match

### DIFF
--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -460,7 +460,8 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
         {
             // no-op
         } else if !ty::type_is_numeric(b_ty) && !ty::type_is_char(b_ty) {
-            tcx.sess.span_err(pat.span, "non-numeric type used in range");
+            tcx.sess.span_err(pat.span,
+                "only char and numeric types are allowed in range");
         } else {
             match valid_range_bounds(fcx.ccx, begin, end) {
                 Some(false) => {

--- a/src/test/compile-fail/match-range-fail.rs
+++ b/src/test/compile-fail/match-range-fail.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 //error-pattern: lower range bound
-//error-pattern: non-numeric
+//error-pattern: only char and numeric types
 //error-pattern: mismatched types
 
 fn main() {


### PR DESCRIPTION
Range allows char and numeric types, but previous error message
mentioned only numeric types.
