### PR TITLE
Fix rustdoc's formatting of lifetimes

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -617,7 +617,7 @@ impl Clean<Lifetime> for ty::RegionParameterDef {
 impl Clean<Option<Lifetime>> for ty::Region {
     fn clean(&self) -> Option<Lifetime> {
         match *self {
-            ty::ReStatic => Some(Lifetime("static".to_string())),
+            ty::ReStatic => Some(Lifetime("'static".to_string())),
             ty::ReLateBound(_, ty::BrNamed(_, name)) =>
                 Some(Lifetime(token::get_name(name).get().to_string())),
             ty::ReEarlyBound(_, _, _, name) => Some(Lifetime(name.clean())),

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -91,7 +91,6 @@ impl fmt::Show for clean::Generics {
 
 impl fmt::Show for clean::Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(f.write("'".as_bytes()));
         try!(f.write(self.get_ref().as_bytes()));
         Ok(())
     }


### PR DESCRIPTION
rustdoc was previously formatting lifetimes with two apostrophes, presumably as a result of #14797.
