### PR TITLE
Remove TraitStore from ty_trait

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -346,10 +346,9 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
         assert_eq!(next(st), '[');
         let def = parse_def(st, NominalType, |x,y| conv(x,y));
         let substs = parse_substs(st, |x,y| conv(x,y));
-        let store = parse_trait_store(st, |x,y| conv(x,y));
         let bounds = parse_bounds(st, |x,y| conv(x,y));
         assert_eq!(next(st), ']');
-        return ty::mk_trait(st.tcx, def, substs, store, bounds.builtin_bounds);
+        return ty::mk_trait(st.tcx, def, substs, bounds.builtin_bounds);
       }
       'p' => {
         let did = parse_def(st, TypeParameter, |x,y| conv(x,y));

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -232,12 +232,10 @@ fn enc_sty(w: &mut MemWriter, cx: &ctxt, st: &ty::sty) {
         ty::ty_trait(box ty::TyTrait {
                 def_id,
                 ref substs,
-                store,
                 bounds
             }) => {
             mywrite!(w, "x[{}|", (cx.ds)(def_id));
             enc_substs(w, cx, substs);
-            enc_trait_store(w, cx, store);
             let bounds = ty::ParamBounds {builtin_bounds: bounds,
                                           trait_bounds: Vec::new()};
             enc_bounds(w, cx, &bounds);

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -361,9 +361,12 @@ fn check_bounds_on_type_parameters(cx: &mut Context, e: &Expr) {
 fn check_trait_cast(cx: &mut Context, source_ty: ty::t, target_ty: ty::t, span: Span) {
     check_cast_for_escaping_regions(cx, source_ty, target_ty, span);
     match ty::get(target_ty).sty {
-        ty::ty_trait(box ty::TyTrait { bounds, .. }) => {
-            check_trait_cast_bounds(cx, span, source_ty, bounds);
-        }
+        ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ ty, .. }) => match ty::get(ty).sty {
+            ty::ty_trait(box ty::TyTrait { bounds, .. }) => {
+                check_trait_cast_bounds(cx, span, source_ty, bounds);
+            }
+            _ => {}
+        },
         _ => {}
     }
 }
@@ -530,9 +533,8 @@ pub fn check_cast_for_escaping_regions(
 {
     // Determine what type we are casting to; if it is not a trait, then no
     // worries.
-    match ty::get(target_ty).sty {
-        ty::ty_trait(..) => {}
-        _ => { return; }
+    if !ty::type_is_trait(target_ty) {
+        return;
     }
 
     // Collect up the regions that appear in the target type.  We want to

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -980,9 +980,6 @@ fn check_heap_type(cx: &Context, span: Span, ty: ty::t) {
                     n_box += 1;
                 }
                 ty::ty_uniq(_) |
-                ty::ty_trait(box ty::TyTrait {
-                    store: ty::UniqTraitStore, ..
-                }) |
                 ty::ty_closure(box ty::ClosureTy {
                     store: ty::UniqTraitStore,
                     ..

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -174,20 +174,12 @@ pub enum deref_kind {
 pub fn opt_deref_kind(t: ty::t) -> Option<deref_kind> {
     match ty::get(t).sty {
         ty::ty_uniq(_) |
-        ty::ty_trait(box ty::TyTrait { store: ty::UniqTraitStore, .. }) |
         ty::ty_closure(box ty::ClosureTy {store: ty::UniqTraitStore, ..}) => {
             Some(deref_ptr(OwnedPtr))
         }
 
         ty::ty_rptr(r, mt) => {
             let kind = ty::BorrowKind::from_mutbl(mt.mutbl);
-            Some(deref_ptr(BorrowedPtr(kind, r)))
-        }
-        ty::ty_trait(box ty::TyTrait {
-                store: ty::RegionTraitStore(r, mutbl),
-                ..
-            }) => {
-            let kind = ty::BorrowKind::from_mutbl(mutbl);
             Some(deref_ptr(BorrowedPtr(kind, r)))
         }
 

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -292,12 +292,11 @@ impl Case {
     fn find_ptr(&self) -> Option<uint> {
         self.tys.iter().position(|&ty| {
             match ty::get(ty).sty {
-                ty::ty_rptr(_, mt) => match ty::get(mt.ty).sty {
-                    ty::ty_vec(_, None) | ty::ty_str => false,
+                ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => match ty::get(ty).sty {
+                    ty::ty_vec(_, None) | ty::ty_str| ty::ty_trait(..) => false,
                     _ => true,
                 },
-                ty::ty_uniq(..) | ty::ty_box(..) |
-                ty::ty_bare_fn(..) => true,
+                ty::ty_box(..) | ty::ty_bare_fn(..) => true,
                 // Is that everything?  Would closures or slices qualify?
                 _ => false
             }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1794,6 +1794,9 @@ pub fn get_fn_llvm_attributes(ccx: &CrateContext, fn_ty: ty::t) -> Vec<(uint, u6
         match ty::get(ret_ty).sty {
             // `~` pointer return values never alias because ownership
             // is transferred
+            ty::ty_uniq(it)  if match ty::get(it).sty {
+                ty::ty_str | ty::ty_vec(..) | ty::ty_trait(..) => true, _ => false
+            } => {}
             ty::ty_uniq(_) => {
                 attrs.push((lib::llvm::ReturnIndex as uint, lib::llvm::NoAliasAttribute as u64));
             }
@@ -1803,9 +1806,9 @@ pub fn get_fn_llvm_attributes(ccx: &CrateContext, fn_ty: ty::t) -> Vec<(uint, u6
         // We can also mark the return value as `nonnull` in certain cases
         match ty::get(ret_ty).sty {
             // These are not really pointers but pairs, (pointer, len)
-            ty::ty_rptr(_, ty::mt { ty: it, .. }) |
+            ty::ty_uniq(it) |
             ty::ty_rptr(_, ty::mt { ty: it, .. }) if match ty::get(it).sty {
-                ty::ty_str | ty::ty_vec(..) => true, _ => false
+                ty::ty_str | ty::ty_vec(..) | ty::ty_trait(..) => true, _ => false
             } => {}
             ty::ty_uniq(_) | ty::ty_rptr(_, _) => {
                 attrs.push((lib::llvm::ReturnIndex as uint, lib::llvm::NonNullAttribute as u64));

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -67,7 +67,7 @@ pub fn type_is_immediate(ccx: &CrateContext, ty: ty::t) -> bool {
         ty::type_is_unique(ty) || ty::type_is_region_ptr(ty) ||
         type_is_newtype_immediate(ccx, ty) || ty::type_is_bot(ty) ||
         ty::type_is_simd(tcx, ty);
-    if simple {
+    if simple && !ty::type_is_trait(ty) {
         return true;
     }
     match ty::get(ty).sty {

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -143,7 +143,9 @@ fn const_deref(cx: &CrateContext, v: ValueRef, t: ty::t, explicit: bool)
             let dv = match ty::get(t).sty {
                 ty::ty_ptr(mt) | ty::ty_rptr(_, mt) => {
                     match ty::get(mt.ty).sty {
-                        ty::ty_vec(_, None) | ty::ty_str => cx.sess().bug("unexpected slice"),
+                        ty::ty_vec(_, None) | ty::ty_str | ty::ty_trait(..) => {
+                            cx.sess().bug("unexpected unsized type")
+                        }
                         _ => const_deref_ptr(cx, v),
                     }
                 }

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -157,9 +157,7 @@ pub fn appropriate_rvalue_mode(ccx: &CrateContext, ty: ty::t) -> RvalueMode {
      * on whether type is immediate or not.
      */
 
-    if type_is_zero_size(ccx, ty) {
-        ByValue
-    } else if type_is_immediate(ccx, ty) {
+    if type_is_immediate(ccx, ty) {
         ByValue
     } else {
         ByRef

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -157,7 +157,7 @@ impl<'a, 'b> Reflector<'a, 'b> {
               let extra = extra.append(self.c_mt(mt).as_slice());
               self.visit("evec_fixed", extra.as_slice())
           }
-          ty::ty_vec(..) | ty::ty_str => fail!("unexpected unsized type"),
+          ty::ty_vec(..) | ty::ty_str | ty::ty_trait(..) => fail!("unexpected unsized type"),
           // Should remove mt from box and uniq.
           ty::ty_box(typ) => {
               let extra = self.c_mt(&ty::mt {
@@ -174,6 +174,13 @@ impl<'a, 'b> Reflector<'a, 'b> {
                       self.visit("evec_uniq", extra.as_slice())
                   }
                   ty::ty_str => self.visit("estr_uniq", &[]),
+                  ty::ty_trait(..) => {
+                      let extra = [
+                          self.c_slice(token::intern_and_get_ident(
+                                  ty_to_str(tcx, t).as_slice()))
+                      ];
+                      self.visit("trait", extra);
+                  }
                   _ => {
                       let extra = self.c_mt(&ty::mt {
                           ty: typ,
@@ -196,6 +203,13 @@ impl<'a, 'b> Reflector<'a, 'b> {
                                  extra.as_slice())
                   }
                   ty::ty_str => self.visit("estr_slice", &[]),
+                  ty::ty_trait(..) => {
+                      let extra = [
+                          self.c_slice(token::intern_and_get_ident(
+                                  ty_to_str(tcx, t).as_slice()))
+                      ];
+                      self.visit("trait", extra);
+                  }
                   _ => {
                       let extra = self.c_mt(mt);
                       self.visit("rptr", extra.as_slice())
@@ -349,14 +363,6 @@ impl<'a, 'b> Reflector<'a, 'b> {
                     })
                 }
             })
-          }
-
-          ty::ty_trait(..) => {
-              let extra = [
-                  self.c_slice(token::intern_and_get_ident(
-                          ty_to_str(tcx, t).as_slice()))
-              ];
-              self.visit("trait", extra);
           }
 
           // Miscellaneous extra types

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -742,7 +742,6 @@ pub enum sty {
 pub struct TyTrait {
     pub def_id: DefId,
     pub substs: Substs,
-    pub store: TraitStore,
     pub bounds: BuiltinBounds
 }
 
@@ -1196,14 +1195,8 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
       &ty_enum(_, ref substs) | &ty_struct(_, ref substs) => {
           flags |= sflags(substs);
       }
-      &ty_trait(box ty::TyTrait { ref substs, store, .. }) => {
+      &ty_trait(box ty::TyTrait { ref substs, .. }) => {
           flags |= sflags(substs);
-          match store {
-              RegionTraitStore(r, _) => {
-                    flags |= rflags(r);
-                }
-              _ => {}
-          }
       }
       &ty_box(tt) | &ty_uniq(tt) => {
         flags |= get(tt).flags
@@ -1434,14 +1427,12 @@ pub fn mk_ctor_fn(cx: &ctxt,
 pub fn mk_trait(cx: &ctxt,
                 did: ast::DefId,
                 substs: Substs,
-                store: TraitStore,
                 bounds: BuiltinBounds)
              -> t {
     // take a copy of substs so that we own the vectors inside
     let inner = box TyTrait {
         def_id: did,
         substs: substs,
-        store: store,
         bounds: bounds
     };
     mk_t(cx, ty_trait(inner))
@@ -1577,9 +1568,9 @@ fn type_is_slice(ty:t) -> bool {
 
 pub fn type_is_structural(ty: t) -> bool {
     match get(ty).sty {
-      ty_struct(..) | ty_tup(_) | ty_enum(..) | ty_closure(_) | ty_trait(..) |
+      ty_struct(..) | ty_tup(_) | ty_enum(..) | ty_closure(_) |
       ty_vec(_, Some(_)) => true,
-      _ => type_is_slice(ty)
+      _ => type_is_slice(ty) | type_is_trait(ty)
     }
 }
 
@@ -1635,7 +1626,7 @@ pub fn type_is_region_ptr(ty: t) -> bool {
         ty_rptr(_, mt) => match get(mt.ty).sty {
             // FIXME(nrc, DST) slices weren't regarded as rptrs, so we preserve this
             // odd behaviour for now. (But ~[] were unique. I have no idea why).
-            ty_vec(_, None) | ty_str => false,
+            ty_vec(_, None) | ty_str | ty_trait(..) => false,
             _ => true
         },
         _ => false
@@ -1651,7 +1642,10 @@ pub fn type_is_unsafe_ptr(ty: t) -> bool {
 
 pub fn type_is_unique(ty: t) -> bool {
     match get(ty).sty {
-        ty_uniq(_) => true,
+        ty_uniq(_) => match get(ty).sty {
+            ty_trait(..) => false,
+            _ => true
+        },
         _ => false
     }
 }
@@ -2060,8 +2054,8 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
                 }
             }
 
-            ty_trait(box ty::TyTrait { store, bounds, .. }) => {
-                object_contents(cx, store, bounds)
+            ty_trait(box ty::TyTrait { bounds, .. }) => {
+                object_contents(cx, bounds)
             }
 
             ty_ptr(ref mt) => {
@@ -2185,7 +2179,16 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
     fn closure_contents(cx: &ctxt, cty: &ClosureTy) -> TypeContents {
         // Closure contents are just like trait contents, but with potentially
         // even more stuff.
-        let st = object_contents(cx, cty.store, cty.bounds);
+        let st = object_contents(cx, cty.bounds);
+
+        let st = match cty.store {
+            UniqTraitStore => {
+                st.owned_pointer()
+            }
+            RegionTraitStore(r, mutbl) => {
+                st.reference(borrowed_contents(r, mutbl))
+            }
+        };
 
         // This also prohibits "@once fn" from being copied, which allows it to
         // be called. Neither way really makes much sense.
@@ -2198,20 +2201,10 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
     }
 
     fn object_contents(cx: &ctxt,
-                       store: TraitStore,
                        bounds: BuiltinBounds)
                        -> TypeContents {
         // These are the type contents of the (opaque) interior
-        let contents = kind_bounds_to_contents(cx, bounds, []);
-
-        match store {
-            UniqTraitStore => {
-                contents.owned_pointer()
-            }
-            RegionTraitStore(r, mutbl) => {
-                contents.reference(borrowed_contents(r, mutbl))
-            }
-        }
+        kind_bounds_to_contents(cx, bounds, [])
     }
 
     fn kind_bounds_to_contents(cx: &ctxt,
@@ -2470,6 +2463,10 @@ pub fn is_type_representable(cx: &ctxt, sp: Span, ty: t) -> Representability {
 
 pub fn type_is_trait(ty: t) -> bool {
     match get(ty).sty {
+        ty_uniq(ty) | ty_rptr(_, mt { ty, ..}) => match get(ty).sty {
+            ty_trait(..) => true,
+            _ => false
+        },
         ty_trait(..) => true,
         _ => false
     }
@@ -2559,7 +2556,7 @@ pub fn deref(t: t, explicit: bool) -> Option<mt> {
     match get(t).sty {
         ty_box(typ) | ty_uniq(typ) => match get(typ).sty {
             // Don't deref ~[] etc., might need to generalise this to all DST.
-            ty_vec(_, None) | ty_str => None,
+            ty_vec(_, None) | ty_str | ty_trait(..) => None,
             _ => Some(mt {
                 ty: typ,
                 mutbl: ast::MutImmutable,
@@ -2567,7 +2564,7 @@ pub fn deref(t: t, explicit: bool) -> Option<mt> {
         },
         ty_rptr(_, mt) => match get(mt.ty).sty {
             // Don't deref &[], might need to generalise this to all DST.
-            ty_vec(_, None) | ty_str => None,
+            ty_vec(_, None) | ty_str | ty_trait(..) => None,
             _ => Some(mt),
         },
         ty_ptr(mt) if explicit => Some(mt),
@@ -2888,7 +2885,19 @@ pub fn adjust_ty(cx: &ctxt,
                 }
 
                 AutoObject(store, bounds, def_id, ref substs) => {
-                    mk_trait(cx, def_id, substs.clone(), store, bounds)
+
+                    let tr = mk_trait(cx, def_id, substs.clone(), bounds);
+                    match store {
+                        UniqTraitStore => {
+                            mk_uniq(cx, tr)
+                        }
+                        RegionTraitStore(r, m) => {
+                            mk_rptr(cx, r, mt {
+                                ty: tr,
+                                mutbl: m
+                            })
+                        }
+                    }
                 }
             }
         }
@@ -2926,10 +2935,20 @@ pub fn adjust_ty(cx: &ctxt,
     fn borrow_obj(cx: &ctxt, span: Span, r: Region,
                   m: ast::Mutability, ty: ty::t) -> ty::t {
         match get(ty).sty {
-            ty_trait(box ty::TyTrait {def_id, ref substs, bounds, .. }) => {
-                ty::mk_trait(cx, def_id, substs.clone(),
-                             RegionTraitStore(r, m), bounds)
-            }
+            ty_uniq(t) | ty_rptr(_, mt{ty: t, ..}) => match get(t).sty {
+                ty_trait(box ty::TyTrait {def_id, ref substs, bounds, .. }) => {
+                    mk_rptr(cx, r, mt {
+                        ty: ty::mk_trait(cx, def_id, substs.clone(), bounds),
+                        mutbl: m
+                    })
+                }
+                _ => {
+                    cx.sess.span_bug(
+                        span,
+                        format!("borrow-trait-obj associated with bad sty: {:?}",
+                                get(ty).sty).as_slice());
+                }
+            },
             ref s => {
                 cx.sess.span_bug(
                     span,
@@ -4264,11 +4283,11 @@ pub fn visitor_object_ty(tcx: &ctxt,
     let substs = Substs::empty();
     let trait_ref = Rc::new(TraitRef { def_id: trait_lang_item, substs: substs });
     Ok((trait_ref.clone(),
-        mk_trait(tcx,
-                 trait_ref.def_id,
-                 trait_ref.substs.clone(),
-                 RegionTraitStore(region, ast::MutMutable),
-                 empty_builtin_bounds())))
+        mk_rptr(tcx, region, mt {mutbl: ast::MutMutable,
+                                 ty: mk_trait(tcx,
+                                              trait_ref.def_id,
+                                              trait_ref.substs.clone(),
+                                              empty_builtin_bounds()) })))
 }
 
 pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> Rc<ItemVariances> {
@@ -4562,17 +4581,9 @@ pub fn hash_crate_independent(tcx: &ctxt, t: t, svh: &Svh) -> u64 {
                     }
                 }
             }
-            ty_trait(box ty::TyTrait { def_id: d, store, bounds, .. }) => {
+            ty_trait(box ty::TyTrait { def_id: d, bounds, .. }) => {
                 byte!(17);
                 did(&mut state, d);
-                match store {
-                    UniqTraitStore => byte!(0),
-                    RegionTraitStore(r, m) => {
-                        byte!(1)
-                        region(&mut state, r);
-                        hash!(m);
-                    }
-                }
                 hash!(bounds);
             }
             ty_struct(d, _) => {

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -364,13 +364,11 @@ pub fn super_fold_sty<T:TypeFolder>(this: &mut T,
         ty::ty_trait(box ty::TyTrait {
                 def_id,
                 ref substs,
-                store,
                 bounds
             }) => {
             ty::ty_trait(box ty::TyTrait {
                 def_id: def_id,
                 substs: substs.fold_with(this),
-                store: store.fold_with(this),
                 bounds: bounds
             })
         }

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -725,10 +725,10 @@ pub fn check_pointer_pat(pcx: &pat_ctxt,
         fcx.write_ty(pat_id, expected);
     };
     match *structure_of(fcx, span, expected) {
-        ty::ty_uniq(e_inner) if pointer_kind == Send => {
+        ty::ty_uniq(e_inner) if pointer_kind == Send && !ty::type_is_trait(e_inner) => {
             check_inner(e_inner);
         }
-        ty::ty_rptr(_, e_inner) if pointer_kind == Borrowed => {
+        ty::ty_rptr(_, e_inner) if pointer_kind == Borrowed && !ty::type_is_trait(e_inner.ty) => {
             check_inner(e_inner.ty);
         }
         _ => {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3021,7 +3021,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         else {
             match ty::get(t_1).sty {
                 // This will be looked up later on
-                ty::ty_trait(..) => (),
+                _ if ty::type_is_trait(t_1) => {},
 
                 _ => {
                     if ty::type_is_nil(t_e) {

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -543,15 +543,18 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             // explaining how it goes about doing that.
             let target_ty = rcx.resolve_node_type(expr.id);
             match ty::get(target_ty).sty {
-                ty::ty_trait(box ty::TyTrait {
-                    store: ty::RegionTraitStore(trait_region, _), ..
-                }) => {
-                    let source_ty = rcx.resolve_expr_type_adjusted(&**source);
-                    constrain_regions_in_type(
-                        rcx,
-                        trait_region,
-                        infer::RelateObjectBound(expr.span),
-                        source_ty);
+                ty::ty_rptr(trait_region, ty::mt{ty, ..}) => {
+                    match ty::get(ty).sty {
+                        ty::ty_trait(..) => {
+                            let source_ty = rcx.resolve_expr_type_adjusted(&**source);
+                            constrain_regions_in_type(
+                                rcx,
+                                trait_region,
+                                infer::RelateObjectBound(expr.span),
+                                source_ty);
+                        }
+                        _ => {}
+                    }
                 }
                 _ => ()
             }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -694,7 +694,6 @@ impl<'a> InferCtxt<'a> {
         let dummy0 = ty::mk_trait(self.tcx,
                                   trait_ref.def_id,
                                   trait_ref.substs.clone(),
-                                  ty::UniqTraitStore,
                                   ty::empty_builtin_bounds());
         let dummy1 = self.resolve_type_vars_if_possible(dummy0);
         match ty::get(dummy1).sty {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -390,7 +390,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> String {
           parameterized(cx, base.as_slice(), substs, &generics)
       }
       ty_trait(box ty::TyTrait {
-          def_id: did, ref substs, store, ref bounds
+          def_id: did, ref substs, ref bounds
       }) => {
           let base = ty::item_path_str(cx, did);
           let trait_def = ty::lookup_trait_def(cx, did);
@@ -398,8 +398,7 @@ pub fn ty_to_str(cx: &ctxt, typ: t) -> String {
                                  substs, &trait_def.generics);
           let bound_sep = if bounds.is_empty() { "" } else { ":" };
           let bound_str = bounds.repr(cx);
-          format!("{}{}{}{}",
-                  trait_store_to_str(cx, store),
+          format!("{}{}{}",
                   ty,
                   bound_sep,
                   bound_str)


### PR DESCRIPTION
Use ty_rptr/ty_uniq(ty_trait) rather than TraitStore to represent trait types.
Also addresses (but doesn't close) #12470.
Part of the work towards DST (#12938).
