### PR TITLE
Correctly stringify! types and paths inside macros

### DIFF
--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -249,6 +249,8 @@ pub fn to_string(t: &Token) -> String {
         match nt {
             &NtExpr(ref e) => ::print::pprust::expr_to_string(&**e),
             &NtMeta(ref e) => ::print::pprust::meta_item_to_string(&**e),
+            &NtTy(ref e) => ::print::pprust::ty_to_string(&**e),
+            &NtPath(ref e) => ::print::pprust::path_to_string(&**e),
             _ => {
                 let mut s = "an interpolated ".to_string();
                 match *nt {
@@ -257,10 +259,10 @@ pub fn to_string(t: &Token) -> String {
                     NtStmt(..) => s.push_str("statement"),
                     NtPat(..) => s.push_str("pattern"),
                     NtMeta(..) => fail!("should have been handled"),
-                    NtExpr(..) => fail!("should have been handled above"),
-                    NtTy(..) => s.push_str("type"),
+                    NtExpr(..) => fail!("should have been handled"),
+                    NtTy(..) => fail!("should have been handled"),
                     NtIdent(..) => s.push_str("identifier"),
-                    NtPath(..) => s.push_str("path"),
+                    NtPath(..) => fail!("should have been handled"),
                     NtTT(..) => s.push_str("tt"),
                     NtMatchers(..) => s.push_str("matcher sequence")
                 };

--- a/src/test/run-pass/issue-8709.rs
+++ b/src/test/run-pass/issue-8709.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+macro_rules! sty(
+    ($t:ty) => (stringify!($t))
+)
+
+macro_rules! spath(
+    ($t:path) => (stringify!($t))
+)
+
+fn main() {
+    assert_eq!(sty!(int), "int")
+    assert_eq!(spath!(std::option), "std::option")
+}


### PR DESCRIPTION
Closes #8709
