### PR TITLE
safety violation fix: RefCell::unwrap

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -238,8 +238,10 @@ impl<T> RefCell<T> {
     /// Consumes the `RefCell`, returning the wrapped value.
     #[unstable = "may be renamed, depending on global conventions"]
     pub fn unwrap(self) -> T {
-        debug_assert!(self.borrow.get() == UNUSED);
-        unsafe{self.value.unwrap()}
+        match self.borrow.get() {
+            UNUSED => unsafe { self.value.unwrap() },
+            _ => fail!("cannot unwrap RefCell<T> because it is already borrowed")
+        }
     }
 
     /// Attempts to immutably borrow the wrapped value.


### PR DESCRIPTION
The `unwrap` method for `RefCell` was using `debug_assert!` to check
that the `RefCell` was not aleady borrowed before unwrapping. However,
disabling this assertion can lead to safety violations.

This commit changes the code to fail explicitly with a useful message,
similarly to the `borrow` and `borrow_mut` methods.
