### PR TITLE
syntax: Handle \r\n in byte string literals

### DIFF
--- a/src/test/run-pass/.gitattributes
+++ b/src/test/run-pass/.gitattributes
@@ -1,1 +1,2 @@
 lexer-crlf-line-endings-string-literal-doc-comment.rs -text
+issue-16278.rs -text

--- a/src/test/run-pass/issue-16278.rs
+++ b/src/test/run-pass/issue-16278.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-cr
+
+// this file has some special \r\n endings (use xxd to see them)
+
+fn main() {assert_eq!(b"", b"\
+                                   ");
+assert_eq!(b"\n", b"
+");
+}
+


### PR DESCRIPTION
This ended up passing through the lexer but dying later on in parsing when it
wasn't handled. The strategy taken was to copy the `str_lit` funciton, but adapt
it for bytes.

Closes #16278
