### PR TITLE
Remove type from variable declaration

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -379,7 +379,7 @@ of your time with Rust.
 The first thing we'll learn about are 'variable bindings.' They look like this:
 
 ```{rust}
-let x = 5i;
+let x = 5;
 ```
 
 In many languages, this is called a 'variable.' But Rust's variable bindings


### PR DESCRIPTION
In the "Variables" chapter:

> Rust is a statically typed language, which means that we specify our types up front. So why does our first example compile?

The first example includes a type declaration, I removed it.
