### PR TITLE
Fix various distribution build targets to package all target bins

### DIFF
--- a/configure
+++ b/configure
@@ -422,6 +422,8 @@ opt rpath 0 "build rpaths into rustc itself"
 opt nightly 0 "build nightly packages"
 opt verify-install 1 "verify installed binaries work"
 opt jemalloc 1 "build liballoc with jemalloc"
+# This is used by the automation to produce single-target nightlies
+opt dist-host-only 0 "only install bins for the host architecture"
 valopt prefix "/usr/local" "set installation prefix"
 valopt local-rust-root "/usr/local" "set prefix for local rust binary"
 valopt llvm-root "" "set LLVM root"

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -156,7 +156,7 @@ define DEF_OSX_PKG
 $$(eval $$(call DEF_PREPARE,osx-$(1)))
 
 dist-prepare-osx-$(1): PREPARE_HOST=$(1)
-dist-prepare-osx-$(1): PREPARE_TARGETS=$(1)
+dist-prepare-osx-$(1): PREPARE_TARGETS=$(2)
 dist-prepare-osx-$(1): PREPARE_DEST_DIR=tmp/dist/pkgroot-$(1)
 dist-prepare-osx-$(1): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-prepare-osx-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
@@ -187,7 +187,11 @@ tmp/dist/pkgres-$(1)/%: $(S)src/etc/pkg/%
 
 endef
 
-$(foreach host,$(CFG_HOST),$(eval $(call DEF_OSX_PKG,$(host))))
+ifneq ($(CFG_ENABLE_DIST_HOST_ONLY),)
+$(foreach host,$(CFG_HOST),$(eval $(call DEF_OSX_PKG,$(host),$(host))))
+else
+$(foreach host,$(CFG_HOST),$(eval $(call DEF_OSX_PKG,$(host),$(TARGET))))
+endif
 
 dist-osx: $(foreach host,$(CFG_HOST),dist/$(PKG_NAME)-$(host).pkg)
 
@@ -210,7 +214,7 @@ define DEF_INSTALLER
 $$(eval $$(call DEF_PREPARE,dir-$(1)))
 
 dist-install-dir-$(1): PREPARE_HOST=$(1)
-dist-install-dir-$(1): PREPARE_TARGETS=$(1)
+dist-install-dir-$(1): PREPARE_TARGETS=$(2)
 dist-install-dir-$(1): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)
 dist-install-dir-$(1): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-install-dir-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
@@ -235,8 +239,13 @@ dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)
 
 endef
 
+ifneq ($(CFG_ENABLE_DIST_HOST_ONLY),)
 $(foreach host,$(CFG_HOST),\
-  $(eval $(call DEF_INSTALLER,$(host))))
+  $(eval $(call DEF_INSTALLER,$(host),$(host))))
+else
+$(foreach host,$(CFG_HOST),\
+  $(eval $(call DEF_INSTALLER,$(host),$(CFG_TARGET))))
+endif
 
 dist-install-dirs: $(foreach host,$(CFG_HOST),dist-install-dir-$(host))
 

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -205,17 +205,19 @@ distcheck-osx: dist-osx
 # Unix binary installer tarballs
 ######################################################################
 
-define DEF_PREPARE_DIST_DIR
+define DEF_INSTALLER
 
-dist-install-dir-$(1)$(3): PREPARE_HOST=$(1)
-dist-install-dir-$(1)$(3): PREPARE_TARGETS=$(2)
-dist-install-dir-$(1)$(3): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)
-dist-install-dir-$(1)$(3): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
-dist-install-dir-$(1)$(3): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
-dist-install-dir-$(1)$(3): PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
-dist-install-dir-$(1)$(3): PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
-dist-install-dir-$(1)$(3): PREPARE_CLEAN=true
-dist-install-dir-$(1)$(3): prepare-base-dir-$(1) docs compiler-docs
+$$(eval $$(call DEF_PREPARE,dir-$(1)))
+
+dist-install-dir-$(1): PREPARE_HOST=$(1)
+dist-install-dir-$(1): PREPARE_TARGETS=$(1)
+dist-install-dir-$(1): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)
+dist-install-dir-$(1): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
+dist-install-dir-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
+dist-install-dir-$(1): PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
+dist-install-dir-$(1): PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
+dist-install-dir-$(1): PREPARE_CLEAN=true
+dist-install-dir-$(1): prepare-base-dir-$(1) docs compiler-docs
 	$$(Q)(cd $$(PREPARE_DEST_DIR)/ && find . -type f | sed 's/^\.\///') \
       > tmp/dist/manifest-$(1).in
 	$$(Q)mv tmp/dist/manifest-$(1).in $$(PREPARE_DEST_DIR)/$$(CFG_LIBDIR_RELATIVE)/rustlib/manifest.in
@@ -226,16 +228,6 @@ dist-install-dir-$(1)$(3): prepare-base-dir-$(1) docs compiler-docs
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)README.md $$(PREPARE_DEST_DIR)
 	$$(Q)cp -r doc $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_BIN_CMD) $$(S)src/etc/install.sh $$(PREPARE_DEST_DIR)
-
-endef
-
-define DEF_INSTALLER
-
-$$(eval $$(call DEF_PREPARE,dir-$(1)))
-
-$$(eval $$(call DEF_PREPARE_DIST_DIR,$(1),$(1),))
-
-$$(eval $$(call DEF_PREPARE_DIST_DIR,$(1),$(CFG_TARGET),-with-target-libs))
 
 dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)
 	@$(call E, build: $$@)

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -14,12 +14,12 @@ else
 MAYBE_DISABLE_VERIFY=
 endif
 
-install: dist-install-dir-$(CFG_BUILD)-with-target-libs | tmp/empty_dir
+install: dist-install-dir-$(CFG_BUILD) | tmp/empty_dir
 	$(Q)cd tmp/empty_dir && sh ../../tmp/dist/$(PKG_NAME)-$(CFG_BUILD)/install.sh --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)" "$(MAYBE_DISABLE_VERIFY)"
 # Remove tmp files while we can because they may have been created under sudo
 	$(Q)rm -R tmp/dist
 
-uninstall: dist-install-dir-$(CFG_BUILD)-with-target-libs | tmp/empty_dir
+uninstall: dist-install-dir-$(CFG_BUILD) | tmp/empty_dir
 	$(Q)cd tmp/empty_dir && sh ../../tmp/dist/$(PKG_NAME)-$(CFG_BUILD)/install.sh --uninstall --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)"
 # Remove tmp files while we can because they may have been created under sudo
 	$(Q)rm -R tmp/dist


### PR DESCRIPTION
The first commit reverts a similar fix that only solves the `make install` case. This adds the `--enable-dist-host-only` flag to configure to preserve the old behavior, which the nightly bots rely on. The bots will need to be updated soon after this lands (or they will ~double in size).

Closes https://github.com/rust-lang/rust/issues/15711
