### PR TITLE
libsync: Add safer abstraction for SPSC queue.

### DIFF
--- a/src/libsync/comm/stream.rs
+++ b/src/libsync/comm/stream.rs
@@ -74,7 +74,7 @@ enum Message<T> {
 impl<T: Send> Packet<T> {
     pub fn new() -> Packet<T> {
         Packet {
-            queue: spsc::Queue::new(128),
+            queue: unsafe { spsc::Queue::new(128) },
 
             cnt: atomics::AtomicInt::new(0),
             steals: 0,


### PR DESCRIPTION
The current spsc implementation doesn't enforce single-producer
single-consumer usage and also allows unsafe memory use through
peek & pop.

For safer usage, `new` now returns a pair of owned objects which
only allow consumer or producer behaviors through an `Arc`.
Through restricting the mutability of the receiver to `mut` the
peek and pop behavior becomes safe again, with the compiler
complaining about usage which could lead to problems.

To fix code broken from this, update:
Queue::new(x) -> unsafe { Queue::unchecked_new(x) }

[breaking-change]

For an example of broken behavior, check the added test which uses the unchecked constructor.
