### PR TITLE
mark Windows binaries as compatible with ASLR

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1475,6 +1475,9 @@ fn link_args(cmd: &mut Command,
 
         // Always enable DEP (NX bit) when it is available
         cmd.arg("-Wl,--nxcompat");
+
+        // Mark all dynamic libraries and executables as compatible with ASLR
+        cmd.arg("-Wl,--dynamicbase");
     }
 
     if sess.targ_cfg.os == abi::OsAndroid {


### PR DESCRIPTION
This is enough for dynamic libraries, but not executables because MinGW
does not output a .reloc section even with `--dynamicbase`. It could
either be worked around by exporting a DLL symbol from the executable or
fixed in MinGW itself.
