### PR TITLE
mk: Don't emit landing pads in stage 0.

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -139,6 +139,10 @@ endif
 RUSTFLAGS_STAGE0 += -C prefer-dynamic
 RUSTFLAGS_STAGE1 += -C prefer-dynamic
 
+# Landing pads require a lot of codegen. We can get through bootstrapping faster
+# by not emitting them.
+RUSTFLAGS_STAGE0 += -Z no-landing-pads
+
 # platform-specific auto-configuration
 include $(CFG_SRC_DIR)mk/platform.mk
 


### PR DESCRIPTION
Reduces time to build stage0 from 11:30 to 9:40 on my machine.

There's a tradeoff here since doing this will make the stage1 compile-fail tests fail.

r? @pcwalton
