### PR TITLE
syntax: Parse GT tokens from `>=` and `>>=`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -706,6 +706,16 @@ impl<'a> Parser<'a> {
                 let lo = span.lo + BytePos(1);
                 self.replace_token(token::GT, lo, span.hi)
             }
+            token::BINOPEQ(token::SHR) => {
+                let span = self.span;
+                let lo = span.lo + BytePos(1);
+                self.replace_token(token::GE, lo, span.hi)
+            }
+            token::GE => {
+                let span = self.span;
+                let lo = span.lo + BytePos(1);
+                self.replace_token(token::EQ, lo, span.hi)
+            }
             _ => {
                 let gt_str = Parser::token_to_str(&token::GT);
                 let this_token_str = self.this_token_to_str();
@@ -726,7 +736,9 @@ impl<'a> Parser<'a> {
         let mut first = true;
         let mut v = Vec::new();
         while self.token != token::GT
-            && self.token != token::BINOP(token::SHR) {
+            && self.token != token::BINOP(token::SHR)
+            && self.token != token::GE
+            && self.token != token::BINOPEQ(token::SHR) {
             match sep {
               Some(ref t) => {
                 if first { first = false; }

--- a/src/test/run-pass/issue-15043.rs
+++ b/src/test/run-pass/issue-15043.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(warnings)]
+
+struct S<T>(T);
+
+static s1: S<S<uint>>=S(S(0));
+static s2: S<uint>=S(0);
+
+fn main() {
+    let foo: S<S<uint>>=S(S(0));
+    let foo: S<uint>=S(0);
+}


### PR DESCRIPTION
The parser already has special logic for parsing `>` tokens from `>>`, and this
commit extends the logic to the acquiring a `>` from the `>=` and `>>=` tokens
as well.

Closes #15043
