### PR TITLE
Optimize {result,option}::collect

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -27,6 +27,7 @@ use core::mem::transmute;
 use core::cell::Cell;
 use core::clone::Clone;
 use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
+use core::default::Default;
 use core::kinds::marker;
 use core::ops::{Deref, Drop};
 use core::option::{Option, Some, None};
@@ -149,6 +150,13 @@ impl<T> Clone for Rc<T> {
     fn clone(&self) -> Rc<T> {
         self.inc_strong();
         Rc { _ptr: self._ptr, _nosend: marker::NoSend, _noshare: marker::NoShare }
+    }
+}
+
+impl<T: Default> Default for Rc<T> {
+    #[inline]
+    fn default() -> Rc<T> {
+        Rc::new(Default::default())
     }
 }
 

--- a/src/libcollections/hash/sip.rs
+++ b/src/libcollections/hash/sip.rs
@@ -265,8 +265,6 @@ pub fn hash_with_keys<T: Hash<SipState>>(k0: u64, k1: u64, value: &T) -> u64 {
     state.result()
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use test::Bencher;


### PR DESCRIPTION
The bug #11084 causes `option::collect` and `result::collect` about twice as slower as it should because llvm is having some trouble optimizing away the scan closure. This gets rid of it so now those functions perform equivalent to a hand written version.

This also adds an impl of `Default` for `Rc` along the way.
