### PR TITLE
Guide: Derive Eq to avoid compile error.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1066,12 +1066,16 @@ feature of Rust, and are used throughout the standard library. Enums look
 like this:
 
 ```
+#[deriving(Eq, PartialEq)]
 enum Ordering {
     Less,
     Equal,
     Greater,
 }
 ```
+
+We will talk about `#[deriving(Eq, PartialEq)]` later, for now we can read
+it as "allow us to use `==` for comparisons."
 
 This is an enum that is provided by the Rust standard library. An `Ordering`
 can only be _one_ of `Less`, `Equal`, or `Greater` at any given time. Here's


### PR DESCRIPTION
If we copy in `Ordering` and use it with the following example we'll get a compile error as `==` has not been defined.

I chose to introduce `deriving(Eq, PartialEq)` but refer to the later discussion (which I assume is going to come). I'm not sure about the formulation however.

It could have been fine to use `match`, but it hasn't been presented yet. In the next example though we _are_ using `match` in the example code, so we could do it here as well. But I'm more inclined to remove the use of `match` there as well as it might be a bit confusing?

cc @steveklabnik
