### PR TITLE
libstd: set baseline stability levels

### DIFF
--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -10,6 +10,8 @@
 
 //! Operations on ASCII strings and characters
 
+#![experimental]
+
 use collections::Collection;
 use fmt;
 use iter::Iterator;

--- a/src/libstd/bitflags.rs
+++ b/src/libstd/bitflags.rs
@@ -105,6 +105,7 @@
 //! - `insert`: inserts the specified flags in-place
 //! - `remove`: removes the specified flags in-place
 
+#![experimental]
 #![macro_escape]
 
 #[macro_export]

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -33,6 +33,8 @@
 //! handled correctly, i.e. that allocated memory is eventually freed
 //! if necessary.
 
+#![experimental]
+
 use collections::Collection;
 use kinds::Send;
 use mem;

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -12,6 +12,8 @@
  * Collection types.
  */
 
+#![experimental]
+
 pub use core_collections::{Collection, Mutable, Map, MutableMap};
 pub use core_collections::{Set, MutableSet, Deque};
 pub use core_collections::{Bitv, BitvSet, BTree, DList, EnumSet};

--- a/src/libstd/failure.rs
+++ b/src/libstd/failure.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![experimental]
+
 use alloc::owned::Box;
 use any::{Any, AnyRefExt};
 use fmt;

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -412,6 +412,8 @@ the `}` character is escaped with `}}`.
 
 */
 
+#![experimental]
+
 use io::Writer;
 use io;
 use result::{Ok, Err};

--- a/src/libstd/from_str.rs
+++ b/src/libstd/from_str.rs
@@ -10,6 +10,8 @@
 
 //! The `FromStr` trait for types that can be created from strings
 
+#![experimental]
+
 use option::{Option, Some, None};
 use string::String;
 use str::StrAllocating;

--- a/src/libstd/gc.rs
+++ b/src/libstd/gc.rs
@@ -16,6 +16,7 @@ collector is task-local so `Gc<T>` is not sendable.
 
 */
 
+#![experimental]
 #![allow(experimental)]
 
 use clone::Clone;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -216,6 +216,7 @@ responding to errors that may occur while attempting to read the numbers.
 
 */
 
+#![experimental]
 #![deny(unused_must_use)]
 
 use char::Char;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -95,6 +95,7 @@
 //! and `format!`, also available to all Rust code.
 
 #![crate_id = "std#0.11.0-pre"]
+#![unstable]
 #![comment = "The Rust standard library"]
 #![license = "MIT/ASL2"]
 #![crate_type = "rlib"]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -14,6 +14,7 @@
 //! library. Each macro is available for use when linking against the standard
 //! library.
 
+#![experimental]
 #![macro_escape]
 
 /// The entry point for failure of rust tasks.

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for 32-bits floats (`f32` type)
 
+#![experimental]
 #![allow(missing_doc)]
 #![allow(unsigned_negate)]
 #![doc(primitive = "f32")]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -10,6 +10,7 @@
 
 //! Operations and constants for 64-bits floats (`f64` type)
 
+#![experimental]
 #![allow(missing_doc)]
 #![doc(primitive = "f64")]
 

--- a/src/libstd/num/float_macros.rs
+++ b/src/libstd/num/float_macros.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![experimental]
 #![macro_escape]
 #![doc(hidden)]
 

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![experimental]
 #![macro_escape]
 #![doc(hidden)]
 

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -13,6 +13,7 @@
 //! These are implemented for the primitive numeric types in `std::{u8, u16,
 //! u32, u64, uint, i8, i16, i32, i64, int, f32, f64}`.
 
+#![experimental]
 #![allow(missing_doc)]
 
 use option::Option;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![experimental]
 #![macro_escape]
 #![doc(hidden)]
 #![allow(unsigned_negate)]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -26,6 +26,8 @@
  * to write OS-ignorant code by default.
  */
 
+#![experimental]
+
 #![allow(missing_doc)]
 #![allow(non_snake_case_functions)]
 

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -63,6 +63,8 @@ println!("path exists: {}", path.exists());
 
 */
 
+#![experimental]
+
 use collections::Collection;
 use c_str::CString;
 use clone::Clone;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -37,6 +37,8 @@
 //! particularly useful standalone functions, like `from_str`, `range`, and
 //! `drop`, `spawn`, and `channel`.
 
+#![experimental]
+
 // Reexported core operators
 #[doc(no_inline)] pub use kinds::{Copy, Send, Sized, Share};
 #[doc(no_inline)] pub use ops::{Add, Sub, Mul, Div, Rem, Neg, Not};

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -73,6 +73,8 @@ println!("{}", tuple)
 ```
 */
 
+#![experimental]
+
 use cell::RefCell;
 use clone::Clone;
 use io::IoResult;

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -51,6 +51,8 @@ Several modules in `core` are clients of `rt`:
 
 */
 
+#![experimental]
+
 // FIXME: this should not be here.
 #![allow(missing_doc)]
 

--- a/src/libstd/rtdeps.rs
+++ b/src/libstd/rtdeps.rs
@@ -12,6 +12,8 @@
 //! the standard library This varies per-platform, but these libraries are
 //! necessary for running libstd.
 
+#![experimental]
+
 // All platforms need to link to rustrt
 #[link(name = "rust_builtin", kind = "static")]
 extern {}

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -15,6 +15,8 @@
 //! and/or blocking at all, but rather provide the necessary tools to build
 //! other types of concurrent primitives.
 
+#![experimental]
+
 pub use core_sync::{atomics, deque, mpmc_bounded_queue, mpsc_queue, spsc_queue};
 pub use core_sync::{Arc, Weak, Mutex, MutexGuard, Condvar, Barrier};
 pub use core_sync::{RWLock, RWLockReadGuard, RWLockWriteGuard};

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -91,6 +91,8 @@
 //! # }
 //! ```
 
+#![experimental]
+
 use any::Any;
 use comm::channel;
 use io::{Writer, stdio};

--- a/src/libstd/to_str.rs
+++ b/src/libstd/to_str.rs
@@ -14,6 +14,8 @@ The `ToStr` trait for converting to strings
 
 */
 
+#![experimental]
+
 use fmt;
 use string::String;
 


### PR DESCRIPTION
Earlier commits have established a baseline of `experimental` stability
for all crates under the facade (so their contents are considered
experimental within libstd). Since `experimental` is `allow` by
default, we should use the same baseline stability for libstd itself.

This commit adds `experimental` tags to all of the modules defined in
`std`, and `unstable` to `std` itself.
