### PR TITLE
avoid redundant translation of items during monomorphization

### DIFF
--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -339,7 +339,8 @@ pub fn trans_unboxing_shim(bcx: &Block,
                           return_type,
                           &empty_param_substs,
                           None,
-                          &block_arena);
+                          &block_arena,
+                          TranslateItems);
     let mut bcx = init_function(&fcx, false, return_type);
 
     // Create the substituted versions of the self type.

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -394,7 +394,8 @@ pub fn trans_expr_fn<'a>(
                   ty::ty_fn_abi(fty),
                   true,
                   NotUnboxedClosure,
-                  |bcx| load_environment(bcx, cdata_ty, &freevars, store));
+                  |bcx| load_environment(bcx, cdata_ty, &freevars, store),
+                  bcx.fcx.handle_items);
     fill_fn_pair(bcx, dest_addr, llfn, llbox);
     bcx
 }
@@ -486,7 +487,8 @@ pub fn trans_unboxed_closure<'a>(
                   ty::ty_fn_abi(function_type),
                   true,
                   IsUnboxedClosure,
-                  |bcx| load_unboxed_closure_environment(bcx, freevars_ptr));
+                  |bcx| load_unboxed_closure_environment(bcx, freevars_ptr),
+                  bcx.fcx.handle_items);
 
     // Don't hoist this to the top of the function. It's perfectly legitimate
     // to have a zero-size unboxed closure (in which case dest will be
@@ -573,7 +575,7 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
     let arena = TypedArena::new();
     let empty_param_substs = param_substs::empty();
     let fcx = new_fn_ctxt(ccx, llfn, -1, true, f.sig.output,
-                          &empty_param_substs, None, &arena);
+                          &empty_param_substs, None, &arena, TranslateItems);
     let bcx = init_function(&fcx, true, f.sig.output);
 
     let args = create_datums_for_fn_args(&fcx,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -221,6 +221,12 @@ impl<T:Subst+Clone> SubstP for T {
 pub type RvalueDatum = datum::Datum<datum::Rvalue>;
 pub type LvalueDatum = datum::Datum<datum::Lvalue>;
 
+#[deriving(Clone, Eq, PartialEq)]
+pub enum HandleItemsFlag {
+    IgnoreItems,
+    TranslateItems,
+}
+
 // Function context.  Every LLVM function we create will have one of
 // these.
 pub struct FunctionContext<'a> {
@@ -289,6 +295,9 @@ pub struct FunctionContext<'a> {
 
     // Cleanup scopes.
     pub scopes: RefCell<Vec<cleanup::CleanupScope<'a>> >,
+
+    // How to handle items encountered during translation of this function.
+    pub handle_items: HandleItemsFlag,
 }
 
 impl<'a> FunctionContext<'a> {

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -68,7 +68,12 @@ pub fn trans_stmt<'a>(cx: &'a Block<'a>,
                         debuginfo::create_local_var_metadata(bcx, &**local);
                     }
                 }
-                ast::DeclItem(ref i) => trans_item(cx.fcx.ccx, &**i)
+                ast::DeclItem(ref i) => {
+                    match fcx.handle_items {
+                        TranslateItems => trans_item(cx.fcx.ccx, &**i),
+                        IgnoreItems => {}
+                    }
+                }
             }
         }
         ast::StmtMac(..) => cx.tcx().sess.bug("unexpanded macro")

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -601,7 +601,8 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
 
         let llfn = base::decl_internal_rust_fn(ccx, t, ps.as_slice());
         base::set_llvm_fn_attrs(attrs, llfn);
-        base::trans_fn(ccx, decl, body, llfn, &param_substs::empty(), id, []);
+        base::trans_fn(ccx, decl, body, llfn, &param_substs::empty(), id, [],
+                       TranslateItems);
         llfn
     }
 

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -468,7 +468,7 @@ fn make_generic_glue(ccx: &CrateContext,
     let arena = TypedArena::new();
     let empty_param_substs = param_substs::empty();
     let fcx = new_fn_ctxt(ccx, llfn, -1, false, ty::mk_nil(),
-                          &empty_param_substs, None, &arena);
+                          &empty_param_substs, None, &arena, TranslateItems);
 
     let bcx = init_function(&fcx, false, ty::mk_nil());
 

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -133,7 +133,7 @@ pub fn maybe_instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
           if unparameterized {
               let llfn = get_item_val(ccx, mth.id);
                 trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), llfn,
-                       &param_substs::empty(), mth.id, []);
+                       &param_substs::empty(), mth.id, [], TranslateItems);
           }
           local_def(mth.id)
         }

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -75,7 +75,8 @@ pub fn trans_impl(ccx: &CrateContext,
                      llfn,
                      &param_substs::empty(),
                      method.id,
-                     []);
+                     [],
+                     TranslateItems);
         } else {
             let mut v = TransItemVisitor{ ccx: ccx };
             visit::walk_method_helper(&mut v, &**method, ());

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -149,7 +149,8 @@ pub fn monomorphic_fn(ccx: &CrateContext,
               } => {
                   let d = mk_lldecl();
                   set_llvm_fn_attrs(i.attrs.as_slice(), d);
-                  trans_fn(ccx, &**decl, &**body, d, &psubsts, fn_id.node, []);
+                  trans_fn(ccx, &**decl, &**body, d, &psubsts, fn_id.node, [],
+                           IgnoreItems);
                   d
               }
               _ => {
@@ -181,7 +182,8 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         ast_map::NodeMethod(mth) => {
             let d = mk_lldecl();
             set_llvm_fn_attrs(mth.attrs.as_slice(), d);
-            trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d, &psubsts, mth.id, []);
+            trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d, &psubsts, mth.id, [],
+                     IgnoreItems);
             d
         }
         ast_map::NodeTraitMethod(method) => {
@@ -190,7 +192,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                     let d = mk_lldecl();
                     set_llvm_fn_attrs(mth.attrs.as_slice(), d);
                     trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d,
-                             &psubsts, mth.id, []);
+                             &psubsts, mth.id, [], IgnoreItems);
                     d
                 }
                 _ => {

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -312,7 +312,7 @@ impl<'a, 'b> Reflector<'a, 'b> {
                 let empty_param_substs = param_substs::empty();
                 let fcx = new_fn_ctxt(ccx, llfdecl, -1, false,
                                       ty::mk_u64(), &empty_param_substs,
-                                      None, &arena);
+                                      None, &arena, TranslateItems);
                 let bcx = init_function(&fcx, false, ty::mk_u64());
 
                 // we know the return type of llfdecl is an int here, so

--- a/src/test/run-make/issue-7349/Makefile
+++ b/src/test/run-make/issue-7349/Makefile
@@ -1,0 +1,11 @@
+-include ../tools.mk
+
+# Test to make sure that inner functions within a polymorphic outer function
+# don't get re-translated when the outer function is monomorphized.  The test
+# code monomorphizes the outer function several times, but the magic constant
+# `8675309` used in the inner function should appear only once in the generated
+# IR.
+
+all:
+	$(RUSTC) foo.rs --emit=ir
+	[ "$$(grep -c 8675309 "$(TMPDIR)/foo.ll")" -eq "1" ]

--- a/src/test/run-make/issue-7349/foo.rs
+++ b/src/test/run-make/issue-7349/foo.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn outer<T>() {
+    #[allow(dead_code)]
+    fn inner() -> uint {
+        8675309
+    }
+}
+
+fn main() {
+    outer::<int>();
+    outer::<uint>();
+}


### PR DESCRIPTION
Currently, each time a function is monomorphized, all items within that function are translated.  This is unnecessary work because the inner items already get translated when the function declaration is visited by `trans_item`.  This patch adds a flag to the `FunctionContext` to prevent translation of items during monomorphization.
