### PR TITLE
Refactored `syntax::fold`

### DIFF
--- a/src/librustc/front/config.rs
+++ b/src/librustc/front/config.rs
@@ -44,7 +44,7 @@ impl<'a> fold::Folder for Context<'a> {
         fold_expr(self, expr)
     }
     fn fold_mac(&mut self, mac: &ast::Mac) -> ast::Mac {
-        fold::fold_mac(mac, self)
+        fold::noop_fold_mac(mac, self)
     }
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -961,7 +961,7 @@ pub enum ExplicitSelf_ {
 
 pub type ExplicitSelf = Spanned<ExplicitSelf_>;
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct Method {
     pub attrs: Vec<Attribute>,
     pub id: NodeId,
@@ -969,7 +969,7 @@ pub struct Method {
     pub node: Method_,
 }
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum Method_ {
     /// Represents a method declaration
     MethDecl(Ident,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -261,7 +261,7 @@ pub struct Crate {
 
 pub type MetaItem = Spanned<MetaItem_>;
 
-#[deriving(Clone, Encodable, Decodable, Eq, Hash, Show)]
+#[deriving(Clone, Eq, Encodable, Decodable, Hash, Show)]
 pub enum MetaItem_ {
     MetaWord(InternedString),
     MetaList(InternedString, Vec<Gc<MetaItem>>),
@@ -423,7 +423,7 @@ pub enum LocalSource {
 // FIXME (pending discussion of #1697, #2178...): local should really be
 // a refinement on pat.
 /// Local represents a `let` statement, e.g., `let <pat>:<ty> = <expr>;`
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct Local {
     pub ty: P<Ty>,
     pub pat: Gc<Pat>,
@@ -435,7 +435,7 @@ pub struct Local {
 
 pub type Decl = Spanned<Decl_>;
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum Decl_ {
     /// A local (let) binding:
     DeclLocal(Gc<Local>),
@@ -677,7 +677,7 @@ pub struct MutTy {
     pub mutbl: Mutability,
 }
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct TypeField {
     pub ident: Ident,
     pub mt: MutTy,
@@ -1048,7 +1048,7 @@ pub type PathListItem = Spanned<PathListItem_>;
 
 pub type ViewPath = Spanned<ViewPath_>;
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum ViewPath_ {
 
     /// `quux = foo::bar::baz`
@@ -1113,7 +1113,7 @@ pub struct Attribute_ {
 /// that the ref_id is for. The impl_id maps to the "self type" of this impl.
 /// If this impl is an ItemImpl, the impl_id is redundant (it could be the
 /// same as the impl's node id).
-#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash,   Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct TraitRef {
     pub path: Path,
     pub ref_id: NodeId,
@@ -1169,7 +1169,7 @@ impl StructFieldKind {
     }
 }
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct StructDef {
     /// Fields, not including ctor
     pub fields: Vec<StructField>,
@@ -1219,7 +1219,7 @@ pub enum Item_ {
     ItemMac(Mac),
 }
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct ForeignItem {
     pub ident: Ident,
     pub attrs: Vec<Attribute>,
@@ -1229,7 +1229,7 @@ pub struct ForeignItem {
     pub vis: Visibility,
 }
 
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum ForeignItem_ {
     ForeignItemFn(P<FnDecl>, Generics),
     ForeignItemStatic(P<Ty>, /* is_mutbl */ bool),
@@ -1238,7 +1238,7 @@ pub enum ForeignItem_ {
 /// The data we save and restore about an inlined item or method.  This is not
 /// part of the AST that we parse from a file, but it becomes part of the tree
 /// that we trans.
-#[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum InlinedItem {
     IIItem(Gc<Item>),
     IIMethod(DefId /* impl id */, bool /* is provided */, Gc<Method>),

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -606,7 +606,7 @@ impl<'a, F: FoldOps> Folder for Ctx<'a, F> {
     }
 
     fn fold_mac(&mut self, mac: &Mac) -> Mac {
-        fold::fold_mac(mac, self)
+        fold::noop_fold_mac(mac, self)
     }
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -341,7 +341,7 @@ fn expand_item_underscore(item: &ast::Item_, fld: &mut MacroExpander) -> ast::It
         ast::ItemFn(decl, fn_style, abi, ref generics, body) => {
             let (rewritten_fn_decl, rewritten_body)
                 = expand_and_rename_fn_decl_and_block(&*decl, body, fld);
-            let expanded_generics = fold::fold_generics(generics,fld);
+            let expanded_generics = fold::noop_fold_generics(generics,fld);
             ast::ItemFn(rewritten_fn_decl, fn_style, abi, expanded_generics, rewritten_body)
         }
         _ => noop_fold_item_underscore(&*item, fld)
@@ -792,7 +792,7 @@ impl<'a> Folder for IdentRenamer<'a> {
         }
     }
     fn fold_mac(&mut self, macro: &ast::Mac) -> ast::Mac {
-        fold::fold_mac(macro, self)
+        fold::noop_fold_mac(macro, self)
     }
 }
 
@@ -824,7 +824,7 @@ impl<'a> Folder for PatIdentRenamer<'a> {
         }
     }
     fn fold_mac(&mut self, macro: &ast::Mac) -> ast::Mac {
-        fold::fold_mac(macro, self)
+        fold::noop_fold_mac(macro, self)
     }
 }
 
@@ -847,7 +847,7 @@ fn expand_method(m: &ast::Method, fld: &mut MacroExpander) -> SmallVector<Gc<ast
                     id: id,
                     span: fld.new_span(m.span),
                     node: ast::MethDecl(fld.fold_ident(ident),
-                                        fold_generics(generics, fld),
+                                        noop_fold_generics(generics, fld),
                                         abi,
                                         fld.fold_explicit_self(explicit_self),
                                         fn_style,
@@ -1014,7 +1014,7 @@ impl Folder for Marker {
         let macro = match m.node {
             MacInvocTT(ref path, ref tts, ctxt) => {
                 MacInvocTT(self.fold_path(path),
-                           fold_tts(tts.as_slice(), self),
+                           self.fold_tts(tts.as_slice()),
                            mtwt::apply_mark(self.mark, ctxt))
             }
         };
@@ -1027,7 +1027,7 @@ impl Folder for Marker {
 
 // apply a given mark to the given token trees. Used prior to expansion of a macro.
 fn mark_tts(tts: &[TokenTree], m: Mrk) -> Vec<TokenTree> {
-    fold_tts(tts, &mut Marker{mark:m})
+    noop_fold_tts(tts, &mut Marker{mark:m})
 }
 
 // apply a given mark to the given expr. Used following the expansion of a macro.


### PR DESCRIPTION
Note: This PR is motivated by an attempt to write an custom syntax extension that tried to use `syntax::fold`, and that could only do so by fixing bugs in it and copying out private functions.

---

Refactored `syntax::fold`

Prior to this, the code there had a few issues:
- Default implementations inconsistenly either had the prefix `noop_` or
  not.
- Some default methods where implemented in terms of a public noop function
  for user code to call, others where implemented directly on the trait
  and did not allow users of the trait to reuse the code.
- Some of the default implementations where private, and thus not reusable
  for other implementors.
- There where some bugs where default implemntations called other default
  implementations directly, rather than to the underlying Folder, with the
  result of some ast nodes never being visted even if the user implemented that
  method. (For example, the current Folder never folded struct fields)

This commit solves this situation somewhat radically by making **all**
`fold_...` functions in the module into Folder methods, and implementing
them all in terms of public `noop_...` functions for other implementors to
call out to.

Some public functions had to be renamed to fit the new system, so this is a
breaking change.

---

Also added a few trait implementations to `ast` types
