### PR TITLE
Fix spans for attributes

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -85,9 +85,9 @@ impl<'a> ParserAttr for Parser<'a> {
 
                 self.expect(&token::LBRACKET);
                 let meta_item = self.parse_meta_item();
+                let hi = self.span.hi;
                 self.expect(&token::RBRACKET);
 
-                let hi = self.span.hi;
                 (mk_sp(lo, hi), meta_item, style)
             }
             _ => {


### PR DESCRIPTION
They used to be one token too long, so you'd see things like

```
rust/rust/test.rs:1:1: 2:2 warning: unused attribute,
rust/rust/test.rs:1 #![foo]
rust/rust/test.rs:2 #![bar]
```

instead of

```
test.rs:1:1: 1:8 warning: unused attribute, #[warn(unused_attribute)] on
by default
test.rs:1 #![foo]
          ^~~~~~~
```
