### PR TITLE
librustc: Ensure that proc upvars have static lifetime.

### DIFF
--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -533,6 +533,10 @@ fn spawn_process_os(cfg: ProcessConfig,
 
     let dirp = cfg.cwd.map(|c| c.with_ref(|p| p)).unwrap_or(ptr::null());
 
+    let cfg = unsafe {
+        mem::transmute::<ProcessConfig,ProcessConfig<'static>>(cfg)
+    };
+
     with_envp(cfg.env, proc(envp) {
         with_argv(cfg.program, cfg.args, proc(argv) unsafe {
             let (mut input, mut output) = try!(pipe());

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -198,8 +198,14 @@ fn with_appropriate_checker(cx: &Context,
     let fty = ty::node_id_to_type(cx.tcx, id);
     match ty::get(fty).sty {
         ty::ty_closure(box ty::ClosureTy {
-            store: ty::UniqTraitStore, bounds, ..
-        }) => b(|cx, fv| check_for_uniq(cx, fv, bounds)),
+            store: ty::UniqTraitStore,
+            bounds: mut bounds, ..
+        }) => {
+            // Procs can't close over non-static references!
+            bounds.add(ty::BoundStatic);
+
+            b(|cx, fv| check_for_uniq(cx, fv, bounds))
+        }
 
         ty::ty_closure(box ty::ClosureTy {
             store: ty::RegionTraitStore(region, _), bounds, ..

--- a/src/test/compile-fail/proc-static-bound.rs
+++ b/src/test/compile-fail/proc-static-bound.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut x = Some(1);
+    let mut p: proc(&mut Option<int>) = proc(_) {};
+    match x {
+        Some(ref y) => {
+            p = proc(z: &mut Option<int>) {
+                *z = None;
+                let _ = y;
+                //~^ ERROR cannot capture variable of type `&int`, which does not fulfill `'static`
+            };
+        }
+        None => {}
+    }
+    p(&mut x);
+}
+


### PR DESCRIPTION
Since procs do not have lifetime bounds, we must do this to maintain
safety.

This can break code that incorrectly captured references in procedure
types. Change such code to not do this, perhaps with a trait object
instead.

Closes #14036.

[breaking-change]

r? @alexcrichton
