### PR TITLE
Use byte literals instead of casts

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1457,7 +1457,7 @@ mod tests {
             109
         ];
         assert_eq!("".as_bytes(), &[]);
-        assert_eq!("abc".as_bytes(), &['a' as u8, 'b' as u8, 'c' as u8]);
+        assert_eq!("abc".as_bytes(), b"abc");
         assert_eq!("ศไทย中华Việt Nam".as_bytes(), v.as_slice());
     }
 
@@ -1475,11 +1475,11 @@ mod tests {
     fn test_as_ptr() {
         let buf = "hello".as_ptr();
         unsafe {
-            assert_eq!(*buf.offset(0), 'h' as u8);
-            assert_eq!(*buf.offset(1), 'e' as u8);
-            assert_eq!(*buf.offset(2), 'l' as u8);
-            assert_eq!(*buf.offset(3), 'l' as u8);
-            assert_eq!(*buf.offset(4), 'o' as u8);
+            assert_eq!(*buf.offset(0), b'h');
+            assert_eq!(*buf.offset(1), b'e');
+            assert_eq!(*buf.offset(2), b'l');
+            assert_eq!(*buf.offset(3), b'l');
+            assert_eq!(*buf.offset(4), b'o');
         }
     }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1040,7 +1040,7 @@ mod tests {
     fn test_push_bytes() {
         let mut s = String::from_str("ABC");
         unsafe {
-            s.push_bytes([ 'D' as u8 ]);
+            s.push_bytes([b'D']);
         }
         assert_eq!(s.as_slice(), "ABCD");
     }

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -198,11 +198,11 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
     // Decide what sign to put in front
     match sign {
         SignNeg | SignAll if neg => {
-            buf[end] = '-' as u8;
+            buf[end] = b'-';
             end += 1;
         }
         SignAll => {
-            buf[end] = '+' as u8;
+            buf[end] = b'+';
             end += 1;
         }
         _ => ()
@@ -218,7 +218,7 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
     // Now emit the fractional part, if any
     deccum = num.fract();
     if deccum != _0 || (limit_digits && exact && digit_count > 0) {
-        buf[end] = '.' as u8;
+        buf[end] = b'.';
         end += 1;
         let mut dig = 0u;
 
@@ -269,8 +269,8 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
                     // If reached left end of number, have to
                     // insert additional digit:
                     if i < 0
-                    || buf[i as uint] == '-' as u8
-                    || buf[i as uint] == '+' as u8 {
+                    || buf[i as uint] == b'-'
+                    || buf[i as uint] == b'+' {
                         for j in range(i as uint + 1, end).rev() {
                             buf[j + 1] = buf[j];
                         }
@@ -280,7 +280,7 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
                     }
 
                     // Skip the '.'
-                    if buf[i as uint] == '.' as u8 { i -= 1; continue; }
+                    if buf[i as uint] == b'.' { i -= 1; continue; }
 
                     // Either increment the digit,
                     // or set to 0 if max and carry the 1.
@@ -306,14 +306,14 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
         let mut i = buf_max_i;
 
         // discover trailing zeros of fractional part
-        while i > start_fractional_digits && buf[i] == '0' as u8 {
+        while i > start_fractional_digits && buf[i] == b'0' {
             i -= 1;
         }
 
         // Only attempt to truncate digits if buf has fractional digits
         if i >= start_fractional_digits {
             // If buf ends with '.', cut that too.
-            if buf[i] == '.' as u8 { i -= 1 }
+            if buf[i] == b'.' { i -= 1 }
 
             // only resize buf if we actually remove digits
             if i < buf_max_i {
@@ -323,7 +323,7 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
     } // If exact and trailing '.', just cut that
     else {
         let max_i = end - 1;
-        if buf[max_i] == '.' as u8 {
+        if buf[max_i] == b'.' {
             end = max_i;
         }
     }

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -104,13 +104,13 @@ macro_rules! radix {
     }
 }
 
-radix!(Binary,    2, "0b", x @  0 .. 2 => '0' as u8 + x)
-radix!(Octal,     8, "0o", x @  0 .. 7 => '0' as u8 + x)
-radix!(Decimal,  10, "",   x @  0 .. 9 => '0' as u8 + x)
-radix!(LowerHex, 16, "0x", x @  0 .. 9 => '0' as u8 + x,
-                           x @ 10 ..15 => 'a' as u8 + (x - 10))
-radix!(UpperHex, 16, "0x", x @  0 .. 9 => '0' as u8 + x,
-                           x @ 10 ..15 => 'A' as u8 + (x - 10))
+radix!(Binary,    2, "0b", x @  0 .. 2 => b'0' + x)
+radix!(Octal,     8, "0o", x @  0 .. 7 => b'0' + x)
+radix!(Decimal,  10, "",   x @  0 .. 9 => b'0' + x)
+radix!(LowerHex, 16, "0x", x @  0 .. 9 => b'0' + x,
+                           x @ 10 ..15 => b'a' + (x - 10))
+radix!(UpperHex, 16, "0x", x @  0 .. 9 => b'0' + x,
+                           x @ 10 ..15 => b'A' + (x - 10))
 
 /// A radix with in the range of `2..36`.
 #[deriving(Clone, PartialEq)]
@@ -129,8 +129,8 @@ impl GenericRadix for Radix {
     fn base(&self) -> u8 { self.base }
     fn digit(&self, x: u8) -> u8 {
         match x {
-            x @  0 ..9 => '0' as u8 + x,
-            x if x < self.base() => 'a' as u8 + (x - 10),
+            x @  0 ..9 => b'0' + x,
+            x if x < self.base() => b'a' + (x - 10),
             x => fail!("number not in the range 0..{}: {}", self.base() - 1, x),
         }
     }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1755,7 +1755,7 @@ impl<'a> StrSlice<'a> for &'a str {
     fn lines_any(&self) -> AnyLines<'a> {
         self.lines().map(|line| {
             let l = line.len();
-            if l > 0 && line.as_bytes()[l - 1] == '\r' as u8 { line.slice(0, l - 1) }
+            if l > 0 && line.as_bytes()[l - 1] == b'\r' { line.slice(0, l - 1) }
             else { line }
         })
     }

--- a/src/libdebug/repr.rs
+++ b/src/libdebug/repr.rs
@@ -165,11 +165,11 @@ impl<'a> ReprVisitor<'a> {
     }
 
     pub fn write_escaped_slice(&mut self, slice: &str) -> bool {
-        try!(self, self.writer.write(['"' as u8]));
+        try!(self, self.writer.write([b'"']));
         for ch in slice.chars() {
             if !self.write_escaped_char(ch, true) { return false }
         }
-        try!(self, self.writer.write(['"' as u8]));
+        try!(self, self.writer.write([b'"']));
         true
     }
 
@@ -188,7 +188,7 @@ impl<'a> ReprVisitor<'a> {
                            inner: *const TyDesc) -> bool {
         let mut p = ptr as *const u8;
         let (sz, al) = unsafe { ((*inner).size, (*inner).align) };
-        try!(self, self.writer.write(['[' as u8]));
+        try!(self, self.writer.write([b'[']));
         let mut first = true;
         let mut left = len;
         // unit structs have 0 size, and don't loop forever.
@@ -203,7 +203,7 @@ impl<'a> ReprVisitor<'a> {
             p = align(unsafe { p.offset(sz as int) as uint }, al) as *const u8;
             left -= dec;
         }
-        try!(self, self.writer.write([']' as u8]));
+        try!(self, self.writer.write([b']']));
         true
     }
 
@@ -263,9 +263,9 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
 
     fn visit_char(&mut self) -> bool {
         self.get::<char>(|this, &ch| {
-            try!(this, this.writer.write(['\'' as u8]));
+            try!(this, this.writer.write([b'\'']));
             if !this.write_escaped_char(ch, false) { return false }
-            try!(this, this.writer.write(['\'' as u8]));
+            try!(this, this.writer.write([b'\'']));
             true
         })
     }
@@ -310,7 +310,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
     }
 
     fn visit_rptr(&mut self, mtbl: uint, inner: *const TyDesc) -> bool {
-        try!(self, self.writer.write(['&' as u8]));
+        try!(self, self.writer.write([b'&']));
         self.write_mut_qualifier(mtbl);
         self.get::<*const u8>(|this, p| {
             this.visit_ptr_inner(*p, inner)
@@ -319,7 +319,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
 
     fn visit_evec_slice(&mut self, mtbl: uint, inner: *const TyDesc) -> bool {
         self.get::<raw::Slice<()>>(|this, s| {
-            try!(this, this.writer.write(['&' as u8]));
+            try!(this, this.writer.write([b'&']));
             this.write_mut_qualifier(mtbl);
             let size = unsafe {
                 if (*inner).size == 0 { 1 } else { (*inner).size }
@@ -338,7 +338,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
 
     fn visit_enter_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
-        try!(self, self.writer.write(['{' as u8]));
+        try!(self, self.writer.write([b'{']));
         true
     }
 
@@ -356,7 +356,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
 
     fn visit_leave_rec(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
-        try!(self, self.writer.write(['}' as u8]));
+        try!(self, self.writer.write([b'}']));
         true
     }
 
@@ -365,9 +365,9 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
         try!(self, self.writer.write(name.as_bytes()));
         if n_fields != 0 {
             if named_fields {
-                try!(self, self.writer.write(['{' as u8]));
+                try!(self, self.writer.write([b'{']));
             } else {
-                try!(self, self.writer.write(['(' as u8]));
+                try!(self, self.writer.write([b'(']));
             }
         }
         true
@@ -390,9 +390,9 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
                          _sz: uint, _align: uint) -> bool {
         if n_fields != 0 {
             if named_fields {
-                try!(self, self.writer.write(['}' as u8]));
+                try!(self, self.writer.write([b'}']));
             } else {
-                try!(self, self.writer.write([')' as u8]));
+                try!(self, self.writer.write([b')']));
             }
         }
         true
@@ -400,7 +400,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
 
     fn visit_enter_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
-        try!(self, self.writer.write(['(' as u8]));
+        try!(self, self.writer.write([b'(']));
         true
     }
 
@@ -415,9 +415,9 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
     fn visit_leave_tup(&mut self, _n_fields: uint,
                        _sz: uint, _align: uint) -> bool {
         if _n_fields == 1 {
-            try!(self, self.writer.write([',' as u8]));
+            try!(self, self.writer.write([b',']));
         }
-        try!(self, self.writer.write([')' as u8]));
+        try!(self, self.writer.write([b')']));
         true
     }
 
@@ -455,7 +455,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
         if write {
             try!(self, self.writer.write(name.as_bytes()));
             if n_fields > 0 {
-                try!(self, self.writer.write(['(' as u8]));
+                try!(self, self.writer.write([b'(']));
             }
         }
         true
@@ -487,7 +487,7 @@ impl<'a> TyVisitor for ReprVisitor<'a> {
         match self.var_stk[self.var_stk.len() - 1] {
             Matched => {
                 if n_fields > 0 {
-                    try!(self, self.writer.write([')' as u8]));
+                    try!(self, self.writer.write([b')']));
                 }
             }
             _ => ()

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -372,7 +372,7 @@ impl Matches {
 }
 
 fn is_arg(arg: &str) -> bool {
-    arg.len() > 1 && arg.as_bytes()[0] == '-' as u8
+    arg.len() > 1 && arg.as_bytes()[0] == b'-'
 }
 
 fn find_opt(opts: &[Opt], nm: Name) -> Option<uint> {
@@ -555,7 +555,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
         } else {
             let mut names;
             let mut i_arg = None;
-            if cur.as_bytes()[1] == '-' as u8 {
+            if cur.as_bytes()[1] == b'-' {
                 let tail = cur.as_slice().slice(2, curlen);
                 let tail_eq: Vec<&str> = tail.split('=').collect();
                 if tail_eq.len() <= 1 {

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -1376,7 +1376,7 @@ impl BigInt {
         if buf.is_empty() { return None; }
         let mut sign  = Plus;
         let mut start = 0;
-        if buf[0] == ('-' as u8) {
+        if buf[0] == b'-' {
             sign  = Minus;
             start = 1;
         }

--- a/src/libregex/test/bench.rs
+++ b/src/libregex/test/bench.rs
@@ -159,7 +159,7 @@ fn gen_text(n: uint) -> String {
                        .collect::<Vec<u8>>();
     for (i, b) in bytes.mut_iter().enumerate() {
         if i % 20 == 0 {
-            *b = '\n' as u8
+            *b = b'\n'
         }
     }
     String::from_utf8(bytes).unwrap()

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -89,8 +89,8 @@ impl<'a> ToBase64 for &'a [u8] {
             match config.line_length {
                 Some(line_length) =>
                     if cur_length >= line_length {
-                        v.push('\r' as u8);
-                        v.push('\n' as u8);
+                        v.push(b'\r');
+                        v.push(b'\n');
                         cur_length = 0;
                     },
                 None => ()
@@ -114,8 +114,8 @@ impl<'a> ToBase64 for &'a [u8] {
             match config.line_length {
                 Some(line_length) =>
                     if cur_length >= line_length {
-                        v.push('\r' as u8);
-                        v.push('\n' as u8);
+                        v.push(b'\r');
+                        v.push(b'\n');
                     },
                 None => ()
             }
@@ -130,8 +130,8 @@ impl<'a> ToBase64 for &'a [u8] {
                 v.push(bytes[((n >> 18) & 63) as uint]);
                 v.push(bytes[((n >> 12) & 63) as uint]);
                 if config.pad {
-                    v.push('=' as u8);
-                    v.push('=' as u8);
+                    v.push(b'=');
+                    v.push(b'=');
                 }
             }
             2 => {
@@ -141,7 +141,7 @@ impl<'a> ToBase64 for &'a [u8] {
                 v.push(bytes[((n >> 12) & 63) as uint]);
                 v.push(bytes[((n >> 6 ) & 63) as uint]);
                 if config.pad {
-                    v.push('=' as u8);
+                    v.push(b'=');
                 }
             }
             _ => fail!("Algebra is broken, please alert the math police")

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -113,9 +113,9 @@ impl<'a> FromHex for &'a str {
             buf <<= 4;
 
             match byte as char {
-                'A'..'F' => buf |= byte - ('A' as u8) + 10,
-                'a'..'f' => buf |= byte - ('a' as u8) + 10,
-                '0'..'9' => buf |= byte - ('0' as u8),
+                'A'..'F' => buf |= byte - b'A' + 10,
+                'a'..'f' => buf |= byte - b'a' + 10,
+                '0'..'9' => buf |= byte - b'0',
                 ' '|'\r'|'\n'|'\t' => {
                     buf >>= 4;
                     continue

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -112,11 +112,11 @@ impl<'a> FromHex for &'a str {
         for (idx, byte) in self.bytes().enumerate() {
             buf <<= 4;
 
-            match byte as char {
-                'A'..'F' => buf |= byte - b'A' + 10,
-                'a'..'f' => buf |= byte - b'a' + 10,
-                '0'..'9' => buf |= byte - b'0',
-                ' '|'\r'|'\n'|'\t' => {
+            match byte {
+                b'A'..b'F' => buf |= byte - b'A' + 10,
+                b'a'..b'f' => buf |= byte - b'a' + 10,
+                b'0'..b'9' => buf |= byte - b'0',
+                b' '|b'\r'|b'\n'|b'\t' => {
                     buf >>= 4;
                     continue
                 }

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -119,7 +119,7 @@ impl Ascii {
     /// Check if the character is a space or horizontal tab
     #[inline]
     pub fn is_blank(&self) -> bool {
-        self.chr == ' ' as u8 || self.chr == '\t' as u8
+        self.chr == b' ' || self.chr == b'\t'
     }
 
     /// Check if the character is a control character
@@ -150,7 +150,7 @@ impl Ascii {
     /// Checks if the character is lowercase
     #[inline]
     pub fn is_lowercase(&self) -> bool {
-        (self.chr - 'a' as u8) < 26
+        (self.chr - b'a') < 26
     }
 
     #[inline]
@@ -163,7 +163,7 @@ impl Ascii {
     /// Checks if the character is uppercase
     #[inline]
     pub fn is_uppercase(&self) -> bool {
-        (self.chr - 'A' as u8) < 26
+        (self.chr - b'A') < 26
     }
 
     /// Checks if the character is punctuation
@@ -175,7 +175,7 @@ impl Ascii {
     /// Checks if the character is a valid hex digit
     #[inline]
     pub fn is_hex(&self) -> bool {
-        self.is_digit() || ((self.chr | 32u8) - 'a' as u8) < 6
+        self.is_digit() || ((self.chr | 32u8) - b'a') < 6
     }
 }
 
@@ -792,13 +792,13 @@ mod tests {
 
     #[test]
     fn test_to_string() {
-        let s = Ascii{ chr: 't' as u8 }.to_string();
+        let s = Ascii{ chr: b't' }.to_string();
         assert_eq!(s, "t".to_string());
     }
 
     #[test]
     fn test_show() {
-        let c = Ascii { chr: 't' as u8 };
+        let c = Ascii { chr: b't' };
         assert_eq!(format!("{}", c), "t".to_string());
     }
 }

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -114,7 +114,7 @@ impl DynamicLibrary {
     }
 
     fn separator() -> u8 {
-        if cfg!(windows) {';' as u8} else {':' as u8}
+        if cfg!(windows) {b';'} else {b':'}
     }
 
     /// Returns the current search path for dynamic libraries being used by this

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -248,7 +248,7 @@ impl<W: Writer> LineBufferedWriter<W> {
 
 impl<W: Writer> Writer for LineBufferedWriter<W> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
-        match buf.iter().rposition(|&b| b == '\n' as u8) {
+        match buf.iter().rposition(|&b| b == b'\n') {
             Some(i) => {
                 try!(self.inner.write(buf.slice_to(i + 1)));
                 try!(self.inner.flush());
@@ -524,15 +524,15 @@ mod test {
         assert_eq!(writer.get_ref().get_ref(), &[]);
         writer.flush().unwrap();
         assert_eq!(writer.get_ref().get_ref(), &[0, 1]);
-        writer.write([0, '\n' as u8, 1, '\n' as u8, 2]).unwrap();
+        writer.write([0, b'\n', 1, b'\n', 2]).unwrap();
         assert_eq!(writer.get_ref().get_ref(),
-                   &[0, 1, 0, '\n' as u8, 1, '\n' as u8]);
+                   &[0, 1, 0, b'\n', 1, b'\n']);
         writer.flush().unwrap();
         assert_eq!(writer.get_ref().get_ref(),
-                   &[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2]);
-        writer.write([3, '\n' as u8]).unwrap();
+                   &[0, 1, 0, b'\n', 1, b'\n', 2]);
+        writer.write([3, b'\n']).unwrap();
         assert_eq!(writer.get_ref().get_ref(),
-            &[0, 1, 0, '\n' as u8, 1, '\n' as u8, 2, 3, '\n' as u8]);
+            &[0, 1, 0, b'\n', 1, b'\n', 2, 3, b'\n']);
     }
 
     #[test]
@@ -579,7 +579,7 @@ mod test {
 
     #[test]
     fn test_chars() {
-        let buf = [195u8, 159u8, 'a' as u8];
+        let buf = [195u8, 159u8, b'a'];
         let mut reader = BufferedReader::with_capacity(1, BufReader::new(buf));
         let mut it = reader.chars();
         assert_eq!(it.next(), Some(Ok('ß')));

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1241,8 +1241,8 @@ mod test {
         let mut cur = [0u8, .. 2];
         for f in files {
             let stem = f.filestem_str().unwrap();
-            let root = stem.as_bytes()[0] - ('0' as u8);
-            let name = stem.as_bytes()[1] - ('0' as u8);
+            let root = stem.as_bytes()[0] - b'0';
+            let name = stem.as_bytes()[1] - b'0';
             assert!(cur[root as uint] < name);
             cur[root as uint] = name;
         }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1103,7 +1103,7 @@ pub trait Writer {
     /// that the `write` method is used specifically instead.
     #[inline]
     fn write_line(&mut self, s: &str) -> IoResult<()> {
-        self.write_str(s).and_then(|()| self.write(['\n' as u8]))
+        self.write_str(s).and_then(|()| self.write([b'\n']))
     }
 
     /// Write a single char, encoded as UTF-8.
@@ -1442,7 +1442,7 @@ pub trait Buffer: Reader {
     /// Additionally, this function can fail if the line of input read is not a
     /// valid UTF-8 sequence of bytes.
     fn read_line(&mut self) -> IoResult<String> {
-        self.read_until('\n' as u8).and_then(|line|
+        self.read_until(b'\n').and_then(|line|
             match String::from_utf8(line) {
                 Ok(s)  => Ok(s),
                 Err(_) => Err(standard_error(InvalidInput)),

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -161,12 +161,12 @@ impl<'a> Parser<'a> {
         fn parse_digit(c: char, radix: u8) -> Option<u8> {
             let c = c as u8;
             // assuming radix is either 10 or 16
-            if c >= '0' as u8 && c <= '9' as u8 {
-                Some(c - '0' as u8)
-            } else if radix > 10 && c >= 'a' as u8 && c < 'a' as u8 + (radix - 10) {
-                Some(c - 'a' as u8 + 10)
-            } else if radix > 10 && c >= 'A' as u8 && c < 'A' as u8 + (radix - 10) {
-                Some(c - 'A' as u8 + 10)
+            if c >= b'0' && c <= b'9' {
+                Some(c - b'0')
+            } else if radix > 10 && c >= b'a' && c < b'a' + (radix - 10) {
+                Some(c - b'a' + 10)
+            } else if radix > 10 && c >= b'A' && c < b'A' + (radix - 10) {
+                Some(c - b'A' + 10)
             } else {
                 None
             }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -239,7 +239,7 @@ pub fn print(s: &str) {
 /// `\n` character is printed to the console after the string.
 pub fn println(s: &str) {
     with_task_stdout(|io| {
-        io.write(s.as_bytes()).and_then(|()| io.write(['\n' as u8]))
+        io.write(s.as_bytes()).and_then(|()| io.write([b'\n']))
     })
 }
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -502,7 +502,7 @@ pub mod builtin {
     ///
     /// ```
     /// let rust = bytes!("r", 'u', "st", 255);
-    /// assert_eq!(rust[1], 'u' as u8);
+    /// assert_eq!(rust[1], b'u');
     /// assert_eq!(rust[4], 255);
     /// ```
     #[macro_export]

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -138,12 +138,10 @@ impl_NumStrConv_Integer!(u64)
 
 
 // Special value strings as [u8] consts.
-static INF_BUF:          [u8, ..3] = ['i' as u8, 'n' as u8, 'f' as u8];
-static POS_INF_BUF: [u8, ..4] = ['+' as u8, 'i' as u8, 'n' as u8,
-                                      'f' as u8];
-static NEG_INF_BUF: [u8, ..4] = ['-' as u8, 'i' as u8, 'n' as u8,
-                                      'f' as u8];
-static NAN_BUF:          [u8, ..3] = ['N' as u8, 'a' as u8, 'N' as u8];
+static INF_BUF:     [u8, ..3] = [b'i', b'n', b'f'];
+static POS_INF_BUF: [u8, ..4] = [b'+', b'i', b'n', b'f'];
+static NEG_INF_BUF: [u8, ..4] = [b'-', b'i', b'n', b'f'];
+static NAN_BUF:     [u8, ..3] = [b'N', b'a', b'N'];
 
 /**
  * Converts an integral number to its string representation as a byte vector.
@@ -201,8 +199,8 @@ pub fn int_to_str_bytes_common<T: Int>(num: T, radix: uint, sign: SignFormat, f:
             current_digit_signed
         };
         buf[cur] = match current_digit.to_u8().unwrap() {
-            i @ 0..9 => '0' as u8 + i,
-            i        => 'a' as u8 + (i - 10),
+            i @ 0..9 => b'0' + i,
+            i        => b'a' + (i - 10),
         };
         cur += 1;
 
@@ -213,8 +211,8 @@ pub fn int_to_str_bytes_common<T: Int>(num: T, radix: uint, sign: SignFormat, f:
 
     // Decide what sign to put in front
     match sign {
-        SignNeg | SignAll if neg => { f('-' as u8); }
-        SignAll => { f('+' as u8); }
+        SignNeg | SignAll if neg => { f(b'-'); }
+        SignAll => { f(b'+'); }
         _ => ()
     }
 
@@ -350,10 +348,10 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Float+
     // Decide what sign to put in front
     match sign {
         SignNeg | SignAll if neg => {
-            buf.push('-' as u8);
+            buf.push(b'-');
         }
         SignAll => {
-            buf.push('+' as u8);
+            buf.push(b'+');
         }
         _ => ()
     }
@@ -368,7 +366,7 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Float+
     // Now emit the fractional part, if any
     deccum = num.fract();
     if deccum != _0 || (limit_digits && exact && digit_count > 0) {
-        buf.push('.' as u8);
+        buf.push(b'.');
         let mut dig = 0u;
 
         // calculate new digits while
@@ -415,14 +413,14 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Float+
                     // If reached left end of number, have to
                     // insert additional digit:
                     if i < 0
-                    || *buf.get(i as uint) == '-' as u8
-                    || *buf.get(i as uint) == '+' as u8 {
+                    || *buf.get(i as uint) == b'-'
+                    || *buf.get(i as uint) == b'+' {
                         buf.insert((i + 1) as uint, value2ascii(1));
                         break;
                     }
 
                     // Skip the '.'
-                    if *buf.get(i as uint) == '.' as u8 { i -= 1; continue; }
+                    if *buf.get(i as uint) == b'.' { i -= 1; continue; }
 
                     // Either increment the digit,
                     // or set to 0 if max and carry the 1.
@@ -448,14 +446,14 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Float+
         let mut i = buf_max_i;
 
         // discover trailing zeros of fractional part
-        while i > start_fractional_digits && *buf.get(i) == '0' as u8 {
+        while i > start_fractional_digits && *buf.get(i) == b'0' {
             i -= 1;
         }
 
         // Only attempt to truncate digits if buf has fractional digits
         if i >= start_fractional_digits {
             // If buf ends with '.', cut that too.
-            if *buf.get(i) == '.' as u8 { i -= 1 }
+            if *buf.get(i) == b'.' { i -= 1 }
 
             // only resize buf if we actually remove digits
             if i < buf_max_i {
@@ -465,7 +463,7 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Float+
     } // If exact and trailing '.', just cut that
     else {
         let max_i = buf.len() - 1;
-        if *buf.get(max_i) == '.' as u8 {
+        if *buf.get(max_i) == b'.' {
             buf = Vec::from_slice(buf.slice(0, max_i));
         }
     }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -293,7 +293,7 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
         fn env_convert(input: Vec<Vec<u8>>) -> Vec<(Vec<u8>, Vec<u8>)> {
             let mut pairs = Vec::new();
             for p in input.iter() {
-                let mut it = p.as_slice().splitn(1, |b| *b == '=' as u8);
+                let mut it = p.as_slice().splitn(1, |b| *b == b'=');
                 let key = Vec::from_slice(it.next().unwrap());
                 let val = Vec::from_slice(it.next().unwrap_or(&[]));
                 pairs.push((key, val));

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -351,7 +351,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
         match self.filename() {
             None => None,
             Some(name) => Some({
-                let dot = '.' as u8;
+                let dot = b'.';
                 match name.rposition_elem(&dot) {
                     None | Some(0) => name,
                     Some(1) if name == b".." => name,
@@ -398,7 +398,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
         match self.filename() {
             None => None,
             Some(name) => {
-                let dot = '.' as u8;
+                let dot = b'.';
                 match name.rposition_elem(&dot) {
                     None | Some(0) => None,
                     Some(1) if name == b".." => None,
@@ -474,7 +474,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
         assert!(!contains_nul(&extension));
 
         let val = self.filename().and_then(|name| {
-            let dot = '.' as u8;
+            let dot = b'.';
             let extlen = extension.container_as_bytes().len();
             match (name.rposition_elem(&dot), extlen) {
                 (None, 0) | (Some(0), 0) => None,

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -237,7 +237,7 @@ impl GenericPath for Path {
         match self.sepidx {
             None if b"." == self.repr.as_slice() => false,
             None => {
-                self.repr = vec!['.' as u8];
+                self.repr = vec![b'.'];
                 self.sepidx = None;
                 true
             }

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -737,12 +737,12 @@ impl Path {
             let mut comps = comps;
             match (comps.is_some(),prefix) {
                 (false, Some(DiskPrefix)) => {
-                    if s.as_bytes()[0] >= 'a' as u8 && s.as_bytes()[0] <= 'z' as u8 {
+                    if s.as_bytes()[0] >= b'a' && s.as_bytes()[0] <= b'z' {
                         comps = Some(vec![]);
                     }
                 }
                 (false, Some(VerbatimDiskPrefix)) => {
-                    if s.as_bytes()[4] >= 'a' as u8 && s.as_bytes()[0] <= 'z' as u8 {
+                    if s.as_bytes()[4] >= b'a' && s.as_bytes()[0] <= b'z' {
                         comps = Some(vec![]);
                     }
                 }
@@ -1010,7 +1010,7 @@ fn parse_prefix<'a>(mut path: &'a str) -> Option<PathPrefix> {
             } else {
                 // \\?\path
                 let idx = path.find('\\');
-                if idx == Some(2) && path.as_bytes()[1] == ':' as u8 {
+                if idx == Some(2) && path.as_bytes()[1] == b':' {
                     let c = path.as_bytes()[0];
                     if c.is_ascii() && (c as char).is_alphabetic() {
                         // \\?\C:\ path
@@ -1033,7 +1033,7 @@ fn parse_prefix<'a>(mut path: &'a str) -> Option<PathPrefix> {
             }
             _ => ()
         }
-    } else if path.len() > 1 && path.as_bytes()[1] == ':' as u8 {
+    } else if path.len() > 1 && path.as_bytes()[1] == b':' {
         // C:
         let c = path.as_bytes()[0];
         if c.is_ascii() && (c as char).is_alphabetic() {

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1131,8 +1131,8 @@ impl<'a> StringReader<'a> {
 
     fn read_one_line_comment(&mut self) -> String {
         let val = self.read_to_eol();
-        assert!((val.as_bytes()[0] == '/' as u8 && val.as_bytes()[1] == '/' as u8)
-             || (val.as_bytes()[0] == '#' as u8 && val.as_bytes()[1] == '!' as u8));
+        assert!((val.as_bytes()[0] == b'/' && val.as_bytes()[1] == b'/')
+             || (val.as_bytes()[0] == b'#' && val.as_bytes()[1] == b'!'));
         return val;
     }
 

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -301,12 +301,12 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             SetVar => {
                 if cur >= 'A' && cur <= 'Z' {
                     if stack.len() > 0 {
-                        let idx = (cur as u8) - ('A' as u8);
+                        let idx = (cur as u8) - b'A';
                         vars.sta[idx as uint] = stack.pop().unwrap();
                     } else { return Err("stack is empty".to_string()) }
                 } else if cur >= 'a' && cur <= 'z' {
                     if stack.len() > 0 {
-                        let idx = (cur as u8) - ('a' as u8);
+                        let idx = (cur as u8) - b'a';
                         vars.dyn[idx as uint] = stack.pop().unwrap();
                     } else { return Err("stack is empty".to_string()) }
                 } else {
@@ -315,10 +315,10 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             },
             GetVar => {
                 if cur >= 'A' && cur <= 'Z' {
-                    let idx = (cur as u8) - ('A' as u8);
+                    let idx = (cur as u8) - b'A';
                     stack.push(vars.sta[idx as uint].clone());
                 } else if cur >= 'a' && cur <= 'z' {
-                    let idx = (cur as u8) - ('a' as u8);
+                    let idx = (cur as u8) - b'a';
                     stack.push(vars.dyn[idx as uint].clone());
                 } else {
                     return Err("bad variable name in %g".to_string());
@@ -505,26 +505,25 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
             if flags.precision > s.len() {
                 let mut s_ = Vec::with_capacity(flags.precision);
                 let n = flags.precision - s.len();
-                s_.grow(n, &('0' as u8));
+                s_.grow(n, &b'0');
                 s_.push_all_move(s);
                 s = s_;
             }
             assert!(!s.is_empty(), "string conversion produced empty result");
             match op {
                 FormatDigit => {
-                    if flags.space && !(s[0] == '-' as u8 ||
-                                        s[0] == '+' as u8) {
-                        s.insert(0, ' ' as u8);
+                    if flags.space && !(s[0] == b'-' || s[0] == b'+' ) {
+                        s.insert(0, b' ');
                     }
                 }
                 FormatOctal => {
-                    if flags.alternate && s[0] != '0' as u8 {
-                        s.insert(0, '0' as u8);
+                    if flags.alternate && s[0] != b'0' {
+                        s.insert(0, b'0');
                     }
                 }
                 FormatHex => {
                     if flags.alternate {
-                        let s_ = replace(&mut s, vec!('0' as u8, 'x' as u8));
+                        let s_ = replace(&mut s, vec!(b'0', b'x'));
                         s.push_all_move(s_);
                     }
                 }
@@ -536,7 +535,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                          .move_iter()
                          .collect();
                     if flags.alternate {
-                        let s_ = replace(&mut s, vec!('0' as u8, 'X' as u8));
+                        let s_ = replace(&mut s, vec!(b'0', b'X'));
                         s.push_all_move(s_);
                     }
                 }
@@ -563,10 +562,10 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
     if flags.width > s.len() {
         let n = flags.width - s.len();
         if flags.left {
-            s.grow(n, &(' ' as u8));
+            s.grow(n, &b' ');
         } else {
             let mut s_ = Vec::with_capacity(flags.width);
-            s_.grow(n, &(' ' as u8));
+            s_.grow(n, &b' ');
             s_.push_all_move(s);
             s = s_;
         }
@@ -655,15 +654,15 @@ mod test {
             let s = format!("%{{1}}%{{2}}%{}%d", op);
             let res = expand(s.as_bytes(), [], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
-            assert_eq!(res.unwrap(), vec!('0' as u8 + bs[0]));
+            assert_eq!(res.unwrap(), vec!(b'0' + bs[0]));
             let s = format!("%{{1}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), [], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
-            assert_eq!(res.unwrap(), vec!('0' as u8 + bs[1]));
+            assert_eq!(res.unwrap(), vec!(b'0' + bs[1]));
             let s = format!("%{{2}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), [], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
-            assert_eq!(res.unwrap(), vec!('0' as u8 + bs[2]));
+            assert_eq!(res.unwrap(), vec!(b'0' + bs[2]));
         }
     }
 


### PR DESCRIPTION
This replaces many instances chars being casted to u8 with byte literals.
