### PR TITLE
Remove typo on collections::treemap::UnionItems

### DIFF
--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -737,7 +737,7 @@ pub struct IntersectionItems<'a, T> {
     b: Peekable<&'a T, SetItems<'a, T>>,
 }
 
-/// Lazy iterator producing elements in the set intersection (in-order)
+/// Lazy iterator producing elements in the set union (in-order)
 pub struct UnionItems<'a, T> {
     a: Peekable<&'a T, SetItems<'a, T>>,
     b: Peekable<&'a T, SetItems<'a, T>>,


### PR DESCRIPTION
The docstring stated it was a intersection iterator, when in fact it is the union iterator
