### PR TITLE
Purge #[!resolve_unexported] from the compiler

### DIFF
--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -152,8 +152,10 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
         for i in mod_folded.items.mut_iter() {
             *i = nomain(*i);
         }
-        mod_folded.items.push(mk_reexport_mod(&mut self.cx, reexports));
-        self.cx.reexports.push(self.cx.path.clone());
+        if !reexports.is_empty() {
+            mod_folded.items.push(mk_reexport_mod(&mut self.cx, reexports));
+            self.cx.reexports.push(self.cx.path.clone());
+        }
 
         mod_folded
     }

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -27,7 +27,6 @@ use util::nodemap::{NodeMap, NodeSet};
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::{is_local, local_def, PostExpansionMethod};
-use syntax::attr;
 use syntax::codemap::Span;
 use syntax::parse::token;
 use syntax::owned_slice::OwnedSlice;
@@ -786,12 +785,6 @@ impl<'a> PrivacyVisitor<'a> {
 
 impl<'a> Visitor<()> for PrivacyVisitor<'a> {
     fn visit_item(&mut self, item: &ast::Item, _: ()) {
-        // Do not check privacy inside items with the resolve_unexported
-        // attribute. This is used for the test runner.
-        if attr::contains_name(item.attrs.as_slice(), "!resolve_unexported") {
-            return;
-        }
-
         let orig_curitem = replace(&mut self.curitem, item.id);
         visit::walk_item(self, item, ());
         self.curitem = orig_curitem;


### PR DESCRIPTION
This rewrites the test harness generation to create modules that reexport things as needed to make sure all tests are visible.
