### PR TITLE
librustc: Remove useless code to handle `let _ = ...`

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -969,23 +969,9 @@ pub fn ignore_lhs(_bcx: &Block, local: &ast::Local) -> bool {
 
 pub fn init_local<'a>(bcx: &'a Block<'a>, local: &ast::Local)
                   -> &'a Block<'a> {
-
-    debug!("init_local(bcx={}, local.id={:?})",
-           bcx.to_str(), local.id);
+    debug!("init_local(bcx={}, local.id={:?})", bcx.to_str(), local.id);
     let _indenter = indenter();
-
     let _icx = push_ctxt("init_local");
-
-    if ignore_lhs(bcx, local) {
-        // Handle let _ = e; just like e;
-        match local.init {
-            Some(ref init) => {
-                return controlflow::trans_stmt_semi(bcx, &**init)
-            }
-            None => { return bcx; }
-        }
-    }
-
     _match::store_local(bcx, local)
 }
 


### PR DESCRIPTION
This code didn't do anything, but was a vestige of the old semantics for
`let _ = ...`.

Closes #10488. (As near as I can tell anyhow.)

r? @nikomatsakis 
