### PR TITLE
Add support for 64-bit Windows builds

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -377,7 +377,7 @@ RUSTC_CROSS_FLAGS_arm-unknown-linux-gnueabi :=
 # mipsel-linux configuration
 CC_mipsel-linux=mipsel-linux-gcc
 CXX_mipsel-linux=mipsel-linux-g++
-CPP_mipsel-linux=mipsel-linux-gcc 
+CPP_mipsel-linux=mipsel-linux-gcc
 AR_mipsel-linux=mipsel-linux-ar
 CFG_LIB_NAME_mipsel-linux=lib$(1).so
 CFG_STATIC_LIB_NAME_mipsel-linux=lib$(1).a
@@ -641,7 +641,7 @@ define CFG_MAKE_TOOLCHAIN
 	CXX_$(1)=$(CROSS_PREFIX_$(1))$(CXX_$(1))
 	CPP_$(1)=$(CROSS_PREFIX_$(1))$(CPP_$(1))
 	AR_$(1)=$(CROSS_PREFIX_$(1))$(AR_$(1))
-	RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(call FIND_COMPILER,$$(CXX_$(1))) \
+	RUSTC_CROSS_FLAGS_$(1)=-C linker=$$(call FIND_COMPILER,$$(CC_$(1))) \
 	    -C ar=$$(call FIND_COMPILER,$$(AR_$(1))) $(RUSTC_CROSS_FLAGS_$(1))
 
 	RUSTC_FLAGS_$(1)=$$(RUSTC_CROSS_FLAGS_$(1)) $(RUSTC_FLAGS_$(1))

--- a/src/etc/get-snapshot.py
+++ b/src/etc/get-snapshot.py
@@ -53,7 +53,7 @@ if len(sys.argv) == 3:
   dl_path = sys.argv[2]
 else:
   # There are no 64-bit Windows snapshots yet, so we'll use 32-bit ones instead, for now
-  snap_triple = triple if triple != "x86_64-w64-mingw32" else "i686-pc-mingw32"
+  snap_triple = triple if triple != "x86_64-w64-mingw32" else "i686-w64-mingw32"
   snap = determine_curr_snapshot(snap_triple)
   dl = os.path.join(download_dir_base, snap)
   url = download_url_base + "/" + snap

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -105,11 +105,11 @@ impl Context {
             // invalid for the current task. Lucky for us `rust_swap_registers`
             // is a C function so we don't have to worry about that!
             match in_context.stack_bounds {
-                Some((lo, hi)) => stack::record_stack_bounds_green(lo, hi),
+                Some((lo, hi)) => stack::record_rust_managed_stack_bounds(lo, hi),
                 // If we're going back to one of the original contexts or
                 // something that's possibly not a "normal task", then reset
                 // the stack limit to 0 to make morestack never fail
-                None => stack::record_stack_bounds_green(0, uint::MAX),
+                None => stack::record_rust_managed_stack_bounds(0, uint::MAX),
             }
             rust_swap_registers(out_regs, in_regs)
         }

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -13,6 +13,8 @@ use std::uint;
 use std::mem::transmute;
 use std::rt::stack;
 use std::raw;
+#[cfg(target_arch = "x86_64")]
+use std::simd;
 
 // FIXME #7761: Registers is boxed so that it is 16-byte aligned, for storing
 // SSE regs.  It would be marginally better not to do this. In C++ we
@@ -186,14 +188,30 @@ fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,
 // windows requires saving more registers (both general and XMM), so the windows
 // register context must be larger.
 #[cfg(windows, target_arch = "x86_64")]
-type Registers = [uint, ..34];
+struct Registers {
+    gpr:[uint, ..14],
+    _xmm:[simd::u32x4, ..10]
+}
 #[cfg(not(windows), target_arch = "x86_64")]
-type Registers = [uint, ..22];
+struct Registers {
+    gpr:[uint, ..10],
+    _xmm:[simd::u32x4, ..6]
+}
 
 #[cfg(windows, target_arch = "x86_64")]
-fn new_regs() -> Box<Registers> { box() ([0, .. 34]) }
+fn new_regs() -> Box<Registers> {
+    box() Registers {
+        gpr:[0,..14],
+        _xmm:[simd::u32x4(0,0,0,0),..10]
+    }
+}
 #[cfg(not(windows), target_arch = "x86_64")]
-fn new_regs() -> Box<Registers> { box() ([0, .. 22]) }
+fn new_regs() -> Box<Registers> {
+    box() Registers {
+        gpr:[0,..10],
+        _xmm:[simd::u32x4(0,0,0,0),..6]
+    }
+}
 
 #[cfg(target_arch = "x86_64")]
 fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,
@@ -222,20 +240,20 @@ fn initialize_call_frame(regs: &mut Registers, fptr: InitFn, arg: uint,
 
     // These registers are frobbed by rust_bootstrap_green_task into the right
     // location so we can invoke the "real init function", `fptr`.
-    regs[RUSTRT_R12] = arg as uint;
-    regs[RUSTRT_R13] = procedure.code as uint;
-    regs[RUSTRT_R14] = procedure.env as uint;
-    regs[RUSTRT_R15] = fptr as uint;
+    regs.gpr[RUSTRT_R12] = arg as uint;
+    regs.gpr[RUSTRT_R13] = procedure.code as uint;
+    regs.gpr[RUSTRT_R14] = procedure.env as uint;
+    regs.gpr[RUSTRT_R15] = fptr as uint;
 
     // These registers are picked up by the regular context switch paths. These
     // will put us in "mostly the right context" except for frobbing all the
     // arguments to the right place. We have the small trampoline code inside of
     // rust_bootstrap_green_task to do that.
-    regs[RUSTRT_RSP] = sp as uint;
-    regs[RUSTRT_IP] = rust_bootstrap_green_task as uint;
+    regs.gpr[RUSTRT_RSP] = sp as uint;
+    regs.gpr[RUSTRT_IP] = rust_bootstrap_green_task as uint;
 
     // Last base pointer on the stack should be 0
-    regs[RUSTRT_RBP] = 0;
+    regs.gpr[RUSTRT_RBP] = 0;
 }
 
 #[cfg(target_arch = "arm")]

--- a/src/libgreen/context.rs
+++ b/src/libgreen/context.rs
@@ -105,11 +105,11 @@ impl Context {
             // invalid for the current task. Lucky for us `rust_swap_registers`
             // is a C function so we don't have to worry about that!
             match in_context.stack_bounds {
-                Some((lo, hi)) => stack::record_stack_bounds(lo, hi),
+                Some((lo, hi)) => stack::record_stack_bounds_green(lo, hi),
                 // If we're going back to one of the original contexts or
                 // something that's possibly not a "normal task", then reset
                 // the stack limit to 0 to make morestack never fail
-                None => stack::record_stack_bounds(0, uint::MAX),
+                None => stack::record_stack_bounds_green(0, uint::MAX),
             }
             rust_swap_registers(out_regs, in_regs)
         }

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -137,7 +137,7 @@ pub fn start(argc: int, argv: *const *const u8, main: proc()) -> int {
     task.name = Some(str::Slice("<main>"));
     drop(task.run(|| {
         unsafe {
-            rt::stack::record_stack_bounds(my_stack_bottom, my_stack_top);
+            rt::stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);
         }
         exit_code = Some(run(main.take_unwrap()));
     }).destroy());

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -84,7 +84,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc():Send) {
         let addr = &something_around_the_top_of_the_stack as *const int;
         let my_stack = addr as uint;
         unsafe {
-            stack::record_stack_bounds(my_stack - stack + 1024, my_stack);
+            stack::record_os_managed_stack_bounds(my_stack - stack + 1024, my_stack);
         }
         let mut ops = ops;
         ops.stack_bounds = (my_stack - stack + 1024, my_stack);

--- a/src/librustrt/libunwind.rs
+++ b/src/librustrt/libunwind.rs
@@ -60,7 +60,7 @@ pub type _Unwind_Word = libc::uintptr_t;
 pub static unwinder_private_data_size: uint = 5;
 
 #[cfg(target_arch = "x86_64")]
-pub static unwinder_private_data_size: uint = 2;
+pub static unwinder_private_data_size: uint = 6;
 
 #[cfg(target_arch = "arm", not(target_os = "ios"))]
 pub static unwinder_private_data_size: uint = 20;

--- a/src/librustrt/stack.rs
+++ b/src/librustrt/stack.rs
@@ -125,7 +125,7 @@ extern fn stack_exhausted() {
 }
 
 #[inline(always)]
-pub unsafe fn record_stack_bounds(stack_lo: uint, stack_hi: uint) {
+pub unsafe fn record_stack_bounds_green(stack_lo: uint, stack_hi: uint) {
     // When the old runtime had segmented stacks, it used a calculation that was
     // "limit + RED_ZONE + FUDGE". The red zone was for things like dynamic
     // symbol resolution, llvm function calls, etc. In theory this red zone
@@ -152,6 +152,11 @@ pub unsafe fn record_stack_bounds(stack_lo: uint, stack_hi: uint) {
         asm!("mov $0, %gs:0x08" :: "r"(stack_hi) :: "volatile");
         asm!("mov $0, %gs:0x10" :: "r"(stack_lo) :: "volatile");
     }
+}
+
+#[inline(always)]
+pub unsafe fn record_stack_bounds(stack_lo: uint, _stack_hi: uint) {
+    record_sp_limit(stack_lo + RED_ZONE);
 }
 
 /// Records the current limit of the stack as specified by `end`.

--- a/src/librustrt/stack.rs
+++ b/src/librustrt/stack.rs
@@ -124,8 +124,23 @@ extern fn stack_exhausted() {
     }
 }
 
+// Windows maintains a record of upper and lower stack bounds in the Thread Information
+// Block (TIB), and some syscalls do check that addresses which are supposed to be in
+// the stack, indeed lie between these two values.
+// (See https://github.com/rust-lang/rust/issues/3445#issuecomment-26114839)
+//
+// When using Rust-managed stacks (libgreen), we must maintain these values accordingly.
+// For OS-managed stacks (libnative), we let the OS manage them for us.
+//
+// On all other platforms both variants behave identically.
+
 #[inline(always)]
-pub unsafe fn record_stack_bounds_green(stack_lo: uint, stack_hi: uint) {
+pub unsafe fn record_os_managed_stack_bounds(stack_lo: uint, _stack_hi: uint) {
+    record_sp_limit(stack_lo + RED_ZONE);
+}
+
+#[inline(always)]
+pub unsafe fn record_rust_managed_stack_bounds(stack_lo: uint, stack_hi: uint) {
     // When the old runtime had segmented stacks, it used a calculation that was
     // "limit + RED_ZONE + FUDGE". The red zone was for things like dynamic
     // symbol resolution, llvm function calls, etc. In theory this red zone
@@ -138,25 +153,21 @@ pub unsafe fn record_stack_bounds_green(stack_lo: uint, stack_hi: uint) {
 
     return target_record_stack_bounds(stack_lo, stack_hi);
 
-    #[cfg(not(windows))] #[cfg(not(target_arch = "x86_64"))] #[inline(always)]
+    #[cfg(not(windows))] #[inline(always)]
     unsafe fn target_record_stack_bounds(_stack_lo: uint, _stack_hi: uint) {}
+
+    #[cfg(windows, target_arch = "x86")] #[inline(always)]
+    unsafe fn target_record_stack_bounds(stack_lo: uint, stack_hi: uint) {
+        // stack range is at TIB: %fs:0x04 (top) and %fs:0x08 (bottom)
+        asm!("mov $0, %fs:0x04" :: "r"(stack_hi) :: "volatile");
+        asm!("mov $0, %fs:0x08" :: "r"(stack_lo) :: "volatile");
+    }
     #[cfg(windows, target_arch = "x86_64")] #[inline(always)]
     unsafe fn target_record_stack_bounds(stack_lo: uint, stack_hi: uint) {
-        // Windows compiles C functions which may check the stack bounds. This
-        // means that if we want to perform valid FFI on windows, then we need
-        // to ensure that the stack bounds are what they truly are for this
-        // task. More info can be found at:
-        //   https://github.com/rust-lang/rust/issues/3445#issuecomment-26114839
-        //
         // stack range is at TIB: %gs:0x08 (top) and %gs:0x10 (bottom)
         asm!("mov $0, %gs:0x08" :: "r"(stack_hi) :: "volatile");
         asm!("mov $0, %gs:0x10" :: "r"(stack_lo) :: "volatile");
     }
-}
-
-#[inline(always)]
-pub unsafe fn record_stack_bounds(stack_lo: uint, _stack_hi: uint) {
-    record_sp_limit(stack_lo + RED_ZONE);
 }
 
 /// Records the current limit of the stack as specified by `end`.

--- a/src/librustrt/thread.rs
+++ b/src/librustrt/thread.rs
@@ -44,7 +44,7 @@ static DEFAULT_STACK_SIZE: uint = 1024 * 1024;
 #[no_split_stack]
 extern fn thread_start(main: *mut libc::c_void) -> imp::rust_thread_return {
     unsafe {
-        stack::record_stack_bounds(0, uint::MAX);
+        stack::record_os_managed_stack_bounds(0, uint::MAX);
         let f: Box<proc()> = mem::transmute(main);
         (*f)();
         mem::transmute(0 as imp::rust_thread_return)

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -136,10 +136,11 @@ mod imp {
     use rand::Rng;
     use result::{Ok, Err};
     use rt::stack;
-    use self::libc::{c_ulong, DWORD, BYTE, LPCSTR, BOOL};
+    use self::libc::{DWORD, BYTE, LPCSTR, BOOL};
+    use self::libc::types::os::arch::extra::{LONG_PTR};
     use slice::MutableVector;
 
-    type HCRYPTPROV = c_ulong;
+    type HCRYPTPROV = LONG_PTR;
 
     /// A random number generator that retrieves randomness straight from
     /// the operating system. Platform sources:

--- a/src/rt/rust_try.ll
+++ b/src/rt/rust_try.ll
@@ -11,6 +11,7 @@
 ; Rust's try-catch
 ; When f(...) returns normally, the return value is null.
 ; When f(...) throws, the return value is a pointer to the caught exception object.
+
 ; See also: librustrt/unwind.rs
 
 define i8* @rust_try(void (i8*,i8*)* %f, i8* %fptr, i8* %env) {
@@ -25,7 +26,7 @@ normal:
 catch:
     landingpad { i8*, i32 } personality i8* bitcast (i32 (...)* @rust_eh_personality_catch to i8*)
         catch i8* null
-    ; execution will never reach here because rust_try_inner's landing pad does not resume unwinds
+    ; rust_try_inner's landing pad does not resume unwinds, so execution will never reach here
     ret i8* null
 }
 

--- a/src/rt/rust_try.ll
+++ b/src/rt/rust_try.ll
@@ -11,24 +11,40 @@
 ; Rust's try-catch
 ; When f(...) returns normally, the return value is null.
 ; When f(...) throws, the return value is a pointer to the caught exception object.
-; See also: libstd/rt/unwind.rs
+; See also: librustrt/unwind.rs
 
 define i8* @rust_try(void (i8*,i8*)* %f, i8* %fptr, i8* %env) {
 
-	invoke void %f(i8* %fptr, i8* %env)
-		to label %normal
-		unwind label %catch
+    %1 = invoke i8* @rust_try_inner(void (i8*,i8*)* %f, i8* %fptr, i8* %env)
+        to label %normal
+        unwind label %catch
 
 normal:
-	ret i8* null
+    ret i8* %1
 
 catch:
-	%1 = landingpad { i8*, i32 } personality i8* bitcast (i32 (...)* @rust_eh_personality_catch to i8*)
-			catch i8* null ; catch everything
-
-	; extract and return pointer to the exception object
-    %2 = extractvalue { i8*, i32 } %1, 0
-	ret i8* %2
+    landingpad { i8*, i32 } personality i8* bitcast (i32 (...)* @rust_eh_personality_catch to i8*)
+        catch i8* null
+    ; execution will never reach here because rust_try_inner's landing pad does not resume unwinds
+    ret i8* null
 }
 
+define internal i8* @rust_try_inner(void (i8*,i8*)* %f, i8* %fptr, i8* %env) {
+
+    invoke void %f(i8* %fptr, i8* %env)
+        to label %normal
+        unwind label %catch
+
+normal:
+    ret i8* null
+
+catch:
+    %1 = landingpad { i8*, i32 } personality i8* bitcast (i32 (...)* @rust_eh_personality to i8*)
+        catch i8* null
+    ; extract and return pointer to the exception object
+    %2 = extractvalue { i8*, i32 } %1, 0
+    ret i8* %2
+}
+
+declare i32 @rust_eh_personality(...)
 declare i32 @rust_eh_personality_catch(...)

--- a/src/rt/valgrind/valgrind.h
+++ b/src/rt/valgrind/valgrind.h
@@ -21,16 +21,16 @@
    1. Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
 
-   2. The origin of this software must not be misrepresented; you must 
-      not claim that you wrote the original software.  If you use this 
-      software in a product, an acknowledgment in the product 
+   2. The origin of this software must not be misrepresented; you must
+      not claim that you wrote the original software.  If you use this
+      software in a product, an acknowledgment in the product
       documentation would be appreciated but is not required.
 
    3. Altered source versions must be plainly marked as such, and must
       not be misrepresented as being the original software.
 
-   4. The name of the author may not be used to endorse or promote 
-      products derived from this software without specific prior written 
+   4. The name of the author may not be used to endorse or promote
+      products derived from this software without specific prior written
       permission.
 
    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
@@ -52,13 +52,13 @@
    the terms of the GNU General Public License, version 2.  See the
    COPYING file in the source distribution for details.
 
-   ---------------------------------------------------------------- 
+   ----------------------------------------------------------------
 */
 
 
 /* This file is for inclusion into client (your!) code.
 
-   You can use these macros to manipulate and query Valgrind's 
+   You can use these macros to manipulate and query Valgrind's
    execution inside your own programs.
 
    The resulting executables will still run without Valgrind, just a
@@ -126,11 +126,11 @@
 #  define PLAT_x86_darwin 1
 #elif defined(__APPLE__) && defined(__x86_64__)
 #  define PLAT_amd64_darwin 1
+#elif defined(__MINGW64__) || (defined(_WIN64) && defined(_M_X64))
+#  define PLAT_amd64_win64 1
 #elif defined(__MINGW32__) || defined(__CYGWIN32__) \
       || (defined(_WIN32) && defined(_M_IX86))
 #  define PLAT_x86_win32 1
-#elif defined(__MINGW64__) || (defined(_WIN64) && defined(_M_X64))
-#  define PLAT_amd64_win64 1
 #elif defined(__linux__) && defined(__i386__)
 #  define PLAT_x86_linux 1
 #elif defined(__linux__) && defined(__x86_64__)
@@ -214,8 +214,8 @@
    this is executed not under Valgrind.  Args are passed in a memory
    block, and so there's no intrinsic limit to the number that could
    be passed, but it's currently five.
-   
-   The macro args are: 
+
+   The macro args are:
       _zzq_rlval    result lvalue
       _zzq_default  default value (result returned when running on real CPU)
       _zzq_request  request code
@@ -242,7 +242,7 @@
     ||  (defined(PLAT_x86_win32) && defined(__GNUC__))
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -306,7 +306,7 @@ typedef
 #if defined(PLAT_x86_win32) && !defined(__GNUC__)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -374,12 +374,13 @@ valgrind_do_client_request_expr(uintptr_t _zzq_default, uintptr_t _zzq_request,
 
 #endif /* PLAT_x86_win32 */
 
-/* ------------------------ amd64-{linux,darwin} --------------- */
+/* -------------------- amd64-{linux,darwin,win64} ------------- */
 
-#if defined(PLAT_amd64_linux)  ||  defined(PLAT_amd64_darwin)
+#if defined(PLAT_amd64_linux)  ||  defined(PLAT_amd64_darwin) \
+    || defined(PLAT_amd64_win64)
 
 typedef
-   struct { 
+   struct {
       unsigned long long int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -443,7 +444,7 @@ typedef
 #if defined(PLAT_ppc32_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -512,7 +513,7 @@ typedef
 #if defined(PLAT_ppc64_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned long long int nraddr; /* where's the code? */
       unsigned long long int r2;  /* what tocptr do we need? */
    }
@@ -591,7 +592,7 @@ typedef
 #if defined(PLAT_arm_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -736,7 +737,7 @@ typedef
 #if defined(PLAT_mips32_linux)
 
 typedef
-   struct { 
+   struct {
       unsigned int nraddr; /* where's the code? */
    }
    OrigFn;
@@ -750,7 +751,7 @@ typedef
                      "srl $0, $0, 29\n\t"       \
                      "srl $0, $0, 3\n\t"        \
                      "srl $0, $0, 19\n\t"
-                    
+
 #define VALGRIND_DO_CLIENT_REQUEST_EXPR(                          \
        _zzq_default, _zzq_request,                                \
        _zzq_arg1, _zzq_arg2, _zzq_arg3, _zzq_arg4, _zzq_arg5)     \
@@ -1999,7 +2000,7 @@ typedef
 #define VALGRIND_RESTORE_STACK             \
       "mr 1,28\n\t"
 
-/* These CALL_FN_ macros assume that on ppc32-linux, 
+/* These CALL_FN_ macros assume that on ppc32-linux,
    sizeof(unsigned long) == 4. */
 
 #define CALL_FN_W_v(lval, orig)                                   \
@@ -3509,7 +3510,7 @@ typedef
 #define __CALLER_SAVED_REGS "0","1","2","3","4","5","14", \
                            "f0","f1","f2","f3","f4","f5","f6","f7"
 
-/* Nb: Although r11 is modified in the asm snippets below (inside 
+/* Nb: Although r11 is modified in the asm snippets below (inside
    VALGRIND_CFI_PROLOGUE) it is not listed in the clobber section, for
    two reasons:
    (1) r11 is restored in VALGRIND_CFI_EPILOGUE, so effectively it is not
@@ -3959,7 +3960,7 @@ typedef
 #endif /* PLAT_s390x_linux */
 
 /* ------------------------- mips32-linux ----------------------- */
- 
+
 #if defined(PLAT_mips32_linux)
 
 /* These regs are trashed by the hidden call. */
@@ -4935,7 +4936,7 @@ typedef
 #define VG_IS_TOOL_USERREQ(a, b, v) \
    (VG_USERREQ_TOOL_BASE(a,b) == ((v) & 0xffff0000))
 
-/* !! ABIWARNING !! ABIWARNING !! ABIWARNING !! ABIWARNING !! 
+/* !! ABIWARNING !! ABIWARNING !! ABIWARNING !! ABIWARNING !!
    This enum comprises an ABI exported by Valgrind to programs
    which use client requests.  DO NOT CHANGE THE ORDER OF THESE
    ENTRIES, NOR DELETE ANY -- add new ones at the end. */
@@ -5073,7 +5074,7 @@ VALGRIND_PRINTF(const char *format, ...)
    _qzz_res = VALGRIND_DO_CLIENT_REQUEST_EXPR(0,
                               VG_USERREQ__PRINTF_VALIST_BY_REF,
                               (unsigned long)format,
-                              (unsigned long)&vargs, 
+                              (unsigned long)&vargs,
                               0, 0, 0);
 #endif
    va_end(vargs);
@@ -5111,7 +5112,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    _qzz_res = VALGRIND_DO_CLIENT_REQUEST_EXPR(0,
                               VG_USERREQ__PRINTF_BACKTRACE_VALIST_BY_REF,
                               (unsigned long)format,
-                              (unsigned long)&vargs, 
+                              (unsigned long)&vargs,
                               0, 0, 0);
 #endif
    va_end(vargs);
@@ -5122,7 +5123,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
 
 /* These requests allow control to move from the simulated CPU to the
    real CPU, calling an arbitary function.
-   
+
    Note that the current ThreadId is inserted as the first argument.
    So this call:
 
@@ -5208,7 +5209,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    - It marks the block as being addressable and undefined (if 'is_zeroed' is
      not set), or addressable and defined (if 'is_zeroed' is set).  This
      controls how accesses to the block by the program are handled.
-   
+
    'addr' is the start of the usable block (ie. after any
    redzone), 'sizeB' is its size.  'rzB' is the redzone size if the allocator
    can apply redzones -- these are blocks of padding at the start and end of
@@ -5216,7 +5217,7 @@ VALGRIND_PRINTF_BACKTRACE(const char *format, ...)
    Valgrind will spot block overruns.  `is_zeroed' indicates if the memory is
    zeroed (or filled with another predictable value), as is the case for
    calloc().
-   
+
    VALGRIND_MALLOCLIKE_BLOCK should be put immediately after the point where a
    heap block -- that will be used by the client program -- is allocated.
    It's best to put it at the outermost level of the allocator if possible;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -282,7 +282,7 @@ extern "C" LLVMValueRef LLVMDIBuilderCreateSubroutineType(
     LLVMValueRef ParameterTypes) {
     return wrap(Builder->createSubroutineType(
         unwrapDI<DIFile>(File),
-        unwrapDI<DIArray>(ParameterTypes)));
+        unwrapDI<DITypeArray>(ParameterTypes)));
 }
 
 extern "C" LLVMValueRef LLVMDIBuilderCreateFunction(
@@ -634,7 +634,7 @@ extern "C" void LLVMDICompositeTypeSetTypeArray(
     LLVMValueRef CompositeType,
     LLVMValueRef TypeArray)
 {
-    unwrapDI<DICompositeType>(CompositeType).setTypeArray(unwrapDI<DIArray>(TypeArray));
+    unwrapDI<DICompositeType>(CompositeType).setArrays(unwrapDI<DIArray>(TypeArray));
 }
 
 extern "C" char *LLVMTypeToString(LLVMTypeRef Type) {

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2014-07-29
+2014-08-24

--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2014-08-24
+2014-08-05

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -51,6 +51,15 @@ mod m {
             assert_eq!(::rusti::min_align_of::<u64>(), 8u);
         }
     }
+
+    #[main]
+    #[cfg(target_arch = "x86_64")]
+    pub fn main() {
+        unsafe {
+            assert_eq!(::rusti::pref_align_of::<u64>(), 8u);
+            assert_eq!(::rusti::min_align_of::<u64>(), 8u);
+        }
+    }
 }
 
 #[cfg(target_os = "android")]

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -61,6 +61,12 @@ mod m {
         pub fn align() -> uint { 8u }
         pub fn size() -> uint { 16u }
     }
+
+    #[cfg(target_arch = "x86_64")]
+    pub mod m {
+        pub fn align() -> uint { 8u }
+        pub fn size() -> uint { 16u }
+    }
 }
 
 #[cfg(target_os = "android")]


### PR DESCRIPTION
Finally landed all the required fixes in LLVM master!

These 4 tests currently fail in win64 build, I suspect there's some ABI conformance bug:
run-pass/extern-pass-TwoU64s.rs
run-pass/extern-pass-empty.rs
run-pass/extern-return-TwoU64s.rs
run-pass/tcp-connect-timeouts.rs

Closes #1237
