### PR TITLE
Temporary bootstrapping hack: introduce syntax for lifetime bounds

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -576,7 +576,7 @@ impl<'a> Visitor<()> for Context<'a> {
         run_lints!(self, check_lifetime_ref, lt);
     }
 
-    fn visit_lifetime_decl(&mut self, lt: &ast::Lifetime, _: ()) {
+    fn visit_lifetime_decl(&mut self, lt: &ast::LifetimeDef, _: ()) {
         run_lints!(self, check_lifetime_decl, lt);
     }
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -150,7 +150,7 @@ pub trait LintPass {
     fn check_variant(&mut self, _: &Context, _: &ast::Variant, _: &ast::Generics) { }
     fn check_opt_lifetime_ref(&mut self, _: &Context, _: Span, _: &Option<ast::Lifetime>) { }
     fn check_lifetime_ref(&mut self, _: &Context, _: &ast::Lifetime) { }
-    fn check_lifetime_decl(&mut self, _: &Context, _: &ast::Lifetime) { }
+    fn check_lifetime_decl(&mut self, _: &Context, _: &ast::LifetimeDef) { }
     fn check_explicit_self(&mut self, _: &Context, _: &ast::ExplicitSelf) { }
     fn check_mac(&mut self, _: &Context, _: &ast::Mac) { }
     fn check_path(&mut self, _: &Context, _: &ast::Path, _: ast::NodeId) { }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -804,9 +804,10 @@ pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::Item) -> Rc<ty::TraitDef> {
             generics.lifetimes
                     .iter()
                     .enumerate()
-                    .map(|(i, def)| ty::ReEarlyBound(def.id,
+                    .map(|(i, def)| ty::ReEarlyBound(def.lifetime.id,
                                                      subst::TypeSpace,
-                                                     i, def.name))
+                                                     i,
+                                                     def.lifetime.name))
                     .collect();
 
         let types =
@@ -1073,7 +1074,7 @@ fn add_unsized_bound(ccx: &CrateCtxt,
 
 fn ty_generics(ccx: &CrateCtxt,
                space: subst::ParamSpace,
-               lifetimes: &Vec<ast::Lifetime>,
+               lifetimes: &Vec<ast::LifetimeDef>,
                types: &OwnedSlice<ast::TyParam>,
                base_generics: ty::Generics)
                -> ty::Generics
@@ -1081,10 +1082,10 @@ fn ty_generics(ccx: &CrateCtxt,
     let mut result = base_generics;
 
     for (i, l) in lifetimes.iter().enumerate() {
-        let def = ty::RegionParameterDef { name: l.name,
+        let def = ty::RegionParameterDef { name: l.lifetime.name,
                                            space: space,
                                            index: i,
-                                           def_id: local_def(l.id) };
+                                           def_id: local_def(l.lifetime.id) };
         debug!("ty_generics: def for region param: {}", def);
         result.regions.push(space, def);
     }

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -976,10 +976,13 @@ impl<'a> Rebuilder<'a> {
                         -> ast::Generics {
         let mut lifetimes = Vec::new();
         for lt in add.iter() {
-            lifetimes.push(*lt);
+            lifetimes.push(ast::LifetimeDef { lifetime: *lt,
+                                              bounds: Vec::new() });
         }
         for lt in generics.lifetimes.iter() {
-            if keep.contains(&lt.name) || !remove.contains(&lt.name) {
+            if keep.contains(&lt.lifetime.name) ||
+                !remove.contains(&lt.lifetime.name)
+            {
                 lifetimes.push((*lt).clone());
             }
         }
@@ -1439,7 +1442,7 @@ impl Resolvable for Rc<ty::TraitRef> {
 
 fn lifetimes_in_scope(tcx: &ty::ctxt,
                       scope_id: ast::NodeId)
-                      -> Vec<ast::Lifetime> {
+                      -> Vec<ast::LifetimeDef> {
     let mut taken = Vec::new();
     let parent = tcx.map.get_parent(scope_id);
     let method_id_opt = match tcx.map.find(parent) {
@@ -1486,10 +1489,10 @@ struct LifeGiver {
 }
 
 impl LifeGiver {
-    fn with_taken(taken: &[ast::Lifetime]) -> LifeGiver {
+    fn with_taken(taken: &[ast::LifetimeDef]) -> LifeGiver {
         let mut taken_ = HashSet::new();
         for lt in taken.iter() {
-            let lt_name = token::get_name(lt.name).get().to_string();
+            let lt_name = token::get_name(lt.lifetime.name).get().to_string();
             taken_.insert(lt_name);
         }
         LifeGiver {

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -358,7 +358,8 @@ impl<'a> Visitor<()> for TermsContext<'a> {
             ast::ItemStruct(_, ref generics) |
             ast::ItemTrait(ref generics, _, _, _) => {
                 for (i, p) in generics.lifetimes.iter().enumerate() {
-                    self.add_inferred(item.id, RegionParam, TypeSpace, i, p.id);
+                    let id = p.lifetime.id;
+                    self.add_inferred(item.id, RegionParam, TypeSpace, i, id);
                 }
                 for (i, p) in generics.ty_params.iter().enumerate() {
                     self.add_inferred(item.id, TypeParam, TypeSpace, i, p.id);

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -410,8 +410,8 @@ mod svh_visitor {
             SawLifetimeRef(content(l.name)).hash(self.st);
         }
 
-        fn visit_lifetime_decl(&mut self, l: &Lifetime, _: E) {
-            SawLifetimeDecl(content(l.name)).hash(self.st);
+        fn visit_lifetime_decl(&mut self, l: &LifetimeDef, _: E) {
+            SawLifetimeDecl(content(l.lifetime.name)).hash(self.st);
         }
 
         // We do recursively walk the bodies of functions/methods

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -614,6 +614,12 @@ impl Clean<Lifetime> for ast::Lifetime {
     }
 }
 
+impl Clean<Lifetime> for ast::LifetimeDef {
+    fn clean(&self) -> Lifetime {
+        Lifetime(token::get_name(self.lifetime.name).get().to_string())
+    }
+}
+
 impl Clean<Lifetime> for ty::RegionParameterDef {
     fn clean(&self) -> Lifetime {
         Lifetime(token::get_name(self.name).get().to_string())

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -160,6 +160,12 @@ pub struct Lifetime {
     pub name: Name
 }
 
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub struct LifetimeDef {
+    pub lifetime: Lifetime,
+    pub bounds: Vec<Lifetime>
+}
+
 /// A "Path" is essentially Rust's notion of a name; for instance:
 /// std::cmp::PartialEq  .  It's represented as a sequence of identifiers,
 /// along with a bunch of supporting information.
@@ -231,7 +237,7 @@ pub struct TyParam {
 /// of a function, enum, trait, etc.
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct Generics {
-    pub lifetimes: Vec<Lifetime>,
+    pub lifetimes: Vec<LifetimeDef>,
     pub ty_params: OwnedSlice<TyParam>,
 }
 
@@ -861,7 +867,7 @@ impl fmt::Show for Onceness {
 /// Represents the type of a closure
 #[deriving(PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct ClosureTy {
-    pub lifetimes: Vec<Lifetime>,
+    pub lifetimes: Vec<LifetimeDef>,
     pub fn_style: FnStyle,
     pub onceness: Onceness,
     pub decl: P<FnDecl>,
@@ -876,7 +882,7 @@ pub struct ClosureTy {
 pub struct BareFnTy {
     pub fn_style: FnStyle,
     pub abi: Abi,
-    pub lifetimes: Vec<Lifetime>,
+    pub lifetimes: Vec<LifetimeDef>,
     pub decl: P<FnDecl>
 }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -369,7 +369,7 @@ impl<'a, O: IdVisitingOperation> IdVisitor<'a, O> {
             self.operation.visit_id(type_parameter.id)
         }
         for lifetime in generics.lifetimes.iter() {
-            self.operation.visit_id(lifetime.id)
+            self.operation.visit_id(lifetime.lifetime.id)
         }
     }
 }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -73,6 +73,11 @@ pub trait AstBuilder {
     fn trait_ref(&self, path: ast::Path) -> ast::TraitRef;
     fn typarambound(&self, path: ast::Path) -> ast::TyParamBound;
     fn lifetime(&self, span: Span, ident: ast::Name) -> ast::Lifetime;
+    fn lifetime_def(&self,
+                    span: Span,
+                    name: ast::Name,
+                    bounds: Vec<ast::Lifetime>)
+                    -> ast::LifetimeDef;
 
     // statements
     fn stmt_expr(&self, expr: Gc<ast::Expr>) -> Gc<ast::Stmt>;
@@ -454,6 +459,17 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
 
     fn lifetime(&self, span: Span, name: ast::Name) -> ast::Lifetime {
         ast::Lifetime { id: ast::DUMMY_NODE_ID, span: span, name: name }
+    }
+
+    fn lifetime_def(&self,
+                    span: Span,
+                    name: ast::Name,
+                    bounds: Vec<ast::Lifetime>)
+                    -> ast::LifetimeDef {
+        ast::LifetimeDef {
+            lifetime: self.lifetime(span, name),
+            bounds: bounds
+        }
     }
 
     fn stmt_expr(&self, expr: Gc<ast::Expr>) -> Gc<ast::Stmt> {

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -395,7 +395,7 @@ impl<'a> TraitDef<'a> {
         let mut ty_params = ty_params.into_vec();
 
         // Copy the lifetimes
-        lifetimes.extend(generics.lifetimes.iter().map(|l| *l));
+        lifetimes.extend(generics.lifetimes.iter().map(|l| (*l).clone()));
 
         // Create the type parameters.
         ty_params.extend(generics.ty_params.iter().map(|ty_param| {
@@ -429,7 +429,11 @@ impl<'a> TraitDef<'a> {
             cx.ty_ident(self.span, ty_param.ident)
         });
 
-        let self_lifetimes = generics.lifetimes.clone();
+        let self_lifetimes: Vec<ast::Lifetime> =
+            generics.lifetimes
+            .iter()
+            .map(|ld| ld.lifetime)
+            .collect();
 
         // Create the type of `self`.
         let self_type = cx.ty_path(

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2082,8 +2082,24 @@ impl<'a> State<'a> {
     }
 
     pub fn print_lifetime(&mut self,
-                          lifetime: &ast::Lifetime) -> IoResult<()> {
+                          lifetime: &ast::Lifetime)
+                          -> IoResult<()>
+    {
         self.print_name(lifetime.name)
+    }
+
+    pub fn print_lifetime_def(&mut self,
+                              lifetime: &ast::LifetimeDef)
+                              -> IoResult<()>
+    {
+        try!(self.print_lifetime(&lifetime.lifetime));
+        let mut sep = ":";
+        for v in lifetime.bounds.iter() {
+            try!(word(&mut self.s, sep));
+            try!(self.print_lifetime(v));
+            sep = "+";
+        }
+        Ok(())
     }
 
     pub fn print_generics(&mut self,
@@ -2102,7 +2118,7 @@ impl<'a> State<'a> {
                 |s, &idx| {
                     if idx < generics.lifetimes.len() {
                         let lifetime = generics.lifetimes.get(idx);
-                        s.print_lifetime(lifetime)
+                        s.print_lifetime_def(lifetime)
                     } else {
                         let idx = idx - generics.lifetimes.len();
                         let param = generics.ty_params.get(idx);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -122,7 +122,7 @@ pub trait Visitor<E: Clone> {
     fn visit_lifetime_ref(&mut self, _lifetime: &Lifetime, _e: E) {
         /*! Visits a reference to a lifetime */
     }
-    fn visit_lifetime_decl(&mut self, _lifetime: &Lifetime, _e: E) {
+    fn visit_lifetime_decl(&mut self, _lifetime: &LifetimeDef, _e: E) {
         /*! Visits a declaration of a lifetime */
     }
     fn visit_explicit_self(&mut self, es: &ExplicitSelf, e: E) {
@@ -424,7 +424,7 @@ pub fn walk_ty<E: Clone, V: Visitor<E>>(visitor: &mut V, typ: &Ty, env: E) {
 }
 
 fn walk_lifetime_decls<E: Clone, V: Visitor<E>>(visitor: &mut V,
-                                                lifetimes: &Vec<Lifetime>,
+                                                lifetimes: &Vec<LifetimeDef>,
                                                 env: E) {
     for l in lifetimes.iter() {
         visitor.visit_lifetime_decl(l, env.clone());

--- a/src/test/compile-fail/regions-bound-lists-feature-gate-2.rs
+++ b/src/test/compile-fail/regions-bound-lists-feature-gate-2.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty
+
+trait Foo { }
+
+fn foo<'a, 'b:'a>() { //~ ERROR region bounds require `issue_5723_bootstrap`
+}
+
+pub fn main() { }

--- a/src/test/run-pass/regions-bound-lists-feature-gate-2.rs
+++ b/src/test/run-pass/regions-bound-lists-feature-gate-2.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty
+
+#![feature(issue_5723_bootstrap)]
+
+trait Foo { }
+
+fn foo<'a, 'b, 'c:'a+'b, 'd>() {
+}
+
+pub fn main() { }


### PR DESCRIPTION
Introduce syntax for lifetime bounds like `'b:'a`, meaning `'b outlives 'a`. Syntax currently does nothing but is needed for full fix to #5763. To use this syntax, the issue_5763_bootstrap feature guard is required.
