### PR TITLE
dataflow: removed the CFGIndex to bitset mapping.

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -172,7 +172,7 @@ impl<'a> CheckLoanCtxt<'a> {
         //! are issued for future scopes and thus they may have been
         //! *issued* but not yet be in effect.
 
-        self.dfcx_loans.each_bit_on_entry_frozen(scope_id, |loan_index| {
+        self.dfcx_loans.each_bit_on_entry(scope_id, |loan_index| {
             let loan = &self.all_loans[loan_index];
             op(loan)
         })
@@ -271,7 +271,7 @@ impl<'a> CheckLoanCtxt<'a> {
         //! we encounter `scope_id`.
 
         let mut result = Vec::new();
-        self.dfcx_loans.each_gen_bit_frozen(scope_id, |loan_index| {
+        self.dfcx_loans.each_gen_bit(scope_id, |loan_index| {
             result.push(loan_index);
             true
         });

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -576,7 +576,7 @@ impl<'a> FlowedMoveData<'a> {
          * Iterates through each path moved by `id`
          */
 
-        self.dfcx_moves.each_gen_bit_frozen(id, |index| {
+        self.dfcx_moves.each_gen_bit(id, |index| {
             let move = self.move_data.moves.borrow();
             let move = move.get(index);
             let moved_path = move.path;
@@ -592,7 +592,7 @@ impl<'a> FlowedMoveData<'a> {
 
         let mut ret = None;
         for loan_path_index in self.move_data.path_map.borrow().find(&*loan_path).iter() {
-            self.dfcx_moves.each_gen_bit_frozen(id, |move_index| {
+            self.dfcx_moves.each_gen_bit(id, |move_index| {
                 let move = self.move_data.moves.borrow();
                 let move = move.get(move_index);
                 if move.path == **loan_path_index {
@@ -637,7 +637,7 @@ impl<'a> FlowedMoveData<'a> {
 
         let mut ret = true;
 
-        self.dfcx_moves.each_bit_on_entry_frozen(id, |index| {
+        self.dfcx_moves.each_bit_on_entry(id, |index| {
             let move = self.move_data.moves.borrow();
             let move = move.get(index);
             let moved_path = move.path;
@@ -693,7 +693,7 @@ impl<'a> FlowedMoveData<'a> {
             }
         };
 
-        self.dfcx_assign.each_bit_on_entry_frozen(id, |index| {
+        self.dfcx_assign.each_bit_on_entry(id, |index| {
             let assignment = self.move_data.var_assignments.borrow();
             let assignment = assignment.get(index);
             if assignment.path == loan_path_index && !f(assignment) {


### PR DESCRIPTION
Removed `index_to_bitset` field and `_frozen` methods.

Drive-by: Added some missing docs on the `each_bit` method.

Drive-by: Put in a regular pattern: when calling `compute_id_range`, ensure `words_per_id > 0` by either asserting it or checking and returning early.  (The prior code did the latter in a few cases where necessary, but debugging is much aided by the asserts.)

Fix #15019.
