### PR TITLE
librustc: Make sure to run destructors in the right order when matching on moved value.

### DIFF
--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -962,8 +962,8 @@ fn compare_values<'a>(
     }
 }
 
-fn insert_lllocals<'a>(mut bcx: &'a Block<'a>,
-                       bindings_map: &BindingsMap)
+fn insert_lllocals<'a>(mut bcx: &'a Block<'a>, bindings_map: &BindingsMap,
+                       cs: Option<cleanup::ScopeId>)
                        -> &'a Block<'a> {
     /*!
      * For each binding in `data.bindings_map`, adds an appropriate entry into
@@ -990,6 +990,10 @@ fn insert_lllocals<'a>(mut bcx: &'a Block<'a>,
         };
 
         let datum = Datum::new(llval, binding_info.ty, Lvalue);
+        match cs {
+            Some(cs) => bcx.fcx.schedule_drop_and_zero_mem(cs, llval, binding_info.ty),
+            _ => {}
+        }
 
         debug!("binding {:?} to {}",
                binding_info.id,
@@ -1021,7 +1025,7 @@ fn compile_guard<'a, 'b>(
            vec_map_to_str(vals, |v| bcx.val_to_str(*v)));
     let _indenter = indenter();
 
-    let mut bcx = insert_lllocals(bcx, &data.bindings_map);
+    let mut bcx = insert_lllocals(bcx, &data.bindings_map, None);
 
     let val = unpack_datum!(bcx, expr::trans(bcx, guard_expr));
     let val = val.to_llbool(bcx);
@@ -1475,9 +1479,11 @@ fn trans_match_inner<'a>(scope_cx: &'a Block<'a>,
     for arm_data in arm_datas.iter() {
         let mut bcx = arm_data.bodycx;
 
-        // insert bindings into the lllocals map
-        bcx = insert_lllocals(bcx, &arm_data.bindings_map);
+        // insert bindings into the lllocals map and add cleanups
+        let cs = fcx.push_custom_cleanup_scope();
+        bcx = insert_lllocals(bcx, &arm_data.bindings_map, Some(cleanup::CustomScope(cs)));
         bcx = expr::trans_into(bcx, &*arm_data.arm.body, dest);
+        bcx = fcx.pop_and_trans_custom_cleanup_scope(bcx, cs);
         arm_cxs.push(bcx);
     }
 

--- a/src/test/run-pass/order-drop-with-match.rs
+++ b/src/test/run-pass/order-drop-with-match.rs
@@ -1,0 +1,64 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+// Test to make sure the destructors run in the right order.
+// Each destructor sets it's tag in the corresponding entry
+// in ORDER matching up to when it ran.
+// Correct order is: matched, inner, outer
+
+static mut ORDER: [uint, ..3] = [0, 0, 0];
+static mut INDEX: uint = 0;
+
+struct A;
+impl Drop for A {
+    fn drop(&mut self) {
+        unsafe {
+            ORDER[INDEX] = 1;
+            INDEX = INDEX + 1;
+        }
+    }
+}
+
+struct B;
+impl Drop for B {
+    fn drop(&mut self) {
+        unsafe {
+            ORDER[INDEX] = 2;
+            INDEX = INDEX + 1;
+        }
+    }
+}
+
+struct C;
+impl Drop for C {
+    fn drop(&mut self) {
+        unsafe {
+            ORDER[INDEX] = 3;
+            INDEX = INDEX + 1;
+        }
+    }
+}
+
+fn main() {
+    {
+        let matched = A;
+        let _outer = C;
+        {
+            match matched {
+                _s => {}
+            }
+            let _inner = B;
+        }
+    }
+    unsafe {
+        assert_eq!(&[1, 2, 3], ORDER.as_slice());
+    }
+}


### PR DESCRIPTION
Inadvertently changed the order in which destructors ran in certain cases with #15076.

Fixes #15438.
