### PR TITLE
Remove dumb_println

### DIFF
--- a/src/libgreen/macros.rs
+++ b/src/libgreen/macros.rs
@@ -13,15 +13,14 @@
 
 #![macro_escape]
 
-use std::fmt;
-
 // Indicates whether we should perform expensive sanity checks, including rtassert!
 // FIXME: Once the runtime matures remove the `true` below to turn off rtassert, etc.
 pub static ENFORCE_SANITY: bool = true || !cfg!(rtopt) || cfg!(rtdebug) || cfg!(rtassert);
 
 macro_rules! rterrln (
     ($($arg:tt)*) => ( {
-        format_args!(::macros::dumb_println, $($arg)*)
+        use std::io::stdio;
+        format_args!(stdio::println_args, $($arg)*)
     } )
 )
 
@@ -50,12 +49,6 @@ macro_rules! rtabort (
         ::macros::abort(format!($($arg)*).as_slice());
     } )
 )
-
-pub fn dumb_println(args: &fmt::Arguments) {
-    use std::rt;
-    let mut w = rt::Stderr;
-    let _ = writeln!(&mut w, "{}", args);
-}
 
 pub fn abort(msg: &str) -> ! {
     let msg = if !msg.is_empty() { msg } else { "aborted" };

--- a/src/librustuv/macros.rs
+++ b/src/librustuv/macros.rs
@@ -10,11 +10,10 @@
 
 #![macro_escape]
 
-use std::fmt;
-
 macro_rules! uverrln (
     ($($arg:tt)*) => ( {
-        format_args!(::macros::dumb_println, $($arg)*)
+        use std::io::stdio;
+        format_args!(stdio::println_args, $($arg)*)
     } )
 )
 
@@ -27,8 +26,3 @@ macro_rules! uvdebug (
     })
 )
 
-pub fn dumb_println(args: &fmt::Arguments) {
-    use std::rt;
-    let mut w = rt::Stderr;
-    let _ = writeln!(&mut w, "{}", args);
-}


### PR DESCRIPTION
After #10965, which introduces no-context printing, this is no longer needed.

This PR changes the usage sites of dumb_println to just use println_args, which
passes all tests. However, I don't know enough about the intricacies of this
issue to know if this is a satisfactory replacement, even with #10965.

Fixes #11043
