### PR TITLE
Cleanup some fixed Windows issues

### DIFF
--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -395,8 +395,7 @@ mod parse;
 mod re;
 mod vm;
 
-// FIXME(#13725) windows needs fixing.
-#[cfg(test, not(windows))]
+#[cfg(test)]
 mod test;
 
 /// The `native` module exists to support the `regex!` macro. Do not use.

--- a/src/test/bench/shootout-regex-dna.rs
+++ b/src/test/bench/shootout-regex-dna.rs
@@ -38,8 +38,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// FIXME(#13725) windows needs fixing.
-// ignore-windows
 // ignore-stage1
 // ignore-cross-compile #12102
 

--- a/src/test/compile-fail-fulldeps/syntax-extension-regex-invalid.rs
+++ b/src/test/compile-fail-fulldeps/syntax-extension-regex-invalid.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#13725) windows needs fixing.
-// ignore-windows
 // ignore-stage1
 
 #![feature(phase)]

--- a/src/test/compile-fail-fulldeps/syntax-extension-regex-unused-static.rs
+++ b/src/test/compile-fail-fulldeps/syntax-extension-regex-unused-static.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#13725) windows needs fixing.
-// ignore-windows
 // ignore-stage1
 
 #![feature(phase)]

--- a/src/test/compile-fail-fulldeps/syntax-extension-regex-unused.rs
+++ b/src/test/compile-fail-fulldeps/syntax-extension-regex-unused.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME(#13725) windows needs fixing.
-// ignore-windows
 // ignore-stage1
 
 #![feature(phase)]

--- a/src/test/run-make/no-intermediate-extras/foo.rs
+++ b/src/test/run-make/no-intermediate-extras/foo.rs
@@ -7,8 +7,3 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-// FIXME #13793
-#[test]
-fn test_dummy() {
-}

--- a/src/test/run-pass/issue-14393.rs
+++ b/src/test/run-pass/issue-14393.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13793
-
 fn main() {
     match ("", 1u) {
         (_, 42u) => (),

--- a/src/test/run-pass/test-runner-hides-main.rs
+++ b/src/test/run-pass/test-runner-hides-main.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // compile-flags:--test
-// ignore-windows #10872
 // ignore-pretty: does not work well with `--test`
 
 // Building as a test runner means that a synthetic main will be run,


### PR DESCRIPTION
First commit enables regex test on Windows. It was not working at some point (#13725), but it works now.

Second commit removes various FIXMEs regarding #13793, since upstream bug has been fixed.
