### PR TITLE
Use fewer instructions for `fail!()`

### DIFF
--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -33,7 +33,7 @@ extern crate collections;
 #[cfg(test)] #[phase(plugin, link)] extern crate std;
 
 pub use self::util::{Stdio, Stdout, Stderr};
-pub use self::unwind::{begin_unwind, begin_unwind_fmt};
+pub use self::unwind::{begin_unwind, begin_unwind_fmt, begin_unwind_no_time_to_explain};
 
 use core::prelude::*;
 

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -432,6 +432,11 @@ pub fn begin_unwind<M: Any + Send>(msg: M, file: &'static str, line: uint) -> ! 
     begin_unwind_inner(box msg, file, line)
 }
 
+/// Unwinding for `fail!()`. Saves passing a string.
+#[inline(never)] #[cold] #[experimental]
+pub fn begin_unwind_no_time_to_explain(file: &'static str, line: uint) -> ! {
+    begin_unwind_inner(box () ("explicit failure"), file, line)
+}
 
 /// The core of the unwinding.
 ///

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -39,7 +39,7 @@
 #[macro_export]
 macro_rules! fail(
     () => (
-        fail!("explicit failure")
+        ::std::rt::begin_unwind_no_time_to_explain(file!(), line!())
     );
     ($msg:expr) => (
         ::std::rt::begin_unwind($msg, file!(), line!())

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -66,7 +66,8 @@ pub use self::util::{default_sched_threads, min_stack, running_on_valgrind};
 // standard library which work together to create the entire runtime.
 pub use alloc::{heap, libc_heap};
 pub use rustrt::{task, local, mutex, exclusive, stack, args, rtio, thread};
-pub use rustrt::{Stdio, Stdout, Stderr, begin_unwind, begin_unwind_fmt};
+pub use rustrt::{Stdio, Stdout, Stderr};
+pub use rustrt::{begin_unwind, begin_unwind_fmt, begin_unwind_no_time_to_explain};
 pub use rustrt::{bookkeeping, at_exit, unwind, DEFAULT_ERROR_CODE, Runtime};
 
 // Simple backtrace functionality (to print on failure)


### PR DESCRIPTION
Adds a new runtime unwinding function that encapsulates the printing of the words "explicit failure" when `fail!()` is called w/o arguments.

The before/after optimized assembly:

```
        leaq    "str\"str\"(1412)"(%rip), %rax
        movq    %rax, 24(%rsp)
        movq    $16, 32(%rsp)
        leaq    "str\"str\"(1413)"(%rip), %rax
        movq    %rax, 8(%rsp)
        movq    $19, 16(%rsp)
        leaq    24(%rsp), %rdi
        leaq    8(%rsp), %rsi
        movl    $11, %edx
        callq   _ZN6unwind12begin_unwind21h15836560661922107792E
```

```
        leaq    "str\"str\"(1369)"(%rip), %rax
        movq    %rax, 8(%rsp)
        movq    $19, 16(%rsp)
        leaq    8(%rsp), %rdi
        movl    $11, %esi
        callq   _ZN6unwind31begin_unwind_no_time_to_explain20hd1c720cdde6a116480dE@PLT
```

Before/after filesizes:

rwxrwxr-x 1 brian brian 21479503 Jul 20 22:09 stage2-old/lib/librustc-4e7c5e5c.so
rwxrwxr-x 1 brian brian 21475415 Jul 20 22:30 x86_64-unknown-linux-gnu/stage2/lib/librustc-4e7c5e5c.so

This is the lowest-hanging fruit in the fail-bloat wars. Further fixes are going to require harder tradeoffs.

r? @pcwalton
