### PR TITLE
Remove the "NFKC clause" in the reference manual.

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -112,8 +112,7 @@ production. See [tokens](#tokens) for more information.
 
 ## Input format
 
-Rust input is interpreted as a sequence of Unicode codepoints encoded in UTF-8,
-normalized to Unicode normalization form NFKC.
+Rust input is interpreted as a sequence of Unicode codepoints encoded in UTF-8.
 Most Rust grammar rules are defined in terms of printable ASCII-range codepoints,
 but a small number are defined in terms of Unicode properties or explicit
 codepoint lists. [^inputformat]


### PR DESCRIPTION
The reference manual said that code is interpreted as UTF-8 text and a implementation will normalize it to NFKC. However, rustc doesn't do any normalization now.

We may want to do any normalization for symbols, but normalizing whole text seems harmful because doing so loses some sort of information even if we choose a non-K variant of normalization.

I'd suggest removing "normalized to Unicode normalization form NFKC" phrase for the present so that the manual represents the current state properly. When we address the problem (with a RFC?), then the manual should be updated.

Closes #12388.

Reference: https://github.com/rust-lang/rust/issues/2253
