### PR TITLE
libsyntax: Allow `+` to separate trait bounds from objects.

### DIFF
--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -711,6 +711,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                                  .collect();
                 ty::mk_tup(tcx, flds)
             }
+            ast::TyParen(ref typ) => ast_ty_to_ty(this, rscope, &**typ),
             ast::TyBareFn(ref bf) => {
                 if bf.decl.variadic && bf.abi != abi::C {
                     tcx.sess.span_err(ast_ty.span,

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1138,6 +1138,7 @@ impl<'a> Rebuilder<'a> {
                     }
                     ast::TyTup(new_tys)
                 }
+                ast::TyParen(ref typ) => ast::TyParen(build_to(*typ, to)),
                 ref other => other.clone()
             };
             box(GC) ast::Ty { id: from.id, node: new_node, span: from.span }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -53,7 +53,7 @@ impl<T: Clean<U>, U> Clean<Vec<U>> for Vec<T> {
     }
 }
 
-impl<T: Clean<U>, U> Clean<U> for Gc<T> {
+impl<T: 'static + Clean<U>, U> Clean<U> for Gc<T> {
     fn clean(&self) -> U {
         (**self).clean()
     }
@@ -1171,6 +1171,7 @@ impl Clean<Type> for ast::Ty {
             TyClosure(ref c, region) => Closure(box c.clean(), region.clean()),
             TyProc(ref c) => Proc(box c.clean()),
             TyBareFn(ref barefn) => BareFunction(box barefn.clean()),
+            TyParen(ref ty) => ty.clean(),
             TyBot => Bottom,
             ref x => fail!("Unimplemented type {:?}", x),
         }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -792,6 +792,8 @@ pub enum Ty_ {
     TyUnboxedFn(Gc<UnboxedFnTy>),
     TyTup(Vec<P<Ty>> ),
     TyPath(Path, Option<OwnedSlice<TyParamBound>>, NodeId), // for #7264; see above
+    // No-op; kept solely so that we can pretty-print faithfully
+    TyParen(P<Ty>),
     TyTypeof(Gc<Expr>),
     // TyInfer means the type should be inferred instead of it having been
     // specified. This can appear anywhere in a type.

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -737,6 +737,7 @@ pub fn get_inner_tys(ty: P<Ty>) -> Vec<P<Ty>> {
         | ast::TyUniq(ty)
         | ast::TyFixedLengthVec(ty, _) => vec!(ty),
         ast::TyTup(ref tys) => tys.clone(),
+        ast::TyParen(ty) => get_inner_tys(ty),
         _ => Vec::new()
     }
 }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -192,6 +192,7 @@ pub trait Folder {
                 })
             }
             TyTup(ref tys) => TyTup(tys.iter().map(|&ty| self.fold_ty(ty)).collect()),
+            TyParen(ref ty) => TyParen(self.fold_ty(*ty)),
             TyPath(ref path, ref bounds, id) => {
                 let id = self.new_id(id);
                 TyPath(self.fold_path(path),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -336,7 +336,7 @@ pub fn skip_ty<E, V: Visitor<E>>(_: &mut V, _: &Ty, _: E) {
 
 pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
     match typ.node {
-        TyUniq(ty) | TyVec(ty) | TyBox(ty) => {
+        TyUniq(ty) | TyVec(ty) | TyBox(ty) | TyParen(ty) => {
             visitor.visit_ty(&*ty, env)
         }
         TyPtr(ref mutable_type) => {

--- a/src/test/auxiliary/plugin_crate_outlive_expansion_phase.rs
+++ b/src/test/auxiliary/plugin_crate_outlive_expansion_phase.rs
@@ -27,7 +27,7 @@ impl Drop for Foo {
 
 #[plugin_registrar]
 pub fn registrar(_: &mut Registry) {
-    local_data_key!(foo: Box<Any:Send>);
-    foo.replace(Some(box Foo { foo: 10 } as Box<Any:Send>));
+    local_data_key!(foo: Box<Any+Send>);
+    foo.replace(Some(box Foo { foo: 10 } as Box<Any+Send>));
 }
 

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -31,7 +31,7 @@ struct A {
 }
 
 fn main() {
-    let a = A {v: box B{v: None} as Box<Foo:Send>};
+    let a = A {v: box B{v: None} as Box<Foo+Send>};
     //~^ ERROR cannot pack type `~B`, which does not fulfill `Send`
     let v = Rc::new(RefCell::new(a));
     let w = v.clone();

--- a/src/test/compile-fail/kindck-copy.rs
+++ b/src/test/compile-fail/kindck-copy.rs
@@ -45,15 +45,15 @@ fn test<'a,T,U:Copy>(_: &'a int) {
 
     // borrowed object types are generally ok
     assert_copy::<&'a Dummy>();
-    assert_copy::<&'a Dummy:Copy>();
-    assert_copy::<&'static Dummy:Copy>();
+    assert_copy::<&'a Dummy+Copy>();
+    assert_copy::<&'static Dummy+Copy>();
 
     // owned object types are not ok
     assert_copy::<Box<Dummy>>(); //~ ERROR does not fulfill
-    assert_copy::<Box<Dummy:Copy>>(); //~ ERROR does not fulfill
+    assert_copy::<Box<Dummy+Copy>>(); //~ ERROR does not fulfill
 
     // mutable object types are not ok
-    assert_copy::<&'a mut Dummy:Copy>();  //~ ERROR does not fulfill
+    assert_copy::<&'a mut Dummy+Copy>();  //~ ERROR does not fulfill
 
     // closures are like an `&mut` object
     assert_copy::<||>(); //~ ERROR does not fulfill

--- a/src/test/compile-fail/kindck-send.rs
+++ b/src/test/compile-fail/kindck-send.rs
@@ -39,17 +39,17 @@ fn test<'a,T,U:Send>(_: &'a int) {
     // careful with object types, who knows what they close over...
     assert_send::<&'static Dummy>(); //~ ERROR does not fulfill `Send`
     assert_send::<&'a Dummy>(); //~ ERROR does not fulfill `Send`
-    assert_send::<&'a Dummy:Send>(); //~ ERROR does not fulfill `Send`
-    assert_send::<Box<Dummy:>>(); //~ ERROR does not fulfill `Send`
+    assert_send::<&'a Dummy+Send>(); //~ ERROR does not fulfill `Send`
+    assert_send::<Box<Dummy+>>(); //~ ERROR does not fulfill `Send`
 
     // ...unless they are properly bounded
-    assert_send::<&'static Dummy:Send>();
-    assert_send::<Box<Dummy:Send>>();
+    assert_send::<&'static Dummy+Send>();
+    assert_send::<Box<Dummy+Send>>();
 
     // but closure and object types can have lifetime bounds which make
     // them not ok (FIXME #5121)
     // assert_send::<proc:'a()>(); // ERROR does not fulfill `Send`
-    // assert_send::<Box<Dummy:'a>>(); // ERROR does not fulfill `Send`
+    // assert_send::<Box<Dummy+'a>>(); // ERROR does not fulfill `Send`
 
     // unsafe ptrs are ok unless they point at unsendable things
     assert_send::<*int>();

--- a/src/test/compile-fail/trait-bounds-sugar.rs
+++ b/src/test/compile-fail/trait-bounds-sugar.rs
@@ -13,17 +13,17 @@
 
 trait Foo {}
 
-fn a(_x: Box<Foo:Send>) {
+fn a(_x: Box<Foo+Send>) {
 }
 
-fn b(_x: &'static Foo) { // should be same as &'static Foo:'static
+fn b(_x: &'static Foo) { // should be same as &'static Foo+'static
 }
 
-fn c(x: Box<Foo:Share>) {
+fn c(x: Box<Foo+Share>) {
     a(x); //~ ERROR expected bounds `Send`
 }
 
-fn d(x: &'static Foo:Share) {
+fn d(x: &'static Foo+Share) {
     b(x); //~ ERROR expected bounds `'static`
 }
 

--- a/src/test/pretty/path-type-bounds.rs
+++ b/src/test/pretty/path-type-bounds.rs
@@ -14,11 +14,11 @@
 trait Tr { }
 impl Tr for int { }
 
-fn foo(x: Box<Tr: Share>) -> Box<Tr: Share> { x }
+fn foo(x: Box<Tr+ Share>) -> Box<Tr+ Share> { x }
 
 fn main() {
-    let x: Box<Tr: Share>;
+    let x: Box<Tr+ Share>;
 
-    box() 1 as Box<Tr: Share>;
+    box() 1 as Box<Tr+ Share>;
 }
 

--- a/src/test/run-fail/fail-macro-any.rs
+++ b/src/test/run-fail/fail-macro-any.rs
@@ -12,5 +12,5 @@
 
 
 fn main() {
-    fail!(box 413 as Box<::std::any::Any:Send>);
+    fail!(box 413 as Box<::std::any::Any+Send>);
 }

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -33,7 +33,7 @@ fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>:> {
     box Invoker {
         a: a,
         b: b,
-    } as Box<Invokable<A>>:
+    } as (Box<Invokable<A>>+)
 }
 
 pub fn main() {

--- a/src/test/run-pass/as-precedence.rs
+++ b/src/test/run-pass/as-precedence.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,19 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-trait Foo {
+fn main() {
+    assert_eq!(3 as uint * 3, 9);
+    assert_eq!(3 as (uint) * 3, 9);
+    assert_eq!(3 as (uint) / 3, 1);
+    assert_eq!(3 as uint + 3, 6);
+    assert_eq!(3 as (uint) + 3, 6);
 }
 
-fn a(_x: Box<Foo+Send>) {
-}
-
-fn c(x: Box<Foo+Share+Send>) {
-    a(x);
-}
-
-fn d(x: Box<Foo+>) {
-    a(x); //~ ERROR found no bounds
-}
-
-fn main() { }

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -41,7 +41,7 @@ fn main() {
     let (tx, rx) = channel();
     let (mut r, w) = (ChanReader::new(rx), ChanWriter::new(tx));
     spawn(proc() {
-        set_logger(box MyWriter(w) as Box<Logger:Send>);
+        set_logger(box MyWriter(w) as Box<Logger+Send>);
         debug!("debug");
         info!("info");
     });

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -33,11 +33,11 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
     }
 }
 
-fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>:> {
+fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+> {
     box Invoker {
         a: a,
         b: b,
-    } as Box<Invokable<A>>:
+    } as (Box<Invokable<A>>+)
 }
 
 pub fn main() {

--- a/src/test/run-pass/trait-bounds-basic.rs
+++ b/src/test/run-pass/trait-bounds-basic.rs
@@ -12,21 +12,21 @@
 trait Foo {
 }
 
-fn a(_x: Box<Foo:>) {
+fn a(_x: Box<Foo+>) {
 }
 
-fn b(_x: Box<Foo:Send>) {
+fn b(_x: Box<Foo+Send>) {
 }
 
-fn c(x: Box<Foo:Share+Send>) {
+fn c(x: Box<Foo+Share+Send>) {
     a(x);
 }
 
-fn d(x: Box<Foo:Send>) {
+fn d(x: Box<Foo+Send>) {
     b(x);
 }
 
-fn e(x: Box<Foo>) { // sugar for Box<Foo:Owned>
+fn e(x: Box<Foo>) { // sugar for Box<Foo+Owned>
     a(x);
 }
 

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -71,10 +71,10 @@ pub fn main() {
         swim_speed: 998,
         name: "alec_guinness".to_string(),
     };
-    let arc = Arc::new(vec!(box catte  as Box<Pet:Share+Send>,
-                            box dogge1 as Box<Pet:Share+Send>,
-                            box fishe  as Box<Pet:Share+Send>,
-                            box dogge2 as Box<Pet:Share+Send>));
+    let arc = Arc::new(vec!(box catte  as Box<Pet+Share+Send>,
+                            box dogge1 as Box<Pet+Share+Send>,
+                            box fishe  as Box<Pet+Share+Send>,
+                            box dogge2 as Box<Pet+Share+Send>));
     let (tx1, rx1) = channel();
     let arc1 = arc.clone();
     task::spawn(proc() { check_legs(arc1); tx1.send(()); });
@@ -89,21 +89,21 @@ pub fn main() {
     rx3.recv();
 }
 
-fn check_legs(arc: Arc<Vec<Box<Pet:Share+Send>>>) {
+fn check_legs(arc: Arc<Vec<Box<Pet+Share+Send>>>) {
     let mut legs = 0;
     for pet in arc.iter() {
         legs += pet.num_legs();
     }
     assert!(legs == 12);
 }
-fn check_names(arc: Arc<Vec<Box<Pet:Share+Send>>>) {
+fn check_names(arc: Arc<Vec<Box<Pet+Share+Send>>>) {
     for pet in arc.iter() {
         pet.name(|name| {
             assert!(name[0] == 'a' as u8 && name[1] == 'l' as u8);
         })
     }
 }
-fn check_pedigree(arc: Arc<Vec<Box<Pet:Share+Send>>>) {
+fn check_pedigree(arc: Arc<Vec<Box<Pet+Share+Send>>>) {
     for pet in arc.iter() {
         assert!(pet.of_good_pedigree());
     }

--- a/src/test/run-pass/trait-cast.rs
+++ b/src/test/run-pass/trait-cast.rs
@@ -20,7 +20,7 @@ struct Tree(@RefCell<TreeR>);
 struct TreeR {
     left: Option<Tree>,
     right: Option<Tree>,
-    val: Box<to_str:Send>
+    val: Box<to_str+Send>
 }
 
 trait to_str {
@@ -57,10 +57,10 @@ fn foo<T:to_str>(x: T) -> String { x.to_str_() }
 pub fn main() {
     let t1 = Tree(@RefCell::new(TreeR{left: None,
                                       right: None,
-                                      val: box 1 as Box<to_str:Send>}));
+                                      val: box 1 as Box<to_str+Send>}));
     let t2 = Tree(@RefCell::new(TreeR{left: Some(t1),
                                       right: Some(t1),
-                                      val: box 2 as Box<to_str:Send>}));
+                                      val: box 2 as Box<to_str+Send>}));
     let expected =
         "[2, some([1, none, none]), some([1, none, none])]".to_string();
     assert!(t2.to_str_() == expected);

--- a/src/test/run-pass/trait-contravariant-self.rs
+++ b/src/test/run-pass/trait-contravariant-self.rs
@@ -10,8 +10,8 @@
 
 // This is an interesting test case. We have a trait (Bar) that is
 // implemented for a `Box<Foo>` object (note: no bounds). And then we
-// have a `Box<Foo:Send>` object. The impl for `Box<Foo>` is applicable
-// to `Box<Foo:Send>` because:
+// have a `Box<Foo+Send>` object. The impl for `Box<Foo>` is applicable
+// to `Box<Foo+Send>` because:
 //
 // 1. The trait Bar is contravariant w/r/t Self because `Self` appears
 //    only in argument position.
@@ -30,7 +30,7 @@ impl Bar for Box<Foo> { fn dummy(&self) { } }
 fn wants_bar<B:Bar>(b: &B) { }
 
 fn main() {
-    let x: Box<Foo:Send> = (box SFoo);
+    let x: Box<Foo+Send> = (box SFoo);
     wants_bar(&x);
 }
 


### PR DESCRIPTION
RFC #27; issue #12778.

After a snapshot, the old syntax will be removed.

This can break some code that looked like `foo as &Trait:Send`. Now you
will need to write `foo as (&Trait+Send)`.

[breaking-change]

r? @alexcrichton
