### PR TITLE
rustdoc: Larger click areas for sidebar items

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2001,7 +2001,7 @@ impl<'a> fmt::Show for Sidebar<'a> {
                 let class = if cur.name.get_ref() == item &&
                                short == curty { "current" } else { "" };
                 try!(write!(w, "<a class='{ty} {class}' href='{href}{path}'>\
-                                {name}</a><br/>",
+                                {name}</a>",
                        ty = short,
                        class = class,
                        href = if curty == "mod" {"../"} else {""},

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -154,23 +154,27 @@ nav.sub {
 
 .block {
     padding: 0 10px;
-    margin-bottom: 10px;
+    margin-bottom: 14px;
 }
 .block h2 {
     margin-top: 0;
+    margin-bottom: 8px;
     text-align: center;
 }
 
 .block a {
-    display: inline-block;
+    display: block;
     text-overflow: ellipsis;
     overflow: hidden;
     line-height: 15px;
-    padding-left: 5px;
-    padding-bottom: 6px;
+    padding: 7px 5px;
     font-size: 14px;
     font-weight: 300;
     transition: border 500ms ease-out;
+}
+
+.block a:hover {
+    background: #F5F5F5;
 }
 
 .content {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -647,7 +647,6 @@
                 }
                 div.append($('<a>', {'href': '../' + crates[i] + '/index.html',
                                     'class': klass}).text(crates[i]));
-                div.append($('<br>'));
             }
             sidebar.append(div);
         }


### PR DESCRIPTION
There was feedback gathered by @bjz which request for larger click targets in the rustdoc sidebar. Here's my attempt at that.

My only concern with this patch is the removal of `<br>` between sidebar links. This may break formatting for text-only viewers of this documentation. If there is a large enough demographic of people that will be affected, perhaps we can try switching the structure of each sidebar block sidebar to an `<ol>` with each item as a `<li>`. 
- Change links to display:block for click larger targets
- Remove linebreaks due to extra space
- Adjust margins so that element spacing stays the same
- Sidebar item hover background colour chosen from `<pre>` styling
