### PR TITLE
Fix `quote_pat!` & parse outer attributes in `quote_item!`

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -368,9 +368,7 @@ pub fn expand_quote_pat(cx: &mut ExtCtxt,
                         sp: Span,
                         tts: &[ast::TokenTree])
                         -> Box<base::MacResult> {
-    let e_refutable = cx.expr_lit(sp, ast::LitBool(true));
-    let expanded = expand_parse_call(cx, sp, "parse_pat",
-                                    vec!(e_refutable), tts);
+    let expanded = expand_parse_call(cx, sp, "parse_pat", vec!(), tts);
     base::MacExpr::new(expanded)
 }
 

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -358,9 +358,8 @@ pub fn expand_quote_item(cx: &mut ExtCtxt,
                          sp: Span,
                          tts: &[ast::TokenTree])
                          -> Box<base::MacResult> {
-    let e_attrs = cx.expr_vec_ng(sp);
-    let expanded = expand_parse_call(cx, sp, "parse_item",
-                                    vec!(e_attrs), tts);
+    let expanded = expand_parse_call(cx, sp, "parse_item_with_outer_attributes",
+                                    vec!(), tts);
     base::MacExpr::new(expanded)
 }
 

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -73,8 +73,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();
-            let attrs = parser.parse_outer_attributes();
-            match parser.parse_item(attrs) {
+            match parser.parse_item_with_outer_attributes() {
                 Some(item) => ret.push(item),
                 None => break
             }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -117,8 +117,7 @@ pub fn parse_item_from_source_str(name: String,
                                   sess: &ParseSess)
                                   -> Option<Gc<ast::Item>> {
     let mut p = new_parser_from_source_str(sess, cfg, name, source);
-    let attrs = p.parse_outer_attributes();
-    maybe_aborted(p.parse_item(attrs),p)
+    maybe_aborted(p.parse_item_with_outer_attributes(),p)
 }
 
 pub fn parse_meta_from_source_str(name: String,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4900,6 +4900,11 @@ impl<'a> Parser<'a> {
         return IoviNone(attrs);
     }
 
+    pub fn parse_item_with_outer_attributes(&mut self) -> Option<Gc<Item>> {
+        let attrs = self.parse_outer_attributes();
+        self.parse_item(attrs)
+    }
+
     pub fn parse_item(&mut self, attrs: Vec<Attribute> ) -> Option<Gc<Item>> {
         match self.parse_item_or_view_item(attrs, true) {
             IoviNone(_) => None,

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -28,6 +28,9 @@ fn syntax_extension(cx: &ExtCtxt) {
     let _f: @syntax::ast::Expr = quote_expr!(cx, ());
     let _g: @syntax::ast::Expr = quote_expr!(cx, true);
     let _h: @syntax::ast::Expr = quote_expr!(cx, 'a');
+
+    let i: Option<@syntax::ast::Item> = quote_item!(cx, #[deriving(Eq)] struct Foo; );
+    assert!(i.is_some());
 }
 
 fn main() {

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test
-
 #![feature(quote)]
 #![feature(managed_boxes)]
 
@@ -18,11 +16,11 @@ extern crate syntax;
 use syntax::ext::base::ExtCtxt;
 
 fn syntax_extension(cx: &ExtCtxt) {
-    let e_toks : Vec<syntax::ast::token_tree> = quote_tokens!(cx, 1 + 2);
-    let p_toks : Vec<syntax::ast::token_tree> = quote_tokens!(cx, (x, 1 .. 4, *));
+    let e_toks : Vec<syntax::ast::TokenTree> = quote_tokens!(cx, 1 + 2);
+    let p_toks : Vec<syntax::ast::TokenTree> = quote_tokens!(cx, (x, 1 .. 4, *));
 
     let a: @syntax::ast::Expr = quote_expr!(cx, 1 + 2);
-    let _b: Option<@syntax::ast::item> = quote_item!(cx, static foo : int = $e_toks; );
+    let _b: Option<@syntax::ast::Item> = quote_item!(cx, static foo : int = $e_toks; );
     let _c: @syntax::ast::Pat = quote_pat!(cx, (x, 1 .. 4, *) );
     let _d: @syntax::ast::Stmt = quote_stmt!(cx, let x = $a; );
     let _e: @syntax::ast::Expr = quote_expr!(cx, match foo { $p_toks => 10 } );


### PR DESCRIPTION
Fix `quote_pat!` & parse outer attributes in `quote_item!`

Unignores a quasiquoting test too.
