### PR TITLE
Add the `formatter_len_hint` method to Show and use it in `to_string`

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -17,7 +17,7 @@ use core::default::Default;
 use core::fmt;
 use core::intrinsics;
 use core::mem;
-use core::option::Option;
+use core::option::{Option, Some};
 use core::raw::TraitObject;
 use core::result::{Ok, Err, Result};
 
@@ -130,11 +130,21 @@ impl<T: fmt::Show> fmt::Show for Box<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (**self).fmt(f)
     }
+
+    #[inline]
+    fn formatter_len_hint(&self) -> Option<uint> {
+        (**self).formatter_len_hint()
+    }
 }
 
 impl fmt::Show for Box<Any+'static> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("Box<Any>")
+    }
+
+    #[inline]
+    fn formatter_len_hint(&self) -> Option<uint> {
+        Some(8)
     }
 }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -899,6 +899,11 @@ impl fmt::Show for String {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_slice().fmt(f)
     }
+
+    #[inline]
+    fn formatter_len_hint(&self) -> Option<uint> {
+        self.as_slice().formatter_len_hint()
+    }
 }
 
 #[experimental = "waiting on Hash stabilization"]

--- a/src/libcoretest/fmt/mod.rs
+++ b/src/libcoretest/fmt/mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::fmt::Show;
+
 mod num;
 
 #[test]
@@ -15,4 +17,36 @@ fn test_format_flags() {
     // No residual flags left by pointer formatting
     let p = "".as_ptr();
     assert_eq!(format!("{:p} {:x}", p, 16u), format!("{:p} 10", p));
+}
+
+#[test]
+fn test_len_hints_float() {
+    let mut f = 5.0f32;
+    for _ in range(0u, 30) {
+        let s = format!("{}", f);
+        let len = f.formatter_len_hint().unwrap();
+        assert!(len >= s.len());
+        assert!(len <= 128);
+        f /= 10.0;
+    }
+    let mut f = 5.0f32;
+    for _ in range(0u, 30) {
+        let s = format!("{}", f);
+        let len = f.formatter_len_hint().unwrap();
+        assert!(len >= s.len());
+        assert!(len <= 128);
+        f *= 10.0;
+    }
+}
+
+#[test]
+fn test_len_hints_u64() {
+    let mut f = 1u64;
+    for _ in range(0u, 20) {
+        let s = format!("{}", f);
+        let len = f.formatter_len_hint().unwrap();
+        assert!(len >= s.len());
+        assert!(len <= 128);
+        f *= 10;
+    }
 }

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -315,6 +315,11 @@ impl fmt::Show for CString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         String::from_utf8_lossy(self.as_bytes_no_nul()).fmt(f)
     }
+
+    #[inline]
+    fn formatter_len_hint(&self) -> Option<uint> {
+        Some(self.len())
+    }
 }
 
 /// A generic trait for converting a value to a CString.

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -182,6 +182,10 @@ impl<'a> fmt::Show for Ascii {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         (self.chr as char).fmt(f)
     }
+
+    fn formatter_len_hint(&self) -> Option<uint> {
+        Some(1)
+    }
 }
 
 /// Trait for converting into an ascii type.

--- a/src/libstd/to_string.rs
+++ b/src/libstd/to_string.rs
@@ -16,6 +16,8 @@ The `ToString` trait for converting to strings
 
 #![experimental]
 
+use io::Writer;
+use io;
 use fmt;
 use string::String;
 
@@ -33,7 +35,9 @@ pub trait IntoStr {
 
 impl<T: fmt::Show> ToString for T {
     fn to_string(&self) -> String {
-        format!("{}", *self)
+        let mut output = io::MemWriter::with_capacity(self.formatter_len_hint().unwrap_or(128));
+        let _ = write!(&mut output, "{}", *self);
+        String::from_utf8(output.unwrap()).unwrap()
     }
 }
 


### PR DESCRIPTION
I'm trying to balance potential code bloat and precision of the upper bound.
- Can `size_hint` default to 0 instead of None?
- How costly is occasional inaccuracy of the upper bound?
- How to implement `size_hint` for floats? I've yet to think about it.
- Is `size_hint` also that useful for the general case of `format!`, as implemented in this PR, not only `to_string`?

~~UFCS would make this addition prettier.~~
## Examples

``` rust
18446744073709551615u64.to_string().byte_capacity() // => 32
123u.to_string().byte_capacity() // => 3
12.34f32.to_string().byte_capacity() // => 9
"foobar".to_string().byte_capacity() // => 6
```

Fixes #16415
