### PR TITLE
Look for crates in LIBDIR, provided by --libdir option

### DIFF
--- a/configure
+++ b/configure
@@ -550,9 +550,19 @@ CFG_LIBDIR_RELATIVE=lib
 if [ "$CFG_OSTYPE" = "pc-windows-gnu" ]
 then
     CFG_LIBDIR_RELATIVE=bin
-fi
+    CFG_LIBDIR="${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}"
+else
+    valopt libdir "${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries (ignored on windows platform)"
 
-valopt libdir "${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries"
+    case "$CFG_LIBDIR" in
+	"$CFG_PREFIX"/*) CAT_INC=2;;
+	"$CFG_PREFIX"*)  CAT_INC=1;;
+	*)
+            err "libdir must begin with the prefix. Use --prefix to set it accordingly.";;
+    esac
+
+    CFG_LIBDIR_RELATIVE=`echo ${CFG_LIBDIR} | cut -c$((${#CFG_PREFIX}+${CAT_INC}))-`
+fi
 
 if [ $HELP -eq 1 ]
 then
@@ -989,6 +999,15 @@ for h in $CFG_HOST
 do
     for t in $CFG_TARGET
     do
+        # host lib dir stage0
+        make_dir $h/stage0/lib
+
+        # target bin dir stage0
+        make_dir $h/stage0/lib/rustlib/$t/bin
+
+        # target lib dir stage0
+        make_dir $h/stage0/lib/rustlib/$t/lib
+
         for i in 0 1 2 3
         do
             # host bin dir

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -332,7 +332,15 @@ define SREQ
 # Destinations of artifacts for the host compiler
 HROOT$(1)_H_$(3) = $(3)/stage$(1)
 HBIN$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/bin
+ifeq ($$(CFG_WINDOWSY_$(3)),1)
 HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)
+else
+ifeq ($(1),0)
+HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/lib
+else
+HLIB$(1)_H_$(3) = $$(HROOT$(1)_H_$(3))/$$(CFG_LIBDIR_RELATIVE)
+endif
+endif
 
 # Destinations of artifacts for target architectures
 TROOT$(1)_T_$(2)_H_$(3) = $$(HLIB$(1)_H_$(3))/rustlib/$(2)

--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -301,9 +301,16 @@ fi
 flag uninstall "only uninstall from the installation prefix"
 opt verify 1 "verify that the installed binaries run correctly"
 valopt prefix "/usr/local" "set installation prefix"
-# NB This isn't quite the same definition as in `configure`.
-# just using 'lib' instead of CFG_LIBDIR_RELATIVE
+# NB This is exactly the same definition as in `configure`.
 valopt libdir "${CFG_PREFIX}/${CFG_LIBDIR_RELATIVE}" "install libraries"
+case "$CFG_LIBDIR" in
+    "$CFG_PREFIX"/*) CAT_INC=2;;
+    "$CFG_PREFIX"*)  CAT_INC=1;;
+    *)
+        err "libdir must begin with the prefix. Use --prefix to set it accordingly.";;
+esac
+CFG_LIBDIR_RELATIVE=`echo ${CFG_LIBDIR} | cut -c$((${#CFG_PREFIX}+${CAT_INC}))-`
+
 valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 
 if [ $HELP -eq 1 ]
@@ -428,9 +435,9 @@ while read p; do
     # Decide the destination of the file
     FILE_INSTALL_PATH="${CFG_PREFIX}/$p"
 
-    if echo "$p" | grep "^lib/" > /dev/null
+    if echo "$p" | grep "^${CFG_LIBDIR_RELATIVE}/" > /dev/null
     then
-        pp=`echo $p | sed 's/^lib\///'`
+        pp=`echo $p | sed "s%^${CFG_LIBDIR_RELATIVE}/%%"`
         FILE_INSTALL_PATH="${CFG_LIBDIR}/$pp"
     fi
 

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -255,11 +255,16 @@ fn find_libdir(sysroot: &Path) -> String {
     // to lib64/lib32. This would be more foolproof by basing the sysroot off
     // of the directory where librustc is located, rather than where the rustc
     // binary is.
+    //If --libdir is set during configuration to the value other than
+    // "lib" (i.e. non-default), this value is used (see issue #16552).
 
-    if sysroot.join(primary_libdir_name()).join(rustlibdir()).exists() {
-        return primary_libdir_name();
-    } else {
-        return secondary_libdir_name();
+    match option_env!("CFG_LIBDIR_RELATIVE") {
+        Some(libdir) if libdir != "lib" => return libdir.to_string(),
+        _ => if sysroot.join(primary_libdir_name()).join(rustlibdir()).exists() {
+            return primary_libdir_name();
+        } else {
+            return secondary_libdir_name();
+        }
     }
 
     #[cfg(target_word_size = "64")]


### PR DESCRIPTION
Fixies #11671

This commit changes default relative libdir 'lib' to a relative libdir calculated using LIBDIR provided by --libdir configuration option. In case if no option was provided behavior does not change.
