### PR TITLE
rustdoc: Keep hidden struct fields out of search

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -845,8 +845,12 @@ impl DocFolder for Cache {
                     }
                     _ => (None, Some(self.stack.as_slice()))
                 };
+                let hidden_field = match item.inner {
+                    clean::StructFieldItem(clean::HiddenStructField) => true,
+                    _ => false
+                };
                 match parent {
-                    (parent, Some(path)) if !self.privmod => {
+                    (parent, Some(path)) if !self.privmod && !hidden_field => {
                         self.search_index.push(IndexItem {
                             ty: shortty(&item),
                             name: s.to_string(),


### PR DESCRIPTION
Previously, private and `#[doc(hidden)]` struct fields appeared in the
search index despite being hidden from the struct's documentation.

Fix #15490
