### PR TITLE
Minor refactoring and features in rustc driver for embedders

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -593,24 +593,10 @@ fn parse_cfgspecs(cfgspecs: Vec<String> ) -> ast::CrateConfig {
 }
 
 pub fn build_session_options(matches: &getopts::Matches) -> Options {
-    let mut crate_types: Vec<CrateType> = Vec::new();
+
     let unparsed_crate_types = matches.opt_strs("crate-type");
-    for unparsed_crate_type in unparsed_crate_types.iter() {
-        for part in unparsed_crate_type.as_slice().split(',') {
-            let new_part = match part {
-                "lib"       => default_lib_output(),
-                "rlib"      => CrateTypeRlib,
-                "staticlib" => CrateTypeStaticlib,
-                "dylib"     => CrateTypeDylib,
-                "bin"       => CrateTypeExecutable,
-                _ => {
-                    early_error(format!("unknown crate type: `{}`",
-                                        part).as_slice())
-                }
-            };
-            crate_types.push(new_part)
-        }
-    }
+    let crate_types = parse_crate_types_from_list(unparsed_crate_types)
+        .unwrap_or_else(|e| early_error(e.as_slice()));
 
     let parse_only = matches.opt_present("parse-only");
     let no_trans = matches.opt_present("no-trans");
@@ -802,6 +788,29 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         externs: externs,
         crate_name: crate_name,
     }
+}
+
+pub fn parse_crate_types_from_list(crate_types_list_list: Vec<String>) -> Result<Vec<CrateType>, String> {
+
+    let mut crate_types: Vec<CrateType> = Vec::new();
+    for unparsed_crate_type in crate_types_list_list.iter() {
+        for part in unparsed_crate_type.as_slice().split(',') {
+            let new_part = match part {
+                "lib"       => default_lib_output(),
+                "rlib"      => CrateTypeRlib,
+                "staticlib" => CrateTypeStaticlib,
+                "dylib"     => CrateTypeDylib,
+                "bin"       => CrateTypeExecutable,
+                _ => {
+                    return Err(format!("unknown crate type: `{}`",
+                                       part));
+                }
+            };
+            crate_types.push(new_part)
+        }
+    }
+
+    return Ok(crate_types);
 }
 
 impl fmt::Show for CrateType {

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -97,6 +97,7 @@ pub struct Options {
     pub color: ColorConfig,
     pub externs: HashMap<String, Vec<String>>,
     pub crate_name: Option<String>,
+    pub alt_std_name: Option<String>
 }
 
 /// Some reasonable defaults
@@ -124,6 +125,7 @@ pub fn basic_options() -> Options {
         color: Auto,
         externs: HashMap::new(),
         crate_name: None,
+        alt_std_name: None,
     }
 }
 
@@ -787,6 +789,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         color: color,
         externs: externs,
         crate_name: crate_name,
+        alt_std_name: None
     }
 }
 

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -97,6 +97,9 @@ pub struct Options {
     pub color: ColorConfig,
     pub externs: HashMap<String, Vec<String>>,
     pub crate_name: Option<String>,
+    /// An optional name to use as the crate for std during std injection,
+    /// written `extern crate std = "name"`. Default to "std". Used by
+    /// out-of-tree drivers.
     pub alt_std_name: Option<String>
 }
 
@@ -793,10 +796,10 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     }
 }
 
-pub fn parse_crate_types_from_list(crate_types_list_list: Vec<String>) -> Result<Vec<CrateType>, String> {
+pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateType>, String> {
 
     let mut crate_types: Vec<CrateType> = Vec::new();
-    for unparsed_crate_type in crate_types_list_list.iter() {
+    for unparsed_crate_type in list_list.iter() {
         for part in unparsed_crate_type.as_slice().split(',') {
             let new_part = match part {
                 "lib"       => default_lib_output(),

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -181,6 +181,7 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
 // modified
 
 /// Run the "early phases" of the compiler: initial `cfg` processing,
+/// loading compiler plugins (including those from `addl_plugins`),
 /// syntax expansion, secondary `cfg` expansion, synthesis of a test
 /// harness if one is to be provided and injection of a dependency on the
 /// standard library and prelude.

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -69,7 +69,8 @@ pub fn compile_input(sess: Session,
                      cfg: ast::CrateConfig,
                      input: &Input,
                      outdir: &Option<Path>,
-                     output: &Option<Path>) {
+                     output: &Option<Path>,
+                     addl_plugins: Option<Plugins>) {
     // We need nested scopes here, because the intermediate results can keep
     // large chunks of memory alive and we want to free them as soon as
     // possible to keep the peak memory usage low
@@ -85,7 +86,8 @@ pub fn compile_input(sess: Session,
             let id = link::find_crate_name(Some(&sess), krate.attrs.as_slice(),
                                            input);
             let (expanded_crate, ast_map)
-                = match phase_2_configure_and_expand(&sess, krate, id.as_slice()) {
+                = match phase_2_configure_and_expand(&sess, krate, id.as_slice(),
+                                                     addl_plugins) {
                     None => return,
                     Some(p) => p,
                 };
@@ -186,7 +188,8 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
 /// Returns `None` if we're aborting after handling -W help.
 pub fn phase_2_configure_and_expand(sess: &Session,
                                     mut krate: ast::Crate,
-                                    crate_name: &str)
+                                    crate_name: &str,
+                                    addl_plugins: Option<Plugins>)
                                     -> Option<(ast::Crate, syntax::ast_map::Map)> {
     let time_passes = sess.time_passes();
 
@@ -212,9 +215,10 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     krate = time(time_passes, "configuration 1", krate, |krate|
                  front::config::strip_unconfigured_items(krate));
 
+    let mut addl_plugins = Some(addl_plugins);
     let Plugins { macros, registrars }
         = time(time_passes, "plugin loading", (), |_|
-               plugin::load::load_plugins(sess, &krate));
+               plugin::load::load_plugins(sess, &krate, addl_plugins.take_unwrap()));
 
     let mut registry = Registry::new(&krate);
 
@@ -697,7 +701,7 @@ pub fn pretty_print_input(sess: Session,
         PpmExpanded | PpmExpandedIdentified | PpmTyped | PpmFlowGraph(_) => {
             let (krate, ast_map)
                 = match phase_2_configure_and_expand(&sess, krate,
-                                                     id.as_slice()) {
+                                                     id.as_slice(), None) {
                     None => return,
                     Some(p) => p,
                 };

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -418,7 +418,7 @@ pub fn list_metadata(sess: &Session, path: &Path,
 ///
 /// The diagnostic emitter yielded to the procedure should be used for reporting
 /// errors of the compiler.
-fn monitor(f: proc():Send) {
+pub fn monitor(f: proc():Send) {
     // FIXME: This is a hack for newsched since it doesn't support split stacks.
     // rustc needs a lot of stack! When optimizations are disabled, it needs
     // even *more* stack than usual as well.

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -124,7 +124,7 @@ fn run_compiler(args: &[String]) {
         return;
     }
 
-    driver::compile_input(sess, cfg, &input, &odir, &ofile);
+    driver::compile_input(sess, cfg, &input, &odir, &ofile, None);
 }
 
 /// Prints version information and returns None on success or an error

--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -60,9 +60,16 @@ struct StandardLibraryInjector<'a> {
 
 impl<'a> fold::Folder for StandardLibraryInjector<'a> {
     fn fold_crate(&mut self, mut krate: ast::Crate) -> ast::Crate {
+
+        // The name to use in `extern crate std = "name";`
+        let actual_crate_name = match self.sess.opts.alt_std_name {
+            Some(ref s) => token::intern_and_get_ident(s.as_slice()),
+            None => token::intern_and_get_ident("std"),
+        };
+
         let mut vis = vec!(ast::ViewItem {
             node: ast::ViewItemExternCrate(token::str_to_ident("std"),
-                                           None,
+                                           Some((actual_crate_name, ast::CookedStr)),
                                            ast::DUMMY_NODE_ID),
             attrs: vec!(
                 attr::mk_attr_outer(attr::mk_attr_id(), attr::mk_list_item(

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -117,7 +117,7 @@ fn test_env(_test_name: &str,
     let input = driver::StrInput(source_string.to_string());
     let krate = driver::phase_1_parse_input(&sess, krate_config, &input);
     let (krate, ast_map) =
-        driver::phase_2_configure_and_expand(&sess, krate, "test")
+        driver::phase_2_configure_and_expand(&sess, krate, "test", None)
             .expect("phase 2 aborted");
 
     // run just enough stuff to build a tcx:

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -121,7 +121,7 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>)
                                      &input);
 
     let (krate, ast_map)
-        = phase_2_configure_and_expand(&sess, krate, name.as_slice())
+        = phase_2_configure_and_expand(&sess, krate, name.as_slice(), None)
             .expect("phase_2_configure_and_expand aborted in rustdoc!");
 
     let driver::driver::CrateAnalysis {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -69,7 +69,7 @@ pub fn run(input: &str,
     }));
     let krate = driver::phase_1_parse_input(&sess, cfg, &input);
     let (krate, _) = driver::phase_2_configure_and_expand(&sess, krate,
-                                                          "rustdoc-test")
+                                                          "rustdoc-test", None)
         .expect("phase_2_configure_and_expand aborted in rustdoc!");
 
     let ctx = box(GC) core::DocContext {
@@ -166,7 +166,7 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, should_fail: bool,
     let out = Some(outdir.path().clone());
     let cfg = config::build_configuration(&sess);
     let libdir = sess.target_filesearch().get_lib_path();
-    driver::compile_input(sess, cfg, &input, &out, &None);
+    driver::compile_input(sess, cfg, &input, &out, &None, None);
 
     if no_run { return }
 


### PR DESCRIPTION
This fixes some pain points I found while working on a tool that embeds rustc. These changes save me from copy-pasting 500 lines from rustc.

Two refactorings:
- `monitor` is public. Need it to run the compiler properly.
- Extracted parsing of the --crate-type argument.

Two minor features:
- The session's Option type takes an `alt_std_name` that can be used to override the crate that is automatically linked as `extern crate std = "name";`. I'm using this for customization.
- `compile_input` takes a `Option<Plugins>` to customize the compiler pipeline programmatically.

Neither of the two new features are exposed via command line flags since their general utility isn't obvious.
