### PR TITLE
Deprecate some unsafe functions in `str::raw` and remove `OwnedStr` trait

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -555,9 +555,9 @@ impl<'a> fmt::Show for MaybeOwned<'a> {
 
 /// Unsafe operations
 pub mod raw {
-    use core::prelude::*;
     use core::mem;
     use core::raw::Slice;
+    use core::ptr::RawPtr;
 
     use string::String;
     use vec::Vec;
@@ -575,7 +575,8 @@ pub mod raw {
         result
     }
 
-    /// Create a Rust string from a null-terminated C string
+    /// Deprecated. Use `CString::as_str().unwrap().to_string()`
+    #[deprecated = "Use CString::as_str().unwrap().to_string()"]
     pub unsafe fn from_c_str(c_string: *const i8) -> String {
         let mut buf = String::new();
         let mut len = 0;
@@ -1344,16 +1345,6 @@ mod tests {
              [0xd640, 0x71f1, 0xdd7d, 0x77eb, 0x1cd8],
              [0x348b, 0xaef0, 0xdb2c, 0xebf1, 0x1282],
              [0x50d7, 0xd824, 0x5010, 0xb369, 0x22ea]);
-    }
-
-    #[test]
-    fn test_raw_from_c_str() {
-        unsafe {
-            let a = vec![65, 65, 65, 65, 65, 65, 65, 0];
-            let b = a.as_ptr();
-            let c = raw::from_c_str(b);
-            assert_eq!(c, String::from_str("AAAAAAA"));
-        }
     }
 
     #[test]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -596,9 +596,10 @@ pub mod raw {
         string::raw::from_utf8(v)
     }
 
-    /// Converts a byte to a string.
+    /// Deprecated. Use `String::from_bytes`
+    #[deprecated = "Use String::from_bytes"]
     pub unsafe fn from_byte(u: u8) -> String {
-        from_utf8_owned(vec![u])
+        String::from_bytes(vec![u])
     }
 
     #[test]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -555,9 +555,6 @@ impl<'a> fmt::Show for MaybeOwned<'a> {
 
 /// Unsafe operations
 pub mod raw {
-    use core::mem;
-    use core::raw::Slice;
-    use core::ptr::RawPtr;
     use string;
     use string::String;
     use vec::Vec;
@@ -571,19 +568,10 @@ pub mod raw {
         string::raw::from_buf_len(buf, len)
     }
 
-    /// Deprecated. Use `CString::as_str().unwrap().to_string()`
-    #[deprecated = "Use CString::as_str().unwrap().to_string()"]
+    /// Deprecated. Use `string::raw::from_buf`
+    #[deprecated = "Use string::raw::from_buf"]
     pub unsafe fn from_c_str(c_string: *const i8) -> String {
-        let mut buf = String::new();
-        let mut len = 0;
-        while *c_string.offset(len) != 0 {
-            len += 1;
-        }
-        buf.push_bytes(mem::transmute(Slice {
-            data: c_string,
-            len: len as uint,
-        }));
-        buf
+        string::raw::from_buf(c_string as *const u8)
     }
 
     /// Deprecated. Replaced by `string::raw::from_utf8`

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -601,11 +601,6 @@ pub mod raw {
         from_utf8_owned(vec![u])
     }
 
-    /// Sets the length of a string
-    ///
-    /// This will explicitly set the size of the string, without actually
-    /// modifying its buffers, so it is up to the caller to ensure that
-    /// the string is actually the specified size.
     #[test]
     fn test_from_buf_len() {
         use slice::ImmutableVector;
@@ -780,30 +775,6 @@ impl<'a> StrAllocating for &'a str {
     #[inline]
     fn into_string(self) -> String {
         String::from_str(self)
-    }
-}
-
-/// Methods for owned strings
-pub trait OwnedStr {
-    /// Consumes the string, returning the underlying byte buffer.
-    ///
-    /// The buffer does not have a null terminator.
-    fn into_bytes(self) -> Vec<u8>;
-
-    /// Pushes the given string onto this string, returning the concatenation of the two strings.
-    fn append(self, rhs: &str) -> String;
-}
-
-impl OwnedStr for String {
-    #[inline]
-    fn into_bytes(self) -> Vec<u8> {
-        unsafe { mem::transmute(self) }
-    }
-
-    #[inline]
-    fn append(mut self, rhs: &str) -> String {
-        self.push_str(rhs);
-        self
     }
 }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -558,7 +558,8 @@ pub mod raw {
     use core::mem;
     use core::raw::Slice;
     use core::ptr::RawPtr;
-    use string::{mod, String};
+    use string;
+    use string::String;
     use vec::Vec;
 
     pub use core::str::raw::{from_utf8, c_str_to_static_slice, slice_bytes};

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -558,21 +558,16 @@ pub mod raw {
     use core::mem;
     use core::raw::Slice;
     use core::ptr::RawPtr;
-
     use string::{mod, String};
     use vec::Vec;
 
     pub use core::str::raw::{from_utf8, c_str_to_static_slice, slice_bytes};
     pub use core::str::raw::{slice_unchecked};
 
-    /// Create a Rust string from a *u8 buffer of the given length
+    /// Deprecated. Replaced by `string::raw::from_buf_len`
+    #[deprecated = "Use string::raw::from_buf_len"]
     pub unsafe fn from_buf_len(buf: *const u8, len: uint) -> String {
-        let mut result = String::new();
-        result.push_bytes(mem::transmute(Slice {
-            data: buf,
-            len: len,
-        }));
-        result
+        string::raw::from_buf_len(buf, len)
     }
 
     /// Deprecated. Use `CString::as_str().unwrap().to_string()`
@@ -596,22 +591,10 @@ pub mod raw {
         string::raw::from_utf8(v)
     }
 
-    /// Deprecated. Use `String::from_bytes`
-    #[deprecated = "Use String::from_bytes"]
+    /// Deprecated. Use `string::raw::from_utf8`
+    #[deprecated = "Use string::raw::from_utf8"]
     pub unsafe fn from_byte(u: u8) -> String {
-        String::from_bytes(vec![u])
-    }
-
-    #[test]
-    fn test_from_buf_len() {
-        use slice::ImmutableVector;
-
-        unsafe {
-            let a = vec![65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 0u8];
-            let b = a.as_ptr();
-            let c = from_buf_len(b, 3u);
-            assert_eq!(c, String::from_str("AAA"));
-        }
+        string::raw::from_utf8(vec![u])
     }
 }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -559,7 +559,7 @@ pub mod raw {
     use core::raw::Slice;
     use core::ptr::RawPtr;
 
-    use string::String;
+    use string::{mod, String};
     use vec::Vec;
 
     pub use core::str::raw::{from_utf8, c_str_to_static_slice, slice_bytes};
@@ -590,11 +590,10 @@ pub mod raw {
         buf
     }
 
-    /// Converts an owned vector of bytes to a new owned string. This assumes
-    /// that the utf-8-ness of the vector has already been validated
-    #[inline]
+    /// Deprecated. Replaced by `string::raw::from_utf8`
+    #[deprecated = "Use string::raw::from_utf8"]
     pub unsafe fn from_utf8_owned(v: Vec<u8>) -> String {
-        mem::transmute(v)
+        string::raw::from_utf8(v)
     }
 
     /// Converts a byte to a string.

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -570,6 +570,19 @@ impl<S: Str> Add<S, String> for String {
     }
 }
 
+pub mod raw {
+    use super::String;
+    use vec::Vec;
+
+    /// Converts a vector of bytes to a new `String` without checking if
+    /// it contains valid UTF-8. This is unsafe because it assumes that
+    /// the utf-8-ness of the vector has already been validated.
+    #[inline]
+    pub unsafe fn from_utf8(bytes: Vec<u8>) -> String {
+        String { vec: bytes }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::prelude::*;

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -49,20 +49,19 @@ impl String {
         }
     }
 
-    /// Creates a new string buffer from length, capacity, and a pointer.
-    #[inline]
-    pub unsafe fn from_raw_parts(length: uint, capacity: uint, ptr: *mut u8) -> String {
-        String {
-            vec: Vec::from_raw_parts(length, capacity, ptr),
-        }
-    }
-
     /// Creates a new string buffer from the given string.
     #[inline]
     pub fn from_str(string: &str) -> String {
         String {
             vec: Vec::from_slice(string.as_bytes())
         }
+    }
+
+    /// Deprecated. Replaced by `string::raw::from_parts`
+    #[inline]
+    #[deprecated = "Replaced by string::raw::from_parts"]
+    pub unsafe fn from_raw_parts(length: uint, capacity: uint, ptr: *mut u8) -> String {
+        raw::from_parts(length, capacity, ptr)
     }
 
     #[allow(missing_doc)]
@@ -576,6 +575,18 @@ pub mod raw {
 
     use super::String;
     use vec::Vec;
+
+    /// Creates a new `String` from length, capacity, and a pointer.
+    ///
+    /// This is unsafe because:
+    /// * We call `Vec::from_raw_parts` to get a `Vec<u8>`
+    /// * We assume that the `Vec` contains valid UTF-8
+    #[inline]
+    pub unsafe fn from_parts(length: uint, capacity: uint, ptr: *mut u8) -> String {
+        String {
+            vec: Vec::from_raw_parts(length, capacity, ptr),
+        }
+    }
 
     /// Converts a vector of bytes to a new `String` without checking if
     /// it contains valid UTF-8. This is unsafe because it assumes that

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -61,7 +61,7 @@ impl String {
     #[inline]
     #[deprecated = "Replaced by string::raw::from_parts"]
     pub unsafe fn from_raw_parts(length: uint, capacity: uint, ptr: *mut u8) -> String {
-        raw::from_parts(length, capacity, ptr)
+        raw::from_parts(ptr, length, capacity)
     }
 
     #[allow(missing_doc)]
@@ -571,6 +571,7 @@ impl<S: Str> Add<S, String> for String {
 
 pub mod raw {
     use core::mem;
+    use core::ptr::RawPtr;
     use core::raw::Slice;
 
     use super::String;
@@ -582,21 +583,13 @@ pub mod raw {
     /// * We call `Vec::from_raw_parts` to get a `Vec<u8>`
     /// * We assume that the `Vec` contains valid UTF-8
     #[inline]
-    pub unsafe fn from_parts(length: uint, capacity: uint, ptr: *mut u8) -> String {
+    pub unsafe fn from_parts(buf: *mut u8, length: uint, capacity: uint) -> String {
         String {
-            vec: Vec::from_raw_parts(length, capacity, ptr),
+            vec: Vec::from_raw_parts(length, capacity, buf),
         }
     }
 
-    /// Converts a vector of bytes to a new `String` without checking if
-    /// it contains valid UTF-8. This is unsafe because it assumes that
-    /// the utf-8-ness of the vector has already been validated.
-    #[inline]
-    pub unsafe fn from_utf8(bytes: Vec<u8>) -> String {
-        String { vec: bytes }
-    }
-
-    /// Create a Rust string from a *u8 buffer of the given length
+    /// Create `String` from a *u8 buffer of the given length
     ///
     /// This function is unsafe because of two reasons:
     /// * A raw pointer is dereferenced and transmuted to `&[u8]`
@@ -608,6 +601,27 @@ pub mod raw {
             len: len,
         });
         self::from_utf8(slice.to_vec())
+    }
+
+    /// Create a `String` from a null-terminated *u8 buffer
+    ///
+    /// This function is unsafe because we dereference memory until we find the NUL character,
+    /// which is not guaranteed to be present. Additionaly, the slice is not checked to see
+    /// whether it contains valid UTF-8
+    pub unsafe fn from_buf(buf: *const u8) -> String {
+        let mut len = 0;
+        while *buf.offset(len) != 0 {
+            len += 1;
+        }
+        self::from_buf_len(buf, len as uint)
+    }
+
+    /// Converts a vector of bytes to a new `String` without checking if
+    /// it contains valid UTF-8. This is unsafe because it assumes that
+    /// the utf-8-ness of the vector has already been validated.
+    #[inline]
+    pub unsafe fn from_utf8(bytes: Vec<u8>) -> String {
+        String { vec: bytes }
     }
 }
 
@@ -773,6 +787,16 @@ mod tests {
         unsafe {
             let a = vec![65u8, 65, 65, 65, 65, 65, 65, 0];
             assert_eq!(super::raw::from_buf_len(a.as_ptr(), 3), String::from_str("AAA"));
+        }
+    }
+
+    #[test]
+    fn test_from_buf() {
+        unsafe {
+            let a = vec![65, 65, 65, 65, 65, 65, 65, 0];
+            let b = a.as_ptr();
+            let c = super::raw::from_buf(b);
+            assert_eq!(c, String::from_str("AAAAAAA"));
         }
     }
 

--- a/src/libcoretest/ptr.rs
+++ b/src/libcoretest/ptr.rs
@@ -11,8 +11,8 @@
 use core::ptr::*;
 use libc::c_char;
 use core::mem;
-use std::str;
 use libc;
+use std::c_str::CString;
 
 #[test]
 fn test() {
@@ -186,9 +186,8 @@ fn test_ptr_array_each_with_len() {
         let mut ctr = 0;
         let mut iteration_count = 0;
         array_each_with_len(arr.as_ptr(), arr.len(), |e| {
-                let actual = str::raw::from_c_str(e);
-                let expected = str::raw::from_c_str(expected_arr[ctr].as_ptr());
-                assert_eq!(actual.as_slice(), expected.as_slice());
+                let actual = CString::new(e, false);
+                assert_eq!(actual.as_str(), expected_arr[ctr].as_str());
                 ctr += 1;
                 iteration_count += 1;
             });
@@ -217,9 +216,8 @@ fn test_ptr_array_each() {
         let mut ctr = 0u;
         let mut iteration_count = 0u;
         array_each(arr_ptr, |e| {
-                let actual = str::raw::from_c_str(e);
-                let expected = str::raw::from_c_str(expected_arr[ctr].as_ptr());
-                assert_eq!(actual.as_slice(), expected.as_slice());
+                let actual = CString::new(e, false);
+                assert_eq!(actual.as_str(), expected_arr[ctr].as_str());
                 ctr += 1;
                 iteration_count += 1;
             });
@@ -232,7 +230,7 @@ fn test_ptr_array_each() {
 fn test_ptr_array_each_with_len_null_ptr() {
     unsafe {
         array_each_with_len(0 as *const *const libc::c_char, 1, |e| {
-            str::raw::from_c_str(e);
+            CString::new(e, false).as_str().unwrap();
         });
     }
 }
@@ -241,7 +239,7 @@ fn test_ptr_array_each_with_len_null_ptr() {
 fn test_ptr_array_each_null_ptr() {
     unsafe {
         array_each(0 as *const *const libc::c_char, |e| {
-            str::raw::from_c_str(e);
+            CString::new(e, false).as_str().unwrap();
         });
     }
 }

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -233,7 +233,7 @@ use std::io;
 use std::mem;
 use std::ptr;
 use std::slice;
-use std::str;
+use std::string;
 
 use std::collections::{HashMap, HashSet};
 use flate;
@@ -772,7 +772,7 @@ fn get_metadata_section_imp(os: abi::Os, filename: &Path) -> Result<MetadataBlob
         while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
             let mut name_buf = ptr::null();
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
-            let name = str::raw::from_buf_len(name_buf as *const u8,
+            let name = string::raw::from_buf_len(name_buf as *const u8,
                                               name_len as uint);
             debug!("get_metadata_section: name {}", name);
             if read_meta_section_name(os).as_slice() == name.as_slice() {

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -19,11 +19,10 @@ use middle::trans::context::CrateContext;
 use syntax::ast;
 use syntax::abi::{X86, X86_64, Arm, Mips, Mipsel};
 
-use std::c_str::ToCStr;
+use std::c_str::{CString, ToCStr};
 use std::mem;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::str::raw::from_c_str;
 
 use libc::{c_uint, c_void, free};
 
@@ -334,9 +333,9 @@ impl TypeNames {
     pub fn type_to_string(&self, ty: Type) -> String {
         unsafe {
             let s = llvm::LLVMTypeToString(ty.to_ref());
-            let ret = from_c_str(s);
+            let ret = CString::new(s, false).as_str().unwrap().to_string();
             free(s as *mut c_void);
-            ret.to_string()
+            ret
         }
     }
 
@@ -348,9 +347,9 @@ impl TypeNames {
     pub fn val_to_string(&self, val: ValueRef) -> String {
         unsafe {
             let s = llvm::LLVMValueToString(val);
-            let ret = from_c_str(s);
+            let ret = CString::new(s, false).as_str().unwrap().to_string();
             free(s as *mut c_void);
-            ret.to_string()
+            ret
         }
     }
 }

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -19,8 +19,9 @@ use middle::trans::context::CrateContext;
 use syntax::ast;
 use syntax::abi::{X86, X86_64, Arm, Mips, Mipsel};
 
-use std::c_str::{CString, ToCStr};
+use std::c_str::ToCStr;
 use std::mem;
+use std::string;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -333,7 +334,7 @@ impl TypeNames {
     pub fn type_to_string(&self, ty: Type) -> String {
         unsafe {
             let s = llvm::LLVMTypeToString(ty.to_ref());
-            let ret = CString::new(s, false).as_str().unwrap().to_string();
+            let ret = string::raw::from_buf(s as *const u8);
             free(s as *mut c_void);
             ret
         }
@@ -347,7 +348,7 @@ impl TypeNames {
     pub fn val_to_string(&self, val: ValueRef) -> String {
         unsafe {
             let s = llvm::LLVMValueToString(val);
-            let ret = CString::new(s, false).as_str().unwrap().to_string();
+            let ret = string::raw::from_buf(s as *const u8);
             free(s as *mut c_void);
             ret
         }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -32,6 +32,7 @@ use std::cell::{RefCell, Cell};
 use std::fmt;
 use std::slice;
 use std::str;
+use std::string;
 use std::collections::HashMap;
 
 use html::toc::TocBuilder;
@@ -222,7 +223,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
             "".to_string()
         } else {
             unsafe {
-                str::raw::from_buf_len((*text).data, (*text).size as uint)
+                string::raw::from_buf_len((*text).data, (*text).size as uint)
             }
         };
 

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -55,10 +55,10 @@ extern crate libc;
 extern crate alloc;
 
 use libc::{c_int, c_void};
-use std::c_str::CString;
 use std::fmt;
 use std::mem;
 use std::ptr;
+use std::string;
 use std::rt::local::Local;
 use std::rt::rtio;
 use std::rt::rtio::{IoResult, IoError};
@@ -363,7 +363,7 @@ impl UvError {
             let inner = match self { &UvError(a) => a };
             let name_str = uvll::uv_err_name(inner);
             assert!(name_str.is_not_null());
-            CString::new(name_str, false).as_str().unwrap().to_string()
+            string::raw::from_buf(name_str as *const u8)
         }
     }
 
@@ -372,7 +372,7 @@ impl UvError {
             let inner = match self { &UvError(a) => a };
             let desc_str = uvll::uv_strerror(inner);
             assert!(desc_str.is_not_null());
-            CString::new(desc_str, false).as_str().unwrap().to_string()
+            string::raw::from_buf(desc_str as *const u8)
         }
     }
 

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -55,6 +55,7 @@ extern crate libc;
 extern crate alloc;
 
 use libc::{c_int, c_void};
+use std::c_str::CString;
 use std::fmt;
 use std::mem;
 use std::ptr;
@@ -62,7 +63,6 @@ use std::rt::local::Local;
 use std::rt::rtio;
 use std::rt::rtio::{IoResult, IoError};
 use std::rt::task::{BlockedTask, Task};
-use std::str::raw::from_c_str;
 use std::task;
 
 pub use self::async::AsyncWatcher;
@@ -363,7 +363,7 @@ impl UvError {
             let inner = match self { &UvError(a) => a };
             let name_str = uvll::uv_err_name(inner);
             assert!(name_str.is_not_null());
-            from_c_str(name_str).to_string()
+            CString::new(name_str, false).as_str().unwrap().to_string()
         }
     }
 
@@ -372,7 +372,7 @@ impl UvError {
             let inner = match self { &UvError(a) => a };
             let desc_str = uvll::uv_strerror(inner);
             assert!(desc_str.is_not_null());
-            from_c_str(desc_str).to_string()
+            CString::new(desc_str, false).as_str().unwrap().to_string()
         }
     }
 

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -11,8 +11,8 @@
 // ignore-lexer-test FIXME #15679
 
 //! Base64 binary-to-text encoding
-use std::str;
 use std::fmt;
+use std::string;
 
 /// Available encoding character sets
 pub enum CharacterSet {
@@ -148,7 +148,7 @@ impl<'a> ToBase64 for &'a [u8] {
         }
 
         unsafe {
-            str::raw::from_utf8_owned(v)
+            string::raw::from_utf8(v)
         }
     }
 }

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -11,8 +11,8 @@
 // ignore-lexer-test FIXME #15679
 
 //! Hex binary-to-text encoding
-use std::str;
 use std::fmt;
+use std::string;
 
 /// A trait for converting a value to hexadecimal encoding
 pub trait ToHex {
@@ -47,7 +47,7 @@ impl<'a> ToHex for &'a [u8] {
         }
 
         unsafe {
-            str::raw::from_utf8_owned(v)
+            string::raw::from_utf8(v)
         }
     }
 }

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -20,7 +20,7 @@ use iter::Iterator;
 use mem;
 use option::{Option, Some, None};
 use slice::{ImmutableVector, MutableVector, Vector};
-use str::{OwnedStr, Str, StrAllocating, StrSlice};
+use str::{Str, StrAllocating, StrSlice};
 use string::String;
 use to_string::IntoStr;
 use vec::Vec;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -47,9 +47,9 @@ use ptr;
 use result::{Err, Ok, Result};
 use slice::{Vector, ImmutableVector, MutableVector, ImmutableEqVector};
 use str::{Str, StrSlice, StrAllocating};
-use str;
 use string::String;
 use sync::atomics::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
+use to_str::ToString;
 use vec::Vec;
 
 #[cfg(unix)]
@@ -135,7 +135,7 @@ pub fn getcwd() -> Path {
             fail!();
         }
     }
-    Path::new(String::from_utf16(str::truncate_utf16_at_nul(buf))
+    Path::new(String::from_utf16(::str::truncate_utf16_at_nul(buf))
               .expect("GetCurrentDirectoryW returned invalid UTF-16"))
 }
 
@@ -413,7 +413,7 @@ pub fn setenv<T: BytesContainer>(n: &str, v: T) {
     fn _setenv(n: &str, v: &[u8]) {
         let n: Vec<u16> = n.utf16_units().collect();
         let n = n.append_one(0);
-        let v: Vec<u16> = str::from_utf8(v).unwrap().utf16_units().collect();
+        let v: Vec<u16> = ::str::from_utf8(v).unwrap().utf16_units().collect();
         let v = v.append_one(0);
 
         unsafe {
@@ -1045,7 +1045,7 @@ pub fn error_string(errnum: uint) -> String {
                 return format!("OS Error {} (FormatMessageW() returned error {})", errnum, fm_err);
             }
 
-            let msg = String::from_utf16(str::truncate_utf16_at_nul(buf));
+            let msg = String::from_utf16(::str::truncate_utf16_at_nul(buf));
             match msg {
                 Some(msg) => format!("OS Error {}: {}", errnum, msg),
                 None => format!("OS Error {} (FormatMessageW() returned invalid UTF-16)", errnum),
@@ -1202,7 +1202,7 @@ fn real_args() -> Vec<String> {
 
         // Push it onto the list.
         let opt_s = slice::raw::buf_as_slice(ptr as *const _, len, |buf| {
-            String::from_utf16(str::truncate_utf16_at_nul(buf))
+            String::from_utf16(::str::truncate_utf16_at_nul(buf))
         });
         opt_s.expect("CommandLineToArgvW returned invalid UTF-16")
     });

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -49,7 +49,7 @@ use slice::{Vector, ImmutableVector, MutableVector, ImmutableEqVector};
 use str::{Str, StrSlice, StrAllocating};
 use string::String;
 use sync::atomics::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
-use to_str::ToString;
+use to_string::ToString;
 use vec::Vec;
 
 #[cfg(unix)]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -56,8 +56,6 @@ use vec::Vec;
 use c_str::ToCStr;
 #[cfg(unix)]
 use libc::c_char;
-#[cfg(windows)]
-use str::OwnedStr;
 
 /// Get the number of cores available
 pub fn num_cpus() -> uint {
@@ -708,8 +706,6 @@ pub fn self_exe_name() -> Option<Path> {
 
     #[cfg(windows)]
     fn load_self() -> Option<Vec<u8>> {
-        use str::OwnedStr;
-
         unsafe {
             use os::win32::fill_utf16_buf_and_decode;
             fill_utf16_buf_and_decode(|buf, sz| {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -998,7 +998,7 @@ pub fn error_string(errnum: uint) -> String {
                 fail!("strerror_r failure");
             }
 
-            str::raw::from_c_str(p as *const c_char).into_string()
+            ::c_str::CString::new(p as *const c_char, false).as_str().unwrap().to_string()
         }
     }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -49,7 +49,6 @@ use slice::{Vector, ImmutableVector, MutableVector, ImmutableEqVector};
 use str::{Str, StrSlice, StrAllocating};
 use string::String;
 use sync::atomics::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
-use to_string::ToString;
 use vec::Vec;
 
 #[cfg(unix)]
@@ -998,7 +997,7 @@ pub fn error_string(errnum: uint) -> String {
                 fail!("strerror_r failure");
             }
 
-            ::c_str::CString::new(p as *const c_char, false).as_str().unwrap().to_string()
+            ::string::raw::from_buf(p as *const u8)
         }
     }
 

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -76,7 +76,7 @@
 #[doc(no_inline)] pub use path::{GenericPath, Path, PosixPath, WindowsPath};
 #[doc(no_inline)] pub use ptr::RawPtr;
 #[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek};
-#[doc(no_inline)] pub use str::{Str, StrVector, StrSlice, OwnedStr};
+#[doc(no_inline)] pub use str::{Str, StrVector, StrSlice};
 #[doc(no_inline)] pub use str::{IntoMaybeOwned, StrAllocating, UnicodeStrSlice};
 #[doc(no_inline)] pub use to_string::{ToString, IntoStr};
 #[doc(no_inline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::str;
+use std::{str, string};
 
 static A: [u8, ..2] = ['h' as u8, 'i' as u8];
 static B: &'static [u8, ..2] = &A;
@@ -18,8 +18,8 @@ pub fn main() {
     unsafe {
         let foo = &A as *const u8;
         assert_eq!(str::raw::from_utf8(A), "hi");
-        assert_eq!(str::raw::from_buf_len(foo, A.len()), "hi".to_string());
-        assert_eq!(str::raw::from_buf_len(C, B.len()), "hi".to_string());
+        assert_eq!(string::raw::from_buf_len(foo, A.len()), "hi".to_string());
+        assert_eq!(string::raw::from_buf_len(C, B.len()), "hi".to_string());
         assert!(*C == A[0]);
         assert!(*(&B[0] as *const u8) == A[0]);
 

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -24,6 +24,6 @@ pub fn main() {
         assert!(*(&B[0] as *const u8) == A[0]);
 
         let bar = str::raw::from_utf8(A).to_c_str();
-        assert_eq!(str::raw::from_c_str(bar.as_ptr()), "hi".to_string());
+        assert_eq!(bar.as_str(), "hi".to_c_str().as_str());
     }
 }


### PR DESCRIPTION
### Removed the `OwnedStr` trait

This trait was only implemented by `String`. It provided the methods `into_bytes` and `append`, both of which **are already implemented as normal methods** of `String` (they were duplicated). This change improves the consistency of strings.

Its removal shouldn't break any code, except if somebody has implemented `OwnedStr` for his own types.
### Deprecated some unsafe functions
- `from_buf_len` in favor of `string::raw::from_buf_len`
- `from_c_str` in favor of `string::raw::from_buf`
- `from_utf8_owned` in favor of `string::raw::from_utf8`
- `from_byte` in favor of `string::raw::from_utf8` (make a new vector with a single byte and call the function)
- `String::from_raw_parts` in favor of `string::raw::from_parts`

[breaking-change]
