### PR TITLE
Rename functions in the CloneableVector trait

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -277,21 +277,33 @@ impl<T: Clone> Iterator<Vec<T>> for Permutations<T> {
 
 /// Extension methods for vector slices with cloneable elements
 pub trait CloneableVector<T> {
-    /// Copy `self` into a new owned vector
-    fn to_owned(&self) -> Vec<T>;
+    /// Copy `self` into a new vector
+    fn to_vec(&self) -> Vec<T>;
+
+    /// Deprecated. Use `to_vec`
+    #[deprecated = "Replaced by `to_vec`"]
+    fn to_owned(&self) -> Vec<T> {
+        self.to_vec()
+    }
 
     /// Convert `self` into an owned vector, not making a copy if possible.
-    fn into_owned(self) -> Vec<T>;
+    fn into_vec(self) -> Vec<T>;
+
+    /// Deprecated. Use `into_vec`
+    #[deprecated = "Replaced by `into_vec`"]
+    fn into_owned(self) -> Vec<T> {
+        self.into_vec()
+    }
 }
 
 /// Extension methods for vector slices
 impl<'a, T: Clone> CloneableVector<T> for &'a [T] {
     /// Returns a copy of `v`.
     #[inline]
-    fn to_owned(&self) -> Vec<T> { Vec::from_slice(*self) }
+    fn to_vec(&self) -> Vec<T> { Vec::from_slice(*self) }
 
     #[inline(always)]
-    fn into_owned(self) -> Vec<T> { self.to_owned() }
+    fn into_vec(self) -> Vec<T> { self.to_vec() }
 }
 
 /// Extension methods for vectors containing `Clone` elements.
@@ -325,7 +337,7 @@ impl<'a,T:Clone> ImmutableCloneableVector<T> for &'a [T] {
     fn permutations(self) -> Permutations<T> {
         Permutations{
             swaps: ElementSwaps::new(self.len()),
-            v: self.to_owned(),
+            v: self.to_vec(),
         }
     }
 
@@ -888,7 +900,7 @@ mod tests {
     fn test_slice() {
         // Test fixed length vector.
         let vec_fixed = [1i, 2, 3, 4];
-        let v_a = vec_fixed.slice(1u, vec_fixed.len()).to_owned();
+        let v_a = vec_fixed.slice(1u, vec_fixed.len()).to_vec();
         assert_eq!(v_a.len(), 3u);
         let v_a = v_a.as_slice();
         assert_eq!(v_a[0], 2);
@@ -897,7 +909,7 @@ mod tests {
 
         // Test on stack.
         let vec_stack = &[1i, 2, 3];
-        let v_b = vec_stack.slice(1u, 3u).to_owned();
+        let v_b = vec_stack.slice(1u, 3u).to_vec();
         assert_eq!(v_b.len(), 2u);
         let v_b = v_b.as_slice();
         assert_eq!(v_b[0], 2);
@@ -905,7 +917,7 @@ mod tests {
 
         // Test `Box<[T]>`
         let vec_unique = vec![1i, 2, 3, 4, 5, 6];
-        let v_d = vec_unique.slice(1u, 6u).to_owned();
+        let v_d = vec_unique.slice(1u, 6u).to_vec();
         assert_eq!(v_d.len(), 5u);
         let v_d = v_d.as_slice();
         assert_eq!(v_d[0], 2);
@@ -1132,7 +1144,7 @@ mod tests {
             let (min_size, max_opt) = it.size_hint();
             assert_eq!(min_size, 1);
             assert_eq!(max_opt.unwrap(), 1);
-            assert_eq!(it.next(), Some(v.as_slice().to_owned()));
+            assert_eq!(it.next(), Some(v.as_slice().to_vec()));
             assert_eq!(it.next(), None);
         }
         {
@@ -1141,7 +1153,7 @@ mod tests {
             let (min_size, max_opt) = it.size_hint();
             assert_eq!(min_size, 1);
             assert_eq!(max_opt.unwrap(), 1);
-            assert_eq!(it.next(), Some(v.as_slice().to_owned()));
+            assert_eq!(it.next(), Some(v.as_slice().to_vec()));
             assert_eq!(it.next(), None);
         }
         {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -422,8 +422,8 @@ impl<T> Collection for Vec<T> {
 }
 
 impl<T: Clone> CloneableVector<T> for Vec<T> {
-    fn to_owned(&self) -> Vec<T> { self.clone() }
-    fn into_owned(self) -> Vec<T> { self }
+    fn to_vec(&self) -> Vec<T> { self.clone() }
+    fn into_vec(self) -> Vec<T> { self }
 }
 
 // FIXME: #13996: need a way to mark the return value as `noalias`

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -124,15 +124,15 @@ impl<'a,T:fmt::Show> fmt::Show for MaybeOwnedVector<'a,T> {
 
 impl<'a,T:Clone> CloneableVector<T> for MaybeOwnedVector<'a,T> {
     /// Returns a copy of `self`.
-    fn to_owned(&self) -> Vec<T> {
-        self.as_slice().to_owned()
+    fn to_vec(&self) -> Vec<T> {
+        self.as_slice().to_vec()
     }
 
     /// Convert `self` into an owned slice, not making a copy if possible.
-    fn into_owned(self) -> Vec<T> {
+    fn into_vec(self) -> Vec<T> {
         match self {
-            Growable(v) => v.as_slice().to_owned(),
-            Borrowed(v) => v.to_owned(),
+            Growable(v) => v.as_slice().to_vec(),
+            Borrowed(v) => v.to_vec(),
         }
     }
 }
@@ -140,7 +140,7 @@ impl<'a,T:Clone> CloneableVector<T> for MaybeOwnedVector<'a,T> {
 impl<'a, T: Clone> Clone for MaybeOwnedVector<'a, T> {
     fn clone(&self) -> MaybeOwnedVector<'a, T> {
         match *self {
-            Growable(ref v) => Growable(v.to_owned()),
+            Growable(ref v) => Growable(v.to_vec()),
             Borrowed(v) => Borrowed(v)
         }
     }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1238,7 +1238,7 @@ fn link_args(cmd: &mut Command,
         abi::OsMacos | abi::OsiOS => {
             let morestack = lib_path.join("libmorestack.a");
 
-            let mut v = "-Wl,-force_load,".as_bytes().to_owned();
+            let mut v = b"-Wl,-force_load,".to_vec();
             v.push_all(morestack.as_vec());
             cmd.arg(v.as_slice());
         }

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -36,7 +36,7 @@ pub mod config;
 
 
 pub fn main_args(args: &[String]) -> int {
-    let owned_args = args.to_owned();
+    let owned_args = args.to_vec();
     monitor(proc() run_compiler(owned_args.as_slice()));
     0
 }

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -46,7 +46,7 @@ impl<'a> FileSearch<'a> {
                 FileMatches => found = true,
                 FileDoesntMatch => ()
             }
-            visited_dirs.insert(path.as_vec().to_owned());
+            visited_dirs.insert(path.as_vec().to_vec());
         }
 
         debug!("filesearch: searching lib path");
@@ -59,7 +59,7 @@ impl<'a> FileSearch<'a> {
             }
         }
 
-        visited_dirs.insert(tlib_path.as_vec().to_owned());
+        visited_dirs.insert(tlib_path.as_vec().to_vec());
         // Try RUST_PATH
         if !found {
             let rustpath = rust_path();
@@ -67,10 +67,10 @@ impl<'a> FileSearch<'a> {
                 let tlib_path = make_rustpkg_lib_path(
                     self.sysroot, path, self.triple);
                 debug!("is {} in visited_dirs? {:?}", tlib_path.display(),
-                        visited_dirs.contains_equiv(&tlib_path.as_vec().to_owned()));
+                        visited_dirs.contains_equiv(&tlib_path.as_vec().to_vec()));
 
                 if !visited_dirs.contains_equiv(&tlib_path.as_vec()) {
-                    visited_dirs.insert(tlib_path.as_vec().to_owned());
+                    visited_dirs.insert(tlib_path.as_vec().to_vec());
                     // Don't keep searching the RUST_PATH if one match turns up --
                     // if we did, we'd get a "multiple matching crates" error
                     match f(&tlib_path) {

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -369,7 +369,7 @@ impl<'a, O:DataFlowOperator> DataFlowContext<'a, O> {
         let slice = match e {
             Entry => on_entry,
             Exit => {
-                let mut t = on_entry.to_owned();
+                let mut t = on_entry.to_vec();
                 self.apply_gen_kill_frozen(cfgidx, t.as_mut_slice());
                 temp_bits = t;
                 temp_bits.as_slice()
@@ -445,7 +445,7 @@ impl<'a, O:DataFlowOperator> DataFlowContext<'a, O> {
         cfg.graph.each_edge(|_edge_index, edge| {
             let flow_exit = edge.source();
             let (start, end) = self.compute_id_range(flow_exit);
-            let mut orig_kills = self.kills.slice(start, end).to_owned();
+            let mut orig_kills = self.kills.slice(start, end).to_vec();
 
             let mut changed = false;
             for &node_id in edge.data.exiting_scopes.iter() {

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -1136,10 +1136,11 @@ impl<'l> Visitor<DxrVisitorEnv> for DxrVisitor<'l> {
                 }
             },
             ast::ViewItemExternCrate(ident, ref s, id) => {
-                let name = get_ident(ident).get().to_owned();
+                let name = get_ident(ident);
+                let name = name.get();
                 let s = match *s {
-                    Some((ref s, _)) => s.get().to_owned(),
-                    None => name.to_owned(),
+                    Some((ref s, _)) => s.get().to_string(),
+                    None => name.to_string(),
                 };
                 let sub_span = self.span.sub_span_after_keyword(i.span, keywords::Crate);
                 let cnum = match self.sess.cstore.find_extern_mod_stmt_cnum(id) {
@@ -1150,7 +1151,7 @@ impl<'l> Visitor<DxrVisitorEnv> for DxrVisitor<'l> {
                                           sub_span,
                                           id,
                                           cnum,
-                                          name.as_slice(),
+                                          name,
                                           s.as_slice(),
                                           e.cur_scope);
             },
@@ -1273,9 +1274,9 @@ impl<'l> Visitor<DxrVisitorEnv> for DxrVisitor<'l> {
         // process collected paths
         for &(id, ref p, ref immut, ref_kind) in self.collected_paths.iter() {
             let value = if *immut {
-                self.span.snippet(p.span).into_owned()
+                self.span.snippet(p.span).into_string()
             } else {
-                "<mutable>".to_owned()
+                "<mutable>".to_string()
             };
             let sub_span = self.span.span_for_first_ident(p.span);
             let def_map = self.analysis.ty_cx.def_map.borrow();
@@ -1330,7 +1331,7 @@ impl<'l> Visitor<DxrVisitorEnv> for DxrVisitor<'l> {
         let value = self.span.snippet(l.span);
 
         for &(id, ref p, ref immut, _) in self.collected_paths.iter() {
-            let value = if *immut { value.to_owned() } else { "<mutable>".to_owned() };
+            let value = if *immut { value.to_string() } else { "<mutable>".to_string() };
             let types = self.analysis.ty_cx.node_types.borrow();
             let typ = ppaux::ty_to_string(&self.analysis.ty_cx, *types.get(&(id as uint)));
             // Get the span only for the name of the variable (I hope the path

--- a/src/librustc/middle/save/recorder.rs
+++ b/src/librustc/middle/save/recorder.rs
@@ -170,7 +170,7 @@ impl<'a> FmtStrs<'a> {
                 String::from_str(v)
             }
         )));
-        Some(strs.fold(String::new(), |s, ss| s.append(ss.as_slice()))).map(|s| s.into_owned())
+        Some(strs.fold(String::new(), |s, ss| s.append(ss.as_slice())))
     }
 
     pub fn record_without_span(&mut self,
@@ -503,7 +503,7 @@ impl<'a> FmtStrs<'a> {
         };
         let (dcn, dck) = match declid {
             Some(declid) => (s!(declid.node), s!(declid.krate)),
-            None => ("".to_owned(), "".to_owned())
+            None => ("".to_string(), "".to_string())
         };
         self.check_and_record(MethodCall,
                               span,

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -95,7 +95,7 @@ impl Emitter for ExpectErrorEmitter {
 }
 
 fn errors(msgs: &[&str]) -> (Box<Emitter+Send>, uint) {
-    let v = Vec::from_fn(msgs.len(), |i| msgs[i].to_owned());
+    let v = msgs.iter().map(|m| m.to_string()).collect();
     (box ExpectErrorEmitter { messages: v } as Box<Emitter+Send>, msgs.len())
 }
 
@@ -114,7 +114,7 @@ fn test_env(_test_name: &str,
 
     let sess = session::build_session_(options, None, span_diagnostic_handler);
     let krate_config = Vec::new();
-    let input = driver::StrInput(source_string.to_owned());
+    let input = driver::StrInput(source_string.to_string());
     let krate = driver::phase_1_parse_input(&sess, krate_config, &input);
     let (krate, ast_map) =
         driver::phase_2_configure_and_expand(&sess, krate, "test")

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -778,11 +778,11 @@ mod tests {
             c_ = Some(c.clone());
             c.clone();
             // force a copy, reading the memory
-            c.as_bytes().to_owned();
+            c.as_bytes().to_vec();
         });
         let c_ = c_.unwrap();
         // force a copy, reading the memory
-        c_.as_bytes().to_owned();
+        c_.as_bytes().to_vec();
     }
 
     #[test]

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1544,7 +1544,7 @@ mod test {
     fn run_renaming_test(t: &RenamingTest, test_idx: uint) {
         let invalid_name = token::special_idents::invalid.name;
         let (teststr, bound_connections, bound_ident_check) = match *t {
-            (ref str,ref conns, bic) => (str.to_owned(), conns.clone(), bic)
+            (ref str,ref conns, bic) => (str.to_string(), conns.clone(), bic)
         };
         let cr = expand_crate_str(teststr.to_string());
         let bindings = crate_bindings(&cr);

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -72,7 +72,7 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
 
 // given a map, search for the frequency of a pattern
 fn find(mm: &HashMap<Vec<u8> , uint>, key: String) -> uint {
-   let key = key.to_owned().into_ascii().as_slice().to_lower().into_string();
+   let key = key.into_ascii().as_slice().to_lower().into_string();
    match mm.find_equiv(&key.as_bytes()) {
       option::None      => { return 0u; }
       option::Some(&num) => { return num; }
@@ -179,7 +179,7 @@ fn main() {
    let mut proc_mode = false;
 
    for line in rdr.lines() {
-       let line = line.unwrap().as_slice().trim().to_owned();
+       let line = line.unwrap().as_slice().trim().to_string();
 
        if line.len() == 0u { continue; }
 

--- a/src/test/bench/shootout-regex-dna.rs
+++ b/src/test/bench/shootout-regex-dna.rs
@@ -109,7 +109,7 @@ fn main() {
     let (mut variant_strs, mut counts) = (vec!(), vec!());
     for variant in variants.move_iter() {
         let seq_arc_copy = seq_arc.clone();
-        variant_strs.push(variant.to_string().to_owned());
+        variant_strs.push(variant.to_string());
         counts.push(Future::spawn(proc() {
             count_matches(seq_arc_copy.as_slice(), &variant)
         }));

--- a/src/test/run-pass/issue-1696.rs
+++ b/src/test/run-pass/issue-1696.rs
@@ -15,6 +15,6 @@ use std::collections::HashMap;
 
 pub fn main() {
     let mut m = HashMap::new();
-    m.insert("foo".as_bytes().to_owned(), "bar".as_bytes().to_owned());
+    m.insert(b"foo".to_vec(), b"bar".to_vec());
     println!("{:?}", m);
 }

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -56,7 +56,7 @@ priv fn parse_list(len: uint, io: @io::Reader) -> Result {
 }
 
 priv fn chop(s: String) -> String {
-  s.slice(0, s.len() - 1).to_owned()
+  s.slice(0, s.len() - 1).to_string()
 }
 
 priv fn parse_bulk(io: @io::Reader) -> Result {


### PR DESCRIPTION
- Deprecated `to_owned` in favor of `to_vec`
- Deprecated `into_owned` in favor of `into_vec`

[breaking-change]
