### PR TITLE
Add path suffix lookup

### DIFF
--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -21,6 +21,7 @@ use util::small_vector::SmallVector;
 use std::cell::RefCell;
 use std::fmt;
 use std::gc::{Gc, GC};
+use std::io::IoResult;
 use std::iter;
 use std::slice;
 
@@ -817,6 +818,34 @@ pub fn map_decoded_item<F: FoldOps>(map: &Map,
     })));
 
     ii
+}
+
+pub trait NodePrinter {
+    fn print_node(&mut self, node: &Node) -> IoResult<()>;
+}
+
+impl<'a> NodePrinter for pprust::State<'a> {
+    fn print_node(&mut self, node: &Node) -> IoResult<()> {
+        match *node {
+            NodeItem(a)        => self.print_item(&*a),
+            NodeForeignItem(a) => self.print_foreign_item(&*a),
+            NodeTraitMethod(a) => self.print_trait_method(&*a),
+            NodeMethod(a)      => self.print_method(&*a),
+            NodeVariant(a)     => self.print_variant(&*a),
+            NodeExpr(a)        => self.print_expr(&*a),
+            NodeStmt(a)        => self.print_stmt(&*a),
+            NodePat(a)         => self.print_pat(&*a),
+            NodeBlock(a)       => self.print_block(&*a),
+            NodeLifetime(a)    => self.print_lifetime(&*a),
+
+            // these cases do not carry enough information in the
+            // ast_map to reconstruct their full structure for pretty
+            // printing.
+            NodeLocal(_)       => fail!("cannot print isolated Local"),
+            NodeArg(_)         => fail!("cannot print isolated Arg"),
+            NodeStructCtor(_)  => fail!("cannot print isolated StructCtor"),
+        }
+    }
 }
 
 fn node_id_to_string(map: &Map, id: NodeId) -> String {

--- a/src/test/run-make/pretty-print-path-suffix/Makefile
+++ b/src/test/run-make/pretty-print-path-suffix/Makefile
@@ -1,0 +1,9 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) -o $(TMPDIR)/foo.out --pretty normal=foo input.rs
+	$(RUSTC) -o $(TMPDIR)/nest_foo.out --pretty normal=nest::foo input.rs
+	$(RUSTC) -o $(TMPDIR)/foo_method.out --pretty normal=foo_method input.rs
+	diff -u $(TMPDIR)/foo.out foo.pp
+	diff -u $(TMPDIR)/nest_foo.out nest_foo.pp
+	diff -u $(TMPDIR)/foo_method.out foo_method.pp

--- a/src/test/run-make/pretty-print-path-suffix/foo.pp
+++ b/src/test/run-make/pretty-print-path-suffix/foo.pp
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+pub fn foo() -> i32 { 45 } /* foo */
+
+
+pub fn foo() -> &'static str { "i am a foo." } /* nest::foo */

--- a/src/test/run-make/pretty-print-path-suffix/foo_method.pp
+++ b/src/test/run-make/pretty-print-path-suffix/foo_method.pp
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+
+
+
+fn foo_method(&self) -> &'static str { return "i am very similiar to foo."; }
+/* nest::S::foo_method */

--- a/src/test/run-make/pretty-print-path-suffix/input.rs
+++ b/src/test/run-make/pretty-print-path-suffix/input.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+pub fn
+foo() -> i32
+{ 45 }
+
+pub fn bar() -> &'static str { "i am not a foo." }
+
+pub mod nest {
+    pub fn foo() -> &'static str { "i am a foo." }
+
+    struct S;
+    impl S {
+        fn foo_method(&self) -> &'static str {
+            return "i am very similiar to foo.";
+        }
+    }
+}

--- a/src/test/run-make/pretty-print-path-suffix/nest_foo.pp
+++ b/src/test/run-make/pretty-print-path-suffix/nest_foo.pp
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+
+
+pub fn foo() -> &'static str { "i am a foo." } /* nest::foo */


### PR DESCRIPTION
Extended `ast_map::Map` with an iterator over all node id's that match a path suffix.

Extended pretty printer to let users choose particular items to pretty print, either by indicating an integer node-id, or by providing a path suffix.
- Example 1: the suffix `typeck::check::check_struct` matches the item with the path `rustc::middle::typeck::check::check_struct` when compiling the `rustc` crate.
- Example 2: the suffix `and` matches `core::option::Option::and` and `core::result::Result::and` when compiling the `core` crate.

Refactored `pprust` slightly to support the pretty printer changes.

(See individual commits for more description.)
