### PR TITLE
rustc: [T, ..N] and [T, ..N+1] are not the same

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -261,6 +261,14 @@ mod tests {
         let s = format!("{}", b);
         assert_eq!(s.as_slice(), "&Any");
     }
+
+    #[test]
+    fn any_fixed_vec() {
+        let test = [0u, ..8];
+        let test = &test as &Any;
+        assert!(test.is::<[uint, ..8]>());
+        assert!(!test.is::<[uint, ..10]>());
+    }
 }
 
 #[cfg(test)]

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4482,9 +4482,10 @@ pub fn hash_crate_independent(tcx: &ctxt, t: t, svh: &Svh) -> u64 {
             ty_uniq(_) => {
                 byte!(10);
             }
-            ty_vec(m, Some(_)) => {
+            ty_vec(m, Some(n)) => {
                 byte!(11);
                 mt(&mut state, m);
+                n.hash(&mut state);
                 1u8.hash(&mut state);
             }
             ty_vec(m, None) => {


### PR DESCRIPTION
This commit fixes a bug in the calculation of the hash of a type which didn't
factor in the length of a constant-sized vector. As a result of this, a type
placed into an Any of a fixed length could be peeled out with any other fixed
length in a safe manner.
