### PR TITLE
Add resort to slice/vec

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -357,7 +357,6 @@ impl<'a,T:Clone> ImmutableCloneableVector<T> for &'a [T] {
 fn insertion_sort<T>(v: &mut [T], compare: |&T, &T| -> Ordering) {
     let len = v.len() as int;
     let buf_v = v.as_mut_ptr();
-
     // 1 <= i < len;
     for i in range(1, len) {
         // j satisfies: 0 <= j <= i;
@@ -579,6 +578,20 @@ pub trait MutableSliceAllocating<'a, T> {
     /// ```
     fn sort_by(self, compare: |&T, &T| -> Ordering);
 
+    /// Sort the vector, in place, using `compare` to compare the elements,
+    /// assuming that the vector is already mostly sorted, in terms of number
+    /// of inversions.
+    ///
+    /// This sort is stable, and takes `O(n + i)` time,
+    /// where `i` is the number of element inversions.
+    /// As a consequence, this method is generally only appropriate for data
+    /// that is known to be almost completely sorted.
+    /// In the worst case (a reverse ordered list) this is <code>O(n<sup>2</sup>)</code>.
+    /// Further, <code>O(n<sup>2</sup>)</code> is also expected for a random permutation.
+    /// However, for highly sorted inputs, this can be as low as `O(n)`, in contrast to `sort`,
+    /// which always takes `O(n log n)`.
+    fn resort_by(self, compare: |&T, &T| -> Ordering);
+
     /**
      * Consumes `src` and moves as many elements as it can into `self`
      * from the range [start,end).
@@ -612,6 +625,11 @@ impl<'a,T> MutableSliceAllocating<'a, T> for &'a mut [T] {
     }
 
     #[inline]
+    fn resort_by(self, compare: |&T, &T| -> Ordering) {
+        insertion_sort(self, compare)
+    }
+
+    #[inline]
     fn move_from(self, mut src: Vec<T>, start: uint, end: uint) -> uint {
         for (a, b) in self.mut_iter().zip(src.mut_slice(start, end).mut_iter()) {
             mem::swap(a, b);
@@ -636,6 +654,10 @@ pub trait MutableOrdSlice<T> {
     /// assert!(v == [-5i, -3, 1, 2, 4]);
     /// ```
     fn sort(self);
+
+    /// Sort the vector, in place, assuming that the vector is already mostly sorted,
+    /// in terms of number of inversions.
+    fn resort(self);
 
     /// Mutates the slice to the next lexicographic permutation.
     ///
@@ -672,6 +694,11 @@ impl<'a, T: Ord> MutableOrdSlice<T> for &'a mut [T] {
     #[inline]
     fn sort(self) {
         self.sort_by(|a,b| a.cmp(b))
+    }
+
+    #[inline]
+    fn resort(self) {
+        self.resort_by(|a,b| a.cmp(b))
     }
 
     fn next_permutation(self) -> bool {
@@ -2422,6 +2449,87 @@ mod bench {
         let mut v = Vec::from_fn(10000u, |i| (i, i, i, i));
         b.iter(|| {
             v.sort();
+        });
+        b.bytes = (v.len() * mem::size_of_val(v.get(0))) as u64;
+    }
+
+    #[bench]
+    fn resort_random_small(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            let mut v = rng.gen_iter::<u64>().take(5).collect::<Vec<u64>>();
+            v.as_mut_slice().resort();
+        });
+        b.bytes = 5 * mem::size_of::<u64>() as u64;
+    }
+
+    #[bench]
+    fn resort_random_medium(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            let mut v = rng.gen_iter::<u64>().take(100).collect::<Vec<u64>>();
+            v.as_mut_slice().resort();
+        });
+        b.bytes = 100 * mem::size_of::<u64>() as u64;
+    }
+
+    #[bench]
+    fn resort_random_large(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            let mut v = rng.gen_iter::<u64>().take(10000).collect::<Vec<u64>>();
+            v.as_mut_slice().resort();
+        });
+        b.bytes = 10000 * mem::size_of::<u64>() as u64;
+    }
+
+    #[bench]
+    fn resort_sorted(b: &mut Bencher) {
+        let mut v = Vec::from_fn(10000, |i| i);
+        b.iter(|| {
+            v.resort();
+        });
+        b.bytes = (v.len() * mem::size_of_val(v.get(0))) as u64;
+    }
+
+    #[bench]
+    fn resort_big_random_small(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            let mut v = rng.gen_iter::<BigSortable>().take(5)
+                           .collect::<Vec<BigSortable>>();
+            v.resort();
+        });
+        b.bytes = 5 * mem::size_of::<BigSortable>() as u64;
+    }
+
+    #[bench]
+    fn resort_big_random_medium(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            let mut v = rng.gen_iter::<BigSortable>().take(100)
+                           .collect::<Vec<BigSortable>>();
+            v.resort();
+        });
+        b.bytes = 100 * mem::size_of::<BigSortable>() as u64;
+    }
+
+    #[bench]
+    fn resort_big_random_large(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            let mut v = rng.gen_iter::<BigSortable>().take(10000)
+                           .collect::<Vec<BigSortable>>();
+            v.resort();
+        });
+        b.bytes = 10000 * mem::size_of::<BigSortable>() as u64;
+    }
+
+    #[bench]
+    fn resort_big_sorted(b: &mut Bencher) {
+        let mut v = Vec::from_fn(10000u, |i| (i, i, i, i));
+        b.iter(|| {
+            v.resort();
         });
         b.bytes = (v.len() * mem::size_of_val(v.get(0))) as u64;
     }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -864,6 +864,23 @@ impl<T> Vec<T> {
         self.as_mut_slice().sort_by(compare)
     }
 
+    /// Sort the vector, in place, using `compare` to compare the elements,
+    /// assuming that the vector is already mostly sorted, in terms of number
+    /// of inversions.
+    ///
+    /// This sort is stable, and takes `O(n + i)` time,
+    /// where `i` is the number of element inversions.
+    /// As a consequence, this method is generally only appropriate for data
+    /// that is known to be almost completely sorted.
+    /// In the worst case (a reverse ordered list) this is <code>O(n<sup>2</sup>)</code>.
+    /// Further, <code>O(n<sup>2</sup>)</code> is also expected for a random permutation.
+    /// However, for highly sorted inputs, this can be as low as `O(n)`, in contrast to `sort`,
+    /// which always takes `O(n log n)`.
+    #[inline]
+    pub fn resort_by(&mut self, compare: |&T, &T| -> Ordering) {
+        self.as_mut_slice().resort_by(compare)
+    }
+
     /// Returns a slice of self spanning the interval [`start`, `end`).
     ///
     /// # Failure
@@ -1384,6 +1401,22 @@ impl<T:Ord> Vec<T> {
     /// ```
     pub fn sort(&mut self) {
         self.as_mut_slice().sort()
+    }
+
+    /// Sort the vector in place,
+    /// assuming that the vector is already mostly sorted, in terms of number
+    /// of inversions.
+    ///
+    /// This sort is stable, and takes `O(n + i)` time,
+    /// where `i` is the number of element inversions.
+    /// As a consequence, this method is generally only appropriate for data
+    /// that is known to be almost completely sorted.
+    /// In the worst case (a reverse ordered list) this is <code>O(n<sup>2</sup>)</code>.
+    /// Further, <code>O(n<sup>2</sup>)</code> is also expected for a random permutation.
+    /// However, for highly sorted inputs, this can be as low as `O(n)`, in contrast to `sort`,
+    /// which always takes `O(n log n)`.
+    pub fn resort(&mut self) {
+        self.as_mut_slice().resort()
     }
 }
 


### PR DESCRIPTION
We have a perfectly good implementation of insertion sort available, but don't expose it publicly. It's a _great_ sorting algorithm if the data in known to be mostly sorted (e.g. it was already sorted, and we've only touched a few elements).

I think the benchmarks speak for themselves. On sorted data it completely _destroys_ `sort` (because it just reads the damn thing and calls it a day). Benchmark results are from `make check-collections PLEASE_BENCH=1 NO_REBUILD=1`, Can rebuild with different flags if desired:

```
test slice::bench::resort_big_sorted                       ... bench:     54309 ns/iter (+/- 4181) = 5892 MB/s
test slice::bench::resort_sorted                           ... bench:     43509 ns/iter (+/- 376) = 1838 MB/s

test slice::bench::sort_big_sorted                         ... bench:   1721006 ns/iter (+/- 366156) = 185 MB/s
test slice::bench::sort_random_large                       ... bench:   2506750 ns/iter (+/- 115227) = 31 MB/s
```

Other ops: (note: resort is actually competitive on random data up to 100 elements!)

```
test slice::bench::resort_big_random_large                 ... bench: 115285904 ns/iter (+/- 2612076) = 2 MB/s
test slice::bench::resort_big_random_medium                ... bench:     15938 ns/iter (+/- 478) = 200 MB/s
test slice::bench::resort_big_random_small                 ... bench:       445 ns/iter (+/- 20) = 359 MB/s
test slice::bench::resort_random_large                     ... bench:  44449508 ns/iter (+/- 747584) = 1 MB/s
test slice::bench::resort_random_medium                    ... bench:      9628 ns/iter (+/- 119) = 83 MB/s
test slice::bench::resort_random_small                     ... bench:       285 ns/iter (+/- 5) = 140 MB/s

test slice::bench::sort_big_random_large                   ... bench:   4066801 ns/iter (+/- 535054) = 78 MB/s
test slice::bench::sort_big_random_medium                  ... bench:     15441 ns/iter (+/- 549) = 207 MB/s
test slice::bench::sort_big_random_small                   ... bench:       484 ns/iter (+/- 7) = 330 MB/s
test slice::bench::sort_random_medium                      ... bench:     13135 ns/iter (+/- 574) = 60 MB/s
test slice::bench::sort_random_small                       ... bench:       346 ns/iter (+/- 15) = 115 MB/s
test slice::bench::sort_sorted                             ... bench:    726430 ns/iter (+/- 52568) = 110 MB/s
```

I didn't write any new benches to test e.g. "a couple elements are out of order". I can if it's desired. I also didn't add any unit tests since `resort` is implicitly tested by `sort`, for the most part.
