### PR TITLE
libcore: rename private cmp macros

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -273,7 +273,7 @@ mod impls {
               Less, Greater, Equal};
     use option::{Option, Some, None};
 
-    macro_rules! eq_impl(
+    macro_rules! partial_eq_impl(
         ($($t:ty)*) => ($(
             #[unstable = "Trait is unstable."]
             impl PartialEq for $t {
@@ -293,18 +293,18 @@ mod impls {
         fn ne(&self, _other: &()) -> bool { false }
     }
 
-    eq_impl!(bool char uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64)
+    partial_eq_impl!(bool char uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64)
 
-    macro_rules! totaleq_impl(
+    macro_rules! eq_impl(
         ($($t:ty)*) => ($(
             #[unstable = "Trait is unstable."]
             impl Eq for $t {}
         )*)
     )
 
-    totaleq_impl!(() bool char uint u8 u16 u32 u64 int i8 i16 i32 i64)
+    eq_impl!(() bool char uint u8 u16 u32 u64 int i8 i16 i32 i64)
 
-    macro_rules! ord_impl(
+    macro_rules! partial_ord_impl(
         ($($t:ty)*) => ($(
             #[unstable = "Trait is unstable."]
             impl PartialOrd for $t {
@@ -345,9 +345,9 @@ mod impls {
         }
     }
 
-    ord_impl!(char uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64)
+    partial_ord_impl!(char uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64)
 
-    macro_rules! totalord_impl(
+    macro_rules! ord_impl(
         ($($t:ty)*) => ($(
             #[unstable = "Trait is unstable."]
             impl Ord for $t {
@@ -375,7 +375,7 @@ mod impls {
         }
     }
 
-    totalord_impl!(char uint u8 u16 u32 u64 int i8 i16 i32 i64)
+    ord_impl!(char uint u8 u16 u32 u64 int i8 i16 i32 i64)
 
     // & pointers
     #[unstable = "Trait is unstable."]


### PR DESCRIPTION
eq_impl! => partial_eq_impl!
totaleq_impl! => eq_impl!
ord_impl! => partial_ord_impl!
totalord_impl! => ord_impl!
