### PR TITLE
libgetopts: doc fix.

### DIFF
--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -96,7 +96,7 @@
 use std::cmp::PartialEq;
 use std::fmt;
 use std::result::{Err, Ok};
-use std::result;
+use std::result;cou
 use std::string::String;
 
 /// Name of an option. Either a string or a single char.
@@ -117,7 +117,7 @@ pub enum HasArg {
     Yes,
     /// The option is just a flag, therefore no argument.
     No,
-    /// The option argument is optional and it could or not exist.
+    /// The option argument is optional.
     Maybe,
 }
 
@@ -126,7 +126,7 @@ pub enum HasArg {
 pub enum Occur {
     /// The option occurs once.
     Req,
-    /// The option could or not occur.
+    /// The option occurs at most once.
     Optional,
     /// The option occurs zero or more times.
     Multi,

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -128,7 +128,7 @@ pub enum Occur {
     Req,
     /// The option could or not occur.
     Optional,
-    /// The option occurs once or multiple times.
+    /// The option occurs zero or more times.
     Multi,
 }
 


### PR DESCRIPTION
This confused me.

Seems like the Occur Multi enum allows the option to not appear at all, contrary to what the docs say.
