### PR TITLE
Gedit/gtksourceview language spec: add raw strings

### DIFF
--- a/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
+++ b/src/etc/gedit/share/gtksourceview-3.0/language-specs/rust.lang
@@ -269,6 +269,14 @@
       <match>\\\%{common_escape}</match>
     </context>
 
+    <context id="raw-string" style-ref="string" class="string" class-disabled="no-spell-check">
+      <start>r(#*)"</start>
+      <end>"\%{1@start}</end>
+      <include>
+        <context ref="def:line-continue"/>
+      </include>
+    </context>
+
     <context id="string" style-ref="string" class="string" class-disabled="no-spell-check">
       <start>"</start>
       <end>"</end>
@@ -287,6 +295,8 @@
       <end>\]</end>
       <include>
         <context ref="def:in-comment"/>
+        <context ref="string"/>
+        <context ref="raw-string"/>
       </include>
     </context>
 
@@ -305,6 +315,7 @@
         <context ref="number"/>
         <context ref="scope"/>
         <context ref="string"/>
+        <context ref="raw-string"/>
         <context ref="char"/>
         <context ref="lifetime"/>
         <context ref="attribute"/>


### PR DESCRIPTION
… and color (raw) strings as such in attributes. This fixes cases where a string contains ] inside an attribute: that ] used to incorrectly end the attribute coloring.

For large (many lines) doc comments, I’ve found preferable to use `#![doc = r#"..."#]` to avoid prefixing every line with `//!`.
