### PR TITLE
emacs: Attributes highlighting fixes 

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -212,9 +212,9 @@
      ;; Special types
      (,(regexp-opt rust-special-types 'words) . font-lock-type-face)
 
-     ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]`
+     ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]` or `#[bar = "baz"]`
      (,(rust-re-grab (concat "#\\!?\\[" rust-re-ident "[^]]*\\]"))
-      1 font-lock-preprocessor-face)
+      1 font-lock-preprocessor-face t)
 
      ;; Syntax extension invocations like `foo!`, highlight including the !
      (,(concat (rust-re-grab (concat rust-re-ident "!")) "[({[:space:][]")

--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -213,7 +213,7 @@
      (,(regexp-opt rust-special-types 'words) . font-lock-type-face)
 
      ;; Attributes like `#[bar(baz)]` or `#![bar(baz)]`
-     (,(rust-re-grab (concat "#\\!?[" rust-re-ident "[^]]*\\]"))
+     (,(rust-re-grab (concat "#\\!?\\[" rust-re-ident "[^]]*\\]"))
       1 font-lock-preprocessor-face)
 
      ;; Syntax extension invocations like `foo!`, highlight including the !


### PR DESCRIPTION
This addresses two problems noted in #14347: the highlight of `#foo]` as an attribute, and the non-highlight of `#[foo = "bar"]`.
