### PR TITLE
Add 'where' as a keyword in vim syntax file

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -27,6 +27,7 @@ syn keyword   rustKeyword     for in if impl let
 syn keyword   rustKeyword     loop once proc pub
 syn keyword   rustKeyword     return super
 syn keyword   rustKeyword     unsafe virtual while
+syn keyword   rustKeyword     where
 syn keyword   rustKeyword     use nextgroup=rustModPath,rustModPathInUse skipwhite skipempty
 " FIXME: Scoped impl's name is also fallen in this category
 syn keyword   rustKeyword     mod trait struct enum type nextgroup=rustIdentifier skipwhite skipempty


### PR DESCRIPTION
This seems to work for me, but I don't actually know what I'm doing, so if someone who does know what they're doing wants to make this change instead I will close this PR.
