### PR TITLE
rustc: Reorder error and note message to reduce confusion.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -895,13 +895,14 @@ fn add_one(x: int) -> int {
 We would get an error:
 
 ```{ignore,notrust}
-note: consider removing this semicolon:
-     x + 1;
-          ^
 error: not all control paths return a value
 fn add_one(x: int) -> int {
      x + 1;
 }
+
+note: consider removing this semicolon:
+     x + 1;
+          ^
 ```
 
 Remember our earlier discussions about semicolons and `()`? Our function claims

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1458,6 +1458,8 @@ impl<'a> Liveness<'a> {
                         },
                     _ => false
                 };
+                self.ir.tcx.sess.span_err(
+                    sp, "not all control paths return a value");
                 if ends_with_stmt {
                     let last_stmt = body.stmts.last().unwrap();
                     let original_span = original_sp(last_stmt.span, sp);
@@ -1469,8 +1471,6 @@ impl<'a> Liveness<'a> {
                     self.ir.tcx.sess.span_note(
                         span_semicolon, "consider removing this semicolon:");
                 }
-                self.ir.tcx.sess.span_err(
-                    sp, "not all control paths return a value");
            }
         }
     }


### PR DESCRIPTION
Moved note after error to reduce confusion when the pair appears in the
middle of other errors. Closes #13279.
