### PR TITLE
rustc: Don't register syntax crates twice

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -448,7 +448,7 @@ impl<'a> PluginMetadataReader<'a> {
             macros: macros.move_iter().map(|x| x.to_string()).collect(),
             registrar_symbol: registrar,
         };
-        if should_link {
+        if should_link && existing_match(&self.env, &info.crate_id, None).is_none() {
             // register crate now to avoid double-reading metadata
             register_crate(&mut self.env, &None, info.ident.as_slice(),
                            &info.crate_id, krate.span, library);

--- a/src/test/run-pass/issue-14330.rs
+++ b/src/test/run-pass/issue-14330.rs
@@ -1,0 +1,15 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(phase)]
+
+#[phase(plugin, link)] extern crate std;
+
+fn main() {}


### PR DESCRIPTION
We only need to register them once, and once they're registered twice warnings
will start being spewed or worse may happen!

Closes #14330
