### PR TITLE
Fix typo in std::sync module documentation

### DIFF
--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -10,7 +10,7 @@
 
 //! Useful synchronization primitives
 //!
-//! This modules contains useful safe and unsafe synchronization primitives.
+//! This module contains useful safe and unsafe synchronization primitives.
 //! Most of the primitives in this module do not provide any sort of locking
 //! and/or blocking at all, but rather provide the necessary tools to build
 //! other types of concurrent primitives.


### PR DESCRIPTION
Fix typo. It's possible it's `These modules` but I think it's supposed to be singular because it's not refering to nested modules.
