### PR TITLE
Reexport `num_cpus` in `std::os`. Closes #14707

### DIFF
--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -56,6 +56,16 @@ use libc::c_char;
 #[cfg(windows)]
 use str::OwnedStr;
 
+/// Get the number of cores available
+pub fn num_cpus() -> uint {
+    unsafe {
+        return rust_get_num_cpus();
+    }
+
+    extern {
+        fn rust_get_num_cpus() -> libc::uintptr_t;
+    }
+}
 
 pub static TMPBUF_SZ : uint = 1000u;
 static BUF_BYTES : uint = 2048u;
@@ -1749,6 +1759,11 @@ mod tests {
                                      .collect::<String>());
         assert!(getenv(n.as_slice()).is_none());
         n
+    }
+
+    #[test]
+    fn test_num_cpus() {
+        assert!(os::num_cpus() > 0);
     }
 
     #[test]

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -11,22 +11,10 @@
 use from_str::FromStr;
 use from_str::from_str;
 use libc::uintptr_t;
-use libc;
 use option::{Some, None, Option};
 use os;
 use str::Str;
 use sync::atomics;
-
-/// Get the number of cores available
-pub fn num_cpus() -> uint {
-    unsafe {
-        return rust_get_num_cpus();
-    }
-
-    extern {
-        fn rust_get_num_cpus() -> libc::uintptr_t;
-    }
-}
 
 /// Dynamically inquire about whether we're running under V.
 /// You should usually not use this unless your test definitely
@@ -81,7 +69,7 @@ pub fn default_sched_threads() -> uint {
             if limit_thread_creation_due_to_osx_and_valgrind() {
                 1
             } else {
-                num_cpus()
+                os::num_cpus()
             }
         }
     }


### PR DESCRIPTION
I'm not too confident about my approach regarding the handling of the docs, so here goes my train of thought:

The first commit does the reexport. But the side effect is that two `num_cpus` entries appear in the docs: `std::os::num_cpus` and `std::rt::num_cpus`, but we only need the former one.

The second commit deals with the duplicated entry. Is my first time using `rustdoc`, but I expected that a `#[doc(hidden)]` attribute on the `pub use self::util::num_cpus` would remove the duplicated entry - this didn't work and _this seems like a bug to me_ (or it could be my inexperience with `rustdoc`). The only way I found to remove the duplicated entry was to make the `util` module public (this may not be acceptable), in addition to the `#[doc(hidden)]` attribute.

The third commit makes sure that other docs are kept intact (i.e. that the `std::rt::util` module doesn't appear in the docs).

cc @brson who requested the reexport, and @alexcrichton, who has been working on rustdoc lately.
