### PR TITLE
Add constants based on Archimedes' original circle constant

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -52,33 +52,21 @@ pub mod consts {
 
     /// Archimedes' constant
     pub static TAU: f32 = 6.28318530717958647692528676655900576_f32;
-    /// pi * 2.0 = tau
-    pub static PI_2: f32 = TAU;
 
-    /// tau / 2.0 = pi
-    pub static FRAC_TAU_2: f32 = 3.14159265358979323846264338327950288_f32;
     /// pi = tau / 2.0
-    pub static PI: f32 = FRAC_TAU_2;
+    pub static PI: f32 = 3.14159265358979323846264338327950288_f32;
 
     /// tau / 3.0 = 2.0 * pi / 3.0
     pub static FRAC_TAU_3: f32 = 2.094395102393195492308428922186335256_f32;
-    /// 2.0 * pi / 3.0 = tau / 3.0
-    pub static FRAC_2PI_3: f32 = FRAC_TAU_3;
 
-    /// tau / 6.0 = pi / 3.0
-    pub static FRAC_TAU_6: f32 = 1.04719755119659774615421446109316763_f32;
     /// pi / 3.0 = tau / 6.0
-    pub static FRAC_PI_3: f32 = FRAC_TAU_6;
+    pub static FRAC_PI_3: f32 = 1.04719755119659774615421446109316763_f32;
 
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     pub static FRAC_1_TAU: f32 = 0.159154943091895335768883763372514362_f32;
-    /// 1.0 / (pi * 2.0) = 1.0 / tau
-    pub static FRAC_1_2PI: f32 = FRAC_1_TAU;
 
-    /// 2.0 / tau = 1.0 / pi
-    pub static FRAC_2_TAU: f32 = 0.318309886183790671537767526745028724_f32;
     /// 1.0 / pi = 2.0 / tau
-    pub static FRAC_1_PI: f32 = FRAC_2_TAU;
+    pub static FRAC_1_PI: f32 = 0.318309886183790671537767526745028724_f32;
 
     /// sqrt(2.0)
     pub static SQRT2: f32 = 1.41421356237309504880168872420969808_f32;
@@ -266,13 +254,7 @@ impl Float for f32 {
     /// Archimedes' constant
     #[inline]
     fn tau() -> f32 { consts::TAU }
-    /// 2.0 * pi = tau
-    #[inline]
-    fn two_pi() -> f32 { consts::PI_2 }
 
-    /// tau / 2.0 = pi
-    #[inline]
-    fn frac_tau_2() -> f32 { consts::FRAC_TAU_2 }
     /// pi = tau / 2.0
     #[inline]
     fn pi() -> f32 { consts::PI }
@@ -280,13 +262,7 @@ impl Float for f32 {
     /// tau / 3.0 = 2.0 * pi / 3.0
     #[inline]
     fn frac_tau_3() -> f32 { consts::FRAC_TAU_3 }
-    /// 2.0 * pi / 3.0 = tau / 3.0
-    #[inline]
-    fn frac_2pi_3() -> f32 { consts::FRAC_2PI_3 }
 
-    /// tau / 6.0 = pi / 3.0
-    #[inline]
-    fn frac_tau_6() -> f32 { consts::FRAC_TAU_6 }
     /// pi / 3.0 = tau / 6.0
     #[inline]
     fn frac_pi_3() -> f32 { consts::FRAC_PI_3 }
@@ -294,13 +270,7 @@ impl Float for f32 {
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     #[inline]
     fn frac_1_tau() -> f32 { consts::FRAC_1_TAU }
-    /// 1.0 / (pi * 2.0) = 1.0 / tau
-    #[inline]
-    fn frac_1_2pi() -> f32 { consts::FRAC_1_2PI }
 
-    /// 2.0 / tau = 1.0 / pi
-    #[inline]
-    fn frac_2_tau() -> f32 { consts::FRAC_2_TAU }
     /// 1.0 / pi = 2.0 / tau
     #[inline]
     fn frac_1_pi() -> f32 { consts::FRAC_1_PI }

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -51,39 +51,67 @@ pub mod consts {
     // of `Float`.
 
     /// Archimedes' constant
-    pub static PI: f32 = 3.14159265358979323846264338327950288_f32;
+    pub static TAU: f32 = 6.28318530717958647692528676655900576_f32;
+    /// pi * 2.0 = tau
+    pub static PI_2: f32 = TAU;
 
-    /// pi * 2.0
-    pub static PI_2: f32 = 6.28318530717958647692528676655900576_f32;
+    /// tau / 2.0 = pi
+    pub static FRAC_TAU_2: f32 = 3.14159265358979323846264338327950288_f32;
+    /// pi = tau / 2.0
+    pub static PI: f32 = FRAC_TAU_2;
 
-    /// pi/2.0
-    pub static FRAC_PI_2: f32 = 1.57079632679489661923132169163975144_f32;
+    /// tau / 3.0 = 2.0 * pi / 3.0
+    pub static FRAC_TAU_3: f32 = 2.094395102393195492308428922186335256_f32;
+    /// 2.0 * pi / 3.0 = tau / 3.0
+    pub static FRAC_2PI_3: f32 = FRAC_TAU_3;
 
-    /// pi/3.0
-    pub static FRAC_PI_3: f32 = 1.04719755119659774615421446109316763_f32;
+    /// tau / 4.0 = pi / 2.0
+    pub static FRAC_TAU_4: f32 = 1.57079632679489661923132169163975144_f32;
+    /// pi / 2.0 = tau / 4.0
+    pub static FRAC_PI_2: f32 = FRAC_TAU_4;
 
-    /// pi/4.0
-    pub static FRAC_PI_4: f32 = 0.785398163397448309615660845819875721_f32;
+    /// tau / 6.0 = pi / 3.0
+    pub static FRAC_TAU_6: f32 = 1.04719755119659774615421446109316763_f32;
+    /// pi / 3.0 = tau / 6.0
+    pub static FRAC_PI_3: f32 = FRAC_TAU_6;
 
-    /// pi/6.0
-    pub static FRAC_PI_6: f32 = 0.52359877559829887307710723054658381_f32;
+    /// tau / 8.0 = pi / 4.0
+    pub static FRAC_TAU_8: f32 = 0.785398163397448309615660845819875721_f32;
+    /// pi / 4.0 = tau / 8.0
+    pub static FRAC_PI_4: f32 = FRAC_TAU_8;
 
-    /// pi/8.0
-    pub static FRAC_PI_8: f32 = 0.39269908169872415480783042290993786_f32;
+    /// tau / 12.0 = pi / 6.0
+    pub static FRAC_TAU_12: f32 = 0.52359877559829887307710723054658381_f32;
+    /// pi / 6.0 = tau / 12.0
+    pub static FRAC_PI_6: f32 = FRAC_TAU_12;
 
-    /// 1.0/pi
-    pub static FRAC_1_PI: f32 = 0.318309886183790671537767526745028724_f32;
+    /// tau / 16.0 = pi / 8.0
+    pub static FRAC_TAU_16: f32 = 0.39269908169872415480783042290993786_f32;
+    /// pi / 8.0 = tau / 16.0
+    pub static FRAC_PI_8: f32 = FRAC_TAU_16;
 
-    /// 2.0/pi
-    pub static FRAC_2_PI: f32 = 0.636619772367581343075535053490057448_f32;
+    /// 1.0 / tau = 1.0 / (pi * 2.0)
+    pub static FRAC_1_TAU: f32 = 0.159154943091895335768883763372514362_f32;
+    /// 1.0 / (pi * 2.0) = 1.0 / tau
+    pub static FRAC_1_2PI: f32 = FRAC_1_TAU;
 
-    /// 2.0/sqrt(pi)
+    /// 2.0 / tau = 1.0 / pi
+    pub static FRAC_2_TAU: f32 = 0.318309886183790671537767526745028724_f32;
+    /// 1.0 / pi = 2.0 / tau
+    pub static FRAC_1_PI: f32 = FRAC_2_TAU;
+
+    /// 4.0 / tau = 2.0 / pi
+    pub static FRAC_4_TAU: f32 = 0.636619772367581343075535053490057448_f32;
+    /// 2.0 / pi = 4.0 / tau
+    pub static FRAC_2_PI: f32 = FRAC_4_TAU;
+
+    /// 2.0 / sqrt(pi)
     pub static FRAC_2_SQRTPI: f32 = 1.12837916709551257389615890312154517_f32;
 
     /// sqrt(2.0)
     pub static SQRT2: f32 = 1.41421356237309504880168872420969808_f32;
 
-    /// 1.0/sqrt(2.0)
+    /// 1.0 / sqrt(2.0)
     pub static FRAC_1_SQRT2: f32 = 0.707106781186547524400844362104849039_f32;
 
     /// Euler's number
@@ -265,37 +293,78 @@ impl Float for f32 {
 
     /// Archimedes' constant
     #[inline]
-    fn pi() -> f32 { consts::PI }
-
-    /// 2.0 * pi
+    fn tau() -> f32 { consts::TAU }
+    /// 2.0 * pi = tau
     #[inline]
     fn two_pi() -> f32 { consts::PI_2 }
 
-    /// pi / 2.0
+    /// tau / 2.0 = pi
+    #[inline]
+    fn frac_tau_2() -> f32 { consts::FRAC_TAU_2 }
+    /// pi = tau / 2.0
+    #[inline]
+    fn pi() -> f32 { consts::PI }
+
+    /// tau / 3.0 = 2.0 * pi / 3.0
+    #[inline]
+    fn frac_tau_3() -> f32 { consts::FRAC_TAU_3 }
+    /// 2.0 * pi / 3.0 = tau / 3.0
+    #[inline]
+    fn frac_2pi_3() -> f32 { consts::FRAC_2PI_3 }
+
+    /// tau / 4.0 = pi / 2.0
+    #[inline]
+    fn frac_tau_4() -> f32 { consts::FRAC_TAU_4 }
+    /// pi / 2.0 = tau / 4.0
     #[inline]
     fn frac_pi_2() -> f32 { consts::FRAC_PI_2 }
 
-    /// pi / 3.0
+    /// tau / 6.0 = pi / 3.0
+    #[inline]
+    fn frac_tau_6() -> f32 { consts::FRAC_TAU_6 }
+    /// pi / 3.0 = tau / 6.0
     #[inline]
     fn frac_pi_3() -> f32 { consts::FRAC_PI_3 }
 
-    /// pi / 4.0
+    /// tau / 8.0 = pi / 4.0
+    #[inline]
+    fn frac_tau_8() -> f32 { consts::FRAC_TAU_8 }
+    /// pi / 4.0 = tau / 8.0
     #[inline]
     fn frac_pi_4() -> f32 { consts::FRAC_PI_4 }
 
-    /// pi / 6.0
+    /// tau / 12.0 = pi / 6.0
+    #[inline]
+    fn frac_tau_12() -> f32 { consts::FRAC_TAU_12 }
+    /// pi / 6.0 = tau / 12.0
     #[inline]
     fn frac_pi_6() -> f32 { consts::FRAC_PI_6 }
 
-    /// pi / 8.0
+    /// tau / 16.0 = pi / 8.0
+    #[inline]
+    fn frac_tau_16() -> f32 { consts::FRAC_TAU_16 }
+    /// pi / 8.0 = tau / 16.0
     #[inline]
     fn frac_pi_8() -> f32 { consts::FRAC_PI_8 }
 
-    /// 1 .0/ pi
+    /// 1.0 / tau = 1.0 / (pi * 2.0)
+    #[inline]
+    fn frac_1_tau() -> f32 { consts::FRAC_1_TAU }
+    /// 1.0 / (pi * 2.0) = 1.0 / tau
+    #[inline]
+    fn frac_1_2pi() -> f32 { consts::FRAC_1_2PI }
+
+    /// 2.0 / tau = 1.0 / pi
+    #[inline]
+    fn frac_2_tau() -> f32 { consts::FRAC_2_TAU }
+    /// 1.0 / pi = 2.0 / tau
     #[inline]
     fn frac_1_pi() -> f32 { consts::FRAC_1_PI }
 
-    /// 2.0 / pi
+    /// 4.0 / tau = 2.0 / pi
+    #[inline]
+    fn frac_4_tau() -> f32 { consts::FRAC_4_TAU }
+    /// 2.0 / pi = 4.0 / tau
     #[inline]
     fn frac_2_pi() -> f32 { consts::FRAC_2_PI }
 

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -65,30 +65,10 @@ pub mod consts {
     /// 2.0 * pi / 3.0 = tau / 3.0
     pub static FRAC_2PI_3: f32 = FRAC_TAU_3;
 
-    /// tau / 4.0 = pi / 2.0
-    pub static FRAC_TAU_4: f32 = 1.57079632679489661923132169163975144_f32;
-    /// pi / 2.0 = tau / 4.0
-    pub static FRAC_PI_2: f32 = FRAC_TAU_4;
-
     /// tau / 6.0 = pi / 3.0
     pub static FRAC_TAU_6: f32 = 1.04719755119659774615421446109316763_f32;
     /// pi / 3.0 = tau / 6.0
     pub static FRAC_PI_3: f32 = FRAC_TAU_6;
-
-    /// tau / 8.0 = pi / 4.0
-    pub static FRAC_TAU_8: f32 = 0.785398163397448309615660845819875721_f32;
-    /// pi / 4.0 = tau / 8.0
-    pub static FRAC_PI_4: f32 = FRAC_TAU_8;
-
-    /// tau / 12.0 = pi / 6.0
-    pub static FRAC_TAU_12: f32 = 0.52359877559829887307710723054658381_f32;
-    /// pi / 6.0 = tau / 12.0
-    pub static FRAC_PI_6: f32 = FRAC_TAU_12;
-
-    /// tau / 16.0 = pi / 8.0
-    pub static FRAC_TAU_16: f32 = 0.39269908169872415480783042290993786_f32;
-    /// pi / 8.0 = tau / 16.0
-    pub static FRAC_PI_8: f32 = FRAC_TAU_16;
 
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     pub static FRAC_1_TAU: f32 = 0.159154943091895335768883763372514362_f32;
@@ -99,14 +79,6 @@ pub mod consts {
     pub static FRAC_2_TAU: f32 = 0.318309886183790671537767526745028724_f32;
     /// 1.0 / pi = 2.0 / tau
     pub static FRAC_1_PI: f32 = FRAC_2_TAU;
-
-    /// 4.0 / tau = 2.0 / pi
-    pub static FRAC_4_TAU: f32 = 0.636619772367581343075535053490057448_f32;
-    /// 2.0 / pi = 4.0 / tau
-    pub static FRAC_2_PI: f32 = FRAC_4_TAU;
-
-    /// 2.0 / sqrt(pi)
-    pub static FRAC_2_SQRTPI: f32 = 1.12837916709551257389615890312154517_f32;
 
     /// sqrt(2.0)
     pub static SQRT2: f32 = 1.41421356237309504880168872420969808_f32;
@@ -312,40 +284,12 @@ impl Float for f32 {
     #[inline]
     fn frac_2pi_3() -> f32 { consts::FRAC_2PI_3 }
 
-    /// tau / 4.0 = pi / 2.0
-    #[inline]
-    fn frac_tau_4() -> f32 { consts::FRAC_TAU_4 }
-    /// pi / 2.0 = tau / 4.0
-    #[inline]
-    fn frac_pi_2() -> f32 { consts::FRAC_PI_2 }
-
     /// tau / 6.0 = pi / 3.0
     #[inline]
     fn frac_tau_6() -> f32 { consts::FRAC_TAU_6 }
     /// pi / 3.0 = tau / 6.0
     #[inline]
     fn frac_pi_3() -> f32 { consts::FRAC_PI_3 }
-
-    /// tau / 8.0 = pi / 4.0
-    #[inline]
-    fn frac_tau_8() -> f32 { consts::FRAC_TAU_8 }
-    /// pi / 4.0 = tau / 8.0
-    #[inline]
-    fn frac_pi_4() -> f32 { consts::FRAC_PI_4 }
-
-    /// tau / 12.0 = pi / 6.0
-    #[inline]
-    fn frac_tau_12() -> f32 { consts::FRAC_TAU_12 }
-    /// pi / 6.0 = tau / 12.0
-    #[inline]
-    fn frac_pi_6() -> f32 { consts::FRAC_PI_6 }
-
-    /// tau / 16.0 = pi / 8.0
-    #[inline]
-    fn frac_tau_16() -> f32 { consts::FRAC_TAU_16 }
-    /// pi / 8.0 = tau / 16.0
-    #[inline]
-    fn frac_pi_8() -> f32 { consts::FRAC_PI_8 }
 
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     #[inline]
@@ -360,17 +304,6 @@ impl Float for f32 {
     /// 1.0 / pi = 2.0 / tau
     #[inline]
     fn frac_1_pi() -> f32 { consts::FRAC_1_PI }
-
-    /// 4.0 / tau = 2.0 / pi
-    #[inline]
-    fn frac_4_tau() -> f32 { consts::FRAC_4_TAU }
-    /// 2.0 / pi = 4.0 / tau
-    #[inline]
-    fn frac_2_pi() -> f32 { consts::FRAC_2_PI }
-
-    /// 2.0 / sqrt(pi)
-    #[inline]
-    fn frac_2_sqrtpi() -> f32 { consts::FRAC_2_SQRTPI }
 
     /// Euler's number
     #[inline]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -69,30 +69,10 @@ pub mod consts {
     /// 2.0 * pi / 3.0 = tau / 3.0
     pub static FRAC_2PI_3: f64 = FRAC_TAU_3;
 
-    /// tau / 4.0 = pi / 2.0
-    pub static FRAC_TAU_4: f64 = 1.57079632679489661923132169163975144_f64;
-    /// pi / 2.0 = tau / 4.0
-    pub static FRAC_PI_2: f64 = FRAC_TAU_4;
-
     /// tau / 6.0 = pi / 3.0
     pub static FRAC_TAU_6: f64 = 1.04719755119659774615421446109316763_f64;
     /// pi / 3.0 = tau / 6.0
     pub static FRAC_PI_3: f64 = FRAC_TAU_6;
-
-    /// tau / 8.0 = pi / 4.0
-    pub static FRAC_TAU_8: f64 = 0.785398163397448309615660845819875721_f64;
-    /// pi / 4.0 = tau / 8.0
-    pub static FRAC_PI_4: f64 = FRAC_TAU_8;
-
-    /// tau / 12.0 = pi / 6.0
-    pub static FRAC_TAU_12: f64 = 0.52359877559829887307710723054658381_f64;
-    /// pi / 6.0 = tau / 12.0
-    pub static FRAC_PI_6: f64 = FRAC_TAU_12;
-
-    /// tau / 16.0 = pi / 8.0
-    pub static FRAC_TAU_16: f64 = 0.39269908169872415480783042290993786_f64;
-    /// pi / 8.0 = tau / 16.0
-    pub static FRAC_PI_8: f64 = FRAC_TAU_16;
 
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     pub static FRAC_1_TAU: f64 = 0.159154943091895335768883763372514362_f64;
@@ -103,14 +83,6 @@ pub mod consts {
     pub static FRAC_2_TAU: f64 = 0.318309886183790671537767526745028724_f64;
     /// 1.0 / pi = 2.0 / tau
     pub static FRAC_1_PI: f64 = FRAC_2_TAU;
-
-    /// 4.0 / tau = 2.0 / pi
-    pub static FRAC_4_TAU: f64 = 0.636619772367581343075535053490057448_f64;
-    /// 2.0 / pi = 4.0 / tau
-    pub static FRAC_2_PI: f64 = FRAC_4_TAU;
-
-    /// 2.0 / sqrt(pi)
-    pub static FRAC_2_SQRTPI: f64 = 1.12837916709551257389615890312154517_f64;
 
     /// sqrt(2.0)
     pub static SQRT2: f64 = 1.41421356237309504880168872420969808_f64;
@@ -317,40 +289,12 @@ impl Float for f64 {
     #[inline]
     fn frac_2pi_3() -> f64 { consts::FRAC_2PI_3 }
 
-    /// tau / 4.0 = pi / 2.0
-    #[inline]
-    fn frac_tau_4() -> f64 { consts::FRAC_TAU_4 }
-    /// pi / 2.0
-    #[inline]
-    fn frac_pi_2() -> f64 { consts::FRAC_PI_2 }
-
     /// tau / 6.0 = pi / 3.0
     #[inline]
     fn frac_tau_6() -> f64 { consts::FRAC_TAU_6 }
     /// pi / 3.0 = tau / 6.0
     #[inline]
     fn frac_pi_3() -> f64 { consts::FRAC_PI_3 }
-
-    /// tau / 8.0 = pi / 4.0
-    #[inline]
-    fn frac_tau_8() -> f64 { consts::FRAC_TAU_8 }
-    /// pi / 4.0 = tau / 8.0
-    #[inline]
-    fn frac_pi_4() -> f64 { consts::FRAC_PI_4 }
-
-    /// tau / 12.0 = pi / 6.0
-    #[inline]
-    fn frac_tau_12() -> f64 { consts::FRAC_TAU_12 }
-    /// pi / 6.0 = tau / 12.0
-    #[inline]
-    fn frac_pi_6() -> f64 { consts::FRAC_PI_6 }
-
-    /// tau / 16.0 = pi / 8.0
-    #[inline]
-    fn frac_tau_16() -> f64 { consts::FRAC_TAU_16 }
-    /// pi / 8.0 = tau / 16.0
-    #[inline]
-    fn frac_pi_8() -> f64 { consts::FRAC_PI_8 }
 
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     #[inline]
@@ -365,17 +309,6 @@ impl Float for f64 {
     /// 1.0 / pi = 2.0 / tau
     #[inline]
     fn frac_1_pi() -> f64 { consts::FRAC_1_PI }
-
-    /// 4.0 / tau = 2.0 / pi
-    #[inline]
-    fn frac_4_tau() -> f64 { consts::FRAC_4_TAU }
-    /// 2.0 / pi = 4.0 / tau
-    #[inline]
-    fn frac_2_pi() -> f64 { consts::FRAC_2_PI }
-
-    /// 2.0 / sqrt(pi)
-    #[inline]
-    fn frac_2_sqrtpi() -> f64 { consts::FRAC_2_SQRTPI }
 
     /// Euler's number
     #[inline]

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -43,9 +43,7 @@ pub static MIN_10_EXP: int = -307;
 pub static MAX_10_EXP: int = 308;
 
 pub static NAN: f64 = 0.0_f64/0.0_f64;
-
 pub static INFINITY: f64 = 1.0_f64/0.0_f64;
-
 pub static NEG_INFINITY: f64 = -1.0_f64/0.0_f64;
 
 /// Various useful constants.
@@ -57,39 +55,67 @@ pub mod consts {
     // of `Float`.
 
     /// Archimedes' constant
-    pub static PI: f64 = 3.14159265358979323846264338327950288_f64;
+    pub static TAU: f64 = 6.28318530717958647692528676655900576_f64;
+    /// pi * 2.0 = tau
+    pub static PI_2: f64 = TAU;
 
-    /// pi * 2.0
-    pub static PI_2: f64 = 6.28318530717958647692528676655900576_f64;
+    /// tau / 2.0 = pi
+    pub static FRAC_TAU_2: f64 = 3.14159265358979323846264338327950288_f64;
+    /// pi = tau / 2.0
+    pub static PI: f64 = FRAC_TAU_2;
 
-    /// pi/2.0
-    pub static FRAC_PI_2: f64 = 1.57079632679489661923132169163975144_f64;
+    /// tau / 3.0 = 2.0 * pi / 3.0
+    pub static FRAC_TAU_3: f64 = 2.094395102393195492308428922186335256_f64;
+    /// 2.0 * pi / 3.0 = tau / 3.0
+    pub static FRAC_2PI_3: f64 = FRAC_TAU_3;
 
-    /// pi/3.0
-    pub static FRAC_PI_3: f64 = 1.04719755119659774615421446109316763_f64;
+    /// tau / 4.0 = pi / 2.0
+    pub static FRAC_TAU_4: f64 = 1.57079632679489661923132169163975144_f64;
+    /// pi / 2.0 = tau / 4.0
+    pub static FRAC_PI_2: f64 = FRAC_TAU_4;
 
-    /// pi/4.0
-    pub static FRAC_PI_4: f64 = 0.785398163397448309615660845819875721_f64;
+    /// tau / 6.0 = pi / 3.0
+    pub static FRAC_TAU_6: f64 = 1.04719755119659774615421446109316763_f64;
+    /// pi / 3.0 = tau / 6.0
+    pub static FRAC_PI_3: f64 = FRAC_TAU_6;
 
-    /// pi/6.0
-    pub static FRAC_PI_6: f64 = 0.52359877559829887307710723054658381_f64;
+    /// tau / 8.0 = pi / 4.0
+    pub static FRAC_TAU_8: f64 = 0.785398163397448309615660845819875721_f64;
+    /// pi / 4.0 = tau / 8.0
+    pub static FRAC_PI_4: f64 = FRAC_TAU_8;
 
-    /// pi/8.0
-    pub static FRAC_PI_8: f64 = 0.39269908169872415480783042290993786_f64;
+    /// tau / 12.0 = pi / 6.0
+    pub static FRAC_TAU_12: f64 = 0.52359877559829887307710723054658381_f64;
+    /// pi / 6.0 = tau / 12.0
+    pub static FRAC_PI_6: f64 = FRAC_TAU_12;
 
-    /// 1.0/pi
-    pub static FRAC_1_PI: f64 = 0.318309886183790671537767526745028724_f64;
+    /// tau / 16.0 = pi / 8.0
+    pub static FRAC_TAU_16: f64 = 0.39269908169872415480783042290993786_f64;
+    /// pi / 8.0 = tau / 16.0
+    pub static FRAC_PI_8: f64 = FRAC_TAU_16;
 
-    /// 2.0/pi
-    pub static FRAC_2_PI: f64 = 0.636619772367581343075535053490057448_f64;
+    /// 1.0 / tau = 1.0 / (pi * 2.0)
+    pub static FRAC_1_TAU: f64 = 0.159154943091895335768883763372514362_f64;
+    /// 1.0 / (pi * 2.0) = 1.0 / tau
+    pub static FRAC_1_2PI: f64 = FRAC_1_TAU;
 
-    /// 2.0/sqrt(pi)
+    /// 2.0 / tau = 1.0 / pi
+    pub static FRAC_2_TAU: f64 = 0.318309886183790671537767526745028724_f64;
+    /// 1.0 / pi = 2.0 / tau
+    pub static FRAC_1_PI: f64 = FRAC_2_TAU;
+
+    /// 4.0 / tau = 2.0 / pi
+    pub static FRAC_4_TAU: f64 = 0.636619772367581343075535053490057448_f64;
+    /// 2.0 / pi = 4.0 / tau
+    pub static FRAC_2_PI: f64 = FRAC_4_TAU;
+
+    /// 2.0 / sqrt(pi)
     pub static FRAC_2_SQRTPI: f64 = 1.12837916709551257389615890312154517_f64;
 
     /// sqrt(2.0)
     pub static SQRT2: f64 = 1.41421356237309504880168872420969808_f64;
 
-    /// 1.0/sqrt(2.0)
+    /// 1.0 / sqrt(2.0)
     pub static FRAC_1_SQRT2: f64 = 0.707106781186547524400844362104849039_f64;
 
     /// Euler's number
@@ -272,37 +298,78 @@ impl Float for f64 {
 
     /// Archimedes' constant
     #[inline]
-    fn pi() -> f64 { consts::PI }
-
-    /// 2.0 * pi
+    fn tau() -> f64 { consts::TAU }
+    /// 2.0 * pi = tau
     #[inline]
     fn two_pi() -> f64 { consts::PI_2 }
 
+    /// tau / 2.0 = pi
+    #[inline]
+    fn frac_tau_2() -> f64 { consts::FRAC_TAU_2 }
+    /// pi = tau / 2.0
+    #[inline]
+    fn pi() -> f64 { consts::PI }
+
+    /// tau / 3.0 = 2.0 * pi / 3.0
+    #[inline]
+    fn frac_tau_3() -> f64 { consts::FRAC_TAU_3 }
+    /// 2.0 * pi / 3.0 = tau / 3.0
+    #[inline]
+    fn frac_2pi_3() -> f64 { consts::FRAC_2PI_3 }
+
+    /// tau / 4.0 = pi / 2.0
+    #[inline]
+    fn frac_tau_4() -> f64 { consts::FRAC_TAU_4 }
     /// pi / 2.0
     #[inline]
     fn frac_pi_2() -> f64 { consts::FRAC_PI_2 }
 
-    /// pi / 3.0
+    /// tau / 6.0 = pi / 3.0
+    #[inline]
+    fn frac_tau_6() -> f64 { consts::FRAC_TAU_6 }
+    /// pi / 3.0 = tau / 6.0
     #[inline]
     fn frac_pi_3() -> f64 { consts::FRAC_PI_3 }
 
-    /// pi / 4.0
+    /// tau / 8.0 = pi / 4.0
+    #[inline]
+    fn frac_tau_8() -> f64 { consts::FRAC_TAU_8 }
+    /// pi / 4.0 = tau / 8.0
     #[inline]
     fn frac_pi_4() -> f64 { consts::FRAC_PI_4 }
 
-    /// pi / 6.0
+    /// tau / 12.0 = pi / 6.0
+    #[inline]
+    fn frac_tau_12() -> f64 { consts::FRAC_TAU_12 }
+    /// pi / 6.0 = tau / 12.0
     #[inline]
     fn frac_pi_6() -> f64 { consts::FRAC_PI_6 }
 
-    /// pi / 8.0
+    /// tau / 16.0 = pi / 8.0
+    #[inline]
+    fn frac_tau_16() -> f64 { consts::FRAC_TAU_16 }
+    /// pi / 8.0 = tau / 16.0
     #[inline]
     fn frac_pi_8() -> f64 { consts::FRAC_PI_8 }
 
-    /// 1.0 / pi
+    /// 1.0 / tau = 1.0 / (pi * 2.0)
+    #[inline]
+    fn frac_1_tau() -> f64 { consts::FRAC_1_TAU }
+    /// 1.0 / (pi * 2.0) = 1.0 / tau
+    #[inline]
+    fn frac_1_2pi() -> f64 { consts::FRAC_1_2PI }
+
+    /// 2.0 / tau = 1.0 / pi
+    #[inline]
+    fn frac_2_tau() -> f64 { consts::FRAC_2_TAU }
+    /// 1.0 / pi = 2.0 / tau
     #[inline]
     fn frac_1_pi() -> f64 { consts::FRAC_1_PI }
 
-    /// 2.0 / pi
+    /// 4.0 / tau = 2.0 / pi
+    #[inline]
+    fn frac_4_tau() -> f64 { consts::FRAC_4_TAU }
+    /// 2.0 / pi = 4.0 / tau
     #[inline]
     fn frac_2_pi() -> f64 { consts::FRAC_2_PI }
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -56,33 +56,21 @@ pub mod consts {
 
     /// Archimedes' constant
     pub static TAU: f64 = 6.28318530717958647692528676655900576_f64;
-    /// pi * 2.0 = tau
-    pub static PI_2: f64 = TAU;
 
-    /// tau / 2.0 = pi
-    pub static FRAC_TAU_2: f64 = 3.14159265358979323846264338327950288_f64;
     /// pi = tau / 2.0
-    pub static PI: f64 = FRAC_TAU_2;
+    pub static PI: f64 = 3.14159265358979323846264338327950288_f64;
 
     /// tau / 3.0 = 2.0 * pi / 3.0
     pub static FRAC_TAU_3: f64 = 2.094395102393195492308428922186335256_f64;
-    /// 2.0 * pi / 3.0 = tau / 3.0
-    pub static FRAC_2PI_3: f64 = FRAC_TAU_3;
 
-    /// tau / 6.0 = pi / 3.0
-    pub static FRAC_TAU_6: f64 = 1.04719755119659774615421446109316763_f64;
     /// pi / 3.0 = tau / 6.0
-    pub static FRAC_PI_3: f64 = FRAC_TAU_6;
+    pub static FRAC_PI_3: f64 = 1.04719755119659774615421446109316763_f64;
 
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     pub static FRAC_1_TAU: f64 = 0.159154943091895335768883763372514362_f64;
-    /// 1.0 / (pi * 2.0) = 1.0 / tau
-    pub static FRAC_1_2PI: f64 = FRAC_1_TAU;
 
-    /// 2.0 / tau = 1.0 / pi
-    pub static FRAC_2_TAU: f64 = 0.318309886183790671537767526745028724_f64;
     /// 1.0 / pi = 2.0 / tau
-    pub static FRAC_1_PI: f64 = FRAC_2_TAU;
+    pub static FRAC_1_PI: f64 = 0.318309886183790671537767526745028724_f64;
 
     /// sqrt(2.0)
     pub static SQRT2: f64 = 1.41421356237309504880168872420969808_f64;
@@ -271,13 +259,7 @@ impl Float for f64 {
     /// Archimedes' constant
     #[inline]
     fn tau() -> f64 { consts::TAU }
-    /// 2.0 * pi = tau
-    #[inline]
-    fn two_pi() -> f64 { consts::PI_2 }
 
-    /// tau / 2.0 = pi
-    #[inline]
-    fn frac_tau_2() -> f64 { consts::FRAC_TAU_2 }
     /// pi = tau / 2.0
     #[inline]
     fn pi() -> f64 { consts::PI }
@@ -285,13 +267,7 @@ impl Float for f64 {
     /// tau / 3.0 = 2.0 * pi / 3.0
     #[inline]
     fn frac_tau_3() -> f64 { consts::FRAC_TAU_3 }
-    /// 2.0 * pi / 3.0 = tau / 3.0
-    #[inline]
-    fn frac_2pi_3() -> f64 { consts::FRAC_2PI_3 }
 
-    /// tau / 6.0 = pi / 3.0
-    #[inline]
-    fn frac_tau_6() -> f64 { consts::FRAC_TAU_6 }
     /// pi / 3.0 = tau / 6.0
     #[inline]
     fn frac_pi_3() -> f64 { consts::FRAC_PI_3 }
@@ -299,13 +275,7 @@ impl Float for f64 {
     /// 1.0 / tau = 1.0 / (pi * 2.0)
     #[inline]
     fn frac_1_tau() -> f64 { consts::FRAC_1_TAU }
-    /// 1.0 / (pi * 2.0) = 1.0 / tau
-    #[inline]
-    fn frac_1_2pi() -> f64 { consts::FRAC_1_2PI }
 
-    /// 2.0 / tau = 1.0 / pi
-    #[inline]
-    fn frac_2_tau() -> f64 { consts::FRAC_2_TAU }
     /// 1.0 / pi = 2.0 / tau
     #[inline]
     fn frac_1_pi() -> f64 { consts::FRAC_1_PI }

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1495,24 +1495,50 @@ pub trait Float: Signed + Primitive {
     // FIXME (#5527): These should be associated constants
 
     /// Archimedes' constant.
-    fn pi() -> Self;
-    /// 2.0 * pi.
+    fn tau() -> Self;
+    /// 2.0 * pi = tau.
     fn two_pi() -> Self;
-    /// pi / 2.0.
+    /// tau / 2.0 = pi.
+    fn frac_tau_2() -> Self;
+    /// pi = tau / 2.0.
+    fn pi() -> Self;
+    /// tau / 3.0 = 2.0 * pi / 3.0.
+    fn frac_tau_3() -> Self;
+    /// 2.0 * pi / 3.0 = tau / 3.0.
+    fn frac_2pi_3() -> Self;
+    /// tau / 4.0 = pi / 2.0.
+    fn frac_tau_4() -> Self;
+    /// pi / 2.0 = tau / 4.0.
     fn frac_pi_2() -> Self;
-    /// pi / 3.0.
+    /// tau / 6.0 = pi / 3.0.
+    fn frac_tau_6() -> Self;
+    /// pi / 3.0 = tau / 6.0.
     fn frac_pi_3() -> Self;
-    /// pi / 4.0.
+    /// tau / 8.0 = pi / 4.0.
+    fn frac_tau_8() -> Self;
+    /// pi / 4.0 = tau / 8.0.
     fn frac_pi_4() -> Self;
-    /// pi / 6.0.
+    /// tau / 12.0 = pi / 6.0.
+    fn frac_tau_12() -> Self;
+    /// pi / 6.0 = tau / 12.0.
     fn frac_pi_6() -> Self;
-    /// pi / 8.0.
+    /// tau / 16.0 = pi / 8.0.
+    fn frac_tau_16() -> Self;
+    /// pi / 8.0 = tau / 16.0.
     fn frac_pi_8() -> Self;
-    /// 1.0 / pi.
+    /// 1.0 / tau = 1.0 / (pi * 2.0).
+    fn frac_1_tau() -> Self;
+    /// 1.0 / (pi * 2.0) = 1.0 / tau.
+    fn frac_1_2pi() -> Self;
+    /// 2.0 / tau = 1.0 / pi.
+    fn frac_2_tau() -> Self;
+    /// 1.0 / pi = 2.0 / tau.
     fn frac_1_pi() -> Self;
-    /// 2.0 / pi.
+    /// 4.0 / tau = 2.0 / pi.
+    fn frac_4_tau() -> Self;
+    /// 2.0 / pi = 4.0 / tau.
     fn frac_2_pi() -> Self;
-    /// 2.0 / sqrt(pi).
+    /// 2.0 / sqrt(pi) = 2.0 * sqrt(2.0 / tau).
     fn frac_2_sqrtpi() -> Self;
 
     /// Euler's number.

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1496,26 +1496,14 @@ pub trait Float: Signed + Primitive {
 
     /// Archimedes' constant.
     fn tau() -> Self;
-    /// 2.0 * pi = tau.
-    fn two_pi() -> Self;
-    /// tau / 2.0 = pi.
-    fn frac_tau_2() -> Self;
     /// pi = tau / 2.0.
     fn pi() -> Self;
     /// tau / 3.0 = 2.0 * pi / 3.0.
     fn frac_tau_3() -> Self;
-    /// 2.0 * pi / 3.0 = tau / 3.0.
-    fn frac_2pi_3() -> Self;
-    /// tau / 6.0 = pi / 3.0.
-    fn frac_tau_6() -> Self;
     /// pi / 3.0 = tau / 6.0.
     fn frac_pi_3() -> Self;
     /// 1.0 / tau = 1.0 / (pi * 2.0).
     fn frac_1_tau() -> Self;
-    /// 1.0 / (pi * 2.0) = 1.0 / tau.
-    fn frac_1_2pi() -> Self;
-    /// 2.0 / tau = 1.0 / pi.
-    fn frac_2_tau() -> Self;
     /// 1.0 / pi = 2.0 / tau.
     fn frac_1_pi() -> Self;
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1506,26 +1506,10 @@ pub trait Float: Signed + Primitive {
     fn frac_tau_3() -> Self;
     /// 2.0 * pi / 3.0 = tau / 3.0.
     fn frac_2pi_3() -> Self;
-    /// tau / 4.0 = pi / 2.0.
-    fn frac_tau_4() -> Self;
-    /// pi / 2.0 = tau / 4.0.
-    fn frac_pi_2() -> Self;
     /// tau / 6.0 = pi / 3.0.
     fn frac_tau_6() -> Self;
     /// pi / 3.0 = tau / 6.0.
     fn frac_pi_3() -> Self;
-    /// tau / 8.0 = pi / 4.0.
-    fn frac_tau_8() -> Self;
-    /// pi / 4.0 = tau / 8.0.
-    fn frac_pi_4() -> Self;
-    /// tau / 12.0 = pi / 6.0.
-    fn frac_tau_12() -> Self;
-    /// pi / 6.0 = tau / 12.0.
-    fn frac_pi_6() -> Self;
-    /// tau / 16.0 = pi / 8.0.
-    fn frac_tau_16() -> Self;
-    /// pi / 8.0 = tau / 16.0.
-    fn frac_pi_8() -> Self;
     /// 1.0 / tau = 1.0 / (pi * 2.0).
     fn frac_1_tau() -> Self;
     /// 1.0 / (pi * 2.0) = 1.0 / tau.
@@ -1534,12 +1518,6 @@ pub trait Float: Signed + Primitive {
     fn frac_2_tau() -> Self;
     /// 1.0 / pi = 2.0 / tau.
     fn frac_1_pi() -> Self;
-    /// 4.0 / tau = 2.0 / pi.
-    fn frac_4_tau() -> Self;
-    /// 2.0 / pi = 4.0 / tau.
-    fn frac_2_pi() -> Self;
-    /// 2.0 / sqrt(pi) = 2.0 * sqrt(2.0 / tau).
-    fn frac_2_sqrtpi() -> Self;
 
     /// Euler's number.
     fn e() -> Self;

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -594,16 +594,31 @@ mod tests {
 
     #[test]
     fn test_real_consts() {
+        let tau: f32 = Float::tau();
+        let frac_tau_2: f32 = Float::frac_tau_2();
+        let frac_tau_3: f32 = Float::frac_tau_3();
+        let frac_tau_4: f32 = Float::frac_tau_4();
+        let frac_tau_6: f32 = Float::frac_tau_6();
+        let frac_tau_8: f32 = Float::frac_tau_8();
+        let frac_tau_12: f32 = Float::frac_tau_12();
+        let frac_tau_16: f32 = Float::frac_tau_16();
+        let frac_1_tau: f32 = Float::frac_1_tau();
+        let frac_2_tau: f32 = Float::frac_2_tau();
+        let frac_4_tau: f32 = Float::frac_4_tau();
+
         let pi: f32 = Float::pi();
         let two_pi: f32 = Float::two_pi();
+        let frac_2pi_3: f32 = Float::frac_2pi_3();
         let frac_pi_2: f32 = Float::frac_pi_2();
         let frac_pi_3: f32 = Float::frac_pi_3();
         let frac_pi_4: f32 = Float::frac_pi_4();
         let frac_pi_6: f32 = Float::frac_pi_6();
         let frac_pi_8: f32 = Float::frac_pi_8();
+        let frac_1_2pi: f32 = Float::frac_1_2pi();
         let frac_1_pi: f32 = Float::frac_1_pi();
         let frac_2_pi: f32 = Float::frac_2_pi();
         let frac_2_sqrtpi: f32 = Float::frac_2_sqrtpi();
+
         let sqrt2: f32 = Float::sqrt2();
         let frac_1_sqrt2: f32 = Float::frac_1_sqrt2();
         let e: f32 = Float::e();
@@ -612,12 +627,25 @@ mod tests {
         let ln_2: f32 = Float::ln_2();
         let ln_10: f32 = Float::ln_10();
 
+        assert_approx_eq!(frac_tau_2, tau / 2f32);
+        assert_approx_eq!(frac_tau_3, tau / 3f32);
+        assert_approx_eq!(frac_tau_4, tau / 4f32);
+        assert_approx_eq!(frac_tau_6, tau / 6f32);
+        assert_approx_eq!(frac_tau_8, tau / 8f32);
+        assert_approx_eq!(frac_tau_12, tau / 12f32);
+        assert_approx_eq!(frac_tau_16, tau / 16f32);
+        assert_approx_eq!(frac_1_tau, 1f32 / tau);
+        assert_approx_eq!(frac_2_tau, 2f32 / tau);
+        assert_approx_eq!(frac_4_tau, 4f32 / tau);
+
         assert_approx_eq!(two_pi, 2f32 * pi);
+        assert_approx_eq!(frac_2pi_3, 2f32 * pi / 3f32);
         assert_approx_eq!(frac_pi_2, pi / 2f32);
         assert_approx_eq!(frac_pi_3, pi / 3f32);
         assert_approx_eq!(frac_pi_4, pi / 4f32);
         assert_approx_eq!(frac_pi_6, pi / 6f32);
         assert_approx_eq!(frac_pi_8, pi / 8f32);
+        assert_approx_eq!(frac_1_2pi, 1f32 / (2f32 * pi));
         assert_approx_eq!(frac_1_pi, 1f32 / pi);
         assert_approx_eq!(frac_2_pi, 2f32 / pi);
         assert_approx_eq!(frac_2_sqrtpi, 2f32 / pi.sqrt());

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -595,17 +595,10 @@ mod tests {
     #[test]
     fn test_real_consts() {
         let tau: f32 = Float::tau();
-        let frac_tau_2: f32 = Float::frac_tau_2();
         let frac_tau_3: f32 = Float::frac_tau_3();
-        let frac_tau_6: f32 = Float::frac_tau_6();
         let frac_1_tau: f32 = Float::frac_1_tau();
-        let frac_2_tau: f32 = Float::frac_2_tau();
-
         let pi: f32 = Float::pi();
-        let two_pi: f32 = Float::two_pi();
-        let frac_2pi_3: f32 = Float::frac_2pi_3();
         let frac_pi_3: f32 = Float::frac_pi_3();
-        let frac_1_2pi: f32 = Float::frac_1_2pi();
         let frac_1_pi: f32 = Float::frac_1_pi();
 
         let sqrt2: f32 = Float::sqrt2();
@@ -616,16 +609,9 @@ mod tests {
         let ln_2: f32 = Float::ln_2();
         let ln_10: f32 = Float::ln_10();
 
-        assert_approx_eq!(frac_tau_2, tau / 2f32);
         assert_approx_eq!(frac_tau_3, tau / 3f32);
-        assert_approx_eq!(frac_tau_6, tau / 6f32);
         assert_approx_eq!(frac_1_tau, 1f32 / tau);
-        assert_approx_eq!(frac_2_tau, 2f32 / tau);
-
-        assert_approx_eq!(two_pi, 2f32 * pi);
-        assert_approx_eq!(frac_2pi_3, 2f32 * pi / 3f32);
         assert_approx_eq!(frac_pi_3, pi / 3f32);
-        assert_approx_eq!(frac_1_2pi, 1f32 / (2f32 * pi));
         assert_approx_eq!(frac_1_pi, 1f32 / pi);
 
         assert_approx_eq!(sqrt2, 2f32.sqrt());

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -597,27 +597,16 @@ mod tests {
         let tau: f32 = Float::tau();
         let frac_tau_2: f32 = Float::frac_tau_2();
         let frac_tau_3: f32 = Float::frac_tau_3();
-        let frac_tau_4: f32 = Float::frac_tau_4();
         let frac_tau_6: f32 = Float::frac_tau_6();
-        let frac_tau_8: f32 = Float::frac_tau_8();
-        let frac_tau_12: f32 = Float::frac_tau_12();
-        let frac_tau_16: f32 = Float::frac_tau_16();
         let frac_1_tau: f32 = Float::frac_1_tau();
         let frac_2_tau: f32 = Float::frac_2_tau();
-        let frac_4_tau: f32 = Float::frac_4_tau();
 
         let pi: f32 = Float::pi();
         let two_pi: f32 = Float::two_pi();
         let frac_2pi_3: f32 = Float::frac_2pi_3();
-        let frac_pi_2: f32 = Float::frac_pi_2();
         let frac_pi_3: f32 = Float::frac_pi_3();
-        let frac_pi_4: f32 = Float::frac_pi_4();
-        let frac_pi_6: f32 = Float::frac_pi_6();
-        let frac_pi_8: f32 = Float::frac_pi_8();
         let frac_1_2pi: f32 = Float::frac_1_2pi();
         let frac_1_pi: f32 = Float::frac_1_pi();
-        let frac_2_pi: f32 = Float::frac_2_pi();
-        let frac_2_sqrtpi: f32 = Float::frac_2_sqrtpi();
 
         let sqrt2: f32 = Float::sqrt2();
         let frac_1_sqrt2: f32 = Float::frac_1_sqrt2();
@@ -629,26 +618,16 @@ mod tests {
 
         assert_approx_eq!(frac_tau_2, tau / 2f32);
         assert_approx_eq!(frac_tau_3, tau / 3f32);
-        assert_approx_eq!(frac_tau_4, tau / 4f32);
         assert_approx_eq!(frac_tau_6, tau / 6f32);
-        assert_approx_eq!(frac_tau_8, tau / 8f32);
-        assert_approx_eq!(frac_tau_12, tau / 12f32);
-        assert_approx_eq!(frac_tau_16, tau / 16f32);
         assert_approx_eq!(frac_1_tau, 1f32 / tau);
         assert_approx_eq!(frac_2_tau, 2f32 / tau);
-        assert_approx_eq!(frac_4_tau, 4f32 / tau);
 
         assert_approx_eq!(two_pi, 2f32 * pi);
         assert_approx_eq!(frac_2pi_3, 2f32 * pi / 3f32);
-        assert_approx_eq!(frac_pi_2, pi / 2f32);
         assert_approx_eq!(frac_pi_3, pi / 3f32);
-        assert_approx_eq!(frac_pi_4, pi / 4f32);
-        assert_approx_eq!(frac_pi_6, pi / 6f32);
-        assert_approx_eq!(frac_pi_8, pi / 8f32);
         assert_approx_eq!(frac_1_2pi, 1f32 / (2f32 * pi));
         assert_approx_eq!(frac_1_pi, 1f32 / pi);
-        assert_approx_eq!(frac_2_pi, 2f32 / pi);
-        assert_approx_eq!(frac_2_sqrtpi, 2f32 / pi.sqrt());
+
         assert_approx_eq!(sqrt2, 2f32.sqrt());
         assert_approx_eq!(frac_1_sqrt2, 1f32 / 2f32.sqrt());
         assert_approx_eq!(log2_e, e.log2());

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -598,17 +598,10 @@ mod tests {
     #[test]
     fn test_real_consts() {
         let tau: f64 = Float::tau();
-        let frac_tau_2: f64 = Float::frac_tau_2();
         let frac_tau_3: f64 = Float::frac_tau_3();
-        let frac_tau_6: f64 = Float::frac_tau_6();
         let frac_1_tau: f64 = Float::frac_1_tau();
-        let frac_2_tau: f64 = Float::frac_2_tau();
-
         let pi: f64 = Float::pi();
-        let two_pi: f64 = Float::two_pi();
-        let frac_2pi_3: f64 = Float::frac_pi_2();
         let frac_pi_3: f64 = Float::frac_pi_3();
-        let frac_1_2pi: f64 = Float::frac_1_2pi();
         let frac_1_pi: f64 = Float::frac_1_pi();
 
         let sqrt2: f64 = Float::sqrt2();
@@ -619,16 +612,9 @@ mod tests {
         let ln_2: f64 = Float::ln_2();
         let ln_10: f64 = Float::ln_10();
 
-        assert_approx_eq!(frac_tau_2, tau / 2f64);
         assert_approx_eq!(frac_tau_3, tau / 3f64);
-        assert_approx_eq!(frac_tau_6, tau / 6f64);
         assert_approx_eq!(frac_1_tau, 1f64 / tau);
-        assert_approx_eq!(frac_2_tau, 2f64 / tau);
-
-        assert_approx_eq!(two_pi, 2f64 * pi);
-        assert_approx_eq!(frac_2pi_3, 2f64 * pi / 3f64);
         assert_approx_eq!(frac_pi_3, pi / 3f64);
-        assert_approx_eq!(frac_1_2pi, 1f64 / (2f64 * pi));
         assert_approx_eq!(frac_1_pi, 1f64 / pi);
 
         assert_approx_eq!(sqrt2, 2f64.sqrt());

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -600,27 +600,16 @@ mod tests {
         let tau: f64 = Float::tau();
         let frac_tau_2: f64 = Float::frac_tau_2();
         let frac_tau_3: f64 = Float::frac_tau_3();
-        let frac_tau_4: f64 = Float::frac_tau_4();
         let frac_tau_6: f64 = Float::frac_tau_6();
-        let frac_tau_8: f64 = Float::frac_tau_8();
-        let frac_tau_12: f64 = Float::frac_tau_12();
-        let frac_tau_16: f64 = Float::frac_tau_16();
         let frac_1_tau: f64 = Float::frac_1_tau();
         let frac_2_tau: f64 = Float::frac_2_tau();
-        let frac_4_tau: f64 = Float::frac_4_tau();
 
         let pi: f64 = Float::pi();
         let two_pi: f64 = Float::two_pi();
         let frac_2pi_3: f64 = Float::frac_pi_2();
-        let frac_pi_2: f64 = Float::frac_pi_2();
         let frac_pi_3: f64 = Float::frac_pi_3();
-        let frac_pi_4: f64 = Float::frac_pi_4();
-        let frac_pi_6: f64 = Float::frac_pi_6();
-        let frac_pi_8: f64 = Float::frac_pi_8();
         let frac_1_2pi: f64 = Float::frac_1_2pi();
         let frac_1_pi: f64 = Float::frac_1_pi();
-        let frac_2_pi: f64 = Float::frac_2_pi();
-        let frac_2_sqrtpi: f64 = Float::frac_2_sqrtpi();
 
         let sqrt2: f64 = Float::sqrt2();
         let frac_1_sqrt2: f64 = Float::frac_1_sqrt2();
@@ -632,26 +621,16 @@ mod tests {
 
         assert_approx_eq!(frac_tau_2, tau / 2f64);
         assert_approx_eq!(frac_tau_3, tau / 3f64);
-        assert_approx_eq!(frac_tau_4, tau / 4f64);
         assert_approx_eq!(frac_tau_6, tau / 6f64);
-        assert_approx_eq!(frac_tau_8, tau / 8f64);
-        assert_approx_eq!(frac_tau_12, tau / 12f64);
-        assert_approx_eq!(frac_tau_16, tau / 16f64);
         assert_approx_eq!(frac_1_tau, 1f64 / tau);
         assert_approx_eq!(frac_2_tau, 2f64 / tau);
-        assert_approx_eq!(frac_4_tau, 4f64 / tau);
 
         assert_approx_eq!(two_pi, 2f64 * pi);
         assert_approx_eq!(frac_2pi_3, 2f64 * pi / 3f64);
-        assert_approx_eq!(frac_pi_2, pi / 2f64);
         assert_approx_eq!(frac_pi_3, pi / 3f64);
-        assert_approx_eq!(frac_pi_4, pi / 4f64);
-        assert_approx_eq!(frac_pi_6, pi / 6f64);
-        assert_approx_eq!(frac_pi_8, pi / 8f64);
         assert_approx_eq!(frac_1_2pi, 1f64 / (2f64 * pi));
         assert_approx_eq!(frac_1_pi, 1f64 / pi);
-        assert_approx_eq!(frac_2_pi, 2f64 / pi);
-        assert_approx_eq!(frac_2_sqrtpi, 2f64 / pi.sqrt());
+
         assert_approx_eq!(sqrt2, 2f64.sqrt());
         assert_approx_eq!(frac_1_sqrt2, 1f64 / 2f64.sqrt());
         assert_approx_eq!(log2_e, e.log2());

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -597,16 +597,31 @@ mod tests {
 
     #[test]
     fn test_real_consts() {
+        let tau: f64 = Float::tau();
+        let frac_tau_2: f64 = Float::frac_tau_2();
+        let frac_tau_3: f64 = Float::frac_tau_3();
+        let frac_tau_4: f64 = Float::frac_tau_4();
+        let frac_tau_6: f64 = Float::frac_tau_6();
+        let frac_tau_8: f64 = Float::frac_tau_8();
+        let frac_tau_12: f64 = Float::frac_tau_12();
+        let frac_tau_16: f64 = Float::frac_tau_16();
+        let frac_1_tau: f64 = Float::frac_1_tau();
+        let frac_2_tau: f64 = Float::frac_2_tau();
+        let frac_4_tau: f64 = Float::frac_4_tau();
+
         let pi: f64 = Float::pi();
         let two_pi: f64 = Float::two_pi();
+        let frac_2pi_3: f64 = Float::frac_pi_2();
         let frac_pi_2: f64 = Float::frac_pi_2();
         let frac_pi_3: f64 = Float::frac_pi_3();
         let frac_pi_4: f64 = Float::frac_pi_4();
         let frac_pi_6: f64 = Float::frac_pi_6();
         let frac_pi_8: f64 = Float::frac_pi_8();
+        let frac_1_2pi: f64 = Float::frac_1_2pi();
         let frac_1_pi: f64 = Float::frac_1_pi();
         let frac_2_pi: f64 = Float::frac_2_pi();
         let frac_2_sqrtpi: f64 = Float::frac_2_sqrtpi();
+
         let sqrt2: f64 = Float::sqrt2();
         let frac_1_sqrt2: f64 = Float::frac_1_sqrt2();
         let e: f64 = Float::e();
@@ -615,12 +630,25 @@ mod tests {
         let ln_2: f64 = Float::ln_2();
         let ln_10: f64 = Float::ln_10();
 
-        assert_approx_eq!(two_pi, 2.0 * pi);
+        assert_approx_eq!(frac_tau_2, tau / 2f64);
+        assert_approx_eq!(frac_tau_3, tau / 3f64);
+        assert_approx_eq!(frac_tau_4, tau / 4f64);
+        assert_approx_eq!(frac_tau_6, tau / 6f64);
+        assert_approx_eq!(frac_tau_8, tau / 8f64);
+        assert_approx_eq!(frac_tau_12, tau / 12f64);
+        assert_approx_eq!(frac_tau_16, tau / 16f64);
+        assert_approx_eq!(frac_1_tau, 1f64 / tau);
+        assert_approx_eq!(frac_2_tau, 2f64 / tau);
+        assert_approx_eq!(frac_4_tau, 4f64 / tau);
+
+        assert_approx_eq!(two_pi, 2f64 * pi);
+        assert_approx_eq!(frac_2pi_3, 2f64 * pi / 3f64);
         assert_approx_eq!(frac_pi_2, pi / 2f64);
         assert_approx_eq!(frac_pi_3, pi / 3f64);
         assert_approx_eq!(frac_pi_4, pi / 4f64);
         assert_approx_eq!(frac_pi_6, pi / 6f64);
         assert_approx_eq!(frac_pi_8, pi / 8f64);
+        assert_approx_eq!(frac_1_2pi, 1f64 / (2f64 * pi));
         assert_approx_eq!(frac_1_pi, 1f64 / pi);
         assert_approx_eq!(frac_2_pi, 2f64 / pi);
         assert_approx_eq!(frac_2_sqrtpi, 2f64 / pi.sqrt());


### PR DESCRIPTION
It's a little-known fact that Archimedes' original proof and calculations on the circle constant were not of π, i.e. the ratio of circumference to diameter, but of the ratio of circumference to radius, since the radius is the actual defining characteristic of the circle.  It is therefore perplexing that he would then proceed to use π as the basis for many further proofs, a tradition carried forward by Leonard Euler.

Nonetheless, this isn't a math history lesson, just a very minor patch to rectify said history.  The symbol τ has been promoted in recent years to represent the ratio mentioned (equal to 2π), having a variety of practical, aesthetic, and pedagogical benefits.  If anyone is still curious as to why this is an issue at all, I encourage reading the Tau Manifesto at http://tauday.com, although I would be happy to answer questions myself.
