### PR TITLE
librustc: Feature gate lang items and intrinsics.

### DIFF
--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -451,6 +451,7 @@ in the same format as a C:
 
 ```
 #![no_std]
+#![feature(lang_items)]
 
 // Pull in the system libc library for what crt0.o likely requires
 extern crate libc;
@@ -477,6 +478,7 @@ compiler's name mangling too:
 ```ignore
 #![no_std]
 #![no_main]
+#![feature(lang_items)]
 
 extern crate libc;
 
@@ -528,6 +530,7 @@ vectors provided from C, using idiomatic Rust practices.
 ```
 #![no_std]
 #![feature(globs)]
+#![feature(lang_items)]
 
 # extern crate libc;
 extern crate core;
@@ -619,6 +622,9 @@ perform efficient pointer arithmetic, one would import those functions
 via a declaration like
 
 ```
+# #![feature(intrinsics)]
+# fn main() {}
+
 extern "rust-intrinsic" {
     fn transmute<T, U>(x: T) -> U;
 
@@ -647,6 +653,7 @@ sugar for dynamic allocations via `malloc` and `free`:
 
 ```
 #![no_std]
+#![feature(lang_items)]
 
 extern crate libc;
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -69,7 +69,8 @@
        html_root_url = "http://doc.rust-lang.org/")]
 
 #![no_std]
-#![feature(phase, unsafe_destructor)]
+#![feature(lang_items, phase, unsafe_destructor)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
 
 #[phase(plugin, link)]
 extern crate core;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -55,8 +55,10 @@
        html_playground_url = "http://play.rust-lang.org/")]
 
 #![no_std]
-#![feature(globs, macro_rules, managed_boxes, phase, simd, unsafe_destructor)]
+#![feature(globs, intrinsics, lang_items, macro_rules, managed_boxes, phase)]
+#![feature(simd, unsafe_destructor)]
 #![deny(missing_doc)]
+#![allow(unknown_features)] // NOTE: remove after stage0 snapshot
 
 #[cfg(test)] extern crate realcore = "core";
 #[cfg(test)] extern crate libc;

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -55,6 +55,8 @@
 
 #![deny(unused_result, unused_must_use)]
 #![allow(non_camel_case_types, deprecated)]
+#![allow(unknown_features)] // NOTE: remove after a stage0 snap
+#![feature(default_type_params, lang_items)]
 
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the

--- a/src/librlibc/lib.rs
+++ b/src/librlibc/lib.rs
@@ -26,6 +26,8 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/")]
+#![feature(intrinsics)]
+#![allow(unknown_features)] // NOTE: remove after stage0 snapshot
 
 #![no_std]
 #![experimental]

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -17,7 +17,8 @@
        html_root_url = "http://doc.rust-lang.org/")]
 
 #![feature(macro_rules, phase, globs, thread_local, managed_boxes, asm)]
-#![feature(linkage, unsafe_destructor)]
+#![feature(linkage, lang_items, unsafe_destructor)]
+#![allow(unknown_features)] // NOTE: remove after stage0 snapshot
 #![no_std]
 #![experimental]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -104,13 +104,14 @@
        html_root_url = "http://doc.rust-lang.org/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![feature(macro_rules, globs, managed_boxes)]
-#![feature(linkage, default_type_params, phase, unsafe_destructor)]
+#![feature(macro_rules, globs, managed_boxes, linkage)]
+#![feature(default_type_params, phase, lang_items, unsafe_destructor)]
 
 // Don't link to std. We are std.
 #![no_std]
 
 #![allow(deprecated)]
+#![allow(unknown_features)] // NOTE: remove after stage0 snapshot
 #![deny(missing_doc)]
 
 // When testing libstd, bring in libuv as the I/O backend so tests can print

--- a/src/test/auxiliary/cci_intrinsic.rs
+++ b/src/test/auxiliary/cci_intrinsic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(intrinsics)]
+
 pub mod rusti {
     extern "rust-intrinsic" {
         pub fn atomic_xchg<T>(dst: *mut T, src: T) -> T;

--- a/src/test/auxiliary/lang-item-public.rs
+++ b/src/test/auxiliary/lang-item-public.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![no_std]
+#![feature(lang_items)]
 
 #[lang="fail_"]
 fn fail(_: &'static str, _: &'static str, _: uint) -> ! { loop {} }

--- a/src/test/compile-fail/attr.rs
+++ b/src/test/compile-fail/attr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(lang_items)]
+
 fn main() {}
 
 #![lang(foo)] //~ ERROR an inner attribute is not permitted in this context

--- a/src/test/compile-fail/bad-mid-path-type-params.rs
+++ b/src/test/compile-fail/bad-mid-path-type-params.rs
@@ -11,6 +11,7 @@
 // ignore-tidy-linelength
 
 #![no_std]
+#![feature(lang_items)]
 
 #[lang="sized"]
 pub trait Sized {}

--- a/src/test/compile-fail/feature-gate-intrinsics-and-lang-items.rs
+++ b/src/test/compile-fail/feature-gate-intrinsics-and-lang-items.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(intrinsics)]
+#[lang="foo"]   //~ ERROR language items are subject to change
+trait Foo {}
 
-mod rusti {
-    extern "rust-intrinsic" {
-        pub fn uninit<T>() -> T;
-    }
+extern "rust-intrinsic" {   //~ ERROR intrinsics are subject to change
+    fn bar();
 }
-pub fn main() {
-    let _a : int = unsafe {rusti::uninit()};
+
+extern "rust-intrinsic" fn baz() {  //~ ERROR intrinsics are subject to change
 }
+
+fn main() {
+}
+

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -13,6 +13,7 @@
 #![allow(non_camel_case_types)]
 #![allow(visible_private_types)]
 #![deny(dead_code)]
+#![feature(lang_items)]
 
 #![crate_type="lib"]
 

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
+#![feature(globs, lang_items)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang="sized"]

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(intrinsics)]
 
 mod rusti {
     extern "rust-intrinsic" {

--- a/src/test/run-pass/intrinsic-atomics.rs
+++ b/src/test/run-pass/intrinsic-atomics.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(intrinsics)]
+
 mod rusti {
     extern "rust-intrinsic" {
         pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> T;

--- a/src/test/run-pass/intrinsic-move-val.rs
+++ b/src/test/run-pass/intrinsic-move-val.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(intrinsics)]
+
 use std::mem::transmute;
 
 mod rusti {

--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
+#![feature(globs, intrinsics)]
 
 mod rusti {
     extern "rust-intrinsic" {

--- a/src/test/run-pass/intrinsics-math.rs
+++ b/src/test/run-pass/intrinsics-math.rs
@@ -9,7 +9,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, macro_rules)]
+#![feature(globs, macro_rules, intrinsics)]
 
 macro_rules! assert_approx_eq(
     ($a:expr, $b:expr) => ({

--- a/src/test/run-pass/rec-align-u32.rs
+++ b/src/test/run-pass/rec-align-u32.rs
@@ -10,6 +10,8 @@
 
 // Issue #2303
 
+#![feature(intrinsics)]
+
 extern crate debug;
 
 use std::mem;

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -10,6 +10,8 @@
 
 // Issue #2303
 
+#![feature(intrinsics)]
+
 extern crate debug;
 
 use std::mem;

--- a/src/test/run-pass/smallest-hello-world.rs
+++ b/src/test/run-pass/smallest-hello-world.rs
@@ -13,6 +13,7 @@
 // Smallest "hello world" with a libc runtime
 
 #![no_std]
+#![feature(intrinsics, lang_items)]
 
 extern crate libc;
 


### PR DESCRIPTION
If you define lang items in your crate, add `#[feature(lang_items)]`.

If you define intrinsics (`extern "rust-intrinsic"`), add
`#[feature(intrinsics)]`.

Closes #12858.

[breaking-change]

r? @brson
