### PR TITLE
rustuv: Don't zero-out data on clones

### DIFF
--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -191,7 +191,7 @@ impl TcpWatcher {
         TcpWatcher {
             home: home,
             handle: handle,
-            stream: StreamWatcher::new(handle),
+            stream: StreamWatcher::new(handle, true),
             refcount: Refcount::new(),
             read_access: AccessTimeout::new(),
             write_access: AccessTimeout::new(),
@@ -278,7 +278,7 @@ impl rtio::RtioTcpStream for TcpWatcher {
     fn clone(&self) -> Box<rtio::RtioTcpStream + Send> {
         box TcpWatcher {
             handle: self.handle,
-            stream: StreamWatcher::new(self.handle),
+            stream: StreamWatcher::new(self.handle, false),
             home: self.home.clone(),
             refcount: self.refcount.clone(),
             read_access: self.read_access.clone(),

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -67,7 +67,7 @@ impl PipeWatcher {
             handle
         };
         PipeWatcher {
-            stream: StreamWatcher::new(handle),
+            stream: StreamWatcher::new(handle, true),
             home: home,
             defused: false,
             refcount: Refcount::new(),
@@ -131,7 +131,7 @@ impl rtio::RtioPipe for PipeWatcher {
 
     fn clone(&self) -> Box<rtio::RtioPipe + Send> {
         box PipeWatcher {
-            stream: StreamWatcher::new(self.stream.handle),
+            stream: StreamWatcher::new(self.stream.handle, false),
             defused: false,
             home: self.home.clone(),
             refcount: self.refcount.clone(),

--- a/src/librustuv/stream.rs
+++ b/src/librustuv/stream.rs
@@ -59,8 +59,11 @@ impl StreamWatcher {
     // will be manipulated on each of the methods called on this watcher.
     // Wrappers should ensure to always reset the field to an appropriate value
     // if they rely on the field to perform an action.
-    pub fn new(stream: *mut uvll::uv_stream_t) -> StreamWatcher {
-        unsafe { uvll::set_data_for_uv_handle(stream, 0 as *mut int) }
+    pub fn new(stream: *mut uvll::uv_stream_t,
+               init: bool) -> StreamWatcher {
+        if init {
+            unsafe { uvll::set_data_for_uv_handle(stream, 0 as *mut int) }
+        }
         StreamWatcher {
             handle: stream,
             last_write_req: None,

--- a/src/librustuv/tty.rs
+++ b/src/librustuv/tty.rs
@@ -56,7 +56,7 @@ impl TtyWatcher {
         let handle = UvHandle::alloc(None::<TtyWatcher>, uvll::UV_TTY);
         let mut watcher = TtyWatcher {
             tty: handle,
-            stream: StreamWatcher::new(handle),
+            stream: StreamWatcher::new(handle, true),
             home: io.make_handle(),
             fd: fd,
         };

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -649,7 +649,7 @@ fn task_abort_no_kill_runtime() {
     use std::io::timer;
     use mem;
 
-    let mut tb = TaskBuilder::new();
+    let tb = TaskBuilder::new();
     let rx = tb.try_future(proc() {});
     mem::drop(rx);
     timer::sleep(1000);


### PR DESCRIPTION
When cloning a stream, the data is already guaranteed to be in a consistent
state, so there's no need to perform a zeroing. This prevents segfaults as seen
in #15231

Closes #15231
