### PR TITLE
Two adjustments to rustc for cargo

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -579,7 +579,18 @@ pub fn find_crate_name(sess: Option<&Session>,
     match sess {
         Some(sess) => {
             match sess.opts.crate_name {
-                Some(ref s) => return validate(s.clone(), None),
+                Some(ref s) => {
+                    match attr_crate_name {
+                        Some((attr, ref name)) if s.as_slice() != name.get() => {
+                            let msg = format!("--crate-name and #[crate_name] \
+                                               are required to match, but `{}` \
+                                               != `{}`", s, name);
+                            sess.span_err(attr.span, msg.as_slice());
+                        }
+                        _ => {},
+                    }
+                    return validate(s.clone(), None);
+                }
                 None => {}
             }
         }

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -54,17 +54,19 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         };
 
         let archive = ArchiveRO::open(&path).expect("wanted an rlib");
-        debug!("reading {}", name);
+        let file = path.filename_str().unwrap();
+        let file = file.slice(3, file.len() - 5); // chop off lib/.rlib
+        debug!("reading {}", file);
         let bc = time(sess.time_passes(),
                       format!("read {}.bytecode.deflate", name).as_slice(),
                       (),
                       |_| {
                           archive.read(format!("{}.bytecode.deflate",
-                                               name).as_slice())
+                                               file).as_slice())
                       });
         let bc = bc.expect("missing compressed bytecode in archive!");
         let bc = time(sess.time_passes(),
-                      format!("inflate {}.bc", name).as_slice(),
+                      format!("inflate {}.bc", file).as_slice(),
                       (),
                       |_| {
                           match flate::inflate_bytes(bc) {

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -936,6 +936,7 @@ pub struct OutputFilenames {
     pub out_directory: Path,
     pub out_filestem: String,
     pub single_output_file: Option<Path>,
+    extra: String,
 }
 
 impl OutputFilenames {
@@ -948,7 +949,7 @@ impl OutputFilenames {
     }
 
     pub fn temp_path(&self, flavor: link::OutputType) -> Path {
-        let base = self.out_directory.join(self.out_filestem.as_slice());
+        let base = self.out_directory.join(self.filestem());
         match flavor {
             link::OutputTypeBitcode => base.with_extension("bc"),
             link::OutputTypeAssembly => base.with_extension("s"),
@@ -959,8 +960,11 @@ impl OutputFilenames {
     }
 
     pub fn with_extension(&self, extension: &str) -> Path {
-        let stem = self.out_filestem.as_slice();
-        self.out_directory.join(stem).with_extension(extension)
+        self.out_directory.join(self.filestem()).with_extension(extension)
+    }
+
+    fn filestem(&self) -> String {
+        format!("{}{}", self.out_filestem, self.extra)
     }
 }
 
@@ -1000,6 +1004,7 @@ pub fn build_output_filenames(input: &Input,
                 out_directory: dirpath,
                 out_filestem: stem,
                 single_output_file: None,
+                extra: sess.opts.cg.extra_filename.clone(),
             }
         }
 
@@ -1018,6 +1023,7 @@ pub fn build_output_filenames(input: &Input,
                 out_directory: out_file.dir_path(),
                 out_filestem: out_file.filestem_str().unwrap().to_string(),
                 single_output_file: ofile,
+                extra: sess.opts.cg.extra_filename.clone(),
             }
         }
     }

--- a/src/test/compile-fail/crate-name-mismatch.rs
+++ b/src/test/compile-fail/crate-name-mismatch.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-args: --crate-name foo
+
+#![crate_name = "bar"]
+//~^ ERROR: --crate-name and #[crate_name] are required to match, but `foo` != `bar`
+
+fn main() {}

--- a/src/test/run-make/crate-name-priority/Makefile
+++ b/src/test/run-make/crate-name-priority/Makefile
@@ -7,7 +7,5 @@ all:
 	rm $(TMPDIR)/$(call BIN,bar)
 	$(RUSTC) foo1.rs
 	rm $(TMPDIR)/$(call BIN,foo)
-	$(RUSTC) foo1.rs --crate-name bar
-	rm $(TMPDIR)/$(call BIN,bar)
-	$(RUSTC) foo1.rs --crate-name bar -o $(TMPDIR)/bar1
+	$(RUSTC) foo1.rs -o $(TMPDIR)/bar1
 	rm $(TMPDIR)/$(call BIN,bar1)

--- a/src/test/run-make/extra-filename-with-temp-outputs/Makefile
+++ b/src/test/run-make/extra-filename-with-temp-outputs/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -C extra-filename=bar foo.rs -C save-temps
+	rm $(TMPDIR)/foobar.o
+	rm $(TMPDIR)/$(call BIN,foobar)

--- a/src/test/run-make/extra-filename-with-temp-outputs/foo.rs
+++ b/src/test/run-make/extra-filename-with-temp-outputs/foo.rs
@@ -8,9 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --crate-name foo
-
-#![crate_name = "bar"]
-//~^ ERROR: --crate-name and #[crate_name] are required to match, but `foo` != `bar`
-
 fn main() {}

--- a/src/test/run-pass/crate-name-attr-used.rs
+++ b/src/test/run-pass/crate-name-attr-used.rs
@@ -10,6 +10,6 @@
 
 // compile-flags:--crate-name crate-name-attr-used -F unused-attribute
 
-#![crate_name = "test"]
+#![crate_name = "crate-name-attr-used"]
 
 fn main() {}


### PR DESCRIPTION
The first is to require that `#[crate_name]` and `--crate-name` always match (if both are specified). The second is to fix parallel compilation in cargo by mixing in `-C extra-filename` into the temporary outputs of the compiler.
