### PR TITLE
libsyntax: Stop parsing `+` with no bounds after it.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1646,6 +1646,12 @@ impl<'a> Parser<'a> {
             let bounds = {
                 if self.eat(&token::BINOP(token::PLUS)) {
                     let (_, bounds) = self.parse_ty_param_bounds(false);
+                    if bounds.len() == 0 {
+                        let last_span = self.last_span;
+                        self.span_err(last_span,
+                                      "at least one type parameter bound \
+                                       must be specified after the `+`");
+                    }
                     Some(bounds)
                 } else {
                     None

--- a/src/test/compile-fail/kindck-send.rs
+++ b/src/test/compile-fail/kindck-send.rs
@@ -40,7 +40,7 @@ fn test<'a,T,U:Send>(_: &'a int) {
     assert_send::<&'static Dummy>(); //~ ERROR does not fulfill `Send`
     assert_send::<&'a Dummy>(); //~ ERROR does not fulfill `Send`
     assert_send::<&'a Dummy+Send>(); //~ ERROR does not fulfill `Send`
-    assert_send::<Box<Dummy+>>(); //~ ERROR does not fulfill `Send`
+    assert_send::<Box<Dummy>>(); //~ ERROR does not fulfill `Send`
 
     // ...unless they are properly bounded
     assert_send::<&'static Dummy+Send>();

--- a/src/test/compile-fail/trailing-plus-in-bounds.rs
+++ b/src/test/compile-fail/trailing-plus-in-bounds.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::fmt::Show;
 
-trait Foo {
+fn main() {
+    let x: Box<Show+> = box 3 as Box<Show+>;
+    //~^ ERROR at least one type parameter bound must be specified
+    //~^^ ERROR at least one type parameter bound must be specified
 }
 
-fn b(_x: Box<Foo+Send>) {
-}
-
-fn c(x: Box<Foo+Share+Send>) {
-    e(x);
-}
-
-fn d(x: Box<Foo+Send>) {
-    e(x);
-}
-
-fn e(x: Box<Foo>) {
-    e(x);
-}
-
-pub fn main() { }

--- a/src/test/compile-fail/trait-bounds-cant-coerce.rs
+++ b/src/test/compile-fail/trait-bounds-cant-coerce.rs
@@ -19,7 +19,7 @@ fn c(x: Box<Foo+Share+Send>) {
     a(x);
 }
 
-fn d(x: Box<Foo+>) {
+fn d(x: Box<Foo>) {
     a(x); //~ ERROR found no bounds
 }
 

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -33,11 +33,11 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
     }
 }
 
-fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+> {
+fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>> {
     box Invoker {
         a: a,
         b: b,
-    } as (Box<Invokable<A>>+)
+    } as (Box<Invokable<A>>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/closure-syntax.rs
+++ b/src/test/run-pass/closure-syntax.rs
@@ -59,7 +59,6 @@ fn bar<'b>() {
     foo::< <'a>|int, f32, &'a int|:'b + Share -> &'a int>();
     foo::<proc()>();
     foo::<proc() -> ()>();
-    foo::<proc():>();
     foo::<proc():'static>();
     foo::<proc():Share>();
     foo::<proc<'a>(int, f32, &'a int):'static + Share -> &'a int>();

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -20,6 +20,5 @@ pub fn main() {}
 trait A {}
 impl<T: 'static> A for T {}
 
-fn owned1<T: 'static>(a: T) { box a as Box<A+>; } /* note `:` */
 fn owned2<T: 'static>(a: Box<T>) { a as Box<A>; }
 fn owned3<T: 'static>(a: Box<T>) { box a as Box<A>; }

--- a/src/test/run-pass/proc-bounds.rs
+++ b/src/test/run-pass/proc-bounds.rs
@@ -28,7 +28,7 @@ pub fn main() {
 
 
     let a = 3;
-    bar::<proc():>(proc() {
+    bar::<proc()>(proc() {
         let b = &a;
         println!("{}", *b);
     });


### PR DESCRIPTION
This will break code that looks like `Box<Trait+>`. Change that code to
`Box<Trait>` instead.

Closes #14925.

[breaking-change]

r? @brson
