### PR TITLE
Implement RFC #43

### DIFF
--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -1564,7 +1564,8 @@ fn remove<K: Ord, V>(node: &mut Option<Box<TreeNode<K, V>>>,
                 save.level -= 1;
 
                 if right_level > save.level {
-                    for x in save.right.mut_iter() { x.level = save.level }
+                    let save_level = save.level;
+                    for x in save.right.mut_iter() { x.level = save_level }
                 }
 
                 skew(save);

--- a/src/libstd/collections/lru_cache.rs
+++ b/src/libstd/collections/lru_cache.rs
@@ -331,7 +331,8 @@ impl<K, V> Drop for LruCache<K, V> {
         unsafe {
             let node: Box<LruEntry<K, V>> = mem::transmute(self.head);
             // Prevent compiler from trying to drop the un-initialized field in the sigil node.
-            let box LruEntry { key: k, value: v, .. } = node;
+            let box internal_node = node;
+            let LruEntry { next: _, prev: _, key: k, value: v } = internal_node;
             mem::forget(k);
             mem::forget(v);
         }

--- a/src/test/compile-fail/borrowck-borrow-from-owned-ptr.rs
+++ b/src/test/compile-fail/borrowck-borrow-from-owned-ptr.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -52,7 +52,7 @@ fn borrow_same_field_twice_imm_imm() {
 fn borrow_both_fields_mut() {
     let mut foo = make_foo();
     let bar1 = &mut foo.bar1;
-    let _bar2 = &mut foo.bar2;
+    let _bar2 = &mut foo.bar2; //~ ERROR cannot borrow
     *bar1;
 }
 
@@ -60,6 +60,7 @@ fn borrow_both_mut_pattern() {
     let mut foo = make_foo();
     match *foo {
         Foo { bar1: ref mut _bar1, bar2: ref mut _bar2 } => {}
+        //~^ ERROR cannot borrow
     }
 }
 
@@ -120,7 +121,7 @@ fn borrow_imm_and_base_imm() {
 fn borrow_mut_and_imm() {
     let mut foo = make_foo();
     let bar1 = &mut foo.bar1;
-    let _foo1 = &foo.bar2;
+    let _foo1 = &foo.bar2; //~ ERROR cannot borrow
     *bar1;
 }
 
@@ -133,7 +134,7 @@ fn borrow_mut_from_imm() {
 fn borrow_long_path_both_mut() {
     let mut foo = make_foo();
     let bar1 = &mut foo.bar1.int1;
-    let foo1 = &mut foo.bar2.int2;
+    let foo1 = &mut foo.bar2.int2; //~ ERROR cannot borrow
     *bar1;
     *foo1;
 }

--- a/src/test/compile-fail/borrowck-box-insensitivity.rs
+++ b/src/test/compile-fail/borrowck-box-insensitivity.rs
@@ -1,0 +1,150 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct A {
+    x: Box<int>,
+    y: int,
+}
+
+struct B {
+    x: Box<int>,
+    y: Box<int>,
+}
+
+struct C {
+    x: Box<A>,
+    y: int,
+}
+
+struct D {
+    x: Box<A>,
+    y: Box<int>,
+}
+
+fn copy_after_move() {
+    let a = box A { x: box 0, y: 1 };
+    let _x = a.x;
+    let _y = a.y; //~ ERROR use of partially moved
+}
+
+fn move_after_move() {
+    let a = box B { x: box 0, y: box 1 };
+    let _x = a.x;
+    let _y = a.y; //~ ERROR use of partially moved
+}
+
+fn borrow_after_move() {
+    let a = box A { x: box 0, y: 1 };
+    let _x = a.x;
+    let _y = &a.y; //~ ERROR use of partially moved
+}
+
+fn move_after_borrow() {
+    let a = box B { x: box 0, y: box 1 };
+    let _x = &a.x;
+    let _y = a.y; //~ ERROR cannot move
+}
+
+fn copy_after_mut_borrow() {
+    let mut a = box A { x: box 0, y: 1 };
+    let _x = &mut a.x;
+    let _y = a.y; //~ ERROR cannot use
+}
+
+fn move_after_mut_borrow() {
+    let mut a = box B { x: box 0, y: box 1 };
+    let _x = &mut a.x;
+    let _y = a.y; //~ ERROR cannot move
+}
+
+fn borrow_after_mut_borrow() {
+    let mut a = box A { x: box 0, y: 1 };
+    let _x = &mut a.x;
+    let _y = &a.y; //~ ERROR cannot borrow
+}
+
+fn mut_borrow_after_borrow() {
+    let mut a = box A { x: box 0, y: 1 };
+    let _x = &a.x;
+    let _y = &mut a.y; //~ ERROR cannot borrow
+}
+
+fn copy_after_move_nested() {
+    let a = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let _x = a.x.x;
+    let _y = a.y; //~ ERROR use of partially moved
+}
+
+fn move_after_move_nested() {
+    let a = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
+    let _x = a.x.x;
+    let _y = a.y; //~ ERROR use of partially moved
+}
+
+fn borrow_after_move_nested() {
+    let a = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let _x = a.x.x;
+    let _y = &a.y; //~ ERROR use of partially moved
+}
+
+fn move_after_borrow_nested() {
+    let a = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
+    let _x = &a.x.x;
+    let _y = a.y; //~ ERROR cannot move
+}
+
+fn copy_after_mut_borrow_nested() {
+    let mut a = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let _x = &mut a.x.x;
+    let _y = a.y; //~ ERROR cannot use
+}
+
+fn move_after_mut_borrow_nested() {
+    let mut a = box D { x: box A { x: box 0, y: 1 }, y: box 2 };
+    let _x = &mut a.x.x;
+    let _y = a.y; //~ ERROR cannot move
+}
+
+fn borrow_after_mut_borrow_nested() {
+    let mut a = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let _x = &mut a.x.x;
+    let _y = &a.y; //~ ERROR cannot borrow
+}
+
+fn mut_borrow_after_borrow_nested() {
+    let mut a = box C { x: box A { x: box 0, y: 1 }, y: 2 };
+    let _x = &a.x.x;
+    let _y = &mut a.y; //~ ERROR cannot borrow
+}
+
+fn main() {
+    copy_after_move();
+    move_after_move();
+    borrow_after_move();
+
+    move_after_borrow();
+
+    copy_after_mut_borrow();
+    move_after_mut_borrow();
+    borrow_after_mut_borrow();
+    mut_borrow_after_borrow();
+
+    copy_after_move_nested();
+    move_after_move_nested();
+    borrow_after_move_nested();
+
+    move_after_borrow_nested();
+
+    copy_after_mut_borrow_nested();
+    move_after_mut_borrow_nested();
+    borrow_after_mut_borrow_nested();
+    mut_borrow_after_borrow_nested();
+}
+

--- a/src/test/run-pass/match-implicit-copy-unique.rs
+++ b/src/test/run-pass/match-implicit-copy-unique.rs
@@ -13,8 +13,9 @@ struct Pair { a: Box<int>, b: Box<int> }
 
 pub fn main() {
     let mut x = box Pair {a: box 10, b: box 20};
-    match x {
-      box Pair {a: ref mut a, b: ref mut _b} => {
+    let x_internal = &mut *x;
+    match *x_internal {
+      Pair {a: ref mut a, b: ref mut _b} => {
         assert!(**a == 10); *a = box 30; assert!(**a == 30);
       }
     }


### PR DESCRIPTION
This removes the ability of the borrow checker to determine that repeated dereferences of a Box<T> refer to the same memory object.

update: document [RFC 130](https://github.com/rust-lang/rfcs/blob/master/text/0130-box-not-special.md); PR: rust-lang/rfcs#130
