### PR TITLE
libcollections: Add a Multiset data structure.

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -152,60 +152,6 @@ pub trait MutableSet<T>: Set<T> + Mutable {
     fn remove(&mut self, value: &T) -> bool;
 }
 
-/// A multiset is an unordered collection of objects in which each object can
-/// appear multiple times. This trait represents actions which can be performed
-/// on multisets to iterate over them.
-pub trait Multiset<T>: Collection {
-    /// Return the number of occurrences of the value in the multiset.
-    fn count(&self, value: &T) -> uint;
-
-    /// Return true if the multiset has no elements in common with `other`.
-    fn is_disjoint(&self, other: &Self) -> bool;
-
-    /// Return true if, for any given element, the number times it occurs in the
-    /// multiset is not greater than the number of times it occurs in `other`.
-    fn is_subset(&self, other: &Self) -> bool;
-
-    /// Return true if the value occurs at least once in the multiset.
-    fn contains(&self, value: &T) -> bool {
-        self.count(value) > 0u
-    }
-
-    /// Return true if the multiset is a superset of another.
-    fn is_superset(&self, other: &Self) -> bool {
-        other.is_subset(self)
-    }
-
-    // FIXME: Ideally we would have a method to return the underlying set
-    // of a multiset. However, currently there's no way to have a trait method
-    // return a trait. We need something like associated type synonyms (see #5033)
-}
-
-/// This trait represents actions which can be performed on multisets to mutate
-/// them.
-pub trait MutableMultiset<T>: Multiset<T> + Mutable {
-    /// Add `n` occurrences of `value` to the multiset. Return true if the value
-    /// was not already present in the multiset.
-    fn insert_many(&mut self, value: T, n: uint) -> bool;
-
-    /// Remove `n` occurrences of `value` from the multiset. If there are less
-    /// than `n` occurrences, remove all occurrences. Return the number of
-    /// occurrences removed.
-    fn remove_many(&mut self, value: &T, n: uint) -> uint;
-
-    /// Add one occurrence of `value` to the multiset. Return true if the value
-    /// was not already present in the multiset.
-    fn insert(&mut self, value: T) -> bool {
-        self.insert_many(value, 1)
-    }
-
-    /// Remove one occurrence of `value` from the multiset. Return true if the
-    /// value was present in the multiset.
-    fn remove(&mut self, value: &T) -> bool {
-        self.remove_many(value, 1) > 0u
-    }
-}
-
 /// A double-ended sequence that allows querying, insertion and deletion at both
 /// ends.
 pub trait Deque<T> : Mutable {

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -186,23 +186,23 @@ pub trait Multiset<T>: Collection {
 pub trait MutableMultiset<T>: Multiset<T> + Mutable {
     /// Add `n` occurrences of `value` to the multiset. Return true if the value
     /// was not already present in the multiset.
-    fn insert(&mut self, value: T, n: uint) -> bool;
+    fn insert_many(&mut self, value: T, n: uint) -> bool;
 
     /// Remove `n` occurrences of `value` from the multiset. If there are less
     /// than `n` occurrences, remove all occurrences. Return the number of
     /// occurrences removed.
-    fn remove(&mut self, value: &T, n: uint) -> uint;
+    fn remove_many(&mut self, value: &T, n: uint) -> uint;
 
     /// Add one occurrence of `value` to the multiset. Return true if the value
     /// was not already present in the multiset.
-    fn insert_one(&mut self, value: T) -> bool {
-        self.insert(value, 1)
+    fn insert(&mut self, value: T) -> bool {
+        self.insert_many(value, 1)
     }
 
     /// Remove one occurrence of `value` from the multiset. Return true if the
     /// value was present in the multiset.
-    fn remove_one(&mut self, value: &T) -> bool {
-        self.remove(value, 1) > 0u
+    fn remove(&mut self, value: &T) -> bool {
+        self.remove_many(value, 1) > 0u
     }
 }
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -152,6 +152,54 @@ pub trait MutableSet<T>: Set<T> + Mutable {
     fn remove(&mut self, value: &T) -> bool;
 }
 
+/// A multiset is an unordered collection of objects in which each object can
+/// appear multiple times. This trait represents actions which can be performed
+/// on multisets to iterate over them.
+pub trait Multiset<T>: Collection {
+    /// Return the number of occurrences of the value in the multiset.
+    fn count(&self, value: &T) -> uint;
+
+    /// Return true if the multiset has no elements in common with `other`.
+    fn is_disjoint(&self, other: &Self) -> bool;
+
+    /// Return true if, for any given element, the number times it occurs in the
+    /// multiset is not greater than the number of times it occurs in `other`.
+    fn is_subset(&self, other: &Self) -> bool;
+
+    /// Return true if the value occurs at least once in the multiset.
+    fn contains(&self, value: &T) -> bool {
+        self.count(value) > 0u
+    }
+
+    /// Return true if the multiset is a superset of another.
+    fn is_superset(&self, other: &Self) -> bool {
+        other.is_subset(self)
+    }
+
+    // FIXME: Ideally we would have a method to return the underlying set
+    // of a multiset. However, currently there's no way to have a trait method
+    // return a trait. We need something like associated type synonyms (see #5033)
+}
+
+/// This trait represents actions which can be performed on multisets to mutate
+/// them.
+pub trait MutableMultiset<T>: Multiset<T> + Mutable {
+    /// Add `n` occurrences of `value` to the multiset. Return true if the value
+    /// was not already present in the multiset.
+    fn insert(&mut self, value: T, n: uint) -> bool;
+
+    /// Remove `n` occurrences of `value` from the multiset. If there are less
+    /// than `n` occurrences, remove all occurrences. Return the number of
+    /// occurrences removed.
+    fn remove(&mut self, value: &T, n: uint) -> uint;
+
+    /// Add one occurrence of `value` to the multiset. Return true if the value
+    /// was not already present in the multiset.
+    fn insert_one(&mut self, value: T) -> bool {
+        self.insert(value, 1)
+    }
+}
+
 /// A double-ended sequence that allows querying, insertion and deletion at both
 /// ends.
 pub trait Deque<T> : Mutable {

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -198,6 +198,12 @@ pub trait MutableMultiset<T>: Multiset<T> + Mutable {
     fn insert_one(&mut self, value: T) -> bool {
         self.insert(value, 1)
     }
+
+    /// Remove one occurrence of `value` from the multiset. Return true if the
+    /// value was present in the multiset.
+    fn remove_one(&mut self, value: &T) -> bool {
+        self.remove(value, 1) > 0u
+    }
 }
 
 /// A double-ended sequence that allows querying, insertion and deletion at both

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -923,6 +923,7 @@ impl<T: Ord> Extendable<T> for TreeMultiset<T> {
 }
 
 impl<T: Ord> FromIterator<T> for TreeMultiset<T> {
+    #[inline]
     fn from_iter<Iter: Iterator<T>>(iter: Iter) -> TreeMultiset<T> {
         let mut mset = TreeMultiset::new();
         mset.extend(iter);
@@ -941,6 +942,7 @@ impl<T: Ord> TreeMultiset<T> {
     pub fn new() -> TreeMultiset<T> { TreeMultiset {map: TreeMap::new(), length: 0} }
 
     /// Get the number of distinct values in the multiset
+    #[inline]
     pub fn num_distinct(&self) -> uint { self.map.len() }
 
     /// Get a lazy iterator over the values in the multiset.
@@ -973,30 +975,35 @@ impl<T: Ord> TreeMultiset<T> {
     }
 
     /// Visit the values (in-order) representing the difference
+    #[inline]
     pub fn difference<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> DifferenceItems<'a, T, MultisetItems<'a, T>> {
         DifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visit the values (in-order) representing the symmetric difference
+    #[inline]
     pub fn symmetric_difference<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> SymDifferenceItems<'a, T, MultisetItems<'a, T>> {
         SymDifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visit the values (in-order) representing the multiset sum
+    #[inline]
     pub fn sum<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> SumItems<'a, T, MultisetItems<'a, T>> {
         SumItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visit the values (in-order) representing the intersection
+    #[inline]
     pub fn intersection<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> IntersectionItems<'a, T, MultisetItems<'a, T>> {
         IntersectionItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visit the values (in-order) representing the union
+    #[inline]
     pub fn union<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> UnionItems<'a, T, MultisetItems<'a, T>> {
         UnionItems{a: self.iter().peekable(), b: other.iter().peekable()}
@@ -1057,17 +1064,20 @@ impl<T: Ord> TreeMultiset<T> {
     }
 
     /// Return true if the value occurs at least once in the multiset.
+    #[inline]
     pub fn contains(&self, value: &T) -> bool {
-        self.count(value) > 0u
+        self.count(value) > 0
     }
 
     /// Return true if the multiset is a superset of another.
+    #[inline]
     pub fn is_superset(&self, other: &TreeMultiset<T>) -> bool {
         other.is_subset(self)
     }
 
     /// Add `n` occurrences of `value` to the multiset. Return true if the value
     /// was not already present in the multiset.
+    #[inline]
     pub fn insert_many(&mut self, value: T, n: uint) -> bool {
         let curr = self.count(&value);
         self.length += n;
@@ -1077,6 +1087,7 @@ impl<T: Ord> TreeMultiset<T> {
     /// Remove `n` occurrences of `value` from the multiset. If there are less
     /// than `n` occurrences, remove all occurrences. Return the number of
     /// occurrences removed.
+    #[inline]
     pub fn remove_many(&mut self, value: &T, n: uint) -> uint {
         let curr = self.count(value);
 
@@ -1098,12 +1109,14 @@ impl<T: Ord> TreeMultiset<T> {
 
     /// Add one occurrence of `value` to the multiset. Return true if the value
     /// was not already present in the multiset.
+    #[inline]
     pub fn insert(&mut self, value: T) -> bool {
         self.insert_many(value, 1)
     }
 
     /// Remove one occurrence of `value` from the multiset. Return true if the
     /// value was present in the multiset.
+    #[inline]
     pub fn remove(&mut self, value: &T) -> bool {
         self.remove_many(value, 1) > 0u
     }

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -909,7 +909,7 @@ impl<T: Ord> Extendable<T> for TreeMultiset<T> {
     #[inline]
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         for elem in iter {
-            self.insert_one(elem);
+            self.insert(elem);
         }
     }
 }
@@ -976,13 +976,13 @@ impl<T: Ord> Multiset<T> for TreeMultiset<T> {
 }
 
 impl<T: Ord> MutableMultiset<T> for TreeMultiset<T> {
-    fn insert(&mut self, value: T, n: uint) -> bool {
+    fn insert_many(&mut self, value: T, n: uint) -> bool {
         let curr = self.count(&value);
         self.length += n;
         self.map.insert(value, curr + n)
     }
 
-    fn remove(&mut self, value: &T, n: uint) -> uint {
+    fn remove_many(&mut self, value: &T, n: uint) -> uint {
         let curr = self.count(value);
 
         if n >= curr {
@@ -2202,22 +2202,22 @@ mod test_mset {
     fn test_len() {
         let mut s = TreeMultiset::new();
         assert!(s.len() == 0);
-        assert!(s.insert_one(1i));
+        assert!(s.insert(1i));
         assert!(s.len() == 1);
-        assert!(s.insert(3, 5));
+        assert!(s.insert_many(3, 5));
         assert!(s.len() == 6);
-        assert!(s.insert(7, 2));
+        assert!(s.insert_many(7, 2));
         assert!(s.len() == 8);
 
-        assert!(s.remove_one(&7));
+        assert!(s.remove(&7));
         assert!(s.len() == 7);
-        assert!(s.remove_one(&7));
+        assert!(s.remove(&7));
         assert!(s.len() == 6);
-        assert!(!s.remove_one(&7));
+        assert!(!s.remove(&7));
         assert!(s.len() == 6);
-        assert!(s.remove(&3, 3) == 3);
+        assert!(s.remove_many(&3, 3) == 3);
         assert!(s.len() == 3);
-        assert!(s.remove(&3, 8) == 2);
+        assert!(s.remove_many(&3, 8) == 2);
         assert!(s.len() == 1);
     }
 
@@ -2225,9 +2225,9 @@ mod test_mset {
     fn test_clear() {
         let mut s = TreeMultiset::new();
         s.clear();
-        assert!(s.insert_one(5i));
-        assert!(s.insert_one(12));
-        assert!(s.insert_one(19));
+        assert!(s.insert(5i));
+        assert!(s.insert(12));
+        assert!(s.insert(19));
         s.clear();
         assert!(!s.contains(&5));
         assert!(!s.contains(&12));
@@ -2238,19 +2238,19 @@ mod test_mset {
     #[test]
     fn test_count() {
         let mut m = TreeMultiset::new();
-        assert!(m.insert_one(1i));
+        assert!(m.insert(1i));
         assert!(m.count(&1) == 1);
-        assert!(!m.insert_one(1i));
+        assert!(!m.insert(1i));
         assert!(m.count(&1) == 2);
 
         assert!(m.count(&2) == 0);
-        assert!(m.insert(2i, 4));
+        assert!(m.insert_many(2i, 4));
         assert!(m.count(&2) == 4);
-        assert!(m.remove(&2, 3) == 3);
+        assert!(m.remove_many(&2, 3) == 3);
         assert!(m.count(&2) == 1);
-        assert!(m.remove_one(&2));
+        assert!(m.remove(&2));
         assert!(m.count(&2) == 0);
-        assert!(!m.remove_one(&2));
+        assert!(!m.remove(&2));
         assert!(m.count(&2) == 0);
     }
 
@@ -2260,21 +2260,21 @@ mod test_mset {
         let mut ys = TreeMultiset::new();
         assert!(xs.is_disjoint(&ys));
         assert!(ys.is_disjoint(&xs));
-        assert!(xs.insert_one(5i));
-        assert!(ys.insert_one(11i));
+        assert!(xs.insert(5i));
+        assert!(ys.insert(11i));
         assert!(xs.is_disjoint(&ys));
         assert!(ys.is_disjoint(&xs));
-        assert!(xs.insert_one(7));
-        assert!(xs.insert_one(19));
-        assert!(xs.insert_one(4));
-        assert!(ys.insert_one(2));
-        assert!(ys.insert_one(-11));
+        assert!(xs.insert(7));
+        assert!(xs.insert(19));
+        assert!(xs.insert(4));
+        assert!(ys.insert(2));
+        assert!(ys.insert(-11));
         assert!(xs.is_disjoint(&ys));
         assert!(ys.is_disjoint(&xs));
-        assert!(ys.insert_one(7));
+        assert!(ys.insert(7));
         assert!(!ys.is_disjoint(&xs));
         assert!(!xs.is_disjoint(&ys));
-        assert!(!xs.insert_one(7));
+        assert!(!xs.insert(7));
         assert!(!ys.is_disjoint(&xs));
         assert!(!xs.is_disjoint(&ys));
     }
@@ -2282,41 +2282,41 @@ mod test_mset {
     #[test]
     fn test_subset_and_superset() {
         let mut a = TreeMultiset::new();
-        assert!(a.insert_one(0i));
-        assert!(a.insert_one(5));
-        assert!(a.insert_one(11));
-        assert!(a.insert_one(7));
+        assert!(a.insert(0i));
+        assert!(a.insert(5));
+        assert!(a.insert(11));
+        assert!(a.insert(7));
 
         let mut b = TreeMultiset::new();
-        assert!(b.insert_one(0i));
-        assert!(b.insert_one(7));
-        assert!(b.insert_one(19));
-        assert!(b.insert_one(250));
-        assert!(b.insert_one(11));
-        assert!(b.insert_one(200));
+        assert!(b.insert(0i));
+        assert!(b.insert(7));
+        assert!(b.insert(19));
+        assert!(b.insert(250));
+        assert!(b.insert(11));
+        assert!(b.insert(200));
 
         assert!(!a.is_subset(&b));
         assert!(!a.is_superset(&b));
         assert!(!b.is_subset(&a));
         assert!(!b.is_superset(&a));
 
-        assert!(!a.insert_one(5));
-        assert!(b.insert_one(5));
+        assert!(!a.insert(5));
+        assert!(b.insert(5));
 
         assert!(!a.is_subset(&b));
         assert!(!a.is_superset(&b));
         assert!(!b.is_subset(&a));
         assert!(!b.is_superset(&a));
 
-        assert!(!b.insert_one(5));
+        assert!(!b.insert(5));
 
         assert!(a.is_subset(&b));
         assert!(!a.is_superset(&b));
         assert!(!b.is_subset(&a));
         assert!(b.is_superset(&a));
 
-        assert!(!b.insert_one(7));
-        assert!(!b.insert_one(7));
+        assert!(!b.insert(7));
+        assert!(!b.insert(7));
 
         assert!(a.is_subset(&b));
         assert!(!a.is_superset(&b));
@@ -2328,13 +2328,13 @@ mod test_mset {
     fn test_iterator() {
         let mut m = TreeMultiset::new();
 
-        assert!(m.insert_one(3i));
-        assert!(m.insert_one(2));
-        assert!(m.insert_one(0));
-        assert!(m.insert_one(-2));
-        assert!(m.insert_one(4));
-        assert!(!m.insert_one(2));
-        assert!(m.insert_one(1));
+        assert!(m.insert(3i));
+        assert!(m.insert(2));
+        assert!(m.insert(0));
+        assert!(m.insert(-2));
+        assert!(m.insert(4));
+        assert!(!m.insert(2));
+        assert!(m.insert(1));
 
         let v = vec!(-2i, 0, 1, 2, 2, 3, 4);
         for (x, y) in m.iter().zip(v.iter()) {
@@ -2346,13 +2346,13 @@ mod test_mset {
     fn test_rev_iter() {
         let mut m = TreeMultiset::new();
 
-        assert!(m.insert_one(3i));
-        assert!(m.insert_one(2));
-        assert!(m.insert_one(0));
-        assert!(m.insert_one(-2));
-        assert!(m.insert_one(4));
-        assert!(!m.insert_one(2));
-        assert!(m.insert_one(1));
+        assert!(m.insert(3i));
+        assert!(m.insert(2));
+        assert!(m.insert(0));
+        assert!(m.insert(-2));
+        assert!(m.insert(4));
+        assert!(!m.insert(2));
+        assert!(m.insert(1));
 
         let v = vec!(4i, 3, 2, 2, 1, 0, -2);
         for (x, y) in m.rev_iter().zip(v.iter()) {
@@ -2364,8 +2364,8 @@ mod test_mset {
     fn test_clone_eq() {
       let mut m = TreeMultiset::new();
 
-      m.insert_one(1i);
-      m.insert_one(2);
+      m.insert(1i);
+      m.insert(2);
 
       assert!(m.clone() == m);
     }
@@ -2377,8 +2377,8 @@ mod test_mset {
         let mut set_a = TreeMultiset::new();
         let mut set_b = TreeMultiset::new();
 
-        for x in a.iter() { set_a.insert_one(*x); }
-        for y in b.iter() { set_b.insert_one(*y); }
+        for x in a.iter() { set_a.insert(*x); }
+        for y in b.iter() { set_b.insert(*y); }
 
         let mut i = 0;
         f(&set_a, &set_b, |x| {
@@ -2491,8 +2491,8 @@ mod test_mset {
         let mut set: TreeMultiset<int> = TreeMultiset::new();
         let empty: TreeMultiset<int> = TreeMultiset::new();
 
-        set.insert_one(1);
-        set.insert(2, 3);
+        set.insert(1);
+        set.insert_many(2, 3);
 
         let set_str = format!("{}", set);
 

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -957,6 +957,21 @@ impl<T: Ord> TreeMultiset<T> {
         RevMultisetItems{iter: self.map.rev_iter(), current: None, count: 0}
     }
 
+    /// Get a lazy iterator pointing to the first value greater than or equal to `v`.
+    /// If all elements in the multiset are less than `v`, an empty iterator is returned.
+    #[inline]
+    pub fn lower_bound<'a>(&'a self, v: &T) -> MultisetItems<'a, T> {
+        MultisetItems{iter: self.map.lower_bound(v), current: None, count: 0}
+    }
+
+    /// Get a lazy iterator pointing to the first value greater than `v`.
+    /// If all elements in the multiset are not greater than `v`, an empty iterator
+    /// is returned.
+    #[inline]
+    pub fn upper_bound<'a>(&'a self, v: &T) -> MultisetItems<'a, T> {
+        MultisetItems{iter: self.map.upper_bound(v), current: None, count: 0}
+    }
+
     /// Visit the values (in-order) representing the difference
     pub fn difference<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> DifferenceItems<'a, T, MultisetItems<'a, T>> {

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -860,6 +860,19 @@ impl<T: Ord> PartialOrd for TreeMultiset<T> {
     }
 }
 
+impl<T: Ord + Show> Show for TreeMultiset<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "{{"));
+
+        for (i, x) in self.iter().enumerate() {
+            if i != 0 { try!(write!(f, ", ")); }
+            try!(write!(f, "{}", *x));
+        }
+
+        write!(f, "}}")
+    }
+}
+
 impl<T: Ord> Collection for TreeMultiset<T> {
     #[inline]
     fn len(&self) -> uint { self.map.len() }
@@ -963,6 +976,11 @@ impl<T: Ord> MutableMultiset<T> for TreeMultiset<T> {
         }
     }
 
+}
+
+impl<T: Ord> Default for TreeMultiset<T> {
+    #[inline]
+    fn default() -> TreeMultiset<T> { TreeMultiset::new() }
 }
 
 impl<T: Ord> TreeMultiset<T> {
@@ -2162,6 +2180,25 @@ mod test_mset {
     }
 
     #[test]
+    fn test_count() {
+        let mut m = TreeMultiset::new();
+        assert!(m.insert_one(1i));
+        assert!(m.count(&1) == 1);
+        assert!(!m.insert_one(1i));
+        assert!(m.count(&1) == 2);
+
+        assert!(m.count(&2) == 0);
+        assert!(m.insert(2i, 4));
+        assert!(m.count(&2) == 4);
+        assert!(m.remove(&2, 3) == 3);
+        assert!(m.count(&2) == 1);
+        assert!(m.remove_one(&2));
+        assert!(m.count(&2) == 0);
+        assert!(!m.remove_one(&2));
+        assert!(m.count(&2) == 0);
+    }
+
+    #[test]
     fn test_disjoint() {
         let mut xs = TreeMultiset::new();
         let mut ys = TreeMultiset::new();
@@ -2359,5 +2396,19 @@ mod test_mset {
         check_union([1, 3, 5, 9, 11, 16, 19, 24],
                     [-2, 1, 5, 9, 13, 19],
                     [-2, 1, 3, 5, 9, 11, 13, 16, 19, 24]);
+    }
+
+    #[test]
+    fn test_show() {
+        let mut set: TreeMultiset<int> = TreeMultiset::new();
+        let empty: TreeMultiset<int> = TreeMultiset::new();
+
+        set.insert_one(1);
+        set.insert(2, 3);
+
+        let set_str = format!("{}", set);
+
+        assert!(set_str == "{1, 2, 2, 2}".to_string());
+        assert_eq!(format!("{}", empty), "{}".to_string());
     }
 }

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -23,7 +23,7 @@ use core::iter;
 use core::mem::{replace, swap};
 use core::ptr;
 
-use {Collection, Mutable, Set, MutableSet, Multiset, MutableMultiset, MutableMap, Map};
+use {Collection, Mutable, Set, MutableSet, MutableMap, Map};
 use vec::Vec;
 
 // This is implemented as an AA tree, which is a simplified variation of
@@ -858,9 +858,9 @@ impl<'a, T: Ord, I: Iterator<&'a T>> Iterator<&'a T> for UnionItems<'a, T, I> {
 }
 
 
-/// A implementation of the `Multiset` trait on top of the `TreeMap` container.
-/// The only requirement is that the type of the elements contained ascribes to
-/// the `Ord` trait.
+/// A implementation of a multiset on top of the `TreeMap` container. The only
+/// requirement is that the type of the elements contained ascribes to the 
+/// `Ord` trait.
 #[deriving(Clone)]
 pub struct TreeMultiset<T> {
     map: TreeMap<T,uint>,
@@ -930,86 +930,6 @@ impl<T: Ord> FromIterator<T> for TreeMultiset<T> {
     }
 }
 
-impl<T: Ord> Multiset<T> for TreeMultiset<T> {
-    #[inline]
-    fn count(&self, value: &T) -> uint {
-        match self.map.find(value) {
-            None => 0u,
-            Some(count) => *count
-        }
-    }
-
-    fn is_disjoint(&self, other: &TreeMultiset<T>) -> bool {
-        let mut x = self.iter();
-        let mut y = other.iter();
-        let mut a = x.next();
-        let mut b = y.next();
-        while a.is_some() && b.is_some() {
-            let a1 = a.unwrap();
-            let b1 = b.unwrap();
-
-            match a1.cmp(b1) {
-                Less => a = x.next(),
-                Greater => b = y.next(),
-                Equal => return false,
-            }
-        }
-        true
-    }
-
-    fn is_subset(&self, other: &TreeMultiset<T>) -> bool {
-        let mut x = self.iter();
-        let mut y = other.iter();
-        let mut a = x.next();
-        let mut b = y.next();
-        while a.is_some() {
-            if b.is_none() {
-                return false;
-            }
-
-            let a1 = a.unwrap();
-            let b1 = b.unwrap();
-
-            match b1.cmp(a1) {
-                Less => (),
-                Greater => return false,
-                Equal => a = x.next(),
-            }
-
-            b = y.next();
-        }
-        true
-    }
-
-}
-
-impl<T: Ord> MutableMultiset<T> for TreeMultiset<T> {
-    fn insert_many(&mut self, value: T, n: uint) -> bool {
-        let curr = self.count(&value);
-        self.length += n;
-        self.map.insert(value, curr + n)
-    }
-
-    fn remove_many(&mut self, value: &T, n: uint) -> uint {
-        let curr = self.count(value);
-
-        if n >= curr {
-            self.map.remove(value);
-            self.length -= curr;
-            curr
-        } else {
-            match self.map.find_mut(value) {
-                None => 0u,
-                Some(mult) => {
-                    self.length -= n;
-                    *mult = curr - n;
-                    n
-                }
-            }
-        }
-    }
-}
-
 impl<T: Ord> Default for TreeMultiset<T> {
     #[inline]
     fn default() -> TreeMultiset<T> { TreeMultiset::new() }
@@ -1065,6 +985,122 @@ impl<T: Ord> TreeMultiset<T> {
     pub fn union<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> UnionItems<'a, T, MultisetItems<'a, T>> {
         UnionItems{a: self.iter().peekable(), b: other.iter().peekable()}
+    }
+
+    /// Return the number of occurrences of the value in the multiset.
+    #[inline]
+    pub fn count(&self, value: &T) -> uint {
+        match self.map.find(value) {
+            None => 0u,
+            Some(count) => *count
+        }
+    }
+
+    /// Return true if the multiset has no elements in common with `other`.
+    pub fn is_disjoint(&self, other: &TreeMultiset<T>) -> bool {
+        let mut x = self.iter();
+        let mut y = other.iter();
+        let mut a = x.next();
+        let mut b = y.next();
+        while a.is_some() && b.is_some() {
+            let a1 = a.unwrap();
+            let b1 = b.unwrap();
+
+            match a1.cmp(b1) {
+                Less => a = x.next(),
+                Greater => b = y.next(),
+                Equal => return false,
+            }
+        }
+        true
+    }
+
+    /// Return true if, for any given element, the number times it occurs in the
+    /// multiset is not greater than the number of times it occurs in `other`.
+    pub fn is_subset(&self, other: &TreeMultiset<T>) -> bool {
+        let mut x = self.iter();
+        let mut y = other.iter();
+        let mut a = x.next();
+        let mut b = y.next();
+        while a.is_some() {
+            if b.is_none() {
+                return false;
+            }
+
+            let a1 = a.unwrap();
+            let b1 = b.unwrap();
+
+            match b1.cmp(a1) {
+                Less => (),
+                Greater => return false,
+                Equal => a = x.next(),
+            }
+
+            b = y.next();
+        }
+        true
+    }
+
+    /// Return true if the value occurs at least once in the multiset.
+    pub fn contains(&self, value: &T) -> bool {
+        self.count(value) > 0u
+    }
+
+    /// Return true if the multiset is a superset of another.
+    pub fn is_superset(&self, other: &TreeMultiset<T>) -> bool {
+        other.is_subset(self)
+    }
+
+    /// Add `n` occurrences of `value` to the multiset. Return true if the value
+    /// was not already present in the multiset.
+    pub fn insert_many(&mut self, value: T, n: uint) -> bool {
+        let curr = self.count(&value);
+        self.length += n;
+        self.map.insert(value, curr + n)
+    }
+
+    /// Remove `n` occurrences of `value` from the multiset. If there are less
+    /// than `n` occurrences, remove all occurrences. Return the number of
+    /// occurrences removed.
+    pub fn remove_many(&mut self, value: &T, n: uint) -> uint {
+        let curr = self.count(value);
+
+        if n >= curr {
+            self.map.remove(value);
+            self.length -= curr;
+            curr
+        } else {
+            match self.map.find_mut(value) {
+                None => 0u,
+                Some(mult) => {
+                    self.length -= n;
+                    *mult = curr - n;
+                    n
+                }
+            }
+        }
+    }
+
+    /// Add one occurrence of `value` to the multiset. Return true if the value
+    /// was not already present in the multiset.
+    pub fn insert(&mut self, value: T) -> bool {
+        self.insert_many(value, 1)
+    }
+
+    /// Remove one occurrence of `value` from the multiset. Return true if the
+    /// value was present in the multiset.
+    pub fn remove(&mut self, value: &T) -> bool {
+        self.remove_many(value, 1) > 0u
+    }
+}
+
+impl<T: Ord + Clone> TreeMultiset<T> {
+    pub fn to_set(&self) -> TreeSet<T> {
+        let mut set = TreeSet::new();
+        for (k, _) in self.map.clone().move_iter() {
+            set.insert(k);
+        }
+        set
     }
 }
 
@@ -2204,7 +2240,7 @@ mod test_mset {
     use std::prelude::*;
     use std::hash;
 
-    use {Multiset, MutableMultiset, Mutable, MutableMap};
+    use {Mutable, MutableMap};
     use super::{TreeMap, TreeMultiset};
 
     #[test]

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -763,6 +763,12 @@ pub struct SymDifferenceItems<'a, T, I> {
     b: Peekable<&'a T, I>,
 }
 
+/// Lazy iterator producing elements in the multiset sum (in-order)
+pub struct SumItems<'a, T, I> {
+    a: Peekable<&'a T, I>,
+    b: Peekable<&'a T, I>,
+}
+
 /// Lazy iterator producing elements in the set intersection (in-order)
 pub struct IntersectionItems<'a, T, I> {
     a: Peekable<&'a T, I>,
@@ -803,6 +809,18 @@ impl<'a, T: Ord, I: Iterator<&'a T>> Iterator<&'a T> for SymDifferenceItems<'a, 
             match cmp_opt(self.a.peek(), self.b.peek(), Greater, Less) {
                 Less    => return self.a.next(),
                 Equal   => { self.a.next(); self.b.next(); }
+                Greater => return self.b.next(),
+            }
+        }
+    }
+}
+
+impl<'a, T: Ord, I: Iterator<&'a T>> Iterator<&'a T> for SumItems<'a, T, I> {
+    fn next(&mut self) -> Option<&'a T> {
+        loop {
+            match cmp_opt(self.a.peek(), self.b.peek(), Greater, Less) {
+                Less    => return self.a.next(),
+                Equal   => return self.a.next(),
                 Greater => return self.b.next(),
             }
         }
@@ -1021,6 +1039,12 @@ impl<T: Ord> TreeMultiset<T> {
     pub fn symmetric_difference<'a>(&'a self, other: &'a TreeMultiset<T>)
         -> SymDifferenceItems<'a, T, MultisetItems<'a, T>> {
         SymDifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
+    }
+
+    /// Visit the values (in-order) representing the multiset sum
+    pub fn sum<'a>(&'a self, other: &'a TreeMultiset<T>)
+        -> SumItems<'a, T, MultisetItems<'a, T>> {
+        SumItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visit the values (in-order) representing the intersection
@@ -2413,6 +2437,21 @@ mod test_mset {
         check_symmetric_difference([1, 3, 5, 9, 11],
                                    [-2, 3, 9, 14, 22],
                                    [-2, 1, 5, 11, 14, 22]);
+    }
+
+    #[test]
+    fn test_sum() {
+        fn check_sum(a: &[int], b: &[int],
+                                      expected: &[int]) {
+            check(a, b, expected, |x, y, f| x.sum(y).all(f))
+        }
+
+        check_sum([], [], []);
+        check_sum([1, 2, 2, 3], [2], [1, 2, 2, 2, 3]);
+        check_sum([2, 2], [1, 2, 2, 3], [1, 2, 2, 2, 2, 3]);
+        check_sum([1, 3, 5, 9, 11, 16, 19, 24],
+                    [-2, 1, 5, 9, 13, 19],
+                    [-2, 1, 1, 3, 5, 5, 9, 9, 11, 13, 16, 19, 19, 24]);
     }
 
     #[test]

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -879,6 +879,14 @@ impl<T: Ord> PartialOrd for TreeMultiset<T> {
     }
 }
 
+impl<S: Writer, T: Ord + Hash<S>> Hash<S> for TreeMultiset<T> {
+    fn hash(&self, state: &mut S) {
+        for elt in self.iter() {
+            elt.hash(state);
+        }
+    }
+}
+
 impl<T: Ord + Show> Show for TreeMultiset<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "{{"));
@@ -2194,6 +2202,7 @@ mod test_set {
 #[cfg(test)]
 mod test_mset {
     use std::prelude::*;
+    use std::hash;
 
     use {Multiset, MutableMultiset, Mutable, MutableMap};
     use super::{TreeMap, TreeMultiset};
@@ -2368,6 +2377,22 @@ mod test_mset {
       m.insert(2);
 
       assert!(m.clone() == m);
+    }
+
+    #[test]
+    fn test_hash() {
+      let mut x = TreeMultiset::new();
+      let mut y = TreeMultiset::new();
+
+      x.insert(1i);
+      x.insert(2);
+      x.insert(3);
+
+      y.insert(3i);
+      y.insert(2);
+      y.insert(1);
+
+      assert!(hash::hash(&x) == hash::hash(&y));
     }
 
     fn check(a: &[int],

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -2470,6 +2470,23 @@ mod test_mset {
     }
 
     #[test]
+    fn test_from_iter() {
+        let xs = [1i, 2, 3, 3, 3, 4, 5, 4, 6, 7, 8, 9];
+
+        let set: TreeMultiset<int> = xs.iter().map(|&x| x).collect();
+
+        for x in xs.iter() {
+            if *x == 3 {
+                assert!(set.count(x) == 3);
+            } else if *x == 4 {
+                assert!(set.count(x) == 2);
+            } else {
+                assert!(set.count(x) == 1);
+            }
+        }
+    }
+
+    #[test]
     fn test_show() {
         let mut set: TreeMultiset<int> = TreeMultiset::new();
         let empty: TreeMultiset<int> = TreeMultiset::new();

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -859,7 +859,7 @@ impl<'a, T: Ord, I: Iterator<&'a T>> Iterator<&'a T> for UnionItems<'a, T, I> {
 
 
 /// A implementation of a multiset on top of the `TreeMap` container. The only
-/// requirement is that the type of the elements contained ascribes to the 
+/// requirement is that the type of the elements contained ascribes to the
 /// `Ord` trait.
 #[deriving(Clone)]
 pub struct TreeMultiset<T> {
@@ -1106,16 +1106,6 @@ impl<T: Ord> TreeMultiset<T> {
     /// value was present in the multiset.
     pub fn remove(&mut self, value: &T) -> bool {
         self.remove_many(value, 1) > 0u
-    }
-}
-
-impl<T: Ord + Clone> TreeMultiset<T> {
-    pub fn to_set(&self) -> TreeSet<T> {
-        let mut set = TreeSet::new();
-        for (k, _) in self.map.clone().move_iter() {
-            set.insert(k);
-        }
-        set
     }
 }
 

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -891,7 +891,7 @@ impl<T: Ord> Extendable<T> for TreeMultiset<T> {
     #[inline]
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         for elem in iter {
-            self.insert(elem, 1);
+            self.insert_one(elem);
         }
     }
 }


### PR DESCRIPTION
This is not finished, but I want some feedback before I go too far on my own. This defines two new traits, `Multiset` and `MutableMultiset`. I currently have a partial implementation of these traits, `TreeMultiset`, based on TreeMap, and I plan to add another one based on HashMap. I have tried to make these traits and the `TreeMultiset` implementation closely correspond to the Set traits and `TreeSet`.

The `TreeMultiset` implementation is missing a few things, mostly some trait implementations. I also plan on adding  a multiset sum operation, which is distinct from multiset union (see [this Wikipedia page](http://en.wikipedia.org/wiki/Multiset#Multiplicity_function) for reference).

One thing I want to add to the Multiset trait is a `to_set` method that will return the underlying set of the multiset, which would just be all the distinct values in the multiset with multiple occurrences removed. However, this currently doesn't seem possible, as noted in #8154.

Another thing I've wondered about: the Multiset trait could inherit the Set trait, but the way I've written it, MutableMultiset could not inherit MutableSet. One way this could be changed is to inherit MutableSet and use `insert` as a method to insert one occurrence (and `remove` as a method to remove one occurrence) and then add trait methods for inserting multiple occurrence, perhaps called `insert_multiple`/`remove_multiple` or `insert_many`/`remove_many`. I'm just not sure if this makes sense.
