### PR TITLE
librustc: Allow trait bounds on structures and enumerations, and check

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1456,13 +1456,24 @@ pub mod types {
                     pub Data4: [BYTE, ..8],
                 }
 
+                // NOTE(pcwalton, stage0): Remove after snapshot (typeck bug
+                // workaround).
+                #[cfg(stage0)]
                 pub struct WSAPROTOCOLCHAIN {
                     pub ChainLen: c_int,
                     pub ChainEntries: [DWORD, ..MAX_PROTOCOL_CHAIN],
                 }
+                #[cfg(not(stage0))]
+                pub struct WSAPROTOCOLCHAIN {
+                    pub ChainLen: c_int,
+                    pub ChainEntries: [DWORD, ..MAX_PROTOCOL_CHAIN as uint],
+                }
 
                 pub type LPWSAPROTOCOLCHAIN = *mut WSAPROTOCOLCHAIN;
 
+                // NOTE(pcwalton, stage0): Remove after snapshot (typeck bug
+                // workaround).
+                #[cfg(stage0)]
                 pub struct WSAPROTOCOL_INFO {
                     pub dwServiceFlags1: DWORD,
                     pub dwServiceFlags2: DWORD,
@@ -1484,6 +1495,29 @@ pub mod types {
                     pub dwMessageSize: DWORD,
                     pub dwProviderReserved: DWORD,
                     pub szProtocol: [u8, ..WSAPROTOCOL_LEN+1],
+                }
+                #[cfg(not(stage0))]
+                pub struct WSAPROTOCOL_INFO {
+                    pub dwServiceFlags1: DWORD,
+                    pub dwServiceFlags2: DWORD,
+                    pub dwServiceFlags3: DWORD,
+                    pub dwServiceFlags4: DWORD,
+                    pub dwProviderFlags: DWORD,
+                    pub ProviderId: GUID,
+                    pub dwCatalogEntryId: DWORD,
+                    pub ProtocolChain: WSAPROTOCOLCHAIN,
+                    pub iVersion: c_int,
+                    pub iAddressFamily: c_int,
+                    pub iMaxSockAddr: c_int,
+                    pub iMinSockAddr: c_int,
+                    pub iSocketType: c_int,
+                    pub iProtocol: c_int,
+                    pub iProtocolMaxOffset: c_int,
+                    pub iNetworkByteOrder: c_int,
+                    pub iSecurityScheme: c_int,
+                    pub dwMessageSize: DWORD,
+                    pub dwProviderReserved: DWORD,
+                    pub szProtocol: [u8, ..(WSAPROTOCOL_LEN as uint) + 1u],
                 }
 
                 pub type LPWSAPROTOCOL_INFO = *mut WSAPROTOCOL_INFO;

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -17,6 +17,7 @@ use middle::def;
 use middle::pat_util::def_to_path;
 use middle::ty;
 use middle::typeck::astconv;
+use middle::typeck::check;
 use util::nodemap::{DefIdMap};
 
 use syntax::ast::*;
@@ -274,6 +275,17 @@ impl<'a> ConstEvalVisitor<'a> {
 }
 
 impl<'a> Visitor<()> for ConstEvalVisitor<'a> {
+    fn visit_ty(&mut self, t: &Ty, _: ()) {
+        match t.node {
+            TyFixedLengthVec(_, expr) => {
+                check::check_const_in_type(self.tcx, &*expr, ty::mk_uint());
+            }
+            _ => {}
+        }
+
+        visit::walk_ty(self, t, ());
+    }
+
     fn visit_expr_post(&mut self, e: &Expr, _: ()) {
         self.classify(e);
     }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -879,7 +879,6 @@ pub fn ast_ty_to_ty<AC:AstConv, RS:RegionScope>(
                 }
             }
             ast::TyFixedLengthVec(ty, e) => {
-                typeck::write_ty_to_tcx(tcx, e.id, ty::mk_uint());
                 match const_eval::eval_const_expr_partial(tcx, &*e) {
                     Ok(ref r) => {
                         match *r {

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -462,7 +462,6 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
         // These don't define types.
         ast::ItemForeignMod(_) | ast::ItemMod(_) | ast::ItemMac(_) => {}
         ast::ItemEnum(ref enum_definition, ref generics) => {
-            ensure_no_ty_param_bounds(ccx, it.span, generics, "enumeration");
             let pty = ty_of_item(ccx, it);
             write_ty_to_tcx(tcx, it.id, pty.ty);
             get_enum_variant_types(ccx,
@@ -559,9 +558,7 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
             // static trait methods. This is somewhat unfortunate.
             ensure_trait_methods(ccx, it.id, &*trait_def);
         },
-        ast::ItemStruct(struct_def, ref generics) => {
-            ensure_no_ty_param_bounds(ccx, it.span, generics, "structure");
-
+        ast::ItemStruct(struct_def, _) => {
             // Write the class type.
             let pty = ty_of_item(ccx, it);
             write_ty_to_tcx(tcx, it.id, pty.ty);

--- a/src/test/auxiliary/trait_bounds_on_structs_and_enums_xc.rs
+++ b/src/test/auxiliary/trait_bounds_on_structs_and_enums_xc.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Check that constant expressions can be used for declaring the
-// type of a fixed length vector.
+pub trait Trait {}
 
-pub fn main() {
-
-    static FOO: uint = 2;
-    let _v: [int, ..FOO*3];
-
+pub struct Foo<T:Trait> {
+    pub x: T,
 }
+
+pub enum Bar<T:Trait> {
+    ABar(int),
+    BBar(T),
+    CBar(uint),
+}
+

--- a/src/test/compile-fail/deriving-span-Zero-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-struct.rs
@@ -16,9 +16,11 @@ extern crate rand;
 
 struct Error;
 
-#[deriving(Zero)]
+#[deriving(Zero)]   //~ ERROR failed to find an implementation
 struct Struct {
-    x: Error //~ ERROR
+    x: Error //~ ERROR failed to find an implementation
+    //~^ ERROR failed to find an implementation
+    //~^^ ERROR type `Error` does not implement any method in scope
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-14915.rs
+++ b/src/test/compile-fail/issue-14915.rs
@@ -18,4 +18,5 @@ fn main() {
     //~^ ERROR cannot determine a type for this bounded type parameter: unconstrained type
     println!("{}", y + 1);
     //~^ ERROR binary operation `+` cannot be applied to type `Gc<int>`
+    //~^^ ERROR cannot determine a type for this bounded type parameter: unconstrained type
 }

--- a/src/test/compile-fail/map-types.rs
+++ b/src/test/compile-fail/map-types.rs
@@ -19,5 +19,5 @@ fn main() {
     let x: Box<Map<int, int>> = x;
     let y: Box<Map<uint, int>> = box x;
     //~^ ERROR failed to find an implementation of trait collections::Map<uint,int>
-    //         for ~collections::Map<int,int>:Send
+    //~^^ ERROR failed to find an implementation of trait core::collections::Collection
 }

--- a/src/test/compile-fail/non-constant-expr-for-fixed-len-vec.rs
+++ b/src/test/compile-fail/non-constant-expr-for-fixed-len-vec.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test
+//
+// Ignored because of an ICE at the moment.
+
 // Check that non-constant exprs do fail as count in fixed length vec type
 
 fn main() {

--- a/src/test/compile-fail/object-does-not-impl-trait.rs
+++ b/src/test/compile-fail/object-does-not-impl-trait.rs
@@ -15,4 +15,5 @@
 trait Foo {}
 fn take_foo<F:Foo>(f: F) {}
 fn take_object(f: Box<Foo>) { take_foo(f); } //~ ERROR failed to find an implementation of trait
+//~^ ERROR failed to find an implementation
 fn main() {}

--- a/src/test/compile-fail/pinned-deep-copy.rs
+++ b/src/test/compile-fail/pinned-deep-copy.rs
@@ -44,6 +44,7 @@ fn main() {
         // Can't do this copy
         let x = box box box A {y: r(i)};
         let _z = x.clone(); //~ ERROR failed to find an implementation
+        //~^ ERROR failed to find an implementation
         println!("{:?}", x);
     }
     println!("{:?}", *i);

--- a/src/test/compile-fail/trait-bounds-on-structs-and-enums-locals.rs
+++ b/src/test/compile-fail/trait-bounds-on-structs-and-enums-locals.rs
@@ -8,19 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
+trait Trait {}
 
-#![feature(struct_variant)]
-extern crate rand;
+struct Foo<T:Trait> {
+    x: T,
+}
 
-
-struct Error;
-
-#[deriving(Zero)]   //~ ERROR failed to find an implementation
-struct Struct(
-    Error //~ ERROR
+fn main() {
+    let foo = Foo {
     //~^ ERROR failed to find an implementation
-    //~^^ ERROR type `Error` does not implement any method in scope
-);
+    //~^^ ERROR instantiating a type parameter with an incompatible type
+        x: 3i
+    };
+    let baz: Foo<uint> = fail!();
+    //~^ ERROR failed to find an implementation
+    //~^^ ERROR instantiating a type parameter with an incompatible type
+}
 
-fn main() {}

--- a/src/test/compile-fail/trait-bounds-on-structs-and-enums-static.rs
+++ b/src/test/compile-fail/trait-bounds-on-structs-and-enums-static.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Check that constant expressions can be used for declaring the
-// type of a fixed length vector.
+trait Trait {}
 
-pub fn main() {
-
-    static FOO: uint = 2;
-    let _v: [int, ..FOO*3];
-
+struct Foo<T:Trait> {
+    x: T,
 }
+
+static X: Foo<uint> = Foo {
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+    x: 1,
+};
+
+fn main() {
+}
+

--- a/src/test/compile-fail/trait-bounds-on-structs-and-enums-xc.rs
+++ b/src/test/compile-fail/trait-bounds-on-structs-and-enums-xc.rs
@@ -1,0 +1,36 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:trait_bounds_on_structs_and_enums_xc.rs
+
+extern crate trait_bounds_on_structs_and_enums_xc;
+
+use trait_bounds_on_structs_and_enums_xc::{Bar, Foo, Trait};
+
+fn explode(x: Foo<uint>) {}
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+
+fn kaboom(y: Bar<f32>) {}
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+
+fn main() {
+    let foo = Foo {
+    //~^ ERROR failed to find an implementation
+    //~^^ ERROR instantiating a type parameter with an incompatible type
+        x: 3i
+    };
+    let bar: Bar<f64> = return;
+    //~^ ERROR failed to find an implementation
+    //~^^ ERROR instantiating a type parameter with an incompatible type
+    let _ = bar;
+}
+

--- a/src/test/compile-fail/trait-bounds-on-structs-and-enums.rs
+++ b/src/test/compile-fail/trait-bounds-on-structs-and-enums.rs
@@ -1,0 +1,77 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Trait {}
+
+struct Foo<T:Trait> {
+    x: T,
+}
+
+enum Bar<T:Trait> {
+    ABar(int),
+    BBar(T),
+    CBar(uint),
+}
+
+fn explode(x: Foo<uint>) {}
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+
+fn kaboom(y: Bar<f32>) {}
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+
+impl<T> Foo<T> {
+    fn uhoh() {}
+}
+
+struct Baz {
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+    a: Foo<int>,
+}
+
+enum Boo {
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+    Quux(Bar<uint>),
+}
+
+struct Badness<T> {
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+    b: Foo<T>,
+}
+
+enum MoreBadness<T> {
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+    EvenMoreBadness(Bar<T>),
+}
+
+trait PolyTrait<T> {
+    fn whatever() {}
+}
+
+struct Struct;
+
+impl PolyTrait<Foo<uint>> for Struct {
+//~^ ERROR failed to find an implementation
+//~^^ ERROR instantiating a type parameter with an incompatible type
+    fn whatever() {}
+}
+
+fn main() {
+    let bar: Bar<f64> = return;
+    //~^ ERROR failed to find an implementation
+    //~^^ ERROR instantiating a type parameter with an incompatible type
+    let _ = bar;
+}
+

--- a/src/test/compile-fail/unique-pinned-nocopy.rs
+++ b/src/test/compile-fail/unique-pinned-nocopy.rs
@@ -21,5 +21,6 @@ impl Drop for r {
 fn main() {
     let i = box r { b: true };
     let _j = i.clone(); //~ ERROR failed to find an implementation
+    //~^ ERROR failed to find an implementation
     println!("{:?}", i);
 }

--- a/src/test/compile-fail/unique-vec-res.rs
+++ b/src/test/compile-fail/unique-vec-res.rs
@@ -37,6 +37,9 @@ fn main() {
     let r2 = vec!(box r { i: i2 });
     f(r1.clone(), r2.clone());
     //~^ ERROR failed to find an implementation of
+    //~^^ ERROR failed to find an implementation of
+    //~^^^ ERROR failed to find an implementation of
+    //~^^^^ ERROR failed to find an implementation of
     println!("{:?}", (r2, i1.get()));
     println!("{:?}", (r1, i2.get()));
 }

--- a/src/test/compile-fail/vtable-res-trait-param.rs
+++ b/src/test/compile-fail/vtable-res-trait-param.rs
@@ -25,6 +25,7 @@ impl TraitB for int {
 fn call_it<B:TraitB>(b: B)  -> int {
     let y = 4u;
     b.gimme_an_a(y) //~ ERROR failed to find an implementation of trait TraitA
+    //~^ ERROR failed to find an implementation of trait TraitA
 }
 
 fn main() {

--- a/src/test/compile-fail/where-clauses-unsatisfied.rs
+++ b/src/test/compile-fail/where-clauses-unsatisfied.rs
@@ -14,7 +14,10 @@ fn equal<T>(_: &T, _: &T) -> bool where T : Eq {
 struct Struct;
 
 fn main() {
-    equal(&Struct, &Struct)
-    //~^ ERROR failed to find an implementation of trait
+    drop(equal(&Struct, &Struct))
+    //~^ ERROR failed to find an implementation of trait core::cmp::Eq
+    //~^^ ERROR failed to find an implementation of trait core::cmp::PartialEq
+    //~^^^ ERROR failed to find an implementation of trait core::cmp::Eq
+    //~^^^^ ERROR failed to find an implementation of trait core::cmp::PartialEq
 }
 

--- a/src/test/run-pass/trait-bounds-on-structs-and-enums.rs
+++ b/src/test/run-pass/trait-bounds-on-structs-and-enums.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Check that constant expressions can be used for declaring the
-// type of a fixed length vector.
+trait U {}
+trait T<X: U> {}
 
-pub fn main() {
-
-    static FOO: uint = 2;
-    let _v: [int, ..FOO*3];
-
+trait S2<Y: U> {
+    fn m(x: Box<T<Y>>) {}
 }
+
+struct St<X: U> {
+    f: Box<T<X>>,
+}
+
+impl<X: U> St<X> {
+    fn blah() {}
+}
+
+fn main() {}


### PR DESCRIPTION
them during kind checking.

This implements RFC #11.

Closes #15759.

r? @nikomatsakis
