### PR TITLE
Fix #15896

### DIFF
--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -390,7 +390,9 @@ pub fn check_struct_like_enum_variant_pat(pcx: &pat_ctxt,
             check_struct_pat_fields(pcx, span, fields, class_fields,
                                     variant_id, substitutions, etc);
         }
-        Some(&def::DefStruct(..)) | Some(&def::DefVariant(..)) => {
+        Some(&def::DefStruct(..)) |
+        Some(&def::DefVariant(..)) |
+        Some(&def::DefTy(..)) => {
             let name = pprust::path_to_string(path);
             span_err!(tcx.sess, span, E0028,
                 "mismatched types: expected `{}` but found `{}`",

--- a/src/test/compile-fail/issue-15896.rs
+++ b/src/test/compile-fail/issue-15896.rs
@@ -1,0 +1,24 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #15896. It used to ICE rustc.
+
+fn main() {
+    enum R { REB(()) }
+    struct Tau { t: uint }
+    enum E { B(R, Tau) }
+
+    let e = B(REB(()), Tau { t: 3 });
+    let u = match e {
+        B(
+          Tau{t: x},    //~ ERROR mismatched types
+          _) => x,
+    };
+}


### PR DESCRIPTION
Fix ICE when there's an incorrect enum variant constructor in match arm.

Closes #15896.
