### PR TITLE
libnative: process spawning should not close inherited file descriptors

### DIFF
--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -80,7 +80,7 @@ impl Process {
                 rtio::Ignored => { ret.push(None); Ok(None) }
                 rtio::InheritFd(fd) => {
                     ret.push(None);
-                    Ok(Some(file::FileDesc::new(fd, true)))
+                    Ok(Some(file::FileDesc::new(fd, false)))
                 }
                 rtio::CreatePipe(readable, _writable) => {
                     let (reader, writer) = try!(pipe());


### PR DESCRIPTION
Retry pull requesting of https://github.com/rust-lang/rust/pull/16407 after accidentally messing up rebasing of branches and making bors think the PR was merged
