### PR TITLE
13570 add see below to a reference to a new concept 2

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -474,7 +474,7 @@ often convenient to use a block expression for each case, in which case
 the commas are optional as shown below. Literals are valid patterns and
 match only their own value. A single arm may match multiple different
 patterns by combining them with the pipe operator (`|`), so long as every
-pattern binds the same set of variables. Ranges of numeric literal
+pattern binds the same set of variables (see "destructuring" below). Ranges of numeric literal
 patterns can be expressed with two dots, as in `M..N`. The underscore
 (`_`) is a wildcard pattern that matches any single value. (`..`) is a
 different wildcard that can match one or more fields in an `enum` variant.

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -473,11 +473,12 @@ by an *action* (expression). Each case is separated by commas. It is
 often convenient to use a block expression for each case, in which case
 the commas are optional as shown below. Literals are valid patterns and
 match only their own value. A single arm may match multiple different
-patterns by combining them with the pipe operator (`|`), so long as every
-pattern binds the same set of variables (see "destructuring" below). Ranges of numeric literal
-patterns can be expressed with two dots, as in `M..N`. The underscore
-(`_`) is a wildcard pattern that matches any single value. (`..`) is a
-different wildcard that can match one or more fields in an `enum` variant.
+patterns by combining them with the pipe operator (`|`), so long as
+every pattern binds the same set of variables (see "destructuring"
+below). Ranges of numeric literal patterns can be expressed with two
+dots, as in `M..N`. The underscore (`_`) is a wildcard pattern that
+matches any single value. (`..`) is a different wildcard that can match
+one or more fields in an `enum` variant.
 
 ~~~
 # let my_number = 1;


### PR DESCRIPTION
This is the same patch as submitted to https://github.com/rust-lang/rust/issues/13570 and https://github.com/rust-lang/rust/pull/14124, but with @pnkfelix's comment (https://github.com/rust-lang/rust/pull/14124#issuecomment-42797536) addressed, and with reflow as a separate commit. I'm submitting it in case @steveklabnik hasn't yet merged a rewrite of the tutorial (https://github.com/rust-lang/rust/issues/13570#issuecomment-46864789), in which case this patch might as well be merged into the old tutorial.
