### PR TITLE
Add tests for #12470 and #14285

### DIFF
--- a/src/test/compile-fail/issue-14285.rs
+++ b/src/test/compile-fail/issue-14285.rs
@@ -1,0 +1,25 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {}
+
+struct A;
+
+impl Foo for A {}
+
+struct B<'a>(&'a Foo);
+
+fn foo<'a>(a: &Foo) -> B<'a> {
+    B(a)    //~ ERROR cannot infer an appropriate lifetime
+}
+
+fn main() {
+    let _test = foo(&A);
+}

--- a/src/test/compile-fail/isuue-12470.rs
+++ b/src/test/compile-fail/isuue-12470.rs
@@ -1,0 +1,42 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait X {
+    fn get_i(&self) -> int;
+}
+
+
+struct B {
+    i: int
+}
+
+impl X for B {
+    fn get_i(&self) -> int {
+        self.i
+    }
+}
+
+struct A<'a> {
+    p: &'a X
+}
+
+fn make_a<'a>(p: &'a X) -> A<'a> {
+    A { p: p }
+}
+
+fn make_make_a() -> A {
+    let b: Box<B> = box B {i:1};
+    let bb: &B = b;    //~ ERROR does not live long enough
+    make_a(bb)
+}
+
+fn main() {
+    let _a = make_make_a();
+}


### PR DESCRIPTION
The #14869 removed `TraitStore` from `ty_trait` and represented trait
reference as regular `ty_rptr`. An old bug of the missing constraint
upon lifetime parameter of trait reference then is fixed as a side
effect. Adds tests for affected bugs and closes them.

Closes #12470.
Closes #14285.
