### PR TITLE
hexfloat: Deprecate to move out of the repo

### DIFF
--- a/src/libhexfloat/lib.rs
+++ b/src/libhexfloat/lib.rs
@@ -37,7 +37,8 @@ fn main() {
 */
 
 #![crate_name = "hexfloat"]
-#![experimental]
+#![deprecated = "This is now a cargo package located at: \
+                 https://github.com/rust-lang/hexfloat"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]


### PR DESCRIPTION
This deprecates the hexfloat library as it is now located in the rust-lang
organization as a cargo package
