### PR TITLE
librustc: Implement simple `where` clauses.

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -208,7 +208,6 @@ use syntax::util::interner::Interner;
 use syntax::codemap::{Span, Pos};
 use syntax::{abi, ast, codemap, ast_util, ast_map};
 use syntax::ast_util::PostExpansionMethod;
-use syntax::owned_slice::OwnedSlice;
 use syntax::parse::token;
 use syntax::parse::token::special_idents;
 
@@ -1123,8 +1122,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
         return FunctionDebugContext { repr: FunctionWithoutDebugInfo };
     }
 
-    let empty_generics = ast::Generics { lifetimes: Vec::new(),
-                                         ty_params: OwnedSlice::empty() };
+    let empty_generics = ast_util::empty_generics();
 
     let fnitem = cx.tcx.map.get(fn_ast_id);
 

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -781,6 +781,7 @@ impl<'a> Rebuilder<'a> {
         let mut inputs = self.fn_decl.inputs.clone();
         let mut output = self.fn_decl.output;
         let mut ty_params = self.generics.ty_params.clone();
+        let where_clause = self.generics.where_clause.clone();
         let mut kept_lifetimes = HashSet::new();
         for sr in self.same_regions.iter() {
             self.cur_anon.set(0);
@@ -807,7 +808,8 @@ impl<'a> Rebuilder<'a> {
                                              &fresh_lifetimes,
                                              &kept_lifetimes,
                                              &all_region_names,
-                                             ty_params);
+                                             ty_params,
+                                             where_clause);
         let new_fn_decl = ast::FnDecl {
             inputs: inputs,
             output: output,
@@ -981,7 +983,8 @@ impl<'a> Rebuilder<'a> {
                         add: &Vec<ast::Lifetime>,
                         keep: &HashSet<ast::Name>,
                         remove: &HashSet<ast::Name>,
-                        ty_params: OwnedSlice<ast::TyParam>)
+                        ty_params: OwnedSlice<ast::TyParam>,
+                        where_clause: ast::WhereClause)
                         -> ast::Generics {
         let mut lifetimes = Vec::new();
         for lt in add.iter() {
@@ -990,14 +993,14 @@ impl<'a> Rebuilder<'a> {
         }
         for lt in generics.lifetimes.iter() {
             if keep.contains(&lt.lifetime.name) ||
-                !remove.contains(&lt.lifetime.name)
-            {
+                !remove.contains(&lt.lifetime.name) {
                 lifetimes.push((*lt).clone());
             }
         }
         ast::Generics {
             lifetimes: lifetimes,
-            ty_params: ty_params
+            ty_params: ty_params,
+            where_clause: where_clause,
         }
     }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -363,7 +363,7 @@ impl Clean<Item> for doctree::Module {
 
         // determine if we should display the inner contents or
         // the outer `mod` item for the source code.
-        let where = {
+        let whence = {
             let ctxt = super::ctxtkey.get().unwrap();
             let cm = ctxt.sess().codemap();
             let outer = cm.lookup_char_pos(self.where_outer.lo);
@@ -380,7 +380,7 @@ impl Clean<Item> for doctree::Module {
         Item {
             name: Some(name),
             attrs: self.attrs.clean(),
-            source: where.clean(),
+            source: whence.clean(),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
             def_id: ast_util::local_def(self.id),
@@ -781,7 +781,7 @@ impl Clean<Item> for doctree::Function {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
             def_id: ast_util::local_def(self.id),
@@ -917,7 +917,7 @@ impl Clean<Item> for doctree::Trait {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             def_id: ast_util::local_def(self.id),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
@@ -1397,7 +1397,7 @@ impl Clean<Item> for doctree::Struct {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             def_id: ast_util::local_def(self.id),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
@@ -1443,7 +1443,7 @@ impl Clean<Item> for doctree::Enum {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             def_id: ast_util::local_def(self.id),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
@@ -1466,7 +1466,7 @@ impl Clean<Item> for doctree::Variant {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
             def_id: ast_util::local_def(self.id),
@@ -1652,7 +1652,7 @@ impl Clean<Item> for doctree::Typedef {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             def_id: ast_util::local_def(self.id.clone()),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
@@ -1702,7 +1702,7 @@ impl Clean<Item> for doctree::Static {
         Item {
             name: Some(self.name.clean()),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             def_id: ast_util::local_def(self.id),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
@@ -1748,7 +1748,7 @@ impl Clean<Item> for doctree::Impl {
         Item {
             name: None,
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             def_id: ast_util::local_def(self.id),
             visibility: self.vis.clean(),
             stability: self.stab.clean(),
@@ -2115,12 +2115,12 @@ impl Clean<Item> for doctree::Macro {
         Item {
             name: Some(format!("{}!", self.name.clean())),
             attrs: self.attrs.clean(),
-            source: self.where.clean(),
+            source: self.whence.clean(),
             visibility: ast::Public.clean(),
             stability: self.stab.clean(),
             def_id: ast_util::local_def(self.id),
             inner: MacroItem(Macro {
-                source: self.where.to_src(),
+                source: self.whence.to_src(),
             }),
         }
     }

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -93,7 +93,7 @@ pub struct Struct {
     pub generics: ast::Generics,
     pub attrs: Vec<ast::Attribute>,
     pub fields: Vec<ast::StructField>,
-    pub where: Span,
+    pub whence: Span,
 }
 
 pub struct Enum {
@@ -103,7 +103,7 @@ pub struct Enum {
     pub generics: ast::Generics,
     pub attrs: Vec<ast::Attribute>,
     pub id: NodeId,
-    pub where: Span,
+    pub whence: Span,
     pub name: Ident,
 }
 
@@ -114,7 +114,7 @@ pub struct Variant {
     pub id: ast::NodeId,
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
-    pub where: Span,
+    pub whence: Span,
 }
 
 pub struct Function {
@@ -125,7 +125,7 @@ pub struct Function {
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
     pub fn_style: ast::FnStyle,
-    pub where: Span,
+    pub whence: Span,
     pub generics: ast::Generics,
 }
 
@@ -135,7 +135,7 @@ pub struct Typedef {
     pub name: Ident,
     pub id: ast::NodeId,
     pub attrs: Vec<ast::Attribute>,
-    pub where: Span,
+    pub whence: Span,
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
 }
@@ -149,7 +149,7 @@ pub struct Static {
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
     pub id: ast::NodeId,
-    pub where: Span,
+    pub whence: Span,
 }
 
 pub struct Trait {
@@ -159,7 +159,7 @@ pub struct Trait {
     pub parents: Vec<ast::TraitRef>,
     pub attrs: Vec<ast::Attribute>,
     pub id: ast::NodeId,
-    pub where: Span,
+    pub whence: Span,
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
 }
@@ -170,7 +170,7 @@ pub struct Impl {
     pub for_: ast::P<ast::Ty>,
     pub items: Vec<ast::ImplItem>,
     pub attrs: Vec<ast::Attribute>,
-    pub where: Span,
+    pub whence: Span,
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
     pub id: ast::NodeId,
@@ -180,7 +180,7 @@ pub struct Macro {
     pub name: Ident,
     pub id: ast::NodeId,
     pub attrs: Vec<ast::Attribute>,
-    pub where: Span,
+    pub whence: Span,
     pub stab: Option<attr::Stability>,
 }
 

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -91,7 +91,7 @@ impl<'a> RustdocVisitor<'a> {
             attrs: item.attrs.iter().map(|x| *x).collect(),
             generics: generics.clone(),
             fields: sd.fields.iter().map(|x| (*x).clone()).collect(),
-            where: item.span
+            whence: item.span
         }
     }
 
@@ -107,7 +107,7 @@ impl<'a> RustdocVisitor<'a> {
                 stab: self.stability(x.node.id),
                 id: x.node.id,
                 kind: x.node.kind.clone(),
-                where: x.span,
+                whence: x.span,
             });
         }
         Enum {
@@ -118,7 +118,7 @@ impl<'a> RustdocVisitor<'a> {
             generics: params.clone(),
             attrs: it.attrs.iter().map(|x| *x).collect(),
             id: it.id,
-            where: it.span,
+            whence: it.span,
         }
     }
 
@@ -133,7 +133,7 @@ impl<'a> RustdocVisitor<'a> {
             attrs: item.attrs.iter().map(|x| *x).collect(),
             decl: fd.clone(),
             name: item.ident,
-            where: item.span,
+            whence: item.span,
             generics: gen.clone(),
             fn_style: *fn_style,
         }
@@ -297,7 +297,7 @@ impl<'a> RustdocVisitor<'a> {
                     name: item.ident,
                     id: item.id,
                     attrs: item.attrs.iter().map(|x| *x).collect(),
-                    where: item.span,
+                    whence: item.span,
                     vis: item.vis,
                     stab: self.stability(item.id),
                 };
@@ -311,7 +311,7 @@ impl<'a> RustdocVisitor<'a> {
                     id: item.id,
                     name: item.ident,
                     attrs: item.attrs.iter().map(|x| *x).collect(),
-                    where: item.span,
+                    whence: item.span,
                     vis: item.vis,
                     stab: self.stability(item.id),
                 };
@@ -325,7 +325,7 @@ impl<'a> RustdocVisitor<'a> {
                     parents: tr.iter().map(|x| (*x).clone()).collect(),
                     id: item.id,
                     attrs: item.attrs.iter().map(|x| *x).collect(),
-                    where: item.span,
+                    whence: item.span,
                     vis: item.vis,
                     stab: self.stability(item.id),
                 };
@@ -339,7 +339,7 @@ impl<'a> RustdocVisitor<'a> {
                     items: items.iter().map(|x| *x).collect(),
                     attrs: item.attrs.iter().map(|x| *x).collect(),
                     id: item.id,
-                    where: item.span,
+                    whence: item.span,
                     vis: item.vis,
                     stab: self.stability(item.id),
                 };
@@ -360,7 +360,7 @@ impl<'a> RustdocVisitor<'a> {
             id: item.id,
             attrs: item.attrs.iter().map(|x| *x).collect(),
             name: item.ident,
-            where: item.span,
+            whence: item.span,
             stab: self.stability(item.id),
         }
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -245,6 +245,7 @@ pub struct TyParam {
 pub struct Generics {
     pub lifetimes: Vec<LifetimeDef>,
     pub ty_params: OwnedSlice<TyParam>,
+    pub where_clause: WhereClause,
 }
 
 impl Generics {
@@ -259,9 +260,23 @@ impl Generics {
     }
 }
 
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub struct WhereClause {
+    pub id: NodeId,
+    pub predicates: Vec<WherePredicate>,
+}
+
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub struct WherePredicate {
+    pub id: NodeId,
+    pub span: Span,
+    pub ident: Ident,
+    pub bounds: OwnedSlice<TyParamBound>,
+}
+
 /// The set of MetaItems that define the compilation environment of the crate,
 /// used to drive conditional compilation
-pub type CrateConfig = Vec<Gc<MetaItem>> ;
+pub type CrateConfig = Vec<Gc<MetaItem>>;
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct Crate {

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -431,11 +431,14 @@ impl Map {
     /// the iterator will produce node id's for items with paths
     /// such as `foo::bar::quux`, `bar::quux`, `other::bar::quux`, and
     /// any other such items it can find in the map.
-    pub fn nodes_matching_suffix<'a, S:Str>(&'a self, parts: &'a [S]) -> NodesMatchingSuffix<'a,S> {
-        NodesMatchingSuffix { map: self,
-                              item_name: parts.last().unwrap(),
-                              where: parts.slice_to(parts.len() - 1),
-                              idx: 0 }
+    pub fn nodes_matching_suffix<'a, S:Str>(&'a self, parts: &'a [S])
+                                 -> NodesMatchingSuffix<'a,S> {
+        NodesMatchingSuffix {
+            map: self,
+            item_name: parts.last().unwrap(),
+            in_which: parts.slice_to(parts.len() - 1),
+            idx: 0,
+        }
     }
 
     pub fn opt_span(&self, id: NodeId) -> Option<Span> {
@@ -478,20 +481,20 @@ impl Map {
 pub struct NodesMatchingSuffix<'a, S> {
     map: &'a Map,
     item_name: &'a S,
-    where: &'a [S],
+    in_which: &'a [S],
     idx: NodeId,
 }
 
 impl<'a,S:Str> NodesMatchingSuffix<'a,S> {
     /// Returns true only if some suffix of the module path for parent
-    /// matches `self.where`.
+    /// matches `self.in_which`.
     ///
-    /// In other words: let `[x_0,x_1,...,x_k]` be `self.where`;
+    /// In other words: let `[x_0,x_1,...,x_k]` be `self.in_which`;
     /// returns true if parent's path ends with the suffix
     /// `x_0::x_1::...::x_k`.
     fn suffix_matches(&self, parent: NodeId) -> bool {
         let mut cursor = parent;
-        for part in self.where.iter().rev() {
+        for part in self.in_which.iter().rev() {
             let (mod_id, mod_name) = match find_first_mod_parent(self.map, cursor) {
                 None => return false,
                 Some((node_id, name)) => (node_id, name),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -320,8 +320,14 @@ pub fn operator_prec(op: ast::BinOp) -> uint {
 pub static as_prec: uint = 12u;
 
 pub fn empty_generics() -> Generics {
-    Generics {lifetimes: Vec::new(),
-              ty_params: OwnedSlice::empty()}
+    Generics {
+        lifetimes: Vec::new(),
+        ty_params: OwnedSlice::empty(),
+        where_clause: WhereClause {
+            id: DUMMY_NODE_ID,
+            predicates: Vec::new(),
+        }
+    }
 }
 
 // ______________________________________________________________________

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -390,7 +390,7 @@ impl<'a> TraitDef<'a> {
                            methods: Vec<Gc<ast::Method>> ) -> Gc<ast::Item> {
         let trait_path = self.path.to_path(cx, self.span, type_ident, generics);
 
-        let Generics { mut lifetimes, ty_params } =
+        let Generics { mut lifetimes, ty_params, where_clause: _ } =
             self.generics.to_generics(cx, self.span, type_ident, generics);
         let mut ty_params = ty_params.into_vec();
 
@@ -418,7 +418,11 @@ impl<'a> TraitDef<'a> {
         }));
         let trait_generics = Generics {
             lifetimes: lifetimes,
-            ty_params: OwnedSlice::from_vec(ty_params)
+            ty_params: OwnedSlice::from_vec(ty_params),
+            where_clause: ast::WhereClause {
+                id: ast::DUMMY_NODE_ID,
+                predicates: Vec::new(),
+            },
         };
 
         // Create the reference to the trait.

--- a/src/libsyntax/ext/deriving/generic/ty.rs
+++ b/src/libsyntax/ext/deriving/generic/ty.rs
@@ -202,10 +202,15 @@ fn mk_ty_param(cx: &ExtCtxt, span: Span, name: &str,
     cx.typaram(span, cx.ident_of(name), bounds, unbound, None)
 }
 
-fn mk_generics(lifetimes: Vec<ast::LifetimeDef>, ty_params: Vec<ast::TyParam> ) -> Generics {
+fn mk_generics(lifetimes: Vec<ast::LifetimeDef>, ty_params: Vec<ast::TyParam>)
+               -> Generics {
     Generics {
         lifetimes: lifetimes,
-        ty_params: OwnedSlice::from_vec(ty_params)
+        ty_params: OwnedSlice::from_vec(ty_params),
+        where_clause: ast::WhereClause {
+            id: ast::DUMMY_NODE_ID,
+            predicates: Vec::new(),
+        },
     }
 }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -543,7 +543,7 @@ impl<'a> StringReader<'a> {
     // favors rustc debugging effectiveness over runtime efficiency.
 
     /// Scan through input of form \x00name_NNNNNN,ctxt_CCCCCCC\x00
-    /// where: `NNNNNN` is a string of characters forming an integer
+    /// whence: `NNNNNN` is a string of characters forming an integer
     /// (the name) and `CCCCCCC` is a string of characters forming an
     /// integer (the ctxt), separate by a comma and delimited by a
     /// `\x00` marker.
@@ -552,22 +552,22 @@ impl<'a> StringReader<'a> {
         fn bump_expecting_char<'a,D:fmt::Show>(r: &mut StringReader<'a>,
                                                c: char,
                                                described_c: D,
-                                               where: &str) {
+                                               whence: &str) {
             match r.curr {
                 Some(r_c) if r_c == c => r.bump(),
-                Some(r_c) => fail!("expected {}, hit {}, {}", described_c, r_c, where),
-                None      => fail!("expected {}, hit EOF, {}", described_c, where),
+                Some(r_c) => fail!("expected {}, hit {}, {}", described_c, r_c, whence),
+                None      => fail!("expected {}, hit EOF, {}", described_c, whence),
             }
         }
 
-        let where = "while scanning embedded hygienic ident";
+        let whence = "while scanning embedded hygienic ident";
 
         // skip over the leading `\x00`
-        bump_expecting_char(self, '\x00', "nul-byte", where);
+        bump_expecting_char(self, '\x00', "nul-byte", whence);
 
         // skip over the "name_"
         for c in "name_".chars() {
-            bump_expecting_char(self, c, c, where);
+            bump_expecting_char(self, c, c, whence);
         }
 
         let start_bpos = self.last_pos;
@@ -578,16 +578,16 @@ impl<'a> StringReader<'a> {
         let encoded_name : u32 = self.with_str_from(start_bpos, |s| {
             num::from_str_radix(s, 10).unwrap_or_else(|| {
                 fail!("expected digits representing a name, got `{}`, {}, range [{},{}]",
-                      s, where, start_bpos, self.last_pos);
+                      s, whence, start_bpos, self.last_pos);
             })
         });
 
         // skip over the `,`
-        bump_expecting_char(self, ',', "comma", where);
+        bump_expecting_char(self, ',', "comma", whence);
 
         // skip over the "ctxt_"
         for c in "ctxt_".chars() {
-            bump_expecting_char(self, c, c, where);
+            bump_expecting_char(self, c, c, whence);
         }
 
         // find the integer representing the ctxt
@@ -595,12 +595,12 @@ impl<'a> StringReader<'a> {
         self.scan_digits(base);
         let encoded_ctxt : ast::SyntaxContext = self.with_str_from(start_bpos, |s| {
             num::from_str_radix(s, 10).unwrap_or_else(|| {
-                fail!("expected digits representing a ctxt, got `{}`, {}", s, where);
+                fail!("expected digits representing a ctxt, got `{}`, {}", s, whence);
             })
         });
 
         // skip over the `\x00`
-        bump_expecting_char(self, '\x00', "nul-byte", where);
+        bump_expecting_char(self, '\x00', "nul-byte", whence);
 
         ast::Ident { name: ast::Name(encoded_name),
                      ctxt: encoded_ctxt, }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -1053,6 +1053,10 @@ mod test {
                                     ast::Generics{ // no idea on either of these:
                                         lifetimes: Vec::new(),
                                         ty_params: OwnedSlice::empty(),
+                                        where_clause: ast::WhereClause {
+                                            id: ast::DUMMY_NODE_ID,
+                                            predicates: Vec::new(),
+                                        }
                                     },
                                     ast::P(ast::Block {
                                         view_items: Vec::new(),

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -499,18 +499,19 @@ declare_special_idents_and_keywords! {
         (41,                         Proc,       "proc");
         (42,                         Box,        "box");
         (43,                         Const,      "const");
+        (44,                         Where,      "where");
 
         'reserved:
-        (44,                         Alignof,    "alignof");
-        (45,                         Be,         "be");
-        (46,                         Offsetof,   "offsetof");
-        (47,                         Priv,       "priv");
-        (48,                         Pure,       "pure");
-        (49,                         Sizeof,     "sizeof");
-        (50,                         Typeof,     "typeof");
-        (51,                         Unsized,    "unsized");
-        (52,                         Yield,      "yield");
-        (53,                         Do,         "do");
+        (45,                         Alignof,    "alignof");
+        (46,                         Be,         "be");
+        (47,                         Offsetof,   "offsetof");
+        (48,                         Priv,       "priv");
+        (49,                         Pure,       "pure");
+        (50,                         Sizeof,     "sizeof");
+        (51,                         Typeof,     "typeof");
+        (52,                         Unsized,    "unsized");
+        (53,                         Yield,      "yield");
+        (54,                         Do,         "do");
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -584,7 +584,11 @@ impl<'a> State<'a> {
             ast::TyBareFn(f) => {
                 let generics = ast::Generics {
                     lifetimes: f.lifetimes.clone(),
-                    ty_params: OwnedSlice::empty()
+                    ty_params: OwnedSlice::empty(),
+                    where_clause: ast::WhereClause {
+                        id: ast::DUMMY_NODE_ID,
+                        predicates: Vec::new(),
+                    },
                 };
                 try!(self.print_ty_fn(Some(f.abi),
                                       None,
@@ -601,7 +605,11 @@ impl<'a> State<'a> {
             ast::TyClosure(f, ref region) => {
                 let generics = ast::Generics {
                     lifetimes: f.lifetimes.clone(),
-                    ty_params: OwnedSlice::empty()
+                    ty_params: OwnedSlice::empty(),
+                    where_clause: ast::WhereClause {
+                        id: ast::DUMMY_NODE_ID,
+                        predicates: Vec::new(),
+                    },
                 };
                 try!(self.print_ty_fn(None,
                                       Some('&'),
@@ -618,7 +626,11 @@ impl<'a> State<'a> {
             ast::TyProc(ref f) => {
                 let generics = ast::Generics {
                     lifetimes: f.lifetimes.clone(),
-                    ty_params: OwnedSlice::empty()
+                    ty_params: OwnedSlice::empty(),
+                    where_clause: ast::WhereClause {
+                        id: ast::DUMMY_NODE_ID,
+                        predicates: Vec::new(),
+                    },
                 };
                 try!(self.print_ty_fn(None,
                                       Some('~'),
@@ -765,6 +777,7 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 try!(self.word_space("="));
                 try!(self.print_type(&**ty));
+                try!(self.print_where_clause(params));
                 try!(word(&mut self.s, ";"));
                 try!(self.end()); // end the outer ibox
             }
@@ -808,6 +821,7 @@ impl<'a> State<'a> {
                 }
 
                 try!(self.print_type(&**ty));
+                try!(self.print_where_clause(generics));
 
                 try!(space(&mut self.s));
                 try!(self.bopen());
@@ -845,6 +859,7 @@ impl<'a> State<'a> {
                         try!(self.print_path(&trait_.path, false));
                     }
                 }
+                try!(self.print_where_clause(generics));
                 try!(word(&mut self.s, " "));
                 try!(self.bopen());
                 for meth in methods.iter() {
@@ -880,6 +895,7 @@ impl<'a> State<'a> {
         try!(self.head(visibility_qualified(visibility, "enum").as_slice()));
         try!(self.print_ident(ident));
         try!(self.print_generics(generics));
+        try!(self.print_where_clause(generics));
         try!(space(&mut self.s));
         self.print_variants(enum_definition.variants.as_slice(), span)
     }
@@ -2010,7 +2026,8 @@ impl<'a> State<'a> {
         try!(self.nbsp());
         try!(self.print_ident(name));
         try!(self.print_generics(generics));
-        self.print_fn_args_and_ret(decl, opt_explicit_self)
+        try!(self.print_fn_args_and_ret(decl, opt_explicit_self))
+        self.print_where_clause(generics)
     }
 
     pub fn print_fn_args(&mut self, decl: &ast::FnDecl,
@@ -2201,52 +2218,81 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_generics(&mut self,
-                          generics: &ast::Generics) -> IoResult<()> {
-        let total = generics.lifetimes.len() + generics.ty_params.len();
-        if total > 0 {
-            try!(word(&mut self.s, "<"));
+    fn print_type_parameters(&mut self,
+                             lifetimes: &[ast::LifetimeDef],
+                             ty_params: &[ast::TyParam])
+                             -> IoResult<()> {
+        let total = lifetimes.len() + ty_params.len();
+        let mut ints = Vec::new();
+        for i in range(0u, total) {
+            ints.push(i);
+        }
 
-            let mut ints = Vec::new();
-            for i in range(0u, total) {
-                ints.push(i);
-            }
-
-            try!(self.commasep(
-                Inconsistent, ints.as_slice(),
-                |s, &idx| {
-                    if idx < generics.lifetimes.len() {
-                        let lifetime = generics.lifetimes.get(idx);
-                        s.print_lifetime_def(lifetime)
-                    } else {
-                        let idx = idx - generics.lifetimes.len();
-                        let param = generics.ty_params.get(idx);
-                        match param.unbound {
-                            Some(TraitTyParamBound(ref tref)) => {
-                                try!(s.print_trait_ref(tref));
-                                try!(s.word_space("?"));
-                            }
-                            _ => {}
-                        }
-                        try!(s.print_ident(param.ident));
-                        try!(s.print_bounds(&None,
-                                            &param.bounds,
-                                            false,
-                                            false));
-                        match param.default {
-                            Some(ref default) => {
-                                try!(space(&mut s.s));
-                                try!(s.word_space("="));
-                                s.print_type(&**default)
-                            }
-                            _ => Ok(())
-                        }
+        self.commasep(Inconsistent, ints.as_slice(), |s, &idx| {
+            if idx < lifetimes.len() {
+                let lifetime = &lifetimes[idx];
+                s.print_lifetime_def(lifetime)
+            } else {
+                let idx = idx - lifetimes.len();
+                let param = &ty_params[idx];
+                match param.unbound {
+                    Some(TraitTyParamBound(ref tref)) => {
+                        try!(s.print_trait_ref(tref));
+                        try!(s.word_space("?"));
                     }
-                }));
+                    _ => {}
+                }
+                try!(s.print_ident(param.ident));
+                try!(s.print_bounds(&None,
+                                    &param.bounds,
+                                    false,
+                                    false));
+                match param.default {
+                    Some(ref default) => {
+                        try!(space(&mut s.s));
+                        try!(s.word_space("="));
+                        s.print_type(&**default)
+                    }
+                    _ => Ok(())
+                }
+            }
+        })
+    }
+
+    pub fn print_generics(&mut self, generics: &ast::Generics)
+                          -> IoResult<()> {
+        if generics.lifetimes.len() + generics.ty_params.len() > 0 {
+            try!(word(&mut self.s, "<"));
+            try!(self.print_type_parameters(generics.lifetimes.as_slice(),
+                                            generics.ty_params.as_slice()));
             word(&mut self.s, ">")
         } else {
             Ok(())
         }
+    }
+
+    pub fn print_where_clause(&mut self, generics: &ast::Generics)
+                              -> IoResult<()> {
+        if generics.where_clause.predicates.len() == 0 {
+            return Ok(())
+        }
+
+        try!(space(&mut self.s));
+        try!(self.word_space("where"));
+
+        for (i, predicate) in generics.where_clause
+                                      .predicates
+                                      .iter()
+                                      .enumerate() {
+            if i != 0 {
+                try!(self.word_space(","));
+            }
+
+            try!(self.print_ident(predicate.ident));
+            try!(self.print_bounds(&None, &predicate.bounds, false, false));
+        }
+
+        Ok(())
     }
 
     pub fn print_meta_item(&mut self, item: &ast::MetaItem) -> IoResult<()> {
@@ -2470,6 +2516,11 @@ impl<'a> State<'a> {
                 }
                 try!(self.end());
             }
+        }
+
+        match generics {
+            Some(generics) => try!(self.print_where_clause(generics)),
+            None => {}
         }
 
         self.end()

--- a/src/test/auxiliary/where_clauses_xc.rs
+++ b/src/test/auxiliary/where_clauses_xc.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Equal {
+    fn equal(&self, other: &Self) -> bool;
+    fn equals<T,U>(&self, this: &T, that: &T, x: &U, y: &U) -> bool
+            where T: Eq, U: Eq;
+}
+
+impl<T> Equal for T where T: Eq {
+    fn equal(&self, other: &T) -> bool {
+        self == other
+    }
+    fn equals<U,X>(&self, this: &U, other: &U, x: &X, y: &X) -> bool
+            where U: Eq, X: Eq {
+        this == other && x == y
+    }
+}
+
+pub fn equal<T>(x: &T, y: &T) -> bool where T: Eq {
+    x == y
+}
+

--- a/src/test/compile-fail/where-clauses-no-bounds-or-predicates.rs
+++ b/src/test/compile-fail/where-clauses-no-bounds-or-predicates.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn equal1<T>(_: &T, _: &T) -> bool where {
+//~^ ERROR a `where` clause must have at least one predicate in it
+    true
+}
+
+fn equal2<T>(_: &T, _: &T) -> bool where T: {
+//~^ ERROR each predicate in a `where` clause must have at least one bound
+    true
+}
+
+fn main() {
+}
+

--- a/src/test/compile-fail/where-clauses-not-parameter.rs
+++ b/src/test/compile-fail/where-clauses-not-parameter.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn equal<T>(_: &T, _: &T) -> bool where int : Eq {
+    //~^ ERROR undeclared type parameter
+}
+
+fn main() {
+}
+

--- a/src/test/compile-fail/where-clauses-unsatisfied.rs
+++ b/src/test/compile-fail/where-clauses-unsatisfied.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn equal<T>(_: &T, _: &T) -> bool where T : Eq {
+}
+
+struct Struct;
+
+fn main() {
+    equal(&Struct, &Struct)
+    //~^ ERROR failed to find an implementation of trait
+}
+

--- a/src/test/run-pass/where-clauses-cross-crate.rs
+++ b/src/test/run-pass/where-clauses-cross-crate.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:where_clauses_xc.rs
+
+extern crate where_clauses_xc;
+
+use where_clauses_xc::{Equal, equal};
+
+fn main() {
+    println!("{}", equal(&1i, &2i));
+    println!("{}", equal(&1i, &1i));
+    println!("{}", "hello".equal(&"hello"));
+    println!("{}", "hello".equals::<int,&str>(&1i, &1i, &"foo", &"bar"));
+}
+

--- a/src/test/run-pass/where-clauses.rs
+++ b/src/test/run-pass/where-clauses.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Equal {
+    fn equal(&self, other: &Self) -> bool;
+    fn equals<T,U>(&self, this: &T, that: &T, x: &U, y: &U) -> bool
+            where T: Eq, U: Eq;
+}
+
+impl<T> Equal for T where T: Eq {
+    fn equal(&self, other: &T) -> bool {
+        self == other
+    }
+    fn equals<U,X>(&self, this: &U, other: &U, x: &X, y: &X) -> bool
+            where U: Eq, X: Eq {
+        this == other && x == y
+    }
+}
+
+fn equal<T>(x: &T, y: &T) -> bool where T: Eq {
+    x == y
+}
+
+fn main() {
+    println!("{}", equal(&1i, &2i));
+    println!("{}", equal(&1i, &1i));
+    println!("{}", "hello".equal(&"hello"));
+    println!("{}", "hello".equals::<int,&str>(&1i, &1i, &"foo", &"bar"));
+}
+


### PR DESCRIPTION
These `where` clauses are accepted everywhere generics are currently
accepted and desugar during type collection to the type parameter bounds
we have today.

A new keyword, `where`, has been added. Therefore, this is a breaking
change. Change uses of `where` to other identifiers.

[breaking-change]

r? @nikomatsakis (or whoever)
