### PR TITLE
debuginfo: Add a "no_debug" attribute that allows to exclude functions from debuginfo generation.

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -578,6 +578,7 @@ impl LintPass for UnusedAttribute {
             "packed",
             "static_assert",
             "thread_local",
+            "no_debug",
 
             // not used anywhere (!?) but apparently we want to keep them around
             "comment",

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -1,0 +1,45 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-android: FIXME(#10381)
+// ignore-lldb
+
+// compile-flags:-g
+
+// gdb-command:break 'no-debug-attribute.rs':32
+// gdb-command:break 'no-debug-attribute.rs':38
+// gdb-command:run
+
+// gdb-command:info locals
+// gdb-check:No locals.
+// gdb-command:continue
+
+// gdb-command:info locals
+// gdb-check:abc = 10
+// gdb-command:continue
+
+#![allow(unused_variable)]
+
+fn function_with_debuginfo() {
+    let abc = 10u;
+    return (); // #break
+}
+
+#[no_debug]
+fn function_without_debuginfo() {
+    let abc = -57i32;
+    return (); // #break
+}
+
+fn main() {
+    function_without_debuginfo();
+    function_with_debuginfo();
+}
+


### PR DESCRIPTION
Fixes #15332.
