### PR TITLE
libsyntax: don't allow enum structs with no fields

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4116,6 +4116,11 @@ impl<'a> Parser<'a> {
                 };
                 spanned(lo, p.span.hi, struct_field_)
             });
+            if fields.len() == 0 {
+                self.fatal(format!("unit-like struct definition should be \
+                                    written as `struct {};`",
+                                   token::get_ident(class_name)).as_slice());
+            }
             self.expect(&token::SEMI);
         } else if self.eat(&token::SEMI) {
             // It's a unit-like struct.

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -37,7 +37,7 @@ static USED_STATIC: int = 0;
 static STATIC_USED_IN_ENUM_DISCRIMINANT: uint = 10;
 
 pub type typ = *UsedStruct4;
-pub struct PubStruct();
+pub struct PubStruct;
 struct PrivStruct; //~ ERROR: code is never used
 struct UsedStruct1 {
     #[allow(dead_code)]

--- a/src/test/compile-fail/struct-no-fields-enumlike.rs
+++ b/src/test/compile-fail/struct-no-fields-enumlike.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo(); //~ ERROR unit-like struct definition should be written as `struct Foo;`
+
+fn main() {}


### PR DESCRIPTION
Reject `struct Foo();` to fix #15095.
