### PR TITLE
core: Add stability attributes to Clone

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -110,6 +110,7 @@ impl<T: Share + Send> Arc<T> {
     }
 }
 
+#[unstable]
 impl<T: Share + Send> Clone for Arc<T> {
     /// Duplicate an atomically reference counted wrapper.
     ///
@@ -236,6 +237,7 @@ impl<T: Share + Send> Weak<T> {
     }
 }
 
+#[unstable]
 impl<T: Share + Send> Clone for Weak<T> {
     #[inline]
     fn clone(&self) -> Weak<T> {

--- a/src/liballoc/owned.rs
+++ b/src/liballoc/owned.rs
@@ -42,6 +42,7 @@ impl<T: Default> Default for Box<T> {
     fn default() -> Box<T> { box Default::default() }
 }
 
+#[unstable]
 impl<T: Clone> Clone for Box<T> {
     /// Return a copy of the owned box.
     #[inline]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -143,6 +143,7 @@ impl<T> Drop for Rc<T> {
     }
 }
 
+#[unstable]
 impl<T> Clone for Rc<T> {
     #[inline]
     fn clone(&self) -> Rc<T> {
@@ -224,6 +225,7 @@ impl<T> Drop for Weak<T> {
     }
 }
 
+#[unstable]
 impl<T> Clone for Weak<T> {
     #[inline]
     fn clone(&self) -> Weak<T> {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -316,6 +316,7 @@ impl<T: Clone> Vec<T> {
     }
 }
 
+#[unstable]
 impl<T:Clone> Clone for Vec<T> {
     fn clone(&self) -> Vec<T> {
         let len = self.len;

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -192,6 +192,7 @@ impl<T:Copy> Cell<T> {
     }
 }
 
+#[unstable]
 impl<T:Copy> Clone for Cell<T> {
     fn clone(&self) -> Cell<T> {
         Cell::new(self.get())
@@ -298,6 +299,7 @@ impl<T> RefCell<T> {
     }
 }
 
+#[unstable]
 impl<T: Clone> Clone for RefCell<T> {
     fn clone(&self) -> RefCell<T> {
         RefCell::new(self.borrow().clone())

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -21,6 +21,8 @@ the `clone` method.
 
 */
 
+#![unstable]
+
 /// A common trait for cloning an object.
 pub trait Clone {
     /// Returns a copy of the value. The contents of owned pointers
@@ -34,6 +36,7 @@ pub trait Clone {
     /// but can be overridden to reuse the resources of `a` to avoid unnecessary
     /// allocations.
     #[inline(always)]
+    #[experimental = "this function is mostly unused"]
     fn clone_from(&mut self, source: &Self) {
         *self = source.clone()
     }
@@ -88,6 +91,7 @@ clone_impl!(char)
 
 macro_rules! extern_fn_clone(
     ($($A:ident),*) => (
+        #[experimental = "this may not be sufficient for fns with region parameters"]
         impl<$($A,)* ReturnType> Clone for extern "Rust" fn($($A),*) -> ReturnType {
             /// Return a copy of a function pointer
             #[inline]

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -104,6 +104,7 @@ macro_rules! tuple_impls {
                 )+
             }
 
+            #[unstable]
             impl<$($T:Clone),+> Clone for ($($T,)+) {
                 fn clone(&self) -> ($($T,)+) {
                     ($(self.$refN().clone(),)+)

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -37,6 +37,7 @@ pub struct Gc<T> {
     marker: marker::NoSend,
 }
 
+#[unstable]
 impl<T> Clone for Gc<T> {
     /// Clone the pointer only
     #[inline]


### PR DESCRIPTION
The following are tagged 'unstable'
- core::clone
- Clone
- Clone::clone
- impl Clone for Arc
- impl Clone for arc::Weak
- impl Clone for Rc
- impl Clone for rc::Weak
- impl Clone for Vec
- impl Clone for Cell
- impl Clone for RefCell
- impl Clone for small tuples

The following are tagged 'experimental'
- Clone::clone_from - may not provide enough utility
- impls for various extern "Rust" fns - may not handle lifetimes correctly

See https://github.com/rust-lang/rust/wiki/Meeting-API-review-2014-06-23#clone
