### PR TITLE
Update rustc analyses to reflect asm! order-of-eval: outputs, then inputs

### DIFF
--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -606,10 +606,10 @@ impl<'a, 'b, O:DataFlowOperator> PropagationContext<'a, 'b, O> {
             }
 
             ast::ExprInlineAsm(ref inline_asm) => {
-                for &(_, ref expr) in inline_asm.inputs.iter() {
+                for &(_, ref expr) in inline_asm.outputs.iter() {
                     self.walk_expr(&**expr, in_out, loop_scopes);
                 }
-                for &(_, ref expr) in inline_asm.outputs.iter() {
+                for &(_, ref expr) in inline_asm.inputs.iter() {
                     self.walk_expr(&**expr, in_out, loop_scopes);
                 }
             }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -318,12 +318,15 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
             }
 
             ast::ExprInlineAsm(ref ia) => {
-                for &(_, ref input) in ia.inputs.iter() {
-                    self.consume_expr(&**input);
-                }
-
+                // FIXME(#14936): A read-write output should
+                // eventually be modelled as a single expression,
+                // which will then require updating this code.
                 for &(_, ref output) in ia.outputs.iter() {
                     self.mutate_expr(expr, &**output, JustWrite);
+                }
+
+                for &(_, ref input) in ia.inputs.iter() {
+                    self.consume_expr(&**input);
                 }
             }
 

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -3572,11 +3572,11 @@ fn populate_scope_map(cx: &CrateContext,
                                                 outputs: ref outputs,
                                                 .. }) => {
                 // inputs, outputs: ~[(String, Gc<expr>)]
-                for &(_, ref exp) in inputs.iter() {
+                for &(_, ref exp) in outputs.iter() {
                     walk_expr(cx, &**exp, scope_stack, scope_map);
                 }
 
-                for &(_, ref exp) in outputs.iter() {
+                for &(_, ref exp) in inputs.iter() {
                     walk_expr(cx, &**exp, scope_stack, scope_map);
                 }
             }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2859,11 +2859,11 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         instantiate_path(fcx, pth, tpt, defn, expr.span, expr.id);
       }
       ast::ExprInlineAsm(ref ia) => {
-          for &(_, ref input) in ia.inputs.iter() {
-              check_expr(fcx, &**input);
-          }
           for &(_, ref out) in ia.outputs.iter() {
               check_expr(fcx, &**out);
+          }
+          for &(_, ref input) in ia.inputs.iter() {
+              check_expr(fcx, &**input);
           }
           fcx.write_nil(id);
       }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -802,9 +802,9 @@ pub enum AsmDialect {
 pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
-    pub clobbers: InternedString,
-    pub inputs: Vec<(InternedString, Gc<Expr>)>,
     pub outputs: Vec<(InternedString, Gc<Expr>)>,
+    pub inputs: Vec<(InternedString, Gc<Expr>)>,
+    pub clobbers: InternedString,
     pub volatile: bool,
     pub alignstack: bool,
     pub dialect: AsmDialect

--- a/src/test/compile-fail/asm-disorder-of-eval.rs
+++ b/src/test/compile-fail/asm-disorder-of-eval.rs
@@ -1,0 +1,29 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(asm)]
+
+#[cfg(target_arch = "x86")]
+#[cfg(target_arch = "x86_64")]
+pub fn main() {
+    let mut x: int = 0;
+    let y: int;
+    let z: int;
+    unsafe {
+        // Output expressions are evaluated before input expressions.
+        asm!("mov $1, $0" : "=r"(*{z = y; &mut x}) : "r"({y = 3; 7}));
+        //~^ ERROR use of possibly uninitialized variable: `y`
+    }
+    assert_eq!(x, 7);
+    assert_eq!(z, 3);
+}
+
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+pub fn main() {}

--- a/src/test/run-pass/asm-order-of-eval.rs
+++ b/src/test/run-pass/asm-order-of-eval.rs
@@ -1,0 +1,28 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(asm)]
+
+#[cfg(target_arch = "x86")]
+#[cfg(target_arch = "x86_64")]
+pub fn main() {
+    let mut x: int = 0;
+    let y: int;
+    let z: int;
+    unsafe {
+        // Output expressions are evaluated before input expressions.
+        asm!("mov $1, $0" : "=r"(*{y = 3; &mut x}) : "r"({z = y; 7}));
+    }
+    assert_eq!(x, 7);
+    assert_eq!(z, 3);
+}
+
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+pub fn main() {}


### PR DESCRIPTION
Fix #14962.

Update rustc analyses to reflect asm! order-of-eval: outputs, then inputs.

Also reordered the fields in libsyntax to reflect the order that the
expressions occur in an instance of `asm!`, as an attempt to remind
others of this ordering.

Finally, added a couple notes about cases that may need to be further
revised when/if #14936 is addressed.
