### PR TITLE
Replace reference to ~"string" with box "string" in compiler error message

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2651,7 +2651,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                     let error = if vst == ast::ExprVstoreSlice {
                         "`&\"string\"` has been removed; use `\"string\"` instead"
                     } else {
-                        "`~\"string\"` has been removed; use `\"string\".to_string()` instead"
+                        "`box \"string\"` has been removed; use `\"string\".to_string()` instead"
                     };
                     tcx.sess.span_err(expr.span, error);
                     ty::mk_err()


### PR DESCRIPTION
Using something like:

``` rust
box "string"
```

yields

``` shell
"`~\"string\"` has been removed; use `\"string\".to_string()` instead"
```

Should the error message maybe say `box "string"` instead?
