### PR TITLE
rustc: Remove `&str` indexing from the language.

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1569,8 +1569,8 @@ mod tests {
         let n2: uint = v.len();
         assert_eq!(n1, n2);
         while i < n1 {
-            let a: u8 = s1.as_slice()[i];
-            let b: u8 = s2.as_slice()[i];
+            let a: u8 = s1.as_bytes()[i];
+            let b: u8 = s2.as_bytes()[i];
             debug!("{}", a);
             debug!("{}", b);
             assert_eq!(a, b);

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -222,7 +222,7 @@ impl String {
             return None
         }
 
-        let byte = self.as_slice()[len - 1];
+        let byte = self.as_bytes()[len - 1];
         self.vec.set_len(len - 1);
         Some(byte)
     }

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -370,7 +370,7 @@ impl Matches {
 }
 
 fn is_arg(arg: &str) -> bool {
-    arg.len() > 1 && arg[0] == '-' as u8
+    arg.len() > 1 && arg.as_bytes()[0] == '-' as u8
 }
 
 fn find_opt(opts: &[Opt], nm: Name) -> Option<uint> {
@@ -553,7 +553,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
         } else {
             let mut names;
             let mut i_arg = None;
-            if cur.as_slice()[1] == '-' as u8 {
+            if cur.as_bytes()[1] == '-' as u8 {
                 let tail = cur.as_slice().slice(2, curlen);
                 let tail_eq: Vec<&str> = tail.split('=').collect();
                 if tail_eq.len() <= 1 {

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -657,8 +657,8 @@ pub fn sanitize(s: &str) -> String {
 
     // Underscore-qualify anything that didn't start as an ident.
     if result.len() > 0u &&
-        result.as_slice()[0] != '_' as u8 &&
-        ! char::is_XID_start(result.as_slice()[0] as char) {
+        result.as_bytes()[0] != '_' as u8 &&
+        ! char::is_XID_start(result.as_bytes()[0] as char) {
         return format!("_{}", result.as_slice());
     }
 
@@ -737,9 +737,9 @@ pub fn mangle_exported_name(ccx: &CrateContext, path: PathElems,
     let extra2 = id % EXTRA_CHARS.len();
     let id = id / EXTRA_CHARS.len();
     let extra3 = id % EXTRA_CHARS.len();
-    hash.push_char(EXTRA_CHARS[extra1] as char);
-    hash.push_char(EXTRA_CHARS[extra2] as char);
-    hash.push_char(EXTRA_CHARS[extra3] as char);
+    hash.push_char(EXTRA_CHARS.as_bytes()[extra1] as char);
+    hash.push_char(EXTRA_CHARS.as_bytes()[extra2] as char);
+    hash.push_char(EXTRA_CHARS.as_bytes()[extra3] as char);
 
     exported_name(path,
                   hash.as_slice(),

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -181,7 +181,7 @@ fn item_sized(item: ebml::Doc) -> ast::Sized {
 fn item_method_sort(item: ebml::Doc) -> char {
     let mut ret = 'r';
     reader::tagged_docs(item, tag_item_trait_method_sort, |doc| {
-        ret = doc.as_str_slice()[0] as char;
+        ret = doc.as_str_slice().as_bytes()[0] as char;
         false
     });
     ret
@@ -757,13 +757,13 @@ fn get_explicit_self(item: ebml::Doc) -> ast::ExplicitSelf_ {
     let explicit_self_doc = reader::get_doc(item, tag_item_trait_method_explicit_self);
     let string = explicit_self_doc.as_str_slice();
 
-    let explicit_self_kind = string[0];
+    let explicit_self_kind = string.as_bytes()[0];
     match explicit_self_kind as char {
         's' => ast::SelfStatic,
         'v' => ast::SelfValue,
         '~' => ast::SelfUniq,
         // FIXME(#4846) expl. region
-        '&' => ast::SelfRegion(None, get_mutability(string[1])),
+        '&' => ast::SelfRegion(None, get_mutability(string.as_bytes()[1])),
         _ => fail!("unknown self type code: `{}`", explicit_self_kind as char)
     }
 }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -399,7 +399,7 @@ struct DeadVisitor<'a> {
 impl<'a> DeadVisitor<'a> {
     fn should_warn_about_field(&mut self, node: &ast::StructField_) -> bool {
         let (is_named, has_leading_underscore) = match node.ident() {
-            Some(ref ident) => (true, token::get_ident(*ident).get()[0] == ('_' as u8)),
+            Some(ref ident) => (true, token::get_ident(*ident).get().as_bytes()[0] == ('_' as u8)),
             _ => (false, false)
         };
         let field_type = ty::node_id_to_type(self.tcx, node.id);

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1511,7 +1511,7 @@ impl<'a> Liveness<'a> {
 
     fn should_warn(&self, var: Variable) -> Option<String> {
         let name = self.ir.variable_name(var);
-        if name.len() == 0 || name.as_slice()[0] == ('_' as u8) {
+        if name.len() == 0 || name.as_bytes()[0] == ('_' as u8) {
             None
         } else {
             Some(name)

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -126,7 +126,6 @@ pub enum FieldName {
 #[deriving(Clone, PartialEq, Eq, Hash)]
 pub enum ElementKind {
     VecElement,
-    StrElement,
     OtherElement,
 }
 
@@ -794,7 +793,7 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
         //! - `derefs`: the deref number to be used for
         //!   the implicit index deref, if any (see above)
 
-        let element_ty = match ty::index(base_cmt.ty) {
+        let element_ty = match ty::array_element_ty(base_cmt.ty) {
           Some(ref mt) => mt.ty,
           None => {
             self.tcx().sess.span_bug(
@@ -1137,9 +1136,6 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
           cat_interior(_, InteriorElement(VecElement)) => {
               "vec content".to_string()
           }
-          cat_interior(_, InteriorElement(StrElement)) => {
-              "str content".to_string()
-          }
           cat_interior(_, InteriorElement(OtherElement)) => {
               "indexed content".to_string()
           }
@@ -1320,7 +1316,6 @@ fn element_kind(t: ty::t) -> ElementKind {
         ty::ty_rptr(_, ty::mt{ty:ty, ..}) |
         ty::ty_uniq(ty) => match ty::get(ty).sty {
             ty::ty_vec(_, None) => VecElement,
-            ty::ty_str => StrElement,
             _ => OtherElement
         },
         ty::ty_vec(..) => VecElement,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2556,6 +2556,21 @@ pub fn index(t: t) -> Option<mt> {
         ty_ptr(mt{ty: t, ..}) | ty_rptr(_, mt{ty: t, ..}) |
         ty_box(t) | ty_uniq(t) => match get(t).sty {
             ty_vec(mt, None) => Some(mt),
+            _ => None,
+        },
+        _ => None
+    }
+}
+
+// Returns the type of elements contained within an 'array-like' type.
+// This is exactly the same as the above, except it supports strings,
+// which can't actually be indexed.
+pub fn array_element_ty(t: t) -> Option<mt> {
+    match get(t).sty {
+        ty_vec(mt, Some(_)) => Some(mt),
+        ty_ptr(mt{ty: t, ..}) | ty_rptr(_, mt{ty: t, ..}) |
+        ty_box(t) | ty_uniq(t) => match get(t).sty {
+            ty_vec(mt, None) => Some(mt),
             ty_str => Some(mt {ty: mk_u8(), mutbl: ast::MutImmutable}),
             _ => None,
         },

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1206,8 +1206,8 @@ mod test {
         let mut cur = [0u8, .. 2];
         for f in files {
             let stem = f.filestem_str().unwrap();
-            let root = stem[0] - ('0' as u8);
-            let name = stem[1] - ('0' as u8);
+            let root = stem.as_bytes()[0] - ('0' as u8);
+            let name = stem.as_bytes()[1] - ('0' as u8);
             assert!(cur[root as uint] < name);
             cur[root as uint] = name;
         }

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -242,14 +242,18 @@ impl GenericPathUnsafe for Path {
         fn is_vol_abs(path: &str, prefix: Option<PathPrefix>) -> bool {
             // assume prefix is Some(DiskPrefix)
             let rest = path.slice_from(prefix_len(prefix));
-            !rest.is_empty() && rest[0].is_ascii() && is_sep(rest[0] as char)
+            !rest.is_empty() && rest.as_bytes()[0].is_ascii() && is_sep(rest.as_bytes()[0] as char)
         }
         fn shares_volume(me: &Path, path: &str) -> bool {
             // path is assumed to have a prefix of Some(DiskPrefix)
             let repr = me.repr.as_slice();
             match me.prefix {
-                Some(DiskPrefix) => repr[0] == path[0].to_ascii().to_upper().to_byte(),
-                Some(VerbatimDiskPrefix) => repr[4] == path[0].to_ascii().to_upper().to_byte(),
+                Some(DiskPrefix) => {
+                    repr.as_bytes()[0] == path.as_bytes()[0].to_ascii().to_upper().to_byte()
+                }
+                Some(VerbatimDiskPrefix) => {
+                    repr.as_bytes()[4] == path.as_bytes()[0].to_ascii().to_upper().to_byte()
+                }
                 _ => false
             }
         }
@@ -279,7 +283,7 @@ impl GenericPathUnsafe for Path {
             // if me is "C:" we don't want to add a path separator
             match me.prefix {
                 Some(DiskPrefix) if me.repr.len() == plen => (),
-                _ if !(me.repr.len() > plen && me.repr.as_slice()[me.repr.len()-1] == SEP_BYTE) => {
+                _ if !(me.repr.len() > plen && me.repr.as_bytes()[me.repr.len()-1] == SEP_BYTE) => {
                     s.push_char(SEP);
                 }
                 _ => ()
@@ -302,7 +306,7 @@ impl GenericPathUnsafe for Path {
                     // absolute path, or cwd-relative and self is not same volume
                     replace_path(self, path, prefix);
                 }
-                None if !path.is_empty() && is_sep_(self.prefix, path[0]) => {
+                None if !path.is_empty() && is_sep_(self.prefix, path.as_bytes()[0]) => {
                     // volume-relative path
                     if self.prefix.is_some() {
                         // truncate self down to the prefix, then append
@@ -478,7 +482,7 @@ impl GenericPath for Path {
         match self.prefix {
             Some(DiskPrefix) => {
                 let rest = self.repr.as_slice().slice_from(self.prefix_len());
-                rest.len() > 0 && rest[0] == SEP_BYTE
+                rest.len() > 0 && rest.as_bytes()[0] == SEP_BYTE
             }
             Some(_) => true,
             None => false
@@ -638,11 +642,11 @@ impl Path {
         let s = match self.prefix {
             Some(_) => {
                 let plen = self.prefix_len();
-                if repr.len() > plen && repr[plen] == SEP_BYTE {
+                if repr.len() > plen && repr.as_bytes()[plen] == SEP_BYTE {
                     repr.slice_from(plen+1)
                 } else { repr.slice_from(plen) }
             }
-            None if repr[0] == SEP_BYTE => repr.slice_from(1),
+            None if repr.as_bytes()[0] == SEP_BYTE => repr.slice_from(1),
             None => repr
         };
         let ret = s.split_terminator(SEP).map(Some);
@@ -665,14 +669,14 @@ impl Path {
         match (self.prefix, other.prefix) {
             (Some(DiskPrefix), Some(VerbatimDiskPrefix)) => {
                 self.is_absolute() &&
-                    s_repr[0].to_ascii().eq_ignore_case(o_repr[4].to_ascii())
+                    s_repr.as_bytes()[0].to_ascii().eq_ignore_case(o_repr.as_bytes()[4].to_ascii())
             }
             (Some(VerbatimDiskPrefix), Some(DiskPrefix)) => {
                 other.is_absolute() &&
-                    s_repr[4].to_ascii().eq_ignore_case(o_repr[0].to_ascii())
+                    s_repr.as_bytes()[4].to_ascii().eq_ignore_case(o_repr.as_bytes()[0].to_ascii())
             }
             (Some(VerbatimDiskPrefix), Some(VerbatimDiskPrefix)) => {
-                s_repr[4].to_ascii().eq_ignore_case(o_repr[4].to_ascii())
+                s_repr.as_bytes()[4].to_ascii().eq_ignore_case(o_repr.as_bytes()[4].to_ascii())
             }
             (Some(UNCPrefix(_,_)), Some(VerbatimUNCPrefix(_,_))) => {
                 s_repr.slice(2, self.prefix_len()) == o_repr.slice(8, other.prefix_len())
@@ -718,12 +722,12 @@ impl Path {
             let mut comps = comps;
             match (comps.is_some(),prefix) {
                 (false, Some(DiskPrefix)) => {
-                    if s[0] >= 'a' as u8 && s[0] <= 'z' as u8 {
+                    if s.as_bytes()[0] >= 'a' as u8 && s.as_bytes()[0] <= 'z' as u8 {
                         comps = Some(vec![]);
                     }
                 }
                 (false, Some(VerbatimDiskPrefix)) => {
-                    if s[4] >= 'a' as u8 && s[0] <= 'z' as u8 {
+                    if s.as_bytes()[4] >= 'a' as u8 && s.as_bytes()[0] <= 'z' as u8 {
                         comps = Some(vec![]);
                     }
                 }
@@ -778,12 +782,12 @@ impl Path {
                         let mut s = String::with_capacity(n);
                         match prefix {
                             Some(DiskPrefix) => {
-                                s.push_char(prefix_[0].to_ascii().to_upper().to_char());
+                                s.push_char(prefix_.as_bytes()[0].to_ascii().to_upper().to_char());
                                 s.push_char(':');
                             }
                             Some(VerbatimDiskPrefix) => {
                                 s.push_str(prefix_.slice_to(4));
-                                s.push_char(prefix_[4].to_ascii().to_upper().to_char());
+                                s.push_char(prefix_.as_bytes()[4].to_ascii().to_upper().to_char());
                                 s.push_str(prefix_.slice_from(5));
                             }
                             Some(UNCPrefix(a,b)) => {
@@ -845,7 +849,7 @@ impl Path {
 
     fn has_nonsemantic_trailing_slash(&self) -> bool {
         is_verbatim(self) && self.repr.len() > self.prefix_len()+1 &&
-            self.repr.as_slice()[self.repr.len()-1] == SEP_BYTE
+            self.repr.as_bytes()[self.repr.len()-1] == SEP_BYTE
     }
 
     fn update_normalized<S: Str>(&mut self, s: S) {
@@ -861,7 +865,7 @@ impl Path {
 /// but absolute within that volume.
 #[inline]
 pub fn is_vol_relative(path: &Path) -> bool {
-    path.prefix.is_none() && is_sep_byte(&path.repr.as_slice()[0])
+    path.prefix.is_none() && is_sep_byte(&path.repr.as_bytes()[0])
 }
 
 /// Returns whether the path is considered "cwd-relative", which means a path
@@ -991,8 +995,8 @@ fn parse_prefix<'a>(mut path: &'a str) -> Option<PathPrefix> {
             } else {
                 // \\?\path
                 let idx = path.find('\\');
-                if idx == Some(2) && path[1] == ':' as u8 {
-                    let c = path[0];
+                if idx == Some(2) && path.as_bytes()[1] == ':' as u8 {
+                    let c = path.as_bytes()[0];
                     if c.is_ascii() && ::char::is_alphabetic(c as char) {
                         // \\?\C:\ path
                         return Some(VerbatimDiskPrefix);
@@ -1014,9 +1018,9 @@ fn parse_prefix<'a>(mut path: &'a str) -> Option<PathPrefix> {
             }
             _ => ()
         }
-    } else if path.len() > 1 && path[1] == ':' as u8 {
+    } else if path.len() > 1 && path.as_bytes()[1] == ':' as u8 {
         // C:
-        let c = path[0];
+        let c = path.as_bytes()[0];
         if c.is_ascii() && ::char::is_alphabetic(c as char) {
             return Some(DiskPrefix);
         }

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -415,7 +415,7 @@ fn highlight_lines(err: &mut EmitterWriter,
         }
         let orig = fm.get_line(*lines.lines.get(0) as int);
         for pos in range(0u, left-skip) {
-            let cur_char = orig.as_slice()[pos] as char;
+            let cur_char = orig.as_bytes()[pos] as char;
             // Whenever a tab occurs on the previous line, we insert one on
             // the error-point-squiggly-line as well (instead of a space).
             // That way the squiggly line will usually appear in the correct

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1203,8 +1203,8 @@ impl<'a> StringReader<'a> {
 
     fn read_one_line_comment(&mut self) -> String {
         let val = self.read_to_eol();
-        assert!((val.as_slice()[0] == '/' as u8 && val.as_slice()[1] == '/' as u8)
-             || (val.as_slice()[0] == '#' as u8 && val.as_slice()[1] == '!' as u8));
+        assert!((val.as_bytes()[0] == '/' as u8 && val.as_bytes()[1] == '/' as u8)
+             || (val.as_bytes()[0] == '#' as u8 && val.as_bytes()[1] == '!' as u8));
         return val;
     }
 

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -375,7 +375,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, String> {
     fn match_str(s: &str, pos: uint, needle: &str) -> bool {
         let mut i = pos;
         for ch in needle.bytes() {
-            if s[i] != ch {
+            if s.as_bytes()[i] != ch {
                 return false;
             }
             i += 1u;

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -324,8 +324,8 @@ impl Uuid {
         let mut s: Vec<u8> = Vec::from_elem(32, 0u8);
         for i in range(0u, 16u) {
             let digit = format!("{:02x}", self.bytes[i] as uint);
-            *s.get_mut(i*2+0) = digit.as_slice()[0];
-            *s.get_mut(i*2+1) = digit.as_slice()[1];
+            *s.get_mut(i*2+0) = digit.as_bytes()[0];
+            *s.get_mut(i*2+1) = digit.as_bytes()[1];
         }
         str::from_utf8(s.as_slice()).unwrap().to_string()
     }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -183,7 +183,7 @@ fn main() {
 
        if line.len() == 0u { continue; }
 
-       match (line.as_slice()[0] as char, proc_mode) {
+       match (line.as_bytes()[0] as char, proc_mode) {
 
            // start processing if this is the one
            ('>', false) => {

--- a/src/test/compile-fail/integral-indexing.rs
+++ b/src/test/compile-fail/integral-indexing.rs
@@ -17,10 +17,10 @@ pub fn main() {
     assert_eq!(v.as_slice()[3u32], 3); //~ ERROR: mismatched types
     assert_eq!(v.as_slice()[3i32], 3); //~ ERROR: mismatched types
     println!("{}", v.as_slice()[3u8]); //~ ERROR: mismatched types
-    assert_eq!(s.as_slice()[3u], 'd' as u8);
-    assert_eq!(s.as_slice()[3u8], 'd' as u8); //~ ERROR: mismatched types
-    assert_eq!(s.as_slice()[3i8], 'd' as u8); //~ ERROR: mismatched types
-    assert_eq!(s.as_slice()[3u32], 'd' as u8); //~ ERROR: mismatched types
-    assert_eq!(s.as_slice()[3i32], 'd' as u8); //~ ERROR: mismatched types
-    println!("{}", s.as_slice()[3u8]); //~ ERROR: mismatched types
+    assert_eq!(s.as_bytes()[3u], 'd' as u8);
+    assert_eq!(s.as_bytes()[3u8], 'd' as u8); //~ ERROR: mismatched types
+    assert_eq!(s.as_bytes()[3i8], 'd' as u8); //~ ERROR: mismatched types
+    assert_eq!(s.as_bytes()[3u32], 'd' as u8); //~ ERROR: mismatched types
+    assert_eq!(s.as_bytes()[3i32], 'd' as u8); //~ ERROR: mismatched types
+    println!("{}", s.as_bytes()[3u8]); //~ ERROR: mismatched types
 }

--- a/src/test/compile-fail/str-idx.rs
+++ b/src/test/compile-fail/str-idx.rs
@@ -11,8 +11,6 @@
 extern crate debug;
 
 pub fn main() {
-    let s = "hello".to_string();
-    let c: u8 = s.as_slice()[4];
-    println!("{:?}", c);
-    assert_eq!(c, 0x6f as u8);
+    let s: &str = "hello";
+    let c: u8 = s[4]; //~ ERROR cannot index a value of type `&str`
 }

--- a/src/test/run-fail/str-overrun.rs
+++ b/src/test/run-fail/str-overrun.rs
@@ -14,5 +14,5 @@ fn main() {
     let s: String = "hello".to_string();
 
     // Bounds-check failure.
-    assert_eq!(s.as_slice()[5], 0x0 as u8);
+    assert_eq!(s.as_bytes()[5], 0x0 as u8);
 }

--- a/src/test/run-pass/estr-slice.rs
+++ b/src/test/run-pass/estr-slice.rs
@@ -17,8 +17,8 @@ pub fn main() {
     println!("{}", x);
     println!("{}", y);
 
-    assert_eq!(x[0], 'h' as u8);
-    assert_eq!(x[4], 'o' as u8);
+    assert_eq!(x.as_bytes()[0], 'h' as u8);
+    assert_eq!(x.as_bytes()[4], 'o' as u8);
 
     let z : &str = "thing";
     assert_eq!(v, x);

--- a/src/test/run-pass/estr-uniq.rs
+++ b/src/test/run-pass/estr-uniq.rs
@@ -15,6 +15,6 @@ pub fn main() {
     let _y : String = "there".to_string();
     let mut z = "thing".to_string();
     z = x;
-    assert_eq!(z.as_slice()[0], ('h' as u8));
-    assert_eq!(z.as_slice()[4], ('o' as u8));
+    assert_eq!(z.as_bytes()[0], ('h' as u8));
+    assert_eq!(z.as_bytes()[4], ('o' as u8));
 }

--- a/src/test/run-pass/str-concat.rs
+++ b/src/test/run-pass/str-concat.rs
@@ -16,5 +16,5 @@ pub fn main() {
     let b: String = "world".to_string();
     let s: String = format!("{}{}", a, b);
     println!("{}", s.clone());
-    assert_eq!(s.as_slice()[9], 'd' as u8);
+    assert_eq!(s.as_bytes()[9], 'd' as u8);
 }

--- a/src/test/run-pass/task-comm-16.rs
+++ b/src/test/run-pass/task-comm-16.rs
@@ -39,10 +39,10 @@ fn test_str() {
     let s0 = "test".to_string();
     tx.send(s0);
     let s1 = rx.recv();
-    assert_eq!(s1.as_slice()[0], 't' as u8);
-    assert_eq!(s1.as_slice()[1], 'e' as u8);
-    assert_eq!(s1.as_slice()[2], 's' as u8);
-    assert_eq!(s1.as_slice()[3], 't' as u8);
+    assert_eq!(s1.as_bytes()[0], 't' as u8);
+    assert_eq!(s1.as_bytes()[1], 'e' as u8);
+    assert_eq!(s1.as_bytes()[2], 's' as u8);
+    assert_eq!(s1.as_bytes()[3], 't' as u8);
 }
 
 #[deriving(Show)]

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -99,7 +99,7 @@ fn check_legs(arc: Arc<Vec<Box<Pet+Share+Send>>>) {
 fn check_names(arc: Arc<Vec<Box<Pet+Share+Send>>>) {
     for pet in arc.iter() {
         pet.name(|name| {
-            assert!(name[0] == 'a' as u8 && name[1] == 'l' as u8);
+            assert!(name.as_bytes()[0] == 'a' as u8 && name.as_bytes()[1] == 'l' as u8);
         })
     }
 }

--- a/src/test/run-pass/utf8.rs
+++ b/src/test/run-pass/utf8.rs
@@ -46,7 +46,7 @@ pub fn main() {
         for ab in a.as_slice().bytes() {
             println!("{}", i);
             println!("{}", ab);
-            let bb: u8 = b.as_slice()[i as uint];
+            let bb: u8 = b.as_bytes()[i as uint];
             println!("{}", bb);
             assert_eq!(ab, bb);
             i += 1;


### PR DESCRIPTION
Being able to index into the bytes of a string encourages
poor UTF-8 hygiene. To get a view of `&[u8]` from either
a `String` or `&str` slice, use the `as_bytes()` method.

Closes #12710.

[breaking-change]

If the diffstat is any indication this shouldn't have a huge impact but it will have some. Most changes in the `str` and `path` module. A lot of the existing usages were in tests where ascii is expected. There are a number of other legit uses where the characters are known to be ascii.
