### PR TITLE
Introduce VecPerParamSpace and use it to represent sets of types and parameters

### DIFF
--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -189,9 +189,7 @@ pub static tag_impls_impl: uint = 0x81;
 pub static tag_items_data_item_inherent_impl: uint = 0x82;
 pub static tag_items_data_item_extension_impl: uint = 0x83;
 
-pub static tag_region_param_def: uint = 0x84;
-pub static tag_region_param_def_ident: uint = 0x85;
-pub static tag_region_param_def_def_id: uint = 0x86;
+// GAP 0x84, 0x85, 0x86
 
 pub static tag_native_libraries: uint = 0x87;
 pub static tag_native_libraries_lib: uint = 0x88;
@@ -217,3 +215,9 @@ pub struct LinkMeta {
     pub crateid: CrateId,
     pub crate_hash: Svh,
 }
+
+pub static tag_region_param_def: uint = 0x90;
+pub static tag_region_param_def_ident: uint = 0x91;
+pub static tag_region_param_def_def_id: uint = 0x92;
+pub static tag_region_param_def_space: uint = 0x93;
+pub static tag_region_param_def_index: uint = 0x94;

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -18,6 +18,7 @@ use metadata::decoder;
 use middle::lang_items;
 use middle::ty;
 use middle::typeck;
+use middle::subst::VecPerParamSpace;
 
 use serialize::ebml;
 use serialize::ebml::reader;
@@ -223,8 +224,8 @@ pub fn get_field_type(tcx: &ty::ctxt, class_id: ast::DefId,
         });
     let ty = decoder::item_type(def, the_field, tcx, &*cdata);
     ty::ty_param_bounds_and_ty {
-        generics: ty::Generics {type_param_defs: Rc::new(Vec::new()),
-                                region_param_defs: Rc::new(Vec::new())},
+        generics: ty::Generics {types: VecPerParamSpace::empty(),
+                                regions: VecPerParamSpace::empty()},
         ty: ty
     }
 }
@@ -240,7 +241,8 @@ pub fn get_impl_trait(tcx: &ty::ctxt,
 
 // Given a def_id for an impl, return information about its vtables
 pub fn get_impl_vtables(tcx: &ty::ctxt,
-                        def: ast::DefId) -> typeck::impl_res {
+                        def: ast::DefId)
+                        -> typeck::vtable_res {
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_impl_vtables(&*cdata, def.node, tcx)

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -17,6 +17,7 @@
 #![allow(non_camel_case_types)]
 
 use middle::subst;
+use middle::subst::VecPerParamSpace;
 use middle::ty;
 
 use std::rc::Rc;
@@ -114,26 +115,45 @@ pub fn parse_state_from_data<'a>(data: &'a [u8], crate_num: ast::CrateNum,
     }
 }
 
+fn data_log_string(data: &[u8], pos: uint) -> String {
+    let mut buf = String::new();
+    buf.push_str("<<");
+    for i in range(pos, data.len()) {
+        let c = data[i];
+        if c > 0x20 && c <= 0x7F {
+            buf.push_char(c as char);
+        } else {
+            buf.push_char('.');
+        }
+    }
+    buf.push_str(">>");
+    buf
+}
+
 pub fn parse_ty_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                      conv: conv_did) -> ty::t {
+    debug!("parse_ty_data {}", data_log_string(data, pos));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_ty(&mut st, conv)
 }
 
 pub fn parse_bare_fn_ty_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                              conv: conv_did) -> ty::BareFnTy {
+    debug!("parse_bare_fn_ty_data {}", data_log_string(data, pos));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_bare_fn_ty(&mut st, conv)
 }
 
 pub fn parse_trait_ref_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                             conv: conv_did) -> ty::TraitRef {
+    debug!("parse_trait_ref_data {}", data_log_string(data, pos));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_trait_ref(&mut st, conv)
 }
 
 pub fn parse_substs_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                          conv: conv_did) -> subst::Substs {
+    debug!("parse_substs_data {}", data_log_string(data, pos));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_substs(&mut st, conv)
 }
@@ -162,34 +182,39 @@ fn parse_trait_store(st: &mut PState, conv: conv_did) -> ty::TraitStore {
     }
 }
 
+fn parse_vec_per_param_space<T>(st: &mut PState,
+                                f: |&mut PState| -> T)
+                                -> VecPerParamSpace<T>
+{
+    let mut r = VecPerParamSpace::empty();
+    for &space in subst::ParamSpace::all().iter() {
+        assert_eq!(next(st), '[');
+        while peek(st) != ']' {
+            r.push(space, f(st));
+        }
+        assert_eq!(next(st), ']');
+    }
+    r
+}
+
 fn parse_substs(st: &mut PState, conv: conv_did) -> subst::Substs {
-    let regions = parse_region_substs(st, |x,y| conv(x,y));
+    let regions =
+        parse_region_substs(st, |x,y| conv(x,y));
 
-    let self_ty = parse_opt(st, |st| parse_ty(st, |x,y| conv(x,y)) );
+    let types =
+        parse_vec_per_param_space(st, |st| parse_ty(st, |x,y| conv(x,y)));
 
-    assert_eq!(next(st), '[');
-    let mut params: Vec<ty::t> = Vec::new();
-    while peek(st) != ']' { params.push(parse_ty(st, |x,y| conv(x,y))); }
-    st.pos = st.pos + 1u;
-
-    return subst::Substs {
-        regions: regions,
-        self_ty: self_ty,
-        tps: params
-    };
+    return subst::Substs { types: types,
+                           regions: regions };
 }
 
 fn parse_region_substs(st: &mut PState, conv: conv_did) -> subst::RegionSubsts {
     match next(st) {
         'e' => subst::ErasedRegions,
         'n' => {
-            let mut regions = vec!();
-            while peek(st) != '.' {
-                let r = parse_region(st, |x,y| conv(x,y));
-                regions.push(r);
-            }
-            assert_eq!(next(st), '.');
-            subst::NonerasedRegions(regions)
+            subst::NonerasedRegions(
+                parse_vec_per_param_space(
+                    st, |st| parse_region(st, |x,y| conv(x,y))))
         }
         _ => fail!("parse_bound_region: bad input")
     }
@@ -230,10 +255,12 @@ fn parse_region(st: &mut PState, conv: conv_did) -> ty::Region {
         assert_eq!(next(st), '[');
         let node_id = parse_uint(st) as ast::NodeId;
         assert_eq!(next(st), '|');
+        let space = parse_param_space(st);
+        assert_eq!(next(st), '|');
         let index = parse_uint(st);
         assert_eq!(next(st), '|');
         let nm = token::str_to_ident(parse_str(st, ']').as_slice());
-        ty::ReEarlyBound(node_id, index, nm.name)
+        ty::ReEarlyBound(node_id, space, index, nm.name)
       }
       'f' => {
         assert_eq!(next(st), '[');
@@ -327,11 +354,11 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
       'p' => {
         let did = parse_def(st, TypeParameter, |x,y| conv(x,y));
         debug!("parsed ty_param: did={:?}", did);
-        return ty::mk_param(st.tcx, parse_uint(st), did);
-      }
-      's' => {
-        let did = parse_def(st, TypeParameter, |x,y| conv(x,y));
-        return ty::mk_self(st.tcx, did);
+        let index = parse_uint(st);
+        assert_eq!(next(st), '|');
+        let space = parse_param_space(st);
+        assert_eq!(next(st), '|');
+        return ty::mk_param(st.tcx, space, index, did);
       }
       '@' => return ty::mk_box(st.tcx, parse_ty(st, |x,y| conv(x,y))),
       '~' => return ty::mk_uniq(st.tcx, parse_ty(st, |x,y| conv(x,y))),
@@ -395,6 +422,9 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
           assert_eq!(next(st), ']');
           return ty::mk_struct(st.tcx, did, substs);
       }
+      'e' => {
+          return ty::mk_err();
+      }
       c => { fail!("unexpected char in type string: {}", c);}
     }
 }
@@ -425,6 +455,10 @@ fn parse_uint(st: &mut PState) -> uint {
         n *= 10;
         n += (cur as uint) - ('0' as uint);
     };
+}
+
+fn parse_param_space(st: &mut PState) -> subst::ParamSpace {
+    subst::ParamSpace::from_uint(parse_uint(st))
 }
 
 fn parse_hex(st: &mut PState) -> uint {
@@ -546,11 +580,22 @@ pub fn parse_type_param_def_data(data: &[u8], start: uint,
 }
 
 fn parse_type_param_def(st: &mut PState, conv: conv_did) -> ty::TypeParameterDef {
+    let ident = parse_ident(st, ':');
+    let def_id = parse_def(st, NominalType, |x,y| conv(x,y));
+    let space = parse_param_space(st);
+    assert_eq!(next(st), '|');
+    let index = parse_uint(st);
+    assert_eq!(next(st), '|');
+    let bounds = Rc::new(parse_bounds(st, |x,y| conv(x,y)));
+    let default = parse_opt(st, |st| parse_ty(st, |x,y| conv(x,y)));
+
     ty::TypeParameterDef {
-        ident: parse_ident(st, ':'),
-        def_id: parse_def(st, NominalType, |x,y| conv(x,y)),
-        bounds: Rc::new(parse_bounds(st, |x,y| conv(x,y))),
-        default: parse_opt(st, |st| parse_ty(st, |x,y| conv(x,y)))
+        ident: ident,
+        def_id: def_id,
+        space: space,
+        index: index,
+        bounds: bounds,
+        default: default
     }
 }
 

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use middle::subst::ParamSpace;
 use syntax::ast;
 use syntax::ast_util::local_def;
 
@@ -27,7 +28,7 @@ pub enum Def {
     DefTy(ast::DefId),
     DefTrait(ast::DefId),
     DefPrimTy(ast::PrimTy),
-    DefTyParam(ast::DefId, uint),
+    DefTyParam(ParamSpace, ast::DefId, uint),
     DefBinding(ast::NodeId, ast::BindingMode),
     DefUse(ast::DefId),
     DefUpvar(ast::NodeId,  // id of closed over var
@@ -61,7 +62,7 @@ impl Def {
         match *self {
             DefFn(id, _) | DefStaticMethod(id, _, _) | DefMod(id) |
             DefForeignMod(id) | DefStatic(id, _) |
-            DefVariant(_, id, _) | DefTy(id) | DefTyParam(id, _) |
+            DefVariant(_, id, _) | DefTy(id) | DefTyParam(_, id, _) |
             DefUse(id) | DefStruct(id) | DefTrait(id) | DefMethod(id, _) => {
                 id
             }

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -231,7 +231,7 @@ impl <'l> DxrVisitor<'l> {
             def::DefTyParamBinder(_) |
             def::DefLabel(_) |
             def::DefStaticMethod(_, _, _) |
-            def::DefTyParam(_, _) |
+            def::DefTyParam(..) |
             def::DefUse(_) |
             def::DefMethod(_, _) |
             def::DefPrimTy(_) => {

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -15,10 +15,80 @@ use middle::ty_fold;
 use middle::ty_fold::{TypeFoldable, TypeFolder};
 use util::ppaux::Repr;
 
+use std::iter::Chain;
+use std::mem;
+use std::raw;
+use std::slice::{Items, MutItems};
 use std::vec::Vec;
-use syntax::codemap::Span;
+use syntax::codemap::{Span, DUMMY_SP};
 
 ///////////////////////////////////////////////////////////////////////////
+// HomogeneousTuple3 trait
+//
+// This could be moved into standard library at some point.
+
+trait HomogeneousTuple3<T> {
+    fn len(&self) -> uint;
+    fn as_slice<'a>(&'a self) -> &'a [T];
+    fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T];
+    fn iter<'a>(&'a self) -> Items<'a, T>;
+    fn mut_iter<'a>(&'a mut self) -> MutItems<'a, T>;
+    fn get<'a>(&'a self, index: uint) -> Option<&'a T>;
+    fn get_mut<'a>(&'a mut self, index: uint) -> Option<&'a mut T>;
+}
+
+impl<T> HomogeneousTuple3<T> for (T, T, T) {
+    fn len(&self) -> uint {
+        3
+    }
+
+    fn as_slice<'a>(&'a self) -> &'a [T] {
+        unsafe {
+            let ptr: *T = mem::transmute(self);
+            let slice = raw::Slice { data: ptr, len: 3 };
+            mem::transmute(slice)
+        }
+    }
+
+    fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
+        unsafe {
+            let ptr: *T = mem::transmute(self);
+            let slice = raw::Slice { data: ptr, len: 3 };
+            mem::transmute(slice)
+        }
+    }
+
+    fn iter<'a>(&'a self) -> Items<'a, T> {
+        let slice: &'a [T] = self.as_slice();
+        slice.iter()
+    }
+
+    fn mut_iter<'a>(&'a mut self) -> MutItems<'a, T> {
+        self.as_mut_slice().mut_iter()
+    }
+
+    fn get<'a>(&'a self, index: uint) -> Option<&'a T> {
+        self.as_slice().get(index)
+    }
+
+    fn get_mut<'a>(&'a mut self, index: uint) -> Option<&'a mut T> {
+        Some(&mut self.as_mut_slice()[index]) // wrong: fallible
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+/**
+ * A substitution mapping type/region parameters to new values. We
+ * identify each in-scope parameter by an *index* and a *parameter
+ * space* (which indices where the parameter is defined; see
+ * `ParamSpace`).
+ */
+#[deriving(Clone, PartialEq, Eq, Hash)]
+pub struct Substs {
+    pub types: VecPerParamSpace<ty::t>,
+    pub regions: RegionSubsts,
+}
 
 /**
  * Represents the values to use when substituting lifetime parameters.
@@ -27,46 +97,49 @@ use syntax::codemap::Span;
 #[deriving(Clone, PartialEq, Eq, Hash)]
 pub enum RegionSubsts {
     ErasedRegions,
-    NonerasedRegions(Vec<ty::Region>)
-}
-
-/**
- * The type `Substs` represents the kinds of things that can be substituted to
- * convert a polytype into a monotype.  Note however that substituting bound
- * regions other than `self` is done through a different mechanism:
- *
- * - `tps` represents the type parameters in scope.  They are indexed
- *   according to the order in which they were declared.
- *
- * - `self_r` indicates the region parameter `self` that is present on nominal
- *   types (enums, structs) declared as having a region parameter.  `self_r`
- *   should always be none for types that are not region-parameterized and
- *   Some(_) for types that are.  The only bound region parameter that should
- *   appear within a region-parameterized type is `self`.
- *
- * - `self_ty` is the type to which `self` should be remapped, if any.  The
- *   `self` type is rather funny in that it can only appear on traits and is
- *   always substituted away to the implementing type for a trait. */
-#[deriving(Clone, PartialEq, Eq, Hash)]
-pub struct Substs {
-    pub self_ty: Option<ty::t>,
-    pub tps: Vec<ty::t>,
-    pub regions: RegionSubsts,
+    NonerasedRegions(VecPerParamSpace<ty::Region>)
 }
 
 impl Substs {
+    pub fn new(t: VecPerParamSpace<ty::t>,
+               r: VecPerParamSpace<ty::Region>)
+               -> Substs
+    {
+        Substs { types: t, regions: NonerasedRegions(r) }
+    }
+
+    pub fn new_type(t: Vec<ty::t>,
+                    r: Vec<ty::Region>)
+                    -> Substs
+    {
+        Substs::new(VecPerParamSpace::new(t, Vec::new(), Vec::new()),
+                    VecPerParamSpace::new(r, Vec::new(), Vec::new()))
+    }
+
+    pub fn new_trait(t: Vec<ty::t>,
+                     r: Vec<ty::Region>,
+                     s: ty::t)
+                    -> Substs
+    {
+        Substs::new(VecPerParamSpace::new(t, vec!(s), Vec::new()),
+                    VecPerParamSpace::new(r, Vec::new(), Vec::new()))
+    }
+
+    pub fn erased(t: VecPerParamSpace<ty::t>) -> Substs
+    {
+        Substs { types: t, regions: ErasedRegions }
+    }
+
     pub fn empty() -> Substs {
         Substs {
-            self_ty: None,
-            tps: Vec::new(),
-            regions: NonerasedRegions(Vec::new())
+            types: VecPerParamSpace::empty(),
+            regions: NonerasedRegions(VecPerParamSpace::empty()),
         }
     }
 
     pub fn trans_empty() -> Substs {
         Substs {
-            self_ty: None,
-            tps: Vec::new(),
+            types: VecPerParamSpace::empty(),
             regions: ErasedRegions
         }
     }
@@ -74,16 +147,251 @@ impl Substs {
     pub fn is_noop(&self) -> bool {
         let regions_is_noop = match self.regions {
             ErasedRegions => false, // may be used to canonicalize
-            NonerasedRegions(ref regions) => regions.is_empty()
+            NonerasedRegions(ref regions) => regions.is_empty(),
         };
 
-        self.tps.len() == 0u &&
-            regions_is_noop &&
-            self.self_ty.is_none()
+        regions_is_noop && self.types.is_empty()
     }
 
-    pub fn self_ty(&self) -> ty::t {
-        self.self_ty.unwrap()
+    pub fn self_ty(&self) -> Option<ty::t> {
+        self.types.get_self().map(|&t| t)
+    }
+
+    pub fn with_self_ty(&self, self_ty: ty::t) -> Substs {
+        assert!(self.self_ty().is_none());
+        let mut s = (*self).clone();
+        s.types.push(SelfSpace, self_ty);
+        s
+    }
+
+    pub fn regions<'a>(&'a self) -> &'a VecPerParamSpace<ty::Region> {
+        /*!
+         * Since ErasedRegions are only to be used in trans, most of
+         * the compiler can use this method to easily access the set
+         * of region substitutions.
+         */
+
+        match self.regions {
+            ErasedRegions => fail!("Erased regions only expected in trans"),
+            NonerasedRegions(ref r) => r
+        }
+    }
+
+    pub fn mut_regions<'a>(&'a mut self) -> &'a mut VecPerParamSpace<ty::Region> {
+        /*!
+         * Since ErasedRegions are only to be used in trans, most of
+         * the compiler can use this method to easily access the set
+         * of region substitutions.
+         */
+
+        match self.regions {
+            ErasedRegions => fail!("Erased regions only expected in trans"),
+            NonerasedRegions(ref mut r) => r
+        }
+    }
+
+    pub fn with_method_from(self, substs: &Substs) -> Substs {
+        self.with_method((*substs.types.get_vec(FnSpace)).clone(),
+                         (*substs.regions().get_vec(FnSpace)).clone())
+    }
+
+    pub fn with_method(self,
+                       m_types: Vec<ty::t>,
+                       m_regions: Vec<ty::Region>)
+                       -> Substs
+    {
+        let Substs { types, regions } = self;
+        let types = types.with_vec(FnSpace, m_types);
+        let regions = regions.map(m_regions,
+                                  |r, m_regions| r.with_vec(FnSpace, m_regions));
+        Substs { types: types, regions: regions }
+    }
+}
+
+impl RegionSubsts {
+    fn map<A>(self,
+              a: A,
+              op: |VecPerParamSpace<ty::Region>, A| -> VecPerParamSpace<ty::Region>)
+              -> RegionSubsts {
+        match self {
+            ErasedRegions => ErasedRegions,
+            NonerasedRegions(r) => NonerasedRegions(op(r, a))
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// ParamSpace
+
+#[deriving(PartialOrd, Ord, PartialEq, Eq,
+           Clone, Hash, Encodable, Decodable, Show)]
+pub enum ParamSpace {
+    TypeSpace, // Type parameters attached to a type definition, trait, or impl
+    SelfSpace, // Self parameter on a trait
+    FnSpace,   // Type parameters attached to a method or fn
+}
+
+impl ParamSpace {
+    pub fn all() -> [ParamSpace, ..3] {
+        [TypeSpace, SelfSpace, FnSpace]
+    }
+
+    pub fn to_uint(self) -> uint {
+        match self {
+            TypeSpace => 0,
+            SelfSpace => 1,
+            FnSpace => 2,
+        }
+    }
+
+    pub fn from_uint(u: uint) -> ParamSpace {
+        match u {
+            0 => TypeSpace,
+            1 => SelfSpace,
+            2 => FnSpace,
+            _ => fail!("Invalid ParamSpace: {}", u)
+        }
+    }
+}
+
+/**
+ * Vector of things sorted by param space. Used to keep
+ * the set of things declared on the type, self, or method
+ * distinct.
+ */
+#[deriving(PartialEq, Eq, Clone, Hash, Encodable, Decodable)]
+pub struct VecPerParamSpace<T> {
+    vecs: (Vec<T>, Vec<T>, Vec<T>)
+}
+
+impl<T> VecPerParamSpace<T> {
+    pub fn empty() -> VecPerParamSpace<T> {
+        VecPerParamSpace {
+            vecs: (Vec::new(), Vec::new(), Vec::new())
+        }
+    }
+
+    pub fn params_from_type(types: Vec<T>) -> VecPerParamSpace<T> {
+        VecPerParamSpace::empty().with_vec(TypeSpace, types)
+    }
+
+    pub fn new(t: Vec<T>, s: Vec<T>, f: Vec<T>) -> VecPerParamSpace<T> {
+        VecPerParamSpace {
+            vecs: (t, s, f)
+        }
+    }
+
+    pub fn sort(t: Vec<T>, space: |&T| -> ParamSpace) -> VecPerParamSpace<T> {
+        let mut result = VecPerParamSpace::empty();
+        for t in t.move_iter() {
+            result.push(space(&t), t);
+        }
+        result
+    }
+
+    pub fn push(&mut self, space: ParamSpace, value: T) {
+        self.get_mut_vec(space).push(value);
+    }
+
+    pub fn get_self<'a>(&'a self) -> Option<&'a T> {
+        let v = self.get_vec(SelfSpace);
+        assert!(v.len() <= 1);
+        if v.len() == 0 { None } else { Some(v.get(0)) }
+    }
+
+    pub fn len(&self, space: ParamSpace) -> uint {
+        self.get_vec(space).len()
+    }
+
+    pub fn get_vec<'a>(&'a self, space: ParamSpace) -> &'a Vec<T> {
+        self.vecs.get(space as uint).unwrap()
+    }
+
+    pub fn get_mut_vec<'a>(&'a mut self, space: ParamSpace) -> &'a mut Vec<T> {
+        self.vecs.get_mut(space as uint).unwrap()
+    }
+
+    pub fn opt_get<'a>(&'a self,
+                       space: ParamSpace,
+                       index: uint)
+                       -> Option<&'a T> {
+        let v = self.get_vec(space);
+        if index < v.len() { Some(v.get(index)) } else { None }
+    }
+
+    pub fn get<'a>(&'a self, space: ParamSpace, index: uint) -> &'a T {
+        self.get_vec(space).get(index)
+    }
+
+    pub fn get_mut<'a>(&'a mut self,
+                       space: ParamSpace,
+                       index: uint) -> &'a mut T {
+        self.get_mut_vec(space).get_mut(index)
+    }
+
+    pub fn iter<'a>(&'a self) -> Chain<Items<'a,T>,
+                                       Chain<Items<'a,T>,
+                                             Items<'a,T>>> {
+        let (ref r, ref s, ref f) = self.vecs;
+        r.iter().chain(s.iter().chain(f.iter()))
+    }
+
+    pub fn all_vecs(&self, pred: |&Vec<T>| -> bool) -> bool {
+        self.vecs.iter().all(pred)
+    }
+
+    pub fn all(&self, pred: |&T| -> bool) -> bool {
+        self.iter().all(pred)
+    }
+
+    pub fn any(&self, pred: |&T| -> bool) -> bool {
+        self.iter().any(pred)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.all_vecs(|v| v.is_empty())
+    }
+
+    pub fn map<U>(&self, pred: |&T| -> U) -> VecPerParamSpace<U> {
+        VecPerParamSpace::new(self.vecs.ref0().iter().map(|p| pred(p)).collect(),
+                              self.vecs.ref1().iter().map(|p| pred(p)).collect(),
+                              self.vecs.ref2().iter().map(|p| pred(p)).collect())
+    }
+
+    pub fn map_rev<U>(&self, pred: |&T| -> U) -> VecPerParamSpace<U> {
+        /*!
+         * Executes the map but in reverse order. For hacky reasons, we rely
+         * on this in table.
+         *
+         * FIXME(#5527) -- order of eval becomes irrelevant with newer
+         * trait reform, which features an idempotent algorithm that
+         * can be run to a fixed point
+         */
+
+        let mut fns: Vec<U> = self.vecs.ref2().iter().rev().map(|p| pred(p)).collect();
+
+        // NB: Calling foo.rev().map().rev() causes the calls to map
+        // to occur in the wrong order. This was somewhat surprising
+        // to me, though it makes total sense.
+        fns.reverse();
+
+        let mut selfs: Vec<U> = self.vecs.ref1().iter().rev().map(|p| pred(p)).collect();
+        selfs.reverse();
+        let mut tys: Vec<U> = self.vecs.ref0().iter().rev().map(|p| pred(p)).collect();
+        tys.reverse();
+        VecPerParamSpace::new(tys, selfs, fns)
+    }
+
+    pub fn split(self) -> (Vec<T>, Vec<T>, Vec<T>) {
+        self.vecs
+    }
+
+    pub fn with_vec(mut self, space: ParamSpace, vec: Vec<T>)
+                    -> VecPerParamSpace<T>
+    {
+        assert!(self.get_vec(space).is_empty());
+        *self.get_mut_vec(space) = vec;
+        self
     }
 }
 
@@ -149,10 +457,10 @@ impl<'a> TypeFolder for SubstFolder<'a> {
         // the specialized routine
         // `middle::typeck::check::regionmanip::replace_late_regions_in_fn_sig()`.
         match r {
-            ty::ReEarlyBound(_, i, _) => {
+            ty::ReEarlyBound(_, space, i, _) => {
                 match self.substs.regions {
                     ErasedRegions => ty::ReStatic,
-                    NonerasedRegions(ref regions) => *regions.get(i),
+                    NonerasedRegions(ref regions) => *regions.get(space, i),
                 }
             }
             _ => r
@@ -173,52 +481,11 @@ impl<'a> TypeFolder for SubstFolder<'a> {
 
         let t1 = match ty::get(t).sty {
             ty::ty_param(p) => {
-                // FIXME -- This...really shouldn't happen. We should
-                // never be substituting without knowing what's in
-                // scope and knowing that the indices will line up!
-                if p.idx < self.substs.tps.len() {
-                    *self.substs.tps.get(p.idx)
-                } else {
-                    let root_msg = match self.root_ty {
-                        Some(root) => format!(" in the substitution of `{}`",
-                                              root.repr(self.tcx)),
-                        None => "".to_string()
-                    };
-                    let m = format!("can't use type parameters from outer \
-                                    function{}; try using a local type \
-                                    parameter instead",
-                                    root_msg);
-                    match self.span {
-                        Some(span) => {
-                            self.tcx.sess.span_err(span, m.as_slice())
-                        }
-                        None => self.tcx.sess.err(m.as_slice())
-                    }
-                    ty::mk_err()
-                }
+                check(self, t, self.substs.types.opt_get(p.space, p.idx))
             }
-            ty::ty_self(_) => {
-                match self.substs.self_ty {
-                    Some(ty) => ty,
-                    None => {
-                        let root_msg = match self.root_ty {
-                            Some(root) => format!(" in the substitution of `{}`",
-                                                  root.repr(self.tcx)),
-                            None => "".to_string()
-                        };
-                        let m = format!("missing `Self` type param{}",
-                                        root_msg);
-                        match self.span {
-                            Some(span) => {
-                                self.tcx.sess.span_err(span, m.as_slice())
-                            }
-                            None => self.tcx.sess.err(m.as_slice())
-                        }
-                        ty::mk_err()
-                    }
-                }
+            _ => {
+                ty_fold::super_fold_ty(self, t)
             }
-            _ => ty_fold::super_fold_ty(self, t)
         };
 
         assert_eq!(depth + 1, self.ty_stack_depth);
@@ -227,6 +494,24 @@ impl<'a> TypeFolder for SubstFolder<'a> {
             self.root_ty = None;
         }
 
-        t1
+        return t1;
+
+        fn check(this: &SubstFolder,
+                 source_ty: ty::t,
+                 opt_ty: Option<&ty::t>)
+                 -> ty::t {
+            match opt_ty {
+                Some(t) => *t,
+                None => {
+                    let span = this.span.unwrap_or(DUMMY_SP);
+                    this.tcx().sess.span_bug(
+                        span,
+                        format!("Type parameter {} out of range \
+                                 when substituting (root type={})",
+                                source_ty.repr(this.tcx()),
+                                this.root_ty.repr(this.tcx())).as_slice());
+                }
+            }
+        }
     }
 }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -457,11 +457,11 @@ pub fn get_res_dtor(ccx: &CrateContext,
         did
     };
 
-    if !substs.tps.is_empty() || !substs.self_ty.is_none() {
+    if !substs.types.is_empty() {
         assert_eq!(did.krate, ast::LOCAL_CRATE);
 
         let vtables = typeck::check::vtable::trans_resolve_method(ccx.tcx(), did.node, substs);
-        let (val, _) = monomorphize::monomorphic_fn(ccx, did, substs, vtables, None, None);
+        let (val, _) = monomorphize::monomorphic_fn(ccx, did, substs, vtables, None);
 
         val
     } else if did.krate == ast::LOCAL_CRATE {

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -23,7 +23,7 @@ use lib::llvm::llvm;
 use metadata::csearch;
 use middle::def;
 use middle::subst;
-use middle::subst::Subst;
+use middle::subst::{Subst, VecPerParamSpace};
 use middle::trans::base;
 use middle::trans::base::*;
 use middle::trans::build::*;
@@ -198,12 +198,10 @@ fn trans_fn_ref_with_vtables_to_callee<'a>(bcx: &'a Block<'a>,
 
 fn resolve_default_method_vtables(bcx: &Block,
                                   impl_id: ast::DefId,
-                                  method: &ty::Method,
                                   substs: &subst::Substs,
                                   impl_vtables: typeck::vtable_res)
-                          -> (typeck::vtable_res, typeck::vtable_param_res)
+                                  -> typeck::vtable_res
 {
-
     // Get the vtables that the impl implements the trait at
     let impl_res = ty::lookup_impl_vtables(bcx.tcx(), impl_id);
 
@@ -211,32 +209,30 @@ fn resolve_default_method_vtables(bcx: &Block,
     // trait_vtables under.
     let param_substs = param_substs {
         substs: (*substs).clone(),
-        vtables: impl_vtables.clone(),
-        self_vtables: None
+        vtables: impl_vtables.clone()
     };
 
     let mut param_vtables = resolve_vtables_under_param_substs(
-        bcx.tcx(), &param_substs, impl_res.trait_vtables.as_slice());
+        bcx.tcx(), &param_substs, &impl_res);
 
     // Now we pull any vtables for parameters on the actual method.
-    let num_method_vtables = method.generics.type_param_defs().len();
-    let num_impl_type_parameters = impl_vtables.len() - num_method_vtables;
-    param_vtables.push_all(impl_vtables.tailn(num_impl_type_parameters));
+    param_vtables
+        .get_mut_vec(subst::FnSpace)
+        .push_all(
+            impl_vtables.get_vec(subst::FnSpace).as_slice());
 
-    let self_vtables = resolve_param_vtables_under_param_substs(
-        bcx.tcx(), &param_substs, impl_res.self_vtables.as_slice());
-
-    (param_vtables, self_vtables)
+    param_vtables
 }
 
 
 pub fn trans_fn_ref_with_vtables(
-        bcx: &Block,       //
-        def_id: ast::DefId,   // def id of fn
-        node: ExprOrMethodCall,  // node id of use of fn; may be zero if N/A
-        substs: subst::Substs, // values for fn's ty params
-        vtables: typeck::vtable_res) // vtables for the call
-     -> ValueRef {
+    bcx: &Block,                 //
+    def_id: ast::DefId,          // def id of fn
+    node: ExprOrMethodCall,      // node id of use of fn; may be zero if N/A
+    substs: subst::Substs,       // values for fn's ty params
+    vtables: typeck::vtable_res) // vtables for the call
+    -> ValueRef
+{
     /*!
      * Translates a reference to a fn/method item, monomorphizing and
      * inlining as it goes.
@@ -264,7 +260,7 @@ pub fn trans_fn_ref_with_vtables(
            substs.repr(tcx),
            vtables.repr(tcx));
 
-    assert!(substs.tps.iter().all(|t| !ty::type_needs_infer(*t)));
+    assert!(substs.types.all(|t| !ty::type_needs_infer(*t)));
 
     // Polytype of the function item (may have type params)
     let fn_tpt = ty::lookup_item_type(tcx, def_id);
@@ -280,9 +276,9 @@ pub fn trans_fn_ref_with_vtables(
     // We need to do a bunch of special handling for default methods.
     // We need to modify the def_id and our substs in order to monomorphize
     // the function.
-    let (is_default, def_id, substs, self_vtables, vtables) =
+    let (is_default, def_id, substs, vtables) =
         match ty::provided_source(tcx, def_id) {
-        None => (false, def_id, substs, None, vtables),
+        None => (false, def_id, substs, vtables),
         Some(source_id) => {
             // There are two relevant substitutions when compiling
             // default methods. First, there is the substitution for
@@ -305,7 +301,7 @@ pub fn trans_fn_ref_with_vtables(
 
             // Compute the first substitution
             let first_subst = make_substs_for_receiver_types(
-                tcx, impl_id, &*trait_ref, &*method);
+                tcx, &*trait_ref, &*method);
 
             // And compose them
             let new_substs = first_subst.subst(tcx, &substs);
@@ -318,16 +314,14 @@ pub fn trans_fn_ref_with_vtables(
                    first_subst.repr(tcx), new_substs.repr(tcx),
                    vtables.repr(tcx));
 
-            let (param_vtables, self_vtables) =
-                resolve_default_method_vtables(bcx, impl_id,
-                                               &*method, &substs, vtables);
+            let param_vtables =
+                resolve_default_method_vtables(bcx, impl_id, &substs, vtables);
 
             debug!("trans_fn_with_vtables - default method: \
-                    self_vtable = {}, param_vtables = {}",
-                   self_vtables.repr(tcx), param_vtables.repr(tcx));
+                    param_vtables = {}",
+                   param_vtables.repr(tcx));
 
-            (true, source_id,
-             new_substs, Some(self_vtables), param_vtables)
+            (true, source_id, new_substs, param_vtables)
         }
     };
 
@@ -345,7 +339,7 @@ pub fn trans_fn_ref_with_vtables(
     // intrinsic, or is a default method.  In particular, if we see an
     // intrinsic that is inlined from a different crate, we want to reemit the
     // intrinsic instead of trying to call it in the other crate.
-    let must_monomorphise = if substs.tps.len() > 0 || is_default {
+    let must_monomorphise = if !substs.types.is_empty() || is_default {
         true
     } else if def_id.krate == ast::LOCAL_CRATE {
         let map_node = session::expect(
@@ -375,8 +369,7 @@ pub fn trans_fn_ref_with_vtables(
 
         let (val, must_cast) =
             monomorphize::monomorphic_fn(ccx, def_id, &substs,
-                                         vtables, self_vtables,
-                                         opt_ref_id);
+                                         vtables, opt_ref_id);
         let mut val = val;
         if must_cast && node != ExprId(0) {
             // Monotype of the REFERENCE to the function (type params
@@ -498,7 +491,7 @@ pub fn trans_lang_call<'a>(
                                                                     did,
                                                                     0,
                                                                     subst::Substs::empty(),
-                                                                    Vec::new())
+                                                                    VecPerParamSpace::empty())
                              },
                              ArgVals(args),
                              dest)

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -118,18 +118,18 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             ccx.external.borrow_mut().insert(fn_id, Some(mth.id));
             ccx.external_srcs.borrow_mut().insert(mth.id, fn_id);
 
-          ccx.stats.n_inlines.set(ccx.stats.n_inlines.get() + 1);
+            ccx.stats.n_inlines.set(ccx.stats.n_inlines.get() + 1);
 
-          // If this is a default method, we can't look up the
-          // impl type. But we aren't going to translate anyways, so don't.
-          if is_provided { return local_def(mth.id); }
+            // If this is a default method, we can't look up the
+            // impl type. But we aren't going to translate anyways, so don't.
+            if is_provided { return local_def(mth.id); }
 
             let impl_tpt = ty::lookup_item_type(ccx.tcx(), impl_did);
-            let num_type_params =
-                impl_tpt.generics.type_param_defs().len() +
-                mth.generics.ty_params.len();
+            let unparameterized =
+                impl_tpt.generics.types.is_empty() &&
+                mth.generics.ty_params.is_empty();
 
-          if num_type_params == 0 {
+          if unparameterized {
               let llfn = get_item_val(ccx, mth.id);
               trans_fn(ccx, &*mth.decl, &*mth.body, llfn,
                        &param_substs::empty(), mth.id, []);

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -14,6 +14,7 @@ use arena::TypedArena;
 use lib::llvm::{SequentiallyConsistent, Acquire, Release, Xchg};
 use lib::llvm::{ValueRef, Pointer, Array, Struct};
 use lib;
+use middle::subst::FnSpace;
 use middle::trans::base::*;
 use middle::trans::build::*;
 use middle::trans::common::*;
@@ -295,7 +296,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             RetVoid(bcx);
         }
         "size_of" => {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llsize_of_real(ccx, lltp_ty) as uint));
         }
@@ -305,7 +306,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             // if the value is non-immediate. Note that, with
             // intrinsics, there are no argument cleanups to
             // concern ourselves with, so we can use an rvalue datum.
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             let mode = appropriate_rvalue_mode(ccx, tp_ty);
             let src = Datum {val: get_param(decl, first_real_arg + 1u),
                              ty: tp_ty,
@@ -314,17 +315,17 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             RetVoid(bcx);
         }
         "min_align_of" => {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_min(ccx, lltp_ty) as uint));
         }
         "pref_align_of"=> {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             Ret(bcx, C_uint(ccx, machine::llalign_of_pref(ccx, lltp_ty) as uint));
         }
         "get_tydesc" => {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             let static_ti = get_tydesc(ccx, tp_ty);
             glue::lazily_emit_visit_glue(ccx, &*static_ti);
 
@@ -339,7 +340,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
         "type_id" => {
             let hash = ty::hash_crate_independent(
                 ccx.tcx(),
-                *substs.substs.tps.get(0),
+                *substs.substs.types.get(FnSpace, 0),
                 &ccx.link_meta.crate_hash);
             // NB: This needs to be kept in lockstep with the TypeId struct in
             //     libstd/unstable/intrinsics.rs
@@ -354,7 +355,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             }
         }
         "init" => {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
             match bcx.fcx.llretptr.get() {
                 Some(ptr) => { Store(bcx, C_null(lltp_ty), ptr); RetVoid(bcx); }
@@ -364,7 +365,7 @@ pub fn trans_intrinsic(ccx: &CrateContext,
         }
         "uninit" => {
             // Do nothing, this is effectively a no-op
-            let retty = *substs.substs.tps.get(0);
+            let retty = *substs.substs.types.get(FnSpace, 0);
             if type_is_immediate(ccx, retty) && !return_type_is_void(ccx, retty) {
                 unsafe {
                     Ret(bcx, lib::llvm::llvm::LLVMGetUndef(type_of(ccx, retty).to_ref()));
@@ -377,8 +378,8 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             RetVoid(bcx);
         }
         "transmute" => {
-            let (in_type, out_type) = (*substs.substs.tps.get(0),
-                                       *substs.substs.tps.get(1));
+            let (in_type, out_type) = (*substs.substs.types.get(FnSpace, 0),
+                                       *substs.substs.types.get(FnSpace, 1));
             let llintype = type_of::type_of(ccx, in_type);
             let llouttype = type_of::type_of(ccx, out_type);
 
@@ -447,11 +448,11 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             }
         }
         "needs_drop" => {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             Ret(bcx, C_bool(ccx, ty::type_needs_drop(ccx.tcx(), tp_ty)));
         }
         "owns_managed" => {
-            let tp_ty = *substs.substs.tps.get(0);
+            let tp_ty = *substs.substs.types.get(FnSpace, 0);
             Ret(bcx, C_bool(ccx, ty::type_contents(ccx.tcx(), tp_ty).owns_managed()));
         }
         "visit_tydesc" => {
@@ -468,19 +469,26 @@ pub fn trans_intrinsic(ccx: &CrateContext,
             Ret(bcx, lladdr);
         }
         "copy_nonoverlapping_memory" => {
-            copy_intrinsic(bcx, false, false, *substs.substs.tps.get(0))
+            copy_intrinsic(bcx, false, false, *substs.substs.types.get(FnSpace, 0))
         }
         "copy_memory" => {
-            copy_intrinsic(bcx, true, false, *substs.substs.tps.get(0))
+            copy_intrinsic(bcx, true, false, *substs.substs.types.get(FnSpace, 0))
         }
         "set_memory" => {
-            memset_intrinsic(bcx, false, *substs.substs.tps.get(0))
+            memset_intrinsic(bcx, false, *substs.substs.types.get(FnSpace, 0))
         }
 
-        "volatile_copy_nonoverlapping_memory" =>
-            copy_intrinsic(bcx, false, true, *substs.substs.tps.get(0)),
-        "volatile_copy_memory" => copy_intrinsic(bcx, true, true, *substs.substs.tps.get(0)),
-        "volatile_set_memory" => memset_intrinsic(bcx, true, *substs.substs.tps.get(0)),
+        "volatile_copy_nonoverlapping_memory" => {
+            copy_intrinsic(bcx, false, true, *substs.substs.types.get(FnSpace, 0))
+        }
+
+        "volatile_copy_memory" => {
+            copy_intrinsic(bcx, true, true, *substs.substs.types.get(FnSpace, 0))
+        }
+
+        "volatile_set_memory" => {
+            memset_intrinsic(bcx, true, *substs.substs.types.get(FnSpace, 0))
+        }
 
         "ctlz8" => count_zeros_intrinsic(bcx, "llvm.ctlz.i8"),
         "ctlz16" => count_zeros_intrinsic(bcx, "llvm.ctlz.i16"),

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -366,7 +366,6 @@ impl<'a, 'b> Reflector<'a, 'b> {
               let extra = vec!(self.c_uint(p.idx));
               self.visit("param", extra.as_slice())
           }
-          ty::ty_self(..) => self.leaf("self")
         }
     }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -24,7 +24,7 @@ use middle::freevars;
 use middle::resolve;
 use middle::resolve_lifetime;
 use middle::subst;
-use middle::subst::{Subst, Substs};
+use middle::subst::{Subst, Substs, VecPerParamSpace};
 use middle::ty;
 use middle::typeck;
 use middle::typeck::MethodCall;
@@ -58,7 +58,6 @@ use syntax::codemap::Span;
 use syntax::parse::token;
 use syntax::parse::token::InternedString;
 use syntax::{ast, ast_map};
-use syntax::owned_slice::OwnedSlice;
 use syntax::util::small_vector::SmallVector;
 use std::collections::enum_set::{EnumSet, CLike};
 
@@ -190,9 +189,8 @@ pub enum ast_ty_to_ty_cache_entry {
 
 #[deriving(Clone, PartialEq, Decodable, Encodable)]
 pub struct ItemVariances {
-    pub self_param: Option<Variance>,
-    pub type_params: OwnedSlice<Variance>,
-    pub region_params: OwnedSlice<Variance>
+    pub types: VecPerParamSpace<Variance>,
+    pub regions: VecPerParamSpace<Variance>,
 }
 
 #[deriving(Clone, PartialEq, Decodable, Encodable, Show)]
@@ -455,7 +453,8 @@ pub struct FnSig {
 }
 
 #[deriving(Clone, PartialEq, Eq, Hash)]
-pub struct param_ty {
+pub struct ParamTy {
+    pub space: subst::ParamSpace,
     pub idx: uint,
     pub def_id: DefId
 }
@@ -466,7 +465,10 @@ pub enum Region {
     // Region bound in a type or fn declaration which will be
     // substituted 'early' -- that is, at the same time when type
     // parameters are substituted.
-    ReEarlyBound(/* param id */ ast::NodeId, /*index*/ uint, ast::Name),
+    ReEarlyBound(/* param id */ ast::NodeId,
+                 subst::ParamSpace,
+                 /*index*/ uint,
+                 ast::Name),
 
     // Region bound in a function scope, which will be substituted when the
     // function is called. The first argument must be the `binder_id` of
@@ -713,10 +715,7 @@ pub enum sty {
     ty_struct(DefId, Substs),
     ty_tup(Vec<t>),
 
-    ty_param(param_ty), // type parameter
-    ty_self(DefId), /* special, implicit `self` type parameter;
-                      * def_id is the id of the trait */
-
+    ty_param(ParamTy), // type parameter
     ty_infer(InferTy), // something used only during inference/typeck
     ty_err, // Also only used during inference/typeck, to represent
             // the type of an erroneous expression (helps cut down
@@ -734,7 +733,7 @@ pub struct TyTrait {
 #[deriving(PartialEq, Eq, Hash)]
 pub struct TraitRef {
     pub def_id: DefId,
-    pub substs: Substs
+    pub substs: Substs,
 }
 
 #[deriving(Clone, PartialEq)]
@@ -964,6 +963,8 @@ impl fmt::Show for IntVarValue {
 pub struct TypeParameterDef {
     pub ident: ast::Ident,
     pub def_id: ast::DefId,
+    pub space: subst::ParamSpace,
+    pub index: uint,
     pub bounds: Rc<ParamBounds>,
     pub default: Option<ty::t>
 }
@@ -972,29 +973,26 @@ pub struct TypeParameterDef {
 pub struct RegionParameterDef {
     pub name: ast::Name,
     pub def_id: ast::DefId,
+    pub space: subst::ParamSpace,
+    pub index: uint,
 }
 
-/// Information about the type/lifetime parameters associated with an item.
-/// Analogous to ast::Generics.
+/// Information about the type/lifetime parameters associated with an
+/// item or method. Analogous to ast::Generics.
 #[deriving(Clone)]
 pub struct Generics {
-    /// List of type parameters declared on the item.
-    pub type_param_defs: Rc<Vec<TypeParameterDef>>,
-
-    /// List of region parameters declared on the item.
-    /// For a fn or method, only includes *early-bound* lifetimes.
-    pub region_param_defs: Rc<Vec<RegionParameterDef>>,
+    pub types: VecPerParamSpace<TypeParameterDef>,
+    pub regions: VecPerParamSpace<RegionParameterDef>,
 }
 
 impl Generics {
-    pub fn has_type_params(&self) -> bool {
-        !self.type_param_defs.is_empty()
+    pub fn empty() -> Generics {
+        Generics { types: VecPerParamSpace::empty(),
+                   regions: VecPerParamSpace::empty() }
     }
-    pub fn type_param_defs<'a>(&'a self) -> &'a [TypeParameterDef] {
-        self.type_param_defs.as_slice()
-    }
-    pub fn region_param_defs<'a>(&'a self) -> &'a [RegionParameterDef] {
-        self.region_param_defs.as_slice()
+
+    pub fn has_type_params(&self, space: subst::ParamSpace) -> bool {
+        !self.types.get_vec(space).is_empty()
     }
 }
 
@@ -1018,11 +1016,8 @@ pub struct ParameterEnvironment {
     /// parameters in the same way, this only has an affect on regions.
     pub free_substs: Substs,
 
-    /// Bound on the Self parameter
-    pub self_param_bound: Option<Rc<TraitRef>>,
-
-    /// Bounds on each numbered type parameter
-    pub type_param_bounds: Vec<ParamBounds>,
+    /// Bounds on the various type parameters
+    pub bounds: VecPerParamSpace<ParamBounds>,
 }
 
 /// A polytype.
@@ -1162,7 +1157,10 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
     }
     fn sflags(substs: &Substs) -> uint {
         let mut f = 0u;
-        for tt in substs.tps.iter() { f |= get(*tt).flags; }
+        let mut i = substs.types.iter();
+        for tt in i {
+            f |= get(*tt).flags;
+        }
         match substs.regions {
             subst::ErasedRegions => {}
             subst::NonerasedRegions(ref regions) => {
@@ -1185,9 +1183,14 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
       // so we're doing it this way.
       &ty_bot => flags |= has_ty_bot as uint,
       &ty_err => flags |= has_ty_err as uint,
-      &ty_param(_) => flags |= has_params as uint,
+      &ty_param(ref p) => {
+          if p.space == subst::SelfSpace {
+              flags |= has_self as uint;
+          } else {
+              flags |= has_params as uint;
+          }
+      }
       &ty_infer(_) => flags |= needs_infer as uint,
-      &ty_self(_) => flags |= has_self as uint,
       &ty_enum(_, ref substs) | &ty_struct(_, ref substs) => {
           flags |= sflags(substs);
       }
@@ -1455,10 +1458,16 @@ pub fn mk_float_var(cx: &ctxt, v: FloatVid) -> t { mk_infer(cx, FloatVar(v)) }
 
 pub fn mk_infer(cx: &ctxt, it: InferTy) -> t { mk_t(cx, ty_infer(it)) }
 
-pub fn mk_self(cx: &ctxt, did: ast::DefId) -> t { mk_t(cx, ty_self(did)) }
+pub fn mk_param(cx: &ctxt, space: subst::ParamSpace, n: uint, k: DefId) -> t {
+    mk_t(cx, ty_param(ParamTy { space: space, idx: n, def_id: k }))
+}
 
-pub fn mk_param(cx: &ctxt, n: uint, k: DefId) -> t {
-    mk_t(cx, ty_param(param_ty { idx: n, def_id: k }))
+pub fn mk_self_type(cx: &ctxt, did: ast::DefId) -> t {
+    mk_param(cx, subst::SelfSpace, 0, did)
+}
+
+pub fn mk_param_from_def(cx: &ctxt, def: &TypeParameterDef) -> t {
+    mk_param(cx, def.space, def.index, def.def_id)
 }
 
 pub fn walk_ty(ty: t, f: |t|) {
@@ -1471,15 +1480,17 @@ pub fn maybe_walk_ty(ty: t, f: |t| -> bool) {
     }
     match get(ty).sty {
         ty_nil | ty_bot | ty_bool | ty_char | ty_int(_) | ty_uint(_) | ty_float(_) |
-        ty_str | ty_self(_) |
-        ty_infer(_) | ty_param(_) | ty_err => {}
+        ty_str | ty_infer(_) | ty_param(_) | ty_err => {
+        }
         ty_box(ty) | ty_uniq(ty) => maybe_walk_ty(ty, f),
         ty_ptr(ref tm) | ty_rptr(_, ref tm) | ty_vec(ref tm, _) => {
             maybe_walk_ty(tm.ty, f);
         }
         ty_enum(_, ref substs) | ty_struct(_, ref substs) |
         ty_trait(box TyTrait { ref substs, .. }) => {
-            for subty in (*substs).tps.iter() { maybe_walk_ty(*subty, |x| f(x)); }
+            for subty in (*substs).types.iter() {
+                maybe_walk_ty(*subty, |x| f(x));
+            }
         }
         ty_tup(ref ts) => { for tt in ts.iter() { maybe_walk_ty(*tt, |x| f(x)); } }
         ty_bare_fn(ref ft) => {
@@ -1533,8 +1544,7 @@ pub fn type_needs_subst(ty: t) -> bool {
 }
 
 pub fn trait_ref_contains_error(tref: &ty::TraitRef) -> bool {
-    tref.substs.self_ty.iter().any(|&t| type_is_error(t)) ||
-        tref.substs.tps.iter().any(|&t| type_is_error(t))
+    tref.substs.types.any(|&t| type_is_error(t))
 }
 
 pub fn type_is_ty_var(ty: t) -> bool {
@@ -1548,7 +1558,7 @@ pub fn type_is_bool(ty: t) -> bool { get(ty).sty == ty_bool }
 
 pub fn type_is_self(ty: t) -> bool {
     match get(ty).sty {
-        ty_self(..) => true,
+        ty_param(ref p) => p.space == subst::SelfSpace,
         _ => false
     }
 }
@@ -2103,16 +2113,6 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
                                         tp_def.bounds.trait_bounds.as_slice())
             }
 
-            ty_self(def_id) => {
-                // FIXME(#4678)---self should just be a ty param
-
-                // Self may be bounded if the associated trait has builtin kinds
-                // for supertraits. If so we can use those bounds.
-                let trait_def = lookup_trait_def(cx, def_id);
-                let traits = [trait_def.trait_ref.clone()];
-                kind_bounds_to_contents(cx, trait_def.bounds, traits)
-            }
-
             ty_infer(_) => {
                 // This occurs during coherence, but shouldn't occur at other
                 // times.
@@ -2292,7 +2292,6 @@ pub fn is_instantiable(cx: &ctxt, r_ty: t) -> bool {
             ty_infer(_) |
             ty_err |
             ty_param(_) |
-            ty_self(_) |
             ty_vec(_, None) => {
                 false
             }
@@ -2688,6 +2687,14 @@ pub fn ty_region(tcx: &ctxt,
     }
 }
 
+pub fn free_region_from_def(free_id: ast::NodeId, def: &RegionParameterDef)
+    -> ty::Region
+{
+    ty::ReFree(ty::FreeRegion { scope_id: free_id,
+                                bound_region: ty::BrNamed(def.def_id,
+                                                          def.name) })
+}
+
 // Returns the type of a pattern as a monotype. Like @expr_ty, this function
 // doesn't provide type parameter substitutions.
 pub fn pat_ty(cx: &ctxt, pat: &ast::Pat) -> t {
@@ -2937,27 +2944,16 @@ impl AutoRef {
 }
 
 pub fn method_call_type_param_defs(tcx: &ctxt, origin: typeck::MethodOrigin)
-                                   -> Rc<Vec<TypeParameterDef>> {
+                                   -> VecPerParamSpace<TypeParameterDef> {
     match origin {
         typeck::MethodStatic(did) => {
-            // n.b.: When we encode impl methods, the bounds
-            // that we encode include both the impl bounds
-            // and then the method bounds themselves...
-            ty::lookup_item_type(tcx, did).generics.type_param_defs
+            ty::lookup_item_type(tcx, did).generics.types.clone()
         }
-        typeck::MethodParam(typeck::MethodParam {
-            trait_id: trt_id,
-            method_num: n_mth, ..}) |
-        typeck::MethodObject(typeck::MethodObject {
-            trait_id: trt_id,
-            method_num: n_mth, ..}) => {
-            // ...trait methods bounds, in contrast, include only the
-            // method bounds, so we must preprend the tps from the
-            // trait itself.  This ought to be harmonized.
-            let trait_type_param_defs =
-                Vec::from_slice(lookup_trait_def(tcx, trt_id).generics.type_param_defs());
-            Rc::new(trait_type_param_defs.append(
-                        ty::trait_method(tcx, trt_id, n_mth).generics.type_param_defs()))
+        typeck::MethodParam(typeck::MethodParam{trait_id: trt_id,
+                                                method_num: n_mth, ..}) |
+        typeck::MethodObject(typeck::MethodObject{trait_id: trt_id,
+                                                  method_num: n_mth, ..}) => {
+            ty::trait_method(tcx, trt_id, n_mth).generics.types.clone()
         }
     }
 }
@@ -3176,7 +3172,7 @@ pub fn method_idx(id: ast::Ident, meths: &[Rc<Method>]) -> Option<uint> {
 /// Returns a vector containing the indices of all type parameters that appear
 /// in `ty`.  The vector may contain duplicates.  Probably should be converted
 /// to a bitset or some other representation.
-pub fn param_tys_in_type(ty: t) -> Vec<param_ty> {
+pub fn param_tys_in_type(ty: t) -> Vec<ParamTy> {
     let mut rslt = Vec::new();
     walk_ty(ty, |ty| {
         match get(ty).sty {
@@ -3214,8 +3210,13 @@ pub fn ty_sort_str(cx: &ctxt, t: t) -> String {
         ty_infer(TyVar(_)) => "inferred type".to_string(),
         ty_infer(IntVar(_)) => "integral variable".to_string(),
         ty_infer(FloatVar(_)) => "floating-point variable".to_string(),
-        ty_param(_) => "type parameter".to_string(),
-        ty_self(_) => "self".to_string(),
+        ty_param(ref p) => {
+            if p.space == subst::SelfSpace {
+                "Self".to_string()
+            } else {
+                "type parameter".to_string()
+            }
+        }
         ty_err => "type error".to_string(),
     }
 }
@@ -3821,7 +3822,7 @@ pub fn lookup_item_type(cx: &ctxt,
 
 pub fn lookup_impl_vtables(cx: &ctxt,
                            did: ast::DefId)
-                     -> typeck::impl_res {
+                           -> typeck::vtable_res {
     lookup_locally_or_in_crate_store(
         "impl_vtables", did, &mut *cx.impl_vtables.borrow_mut(),
         || csearch::get_impl_vtables(cx, did) )
@@ -4103,8 +4104,7 @@ pub fn normalize_ty(cx: &ctxt, t: t) -> t {
                        substs: &subst::Substs)
                        -> subst::Substs {
             subst::Substs { regions: subst::ErasedRegions,
-                            self_ty: substs.self_ty.fold_with(self),
-                            tps: substs.tps.fold_with(self) }
+                            types: substs.types.fold_with(self) }
         }
 
         fn fold_sig(&mut self,
@@ -4252,11 +4252,7 @@ pub fn visitor_object_ty(tcx: &ctxt,
         Ok(id) => id,
         Err(s) => { return Err(s); }
     };
-    let substs = Substs {
-        regions: subst::NonerasedRegions(Vec::new()),
-        self_ty: None,
-        tps: Vec::new()
-    };
+    let substs = Substs::empty();
     let trait_ref = Rc::new(TraitRef { def_id: trait_lang_item, substs: substs });
     Ok((trait_ref.clone(),
         mk_trait(tcx,
@@ -4582,10 +4578,6 @@ pub fn hash_crate_independent(tcx: &ctxt, t: t, svh: &Svh) -> u64 {
                 hash!(p.idx);
                 did(&mut state, p.def_id);
             }
-            ty_self(d) => {
-                byte!(21);
-                did(&mut state, d);
-            }
             ty_infer(_) => unreachable!(),
             ty_err => byte!(23),
         }
@@ -4607,11 +4599,7 @@ impl Variance {
 
 pub fn construct_parameter_environment(
     tcx: &ctxt,
-    self_bound: Option<Rc<TraitRef>>,
-    item_type_params: &[TypeParameterDef],
-    method_type_params: &[TypeParameterDef],
-    item_region_params: &[RegionParameterDef],
-    method_region_params: &[RegionParameterDef],
+    generics: &ty::Generics,
     free_id: ast::NodeId)
     -> ParameterEnvironment
 {
@@ -4621,75 +4609,76 @@ pub fn construct_parameter_environment(
     // Construct the free substs.
     //
 
-    // map Self => Self
-    let self_ty = self_bound.as_ref().map(|t| ty::mk_self(tcx, t.def_id));
-
-    // map A => A
-    let num_item_type_params = item_type_params.len();
-    let num_method_type_params = method_type_params.len();
-    let num_type_params = num_item_type_params + num_method_type_params;
-    let type_params = Vec::from_fn(num_type_params, |i| {
-            let def_id = if i < num_item_type_params {
-                item_type_params[i].def_id
-            } else {
-                method_type_params[i - num_item_type_params].def_id
-            };
-
-            ty::mk_param(tcx, i, def_id)
-        });
+    // map T => T
+    let mut types = VecPerParamSpace::empty();
+    for &space in subst::ParamSpace::all().iter() {
+        push_types_from_defs(tcx, &mut types, space,
+                             generics.types.get_vec(space));
+    }
 
     // map bound 'a => free 'a
-    let region_params = {
-        fn push_region_params(mut accum: Vec<ty::Region>,
-                              free_id: ast::NodeId,
-                              region_params: &[RegionParameterDef])
-                              -> Vec<ty::Region> {
-            for r in region_params.iter() {
-                accum.push(
-                    ty::ReFree(ty::FreeRegion {
-                            scope_id: free_id,
-                            bound_region: ty::BrNamed(r.def_id, r.name)}));
-            }
-            accum
-        }
-
-        let t = push_region_params(vec!(), free_id, item_region_params);
-        push_region_params(t, free_id, method_region_params)
-    };
+    let mut regions = VecPerParamSpace::empty();
+    for &space in subst::ParamSpace::all().iter() {
+        push_region_params(&mut regions, space, free_id,
+                           generics.regions.get_vec(space));
+    }
 
     let free_substs = Substs {
-        self_ty: self_ty,
-        tps: type_params,
-        regions: subst::NonerasedRegions(region_params)
+        types: types,
+        regions: subst::NonerasedRegions(regions)
     };
 
     //
     // Compute the bounds on Self and the type parameters.
     //
 
-    let self_bound_substd = self_bound.map(|b| b.subst(tcx, &free_substs));
-    let type_param_bounds_substd = Vec::from_fn(num_type_params, |i| {
-        if i < num_item_type_params {
-            (*item_type_params[i].bounds).subst(tcx, &free_substs)
-        } else {
-            let j = i - num_item_type_params;
-            (*method_type_params[j].bounds).subst(tcx, &free_substs)
-        }
-    });
+    let mut bounds = VecPerParamSpace::empty();
+    for &space in subst::ParamSpace::all().iter() {
+        push_bounds_from_defs(tcx, &mut bounds, space, &free_substs,
+                              generics.types.get_vec(space));
+    }
 
     debug!("construct_parameter_environment: free_id={} \
            free_subst={} \
-           self_param_bound={} \
-           type_param_bound={}",
+           bounds={}",
            free_id,
            free_substs.repr(tcx),
-           self_bound_substd.repr(tcx),
-           type_param_bounds_substd.repr(tcx));
+           bounds.repr(tcx));
 
-    ty::ParameterEnvironment {
+    return ty::ParameterEnvironment {
         free_substs: free_substs,
-        self_param_bound: self_bound_substd,
-        type_param_bounds: type_param_bounds_substd,
+        bounds: bounds
+    };
+
+    fn push_region_params(regions: &mut VecPerParamSpace<ty::Region>,
+                          space: subst::ParamSpace,
+                          free_id: ast::NodeId,
+                          region_params: &Vec<RegionParameterDef>)
+    {
+        for r in region_params.iter() {
+            regions.push(space, ty::free_region_from_def(free_id, r));
+        }
+    }
+
+    fn push_types_from_defs(tcx: &ty::ctxt,
+                            types: &mut subst::VecPerParamSpace<ty::t>,
+                            space: subst::ParamSpace,
+                            defs: &Vec<TypeParameterDef>) {
+        for (i, def) in defs.iter().enumerate() {
+            let ty = ty::mk_param(tcx, space, i, def.def_id);
+            types.push(space, ty);
+        }
+    }
+
+    fn push_bounds_from_defs(tcx: &ty::ctxt,
+                             bounds: &mut subst::VecPerParamSpace<ParamBounds>,
+                             space: subst::ParamSpace,
+                             free_substs: &subst::Substs,
+                             defs: &Vec<TypeParameterDef>) {
+        for def in defs.iter() {
+            let b = (*def.bounds).subst(tcx, free_substs);
+            bounds.push(space, b);
+        }
     }
 }
 

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -10,7 +10,7 @@
 
 
 use middle::ty;
-use middle::ty::{AutoAddEnv, AutoDerefRef, AutoObject, param_ty};
+use middle::ty::{AutoAddEnv, AutoDerefRef, AutoObject, ParamTy};
 use middle::ty_fold::TypeFolder;
 use middle::typeck::astconv::AstConv;
 use middle::typeck::check::{FnCtxt, impl_self_ty};
@@ -20,11 +20,11 @@ use middle::typeck::infer::fixup_err_to_str;
 use middle::typeck::infer::{resolve_and_force_all_but_regions, resolve_type};
 use middle::typeck::infer;
 use middle::typeck::{vtable_origin, vtable_res, vtable_param_res};
-use middle::typeck::{vtable_static, vtable_param, impl_res};
-use middle::typeck::{param_numbered, param_self, param_index};
+use middle::typeck::{vtable_static, vtable_param, vtable_error};
+use middle::typeck::{param_index};
 use middle::typeck::MethodCall;
 use middle::subst;
-use middle::subst::Subst;
+use middle::subst::{Subst, VecPerParamSpace};
 use util::common::indenter;
 use util::ppaux;
 use util::ppaux::Repr;
@@ -76,38 +76,32 @@ impl<'a> VtableContext<'a> {
 
 fn lookup_vtables(vcx: &VtableContext,
                   span: Span,
-                  type_param_defs: &[ty::TypeParameterDef],
+                  type_param_defs: &VecPerParamSpace<ty::TypeParameterDef>,
                   substs: &subst::Substs,
-                  is_early: bool) -> vtable_res {
-    debug!("lookup_vtables(span={:?}, \
-            type_param_defs={}, \
-            substs={}",
-           span,
+                  is_early: bool)
+                  -> VecPerParamSpace<vtable_param_res>
+{
+    debug!("lookup_vtables(\
+           type_param_defs={}, \
+           substs={}",
            type_param_defs.repr(vcx.tcx()),
            substs.repr(vcx.tcx()));
 
     // We do this backwards for reasons discussed above.
-    assert_eq!(substs.tps.len(), type_param_defs.len());
-    let mut result: Vec<vtable_param_res> =
-        substs.tps.iter()
-        .rev()
-        .zip(type_param_defs.iter().rev())
-        .map(|(ty, def)|
-            lookup_vtables_for_param(vcx, span, Some(substs),
-                                     &*def.bounds, *ty, is_early))
-        .collect();
-    result.reverse();
+    let result = type_param_defs.map_rev(|def| {
+        let ty = *substs.types.get(def.space, def.index);
+        lookup_vtables_for_param(vcx, span, Some(substs),
+                                 &*def.bounds, ty, is_early)
+    });
 
-    assert_eq!(substs.tps.len(), result.len());
     debug!("lookup_vtables result(\
-            span={:?}, \
             type_param_defs={}, \
             substs={}, \
             result={})",
-           span,
            type_param_defs.repr(vcx.tcx()),
            substs.repr(vcx.tcx()),
            result.repr(vcx.tcx()));
+
     result
 }
 
@@ -117,8 +111,14 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
                             substs: Option<&subst::Substs>,
                             type_param_bounds: &ty::ParamBounds,
                             ty: ty::t,
-                            is_early: bool) -> vtable_param_res {
+                            is_early: bool)
+                            -> vtable_param_res {
     let tcx = vcx.tcx();
+
+    debug!("lookup_vtables_for_param(ty={}, type_param_bounds={}, is_early={})",
+           ty.repr(vcx.tcx()),
+           type_param_bounds.repr(vcx.tcx()),
+           is_early);
 
     // ty is the value supplied for the type parameter A...
     let mut param_result = Vec::new();
@@ -129,6 +129,10 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
                                          |trait_ref| {
         // ...and here trait_ref is each bound that was declared on A,
         // expressed in terms of the type parameters.
+
+        debug!("matching ty={} trait_ref={}",
+               ty.repr(vcx.tcx()),
+               trait_ref.repr(vcx.tcx()));
 
         ty::populate_implementations_for_trait_if_necessary(tcx,
                                                             trait_ref.def_id);
@@ -157,11 +161,9 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
     });
 
     debug!("lookup_vtables_for_param result(\
-            span={:?}, \
             type_param_bounds={}, \
             ty={}, \
             result={})",
-           span,
            type_param_bounds.repr(vcx.tcx()),
            ty.repr(vcx.tcx()),
            param_result.repr(vcx.tcx()));
@@ -216,10 +218,11 @@ fn lookup_vtable(vcx: &VtableContext,
                  ty: ty::t,
                  trait_ref: Rc<ty::TraitRef>,
                  is_early: bool)
-                 -> Option<vtable_origin> {
+                 -> Option<vtable_origin>
+{
     debug!("lookup_vtable(ty={}, trait_ref={})",
-           vcx.infcx.ty_to_str(ty),
-           vcx.infcx.trait_ref_to_str(&*trait_ref));
+           ty.repr(vcx.tcx()),
+           trait_ref.repr(vcx.tcx()));
     let _i = indenter();
 
     let ty = match fixup_ty(vcx, span, ty, is_early) {
@@ -230,32 +233,24 @@ fn lookup_vtable(vcx: &VtableContext,
             // The type has unconstrained type variables in it, so we can't
             // do early resolution on it. Return some completely bogus vtable
             // information: we aren't storing it anyways.
-            return Some(vtable_param(param_self, 0));
+            return Some(vtable_error);
         }
     };
+
+    if ty::type_is_error(ty) {
+        return Some(vtable_error);
+    }
 
     // If the type is self or a param, we look at the trait/supertrait
     // bounds to see if they include the trait we are looking for.
     let vtable_opt = match ty::get(ty).sty {
-        ty::ty_param(param_ty {idx: n, ..}) => {
-            let env_bounds = &vcx.param_env.type_param_bounds;
-            if env_bounds.len() > n {
-                let type_param_bounds: &[Rc<ty::TraitRef>] =
-                    env_bounds.get(n).trait_bounds.as_slice();
-                lookup_vtable_from_bounds(vcx, span,
-                                          type_param_bounds,
-                                          param_numbered(n),
-                                          trait_ref.clone())
-            } else {
-                None
-            }
-        }
-
-        ty::ty_self(_) => {
-            let self_param_bound = vcx.param_env.self_param_bound.clone().unwrap();
+        ty::ty_param(ParamTy {space, idx: n, ..}) => {
+            let env_bounds = &vcx.param_env.bounds;
+            let type_param_bounds = &env_bounds.get(space, n).trait_bounds;
             lookup_vtable_from_bounds(vcx, span,
-                                      [self_param_bound],
-                                      param_self,
+                                      type_param_bounds.as_slice(),
+                                      param_index { space: space,
+                                                    index: n },
                                       trait_ref.clone())
         }
 
@@ -373,8 +368,8 @@ fn search_for_vtable(vcx: &VtableContext,
         // Now, in the previous example, for_ty is bound to
         // the type self_ty, and substs is bound to [T].
         debug!("The self ty is {} and its substs are {}",
-               vcx.infcx.ty_to_str(for_ty),
-               vcx.infcx.tys_to_str(substs.tps.as_slice()));
+               for_ty.repr(tcx),
+               substs.types.repr(tcx));
 
         // Next, we unify trait_ref -- the type that we want to cast
         // to -- with of_trait_ref -- the trait that im implements. At
@@ -386,12 +381,13 @@ fn search_for_vtable(vcx: &VtableContext,
         // some value of U) with some_trait<T>. This would fail if T
         // and U weren't compatible.
 
-        debug!("(checking vtable) {}2 relating trait \
-                ty {} to of_trait_ref {}", "#",
+        let of_trait_ref = of_trait_ref.subst(tcx, &substs);
+
+        debug!("(checking vtable) num 2 relating trait \
+                ty {} to of_trait_ref {}",
                vcx.infcx.trait_ref_to_str(&*trait_ref),
                vcx.infcx.trait_ref_to_str(&*of_trait_ref));
 
-        let of_trait_ref = of_trait_ref.subst(tcx, &substs);
         relate_trait_refs(vcx, span, of_trait_ref, trait_ref.clone());
 
 
@@ -404,10 +400,11 @@ fn search_for_vtable(vcx: &VtableContext,
         // process of looking up bounds might constrain some of them.
         let im_generics =
             ty::lookup_item_type(tcx, impl_did).generics;
-        let subres = lookup_vtables(vcx, span,
-                                    im_generics.type_param_defs(), &substs,
+        let subres = lookup_vtables(vcx,
+                                    span,
+                                    &im_generics.types,
+                                    &substs,
                                     is_early);
-
 
         // substs might contain type variables, so we call
         // fixup_substs to resolve them.
@@ -419,15 +416,15 @@ fn search_for_vtable(vcx: &VtableContext,
             None => {
                 assert!(is_early);
                 // Bail out with a bogus answer
-                return Some(vtable_param(param_self, 0));
+                return Some(vtable_error);
             }
         };
 
         debug!("The fixed-up substs are {} - \
                 they will be unified with the bounds for \
                 the target ty, {}",
-               vcx.infcx.tys_to_str(substs_f.tps.as_slice()),
-               vcx.infcx.trait_ref_to_str(&*trait_ref));
+               substs_f.types.repr(tcx),
+               trait_ref.repr(tcx));
 
         // Next, we unify the fixed-up substitutions for the impl self
         // ty with the substitutions from the trait type that we're
@@ -515,7 +512,7 @@ fn connect_trait_tps(vcx: &VtableContext,
 }
 
 fn insert_vtables(fcx: &FnCtxt, vtable_key: MethodCall, vtables: vtable_res) {
-    debug!("insert_vtables(vtable_key={}, vtables={:?})",
+    debug!("insert_vtables(vtable_key={}, vtables={})",
            vtable_key, vtables.repr(fcx.tcx()));
     fcx.inh.vtable_map.borrow_mut().insert(vtable_key, vtables);
 }
@@ -560,12 +557,20 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
                     };
 
                       let vcx = fcx.vtable_context();
+
+                      // Take the type parameters from the object
+                      // type, but set the Self type (which is
+                      // unknown, for the object type) to be the type
+                      // we are casting from.
+                      let mut target_types = target_substs.types.clone();
+                      assert!(target_types.get_self().is_none());
+                      target_types.push(subst::SelfSpace, typ);
+
                       let target_trait_ref = Rc::new(ty::TraitRef {
                           def_id: target_def_id,
                           substs: subst::Substs {
-                              tps: target_substs.tps.clone(),
                               regions: target_substs.regions.clone(),
-                              self_ty: Some(typ)
+                              types: target_types
                           }
                       });
 
@@ -582,7 +587,9 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
                                                      is_early);
 
                       if !is_early {
-                          insert_vtables(fcx, MethodCall::expr(ex.id), vec!(vtables));
+                          let mut r = VecPerParamSpace::empty();
+                          r.push(subst::SelfSpace, vtables);
+                          insert_vtables(fcx, MethodCall::expr(ex.id), r);
                       }
 
                       // Now, if this is &trait, we need to link the
@@ -632,10 +639,10 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
             debug!("early resolve expr: def {:?} {:?}, {:?}, {}", ex.id, did, def,
                    fcx.infcx().ty_to_str(item_ty.ty));
             debug!("early_resolve_expr: looking up vtables for type params {}",
-                   item_ty.generics.type_param_defs().repr(fcx.tcx()));
+                   item_ty.generics.types.repr(fcx.tcx()));
             let vcx = fcx.vtable_context();
             let vtbls = lookup_vtables(&vcx, ex.span,
-                                       item_ty.generics.type_param_defs(),
+                                       &item_ty.generics.types,
                                        &item_substs.substs, is_early);
             if !is_early {
                 insert_vtables(fcx, MethodCall::expr(ex.id), vtbls);
@@ -657,7 +664,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
               let substs = fcx.method_ty_substs(ex.id);
               let vcx = fcx.vtable_context();
               let vtbls = lookup_vtables(&vcx, ex.span,
-                                         type_param_defs.as_slice(),
+                                         &type_param_defs,
                                          &substs, is_early);
               if !is_early {
                   insert_vtables(fcx, MethodCall::expr(ex.id), vtbls);
@@ -689,8 +696,7 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
                                     ty::method_call_type_param_defs(cx.tcx, method.origin);
                                 let vcx = fcx.vtable_context();
                                 let vtbls = lookup_vtables(&vcx, ex.span,
-                                                           type_param_defs.deref()
-                                                           .as_slice(),
+                                                           &type_param_defs,
                                                            &method.substs, is_early);
                                 if !is_early {
                                     insert_vtables(fcx, method_call, vtbls);
@@ -726,64 +732,84 @@ pub fn resolve_impl(tcx: &ty::ctxt,
                     impl_item: &ast::Item,
                     impl_generics: &ty::Generics,
                     impl_trait_ref: &ty::TraitRef) {
+    /*!
+     * The situation is as follows. We have some trait like:
+     *
+     *    trait Foo<A:Clone> : Bar {
+     *        fn method() { ... }
+     *    }
+     *
+     * and an impl like:
+     *
+     *    impl<B:Clone> Foo<B> for int { ... }
+     *
+     * We want to validate that the various requirements of the trait
+     * are met:
+     *
+     *    A:Clone, Self:Bar
+     *
+     * But of course after substituting the types from the impl:
+     *
+     *    B:Clone, int:Bar
+     *
+     * We store these results away as the "impl_res" for use by the
+     * default methods.
+     */
+
     debug!("resolve_impl(impl_item.id={})",
            impl_item.id);
 
-    let param_env = ty::construct_parameter_environment(
-        tcx,
-        None,
-        impl_generics.type_param_defs(),
-        [],
-        impl_generics.region_param_defs(),
-        [],
-        impl_item.id);
+    let param_env = ty::construct_parameter_environment(tcx,
+                                                        impl_generics,
+                                                        impl_item.id);
 
+    // The impl_trait_ref in our example above would be
+    //     `Foo<B> for int`
     let impl_trait_ref = impl_trait_ref.subst(tcx, &param_env.free_substs);
     debug!("impl_trait_ref={}", impl_trait_ref.repr(tcx));
 
     let infcx = &infer::new_infer_ctxt(tcx);
     let vcx = VtableContext { infcx: infcx, param_env: &param_env };
 
-    // First, check that the impl implements any trait bounds
-    // on the trait.
+    // Resolve the vtables for the trait reference on the impl.  This
+    // serves many purposes, best explained by example. Imagine we have:
+    //
+    //    trait A<T:B> : C { fn x(&self) { ... } }
+    //
+    // and
+    //
+    //    impl A<int> for uint { ... }
+    //
+    // In that case, the trait ref will be `A<int> for uint`. Resolving
+    // this will first check that the various types meet their requirements:
+    //
+    // 1. Because of T:B, int must implement the trait B
+    // 2. Because of the supertrait C, uint must implement the trait C.
+    //
+    // Simultaneously, the result of this resolution (`vtbls`), is precisely
+    // the set of vtable information needed to compile the default method
+    // `x()` adapted to the impl. (After all, a default method is basically
+    // the same as:
+    //
+    //     fn default_x<T:B, Self:A>(...) { .. .})
+
     let trait_def = ty::lookup_trait_def(tcx, impl_trait_ref.def_id);
-    let vtbls = lookup_vtables(&vcx, impl_item.span,
-                               trait_def.generics.type_param_defs(),
-                               &impl_trait_ref.substs,
-                               false);
-
-    // Now, locate the vtable for the impl itself. The real
-    // purpose of this is to check for supertrait impls,
-    // but that falls out of doing this.
-    let param_bounds = ty::ParamBounds {
-        builtin_bounds: ty::empty_builtin_bounds(),
-        trait_bounds: vec!(Rc::new(impl_trait_ref))
-    };
-    let t = ty::node_id_to_type(tcx, impl_item.id);
-    let t = t.subst(tcx, &param_env.free_substs);
-    debug!("=== Doing a self lookup now.");
-
-    // Right now, we don't have any place to store this.
-    // We will need to make one so we can use this information
-    // for compiling default methods that refer to supertraits.
-    let self_vtable_res =
-        lookup_vtables_for_param(&vcx, impl_item.span, None,
-                                 &param_bounds, t, false);
+    let vtbls = lookup_vtables(&vcx,
+                                   impl_item.span,
+                                   &trait_def.generics.types,
+                                   &impl_trait_ref.substs,
+                                   false);
 
     infcx.resolve_regions_and_report_errors();
 
-    let res = impl_res {
-        trait_vtables: vtbls,
-        self_vtables: self_vtable_res
-    };
-    let res = writeback::resolve_impl_res(infcx, impl_item.span, &res);
+    let vtbls = writeback::resolve_impl_res(infcx, impl_item.span, &vtbls);
     let impl_def_id = ast_util::local_def(impl_item.id);
 
     debug!("impl_vtables for {} are {}",
            impl_def_id.repr(tcx),
-           res.repr(tcx));
+           vtbls.repr(tcx));
 
-    tcx.impl_vtables.borrow_mut().insert(impl_def_id, res);
+    tcx.impl_vtables.borrow_mut().insert(impl_def_id, vtbls);
 }
 
 /// Resolve vtables for a method call after typeck has finished.
@@ -791,15 +817,14 @@ pub fn resolve_impl(tcx: &ty::ctxt,
 pub fn trans_resolve_method(tcx: &ty::ctxt, id: ast::NodeId,
                             substs: &subst::Substs) -> vtable_res {
     let generics = ty::lookup_item_type(tcx, ast_util::local_def(id)).generics;
-    let type_param_defs = &*generics.type_param_defs;
     let vcx = VtableContext {
         infcx: &infer::new_infer_ctxt(tcx),
-        param_env: &ty::construct_parameter_environment(tcx, None, [], [], [], [], id)
+        param_env: &ty::construct_parameter_environment(tcx, &ty::Generics::empty(), id)
     };
 
     lookup_vtables(&vcx,
                    tcx.map.span(id),
-                   type_param_defs.as_slice(),
+                   &generics.types,
                    substs,
                    false)
 }

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -61,6 +61,7 @@ time of error detection.
 
 use std::collections::HashSet;
 use middle::def;
+use middle::subst;
 use middle::ty;
 use middle::ty::{Region, ReFree};
 use middle::typeck::infer;
@@ -1055,9 +1056,10 @@ impl<'a> Rebuilder<'a> {
                                 ty: _
                             } = ty::lookup_item_type(self.tcx, did);
 
-                            let expected = generics.region_param_defs().len();
-                            let lifetimes = &path.segments.last()
-                                                 .unwrap().lifetimes;
+                            let expected =
+                                generics.regions.len(subst::TypeSpace);
+                            let lifetimes =
+                                &path.segments.last().unwrap().lifetimes;
                             let mut insert = Vec::new();
                             if lifetimes.len() == 0 {
                                 let anon = self.cur_anon.get();

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -66,6 +66,7 @@ use driver::config;
 use middle::def;
 use middle::resolve;
 use middle::subst;
+use middle::subst::VecPerParamSpace;
 use middle::ty;
 use util::common::time;
 use util::ppaux::Repr;
@@ -73,7 +74,6 @@ use util::ppaux;
 use util::nodemap::{DefIdMap, FnvHashMap};
 
 use std::cell::RefCell;
-use std::rc::Rc;
 use syntax::codemap::Span;
 use syntax::print::pprust::*;
 use syntax::{ast, ast_map, abi};
@@ -87,9 +87,9 @@ pub mod coherence;
 pub mod variance;
 
 #[deriving(Clone, Encodable, Decodable, PartialEq, PartialOrd)]
-pub enum param_index {
-    param_numbered(uint),
-    param_self
+pub struct param_index {
+    pub space: subst::ParamSpace,
+    pub index: uint
 }
 
 #[deriving(Clone, Encodable, Decodable)]
@@ -176,8 +176,9 @@ impl MethodCall {
 pub type MethodMap = RefCell<FnvHashMap<MethodCall, MethodCallee>>;
 
 pub type vtable_param_res = Vec<vtable_origin>;
+
 // Resolutions for bounds of all parameters, left to right, for a given path.
-pub type vtable_res = Vec<vtable_param_res>;
+pub type vtable_res = VecPerParamSpace<vtable_param_res>;
 
 #[deriving(Clone)]
 pub enum vtable_origin {
@@ -197,6 +198,14 @@ pub enum vtable_origin {
       and the second is the bound number (identifying baz)
      */
     vtable_param(param_index, uint),
+
+    /*
+      Asked to determine the vtable for ty_err. This is the value used
+      for the vtables of `Self` in a virtual call like `foo.bar()`
+      where `foo` is of object type. The same value is also used when
+      type errors occur.
+     */
+    vtable_error,
 }
 
 impl Repr for vtable_origin {
@@ -213,6 +222,10 @@ impl Repr for vtable_origin {
             vtable_param(x, y) => {
                 format!("vtable_param({:?}, {:?})", x, y)
             }
+
+            vtable_error => {
+                format!("vtable_error")
+            }
         }
     }
 }
@@ -220,33 +233,7 @@ impl Repr for vtable_origin {
 pub type vtable_map = RefCell<FnvHashMap<MethodCall, vtable_res>>;
 
 
-// Information about the vtable resolutions for a trait impl.
-// Mostly the information is important for implementing default
-// methods.
-#[deriving(Clone)]
-pub struct impl_res {
-    // resolutions for any bounded params on the trait definition
-    pub trait_vtables: vtable_res,
-    // resolutions for the trait /itself/ (and for supertraits)
-    pub self_vtables: vtable_param_res
-}
-
-impl Repr for impl_res {
-    #[cfg(stage0)]
-    fn repr(&self, tcx: &ty::ctxt) -> String {
-        format!("impl_res \\{trait_vtables={}, self_vtables={}\\}",
-                self.trait_vtables.repr(tcx),
-                self.self_vtables.repr(tcx))
-    }
-    #[cfg(not(stage0))]
-    fn repr(&self, tcx: &ty::ctxt) -> String {
-        format!("impl_res {{trait_vtables={}, self_vtables={}}}",
-                self.trait_vtables.repr(tcx),
-                self.self_vtables.repr(tcx))
-    }
-}
-
-pub type impl_vtable_map = RefCell<DefIdMap<impl_res>>;
+pub type impl_vtable_map = RefCell<DefIdMap<vtable_res>>;
 
 pub struct CrateCtxt<'a> {
     // A mapping from method call sites to traits that have that method.
@@ -268,8 +255,7 @@ pub fn write_substs_to_tcx(tcx: &ty::ctxt,
                node_id,
                item_substs.repr(tcx));
 
-        assert!(item_substs.substs.tps.iter().
-                all(|t| !ty::type_needs_infer(*t)));
+        assert!(item_substs.substs.types.all(|t| !ty::type_needs_infer(*t)));
 
         tcx.item_substs.borrow_mut().insert(node_id, item_substs);
     }
@@ -290,8 +276,8 @@ pub fn lookup_def_ccx(ccx: &CrateCtxt, sp: Span, id: ast::NodeId)
 
 pub fn no_params(t: ty::t) -> ty::ty_param_bounds_and_ty {
     ty::ty_param_bounds_and_ty {
-        generics: ty::Generics {type_param_defs: Rc::new(Vec::new()),
-                                region_param_defs: Rc::new(Vec::new())},
+        generics: ty::Generics {types: VecPerParamSpace::empty(),
+                                regions: VecPerParamSpace::empty()},
         ty: t
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -27,6 +27,7 @@ use rustc::metadata::csearch;
 use rustc::metadata::decoder;
 use rustc::middle::def;
 use rustc::middle::subst;
+use rustc::middle::subst::VecPerParamSpace;
 use rustc::middle::ty;
 
 use std::rc::Rc;
@@ -50,6 +51,12 @@ pub trait Clean<T> {
 impl<T: Clean<U>, U> Clean<Vec<U>> for Vec<T> {
     fn clean(&self) -> Vec<U> {
         self.iter().map(|x| x.clean()).collect()
+    }
+}
+
+impl<T: Clean<U>, U> Clean<VecPerParamSpace<U>> for VecPerParamSpace<T> {
+    fn clean(&self) -> VecPerParamSpace<U> {
+        self.map(|x| x.clean())
     }
 }
 
@@ -488,17 +495,17 @@ impl Clean<TyParamBound> for ast::TyParamBound {
 }
 
 fn external_path(name: &str, substs: &subst::Substs) -> Path {
+    let lifetimes = substs.regions().get_vec(subst::TypeSpace)
+                    .iter()
+                    .filter_map(|v| v.clean())
+                    .collect();
+    let types = substs.types.get_vec(subst::TypeSpace).clean();
     Path {
         global: false,
         segments: vec![PathSegment {
             name: name.to_string(),
-            lifetimes: match substs.regions {
-                subst::ErasedRegions => Vec::new(),
-                subst::NonerasedRegions(ref v) => {
-                    v.iter().filter_map(|v| v.clean()).collect()
-                }
-            },
-            types: substs.tps.clean(),
+            lifetimes: lifetimes,
+            types: types,
         }],
     }
 }
@@ -578,12 +585,8 @@ impl Clean<Vec<TyParamBound>> for ty::ParamBounds {
 impl Clean<Option<Vec<TyParamBound>>> for subst::Substs {
     fn clean(&self) -> Option<Vec<TyParamBound>> {
         let mut v = Vec::new();
-        match self.regions {
-            subst::NonerasedRegions(..) => v.push(RegionBound),
-            subst::ErasedRegions => {}
-        }
-        v.extend(self.tps.iter().map(|t| TraitBound(t.clean())));
-
+        v.extend(self.regions().iter().map(|_| RegionBound));
+        v.extend(self.types.iter().map(|t| TraitBound(t.clean())));
         if v.len() > 0 {Some(v)} else {None}
     }
 }
@@ -617,7 +620,7 @@ impl Clean<Option<Lifetime>> for ty::Region {
             ty::ReStatic => Some(Lifetime("static".to_string())),
             ty::ReLateBound(_, ty::BrNamed(_, name)) =>
                 Some(Lifetime(token::get_name(name).get().to_string())),
-            ty::ReEarlyBound(_, _, name) => Some(Lifetime(name.clean())),
+            ty::ReEarlyBound(_, _, _, name) => Some(Lifetime(name.clean())),
 
             ty::ReLateBound(..) |
             ty::ReFree(..) |
@@ -638,17 +641,41 @@ pub struct Generics {
 impl Clean<Generics> for ast::Generics {
     fn clean(&self) -> Generics {
         Generics {
-            lifetimes: self.lifetimes.clean().move_iter().collect(),
-            type_params: self.ty_params.clean().move_iter().collect(),
+            lifetimes: self.lifetimes.clean(),
+            type_params: self.ty_params.clean(),
         }
     }
 }
 
 impl Clean<Generics> for ty::Generics {
     fn clean(&self) -> Generics {
+        // In the type space, generics can come in one of multiple
+        // namespaces.  This means that e.g. for fn items the type
+        // parameters will live in FnSpace, but for types the
+        // parameters will live in TypeSpace (trait definitions also
+        // define a parameter in SelfSpace). *Method* definitions are
+        // the one exception: they combine the TypeSpace parameters
+        // from the enclosing impl/trait with their own FnSpace
+        // parameters.
+        //
+        // In general, when we clean, we are trying to produce the
+        // "user-facing" generics. Hence we select the most specific
+        // namespace that is occupied, ignoring SelfSpace because it
+        // is implicit.
+
+        let space = {
+            if !self.types.get_vec(subst::FnSpace).is_empty() ||
+                !self.regions.get_vec(subst::FnSpace).is_empty()
+            {
+                subst::FnSpace
+            } else {
+                subst::TypeSpace
+            }
+        };
+
         Generics {
-            lifetimes: self.region_param_defs.clean(),
-            type_params: self.type_param_defs.clean(),
+            type_params: self.types.get_vec(space).clean(),
+            lifetimes: self.regions.get_vec(space).clean(),
         }
     }
 }
@@ -1259,8 +1286,13 @@ impl Clean<Type> for ty::t {
             }
             ty::ty_tup(ref t) => Tuple(t.iter().map(|t| t.clean()).collect()),
 
-            ty::ty_param(ref p) => Generic(p.def_id),
-            ty::ty_self(did) => Self(did),
+            ty::ty_param(ref p) => {
+                if p.space == subst::SelfSpace {
+                    Self(p.def_id)
+                } else {
+                    Generic(p.def_id)
+                }
+            }
 
             ty::ty_infer(..) => fail!("ty_infer"),
             ty::ty_err => fail!("ty_err"),
@@ -1968,7 +2000,7 @@ fn resolve_type(path: Path, tpbs: Option<Vec<TyParamBound>>,
             ast::TyFloat(ast::TyF64) => return Primitive(F64),
             ast::TyFloat(ast::TyF128) => return Primitive(F128),
         },
-        def::DefTyParam(i, _) => return Generic(i),
+        def::DefTyParam(_, i, _) => return Generic(i),
         def::DefTyParamBinder(i) => return TyParamBinder(i),
         _ => {}
     };

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -208,14 +208,6 @@ impl Generics {
     }
 }
 
-#[deriving(Clone, PartialEq, Eq, Hash, Encodable, Decodable, Show)]
-pub enum DefRegion {
-    DefStaticRegion,
-    DefEarlyBoundRegion(/* index */ uint, /* lifetime decl */ NodeId),
-    DefLateBoundRegion(/* binder_id */ NodeId, /* depth */ uint, /* lifetime decl */ NodeId),
-    DefFreeRegion(/* block scope */ NodeId, /* lifetime decl */ NodeId),
-}
-
 // The set of MetaItems that define the compilation environment of the crate,
 // used to drive conditional compilation
 pub type CrateConfig = Vec<Gc<MetaItem>>;

--- a/src/test/compile-fail/bad-mid-path-type-params.rs
+++ b/src/test/compile-fail/bad-mid-path-type-params.rs
@@ -45,11 +45,16 @@ impl Trait<int> for S2 {
 
 fn foo<'a>() {
     let _ = S::new::<int,f64>(1, 1.0);
-    //~^ ERROR the impl referenced by this path needs 1 type parameter, but 0 type parameters were supplied
-    let _ = S::<'a,int>::new::<f64>(1, 1.0); //~ ERROR expected 0 lifetime parameters
+    //~^ ERROR too many type parameters provided
+
+    let _ = S::<'a,int>::new::<f64>(1, 1.0);
+    //~^ ERROR too many lifetime parameters provided
+
     let _: S2 = Trait::new::<int,f64>(1, 1.0);
-    //~^ ERROR the trait referenced by this path needs 1 type parameter, but 0 type parameters were supplied
-    let _: S2 = Trait::<'a,int>::new::<f64>(1, 1.0); //~ ERROR expected 0 lifetime parameters
+    //~^ ERROR too many type parameters provided
+
+    let _: S2 = Trait::<'a,int>::new::<f64>(1, 1.0);
+    //~^ ERROR too many lifetime parameters provided
 }
 
 fn main() {}

--- a/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
@@ -18,7 +18,5 @@ impl<A, B, C = (A, B)> Foo<A, B, C> {
 
 fn main() {
     Foo::<int>::new();
-    //~^ ERROR the impl referenced by this path needs at least 2 type parameters,
-    //         but 1 was supplied
-    //~^^^ ERROR not enough type parameters provided: expected at least 2, found 1
+    //~^ ERROR too few type parameters provided
 }

--- a/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
@@ -20,7 +20,5 @@ impl<T, A = Heap> Vec<T, A> {
 
 fn main() {
     Vec::<int, Heap, bool>::new();
-    //~^ ERROR the impl referenced by this path needs at most 2 type parameters,
-    //         but 3 were supplied
-    //~^^^ ERROR too many type parameters provided: expected at most 2, found 3
+    //~^ ERROR too many type parameters provided
 }

--- a/src/test/compile-fail/issue-11844.rs
+++ b/src/test/compile-fail/issue-11844.rs
@@ -12,7 +12,7 @@ fn main() {
     let a = Some(box 1);
     match a {
         Ok(a) => //~ ERROR: mismatched types
-            println!("{}",a), //~ ERROR: failed to find an implementation of trait
+            println!("{}",a),
         None => fail!()
     }
 }

--- a/src/test/compile-fail/issue-13466.rs
+++ b/src/test/compile-fail/issue-13466.rs
@@ -15,7 +15,6 @@ pub fn main() {
     // the actual arm `Result<T, E>` has two. typeck should not be
     // tricked into looking up a non-existing second type parameter.
     let _x: uint = match Some(1u) {
-    //~^ ERROR mismatched types: expected `uint` but found `<generic #0>`
         Ok(u) => u, //~ ERROR  mismatched types: expected `core::option::Option<uint>`
         Err(e) => fail!(e)  //~ ERROR mismatched types: expected `core::option::Option<uint>`
     };

--- a/src/test/compile-fail/issue-7092.rs
+++ b/src/test/compile-fail/issue-7092.rs
@@ -15,7 +15,6 @@ fn foo(x: Whatever) {
     match x {
         Some(field) => field.access(),
         //~^ ERROR: mismatched types: expected `Whatever` but found
-        //~^^ ERROR: does not implement any method in scope named `access`
     }
 }
 

--- a/src/test/compile-fail/variance-regions-direct.rs
+++ b/src/test/compile-fail/variance-regions-direct.rs
@@ -14,7 +14,7 @@
 // Regions that just appear in normal spots are contravariant:
 
 #[rustc_variance]
-struct Test2<'a, 'b, 'c> { //~ ERROR region_params=[-, -, -]
+struct Test2<'a, 'b, 'c> { //~ ERROR regions=[[-, -, -];[];[]]
     x: &'a int,
     y: &'b [int],
     c: &'c str
@@ -23,7 +23,7 @@ struct Test2<'a, 'b, 'c> { //~ ERROR region_params=[-, -, -]
 // Those same annotations in function arguments become covariant:
 
 #[rustc_variance]
-struct Test3<'a, 'b, 'c> { //~ ERROR region_params=[+, +, +]
+struct Test3<'a, 'b, 'c> { //~ ERROR regions=[[+, +, +];[];[]]
     x: extern "Rust" fn(&'a int),
     y: extern "Rust" fn(&'b [int]),
     c: extern "Rust" fn(&'c str),
@@ -32,7 +32,7 @@ struct Test3<'a, 'b, 'c> { //~ ERROR region_params=[+, +, +]
 // Mutability induces invariance:
 
 #[rustc_variance]
-struct Test4<'a, 'b> { //~ ERROR region_params=[-, o]
+struct Test4<'a, 'b> { //~ ERROR regions=[[-, o];[];[]]
     x: &'a mut &'b int,
 }
 
@@ -40,7 +40,7 @@ struct Test4<'a, 'b> { //~ ERROR region_params=[-, o]
 // contravariant context:
 
 #[rustc_variance]
-struct Test5<'a, 'b> { //~ ERROR region_params=[+, o]
+struct Test5<'a, 'b> { //~ ERROR regions=[[+, o];[];[]]
     x: extern "Rust" fn(&'a mut &'b int),
 }
 
@@ -50,21 +50,21 @@ struct Test5<'a, 'b> { //~ ERROR region_params=[+, o]
 // argument list occurs in an invariant context.
 
 #[rustc_variance]
-struct Test6<'a, 'b> { //~ ERROR region_params=[-, o]
+struct Test6<'a, 'b> { //~ ERROR regions=[[-, o];[];[]]
     x: &'a mut extern "Rust" fn(&'b int),
 }
 
 // No uses at all is bivariant:
 
 #[rustc_variance]
-struct Test7<'a> { //~ ERROR region_params=[*]
+struct Test7<'a> { //~ ERROR regions=[[*];[];[]]
     x: int
 }
 
 // Try enums too.
 
 #[rustc_variance]
-enum Test8<'a, 'b, 'c> { //~ ERROR region_params=[+, -, o]
+enum Test8<'a, 'b, 'c> { //~ ERROR regions=[[+, -, o];[];[]]
     Test8A(extern "Rust" fn(&'a int)),
     Test8B(&'b [int]),
     Test8C(&'b mut &'c str),

--- a/src/test/compile-fail/variance-regions-indirect.rs
+++ b/src/test/compile-fail/variance-regions-indirect.rs
@@ -13,29 +13,29 @@
 // Try enums too.
 
 #[rustc_variance]
-enum Base<'a, 'b, 'c, 'd> { //~ ERROR region_params=[+, -, o, *]
+enum Base<'a, 'b, 'c, 'd> { //~ ERROR regions=[[+, -, o, *];[];[]]
     Test8A(extern "Rust" fn(&'a int)),
     Test8B(&'b [int]),
     Test8C(&'b mut &'c str),
 }
 
 #[rustc_variance]
-struct Derived1<'w, 'x, 'y, 'z> { //~ ERROR region_params=[*, o, -, +]
+struct Derived1<'w, 'x, 'y, 'z> { //~ ERROR regions=[[*, o, -, +];[];[]]
     f: Base<'z, 'y, 'x, 'w>
 }
 
 #[rustc_variance] // Combine - and + to yield o
-struct Derived2<'a, 'b, 'c> { //~ ERROR region_params=[o, o, *]
+struct Derived2<'a, 'b, 'c> { //~ ERROR regions=[[o, o, *];[];[]]
     f: Base<'a, 'a, 'b, 'c>
 }
 
 #[rustc_variance] // Combine + and o to yield o (just pay attention to 'a here)
-struct Derived3<'a, 'b, 'c> { //~ ERROR region_params=[o, -, *]
+struct Derived3<'a, 'b, 'c> { //~ ERROR regions=[[o, -, *];[];[]]
     f: Base<'a, 'b, 'a, 'c>
 }
 
 #[rustc_variance] // Combine + and * to yield + (just pay attention to 'a here)
-struct Derived4<'a, 'b, 'c> { //~ ERROR region_params=[+, -, o]
+struct Derived4<'a, 'b, 'c> { //~ ERROR regions=[[+, -, o];[];[]]
     f: Base<'a, 'b, 'c, 'a>
 }
 


### PR DESCRIPTION
This involves numerous substeps:
1. Treat Self same as any other parameter.
2. No longer compute offsets for method parameters.
3. Store all generic types (both trait/impl and method) with a method,
   eliminating odd discrepancies.
4. Stop doing unspeakable things to static methods and instead just use
   the natural types, now that we can easily add the type parameters from
   trait into the method's polytype.
5. No doubt some more. It was hard to separate these into distinct commits.

Fixes #13564
