### PR TITLE
librustc: Require that types mentioned anywhere in public signatures be

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -28,8 +28,11 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/master/")]
 
-#![feature(unsafe_destructor)]
+#![feature(unsafe_destructor, visible_private_types)]
 #![allow(missing_doc)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 use std::cell::{Cell, RefCell};
 use std::cmp;
@@ -359,6 +362,7 @@ pub struct TypedArena<T> {
     /// A pointer to the first arena segment.
     first: RefCell<TypedArenaChunkRef<T>>,
 }
+
 type TypedArenaChunkRef<T> = Option<Box<TypedArenaChunk<T>>>;
 
 struct TypedArenaChunk<T> {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2182,7 +2182,6 @@ pub type Iterate<'a, T> = Unfold<'a, T, IterateState<'a, T>>;
 
 /// Creates a new iterator that produces an infinite sequence of
 /// repeated applications of the given function `f`.
-#[allow(visible_private_types)]
 pub fn iterate<'a, T: Clone>(f: |T|: 'a -> T, seed: T) -> Iterate<'a, T> {
     Unfold::new((f, Some(seed), true), |st| {
         let &(ref mut f, ref mut val, ref mut first) = st;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -58,8 +58,11 @@
 
 #![no_std]
 #![feature(globs, intrinsics, lang_items, macro_rules, managed_boxes, phase)]
-#![feature(simd, unsafe_destructor)]
+#![feature(simd, unsafe_destructor, visible_private_types)]
 #![deny(missing_doc)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 mod macros;
 

--- a/src/libdebug/lib.rs
+++ b/src/libdebug/lib.rs
@@ -25,8 +25,11 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/master/")]
 #![experimental]
-#![feature(managed_boxes, macro_rules)]
+#![feature(managed_boxes, macro_rules, visible_private_types)]
 #![allow(experimental)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 pub mod fmt;
 pub mod reflect;

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -217,8 +217,11 @@
        html_playground_url = "http://play.rust-lang.org/")]
 
 // NB this does *not* include globs, please keep it that way.
-#![feature(macro_rules, phase, default_type_params)]
-#![allow(visible_private_types, deprecated)]
+#![feature(macro_rules, phase, default_type_params, visible_private_types)]
+#![allow(deprecated)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 #[cfg(test)] #[phase(plugin, link)] extern crate log;
 #[cfg(test)] extern crate rustuv;

--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -74,7 +74,6 @@ struct Inner {
     id: uint,
 }
 
-#[allow(visible_private_types)]
 pub enum Req {
     // Add a new timer to the helper thread.
     NewTimer(Box<Inner>),

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -63,6 +63,10 @@
 //    consider whether they're needed before adding that feature here (the
 //    answer is that you don't need them)
 #![feature(macro_rules, unsafe_destructor, default_type_params)]
+#![feature(visible_private_types)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 extern crate alloc;
 extern crate libc;

--- a/src/libregex/compile.rs
+++ b/src/libregex/compile.rs
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Enable this to squash warnings due to exporting pieces of the representation
-// for use with the regex! macro. See lib.rs for explanation.
-#![allow(visible_private_types)]
+#![allow(missing_doc)]
 
 use std::cmp;
 use parse;

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -368,8 +368,11 @@
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![feature(macro_rules, phase)]
+#![feature(macro_rules, phase, visible_private_types)]
 #![deny(missing_doc)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 #[cfg(test)]
 extern crate stdtest = "test";

--- a/src/libregex/re.rs
+++ b/src/libregex/re.rs
@@ -102,7 +102,6 @@ pub fn is_match(regex: &str, text: &str) -> Result<bool, parse::Error> {
 /// More details about the `regex!` macro can be found in the `regex` crate
 /// documentation.
 #[deriving(Clone)]
-#[allow(visible_private_types)]
 pub enum Regex {
     // The representation of `Regex` is exported to support the `regex!`
     // syntax extension. Do not rely on it.
@@ -516,7 +515,6 @@ impl Regex {
     }
 
     #[doc(hidden)]
-    #[allow(visible_private_types)]
     #[experimental]
     pub fn names_iter<'a>(&'a self) -> NamesIter<'a> {
         match *self {

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -68,6 +68,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
 
     ("rustc_diagnostic_macros", Active),
     ("unboxed_closures", Active),
+    ("visible_private_types", Active),
 
     // if you change this list without updating src/doc/rust.md, cmr will be sad
 
@@ -98,7 +99,8 @@ pub struct Features {
     pub default_type_params: Cell<bool>,
     pub issue_5723_bootstrap: Cell<bool>,
     pub overloaded_calls: Cell<bool>,
-    pub rustc_diagnostic_macros: Cell<bool>
+    pub rustc_diagnostic_macros: Cell<bool>,
+    pub visible_private_types: Cell<bool>,
 }
 
 impl Features {
@@ -107,7 +109,8 @@ impl Features {
             default_type_params: Cell::new(false),
             issue_5723_bootstrap: Cell::new(false),
             overloaded_calls: Cell::new(false),
-            rustc_diagnostic_macros: Cell::new(false)
+            rustc_diagnostic_macros: Cell::new(false),
+            visible_private_types: Cell::new(false),
         }
     }
 }
@@ -439,4 +442,5 @@ pub fn check_crate(sess: &Session, krate: &ast::Crate) {
     sess.features.issue_5723_bootstrap.set(cx.has_feature("issue_5723_bootstrap"));
     sess.features.overloaded_calls.set(cx.has_feature("overloaded_calls"));
     sess.features.rustc_diagnostic_macros.set(cx.has_feature("rustc_diagnostic_macros"));
+    sess.features.visible_private_types.set(cx.has_feature("visible_private_types"));
 }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1539,9 +1539,6 @@ declare_lint!(pub DEAD_ASSIGNMENT, Warn,
 declare_lint!(pub DEAD_CODE, Warn,
               "detect piece of code that will never be used")
 
-declare_lint!(pub VISIBLE_PRIVATE_TYPES, Warn,
-              "detect use of private types in exported type signatures")
-
 declare_lint!(pub UNREACHABLE_CODE, Warn,
               "detects unreachable code")
 
@@ -1570,7 +1567,6 @@ impl LintPass for HardwiredLints {
             UNUSED_VARIABLE,
             DEAD_ASSIGNMENT,
             DEAD_CODE,
-            VISIBLE_PRIVATE_TYPES,
             UNREACHABLE_CODE,
             WARNINGS,
             UNKNOWN_FEATURES,

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -224,7 +224,7 @@ pub fn deref_kind(tcx: &ty::ctxt, t: ty::t) -> deref_kind {
     }
 }
 
-trait ast_node {
+pub trait ast_node {
     fn id(&self) -> ast::NodeId;
     fn span(&self) -> Span;
 }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -44,7 +44,7 @@ use std::uint;
 // Definition mapping
 pub type DefMap = RefCell<NodeMap<Def>>;
 
-struct binding_info {
+pub struct binding_info {
     span: Span,
     binding_mode: BindingMode,
 }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -56,7 +56,7 @@ struct LifetimeContext<'a> {
     named_region_map: NamedRegionMap,
 }
 
-enum ScopeChain<'a> {
+pub enum ScopeChain<'a> {
     /// EarlyScope(i, ['a, 'b, ...], s) extends s with early-bound
     /// lifetimes, assigning indexes 'a => i, 'b => i+1, ... etc.
     EarlyScope(subst::ParamSpace, &'a Vec<ast::LifetimeDef>, Scope<'a>),
@@ -69,7 +69,7 @@ enum ScopeChain<'a> {
     RootScope
 }
 
-type Scope<'a> = &'a ScopeChain<'a>;
+pub type Scope<'a> = &'a ScopeChain<'a>;
 
 pub fn krate(sess: &Session, krate: &ast::Crate) -> NamedRegionMap {
     let mut ctxt = LifetimeContext {

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1429,7 +1429,7 @@ impl<'a> ErrorReportingHelpers for InferCtxt<'a> {
     }
 }
 
-trait Resolvable {
+pub trait Resolvable {
     fn resolve(&self, infcx: &InferCtxt) -> Self;
     fn contains_error(&self) -> bool;
 }

--- a/src/librustc/middle/typeck/infer/lattice.rs
+++ b/src/librustc/middle/typeck/infer/lattice.rs
@@ -45,7 +45,7 @@ use util::ppaux::Repr;
 
 use std::collections::HashMap;
 
-trait LatticeValue : Clone + Repr + PartialEq {
+pub trait LatticeValue : Clone + Repr + PartialEq {
     fn sub(cf: CombineFields, a: &Self, b: &Self) -> ures;
     fn lub(cf: CombineFields, a: &Self, b: &Self) -> cres<Self>;
     fn glb(cf: CombineFields, a: &Self, b: &Self) -> cres<Self>;

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -230,11 +230,11 @@ pub fn infer_variance(tcx: &ty::ctxt,
  * a variable.
  */
 
-type VarianceTermPtr<'a> = &'a VarianceTerm<'a>;
+pub type VarianceTermPtr<'a> = &'a VarianceTerm<'a>;
 
-struct InferredIndex(uint);
+pub struct InferredIndex(uint);
 
-enum VarianceTerm<'a> {
+pub enum VarianceTerm<'a> {
     ConstantTerm(ty::Variance),
     TransformTerm(VarianceTermPtr<'a>, VarianceTermPtr<'a>),
     InferredTerm(InferredIndex),

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -140,7 +140,7 @@ pub enum AttributeSet {
     FunctionIndex = !0
 }
 
-trait AttrHelper {
+pub trait AttrHelper {
     fn apply_llfn(&self, idx: c_uint, llfn: ValueRef);
     fn apply_callsite(&self, idx: c_uint, callsite: ValueRef);
 }

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -18,8 +18,12 @@
 
 #![feature(macro_rules, phase, globs, thread_local, managed_boxes, asm)]
 #![feature(linkage, lang_items, unsafe_destructor, default_type_params)]
+#![feature(visible_private_types)]
 #![no_std]
 #![experimental]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 #[phase(plugin, link)] extern crate core;
 extern crate alloc;
@@ -45,10 +49,10 @@ use task::{Task, BlockedTask, TaskOpts};
 mod macros;
 
 mod at_exit_imp;
+mod libunwind;
 mod local_ptr;
 mod thread_local_storage;
 mod util;
-mod libunwind;
 
 pub mod args;
 pub mod bookkeeping;

--- a/src/librustrt/local.rs
+++ b/src/librustrt/local.rs
@@ -26,7 +26,6 @@ pub trait Local<Borrowed> {
     unsafe fn try_unsafe_borrow() -> Option<*mut Self>;
 }
 
-#[allow(visible_private_types)]
 impl Local<local_ptr::Borrowed<Task>> for Task {
     #[inline]
     fn put(value: Box<Task>) { unsafe { local_ptr::put(value) } }

--- a/src/librustrt/local_ptr.rs
+++ b/src/librustrt/local_ptr.rs
@@ -374,7 +374,6 @@ pub mod native {
 
     #[inline]
     #[cfg(not(test))]
-    #[allow(visible_private_types)]
     pub fn maybe_tls_key() -> Option<tls::Key> {
         unsafe {
             // NB: This is a little racy because, while the key is

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -236,7 +236,6 @@ fn rust_exception_class() -> uw::_Unwind_Exception_Class {
 
 #[cfg(not(target_arch = "arm"), not(windows, target_arch = "x86_64"), not(test))]
 #[doc(hidden)]
-#[allow(visible_private_types)]
 pub mod eabi {
     use uw = libunwind;
     use libc::c_int;
@@ -290,7 +289,6 @@ pub mod eabi {
 
 #[cfg(target_os = "ios", target_arch = "arm", not(test))]
 #[doc(hidden)]
-#[allow(visible_private_types)]
 pub mod eabi {
     use uw = libunwind;
     use libc::c_int;
@@ -343,7 +341,6 @@ pub mod eabi {
 // but otherwise works the same.
 #[cfg(target_arch = "arm", not(target_os = "ios"), not(test))]
 #[doc(hidden)]
-#[allow(visible_private_types)]
 pub mod eabi {
     use uw = libunwind;
     use libc::c_int;
@@ -393,7 +390,6 @@ pub mod eabi {
 
 #[cfg(windows, target_arch = "x86_64", not(test))]
 #[doc(hidden)]
-#[allow(visible_private_types)]
 #[allow(non_camel_case_types)]
 pub mod eabi {
     use uw = libunwind;

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -44,9 +44,11 @@ via `close` and `delete` methods.
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![feature(macro_rules, unsafe_destructor)]
+#![feature(macro_rules, unsafe_destructor, visible_private_types)]
 #![deny(unused_result, unused_must_use)]
-#![allow(visible_private_types)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 #![reexport_test_harness_main = "test_main"]
 
@@ -86,9 +88,9 @@ fn start(argc: int, argv: *const *const u8) -> int {
 mod macros;
 
 mod access;
-mod timeout;
 mod homing;
 mod queue;
+mod timeout;
 mod rc;
 
 pub mod uvio;

--- a/src/libstd/collections/hashmap.rs
+++ b/src/libstd/collections/hashmap.rs
@@ -28,6 +28,7 @@ use option::{Some, None, Option};
 use result::{Ok, Err};
 use ops::Index;
 
+#[allow(missing_doc)]
 mod table {
     use clone::Clone;
     use cmp;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -107,12 +107,16 @@
 
 #![feature(macro_rules, globs, managed_boxes, linkage)]
 #![feature(default_type_params, phase, lang_items, unsafe_destructor)]
+#![feature(visible_private_types)]
 
 // Don't link to std. We are std.
 #![no_std]
 
 #![allow(deprecated)]
 #![deny(missing_doc)]
+
+// NOTE(stage0, pcwalton): Remove after snapshot.
+#![allow(unknown_features)]
 
 #![reexport_test_harness_main = "test_main"]
 

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -269,7 +269,9 @@ impl reseeding::Reseeder<StdRng> for TaskRngReseeder {
         }
     }
 }
+
 static TASK_RNG_RESEED_THRESHOLD: uint = 32_768;
+
 type TaskRngInner = reseeding::ReseedingRng<StdRng, TaskRngReseeder>;
 
 /// The task-local RNG.

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -235,6 +235,7 @@ fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
 /// to symbols. This is a bit of a hokey implementation as-is, but it works for
 /// all unix platforms we support right now, so it at least gets the job done.
 #[cfg(unix)]
+#[allow(missing_doc)]
 mod imp {
     use c_str::CString;
     use io::{IoResult, Writer};
@@ -657,7 +658,7 @@ mod imp {
 /// copy of that function in my mingw install (maybe it was broken?). Instead,
 /// this takes the route of using StackWalk64 in order to walk the stack.
 #[cfg(windows)]
-#[allow(dead_code, uppercase_variables)]
+#[allow(dead_code, uppercase_variables, missing_doc)]
 mod imp {
     use c_str::CString;
     use core_collections::Collection;

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -49,12 +49,12 @@ impl fmt::Show for PathElem {
 }
 
 #[deriving(Clone)]
-struct LinkedPathNode<'a> {
+pub struct LinkedPathNode<'a> {
     node: PathElem,
     next: LinkedPath<'a>,
 }
 
-type LinkedPath<'a> = Option<&'a LinkedPathNode<'a>>;
+pub type LinkedPath<'a> = Option<&'a LinkedPathNode<'a>>;
 
 impl<'a> Iterator<PathElem> for LinkedPath<'a> {
     fn next(&mut self) -> Option<PathElem> {

--- a/src/test/auxiliary/iss.rs
+++ b/src/test/auxiliary/iss.rs
@@ -12,7 +12,7 @@
 
 // part of issue-6919.rs
 
-struct C<'a> {
+pub struct C<'a> {
     pub k: ||: 'a,
 }
 

--- a/src/test/auxiliary/issue-11225-2.rs
+++ b/src/test/auxiliary/issue-11225-2.rs
@@ -10,7 +10,7 @@
 
 use inner::Trait;
 
-mod inner {
+pub mod inner {
     pub struct Foo;
     pub trait Trait {
         fn f(&self);

--- a/src/test/auxiliary/issue-2526.rs
+++ b/src/test/auxiliary/issue-2526.rs
@@ -36,7 +36,7 @@ fn init() -> arc_destruct<context_res> {
     arc(context_res())
 }
 
-struct context_res {
+pub struct context_res {
     ctx : int,
 }
 

--- a/src/test/auxiliary/noexporttypelib.rs
+++ b/src/test/auxiliary/noexporttypelib.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type oint = Option<int>;
+pub type oint = Option<int>;
 pub fn foo() -> oint { Some(3) }

--- a/src/test/auxiliary/priv-impl-prim-ty.rs
+++ b/src/test/auxiliary/priv-impl-prim-ty.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait A {
+pub trait A {
     fn frob(&self);
 }
 

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -11,7 +11,6 @@
 #![no_std]
 #![allow(unused_variable)]
 #![allow(non_camel_case_types)]
-#![allow(visible_private_types)]
 #![deny(dead_code)]
 #![feature(lang_items)]
 
@@ -46,7 +45,7 @@ struct UsedStruct1 {
 }
 struct UsedStruct2(int);
 struct UsedStruct3;
-struct UsedStruct4;
+pub struct UsedStruct4;
 // this struct is never used directly, but its method is, so we don't want
 // to warn it
 struct SemiUsedStruct;
@@ -54,7 +53,7 @@ impl SemiUsedStruct {
     fn la_la_la() {}
 }
 struct StructUsedAsField;
-struct StructUsedInEnum;
+pub struct StructUsedInEnum;
 struct StructUsedInGeneric;
 pub struct PubStruct2 {
     #[allow(dead_code)]

--- a/src/test/compile-fail/visible-private-trait-bounds.rs
+++ b/src/test/compile-fail/visible-private-trait-bounds.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub mod inner {
-    pub trait Trait {
-        fn f(&self) { f(); }
-    }
+pub mod a {
+    trait Foo {}
 
-    impl Trait for int {}
-
-    fn f() {}
+    pub fn f<T:Foo>() {}    //~ ERROR private type in exported type signature
 }
 
-pub fn foo<T: inner::Trait>(t: T) {
-    t.f();
-}
+fn main() {}
+

--- a/src/test/compile-fail/visible-private-typedefs.rs
+++ b/src/test/compile-fail/visible-private-typedefs.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub mod inner {
-    pub trait Trait {
-        fn f(&self) { f(); }
-    }
+pub mod a {
+    type Foo = int;
 
-    impl Trait for int {}
-
-    fn f() {}
+    pub fn f(_: Foo) {}    //~ ERROR private type in exported type signature
 }
 
-pub fn foo<T: inner::Trait>(t: T) {
-    t.f();
-}
+fn main() {}
+
+

--- a/src/test/run-pass/deriving-enum-single-variant.rs
+++ b/src/test/run-pass/deriving-enum-single-variant.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type task_id = int;
+pub type task_id = int;
 
 #[deriving(PartialEq)]
 pub enum Task {

--- a/src/test/run-pass/extern-pass-TwoU16s.rs
+++ b/src/test/run-pass/extern-pass-TwoU16s.rs
@@ -12,7 +12,7 @@
 // by value.
 
 #[deriving(PartialEq, Show)]
-struct TwoU16s {
+pub struct TwoU16s {
     one: u16, two: u16
 }
 

--- a/src/test/run-pass/extern-pass-TwoU32s.rs
+++ b/src/test/run-pass/extern-pass-TwoU32s.rs
@@ -12,7 +12,7 @@
 // by value.
 
 #[deriving(PartialEq, Show)]
-struct TwoU32s {
+pub struct TwoU32s {
     one: u32, two: u32
 }
 

--- a/src/test/run-pass/extern-pass-TwoU64s.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s.rs
@@ -12,7 +12,7 @@
 // by value.
 
 #[deriving(PartialEq, Show)]
-struct TwoU64s {
+pub struct TwoU64s {
     one: u64, two: u64
 }
 

--- a/src/test/run-pass/extern-pass-TwoU8s.rs
+++ b/src/test/run-pass/extern-pass-TwoU8s.rs
@@ -12,7 +12,7 @@
 // by value.
 
 #[deriving(PartialEq, Show)]
-struct TwoU8s {
+pub struct TwoU8s {
     one: u8, two: u8
 }
 

--- a/src/test/run-pass/extern-return-TwoU16s.rs
+++ b/src/test/run-pass/extern-return-TwoU16s.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct TwoU16s {
+pub struct TwoU16s {
     one: u16, two: u16
 }
 

--- a/src/test/run-pass/extern-return-TwoU32s.rs
+++ b/src/test/run-pass/extern-return-TwoU32s.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct TwoU32s {
+pub struct TwoU32s {
     one: u32, two: u32
 }
 

--- a/src/test/run-pass/extern-return-TwoU64s.rs
+++ b/src/test/run-pass/extern-return-TwoU64s.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct TwoU64s {
+pub struct TwoU64s {
     one: u64, two: u64
 }
 

--- a/src/test/run-pass/extern-return-TwoU8s.rs
+++ b/src/test/run-pass/extern-return-TwoU8s.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct TwoU8s {
+pub struct TwoU8s {
     one: u8, two: u8
 }
 

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -23,7 +23,7 @@ pub fn map(filename: String, emit: map_reduce::putter) {
     emit(filename, "1".to_string());
 }
 
-mod map_reduce {
+pub mod map_reduce {
     use std::collections::HashMap;
     use std::str;
     use std::task;

--- a/src/test/run-pass/issue-3656.rs
+++ b/src/test/run-pass/issue-3656.rs
@@ -15,7 +15,7 @@
 extern crate libc;
 use libc::{c_uint, uint32_t, c_void};
 
-struct KEYGEN {
+pub struct KEYGEN {
     hash_algorithm: [c_uint, ..2],
     count: uint32_t,
     salt: *const c_void,

--- a/src/test/run-pass/issue-3753.rs
+++ b/src/test/run-pass/issue-3753.rs
@@ -14,7 +14,7 @@
 
 use std::f64;
 
-struct Point {
+pub struct Point {
     x: f64,
     y: f64
 }

--- a/src/test/run-pass/issue-5708.rs
+++ b/src/test/run-pass/issue-5708.rs
@@ -48,7 +48,7 @@ pub fn main() {
 
 
 // minimal
-trait MyTrait<T> { }
+pub trait MyTrait<T> { }
 
 pub struct MyContainer<'a, T> {
     foos: Vec<&'a MyTrait<T>> ,

--- a/src/test/run-pass/regions-no-variance-from-fn-generics.rs
+++ b/src/test/run-pass/regions-no-variance-from-fn-generics.rs
@@ -12,7 +12,7 @@
 // should not upset the variance inference for actual occurrences of
 // that lifetime in type expressions.
 
-trait HasLife<'a> { }
+pub trait HasLife<'a> { }
 
 trait UseLife01 {
     fn refs<'a, H: HasLife<'a>>(&'a self) -> H;
@@ -23,7 +23,7 @@ trait UseLife02 {
 }
 
 
-trait HasType<T> { }
+pub trait HasType<T> { }
 
 trait UseLife03<T> {
     fn refs<'a, H: HasType<&'a T>>(&'a self) -> H;

--- a/src/test/run-pass/struct-partial-move-1.rs
+++ b/src/test/run-pass/struct-partial-move-1.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[deriving(PartialEq, Show)]
-struct Partial<T> { x: T, y: T }
+pub struct Partial<T> { x: T, y: T }
 
 #[deriving(PartialEq, Show)]
 struct S { val: int }

--- a/src/test/run-pass/struct-partial-move-2.rs
+++ b/src/test/run-pass/struct-partial-move-2.rs
@@ -9,14 +9,14 @@
 // except according to those terms.
 
 #[deriving(PartialEq, Show)]
-struct Partial<T> { x: T, y: T }
+pub struct Partial<T> { x: T, y: T }
 
 #[deriving(PartialEq, Show)]
 struct S { val: int }
 impl S { fn new(v: int) -> S { S { val: v } } }
 impl Drop for S { fn drop(&mut self) { } }
 
-type Two<T> = (Partial<T>, Partial<T>);
+pub type Two<T> = (Partial<T>, Partial<T>);
 
 pub fn f<T>((b1, b2): (T, T), (b3, b4): (T, T), f: |T| -> T) -> Two<T> {
     let p = Partial { x: b1, y: b2 };

--- a/src/test/run-pass/visible-private-types-feature-gate.rs
+++ b/src/test/run-pass/visible-private-types-feature-gate.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub mod inner {
-    pub trait Trait {
-        fn f(&self) { f(); }
+#![feature(visible_private_types)]
+
+pub mod a {
+    struct Struct {
+        x: int,
     }
 
-    impl Trait for int {}
-
-    fn f() {}
+    pub fn f(x: Struct) {}
 }
 
-pub fn foo<T: inner::Trait>(t: T) {
-    t.f();
-}
+fn main() {}
+


### PR DESCRIPTION
public, including in trait bounds and typedefs.

There are three main patterns that this breaks. First is code that uses
private trait bounds in public APIs:

```
pub mod a {
    trait Trait { ... }
    pub fn f<T:Trait>() { ... }
}
```

Change that code to export the trait. For example:

```
pub mod a {
    pub trait Trait { ... }     // note `pub`
    pub fn f<T:Trait>() { ... }
}
```

Second, this change breaks code that was relying on
`#[allow(visible_private_types)]`. That lint is now a hard error, and
cannot be overridden. For example:

```
mod helper {
    pub struct Foo { ... }
}
pub mod public {
    use helper::Foo;
    pub fn f() -> Foo;
}
```

Because there is no way for code that uses `public::f` to name `Foo`,
this is no longer allowed. Change affected code to look like this:

```
pub mod helper {    // note `pub`
    pub struct Foo { ... }
}
pub mod public {
    use helper::Foo;
    pub fn f() -> Foo;
}
```

Third, this change breaks code that was relying on being able to
reference private typedefs in public APIs. For example:

```
pub mod b {
    type Foo = int;
    pub fn f(_: Foo) { ... }
}
```

Change this code to:

```
pub mod b {
    pub type Foo = int; // note `pub`
    pub fn f(_: Foo) { ... }
}
```

This implements RFC #48.

Closes #16463.

[breaking-change]

r? @alexcrichton
