### PR TITLE
Fix display of `-NaN%` in borrowck stats caused by div by zero

### DIFF
--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -98,9 +98,9 @@ pub fn check_crate(tcx: &ty::ctxt,
     }
 
     fn make_stat(bccx: &BorrowckCtxt, stat: uint) -> String {
-        let stat_f = stat as f64;
         let total = bccx.stats.guaranteed_paths.get() as f64;
-        format!("{} ({:.0f}%)", stat  , stat_f * 100.0 / total)
+        let perc = if total == 0.0 { 0.0 } else { stat as f64 * 100.0 / total };
+        format!("{} ({:.0f}%)", stat, perc)
     }
 }
 


### PR DESCRIPTION
`rustc -Z borrowck-stats` displays ugly `-NaN%` in the stats

```
paths requiring guarantees: 0
paths requiring loans     : 0 (-NaN%)
paths requiring imm loans : 0 (-NaN%)
stable paths              : 0 (-NaN%)
```
