### PR TITLE
A few more changes for Vim

### DIFF
--- a/src/etc/vim/doc/rust.txt
+++ b/src/etc/vim/doc/rust.txt
@@ -53,6 +53,18 @@ g:rust_conceal_pub~
 	    let g:rust_conceal_pub = 1
 <
 
+                                                                 *g:rust_fold*
+g:rust_fold~
+	Set this option to turn on |folding|: >
+	    let g:rust_fold = 1
+<
+	Value		Effect ~
+	0		No folding
+	1		Braced blocks are folded. All folds are open by
+			default.
+	2		Braced blocks are folded. 'foldlevel' is left at the
+			global value (all folds are closed by default).
+
                                                   *g:rust_bang_comment_leader*
 g:rust_bang_comment_leader~
 	Set this option to 1 to preserve the leader on multi-line doc comments

--- a/src/etc/vim/doc/rust.txt
+++ b/src/etc/vim/doc/rust.txt
@@ -34,12 +34,6 @@ g:rustc_makeprg_no_percent~
 	    let g:rustc_makeprg_no_percent = 1
 <
 
-                                                          *g:rust_colorcolumn*
-g:rust_colorcolumn~
-	Set this option to use 'colorcolumn' to highlight the text width
-	indicate the 100 column recommended hard limit on line lengths: >
-	    let g:rust_colorcolumn = 1
-<
                                                               *g:rust_conceal*
 g:rust_conceal~
 	Set this option to turn on the basic |conceal| support: >

--- a/src/etc/vim/doc/rust.txt
+++ b/src/etc/vim/doc/rust.txt
@@ -1,7 +1,7 @@
 *rust.txt*      Filetype plugin for Rust
 
 ==============================================================================
-CONTENTS                                                                *rust*
+CONTENTS                                                      *rust* *ft-rust*
 
 1. Introduction                                                   |rust-intro|
 2. Settings                                                    |rust-settings|
@@ -34,6 +34,12 @@ g:rustc_makeprg_no_percent~
 	    let g:rustc_makeprg_no_percent = 1
 <
 
+                                                          *g:rust_colorcolumn*
+g:rust_colorcolumn~
+	Set this option to use 'colorcolumn' to highlight the text width
+	indicate the 100 column recommended hard limit on line lengths: >
+	    let g:rust_colorcolumn = 1
+<
                                                               *g:rust_conceal*
 g:rust_conceal~
 	Set this option to turn on the basic |conceal| support: >

--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -2,7 +2,7 @@
 " Description:  Vim syntax file for Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
 " Maintainer:   Kevin Ballard <kevin@sb.org>
-" Last Change:  May 27, 2014
+" Last Change:  July 06, 2014
 
 if exists("b:did_ftplugin")
 	finish
@@ -35,7 +35,24 @@ silent! setlocal formatoptions+=j
 " otherwise it's better than nothing.
 setlocal smartindent nocindent
 
-setlocal tabstop=4 shiftwidth=4 expandtab
+setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
+
+" Line lengths {{{2
+
+" Rust style conventions for line lengths say you SHOULD not go over 80
+" columns and MUST not go over 100.
+" Without a good 'formatexpr' we can't automatically wrap code, but we can
+" still wrap comments just fine with 'textwidth'.
+setlocal textwidth=80
+
+" We can also use 'colorcolumn' to highlight both the 80 and 100 limits. Not
+" everyone likes this so it's gated.
+if exists('g:rust_colorcolumn')
+	setlocal colorcolumn=+1,101
+	let b:rust_colorcolumn=1
+endif
+
+" }}}2
 
 " This includeexpr isn't perfect, but it's a good start
 setlocal includeexpr=substitute(v:fname,'::','/','g')
@@ -93,7 +110,12 @@ endif
 " Cleanup {{{1
 
 let b:undo_ftplugin = "
-		\setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
+		\ setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
+		\|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
+		\|if exists('b:rust_colorcolumn')
+		  \|setlocal colorcolumn<
+		  \|unlet b:rust_colorcolumn
+		\|endif
 		\|if exists('b:rust_original_delimitMate_excluded_regions')
 		  \|let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions
 		  \|unlet b:rust_original_delimitMate_excluded_regions

--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -2,7 +2,7 @@
 " Description:  Vim syntax file for Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
 " Maintainer:   Kevin Ballard <kevin@sb.org>
-" Last Change:  July 06, 2014
+" Last Change:  Jul 07, 2014
 
 if exists("b:did_ftplugin")
 	finish
@@ -37,22 +37,7 @@ setlocal smartindent nocindent
 
 setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 
-" Line lengths {{{2
-
-" Rust style conventions for line lengths say you SHOULD not go over 80
-" columns and MUST not go over 100.
-" Without a good 'formatexpr' we can't automatically wrap code, but we can
-" still wrap comments just fine with 'textwidth'.
-setlocal textwidth=80
-
-" We can also use 'colorcolumn' to highlight both the 80 and 100 limits. Not
-" everyone likes this so it's gated.
-if exists('g:rust_colorcolumn')
-	setlocal colorcolumn=+1,101
-	let b:rust_colorcolumn=1
-endif
-
-" }}}2
+setlocal textwidth=99
 
 " This includeexpr isn't perfect, but it's a good start
 setlocal includeexpr=substitute(v:fname,'::','/','g')
@@ -112,10 +97,6 @@ endif
 let b:undo_ftplugin = "
 		\ setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
 		\|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
-		\|if exists('b:rust_colorcolumn')
-		  \|setlocal colorcolumn<
-		  \|unlet b:rust_colorcolumn
-		\|endif
 		\|if exists('b:rust_original_delimitMate_excluded_regions')
 		  \|let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions
 		  \|unlet b:rust_original_delimitMate_excluded_regions

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -3,12 +3,23 @@
 " Maintainer:   Patrick Walton <pcwalton@mozilla.com>
 " Maintainer:   Ben Blum <bblum@cs.cmu.edu>
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
-" Last Change:  2014 Feb 27
+" Last Change:  July 06, 2014
 
 if version < 600
   syntax clear
 elseif exists("b:current_syntax")
   finish
+endif
+
+" Fold settings {{{1
+
+if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
+  setlocal foldmethod=syntax
+  if g:rust_fold == 2
+    setlocal foldlevel<
+  else
+    setlocal foldlevel=99
+  endif
 endif
 
 " Syntax definitions {{{1
@@ -213,8 +224,6 @@ syn keyword rustTodo contained TODO FIXME XXX NB NOTE
 " Trivial folding rules to begin with.
 " TODO: use the AST to make really good folding
 syn region rustFoldBraces start="{" end="}" transparent fold
-" If you wish to enable this, setlocal foldmethod=syntax
-" It's not enabled by default as it would drive some people mad.
 
 " Default highlighting {{{1
 hi def link rustDecNumber       rustNumber


### PR DESCRIPTION
Tweak the text editing settings (softtabstop, textwidth, etc).

Add some settings to turn on folding and colorcolumn.

Add the undo_ftplugin changes that my previous patch forgot.
