### PR TITLE
std: Read HOME instead of USER

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -425,8 +425,8 @@ pub mod builtin {
     /// # Example
     ///
     /// ```rust
-    /// let user: &'static str = env!("USER");
-    /// println!("the user who compiled this code is: {}", user);
+    /// let home: &'static str = env!("HOME");
+    /// println!("the home directory at the time of compiling was: {}", home);
     /// ```
     #[macro_export]
     macro_rules! env( ($name:expr) => ({ /* compiler built-in */ }) )


### PR DESCRIPTION
Apparently one of the linux bots doesn't have the USER variable defined, and
this fix will likely land more quickly than a fix to the bots.
