### PR TITLE
libcore::iter Refactor Iterator::next() for Skip

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1581,27 +1581,16 @@ pub struct Skip<T> {
 impl<A, T: Iterator<A>> Iterator<A> for Skip<T> {
     #[inline]
     fn next(&mut self) -> Option<A> {
-        let mut next = self.iter.next();
-        if self.n == 0 {
-            next
-        } else {
-            let mut n = self.n;
-            while n > 0 {
-                n -= 1;
-                match next {
-                    Some(_) => {
-                        next = self.iter.next();
-                        continue
-                    }
-                    None => {
-                        self.n = 0;
-                        return None
-                    }
-                }
+        let mut n = self.n;
+        for elem in self.iter {
+            if n == 0 {
+                self.n = 0;
+                return Some(elem);
             }
-            self.n = 0;
-            next
+            n -= 1;
         }
+        if n != self.n { self.n = n }
+        None
     }
 
     #[inline]

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -13,6 +13,7 @@ use core::iter::order::*;
 use core::uint;
 use core::cmp;
 use core::num;
+use test::Bencher;
 
 #[test]
 fn test_lt() {
@@ -842,3 +843,24 @@ fn test_iterate() {
     assert_eq!(it.next(), Some(4u));
     assert_eq!(it.next(), Some(8u));
 }
+
+// Some benchmarks
+
+#[bench]
+fn bench_skip(b: &mut Bencher) {
+    let xs = [0u, 1, 2, 3, 5, 13, 15, 16, 17, 19, 20, 30];
+    b.iter(|| xs.iter().skip(5).next());
+}
+
+#[bench]
+fn bench_skip_zero(b: &mut Bencher) {
+    let xs = [0u, 1, 2, 3, 5, 13, 15, 16, 17, 19, 20, 30];
+    b.iter(|| xs.iter().skip(0).next());
+}
+
+#[bench]
+fn bench_skip_reach_end(b: &mut Bencher) {
+    let xs = [0u, 1, 2, 3, 5, 13, 15, 16, 17, 19, 20, 30];
+    b.iter(|| xs.iter().skip(20).next());
+}
+


### PR DESCRIPTION
So I simplified the code, taking into account the points raised in the discussion.

I added some benchmarks, and verified that the performance improved. It's about twice as fast on the benchmarks.

Close reason (last comment)

> Hmm now that I understand more the code I think I need more benchmarks before changing that part. I need to test with big iterators and big skip ranges. I will close that request for now and think more. I will come back with more detailed benchmarks at least, even if I am not changing the code.
