### PR TITLE
Xfailed tests for hygiene, etc.

### DIFF
--- a/src/test/run-pass/issue-9737.rs
+++ b/src/test/run-pass/issue-9737.rs
@@ -1,0 +1,20 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-test #9737
+
+#![feature(macro_rules)]
+
+macro_rules! f((v: $x:expr) => ( println!("{:?}", $x) ))
+
+fn main () {
+    let v = 5;
+    f!(v: 3);
+}

--- a/src/test/run-pass/lambda-var-hygiene.rs
+++ b/src/test/run-pass/lambda-var-hygiene.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-test #9383
+
+#![feature(macro_rules)]
+
+// shouldn't affect evaluation of $ex:
+macro_rules! bad_macro (($ex:expr) => ({(|_x| { $ex }) (9) }))
+
+fn takes_x(_x : int) {
+    assert_eq!(bad_macro!(_x),8);
+}
+fn main() {
+    takes_x(8);
+}

--- a/src/test/run-pass/match-var-hygiene.rs
+++ b/src/test/run-pass/match-var-hygiene.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-test #9384
+
+#![feature(macro_rules)]
+
+// shouldn't affect evaluation of $ex.
+macro_rules! bad_macro (($ex:expr) => (
+    {match 9 {_x => $ex}}
+))
+
+fn main() {
+    match 8 {
+        _x => assert_eq!(bad_macro!(_x),8)
+    }
+}


### PR DESCRIPTION
Adding three tests. Two are for lambda-var and match-var hygiene, one is for issue 9737. All are currently ignore-test.
