### PR TITLE
mk: Make whitespace before line continuation backslashes consistent

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -12,21 +12,21 @@
 # Cleanup
 ######################################################################
 
-CLEAN_STAGE_RULES :=							\
- $(foreach stage, $(STAGES),						\
-  $(foreach host, $(CFG_HOST),						\
-   clean$(stage)_H_$(host)						\
-   $(foreach target, $(CFG_TARGET),					\
+CLEAN_STAGE_RULES := \
+ $(foreach stage, $(STAGES), \
+  $(foreach host, $(CFG_HOST), \
+   clean$(stage)_H_$(host) \
+   $(foreach target, $(CFG_TARGET), \
     clean$(stage)_T_$(target)_H_$(host))))
 
-CLEAN_STAGE_RULES := $(CLEAN_STAGE_RULES)				\
+CLEAN_STAGE_RULES := $(CLEAN_STAGE_RULES) \
     $(foreach host, $(CFG_HOST), clean-generic-H-$(host))
 
-CLEAN_STAGE_RULES := $(CLEAN_STAGE_RULES)				\
+CLEAN_STAGE_RULES := $(CLEAN_STAGE_RULES) \
     $(foreach host, $(CFG_TARGET), clean-generic-T-$(host))
 
-CLEAN_LLVM_RULES = 								\
- $(foreach target, $(CFG_HOST),		\
+CLEAN_LLVM_RULES = \
+ $(foreach target, $(CFG_HOST), \
   clean-llvm$(target))
 
 .PHONY: clean clean-all clean-misc clean-llvm
@@ -54,20 +54,20 @@ clean-generic-$(2)-$(1):
 	         $(1)/rt \
 		 $(1)/test \
 		 $(1)/stage* \
-		 -type f \(           \
+		 -type f \( \
          -name '*.[odasS]' -o \
-         -name '*.so' -o      \
-         -name '*.dylib' -o   \
-         -name '*.rlib' -o   \
-         -name 'stamp.*' -o   \
-         -name '*.lib' -o     \
-         -name '*.dll' -o     \
-         -name '*.def' -o     \
-         -name '*.bc'         \
-         \)                   \
+         -name '*.so' -o \
+         -name '*.dylib' -o \
+         -name '*.rlib' -o \
+         -name 'stamp.*' -o \
+         -name '*.lib' -o \
+         -name '*.dll' -o \
+         -name '*.def' -o \
+         -name '*.bc' \
+         \) \
          | xargs rm -f
 	$(Q)find $(1)\
-         -name '*.dSYM'       \
+         -name '*.dSYM' \
          | xargs rm -Rf
 endef
 
@@ -76,8 +76,8 @@ $(foreach targ, $(CFG_TARGET), $(eval $(call CLEAN_GENERIC,$(targ),T)))
 
 define CLEAN_HOST_STAGE_N
 
-clean$(1)_H_$(2):							    \
-	    $$(foreach crate,$$(CRATES),clean$(1)_H_$(2)-lib-$$(crate))	    \
+clean$(1)_H_$(2): \
+	    $$(foreach crate,$$(CRATES),clean$(1)_H_$(2)-lib-$$(crate)) \
 	    $$(foreach tool,$$(TOOLS),clean$(1)_H_$(2)-tool-$$(tool))
 	$$(Q)rm -fr $(2)/rt/libbacktrace
 
@@ -96,8 +96,8 @@ $(foreach host, $(CFG_HOST), \
 
 define CLEAN_TARGET_STAGE_N
 
-clean$(1)_T_$(2)_H_$(3):						       \
-	    $$(foreach crate,$$(CRATES),clean$(1)_T_$(2)_H_$(3)-lib-$$(crate))  \
+clean$(1)_T_$(2)_H_$(3): \
+	    $$(foreach crate,$$(CRATES),clean$(1)_T_$(2)_H_$(3)-lib-$$(crate)) \
 	    $$(foreach tool,$$(TOOLS),clean$(1)_T_$(2)_H_$(3)-tool-$$(tool))
 	$$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/libmorestack.a
 	$$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/libcompiler-rt.a

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -66,7 +66,7 @@ clean-generic-$(2)-$(1):
          -name '*.bc' \
          \) \
          | xargs rm -f
-	$(Q)find $(1)\
+	$(Q)find $(1) \
          -name '*.dSYM' \
          | xargs rm -Rf
 endef

--- a/mk/ctags.mk
+++ b/mk/ctags.mk
@@ -18,18 +18,18 @@
 # This is using a blacklist approach, probably more durable than a whitelist.
 # We exclude: external dependencies (llvm, libuv, gyp, rt/{msvc,sundown,vg}),
 # tests (compiletest, test) and a couple of other things (rt/arch, etc)
-CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/llvm,,\
-				$(patsubst ${CFG_SRC_DIR}src/libuv,,\
-				$(patsubst ${CFG_SRC_DIR}src/compiletest,,\
-				$(patsubst ${CFG_SRC_DIR}src/test,,\
-				$(patsubst ${CFG_SRC_DIR}src/gyp,,\
-				$(patsubst ${CFG_SRC_DIR}src/etc,,\
-				$(patsubst ${CFG_SRC_DIR}src/rt,,\
-				$(patsubst ${CFG_SRC_DIR}src/rt/arch,,\
-				$(patsubst ${CFG_SRC_DIR}src/rt/msvc,,\
-				$(patsubst ${CFG_SRC_DIR}src/rt/sundown,,\
-				$(patsubst ${CFG_SRC_DIR}src/rt/vg,,\
-				$(wildcard ${CFG_SRC_DIR}src/*) $(wildcard ${CFG_SRC_DIR}src/rt/*)\
+CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/llvm,, \
+				$(patsubst ${CFG_SRC_DIR}src/libuv,, \
+				$(patsubst ${CFG_SRC_DIR}src/compiletest,, \
+				$(patsubst ${CFG_SRC_DIR}src/test,, \
+				$(patsubst ${CFG_SRC_DIR}src/gyp,, \
+				$(patsubst ${CFG_SRC_DIR}src/etc,, \
+				$(patsubst ${CFG_SRC_DIR}src/rt,, \
+				$(patsubst ${CFG_SRC_DIR}src/rt/arch,, \
+				$(patsubst ${CFG_SRC_DIR}src/rt/msvc,, \
+				$(patsubst ${CFG_SRC_DIR}src/rt/sundown,, \
+				$(patsubst ${CFG_SRC_DIR}src/rt/vg,, \
+				$(wildcard ${CFG_SRC_DIR}src/*) $(wildcard ${CFG_SRC_DIR}src/rt/*) \
 				)))))))))))
 CTAGS_OPTS=--options="${CFG_SRC_DIR}src/etc/ctags.rust" --languages=-javascript --recurse ${CTAGS_LOCATIONS}
 # We could use `--languages=Rust`, but there is value in producing tags for the

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -112,8 +112,8 @@ HTML_DEPS += doc/version_info.html
 doc/version_info.html: $(D)/version_info.html.template $(MKFILE_DEPS) \
                        $(wildcard $(D)/*.*) | doc/
 	@$(call E, version-info: $@)
-	$(Q)sed -e "s/VERSION/$(CFG_RELEASE)/; s/SHORT_HASH/$(\
-                    CFG_SHORT_VER_HASH)/;\
+	$(Q)sed -e "s/VERSION/$(CFG_RELEASE)/; s/SHORT_HASH/$( \
+                    CFG_SHORT_VER_HASH)/; \
                 s/STAMP/$(CFG_VER_HASH)/;" $< >$@
 
 GENERATED += doc/version.tex doc/version_info.html

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -24,12 +24,12 @@ $$(HLIB$(2)_H_$(4))/stamp.$(5): \
 	$$(RUST_DEPS_$(5):%=$$(HLIB$(2)_H_$(4))/stamp.%) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$(@D)/lib$(5))
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_LIB_GLOB_$(3),$(5)))
 	$$(Q)cp $$< $$@
 	$$(Q)cp -R $$(TLIB$(1)_T_$(3)_H_$(4))/$$(call CFG_LIB_GLOB_$(3),$(5)) \
 	        $$(HLIB$(2)_H_$(4))
-	$$(call LIST_ALL_OLD_GLOB_MATCHES,\
+	$$(call LIST_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_LIB_GLOB_$(3),$(5)))
 else
 $$(HLIB$(2)_H_$(4))/stamp.$(5):

--- a/mk/host.mk
+++ b/mk/host.mk
@@ -19,9 +19,9 @@
 define CP_HOST_STAGE_N_CRATE
 
 ifeq ($$(ONLY_RLIB_$(5)),)
-$$(HLIB$(2)_H_$(4))/stamp.$(5):					\
-	$$(TLIB$(1)_T_$(3)_H_$(4))/stamp.$(5)			\
-	$$(RUST_DEPS_$(5):%=$$(HLIB$(2)_H_$(4))/stamp.%)	\
+$$(HLIB$(2)_H_$(4))/stamp.$(5): \
+	$$(TLIB$(1)_T_$(3)_H_$(4))/stamp.$(5) \
+	$$(RUST_DEPS_$(5):%=$$(HLIB$(2)_H_$(4))/stamp.%) \
 	| $$(HLIB$(2)_H_$(4))/
 	@$$(call E, cp: $$(@D)/lib$(5))
 	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
@@ -66,19 +66,19 @@ endif
 
 endef
 
-$(foreach t,$(CFG_HOST),						    \
-	$(eval $(call CP_HOST_STAGE_N,0,1,$(t),$(t)))			    \
-	$(eval $(call CP_HOST_STAGE_N,1,2,$(t),$(t)))			    \
+$(foreach t,$(CFG_HOST), \
+	$(eval $(call CP_HOST_STAGE_N,0,1,$(t),$(t))) \
+	$(eval $(call CP_HOST_STAGE_N,1,2,$(t),$(t))) \
 	$(eval $(call CP_HOST_STAGE_N,2,3,$(t),$(t))))
 
-$(foreach crate,$(CRATES),						    \
- $(foreach t,$(CFG_HOST),						    \
-  $(eval $(call CP_HOST_STAGE_N_CRATE,0,1,$(t),$(t),$(crate)))		    \
-  $(eval $(call CP_HOST_STAGE_N_CRATE,1,2,$(t),$(t),$(crate)))		    \
+$(foreach crate,$(CRATES), \
+ $(foreach t,$(CFG_HOST), \
+  $(eval $(call CP_HOST_STAGE_N_CRATE,0,1,$(t),$(t),$(crate))) \
+  $(eval $(call CP_HOST_STAGE_N_CRATE,1,2,$(t),$(t),$(crate))) \
   $(eval $(call CP_HOST_STAGE_N_CRATE,2,3,$(t),$(t),$(crate)))))
 
-$(foreach tool,$(TOOLS),						    \
- $(foreach t,$(CFG_HOST),						    \
-  $(eval $(call CP_HOST_STAGE_N_TOOL,0,1,$(t),$(t),$(tool)))		    \
-  $(eval $(call CP_HOST_STAGE_N_TOOL,1,2,$(t),$(t),$(tool)))		    \
+$(foreach tool,$(TOOLS), \
+ $(foreach t,$(CFG_HOST), \
+  $(eval $(call CP_HOST_STAGE_N_TOOL,0,1,$(t),$(t),$(tool))) \
+  $(eval $(call CP_HOST_STAGE_N_TOOL,1,2,$(t),$(t),$(tool))) \
   $(eval $(call CP_HOST_STAGE_N_TOOL,2,3,$(t),$(t),$(tool)))))

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -81,15 +81,15 @@ endif
 define INSTALL_RUNTIME_TARGET_N
 install-runtime-target-$(1)-host-$(2): $$(TSREQ$$(ISTAGE)_T_$(1)_H_$(2)) $$(SREQ$$(ISTAGE)_T_$(1)_H_$(2))
 	$$(Q)$$(call ADB_SHELL,mkdir,$(CFG_RUNTIME_PUSH_DIR))
-	$$(Q)$$(foreach crate,$$(TARGET_CRATES),\
-	    $$(call ADB_PUSH,$$(TL$(1)$(2))/$$(call CFG_LIB_GLOB_$(1),$$(crate)),\
+	$$(Q)$$(foreach crate,$$(TARGET_CRATES), \
+	    $$(call ADB_PUSH,$$(TL$(1)$(2))/$$(call CFG_LIB_GLOB_$(1),$$(crate)), \
 			$$(CFG_RUNTIME_PUSH_DIR));)
 endef
 
 define INSTALL_RUNTIME_TARGET_CLEANUP_N
 install-runtime-target-$(1)-cleanup:
 	$$(Q)$$(call ADB,remount)
-	$$(Q)$$(foreach crate,$$(TARGET_CRATES),\
+	$$(Q)$$(foreach crate,$$(TARGET_CRATES), \
 	    $$(call ADB_SHELL,rm,$$(CFG_RUNTIME_PUSH_DIR)/$$(call CFG_LIB_GLOB_$(1),$$(crate)));)
 endef
 

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -416,20 +416,20 @@ RPATH_VAR$(1)_T_$(2)_H_$(3) := $$(TARGET_RPATH_VAR$(1)_T_$(2)_H_$(3))
 endif
 endif
 
-STAGE$(1)_T_$(2)_H_$(3) := 						\
-	$$(Q)$$(RPATH_VAR$(1)_T_$(2)_H_$(3))                            \
-		$$(call CFG_RUN_TARG_$(3),$(1),				\
-		$$(CFG_VALGRIND_COMPILE$(1))				\
-		$$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
-		--cfg $$(CFGFLAG$(1)_T_$(2)_H_$(3))			\
+STAGE$(1)_T_$(2)_H_$(3) := \
+	$$(Q)$$(RPATH_VAR$(1)_T_$(2)_H_$(3)) \
+		$$(call CFG_RUN_TARG_$(3),$(1), \
+		$$(CFG_VALGRIND_COMPILE$(1)) \
+		$$(HBIN$(1)_H_$(3))/rustc$$(X_$(3)) \
+		--cfg $$(CFGFLAG$(1)_T_$(2)_H_$(3)) \
 		$$(CFG_RUSTC_FLAGS) $$(EXTRAFLAGS_STAGE$(1)) --target=$(2)) \
                 $$(RUSTC_FLAGS_$(2))
 
-PERF_STAGE$(1)_T_$(2)_H_$(3) :=						\
-	$$(Q)$$(call CFG_RUN_TARG_$(3),$(1),				\
-		$$(CFG_PERF_TOOL) 					\
-		$$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
-		--cfg $$(CFGFLAG$(1)_T_$(2)_H_$(3))			\
+PERF_STAGE$(1)_T_$(2)_H_$(3) := \
+	$$(Q)$$(call CFG_RUN_TARG_$(3),$(1), \
+		$$(CFG_PERF_TOOL) \
+		$$(HBIN$(1)_H_$(3))/rustc$$(X_$(3)) \
+		--cfg $$(CFGFLAG$(1)_T_$(2)_H_$(3)) \
 		$$(CFG_RUSTC_FLAGS) $$(EXTRAFLAGS_STAGE$(1)) --target=$(2)) \
                 $$(RUSTC_FLAGS_$(2))
 
@@ -455,13 +455,13 @@ define DEF_RUSTC_STAGE_TARGET
 # $(1) == architecture
 # $(2) == stage
 
-rustc-stage$(2)-H-$(1):							\
+rustc-stage$(2)-H-$(1): \
 	$$(foreach target,$$(CFG_TARGET),$$(SREQ$(2)_T_$$(target)_H_$(1)))
 
 endef
 
-$(foreach host,$(CFG_HOST),						\
- $(eval $(foreach stage,1 2 3,						\
+$(foreach host,$(CFG_HOST), \
+ $(eval $(foreach stage,1 2 3, \
   $(eval $(call DEF_RUSTC_STAGE_TARGET,$(host),$(stage))))))
 
 rustc-stage1: rustc-stage1-H-$(CFG_BUILD)
@@ -474,7 +474,7 @@ define DEF_RUSTC_TARGET
 rustc-H-$(1): rustc-stage2-H-$(1)
 endef
 
-$(foreach host,$(CFG_TARGET),			\
+$(foreach host,$(CFG_TARGET), \
  $(eval $(call DEF_RUSTC_TARGET,$(host))))
 
 rustc-stage1: rustc-stage1-H-$(CFG_BUILD)

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -167,7 +167,7 @@ endif
 define DEF_X
 X_$(1) := $(CFG_EXE_SUFFIX_$(1))
 endef
-$(foreach target,$(CFG_TARGET),\
+$(foreach target,$(CFG_TARGET), \
   $(eval $(call DEF_X,$(target))))
 
 # "Source" files we generate in builddir along the way.
@@ -333,7 +333,7 @@ TSREQ$(1)_T_$(2)_H_$(3) = \
 # target
 SREQ$(1)_T_$(2)_H_$(3) = \
 	$$(TSREQ$(1)_T_$(2)_H_$(3)) \
-	$$(foreach dep,$$(TARGET_CRATES),\
+	$$(foreach dep,$$(TARGET_CRATES), \
 	    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep))
 
 # Prerequisites for a working stageN compiler and complete set of target

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -32,7 +32,7 @@ $(foreach t,$(CFG_TARGET),$(info cfg: os for $(t) is $(OSTYPE_$(t))))
 CFG_DSYMUTIL := true
 
 # Hack: not sure how to test if a file exists in make other than this
-OS_SUPP = $(patsubst %,--suppressions=%,\
+OS_SUPP = $(patsubst %,--suppressions=%, \
       $(wildcard $(CFG_SRC_DIR)src/etc/$(CFG_OSTYPE).supp*))
 
 ifdef CFG_DISABLE_OPTIMIZE_CXX
@@ -67,7 +67,7 @@ ifneq ($(findstring linux,$(CFG_OSTYPE)),)
     endif
   else
     ifdef CFG_VALGRIND
-      CFG_PERF_TOOL :=\
+      CFG_PERF_TOOL := \
         $(CFG_VALGRIND) --tool=cachegrind --cache-sim=yes --branch-sim=yes
     else
       CFG_PERF_TOOL := /usr/bin/time --verbose
@@ -94,7 +94,7 @@ define SET_FROM_CFG
   endif
 endef
 
-$(foreach cvar,CC CXX CPP CFLAGS CXXFLAGS CPPFLAGS,\
+$(foreach cvar,CC CXX CPP CFLAGS CXXFLAGS CPPFLAGS, \
   $(eval $(call SET_FROM_CFG,$(cvar))))
 
 CFG_RLIB_GLOB=lib$(1)-*.rlib
@@ -591,7 +591,7 @@ define FILTER_FLAGS
   endif
 endef
 
-$(foreach target,$(CFG_TARGET),\
+$(foreach target,$(CFG_TARGET), \
   $(eval $(call FILTER_FLAGS,$(target))))
 
 
@@ -664,5 +664,5 @@ define CFG_MAKE_TOOLCHAIN
 
 endef
 
-$(foreach target,$(CFG_TARGET),\
+$(foreach target,$(CFG_TARGET), \
   $(eval $(call CFG_MAKE_TOOLCHAIN,$(target))))

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -486,8 +486,8 @@ CFG_LIBUV_LINK_FLAGS_i586-mingw32msvc := -L$(CFG_MINGW32_CROSS_PATH)/i586-mingw3
 CFG_EXE_SUFFIX_i586-mingw32msvc := .exe
 CFG_WINDOWSY_i586-mingw32msvc := 1
 CFG_UNIXY_i586-mingw32msvc :=
-CFG_PATH_MUNGE_i586-mingw32msvc := $(strip perl -i.bak -p   \
-                             -e 's@\\(\S)@/\1@go;'       \
+CFG_PATH_MUNGE_i586-mingw32msvc := $(strip perl -i.bak -p \
+                             -e 's@\\(\S)@/\1@go;' \
                              -e 's@^/([a-zA-Z])/@\1:/@o;')
 CFG_LDPATH_i586-mingw32msvc :=
 CFG_RUN_i586-mingw32msvc=
@@ -620,27 +620,27 @@ define CFG_MAKE_TOOLCHAIN
 	RUSTC_FLAGS_$(1)=$$(RUSTC_CROSS_FLAGS_$(1)) $(RUSTC_FLAGS_$(1))
   endif
 
-  CFG_COMPILE_C_$(1) = $$(CC_$(1))  \
-        $$(CFG_GCCISH_CFLAGS)      \
+  CFG_COMPILE_C_$(1) = $$(CC_$(1)) \
+        $$(CFG_GCCISH_CFLAGS) \
         $$(CFG_GCCISH_CFLAGS_$(1)) \
-        $$(CFG_DEPEND_FLAGS)       \
+        $$(CFG_DEPEND_FLAGS) \
         -c -o $$(1) $$(2)
   CFG_LINK_C_$(1) = $$(CC_$(1)) \
-        $$(CFG_GCCISH_LINK_FLAGS) -o $$(1)          \
-        $$(CFG_GCCISH_LINK_FLAGS_$(1))              \
-        $$(CFG_GCCISH_DEF_FLAG_$(1))$$(3) $$(2)     \
+        $$(CFG_GCCISH_LINK_FLAGS) -o $$(1) \
+        $$(CFG_GCCISH_LINK_FLAGS_$(1)) \
+        $$(CFG_GCCISH_DEF_FLAG_$(1))$$(3) $$(2) \
         $$(call CFG_INSTALL_NAME_$(1),$$(4))
   CFG_COMPILE_CXX_$(1) = $$(CXX_$(1)) \
-        $$(CFG_GCCISH_CFLAGS)      \
-        $$(CFG_GCCISH_CXXFLAGS)    \
+        $$(CFG_GCCISH_CFLAGS) \
+        $$(CFG_GCCISH_CXXFLAGS) \
         $$(CFG_GCCISH_CFLAGS_$(1)) \
-        $$(CFG_GCCISH_CXXFLAGS_$(1))    \
-        $$(CFG_DEPEND_FLAGS)       \
+        $$(CFG_GCCISH_CXXFLAGS_$(1)) \
+        $$(CFG_DEPEND_FLAGS) \
         -c -o $$(1) $$(2)
   CFG_LINK_CXX_$(1) = $$(CXX_$(1)) \
-        $$(CFG_GCCISH_LINK_FLAGS) -o $$(1)             \
-        $$(CFG_GCCISH_LINK_FLAGS_$(1))                 \
-        $$(CFG_GCCISH_DEF_FLAG_$(1))$$(3) $$(2)        \
+        $$(CFG_GCCISH_LINK_FLAGS) -o $$(1) \
+        $$(CFG_GCCISH_LINK_FLAGS_$(1)) \
+        $$(CFG_GCCISH_DEF_FLAG_$(1))$$(3) $$(2) \
         $$(call CFG_INSTALL_NAME_$(1),$$(4))
 
   ifeq ($$(findstring $(HOST_$(1)),arm mips mipsel),)

--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -54,11 +54,11 @@ define PREPARE_LIB
 	$(Q)LIB_NAME="$(notdir $(lastword $(wildcard $(PREPARE_WORKING_SOURCE_LIB_DIR)/$(1))))"; \
 	MATCHES="$(filter-out %$(notdir $(lastword $(wildcard $(PREPARE_WORKING_SOURCE_LIB_DIR)/$(1)))),\
                         $(wildcard $(PREPARE_WORKING_DEST_LIB_DIR)/$(1)))"; \
-	if [ -n "$$MATCHES" ]; then                                              \
-	  echo "warning: one or libraries matching Rust library '$(1)'" &&       \
-	  echo "  (other than '$$LIB_NAME' itself) already present"     &&       \
-	  echo "  at destination $(PREPARE_WORKING_DEST_LIB_DIR):"                    &&       \
-	  echo $$MATCHES ;                                                       \
+	if [ -n "$$MATCHES" ]; then \
+	  echo "warning: one or libraries matching Rust library '$(1)'" && \
+	  echo "  (other than '$$LIB_NAME' itself) already present"     && \
+	  echo "  at destination $(PREPARE_WORKING_DEST_LIB_DIR):"      && \
+	  echo $$MATCHES ; \
 	fi
 	$(Q)$(PREPARE_LIB_CMD) `ls -drt1 $(PREPARE_WORKING_SOURCE_LIB_DIR)/$(1) | tail -1` $(PREPARE_WORKING_DEST_LIB_DIR)/
 endef

--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -52,7 +52,7 @@ define PREPARE_LIB
 	$(nop)
 	@$(call E, prepare: $(PREPARE_WORKING_DEST_LIB_DIR)/$(1))
 	$(Q)LIB_NAME="$(notdir $(lastword $(wildcard $(PREPARE_WORKING_SOURCE_LIB_DIR)/$(1))))"; \
-	MATCHES="$(filter-out %$(notdir $(lastword $(wildcard $(PREPARE_WORKING_SOURCE_LIB_DIR)/$(1)))),\
+	MATCHES="$(filter-out %$(notdir $(lastword $(wildcard $(PREPARE_WORKING_SOURCE_LIB_DIR)/$(1)))), \
                         $(wildcard $(PREPARE_WORKING_DEST_LIB_DIR)/$(1)))"; \
 	if [ -n "$$MATCHES" ]; then \
 	  echo "warning: one or libraries matching Rust library '$(1)'" && \
@@ -82,11 +82,11 @@ prepare-host-tool-$(1)-$(2)-$(3)-$(4): prepare-maybe-clean-$(4) \
                                   $$(foreach dep,$$(TOOL_DEPS_$(1)),prepare-host-lib-$$(dep)-$(2)-$(3)-$(4)) \
                                   $$(HBIN$(2)_H_$(3))/$(1)$$(X_$(3)) \
                                   prepare-host-dirs-$(4)
-	$$(if $$(findstring $(2), $$(PREPARE_STAGE)),\
-      $$(if $$(findstring $(3), $$(PREPARE_HOST)),\
+	$$(if $$(findstring $(2), $$(PREPARE_STAGE)), \
+      $$(if $$(findstring $(3), $$(PREPARE_HOST)), \
         $$(call PREPARE_BIN,$(1)$$(X_$$(PREPARE_HOST))),),)
-	$$(if $$(findstring $(2), $$(PREPARE_STAGE)),\
-      $$(if $$(findstring $(3), $$(PREPARE_HOST)),\
+	$$(if $$(findstring $(2), $$(PREPARE_STAGE)), \
+      $$(if $$(findstring $(3), $$(PREPARE_HOST)), \
         $$(call PREPARE_MAN,$(1).1),),)
 endef
 
@@ -101,12 +101,12 @@ define DEF_PREPARE_HOST_LIB
 prepare-host-lib-$(1)-$(2)-$(3)-$(4): PREPARE_WORKING_SOURCE_LIB_DIR=$$(PREPARE_SOURCE_LIB_DIR)
 prepare-host-lib-$(1)-$(2)-$(3)-$(4): PREPARE_WORKING_DEST_LIB_DIR=$$(PREPARE_DEST_LIB_DIR)
 prepare-host-lib-$(1)-$(2)-$(3)-$(4): prepare-maybe-clean-$(4) \
-                                 $$(foreach dep,$$(RUST_DEPS_$(1)),prepare-host-lib-$$(dep)-$(2)-$(3)-$(4))\
+                                 $$(foreach dep,$$(RUST_DEPS_$(1)),prepare-host-lib-$$(dep)-$(2)-$(3)-$(4)) \
                                  $$(HLIB$(2)_H_$(3))/stamp.$(1) \
                                  prepare-host-dirs-$(4)
-	$$(if $$(findstring $(2), $$(PREPARE_STAGE)),\
-      $$(if $$(findstring $(3), $$(PREPARE_HOST)),\
-        $$(if $$(findstring 1,$$(ONLY_RLIB_$(1))),,\
+	$$(if $$(findstring $(2), $$(PREPARE_STAGE)), \
+      $$(if $$(findstring $(3), $$(PREPARE_HOST)), \
+        $$(if $$(findstring 1,$$(ONLY_RLIB_$(1))),, \
           $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$$(PREPARE_HOST),$(1)))),),)
 endef
 
@@ -129,17 +129,17 @@ prepare-target-$(2)-host-$(3)-$(1)-$(4): prepare-maybe-clean-$(4) \
 # *not* install the rlibs for host crates because there's no need to statically
 # link against most of them. They just produce a large amount of extra size
 # bloat.
-	$$(if $$(findstring $(1), $$(PREPARE_STAGE)),\
-      $$(if $$(findstring $(2), $$(PREPARE_TARGETS)),\
-        $$(if $$(findstring $(3), $$(PREPARE_HOST)),\
-          $$(call PREPARE_DIR,$$(PREPARE_WORKING_DEST_LIB_DIR))\
-          $$(foreach crate,$$(TARGET_CRATES),\
-	    $$(if $$(findstring 1, $$(ONLY_RLIB_$$(crate))),,\
-              $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$(2),$$(crate))))\
-            $$(call PREPARE_LIB,$$(call CFG_RLIB_GLOB,$$(crate))))\
-          $$(if $$(findstring $(2),$$(CFG_HOST)),\
-            $$(foreach crate,$$(HOST_CRATES),\
-              $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$(2),$$(crate)))),)\
+	$$(if $$(findstring $(1), $$(PREPARE_STAGE)), \
+      $$(if $$(findstring $(2), $$(PREPARE_TARGETS)), \
+        $$(if $$(findstring $(3), $$(PREPARE_HOST)), \
+          $$(call PREPARE_DIR,$$(PREPARE_WORKING_DEST_LIB_DIR)) \
+          $$(foreach crate,$$(TARGET_CRATES), \
+	    $$(if $$(findstring 1, $$(ONLY_RLIB_$$(crate))),, \
+              $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$(2),$$(crate)))) \
+            $$(call PREPARE_LIB,$$(call CFG_RLIB_GLOB,$$(crate)))) \
+          $$(if $$(findstring $(2),$$(CFG_HOST)), \
+            $$(foreach crate,$$(HOST_CRATES), \
+              $$(call PREPARE_LIB,$$(call CFG_LIB_GLOB_$(2),$$(crate)))),) \
           $$(call PREPARE_LIB,libmorestack.a) \
           $$(call PREPARE_LIB,libcompiler-rt.a),),),)
 endef
@@ -160,8 +160,8 @@ prepare-everything-$(1): prepare-host-$(1) prepare-targets-$(1)
 prepare-host-$(1): prepare-host-tools-$(1)
 
 prepare-host-tools-$(1): \
-        $$(foreach tool, $$(PREPARE_TOOLS),\
-          $$(foreach host,$$(CFG_HOST),\
+        $$(foreach tool, $$(PREPARE_TOOLS), \
+          $$(foreach host,$$(CFG_HOST), \
             prepare-host-tool-$$(tool)-$$(PREPARE_STAGE)-$$(host)-$(1)))
 
 prepare-host-dirs-$(1): prepare-maybe-clean-$(1)
@@ -169,27 +169,27 @@ prepare-host-dirs-$(1): prepare-maybe-clean-$(1)
 	$$(call PREPARE_DIR,$$(PREPARE_DEST_LIB_DIR))
 	$$(call PREPARE_DIR,$$(PREPARE_DEST_MAN_DIR))
 
-$$(foreach tool,$$(PREPARE_TOOLS),\
-  $$(foreach host,$$(CFG_HOST),\
+$$(foreach tool,$$(PREPARE_TOOLS), \
+  $$(foreach host,$$(CFG_HOST), \
       $$(eval $$(call DEF_PREPARE_HOST_TOOL,$$(tool),$$(PREPARE_STAGE),$$(host),$(1)))))
 
-$$(foreach lib,$$(CRATES),\
-  $$(foreach host,$$(CFG_HOST),\
+$$(foreach lib,$$(CRATES), \
+  $$(foreach host,$$(CFG_HOST), \
     $$(eval $$(call DEF_PREPARE_HOST_LIB,$$(lib),$$(PREPARE_STAGE),$$(host),$(1)))))
 
-prepare-targets-$(1):\
-        $$(foreach host,$$(CFG_HOST),\
-           $$(foreach target,$$(CFG_TARGET),\
+prepare-targets-$(1): \
+        $$(foreach host,$$(CFG_HOST), \
+           $$(foreach target,$$(CFG_TARGET), \
              prepare-target-$$(target)-host-$$(host)-$$(PREPARE_STAGE)-$(1)))
 
-$$(foreach host,$$(CFG_HOST),\
+$$(foreach host,$$(CFG_HOST), \
   $$(foreach target,$$(CFG_TARGET), \
     $$(eval $$(call DEF_PREPARE_TARGET_N,$$(PREPARE_STAGE),$$(target),$$(host),$(1)))))
 
 prepare-maybe-clean-$(1):
-	$$(if $$(findstring true,$$(PREPARE_CLEAN)),\
+	$$(if $$(findstring true,$$(PREPARE_CLEAN)), \
       @$$(call E, cleaning destination $$(PREPARE_DEST_DIR)),)
-	$$(if $$(findstring true,$$(PREPARE_CLEAN)),\
+	$$(if $$(findstring true,$$(PREPARE_CLEAN)), \
       $$(Q)rm -rf $$(PREPARE_DEST_DIR),)
 
 

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -114,10 +114,10 @@ $$(RT_OUTPUT_DIR_$(1))/$$(NATIVE_$(2)_$(1)): $$(OBJS_$(2)_$(1))
 
 endef
 
-$(foreach target,$(CFG_TARGET),					    \
+$(foreach target,$(CFG_TARGET), \
  $(eval $(call RUNTIME_RULES,$(target))))
-$(foreach lib,$(NATIVE_LIBS),					    \
- $(foreach target,$(CFG_TARGET),				    \
+$(foreach lib,$(NATIVE_LIBS), \
+ $(foreach target,$(CFG_TARGET), \
   $(eval $(call THIRD_PARTY_LIB,$(target),$(lib)))))
 
 

--- a/mk/snap.mk
+++ b/mk/snap.mk
@@ -17,8 +17,8 @@ snap-stage$(1)-H-$(2): $$(HSREQ$(1)_H_$(2))
 
 endef
 
-$(foreach host,$(CFG_HOST),						\
- $(eval $(foreach stage,1 2 3,								\
+$(foreach host,$(CFG_HOST), \
+ $(eval $(foreach stage,1 2 3, \
   $(eval $(call DEF_SNAP_FOR_STAGE_H,$(stage),$(host))))))
 
 snap-stage1: snap-stage1-H-$(CFG_BUILD)

--- a/mk/stage0.mk
+++ b/mk/stage0.mk
@@ -6,9 +6,9 @@ $(HBIN0_H_$(CFG_BUILD))/:
 $(HLIB0_H_$(CFG_BUILD))/:
 	mkdir -p $@
 
-$(SNAPSHOT_RUSTC_POST_CLEANUP):						\
-		$(S)src/snapshots.txt					\
-		$(S)src/etc/get-snapshot.py $(MKFILE_DEPS)		\
+$(SNAPSHOT_RUSTC_POST_CLEANUP): \
+		$(S)src/snapshots.txt \
+		$(S)src/etc/get-snapshot.py $(MKFILE_DEPS) \
 		| $(HBIN0_H_$(CFG_BUILD))/
 
 	@$(call E, fetch: $@)
@@ -44,5 +44,5 @@ endef
 
 # Use stage1 to build other architectures: then you don't have to wait
 # for stage2, but you get the latest updates to the compiler source.
-$(foreach t,$(NON_BUILD_HOST),								\
+$(foreach t,$(NON_BUILD_HOST), \
  $(eval $(call BOOTSTRAP_STAGE0,$(t),1,$(CFG_BUILD))))

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -29,19 +29,19 @@ WFLAGS_ST2 = -D warnings
 # $(3) - host
 # $(4) crate
 define RUST_CRATE_FULLDEPS
-CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4) :=			    \
-		$$(CRATEFILE_$(4))				    \
-		$$(RSINPUTS_$(4))				    \
-		$$(foreach dep,$$(RUST_DEPS_$(4)),		    \
-		  $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep))	    \
-		$$(foreach dep,$$(NATIVE_DEPS_$(4)),		    \
+CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4) := \
+		$$(CRATEFILE_$(4)) \
+		$$(RSINPUTS_$(4)) \
+		$$(foreach dep,$$(RUST_DEPS_$(4)), \
+		  $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep)) \
+		$$(foreach dep,$$(NATIVE_DEPS_$(4)), \
 		  $$(RT_OUTPUT_DIR_$(2))/$$(call CFG_STATIC_LIB_NAME_$(2),$$(dep)))
 endef
 
-$(foreach host,$(CFG_HOST),						    \
- $(foreach target,$(CFG_TARGET),					    \
-  $(foreach stage,$(STAGES),						    \
-   $(foreach crate,$(CRATES),						    \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
+  $(foreach stage,$(STAGES), \
+   $(foreach crate,$(CRATES), \
     $(eval $(call RUST_CRATE_FULLDEPS,$(stage),$(target),$(host),$(crate)))))))
 
 # RUST_TARGET_STAGE_N template: This defines how target artifacts are built
@@ -69,10 +69,10 @@ $(foreach host,$(CFG_HOST),						    \
 define RUST_TARGET_STAGE_N
 
 $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): CFG_COMPILER_HOST_TRIPLE = $(2)
-$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4):				    \
-		$$(CRATEFILE_$(4))				    \
-		$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4))	    \
-		$$(TSREQ$(1)_T_$(2)_H_$(3))			    \
+$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
+		$$(CRATEFILE_$(4)) \
+		$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4)) \
+		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, rustc: $$(@D)/lib$(4))
 	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
@@ -110,12 +110,12 @@ endef
 # $(4) - name of the tool being built
 define TARGET_TOOL
 
-$$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)):			\
-		$$(TOOL_SOURCE_$(4))				\
-		$$(TOOL_INPUTS_$(4))				\
-		$$(foreach dep,$$(TOOL_DEPS_$(4)),		\
-		    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep))	\
-		$$(TSREQ$(1)_T_$(2)_H_$(3))			\
+$$(TBIN$(1)_T_$(2)_H_$(3))/$(4)$$(X_$(2)): \
+		$$(TOOL_SOURCE_$(4)) \
+		$$(TOOL_INPUTS_$(4)) \
+		$$(foreach dep,$$(TOOL_DEPS_$(4)), \
+		    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep)) \
+		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TBIN$(1)_T_$(4)_H_$(3))/
 	@$$(call E, rustc: $$@)
 	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --cfg $(4)
@@ -155,24 +155,24 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/libmorestack.a: \
 	$$(Q)cp $$< $$@
 endef
 
-$(foreach source,$(CFG_HOST),						    \
- $(foreach target,$(CFG_TARGET),					    \
-  $(eval $(call TARGET_HOST_RULES,0,$(target),$(source)))		    \
-  $(eval $(call TARGET_HOST_RULES,1,$(target),$(source)))		    \
-  $(eval $(call TARGET_HOST_RULES,2,$(target),$(source)))		    \
+$(foreach source,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
+  $(eval $(call TARGET_HOST_RULES,0,$(target),$(source))) \
+  $(eval $(call TARGET_HOST_RULES,1,$(target),$(source))) \
+  $(eval $(call TARGET_HOST_RULES,2,$(target),$(source))) \
   $(eval $(call TARGET_HOST_RULES,3,$(target),$(source)))))
 
 # In principle, each host can build each target for both libs and tools
-$(foreach crate,$(CRATES),						    \
- $(foreach source,$(CFG_HOST),						    \
-  $(foreach target,$(CFG_TARGET),					    \
-   $(eval $(call RUST_TARGET_STAGE_N,0,$(target),$(source),$(crate)))	    \
-   $(eval $(call RUST_TARGET_STAGE_N,1,$(target),$(source),$(crate)))	    \
-   $(eval $(call RUST_TARGET_STAGE_N,2,$(target),$(source),$(crate)))	    \
+$(foreach crate,$(CRATES), \
+ $(foreach source,$(CFG_HOST), \
+  $(foreach target,$(CFG_TARGET), \
+   $(eval $(call RUST_TARGET_STAGE_N,0,$(target),$(source),$(crate))) \
+   $(eval $(call RUST_TARGET_STAGE_N,1,$(target),$(source),$(crate))) \
+   $(eval $(call RUST_TARGET_STAGE_N,2,$(target),$(source),$(crate))) \
    $(eval $(call RUST_TARGET_STAGE_N,3,$(target),$(source),$(crate))))))
 
-$(foreach host,$(CFG_HOST),						    \
- $(foreach target,$(CFG_TARGET),					    \
-  $(foreach stage,$(STAGES),						    \
-   $(foreach tool,$(TOOLS),						    \
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
+  $(foreach stage,$(STAGES), \
+   $(foreach tool,$(TOOLS), \
     $(eval $(call TARGET_TOOL,$(stage),$(target),$(host),$(tool)))))))

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -75,9 +75,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, rustc: $$(@D)/lib$(4))
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_LIB_GLOB_$(2),$(4)))
-	$$(call REMOVE_ALL_OLD_GLOB_MATCHES,\
+	$$(call REMOVE_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_RLIB_GLOB,$(4)))
 	$$(STAGE$(1)_T_$(2)_H_$(3)) \
 		$$(WFLAGS_ST$(1)) \
@@ -89,9 +89,9 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		-C extra-filename=-$$(CFG_FILENAME_EXTRA) \
 		$$<
 	@touch $$@
-	$$(call LIST_ALL_OLD_GLOB_MATCHES,\
+	$$(call LIST_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_LIB_GLOB_$(2),$(4)))
-	$$(call LIST_ALL_OLD_GLOB_MATCHES,\
+	$$(call LIST_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_RLIB_GLOB,$(4)))
 
 endef

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -202,15 +202,15 @@ cleantmptestlogs:
 cleantestlibs:
 	$(Q)find $(CFG_BUILD)/test \
          -name '*.[odasS]' -o \
-         -name '*.so' -o      \
-         -name '*.dylib' -o   \
-         -name '*.dll' -o     \
-         -name '*.def' -o     \
-         -name '*.bc' -o      \
-         -name '*.dSYM' -o    \
-         -name '*.libaux' -o      \
-         -name '*.out' -o     \
-         -name '*.err' -o     \
+         -name '*.so' -o \
+         -name '*.dylib' -o \
+         -name '*.dll' -o \
+         -name '*.def' -o \
+         -name '*.bc' -o \
+         -name '*.dSYM' -o \
+         -name '*.libaux' -o \
+         -name '*.out' -o \
+         -name '*.err' -o \
 	 -name '*.debugger.script' \
          | xargs rm -rf
 
@@ -293,16 +293,16 @@ endif
 
 define DEF_TEST_SETS
 
-check-stage$(1)-T-$(2)-H-$(3)-exec:     				\
-	check-stage$(1)-T-$(2)-H-$(3)-rpass-exec			\
-	check-stage$(1)-T-$(2)-H-$(3)-rfail-exec			\
-	check-stage$(1)-T-$(2)-H-$(3)-cfail-exec			\
-	check-stage$(1)-T-$(2)-H-$(3)-rpass-full-exec			\
-	check-stage$(1)-T-$(2)-H-$(3)-cfail-full-exec			\
-	check-stage$(1)-T-$(2)-H-$(3)-rmake-exec			\
-        check-stage$(1)-T-$(2)-H-$(3)-crates-exec                       \
-        check-stage$(1)-T-$(2)-H-$(3)-doc-crates-exec                   \
-	check-stage$(1)-T-$(2)-H-$(3)-bench-exec			\
+check-stage$(1)-T-$(2)-H-$(3)-exec: \
+	check-stage$(1)-T-$(2)-H-$(3)-rpass-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-rfail-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-cfail-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-rpass-full-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-cfail-full-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-rmake-exec \
+        check-stage$(1)-T-$(2)-H-$(3)-crates-exec \
+        check-stage$(1)-T-$(2)-H-$(3)-doc-crates-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-bench-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-debuginfo-gdb-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-debuginfo-lldb-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-codegen-exec \
@@ -334,10 +334,10 @@ check-stage$(1)-T-$(2)-H-$(3)-doc-exec: \
            check-stage$(1)-T-$(2)-H-$(3)-doc-$$(docname)-exec)
 
 check-stage$(1)-T-$(2)-H-$(3)-pretty-exec: \
-	check-stage$(1)-T-$(2)-H-$(3)-pretty-rpass-exec	\
-	check-stage$(1)-T-$(2)-H-$(3)-pretty-rpass-full-exec	\
-	check-stage$(1)-T-$(2)-H-$(3)-pretty-rfail-exec	\
-	check-stage$(1)-T-$(2)-H-$(3)-pretty-bench-exec	\
+	check-stage$(1)-T-$(2)-H-$(3)-pretty-rpass-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-pretty-rpass-full-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-pretty-rfail-exec \
+	check-stage$(1)-T-$(2)-H-$(3)-pretty-bench-exec \
 	check-stage$(1)-T-$(2)-H-$(3)-pretty-pretty-exec
 
 endef
@@ -377,13 +377,13 @@ TESTDEP_$(1)_$(2)_$(3)_$(4) = $$(RSINPUTS_$(4))
 endif
 
 $(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)): CFG_COMPILER_HOST_TRIPLE = $(2)
-$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)):				\
+$(3)/stage$(1)/test/$(4)test-$(2)$$(X_$(2)): \
 		$$(CRATEFILE_$(4)) \
 		$$(TESTDEP_$(1)_$(2)_$(3)_$(4))
 	@$$(call E, rustc: $$@)
-	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test	\
-		-L "$$(RT_OUTPUT_DIR_$(2))"		\
-		-L "$$(LLVM_LIBDIR_$(2))"		\
+	$$(STAGE$(1)_T_$(2)_H_$(3)) -o $$@ $$< --test \
+		-L "$$(RT_OUTPUT_DIR_$(2))" \
+		-L "$$(LLVM_LIBDIR_$(2))" \
 		$$(RUSTFLAGS_$(4))
 
 endef
@@ -600,19 +600,19 @@ ifndef CFG_DISABLE_OPTIMIZE_TESTS
 CTEST_RUSTC_FLAGS += -O
 endif
 
-CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) :=						\
-		--compile-lib-path $$(HLIB$(1)_H_$(3))				\
-        --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3))			\
-        --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))			\
+CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
+		--compile-lib-path $$(HLIB$(1)_H_$(3)) \
+        --run-lib-path $$(TLIB$(1)_T_$(2)_H_$(3)) \
+        --rustc-path $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3)) \
         --clang-path $(if $(CFG_CLANG),$(CFG_CLANG),clang) \
         --llvm-bin-path $(CFG_LLVM_INST_DIR_$(CFG_BUILD))/bin \
-        --aux-base $$(S)src/test/auxiliary/                 \
-        --stage-id stage$(1)-$(2)							\
-        --target $(2)                                       \
-        --host $(3)                                       \
-        --android-cross-path=$(CFG_ANDROID_CROSS_PATH)    \
-        --adb-path=$(CFG_ADB)                          \
-        --adb-test-dir=$(CFG_ADB_TEST_DIR)                  \
+        --aux-base $$(S)src/test/auxiliary/ \
+        --stage-id stage$(1)-$(2) \
+        --target $(2) \
+        --host $(3) \
+        --android-cross-path=$(CFG_ANDROID_CROSS_PATH) \
+        --adb-path=$(CFG_ADB) \
+        --adb-test-dir=$(CFG_ADB_TEST_DIR) \
         --host-rustcflags "$(RUSTC_FLAGS_$(3)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(3))" \
         --lldb-python-dir=$(CFG_LLDB_PYTHON_DIR) \
         --target-rustcflags "$(RUSTC_FLAGS_$(2)) $$(CTEST_RUSTC_FLAGS) -L $$(RT_OUTPUT_DIR_$(2))" \
@@ -639,7 +639,7 @@ $(foreach host,$(CFG_HOST), \
 define DEF_RUN_COMPILETEST
 
 CTEST_ARGS$(1)-T-$(2)-H-$(3)-$(4) := \
-        $$(CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3))	\
+        $$(CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3)) \
         --src-base $$(S)src/test/$$(CTEST_SRC_BASE_$(4))/ \
         --build-base $(3)/test/$$(CTEST_BUILD_BASE_$(4))/ \
         --ratchet-metrics $(call TEST_RATCHET_FILE,$(1),$(2),$(3),$(4)) \
@@ -712,8 +712,8 @@ PRETTY_DIRNAME_pretty-pretty = pretty
 
 define DEF_RUN_PRETTY_TEST
 
-PRETTY_ARGS$(1)-T-$(2)-H-$(3)-$(4) :=			\
-		$$(CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3))	\
+PRETTY_ARGS$(1)-T-$(2)-H-$(3)-$(4) := \
+		$$(CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3)) \
         --src-base $$(S)src/test/$$(PRETTY_DIRNAME_$(4))/ \
         --build-base $(3)/test/$$(PRETTY_DIRNAME_$(4))/ \
         --mode pretty
@@ -721,7 +721,7 @@ PRETTY_ARGS$(1)-T-$(2)-H-$(3)-$(4) :=			\
 check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4))
 
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
-	        $$(TEST_SREQ$(1)_T_$(2)_H_$(3))		\
+	        $$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
 	        $$(PRETTY_DEPS_$(4))
 	@$$(call E, run pretty-rpass [$(2)]: $$<)
 	$$(Q)$$(call CFG_RUN_CTEST_$(2),$(1),$$<,$(3)) \
@@ -764,7 +764,7 @@ check-stage$(1)-T-$(2)-H-$(3)-doc-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3)
 ifeq ($(NO_REBUILD),)
 DOCTESTDEP_$(1)_$(2)_$(3)_$(4) = \
 	$$(D)/$(4).md \
-	$$(TEST_SREQ$(1)_T_$(2)_H_$(3))				\
+	$$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
 	$$(RUSTDOC_EXE_$(1)_T_$(2)_H_$(3))
 else
 DOCTESTDEP_$(1)_$(2)_$(3)_$(4) = $$(D)/$(4).md
@@ -795,8 +795,8 @@ define DEF_CRATE_DOC_TEST
 # rebuilding any of the parent crates.
 ifeq ($(NO_REBUILD),)
 CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4) = \
-	$$(TEST_SREQ$(1)_T_$(2)_H_$(3))				\
-	$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4))		\
+	$$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
+	$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4)) \
 	$$(RUSTDOC_EXE_$(1)_T_$(2)_H_$(3))
 else
 CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4) = $$(RSINPUTS_$(4))

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -75,12 +75,12 @@ TEST_RATCHET_NOISE_PERCENT=10.0
 
 # Whether to ratchet or merely save benchmarks
 ifdef CFG_RATCHET_BENCH
-CRATE_TEST_EXTRA_ARGS=\
+CRATE_TEST_EXTRA_ARGS= \
   --test $(TEST_BENCH) \
   --ratchet-metrics $(call TEST_RATCHET_FILE,$(1),$(2),$(3),$(4)) \
   --ratchet-noise-percent $(TEST_RATCHET_NOISE_PERCENT)
 else
-CRATE_TEST_EXTRA_ARGS=\
+CRATE_TEST_EXTRA_ARGS= \
   --test $(TEST_BENCH) \
   --save-metrics $(call TEST_RATCHET_FILE,$(1),$(2),$(3),$(4))
 endif
@@ -158,9 +158,9 @@ $(info check: android device test dir $(CFG_ADB_TEST_DIR) ready \
  $(shell $(CFG_ADB) shell mkdir $(CFG_ADB_TEST_DIR)) \
  $(shell $(CFG_ADB) shell mkdir $(CFG_ADB_TEST_DIR)/tmp) \
  $(shell $(CFG_ADB) push $(S)src/etc/adb_run_wrapper.sh $(CFG_ADB_TEST_DIR) 1>/dev/null) \
- $(foreach crate,$(TARGET_CRATES),\
+ $(foreach crate,$(TARGET_CRATES), \
     $(shell $(CFG_ADB) push $(TLIB2_T_arm-linux-androideabi_H_$(CFG_BUILD))/$(call CFG_LIB_GLOB_arm-linux-androideabi,$(crate)) \
-                    $(CFG_ADB_TEST_DIR)))\
+                    $(CFG_ADB_TEST_DIR))) \
  )
 else
 CFG_ADB_TEST_DIR=
@@ -359,7 +359,7 @@ define TEST_RUNNER
 # parent crates.
 ifeq ($(NO_REBUILD),)
 TESTDEP_$(1)_$(2)_$(3)_$(4) = $$(SREQ$(1)_T_$(2)_H_$(3)) \
-			    $$(foreach crate,$$(TARGET_CRATES),\
+			    $$(foreach crate,$$(TARGET_CRATES), \
 				$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(crate)) \
 				$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4))
 
@@ -930,9 +930,9 @@ $(foreach stage,$(STAGES), \
    $(eval $(call DEF_CHECK_FOR_STAGE_AND_HOSTS_AND_GROUP,$(stage),$(host),$(group))))))
 
 define DEF_CHECK_DOC_FOR_STAGE
-check-stage$(1)-docs: $$(foreach docname,$$(DOCS),\
+check-stage$(1)-docs: $$(foreach docname,$$(DOCS), \
                        check-stage$(1)-T-$$(CFG_BUILD)-H-$$(CFG_BUILD)-doc-$$(docname)) \
-                     $$(foreach crate,$$(TEST_DOC_CRATES),\
+                     $$(foreach crate,$$(TEST_DOC_CRATES), \
                        check-stage$(1)-T-$$(CFG_BUILD)-H-$$(CFG_BUILD)-doc-crate-$$(crate))
 endef
 


### PR DESCRIPTION
The alignment of the line continuation backslashes is rather inconsistent. These commits solve that by removing the extra whitespace and adding a space where there previously was none. An alternative solution would be to fix the alignment.
