### PR TITLE
rustc: update the unnecessary parens lint for struct literals.

### DIFF
--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -299,7 +299,7 @@ pub fn start(argc: int, argv: **u8,
     let mut ret = None;
     simple::task().run(|| {
         ret = Some(run(event_loop_factory, main.take_unwrap()));
-    });
+    }).destroy();
     // unsafe is ok b/c we're sure that the runtime is gone
     unsafe { rt::cleanup() }
     ret.unwrap()

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -110,7 +110,7 @@ extern fn bootstrap_green_task(task: uint, code: *(), env: *()) -> ! {
     // requested. This is the "try/catch" block for this green task and
     // is the wrapper for *all* code run in the task.
     let mut start = Some(start);
-    let task = task.swap().run(|| start.take_unwrap()());
+    let task = task.swap().run(|| start.take_unwrap()()).destroy();
 
     // Once the function has exited, it's time to run the termination
     // routine. This means we need to context switch one more time but
@@ -120,7 +120,7 @@ extern fn bootstrap_green_task(task: uint, code: *(), env: *()) -> ! {
     // this we could add a `terminate` function to the `Runtime` trait
     // in libstd, but that seems less appropriate since the coversion
     // method exists.
-    GreenTask::convert(task).terminate()
+    GreenTask::convert(task).terminate();
 }
 
 impl GreenTask {

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -533,6 +533,10 @@ fn spawn_process_os(cfg: ProcessConfig,
 
     let dirp = cfg.cwd.map(|c| c.with_ref(|p| p)).unwrap_or(ptr::null());
 
+    let cfg = unsafe {
+        mem::transmute::<ProcessConfig,ProcessConfig<'static>>(cfg)
+    };
+
     with_envp(cfg.env, proc(envp) {
         with_argv(cfg.program, cfg.args, proc(argv) unsafe {
             let (mut input, mut output) = try!(pipe());

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -134,13 +134,12 @@ pub fn start(argc: int, argv: **u8, main: proc()) -> int {
     let mut main = Some(main);
     let mut task = task::new((my_stack_bottom, my_stack_top));
     task.name = Some(str::Slice("<main>"));
-    let t = task.run(|| {
+    drop(task.run(|| {
         unsafe {
             rt::stack::record_stack_bounds(my_stack_bottom, my_stack_top);
         }
         exit_code = Some(run(main.take_unwrap()));
-    });
-    drop(t);
+    }).destroy());
     unsafe { rt::cleanup(); }
     // If the exit code wasn't set, then the task block must have failed.
     return exit_code.unwrap_or(rt::DEFAULT_ERROR_CODE);

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -92,8 +92,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc():Send) {
         let mut f = Some(f);
         let mut task = task;
         task.put_runtime(ops);
-        let t = task.run(|| { f.take_unwrap()() });
-        drop(t);
+        drop(task.run(|| { f.take_unwrap()() }).destroy());
         bookkeeping::decrement();
     })
 }

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -198,8 +198,14 @@ fn with_appropriate_checker(cx: &Context,
     let fty = ty::node_id_to_type(cx.tcx, id);
     match ty::get(fty).sty {
         ty::ty_closure(box ty::ClosureTy {
-            store: ty::UniqTraitStore, bounds, ..
-        }) => b(|cx, fv| check_for_uniq(cx, fv, bounds)),
+            store: ty::UniqTraitStore,
+            bounds: mut bounds, ..
+        }) => {
+            // Procs can't close over non-static references!
+            bounds.add(ty::BoundStatic);
+
+            b(|cx, fv| check_for_uniq(cx, fv, bounds))
+        }
 
         ty::ty_closure(box ty::ClosureTy {
             store: ty::RegionTraitStore(region, _), bounds, ..

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -78,7 +78,6 @@ use uw = libunwind;
 
 pub struct Unwinder {
     unwinding: bool,
-    cause: Option<Box<Any + Send>>
 }
 
 struct Exception {
@@ -107,24 +106,11 @@ impl Unwinder {
     pub fn new() -> Unwinder {
         Unwinder {
             unwinding: false,
-            cause: None,
         }
     }
 
     pub fn unwinding(&self) -> bool {
         self.unwinding
-    }
-
-    pub fn try(&mut self, f: ||) {
-        self.cause = unsafe { try(f) }.err();
-    }
-
-    pub fn result(&mut self) -> Result {
-        if self.unwinding {
-            Err(self.cause.take().unwrap())
-        } else {
-            Ok(())
-        }
     }
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -83,7 +83,7 @@ Some examples of obvious things you might want to do
 
     ```rust
     # #![allow(unused_must_use)]
-    use std::io::net::tcp::TcpStream;
+    use std::io::TcpStream;
 
     # // connection doesn't fail if a server is running on 8080
     # // locally, we still want to be type checking this code, so lets

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -41,7 +41,7 @@ use rt::rtio;
 ///
 /// ```no_run
 /// # #![allow(unused_must_use)]
-/// use std::io::net::tcp::TcpStream;
+/// use std::io::TcpStream;
 ///
 /// let mut stream = TcpStream::connect("127.0.0.1", 34254);
 ///
@@ -162,7 +162,7 @@ impl TcpStream {
     /// ```no_run
     /// # #![allow(unused_must_use)]
     /// use std::io::timer;
-    /// use std::io::net::tcp::TcpStream;
+    /// use std::io::TcpStream;
     ///
     /// let mut stream = TcpStream::connect("127.0.0.1", 34254).unwrap();
     /// let stream2 = stream.clone();
@@ -406,7 +406,7 @@ impl TcpAcceptor {
     ///
     /// ```no_run
     /// # #![allow(experimental)]
-    /// use std::io::net::tcp::TcpListener;
+    /// use std::io::TcpListener;
     /// use std::io::{Listener, Acceptor, TimedOut};
     ///
     /// let mut a = TcpListener::bind("127.0.0.1", 8482).listen().unwrap();

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -476,8 +476,8 @@ impl Process {
     ///
     /// ```no_run
     /// # #![allow(experimental)]
-    /// use std::io::process::{Command, ProcessExit};
-    /// use std::io::IoResult;
+    /// use std::io::{Command, IoResult};
+    /// use std::io::process::ProcessExit;
     ///
     /// fn run_gracefully(prog: &str) -> IoResult<ProcessExit> {
     ///     let mut p = try!(Command::new("long-running-process").spawn());

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -110,7 +110,7 @@ impl Timer {
     /// # Example
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// let mut timer = Timer::new().unwrap();
     /// let ten_milliseconds = timer.oneshot(10);
@@ -122,7 +122,7 @@ impl Timer {
     /// ```
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// // Incorrect, method chaining-style:
     /// let mut five_ms = Timer::new().unwrap().oneshot(5);
@@ -152,7 +152,7 @@ impl Timer {
     /// # Example
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// let mut timer = Timer::new().unwrap();
     /// let ten_milliseconds = timer.periodic(10);
@@ -170,7 +170,7 @@ impl Timer {
     /// ```
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// // Incorrect, method chaining-style.
     /// let mut five_ms = Timer::new().unwrap().periodic(5);

--- a/src/test/compile-fail/lint-unnecessary-parens.rs
+++ b/src/test/compile-fail/lint-unnecessary-parens.rs
@@ -10,18 +10,41 @@
 
 #![deny(unnecessary_parens)]
 
+#[deriving(Eq, PartialEq)]
+struct X { y: bool }
+impl X {
+    fn foo(&self) -> bool { self.y }
+}
+
 fn foo() -> int {
     return (1); //~ ERROR unnecessary parentheses around `return` value
+}
+fn bar() -> X {
+    return (X { y: true }); //~ ERROR unnecessary parentheses around `return` value
 }
 
 fn main() {
     foo();
+    bar();
 
     if (true) {} //~ ERROR unnecessary parentheses around `if` condition
     while (true) {} //~ ERROR unnecessary parentheses around `while` condition
     match (true) { //~ ERROR unnecessary parentheses around `match` head expression
         _ => {}
     }
+    let v = X { y: false };
+    // struct lits needs parens, so these shouldn't warn.
+    if (v == X { y: true }) {}
+    if (X { y: true } == v) {}
+    if (X { y: false }.y) {}
+
+    while (X { y: false }.foo()) {}
+    while (true | X { y: false }.y) {}
+
+    match (X { y: false }) {
+        _ => {}
+    }
+
     let mut _a = (0); //~ ERROR unnecessary parentheses around assigned value
     _a = (0); //~ ERROR unnecessary parentheses around assigned value
     _a += (1); //~ ERROR unnecessary parentheses around assigned value

--- a/src/test/compile-fail/proc-static-bound.rs
+++ b/src/test/compile-fail/proc-static-bound.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut x = Some(1);
+    let mut p: proc(&mut Option<int>) = proc(_) {};
+    match x {
+        Some(ref y) => {
+            p = proc(z: &mut Option<int>) {
+                *z = None;
+                let _ = y;
+                //~^ ERROR cannot capture variable of type `&int`, which does not fulfill `'static`
+            };
+        }
+        None => {}
+    }
+    p(&mut x);
+}
+

--- a/src/test/run-pass/fail-during-tld-destroy.rs
+++ b/src/test/run-pass/fail-during-tld-destroy.rs
@@ -1,0 +1,53 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::task;
+use std::gc::{GC, Gc};
+use std::cell::RefCell;
+
+static mut DROPS: uint = 0;
+
+struct Foo(bool);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        let Foo(fail) = *self;
+        unsafe { DROPS += 1; }
+        if fail { fail!() }
+    }
+}
+
+fn tld_fail(fail: bool) {
+    local_data_key!(foo: Foo);
+    foo.replace(Some(Foo(fail)));
+}
+
+fn gc_fail(fail: bool) {
+    struct A {
+        inner: RefCell<Option<Gc<A>>>,
+        other: Foo,
+    }
+    let a = box(GC) A {
+        inner: RefCell::new(None),
+        other: Foo(fail),
+    };
+    *a.inner.borrow_mut() = Some(a.clone());
+}
+
+fn main() {
+    let _ = task::try(proc() {
+        tld_fail(true);
+        gc_fail(false);
+    });
+
+    unsafe {
+        assert_eq!(DROPS, 2);
+    }
+}
+


### PR DESCRIPTION
rustc: update the unnecessary parens lint for struct literals.

Things like `match X { x: 1 } { ... }` now need to be written with
parentheses, so the lint should avoid warning in cases like that.
