### PR TITLE
test: readd TMPDIR to LD_LIBRARY_PATH for run-make

### DIFF
--- a/src/test/run-make/tools.mk
+++ b/src/test/run-make/tools.mk
@@ -1,9 +1,9 @@
 # These deliberately use `=` and not `:=` so that client makefiles can
 # augment HOST_RPATH_DIR / TARGET_RPATH_DIR.
 HOST_RPATH_ENV = \
-    $(LD_LIB_PATH_ENVVAR)="$(HOST_RPATH_DIR):$($(LD_LIB_PATH_ENVVAR))"
+    $(LD_LIB_PATH_ENVVAR)="$(TMPDIR):$(HOST_RPATH_DIR):$($(LD_LIB_PATH_ENVVAR))"
 TARGET_RPATH_ENV = \
-    $(LD_LIB_PATH_ENVVAR)="$(TARGET_RPATH_DIR):$($(LD_LIB_PATH_ENVVAR))"
+    $(LD_LIB_PATH_ENVVAR)="$(TMPDIR):$(TARGET_RPATH_DIR):$($(LD_LIB_PATH_ENVVAR))"
 
 RUSTC := $(HOST_RPATH_ENV) $(RUSTC) --out-dir $(TMPDIR) -L $(TMPDIR)
 CC := $(CC) -L $(TMPDIR)


### PR DESCRIPTION
It was accidentally removed in #15006 and that somehow got past the
build bots, causing `src/test/run-make/c-dynamic-dylib` to fail on at
least my linux system.

This resolves #15103 (thanks to @alexcrichton!).
