### PR TITLE
librustc: Record unique immutable borrows in the restrictions table.

### DIFF
--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -261,6 +261,8 @@ impl<'a> GatherLoanCtxt<'a> {
             self.bccx, borrow_span, cause,
             cmt.clone(), loan_region);
 
+        debug!("guarantee_valid(): restrictions={:?}", restr);
+
         // Create the loan record (if needed).
         let loan = match restr {
             restrictions::Safe => {

--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -122,9 +122,7 @@ impl<'a> RestrictionsContext<'a> {
             }
 
             mc::cat_deref(cmt_base, _, mc::BorrowedPtr(ty::ImmBorrow, lt)) |
-            mc::cat_deref(cmt_base, _, mc::BorrowedPtr(ty::UniqueImmBorrow, lt)) |
-            mc::cat_deref(cmt_base, _, mc::Implicit(ty::ImmBorrow, lt)) |
-            mc::cat_deref(cmt_base, _, mc::Implicit(ty::UniqueImmBorrow, lt)) => {
+            mc::cat_deref(cmt_base, _, mc::Implicit(ty::ImmBorrow, lt)) => {
                 // R-Deref-Imm-Borrowed
                 if !self.bccx.is_subregion_of(self.loan_region, lt) {
                     self.bccx.report(
@@ -142,7 +140,9 @@ impl<'a> RestrictionsContext<'a> {
             mc::cat_deref(cmt_base, _, pk) => {
                 match pk {
                     mc::BorrowedPtr(ty::MutBorrow, lt) |
-                    mc::Implicit(ty::MutBorrow, lt) => {
+                    mc::BorrowedPtr(ty::UniqueImmBorrow, lt) |
+                    mc::Implicit(ty::MutBorrow, lt) |
+                    mc::Implicit(ty::UniqueImmBorrow, lt) => {
                         // R-Deref-Mut-Borrowed
                         if !self.bccx.is_subregion_of(self.loan_region, lt) {
                             self.bccx.report(

--- a/src/test/compile-fail/borrowck-closures-unique-imm.rs
+++ b/src/test/compile-fail/borrowck-closures-unique-imm.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+    x: int,
+}
+
+pub fn main() {
+    let mut this = &mut Foo {
+        x: 1,
+    };
+    let r = || {
+        let p = &this.x;
+        &mut this.x; //~ ERROR cannot borrow
+    };
+    r()
+}
+


### PR DESCRIPTION
This fixes borrow checking for closures. Code like this will break:

```
struct Foo {
    x: int,
}

pub fn main() {
    let mut this = &mut Foo {
        x: 1,
    };
    let r = || {
        let p = &this.x;
        &mut this.x;
    };
    r()
}
```

Change this code to not take multiple mutable references to the same value. For
example:

```
struct Foo {
    x: int,
}

pub fn main() {
    let mut this = &mut Foo {
        x: 1,
    };
    let r = || {
        &mut this.x;
    };
    r()
}
```

Closes #16361.

[breaking-change]

r? @nikomatsakis
