### PR TITLE
Properly document hotkeys in generated documentation.

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -63,7 +63,7 @@ r##"<!DOCTYPE html>
             <div class="search-container">
                 <input class="search-input" name="search"
                        autocomplete="off"
-                       placeholder="Click or press 's' to search, '?' for more options..."
+                       placeholder="Click or press 'S' to search, '?' for more options..."
                        type="search">
             </div>
         </form>
@@ -82,9 +82,9 @@ r##"<!DOCTYPE html>
                 <dd>Show this help dialog</dd>
                 <dt>S</dt>
                 <dd>Focus the search field</dd>
-                <dt>&uarr;</dt>
+                <dt>&larrb;</dt>
                 <dd>Move up in search results</dd>
-                <dt>&darr;</dt>
+                <dt>&rarrb;</dt>
                 <dd>Move down in search results</dd>
                 <dt>&#9166;</dt>
                 <dd>Go to active search result</dd>

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -347,7 +347,7 @@ p a:hover { text-decoration: underline; }
     margin-top: -125px;
     margin-left: -275px;
     width: 550px;
-    height: 250px;
+    height: 300px;
     border: 1px solid #bfbfbf;
 }
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -71,10 +71,10 @@
             return;
         }
 
-        if (e.keyCode === 188 && $('#help').hasClass('hidden')) { // question mark
+        if (e.which === 191 && $('#help').hasClass('hidden')) { // question mark
             e.preventDefault();
             $('#help').removeClass('hidden');
-        } else if (e.keyCode === 27) { // esc
+        } else if (e.which === 27) { // esc
             if (!$('#help').hasClass('hidden')) {
                 e.preventDefault();
                 $('#help').addClass('hidden');
@@ -83,7 +83,7 @@
                 $('#search').addClass('hidden');
                 $('#main').removeClass('hidden');
             }
-        } else if (e.keyCode === 83) { // S
+        } else if (e.which === 83) { // S
             e.preventDefault();
             $('.search-input').focus();
         }
@@ -361,7 +361,7 @@
             $(document).on('keypress.searchnav', function(e) {
                 var $active = $results.filter('.highlighted');
 
-                if (e.keyCode === 38) { // up
+                if (e.which === 38) { // up
                     e.preventDefault();
                     if (!$active.length || !$active.prev()) {
                         return;
@@ -369,7 +369,7 @@
 
                     $active.prev().addClass('highlighted');
                     $active.removeClass('highlighted');
-                } else if (e.keyCode === 40) { // down
+                } else if (e.which === 40) { // down
                     e.preventDefault();
                     if (!$active.length) {
                         $results.first().addClass('highlighted');
@@ -377,7 +377,7 @@
                         $active.next().addClass('highlighted');
                         $active.removeClass('highlighted');
                     }
-                } else if (e.keyCode === 13) { // return
+                } else if (e.which === 13) { // return
                     e.preventDefault();
                     if ($active.length) {
                         document.location.href = $active.find('a').prop('href');


### PR DESCRIPTION
Continuing from #15012, this makes four changes to the `rustdoc` static files.
- Change the placeholder text of the search bar to `Click or press 'S' to search, '?' for more options...` to make keyboard hotkeys more apparent (capitalizing the `S` to match the help text).
- Change the `main.js` file to use browser-normalized key codes (`e.which`, from `jQuery`), instead of `e.keyCode`.
- Change the key code for `?` to be the correct `191` instead of `188`, so that the hotkey works to bring up search information.
- Change the search information to display `tab` and `shift+tab` instead of `up` and `down`, as those do not yet work outside of Firefox (see #15011). Also, adjust the height so it does not cut off the help text.

<s>I've also opened up #15038 about the non-functional `up` and `down` functionality, although this does nothing to fix it.</s>
