### PR TITLE
collections: deprecate BTree.

### DIFF
--- a/src/libcollections/btree.rs
+++ b/src/libcollections/btree.rs
@@ -11,6 +11,13 @@
 // btree.rs
 //
 
+// NB. this is not deprecated for removal, just deprecating the
+// current implementation. If the major pain-points are addressed
+// (overuse of by-value self and .clone), this can be removed.
+#![deprecated = "the current implementation is extremely inefficient, \
+                 prefer a HashMap, TreeMap or TrieMap"]
+#![allow(deprecated)]
+
 //! Starting implementation of a btree for rust.
 //! Structure inspired by github user davidhalperin's gist.
 


### PR DESCRIPTION
This is very half-baked at the moment and very inefficient, e.g.
inappropriate use of by-value `self` (and thus being forced into an
overuse of `clone`). People get the wrong impression about Rust when
using it, e.g. that Rust cannot express what other languages can because
the implementation is inefficient: https://news.ycombinator.com/item?id=8187831 .
