### PR TITLE
rustdoc: add tooltips to sidebar

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -63,6 +63,26 @@ use html::markdown::Markdown;
 use html::markdown;
 use stability_summary;
 
+/// A pair of name and its optional document.
+#[deriving(Clone, Eq, Ord)]
+pub struct NameDoc(String, Option<String>);
+
+impl PartialOrd for NameDoc {
+    fn partial_cmp(&self, other: &NameDoc) -> Option<Ordering> {
+        let &NameDoc(ref name1, _) = self;
+        let &NameDoc(ref name2, _) = other;
+        name1.partial_cmp(name2)
+    }
+}
+
+impl PartialEq for NameDoc {
+    fn eq(&self, other: &NameDoc) -> bool {
+        let &NameDoc(ref name1, _) = self;
+        let &NameDoc(ref name2, _) = other;
+        name1.eq(name2)
+    }
+}
+
 /// Major driving force in all rustdoc rendering. This contains information
 /// about where in the tree-like hierarchy rendering is occurring and controls
 /// how the current page is being rendered.
@@ -89,7 +109,7 @@ pub struct Context {
     /// functions), and the value is the list of containers belonging to this
     /// header. This map will change depending on the surrounding context of the
     /// page.
-    pub sidebar: HashMap<String, Vec<String>>,
+    pub sidebar: HashMap<String, Vec<NameDoc>>,
     /// This flag indicates whether [src] links should be generated or not. If
     /// the source files are present in the html rendering, then this will be
     /// `true`.
@@ -1418,6 +1438,11 @@ fn shorter<'a>(s: Option<&'a str>) -> &'a str {
     }
 }
 
+#[inline]
+fn shorter_line(s: Option<&str>) -> String {
+    shorter(s).replace("\n", " ")
+}
+
 fn document(w: &mut fmt::Formatter, item: &clean::Item) -> fmt::Result {
     match item.doc_value() {
         Some(s) => {
@@ -2080,21 +2105,22 @@ impl<'a> fmt::Show for Sidebar<'a> {
                 None => return Ok(())
             };
             try!(write!(w, "<div class='block {}'><h2>{}</h2>", short, longty));
-            for item in items.iter() {
+            for &NameDoc(ref name, ref doc) in items.iter() {
                 let curty = shortty(cur).to_static_str();
-                let class = if cur.name.get_ref() == item &&
+                let class = if cur.name.get_ref() == name &&
                                short == curty { "current" } else { "" };
-                try!(write!(w, "<a class='{ty} {class}' href='{href}{path}'>\
+                try!(write!(w, "<a class='{ty} {class}' href='{href}{path}' title='{title}'>\
                                 {name}</a>",
                        ty = short,
                        class = class,
                        href = if curty == "mod" {"../"} else {""},
                        path = if short == "mod" {
-                           format!("{}/index.html", item.as_slice())
+                           format!("{}/index.html", name.as_slice())
                        } else {
-                           format!("{}.{}.html", short, item.as_slice())
+                           format!("{}.{}.html", short, name.as_slice())
                        },
-                       name = item.as_slice()));
+                       title = doc.get_ref().as_slice(),
+                       name = name.as_slice()));
             }
             try!(write!(w, "</div>"));
             Ok(())
@@ -2110,7 +2136,7 @@ impl<'a> fmt::Show for Sidebar<'a> {
     }
 }
 
-fn build_sidebar(m: &clean::Module) -> HashMap<String, Vec<String>> {
+fn build_sidebar(m: &clean::Module) -> HashMap<String, Vec<NameDoc>> {
     let mut map = HashMap::new();
     for item in m.items.iter() {
         if ignore_private_item(item) { continue }
@@ -2121,7 +2147,7 @@ fn build_sidebar(m: &clean::Module) -> HashMap<String, Vec<String>> {
             Some(ref s) => s.to_string(),
         };
         let v = map.find_or_insert_with(short.to_string(), |_| Vec::new());
-        v.push(myname);
+        v.push(NameDoc(myname, Some(shorter_line(item.doc_value()))));
     }
 
     for (_, items) in map.mut_iter() {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -694,8 +694,10 @@
                 if (crates[i] == window.currentCrate) {
                     klass += ' current';
                 }
+                var desc = rawSearchIndex[crates[i]].items[0][3];
                 div.append($('<a>', {'href': '../' + crates[i] + '/index.html',
-                                    'class': klass}).text(crates[i]));
+                                     'title': desc.replace(/\n/g, ' '),
+                                     'class': klass}).text(crates[i]));
             }
             sidebar.append(div);
         }


### PR DESCRIPTION
This PR add tooltip to most every links in sidebar, showing its primary description.

Online preview:
http://liigo.com/tmp/rust/std/index.html
http://liigo.com/tmp/rust/std/str/trait.StrSlice.html
