### PR TITLE
librustc: Stop assuming that implementations and traits only contain

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -563,9 +563,9 @@ impl<'a> Visitor<()> for Context<'a> {
         visit::walk_generics(self, g, ());
     }
 
-    fn visit_trait_method(&mut self, m: &ast::TraitMethod, _: ()) {
+    fn visit_trait_item(&mut self, m: &ast::TraitItem, _: ()) {
         run_lints!(self, check_trait_method, m);
-        visit::walk_trait_method(self, m, ());
+        visit::walk_trait_item(self, m, ());
     }
 
     fn visit_opt_lifetime_ref(&mut self, sp: Span, lt: &Option<ast::Lifetime>, _: ()) {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -141,7 +141,7 @@ pub trait LintPass {
     fn check_fn(&mut self, _: &Context,
         _: &FnKind, _: &ast::FnDecl, _: &ast::Block, _: Span, _: ast::NodeId) { }
     fn check_ty_method(&mut self, _: &Context, _: &ast::TypeMethod) { }
-    fn check_trait_method(&mut self, _: &Context, _: &ast::TraitMethod) { }
+    fn check_trait_method(&mut self, _: &Context, _: &ast::TraitItem) { }
     fn check_struct_def(&mut self, _: &Context,
         _: &ast::StructDef, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) { }
     fn check_struct_def_post(&mut self, _: &Context,

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -77,7 +77,7 @@ pub static tag_crate_dep_hash: uint = 0x1e;
 
 pub static tag_mod_impl: uint = 0x1f;
 
-pub static tag_item_trait_method: uint = 0x20;
+pub static tag_item_trait_item: uint = 0x20;
 
 pub static tag_item_trait_ref: uint = 0x21;
 pub static tag_item_super_trait_ref: uint = 0x22;
@@ -95,14 +95,14 @@ pub static tag_item_field_origin: uint = 0x29;
 
 pub static tag_item_variances: uint = 0x2a;
 /*
-  trait items contain tag_item_trait_method elements,
-  impl items contain tag_item_impl_method elements, and classes
+  trait items contain tag_item_trait_item elements,
+  impl items contain tag_item_impl_item elements, and classes
   have both. That's because some code treats classes like traits,
   and other code treats them like impls. Because classes can contain
-  both, tag_item_trait_method and tag_item_impl_method have to be two
+  both, tag_item_trait_item and tag_item_impl_item have to be two
   different tags.
  */
-pub static tag_item_impl_method: uint = 0x30;
+pub static tag_item_impl_item: uint = 0x30;
 pub static tag_item_trait_method_explicit_self: uint = 0x31;
 
 
@@ -154,9 +154,11 @@ impl astencode_tag {
     }
 }
 
-pub static tag_item_trait_method_sort: uint = 0x60;
+pub static tag_item_trait_item_sort: uint = 0x60;
 
-pub static tag_item_impl_type_basename: uint = 0x61;
+pub static tag_item_trait_parent_sort: uint = 0x61;
+
+pub static tag_item_impl_type_basename: uint = 0x62;
 
 pub static tag_crate_triple: uint = 0x66;
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -16,6 +16,7 @@ use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
 use middle::lang_items;
+use middle::resolve;
 use middle::ty;
 use middle::typeck;
 use middle::subst::VecPerParamSpace;
@@ -121,30 +122,33 @@ pub fn get_enum_variants(tcx: &ty::ctxt, def: ast::DefId)
 }
 
 /// Returns information about the given implementation.
-pub fn get_impl_methods(cstore: &cstore::CStore, impl_def_id: ast::DefId)
-                        -> Vec<ast::DefId> {
+pub fn get_impl_items(cstore: &cstore::CStore, impl_def_id: ast::DefId)
+                      -> Vec<ty::ImplOrTraitItemId> {
     let cdata = cstore.get_crate_data(impl_def_id.krate);
-    decoder::get_impl_methods(&*cdata, impl_def_id.node)
+    decoder::get_impl_items(&*cdata, impl_def_id.node)
 }
 
-pub fn get_method(tcx: &ty::ctxt, def: ast::DefId) -> ty::Method {
+pub fn get_impl_or_trait_item(tcx: &ty::ctxt, def: ast::DefId)
+                              -> ty::ImplOrTraitItem {
     let cdata = tcx.sess.cstore.get_crate_data(def.krate);
-    decoder::get_method(tcx.sess.cstore.intr.clone(), &*cdata, def.node, tcx)
+    decoder::get_impl_or_trait_item(tcx.sess.cstore.intr.clone(),
+                                    &*cdata,
+                                    def.node,
+                                    tcx)
 }
 
-pub fn get_method_name_and_explicit_self(cstore: &cstore::CStore,
-                                         def: ast::DefId)
-                                         -> (ast::Ident,
-                                             ty::ExplicitSelfCategory)
-{
+pub fn get_trait_item_name_and_kind(cstore: &cstore::CStore, def: ast::DefId)
+                                    -> (ast::Ident, resolve::TraitItemKind) {
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_method_name_and_explicit_self(cstore.intr.clone(), &*cdata, def.node)
+    decoder::get_trait_item_name_and_kind(cstore.intr.clone(),
+                                          &*cdata,
+                                          def.node)
 }
 
-pub fn get_trait_method_def_ids(cstore: &cstore::CStore,
-                                def: ast::DefId) -> Vec<ast::DefId> {
+pub fn get_trait_item_def_ids(cstore: &cstore::CStore, def: ast::DefId)
+                              -> Vec<ty::ImplOrTraitItemId> {
     let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_trait_method_def_ids(&*cdata, def.node)
+    decoder::get_trait_item_def_ids(&*cdata, def.node)
 }
 
 pub fn get_item_variances(cstore: &cstore::CStore,
@@ -286,15 +290,15 @@ pub fn each_implementation_for_trait(cstore: &cstore::CStore,
     decoder::each_implementation_for_trait(&*cdata, def_id.node, callback)
 }
 
-/// If the given def ID describes a method belonging to a trait (either a
+/// If the given def ID describes an item belonging to a trait (either a
 /// default method or an implementation of a trait method), returns the ID of
 /// the trait that the method belongs to. Otherwise, returns `None`.
-pub fn get_trait_of_method(cstore: &cstore::CStore,
-                           def_id: ast::DefId,
-                           tcx: &ty::ctxt)
-                           -> Option<ast::DefId> {
+pub fn get_trait_of_item(cstore: &cstore::CStore,
+                         def_id: ast::DefId,
+                         tcx: &ty::ctxt)
+                         -> Option<ast::DefId> {
     let cdata = cstore.get_crate_data(def_id.krate);
-    decoder::get_trait_of_method(&*cdata, def_id.node, tcx)
+    decoder::get_trait_of_item(&*cdata, def_id.node, tcx)
 }
 
 pub fn get_tuple_struct_definition_if_ctor(cstore: &cstore::CStore,

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -131,12 +131,14 @@ impl OverloadedCallType {
     fn from_method_id(tcx: &ty::ctxt, method_id: ast::DefId)
                       -> OverloadedCallType {
         let method_descriptor =
-            match tcx.methods.borrow_mut().find(&method_id) {
+            match tcx.impl_or_trait_items.borrow_mut().find(&method_id) {
+                Some(&ty::MethodTraitItem(ref method_descriptor)) => {
+                    (*method_descriptor).clone()
+                }
                 None => {
                     tcx.sess.bug("overloaded call method wasn't in method \
                                   map")
                 }
-                Some(ref method_descriptor) => (*method_descriptor).clone(),
             };
         let impl_id = match method_descriptor.container {
             ty::TraitContainer(_) => {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1140,13 +1140,17 @@ pub fn create_function_debug_context(cx: &CrateContext,
                 }
             }
         }
-        ast_map::NodeMethod(ref method) => {
-            (method.pe_ident(),
-             method.pe_fn_decl(),
-             method.pe_generics(),
-             method.pe_body(),
-             method.span,
-             true)
+        ast_map::NodeImplItem(ref item) => {
+            match **item {
+                ast::MethodImplItem(ref method) => {
+                    (method.pe_ident(),
+                     method.pe_fn_decl(),
+                     method.pe_generics(),
+                     method.pe_body(),
+                     method.span,
+                     true)
+                }
+            }
         }
         ast_map::NodeExpr(ref expr) => {
             match expr.node {
@@ -1168,9 +1172,9 @@ pub fn create_function_debug_context(cx: &CrateContext,
                         "create_function_debug_context: expected an expr_fn_block here")
             }
         }
-        ast_map::NodeTraitMethod(ref trait_method) => {
+        ast_map::NodeTraitItem(ref trait_method) => {
             match **trait_method {
-                ast::Provided(ref method) => {
+                ast::ProvidedMethod(ref method) => {
                     (method.pe_ident(),
                      method.pe_fn_decl(),
                      method.pe_generics(),

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -197,15 +197,25 @@ pub fn monomorphic_fn(ccx: &CrateContext,
             }
             d
         }
-        ast_map::NodeMethod(mth) => {
-            let d = mk_lldecl(abi::Rust);
-            set_llvm_fn_attrs(mth.attrs.as_slice(), d);
-            trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d, &psubsts, mth.id, []);
-            d
+        ast_map::NodeImplItem(ii) => {
+            match *ii {
+                ast::MethodImplItem(mth) => {
+                    let d = mk_lldecl(abi::Rust);
+                    set_llvm_fn_attrs(mth.attrs.as_slice(), d);
+                    trans_fn(ccx,
+                             &*mth.pe_fn_decl(),
+                             &*mth.pe_body(),
+                             d,
+                             &psubsts,
+                             mth.id,
+                             []);
+                    d
+                }
+            }
         }
-        ast_map::NodeTraitMethod(method) => {
+        ast_map::NodeTraitItem(method) => {
             match *method {
-                ast::Provided(mth) => {
+                ast::ProvidedMethod(mth) => {
                     let d = mk_lldecl(abi::Rust);
                     set_llvm_fn_attrs(mth.attrs.as_slice(), d);
                     trans_fn(ccx, &*mth.pe_fn_decl(), &*mth.pe_body(), d,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -76,9 +76,62 @@ pub struct field {
 }
 
 #[deriving(Clone)]
-pub enum MethodContainer {
+pub enum ImplOrTraitItemContainer {
     TraitContainer(ast::DefId),
     ImplContainer(ast::DefId),
+}
+
+impl ImplOrTraitItemContainer {
+    pub fn id(&self) -> ast::DefId {
+        match *self {
+            TraitContainer(id) => id,
+            ImplContainer(id) => id,
+        }
+    }
+}
+
+#[deriving(Clone)]
+pub enum ImplOrTraitItem {
+    MethodTraitItem(Rc<Method>),
+}
+
+impl ImplOrTraitItem {
+    fn id(&self) -> ImplOrTraitItemId {
+        match *self {
+            MethodTraitItem(ref method) => MethodTraitItemId(method.def_id),
+        }
+    }
+
+    pub fn def_id(&self) -> ast::DefId {
+        match *self {
+            MethodTraitItem(ref method) => method.def_id,
+        }
+    }
+
+    pub fn ident(&self) -> ast::Ident {
+        match *self {
+            MethodTraitItem(ref method) => method.ident,
+        }
+    }
+
+    pub fn container(&self) -> ImplOrTraitItemContainer {
+        match *self {
+            MethodTraitItem(ref method) => method.container,
+        }
+    }
+}
+
+#[deriving(Clone)]
+pub enum ImplOrTraitItemId {
+    MethodTraitItemId(ast::DefId),
+}
+
+impl ImplOrTraitItemId {
+    pub fn def_id(&self) -> ast::DefId {
+        match *self {
+            MethodTraitItemId(def_id) => def_id,
+        }
+    }
 }
 
 #[deriving(Clone)]
@@ -89,7 +142,7 @@ pub struct Method {
     pub explicit_self: ExplicitSelfCategory,
     pub vis: ast::Visibility,
     pub def_id: ast::DefId,
-    pub container: MethodContainer,
+    pub container: ImplOrTraitItemContainer,
 
     // If this method is provided, we need to know where it came from
     pub provided_source: Option<ast::DefId>
@@ -102,7 +155,7 @@ impl Method {
                explicit_self: ExplicitSelfCategory,
                vis: ast::Visibility,
                def_id: ast::DefId,
-               container: MethodContainer,
+               container: ImplOrTraitItemContainer,
                provided_source: Option<ast::DefId>)
                -> Method {
        Method {
@@ -274,14 +327,14 @@ pub struct ctxt {
     /// other items.
     pub item_substs: RefCell<NodeMap<ItemSubsts>>,
 
-    /// Maps from a method to the method "descriptor"
-    pub methods: RefCell<DefIdMap<Rc<Method>>>,
+    /// Maps from a trait item to the trait item "descriptor"
+    pub impl_or_trait_items: RefCell<DefIdMap<ImplOrTraitItem>>,
 
-    /// Maps from a trait def-id to a list of the def-ids of its methods
-    pub trait_method_def_ids: RefCell<DefIdMap<Rc<Vec<DefId>>>>,
+    /// Maps from a trait def-id to a list of the def-ids of its trait items
+    pub trait_item_def_ids: RefCell<DefIdMap<Rc<Vec<ImplOrTraitItemId>>>>,
 
-    /// A cache for the trait_methods() routine
-    pub trait_methods_cache: RefCell<DefIdMap<Rc<Vec<Rc<Method>>>>>,
+    /// A cache for the trait_items() routine
+    pub trait_items_cache: RefCell<DefIdMap<Rc<Vec<ImplOrTraitItem>>>>,
 
     pub impl_trait_cache: RefCell<DefIdMap<Option<Rc<ty::TraitRef>>>>,
 
@@ -332,11 +385,11 @@ pub struct ctxt {
     /// Methods in these implementations don't need to be exported.
     pub inherent_impls: RefCell<DefIdMap<Rc<RefCell<Vec<ast::DefId>>>>>,
 
-    /// Maps a DefId of an impl to a list of its methods.
+    /// Maps a DefId of an impl to a list of its items.
     /// Note that this contains all of the impls that we know about,
     /// including ones in other crates. It's not clear that this is the best
     /// way to do it.
-    pub impl_methods: RefCell<DefIdMap<Vec<ast::DefId>>>,
+    pub impl_items: RefCell<DefIdMap<Vec<ImplOrTraitItemId>>>,
 
     /// Set of used unsafe nodes (functions or blocks). Unsafe nodes not
     /// present in this set can be warned about.
@@ -1104,9 +1157,9 @@ pub fn mk_ctxt(s: Session,
         tc_cache: RefCell::new(HashMap::new()),
         ast_ty_to_ty_cache: RefCell::new(NodeMap::new()),
         enum_var_cache: RefCell::new(DefIdMap::new()),
-        methods: RefCell::new(DefIdMap::new()),
-        trait_method_def_ids: RefCell::new(DefIdMap::new()),
-        trait_methods_cache: RefCell::new(DefIdMap::new()),
+        impl_or_trait_items: RefCell::new(DefIdMap::new()),
+        trait_item_def_ids: RefCell::new(DefIdMap::new()),
+        trait_items_cache: RefCell::new(DefIdMap::new()),
         impl_trait_cache: RefCell::new(DefIdMap::new()),
         ty_param_defs: RefCell::new(NodeMap::new()),
         adjustments: RefCell::new(NodeMap::new()),
@@ -1120,7 +1173,7 @@ pub fn mk_ctxt(s: Session,
         destructors: RefCell::new(DefIdSet::new()),
         trait_impls: RefCell::new(DefIdMap::new()),
         inherent_impls: RefCell::new(DefIdMap::new()),
-        impl_methods: RefCell::new(DefIdMap::new()),
+        impl_items: RefCell::new(DefIdMap::new()),
         used_unsafe: RefCell::new(NodeSet::new()),
         used_mut_nodes: RefCell::new(NodeSet::new()),
         impl_vtables: RefCell::new(DefIdMap::new()),
@@ -3075,11 +3128,19 @@ pub fn method_call_type_param_defs(tcx: &ctxt, origin: typeck::MethodOrigin)
                 Err(s) => tcx.sess.fatal(s.as_slice()),
             }
         }
-        typeck::MethodParam(typeck::MethodParam{trait_id: trt_id,
-                                                method_num: n_mth, ..}) |
-        typeck::MethodObject(typeck::MethodObject{trait_id: trt_id,
-                                                  method_num: n_mth, ..}) => {
-            ty::trait_method(tcx, trt_id, n_mth).generics.types.clone()
+        typeck::MethodParam(typeck::MethodParam{
+            trait_id: trt_id,
+            method_num: n_mth,
+            ..
+        }) |
+        typeck::MethodObject(typeck::MethodObject{
+                trait_id: trt_id,
+                method_num: n_mth,
+                ..
+        }) => {
+            match ty::trait_item(tcx, trt_id, n_mth) {
+                ty::MethodTraitItem(method) => method.generics.types.clone(),
+            }
         }
     }
 }
@@ -3297,8 +3358,9 @@ pub fn field_idx_strict(tcx: &ctxt, name: ast::Name, fields: &[field])
               .collect::<Vec<String>>()).as_slice());
 }
 
-pub fn method_idx(id: ast::Ident, meths: &[Rc<Method>]) -> Option<uint> {
-    meths.iter().position(|m| m.ident == id)
+pub fn impl_or_trait_item_idx(id: ast::Ident, trait_items: &[ImplOrTraitItem])
+                              -> Option<uint> {
+    trait_items.iter().position(|m| m.ident() == id)
 }
 
 /// Returns a vector containing the indices of all type parameters that appear
@@ -3540,7 +3602,15 @@ pub fn provided_trait_methods(cx: &ctxt, id: ast::DefId) -> Vec<Rc<Method>> {
                 match item.node {
                     ItemTrait(_, _, _, ref ms) => {
                         let (_, p) = ast_util::split_trait_methods(ms.as_slice());
-                        p.iter().map(|m| method(cx, ast_util::local_def(m.id))).collect()
+                        p.iter()
+                         .map(|m| {
+                            match impl_or_trait_item(
+                                    cx,
+                                    ast_util::local_def(m.id)) {
+                                MethodTraitItem(m) => m,
+                            }
+                         })
+                         .collect()
                     }
                     _ => {
                         cx.sess.bug(format!("provided_trait_methods: `{}` is \
@@ -3592,7 +3662,7 @@ fn lookup_locally_or_in_crate_store<V:Clone>(
     /*!
      * Helper for looking things up in the various maps
      * that are populated during typeck::collect (e.g.,
-     * `cx.methods`, `cx.tcache`, etc).  All of these share
+     * `cx.impl_or_trait_items`, `cx.tcache`, etc).  All of these share
      * the pattern that if the id is local, it should have
      * been loaded into the map by the `typeck::collect` phase.
      * If the def-id is external, then we have to go consult
@@ -3612,40 +3682,47 @@ fn lookup_locally_or_in_crate_store<V:Clone>(
     v
 }
 
-pub fn trait_method(cx: &ctxt, trait_did: ast::DefId, idx: uint) -> Rc<Method> {
-    let method_def_id = *ty::trait_method_def_ids(cx, trait_did).get(idx);
-    ty::method(cx, method_def_id)
+pub fn trait_item(cx: &ctxt, trait_did: ast::DefId, idx: uint)
+                  -> ImplOrTraitItem {
+    let method_def_id = ty::trait_item_def_ids(cx, trait_did).get(idx)
+                                                             .def_id();
+    impl_or_trait_item(cx, method_def_id)
 }
 
-
-pub fn trait_methods(cx: &ctxt, trait_did: ast::DefId) -> Rc<Vec<Rc<Method>>> {
-    let mut trait_methods = cx.trait_methods_cache.borrow_mut();
-    match trait_methods.find_copy(&trait_did) {
-        Some(methods) => methods,
+pub fn trait_items(cx: &ctxt, trait_did: ast::DefId)
+                   -> Rc<Vec<ImplOrTraitItem>> {
+    let mut trait_items = cx.trait_items_cache.borrow_mut();
+    match trait_items.find_copy(&trait_did) {
+        Some(trait_items) => trait_items,
         None => {
-            let def_ids = ty::trait_method_def_ids(cx, trait_did);
-            let methods: Rc<Vec<Rc<Method>>> = Rc::new(def_ids.iter().map(|d| {
-                ty::method(cx, *d)
-            }).collect());
-            trait_methods.insert(trait_did, methods.clone());
-            methods
+            let def_ids = ty::trait_item_def_ids(cx, trait_did);
+            let items: Rc<Vec<ImplOrTraitItem>> =
+                Rc::new(def_ids.iter()
+                               .map(|d| impl_or_trait_item(cx, d.def_id()))
+                               .collect());
+            trait_items.insert(trait_did, items.clone());
+            items
         }
     }
 }
 
-pub fn method(cx: &ctxt, id: ast::DefId) -> Rc<Method> {
-    lookup_locally_or_in_crate_store("methods", id,
-                                     &mut *cx.methods.borrow_mut(), || {
-        Rc::new(csearch::get_method(cx, id))
+pub fn impl_or_trait_item(cx: &ctxt, id: ast::DefId) -> ImplOrTraitItem {
+    lookup_locally_or_in_crate_store("impl_or_trait_items",
+                                     id,
+                                     &mut *cx.impl_or_trait_items
+                                             .borrow_mut(),
+                                     || {
+        csearch::get_impl_or_trait_item(cx, id)
     })
 }
 
-pub fn trait_method_def_ids(cx: &ctxt, id: ast::DefId) -> Rc<Vec<DefId>> {
-    lookup_locally_or_in_crate_store("trait_method_def_ids",
+pub fn trait_item_def_ids(cx: &ctxt, id: ast::DefId)
+                          -> Rc<Vec<ImplOrTraitItemId>> {
+    lookup_locally_or_in_crate_store("trait_item_def_ids",
                                      id,
-                                     &mut *cx.trait_method_def_ids.borrow_mut(),
+                                     &mut *cx.trait_item_def_ids.borrow_mut(),
                                      || {
-        Rc::new(csearch::get_trait_method_def_ids(&cx.sess.cstore, id))
+        Rc::new(csearch::get_trait_item_def_ids(&cx.sess.cstore, id))
     })
 }
 
@@ -4459,7 +4536,8 @@ pub fn populate_implementations_for_type_if_necessary(tcx: &ctxt,
 
     csearch::each_implementation_for_type(&tcx.sess.cstore, type_id,
             |impl_def_id| {
-        let methods = csearch::get_impl_methods(&tcx.sess.cstore, impl_def_id);
+        let impl_items = csearch::get_impl_items(&tcx.sess.cstore,
+                                                 impl_def_id);
 
         // Record the trait->implementation mappings, if applicable.
         let associated_traits = csearch::get_impl_trait(tcx, impl_def_id);
@@ -4469,14 +4547,21 @@ pub fn populate_implementations_for_type_if_necessary(tcx: &ctxt,
 
         // For any methods that use a default implementation, add them to
         // the map. This is a bit unfortunate.
-        for &method_def_id in methods.iter() {
-            for &source in ty::method(tcx, method_def_id).provided_source.iter() {
-                tcx.provided_method_sources.borrow_mut().insert(method_def_id, source);
+        for impl_item_def_id in impl_items.iter() {
+            let method_def_id = impl_item_def_id.def_id();
+            match impl_or_trait_item(tcx, method_def_id) {
+                MethodTraitItem(method) => {
+                    for &source in method.provided_source.iter() {
+                        tcx.provided_method_sources
+                           .borrow_mut()
+                           .insert(method_def_id, source);
+                    }
+                }
             }
         }
 
         // Store the implementation info.
-        tcx.impl_methods.borrow_mut().insert(impl_def_id, methods);
+        tcx.impl_items.borrow_mut().insert(impl_def_id, impl_items);
 
         // If this is an inherent implementation, record it.
         if associated_traits.is_none() {
@@ -4509,21 +4594,28 @@ pub fn populate_implementations_for_trait_if_necessary(
 
     csearch::each_implementation_for_trait(&tcx.sess.cstore, trait_id,
             |implementation_def_id| {
-        let methods = csearch::get_impl_methods(&tcx.sess.cstore, implementation_def_id);
+        let impl_items = csearch::get_impl_items(&tcx.sess.cstore, implementation_def_id);
 
         // Record the trait->implementation mapping.
         record_trait_implementation(tcx, trait_id, implementation_def_id);
 
         // For any methods that use a default implementation, add them to
         // the map. This is a bit unfortunate.
-        for &method_def_id in methods.iter() {
-            for &source in ty::method(tcx, method_def_id).provided_source.iter() {
-                tcx.provided_method_sources.borrow_mut().insert(method_def_id, source);
+        for impl_item_def_id in impl_items.iter() {
+            let method_def_id = impl_item_def_id.def_id();
+            match impl_or_trait_item(tcx, method_def_id) {
+                MethodTraitItem(method) => {
+                    for &source in method.provided_source.iter() {
+                        tcx.provided_method_sources
+                           .borrow_mut()
+                           .insert(method_def_id, source);
+                    }
+                }
             }
         }
 
         // Store the implementation info.
-        tcx.impl_methods.borrow_mut().insert(implementation_def_id, methods);
+        tcx.impl_items.borrow_mut().insert(implementation_def_id, impl_items);
     });
 
     tcx.populated_external_traits.borrow_mut().insert(trait_id);
@@ -4555,14 +4647,15 @@ pub fn trait_id_of_impl(tcx: &ctxt,
 pub fn impl_of_method(tcx: &ctxt, def_id: ast::DefId)
                        -> Option<ast::DefId> {
     if def_id.krate != LOCAL_CRATE {
-        return match csearch::get_method(tcx, def_id).container {
+        return match csearch::get_impl_or_trait_item(tcx,
+                                                     def_id).container() {
             TraitContainer(_) => None,
             ImplContainer(def_id) => Some(def_id),
         };
     }
-    match tcx.methods.borrow().find_copy(&def_id) {
-        Some(method) => {
-            match method.container {
+    match tcx.impl_or_trait_items.borrow().find_copy(&def_id) {
+        Some(trait_item) => {
+            match trait_item.container() {
                 TraitContainer(_) => None,
                 ImplContainer(def_id) => Some(def_id),
             }
@@ -4571,17 +4664,16 @@ pub fn impl_of_method(tcx: &ctxt, def_id: ast::DefId)
     }
 }
 
-/// If the given def ID describes a method belonging to a trait (either a
+/// If the given def ID describes an item belonging to a trait (either a
 /// default method or an implementation of a trait method), return the ID of
 /// the trait that the method belongs to. Otherwise, return `None`.
-pub fn trait_of_method(tcx: &ctxt, def_id: ast::DefId)
-                       -> Option<ast::DefId> {
+pub fn trait_of_item(tcx: &ctxt, def_id: ast::DefId) -> Option<ast::DefId> {
     if def_id.krate != LOCAL_CRATE {
-        return csearch::get_trait_of_method(&tcx.sess.cstore, def_id, tcx);
+        return csearch::get_trait_of_item(&tcx.sess.cstore, def_id, tcx);
     }
-    match tcx.methods.borrow().find_copy(&def_id) {
-        Some(method) => {
-            match method.container {
+    match tcx.impl_or_trait_items.borrow().find_copy(&def_id) {
+        Some(impl_or_trait_item) => {
+            match impl_or_trait_item.container() {
                 TraitContainer(def_id) => Some(def_id),
                 ImplContainer(def_id) => trait_id_of_impl(tcx, def_id),
             }
@@ -4590,25 +4682,27 @@ pub fn trait_of_method(tcx: &ctxt, def_id: ast::DefId)
     }
 }
 
-/// If the given def ID describes a method belonging to a trait, (either a
+/// If the given def ID describes an item belonging to a trait, (either a
 /// default method or an implementation of a trait method), return the ID of
 /// the method inside trait definition (this means that if the given def ID
 /// is already that of the original trait method, then the return value is
 /// the same).
 /// Otherwise, return `None`.
-pub fn trait_method_of_method(tcx: &ctxt,
-                              def_id: ast::DefId) -> Option<ast::DefId> {
-    let method = match tcx.methods.borrow().find(&def_id) {
+pub fn trait_item_of_item(tcx: &ctxt, def_id: ast::DefId)
+                          -> Option<ImplOrTraitItemId> {
+    let impl_item = match tcx.impl_or_trait_items.borrow().find(&def_id) {
         Some(m) => m.clone(),
         None => return None,
     };
-    let name = method.ident.name;
-    match trait_of_method(tcx, def_id) {
+    let name = match impl_item {
+        MethodTraitItem(method) => method.ident.name,
+    };
+    match trait_of_item(tcx, def_id) {
         Some(trait_did) => {
-            let trait_methods = ty::trait_methods(tcx, trait_did);
-            trait_methods.iter()
-                .position(|m| m.ident.name == name)
-                .map(|idx| ty::trait_method(tcx, trait_did, idx).def_id)
+            let trait_items = ty::trait_items(tcx, trait_did);
+            trait_items.iter()
+                .position(|m| m.ident().name == name)
+                .map(|idx| ty::trait_item(tcx, trait_did, idx).id())
         }
         None => None
     }

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -220,9 +220,15 @@ fn get_method_index(tcx: &ty::ctxt,
     // methods from them.
     let mut method_count = 0;
     ty::each_bound_trait_and_supertraits(tcx, &[subtrait], |bound_ref| {
-        if bound_ref.def_id == trait_ref.def_id { false }
-            else {
-            method_count += ty::trait_methods(tcx, bound_ref.def_id).len();
+        if bound_ref.def_id == trait_ref.def_id {
+            false
+        } else {
+            let trait_items = ty::trait_items(tcx, bound_ref.def_id);
+            for trait_item in trait_items.iter() {
+                match *trait_item {
+                    ty::MethodTraitItem(_) => method_count += 1,
+                }
+            }
             true
         }
     });
@@ -488,11 +494,13 @@ impl<'a> LookupContext<'a> {
         ty::populate_implementations_for_trait_if_necessary(self.tcx(), trait_did);
 
         // Look for explicit implementations.
-        let impl_methods = self.tcx().impl_methods.borrow();
+        let impl_items = self.tcx().impl_items.borrow();
         for impl_infos in self.tcx().trait_impls.borrow().find(&trait_did).iter() {
             for impl_did in impl_infos.borrow().iter() {
-                let methods = impl_methods.get(impl_did);
-                self.push_candidates_from_impl(*impl_did, methods.as_slice(), true);
+                let items = impl_items.get(impl_did);
+                self.push_candidates_from_impl(*impl_did,
+                                               items.as_slice(),
+                                               true);
             }
         }
     }
@@ -520,8 +528,11 @@ impl<'a> LookupContext<'a> {
             trait_did: DefId,
             closure_did: DefId,
             closure_function_type: &ClosureTy) {
-        let method =
-            ty::trait_methods(self.tcx(), trait_did).get(0).clone();
+        let trait_item = ty::trait_items(self.tcx(), trait_did).get(0)
+                                                               .clone();
+        let method = match trait_item {
+            ty::MethodTraitItem(method) => method,
+        };
 
         let vcx = self.fcx.vtable_context();
         let region_params =
@@ -701,14 +712,24 @@ impl<'a> LookupContext<'a> {
             let this_bound_idx = next_bound_idx;
             next_bound_idx += 1;
 
-            let trait_methods = ty::trait_methods(tcx, bound_trait_ref.def_id);
-            match trait_methods.iter().position(|m| {
-                m.explicit_self != ty::StaticExplicitSelfCategory &&
-                m.ident.name == self.m_name }) {
+            let trait_items = ty::trait_items(tcx, bound_trait_ref.def_id);
+            match trait_items.iter().position(|ti| {
+                match *ti {
+                    ty::MethodTraitItem(ref m) => {
+                        m.explicit_self != ty::StaticExplicitSelfCategory &&
+                        m.ident.name == self.m_name
+                    }
+                }
+            }) {
                 Some(pos) => {
-                    let method = trait_methods.get(pos).clone();
+                    let method = match *trait_items.get(pos) {
+                        ty::MethodTraitItem(ref method) => (*method).clone(),
+                    };
 
-                    match mk_cand(bound_trait_ref, method, pos, this_bound_idx) {
+                    match mk_cand(bound_trait_ref,
+                                  method,
+                                  pos,
+                                  this_bound_idx) {
                         Some(cand) => {
                             debug!("pushing inherent candidate for param: {}",
                                    cand.repr(self.tcx()));
@@ -733,18 +754,20 @@ impl<'a> LookupContext<'a> {
         // metadata if necessary.
         ty::populate_implementations_for_type_if_necessary(self.tcx(), did);
 
-        let impl_methods = self.tcx().impl_methods.borrow();
+        let impl_items = self.tcx().impl_items.borrow();
         for impl_infos in self.tcx().inherent_impls.borrow().find(&did).iter() {
             for impl_did in impl_infos.borrow().iter() {
-                let methods = impl_methods.get(impl_did);
-                self.push_candidates_from_impl(*impl_did, methods.as_slice(), false);
+                let items = impl_items.get(impl_did);
+                self.push_candidates_from_impl(*impl_did,
+                                               items.as_slice(),
+                                               false);
             }
         }
     }
 
     fn push_candidates_from_impl(&mut self,
                                  impl_did: DefId,
-                                 impl_methods: &[DefId],
+                                 impl_items: &[ImplOrTraitItemId],
                                  is_extension: bool) {
         let did = if self.report_statics == ReportStaticMethods {
             // we only want to report each base trait once
@@ -762,13 +785,23 @@ impl<'a> LookupContext<'a> {
 
         debug!("push_candidates_from_impl: {} {}",
                token::get_name(self.m_name),
-               impl_methods.iter().map(|&did| ty::method(self.tcx(), did).ident)
-                                 .collect::<Vec<ast::Ident>>()
-                                 .repr(self.tcx()));
+               impl_items.iter()
+                         .map(|&did| {
+                             ty::impl_or_trait_item(self.tcx(),
+                                                    did.def_id()).ident()
+                         })
+                         .collect::<Vec<ast::Ident>>()
+                         .repr(self.tcx()));
 
-        let method = match impl_methods.iter().map(|&did| ty::method(self.tcx(), did))
-                                              .find(|m| m.ident.name == self.m_name) {
-            Some(method) => method,
+        let method = match impl_items.iter()
+                                     .map(|&did| {
+                                         ty::impl_or_trait_item(self.tcx(),
+                                                                did.def_id())
+                                     })
+                                     .find(|m| {
+                                         m.ident().name == self.m_name
+                                     }) {
+            Some(ty::MethodTraitItem(method)) => method,
             None => { return; } // No method with the right name.
         };
 
@@ -1486,9 +1519,16 @@ impl<'a> LookupContext<'a> {
                 let did = if self.report_statics == ReportStaticMethods {
                     // If we're reporting statics, we want to report the trait
                     // definition if possible, rather than an impl
-                    match ty::trait_method_of_method(self.tcx(), impl_did) {
-                        None => {debug!("(report candidate) No trait method found"); impl_did},
-                        Some(trait_did) => {debug!("(report candidate) Found trait ref"); trait_did}
+                    match ty::trait_item_of_item(self.tcx(), impl_did) {
+                        None => {
+                            debug!("(report candidate) No trait method \
+                                    found");
+                            impl_did
+                        }
+                        Some(MethodTraitItemId(trait_did)) => {
+                            debug!("(report candidate) Found trait ref");
+                            trait_did
+                        }
                     }
                 } else {
                     // If it is an instantiated default method, use the original

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -123,7 +123,7 @@ use std::mem::replace;
 use std::rc::Rc;
 use std::gc::Gc;
 use syntax::abi;
-use syntax::ast::{Provided, Required};
+use syntax::ast::{ProvidedMethod, RequiredMethod};
 use syntax::ast;
 use syntax::ast_map;
 use syntax::ast_util::{local_def, PostExpansionMethod};
@@ -680,23 +680,27 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
 
         check_bare_fn(ccx, &**decl, &**body, it.id, fn_pty.ty, param_env);
       }
-      ast::ItemImpl(_, ref opt_trait_ref, _, ref ms) => {
+      ast::ItemImpl(_, ref opt_trait_ref, _, ref impl_items) => {
         debug!("ItemImpl {} with id {}", token::get_ident(it.ident), it.id);
 
         let impl_pty = ty::lookup_item_type(ccx.tcx, ast_util::local_def(it.id));
-        for m in ms.iter() {
-            check_method_body(ccx, &impl_pty.generics, &**m);
+        for impl_item in impl_items.iter() {
+            match *impl_item {
+                ast::MethodImplItem(m) => {
+                    check_method_body(ccx, &impl_pty.generics, &*m);
+                }
+            }
         }
 
         match *opt_trait_ref {
             Some(ref ast_trait_ref) => {
                 let impl_trait_ref =
                     ty::node_id_to_trait_ref(ccx.tcx, ast_trait_ref.ref_id);
-                check_impl_methods_against_trait(ccx,
-                                             it.span,
-                                             ast_trait_ref,
-                                             &*impl_trait_ref,
-                                             ms.as_slice());
+                check_impl_items_against_trait(ccx,
+                                               it.span,
+                                               ast_trait_ref,
+                                               &*impl_trait_ref,
+                                               impl_items.as_slice());
                 vtable::resolve_impl(ccx.tcx, it, &impl_pty.generics, &*impl_trait_ref);
             }
             None => { }
@@ -707,11 +711,11 @@ pub fn check_item(ccx: &CrateCtxt, it: &ast::Item) {
         let trait_def = ty::lookup_trait_def(ccx.tcx, local_def(it.id));
         for trait_method in (*trait_methods).iter() {
             match *trait_method {
-                Required(..) => {
+                RequiredMethod(..) => {
                     // Nothing to do, since required methods don't have
                     // bodies to check.
                 }
-                Provided(m) => {
+                ProvidedMethod(m) => {
                     check_method_body(ccx, &trait_def.generics, &*m);
                 }
             }
@@ -770,7 +774,9 @@ fn check_method_body(ccx: &CrateCtxt,
             item_generics.repr(ccx.tcx),
             method.id);
     let method_def_id = local_def(method.id);
-    let method_ty = ty::method(ccx.tcx, method_def_id);
+    let method_ty = match ty::impl_or_trait_item(ccx.tcx, method_def_id) {
+        ty::MethodTraitItem(ref method_ty) => (*method_ty).clone(),
+    };
     let method_generics = &method_ty.generics;
 
     let param_env = ty::construct_parameter_environment(ccx.tcx,
@@ -787,43 +793,58 @@ fn check_method_body(ccx: &CrateCtxt,
                   param_env);
 }
 
-fn check_impl_methods_against_trait(ccx: &CrateCtxt,
-                                    impl_span: Span,
-                                    ast_trait_ref: &ast::TraitRef,
-                                    impl_trait_ref: &ty::TraitRef,
-                                    impl_methods: &[Gc<ast::Method>]) {
+fn check_impl_items_against_trait(ccx: &CrateCtxt,
+                                  impl_span: Span,
+                                  ast_trait_ref: &ast::TraitRef,
+                                  impl_trait_ref: &ty::TraitRef,
+                                  impl_items: &[ast::ImplItem]) {
     // Locate trait methods
     let tcx = ccx.tcx;
-    let trait_methods = ty::trait_methods(tcx, impl_trait_ref.def_id);
+    let trait_items = ty::trait_items(tcx, impl_trait_ref.def_id);
 
     // Check existing impl methods to see if they are both present in trait
     // and compatible with trait signature
-    for impl_method in impl_methods.iter() {
-        let impl_method_def_id = local_def(impl_method.id);
-        let impl_method_ty = ty::method(ccx.tcx, impl_method_def_id);
+    for impl_item in impl_items.iter() {
+        match *impl_item {
+            ast::MethodImplItem(impl_method) => {
+                let impl_method_def_id = local_def(impl_method.id);
+                let impl_item_ty = ty::impl_or_trait_item(ccx.tcx,
+                                                          impl_method_def_id);
 
-        // If this is an impl of a trait method, find the corresponding
-        // method definition in the trait.
-        let opt_trait_method_ty =
-            trait_methods.iter().
-            find(|tm| tm.ident.name == impl_method_ty.ident.name);
-        match opt_trait_method_ty {
-            Some(trait_method_ty) => {
-                compare_impl_method(ccx.tcx,
-                                    &*impl_method_ty,
-                                    impl_method.span,
-                                    impl_method.pe_body().id,
-                                    &**trait_method_ty,
-                                    &impl_trait_ref.substs);
-            }
-            None => {
-                // This is span_bug as it should have already been caught in resolve.
-                tcx.sess.span_bug(
-                    impl_method.span,
-                    format!(
-                        "method `{}` is not a member of trait `{}`",
-                        token::get_ident(impl_method_ty.ident),
-                        pprust::path_to_string(&ast_trait_ref.path)).as_slice());
+                // If this is an impl of a trait method, find the
+                // corresponding method definition in the trait.
+                let opt_trait_method_ty =
+                    trait_items.iter()
+                               .find(|ti| {
+                                   ti.ident().name == impl_item_ty.ident()
+                                                                  .name
+                               });
+                match opt_trait_method_ty {
+                    Some(trait_method_ty) => {
+                        match (trait_method_ty, &impl_item_ty) {
+                            (&ty::MethodTraitItem(ref trait_method_ty),
+                             &ty::MethodTraitItem(ref impl_method_ty)) => {
+                                compare_impl_method(ccx.tcx,
+                                                    &**impl_method_ty,
+                                                    impl_method.span,
+                                                    impl_method.pe_body().id,
+                                                    &**trait_method_ty,
+                                                    &impl_trait_ref.substs);
+                            }
+                        }
+                    }
+                    None => {
+                        // This is span_bug as it should have already been
+                        // caught in resolve.
+                        tcx.sess.span_bug(
+                            impl_method.span,
+                            format!(
+                                "method `{}` is not a member of trait `{}`",
+                                token::get_ident(impl_item_ty.ident()),
+                                pprust::path_to_string(
+                                    &ast_trait_ref.path)).as_slice());
+                    }
+                }
             }
         }
     }
@@ -832,16 +853,26 @@ fn check_impl_methods_against_trait(ccx: &CrateCtxt,
     let provided_methods = ty::provided_trait_methods(tcx,
                                                       impl_trait_ref.def_id);
     let mut missing_methods = Vec::new();
-    for trait_method in trait_methods.iter() {
-        let is_implemented =
-            impl_methods.iter().any(
-                |m| m.pe_ident().name == trait_method.ident.name);
-        let is_provided =
-            provided_methods.iter().any(
-                |m| m.ident.name == trait_method.ident.name);
-        if !is_implemented && !is_provided {
-            missing_methods.push(
-                format!("`{}`", token::get_ident(trait_method.ident)));
+    for trait_item in trait_items.iter() {
+        match *trait_item {
+            ty::MethodTraitItem(ref trait_method) => {
+                let is_implemented =
+                    impl_items.iter().any(|ii| {
+                        match *ii {
+                            ast::MethodImplItem(m) => {
+                                m.pe_ident().name == trait_method.ident.name
+                            }
+                        }
+                    });
+                let is_provided =
+                    provided_methods.iter().any(
+                        |m| m.ident.name == trait_method.ident.name);
+                if !is_implemented && !is_provided {
+                    missing_methods.push(
+                        format!("`{}`",
+                                token::get_ident(trait_method.ident)));
+                }
+            }
         }
     }
 
@@ -853,7 +884,7 @@ fn check_impl_methods_against_trait(ccx: &CrateCtxt,
 }
 
 /**
- * Checks that a method from an impl/class conforms to the signature of
+ * Checks that a method from an impl conforms to the signature of
  * the same method as declared in the trait.
  *
  * # Parameters

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -305,7 +305,8 @@ impl<'a> ErrorReporting for InferCtxt<'a> {
                         },
                         _ => None
                     },
-                    ast_map::NodeMethod(..) => {
+                    ast_map::NodeImplItem(..) |
+                    ast_map::NodeTraitItem(..) => {
                         Some(FreeRegionsFromSameFn::new(fr1, fr2, scope_id))
                     },
                     _ => None
@@ -699,9 +700,17 @@ impl<'a> ErrorReporting for InferCtxt<'a> {
                         _ => None
                     }
                 }
-                ast_map::NodeMethod(ref m) => {
-                    Some((m.pe_fn_decl(), m.pe_generics(), m.pe_fn_style(),
-                          m.pe_ident(), Some(m.pe_explicit_self().node), m.span))
+                ast_map::NodeImplItem(ref item) => {
+                    match **item {
+                        ast::MethodImplItem(ref m) => {
+                            Some((m.pe_fn_decl(),
+                                  m.pe_generics(),
+                                  m.pe_fn_style(),
+                                  m.pe_ident(),
+                                  Some(m.pe_explicit_self().node),
+                                  m.span))
+                        }
+                    }
                 },
                 _ => None
             },
@@ -1454,10 +1463,14 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
                 },
                 _ => None
             },
-            ast_map::NodeMethod(m) => {
-                taken.push_all(m.pe_generics().lifetimes.as_slice());
-                Some(m.id)
-            },
+            ast_map::NodeImplItem(ii) => {
+                match *ii {
+                    ast::MethodImplItem(m) => {
+                        taken.push_all(m.pe_generics().lifetimes.as_slice());
+                        Some(m.id)
+                    }
+                }
+            }
             _ => None
         },
         None => None

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -515,10 +515,14 @@ impl<'a> Visitor<()> for ConstraintContext<'a> {
             }
 
             ast::ItemTrait(..) => {
-                let methods = ty::trait_methods(tcx, did);
-                for method in methods.iter() {
-                    self.add_constraints_from_sig(
-                        &method.fty.sig, self.covariant);
+                let trait_items = ty::trait_items(tcx, did);
+                for trait_item in trait_items.iter() {
+                    match *trait_item {
+                        ty::MethodTraitItem(ref method) => {
+                            self.add_constraints_from_sig(&method.fty.sig,
+                                                          self.covariant);
+                        }
+                    }
                 }
             }
 
@@ -609,8 +613,8 @@ impl<'a> ConstraintContext<'a> {
                         _                    => cannot_happen!(),
                     }
                 }
-                ast_map::NodeTraitMethod(..) => is_inferred = false,
-                ast_map::NodeMethod(_)       => is_inferred = false,
+                ast_map::NodeTraitItem(..)   => is_inferred = false,
+                ast_map::NodeImplItem(..)    => is_inferred = false,
                 _                            => cannot_happen!(),
             }
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -762,8 +762,8 @@ impl Repr for ast::DefId {
                 match tcx.map.find(self.node) {
                     Some(ast_map::NodeItem(..)) |
                     Some(ast_map::NodeForeignItem(..)) |
-                    Some(ast_map::NodeMethod(..)) |
-                    Some(ast_map::NodeTraitMethod(..)) |
+                    Some(ast_map::NodeImplItem(..)) |
+                    Some(ast_map::NodeTraitItem(..)) |
                     Some(ast_map::NodeVariant(..)) |
                     Some(ast_map::NodeStructCtor(..)) => {
                         return format!(

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -480,8 +480,8 @@ mod svh_visitor {
             SawTyMethod.hash(self.st); visit::walk_ty_method(self, t, e)
         }
 
-        fn visit_trait_method(&mut self, t: &TraitMethod, e: E) {
-            SawTraitMethod.hash(self.st); visit::walk_trait_method(self, t, e)
+        fn visit_trait_item(&mut self, t: &TraitItem, e: E) {
+            SawTraitMethod.hash(self.st); visit::walk_trait_item(self, t, e)
         }
 
         fn visit_struct_field(&mut self, s: &StructField, e: E) {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -154,7 +154,7 @@ pub struct Static {
 
 pub struct Trait {
     pub name: Ident,
-    pub methods: Vec<ast::TraitMethod>, //should be TraitMethod
+    pub items: Vec<ast::TraitItem>, //should be TraitItem
     pub generics: ast::Generics,
     pub parents: Vec<ast::TraitRef>,
     pub attrs: Vec<ast::Attribute>,
@@ -168,7 +168,7 @@ pub struct Impl {
     pub generics: ast::Generics,
     pub trait_: Option<ast::TraitRef>,
     pub for_: ast::P<ast::Ty>,
-    pub methods: Vec<Gc<ast::Method>>,
+    pub items: Vec<ast::ImplItem>,
     pub attrs: Vec<ast::Attribute>,
     pub where: Span,
     pub vis: ast::Visibility,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -40,29 +40,31 @@ pub trait DocFolder {
                 EnumItem(i)
             },
             TraitItem(mut i) => {
-                fn vtrm<T: DocFolder>(this: &mut T, trm: TraitMethod) -> Option<TraitMethod> {
+                fn vtrm<T: DocFolder>(this: &mut T, trm: TraitItem)
+                        -> Option<TraitItem> {
                     match trm {
-                        Required(it) => {
+                        RequiredMethod(it) => {
                             match this.fold_item(it) {
-                                Some(x) => return Some(Required(x)),
+                                Some(x) => return Some(RequiredMethod(x)),
                                 None => return None,
                             }
                         },
-                        Provided(it) => {
+                        ProvidedMethod(it) => {
                             match this.fold_item(it) {
-                                Some(x) => return Some(Provided(x)),
+                                Some(x) => return Some(ProvidedMethod(x)),
                                 None => return None,
                             }
                         },
                     }
                 }
-                let mut foo = Vec::new(); swap(&mut foo, &mut i.methods);
-                i.methods.extend(foo.move_iter().filter_map(|x| vtrm(self, x)));
+                let mut foo = Vec::new(); swap(&mut foo, &mut i.items);
+                i.items.extend(foo.move_iter().filter_map(|x| vtrm(self, x)));
                 TraitItem(i)
             },
             ImplItem(mut i) => {
-                let mut foo = Vec::new(); swap(&mut foo, &mut i.methods);
-                i.methods.extend(foo.move_iter().filter_map(|x| self.fold_item(x)));
+                let mut foo = Vec::new(); swap(&mut foo, &mut i.items);
+                i.items.extend(foo.move_iter()
+                                  .filter_map(|x| self.fold_item(x)));
                 ImplItem(i)
             },
             VariantItem(i) => {

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -202,7 +202,7 @@ impl<'a> fold::DocFolder for Stripper<'a> {
                     clean::ModuleItem(ref m)
                         if m.items.len() == 0 &&
                            i.doc_value().is_none() => None,
-                    clean::ImplItem(ref i) if i.methods.len() == 0 => None,
+                    clean::ImplItem(ref i) if i.items.len() == 0 => None,
                     _ => {
                         self.retained.insert(i.def_id.node);
                         Some(i)

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -317,10 +317,10 @@ impl<'a> RustdocVisitor<'a> {
                 };
                 om.statics.push(s);
             },
-            ast::ItemTrait(ref gen, _, ref tr, ref met) => {
+            ast::ItemTrait(ref gen, _, ref tr, ref items) => {
                 let t = Trait {
                     name: item.ident,
-                    methods: met.iter().map(|x| (*x).clone()).collect(),
+                    items: items.iter().map(|x| (*x).clone()).collect(),
                     generics: gen.clone(),
                     parents: tr.iter().map(|x| (*x).clone()).collect(),
                     id: item.id,
@@ -331,12 +331,12 @@ impl<'a> RustdocVisitor<'a> {
                 };
                 om.traits.push(t);
             },
-            ast::ItemImpl(ref gen, ref tr, ty, ref meths) => {
+            ast::ItemImpl(ref gen, ref tr, ty, ref items) => {
                 let i = Impl {
                     generics: gen.clone(),
                     trait_: tr.clone(),
                     for_: ty,
-                    methods: meths.iter().map(|x| *x).collect(),
+                    items: items.iter().map(|x| *x).collect(),
                     attrs: item.attrs.iter().map(|x| *x).collect(),
                     id: item.id,
                     where: item.span,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -767,9 +767,14 @@ pub struct TypeMethod {
 /// doesn't have an implementation, just a signature) or provided (meaning it
 /// has a default implementation).
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
-pub enum TraitMethod {
-    Required(TypeMethod),
-    Provided(Gc<Method>),
+pub enum TraitItem {
+    RequiredMethod(TypeMethod),
+    ProvidedMethod(Gc<Method>),
+}
+
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub enum ImplItem {
+    MethodImplItem(Gc<Method>),
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash)]
@@ -1273,11 +1278,11 @@ pub enum Item_ {
               Option<TyParamBound>, // (optional) default bound not required for Self.
                                     // Currently, only Sized makes sense here.
               Vec<TraitRef> ,
-              Vec<TraitMethod>),
+              Vec<TraitItem>),
     ItemImpl(Generics,
              Option<TraitRef>, // (optional) trait this impl implements
              P<Ty>, // self
-             Vec<Gc<Method>>),
+             Vec<ImplItem>),
     /// A macro invocation (which includes macro definition)
     ItemMac(Mac),
 }
@@ -1311,8 +1316,14 @@ pub enum UnboxedClosureKind {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum InlinedItem {
     IIItem(Gc<Item>),
-    IIMethod(DefId /* impl id */, bool /* is provided */, Gc<Method>),
+    IITraitItem(DefId /* impl id */, InlinedTraitItem),
     IIForeign(Gc<ForeignItem>),
+}
+
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub enum InlinedTraitItem {
+    ProvidedInlinedTraitItem(Gc<Method>),
+    RequiredInlinedTraitItem(Gc<Method>),
 }
 
 #[cfg(test)]

--- a/src/libsyntax/ast_map/blocks.rs
+++ b/src/libsyntax/ast_map/blocks.rs
@@ -60,9 +60,9 @@ impl MaybeFnLike for ast::Item {
     }
 }
 
-impl MaybeFnLike for ast::TraitMethod {
+impl MaybeFnLike for ast::TraitItem {
     fn is_fn_like(&self) -> bool {
-        match *self { ast::Provided(_) => true, _ => false, }
+        match *self { ast::ProvidedMethod(_) => true, _ => false, }
     }
 }
 
@@ -97,9 +97,9 @@ impl Code {
         match node {
             ast_map::NodeItem(item) if item.is_fn_like() =>
                 Some(FnLikeCode(new(node))),
-            ast_map::NodeTraitMethod(tm) if tm.is_fn_like() =>
+            ast_map::NodeTraitItem(tm) if tm.is_fn_like() =>
                 Some(FnLikeCode(new(node))),
-            ast_map::NodeMethod(_) =>
+            ast_map::NodeImplItem(_) =>
                 Some(FnLikeCode(new(node))),
             ast_map::NodeExpr(e) if e.is_fn_like() =>
                 Some(FnLikeCode(new(node))),
@@ -200,11 +200,15 @@ impl FnLikeNode {
                     }),
                 _ => fail!("item FnLikeNode that is not fn-like"),
             },
-            ast_map::NodeTraitMethod(ref t) => match **t {
-                ast::Provided(ref m) => method(&**m),
+            ast_map::NodeTraitItem(ref t) => match **t {
+                ast::ProvidedMethod(ref m) => method(&**m),
                 _ => fail!("trait method FnLikeNode that is not fn-like"),
             },
-            ast_map::NodeMethod(ref m) => method(&**m),
+            ast_map::NodeImplItem(ref ii) => {
+                match **ii {
+                    ast::MethodImplItem(ref m) => method(&**m),
+                }
+            }
             ast_map::NodeExpr(ref e) => match e.node {
                 ast::ExprFnBlock(_, ref decl, ref block) =>
                     closure(ClosureParts::new(*decl, *block, e.id, e.span)),

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -99,8 +99,8 @@ pub fn path_to_string<PI: Iterator<PathElem>>(mut path: PI) -> String {
 pub enum Node {
     NodeItem(Gc<Item>),
     NodeForeignItem(Gc<ForeignItem>),
-    NodeTraitMethod(Gc<TraitMethod>),
-    NodeMethod(Gc<Method>),
+    NodeTraitItem(Gc<TraitItem>),
+    NodeImplItem(Gc<ImplItem>),
     NodeVariant(P<Variant>),
     NodeExpr(Gc<Expr>),
     NodeStmt(Gc<Stmt>),
@@ -125,8 +125,8 @@ enum MapEntry {
     /// All the node types, with a parent ID.
     EntryItem(NodeId, Gc<Item>),
     EntryForeignItem(NodeId, Gc<ForeignItem>),
-    EntryTraitMethod(NodeId, Gc<TraitMethod>),
-    EntryMethod(NodeId, Gc<Method>),
+    EntryTraitItem(NodeId, Gc<TraitItem>),
+    EntryImplItem(NodeId, Gc<ImplItem>),
     EntryVariant(NodeId, P<Variant>),
     EntryExpr(NodeId, Gc<Expr>),
     EntryStmt(NodeId, Gc<Stmt>),
@@ -144,7 +144,7 @@ enum MapEntry {
 
 struct InlinedParent {
     path: Vec<PathElem> ,
-    /// Required by NodeTraitMethod and NodeMethod.
+    /// RequiredMethod by NodeTraitItem and NodeImplItem.
     def_id: DefId
 }
 
@@ -153,8 +153,8 @@ impl MapEntry {
         Some(match *self {
             EntryItem(id, _) => id,
             EntryForeignItem(id, _) => id,
-            EntryTraitMethod(id, _) => id,
-            EntryMethod(id, _) => id,
+            EntryTraitItem(id, _) => id,
+            EntryImplItem(id, _) => id,
             EntryVariant(id, _) => id,
             EntryExpr(id, _) => id,
             EntryStmt(id, _) => id,
@@ -172,8 +172,8 @@ impl MapEntry {
         Some(match *self {
             EntryItem(_, p) => NodeItem(p),
             EntryForeignItem(_, p) => NodeForeignItem(p),
-            EntryTraitMethod(_, p) => NodeTraitMethod(p),
-            EntryMethod(_, p) => NodeMethod(p),
+            EntryTraitItem(_, p) => NodeTraitItem(p),
+            EntryImplItem(_, p) => NodeImplItem(p),
             EntryVariant(_, p) => NodeVariant(p),
             EntryExpr(_, p) => NodeExpr(p),
             EntryStmt(_, p) => NodeStmt(p),
@@ -324,13 +324,23 @@ impl Map {
                 }
             }
             NodeForeignItem(i) => PathName(i.ident.name),
-            NodeMethod(m) => match m.node {
-                MethDecl(ident, _, _, _, _, _, _, _) => PathName(ident.name),
-                MethMac(_) => fail!("no path elem for {:?}", node)
+            NodeImplItem(ii) => {
+                match *ii {
+                    MethodImplItem(ref m) => {
+                        match m.node {
+                            MethDecl(ident, _, _, _, _, _, _, _) => {
+                                PathName(ident.name)
+                            }
+                            MethMac(_) => {
+                                fail!("no path elem for {:?}", node)
+                            }
+                        }
+                    }
+                }
             },
-            NodeTraitMethod(tm) => match *tm {
-                Required(ref m) => PathName(m.ident.name),
-                Provided(m) => match m.node {
+            NodeTraitItem(tm) => match *tm {
+                RequiredMethod(ref m) => PathName(m.ident.name),
+                ProvidedMethod(m) => match m.node {
                     MethDecl(ident, _, _, _, _, _, _, _) => {
                         PathName(ident.name)
                     }
@@ -393,11 +403,15 @@ impl Map {
         let attrs = match node {
             NodeItem(ref i) => Some(i.attrs.as_slice()),
             NodeForeignItem(ref fi) => Some(fi.attrs.as_slice()),
-            NodeTraitMethod(ref tm) => match **tm {
-                Required(ref type_m) => Some(type_m.attrs.as_slice()),
-                Provided(ref m) => Some(m.attrs.as_slice())
+            NodeTraitItem(ref tm) => match **tm {
+                RequiredMethod(ref type_m) => Some(type_m.attrs.as_slice()),
+                ProvidedMethod(ref m) => Some(m.attrs.as_slice())
             },
-            NodeMethod(ref m) => Some(m.attrs.as_slice()),
+            NodeImplItem(ref ii) => {
+                match **ii {
+                    MethodImplItem(ref m) => Some(m.attrs.as_slice()),
+                }
+            }
             NodeVariant(ref v) => Some(v.node.attrs.as_slice()),
             // unit/tuple structs take the attributes straight from
             // the struct definition.
@@ -428,13 +442,17 @@ impl Map {
         let sp = match self.find(id) {
             Some(NodeItem(item)) => item.span,
             Some(NodeForeignItem(foreign_item)) => foreign_item.span,
-            Some(NodeTraitMethod(trait_method)) => {
+            Some(NodeTraitItem(trait_method)) => {
                 match *trait_method {
-                    Required(ref type_method) => type_method.span,
-                    Provided(ref method) => method.span,
+                    RequiredMethod(ref type_method) => type_method.span,
+                    ProvidedMethod(ref method) => method.span,
                 }
             }
-            Some(NodeMethod(method)) => method.span,
+            Some(NodeImplItem(ref impl_item)) => {
+                match **impl_item {
+                    MethodImplItem(ref method) => method.span,
+                }
+            }
             Some(NodeVariant(variant)) => variant.span,
             Some(NodeExpr(expr)) => expr.span,
             Some(NodeStmt(stmt)) => stmt.span,
@@ -532,8 +550,8 @@ impl<'a,S:Str> Iterator<NodeId> for NodesMatchingSuffix<'a,S> {
             let (p, name) = match self.map.find_entry(idx) {
                 Some(EntryItem(p, n))        => (p, n.name()),
                 Some(EntryForeignItem(p, n)) => (p, n.name()),
-                Some(EntryTraitMethod(p, n)) => (p, n.name()),
-                Some(EntryMethod(p, n))      => (p, n.name()),
+                Some(EntryTraitItem(p, n))   => (p, n.name()),
+                Some(EntryImplItem(p, n))    => (p, n.name()),
                 Some(EntryVariant(p, n))     => (p, n.name()),
                 _ => continue,
             };
@@ -553,11 +571,18 @@ impl<T:Named> Named for Spanned<T> { fn name(&self) -> Name { self.node.name() }
 impl Named for Item { fn name(&self) -> Name { self.ident.name } }
 impl Named for ForeignItem { fn name(&self) -> Name { self.ident.name } }
 impl Named for Variant_ { fn name(&self) -> Name { self.name.name } }
-impl Named for TraitMethod {
+impl Named for TraitItem {
     fn name(&self) -> Name {
         match *self {
-            Required(ref tm) => tm.ident.name,
-            Provided(m) => m.name(),
+            RequiredMethod(ref tm) => tm.ident.name,
+            ProvidedMethod(m) => m.name(),
+        }
+    }
+}
+impl Named for ImplItem {
+    fn name(&self) -> Name {
+        match *self {
+            MethodImplItem(ref m) => m.name(),
         }
     }
 }
@@ -616,9 +641,15 @@ impl<'a, F: FoldOps> Folder for Ctx<'a, F> {
         assert_eq!(self.parent, i.id);
 
         match i.node {
-            ItemImpl(_, _, _, ref ms) => {
-                for &m in ms.iter() {
-                    self.insert(m.id, EntryMethod(self.parent, m));
+            ItemImpl(_, _, _, ref impl_items) => {
+                for impl_item in impl_items.iter() {
+                    match *impl_item {
+                        MethodImplItem(m) => {
+                            self.insert(m.id,
+                                        EntryImplItem(self.parent,
+                                                      box(GC) *impl_item));
+                        }
+                    }
                 }
             }
             ItemEnum(ref enum_definition, _) => {
@@ -649,13 +680,13 @@ impl<'a, F: FoldOps> Folder for Ctx<'a, F> {
 
                 for tm in methods.iter() {
                     match *tm {
-                        Required(ref m) => {
-                            self.insert(m.id, EntryTraitMethod(self.parent,
+                        RequiredMethod(ref m) => {
+                            self.insert(m.id, EntryTraitItem(self.parent,
                                                                box(GC) (*tm).clone()));
                         }
-                        Provided(m) => {
-                            self.insert(m.id, EntryTraitMethod(self.parent,
-                                                               box(GC) Provided(m)));
+                        ProvidedMethod(m) => {
+                            self.insert(m.id, EntryTraitItem(self.parent,
+                                                               box(GC) ProvidedMethod(m)));
                         }
                     }
                 }
@@ -798,13 +829,18 @@ pub fn map_decoded_item<F: FoldOps>(map: &Map,
     let ii = fold(&mut cx);
     match ii {
         IIItem(_) => {}
-        IIMethod(impl_did, is_provided, m) => {
-            let entry = if is_provided {
-                EntryTraitMethod(cx.parent, box(GC) Provided(m))
-            } else {
-                EntryMethod(cx.parent, m)
+        IITraitItem(impl_did, inlined_trait_item) => {
+            let (trait_item_id, entry) = match inlined_trait_item {
+                ProvidedInlinedTraitItem(m) => {
+                    (m.id,
+                     EntryTraitItem(cx.parent, box(GC) ProvidedMethod(m)))
+                }
+                RequiredInlinedTraitItem(m) => {
+                    (m.id,
+                     EntryImplItem(cx.parent, box(GC) MethodImplItem(m)))
+                }
             };
-            cx.insert(m.id, entry);
+            cx.insert(trait_item_id, entry);
             def_id = impl_did;
         }
         IIForeign(i) => {
@@ -829,8 +865,8 @@ impl<'a> NodePrinter for pprust::State<'a> {
         match *node {
             NodeItem(a)        => self.print_item(&*a),
             NodeForeignItem(a) => self.print_foreign_item(&*a),
-            NodeTraitMethod(a) => self.print_trait_method(&*a),
-            NodeMethod(a)      => self.print_method(&*a),
+            NodeTraitItem(a)   => self.print_trait_method(&*a),
+            NodeImplItem(a)    => self.print_impl_item(&*a),
             NodeVariant(a)     => self.print_variant(&*a),
             NodeExpr(a)        => self.print_expr(&*a),
             NodeStmt(a)        => self.print_stmt(&*a),
@@ -870,17 +906,23 @@ fn node_id_to_string(map: &Map, id: NodeId) -> String {
             let path_str = map.path_to_str_with_ident(id, item.ident);
             format!("foreign item {} (id={})", path_str, id)
         }
-        Some(NodeMethod(m)) => match m.node {
-            MethDecl(ident, _, _, _, _, _, _, _) =>
-                format!("method {} in {} (id={})",
-                        token::get_ident(ident),
-                        map.path_to_string(id), id),
-            MethMac(ref mac) =>
-                format!("method macro {} (id={})",
-                        pprust::mac_to_string(mac), id)
-        },
-        Some(NodeTraitMethod(ref tm)) => {
-            let m = ast_util::trait_method_to_ty_method(&**tm);
+        Some(NodeImplItem(ref ii)) => {
+            match **ii {
+                MethodImplItem(ref m) => {
+                    match m.node {
+                        MethDecl(ident, _, _, _, _, _, _, _) =>
+                            format!("method {} in {} (id={})",
+                                    token::get_ident(ident),
+                                    map.path_to_string(id), id),
+                        MethMac(ref mac) =>
+                            format!("method macro {} (id={})",
+                                    pprust::mac_to_string(mac), id)
+                    }
+                }
+            }
+        }
+        Some(NodeTraitItem(ref tm)) => {
+            let m = ast_util::trait_item_to_ty_method(&**tm);
             format!("method {} in {} (id={})",
                     token::get_ident(m.ident),
                     map.path_to_string(id), id)

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -452,8 +452,13 @@ impl<'a> TraitDef<'a> {
             self.span,
             ident,
             (vec!(attr)).append(self.attributes.as_slice()),
-            ast::ItemImpl(trait_generics, opt_trait_ref,
-                          self_type, methods))
+            ast::ItemImpl(trait_generics,
+                          opt_trait_ref,
+                          self_type,
+                          methods.move_iter()
+                                 .map(|method| {
+                                     ast::MethodImplItem(method)
+                                 }).collect()))
     }
 
     fn expand_struct_def(&self,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -99,7 +99,7 @@ pub trait Visitor<E: Clone> {
         walk_fn(self, fk, fd, b, s, e)
     }
     fn visit_ty_method(&mut self, t: &TypeMethod, e: E) { walk_ty_method(self, t, e) }
-    fn visit_trait_method(&mut self, t: &TraitMethod, e: E) { walk_trait_method(self, t, e) }
+    fn visit_trait_item(&mut self, t: &TraitItem, e: E) { walk_trait_item(self, t, e) }
     fn visit_struct_def(&mut self, s: &StructDef, _: Ident, _: &Generics, _: NodeId, e: E) {
         walk_struct_def(self, s, e)
     }
@@ -148,7 +148,16 @@ pub fn walk_inlined_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
     match *item {
         IIItem(i) => visitor.visit_item(&*i, env),
         IIForeign(i) => visitor.visit_foreign_item(&*i, env),
-        IIMethod(_, _, m) => walk_method_helper(visitor, &*m, env),
+        IITraitItem(_, iti) => {
+            match iti {
+                ProvidedInlinedTraitItem(m) => {
+                    walk_method_helper(visitor, &*m, env)
+                }
+                RequiredInlinedTraitItem(m) => {
+                    walk_method_helper(visitor, &*m, env)
+                }
+            }
+        }
     }
 }
 
@@ -269,7 +278,7 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
         ItemImpl(ref type_parameters,
                  ref trait_reference,
                  typ,
-                 ref methods) => {
+                 ref impl_items) => {
             visitor.visit_generics(type_parameters, env.clone());
             match *trait_reference {
                 Some(ref trait_reference) => walk_trait_ref_helper(visitor,
@@ -277,8 +286,12 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
                 None => ()
             }
             visitor.visit_ty(&*typ, env.clone());
-            for method in methods.iter() {
-                walk_method_helper(visitor, &**method, env.clone())
+            for impl_item in impl_items.iter() {
+                match *impl_item {
+                    MethodImplItem(method) => {
+                        walk_method_helper(visitor, &*method, env.clone())
+                    }
+                }
             }
         }
         ItemStruct(ref struct_definition, ref generics) => {
@@ -297,7 +310,7 @@ pub fn walk_item<E: Clone, V: Visitor<E>>(visitor: &mut V, item: &Item, env: E) 
                                    env.clone())
             }
             for method in methods.iter() {
-                visitor.visit_trait_method(method, env.clone())
+                visitor.visit_trait_item(method, env.clone())
             }
         }
         ItemMac(ref macro) => visitor.visit_mac(macro, env.clone()),
@@ -626,14 +639,14 @@ pub fn walk_ty_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
     }
 }
 
-pub fn walk_trait_method<E: Clone, V: Visitor<E>>(visitor: &mut V,
-                                                  trait_method: &TraitMethod,
+pub fn walk_trait_item<E: Clone, V: Visitor<E>>(visitor: &mut V,
+                                                  trait_method: &TraitItem,
                                                   env: E) {
     match *trait_method {
-        Required(ref method_type) => {
+        RequiredMethod(ref method_type) => {
             visitor.visit_ty_method(method_type, env)
         }
-        Provided(ref method) => walk_method_helper(visitor, &**method, env),
+        ProvidedMethod(ref method) => walk_method_helper(visitor, &**method, env),
     }
 }
 


### PR DESCRIPTION
methods.

This paves the way to associated items by introducing an extra level of
abstraction ("impl-or-trait item") between traits/implementations and
methods. This new abstraction is encoded in the metadata and used
throughout the compiler where appropriate.

There are no functional changes; this is purely a refactoring.

r? @nick29581
