### PR TITLE
Revamp `Bitv` and `BitvSet`

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -31,7 +31,7 @@ use vec::Vec;
 /// ```rust
 /// use collections::bitv::Bitv;
 ///
-/// let mut bv = Bitv::new(10, false);
+/// let mut bv = Bitv::with_capacity(10, false);
 ///
 /// // insert all primes less than 10
 /// bv.set(2, true);
@@ -126,9 +126,14 @@ impl Bitv {
         }
     }
 
-    /// Creates an empty Bitv that holds `nbits` elements, setting each element
+    /// Creates an empty Bitv
+    pub fn new() -> Bitv {
+        Bitv { storage: Vec::new(), nbits: 0 }
+    }
+
+    /// Creates a Bitv that holds `nbits` elements, setting each element
     /// to `init`.
-    pub fn new(nbits: uint, init: bool) -> Bitv {
+    pub fn with_capacity(nbits: uint, init: bool) -> Bitv {
         Bitv {
             storage: Vec::from_elem((nbits + uint::BITS - 1) / uint::BITS,
                                     if init { !0u } else { 0u }),
@@ -226,7 +231,7 @@ impl Bitv {
     ///
     /// ```rust
     /// use collections::bitv::Bitv;
-    /// let mut bv = Bitv::new(10, false);
+    /// let mut bv = Bitv::with_capacity(10, false);
     /// bv.set(1, true);
     /// bv.set(2, true);
     /// bv.set(3, true);
@@ -441,7 +446,7 @@ pub fn from_bytes(bytes: &[u8]) -> Bitv {
  * index is `f(index)`.
  */
 pub fn from_fn(len: uint, f: |index: uint| -> bool) -> Bitv {
-    let mut bitv = Bitv::new(len, false);
+    let mut bitv = Bitv::with_capacity(len, false);
     for i in range(0u, len) {
         bitv.set(i, f(i));
     }
@@ -450,7 +455,7 @@ pub fn from_fn(len: uint, f: |index: uint| -> bool) -> Bitv {
 
 impl Default for Bitv {
     #[inline]
-    fn default() -> Bitv { Bitv::new(0, false) }
+    fn default() -> Bitv { Bitv::new() }
 }
 
 impl Collection for Bitv {
@@ -467,7 +472,7 @@ impl Mutable for Bitv {
 
 impl FromIterator<bool> for Bitv {
     fn from_iter<I:Iterator<bool>>(iterator: I) -> Bitv {
-        let mut ret = Bitv::new(0, false);
+        let mut ret = Bitv::new();
         ret.extend(iterator);
         ret
     }
@@ -609,7 +614,14 @@ impl BitvSet {
     /// Creates a new bit vector set with initially no contents
     #[inline]
     pub fn new() -> BitvSet {
-        BitvSet(Bitv::new(0, false))
+        BitvSet(Bitv::new())
+    }
+
+    /// Creates a new bit vector set with initially no contents, able to
+    /// hold `nbits` elements without resizing
+    #[inline]
+    pub fn with_capacity(nbits: uint) -> BitvSet {
+        BitvSet(Bitv::with_capacity(nbits, false))
     }
 
     /// Creates a new bit vector set from the given bit vector
@@ -994,31 +1006,31 @@ mod tests {
 
     #[test]
     fn test_to_str() {
-        let zerolen = Bitv::new(0u, false);
+        let zerolen = Bitv::new();
         assert_eq!(zerolen.to_str().as_slice(), "");
 
-        let eightbits = Bitv::new(8u, false);
+        let eightbits = Bitv::with_capacity(8u, false);
         assert_eq!(eightbits.to_str().as_slice(), "00000000")
     }
 
     #[test]
     fn test_0_elements() {
-        let act = Bitv::new(0u, false);
+        let act = Bitv::new();
         let exp = Vec::from_elem(0u, false);
         assert!(act.eq_vec(exp.as_slice()));
     }
 
     #[test]
     fn test_1_element() {
-        let mut act = Bitv::new(1u, false);
+        let mut act = Bitv::with_capacity(1u, false);
         assert!(act.eq_vec([false]));
-        act = Bitv::new(1u, true);
+        act = Bitv::with_capacity(1u, true);
         assert!(act.eq_vec([true]));
     }
 
     #[test]
     fn test_2_elements() {
-        let mut b = bitv::Bitv::new(2, false);
+        let mut b = bitv::Bitv::with_capacity(2, false);
         b.set(0, true);
         b.set(1, false);
         assert_eq!(b.to_str().as_slice(), "10");
@@ -1029,16 +1041,16 @@ mod tests {
         let mut act;
         // all 0
 
-        act = Bitv::new(10u, false);
+        act = Bitv::with_capacity(10u, false);
         assert!((act.eq_vec(
                     [false, false, false, false, false, false, false, false, false, false])));
         // all 1
 
-        act = Bitv::new(10u, true);
+        act = Bitv::with_capacity(10u, true);
         assert!((act.eq_vec([true, true, true, true, true, true, true, true, true, true])));
         // mixed
 
-        act = Bitv::new(10u, false);
+        act = Bitv::with_capacity(10u, false);
         act.set(0u, true);
         act.set(1u, true);
         act.set(2u, true);
@@ -1047,7 +1059,7 @@ mod tests {
         assert!((act.eq_vec([true, true, true, true, true, false, false, false, false, false])));
         // mixed
 
-        act = Bitv::new(10u, false);
+        act = Bitv::with_capacity(10u, false);
         act.set(5u, true);
         act.set(6u, true);
         act.set(7u, true);
@@ -1056,7 +1068,7 @@ mod tests {
         assert!((act.eq_vec([false, false, false, false, false, true, true, true, true, true])));
         // mixed
 
-        act = Bitv::new(10u, false);
+        act = Bitv::with_capacity(10u, false);
         act.set(0u, true);
         act.set(3u, true);
         act.set(6u, true);
@@ -1069,21 +1081,21 @@ mod tests {
         let mut act;
         // all 0
 
-        act = Bitv::new(31u, false);
+        act = Bitv::with_capacity(31u, false);
         assert!(act.eq_vec(
                 [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false]));
         // all 1
 
-        act = Bitv::new(31u, true);
+        act = Bitv::with_capacity(31u, true);
         assert!(act.eq_vec(
                 [true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true]));
         // mixed
 
-        act = Bitv::new(31u, false);
+        act = Bitv::with_capacity(31u, false);
         act.set(0u, true);
         act.set(1u, true);
         act.set(2u, true);
@@ -1098,7 +1110,7 @@ mod tests {
                 false, false, false, false, false, false]));
         // mixed
 
-        act = Bitv::new(31u, false);
+        act = Bitv::with_capacity(31u, false);
         act.set(16u, true);
         act.set(17u, true);
         act.set(18u, true);
@@ -1113,7 +1125,7 @@ mod tests {
                 false, false, false, false, false, false, false]));
         // mixed
 
-        act = Bitv::new(31u, false);
+        act = Bitv::with_capacity(31u, false);
         act.set(24u, true);
         act.set(25u, true);
         act.set(26u, true);
@@ -1127,7 +1139,7 @@ mod tests {
                 false, true, true, true, true, true, true, true]));
         // mixed
 
-        act = Bitv::new(31u, false);
+        act = Bitv::with_capacity(31u, false);
         act.set(3u, true);
         act.set(17u, true);
         act.set(30u, true);
@@ -1142,21 +1154,21 @@ mod tests {
         let mut act;
         // all 0
 
-        act = Bitv::new(32u, false);
+        act = Bitv::with_capacity(32u, false);
         assert!(act.eq_vec(
                 [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false]));
         // all 1
 
-        act = Bitv::new(32u, true);
+        act = Bitv::with_capacity(32u, true);
         assert!(act.eq_vec(
                 [true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true]));
         // mixed
 
-        act = Bitv::new(32u, false);
+        act = Bitv::with_capacity(32u, false);
         act.set(0u, true);
         act.set(1u, true);
         act.set(2u, true);
@@ -1171,7 +1183,7 @@ mod tests {
                 false, false, false, false, false, false, false]));
         // mixed
 
-        act = Bitv::new(32u, false);
+        act = Bitv::with_capacity(32u, false);
         act.set(16u, true);
         act.set(17u, true);
         act.set(18u, true);
@@ -1186,7 +1198,7 @@ mod tests {
                 false, false, false, false, false, false, false, false]));
         // mixed
 
-        act = Bitv::new(32u, false);
+        act = Bitv::with_capacity(32u, false);
         act.set(24u, true);
         act.set(25u, true);
         act.set(26u, true);
@@ -1201,7 +1213,7 @@ mod tests {
                 false, true, true, true, true, true, true, true, true]));
         // mixed
 
-        act = Bitv::new(32u, false);
+        act = Bitv::with_capacity(32u, false);
         act.set(3u, true);
         act.set(17u, true);
         act.set(30u, true);
@@ -1217,21 +1229,21 @@ mod tests {
         let mut act;
         // all 0
 
-        act = Bitv::new(33u, false);
+        act = Bitv::with_capacity(33u, false);
         assert!(act.eq_vec(
                 [false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, false, false, false, false, false, false]));
         // all 1
 
-        act = Bitv::new(33u, true);
+        act = Bitv::with_capacity(33u, true);
         assert!(act.eq_vec(
                 [true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true, true, true, true, true, true, true, true, true,
                 true, true, true, true, true, true]));
         // mixed
 
-        act = Bitv::new(33u, false);
+        act = Bitv::with_capacity(33u, false);
         act.set(0u, true);
         act.set(1u, true);
         act.set(2u, true);
@@ -1246,7 +1258,7 @@ mod tests {
                 false, false, false, false, false, false, false, false]));
         // mixed
 
-        act = Bitv::new(33u, false);
+        act = Bitv::with_capacity(33u, false);
         act.set(16u, true);
         act.set(17u, true);
         act.set(18u, true);
@@ -1261,7 +1273,7 @@ mod tests {
                 false, false, false, false, false, false, false, false, false]));
         // mixed
 
-        act = Bitv::new(33u, false);
+        act = Bitv::with_capacity(33u, false);
         act.set(24u, true);
         act.set(25u, true);
         act.set(26u, true);
@@ -1276,7 +1288,7 @@ mod tests {
                 false, true, true, true, true, true, true, true, true, false]));
         // mixed
 
-        act = Bitv::new(33u, false);
+        act = Bitv::with_capacity(33u, false);
         act.set(3u, true);
         act.set(17u, true);
         act.set(30u, true);
@@ -1290,24 +1302,24 @@ mod tests {
 
     #[test]
     fn test_equal_differing_sizes() {
-        let v0 = Bitv::new(10u, false);
-        let v1 = Bitv::new(11u, false);
+        let v0 = Bitv::with_capacity(10u, false);
+        let v1 = Bitv::with_capacity(11u, false);
         assert!(v0 != v1);
     }
 
     #[test]
     fn test_equal_greatly_differing_sizes() {
-        let v0 = Bitv::new(10u, false);
-        let v1 = Bitv::new(110u, false);
+        let v0 = Bitv::with_capacity(10u, false);
+        let v1 = Bitv::with_capacity(110u, false);
         assert!(v0 != v1);
     }
 
     #[test]
     fn test_equal_sneaky_small() {
-        let mut a = bitv::Bitv::new(1, false);
+        let mut a = bitv::Bitv::with_capacity(1, false);
         a.set(0, true);
 
-        let mut b = bitv::Bitv::new(1, true);
+        let mut b = bitv::Bitv::with_capacity(1, true);
         b.set(0, true);
 
         assert_eq!(a, b);
@@ -1315,12 +1327,12 @@ mod tests {
 
     #[test]
     fn test_equal_sneaky_big() {
-        let mut a = bitv::Bitv::new(100, false);
+        let mut a = bitv::Bitv::with_capacity(100, false);
         for i in range(0u, 100) {
             a.set(i, true);
         }
 
-        let mut b = bitv::Bitv::new(100, true);
+        let mut b = bitv::Bitv::with_capacity(100, true);
         for i in range(0u, 100) {
             b.set(i, true);
         }
@@ -1337,11 +1349,11 @@ mod tests {
 
     #[test]
     fn test_to_bytes() {
-        let mut bv = Bitv::new(3, true);
+        let mut bv = Bitv::with_capacity(3, true);
         bv.set(1, false);
         assert_eq!(bv.to_bytes(), vec!(0b10100000));
 
-        let mut bv = Bitv::new(9, false);
+        let mut bv = Bitv::with_capacity(9, false);
         bv.set(2, true);
         bv.set(8, true);
         assert_eq!(bv.to_bytes(), vec!(0b00100000, 0b10000000));
@@ -1385,7 +1397,7 @@ mod tests {
         let lengths = [10, 64, 100];
         for &b in bools.iter() {
             for &l in lengths.iter() {
-                let bitset = BitvSet::from_bitv(Bitv::new(l, b));
+                let bitset = BitvSet::from_bitv(Bitv::with_capacity(l, b));
                 assert_eq!(bitset.contains(&1u), b)
                 assert_eq!(bitset.contains(&(l-1u)), b)
                 assert!(!bitset.contains(&l))
@@ -1395,8 +1407,8 @@ mod tests {
 
     #[test]
     fn test_small_difference() {
-        let mut b1 = Bitv::new(3, false);
-        let mut b2 = Bitv::new(3, false);
+        let mut b1 = Bitv::with_capacity(3, false);
+        let mut b2 = Bitv::with_capacity(3, false);
         b1.set(0, true);
         b1.set(1, true);
         b2.set(1, true);
@@ -1409,8 +1421,8 @@ mod tests {
 
     #[test]
     fn test_big_difference() {
-        let mut b1 = Bitv::new(100, false);
-        let mut b2 = Bitv::new(100, false);
+        let mut b1 = Bitv::with_capacity(100, false);
+        let mut b2 = Bitv::with_capacity(100, false);
         b1.set(0, true);
         b1.set(40, true);
         b2.set(40, true);
@@ -1423,7 +1435,7 @@ mod tests {
 
     #[test]
     fn test_small_clear() {
-        let mut b = Bitv::new(14, true);
+        let mut b = Bitv::with_capacity(14, true);
         b.clear();
         BitvSet::from_bitv(b).iter().advance(|i| {
             fail!("found 1 at {:?}", i)
@@ -1432,7 +1444,7 @@ mod tests {
 
     #[test]
     fn test_big_clear() {
-        let mut b = Bitv::new(140, true);
+        let mut b = Bitv::with_capacity(140, true);
         b.clear();
         BitvSet::from_bitv(b).iter().advance(|i| {
             fail!("found 1 at {:?}", i)
@@ -1441,7 +1453,7 @@ mod tests {
 
     #[test]
     fn test_bitv_masking() {
-        let b = Bitv::new(140, true); 
+        let b = Bitv::with_capacity(140, true);
         let mut bs = BitvSet::from_bitv(b);
         assert!(bs.contains(&139));
         assert!(!bs.contains(&140));
@@ -1664,7 +1676,7 @@ mod tests {
 
     #[test]
     fn test_bitv_push_pop() {
-        let mut s = Bitv::new(5 * uint::BITS - 2, false);
+        let mut s = Bitv::with_capacity(5 * uint::BITS - 2, false);
         assert_eq!(s.len(), 5 * uint::BITS - 2);
         assert_eq!(s.get(5 * uint::BITS - 3), false);
         s.push(true);
@@ -1687,28 +1699,28 @@ mod tests {
 
     #[test]
     fn test_bitv_truncate() {
-        let mut s = Bitv::new(5 * uint::BITS, true);
+        let mut s = Bitv::with_capacity(5 * uint::BITS, true);
 
-        assert_eq!(s, Bitv::new(5 * uint::BITS, true));
+        assert_eq!(s, Bitv::with_capacity(5 * uint::BITS, true));
         assert_eq!(s.len(), 5 * uint::BITS);
         s.truncate(4 * uint::BITS);
-        assert_eq!(s, Bitv::new(4 * uint::BITS, true));
+        assert_eq!(s, Bitv::with_capacity(4 * uint::BITS, true));
         assert_eq!(s.len(), 4 * uint::BITS);
         // Truncating to a size > s.len() should be a noop
         s.truncate(5 * uint::BITS);
-        assert_eq!(s, Bitv::new(4 * uint::BITS, true));
+        assert_eq!(s, Bitv::with_capacity(4 * uint::BITS, true));
         assert_eq!(s.len(), 4 * uint::BITS);
         s.truncate(3 * uint::BITS - 10);
-        assert_eq!(s, Bitv::new(3 * uint::BITS - 10, true));
+        assert_eq!(s, Bitv::with_capacity(3 * uint::BITS - 10, true));
         assert_eq!(s.len(), 3 * uint::BITS - 10);
         s.truncate(0);
-        assert_eq!(s, Bitv::new(0, true));
+        assert_eq!(s, Bitv::with_capacity(0, true));
         assert_eq!(s.len(), 0);
     }
 
     #[test]
     fn test_bitv_reserve() {
-        let mut s = Bitv::new(5 * uint::BITS, true);
+        let mut s = Bitv::with_capacity(5 * uint::BITS, true);
         // Check capacity
         assert_eq!(s.capacity(), 5 * uint::BITS);
         s.reserve(2 * uint::BITS);
@@ -1781,7 +1793,7 @@ mod tests {
     #[bench]
     fn bench_bitv_big(b: &mut Bencher) {
         let mut r = rng();
-        let mut bitv = Bitv::new(BENCH_BITS, false);
+        let mut bitv = Bitv::with_capacity(BENCH_BITS, false);
         b.iter(|| {
             bitv.set((r.next_u32() as uint) % BENCH_BITS, true);
             &bitv
@@ -1791,7 +1803,7 @@ mod tests {
     #[bench]
     fn bench_bitv_small(b: &mut Bencher) {
         let mut r = rng();
-        let mut bitv = Bitv::new(uint::BITS, false);
+        let mut bitv = Bitv::with_capacity(uint::BITS, false);
         b.iter(|| {
             bitv.set((r.next_u32() as uint) % uint::BITS, true);
             &bitv
@@ -1820,8 +1832,8 @@ mod tests {
 
     #[bench]
     fn bench_bitv_big_union(b: &mut Bencher) {
-        let mut b1 = Bitv::new(BENCH_BITS, false);
-        let b2 = Bitv::new(BENCH_BITS, false);
+        let mut b1 = Bitv::with_capacity(BENCH_BITS, false);
+        let b2 = Bitv::with_capacity(BENCH_BITS, false);
         b.iter(|| {
             b1.union(&b2);
         })
@@ -1829,7 +1841,7 @@ mod tests {
 
     #[bench]
     fn bench_btv_small_iter(b: &mut Bencher) {
-        let bitv = Bitv::new(uint::BITS, false);
+        let bitv = Bitv::with_capacity(uint::BITS, false);
         b.iter(|| {
             let mut _sum = 0;
             for pres in bitv.iter() {
@@ -1840,7 +1852,7 @@ mod tests {
 
     #[bench]
     fn bench_bitv_big_iter(b: &mut Bencher) {
-        let bitv = Bitv::new(BENCH_BITS, false);
+        let bitv = Bitv::with_capacity(BENCH_BITS, false);
         b.iter(|| {
             let mut _sum = 0;
             for pres in bitv.iter() {

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -68,6 +68,7 @@ struct MaskWords<'a> {
 
 impl<'a> Iterator<(uint, uint)> for MaskWords<'a> {
     /// Returns (offset, word)
+    #[inline]
     fn next<'a>(&'a mut self) -> Option<(uint, uint)> {
         let ret = self.next_word;
         match ret {
@@ -347,6 +348,7 @@ pub fn from_fn(len: uint, f: |index: uint| -> bool) -> Bitv {
 }
 
 impl ops::Index<uint,bool> for Bitv {
+    #[inline]
     fn index(&self, i: &uint) -> bool {
         self.get(*i)
     }
@@ -453,23 +455,27 @@ impl Default for BitvSet {
 
 impl BitvSet {
     /// Creates a new bit vector set with initially no contents
+    #[inline]
     pub fn new() -> BitvSet {
         BitvSet(Bitv::new(0, false))
     }
 
     /// Creates a new bit vector set from the given bit vector
+    #[inline]
     pub fn from_bitv(bitv: Bitv) -> BitvSet {
         BitvSet(bitv)
     }
 
     /// Returns the capacity in bits for this bit vector. Inserting any
     /// element less than this amount will not trigger a resizing.
+    #[inline]
     pub fn capacity(&self) -> uint {
         let &BitvSet(ref bitv) = self;
         bitv.storage.len() * uint::BITS
     }
 
     /// Consumes this set to return the underlying bit vector
+    #[inline]
     pub fn unwrap(self) -> Bitv {
         let BitvSet(bitv) = self;
         bitv
@@ -515,29 +521,37 @@ impl BitvSet {
     }
 
     /// Union in-place with the specified other bit vector
+    #[inline]
     pub fn union_with(&mut self, other: &BitvSet) {
         self.other_op(other, |w1, w2| w1 | w2);
     }
 
     /// Intersect in-place with the specified other bit vector
+    #[inline]
     pub fn intersect_with(&mut self, other: &BitvSet) {
         self.other_op(other, |w1, w2| w1 & w2);
     }
 
     /// Difference in-place with the specified other bit vector
+    #[inline]
     pub fn difference_with(&mut self, other: &BitvSet) {
         self.other_op(other, |w1, w2| w1 & !w2);
     }
 
     /// Symmetric difference in-place with the specified other bit vector
+    #[inline]
     pub fn symmetric_difference_with(&mut self, other: &BitvSet) {
         self.other_op(other, |w1, w2| w1 ^ w2);
     }
 
+    /// Iterator over each uint stored in the BitvSet
+    #[inline]
     pub fn iter<'a>(&'a self) -> BitPositions<'a> {
         BitPositions {set: self, next_idx: 0}
     }
 
+    /// Iterator over each uint stored in the `self` setminus `other`
+    #[inline]
     pub fn difference<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
         TwoBitPositions {
             set: self,
@@ -548,6 +562,8 @@ impl BitvSet {
         }
     }
 
+    /// Iterator over each uint stored in the symmetric difference of `self` and `other`
+    #[inline]
     pub fn symmetric_difference<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
         TwoBitPositions {
             set: self,
@@ -558,6 +574,8 @@ impl BitvSet {
         }
     }
 
+    /// Iterator over each uint stored in `self` intersect `other`
+    #[inline]
     pub fn intersection<'a>(&'a self, other: &'a BitvSet) -> Take<TwoBitPositions<'a>> {
         let min = cmp::min(self.capacity(), other.capacity());
         TwoBitPositions {
@@ -569,6 +587,8 @@ impl BitvSet {
         }.take(min)
     }
 
+    /// Iterator over each uint stored in `self` union `other`
+    #[inline]
     pub fn union<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
         TwoBitPositions {
             set: self,
@@ -612,6 +632,7 @@ impl Collection for BitvSet {
 }
 
 impl Mutable for BitvSet {
+    #[inline]
     fn clear(&mut self) {
         let &BitvSet(ref mut bitv) = self;
         bitv.clear();
@@ -619,11 +640,13 @@ impl Mutable for BitvSet {
 }
 
 impl Set<uint> for BitvSet {
+    #[inline]
     fn contains(&self, value: &uint) -> bool {
         let &BitvSet(ref bitv) = self;
         *value < bitv.nbits && bitv.get(*value)
     }
 
+    #[inline]
     fn is_disjoint(&self, other: &BitvSet) -> bool {
         self.intersection(other).count() > 0
     }
@@ -647,6 +670,7 @@ impl Set<uint> for BitvSet {
         return true;
     }
 
+    #[inline]
     fn is_superset(&self, other: &BitvSet) -> bool {
         other.is_subset(self)
     }
@@ -737,7 +761,6 @@ pub struct TwoBitPositions<'a> {
 }
 
 impl<'a> Iterator<uint> for BitPositions<'a> {
-    #[inline]
     fn next(&mut self) -> Option<uint> {
         while self.next_idx < self.set.capacity() {
             let idx = self.next_idx;
@@ -751,13 +774,13 @@ impl<'a> Iterator<uint> for BitPositions<'a> {
         return None;
     }
 
+    #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) {
         (0, Some(self.set.capacity() - self.next_idx))
     }
 }
 
 impl<'a> Iterator<uint> for TwoBitPositions<'a> {
-    #[inline]
     fn next(&mut self) -> Option<uint> {
         while self.next_idx < self.set.capacity() ||
               self.next_idx < self.other.capacity() {
@@ -785,6 +808,7 @@ impl<'a> Iterator<uint> for TwoBitPositions<'a> {
         return None;
     }
 
+    #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) {
         let cap = cmp::max(self.set.capacity(), self.other.capacity());
         (0, Some(cap - self.next_idx))

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -515,9 +515,10 @@ impl BitvSet {
     /// Grows the vector to be able to store bits with indices `[0, size - 1]`
     fn grow(&mut self, size: uint) {
         let &BitvSet(ref mut bitv) = self;
+        let old_size = bitv.storage.len();
         let size = (size + uint::BITS - 1) / uint::BITS;
-        if bitv.storage.len() < size {
-            bitv.storage.grow(size, &0);
+        if old_size < size {
+            bitv.storage.grow(size - old_size, &0);
         }
     }
 
@@ -1253,14 +1254,22 @@ mod tests {
 
     #[test]
     fn test_bitv_set_basic() {
+        // calculate nbits with uint::BITS granularity
+        fn calc_nbits(bits: uint) -> uint {
+            uint::BITS * ((bits + uint::BITS - 1) / uint::BITS)
+        }
+
         let mut b = BitvSet::new();
+        assert_eq!(b.capacity(), calc_nbits(0));
         assert!(b.insert(3));
+        assert_eq!(b.capacity(), calc_nbits(3));
         assert!(!b.insert(3));
         assert!(b.contains(&3));
         assert!(b.insert(4));
         assert!(!b.insert(4));
         assert!(b.contains(&3));
         assert!(b.insert(400));
+        assert_eq!(b.capacity(), calc_nbits(400));
         assert!(!b.insert(400));
         assert!(b.contains(&400));
         assert_eq!(b.len(), 3);

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -269,15 +269,6 @@ impl Bitv {
     }
 
     /**
-     * Converts `self` to a vector of `uint` with the same length.
-     *
-     * Each `uint` in the resulting vector has either value `0u` or `1u`.
-     */
-    pub fn to_vec(&self) -> Vec<uint> {
-        Vec::from_fn(self.nbits, |i| if self.get(i) { 1 } else { 0 })
-    }
-
-    /**
      * Organise the bits into bytes, such that the first bit in the
      * `Bitv` becomes the high-order bit of the first byte. If the
      * size of the `Bitv` is not a multiple of 8 then trailing bits
@@ -308,13 +299,6 @@ impl Bitv {
     }
 
     /**
-     * Transform `self` into a `Vec<bool>` by turning each bit into a `bool`.
-     */
-    pub fn to_bools(&self) -> Vec<bool> {
-        Vec::from_fn(self.nbits, |i| self[i])
-    }
-
-    /**
      * Compare a bitvector to a vector of `bool`.
      *
      * Both the bitvector and vector must have the same length.
@@ -328,11 +312,6 @@ impl Bitv {
         }
         true
     }
-
-    pub fn ones(&self, f: |uint| -> bool) -> bool {
-        range(0u, self.nbits).advance(|i| !self.get(i) || f(i))
-    }
-
 }
 
 /**
@@ -1157,7 +1136,7 @@ mod tests {
     #[test]
     fn test_to_bools() {
         let bools = vec!(false, false, true, false, false, true, true, false);
-        assert_eq!(from_bytes([0b00100110]).to_bools(), bools);
+        assert_eq!(from_bytes([0b00100110]).iter().collect::<Vec<bool>>(), bools);
     }
 
     #[test]
@@ -1225,7 +1204,7 @@ mod tests {
     fn test_small_clear() {
         let mut b = Bitv::new(14, true);
         b.clear();
-        b.ones(|i| {
+        BitvSet::from_bitv(b).iter().advance(|i| {
             fail!("found 1 at {:?}", i)
         });
     }
@@ -1234,7 +1213,7 @@ mod tests {
     fn test_big_clear() {
         let mut b = Bitv::new(140, true);
         b.clear();
-        b.ones(|i| {
+        BitvSet::from_bitv(b).iter().advance(|i| {
             fail!("found 1 at {:?}", i)
         });
     }

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -13,8 +13,8 @@ extern crate collections;
 use std::collections::Bitv;
 
 fn bitv_test() {
-    let mut v1 = box Bitv::new(31, false);
-    let v2 = box Bitv::new(31, true);
+    let mut v1 = box Bitv::with_capacity(31, false);
+    let v2 = box Bitv::with_capacity(31, true);
     v1.union(v2);
 }
 

--- a/src/test/run-pass/issue-11736.rs
+++ b/src/test/run-pass/issue-11736.rs
@@ -16,7 +16,7 @@ use std::collections::Bitv;
 fn main() {
     // Generate sieve of Eratosthenes for n up to 1e6
     let n = 1000000u;
-    let sieve = Bitv::new(n+1, true);
+    let sieve = Bitv::with_capacity(n+1, true);
     let limit: uint = (n as f32).sqrt() as uint;
     for i in range(2, limit+1) {
         if sieve[i] {


### PR DESCRIPTION
The types `Bitv` and `BitvSet` are badly out of date. This PR:
- cleans up the code (primarily, simplifies `Bitv` and implements `BitvSet` in terms of `Bitv`)
- implements several new traits for `Bitv`
- adds new functionality to `Bitv` and `BitvSet`
- replaces internal iterators with external ones
- updates documentation
- minor bug fixes

This is a significantly souped-up version of PR #15139 and is the result of the discussion there.
