### PR TITLE
Rustdoc: Fixup Search String Mangling

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -106,7 +106,7 @@ r##"<!DOCTYPE html>
             </p>
             <p>
                 Accepted types are: <code>fn</code>, <code>mod</code>,
-                <code>struct</code> (or <code>str</code>), <code>enum</code>,
+                <code>struct</code>, <code>enum</code>,
                 <code>trait</code>, <code>typedef</code> (or
                 <code>tdef</code>).
             </p>

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -370,10 +370,9 @@
         function getQuery() {
             var matches, type, query = $('.search-input').val();
 
-            matches = query.match(/^(fn|mod|str(uct)?|enum|trait|t(ype)?d(ef)?)\s*:\s*/i);
+            matches = query.match(/^(fn|mod|struct|enum|trait|t(ype)?d(ef)?)\s*:\s*/i);
             if (matches) {
                 type = matches[1].replace(/^td$/, 'typedef')
-                                 .replace(/^str$/, 'struct')
                                  .replace(/^tdef$/, 'typedef')
                                  .replace(/^typed$/, 'typedef');
                 query = query.substring(matches[0].length);

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -368,7 +368,8 @@
         }
 
         function getQuery() {
-            var matches, type, query = $('.search-input').val();
+            var matches, type, query, raw = $('.search-input').val();
+            query = raw;
 
             matches = query.match(/^(fn|mod|struct|enum|trait|t(ype)?d(ef)?)\s*:\s*/i);
             if (matches) {
@@ -379,6 +380,7 @@
             }
 
             return {
+                raw: raw,
                 query: query,
                 type: type,
                 id: query + type,
@@ -534,10 +536,10 @@
             if (browserSupportsHistoryApi()) {
                 if (!history.state && !params.search) {
                     history.pushState(query, "", "?search=" +
-                                                encodeURIComponent(query.query));
+                                                encodeURIComponent(query.raw));
                 } else {
                     history.replaceState(query, "", "?search=" +
-                                                encodeURIComponent(query.query));
+                                                encodeURIComponent(query.raw));
                 }
             }
 


### PR DESCRIPTION
Fixes str/struct ambiguity (by removing the synonym) and pushes raw searches to the history instead of processed ones. 
# [Live Version Here](http://cg.scs.carleton.ca/~abeinges/doc/std/)
