### PR TITLE
libsyntax: Remove `~self` and `mut ~self` from the language.

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3864,13 +3864,13 @@ Function parameters are immutable unless declared with `mut`. The
 and `fn f(mut x: Box<int>, y: Box<int>)` declare one mutable variable `x` and
 one immutable variable `y`).
 
-Methods that take either `self` or `~self` can optionally place them in a
+Methods that take either `self` or `Box<Self>` can optionally place them in a
 mutable slot by prefixing them with `mut` (similar to regular arguments):
 
 ~~~
 trait Changer {
     fn change(mut self) -> Self;
-    fn modify(mut ~self) -> Box<Self>;
+    fn modify(mut self: Box<Self>) -> Box<Self>;
 }
 ~~~
 

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1971,7 +1971,7 @@ like any other function, except for the name `self`.
 
 The type of `self` is the type on which the method is implemented,
 or a pointer thereof. As an argument it is written either `self`,
-`&self`, or `~self`.
+`&self`, or `self: TYPE`.
 A caller must in turn have a compatible pointer type to call the method.
 
 ~~~
@@ -1984,7 +1984,7 @@ A caller must in turn have a compatible pointer type to call the method.
 # }
 impl Shape {
     fn draw_reference(&self) { /* ... */ }
-    fn draw_owned(~self) { /* ... */ }
+    fn draw_owned(self: Box<Shape>) { /* ... */ }
     fn draw_value(self) { /* ... */ }
 }
 
@@ -2009,7 +2009,7 @@ to a reference.
 # }
 # impl Shape {
 #    fn draw_reference(&self) { /* ... */ }
-#    fn draw_owned(~self) { /* ... */ }
+#    fn draw_owned(self: Box<Shape>) { /* ... */ }
 #    fn draw_value(self) { /* ... */ }
 # }
 # let s = Circle(Point { x: 1.0, y: 2.0 }, 3.0);

--- a/src/libgreen/simple.rs
+++ b/src/libgreen/simple.rs
@@ -27,7 +27,9 @@ struct SimpleTask {
 impl Runtime for SimpleTask {
     // Implement the simple tasks of descheduling and rescheduling, but only in
     // a simple number of cases.
-    fn deschedule(mut ~self, times: uint, mut cur_task: Box<Task>,
+    fn deschedule(mut self: Box<SimpleTask>,
+                  times: uint,
+                  mut cur_task: Box<Task>,
                   f: |BlockedTask| -> Result<(), BlockedTask>) {
         assert!(times == 1);
 
@@ -54,7 +56,7 @@ impl Runtime for SimpleTask {
         }
         Local::put(cur_task);
     }
-    fn reawaken(mut ~self, mut to_wake: Box<Task>) {
+    fn reawaken(mut self: Box<SimpleTask>, mut to_wake: Box<Task>) {
         let me = &mut *self as *mut SimpleTask;
         to_wake.put_runtime(self);
         unsafe {
@@ -69,9 +71,9 @@ impl Runtime for SimpleTask {
     // purpose. A "simple task" is just that, a very simple task that can't
     // really do a whole lot. The only purpose of the task is to get us off our
     // feet and running.
-    fn yield_now(~self, _cur_task: Box<Task>) { fail!() }
-    fn maybe_yield(~self, _cur_task: Box<Task>) { fail!() }
-    fn spawn_sibling(~self,
+    fn yield_now(self: Box<SimpleTask>, _cur_task: Box<Task>) { fail!() }
+    fn maybe_yield(self: Box<SimpleTask>, _cur_task: Box<Task>) { fail!() }
+    fn spawn_sibling(self: Box<SimpleTask>,
                      _cur_task: Box<Task>,
                      _opts: TaskOpts,
                      _f: proc():Send) {
@@ -80,7 +82,7 @@ impl Runtime for SimpleTask {
     fn local_io<'a>(&'a mut self) -> Option<rtio::LocalIo<'a>> { None }
     fn stack_bounds(&self) -> (uint, uint) { fail!() }
     fn can_block(&self) -> bool { true }
-    fn wrap(~self) -> Box<Any> { fail!() }
+    fn wrap(self: Box<SimpleTask>) -> Box<Any> { fail!() }
 }
 
 pub fn task() -> Box<Task> {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -484,7 +484,8 @@ impl TcpListener {
 }
 
 impl rtio::RtioTcpListener for TcpListener {
-    fn listen(~self) -> IoResult<Box<rtio::RtioTcpAcceptor + Send>> {
+    fn listen(self: Box<TcpListener>)
+              -> IoResult<Box<rtio::RtioTcpAcceptor + Send>> {
         self.native_listen(128).map(|a| {
             box a as Box<rtio::RtioTcpAcceptor + Send>
         })

--- a/src/libnative/io/pipe_unix.rs
+++ b/src/libnative/io/pipe_unix.rs
@@ -229,7 +229,8 @@ impl UnixListener {
 }
 
 impl rtio::RtioUnixListener for UnixListener {
-    fn listen(~self) -> IoResult<Box<rtio::RtioUnixAcceptor + Send>> {
+    fn listen(self: Box<UnixListener>)
+              -> IoResult<Box<rtio::RtioUnixAcceptor + Send>> {
         self.native_listen(128).map(|a| {
             box a as Box<rtio::RtioUnixAcceptor + Send>
         })

--- a/src/libnative/io/pipe_win32.rs
+++ b/src/libnative/io/pipe_win32.rs
@@ -588,7 +588,8 @@ impl Drop for UnixListener {
 }
 
 impl rtio::RtioUnixListener for UnixListener {
-    fn listen(~self) -> IoResult<Box<rtio::RtioUnixAcceptor + Send>> {
+    fn listen(self: Box<UnixListener>)
+              -> IoResult<Box<rtio::RtioUnixAcceptor + Send>> {
         self.native_listen().map(|a| {
             box a as Box<rtio::RtioUnixAcceptor + Send>
         })

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -131,21 +131,21 @@ struct Ops {
 }
 
 impl rt::Runtime for Ops {
-    fn yield_now(~self, mut cur_task: Box<Task>) {
+    fn yield_now(self: Box<Ops>, mut cur_task: Box<Task>) {
         // put the task back in TLS and then invoke the OS thread yield
         cur_task.put_runtime(self);
         Local::put(cur_task);
         Thread::yield_now();
     }
 
-    fn maybe_yield(~self, mut cur_task: Box<Task>) {
+    fn maybe_yield(self: Box<Ops>, mut cur_task: Box<Task>) {
         // just put the task back in TLS, on OS threads we never need to
         // opportunistically yield b/c the OS will do that for us (preemption)
         cur_task.put_runtime(self);
         Local::put(cur_task);
     }
 
-    fn wrap(~self) -> Box<Any> {
+    fn wrap(self: Box<Ops>) -> Box<Any> {
         self as Box<Any>
     }
 
@@ -192,7 +192,9 @@ impl rt::Runtime for Ops {
     // `awoken` field which indicates whether we were actually woken up via some
     // invocation of `reawaken`. This flag is only ever accessed inside the
     // lock, so there's no need to make it atomic.
-    fn deschedule(mut ~self, times: uint, mut cur_task: Box<Task>,
+    fn deschedule(mut self: Box<Ops>,
+                  times: uint,
+                  mut cur_task: Box<Task>,
                   f: |BlockedTask| -> Result<(), BlockedTask>) {
         let me = &mut *self as *mut Ops;
         cur_task.put_runtime(self);
@@ -250,7 +252,7 @@ impl rt::Runtime for Ops {
 
     // See the comments on `deschedule` for why the task is forgotten here, and
     // why it's valid to do so.
-    fn reawaken(mut ~self, mut to_wake: Box<Task>) {
+    fn reawaken(mut self: Box<Ops>, mut to_wake: Box<Task>) {
         unsafe {
             let me = &mut *self as *mut Ops;
             to_wake.put_runtime(self);
@@ -261,7 +263,7 @@ impl rt::Runtime for Ops {
         }
     }
 
-    fn spawn_sibling(~self,
+    fn spawn_sibling(self: Box<Ops>,
                      mut cur_task: Box<Task>,
                      opts: TaskOpts,
                      f: proc():Send) {

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -1051,7 +1051,6 @@ fn determine_explicit_self_category<AC:AstConv,
                                          lifetime);
             ty::ByReferenceExplicitSelfCategory(region, mutability)
         }
-        ast::SelfUniq(_) => ty::ByBoxExplicitSelfCategory,
         ast::SelfExplicit(ast_type, _) => {
             let explicit_type = ast_ty_to_ty(this, rscope, &*ast_type);
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -779,7 +779,6 @@ impl Clean<SelfTy> for ast::ExplicitSelf_ {
         match *self {
             ast::SelfStatic => SelfStatic,
             ast::SelfValue(_) => SelfValue,
-            ast::SelfUniq(_) => SelfOwned,
             ast::SelfRegion(lt, mt, _) => {
                 SelfBorrowed(lt.clean(), mt.clean())
             }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -491,7 +491,7 @@ impl<'a> fmt::Show for Method<'a> {
         match *selfty {
             clean::SelfStatic => {},
             clean::SelfValue => args.push_str("self"),
-            clean::SelfOwned => args.push_str("~self"),
+            clean::SelfOwned => args.push_str("self: Box<Self>"),
             clean::SelfBorrowed(Some(ref lt), mtbl) => {
                 args.push_str(format!("&amp;{} {}self", *lt,
                                       MutableSpace(mtbl)).as_slice());

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -74,15 +74,17 @@ pub mod unwind;
 pub trait Runtime {
     // Necessary scheduling functions, used for channels and blocking I/O
     // (sometimes).
-    fn yield_now(~self, cur_task: Box<Task>);
-    fn maybe_yield(~self, cur_task: Box<Task>);
-    fn deschedule(~self, times: uint, cur_task: Box<Task>,
+    fn yield_now(self: Box<Self>, cur_task: Box<Task>);
+    fn maybe_yield(self: Box<Self>, cur_task: Box<Task>);
+    fn deschedule(self: Box<Self>,
+                  times: uint,
+                  cur_task: Box<Task>,
                   f: |BlockedTask| -> Result<(), BlockedTask>);
-    fn reawaken(~self, to_wake: Box<Task>);
+    fn reawaken(self: Box<Self>, to_wake: Box<Task>);
 
     // Miscellaneous calls which are very different depending on what context
     // you're in.
-    fn spawn_sibling(~self,
+    fn spawn_sibling(self: Box<Self>,
                      cur_task: Box<Task>,
                      opts: TaskOpts,
                      f: proc():Send);
@@ -92,7 +94,7 @@ pub trait Runtime {
     fn can_block(&self) -> bool;
 
     // FIXME: This is a serious code smell and this should not exist at all.
-    fn wrap(~self) -> Box<Any>;
+    fn wrap(self: Box<Self>) -> Box<Any>;
 }
 
 /// The default error code of the rust runtime if the main task fails instead

--- a/src/librustrt/rtio.rs
+++ b/src/librustrt/rtio.rs
@@ -238,7 +238,7 @@ pub trait IoFactory {
 }
 
 pub trait RtioTcpListener : RtioSocket {
-    fn listen(~self) -> IoResult<Box<RtioTcpAcceptor + Send>>;
+    fn listen(self: Box<Self>) -> IoResult<Box<RtioTcpAcceptor + Send>>;
 }
 
 pub trait RtioTcpAcceptor : RtioSocket {
@@ -329,7 +329,7 @@ pub trait RtioPipe {
 }
 
 pub trait RtioUnixListener {
-    fn listen(~self) -> IoResult<Box<RtioUnixAcceptor + Send>>;
+    fn listen(self: Box<Self>) -> IoResult<Box<RtioUnixAcceptor + Send>>;
 }
 
 pub trait RtioUnixAcceptor {

--- a/src/librustrt/task.rs
+++ b/src/librustrt/task.rs
@@ -203,7 +203,7 @@ impl Task {
     /// }).destroy();
     /// # }
     /// ```
-    pub fn run(~self, f: ||) -> Box<Task> {
+    pub fn run(self: Box<Task>, f: ||) -> Box<Task> {
         assert!(!self.is_destroyed(), "cannot re-use a destroyed task");
 
         // First, make sure that no one else is in TLS. This does not allow
@@ -239,7 +239,7 @@ impl Task {
     ///
     /// The returned task cannot be used for running any more code, but it may
     /// be used to extract the runtime as necessary.
-    pub fn destroy(~self) -> Box<Task> {
+    pub fn destroy(self: Box<Task>) -> Box<Task> {
         if self.is_destroyed() {
             self
         } else {
@@ -252,7 +252,7 @@ impl Task {
     /// This function consumes ownership of the task, deallocating it once it's
     /// done being processed. It is assumed that TLD and the local heap have
     /// already been destroyed and/or annihilated.
-    fn cleanup(~self, result: Result) -> Box<Task> {
+    fn cleanup(self: Box<Task>, result: Result) -> Box<Task> {
         // The first thing to do when cleaning up is to deallocate our local
         // resources, such as TLD and GC data.
         //
@@ -394,7 +394,9 @@ impl Task {
 
     /// Spawns a sibling to this task. The newly spawned task is configured with
     /// the `opts` structure and will run `f` as the body of its code.
-    pub fn spawn_sibling(mut ~self, opts: TaskOpts, f: proc(): Send) {
+    pub fn spawn_sibling(mut self: Box<Task>,
+                         opts: TaskOpts,
+                         f: proc(): Send) {
         let ops = self.imp.take_unwrap();
         ops.spawn_sibling(self, opts, f)
     }
@@ -402,7 +404,8 @@ impl Task {
     /// Deschedules the current task, invoking `f` `amt` times. It is not
     /// recommended to use this function directly, but rather communication
     /// primitives in `std::comm` should be used.
-    pub fn deschedule(mut ~self, amt: uint,
+    pub fn deschedule(mut self: Box<Task>,
+                      amt: uint,
                       f: |BlockedTask| -> ::core::result::Result<(), BlockedTask>) {
         let ops = self.imp.take_unwrap();
         ops.deschedule(amt, self, f)
@@ -411,7 +414,7 @@ impl Task {
     /// Wakes up a previously blocked task, optionally specifying whether the
     /// current task can accept a change in scheduling. This function can only
     /// be called on tasks that were previously blocked in `deschedule`.
-    pub fn reawaken(mut ~self) {
+    pub fn reawaken(mut self: Box<Task>) {
         let ops = self.imp.take_unwrap();
         ops.reawaken(self);
     }
@@ -419,14 +422,14 @@ impl Task {
     /// Yields control of this task to another task. This function will
     /// eventually return, but possibly not immediately. This is used as an
     /// opportunity to allow other tasks a chance to run.
-    pub fn yield_now(mut ~self) {
+    pub fn yield_now(mut self: Box<Task>) {
         let ops = self.imp.take_unwrap();
         ops.yield_now(self);
     }
 
     /// Similar to `yield_now`, except that this function may immediately return
     /// without yielding (depending on what the runtime decides to do).
-    pub fn maybe_yield(mut ~self) {
+    pub fn maybe_yield(mut self: Box<Task>) {
         let ops = self.imp.take_unwrap();
         ops.maybe_yield(self);
     }

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -154,7 +154,7 @@ pub trait UvHandle<T> {
         mem::transmute(uvll::get_data_for_uv_handle(*h))
     }
 
-    fn install(~self) -> Box<Self> {
+    fn install(self: Box<Self>) -> Box<Self> {
         unsafe {
             let myptr = mem::transmute::<&Box<Self>, &*mut u8>(&self);
             uvll::set_data_for_uv_handle(self.uv_handle(), *myptr);

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -389,7 +389,8 @@ impl rtio::RtioSocket for TcpListener {
 }
 
 impl rtio::RtioTcpListener for TcpListener {
-    fn listen(~self) -> Result<Box<rtio::RtioTcpAcceptor + Send>, IoError> {
+    fn listen(self: Box<TcpListener>)
+              -> Result<Box<rtio::RtioTcpAcceptor + Send>, IoError> {
         // create the acceptor object from ourselves
         let mut acceptor = box TcpAcceptor {
             listener: self,

--- a/src/librustuv/pipe.rs
+++ b/src/librustuv/pipe.rs
@@ -248,7 +248,8 @@ impl PipeListener {
 }
 
 impl rtio::RtioUnixListener for PipeListener {
-    fn listen(~self) -> IoResult<Box<rtio::RtioUnixAcceptor + Send>> {
+    fn listen(self: Box<PipeListener>)
+              -> IoResult<Box<rtio::RtioUnixAcceptor + Send>> {
         // create the acceptor object from ourselves
         let mut acceptor = box PipeAcceptor {
             listener: self,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -955,8 +955,6 @@ pub enum ExplicitSelf_ {
     SelfValue(Ident),
     /// `&'lt self`, `&'lt mut self`
     SelfRegion(Option<Lifetime>, Mutability, Ident),
-    /// `~self`
-    SelfUniq(Ident),
     /// `self: TYPE`
     SelfExplicit(P<Ty>, Ident),
 }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -340,7 +340,7 @@ pub trait Folder {
 
     fn fold_explicit_self_(&mut self, es: &ExplicitSelf_) -> ExplicitSelf_ {
         match *es {
-            SelfStatic | SelfValue(_) | SelfUniq(_) => *es,
+            SelfStatic | SelfValue(_) => *es,
             SelfRegion(ref lifetime, m, id) => {
                 SelfRegion(fold_opt_lifetime(lifetime, self), m, id)
             }

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -31,6 +31,7 @@ pub enum ObsoleteSyntax {
     ObsoleteOwnedExpr,
     ObsoleteOwnedPattern,
     ObsoleteOwnedVector,
+    ObsoleteOwnedSelf,
     ObsoleteManagedType,
     ObsoleteManagedExpr,
 }
@@ -69,6 +70,10 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
             ObsoleteOwnedVector => (
                 "`~[T]` is no longer a type",
                 "use the `Vec` type instead"
+            ),
+            ObsoleteOwnedSelf => (
+                "`~self` is no longer supported",
+                "write `self: Box<Self>` instead"
             ),
             ObsoleteManagedType => (
                 "`@` notation for managed pointers",

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1892,9 +1892,6 @@ impl<'a> State<'a> {
             ast::SelfValue(_) => {
                 try!(word(&mut self.s, "self"));
             }
-            ast::SelfUniq(_) => {
-                try!(word(&mut self.s, "~self"));
-            }
             ast::SelfRegion(ref lt, m, _) => {
                 try!(word(&mut self.s, "&"));
                 try!(self.print_opt_lifetime(lt));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -216,7 +216,7 @@ pub fn walk_explicit_self<E: Clone, V: Visitor<E>>(visitor: &mut V,
                                                    explicit_self: &ExplicitSelf,
                                                    env: E) {
     match explicit_self.node {
-        SelfStatic | SelfValue(_) | SelfUniq(_) => {},
+        SelfStatic | SelfValue(_) => {},
         SelfRegion(ref lifetime, _, _) => {
             visitor.visit_opt_lifetime_ref(explicit_self.span, lifetime, env)
         }


### PR DESCRIPTION
This eliminates the last vestige of the `~` syntax.

Instead of `~self`, write `self: Box<TypeOfSelf>`; instead of `mut
~self`, write `mut self: Box<TypeOfSelf>`, replacing `TypeOfSelf` with
the self-type parameter as specified in the implementation.

Closes #13885.

[breaking-change]

r? @alexcrichton
