### PR TITLE
rustdoc: make table of contents optional

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -131,7 +131,8 @@ pub fn opts() -> Vec<getopts::OptGroup> {
                  Markdown file or generated documentation",
                  "FILES"),
         optopt("", "markdown-playground-url",
-               "URL to send code snippets to", "URL")
+               "URL to send code snippets to", "URL"),
+        optflag("", "markdown-no-toc", "don't include table of contents")
     )
 }
 
@@ -220,7 +221,8 @@ pub fn main_args(args: &[String]) -> int {
             return test::run(input, cfgs, libs, externs, test_args)
         }
         (false, true) => return markdown::render(input, output.unwrap_or(Path::new("doc")),
-                                                 &matches, &external_html),
+                                                 &matches, &external_html,
+                                                 !matches.opt_present("markdown-no-toc")),
         (false, false) => {}
     }
 

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -20,7 +20,7 @@ use externalfiles::ExternalHtml;
 
 use html::escape::Escape;
 use html::markdown;
-use html::markdown::{MarkdownWithToc, find_testable_code, reset_headers};
+use html::markdown::{Markdown, MarkdownWithToc, find_testable_code, reset_headers};
 use test::Collector;
 
 /// Separate any lines at the start of the file that begin with `%`.
@@ -42,7 +42,7 @@ fn extract_leading_metadata<'a>(s: &'a str) -> (Vec<&'a str>, &'a str) {
 /// Render `input` (e.g. "foo.md") into an HTML file in `output`
 /// (e.g. output = "bar" => "bar/foo.html").
 pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
-              external_html: &ExternalHtml) -> int {
+              external_html: &ExternalHtml, include_toc: bool) -> int {
     let input_p = Path::new(input);
     output.push(input_p.filestem().unwrap());
     output.set_extension("html");
@@ -80,6 +80,12 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
 
     reset_headers();
 
+    let rendered = if include_toc {
+        format!("{}", MarkdownWithToc(text))
+    } else {
+        format!("{}", Markdown(text))
+    };
+
     let err = write!(
         &mut out,
         r#"<!DOCTYPE html>
@@ -113,7 +119,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
         css = css,
         in_header = external_html.in_header,
         before_content = external_html.before_content,
-        text = MarkdownWithToc(text),
+        text = rendered,
         after_content = external_html.after_content,
         playground = playground,
         );


### PR DESCRIPTION
rustdoc currently determines whether to produce a table of
contents (along with numbered sections) from the input type: yes for
markdown input, no for Rust input. This commit adds a flag to disable
the table of contents for markdown input, which is useful for embedding
the output in a larger context.
