### PR TITLE
librustc: Remove the `&LIFETIME EXPR` production from the language.

### DIFF
--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -316,7 +316,7 @@ fn exec<'t>(which: ::regex::native::MatchKind, input: &'t str,
 
         #[inline]
         fn groups<'r>(&'r mut self, i: uint) -> &'r mut Captures {
-            &'r mut self.queue[i].groups
+            &mut self.queue[i].groups
         }
     }
 }

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -427,7 +427,7 @@ pub fn get_os(triple: &str) -> Option<abi::Os> {
     }
     None
 }
-static os_names : &'static [(&'static str, abi::Os)] = &'static [
+static os_names : &'static [(&'static str, abi::Os)] = &[
     ("mingw32", abi::OsWin32),
     ("win32",   abi::OsWin32),
     ("darwin",  abi::OsMacos),
@@ -442,7 +442,7 @@ pub fn get_arch(triple: &str) -> Option<abi::Architecture> {
     }
     None
 }
-static architecture_abis : &'static [(&'static str, abi::Architecture)] = &'static [
+static architecture_abis : &'static [(&'static str, abi::Architecture)] = &[
     ("i386",   abi::X86),
     ("i486",   abi::X86),
     ("i586",   abi::X86),

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -540,7 +540,7 @@ impl LintPass for UnusedAttribute {
     }
 
     fn check_attribute(&mut self, cx: &Context, attr: &ast::Attribute) {
-        static ATTRIBUTE_WHITELIST: &'static [&'static str] = &'static [
+        static ATTRIBUTE_WHITELIST: &'static [&'static str] = &[
             // FIXME: #14408 whitelist docs since rustdoc looks at them
             "doc",
 
@@ -574,7 +574,7 @@ impl LintPass for UnusedAttribute {
             "unstable",
         ];
 
-        static CRATE_ATTRS: &'static [&'static str] = &'static [
+        static CRATE_ATTRS: &'static [&'static str] = &[
             "crate_type",
             "feature",
             "no_start",

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1118,7 +1118,7 @@ impl<T: Iterator<char>> Parser<T> {
     /// Provides access to the current position in the logical structure of the
     /// JSON stream.
     pub fn stack<'l>(&'l self) -> &'l Stack {
-        return &'l self.stack;
+        return &self.stack;
     }
 
     fn eof(&self) -> bool { self.ch.is_none() }

--- a/src/libstd/collections/hashmap.rs
+++ b/src/libstd/collections/hashmap.rs
@@ -294,8 +294,7 @@ mod table {
 
             unsafe {
                 debug_assert!(*self.hashes.offset(idx) != EMPTY_BUCKET);
-                (&'a *self.keys.offset(idx),
-                 &'a *self.vals.offset(idx))
+                (&*self.keys.offset(idx), &*self.vals.offset(idx))
             }
         }
 
@@ -306,8 +305,7 @@ mod table {
 
             unsafe {
                 debug_assert!(*self.hashes.offset(idx) != EMPTY_BUCKET);
-                (&'a     *self.keys.offset(idx),
-                 &'a mut *self.vals.offset(idx))
+                (&*self.keys.offset(idx), &mut *self.vals.offset(idx))
             }
         }
 
@@ -319,8 +317,7 @@ mod table {
             unsafe {
                 debug_assert!(*self.hashes.offset(idx) != EMPTY_BUCKET);
                 (transmute(self.hashes.offset(idx)),
-                 &'a mut *self.keys.offset(idx),
-                 &'a mut *self.vals.offset(idx))
+                 &mut *self.keys.offset(idx), &mut *self.vals.offset(idx))
             }
         }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2400,7 +2400,6 @@ impl<'a> Parser<'a> {
           }
           token::BINOP(token::AND) | token::ANDAND => {
             self.expect_and();
-            let _lt = self.parse_opt_lifetime();
             let m = self.parse_mutability();
             let e = self.parse_prefix_expr();
             hi = e.span.hi;

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -19,7 +19,7 @@ use super::super::TermInfo;
 
 // These are the orders ncurses uses in its compiled format (as of 5.9). Not sure if portable.
 
-pub static boolfnames: &'static[&'static str] = &'static["auto_left_margin", "auto_right_margin",
+pub static boolfnames: &'static[&'static str] = &["auto_left_margin", "auto_right_margin",
     "no_esc_ctlc", "ceol_standout_glitch", "eat_newline_glitch", "erase_overstrike", "generic_type",
     "hard_copy", "has_meta_key", "has_status_line", "insert_null_glitch", "memory_above",
     "memory_below", "move_insert_mode", "move_standout_mode", "over_strike", "status_line_esc_ok",
@@ -31,12 +31,12 @@ pub static boolfnames: &'static[&'static str] = &'static["auto_left_margin", "au
     "no_correctly_working_cr", "gnu_has_meta_key", "linefeed_is_newline", "has_hardware_tabs",
     "return_does_clr_eol"];
 
-pub static boolnames: &'static[&'static str] = &'static["bw", "am", "xsb", "xhp", "xenl", "eo",
+pub static boolnames: &'static[&'static str] = &["bw", "am", "xsb", "xhp", "xenl", "eo",
     "gn", "hc", "km", "hs", "in", "db", "da", "mir", "msgr", "os", "eslok", "xt", "hz", "ul", "xon",
     "nxon", "mc5i", "chts", "nrrmc", "npc", "ndscr", "ccc", "bce", "hls", "xhpa", "crxm", "daisy",
     "xvpa", "sam", "cpix", "lpix", "OTbs", "OTns", "OTnc", "OTMT", "OTNL", "OTpt", "OTxr"];
 
-pub static numfnames: &'static[&'static str] = &'static[ "columns", "init_tabs", "lines",
+pub static numfnames: &'static[&'static str] = &[ "columns", "init_tabs", "lines",
     "lines_of_memory", "magic_cookie_glitch", "padding_baud_rate", "virtual_terminal",
     "width_status_line", "num_labels", "label_height", "label_width", "max_attributes",
     "maximum_windows", "max_colors", "max_pairs", "no_color_video", "buffer_capacity",
@@ -46,12 +46,12 @@ pub static numfnames: &'static[&'static str] = &'static[ "columns", "init_tabs",
     "bit_image_entwining", "bit_image_type", "magic_cookie_glitch_ul", "carriage_return_delay",
     "new_line_delay", "backspace_delay", "horizontal_tab_delay", "number_of_function_keys"];
 
-pub static numnames: &'static[&'static str] = &'static[ "cols", "it", "lines", "lm", "xmc", "pb",
+pub static numnames: &'static[&'static str] = &[ "cols", "it", "lines", "lm", "xmc", "pb",
     "vt", "wsl", "nlab", "lh", "lw", "ma", "wnum", "colors", "pairs", "ncv", "bufsz", "spinv",
     "spinh", "maddr", "mjump", "mcs", "mls", "npins", "orc", "orl", "orhi", "orvi", "cps", "widcs",
     "btns", "bitwin", "bitype", "UTug", "OTdC", "OTdN", "OTdB", "OTdT", "OTkn"];
 
-pub static stringfnames: &'static[&'static str] = &'static[ "back_tab", "bell", "carriage_return",
+pub static stringfnames: &'static[&'static str] = &[ "back_tab", "bell", "carriage_return",
     "change_scroll_region", "clear_all_tabs", "clear_screen", "clr_eol", "clr_eos",
     "column_address", "command_character", "cursor_address", "cursor_down", "cursor_home",
     "cursor_invisible", "cursor_left", "cursor_mem_address", "cursor_normal", "cursor_right",
@@ -124,7 +124,7 @@ pub static stringfnames: &'static[&'static str] = &'static[ "back_tab", "bell", 
     "acs_lrcorner", "acs_ltee", "acs_rtee", "acs_btee", "acs_ttee", "acs_hline", "acs_vline",
     "acs_plus", "memory_lock", "memory_unlock", "box_chars_1"];
 
-pub static stringnames: &'static[&'static str] = &'static[ "cbt", "_", "cr", "csr", "tbc", "clear",
+pub static stringnames: &'static[&'static str] = &[ "cbt", "_", "cr", "csr", "tbc", "clear",
     "_", "_", "hpa", "cmdch", "cup", "cud1", "home", "civis", "cub1", "mrcup", "cnorm", "cuf1",
     "ll", "cuu1", "cvvis", "dch1", "dl1", "dsl", "hd", "smacs", "blink", "bold", "smcup", "smdc",
     "dim", "smir", "invis", "prot", "rev", "smso", "smul", "ech", "rmacs", "sgr0", "rmcup", "rmdc",

--- a/src/test/compile-fail/borrowck-forbid-static-unsafe-interior.rs
+++ b/src/test/compile-fail/borrowck-forbid-static-unsafe-interior.rs
@@ -32,7 +32,7 @@ static STATIC1: UnsafeEnum<int> = VariantSafe;
 static STATIC2: Unsafe<int> = Unsafe{value: 1, marker1: marker::InvariantType};
 static STATIC3: MyUnsafe<int> = MyUnsafe{value: STATIC2};
 
-static STATIC4: &'static Unsafe<int> = &'static STATIC2;
+static STATIC4: &'static Unsafe<int> = &STATIC2;
 //~^ ERROR borrow of immutable static items with unsafe interior is not allowed
 
 struct Wrap<T> {

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -113,12 +113,12 @@ static mut STATIC14: SafeStruct = SafeStruct {
     field2: Variant4("str".to_string())
 };
 
-static STATIC15: &'static [Box<MyOwned>] = &'static [box MyOwned, box MyOwned];
+static STATIC15: &'static [Box<MyOwned>] = &[box MyOwned, box MyOwned];
 //~^ ERROR static items are not allowed to have custom pointers
 //~^^ ERROR static items are not allowed to have custom pointers
 
 static STATIC16: (&'static Box<MyOwned>, &'static Box<MyOwned>) =
-    (&'static box MyOwned, &'static box MyOwned);
+    (&box MyOwned, &box MyOwned);
 //~^ ERROR static items are not allowed to have custom pointers
 //~^^ ERROR static items are not allowed to have custom pointers
 

--- a/src/test/run-pass/issue-5917.rs
+++ b/src/test/run-pass/issue-5917.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct T (&'static [int]);
-static t : T = T (&'static [5, 4, 3]);
+static t : T = T (&[5, 4, 3]);
 pub fn main () {
     let T(ref v) = t;
     assert_eq!(v[0], 5);

--- a/src/test/run-pass/issue-8578.rs
+++ b/src/test/run-pass/issue-8578.rs
@@ -17,7 +17,7 @@ impl<'a> UninterpretedOption_NamePart {
         static instance: UninterpretedOption_NamePart = UninterpretedOption_NamePart {
             name_part: None,
         };
-        &'static instance
+        &instance
     }
 }
 

--- a/src/test/run-pass/trans-tag-static-padding.rs
+++ b/src/test/run-pass/trans-tag-static-padding.rs
@@ -43,7 +43,7 @@ fn default_instance() -> &'static Request {
         // size of struct may be not equal to size of struct, and
         // compiler crashes in internal assertion check.
     };
-    &'static instance
+    &instance
 }
 
 fn non_default_instance() -> &'static Request {
@@ -51,7 +51,7 @@ fn non_default_instance() -> &'static Request {
         foo: TestSome(0x1020304050607080),
         bar: 19,
     };
-    &'static instance
+    &instance
 }
 
 pub fn main() {

--- a/src/test/run-pass/typeck_type_placeholder_1.rs
+++ b/src/test/run-pass/typeck_type_placeholder_1.rs
@@ -11,7 +11,7 @@
 // This test checks that the `_` type placeholder works
 // correctly for enabling type inference.
 
-static CONSTEXPR: *const int = &'static 413 as *const _;
+static CONSTEXPR: *const int = &413 as *const _;
 
 pub fn main() {
     let x: Vec<_> = range(0u, 5).collect();


### PR DESCRIPTION
This was parsed by the parser but completely ignored; not even stored in
the AST!

This breaks code that looks like:

```
static X: &'static [u8] = &'static [1, 2, 3];
```

Change this code to the shorter:

```
static X: &'static [u8] = &[1, 2, 3];
```

Closes #15312.

[breaking-change]

r? @nick29581
