### PR TITLE
vim: Stop setting conceallevel in the syntax file

### DIFF
--- a/src/etc/vim/after/syntax/rust.vim
+++ b/src/etc/vim/after/syntax/rust.vim
@@ -29,5 +29,3 @@ hi link rustNiceOperator Operator
 if !exists('g:rust_conceal_mod_path')
     hi! link Conceal Operator
 endif
-
-setlocal conceallevel=2

--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -56,6 +56,11 @@ if exists("g:loaded_delimitMate")
 	let b:delimitMate_excluded_regions = delimitMate#Get("excluded_regions") . ',rustLifetimeCandidate,rustGenericLifetimeCandidate'
 endif
 
+if has('conceal') && exists('g:rust_conceal')
+	let b:rust_set_conceallevel=1
+	setlocal conceallevel=2
+endif
+
 " Motion Commands {{{1
 
 " Bind motion commands to support hanging indents
@@ -102,6 +107,10 @@ let b:undo_ftplugin = "
 		  \|unlet b:rust_original_delimitMate_excluded_regions
 		\|else
 		  \|unlet! b:delimitMate_excluded_regions
+		\|endif
+		\|if exists('b:rust_set_conceallevel')
+		  \|setlocal conceallevel<
+		  \|unlet b:rust_set_conceallevel
 		\|endif
 		\|unlet! b:rust_last_rustc_args b:rust_last_args
 		\|delcommand RustRun


### PR DESCRIPTION
We shouldn't be setting conceallevel in the syntax file. Besides not
being able to undo this if we switch to another syntax later, it also
interferes with embedding rust in other filetypes (such as markdown).

Instead, set it in the ftplugin, where it belongs.
