### PR TITLE
Allow macros in type expressions

### DIFF
--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -859,6 +859,9 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                     }
                 }
             }
+            ast::TyMac(ref _mac) => {
+                tcx.sess.span_bug(ast_ty.span, "type macro not expanded");
+            }
             ast::TyTypeof(_e) => {
                 tcx.sess.span_bug(ast_ty.span, "typeof is reserved but unimplemented");
             }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -859,6 +859,7 @@ pub enum Ty_ {
     TyPath(Path, Option<OwnedSlice<TyParamBound>>, NodeId), // for #7264; see above
     /// No-op; kept solely so that we can pretty-print faithfully
     TyParen(P<Ty>),
+    TyMac(Mac),
     TyTypeof(Gc<Expr>),
     /// TyInfer means the type should be inferred instead of it having been
     /// specified. This can appear anywhere in a type.

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -114,6 +114,10 @@ pub trait MacResult {
     fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         None
     }
+    /// Create an type.
+    fn make_ty(&self) -> Option<Gc<ast::Ty>> {
+        None
+    }
     /// Create zero or more items.
     fn make_items(&self) -> Option<SmallVector<Gc<ast::Item>>> {
         None
@@ -151,6 +155,20 @@ impl MacExpr {
 impl MacResult for MacExpr {
     fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         Some(self.e)
+    }
+}
+/// A convenience type for macros that return a single type.
+pub struct MacTy {
+    t: Gc<ast::Ty>,
+}
+impl MacTy {
+    pub fn new(t: Gc<ast::Ty>) -> Box<MacResult> {
+        box MacTy { t: t } as Box<MacResult>
+    }
+}
+impl MacResult for MacTy {
+    fn make_ty(&self) -> Option<Gc<ast::Ty>> {
+        Some(self.t)
     }
 }
 /// A convenience type for macros that return a single pattern.
@@ -223,6 +241,15 @@ impl DummyResult {
         }
     }
 
+    /// A plain dummy type.
+    pub fn raw_ty(sp: Span) -> Gc<ast::Ty> {
+        box(GC) ast::Ty {
+            id: ast::DUMMY_NODE_ID,
+            node: ast::TyNil, // FIXME: Is this suitable?
+            span: sp,
+        }
+    }
+
     /// A plain dummy pattern.
     pub fn raw_pat(sp: Span) -> Gc<ast::Pat> {
         box(GC) ast::Pat {
@@ -237,6 +264,9 @@ impl DummyResult {
 impl MacResult for DummyResult {
     fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         Some(DummyResult::raw_expr(self.span))
+    }
+    fn make_ty(&self) -> Option<Gc<ast::Ty>> {
+        Some(DummyResult::raw_ty(self.span))
     }
     fn make_pat(&self) -> Option<Gc<ast::Pat>> {
         Some(DummyResult::raw_pat(self.span))

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -59,6 +59,11 @@ impl<'a> ParserAnyMacro<'a> {
 }
 
 impl<'a> MacResult for ParserAnyMacro<'a> {
+    fn make_ty(&self) -> Option<Gc<ast::Ty>> {
+        let ret = self.parser.borrow_mut().parse_ty(true); // Allow plus in types?
+        self.ensure_complete_parse(true);
+        Some(ret)
+    }
     fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         let ret = self.parser.borrow_mut().parse_expr();
         self.ensure_complete_parse(true);

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -580,6 +580,9 @@ impl<'a> State<'a> {
             ast::TyPath(ref path, ref bounds, _) => {
                 try!(self.print_bounded_path(path, bounds));
             }
+            ast::TyMac(ref mac) => {
+                try!(self.print_mac(mac));
+            }
             ast::TyFixedLengthVec(ref ty, ref v) => {
                 try!(word(&mut self.s, "["));
                 try!(self.print_type(&**ty));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -412,6 +412,9 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
                 walk_ty_param_bounds(visitor, bounds, env.clone())
             }
         }
+        TyMac(ref macro) => {
+            visitor.visit_mac(macro, env.clone());
+        }
         TyFixedLengthVec(ref ty, ref expression) => {
             visitor.visit_ty(&**ty, env.clone());
             visitor.visit_expr(&**expression, env)

--- a/src/test/run-pass/macro-type.rs
+++ b/src/test/run-pass/macro-type.rs
@@ -1,0 +1,53 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+struct Nested<T> {
+    _f: T
+}
+
+macro_rules! int_type(
+    () => (
+        int
+    )
+)
+
+macro_rules! nested_type(
+    ($x:ty) => (
+        Nested<$x>
+    )
+)
+
+macro_rules! indirect(
+    () => (
+        nested_type!(int_type!())
+    )
+)
+
+macro_rules! ident_type(
+    ($x:ident) => (
+        $x
+    )
+)
+
+pub fn main() {
+    let a: int_type!();
+    let _: int = a;
+
+    let b: nested_type!(bool);
+    let _: Nested<bool> = b;
+
+    let c: indirect!();
+    let _: Nested<int> = c;
+
+    let d: ident_type!(u32);
+    let _: u32 = d;
+}


### PR DESCRIPTION
This allows you to use macros to write out your awfully long types.
