### PR TITLE
#[!resolve_unexported] => #[resolve_unexported] to fix pretty printing

### DIFF
--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -276,7 +276,7 @@ fn add_test_module(cx: &TestCtxt, m: &ast::Mod) -> ast::Mod {
 We're going to be building a module that looks more or less like:
 
 mod __test {
-  #![!resolve_unexported]
+  #![resolve_unexported]
   extern crate test (name = "test", vers = "...");
   fn main() {
     test::test_main_static(::os::args().as_slice(), tests)
@@ -336,7 +336,7 @@ fn mk_test_module(cx: &TestCtxt) -> Gc<ast::Item> {
     let item_ = ast::ItemMod(testmod);
 
     // This attribute tells resolve to let us call unexported functions
-    let resolve_unexported_str = InternedString::new("!resolve_unexported");
+    let resolve_unexported_str = InternedString::new("resolve_unexported");
     let resolve_unexported_attr =
         attr::mk_attr_inner(attr::mk_attr_id(),
                             attr::mk_word_item(resolve_unexported_str));

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -787,7 +787,7 @@ impl<'a> Visitor<()> for PrivacyVisitor<'a> {
     fn visit_item(&mut self, item: &ast::Item, _: ()) {
         // Do not check privacy inside items with the resolve_unexported
         // attribute. This is used for the test runner.
-        if attr::contains_name(item.attrs.as_slice(), "!resolve_unexported") {
+        if attr::contains_name(item.attrs.as_slice(), "resolve_unexported") {
             return;
         }
 


### PR DESCRIPTION
Without this change, we were unable to do:

% rustc --test --pretty expanded foo.rs > bar.rs
% rustc bar.s
