### PR TITLE
mk: Don't run rustc manually during distcheck

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -259,7 +259,6 @@ distcheck-tar-bins: dist-tar-bins
 	$(Q)cd tmp/distcheck && tar -xzf ../../dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz
 	$(Q)mkdir -p tmp/distcheck/tarbininstall
 	$(Q)sh tmp/distcheck/$(PKG_NAME)-$(CFG_BUILD)/install.sh --prefix=tmp/distcheck/tarbininstall
-	$(Q)tmp/distcheck/tarbininstall/bin/rustc --version
 	$(Q)sh tmp/distcheck/$(PKG_NAME)-$(CFG_BUILD)/install.sh --prefix=tmp/distcheck/tarbininstall --uninstall
 	$(Q)rm -Rf tmp/distcheck/$(PKG_NAME)-$(CFG_BUILD)
 	$(Q)rm -Rf tmp/distcheck/tarbininstall


### PR DESCRIPTION
This is already checked by the install script, no need to check it twice.
