### PR TITLE
core: add Pow trait

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -306,6 +306,50 @@ pub trait Unsigned: Num {}
 
 trait_impl!(Unsigned for uint u8 u16 u32 u64)
 
+/// A trait for raising a value by an exponent.
+pub trait Pow {
+
+    /// Returns the value of raising to the provided exponent.
+    fn pow(&self, exp: uint) -> Self;
+
+}
+
+macro_rules! pow_impl(
+    ($t:ty) => {
+        impl Pow for $t {
+            fn pow(&self, exp: uint) -> $t {
+                if exp == 1 { *self }
+                else {
+                    let mut base = *self;
+                    let mut exp = exp;
+                    let mut acc: $t = one();
+                    while exp > 0 {
+                        if (exp & 1) == 1 {
+                            acc = acc * base;
+                        }
+                        base = base * base;
+                        exp = exp >> 1;
+                    }
+                    acc
+                }
+            }
+        }
+    }
+)
+
+pow_impl!(uint)
+pow_impl!(u8)
+pow_impl!(u16)
+pow_impl!(u32)
+pow_impl!(u64)
+pow_impl!(int)
+pow_impl!(i8)
+pow_impl!(i16)
+pow_impl!(i32)
+pow_impl!(i64)
+pow_impl!(f32)
+pow_impl!(f64)
+
 /// Raises a value to the power of exp, using exponentiation by squaring.
 ///
 /// # Example
@@ -316,19 +360,8 @@ trait_impl!(Unsigned for uint u8 u16 u32 u64)
 /// assert_eq!(num::pow(2i, 4), 16);
 /// ```
 #[inline]
-pub fn pow<T: One + Mul<T, T>>(mut base: T, mut exp: uint) -> T {
-    if exp == 1 { base }
-    else {
-        let mut acc = one::<T>();
-        while exp > 0 {
-            if (exp & 1) == 1 {
-                acc = acc * base;
-            }
-            base = base * base;
-            exp = exp >> 1;
-        }
-        acc
-    }
+pub fn pow<T: Pow>(base: T, exp: uint) -> T {
+    base.pow(exp)
 }
 
 /// Numbers which have upper and lower bounds

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -23,7 +23,7 @@ use string::String;
 
 pub use core::num::{Num, div_rem, Zero, zero, One, one};
 pub use core::num::{Signed, abs, abs_sub, signum};
-pub use core::num::{Unsigned, pow, Bounded};
+pub use core::num::{Unsigned, Pow, pow, Bounded};
 pub use core::num::{Primitive, Int, Saturating};
 pub use core::num::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
 pub use core::num::{cast, FromPrimitive, NumCast, ToPrimitive};

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -15,7 +15,7 @@
 use char;
 use clone::Clone;
 use collections::{Collection, MutableSeq};
-use num::{NumCast, Zero, One, cast, Int};
+use num::{NumCast, Zero, One, cast, Int, Pow};
 use num::{Float, FPNaN, FPInfinite, ToPrimitive};
 use num;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
@@ -548,7 +548,7 @@ static DIGIT_E_RADIX: uint = ('e' as uint) - ('a' as uint) + 11u;
  * - Fails if `radix` > 18 and `special == true` due to conflict
  *   between digit and lowest first character in `inf` and `NaN`, the `'i'`.
  */
-pub fn from_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Div<T,T>+
+pub fn from_str_bytes_common<T:NumCast+Zero+One+Pow+PartialEq+PartialOrd+Div<T,T>+
                                     Mul<T,T>+Sub<T,T>+Neg<T>+Add<T,T>+
                                     NumStrConv+Clone>(
         buf: &[u8], radix: uint, negative: bool, fractional: bool,
@@ -755,7 +755,7 @@ pub fn from_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Div<T,T>+
  * `from_str_bytes_common()`, for details see there.
  */
 #[inline]
-pub fn from_str_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Div<T,T>+Mul<T,T>+
+pub fn from_str_common<T:NumCast+Zero+One+Pow+PartialEq+PartialOrd+Div<T,T>+Mul<T,T>+
                               Sub<T,T>+Neg<T>+Add<T,T>+NumStrConv+Clone>(
         buf: &str, radix: uint, negative: bool, fractional: bool,
         special: bool, exponent: ExponentFormat, empty_zero: bool,


### PR DESCRIPTION
Allows overloading of a Pow function, motivated by this [thread](https://mail.mozilla.org/pipermail/rust-dev/2014-July/010902.html).
