### PR TITLE
librustc: Resolve regions and report errors in trait/impl method

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1076,6 +1076,10 @@ fn compare_impl_method(tcx: &ty::ctxt,
             ty::note_and_explain_type_err(tcx, terr);
         }
     }
+
+    // Finally, resolve all regions. This catches wily misuses of lifetime
+    // parameters.
+    infcx.resolve_regions_and_report_errors();
 }
 
 fn check_cast(fcx: &FnCtxt,

--- a/src/test/compile-fail/trait-matching-lifetimes.rs
+++ b/src/test/compile-fail/trait-matching-lifetimes.rs
@@ -1,0 +1,30 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that the trait matching code takes lifetime parameters into account.
+// (Issue #15517.)
+
+struct Foo<'a,'b> {
+    x: &'a int,
+    y: &'b int,
+}
+
+trait Tr {
+    fn foo(x: Self) {}
+}
+
+impl<'a,'b> Tr for Foo<'a,'b> {
+    fn foo(x: Foo<'b,'a>) {
+        //~^ ERROR method not compatible with trait
+        //~^^ ERROR method not compatible with trait
+    }
+}
+
+fn main(){}


### PR DESCRIPTION
matching.

This breaks code like:

```
struct Foo<'a,'b> {
    x: &'a int,
    y: &'b int,
}

trait Tr {
    fn foo(x: Self) {}
}

impl<'a,'b> Tr for Foo<'a,'b> {
    fn foo(x: Foo<'b,'a>) {} // <-- bad
}
```

Change this code to not contain a lifetime mismatch error. For example:

```
struct Foo<'a,'b> {
    x: &'a int,
    y: &'b int,
}

trait Tr {
    fn foo(x: Self) {}
}

impl<'a,'b> Tr for Foo<'a,'b> {
    fn foo(x: Foo<'a,'b>) {} // OK
}
```

Closes #15517.

[breaking-change]

r? @alexcrichton
