### PR TITLE
Derive Clone for Command and StdioContainer

### DIFF
--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -94,6 +94,7 @@ pub struct Process {
 ///
 /// let output = process.stdout.get_mut_ref().read_to_end();
 /// ```
+#[deriving(Clone)]
 pub struct Command {
     // The internal data for the builder. Documented by the builder
     // methods below, and serialized into rt::rtio::ProcessConfig.
@@ -340,6 +341,7 @@ pub struct ProcessOutput {
 }
 
 /// Describes what to do with a standard io stream for a child process.
+#[deriving(Clone)]
 pub enum StdioContainer {
     /// This stream will be ignored. This is the equivalent of attaching the
     /// stream to `/dev/null`


### PR DESCRIPTION
Allows use cases like this one:

``` rust
use std::io::Command;

fn main() {
    let mut cmd = Command::new("ls");
    cmd.arg("-l");

    for &dir in ["a", "b", "c"].iter() {
        println!("{}", cmd.clone().arg(dir));
    }
}
```

Output:

```
ls '-l' 'a'
ls '-l' 'b'
ls '-l' 'c'
```

Without the `clone()`, you'll end up with:

```
ls '-l' 'a'
ls '-l' 'a' 'b'
ls '-l' 'a' 'b' 'c'
```

cc #15294
