### PR TITLE
rustc: use Name numbers rather than the Show impl for constants.

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -574,7 +574,7 @@ pub fn C_cstr(cx: &CrateContext, s: InternedString, null_terminated: bool) -> Va
                                                 !null_terminated as Bool);
 
         let gsym = token::gensym("str");
-        let g = format!("str{}", gsym).with_c_str(|buf| {
+        let g = format!("str{}", gsym.uint()).with_c_str(|buf| {
             llvm::LLVMAddGlobal(cx.llmod, val_ty(sc).to_ref(), buf)
         });
         llvm::LLVMSetInitializer(g, sc);
@@ -603,7 +603,7 @@ pub fn C_binary_slice(cx: &CrateContext, data: &[u8]) -> ValueRef {
         let lldata = C_bytes(cx, data);
 
         let gsym = token::gensym("binary");
-        let g = format!("binary{}", gsym).with_c_str(|buf| {
+        let g = format!("binary{}", gsym.uint()).with_c_str(|buf| {
             llvm::LLVMAddGlobal(cx.llmod, val_ty(lldata).to_ref(), buf)
         });
         llvm::LLVMSetInitializer(g, lldata);

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -528,7 +528,7 @@ pub fn make_vtable<I: Iterator<ValueRef>>(ccx: &CrateContext,
     unsafe {
         let tbl = C_struct(ccx, components.as_slice(), false);
         let sym = token::gensym("vtable");
-        let vt_gvar = format!("vtable{}", sym).with_c_str(|buf| {
+        let vt_gvar = format!("vtable{}", sym.uint()).with_c_str(|buf| {
             llvm::LLVMAddGlobal(ccx.llmod, val_ty(tbl).to_ref(), buf)
         });
         llvm::LLVMSetInitializer(vt_gvar, tbl);

--- a/src/test/run-make/symbols-are-reasonable/Makefile
+++ b/src/test/run-make/symbols-are-reasonable/Makefile
@@ -1,0 +1,15 @@
+-include ../tools.mk
+
+# check that the compile generated symbols for strings, binaries,
+# vtables, etc. have semisane names (e.g. `str1234`); it's relatively
+# easy to accidentally modify the compiler internals to make them
+# become things like `str"str"(1234)`.
+
+OUT=$(TMPDIR)/lib.s
+
+all:
+	$(RUSTC) lib.rs --emit=asm --crate-type=staticlib
+	# just check for symbol declarations with the names we're expecting.
+	grep 'str[0-9]\+:' $(OUT)
+	grep 'binary[0-9]\+:' $(OUT)
+	grep 'vtable[0-9]\+' $(OUT)

--- a/src/test/run-make/symbols-are-reasonable/lib.rs
+++ b/src/test/run-make/symbols-are-reasonable/lib.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub static X: &'static str = "foobarbaz";
+pub static Y: &'static [u8] = include_bin!("lib.rs");
+
+trait Foo {}
+impl Foo for uint {}
+
+pub fn dummy() {
+    // force the vtable to be created
+    let _x = &1u as &Foo;
+}


### PR DESCRIPTION
Using the Show impl for Names created global symbols with names like
`"str\"str\"(1027)"`. This adjusts strings, binaries and vtables to
avoid using that impl.
