### PR TITLE
librustc: lifetimes in values-with-dtors must outlive such values themselves

### DIFF
--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -1084,27 +1084,29 @@ impl<T: Ord> Set<T> for TreeSet<T> {
     }
 
     fn is_subset(&self, other: &TreeSet<T>) -> bool {
-        let mut x = self.iter();
-        let mut y = other.iter();
-        let mut a = x.next();
-        let mut b = y.next();
-        while a.is_some() {
-            if b.is_none() {
-                return false;
+        {
+            let mut x = self.iter();
+            let mut y = other.iter();
+            let mut a = x.next();
+            let mut b = y.next();
+            while a.is_some() {
+                if b.is_none() {
+                    return false;
+                }
+
+                let a1 = a.unwrap();
+                let b1 = b.unwrap();
+
+                match b1.cmp(a1) {
+                    Less => (),
+                    Greater => return false,
+                    Equal => a = x.next(),
+                }
+
+                b = y.next();
             }
-
-            let a1 = a.unwrap();
-            let b1 = b.unwrap();
-
-            match b1.cmp(a1) {
-                Less => (),
-                Greater => return false,
-                Equal => a = x.next(),
-            }
-
-            b = y.next();
+            true
         }
-        true
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -310,8 +310,11 @@ impl<T> RefCell<T> {
 
 #[unstable = "waiting for `Clone` to become stable"]
 impl<T: Clone> Clone for RefCell<T> {
-    fn clone(&self) -> RefCell<T> {
-        RefCell::new(self.borrow().clone())
+    fn clone<'a>(&'a self) -> RefCell<T> {
+        {
+            let borrowed: Ref<'a,T> = self.borrow();
+            RefCell::new(borrowed.clone())
+        }
     }
 }
 

--- a/src/libcore/finally.rs
+++ b/src/libcore/finally.rs
@@ -90,16 +90,22 @@ impl<T> Finally<T> for fn() -> T {
  *     })
  * ```
  */
-pub fn try_finally<T,U,R>(mutate: &mut T,
-                          drop: U,
-                          try_fn: |&mut T, U| -> R,
-                          finally_fn: |&mut T|)
-                          -> R {
-    let f = Finallyalizer {
-        mutate: mutate,
-        dtor: finally_fn,
-    };
-    try_fn(&mut *f.mutate, drop)
+pub fn try_finally<'a,
+                   T,
+                   U,
+                   R>(
+                   mutate: &'a mut T,
+                   drop: U,
+                   try_fn: |&mut T, U| -> R,
+                   finally_fn: |&mut T|:'a)
+                   -> R {
+    {
+        let f: Finallyalizer<'a,T> = Finallyalizer {
+            mutate: mutate,
+            dtor: finally_fn,
+        };
+        try_fn(&mut *f.mutate, drop)
+    }
 }
 
 struct Finallyalizer<'a,A:'a> {

--- a/src/libgreen/basic.rs
+++ b/src/libgreen/basic.rs
@@ -61,10 +61,13 @@ impl BasicLoop {
 
     fn remote_work(&mut self) {
         let messages = unsafe {
-            mem::replace(&mut *self.messages.lock(), Vec::new())
+            let lock = &mut *self.messages.lock();
+            mem::replace(lock, Vec::new())
         };
-        for message in messages.move_iter() {
-            self.message(message);
+        {
+            for message in messages.move_iter() {
+                self.message(message);
+            }
         }
     }
 

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -258,7 +258,10 @@ pub fn build_session_(sopts: config::Options,
         recursion_limit: Cell::new(64),
     };
 
-    sess.lint_store.borrow_mut().register_builtin(Some(&sess));
+    {
+        sess.lint_store.borrow_mut().register_builtin(Some(&sess));
+    }
+
     sess
 }
 

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -244,9 +244,8 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
                                        "unsafe_destructor") {
                     self.gate_feature("unsafe_destructor",
                                       i.span,
-                                      "`#[unsafe_destructor]` allows too \
-                                       many unsafe patterns and may be \
-                                       removed in the future");
+                                      "`#[unsafe_destructor]` does nothing \
+                                       anymore")
                 }
             }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -318,6 +318,9 @@ fn parse_region(st: &mut PState, conv: conv_did) -> ty::Region {
       't' => {
         ty::ReStatic
       }
+      'n' => {
+        ty::ReFunction
+      }
       'e' => {
         ty::ReStatic
       }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -149,6 +149,9 @@ pub fn enc_region(w: &mut SeekableMemWriter, cx: &ctxt, r: ty::Region) {
         ty::ReScope(nid) => {
             mywrite!(w, "s{}|", nid);
         }
+        ty::ReFunction => {
+            mywrite!(w, "n");
+        }
         ty::ReStatic => {
             mywrite!(w, "t");
         }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -490,7 +490,7 @@ impl tr for ty::Region {
             ty::ReScope(id) => {
                 ty::ReScope(dcx.tr_id(id))
             }
-            ty::ReEmpty | ty::ReStatic | ty::ReInfer(..) => {
+            ty::ReEmpty | ty::ReStatic | ty::ReInfer(..) | ty::ReFunction => {
                 *self
             }
             ty::ReFree(ref fr) => {

--- a/src/librustc/middle/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc/middle/borrowck/gather_loans/lifetime.rs
@@ -163,36 +163,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
 
         // See the SCOPE(LV) function in doc.rs
 
-        match cmt.cat {
-            mc::cat_rvalue(temp_scope) => {
-                temp_scope
-            }
-            mc::cat_upvar(..) |
-            mc::cat_copied_upvar(_) => {
-                ty::ReScope(self.item_scope_id)
-            }
-            mc::cat_static_item => {
-                ty::ReStatic
-            }
-            mc::cat_local(local_id) |
-            mc::cat_arg(local_id) => {
-                ty::ReScope(self.bccx.tcx.region_maps.var_scope(local_id))
-            }
-            mc::cat_deref(_, _, mc::UnsafePtr(..)) => {
-                ty::ReStatic
-            }
-            mc::cat_deref(_, _, mc::BorrowedPtr(_, r)) |
-            mc::cat_deref(_, _, mc::Implicit(_, r)) => {
-                r
-            }
-            mc::cat_downcast(ref cmt) |
-            mc::cat_deref(ref cmt, _, mc::OwnedPtr) |
-            mc::cat_deref(ref cmt, _, mc::GcPtr) |
-            mc::cat_interior(ref cmt, _) |
-            mc::cat_discr(ref cmt, _) => {
-                self.scope(cmt)
-            }
-        }
+        mc::scope(self.bccx.tcx, cmt, self.item_scope_id)
     }
 
     fn report_error(&self, code: bckerr_code) {

--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -275,6 +275,12 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
                     ty::ReScope(id) => id,
                     ty::ReFree(ref fr) => fr.scope_id,
 
+                    ty::ReFunction => {
+                        // For purposes of the borrow check, we can consider
+                        // this a loan for the outer function block.
+                        self.item_ub
+                    }
+
                     ty::ReStatic => {
                         // If we get here, an error must have been
                         // reported in

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -67,76 +67,7 @@ pub fn check_crate(tcx: &ty::ctxt) {
     tcx.sess.abort_if_errors();
 }
 
-struct EmptySubstsFolder<'a, 'tcx: 'a> {
-    tcx: &'a ty::ctxt<'tcx>
-}
-impl<'a, 'tcx> ty_fold::TypeFolder<'tcx> for EmptySubstsFolder<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
-        self.tcx
-    }
-    fn fold_substs(&mut self, _: &subst::Substs) -> subst::Substs {
-        subst::Substs::empty()
-    }
-}
-
-fn check_struct_safe_for_destructor(cx: &mut Context,
-                                    span: Span,
-                                    struct_did: DefId) {
-    let struct_tpt = ty::lookup_item_type(cx.tcx, struct_did);
-    if !struct_tpt.generics.has_type_params(subst::TypeSpace)
-      && !struct_tpt.generics.has_region_params(subst::TypeSpace) {
-        let mut folder = EmptySubstsFolder { tcx: cx.tcx };
-        if !ty::type_is_sendable(cx.tcx, struct_tpt.ty.fold_with(&mut folder)) {
-            span_err!(cx.tcx.sess, span, E0125,
-                      "cannot implement a destructor on a \
-                       structure or enumeration that does not satisfy Send");
-            span_note!(cx.tcx.sess, span,
-                       "use \"#[unsafe_destructor]\" on the implementation \
-                        to force the compiler to allow this");
-        }
-    } else {
-        span_err!(cx.tcx.sess, span, E0141,
-                  "cannot implement a destructor on a structure \
-                   with type parameters");
-        span_note!(cx.tcx.sess, span,
-                   "use \"#[unsafe_destructor]\" on the implementation \
-                    to force the compiler to allow this");
-    }
-}
-
-fn check_impl_of_trait(cx: &mut Context, it: &Item, trait_ref: &TraitRef, self_type: &Ty) {
-    let ast_trait_def = *cx.tcx.def_map.borrow()
-                              .find(&trait_ref.ref_id)
-                              .expect("trait ref not in def map!");
-    let trait_def_id = ast_trait_def.def_id();
-
-    // If this is a destructor, check kinds.
-    if cx.tcx.lang_items.drop_trait() == Some(trait_def_id) &&
-        !attr::contains_name(it.attrs.as_slice(), "unsafe_destructor")
-    {
-        match self_type.node {
-            TyPath(_, ref bounds, path_node_id) => {
-                assert!(bounds.is_none());
-                let struct_def = cx.tcx.def_map.borrow().get_copy(&path_node_id);
-                let struct_did = struct_def.def_id();
-                check_struct_safe_for_destructor(cx, self_type.span, struct_did);
-            }
-            _ => {
-                cx.tcx.sess.span_bug(self_type.span,
-                    "the self type for the Drop trait impl is not a path");
-            }
-        }
-    }
-}
-
 fn check_item(cx: &mut Context, item: &Item) {
-    match item.node {
-        ItemImpl(_, Some(ref trait_ref), ref self_type, _) => {
-            check_impl_of_trait(cx, item, trait_ref, &**self_type);
-        }
-        _ => {}
-    }
-
     visit::walk_item(cx, item)
 }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -276,9 +276,11 @@ impl RegionMaps {
         sub_region == super_region || {
             match (sub_region, super_region) {
                 (ty::ReEmpty, _) |
-                (_, ty::ReStatic) => {
-                    true
-                }
+                (_, ty::ReStatic) => true,
+                (ty::ReScope(_), ty::ReFunction) => true,
+                (ty::ReFunction, ty::ReFree(_)) => true,
+                (ty::ReFunction, ty::ReScope(_)) => false,
+                (ty::ReFree(_), ty::ReFunction) => false,
 
                 (ty::ReScope(sub_scope), ty::ReScope(super_scope)) => {
                     self.is_subscope_of(sub_scope, super_scope)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -3160,7 +3160,11 @@ pub fn trans_crate<'tcx>(analysis: CrateAnalysis<'tcx>)
         llcx: shared_ccx.metadata_llcx(),
         llmod: shared_ccx.metadata_llmod(),
     };
-    let formats = shared_ccx.tcx().dependency_formats.borrow().clone();
+    let formats;
+    {
+        let dependency_formats = shared_ccx.tcx().dependency_formats.borrow();
+        formats = dependency_formats.clone()
+    }
     let no_builtins = attr::contains_name(krate.attrs.as_slice(), "no_builtins");
 
     let translation = CrateTranslation {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1292,7 +1292,9 @@ pub fn create_function_debug_context(cx: &CrateContext,
                        fn_metadata,
                        &mut *fn_debug_context.scope_map.borrow_mut());
 
-    return FunctionDebugContext { repr: FunctionDebugContext(fn_debug_context) };
+    return FunctionDebugContext {
+        repr: FunctionDebugContext(fn_debug_context)
+    };
 
     fn get_function_signature(cx: &CrateContext,
                               fn_ast_id: ast::NodeId,

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -749,6 +749,22 @@ impl<'a, 'tcx> ErrorReporting for InferCtxt<'a, 'tcx> {
                     sup,
                     "");
             }
+            infer::SafeDestructor(span) => {
+                self.tcx.sess.span_err(
+                    span,
+                    "unsafe use of destructor: destructor might be called \
+                     while references are dead");
+                note_and_explain_region(
+                    self.tcx,
+                    "superregion: ",
+                    sup,
+                    "");
+                note_and_explain_region(
+                    self.tcx,
+                    "subregion: ",
+                    sub,
+                    "");
+            }
             infer::BindingTypeIsNotValidAtDecl(span) => {
                 self.tcx.sess.span_err(
                     span,
@@ -1639,6 +1655,12 @@ impl<'a, 'tcx> ErrorReportingHelpers for InferCtxt<'a, 'tcx> {
                     span,
                     format!("...so that the declared lifetime parameter bounds \
                                 are satisfied").as_slice());
+            }
+            infer::SafeDestructor(span) => {
+                self.tcx.sess.span_note(
+                    span,
+                    "...so that references are valid when the destructor \
+                     runs")
             }
         }
     }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -225,6 +225,9 @@ pub enum SubregionOrigin {
 
     // Managed data cannot contain borrowed pointers.
     Managed(Span),
+
+    // Region constraint arriving from destructor safety
+    SafeDestructor(Span),
 }
 
 /// Reasons to create a region inference variable
@@ -1046,6 +1049,7 @@ impl SubregionOrigin {
             AddrOf(a) => a,
             AutoBorrow(a) => a,
             Managed(a) => a,
+            SafeDestructor(a) => a,
         }
     }
 }
@@ -1119,6 +1123,7 @@ impl Repr for SubregionOrigin {
             AddrOf(a) => format!("AddrOf({})", a.repr(tcx)),
             AutoBorrow(a) => format!("AutoBorrow({})", a.repr(tcx)),
             Managed(a) => format!("Managed({})", a.repr(tcx)),
+            SafeDestructor(a) => format!("SafeDestructor({})", a.repr(tcx)),
         }
     }
 }

--- a/src/librustc/middle/typeck/infer/skolemize.rs
+++ b/src/librustc/middle/typeck/infer/skolemize.rs
@@ -98,6 +98,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeSkolemizer<'a, 'tcx> {
             ty::ReFree(_) |
             ty::ReScope(_) |
             ty::ReInfer(_) |
+            ty::ReFunction |
             ty::ReEmpty => {
                 // replace all free regions with 'static
                 ty::ReStatic

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -903,7 +903,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             }
 
             ty::ReFree(..) | ty::ReScope(..) | ty::ReInfer(..) |
-            ty::ReEmpty => {
+            ty::ReFunction | ty::ReEmpty => {
                 // We don't expect to see anything but 'static or bound
                 // regions when visiting member types or method types.
                 self.tcx()

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -14,8 +14,8 @@ use middle::subst::{VecPerParamSpace,Subst};
 use middle::subst;
 use middle::ty::{BoundRegion, BrAnon, BrNamed};
 use middle::ty::{ReEarlyBound, BrFresh, ctxt};
-use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region, ReEmpty};
-use middle::ty::{ReSkolemized, ReVar};
+use middle::ty::{ReEmpty, ReFree, ReFunction, ReScope, ReInfer, ReStatic};
+use middle::ty::{ReSkolemized, ReVar, Region};
 use middle::ty::{mt, t, ParamTy};
 use middle::ty::{ty_bool, ty_char, ty_bot, ty_box, ty_struct, ty_enum};
 use middle::ty::{ty_err, ty_str, ty_vec, ty_float, ty_bare_fn, ty_closure};
@@ -140,6 +140,8 @@ pub fn explain_region_and_span(cx: &ctxt, region: ty::Region)
         }
       }
 
+      ReFunction => { ("the lifetime of the function".to_string(), None) }
+
       ReStatic => { ("the static lifetime".to_string(), None) }
 
       ReEmpty => { ("the empty lifetime".to_string(), None) }
@@ -214,6 +216,7 @@ pub fn region_to_string(cx: &ctxt, prefix: &str, space: bool, region: Region) ->
             bound_region_to_string(cx, prefix, space, br)
         }
         ty::ReInfer(ReVar(_)) => prefix.to_string(),
+        ty::ReFunction => format!("{}'<function>{}", prefix, space_str),
         ty::ReStatic => format!("{}'static{}", prefix, space_str),
         ty::ReEmpty => format!("{}'<empty>{}", prefix, space_str),
     }
@@ -790,6 +793,10 @@ impl Repr for ty::Region {
 
             ty::ReScope(id) => {
                 format!("ReScope({})", id)
+            }
+
+            ty::ReFunction => {
+                "ReStatic".to_string()
             }
 
             ty::ReStatic => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -458,9 +458,26 @@ impl Clean<TyParam> for ast::TyParam {
 }
 
 impl Clean<TyParam> for ty::TypeParameterDef {
+<<<<<<< HEAD
     fn clean(&self, cx: &DocContext) -> TyParam {
         cx.external_typarams.borrow_mut().as_mut().unwrap()
           .insert(self.def_id, self.ident.clean(cx));
+=======
+    fn clean(&self) -> TyParam {
+        {
+            let cx = get_cx();
+            {
+                let mut external_typarams = cx.external_typarams.borrow_mut();
+                {
+                    let external_typarams = external_typarams.get_mut_ref();
+                    {
+                        external_typarams.insert(self.def_id,
+                                                 self.ident.clean());
+                    }
+                }
+            }
+        }
+>>>>>>> librustc: Require lifetimes within the types of values with destructors
         TyParam {
             name: self.ident.clean(cx),
             did: self.def_id,
@@ -635,7 +652,8 @@ impl Clean<Option<Lifetime>> for ty::Region {
             ty::ReFree(..) |
             ty::ReScope(..) |
             ty::ReInfer(..) |
-            ty::ReEmpty(..) => None
+            ty::ReEmpty(..) |
+            ty::ReFunction => None
         }
     }
 }
@@ -1284,7 +1302,23 @@ impl Clean<Type> for ty::t {
                 };
                 let path = external_path(cx, fqn.last().unwrap().to_string().as_slice(),
                                          substs);
+<<<<<<< HEAD
                 cx.external_paths.borrow_mut().as_mut().unwrap().insert(did, (fqn, kind));
+=======
+                {
+                    let cx = get_cx();
+                    {
+                        let mut external_paths = cx.external_paths
+                                                   .borrow_mut();
+                        {
+                            let external_paths = external_paths.get_mut_ref();
+                            {
+                                external_paths.insert(did, (fqn, kind));
+                            }
+                        }
+                    }
+                }
+>>>>>>> librustc: Require lifetimes within the types of values with destructors
                 ResolvedPath {
                     path: path,
                     typarams: None,
@@ -2134,7 +2168,15 @@ fn lang_struct(cx: &DocContext, did: Option<ast::DefId>,
     let fqn: Vec<String> = fqn.move_iter().map(|i| {
         i.to_string()
     }).collect();
-    cx.external_paths.borrow_mut().as_mut().unwrap().insert(did, (fqn, TypeStruct));
+    {
+        let mut external_paths = cx.external_paths.borrow_mut();
+        {
+            let external_paths = external_paths.get_mut_ref();
+            {
+                external_paths.insert(did, (fqn, TypeStruct));
+            }
+        }
+    }
     ResolvedPath {
         typarams: None,
         did: did,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -157,13 +157,16 @@ pub fn run_core(libs: Vec<Path>, cfgs: Vec<String>, externs: Externs,
         v.clean(&ctxt)
     };
 
-    let external_paths = ctxt.external_paths.borrow_mut().take();
-    *analysis.external_paths.borrow_mut() = external_paths;
-    let map = ctxt.external_traits.borrow_mut().take();
-    *analysis.external_traits.borrow_mut() = map;
-    let map = ctxt.external_typarams.borrow_mut().take();
-    *analysis.external_typarams.borrow_mut() = map;
-    let map = ctxt.inlined.borrow_mut().take();
-    *analysis.inlined.borrow_mut() = map;
+    {
+        let external_paths = ctxt.external_paths.borrow_mut().take();
+        *analysis.external_paths.borrow_mut() = external_paths;
+        let map = ctxt.external_traits.borrow_mut().take();
+        *analysis.external_traits.borrow_mut() = map;
+        let map = ctxt.external_typarams.borrow_mut().take();
+        *analysis.external_typarams.borrow_mut() = map;
+        let map = ctxt.inlined.borrow_mut().take();
+        *analysis.inlined.borrow_mut() = map;
+    }
+
     (krate, analysis)
 }

--- a/src/librustrt/exclusive.rs
+++ b/src/librustrt/exclusive.rs
@@ -49,12 +49,14 @@ impl<T: Send> Exclusive<T> {
     /// This method is unsafe due to many of the same reasons that the
     /// NativeMutex itself is unsafe.
     pub unsafe fn lock<'a>(&'a self) -> ExclusiveGuard<'a, T> {
-        let guard = self.lock.lock();
-        let data = &mut *self.data.get();
+        {
+            let guard = self.lock.lock();
+            let data = &mut *self.data.get();
 
-        ExclusiveGuard {
-            _data: data,
-            _guard: guard,
+            ExclusiveGuard {
+                _data: data,
+                _guard: guard,
+            }
         }
     }
 }

--- a/src/librustrt/local_data.rs
+++ b/src/librustrt/local_data.rs
@@ -121,20 +121,22 @@ struct TLDValueBox<T> {
 unsafe fn get_local_map<'a>() -> Option<&'a mut Map> {
     if !Local::exists(None::<Task>) { return None }
 
-    let task: *mut Task = Local::unsafe_borrow();
-    match &mut (*task).storage {
-        // If the at_exit function is already set, then we just need to take
-        // a loan out on the TLD map stored inside
-        &LocalStorage(Some(ref mut map_ptr)) => {
-            return Some(map_ptr);
-        }
-        // If this is the first time we've accessed TLD, perform similar
-        // actions to the oldsched way of doing things.
-        &LocalStorage(ref mut slot) => {
-            *slot = Some(TreeMap::new());
-            match *slot {
-                Some(ref mut map_ptr) => { return Some(map_ptr) }
-                None => fail!("unreachable code"),
+    {
+        let task: *mut Task = Local::unsafe_borrow();
+        match &mut (*task).storage {
+            // If the at_exit function is already set, then we just need to
+            // take a loan out on the TLD map stored inside
+            &LocalStorage(Some(ref mut map_ptr)) => {
+                return Some(map_ptr);
+            }
+            // If this is the first time we've accessed TLD, perform similar
+            // actions to the oldsched way of doing things.
+            &LocalStorage(ref mut slot) => {
+                *slot = Some(TreeMap::new());
+                match *slot {
+                    Some(ref mut map_ptr) => { return Some(map_ptr) }
+                    None => fail!("unreachable code"),
+                }
             }
         }
     }

--- a/src/librustrt/local_heap.rs
+++ b/src/librustrt/local_heap.rs
@@ -296,12 +296,14 @@ pub unsafe fn local_malloc_(drop_glue: fn(*mut u8), size: uint,
 pub unsafe fn local_malloc(drop_glue: fn(*mut u8), size: uint,
                            align: uint) -> *mut u8 {
     // FIXME: Unsafe borrow for speed. Lame.
-    let task: Option<*mut Task> = Local::try_unsafe_borrow();
-    match task {
-        Some(task) => {
-            (*task).heap.alloc(drop_glue, size, align) as *mut u8
+    {
+        let task: Option<*mut Task> = Local::try_unsafe_borrow();
+        match task {
+            Some(task) => {
+                (*task).heap.alloc(drop_glue, size, align) as *mut u8
+            }
+            None => rtabort!("local malloc outside of task")
         }
-        None => rtabort!("local malloc outside of task")
     }
 }
 
@@ -318,12 +320,14 @@ pub unsafe fn local_free_(ptr: *mut u8) {
 #[inline]
 pub unsafe fn local_free(ptr: *mut u8) {
     // FIXME: Unsafe borrow for speed. Lame.
-    let task_ptr: Option<*mut Task> = Local::try_unsafe_borrow();
-    match task_ptr {
-        Some(task) => {
-            (*task).heap.free(ptr as *mut Box)
+    {
+        let task_ptr: Option<*mut Task> = Local::try_unsafe_borrow();
+        match task_ptr {
+            Some(task) => {
+                (*task).heap.free(ptr as *mut Box)
+            }
+            None => rtabort!("local free outside of task")
         }
-        None => rtabort!("local free outside of task")
     }
 }
 

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -574,8 +574,8 @@ fn begin_unwind_inner(msg: Box<Any + Send>, file_line: &(&'static str, uint)) ->
                 let (file, line) = *file_line;
                 f(&*msg, file, line);
             }
-        }
-    };
+        };
+    }
 
     // Now that we've run all the necessary unwind callbacks, we actually
     // perform the unwinding. If we don't have a task, then it's time to die
@@ -599,7 +599,7 @@ fn begin_unwind_inner(msg: Box<Any + Send>, file_line: &(&'static str, uint)) ->
     // requires the task. We need a handle to its unwinder, however, so after
     // this we unsafely extract it and continue along.
     Local::put(task);
-    rust_fail(msg);
+    rust_fail(msg)
 }
 
 /// Register a callback to be invoked when a task unwinds.

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -513,14 +513,17 @@ impl CodeMap {
         let FileMapAndLine {fm: f, line: a} = self.lookup_line(pos);
         let line = a + 1u; // Line numbers start at 1
         let chpos = self.bytepos_to_file_charpos(pos);
-        let linebpos = *f.lines.borrow().get(a);
-        let linechpos = self.bytepos_to_file_charpos(linebpos);
-        debug!("byte pos {} is on the line at byte pos {}",
-               pos, linebpos);
-        debug!("char pos {} is on the line at char pos {}",
-               chpos, linechpos);
-        debug!("byte is on line: {}", line);
-        assert!(chpos >= linechpos);
+        let linechpos;
+        {
+            let linebpos = *f.lines.borrow().get(a);
+            linechpos = self.bytepos_to_file_charpos(linebpos);
+            debug!("byte pos {} is on the line at byte pos {}",
+                   pos, linebpos);
+            debug!("char pos {} is on the line at char pos {}",
+                   chpos, linechpos);
+            debug!("byte is on line: {}", line);
+            assert!(chpos >= linechpos);
+        }
         Loc {
             file: f,
             line: line,

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -168,7 +168,10 @@ fn with_resolve_table_mut<T>(op: |&mut ResolveTable| -> T) -> T {
         None => {
             let ts = Rc::new(RefCell::new(HashMap::new()));
             resolve_table_key.replace(Some(ts.clone()));
-            op(&mut *ts.borrow_mut())
+            {
+                let mut tsb = ts.borrow_mut();
+                op(&mut *tsb)
+            }
         }
     }
 }
@@ -257,9 +260,12 @@ fn marksof_internal(ctxt: SyntaxContext,
 /// FAILS when outside is not a mark.
 pub fn outer_mark(ctxt: SyntaxContext) -> Mrk {
     with_sctable(|sctable| {
-        match *sctable.table.borrow().get(ctxt as uint) {
-            Mark(mrk, _) => mrk,
-            _ => fail!("can't retrieve outer mark when outside is not a mark")
+        {
+            let table = sctable.table.borrow();
+            match *table.get(ctxt as uint) {
+                Mark(mrk, _) => mrk,
+                _ => fail!("can't retrieve outer mark when outside is not a mark")
+            }
         }
     })
 }

--- a/src/test/compile-fail/destructor-restrictions.rs
+++ b/src/test/compile-fail/destructor-restrictions.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests the new destructor semantics.
+
+use std::cell::RefCell;
+
+fn main() {
+    let b = {
+        let a = box RefCell::new(4i);
+        *a.borrow() + 1i    //~ ERROR `*a` does not live long enough
+    };
+    println!("{}", b);
+}


### PR DESCRIPTION
librustc: Require lifetimes within the types of values with destructors to have strictly greater lifetime than the values themselves.

Additionally, remove `#[unsafe_destructor]` in favor of these new
restrictions.

This broke a fair amount of code that had to do with `RefCell`s. We will
probably need to do some work to improve the resulting ergonomics. Most
code that broke looked like:

```
match foo.bar.borrow().baz { ... }
use_foo(&mut foo);
```

Change this code to:

```
{
    let bar = foo.bar.borrow();
    match bar.baz { ... }
}
use_foo(&mut foo);
```

This fixes an important memory safety hole relating to destructors,
represented by issue #8861.

[breaking-change]

r? @nikomatsakis 

If you want I can talk about the followups to improve ergonomics of RefCell that I want to do, but this is the BC change.
