### PR TITLE
Make use of the dereferenceable attribute instead of nonnull where we can.

### DIFF
--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -12,7 +12,7 @@
 #![allow(non_snake_case_functions)]
 
 use llvm;
-use llvm::{CallConv, AtomicBinOp, AtomicOrdering, AsmDialect};
+use llvm::{CallConv, AtomicBinOp, AtomicOrdering, AsmDialect, AttrBuilder};
 use llvm::{Opcode, IntPredicate, RealPredicate};
 use llvm::{ValueRef, BasicBlockRef};
 use middle::trans::common::*;
@@ -113,7 +113,7 @@ pub fn Invoke(cx: &Block,
               args: &[ValueRef],
               then: BasicBlockRef,
               catch: BasicBlockRef,
-              attributes: &[(uint, u64)])
+              attributes: Option<AttrBuilder>)
               -> ValueRef {
     if cx.unreachable.get() {
         return C_null(Type::i8(cx.ccx()));
@@ -681,13 +681,13 @@ pub fn InlineAsmCall(cx: &Block, asm: *const c_char, cons: *const c_char,
 }
 
 pub fn Call(cx: &Block, fn_: ValueRef, args: &[ValueRef],
-            attributes: &[(uint, u64)]) -> ValueRef {
+            attributes: Option<AttrBuilder>) -> ValueRef {
     if cx.unreachable.get() { return _UndefReturn(cx, fn_); }
     B(cx).call(fn_, args, attributes)
 }
 
 pub fn CallWithConv(cx: &Block, fn_: ValueRef, args: &[ValueRef], conv: CallConv,
-                    attributes: &[(uint, u64)]) -> ValueRef {
+                    attributes: Option<AttrBuilder>) -> ValueRef {
     if cx.unreachable.get() { return _UndefReturn(cx, fn_); }
     B(cx).call_with_conv(fn_, args, conv, attributes)
 }

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -588,7 +588,7 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
     }
     llargs.extend(args.iter().map(|arg| arg.val));
 
-    let retval = Call(bcx, fn_ptr, llargs.as_slice(), []);
+    let retval = Call(bcx, fn_ptr, llargs.as_slice(), None);
     if type_is_zero_size(ccx, f.sig.output) || fcx.llretptr.get().is_some() {
         RetVoid(bcx);
     } else {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -553,7 +553,7 @@ fn trans_index<'a>(bcx: &'a Block<'a>,
             let expected = Call(bcx,
                                 expect,
                                 [bounds_check, C_bool(ccx, false)],
-                                []);
+                                None);
             bcx = with_cond(bcx, expected, |bcx| {
                 controlflow::trans_fail_bounds_check(bcx,
                                                      index_expr.span,

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -382,21 +382,21 @@ pub fn trans_native_call<'a>(
 
     // A function pointer is called without the declaration available, so we have to apply
     // any attributes with ABI implications directly to the call instruction.
-    let mut attrs = Vec::new();
+    let mut attrs = llvm::AttrBuilder::new();
 
     // Add attributes that are always applicable, independent of the concrete foreign ABI
     if fn_type.ret_ty.is_indirect() {
         // The outptr can be noalias and nocapture because it's entirely
         // invisible to the program. We can also mark it as nonnull
-        attrs.push((1, llvm::NoAliasAttribute as u64));
-        attrs.push((1, llvm::NoCaptureAttribute as u64));
-        attrs.push((1, llvm::NonNullAttribute as u64));
+        attrs.arg(1, llvm::NoAliasAttribute)
+             .arg(1, llvm::NoCaptureAttribute)
+             .arg(1, llvm::NonNullAttribute);
     };
 
     // Add attributes that depend on the concrete foreign ABI
     let mut arg_idx = if fn_type.ret_ty.is_indirect() { 1 } else { 0 };
     match fn_type.ret_ty.attr {
-        Some(attr) => attrs.push((arg_idx, attr as u64)),
+        Some(attr) => { attrs.arg(arg_idx, attr); },
         _ => ()
     }
 
@@ -409,7 +409,7 @@ pub fn trans_native_call<'a>(
         if arg_ty.pad.is_some() { arg_idx += 1; }
 
         match arg_ty.attr {
-            Some(attr) => attrs.push((arg_idx, attr as u64)),
+            Some(attr) => { attrs.arg(arg_idx, attr); },
             _ => {}
         }
 
@@ -420,7 +420,7 @@ pub fn trans_native_call<'a>(
                                         llfn,
                                         llargs_foreign.as_slice(),
                                         cc,
-                                        attrs.as_slice());
+                                        Some(attrs));
 
     // If the function we just called does not use an outpointer,
     // store the result into the rust outpointer. Cast the outpointer
@@ -762,7 +762,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
         // Perform the call itself
         debug!("calling llrustfn = {}, t = {}", ccx.tn.val_to_string(llrustfn), t.repr(ccx.tcx()));
         let attributes = base::get_fn_llvm_attributes(ccx, t);
-        let llrust_ret_val = builder.call(llrustfn, llrust_args.as_slice(), attributes.as_slice());
+        let llrust_ret_val = builder.call(llrustfn, llrust_args.as_slice(), Some(attributes));
 
         // Get the return value where the foreign fn expects it.
         let llforeign_ret_ty = match tys.fn_ty.ret_ty.cast {

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -386,11 +386,14 @@ pub fn trans_native_call<'a>(
 
     // Add attributes that are always applicable, independent of the concrete foreign ABI
     if fn_type.ret_ty.is_indirect() {
+        let llret_sz = machine::llsize_of_real(ccx, fn_type.ret_ty.ty);
+
         // The outptr can be noalias and nocapture because it's entirely
-        // invisible to the program. We can also mark it as nonnull
+        // invisible to the program. We also know it's nonnull as well
+        // as how many bytes we can dereference
         attrs.arg(1, llvm::NoAliasAttribute)
              .arg(1, llvm::NoCaptureAttribute)
-             .arg(1, llvm::NonNullAttribute);
+             .arg(1, llvm::DereferenceableAttribute(llret_sz));
     };
 
     // Add attributes that depend on the concrete foreign ABI

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -129,7 +129,7 @@ pub fn drop_ty<'a>(bcx: &'a Block<'a>, v: ValueRef, t: ty::t)
         } else {
             v
         };
-        Call(bcx, glue, [ptr], []);
+        Call(bcx, glue, [ptr], None);
     }
     bcx
 }
@@ -185,7 +185,7 @@ pub fn call_visit_glue(bcx: &Block, v: ValueRef, tydesc: ValueRef) {
     let llfn = Load(bcx, GEPi(bcx, tydesc, [0u, abi::tydesc_field_visit_glue]));
     let llrawptr = PointerCast(bcx, v, Type::i8p(bcx.ccx()));
 
-    Call(bcx, llfn, [llrawptr], []);
+    Call(bcx, llfn, [llrawptr], None);
 }
 
 fn make_visit_glue<'a>(bcx: &'a Block<'a>, v: ValueRef, t: ty::t)
@@ -303,7 +303,7 @@ fn make_drop_glue<'a>(bcx: &'a Block<'a>, v0: ValueRef, t: ty::t) -> &'a Block<'
                         Call(bcx,
                              dtor,
                              [PointerCast(bcx, lluniquevalue, Type::i8p(bcx.ccx()))],
-                             []);
+                             None);
                         bcx
                     })
                 }
@@ -342,7 +342,7 @@ fn make_drop_glue<'a>(bcx: &'a Block<'a>, v0: ValueRef, t: ty::t) -> &'a Block<'
                 let dtor_ptr = GEPi(bcx, env, [0u, abi::box_field_tydesc]);
                 let dtor = Load(bcx, dtor_ptr);
                 let cdata = GEPi(bcx, env, [0u, abi::box_field_body]);
-                Call(bcx, dtor, [PointerCast(bcx, cdata, Type::i8p(bcx.ccx()))], []);
+                Call(bcx, dtor, [PointerCast(bcx, cdata, Type::i8p(bcx.ccx()))], None);
 
                 // Free the environment itself
                 // FIXME: #13994: pass align and size here

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -208,17 +208,17 @@ pub fn trans_intrinsic_call<'a>(mut bcx: &'a Block<'a>, node: ast::NodeId,
 
     let llval = match (simple, name.get()) {
         (Some(llfn), _) => {
-            Call(bcx, llfn, llargs.as_slice(), [])
+            Call(bcx, llfn, llargs.as_slice(), None)
         }
         (_, "abort") => {
             let llfn = ccx.get_intrinsic(&("llvm.trap"));
-            let v = Call(bcx, llfn, [], []);
+            let v = Call(bcx, llfn, [], None);
             Unreachable(bcx);
             v
         }
         (_, "breakpoint") => {
             let llfn = ccx.get_intrinsic(&("llvm.debugtrap"));
-            Call(bcx, llfn, [], [])
+            Call(bcx, llfn, [], None)
         }
         (_, "size_of") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
@@ -553,7 +553,7 @@ fn copy_intrinsic(bcx: &Block, allow_overlap: bool, volatile: bool,
     let llfn = ccx.get_intrinsic(&name);
 
     Call(bcx, llfn, [dst_ptr, src_ptr, Mul(bcx, size, count), align,
-                     C_bool(ccx, volatile)], [])
+                     C_bool(ccx, volatile)], None)
 }
 
 fn memset_intrinsic(bcx: &Block, volatile: bool, tp_ty: ty::t,
@@ -572,13 +572,13 @@ fn memset_intrinsic(bcx: &Block, volatile: bool, tp_ty: ty::t,
     let llfn = ccx.get_intrinsic(&name);
 
     Call(bcx, llfn, [dst_ptr, val, Mul(bcx, size, count), align,
-                     C_bool(ccx, volatile)], [])
+                     C_bool(ccx, volatile)], None)
 }
 
 fn count_zeros_intrinsic(bcx: &Block, name: &'static str, val: ValueRef) -> ValueRef {
     let y = C_bool(bcx.ccx(), false);
     let llfn = bcx.ccx().get_intrinsic(&name);
-    Call(bcx, llfn, [val, y], [])
+    Call(bcx, llfn, [val, y], None)
 }
 
 fn with_overflow_intrinsic(bcx: &Block, name: &'static str, t: ty::t,
@@ -586,7 +586,7 @@ fn with_overflow_intrinsic(bcx: &Block, name: &'static str, t: ty::t,
     let llfn = bcx.ccx().get_intrinsic(&name);
 
     // Convert `i1` to a `bool`, and write it to the out parameter
-    let val = Call(bcx, llfn, [a, b], []);
+    let val = Call(bcx, llfn, [a, b], None);
     let result = ExtractValue(bcx, val, 0);
     let overflow = ZExt(bcx, ExtractValue(bcx, val, 1), Type::bool(bcx.ccx()));
     let ret = C_undef(type_of::type_of(bcx.ccx(), t));

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -113,6 +113,8 @@ extern "C" void LLVMAddCallSiteAttribute(LLVMValueRef Instr, unsigned index, uin
                                                          index, B)));
 }
 
+
+#if LLVM_VERSION_MINOR >= 5
 extern "C" void LLVMAddDereferenceableCallSiteAttr(LLVMValueRef Instr, unsigned idx, uint64_t b) {
   CallSite Call = CallSite(unwrap<Instruction>(Instr));
   AttrBuilder B;
@@ -122,6 +124,9 @@ extern "C" void LLVMAddDereferenceableCallSiteAttr(LLVMValueRef Instr, unsigned 
                                        AttributeSet::get(Call->getContext(),
                                                          idx, B)));
 }
+#else
+extern "C" void LLVMAddDereferenceableCallSiteAttr(LLVMValueRef, unsigned, uint64_t) {}
+#endif
 
 extern "C" void LLVMAddFunctionAttribute(LLVMValueRef Fn, unsigned index, uint64_t Val) {
   Function *A = unwrap<Function>(Fn);
@@ -130,12 +135,16 @@ extern "C" void LLVMAddFunctionAttribute(LLVMValueRef Fn, unsigned index, uint64
   A->addAttributes(index, AttributeSet::get(A->getContext(), index, B));
 }
 
+#if LLVM_VERSION_MINOR >= 5
 extern "C" void LLVMAddDereferenceableAttr(LLVMValueRef Fn, unsigned index, uint64_t bytes) {
   Function *A = unwrap<Function>(Fn);
   AttrBuilder B;
   B.addDereferenceableAttr(bytes);
   A->addAttributes(index, AttributeSet::get(A->getContext(), index, B));
 }
+#else
+extern "C" void LLVMAddDereferenceableAttr(LLVMValueRef, unsigned, uint64_t) {}
+#endif
 
 extern "C" void LLVMAddFunctionAttrString(LLVMValueRef Fn, unsigned index, const char *Name) {
   Function *F = unwrap<Function>(Fn);

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -113,10 +113,27 @@ extern "C" void LLVMAddCallSiteAttribute(LLVMValueRef Instr, unsigned index, uin
                                                          index, B)));
 }
 
+extern "C" void LLVMAddDereferenceableCallSiteAttr(LLVMValueRef Instr, unsigned idx, uint64_t b) {
+  CallSite Call = CallSite(unwrap<Instruction>(Instr));
+  AttrBuilder B;
+  B.addDereferenceableAttr(b);
+  Call.setAttributes(
+    Call.getAttributes().addAttributes(Call->getContext(), idx,
+                                       AttributeSet::get(Call->getContext(),
+                                                         idx, B)));
+}
+
 extern "C" void LLVMAddFunctionAttribute(LLVMValueRef Fn, unsigned index, uint64_t Val) {
   Function *A = unwrap<Function>(Fn);
   AttrBuilder B;
   B.addRawValue(Val);
+  A->addAttributes(index, AttributeSet::get(A->getContext(), index, B));
+}
+
+extern "C" void LLVMAddDereferenceableAttr(LLVMValueRef Fn, unsigned index, uint64_t bytes) {
+  Function *A = unwrap<Function>(Fn);
+  AttrBuilder B;
+  B.addDereferenceableAttr(bytes);
   A->addAttributes(index, AttributeSet::get(A->getContext(), index, B));
 }
 


### PR DESCRIPTION
LLVM recently added a new attribute, dereferenceable: http://reviews.llvm.org/D4449

> This patch adds a dereferencable attribute. In some sense, this is a companion to the nonnull attribute, but specifies that the pointer is known to be dereferencable in the same sense as a pointer generated by alloca is known to be dereferencable.

With rust, everywhere that we previously marked `nonnull` we can actually mark as `dereferenceable` (which implies nonnull) since we know the size. That is, except for one case: when generating calls for TyVisitor. It seems like we haven't substituted the self type (so we have `ty_param`) and just treat it as an opaque pointer so I just left that bit as nonnull.

With this, LLVM can for example hoist a load out of a loop where it previously couldn't:

``` Rust
pub fn baz(c: &uint, n: uint) -> uint {
    let mut res = 0;
    for i in range(0, n) {
        if i > 0 {
            res += *c * i;
        }
    }
    res
}
```

Before:

``` llvm
define i64 @baz(i64* noalias nocapture nonnull readonly, i64) unnamed_addr #0 {
entry-block:
  br label %for_loopback.outer

for_loopback.outer:                               ; preds = %then-block-33-, %entry-block
  %.ph = phi i64 [ %.lcssa, %then-block-33- ], [ 0, %entry-block ]
  %res.0.ph = phi i64 [ %8, %then-block-33- ], [ 0, %entry-block ]
  br label %for_loopback

for_exit:                                         ; preds = %for_loopback
  %res.0.ph.lcssa = phi i64 [ %res.0.ph, %for_loopback ]
  ret i64 %res.0.ph.lcssa

for_loopback:                                     ; preds = %for_loopback.outer, %for_body
  %2 = phi i64 [ %4, %for_body ], [ %.ph, %for_loopback.outer ]
  %3 = icmp ult i64 %2, %1
  br i1 %3, label %for_body, label %for_exit

for_body:                                         ; preds = %for_loopback
  %4 = add i64 %2, 1
  %5 = icmp eq i64 %2, 0
  br i1 %5, label %for_loopback, label %then-block-33-

then-block-33-:                                   ; preds = %for_body
  %.lcssa = phi i64 [ %4, %for_body ]
  %.lcssa15 = phi i64 [ %2, %for_body ]
  %6 = load i64* %0, align 8                     ; <------- this load
  %7 = mul i64 %6, %.lcssa15
  %8 = add i64 %7, %res.0.ph
  br label %for_loopback.outer
}
```

After:

``` llvm
define i64 @baz(i64* noalias nocapture readonly dereferenceable(8), i64) unnamed_addr #0 {
entry-block:
  %2 = load i64* %0, align 8                    ; <------- load once instead
  br label %for_loopback.outer

for_loopback.outer:                               ; preds = %then-block-33-, %entry-block
  %.ph = phi i64 [ %.lcssa, %then-block-33- ], [ 0, %entry-block ]
  %res.0.ph = phi i64 [ %8, %then-block-33- ], [ 0, %entry-block ]
  br label %for_loopback

for_exit:                                         ; preds = %for_loopback
  %res.0.ph.lcssa = phi i64 [ %res.0.ph, %for_loopback ]
  ret i64 %res.0.ph.lcssa

for_loopback:                                     ; preds = %for_loopback.outer, %for_body
  %3 = phi i64 [ %5, %for_body ], [ %.ph, %for_loopback.outer ]
  %4 = icmp ult i64 %3, %1
  br i1 %4, label %for_body, label %for_exit

for_body:                                         ; preds = %for_loopback
  %5 = add i64 %3, 1
  %6 = icmp eq i64 %3, 0
  br i1 %6, label %for_loopback, label %then-block-33-

then-block-33-:                                   ; preds = %for_body
  %.lcssa = phi i64 [ %5, %for_body ]
  %.lcssa15 = phi i64 [ %3, %for_body ]
  %7 = mul i64 %2, %.lcssa15
  %8 = add i64 %7, %res.0.ph
  br label %for_loopback.outer
}
```
