### PR TITLE
Improve usage of lifetime intrinsics in match expressions

### DIFF
--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -120,7 +120,11 @@ pub fn lvalue_scratch_datum<'a, A>(bcx: &'a Block<'a>,
      */
 
     let llty = type_of::type_of(bcx.ccx(), ty);
-    let scratch = alloca_maybe_zeroed(bcx, llty, name, zero);
+    let scratch = if zero {
+        alloca_zeroed(bcx, llty, name)
+    } else {
+        alloca(bcx, llty, name)
+    };
 
     // Subtle. Populate the scratch memory *before* scheduling cleanup.
     let bcx = populate(arg, bcx, scratch);
@@ -145,7 +149,7 @@ pub fn rvalue_scratch_datum(bcx: &Block,
      */
 
     let llty = type_of::type_of(bcx.ccx(), ty);
-    let scratch = alloca_maybe_zeroed(bcx, llty, name, false);
+    let scratch = alloca(bcx, llty, name);
     Datum::new(scratch, ty, Rvalue::new(ByRef))
 }
 


### PR DESCRIPTION
The allocas used in match expression currently don't get good lifetime
markers, in fact they only get lifetime start markers, because their
lifetimes don't match to cleanup scopes.

While the bindings themselves are bog standard and just need a matching
pair of start and end markers, they might need them twice, once for a
guard clause and once for the match body.

The __llmatch alloca OTOH needs a single lifetime start marker, but
when there's a guard clause, it needs two end markers, because its
lifetime ends either when the guard doesn't match or after the match
body.

With these intrinsics in place, LLVM can now, for example, optimize
code like this:

``` rust
enum E {
  A1(int),
  A2(int),
  A3(int),
  A4(int),
}

pub fn variants(x: E) {
  match x {
    A1(m) => bar(&m),
    A2(m) => bar(&m),
    A3(m) => bar(&m),
    A4(m) => bar(&m),
  }
}
```

To a single call to bar, using only a single stack slot. It still fails
to eliminate some of checks.

``` gas
.Ltmp5:
    .cfi_def_cfa_offset 16
    movb    (%rdi), %al
    testb   %al, %al
    je  .LBB3_5
    movzbl  %al, %eax
    cmpl    $1, %eax
    je  .LBB3_5
    cmpl    $2, %eax
.LBB3_5:
    movq    8(%rdi), %rax
    movq    %rax, (%rsp)
    leaq    (%rsp), %rdi
    callq   _ZN3bar20hcb7a0d8be8e17e37daaE@PLT
    popq    %rax
    retq
```

Refs #15665
