### PR TITLE
rustc: Allow safe access of shareable static muts

### DIFF
--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -395,6 +395,7 @@ impl SchedPool {
     ///
     /// This will configure the pool according to the `config` parameter, and
     /// initially run `main` inside the pool of schedulers.
+    #[allow(unused_unsafe)] // NOTE: remove after a stage0 snap
     pub fn new(config: PoolConfig) -> SchedPool {
         static mut POOL_ID: AtomicUint = INIT_ATOMIC_UINT;
 

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -932,6 +932,7 @@ fn waitpid(pid: pid_t, deadline: u64) -> IoResult<rtio::ProcessExit> {
 }
 
 #[cfg(unix)]
+#[allow(unused_unsafe)] // NOTE: remove after a stage0 snap
 fn waitpid(pid: pid_t, deadline: u64) -> IoResult<rtio::ProcessExit> {
     use std::cmp;
     use std::comm;

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -15,6 +15,9 @@ use middle::def;
 use middle::ty;
 use middle::typeck::MethodCall;
 use util::ppaux;
+use util::nodemap::NodeSet;
+use euv = middle::expr_use_visitor;
+use mc = middle::mem_categorization;
 
 use syntax::ast;
 use syntax::ast_util::PostExpansionMethod;
@@ -40,8 +43,16 @@ fn type_is_unsafe_function(ty: ty::t) -> bool {
 struct EffectCheckVisitor<'a> {
     tcx: &'a ty::ctxt,
 
+    mutably_accessed_statics: &'a mut NodeSet,
+
     /// Whether we're in an unsafe context.
     unsafe_context: UnsafeContext,
+}
+
+struct FunctionVisitor<'a, 'b>(euv::ExprUseVisitor<'a, 'b, ty::ctxt>);
+
+struct StaticMutChecker<'a> {
+    mutably_accessed_statics: NodeSet,
 }
 
 impl<'a> EffectCheckVisitor<'a> {
@@ -142,6 +153,10 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
     }
 
     fn visit_expr(&mut self, expr: &ast::Expr, _:()) {
+        if self.mutably_accessed_statics.remove(&expr.id) {
+            self.require_unsafe(expr.span, "mutable use of static")
+        }
+
         match expr.node {
             ast::ExprMethodCall(_, _, _) => {
                 let method_call = MethodCall::expr(expr.id);
@@ -185,7 +200,12 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
             ast::ExprPath(..) => {
                 match ty::resolve_expr(self.tcx, expr) {
                     def::DefStatic(_, true) => {
-                        self.require_unsafe(expr.span, "use of mutable static")
+                        let ty = ty::node_id_to_type(self.tcx, expr.id);
+                        let contents = ty::type_contents(self.tcx, ty);
+                        if !contents.is_sharable(self.tcx) {
+                            self.require_unsafe(expr.span,
+                                                "use of non-Share static mut")
+                        }
                     }
                     _ => {}
                 }
@@ -197,11 +217,98 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
     }
 }
 
+impl<'a, 'b> Visitor<()> for FunctionVisitor<'a, 'b> {
+    fn visit_fn(&mut self, fk: &visit::FnKind, fd: &ast::FnDecl,
+                b: &ast::Block, s: Span, _: ast::NodeId, _: ()) {
+        {
+            let FunctionVisitor(ref mut inner) = *self;
+            inner.walk_fn(fd, b);
+        }
+        visit::walk_fn(self, fk, fd, b, s, ());
+    }
+}
+
+impl<'a> StaticMutChecker<'a> {
+    fn is_static_mut(&self, mut cur: &mc::cmt) -> bool {
+        loop {
+            match cur.cat {
+                mc::cat_static_item => {
+                    return match cur.mutbl {
+                        mc::McImmutable => return false,
+                        _ => true
+                    }
+                }
+                mc::cat_deref(ref cmt, _, _) |
+                mc::cat_discr(ref cmt, _) |
+                mc::cat_downcast(ref cmt) |
+                mc::cat_interior(ref cmt, _) => cur = cmt,
+
+                mc::cat_rvalue(..) |
+                mc::cat_copied_upvar(..) |
+                mc::cat_upvar(..) |
+                mc::cat_local(..) |
+                mc::cat_arg(..) => return false
+            }
+        }
+    }
+}
+
+impl<'a> euv::Delegate for StaticMutChecker<'a> {
+    fn borrow(&mut self,
+              borrow_id: ast::NodeId,
+              _borrow_span: Span,
+              cmt: mc::cmt,
+              _loan_region: ty::Region,
+              bk: ty::BorrowKind,
+              _loan_cause: euv::LoanCause) {
+        if !self.is_static_mut(&cmt) {
+            return
+        }
+        match bk {
+            ty::ImmBorrow => {}
+            ty::UniqueImmBorrow | ty::MutBorrow => {
+                self.mutably_accessed_statics.insert(borrow_id);
+            }
+        }
+    }
+
+    fn mutate(&mut self,
+              assignment_id: ast::NodeId,
+              _assignment_span: Span,
+              assignee_cmt: mc::cmt,
+              _mode: euv::MutateMode) {
+        if !self.is_static_mut(&assignee_cmt) {
+            return
+        }
+        self.mutably_accessed_statics.insert(assignment_id);
+    }
+
+    fn consume(&mut self,
+               _consume_id: ast::NodeId,
+               _consume_span: Span,
+               _cmt: mc::cmt,
+               _mode: euv::ConsumeMode) {}
+    fn consume_pat(&mut self,
+                   _consume_pat: &ast::Pat,
+                   _cmt: mc::cmt,
+                   _mode: euv::ConsumeMode) {}
+    fn decl_without_init(&mut self, _id: ast::NodeId, _span: Span) {}
+}
+
 pub fn check_crate(tcx: &ty::ctxt, krate: &ast::Crate) {
+    let mut delegate = StaticMutChecker {
+        mutably_accessed_statics: NodeSet::new(),
+    };
+    {
+        let visitor = euv::ExprUseVisitor::new(&mut delegate, tcx);
+        visit::walk_crate(&mut FunctionVisitor(visitor), krate, ());
+    }
+
     let mut visitor = EffectCheckVisitor {
         tcx: tcx,
         unsafe_context: SafeContext,
+        mutably_accessed_statics: &mut delegate.mutably_accessed_statics,
     };
-
     visit::walk_crate(&mut visitor, krate, ());
+    assert!(visitor.mutably_accessed_statics.len() == 0);
 }

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -341,11 +341,11 @@ mod test {
         let mut multi = MultiWriter::new(vec!(box TestWriter as Box<Writer>,
                                               box TestWriter as Box<Writer>));
         multi.write([1, 2, 3]).unwrap();
-        assert_eq!(2, unsafe { writes });
-        assert_eq!(0, unsafe { flushes });
+        assert_eq!(2, writes);
+        assert_eq!(0, flushes);
         multi.flush().unwrap();
-        assert_eq!(2, unsafe { writes });
-        assert_eq!(2, unsafe { flushes });
+        assert_eq!(2, writes);
+        assert_eq!(2, flushes);
     }
 
     #[test]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1082,12 +1082,22 @@ static mut EXIT_STATUS: AtomicInt = INIT_ATOMIC_INT;
  *
  * Note that this is not synchronized against modifications of other threads.
  */
+#[cfg(not(stage0))]
+pub fn set_exit_status(code: int) {
+    EXIT_STATUS.store(code, SeqCst)
+}
+#[cfg(stage0)]
 pub fn set_exit_status(code: int) {
     unsafe { EXIT_STATUS.store(code, SeqCst) }
 }
 
 /// Fetches the process's current exit code. This defaults to 0 and can change
 /// by calling `set_exit_status`.
+#[cfg(not(stage0))]
+pub fn get_exit_status() -> int {
+    EXIT_STATUS.load(SeqCst)
+}
+#[cfg(stage0)]
 pub fn get_exit_status() -> int {
     unsafe { EXIT_STATUS.load(SeqCst) }
 }

--- a/src/libsync/atomics.rs
+++ b/src/libsync/atomics.rs
@@ -95,10 +95,8 @@
 //!
 //! static mut GLOBAL_TASK_COUNT: AtomicUint = INIT_ATOMIC_UINT;
 //!
-//! unsafe {
-//!     let old_task_count = GLOBAL_TASK_COUNT.fetch_add(1, SeqCst);
-//!     println!("live tasks: {}", old_task_count + 1);
-//! }
+//! let old_task_count = GLOBAL_TASK_COUNT.fetch_add(1, SeqCst);
+//! println!("live tasks: {}", old_task_count + 1);
 //! ```
 
 use core::prelude::*;

--- a/src/libsync/mutex.rs
+++ b/src/libsync/mutex.rs
@@ -129,7 +129,7 @@ enum Flavor {
 ///
 /// static mut LOCK: StaticMutex = MUTEX_INIT;
 ///
-/// unsafe {
+/// {
 ///     let _g = LOCK.lock();
 ///     // do some productive work
 /// }

--- a/src/libsync/one.rs
+++ b/src/libsync/one.rs
@@ -32,11 +32,9 @@ use mutex::{StaticMutex, MUTEX_INIT};
 ///
 /// static mut START: Once = ONCE_INIT;
 ///
-/// unsafe {
-///     START.doit(|| {
-///         // run initialization here
-///     });
-/// }
+/// START.doit(|| {
+///     // run initialization here
+/// });
 /// ```
 pub struct Once {
     mutex: StaticMutex,

--- a/src/test/compile-fail/static-mut-foreign-requires-unsafe.rs
+++ b/src/test/compile-fail/static-mut-foreign-requires-unsafe.rs
@@ -17,5 +17,4 @@ extern {
 fn main() {
     a += 3;     //~ ERROR: requires unsafe
     a = 4;      //~ ERROR: requires unsafe
-    let _b = a; //~ ERROR: requires unsafe
 }

--- a/src/test/compile-fail/static-mut-needs-unsafe.rs
+++ b/src/test/compile-fail/static-mut-needs-unsafe.rs
@@ -1,0 +1,66 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::kinds::marker;
+
+struct NonSharable {
+    field: uint,
+    noshare: marker::NoShare
+}
+
+struct Sharable {
+    field: uint
+}
+
+impl Sharable {
+    fn foo(&self) {}
+    fn foo_mut(&mut self) {}
+}
+
+static mut NON_SHARABLE: NonSharable = NonSharable {
+    field: 1,
+    noshare: marker::NoShare,
+};
+
+static mut SHARABLE: Sharable = Sharable { field: 0 };
+
+pub fn fn_mut(_: &mut Sharable) {}
+
+pub fn main() {
+    SHARABLE.foo();
+
+    SHARABLE.foo_mut();
+    //~^ ERROR: mutable use of static requires unsafe function or block
+
+    SHARABLE.field = 2;
+    //~^ ERROR: mutable use of static requires unsafe function or block
+
+    fn_mut(&mut SHARABLE);
+    //~^ ERROR mutable use of static requires unsafe function or block
+
+    NON_SHARABLE.field = 2;
+    //~^ ERROR: use of non-Share static mut requires unsafe function or block
+    //~^^ ERROR: mutable use of static requires unsafe function or block
+
+    SHARABLE = Sharable {field: 1};
+    //~^ ERROR: mutable use of static requires unsafe function or block
+
+    let _: &mut Sharable = &mut SHARABLE;
+    //~^ ERROR mutable use of static requires unsafe function or block
+
+    let _ = &NON_SHARABLE.field;
+    //~^ ERROR: use of non-Share static mut requires unsafe function or block
+
+    let mut slc = ['a', 'c'];
+    slc[NON_SHARABLE.field] = 'b';
+    //~^ ERROR: use of non-Share static mut requires unsafe function or block
+
+    slc[SHARABLE.field] = 'b';
+}

--- a/src/test/compile-fail/static-mut-requires-unsafe.rs
+++ b/src/test/compile-fail/static-mut-requires-unsafe.rs
@@ -13,5 +13,4 @@ static mut a: int = 3;
 fn main() {
     a += 3;         //~ ERROR: requires unsafe
     a = 4;          //~ ERROR: requires unsafe
-    let _b = a;     //~ ERROR: requires unsafe
 }

--- a/src/test/run-pass/static-mut-no-need-unsafe.rs
+++ b/src/test/run-pass/static-mut-no-need-unsafe.rs
@@ -1,0 +1,39 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Sharable {
+    field: uint
+}
+
+impl Sharable {
+    fn foo(&self) {}
+    fn foo_mut(&mut self) {}
+}
+
+static mut FOO: Sharable = Sharable { field: 1 };
+
+fn borrow_static(_: &Sharable) {}
+
+pub fn main() {
+
+    FOO.foo();
+
+    borrow_static(&FOO);
+
+    let _ = &FOO;
+
+    unsafe { let _: &mut Sharable = &mut FOO; }
+
+    let mut slc = ['a', 'c'];
+    slc[FOO.field] = 'b';
+
+    let _ =  &((((FOO))));
+}
+


### PR DESCRIPTION
Taking a shareable loan of a `static mut` is safe if the type contained in the
location is ascribes to `Share`. This commit removes the need to have an
`unsafe` block in these situations.

Unsafe blocks are still required to write to or take mutable loans out of
statics. An example of code that no longer requires unsafe code is:

```
use std::sync::atomics;

static mut CNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;

let cnt = CNT.fetch_add(1, atomics::SeqCst);
```

As a consequence of this change, this code is now permitted:

```
static mut FOO: uint = 30;

println!("{}", FOO);
```

The type `uint` is `Share`, and the static only has a shareable loan taken out
on it, so the access does not require an unsafe block. Writes to the static are
still unsafe, however, as they can invoke undefined behavior if not properly
synchronized.

Closes #13232
