### PR TITLE
Fix implicit overwrite for extensionless files

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -894,6 +894,11 @@ pub fn build_output_filenames(input: &Input,
             };
 
             let mut stem = input.filestem();
+            
+             //Prevents damage to unstemmed source files
+            if stem == source_name(input){
+                sess.err(format!("File `{}` has a missing file extension", stem).as_slice());
+            }
 
             // If a crateid is present, we use it as the link name
             let crateid = attr::find_crateid(attrs);


### PR DESCRIPTION
This change fixes issues #15240, which I filed earlier. It's a check to ensure that any file being compiled cannot be assigned an output file with the same name as the source implicitly. 

For instance, `rustc myfile` would before overwrite myfile with the binary of itself. Now, the compiler sees this as an error, unless the compiler is given a directive to overwrite the file via the -o flag.
