### PR TITLE
Parser: fix small PatIdent span bug

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3119,8 +3119,9 @@ impl<'a> Parser<'a> {
             self.span_fatal(last_span,
                             "expected identifier, found path");
         }
-        // why a path here, and not just an identifier?
-        let name = codemap::Spanned{span: self.last_span, node: self.parse_ident()};
+        let ident = self.parse_ident();
+        let last_span = self.last_span;
+        let name = codemap::Spanned{span: last_span, node: ident};
         let sub = if self.eat(&token::AT) {
             Some(self.parse_pat())
         } else {


### PR DESCRIPTION
Fix small bug introduced in e38cb972dcf: PatIdent span was incorrect
because self.last_span was being used before the ident token was
parsed.
