### PR TITLE
rustc: Fix naming output files with --crate-name

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -575,12 +575,12 @@ impl LintPass for UnusedAttribute {
         ];
 
         static CRATE_ATTRS: &'static [&'static str] = &[
+            "crate_name",
             "crate_type",
             "feature",
             "no_start",
             "no_main",
             "no_std",
-            "crate_id",
             "desc",
             "comment",
             "license",

--- a/src/test/run-make/crate-name-priority/Makefile
+++ b/src/test/run-make/crate-name-priority/Makefile
@@ -1,0 +1,13 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo.rs --crate-name bar
+	rm $(TMPDIR)/$(call BIN,bar)
+	$(RUSTC) foo1.rs
+	rm $(TMPDIR)/$(call BIN,foo)
+	$(RUSTC) foo1.rs --crate-name bar
+	rm $(TMPDIR)/$(call BIN,bar)
+	$(RUSTC) foo1.rs --crate-name bar -o $(TMPDIR)/bar1
+	rm $(TMPDIR)/$(call BIN,bar1)

--- a/src/test/run-make/crate-name-priority/foo.rs
+++ b/src/test/run-make/crate-name-priority/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}

--- a/src/test/run-make/crate-name-priority/foo1.rs
+++ b/src/test/run-make/crate-name-priority/foo1.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+fn main() {}
+


### PR DESCRIPTION
The output file was only being renamed based off #[crate_name], not #[crate_id]
or --crate-name. Both of these behaviors have been restored now.
