### PR TITLE
Emit description and keyword metadata from rustdoc

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -26,7 +26,8 @@ pub struct Page<'a> {
     pub title: &'a str,
     pub ty: &'a str,
     pub root_path: &'a str,
-    pub description: &'a str
+    pub description: &'a str,
+    pub keywords: &'a str
 }
 
 pub fn render<T: fmt::Show, S: fmt::Show>(
@@ -41,6 +42,7 @@ r##"<!DOCTYPE html>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="rustdoc">
     <meta name="description" content="{description}">
+    <meta name="keywords" content="{keywords}">
 
     <title>{title}</title>
 
@@ -137,6 +139,7 @@ r##"<!DOCTYPE html>
     },
     title     = page.title,
     description = page.description,
+    keywords = page.keywords,
     favicon   = if layout.favicon.len() == 0 {
         "".to_string()
     } else {

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -26,6 +26,7 @@ pub struct Page<'a> {
     pub title: &'a str,
     pub ty: &'a str,
     pub root_path: &'a str,
+    pub description: &'a str
 }
 
 pub fn render<T: fmt::Show, S: fmt::Show>(
@@ -38,8 +39,8 @@ r##"<!DOCTYPE html>
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The {krate} library documentation.">
     <meta name="generator" content="rustdoc">
+    <meta name="description" content="{description}">
 
     <title>{title}</title>
 
@@ -135,6 +136,7 @@ r##"<!DOCTYPE html>
                 layout.logo)
     },
     title     = page.title,
+    description = page.description,
     favicon   = if layout.favicon.len() == 0 {
         "".to_string()
     } else {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1333,7 +1333,7 @@ impl<'a> fmt::Show for Item<'a> {
         // Write stability dashboard link
         match self.item.inner {
             clean::ModuleItem(ref m) if m.is_crate => {
-                try!(write!(fmt, "<a href='stability.html'>[stability dashboard]</a> "));
+                try!(write!(fmt, "<a href='stability.html'>[stability]</a> "));
             }
             _ => {}
         };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -745,9 +745,9 @@ impl<'a> SourceCollector<'a> {
         let desc = format!("Source to the Rust file `{}`.", filename);
         let page = layout::Page {
             title: title.as_slice(),
-            description: desc.as_slice(),
             ty: "source",
             root_path: root_path.as_slice(),
+            description: desc.as_slice(),
         };
         try!(layout::render(&mut w as &mut Writer, &self.cx.layout,
                             &page, &(""), &Source(contents)));
@@ -1078,9 +1078,9 @@ impl Context {
                                this.layout.krate);
             let page = layout::Page {
                 ty: "mod",
-                description: desc.as_slice(),
                 root_path: this.root_path.as_slice(),
                 title: title.as_slice(),
+                description: desc.as_slice(),
             };
             let html_dst = &this.dst.join("stability.html");
             let mut html_out = BufferedWriter::new(try!(File::create(html_dst)));
@@ -1139,9 +1139,9 @@ impl Context {
             };
             let page = layout::Page {
                 ty: tyname,
-                description: desc.as_slice(),
                 root_path: cx.root_path.as_slice(),
                 title: title.as_slice(),
+                description: desc.as_slice(),
             };
 
             markdown::reset_headers();

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -748,6 +748,7 @@ impl<'a> SourceCollector<'a> {
             ty: "source",
             root_path: root_path.as_slice(),
             description: desc.as_slice(),
+            keywords: get_basic_keywords(),
         };
         try!(layout::render(&mut w as &mut Writer, &self.cx.layout,
                             &page, &(""), &Source(contents)));
@@ -1081,6 +1082,7 @@ impl Context {
                 root_path: this.root_path.as_slice(),
                 title: title.as_slice(),
                 description: desc.as_slice(),
+                keywords: get_basic_keywords(),
             };
             let html_dst = &this.dst.join("stability.html");
             let mut html_out = BufferedWriter::new(try!(File::create(html_dst)));
@@ -1137,11 +1139,13 @@ impl Context {
                 format!("API documentation for the Rust `{}` {} in crate `{}`.",
                         it.name.get_ref(), tyname, cx.layout.krate)
             };
+            let keywords = make_item_keywords(it);
             let page = layout::Page {
                 ty: tyname,
                 root_path: cx.root_path.as_slice(),
                 title: title.as_slice(),
                 description: desc.as_slice(),
+                keywords: keywords.as_slice(),
             };
 
             markdown::reset_headers();
@@ -2169,4 +2173,12 @@ fn ignore_private_item(it: &clean::Item) -> bool {
         clean::PrimitiveItem(..) => it.visibility != Some(ast::Public),
         _ => false,
     }
+}
+
+fn get_basic_keywords() -> &'static str {
+    "rust, rustlang, rust-lang"
+}
+
+fn make_item_keywords(it: &clean::Item) -> String {
+    format!("{}, {}", get_basic_keywords(), it.name.get_ref())
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -742,8 +742,10 @@ impl<'a> SourceCollector<'a> {
         let mut w = BufferedWriter::new(try!(File::create(&cur)));
 
         let title = format!("{} -- source", cur.filename_display());
+        let desc = format!("Source to the Rust file `{}`.", filename);
         let page = layout::Page {
             title: title.as_slice(),
+            description: desc.as_slice(),
             ty: "source",
             root_path: root_path.as_slice(),
         };
@@ -1072,8 +1074,11 @@ impl Context {
             try!(stability.encode(&mut json::Encoder::new(&mut json_out)));
 
             let title = stability.name.clone().append(" - Stability dashboard");
+            let desc = format!("API stability overview for the Rust `{}` crate.",
+                               this.layout.krate);
             let page = layout::Page {
                 ty: "mod",
+                description: desc.as_slice(),
                 root_path: this.root_path.as_slice(),
                 title: title.as_slice(),
             };
@@ -1120,8 +1125,21 @@ impl Context {
                 title.push_str(it.name.get_ref().as_slice());
             }
             title.push_str(" - Rust");
+            let tyname = shortty(it).to_static_str();
+            let is_crate = match it.inner {
+                clean::ModuleItem(clean::Module { items: _, is_crate: true }) => true,
+                _ => false
+            };
+            let desc = if is_crate {
+                format!("API documentation for the Rust `{}` crate.",
+                        cx.layout.krate)
+            } else {
+                format!("API documentation for the Rust `{}` {} in crate `{}`.",
+                        it.name.get_ref(), tyname, cx.layout.krate)
+            };
             let page = layout::Page {
-                ty: shortty(it).to_static_str(),
+                ty: tyname,
+                description: desc.as_slice(),
                 root_path: cx.root_path.as_slice(),
                 title: title.as_slice(),
             };


### PR DESCRIPTION
This teach rustdoc to add `<meta name="description">` and `<meta name="keywords">` tags to crate docs. Description is important for search engines because they display it as the page description. Keywords are less useful but still generally recommended.

This also changes the "stability dashboard" link to just say "stability", because the current link takes up a lot of space.

cc https://github.com/rust-lang/rust/issues/12466
