### PR TITLE
Remove outdated unreachable check from `call_visit_glue`

### DIFF
--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -180,12 +180,8 @@ pub fn lazily_emit_visit_glue(ccx: &CrateContext, ti: &tydesc_info) -> ValueRef 
 // See [Note-arg-mode]
 pub fn call_visit_glue(bcx: &Block, v: ValueRef, tydesc: ValueRef,
                        static_ti: Option<&tydesc_info>) {
-    let _icx = push_ctxt("call_tydesc_glue_full");
+    let _icx = push_ctxt("call_visit_glue");
     let ccx = bcx.ccx();
-    // NB: Don't short-circuit even if this block is unreachable because
-    // GC-based cleanup needs to the see that the roots are live.
-    if bcx.unreachable.get() && !ccx.sess().no_landing_pads() { return; }
-
     let static_glue_fn = static_ti.map(|sti| lazily_emit_visit_glue(ccx, sti));
 
     // When static type info is available, avoid casting to a generic pointer.

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -178,29 +178,12 @@ pub fn lazily_emit_visit_glue(ccx: &CrateContext, ti: &tydesc_info) -> ValueRef 
 }
 
 // See [Note-arg-mode]
-pub fn call_visit_glue(bcx: &Block, v: ValueRef, tydesc: ValueRef,
-                       static_ti: Option<&tydesc_info>) {
+pub fn call_visit_glue(bcx: &Block, v: ValueRef, tydesc: ValueRef) {
     let _icx = push_ctxt("call_visit_glue");
-    let ccx = bcx.ccx();
-    let static_glue_fn = static_ti.map(|sti| lazily_emit_visit_glue(ccx, sti));
 
-    // When static type info is available, avoid casting to a generic pointer.
-    let llrawptr = if static_glue_fn.is_none() {
-        PointerCast(bcx, v, Type::i8p(ccx))
-    } else {
-        v
-    };
-
-    let llfn = {
-        match static_glue_fn {
-            None => {
-                // Select out the glue function to call from the tydesc
-                let llfnptr = GEPi(bcx, tydesc, [0u, abi::tydesc_field_visit_glue]);
-                Load(bcx, llfnptr)
-            }
-            Some(sgf) => sgf
-        }
-    };
+    // Select the glue function to call from the tydesc
+    let llfn = Load(bcx, GEPi(bcx, tydesc, [0u, abi::tydesc_field_visit_glue]));
+    let llrawptr = PointerCast(bcx, v, Type::i8p(bcx.ccx()));
 
     Call(bcx, llfn, [llrawptr], []);
 }

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -290,7 +290,7 @@ pub fn trans_intrinsic_call<'a>(mut bcx: &'a Block<'a>, node: ast::NodeId,
             let td = *llargs.get(0);
             let visitor = *llargs.get(1);
             let td = PointerCast(bcx, td, ccx.tydesc_type().ptr_to());
-            glue::call_visit_glue(bcx, visitor, td, None);
+            glue::call_visit_glue(bcx, visitor, td);
             C_nil(ccx)
         }
         (_, "offset") => {


### PR DESCRIPTION
`call_visit_glue` is only ever called from trans_intrinsic, and the
block won't be unreachable there. Also, the comment doesn't make sense
anymore. When the code was introduced in 38fee9526a the function was
also responsible for the cleanup glue, which is no longer the case.

While we're at it, also fixed the debug message to output the right
function name.
