### PR TITLE
Remove references to non-existant functions in the std::path documentation

### DIFF
--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -178,16 +178,13 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     fn into_vec(self) -> Vec<u8>;
 
     /// Returns an object that implements `Show` for printing paths
-    ///
-    /// This will print the equivalent of `to_display_str()` when used with a {} format parameter.
     fn display<'a>(&'a self) -> Display<'a, Self> {
         Display{ path: self, filename: false }
     }
 
     /// Returns an object that implements `Show` for printing filenames
     ///
-    /// This will print the equivalent of `to_filename_display_str()` when used with a {}
-    /// format parameter. If there is no filename, nothing will be printed.
+    /// If there is no filename, nothing will be printed.
     fn filename_display<'a>(&'a self) -> Display<'a, Self> {
         Display{ path: self, filename: true }
     }


### PR DESCRIPTION
Two methods for `GenericPath` reference functions (`to_display_str` and `to_filename_display_str`) which appear to no longer exist. The only reference I was able to find for these was a commit message for a commit in September 2013.
