### PR TITLE
collections: Add missing Default impls

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -13,6 +13,7 @@
 use core::prelude::*;
 
 use core::cmp;
+use core::default::Default;
 use core::fmt;
 use core::iter::{Enumerate, Repeat, Map, Zip};
 use core::ops;
@@ -695,6 +696,11 @@ pub struct BitvSet {
     // there's an array of storage makes our lives a whole lot easier when
     // performing union/intersection/etc operations
     bitv: BigBitv
+}
+
+impl Default for BitvSet {
+    #[inline]
+    fn default() -> BitvSet { BitvSet::new() }
 }
 
 impl BitvSet {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -24,6 +24,7 @@
 use core::prelude::*;
 
 use alloc::owned::Box;
+use core::default::Default;
 use core::fmt;
 use core::iter;
 use core::mem;
@@ -260,6 +261,11 @@ impl<T> Deque<T> for DList<T> {
     fn pop_back(&mut self) -> Option<T> {
         self.pop_back_node().map(|box Node{value, ..}| value)
     }
+}
+
+impl<T> Default for DList<T> {
+    #[inline]
+    fn default() -> DList<T> { DList::new() }
 }
 
 impl<T> DList<T> {

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -14,6 +14,7 @@
 
 use core::prelude::*;
 
+use core::default::Default;
 use core::mem::{zeroed, replace, swap};
 use core::ptr;
 
@@ -34,6 +35,11 @@ impl<T: Ord> Container for PriorityQueue<T> {
 impl<T: Ord> Mutable for PriorityQueue<T> {
     /// Drop all items from the queue
     fn clear(&mut self) { self.data.truncate(0) }
+}
+
+impl<T: Ord> Default for PriorityQueue<T> {
+    #[inline]
+    fn default() -> PriorityQueue<T> { PriorityQueue::new() }
 }
 
 impl<T: Ord> PriorityQueue<T> {

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -16,6 +16,7 @@
 use core::prelude::*;
 
 use core::cmp;
+use core::default::Default;
 use core::fmt;
 use core::iter::RandomAccessIterator;
 
@@ -110,6 +111,11 @@ impl<T> Deque<T> for RingBuf<T> {
         *self.elts.get_mut(hi) = Some(t);
         self.nelts += 1u;
     }
+}
+
+impl<T> Default for RingBuf<T> {
+    #[inline]
+    fn default() -> RingBuf<T> { RingBuf::new() }
 }
 
 impl<T> RingBuf<T> {

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -17,6 +17,7 @@
 
 use core::prelude::*;
 
+use core::default::Default;
 use core::fmt;
 use core::iter::{Enumerate, FilterMap};
 use core::mem::replace;
@@ -111,6 +112,11 @@ impl<V> MutableMap<uint, V> for SmallIntMap<V> {
         }
         self.v.get_mut(*key).take()
     }
+}
+
+impl<V> Default for SmallIntMap<V> {
+    #[inline]
+    fn default() -> SmallIntMap<V> { SmallIntMap::new() }
 }
 
 impl<V> SmallIntMap<V> {

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -15,6 +15,7 @@
 use core::prelude::*;
 
 use alloc::owned::Box;
+use core::default::Default;
 use core::fmt;
 use core::fmt::Show;
 use core::iter::Peekable;
@@ -132,6 +133,11 @@ impl<K: Ord, V> MutableMap<K, V> for TreeMap<K, V> {
         if ret.is_some() { self.length -= 1 }
         ret
     }
+}
+
+impl<K: Ord, V> Default for TreeMap<K,V> {
+    #[inline]
+    fn default() -> TreeMap<K, V> { TreeMap::new() }
 }
 
 impl<K: Ord, V> TreeMap<K, V> {
@@ -630,6 +636,11 @@ impl<T: Ord> MutableSet<T> for TreeSet<T> {
 
     #[inline]
     fn remove(&mut self, value: &T) -> bool { self.map.remove(value) }
+}
+
+impl<T: Ord> Default for TreeSet<T> {
+    #[inline]
+    fn default() -> TreeSet<T> { TreeSet::new() }
 }
 
 impl<T: Ord> TreeSet<T> {

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -13,6 +13,7 @@
 use core::prelude::*;
 
 use alloc::owned::Box;
+use core::default::Default;
 use core::mem::zeroed;
 use core::mem;
 use core::uint;
@@ -102,6 +103,11 @@ impl<T> MutableMap<uint, T> for TrieMap<T> {
         if ret.is_some() { self.length -= 1 }
         ret
     }
+}
+
+impl<T> Default for TrieMap<T> {
+    #[inline]
+    fn default() -> TrieMap<T> { TrieMap::new() }
 }
 
 impl<T> TrieMap<T> {
@@ -329,6 +335,11 @@ impl MutableSet<uint> for TrieSet {
     fn remove(&mut self, value: &uint) -> bool {
         self.map.remove(value)
     }
+}
+
+impl Default for TrieSet {
+    #[inline]
+    fn default() -> TrieSet { TrieSet::new() }
 }
 
 impl TrieSet {


### PR DESCRIPTION
Add `Default` impls for `TreeMap`, `TreeSet`, `SmallIntMap`, `BitvSet`, `DList`,
`PriorityQueue`, `RingBuf`, `TrieMap`, and `TrieSet`.
