### PR TITLE
Derive PartialOrd/Ord/Hash for bitflags structs. Implement Default for io::FilePermission

### DIFF
--- a/src/libstd/bitflags.rs
+++ b/src/libstd/bitflags.rs
@@ -113,7 +113,7 @@ macro_rules! bitflags(
     ($(#[$attr:meta])* flags $BitFlags:ident: $T:ty {
         $($(#[$Flag_attr:meta])* static $Flag:ident = $value:expr),+
     }) => (
-        #[deriving(PartialEq, Eq, Clone)]
+        #[deriving(PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
         $(#[$attr])*
         pub struct $BitFlags {
             bits: $T,
@@ -220,6 +220,7 @@ macro_rules! bitflags(
 
 #[cfg(test)]
 mod tests {
+    use hash;
     use option::{Some, None};
     use ops::{BitOr, BitAnd, Sub, Not};
 
@@ -335,5 +336,43 @@ mod tests {
         assert!((e1 & e2) == FlagC);     // intersection
         assert!((e1 - e2) == FlagA);     // set difference
         assert!(!e2 == FlagA);           // set complement
+    }
+
+    #[test]
+    fn test_lt() {
+        let mut a = Flags::empty();
+        let mut b = Flags::empty();
+
+        assert!(!(a < b) && !(b < a));
+        b = FlagB;
+        assert!(a < b);
+        a = FlagC;
+        assert!(!(a < b) && b < a);
+        b = FlagC | FlagB;
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_ord() {
+        let mut a = Flags::empty();
+        let mut b = Flags::empty();
+
+        assert!(a <= b && a >= b);
+        a = FlagA;
+        assert!(a > b && a >= b);
+        assert!(b < a && b <= a);
+        b = FlagB;
+        assert!(b > a && b >= a);
+        assert!(a < b && a <= b);
+    }
+
+    #[test]
+    fn test_hash() {
+      let mut x = Flags::empty();
+      let mut y = Flags::empty();
+      assert!(hash::hash(&x) == hash::hash(&y));
+      x = Flags::all();
+      y = FlagABC;
+      assert!(hash::hash(&x) == hash::hash(&y));
     }
 }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -223,6 +223,7 @@ responding to errors that may occur while attempting to read the numbers.
 
 use char::Char;
 use collections::Collection;
+use default::Default;
 use fmt;
 use int;
 use iter::Iterator;
@@ -1828,6 +1829,11 @@ on unix-like systems."]
         static AllPermissions = UserRWX.bits | GroupRWX.bits | OtherRWX.bits
     }
 )
+
+impl Default for FilePermission {
+    #[inline]
+    fn default() -> FilePermission { FilePermission::empty() }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1795,7 +1795,6 @@ pub struct UnstableFileStat {
 bitflags!(
     #[doc="A set of permissions for a file or directory is represented
 by a set of flags which are or'd together."]
-    #[deriving(Hash)]
     #[deriving(Show)]
     flags FilePermission: u32 {
         static UserRead     = 0o400,


### PR DESCRIPTION
I wanted to add an implementation of `Default` inside the bitflags macro, but `Default` isn't in the prelude, which means anyone who wants to use `bitflags!` needs to import it. This seems not nice, so I've just implemented for `FilePermission` instead.
