### PR TITLE
Fix API docs css reversing elements that it shouldn't

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -324,13 +324,14 @@ table th {
 
 .rusttest { display: none; }
 pre.rust { position: relative; }
-pre.rust a { transform: scaleX(-1); }
 .test-arrow {
     display: inline-block;
     position: absolute;
     top: 0;
     right: 10px;
     font-size: 150%;
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
 }
 
 @media (min-width: 1170px) {

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -441,13 +441,14 @@ pre.rust .lifetime { color: #B76514; }
 
 .rusttest { display: none; }
 pre.rust { position: relative; }
-pre.rust a { transform: scaleX(-1); }
 .test-arrow {
     display: inline-block;
     position: absolute;
     top: 0;
     right: 10px;
     font-size: 150%;
+    -webkit-transform: scaleX(-1); 
+    transform: scaleX(-1); 
 }
 
 .methods .section-header {


### PR DESCRIPTION
remove unneeded `pre.rust a' selector

move transform into `.test-arrow`

fixes #16138
