### PR TITLE
sync: Ensure try_send() wakes up receivers

### DIFF
--- a/src/libsync/comm/mod.rs
+++ b/src/libsync/comm/mod.rs
@@ -2098,4 +2098,23 @@ mod sync_tests {
         });
         assert_eq!(rx.recv(), 1);
     } #[ignore(reason = "flaky on libnative")])
+
+    test!(fn issue_15761() {
+        fn repro() {
+            let (tx1, rx1) = sync_channel::<()>(3);
+            let (tx2, rx2) = sync_channel::<()>(3);
+
+            spawn(proc() {
+                rx1.recv();
+                tx2.try_send(()).unwrap();
+            });
+
+            tx1.try_send(()).unwrap();
+            rx2.recv();
+        }
+
+        for _ in range(0u, 100) {
+            repro()
+        }
+    })
 }


### PR DESCRIPTION
This branch of try_send() just forgot to wake up any receiver waiting for data.

Closes #15761
