### PR TITLE
Document Deque trait and bitv.

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -170,28 +170,6 @@ impl Bitv {
         }
     }
 
-    /**
-     * Calculates the union of two bitvectors
-     *
-     * Sets `self` to the union of `self` and `v1`. Both bitvectors must be
-     * the same length. Returns `true` if `self` changed.
-    */
-    #[inline]
-    pub fn union(&mut self, other: &Bitv) -> bool {
-        self.process(other, |w1, w2| w1 | w2)
-    }
-
-    /**
-     * Calculates the intersection of two bitvectors
-     *
-     * Sets `self` to the intersection of `self` and `v1`. Both bitvectors
-     * must be the same length. Returns `true` if `self` changed.
-    */
-    #[inline]
-    pub fn intersect(&mut self, other: &Bitv) -> bool {
-        self.process(other, |w1, w2| w1 & w2)
-    }
-
     /// Retrieve the value at index `i`
     #[inline]
     pub fn get(&self, i: uint) -> bool {
@@ -227,6 +205,28 @@ impl Bitv {
     #[inline]
     pub fn negate(&mut self) {
         for w in self.storage.mut_iter() { *w = !*w; }
+    }
+
+    /**
+     * Calculates the union of two bitvectors
+     *
+     * Sets `self` to the union of `self` and `v1`. Both bitvectors must be
+     * the same length. Returns `true` if `self` changed.
+    */
+    #[inline]
+    pub fn union(&mut self, other: &Bitv) -> bool {
+        self.process(other, |w1, w2| w1 | w2)
+    }
+
+    /**
+     * Calculates the intersection of two bitvectors
+     *
+     * Sets `self` to the intersection of `self` and `v1`. Both bitvectors
+     * must be the same length. Returns `true` if `self` changed.
+    */
+    #[inline]
+    pub fn intersect(&mut self, other: &Bitv) -> bool {
+        self.process(other, |w1, w2| w1 & w2)
     }
 
     /**

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -1124,6 +1124,35 @@ impl BitvSet {
         }
     }
 
+    /// Iterator over each uint stored in `self` intersect `other`.
+    /// See [intersect_with](#method.intersect_with) for an efficient in-place version.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::BitvSet;
+    /// use std::collections::bitv::from_bytes;
+    ///
+    /// let a = BitvSet::from_bitv(from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    ///
+    /// // Print 2
+    /// for x in a.intersection(&b) {
+    ///     println!("{}", x);
+    /// }
+    /// ```
+    #[inline]
+    pub fn intersection<'a>(&'a self, other: &'a BitvSet) -> Take<TwoBitPositions<'a>> {
+        let min = cmp::min(self.capacity(), other.capacity());
+        TwoBitPositions {
+            set: self,
+            other: other,
+            merge: |w1, w2| w1 & w2,
+            current_word: 0,
+            next_idx: 0
+        }.take(min)
+    }
+
     /// Iterator over each uint stored in the `self` setminus `other`.
     /// See [difference_with](#method.difference_with) for an efficient in-place version.
     ///
@@ -1186,35 +1215,6 @@ impl BitvSet {
             current_word: 0,
             next_idx: 0
         }
-    }
-
-    /// Iterator over each uint stored in `self` intersect `other`.
-    /// See [intersect_with](#method.intersect_with) for an efficient in-place version.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
-    ///
-    /// let a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
-    ///
-    /// // Print 2
-    /// for x in a.intersection(&b) {
-    ///     println!("{}", x);
-    /// }
-    /// ```
-    #[inline]
-    pub fn intersection<'a>(&'a self, other: &'a BitvSet) -> Take<TwoBitPositions<'a>> {
-        let min = cmp::min(self.capacity(), other.capacity());
-        TwoBitPositions {
-            set: self,
-            other: other,
-            merge: |w1, w2| w1 & w2,
-            current_word: 0,
-            next_idx: 0
-        }.take(min)
     }
 
     /// Union in-place with the specified other bit vector.

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -1450,11 +1450,13 @@ impl MutableSet<uint> for BitvSet {
     }
 }
 
+/// An iterator for `BitvSet`.
 pub struct BitPositions<'a> {
     set: &'a BitvSet,
     next_idx: uint
 }
 
+/// An iterator combining wo `BitvSet` iterators.
 pub struct TwoBitPositions<'a> {
     set: &'a BitvSet,
     other: &'a BitvSet,

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -98,7 +98,7 @@ enum BitvVariant { Big(BigBitv), Small(SmallBitv) }
 /// # Example
 ///
 /// ```rust
-/// use collections::bitv::Bitv;
+/// use collections::Bitv;
 ///
 /// let mut bv = Bitv::with_capacity(10, false);
 ///
@@ -249,9 +249,9 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let bv: Bitv = [false, true].iter().map(|n| *n).collect();
+    /// let bv = bitv::from_bytes([0b01100000]);
     /// assert_eq!(bv.get(0), false);
     /// assert_eq!(bv.get(1), true);
     ///
@@ -297,11 +297,15 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv: Bitv = [false, true, false].iter().map(|n| *n).collect();
+    /// let before = 0b01100000;
+    /// let after  = 0b11111111;
+    ///
+    /// let mut bv = bitv::from_bytes([before]);
     /// bv.set_all();
-    /// assert!(bv.eq_vec([true, true, true]));
+    /// assert_eq!(bv, bitv::from_bytes([after]));
+    /// ```
     #[inline]
     pub fn set_all(&mut self) {
         for w in self.storage.mut_iter() { *w = !0u; }
@@ -312,11 +316,15 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv: Bitv = [false, true, false].iter().map(|n| *n).collect();
+    /// let before = 0b01100000;
+    /// let after  = 0b10011111;
+    ///
+    /// let mut bv = bitv::from_bytes([before]);
     /// bv.negate();
-    /// assert!(bv.eq_vec([true, false, true]));
+    /// assert_eq!(bv, bitv::from_bytes([after]));
+    /// ```
     #[inline]
     pub fn negate(&mut self) {
         for w in self.storage.mut_iter() { *w = !*w; }
@@ -334,14 +342,17 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv1: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
-    /// let bv2: Bitv = [false, true, false, true].iter().map(|n| *n).collect();
-    /// let res: Bitv = [false, true, true, true].iter().map(|n| *n).collect();
+    /// let a   = 0b01100100;
+    /// let b   = 0b01011010;
+    /// let res = 0b01111110;
     ///
-    /// assert!(bv1.union(&bv2));
-    /// assert_eq!(bv1, res);
+    /// let mut a = bitv::from_bytes([a]);
+    /// let b = bitv::from_bytes([b]);
+    ///
+    /// assert!(a.union(&b));
+    /// assert_eq!(a, bitv::from_bytes([res]));
     /// ```
     #[inline]
     pub fn union(&mut self, other: &Bitv) -> bool {
@@ -360,14 +371,17 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv1: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
-    /// let bv2: Bitv = [false, true, false, true].iter().map(|n| *n).collect();
-    /// let res: Bitv = [false, true, false, false].iter().map(|n| *n).collect();
+    /// let a   = 0b01100100;
+    /// let b   = 0b01011010;
+    /// let res = 0b01000000;
     ///
-    /// assert!(bv1.intersect(&bv2));
-    /// assert_eq!(bv1, res);
+    /// let mut a = bitv::from_bytes([a]);
+    /// let b = bitv::from_bytes([b]);
+    ///
+    /// assert!(a.intersect(&b));
+    /// assert_eq!(a, bitv::from_bytes([res]));
     /// ```
     #[inline]
     pub fn intersect(&mut self, other: &Bitv) -> bool {
@@ -387,14 +401,24 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv1: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
-    /// let bv2: Bitv = [false, true, false, true].iter().map(|n| *n).collect();
-    /// let res: Bitv = [false, false, true, false].iter().map(|n| *n).collect();
+    /// let a   = 0b01100100;
+    /// let b   = 0b01011010;
+    /// let a_b = 0b00100100; // a - b
+    /// let b_a = 0b00011010; // b - a
     ///
-    /// assert!(bv1.difference(&bv2));
-    /// assert_eq!(bv1, res);
+    /// let mut bva = bitv::from_bytes([a]);
+    /// let bvb = bitv::from_bytes([b]);
+    ///
+    /// assert!(bva.difference(&bvb));
+    /// assert_eq!(bva, bitv::from_bytes([a_b]));
+    ///
+    /// let bva = bitv::from_bytes([a]);
+    /// let mut bvb = bitv::from_bytes([b]);
+    ///
+    /// assert!(bvb.difference(&bva));
+    /// assert_eq!(bvb, bitv::from_bytes([b_a]));
     /// ```
     #[inline]
     pub fn difference(&mut self, other: &Bitv) -> bool {
@@ -406,7 +430,7 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
     /// let mut bv = Bitv::with_capacity(5, true);
     /// assert_eq!(bv.all(), true);
@@ -429,16 +453,10 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv = Bitv::with_capacity(10, false);
-    /// bv.set(1, true);
-    /// bv.set(2, true);
-    /// bv.set(3, true);
-    /// bv.set(5, true);
-    /// bv.set(8, true);
-    ///
-    /// assert_eq!(bv.iter().filter(|x| *x).count(), 5);
+    /// let bv = bitv::from_bytes([0b01110100, 0b10010010]);
+    /// assert_eq!(bv.iter().filter(|x| *x).count(), 7);
     /// ```
     #[inline]
     pub fn iter<'a>(&'a self) -> Bits<'a> {
@@ -450,7 +468,7 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
     /// let mut bv = Bitv::with_capacity(10, false);
     /// assert_eq!(bv.none(), true);
@@ -467,7 +485,7 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
     /// let mut bv = Bitv::with_capacity(10, false);
     /// assert_eq!(bv.any(), false);
@@ -488,7 +506,7 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
     /// let mut bv = Bitv::with_capacity(3, true);
     /// bv.set(1, false);
@@ -530,10 +548,11 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let bv: Bitv = [true, false, true].iter().map(|n| *n).collect();
-    /// assert_eq!(bv.to_bools(), vec!(true, false, true));
+    /// let bv = bitv::from_bytes([0b10100000]);
+    /// assert_eq!(bv.to_bools(), vec!(true, false, true, false,
+    ///                                false, false, false, false));
     /// ```
     pub fn to_bools(&self) -> Vec<bool> {
         Vec::from_fn(self.nbits, |i| self.get(i))
@@ -548,11 +567,12 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let bv: Bitv = [false, true, true].iter().map(|n| *n).collect();
+    /// let bv = bitv::from_bytes([0b10100000]);
     ///
-    /// assert!(bv.eq_vec([false, true, true]));
+    /// assert!(bv.eq_vec([true, false, true, false,
+    ///                    false, false, false, false]));
     /// ```
     pub fn eq_vec(&self, v: &[bool]) -> bool {
         assert_eq!(self.nbits, v.len());
@@ -572,9 +592,9 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
+    /// let mut bv = bitv::from_bytes([0b01001011]);
     /// bv.truncate(2);
     /// assert!(bv.eq_vec([false, true]));
     /// ```
@@ -595,7 +615,7 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
     /// let mut bv = Bitv::with_capacity(3, false);
     /// bv.reserve(10);
@@ -616,7 +636,7 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
     /// let mut bv = Bitv::new();
     /// bv.reserve(10);
@@ -632,11 +652,12 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
+    /// let mut bv = bitv::from_bytes([0b01001011]);
     /// bv.grow(2, true);
-    /// assert!(bv.eq_vec([false, true, true, false, true, true]));
+    /// assert_eq!(bv.len(), 10);
+    /// assert_eq!(bv.to_bytes(), vec!(0b01001011, 0b11000000));
     /// ```
     pub fn grow(&mut self, n: uint, value: bool) {
         let new_nbits = self.nbits + n;
@@ -676,11 +697,13 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::bitv;
     ///
-    /// let mut bv: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
+    /// let mut bv = bitv::from_bytes([0b01001001]);
+    /// assert_eq!(bv.pop(), true);
     /// assert_eq!(bv.pop(), false);
-    /// assert!(bv.eq_vec([false, true, true]));
+    /// assert_eq!(bv.len(), 6);
+    /// assert_eq!(bv.to_bytes(), vec!(0b01001000));
     /// ```
     pub fn pop(&mut self) -> bool {
         let ret = self.get(self.nbits - 1);
@@ -697,12 +720,12 @@ impl Bitv {
     /// # Example
     ///
     /// ```
-    /// use std::collections::bitv::Bitv;
+    /// use std::collections::Bitv;
     ///
-    /// let mut bv: Bitv = [false, true].iter().map(|n| *n).collect();
+    /// let mut bv = Bitv::new();
     /// bv.push(true);
     /// bv.push(false);
-    /// assert!(bv.eq_vec([false, true, true, false]));
+    /// assert!(bv.eq_vec([true, false]));
     /// ```
     pub fn push(&mut self, elem: bool) {
         let insert_pos = self.nbits;
@@ -974,9 +997,9 @@ impl BitvSet {
     /// # Example
     ///
     /// ```
-    /// use std::collections::{Bitv, BitvSet};
+    /// use std::collections::{bitv, BitvSet};
     ///
-    /// let bv: Bitv = [false, true, true, false].iter().map(|n| *n).collect();
+    /// let bv = bitv::from_bytes([0b01100000]);
     /// let s = BitvSet::from_bitv(bv);
     ///
     /// // Print 1, 2 in arbitrary order
@@ -1279,11 +1302,15 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a   = 0b01101000;
+    /// let b   = 0b10100000;
+    /// let res = 0b11101000;
+    ///
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([a]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([b]));
     ///
     /// a.union_with(&b);
-    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b11101000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([res]));
     /// ```
     #[inline]
     pub fn union_with(&mut self, other: &BitvSet) {
@@ -1298,11 +1325,15 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a   = 0b01101000;
+    /// let b   = 0b10100000;
+    /// let res = 0b00100000;
+    ///
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([a]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([b]));
     ///
     /// a.intersect_with(&b);
-    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b00100000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([res]));
     /// ```
     #[inline]
     pub fn intersect_with(&mut self, other: &BitvSet) {
@@ -1317,11 +1348,22 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a   = 0b01101000;
+    /// let b   = 0b10100000;
+    /// let a_b = 0b01001000; // a - b
+    /// let b_a = 0b10000000; // b - a
     ///
-    /// a.difference_with(&b);
-    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b01001000]));
+    /// let mut bva = BitvSet::from_bitv(bitv::from_bytes([a]));
+    /// let bvb = BitvSet::from_bitv(bitv::from_bytes([b]));
+    ///
+    /// bva.difference_with(&bvb);
+    /// assert_eq!(bva.unwrap(), bitv::from_bytes([a_b]));
+    ///
+    /// let bva = BitvSet::from_bitv(bitv::from_bytes([a]));
+    /// let mut bvb = BitvSet::from_bitv(bitv::from_bytes([b]));
+    ///
+    /// bvb.difference_with(&bva);
+    /// assert_eq!(bvb.unwrap(), bitv::from_bytes([b_a]));
     /// ```
     #[inline]
     pub fn difference_with(&mut self, other: &BitvSet) {
@@ -1336,11 +1378,15 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a   = 0b01101000;
+    /// let b   = 0b10100000;
+    /// let res = 0b11001000;
+    ///
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([a]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([b]));
     ///
     /// a.symmetric_difference_with(&b);
-    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b11001000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([res]));
     /// ```
     #[inline]
     pub fn symmetric_difference_with(&mut self, other: &BitvSet) {

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -729,6 +729,18 @@ impl BitvSet {
         BitPositions {set: self, next_idx: 0}
     }
 
+    /// Iterator over each uint stored in `self` union `other`
+    #[inline]
+    pub fn union<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
+        TwoBitPositions {
+            set: self,
+            other: other,
+            merge: |w1, w2| w1 | w2,
+            current_word: 0,
+            next_idx: 0
+        }
+    }
+
     /// Iterator over each uint stored in the `self` setminus `other`
     #[inline]
     pub fn difference<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
@@ -764,18 +776,6 @@ impl BitvSet {
             current_word: 0,
             next_idx: 0
         }.take(min)
-    }
-
-    /// Iterator over each uint stored in `self` union `other`
-    #[inline]
-    pub fn union<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
-        TwoBitPositions {
-            set: self,
-            other: other,
-            merge: |w1, w2| w1 | w2,
-            current_word: 0,
-            next_idx: 0
-        }
     }
 
     /// Union in-place with the specified other bit vector

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -25,6 +25,8 @@
 //!
 //! // Store the primes as a BitvSet
 //! let primes = {
+//!     // Assume all numbers are prime to begin, and then we
+//!     // cross off non-primes progressively
 //!     let mut bv = Bitv::with_capacity(max_prime, true);
 //!
 //!     // Neither 0 nor 1 are prime
@@ -33,8 +35,8 @@
 //!
 //!     for i in range(2, max_prime) {
 //!         // if i is a prime
-//!         if bv.get(i) {
-//!             // mark all multiples of i as non-prime (any multiples below i * i
+//!         if bv[i] {
+//!             // Mark all multiples of i as non-prime (any multiples below i * i
 //!             // will have been marked as non-prime previously)
 //!             for j in iter::range_step(i * i, max_prime, i) { bv.set(j, false) }
 //!         }
@@ -252,6 +254,9 @@ impl Bitv {
     /// let bv: Bitv = [false, true].iter().map(|n| *n).collect();
     /// assert_eq!(bv.get(0), false);
     /// assert_eq!(bv.get(1), true);
+    ///
+    /// // Can also use array indexing
+    /// assert_eq!(bv[1], true);
     /// ```
     #[inline]
     pub fn get(&self, i: uint) -> bool {
@@ -275,7 +280,7 @@ impl Bitv {
     ///
     /// let mut bv = Bitv::with_capacity(5, false);
     /// bv.set(3, true);
-    /// assert_eq!(bv.get(3), true);
+    /// assert_eq!(bv[3], true);
     /// ```
     #[inline]
     pub fn set(&mut self, i: uint, x: bool) {
@@ -478,7 +483,7 @@ impl Bitv {
     /// Organise the bits into bytes, such that the first bit in the
     /// `Bitv` becomes the high-order bit of the first byte. If the
     /// size of the `Bitv` is not a multiple of 8 then trailing bits
-    /// will be filled-in with false/0.
+    /// will be filled-in with `false`.
     ///
     /// # Example
     ///
@@ -716,9 +721,9 @@ impl Bitv {
 /// # Example
 ///
 /// ```
-/// use std::collections::bitv::from_bytes;
+/// use std::collections::bitv;
 ///
-/// let bv = from_bytes([0b10100000, 0b00010010]);
+/// let bv = bitv::from_bytes([0b10100000, 0b00010010]);
 /// assert!(bv.eq_vec([true, false, true, false,
 ///                    false, false, false, false,
 ///                    false, false, false, true,
@@ -898,7 +903,7 @@ impl<'a> RandomAccessIterator<bool> for Bits<'a> {
 ///
 /// ```
 /// use std::collections::{BitvSet, Bitv};
-/// use std::collections::bitv::from_bytes;
+/// use std::collections::bitv;
 ///
 /// // It's a regular set
 /// let mut s = BitvSet::new();
@@ -913,7 +918,7 @@ impl<'a> RandomAccessIterator<bool> for Bits<'a> {
 /// }
 ///
 /// // Can initialize from a `Bitv`
-/// let other = BitvSet::from_bitv(from_bytes([0b11010000]));
+/// let other = BitvSet::from_bitv(bitv::from_bytes([0b11010000]));
 ///
 /// s.union_with(&other);
 ///
@@ -1048,7 +1053,7 @@ impl BitvSet {
     /// s.insert(0);
     ///
     /// let bv = s.get_ref();
-    /// assert_eq!(bv.get(0), true);
+    /// assert_eq!(bv[0], true);
     /// ```
     #[inline]
     pub fn get_ref<'a>(&'a self) -> &'a Bitv {
@@ -1131,9 +1136,9 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let s = BitvSet::from_bitv(from_bytes([0b01001010]));
+    /// let s = BitvSet::from_bitv(bitv::from_bytes([0b01001010]));
     ///
     /// // Print 1, 4, 6 in arbitrary order
     /// for x in s.iter() {
@@ -1152,10 +1157,10 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// // Print 0, 1, 2, 4 in arbitrary order
     /// for x in a.union(&b) {
@@ -1180,10 +1185,10 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// // Print 2
     /// for x in a.intersection(&b) {
@@ -1209,10 +1214,10 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// // Print 2, 4 in arbitrary order
     /// for x in a.difference(&b) {
@@ -1245,10 +1250,10 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// // Print 0, 1, 4 in arbitrary order
     /// for x in a.symmetric_difference(&b) {
@@ -1272,13 +1277,13 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// a.union_with(&b);
-    /// assert_eq!(a.unwrap(), from_bytes([0b11101000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b11101000]));
     /// ```
     #[inline]
     pub fn union_with(&mut self, other: &BitvSet) {
@@ -1291,13 +1296,13 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// a.intersect_with(&b);
-    /// assert_eq!(a.unwrap(), from_bytes([0b00100000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b00100000]));
     /// ```
     #[inline]
     pub fn intersect_with(&mut self, other: &BitvSet) {
@@ -1310,13 +1315,13 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// a.difference_with(&b);
-    /// assert_eq!(a.unwrap(), from_bytes([0b01001000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b01001000]));
     /// ```
     #[inline]
     pub fn difference_with(&mut self, other: &BitvSet) {
@@ -1329,13 +1334,13 @@ impl BitvSet {
     ///
     /// ```
     /// use std::collections::BitvSet;
-    /// use std::collections::bitv::from_bytes;
+    /// use std::collections::bitv;
     ///
-    /// let mut a = BitvSet::from_bitv(from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(from_bytes([0b10100000]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
     ///
     /// a.symmetric_difference_with(&b);
-    /// assert_eq!(a.unwrap(), from_bytes([0b11001000]));
+    /// assert_eq!(a.unwrap(), bitv::from_bytes([0b11001000]));
     /// ```
     #[inline]
     pub fn symmetric_difference_with(&mut self, other: &BitvSet) {

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -8,6 +8,55 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Collections implemented with bit vectors.
+//!
+//! # Example
+//!
+//! This is a simple example of the [Sieve of Eratosthenes][sieve]
+//! which calculates prime numbers up to a given limit.
+//!
+//! [sieve]: http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
+//!
+//! ```
+//! use std::collections::{BitvSet, Bitv};
+//! use std::iter;
+//!
+//! let max_prime = 10000;
+//!
+//! // Store the primes as a BitvSet
+//! let primes = {
+//!     let mut bv = Bitv::with_capacity(max_prime, true);
+//!
+//!     // Neither 0 nor 1 are prime
+//!     bv.set(0, false);
+//!     bv.set(1, false);
+//!
+//!     for i in range(2, max_prime) {
+//!         // if i is a prime
+//!         if bv.get(i) {
+//!             // mark all multiples of i as non-prime (any multiples below i * i
+//!             // will have been marked as non-prime previously)
+//!             for j in iter::range_step(i * i, max_prime, i) { bv.set(j, false) }
+//!         }
+//!     }
+//!     BitvSet::from_bitv(bv)
+//! };
+//!
+//! // Simple primality tests below our max bound
+//! let print_primes = 20;
+//! print!("The primes below {} are: ", print_primes);
+//! for x in range(0, print_primes) {
+//!     if primes.contains(&x) {
+//!         print!("{} ", x);
+//!     }
+//! }
+//! println!("");
+//!
+//! // We can manipulate the internal Bitv
+//! let num_primes = primes.get_ref().iter().filter(|x| *x).count();
+//! println!("There are {} primes below {}", num_primes, max_prime);
+//! ```
+
 #![allow(missing_doc)]
 
 use core::prelude::*;

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -723,30 +723,6 @@ impl BitvSet {
         bitv.nbits = trunc_len * uint::BITS;
     }
 
-    /// Union in-place with the specified other bit vector
-    #[inline]
-    pub fn union_with(&mut self, other: &BitvSet) {
-        self.other_op(other, |w1, w2| w1 | w2);
-    }
-
-    /// Intersect in-place with the specified other bit vector
-    #[inline]
-    pub fn intersect_with(&mut self, other: &BitvSet) {
-        self.other_op(other, |w1, w2| w1 & w2);
-    }
-
-    /// Difference in-place with the specified other bit vector
-    #[inline]
-    pub fn difference_with(&mut self, other: &BitvSet) {
-        self.other_op(other, |w1, w2| w1 & !w2);
-    }
-
-    /// Symmetric difference in-place with the specified other bit vector
-    #[inline]
-    pub fn symmetric_difference_with(&mut self, other: &BitvSet) {
-        self.other_op(other, |w1, w2| w1 ^ w2);
-    }
-
     /// Iterator over each uint stored in the BitvSet
     #[inline]
     pub fn iter<'a>(&'a self) -> BitPositions<'a> {
@@ -800,6 +776,30 @@ impl BitvSet {
             current_word: 0,
             next_idx: 0
         }
+    }
+
+    /// Union in-place with the specified other bit vector
+    #[inline]
+    pub fn union_with(&mut self, other: &BitvSet) {
+        self.other_op(other, |w1, w2| w1 | w2);
+    }
+
+    /// Intersect in-place with the specified other bit vector
+    #[inline]
+    pub fn intersect_with(&mut self, other: &BitvSet) {
+        self.other_op(other, |w1, w2| w1 & w2);
+    }
+
+    /// Difference in-place with the specified other bit vector
+    #[inline]
+    pub fn difference_with(&mut self, other: &BitvSet) {
+        self.other_op(other, |w1, w2| w1 & !w2);
+    }
+
+    /// Symmetric difference in-place with the specified other bit vector
+    #[inline]
+    pub fn symmetric_difference_with(&mut self, other: &BitvSet) {
+        self.other_op(other, |w1, w2| w1 ^ w2);
     }
 }
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -154,33 +154,196 @@ pub trait MutableSet<T>: Set<T> + Mutable {
 
 /// A double-ended sequence that allows querying, insertion and deletion at both
 /// ends.
+///
+/// # Example
+///
+/// With a `Deque` we can simulate a stack:
+///
+/// ```
+/// use std::collections::{RingBuf, Deque};
+///
+/// let mut stack = RingBuf::new();
+/// stack.push_front(1i);
+/// stack.push_front(2i);
+/// stack.push_front(3i);
+///
+/// // Will print 3, 2, 1
+/// while !stack.is_empty() {
+///     let x = stack.pop_front().unwrap();
+///     println!("{}", x);
+/// }
+/// ```
+///
+/// We can simulate a queue:
+///
+/// ```
+/// use std::collections::{RingBuf, Deque};
+///
+/// let mut queue = RingBuf::new();
+/// queue.push_back(1i);
+/// queue.push_back(2i);
+/// queue.push_back(3i);
+///
+/// // Will print 1, 2, 3
+/// while !queue.is_empty() {
+///     let x = queue.pop_front().unwrap();
+///     println!("{}", x);
+/// }
+/// ```
+///
+/// And of course we can mix and match:
+///
+/// ```
+/// use std::collections::{DList, Deque};
+///
+/// let mut deque = DList::new();
+///
+/// // Init deque with 1, 2, 3, 4
+/// deque.push_front(2i);
+/// deque.push_front(1i);
+/// deque.push_back(3i);
+/// deque.push_back(4i);
+///
+/// // Will print (1, 4) and (2, 3)
+/// while !deque.is_empty() {
+///     let f = deque.pop_front().unwrap();
+///     let b = deque.pop_back().unwrap();
+///     println!("{}", (f, b));
+/// }
+/// ```
 pub trait Deque<T> : Mutable {
-    /// Provide a reference to the front element, or None if the sequence is
-    /// empty
+    /// Provide a reference to the front element, or `None` if the sequence is.
+    /// empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{RingBuf, Deque};
+    ///
+    /// let mut d = RingBuf::new();
+    /// assert_eq!(d.front(), None);
+    ///
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    /// assert_eq!(d.front(), Some(&1i));
+    /// ```
     fn front<'a>(&'a self) -> Option<&'a T>;
 
-    /// Provide a mutable reference to the front element, or None if the
-    /// sequence is empty
+    /// Provide a mutable reference to the front element, or `None` if the
+    /// sequence is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{RingBuf, Deque};
+    ///
+    /// let mut d = RingBuf::new();
+    /// assert_eq!(d.front_mut(), None);
+    ///
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    /// match d.front_mut() {
+    ///     Some(x) => *x = 9i,
+    ///     None => (),
+    /// }
+    /// assert_eq!(d.front(), Some(&9i));
+    /// ```
     fn front_mut<'a>(&'a mut self) -> Option<&'a mut T>;
 
     /// Provide a reference to the back element, or None if the sequence is
-    /// empty
+    /// empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{DList, Deque};
+    ///
+    /// let mut d = DList::new();
+    /// assert_eq!(d.back(), None);
+    ///
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    /// assert_eq!(d.back(), Some(&2i));
+    /// ```
     fn back<'a>(&'a self) -> Option<&'a T>;
 
     /// Provide a mutable reference to the back element, or None if the sequence
-    /// is empty
+    /// is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{DList, Deque};
+    ///
+    /// let mut d = DList::new();
+    /// assert_eq!(d.back(), None);
+    ///
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    /// match d.back_mut() {
+    ///     Some(x) => *x = 9i,
+    ///     None => (),
+    /// }
+    /// assert_eq!(d.back(), Some(&9i));
+    /// ```
     fn back_mut<'a>(&'a mut self) -> Option<&'a mut T>;
 
-    /// Insert an element first in the sequence
+    /// Insert an element first in the sequence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{DList, Deque};
+    ///
+    /// let mut d = DList::new();
+    /// d.push_front(1i);
+    /// d.push_front(2i);
+    /// assert_eq!(d.front(), Some(&2i));
     fn push_front(&mut self, elt: T);
 
-    /// Insert an element last in the sequence
+    /// Insert an element last in the sequence.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{DList, Deque};
+    ///
+    /// let mut d = DList::new();
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    /// assert_eq!(d.front(), Some(&1i));
     fn push_back(&mut self, elt: T);
 
-    /// Remove the last element and return it, or None if the sequence is empty
+    /// Remove the last element and return it, or None if the sequence is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{RingBuf, Deque};
+    ///
+    /// let mut d = RingBuf::new();
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    ///
+    /// assert_eq!(d.pop_back(), Some(2i));
+    /// assert_eq!(d.pop_back(), Some(1i));
+    /// assert_eq!(d.pop_back(), None);
     fn pop_back(&mut self) -> Option<T>;
 
-    /// Remove the first element and return it, or None if the sequence is empty
+    /// Remove the first element and return it, or None if the sequence is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::{RingBuf, Deque};
+    ///
+    /// let mut d = RingBuf::new();
+    /// d.push_back(1i);
+    /// d.push_back(2i);
+    ///
+    /// assert_eq!(d.pop_front(), Some(1i));
+    /// assert_eq!(d.pop_front(), Some(2i));
+    /// assert_eq!(d.pop_front(), None);
     fn pop_front(&mut self) -> Option<T>;
 }
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -250,7 +250,7 @@ pub trait Deque<T> : Mutable {
     /// ```
     fn front_mut<'a>(&'a mut self) -> Option<&'a mut T>;
 
-    /// Provide a reference to the back element, or None if the sequence is
+    /// Provide a reference to the back element, or `None` if the sequence is
     /// empty.
     ///
     /// # Example
@@ -267,7 +267,7 @@ pub trait Deque<T> : Mutable {
     /// ```
     fn back<'a>(&'a self) -> Option<&'a T>;
 
-    /// Provide a mutable reference to the back element, or None if the sequence
+    /// Provide a mutable reference to the back element, or `None` if the sequence
     /// is empty.
     ///
     /// # Example
@@ -314,7 +314,7 @@ pub trait Deque<T> : Mutable {
     /// assert_eq!(d.front(), Some(&1i));
     fn push_back(&mut self, elt: T);
 
-    /// Remove the last element and return it, or None if the sequence is empty.
+    /// Remove the last element and return it, or `None` if the sequence is empty.
     ///
     /// # Example
     ///
@@ -330,7 +330,7 @@ pub trait Deque<T> : Mutable {
     /// assert_eq!(d.pop_back(), None);
     fn pop_back(&mut self) -> Option<T>;
 
-    /// Remove the first element and return it, or None if the sequence is empty.
+    /// Remove the first element and return it, or `None` if the sequence is empty.
     ///
     /// # Example
     ///

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -157,24 +157,7 @@ pub trait MutableSet<T>: Set<T> + Mutable {
 ///
 /// # Example
 ///
-/// With a `Deque` we can simulate a stack:
-///
-/// ```
-/// use std::collections::{RingBuf, Deque};
-///
-/// let mut stack = RingBuf::new();
-/// stack.push_front(1i);
-/// stack.push_front(2i);
-/// stack.push_front(3i);
-///
-/// // Will print 3, 2, 1
-/// while !stack.is_empty() {
-///     let x = stack.pop_front().unwrap();
-///     println!("{}", x);
-/// }
-/// ```
-///
-/// We can simulate a queue:
+/// With a `Deque` we can simulate a queue efficiently:
 ///
 /// ```
 /// use std::collections::{RingBuf, Deque};
@@ -187,6 +170,23 @@ pub trait MutableSet<T>: Set<T> + Mutable {
 /// // Will print 1, 2, 3
 /// while !queue.is_empty() {
 ///     let x = queue.pop_front().unwrap();
+///     println!("{}", x);
+/// }
+/// ```
+///
+/// We can also simulate a stack:
+///
+/// ```
+/// use std::collections::{RingBuf, Deque};
+///
+/// let mut stack = RingBuf::new();
+/// stack.push_front(1i);
+/// stack.push_front(2i);
+/// stack.push_front(3i);
+///
+/// // Will print 3, 2, 1
+/// while !stack.is_empty() {
+///     let x = stack.pop_front().unwrap();
 ///     println!("{}", x);
 /// }
 /// ```
@@ -212,7 +212,7 @@ pub trait MutableSet<T>: Set<T> + Mutable {
 /// }
 /// ```
 pub trait Deque<T> : Mutable {
-    /// Provide a reference to the front element, or `None` if the sequence is.
+    /// Provide a reference to the front element, or `None` if the sequence is
     /// empty.
     ///
     /// # Example
@@ -299,6 +299,7 @@ pub trait Deque<T> : Mutable {
     /// d.push_front(1i);
     /// d.push_front(2i);
     /// assert_eq!(d.front(), Some(&2i));
+    /// ```
     fn push_front(&mut self, elt: T);
 
     /// Insert an element last in the sequence.
@@ -312,6 +313,7 @@ pub trait Deque<T> : Mutable {
     /// d.push_back(1i);
     /// d.push_back(2i);
     /// assert_eq!(d.front(), Some(&1i));
+    /// ```
     fn push_back(&mut self, elt: T);
 
     /// Remove the last element and return it, or `None` if the sequence is empty.
@@ -328,6 +330,7 @@ pub trait Deque<T> : Mutable {
     /// assert_eq!(d.pop_back(), Some(2i));
     /// assert_eq!(d.pop_back(), Some(1i));
     /// assert_eq!(d.pop_back(), None);
+    /// ```
     fn pop_back(&mut self) -> Option<T>;
 
     /// Remove the first element and return it, or `None` if the sequence is empty.
@@ -344,6 +347,7 @@ pub trait Deque<T> : Mutable {
     /// assert_eq!(d.pop_front(), Some(1i));
     /// assert_eq!(d.pop_front(), Some(2i));
     /// assert_eq!(d.pop_front(), None);
+    /// ```
     fn pop_front(&mut self) -> Option<T>;
 }
 


### PR DESCRIPTION
Examples for `Deque`, `Bitv` and `BitvSet`. Normalize documentation style and some source code reorganization.
