### PR TITLE
doc: reduce spacing of table of contents.

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -132,6 +132,7 @@ nav {
     -moz-column-count: 2;
     -webkit-column-count: 2;
     font-size: 15px;
+    margin: 0 0 1em 0;
 }
 p {
     margin: 0 0 1em 0;
@@ -275,7 +276,7 @@ dd {
 
 nav ul {
     list-style-type: none;
-    margin: 0 0 20px 0;
+    margin: 0;
     padding-left: 0px;
 }
 


### PR DESCRIPTION
A margin for the top level list was leaking into nested ones.

before; after:

![screenshot from 2014-07-04 08 18 32](https://cloud.githubusercontent.com/assets/1203825/3476459/0b7f8ea8-0300-11e4-8b67-0c47b7931d56.png)
