### PR TITLE
Fix a typo in SmallIntMap documentation

### DIFF
--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -263,7 +263,7 @@ impl<V> SmallIntMap<V> {
         }
     }
 
-    /// Empties the hash map, moving all values into the specified closure.
+    /// Empties the map, moving all values into the specified closure.
     ///
     /// # Example
     ///


### PR DESCRIPTION
SmallIntMap doesn't involve hashing?
