### PR TITLE
std::task - Revamp TaskBuilder API

### DIFF
--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -32,10 +32,13 @@
 //! ```rust
 //! extern crate native;
 //!
+//! use std::task::TaskBuilder;
+//! use native::NativeTaskBuilder;
+//!
 //! fn main() {
 //!     // We're not sure whether this main function is run in 1:1 or M:N mode.
 //!
-//!     native::task::spawn(proc() {
+//!     TaskBuilder::new().native().spawn(proc() {
 //!         // this code is guaranteed to be run on a native thread
 //!     });
 //! }
@@ -50,7 +53,8 @@
        html_root_url = "http://doc.rust-lang.org/")]
 #![deny(unused_result, unused_must_use)]
 #![allow(non_camel_case_types)]
-#![feature(macro_rules)]
+#![allow(deprecated)]
+#![feature(default_type_params)]
 
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the
@@ -64,6 +68,8 @@ extern crate libc;
 use std::os;
 use std::rt;
 use std::str;
+
+pub use task::NativeTaskBuilder;
 
 pub mod io;
 pub mod task;

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -8,71 +8,110 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*!
- * Utilities for managing and scheduling tasks
- *
- * An executing Rust program consists of a collection of tasks, each with their
- * own stack, and sole ownership of their allocated heap data. Tasks communicate
- * with each other using channels (see `std::comm` for more info about how
- * communication works).
- *
- * Failure in one task does not propagate to any others (not to parent, not to
- * child).  Failure propagation is instead handled by using the channel send()
- * and recv() methods which will fail if the other end has hung up already.
- *
- * Task Scheduling:
- *
- * By default, every task is created with the same "flavor" as the calling task.
- * This flavor refers to the scheduling mode, with two possibilities currently
- * being 1:1 and M:N modes. Green (M:N) tasks are cooperatively scheduled and
- * native (1:1) tasks are scheduled by the OS kernel.
- *
- * # Example
- *
- * ```rust
- * spawn(proc() {
- *     println!("Hello, World!");
- * })
- * ```
- */
+//! Utilities for managing and scheduling tasks
+//!
+//! An executing Rust program consists of a collection of lightweight tasks,
+//! each with their own stack. Tasks communicate with each other using channels
+//! (see `std::comm`) or other forms of synchronization (see `std::sync`) that
+//! ensure data-race freedom.
+//!
+//! Failure in one task does immediately propagate to any others (not to parent,
+//! not to child). Failure propagation is instead handled as part of task
+//! synchronization. For example, the channel `send()` and `recv()` methods will
+//! fail if the other end has hung up already.
+//!
+//! # Basic task scheduling
+//!
+//! By default, every task is created with the same "flavor" as the calling task.
+//! This flavor refers to the scheduling mode, with two possibilities currently
+//! being 1:1 and M:N modes. Green (M:N) tasks are cooperatively scheduled and
+//! native (1:1) tasks are scheduled by the OS kernel.
+//!
+//! ## Example
+//!
+//! ```rust
+//! spawn(proc() {
+//!     println!("Hello, World!");
+//! })
+//! ```
+//!
+//! # Advanced task scheduling
+//!
+//! Task spawning can also be configured to use a particular scheduler, to
+//! redirect the new task's output, or to yield a `future` representing the
+//! task's final result. The configuration is established using the
+//! `TaskBuilder` API:
+//!
+//! ## Example
+//!
+//! ```rust
+//! extern crate green;
+//! extern crate native;
+//!
+//! use std::task::TaskBuilder;
+//! use green::{SchedPool, PoolConfig, GreenTaskBuilder};
+//! use native::NativeTaskBuilder;
+//!
+//! # fn main() {
+//! // Create a green scheduler pool with the default configuration
+//! let mut pool = SchedPool::new(PoolConfig::new());
+//!
+//! // Spawn a task in the green pool
+//! let mut fut_green = TaskBuilder::new().green(&mut pool).try_future(proc() {
+//!     /* ... */
+//! });
+//!
+//! // Spawn a native task
+//! let mut fut_native = TaskBuilder::new().native().try_future(proc() {
+//!     /* ... */
+//! });
+//!
+//! // Wait for both tasks to finish, recording their outcome
+//! let res_green  = fut_green.unwrap();
+//! let res_native = fut_native.unwrap();
+//!
+//! // Shut down the green scheduler pool
+//! pool.shutdown();
+//! # }
+//! ```
 
 use any::Any;
-use comm::{Sender, Receiver, channel};
+use comm::channel;
 use io::{Writer, stdio};
 use kinds::{Send, marker};
 use option::{None, Some, Option};
 use owned::Box;
-use result::{Result, Ok, Err};
+use result::Result;
 use rt::local::Local;
 use rt::task;
 use rt::task::Task;
 use str::{Str, SendStr, IntoMaybeOwned};
+use sync::Future;
 
-#[cfg(test)] use any::AnyRefExt;
-#[cfg(test)] use owned::AnyOwnExt;
-#[cfg(test)] use result;
-#[cfg(test)] use str::StrAllocating;
-#[cfg(test)] use string::String;
-
-/// Task configuration options
-pub struct TaskOpts {
-    /// Enable lifecycle notifications on the given channel
-    pub notify_chan: Option<Sender<task::Result>>,
-    /// A name for the task-to-be, for identification in failure messages
-    pub name: Option<SendStr>,
-    /// The size of the stack for the spawned task
-    pub stack_size: Option<uint>,
-    /// Task-local stdout
-    pub stdout: Option<Box<Writer + Send>>,
-    /// Task-local stderr
-    pub stderr: Option<Box<Writer + Send>>,
+/// A means of spawning a task
+pub trait Spawner {
+    /// Spawn a task, given low-level task options.
+    fn spawn(self, opts: task::TaskOpts, f: proc():Send);
 }
 
-/**
- * The task builder type.
- *
- * Provides detailed control over the properties and behavior of new tasks.
- */
+/// The default task spawner, which spawns siblings to the current task.
+pub struct SiblingSpawner;
+
+impl Spawner for SiblingSpawner {
+    fn spawn(self, opts: task::TaskOpts, f: proc():Send) {
+        // bind tb to provide type annotation
+        let tb: Option<Box<Task>> = Local::try_take();
+        match tb {
+            Some(t) => t.spawn_sibling(opts, f),
+            None => fail!("need a local task to spawn a sibling task"),
+        };
+    }
+}
+
+/// The task builder type.
+///
+/// Provides detailed control over the properties and behavior of new tasks.
+
 // NB: Builders are designed to be single-use because they do stateful
 // things that get weird when reusing - e.g. if you create a result future
 // it only applies to a single task, so then you have to maintain Some
@@ -80,75 +119,102 @@ pub struct TaskOpts {
 // when you try to reuse the builder to spawn a new task. We'll just
 // sidestep that whole issue by making builders uncopyable and making
 // the run function move them in.
-pub struct TaskBuilder {
-    /// Options to spawn the new task with
-    pub opts: TaskOpts,
-    gen_body: Option<proc(v: proc(): Send): Send -> proc(): Send>,
+pub struct TaskBuilder<S = SiblingSpawner> {
+    // A name for the task-to-be, for identification in failure messages
+    name: Option<SendStr>,
+    // The size of the stack for the spawned task
+    stack_size: Option<uint>,
+    // Task-local stdout
+    stdout: Option<Box<Writer + Send>>,
+    // Task-local stderr
+    stderr: Option<Box<Writer + Send>>,
+    // The mechanics of actually spawning the task (i.e.: green or native)
+    spawner: S,
+    // Optionally wrap the eventual task body
+    gen_body: Option<proc(v: proc():Send):Send -> proc():Send>,
     nocopy: marker::NoCopy,
 }
 
-impl TaskBuilder {
-     /// Generate the base configuration for spawning a task, off of which more
-     /// configuration methods can be chained.
-    pub fn new() -> TaskBuilder {
+impl TaskBuilder<SiblingSpawner> {
+    /// Generate the base configuration for spawning a task, off of which more
+    /// configuration methods can be chained.
+    pub fn new() -> TaskBuilder<SiblingSpawner> {
         TaskBuilder {
-            opts: TaskOpts::new(),
+            name: None,
+            stack_size: None,
+            stdout: None,
+            stderr: None,
+            spawner: SiblingSpawner,
             gen_body: None,
             nocopy: marker::NoCopy,
         }
     }
+}
 
-    /// Get a future representing the exit status of the task.
-    ///
-    /// Taking the value of the future will block until the child task
-    /// terminates. The future result return value will be created *before* the task is
-    /// spawned; as such, do not invoke .get() on it directly;
-    /// rather, store it in an outer variable/list for later use.
-    ///
-    /// # Failure
-    /// Fails if a future_result was already set for this task.
-    pub fn future_result(&mut self) -> Receiver<task::Result> {
-        // FIXME (#3725): Once linked failure and notification are
-        // handled in the library, I can imagine implementing this by just
-        // registering an arbitrary number of task::on_exit handlers and
-        // sending out messages.
-
-        if self.opts.notify_chan.is_some() {
-            fail!("Can't set multiple future_results for one task!");
-        }
-
-        // Construct the future and give it to the caller.
-        let (tx, rx) = channel();
-
-        // Reconfigure self to use a notify channel.
-        self.opts.notify_chan = Some(tx);
-
-        rx
-    }
-
+impl<S: Spawner> TaskBuilder<S> {
     /// Name the task-to-be. Currently the name is used for identification
     /// only in failure messages.
-    pub fn named<S: IntoMaybeOwned<'static>>(mut self, name: S) -> TaskBuilder {
-        self.opts.name = Some(name.into_maybe_owned());
+    pub fn named<T: IntoMaybeOwned<'static>>(mut self, name: T) -> TaskBuilder<S> {
+        self.name = Some(name.into_maybe_owned());
         self
     }
 
-    /**
-     * Add a wrapper to the body of the spawned task.
-     *
-     * Before the task is spawned it is passed through a 'body generator'
-     * function that may perform local setup operations as well as wrap
-     * the task body in remote setup operations. With this the behavior
-     * of tasks can be extended in simple ways.
-     *
-     * This function augments the current body generator with a new body
-     * generator by applying the task body which results from the
-     * existing body generator to the new body generator.
-     */
-    pub fn with_wrapper(mut self,
-                        wrapper: proc(v: proc(): Send): Send -> proc(): Send)
-        -> TaskBuilder
-    {
+    /// Set the size of the stack for the new task.
+    pub fn stack_size(mut self, size: uint) -> TaskBuilder<S> {
+        self.stack_size = Some(size);
+        self
+    }
+
+    /// Redirect task-local stdout.
+    pub fn stdout(mut self, stdout: Box<Writer + Send>) -> TaskBuilder<S> {
+        self.stdout = Some(stdout);
+        self
+    }
+
+    /// Redirect task-local stderr.
+    pub fn stderr(mut self, stderr: Box<Writer + Send>) -> TaskBuilder<S> {
+        self.stderr = Some(stderr);
+        self
+    }
+
+    /// Set the spawning mechanism for the task.
+    ///
+    /// The `TaskBuilder` API configures a task to be spawned, but defers to the
+    /// "spawner" to actually create and spawn the task. The `spawner` method
+    /// should not be called directly by `TaskBuiler` clients. It is intended
+    /// for use by downstream crates (like `native` and `green`) that implement
+    /// tasks. These downstream crates then add extension methods to the
+    /// builder, like `.native()` and `.green(pool)`, that actually set the
+    /// spawner.
+    pub fn spawner<T: Spawner>(self, spawner: T) -> TaskBuilder<T> {
+        // repackage the entire TaskBuilder since its type is changing.
+        let TaskBuilder {
+            name, stack_size, stdout, stderr, spawner: _, gen_body, nocopy
+        } = self;
+        TaskBuilder {
+            name: name,
+            stack_size: stack_size,
+            stdout: stdout,
+            stderr: stderr,
+            spawner: spawner,
+            gen_body: gen_body,
+            nocopy: nocopy,
+        }
+    }
+
+    /// Add a wrapper to the body of the spawned task.
+    ///
+    /// Before the task is spawned it is passed through a 'body generator'
+    /// function that may perform local setup operations as well as wrap
+    /// the task body in remote setup operations. With this the behavior
+    /// of tasks can be extended in simple ways.
+    ///
+    /// This function augments the current body generator with a new body
+    /// generator by applying the task body which results from the
+    /// existing body generator to the new body generator.
+    #[deprecated = "this function will be removed soon"]
+    pub fn with_wrapper(mut self, wrapper: proc(v: proc():Send):Send -> proc():Send)
+                        -> TaskBuilder<S> {
         self.gen_body = match self.gen_body.take() {
             Some(prev) => Some(proc(body) { wrapper(prev(body)) }),
             None => Some(wrapper)
@@ -156,90 +222,80 @@ impl TaskBuilder {
         self
     }
 
-    /**
-     * Creates and executes a new child task
-     *
-     * Sets up a new task with its own call stack and schedules it to run
-     * the provided unique closure. The task has the properties and behavior
-     * specified by the task_builder.
-     */
-    pub fn spawn(mut self, f: proc(): Send) {
-        let gen_body = self.gen_body.take();
-        let f = match gen_body {
+    // Where spawning actually happens (whether yielding a future or not)
+    fn spawn_internal(self, f: proc():Send,
+                      on_exit: Option<proc(Result<(), Box<Any + Send>>):Send>) {
+        let TaskBuilder {
+            name, stack_size, stdout, stderr, spawner, mut gen_body, nocopy: _
+        } = self;
+        let f = match gen_body.take() {
             Some(gen) => gen(f),
             None => f
         };
-        let t: Box<Task> = match Local::try_take() {
-            Some(t) => t,
-            None => fail!("need a local task to spawn a new task"),
-        };
-        let TaskOpts { notify_chan, name, stack_size, stdout, stderr } = self.opts;
-
         let opts = task::TaskOpts {
-            on_exit: notify_chan.map(|c| proc(r) c.send(r)),
+            on_exit: on_exit,
             name: name,
             stack_size: stack_size,
         };
         if stdout.is_some() || stderr.is_some() {
-            t.spawn_sibling(opts, proc() {
+            spawner.spawn(opts, proc() {
                 let _ = stdout.map(stdio::set_stdout);
                 let _ = stderr.map(stdio::set_stderr);
                 f();
-            });
+            })
         } else {
-            t.spawn_sibling(opts, f);
+            spawner.spawn(opts, f)
         }
     }
 
-    /**
-     * Execute a function in another task and return either the return value
-     * of the function or result::err.
-     *
-     * # Return value
-     *
-     * If the function executed successfully then try returns result::ok
-     * containing the value returned by the function. If the function fails
-     * then try returns result::err containing nil.
-     *
-     * # Failure
-     * Fails if a future_result was already set for this task.
-     */
-    pub fn try<T: Send>(mut self, f: proc(): Send -> T)
-               -> Result<T, Box<Any + Send>> {
-        let (tx, rx) = channel();
+    /// Creates and executes a new child task.
+    ///
+    /// Sets up a new task with its own call stack and schedules it to run
+    /// the provided proc. The task has the properties and behavior
+    /// specified by the `TaskBuilder`.
+    pub fn spawn(self, f: proc():Send) {
+        self.spawn_internal(f, None)
+    }
 
-        let result = self.future_result();
+    /// Execute a proc in a newly-spawned task and return a future representing
+    /// the task's result. The task has the properties and behavior
+    /// specified by the `TaskBuilder`.
+    ///
+    /// Taking the value of the future will block until the child task
+    /// terminates.
+    ///
+    /// # Return value
+    ///
+    /// If the child task executes successfully (without failing) then the
+    /// future returns `result::Ok` containing the value returned by the
+    /// function. If the child task fails then the future returns `result::Err`
+    /// containing the argument to `fail!(...)` as an `Any` trait object.
+    pub fn try_future<T:Send>(self, f: proc():Send -> T)
+                              -> Future<Result<T, Box<Any + Send>>> {
+        // currently, the on_exit proc provided by librustrt only works for unit
+        // results, so we use an additional side-channel to communicate the
+        // result.
 
-        self.spawn(proc() {
-            tx.send(f());
-        });
+        let (tx_done, rx_done) = channel(); // signal that task has exited
+        let (tx_retv, rx_retv) = channel(); // return value from task
 
-        match result.recv() {
-            Ok(())     => Ok(rx.recv()),
-            Err(cause) => Err(cause)
-        }
+        let on_exit = proc(res) { tx_done.send(res) };
+        self.spawn_internal(proc() { tx_retv.send(f()) },
+                            Some(on_exit));
+
+        Future::from_fn(proc() {
+            rx_done.recv().map(|_| rx_retv.recv())
+        })
+    }
+
+    /// Execute a function in a newly-spawnedtask and block until the task
+    /// completes or fails. Equivalent to `.try_future(f).unwrap()`.
+    pub fn try<T:Send>(self, f: proc():Send -> T) -> Result<T, Box<Any + Send>> {
+        self.try_future(f).unwrap()
     }
 }
 
-/* Task construction */
-
-impl TaskOpts {
-    pub fn new() -> TaskOpts {
-        /*!
-         * The default task options
-         */
-
-        TaskOpts {
-            notify_chan: None,
-            name: None,
-            stack_size: None,
-            stdout: None,
-            stderr: None,
-        }
-    }
-}
-
-/* Spawn convenience functions */
+/* Convenience functions */
 
 /// Creates and executes a new child task
 ///
@@ -251,12 +307,20 @@ pub fn spawn(f: proc(): Send) {
     TaskBuilder::new().spawn(f)
 }
 
-/// Execute a function in another task and return either the return value of
-/// the function or an error if the task failed
+/// Execute a function in a newly-spawned task and return either the return
+/// value of the function or an error if the task failed.
 ///
-/// This is equivalent to TaskBuilder::new().try
+/// This is equivalent to `TaskBuilder::new().try`.
 pub fn try<T: Send>(f: proc(): Send -> T) -> Result<T, Box<Any + Send>> {
     TaskBuilder::new().try(f)
+}
+
+/// Execute a function in another task and return a future representing the
+/// task's result.
+///
+/// This is equivalent to `TaskBuilder::new().try_future`.
+pub fn try_future<T:Send>(f: proc():Send -> T) -> Future<Result<T, Box<Any + Send>>> {
+    TaskBuilder::new().try_future(f)
 }
 
 
@@ -273,9 +337,8 @@ pub fn with_task_name<U>(blk: |Option<&str>| -> U) -> U {
     }
 }
 
+/// Yield control to the task scheduler.
 pub fn deschedule() {
-    //! Yield control to the task scheduler
-
     use rt::local::Local;
 
     // FIXME(#7544): Optimize this, since we know we won't block.
@@ -283,266 +346,282 @@ pub fn deschedule() {
     task.yield_now();
 }
 
+/// True if the running task is currently failing (e.g. will return `true` inside a
+/// destructor that is run while unwinding the stack after a call to `fail!()`).
 pub fn failing() -> bool {
-    //! True if the running task has failed
     use rt::task::Task;
     Local::borrow(None::<Task>).unwinder.unwinding()
 }
 
-// The following 8 tests test the following 2^3 combinations:
-// {un,}linked {un,}supervised failure propagation {up,down}wards.
-
-// !!! These tests are dangerous. If Something is buggy, they will hang, !!!
-// !!! instead of exiting cleanly. This might wedge the buildbots.       !!!
-
-#[test]
-fn test_unnamed_task() {
-    spawn(proc() {
-        with_task_name(|name| {
-            assert!(name.is_none());
-        })
-    })
-}
-
-#[test]
-fn test_owned_named_task() {
-    TaskBuilder::new().named("ada lovelace".to_string()).spawn(proc() {
-        with_task_name(|name| {
-            assert!(name.unwrap() == "ada lovelace");
-        })
-    })
-}
-
-#[test]
-fn test_static_named_task() {
-    TaskBuilder::new().named("ada lovelace").spawn(proc() {
-        with_task_name(|name| {
-            assert!(name.unwrap() == "ada lovelace");
-        })
-    })
-}
-
-#[test]
-fn test_send_named_task() {
-    TaskBuilder::new().named("ada lovelace".into_maybe_owned()).spawn(proc() {
-        with_task_name(|name| {
-            assert!(name.unwrap() == "ada lovelace");
-        })
-    })
-}
-
-#[test]
-fn test_run_basic() {
-    let (tx, rx) = channel();
-    TaskBuilder::new().spawn(proc() {
-        tx.send(());
-    });
-    rx.recv();
-}
-
-#[test]
-fn test_with_wrapper() {
-    let (tx, rx) = channel();
-    TaskBuilder::new().with_wrapper(proc(body) {
-        let result: proc(): Send = proc() {
-            body();
-            tx.send(());
-        };
-        result
-    }).spawn(proc() { });
-    rx.recv();
-}
-
-#[test]
-fn test_future_result() {
-    let mut builder = TaskBuilder::new();
-    let result = builder.future_result();
-    builder.spawn(proc() {});
-    assert!(result.recv().is_ok());
-
-    let mut builder = TaskBuilder::new();
-    let result = builder.future_result();
-    builder.spawn(proc() {
-        fail!();
-    });
-    assert!(result.recv().is_err());
-}
-
-#[test] #[should_fail]
-fn test_back_to_the_future_result() {
-    let mut builder = TaskBuilder::new();
-    builder.future_result();
-    builder.future_result();
-}
-
-#[test]
-fn test_try_success() {
-    match try(proc() {
-        "Success!".to_string()
-    }).as_ref().map(|s| s.as_slice()) {
-        result::Ok("Success!") => (),
-        _ => fail!()
-    }
-}
-
-#[test]
-fn test_try_fail() {
-    match try(proc() {
-        fail!()
-    }) {
-        result::Err(_) => (),
-        result::Ok(()) => fail!()
-    }
-}
-
-#[test]
-fn test_spawn_sched() {
-    use clone::Clone;
-
-    let (tx, rx) = channel();
-
-    fn f(i: int, tx: Sender<()>) {
-        let tx = tx.clone();
-        spawn(proc() {
-            if i == 0 {
-                tx.send(());
-            } else {
-                f(i - 1, tx);
-            }
-        });
-
-    }
-    f(10, tx);
-    rx.recv();
-}
-
-#[test]
-fn test_spawn_sched_childs_on_default_sched() {
-    let (tx, rx) = channel();
-
-    spawn(proc() {
-        spawn(proc() {
-            tx.send(());
-        });
-    });
-
-    rx.recv();
-}
-
 #[cfg(test)]
-fn avoid_copying_the_body(spawnfn: |v: proc(): Send|) {
-    let (tx, rx) = channel::<uint>();
+mod test {
+    use any::{Any, AnyRefExt};
+    use owned::AnyOwnExt;
+    use result;
+    use result::{Ok, Err};
+    use str::StrAllocating;
+    use string::String;
+    use std::io::{ChanReader, ChanWriter};
+    use prelude::*;
+    use super::*;
 
-    let x = box 1;
-    let x_in_parent = (&*x) as *int as uint;
+    // !!! These tests are dangerous. If something is buggy, they will hang, !!!
+    // !!! instead of exiting cleanly. This might wedge the buildbots.       !!!
 
-    spawnfn(proc() {
-        let x_in_child = (&*x) as *int as uint;
-        tx.send(x_in_child);
-    });
+    #[test]
+    fn test_unnamed_task() {
+        spawn(proc() {
+            with_task_name(|name| {
+                assert!(name.is_none());
+            })
+        })
+    }
 
-    let x_in_child = rx.recv();
-    assert_eq!(x_in_parent, x_in_child);
-}
+    #[test]
+    fn test_owned_named_task() {
+        TaskBuilder::new().named("ada lovelace".to_string()).spawn(proc() {
+            with_task_name(|name| {
+                assert!(name.unwrap() == "ada lovelace");
+            })
+        })
+    }
 
-#[test]
-fn test_avoid_copying_the_body_spawn() {
-    avoid_copying_the_body(spawn);
-}
+    #[test]
+    fn test_static_named_task() {
+        TaskBuilder::new().named("ada lovelace").spawn(proc() {
+            with_task_name(|name| {
+                assert!(name.unwrap() == "ada lovelace");
+            })
+        })
+    }
 
-#[test]
-fn test_avoid_copying_the_body_task_spawn() {
-    avoid_copying_the_body(|f| {
-        let builder = TaskBuilder::new();
-        builder.spawn(proc() {
-            f();
+    #[test]
+    fn test_send_named_task() {
+        TaskBuilder::new().named("ada lovelace".into_maybe_owned()).spawn(proc() {
+            with_task_name(|name| {
+                assert!(name.unwrap() == "ada lovelace");
+            })
+        })
+    }
+
+    #[test]
+    fn test_run_basic() {
+        let (tx, rx) = channel();
+        TaskBuilder::new().spawn(proc() {
+            tx.send(());
         });
-    })
-}
+        rx.recv();
+    }
 
-#[test]
-fn test_avoid_copying_the_body_try() {
-    avoid_copying_the_body(|f| {
-        let _ = try(proc() {
-            f()
+    #[test]
+    fn test_with_wrapper() {
+        let (tx, rx) = channel();
+        TaskBuilder::new().with_wrapper(proc(body) {
+            let result: proc():Send = proc() {
+                body();
+                tx.send(());
+            };
+            result
+        }).spawn(proc() { });
+        rx.recv();
+    }
+
+    #[test]
+    fn test_try_future() {
+        let result = TaskBuilder::new().try_future(proc() {});
+        assert!(result.unwrap().is_ok());
+
+        let result = TaskBuilder::new().try_future(proc() -> () {
+            fail!();
         });
-    })
-}
+        assert!(result.unwrap().is_err());
+    }
 
-#[test]
-fn test_child_doesnt_ref_parent() {
-    // If the child refcounts the parent task, this will stack overflow when
-    // climbing the task tree to dereference each ancestor. (See #1789)
-    // (well, it would if the constant were 8000+ - I lowered it to be more
-    // valgrind-friendly. try this at home, instead..!)
-    static generations: uint = 16;
-    fn child_no(x: uint) -> proc(): Send {
-        return proc() {
-            if x < generations {
-                TaskBuilder::new().spawn(child_no(x+1));
+    #[test]
+    fn test_try_success() {
+        match try(proc() {
+            "Success!".to_string()
+        }).as_ref().map(|s| s.as_slice()) {
+            result::Ok("Success!") => (),
+            _ => fail!()
+        }
+    }
+
+    #[test]
+    fn test_try_fail() {
+        match try(proc() {
+            fail!()
+        }) {
+            result::Err(_) => (),
+            result::Ok(()) => fail!()
+        }
+    }
+
+    #[test]
+    fn test_spawn_sched() {
+        use clone::Clone;
+
+        let (tx, rx) = channel();
+
+        fn f(i: int, tx: Sender<()>) {
+            let tx = tx.clone();
+            spawn(proc() {
+                if i == 0 {
+                    tx.send(());
+                } else {
+                    f(i - 1, tx);
+                }
+            });
+
+        }
+        f(10, tx);
+        rx.recv();
+    }
+
+    #[test]
+    fn test_spawn_sched_childs_on_default_sched() {
+        let (tx, rx) = channel();
+
+        spawn(proc() {
+            spawn(proc() {
+                tx.send(());
+            });
+        });
+
+        rx.recv();
+    }
+
+    fn avoid_copying_the_body(spawnfn: |v: proc():Send|) {
+        let (tx, rx) = channel::<uint>();
+
+        let x = box 1;
+        let x_in_parent = (&*x) as *int as uint;
+
+        spawnfn(proc() {
+            let x_in_child = (&*x) as *int as uint;
+            tx.send(x_in_child);
+        });
+
+        let x_in_child = rx.recv();
+        assert_eq!(x_in_parent, x_in_child);
+    }
+
+    #[test]
+    fn test_avoid_copying_the_body_spawn() {
+        avoid_copying_the_body(spawn);
+    }
+
+    #[test]
+    fn test_avoid_copying_the_body_task_spawn() {
+        avoid_copying_the_body(|f| {
+            let builder = TaskBuilder::new();
+            builder.spawn(proc() {
+                f();
+            });
+        })
+    }
+
+    #[test]
+    fn test_avoid_copying_the_body_try() {
+        avoid_copying_the_body(|f| {
+            let _ = try(proc() {
+                f()
+            });
+        })
+    }
+
+    #[test]
+    fn test_child_doesnt_ref_parent() {
+        // If the child refcounts the parent task, this will stack overflow when
+        // climbing the task tree to dereference each ancestor. (See #1789)
+        // (well, it would if the constant were 8000+ - I lowered it to be more
+        // valgrind-friendly. try this at home, instead..!)
+        static generations: uint = 16;
+        fn child_no(x: uint) -> proc(): Send {
+            return proc() {
+                if x < generations {
+                    TaskBuilder::new().spawn(child_no(x+1));
+                }
             }
         }
+        TaskBuilder::new().spawn(child_no(0));
     }
-    TaskBuilder::new().spawn(child_no(0));
-}
 
-#[test]
-fn test_simple_newsched_spawn() {
-    spawn(proc()())
-}
+    #[test]
+    fn test_simple_newsched_spawn() {
+        spawn(proc()())
+    }
 
-#[test]
-fn test_try_fail_message_static_str() {
-    match try(proc() {
-        fail!("static string");
-    }) {
-        Err(e) => {
-            type T = &'static str;
-            assert!(e.is::<T>());
-            assert_eq!(*e.move::<T>().unwrap(), "static string");
+    #[test]
+    fn test_try_fail_message_static_str() {
+        match try(proc() {
+            fail!("static string");
+        }) {
+            Err(e) => {
+                type T = &'static str;
+                assert!(e.is::<T>());
+                assert_eq!(*e.move::<T>().unwrap(), "static string");
+            }
+            Ok(()) => fail!()
         }
-        Ok(()) => fail!()
     }
-}
 
-#[test]
-fn test_try_fail_message_owned_str() {
-    match try(proc() {
-        fail!("owned string".to_string());
-    }) {
-        Err(e) => {
-            type T = String;
-            assert!(e.is::<T>());
-            assert_eq!(*e.move::<T>().unwrap(), "owned string".to_string());
+    #[test]
+    fn test_try_fail_message_owned_str() {
+        match try(proc() {
+            fail!("owned string".to_string());
+        }) {
+            Err(e) => {
+                type T = String;
+                assert!(e.is::<T>());
+                assert_eq!(*e.move::<T>().unwrap(), "owned string".to_string());
+            }
+            Ok(()) => fail!()
         }
-        Ok(()) => fail!()
     }
-}
 
-#[test]
-fn test_try_fail_message_any() {
-    match try(proc() {
-        fail!(box 413u16 as Box<Any + Send>);
-    }) {
-        Err(e) => {
-            type T = Box<Any + Send>;
-            assert!(e.is::<T>());
-            let any = e.move::<T>().unwrap();
-            assert!(any.is::<u16>());
-            assert_eq!(*any.move::<u16>().unwrap(), 413u16);
+    #[test]
+    fn test_try_fail_message_any() {
+        match try(proc() {
+            fail!(box 413u16 as Box<Any + Send>);
+        }) {
+            Err(e) => {
+                type T = Box<Any + Send>;
+                assert!(e.is::<T>());
+                let any = e.move::<T>().unwrap();
+                assert!(any.is::<u16>());
+                assert_eq!(*any.move::<u16>().unwrap(), 413u16);
+            }
+            Ok(()) => fail!()
         }
-        Ok(()) => fail!()
     }
-}
 
-#[test]
-fn test_try_fail_message_unit_struct() {
-    struct Juju;
+    #[test]
+    fn test_try_fail_message_unit_struct() {
+        struct Juju;
 
-    match try(proc() {
-        fail!(Juju)
-    }) {
-        Err(ref e) if e.is::<Juju>() => {}
-        Err(_) | Ok(()) => fail!()
+        match try(proc() {
+            fail!(Juju)
+        }) {
+            Err(ref e) if e.is::<Juju>() => {}
+            Err(_) | Ok(()) => fail!()
+        }
     }
+
+    #[test]
+    fn test_stdout() {
+        let (tx, rx) = channel();
+        let mut reader = ChanReader::new(rx);
+        let stdout = ChanWriter::new(tx);
+
+        TaskBuilder::new().stdout(box stdout as Box<Writer + Send>).try(proc() {
+            print!("Hello, world!");
+        }).unwrap();
+
+        let output = reader.read_to_str().unwrap();
+        assert_eq!(output, "Hello, world!".to_string());
+    }
+
+    // NOTE: the corresponding test for stderr is in run-pass/task-stderr, due
+    // to the test harness apparently interfering with stderr configuration.
 }

--- a/src/libsync/lock.rs
+++ b/src/libsync/lock.rs
@@ -459,7 +459,7 @@ mod tests {
     use std::prelude::*;
     use std::comm::Empty;
     use std::task;
-    use std::task::TaskBuilder;
+    use std::task::try_future;
 
     use Arc;
     use super::{Mutex, Barrier, RWLock};
@@ -629,17 +629,15 @@ mod tests {
         let mut children = Vec::new();
         for _ in range(0, 5) {
             let arc3 = arc.clone();
-            let mut builder = TaskBuilder::new();
-            children.push(builder.future_result());
-            builder.spawn(proc() {
+            children.push(try_future(proc() {
                 let lock = arc3.read();
                 assert!(*lock >= 0);
-            });
+            }));
         }
 
         // Wait for children to pass their asserts
         for r in children.mut_iter() {
-            assert!(r.recv().is_ok());
+            assert!(r.get_ref().is_ok());
         }
 
         // Wait for writer to finish

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1049,14 +1049,13 @@ pub fn run_test(opts: &TestOpts,
             if nocapture {
                 drop((stdout, stderr));
             } else {
-                task.opts.stdout = Some(box stdout as Box<Writer + Send>);
-                task.opts.stderr = Some(box stderr as Box<Writer + Send>);
+                task = task.stdout(box stdout as Box<Writer + Send>);
+                task = task.stderr(box stderr as Box<Writer + Send>);
             }
-            let result_future = task.future_result();
-            task.spawn(testfn);
+            let result_future = task.try_future(testfn);
 
             let stdout = reader.read_to_end().unwrap().move_iter().collect();
-            let task_result = result_future.recv();
+            let task_result = result_future.unwrap();
             let test_result = calc_result(&desc, task_result.is_ok());
             monitor_ch.send((desc.clone(), test_result, stdout));
         })

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -19,7 +19,6 @@ extern crate debug;
 
 use std::os;
 use std::task;
-use std::task::TaskBuilder;
 use std::uint;
 
 fn move_out<T>(_x: T) {}
@@ -58,29 +57,25 @@ fn run(args: &[String]) {
     let mut worker_results = Vec::new();
     let from_parent = if workers == 1 {
         let (to_child, from_parent) = channel();
-        let mut builder = TaskBuilder::new();
-        worker_results.push(builder.future_result());
-        builder.spawn(proc() {
+        worker_results.push(task::try_future(proc() {
             for _ in range(0u, size / workers) {
                 //println!("worker {:?}: sending {:?} bytes", i, num_bytes);
                 to_child.send(bytes(num_bytes));
             }
             //println!("worker {:?} exiting", i);
-        });
+        }));
         from_parent
     } else {
         let (to_child, from_parent) = channel();
         for _ in range(0u, workers) {
             let to_child = to_child.clone();
-            let mut builder = TaskBuilder::new();
-            worker_results.push(builder.future_result());
-            builder.spawn(proc() {
+            worker_results.push(task::try_future(proc() {
                 for _ in range(0u, size / workers) {
                     //println!("worker {:?}: sending {:?} bytes", i, num_bytes);
                     to_child.send(bytes(num_bytes));
                 }
                 //println!("worker {:?} exiting", i);
-            });
+            }));
         }
         from_parent
     };
@@ -88,8 +83,8 @@ fn run(args: &[String]) {
         server(&from_parent, &to_parent);
     });
 
-    for r in worker_results.iter() {
-        r.recv();
+    for r in worker_results.move_iter() {
+        r.unwrap();
     }
 
     //println!("sending stop message");

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -24,7 +24,6 @@ extern crate time;
 use std::os;
 use std::result::{Ok, Err};
 use std::task;
-use std::task::TaskBuilder;
 use std::uint;
 
 fn fib(n: int) -> int {
@@ -79,14 +78,12 @@ fn stress_task(id: int) {
 fn stress(num_tasks: int) {
     let mut results = Vec::new();
     for i in range(0, num_tasks) {
-        let mut builder = TaskBuilder::new();
-        results.push(builder.future_result());
-        builder.spawn(proc() {
+        results.push(task::try_future(proc() {
             stress_task(i);
-        });
+        }));
     }
-    for r in results.iter() {
-        r.recv();
+    for r in results.move_iter() {
+        r.unwrap();
     }
 }
 

--- a/src/test/run-pass/issue-2190-1.rs
+++ b/src/test/run-pass/issue-2190-1.rs
@@ -13,9 +13,7 @@ use std::task::TaskBuilder;
 static generations: uint = 1024+256+128+49;
 
 fn spawn(f: proc():Send) {
-    let mut t = TaskBuilder::new();
-    t.opts.stack_size = Some(32 * 1024);
-    t.spawn(f);
+    TaskBuilder::new().stack_size(32 * 1024).spawn(f)
 }
 
 fn child_no(x: uint) -> proc():Send {

--- a/src/test/run-pass/task-comm-12.rs
+++ b/src/test/run-pass/task-comm-12.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::task;
-use std::task::TaskBuilder;
 
 pub fn main() { test00(); }
 
@@ -17,9 +16,7 @@ fn start(_task_number: int) { println!("Started / Finished task."); }
 
 fn test00() {
     let i: int = 0;
-    let mut builder = TaskBuilder::new();
-    let mut result = builder.future_result();
-    builder.spawn(proc() {
+    let mut result = task::try_future(proc() {
         start(i)
     });
 
@@ -31,7 +28,7 @@ fn test00() {
     }
 
     // Try joining tasks that have already finished.
-    result.recv();
+    result.unwrap();
 
     println!("Joined task.");
 }

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -10,7 +10,7 @@
 
 extern crate debug;
 
-use std::task::TaskBuilder;
+use std::task;
 
 pub fn main() { println!("===== WITHOUT THREADS ====="); test00(); }
 
@@ -39,14 +39,12 @@ fn test00() {
     let mut results = Vec::new();
     while i < number_of_tasks {
         let tx = tx.clone();
-        let mut builder = TaskBuilder::new();
-        results.push(builder.future_result());
-        builder.spawn({
+        results.push(task::try_future({
             let i = i;
             proc() {
                 test00_start(&tx, i, number_of_messages)
             }
-        });
+        }));
         i = i + 1;
     }
 
@@ -62,7 +60,7 @@ fn test00() {
     }
 
     // Join spawned tasks...
-    for r in results.iter() { r.recv(); }
+    for r in results.mut_iter() { r.get_ref(); }
 
     println!("Completed: Final number is: ");
     println!("{:?}", sum);

--- a/src/test/run-pass/task-comm-9.rs
+++ b/src/test/run-pass/task-comm-9.rs
@@ -10,7 +10,7 @@
 
 extern crate debug;
 
-use std::task::TaskBuilder;
+use std::task;
 
 pub fn main() { test00(); }
 
@@ -25,9 +25,7 @@ fn test00() {
     let (tx, rx) = channel();
     let number_of_messages: int = 10;
 
-    let mut builder = TaskBuilder::new();
-    let result = builder.future_result();
-    builder.spawn(proc() {
+    let result = task::try_future(proc() {
         test00_start(&tx, number_of_messages);
     });
 
@@ -38,7 +36,7 @@ fn test00() {
         i += 1;
     }
 
-    result.recv();
+    result.unwrap();
 
     assert_eq!(sum, number_of_messages * (number_of_messages - 1) / 2);
 }

--- a/src/test/run-pass/task-stderr.rs
+++ b/src/test/run-pass/task-stderr.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io::{ChanReader, ChanWriter};
+use std::task::build;
+
+fn main() {
+    let (tx, rx) = channel();
+    let mut reader = ChanReader::new(rx);
+    let stderr = ChanWriter::new(tx);
+
+    let res = build().stderr(box stderr as Box<Writer + Send>).try(proc() -> () {
+        fail!("Hello, world!")
+    });
+    assert!(res.is_err());
+
+    let output = reader.read_to_str().unwrap();
+    assert!(output.as_slice().contains("Hello, world!"));
+}

--- a/src/test/run-pass/task-stderr.rs
+++ b/src/test/run-pass/task-stderr.rs
@@ -9,14 +9,14 @@
 // except according to those terms.
 
 use std::io::{ChanReader, ChanWriter};
-use std::task::build;
+use std::task::TaskBuilder;
 
 fn main() {
     let (tx, rx) = channel();
     let mut reader = ChanReader::new(rx);
     let stderr = ChanWriter::new(tx);
 
-    let res = build().stderr(box stderr as Box<Writer + Send>).try(proc() -> () {
+    let res = TaskBuilder::new().stderr(box stderr as Box<Writer + Send>).try(proc() -> () {
         fail!("Hello, world!")
     });
     assert!(res.is_err());

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -60,9 +60,7 @@ fn main() {
     let (tx, rx) = channel();
     for _ in range(0, 1000) {
         let tx = tx.clone();
-        let mut builder = TaskBuilder::new();
-        builder.opts.stack_size = Some(64 * 1024);
-        builder.spawn(proc() {
+        TaskBuilder::new().stack_size(64 * 1024).spawn(proc() {
             let host = addr.ip.to_str();
             let port = addr.port;
             match TcpStream::connect(host.as_slice(), port) {

--- a/src/test/run-pass/yield.rs
+++ b/src/test/run-pass/yield.rs
@@ -9,18 +9,15 @@
 // except according to those terms.
 
 use std::task;
-use std::task::TaskBuilder;
 
 pub fn main() {
-    let mut builder = TaskBuilder::new();
-    let mut result = builder.future_result();
-    builder.spawn(child);
+    let mut result = task::try_future(child);
     println!("1");
     task::deschedule();
     println!("2");
     task::deschedule();
     println!("3");
-    result.recv();
+    result.unwrap();
 }
 
 fn child() {

--- a/src/test/run-pass/yield1.rs
+++ b/src/test/run-pass/yield1.rs
@@ -9,15 +9,12 @@
 // except according to those terms.
 
 use std::task;
-use std::task::TaskBuilder;
 
 pub fn main() {
-    let mut builder = TaskBuilder::new();
-    let mut result = builder.future_result();
-    builder.spawn(child);
+    let mut result = task::try_future(child);
     println!("1");
     task::deschedule();
-    result.recv();
+    result.unwrap();
 }
 
 fn child() { println!("2"); }


### PR DESCRIPTION
This patch consolidates and cleans up the task spawning APIs:
- Removes the problematic `future_result` method from `std::task::TaskBuilder`,
  and adds a `try_future` that both spawns the task and returns a future
  representing its eventual result (or failure).
- Removes the public `opts` field from `TaskBuilder`, instead adding appropriate
  builder methods to configure the task.
- Adds extension traits to libgreen and libnative that add methods to
  `TaskBuilder` for spawning the task as a green or native thread.

Previously, there was no way to benefit from the `TaskBuilder` functionality and
also set the scheduler to spawn within.

With this change, all task spawning scenarios are supported through the
`TaskBuilder` interface.

Closes #3725.

[breaking-change]
