### PR TITLE
Add an option to disable the use of the redzone

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -332,6 +332,8 @@ cgoptions!(
         "prefer dynamic linking to static linking"),
     no_integrated_as: bool = (false, parse_bool,
         "use an external assembler rather than LLVM's integrated one"),
+    no_redzone: bool = (false, parse_bool,
+        "disable the use of the redzone"),
     relocation_model: String = ("pic".to_string(), parse_string,
          "choose the relocation model to use (llc -relocation-model for details)"),
     metadata: Vec<String> = (Vec::new(), parse_list,

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -193,6 +193,14 @@ fn decl_fn(ccx: &CrateContext, name: &str, cc: llvm::CallConv,
         _ => {}
     }
 
+    if ccx.tcx.sess.opts.cg.no_redzone {
+        unsafe {
+            llvm::LLVMAddFunctionAttribute(llfn,
+                                           llvm::FunctionIndex as c_uint,
+                                           llvm::NoRedZoneAttribute as uint64_t)
+        }
+    }
+
     llvm::SetFunctionCallConv(llfn, cc);
     // Function addresses in Rust are never significant, allowing functions to be merged.
     llvm::SetUnnamedAddr(llfn, true);


### PR DESCRIPTION
Disabling the redzone is required in x86-64's kernel mode to avoid interrupts trashing the stack.

I'm not sure if decl_fn is the right place to tag all functions with noredzone. It might have interactions with external functions when linking with bitcode built without -C no-redzone although I see no reason to do that.

I'm not sure how to write a test inspecting the bitcode output for noredzone attributes on all functions either.
