### PR TITLE
Stop using the Show impl for ast::Name in our symbols

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -106,7 +106,7 @@ pub fn return_type_is_void(ccx: &CrateContext, ty: ty::t) -> bool {
 /// Generates a unique symbol based off the name given. This is used to create
 /// unique symbols for things like closures.
 pub fn gensym_name(name: &str) -> PathElem {
-    let num = token::gensym(name);
+    let num = token::gensym(name).uint();
     // use one colon which will get translated to a period by the mangler, and
     // we're guaranteed that `num` is globally unique for this crate.
     PathName(token::gensym(format!("{}:{}", name, num).as_slice()))


### PR DESCRIPTION
When generating a unique symbol for things like closures or glue_drop,
we call token::gensym() to create a crate-unique Name. Recently, Name
changed its Show impl so it no longer prints as a number. This caused
symbols like glue_drop:1542 to become glue_drop:"glue_drop"(1542), or in
mangled form, glue_drop.$x22glue_drop$x22$LP$1542$RP$.
