### PR TITLE
rustrt: Don't conditionally init the at_exit QUEUE

### DIFF
--- a/src/librustrt/at_exit_imp.rs
+++ b/src/librustrt/at_exit_imp.rs
@@ -31,7 +31,7 @@ pub fn init() {
     let state: Box<Queue> = box Exclusive::new(Vec::new());
     unsafe {
         rtassert!(!RUNNING.load(atomics::SeqCst));
-        rtassert!(QUEUE.swap(mem::transmute(state), atomics::SeqCst) == 0);
+        assert!(QUEUE.swap(mem::transmute(state), atomics::SeqCst) == 0);
     }
 }
 


### PR DESCRIPTION
This initialization should happen unconditionally, but the rtassert! macro is
gated on the ENFORCE_SANITY define

Closes #16106
