### PR TITLE
librustc: Make addresses of immutable statics insignificant unless

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1829,8 +1829,6 @@ type int8_t = i8;
 
 ### Static-only attributes
 
-- `address_insignificant` - references to this static may alias with
-  references to other statics, potentially of unrelated type.
 - `thread_local` - on a `static mut`, this signals that the value of this
   static may change depending on the current thread. The exact consequences of
   this are implementation-defined.
@@ -2141,12 +2139,21 @@ These types help drive the compiler's analysis
 ### Inline attributes
 
 The inline attribute is used to suggest to the compiler to perform an inline
-expansion and place a copy of the function in the caller rather than generating
-code to call the function where it is defined.
+expansion and place a copy of the function or static in the caller rather than
+generating code to call the function or access the static where it is defined.
 
 The compiler automatically inlines functions based on internal heuristics.
 Incorrectly inlining functions can actually making the program slower, so it
 should be used with care.
+
+Immutable statics are always considered inlineable
+unless marked with `#[inline(never)]`.
+It is undefined
+whether two different inlineable statics
+have the same memory address.
+In other words,
+the compiler is free
+to collapse duplicate inlineable statics together.
 
 `#[inline]` and `#[inline(always)]` always causes the function to be serialized
 into crate metadata to allow cross-crate inlining.

--- a/src/librustc/middle/lint.rs
+++ b/src/librustc/middle/lint.rs
@@ -1087,7 +1087,6 @@ fn check_unused_attribute(cx: &Context, attr: &ast::Attribute) {
 
         // FIXME: #14406 these are processed in trans, which happens after the
         // lint pass
-        "address_insignificant",
         "cold",
         "inline",
         "link",

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -17,7 +17,7 @@ use middle::ty;
 
 use syntax::ast;
 use syntax::ast_util::local_def;
-use syntax::attr;
+use syntax::ast_util;
 
 pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
     -> ast::DefId {
@@ -62,12 +62,13 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             // however, so we use the available_externally linkage which llvm
             // provides
             match item.node {
-                ast::ItemStatic(..) => {
+                ast::ItemStatic(_, mutbl, _) => {
                     let g = get_item_val(ccx, item.id);
                     // see the comment in get_item_val() as to why this check is
                     // performed here.
-                    if !attr::contains_name(item.attrs.as_slice(),
-                                            "address_insignificant") {
+                    if ast_util::static_has_significant_address(
+                            mutbl,
+                            item.attrs.as_slice()) {
                         SetLinkage(g, AvailableExternallyLinkage);
                     }
                 }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -11,6 +11,8 @@
 use ast::*;
 use ast;
 use ast_util;
+use attr::{InlineNever, InlineNone};
+use attr;
 use codemap;
 use codemap::Span;
 use owned_slice::OwnedSlice;
@@ -742,6 +744,17 @@ pub fn get_inner_tys(ty: P<Ty>) -> Vec<P<Ty>> {
     }
 }
 
+/// Returns true if the static with the given mutability and attributes
+/// has a significant address and false otherwise.
+pub fn static_has_significant_address(mutbl: ast::Mutability,
+                                              attrs: &[ast::Attribute])
+                                              -> bool {
+    if mutbl == ast::MutMutable {
+        return true
+    }
+    let inline = attr::find_inline_attr(attrs);
+    inline == InlineNever || inline == InlineNone
+}
 
 #[cfg(test)]
 mod test {

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -312,14 +312,6 @@ impl<'a, 'b> Context<'a, 'b> {
     /// These attributes are applied to all statics that this syntax extension
     /// will generate.
     fn static_attrs(&self) -> Vec<ast::Attribute> {
-        // Flag statics as `address_insignificant` so LLVM can merge duplicate
-        // globals as much as possible (which we're generating a whole lot of).
-        let unnamed = self.ecx
-                          .meta_word(self.fmtsp,
-                                     InternedString::new(
-                                         "address_insignificant"));
-        let unnamed = self.ecx.attribute(self.fmtsp, unnamed);
-
         // Do not warn format string as dead code
         let dead_code = self.ecx.meta_word(self.fmtsp,
                                            InternedString::new("dead_code"));
@@ -327,7 +319,7 @@ impl<'a, 'b> Context<'a, 'b> {
                                                  InternedString::new("allow"),
                                                  vec!(dead_code));
         let allow_dead_code = self.ecx.attribute(self.fmtsp, allow_dead_code);
-        return vec!(unnamed, allow_dead_code);
+        return vec!(allow_dead_code);
     }
 
     fn rtpath(&self, s: &str) -> Vec<ast::Ident> {

--- a/src/test/auxiliary/xcrate_address_insignificant.rs
+++ b/src/test/auxiliary/xcrate_address_insignificant.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 pub fn foo<T>() -> int {
-    #[address_insignificant]
     static a: int = 3;
     a
 }

--- a/src/test/auxiliary/xcrate_static_addresses.rs
+++ b/src/test/auxiliary/xcrate_static_addresses.rs
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[inline(never)]
 pub static global: int = 3;
 
+#[inline(never)]
 static global0: int = 4;
+
+#[inline(never)]
 pub static global2: &'static int = &global0;
 
 pub fn verify_same(a: &'static int) {


### PR DESCRIPTION
`#[inline(never)]` is used.

Closes #8958.

This can break some code that relied on the addresses of statics
being distinct; add `#[inline(never)]` to the affected statics.

[breaking-change]

r? @brson
