### PR TITLE
libsyntax: no inheritance with tuple/unit structs

### DIFF
--- a/src/test/compile-fail/inherit-struct1.rs
+++ b/src/test/compile-fail/inherit-struct1.rs
@@ -12,7 +12,7 @@
 #![feature(struct_inherit)]
 
 
-struct S6 : int; //~ ERROR super-struct could not be resolved
+struct S6 : int { x: () } //~ ERROR super-struct could not be resolved
 
 pub fn main() {
 }

--- a/src/test/compile-fail/inherit-struct10.rs
+++ b/src/test/compile-fail/inherit-struct10.rs
@@ -11,8 +11,7 @@
 // Test struct inheritance.
 #![feature(struct_inherit)]
 
-struct s9 { i: int }
-struct s10 : s9 { j: int } //~ ERROR struct inheritance is only allowed from virtual structs
+virtual struct UnitLikeVirtual;         //~ ERROR unit-like and tuple structs cannot be virtual
+virtual struct TupleStructVirtual(int); //~ ERROR unit-like and tuple structs cannot be virtual
 
-pub fn main() {
-}
+fn main() {}

--- a/src/test/compile-fail/inherit-struct11.rs
+++ b/src/test/compile-fail/inherit-struct11.rs
@@ -11,8 +11,7 @@
 // Test struct inheritance.
 #![feature(struct_inherit)]
 
-struct s9 { i: int }
-struct s10 : s9 { j: int } //~ ERROR struct inheritance is only allowed from virtual structs
+virtual struct RecordLikeVirtual { i: int }
+struct UnitLike : RecordLikeVirtual; //~ ERROR expected `{` after super-struct path but found `;`
 
-pub fn main() {
-}
+fn main() {}

--- a/src/test/compile-fail/inherit-struct12.rs
+++ b/src/test/compile-fail/inherit-struct12.rs
@@ -11,8 +11,7 @@
 // Test struct inheritance.
 #![feature(struct_inherit)]
 
-struct s9 { i: int }
-struct s10 : s9 { j: int } //~ ERROR struct inheritance is only allowed from virtual structs
+virtual struct RecordLikeVirtual { i: int }
+struct TupleStruct(int) : RecordLikeVirtual; //~ ERROR expected `;` but found `:`
 
-pub fn main() {
-}
+fn main() {}

--- a/src/test/compile-fail/inherit-struct13.rs
+++ b/src/test/compile-fail/inherit-struct13.rs
@@ -11,8 +11,8 @@
 // Test struct inheritance.
 #![feature(struct_inherit)]
 
-struct s9 { i: int }
-struct s10 : s9 { j: int } //~ ERROR struct inheritance is only allowed from virtual structs
+virtual struct RecordLikeVirtual { i: int }
+struct TupleStruct : RecordLikeVirtual (int);
+//~^ ERROR expected `{` after super-struct path but found `(`
 
-pub fn main() {
-}
+fn main() {}

--- a/src/test/compile-fail/inherit-struct5.rs
+++ b/src/test/compile-fail/inherit-struct5.rs
@@ -14,7 +14,7 @@
 // aux-build:inherit_struct_lib.rs
 extern crate inherit_struct_lib;
 
-struct S3 : inherit_struct_lib::S1; //~ ERROR super-struct is defined in a different crate
+struct S3 : inherit_struct_lib::S1 { x: () } //~ ERROR super-struct is defined in a different crate
 
 pub fn main() {
 }


### PR DESCRIPTION
Stops parsing inheritance with tuple structs and unit-like structs to fix #15096.
