### PR TITLE
native: Search the child's PATH on win32

### DIFF
--- a/src/test/run-pass/issue-15149.rs
+++ b/src/test/run-pass/issue-15149.rs
@@ -1,0 +1,56 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(phase)]
+extern crate native;
+#[phase(plugin)]
+extern crate green;
+
+use native::NativeTaskBuilder;
+use std::io::{TempDir, Command, fs};
+use std::os;
+use std::task::TaskBuilder;
+
+// FIXME(#15149) libgreen still needs to be update. There is an open PR for it
+//               but it is not yet merged.
+// green_start!(main)
+
+fn main() {
+    // If we're the child, make sure we were invoked correctly
+    let args = os::args();
+    if args.len() > 1 && args.get(1).as_slice() == "child" {
+        return assert_eq!(args.get(0).as_slice(), "mytest");
+    }
+
+    test();
+    let (tx, rx) = channel();
+    TaskBuilder::new().native().spawn(proc() {
+        tx.send(test());
+    });
+    rx.recv();
+}
+
+fn test() {
+    // If we're the parent, copy our own binary to a tempr directory, and then
+    // make it executable.
+    let dir = TempDir::new("mytest").unwrap();
+    let me = os::self_exe_name().unwrap();
+    let dest = dir.path().join(format!("mytest{}", os::consts::EXE_SUFFIX));
+    fs::copy(&me, &dest).unwrap();
+
+    // Append the temp directory to our own PATH.
+    let mut path = os::split_paths(os::getenv("PATH").unwrap_or(String::new()));
+    path.push(dir.path().clone());
+    let path = os::join_paths(path.as_slice()).unwrap();
+
+    Command::new("mytest").env("PATH", path.as_slice())
+                          .arg("child")
+                          .spawn().unwrap();
+}


### PR DESCRIPTION
In order to have the spawning semantics be the same for unix/windows, the
child's PATH environment variable needs to be searched rather than the parent's
environment variable.

If the child is inheriting the parent's PATH, then no action need be taken as
windows will do the heavy lifting. If the child specifies its own PATH, then it
is searched beforehand for the target program and the result is favored if a hit
is found.

cc #15149, but does not close the issue because libgreen still needs to be
updated.
