### PR TITLE
fix formatting in pointer guide table

### DIFF
--- a/src/doc/guide-pointers.md
+++ b/src/doc/guide-pointers.md
@@ -733,18 +733,15 @@ This part is coming soon.
 
 Here's a quick rundown of Rust's pointer types:
 
-| Type         | Name                | Summary                                   |
-|--------------|---------------------|-------------------------------------------|
-| `&T`         | Reference           | Allows one or more references to read `T` |
-| `&mut T`     | Mutable Reference   | Allows a single reference to              |
-|              |                     | read and write `T`                        |
-| `Box<T>`     | Box                 | Heap allocated `T` with a single owner    |
-|              |                     | that may read and write `T`.              |
-| `Rc<T>`      | "arr cee" pointer   | Heap allocated `T` with many readers      |
-| `Arc<T>`     | Arc pointer         | Same as above, but safe sharing across    |
-|              |                     | threads                                   |
-| `*const T`   | Raw pointer         | Unsafe read access to `T`                 |
-| `*mut T`     | Mutable raw pointer | Unsafe read and write access to `T`       |
+| Type         | Name                | Summary                                                             |
+|--------------|---------------------|---------------------------------------------------------------------|
+| `&T`         | Reference           | Allows one or more references to read `T`                           |
+| `&mut T`     | Mutable Reference   | Allows a single reference to read and write `T`                     |
+| `Box<T>`     | Box                 | Heap allocated `T` with a single owner that may read and write `T`. |
+| `Rc<T>`      | "arr cee" pointer   | Heap allocated `T` with many readers                                |
+| `Arc<T>`     | Arc pointer         | Same as above, but safe sharing across threads                      |
+| `*const T`   | Raw pointer         | Unsafe read access to `T`                                           |
+| `*mut T`     | Mutable raw pointer | Unsafe read and write access to `T`                                 |
 
 # Related resources
 


### PR DESCRIPTION
http://doc.rust-lang.org/guide-pointers.html#cheat-sheet is a little weird. I thought it would handle this, but I guess not. Looks like we need to go over 80 cols.
