### PR TITLE
doc: Fix margins around tables of contents

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -275,7 +275,7 @@ dd {
 
 nav ul {
     list-style-type: none;
-    margin: 0;
+    margin: 0 0 20px 0;
     padding-left: 0px;
 }
 


### PR DESCRIPTION
There is no space between the TOC and the succeeding para.

See http://doc.rust-lang.org/guide-pointers.html for example.
