### PR TITLE
Add non_camel_case_enum_variants lint

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -70,6 +70,7 @@
 */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 #![allow(non_snake_case_functions)]
 #![allow(non_uppercase_statics)]
 #![allow(missing_doc)]

--- a/src/librustc/lib/llvm.rs
+++ b/src/librustc/lib/llvm.rs
@@ -10,6 +10,7 @@
 
 #![allow(non_uppercase_pattern_statics)]
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 #![allow(non_snake_case_functions)]
 #![allow(dead_code)]
 

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use std::mem;
 use syntax::crateid::CrateId;

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(non_camel_case_types)]
 
 //! Validates all used crates and extern libraries and loads their metadata
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -11,6 +11,7 @@
 // Searching for information from the cstore
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use metadata::common::*;
 use metadata::cstore;

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -10,7 +10,6 @@
 
 // Decoding metadata from a single crate's metadata
 
-#![allow(non_camel_case_types)]
 
 use back::svh::Svh;
 use metadata::cstore::crate_metadata;

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -11,6 +11,7 @@
 /*! See doc.rs for a thorough explanation of the borrow checker */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use middle::dataflow::DataFlowContext;
 use middle::dataflow::DataFlowOperator;

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use middle::const_eval::{compare_const_vals, lookup_const_by_id};
 use middle::const_eval::{eval_const_expr, const_val, const_bool, const_float};

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 #![allow(unsigned_negate)]
 
 use metadata::csearch;

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -61,6 +61,7 @@
  */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use middle::def;
 use middle::ty;

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -193,6 +193,7 @@
  */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use back::abi;
 use driver::config::FullDebugInfo;

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -24,6 +24,7 @@
 //     int) and rec(x=int, y=int, z=int) will have the same TypeRef.
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use back::link::{mangle_exported_name};
 use back::{link, abi};

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -32,6 +32,7 @@
  */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use back::abi;
 use lib::llvm::{ValueRef, llvm};

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use middle::subst;
 use middle::trans::adt;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use back::svh::Svh;
 use driver::session::Session;

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -11,6 +11,7 @@
 /*! See doc.rs for documentation */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 pub use middle::ty::IntVarValue;
 pub use middle::typeck::infer::resolve::resolve_and_force_all_but_regions;

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -60,6 +60,7 @@ independently:
 */
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use driver::config;
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(non_camel_case_types)]
 
 use syntax::ast;
 use syntax::visit;

--- a/src/librustrt/libunwind.rs
+++ b/src/librustrt/libunwind.rs
@@ -11,6 +11,7 @@
 //! Unwind library interface
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 #![allow(non_snake_case_functions)]
 #![allow(dead_code)] // these are just bindings
 

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -28,6 +28,7 @@
  */
 
 #![allow(non_camel_case_types)] // C types
+#![allow(non_camel_case_enum_variants)]
 
 use libc::{size_t, c_int, c_uint, c_void, c_char, c_double};
 use libc::{ssize_t, sockaddr, free, addrinfo};

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -11,6 +11,7 @@
 //! Simple backtrace functionality (to print on failure)
 
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 use char::Char;
 use collections::Collection;

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -32,7 +32,7 @@ pub enum Abi {
     RustIntrinsic,
 }
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_enum_variants)]
 #[deriving(PartialEq)]
 pub enum Architecture {
     // NB. You cannot change the ordering of these

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -82,6 +82,7 @@ use std::rc::Rc;
 use std::gc::{Gc, GC};
 
 #[allow(non_camel_case_types)]
+#[allow(non_camel_case_enum_variants)]
 #[deriving(PartialEq)]
 pub enum restriction {
     UNRESTRICTED,

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -23,7 +23,7 @@ use std::mem;
 use std::path::BytesContainer;
 use std::rc::Rc;
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_enum_variants)]
 #[deriving(Clone, Encodable, Decodable, PartialEq, Eq, Hash, Show)]
 pub enum BinOp {
     PLUS,
@@ -38,7 +38,7 @@ pub enum BinOp {
     SHR,
 }
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_enum_variants)]
 #[deriving(Clone, Encodable, Decodable, PartialEq, Eq, Hash, Show)]
 pub enum Token {
     /* Expression-operator symbols. */

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -11,6 +11,7 @@
 #![no_std]
 #![allow(unused_variable)]
 #![allow(non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 #![allow(visible_private_types)]
 #![deny(dead_code)]
 

--- a/src/test/compile-fail/lint-non-camel-case-enum-variants.rs
+++ b/src/test/compile-fail/lint-non-camel-case-enum-variants.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,17 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(non_camel_case_types)]
-#![allow(non_camel_case_enum_variants)]
+#![forbid(non_camel_case_enum_variants)]
+#![allow(dead_code)]
 
-pub fn main() {
-    let one: || -> uint = || {
-        enum r { a };
-        a as uint
-    };
-    let two: || -> uint = || {
-        enum r { a };
-        a as uint
-    };
-    one(); two();
+enum Foo {
+    bar //~ ERROR variant `bar` should have a camel case name such as `Bar`
 }
+
+fn main() { }

--- a/src/test/compile-fail/lint-non-camel-case-types.rs
+++ b/src/test/compile-fail/lint-non-camel-case-types.rs
@@ -25,10 +25,6 @@ struct foo3 { //~ ERROR type `foo3` should have a camel case name such as `Foo3`
 
 type foo4 = int; //~ ERROR type `foo4` should have a camel case name such as `Foo4`
 
-enum Foo5 {
-    bar //~ ERROR variant `bar` should have a camel case name such as `Bar`
-}
-
 trait foo6 { //~ ERROR trait `foo6` should have a camel case name such as `Foo6`
 }
 

--- a/src/test/compile-fail/liveness-unused.rs
+++ b/src/test/compile-fail/liveness-unused.rs
@@ -11,6 +11,7 @@
 #![deny(unused_variable)]
 #![deny(dead_assignment)]
 #![allow(dead_code, non_camel_case_types)]
+#![allow(non_camel_case_enum_variants)]
 
 fn f1(x: int) {
     //~^ ERROR unused variable: `x`


### PR DESCRIPTION
non_camel_case_types lint checked enum variants, but they are not types.

Closes #14599
