### PR TITLE
rustc: Don't mark type parameters as exported

### DIFF
--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -303,7 +303,7 @@ impl<'a> Visitor<()> for EmbargoVisitor<'a> {
                 match ty.node {
                     ast::TyPath(_, _, id) => {
                         match self.tcx.def_map.borrow().get_copy(&id) {
-                            def::DefPrimTy(..) => {},
+                            def::DefPrimTy(..) | def::DefTyParam(..) => {},
                             def => {
                                 let did = def.def_id();
                                 if is_local(did) {

--- a/src/test/run-pass/issue-14933.rs
+++ b/src/test/run-pass/issue-14933.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(default_type_params)]
+
+pub type BigRat<T = int> = T;
+
+fn main() {}


### PR DESCRIPTION
This ends up causing the privacy pass to get all confused, and there's nothing
inherently exported about them anyway.

Closes #14933
