### PR TITLE
librustc: Don't ICE on binding same field multiple times in struct pattern.

### DIFF
--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -318,6 +318,9 @@ pub fn check_struct_pat_fields(pcx: &pat_ctxt,
     for field in fields.iter() {
         match field_map.find_mut(&field.ident.name) {
             Some(&(_, true)) => {
+                // Check the pattern anyway, so that attempts to look
+                // up its type won't fail
+                check_pat(pcx, &*field.pat, ty::mk_err());
                 tcx.sess.span_err(span,
                     format!("field `{}` bound twice in pattern",
                             token::get_ident(field.ident)).as_slice());

--- a/src/test/compile-fail/issue-15260.rs
+++ b/src/test/compile-fail/issue-15260.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+  a: uint,
+}
+
+fn main(){
+    let Foo {a: _, a: _} = Foo {a: 29};
+    //~^ ERROR field `a` bound twice in pattern
+}
+


### PR DESCRIPTION
Fixes #15260 
