### PR TITLE
librustc: Check function argument patterns for legality of by-move

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -734,6 +734,7 @@ fn check_fn(cx: &mut MatchCheckCtxt,
             },
             None => ()
         }
+        check_legality_of_move_bindings(cx, false, [input.pat]);
     }
 }
 

--- a/src/test/compile-fail/bind-by-move-no-sub-bindings-fun-args.rs
+++ b/src/test/compile-fail/bind-by-move-no-sub-bindings-fun-args.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #12534.
+
+struct A(Box<uint>);
+
+fn f(a @ A(u): A) -> Box<uint> {    //~ ERROR cannot bind by-move with sub-bindings
+    drop(a);
+    u
+}
+
+fn main() {}
+


### PR DESCRIPTION
bindings.

This will break code that incorrectly did things like:

```
fn f(a @ box b: Box<String>) {}
```

Fix such code to not rely on undefined behavior.

Closes #12534.

[breaking-change]

r? @alexcrichton
