### PR TITLE
rustdoc: Use --crate-name with --test

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -214,13 +214,14 @@ pub fn main_args(args: &[String]) -> int {
         Some(eh) => eh,
         None => return 3
     };
+    let crate_name = matches.opt_str("crate-name");
 
     match (should_test, markdown_input) {
         (true, true) => {
             return markdown::test(input, libs, externs, test_args)
         }
         (true, false) => {
-            return test::run(input, cfgs, libs, externs, test_args)
+            return test::run(input, cfgs, libs, externs, test_args, crate_name)
         }
         (false, true) => return markdown::render(input, output.unwrap_or(Path::new("doc")),
                                                  &matches, &external_html,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -41,7 +41,8 @@ pub fn run(input: &str,
            cfgs: Vec<String>,
            libs: HashSet<Path>,
            externs: core::Externs,
-           mut test_args: Vec<String>)
+           mut test_args: Vec<String>,
+           crate_name: Option<String>)
            -> int {
     let input_path = Path::new(input);
     let input = driver::FileInput(input_path.clone());
@@ -87,7 +88,11 @@ pub fn run(input: &str,
 
     let mut v = RustdocVisitor::new(&*ctx, None);
     v.visit(&ctx.krate);
-    let krate = v.clean();
+    let mut krate = v.clean();
+    match crate_name {
+        Some(name) => krate.name = name,
+        None => {}
+    }
     let (krate, _) = passes::collapse_docs(krate);
     let (krate, _) = passes::unindent_comments(krate);
 


### PR DESCRIPTION
This ensures that the name of the crate is set from the command line for tests
so the auto-injection of `extern crate <name>` in doc tests works correctly.
