### PR TITLE
Allow trailing comma in `concat!`

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -593,11 +593,14 @@ pub fn get_exprs_from_tts(cx: &mut ExtCtxt,
                                               .collect());
     let mut es = Vec::new();
     while p.token != token::EOF {
-        if es.len() != 0 && !p.eat(&token::COMMA) {
+        es.push(cx.expand_expr(p.parse_expr()));
+        if p.eat(&token::COMMA) {
+            continue;
+        }
+        if p.token != token::EOF {
             cx.span_err(sp, "expected token: `,`");
             return None;
         }
-        es.push(cx.expand_expr(p.parse_expr()));
     }
     Some(es)
 }

--- a/src/test/run-pass/concat.rs
+++ b/src/test/run-pass/concat.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,8 @@
 pub fn main() {
     assert_eq!(format!(concat!("foo", "bar", "{}"), "baz"), "foobarbaz".to_string());
     assert_eq!(format!(concat!()), "".to_string());
+    // check trailing comma is allowed in concat
+    assert_eq!(concat!("qux", "quux",).to_string(), "quxquux".to_string());
 
     assert_eq!(
         concat!(1, 2i, 3u, 4f32, 4.0, 'a', true, ()),


### PR DESCRIPTION
(And in other extensions implemented with `get_exprs_from_tts` function).
