### PR TITLE
Fix missing word in the lifetime guide.

### DIFF
--- a/src/doc/guide-lifetimes.md
+++ b/src/doc/guide-lifetimes.md
@@ -111,8 +111,8 @@ let on_the_stack2: &Point = &Point {x: 3.0, y: 4.0};
 ~~~
 
 Applying `&` to an rvalue (non-assignable location) is just a convenient
-shorthand for creating a temporary and taking its address. A more verbose
-way to write the same code is:
+shorthand for creating a temporary struct and taking its address. A more
+verbose way to write the same code is:
 
 ~~~
 # struct Point {x: f64, y: f64}


### PR DESCRIPTION
I was reading the lifetime guide and noticed that a word was missing from the sentence. I'm not sure if `struct` is the best word to describe what's happening here, let me know if you want something else.
