### PR TITLE
librustc: WIP patch for upgrading the way rvalues are treated.

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2006,7 +2006,8 @@ impl<A: Add<A, A> + PartialOrd + Clone + ToPrimitive> Iterator<A> for Range<A> {
         // This first checks if the elements are representable as i64. If they aren't, try u64 (to
         // handle cases like range(huge, huger)). We don't use uint/int because the difference of
         // the i64/u64 might lie within their range.
-        let bound = match self.state.to_i64() {
+        let state = self.state.to_i64();
+        let bound = match state {
             Some(a) => {
                 let sz = self.stop.to_i64().map(|b| b.checked_sub(&a));
                 match sz {

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -840,8 +840,10 @@ fn encode_inlined_item(ecx: &EncodeContext,
                        ebml_w: &mut Encoder,
                        ii: InlinedItemRef) {
     let mut eii = ecx.encode_inlined_item.borrow_mut();
-    let eii: &mut EncodeInlinedItem = &mut *eii;
-    (*eii)(ecx, ebml_w, ii)
+    unsafe {
+        let eii: &mut EncodeInlinedItem = ::std::mem::transmute_copy(& &mut *eii);
+        (*eii)(ecx, ebml_w, ii)
+    }
 }
 
 fn style_fn_family(s: FnStyle) -> char {

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -242,7 +242,7 @@ impl<'a> CheckLoanCtxt<'a> {
         let mut loan_path = loan_path;
         loop {
             match *loan_path {
-                LpVar(_) | LpUpvar(_) => {
+                LpVar(_) | LpUpvar(_) | LpAliasableRvalue(_) => {
                     break;
                 }
                 LpExtend(ref lp_base, _, _) => {
@@ -633,7 +633,7 @@ impl<'a> CheckLoanCtxt<'a> {
          */
 
         match **lp {
-            LpVar(_) | LpUpvar(_) => {
+            LpVar(_) | LpUpvar(_) | LpAliasableRvalue(_) => {
                 // assigning to `x` does not require that `x` is initialized
             }
             LpExtend(ref lp_base, _, LpInterior(_)) => {
@@ -722,7 +722,9 @@ impl<'a> CheckLoanCtxt<'a> {
                 debug!("mark_writes_through_upvars_as_used_mut(cmt={})",
                        cmt.repr(this.tcx()));
                 match cmt.cat.clone() {
-                    mc::cat_local(id) | mc::cat_arg(id) => {
+                    mc::cat_local(id) |
+                    mc::cat_arg(id) |
+                    mc::cat_aliasable_rvalue(id) => {
                         this.tcx().used_mut_nodes.borrow_mut().insert(id);
                         return;
                     }

--- a/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc/middle/borrowck/gather_loans/gather_moves.rs
@@ -148,7 +148,8 @@ fn check_and_get_illegal_move_origin(bccx: &BorrowckCtxt,
 
         mc::cat_rvalue(..) |
         mc::cat_local(..) |
-        mc::cat_arg(..) => {
+        mc::cat_arg(..) |
+        mc::cat_aliasable_rvalue(..) => {
             None
         }
 

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -73,6 +73,12 @@ impl<'a> RestrictionsContext<'a> {
                 SafeIf(lp.clone(), vec!(lp))
             }
 
+            mc::cat_aliasable_rvalue(expr_id) => {
+                // R-Variable, effectively
+                let lp = Rc::new(LpAliasableRvalue(expr_id));
+                SafeIf(lp.clone(), vec!(lp))
+            }
+
             mc::cat_upvar(upvar_id, _) => {
                 // R-Variable, captured into closure
                 let lp = Rc::new(LpUpvar(upvar_id));

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4862,6 +4862,10 @@ impl mc::Typer for ty::ctxt {
     fn upvar_borrow(&self, upvar_id: ty::UpvarId) -> ty::UpvarBorrow {
         self.upvar_borrow_map.borrow().get_copy(&upvar_id)
     }
+
+    fn is_rvalue_aliasable(&self, expr_id: ast::NodeId) -> bool {
+        self.region_maps.aliasable_rvalues.borrow().contains(&expr_id)
+    }
 }
 
 /// The category of explicit self.

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -290,6 +290,10 @@ impl<'fcx> mc::Typer for Rcx<'fcx> {
     fn upvar_borrow(&self, id: ty::UpvarId) -> ty::UpvarBorrow {
         self.fcx.inh.upvar_borrow_map.borrow().get_copy(&id)
     }
+
+    fn is_rvalue_aliasable(&self, expr_id: ast::NodeId) -> bool {
+        self.tcx().region_maps.aliasable_rvalues.borrow().contains(&expr_id)
+    }
 }
 
 pub fn regionck_expr(fcx: &FnCtxt, e: &ast::Expr) {
@@ -1319,7 +1323,8 @@ fn link_region(rcx: &Rcx,
             mc::cat_local(..) |
             mc::cat_arg(..) |
             mc::cat_upvar(..) |
-            mc::cat_rvalue(..) => {
+            mc::cat_rvalue(..) |
+            mc::cat_aliasable_rvalue(..) => {
                 // These are all "base cases" with independent lifetimes
                 // that are not subject to inference
                 return;
@@ -1390,7 +1395,8 @@ fn adjust_upvar_borrow_kind_for_mut(rcx: &Rcx,
             mc::cat_copied_upvar(_) |
             mc::cat_local(_) |
             mc::cat_arg(_) |
-            mc::cat_upvar(..) => {
+            mc::cat_upvar(..) |
+            mc::cat_aliasable_rvalue(..) => {
                 return;
             }
         }
@@ -1442,7 +1448,8 @@ fn adjust_upvar_borrow_kind_for_unique(rcx: &Rcx, cmt: mc::cmt) {
             mc::cat_copied_upvar(_) |
             mc::cat_local(_) |
             mc::cat_arg(_) |
-            mc::cat_upvar(..) => {
+            mc::cat_upvar(..) |
+            mc::cat_aliasable_rvalue(..) => {
                 return;
             }
         }

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -559,8 +559,10 @@ impl<'a> MethodDef<'a> {
             fields: fields
         };
         let mut f = self.combine_substructure.borrow_mut();
-        let f: &mut CombineSubstructureFunc = &mut *f;
-        (*f)(cx, trait_.span, &substructure)
+        unsafe {
+            let f: &mut CombineSubstructureFunc = ::std::mem::transmute_copy(& &mut *f);
+            (*f)(cx, trait_.span, &substructure)
+        }
     }
 
     fn get_ret_ty(&self,


### PR DESCRIPTION
WIP. Do not merge.

@nikomatsakis I'd like to get your feedback on this. I've implemented a patch which fixes #14587, but it has some nasty fallout in other parts of the codebase.

I first tried to make all rvalues treated like lvalues. This ran into problems with method chaining: `foo.bar().baz()` would not work anymore if `baz` required `&mut self`, as it thought it was a double borrow. I believe this is because of the rvalue temporary rules.

The next thing, which is in this patch, was to formulate the notion of "aliasable rvalues". These are rvalues that could be aliasable because they're about to be unpacked into a pattern. Local initializers, match values, and for loop heads fall into this list. This causes a few strange errors:

```
/Users/pcwalton/Source/rust/src/libcollections/treemap.rs:554:17: 554:18 error: cannot move out of `<rvalue>` because it is borrowed
/Users/pcwalton/Source/rust/src/libcollections/treemap.rs:554             let n: &mut TreeNode<K, V> = &mut **n;
                                                                              ^
/Users/pcwalton/Source/rust/src/libcollections/treemap.rs:554:42: 554:50 note: borrow of `*<rvalue>` occurs here
/Users/pcwalton/Source/rust/src/libcollections/treemap.rs:554             let n: &mut TreeNode<K, V> = &mut **n;
```

This may be related to the rvalue scope extension rules. I haven't dug into that to see whether it's the case.

Any thoughts as to the right way to go here?
