### PR TITLE
Make BigUint and BigInt Hash, fixes #16551

### DIFF
--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -43,6 +43,7 @@
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
 
 #![feature(macro_rules)]
+#![feature(default_type_params)]
 
 #![crate_name = "num"]
 #![experimental]


### PR DESCRIPTION
Pretty self-explanatory. Only annoying thing is that it _seems_ that I had to add `#![feature(default_type_params)]` to libnum because of Hasher. Don't know if there's a way around that.

Fix #16551
