### PR TITLE
Rename Option in tutorial to workaround iteration bug.

### DIFF
--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -979,7 +979,7 @@ let mut b = Foo { x: 5, y: box 10 };
 b.x = 10;
 ~~~~
 
-If an object doesn't contain any non-Send types, it consists of a single
+If an object doesn't contain any non-`Send` types, it consists of a single
 ownership tree and is itself given the `Send` trait which allows it to be sent
 between tasks. Custom destructors can only be implemented directly on types
 that are `Send`, but non-`Send` types can still *contain* types with custom

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -979,7 +979,7 @@ let mut b = Foo { x: 5, y: box 10 };
 b.x = 10;
 ~~~~
 
-If an object doesn't contain any non-`Send` types, it consists of a single
+If an object doesn't contain any non-Send types, it consists of a single
 ownership tree and is itself given the `Send` trait which allows it to be sent
 between tasks. Custom destructors can only be implemented directly on types
 that are `Send`, but non-`Send` types can still *contain* types with custom
@@ -2095,7 +2095,7 @@ the type `Option` with the constants `Some(T)` and `None`.
 Because Rust does not have null pointers (except in unsafe code),
 we need another way to write a function whose result isn't defined on every
 possible combination of arguments of the appropriate types. The usual way is to
-write a function that returns `Option<T>` instead of `T`.`
+write a function that returns `Option<T>` instead of `T`.
 
 ~~~~
 # struct Point { x: f64, y: f64 }

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2090,7 +2090,7 @@ These declarations can be instantiated to valid types like `Set<int>`,
 `Stack<int>`, and `Maybe<int>`.
 
 The last type in that example, `Maybe`, is already defined in Rust as
-the type `Option` with the constants `Some(T)` and `None`.
+the type `Option` with the variants `Some(T)` and `None`.
 `Option` appears frequently in Rust code. 
 Because Rust does not have null pointers (except in unsafe code),
 we need another way to write a function whose result isn't defined on every

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2079,21 +2079,23 @@ struct Stack<T> {
     elements: Vec<T>
 }
 
-enum Option<T> {
-    Some(T),
-    None
+enum MyOption<T> {
+    MySome(T),
+    MyNone
 }
 # fn main() {}
 ~~~~
 
 These declarations can be instantiated to valid types like `Set<int>`,
-`Stack<int>`, and `Option<int>`.
+`Stack<int>`, and `MyOption<int>`.
 
-The last type in that example, `Option`, appears frequently in Rust code.
-Because Rust does not have null pointers (except in unsafe code), we need
-another way to write a function whose result isn't defined on every possible
-combination of arguments of the appropriate types. The usual way is to write
-a function that returns `Option<T>` instead of `T`.
+The last type in that example, `MyOption`, is already defined in Rust as
+the type `Option` with the constants `Some(T)` and `None`.
+`Option` appears frequently in Rust code. 
+Because Rust does not have null pointers (except in unsafe code),
+we need another way to write a function whose result isn't defined on every
+possible combination of arguments of the appropriate types. The usual way is to
+write a function that returns `Option<T>` instead of `T`.`
 
 ~~~~
 # struct Point { x: f64, y: f64 }

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -2079,17 +2079,17 @@ struct Stack<T> {
     elements: Vec<T>
 }
 
-enum MyOption<T> {
-    MySome(T),
-    MyNone
+enum Maybe<T> {
+    Just(T),
+    Nothing
 }
 # fn main() {}
 ~~~~
 
 These declarations can be instantiated to valid types like `Set<int>`,
-`Stack<int>`, and `MyOption<int>`.
+`Stack<int>`, and `Maybe<int>`.
 
-The last type in that example, `MyOption`, is already defined in Rust as
+The last type in that example, `Maybe`, is already defined in Rust as
 the type `Option` with the constants `Some(T)` and `None`.
 `Option` appears frequently in Rust code. 
 Because Rust does not have null pointers (except in unsafe code),


### PR DESCRIPTION
 Fix for #15409. 

I opted to rename `Option` to `MyOption` so we won't get an error if we simply type in all code. 

Explicitly mention that rust has an `Option` type and in the following code snippets we use rust's built in type. It should be clear what's going on I hope.
