### PR TITLE
Change std::fmt::{Float,LowerExp,UpperExp} to not print '-NaN' for NANs

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -19,6 +19,7 @@ use collections::Collection;
 use iter::{Iterator, range};
 use kinds::Copy;
 use mem;
+use num::Float;
 use option::{Option, Some, None};
 use ops::Deref;
 use result::{Ok, Err};
@@ -584,7 +585,7 @@ macro_rules! floating(($ty:ident) => {
                                              float::ExpNone,
                                              false,
                                              |bytes| {
-                fmt.pad_integral(*self >= 0.0, "", bytes)
+                fmt.pad_integral(self.is_nan() || *self >= 0.0, "", bytes)
             })
         }
     }
@@ -605,7 +606,7 @@ macro_rules! floating(($ty:ident) => {
                                              float::ExpDec,
                                              false,
                                              |bytes| {
-                fmt.pad_integral(*self >= 0.0, "", bytes)
+                fmt.pad_integral(self.is_nan() || *self >= 0.0, "", bytes)
             })
         }
     }
@@ -626,7 +627,7 @@ macro_rules! floating(($ty:ident) => {
                                              float::ExpDec,
                                              true,
                                              |bytes| {
-                fmt.pad_integral(*self >= 0.0, "", bytes)
+                fmt.pad_integral(self.is_nan() || *self >= 0.0, "", bytes)
             })
         }
     }

--- a/src/test/run-pass/format-nan.rs
+++ b/src/test/run-pass/format-nan.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    use std::f64;
+    let x = "NaN".to_string();
+    assert_eq!(format!("{}", f64::NAN), x);
+    assert_eq!(format!("{:e}", f64::NAN), x);
+    assert_eq!(format!("{:E}", f64::NAN), x);
+}
+


### PR DESCRIPTION
Currently, this:

```
println!("{}", std::f64::NAN);
```

prints "-NaN". This commit is an attempt to change that to "NaN" instead.
