### PR TITLE
getopts: example does not build

### DIFF
--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -59,7 +59,7 @@
 //!     ];
 //!     let matches = match getopts(args.tail(), opts) {
 //!         Ok(m) => { m }
-//!         Err(f) => { fail!(f.to_string()) }
+//!         Err(f) => { fail!(f) }
 //!     };
 //!     if matches.opt_present("h") {
 //!         print_usage(program.as_slice(), opts);


### PR DESCRIPTION
```
error: type `getopts::Fail_` does not implement any method in scope named `to_string`
```

Not needed. Fail_ implements Show.
