### PR TITLE
libsyntax: Don't strip types and lifetimes from single-segment paths in

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3157,7 +3157,16 @@ impl<'a> Parser<'a> {
                             }
                           },
                           _ => {
-                              if !enum_path.global && enum_path.segments.len() == 1 {
+                              if !enum_path.global &&
+                                    enum_path.segments.len() == 1 &&
+                                    enum_path.segments
+                                             .get(0)
+                                             .lifetimes
+                                             .len() == 0 &&
+                                    enum_path.segments
+                                             .get(0)
+                                             .types
+                                             .len() == 0 {
                                   // it could still be either an enum
                                   // or an identifier pattern, resolve
                                   // will sort it out:

--- a/src/test/compile-fail/pattern-ident-path-generics.rs
+++ b/src/test/compile-fail/pattern-ident-path-generics.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    match Some("foo") {
+        None::<int> => {}   //~ ERROR mismatched types
+        Some(_) => {}
+    }
+}
+


### PR DESCRIPTION
patterns.

This breaks code like:

```
fn main() {
    match Some("foo") {
        None::<int> => {}
        Some(_) => {}
    }
}
```

Change this code to not contain a type error. For example:

```
fn main() {
    match Some("foo") {
        None::<&str> => {}
        Some(_) => {}
    }
}
```

Closes #16353.

[breaking-change]

r? @huonw
