### PR TITLE
debuginfo: Don't crash when encountering global variable with unknown source span

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -798,15 +798,16 @@ pub fn create_global_var_metadata(cx: &CrateContext,
                                    var_item).as_slice())
     };
 
-    let filename = span_start(cx, span).file.name.clone();
-    let file_metadata = file_metadata(cx, filename.as_slice());
+    let (file_metadata, line_number) = if span != codemap::DUMMY_SP {
+        let loc = span_start(cx, span);
+        (file_metadata(cx, loc.file.name.as_slice()), loc.line as c_uint)
+    } else {
+        (UNKNOWN_FILE_METADATA, UNKNOWN_LINE_NUMBER)
+    };
 
     let is_local_to_unit = is_node_local_to_unit(cx, node_id);
-    let loc = span_start(cx, span);
-
     let variable_type = ty::node_id_to_type(cx.tcx(), node_id);
     let type_metadata = type_metadata(cx, variable_type, span);
-
     let namespace_node = namespace_for_item(cx, ast_util::local_def(node_id));
     let var_name = token::get_ident(ident).get().to_string();
     let linkage_name =
@@ -821,7 +822,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
                                                         var_name,
                                                         linkage_name,
                                                         file_metadata,
-                                                        loc.line as c_uint,
+                                                        line_number,
                                                         type_metadata,
                                                         is_local_to_unit,
                                                         global,


### PR DESCRIPTION
This should fix issue #15541. It would be good to have an test case for this would also be nice but I haven't had the time to write one. The change is very small though and it doesn't break anything in the existing test suite, so I guess we can add it without test for now.
