### PR TITLE
test: Try to fix a failing snapshot test

### DIFF
--- a/src/test/compile-fail-fulldeps/macro-crate-rlib.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-rlib.rs
@@ -12,6 +12,7 @@
 // ignore-stage1
 // ignore-tidy-linelength
 // ignore-android
+// ignore-cross-compile gives a different error message
 
 #![feature(phase)]
 #[phase(plugin)] extern crate rlib_crate_test;


### PR DESCRIPTION
This test seems to yield a different error message on cross compiles, so just
ignore it when cross compiling.
