### PR TITLE
Stabilization for `owned` (now `boxed`) and `cell`

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -21,11 +21,11 @@
 //!
 //! Currently, there are four major definitions in this library.
 //!
-//! ## Owned pointers
+//! ## Boxed values
 //!
-//! The [`Box`](owned/index.html) type is the core owned pointer type in rust.
+//! The [`Box`](boxed/index.html) type is the core owned pointer type in rust.
 //! There can only be one owner of a `Box`, and the owner can decide to mutate
-//! the contents.
+//! the contents, which live on the heap.
 //!
 //! This type can be sent among tasks efficiently as the size of a `Box` value
 //! is just a pointer. Tree-like data structures are often built on owned
@@ -82,6 +82,12 @@ extern crate libc;
 #[cfg(test)] #[phase(plugin, link)] extern crate std;
 #[cfg(test)] #[phase(plugin, link)] extern crate log;
 
+// The deprecated name of the boxed module
+
+#[deprecated = "use boxed instead"]
+#[cfg(not(test))]
+pub use owned = boxed;
+
 // Heaps provided for low-level allocation strategies
 
 pub mod heap;
@@ -91,7 +97,7 @@ pub mod util;
 // Primitive types using the heaps above
 
 #[cfg(not(test))]
-pub mod owned;
+pub mod boxed;
 pub mod arc;
 pub mod rc;
 

--- a/src/libcollections/btree.rs
+++ b/src/libcollections/btree.rs
@@ -20,7 +20,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::fmt;
 use core::fmt::Show;
 

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -23,7 +23,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::default::Default;
 use core::fmt;
 use core::iter;

--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -65,7 +65,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::intrinsics::TypeId;
 use core::mem;

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -14,7 +14,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::default::Default;
 use core::fmt;
 use core::fmt::Show;

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -12,7 +12,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::default::Default;
 use core::mem::zeroed;
 use core::mem;

--- a/src/librustrt/args.rs
+++ b/src/librustrt/args.rs
@@ -45,7 +45,7 @@ pub fn clone() -> Option<Vec<Vec<u8>>> { imp::clone() }
 mod imp {
     use core::prelude::*;
 
-    use alloc::owned::Box;
+    use alloc::boxed::Box;
     use collections::vec::Vec;
     use core::mem;
     use core::slice;

--- a/src/librustrt/at_exit_imp.rs
+++ b/src/librustrt/at_exit_imp.rs
@@ -14,7 +14,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use collections::vec::Vec;
 use core::atomics;
 use core::mem;

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -37,7 +37,7 @@ pub use self::unwind::{begin_unwind, begin_unwind_fmt};
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::any::Any;
 
 use task::{Task, BlockedTask, TaskOpts};

--- a/src/librustrt/local.rs
+++ b/src/librustrt/local.rs
@@ -10,7 +10,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use local_ptr;
 use task::Task;
 

--- a/src/librustrt/local_data.rs
+++ b/src/librustrt/local_data.rs
@@ -40,7 +40,7 @@ assert_eq!(*key_vector.get().unwrap(), vec![4]);
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use collections::vec::Vec;
 use core::kinds::marker;
 use core::mem;

--- a/src/librustrt/local_ptr.rs
+++ b/src/librustrt/local_ptr.rs
@@ -20,7 +20,7 @@
 use core::prelude::*;
 
 use core::mem;
-use alloc::owned::Box;
+use alloc::boxed::Box;
 
 #[cfg(windows)]               // mingw-w32 doesn't like thread_local things
 #[cfg(target_os = "android")] // see #10686
@@ -86,7 +86,7 @@ pub unsafe fn borrow<T>() -> Borrowed<T> {
 pub mod compiled {
     use core::prelude::*;
 
-    use alloc::owned::Box;
+    use alloc::boxed::Box;
     use core::mem;
 
     #[cfg(test)]
@@ -237,7 +237,7 @@ pub mod compiled {
 pub mod native {
     use core::prelude::*;
 
-    use alloc::owned::Box;
+    use alloc::boxed::Box;
     use core::mem;
     use core::ptr;
     use tls = thread_local_storage;

--- a/src/librustrt/rtio.rs
+++ b/src/librustrt/rtio.rs
@@ -11,7 +11,7 @@
 //! The EventLoop and internal synchronous I/O interface.
 
 use core::prelude::*;
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use collections::string::String;
 use collections::vec::Vec;
 use core::fmt;

--- a/src/librustrt/stack.rs
+++ b/src/librustrt/stack.rs
@@ -56,7 +56,7 @@ pub static RED_ZONE: uint = 20 * 1024;
 #[lang = "stack_exhausted"]
 extern fn stack_exhausted() {
     use core::prelude::*;
-    use alloc::owned::Box;
+    use alloc::boxed::Box;
     use local::Local;
     use task::Task;
     use core::intrinsics;

--- a/src/librustrt/task.rs
+++ b/src/librustrt/task.rs
@@ -16,7 +16,7 @@
 use core::prelude::*;
 
 use alloc::arc::Arc;
-use alloc::owned::{AnyOwnExt, Box};
+use alloc::boxed::{BoxAny, Box};
 use core::any::Any;
 use core::atomics::{AtomicUint, SeqCst};
 use core::iter::Take;
@@ -376,7 +376,7 @@ impl Task {
         unsafe {
             let imp = self.imp.take_unwrap();
             let vtable = mem::transmute::<_, &raw::TraitObject>(&imp).vtable;
-            match imp.wrap().move::<T>() {
+            match imp.wrap().downcast::<T>() {
                 Ok(t) => Some(t),
                 Err(t) => {
                     let data = mem::transmute::<_, raw::TraitObject>(t).data;

--- a/src/librustrt/thread.rs
+++ b/src/librustrt/thread.rs
@@ -18,7 +18,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::mem;
 use core::uint;
 use libc;
@@ -147,7 +147,7 @@ impl<T: Send> Drop for Thread<T> {
 mod imp {
     use core::prelude::*;
 
-    use alloc::owned::Box;
+    use alloc::boxed::Box;
     use core::cmp;
     use core::mem;
     use core::ptr;
@@ -215,7 +215,7 @@ mod imp {
 mod imp {
     use core::prelude::*;
 
-    use alloc::owned::Box;
+    use alloc::boxed::Box;
     use core::cmp;
     use core::mem;
     use core::ptr;

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -59,7 +59,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use collections::string::String;
 use collections::vec::Vec;
 use core::any::Any;

--- a/src/libstd/collections/lru_cache.rs
+++ b/src/libstd/collections/lru_cache.rs
@@ -45,7 +45,7 @@ use iter::{range, Iterator};
 use mem;
 use ops::Drop;
 use option::{Some, None, Option};
-use owned::Box;
+use boxed::Box;
 use ptr;
 use result::{Ok, Err};
 

--- a/src/libstd/failure.rs
+++ b/src/libstd/failure.rs
@@ -10,7 +10,7 @@
 
 #![experimental]
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use any::{Any, AnyRefExt};
 use fmt;
 use io::{Writer, IoResult};

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -62,7 +62,7 @@ use iter::Iterator;
 use kinds::Send;
 use libc;
 use option::{Some, None, Option};
-use owned::Box;
+use boxed::Box;
 use path::{Path, GenericPath};
 use path;
 use result::{Err, Ok};

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -229,7 +229,7 @@ use mem::transmute;
 use ops::{BitOr, BitAnd, Sub, Not};
 use option::{Option, Some, None};
 use os;
-use owned::Box;
+use boxed::Box;
 use result::{Ok, Err, Result};
 use rt::rtio;
 use slice::{Vector, MutableVector, ImmutableVector};

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -29,7 +29,7 @@ use io::{Reader, Writer, Listener, Acceptor};
 use from_str::FromStr;
 use kinds::Send;
 use option::{None, Some, Option};
-use owned::Box;
+use boxed::Box;
 use rt::rtio::{IoFactory, LocalIo, RtioSocket, RtioTcpListener};
 use rt::rtio::{RtioTcpAcceptor, RtioTcpStream};
 use rt::rtio;

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -19,7 +19,7 @@ use clone::Clone;
 use io::net::ip::{SocketAddr, IpAddr};
 use io::{Reader, Writer, IoResult, IoError};
 use kinds::Send;
-use owned::Box;
+use boxed::Box;
 use option::Option;
 use result::{Ok, Err};
 use rt::rtio::{RtioSocket, RtioUdpSocket, IoFactory, LocalIo};

--- a/src/libstd/io/net/unix.rs
+++ b/src/libstd/io/net/unix.rs
@@ -30,7 +30,7 @@ use c_str::ToCStr;
 use clone::Clone;
 use io::{Listener, Acceptor, Reader, Writer, IoResult, IoError};
 use kinds::Send;
-use owned::Box;
+use boxed::Box;
 use rt::rtio::{IoFactory, LocalIo, RtioUnixListener};
 use rt::rtio::{RtioUnixAcceptor, RtioPipe};
 

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -20,7 +20,7 @@ use prelude::*;
 use io::{IoResult, IoError};
 use libc;
 use os;
-use owned::Box;
+use boxed::Box;
 use rt::rtio::{RtioPipe, LocalIo};
 
 /// A synchronous, in-memory pipe.

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -21,7 +21,7 @@ use io::{IoResult, IoError};
 use io;
 use libc;
 use mem;
-use owned::Box;
+use boxed::Box;
 use rt::rtio::{RtioProcess, ProcessConfig, IoFactory, LocalIo};
 use rt::rtio;
 use c_str::CString;

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -26,7 +26,7 @@ use iter::Iterator;
 use kinds::Send;
 use mem::drop;
 use option::{Some, None};
-use owned::Box;
+use boxed::Box;
 use result::{Ok, Err};
 use rt::rtio::{IoFactory, LocalIo, RtioSignal, Callback};
 use slice::ImmutableVector;

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -35,7 +35,7 @@ use iter::Iterator;
 use kinds::Send;
 use libc;
 use option::{Option, Some, None};
-use owned::Box;
+use boxed::Box;
 use result::{Ok, Err};
 use rt;
 use rt::local::Local;

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -20,7 +20,7 @@ and create receivers which will receive notifications after a period of time.
 use comm::{Receiver, Sender, channel};
 use io::{IoResult, IoError};
 use kinds::Send;
-use owned::Box;
+use boxed::Box;
 use rt::rtio::{IoFactory, LocalIo, RtioTimer, Callback};
 
 /// A synchronous timer object

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -13,7 +13,7 @@
 use prelude::*;
 use cmp;
 use io;
-use owned::Box;
+use boxed::Box;
 use slice::bytes::MutableByteVector;
 
 /// Wraps a `Reader`, limiting the number of bytes that can be read from it.
@@ -263,7 +263,7 @@ impl<T: Iterator<u8>> Reader for IterReader<T> {
 mod test {
     use io::{MemReader, MemWriter, BufReader};
     use io;
-    use owned::Box;
+    use boxed::Box;
     use super::*;
     use prelude::*;
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -138,7 +138,7 @@ extern crate rustrt;
 #[cfg(test)] pub use realstd::ops;
 #[cfg(test)] pub use realstd::cmp;
 #[cfg(test)] pub use realstd::ty;
-#[cfg(test)] pub use realstd::owned;
+#[cfg(test)] pub use realstd::boxed;
 #[cfg(test)] pub use realstd::gc;
 
 
@@ -167,7 +167,10 @@ pub use core::unit;
 pub use core::result;
 pub use core::option;
 
-pub use alloc::owned;
+pub use alloc::boxed;
+#[deprecated = "use boxed instead"]
+pub use owned = boxed;
+
 pub use alloc::rc;
 
 pub use core_collections::slice;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -72,7 +72,7 @@
 #[doc(no_inline)] pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 #[doc(no_inline)] pub use num::{Signed, Unsigned, Primitive, Int, Float};
 #[doc(no_inline)] pub use num::{FloatMath, ToPrimitive, FromPrimitive};
-#[doc(no_inline)] pub use owned::Box;
+#[doc(no_inline)] pub use boxed::Box;
 #[doc(no_inline)] pub use path::{GenericPath, Path, PosixPath, WindowsPath};
 #[doc(no_inline)] pub use ptr::RawPtr;
 #[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek};

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -98,7 +98,7 @@ use comm::channel;
 use io::{Writer, stdio};
 use kinds::{Send, marker};
 use option::{None, Some, Option};
-use owned::Box;
+use boxed::Box;
 use result::Result;
 use rt::local::Local;
 use rt::task;
@@ -374,7 +374,7 @@ pub fn failing() -> bool {
 #[cfg(test)]
 mod test {
     use any::{Any, AnyRefExt};
-    use owned::AnyOwnExt;
+    use boxed::BoxAny;
     use result;
     use result::{Ok, Err};
     use str::StrAllocating;
@@ -578,7 +578,7 @@ mod test {
             Err(e) => {
                 type T = &'static str;
                 assert!(e.is::<T>());
-                assert_eq!(*e.move::<T>().unwrap(), "static string");
+                assert_eq!(*e.downcast::<T>().unwrap(), "static string");
             }
             Ok(()) => fail!()
         }
@@ -592,7 +592,7 @@ mod test {
             Err(e) => {
                 type T = String;
                 assert!(e.is::<T>());
-                assert_eq!(*e.move::<T>().unwrap(), "owned string".to_string());
+                assert_eq!(*e.downcast::<T>().unwrap(), "owned string".to_string());
             }
             Ok(()) => fail!()
         }
@@ -606,9 +606,9 @@ mod test {
             Err(e) => {
                 type T = Box<Any + Send>;
                 assert!(e.is::<T>());
-                let any = e.move::<T>().unwrap();
+                let any = e.downcast::<T>().unwrap();
                 assert!(any.is::<u16>());
-                assert_eq!(*any.move::<u16>().unwrap(), 413u16);
+                assert_eq!(*any.downcast::<u16>().unwrap(), 413u16);
             }
             Ok(()) => fail!()
         }

--- a/src/libsync/atomics.rs
+++ b/src/libsync/atomics.rs
@@ -103,7 +103,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::mem;
 
 pub use core::atomics::{AtomicBool, AtomicInt, AtomicUint, AtomicPtr};

--- a/src/libsync/comm/mod.rs
+++ b/src/libsync/comm/mod.rs
@@ -320,7 +320,7 @@
 use core::prelude::*;
 
 use alloc::arc::Arc;
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::cell::Cell;
 use core::kinds::marker;
 use core::mem;

--- a/src/libsync/comm/oneshot.rs
+++ b/src/libsync/comm/oneshot.rs
@@ -34,7 +34,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::mem;
 use rustrt::local::Local;
 use rustrt::task::{Task, BlockedTask};

--- a/src/libsync/comm/select.rs
+++ b/src/libsync/comm/select.rs
@@ -54,7 +54,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::cell::Cell;
 use core::kinds::marker;
 use core::mem;

--- a/src/libsync/comm/shared.rs
+++ b/src/libsync/comm/shared.rs
@@ -20,7 +20,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::cmp;
 use core::int;
 use rustrt::local::Local;

--- a/src/libsync/comm/stream.rs
+++ b/src/libsync/comm/stream.rs
@@ -19,7 +19,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::cmp;
 use core::int;
 use rustrt::local::Local;

--- a/src/libsync/comm/sync.rs
+++ b/src/libsync/comm/sync.rs
@@ -35,7 +35,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use collections::Vec;
 use collections::Collection;
 use core::mem;

--- a/src/libsync/deque.rs
+++ b/src/libsync/deque.rs
@@ -54,7 +54,7 @@ use core::prelude::*;
 
 use alloc::arc::Arc;
 use alloc::heap::{allocate, deallocate};
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use collections::Vec;
 use core::kinds::marker;
 use core::mem::{forget, min_align_of, size_of, transmute};

--- a/src/libsync/mpsc_queue.rs
+++ b/src/libsync/mpsc_queue.rs
@@ -42,7 +42,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::mem;
 use core::ty::Unsafe;
 

--- a/src/libsync/mutex.rs
+++ b/src/libsync/mutex.rs
@@ -59,7 +59,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::atomics;
 use core::kinds::marker;
 use core::mem;

--- a/src/libsync/spsc_queue.rs
+++ b/src/libsync/spsc_queue.rs
@@ -37,7 +37,7 @@
 
 use core::prelude::*;
 
-use alloc::owned::Box;
+use alloc::boxed::Box;
 use core::mem;
 use core::ty::Unsafe;
 

--- a/src/test/compile-fail/new-box-syntax-bad.rs
+++ b/src/test/compile-fail/new-box-syntax-bad.rs
@@ -14,7 +14,7 @@
 // Tests that the new `box` syntax works with unique pointers and GC pointers.
 
 use std::gc::{Gc, GC};
-use std::owned::{Box, HEAP};
+use std::boxed::{Box, HEAP};
 
 pub fn main() {
     let x: Gc<int> = box(HEAP) 2;  //~ ERROR mismatched types

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -14,7 +14,7 @@
 // Tests that the new `box` syntax works with unique pointers and GC pointers.
 
 use std::gc::{Gc, GC};
-use std::owned::{Box, HEAP};
+use std::boxed::{Box, HEAP};
 
 struct Structure {
     x: int,
@@ -33,4 +33,3 @@ pub fn main() {
     let c = box()(3i + 4);
     let d = box(GC)(5i + 6);
 }
-

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -10,7 +10,7 @@
 
 // Make sure the destructor is run for unit-like structs.
 
-use std::owned::AnyOwnExt;
+use std::boxed::BoxAny;
 use std::task;
 
 struct Foo;
@@ -26,6 +26,6 @@ pub fn main() {
         let _b = Foo;
     });
 
-    let s = x.unwrap_err().move::<&'static str>().unwrap();
+    let s = x.unwrap_err().downcast::<&'static str>().unwrap();
     assert_eq!(s.as_slice(), "This failure should happen.");
 }


### PR DESCRIPTION
This PR is the outcome of the library stabilization meeting for the
`liballoc::owned` and `libcore::cell` modules.

Aside from the stability attributes, there are a few breaking changes:
- The `owned` modules is now named `boxed`, to better represent its
  contents. (`box` was unavailable, since it's a keyword.) This will
  help avoid the misconception that `Box` plays a special role wrt
  ownership.
- The `AnyOwnExt` extension trait is renamed to `BoxAny`, and its `move`
  method is renamed to `downcast`, in both cases to improve clarity.
- The recently-added `AnySendOwnExt` extension trait is removed; it was
  not being used and is unnecessary.

[breaking-change]
