### PR TITLE
Fix distcheck

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -54,6 +54,7 @@ PKG_FILES := \
       driver                                   \
       etc                                      \
       $(foreach crate,$(CRATES),lib$(crate))   \
+      libcoretest                              \
       libbacktrace                             \
       rt                                       \
       rustllvm                                 \


### PR DESCRIPTION
libcoretest wasn't being included which broke the verification of the
tarball.
