### PR TITLE
librustc: Use expr_ty_adjusted in trans_overloaded_call.

### DIFF
--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1466,7 +1466,7 @@ fn trans_overloaded_call<'a>(
     // Evaluate and tuple the arguments.
     let tuple_type = ty::mk_tup(bcx.tcx(),
                                 args.iter()
-                                    .map(|e| expr_ty(bcx, &**e))
+                                    .map(|e| ty::expr_ty_adjusted(bcx.tcx(), &**e))
                                     .collect());
     let repr = adt::represent_type(bcx.ccx(), tuple_type);
     let numbered_fields: Vec<(uint, Gc<ast::Expr>)> =

--- a/src/test/run-pass/issue-14958.rs
+++ b/src/test/run-pass/issue-14958.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(overloaded_calls)]
+
+trait Foo {}
+
+struct Bar;
+
+impl<'a> std::ops::Fn<(&'a Foo,), ()> for Bar {
+    fn call(&self, _: (&'a Foo,)) {}
+}
+
+struct Baz;
+
+impl Foo for Baz {}
+
+fn main() {
+    let bar = Bar;
+    let baz = &Baz;
+    bar(baz);
+}


### PR DESCRIPTION
Fixes #14958.

We were passing the wrong type in the cases where we had adjustments for the arguments of an overloaded call.
