### PR TITLE
Correct RFC reference in time::Tm::rfc3339 docs

### DIFF
--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -364,7 +364,7 @@ impl Tm {
     }
 
     /**
-     * Returns a time string formatted according to RFC 3999. RFC 3999 is
+     * Returns a time string formatted according to RFC 3339. RFC 3339 is
      * compatible with ISO 8601.
      *
      * local: "2012-02-22T07:53:18-07:00"


### PR DESCRIPTION
Fixes #16158
