### PR TITLE
Mistake in AtomicBool spinlock example

### DIFF
--- a/src/libcore/atomics.rs
+++ b/src/libcore/atomics.rs
@@ -141,7 +141,7 @@ impl AtomicBool {
     ///
     /// fn with_lock(spinlock: &Arc<AtomicBool>, f: || -> ()) {
     ///     // CAS loop until we are able to replace `false` with `true`
-    ///     while spinlock.compare_and_swap(false, true, SeqCst) == false {
+    ///     while spinlock.compare_and_swap(false, true, SeqCst) != false {
     ///         // Since tasks may not be preemptive (if they are green threads)
     ///         // yield to the scheduler to let the other task run. Low level
     ///         // concurrent code needs to take into account Rust's two threading


### PR DESCRIPTION
The current example of a spinlock was not correct. The lock is actually acquired
when `old == result`. So we only need to deschedule when this is not the case.
