### PR TITLE
stabilize atomics (now atomic)

### DIFF
--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -10,29 +10,35 @@
 
 //! Core atomic primitives
 
+#![stable]
+
 use intrinsics;
 use std::kinds::marker;
 use cell::UnsafeCell;
 
 /// An atomic boolean type.
+#[stable]
 pub struct AtomicBool {
     v: UnsafeCell<uint>,
     nocopy: marker::NoCopy
 }
 
 /// A signed atomic integer type, supporting basic atomic arithmetic operations
+#[stable]
 pub struct AtomicInt {
     v: UnsafeCell<int>,
     nocopy: marker::NoCopy
 }
 
 /// An unsigned atomic integer type, supporting basic atomic arithmetic operations
+#[stable]
 pub struct AtomicUint {
     v: UnsafeCell<uint>,
     nocopy: marker::NoCopy
 }
 
 /// An unsafe atomic pointer. Only supports basic atomic operations
+#[stable]
 pub struct AtomicPtr<T> {
     p: UnsafeCell<uint>,
     nocopy: marker::NoCopy
@@ -49,6 +55,7 @@ pub struct AtomicPtr<T> {
 /// Rust's memory orderings are the same as in C++[1].
 ///
 /// 1: http://gcc.gnu.org/wiki/Atomic/GCCMM/AtomicSync
+#[stable]
 pub enum Ordering {
     /// No ordering constraints, only atomic operations
     Relaxed,
@@ -69,18 +76,22 @@ pub enum Ordering {
 }
 
 /// An `AtomicBool` initialized to `false`
+#[unstable = "may be renamed, pending conventions for static initalizers"]
 pub static INIT_ATOMIC_BOOL: AtomicBool =
         AtomicBool { v: UnsafeCell { value: 0 }, nocopy: marker::NoCopy };
 /// An `AtomicInt` initialized to `0`
+#[unstable = "may be renamed, pending conventions for static initalizers"]
 pub static INIT_ATOMIC_INT: AtomicInt =
         AtomicInt { v: UnsafeCell { value: 0 }, nocopy: marker::NoCopy };
 /// An `AtomicUint` initialized to `0`
+#[unstable = "may be renamed, pending conventions for static initalizers"]
 pub static INIT_ATOMIC_UINT: AtomicUint =
         AtomicUint { v: UnsafeCell { value: 0, }, nocopy: marker::NoCopy };
 
 // NB: Needs to be -1 (0b11111111...) to make fetch_nand work correctly
 static UINT_TRUE: uint = -1;
 
+#[stable]
 impl AtomicBool {
     /// Create a new `AtomicBool`
     pub fn new(v: bool) -> AtomicBool {
@@ -89,12 +100,20 @@ impl AtomicBool {
     }
 
     /// Load the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Release` or `AcqRel`.
     #[inline]
     pub fn load(&self, order: Ordering) -> bool {
         unsafe { atomic_load(self.v.get() as *const uint, order) > 0 }
     }
 
     /// Store the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Acquire` or `AcqRel`.
     #[inline]
     pub fn store(&self, val: bool, order: Ordering) {
         let val = if val { UINT_TRUE } else { 0 };
@@ -120,7 +139,7 @@ impl AtomicBool {
     ///
     /// ```rust
     /// use std::sync::Arc;
-    /// use std::sync::atomics::{AtomicBool, SeqCst};
+    /// use std::sync::atomic::{AtomicBool, SeqCst};
     /// use std::task::deschedule;
     ///
     /// fn main() {
@@ -170,7 +189,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicBool, SeqCst};
+    /// use std::sync::atomic::{AtomicBool, SeqCst};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(true, foo.fetch_and(false, SeqCst));
@@ -200,7 +219,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicBool, SeqCst};
+    /// use std::sync::atomic::{AtomicBool, SeqCst};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(true, foo.fetch_nand(false, SeqCst));
@@ -231,7 +250,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicBool, SeqCst};
+    /// use std::sync::atomic::{AtomicBool, SeqCst};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(true, foo.fetch_or(false, SeqCst));
@@ -261,7 +280,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicBool, SeqCst};
+    /// use std::sync::atomic::{AtomicBool, SeqCst};
     ///
     /// let foo = AtomicBool::new(true);
     /// assert_eq!(true, foo.fetch_xor(false, SeqCst));
@@ -283,6 +302,7 @@ impl AtomicBool {
     }
 }
 
+#[stable]
 impl AtomicInt {
     /// Create a new `AtomicInt`
     pub fn new(v: int) -> AtomicInt {
@@ -290,12 +310,20 @@ impl AtomicInt {
     }
 
     /// Load the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Release` or `AcqRel`.
     #[inline]
     pub fn load(&self, order: Ordering) -> int {
         unsafe { atomic_load(self.v.get() as *const int, order) }
     }
 
     /// Store the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Acquire` or `AcqRel`.
     #[inline]
     pub fn store(&self, val: int, order: Ordering) {
         unsafe { atomic_store(self.v.get(), val, order); }
@@ -322,7 +350,7 @@ impl AtomicInt {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicInt, SeqCst};
+    /// use std::sync::atomic::{AtomicInt, SeqCst};
     ///
     /// let foo = AtomicInt::new(0);
     /// assert_eq!(0, foo.fetch_add(10, SeqCst));
@@ -338,7 +366,7 @@ impl AtomicInt {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicInt, SeqCst};
+    /// use std::sync::atomic::{AtomicInt, SeqCst};
     ///
     /// let foo = AtomicInt::new(0);
     /// assert_eq!(0, foo.fetch_sub(10, SeqCst));
@@ -354,7 +382,7 @@ impl AtomicInt {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0b101101);
     /// assert_eq!(0b101101, foo.fetch_and(0b110011, SeqCst));
@@ -369,7 +397,7 @@ impl AtomicInt {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0b101101);
     /// assert_eq!(0b101101, foo.fetch_or(0b110011, SeqCst));
@@ -384,7 +412,7 @@ impl AtomicInt {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0b101101);
     /// assert_eq!(0b101101, foo.fetch_xor(0b110011, SeqCst));
@@ -395,6 +423,7 @@ impl AtomicInt {
     }
 }
 
+#[stable]
 impl AtomicUint {
     /// Create a new `AtomicUint`
     pub fn new(v: uint) -> AtomicUint {
@@ -402,12 +431,20 @@ impl AtomicUint {
     }
 
     /// Load the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Release` or `AcqRel`.
     #[inline]
     pub fn load(&self, order: Ordering) -> uint {
         unsafe { atomic_load(self.v.get() as *const uint, order) }
     }
 
     /// Store the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Acquire` or `AcqRel`.
     #[inline]
     pub fn store(&self, val: uint, order: Ordering) {
         unsafe { atomic_store(self.v.get(), val, order); }
@@ -434,7 +471,7 @@ impl AtomicUint {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0);
     /// assert_eq!(0, foo.fetch_add(10, SeqCst));
@@ -450,7 +487,7 @@ impl AtomicUint {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(10);
     /// assert_eq!(10, foo.fetch_sub(10, SeqCst));
@@ -466,7 +503,7 @@ impl AtomicUint {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0b101101);
     /// assert_eq!(0b101101, foo.fetch_and(0b110011, SeqCst));
@@ -481,7 +518,7 @@ impl AtomicUint {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0b101101);
     /// assert_eq!(0b101101, foo.fetch_or(0b110011, SeqCst));
@@ -496,7 +533,7 @@ impl AtomicUint {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::atomics::{AtomicUint, SeqCst};
+    /// use std::sync::atomic::{AtomicUint, SeqCst};
     ///
     /// let foo = AtomicUint::new(0b101101);
     /// assert_eq!(0b101101, foo.fetch_xor(0b110011, SeqCst));
@@ -507,6 +544,7 @@ impl AtomicUint {
     }
 }
 
+#[stable]
 impl<T> AtomicPtr<T> {
     /// Create a new `AtomicPtr`
     pub fn new(p: *mut T) -> AtomicPtr<T> {
@@ -514,6 +552,10 @@ impl<T> AtomicPtr<T> {
     }
 
     /// Load the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Release` or `AcqRel`.
     #[inline]
     pub fn load(&self, order: Ordering) -> *mut T {
         unsafe {
@@ -522,6 +564,10 @@ impl<T> AtomicPtr<T> {
     }
 
     /// Store the value
+    ///
+    /// # Failure
+    ///
+    /// Fails if `order` is `Acquire` or `AcqRel`.
     #[inline]
     pub fn store(&self, ptr: *mut T, order: Ordering) {
         unsafe { atomic_store(self.p.get(), ptr as uint, order); }
@@ -552,7 +598,9 @@ unsafe fn atomic_store<T>(dst: *mut T, val: T, order:Ordering) {
     match order {
         Release => intrinsics::atomic_store_rel(dst, val),
         Relaxed => intrinsics::atomic_store_relaxed(dst, val),
-        _       => intrinsics::atomic_store(dst, val)
+        SeqCst  => intrinsics::atomic_store(dst, val),
+        Acquire => fail!("there is no such thing as an acquire store"),
+        AcqRel  => fail!("there is no such thing as an acquire/release store"),
     }
 }
 
@@ -561,7 +609,9 @@ unsafe fn atomic_load<T>(dst: *const T, order:Ordering) -> T {
     match order {
         Acquire => intrinsics::atomic_load_acq(dst),
         Relaxed => intrinsics::atomic_load_relaxed(dst),
-        _       => intrinsics::atomic_load(dst)
+        SeqCst  => intrinsics::atomic_load(dst),
+        Release => fail!("there is no such thing as a release load"),
+        AcqRel  => fail!("there is no such thing as an acquire/release load"),
     }
 }
 
@@ -572,7 +622,7 @@ unsafe fn atomic_swap<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_xchg_rel(dst, val),
         AcqRel  => intrinsics::atomic_xchg_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xchg_relaxed(dst, val),
-        _       => intrinsics::atomic_xchg(dst, val)
+        SeqCst  => intrinsics::atomic_xchg(dst, val)
     }
 }
 
@@ -584,7 +634,7 @@ unsafe fn atomic_add<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_xadd_rel(dst, val),
         AcqRel  => intrinsics::atomic_xadd_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xadd_relaxed(dst, val),
-        _       => intrinsics::atomic_xadd(dst, val)
+        SeqCst  => intrinsics::atomic_xadd(dst, val)
     }
 }
 
@@ -596,7 +646,7 @@ unsafe fn atomic_sub<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_xsub_rel(dst, val),
         AcqRel  => intrinsics::atomic_xsub_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xsub_relaxed(dst, val),
-        _       => intrinsics::atomic_xsub(dst, val)
+        SeqCst  => intrinsics::atomic_xsub(dst, val)
     }
 }
 
@@ -607,7 +657,7 @@ unsafe fn atomic_compare_and_swap<T>(dst: *mut T, old:T, new:T, order: Ordering)
         Release => intrinsics::atomic_cxchg_rel(dst, old, new),
         AcqRel  => intrinsics::atomic_cxchg_acqrel(dst, old, new),
         Relaxed => intrinsics::atomic_cxchg_relaxed(dst, old, new),
-        _       => intrinsics::atomic_cxchg(dst, old, new),
+        SeqCst  => intrinsics::atomic_cxchg(dst, old, new),
     }
 }
 
@@ -618,7 +668,7 @@ unsafe fn atomic_and<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_and_rel(dst, val),
         AcqRel  => intrinsics::atomic_and_acqrel(dst, val),
         Relaxed => intrinsics::atomic_and_relaxed(dst, val),
-        _       => intrinsics::atomic_and(dst, val)
+        SeqCst  => intrinsics::atomic_and(dst, val)
     }
 }
 
@@ -629,7 +679,7 @@ unsafe fn atomic_nand<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_nand_rel(dst, val),
         AcqRel  => intrinsics::atomic_nand_acqrel(dst, val),
         Relaxed => intrinsics::atomic_nand_relaxed(dst, val),
-        _       => intrinsics::atomic_nand(dst, val)
+        SeqCst  => intrinsics::atomic_nand(dst, val)
     }
 }
 
@@ -641,7 +691,7 @@ unsafe fn atomic_or<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_or_rel(dst, val),
         AcqRel  => intrinsics::atomic_or_acqrel(dst, val),
         Relaxed => intrinsics::atomic_or_relaxed(dst, val),
-        _       => intrinsics::atomic_or(dst, val)
+        SeqCst  => intrinsics::atomic_or(dst, val)
     }
 }
 
@@ -653,7 +703,7 @@ unsafe fn atomic_xor<T>(dst: *mut T, val: T, order: Ordering) -> T {
         Release => intrinsics::atomic_xor_rel(dst, val),
         AcqRel  => intrinsics::atomic_xor_acqrel(dst, val),
         Relaxed => intrinsics::atomic_xor_relaxed(dst, val),
-        _       => intrinsics::atomic_xor(dst, val)
+        SeqCst  => intrinsics::atomic_xor(dst, val)
     }
 }
 
@@ -679,6 +729,7 @@ unsafe fn atomic_xor<T>(dst: *mut T, val: T, order: Ordering) -> T {
 ///
 /// Fails if `order` is `Relaxed`
 #[inline]
+#[stable]
 pub fn fence(order: Ordering) {
     unsafe {
         match order {

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -113,7 +113,7 @@ pub mod ty {
 /* Core types and methods on primitives */
 
 pub mod any;
-pub mod atomics;
+pub mod atomic;
 pub mod bool;
 pub mod cell;
 pub mod char;

--- a/src/libcoretest/atomic.rs
+++ b/src/libcoretest/atomic.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use core::atomics::*;
+use core::atomic::*;
 
 #[test]
 fn bool_() {

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -14,7 +14,7 @@ extern crate test;
 extern crate libc;
 
 mod any;
-mod atomics;
+mod atomic;
 mod cell;
 mod char;
 mod cmp;

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -232,7 +232,7 @@ use std::rt::rtio;
 use std::rt::thread::Thread;
 use std::rt::task::TaskOpts;
 use std::rt;
-use std::sync::atomics::{SeqCst, AtomicUint, INIT_ATOMIC_UINT};
+use std::sync::atomic::{SeqCst, AtomicUint, INIT_ATOMIC_UINT};
 use std::sync::deque;
 use std::task::{TaskBuilder, Spawner};
 

--- a/src/libgreen/stack.rs
+++ b/src/libgreen/stack.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::ptr;
-use std::sync::atomics;
+use std::sync::atomic;
 use std::os::{errno, page_size, MemoryMap, MapReadable, MapWritable,
               MapNonStandardFlags, getenv};
 use libc;
@@ -158,8 +158,8 @@ impl StackPool {
 }
 
 fn max_cached_stacks() -> uint {
-    static mut AMT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
-    match unsafe { AMT.load(atomics::SeqCst) } {
+    static mut AMT: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
+    match unsafe { AMT.load(atomic::SeqCst) } {
         0 => {}
         n => return n - 1,
     }
@@ -169,7 +169,7 @@ fn max_cached_stacks() -> uint {
     let amt = amt.unwrap_or(10);
     // 0 is our sentinel value, so ensure that we'll never see 0 after
     // initialization has run
-    unsafe { AMT.store(amt + 1, atomics::SeqCst); }
+    unsafe { AMT.store(amt + 1, atomic::SeqCst); }
     return amt;
 }
 

--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -52,7 +52,7 @@ use std::os;
 use std::ptr;
 use std::rt::rtio;
 use std::rt::rtio::IoResult;
-use std::sync::atomics;
+use std::sync::atomic;
 use std::comm;
 
 use io::c;
@@ -207,8 +207,8 @@ impl Timer {
         // instead of ()
         unsafe { HELPER.boot(|| {}, helper); }
 
-        static mut ID: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
-        let id = unsafe { ID.fetch_add(1, atomics::Relaxed) };
+        static mut ID: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
+        let id = unsafe { ID.fetch_add(1, atomic::Relaxed) };
         Ok(Timer {
             id: id,
             inner: Some(box Inner {

--- a/src/librustrt/at_exit_imp.rs
+++ b/src/librustrt/at_exit_imp.rs
@@ -17,21 +17,21 @@ use core::prelude::*;
 use alloc::boxed::Box;
 use collections::MutableSeq;
 use collections::vec::Vec;
-use core::atomics;
+use core::atomic;
 use core::mem;
 
 use exclusive::Exclusive;
 
 type Queue = Exclusive<Vec<proc():Send>>;
 
-static mut QUEUE: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
-static mut RUNNING: atomics::AtomicBool = atomics::INIT_ATOMIC_BOOL;
+static mut QUEUE: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
+static mut RUNNING: atomic::AtomicBool = atomic::INIT_ATOMIC_BOOL;
 
 pub fn init() {
     let state: Box<Queue> = box Exclusive::new(Vec::new());
     unsafe {
-        rtassert!(!RUNNING.load(atomics::SeqCst));
-        assert!(QUEUE.swap(mem::transmute(state), atomics::SeqCst) == 0);
+        rtassert!(!RUNNING.load(atomic::SeqCst));
+        assert!(QUEUE.swap(mem::transmute(state), atomic::SeqCst) == 0);
     }
 }
 
@@ -41,8 +41,8 @@ pub fn push(f: proc():Send) {
         // all with respect to `run`, meaning that this could theoretically be a
         // use-after-free. There's not much we can do to protect against that,
         // however. Let's just assume a well-behaved runtime and go from there!
-        rtassert!(!RUNNING.load(atomics::SeqCst));
-        let queue = QUEUE.load(atomics::SeqCst);
+        rtassert!(!RUNNING.load(atomic::SeqCst));
+        let queue = QUEUE.load(atomic::SeqCst);
         rtassert!(queue != 0);
         (*(queue as *const Queue)).lock().push(f);
     }
@@ -50,8 +50,8 @@ pub fn push(f: proc():Send) {
 
 pub fn run() {
     let cur = unsafe {
-        rtassert!(!RUNNING.load(atomics::SeqCst));
-        let queue = QUEUE.swap(0, atomics::SeqCst);
+        rtassert!(!RUNNING.load(atomic::SeqCst));
+        let queue = QUEUE.swap(0, atomic::SeqCst);
         rtassert!(queue != 0);
 
         let queue: Box<Queue> = mem::transmute(queue);

--- a/src/librustrt/task.rs
+++ b/src/librustrt/task.rs
@@ -18,7 +18,7 @@ use core::prelude::*;
 use alloc::arc::Arc;
 use alloc::boxed::{BoxAny, Box};
 use core::any::Any;
-use core::atomics::{AtomicUint, SeqCst};
+use core::atomic::{AtomicUint, SeqCst};
 use core::iter::Take;
 use core::kinds::marker;
 use core::mem;

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -63,7 +63,7 @@ use alloc::boxed::Box;
 use collections::string::String;
 use collections::vec::Vec;
 use core::any::Any;
-use core::atomics;
+use core::atomic;
 use core::cmp;
 use core::fmt;
 use core::intrinsics;
@@ -91,16 +91,16 @@ pub type Callback = fn(msg: &Any + Send, file: &'static str, line: uint);
 //
 // For more information, see below.
 static MAX_CALLBACKS: uint = 16;
-static mut CALLBACKS: [atomics::AtomicUint, ..MAX_CALLBACKS] =
-        [atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT,
-         atomics::INIT_ATOMIC_UINT, atomics::INIT_ATOMIC_UINT];
-static mut CALLBACK_CNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
+static mut CALLBACKS: [atomic::AtomicUint, ..MAX_CALLBACKS] =
+        [atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT,
+         atomic::INIT_ATOMIC_UINT, atomic::INIT_ATOMIC_UINT];
+static mut CALLBACK_CNT: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
 
 impl Unwinder {
     pub fn new() -> Unwinder {
@@ -466,11 +466,11 @@ fn begin_unwind_inner(msg: Box<Any + Send>, file_line: &(&'static str, uint)) ->
     // callback. Additionally, CALLBACK_CNT may briefly be higher than
     // MAX_CALLBACKS, so we're sure to clamp it as necessary.
     let callbacks = unsafe {
-        let amt = CALLBACK_CNT.load(atomics::SeqCst);
+        let amt = CALLBACK_CNT.load(atomic::SeqCst);
         CALLBACKS.slice_to(cmp::min(amt, MAX_CALLBACKS))
     };
     for cb in callbacks.iter() {
-        match cb.load(atomics::SeqCst) {
+        match cb.load(atomic::SeqCst) {
             0 => {}
             n => {
                 let f: Callback = unsafe { mem::transmute(n) };
@@ -518,18 +518,18 @@ fn begin_unwind_inner(msg: Box<Any + Send>, file_line: &(&'static str, uint)) ->
 /// currently possible to unregister a callback once it has been registered.
 #[experimental]
 pub unsafe fn register(f: Callback) -> bool {
-    match CALLBACK_CNT.fetch_add(1, atomics::SeqCst) {
+    match CALLBACK_CNT.fetch_add(1, atomic::SeqCst) {
         // The invocation code has knowledge of this window where the count has
         // been incremented, but the callback has not been stored. We're
         // guaranteed that the slot we're storing into is 0.
         n if n < MAX_CALLBACKS => {
-            let prev = CALLBACKS[n].swap(mem::transmute(f), atomics::SeqCst);
+            let prev = CALLBACKS[n].swap(mem::transmute(f), atomic::SeqCst);
             rtassert!(prev == 0);
             true
         }
         // If we accidentally bumped the count too high, pull it back.
         _ => {
-            CALLBACK_CNT.store(MAX_CALLBACKS, atomics::SeqCst);
+            CALLBACK_CNT.store(MAX_CALLBACKS, atomic::SeqCst);
             false
         }
     }

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -19,7 +19,7 @@ use option::{Option, None, Some};
 use os;
 use path::{Path, GenericPath};
 use result::{Ok, Err};
-use sync::atomics;
+use sync::atomic;
 
 #[cfg(stage0)]
 use iter::Iterator; // NOTE(stage0): Remove after snapshot.
@@ -42,13 +42,13 @@ impl TempDir {
             return TempDir::new_in(&os::make_absolute(tmpdir), suffix);
         }
 
-        static mut CNT: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
+        static mut CNT: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
 
         for _ in range(0u, 1000) {
             let filename =
                 format!("rs-{}-{}-{}",
                         unsafe { libc::getpid() },
-                        unsafe { CNT.fetch_add(1, atomics::SeqCst) },
+                        unsafe { CNT.fetch_add(1, atomic::SeqCst) },
                         suffix);
             let p = tmpdir.join(filename);
             match fs::mkdir(&p, io::UserRWX) {

--- a/src/libstd/io/test.rs
+++ b/src/libstd/io/test.rs
@@ -16,7 +16,7 @@ use libc;
 use os;
 use prelude::*;
 use std::io::net::ip::*;
-use sync::atomics::{AtomicUint, INIT_ATOMIC_UINT, Relaxed};
+use sync::atomic::{AtomicUint, INIT_ATOMIC_UINT, Relaxed};
 
 macro_rules! iotest (
     { fn $name:ident() $b:block $(#[$a:meta])* } => (

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -48,7 +48,7 @@ use result::{Err, Ok, Result};
 use slice::{Vector, ImmutableVector, MutableVector, ImmutableEqVector};
 use str::{Str, StrSlice, StrAllocating};
 use string::String;
-use sync::atomics::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
+use sync::atomic::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
 use vec::Vec;
 
 #[cfg(unix)]

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -20,7 +20,7 @@ use option::{Some, None};
 use os;
 use result::{Ok, Err};
 use str::StrSlice;
-use sync::atomics;
+use sync::atomic;
 use unicode::char::UnicodeChar;
 
 pub use self::imp::write;
@@ -28,9 +28,9 @@ pub use self::imp::write;
 // For now logging is turned off by default, and this function checks to see
 // whether the magical environment variable is present to see if it's turned on.
 pub fn log_enabled() -> bool {
-    static mut ENABLED: atomics::AtomicInt = atomics::INIT_ATOMIC_INT;
+    static mut ENABLED: atomic::AtomicInt = atomic::INIT_ATOMIC_INT;
     unsafe {
-        match ENABLED.load(atomics::SeqCst) {
+        match ENABLED.load(atomic::SeqCst) {
             1 => return false,
             2 => return true,
             _ => {}
@@ -41,7 +41,7 @@ pub fn log_enabled() -> bool {
         Some(..) => 2,
         None => 1,
     };
-    unsafe { ENABLED.store(val, atomics::SeqCst); }
+    unsafe { ENABLED.store(val, atomic::SeqCst); }
     val == 2
 }
 

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -14,7 +14,7 @@ use libc::uintptr_t;
 use option::{Some, None, Option};
 use os;
 use str::Str;
-use sync::atomics;
+use sync::atomic;
 
 /// Dynamically inquire about whether we're running under V.
 /// You should usually not use this unless your test definitely
@@ -41,8 +41,8 @@ pub fn limit_thread_creation_due_to_osx_and_valgrind() -> bool {
 }
 
 pub fn min_stack() -> uint {
-    static mut MIN: atomics::AtomicUint = atomics::INIT_ATOMIC_UINT;
-    match unsafe { MIN.load(atomics::SeqCst) } {
+    static mut MIN: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
+    match unsafe { MIN.load(atomic::SeqCst) } {
         0 => {}
         n => return n - 1,
     }
@@ -50,7 +50,7 @@ pub fn min_stack() -> uint {
     let amt = amt.unwrap_or(2 * 1024 * 1024);
     // 0 is our sentinel value, so ensure that we'll never see 0 after
     // initialization has run
-    unsafe { MIN.store(amt + 1, atomics::SeqCst); }
+    unsafe { MIN.store(amt + 1, atomic::SeqCst); }
     return amt;
 }
 

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -17,11 +17,17 @@
 
 #![experimental]
 
-pub use core_sync::{atomics, deque, mpmc_bounded_queue, mpsc_queue, spsc_queue};
+#[stable]
+pub use core_sync::atomic;
+
+pub use core_sync::{deque, mpmc_bounded_queue, mpsc_queue, spsc_queue};
 pub use core_sync::{Arc, Weak, Mutex, MutexGuard, Condvar, Barrier};
 pub use core_sync::{RWLock, RWLockReadGuard, RWLockWriteGuard};
 pub use core_sync::{Semaphore, SemaphoreGuard};
 pub use core_sync::one::{Once, ONCE_INIT};
+
+#[deprecated = "use atomic instead"]
+pub use atomics = core_sync::atomic;
 
 pub use self::future::Future;
 pub use self::task_pool::TaskPool;

--- a/src/libsync/atomic.rs
+++ b/src/libsync/atomic.rs
@@ -41,7 +41,7 @@
 //!
 //! ```
 //! use std::sync::Arc;
-//! use std::sync::atomics::{AtomicUint, SeqCst};
+//! use std::sync::atomic::{AtomicUint, SeqCst};
 //! use std::task::deschedule;
 //!
 //! fn main() {
@@ -67,7 +67,7 @@
 //!
 //! ```
 //! use std::sync::Arc;
-//! use std::sync::atomics::{AtomicOption, SeqCst};
+//! use std::sync::atomic::{AtomicOption, SeqCst};
 //!
 //! fn main() {
 //!     struct BigObject;
@@ -91,7 +91,7 @@
 //! Keep a global count of live tasks:
 //!
 //! ```
-//! use std::sync::atomics::{AtomicUint, SeqCst, INIT_ATOMIC_UINT};
+//! use std::sync::atomic::{AtomicUint, SeqCst, INIT_ATOMIC_UINT};
 //!
 //! static mut GLOBAL_TASK_COUNT: AtomicUint = INIT_ATOMIC_UINT;
 //!
@@ -106,16 +106,18 @@ use core::prelude::*;
 use alloc::boxed::Box;
 use core::mem;
 
-pub use core::atomics::{AtomicBool, AtomicInt, AtomicUint, AtomicPtr};
-pub use core::atomics::{Ordering, Relaxed, Release, Acquire, AcqRel, SeqCst};
-pub use core::atomics::{INIT_ATOMIC_BOOL, INIT_ATOMIC_INT, INIT_ATOMIC_UINT};
-pub use core::atomics::fence;
+pub use core::atomic::{AtomicBool, AtomicInt, AtomicUint, AtomicPtr};
+pub use core::atomic::{Ordering, Relaxed, Release, Acquire, AcqRel, SeqCst};
+pub use core::atomic::{INIT_ATOMIC_BOOL, INIT_ATOMIC_INT, INIT_ATOMIC_UINT};
+pub use core::atomic::fence;
 
 /// An atomic, nullable unique pointer
 ///
 /// This can be used as the concurrency primitive for operations that transfer
 /// owned heap objects across tasks.
 #[unsafe_no_drop_flag]
+#[deprecated = "no longer used; will eventually be replaced by a higher-level\
+                concept like MVar"]
 pub struct AtomicOption<T> {
     p: AtomicUint,
 }
@@ -227,4 +229,3 @@ mod test {
         assert!(p.take(SeqCst) == Some(box 2));
     }
 }
-

--- a/src/libsync/deque.rs
+++ b/src/libsync/deque.rs
@@ -61,7 +61,7 @@ use core::mem::{forget, min_align_of, size_of, transmute};
 use core::ptr;
 use rustrt::exclusive::Exclusive;
 
-use atomics::{AtomicInt, AtomicPtr, SeqCst};
+use atomic::{AtomicInt, AtomicPtr, SeqCst};
 
 // Once the queue is less than 1/K full, then it will be downsized. Note that
 // the deque requires that this number be less than 2.
@@ -414,7 +414,7 @@ mod tests {
     use std::rt::thread::Thread;
     use std::rand;
     use std::rand::Rng;
-    use atomics::{AtomicBool, INIT_ATOMIC_BOOL, SeqCst,
+    use atomic::{AtomicBool, INIT_ATOMIC_BOOL, SeqCst,
                   AtomicUint, INIT_ATOMIC_UINT};
     use std::vec;
 

--- a/src/libsync/lib.rs
+++ b/src/libsync/lib.rs
@@ -49,7 +49,7 @@ pub use raw::{Semaphore, SemaphoreGuard};
 
 // Core building blocks for all primitives in this crate
 
-pub mod atomics;
+pub mod atomic;
 
 // Concurrent data structures
 

--- a/src/libsync/mpmc_bounded_queue.rs
+++ b/src/libsync/mpmc_bounded_queue.rs
@@ -37,7 +37,7 @@ use collections::Vec;
 use core::num::next_power_of_two;
 use core::cell::UnsafeCell;
 
-use atomics::{AtomicUint,Relaxed,Release,Acquire};
+use atomic::{AtomicUint,Relaxed,Release,Acquire};
 
 struct Node<T> {
     sequence: AtomicUint,

--- a/src/libsync/mpsc_queue.rs
+++ b/src/libsync/mpsc_queue.rs
@@ -46,7 +46,7 @@ use alloc::boxed::Box;
 use core::mem;
 use core::cell::UnsafeCell;
 
-use atomics::{AtomicPtr, Release, Acquire, AcqRel, Relaxed};
+use atomic::{AtomicPtr, Release, Acquire, AcqRel, Relaxed};
 
 /// A result of the `pop` function.
 pub enum PopResult<T> {

--- a/src/libsync/spsc_queue.rs
+++ b/src/libsync/spsc_queue.rs
@@ -42,7 +42,7 @@ use core::mem;
 use core::cell::UnsafeCell;
 use alloc::arc::Arc;
 
-use atomics::{AtomicPtr, Relaxed, AtomicUint, Acquire, Release};
+use atomic::{AtomicPtr, Relaxed, AtomicUint, Acquire, Release};
 
 // Node within the linked list queue of messages to send
 struct Node<T> {

--- a/src/test/compile-fail/std-uncopyable-atomics.rs
+++ b/src/test/compile-fail/std-uncopyable-atomics.rs
@@ -12,7 +12,7 @@
 
 #![feature(globs)]
 
-use std::sync::atomics::*;
+use std::sync::atomic::*;
 use std::ptr;
 
 fn main() {


### PR DESCRIPTION
This commit stabilizes the `std::sync::atomics` module, renaming it to
`std::sync::atomic` to match library precedent elsewhere, and tightening
up behavior around incorrect memory ordering annotations.

The vast majority of the module is now `stable`. However, the
`AtomicOption` type has been deprecated, since it is essentially unused
and is not truly a primitive atomic type. It will eventually be replaced
by a higher-level abstraction like MVars.

Due to deprecations, this is a:

[breaking-change]
