### PR TITLE
Correct plural of arguments in format_args!

### DIFF
--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -215,12 +215,21 @@ impl<'a, 'b> Context<'a, 'b> {
         }
     }
 
+    fn describe_num_args(&self) -> String {
+        if self.args.len() == 1 {
+            "there is 1 argument".to_string()
+        } else {
+            format!("there are {} arguments", self.args.len())
+        }
+    }
+
     fn verify_arg_type(&mut self, arg: Position, ty: ArgumentType) {
         match arg {
             Exact(arg) => {
                 if self.args.len() <= arg {
-                    let msg = format!("invalid reference to argument `{}` (there \
-                                    are {} arguments)", arg, self.args.len());
+                    let msg = format!("invalid reference to argument `{}` ({:s})",
+                                      arg, self.describe_num_args());
+
                     self.ecx.span_err(self.fmtsp, msg.as_slice());
                     return;
                 }

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -216,10 +216,10 @@ impl<'a, 'b> Context<'a, 'b> {
     }
 
     fn describe_num_args(&self) -> String {
-        if self.args.len() == 1 {
-            "there is 1 argument".to_string()
-        } else {
-            format!("there are {} arguments", self.args.len())
+        match self.args.len() {
+            0 => "no arguments given".to_string(),
+            1 => "there is 1 argument".to_string(),
+            x => format!("there are {} arguments", x),
         }
     }
 

--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -32,13 +32,17 @@ fn main() {
     // bad number of arguments, see #15780
 
     format!("{0}");
-    //^~ ERROR invalid reference to argument `0` (there are 0 arguments)
+    //~^ ERROR invalid reference to argument `0` (no arguments given)
 
     format!("{0} {1}", 1);
-    //^~ ERROR invalid reference to argument `1` (there is 1 argument)
+    //~^ ERROR invalid reference to argument `1` (there is 1 argument)
 
     format!("{0} {1} {2}", 1, 2);
-    //^~ ERROR invalid reference to argument `2` (there are 2 arguments)
+    //~^ ERROR invalid reference to argument `2` (there are 2 arguments)
+
+    format!("{0} {1}");
+    //~^ ERROR invalid reference to argument `0` (no arguments given)
+    //~^^ ERROR invalid reference to argument `1` (no arguments given)
 
     // bad syntax of the format string
 

--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -29,6 +29,17 @@ fn main() {
     format!("{foo}", foo=1, foo=2);    //~ ERROR: duplicate argument
     format!("", foo=1, 2);             //~ ERROR: positional arguments cannot follow
 
+    // bad number of arguments, see #15780
+
+    format!("{0}");
+    //^~ ERROR invalid reference to argument `0` (there are 0 arguments)
+
+    format!("{0} {1}", 1);
+    //^~ ERROR invalid reference to argument `1` (there is 1 argument)
+
+    format!("{0} {1} {2}", 1, 2);
+    //^~ ERROR invalid reference to argument `2` (there are 2 arguments)
+
     // bad syntax of the format string
 
     format!("{"); //~ ERROR: expected `}` but string was terminated


### PR DESCRIPTION
Fix for #15780.
