### PR TITLE
Show impl for RefCell

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -426,7 +426,18 @@ mod test {
 
         let refcell_ref = refcell.borrow();
         assert!(format!("{}", refcell_ref).as_slice().contains("foo"));
-        drop(refcell_ref);
+    }
+
+    #[test]
+    fn refcell_has_sensible_show() {
+        use str::StrSlice;
+        use realstd::str::Str;
+
+        let rc = RefCell::new("foo");
+        assert!(format!("{}", rc).as_slice().contains("foo"));
+
+        let _rc_mut = rc.borrow_mut();
+        assert!(format!("{}", rc).as_slice().contains("RefCell (borrowed)"));
     }
 
     #[test]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -13,7 +13,7 @@
 #![allow(unused_variable)]
 
 use any;
-use cell::{Cell, Ref, RefMut};
+use cell::{Cell, RefCell, Ref, RefMut};
 use char::Char;
 use collections::Collection;
 use iter::{Iterator, range};
@@ -758,6 +758,15 @@ impl<'b, T: Show> Show for Ref<'b, T> {
 impl<'b, T: Show> Show for RefMut<'b, T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         (*(self.deref())).fmt(f)
+    }
+}
+
+impl<T: Show> Show for RefCell<T> {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self.try_borrow() {
+            Some(_) => (*self.borrow()).fmt(f),
+            None => f.pad("RefCell (borrowed)")
+        }
     }
 }
 


### PR DESCRIPTION
Safe `Show` impl for `RefCell`.

I'm open to debate about how to handle the case where `try_borrow()` fails.  I went with displaying that the refcell is borrowed to minimize surprises
