### PR TITLE
rustc: fix ICE regarding struct variants in enums

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3665,8 +3665,10 @@ impl VariantInfo {
             ast::StructVariantKind(ref struct_def) => {
 
                 let fields: &[StructField] = struct_def.fields.as_slice();
-
-                assert!(fields.len() > 0);
+                if fields.len() == 0 {
+                    cx.sess.span_fatal(ast_variant.span,
+                        "struct variant must have at least one field")
+                }
 
                 let arg_tys = ty_fn_args(ctor_ty).iter().map(|a| *a).collect();
                 let arg_names = fields.iter().map(|field| {

--- a/src/test/compile-fail/struct-variant-no-fields.rs
+++ b/src/test/compile-fail/struct-variant-no-fields.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(struct_variant)]
+
+enum Foo {
+    Bar { } //~ ERROR struct variant must have at least one field
+}
+
+fn main() {}


### PR DESCRIPTION
Hi, this is inspired by the output of previous rustc output:

```
note: the compiler hit an unexpected failure path. this is a bug.
note: we would appreciate a bug report: http://doc.rust-lang.org/complement-bugreport.html
note: run with `RUST_BACKTRACE=1` for a backtrace
task 'rustc' failed at 'assertion failed: fields.len() > 0', /Users/rustbuild/src/rust-buildbot/slave/nightly-mac/build/src/librustc/middle/ty.rs:3657
```

This **unexpected failure** will scare off someone IMO, right, then such that a better error print would be better :p
