### PR TITLE
Support for specifying the code model

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -186,6 +186,22 @@ pub mod write {
                 }
             };
 
+            let code_model = match sess.opts.cg.code_model.as_slice() {
+                "default" => llvm::CodeModelDefault,
+                "small" => llvm::CodeModelSmall,
+                "kernel" => llvm::CodeModelKernel,
+                "medium" => llvm::CodeModelMedium,
+                "large" => llvm::CodeModelLarge,
+                _ => {
+                    sess.err(format!("{} is not a valid code model",
+                                     sess.opts
+                                         .cg
+                                         .code_model).as_slice());
+                    sess.abort_if_errors();
+                    return;
+                }
+            };
+
             let tm = sess.targ_cfg
                          .target_strs
                          .target_triple
@@ -195,7 +211,7 @@ pub mod write {
                     target_feature(sess).with_c_str(|features| {
                         llvm::LLVMRustCreateTargetMachine(
                             t, cpu, features,
-                            llvm::CodeModelDefault,
+                            code_model,
                             reloc_model,
                             opt_level,
                             true /* EnableSegstk */,

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -334,6 +334,8 @@ cgoptions!(
         "use an external assembler rather than LLVM's integrated one"),
     relocation_model: String = ("pic".to_string(), parse_string,
          "choose the relocation model to use (llc -relocation-model for details)"),
+    code_model: String = ("default".to_string(), parse_string,
+         "choose the code model to use (llc -code-model for details)"),
     metadata: Vec<String> = (Vec::new(), parse_list,
          "metadata to mangle symbol names with"),
     extra_filename: String = ("".to_string(), parse_string,


### PR DESCRIPTION
The default code model is usually unsuitable for kernels,
so we add an option to specify which model we want.

Testing for this would be fragile and very architecture specific and is better left to LLVM.
