### PR TITLE
rustc: Start accepting `*const T`

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -160,7 +160,7 @@ block_comment_body : [block_comment | character] * ;
 line_comment : "//" non_eol * ;
 ~~~~
 
-Comments in Rust code follow the general C++ style of line and block-comment forms. 
+Comments in Rust code follow the general C++ style of line and block-comment forms.
 Nested block comments are supported.
 
 Line comments beginning with exactly _three_ slashes (`///`), and block
@@ -3468,10 +3468,11 @@ There are four varieties of pointer in Rust:
 
 * Raw pointers (`*`)
   : Raw pointers are pointers without safety or liveness guarantees.
-    Raw pointers are written `*content`,
-    for example `*int` means a raw pointer to an integer.
-    Copying or dropping a raw pointer has no effect on the lifecycle of any other value.
-    Dereferencing a raw pointer or converting it to any other pointer type is an [`unsafe` operation](#unsafe-functions).
+    Raw pointers are written as `*const T` or `*mut T`,
+    for example `*const int` means a raw pointer to an integer.
+    Copying or dropping a raw pointer has no effect on the lifecycle of any
+    other value.  Dereferencing a raw pointer or converting it to any other
+    pointer type is an [`unsafe` operation](#unsafe-functions).
     Raw pointers are generally discouraged in Rust code;
     they exist to support interoperability with foreign code,
     and writing performance-critical or low-level functions.

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -30,8 +30,7 @@ syn keyword   rustKeyword     unsafe virtual while
 syn keyword   rustKeyword     use nextgroup=rustModPath skipwhite skipempty
 " FIXME: Scoped impl's name is also fallen in this category
 syn keyword   rustKeyword     mod trait struct enum type nextgroup=rustIdentifier skipwhite skipempty
-syn keyword   rustStorage     mut ref static
-syn keyword   rustObsoleteStorage const
+syn keyword   rustStorage     mut ref static const
 
 syn keyword   rustInvalidBareKeyword crate
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1352,7 +1352,7 @@ impl<'a> Parser<'a> {
         } else if self.token == token::BINOP(token::STAR) {
             // STAR POINTER (bare pointer?)
             self.bump();
-            TyPtr(self.parse_mt())
+            TyPtr(self.parse_ptr())
         } else if self.token == token::LBRACKET {
             // VECTOR
             self.expect(&token::LBRACKET);
@@ -1427,6 +1427,19 @@ impl<'a> Parser<'a> {
 
         let mt = self.parse_mt();
         return TyRptr(opt_lifetime, mt);
+    }
+
+    pub fn parse_ptr(&mut self) -> MutTy {
+        let mutbl = if self.eat_keyword(keywords::Mut) {
+            MutMutable
+        } else if self.eat_keyword(keywords::Const) {
+            MutImmutable
+        } else {
+            // NOTE: after a stage0 snap this should turn into a span_err.
+            MutImmutable
+        };
+        let t = self.parse_ty(true);
+        MutTy { ty: t, mutbl: mutbl }
     }
 
     pub fn is_named_argument(&mut self) -> bool {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -486,11 +486,11 @@ declare_special_idents_and_keywords! {
         (40,                         Continue,   "continue");
         (41,                         Proc,       "proc");
         (42,                         Box,        "box");
+        (43,                         Const,      "const");
 
         'reserved:
-        (43,                         Alignof,    "alignof");
-        (44,                         Be,         "be");
-        (45,                         Const,      "const");
+        (44,                         Alignof,    "alignof");
+        (45,                         Be,         "be");
         (46,                         Offsetof,   "offsetof");
         (47,                         Priv,       "priv");
         (48,                         Pure,       "pure");

--- a/src/test/run-pass/new-unsafe-pointers.rs
+++ b/src/test/run-pass/new-unsafe-pointers.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _a: *const int = 3 as *const int;
+    let _a: *mut int = 3 as *mut int;
+}


### PR DESCRIPTION
This does not yet change the compiler and libraries from `*T` to `*const T` as
it will require a snapshot to do so.

cc #7362

---

Note that the corresponding RFC, https://github.com/rust-lang/rfcs/pull/68, has not yet been accepted. It was [discussed at the last meeting](https://github.com/rust-lang/rust/wiki/Meeting-weekly-2014-06-10#rfc-pr-68-unsafe-pointers-rename-t-to-const-t) and decided to be accepted, however. I figured I'd get started on the preliminary work for the RFC that will be required regardless.
