### PR TITLE
Include import name in import shadowing error messages.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2820,9 +2820,10 @@ impl<'a> Resolver<'a> {
                  .contains_key(&name) {
             match import_resolution.type_target {
                 Some(ref target) if !target.shadowable => {
-                    self.session.span_err(import_span,
-                                          "import conflicts with imported \
-                                           crate in this module");
+                    let msg = format!("import `{}` conflicts with imported \
+                                       crate in this module",
+                                      token::get_name(name).get());
+                    self.session.span_err(import_span, msg.as_slice());
                 }
                 Some(_) | None => {}
             }
@@ -2843,9 +2844,10 @@ impl<'a> Resolver<'a> {
                 match *name_bindings.value_def.borrow() {
                     None => {}
                     Some(ref value) => {
-                        self.session.span_err(import_span,
-                                              "import conflicts with value \
-                                               in this module");
+                        let msg = format!("import `{}` conflicts with value \
+                                           in this module",
+                                          token::get_name(name).get());
+                        self.session.span_err(import_span, msg.as_slice());
                         match value.value_span {
                             None => {}
                             Some(span) => {
@@ -2865,9 +2867,10 @@ impl<'a> Resolver<'a> {
                 match *name_bindings.type_def.borrow() {
                     None => {}
                     Some(ref ty) => {
-                        self.session.span_err(import_span,
-                                              "import conflicts with type in \
-                                               this module");
+                        let msg = format!("import `{}` conflicts with type in \
+                                           this module",
+                                          token::get_name(name).get());
+                        self.session.span_err(import_span, msg.as_slice());
                         match ty.type_span {
                             None => {}
                             Some(span) => {

--- a/src/test/compile-fail/resolve-conflict-import-vs-extern-crate.rs
+++ b/src/test/compile-fail/resolve-conflict-import-vs-extern-crate.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::slice as std; //~ ERROR import conflicts with imported crate
+use std::slice as std; //~ ERROR import `std` conflicts with imported crate
 
 fn main() {
 }

--- a/src/test/compile-fail/resolve-conflict-item-vs-import.rs
+++ b/src/test/compile-fail/resolve-conflict-item-vs-import.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::mem::transmute;
-//~^ ERROR import conflicts with value in this module
+//~^ ERROR import `transmute` conflicts with value in this module
 
 fn transmute() {}
 

--- a/src/test/compile-fail/resolve-conflict-type-vs-import.rs
+++ b/src/test/compile-fail/resolve-conflict-type-vs-import.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::slice::Items;
+//~^ ERROR import `Items` conflicts with type in this module
+
+struct Items;
+
+fn main() {
+}
+


### PR DESCRIPTION
This partially alleviates the confusing behavior in issue #16597
