### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ documentation.
     When complete, `make install` will place several programs into
     `/usr/local/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
     API-documentation tool.
-    system.
 3. Read the [tutorial].
 4. Enjoy!
 


### PR DESCRIPTION
[This commit](https://github.com/rust-lang/rust/commit/25fe2cadb10db1a54cefbd1520708d4397874bc3#diff-04c6e90faac2675aa89e2176d2eec7d8R57) forgot to remove one line.
