### PR TITLE
Assorted small fixes

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2008,6 +2008,7 @@ pub mod consts {
         pub mod posix88 {
             use types::os::arch::c95::c_int;
             use types::common::c95::c_void;
+            use types::os::arch::posix88::mode_t;
 
             pub static O_RDONLY : c_int = 0;
             pub static O_WRONLY : c_int = 1;
@@ -2016,20 +2017,20 @@ pub mod consts {
             pub static O_CREAT : c_int = 64;
             pub static O_EXCL : c_int = 128;
             pub static O_TRUNC : c_int = 512;
-            pub static S_IFIFO : c_int = 4096;
-            pub static S_IFCHR : c_int = 8192;
-            pub static S_IFBLK : c_int = 24576;
-            pub static S_IFDIR : c_int = 16384;
-            pub static S_IFREG : c_int = 32768;
-            pub static S_IFLNK : c_int = 40960;
-            pub static S_IFMT : c_int = 61440;
-            pub static S_IEXEC : c_int = 64;
-            pub static S_IWRITE : c_int = 128;
-            pub static S_IREAD : c_int = 256;
-            pub static S_IRWXU : c_int = 448;
-            pub static S_IXUSR : c_int = 64;
-            pub static S_IWUSR : c_int = 128;
-            pub static S_IRUSR : c_int = 256;
+            pub static S_IFIFO : mode_t = 4096;
+            pub static S_IFCHR : mode_t = 8192;
+            pub static S_IFBLK : mode_t = 24576;
+            pub static S_IFDIR : mode_t = 16384;
+            pub static S_IFREG : mode_t = 32768;
+            pub static S_IFLNK : mode_t = 40960;
+            pub static S_IFMT : mode_t = 61440;
+            pub static S_IEXEC : mode_t = 64;
+            pub static S_IWRITE : mode_t = 128;
+            pub static S_IREAD : mode_t = 256;
+            pub static S_IRWXU : mode_t = 448;
+            pub static S_IXUSR : mode_t = 64;
+            pub static S_IWUSR : mode_t = 128;
+            pub static S_IRUSR : mode_t = 256;
             pub static F_OK : c_int = 0;
             pub static R_OK : c_int = 4;
             pub static W_OK : c_int = 2;
@@ -2220,6 +2221,7 @@ pub mod consts {
         pub mod posix88 {
             use types::os::arch::c95::c_int;
             use types::common::c95::c_void;
+            use types::os::arch::posix88::mode_t;
 
             pub static O_RDONLY : c_int = 0;
             pub static O_WRONLY : c_int = 1;
@@ -2228,20 +2230,20 @@ pub mod consts {
             pub static O_CREAT : c_int = 256;
             pub static O_EXCL : c_int = 1024;
             pub static O_TRUNC : c_int = 512;
-            pub static S_IFIFO : c_int = 4096;
-            pub static S_IFCHR : c_int = 8192;
-            pub static S_IFBLK : c_int = 24576;
-            pub static S_IFDIR : c_int = 16384;
-            pub static S_IFREG : c_int = 32768;
-            pub static S_IFLNK : c_int = 40960;
-            pub static S_IFMT : c_int = 61440;
-            pub static S_IEXEC : c_int = 64;
-            pub static S_IWRITE : c_int = 128;
-            pub static S_IREAD : c_int = 256;
-            pub static S_IRWXU : c_int = 448;
-            pub static S_IXUSR : c_int = 64;
-            pub static S_IWUSR : c_int = 128;
-            pub static S_IRUSR : c_int = 256;
+            pub static S_IFIFO : mode_t = 4096;
+            pub static S_IFCHR : mode_t = 8192;
+            pub static S_IFBLK : mode_t = 24576;
+            pub static S_IFDIR : mode_t = 16384;
+            pub static S_IFREG : mode_t = 32768;
+            pub static S_IFLNK : mode_t = 40960;
+            pub static S_IFMT : mode_t = 61440;
+            pub static S_IEXEC : mode_t = 64;
+            pub static S_IWRITE : mode_t = 128;
+            pub static S_IREAD : mode_t = 256;
+            pub static S_IRWXU : mode_t = 448;
+            pub static S_IXUSR : mode_t = 64;
+            pub static S_IWUSR : mode_t = 128;
+            pub static S_IRUSR : mode_t = 256;
             pub static F_OK : c_int = 0;
             pub static R_OK : c_int = 4;
             pub static W_OK : c_int = 2;
@@ -2759,6 +2761,7 @@ pub mod consts {
         pub mod posix88 {
             use types::common::c95::c_void;
             use types::os::arch::c95::c_int;
+            use types::os::arch::posix88::mode_t;
 
             pub static O_RDONLY : c_int = 0;
             pub static O_WRONLY : c_int = 1;
@@ -2767,20 +2770,20 @@ pub mod consts {
             pub static O_CREAT : c_int = 512;
             pub static O_EXCL : c_int = 2048;
             pub static O_TRUNC : c_int = 1024;
-            pub static S_IFIFO : c_int = 4096;
-            pub static S_IFCHR : c_int = 8192;
-            pub static S_IFBLK : c_int = 24576;
-            pub static S_IFDIR : c_int = 16384;
-            pub static S_IFREG : c_int = 32768;
-            pub static S_IFLNK : c_int = 40960;
-            pub static S_IFMT : c_int = 61440;
-            pub static S_IEXEC : c_int = 64;
-            pub static S_IWRITE : c_int = 128;
-            pub static S_IREAD : c_int = 256;
-            pub static S_IRWXU : c_int = 448;
-            pub static S_IXUSR : c_int = 64;
-            pub static S_IWUSR : c_int = 128;
-            pub static S_IRUSR : c_int = 256;
+            pub static S_IFIFO : mode_t = 4096;
+            pub static S_IFCHR : mode_t = 8192;
+            pub static S_IFBLK : mode_t = 24576;
+            pub static S_IFDIR : mode_t = 16384;
+            pub static S_IFREG : mode_t = 32768;
+            pub static S_IFLNK : mode_t = 40960;
+            pub static S_IFMT : mode_t = 61440;
+            pub static S_IEXEC : mode_t = 64;
+            pub static S_IWRITE : mode_t = 128;
+            pub static S_IREAD : mode_t = 256;
+            pub static S_IRWXU : mode_t = 448;
+            pub static S_IXUSR : mode_t = 64;
+            pub static S_IWUSR : mode_t = 128;
+            pub static S_IRUSR : mode_t = 256;
             pub static F_OK : c_int = 0;
             pub static R_OK : c_int = 4;
             pub static W_OK : c_int = 2;
@@ -3148,6 +3151,7 @@ pub mod consts {
         pub mod posix88 {
             use types::common::c95::c_void;
             use types::os::arch::c95::c_int;
+            use types::os::arch::posix88::mode_t;
 
             pub static O_RDONLY : c_int = 0;
             pub static O_WRONLY : c_int = 1;
@@ -3156,20 +3160,20 @@ pub mod consts {
             pub static O_CREAT : c_int = 512;
             pub static O_EXCL : c_int = 2048;
             pub static O_TRUNC : c_int = 1024;
-            pub static S_IFIFO : c_int = 4096;
-            pub static S_IFCHR : c_int = 8192;
-            pub static S_IFBLK : c_int = 24576;
-            pub static S_IFDIR : c_int = 16384;
-            pub static S_IFREG : c_int = 32768;
-            pub static S_IFLNK : c_int = 40960;
-            pub static S_IFMT : c_int = 61440;
-            pub static S_IEXEC : c_int = 64;
-            pub static S_IWRITE : c_int = 128;
-            pub static S_IREAD : c_int = 256;
-            pub static S_IRWXU : c_int = 448;
-            pub static S_IXUSR : c_int = 64;
-            pub static S_IWUSR : c_int = 128;
-            pub static S_IRUSR : c_int = 256;
+            pub static S_IFIFO : mode_t = 4096;
+            pub static S_IFCHR : mode_t = 8192;
+            pub static S_IFBLK : mode_t = 24576;
+            pub static S_IFDIR : mode_t = 16384;
+            pub static S_IFREG : mode_t = 32768;
+            pub static S_IFLNK : mode_t = 40960;
+            pub static S_IFMT : mode_t = 61440;
+            pub static S_IEXEC : mode_t = 64;
+            pub static S_IWRITE : mode_t = 128;
+            pub static S_IREAD : mode_t = 256;
+            pub static S_IRWXU : mode_t = 448;
+            pub static S_IXUSR : mode_t = 64;
+            pub static S_IWUSR : mode_t = 128;
+            pub static S_IRUSR : mode_t = 256;
             pub static F_OK : c_int = 0;
             pub static R_OK : c_int = 4;
             pub static W_OK : c_int = 2;
@@ -3858,7 +3862,7 @@ pub mod funcs {
             use types::os::arch::posix88::mode_t;
 
             extern {
-                pub fn open(path: *const c_char, oflag: c_int, mode: c_int)
+                pub fn open(path: *const c_char, oflag: c_int, mode: mode_t)
                             -> c_int;
                 pub fn creat(path: *const c_char, mode: mode_t) -> c_int;
                 pub fn fcntl(fd: c_int, cmd: c_int, ...) -> c_int;

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -555,6 +555,12 @@ pub fn find_crate_name(sess: Option<&Session>,
         s
     };
 
+    // Look in attributes 100% of the time to make sure the attribute is marked
+    // as used. After doing this, however, favor crate names from the command
+    // line.
+    let attr_crate_name = attrs.iter().find(|at| at.check_name("crate_name"))
+                               .and_then(|at| at.value_str().map(|s| (at, s)));
+
     match sess {
         Some(sess) => {
             match sess.opts.crate_name {
@@ -565,9 +571,7 @@ pub fn find_crate_name(sess: Option<&Session>,
         None => {}
     }
 
-    let crate_name = attrs.iter().find(|at| at.check_name("crate_name"))
-                          .and_then(|at| at.value_str().map(|s| (at, s)));
-    match crate_name {
+    match attr_crate_name {
         Some((attr, s)) => return validate(s.get().to_string(), Some(attr.span)),
         None => {}
     }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -744,6 +744,11 @@ impl LintPass for NonCamelCaseTypes {
             }
         }
 
+        let has_extern_repr = it.attrs.iter().fold(attr::ReprAny, |acc, attr| {
+            attr::find_repr_attr(cx.tcx.sess.diagnostic(), attr, acc)
+        }) == attr::ReprExtern;
+        if has_extern_repr { return }
+
         match it.node {
             ast::ItemTy(..) | ast::ItemStruct(..) => {
                 check_case(cx, "type", it.ident, it.span)

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -547,7 +547,7 @@ mod test {
         let path = &"./tmp/mk_rm_dir".to_c_str();
         let mode = S_IWUSR | S_IRUSR;
 
-        let result = FsRequest::mkdir(l(), path, mode);
+        let result = FsRequest::mkdir(l(), path, mode as c_int);
         assert!(result.is_ok());
 
         let result = FsRequest::rmdir(l(), path);

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -330,6 +330,11 @@ pub fn lstat(path: &Path) -> IoResult<FileStat> {
 }
 
 fn from_rtio(s: rtio::FileStat) -> FileStat {
+    #[cfg(windows)]
+    type Mode = libc::c_int;
+    #[cfg(unix)]
+    type Mode = libc::mode_t;
+
     let rtio::FileStat {
         size, kind, perm, created, modified,
         accessed, device, inode, rdev,
@@ -338,7 +343,7 @@ fn from_rtio(s: rtio::FileStat) -> FileStat {
 
     FileStat {
         size: size,
-        kind: match (kind as libc::c_int) & libc::S_IFMT {
+        kind: match (kind as Mode) & libc::S_IFMT {
             libc::S_IFREG => io::TypeFile,
             libc::S_IFDIR => io::TypeDirectory,
             libc::S_IFIFO => io::TypeNamedPipe,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -58,7 +58,14 @@ impl Ident {
 
 impl Show for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "\"{}\"#{}", token::get_ident(*self).get(), self.ctxt)
+        write!(f, "{}#{}", self.name, self.ctxt)
+    }
+}
+
+impl Show for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Name(nm) = *self;
+        write!(f, "\"{}\"({})", token::get_name(*self).get(), nm)
     }
 }
 
@@ -106,7 +113,7 @@ pub static ILLEGAL_CTXT : SyntaxContext = 1;
 
 /// A name is a part of an identifier, representing a string or gensym. It's
 /// the result of interning.
-#[deriving(Eq, Ord, PartialEq, PartialOrd, Hash, Encodable, Decodable, Clone, Show)]
+#[deriving(Eq, Ord, PartialEq, PartialOrd, Hash, Encodable, Decodable, Clone)]
 pub struct Name(pub u32);
 
 impl Name {

--- a/src/test/compile-fail/lint-non-camel-case-types.rs
+++ b/src/test/compile-fail/lint-non-camel-case-types.rs
@@ -32,4 +32,9 @@ enum Foo5 {
 trait foo6 { //~ ERROR trait `foo6` should have a camel case name such as `Foo6`
 }
 
+#[repr(C)]
+struct foo7 {
+    bar: int,
+}
+
 fn main() { }

--- a/src/test/run-pass/crate-name-attr-used.rs
+++ b/src/test/run-pass/crate-name-attr-used.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--crate-name crate-name-attr-used -F unused-attribute
+
+#![crate_name = "test"]
+
+fn main() {}


### PR DESCRIPTION
- Don't warn about `#[crate_name]` if `--crate-name` is specified
- Don't warn about non camel case identifiers on `#[repr(C)]` structs
- Switch `mode` to `mode_t` in libc.
