### PR TITLE
collections: Implement more missing traits

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -978,6 +978,21 @@ impl Default for BitvSet {
     fn default() -> BitvSet { BitvSet::new() }
 }
 
+impl FromIterator<bool> for BitvSet {
+    fn from_iter<I:Iterator<bool>>(iterator: I) -> BitvSet {
+        let mut ret = BitvSet::new();
+        ret.extend(iterator);
+        ret
+    }
+}
+
+impl Extendable<bool> for BitvSet {
+    #[inline]
+    fn extend<I: Iterator<bool>>(&mut self, iterator: I) {
+        self.get_mut_ref().extend(iterator);
+    }
+}
+
 impl BitvSet {
     /// Create a new bit vector set with initially no contents.
     ///
@@ -1959,6 +1974,17 @@ mod tests {
     }
 
     #[test]
+    fn test_bitv_set_from_bools() {
+        let bools = vec![true, false, true, true];
+        let a: BitvSet = bools.iter().map(|n| *n).collect();
+        let mut b = BitvSet::new();
+        b.insert(0);
+        b.insert(2);
+        b.insert(3);
+        assert_eq!(a, b);
+    }
+
+    #[test]
     fn test_to_bools() {
         let bools = vec!(false, false, true, false, false, true, true, false);
         assert_eq!(from_bytes([0b00100110]).iter().collect::<Vec<bool>>(), bools);
@@ -1977,7 +2003,7 @@ mod tests {
     #[test]
     fn test_bitv_set_iterator() {
         let bools = [true, false, true, true];
-        let bitv = BitvSet::from_bitv(bools.iter().map(|n| *n).collect());
+        let bitv: BitvSet = bools.iter().map(|n| *n).collect();
 
         let idxs: Vec<uint> = bitv.iter().collect();
         assert_eq!(idxs, vec!(0, 2, 3));

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -691,6 +691,13 @@ impl<A: PartialOrd> PartialOrd for DList<A> {
     }
 }
 
+impl<A: Ord> Ord for DList<A> {
+    #[inline]
+    fn cmp(&self, other: &DList<A>) -> Ordering {
+        iter::order::cmp(self.iter(), other.iter())
+    }
+}
+
 impl<A: Clone> Clone for DList<A> {
     fn clone(&self) -> DList<A> {
         self.iter().map(|x| x.clone()).collect()

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -683,6 +683,8 @@ impl<A: PartialEq> PartialEq for DList<A> {
     }
 }
 
+impl<A: Eq> Eq for DList<A> {}
+
 impl<A: PartialOrd> PartialOrd for DList<A> {
     fn partial_cmp(&self, other: &DList<A>) -> Option<Ordering> {
         iter::order::partial_cmp(self.iter(), other.iter())

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -460,6 +460,13 @@ impl<A: PartialOrd> PartialOrd for RingBuf<A> {
     }
 }
 
+impl<A: Ord> Ord for RingBuf<A> {
+    #[inline]
+    fn cmp(&self, other: &RingBuf<A>) -> Ordering {
+        iter::order::cmp(self.iter(), other.iter())
+    }
+}
+
 impl<S: Writer, A: Hash<S>> Hash<S> for RingBuf<A> {
     fn hash(&self, state: &mut S) {
         self.len().hash(state);

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -452,6 +452,8 @@ impl<A: PartialEq> PartialEq for RingBuf<A> {
     }
 }
 
+impl<A: Eq> Eq for RingBuf<A> {}
+
 impl<A: PartialOrd> PartialOrd for RingBuf<A> {
     fn partial_cmp(&self, other: &RingBuf<A>) -> Option<Ordering> {
         iter::order::partial_cmp(self.iter(), other.iter())

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -173,6 +173,8 @@ impl<K: PartialEq + Ord, V: PartialEq> PartialEq for TreeMap<K, V> {
     }
 }
 
+impl<K: Eq + Ord, V: Eq> Eq for TreeMap<K, V> {}
+
 impl<K: Ord, V: PartialOrd> PartialOrd for TreeMap<K, V> {
     #[inline]
     fn partial_cmp(&self, other: &TreeMap<K, V>) -> Option<Ordering> {
@@ -1009,6 +1011,8 @@ impl<T: PartialEq + Ord> PartialEq for TreeSet<T> {
     #[inline]
     fn eq(&self, other: &TreeSet<T>) -> bool { self.map == other.map }
 }
+
+impl<T: Eq + Ord> Eq for TreeSet<T> {}
 
 impl<T: Ord> PartialOrd for TreeSet<T> {
     #[inline]

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -182,6 +182,13 @@ impl<K: Ord, V: PartialOrd> PartialOrd for TreeMap<K, V> {
     }
 }
 
+impl<K: Ord, V: Ord> Ord for TreeMap<K, V> {
+    #[inline]
+    fn cmp(&self, other: &TreeMap<K, V>) -> Ordering {
+        iter::order::cmp(self.iter(), other.iter())
+    }
+}
+
 impl<K: Ord + Show, V: Show> Show for TreeMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "{{"));
@@ -1018,6 +1025,13 @@ impl<T: Ord> PartialOrd for TreeSet<T> {
     #[inline]
     fn partial_cmp(&self, other: &TreeSet<T>) -> Option<Ordering> {
         self.map.partial_cmp(&other.map)
+    }
+}
+
+impl<T: Ord> Ord for TreeSet<T> {
+    #[inline]
+    fn cmp(&self, other: &TreeSet<T>) -> Ordering {
+        iter::order::cmp(self.iter(), other.iter())
     }
 }
 


### PR DESCRIPTION
This implements:
- Eq and Ord for DList, RingBuf, TreeMap and TreeSet
- FromIterator and Extendable for BitvSet

cc #15294
