### PR TITLE
Fix minor issues in the documentation of libtime.

### DIFF
--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -330,7 +330,7 @@ impl Tm {
      * Returns a time string formatted according to RFC 822.
      *
      * local: "Thu, 22 Mar 2012 07:53:18 PST"
-     * utc:   "Thu, 22 Mar 2012 14:53:18 UTC"
+     * utc:   "Thu, 22 Mar 2012 14:53:18 GMT"
      */
     pub fn rfc822(&self) -> String {
         if self.tm_gmtoff == 0_i32 {
@@ -351,7 +351,8 @@ impl Tm {
     }
 
     /**
-     * Returns a time string formatted according to ISO 8601.
+     * Returns a time string formatted according to RFC 3999. RFC 3999 is
+     * compatible with ISO 8601.
      *
      * local: "2012-02-22T07:53:18-07:00"
      * utc:   "2012-02-22T14:53:18Z"


### PR DESCRIPTION
- When the timezone is UTC, the "zone" field of the RFC 822 format is
  "GMT" (or "UT"), not "UTC."
- Although the name of `rfc3999` refers to RFC 3999, the documentation
  of it refers only to ISO 8601. This commit adds a description of the
  relation between ISO 8601 and RFC 3999.
