### PR TITLE
sync: Enable the fast path of select()

### DIFF
--- a/src/libsync/comm/select.rs
+++ b/src/libsync/comm/select.rs
@@ -132,7 +132,7 @@ impl Select {
     /// event could either be that data is available or the corresponding
     /// channel has been closed.
     pub fn wait(&self) -> uint {
-        self.wait2(false)
+        self.wait2(true)
     }
 
     /// Helper method for skipping the preflight checks during testing


### PR DESCRIPTION
This was erroneously disabled as part of 065e121f and it hasn't been turned on
since. This was a 3x perf improvement in a test of mine.
