### PR TITLE
Fix typo in manual

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3889,12 +3889,11 @@ by the prefix operator `box`. When the standard library is in use, the type of a
 An example of an owned box type and value:
 
 ~~~~
-
 let x: Box<int> = box 10;
 ~~~~
 
-Owned box values exist in 1:1 correspondence with their heap allocation
-copying an owned box value makes a shallow copy of the pointer
+Owned box values exist in 1:1 correspondence with their heap allocation,
+copying an owned box value makes a shallow copy of the pointer.
 Rust will consider a shallow copy of an owned box to move ownership of the value. After a value has been moved, the source location cannot be used unless it is reinitialized.
 
 ~~~~


### PR DESCRIPTION
Also removes redundant newline in code block.
