### PR TITLE
Fix typo.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -583,7 +583,7 @@ arguments we pass to functions and macros, if you're passing more than one.
 When you just use the double curly braces, Rust will attempt to display the
 value in a meaningful way by checking out its type. If you want to specify the
 format in a more detailed manner, there are a [wide number of options
-available](/std/fmt/index.html). Fow now, we'll just stick to the default:
+available](/std/fmt/index.html). For now, we'll just stick to the default:
 integers aren't very complicated to print.
 
 So, we've cleared up all of the confusion around bindings, with one exception:


### PR DESCRIPTION
Fix small typo in guide.
