### PR TITLE
Enable deprecation lint on crate-local items

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -264,7 +264,7 @@ impl Bitv {
         assert!(i < self.nbits);
         let w = i / uint::BITS;
         let b = i % uint::BITS;
-        let x = self.storage.get(w) & (1 << b);
+        let x = self.storage[w] & (1 << b);
         x != 0
     }
 
@@ -289,8 +289,8 @@ impl Bitv {
         let w = i / uint::BITS;
         let b = i % uint::BITS;
         let flag = 1 << b;
-        *self.storage.get_mut(w) = if x { *self.storage.get(w) | flag }
-                          else { *self.storage.get(w) & !flag };
+        *self.storage.get_mut(w) = if x { self.storage[w] | flag }
+                          else { self.storage[w] & !flag };
     }
 
     /// Set all bits to 1.
@@ -827,7 +827,7 @@ impl Clone for Bitv {
     fn clone_from(&mut self, source: &Bitv) {
         self.nbits = source.nbits;
         self.storage.reserve(source.storage.len());
-        for (i, w) in self.storage.mut_iter().enumerate() { *w = *source.storage.get(i); }
+        for (i, w) in self.storage.mut_iter().enumerate() { *w = source.storage[i]; }
     }
 }
 
@@ -1146,7 +1146,7 @@ impl BitvSet {
         self_bitv.reserve(other_bitv.capacity());
         // Apply values
         for (i, w) in other_bitv.mask_words(0) {
-            let old = *self_bitv.storage.get(i);
+            let old = self_bitv.storage[i];
             let new = f(old, w);
             *self_bitv.storage.get_mut(i) = new;
         }
@@ -1573,10 +1573,10 @@ impl<'a> Iterator<uint> for TwoBitPositions<'a> {
                 // one Bitv might be longer than the other
                 let word_idx = self.next_idx / uint::BITS;
                 let w1 = if word_idx < s_bitv.storage.len() {
-                             *s_bitv.storage.get(word_idx)
+                             s_bitv.storage[word_idx]
                          } else { 0 };
                 let w2 = if word_idx < o_bitv.storage.len() {
-                             *o_bitv.storage.get(word_idx)
+                             o_bitv.storage[word_idx]
                          } else { 0 };
                 self.current_word = (self.merge)(w1, w2);
             }

--- a/src/libcollections/btree.rs
+++ b/src/libcollections/btree.rs
@@ -299,14 +299,14 @@ impl<K: Ord, V> Leaf<K, V> {
             midpoint = 0;
         }
         loop {
-            let order = self.elts.get(midpoint).key.cmp(&k);
+            let order = self.elts[midpoint].key.cmp(&k);
             match order {
                 Equal => {
                     return None;
                 }
                 Greater => {
                     if midpoint > 0 {
-                        if self.elts.get(midpoint - 1).key.cmp(&k) == Less {
+                        if self.elts[midpoint - 1].key.cmp(&k) == Less {
                             return Some(midpoint);
                         }
                         else {
@@ -322,7 +322,7 @@ impl<K: Ord, V> Leaf<K, V> {
                 }
                 Less => {
                     if midpoint + 1 < self.elts.len() {
-                        if self.elts.get(midpoint + 1).key.cmp(&k) == Greater {
+                        if self.elts[midpoint + 1].key.cmp(&k) == Greater {
                             return Some(midpoint);
                         }
                         else {
@@ -422,7 +422,7 @@ impl<K: Ord, V: Eq> Ord for Leaf<K, V> {
         if self.elts.len() < other.elts.len() {
             return Less;
         }
-        self.elts.get(0).cmp(other.elts.get(0))
+        self.elts[0].cmp(&other.elts[0])
     }
 }
 
@@ -457,14 +457,14 @@ impl<K: Ord, V> Branch<K, V> {
             midpoint = 0u;
         }
         loop {
-            let order = self.elts.get(midpoint).key.cmp(&k);
+            let order = self.elts[midpoint].key.cmp(&k);
             match order {
                 Equal => {
                     return None;
                 }
                 Greater => {
                     if midpoint > 0 {
-                        if self.elts.get(midpoint - 1).key.cmp(&k) == Less {
+                        if self.elts[midpoint - 1].key.cmp(&k) == Less {
                             return Some(midpoint);
                         }
                         else {
@@ -480,7 +480,7 @@ impl<K: Ord, V> Branch<K, V> {
                 }
                 Less => {
                     if midpoint + 1 < self.elts.len() {
-                        if self.elts.get(midpoint + 1).key.cmp(&k) == Greater {
+                        if self.elts[midpoint + 1].key.cmp(&k) == Greater {
                             return Some(midpoint);
                         }
                         else {
@@ -529,15 +529,15 @@ impl<K: Clone + Ord, V: Clone> Branch<K, V> {
             Some(i) => {
                 if i == self.elts.len() {
                     let new_outcome = self.clone().rightmost_child.insert(k.clone(),
-                                                                       v.clone(),
-                                                                       ub.clone());
+                                                                          v.clone(),
+                                                                          ub.clone());
                     new_branch = new_outcome.clone().val0();
                     outcome = new_outcome.val1();
                 }
                 else {
-                    let new_outcome = self.elts.get(i).left.clone().insert(k.clone(),
-                                                                                 v.clone(),
-                                                                                 ub.clone());
+                    let new_outcome = self.elts[i].left.clone().insert(k.clone(),
+                                                                       v.clone(),
+                                                                       ub.clone());
                     new_branch = new_outcome.clone().val0();
                     outcome = new_outcome.val1();
                 }
@@ -581,7 +581,7 @@ impl<K: Clone + Ord, V: Clone> Branch<K, V> {
                 //If we have a new branch node, attempt to insert it into the tree
                 //as with the key-value pair, then check to see if the node is overfull.
                 BranchNode(branch) => {
-                    let new_elt = branch.elts.get(0).clone();
+                    let new_elt = branch.elts[0].clone();
                     let new_elt_index = self.bsearch_branch(new_elt.clone().key);
                     match new_elt_index {
                         None => {
@@ -652,7 +652,7 @@ impl<K: Ord, V: Eq> Ord for Branch<K, V> {
         if self.elts.len() < other.elts.len() {
             return Less;
         }
-        self.elts.get(0).cmp(other.elts.get(0))
+        self.elts[0].cmp(&other.elts[0])
     }
 }
 

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -654,7 +654,7 @@ impl<A> Iterator<A> for MoveItems<A> {
 
 impl<A> DoubleEndedIterator<A> for MoveItems<A> {
     #[inline]
-    fn next_back(&mut self) -> Option<A> { self.list.pop_back() }
+    fn next_back(&mut self) -> Option<A> { self.list.pop() }
 }
 
 impl<A> FromIterator<A> for DList<A> {
@@ -667,7 +667,7 @@ impl<A> FromIterator<A> for DList<A> {
 
 impl<A> Extendable<A> for DList<A> {
     fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
-        for elt in iterator { self.push_back(elt); }
+        for elt in iterator { self.push(elt); }
     }
 }
 

--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -261,7 +261,7 @@ impl<T: Ord> PriorityQueue<T> {
     ///
     /// ```
     pub fn top<'a>(&'a self) -> Option<&'a T> {
-        if self.is_empty() { None } else { Some(self.data.get(0)) }
+        if self.is_empty() { None } else { Some(&self.data[0]) }
     }
 
     #[deprecated="renamed to `top`"]
@@ -473,7 +473,7 @@ impl<T: Ord> PriorityQueue<T> {
 
             while pos > start {
                 let parent = (pos - 1) >> 1;
-                if new > *self.data.get(parent) {
+                if new > self.data[parent] {
                     let x = replace(self.data.get_mut(parent), zeroed());
                     ptr::write(self.data.get_mut(pos), x);
                     pos = parent;
@@ -493,7 +493,7 @@ impl<T: Ord> PriorityQueue<T> {
             let mut child = 2 * pos + 1;
             while child < end {
                 let right = child + 1;
-                if right < end && !(*self.data.get(child) > *self.data.get(right)) {
+                if right < end && !(self.data[child] > self.data[right]) {
                     child = right;
                 }
                 let x = replace(self.data.get_mut(child), zeroed());

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -53,7 +53,7 @@ impl<T> Mutable for RingBuf<T> {
 impl<T> Deque<T> for RingBuf<T> {
     /// Return a reference to the first element in the RingBuf
     fn front<'a>(&'a self) -> Option<&'a T> {
-        if self.nelts > 0 { Some(self.get(0)) } else { None }
+        if self.nelts > 0 { Some(&self[0]) } else { None }
     }
 
     /// Return a mutable reference to the first element in the RingBuf
@@ -63,7 +63,7 @@ impl<T> Deque<T> for RingBuf<T> {
 
     /// Return a reference to the last element in the RingBuf
     fn back<'a>(&'a self) -> Option<&'a T> {
-        if self.nelts > 0 { Some(self.get(self.nelts - 1)) } else { None }
+        if self.nelts > 0 { Some(&self[self.nelts - 1]) } else { None }
     }
 
     /// Return a mutable reference to the last element in the RingBuf
@@ -152,7 +152,7 @@ impl<T> RingBuf<T> {
     #[deprecated = "prefer using indexing, e.g., ringbuf[0]"]
     pub fn get<'a>(&'a self, i: uint) -> &'a T {
         let idx = self.raw_index(i);
-        match *self.elts.get(idx) {
+        match self.elts[idx] {
             None => fail!(),
             Some(ref v) => v
         }
@@ -481,6 +481,7 @@ impl<S: Writer, A: Hash<S>> Hash<S> for RingBuf<A> {
 
 impl<A> Index<uint, A> for RingBuf<A> {
     #[inline]
+    #[allow(deprecated)]
     fn index<'a>(&'a self, i: &uint) -> &'a A {
         self.get(*i)
     }
@@ -506,7 +507,7 @@ impl<A> FromIterator<A> for RingBuf<A> {
 impl<A> Extendable<A> for RingBuf<A> {
     fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
         for elt in iterator {
-            self.push_back(elt);
+            self.push(elt);
         }
     }
 }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -190,7 +190,7 @@ impl Iterator<(uint, uint)> for ElementSwaps {
         let max = self.sdir.iter().map(|&x| x).enumerate()
                            .filter(|&(i, sd)|
                                 new_pos(i, sd.dir) < self.sdir.len() &&
-                                self.sdir.get(new_pos(i, sd.dir)).size < sd.size)
+                                self.sdir[new_pos(i, sd.dir)].size < sd.size)
                            .max_by(|&(_, sd)| sd.size);
         match max {
             Some((i, sd)) => {

--- a/src/libcollections/smallintmap.rs
+++ b/src/libcollections/smallintmap.rs
@@ -86,7 +86,7 @@ impl<V> Map<uint, V> for SmallIntMap<V> {
     /// Return a reference to the value corresponding to the key.
     fn find<'a>(&'a self, key: &uint) -> Option<&'a V> {
         if *key < self.v.len() {
-            match *self.v.get(*key) {
+            match self.v[*key] {
               Some(ref value) => Some(value),
               None => None
             }
@@ -421,6 +421,7 @@ impl<V> Extendable<(uint, V)> for SmallIntMap<V> {
 
 impl<V> Index<uint, V> for SmallIntMap<V> {
     #[inline]
+    #[allow(deprecated)]
     fn index<'a>(&'a self, i: &uint) -> &'a V {
         self.get(i)
     }

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -251,11 +251,11 @@ impl<'a> Iterator<char> for Decompositions<'a> {
         match self.buffer.as_slice().head() {
             Some(&(c, 0)) => {
                 self.sorted = false;
-                self.buffer.shift();
+                self.buffer.remove(0);
                 return Some(c);
             }
             Some(&(c, _)) if self.sorted => {
-                self.buffer.shift();
+                self.buffer.remove(0);
                 return Some(c);
             }
             _ => self.sorted = false
@@ -287,7 +287,7 @@ impl<'a> Iterator<char> for Decompositions<'a> {
             self.sorted = true;
         }
 
-        match self.buffer.shift() {
+        match self.buffer.remove(0) {
             Some((c, 0)) => {
                 self.sorted = false;
                 Some(c)
@@ -805,21 +805,21 @@ pub trait StrAllocating: Str {
 
             for (j, tc) in t.chars().enumerate() {
 
-                let next = *dcol.get(j + 1);
+                let next = dcol[j + 1];
 
                 if sc == tc {
                     *dcol.get_mut(j + 1) = current;
                 } else {
                     *dcol.get_mut(j + 1) = cmp::min(current, next);
-                    *dcol.get_mut(j + 1) = cmp::min(*dcol.get(j + 1),
-                                                    *dcol.get(j)) + 1;
+                    *dcol.get_mut(j + 1) = cmp::min(dcol[j + 1],
+                                                    dcol[j]) + 1;
                 }
 
                 current = next;
             }
         }
 
-        return *dcol.get(tlen);
+        return dcol[tlen];
     }
 
     /// An Iterator over the string in Unicode Normalization Form D

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -669,7 +669,7 @@ impl String {
     /// }
     /// ```
     pub unsafe fn shift_byte(&mut self) -> Option<u8> {
-        self.vec.shift()
+        self.vec.remove(0)
     }
 
     /// Removes the first character from the string buffer and returns it.

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -453,6 +453,7 @@ impl<T:Clone> Clone for Vec<T> {
 
 impl<T> Index<uint,T> for Vec<T> {
     #[inline]
+    #[allow(deprecated)] // allow use of get
     fn index<'a>(&'a self, index: &uint) -> &'a T {
         self.get(*index)
     }

--- a/src/libfourcc/lib.rs
+++ b/src/libfourcc/lib.rs
@@ -42,6 +42,7 @@ fn main() {
 #![crate_name = "fourcc"]
 #![deprecated = "This is now a cargo package located at: \
                  https://github.com/rust-lang/fourcc"]
+#![allow(deprecated)]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libhexfloat/lib.rs
+++ b/src/libhexfloat/lib.rs
@@ -39,6 +39,7 @@ fn main() {
 #![crate_name = "hexfloat"]
 #![deprecated = "This is now a cargo package located at: \
                  https://github.com/rust-lang/hexfloat"]
+#![allow(deprecated)]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1479,20 +1479,20 @@ impl LintPass for Stability {
             _ => return
         };
 
-        // stability attributes are promises made across crates; do not
-        // check anything for crate-local usage.
-        if ast_util::is_local(id) { return }
-
         let stability = stability::lookup(cx.tcx, id);
+        let cross_crate = !ast_util::is_local(id);
+
+        // stability attributes are promises made across crates; only
+        // check DEPRECATED for crate-local usage.
         let (lint, label) = match stability {
             // no stability attributes == Unstable
-            None => (UNSTABLE, "unmarked"),
-            Some(attr::Stability { level: attr::Unstable, .. }) =>
-                    (UNSTABLE, "unstable"),
-            Some(attr::Stability { level: attr::Experimental, .. }) =>
-                    (EXPERIMENTAL, "experimental"),
+            None if cross_crate => (UNSTABLE, "unmarked"),
+            Some(attr::Stability { level: attr::Unstable, .. }) if cross_crate =>
+                (UNSTABLE, "unstable"),
+            Some(attr::Stability { level: attr::Experimental, .. }) if cross_crate =>
+                (EXPERIMENTAL, "experimental"),
             Some(attr::Stability { level: attr::Deprecated, .. }) =>
-                    (DEPRECATED, "deprecated"),
+                (DEPRECATED, "deprecated"),
             _ => return
         };
 

--- a/src/libsemver/lib.rs
+++ b/src/libsemver/lib.rs
@@ -31,6 +31,7 @@
 #![crate_name = "semver"]
 #![deprecated = "This is now a cargo package located at: \
                  https://github.com/rust-lang/semver"]
+#![allow(deprecated)]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libsync/atomic.rs
+++ b/src/libsync/atomic.rs
@@ -101,6 +101,8 @@
 //! }
 //! ```
 
+#![allow(deprecated)]
+
 use core::prelude::*;
 
 use alloc::boxed::Box;

--- a/src/libsync/comm/duplex.rs
+++ b/src/libsync/comm/duplex.rs
@@ -15,6 +15,7 @@ Higher level communication abstractions.
 */
 
 #![allow(missing_doc)]
+#![allow(deprecated)]
 #![deprecated = "This type is replaced by having a pair of channels. This type \
                  is not fully composable with other channels in terms of \
                  or possible semantics on a duplex stream. It will be removed \

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -12,6 +12,7 @@
 
 #![crate_name = "url"]
 #![deprecated="This is being removed. Use rust-url instead. http://servo.github.io/rust-url/"]
+#![allow(deprecated)]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -59,6 +59,7 @@ Examples of string representations:
 #![crate_name = "uuid"]
 #![deprecated = "This is now a cargo package located at: \
                  https://github.com/rust-lang/uuid"]
+#![allow(deprecated)]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![license = "MIT/ASL2"]

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -329,19 +329,19 @@ mod this_crate {
     pub struct LockedTupleStruct(int);
 
     fn test() {
-        // None of the following should generate errors, because
-        // stability attributes now have meaning only *across* crates,
-        // not within a single crate.
+        // Only the deprecated cases of the following should generate
+        // errors, because other stability attributes now have meaning
+        // only *across* crates, not within a single crate.
 
         let foo = MethodTester;
 
-        deprecated();
-        foo.method_deprecated();
-        foo.trait_deprecated();
+        deprecated(); //~ ERROR use of deprecated item
+        foo.method_deprecated(); //~ ERROR use of deprecated item
+        foo.trait_deprecated(); //~ ERROR use of deprecated item
 
-        deprecated_text();
-        foo.method_deprecated_text();
-        foo.trait_deprecated_text();
+        deprecated_text(); //~ ERROR use of deprecated item: text
+        foo.method_deprecated_text(); //~ ERROR use of deprecated item: text
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
 
         experimental();
         foo.method_experimental();
@@ -387,8 +387,7 @@ mod this_crate {
         foo.method_locked_text();
         foo.trait_locked_text();
 
-
-        let _ = DeprecatedStruct { i: 0 };
+        let _ = DeprecatedStruct { i: 0 }; //~ ERROR use of deprecated item
         let _ = ExperimentalStruct { i: 0 };
         let _ = UnstableStruct { i: 0 };
         let _ = UnmarkedStruct { i: 0 };
@@ -396,7 +395,7 @@ mod this_crate {
         let _ = FrozenStruct { i: 0 };
         let _ = LockedStruct { i: 0 };
 
-        let _ = DeprecatedUnitStruct;
+        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated item
         let _ = ExperimentalUnitStruct;
         let _ = UnstableUnitStruct;
         let _ = UnmarkedUnitStruct;
@@ -404,7 +403,7 @@ mod this_crate {
         let _ = FrozenUnitStruct;
         let _ = LockedUnitStruct;
 
-        let _ = DeprecatedVariant;
+        let _ = DeprecatedVariant; //~ ERROR use of deprecated item
         let _ = ExperimentalVariant;
         let _ = UnstableVariant;
         let _ = UnmarkedVariant;
@@ -412,7 +411,7 @@ mod this_crate {
         let _ = FrozenVariant;
         let _ = LockedVariant;
 
-        let _ = DeprecatedTupleStruct (1);
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated item
         let _ = ExperimentalTupleStruct (1);
         let _ = UnstableTupleStruct (1);
         let _ = UnmarkedTupleStruct (1);
@@ -422,8 +421,8 @@ mod this_crate {
     }
 
     fn test_method_param<F: Trait>(foo: F) {
-        foo.trait_deprecated();
-        foo.trait_deprecated_text();
+        foo.trait_deprecated(); //~ ERROR use of deprecated item
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
         foo.trait_experimental();
         foo.trait_experimental_text();
         foo.trait_unstable();
@@ -433,8 +432,8 @@ mod this_crate {
     }
 
     fn test_method_object(foo: &Trait) {
-        foo.trait_deprecated();
-        foo.trait_deprecated_text();
+        foo.trait_deprecated(); //~ ERROR use of deprecated item
+        foo.trait_deprecated_text(); //~ ERROR use of deprecated item: text
         foo.trait_experimental();
         foo.trait_experimental_text();
         foo.trait_unstable();


### PR DESCRIPTION
Previously the stability lint considered cross-crate items only. That's appropriate for unstable and experimental levels, but not for deprecation.

In addition to changing the lint, this PR takes care of the fallout: a number of deprecated items that were being used throughout libstd.

Closes #16409

Due to deny(deprecated), this is a:

[breaking-change]
