### PR TITLE
Optimize String::push_byte()

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -208,7 +208,7 @@ impl String {
     /// Appends a byte to this string buffer. The caller must preserve the valid UTF-8 property.
     #[inline]
     pub unsafe fn push_byte(&mut self, byte: u8) {
-        self.push_bytes([byte])
+        self.vec.push(byte)
     }
 
     /// Removes the last byte from the string buffer and returns it. Returns `None` if this string


### PR DESCRIPTION
`Vec::push_all` with a length 1 slice seems to have significant overhead compared to `Vec::push`.

```
test new_push_byte ... bench:      6985 ns/iter (+/- 487) = 17 MB/s
test old_push_byte ... bench:     19335 ns/iter (+/- 1368) = 6 MB/s
```

``` rust
extern crate test;
use test::Bencher;

static TEXT: &'static str = "\
    Unicode est un standard informatique qui permet des échanges \
    de textes dans différentes langues, à un niveau mondial.";

#[bench]
fn old_push_byte(bencher: &mut Bencher) {
    bencher.bytes = TEXT.len() as u64;
    bencher.iter(|| {
        let mut new = String::new();
        for b in TEXT.bytes() {
            unsafe { new.as_mut_vec().push_all([b]) }
        }
    })
}

#[bench]
fn new_push_byte(bencher: &mut Bencher) {
    bencher.bytes = TEXT.len() as u64;
    bencher.iter(|| {
        let mut new = String::new();
        for b in TEXT.bytes() {
            unsafe { new.as_mut_vec().push(b) }
        }
    })
}
```
