### PR TITLE
making raw source display better

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -129,6 +129,14 @@ pre {
     padding: 20px;
 }
 
+.content.source {
+    margin-top: 50px;
+    max-width: none;
+    overflow: visible;
+    margin-left: 0px;
+    min-width: 70em;
+}
+
 nav.sub {
     font-size: 16px;
     text-transform: uppercase;


### PR DESCRIPTION
Summary of changes:
- Make the code fill up the full width of the page (no massive whitespace on the left)
- Move the code down to make it not intersect the logo
- Set a min-width and remove the max-width so that the code doesn't scroll internally, but instead scrolls the page, meaning horizontal scroll bars are always available
- Set overflow to actually overflow, just to be sure

Fixes #15891

![two-screen](https://cloud.githubusercontent.com/assets/1136864/3730216/3315a45e-16cc-11e4-9268-4ebf65583f20.png)
![wide-screen](https://cloud.githubusercontent.com/assets/1136864/3730217/33301302-16cc-11e4-9aa9-6c28e1203999.png)
