### PR TITLE
core: add functions for creating empty slice iterators.

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2109,6 +2109,26 @@ mod tests {
         let y: &mut [int] = [];
         assert!(y.mut_last().is_none());
     }
+
+    #[test]
+    fn test_items_empty() {
+        for _ in Items::<u8>::empty() {
+            unreachable!()
+        }
+        for _ in Items::<Box<uint>>::empty() {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn test_mutitems_empty() {
+        for _ in MutItems::<u8>::empty() {
+            unreachable!()
+        }
+        for _ in MutItems::<Box<uint>>::empty() {
+            unreachable!()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -952,11 +952,41 @@ macro_rules! iterator {
     }
 }
 
+#[inline(never)]
+static PTR_MARKER: u8 = 0;
+
 /// Immutable slice iterator
 pub struct Items<'a, T> {
     ptr: *const T,
     end: *const T,
     marker: marker::ContravariantLifetime<'a>
+}
+
+impl<'a, T> Items<'a, T> {
+    /// Create an `Items` that yields no values.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::slice::Items;
+    ///
+    /// for _ in Items::<u8>::empty() {
+    ///     // the iterator is empty, so this should never execute.
+    ///     fail!("the impossible happened!")
+    /// }
+    /// ```
+    pub fn empty() -> Items<'a, T> {
+        unsafe {
+            // this is safe because the pointer is non-null, and `len
+            // == 0` so it is never dereferenced, or `offset`d.
+            let array: &'a [T] = transmute(Slice {
+                data: &PTR_MARKER,
+                len: 0
+            });
+            array.iter()
+        }
+    }
 }
 
 iterator!{struct Items -> *const T, &'a T}
@@ -997,6 +1027,33 @@ pub struct MutItems<'a, T> {
     end: *mut T,
     marker: marker::ContravariantLifetime<'a>,
     marker2: marker::NoCopy
+}
+
+impl<'a, T> MutItems<'a, T> {
+    /// Create a `MutItems` that yields no values.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::slice::MutItems;
+    ///
+    /// for _ in MutItems::<u8>::empty() {
+    ///     // the iterator is empty, so this should never execute.
+    ///     fail!("the impossible happened!")
+    /// }
+    /// ```
+    pub fn empty() -> MutItems<'a, T> {
+        unsafe {
+            // this is safe because the pointer is non-null, and `len
+            // == 0` so it is never dereferenced, or `offset`d.
+            let array: &'a mut [T] = transmute(Slice {
+                data: &PTR_MARKER,
+                len: 0
+            });
+            array.mut_iter()
+        }
+    }
 }
 
 iterator!{struct MutItems -> *mut T, &'a mut T}


### PR DESCRIPTION
This is useful when building iterators over data structures containing
`Vec`s (or `[]`s) since one can store `slice::Items`s in the iterator,
initialising it to `Items::empty()` and thus avoiding the need for
duplicated code between the initialiser and the `next` method, and
avoiding duplicated checks from storing `Option<slice::Items<...>>`
instead.
