### PR TITLE
test: Add tests for issue #12223, "drop allowed while active borrows

### DIFF
--- a/src/test/compile-fail/drop-with-active-borrows-1.rs
+++ b/src/test/compile-fail/drop-with-active-borrows-1.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let a = "".to_string();
+    let b: Vec<&str> = a.as_slice().lines().collect();
+    drop(a);    //~ ERROR cannot move out of `a` because it is borrowed
+    for s in b.iter() {
+        println!("{}", *s);
+    }
+}
+

--- a/src/test/compile-fail/drop-with-active-borrows-2.rs
+++ b/src/test/compile-fail/drop-with-active-borrows-2.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn read_lines_borrowed() -> Vec<&str> {
+    let raw_lines: Vec<String> = vec!("foo  ".to_string(), "  bar".to_string());
+    raw_lines.iter().map(|l| l.as_slice().trim()).collect()
+    //~^ ERROR `raw_lines` does not live long enough
+}
+
+fn main() {
+    println!("{}", read_lines_borrowed());
+}

--- a/src/test/run-pass/drop-with-type-ascription-1.rs
+++ b/src/test/run-pass/drop-with-type-ascription-1.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let foo = "hello".to_string();
+    let foo: Vec<&str> = foo.as_slice().words().collect();
+    let invalid_string = foo.get(0);
+    assert_eq!(*invalid_string, "hello");
+}
+

--- a/src/test/run-pass/drop-with-type-ascription-2.rs
+++ b/src/test/run-pass/drop-with-type-ascription-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let args = vec!("foobie", "asdf::asdf");
+    let arr: Vec<&str> = args.get(1).as_slice().split_str("::").collect();
+    assert_eq!(*arr.get(0), "asdf");
+    assert_eq!(*arr.get(0), "asdf");
+}
+


### PR DESCRIPTION
still in scope".

This issue was fixed by PR #12828 and #5781. All that was left was to
add tests.

Closes #12223.
