### PR TITLE
librustc: Permit by-value-self methods to be invoked on objects referenced by boxes.

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1220,7 +1220,7 @@ pub fn init_function<'a>(fcx: &'a FunctionContext<'a>,
 //  - new_fn_ctxt
 //  - trans_args
 
-fn arg_kind(cx: &FunctionContext, t: ty::t) -> datum::Rvalue {
+pub fn arg_kind(cx: &FunctionContext, t: ty::t) -> datum::Rvalue {
     use middle::trans::datum::{ByRef, ByValue};
 
     datum::Rvalue {

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -159,6 +159,14 @@ impl<'a> Builder<'a> {
                   attributes: &[(uint, u64)])
                   -> ValueRef {
         self.count_insn("invoke");
+
+        debug!("Invoke {} with args ({})",
+               self.ccx.tn.val_to_str(llfn),
+               args.iter()
+                   .map(|&v| self.ccx.tn.val_to_str(v))
+                   .collect::<Vec<String>>()
+                   .connect(", "));
+
         unsafe {
             let v = llvm::LLVMBuildInvoke(self.llbuilder,
                                           llfn,

--- a/src/test/run-fail/by-value-self-objects-fail.rs
+++ b/src/test/run-fail/by-value-self-objects-fail.rs
@@ -1,0 +1,51 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:explicit failure
+
+trait Foo {
+    fn foo(self, x: int);
+}
+
+struct S {
+    x: int,
+    y: int,
+    z: int,
+    s: String,
+}
+
+impl Foo for S {
+    fn foo(self, x: int) {
+        fail!()
+    }
+}
+
+impl Drop for S {
+    fn drop(&mut self) {
+        println!("bye 1!");
+    }
+}
+
+fn f() {
+    let s = S {
+        x: 2,
+        y: 3,
+        z: 4,
+        s: "hello".to_string(),
+    };
+    let st = box s as Box<Foo>;
+    st.foo(5);
+}
+
+fn main() {
+    f();
+}
+
+

--- a/src/test/run-pass/by-value-self-objects.rs
+++ b/src/test/run-pass/by-value-self-objects.rs
@@ -1,0 +1,77 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+static mut destructor_count: uint = 0;
+
+trait Foo {
+    fn foo(self, x: int);
+}
+
+struct S {
+    x: int,
+    y: int,
+    z: int,
+    s: String,
+}
+
+impl Foo for S {
+    fn foo(self, x: int) {
+        assert!(self.x == 2);
+        assert!(self.y == 3);
+        assert!(self.z == 4);
+        assert!(self.s.as_slice() == "hello");
+        assert!(x == 5);
+    }
+}
+
+impl Drop for S {
+    fn drop(&mut self) {
+        println!("bye 1!");
+        unsafe {
+            destructor_count += 1;
+        }
+    }
+}
+
+impl Foo for int {
+    fn foo(self, x: int) {
+        println!("{}", x * x);
+    }
+}
+
+fn f() {
+    let s = S {
+        x: 2,
+        y: 3,
+        z: 4,
+        s: "hello".to_string(),
+    };
+    let st = box s as Box<Foo>;
+    st.foo(5);
+    println!("bye 2!");
+}
+
+fn g() {
+    let s = 2i;
+    let st = box s as Box<Foo>;
+    st.foo(3);
+    println!("bye 3!");
+}
+
+fn main() {
+    f();
+
+    unsafe {
+        assert!(destructor_count == 1);
+    }
+
+    g();
+}
+


### PR DESCRIPTION
I can't believe this worked! I believe that the way the ABI and
immediates work mean that this Just Works.

Closes #10672.

r? @alexcrichton
