### PR TITLE
stability lint: ignore code from macro expansion

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1433,6 +1433,9 @@ impl LintPass for Stability {
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
+        // if the expression was produced by a macro expansion,
+        if e.span.expn_info.is_some() { return }
+
         let id = match e.node {
             ast::ExprPath(..) | ast::ExprStruct(..) => {
                 match cx.tcx.def_map.borrow().find(&e.id) {

--- a/src/test/auxiliary/lint_stability.rs
+++ b/src/test/auxiliary/lint_stability.rs
@@ -10,6 +10,9 @@
 #![crate_id="lint_stability#0.1"]
 #![crate_type = "lib"]
 
+#![feature(macro_rules)]
+#![macro_escape]
+
 #[deprecated]
 pub fn deprecated() {}
 #[deprecated="text"]
@@ -173,3 +176,8 @@ pub struct StableTupleStruct(pub int);
 pub struct FrozenTupleStruct(pub int);
 #[locked]
 pub struct LockedTupleStruct(pub int);
+
+#[macro_export]
+macro_rules! macro_test(
+    () => (deprecated());
+)

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -11,13 +11,14 @@
 // aux-build:lint_stability.rs
 // aux-build:inherited_stability.rs
 
-#![feature(globs)]
+#![feature(globs, phase)]
 #![deny(unstable)]
 #![deny(deprecated)]
 #![deny(experimental)]
 #![allow(dead_code)]
 
 mod cross_crate {
+    #[phase(plugin, link)]
     extern crate lint_stability;
     use self::lint_stability::*;
 
@@ -76,7 +77,6 @@ mod cross_crate {
         foo.method_locked_text();
         foo.trait_locked_text();
 
-
         let _ = DeprecatedStruct { i: 0 }; //~ ERROR use of deprecated item
         let _ = ExperimentalStruct { i: 0 }; //~ ERROR use of experimental item
         let _ = UnstableStruct { i: 0 }; //~ ERROR use of unstable item
@@ -108,6 +108,13 @@ mod cross_crate {
         let _ = StableTupleStruct (1);
         let _ = FrozenTupleStruct (1);
         let _ = LockedTupleStruct (1);
+
+        // At the moment, the following just checks that the stability
+        // level of expanded code does not trigger the
+        // lint. Eventually, we will want to lint the contents of the
+        // macro in the module *defining* it. Also, stability levels
+        // on macros themselves are not yet linted.
+        macro_test!();
     }
 
     fn test_method_param<F: Trait>(foo: F) {


### PR DESCRIPTION
This small patch causes the stability lint to bail out when traversing
any AST produced via a macro expansion. Ultimately, we would like to
lint the contents of the macro at the place where the macro is defined,
but regardless we should not be linting it at the use site.

Closes #15703
