### PR TITLE
Match var hygiene, etc

### DIFF
--- a/src/doc/guide-macros.md
+++ b/src/doc/guide-macros.md
@@ -355,6 +355,7 @@ macro_rules! biased_match_rec (
             _ => { $err }
         }
     );
+    // Produce the requested values
     ( binds $( $bind_res:ident ),* ) => ( ($( $bind_res ),*) )
 )
 
@@ -364,7 +365,7 @@ macro_rules! biased_match (
     ( $( ($e:expr) ~ ($p:pat) else $err:stmt ; )*
       binds $bind_res:ident
     ) => (
-        let ( $( $bind_res ),* ) = biased_match_rec!(
+        let $bind_res = biased_match_rec!(
             $( ($e) ~ ($p) else $err ; )*
             binds $bind_res
         );

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -401,6 +401,7 @@ pub enum Decl_ {
     DeclItem(Gc<Item>),
 }
 
+/// represents one arm of a 'match'
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
 pub struct Arm {
     pub attrs: Vec<Attribute>,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1281,7 +1281,7 @@ mod test {
             0)
     }
 
-    // FIXME #9384, match variable hygiene. Should expand into
+    // match variable hygiene. Should expand into
     // fn z() {match 8 {x_1 => {match 9 {x_2 | x_2 if x_2 == x_1 => x_2 + x_1}}}}
     #[test] fn issue_9384(){
         run_renaming_test(
@@ -1293,7 +1293,7 @@ mod test {
             0)
     }
 
-    // FIXME #15221, somehow pats aren't getting labeled correctly?
+    // interpolated nodes weren't getting labeled.
     // should expand into
     // fn main(){let g1_1 = 13; g1_1}}
     #[test] fn pat_expand_issue_15221(){

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1274,13 +1274,13 @@ mod test {
     }
 
     // FIXME #9384, match variable hygiene. Should expand into
-    // fn z() {match 8 {x_1 => {match 9 {x_2 | x_2 => x_2 + x_1}}}}
+    // fn z() {match 8 {x_1 => {match 9 {x_2 | x_2 if x_2 == x_1 => x_2 + x_1}}}}
     #[test] fn issue_9384(){
         run_renaming_test(
-            &("macro_rules! bad_macro (($ex:expr) => ({match 9 {x | x => x + $ex}}))
-              fn z() {match 8 {x => bad_macro!(_x)}}",
+            &("macro_rules! bad_macro (($ex:expr) => ({match 9 {x | x if x == $ex => x + $ex}}))
+              fn z() {match 8 {x => bad_macro!(x)}}",
               // NB: the third "binding" is the repeat of the second one.
-              vec!(vec!(1),vec!(0),vec!(0)),
+              vec!(vec!(1,3),vec!(0,2),vec!(0,2)),
               true),
             0)
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -687,7 +687,7 @@ fn expand_arm(arm: &ast::Arm, fld: &mut MacroExpander) -> ast::Arm {
         pats: rewritten_pats,
         guard: rewritten_guard,
         body: rewritten_body,
-    }    
+    }
 }
 
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -659,15 +659,15 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
 }
 
 fn expand_arm(arm: &ast::Arm, fld: &mut MacroExpander) -> ast::Arm {
-    if a.pats.len() == 0 {
+    if arm.pats.len() == 0 {
         fail!("encountered match arm with 0 patterns");
     }
-    let first_pat = match a.pats.get(0) {
-        
-    }
+    // all of the pats must have the same set of bindings, so use the
+    // first one to extract them and generate new names:
+    let first_pat = arm.pats.get(0);
     // code duplicated from 'let', above. Perhaps this can be lifted
     // into a separate function:
-    let expanded_pat = fld.fold_pat(pat);
+    let expanded_pat = fld.fold_pat(*first_pat);
     let mut name_finder = new_name_finder(Vec::new());
     name_finder.visit_pat(&*expanded_pat,());
     let mut new_pending_renames = Vec::new();
@@ -681,13 +681,13 @@ fn expand_arm(arm: &ast::Arm, fld: &mut MacroExpander) -> ast::Arm {
         // ones have already been applied):
         rename_fld.fold_pat(expanded_pat)
     };
-    
-    let bound_names
-        ast::Arm {
-        attrs: a.attrs.iter().map(|x| self.fold_attribute(*x)).collect(),
-        pats: a.pats.iter().map(|x| self.fold_pat(*x)).collect(),
-        guard: a.guard.map(|x| self.fold_expr(x)),
-        body: self.fold_expr(a.body),
+    /*
+    */
+    ast::Arm {
+        attrs: arm.attrs.iter().map(|x| fld.fold_attribute(*x)).collect(),
+        pats: arm.pats.iter().map(|x| fld.fold_pat(*x)).collect(),
+        guard: arm.guard.map(|x| fld.fold_expr(x)),
+        body: fld.fold_expr(arm.body),
     }    
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -988,35 +988,30 @@ impl Folder for Marker {
     }
 }
 
-// just a convenience:
-fn new_mark_folder(m: Mrk) -> Marker {
-    Marker {mark: m}
-}
-
 // apply a given mark to the given token trees. Used prior to expansion of a macro.
 fn mark_tts(tts: &[TokenTree], m: Mrk) -> Vec<TokenTree> {
-    fold_tts(tts, &mut new_mark_folder(m))
+    fold_tts(tts, &mut Marker{mark:m})
 }
 
 // apply a given mark to the given expr. Used following the expansion of a macro.
 fn mark_expr(expr: Gc<ast::Expr>, m: Mrk) -> Gc<ast::Expr> {
-    new_mark_folder(m).fold_expr(expr)
+    Marker{mark:m}.fold_expr(expr)
 }
 
 // apply a given mark to the given pattern. Used following the expansion of a macro.
 fn mark_pat(pat: Gc<ast::Pat>, m: Mrk) -> Gc<ast::Pat> {
-    new_mark_folder(m).fold_pat(pat)
+    Marker{mark:m}.fold_pat(pat)
 }
 
 // apply a given mark to the given stmt. Used following the expansion of a macro.
 fn mark_stmt(expr: &ast::Stmt, m: Mrk) -> Gc<ast::Stmt> {
-    new_mark_folder(m).fold_stmt(expr)
+    Marker{mark:m}.fold_stmt(expr)
             .expect_one("marking a stmt didn't return a stmt")
 }
 
 // apply a given mark to the given item. Used following the expansion of a macro.
 fn mark_item(expr: Gc<ast::Item>, m: Mrk) -> SmallVector<Gc<ast::Item>> {
-    new_mark_folder(m).fold_item(expr)
+    Marker{mark:m}.fold_item(expr)
 }
 
 fn original_span(cx: &ExtCtxt) -> Gc<codemap::ExpnInfo> {

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -160,7 +160,7 @@ fn with_resolve_table_mut<T>(op: |&mut ResolveTable| -> T) -> T {
 }
 
 // Resolve a syntax object to a name, per MTWT.
-// adding memorization to possibly resolve 500+ seconds in resolve for librustc (!)
+// adding memoization to possibly resolve 500+ seconds in resolve for librustc (!)
 fn resolve_internal(id: Ident,
                     table: &SCTable,
                     resolve_table: &mut ResolveTable) -> Name {

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -30,6 +30,7 @@ use std::collections::HashMap;
 // change the semantics--everything here is immutable--but
 // it should cut down on memory use *a lot*; applying a mark
 // to a tree containing 50 identifiers would otherwise generate
+// 50 new contexts
 pub struct SCTable {
     table: RefCell<Vec<SyntaxContext_>>,
     mark_memo: RefCell<HashMap<(SyntaxContext,Mrk),SyntaxContext>>,
@@ -160,7 +161,7 @@ fn with_resolve_table_mut<T>(op: |&mut ResolveTable| -> T) -> T {
 }
 
 // Resolve a syntax object to a name, per MTWT.
-// adding memoization to possibly resolve 500+ seconds in resolve for librustc (!)
+// adding memoization to resolve 500+ seconds in resolve for librustc (!)
 fn resolve_internal(id: Ident,
                     table: &SCTable,
                     resolve_table: &mut ResolveTable) -> Name {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -391,23 +391,6 @@ fn fold_arg_<T: Folder>(a: &Arg, fld: &mut T) -> Arg {
 
 // build a new vector of tts by appling the Folder's fold_ident to
 // all of the identifiers in the token trees.
-//
-// This is part of hygiene magic. As far as hygiene is concerned, there
-// are three types of let pattern bindings or loop labels:
-//      - those defined and used in non-macro part of the program
-//      - those used as part of macro invocation arguments
-//      - those defined and used inside macro definitions
-// Lexically, type 1 and 2 are in one group and type 3 the other. If they
-// clash, in order for let and loop label to work hygienically, one group
-// or the other needs to be renamed. The problem is that type 2 and 3 are
-// parsed together (inside the macro expand function). After being parsed and
-// AST being constructed, they can no longer be distinguished from each other.
-//
-// For that reason, type 2 let bindings and loop labels are actually renamed
-// in the form of tokens instead of AST nodes, here. There are wasted effort
-// since many token::IDENT are not necessary part of let bindings and most
-// token::LIFETIME are certainly not loop labels. But we can't tell in their
-// token form. So this is less ideal and hacky but it works.
 pub fn fold_tts<T: Folder>(tts: &[TokenTree], fld: &mut T) -> Vec<TokenTree> {
     tts.iter().map(|tt| {
         match *tt {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -114,6 +114,7 @@ pub enum Nonterminal {
     NtPat( Gc<ast::Pat>),
     NtExpr(Gc<ast::Expr>),
     NtTy(  P<ast::Ty>),
+    // see IDENT, above, for meaning of bool in NtIdent:
     NtIdent(Box<ast::Ident>, bool),
     NtMeta(Gc<ast::MetaItem>), // stuff inside brackets for attributes
     NtPath(Box<ast::Path>),

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -15,7 +15,7 @@
 
 // This also serves as a pipes test, because Arcs are implemented with pipes.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 extern crate time;
 

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -15,7 +15,7 @@
 
 // This also serves as a pipes test, because Arcs are implemented with pipes.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 extern crate time;
 

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -38,7 +38,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 #![feature(phase)]
 #[phase(plugin)] extern crate green;

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 #![feature(phase)]
 #![allow(non_snake_case_functions)]

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 // ignore-win32 FIXME #13259
 extern crate native;
 

--- a/src/test/run-pass/deriving-cmp-generic-enum.rs
+++ b/src/test/run-pass/deriving-cmp-generic-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 #[deriving(PartialEq, Eq, PartialOrd, Ord)]
 enum E<T> {

--- a/src/test/run-pass/deriving-cmp-generic-struct-enum.rs
+++ b/src/test/run-pass/deriving-cmp-generic-struct-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 #![feature(struct_variant)]
 

--- a/src/test/run-pass/deriving-cmp-generic-struct.rs
+++ b/src/test/run-pass/deriving-cmp-generic-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 #[deriving(PartialEq, Eq, PartialOrd, Ord)]
 struct S<T> {

--- a/src/test/run-pass/deriving-cmp-generic-tuple-struct.rs
+++ b/src/test/run-pass/deriving-cmp-generic-tuple-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 #[deriving(PartialEq, Eq, PartialOrd, Ord)]
 struct TS<T>(T,T);

--- a/src/test/run-pass/issue-15221.rs
+++ b/src/test/run-pass/issue-15221.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+macro_rules! inner_bind (
+    ( $p:pat, $id:ident) => ({let $p = 13; $id}))
+
+macro_rules! outer_bind (
+    ($p:pat, $id:ident ) => (inner_bind!($p, $id)))
+
+fn main() {
+    outer_bind!(g1,g1);
+}
+

--- a/src/test/run-pass/issue-15221.rs
+++ b/src/test/run-pass/issue-15221.rs
@@ -10,13 +10,14 @@
 
 #![feature(macro_rules)]
 
-macro_rules! inner_bind (
-    ( $p:pat, $id:ident) => ({let $p = 13; $id}))
+macro_rules! inner (
+    ($e:pat ) => ($e))
 
-macro_rules! outer_bind (
-    ($p:pat, $id:ident ) => (inner_bind!($p, $id)))
+macro_rules! outer (
+    ($e:pat ) => (inner!($e)))
 
 fn main() {
-    outer_bind!(g1,g1);
+    let outer!(g1) = 13;
+    g1;
 }
 

--- a/src/test/run-pass/issue-8851.rs
+++ b/src/test/run-pass/issue-8851.rs
@@ -10,23 +10,28 @@
 
 #![feature(macro_rules)]
 
+// after fixing #9384 and implementing hygiene for match bindings,
+// this now fails because the insertion of the 'y' into the match
+// doesn't cause capture. Making this macro hygienic (as I've done)
+// could very well make this test case completely pointless....
+
 enum T {
     A(int),
     B(uint)
 }
 
 macro_rules! test(
-    ($e:expr) => (
+    ($id:ident, $e:expr) => (
         fn foo(t: T) -> int {
             match t {
-                A(y) => $e,
-                B(y) => $e
+                A($id) => $e,
+                B($id) => $e
             }
         }
     )
 )
 
-test!(10 + (y as int))
+test!(y, 10 + (y as int))
 
 pub fn main() {
     foo(A(20));

--- a/src/test/run-pass/linear-for-loop.rs
+++ b/src/test/run-pass/linear-for-loop.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 extern crate debug;
 

--- a/src/test/run-pass/task-comm-3.rs
+++ b/src/test/run-pass/task-comm-3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 extern crate debug;
 

--- a/src/test/run-pass/typeck-macro-interaction-issue-8852.rs
+++ b/src/test/run-pass/typeck-macro-interaction-issue-8852.rs
@@ -15,19 +15,24 @@ enum T {
     B(f64)
 }
 
+// after fixing #9384 and implementing hygiene for match bindings,
+// this now fails because the insertion of the 'y' into the match
+// doesn't cause capture. Making this macro hygienic (as I've done)
+// could very well make this test case completely pointless....
+
 macro_rules! test(
-    ($e:expr) => (
+    ($id1:ident, $id2:ident, $e:expr) => (
         fn foo(a:T, b:T) -> T {
             match (a, b) {
-                (A(x), A(y)) => A($e),
-                (B(x), B(y)) => B($e),
+                (A($id1), A($id2)) => A($e),
+                (B($id1), B($id2)) => B($e),
                 _ => fail!()
             }
         }
     )
 )
 
-test!(x + y)
+test!(x,y,x + y)
 
 pub fn main() {
     foo(A(1), A(2));

--- a/src/test/run-pass/unfold-cross-crate.rs
+++ b/src/test/run-pass/unfold-cross-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 use std::iter::Unfold;
 

--- a/src/test/run-pass/utf8.rs
+++ b/src/test/run-pass/utf8.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-pretty FIXME #15189
+// no-pretty-expanded FIXME #15189
 
 pub fn main() {
     let yen: char = '¥'; // 0xa5


### PR DESCRIPTION
This PR includes two big things and a bunch of little ones.

1) It enables hygiene for variables bound by 'match' expressions.
2) It fixes a bug discovered indirectly (#15221), wherein fold traversal failed to visit nonterminal nodes.
3) It fixes a small bug in the macro tutorial.

It also adds tests for the first two, and makes a bunch of small comment improvements and cleanup.
