### PR TITLE
Rename Nullable::Some to Nullable::NotNull

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -304,7 +304,7 @@ extern {}
 // If/when libprim happens, this can be removed in favor of that
 pub enum Nullable<T> {
     Null,
-    Some(T)
+    NotNull(T)
 }
 
 pub mod types {


### PR DESCRIPTION
A few reasons:
- `Nullable` is basically unused, save for one argument in the `glob` function in `liblibc`, so this change likely impacts nobody negatively. The constructors are never used, and I don't foresee people using them. The people implementing the glob functionality don't seem to be reaching for this POSIX `glob` function, so it seems unlikely to be used heavily.
- At the same time, the old name, `Some`, needlessly conflicted with the same re-exported name in the prelude, which impacted everybody who use glob imports with `libc`. Changing it to something else would simplify things greatly for those people.
- `NotNull` seemed like the best option (others included `Just`, `Valid`, etc. which all had somewhat different connotations than what this type was going for (even `Some` doesn't quite seem like the opposite of `Null`)). Other options included removing the type completely and adding a special, `glob`-specific type. This latter approach doesn't seem future-proof.

Overall, I feel like this is a mildly positive change.
