### PR TITLE
Implement slice::Vector for Option<T> and CVec<T>

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -143,6 +143,7 @@
 
 use cmp::{PartialEq, Eq, Ord};
 use default::Default;
+use slice::Vector;
 use iter::{Iterator, DoubleEndedIterator, FromIterator, ExactSize};
 use mem;
 use slice;
@@ -214,15 +215,6 @@ impl<T> Option<T> {
     #[inline]
     pub fn as_mut<'r>(&'r mut self) -> Option<&'r mut T> {
         match *self { Some(ref mut x) => Some(x), None => None }
-    }
-
-    /// Convert from `Option<T>` to `&[T]` (without copying)
-    #[inline]
-    pub fn as_slice<'r>(&'r self) -> &'r [T] {
-        match *self {
-            Some(ref x) => slice::ref_slice(x),
-            None => &[]
-        }
     }
 
     /// Convert from `Option<T>` to `&mut [T]` (without copying)
@@ -525,6 +517,17 @@ impl<T: Default> Option<T> {
 /////////////////////////////////////////////////////////////////////////////
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
+
+impl<T> Vector<T> for Option<T> {
+    /// Convert from `Option<T>` to `&[T]` (without copying)
+    #[inline]
+    fn as_slice<'a>(&'a self) -> &'a [T] {
+        match *self {
+            Some(ref x) => slice::ref_slice(x),
+            None => &[]
+        }
+    }
+}
 
 impl<T> Default for Option<T> {
     #[inline]

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -43,6 +43,7 @@ use option::{Option, Some, None};
 use ptr::RawPtr;
 use ptr;
 use raw;
+use slice::Vector;
 
 /// The type representing a foreign chunk of memory
 pub struct CVec<T> {
@@ -101,13 +102,6 @@ impl<T> CVec<T> {
         }
     }
 
-    /// View the stored data as a slice.
-    pub fn as_slice<'a>(&'a self) -> &'a [T] {
-        unsafe {
-            mem::transmute(raw::Slice { data: self.base as *const T, len: self.len })
-        }
-    }
-
     /// View the stored data as a mutable slice.
     pub fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
         unsafe {
@@ -148,6 +142,15 @@ impl<T> CVec<T> {
     pub unsafe fn unwrap(mut self) -> *mut T {
         self.dtor = None;
         self.base
+    }
+}
+
+impl<T> Vector<T> for CVec<T> {
+    /// View the stored data as a slice.
+    fn as_slice<'a>(&'a self) -> &'a [T] {
+        unsafe {
+            mem::transmute(raw::Slice { data: self.base as *const T, len: self.len })
+        }
     }
 }
 


### PR DESCRIPTION
The `std::slice::Vector` trait effectively provides an interface for saying an object can give a slice view in to itself.  Both `Option<T>` and `CVec<T>` expose `as_slice` but do so by implementing them directly rather than implementing them via the `Vector` trait.

This patch alters both `Option<T>` and `CVec<T>` to instead expose it by implementing `Vector`.
