### PR TITLE
Add the Guide, add warning to tutorial.

### DIFF
--- a/configure
+++ b/configure
@@ -869,6 +869,7 @@ do
     make_dir $h/test/debuginfo-lldb
     make_dir $h/test/codegen
     make_dir $h/test/doc-tutorial
+    make_dir $h/test/doc-guide
     make_dir $h/test/doc-guide-ffi
     make_dir $h/test/doc-guide-runtime
     make_dir $h/test/doc-guide-macros

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -26,7 +26,7 @@
 # L10N_LANGS are the languages for which the docs have been
 # translated.
 ######################################################################
-DOCS := index intro tutorial guide-ffi guide-macros guide-lifetimes \
+DOCS := index intro tutorial guide guide-ffi guide-macros guide-lifetimes \
 	guide-tasks guide-container guide-pointers guide-testing \
 	guide-runtime complement-bugreport complement-cheatsheet \
 	complement-lang-faq complement-design-faq complement-project-faq rust \

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1,0 +1,10 @@
+% The Rust Guide
+
+<div style="border: 2px solid red; padding:5px;">
+This guide is a work in progress. Until it is ready, we highly recommend that
+you read the <a href="tutorial.html">Tutorial</a> instead. This work-in-progress Guide is being
+displayed here in line with Rust's open development policy. Please open any
+issues you find as usual.
+</div>
+
+Coming soon. :)

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1,5 +1,12 @@
 % The Rust Language Tutorial
 
+<div style="border: 2px solid red; padding:5px;">
+The tutorial is undergoing a complete re-write as <a href="guide.html">the Guide</a>.
+Until it's ready, this tutorial is the right place to come to start learning
+Rust.  Please submit improvements as pull requests, but understand that
+eventually it will be going away.
+</div>
+
 # Introduction
 
 Rust is a programming language with a focus on type safety, memory


### PR DESCRIPTION
In line with what @brson, @cmr, @nikomatsakis and I discussed this morning, my
redux of the tutorial will be implemented as the Guide. This way, I can work in
small iterations, rather than dropping a huge PR, which is hard to review.  In
addition, the community can observe my work as I'm doing it.

This adds a note in line with [this comment](http://www.reddit.com/r/rust/comments/28bew8/rusts_documentation_is_about_to_drastically/ci9c98k) that clarifies the state
of the tutorial, and the community's involvement with it.

Here's a screenshot of the warning: 

![warning](https://cloud.githubusercontent.com/assets/27786/3364870/1e3905fc-fb25-11e3-992b-9adcc41b4854.png)
