### PR TITLE
Port Rust to DragonFlyBSD

### DIFF
--- a/configure
+++ b/configure
@@ -291,6 +291,10 @@ case $CFG_OSTYPE in
         CFG_OSTYPE=unknown-freebsd
         ;;
 
+    DragonFly)
+        CFG_OSTYPE=unknown-dragonfly
+        ;;
+
     Darwin)
         CFG_OSTYPE=apple-darwin
         ;;

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -580,6 +580,33 @@ CFG_LDPATH_x86_64-unknown-freebsd :=
 CFG_RUN_x86_64-unknown-freebsd=$(2)
 CFG_RUN_TARG_x86_64-unknown-freebsd=$(call CFG_RUN_x86_64-unknown-freebsd,,$(2))
 
+# x86_64-pc-dragonfly-elf configuration
+CC_x86_64-unknown-dragonfly=$(CC)
+CXX_x86_64-unknown-dragonfly=$(CXX)
+CPP_x86_64-unknown-dragonfly=$(CPP)
+AR_x86_64-unknown-dragonfly=$(AR)
+CFG_LIB_NAME_x86_64-unknown-dragonfly=lib$(1).so
+CFG_STATIC_LIB_NAME_x86_64-unknown-dragonfly=lib$(1).a
+CFG_LIB_GLOB_x86_64-unknown-dragonfly=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_x86_64-unknown-dragonfly=$(1)-*.dylib.dSYM
+CFG_CFLAGS_x86_64-unknown-dragonfly := -I/usr/include -I/usr/local/include $(CFLAGS)
+CFG_GCCISH_CFLAGS_x86_64-unknown-dragonfly := -Wall -Werror -g -fPIC -I/usr/include -I/usr/local/include $(CFLAGS)
+CFG_GCCISH_LINK_FLAGS_x86_64-unknown-dragonfly := -shared -fPIC -g -pthread  -lrt
+CFG_GCCISH_DEF_FLAG_x86_64-unknown-dragonfly := -Wl,--export-dynamic,--dynamic-list=
+CFG_GCCISH_PRE_LIB_FLAGS_x86_64-unknown-dragonfly := -Wl,-whole-archive
+CFG_GCCISH_POST_LIB_FLAGS_x86_64-unknown-dragonfly := -Wl,-no-whole-archive
+CFG_DEF_SUFFIX_x86_64-unknown-dragonfly := .bsd.def
+CFG_LLC_FLAGS_x86_64-unknown-dragonfly :=
+CFG_INSTALL_NAME_x86_64-unknown-dragonfly =
+CFG_LIBUV_LINK_FLAGS_x86_64-unknown-dragonfly := -pthread  -lkvm
+CFG_EXE_SUFFIX_x86_64-unknown-dragonfly :=
+CFG_WINDOWSY_x86_64-unknown-dragonfly :=
+CFG_UNIXY_x86_64-unknown-dragonfly := 1
+CFG_PATH_MUNGE_x86_64-unknown-dragonfly :=
+CFG_LDPATH_x86_64-unknown-dragonfly :=
+CFG_RUN_x86_64-unknown-dragonfly=$(2)
+CFG_RUN_TARG_x86_64-unknown-dragonfly=$(call CFG_RUN_x86_64-unknown-dragonfly,,$(2))
+
 
 # The -Qunused-arguments sidesteps spurious warnings from clang
 define FILTER_FLAGS

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -171,6 +171,10 @@ else ifeq ($(OSTYPE_$(1)), apple-ios)
   JEMALLOC_ARGS_$(1) := --disable-tls
 else ifeq ($(OSTYPE_$(1)), unknown-freebsd)
   LIBUV_OSTYPE_$(1) := freebsd
+else ifeq ($(OSTYPE_$(1)), unknown-dragonfly)
+  LIBUV_OSTYPE_$(1) := freebsd
+  # required on DragonFly, otherwise gyp fails with a Python exception
+  LIBUV_GYP_ARGS_$(1) := --no-parallel
 else ifeq ($(OSTYPE_$(1)), linux-androideabi)
   LIBUV_OSTYPE_$(1) := android
   LIBUV_ARGS_$(1) := PLATFORM=android host=android OS=linux
@@ -202,7 +206,7 @@ $$(LIBUV_MAKEFILE_$(1)): $$(LIBUV_DEPS) $$(MKFILE_DEPS) $$(LIBUV_STAMP_$(1))
 	 $$(CFG_PYTHON) ./gyp_uv.py -f make -Dtarget_arch=$$(LIBUV_ARCH_$(1)) \
 	   -D ninja \
 	   -DOS=$$(LIBUV_OSTYPE_$(1)) \
-	   -Goutput_dir=$$(@D) --generator-output $$(@D))
+	   -Goutput_dir=$$(@D) $$(LIBUV_GYP_ARGS_$(1)) --generator-output $$(@D))
 	touch $$@
 
 # Windows has a completely different build system for libuv because of mingw. In

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -834,6 +834,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
     #[cfg(target_os = "linux")]
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     fn prefix_matches( line : &str, prefix : &str ) -> bool {
         line.starts_with( prefix )
     }
@@ -1237,6 +1238,7 @@ fn program_output(config: &Config, testfile: &Path, lib_path: &str, prog: String
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 fn make_cmdline(_libpath: &str, prog: &str, args: &[String]) -> String {
     format!("{} {}", prog, args.connect(" "))
 }

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -21,6 +21,7 @@ static OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("android", "android"),
     ("linux", "linux"),
     ("freebsd", "freebsd"),
+    ("dragonfly", "dragonfly"),
 ];
 
 pub fn get_os(triple: &str) -> &'static str {

--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -2001,7 +2001,7 @@ The following configurations must be defined by the implementation:
    `"unix"` or `"windows"`. The value of this configuration option is defined as
    a configuration itself, like `unix` or `windows`.
  * `target_os = "..."`. Operating system of the target, examples include
-   `"win32"`, `"macos"`, `"linux"`, `"android"` or `"freebsd"`.
+   `"win32"`, `"macos"`, `"linux"`, `"android"`, `"freebsd"` or `"dragonfly"`.
  * `target_word_size = "..."`. Target word size in bits. This is set to `"32"`
    for targets with 32-bit pointers, and likewise set to `"64"` for 64-bit
    pointers.

--- a/src/etc/local_stage0.sh
+++ b/src/etc/local_stage0.sh
@@ -18,7 +18,7 @@ LIB_PREFIX=lib
 
 OS=`uname -s`
 case $OS in
-    ("Linux"|"FreeBSD")
+    ("Linux"|"FreeBSD"|"DragonFly")
     BIN_SUF=
     LIB_SUF=.so
     break
@@ -58,3 +58,6 @@ cp ${PREFIX}/${LIB_DIR}/${LIB_PREFIX}extra*${LIB_SUF} ${TARG_DIR}/stage0/${LIB_D
 cp ${PREFIX}/${LIB_DIR}/${LIB_PREFIX}rust*${LIB_SUF} ${TARG_DIR}/stage0/${LIB_DIR}/
 cp ${PREFIX}/${LIB_DIR}/${LIB_PREFIX}std*${LIB_SUF} ${TARG_DIR}/stage0/${LIB_DIR}/
 cp ${PREFIX}/${LIB_DIR}/${LIB_PREFIX}syntax*${LIB_SUF} ${TARG_DIR}/stage0/${LIB_DIR}/
+
+# do not fail if one of the above fails, as all we need is a working rustc!
+exit 0

--- a/src/etc/mklldeps.py
+++ b/src/etc/mklldeps.py
@@ -56,6 +56,8 @@ for llconfig in sys.argv[4:]:
         os = 'linux'
     elif 'freebsd' in os:
         os = 'freebsd'
+    elif 'dragonfly' in os:
+        os = 'dragonfly'
     elif 'android' in os:
         os = 'android'
     elif 'win' in os or 'mingw' in os:

--- a/src/libgreen/stack.rs
+++ b/src/libgreen/stack.rs
@@ -25,10 +25,14 @@ pub struct Stack {
 // anyway), but some platforms don't support it at all. For example, it appears
 // that there's a bug in freebsd that MAP_STACK implies MAP_FIXED (so it always
 // fails): http://lists.freebsd.org/pipermail/freebsd-bugs/2011-July/044840.html
-#[cfg(not(windows), not(target_os = "freebsd"))]
+//
+// DragonFly BSD also seems to suffer from the same problem. When MAP_STACK is
+// used, it returns the same `ptr` multiple times.
+#[cfg(not(windows), not(target_os = "freebsd"), not(target_os = "dragonfly"))]
 static STACK_FLAGS: libc::c_int = libc::MAP_STACK | libc::MAP_PRIVATE |
                                   libc::MAP_ANON;
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 static STACK_FLAGS: libc::c_int = libc::MAP_PRIVATE | libc::MAP_ANON;
 #[cfg(windows)]
 static STACK_FLAGS: libc::c_int = 0;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -269,7 +269,8 @@ pub use funcs::bsd43::{shutdown};
 #[cfg(windows)] pub use funcs::extra::kernel32::{MoveFileExW, VirtualProtect};
 #[cfg(windows)] pub use funcs::extra::msvcrt::{get_osfhandle, open_osfhandle};
 
-#[cfg(target_os = "linux")] #[cfg(target_os = "android")] #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "linux")] #[cfg(target_os = "android")]
+#[cfg(target_os = "freebsd")] #[cfg(target_os = "dragonfly")]
 pub use consts::os::posix01::{CLOCK_REALTIME, CLOCK_MONOTONIC};
 
 #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
@@ -279,6 +280,7 @@ pub use funcs::posix01::unistd::{fdatasync};
 pub use consts::os::extra::{MAP_STACK};
 
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 pub use consts::os::bsd44::{TCP_KEEPIDLE};
 
 #[cfg(target_os = "macos")]
@@ -921,6 +923,205 @@ pub mod types {
                     pub __unused: [uint8_t, ..2],
                 }
 
+                pub struct utimbuf {
+                    pub actime: time_t,
+                    pub modtime: time_t,
+                }
+
+                pub type pthread_attr_t = *mut c_void;
+            }
+            pub mod posix08 {
+            }
+            pub mod bsd44 {
+            }
+            pub mod extra {
+            }
+        }
+    }
+
+    #[cfg(target_os = "dragonfly")]
+    pub mod os {
+        pub mod common {
+            pub mod posix01 {
+                use types::common::c95::{c_void};
+                use types::os::arch::c95::{c_char, c_int, size_t,
+                                                 time_t, suseconds_t, c_long};
+                use types::os::arch::c99::{uintptr_t};
+
+                pub type pthread_t = uintptr_t;
+
+                pub struct glob_t {
+                    pub gl_pathc:  size_t,
+                    pub __unused1: size_t,
+                    pub gl_offs:   size_t,
+                    pub __unused2: c_int,
+                    pub gl_pathv:  *mut *mut c_char,
+
+                    pub __unused3: *mut c_void,
+
+                    pub __unused4: *mut c_void,
+                    pub __unused5: *mut c_void,
+                    pub __unused6: *mut c_void,
+                    pub __unused7: *mut c_void,
+                    pub __unused8: *mut c_void,
+                }
+
+                pub struct timeval {
+                    pub tv_sec: time_t,
+                    pub tv_usec: suseconds_t,
+                }
+
+                pub struct timespec {
+                    pub tv_sec: time_t,
+                    pub tv_nsec: c_long,
+                }
+
+                pub enum timezone {}
+
+                pub type sighandler_t = size_t;
+            }
+            pub mod bsd44 {
+                use types::os::arch::c95::{c_char, c_int, c_uint};
+
+                pub type socklen_t = u32;
+                pub type sa_family_t = u8;
+                pub type in_port_t = u16;
+                pub type in_addr_t = u32;
+                pub struct sockaddr {
+                    pub sa_len: u8,
+                    pub sa_family: sa_family_t,
+                    pub sa_data: [u8, ..14],
+                }
+                pub struct sockaddr_storage {
+                    pub ss_len: u8,
+                    pub ss_family: sa_family_t,
+                    pub __ss_pad1: [u8, ..6],
+                    pub __ss_align: i64,
+                    pub __ss_pad2: [u8, ..112],
+                }
+                pub struct sockaddr_in {
+                    pub sin_len: u8,
+                    pub sin_family: sa_family_t,
+                    pub sin_port: in_port_t,
+                    pub sin_addr: in_addr,
+                    pub sin_zero: [u8, ..8],
+                }
+                pub struct in_addr {
+                    pub s_addr: in_addr_t,
+                }
+                pub struct sockaddr_in6 {
+                    pub sin6_len: u8,
+                    pub sin6_family: sa_family_t,
+                    pub sin6_port: in_port_t,
+                    pub sin6_flowinfo: u32,
+                    pub sin6_addr: in6_addr,
+                    pub sin6_scope_id: u32,
+                }
+                pub struct in6_addr {
+                    pub s6_addr: [u16, ..8]
+                }
+                pub struct ip_mreq {
+                    pub imr_multiaddr: in_addr,
+                    pub imr_interface: in_addr,
+                }
+                pub struct ip6_mreq {
+                    pub ipv6mr_multiaddr: in6_addr,
+                    pub ipv6mr_interface: c_uint,
+                }
+                pub struct addrinfo {
+                    pub ai_flags: c_int,
+                    pub ai_family: c_int,
+                    pub ai_socktype: c_int,
+                    pub ai_protocol: c_int,
+                    pub ai_addrlen: socklen_t,
+                    pub ai_canonname: *mut c_char,
+                    pub ai_addr: *mut sockaddr,
+                    pub ai_next: *mut addrinfo,
+                }
+                pub struct sockaddr_un {
+                    pub sun_len: u8,
+                    pub sun_family: sa_family_t,
+                    pub sun_path: [c_char, ..104]
+                }
+            }
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        pub mod arch {
+            pub mod c95 {
+                pub type c_char = i8;
+                pub type c_schar = i8;
+                pub type c_uchar = u8;
+                pub type c_short = i16;
+                pub type c_ushort = u16;
+                pub type c_int = i32;
+                pub type c_uint = u32;
+                pub type c_long = i64;
+                pub type c_ulong = u64;
+                pub type c_float = f32;
+                pub type c_double = f64;
+                pub type size_t = u64;
+                pub type ptrdiff_t = i64;
+                pub type clock_t = i32;
+                pub type time_t = i64;
+                pub type suseconds_t = i64;
+                pub type wchar_t = i32;
+            }
+            pub mod c99 {
+                pub type c_longlong = i64;
+                pub type c_ulonglong = u64;
+                pub type intptr_t = int;
+                pub type uintptr_t = uint;
+            }
+            pub mod posix88 {
+                pub type off_t = i64;
+                pub type dev_t = u32;
+                pub type ino_t = u32;
+                pub type pid_t = i32;
+                pub type uid_t = u32;
+                pub type gid_t = u32;
+                pub type useconds_t = u32;
+                pub type mode_t = u16;
+                pub type ssize_t = i64;
+            }
+            pub mod posix01 {
+                use types::common::c95::{c_void};
+                use types::common::c99::{uint16_t, uint32_t, int32_t, uint64_t, int64_t};
+                use types::os::arch::c95::{c_long, time_t};
+                use types::os::arch::posix88::{dev_t, gid_t};
+                use types::os::arch::posix88::{mode_t, off_t};
+                use types::os::arch::posix88::{uid_t};
+
+                pub type nlink_t = u16;
+                pub type blksize_t = uint32_t;
+                pub type ino_t = uint64_t;
+                pub type blkcnt_t = i64;
+                pub type fflags_t = u32;
+
+                pub struct stat {
+                    pub st_ino: ino_t,
+                    pub st_nlink: nlink_t,
+                    pub st_dev: dev_t,
+                    pub st_mode: mode_t,
+                    pub st_padding1: uint16_t,
+                    pub st_uid: uid_t,
+                    pub st_gid: gid_t,
+                    pub st_rdev: dev_t,
+                    pub st_atime: time_t,
+                    pub st_atime_nsec: c_long,
+                    pub st_mtime: time_t,
+                    pub st_mtime_nsec: c_long,
+                    pub st_ctime: time_t,
+                    pub st_ctime_nsec: c_long,
+                    pub st_size: off_t,
+                    pub st_blocks: blkcnt_t,
+                    pub st_blksize: blksize_t,
+                    pub st_flags: fflags_t,
+                    pub st_gen: uint32_t,
+                    pub st_lspare: int32_t,
+                    pub st_qspare1: int64_t,
+                    pub st_qspare2: int64_t,
+                }
                 pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
@@ -2736,6 +2937,7 @@ pub mod consts {
     }
 
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub mod os {
         pub mod c95 {
             use types::os::arch::c95::{c_int, c_uint};
@@ -2989,11 +3191,14 @@ pub mod consts {
             #[cfg(target_arch = "arm")]
             pub static PTHREAD_STACK_MIN: size_t = 4096;
 
-            #[cfg(target_arch = "mips")]
-            #[cfg(target_arch = "mipsel")]
-            #[cfg(target_arch = "x86")]
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(target_os = "freebsd", target_arch = "mips")]
+            #[cfg(target_os = "freebsd", target_arch = "mipsel")]
+            #[cfg(target_os = "freebsd", target_arch = "x86")]
+            #[cfg(target_os = "freebsd", target_arch = "x86_64")]
             pub static PTHREAD_STACK_MIN: size_t = 2048;
+
+            #[cfg(target_os = "dragonfly")]
+            pub static PTHREAD_STACK_MIN: size_t = 1024;
 
             pub static CLOCK_REALTIME: c_int = 0;
             pub static CLOCK_MONOTONIC: c_int = 4;
@@ -3056,7 +3261,10 @@ pub mod consts {
             pub static O_SYNC : c_int = 128;
             pub static CTL_KERN: c_int = 1;
             pub static KERN_PROC: c_int = 14;
+            #[cfg(target_os = "freebsd")]
             pub static KERN_PROC_PATHNAME: c_int = 12;
+            #[cfg(target_os = "dragonfly")]
+            pub static KERN_PROC_PATHNAME: c_int = 9;
 
             pub static MAP_COPY : c_int = 0x0002;
             pub static MAP_RENAME : c_int = 0x0020;
@@ -3809,6 +4017,7 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "ios")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub mod posix88 {
         pub mod stat_ {
             use types::os::arch::c95::{c_char, c_int};
@@ -3821,6 +4030,7 @@ pub mod funcs {
 
                 #[cfg(target_os = "linux")]
                 #[cfg(target_os = "freebsd")]
+                #[cfg(target_os = "dragonfly")]
                 #[cfg(target_os = "android")]
                 #[cfg(target_os = "ios")]
                 pub fn fstat(fildes: c_int, buf: *mut stat) -> c_int;
@@ -3834,6 +4044,7 @@ pub mod funcs {
 
                 #[cfg(target_os = "linux")]
                 #[cfg(target_os = "freebsd")]
+                #[cfg(target_os = "dragonfly")]
                 #[cfg(target_os = "android")]
                 #[cfg(target_os = "ios")]
                 pub fn stat(path: *const c_char, buf: *mut stat) -> c_int;
@@ -4016,6 +4227,7 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "ios")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub mod posix01 {
         pub mod stat_ {
             use types::os::arch::c95::{c_char, c_int};
@@ -4024,6 +4236,7 @@ pub mod funcs {
             extern {
                 #[cfg(target_os = "linux")]
                 #[cfg(target_os = "freebsd")]
+                #[cfg(target_os = "dragonfly")]
                 #[cfg(target_os = "android")]
                 #[cfg(target_os = "ios")]
                 pub fn lstat(path: *const c_char, buf: *mut stat) -> c_int;
@@ -4129,6 +4342,7 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "ios")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub mod posix08 {
         pub mod unistd {
         }
@@ -4212,6 +4426,7 @@ pub mod funcs {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "ios")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub mod bsd44 {
         use types::common::c95::{c_void};
         use types::os::arch::c95::{c_char, c_uchar, c_int, c_uint, size_t};
@@ -4275,6 +4490,7 @@ pub mod funcs {
     }
 
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub mod extra {
     }
 

--- a/src/libnative/io/c_unix.rs
+++ b/src/libnative/io/c_unix.rs
@@ -22,6 +22,7 @@ use libc;
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 pub static FIONBIO: libc::c_ulong = 0x8004667e;
 #[cfg(target_os = "linux", target_arch = "x86")]
 #[cfg(target_os = "linux", target_arch = "x86_64")]
@@ -35,6 +36,7 @@ pub static FIONBIO: libc::c_ulong = 0x667e;
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 pub static FIOCLEX: libc::c_ulong = 0x20006601;
 #[cfg(target_os = "linux", target_arch = "x86")]
 #[cfg(target_os = "linux", target_arch = "x86_64")]
@@ -48,6 +50,7 @@ pub static FIOCLEX: libc::c_ulong = 0x6601;
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 pub static MSG_DONTWAIT: libc::c_int = 0x80;
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "android")]
@@ -99,6 +102,7 @@ mod select {
 
 #[cfg(target_os = "android")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 #[cfg(target_os = "linux")]
 mod select {
     use std::uint;
@@ -106,6 +110,7 @@ mod select {
     pub static FD_SETSIZE: uint = 1024;
 
     pub struct fd_set {
+        // FIXME: shouldn't this be a c_ulong?
         fds_bits: [uint, ..(FD_SETSIZE / uint::BITS)]
     }
 
@@ -202,6 +207,7 @@ mod signal {
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 mod signal {
     use libc;
 
@@ -218,6 +224,7 @@ mod signal {
     #[cfg(target_os = "ios")]
     pub type sigset_t = u32;
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub struct sigset_t {
         bits: [u32, ..4],
     }
@@ -243,6 +250,7 @@ mod signal {
     }
 
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     pub struct sigaction {
         pub sa_handler: extern fn(libc::c_int),
         pub sa_flags: libc::c_int,

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -52,6 +52,7 @@ pub mod file;
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 #[cfg(target_os = "android")]
 #[cfg(target_os = "linux")]
 #[path = "timer_unix.rs"]

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -326,11 +326,13 @@ impl TcpStream {
                    seconds as libc::c_int)
     }
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     fn set_tcp_keepalive(&mut self, seconds: uint) -> IoResult<()> {
         setsockopt(self.fd(), libc::IPPROTO_TCP, libc::TCP_KEEPIDLE,
                    seconds as libc::c_int)
     }
-    #[cfg(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "freebsd"))]
+    #[cfg(not(target_os = "macos"), not(target_os = "ios"), not(target_os = "freebsd"),
+      not(target_os = "dragonfly"))]
     fn set_tcp_keepalive(&mut self, _seconds: uint) -> IoResult<()> {
         Ok(())
     }

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -847,6 +847,7 @@ fn translate_status(status: c_int) -> rtio::ProcessExit {
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "ios")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     mod imp {
         pub fn WIFEXITED(status: i32) -> bool { (status & 0x7f) == 0 }
         pub fn WEXITSTATUS(status: i32) -> i32 { status >> 8 }

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -927,6 +927,7 @@ pub fn filename_for_input(sess: &Session,
                 abi::OsLinux => (loader::LINUX_DLL_PREFIX, loader::LINUX_DLL_SUFFIX),
                 abi::OsAndroid => (loader::ANDROID_DLL_PREFIX, loader::ANDROID_DLL_SUFFIX),
                 abi::OsFreebsd => (loader::FREEBSD_DLL_PREFIX, loader::FREEBSD_DLL_SUFFIX),
+                abi::OsDragonfly => (loader::DRAGONFLY_DLL_PREFIX, loader::DRAGONFLY_DLL_SUFFIX),
                 abi::OsiOS => unreachable!(),
             };
             out_filename.with_filename(format!("{}{}{}",
@@ -944,6 +945,7 @@ pub fn filename_for_input(sess: &Session,
                 abi::OsLinux |
                 abi::OsAndroid |
                 abi::OsFreebsd |
+                abi::OsDragonfly |
                 abi::OsiOS => out_filename.clone(),
             }
         }
@@ -1311,7 +1313,7 @@ fn link_args(cmd: &mut Command,
         cmd.arg("-Wl,--gc-sections");
     }
 
-    if sess.targ_cfg.os == abi::OsLinux {
+    if sess.targ_cfg.os == abi::OsLinux || sess.targ_cfg.os == abi::OsDragonfly {
         // GNU-style linkers will use this to omit linking to libraries which
         // don't actually fulfill any relocations, but only for libraries which
         // follow this flag. Thus, use it before specifying libraries to link to.
@@ -1436,6 +1438,12 @@ fn link_args(cmd: &mut Command,
                   "-L/usr/local/lib/gcc46",
                   "-L/usr/local/lib/gcc44"]);
     }
+    else if sess.targ_cfg.os == abi::OsDragonfly {
+        cmd.args(["-L/usr/local/lib",
+                  "-L/usr/lib/gcc47",
+                  "-L/usr/lib/gcc44"]);
+    }
+
 
     // FIXME (#2397): At some point we want to rpath our guesses as to
     // where extern libraries might live, based on the

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -390,12 +390,13 @@ pub fn default_lib_output() -> CrateType {
 
 pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     let tos = match sess.targ_cfg.os {
-        abi::OsWin32 =>   InternedString::new("win32"),
-        abi::OsMacos =>   InternedString::new("macos"),
-        abi::OsLinux =>   InternedString::new("linux"),
-        abi::OsAndroid => InternedString::new("android"),
-        abi::OsFreebsd => InternedString::new("freebsd"),
-        abi::OsiOS =>     InternedString::new("ios"),
+        abi::OsWin32 =>     InternedString::new("win32"),
+        abi::OsMacos =>     InternedString::new("macos"),
+        abi::OsLinux =>     InternedString::new("linux"),
+        abi::OsAndroid =>   InternedString::new("android"),
+        abi::OsFreebsd =>   InternedString::new("freebsd"),
+        abi::OsDragonfly => InternedString::new("dragonfly"),
+        abi::OsiOS =>       InternedString::new("ios"),
     };
 
     // ARM is bi-endian, however using NDK seems to default
@@ -451,13 +452,14 @@ pub fn get_os(triple: &str) -> Option<abi::Os> {
     None
 }
 static os_names : &'static [(&'static str, abi::Os)] = &[
-    ("mingw32", abi::OsWin32),
-    ("win32",   abi::OsWin32),
-    ("darwin",  abi::OsMacos),
-    ("android", abi::OsAndroid),
-    ("linux",   abi::OsLinux),
-    ("freebsd", abi::OsFreebsd),
-    ("ios",     abi::OsiOS)];
+    ("mingw32",   abi::OsWin32),
+    ("win32",     abi::OsWin32),
+    ("darwin",    abi::OsMacos),
+    ("android",   abi::OsAndroid),
+    ("linux",     abi::OsLinux),
+    ("freebsd",   abi::OsFreebsd),
+    ("dragonfly", abi::OsDragonfly),
+    ("ios",       abi::OsiOS)];
 
 pub fn get_arch(triple: &str) -> Option<abi::Architecture> {
     for &(arch, abi) in architecture_abis.iter() {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -251,6 +251,9 @@ pub static LINUX_DLL_SUFFIX: &'static str = ".so";
 pub static FREEBSD_DLL_PREFIX: &'static str = "lib";
 pub static FREEBSD_DLL_SUFFIX: &'static str = ".so";
 
+pub static DRAGONFLY_DLL_PREFIX: &'static str = "lib";
+pub static DRAGONFLY_DLL_SUFFIX: &'static str = ".so";
+
 pub static ANDROID_DLL_PREFIX: &'static str = "lib";
 pub static ANDROID_DLL_SUFFIX: &'static str = ".so";
 
@@ -617,6 +620,7 @@ impl<'a> Context<'a> {
             abi::OsLinux => Some((LINUX_DLL_PREFIX, LINUX_DLL_SUFFIX)),
             abi::OsAndroid => Some((ANDROID_DLL_PREFIX, ANDROID_DLL_SUFFIX)),
             abi::OsFreebsd => Some((FREEBSD_DLL_PREFIX, FREEBSD_DLL_SUFFIX)),
+            abi::OsDragonfly => Some((DRAGONFLY_DLL_PREFIX, DRAGONFLY_DLL_SUFFIX)),
             abi::OsiOS => None,
         }
     }
@@ -823,7 +827,8 @@ pub fn meta_section_name(os: abi::Os) -> Option<&'static str> {
         abi::OsWin32 => Some(".note.rustc"),
         abi::OsLinux => Some(".note.rustc"),
         abi::OsAndroid => Some(".note.rustc"),
-        abi::OsFreebsd => Some(".note.rustc")
+        abi::OsFreebsd => Some(".note.rustc"),
+        abi::OsDragonfly => Some(".note.rustc"),
     }
 }
 
@@ -834,7 +839,8 @@ pub fn read_meta_section_name(os: abi::Os) -> &'static str {
         abi::OsWin32 => ".note.rustc",
         abi::OsLinux => ".note.rustc",
         abi::OsAndroid => ".note.rustc",
-        abi::OsFreebsd => ".note.rustc"
+        abi::OsFreebsd => ".note.rustc",
+        abi::OsDragonfly => ".note.rustc"
     }
 }
 

--- a/src/librustc_back/arm.rs
+++ b/src/librustc_back/arm.rs
@@ -61,7 +61,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 -a0:0:64-n32".to_string()
           }
 
-          abi::OsFreebsd => {
+          abi::OsFreebsd | abi::OsDragonfly => {
             "e-p:32:32:32\
                 -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
                 -f32:32:32-f64:64:64\

--- a/src/librustc_back/mips.rs
+++ b/src/librustc_back/mips.rs
@@ -56,7 +56,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 -a0:0:64-n32".to_string()
           }
 
-          abi::OsFreebsd => {
+          abi::OsFreebsd | abi::OsDragonfly => {
             "E-p:32:32:32\
                 -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
                 -f32:32:32-f64:64:64\

--- a/src/librustc_back/mipsel.rs
+++ b/src/librustc_back/mipsel.rs
@@ -56,7 +56,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 -a0:0:64-n32".to_string()
           }
 
-          abi::OsFreebsd => {
+          abi::OsFreebsd | abi::OsDragonfly => {
             "e-p:32:32:32\
                 -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
                 -f32:32:32-f64:64:64\

--- a/src/librustc_back/x86.rs
+++ b/src/librustc_back/x86.rs
@@ -48,6 +48,10 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os)
           abi::OsFreebsd => {
             "e-p:32:32-f64:32:64-i64:32:64-f80:32:32-n8:16:32".to_string()
           }
+          abi::OsDragonfly => {
+            "e-p:32:32-f64:32:64-i64:32:64-f80:32:32-n8:16:32".to_string()
+          }
+
         },
 
         target_triple: target_triple,

--- a/src/librustc_back/x86_64.rs
+++ b/src/librustc_back/x86_64.rs
@@ -52,6 +52,12 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-\
                 s0:64:64-f80:128:128-n8:16:32:64-S128".to_string()
           }
+          abi::OsDragonfly => {
+            "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-\
+                f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-\
+                s0:64:64-f80:128:128-n8:16:32:64-S128".to_string()
+          }
+
         },
 
         target_triple: target_triple,

--- a/src/librustdoc/flock.rs
+++ b/src/librustdoc/flock.rs
@@ -63,6 +63,27 @@ mod imp {
         pub static F_SETLKW: libc::c_int = 13;
     }
 
+    #[cfg(target_os = "dragonfly")]
+    mod os {
+        use libc;
+
+        pub struct flock {
+            pub l_start: libc::off_t,
+            pub l_len: libc::off_t,
+            pub l_pid: libc::pid_t,
+            pub l_type: libc::c_short,
+            pub l_whence: libc::c_short,
+
+            // not actually here, but brings in line with freebsd
+            pub l_sysid: libc::c_int,
+        }
+
+        pub static F_UNLCK: libc::c_short = 2;
+        pub static F_WRLCK: libc::c_short = 3;
+        pub static F_SETLK: libc::c_int = 8;
+        pub static F_SETLKW: libc::c_int = 9;
+    }
+
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "ios")]
     mod os {

--- a/src/librustrt/args.rs
+++ b/src/librustrt/args.rs
@@ -42,6 +42,7 @@ pub fn clone() -> Option<Vec<Vec<u8>>> { imp::clone() }
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "android")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 mod imp {
     use core::prelude::*;
 

--- a/src/librustrt/libunwind.rs
+++ b/src/librustrt/libunwind.rs
@@ -94,6 +94,9 @@ extern {}
 #[link(name = "gcc")]
 extern {}
 
+#[cfg(target_os = "dragonfly")]
+#[link(name = "gcc_pic")]
+extern {}
 
 extern "C" {
     // iOS on armv7 uses SjLj exceptions and requires to link

--- a/src/librustrt/mutex.rs
+++ b/src/librustrt/mutex.rs
@@ -347,6 +347,7 @@ mod imp {
     type pthread_condattr_t = libc::c_void;
 
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     mod os {
         use libc;
 

--- a/src/librustrt/stack.rs
+++ b/src/librustrt/stack.rs
@@ -194,6 +194,10 @@ pub unsafe fn record_sp_limit(limit: uint) {
     unsafe fn target_record_sp_limit(limit: uint) {
         asm!("movq $0, %fs:24" :: "r"(limit) :: "volatile")
     }
+    #[cfg(target_arch = "x86_64", target_os = "dragonfly")] #[inline(always)]
+    unsafe fn target_record_sp_limit(limit: uint) {
+        asm!("movq $0, %fs:32" :: "r"(limit) :: "volatile")
+    }
 
     // x86
     #[cfg(target_arch = "x86", target_os = "macos")]
@@ -272,6 +276,13 @@ pub unsafe fn get_sp_limit() -> uint {
         asm!("movq %fs:24, $0" : "=r"(limit) ::: "volatile");
         return limit;
     }
+    #[cfg(target_arch = "x86_64", target_os = "dragonfly")] #[inline(always)]
+    unsafe fn target_get_sp_limit() -> uint {
+        let limit;
+        asm!("movq %fs:32, $0" : "=r"(limit) ::: "volatile");
+        return limit;
+    }
+
 
     // x86
     #[cfg(target_arch = "x86", target_os = "macos")]

--- a/src/librustrt/thread_local_storage.rs
+++ b/src/librustrt/thread_local_storage.rs
@@ -43,6 +43,7 @@ type pthread_key_t = ::libc::c_ulong;
 
 #[cfg(target_os="linux")]
 #[cfg(target_os="freebsd")]
+#[cfg(target_os="dragonfly")]
 #[cfg(target_os="android")]
 #[cfg(target_os = "ios")]
 #[allow(non_camel_case_types)] // foreign type

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -719,6 +719,7 @@ extern {
 extern {}
 
 #[cfg(target_os = "linux")]
+#[cfg(target_os = "dragonfly")]
 #[link(name = "rt")]
 extern {}
 
@@ -729,5 +730,6 @@ extern {}
 extern {}
 
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 #[link(name = "kvm")]
 extern {}

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -193,6 +193,7 @@ mod test {
     #[cfg(target_os = "linux")]
     #[cfg(target_os = "macos")]
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     fn test_errors_do_not_crash() {
         // Open /dev/null as a library to get an error, and make sure
         // that only causes an error, and not a crash.
@@ -209,6 +210,7 @@ mod test {
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 pub mod dl {
 
     use c_str::{CString, ToCStr};

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -651,6 +651,7 @@ pub fn dll_filename(base: &str) -> String {
 pub fn self_exe_name() -> Option<Path> {
 
     #[cfg(target_os = "freebsd")]
+    #[cfg(target_os = "dragonfly")]
     fn load_self() -> Option<Vec<u8>> {
         unsafe {
             use libc::funcs::bsd44::*;
@@ -913,6 +914,16 @@ pub fn errno() -> int {
         }
     }
 
+    #[cfg(target_os = "dragonfly")]
+    fn errno_location() -> *const c_int {
+        extern {
+            fn __dfly_error() -> *const c_int;
+        }
+        unsafe {
+            __dfly_error()
+        }
+    }
+
     #[cfg(target_os = "linux")]
     #[cfg(target_os = "android")]
     fn errno_location() -> *const c_int {
@@ -961,6 +972,7 @@ pub fn error_string(errnum: uint) -> String {
         #[cfg(target_os = "ios")]
         #[cfg(target_os = "android")]
         #[cfg(target_os = "freebsd")]
+        #[cfg(target_os = "dragonfly")]
         fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: libc::size_t)
                       -> c_int {
             extern {
@@ -1167,6 +1179,7 @@ fn real_args_as_bytes() -> Vec<Vec<u8>> {
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "android")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 fn real_args_as_bytes() -> Vec<Vec<u8>> {
     use rt;
 
@@ -1745,6 +1758,37 @@ pub mod consts {
     /// A string describing the specific operating system in use: in this
     /// case, `freebsd`.
     pub static SYSNAME: &'static str = "freebsd";
+
+    /// Specifies the filename prefix used for shared libraries on this
+    /// platform: in this case, `lib`.
+    pub static DLL_PREFIX: &'static str = "lib";
+
+    /// Specifies the filename suffix used for shared libraries on this
+    /// platform: in this case, `.so`.
+    pub static DLL_SUFFIX: &'static str = ".so";
+
+    /// Specifies the file extension used for shared libraries on this
+    /// platform that goes after the dot: in this case, `so`.
+    pub static DLL_EXTENSION: &'static str = "so";
+
+    /// Specifies the filename suffix used for executable binaries on this
+    /// platform: in this case, the empty string.
+    pub static EXE_SUFFIX: &'static str = "";
+
+    /// Specifies the file extension, if any, used for executable binaries
+    /// on this platform: in this case, the empty string.
+    pub static EXE_EXTENSION: &'static str = "";
+}
+
+#[cfg(target_os = "dragonfly")]
+pub mod consts {
+    pub use os::arch_consts::ARCH;
+
+    pub static FAMILY: &'static str = "unix";
+
+    /// A string describing the specific operating system in use: in this
+    /// case, `dragonfly`.
+    pub static SYSNAME: &'static str = "dragonfly";
 
     /// Specifies the filename prefix used for shared libraries on this
     /// platform: in this case, `lib`.

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -464,11 +464,15 @@ mod imp {
         // the symbols. The libbacktrace API also states that the filename must
         // be in "permanent memory", so we copy it to a static and then use the
         // static as the pointer.
+        //
+        // FIXME: We also call self_exe_name() on DragonFly BSD. I haven't 
+        //        tested if this is required or not.
         unsafe fn init_state() -> *mut backtrace_state {
             static mut STATE: *mut backtrace_state = 0 as *mut backtrace_state;
             static mut LAST_FILENAME: [libc::c_char, ..256] = [0, ..256];
             if !STATE.is_null() { return STATE }
-            let selfname = if cfg!(target_os = "freebsd") {
+            let selfname = if cfg!(target_os = "freebsd") || 
+                              cfg!(target_os = "dragonfly") {
                 os::self_exe_name()
             } else {
                 None

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -465,13 +465,13 @@ mod imp {
         // be in "permanent memory", so we copy it to a static and then use the
         // static as the pointer.
         //
-        // FIXME: We also call self_exe_name() on DragonFly BSD. I haven't 
+        // FIXME: We also call self_exe_name() on DragonFly BSD. I haven't
         //        tested if this is required or not.
         unsafe fn init_state() -> *mut backtrace_state {
             static mut STATE: *mut backtrace_state = 0 as *mut backtrace_state;
             static mut LAST_FILENAME: [libc::c_char, ..256] = [0, ..256];
             if !STATE.is_null() { return STATE }
-            let selfname = if cfg!(target_os = "freebsd") || 
+            let selfname = if cfg!(target_os = "freebsd") ||
                               cfg!(target_os = "dragonfly") {
                 os::self_exe_name()
             } else {

--- a/src/libstd/rtdeps.rs
+++ b/src/libstd/rtdeps.rs
@@ -38,6 +38,10 @@ extern {}
 #[link(name = "pthread")]
 extern {}
 
+#[cfg(target_os = "dragonfly")]
+#[link(name = "pthread")]
+extern {}
+
 #[cfg(target_os = "macos")]
 #[link(name = "System")]
 extern {}

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -11,7 +11,7 @@
 use std::fmt;
 
 #[deriving(PartialEq)]
-pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, OsiOS, 
+pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, OsiOS,
               OsDragonfly }
 
 #[deriving(PartialEq, Eq, Hash, Encodable, Decodable, Clone)]

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -11,7 +11,8 @@
 use std::fmt;
 
 #[deriving(PartialEq)]
-pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, OsiOS, }
+pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, OsiOS, 
+              OsDragonfly }
 
 #[deriving(PartialEq, Eq, Hash, Encodable, Decodable, Clone)]
 pub enum Abi {
@@ -150,7 +151,8 @@ impl fmt::Show for Os {
             OsMacos => "macos".fmt(f),
             OsiOS => "ios".fmt(f),
             OsAndroid => "android".fmt(f),
-            OsFreebsd => "freebsd".fmt(f)
+            OsFreebsd => "freebsd".fmt(f),
+            OsDragonfly => "dragonfly".fmt(f)
         }
     }
 }

--- a/src/rt/arch/x86_64/morestack.S
+++ b/src/rt/arch/x86_64/morestack.S
@@ -15,13 +15,13 @@
 
 #if defined(__APPLE__)
 #define EXHAUSTED               _rust_stack_exhausted
-#elif defined(__linux__) || defined(__FreeBSD__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 #define EXHAUSTED               rust_stack_exhausted@PLT
 #else
 #define EXHAUSTED               rust_stack_exhausted
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 	.hidden MORESTACK
 #else
 #if defined(__APPLE__)

--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -70,7 +70,7 @@ extern char **environ;
 #endif
 #endif
 
-#if defined(__FreeBSD__) || defined(__linux__) || defined(__ANDROID__)
+#if defined(__FreeBSD__) || defined(__linux__) || defined(__ANDROID__) || defined(__DragonFly__)
 extern char **environ;
 #endif
 
@@ -355,6 +355,13 @@ rust_unset_sigprocmask() {
     sigprocmask(SIG_SETMASK, &sset, NULL);
 }
 
+#endif
+
+#if defined(__DragonFly__)
+#include <errno.h>
+// In DragonFly __error() is an inline function and as such
+// no symbol exists for it.
+int *__dfly_error(void) { return __error(); }
 #endif
 
 //

--- a/src/test/run-pass/dupe-first-attr.rc
+++ b/src/test/run-pass/dupe-first-attr.rc
@@ -23,6 +23,9 @@ mod hello;
 #[cfg(target_os = "freebsd")]
 mod hello;
 
+#[cfg(target_os = "dragonfly")]
+mod hello;
+
 #[cfg(target_os = "android")]
 mod hello;
 

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -20,6 +20,7 @@ mod rusti {
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]

--- a/src/test/run-pass/lang-item-public.rs
+++ b/src/test/run-pass/lang-item-public.rs
@@ -28,6 +28,10 @@ extern {}
 #[link(name = "execinfo")]
 extern {}
 
+#[cfg(target_os = "dragonfly")]
+#[link(name = "c")]
+extern {}
+
 #[cfg(target_os = "macos")]
 #[link(name = "System")]
 extern {}

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -39,6 +39,7 @@ struct Outer {
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 mod m {
     #[cfg(target_arch = "x86")]
     pub mod m {

--- a/src/test/run-pass/x86stdcall.rs
+++ b/src/test/run-pass/x86stdcall.rs
@@ -33,5 +33,6 @@ pub fn main() {
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "freebsd")]
+#[cfg(target_os = "dragonfly")]
 #[cfg(target_os = "android")]
 pub fn main() { }


### PR DESCRIPTION
Not included are two required patches:
- LLVM: segmented stack support for DragonFly [1](http://reviews.llvm.org/D4705)
- jemalloc: simple configure patches
