### PR TITLE
std::io: Use re-exported pathes in examples.

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -83,7 +83,7 @@ Some examples of obvious things you might want to do
 
     ```rust
     # #![allow(unused_must_use)]
-    use std::io::net::tcp::TcpStream;
+    use std::io::TcpStream;
 
     # // connection doesn't fail if a server is running on 8080
     # // locally, we still want to be type checking this code, so lets

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -41,7 +41,7 @@ use rt::rtio;
 ///
 /// ```no_run
 /// # #![allow(unused_must_use)]
-/// use std::io::net::tcp::TcpStream;
+/// use std::io::TcpStream;
 ///
 /// let mut stream = TcpStream::connect("127.0.0.1", 34254);
 ///
@@ -162,7 +162,7 @@ impl TcpStream {
     /// ```no_run
     /// # #![allow(unused_must_use)]
     /// use std::io::timer;
-    /// use std::io::net::tcp::TcpStream;
+    /// use std::io::TcpStream;
     ///
     /// let mut stream = TcpStream::connect("127.0.0.1", 34254).unwrap();
     /// let stream2 = stream.clone();
@@ -406,7 +406,7 @@ impl TcpAcceptor {
     ///
     /// ```no_run
     /// # #![allow(experimental)]
-    /// use std::io::net::tcp::TcpListener;
+    /// use std::io::TcpListener;
     /// use std::io::{Listener, Acceptor, TimedOut};
     ///
     /// let mut a = TcpListener::bind("127.0.0.1", 8482).listen().unwrap();

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -476,8 +476,8 @@ impl Process {
     ///
     /// ```no_run
     /// # #![allow(experimental)]
-    /// use std::io::process::{Command, ProcessExit};
-    /// use std::io::IoResult;
+    /// use std::io::{Command, IoResult};
+    /// use std::io::process::ProcessExit;
     ///
     /// fn run_gracefully(prog: &str) -> IoResult<ProcessExit> {
     ///     let mut p = try!(Command::new("long-running-process").spawn());

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -110,7 +110,7 @@ impl Timer {
     /// # Example
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// let mut timer = Timer::new().unwrap();
     /// let ten_milliseconds = timer.oneshot(10);
@@ -122,7 +122,7 @@ impl Timer {
     /// ```
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// // Incorrect, method chaining-style:
     /// let mut five_ms = Timer::new().unwrap().oneshot(5);
@@ -152,7 +152,7 @@ impl Timer {
     /// # Example
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// let mut timer = Timer::new().unwrap();
     /// let ten_milliseconds = timer.periodic(10);
@@ -170,7 +170,7 @@ impl Timer {
     /// ```
     ///
     /// ```rust
-    /// use std::io::timer::Timer;
+    /// use std::io::Timer;
     ///
     /// // Incorrect, method chaining-style.
     /// let mut five_ms = Timer::new().unwrap().periodic(5);


### PR DESCRIPTION
We use re-exported pathes (e.g. std::io::Command) and original ones
(e.g. std::io::process::Command) together in examples now. Using
re-exported ones consistently avoids confusion.
