### PR TITLE
Index all the collections

### DIFF
--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -139,6 +139,8 @@ impl<T> RingBuf<T> {
     /// # Example
     ///
     /// ```rust
+    /// #![allow(deprecated)]
+    ///
     /// use std::collections::RingBuf;
     ///
     /// let mut buf = RingBuf::new();
@@ -147,6 +149,7 @@ impl<T> RingBuf<T> {
     /// buf.push(5);
     /// assert_eq!(buf.get(1), &4);
     /// ```
+    #[deprecated = "prefer using indexing, e.g., ringbuf[0]"]
     pub fn get<'a>(&'a self, i: uint) -> &'a T {
         let idx = self.raw_index(i);
         match *self.elts.get(idx) {
@@ -169,7 +172,7 @@ impl<T> RingBuf<T> {
     /// buf.push(4);
     /// buf.push(5);
     /// *buf.get_mut(1) = 7;
-    /// assert_eq!(buf.get(1), &7);
+    /// assert_eq!(buf[1], 7);
     /// ```
     pub fn get_mut<'a>(&'a mut self, i: uint) -> &'a mut T {
         let idx = self.raw_index(i);
@@ -195,8 +198,8 @@ impl<T> RingBuf<T> {
     /// buf.push(4);
     /// buf.push(5);
     /// buf.swap(0, 2);
-    /// assert_eq!(buf.get(0), &5);
-    /// assert_eq!(buf.get(2), &3);
+    /// assert_eq!(buf[0], 5);
+    /// assert_eq!(buf[2], 3);
     /// ```
     pub fn swap(&mut self, i: uint, j: uint) {
         assert!(i < self.len());
@@ -467,6 +470,21 @@ impl<S: Writer, A: Hash<S>> Hash<S> for RingBuf<A> {
     }
 }
 
+impl<A> Index<uint, A> for RingBuf<A> {
+    #[inline]
+    fn index<'a>(&'a self, i: &uint) -> &'a A {
+        self.get(*i)
+    }
+}
+
+// FIXME(#12825) Indexing will always try IndexMut first and that causes issues.
+/*impl<A> IndexMut<uint, A> for RingBuf<A> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, index: &uint) -> &'a mut A {
+        self.get_mut(*index)
+    }
+}*/
+
 impl<A> FromIterator<A> for RingBuf<A> {
     fn from_iter<T: Iterator<A>>(iterator: T) -> RingBuf<A> {
         let (lower, _) = iterator.size_hint();
@@ -642,6 +660,25 @@ mod tests {
         for i in range(0u, 66) {
             assert_eq!(*deq.get(i), i);
         }
+    }
+
+    #[test]
+    fn test_index() {
+        let mut deq = RingBuf::new();
+        for i in range(1u, 4) {
+            deq.push_front(i);
+        }
+        assert_eq!(deq[1], 2);
+    }
+
+    #[test]
+    #[should_fail]
+    fn test_index_out_of_bounds() {
+        let mut deq = RingBuf::new();
+        for i in range(1u, 4) {
+            deq.push_front(i);
+        }
+        deq[3];
     }
 
     #[bench]

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -237,6 +237,20 @@ impl<K: Ord, V> Default for TreeMap<K,V> {
     fn default() -> TreeMap<K, V> { TreeMap::new() }
 }
 
+impl<K: Ord, V> Index<K, V> for TreeMap<K, V> {
+    #[inline]
+    fn index<'a>(&'a self, i: &K) -> &'a V {
+        self.find(i).expect("no entry found for key")
+    }
+}
+
+/*impl<K: Ord, V> IndexMut<K, V> for TreeMap<K, V> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, i: &K) -> &'a mut V {
+        self.find_mut(i).expect("no entry found for key")
+    }
+}*/
+
 impl<K: Ord, V> TreeMap<K, V> {
     /// Create an empty `TreeMap`.
     ///
@@ -2131,6 +2145,28 @@ mod test_treemap {
         }
     }
 
+    #[test]
+    fn test_index() {
+        let mut map: TreeMap<int, int> = TreeMap::new();
+
+        map.insert(1, 2);
+        map.insert(2, 1);
+        map.insert(3, 4);
+
+        assert_eq!(map[2], 1);
+    }
+
+    #[test]
+    #[should_fail]
+    fn test_index_nonexistent() {
+        let mut map: TreeMap<int, int> = TreeMap::new();
+
+        map.insert(1, 2);
+        map.insert(2, 1);
+        map.insert(3, 4);
+
+        map[4];
+    }
 }
 
 #[cfg(test)]

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -502,6 +502,21 @@ impl<S: Writer, T: Hash<S>> Hash<S> for TrieMap<T> {
     }
 }
 
+impl<T> Index<uint, T> for TrieMap<T> {
+    #[inline]
+    fn index<'a>(&'a self, i: &uint) -> &'a T {
+        self.find(i).expect("key not present")
+    }
+}
+
+// FIXME(#12825) Indexing will always try IndexMut first and that causes issues.
+/*impl<T> IndexMut<uint, T> for TrieMap<T> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut T {
+        self.find_mut(i).expect("key not present")
+    }
+}*/
+
 /// A set implemented as a radix trie.
 ///
 /// # Example
@@ -1390,6 +1405,29 @@ mod test_map {
 
         assert!(map_str == "{1: a, 2: b}".to_string());
         assert_eq!(format!("{}", empty), "{}".to_string());
+    }
+
+    #[test]
+    fn test_index() {
+        let mut map = TrieMap::new();
+
+        map.insert(1, 2i);
+        map.insert(2, 1i);
+        map.insert(3, 4i);
+
+        assert_eq!(map[2], 1);
+    }
+
+    #[test]
+    #[should_fail]
+    fn test_index_nonexistent() {
+        let mut map = TrieMap::new();
+
+        map.insert(1, 2i);
+        map.insert(2, 1i);
+        map.insert(3, 4i);
+
+        map[4];
     }
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -166,7 +166,7 @@ fn resolved_path(w: &mut fmt::Formatter, did: ast::DefId, p: &clean::Path,
             if ast_util::is_local(did) || cache.inlined.contains(&did) {
                 Some(("../".repeat(loc.len())).to_string())
             } else {
-                match *cache.extern_locations.get(&did.krate) {
+                match cache.extern_locations[did.krate] {
                     render::Remote(ref s) => Some(s.to_string()),
                     render::Local => {
                         Some(("../".repeat(loc.len())).to_string())
@@ -291,11 +291,11 @@ fn primitive_link(f: &mut fmt::Formatter,
             needs_termination = true;
         }
         Some(&cnum) => {
-            let path = m.paths.get(&ast::DefId {
+            let path = &m.paths[ast::DefId {
                 krate: cnum,
                 node: ast::CRATE_NODE_ID,
-            });
-            let loc = match *m.extern_locations.get(&cnum) {
+            }];
+            let loc = match m.extern_locations[cnum] {
                 render::Remote(ref s) => Some(s.to_string()),
                 render::Local => {
                     let loc = current_location_key.get().unwrap();
@@ -343,11 +343,11 @@ impl fmt::Show for clean::Type {
         match *self {
             clean::TyParamBinder(id) => {
                 let m = cache_key.get().unwrap();
-                f.write(m.typarams.get(&ast_util::local_def(id)).as_bytes())
+                f.write(m.typarams[ast_util::local_def(id)].as_bytes())
             }
             clean::Generic(did) => {
                 let m = cache_key.get().unwrap();
-                f.write(m.typarams.get(&did).as_bytes())
+                f.write(m.typarams[did].as_bytes())
             }
             clean::ResolvedPath{ did, ref typarams, ref path } => {
                 try!(resolved_path(f, did, path, false));

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1252,8 +1252,8 @@ impl<'a> Item<'a> {
         // located, then we return `None`.
         } else {
             let cache = cache_key.get().unwrap();
-            let path = cache.external_paths.get(&self.item.def_id);
-            let root = match *cache.extern_locations.get(&self.item.def_id.krate) {
+            let path = &cache.external_paths[self.item.def_id];
+            let root = match cache.extern_locations[self.item.def_id.krate] {
                 Remote(ref s) => s.to_string(),
                 Local => self.cx.root_path.clone(),
                 Unknown => return None,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -229,7 +229,7 @@ impl<'a> RustdocVisitor<'a> {
             core::Typed(ref tcx) => tcx,
             core::NotTyped(_) => return false
         };
-        let def = tcx.def_map.borrow().get(&id).def_id();
+        let def = (*tcx.def_map.borrow())[id].def_id();
         if !ast_util::is_local(def) { return false }
         let analysis = match self.analysis {
             Some(analysis) => analysis, None => return false


### PR DESCRIPTION
Implement `Index` for `RingBuf`, `HashMap`, `TreeMap`, `SmallIntMap`, and `TrieMap`.

If there’s anything that I missed or should be removed, let me know.
