### PR TITLE
librustc: Don't overwrite vtables when coercing to trait object.

### DIFF
--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -611,7 +611,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         debug!("walk_autoderefs expr={} autoderefs={}", expr.repr(self.tcx()), autoderefs);
 
         for i in range(0, autoderefs) {
-            let deref_id = typeck::MethodCall::autoderef(expr.id, i as u32);
+            let deref_id = typeck::MethodCall::autoderef(expr.id, i);
             match self.typer.node_method_ty(deref_id) {
                 None => {}
                 Some(method_ty) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -697,9 +697,14 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
                              base_cmt: cmt,
                              deref_cnt: uint)
                              -> cmt {
+        let adjustment = match self.typer.adjustments().borrow().find(&node.id()) {
+            Some(&ty::AutoObject(..)) => typeck::AutoObject,
+            _ if deref_cnt != 0 => typeck::AutoDeref(deref_cnt),
+            _ => typeck::NoAdjustment
+        };
         let method_call = typeck::MethodCall {
             expr_id: node.id(),
-            autoderef: deref_cnt as u32
+            adjustment: adjustment
         };
         let method_ty = self.typer.node_method_ty(method_call);
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2823,7 +2823,7 @@ pub fn adjust_ty(cx: &ctxt,
 
                     if !ty::type_is_error(adjusted_ty) {
                         for i in range(0, adj.autoderefs) {
-                            let method_call = typeck::MethodCall::autoderef(expr_id, i as u32);
+                            let method_call = typeck::MethodCall::autoderef(expr_id, i);
                             match method_type(method_call) {
                                 Some(method_ty) => {
                                     adjusted_ty = ty_fn_ret(method_ty);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1331,8 +1331,7 @@ pub fn autoderef<T>(fcx: &FnCtxt, sp: Span, base_ty: ty::t,
         let mt = match ty::deref(resolved_t, false) {
             Some(mt) => Some(mt),
             None => {
-                let method_call =
-                    expr_id.map(|id| MethodCall::autoderef(id, autoderefs as u32));
+                let method_call = expr_id.map(|id| MethodCall::autoderef(id, autoderefs));
                 try_overloaded_deref(fcx, sp, method_call, None, resolved_t, lvalue_pref)
             }
         };

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -879,7 +879,7 @@ fn constrain_autoderefs(rcx: &mut Rcx,
                rcx.fcx.infcx().ty_to_str(derefd_ty),
                i, derefs);
 
-        let method_call = MethodCall::autoderef(deref_expr.id, i as u32);
+        let method_call = MethodCall::autoderef(deref_expr.id, i);
         derefd_ty = match rcx.fcx.inh.method_map.borrow().find(&method_call) {
             Some(method) => {
                 // Treat overloaded autoderefs as if an AutoRef adjustment

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -248,7 +248,7 @@ impl<'cx> WritebackCx<'cx> {
 
                     ty::AutoDerefRef(adj) => {
                         for autoderef in range(0, adj.autoderefs) {
-                            let method_call = MethodCall::autoderef(id, autoderef as u32);
+                            let method_call = MethodCall::autoderef(id, autoderef);
                             self.visit_method_map_entry(reason, method_call);
                             self.visit_vtable_map_entry(reason, method_call);
                         }
@@ -260,6 +260,10 @@ impl<'cx> WritebackCx<'cx> {
                     }
 
                     ty::AutoObject(trait_store, bb, def_id, substs) => {
+                        let method_call = MethodCall::autoobject(id);
+                        self.visit_method_map_entry(reason, method_call);
+                        self.visit_vtable_map_entry(reason, method_call);
+
                         ty::AutoObject(
                             self.resolve(&trait_store, reason),
                             self.resolve(&bb, reason),

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -149,24 +149,52 @@ pub struct MethodCallee {
     pub substs: subst::Substs
 }
 
+/**
+ * With method calls, we store some extra information in
+ * side tables (i.e method_map, vtable_map). We use
+ * MethodCall as a key to index into these tables instead of
+ * just directly using the expression's NodeId. The reason
+ * for this being that we may apply adjustments (coercions)
+ * with the resulting expression also needing to use the
+ * side tables. The problem with this is that we don't
+ * assign a separate NodeId to this new expression
+ * and so it would clash with the base expression if both
+ * needed to add to the side tables. Thus to disambiguate
+ * we also keep track of whether there's an adjustment in
+ * our key.
+ */
 #[deriving(Clone, PartialEq, Eq, Hash, Show)]
 pub struct MethodCall {
     pub expr_id: ast::NodeId,
-    pub autoderef: u32
+    pub adjustment: ExprAdjustment
+}
+
+#[deriving(Clone, PartialEq, Eq, Hash, Show, Encodable, Decodable)]
+pub enum ExprAdjustment {
+    NoAdjustment,
+    AutoDeref(uint),
+    AutoObject
 }
 
 impl MethodCall {
     pub fn expr(id: ast::NodeId) -> MethodCall {
         MethodCall {
             expr_id: id,
-            autoderef: 0
+            adjustment: NoAdjustment
         }
     }
 
-    pub fn autoderef(expr_id: ast::NodeId, autoderef: u32) -> MethodCall {
+    pub fn autoobject(id: ast::NodeId) -> MethodCall {
+        MethodCall {
+            expr_id: id,
+            adjustment: AutoObject
+        }
+    }
+
+    pub fn autoderef(expr_id: ast::NodeId, autoderef: uint) -> MethodCall {
         MethodCall {
             expr_id: expr_id,
-            autoderef: 1 + autoderef
+            adjustment: AutoDeref(1 + autoderef)
         }
     }
 }

--- a/src/test/run-pass/deref-rc.rs
+++ b/src/test/run-pass/deref-rc.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::rc::Rc;
+
+fn main() {
+    let x = Rc::new([1, 2, 3, 4]);
+    assert!(*x == [1, 2, 3, 4]);
+}

--- a/src/test/run-pass/issue-14399.rs
+++ b/src/test/run-pass/issue-14399.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// #14399
+// We'd previously ICE if we had a method call whose return
+// value was coerced to a trait object. (v.clone() returns Box<B1>
+// which is coerced to Box<A>).
+
+#[deriving(Clone)]
+struct B1;
+
+trait A {}
+impl A for B1 {}
+
+fn main() {
+    let v = box B1;
+    let _c: Box<A> = v.clone();
+}


### PR DESCRIPTION
Fixes #14399.
