### PR TITLE
Fix ICE with nested macro_rules!-style macros

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3243,7 +3243,7 @@ impl<'a> Parser<'a> {
                 None      => {
                     // we only expect an ident if we didn't parse one
                     // above.
-                    let ident_str = if id == token::special_idents::invalid {
+                    let ident_str = if id.name == token::special_idents::invalid.name {
                         "identifier, "
                     } else {
                         ""
@@ -3263,7 +3263,7 @@ impl<'a> Parser<'a> {
             );
             let hi = self.span.hi;
 
-            if id == token::special_idents::invalid {
+            if id.name == token::special_idents::invalid.name {
                 return box(GC) spanned(lo, hi, StmtMac(
                     spanned(lo, hi, MacInvocTT(pth, tts, EMPTY_CTXT)), false));
             } else {

--- a/src/test/compile-fail/issue-10536.rs
+++ b/src/test/compile-fail/issue-10536.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// We only want to assert that this doesn't ICE, we don't particularly care
+// about whether it nor it fails to compile.
+
+// error-pattern:
+
+#![feature(macro_rules)]
+
+macro_rules! foo{
+    () => {{
+        macro_rules! bar{() => (())}
+        1
+    }}
+}
+
+pub fn main() {
+    foo!();
+
+    assert!({one! two()});
+
+    // regardless of whether nested macro_rules works, the following should at
+    // least throw a conventional error.
+    assert!({one! two});
+}
+


### PR DESCRIPTION
Fixes #10536.
