### PR TITLE
librustc: Check built-in trait bounds on implementations when direct

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -55,7 +55,7 @@
 //! }
 //!
 //! // This function wants to log its parameter out prior to doing work with it.
-//! fn do_work<T: Show>(value: &T) {
+//! fn do_work<T: Show+'static>(value: &T) {
 //!     log(value);
 //!     // ...do some other work
 //! }

--- a/src/test/compile-fail/kindck-impl-type-params-2.rs
+++ b/src/test/compile-fail/kindck-impl-type-params-2.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo {
+}
+
+impl<T:Copy> Foo for T {
+}
+
+fn take_param<T:Foo>(foo: &T) { }
+
+fn main() {
+    let x = box 3i;
+    take_param(&x);
+    //~^ ERROR instantiating a type parameter with an incompatible type
+}


### PR DESCRIPTION
method calls are involved.

This breaks code like:

```
impl<T:Copy> Foo for T { ... }

fn take_param<T:Foo>(foo: &T) { ... }

fn main() {
    let x = box 3i; // note no `Copy` bound
    take_param(&x);
}
```

Change this code to not contain a type error. For example:

```
impl<T:Copy> Foo for T { ... }

fn take_param<T:Foo>(foo: &T) { ... }

fn main() {
    let x = 3i; // satisfies `Copy` bound
    take_param(&x);
}
```

Closes #15860.

[breaking-change]

r? @alexcrichton
