### PR TITLE
Mark all crates except std as experimental

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -61,6 +61,7 @@
 //! the system malloc/free.
 
 #![crate_id = "alloc#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -20,6 +20,7 @@
 //! more complex, slower Arena which can hold objects of any type.
 
 #![crate_id = "arena#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -13,6 +13,7 @@
  */
 
 #![crate_id = "collections#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -46,6 +46,7 @@
 //!
 
 #![crate_id = "core#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libdebug/lib.rs
+++ b/src/libdebug/lib.rs
@@ -17,6 +17,7 @@
 //! will persist into the future.
 
 #![crate_id = "debug#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -19,6 +19,7 @@ Simple [DEFLATE][def]-based compression. This is a wrapper around the
 */
 
 #![crate_id = "flate#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -15,11 +15,11 @@
 //! generated instead.
 
 #![crate_id = "fmt_macros#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![feature(macro_rules, globs)]
-#![experimental]
 
 use std::char;
 use std::str;

--- a/src/libfourcc/lib.rs
+++ b/src/libfourcc/lib.rs
@@ -40,6 +40,7 @@ fn main() {
 */
 
 #![crate_id = "fourcc#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -79,6 +79,7 @@
 //! ~~~
 
 #![crate_id = "getopts#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -24,6 +24,7 @@
  */
 
 #![crate_id = "glob#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -267,6 +267,7 @@ pub fn main() {
 */
 
 #![crate_id = "graphviz#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -198,6 +198,7 @@
 //! ```
 
 #![crate_id = "green#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libhexfloat/lib.rs
+++ b/src/libhexfloat/lib.rs
@@ -37,6 +37,7 @@ fn main() {
 */
 
 #![crate_id = "hexfloat#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -106,6 +106,7 @@ if logging is disabled, none of the components of the log will be executed.
 */
 
 #![crate_id = "log#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -42,6 +42,7 @@
 //! ```
 
 #![crate_id = "native#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -45,6 +45,7 @@
 #![feature(macro_rules)]
 
 #![crate_id = "num#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -19,6 +19,7 @@ This API is completely unstable and subject to change.
 */
 
 #![crate_id = "rustc#0.11.0-pre"]
+#![experimental]
 #![comment = "The Rust compiler"]
 #![license = "MIT/ASL2"]
 #![crate_type = "dylib"]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![crate_id = "rustdoc#0.11.0-pre"]
+#![experimental]
 #![desc = "rustdoc, the Rust documentation extractor"]
 #![license = "MIT/ASL2"]
 #![crate_type = "dylib"]

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -35,6 +35,7 @@ via `close` and `delete` methods.
 */
 
 #![crate_id = "rustuv#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/libsemver/lib.rs
+++ b/src/libsemver/lib.rs
@@ -29,6 +29,7 @@
 //! `0.8.1-rc.3.0+20130922.linux`.
 
 #![crate_id = "semver#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -15,6 +15,7 @@ Core encoding and decoding interfaces.
 */
 
 #![crate_id = "serialize#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -18,6 +18,7 @@
 //! through `std::sync`.
 
 #![crate_id = "sync#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -19,6 +19,7 @@ This API is completely unstable and subject to change.
 */
 
 #![crate_id = "syntax#0.11.0-pre"]
+#![experimental]
 #![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -39,6 +39,7 @@
 //! [ti]: https://en.wikipedia.org/wiki/Terminfo
 
 #![crate_id = "term#0.11.0-pre"]
+#![experimental]
 #![comment = "Simple ANSI color library"]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -24,6 +24,7 @@
 // build off of.
 
 #![crate_id = "test#0.11.0-pre"]
+#![experimental]
 #![comment = "Rust internal test library only used by rustc"]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -11,6 +11,7 @@
 //! Simple time handling.
 
 #![crate_id = "time#0.11.0-pre"]
+#![experimental]
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -11,6 +11,7 @@
 //! Types/fns concerning URLs (see RFC 3986)
 
 #![crate_id = "url#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -55,6 +55,7 @@ Examples of string representations:
 */
 
 #![crate_id = "uuid#0.11.0-pre"]
+#![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]


### PR DESCRIPTION
This creates a stability baseline for all crates that we distribute that are not `std`. In general, all library code must start as experimental and progress in stages to become stable.
