### PR TITLE
glob::MatchOptions struct fields should be public

### DIFF
--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -601,13 +601,13 @@ pub struct MatchOptions {
      * currently only considers upper/lower case relationships between ASCII characters,
      * but in future this might be extended to work with Unicode.
      */
-    case_sensitive: bool,
+    pub case_sensitive: bool,
 
     /**
      * If this is true then path-component separator characters (e.g. `/` on Posix)
      * must be matched by a literal `/`, rather than by `*` or `?` or `[...]`
      */
-    require_literal_separator: bool,
+    pub require_literal_separator: bool,
 
     /**
      * If this is true then paths that contain components that start with a `.` will
@@ -615,7 +615,7 @@ pub struct MatchOptions {
      * will not match. This is useful because such files are conventionally considered
      * hidden on Unix systems and it might be desirable to skip them when listing files.
      */
-    require_literal_leading_dot: bool
+    pub require_literal_leading_dot: bool
 }
 
 impl MatchOptions {


### PR DESCRIPTION
Not sure how to test this correctly I assume the current tests pass now because of the crate boundaries [and that this is fallout from private by default]?
