### PR TITLE
rustc: Future proof runtime injection

### DIFF
--- a/src/librustc/front/std_inject.rs
+++ b/src/librustc/front/std_inject.rs
@@ -86,9 +86,15 @@ impl<'a> fold::Folder for StandardLibraryInjector<'a> {
             *ty == config::CrateTypeExecutable
         });
         if use_start(&krate) && any_exe {
+            let visible_rt_name = "rt";
+            let actual_rt_name = "native";
+            // Gensym the ident so it can't be named
+            let visible_rt_name = token::gensym_ident(visible_rt_name);
+            let actual_rt_name = token::intern_and_get_ident(actual_rt_name);
+
             vis.push(ast::ViewItem {
-                node: ast::ViewItemExternCrate(token::str_to_ident("native"),
-                                               None,
+                node: ast::ViewItemExternCrate(visible_rt_name,
+                                               Some((actual_rt_name, ast::CookedStr)),
                                                ast::DUMMY_NODE_ID),
                 attrs: Vec::new(),
                 vis: ast::Inherited,

--- a/src/test/compile-fail/hidden-rt-injection.rs
+++ b/src/test/compile-fail/hidden-rt-injection.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This is testing that users can't access the runtime crate.
+
+mod m {
+    // The rt has been called both 'native' and 'rt'
+    use native; //~ ERROR unresolved import
+}
+
+fn main() { }

--- a/src/test/compile-fail/hidden-rt-injection2.rs
+++ b/src/test/compile-fail/hidden-rt-injection2.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This is testing that users can't access the runtime crate.
+
+mod m {
+    // The rt has been called both 'native' and 'rt'
+    use rt; //~ ERROR unresolved import
+}
+
+fn main() { }


### PR DESCRIPTION
Rename and gensym the runtime on import, so that users
can't refer to the `native` crate.

This is unlikely to break code, but users should import the "native" crate directly.

[breaking-change]

cc @alexcrichton
