### PR TITLE
make rustdoc distinguish between `enum` and `type`

### DIFF
--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -45,7 +45,7 @@ impl ItemType {
         match *self {
             Module          => "mod",
             Struct          => "struct",
-            Enum            => "type",
+            Enum            => "enum",
             Function        => "fn",
             Typedef         => "type",
             Static          => "static",

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -514,7 +514,7 @@
         // `rustdoc::html::item_type::ItemType` type in Rust.
         var itemTypes = ["mod",
                          "struct",
-                         "type",
+                         "enum",
                          "fn",
                          "type",
                          "static",


### PR DESCRIPTION
rustdoc was not previously distinguishing between `enum` and `type` definitions, formatting them similarly.
