### PR TITLE
native: Fix utime() for windows

### DIFF
--- a/src/libnative/io/file_win32.rs
+++ b/src/libnative/io/file_win32.rs
@@ -516,8 +516,8 @@ pub fn lstat(_p: &CString) -> IoResult<rtio::FileStat> {
 
 pub fn utime(p: &CString, atime: u64, mtime: u64) -> IoResult<()> {
     let mut buf = libc::utimbuf {
-        actime: (atime / 1000) as libc::time64_t,
-        modtime: (mtime / 1000) as libc::time64_t,
+        actime: atime as libc::time64_t,
+        modtime: mtime as libc::time64_t,
     };
     let p = try!(to_utf16(p));
     super::mkerr_libc(unsafe {

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1588,8 +1588,7 @@ mod test {
                 "truncate didn't truncate");
     })
 
-    #[test]
-    fn utime() {
+    iotest!(fn utime() {
         let tmpdir = tmpdir();
         let path = tmpdir.join("a");
         check!(File::create(&path));
@@ -1597,17 +1596,16 @@ mod test {
         check!(change_file_times(&path, 1000, 2000));
         assert_eq!(check!(path.stat()).accessed, 1000);
         assert_eq!(check!(path.stat()).modified, 2000);
-    }
+    })
 
-    #[test]
-    fn utime_noexist() {
+    iotest!(fn utime_noexist() {
         let tmpdir = tmpdir();
 
         match change_file_times(&tmpdir.join("a"), 100, 200) {
             Ok(..) => fail!(),
             Err(..) => {}
         }
-    }
+    })
 
     iotest!(fn binary_file() {
         use rand::{StdRng, Rng};


### PR DESCRIPTION
Apparently the units are in milliseconds, not in seconds!
