### PR TITLE
Update the lint warnings to use the right syntax for `#![warn(...)]`.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -475,7 +475,7 @@ but it will still print "Hello, world!":
 
 ```{ignore,notrust}
    Compiling guessing_game v0.1.0 (file:/home/you/projects/guessing_game)
-src/guessing_game.rs:2:9: 2:10 warning: unused variable: `x`, #[warn(unused_variable)] on by default
+src/guessing_game.rs:2:9: 2:10 warning: unused variable: `x`, #![warn(unused_variable)] on by default
 src/guessing_game.rs:2     let x: int;
                                ^
 ```

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -262,7 +262,7 @@ pub fn raw_emit_lint(sess: &Session, lint: &'static Lint,
     let mut note = None;
     let msg = match source {
         Default => {
-            format!("{}, #[{}({})] on by default", msg,
+            format!("{}, #![{}({})] on by default", msg,
                     level.as_str(), name)
         },
         CommandLine => {

--- a/src/test/compile-fail/lint-output-format.rs
+++ b/src/test/compile-fail/lint-output-format.rs
@@ -15,7 +15,7 @@ extern crate lint_output_format;
 use lint_output_format::{foo, bar, baz};
 
 fn main() {
-    let _x = foo(); //~ WARNING #[warn(deprecated)] on by default
+    let _x = foo(); //~ WARNING #![warn(deprecated)] on by default
     let _y = bar(); //~ ERROR [-F experimental]
     let _z = baz(); //~ ERROR [-D unstable]
 }


### PR DESCRIPTION
Rather than `#[warn(...)]`, update to include a `!`.
