### PR TITLE
enable DEP (NX bit) for 32-bit Windows executables

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1472,6 +1472,9 @@ fn link_args(cmd: &mut Command,
         // [1] - https://sourceware.org/bugzilla/show_bug.cgi?id=13130
         // [2] - https://code.google.com/p/go/issues/detail?id=2139
         cmd.arg("-Wl,--enable-long-section-names");
+
+        // Always enable DEP (NX bit) when it is available
+        cmd.arg("-Wl,--nxcompat");
     }
 
     if sess.targ_cfg.os == abi::OsAndroid {


### PR DESCRIPTION
This is already enabled by default for x86_64 executables on Windows,
but it needs to be manually enabled on x86.

Closes #16533
