### PR TITLE
std: Add stability attributes to primitive numeric modules

### DIFF
--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
+#![unstable]
 #![doc(primitive = "i16")]
 
 int_module!(i16, 16)

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 32-bits integers (`i32` type)
 
+#![unstable]
 #![doc(primitive = "i32")]
 
 int_module!(i32, 32)

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 64-bits integers (`i64` type)
 
+#![unstable]
 #![doc(primitive = "i64")]
 
 int_module!(i64, 64)

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 8-bits integers (`i8` type)
 
+#![unstable]
 #![doc(primitive = "i8")]
 
 int_module!(i8, 8)

--- a/src/libcore/num/int.rs
+++ b/src/libcore/num/int.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for architecture-sized signed integers (`int` type)
 
+#![unstable]
 #![doc(primitive = "int")]
 
 #[cfg(target_word_size = "32")] int_module!(int, 32)

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -15,17 +15,21 @@ macro_rules! int_module (($T:ty, $bits:expr) => (
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
+#[unstable]
 pub static BITS : uint = $bits;
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
+#[unstable]
 pub static BYTES : uint = ($bits / 8);
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::min_value` function.
+#[unstable]
 pub static MIN: $T = (-1 as $T) << (BITS - 1);
 // FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::max_value` function.
+#[unstable]
 pub static MAX: $T = !MIN;
 
 #[cfg(test)]

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
+#![unstable]
 #![doc(primitive = "u16")]
 
 uint_module!(u16, i16, 16)

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
+#![unstable]
 #![doc(primitive = "u32")]
 
 uint_module!(u32, i32, 32)

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
+#![unstable]
 #![doc(primitive = "u64")]
 
 uint_module!(u64, i64, 64)

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
+#![unstable]
 #![doc(primitive = "u8")]
 
 uint_module!(u8, i8, 8)

--- a/src/libcore/num/uint.rs
+++ b/src/libcore/num/uint.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
+#![unstable]
 #![doc(primitive = "uint")]
 
 uint_module!(uint, int, ::int::BITS)

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -13,10 +13,14 @@
 
 macro_rules! uint_module (($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
+#[unstable]
 pub static BITS : uint = $bits;
+#[unstable]
 pub static BYTES : uint = ($bits / 8);
 
+#[unstable]
 pub static MIN: $T = 0 as $T;
+#[unstable]
 pub static MAX: $T = 0 as $T - 1 as $T;
 
 #[cfg(test)]

--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -54,6 +54,8 @@
        html_root_url = "http://doc.rust-lang.org/",
        html_playground_url = "http://play.rust-lang.org/")]
 
+#![allow(deprecated)] // from_str_radix
+
 extern crate rand;
 
 pub use bigint::{BigInt, BigUint};

--- a/src/libstd/from_str.rs
+++ b/src/libstd/from_str.rs
@@ -16,6 +16,7 @@ use str::StrAllocating;
 
 /// A trait to abstract the idea of creating a new instance of a type from a
 /// string.
+#[experimental = "might need to return Result"]
 pub trait FromStr {
     /// Parses a string `s` to return an optional value of this type. If the
     /// string is ill-formatted, the None is returned.

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
+#![unstable]
 #![doc(primitive = "i16")]
 
 use from_str::FromStr;

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 32-bits integers (`i32` type)
 
+#![unstable]
 #![doc(primitive = "i32")]
 
 use from_str::FromStr;

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 64-bits integers (`i64` type)
 
+#![unstable]
 #![doc(primitive = "i64")]
 
 use from_str::FromStr;

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for signed 8-bits integers (`i8` type)
 
+#![unstable]
 #![doc(primitive = "i8")]
 
 use from_str::FromStr;

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for architecture-sized signed integers (`int` type)
 
+#![unstable]
 #![doc(primitive = "int")]
 
 use from_str::FromStr;

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -26,11 +26,13 @@ macro_rules! int_module (($T:ty) => (
 /// assert!(num == Some(123456789));
 /// ```
 #[inline]
+#[experimental = "might need to return Result"]
 pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
     strconv::from_str_bytes_common(buf, radix, true, false, false,
                                strconv::ExpNone, false, false)
 }
 
+#[experimental = "might need to return Result"]
 impl FromStr for $T {
     #[inline]
     fn from_str(s: &str) -> Option<$T> {
@@ -39,6 +41,7 @@ impl FromStr for $T {
     }
 }
 
+#[experimental = "might need to return Result"]
 impl FromStrRadix for $T {
     #[inline]
     fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
@@ -61,6 +64,7 @@ impl FromStrRadix for $T {
 /// });
 /// ```
 #[inline]
+#[deprecated = "just use .to_string(), or a BufWriter with write! if you mustn't allocate"]
 pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
     use io::{Writer, Seek};
     // The radix can be as low as 2, so we need at least 64 characters for a
@@ -74,6 +78,7 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
     f(buf.slice(0, amt))
 }
 
+#[deprecated = "use fmt::radix"]
 impl ToStrRadix for $T {
     /// Convert to a string in a given base.
     #[inline]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -111,16 +111,19 @@ pub trait FloatMath: Float {
 }
 
 /// A generic trait for converting a value to a string with a radix (base)
+#[deprecated = "use fmt::radix"]
 pub trait ToStrRadix {
     fn to_str_radix(&self, radix: uint) -> String;
 }
 
 /// A generic trait for converting a string with a radix (base) to a value
+#[experimental = "might need to return Result"]
 pub trait FromStrRadix {
     fn from_str_radix(str: &str, radix: uint) -> Option<Self>;
 }
 
 /// A utility function that just calls FromStrRadix::from_str_radix.
+#[experimental = "might need to return Result"]
 pub fn from_str_radix<T: FromStrRadix>(str: &str, radix: uint) -> Option<T> {
     FromStrRadix::from_str_radix(str, radix)
 }

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
+#![unstable]
 #![doc(primitive = "u16")]
 
 use from_str::FromStr;

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
+#![unstable]
 #![doc(primitive = "u32")]
 
 use from_str::FromStr;

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
+#![unstable]
 #![doc(primitive = "u64")]
 
 use from_str::FromStr;

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
+#![unstable]
 #![doc(primitive = "u8")]
 
 use from_str::FromStr;

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
+#![unstable]
 #![doc(primitive = "uint")]
 
 use from_str::FromStr;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -27,11 +27,13 @@ macro_rules! uint_module (($T:ty) => (
 /// assert!(num == Some(123456789));
 /// ```
 #[inline]
+#[experimental = "might need to return Result"]
 pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
     strconv::from_str_bytes_common(buf, radix, false, false, false,
                                    strconv::ExpNone, false, false)
 }
 
+#[experimental = "might need to return Result"]
 impl FromStr for $T {
     #[inline]
     fn from_str(s: &str) -> Option<$T> {
@@ -40,6 +42,7 @@ impl FromStr for $T {
     }
 }
 
+#[experimental = "might need to return Result"]
 impl FromStrRadix for $T {
     #[inline]
     fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
@@ -62,6 +65,7 @@ impl FromStrRadix for $T {
 /// });
 /// ```
 #[inline]
+#[deprecated = "just use .to_string(), or a BufWriter with write! if you mustn't allocate"]
 pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
     use io::{Writer, Seek};
     // The radix can be as low as 2, so we need at least 64 characters for a
@@ -75,6 +79,7 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
     f(buf.slice(0, amt))
 }
 
+#[deprecated = "use fmt::radix"]
 impl ToStrRadix for $T {
     /// Convert to a string in a given base.
     #[inline]


### PR DESCRIPTION
The following are unstable:
- core::int, i8, i16, i32, i64
- core::uint, u8, u16, u32, u64
- core::int::{BITS, BYTES, MIN, MAX}, etc.
- std::int, i8, i16, i32, i64
- std::uint, u8, u16, u32, u64

The following are experimental:
- std::from_str::FromStr and impls - may need to return Result instead of Option
- std::int::parse_bytes, etc. - ditto
- std::num::FromStrRadix and impls - ditto
- std::num::from_str_radix - ditto

The following are deprecated:
- std::num::ToStrRadix and impls - Wrapper around fmt::radix. Wrong name (Str vs String)

See https://github.com/rust-lang/rust/wiki/Meeting-API-review-2014-06-23#uint
