### PR TITLE
Remove & -> &mut transmutation from libarena

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -299,6 +299,20 @@ fn test_arena_destructors() {
 }
 
 #[test]
+fn test_arena_alloc_nested() {
+    struct Inner { value: uint }
+    struct Outer<'a> { inner: &'a Inner }
+
+    let arena = Arena::new();
+
+    let result = arena.alloc(|| Outer {
+        inner: arena.alloc(|| Inner { value: 10 })
+    });
+
+    assert_eq!(result.inner.value, 10);
+}
+
+#[test]
 #[should_fail]
 fn test_arena_destructors_fail() {
     let arena = Arena::new();


### PR DESCRIPTION
**Update**

I've reimplemented this using `Cell` and `RefCell`, as suggested by @alexcrichton. By taking care with the duration of the borrows, I was able to maintain the recursive allocation feature (now covered by a test) without the use of `Unsafe`, and without breaking the non-aliasing `&mut` invariant.

**Original**

Changes both `Arena` and `TypedArena` to contain an inner struct wrapped in a `Unsafe`, and change field access to go through those instead of transmuting `&self` to `&mut self`.

Part of #13933
