### PR TITLE
Json cleanup and improvements

### DIFF
--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2015,25 +2015,37 @@ impl ToJson for String {
     fn to_json(&self) -> Json { String((*self).clone()) }
 }
 
-impl<A: ToJson, B: ToJson> ToJson for (A, B) {
-    fn to_json(&self) -> Json {
-        match *self {
-            (ref a, ref b) => {
-                List(vec![a.to_json(), b.to_json()])
+macro_rules! tuple_impl {
+    // use variables to indicate the arity of the tuple
+    ($($tyvar:ident),* ) => {
+        // the trailing commas are for the 1 tuple
+        impl<
+            $( $tyvar : ToJson ),*
+            > ToJson for ( $( $tyvar ),* , ) {
+
+            #[inline]
+            #[allow(uppercase_variables)]
+            fn to_json(&self) -> Json {
+                match *self {
+                    ($(ref $tyvar),*,) => List(vec![$($tyvar.to_json()),*])
+                }
             }
         }
     }
 }
 
-impl<A: ToJson, B: ToJson, C: ToJson> ToJson for (A, B, C) {
-    fn to_json(&self) -> Json {
-        match *self {
-            (ref a, ref b, ref c) => {
-                List(vec![a.to_json(), b.to_json(), c.to_json()])
-            }
-        }
-    }
-}
+tuple_impl!{A}
+tuple_impl!{A, B}
+tuple_impl!{A, B, C}
+tuple_impl!{A, B, C, D}
+tuple_impl!{A, B, C, D, E}
+tuple_impl!{A, B, C, D, E, F}
+tuple_impl!{A, B, C, D, E, F, G}
+tuple_impl!{A, B, C, D, E, F, G, H}
+tuple_impl!{A, B, C, D, E, F, G, H, I}
+tuple_impl!{A, B, C, D, E, F, G, H, I, J}
+tuple_impl!{A, B, C, D, E, F, G, H, I, J, K}
+tuple_impl!{A, B, C, D, E, F, G, H, I, J, K, L}
 
 impl<'a, A: ToJson> ToJson for &'a [A] {
     fn to_json(&self) -> Json { List(self.iter().map(|elt| elt.to_json()).collect()) }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -246,7 +246,7 @@ pub enum Json {
     String(String),
     Boolean(bool),
     List(List),
-    Object(Box<Object>),
+    Object(Object),
     Null,
 }
 
@@ -888,7 +888,7 @@ impl Json {
     /// Returns None otherwise.
     pub fn as_object<'a>(&'a self) -> Option<&'a Object> {
         match self {
-            &Object(ref map) => Some(&**map),
+            &Object(ref map) => Some(map),
             _ => None
         }
     }
@@ -1720,7 +1720,7 @@ impl<T: Iterator<char>> Builder<T> {
     fn build_object(&mut self) -> Result<Json, BuilderError> {
         self.bump();
 
-        let mut values = box TreeMap::new();
+        let mut values = TreeMap::new();
 
         loop {
             match self.token {
@@ -2117,7 +2117,7 @@ impl<A: ToJson> ToJson for TreeMap<String, A> {
         for (key, value) in self.iter() {
             d.insert((*key).clone(), value.to_json());
         }
-        Object(box d)
+        Object(d)
     }
 }
 
@@ -2127,7 +2127,7 @@ impl<A: ToJson> ToJson for HashMap<String, A> {
         for (key, value) in self.iter() {
             d.insert((*key).clone(), value.to_json());
         }
-        Object(box d)
+        Object(d)
     }
 }
 
@@ -2185,7 +2185,7 @@ mod tests {
     }
 
     fn mk_object(items: &[(String, Json)]) -> Json {
-        let mut d = box TreeMap::new();
+        let mut d = TreeMap::new();
 
         for item in items.iter() {
             match *item {
@@ -3252,7 +3252,7 @@ mod tests {
             let mut tree_map = TreeMap::new();
             tree_map.insert("a".to_string(), Number(1.0_f64));
             tree_map.insert("b".to_string(), Number(2.0_f64));
-            Object(box tree_map)
+            Object(tree_map)
         };
 
         assert_eq!(list2.to_json(), list2);

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2166,6 +2166,12 @@ impl fmt::Show for Json {
     }
 }
 
+impl std::from_str::FromStr for Json {
+    fn from_str(s: &str) -> Option<Json> {
+        from_str(s).ok()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate test;
@@ -2180,9 +2186,7 @@ mod tests {
                 InvalidSyntax, InvalidNumber, EOFWhileParsingObject, EOFWhileParsingList,
                 EOFWhileParsingValue, EOFWhileParsingString, KeyMustBeAString, ExpectedColon,
                 TrailingCharacters};
-    use std::f32;
-    use std::f64;
-    use std::io;
+    use std::{f32, f64, io};
     use std::collections::TreeMap;
 
     #[deriving(PartialEq, Encodable, Decodable, Show)]
@@ -2213,6 +2217,12 @@ mod tests {
         };
 
         Object(d)
+    }
+
+    #[test]
+    fn test_from_str_trait() {
+        let s = "null";
+        assert!(::std::from_str::from_str::<Json>(s).unwrap() == from_str(s).unwrap());
     }
 
     #[test]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1104,7 +1104,7 @@ fn calc_result(desc: &TestDesc, task_succeeded: bool) -> TestResult {
 
 impl ToJson for Metric {
     fn to_json(&self) -> json::Json {
-        let mut map = box TreeMap::new();
+        let mut map = TreeMap::new();
         map.insert("value".to_string(), json::Number(self.value));
         map.insert("noise".to_string(), json::Number(self.noise));
         json::Object(map)

--- a/src/test/run-pass/issue-2804.rs
+++ b/src/test/run-pass/issue-2804.rs
@@ -22,11 +22,11 @@ enum object {
     int_value(i64),
 }
 
-fn lookup(table: Box<json::Object>, key: String, default: String) -> String
+fn lookup(table: json::Object, key: String, default: String) -> String
 {
     match table.find(&key.to_string()) {
         option::Some(&json::String(ref s)) => {
-            (*s).to_string()
+            s.to_string()
         }
         option::Some(value) => {
             println!("{} was expected to be a string but is a {:?}", key, value);
@@ -42,7 +42,7 @@ fn add_interface(_store: int, managed_ip: String, data: json::Json) -> (String, 
 {
     match &data {
         &json::Object(ref interface) => {
-            let name = lookup((*interface).clone(),
+            let name = lookup(interface.clone(),
                               "ifDescr".to_string(),
                               "".to_string());
             let label = format!("{}-{}", managed_ip, name);


### PR DESCRIPTION
### Breaking changes:
- **Removed unnecessary `box` from enum variant (`Object(Box<Object>)` becomes `Object(Object)`)**
- **Deprecated `Encoder::str_encode`**
### Other changes:
- Tried to make the code more idiomatic
- Renamed the `wr` field of the `Encoder` and `PrettyEncoder` structs to `writer`
- Replaced some `from_utf8` by `from_utf8_owned` to avoid unnecessary allocations
- Removed unnecessary `unsafe` code
- Added `encode` and `decode` shortcut functions
- Implemented `FromStr` for `Json`
- Implemented `ToJson` for tuples of arity up to 12
- Fixed some details in the documentation
### Questions
- ~~The `encode` shortcut function does the same as the `Encoder::str_encode` function. It seems wrong to me that two functions do exactly the same. Should we deprecate `Encoder::str_encode`?~~
- ~~Do we really want the ToJson trait for tuples? At the moment we have it for (), (A, B), (A, B, C). I would like to remove them.~~
- ~~We are using `String` as key in the `TreeMap` representing a `Json` object. It would be better to use `&str`, but this would require to annotate lots of lifetimes. Is there any easy solution for this?~~
- There is a lot of duplicated code (`PrettyEncoder` copies about 50 lines from `Encoder`). In an OO language this could be solved very elegantly by using inheritance and overriding. What can we do here to reduce the amount of boilerplate?

[breaking-change]
