### PR TITLE
(doc/feat) Add autofocus to docs' search bar.

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -66,6 +66,7 @@ r##"<!DOCTYPE html>
             <div class="search-container">
                 <input class="search-input" name="search"
                        autocomplete="off"
+                       autofocus="autofocus"
                        placeholder="Search documentation..."
                        type="search">
             </div>


### PR DESCRIPTION
This is a fix for convenience for heavy keyboard users. It allows the docs to be searched without using the mouse, by giving focus to the search bar on document load.
The mouse will still need to be used to select the docs returned by the search.

This is done by giving the `input.search-container` an `autofocus="autofocus"` attribute.
