### PR TITLE
Change Shl<T, T> (resp Shr<T, T>) for Int to Shl<uint, T> (resp Shr<uint, T>)

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -400,8 +400,8 @@ pub trait Int: Primitive
              + BitAnd<Self,Self>
              + BitOr<Self,Self>
              + BitXor<Self,Self>
-             + Shl<Self,Self>
-             + Shr<Self,Self> {
+             + Shl<uint,Self>
+             + Shr<uint,Self> {
     /// Returns the number of ones in the binary representation of the integer.
     ///
     /// # Example
@@ -667,12 +667,12 @@ int_cast_impl!(i64, u64)
 /// Returns the smallest power of 2 greater than or equal to `n`.
 #[inline]
 pub fn next_power_of_two<T: Unsigned + Int>(n: T) -> T {
-    let halfbits: T = cast(size_of::<T>() * 4).unwrap();
+    let halfbits = size_of::<T>() * 4;
     let mut tmp: T = n - one();
-    let mut shift: T = one();
+    let mut shift = 1u;
     while shift <= halfbits {
         tmp = tmp | (tmp >> shift);
-        shift = shift << one();
+        shift = shift << 1u;
     }
     tmp + one()
 }
@@ -688,12 +688,12 @@ pub fn is_power_of_two<T: Unsigned + Int>(n: T) -> bool {
 /// otherwise the power of 2 is wrapped in `Some`.
 #[inline]
 pub fn checked_next_power_of_two<T: Unsigned + Int>(n: T) -> Option<T> {
-    let halfbits: T = cast(size_of::<T>() * 4).unwrap();
+    let halfbits = size_of::<T>() * 4;
     let mut tmp: T = n - one();
-    let mut shift: T = one();
+    let mut shift = 1u;
     while shift <= halfbits {
         tmp = tmp | (tmp >> shift);
-        shift = shift << one();
+        shift = shift << 1u;
     }
     tmp.checked_add(&one())
 }

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -558,10 +558,10 @@ pub trait Shl<RHS,Result> {
 
 macro_rules! shl_impl(
     ($($t:ty)*) => ($(
-        impl Shl<$t, $t> for $t {
+        impl Shl<uint, $t> for $t {
             #[inline]
-            fn shl(&self, other: &$t) -> $t {
-                (*self) << (*other as uint)
+            fn shl(&self, other: &uint) -> $t {
+                (*self) << (*other)
             }
         }
     )*)
@@ -601,9 +601,9 @@ pub trait Shr<RHS,Result> {
 
 macro_rules! shr_impl(
     ($($t:ty)*) => ($(
-        impl Shr<$t, $t> for $t {
+        impl Shr<uint, $t> for $t {
             #[inline]
-            fn shr(&self, other: &$t) -> $t { (*self) >> (*other as uint) }
+            fn shr(&self, other: &uint) -> $t { (*self) >> (*other) }
         }
     )*)
 )

--- a/src/libcoretest/num/int_macros.rs
+++ b/src/libcoretest/num/int_macros.rs
@@ -74,8 +74,8 @@ mod tests {
         assert!(0b1110 as $T == (0b1100 as $T).bitor(&(0b1010 as $T)));
         assert!(0b1000 as $T == (0b1100 as $T).bitand(&(0b1010 as $T)));
         assert!(0b0110 as $T == (0b1100 as $T).bitxor(&(0b1010 as $T)));
-        assert!(0b1110 as $T == (0b0111 as $T).shl(&(1 as $T)));
-        assert!(0b0111 as $T == (0b1110 as $T).shr(&(1 as $T)));
+        assert!(0b1110 as $T == (0b0111 as $T).shl(&1));
+        assert!(0b0111 as $T == (0b1110 as $T).shr(&1));
         assert!(-(0b11 as $T) - (1 as $T) == (0b11 as $T).not());
     }
 

--- a/src/libcoretest/num/uint_macros.rs
+++ b/src/libcoretest/num/uint_macros.rs
@@ -34,8 +34,8 @@ mod tests {
         assert!(0b1110 as $T == (0b1100 as $T).bitor(&(0b1010 as $T)));
         assert!(0b1000 as $T == (0b1100 as $T).bitand(&(0b1010 as $T)));
         assert!(0b0110 as $T == (0b1100 as $T).bitxor(&(0b1010 as $T)));
-        assert!(0b1110 as $T == (0b0111 as $T).shl(&(1 as $T)));
-        assert!(0b0111 as $T == (0b1110 as $T).shr(&(1 as $T)));
+        assert!(0b1110 as $T == (0b0111 as $T).shl(&1u));
+        assert!(0b0111 as $T == (0b1110 as $T).shr(&1u));
         assert!(MAX - (0b1011 as $T) == (0b1011 as $T).not());
     }
 


### PR DESCRIPTION
At the moment, writing generic functions for integer types that involve shifting is rather verbose. For example, a function at shifts an integer left by 1 currently requires 

```
use std::num::One;
fn f<T: Int>(x : T) -> T {
    x << One::one()
}
```

If the shift amount is not 1, it's even worse:

```
use std::num::FromPrimitive;
fn f<T: Int + FromPrimitive>(x: T) -> T {
    x << FromPrimitive::from_int(2).unwrap()
}
```

This patch allows the much simpler implementation

```
fn f<T: Int>(x: T) -> T { 
    x << 2
}
```

It accomplishes this by changing the built-in integer types (and the `Int` trait) to implement `Shl<uint, T>` instead of `Shl<T, T>` as it currently is defined. Note that the internal implementations of `shl` already cast the right-hand side to `uint`. `BigInt` also implements `Shl<uint, BigInt>`, so this increases consistency.

All of the above applies similarly to right shifts, i.e., `Shr<uint, T>`.
