### PR TITLE
Guide.md: Change download instructions and remove bad info

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -30,11 +30,9 @@ install Rust, but the easiest is to use the the `rustup` script. If you're on
 Linux or a Mac, All you need to do is this:
 
 ```{ignore}
-$ curl -s http://www.rust-lang.org/rustup.sh | sudo sh
+$ curl http://www.rust-lang.org/rustup.sh -o rustup.sh
+$ sudo sh rustup.sh
 ```
-
-(If you're concerned about `curl | sudo sh`, please keep reading. Disclaimer
-below.)
 
 If you're on Windows, please [download this .exe and run
 it](http://static.rust-lang.org/dist/rust-nightly-install.exe).
@@ -44,7 +42,7 @@ Not every programming language is great for everyone. Just pass an argument to
 the script:
 
 ```{ignore}
-$ curl -s http://www.rust-lang.org/rustup.sh | sudo sh -s -- --uninstall
+$ sudo sh rustup.sh --uninstall
 ```
 
 If you used the Windows installer, just re-run the `.exe` and it will give you
@@ -54,15 +52,11 @@ You can re-run this script any time you want to update Rust. Which, at this
 point, is often. Rust is still pre-1.0, and so people assume that you're using
 a very recent Rust. 
 
-This brings me to one other point: some people, and somewhat rightfully so, get
-very upset when we tell you to `curl | sudo sh`. And they should be! Basically,
-when you do this, you are trusting that the good people who maintain Rust
-aren't going to hack your computer and do bad things. That's a good instinct!
-If you're one of those people, please check out the documentation on [building
+
+If you don't want to use the script to download binaries, you can also [build
 Rust from Source](https://github.com/rust-lang/rust#building-from-source), or
-[the official binary downloads](http://www.rust-lang.org/install.html). And we
-promise that this method will not be the way to install Rust forever: it's just
-the easiest way to keep people updated while Rust is in its alpha state.
+manually download the [official binaries from Rust's website]
+(http://www.rust-lang.org/install.html).
 
 Oh, we should also mention the officially supported platforms:
 


### PR DESCRIPTION
Piping `curl` directly to `| sudo sh` has very weird failure modes:  If the connection is interrupted, you can end up executing part of a script.

The small rant about "Trusting Rust" to not hack your computer is completely misguided as well.  You're going to run binaries one way or another, so you're still trusting Rust developers.

The fact that we're delivering unsigned binaries over http is still cringeworthy though.
