### PR TITLE
num: Fix the documentation of abs_sub.

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -279,8 +279,8 @@ pub fn abs<T: Signed>(value: T) -> T {
 
 /// The positive difference of two numbers.
 ///
-/// Returns `zero` if the number is less than or equal to `other`,
-/// otherwise the difference between `self` and `other` is returned.
+/// Returns zero if `x` is less than or equal to `y`, otherwise the difference
+/// between `x` and `y` is returned.
 #[inline(always)]
 pub fn abs_sub<T: Signed>(x: T, y: T) -> T {
     x.abs_sub(&y)


### PR DESCRIPTION
Use proper argument names and unbackquote the word "zero" because it is not an identifier.
