### PR TITLE
Char::from_digit signature fix

### DIFF
--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -271,7 +271,7 @@ pub trait Char {
     /// # Failure
     ///
     /// Fails if given a radix > 36.
-    fn from_digit(num: uint, radix: uint) -> Option<char>;
+    fn from_digit(num: uint, radix: uint) -> Option<Self>;
 
     /// Returns the hexadecimal Unicode escape of a character.
     ///


### PR DESCRIPTION
Signature for `from_digit` in `Char` wasn't using `Self` so there was no way to use this method
