### PR TITLE
extending Saturating to include other arithmetic operations

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1195,9 +1195,18 @@ pub trait Saturating {
     /// Saturating subtraction operator.
     /// Returns a-b, saturating at the numeric bounds instead of overflowing.
     fn saturating_sub(self, v: Self) -> Self;
+
+    /// Saturating multiplication operator.
+    /// Returns a\*b, saturating at the numeric bounds instead of overflowing.
+    fn saturating_mul(self, v: Self) -> Self;
+
+    /// Saturating division operator.
+    /// Returns a/b, saturating at the numeric bounds instead of overflowing.
+    fn saturating_div(self, v: Self) -> Self;
 }
 
-impl<T: CheckedAdd + CheckedSub + Zero + PartialOrd + Bounded> Saturating for T {
+impl<T: CheckedAdd + CheckedSub + CheckedDiv + CheckedMul + Zero + PartialOrd + Bounded>
+Saturating for T {
     #[inline]
     fn saturating_add(self, v: T) -> T {
         match self.checked_add(&v) {
@@ -1218,6 +1227,32 @@ impl<T: CheckedAdd + CheckedSub + Zero + PartialOrd + Bounded> Saturating for T 
                 Bounded::min_value()
             } else {
                 Bounded::max_value()
+            }
+        }
+    }
+
+    #[inline]
+    fn saturating_mul(self, v: T) -> T {
+        match self.checked_mul(&v) {
+            Some(x) => x,
+            None => if (self < Zero::zero()) == (v < Zero::zero()) {
+                Bounded::max_value()
+            } else {
+                Bounded::min_value()
+            }
+        }
+    }
+
+    #[inline]
+    fn saturating_div(self, v: T) -> T {
+        match self.checked_div(&v) {
+            Some(x) => x,
+            None => if v == Zero::zero() {
+                fail!("div by zero cannot be saturated")
+            } else if (self < Zero::zero()) == (v < Zero::zero()) {
+                Bounded::max_value()
+            } else {
+                Bounded::min_value()
             }
         }
     }


### PR DESCRIPTION
I see no reason not to support mul/div here. Div is perhaps a bit over-engineered since there's no plausible mechanism to get to the min_value branch using our integer types (which are the only ones we support right now). Still, a theoretical Num type could reach there.

I'm a bit irked that I basically regress the div-by-zero checking provided by CheckedDiv, but I see no way to reasonably handle it.

I can't seem to find _any_ existing tests for Saturating. I'd be more than happy to write tests if someone could point me to the right place.
