### PR TITLE
remove unnecessary PaX detection

### DIFF
--- a/configure
+++ b/configure
@@ -416,7 +416,6 @@ opt mingw-cross 0 "cross-compile for win32 using mingw"
 opt clang 0 "prefer clang to gcc for building the runtime"
 opt ccache 0 "invoke gcc/clang via ccache to reuse object files between builds"
 opt local-rust 0 "use an installed rustc rather than downloading a snapshot"
-opt pax-flags 0 "apply PaX flags to rustc binaries (required for GRSecurity/PaX-patched kernels)"
 opt inject-std-version 1 "inject the current compiler version of libstd into programs"
 opt llvm-static-stdcpp 0 "statically link to libstdc++ for LLVM"
 opt rpath 1 "build rpaths into rustc itself"
@@ -516,12 +515,6 @@ then
     fi
 fi
 
-if [ "$CFG_OSTYPE" = "unknown-linux-gnu" ]
-then
-    probe CFG_PAXCTL           paxctl /sbin/paxctl
-    probe CFG_ZCAT             zcat
-fi
-
 step_msg "looking for target specific programs"
 
 probe CFG_ADB        adb
@@ -541,51 +534,6 @@ then
     then
         step_msg "pandoc $PV_MAJOR.$PV_MINOR is too old. Need at least $MIN_PV_MAJOR.$MIN_PV_MINOR. Disabling"
         BAD_PANDOC=1
-    fi
-fi
-
-if [ "$CFG_OSTYPE" = "unknown-linux-gnu" ]
-then
-    if [ ! -z "$CFG_ENABLE_PAX_FLAGS" -a -z "$CFG_PAXCTL" ]
-    then
-        err "enabled PaX markings but no paxctl binary found"
-    fi
-
-    if [ -z "$CFG_DISABLE_PAX_FLAGS" ]
-    then
-        # GRSecurity/PaX detection. This can be very flaky.
-        GRSEC_DETECTED=
-
-        # /dev/grsec only exists if CONFIG_GRKERNSEC_NO_RBAC is not set.
-        # /proc/sys/kernel/grsecurity is not available if ÇONFIG_GRKERNSEC_SYSCTL is not set.
-        if [ -e /dev/grsec -o -d /proc/sys/kernel/grsecurity ]
-        then
-            GRSEC_DETECTED=1
-        # /proc/config.gz is normally only available to root, and only if CONFIG_IKCONFIG_PROC has been set.
-        elif [ -r /proc/config.gz -a ! -z "$CFG_ZCAT" ]
-        then
-            if "$CFG_ZCAT" /proc/config.gz | grep --quiet "CONFIG_GRKERNSEC=y"
-            then
-                GRSEC_DETECTED=1
-            fi
-        # Flaky.
-        elif grep --quiet grsec /proc/version
-        then
-            GRSEC_DETECTED=1
-        fi
-
-        if [ ! -z "$GRSEC_DETECTED" ]
-        then
-            step_msg "GRSecurity: yes"
-            if [ ! -z "$CFG_PAXCTL" ]
-            then
-                CFG_ENABLE_PAX_FLAGS=1
-            else
-                warn "GRSecurity kernel detected but no paxctl binary found: not setting CFG_ENABLE_PAX_FLAGS"
-            fi
-        else
-            step_msg "GRSecurity: no"
-        fi
     fi
 fi
 

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -18,10 +18,6 @@ ifdef CFG_ENABLE_LOCAL_RUST
 	$(Q)$(S)src/etc/local_stage0.sh $(CFG_BUILD) $(CFG_LOCAL_RUST_ROOT) rustlib
 else
 	$(Q)$(CFG_PYTHON) $(S)src/etc/get-snapshot.py $(CFG_BUILD) $(SNAPSHOT_FILE)
-ifdef CFG_ENABLE_PAX_FLAGS
-	@$(call E, apply PaX flags: $@)
-	@"$(CFG_PAXCTL)" -cm "$@"
-endif
 endif
 	$(Q)touch $@
 


### PR DESCRIPTION
Rust no longer has support for JIT compilation, so it doesn't currently
require a PaX MPROTECT exception. The extended attributes are preferred
over modifying the binaries so it's not actually going to work on most
systems like this anyway.

If JIT compilation ends up being supported again, it should handle this
by _always_ applying the exception via an extended attribute without
performing auto-detection of PaX on the host. The `paxctl` tool is only
necessary with the older method involving modifying the ELF binary.
