### PR TITLE
Allow mutation of moved upvars when they're marked as mutable.

### DIFF
--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -764,18 +764,17 @@ impl<'a> CheckLoanCtxt<'a> {
         return;
 
         fn mark_variable_as_used_mut(this: &CheckLoanCtxt,
-                                     cmt: mc::cmt) {
+                                     mut cmt: mc::cmt) {
             //! If the mutability of the `cmt` being written is inherited
             //! from a local variable, liveness will
             //! not have been able to detect that this variable's mutability
             //! is important, so we must add the variable to the
             //! `used_mut_nodes` table here.
 
-            let mut cmt = cmt;
             loop {
-                debug!("mark_writes_through_upvars_as_used_mut(cmt={})",
-                       cmt.repr(this.tcx()));
+                debug!("mark_variable_as_used_mut(cmt={})", cmt.repr(this.tcx()));
                 match cmt.cat.clone() {
+                    mc::cat_copied_upvar(mc::CopiedUpvar { upvar_id: id, .. }) |
                     mc::cat_local(id) | mc::cat_arg(id) => {
                         this.tcx().used_mut_nodes.borrow_mut().insert(id);
                         return;
@@ -792,7 +791,6 @@ impl<'a> CheckLoanCtxt<'a> {
 
                     mc::cat_rvalue(..) |
                     mc::cat_static_item |
-                    mc::cat_copied_upvar(..) |
                     mc::cat_deref(_, _, mc::UnsafePtr(..)) |
                     mc::cat_deref(_, _, mc::BorrowedPtr(..)) |
                     mc::cat_deref(_, _, mc::Implicit(..)) => {

--- a/src/test/compile-fail/cannot-mutate-captured-non-mut-var.rs
+++ b/src/test/compile-fail/cannot-mutate-captured-non-mut-var.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = 1i;
+    proc() { x = 2; };
+    //~^ ERROR: cannot assign to immutable captured outer variable in a proc `x`
+}

--- a/src/test/compile-fail/unused-mut-warning-captured-var.rs
+++ b/src/test/compile-fail/unused-mut-warning-captured-var.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![forbid(unused_mut)]
+
+fn main() {
+    let mut x = 1i;
+    //~^ ERROR: variable does not need to be mutable
+    proc() { println!("{}", x); };
+}

--- a/src/test/run-pass/issue-11958.rs
+++ b/src/test/run-pass/issue-11958.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![forbid(warnings)]
+
+// Pretty printing tests complain about `use std::predule::*`
+#![allow(unused_imports)]
+
+// We shouldn't need to rebind a moved upvar as mut if it's already
+// marked as mut
+
+pub fn main() {
+    let mut x = 1i;
+    proc() { x = 2; };
+}


### PR DESCRIPTION
Fixes #11958.
