### PR TITLE
Provide a way of obtaining numeric file descriptors.

### DIFF
--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -159,6 +159,8 @@ impl rtio::RtioFileStream for FileDesc {
             _ => Err(super::last_error()),
         }
     }
+
+    fn get_fd(&self) -> libc::c_int { self.fd() }
 }
 
 impl rtio::RtioPipe for FileDesc {
@@ -314,6 +316,8 @@ impl rtio::RtioFileStream for CFile {
     fn fstat(&mut self) -> IoResult<rtio::FileStat> {
         self.flush().and_then(|()| self.fd.fstat())
     }
+
+    fn get_fd(&self) -> libc::c_int { self.fd.get_fd() }
 }
 
 impl Drop for CFile {

--- a/src/librustrt/rtio.rs
+++ b/src/librustrt/rtio.rs
@@ -307,6 +307,7 @@ pub trait RtioFileStream {
     fn datasync(&mut self) -> IoResult<()>;
     fn truncate(&mut self, offset: i64) -> IoResult<()>;
     fn fstat(&mut self) -> IoResult<FileStat>;
+    fn get_fd(&self) -> c_int;
 }
 
 pub trait RtioProcess {

--- a/src/librustrt/rtio.rs
+++ b/src/librustrt/rtio.rs
@@ -235,6 +235,7 @@ pub trait IoFactory {
             -> IoResult<Box<RtioTTY + Send>>;
     fn signal(&mut self, signal: int, cb: Box<Callback + Send>)
         -> IoResult<Box<RtioSignal + Send>>;
+    fn get_fd(&self) -> int;
 }
 
 pub trait RtioTcpListener : RtioSocket {
@@ -262,6 +263,7 @@ pub trait RtioTcpStream : RtioSocket {
     fn set_timeout(&mut self, timeout_ms: Option<u64>);
     fn set_read_timeout(&mut self, timeout_ms: Option<u64>);
     fn set_write_timeout(&mut self, timeout_ms: Option<u64>);
+    fn get_fd(&self) -> int;
 }
 
 pub trait RtioSocket {
@@ -307,7 +309,7 @@ pub trait RtioFileStream {
     fn datasync(&mut self) -> IoResult<()>;
     fn truncate(&mut self, offset: i64) -> IoResult<()>;
     fn fstat(&mut self) -> IoResult<FileStat>;
-    fn get_fd(&self) -> c_int;
+    fn get_fd(&self) -> int;
 }
 
 pub trait RtioProcess {
@@ -327,6 +329,7 @@ pub trait RtioPipe {
     fn set_timeout(&mut self, timeout_ms: Option<u64>);
     fn set_read_timeout(&mut self, timeout_ms: Option<u64>);
     fn set_write_timeout(&mut self, timeout_ms: Option<u64>);
+    fn get_fd(&self) -> int;
 }
 
 pub trait RtioUnixListener {
@@ -344,6 +347,7 @@ pub trait RtioTTY {
     fn set_raw(&mut self, raw: bool) -> IoResult<()>;
     fn get_winsize(&mut self) -> IoResult<(int, int)>;
     fn isatty(&self) -> bool;
+    fn get_fd(&self) -> int;
 }
 
 pub trait PausableIdleCallback {

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -458,6 +458,8 @@ impl rtio::RtioFileStream for FileWatcher {
         let _m = self.fire_homing_missile();
         FsRequest::fstat(&self.loop_, self.fd).map_err(uv_error_to_io_error)
     }
+
+    fn get_fd(&self) -> libc::c_int { self.fd }
 }
 
 #[cfg(test)]

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -251,6 +251,17 @@ impl File {
         err.update_err("couldn't fstat file",
                        |e| format!("{}; path={}", e, self.path.display()))
     }
+
+    /// Obtain numeric file descriptor that can be passed to a C library call.
+    ///
+    /// It is not considered unsafe to obtain this, however calling C library
+    /// is inherently unsafe. The advantage of this method is that opening
+    /// a file and handling of error cases with pattern matching is much nicer
+    /// in Rust, then it is in C. If one is to call `libc::open()`, or other
+    /// similar function that opens files in POSIX fashion, they would need
+    /// to reimplement a large chunk of code that copies some of the functions
+    /// from this and the underlying traits and modules.
+    pub fn get_fd(&self) -> libc::c_int { self.fd.get_fd() }
 }
 
 /// Unlink a file from the underlying filesystem.

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -97,6 +97,8 @@ impl PipeStream {
             }
         }
     }
+
+    pub fn get_fd(&self) -> int { self.fd as int }
 }
 
 impl Clone for PipeStream {


### PR DESCRIPTION
This is to improve the interoperability with external C libraries.
One should be able to leverage most Rust's standard run-time functions
for openning and closing files with all the error handling etc, while
only making C library calls when it's very neccessary.
