### PR TITLE
Removed LLVM bug workaround

### DIFF
--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -93,20 +93,7 @@ pub fn now() -> u64 {
     }
 }
 
-
-// Note: although the last parameter isn't used there is no way now to
-// convert it to unit type, because LLVM dies in SjLj preparation
-// step (unfortunately iOS uses SjLJ exceptions)
-//
-// It's definitely a temporary workaround just to get it working.
-// So far it looks like an LLVM issue and it was reported:
-// http://llvm.org/bugs/show_bug.cgi?id=19855
-// Actually this issue is pretty common while compiling for armv7 iOS
-// and in most cases it is simply solved by using --opt-level=2 (or -O)
-//
-// For this specific case unfortunately turning optimizations wasn't
-// enough.
-fn helper(input: libc::c_int, messages: Receiver<Req>, _: int) {
+fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
     let mut set: c::fd_set = unsafe { mem::zeroed() };
 
     let mut fd = FileDesc::new(input, true);
@@ -218,7 +205,7 @@ impl Timer {
     pub fn new() -> IoResult<Timer> {
         // See notes above regarding using int return value
         // instead of ()
-        unsafe { HELPER.boot(|| {0}, helper); }
+        unsafe { HELPER.boot(|| {}, helper); }
 
         static mut ID: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
         let id = unsafe { ID.fetch_add(1, atomics::Relaxed) };


### PR DESCRIPTION
It was required to get iOS compilable but since
that time a couple of changes were introduced
which cause the same bug to re-appear and broke 
build anyway. Fixing all of them doesn’t look a 
viable alternative to me as it will pollute the 
code too much.

So it should be fixed from LLVM side and I hope 
LLVM will upstream corresponding changes in a 
month.

Meanwhile, who wants to play with Rust on iOS is 
better to use a fork which uses patched LLVM:
https://github.com/vhbit/rust/tree/ios . It may 
lag behind master a bit, but it is Travis-checked 
to compile successfully.
