### PR TITLE
Fix example in docs on documentation

### DIFF
--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -51,7 +51,7 @@ Calculates the factorial of a number.
 
 Given the input integer `n`, this function will calculate `n!` and return it.
 "]
-pub fn factorial(n: int) -> int { if n < 2 {1} else {n * factorial(n)} }
+pub fn factorial(n: int) -> int { if n < 2 {1} else {n * factorial(n - 1)} }
 # fn main() {}
 ~~~
 


### PR DESCRIPTION
One of the examples in the docs on adding documentation to rust code has an error that will cause the function to run endlessly rather than return the desired result, should someone actually implement this for some reason. While the error does not hinder the explanation of documenting code, it does look better if it is corrected.
