### PR TITLE
Removed doubled wording.

### DIFF
--- a/src/doc/guide-lifetimes.md
+++ b/src/doc/guide-lifetimes.md
@@ -78,7 +78,7 @@ value. We also call this _borrowing_ the local variable
 name for the same data.
 
 In the case of `on_the_heap`, however, no explicit action is necessary. 
-The compiler will automatically convert a box box point to a reference like &point. 
+The compiler will automatically convert a box point to a reference like &point. 
 This is another form of borrowing; in this case, the contents of the owned box 
 are being lent out.
 


### PR DESCRIPTION
The guide previously stated:

> The compiler will automatically convert a box box point to a reference like &amp;point.

This fixes the doubled word `box`, so the statement reads

> The compiler will automatically convert a box point to a reference like &amp;point.

The code it is referring to is `compute_distance(&on_the_stack, on_the_heap);`, so a single `box` is appropriate.
