### PR TITLE
move most of front to libsyntax

### DIFF
--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -47,7 +47,6 @@ pub struct Session {
     pub working_dir: Path,
     pub lint_store: RefCell<lint::LintStore>,
     pub lints: RefCell<NodeMap<Vec<(lint::LintId, codemap::Span, String)>>>,
-    pub node_id: Cell<ast::NodeId>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
     pub crate_metadata: RefCell<Vec<String>>,
     pub features: front::feature_gate::Features,
@@ -129,17 +128,10 @@ impl Session {
         lints.insert(id, vec!((lint_id, sp, msg)));
     }
     pub fn next_node_id(&self) -> ast::NodeId {
-        self.reserve_node_ids(1)
+        self.parse_sess.next_node_id()
     }
     pub fn reserve_node_ids(&self, count: ast::NodeId) -> ast::NodeId {
-        let v = self.node_id.get();
-
-        match v.checked_add(&count) {
-            Some(next) => { self.node_id.set(next); }
-            None => self.bug("Input too large, ran out of node ids!")
-        }
-
-        v
+        self.parse_sess.reserve_node_ids(count)
     }
     pub fn diagnostic<'a>(&'a self) -> &'a diagnostic::SpanHandler {
         &self.parse_sess.span_diagnostic
@@ -251,7 +243,6 @@ pub fn build_session_(sopts: config::Options,
         working_dir: os::getcwd(),
         lint_store: RefCell::new(lint::LintStore::new()),
         lints: RefCell::new(NodeMap::new()),
-        node_id: Cell::new(1),
         crate_types: RefCell::new(Vec::new()),
         crate_metadata: RefCell::new(Vec::new()),
         features: front::feature_gate::Features::new(),

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -111,12 +111,8 @@ pub mod middle {
 }
 
 pub mod front {
-    pub mod config;
-    pub mod test;
     pub mod std_inject;
-    pub mod assign_node_ids_and_map;
     pub mod feature_gate;
-    pub mod show_span;
 }
 
 pub mod metadata;

--- a/src/libsyntax/assign_node_ids_and_map.rs
+++ b/src/libsyntax/assign_node_ids_and_map.rs
@@ -8,13 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use driver::session::Session;
-
-use syntax::ast;
-use syntax::ast_map;
+use ast;
+use ast_map;
+use parse::ParseSess;
 
 struct NodeIdAssigner<'a> {
-    sess: &'a Session
+    sess: &'a ParseSess
 }
 
 impl<'a> ast_map::FoldOps for NodeIdAssigner<'a> {
@@ -24,6 +23,7 @@ impl<'a> ast_map::FoldOps for NodeIdAssigner<'a> {
     }
 }
 
-pub fn assign_node_ids_and_map(sess: &Session, krate: ast::Crate) -> (ast::Crate, ast_map::Map) {
+pub fn assign_node_ids_and_map(sess: &ParseSess,
+                               krate: ast::Crate) -> (ast::Crate, ast_map::Map) {
     ast_map::map_crate(krate, NodeIdAssigner { sess: sess })
 }

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use syntax::fold::Folder;
-use syntax::{ast, fold, attr};
-use syntax::codemap;
+use fold::Folder;
+use {ast, fold, attr};
+use codemap;
 
 use std::gc::{Gc, GC};
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -53,16 +53,20 @@ pub mod syntax {
 }
 
 pub mod abi;
+pub mod assign_node_ids_and_map;
 pub mod ast;
 pub mod ast_map;
 pub mod ast_util;
 pub mod attr;
 pub mod codemap;
+pub mod config;
 pub mod crateid;
 pub mod diagnostic;
 pub mod fold;
 pub mod owned_slice;
 pub mod parse;
+pub mod show_span;
+pub mod test;
 pub mod visit;
 
 pub mod print {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -16,7 +16,7 @@ use diagnostic::{SpanHandler, mk_span_handler, default_handler, Auto};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 
-use std::cell::RefCell;
+use std::cell::{Cell,RefCell};
 use std::gc::Gc;
 use std::io::File;
 use std::rc::Rc;
@@ -36,12 +36,14 @@ pub struct ParseSess {
     pub span_diagnostic: SpanHandler, // better be the same as the one in the reader!
     /// Used to determine and report recursive mod inclusions
     included_mod_stack: RefCell<Vec<Path>>,
+    pub node_id: Cell<ast::NodeId>,
 }
 
 pub fn new_parse_sess() -> ParseSess {
     ParseSess {
         span_diagnostic: mk_span_handler(default_handler(Auto, None), CodeMap::new()),
         included_mod_stack: RefCell::new(Vec::new()),
+        node_id: Cell::new(1),
     }
 }
 
@@ -49,6 +51,23 @@ pub fn new_parse_sess_special_handler(sh: SpanHandler) -> ParseSess {
     ParseSess {
         span_diagnostic: sh,
         included_mod_stack: RefCell::new(Vec::new()),
+        node_id: Cell::new(1),
+    }
+}
+
+impl ParseSess {
+    pub fn next_node_id(&self) -> ast::NodeId {
+        self.reserve_node_ids(1)
+    }
+    pub fn reserve_node_ids(&self, count: ast::NodeId) -> ast::NodeId {
+        let v = self.node_id.get();
+
+        match v.checked_add(&count) {
+            Some(next) => { self.node_id.set(next); }
+            None => fail!("Input too large, ran out of node ids!")
+        }
+
+        v
     }
 }
 

--- a/src/libsyntax/show_span.rs
+++ b/src/libsyntax/show_span.rs
@@ -13,24 +13,23 @@
 //! This module shows spans for all expressions in the crate
 //! to help with compiler debugging.
 
-use syntax::ast;
-use syntax::visit;
-use syntax::visit::Visitor;
-
-use driver::session::Session;
+use ast;
+use diagnostic;
+use visit;
+use visit::Visitor;
 
 struct ShowSpanVisitor<'a> {
-    sess: &'a Session
+    span_diagnostic: &'a diagnostic::SpanHandler,
 }
 
 impl<'a> Visitor<()> for ShowSpanVisitor<'a> {
     fn visit_expr(&mut self, e: &ast::Expr, _: ()) {
-        self.sess.span_note(e.span, "expression");
+        self.span_diagnostic.span_note(e.span, "expression");
         visit::walk_expr(self, e, ());
     }
 }
 
-pub fn run(sess: &Session, krate: &ast::Crate) {
-    let mut v = ShowSpanVisitor { sess: sess };
+pub fn run(span_diagnostic: &diagnostic::SpanHandler, krate: &ast::Crate) {
+    let mut v = ShowSpanVisitor { span_diagnostic: span_diagnostic };
     visit::walk_crate(&mut v, krate, ());
 }


### PR DESCRIPTION
I tried to move all of front to libsyntax but feature_gate.rs and std_inject.rs have small but annoying dependencies on other rustc stuff. So I'm not really sure if moving just this stuff is worthwhile, but it does seem a bit of a better fit in libsyntax.

r?
