### PR TITLE
libsyntax: Accept `use foo as bar;` in lieu of `use bar = foo;`

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -919,7 +919,7 @@ extern crate foo = "some/where/rust-foo#foo:1.0"; // a full crate ID for externa
 ##### Use declarations
 
 ~~~~ {.ebnf .gram}
-use_decl : "pub" ? "use" [ ident '=' path
+use_decl : "pub" ? "use" [ path "as" ident
                           | path_glob ] ;
 
 path_glob : ident [ "::" [ path_glob
@@ -939,7 +939,7 @@ module item. These declarations may appear at the top of [modules](#modules) and
 
 Use declarations support a number of convenient shortcuts:
 
-  * Rebinding the target name as a new local name, using the syntax `use x = p::q::r;`.
+  * Rebinding the target name as a new local name, using the syntax `use p::q::r as x;`.
   * Simultaneously binding a list of paths differing only in their final element,
     using the glob-like brace syntax `use a::b::{c,d,e,f};`
   * Binding all paths matching a given prefix, using the asterisk wildcard syntax `use a::b::*;`

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1114,11 +1114,11 @@ pub type ViewPath = Spanned<ViewPath_>;
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum ViewPath_ {
 
-    /// `quux = foo::bar::baz`
+    /// `foo::bar::baz as quux`
     ///
     /// or just
     ///
-    /// `foo::bar::baz ` (with 'baz =' implicitly on the left)
+    /// `foo::bar::baz` (with `as baz` implicitly on the right)
     ViewPathSimple(Ident, Path, NodeId),
 
     /// `foo::bar::*`

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5309,6 +5309,7 @@ impl<'a> Parser<'a> {
         match self.token {
           token::EQ => {
             // x = foo::bar
+            // NOTE(stage0, #16461, pcwalton): Deprecate after snapshot.
             self.bump();
             let path_lo = self.span.lo;
             path = vec!(self.parse_ident());
@@ -5391,7 +5392,7 @@ impl<'a> Parser<'a> {
           }
           _ => ()
         }
-        let last = *path.get(path.len() - 1u);
+        let mut rename_to = *path.get(path.len() - 1u);
         let path = ast::Path {
             span: mk_sp(lo, self.span.hi),
             global: false,
@@ -5403,9 +5404,12 @@ impl<'a> Parser<'a> {
                 }
             }).collect()
         };
+        if self.eat_keyword(keywords::As) {
+            rename_to = self.parse_ident()
+        }
         return box(GC) spanned(lo,
                         self.last_span.hi,
-                        ViewPathSimple(last, path, ast::DUMMY_NODE_ID));
+                        ViewPathSimple(rename_to, path, ast::DUMMY_NODE_ID));
     }
 
     /// Parses a sequence of items. Stops when it finds program

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2262,13 +2262,17 @@ impl<'a> State<'a> {
     pub fn print_view_path(&mut self, vp: &ast::ViewPath) -> IoResult<()> {
         match vp.node {
             ast::ViewPathSimple(ident, ref path, _) => {
+                try!(self.print_path(path, false));
+
                 // FIXME(#6993) can't compare identifiers directly here
-                if path.segments.last().unwrap().identifier.name != ident.name {
-                    try!(self.print_ident(ident));
+                if path.segments.last().unwrap().identifier.name !=
+                        ident.name {
                     try!(space(&mut self.s));
-                    try!(self.word_space("="));
+                    try!(self.word_space("as"));
+                    try!(self.print_ident(ident));
                 }
-                self.print_path(path, false)
+
+                Ok(())
             }
 
             ast::ViewPathGlob(ref path, _) => {

--- a/src/test/auxiliary/privacy_reexport.rs
+++ b/src/test/auxiliary/privacy_reexport.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use bar = foo;
+pub use foo as bar;
 
 mod foo {
     pub fn frob() {}

--- a/src/test/auxiliary/reexported_static_methods.rs
+++ b/src/test/auxiliary/reexported_static_methods.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 pub use sub_foo::Foo;
-pub use Baz = self::Bar;
+pub use self::Bar as Baz;
 pub use sub_foo::Boz;
 pub use sub_foo::Bort;
 

--- a/src/test/auxiliary/static_priv_by_default.rs
+++ b/src/test/auxiliary/static_priv_by_default.rs
@@ -39,10 +39,10 @@ mod foo {
 }
 
 pub mod bar {
-    pub use e = foo::reexported_a;
-    pub use f = foo::reexported_b;
-    pub use g = foo::reexported_c;
-    pub use h = foo::reexported_d;
+    pub use foo::reexported_a as e;
+    pub use foo::reexported_b as f;
+    pub use foo::reexported_c as g;
+    pub use foo::reexported_d as h;
 }
 
 pub static a: int = 0;

--- a/src/test/compile-fail/borrowck-struct-update-with-dtor.rs
+++ b/src/test/compile-fail/borrowck-struct-update-with-dtor.rs
@@ -12,7 +12,7 @@
 // move, when the struct implements Drop.
 
 // NoCopy
-use NP = std::kinds::marker::NoCopy;
+use std::kinds::marker::NoCopy as NP;
 
 
 struct S { a: int, np: NP }

--- a/src/test/compile-fail/glob-resolve1.rs
+++ b/src/test/compile-fail/glob-resolve1.rs
@@ -15,7 +15,7 @@
 use bar::*;
 
 mod bar {
-    use import = self::fpriv;
+    use self::fpriv as import;
     fn fpriv() {}
     extern {
         fn epriv();

--- a/src/test/compile-fail/import-from-rename.rs
+++ b/src/test/compile-fail/import-from-rename.rs
@@ -10,7 +10,7 @@
 
 // error-pattern:expected
 
-use baz = foo::{bar};
+use foo::{bar} as baz;
 
 mod foo {
     pub fn bar() {}

--- a/src/test/compile-fail/import-glob-rename.rs
+++ b/src/test/compile-fail/import-glob-rename.rs
@@ -10,7 +10,7 @@
 
 // error-pattern:expected
 
-use baz = foo::*;
+use foo::* as baz;
 
 mod foo {
     pub fn bar() {}

--- a/src/test/compile-fail/inaccessible-test-modules.rs
+++ b/src/test/compile-fail/inaccessible-test-modules.rs
@@ -12,8 +12,8 @@
 
 // the `--test` harness creates modules with these textual names, but
 // they should be inaccessible from normal code.
-use x = __test; //~ ERROR unresolved import `__test`
-use y = __test_reexports; //~ ERROR unresolved import `__test_reexports`
+use __test as x; //~ ERROR unresolved import `__test`
+use __test_reexports as y; //~ ERROR unresolved import `__test_reexports`
 
 #[test]
 fn baz() {}

--- a/src/test/compile-fail/issue-2937.rs
+++ b/src/test/compile-fail/issue-2937.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use x = m::f; //~ ERROR unresolved import `m::f`. There is no `f` in `m`
+use m::f as x; //~ ERROR unresolved import `m::f`. There is no `f` in `m`
 
 mod m {}
 

--- a/src/test/compile-fail/lint-dead-code-3.rs
+++ b/src/test/compile-fail/lint-dead-code-3.rs
@@ -16,7 +16,7 @@
 
 extern crate libc;
 
-pub use x = extern_foo;
+pub use extern_foo as x;
 extern {
     fn extern_foo();
 }

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -148,8 +148,8 @@ mod internal_impl {
 }
 /// dox
 pub mod public_interface {
-    pub use foo = internal_impl::documented;
-    pub use bar = internal_impl::undocumented1;
+    pub use internal_impl::documented as foo;
+    pub use internal_impl::undocumented1 as bar;
     pub use internal_impl::{documented, undocumented2};
     pub use internal_impl::globbed::*;
 }

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -12,7 +12,7 @@
 #![deny(unused_imports)]
 #![allow(dead_code)]
 
-use cal = bar::c::cc;
+use bar::c::cc as cal;
 
 use std::mem::*;            // shouldn't get errors for not using
                             // everything imported

--- a/src/test/compile-fail/match-static-const-lc.rs
+++ b/src/test/compile-fail/match-static-const-lc.rs
@@ -43,7 +43,7 @@ mod n {
 }
 
 fn h() {
-    use not_okay = self::n::OKAY;
+    use self::n::OKAY as not_okay;
     let r = match (0,0) {
         (0, not_okay) => 0,
 //~^ ERROR static constant in pattern `not_okay` should have an uppercase name such as `NOT_OKAY`

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -176,7 +176,7 @@ pub mod mytest {
                          //~^ NOTE: module `i` is private
 
     pub mod foo {
-        pub use foo = self::i::A;
+        pub use self::i::A as foo;
 
         mod i {
             pub struct A;

--- a/src/test/compile-fail/unresolved-import.rs
+++ b/src/test/compile-fail/unresolved-import.rs
@@ -10,7 +10,7 @@
 
 use foo::bar; //~ ERROR unresolved import `foo::bar`. Maybe a missing `extern crate foo`?
 
-use x = bar::baz; //~ ERROR unresolved import `bar::baz`. There is no `baz` in `bar`
+use bar::baz as x; //~ ERROR unresolved import `bar::baz`. There is no `baz` in `bar`
 
 mod bar {
     struct bar;

--- a/src/test/run-pass/auto-encode.rs
+++ b/src/test/run-pass/auto-encode.rs
@@ -19,8 +19,8 @@ extern crate time;
 
 use std::hashmap::{HashMap, HashSet};
 
-use EBReader = rbml::reader;
-use EBWriter = rbml::writer;
+use rbml::reader as EBReader;
+use rbml::writer as EBWriter;
 use std::cmp::Eq;
 use std::cmp;
 use std::io;

--- a/src/test/run-pass/exponential-notation.rs
+++ b/src/test/run-pass/exponential-notation.rs
@@ -10,8 +10,8 @@
 
 #![feature(macro_rules)]
 
-use s = std::num::strconv;
-use to_string = std::num::strconv::float_to_str_common;
+use std::num::strconv as s;
+use std::num::strconv::float_to_str_common as to_string;
 
 macro_rules! t(($a:expr, $b:expr) => { { let (r, _) = $a; assert_eq!(r, $b.to_string()) } })
 

--- a/src/test/run-pass/filter-block-view-items.rs
+++ b/src/test/run-pass/filter-block-view-items.rs
@@ -11,5 +11,5 @@
 pub fn main() {
     // Make sure that this view item is filtered out because otherwise it would
     // trigger a compilation error
-    #[cfg(not_present)] use foo = bar;
+    #[cfg(not_present)] use bar as foo;
 }

--- a/src/test/run-pass/fsu-moves-and-copies.rs
+++ b/src/test/run-pass/fsu-moves-and-copies.rs
@@ -11,7 +11,7 @@
 // Issue 4691: Ensure that functional-struct-updates operates
 // correctly and moves rather than copy when appropriate.
 
-use NP = std::kinds::marker::NoCopy;
+use std::kinds::marker::NoCopy as NP;
 
 struct ncint { np: NP, v: int }
 fn ncint(v: int) -> ncint { ncint { np: NP, v: v } }

--- a/src/test/run-pass/import.rs
+++ b/src/test/run-pass/import.rs
@@ -16,7 +16,7 @@ mod foo {
 
 mod bar {
     use foo::x;
-    use z = foo::x;
+    use foo::x as z;
     pub fn thing() { x(10); z(10); }
 }
 

--- a/src/test/run-pass/import8.rs
+++ b/src/test/run-pass/import8.rs
@@ -11,7 +11,7 @@
 
 
 use foo::x;
-use z = foo::x;
+use foo::x as z;
 
 mod foo {
     pub fn x(y: int) { println!("{}", y); }

--- a/src/test/run-pass/issue-5950.rs
+++ b/src/test/run-pass/issue-5950.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-pub use local_alias = local;
+pub use local as local_alias;
 
 mod local { }
 

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -38,7 +38,7 @@ mod m {
 }
 
 fn g() {
-    use AHA = self::m::aha;
+    use self::m::aha as AHA;
     let r = match (0,0) {
         (0, AHA) => 0,
         (x, y)   => 1 + x + y,

--- a/src/test/run-pass/use.rs
+++ b/src/test/run-pass/use.rs
@@ -18,9 +18,9 @@ extern crate zed = "std";
 
 
 use std::str;
-use x = zed::str;
+use zed::str as x;
 mod baz {
-    pub use x = std::str;
+    pub use std::str as x;
 }
 
 #[start]

--- a/src/test/run-pass/xcrate-static-addresses.rs
+++ b/src/test/run-pass/xcrate-static-addresses.rs
@@ -12,7 +12,7 @@
 
 extern crate xcrate_static_addresses;
 
-use other = xcrate_static_addresses;
+use xcrate_static_addresses as other;
 
 pub fn main() {
     other::verify_same(&other::global);


### PR DESCRIPTION
The old syntax will be removed after a snapshot.

RFC #47.

Issue #16461.

r? @brson
