### PR TITLE
Allow generic foreign functions.

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1755,7 +1755,8 @@ fn encode_reachable_extern_fns(ecx: &EncodeContext, rbml_w: &mut Encoder) {
         match ecx.tcx.map.find(*id) {
             Some(ast_map::NodeItem(i)) => {
                 match i.node {
-                    ast::ItemFn(_, _, abi, _, _) if abi != abi::Rust => {
+                    ast::ItemFn(_, _, abi, ref generics, _)
+                                if abi != abi::Rust && !generics.is_type_parameterized() => {
                         rbml_w.wr_tagged_u32(tag_reachable_extern_fn_id, *id);
                     }
                     _ => {}

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -444,17 +444,6 @@ pub fn ensure_no_ty_param_bounds(ccx: &CrateCtxt,
     }
 }
 
-fn ensure_generics_abi(ccx: &CrateCtxt,
-                       span: Span,
-                       abi: abi::Abi,
-                       generics: &ast::Generics) {
-    if generics.ty_params.len() > 0 &&
-       !(abi == abi::Rust || abi == abi::RustIntrinsic) {
-        span_err!(ccx.tcx.sess, span, E0123,
-                  "foreign functions may not use type parameters");
-    }
-}
-
 pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
     let tcx = ccx.tcx;
     debug!("convert: item {} with id {}", token::get_ident(it.ident), it.id);
@@ -572,13 +561,8 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
         },
         ast::ItemTy(_, ref generics) => {
             ensure_no_ty_param_bounds(ccx, it.span, generics, "type");
-            let pty = ty_of_item(ccx, it);
-            write_ty_to_tcx(tcx, it.id, pty.ty);
-        },
-        ast::ItemFn(_, _, abi, ref generics, _) => {
-            ensure_generics_abi(ccx, it.span, abi, generics);
-            let pty = ty_of_item(ccx, it);
-            write_ty_to_tcx(tcx, it.id, pty.ty);
+            let tpt = ty_of_item(ccx, it);
+            write_ty_to_tcx(tcx, it.id, tpt.ty);
         },
         _ => {
             // This call populates the type cache with the converted type

--- a/src/test/compile-fail/generic-no-mangle.rs
+++ b/src/test/compile-fail/generic-no-mangle.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-test this should fail to compile (#15844)
+
+#[no_mangle]
+fn foo<T>() {} //~ ERROR generic functions must be mangled
+
+#[no_mangle]
+extern fn foo<T>() {} //~ ERROR generic functions must be mangled
+

--- a/src/test/run-make/extern-fn-generic/Makefile
+++ b/src/test/run-make/extern-fn-generic/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+all:
+	$(CC) -std=c99 test.c -c -o $(TMPDIR)/test.o
+	$(AR) rcs $(TMPDIR)/libtest.a $(TMPDIR)/test.o
+	$(RUSTC) testcrate.rs -L $(TMPDIR)
+	$(RUSTC) test.rs -L $(TMPDIR)
+	$(call RUN,test) || exit 1

--- a/src/test/run-make/extern-fn-generic/test.c
+++ b/src/test/run-make/extern-fn-generic/test.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+typedef struct TestStruct {
+	uint8_t x;
+	int32_t y;
+} TestStruct;
+
+typedef int callback(TestStruct s);
+
+uint32_t call(callback *c) {
+	TestStruct s;
+	s.x = 'a';
+	s.y = 3;
+
+	return c(s);
+}

--- a/src/test/run-make/extern-fn-generic/test.rs
+++ b/src/test/run-make/extern-fn-generic/test.rs
@@ -8,10 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate testcrate;
+
+extern "C" fn bar<T>(ts: testcrate::TestStruct<T>) -> T { ts.y }
+
+#[link(name = "test")]
 extern {
-    fn foo<T>(); //~ ERROR foreign items may not have type parameters
+    fn call(c: extern "C" fn(testcrate::TestStruct<i32>) -> i32) -> i32;
 }
 
 fn main() {
-    foo::<i32>();
+    // Let's test calling it cross crate
+    let back = unsafe {
+        testcrate::call(testcrate::foo::<i32>)
+    };
+    assert_eq!(3, back);
+
+    // And just within this crate
+    let back = unsafe {
+        call(bar::<i32>)
+    };
+    assert_eq!(3, back);
 }

--- a/src/test/run-make/extern-fn-generic/testcrate.rs
+++ b/src/test/run-make/extern-fn-generic/testcrate.rs
@@ -8,10 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern {
-    fn foo<T>(); //~ ERROR foreign items may not have type parameters
+#![crate_type = "lib"]
+
+#[repr(C)]
+pub struct TestStruct<T> {
+    pub x: u8,
+    pub y: T
 }
 
-fn main() {
-    foo::<i32>();
+pub extern "C" fn foo<T>(ts: TestStruct<T>) -> T { ts.y }
+
+#[link(name = "test")]
+extern {
+    pub fn call(c: extern "C" fn(TestStruct<i32>) -> i32) -> i32;
 }

--- a/src/test/run-make/extern-fn-mangle/Makefile
+++ b/src/test/run-make/extern-fn-mangle/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	$(CC) -std=c99 test.c -c -o $(TMPDIR)/test.o
+	$(AR) rcs $(TMPDIR)/libtest.a $(TMPDIR)/test.o
+	$(RUSTC) test.rs -L $(TMPDIR)
+	$(call RUN,test) || exit 1

--- a/src/test/run-make/extern-fn-mangle/test.c
+++ b/src/test/run-make/extern-fn-mangle/test.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+uint32_t foo();
+uint32_t bar();
+
+uint32_t add() {
+	return foo() + bar();
+}

--- a/src/test/run-make/extern-fn-mangle/test.rs
+++ b/src/test/run-make/extern-fn-mangle/test.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[no_mangle]
+pub extern "C" fn foo() -> i32 { 3 }
+
+#[no_mangle]
+pub extern "C" fn bar() -> i32 { 5 }
+
+#[link(name = "test", kind = "static")]
+extern {
+    fn add() -> i32;
+}
+
+fn main() {
+    let back = unsafe { add() };
+    assert_eq!(8, back);
+}

--- a/src/test/run-pass/generic-extern-mangle.rs
+++ b/src/test/run-pass/generic-extern-mangle.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern {
-    fn foo<T>(); //~ ERROR foreign items may not have type parameters
-}
+extern "C" fn foo<T: Int>(a: T, b: T) -> T { a + b }
 
 fn main() {
-    foo::<i32>();
+    assert_eq!(99u8, foo(255u8, 100u8));
+    assert_eq!(99u16, foo(65535u16, 100u16));
 }


### PR DESCRIPTION
This allows for things like this:

```
extern "C" fn callback<T>(t: T) { /* ... */ }
extern "C" {
    fn take_callback(c: extern fn(i32));
}
```

and later:

```
take_callback(callback::<i32>);
```

Closes #12502.
