### PR TITLE
TcpListener::bind/TcpStream::connect (&str, Int), &str and SocketAddr{...} overrides

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -397,7 +397,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                 //waiting 1 second for gdbserver start
                 timer::sleep(1000);
                 let result = task::try(proc() {
-                    tcp::TcpStream::connect("127.0.0.1", 5039).unwrap();
+                    tcp::TcpStream::connect(("127.0.0.1", 5039)).unwrap();
                 });
                 if result.is_err() {
                     continue;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -85,7 +85,7 @@ Some examples of obvious things you might want to do
     # #![allow(unused_must_use)]
     use std::io::net::tcp::TcpStream;
 
-    let mut socket = TcpStream::connect("127.0.0.1", 8080).unwrap();
+    let mut socket = TcpStream::connect(("127.0.0.1", 8080)).unwrap();
     socket.write(bytes!("GET / HTTP/1.0\n\n"));
     let response = socket.read_to_end();
     ```
@@ -99,7 +99,7 @@ Some examples of obvious things you might want to do
     use std::io::{TcpListener, TcpStream};
     use std::io::{Acceptor, Listener};
 
-    let listener = TcpListener::bind("127.0.0.1", 80);
+    let listener = TcpListener::bind(("127.0.0.1", 80));
 
     // bind the listener to the specified address
     let mut acceptor = listener.listen();

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -20,7 +20,11 @@
 use clone::Clone;
 use io::IoResult;
 use iter::Iterator;
+use container::Container;
+use vec::Vec;
 use slice::ImmutableVector;
+use str::StrSlice;
+use num::Int;
 use result::{Ok,Err};
 use io::net::addrinfo::get_host_addresses;
 use io::net::ip::SocketAddr;
@@ -34,6 +38,86 @@ use rt::rtio::{IoFactory, LocalIo, RtioSocket, RtioTcpListener};
 use rt::rtio::{RtioTcpAcceptor, RtioTcpStream};
 use rt::rtio;
 
+fn invalid_address<T>() -> IoResult<T> {
+    Err(IoError{
+        kind: InvalidInput,
+        desc: "error parsing bind address",
+        detail: None
+    })
+}
+
+#[doc(hidden)]
+trait ToSocketAddrs {
+    fn to_socket_addrs(self) -> IoResult<Vec<SocketAddr>>;
+}
+
+impl ToSocketAddrs for SocketAddr {
+    fn to_socket_addrs(self) -> IoResult<Vec<SocketAddr>> {
+        Ok(vec!(self))
+    }
+}
+
+impl<'a> ToSocketAddrs for &'a str {
+    fn to_socket_addrs(self) -> IoResult<Vec<SocketAddr>> {
+        fn host_and_port<'a>(input: &'a str) -> Option<(&'a str, int)> {
+            let sep = input.rfind(':');
+            match sep {
+                Some(sep) => {
+                    let host = input.slice(0, sep);
+                    let opt_port: Option<int> =
+                        FromStr::from_str(input.slice_from(sep+1));
+                    match opt_port {
+                        Some(port) => Some((host, port)),
+                        None => None
+                    }
+                }
+                None => None
+            }
+        }
+
+        let opt_addr: Option<SocketAddr> = FromStr::from_str(self);
+        match opt_addr {
+            Some(addr) => {
+                Ok(vec!(addr))
+            }
+            None => {
+                match host_and_port(self) {
+                    Some((host, port)) => {
+                        let addrs = try!(get_host_addresses(host));
+                        let mut result = Vec::with_capacity(addrs.len());
+                        let port = port as u16;
+                        for addr in addrs.iter() {
+                            result.push(SocketAddr{ip: *addr, port: port})
+                        }
+                        Ok(result)
+                    }
+                    None => invalid_address()
+                }
+            }
+        }
+    }
+}
+
+impl<'a, T: Int> ToSocketAddrs for (&'a str, T) {
+    fn to_socket_addrs(self) -> IoResult<Vec<SocketAddr>> {
+        let (host, port) = self;
+        match port.to_u16() {
+            Some(port) => {
+                let addresses = match FromStr::from_str(host) {
+                    Some(addr) => vec!(addr),
+                    None => try!(get_host_addresses(host))
+                };
+                let mut result = Vec::with_capacity(addresses.len());
+                for address in addresses.iter() {
+                    result.push(SocketAddr{ip: *address, port: port});
+                }
+                Ok(result)
+            }
+            None => invalid_address()
+        }
+    }
+}
+
 /// A structure which represents a TCP stream between a local socket and a
 /// remote socket.
 ///
@@ -43,7 +127,7 @@ use rt::rtio;
 /// # #![allow(unused_must_use)]
 /// use std::io::net::tcp::TcpStream;
 ///
-/// let mut stream = TcpStream::connect("127.0.0.1", 34254);
+/// let mut stream = TcpStream::connect(("127.0.0.1", 34254));
 ///
 /// stream.write([1]);
 /// let mut buf = [0];
@@ -61,22 +145,24 @@ impl TcpStream {
 
     /// Open a TCP connection to a remote host by hostname or IP address.
     ///
-    /// `host` can be a hostname or IP address string. If no error is
-    /// encountered, then `Ok(stream)` is returned.
-    pub fn connect(host: &str, port: u16) -> IoResult<TcpStream> {
-        let addresses = match FromStr::from_str(host) {
-            Some(addr) => vec!(addr),
-            None => try!(get_host_addresses(host))
-        };
-        let mut err = IoError {
+    /// `addr` is any type that implements ToSocketAddrs. If the connection
+    /// is successfully established to the remote host, then Ok(stream) is
+    /// returned.
+    pub fn connect<T: ToSocketAddrs>(addr: T) -> IoResult<TcpStream> {
+        let addresses = try!(addr.to_socket_addrs());
+        let mut err = IoError{
             kind: ConnectionFailed,
             desc: "no addresses found for hostname",
             detail: None
         };
-        for addr in addresses.iter() {
-            let addr = rtio::SocketAddr{ ip: super::to_rtio(*addr), port: port };
+        for address in addresses.iter() {
+            let SocketAddr{ip, port} = *address;
+            let address = rtio::SocketAddr{
+                ip: super::to_rtio(ip),
+                port: port
+            };
             let result = LocalIo::maybe_raise(|io| {
-                io.tcp_connect(addr, None).map(TcpStream::new)
+                io.tcp_connect(address, None).map(TcpStream::new)
             });
             match result {
                 Ok(stream) => {
@@ -164,7 +250,7 @@ impl TcpStream {
     /// use std::io::timer;
     /// use std::io::net::tcp::TcpStream;
     ///
-    /// let mut stream = TcpStream::connect("127.0.0.1", 34254).unwrap();
+    /// let mut stream = TcpStream::connect(("127.0.0.1", 34254)).unwrap();
     /// let stream2 = stream.clone();
     ///
     /// spawn(proc() {
@@ -289,6 +375,41 @@ impl Writer for TcpStream {
     }
 }
 
+#[doc(hidden)]
+trait ToBindSocketAddr {
+    fn to_bind_socket_addr(self) -> IoResult<SocketAddr>;
+}
+
+impl ToBindSocketAddr for SocketAddr {
+    fn to_bind_socket_addr(self) -> IoResult<SocketAddr> {
+        Ok(self)
+    }
+}
+
+impl<'a> ToBindSocketAddr for &'a str {
+    fn to_bind_socket_addr(self) -> IoResult<SocketAddr> {
+        match FromStr::from_str(self) {
+            Some(addr) => Ok(addr),
+            None => invalid_address()
+        }
+    }
+}
+
+impl<'a, T: Int> ToBindSocketAddr for (&'a str, T) {
+    fn to_bind_socket_addr(self) -> IoResult<SocketAddr> {
+        let (host, port) = self;
+        match port.to_u16() {
+            Some(port) => {
+                match FromStr::from_str(host) {
+                    Some(addr) => Ok(SocketAddr{ip: addr, port: port}),
+                    None => invalid_address()
+                }
+            }
+            None => invalid_address()
+        }
+    }
+}
+
 /// A structure representing a socket server. This listener is used to create a
 /// `TcpAcceptor` which can be used to accept sockets on a local port.
 ///
@@ -301,7 +422,7 @@ impl Writer for TcpStream {
 /// use std::io::{TcpListener, TcpStream};
 /// use std::io::{Acceptor, Listener};
 ///
-/// let listener = TcpListener::bind("127.0.0.1", 80);
+/// let listener = TcpListener::bind(("127.0.0.1", 80));
 ///
 /// // bind the listener to the specified address
 /// let mut acceptor = listener.listen();
@@ -337,25 +458,15 @@ impl TcpListener {
     /// Binding with a port number of 0 will request that the OS assigns a port
     /// to this listener. The port allocated can be queried via the
     /// `socket_name` function.
-    pub fn bind(addr: &str, port: u16) -> IoResult<TcpListener> {
-        match FromStr::from_str(addr) {
-            Some(ip) => {
-                let addr = rtio::SocketAddr{
-                    ip: super::to_rtio(ip),
-                    port: port,
-                };
-                LocalIo::maybe_raise(|io| {
-                    io.tcp_bind(addr).map(|l| TcpListener { obj: l })
-                }).map_err(IoError::from_rtio_error)
-            }
-            None => {
-                Err(IoError{
-                    kind: InvalidInput,
-                    desc: "invalid IP address specified",
-                    detail: None
-                })
-            }
-        }
+    pub fn bind<T: ToBindSocketAddr>(addr: T) -> IoResult<TcpListener> {
+        let SocketAddr{ip, port} = try!(addr.to_bind_socket_addr());
+        let address = rtio::SocketAddr{
+            ip: super::to_rtio(ip),
+            port: port
+        };
+        LocalIo::maybe_raise(|io| {
+            io.tcp_bind(address).map(|l| TcpListener { obj: l })
+        }).map_err(IoError::from_rtio_error)
     }
 
     /// Returns the local socket address of this listener.
@@ -409,7 +520,7 @@ impl TcpAcceptor {
     /// use std::io::net::tcp::TcpListener;
     /// use std::io::{Listener, Acceptor, TimedOut};
     ///
-    /// let mut a = TcpListener::bind("127.0.0.1", 8482).listen().unwrap();
+    /// let mut a = TcpListener::bind(("127.0.0.1", 8482)).listen().unwrap();
     ///
     /// // After 100ms have passed, all accepts will fail
     /// a.set_timeout(Some(100));
@@ -452,14 +563,14 @@ mod test {
 
     // FIXME #11530 this fails on android because tests are run as root
     iotest!(fn bind_error() {
-        match TcpListener::bind("0.0.0.0", 1) {
+        match TcpListener::bind(("0.0.0.0", 1)) {
             Ok(..) => fail!(),
             Err(e) => assert_eq!(e.kind, PermissionDenied),
         }
     } #[ignore(cfg(windows))] #[ignore(cfg(target_os = "android"))])
 
     iotest!(fn connect_error() {
-        match TcpStream::connect("0.0.0.0", 1) {
+        match TcpStream::connect(("0.0.0.0", 1)) {
             Ok(..) => fail!(),
             Err(e) => assert_eq!(e.kind, ConnectionRefused),
         }
@@ -469,11 +580,11 @@ mod test {
         let socket_addr = next_test_ip4();
         let ip_str = socket_addr.ip.to_str();
         let port = socket_addr.port;
-        let listener = TcpListener::bind(ip_str.as_slice(), port);
+        let listener = TcpListener::bind((ip_str.as_slice(), port));
         let mut acceptor = listener.listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect("localhost", port);
+            let mut stream = TcpStream::connect(("localhost", port));
             stream.write([144]).unwrap();
         });
 
@@ -487,10 +598,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect("localhost", addr.port);
+            let mut stream = TcpStream::connect(("localhost", addr.port));
             stream.write([64]).unwrap();
         });
 
@@ -504,10 +615,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect("127.0.0.1", addr.port);
+            let mut stream = TcpStream::connect(("127.0.0.1", addr.port));
             stream.write([44]).unwrap();
         });
 
@@ -521,10 +632,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect("::1", addr.port);
+            let mut stream = TcpStream::connect(("::1", addr.port));
             stream.write([66]).unwrap();
         });
 
@@ -538,10 +649,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+            let mut stream = TcpStream::connect((ip_str.as_slice(), port));
             stream.write([99]).unwrap();
         });
 
@@ -555,10 +666,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+            let mut stream = TcpStream::connect((ip_str.as_slice(), port));
             stream.write([99]).unwrap();
         });
 
@@ -572,10 +683,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str.as_slice(), port);
+            let _stream = TcpStream::connect((ip_str.as_slice(), port));
             // Close
         });
 
@@ -589,10 +700,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str.as_slice(), port);
+            let _stream = TcpStream::connect((ip_str.as_slice(), port));
             // Close
         });
 
@@ -606,10 +717,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str.as_slice(), port);
+            let _stream = TcpStream::connect((ip_str.as_slice(), port));
             // Close
         });
 
@@ -631,10 +742,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str.as_slice(), port);
+            let _stream = TcpStream::connect((ip_str.as_slice(), port));
             // Close
         });
 
@@ -656,10 +767,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str.as_slice(), port);
+            let _stream = TcpStream::connect((ip_str.as_slice(), port));
             // Close
         });
 
@@ -683,10 +794,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let _stream = TcpStream::connect(ip_str.as_slice(), port);
+            let _stream = TcpStream::connect((ip_str.as_slice(), port));
             // Close
         });
 
@@ -711,11 +822,11 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         let max = 10u;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
             for _ in range(0, max) {
-                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+                let mut stream = TcpStream::connect((ip_str.as_slice(), port));
                 stream.write([99]).unwrap();
             }
         });
@@ -732,11 +843,11 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         let max = 10u;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
             for _ in range(0, max) {
-                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+                let mut stream = TcpStream::connect((ip_str.as_slice(), port));
                 stream.write([99]).unwrap();
             }
         });
@@ -753,7 +864,7 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         static MAX: int = 10;
-        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -778,7 +889,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+                let mut stream = TcpStream::connect((ip_str.as_slice(), port));
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -792,7 +903,7 @@ mod test {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
         static MAX: int = 10;
-        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -817,7 +928,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+                let mut stream = TcpStream::connect((ip_str.as_slice(), port));
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -831,7 +942,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -856,7 +967,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+                let mut stream = TcpStream::connect((ip_str.as_slice(), port));
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -870,7 +981,7 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
             let mut acceptor = acceptor;
@@ -895,7 +1006,7 @@ mod test {
 
             spawn(proc() {
                 debug!("connecting");
-                let mut stream = TcpStream::connect(ip_str.as_slice(), port);
+                let mut stream = TcpStream::connect((ip_str.as_slice(), port));
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
@@ -907,7 +1018,7 @@ mod test {
     pub fn socket_name(addr: SocketAddr) {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut listener = TcpListener::bind(ip_str.as_slice(), port).unwrap();
+        let mut listener = TcpListener::bind((ip_str.as_slice(), port)).unwrap();
 
         // Make sure socket_name gives
         // us the socket we binded to.
@@ -919,13 +1030,13 @@ mod test {
     pub fn peer_name(addr: SocketAddr) {
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
         spawn(proc() {
             let mut acceptor = acceptor;
             acceptor.accept().unwrap();
         });
 
-        let stream = TcpStream::connect(ip_str.as_slice(), port);
+        let stream = TcpStream::connect((ip_str.as_slice(), port));
 
         assert!(stream.is_ok());
         let mut stream = stream.unwrap();
@@ -955,7 +1066,7 @@ mod test {
         let (tx, rx) = channel();
         spawn(proc() {
             let ip_str = addr.ip.to_str();
-            let mut srv = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+            let mut srv = TcpListener::bind((ip_str.as_slice(), port)).listen().unwrap();
             tx.send(());
             let mut cl = srv.accept().unwrap();
             cl.write([10]).unwrap();
@@ -966,7 +1077,7 @@ mod test {
 
         rx.recv();
         let ip_str = addr.ip.to_str();
-        let mut c = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+        let mut c = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
         let mut b = [0, ..10];
         assert_eq!(c.read(b), Ok(1));
         c.write([1]).unwrap();
@@ -977,9 +1088,9 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let listener = TcpListener::bind(ip_str.as_slice(), port).unwrap().listen();
+        let listener = TcpListener::bind((ip_str.as_slice(), port)).unwrap().listen();
         assert!(listener.is_ok());
-        match TcpListener::bind(ip_str.as_slice(), port).listen() {
+        match TcpListener::bind((ip_str.as_slice(), port)).listen() {
             Ok(..) => fail!(),
             Err(e) => {
                 assert!(e.kind == ConnectionRefused || e.kind == OtherIoError,
@@ -996,14 +1107,14 @@ mod test {
         spawn(proc() {
             let ip_str = addr.ip.to_str();
             rx.recv();
-            let _stream = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+            let _stream = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
             // Close
             rx.recv();
         });
 
         {
             let ip_str = addr.ip.to_str();
-            let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+            let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
             tx.send(());
             {
                 let _stream = acceptor.accept().unwrap();
@@ -1012,17 +1123,17 @@ mod test {
             }
             // Close listener
         }
-        let _listener = TcpListener::bind(addr.ip.to_str().as_slice(), port);
+        let _listener = TcpListener::bind((addr.ip.to_str().as_slice(), port));
     })
 
     iotest!(fn tcp_clone_smoke() {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port);
+            let mut s = TcpStream::connect((ip_str.as_slice(), port));
             let mut buf = [0, 0];
             assert_eq!(s.read(buf), Ok(1));
             assert_eq!(buf[0], 1);
@@ -1050,12 +1161,12 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
         let (tx1, rx) = channel();
         let tx2 = tx1.clone();
 
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port);
+            let mut s = TcpStream::connect((ip_str.as_slice(), port));
             s.write([1]).unwrap();
             rx.recv();
             s.write([2]).unwrap();
@@ -1084,10 +1195,10 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut acceptor = TcpListener::bind(ip_str.as_slice(), port).listen();
+        let mut acceptor = TcpListener::bind((ip_str.as_slice(), port)).listen();
 
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port);
+            let mut s = TcpStream::connect((ip_str.as_slice(), port));
             let mut buf = [0, 1];
             s.read(buf).unwrap();
             s.read(buf).unwrap();
@@ -1113,7 +1224,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let a = TcpListener::bind(ip_str.as_slice(), port).unwrap().listen();
+        let a = TcpListener::bind((ip_str.as_slice(), port)).unwrap().listen();
         spawn(proc() {
             let mut a = a;
             let mut c = a.accept().unwrap();
@@ -1121,7 +1232,7 @@ mod test {
             c.write([1]).unwrap();
         });
 
-        let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+        let mut s = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
         assert!(s.obj.close_write().is_ok());
         assert!(s.write([1]).is_err());
         assert_eq!(s.read_to_end(), Ok(vec!(1)));
@@ -1131,7 +1242,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str.as_slice(), port).unwrap().listen().unwrap();
+        let mut a = TcpListener::bind((ip_str.as_slice(), port)).unwrap().listen().unwrap();
 
         a.set_timeout(Some(10));
 
@@ -1150,8 +1261,8 @@ mod test {
         if !cfg!(target_os = "freebsd") {
             let (tx, rx) = channel();
             spawn(proc() {
-                tx.send(TcpStream::connect(addr.ip.to_str().as_slice(),
-                                           port).unwrap());
+                tx.send(TcpStream::connect((addr.ip.to_str().as_slice(),
+                                           port)).unwrap());
             });
             let _l = rx.recv();
             for i in range(0, 1001) {
@@ -1168,8 +1279,8 @@ mod test {
         // Unset the timeout and make sure that this always blocks.
         a.set_timeout(None);
         spawn(proc() {
-            drop(TcpStream::connect(addr.ip.to_str().as_slice(),
-                                    port).unwrap());
+            drop(TcpStream::connect((addr.ip.to_str().as_slice(),
+                                    port)).unwrap());
         });
         a.accept().unwrap();
     })
@@ -1178,7 +1289,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+        let a = TcpListener::bind((ip_str.as_slice(), port)).listen().unwrap();
         let (_tx, rx) = channel::<()>();
         spawn(proc() {
             let mut a = a;
@@ -1187,7 +1298,7 @@ mod test {
         });
 
         let mut b = [0];
-        let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+        let mut s = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
         let mut s2 = s.clone();
 
         // closing should prevent reads/writes
@@ -1216,7 +1327,7 @@ mod test {
         let addr = next_test_ip4();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+        let a = TcpListener::bind((ip_str.as_slice(), port)).listen().unwrap();
         let (_tx, rx) = channel::<()>();
         spawn(proc() {
             let mut a = a;
@@ -1224,7 +1335,7 @@ mod test {
             let _ = rx.recv_opt();
         });
 
-        let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+        let mut s = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
         let s2 = s.clone();
         let (tx, rx) = channel();
         spawn(proc() {
@@ -1243,10 +1354,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+        let mut a = TcpListener::bind((ip_str.as_slice(), port)).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+            let mut s = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
             rx.recv();
             assert!(s.write([0]).is_ok());
             let _ = rx.recv_opt();
@@ -1277,10 +1388,10 @@ mod test {
         let addr = next_test_ip6();
         let ip_str = addr.ip.to_str();
         let port = addr.port;
-        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+        let mut a = TcpListener::bind((ip_str.as_slice(), port)).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+            let mut s = TcpStream::connect((ip_str.as_slice(), port)).unwrap();
             rx.recv();
             let mut amt = 0;
             while amt < 100 * 128 * 1024 {
@@ -1305,12 +1416,10 @@ mod test {
 
     iotest!(fn write_timeouts() {
         let addr = next_test_ip6();
-        let ip_str = addr.ip.to_str();
-        let port = addr.port;
-        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+        let mut a = TcpListener::bind(addr).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+            let mut s = TcpStream::connect(addr).unwrap();
             rx.recv();
             assert!(s.write([0]).is_ok());
             let _ = rx.recv_opt();
@@ -1334,12 +1443,10 @@ mod test {
 
     iotest!(fn timeout_concurrent_read() {
         let addr = next_test_ip6();
-        let ip_str = addr.ip.to_str();
-        let port = addr.port;
-        let mut a = TcpListener::bind(ip_str.as_slice(), port).listen().unwrap();
+        let mut a = TcpListener::bind(addr.to_str().as_slice()).listen().unwrap();
         let (tx, rx) = channel::<()>();
         spawn(proc() {
-            let mut s = TcpStream::connect(ip_str.as_slice(), port).unwrap();
+            let mut s = TcpStream::connect(addr.to_str().as_slice()).unwrap();
             rx.recv();
             assert_eq!(s.write([0]), Ok(()));
             let _ = rx.recv_opt();

--- a/src/test/run-pass/tcp-connect-timeouts.rs
+++ b/src/test/run-pass/tcp-connect-timeouts.rs
@@ -63,7 +63,7 @@ iotest!(fn eventual_timeout() {
     let (tx1, rx1) = channel();
     let (_tx2, rx2) = channel::<()>();
     native::task::spawn(proc() {
-        let _l = TcpListener::bind(host.as_slice(), port).unwrap().listen();
+        let _l = TcpListener::bind((host.as_slice(), port)).unwrap().listen();
         tx1.send(());
         let _ = rx2.recv_opt();
     });
@@ -84,7 +84,7 @@ iotest!(fn timeout_success() {
     let addr = next_test_ip4();
     let host = addr.ip.to_str();
     let port = addr.port;
-    let _l = TcpListener::bind(host.as_slice(), port).unwrap().listen();
+    let _l = TcpListener::bind((host.as_slice(), port)).unwrap().listen();
 
     assert!(TcpStream::connect_timeout(addr, 1000).is_ok());
 })


### PR DESCRIPTION
cc @alexcrichton

In #13919 we changed `TcpStream::connect` to accept a host and a port parameter instead of a somewhat "uncomfortable" `SocketAddr`. There were some reasonable complaints following the merge that basically said sometimes you might _want_ a SocketAddr for various different reasons, and that carting strings around everywhere might be painful in certain situations.

@huonw and @zargony suggested it might be better for `TcpStream::connect` and `TcpListener::bind` to use traits so that they can operate with various different types of arguments. I gave that a shot, and I think the results are really nice.

This change allows the following:

```
// (&str, Int)
let conn1 = try!(TcpStream::connect(("mozilla.org", 80)))

// &str (I think this is what @alexcrichton originally wanted the API to look like prior to #13919)
let conn2 = try!(TcpStream::connect("mozilla.org:80"))

// SocketAddr{...} (this is the old pre-#13919 API)
let conn3 = try!(TcpStream::connect(SocketAddr{ip: Ipv4Addr(63, 254, 215, 20), port: 80}))
```

It would also be trivial to add support for e.g. (IpAddr, Int) tuples too, but I didn't want to get too carried away :)

I think this PR needs some work before it gets merged. In particular, `connect_timeout` hasn't been modified, and I'm not sure that we want two distinct traits (`ToBindSocketAddr` and `ToSocketAddrs`) for very similar use-cases. Figure it's at a point where it'll probably drive some discussion, though.
