### PR TITLE
librustc: Put `#[unsafe_destructor]` behind a feature gate.

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -192,6 +192,8 @@ As an example, we give a reimplementation of owned boxes by wrapping
 reimplementation is as safe as the `Box` type.
 
 ```
+#![feature(unsafe_destructor)]
+
 extern crate libc;
 use libc::{c_void, size_t, malloc, free};
 use std::mem;
@@ -242,10 +244,12 @@ impl<T: Send> Unique<T> {
 // A key ingredient for safety, we associate a destructor with
 // Unique<T>, making the struct manage the raw pointer: when the
 // struct goes out of scope, it will automatically free the raw pointer.
+//
 // NB: This is an unsafe destructor, because rustc will not normally
-// allow destructors to be associated with parametrized types, due to
+// allow destructors to be associated with parameterized types, due to
 // bad interaction with managed boxes. (With the Send restriction,
-// we don't have this problem.)
+// we don't have this problem.) Note that the `#[unsafe_destructor]`
+// feature gate is required to use unsafe destructors.
 #[unsafe_destructor]
 impl<T: Send> Drop for Unique<T> {
     fn drop(&mut self) {

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1940,12 +1940,13 @@ interpreted:
   enum representation in C is undefined, and this may be incorrect when the C
   code is compiled with certain flags.
 - `simd` - on certain tuple structs, derive the arithmetic operators, which
-  lower to the target's SIMD instructions, if any.
+  lower to the target's SIMD instructions, if any; the `simd` feature gate
+  is necessary to use this attribute.
 - `static_assert` - on statics whose type is `bool`, terminates compilation
   with an error if it is not initialized to `true`.
 - `unsafe_destructor` - allow implementations of the "drop" language item
   where the type it is implemented for does not implement the "send" language
-  item.
+  item; the `unsafe_destructor` feature gate is needed to use this attribute
 - `unsafe_no_drop_flag` - on structs, remove the flag that prevents
   destructors from being run twice. Destructors might be run multiple times on
   the same object with this attribute.

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -69,7 +69,8 @@
        html_root_url = "http://doc.rust-lang.org/")]
 
 #![no_std]
-#![feature(phase)]
+#![feature(phase, unsafe_destructor)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 #[phase(plugin, link)]
 extern crate core;

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -27,7 +27,10 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/")]
+
+#![feature(unsafe_destructor)]
 #![allow(missing_doc)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 use std::cell::{Cell, RefCell};
 use std::cmp;

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -22,7 +22,9 @@
        html_playground_url = "http://play.rust-lang.org/")]
 
 #![feature(macro_rules, managed_boxes, default_type_params, phase, globs)]
+#![feature(unsafe_destructor)]
 #![no_std]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 #[phase(plugin, link)] extern crate core;
 extern crate alloc;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -55,8 +55,9 @@
        html_playground_url = "http://play.rust-lang.org/")]
 
 #![no_std]
-#![feature(globs, macro_rules, managed_boxes, phase, simd)]
+#![feature(globs, macro_rules, managed_boxes, phase, simd, unsafe_destructor)]
 #![deny(missing_doc)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 #[cfg(test)] extern crate realcore = "core";
 #[cfg(test)] extern crate libc;

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -52,15 +52,17 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/")]
+
 #![deny(unused_result, unused_must_use)]
 #![allow(non_camel_case_types)]
 #![allow(deprecated)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 #![feature(default_type_params)]
 
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the
 //    answer is that you don't need them)
-#![feature(macro_rules)]
+#![feature(macro_rules, unsafe_destructor)]
 
 extern crate alloc;
 extern crate libc;

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -50,6 +50,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("log_syntax", Active),
     ("trace_macros", Active),
     ("concat_idents", Active),
+    ("unsafe_destructor", Active),
 
     ("simd", Active),
     ("default_type_params", Active),
@@ -217,6 +218,17 @@ impl<'a> Visitor<()> for Context<'a> {
                     self.gate_feature("struct_inherit", i.span,
                                       "struct inheritance (`virtual` keyword) is \
                                        experimental and possibly buggy");
+                }
+            }
+
+            ast::ItemImpl(..) => {
+                if attr::contains_name(i.attrs.as_slice(),
+                                       "unsafe_destructor") {
+                    self.gate_feature("unsafe_destructor",
+                                      i.span,
+                                      "`#[unsafe_destructor]` allows too \
+                                       many unsafe patterns and may be \
+                                       removed in the future");
                 }
             }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,8 +29,9 @@ This API is completely unstable and subject to change.
       html_root_url = "http://doc.rust-lang.org/")]
 
 #![allow(deprecated)]
-#![feature(macro_rules, globs, struct_variant, managed_boxes, quote,
-           default_type_params, phase)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
+#![feature(macro_rules, globs, struct_variant, managed_boxes, quote)]
+#![feature(default_type_params, phase, unsafe_destructor)]
 
 extern crate arena;
 extern crate debug;

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -15,10 +15,12 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/")]
-#![feature(macro_rules, phase, globs, thread_local, managed_boxes, asm,
-           linkage)]
+
+#![feature(macro_rules, phase, globs, thread_local, managed_boxes, asm)]
+#![feature(linkage, unsafe_destructor)]
 #![no_std]
 #![experimental]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 #[phase(plugin, link)] extern crate core;
 extern crate alloc;

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -40,7 +40,7 @@ via `close` and `delete` methods.
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 
-#![feature(macro_rules)]
+#![feature(macro_rules, unsafe_destructor)]
 #![deny(unused_result, unused_must_use)]
 #![allow(visible_private_types)]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -103,14 +103,16 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![feature(macro_rules, globs, managed_boxes,
-           linkage, default_type_params, phase)]
+
+#![feature(macro_rules, globs, managed_boxes)]
+#![feature(linkage, default_type_params, phase, unsafe_destructor)]
 
 // Don't link to std. We are std.
 #![no_std]
 
 #![allow(deprecated)]
 #![deny(missing_doc)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 // When testing libstd, bring in libuv as the I/O backend so tests can print
 // things and all of the std::io tests have an I/O interface to run on top

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -26,10 +26,11 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![feature(phase, globs, macro_rules)]
 
+#![feature(phase, globs, macro_rules, unsafe_destructor)]
 #![deny(missing_doc)]
 #![no_std]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 #[phase(plugin, link)] extern crate core;
 extern crate alloc;

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -27,9 +27,10 @@ This API is completely unstable and subject to change.
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/")]
 
-#![feature(macro_rules, globs, managed_boxes, default_type_params, phase,
-           quote)]
+#![feature(macro_rules, globs, managed_boxes, default_type_params, phase)]
+#![feature(quote, unsafe_destructor)]
 #![allow(deprecated)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 extern crate serialize;
 extern crate term;

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -11,6 +11,8 @@
 #![crate_id="issue_2526#0.2"]
 #![crate_type = "lib"]
 
+#![feature(unsafe_destructor)]
+
 struct arc_destruct<T> {
   _data: int,
 }

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 extern crate collections;
 extern crate time;

--- a/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_destructor)]
+
 extern crate debug;
 
 struct defer<'a> {

--- a/src/test/compile-fail/no-send-res-ports.rs
+++ b/src/test/compile-fail/no-send-res-ports.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 extern crate debug;
 

--- a/src/test/compile-fail/pinned-deep-copy.rs
+++ b/src/test/compile-fail/pinned-deep-copy.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 extern crate debug;
 

--- a/src/test/compile-fail/unique-vec-res.rs
+++ b/src/test/compile-fail/unique-vec-res.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 extern crate debug;
 use std::cell::Cell;

--- a/src/test/run-fail/unwind-resource-fail3.rs
+++ b/src/test/run-fail/unwind-resource-fail3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 // error-pattern:quux
 

--- a/src/test/run-pass/attr-no-drop-flag-size.rs
+++ b/src/test/run-pass/attr-no-drop-flag-size.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_destructor)]
+
 use std::mem::size_of;
 
 #[unsafe_no_drop_flag]

--- a/src/test/run-pass/drop-trait-generic.rs
+++ b/src/test/run-pass/drop-trait-generic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_destructor)]
+
 struct S<T> {
     x: T
 }

--- a/src/test/run-pass/init-res-into-things.rs
+++ b/src/test/run-pass/init-res-into-things.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{Gc, GC};

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -9,6 +9,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_destructor)]
+
 pub type Task = int;
 
 // tjc: I don't know why

--- a/src/test/run-pass/issue-2735-2.rs
+++ b/src/test/run-pass/issue-2735-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{Gc, GC};

--- a/src/test/run-pass/issue-2735-3.rs
+++ b/src/test/run-pass/issue-2735-3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{Gc, GC};

--- a/src/test/run-pass/issue-4252.rs
+++ b/src/test/run-pass/issue-4252.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_destructor)]
+
 extern crate debug;
 
 trait X {

--- a/src/test/run-pass/issue-979.rs
+++ b/src/test/run-pass/issue-979.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{GC, Gc};

--- a/src/test/run-pass/newtype-struct-drop-run.rs
+++ b/src/test/run-pass/newtype-struct-drop-run.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 // Make sure the destructor is run for newtype structs.
 

--- a/src/test/run-pass/option-unwrap.rs
+++ b/src/test/run-pass/option-unwrap.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{GC, Gc};

--- a/src/test/run-pass/resource-assign-is-not-copy.rs
+++ b/src/test/run-pass/resource-assign-is-not-copy.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 extern crate debug;
 

--- a/src/test/run-pass/resource-destruct.rs
+++ b/src/test/run-pass/resource-destruct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{GC, Gc};

--- a/src/test/run-pass/resource-in-struct.rs
+++ b/src/test/run-pass/resource-in-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 // Ensures that class dtors run if the object is inside an enum
 // variant

--- a/src/test/run-pass/unwind-resource2.rs
+++ b/src/test/run-pass/unwind-resource2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::task;
 use std::gc::{Gc, GC};

--- a/src/test/run-pass/vec-slice-drop.rs
+++ b/src/test/run-pass/vec-slice-drop.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(managed_boxes)]
+#![feature(managed_boxes, unsafe_destructor)]
 
 use std::cell::Cell;
 use std::gc::{Gc, GC};


### PR DESCRIPTION
Closes #8142.

This is not the semantics we want long-term. You can continue to use
`#[unsafe_destructor]`, but you'll need to add
`#![feature(unsafe_destructor)]` to the crate attributes.

[breaking-change]

r? @alexcrichton
