### PR TITLE
Exported range_inclusive in the prelude

### DIFF
--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -48,7 +48,7 @@
 
 // Reexported functions
 #[doc(no_inline)] pub use from_str::from_str;
-#[doc(no_inline)] pub use iter::range;
+#[doc(no_inline)] pub use iter::{range, range_inclusive};
 #[doc(no_inline)] pub use mem::drop;
 
 // Reexported types and traits


### PR DESCRIPTION
There are several examples I've noticed of people using `range` with an upper bound one larger than what the really want to simulate an inclusive range, the ones I remember at the moment being [these](http://rustbyexample.com/for.html) [two](http://rustbyexample.com/fn.html) Rust by Example pages. Moreover, there has recently been [some confusion](http://www.reddit.com/r/rust/comments/298js2/what_is_the_rationale_behind_the_second_parameter/) about the lack of an inclusive `range`. This seems to be a general problem of people not realizing that `range_inclusive` exists. Therefore, in hopes of making it more visible and easier to use, this PR puts it the prelude. This allows the Rust by Example pages to switch to using the more readable `range_inclusive` without having to introduce `use` first.
