### PR TITLE
libserialize: add new `error()` to `Decoder` for Decodable objects to signal parse errors

### DIFF
--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -105,7 +105,8 @@ pub enum EbmlEncoderTag {
 pub enum Error {
     IntTooBig(uint),
     Expected(String),
-    IoError(std::io::IoError)
+    IoError(std::io::IoError),
+    ApplicationError(String)
 }
 // --------------------------------------
 
@@ -119,11 +120,11 @@ pub mod reader {
 
     use serialize;
 
-    use super::{ EsVec, EsMap, EsEnum, EsVecLen, EsVecElt, EsMapLen, EsMapKey,
-        EsEnumVid, EsU64, EsU32, EsU16, EsU8, EsInt, EsI64, EsI32, EsI16, EsI8,
-        EsBool, EsF64, EsF32, EsChar, EsStr, EsMapVal, EsEnumBody, EsUint,
-        EsOpaque, EsLabel, EbmlEncoderTag, Doc, TaggedDoc, Error, IntTooBig,
-        Expected };
+    use super::{ ApplicationError, EsVec, EsMap, EsEnum, EsVecLen, EsVecElt,
+        EsMapLen, EsMapKey, EsEnumVid, EsU64, EsU32, EsU16, EsU8, EsInt, EsI64,
+        EsI32, EsI16, EsI8, EsBool, EsF64, EsF32, EsChar, EsStr, EsMapVal,
+        EsEnumBody, EsUint, EsOpaque, EsLabel, EbmlEncoderTag, Doc, TaggedDoc,
+        Error, IntTooBig, Expected };
 
     pub type DecodeResult<T> = Result<T, Error>;
     // rbml reading
@@ -635,6 +636,10 @@ pub mod reader {
                                -> DecodeResult<T> {
             debug!("read_map_elt_val(idx={})", idx);
             self.push_doc(EsMapVal, f)
+        }
+
+        fn error(&mut self, err: &str) -> Error {
+            ApplicationError(err.to_string())
         }
     }
 }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -257,6 +257,7 @@ pub enum DecoderError {
     ExpectedError(String, String),
     MissingFieldError(String),
     UnknownVariantError(String),
+    ApplicationError(String)
 }
 
 /// Returns a readable error string for a given error code.
@@ -2070,6 +2071,10 @@ impl ::Decoder<DecoderError> for Decoder {
                            -> DecodeResult<T> {
         debug!("read_map_elt_val(idx={})", idx);
         f(self)
+    }
+
+    fn error(&mut self, err: &str) -> DecoderError {
+        ApplicationError(err.to_string())
     }
 }
 

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -163,6 +163,9 @@ pub trait Decoder<E> {
     fn read_map<T>(&mut self, f: |&mut Self, uint| -> Result<T, E>) -> Result<T, E>;
     fn read_map_elt_key<T>(&mut self, idx: uint, f: |&mut Self| -> Result<T, E>) -> Result<T, E>;
     fn read_map_elt_val<T>(&mut self, idx: uint, f: |&mut Self| -> Result<T, E>) -> Result<T, E>;
+
+    // Failure
+    fn error(&mut self, err: &str) -> E;
 }
 
 pub trait Encodable<S:Encoder<E>, E> {


### PR DESCRIPTION
A quick and dirty fix for #15036 until we get serious decoder reform.

Right now it is impossible for a `Decodable` to signal a decode error, for example if it has only finitely many allowed values, is a string which must be encoded a certain way, needs a valid checksum, etc. For example in the `libuuid` implementation of `Decodable` an `Option` is unwrapped, meaning that a decode of a malformed UUID will cause the task to fail.
