### PR TITLE
librustc: Take in account mutability when casting array to raw ptr.

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3099,9 +3099,9 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                         /* this cast is only allowed from &[T] to *T or
                         &T to *T. */
                         match (&ty::get(te).sty, &ty::get(t_1).sty) {
-                            (&ty::ty_rptr(_, mt1), &ty::ty_ptr(mt2))
-                            if types_compatible(fcx, e.span,
-                                                mt1.ty, mt2.ty) => {
+                            (&ty::ty_rptr(_, ty::mt { ty: mt1, mutbl: ast::MutImmutable }),
+                             &ty::ty_ptr(ty::mt { ty: mt2, mutbl: ast::MutImmutable }))
+                            if types_compatible(fcx, e.span, mt1, mt2) => {
                                 /* this case is allowed */
                             }
                             _ => {

--- a/src/test/compile-fail/issue-14845.rs
+++ b/src/test/compile-fail/issue-14845.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+struct X {
+    a: [u8, ..1]
+}
+
+fn main() {
+    let x = X { a: [0] };
+    let _f = &x.a as *mut u8;
+    //~^ ERROR mismatched types: expected `*mut u8` but found `&[u8, .. 1]`
+
+    let local = [0u8];
+    let _v = &local as *mut u8;
+    //~^ ERROR mismatched types: expected `*mut u8` but found `&[u8, .. 1]`
+}


### PR DESCRIPTION
Fixes #14845.
