### PR TITLE
Remove unnecessary cast from intro

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -276,7 +276,7 @@ fn main() {
 
         spawn(proc() {
             let numbers = rx.recv();
-            println!("{:d}", numbers[num as uint]);
+            println!("{:d}", numbers[num]);
         })
     }
 }


### PR DESCRIPTION
Tested this on the playground, the range specifies range(0u, 3), so it should be okay to remove this cast.
