### PR TITLE
Improved code generation for `char`s UTF-8/UTF-16 encoding methods

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1680,7 +1680,7 @@ mod tests {
     fn test_chars_decoding() {
         let mut bytes = [0u8, ..4];
         for c in range(0u32, 0x110000).filter_map(|c| ::core::char::from_u32(c)) {
-            let len = c.encode_utf8(bytes);
+            let len = c.encode_utf8(bytes).unwrap_or(0);
             let s = ::core::str::from_utf8(bytes.slice_to(len)).unwrap();
             if Some(c) != s.chars().next() {
                 fail!("character {:x}={} does not decode correctly", c as u32, c);
@@ -1692,7 +1692,7 @@ mod tests {
     fn test_chars_rev_decoding() {
         let mut bytes = [0u8, ..4];
         for c in range(0u32, 0x110000).filter_map(|c| ::core::char::from_u32(c)) {
-            let len = c.encode_utf8(bytes);
+            let len = c.encode_utf8(bytes).unwrap_or(0);
             let s = ::core::str::from_utf8(bytes.slice_to(len)).unwrap();
             if Some(c) != s.chars().rev().next() {
                 fail!("character {:x}={} does not decode correctly", c as u32, c);

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -503,7 +503,7 @@ impl String {
                 data: self.vec.as_ptr().offset(cur_len as int),
                 len: 4,
             };
-            let used = ch.encode_utf8(mem::transmute(slice));
+            let used = ch.encode_utf8(mem::transmute(slice)).unwrap_or(0);
             self.vec.set_len(cur_len + used);
         }
     }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -364,7 +364,7 @@ impl<'a> Formatter<'a> {
         let write_prefix = |f: &mut Formatter| {
             for c in sign.move_iter() {
                 let mut b = [0, ..4];
-                let n = c.encode_utf8(b);
+                let n = c.encode_utf8(b).unwrap_or(0);
                 try!(f.buf.write(b.slice_to(n)));
             }
             if prefixed { f.buf.write(prefix.as_bytes()) }
@@ -464,7 +464,7 @@ impl<'a> Formatter<'a> {
             try!(f(self));
         }
         let mut fill = [0u8, ..4];
-        let len = self.fill.encode_utf8(fill);
+        let len = self.fill.encode_utf8(fill).unwrap_or(0);
         for _ in range(0, padding) {
             try!(self.buf.write(fill.slice_to(len)));
         }
@@ -540,7 +540,7 @@ impl<'a, T: str::Str> String for T {
 impl Char for char {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let mut utf8 = [0u8, ..4];
-        let amt = self.encode_utf8(utf8);
+        let amt = self.encode_utf8(utf8).unwrap_or(0);
         let s: &str = unsafe { mem::transmute(utf8.slice_to(amt)) };
         secret_string(&s, f)
     }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -30,7 +30,7 @@ use iter::range;
 use num::{CheckedMul, Saturating};
 use option::{Option, None, Some};
 use raw::Repr;
-use slice::ImmutableSlice;
+use slice::{ImmutableSlice, MutableSlice};
 use slice;
 use uint;
 
@@ -646,7 +646,7 @@ impl<'a> Iterator<u16> for Utf16CodeUnits<'a> {
 
         let mut buf = [0u16, ..2];
         self.chars.next().map(|ch| {
-            let n = ch.encode_utf16(buf /* as mut slice! */);
+            let n = ch.encode_utf16(buf.as_mut_slice()).unwrap_or(0);
             if n == 2 { self.extra = buf[1]; }
             buf[0]
         })

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -173,7 +173,7 @@ fn test_escape_unicode() {
 fn test_encode_utf8() {
     fn check(input: char, expect: &[u8]) {
         let mut buf = [0u8, ..4];
-        let n = input.encode_utf8(buf /* as mut slice! */);
+        let n = input.encode_utf8(buf.as_mut_slice()).unwrap_or(0);
         assert_eq!(buf.slice_to(n), expect);
     }
 
@@ -187,7 +187,7 @@ fn test_encode_utf8() {
 fn test_encode_utf16() {
     fn check(input: char, expect: &[u16]) {
         let mut buf = [0u16, ..2];
-        let n = input.encode_utf16(buf /* as mut slice! */);
+        let n = input.encode_utf16(buf.as_mut_slice()).unwrap_or(0);
         assert_eq!(buf.slice_to(n), expect);
     }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1110,7 +1110,7 @@ pub trait Writer {
     #[inline]
     fn write_char(&mut self, c: char) -> IoResult<()> {
         let mut buf = [0u8, ..4];
-        let n = c.encode_utf8(buf.as_mut_slice());
+        let n = c.encode_utf8(buf.as_mut_slice()).unwrap_or(0);
         self.write(buf.slice_to(n))
     }
 


### PR DESCRIPTION
The first commit improves code generation through a few changes:
- The `#[inline]` attributes allow llvm to constant fold the encoding step away in certain situations. For example, code like this changes from a call to `encode_utf8` in a inner loop to the pushing of a byte constant:
  
  ``` rust
  let mut s = String::new();
  for _ in range(0u, 21) {
      s.push_char('a');
  }
  ```
- Both methods changed their semantic from causing run time failure if the target buffer is not large enough to returning `None` instead. This makes llvm no longer emit code for causing failure for these methods.
- A few debug `assert!()` calls got removed because they affected code generation due to unwinding, and where basically unnecessary with today's sound handling of `char` as a Unicode scalar value.

~~The second commit is optional. It changes the methods from regular indexing with the `dst[i]` syntax to unsafe indexing with `dst.unsafe_mut_ref(i)`. This does not change code generation directly - in both cases llvm is smart enough to see that there can never be an out-of-bounds access. But it makes it emit a `nounwind` attribute for the function. 
However, I'm not sure whether that is a real improvement, so if there is any objection to this I'll remove the commit.~~

This changes how the methods behave on a too small buffer, so this is a 

[breaking-change]
