### PR TITLE
Fix double evaluation of read+write operands in inline assembly

### DIFF
--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -473,14 +473,15 @@ impl<'a> CFGBuilder<'a> {
             ast::ExprInlineAsm(ref inline_asm) => {
                 let inputs = inline_asm.inputs.iter();
                 let outputs = inline_asm.outputs.iter();
-                fn extract_expr<A>(&(_, expr): &(A, Gc<ast::Expr>)) -> Gc<ast::Expr> { expr }
                 let post_inputs = self.exprs(inputs.map(|a| {
                     debug!("cfg::construct InlineAsm id:{} input:{:?}", expr.id, a);
-                    extract_expr(a)
+                    let &(_, expr) = a;
+                    expr
                 }), pred);
                 let post_outputs = self.exprs(outputs.map(|a| {
                     debug!("cfg::construct InlineAsm id:{} output:{:?}", expr.id, a);
-                    extract_expr(a)
+                    let &(_, expr, _) = a;
+                    expr
                 }), post_inputs);
                 self.add_node(expr.id, [post_outputs])
             }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -380,8 +380,9 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                     self.consume_expr(&**input);
                 }
 
-                for &(_, ref output) in ia.outputs.iter() {
-                    self.mutate_expr(expr, &**output, JustWrite);
+                for &(_, ref output, is_rw) in ia.outputs.iter() {
+                    self.mutate_expr(expr, &**output,
+                                           if is_rw { WriteAndRead } else { JustWrite });
                 }
             }
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1192,9 +1192,10 @@ impl<'a> Liveness<'a> {
           }
 
           ExprInlineAsm(ref ia) => {
-            let succ = ia.outputs.iter().rev().fold(succ, |succ, &(_, ref expr)| {
-                // see comment on lvalues in
-                // propagate_through_lvalue_components()
+
+            let succ = ia.outputs.iter().rev().fold(succ, |succ, &(_, ref expr, _)| {
+                // see comment on lvalues
+                // in propagate_through_lvalue_components()
                 let succ = self.write_lvalue(&**expr, succ, ACC_WRITE);
                 self.propagate_through_lvalue_components(&**expr, succ)
             });
@@ -1437,7 +1438,7 @@ fn check_expr(this: &mut Liveness, expr: &Expr) {
         }
 
         // Output operands must be lvalues
-        for &(_, ref out) in ia.outputs.iter() {
+        for &(_, ref out, _) in ia.outputs.iter() {
           this.check_lvalue(&**out);
           this.visit_expr(&**out, ());
         }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -3729,7 +3729,7 @@ fn populate_scope_map(cx: &CrateContext,
                     walk_expr(cx, &**exp, scope_stack, scope_map);
                 }
 
-                for &(_, ref exp) in outputs.iter() {
+                for &(_, ref exp, _) in outputs.iter() {
                     walk_expr(cx, &**exp, scope_stack, scope_map);
                 }
             }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3332,7 +3332,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
           for &(_, ref input) in ia.inputs.iter() {
               check_expr(fcx, &**input);
           }
-          for &(_, ref out) in ia.outputs.iter() {
+          for &(_, ref out, _) in ia.outputs.iter() {
               check_expr(fcx, &**out);
           }
           fcx.write_nil(id);

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -958,9 +958,9 @@ pub enum AsmDialect {
 pub struct InlineAsm {
     pub asm: InternedString,
     pub asm_str_style: StrStyle,
-    pub clobbers: InternedString,
+    pub outputs: Vec<(InternedString, Gc<Expr>, bool)>,
     pub inputs: Vec<(InternedString, Gc<Expr>)>,
-    pub outputs: Vec<(InternedString, Gc<Expr>)>,
+    pub clobbers: InternedString,
     pub volatile: bool,
     pub alignstack: bool,
     pub dialect: AsmDialect

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1189,8 +1189,8 @@ pub fn noop_fold_expr<T: Folder>(e: Gc<Expr>, folder: &mut T) -> Gc<Expr> {
                 inputs: a.inputs.iter().map(|&(ref c, input)| {
                     ((*c).clone(), folder.fold_expr(input))
                 }).collect(),
-                outputs: a.outputs.iter().map(|&(ref c, out)| {
-                    ((*c).clone(), folder.fold_expr(out))
+                outputs: a.outputs.iter().map(|&(ref c, out, is_rw)| {
+                    ((*c).clone(), folder.fold_expr(out), is_rw)
                 }).collect(),
                 .. (*a).clone()
             })

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1671,8 +1671,14 @@ impl<'a> State<'a> {
                 try!(self.word_space(":"));
 
                 try!(self.commasep(Inconsistent, a.outputs.as_slice(),
-                                   |s, &(ref co, ref o)| {
-                    try!(s.print_string(co.get(), ast::CookedStr));
+                                   |s, &(ref co, ref o, is_rw)| {
+                    match co.get().slice_shift_char() {
+                        (Some('='), operand) if is_rw => {
+                            try!(s.print_string(format!("+{}", operand).as_slice(),
+                                                ast::CookedStr))
+                        }
+                        _ => try!(s.print_string(co.get(), ast::CookedStr))
+                    }
                     try!(s.popen());
                     try!(s.print_expr(&**o));
                     try!(s.pclose());

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -854,11 +854,11 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
         ExprParen(ref subexpression) => {
             visitor.visit_expr(&**subexpression, env.clone())
         }
-        ExprInlineAsm(ref assembler) => {
-            for &(_, ref input) in assembler.inputs.iter() {
+        ExprInlineAsm(ref ia) => {
+            for &(_, ref input) in ia.inputs.iter() {
                 visitor.visit_expr(&**input, env.clone())
             }
-            for &(_, ref output) in assembler.outputs.iter() {
+            for &(_, ref output, _) in ia.outputs.iter() {
                 visitor.visit_expr(&**output, env.clone())
             }
         }

--- a/src/test/run-pass/issue-14936.rs
+++ b/src/test/run-pass/issue-14936.rs
@@ -1,0 +1,54 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(asm, macro_rules)]
+
+type History = Vec<&'static str>;
+
+fn wrap<A>(x:A, which: &'static str, history: &mut History) -> A {
+    history.push(which);
+    x
+}
+
+macro_rules! demo {
+    ( $output_constraint:tt ) => {
+        {
+            let mut x: int = 0;
+            let y: int = 1;
+
+            let mut history: History = vec!();
+            unsafe {
+                asm!("mov ($1), $0"
+                     : $output_constraint (*wrap(&mut x, "out", &mut history))
+                     : "r"(&wrap(y, "in", &mut history)));
+            }
+            assert_eq!((x,y), (1,1));
+            assert_eq!(history.as_slice(), &["out", "in"]);
+        }
+    }
+}
+
+#[cfg(target_arch = "x86")]
+#[cfg(target_arch = "x86_64")]
+fn main() {
+    fn out_write_only_expr_then_in_expr() {
+        demo!("=r")
+    }
+
+    fn out_read_write_expr_then_in_expr() {
+        demo!("+r")
+    }
+
+    out_write_only_expr_then_in_expr();
+    out_read_write_expr_then_in_expr();
+}
+
+#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+pub fn main() {}


### PR DESCRIPTION
It's unfortunate that the read+write operands need special treatment in the AST. A separate vec for all expressions is an alternative, but it doesn't play nicely with trans.

Fixes #14936
