### PR TITLE
Fix --disable-rpath and tests

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -360,10 +360,10 @@ endef
 #   contains spaces which confuse make.
 # * `LD_LIBRARY_PATH_ENV_HOSTDIR`: the entry to add to lookup path for the host
 # * `LD_LIBRARY_PATH_ENV_TARGETDIR`: the entry to add to lookup path for target
-# 
+#
 # Below that, HOST_RPATH_VAR and TARGET_RPATH_VAR are defined in terms of the
 # above settings.
-# 
+#
 define SREQ_CMDS
 
 ifeq ($$(OSTYPE_$(3)),apple-darwin)
@@ -382,9 +382,9 @@ LD_LIBRARY_PATH_ENV_TARGETDIR$(1)_T_$(2)_H_$(3) := \
     $$(CURDIR)/$$(TLIB1_T_$(2)_H_$(CFG_BUILD))
 
 HOST_RPATH_VAR$(1)_T_$(2)_H_$(3) := \
-  $$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3))=$$$$$$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3)):$$(LD_LIBRARY_PATH_ENV_HOSTDIR$(1)_T_$(2)_H_$(3))
+  $$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3))=$$(LD_LIBRARY_PATH_ENV_HOSTDIR$(1)_T_$(2)_H_$(3)):$$$$$$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3))
 TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3) := \
-  $$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3))=$$$$$$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3)):$$(LD_LIBRARY_PATH_ENV_TARGETDIR$(1)_T_$(2)_H_$(3))
+  $$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3))=$$(LD_LIBRARY_PATH_ENV_TARGETDIR$(1)_T_$(2)_H_$(3)):$$$$$$(LD_LIBRARY_PATH_ENV_NAME$(1)_T_$(2)_H_$(3))
 
 RPATH_VAR$(1)_T_$(2)_H_$(3) := $$(HOST_RPATH_VAR$(1)_T_$(2)_H_$(3))
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -91,7 +91,8 @@ endif
 define DEF_TARGET_COMMANDS
 
 ifdef CFG_UNIXY_$(1)
-  CFG_RUN_TEST_$(1)=$$(call CFG_RUN_$(1),,$$(CFG_VALGRIND) $$(1))
+  CFG_RUN_TEST_$(1)=$$(TARGET_RPATH_VAR$$(2)_T_$$(3)_H_$$(4)) \
+	  $$(call CFG_RUN_$(1),,$$(CFG_VALGRIND) $$(1))
 endif
 
 ifdef CFG_WINDOWSY_$(1)
@@ -105,13 +106,13 @@ ifdef CFG_WINDOWSY_$(1)
                $$(if $$(findstring stage3,$$(1)), \
                     stage3/$$(CFG_LIBDIR_RELATIVE), \
                )))))/rustlib/$$(CFG_BUILD)/lib
-  CFG_RUN_TEST_$(1)=$$(call CFG_RUN_$(1),$$(call CFG_TESTLIB_$(1),$$(1),$$(3)),$$(1))
+  CFG_RUN_TEST_$(1)=$$(call CFG_RUN_$(1),$$(call CFG_TESTLIB_$(1),$$(1),$$(4)),$$(1))
 endif
 
 # Run the compiletest runner itself under valgrind
 ifdef CTEST_VALGRIND
 CFG_RUN_CTEST_$(1)=$$(RPATH_VAR$$(1)_T_$$(3)_H_$$(3)) \
-      $$(call CFG_RUN_TEST_$$(CFG_BUILD),$$(2),$$(3))
+      $$(call CFG_RUN_TEST_$$(CFG_BUILD),$$(3),$$(4))
 else
 CFG_RUN_CTEST_$(1)=$$(RPATH_VAR$$(1)_T_$$(3)_H_$$(3)) \
       $$(call CFG_RUN_$$(CFG_BUILD),$$(TLIB$$(1)_T_$$(3)_H_$$(3)),$$(2))
@@ -391,7 +392,7 @@ check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 		$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2))
 	@$$(call E, run: $$<)
-	$$(Q)$$(call CFG_RUN_TEST_$(2),$$<,$(2),$(3)) $$(TESTARGS) \
+	$$(Q)$$(call CFG_RUN_TEST_$(2),$$<,$(1),$(2),$(3)) $$(TESTARGS) \
 	    --logfile $$(call TEST_LOG_FILE,$(1),$(2),$(3),$(4)) \
 	    $$(call CRATE_TEST_EXTRA_ARGS,$(1),$(2),$(3),$(4)) \
 	    && touch $$@

--- a/src/test/run-make/rustdoc-hidden-line/Makefile
+++ b/src/test/run-make/rustdoc-hidden-line/Makefile
@@ -4,8 +4,8 @@
 ifndef IS_WINDOWS
 
 all:
-	$(RUSTDOC) --test foo.rs
-	$(RUSTDOC) -w html -o $(TMPDIR)/doc foo.rs
+	$(HOST_RPATH_ENV) $(RUSTDOC) --test foo.rs
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w html -o $(TMPDIR)/doc foo.rs
 	cp verify.sh $(TMPDIR)
 	$(call RUN,verify.sh) $(TMPDIR)
 

--- a/src/test/run-make/rustdoc-json/Makefile
+++ b/src/test/run-make/rustdoc-json/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 all:
-	$(RUSTDOC) -w json -o $(TMPDIR)/doc.json foo.rs
-	$(RUSTDOC) -o $(TMPDIR)/doc $(TMPDIR)/doc.json
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w json -o $(TMPDIR)/doc.json foo.rs
+	$(HOST_RPATH_ENV) $(RUSTDOC) -o $(TMPDIR)/doc $(TMPDIR)/doc.json

--- a/src/test/run-make/rustdoc-smoke/Makefile
+++ b/src/test/run-make/rustdoc-smoke/Makefile
@@ -1,5 +1,5 @@
 -include ../tools.mk
 all:
-	$(RUSTDOC) -w html -o $(TMPDIR)/doc foo.rs
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w html -o $(TMPDIR)/doc foo.rs
 	cp verify.sh $(TMPDIR)
 	$(call RUN,verify.sh) $(TMPDIR)

--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -1,15 +1,15 @@
 export LD_LIBRARY_PATH:=$(TMPDIR):$(LD_LIBRARY_PATH)
 export DYLD_LIBRARY_PATH:=$(TMPDIR):$(DYLD_LIBRARY_PATH)
 
-RUSTC := $(RUSTC) --out-dir $(TMPDIR) -L $(TMPDIR)
-CC := $(CC) -L $(TMPDIR)
-
 # These deliberately use `=` and not `:=` so that client makefiles can
 # augment HOST_RPATH_DIR / TARGET_RPATH_DIR.
 HOST_RPATH_ENV = \
-    $(LD_LIB_PATH_ENVVAR)=$$$(LD_LIB_PATH_ENVVAR):$(HOST_RPATH_DIR)
+    $(LD_LIB_PATH_ENVVAR)=$(HOST_RPATH_DIR):$$$(LD_LIB_PATH_ENVVAR)
 TARGET_RPATH_ENV = \
-    $(LD_LIB_PATH_ENVVAR)=$$$(LD_LIB_PATH_ENVVAR):$(TARGET_RPATH_DIR)
+    $(LD_LIB_PATH_ENVVAR)=$(TARGET_RPATH_DIR):$$$(LD_LIB_PATH_ENVVAR)
+
+RUSTC := $(HOST_RPATH_ENV) $(RUSTC) --out-dir $(TMPDIR) -L $(TMPDIR)
+CC := $(CC) -L $(TMPDIR)
 
 # This is the name of the binary we will generate and run; use this
 # e.g. for `$(CC) -o $(RUN_BINFILE)`.

--- a/src/test/run-pass/logging-separate-lines.rs
+++ b/src/test/run-pass/logging-separate-lines.rs
@@ -10,6 +10,7 @@
 
 // ignore-android
 // ignore-win32
+// exec-env:RUST_LOG=debug
 
 #![feature(phase)]
 
@@ -29,9 +30,8 @@ fn main() {
         return
     }
 
-    let env = [("RUST_LOG".to_string(), "debug".to_string())];
     let p = Command::new(args[0].as_slice())
-                    .arg("child").env(env.as_slice())
+                    .arg("child")
                     .spawn().unwrap().wait_with_output().unwrap();
     assert!(p.status.success());
     let mut lines = str::from_utf8(p.error.as_slice()).unwrap().lines();


### PR DESCRIPTION
This involved a few changes to the local build system:
- Makefiles now prefer our own LD_LIBRARY_PATH over the user's LD_LIBRARY_PATH
  in order to support building rust with rust already installed.
- The compiletest program was taught to correctly pass through the aux dir as a
  component of LD_LIBRARY_PATH in more situations.

This change was spliced out of #14832 to consist of just the fixes to running
tests without an rpath setting embedded in executables.
