### PR TITLE
Increase stack size in src/test/run-pass/spawn-stack-too-big.rs

### DIFF
--- a/src/test/run-pass/spawn-stack-too-big.rs
+++ b/src/test/run-pass/spawn-stack-too-big.rs
@@ -38,7 +38,7 @@ fn test() {}
 fn test() {
     let (tx, rx) = channel();
     spawn(proc() {
-        TaskBuilder::new().stack_size(1024 * 1024 * 1024 * 64).spawn(proc() {
+        TaskBuilder::new().stack_size(128 * 1024 * 1024 * 1024).spawn(proc() {
         });
         tx.send(());
     });


### PR DESCRIPTION
This test should fail by creating a task which allocates too
much stack space, but some recent change in Travis has caused
it to succeed. Jack up the memory by a million times or so and
see if that corrects it.
