### PR TITLE
Add keys() and values() methods for SmallIntMap, TreeMap and TrieMap

### DIFF
--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -17,6 +17,7 @@ use core::prelude::*;
 
 use core::default::Default;
 use core::fmt;
+use core::iter;
 use core::iter::{Enumerate, FilterMap};
 use core::mem::replace;
 
@@ -192,6 +193,18 @@ impl<V> SmallIntMap<V> {
     /// ```
     pub fn get<'a>(&'a self, key: &uint) -> &'a V {
         self.find(key).expect("key not present")
+    }
+
+    /// An iterator visiting all keys in ascending order by the keys.
+    /// Iterator element type is `uint`.
+    pub fn keys<'r>(&'r self) -> Keys<'r, V> {
+        self.iter().map(|(k, _v)| k)
+    }
+
+    /// An iterator visiting all values in ascending order by the keys.
+    /// Iterator element type is `&'r V`.
+    pub fn values<'r>(&'r self) -> Values<'r, V> {
+        self.iter().map(|(_k, v)| v)
     }
 
     /// An iterator visiting all key-value pairs in ascending order by the keys.
@@ -422,6 +435,14 @@ pub struct MutEntries<'a, T> {
 iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
 double_ended_iterator!(impl MutEntries -> (uint, &'a mut T), get_mut_ref)
 
+/// Forward iterator over the keys of a map
+pub type Keys<'a, T> =
+    iter::Map<'static, (uint, &'a T), uint, Entries<'a, T>>;
+
+/// Forward iterator over the values of a map
+pub type Values<'a, T> =
+    iter::Map<'static, (uint, &'a T), &'a T, Entries<'a, T>>;
+
 #[cfg(test)]
 mod test_map {
     use std::prelude::*;
@@ -515,6 +536,32 @@ mod test_map {
         m.insert(1, 2i);
         assert_eq!(m.pop(&1), Some(2));
         assert_eq!(m.pop(&1), None);
+    }
+
+    #[test]
+    fn test_keys() {
+        let mut map = SmallIntMap::new();
+        map.insert(1, 'a');
+        map.insert(2, 'b');
+        map.insert(3, 'c');
+        let keys = map.keys().collect::<Vec<uint>>();
+        assert_eq!(keys.len(), 3);
+        assert!(keys.contains(&1));
+        assert!(keys.contains(&2));
+        assert!(keys.contains(&3));
+    }
+
+    #[test]
+    fn test_values() {
+        let mut map = SmallIntMap::new();
+        map.insert(1, 'a');
+        map.insert(2, 'b');
+        map.insert(3, 'c');
+        let values = map.values().map(|&v| v).collect::<Vec<char>>();
+        assert_eq!(values.len(), 3);
+        assert!(values.contains(&'a'));
+        assert!(values.contains(&'b'));
+        assert!(values.contains(&'c'));
     }
 
     #[test]

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -141,6 +141,16 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// Create an empty TreeMap
     pub fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
 
+    /// Get a lazy iterator over the keys in the map.
+    pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
+        self.iter().map(|(k, _v)| k)
+    }
+
+    /// Get a lazy iterator over the values in the map.
+    pub fn values<'a>(&'a self) -> Values<'a, K, V> {
+        self.iter().map(|(_k, v)| v)
+    }
+
     /// Get a lazy iterator over the key-value pairs in the map.
     /// Requires that it be frozen (immutable).
     pub fn iter<'a>(&'a self) -> Entries<'a, K, V> {
@@ -379,6 +389,15 @@ pub struct MutEntries<'a, K, V> {
 pub struct RevMutEntries<'a, K, V> {
     iter: MutEntries<'a, K, V>,
 }
+
+
+/// TreeMap keys iterator
+pub type Keys<'a, K, V> =
+    iter::Map<'static, (&'a K, &'a V), &'a K, Entries<'a, K, V>>;
+
+/// TreeMap values iterator
+pub type Values<'a, K, V> =
+    iter::Map<'static, (&'a K, &'a V), &'a V, Entries<'a, K, V>>;
 
 
 // FIXME #5846 we want to be able to choose between &x and &mut x
@@ -1468,6 +1487,28 @@ mod test_treemap {
 
         assert!(m_lower.iter().all(|(_, &x)| x == 0));
         assert!(m_upper.iter().all(|(_, &x)| x == 0));
+    }
+
+    #[test]
+    fn test_keys() {
+        let vec = vec![(1i, 'a'), (2i, 'b'), (3i, 'c')];
+        let map = vec.move_iter().collect::<TreeMap<int, char>>();
+        let keys = map.keys().map(|&k| k).collect::<Vec<int>>();
+        assert_eq!(keys.len(), 3);
+        assert!(keys.contains(&1));
+        assert!(keys.contains(&2));
+        assert!(keys.contains(&3));
+    }
+
+    #[test]
+    fn test_values() {
+        let vec = vec![(1i, 'a'), (2i, 'b'), (3i, 'c')];
+        let map = vec.move_iter().collect::<TreeMap<int, char>>();
+        let values = map.values().map(|&v| v).collect::<Vec<char>>();
+        assert_eq!(values.len(), 3);
+        assert!(values.contains(&'a'));
+        assert!(values.contains(&'b'));
+        assert!(values.contains(&'c'));
     }
 
     #[test]


### PR DESCRIPTION
Adds methods for obtaining iterators over the keys or values of a SmallIntMap/TreeMap/TrieMap.

Closes #14376
