### PR TITLE
configure: Don't sync unused submodules

### DIFF
--- a/configure
+++ b/configure
@@ -940,8 +940,25 @@ then
     msg "git: submodule sync"
     "${CFG_GIT}" submodule sync
 
+    msg "git: submodule init"
+    "${CFG_GIT}" submodule init
+
+    # Disable submodules that we're not using
+    if [ ! -z "${CFG_LLVM_ROOT}" ]; then
+        msg "git: submodule deinit src/llvm"
+        "${CFG_GIT}" submodule deinit src/llvm
+    fi
+    if [ ! -z "${CFG_JEMALLOC_ROOT}" ]; then
+        msg "git: submodule deinit src/jemalloc"
+        "${CFG_GIT}" submodule deinit src/jemalloc
+    fi
+    if [ ! -z "${CFG_LIBUV_ROOT}" ]; then
+        msg "git: submodule deinit src/libuv"
+        "${CFG_GIT}" submodule deinit src/libuv
+    fi
+
     msg "git: submodule update"
-    "${CFG_GIT}" submodule update --init
+    "${CFG_GIT}" submodule update
     need_ok "git failed"
 
     msg "git: submodule foreach sync"
@@ -949,7 +966,7 @@ then
     need_ok "git failed"
 
     msg "git: submodule foreach update"
-    "${CFG_GIT}" submodule update --init --recursive
+    "${CFG_GIT}" submodule update --recursive
     need_ok "git failed"
 
     # NB: this is just for the sake of getting the submodule SHA1 values


### PR DESCRIPTION
If the compiler is built with --{llvm,jemalloc,libuv}-root, then the configure
script can skip updating these submodules.

Closes #14822
