### PR TITLE
Add a put_back() method to the Peekable iterator.

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1475,6 +1475,14 @@ impl<'a, A, T: Iterator<A>> Peekable<A, T> {
     pub fn is_empty(&mut self) -> bool {
         self.peek().is_none()
     }
+
+    /// Put a value "back" in the iterator,
+    /// so that the next call to `peek()` or `next()` will return it.
+    #[inline]
+    pub fn put_back(&mut self, value: A) {
+        assert!(self.peeked.is_none(), "Can not put back into a peeked iterator.");
+        self.peeked = Some(value);
+    }
 }
 
 /// An iterator which rejects elements while `predicate` is true

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1478,6 +1478,8 @@ impl<'a, A, T: Iterator<A>> Peekable<A, T> {
 
     /// Put a value "back" in the iterator,
     /// so that the next call to `peek()` or `next()` will return it.
+    ///
+    /// Fails if `peek()` or `put_back()` has been called more recently than `next()`.
     #[inline]
     pub fn put_back(&mut self, value: A) {
         assert!(self.peeked.is_none(), "Can not put back into a peeked iterator.");

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -116,7 +116,7 @@ fn test_iterator_enumerate() {
 #[test]
 fn test_iterator_peekable() {
     let xs = vec![0u, 1, 2, 3, 4, 5];
-    let mut it = xs.iter().map(|&x|x).peekable();
+    let mut it = xs.move_iter().peekable();
     assert_eq!(it.peek().unwrap(), &0);
     assert_eq!(it.next().unwrap(), 0);
     assert_eq!(it.next().unwrap(), 1);
@@ -124,11 +124,23 @@ fn test_iterator_peekable() {
     assert_eq!(it.peek().unwrap(), &3);
     assert_eq!(it.peek().unwrap(), &3);
     assert_eq!(it.next().unwrap(), 3);
+    it.put_back(12);
+    assert_eq!(it.peek().unwrap(), &12);
+    assert_eq!(it.next().unwrap(), 12);
     assert_eq!(it.next().unwrap(), 4);
     assert_eq!(it.peek().unwrap(), &5);
     assert_eq!(it.next().unwrap(), 5);
     assert!(it.peek().is_none());
     assert!(it.next().is_none());
+}
+
+#[test]
+#[should_fail]
+fn test_iterator_peekable_put_back_fail() {
+    let xs = vec![0u, 1, 2, 3, 4, 5];
+    let mut it = xs.move_iter().peekable();
+    assert_eq!(it.peek().unwrap(), &0);
+    it.put_back(12);
 }
 
 #[test]


### PR DESCRIPTION
Sometimes, rather than peek()’ing and then potentialy calling next() to go past the item you’ve already handled, it’s more convenient to call next() first and potentially put the item "back" in the iterator, to be consumed by another part of the code.

As shown in tests, the parameter need not actually come from the iterator, but it usually is in more typical usage.

(I assumed this addition was small enough to not need an RFC.)
