### PR TITLE
Don't ICE when dealing with the count expr for fixed array types in various places.

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -168,7 +168,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                                     props,
                                     testfile,
                                     srcs[round].to_string(),
-                                    "normal");
+                                    props.pretty_mode.as_slice());
 
         if !proc_res.status.success() {
             fatal_proc_rec(format!("pretty-printing failed in round {}",
@@ -199,6 +199,9 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
     }
 
     compare_source(expected.as_slice(), actual.as_slice());
+
+    // If we're only making sure that the output matches then just stop here
+    if props.pretty_compare_only { return; }
 
     // Finally, let's make sure it actually appears to remain valid code
     let proc_res = typecheck_source(config, props, testfile, actual);

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -877,6 +877,7 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                 }
             }
             ast::TyFixedLengthVec(ty, e) => {
+                typeck::write_ty_to_tcx(tcx, e.id, ty::mk_uint());
                 match const_eval::eval_const_expr_partial(tcx, &*e) {
                     Ok(ref r) => {
                         match *r {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -429,6 +429,18 @@ impl<'a> Visitor<()> for GatherLocalsVisitor<'a> {
         self.fcx.with_region_lb(b.id, || visit::walk_block(self, b, ()));
     }
 
+    // Since an expr occurs as part of the type fixed size arrays we
+    // need to record the type for that node
+    fn visit_ty(&mut self, t: &ast::Ty, _: ()) {
+        match t.node {
+            ast::TyFixedLengthVec(ref ty, ref count_expr) => {
+                self.visit_ty(&**ty, ());
+                check_expr_with_hint(self.fcx, &**count_expr, ty::mk_uint());
+            }
+            _ => visit::walk_ty(self, t, ())
+        }
+    }
+
     // Don't descend into fns and items
     fn visit_fn(&mut self, _: &visit::FnKind, _: &ast::FnDecl,
                 _: &ast::Block, _: Span, _: ast::NodeId, _: ()) { }
@@ -3353,6 +3365,12 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         }
       }
       ast::ExprCast(ref e, ref t) => {
+        match t.node {
+            ast::TyFixedLengthVec(_, ref count_expr) => {
+                check_expr_with_hint(fcx, &**count_expr, ty::mk_uint());
+            }
+            _ => {}
+        }
         check_cast(fcx, &**e, &**t, id, expr.span);
       }
       ast::ExprVec(ref args) => {

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -181,8 +181,14 @@ impl<'cx> Visitor<()> for WritebackCx<'cx> {
         visit::walk_local(self, l, ());
     }
 
-    fn visit_ty(&mut self, _t: &ast::Ty, _: ()) {
-        // ignore
+    fn visit_ty(&mut self, t: &ast::Ty, _: ()) {
+        match t.node {
+            ast::TyFixedLengthVec(ref ty, ref count_expr) => {
+                self.visit_ty(&**ty, ());
+                write_ty_to_tcx(self.tcx(), count_expr.id, ty::mk_uint());
+            }
+            _ => visit::walk_ty(self, t, ())
+        }
     }
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -626,13 +626,16 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
                 } => {
                     // take it apart:
                     let Local {
-                        ty: _,
+                        ty: ty,
                         pat: pat,
                         init: init,
                         id: id,
                         span: span,
                         source: source,
                     } = **local;
+                    // expand the ty since TyFixedLengthVec contains an Expr
+                    // and thus may have a macro use
+                    let expanded_ty = fld.fold_ty(ty);
                     // expand the pat (it might contain macro uses):
                     let expanded_pat = fld.fold_pat(pat);
                     // find the PatIdents in the pattern:
@@ -656,7 +659,7 @@ fn expand_non_macro_stmt(s: &Stmt, fld: &mut MacroExpander)
                     let new_init_opt = init.map(|e| fld.fold_expr(e));
                     let rewritten_local =
                         box(GC) Local {
-                            ty: local.ty,
+                            ty: expanded_ty,
                             pat: rewritten_pat,
                             init: new_init_opt,
                             id: id,

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -1,0 +1,95 @@
+#![feature(phase)]
+#![no_std]
+#![feature(globs)]
+#[phase(plugin, link)]
+extern crate std = "std";
+extern crate native;
+use std::prelude::*;
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pretty-compare-only
+// pretty-mode:typed
+// pp-exact:issue-4264.pp
+
+// #4264 fixed-length vector types
+
+pub fn foo(_: [int, ..(3 as uint)]) { }
+
+pub fn bar() {
+    static FOO: uint = ((5u as uint) - (4u as uint) as uint);
+    let _: [(), ..(FOO as uint)] = ([(() as ())] as [(), .. 1]);
+
+    let _: [(), ..(1u as uint)] = ([(() as ())] as [(), .. 1]);
+
+    let _ =
+        (((&((([(1i as int), (2 as int), (3 as int)] as [int, .. 3])) as
+                [int, .. 3]) as &[int, .. 3]) as *const _ as
+             *const [int, .. 3]) as *const [int, ..(3u as uint)] as
+            *const [int, .. 3]);
+    (match (() as ()) {
+         () => {
+             #[inline]
+             #[allow(dead_code)]
+             static __STATIC_FMTSTR:
+                    [::std::fmt::rt::Piece<'static>, ..(1u as uint)] =
+                 ([((::std::fmt::rt::String as
+                        fn(&'static str) -> core::fmt::rt::Piece<'static>)(("test"
+                                                                               as
+                                                                               &'static str))
+                       as core::fmt::rt::Piece<'static>)] as
+                     [core::fmt::rt::Piece<'static>, .. 1]);
+             let __args_vec =
+                 (&([] as &'static [core::fmt::Argument<'static>]) as
+                     &'static [core::fmt::Argument<'static>]);
+             let __args =
+                 (unsafe {
+                      ((::std::fmt::Arguments::new as
+                           unsafe fn(&'static [core::fmt::rt::Piece<'static>], &'a [core::fmt::Argument<'a>]) -> core::fmt::Arguments<'a>)((__STATIC_FMTSTR
+                                                                                                                                               as
+                                                                                                                                               [core::fmt::rt::Piece<'static>, .. 1]),
+                                                                                                                                           (__args_vec
+                                                                                                                                               as
+                                                                                                                                               &'static [core::fmt::Argument<'static>]))
+                          as core::fmt::Arguments<'static>)
+                  } as core::fmt::Arguments<'static>);
+
+
+
+
+
+
+
+
+             ((::std::fmt::format as
+                  fn(&core::fmt::Arguments<'_>) -> collections::string::String)((&(__args
+                                                                                      as
+                                                                                      core::fmt::Arguments<'static>)
+                                                                                    as
+                                                                                    &core::fmt::Arguments<'static>))
+                 as collections::string::String)
+         }
+     } as collections::string::String);
+}
+pub type Foo = [int, ..(3u as uint)];
+pub struct Bar {
+    pub x: [int, ..(3u as uint)],
+}
+pub struct TupleBar([int, ..(4u as uint)]);
+pub enum Baz { BazVariant([int, ..(5u as uint)]), }
+pub fn id<T>(x: T) -> T { (x as T) }
+pub fn use_id() {
+    let _ =
+        ((id::<[int, ..(3u as uint)]> as
+             fn([int, .. 3]) -> [int, .. 3])(([(1 as int), (2 as int),
+                                               (3 as int)] as [int, .. 3])) as
+            [int, .. 3]);
+}
+fn main() { }

--- a/src/test/pretty/issue-4264.rs
+++ b/src/test/pretty/issue-4264.rs
@@ -1,0 +1,49 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pretty-compare-only
+// pretty-mode:typed
+// pp-exact:issue-4264.pp
+
+// #4264 fixed-length vector types
+
+pub fn foo(_: [int, ..3]) {}
+
+pub fn bar() {
+    static FOO: uint = 5u - 4u;
+    let _: [(), ..FOO] = [()];
+
+    let _ : [(), ..1u] = [()];
+
+    let _ = &([1i,2,3]) as *const _ as *const [int, ..3u];
+
+    format!("test");
+}
+
+pub type Foo = [int, ..3u];
+
+pub struct Bar {
+    pub x: [int, ..3u]
+}
+
+pub struct TupleBar([int, ..4u]);
+
+pub enum Baz {
+    BazVariant([int, ..5u])
+}
+
+pub fn id<T>(x: T) -> T { x }
+
+pub fn use_id() {
+    let _ = id::<[int, ..3u]>([1,2,3]);
+}
+
+
+fn main() {}

--- a/src/test/run-pass/macro-invocation-in-count-expr-fixed-array-type.rs
+++ b/src/test/run-pass/macro-invocation-in-count-expr-fixed-array-type.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+macro_rules! four (
+    () => (4)
+)
+fn main() {
+    let _x: [u16, ..four!()];
+}


### PR DESCRIPTION
The fact that `TyFixedLengthVec` contains an `Expr` seems to have been overlooked in a couple of places causes ICE's to pop up (especially obvious in `pretty=typed`)

Previously this would also ICE:

```
let _x: [u16, ..four!()];
```

where `four!()` just expanded to the literal `4` since we never consider that expression when expanded macros.

Fixes #15801 (in that it no longer ICE's and just outputs an error instead)
Fixes #4264 

r? @jbclements re the macro expansion changes
r? @pcwalton re typeck changes
