### PR TITLE
Run ldconfig on install

### DIFF
--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -489,8 +489,7 @@ then
             err "${ERR}"
         else
             echo
-            echo "    please ensure '${CFG_PREFIX}/lib' is added to ${CFG_LD_PATH_VAR}"
-            echo
+            echo "    Note: please ensure '${CFG_PREFIX}/lib' is added to ${CFG_LD_PATH_VAR}"
         fi
     fi
 fi

--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -293,11 +293,9 @@ elif [ "$CFG_OSTYPE" = "Darwin" ]
 then
     CFG_LD_PATH_VAR=DYLD_LIBRARY_PATH
     CFG_OLD_LD_PATH_VAR=$DYLD_LIBRARY_PATH
-    UNIX=1
 else
     CFG_LD_PATH_VAR=LD_LIBRARY_PATH
     CFG_OLD_LD_PATH_VAR=$LD_LIBRARY_PATH
-    UNIX=1
 fi
 
 flag uninstall "only uninstall from the installation prefix"
@@ -469,13 +467,13 @@ while read p; do
 done < "${CFG_SRC_DIR}/${CFG_LIBDIR_RELATIVE}/rustlib/manifest.in"
 
 # Run ldconfig to make dynamic libraries available to the linker
-if [ $UNIX -eq 1 ]
+if [ "$CFG_OSTYPE" = "Linux" ]
     then
     ldconfig
     if [ $? -ne 0 ]
     then
-	warn "failed to run ldconfig."
-	warn "this may happen when not installing as root, in which case you know what you are doing and it's probably fine."
+        warn "failed to run ldconfig."
+        warn "this may happen when not installing as root and may be fine"
     fi
 fi
 

--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -293,9 +293,11 @@ elif [ "$CFG_OSTYPE" = "Darwin" ]
 then
     CFG_LD_PATH_VAR=DYLD_LIBRARY_PATH
     CFG_OLD_LD_PATH_VAR=$DYLD_LIBRARY_PATH
+    UNIX=1
 else
     CFG_LD_PATH_VAR=LD_LIBRARY_PATH
     CFG_OLD_LD_PATH_VAR=$LD_LIBRARY_PATH
+    UNIX=1
 fi
 
 flag uninstall "only uninstall from the installation prefix"
@@ -466,6 +468,17 @@ while read p; do
 # The manifest lists all files to install
 done < "${CFG_SRC_DIR}/${CFG_LIBDIR_RELATIVE}/rustlib/manifest.in"
 
+# Run ldconfig to make dynamic libraries available to the linker
+if [ $UNIX -eq 1 ]
+    then
+    ldconfig
+    if [ $? -ne 0 ]
+    then
+	warn "failed to run ldconfig."
+	warn "this may happen when not installing as root, in which case you know what you are doing and it's probably fine."
+    fi
+fi
+
 # Sanity check: can we run the installed binaries?
 #
 # As with the verification above, make sure the right LD_LIBRARY_PATH-equivalent
@@ -493,7 +506,6 @@ then
         fi
     fi
 fi
-
 
 echo
 echo "    Rust is ready to roll."


### PR DESCRIPTION
If ldconfig fails it emits a warning. This is very possible when installing
to a non-system directory, so the warning tries to indicate that it may
not be a problem.
