### PR TITLE
Win32 => Windows

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -16,7 +16,8 @@ use header::TestProps;
 use header;
 use procsrv;
 use util::logv;
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 use util;
 
 use std::io::File;
@@ -816,7 +817,8 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         format!("{}:{}:", testfile.display(), ee.line)
     }).collect::<Vec<String> >();
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     fn to_lower( s : &str ) -> String {
         let i = s.chars();
         let c : Vec<char> = i.map( |c| {
@@ -829,7 +831,8 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         String::from_chars(c.as_slice())
     }
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     fn prefix_matches( line : &str, prefix : &str ) -> bool {
         to_lower(line).as_slice().starts_with(to_lower(prefix).as_slice())
     }
@@ -1246,14 +1249,16 @@ fn make_cmdline(_libpath: &str, prog: &str, args: &[String]) -> String {
     format!("{} {}", prog, args.connect(" "))
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 fn make_cmdline(libpath: &str, prog: &str, args: &[String]) -> String {
     format!("{} {} {}", lib_path_cmd_prefix(libpath), prog, args.connect(" "))
 }
 
 // Build the LD_LIBRARY_PATH variable as it would be seen on the command line
 // for diagnostic purposes
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 fn lib_path_cmd_prefix(path: &str) -> String {
     format!("{}=\"{}\"", util::lib_path_env_var(), util::make_new_path(path))
 }

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -10,13 +10,15 @@
 
 use common::Config;
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 use std::os::getenv;
 
 /// Conversion table from triple OS name to Rust SYSNAME
 static OS_TABLE: &'static [(&'static str, &'static str)] = &[
-    ("mingw32", "win32"),
-    ("win32", "win32"),
+    ("mingw32", "windows"),
+    ("win32", "windows"),
+    ("windows", "windows"),
     ("darwin", "macos"),
     ("android", "android"),
     ("linux", "linux"),
@@ -33,7 +35,8 @@ pub fn get_os(triple: &str) -> &'static str {
     fail!("Cannot determine OS from triple");
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 pub fn make_new_path(path: &str) -> String {
 
     // Windows just uses PATH as the library search path, so we have to
@@ -46,10 +49,12 @@ pub fn make_new_path(path: &str) -> String {
     }
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 pub fn lib_path_env_var() -> &'static str { "PATH" }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 pub fn path_div() -> &'static str { ";" }
 
 pub fn logv(config: &Config, s: String) {

--- a/src/etc/mklldeps.py
+++ b/src/etc/mklldeps.py
@@ -61,13 +61,15 @@ for llconfig in sys.argv[4:]:
     elif 'android' in os:
         os = 'android'
     elif 'win' in os or 'mingw' in os:
-        os = 'win32'
+        os = 'windows'
     cfg = [
         "target_arch = \"" + arch + "\"",
         "target_os = \"" + os + "\"",
     ]
 
     f.write("#[cfg(" + ', '.join(cfg) + ")]\n")
+    if os == "windows": # NOTE: Remove after snapshot
+        f.write("#[cfg(stage0, target_arch = \"%s\", target_os = \"win32\")]\n" % (arch,))
 
     version = run([llconfig, '--version']).strip()
 

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1138,7 +1138,8 @@ pub mod types {
         }
     }
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     pub mod os {
         pub mod common {
             pub mod posix01 {
@@ -1803,7 +1804,8 @@ pub mod consts {
     // Consts tend to vary per OS so we pull their definitions out
     // into this module.
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     pub mod os {
         pub mod c95 {
             use types::os::arch::c95::{c_int, c_uint};
@@ -3887,7 +3889,8 @@ pub mod funcs {
     // so be careful when trying to write portable code; it won't always work
     // with the same POSIX functions and types as other platforms.
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     pub mod posix88 {
         pub mod stat_ {
             use types::os::common::posix01::{stat, utimbuf};
@@ -4316,7 +4319,8 @@ pub mod funcs {
         }
     }
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     pub mod posix01 {
         pub mod stat_ {
         }
@@ -4332,7 +4336,8 @@ pub mod funcs {
     }
 
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     #[cfg(target_os = "linux")]
     #[cfg(target_os = "android")]
     #[cfg(target_os = "macos")]
@@ -4470,7 +4475,8 @@ pub mod funcs {
     }
 
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     pub mod bsd44 {
     }
 
@@ -4496,7 +4502,8 @@ pub mod funcs {
     }
 
 
-    #[cfg(target_os = "win32")]
+    #[cfg(target_os = "windows")]
+    #[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
     pub mod extra {
 
         pub mod kernel32 {

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -58,7 +58,8 @@ pub mod file;
 #[path = "timer_unix.rs"]
 pub mod timer;
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 #[path = "timer_win32.rs"]
 pub mod timer;
 

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -200,7 +200,7 @@ pub mod write {
             // OSX has -dead_strip, which doesn't rely on ffunction_sections
             // FIXME(#13846) this should be enabled for windows
             let ffunction_sections = sess.targ_cfg.os != abi::OsMacos &&
-                                     sess.targ_cfg.os != abi::OsWin32;
+                                     sess.targ_cfg.os != abi::OsWindows;
             let fdata_sections = ffunction_sections;
 
             let reloc_model = match sess.opts.cg.relocation_model.as_slice() {
@@ -858,7 +858,7 @@ pub fn get_cc_prog(sess: &Session) -> String {
     // instead of hard-coded gcc.
     // For win32, there is no cc command, so we add a condition to make it use gcc.
     match sess.targ_cfg.os {
-        abi::OsWin32 => "gcc",
+        abi::OsWindows => "gcc",
         _ => "cc",
     }.to_string()
 }
@@ -954,7 +954,7 @@ pub fn filename_for_input(sess: &Session,
         }
         config::CrateTypeDylib => {
             let (prefix, suffix) = match sess.targ_cfg.os {
-                abi::OsWin32 => (loader::WIN32_DLL_PREFIX, loader::WIN32_DLL_SUFFIX),
+                abi::OsWindows => (loader::WIN32_DLL_PREFIX, loader::WIN32_DLL_SUFFIX),
                 abi::OsMacos => (loader::MACOS_DLL_PREFIX, loader::MACOS_DLL_SUFFIX),
                 abi::OsLinux => (loader::LINUX_DLL_PREFIX, loader::LINUX_DLL_SUFFIX),
                 abi::OsAndroid => (loader::ANDROID_DLL_PREFIX, loader::ANDROID_DLL_SUFFIX),
@@ -972,7 +972,7 @@ pub fn filename_for_input(sess: &Session,
         }
         config::CrateTypeExecutable => {
             match sess.targ_cfg.os {
-                abi::OsWin32 => out_filename.with_extension("exe"),
+                abi::OsWindows => out_filename.with_extension("exe"),
                 abi::OsMacos |
                 abi::OsLinux |
                 abi::OsAndroid |
@@ -1388,7 +1388,7 @@ fn link_args(cmd: &mut Command,
     // subset we wanted.
     //
     // FIXME(#11937) we should invoke the system linker directly
-    if sess.targ_cfg.os != abi::OsWin32 {
+    if sess.targ_cfg.os != abi::OsWindows {
         cmd.arg("-nodefaultlibs");
     }
 
@@ -1440,7 +1440,7 @@ fn link_args(cmd: &mut Command,
         cmd.arg("-Wl,-dead_strip");
     }
 
-    if sess.targ_cfg.os == abi::OsWin32 {
+    if sess.targ_cfg.os == abi::OsWindows {
         // Make sure that we link to the dynamic libgcc, otherwise cross-module
         // DWARF stack unwinding will not work.
         // This behavior may be overridden by --link-args "-static-libgcc"
@@ -1715,7 +1715,7 @@ fn add_upstream_rust_crates(cmd: &mut Command, sess: &Session,
 
     // Converts a library file-stem into a cc -l argument
     fn unlib<'a>(config: &config::Config, stem: &'a [u8]) -> &'a [u8] {
-        if stem.starts_with("lib".as_bytes()) && config.os != abi::OsWin32 {
+        if stem.starts_with("lib".as_bytes()) && config.os != abi::OsWindows {
             stem.tailn(3)
         } else {
             stem

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -390,7 +390,7 @@ pub fn default_lib_output() -> CrateType {
 
 pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     let tos = match sess.targ_cfg.os {
-        abi::OsWin32 =>     InternedString::new("win32"),
+        abi::OsWindows =>   InternedString::new("win32"),
         abi::OsMacos =>     InternedString::new("macos"),
         abi::OsLinux =>     InternedString::new("linux"),
         abi::OsAndroid =>   InternedString::new("android"),
@@ -410,7 +410,7 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     };
 
     let fam = match sess.targ_cfg.os {
-        abi::OsWin32 => InternedString::new("windows"),
+        abi::OsWindows => InternedString::new("windows"),
         _ => InternedString::new("unix")
     };
 
@@ -452,8 +452,8 @@ pub fn get_os(triple: &str) -> Option<abi::Os> {
     None
 }
 static os_names : &'static [(&'static str, abi::Os)] = &[
-    ("mingw32",   abi::OsWin32),
-    ("win32",     abi::OsWin32),
+    ("mingw32",   abi::OsWindows),
+    ("win32",     abi::OsWindows),
     ("darwin",    abi::OsMacos),
     ("android",   abi::OsAndroid),
     ("linux",     abi::OsLinux),

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -390,7 +390,7 @@ pub fn default_lib_output() -> CrateType {
 
 pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     let tos = match sess.targ_cfg.os {
-        abi::OsWindows =>   InternedString::new("win32"),
+        abi::OsWindows =>   InternedString::new("windows"),
         abi::OsMacos =>     InternedString::new("macos"),
         abi::OsLinux =>     InternedString::new("linux"),
         abi::OsAndroid =>   InternedString::new("android"),
@@ -454,6 +454,7 @@ pub fn get_os(triple: &str) -> Option<abi::Os> {
 static os_names : &'static [(&'static str, abi::Os)] = &[
     ("mingw32",   abi::OsWindows),
     ("win32",     abi::OsWindows),
+    ("windows",   abi::OsWindows),
     ("darwin",    abi::OsMacos),
     ("android",   abi::OsAndroid),
     ("linux",     abi::OsLinux),

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -615,7 +615,7 @@ impl<'a> Context<'a> {
     // dynamic libraries
     fn dylibname(&self) -> Option<(&'static str, &'static str)> {
         match self.os {
-            abi::OsWin32 => Some((WIN32_DLL_PREFIX, WIN32_DLL_SUFFIX)),
+            abi::OsWindows => Some((WIN32_DLL_PREFIX, WIN32_DLL_SUFFIX)),
             abi::OsMacos => Some((MACOS_DLL_PREFIX, MACOS_DLL_SUFFIX)),
             abi::OsLinux => Some((LINUX_DLL_PREFIX, LINUX_DLL_SUFFIX)),
             abi::OsAndroid => Some((ANDROID_DLL_PREFIX, ANDROID_DLL_SUFFIX)),
@@ -824,7 +824,7 @@ pub fn meta_section_name(os: abi::Os) -> Option<&'static str> {
     match os {
         abi::OsMacos => Some("__DATA,__note.rustc"),
         abi::OsiOS => Some("__DATA,__note.rustc"),
-        abi::OsWin32 => Some(".note.rustc"),
+        abi::OsWindows => Some(".note.rustc"),
         abi::OsLinux => Some(".note.rustc"),
         abi::OsAndroid => Some(".note.rustc"),
         abi::OsFreebsd => Some(".note.rustc"),
@@ -836,7 +836,7 @@ pub fn read_meta_section_name(os: abi::Os) -> &'static str {
     match os {
         abi::OsMacos => "__note.rustc",
         abi::OsiOS => unreachable!(),
-        abi::OsWin32 => ".note.rustc",
+        abi::OsWindows => ".note.rustc",
         abi::OsLinux => ".note.rustc",
         abi::OsAndroid => ".note.rustc",
         abi::OsFreebsd => ".note.rustc",

--- a/src/librustc/middle/trans/cabi.rs
+++ b/src/librustc/middle/trans/cabi.rs
@@ -18,7 +18,7 @@ use middle::trans::cabi_arm;
 use middle::trans::cabi_mips;
 use middle::trans::type_::Type;
 use syntax::abi::{X86, X86_64, Arm, Mips, Mipsel};
-use syntax::abi::{OsWin32};
+use syntax::abi::{OsWindows};
 
 #[deriving(Clone, PartialEq)]
 pub enum ArgKind {
@@ -110,7 +110,7 @@ pub fn compute_abi_info(ccx: &CrateContext,
     match ccx.sess().targ_cfg.arch {
         X86 => cabi_x86::compute_abi_info(ccx, atys, rty, ret_def),
         X86_64 =>
-            if ccx.sess().targ_cfg.os == OsWin32 {
+            if ccx.sess().targ_cfg.os == OsWindows {
                 cabi_x86_win64::compute_abi_info(ccx, atys, rty, ret_def)
             } else {
                 cabi_x86_64::compute_abi_info(ccx, atys, rty, ret_def)

--- a/src/librustc/middle/trans/cabi_x86.rs
+++ b/src/librustc/middle/trans/cabi_x86.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-use syntax::abi::{OsWin32, OsMacos, OsiOS};
+use syntax::abi::{OsWindows, OsMacos, OsiOS};
 use llvm::*;
 use super::cabi::*;
 use super::common::*;
@@ -36,7 +36,7 @@ pub fn compute_abi_info(ccx: &CrateContext,
 
         enum Strategy { RetValue(Type), RetPointer }
         let strategy = match ccx.sess().targ_cfg.os {
-            OsWin32 | OsMacos | OsiOS => {
+            OsWindows | OsMacos | OsiOS => {
                 match llsize_of_alloc(ccx, rty) {
                     1 => RetValue(Type::i8(ccx)),
                     2 => RetValue(Type::i16(ccx)),

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -98,7 +98,7 @@ fn run_ar(handler: &ErrorHandler, maybe_ar_prog: &Option<String>,
 pub fn find_library(name: &str, os: abi::Os, search_paths: &[Path],
                     handler: &ErrorHandler) -> Path {
     let (osprefix, osext) = match os {
-        abi::OsWin32 => ("", "lib"), _ => ("lib", "a"),
+        abi::OsWindows => ("", "lib"), _ => ("lib", "a"),
     };
     // On Windows, static libraries sometimes show up as libfoo.a and other
     // times show up as foo.lib

--- a/src/librustc_back/arm.rs
+++ b/src/librustc_back/arm.rs
@@ -37,7 +37,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 -a0:0:64-n32".to_string()
           }
 
-          abi::OsWin32 => {
+          abi::OsWindows => {
             "e-p:32:32:32\
                 -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
                 -f32:32:32-f64:64:64\

--- a/src/librustc_back/mips.rs
+++ b/src/librustc_back/mips.rs
@@ -32,7 +32,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 -a0:0:64-n32".to_string()
           }
 
-          abi::OsWin32 => {
+          abi::OsWindows => {
             "E-p:32:32:32\
                 -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
                 -f32:32:32-f64:64:64\

--- a/src/librustc_back/mipsel.rs
+++ b/src/librustc_back/mipsel.rs
@@ -32,7 +32,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 -a0:0:64-n32".to_string()
           }
 
-          abi::OsWin32 => {
+          abi::OsWindows => {
             "e-p:32:32:32\
                 -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
                 -f32:32:32-f64:64:64\

--- a/src/librustc_back/rpath.rs
+++ b/src/librustc_back/rpath.rs
@@ -26,7 +26,7 @@ pub struct RPathConfig<'a> {
 pub fn get_rpath_flags(config: RPathConfig) -> Vec<String> {
 
     // No rpath on windows
-    if config.os == abi::OsWin32 {
+    if config.os == abi::OsWindows {
         return Vec::new();
     }
 
@@ -107,14 +107,14 @@ fn get_rpath_relative_to_output(config: &mut RPathConfig,
                                 lib: &Path) -> String {
     use std::os;
 
-    assert!(config.os != abi::OsWin32);
+    assert!(config.os != abi::OsWindows);
 
     // Mac doesn't appear to support $ORIGIN
     let prefix = match config.os {
         abi::OsAndroid | abi::OsLinux | abi::OsFreebsd | abi::OsDragonfly
                           => "$ORIGIN",
         abi::OsMacos => "@loader_path",
-        abi::OsWin32 | abi::OsiOS => unreachable!()
+        abi::OsWindows | abi::OsiOS => unreachable!()
     };
 
     let mut lib = (config.realpath)(&os::make_absolute(lib)).unwrap();

--- a/src/librustc_back/x86.rs
+++ b/src/librustc_back/x86.rs
@@ -34,7 +34,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os)
                 -n8:16:32".to_string()
           }
 
-          abi::OsWin32 => {
+          abi::OsWindows => {
             "e-p:32:32-f64:64:64-i64:64:64-f80:32:32-n8:16:32".to_string()
           }
 

--- a/src/librustc_back/x86_64.rs
+++ b/src/librustc_back/x86_64.rs
@@ -29,7 +29,7 @@ pub fn get_target_strs(target_triple: String, target_os: abi::Os) -> target_strs
                 s0:64:64-f80:128:128-n8:16:32:64".to_string()
           }
 
-          abi::OsWin32 => {
+          abi::OsWindows => {
             // FIXME: Test this. Copied from linux (#2398)
             "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-\
                 f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-\

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -73,7 +73,8 @@ impl PluginManager {
     }
 }
 
-#[cfg(target_os="win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 fn libname(mut n: String) -> String {
     n.push_str(".dll");
     n
@@ -85,7 +86,8 @@ fn libname(mut n: String) -> String {
     n
 }
 
-#[cfg(not(target_os="win32"), not(target_os="macos"))]
+#[cfg(not(stage0), not(target_os="windows"), not(target_os="macos"))]
+#[cfg(stage0, not(target_os="win32"), not(target_os="macos"))] // NOTE: Remove after snapshot
 fn libname(n: String) -> String {
     let mut i = String::from_str("lib");
     i.push_str(n.as_slice());

--- a/src/librustrt/args.rs
+++ b/src/librustrt/args.rs
@@ -147,7 +147,8 @@ mod imp {
 
 #[cfg(target_os = "macos")]
 #[cfg(target_os = "ios")]
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 mod imp {
     use core::prelude::*;
     use collections::vec::Vec;

--- a/src/librustrt/libunwind.rs
+++ b/src/librustrt/libunwind.rs
@@ -86,7 +86,8 @@ pub type _Unwind_Exception_Cleanup_Fn =
 
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "freebsd")]
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 #[link(name = "gcc_s")]
 extern {}
 

--- a/src/librustrt/stack.rs
+++ b/src/librustrt/stack.rs
@@ -199,7 +199,8 @@ pub unsafe fn record_sp_limit(limit: uint) {
     unsafe fn target_record_sp_limit(limit: uint) {
         asm!("movq $0, %fs:112" :: "r"(limit) :: "volatile")
     }
-    #[cfg(target_arch = "x86_64", target_os = "win32")] #[inline(always)]
+    #[cfg(target_arch = "x86_64", target_os = "windows")] #[inline(always)]
+    #[cfg(stage0, target_arch = "x86_64", target_os = "win32")] // NOTE: Remove after snapshot
     unsafe fn target_record_sp_limit(limit: uint) {
         // see: http://en.wikipedia.org/wiki/Win32_Thread_Information_Block
         // store this inside of the "arbitrary data slot", but double the size
@@ -227,7 +228,8 @@ pub unsafe fn record_sp_limit(limit: uint) {
     unsafe fn target_record_sp_limit(limit: uint) {
         asm!("movl $0, %gs:48" :: "r"(limit) :: "volatile")
     }
-    #[cfg(target_arch = "x86", target_os = "win32")] #[inline(always)]
+    #[cfg(target_arch = "x86", target_os = "windows")] #[inline(always)]
+    #[cfg(stage0, target_arch = "x86", target_os = "win32")] // NOTE: Remove after snapshot
     unsafe fn target_record_sp_limit(limit: uint) {
         // see: http://en.wikipedia.org/wiki/Win32_Thread_Information_Block
         // store this inside of the "arbitrary data slot"
@@ -280,7 +282,8 @@ pub unsafe fn get_sp_limit() -> uint {
         asm!("movq %fs:112, $0" : "=r"(limit) ::: "volatile");
         return limit;
     }
-    #[cfg(target_arch = "x86_64", target_os = "win32")] #[inline(always)]
+    #[cfg(target_arch = "x86_64", target_os = "windows")] #[inline(always)]
+    #[cfg(stage0, target_arch = "x86_64", target_os = "win32")] // NOTE: Remove after snapshot
     unsafe fn target_get_sp_limit() -> uint {
         let limit;
         asm!("movq %gs:0x28, $0" : "=r"(limit) ::: "volatile");
@@ -316,7 +319,8 @@ pub unsafe fn get_sp_limit() -> uint {
         asm!("movl %gs:48, $0" : "=r"(limit) ::: "volatile");
         return limit;
     }
-    #[cfg(target_arch = "x86", target_os = "win32")] #[inline(always)]
+    #[cfg(target_arch = "x86", target_os = "windows")] #[inline(always)]
+    #[cfg(stage0, target_arch = "x86", target_os = "win32")] // NOTE: Remove after snapshot
     unsafe fn target_get_sp_limit() -> uint {
         let limit;
         asm!("movl %fs:0x14, $0" : "=r"(limit) ::: "volatile");

--- a/src/librustuv/uvll.rs
+++ b/src/librustuv/uvll.rs
@@ -723,7 +723,8 @@ extern {}
 #[link(name = "rt")]
 extern {}
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 #[link(name = "ws2_32")]
 #[link(name = "psapi")]
 #[link(name = "iphlpapi")]

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -278,7 +278,8 @@ pub mod dl {
     }
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 pub mod dl {
     use c_str::ToCStr;
     use iter::Iterator;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1842,7 +1842,8 @@ pub mod consts {
     pub static EXE_EXTENSION: &'static str = "";
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 pub mod consts {
     pub use os::arch_consts::ARCH;
 
@@ -1850,7 +1851,7 @@ pub mod consts {
 
     /// A string describing the specific operating system in use: in this
     /// case, `win32`.
-    pub static SYSNAME: &'static str = "win32";
+    pub static SYSNAME: &'static str = "windows";
 
     /// Specifies the filename prefix used for shared libraries on this
     /// platform: in this case, the empty string.

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -11,7 +11,7 @@
 use std::fmt;
 
 #[deriving(PartialEq)]
-pub enum Os { OsWin32, OsMacos, OsLinux, OsAndroid, OsFreebsd, OsiOS,
+pub enum Os { OsWindows, OsMacos, OsLinux, OsAndroid, OsFreebsd, OsiOS,
               OsDragonfly }
 
 #[deriving(PartialEq, Eq, Hash, Encodable, Decodable, Clone)]
@@ -124,7 +124,7 @@ impl Abi {
         // Transform this ABI as appropriate for the requested os/arch
         // combination.
         Some(match (*self, os, arch) {
-            (System, OsWin32, X86) => Stdcall,
+            (System, OsWindows, X86) => Stdcall,
             (System, _, _) => C,
             (me, _, _) => me,
         })
@@ -147,7 +147,7 @@ impl fmt::Show for Os {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             OsLinux => "linux".fmt(f),
-            OsWin32 => "win32".fmt(f),
+            OsWindows => "win32".fmt(f),
             OsMacos => "macos".fmt(f),
             OsiOS => "ios".fmt(f),
             OsAndroid => "android".fmt(f),
@@ -195,9 +195,9 @@ fn pick_uniplatform() {
     assert_eq!(Stdcall.for_target(OsLinux, X86), Some(Stdcall));
     assert_eq!(Stdcall.for_target(OsLinux, Arm), None);
     assert_eq!(System.for_target(OsLinux, X86), Some(C));
-    assert_eq!(System.for_target(OsWin32, X86), Some(Stdcall));
-    assert_eq!(System.for_target(OsWin32, X86_64), Some(C));
-    assert_eq!(System.for_target(OsWin32, Arm), Some(C));
-    assert_eq!(Stdcall.for_target(OsWin32, X86), Some(Stdcall));
-    assert_eq!(Stdcall.for_target(OsWin32, X86_64), Some(Stdcall));
+    assert_eq!(System.for_target(OsWindows, X86), Some(Stdcall));
+    assert_eq!(System.for_target(OsWindows, X86_64), Some(C));
+    assert_eq!(System.for_target(OsWindows, Arm), Some(C));
+    assert_eq!(Stdcall.for_target(OsWindows, X86), Some(Stdcall));
+    assert_eq!(Stdcall.for_target(OsWindows, X86_64), Some(Stdcall));
 }

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -147,7 +147,7 @@ impl fmt::Show for Os {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             OsLinux => "linux".fmt(f),
-            OsWindows => "win32".fmt(f),
+            OsWindows => "windows".fmt(f),
             OsMacos => "macos".fmt(f),
             OsiOS => "ios".fmt(f),
             OsAndroid => "android".fmt(f),

--- a/src/test/bench/shootout-regex-dna.rs
+++ b/src/test/bench/shootout-regex-dna.rs
@@ -39,7 +39,7 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // FIXME(#13725) windows needs fixing.
-// ignore-win32
+// ignore-windows
 // ignore-stage1
 // ignore-cross-compile #12102
 

--- a/src/test/compile-fail-fulldeps/syntax-extension-regex-invalid.rs
+++ b/src/test/compile-fail-fulldeps/syntax-extension-regex-invalid.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // FIXME(#13725) windows needs fixing.
-// ignore-win32
+// ignore-windows
 // ignore-stage1
 
 #![feature(phase)]

--- a/src/test/compile-fail-fulldeps/syntax-extension-regex-unused-static.rs
+++ b/src/test/compile-fail-fulldeps/syntax-extension-regex-unused-static.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // FIXME(#13725) windows needs fixing.
-// ignore-win32
+// ignore-windows
 // ignore-stage1
 
 #![feature(phase)]

--- a/src/test/compile-fail-fulldeps/syntax-extension-regex-unused.rs
+++ b/src/test/compile-fail-fulldeps/syntax-extension-regex-unused.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // FIXME(#13725) windows needs fixing.
-// ignore-win32
+// ignore-windows
 // ignore-stage1
 
 #![feature(phase)]

--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -14,7 +14,7 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -14,7 +14,7 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13256
+// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // no-pretty-expanded FIXME #15189
-// ignore-win32 FIXME #13259
+// ignore-windows FIXME #13259
 extern crate native;
 
 use std::os;

--- a/src/test/run-pass/dupe-first-attr.rc
+++ b/src/test/run-pass/dupe-first-attr.rc
@@ -18,7 +18,7 @@ mod hello;
 mod hello;
 
 #[cfg(target_os = "windows")]
-#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
+/* NOTE: Remove after snapshot */#[cfg(stage0, target_os = "win32")]
 mod hello;
 
 #[cfg(target_os = "freebsd")]

--- a/src/test/run-pass/dupe-first-attr.rc
+++ b/src/test/run-pass/dupe-first-attr.rc
@@ -17,7 +17,8 @@ mod hello;
 #[cfg(target_os = "macos")]
 mod hello;
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 mod hello;
 
 #[cfg(target_os = "freebsd")]

--- a/src/test/run-pass/glob-std.rs
+++ b/src/test/run-pass/glob-std.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32 TempDir may cause IoError on windows: #10462
+// ignore-windows TempDir may cause IoError on windows: #10462
 
 #![feature(macro_rules)]
 

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -43,7 +43,7 @@ mod m {
 }
 
 #[cfg(target_os = "windows")]
-#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
+/* NOTE: Remove after snapshot */#[cfg(stage0, target_os = "win32")]
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -42,7 +42,8 @@ mod m {
     }
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]

--- a/src/test/run-pass/issue-14393.rs
+++ b/src/test/run-pass/issue-14393.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32: FIXME #13793
+// ignore-windows: FIXME #13793
 
 fn main() {
     match ("", 1u) {

--- a/src/test/run-pass/issue-15487.rs
+++ b/src/test/run-pass/issue-15487.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32
+// ignore-windows
 
 #![feature(link_args)]
 

--- a/src/test/run-pass/lang-item-public.rs
+++ b/src/test/run-pass/lang-item-public.rs
@@ -10,7 +10,7 @@
 
 // aux-build:lang-item-public.rs
 // ignore-android
-// ignore-win32 #13361
+// ignore-windows #13361
 
 #![no_std]
 

--- a/src/test/run-pass/linkage-visibility.rs
+++ b/src/test/run-pass/linkage-visibility.rs
@@ -10,7 +10,7 @@
 
 // aux-build:linkage-visibility.rs
 // ignore-android: FIXME(#10379)
-// ignore-win32: std::dynamic_lib does not work on win32 well
+// ignore-windows: std::dynamic_lib does not work on win32 well
 
 extern crate foo = "linkage-visibility";
 

--- a/src/test/run-pass/linkage1.rs
+++ b/src/test/run-pass/linkage1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32
+// ignore-windows
 // ignore-android
 // ignore-macos
 // aux-build:linkage1.rs

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32
+// ignore-windows
 // exec-env:RUST_LOG=debug
 
 use std::cell::Cell;

--- a/src/test/run-pass/logging-separate-lines.rs
+++ b/src/test/run-pass/logging-separate-lines.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-android
-// ignore-win32
+// ignore-windows
 // exec-env:RUST_LOG=debug
 
 #![feature(phase)]

--- a/src/test/run-pass/process-detach.rs
+++ b/src/test/run-pass/process-detach.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32
+// ignore-windows
 // ignore-android
 
 // This test ensures that the 'detach' field on processes does the right thing.

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -56,7 +56,7 @@ mod m {
 }
 
 #[cfg(target_os = "windows")]
-#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
+/* NOTE: Remove after snapshot */#[cfg(stage0, target_os = "win32")]
 mod m {
     #[cfg(target_arch = "x86")]
     pub mod m {

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -55,7 +55,8 @@ mod m {
     }
 }
 
-#[cfg(target_os = "win32")]
+#[cfg(target_os = "windows")]
+#[cfg(stage0, target_os = "win32")] // NOTE: Remove after snapshot
 mod m {
     #[cfg(target_arch = "x86")]
     pub mod m {

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32
+// ignore-windows
 
 extern crate debug;
 

--- a/src/test/run-pass/spawning-with-debug.rs
+++ b/src/test/run-pass/spawning-with-debug.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32
+// ignore-windows
 // exec-env:RUST_LOG=debug
 
 // regression test for issue #10405, make sure we don't call println! too soon.

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-win32 TempDir may cause IoError on windows: #10463
+// ignore-windows TempDir may cause IoError on windows: #10463
 
 // These tests are here to exercise the functionality of the `tempfile` module.
 // One might expect these tests to be located in that module, but sadly they

--- a/src/test/run-pass/test-runner-hides-main.rs
+++ b/src/test/run-pass/test-runner-hides-main.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:--test
-// ignore-win32 #10872
+// ignore-windows #10872
 // ignore-pretty: does not work well with `--test`
 
 // Building as a test runner means that a synthetic main will be run,


### PR DESCRIPTION
Using "win32" to mean "Windows" is confusing, especially now, that Rust supports win64 builds.
Let's call spade a spade.
