### PR TITLE
optimize position independent code in executables

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -197,6 +197,10 @@ pub mod write {
                              (sess.targ_cfg.os == abi::OsMacos &&
                               sess.targ_cfg.arch == abi::X86_64);
 
+            let any_library = sess.crate_types.borrow().iter().any(|ty| {
+                *ty != config::CrateTypeExecutable
+            });
+
             // OSX has -dead_strip, which doesn't rely on ffunction_sections
             // FIXME(#13846) this should be enabled for windows
             let ffunction_sections = sess.targ_cfg.os != abi::OsMacos &&
@@ -249,6 +253,7 @@ pub mod write {
                             true /* EnableSegstk */,
                             use_softfp,
                             no_fp_elim,
+                            !any_library && reloc_model == llvm::RelocPIC,
                             ffunction_sections,
                             fdata_sections,
                         )

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -340,6 +340,7 @@ pub enum CodeGenOptLevel {
     CodeGenLevelAggressive = 3,
 }
 
+#[deriving(PartialEq)]
 #[repr(C)]
 pub enum RelocMode {
     RelocDefault = 0,
@@ -1869,6 +1870,7 @@ extern {
                                        EnableSegstk: bool,
                                        UseSoftFP: bool,
                                        NoFramePointerElim: bool,
+                                       PositionIndependentExecutable: bool,
                                        FunctionSections: bool,
                                        DataSections: bool) -> TargetMachineRef;
     pub fn LLVMRustDisposeTargetMachine(T: TargetMachineRef);

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -71,6 +71,7 @@ LLVMRustCreateTargetMachine(const char *triple,
                             bool EnableSegmentedStacks,
                             bool UseSoftFloat,
                             bool NoFramePointerElim,
+                            bool PositionIndependentExecutable,
                             bool FunctionSections,
                             bool DataSections) {
     std::string Error;
@@ -83,6 +84,7 @@ LLVMRustCreateTargetMachine(const char *triple,
     }
 
     TargetOptions Options;
+    Options.PositionIndependentExecutable = PositionIndependentExecutable;
     Options.NoFramePointerElim = NoFramePointerElim;
 #if LLVM_VERSION_MINOR < 5
     Options.EnableSegmentedStacks = EnableSegmentedStacks;


### PR DESCRIPTION
Position independent code has fewer requirements in executables, so pass
the appropriate flag to LLVM in order to allow more optimization. At the
moment this means faster thread-local storage.
