### PR TITLE
lint: Improve ffi-unsafe enum lint warning

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -358,9 +358,9 @@ impl LintPass for CTypes {
                         def::DefTy(def_id) => {
                             if !adt::is_ffi_safe(cx.tcx, def_id) {
                                 cx.span_lint(CTYPES, ty.span,
-                                             "found enum type without foreign-function-safe \
-                                              representation annotation in foreign module");
-                                // hmm... this message could be more helpful
+                                             "found enum type without foreign-function-safe
+                                             representation annotation in foreign module, consider \
+                                             adding a #[repr(...)] attribute to the enumeration");
                             }
                         }
                         _ => ()


### PR DESCRIPTION
I think this is an improvement of the previous warning message, which
- like the comment that I removed implies - is in need of some
  improvement.
  I've opted to point the user in the right direction w.r.t how to fix the
  problem, which I think is good form.

Not being familiar with the repr(...) attribute, I personally had to
check the lint rules myself to figure out what was wrong. Hopefully,
this will save he next person some time and headache.

Signed-off-by: Anton Lofgren alofgren@op5.com
