### PR TITLE
vim: Don't set foldmethod in the syntax file either

### DIFF
--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -56,6 +56,16 @@ if exists("g:loaded_delimitMate")
 	let b:delimitMate_excluded_regions = delimitMate#Get("excluded_regions") . ',rustLifetimeCandidate,rustGenericLifetimeCandidate'
 endif
 
+if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
+	let b:rust_set_foldmethod=1
+	setlocal foldmethod=syntax
+	if g:rust_fold == 2
+		setlocal foldlevel<
+	else
+		setlocal foldlevel=99
+	endif
+endif
+
 if has('conceal') && exists('g:rust_conceal')
 	let b:rust_set_conceallevel=1
 	setlocal conceallevel=2
@@ -107,6 +117,10 @@ let b:undo_ftplugin = "
 		  \|unlet b:rust_original_delimitMate_excluded_regions
 		\|else
 		  \|unlet! b:delimitMate_excluded_regions
+		\|endif
+		\|if exists('b:rust_set_foldmethod')
+		  \|setlocal foldmethod< foldlevel<
+		  \|unlet b:rust_set_foldmethod
 		\|endif
 		\|if exists('b:rust_set_conceallevel')
 		  \|setlocal conceallevel<

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -11,17 +11,6 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-" Fold settings {{{1
-
-if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
-  setlocal foldmethod=syntax
-  if g:rust_fold == 2
-    setlocal foldlevel<
-  else
-    setlocal foldlevel=99
-  endif
-endif
-
 " Syntax definitions {{{1
 " Basic keywords {{{2
 syn keyword   rustConditional match if else


### PR DESCRIPTION
We shouldn't be setting any settings in the syntax file. Better to put
them in the ftplugin, where they won't be pulled in by :syn-include and
can be cleaned up when changing the filetype.
