### PR TITLE
Remove duplicated slash in install script path

### DIFF
--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -214,7 +214,7 @@ need_cmd uname
 need_cmd tr
 need_cmd sed
 
-CFG_SRC_DIR="$(cd $(dirname $0) && pwd)/"
+CFG_SRC_DIR="$(cd $(dirname $0) && pwd)"
 CFG_SELF="$0"
 CFG_ARGS="$@"
 


### PR DESCRIPTION
The `CFG_SRC_DIR` variable ended with a slash, but it was used like `${CFG_SRC_DIR}/...`, so the slash was duplicated.
