### PR TITLE
mk: Run tidy after tests in 'make check'

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -171,7 +171,7 @@ endif
 # Main test targets
 ######################################################################
 
-check: cleantmptestlogs cleantestlibs tidy check-notidy
+check: cleantmptestlogs cleantestlibs check-notidy tidy
 
 check-notidy: cleantmptestlogs cleantestlibs all check-stage2
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log


### PR DESCRIPTION
Tidy takes like forever to run. How many times have I wished I didn't have to sit through tidy before seeing my tests fail?
