### PR TITLE
librustc: Fix poorly formatted doc in feature_gate

### DIFF
--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -16,7 +16,7 @@
 //! enabled.
 //!
 //! Features are enabled in programs via the crate-level attributes of
-//! #![feature(...)] with a comma-separated list of features.
+//! `#![feature(...)]` with a comma-separated list of features.
 
 use middle::lint;
 


### PR DESCRIPTION
See http://static.rust-lang.org/doc/master/rustc/front/feature_gate/index.html for the problem this fixes.
