### PR TITLE
tutorial.md: tiny correction for --crate-type=lib

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -3247,7 +3247,7 @@ fn main() { println!("hello {}", world::explore()); }
 Now compile and run like this (adjust to your platform if necessary):
 
 ~~~~console
-$ rustc --crate-type=lib world.rs  # compiles libworld-<HASH>-0.42.so
+$ rustc --crate-type=lib world.rs  # compiles libworld-<HASH>-0.42.rlib
 $ rustc main.rs -L .               # compiles main
 $ ./main
 "hello world"


### PR DESCRIPTION
Compiling a crate with `rustc --crate-type=lib` produces an rlib file, not a shared object. The latter is only produced for `--crate-type=dylib`.
