### PR TITLE
librustc: Don't ICE with struct exprs where the name is not a valid struct.

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3529,6 +3529,17 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                         span_err!(tcx.sess, path.span, E0071,
                             "`{}` does not name a structure",
                             pprust::path_to_string(path));
+
+                        // Make sure to still write the types
+                        // otherwise we might ICE
+                        fcx.write_error(id);
+                        for field in fields.iter() {
+                            check_expr(fcx, &*field.expr);
+                        }
+                        match base_expr {
+                            Some(ref base) => check_expr(fcx, &**base),
+                            None => {}
+                        }
                     }
                 }
 

--- a/src/test/compile-fail/issue-16058.rs
+++ b/src/test/compile-fail/issue-16058.rs
@@ -1,0 +1,26 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+pub struct GslResult {
+    pub val: f64,
+    pub err: f64
+}
+
+impl GslResult {
+    pub fn new() -> GslResult {
+        Result { //~ ERROR: `Result` does not name a structure
+            val: 0f64,
+            err: 0f64
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #16058.
