### PR TITLE
rustdoc: Add a --crate-name option

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -102,6 +102,7 @@ pub fn opts() -> Vec<getopts::OptGroup> {
         optopt("w", "output-format", "the output type to write",
                "[html|json]"),
         optopt("o", "output", "where to place the output", "PATH"),
+        optopt("", "crate-name", "specify the name of this crate", "NAME"),
         optmulti("L", "library-path", "directory to add to crate search path",
                  "DIR"),
         optmulti("", "cfg", "pass a --cfg to rustc", ""),
@@ -321,7 +322,7 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
 
     let cr = Path::new(cratefile);
     info!("starting to run rustc");
-    let (krate, analysis) = std::task::try(proc() {
+    let (mut krate, analysis) = std::task::try(proc() {
         let cr = cr;
         core::run_core(libs.move_iter().collect(),
                        cfgs,
@@ -330,6 +331,11 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
     }).map_err(|boxed_any|format!("{:?}", boxed_any)).unwrap();
     info!("finished with rustc");
     analysiskey.replace(Some(analysis));
+
+    match matches.opt_str("crate-name") {
+        Some(name) => krate.name = name,
+        None => {}
+    }
 
     // Process all of the crate attributes, extracting plugin metadata along
     // with the passes which we are supposed to run.


### PR DESCRIPTION
Like rustc, this is required by cargo to build documentation.
