### PR TITLE
librustc: Remove outdated reference to `~` syntax

### DIFF
--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1121,7 +1121,10 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
                       "captured outer variable".to_string()
                   }
                   _ => {
-                      format!("dereference of `{}`-pointer", ptr_sigil(pk))
+                      match pk {
+                          OwnedPtr | GcPtr => format!("dereference of `{}`", ptr_sigil(pk)),
+                          _ => format!("dereference of `{}`-pointer", ptr_sigil(pk))
+                      }
                   }
               }
           }
@@ -1291,8 +1294,8 @@ impl Repr for categorization {
 
 pub fn ptr_sigil(ptr: PointerKind) -> &'static str {
     match ptr {
-        OwnedPtr => "~",
-        GcPtr => "@",
+        OwnedPtr => "Box",
+        GcPtr => "Gc",
         BorrowedPtr(ty::ImmBorrow, _) => "&",
         BorrowedPtr(ty::MutBorrow, _) => "&mut",
         BorrowedPtr(ty::UniqueImmBorrow, _) => "&unique",

--- a/src/test/compile-fail/borrowck-borrow-immut-deref-of-box-as-mut.rs
+++ b/src/test/compile-fail/borrowck-borrow-immut-deref-of-box-as-mut.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A;
+
+impl A {
+    fn foo(&mut self) {
+    }
+}
+
+pub fn main() {
+    let a = box A;
+    a.foo();
+    //~^ ERROR cannot borrow immutable dereference of `Box` `*a` as mutable
+}

--- a/src/test/compile-fail/borrowck-borrow-immut-deref-of-gc-as-mut.rs
+++ b/src/test/compile-fail/borrowck-borrow-immut-deref-of-gc-as-mut.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(managed_boxes)]
+
+use std::gc::GC;
+
+struct A;
+
+impl A {
+    fn foo(&mut self) {
+    }
+}
+
+pub fn main() {
+    let a = box(GC) A;
+    a.foo();
+    //~^ ERROR cannot borrow immutable dereference of `Gc` `*a` as mutable
+}


### PR DESCRIPTION
Fix #15052
