### PR TITLE
Change /bin/env to /usr/bin/env in helper python script.

### DIFF
--- a/src/etc/2014-06-rewrite-bytes-macros.py
+++ b/src/etc/2014-06-rewrite-bytes-macros.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 #
 # Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at


### PR DESCRIPTION
/usr/bin/env appears to be more portable.
