### PR TITLE
Guide: Remove "bin" section from Cargo.toml

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1626,10 +1626,6 @@ Check out the generated `Cargo.toml`:
 name = "guessing_game"
 version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
-
-[[bin]]
-
-name = "guessing_game"
 ```
 
 Cargo gets this information from your environment. If it's not correct, go ahead


### PR DESCRIPTION
According to the [source code](https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_new.rs#L31) <code>cargo new</code> doesn't generate a <code>[[bin]]</code> section in the <code>Cargo.toml</code>, hence removing it from the example.
