### PR TITLE
Make vec!() macro create a vector with precise capacity

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -362,7 +362,7 @@ macro_rules! count_args(
 macro_rules! vec(
     ($($e:expr),*) => ({
         // leading _ to allow empty construction without a warning.
-        let mut _temp = ::std::vec::Vec::new();
+        let mut _temp = ::std::vec::Vec::with_capacity(count_args!($($e),*));
         $(_temp.push($e);)*
         _temp
     });

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -348,6 +348,15 @@ macro_rules! try(
     ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
 )
 
+/// Expands to an expression which evaluates to the number of
+/// comma-separated expression parameters passed to it.
+#[macro_export]
+macro_rules! count_args(
+    ($e:expr $(,$e_rest:expr)*) => (1u + count_args!($($e_rest),*));
+    () => (0u);
+    ($($e:expr),*,) => (count_args!($($e),*))
+)
+
 /// Create a `std::vec::Vec` containing the arguments.
 #[macro_export]
 macro_rules! vec(


### PR DESCRIPTION
This seemed like a small but obvious optimization.  Feedback questions:
- Is the count_args!() macro a good fit for libstd?  It seems like it might be generally useful for macro writers.
- I can add a few unit tests, but where should I put them?
