### PR TITLE
Fix handling of ignored arguments in FFI wrappers for rust functions

### DIFF
--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -741,6 +741,12 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
             let llforeign_arg_ty = *tys.fn_ty.arg_tys.get(i);
             let foreign_indirect = llforeign_arg_ty.is_indirect();
 
+            if llforeign_arg_ty.is_ignore() {
+                debug!("skipping ignored arg #{}", i);
+                llrust_args.push(C_undef(llrust_ty));
+                continue;
+            }
+
             // skip padding
             let foreign_index = next_foreign_arg(llforeign_arg_ty.pad.is_some());
             let mut llforeign_arg = get_param(llwrapfn, foreign_index);

--- a/src/test/run-pass/issue-16441.rs
+++ b/src/test/run-pass/issue-16441.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Empty;
+
+// This used to cause an ICE
+extern "C" fn ice(_a: Empty) {}
+
+fn main() {
+}


### PR DESCRIPTION
Fixes #16441.
