### PR TITLE
std: Make unlink() more consistent

### DIFF
--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -420,6 +420,7 @@ pub fn uv_error_to_io_error(uverr: UvError) -> IoError {
             uvll::EADDRNOTAVAIL => libc::WSAEADDRNOTAVAIL,
             uvll::ECANCELED => libc::ERROR_OPERATION_ABORTED,
             uvll::EADDRINUSE => libc::WSAEADDRINUSE,
+            uvll::EPERM => libc::ERROR_ACCESS_DENIED,
             err => {
                 uvdebug!("uverr.code {}", err as int);
                 // FIXME: Need to map remaining uv error types

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -39,7 +39,7 @@ use libc::uintptr_t;
 
 pub use self::errors::{EACCES, ECONNREFUSED, ECONNRESET, EPIPE, ECONNABORTED,
                        ECANCELED, EBADF, ENOTCONN, ENOENT, EADDRNOTAVAIL,
-                       EADDRINUSE};
+                       EADDRINUSE, EPERM};
 
 pub static OK: c_int = 0;
 pub static EOF: c_int = -4095;
@@ -63,6 +63,7 @@ pub mod errors {
     pub static EBADF: c_int = -4083;
     pub static EADDRNOTAVAIL: c_int = -4090;
     pub static EADDRINUSE: c_int = -4091;
+    pub static EPERM: c_int = -4048;
 }
 #[cfg(not(windows))]
 pub mod errors {
@@ -80,6 +81,7 @@ pub mod errors {
     pub static EBADF : c_int = -libc::EBADF;
     pub static EADDRNOTAVAIL : c_int = -libc::EADDRNOTAVAIL;
     pub static EADDRINUSE : c_int = -libc::EADDRINUSE;
+    pub static EPERM: c_int = -libc::EPERM;
 }
 
 pub static PROCESS_SETUID: c_int = 1 << 0;


### PR DESCRIPTION
Currently when a read-only file has unlink() invoked on it on windows, the call
will fail. On unix, however, the call will succeed. In order to have a more
consistent behavior across platforms, this error is recognized on windows and
the file is changed to read-write before removal is attempted.
