### PR TITLE
(doc) Change search placeholder text.

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -66,7 +66,7 @@ r##"<!DOCTYPE html>
             <div class="search-container">
                 <input class="search-input" name="search"
                        autocomplete="off"
-                       placeholder="Search documentation..."
+                       placeholder="Click or press 's' to search, '?' for more options..."
                        type="search">
             </div>
         </form>


### PR DESCRIPTION
Update placeholder text to make keyboard shortcuts more apparent. As discussed in #15010.
