### PR TITLE
rustrt: Fix invalid reads caught by valgrind

### DIFF
--- a/src/librustrt/at_exit_imp.rs
+++ b/src/librustrt/at_exit_imp.rs
@@ -54,7 +54,8 @@ pub fn run() {
         rtassert!(queue != 0);
 
         let queue: Box<Queue> = mem::transmute(queue);
-        mem::replace(&mut *queue.lock(), Vec::new())
+        let v = mem::replace(&mut *queue.lock(), Vec::new());
+        v
     };
 
     for to_run in cur.move_iter() {


### PR DESCRIPTION
This is another case of #13246. The RAII lock wasn't being destroyed until after
the allocation was free'd due to destructor scheduling.

Closes #14784
