### PR TITLE
librustc: Remove `for` desugaring

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -17,7 +17,10 @@
 
 use mem::transmute;
 use option::{None, Option, Some};
-use iter::{Iterator, range_step};
+use iter::range_step;
+
+#[cfg(stage0)]
+use iter::Iterator; // NOTE(stage0): Remove after snapshot.
 
 // UTF-8 ranges and tags for encoding characters
 static TAG_CONT: u8    = 0b1000_0000u8;

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -13,14 +13,18 @@
 use char;
 use collections::Collection;
 use fmt;
-use iter::{Iterator, range, DoubleEndedIterator};
+use iter::{range, DoubleEndedIterator};
 use num::{Float, FPNaN, FPInfinite, ToPrimitive, Primitive};
 use num::{Zero, One, cast};
-use option::{None, Some};
 use result::Ok;
 use slice::{ImmutableVector, MutableVector};
 use slice;
 use str::StrSlice;
+
+#[cfg(stage0)]
+use iter::Iterator;         // NOTE(stage0): Remove after snapshot.
+#[cfg(stage0)]
+use option::{Some, None};   // NOTE(stage0): Remove after snapshot.
 
 /// A flag that specifies whether to use exponential (scientific) notation.
 pub enum ExponentFormat {

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -16,10 +16,14 @@
 
 use collections::Collection;
 use fmt;
-use iter::{Iterator, DoubleEndedIterator};
+use iter::DoubleEndedIterator;
 use num::{Int, cast, zero};
-use option::{Some, None};
 use slice::{ImmutableVector, MutableVector};
+
+#[cfg(stage0)]
+use iter::Iterator;         // NOTE(stage0): Remove after snapshot.
+#[cfg(stage0)]
+use option::{Some, None};   // NOTE(stage0): Remove after snapshot.
 
 /// A type that represents a specific radix
 trait GenericRadix {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -95,6 +95,7 @@ pub trait Extendable<A>: FromIterator<A> {
 /// is returned. A concrete Iterator implementation may choose to behave however
 /// it wishes, either by returning `None` infinitely, or by doing something
 /// else.
+#[lang="iterator"]
 pub trait Iterator<A> {
     /// Advance the iterator and return the next value. Return `None` when the end is reached.
     fn next(&mut self) -> Option<A>;

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -147,7 +147,12 @@ use iter::{Iterator, DoubleEndedIterator, FromIterator, ExactSize};
 use mem;
 use slice;
 
-/// The `Option`
+// Note that this is not a lang item per se, but it has a hidden dependency on
+// `Iterator`, which is one. The compiler assumes that the `next` method of
+// `Iterator` is an enumeration with one type parameter and two variants,
+// which basically means it must be `Option`.
+
+/// The `Option` type.
 #[deriving(Clone, PartialEq, PartialOrd, Eq, Ord, Show)]
 pub enum Option<T> {
     /// No value

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -90,10 +90,13 @@
 use mem;
 use clone::Clone;
 use intrinsics;
-use iter::{range, Iterator};
+use iter::range;
 use option::{Some, None, Option};
 
 use cmp::{PartialEq, Eq, PartialOrd, Equiv, Ordering, Less, Equal, Greater};
+
+#[cfg(stage0)]
+use iter::Iterator; // NOTE(stage0): Remove after snapshot.
 
 pub use intrinsics::copy_memory;
 pub use intrinsics::copy_nonoverlapping_memory;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -28,7 +28,7 @@ use iter::{Map, Iterator};
 use iter::{DoubleEndedIterator, ExactSize};
 use iter::range;
 use num::{CheckedMul, Saturating};
-use option::{None, Option, Some};
+use option::{Option, None, Some};
 use raw::Repr;
 use slice::ImmutableVector;
 use slice;
@@ -1027,8 +1027,11 @@ pub mod traits {
     use cmp::{Ord, Ordering, Less, Equal, Greater, PartialEq, PartialOrd, Equiv, Eq};
     use collections::Collection;
     use iter::Iterator;
-    use option::{Option, Some, None};
+    use option::{Option, Some};
     use str::{Str, StrSlice, eq_slice};
+
+    #[cfg(stage0)]
+    use option::None;   // NOTE(stage0): Remove after snapshot.
 
     impl<'a> Ord for &'a str {
         #[inline]

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -137,8 +137,8 @@ fn test_iterator_take_while() {
     let ys = [0u, 1, 2, 3, 5, 13];
     let mut it = xs.iter().take_while(|&x| *x < 15u);
     let mut i = 0;
-    for &x in it {
-        assert_eq!(x, ys[i]);
+    for x in it {
+        assert_eq!(*x, ys[i]);
         i += 1;
     }
     assert_eq!(i, ys.len());
@@ -150,8 +150,8 @@ fn test_iterator_skip_while() {
     let ys = [15, 16, 17, 19];
     let mut it = xs.iter().skip_while(|&x| *x < 15u);
     let mut i = 0;
-    for &x in it {
-        assert_eq!(x, ys[i]);
+    for x in it {
+        assert_eq!(*x, ys[i]);
         i += 1;
     }
     assert_eq!(i, ys.len());

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -440,6 +440,7 @@ impl<'a> CheckLoanCtxt<'a> {
                 euv::AddrOf(..) |
                 euv::AutoRef(..) |
                 euv::ClosureInvocation(..) |
+                euv::ForLoop(..) |
                 euv::RefBinding(..) => {
                     format!("previous borrow of `{}` occurs here",
                             self.bccx.loan_path_to_string(&*old_loan.loan_path))
@@ -666,6 +667,11 @@ impl<'a> CheckLoanCtxt<'a> {
                 }
             }
             return;
+        }
+
+        // Initializations are OK.
+        if mode == euv::Init {
+            return
         }
 
         // For immutable local variables, assignments are legal

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -651,7 +651,8 @@ impl<'a> BorrowckCtxt<'a> {
                     euv::OverloadedOperator |
                     euv::AddrOf |
                     euv::RefBinding |
-                    euv::AutoRef => {
+                    euv::AutoRef |
+                    euv::ForLoop => {
                         format!("cannot borrow {} as mutable", descr)
                     }
                     euv::ClosureInvocation => {
@@ -711,6 +712,10 @@ impl<'a> BorrowckCtxt<'a> {
 
             BorrowViolation(euv::ClosureInvocation) => {
                 "closure invocation"
+            }
+
+            BorrowViolation(euv::ForLoop) => {
+                "`for` loop"
             }
         };
 

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -42,6 +42,10 @@ impl<'a> Visitor<Context> for CheckLoopVisitor<'a> {
             ast::ExprLoop(ref b, _) => {
                 self.visit_block(&**b, Loop);
             }
+            ast::ExprForLoop(_, ref e, ref b, _) => {
+                self.visit_expr(&**e, cx);
+                self.visit_block(&**b, Loop);
+            }
             ast::ExprFnBlock(_, ref b) |
             ast::ExprProc(_, ref b) |
             ast::ExprUnboxedFn(_, ref b) => {

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -354,11 +354,11 @@ fn create_and_seed_worklist(tcx: &ty::ctxt,
     // depending on whether a crate is built as bin or lib, and we want
     // the warning to be consistent, we also seed the worklist with
     // exported symbols.
-    for &id in exported_items.iter() {
-        worklist.push(id);
+    for id in exported_items.iter() {
+        worklist.push(*id);
     }
-    for &id in reachable_symbols.iter() {
-        worklist.push(id);
+    for id in reachable_symbols.iter() {
+        worklist.push(*id);
     }
 
     // Seed entry point

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -299,5 +299,7 @@ lets_do_this! {
     NoShareItem,                     "no_share_bound",          no_share_bound;
     ManagedItem,                     "managed_bound",           managed_bound;
 
+    IteratorItem,                    "iterator",                iterator;
+
     StackExhaustedLangItem,          "stack_exhausted",         stack_exhausted;
 }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -482,11 +482,10 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
           ast::ExprBlock(..) | ast::ExprLoop(..) | ast::ExprMatch(..) |
           ast::ExprLit(..) | ast::ExprBreak(..) | ast::ExprMac(..) |
           ast::ExprAgain(..) | ast::ExprStruct(..) | ast::ExprRepeat(..) |
-          ast::ExprInlineAsm(..) | ast::ExprBox(..) => {
+          ast::ExprInlineAsm(..) | ast::ExprBox(..) |
+          ast::ExprForLoop(..) => {
             Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
           }
-
-          ast::ExprForLoop(..) => fail!("non-desugared expr_for_loop")
         }
     }
 
@@ -1113,7 +1112,7 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
           }
 
           ast::PatBox(ref subpat) | ast::PatRegion(ref subpat) => {
-            // @p1, ~p1
+            // @p1, ~p1, ref p1
             let subcmt = self.cat_deref(pat, cmt, 0, false);
             if_ok!(self.cat_pattern(subcmt, &**subpat, op));
           }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -365,8 +365,8 @@ pub fn find_reachable(tcx: &ty::ctxt,
     //         other crates link to us, they're going to expect to be able to
     //         use the lang items, so we need to be sure to mark them as
     //         exported.
-    for &id in exported_items.iter() {
-        reachable_context.worklist.push(id);
+    for id in exported_items.iter() {
+        reachable_context.worklist.push(*id);
     }
     for (_, item) in tcx.lang_items.items() {
         match *item {

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -1543,6 +1543,31 @@ pub fn store_arg<'a>(mut bcx: &'a Block<'a>,
     }
 }
 
+/// Generates code for the pattern binding in a `for` loop like
+/// `for <pat> in <expr> { ... }`.
+pub fn store_for_loop_binding<'a>(
+                              bcx: &'a Block<'a>,
+                              pat: Gc<ast::Pat>,
+                              llvalue: ValueRef,
+                              body_scope: cleanup::ScopeId)
+                              -> &'a Block<'a> {
+    let _icx = push_ctxt("match::store_for_loop_binding");
+
+    if simple_identifier(&*pat).is_some() {
+        // Generate nicer LLVM for the common case of a `for` loop pattern
+        // like `for x in blahblah { ... }`.
+        let binding_type = node_id_type(bcx, pat.id);
+        bcx.fcx.lllocals.borrow_mut().insert(pat.id,
+                                             Datum::new(llvalue,
+                                                        binding_type,
+                                                        Lvalue));
+        return bcx
+    }
+
+    // General path. Copy out the values that are used in the pattern.
+    bind_irrefutable_pat(bcx, pat, llvalue, BindLocal, body_scope)
+}
+
 fn mk_binding_alloca<'a,A>(bcx: &'a Block<'a>,
                            p_id: ast::NodeId,
                            ident: &ast::Ident,

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -12,16 +12,23 @@ use llvm::*;
 use driver::config::FullDebugInfo;
 use middle::def;
 use middle::lang_items::{FailFnLangItem, FailBoundsCheckFnLangItem};
+use middle::trans::_match;
+use middle::trans::adt;
 use middle::trans::base::*;
 use middle::trans::build::*;
 use middle::trans::callee;
 use middle::trans::cleanup::CleanupMethods;
 use middle::trans::cleanup;
 use middle::trans::common::*;
+use middle::trans::datum;
 use middle::trans::debuginfo;
 use middle::trans::expr;
+use middle::trans::meth;
+use middle::trans::type_::Type;
 use middle::ty;
+use middle::typeck::MethodCall;
 use util::ppaux::Repr;
+use util::ppaux;
 
 use syntax::ast;
 use syntax::ast::Ident;
@@ -235,6 +242,129 @@ pub fn trans_while<'a>(bcx: &'a Block<'a>,
 
     fcx.pop_loop_cleanup_scope(loop_id);
     return next_bcx_in;
+}
+
+/// Translates a `for` loop.
+pub fn trans_for<'a>(
+                 mut bcx: &'a Block<'a>,
+                 loop_info: NodeInfo,
+                 pat: Gc<ast::Pat>,
+                 head: &ast::Expr,
+                 body: &ast::Block)
+                 -> &'a Block<'a> {
+    let _icx = push_ctxt("trans_for");
+
+    //            bcx
+    //             |
+    //      loopback_bcx_in  <-------+
+    //             |                 |
+    //      loopback_bcx_out         |
+    //           |      |            |
+    //           |    body_bcx_in    |
+    // cleanup_blk      |            |
+    //    |           body_bcx_out --+
+    // next_bcx_in
+
+    // Codegen the head to create the iterator value.
+    let iterator_datum =
+        unpack_datum!(bcx, expr::trans_to_lvalue(bcx, head, "for_head"));
+    let iterator_type = node_id_type(bcx, head.id);
+    debug!("iterator type is {}, datum type is {}",
+           ppaux::ty_to_string(bcx.tcx(), iterator_type),
+           ppaux::ty_to_string(bcx.tcx(), iterator_datum.ty));
+    let lliterator = load_ty(bcx, iterator_datum.val, iterator_datum.ty);
+
+    // Create our basic blocks and set up our loop cleanups.
+    let next_bcx_in = bcx.fcx.new_id_block("for_exit", loop_info.id);
+    let loopback_bcx_in = bcx.fcx.new_id_block("for_loopback", head.id);
+    let body_bcx_in = bcx.fcx.new_id_block("for_body", body.id);
+    bcx.fcx.push_loop_cleanup_scope(loop_info.id,
+                                    [next_bcx_in, loopback_bcx_in]);
+    Br(bcx, loopback_bcx_in.llbb);
+    let cleanup_llbb = bcx.fcx.normal_exit_block(loop_info.id,
+                                                 cleanup::EXIT_BREAK);
+
+    // Set up the method call (to `.next()`).
+    let method_call = MethodCall::expr(loop_info.id);
+    let method_type = loopback_bcx_in.tcx()
+                                     .method_map
+                                     .borrow()
+                                     .get(&method_call)
+                                     .ty;
+    let method_type = monomorphize_type(loopback_bcx_in, method_type);
+    let method_result_type = ty::ty_fn_ret(method_type);
+    let option_cleanup_scope = body_bcx_in.fcx.push_custom_cleanup_scope();
+    let option_cleanup_scope_id = cleanup::CustomScope(option_cleanup_scope);
+
+    // Compile the method call (to `.next()`).
+    let mut loopback_bcx_out = loopback_bcx_in;
+    let option_datum =
+        unpack_datum!(loopback_bcx_out,
+                      datum::lvalue_scratch_datum(loopback_bcx_out,
+                                                  method_result_type,
+                                                  "loop_option",
+                                                  false,
+                                                  option_cleanup_scope_id,
+                                                  (),
+                                                  |(), bcx, lloption| {
+        let Result {
+            bcx: bcx,
+            val: _
+        } = callee::trans_call_inner(bcx,
+                                     Some(loop_info),
+                                     method_type,
+                                     |bcx, arg_cleanup_scope| {
+                                         meth::trans_method_callee(
+                                             bcx,
+                                             method_call,
+                                             None,
+                                             arg_cleanup_scope)
+                                     },
+                                     callee::ArgVals([lliterator]),
+                                     Some(expr::SaveIn(lloption)));
+        bcx
+    }));
+
+    // Check the discriminant; if the `None` case, exit the loop.
+    let option_representation = adt::represent_type(loopback_bcx_out.ccx(),
+                                                    method_result_type);
+    let i8_type = Type::i8(loopback_bcx_out.ccx());
+    let lldiscriminant = adt::trans_get_discr(loopback_bcx_out,
+                                              &*option_representation,
+                                              option_datum.val,
+                                              Some(i8_type));
+    let llzero = C_u8(loopback_bcx_out.ccx(), 0);
+    let llcondition = ICmp(loopback_bcx_out, IntNE, lldiscriminant, llzero);
+    CondBr(loopback_bcx_out, llcondition, body_bcx_in.llbb, cleanup_llbb);
+
+    // Now we're in the body. Unpack the `Option` value into the programmer-
+    // supplied pattern.
+    let llpayload = adt::trans_field_ptr(body_bcx_in,
+                                         &*option_representation,
+                                         option_datum.val,
+                                         1,
+                                         0);
+    let binding_cleanup_scope = body_bcx_in.fcx.push_custom_cleanup_scope();
+    let binding_cleanup_scope_id =
+        cleanup::CustomScope(binding_cleanup_scope);
+    let mut body_bcx_out =
+        _match::store_for_loop_binding(body_bcx_in,
+                                       pat,
+                                       llpayload,
+                                       binding_cleanup_scope_id);
+
+    // Codegen the body.
+    body_bcx_out = trans_block(body_bcx_out, body, expr::Ignore);
+    body_bcx_out.fcx.pop_custom_cleanup_scope(binding_cleanup_scope);
+    body_bcx_out =
+        body_bcx_out.fcx
+                    .pop_and_trans_custom_cleanup_scope(body_bcx_out,
+                                                        option_cleanup_scope);
+    Br(body_bcx_out, loopback_bcx_in.llbb);
+
+    // Codegen cleanups and leave.
+    next_bcx_in.fcx.pop_loop_cleanup_scope(loop_info.id);
+    next_bcx_in
 }
 
 pub fn trans_loop<'a>(bcx:&'a Block<'a>,

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -3582,9 +3582,24 @@ fn populate_scope_map(cx: &CrateContext,
                 })
             }
 
-            ast::ExprForLoop(_, _, _, _) => {
-                cx.sess().span_bug(exp.span, "debuginfo::populate_scope_map() - \
-                                              Found unexpanded for-loop.");
+            ast::ExprForLoop(ref pattern, ref head, ref body, _) => {
+                walk_expr(cx, &**head, scope_stack, scope_map);
+
+                with_new_scope(cx,
+                               exp.span,
+                               scope_stack,
+                               scope_map,
+                               |cx, scope_stack, scope_map| {
+                    scope_map.insert(exp.id,
+                                     scope_stack.last()
+                                                .unwrap()
+                                                .scope_metadata);
+                    walk_pattern(cx,
+                                 *pattern,
+                                 scope_stack,
+                                 scope_map);
+                    walk_block(cx, &**body, scope_stack, scope_map);
+                })
             }
 
             ast::ExprMac(_) => {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -665,6 +665,13 @@ fn trans_rvalue_stmt_unadjusted<'a>(bcx: &'a Block<'a>,
         ast::ExprWhile(ref cond, ref body) => {
             controlflow::trans_while(bcx, expr.id, &**cond, &**body)
         }
+        ast::ExprForLoop(ref pat, ref head, ref body, _) => {
+            controlflow::trans_for(bcx,
+                                   expr_info(expr),
+                                   *pat,
+                                   &**head,
+                                   &**body)
+        }
         ast::ExprLoop(ref body, _) => {
             controlflow::trans_loop(bcx, expr.id, &**body)
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3090,7 +3090,7 @@ pub enum ExprKind {
 pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
     if tcx.method_map.borrow().contains_key(&typeck::MethodCall::expr(expr.id)) {
         // Overloaded operations are generally calls, and hence they are
-        // generated via DPS, but there are two exceptions:
+        // generated via DPS, but there are a few exceptions:
         return match expr.node {
             // `a += b` has a unit result.
             ast::ExprAssignOp(..) => RvalueStmtExpr,
@@ -3100,6 +3100,9 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
 
             // the index method invoked for `a[i]` always yields an `&T`
             ast::ExprIndex(..) => LvalueExpr,
+
+            // `for` loops are statements
+            ast::ExprForLoop(..) => RvalueStmtExpr,
 
             // in the general case, result could be any type, use DPS
             _ => RvalueDpsExpr
@@ -3209,11 +3212,10 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
         ast::ExprLoop(..) |
         ast::ExprAssign(..) |
         ast::ExprInlineAsm(..) |
-        ast::ExprAssignOp(..) => {
+        ast::ExprAssignOp(..) |
+        ast::ExprForLoop(..) => {
             RvalueStmtExpr
         }
-
-        ast::ExprForLoop(..) => fail!("non-desugared expr_for_loop"),
 
         ast::ExprLit(_) | // Note: LitStr is carved out above
         ast::ExprUnary(..) |

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -21,6 +21,7 @@ use middle::typeck::check::{instantiate_path, lookup_def};
 use middle::typeck::check::{structure_of, valid_range_bounds};
 use middle::typeck::infer;
 use middle::typeck::require_same_types;
+use util::ppaux;
 
 use std::collections::{HashMap, HashSet};
 use std::gc::Gc;
@@ -484,7 +485,10 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
         }
         fcx.write_ty(pat.id, typ);
 
-        debug!("(checking match) writing type for pat id {}", pat.id);
+        debug!("(checking match) writing type {} (expected {}) for pat id {}",
+               ppaux::ty_to_string(tcx, typ),
+               ppaux::ty_to_string(tcx, expected),
+               pat.id);
 
         match sub {
           Some(ref p) => check_pat(pcx, &**p, expected),

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -609,6 +609,22 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             rcx.set_repeating_scope(repeating_scope);
         }
 
+        ast::ExprForLoop(ref pat, ref head, ref body, _) => {
+            constrain_bindings_in_pat(&**pat, rcx);
+
+            {
+                let mc = mc::MemCategorizationContext::new(rcx);
+                let head_cmt = ignore_err!(mc.cat_expr(&**head));
+                link_pattern(rcx, mc, head_cmt, &**pat);
+            }
+
+            rcx.visit_expr(&**head, ());
+
+            let repeating_scope = rcx.set_repeating_scope(body.id);
+            rcx.visit_block(&**body, ());
+            rcx.set_repeating_scope(repeating_scope);
+        }
+
         _ => {
             visit::walk_expr(rcx, expr, ());
         }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -756,7 +756,8 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
       ast::ExprUnary(_, _) |
       ast::ExprAssignOp(_, _, _) |
       ast::ExprIndex(_, _) |
-      ast::ExprMethodCall(_, _, _) => {
+      ast::ExprMethodCall(_, _, _) |
+      ast::ExprForLoop(..) => {
         match fcx.inh.method_map.borrow().find(&MethodCall::expr(ex.id)) {
           Some(method) => {
               debug!("vtable resolution on parameter bounds for method call {}",

--- a/src/librustc/middle/typeck/coherence.rs
+++ b/src/librustc/middle/typeck/coherence.rs
@@ -419,8 +419,8 @@ impl<'a> CoherenceChecker<'a> {
     }
 
     fn check_implementation_coherence(&self) {
-        for &trait_id in self.crate_context.tcx.trait_impls.borrow().keys() {
-            self.check_implementation_coherence_of(trait_id);
+        for trait_id in self.crate_context.tcx.trait_impls.borrow().keys() {
+            self.check_implementation_coherence_of(*trait_id);
         }
     }
 

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -66,7 +66,7 @@ impl<'a> Visitor<()> for LoopQueryVisitor<'a> {
         match e.node {
           // Skip inner loops, since a break in the inner loop isn't a
           // break inside the outer loop
-          ast::ExprLoop(..) | ast::ExprWhile(..) => {}
+          ast::ExprLoop(..) | ast::ExprWhile(..) | ast::ExprForLoop(..) => {}
           _ => visit::walk_expr(self, e, ())
         }
     }

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -252,6 +252,7 @@ mod svh_visitor {
         SawExprStruct,
         SawExprRepeat,
         SawExprParen,
+        SawExprForLoop,
     }
 
     fn saw_expr<'a>(node: &'a Expr_) -> SawExprComponent<'a> {
@@ -287,9 +288,9 @@ mod svh_visitor {
             ExprStruct(..)           => SawExprStruct,
             ExprRepeat(..)           => SawExprRepeat,
             ExprParen(..)            => SawExprParen,
+            ExprForLoop(..)          => SawExprForLoop,
 
             // just syntactic artifacts, expanded away by time of SVH.
-            ExprForLoop(..)          => unreachable!(),
             ExprMac(..)              => unreachable!(),
         }
     }

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -12,7 +12,7 @@
 
 use io::{fs, IoResult};
 use io;
-use iter::{Iterator, range};
+use iter::range;
 use libc;
 use ops::Drop;
 use option::{Option, None, Some};
@@ -20,6 +20,9 @@ use os;
 use path::{Path, GenericPath};
 use result::{Ok, Err};
 use sync::atomics;
+
+#[cfg(stage0)]
+use iter::Iterator; // NOTE(stage0): Remove after snapshot.
 
 /// A wrapper for a path to temporary directory implementing automatic
 /// scope-based deletion.

--- a/src/libunicode/decompose.rs
+++ b/src/libunicode/decompose.rs
@@ -39,6 +39,7 @@ pub fn decompose_canonical(c: char, i: |char|) { d(c, i, false); }
 pub fn decompose_compatible(c: char, i: |char|) { d(c, i, true); }
 
 fn d(c: char, i: |char|, k: bool) {
+    #[cfg(stage0)]
     use core::iter::Iterator;
 
     // 7-bit ASCII never decomposes

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -297,10 +297,10 @@ fn search(
     // for every unused piece
     for id in range(0u, 10).filter(|id| board & (1 << (id + 50)) == 0) {
         // for each mask that fits on the board
-        for &m in masks_at.get(id).iter().filter(|&m| board & *m == 0) {
+        for m in masks_at.get(id).iter().filter(|&m| board & *m == 0) {
             // This check is too costy.
             //if is_board_unfeasible(board | m, masks) {continue;}
-            search(masks, board | m, i + 1, Cons(m, &cur), data);
+            search(masks, board | *m, i + 1, Cons(*m, &cur), data);
         }
     }
 }
@@ -311,9 +311,10 @@ fn par_search(masks: Vec<Vec<Vec<u64>>>) -> Data {
 
     // launching the search in parallel on every masks at minimum
     // coordinate (0,0)
-    for &m in masks.get(0).iter().flat_map(|masks_pos| masks_pos.iter()) {
+    for m in masks.get(0).iter().flat_map(|masks_pos| masks_pos.iter()) {
         let masks = masks.clone();
         let tx = tx.clone();
+        let m = *m;
         spawn(proc() {
             let mut data = Data::new();
             search(&*masks, m, 1, Cons(m, &Nil), &mut data);

--- a/src/test/compile-fail/for-loop-bogosity.rs
+++ b/src/test/compile-fail/for-loop-bogosity.rs
@@ -8,19 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// macro f should not be able to inject a reference to 'n'.
-//
-// Ignored because `for` loops are not hygienic yet; they will require special
-// handling since they introduce a new pattern binding position.
+struct MyStruct {
+    x: int,
+    y: int,
+}
 
-// ignore-test
-
-#![feature(macro_rules)]
-
-macro_rules! f(() => (n))
-
-fn main() -> (){
-    for n in range(0i, 1) {
-        println!("{}", f!()); //~ ERROR unresolved name `n`
+impl MyStruct {
+    fn next(&mut self) -> Option<int> {
+        Some(self.x)
     }
 }
+
+pub fn main() {
+    let mut bogus = MyStruct {
+        x: 1,
+        y: 2,
+    };
+    for x in bogus {    //~ ERROR does not implement the `Iterator` trait
+        drop(x);
+    }
+}
+

--- a/src/test/compile-fail/vec-mut-iter-borrow.rs
+++ b/src/test/compile-fail/vec-mut-iter-borrow.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 fn main() {
-    let mut xs = vec!(1i, 2, 3, 4);
+    let mut xs: Vec<int> = vec!();
 
     for x in xs.mut_iter() {
-        xs.push(1) //~ ERROR cannot borrow `xs`
+        xs.push(1i) //~ ERROR cannot borrow `xs`
     }
 }

--- a/src/test/debuginfo/lexical-scope-in-for-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-for-loop.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-android: FIXME(#10381)
+// ignore-test: Not sure what is going on here --pcwalton
 
 // compile-flags:-g
 

--- a/src/test/run-pass/for-loop-goofiness.rs
+++ b/src/test/run-pass/for-loop-goofiness.rs
@@ -8,19 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// macro f should not be able to inject a reference to 'n'.
-//
-// Ignored because `for` loops are not hygienic yet; they will require special
-// handling since they introduce a new pattern binding position.
+enum BogusOption<T> {
+    None,
+    Some(T),
+}
 
-// ignore-test
+type Iterator = int;
 
-#![feature(macro_rules)]
-
-macro_rules! f(() => (n))
-
-fn main() -> (){
-    for n in range(0i, 1) {
-        println!("{}", f!()); //~ ERROR unresolved name `n`
+pub fn main() {
+    let x = [ 3i, 3, 3 ];
+    for i in x.iter() {
+        assert_eq!(*i, 3);
     }
 }
+


### PR DESCRIPTION
librustc: Stop desugaring `for` expressions and translate them directly.

This makes edge cases in which the `Iterator` trait was not in scope
and/or `Option` or its variants were not in scope work properly.

This breaks code that looks like:

```
struct MyStruct { ... }

impl MyStruct {
    fn next(&mut self) -> Option<int> { ... }
}

for x in MyStruct { ... } { ... }
```

Change ad-hoc `next` methods like the above to implementations of the
`Iterator` trait. For example:

```
impl Iterator<int> for MyStruct {
    fn next(&mut self) -> Option<int> { ... }
}
```

Closes #15392.

[breaking-change]
