### PR TITLE
don't translate items when monomorphizing foreign-ABI functions

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1932,7 +1932,8 @@ pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
                                                         llfn,
                                                         &param_substs::empty(),
                                                         item.id,
-                                                        None);
+                                                        None,
+                                                        TranslateItems);
             } else {
                 trans_fn(ccx,
                          &**decl,

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -577,7 +577,8 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
                                       llwrapfn: ValueRef,
                                       param_substs: &param_substs,
                                       id: ast::NodeId,
-                                      hash: Option<&str>) {
+                                      hash: Option<&str>,
+                                      handle_items: HandleItemsFlag) {
     let _icx = push_ctxt("foreign::build_foreign_fn");
 
     let fnty = ty::node_id_to_type(ccx.tcx(), id);
@@ -586,7 +587,8 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
 
     unsafe { // unsafe because we call LLVM operations
         // Build up the Rust function (`foo0` above).
-        let llrustfn = build_rust_fn(ccx, decl, body, param_substs, attrs, id, hash);
+        let llrustfn = build_rust_fn(ccx, decl, body, param_substs, attrs, id,
+                                     hash, handle_items);
 
         // Build up the foreign wrapper (`foo` above).
         return build_wrap_fn(ccx, llrustfn, llwrapfn, &tys, mty);
@@ -598,7 +600,8 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
                      param_substs: &param_substs,
                      attrs: &[ast::Attribute],
                      id: ast::NodeId,
-                     hash: Option<&str>)
+                     hash: Option<&str>,
+                     handle_items: HandleItemsFlag)
                      -> ValueRef {
         let _icx = push_ctxt("foreign::foreign::build_rust_fn");
         let tcx = ccx.tcx();
@@ -630,7 +633,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
 
         let llfn = base::decl_internal_rust_fn(ccx, t, ps.as_slice());
         base::set_llvm_fn_attrs(attrs, llfn);
-        base::trans_fn(ccx, decl, body, llfn, param_substs, id, [], TranslateItems);
+        base::trans_fn(ccx, decl, body, llfn, param_substs, id, [], handle_items);
         llfn
     }
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -164,7 +164,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                   if abi != abi::Rust {
                       foreign::trans_rust_fn_with_foreign_abi(
                           ccx, &**decl, &**body, [], d, &psubsts, fn_id.node,
-                          Some(hash.as_slice()));
+                          Some(hash.as_slice()), IgnoreItems);
                   } else {
                       trans_fn(ccx, &**decl, &**body, d, &psubsts, fn_id.node, [],
                                IgnoreItems);

--- a/src/test/run-make/issue-7349/Makefile
+++ b/src/test/run-make/issue-7349/Makefile
@@ -2,10 +2,10 @@
 
 # Test to make sure that inner functions within a polymorphic outer function
 # don't get re-translated when the outer function is monomorphized.  The test
-# code monomorphizes the outer function several times, but the magic constant
-# `8675309` used in the inner function should appear only once in the generated
-# IR.
+# code monomorphizes the outer functions several times, but the magic constants
+# used in the inner functions should each appear only once in the generated IR.
 
 all:
 	$(RUSTC) foo.rs --emit=ir
 	[ "$$(grep -c 8675309 "$(TMPDIR)/foo.ll")" -eq "1" ]
+	[ "$$(grep -c 11235813 "$(TMPDIR)/foo.ll")" -eq "1" ]

--- a/src/test/run-make/issue-7349/foo.rs
+++ b/src/test/run-make/issue-7349/foo.rs
@@ -15,7 +15,16 @@ fn outer<T>() {
     }
 }
 
+extern "C" fn outer_foreign<T>() {
+    #[allow(dead_code)]
+    fn inner() -> uint {
+        11235813
+    }
+}
+
 fn main() {
     outer::<int>();
     outer::<uint>();
+    outer_foreign::<int>();
+    outer_foreign::<uint>();
 }


### PR DESCRIPTION
Extend the changes from #16059 to the new generic foreign functions introduced by #15831.
