### PR TITLE
mark std::hash experimental

### DIFF
--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -61,6 +61,8 @@
  * ```
  */
 
+#![experimental]
+
 pub use core_collections::hash::{Hash, Hasher, Writer, hash, sip};
 
 use default::Default;


### PR DESCRIPTION
The `hash` module was not included in an earlier pass that sets baseline
stability of modules within `std` to `experimental`.
