### PR TITLE
A couple micro-optimizations of Vec and std::io::me::*

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -85,6 +85,7 @@ impl<T> Vec<T> {
     /// # use std::vec::Vec;
     /// let vec: Vec<int> = Vec::with_capacity(10);
     /// ```
+    #[inline]
     pub fn with_capacity(capacity: uint) -> Vec<T> {
         if mem::size_of::<T>() == 0 {
             Vec { len: 0, cap: uint::MAX, ptr: 0 as *mut T }
@@ -110,6 +111,7 @@ impl<T> Vec<T> {
     /// let vec = Vec::from_fn(3, |idx| idx * 2);
     /// assert_eq!(vec, vec!(0, 2, 4));
     /// ```
+    #[inline]
     pub fn from_fn(length: uint, op: |uint| -> T) -> Vec<T> {
         unsafe {
             let mut xs = Vec::with_capacity(length);
@@ -193,6 +195,7 @@ impl<T: Clone> Vec<T> {
     /// let slice = [1, 2, 3];
     /// let vec = Vec::from_slice(slice);
     /// ```
+    #[inline]
     pub fn from_slice(values: &[T]) -> Vec<T> {
         values.iter().map(|x| x.clone()).collect()
     }
@@ -207,6 +210,7 @@ impl<T: Clone> Vec<T> {
     /// let vec = Vec::from_elem(3, "hi");
     /// println!("{}", vec); // prints [hi, hi, hi]
     /// ```
+    #[inline]
     pub fn from_elem(length: uint, value: T) -> Vec<T> {
         unsafe {
             let mut xs = Vec::with_capacity(length);
@@ -353,6 +357,7 @@ impl<T:Clone> Clone for Vec<T> {
 }
 
 impl<T> FromIterator<T> for Vec<T> {
+    #[inline]
     fn from_iter<I:Iterator<T>>(mut iterator: I) -> Vec<T> {
         let (lower, _) = iterator.size_hint();
         let mut vector = Vec::with_capacity(lower);
@@ -364,6 +369,7 @@ impl<T> FromIterator<T> for Vec<T> {
 }
 
 impl<T> Extendable<T> for Vec<T> {
+    #[inline]
     fn extend<I: Iterator<T>>(&mut self, mut iterator: I) {
         let (lower, _) = iterator.size_hint();
         self.reserve_additional(lower);
@@ -1029,6 +1035,7 @@ impl<T> Vec<T> {
     /// vec.push_all_move(vec!(box 2, box 3, box 4));
     /// assert_eq!(vec, vec!(box 1, box 2, box 3, box 4));
     /// ```
+    #[inline]
     pub fn push_all_move(&mut self, other: Vec<T>) {
         self.extend(other.move_iter());
     }
@@ -1306,6 +1313,7 @@ impl<T:PartialEq> Vec<T> {
     /// let vec = vec!(1, 2, 3);
     /// assert!(vec.contains(&1));
     /// ```
+    #[inline]
     pub fn contains(&self, x: &T) -> bool {
         self.as_slice().contains(x)
     }
@@ -1835,5 +1843,112 @@ mod tests {
 
         let mut v = vec![BadElem(1), BadElem(2), BadElem(0xbadbeef), BadElem(4)];
         v.truncate(0);
+    }
+
+    #[bench]
+    fn bench_new(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::new();
+            assert_eq!(v.capacity(), 0);
+            assert!(v.as_slice() == []);
+        })
+    }
+
+    #[bench]
+    fn bench_with_capacity_0(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::with_capacity(0);
+            assert_eq!(v.capacity(), 0);
+            assert!(v.as_slice() == []);
+        })
+    }
+
+
+    #[bench]
+    fn bench_with_capacity_5(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::with_capacity(5);
+            assert_eq!(v.capacity(), 5);
+            assert!(v.as_slice() == []);
+        })
+    }
+
+    #[bench]
+    fn bench_with_capacity_100(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::with_capacity(100);
+            assert_eq!(v.capacity(), 100);
+            assert!(v.as_slice() == []);
+        })
+    }
+
+    #[bench]
+    fn bench_from_fn_0(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::from_fn(0, |_| 5);
+            assert!(v.as_slice() == []);
+        })
+    }
+
+    #[bench]
+    fn bench_from_fn_5(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::from_fn(5, |_| 5);
+            assert!(v.as_slice() == [5, 5, 5, 5, 5]);
+        })
+    }
+
+    #[bench]
+    fn bench_from_slice_0(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::from_slice([]);
+            assert!(v.as_slice() == []);
+        })
+    }
+
+    #[bench]
+    fn bench_from_slice_5(b: &mut Bencher) {
+        b.iter(|| {
+            let v: Vec<int> = Vec::from_slice([1, 2, 3, 4, 5]);
+            assert!(v.as_slice() == [1, 2, 3, 4, 5]);
+        })
+    }
+
+    #[bench]
+    fn bench_from_iter_0(b: &mut Bencher) {
+        b.iter(|| {
+            let v0: Vec<int> = vec!();
+            let v1: Vec<int> = FromIterator::from_iter(v0.move_iter());
+            assert!(v1.as_slice() == []);
+        })
+    }
+
+    #[bench]
+    fn bench_from_iter_5(b: &mut Bencher) {
+        b.iter(|| {
+            let v0: Vec<int> = vec!(1, 2, 3, 4, 5);
+            let v1: Vec<int> = FromIterator::from_iter(v0.move_iter());
+            assert!(v1.as_slice() == [1, 2, 3, 4, 5]);
+        })
+    }
+
+    #[bench]
+    fn bench_extend_0(b: &mut Bencher) {
+        b.iter(|| {
+            let v0: Vec<int> = vec!();
+            let mut v1: Vec<int> = vec!(1, 2, 3, 4, 5);
+            v1.extend(v0.move_iter());
+            assert!(v1.as_slice() == [1, 2, 3, 4, 5]);
+        })
+    }
+
+    #[bench]
+    fn bench_extend_5(b: &mut Bencher) {
+        b.iter(|| {
+            let v0: Vec<int> = vec!(1, 2, 3, 4, 5);
+            let mut v1: Vec<int> = vec!(1, 2, 3, 4, 5);
+            v1.extend(v0.move_iter());
+            assert!(v1.as_slice() == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]);
+        })
     }
 }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1552,8 +1552,11 @@ pub mod raw {
 
 #[cfg(test)]
 mod tests {
+    extern crate test;
+
     use std::prelude::*;
     use std::mem::size_of;
+    use test::Bencher;
     use super::{unzip, raw, Vec};
 
     #[test]

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -71,7 +71,7 @@ fn main() {
     let to_encode_object = TestStruct{data_str:"example of string to encode".to_string()};
     let mut m = io::MemWriter::new();
     {
-        let mut encoder = json::Encoder::new(&mut m as &mut std::io::Writer);
+        let mut encoder = json::Encoder::new(&mut m as &mut Writer);
         match to_encode_object.encode(&mut encoder) {
             Ok(()) => (),
             Err(e) => fail!("json encoding error: {}", e)

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -59,11 +59,13 @@ pub struct MemWriter {
 
 impl MemWriter {
     /// Create a new `MemWriter`.
+    #[inline]
     pub fn new() -> MemWriter {
         MemWriter::with_capacity(128)
     }
     /// Create a new `MemWriter`, allocating at least `n` bytes for
     /// the internal buffer.
+    #[inline]
     pub fn with_capacity(n: uint) -> MemWriter {
         MemWriter { buf: Vec::with_capacity(n), pos: 0 }
     }
@@ -73,13 +75,16 @@ impl MemWriter {
     ///
     /// No method is exposed for acquiring a mutable reference to the buffer
     /// because it could corrupt the state of this `MemWriter`.
+    #[inline]
     pub fn get_ref<'a>(&'a self) -> &'a [u8] { self.buf.as_slice() }
 
     /// Unwraps this `MemWriter`, returning the underlying buffer
+    #[inline]
     pub fn unwrap(self) -> Vec<u8> { self.buf }
 }
 
 impl Writer for MemWriter {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         // Make sure the internal buffer is as least as big as where we
         // currently are
@@ -112,7 +117,10 @@ impl Writer for MemWriter {
 }
 
 impl Seek for MemWriter {
+    #[inline]
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
+
+    #[inline]
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
         let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
@@ -140,6 +148,7 @@ pub struct MemReader {
 impl MemReader {
     /// Creates a new `MemReader` which will read the buffer given. The buffer
     /// can be re-acquired through `unwrap`
+    #[inline]
     pub fn new(buf: Vec<u8>) -> MemReader {
         MemReader {
             buf: buf,
@@ -150,6 +159,7 @@ impl MemReader {
     /// Tests whether this reader has read all bytes in its buffer.
     ///
     /// If `true`, then this will no longer return bytes from `read`.
+    #[inline]
     pub fn eof(&self) -> bool { self.pos >= self.buf.len() }
 
     /// Acquires an immutable reference to the underlying buffer of this
@@ -157,13 +167,16 @@ impl MemReader {
     ///
     /// No method is exposed for acquiring a mutable reference to the buffer
     /// because it could corrupt the state of this `MemReader`.
+    #[inline]
     pub fn get_ref<'a>(&'a self) -> &'a [u8] { self.buf.as_slice() }
 
     /// Unwraps this `MemReader`, returning the underlying buffer
+    #[inline]
     pub fn unwrap(self) -> Vec<u8> { self.buf }
 }
 
 impl Reader for MemReader {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         if self.eof() { return Err(io::standard_error(io::EndOfFile)) }
 
@@ -182,7 +195,10 @@ impl Reader for MemReader {
 }
 
 impl Seek for MemReader {
+    #[inline]
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
+
+    #[inline]
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
         let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
@@ -191,6 +207,7 @@ impl Seek for MemReader {
 }
 
 impl Buffer for MemReader {
+    #[inline]
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos < self.buf.len() {
             Ok(self.buf.slice_from(self.pos))
@@ -198,6 +215,8 @@ impl Buffer for MemReader {
             Err(io::standard_error(io::EndOfFile))
         }
     }
+
+    #[inline]
     fn consume(&mut self, amt: uint) { self.pos += amt; }
 }
 
@@ -227,6 +246,7 @@ pub struct BufWriter<'a> {
 impl<'a> BufWriter<'a> {
     /// Creates a new `BufWriter` which will wrap the specified buffer. The
     /// writer initially starts at position 0.
+    #[inline]
     pub fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a> {
         BufWriter {
             buf: buf,
@@ -236,6 +256,7 @@ impl<'a> BufWriter<'a> {
 }
 
 impl<'a> Writer for BufWriter<'a> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         // return an error if the entire write does not fit in the buffer
         let max_size = self.buf.len();
@@ -254,7 +275,10 @@ impl<'a> Writer for BufWriter<'a> {
 }
 
 impl<'a> Seek for BufWriter<'a> {
+    #[inline]
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
+
+    #[inline]
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
         let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
@@ -282,6 +306,7 @@ pub struct BufReader<'a> {
 
 impl<'a> BufReader<'a> {
     /// Creates a new buffered reader which will read the specified buffer
+    #[inline]
     pub fn new<'a>(buf: &'a [u8]) -> BufReader<'a> {
         BufReader {
             buf: buf,
@@ -292,10 +317,12 @@ impl<'a> BufReader<'a> {
     /// Tests whether this reader has read all bytes in its buffer.
     ///
     /// If `true`, then this will no longer return bytes from `read`.
+    #[inline]
     pub fn eof(&self) -> bool { self.pos >= self.buf.len() }
 }
 
 impl<'a> Reader for BufReader<'a> {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         if self.eof() { return Err(io::standard_error(io::EndOfFile)) }
 
@@ -314,7 +341,10 @@ impl<'a> Reader for BufReader<'a> {
 }
 
 impl<'a> Seek for BufReader<'a> {
+    #[inline]
     fn tell(&self) -> IoResult<u64> { Ok(self.pos as u64) }
+
+    #[inline]
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
         let new = try!(combine(style, self.pos, self.buf.len(), pos));
         self.pos = new as uint;
@@ -323,6 +353,7 @@ impl<'a> Seek for BufReader<'a> {
 }
 
 impl<'a> Buffer for BufReader<'a> {
+    #[inline]
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos < self.buf.len() {
             Ok(self.buf.slice_from(self.pos))
@@ -330,15 +361,19 @@ impl<'a> Buffer for BufReader<'a> {
             Err(io::standard_error(io::EndOfFile))
         }
     }
+
+    #[inline]
     fn consume(&mut self, amt: uint) { self.pos += amt; }
 }
 
 #[cfg(test)]
 mod test {
+    extern crate test;
     use prelude::*;
     use super::*;
     use io::*;
     use io;
+    use self::test::Bencher;
     use str::StrSlice;
 
     #[test]
@@ -570,5 +605,60 @@ mod test {
         assert_eq!(buf.as_slice(), &[4, 5, 6]);
         assert!(r.read_at_least(buf.len(), buf).is_err());
         assert_eq!(buf.as_slice(), &[7, 8, 6]);
+    }
+
+    #[bench]
+    fn bench_mem_writer(b: &mut Bencher) {
+        b.iter(|| {
+            let mut wr = MemWriter::new();
+            for _i in range(0, 10) {
+                wr.write([5, .. 10]).unwrap();
+            }
+            assert_eq!(wr.unwrap().as_slice(), [5, .. 100].as_slice());
+        });
+    }
+
+    #[bench]
+    fn bench_mem_reader(b: &mut Bencher) {
+        b.iter(|| {
+            let buf = Vec::from_slice([5 as u8, ..100]);
+            {
+                let mut rdr = MemReader::new(buf);
+                for _i in range(0, 10) {
+                    let mut buf = [0 as u8, .. 10];
+                    rdr.read(buf).unwrap();
+                    assert_eq!(buf.as_slice(), [5, .. 10].as_slice());
+                }
+            }
+        });
+    }
+
+    #[bench]
+    fn bench_buf_writer(b: &mut Bencher) {
+        b.iter(|| {
+            let mut buf = [0 as u8, ..100];
+            {
+                let mut wr = BufWriter::new(buf);
+                for _i in range(0, 10) {
+                    wr.write([5, .. 10]).unwrap();
+                }
+            }
+            assert_eq!(buf.as_slice(), [5, .. 100].as_slice());
+        });
+    }
+
+    #[bench]
+    fn bench_buf_reader(b: &mut Bencher) {
+        b.iter(|| {
+            let buf = [5 as u8, ..100];
+            {
+                let mut rdr = BufReader::new(buf);
+                for _i in range(0, 10) {
+                    let mut buf = [0 as u8, .. 10];
+                    rdr.read(buf).unwrap();
+                    assert_eq!(buf.as_slice(), [5, .. 10].as_slice());
+                }
+            }
+        });
     }
 }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1084,6 +1084,7 @@ pub trait Writer {
     /// If other encodings are desired, it is recommended to compose this stream
     /// with another performing the conversion, or to use `write` with a
     /// converted byte-array instead.
+    #[inline]
     fn write_str(&mut self, s: &str) -> IoResult<()> {
         self.write(s.as_bytes())
     }
@@ -1095,11 +1096,13 @@ pub trait Writer {
     ///
     /// If other encodings or line ending flavors are desired, it is recommended
     /// that the `write` method is used specifically instead.
+    #[inline]
     fn write_line(&mut self, s: &str) -> IoResult<()> {
         self.write_str(s).and_then(|()| self.write(['\n' as u8]))
     }
 
     /// Write a single char, encoded as UTF-8.
+    #[inline]
     fn write_char(&mut self, c: char) -> IoResult<()> {
         let mut buf = [0u8, ..4];
         let n = c.encode_utf8(buf.as_mut_slice());
@@ -1107,66 +1110,79 @@ pub trait Writer {
     }
 
     /// Write the result of passing n through `int::to_str_bytes`.
+    #[inline]
     fn write_int(&mut self, n: int) -> IoResult<()> {
         write!(self, "{:d}", n)
     }
 
     /// Write the result of passing n through `uint::to_str_bytes`.
+    #[inline]
     fn write_uint(&mut self, n: uint) -> IoResult<()> {
         write!(self, "{:u}", n)
     }
 
     /// Write a little-endian uint (number of bytes depends on system).
+    #[inline]
     fn write_le_uint(&mut self, n: uint) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, uint::BYTES, |v| self.write(v))
     }
 
     /// Write a little-endian int (number of bytes depends on system).
+    #[inline]
     fn write_le_int(&mut self, n: int) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, int::BYTES, |v| self.write(v))
     }
 
     /// Write a big-endian uint (number of bytes depends on system).
+    #[inline]
     fn write_be_uint(&mut self, n: uint) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, uint::BYTES, |v| self.write(v))
     }
 
     /// Write a big-endian int (number of bytes depends on system).
+    #[inline]
     fn write_be_int(&mut self, n: int) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, int::BYTES, |v| self.write(v))
     }
 
     /// Write a big-endian u64 (8 bytes).
+    #[inline]
     fn write_be_u64(&mut self, n: u64) -> IoResult<()> {
         extensions::u64_to_be_bytes(n, 8u, |v| self.write(v))
     }
 
     /// Write a big-endian u32 (4 bytes).
+    #[inline]
     fn write_be_u32(&mut self, n: u32) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, 4u, |v| self.write(v))
     }
 
     /// Write a big-endian u16 (2 bytes).
+    #[inline]
     fn write_be_u16(&mut self, n: u16) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, 2u, |v| self.write(v))
     }
 
     /// Write a big-endian i64 (8 bytes).
+    #[inline]
     fn write_be_i64(&mut self, n: i64) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, 8u, |v| self.write(v))
     }
 
     /// Write a big-endian i32 (4 bytes).
+    #[inline]
     fn write_be_i32(&mut self, n: i32) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, 4u, |v| self.write(v))
     }
 
     /// Write a big-endian i16 (2 bytes).
+    #[inline]
     fn write_be_i16(&mut self, n: i16) -> IoResult<()> {
         extensions::u64_to_be_bytes(n as u64, 2u, |v| self.write(v))
     }
 
     /// Write a big-endian IEEE754 double-precision floating-point (8 bytes).
+    #[inline]
     fn write_be_f64(&mut self, f: f64) -> IoResult<()> {
         unsafe {
             self.write_be_u64(transmute(f))
@@ -1174,6 +1190,7 @@ pub trait Writer {
     }
 
     /// Write a big-endian IEEE754 single-precision floating-point (4 bytes).
+    #[inline]
     fn write_be_f32(&mut self, f: f32) -> IoResult<()> {
         unsafe {
             self.write_be_u32(transmute(f))
@@ -1181,37 +1198,44 @@ pub trait Writer {
     }
 
     /// Write a little-endian u64 (8 bytes).
+    #[inline]
     fn write_le_u64(&mut self, n: u64) -> IoResult<()> {
         extensions::u64_to_le_bytes(n, 8u, |v| self.write(v))
     }
 
     /// Write a little-endian u32 (4 bytes).
+    #[inline]
     fn write_le_u32(&mut self, n: u32) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, 4u, |v| self.write(v))
     }
 
     /// Write a little-endian u16 (2 bytes).
+    #[inline]
     fn write_le_u16(&mut self, n: u16) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, 2u, |v| self.write(v))
     }
 
     /// Write a little-endian i64 (8 bytes).
+    #[inline]
     fn write_le_i64(&mut self, n: i64) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, 8u, |v| self.write(v))
     }
 
     /// Write a little-endian i32 (4 bytes).
+    #[inline]
     fn write_le_i32(&mut self, n: i32) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, 4u, |v| self.write(v))
     }
 
     /// Write a little-endian i16 (2 bytes).
+    #[inline]
     fn write_le_i16(&mut self, n: i16) -> IoResult<()> {
         extensions::u64_to_le_bytes(n as u64, 2u, |v| self.write(v))
     }
 
     /// Write a little-endian IEEE754 double-precision floating-point
     /// (8 bytes).
+    #[inline]
     fn write_le_f64(&mut self, f: f64) -> IoResult<()> {
         unsafe {
             self.write_le_u64(transmute(f))
@@ -1220,6 +1244,7 @@ pub trait Writer {
 
     /// Write a little-endian IEEE754 single-precision floating-point
     /// (4 bytes).
+    #[inline]
     fn write_le_f32(&mut self, f: f32) -> IoResult<()> {
         unsafe {
             self.write_le_u32(transmute(f))
@@ -1227,11 +1252,13 @@ pub trait Writer {
     }
 
     /// Write a u8 (1 byte).
+    #[inline]
     fn write_u8(&mut self, n: u8) -> IoResult<()> {
         self.write([n])
     }
 
     /// Write an i8 (1 byte).
+    #[inline]
     fn write_i8(&mut self, n: i8) -> IoResult<()> {
         self.write([n as u8])
     }
@@ -1240,18 +1267,25 @@ pub trait Writer {
     ///
     /// This is useful to allow applying wrappers while still
     /// retaining ownership of the original value.
+    #[inline]
     fn by_ref<'a>(&'a mut self) -> RefWriter<'a, Self> {
         RefWriter { inner: self }
     }
 }
 
 impl Writer for Box<Writer> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.write(buf) }
+
+    #[inline]
     fn flush(&mut self) -> IoResult<()> { self.flush() }
 }
 
 impl<'a> Writer for &'a mut Writer {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.write(buf) }
+
+    #[inline]
     fn flush(&mut self) -> IoResult<()> { self.flush() }
 }
 
@@ -1285,7 +1319,10 @@ pub struct RefWriter<'a, W> {
 }
 
 impl<'a, W: Writer> Writer for RefWriter<'a, W> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.inner.write(buf) }
+
+    #[inline]
     fn flush(&mut self) -> IoResult<()> { self.inner.flush() }
 }
 


### PR DESCRIPTION
This is a couple micro-optimizations I've been sitting on for a while. This inlines a couple functions that are important to the `std::io::mem`. Ultimately, this results in about a 15% performance increase in some micro-benchmarks for my [libserialize](https://github.com/erickt/rust-serde) rewrite.
