### PR TITLE
native, rustuv: Fix spawning with empty args

### DIFF
--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -479,7 +479,10 @@ fn make_command_line(prog: &CString, args: &[CString]) -> String {
     return cmd;
 
     fn append_arg(cmd: &mut String, arg: &str) {
-        let quote = arg.chars().any(|c| c == ' ' || c == '\t');
+        // If an argument has 0 characters then we need to quote it to ensure
+        // that it actually gets passed through on the command line or otherwise
+        // it will be dropped entirely when parsed on the other end.
+        let quote = arg.chars().any(|c| c == ' ' || c == '\t') || arg.len() == 0;
         if quote {
             cmd.push_char('"');
         }

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -137,7 +137,7 @@ fn socket_name(sk: SocketNameKind,
 
     let sockaddr_p = &mut sockaddr as *mut libc::sockaddr_storage;
     match unsafe {
-        getsockname(handle, sockaddr_p as *mut libc::sockaddr, &mut namelen)
+        getsockname(&*handle, sockaddr_p as *mut libc::sockaddr, &mut namelen)
     } {
         0 => Ok(sockaddr_to_addr(&sockaddr, namelen as uint)),
         n => Err(uv_error_to_io_error(UvError(n)))
@@ -365,7 +365,7 @@ impl TcpListener {
         let _len = addr_to_sockaddr(address, &mut storage);
         let res = unsafe {
             let addr_p = &storage as *const _ as *const libc::sockaddr;
-            uvll::uv_tcp_bind(l.handle, addr_p)
+            uvll::uv_tcp_bind(l.handle, addr_p, 0)
         };
         return match res {
             0 => Ok(l.install()),

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -312,6 +312,7 @@ pub enum uv_req_type {
     UV_FS,
     UV_WORK,
     UV_GETADDRINFO,
+    UV_GETNAMEINFO,
     UV_REQ_TYPE_MAX
 }
 
@@ -329,6 +330,7 @@ pub enum uv_req_type {
     UV_UDP_SEND,
     UV_FS,
     UV_WORK,
+    UV_GETNAMEINFO,
     UV_GETADDRINFO,
     UV_ACCEPT,
     UV_FS_EVENT_REQ,
@@ -578,14 +580,16 @@ extern {
     pub fn uv_tcp_init(l: *mut uv_loop_t, h: *mut uv_tcp_t) -> c_int;
     pub fn uv_tcp_connect(c: *mut uv_connect_t, h: *mut uv_tcp_t,
                           addr: *const sockaddr, cb: uv_connect_cb) -> c_int;
-    pub fn uv_tcp_bind(t: *mut uv_tcp_t, addr: *const sockaddr) -> c_int;
+    pub fn uv_tcp_bind(t: *mut uv_tcp_t,
+                       addr: *const sockaddr,
+                       flags: c_uint) -> c_int;
     pub fn uv_tcp_nodelay(h: *mut uv_tcp_t, enable: c_int) -> c_int;
     pub fn uv_tcp_keepalive(h: *mut uv_tcp_t, enable: c_int,
                             delay: c_uint) -> c_int;
     pub fn uv_tcp_simultaneous_accepts(h: *mut uv_tcp_t, enable: c_int) -> c_int;
-    pub fn uv_tcp_getsockname(h: *mut uv_tcp_t, name: *mut sockaddr,
+    pub fn uv_tcp_getsockname(h: *const uv_tcp_t, name: *mut sockaddr,
                               len: *mut c_int) -> c_int;
-    pub fn uv_tcp_getpeername(h: *mut uv_tcp_t, name: *mut sockaddr,
+    pub fn uv_tcp_getpeername(h: *const uv_tcp_t, name: *mut sockaddr,
                               len: *mut c_int) -> c_int;
 
     // udp bindings
@@ -604,7 +608,7 @@ extern {
     pub fn uv_udp_set_multicast_ttl(handle: *mut uv_udp_t, ttl: c_int) -> c_int;
     pub fn uv_udp_set_ttl(handle: *mut uv_udp_t, ttl: c_int) -> c_int;
     pub fn uv_udp_set_broadcast(handle: *mut uv_udp_t, on: c_int) -> c_int;
-    pub fn uv_udp_getsockname(h: *mut uv_udp_t, name: *mut sockaddr,
+    pub fn uv_udp_getsockname(h: *const uv_udp_t, name: *mut sockaddr,
                               len: *mut c_int) -> c_int;
 
     // timer bindings

--- a/src/test/run-pass/issue-15149.rs
+++ b/src/test/run-pass/issue-15149.rs
@@ -18,9 +18,7 @@ use std::io::{TempDir, Command, fs};
 use std::os;
 use std::task::TaskBuilder;
 
-// FIXME(#15149) libgreen still needs to be update. There is an open PR for it
-//               but it is not yet merged.
-// green_start!(main)
+green_start!(main)
 
 fn main() {
     // If we're the child, make sure we were invoked correctly

--- a/src/test/run-pass/issue-16272.rs
+++ b/src/test/run-pass/issue-16272.rs
@@ -1,0 +1,45 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(phase)]
+#[phase(plugin)]
+extern crate green;
+extern crate native;
+
+use native::NativeTaskBuilder;
+use std::io::{process, Command};
+use std::os;
+use std::task::TaskBuilder;
+
+green_start!(main)
+
+fn main() {
+    let len = os::args().len();
+
+    if len == 1 {
+        test();
+        let (tx, rx) = channel();
+        TaskBuilder::new().native().spawn(proc() {
+            tx.send(test());
+        });
+        rx.recv();
+    } else {
+        assert_eq!(len, 3);
+    }
+}
+
+fn test() {
+    let status = Command::new(os::self_exe_name().unwrap())
+                         .arg("foo").arg("")
+                         .stdout(process::InheritFd(1))
+                         .stderr(process::InheritFd(2))
+                         .status().unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
There was a bug in both libnative and libuv which prevented child processes from
being spawned correctly on windows when one of the arguments was an empty
string. The libuv bug has since been fixed upstream, and the libnative bug was
fixed as part of this commit.

When updating libuv, this also includes a fix for #15149.

Closes #15149
Closes #16272
