### PR TITLE
lint: add method to get level of a specific lint.

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -317,6 +317,12 @@ impl<'a> Context<'a> {
         &self.tcx.sess
     }
 
+    /// Get the level of `lint` at the current position of the lint
+    /// traversal.
+    pub fn current_level(&self, lint: &'static Lint) -> Level {
+        self.lints.levels.find(&LintId::of(lint)).map_or(Allow, |&(lvl, _)| lvl)
+    }
+
     fn lookup_and_emit(&self, lint: &'static Lint, span: Option<Span>, msg: &str) {
         let (level, src) = match self.lints.levels.find(&LintId::of(lint)) {
             None => return,


### PR DESCRIPTION
This allows lint traversals to emit more information (when a lint is
non-allow), or avoid doing expensive computations (when a lint is
allow).
