### PR TITLE
Fix underflow in core::str::Searcher::new

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -562,7 +562,7 @@ enum Searcher {
 impl Searcher {
     fn new(haystack: &[u8], needle: &[u8]) -> Searcher {
         // FIXME: Tune this.
-        if needle.len() > haystack.len() - 20 {
+        if needle.len() + 20 > haystack.len() {
             Naive(NaiveSearcher::new())
         } else {
             let searcher = TwoWaySearcher::new(needle);

--- a/src/libcoretest/str.rs
+++ b/src/libcoretest/str.rs
@@ -7,27 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs, unsafe_destructor, macro_rules)]
 
-extern crate core;
-extern crate test;
-extern crate libc;
-
-mod any;
-mod atomic;
-mod cell;
-mod char;
-mod cmp;
-mod finally;
-mod fmt;
-mod iter;
-mod mem;
-mod num;
-mod ops;
-mod option;
-mod ptr;
-mod raw;
-mod result;
-mod slice;
-mod str;
-mod tuple;
+#[test]
+fn strslice_issue_16589() {
+    assert!("bananas".contains("nana"));
+}


### PR DESCRIPTION
This incidentally fixes #16589, because it will cause `MatchIndices` to use `NaiveSearcher` instead of `TwoWaySearcher`, but I'm not sure #16589 should be closed until the underlying problem in `TwoWaySearcher` is found.
