### PR TITLE
Minor changes to rustdoc html templates

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -39,6 +39,7 @@ r##"<!DOCTYPE html>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The {krate} library documentation.">
+    <meta name="generator" content="rustdoc">
 
     <title>{title}</title>
 

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -48,7 +48,7 @@ r##"<!DOCTYPE html>
     {favicon}
     {in_header}
 </head>
-<body>
+<body class="rustdoc">
     <!--[if lte IE 8]>
     <div class="warning">
         This old browser is unsupported and will most likely display funky

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -98,7 +98,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
     {css}
     {in_header}
 </head>
-<body>
+<body class="rustdoc">
     <!--[if lte IE 8]>
     <div class="warning">
         This old browser is unsupported and will most likely display funky


### PR DESCRIPTION
This PR introduces a couple of minor changes to the rustdoc html templates:
1. The `<meta name="generator" content="rustdoc">` tag now appears in API documentation as well.
2. Adds a `rustdoc` class to the top-level `<body>` tag on all HTML pages.

The second point is a nice-to-have for those who would like to apply a user stylesheet to Rust documentation regardless of where it is hosted. Easier use of user stylesheets may alleviate much of the bikeshedding of personal taste on the rustdoc styles.
