### PR TITLE
librustc: Check regions for overloaded calls.

### DIFF
--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -443,7 +443,10 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
 
     match expr.node {
         ast::ExprCall(ref callee, ref args) => {
-            if !has_method_map {
+            if has_method_map {
+                constrain_call(rcx, None, expr, Some(*callee),
+                               args.as_slice(), false);
+            } else {
                 constrain_callee(rcx, callee.id, expr, &**callee);
                 constrain_call(rcx,
                                Some(callee.id),

--- a/src/test/run-pass/issue-14959.rs
+++ b/src/test/run-pass/issue-14959.rs
@@ -1,0 +1,48 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(overloaded_calls)]
+
+use std::ops::Fn;
+
+trait Response {}
+trait Request {}
+trait Ingot<R, S> {
+    fn enter(&mut self, _: &mut R, _: &mut S, a: &mut Alloy) -> Status;
+}
+
+#[allow(dead_code)]
+struct HelloWorld;
+
+struct SendFile<'a>;
+struct Alloy;
+enum Status {
+    Continue
+}
+
+impl Alloy {
+    fn find<T>(&self) -> Option<T> {
+        None
+    }
+}
+
+impl<'a, 'b> Fn<(&'b mut Response,),()> for SendFile<'a> {
+    fn call(&self, (_res,): (&'b mut Response,)) {}
+}
+
+impl<Rq: Request, Rs: Response> Ingot<Rq, Rs> for HelloWorld {
+    fn enter(&mut self, _req: &mut Rq, res: &mut Rs, alloy: &mut Alloy) -> Status {
+        let send_file = alloy.find::<SendFile>().unwrap();
+        send_file(res);
+        Continue
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #14959.
