### PR TITLE
Note naming convention of lists (xs, ys, ...)

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1110,6 +1110,16 @@ let xs = Cons(1, box Cons(2, box Cons(3, box Nil)));
 let ys = xs; // copies `Cons(u32, pointer)` shallowly
 ~~~
 
+> *Note:* Names like `xs` and `ys` are a naming
+> convention for collection-like data structures
+> (like our `List`). These collections are given 
+> names appended with 's' to signify plurality, 
+> i.e. that the data structure stores multiple 
+> elements.  For example, `xs` in this case can 
+> be read as "a list of ex-es", where "x" here 
+> are elements of type `u32`.
+
+
 Rust will consider a shallow copy of a type with a destructor like `List` to
 *move ownership* of the value. After a value has been moved, the source
 location cannot be used unless it is reinitialized.


### PR DESCRIPTION
People reading the tutorial may not be familiar with the convention of naming lists, vectors and the like as xs, ys, etc. Without some explanation of the reasoning behind it, it might come off as just throwaway non-descriptive names. Languages like Haskell gets flak from using short, non-descriptive names, while in reality, there are clear conventions and reasons for using certain terse variable names. 

This is just a proposed explanation of this convention, as I've interpreted it - I assumed that the convention came from a language like Haskell, so I tailored it according to that. So beware that I might have misjudged how it is used in the Rust language, or at least how it is used in the Rust tutorial.
