### PR TITLE
Add example for from_byte() documenation

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -106,6 +106,14 @@ pub fn from_utf8_owned(vv: Vec<u8>) -> Result<String, Vec<u8>> {
 /// # Failure
 ///
 /// Fails if invalid UTF-8
+///
+/// # Example
+///
+/// ```rust
+/// use std::str;
+/// let string = str::from_byte(66u8);
+/// assert_eq!(string.as_slice(), "B");
+/// ```
 pub fn from_byte(b: u8) -> String {
     assert!(b < 128u8);
     String::from_char(1, b as char)


### PR DESCRIPTION
I'm working on adding examples to the API documentation. Should future pull requests include examples for more than one function? Or is this about the right size for a pull request?
