### PR TITLE
librustc: Don't create extra alloca slot for by value bindings in match.

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -461,6 +461,7 @@ CFG_PATH_MUNGE_i686-pc-mingw32 :=
 CFG_LDPATH_i686-pc-mingw32 :=$(CFG_LDPATH_i686-pc-mingw32):$(PATH)
 CFG_RUN_i686-pc-mingw32=PATH="$(CFG_LDPATH_i686-pc-mingw32):$(1)" $(2)
 CFG_RUN_TARG_i686-pc-mingw32=$(call CFG_RUN_i686-pc-mingw32,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
+RUSTC_FLAGS_i686-pc-mingw32=-C link-args="-Wl,--large-address-aware"
 
 # i586-mingw32msvc configuration
 CC_i586-mingw32msvc=$(CFG_MINGW32_CROSS_PATH)/bin/i586-mingw32msvc-gcc

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -187,8 +187,8 @@ use metadata::csearch;
 use middle::subst;
 use middle::trans::adt;
 use middle::trans::common::*;
-use middle::trans::datum::{Datum, Lvalue};
 use middle::trans::machine;
+use middle::trans::_match::{BindingInfo, TrByValue, TrByRef};
 use middle::trans::type_of;
 use middle::trans::type_::Type;
 use middle::trans;
@@ -938,22 +938,36 @@ pub fn create_captured_var_metadata(bcx: &Block,
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_match_binding_metadata(bcx: &Block,
                                      variable_ident: ast::Ident,
-                                     node_id: ast::NodeId,
-                                     span: Span,
-                                     datum: Datum<Lvalue>) {
+                                     binding: BindingInfo) {
     if fn_should_be_ignored(bcx.fcx) {
         return;
     }
 
-    let scope_metadata = scope_metadata(bcx.fcx, node_id, span);
+    let scope_metadata = scope_metadata(bcx.fcx, binding.id, binding.span);
+    let aops = unsafe {
+        [llvm::LLVMDIBuilderCreateOpDeref(bcx.ccx().int_type.to_ref())]
+    };
+    // Regardless of the actual type (`T`) we're always passed the stack slot (alloca)
+    // for the binding. For ByRef bindings that's a `T*` but for ByValue bindings we
+    // actually have `T**`. So to get the actual variable we need to dereference once
+    // more.
+    let var_type = match binding.trmode {
+        TrByValue => IndirectVariable {
+            alloca: binding.llmatch,
+            address_operations: aops
+        },
+        TrByRef => DirectVariable {
+            alloca: binding.llmatch
+        }
+    };
 
     declare_local(bcx,
                   variable_ident,
-                  datum.ty,
+                  binding.ty,
                   scope_metadata,
-                  DirectVariable { alloca: datum.val },
+                  var_type,
                   LocalVariable,
-                  span);
+                  binding.span);
 }
 
 /// Creates debug information for the given function argument.


### PR DESCRIPTION
``` Rust
struct With {
    x: int,
    f: NoCopy
}

#[no_mangle]
fn bar() {
    let mine = With { x: 3, f: NoCopy };
    match mine {
        c => {
            foo(c);
        }
    }
}

#[no_mangle]
fn foo(_: With) {}
```

Before:

``` LLVM
define internal void @bar() unnamed_addr #1 {
entry-block:
  %mine = alloca %"struct.With<[]>"
  %__llmatch = alloca %"struct.With<[]>"*
  %c = alloca %"struct.With<[]>"
  %0 = getelementptr inbounds %"struct.With<[]>"* %mine, i32 0, i32 0
  store i64 3, i64* %0
  %1 = getelementptr inbounds %"struct.With<[]>"* %mine, i32 0, i32 1
  store %"struct.With<[]>"* %mine, %"struct.With<[]>"** %__llmatch
  br label %case_body

case_body:                                        ; preds = %entry-block
  %2 = load %"struct.With<[]>"** %__llmatch
  %3 = bitcast %"struct.With<[]>"* %2 to i8*
  %4 = bitcast %"struct.With<[]>"* %c to i8*
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %4, i8* %3, i64 8, i32 8, i1 false)
  %5 = load %"struct.With<[]>"* %c
  call void @foo(%"struct.With<[]>" %5)
  br label %join

join:                                             ; preds = %case_body
  ret void
}
```

After:

``` LLVM
define internal void @bar() unnamed_addr #1 {
entry-block:
  %mine = alloca %"struct.With<[]>"
  %c = alloca %"struct.With<[]>"*
  %0 = getelementptr inbounds %"struct.With<[]>"* %mine, i32 0, i32 0
  store i64 3, i64* %0
  %1 = getelementptr inbounds %"struct.With<[]>"* %mine, i32 0, i32 1
  store %"struct.With<[]>"* %mine, %"struct.With<[]>"** %c
  br label %case_body

case_body:                                        ; preds = %entry-block
  %2 = load %"struct.With<[]>"** %c
  %3 = load %"struct.With<[]>"* %2
  call void @foo(%"struct.With<[]>" %3)
  br label %join

join:                                             ; preds = %case_body
  ret void
}
```

r? @pcwalton
