### PR TITLE
Preparing for running lexer tests on bots

### DIFF
--- a/mk/grammar.mk
+++ b/mk/grammar.mk
@@ -13,7 +13,7 @@ SG = $(S)src/grammar/
 B = $(CFG_BUILD_DIR)/$(CFG_BUILD)/stage2/
 L = $(B)lib/rustlib/$(CFG_BUILD)/lib
 LD = $(CFG_BUILD)/stage2/lib/rustlib/$(CFG_BUILD)/lib/
-RUSTC = $(B)bin/rustc
+RUSTC = $(STAGE2_T_$(CFG_BUILD)_H_$(CFG_BUILD))
 
 # Run the reference lexer against libsyntax and compare the tokens and spans.
 # If "// ignore-lexer-test" is present in the file, it will be ignored.
@@ -37,19 +37,25 @@ $(BG)RustLexer.class: $(SG)RustLexer.g4
 $(BG)verify: $(SG)verify.rs rustc-stage2-H-$(CFG_BUILD) $(LD)stamp.regex_macros $(LD)stamp.rustc
 	$(Q)$(RUSTC) -O --out-dir $(BG) -L $(L) $(SG)verify.rs
 
-check-lexer: $(BG) $(BG)RustLexer.class $(BG)verify
 ifdef CFG_JAVAC
 ifdef CFG_ANTLR4
 ifdef CFG_GRUN
+check-lexer: $(BG) $(BG)RustLexer.class $(BG)verify
 	$(info Verifying libsyntax against the reference lexer ...)
 	$(Q)$(SG)check.sh $(S) "$(BG)" \
 		"$(CFG_GRUN)" "$(BG)verify" "$(BG)RustLexer.tokens"
 else
 $(info grun not available, skipping lexer test...)
+check-lexer:
+
 endif
 else
 $(info antlr4 not available, skipping lexer test...)
+check-lexer:
+
 endif
 else
 $(info javac not available, skipping lexer test...)
+check-lexer:
+
 endif

--- a/mk/grammar.mk
+++ b/mk/grammar.mk
@@ -45,17 +45,17 @@ check-lexer: $(BG) $(BG)RustLexer.class $(BG)verify
 	$(Q)$(SG)check.sh $(S) "$(BG)" \
 		"$(CFG_GRUN)" "$(BG)verify" "$(BG)RustLexer.tokens"
 else
-$(info grun not available, skipping lexer test...)
+$(info cfg: grun not available, skipping lexer test...)
 check-lexer:
 
 endif
 else
-$(info antlr4 not available, skipping lexer test...)
+$(info cfg: antlr4 not available, skipping lexer test...)
 check-lexer:
 
 endif
 else
-$(info javac not available, skipping lexer test...)
+$(info cfg: javac not available, skipping lexer test...)
 check-lexer:
 
 endif

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -171,33 +171,43 @@ endif
 # Main test targets
 ######################################################################
 
+# The main testing target. Tests lots of stuff.
 check: cleantmptestlogs cleantestlibs check-notidy tidy
 
+# As above but don't bother running tidy.
 check-notidy: cleantmptestlogs cleantestlibs all check-stage2
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
+# A slightly smaller set of tests for smoke testing.
 check-lite: cleantestlibs cleantmptestlogs \
 	$(foreach crate,$(TEST_TARGET_CRATES),check-stage2-$(crate)) \
 	check-stage2-rpass \
 	check-stage2-rfail check-stage2-cfail check-stage2-rmake
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
+# Only check the 'reference' tests: rpass/cfail/rfail/rmake.
 check-ref: cleantestlibs cleantmptestlogs check-stage2-rpass \
 	check-stage2-rfail check-stage2-cfail check-stage2-rmake
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
+# Only check the docs.
 check-docs: cleantestlibs cleantmptestlogs check-stage2-docs
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
 # NOTE: Remove after reprogramming windows bots
 check-fast: check-lite
 
-check-all: check check-secondary
-
+# Some less critical tests that are not prone to breakage.
+# Not run as part of the normal test suite, but tested by bors on checkin.
 check-secondary: check-syntax check-pretty
 
+# check + check-secondary.
+check-all: check check-secondary
+
+# Run the grammar tests.
 check-syntax: check-lexer
 
+# Pretty-printing tests.
 check-pretty: check-stage2-T-$(CFG_BUILD)-H-$(CFG_BUILD)-pretty-exec
 
 .PHONY: cleantmptestlogs cleantestlibs

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -192,7 +192,13 @@ check-docs: cleantestlibs cleantmptestlogs check-stage2-docs
 # NOTE: Remove after reprogramming windows bots
 check-fast: check-lite
 
+check-all: check check-secondary
+
+check-secondary: check-syntax check-pretty
+
 check-syntax: check-lexer
+
+check-pretty: check-stage2-T-$(CFG_BUILD)-H-$(CFG_BUILD)-pretty-exec
 
 .PHONY: cleantmptestlogs cleantestlibs
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -199,13 +199,10 @@ check-fast: check-lite
 
 # Some less critical tests that are not prone to breakage.
 # Not run as part of the normal test suite, but tested by bors on checkin.
-check-secondary: check-syntax check-pretty
+check-secondary: check-lexer check-pretty
 
 # check + check-secondary.
 check-all: check check-secondary
-
-# Run the grammar tests.
-check-syntax: check-lexer
 
 # Pretty-printing tests.
 check-pretty: check-stage2-T-$(CFG_BUILD)-H-$(CFG_BUILD)-pretty-exec


### PR DESCRIPTION
Add `check-secondary`, which runs the pretty and lexer tests so we can run them on a dedicated bot. Leaves the pretty tests running under `check` until the bots are switched over. Also fixes some issues.

r? @cmr
