### PR TITLE
librustc: Don't ICE when trying to subst regions in destructor call.

### DIFF
--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -584,9 +584,11 @@ impl<'a> TypeFolder for SubstFolder<'a> {
                                 self.tcx().sess.span_bug(
                                     span,
                                     format!("Type parameter out of range \
-                                     when substituting in region {} (root type={})",
+                                     when substituting in region {} (root type={}) \
+                                     (space={}, index={})",
                                     region_name.as_str(),
-                                    self.root_ty.repr(self.tcx())).as_slice());
+                                    self.root_ty.repr(self.tcx()),
+                                    space, i).as_slice());
                             }
                         }
                 }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -485,6 +485,9 @@ pub fn get_res_dtor(ccx: &CrateContext,
     if !substs.types.is_empty() {
         assert_eq!(did.krate, ast::LOCAL_CRATE);
 
+        // Since we're in trans we don't care for any region parameters
+        let ref substs = subst::Substs::erased(substs.types.clone());
+
         let vtables = typeck::check::vtable::trans_resolve_method(ccx.tcx(), did.node, substs);
         let (val, _) = monomorphize::monomorphic_fn(ccx, did, substs, vtables, None);
 

--- a/src/test/run-pass/issue-15858.rs
+++ b/src/test/run-pass/issue-15858.rs
@@ -1,0 +1,45 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsafe_destructor)]
+
+static mut DROP_RAN: bool = false;
+
+trait Bar<'b> {
+    fn do_something(&mut self);
+}
+
+struct BarImpl<'b>;
+
+impl<'b> Bar<'b> for BarImpl<'b> {
+    fn do_something(&mut self) {}
+}
+
+
+struct Foo<B>;
+
+#[unsafe_destructor]
+impl<'b, B: Bar<'b>> Drop for Foo<B> {
+    fn drop(&mut self) {
+        unsafe {
+            DROP_RAN = true;
+        }
+    }
+}
+
+
+fn main() {
+    {
+       let _x: Foo<BarImpl> = Foo;
+    }
+    unsafe {
+        assert_eq!(DROP_RAN, true);
+    }
+}


### PR DESCRIPTION
Fixes #15858.
