### PR TITLE
Method field cleanup

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -43,6 +43,7 @@ use syntax::ast_map::{PathElem, PathElems};
 use syntax::ast_map;
 use syntax::ast_util::*;
 use syntax::ast_util;
+use syntax::ast_util::PostExpansionMethod;
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
 use syntax::diagnostic::SpanHandler;
@@ -798,7 +799,7 @@ fn encode_info_for_method(ecx: &EncodeContext,
         } else {
             encode_symbol(ecx, ebml_w, m.def_id.node);
         }
-        encode_method_argument_names(ebml_w, method_fn_decl(&*ast_method));
+        encode_method_argument_names(ebml_w, &*ast_method.pe_fn_decl());
     }
 
     ebml_w.end_tag();
@@ -1240,7 +1241,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
                     encode_method_sort(ebml_w, 'p');
                     encode_inlined_item(ecx, ebml_w,
                                         IIMethodRef(def_id, true, &*m));
-                    encode_method_argument_names(ebml_w, method_fn_decl(m));
+                    encode_method_argument_names(ebml_w, m.pe_fn_decl());
                 }
             }
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -31,6 +31,7 @@ use middle::{ty, typeck};
 use util::ppaux::ty_to_string;
 
 use syntax::{ast, ast_map, ast_util, codemap, fold};
+use syntax::ast_util::PostExpansionMethod;
 use syntax::codemap::Span;
 use syntax::fold::Folder;
 use syntax::parse::token;
@@ -136,7 +137,7 @@ pub fn decode_inlined_item(cdata: &cstore::crate_metadata,
         let ident = match ii {
             ast::IIItem(i) => i.ident,
             ast::IIForeign(i) => i.ident,
-            ast::IIMethod(_, _, m) => ast_util::method_ident(&*m),
+            ast::IIMethod(_, _, m) => m.pe_ident(),
         };
         debug!("Fn named: {}", token::get_ident(ident));
         debug!("< Decoded inlined fn: {}::{}",

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -22,8 +22,7 @@ use util::nodemap::NodeSet;
 use std::collections::HashSet;
 use syntax::ast;
 use syntax::ast_map;
-use syntax::ast_util;
-use syntax::ast_util::{local_def, is_local};
+use syntax::ast_util::{local_def, is_local, PostExpansionMethod};
 use syntax::attr::AttrMetaMethods;
 use syntax::attr;
 use syntax::codemap;
@@ -213,7 +212,7 @@ impl<'a> MarkSymbolVisitor<'a> {
                 visit::walk_trait_method(self, &*trait_method, ctxt);
             }
             ast_map::NodeMethod(method) => {
-                visit::walk_block(self, ast_util::method_body(&*method), ctxt);
+                visit::walk_block(self, method.pe_body(), ctxt);
             }
             ast_map::NodeForeignItem(foreign_item) => {
                 visit::walk_foreign_item(self, &*foreign_item, ctxt);
@@ -521,8 +520,7 @@ impl<'a> Visitor<()> for DeadVisitor<'a> {
     // Overwrite so that we don't warn the trait method itself.
     fn visit_trait_method(&mut self, trait_method: &ast::TraitMethod, _: ()) {
         match *trait_method {
-            ast::Provided(ref method) => visit::walk_block(self,
-                                                           ast_util::method_body(&**method), ()),
+            ast::Provided(ref method) => visit::walk_block(self, method.pe_body(), ()),
             ast::Required(_) => ()
         }
     }

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -17,7 +17,7 @@ use middle::typeck::MethodCall;
 use util::ppaux;
 
 use syntax::ast;
-use syntax::ast_util;
+use syntax::ast_util::PostExpansionMethod;
 use syntax::codemap::Span;
 use syntax::visit;
 use syntax::visit::Visitor;
@@ -95,7 +95,7 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
             visit::FkItemFn(_, _, fn_style, _) =>
                 (true, fn_style == ast::UnsafeFn),
             visit::FkMethod(_, _, method) =>
-                (true, ast_util::method_fn_style(method) == ast::UnsafeFn),
+                (true, method.pe_fn_style() == ast::UnsafeFn),
             _ => (false, false),
         };
 

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -43,6 +43,7 @@ use std::os;
 
 use syntax::ast;
 use syntax::ast_util;
+use syntax::ast_util::PostExpansionMethod;
 use syntax::ast::{NodeId,DefId};
 use syntax::ast_map::NodeItem;
 use syntax::attr;
@@ -333,7 +334,7 @@ impl <'l> DxrVisitor<'l> {
             },
         };
 
-        qualname.push_str(get_ident(ast_util::method_ident(&*method)).get());
+        qualname.push_str(get_ident(method.pe_ident()).get());
         let qualname = qualname.as_slice();
 
         // record the decl for this def (if it has one)
@@ -349,18 +350,17 @@ impl <'l> DxrVisitor<'l> {
                             decl_id,
                             scope_id);
 
-        let m_decl = ast_util::method_fn_decl(&*method);
-        self.process_formals(&m_decl.inputs, qualname, e);
+        self.process_formals(&method.pe_fn_decl().inputs, qualname, e);
 
         // walk arg and return types
-        for arg in m_decl.inputs.iter() {
+        for arg in method.pe_fn_decl().inputs.iter() {
             self.visit_ty(&*arg.ty, e);
         }
-        self.visit_ty(m_decl.output, e);
+        self.visit_ty(method.pe_fn_decl().output, e);
         // walk the fn body
-        self.visit_block(ast_util::method_body(&*method), DxrVisitorEnv::new_nested(method.id));
+        self.visit_block(method.pe_body(), DxrVisitorEnv::new_nested(method.id));
 
-        self.process_generic_params(ast_util::method_generics(&*method),
+        self.process_generic_params(method.pe_generics(),
                                     method.span,
                                     qualname,
                                     method.id,

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -207,6 +207,7 @@ use std::rc::{Rc, Weak};
 use syntax::util::interner::Interner;
 use syntax::codemap::{Span, Pos};
 use syntax::{abi, ast, codemap, ast_util, ast_map};
+use syntax::ast_util::PostExpansionMethod;
 use syntax::owned_slice::OwnedSlice;
 use syntax::parse::token;
 use syntax::parse::token::special_idents;
@@ -1138,10 +1139,10 @@ pub fn create_function_debug_context(cx: &CrateContext,
             }
         }
         ast_map::NodeMethod(ref method) => {
-            (ast_util::method_ident(&**method),
-             ast_util::method_fn_decl(&**method),
-             ast_util::method_generics(&**method),
-             ast_util::method_body(&**method),
+            (method.pe_ident(),
+             method.pe_fn_decl(),
+             method.pe_generics(),
+             method.pe_body(),
              method.span,
              true)
         }
@@ -1167,10 +1168,10 @@ pub fn create_function_debug_context(cx: &CrateContext,
         ast_map::NodeTraitMethod(ref trait_method) => {
             match **trait_method {
                 ast::Provided(ref method) => {
-                    (ast_util::method_ident(&**method),
-                     ast_util::method_fn_decl(&**method),
-                     ast_util::method_generics(&**method),
-                     ast_util::method_body(&**method),
+                    (method.pe_ident(),
+                     method.pe_fn_decl(),
+                     method.pe_generics(),
+                     method.pe_body(),
                      method.span,
                      true)
                 }

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -16,7 +16,7 @@ use middle::trans::common::*;
 use middle::ty;
 
 use syntax::ast;
-use syntax::ast_util::local_def;
+use syntax::ast_util::{local_def, PostExpansionMethod};
 use syntax::ast_util;
 
 pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
@@ -128,12 +128,11 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             let impl_tpt = ty::lookup_item_type(ccx.tcx(), impl_did);
             let unparameterized =
                 impl_tpt.generics.types.is_empty() &&
-                ast_util::method_generics(&*mth).ty_params.is_empty();
+                mth.pe_generics().ty_params.is_empty();
 
           if unparameterized {
               let llfn = get_item_val(ccx, mth.id);
-              trans_fn(ccx, ast_util::method_fn_decl(&*mth),
-                       ast_util::method_body(&*mth), llfn,
+                trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), llfn,
                        &param_substs::empty(), mth.id, []);
           }
           local_def(mth.id)

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -25,8 +25,7 @@ use util::ppaux::Repr;
 use syntax::abi;
 use syntax::ast;
 use syntax::ast_map;
-use syntax::ast_util;
-use syntax::ast_util::local_def;
+use syntax::ast_util::{local_def, PostExpansionMethod};
 use std::hash::{sip, Hash};
 
 pub fn monomorphic_fn(ccx: &CrateContext,
@@ -182,8 +181,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         ast_map::NodeMethod(mth) => {
             let d = mk_lldecl();
             set_llvm_fn_attrs(mth.attrs.as_slice(), d);
-            trans_fn(ccx, ast_util::method_fn_decl(&*mth),
-                     ast_util::method_body(&*mth), d, &psubsts, mth.id, []);
+            trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d, &psubsts, mth.id, []);
             d
         }
         ast_map::NodeTraitMethod(method) => {
@@ -191,8 +189,8 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                 ast::Provided(mth) => {
                     let d = mk_lldecl();
                     set_llvm_fn_attrs(mth.attrs.as_slice(), d);
-                    trans_fn(ccx, ast_util::method_fn_decl(&*mth),
-                             ast_util::method_body(&*mth), d, &psubsts, mth.id, []);
+                    trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d,
+                             &psubsts, mth.id, []);
                     d
                 }
                 _ => {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -125,7 +125,7 @@ use syntax::abi;
 use syntax::ast::{Provided, Required};
 use syntax::ast;
 use syntax::ast_map;
-use syntax::ast_util::local_def;
+use syntax::ast_util::{local_def, PostExpansionMethod};
 use syntax::ast_util;
 use syntax::attr;
 use syntax::codemap::Span;
@@ -757,16 +757,14 @@ fn check_method_body(ccx: &CrateCtxt,
     let method_def_id = local_def(method.id);
     let method_ty = ty::method(ccx.tcx, method_def_id);
     let method_generics = &method_ty.generics;
-    let m_body = ast_util::method_body(&*method);
 
     let param_env = ty::construct_parameter_environment(ccx.tcx,
                                                         method_generics,
-                                                        m_body.id);
+                                                        method.pe_body().id);
 
     let fty = ty::node_id_to_type(ccx.tcx, method.id);
 
-    check_bare_fn(ccx, ast_util::method_fn_decl(&*method),
-                  m_body, method.id, fty, param_env);
+    check_bare_fn(ccx, method.pe_fn_decl(), method.pe_body(), method.id, fty, param_env);
 }
 
 fn check_impl_methods_against_trait(ccx: &CrateCtxt,
@@ -794,7 +792,7 @@ fn check_impl_methods_against_trait(ccx: &CrateCtxt,
                 compare_impl_method(ccx.tcx,
                                     &*impl_method_ty,
                                     impl_method.span,
-                                    ast_util::method_body(&**impl_method).id,
+                                    impl_method.pe_body().id,
                                     &**trait_method_ty,
                                     &impl_trait_ref.substs);
             }
@@ -817,7 +815,7 @@ fn check_impl_methods_against_trait(ccx: &CrateCtxt,
     for trait_method in trait_methods.iter() {
         let is_implemented =
             impl_methods.iter().any(
-                |m| ast_util::method_ident(&**m).name == trait_method.ident.name);
+                |m| m.pe_ident().name == trait_method.ident.name);
         let is_provided =
             provided_methods.iter().any(
                 |m| m.ident.name == trait_method.ident.name);

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -84,7 +84,7 @@ use std::string::String;
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util;
-use syntax::ast_util::name_to_dummy_lifetime;
+use syntax::ast_util::{name_to_dummy_lifetime, PostExpansionMethod};
 use syntax::owned_slice::OwnedSlice;
 use syntax::codemap;
 use syntax::parse::token;
@@ -700,11 +700,8 @@ impl<'a> ErrorReporting for InferCtxt<'a> {
                     }
                 }
                 ast_map::NodeMethod(ref m) => {
-                    Some((ast_util::method_fn_decl(&**m),
-                          ast_util::method_generics(&**m),
-                          ast_util::method_fn_style(&**m),
-                          ast_util::method_ident(&**m),
-                          Some(ast_util::method_explicit_self(&**m).node), m.span))
+                    Some((m.pe_fn_decl(), m.pe_generics(), m.pe_fn_style(),
+                          m.pe_ident(), Some(m.pe_explicit_self().node), m.span))
                 },
                 _ => None
             },
@@ -1455,7 +1452,7 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
                 _ => None
             },
             ast_map::NodeMethod(m) => {
-                taken.push_all(ast_util::method_generics(&*m).lifetimes.as_slice());
+                taken.push_all(m.pe_generics().lifetimes.as_slice());
                 Some(m.id)
             },
             _ => None

--- a/src/libsyntax/ast_map/blocks.rs
+++ b/src/libsyntax/ast_map/blocks.rs
@@ -26,7 +26,7 @@ use ast::{P, Block, FnDecl, NodeId};
 use ast;
 use ast_map::{Node};
 use ast_map;
-use ast_util;
+use ast_util::PostExpansionMethod;
 use codemap::Span;
 use visit;
 
@@ -152,13 +152,13 @@ impl FnLikeNode {
 
     pub fn body<'a>(&'a self) -> P<Block> {
         self.handle(|i: ItemFnParts|     i.body,
-                    |m: &'a ast::Method| ast_util::method_body(m),
+                    |m: &'a ast::Method| m.pe_body(),
                     |c: ClosureParts|    c.body)
     }
 
     pub fn decl<'a>(&'a self) -> P<FnDecl> {
         self.handle(|i: ItemFnParts|     i.decl,
-                    |m: &'a ast::Method| ast_util::method_fn_decl(m),
+                    |m: &'a ast::Method| m.pe_fn_decl(),
                     |c: ClosureParts|    c.decl)
     }
 
@@ -182,7 +182,7 @@ impl FnLikeNode {
             visit::FkFnBlock
         };
         let method = |m: &'a ast::Method| {
-            visit::FkMethod(ast_util::method_ident(m), ast_util::method_generics(m), m)
+            visit::FkMethod(m.pe_ident(), m.pe_generics(), m)
         };
         self.handle(item, method, closure)
     }


### PR DESCRIPTION
This patch applies the excellent suggestion of @pnkfelix to group the helper methods for method field access into a Trait, making the code much more readable, and much more similar to the way it was before.
