### PR TITLE
Disallow importing from types when reexport is involved

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1599,6 +1599,12 @@ impl<'a> Resolver<'a> {
         if is_exported {
             self.external_exports.insert(def.def_id());
         }
+
+        let kind = match def {
+            DefStruct(..) | DefTy(..) => ImplModuleKind,
+            _ => NormalModuleKind
+        };
+
         match def {
           DefMod(def_id) | DefForeignMod(def_id) | DefStruct(def_id) |
           DefTy(def_id) => {
@@ -1617,7 +1623,7 @@ impl<'a> Resolver<'a> {
 
                 child_name_bindings.define_module(parent_link,
                                                   Some(def_id),
-                                                  NormalModuleKind,
+                                                  kind,
                                                   true,
                                                   is_public,
                                                   DUMMY_SP);

--- a/src/test/auxiliary/use_from_trait_xc.rs
+++ b/src/test/auxiliary/use_from_trait_xc.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+pub use self::sub::Bar;
+
 pub trait Trait {
     fn foo();
 }
@@ -16,4 +18,12 @@ struct Foo;
 
 impl Foo {
     pub fn new() {}
+}
+
+mod sub {
+    pub struct Bar;
+
+    impl Bar {
+        pub fn new() {}
+    }
 }

--- a/src/test/compile-fail/use-from-trait-xc.rs
+++ b/src/test/compile-fail/use-from-trait-xc.rs
@@ -18,4 +18,7 @@ use use_from_trait_xc::Trait::foo;
 use use_from_trait_xc::Foo::new;
 //~^ ERROR unresolved import `use_from_trait_xc::Foo::new`. Cannot import from a trait or type imple
 
+use use_from_trait_xc::Bar::new;
+//~^ ERROR unresolved import `use_from_trait_xc::Bar::new`. Cannot import from a trait or type
+
 fn main() {}


### PR DESCRIPTION
Importing from types was disallowed in #6462. Flag was set for paths whether it is a module or a type. Type flag was set when impl was seen. The problem is, for cross-crate situations, when reexport is involved, it is possible that impl is seen too late because metadata is loaded lazily.

Fix #15664.
