### PR TITLE
Libcore: Fix documentation comment for f32.

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -293,7 +293,7 @@ impl Float for f32 {
     #[inline]
     fn frac_pi_8() -> f32 { consts::FRAC_PI_8 }
 
-    /// 1 .0/ pi
+    /// 1.0 / pi
     #[inline]
     fn frac_1_pi() -> f32 { consts::FRAC_1_PI }
 


### PR DESCRIPTION
On a side note (but maybe this is not the right place to ask), the name `Float::two_pi` is inconsistent with `f32::consts::PI_2`.
