### PR TITLE
Implement Win64 system ABI.

### DIFF
--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -13,10 +13,12 @@ use std::option;
 use middle::trans::context::CrateContext;
 use middle::trans::cabi_x86;
 use middle::trans::cabi_x86_64;
+use middle::trans::cabi_x86_win64;
 use middle::trans::cabi_arm;
 use middle::trans::cabi_mips;
 use middle::trans::type_::Type;
 use syntax::abi::{X86, X86_64, Arm, Mips, Mipsel};
+use syntax::abi::{OsWin32};
 
 #[deriving(Clone, PartialEq)]
 pub enum ArgKind {
@@ -107,7 +109,12 @@ pub fn compute_abi_info(ccx: &CrateContext,
                         ret_def: bool) -> FnType {
     match ccx.sess().targ_cfg.arch {
         X86 => cabi_x86::compute_abi_info(ccx, atys, rty, ret_def),
-        X86_64 => cabi_x86_64::compute_abi_info(ccx, atys, rty, ret_def),
+        X86_64 =>
+            if ccx.sess().targ_cfg.os == OsWin32 {
+                cabi_x86_win64::compute_abi_info(ccx, atys, rty, ret_def)
+            } else {
+                cabi_x86_64::compute_abi_info(ccx, atys, rty, ret_def)
+            },
         Arm => cabi_arm::compute_abi_info(ccx, atys, rty, ret_def),
         Mips => cabi_mips::compute_abi_info(ccx, atys, rty, ret_def),
         Mipsel => cabi_mips::compute_abi_info(ccx, atys, rty, ret_def),

--- a/src/librustc/middle/trans/cabi_x86_win64.rs
+++ b/src/librustc/middle/trans/cabi_x86_win64.rs
@@ -1,0 +1,64 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use llvm::*;
+use super::cabi::*;
+use super::common::*;
+use super::machine::*;
+use middle::trans::type_::Type;
+
+// Win64 ABI: http://msdn.microsoft.com/en-us/library/zthk2dkh.aspx
+
+pub fn compute_abi_info(ccx: &CrateContext,
+                          atys: &[Type],
+                          rty: Type,
+                          ret_def: bool) -> FnType {
+    let mut arg_tys = Vec::new();
+
+    let ret_ty;
+    if !ret_def {
+        ret_ty = ArgType::direct(Type::void(ccx), None, None, None);
+    } else if rty.kind() == Struct {
+        ret_ty = match llsize_of_alloc(ccx, rty) {
+            1 => ArgType::direct(rty, Some(Type::i8(ccx)), None, None),
+            2 => ArgType::direct(rty, Some(Type::i16(ccx)), None, None),
+            4 => ArgType::direct(rty, Some(Type::i32(ccx)), None, None),
+            8 => ArgType::direct(rty, Some(Type::i64(ccx)), None, None),
+            _ => ArgType::indirect(rty, Some(StructRetAttribute))
+        };
+    } else {
+        let attr = if rty == Type::i1(ccx) { Some(ZExtAttribute) } else { None };
+        ret_ty = ArgType::direct(rty, None, None, attr);
+    }
+
+    for &t in atys.iter() {
+        let ty = match t.kind() {
+            Struct => {
+                match llsize_of_alloc(ccx, t) {
+                    1 => ArgType::direct(rty, Some(Type::i8(ccx)), None, None),
+                    2 => ArgType::direct(rty, Some(Type::i16(ccx)), None, None),
+                    4 => ArgType::direct(rty, Some(Type::i32(ccx)), None, None),
+                    8 => ArgType::direct(rty, Some(Type::i64(ccx)), None, None),
+                    _ => ArgType::indirect(t, Some(ByValAttribute))
+                }
+            }
+            _ => {
+                let attr = if t == Type::i1(ccx) { Some(ZExtAttribute) } else { None };
+                ArgType::direct(t, None, None, attr)
+            }
+        };
+        arg_tys.push(ty);
+    }
+
+    return FnType {
+        arg_tys: arg_tys,
+        ret_ty: ret_ty,
+    };
+}

--- a/src/librustc/middle/trans/mod.rs
+++ b/src/librustc/middle/trans/mod.rs
@@ -31,6 +31,7 @@ pub mod meth;
 pub mod cabi;
 pub mod cabi_x86;
 pub mod cabi_x86_64;
+pub mod cabi_x86_win64;
 pub mod cabi_arm;
 pub mod cabi_mips;
 pub mod foreign;


### PR DESCRIPTION
This fixes
run-pass/extern-pass-TwoU64s.rs
run-pass/extern-pass-empty.rs
run-pass/extern-return-TwoU64s.rs
