### PR TITLE
librustc: Require the `ref` keyword to get by-reference closure

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -295,7 +295,7 @@ pub fn make_tests(config: &Config) -> Vec<test::TestDescAndFn> {
         let file = file.clone();
         debug!("inspecting file {}", file.display());
         if is_test(config, &file) {
-            let t = make_test(config, &file, || {
+            let t = make_test(config, &file, ref || {
                 match config.mode {
                     Codegen => make_metrics_test_closure(config, &file),
                     _ => make_test_closure(config, &file)

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -57,7 +57,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut no_pretty_expanded = false;
     let mut pretty_mode = None;
     let mut pretty_compare_only = false;
-    iter_header(testfile, |ln| {
+    iter_header(testfile, ref |ln| {
         match parse_error_pattern(ln) {
           Some(ep) => error_patterns.push(ep),
           None => ()

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -643,13 +643,13 @@ fn parse_debugger_commands(file_path: &Path, debugger_prefix: &str)
 
                 header::parse_name_value_directive(
                         line.as_slice(),
-                        command_directive.as_slice()).map(|cmd| {
+                        command_directive.as_slice()).map(ref |cmd| {
                     commands.push(cmd)
                 });
 
                 header::parse_name_value_directive(
                         line.as_slice(),
-                        check_directive.as_slice()).map(|cmd| {
+                        check_directive.as_slice()).map(ref |cmd| {
                     check_lines.push(cmd)
                 });
             }

--- a/src/doc/guide-container.md
+++ b/src/doc/guide-container.md
@@ -156,7 +156,7 @@ into a single value:
 
 ~~~
 let xs = [1i, 9, 2, 3, 14, 12];
-let result = xs.iter().fold(0, |accumulator, item| accumulator - *item);
+let result = xs.iter().fold(0, ref |accumulator, item| accumulator - *item);
 assert_eq!(result, -41);
 ~~~
 
@@ -165,7 +165,7 @@ Most adaptors return an adaptor object implementing the `Iterator` trait itself:
 ~~~
 let xs = [1i, 9, 2, 3, 14, 12];
 let ys = [5i, 2, 1, 8];
-let sum = xs.iter().chain(ys.iter()).fold(0, |a, b| a + *b);
+let sum = xs.iter().chain(ys.iter()).fold(0, ref |a, b| a + *b);
 assert_eq!(sum, 57);
 ~~~
 
@@ -184,7 +184,7 @@ let xs = [1i,2,3,4,5];
 let mut calls = 0i;
 
 {
-    let it = xs.iter().scan((), |_, x| {
+    let it = xs.iter().scan((), ref |_, x| {
         calls += 1;
         if *x < 3 { Some(x) } else { None }});
 
@@ -266,7 +266,7 @@ Iterators offer generic conversion to containers with the `collect` adaptor:
 
 ~~~
 let xs = [0i, 1, 1, 2, 3, 5, 8];
-let ys = xs.iter().rev().skip(1).map(|&x| x * 2).collect::<Vec<int>>();
+let ys = xs.iter().rev().skip(1).map(ref |&x| x * 2).collect::<Vec<int>>();
 assert_eq!(ys, vec![10, 6, 4, 2, 2, 0]);
 ~~~
 
@@ -365,7 +365,7 @@ The `chain`, `map`, `filter`, `filter_map` and `inspect` adaptors are
 ~~~
 let xs = [1i, 2, 3, 4];
 let ys = [5i, 6, 7, 8];
-let mut it = xs.iter().chain(ys.iter()).map(|&x| x * 2);
+let mut it = xs.iter().chain(ys.iter()).map(ref |&x| x * 2);
 
 println!("{}", it.next()); // prints `Some(2)`
 

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -331,7 +331,7 @@ mod bench {
 
     #[bench]
     fn alloc_owned_small(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             box 10i
         })
     }

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -316,8 +316,8 @@ fn test_arena_alloc_nested() {
 
     let arena = Arena::new();
 
-    let result = arena.alloc(|| Outer {
-        inner: arena.alloc(|| Inner { value: 10 })
+    let result = arena.alloc(ref || Outer {
+        inner: arena.alloc(ref || Inner { value: 10 })
     });
 
     assert_eq!(result.inner.value, 10);
@@ -527,7 +527,7 @@ mod tests {
     #[bench]
     pub fn bench_copy(b: &mut Bencher) {
         let arena = TypedArena::new();
-        b.iter(|| {
+        b.iter(ref || {
             arena.alloc(Point {
                 x: 1,
                 y: 2,
@@ -538,7 +538,7 @@ mod tests {
 
     #[bench]
     pub fn bench_copy_nonarena(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             box Point {
                 x: 1,
                 y: 2,
@@ -550,8 +550,8 @@ mod tests {
     #[bench]
     pub fn bench_copy_old_arena(b: &mut Bencher) {
         let arena = Arena::new();
-        b.iter(|| {
-            arena.alloc(|| {
+        b.iter(ref || {
+            arena.alloc(ref || {
                 Point {
                     x: 1,
                     y: 2,
@@ -580,7 +580,7 @@ mod tests {
     #[bench]
     pub fn bench_noncopy(b: &mut Bencher) {
         let arena = TypedArena::new();
-        b.iter(|| {
+        b.iter(ref || {
             arena.alloc(Noncopy {
                 string: "hello world".to_string(),
                 array: vec!( 1, 2, 3, 4, 5 ),
@@ -590,7 +590,7 @@ mod tests {
 
     #[bench]
     pub fn bench_noncopy_nonarena(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             box Noncopy {
                 string: "hello world".to_string(),
                 array: vec!( 1, 2, 3, 4, 5 ),
@@ -601,8 +601,8 @@ mod tests {
     #[bench]
     pub fn bench_noncopy_old_arena(b: &mut Bencher) {
         let arena = Arena::new();
-        b.iter(|| {
-            arena.alloc(|| Noncopy {
+        b.iter(ref || {
+            arena.alloc(ref || Noncopy {
                 string: "hello world".to_string(),
                 array: vec!( 1, 2, 3, 4, 5 ),
             })

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -458,8 +458,11 @@ impl Bitv {
     pub fn all(&self) -> bool {
         let mut last_word = !0u;
         // Check that every word but the last is all-ones...
-        self.mask_words(0).all(|(_, elem)|
-            { let tmp = last_word; last_word = elem; tmp == !0u }) &&
+        self.mask_words(0).all(ref |(_, elem)| {
+            let tmp = last_word;
+            last_word = elem;
+            tmp == !0u
+        }) &&
         // ...and that the last word is ones as far as it needs to be
         (last_word == ((1 << self.nbits % uint::BITS) - 1) || last_word == !0u)
     }
@@ -2560,7 +2563,7 @@ mod tests {
     fn bench_uint_small(b: &mut Bencher) {
         let mut r = rng();
         let mut bitv = 0 as uint;
-        b.iter(|| {
+        b.iter(ref || {
             bitv |= 1 << ((r.next_u32() as uint) % uint::BITS);
             &bitv
         })
@@ -2570,7 +2573,7 @@ mod tests {
     fn bench_bitv_big(b: &mut Bencher) {
         let mut r = rng();
         let mut bitv = Bitv::with_capacity(BENCH_BITS, false);
-        b.iter(|| {
+        b.iter(ref || {
             bitv.set((r.next_u32() as uint) % BENCH_BITS, true);
             &bitv
         })
@@ -2580,7 +2583,7 @@ mod tests {
     fn bench_bitv_small(b: &mut Bencher) {
         let mut r = rng();
         let mut bitv = Bitv::with_capacity(uint::BITS, false);
-        b.iter(|| {
+        b.iter(ref || {
             bitv.set((r.next_u32() as uint) % uint::BITS, true);
             &bitv
         })
@@ -2590,7 +2593,7 @@ mod tests {
     fn bench_bitv_set_small(b: &mut Bencher) {
         let mut r = rng();
         let mut bitv = BitvSet::new();
-        b.iter(|| {
+        b.iter(ref || {
             bitv.insert((r.next_u32() as uint) % uint::BITS);
             &bitv
         })
@@ -2600,7 +2603,7 @@ mod tests {
     fn bench_bitv_set_big(b: &mut Bencher) {
         let mut r = rng();
         let mut bitv = BitvSet::new();
-        b.iter(|| {
+        b.iter(ref || {
             bitv.insert((r.next_u32() as uint) % BENCH_BITS);
             &bitv
         })
@@ -2610,7 +2613,7 @@ mod tests {
     fn bench_bitv_big_union(b: &mut Bencher) {
         let mut b1 = Bitv::with_capacity(BENCH_BITS, false);
         let b2 = Bitv::with_capacity(BENCH_BITS, false);
-        b.iter(|| {
+        b.iter(ref || {
             b1.union(&b2);
         })
     }
@@ -2618,7 +2621,7 @@ mod tests {
     #[bench]
     fn bench_btv_small_iter(b: &mut Bencher) {
         let bitv = Bitv::with_capacity(uint::BITS, false);
-        b.iter(|| {
+        b.iter(ref || {
             let mut _sum = 0;
             for pres in bitv.iter() {
                 _sum += pres as uint;
@@ -2629,7 +2632,7 @@ mod tests {
     #[bench]
     fn bench_bitv_big_iter(b: &mut Bencher) {
         let bitv = Bitv::with_capacity(BENCH_BITS, false);
-        b.iter(|| {
+        b.iter(ref || {
             let mut _sum = 0;
             for pres in bitv.iter() {
                 _sum += pres as uint;
@@ -2641,7 +2644,7 @@ mod tests {
     fn bench_bitvset_iter(b: &mut Bencher) {
         let bitv = BitvSet::from_bitv(from_fn(BENCH_BITS,
                                               |idx| {idx % 3 == 0}));
-        b.iter(|| {
+        b.iter(ref || {
             let mut _sum = 0;
             for idx in bitv.iter() {
                 _sum += idx;

--- a/src/libcollections/btree.rs
+++ b/src/libcollections/btree.rs
@@ -386,9 +386,9 @@ impl<K: Clone + Ord, V: Clone> Leaf<K, V> {
         if self.elts.len() > ub {
             let midpoint_opt = self.elts.remove(ub / 2);
             let midpoint = midpoint_opt.unwrap();
-            let (left_leaf, right_leaf) = self.elts.partition(|le|
-                                                              le.key.cmp(&midpoint.key.clone())
-                                                              == Less);
+            let (left_leaf, right_leaf) = self.elts.partition(ref |le| {
+                le.key.cmp(&midpoint.key.clone()) == Less
+            });
             let branch_return = Node::new_branch(vec!(BranchElt::new(midpoint.key.clone(),
                                                                   midpoint.value.clone(),
                                                              box Node::new_leaf(left_leaf))),
@@ -613,9 +613,11 @@ impl<K: Clone + Ord, V: Clone> Branch<K, V> {
             //and two children.
             if self.elts.len() > ub {
                 let midpoint = self.elts.remove(ub / 2).unwrap();
-                let (new_left, new_right) = self.clone().elts.partition(|le|
-                                                                midpoint.key.cmp(&le.key)
-                                                                        == Greater);
+                let (new_left, new_right) = self.clone()
+                                                .elts
+                                                .partition(ref |le| {
+                    midpoint.key.cmp(&le.key) == Greater
+                });
                 new_branch = Node::new_branch(
                     vec!(BranchElt::new(midpoint.clone().key,
                                      midpoint.clone().value,

--- a/src/libcollections/deque.rs
+++ b/src/libcollections/deque.rs
@@ -30,7 +30,7 @@ pub mod bench {
         }
 
         // measure
-        b.iter(|| {
+        b.iter(ref || {
             let k = rng.gen::<uint>() % n;
             map.insert(k, 1);
             map.remove(&k);
@@ -48,7 +48,7 @@ pub mod bench {
 
         // measure
         let mut i = 1;
-        b.iter(|| {
+        b.iter(ref || {
             map.insert(i, 1);
             map.remove(&i);
             i = (i + 2) % n;
@@ -70,7 +70,7 @@ pub mod bench {
 
         // measure
         let mut i = 0;
-        b.iter(|| {
+        b.iter(ref || {
             map.find(&keys[i]);
             i = (i + 1) % n;
         })
@@ -86,7 +86,7 @@ pub mod bench {
 
         // measure
         let mut i = 0;
-        b.iter(|| {
+        b.iter(ref || {
             let x = map.find(&i);
             i = (i + 1) % n;
             x

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1215,7 +1215,7 @@ mod tests {
     #[bench]
     fn bench_collect_into(b: &mut test::Bencher) {
         let v = &[0i, ..64];
-        b.iter(|| {
+        b.iter(ref || {
             let _: DList<int> = v.iter().map(|x| *x).collect();
         })
     }
@@ -1223,7 +1223,7 @@ mod tests {
     #[bench]
     fn bench_push_front(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
-        b.iter(|| {
+        b.iter(ref || {
             m.push_front(0);
         })
     }
@@ -1231,7 +1231,7 @@ mod tests {
     #[bench]
     fn bench_push_back(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
-        b.iter(|| {
+        b.iter(ref || {
             m.push_back(0);
         })
     }
@@ -1239,7 +1239,7 @@ mod tests {
     #[bench]
     fn bench_push_back_pop_back(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
-        b.iter(|| {
+        b.iter(ref || {
             m.push_back(0);
             m.pop_back();
         })
@@ -1248,7 +1248,7 @@ mod tests {
     #[bench]
     fn bench_push_front_pop_front(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
-        b.iter(|| {
+        b.iter(ref || {
             m.push_front(0);
             m.pop_front();
         })
@@ -1259,7 +1259,7 @@ mod tests {
         let mut m: DList<int> = DList::new();
         m.push_front(0i);
         m.push_front(1);
-        b.iter(|| {
+        b.iter(ref || {
             m.rotate_forward();
         })
     }
@@ -1269,7 +1269,7 @@ mod tests {
         let mut m: DList<int> = DList::new();
         m.push_front(0i);
         m.push_front(1);
-        b.iter(|| {
+        b.iter(ref || {
             m.rotate_backward();
         })
     }
@@ -1278,7 +1278,7 @@ mod tests {
     fn bench_iter(b: &mut test::Bencher) {
         let v = &[0i, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
-        b.iter(|| {
+        b.iter(ref || {
             assert!(m.iter().count() == 128);
         })
     }
@@ -1286,7 +1286,7 @@ mod tests {
     fn bench_iter_mut(b: &mut test::Bencher) {
         let v = &[0i, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
-        b.iter(|| {
+        b.iter(ref || {
             assert!(m.mut_iter().count() == 128);
         })
     }
@@ -1294,7 +1294,7 @@ mod tests {
     fn bench_iter_rev(b: &mut test::Bencher) {
         let v = &[0i, ..128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
-        b.iter(|| {
+        b.iter(ref || {
             assert!(m.iter().rev().count() == 128);
         })
     }
@@ -1302,7 +1302,7 @@ mod tests {
     fn bench_iter_mut_rev(b: &mut test::Bencher) {
         let v = &[0i, ..128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
-        b.iter(|| {
+        b.iter(ref || {
             assert!(m.mut_iter().rev().count() == 128);
         })
     }

--- a/src/libcollections/hash/sip.rs
+++ b/src/libcollections/hash/sip.rs
@@ -507,7 +507,7 @@ mod tests {
     #[bench]
     fn bench_str_under_8_bytes(b: &mut Bencher) {
         let s = "foo";
-        b.iter(|| {
+        b.iter(ref || {
             assert_eq!(hash(&s), 16262950014981195938);
         })
     }
@@ -515,7 +515,7 @@ mod tests {
     #[bench]
     fn bench_str_of_8_bytes(b: &mut Bencher) {
         let s = "foobar78";
-        b.iter(|| {
+        b.iter(ref || {
             assert_eq!(hash(&s), 4898293253460910787);
         })
     }
@@ -523,7 +523,7 @@ mod tests {
     #[bench]
     fn bench_str_over_8_bytes(b: &mut Bencher) {
         let s = "foobarbaz0";
-        b.iter(|| {
+        b.iter(ref || {
             assert_eq!(hash(&s), 10581415515220175264);
         })
     }
@@ -536,7 +536,7 @@ exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute 
 irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla \
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
 officia deserunt mollit anim id est laborum.";
-        b.iter(|| {
+        b.iter(ref || {
             assert_eq!(hash(&s), 17717065544121360093);
         })
     }
@@ -544,7 +544,7 @@ officia deserunt mollit anim id est laborum.";
     #[bench]
     fn bench_u64(b: &mut Bencher) {
         let u = 16262950014981195938u64;
-        b.iter(|| {
+        b.iter(ref || {
             assert_eq!(hash(&u), 5254097107239593357);
         })
     }

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -694,7 +694,7 @@ mod tests {
 
     #[bench]
     fn bench_new(b: &mut test::Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let _: RingBuf<u64> = RingBuf::new();
         })
     }
@@ -702,7 +702,7 @@ mod tests {
     #[bench]
     fn bench_push_back(b: &mut test::Bencher) {
         let mut deq = RingBuf::new();
-        b.iter(|| {
+        b.iter(ref || {
             deq.push_back(0i);
         })
     }
@@ -710,7 +710,7 @@ mod tests {
     #[bench]
     fn bench_push_front(b: &mut test::Bencher) {
         let mut deq = RingBuf::new();
-        b.iter(|| {
+        b.iter(ref || {
             deq.push_front(0i);
         })
     }
@@ -718,7 +718,7 @@ mod tests {
     #[bench]
     fn bench_grow(b: &mut test::Bencher) {
         let mut deq = RingBuf::new();
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0i, 65) {
                 deq.push_front(1i);
             }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -187,11 +187,11 @@ impl Iterator<(uint, uint)> for ElementSwaps {
         // Find the index of the largest mobile element:
         // The direction should point into the vector, and the
         // swap should be with a smaller `size` element.
-        let max = self.sdir.iter().map(|&x| x).enumerate()
-                           .filter(|&(i, sd)|
+        let max = self.sdir.iter().map(ref |&x| x).enumerate()
+                           .filter(ref |&(i, sd)|
                                 new_pos(i, sd.dir) < self.sdir.len() &&
                                 self.sdir[new_pos(i, sd.dir)].size < sd.size)
-                           .max_by(|&(_, sd)| sd.size);
+                           .max_by(ref |&(_, sd)| sd.size);
         match max {
             Some((i, sd)) => {
                 let j = new_pos(i, sd.dir);
@@ -2161,7 +2161,7 @@ mod bench {
         // out.
         let v = Vec::from_fn(100, |i| i ^ (i << 1) ^ (i >> 1));
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut sum = 0;
             for x in v.iter() {
                 sum += *x;
@@ -2175,7 +2175,7 @@ mod bench {
     fn mut_iterator(b: &mut Bencher) {
         let mut v = Vec::from_elem(100, 0i);
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut i = 0i;
             for x in v.mut_iter() {
                 *x = i;
@@ -2188,7 +2188,7 @@ mod bench {
     fn concat(b: &mut Bencher) {
         let xss: Vec<Vec<uint>> =
             Vec::from_fn(100, |i| range(0u, i).collect());
-        b.iter(|| {
+        b.iter(ref || {
             xss.as_slice().concat_vec()
         });
     }
@@ -2197,7 +2197,7 @@ mod bench {
     fn connect(b: &mut Bencher) {
         let xss: Vec<Vec<uint>> =
             Vec::from_fn(100, |i| range(0u, i).collect());
-        b.iter(|| {
+        b.iter(ref || {
             xss.as_slice().connect_vec(&0)
         });
     }
@@ -2205,7 +2205,7 @@ mod bench {
     #[bench]
     fn push(b: &mut Bencher) {
         let mut vec: Vec<uint> = vec![];
-        b.iter(|| {
+        b.iter(ref || {
             vec.push(0);
             &vec
         })
@@ -2214,7 +2214,7 @@ mod bench {
     #[bench]
     fn starts_with_same_vector(b: &mut Bencher) {
         let vec: Vec<uint> = Vec::from_fn(100, |i| i);
-        b.iter(|| {
+        b.iter(ref || {
             vec.as_slice().starts_with(vec.as_slice())
         })
     }
@@ -2222,7 +2222,7 @@ mod bench {
     #[bench]
     fn starts_with_single_element(b: &mut Bencher) {
         let vec: Vec<uint> = vec![0];
-        b.iter(|| {
+        b.iter(ref || {
             vec.as_slice().starts_with(vec.as_slice())
         })
     }
@@ -2232,7 +2232,7 @@ mod bench {
         let vec: Vec<uint> = Vec::from_fn(100, |i| i);
         let mut match_vec: Vec<uint> = Vec::from_fn(99, |i| i);
         match_vec.push(0);
-        b.iter(|| {
+        b.iter(ref || {
             vec.as_slice().starts_with(match_vec.as_slice())
         })
     }
@@ -2240,7 +2240,7 @@ mod bench {
     #[bench]
     fn ends_with_same_vector(b: &mut Bencher) {
         let vec: Vec<uint> = Vec::from_fn(100, |i| i);
-        b.iter(|| {
+        b.iter(ref || {
             vec.as_slice().ends_with(vec.as_slice())
         })
     }
@@ -2248,7 +2248,7 @@ mod bench {
     #[bench]
     fn ends_with_single_element(b: &mut Bencher) {
         let vec: Vec<uint> = vec![0];
-        b.iter(|| {
+        b.iter(ref || {
             vec.as_slice().ends_with(vec.as_slice())
         })
     }
@@ -2258,7 +2258,7 @@ mod bench {
         let vec: Vec<uint> = Vec::from_fn(100, |i| i);
         let mut match_vec: Vec<uint> = Vec::from_fn(100, |i| i);
         match_vec.as_mut_slice()[0] = 200;
-        b.iter(|| {
+        b.iter(ref || {
             vec.as_slice().starts_with(match_vec.as_slice())
         })
     }
@@ -2266,21 +2266,21 @@ mod bench {
     #[bench]
     fn contains_last_element(b: &mut Bencher) {
         let vec: Vec<uint> = Vec::from_fn(100, |i| i);
-        b.iter(|| {
+        b.iter(ref || {
             vec.contains(&99u)
         })
     }
 
     #[bench]
     fn zero_1kb_from_elem(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             Vec::from_elem(1024, 0u8)
         });
     }
 
     #[bench]
     fn zero_1kb_set_memory(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let mut v: Vec<uint> = Vec::with_capacity(1024);
             unsafe {
                 let vp = v.as_mut_ptr();
@@ -2293,7 +2293,7 @@ mod bench {
 
     #[bench]
     fn zero_1kb_loop_set(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let mut v: Vec<uint> = Vec::with_capacity(1024);
             unsafe {
                 v.set_len(1024);
@@ -2306,7 +2306,7 @@ mod bench {
 
     #[bench]
     fn zero_1kb_mut_iter(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = Vec::with_capacity(1024);
             unsafe {
                 v.set_len(1024);
@@ -2321,7 +2321,7 @@ mod bench {
     #[bench]
     fn random_inserts(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
                 let mut v = Vec::from_elem(30, (0u, 0u));
                 for _ in range(0u, 100) {
                     let l = v.len();
@@ -2333,7 +2333,7 @@ mod bench {
     #[bench]
     fn random_removes(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
                 let mut v = Vec::from_elem(130, (0u, 0u));
                 for _ in range(0u, 100) {
                     let l = v.len();
@@ -2345,7 +2345,7 @@ mod bench {
     #[bench]
     fn sort_random_small(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = rng.gen_iter::<u64>().take(5).collect::<Vec<u64>>();
             v.as_mut_slice().sort();
         });
@@ -2355,7 +2355,7 @@ mod bench {
     #[bench]
     fn sort_random_medium(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = rng.gen_iter::<u64>().take(100).collect::<Vec<u64>>();
             v.as_mut_slice().sort();
         });
@@ -2365,7 +2365,7 @@ mod bench {
     #[bench]
     fn sort_random_large(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = rng.gen_iter::<u64>().take(10000).collect::<Vec<u64>>();
             v.as_mut_slice().sort();
         });
@@ -2375,7 +2375,7 @@ mod bench {
     #[bench]
     fn sort_sorted(b: &mut Bencher) {
         let mut v = Vec::from_fn(10000, |i| i);
-        b.iter(|| {
+        b.iter(ref || {
             v.sort();
         });
         b.bytes = (v.len() * mem::size_of_val(v.get(0))) as u64;
@@ -2386,7 +2386,7 @@ mod bench {
     #[bench]
     fn sort_big_random_small(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = rng.gen_iter::<BigSortable>().take(5)
                            .collect::<Vec<BigSortable>>();
             v.sort();
@@ -2397,7 +2397,7 @@ mod bench {
     #[bench]
     fn sort_big_random_medium(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = rng.gen_iter::<BigSortable>().take(100)
                            .collect::<Vec<BigSortable>>();
             v.sort();
@@ -2408,7 +2408,7 @@ mod bench {
     #[bench]
     fn sort_big_random_large(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| {
+        b.iter(ref || {
             let mut v = rng.gen_iter::<BigSortable>().take(10000)
                            .collect::<Vec<BigSortable>>();
             v.sort();
@@ -2419,7 +2419,7 @@ mod bench {
     #[bench]
     fn sort_big_sorted(b: &mut Bencher) {
         let mut v = Vec::from_fn(10000u, |i| (i, i, i, i));
-        b.iter(|| {
+        b.iter(ref || {
             v.sort();
         });
         b.bytes = (v.len() * mem::size_of_val(v.get(0))) as u64;

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -261,7 +261,7 @@ impl<'a> Iterator<char> for Decompositions<'a> {
             for ch in self.iter {
                 let buffer = &mut self.buffer;
                 let sorted = &mut self.sorted;
-                decomposer(ch, |d| {
+                decomposer(ch, ref |d| {
                     let class = unicode::char::canonical_combining_class(d);
                     if class == 0 && !*sorted {
                         canonical_sort(buffer.as_mut_slice());
@@ -701,7 +701,7 @@ pub trait StrAllocating: Str {
         let me = self.as_slice();
         let mut out = String::with_capacity(me.len());
         for c in me.chars() {
-            c.escape_default(|c| out.push_char(c));
+            c.escape_default(ref |c| out.push_char(c));
         }
         out
     }
@@ -711,7 +711,7 @@ pub trait StrAllocating: Str {
         let me = self.as_slice();
         let mut out = String::with_capacity(me.len());
         for c in me.chars() {
-            c.escape_unicode(|c| out.push_char(c));
+            c.escape_unicode(ref |c| out.push_char(c));
         }
         out
     }
@@ -2372,14 +2372,14 @@ mod bench {
     fn char_iterator(b: &mut Bencher) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
-        b.iter(|| s.chars().count());
+        b.iter(ref || s.chars().count());
     }
 
     #[bench]
     fn char_iterator_for(b: &mut Bencher) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
-        b.iter(|| {
+        b.iter(ref || {
             for ch in s.chars() { black_box(ch) }
         });
     }
@@ -2393,21 +2393,21 @@ mod bench {
         Mary had a little lamb, Little lamb
         Mary had a little lamb, Little lamb";
 
-        b.iter(|| s.chars().count());
+        b.iter(ref || s.chars().count());
     }
 
     #[bench]
     fn char_iterator_rev(b: &mut Bencher) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
-        b.iter(|| s.chars().rev().count());
+        b.iter(ref || s.chars().rev().count());
     }
 
     #[bench]
     fn char_iterator_rev_for(b: &mut Bencher) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
-        b.iter(|| {
+        b.iter(ref || {
             for ch in s.chars().rev() { black_box(ch) }
         });
     }
@@ -2417,7 +2417,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices().count(), len));
+        b.iter(ref || assert_eq!(s.char_indices().count(), len));
     }
 
     #[bench]
@@ -2425,14 +2425,14 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let len = s.char_len();
 
-        b.iter(|| assert_eq!(s.char_indices().rev().count(), len));
+        b.iter(ref || assert_eq!(s.char_indices().rev().count(), len));
     }
 
     #[bench]
     fn split_unicode_ascii(b: &mut Bencher) {
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
-        b.iter(|| assert_eq!(s.split('V').count(), 3));
+        b.iter(ref || assert_eq!(s.split('V').count(), 3));
     }
 
     #[bench]
@@ -2447,7 +2447,7 @@ mod bench {
         }
         let s = "ประเทศไทย中华Việt Namประเทศไทย中华Việt Nam";
 
-        b.iter(|| assert_eq!(s.split(NotAscii('V')).count(), 3));
+        b.iter(ref || assert_eq!(s.split(NotAscii('V')).count(), 3));
     }
 
 
@@ -2456,7 +2456,7 @@ mod bench {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
         let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(' ').count(), len));
+        b.iter(ref || assert_eq!(s.split(' ').count(), len));
     }
 
     #[bench]
@@ -2473,7 +2473,7 @@ mod bench {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
         let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(NotAscii(' ')).count(), len));
+        b.iter(ref || assert_eq!(s.split(NotAscii(' ')).count(), len));
     }
 
     #[bench]
@@ -2482,7 +2482,7 @@ mod bench {
         let len = s.split(' ').count();
         fn pred(c: char) -> bool { c == ' ' }
 
-        b.iter(|| assert_eq!(s.split(pred).count(), len));
+        b.iter(ref || assert_eq!(s.split(pred).count(), len));
     }
 
     #[bench]
@@ -2490,7 +2490,7 @@ mod bench {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
         let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(|c: char| c == ' ').count(), len));
+        b.iter(ref || assert_eq!(s.split(|c: char| c == ' ').count(), len));
     }
 
     #[bench]
@@ -2498,7 +2498,7 @@ mod bench {
         let s = "Mary had a little lamb, Little lamb, little-lamb.";
         let len = s.split(' ').count();
 
-        b.iter(|| assert_eq!(s.split(&[' ']).count(), len));
+        b.iter(ref || assert_eq!(s.split(&[' ']).count(), len));
     }
 
     #[bench]
@@ -2508,7 +2508,7 @@ mod bench {
                   Lorem ipsum dolor sit amet, consectetur. ";
 
         assert_eq!(100, s.len());
-        b.iter(|| {
+        b.iter(ref || {
             is_utf8(s)
         });
     }
@@ -2517,7 +2517,7 @@ mod bench {
     fn is_utf8_100_multibyte(b: &mut Bencher) {
         let s = "𐌀𐌖𐌋𐌄𐌑𐌉ปรدولة الكويتทศไทย中华𐍅𐌿𐌻𐍆𐌹𐌻𐌰".as_bytes();
         assert_eq!(100, s.len());
-        b.iter(|| {
+        b.iter(ref || {
             is_utf8(s)
         });
     }
@@ -2527,7 +2527,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
         let sep = "→";
         let v = [s, s, s, s, s, s, s, s, s, s];
-        b.iter(|| {
+        b.iter(ref || {
             assert_eq!(v.connect(sep).len(), s.len() * 10 + sep.len() * 9);
         })
     }
@@ -2537,7 +2537,7 @@ mod bench {
         let haystack = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
         let needle = "sit";
 
-        b.iter(|| {
+        b.iter(ref || {
             assert!(haystack.contains(needle));
         })
     }
@@ -2581,7 +2581,7 @@ leo suscipit, varius porttitor nulla porta. Pellentesque ut sem nec nisi euismod
 malesuada sollicitudin quam eu fermentum.";
         let needle = "english";
 
-        b.iter(|| {
+        b.iter(ref || {
             assert!(!haystack.contains(needle));
         })
     }
@@ -2591,7 +2591,7 @@ malesuada sollicitudin quam eu fermentum.";
         let haystack = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let needle = "aaaaaaaab";
 
-        b.iter(|| {
+        b.iter(ref || {
             assert!(!haystack.contains(needle));
         })
     }
@@ -2601,7 +2601,7 @@ malesuada sollicitudin quam eu fermentum.";
         let haystack = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
         let needle = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
-        b.iter(|| {
+        b.iter(ref || {
             assert!(haystack.contains(needle));
         })
     }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1142,7 +1142,7 @@ mod tests {
 
     #[bench]
     fn bench_with_capacity(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             String::with_capacity(100)
         });
     }
@@ -1150,7 +1150,7 @@ mod tests {
     #[bench]
     fn bench_push_str(b: &mut Bencher) {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
-        b.iter(|| {
+        b.iter(ref || {
             let mut r = String::new();
             r.push_str(s);
         });
@@ -1162,7 +1162,7 @@ mod tests {
                   Lorem ipsum dolor sit amet, consectetur. ";
 
         assert_eq!(100, s.len());
-        b.iter(|| {
+        b.iter(ref || {
             let _ = String::from_utf8_lossy(s);
         });
     }
@@ -1171,7 +1171,7 @@ mod tests {
     fn from_utf8_lossy_100_multibyte(b: &mut Bencher) {
         let s = "𐌀𐌖𐌋𐌄𐌑𐌉ปรدولة الكويتทศไทย中华𐍅𐌿𐌻𐍆𐌹𐌻𐌰".as_bytes();
         assert_eq!(100, s.len());
-        b.iter(|| {
+        b.iter(ref || {
             let _ = String::from_utf8_lossy(s);
         });
     }
@@ -1179,7 +1179,7 @@ mod tests {
     #[bench]
     fn from_utf8_lossy_invalid(b: &mut Bencher) {
         let s = b"Hello\xC0\x80 There\xE6\x83 Goodbye";
-        b.iter(|| {
+        b.iter(ref || {
             let _ = String::from_utf8_lossy(s);
         });
     }
@@ -1187,7 +1187,7 @@ mod tests {
     #[bench]
     fn from_utf8_lossy_100_invalid(b: &mut Bencher) {
         let s = Vec::from_elem(100, 0xF5u8);
-        b.iter(|| {
+        b.iter(ref || {
             let _ = String::from_utf8_lossy(s.as_slice());
         });
     }

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -1445,7 +1445,7 @@ impl<K: Ord, V> TreeNode<K, V> {
 
 // Remove left horizontal link by rotating right
 fn skew<K: Ord, V>(node: &mut Box<TreeNode<K, V>>) {
-    if node.left.as_ref().map_or(false, |x| x.level == node.level) {
+    if node.left.as_ref().map_or(false, ref |x| x.level == node.level) {
         let mut save = node.left.take_unwrap();
         swap(&mut node.left, &mut save.right); // save.right now None
         swap(node, &mut save);
@@ -1456,8 +1456,9 @@ fn skew<K: Ord, V>(node: &mut Box<TreeNode<K, V>>) {
 // Remove dual horizontal link by rotating left and increasing level of
 // the parent
 fn split<K: Ord, V>(node: &mut Box<TreeNode<K, V>>) {
-    if node.right.as_ref().map_or(false,
-      |x| x.right.as_ref().map_or(false, |y| y.level == node.level)) {
+    if node.right.as_ref().map_or(false, ref |x| {
+        x.right.as_ref().map_or(false, ref |y| y.level == node.level)
+    }) {
         let mut save = node.right.take_unwrap();
         swap(&mut node.right, &mut save.left); // save.left now None
         save.level += 1;
@@ -2418,7 +2419,7 @@ mod test_set {
         for y in b.iter() { assert!(set_b.insert(*y)) }
 
         let mut i = 0;
-        f(&set_a, &set_b, |x| {
+        f(&set_a, &set_b, ref |x| {
             assert_eq!(*x, expected[i]);
             i += 1;
             true
@@ -2445,7 +2446,7 @@ mod test_set {
     #[test]
     fn test_difference() {
         fn check_difference(a: &[int], b: &[int], expected: &[int]) {
-            check(a, b, expected, |x, y, f| x.difference(y).all(f))
+            check(a, b, expected, ref |x, y, f| x.difference(y).all(f))
         }
 
         check_difference([], [], []);
@@ -2463,7 +2464,10 @@ mod test_set {
     fn test_symmetric_difference() {
         fn check_symmetric_difference(a: &[int], b: &[int],
                                       expected: &[int]) {
-            check(a, b, expected, |x, y, f| x.symmetric_difference(y).all(f))
+            check(a,
+                  b,
+                  expected,
+                  ref |x, y, f| x.symmetric_difference(y).all(f))
         }
 
         check_symmetric_difference([], [], []);
@@ -2478,7 +2482,7 @@ mod test_set {
     fn test_union() {
         fn check_union(a: &[int], b: &[int],
                                       expected: &[int]) {
-            check(a, b, expected, |x, y, f| x.union(y).all(f))
+            check(a, b, expected, ref |x, y, f| x.union(y).all(f))
         }
 
         check_union([], [], []);

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -215,12 +215,18 @@ impl<T> TrieMap<T> {
     /// let map: TrieMap<&str> = [(1, "a"), (2, "b"), (3, "c")].iter().map(|&x| x).collect();
     ///
     /// let mut vec = Vec::new();
-    /// assert_eq!(true, map.each_reverse(|&key, &value| { vec.push((key, value)); true }));
+    /// assert_eq!(true, map.each_reverse(ref |&key, &value| {
+    ///     vec.push((key, value));
+    ///     true
+    /// }));
     /// assert_eq!(vec, vec![(3, "c"), (2, "b"), (1, "a")]);
     ///
     /// // Stop when we reach 2
     /// let mut vec = Vec::new();
-    /// assert_eq!(false, map.each_reverse(|&key, &value| { vec.push(value); key != 2 }));
+    /// assert_eq!(false, map.each_reverse(ref |&key, &value| {
+    ///     vec.push(value);
+    ///     key != 2
+    /// }));
     /// assert_eq!(vec, vec!["c", "b"]);
     /// ```
     #[inline]
@@ -640,12 +646,12 @@ impl TrieSet {
     /// let set: TrieSet = [1, 2, 3, 4, 5].iter().map(|&x| x).collect();
     ///
     /// let mut vec = Vec::new();
-    /// assert_eq!(true, set.each_reverse(|&x| { vec.push(x); true }));
+    /// assert_eq!(true, set.each_reverse(ref |&x| { vec.push(x); true }));
     /// assert_eq!(vec, vec![5, 4, 3, 2, 1]);
     ///
     /// // Stop when we reach 3
     /// let mut vec = Vec::new();
-    /// assert_eq!(false, set.each_reverse(|&x| { vec.push(x); x != 3 }));
+    /// assert_eq!(false, set.each_reverse(ref |&x| { vec.push(x); x != 3 }));
     /// assert_eq!(vec, vec![5, 4, 3]);
     /// ```
     #[inline]
@@ -762,7 +768,9 @@ impl<T> TrieNode<T> {
     fn each_reverse<'a>(&'a self, f: |&uint, &'a T| -> bool) -> bool {
         for elt in self.children.iter().rev() {
             match *elt {
-                Internal(ref x) => if !x.each_reverse(|i,t| f(i,t)) { return false },
+                Internal(ref x) => if !x.each_reverse(ref |i,t| f(i,t)) {
+                    return false
+                },
                 External(k, ref v) => if !f(&k, v) { return false },
                 Nothing => ()
             }
@@ -1113,7 +1121,7 @@ mod test_map {
         assert!(m.insert(1, 2));
 
         let mut n = 4;
-        m.each_reverse(|k, v| {
+        m.each_reverse(ref |k, v| {
             assert_eq!(*k, n);
             assert_eq!(*v, n * 2);
             n -= 1;
@@ -1130,7 +1138,7 @@ mod test_map {
         }
 
         let mut n = uint::MAX - 1;
-        m.each_reverse(|k, v| {
+        m.each_reverse(ref |k, v| {
             if n == uint::MAX - 5000 { false } else {
                 assert!(n > uint::MAX - 5000);
 
@@ -1448,7 +1456,7 @@ mod bench_map {
             m.insert(rng.gen(), rng.gen());
         }
 
-        b.iter(|| for _ in m.iter() {})
+        b.iter(ref || for _ in m.iter() {})
     }
 
     #[bench]
@@ -1459,7 +1467,7 @@ mod bench_map {
             m.insert(rng.gen(), rng.gen());
         }
 
-        b.iter(|| for _ in m.iter() {})
+        b.iter(ref || for _ in m.iter() {})
     }
 
     #[bench]
@@ -1470,7 +1478,7 @@ mod bench_map {
             m.insert(rng.gen(), rng.gen());
         }
 
-        b.iter(|| {
+        b.iter(ref || {
                 for _ in range(0u, 10) {
                     m.lower_bound(rng.gen());
                 }
@@ -1485,7 +1493,7 @@ mod bench_map {
             m.insert(rng.gen(), rng.gen());
         }
 
-        b.iter(|| {
+        b.iter(ref || {
                 for _ in range(0u, 10) {
                     m.upper_bound(rng.gen());
                 }
@@ -1497,7 +1505,7 @@ mod bench_map {
         let mut m = TrieMap::<[uint, .. 10]>::new();
         let mut rng = weak_rng();
 
-        b.iter(|| {
+        b.iter(ref || {
                 for _ in range(0u, 1000) {
                     m.insert(rng.gen(), [1, .. 10]);
                 }
@@ -1508,7 +1516,7 @@ mod bench_map {
         let mut m = TrieMap::<[uint, .. 10]>::new();
         let mut rng = weak_rng();
 
-        b.iter(|| {
+        b.iter(ref || {
                 for _ in range(0u, 1000) {
                     // only have the last few bits set.
                     m.insert(rng.gen::<uint>() & 0xff_ff, [1, .. 10]);
@@ -1521,7 +1529,7 @@ mod bench_map {
         let mut m = TrieMap::<()>::new();
         let mut rng = weak_rng();
 
-        b.iter(|| {
+        b.iter(ref || {
                 for _ in range(0u, 1000) {
                     m.insert(rng.gen(), ());
                 }
@@ -1532,7 +1540,7 @@ mod bench_map {
         let mut m = TrieMap::<()>::new();
         let mut rng = weak_rng();
 
-        b.iter(|| {
+        b.iter(ref || {
                 for _ in range(0u, 1000) {
                     // only have the last few bits set.
                     m.insert(rng.gen::<uint>() & 0xff_ff, ());

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -2012,7 +2012,7 @@ mod tests {
 
     #[bench]
     fn bench_new(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let v: Vec<uint> = Vec::new();
             assert_eq!(v.len(), 0);
             assert_eq!(v.capacity(), 0);
@@ -2022,7 +2022,7 @@ mod tests {
     fn do_bench_with_capacity(b: &mut Bencher, src_len: uint) {
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let v: Vec<uint> = Vec::with_capacity(src_len);
             assert_eq!(v.len(), 0);
             assert_eq!(v.capacity(), src_len);
@@ -2052,7 +2052,7 @@ mod tests {
     fn do_bench_from_fn(b: &mut Bencher, src_len: uint) {
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let dst = Vec::from_fn(src_len, |i| i);
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
@@ -2082,7 +2082,7 @@ mod tests {
     fn do_bench_from_elem(b: &mut Bencher, src_len: uint) {
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let dst: Vec<uint> = Vec::from_elem(src_len, 5);
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().all(|x| *x == 5));
@@ -2114,7 +2114,7 @@ mod tests {
 
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let dst = Vec::from_slice(src.clone().as_slice());
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
@@ -2146,7 +2146,7 @@ mod tests {
 
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let dst: Vec<uint> = FromIterator::from_iter(src.clone().move_iter());
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
@@ -2179,7 +2179,7 @@ mod tests {
 
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut dst = dst.clone();
             dst.extend(src.clone().move_iter());
             assert_eq!(dst.len(), dst_len + src_len);
@@ -2228,7 +2228,7 @@ mod tests {
 
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut dst = dst.clone();
             dst.push_all(src.as_slice());
             assert_eq!(dst.len(), dst_len + src_len);
@@ -2277,7 +2277,7 @@ mod tests {
 
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut dst = dst.clone();
             dst.push_all_move(src.clone());
             assert_eq!(dst.len(), dst_len + src_len);
@@ -2325,7 +2325,7 @@ mod tests {
 
         b.bytes = src_len as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let dst = src.clone();
             assert_eq!(dst.len(), src_len);
             assert!(dst.iter().enumerate().all(|(i, x)| i == *x));
@@ -2358,7 +2358,7 @@ mod tests {
 
         b.bytes = (times * src_len) as u64;
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut dst = dst.clone();
 
             for _ in range(0, times) {

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -352,12 +352,12 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
             let mut filler = Filler { buf: buf, end: &mut end };
             match sign {
                 SignNeg => {
-                    let _ = format_args!(|args| {
+                    let _ = format_args!(ref |args| {
                         fmt::write(&mut filler, args)
                     }, "{:-}", exp);
                 }
                 SignNone | SignAll => {
-                    let _ = format_args!(|args| {
+                    let _ = format_args!(ref |args| {
                         fmt::write(&mut filler, args)
                     }, "{}", exp);
                 }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1691,8 +1691,8 @@ impl<'a, A, T: Iterator<A>, B, U: Iterator<B>> Iterator<B> for FlatMap<'a, A, T,
                     return Some(x)
                 }
             }
-            match self.iter.next().map(|x| (self.f)(x)) {
-                None => return self.backiter.as_mut().and_then(|it| it.next()),
+            match self.iter.next().map(ref |x| (self.f)(x)) {
+                None => return self.backiter.as_mut().and_then(ref |it| it.next()),
                 next => self.frontiter = next,
             }
         }
@@ -1723,8 +1723,12 @@ impl<'a,
                     y => return y
                 }
             }
-            match self.iter.next_back().map(|x| (self.f)(x)) {
-                None => return self.frontiter.as_mut().and_then(|it| it.next_back()),
+            match self.iter.next_back().map(ref |x| (self.f)(x)) {
+                None => {
+                    return self.frontiter
+                               .as_mut()
+                               .and_then(ref |it| it.next_back())
+                }
                 next => self.backiter = next,
             }
         }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1141,7 +1141,7 @@ impl<'a, T> Iterator<&'a [T]> for Splits<'a, T> {
     fn next(&mut self) -> Option<&'a [T]> {
         if self.finished { return None; }
 
-        match self.v.iter().position(|x| (self.pred)(x)) {
+        match self.v.iter().position(ref |x| (self.pred)(x)) {
             None => {
                 self.finished = true;
                 Some(self.v)
@@ -1170,7 +1170,7 @@ impl<'a, T> DoubleEndedIterator<&'a [T]> for Splits<'a, T> {
     fn next_back(&mut self) -> Option<&'a [T]> {
         if self.finished { return None; }
 
-        match self.v.iter().rposition(|x| (self.pred)(x)) {
+        match self.v.iter().rposition(ref |x| (self.pred)(x)) {
             None => {
                 self.finished = true;
                 Some(self.v)
@@ -1200,7 +1200,7 @@ impl<'a, T> Iterator<&'a mut [T]> for MutSplits<'a, T> {
         if self.finished { return None; }
 
         let pred = &mut self.pred;
-        match self.v.iter().position(|x| (*pred)(x)) {
+        match self.v.iter().position(ref |x| (*pred)(x)) {
             None => {
                 self.finished = true;
                 let tmp = mem::replace(&mut self.v, &mut []);
@@ -1237,7 +1237,7 @@ impl<'a, T> DoubleEndedIterator<&'a mut [T]> for MutSplits<'a, T> {
         if self.finished { return None; }
 
         let pred = &mut self.pred;
-        match self.v.iter().rposition(|x| (*pred)(x)) {
+        match self.v.iter().rposition(ref |x| (*pred)(x)) {
             None => {
                 self.finished = true;
                 let tmp = mem::replace(&mut self.v, &mut []);

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -645,7 +645,7 @@ impl<'a> Iterator<u16> for Utf16CodeUnits<'a> {
         }
 
         let mut buf = [0u16, ..2];
-        self.chars.next().map(|ch| {
+        self.chars.next().map(ref |ch| {
             let n = ch.encode_utf16(buf.as_mut_slice()).unwrap_or(0);
             if n == 2 { self.extra = buf[1]; }
             buf[0]
@@ -1817,11 +1817,11 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn trim_chars<C: CharEq>(&self, mut to_trim: C) -> &'a str {
-        let cur = match self.find(|c: char| !to_trim.matches(c)) {
+        let cur = match self.find(ref |c: char| !to_trim.matches(c)) {
             None => "",
             Some(i) => unsafe { raw::slice_bytes(*self, i, self.len()) }
         };
-        match cur.rfind(|c: char| !to_trim.matches(c)) {
+        match cur.rfind(ref |c: char| !to_trim.matches(c)) {
             None => "",
             Some(i) => {
                 let right = cur.char_range_at(i).next;
@@ -1832,7 +1832,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn trim_left_chars<C: CharEq>(&self, mut to_trim: C) -> &'a str {
-        match self.find(|c: char| !to_trim.matches(c)) {
+        match self.find(ref |c: char| !to_trim.matches(c)) {
             None => "",
             Some(first) => unsafe { raw::slice_bytes(*self, first, self.len()) }
         }
@@ -1840,7 +1840,7 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn trim_right_chars<C: CharEq>(&self, mut to_trim: C) -> &'a str {
-        match self.rfind(|c: char| !to_trim.matches(c)) {
+        match self.rfind(ref |c: char| !to_trim.matches(c)) {
             None => "",
             Some(last) => {
                 let next = self.char_range_at(last).next;

--- a/src/libcoretest/any.rs
+++ b/src/libcoretest/any.rs
@@ -122,7 +122,7 @@ fn any_fixed_vec() {
 
 #[bench]
 fn bench_as_ref(b: &mut Bencher) {
-    b.iter(|| {
+    b.iter(ref || {
         let mut x = 0i;
         let mut y = &mut x as &mut Any;
         test::black_box(&mut y);

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -117,7 +117,7 @@ fn test_is_digit() {
 fn test_escape_default() {
     fn string(c: char) -> String {
         let mut result = String::new();
-        escape_default(c, |c| { result.push_char(c); });
+        escape_default(c, ref |c| { result.push_char(c); });
         return result;
     }
     let s = string('\n');
@@ -152,7 +152,7 @@ fn test_escape_default() {
 fn test_escape_unicode() {
     fn string(c: char) -> String {
         let mut result = String::new();
-        escape_unicode(c, |c| { result.push_char(c); });
+        escape_unicode(c, ref |c| { result.push_char(c); });
         return result;
     }
     let s = string('\x00');

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -169,31 +169,31 @@ mod uint {
     #[bench]
     fn format_bin(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:t}", rng.gen::<uint>()); })
+        b.iter(ref || { format!("{:t}", rng.gen::<uint>()); })
     }
 
     #[bench]
     fn format_oct(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:o}", rng.gen::<uint>()); })
+        b.iter(ref || { format!("{:o}", rng.gen::<uint>()); })
     }
 
     #[bench]
     fn format_dec(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:u}", rng.gen::<uint>()); })
+        b.iter(ref || { format!("{:u}", rng.gen::<uint>()); })
     }
 
     #[bench]
     fn format_hex(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:x}", rng.gen::<uint>()); })
+        b.iter(ref || { format!("{:x}", rng.gen::<uint>()); })
     }
 
     #[bench]
     fn format_base_36(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{}", radix(rng.gen::<uint>(), 36)); })
+        b.iter(ref || { format!("{}", radix(rng.gen::<uint>(), 36)); })
     }
 }
 
@@ -205,30 +205,30 @@ mod int {
     #[bench]
     fn format_bin(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:t}", rng.gen::<int>()); })
+        b.iter(ref || { format!("{:t}", rng.gen::<int>()); })
     }
 
     #[bench]
     fn format_oct(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:o}", rng.gen::<int>()); })
+        b.iter(ref || { format!("{:o}", rng.gen::<int>()); })
     }
 
     #[bench]
     fn format_dec(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:d}", rng.gen::<int>()); })
+        b.iter(ref || { format!("{:d}", rng.gen::<int>()); })
     }
 
     #[bench]
     fn format_hex(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:x}", rng.gen::<int>()); })
+        b.iter(ref || { format!("{:x}", rng.gen::<int>()); })
     }
 
     #[bench]
     fn format_base_36(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{}", radix(rng.gen::<int>(), 36)); })
+        b.iter(ref || { format!("{}", radix(rng.gen::<int>(), 36)); })
     }
 }

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -224,7 +224,7 @@ fn test_inspect() {
 
     let ys = xs.iter()
                .map(|&x| x)
-               .inspect(|_| n += 1)
+               .inspect(ref |_| n += 1)
                .collect::<Vec<uint>>();
 
     assert_eq!(n, xs.len());
@@ -849,14 +849,14 @@ fn test_iterate() {
 #[bench]
 fn bench_rposition(b: &mut Bencher) {
     let it: Vec<uint> = range(0u, 300).collect();
-    b.iter(|| {
+    b.iter(ref || {
         it.iter().rposition(|&x| x <= 150);
     });
 }
 
 #[bench]
 fn bench_skip_while(b: &mut Bencher) {
-    b.iter(|| {
+    b.iter(ref || {
         let it = range(0u, 100);
         let mut sum = 0;
         it.skip_while(|&x| { sum += x; sum < 4000 }).all(|_| true);
@@ -866,7 +866,7 @@ fn bench_skip_while(b: &mut Bencher) {
 #[bench]
 fn bench_multiple_take(b: &mut Bencher) {
     let mut it = range(0u, 42).cycle();
-    b.iter(|| {
+    b.iter(ref || {
         let n = it.next().unwrap();
         for m in range(0u, n) {
             it.take(it.next().unwrap()).all(|_| true);

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -135,7 +135,7 @@ impl Trait for Struct {
 fn trait_vtable_method_call(b: &mut Bencher) {
     let s = Struct { field: 10 };
     let t = &s as &Trait;
-    b.iter(|| {
+    b.iter(ref || {
         t.method()
     });
 }
@@ -143,7 +143,7 @@ fn trait_vtable_method_call(b: &mut Bencher) {
 #[bench]
 fn trait_static_method_call(b: &mut Bencher) {
     let s = Struct { field: 10 };
-    b.iter(|| {
+    b.iter(ref || {
         s.method()
     });
 }
@@ -153,7 +153,7 @@ fn trait_static_method_call(b: &mut Bencher) {
 #[bench]
 fn match_option_some(b: &mut Bencher) {
     let x = Some(10i);
-    b.iter(|| {
+    b.iter(ref || {
         match x {
             Some(y) => y,
             None => 11
@@ -164,7 +164,7 @@ fn match_option_some(b: &mut Bencher) {
 #[bench]
 fn match_vec_pattern(b: &mut Bencher) {
     let x = [1i,2,3,4,5,6];
-    b.iter(|| {
+    b.iter(ref || {
         match x {
             [1,2,3,..] => 10i,
             _ => 11i,

--- a/src/libcoretest/ops.rs
+++ b/src/libcoretest/ops.rs
@@ -23,7 +23,7 @@ impl Drop for HasDtor {
 
 #[bench]
 fn alloc_obj_with_dtor(b: &mut Bencher) {
-    b.iter(|| {
+    b.iter(ref || {
         HasDtor { _x : 10 };
     })
 }

--- a/src/libcoretest/option.rs
+++ b/src/libcoretest/option.rs
@@ -133,7 +133,7 @@ fn test_or_else() {
 #[test]
 fn test_option_while_some() {
     let mut i = 0i;
-    Some(10i).while_some(|j| {
+    Some(10i).while_some(ref |j| {
         i += 1;
         if j > 0 {
             Some(j-1)

--- a/src/libcoretest/ptr.rs
+++ b/src/libcoretest/ptr.rs
@@ -185,7 +185,7 @@ fn test_ptr_array_each_with_len() {
 
         let mut ctr = 0;
         let mut iteration_count = 0;
-        array_each_with_len(arr.as_ptr(), arr.len(), |e| {
+        array_each_with_len(arr.as_ptr(), arr.len(), ref |e| {
                 let actual = CString::new(e, false);
                 assert_eq!(actual.as_str(), expected_arr[ctr].as_str());
                 ctr += 1;
@@ -215,7 +215,7 @@ fn test_ptr_array_each() {
         let arr_ptr = arr.as_ptr();
         let mut ctr = 0u;
         let mut iteration_count = 0u;
-        array_each(arr_ptr, |e| {
+        array_each(arr_ptr, ref |e| {
                 let actual = CString::new(e, false);
                 assert_eq!(actual.as_str(), expected_arr[ctr].as_str());
                 ctr += 1;

--- a/src/libdebug/repr.rs
+++ b/src/libdebug/repr.rs
@@ -229,7 +229,7 @@ impl<'a> ReprVisitor<'a> {
             }
             '\x20'..'\x7e' => self.writer.write([ch as u8]),
             _ => {
-                char::escape_unicode(ch, |c| {
+                char::escape_unicode(ch, ref |c| {
                     let _ = self.writer.write([c as u8]);
                 });
                 Ok(())

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -381,15 +381,18 @@ fn is_arg(arg: &str) -> bool {
 
 fn find_opt(opts: &[Opt], nm: Name) -> Option<uint> {
     // Search main options.
-    let pos = opts.iter().position(|opt| opt.name == nm);
+    let pos = opts.iter().position(ref |opt| opt.name == nm);
     if pos.is_some() {
         return pos
     }
 
     // Search in aliases.
     for candidate in opts.iter() {
-        if candidate.aliases.iter().position(|opt| opt.name == nm).is_some() {
-            return opts.iter().position(|opt| opt.name == candidate.name);
+        if candidate.aliases
+                    .iter()
+                    .position(ref |opt| opt.name == nm)
+                    .is_some() {
+            return opts.iter().position(ref |opt| opt.name == candidate.name);
         }
     }
 
@@ -742,7 +745,7 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
         let mut desc_rows = Vec::new();
         each_split_within(desc_normalized_whitespace.as_slice(),
                           54,
-                          |substr| {
+                          ref |substr| {
             desc_rows.push(substr.to_string());
             true
         });
@@ -850,7 +853,7 @@ fn each_split_within<'a>(ss: &'a str, lim: uint, it: |&'a str| -> bool)
         lim = fake_i;
     }
 
-    let machine: |&mut bool, (uint, char)| -> bool = |cont, (i, c)| {
+    let machine: |&mut bool, (uint, char)| -> bool = ref |cont, (i, c)| {
         let whitespace = if ::std::char::is_whitespace(c) { Ws }       else { Cr };
         let limit      = if (i - slice_start + 1) <= lim  { UnderLim } else { OverLim };
 
@@ -900,7 +903,7 @@ fn each_split_within<'a>(ss: &'a str, lim: uint, it: |&'a str| -> bool)
         *cont
     };
 
-    ss.char_indices().all(|x| machine(&mut cont, x));
+    ss.char_indices().all(ref |x| machine(&mut cont, x));
 
     // Let the automaton 'run out' by supplying trailing whitespace
     while cont && match state { B | C => true, A => false } {
@@ -914,8 +917,8 @@ fn each_split_within<'a>(ss: &'a str, lim: uint, it: |&'a str| -> bool)
 fn test_split_within() {
     fn t(s: &str, i: uint, u: &[String]) {
         let mut v = Vec::new();
-        each_split_within(s, i, |s| { v.push(s.to_string()); true });
-        assert!(v.iter().zip(u.iter()).all(|(a,b)| a == b));
+        each_split_within(s, i, ref |s| { v.push(s.to_string()); true });
+        assert!(v.iter().zip(u.iter()).all(ref |(a,b)| a == b));
     }
     t("", 0, []);
     t("", 15, []);

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -116,10 +116,10 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> Paths {
         root.push(pat_root.get_ref());
     }
 
-    let root_len = pat_root.map_or(0u, |p| p.as_vec().len());
+    let root_len = pat_root.map_or(0u, ref |p| p.as_vec().len());
     let dir_patterns = pattern.slice_from(cmp::min(root_len, pattern.len()))
                        .split_terminator(is_sep)
-                       .map(|s| Pattern::new(s))
+                       .map(ref |s| Pattern::new(s))
                        .collect::<Vec<Pattern>>();
     let require_dir = pattern.chars().next_back().map(is_sep) == Some(true);
 
@@ -185,7 +185,7 @@ impl Iterator<Path> for Paths {
 fn list_dir_sorted(path: &Path) -> Option<Vec<Path>> {
     match fs::readdir(path) {
         Ok(mut children) => {
-            children.sort_by(|p1, p2| p2.filename().cmp(&p1.filename()));
+            children.sort_by(ref |p1, p2| p2.filename().cmp(&p1.filename()));
             Some(children.move_iter().collect())
         }
         Err(..) => None
@@ -349,7 +349,7 @@ impl Pattern {
      */
     pub fn matches_path(&self, path: &Path) -> bool {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        path.as_str().map_or(false, |s| {
+        path.as_str().map_or(false, ref |s| {
             self.matches(s)
         })
     }
@@ -367,7 +367,7 @@ impl Pattern {
      */
     pub fn matches_path_with(&self, path: &Path, options: MatchOptions) -> bool {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        path.as_str().map_or(false, |s| {
+        path.as_str().map_or(false, ref |s| {
             self.matches_with(s, options)
         })
     }
@@ -380,7 +380,7 @@ impl Pattern {
 
         let prev_char = Cell::new(prev_char);
 
-        let require_literal = |c| {
+        let require_literal = ref |c| {
             (options.require_literal_separator && is_sep(c)) ||
             (options.require_literal_leading_dot && c == '.'
              && is_sep(prev_char.get().unwrap_or('/')))
@@ -472,7 +472,7 @@ fn fill_todo(todo: &mut Vec<(Path, uint)>, patterns: &[Pattern], idx: uint, path
         return Some(s);
     }
 
-    let add = |todo: &mut Vec<_>, next_path: Path| {
+    let add = ref |todo: &mut Vec<_>, next_path: Path| {
         if idx + 1 == patterns.len() {
             // We know it's good, so don't make the iterator match this path
             // against the pattern again. In particular, it can't match
@@ -501,7 +501,7 @@ fn fill_todo(todo: &mut Vec<(Path, uint)>, patterns: &[Pattern], idx: uint, path
         None => {
             match list_dir_sorted(path) {
                 Some(entries) => {
-                    todo.extend(entries.move_iter().map(|x|(x, idx)));
+                    todo.extend(entries.move_iter().map(ref |x|(x, idx)));
 
                     // Matching the special directory entries . and .. that refer to
                     // the current and parent directory respectively requires that
@@ -849,31 +849,31 @@ mod test {
             require_literal_leading_dot: false
         };
 
-        let f = |options| Pattern::new("*.txt").matches_with(".hello.txt", options);
+        let f = ref |options| Pattern::new("*.txt").matches_with(".hello.txt", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(!f(options_require_literal_leading_dot));
 
-        let f = |options| Pattern::new(".*.*").matches_with(".hello.txt", options);
+        let f = ref |options| Pattern::new(".*.*").matches_with(".hello.txt", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(f(options_require_literal_leading_dot));
 
-        let f = |options| Pattern::new("aaa/bbb/*").matches_with("aaa/bbb/.ccc", options);
+        let f = ref |options| Pattern::new("aaa/bbb/*").matches_with("aaa/bbb/.ccc", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(!f(options_require_literal_leading_dot));
 
-        let f = |options| Pattern::new("aaa/bbb/*").matches_with("aaa/bbb/c.c.c.", options);
+        let f = ref |options| Pattern::new("aaa/bbb/*").matches_with("aaa/bbb/c.c.c.", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(f(options_require_literal_leading_dot));
 
-        let f = |options| Pattern::new("aaa/bbb/.*").matches_with("aaa/bbb/.ccc", options);
+        let f = ref |options| Pattern::new("aaa/bbb/.*").matches_with("aaa/bbb/.ccc", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(f(options_require_literal_leading_dot));
 
-        let f = |options| Pattern::new("aaa/?bbb").matches_with("aaa/.bbb", options);
+        let f = ref |options| Pattern::new("aaa/?bbb").matches_with("aaa/.bbb", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(!f(options_require_literal_leading_dot));
 
-        let f = |options| Pattern::new("aaa/[.]bbb").matches_with("aaa/.bbb", options);
+        let f = ref |options| Pattern::new("aaa/[.]bbb").matches_with("aaa/.bbb", options);
         assert!(f(options_not_require_literal_leading_dot));
         assert!(!f(options_require_literal_leading_dot));
     }

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -426,7 +426,7 @@ impl<'a> LabelText<'a> {
     fn escape_str(s: &str) -> String {
         let mut out = String::with_capacity(s.len());
         for c in s.chars() {
-            LabelText::escape_char(c, |c| out.push_char(c));
+            LabelText::escape_char(c, ref |c| out.push_char(c));
         }
         out
     }

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -304,7 +304,7 @@ pub fn start(argc: int, argv: *const *const u8,
     rt::init(argc, argv);
     let mut main = Some(main);
     let mut ret = None;
-    simple::task().run(|| {
+    simple::task().run(ref || {
         ret = Some(run(event_loop_factory, main.take_unwrap()));
     }).destroy();
     // unsafe is ok b/c we're sure that the runtime is gone

--- a/src/libgreen/task.rs
+++ b/src/libgreen/task.rs
@@ -110,7 +110,7 @@ extern fn bootstrap_green_task(task: uint, code: *mut (), env: *mut ()) -> ! {
     // requested. This is the "try/catch" block for this green task and
     // is the wrapper for *all* code run in the task.
     let mut start = Some(start);
-    let task = task.swap().run(|| start.take_unwrap()()).destroy();
+    let task = task.swap().run(ref || start.take_unwrap()()).destroy();
 
     // Once the function has exited, it's time to run the termination
     // routine. This means we need to context switch one more time but

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -154,7 +154,7 @@ impl rtio::RtioFileStream for FileDesc {
 
     fn fstat(&mut self) -> IoResult<rtio::FileStat> {
         let mut stat: libc::stat = unsafe { mem::zeroed() };
-        match retry(|| unsafe { libc::fstat(self.fd(), &mut stat) }) {
+        match retry(ref || unsafe { libc::fstat(self.fd(), &mut stat) }) {
             0 => Ok(mkstat(&stat)),
             _ => Err(super::last_error()),
         }
@@ -428,7 +428,7 @@ pub fn readlink(p: &CString) -> IoResult<CString> {
         len = 1024; // FIXME: read PATH_MAX from C ffi?
     }
     let mut buf: Vec<u8> = Vec::with_capacity(len as uint);
-    match retry(|| unsafe {
+    match retry(ref || unsafe {
         libc::readlink(p, buf.as_ptr() as *mut libc::c_char,
                        len as libc::size_t) as libc::c_int
     }) {
@@ -442,13 +442,13 @@ pub fn readlink(p: &CString) -> IoResult<CString> {
 }
 
 pub fn symlink(src: &CString, dst: &CString) -> IoResult<()> {
-    super::mkerr_libc(retry(|| unsafe {
+    super::mkerr_libc(retry(ref || unsafe {
         libc::symlink(src.as_ptr(), dst.as_ptr())
     }))
 }
 
 pub fn link(src: &CString, dst: &CString) -> IoResult<()> {
-    super::mkerr_libc(retry(|| unsafe {
+    super::mkerr_libc(retry(ref || unsafe {
         libc::link(src.as_ptr(), dst.as_ptr())
     }))
 }
@@ -489,7 +489,7 @@ fn mkstat(stat: &libc::stat) -> rtio::FileStat {
 
 pub fn stat(p: &CString) -> IoResult<rtio::FileStat> {
     let mut stat: libc::stat = unsafe { mem::zeroed() };
-    match retry(|| unsafe { libc::stat(p.as_ptr(), &mut stat) }) {
+    match retry(ref || unsafe { libc::stat(p.as_ptr(), &mut stat) }) {
         0 => Ok(mkstat(&stat)),
         _ => Err(super::last_error()),
     }
@@ -497,7 +497,7 @@ pub fn stat(p: &CString) -> IoResult<rtio::FileStat> {
 
 pub fn lstat(p: &CString) -> IoResult<rtio::FileStat> {
     let mut stat: libc::stat = unsafe { mem::zeroed() };
-    match retry(|| unsafe { libc::lstat(p.as_ptr(), &mut stat) }) {
+    match retry(ref || unsafe { libc::lstat(p.as_ptr(), &mut stat) }) {
         0 => Ok(mkstat(&stat)),
         _ => Err(super::last_error()),
     }
@@ -508,7 +508,7 @@ pub fn utime(p: &CString, atime: u64, mtime: u64) -> IoResult<()> {
         actime: (atime / 1000) as libc::time_t,
         modtime: (mtime / 1000) as libc::time_t,
     };
-    super::mkerr_libc(retry(|| unsafe {
+    super::mkerr_libc(retry(ref || unsafe {
         libc::utime(p.as_ptr(), &buf)
     }))
 }

--- a/src/libnative/io/mod.rs
+++ b/src/libnative/io/mod.rs
@@ -143,7 +143,7 @@ fn keep_going(data: &[u8], f: |*const u8, uint| -> i64) -> i64 {
     let mut data = data.as_ptr();
     let mut amt = origamt;
     while amt > 0 {
-        let ret = retry(|| f(data, amt) as libc::c_int);
+        let ret = retry(ref || f(data, amt) as libc::c_int);
         if ret == 0 {
             break
         } else if ret != -1 {

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -943,7 +943,9 @@ fn waitpid(pid: pid_t, deadline: u64) -> IoResult<rtio::ProcessExit> {
 
     let mut status = 0 as c_int;
     if deadline == 0 {
-        return match retry(|| unsafe { c::waitpid(pid, &mut status, 0) }) {
+        return match retry(ref || unsafe {
+                c::waitpid(pid, &mut status, 0)
+        }) {
             -1 => fail!("unknown waitpid error: {}", super::last_error().code),
             _ => Ok(translate_status(status)),
         }
@@ -1187,7 +1189,7 @@ fn waitpid_nowait(pid: pid_t) -> Option<rtio::ProcessExit> {
     #[cfg(unix)]
     fn waitpid_os(pid: pid_t) -> Option<rtio::ProcessExit> {
         let mut status = 0 as c_int;
-        match retry(|| unsafe {
+        match retry(ref || unsafe {
             c::waitpid(pid, &mut status, c::WNOHANG)
         }) {
             n if n == pid => Some(translate_status(status)),

--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -107,7 +107,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
 
     // inserts a timer into an array of timers (sorted by firing time)
     fn insert(t: Box<Inner>, active: &mut Vec<Box<Inner>>) {
-        match active.iter().position(|tm| tm.target > t.target) {
+        match active.iter().position(ref |tm| tm.target > t.target) {
             Some(pos) => { active.insert(pos, t); }
             None => { active.push(t); }
         }
@@ -172,7 +172,8 @@ fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
                         Ok(NewTimer(timer)) => insert(timer, &mut active),
 
                         Ok(RemoveTimer(id, ack)) => {
-                            match dead.iter().position(|&(i, _)| id == i) {
+                            match dead.iter()
+                                      .position(ref |&(i, _)| id == i) {
                                 Some(i) => {
                                     let (_, i) = dead.remove(i).unwrap();
                                     ack.send(i);
@@ -180,7 +181,8 @@ fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
                                 }
                                 None => {}
                             }
-                            let i = active.iter().position(|i| i.id == id);
+                            let i = active.iter()
+                                          .position(ref |i| i.id == id);
                             let i = i.expect("no timer found");
                             let t = active.remove(i).unwrap();
                             ack.send(t);
@@ -205,7 +207,7 @@ impl Timer {
     pub fn new() -> IoResult<Timer> {
         // See notes above regarding using int return value
         // instead of ()
-        unsafe { HELPER.boot(|| {}, helper); }
+        unsafe { HELPER.boot(ref || {}, helper); }
 
         static mut ID: atomic::AtomicUint = atomic::INIT_ATOMIC_UINT;
         let id = unsafe { ID.fetch_add(1, atomic::Relaxed) };

--- a/src/libnative/io/util.rs
+++ b/src/libnative/io/util.rs
@@ -176,7 +176,7 @@ pub fn await(fd: net::sock_t, deadline: Option<u64>,
     };
     let mut tv: libc::timeval = unsafe { mem::zeroed() };
 
-    match retry(|| {
+    match retry(ref || {
         let now = ::io::timer::now();
         let tvp = match deadline {
             None => ptr::mut_null(),

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -135,7 +135,7 @@ pub fn start(argc: int, argv: *const *const u8, main: proc()) -> int {
     let mut main = Some(main);
     let mut task = task::new((my_stack_bottom, my_stack_top));
     task.name = Some(str::Slice("<main>"));
-    drop(task.run(|| {
+    drop(task.run(ref || {
         unsafe {
             rt::stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);
         }

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -92,7 +92,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc():Send) {
         let mut f = Some(f);
         let mut task = task;
         task.put_runtime(ops);
-        drop(task.run(|| { f.take_unwrap()() }).destroy());
+        drop(task.run(ref || { f.take_unwrap()() }).destroy());
         drop(token);
     })
 }

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -248,7 +248,12 @@ impl Add<BigUint, BigUint> for BigUint {
         let (a, b) = if self.data.len() > other.data.len() { (self, other) } else { (other, self) };
 
         let mut carry = 0;
-        let mut sum: Vec<BigDigit> =  a.data.iter().zip(b.data.iter().chain(zeros)).map(|(ai, bi)| {
+        let mut sum: Vec<BigDigit> = a.data
+                                      .iter()
+                                      .zip(b.data
+                                            .iter()
+                                            .chain(zeros))
+                                      .map(ref |(ai, bi)| {
             let (hi, lo) = BigDigit::from_doublebigdigit(
                 (*ai as DoubleBigDigit) + (*bi as DoubleBigDigit) + (carry as DoubleBigDigit));
             carry = hi;
@@ -266,7 +271,7 @@ impl Sub<BigUint, BigUint> for BigUint {
         let (a, b) = (self.data.iter().chain(zeros.clone()), other.data.iter().chain(zeros));
 
         let mut borrow = 0i;
-        let diff: Vec<BigDigit> =  a.take(new_len).zip(b).map(|(ai, bi)| {
+        let diff: Vec<BigDigit> = a.take(new_len).zip(b).map(ref |(ai, bi)| {
             let (hi, lo) = BigDigit::from_doublebigdigit(
                 BigDigit::base
                     + (*ai as DoubleBigDigit)
@@ -324,7 +329,7 @@ impl Mul<BigUint, BigUint> for BigUint {
             if n == 1 { return (*a).clone(); }
 
             let mut carry = 0;
-            let mut prod: Vec<BigDigit> = a.data.iter().map(|ai| {
+            let mut prod: Vec<BigDigit> = a.data.iter().map(ref |ai| {
                 let (hi, lo) = BigDigit::from_doublebigdigit(
                     (*ai as DoubleBigDigit) * (n as DoubleBigDigit) + (carry as DoubleBigDigit)
                 );
@@ -768,7 +773,7 @@ impl BigUint {
         if n_bits == 0 || self.is_zero() { return (*self).clone(); }
 
         let mut carry = 0;
-        let mut shifted: Vec<BigDigit> = self.data.iter().map(|elem| {
+        let mut shifted: Vec<BigDigit> = self.data.iter().map(ref |elem| {
             let (hi, lo) = BigDigit::from_doublebigdigit(
                 (*elem as DoubleBigDigit) << n_bits | (carry as DoubleBigDigit)
             );
@@ -2918,14 +2923,14 @@ mod bench {
 
     #[bench]
     fn factorial_100(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             factorial(100);
         });
     }
 
     #[bench]
     fn fib_100(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             fib(100);
         });
     }
@@ -2934,10 +2939,10 @@ mod bench {
     fn to_string(b: &mut Bencher) {
         let fac = factorial(100);
         let fib = fib(100);
-        b.iter(|| {
+        b.iter(ref || {
             fac.to_string();
         });
-        b.iter(|| {
+        b.iter(ref || {
             fib.to_string();
         });
     }
@@ -2945,7 +2950,7 @@ mod bench {
     #[bench]
     fn shr(b: &mut Bencher) {
         let n = { let one : BigUint = One::one(); one << 1000 };
-        b.iter(|| {
+        b.iter(ref || {
             let mut m = n.clone();
             for _ in range(0u, 10) {
                 m = m >> 1;

--- a/src/librand/distributions/exponential.rs
+++ b/src/librand/distributions/exponential.rs
@@ -134,7 +134,7 @@ mod bench {
         let mut rng = ::test::weak_rng();
         let mut exp = Exp::new(2.71828 * 3.14159);
 
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, ::RAND_BENCH_N) {
                 exp.sample(&mut rng);
             }

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -394,7 +394,7 @@ mod bench {
         let gamma = Gamma::new(10., 1.0);
         let mut rng = ::test::weak_rng();
 
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, ::RAND_BENCH_N) {
                 gamma.ind_sample(&mut rng);
             }
@@ -407,7 +407,7 @@ mod bench {
         let gamma = Gamma::new(0.1, 1.0);
         let mut rng = ::test::weak_rng();
 
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, ::RAND_BENCH_N) {
                 gamma.ind_sample(&mut rng);
             }

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -200,7 +200,7 @@ mod bench {
         let mut rng = ::test::weak_rng();
         let mut normal = Normal::new(-2.71828, 3.14159);
 
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, ::RAND_BENCH_N) {
                 normal.sample(&mut rng);
             }

--- a/src/librbml/io.rs
+++ b/src/librbml/io.rs
@@ -179,7 +179,7 @@ mod tests {
         let src: Vec<u8> = Vec::from_elem(len, 5);
 
         b.bytes = (times * len) as u64;
-        b.iter(|| {
+        b.iter(ref || {
             let mut wr = SeekableMemWriter::new();
             for _ in range(0, times) {
                 wr.write(src.as_slice()).unwrap();

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -585,10 +585,11 @@ pub mod reader {
         }
 
         fn read_option<T>(&mut self,
-                          f: |&mut Decoder<'doc>, bool| -> DecodeResult<T>) -> DecodeResult<T> {
+                          f: |&mut Decoder<'doc>, bool| -> DecodeResult<T>)
+                          -> DecodeResult<T> {
             debug!("read_option()");
-            self.read_enum("Option", |this| {
-                this.read_enum_variant(["None", "Some"], |this, idx| {
+            self.read_enum("Option", ref |this| {
+                this.read_enum_variant(["None", "Some"], ref |this, idx| {
                     match idx {
                         0 => f(this, false),
                         1 => f(this, true),
@@ -1137,7 +1138,7 @@ mod bench {
             }
         });
         let mut sum = 0u;
-        b.iter(|| {
+        b.iter(ref || {
             let mut i = 0;
             while i < data.len() {
                 sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
@@ -1155,7 +1156,7 @@ mod bench {
             }
         });
         let mut sum = 0u;
-        b.iter(|| {
+        b.iter(ref || {
             let mut i = 1;
             while i < data.len() {
                 sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
@@ -1174,7 +1175,7 @@ mod bench {
             }
         });
         let mut sum = 0u;
-        b.iter(|| {
+        b.iter(ref || {
             let mut i = 0;
             while i < data.len() {
                 sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
@@ -1193,7 +1194,7 @@ mod bench {
             }
         });
         let mut sum = 0u;
-        b.iter(|| {
+        b.iter(ref || {
             let mut i = 1;
             while i < data.len() {
                 sum += reader::vuint_at(data.as_slice(), i).unwrap().val;

--- a/src/libregex/test/bench.rs
+++ b/src/libregex/test/bench.rs
@@ -15,7 +15,7 @@ use stdtest::Bencher;
 use regex::{Regex, NoExpand};
 
 fn bench_assert_match(b: &mut Bencher, re: Regex, text: &str) {
-    b.iter(|| if !re.is_match(text) { fail!("no match") });
+    b.iter(ref || if !re.is_match(text) { fail!("no match") });
 }
 
 #[bench]
@@ -64,77 +64,77 @@ fn replace_all(b: &mut Bencher) {
     // FIXME: This isn't using the $name expand stuff.
     // It's possible RE2/Go is using it, but currently, the expand in this
     // crate is actually compiling a regex, so it's incredibly slow.
-    b.iter(|| re.replace_all(text, NoExpand("")));
+    b.iter(ref || re.replace_all(text, NoExpand("")));
 }
 
 #[bench]
 fn anchored_literal_short_non_match(b: &mut Bencher) {
     let re = regex!("^zbc(d|e)");
     let text = "abcdefghijklmnopqrstuvwxyz";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn anchored_literal_long_non_match(b: &mut Bencher) {
     let re = regex!("^zbc(d|e)");
     let text = "abcdefghijklmnopqrstuvwxyz".repeat(15);
-    b.iter(|| re.is_match(text.as_slice()));
+    b.iter(ref || re.is_match(text.as_slice()));
 }
 
 #[bench]
 fn anchored_literal_short_match(b: &mut Bencher) {
     let re = regex!("^.bc(d|e)");
     let text = "abcdefghijklmnopqrstuvwxyz";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn anchored_literal_long_match(b: &mut Bencher) {
     let re = regex!("^.bc(d|e)");
     let text = "abcdefghijklmnopqrstuvwxyz".repeat(15);
-    b.iter(|| re.is_match(text.as_slice()));
+    b.iter(ref || re.is_match(text.as_slice()));
 }
 
 #[bench]
 fn one_pass_short_a(b: &mut Bencher) {
     let re = regex!("^.bc(d|e)*$");
     let text = "abcddddddeeeededd";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn one_pass_short_a_not(b: &mut Bencher) {
     let re = regex!(".bc(d|e)*$");
     let text = "abcddddddeeeededd";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn one_pass_short_b(b: &mut Bencher) {
     let re = regex!("^.bc(?:d|e)*$");
     let text = "abcddddddeeeededd";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn one_pass_short_b_not(b: &mut Bencher) {
     let re = regex!(".bc(?:d|e)*$");
     let text = "abcddddddeeeededd";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn one_pass_long_prefix(b: &mut Bencher) {
     let re = regex!("^abcdefghijklmnopqrstuvwxyz.*$");
     let text = "abcdefghijklmnopqrstuvwxyz";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 #[bench]
 fn one_pass_long_prefix_not(b: &mut Bencher) {
     let re = regex!("^.bcdefghijklmnopqrstuvwxyz.*$");
     let text = "abcdefghijklmnopqrstuvwxyz";
-    b.iter(|| re.is_match(text));
+    b.iter(ref || re.is_match(text));
 }
 
 macro_rules! throughput(
@@ -143,7 +143,11 @@ macro_rules! throughput(
         fn $name(b: &mut Bencher) {
             let text = gen_text($size);
             b.bytes = $size;
-            b.iter(|| if $regex.is_match(text.as_slice()) { fail!("match") });
+            b.iter(ref || {
+                if $regex.is_match(text.as_slice()) {
+                    fail!("match")
+                }
+            });
         }
     );
 )

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -117,12 +117,14 @@ impl<'a> NfaGen<'a> {
         let num_cap_locs = 2 * self.prog.num_captures();
         let num_insts = self.prog.insts.len();
         let cap_names = self.vec_expr(self.names.as_slice().iter(),
-            |cx, name| match *name {
-                Some(ref name) => {
-                    let name = name.as_slice();
-                    quote_expr!(cx, Some($name))
+            ref |cx, name| {
+                match *name {
+                    Some(ref name) => {
+                        let name = name.as_slice();
+                        quote_expr!(cx, Some($name))
+                    }
+                    None => cx.expr_none(self.sp),
                 }
-                None => cx.expr_none(self.sp),
             }
         );
         let prefix_anchor =
@@ -131,7 +133,7 @@ impl<'a> NfaGen<'a> {
                 _ => false,
             };
         let init_groups = self.vec_expr(range(0, num_cap_locs),
-                                        |cx, _| cx.expr_none(self.sp));
+                                        ref |cx, _| cx.expr_none(self.sp));
 
         let prefix_lit = Rc::new(Vec::from_slice(self.prog.prefix.as_slice().as_bytes()));
         let prefix_bytes = self.cx.expr_lit(self.sp, ast::LitBinary(prefix_lit));

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -456,7 +456,7 @@ pub mod write {
         let mut llvm_c_strs = Vec::new();
         let mut llvm_args = Vec::new();
         {
-            let add = |arg: &str| {
+            let add = ref |arg: &str| {
                 let s = arg.to_c_str();
                 llvm_args.push(s.as_ptr());
                 llvm_c_strs.push(s);
@@ -750,7 +750,7 @@ pub fn sanitize(s: &str) -> String {
 
             _ => {
                 let mut tstr = String::new();
-                char::escape_unicode(c, |c| tstr.push_char(c));
+                char::escape_unicode(c, ref |c| tstr.push_char(c));
                 result.push_char('$');
                 result.push_str(tstr.as_slice().slice_from(1));
             }
@@ -1292,7 +1292,10 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
 
     // Invoke the system linker
     debug!("{}", &cmd);
-    let prog = time(sess.time_passes(), "running linker", (), |()| cmd.output());
+    let prog = time(sess.time_passes(),
+                    "running linker",
+                    (),
+                    ref |()| cmd.output());
     match prog {
         Ok(prog) => {
             if !prog.status.success() {
@@ -1750,7 +1753,8 @@ fn add_upstream_rust_crates(cmd: &mut Command, sess: &Session,
             let name = name.slice(3, name.len() - 5); // chop off lib/.rlib
             time(sess.time_passes(),
                  format!("altering {}.rlib", name).as_slice(),
-                 (), |()| {
+                 (),
+                 ref |()| {
                 let dst = tmpdir.join(cratepath.filename().unwrap());
                 match fs::copy(&cratepath, &dst) {
                     Ok(..) => {}

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -62,13 +62,13 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         let bc_encoded = time(sess.time_passes(),
                               format!("read {}.bytecode.deflate", name).as_slice(),
                               (),
-                              |_| {
+                              ref |_| {
                                   archive.read(format!("{}.bytecode.deflate",
                                                        file).as_slice())
                               });
         let bc_encoded = bc_encoded.expect("missing compressed bytecode in archive!");
         let bc_extractor = if is_versioned_bytecode_format(bc_encoded) {
-            |_| {
+            ref |_| {
                 // Read the version
                 let version = extract_bytecode_format_version(bc_encoded);
 
@@ -94,7 +94,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         } else {
             // the object must be in the old, pre-versioning format, so simply
             // inflate everything and let LLVM decide if it can make sense of it
-            |_| {
+            ref |_| {
                 match flate::inflate_bytes(bc_encoded) {
                     Some(bc) => bc,
                     None => {
@@ -115,7 +115,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         time(sess.time_passes(),
              format!("ll link {}", name).as_slice(),
              (),
-             |()| unsafe {
+             ref |()| unsafe {
             if !llvm::LLVMRustLinkInExternalBitcode(llmod,
                                                     ptr as *const libc::c_char,
                                                     bc_decoded.len() as libc::size_t) {

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -428,7 +428,7 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
 
 pub fn append_configuration(cfg: &mut ast::CrateConfig,
                             name: InternedString) {
-    if !cfg.iter().any(|mi| mi.name() == name) {
+    if !cfg.iter().any(ref |mi| mi.name() == name) {
         cfg.push(attr::mk_word_item(name))
     }
 }

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -95,7 +95,7 @@ fn run_compiler(args: &[String]) {
     let odir = matches.opt_str("out-dir").map(|o| Path::new(o));
     let ofile = matches.opt_str("o").map(|o| Path::new(o));
 
-    let pretty = matches.opt_default("pretty", "normal").map(|a| {
+    let pretty = matches.opt_default("pretty", "normal").map(ref |a| {
         parse_pretty(&sess, a.as_slice())
     });
     match pretty {

--- a/src/librustc/front/test.rs
+++ b/src/librustc/front/test.rs
@@ -184,11 +184,11 @@ fn mk_reexport_mod(cx: &mut TestCtxt, tests: Vec<ast::Ident>,
     let mut view_items = Vec::new();
     let super_ = token::str_to_ident("super");
 
-    view_items.extend(tests.move_iter().map(|r| {
+    view_items.extend(tests.move_iter().map(ref |r| {
         cx.ext_cx.view_use_simple(DUMMY_SP, ast::Public,
                                   cx.ext_cx.path(DUMMY_SP, vec![super_, r]))
     }));
-    view_items.extend(tested_submods.move_iter().map(|r| {
+    view_items.extend(tested_submods.move_iter().map(ref |r| {
         let path = cx.ext_cx.path(DUMMY_SP, vec![super_, r, cx.reexport_mod_ident]);
         cx.ext_cx.view_use_simple_(DUMMY_SP, ast::Public, r, path)
     }));

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -81,7 +81,7 @@ fn dump_crates(cstore: &CStore) {
 
 fn warn_if_multiple_versions(diag: &SpanHandler, cstore: &CStore) {
     let mut map = HashMap::new();
-    cstore.iter_crate_data(|cnum, data| {
+    cstore.iter_crate_data(ref |cnum, data| {
         map.find_or_insert_with(data.name(), |_| Vec::new()).push(cnum);
     });
 
@@ -280,7 +280,7 @@ fn visit_item(e: &Env, i: &ast::Item) {
 fn existing_match(e: &Env, name: &str,
                   hash: Option<&Svh>) -> Option<ast::CrateNum> {
     let mut ret = None;
-    e.sess.cstore.iter_crate_data(|cnum, data| {
+    e.sess.cstore.iter_crate_data(ref |cnum, data| {
         if data.name().as_slice() != name { return }
 
         match hash {
@@ -301,7 +301,7 @@ fn existing_match(e: &Env, name: &str,
         let source = e.sess.cstore.get_used_crate_source(cnum).unwrap();
         match e.sess.opts.externs.find_equiv(&name) {
             Some(locs) => {
-                let found = locs.iter().any(|l| {
+                let found = locs.iter().any(ref |l| {
                     let l = fs::realpath(&Path::new(l.as_slice())).ok();
                     l == source.dylib || l == source.rlib
                 });
@@ -404,7 +404,7 @@ fn resolve_crate_deps(e: &mut Env,
     debug!("resolving deps of external crate");
     // The map from crate numbers in the crate we're resolving to local crate
     // numbers
-    decoder::get_crate_deps(cdata).iter().map(|dep| {
+    decoder::get_crate_deps(cdata).iter().map(ref |dep| {
         debug!("resolving dep crate {} hash: `{}`", dep.name, dep.hash);
         let (local_cnum, _, _) = resolve_crate(e, root,
                                                dep.name.as_slice(),
@@ -474,7 +474,9 @@ impl<'a> PluginMetadataReader<'a> {
             None => { load_ctxt.report_load_errs(); unreachable!() },
         };
         let macros = decoder::get_exported_macros(library.metadata.as_slice());
-        let registrar = decoder::get_plugin_registrar_fn(library.metadata.as_slice()).map(|id| {
+        let registrar =
+            decoder::get_plugin_registrar_fn(
+                library.metadata.as_slice()).map(ref |id| {
             decoder::get_symbol(library.metadata.as_slice(), id)
         });
         if library.dylib.is_none() && registrar.is_some() {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -386,7 +386,7 @@ impl<'a> Context<'a> {
         let dypair = self.dylibname();
 
         // want: crate_name.dir_part() + prefix + crate_name.file_part + "-"
-        let dylib_prefix = dypair.map(|(prefix, _)| {
+        let dylib_prefix = dypair.map(ref |(prefix, _)| {
             format!("{}{}", prefix, self.crate_name)
         });
         let rlib_prefix = format!("lib{}", self.crate_name);
@@ -406,7 +406,7 @@ impl<'a> Context<'a> {
         // of the crate id (path/name/id).
         //
         // The goal of this step is to look at as little metadata as possible.
-        self.filesearch.search(|path| {
+        self.filesearch.search(ref |path| {
             let file = match path.filename_str() {
                 None => return FileDoesntMatch,
                 Some(file) => file,
@@ -415,7 +415,7 @@ impl<'a> Context<'a> {
                     file.ends_with(".rlib") {
                 (file.slice(rlib_prefix.len(), file.len() - ".rlib".len()),
                  true)
-            } else if dypair.map_or(false, |(_, suffix)| {
+            } else if dypair.map_or(false, ref |(_, suffix)| {
                 file.starts_with(dylib_prefix.get_ref().as_slice()) &&
                 file.ends_with(suffix)
             }) {
@@ -799,7 +799,7 @@ fn get_metadata_section_imp(os: abi::Os, filename: &Path) -> Result<MetadataBlob
                 let cvbuf1 = cvbuf.offset(vlen as int);
                 debug!("inflating {} bytes of compressed metadata",
                        csz - vlen);
-                slice::raw::buf_as_slice(cvbuf1, csz-vlen, |bytes| {
+                slice::raw::buf_as_slice(cvbuf1, csz-vlen, ref |bytes| {
                     match flate::inflate_bytes(bytes) {
                         Some(inflated) => found = Ok(MetadataVec(inflated)),
                         None => {

--- a/src/librustc/middle/borrowck/graphviz.rs
+++ b/src/librustc/middle/borrowck/graphviz.rs
@@ -81,7 +81,7 @@ impl<'a> DataflowLabeller<'a> {
                                      to_lp: |uint| -> Rc<LoanPath>) -> String {
         let mut saw_some = false;
         let mut set = "{".to_string();
-        dfcx.each_bit_for_node(e, cfgidx, |index| {
+        dfcx.each_bit_for_node(e, cfgidx, ref |index| {
             let lp = to_lp(index);
             if saw_some {
                 set.push_str(", ");
@@ -96,7 +96,7 @@ impl<'a> DataflowLabeller<'a> {
 
     fn dataflow_loans_for(&self, e: EntryOrExit, cfgidx: CFGIndex) -> String {
         let dfcx = &self.analysis_data.loans;
-        let loan_index_to_path = |loan_index| {
+        let loan_index_to_path = ref |loan_index| {
             let all_loans = &self.analysis_data.all_loans;
             all_loans.get(loan_index).loan_path()
         };
@@ -105,7 +105,7 @@ impl<'a> DataflowLabeller<'a> {
 
     fn dataflow_moves_for(&self, e: EntryOrExit, cfgidx: CFGIndex) -> String {
         let dfcx = &self.analysis_data.move_data.dfcx_moves;
-        let move_index_to_path = |move_index| {
+        let move_index_to_path = ref |move_index| {
             let move_data = &self.analysis_data.move_data.move_data;
             let moves = move_data.moves.borrow();
             let move = moves.get(move_index);
@@ -116,7 +116,7 @@ impl<'a> DataflowLabeller<'a> {
 
     fn dataflow_assigns_for(&self, e: EntryOrExit, cfgidx: CFGIndex) -> String {
         let dfcx = &self.analysis_data.move_data.dfcx_assign;
-        let assign_index_to_path = |assign_index| {
+        let assign_index_to_path = ref |assign_index| {
             let move_data = &self.analysis_data.move_data.move_data;
             let assignments = move_data.var_assignments.borrow();
             let assignment = assignments.get(assign_index);

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -485,7 +485,7 @@ impl MoveData {
 
         let mut p = self.path_first_child(index);
         while p != InvalidMovePathIndex {
-            if !self.each_extending_path(p, |x| f(x)) {
+            if !self.each_extending_path(p, ref |x| f(x)) {
                 return false;
             }
             p = self.path_next_sibling(p);
@@ -499,7 +499,7 @@ impl MoveData {
                             f: |MoveIndex| -> bool)
                             -> bool {
         let mut ret = true;
-        self.each_extending_path(index0, |index| {
+        self.each_extending_path(index0, ref |index| {
             let mut p = self.path_first_move(index);
             while p != InvalidMoveIndex {
                 if !f(p) {
@@ -591,8 +591,11 @@ impl<'a> FlowedMoveData<'a> {
         //! Returns the kind of a move of `loan_path` by `id`, if one exists.
 
         let mut ret = None;
-        for loan_path_index in self.move_data.path_map.borrow().find(&*loan_path).iter() {
-            self.dfcx_moves.each_gen_bit(id, |move_index| {
+        for loan_path_index in self.move_data
+                                   .path_map
+                                   .borrow()
+                                   .find(&*loan_path).iter() {
+            self.dfcx_moves.each_gen_bit(id, ref |move_index| {
                 let move = self.move_data.moves.borrow();
                 let move = move.get(move_index);
                 if move.path == **loan_path_index {
@@ -637,7 +640,7 @@ impl<'a> FlowedMoveData<'a> {
 
         let mut ret = true;
 
-        self.dfcx_moves.each_bit_on_entry(id, |index| {
+        self.dfcx_moves.each_bit_on_entry(id, ref |index| {
             let move = self.move_data.moves.borrow();
             let move = move.get(index);
             let moved_path = move.path;
@@ -649,7 +652,8 @@ impl<'a> FlowedMoveData<'a> {
                 }
             } else {
                 for &loan_path_index in opt_loan_path_index.iter() {
-                    let cont = self.move_data.each_base_path(moved_path, |p| {
+                    let cont = self.move_data.each_base_path(moved_path,
+                                                             ref |p| {
                         if p == loan_path_index {
                             // Scenario 3: some extension of `loan_path`
                             // was moved
@@ -693,7 +697,7 @@ impl<'a> FlowedMoveData<'a> {
             }
         };
 
-        self.dfcx_assign.each_bit_on_entry(id, |index| {
+        self.dfcx_assign.each_bit_on_entry(id, ref |index| {
             let assignment = self.move_data.var_assignments.borrow();
             let assignment = assignment.get(index);
             if assignment.path == loan_path_index && !f(assignment) {

--- a/src/librustc/middle/cfg/graphviz.rs
+++ b/src/librustc/middle/cfg/graphviz.rs
@@ -94,7 +94,7 @@ impl<'a> dot::Labeller<'a, Node<'a>, Edge<'a>> for LabelledCFG<'a> {
 impl<'a> dot::GraphWalk<'a, Node<'a>, Edge<'a>> for &'a cfg::CFG {
     fn nodes(&self) -> dot::Nodes<'a, Node<'a>> {
         let mut v = Vec::new();
-        self.graph.each_node(|i, nd| { v.push((i, nd)); true });
+        self.graph.each_node(ref |i, nd| { v.push((i, nd)); true });
         dot::maybe_owned_vec::Growable(v)
     }
     fn edges(&self) -> dot::Edges<'a, Edge<'a>> {

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -146,9 +146,13 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr, is_const: bool) {
           ExprBlock(ref block) => {
             // Check all statements in the block
             for stmt in block.stmts.iter() {
-                let block_span_err = |span|
-                    span_err!(v.tcx.sess, span, E0016,
-                        "blocks in constants are limited to items and tail expressions");
+                let block_span_err = ref |span| {
+                    span_err!(v.tcx.sess,
+                              span,
+                              E0016,
+                              "blocks in constants are limited to items and \
+                               tail expressions")
+                };
                 match stmt.node {
                     StmtDecl(ref span, _) => {
                         match span.node {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -59,7 +59,7 @@ impl fmt::Show for Matrix {
 
         let column_count = m.iter().map(|row| row.len()).max().unwrap_or(0u);
         assert!(m.iter().all(|row| row.len() == column_count));
-        let column_widths: Vec<uint> = range(0, column_count).map(|col| {
+        let column_widths: Vec<uint> = range(0, column_count).map(ref |col| {
             pretty_printed_matrix.iter().map(|row| row.get(col).len()).max().unwrap_or(0u)
         }).collect();
 
@@ -162,7 +162,7 @@ fn check_expr(cx: &mut MatchCheckCtxt, ex: &Expr) {
             let mut static_inliner = StaticInliner::new(cx.tcx);
             let inlined_arms = arms
                 .iter()
-                .map(|arm| Arm {
+                .map(ref |arm| Arm {
                     pats: arm.pats.iter().map(|pat| {
                         static_inliner.fold_pat(*pat)
                     }).collect(),
@@ -574,7 +574,7 @@ fn is_useful(cx: &MatchCheckCtxt,
 fn is_useful_specialized(cx: &MatchCheckCtxt, &Matrix(ref m): &Matrix, v: &[Gc<Pat>],
                          ctor: Constructor, lty: ty::t, witness: WitnessPreference) -> Usefulness {
     let arity = constructor_arity(cx, &ctor, lty);
-    let matrix = Matrix(m.iter().filter_map(|r| {
+    let matrix = Matrix(m.iter().filter_map(ref |r| {
         specialize(cx, r.as_slice(), &ctor, 0u, arity)
     }).collect());
     match specialize(cx, v, &ctor, 0u, arity) {
@@ -906,7 +906,7 @@ fn check_legality_of_move_bindings(cx: &MatchCheckCtxt,
     let def_map = &tcx.def_map;
     let mut by_ref_span = None;
     for pat in pats.iter() {
-        pat_bindings(def_map, &**pat, |bm, _, span, _path| {
+        pat_bindings(def_map, &**pat, ref |bm, _, span, _path| {
             match bm {
                 BindByRef(_) => {
                     by_ref_span = Some(span);
@@ -933,7 +933,7 @@ fn check_legality_of_move_bindings(cx: &MatchCheckCtxt,
     };
 
     for pat in pats.iter() {
-        walk_pat(&**pat, |p| {
+        walk_pat(&**pat, ref |p| {
             if pat_is_binding(def_map, &*p) {
                 match p.node {
                     PatIdent(BindByValue(_), _, sub) => {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -204,7 +204,7 @@ impl<'a> ConstEvalVisitor<'a> {
 
             ast::ExprTup(ref es) |
             ast::ExprVec(ref es) =>
-                join_all(es.iter().map(|e| self.classify(&**e))),
+                join_all(es.iter().map(ref |e| self.classify(&**e))),
 
             ast::ExprVstore(ref e, vstore) => {
                 match vstore {
@@ -215,7 +215,7 @@ impl<'a> ConstEvalVisitor<'a> {
             }
 
             ast::ExprStruct(_, ref fs, None) => {
-                let cs = fs.iter().map(|f| self.classify(&*f.expr));
+                let cs = fs.iter().map(ref |f| self.classify(&*f.expr));
                 join_all(cs)
             }
 

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -152,7 +152,7 @@ fn build_nodeid_to_index(decl: Option<&ast::FnDecl>,
         Some(decl) => add_entries_from_fn_decl(&mut index, decl, cfg.entry)
     }
 
-    cfg.graph.each_node(|node_idx, node| {
+    cfg.graph.each_node(ref |node_idx, node| {
         if node.data.id != ast::DUMMY_NODE_ID {
             index.insert(node.data.id, node_idx);
         }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -195,11 +195,18 @@ impl<'a> MarkSymbolVisitor<'a> {
             ast_map::NodeItem(item) => {
                 match item.node {
                     ast::ItemStruct(..) => {
-                        let has_extern_repr = item.attrs.iter().fold(attr::ReprAny, |acc, attr| {
-                            attr::find_repr_attr(self.tcx.sess.diagnostic(), attr, acc)
+                        let has_extern_repr = item.attrs
+                                                  .iter()
+                                                  .fold(attr::ReprAny,
+                                                        ref |acc, attr| {
+                            attr::find_repr_attr(self.tcx.sess.diagnostic(),
+                                                 attr,
+                                                 acc)
                         }) == attr::ReprExtern;
 
-                        visit::walk_item(self, &*item, MarkSymbolVisitorContext {
+                        visit::walk_item(self,
+                                         &*item,
+                                         MarkSymbolVisitorContext {
                             struct_has_extern_repr: has_extern_repr,
                             ..(ctxt)
                         });
@@ -449,7 +456,7 @@ impl<'a> DeadVisitor<'a> {
                       ctor_id: Option<ast::NodeId>) -> bool {
         if self.live_symbols.contains(&id)
            || ctor_id.map_or(false,
-                             |ctor| self.live_symbols.contains(&ctor)) {
+                             ref |ctor| self.live_symbols.contains(&ctor)) {
             return true;
         }
         // If it's a type whose methods are live, then it's live, too.

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -132,7 +132,7 @@ fn calculate_type(sess: &session::Session,
     // Sweep all crates for found dylibs. Add all dylibs, as well as their
     // dependencies, ensuring there are no conflicts. The only valid case for a
     // dependency to be relied upon twice is for both cases to rely on a dylib.
-    sess.cstore.iter_crate_data(|cnum, data| {
+    sess.cstore.iter_crate_data(ref |cnum, data| {
         let src = sess.cstore.get_used_crate_source(cnum).unwrap();
         if src.dylib.is_some() {
             add_library(sess, cnum, cstore::RequireDynamic, &mut formats);
@@ -147,7 +147,7 @@ fn calculate_type(sess: &session::Session,
     });
 
     // Collect what we've got so far in the return vector.
-    let mut ret = range(1, sess.cstore.next_crate_num()).map(|i| {
+    let mut ret = range(1, sess.cstore.next_crate_num()).map(ref |i| {
         match formats.find(&i).map(|v| *v) {
             v @ Some(cstore::RequireDynamic) => v,
             _ => None,
@@ -156,7 +156,7 @@ fn calculate_type(sess: &session::Session,
 
     // Run through the dependency list again, and add any missing libraries as
     // static libraries.
-    sess.cstore.iter_crate_data(|cnum, data| {
+    sess.cstore.iter_crate_data(ref |cnum, data| {
         let src = sess.cstore.get_used_crate_source(cnum).unwrap();
         if src.dylib.is_none() && !formats.contains_key(&cnum) {
             assert!(src.rlib.is_some());
@@ -223,8 +223,9 @@ fn add_library(sess: &session::Session,
 
 fn attempt_static(sess: &session::Session) -> Option<DependencyList> {
     let crates = sess.cstore.get_used_crates(cstore::RequireStatic);
-    if crates.iter().all(|&(_, ref p)| p.is_some()) {
-        Some(crates.move_iter().map(|_| Some(cstore::RequireStatic)).collect())
+    if crates.iter().all(ref |&(_, ref p)| p.is_some()) {
+        Some(crates.move_iter()
+                   .map(ref |_| Some(cstore::RequireStatic)).collect())
     } else {
         None
     }

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -81,7 +81,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
     match item.node {
         ItemFn(..) => {
             if item.ident.name == ctxt.main_name {
-                 ctxt.ast_map.with_path(item.id, |mut path| {
+                 ctxt.ast_map.with_path(item.id, ref |mut path| {
                         if path.count() == 1 {
                             // This is a top-level function so can be 'main'
                             if ctxt.main_fn.is_none() {

--- a/src/librustc/middle/freevars.rs
+++ b/src/librustc/middle/freevars.rs
@@ -63,14 +63,11 @@ impl<'a> Visitor<int> for CollectFreevarsVisitor<'a> {
                 self.capture_mode_map.insert(expr.id, CaptureByValue);
                 visit::walk_expr(self, expr, depth + 1)
             }
-            ast::ExprFnBlock(_, _, _) => {
-                // NOTE(stage0): After snapshot, change to:
-                //
-                //let capture_mode = match capture_clause {
-                //    ast::CaptureByValue => CaptureByValue,
-                //    ast::CaptureByRef => CaptureByRef,
-                //};
-                let capture_mode = CaptureByRef;
+            ast::ExprFnBlock(capture_clause, _, _) => {
+                let capture_mode = match capture_clause {
+                    ast::CaptureByValue => CaptureByValue,
+                    ast::CaptureByRef => CaptureByRef,
+                };
                 self.capture_mode_map.insert(expr.id, capture_mode);
                 visit::walk_expr(self, expr, depth + 1)
             }

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -338,7 +338,7 @@ mod test {
     fn each_node() {
         let graph = create_graph();
         let expected = ["A", "B", "C", "D", "E", "F"];
-        graph.each_node(|idx, node| {
+        graph.each_node(ref |idx, node| {
             assert_eq!(&expected[idx.get()], graph.node_data(idx));
             assert_eq!(expected[idx.get()], node.data);
             true
@@ -349,7 +349,7 @@ mod test {
     fn each_edge() {
         let graph = create_graph();
         let expected = ["AB", "BC", "BD", "DE", "EC", "FB"];
-        graph.each_edge(|idx, edge| {
+        graph.each_edge(ref |idx, edge| {
             assert_eq!(&expected[idx.get()], graph.edge_data(idx));
             assert_eq!(expected[idx.get()], edge.data);
             true
@@ -364,7 +364,7 @@ mod test {
         assert!(graph.node_data(start_index) == &start_data);
 
         let mut counter = 0;
-        graph.each_incoming_edge(start_index, |edge_index, edge| {
+        graph.each_incoming_edge(start_index, ref |edge_index, edge| {
             assert!(graph.edge_data(edge_index) == &edge.data);
             assert!(counter < expected_incoming.len());
             debug!("counter={:?} expected={:?} edge_index={:?} edge={:?}",
@@ -382,7 +382,7 @@ mod test {
         assert_eq!(counter, expected_incoming.len());
 
         let mut counter = 0;
-        graph.each_outgoing_edge(start_index, |edge_index, edge| {
+        graph.each_outgoing_edge(start_index, ref |edge_index, edge| {
             assert!(graph.edge_data(edge_index) == &edge.data);
             assert!(counter < expected_outgoing.len());
             debug!("counter={:?} expected={:?} edge_index={:?} edge={:?}",

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -26,7 +26,7 @@ use syntax::visit;
 fn type_size_is_affected_by_type_parameters(tcx: &ty::ctxt, typ: ty::t)
                                             -> bool {
     let mut result = false;
-    ty::maybe_walk_ty(typ, |typ| {
+    ty::maybe_walk_ty(typ, ref |typ| {
         match ty::get(typ).sty {
             ty::ty_box(_) | ty::ty_uniq(_) | ty::ty_ptr(_) |
             ty::ty_rptr(..) | ty::ty_bare_fn(..) | ty::ty_closure(..) => {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -171,8 +171,10 @@ impl<'a> LanguageItemCollector<'a> {
 
     pub fn collect_external_language_items(&mut self) {
         let crate_store = &self.session.cstore;
-        crate_store.iter_crate_data(|crate_number, _crate_metadata| {
-            each_lang_item(crate_store, crate_number, |node_id, item_index| {
+        crate_store.iter_crate_data(ref |crate_number, _crate_metadata| {
+            each_lang_item(crate_store,
+                           crate_number,
+                           ref |node_id, item_index| {
                 let def_id = ast::DefId { krate: crate_number, node: node_id };
                 self.collect_item(item_index, def_id, DUMMY_SP);
                 true

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1079,7 +1079,9 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
                                 pat, downcast_cmt.clone(), subpat_ty,
                                 InteriorField(PositionalField(i)));
 
-                        if_ok!(self.cat_pattern(subcmt, &**subpat, |x,y,z| op(x,y,z)));
+                        if_ok!(self.cat_pattern(subcmt,
+                                                &**subpat,
+                                                ref |x,y,z| op(x,y,z)));
                     }
                 }
                 Some(&def::DefFn(..)) |
@@ -1090,13 +1092,16 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
                             self.cat_imm_interior(
                                 pat, cmt.clone(), subpat_ty,
                                 InteriorField(PositionalField(i)));
-                        if_ok!(self.cat_pattern(cmt_field, &**subpat,
-                                                |x,y,z| op(x,y,z)));
+                        if_ok!(self.cat_pattern(cmt_field,
+                                                &**subpat,
+                                                ref |x,y,z| op(x,y,z)));
                     }
                 }
                 Some(&def::DefStatic(..)) => {
                     for subpat in subpats.iter() {
-                        if_ok!(self.cat_pattern(cmt.clone(), &**subpat, |x,y,z| op(x,y,z)));
+                        if_ok!(self.cat_pattern(cmt.clone(),
+                                                &**subpat,
+                                                ref |x,y,z| op(x,y,z)));
                     }
                 }
                 _ => {
@@ -1120,7 +1125,9 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
             for fp in field_pats.iter() {
                 let field_ty = if_ok!(self.pat_ty(&*fp.pat)); // see (*2)
                 let cmt_field = self.cat_field(pat, cmt.clone(), fp.ident, field_ty);
-                if_ok!(self.cat_pattern(cmt_field, &*fp.pat, |x,y,z| op(x,y,z)));
+                if_ok!(self.cat_pattern(cmt_field,
+                                        &*fp.pat,
+                                        ref |x,y,z| op(x,y,z)));
             }
           }
 
@@ -1132,7 +1139,9 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
                     self.cat_imm_interior(
                         pat, cmt.clone(), subpat_ty,
                         InteriorField(PositionalField(i)));
-                if_ok!(self.cat_pattern(subcmt, &**subpat, |x,y,z| op(x,y,z)));
+                if_ok!(self.cat_pattern(subcmt,
+                                        &**subpat,
+                                        ref |x,y,z| op(x,y,z)));
             }
           }
 
@@ -1145,16 +1154,21 @@ impl<'t,TYPER:Typer> MemCategorizationContext<'t,TYPER> {
           ast::PatVec(ref before, slice, ref after) => {
               let elt_cmt = self.cat_index(pat, cmt, 0);
               for before_pat in before.iter() {
-                  if_ok!(self.cat_pattern(elt_cmt.clone(), &**before_pat,
-                                          |x,y,z| op(x,y,z)));
+                  if_ok!(self.cat_pattern(elt_cmt.clone(),
+                                          &**before_pat,
+                                          ref |x,y,z| op(x,y,z)));
               }
               for slice_pat in slice.iter() {
                   let slice_ty = if_ok!(self.pat_ty(&**slice_pat));
                   let slice_cmt = self.cat_rvalue_node(pat.id(), pat.span(), slice_ty);
-                  if_ok!(self.cat_pattern(slice_cmt, &**slice_pat, |x,y,z| op(x,y,z)));
+                  if_ok!(self.cat_pattern(slice_cmt,
+                                          &**slice_pat,
+                                          ref |x,y,z| op(x,y,z)));
               }
               for after_pat in after.iter() {
-                  if_ok!(self.cat_pattern(elt_cmt.clone(), &**after_pat, |x,y,z| op(x,y,z)));
+                  if_ok!(self.cat_pattern(elt_cmt.clone(),
+                                          &**after_pat,
+                                          ref |x,y,z| op(x,y,z)));
               }
           }
 

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -25,7 +25,7 @@ pub type PatIdMap = HashMap<Ident, NodeId>;
 // use the NodeId of their namesake in the first pattern.
 pub fn pat_id_map(dm: &resolve::DefMap, pat: &Pat) -> PatIdMap {
     let mut map = HashMap::new();
-    pat_bindings(dm, pat, |_bm, p_id, _s, path1| {
+    pat_bindings(dm, pat, ref |_bm, p_id, _s, path1| {
       map.insert(path1.node, p_id);
     });
     map
@@ -93,7 +93,7 @@ pub fn pat_bindings(dm: &resolve::DefMap,
 /// an ident, e.g. `foo`, or `Foo(foo)` or `foo @ Bar(..)`.
 pub fn pat_contains_bindings(dm: &resolve::DefMap, pat: &Pat) -> bool {
     let mut contains_bindings = false;
-    walk_pat(pat, |p| {
+    walk_pat(pat, ref |p| {
         if pat_is_binding(dm, p) {
             contains_bindings = true;
             false // there's at least one binding, can short circuit now.

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -255,7 +255,7 @@ impl<'a> Visitor<()> for EmbargoVisitor<'a> {
                     _ => true,
                 };
                 let tr = ty::impl_trait_ref(self.tcx, local_def(item.id));
-                let public_trait = tr.clone().map_or(false, |tr| {
+                let public_trait = tr.clone().map_or(false, ref |tr| {
                     !is_local(tr.def_id) ||
                      self.exported_items.contains(&tr.def_id.node)
                 });
@@ -686,8 +686,8 @@ impl<'a> PrivacyVisitor<'a> {
     fn check_path(&mut self, span: Span, path_id: ast::NodeId, path: &ast::Path) {
         debug!("privacy - path {}", self.nodestr(path_id));
         let orig_def = self.tcx.def_map.borrow().get_copy(&path_id);
-        let ck = |tyname: &str| {
-            let ck_public = |def: ast::DefId| {
+        let ck = ref |tyname: &str| {
+            let ck_public = ref |def: ast::DefId| {
                 let name = token::get_ident(path.segments
                                                 .last()
                                                 .unwrap()
@@ -862,9 +862,9 @@ impl<'a> Visitor<()> for PrivacyVisitor<'a> {
                 }
             }
             ast::ExprPath(..) => {
-                let guard = |did: ast::DefId| {
+                let guard = ref |did: ast::DefId| {
                     let fields = ty::lookup_struct_fields(self.tcx, did);
-                    let any_priv = fields.iter().any(|f| {
+                    let any_priv = fields.iter().any(ref |f| {
                         f.vis != ast::Public && (
                             !is_local(f.id) ||
                             !self.private_accessible(f.id.node))
@@ -1322,7 +1322,7 @@ impl<'a> Visitor<()> for VisiblePrivateTypesVisitor<'a> {
                 // `true` iff this is `impl Private for ...`.
                 let not_private_trait =
                     trait_ref.as_ref().map_or(true, // no trait counts as public trait
-                                              |tr| {
+                                              ref |tr| {
                         let did = ty::trait_ref_to_def_id(self.tcx, tr);
 
                         !is_local(did) || self.trait_is_public(did.node)
@@ -1339,7 +1339,7 @@ impl<'a> Visitor<()> for VisiblePrivateTypesVisitor<'a> {
                 let trait_or_some_public_method =
                     trait_ref.is_some() ||
                     impl_items.iter()
-                              .any(|impl_item| {
+                              .any(ref |impl_item| {
                                   match *impl_item {
                                       ast::MethodImplItem(m) => {
                                           self.exported_items.contains(&m.id)

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1995,7 +1995,7 @@ impl<'a> Resolver<'a> {
 
         csearch::each_child_of_item(&self.session.cstore,
                                     def_id,
-                                    |def_like, child_ident, visibility| {
+                                    ref |def_like, child_ident, visibility| {
             debug!("(populating external module) ... found ident: {}",
                    token::get_ident(child_ident));
             self.build_reduced_graph_for_external_crate_def(module.clone(),
@@ -4504,7 +4504,7 @@ impl<'a> Resolver<'a> {
     // user and one 'x' came from the macro.
     fn binding_mode_map(&mut self, pat: &Pat) -> BindingMap {
         let mut result = HashMap::new();
-        pat_bindings(&self.def_map, pat, |binding_mode, _id, sp, path1| {
+        pat_bindings(&self.def_map, pat, ref |binding_mode, _id, sp, path1| {
             let name = mtwt::resolve(path1.node);
             result.insert(name,
                           binding_info {span: sp,
@@ -4686,7 +4686,7 @@ impl<'a> Resolver<'a> {
             }
 
             TyClosure(c, _) | TyProc(c) => {
-                c.bounds.as_ref().map(|bounds| {
+                c.bounds.as_ref().map(ref |bounds| {
                     for bound in bounds.iter() {
                         self.resolve_type_parameter_bound(ty.id, bound);
                     }
@@ -5528,7 +5528,11 @@ impl<'a> Resolver<'a> {
                             }
                             _ => {
                                 let mut method_scope = false;
-                                self.value_ribs.borrow().iter().rev().all(|rib| {
+                                self.value_ribs
+                                    .borrow()
+                                    .iter()
+                                    .rev()
+                                    .all(ref |rib| {
                                     let res = match *rib {
                                         Rib { bindings: _, kind: MethodRibKind(_, _) } => true,
                                         Rib { bindings: _, kind: ItemRibKind } => false,
@@ -5796,7 +5800,9 @@ impl<'a> Resolver<'a> {
         assert!(match lp {LastImport{..} => false, _ => true},
                 "Import should only be used for `use` directives");
         self.last_private.insert(node_id, lp);
-        self.def_map.borrow_mut().insert_or_update_with(node_id, def, |_, old_value| {
+        self.def_map
+            .borrow_mut()
+            .insert_or_update_with(node_id, def, ref |_, old_value| {
             // Resolve appears to "resolve" the same ID multiple
             // times, so here is a sanity check it at least comes to
             // the same conclusion! - nmatsakis

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -90,7 +90,7 @@ impl <'l> DxrVisitor<'l> {
         self.fmt.crate_str(krate.span, name);
 
         // dump info about all the external crates referenced from this crate
-        self.sess.cstore.iter_crate_data(|n, cmd| {
+        self.sess.cstore.iter_crate_data(ref |n, cmd| {
             self.fmt.external_crate_str(krate.span, cmd.name.as_slice(), n);
         });
         self.fmt.recorder.record("end_external_crates\n");
@@ -774,7 +774,7 @@ impl <'l> DxrVisitor<'l> {
                                                  .borrow();
                             Some(impl_items.get(&def_id)
                                            .iter()
-                                           .find(|mr| {
+                                           .find(ref |mr| {
                                             match **mr {
                                                 ty::MethodTraitItemId(mr) => {
                                                     ty::impl_or_trait_item(

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -89,7 +89,7 @@ impl Visitor<Option<Stability>> for Annotator {
 
     fn visit_struct_def(&mut self, s: &StructDef, _: Ident, _: &Generics,
                         _: NodeId, parent: Option<Stability>) {
-        s.ctor_id.map(|id| self.annotate(id, &[], parent.clone()));
+        s.ctor_id.map(ref |id| self.annotate(id, &[], parent.clone()));
         visit::walk_struct_def(self, s, parent)
     }
 

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -452,9 +452,9 @@ impl<T> VecPerParamSpace<T> {
         // Vec's, but note that the values of type_limit and self_limit
         // also need to be kept in sync during construction.
         VecPerParamSpace::new(
-            self.get_slice(TypeSpace).iter().map(|p| pred(p)).collect(),
-            self.get_slice(SelfSpace).iter().map(|p| pred(p)).collect(),
-            self.get_slice(FnSpace).iter().map(|p| pred(p)).collect())
+            self.get_slice(TypeSpace).iter().map(ref |p| pred(p)).collect(),
+            self.get_slice(SelfSpace).iter().map(ref |p| pred(p)).collect(),
+            self.get_slice(FnSpace).iter().map(ref |p| pred(p)).collect())
     }
 
     pub fn map_rev<U>(&self, pred: |&T| -> U) -> VecPerParamSpace<U> {
@@ -467,16 +467,28 @@ impl<T> VecPerParamSpace<T> {
          * can be run to a fixed point
          */
 
-        let mut fns: Vec<U> = self.get_slice(FnSpace).iter().rev().map(|p| pred(p)).collect();
+        let mut fns: Vec<U> = self.get_slice(FnSpace)
+                                  .iter()
+                                  .rev()
+                                  .map(ref |p| pred(p))
+                                  .collect();
 
         // NB: Calling foo.rev().map().rev() causes the calls to map
         // to occur in the wrong order. This was somewhat surprising
         // to me, though it makes total sense.
         fns.reverse();
 
-        let mut selfs: Vec<U> = self.get_slice(SelfSpace).iter().rev().map(|p| pred(p)).collect();
+        let mut selfs: Vec<U> = self.get_slice(SelfSpace)
+                                    .iter()
+                                    .rev()
+                                    .map(ref |p| pred(p))
+                                    .collect();
         selfs.reverse();
-        let mut tys: Vec<U> = self.get_slice(TypeSpace).iter().rev().map(|p| pred(p)).collect();
+        let mut tys: Vec<U> = self.get_slice(TypeSpace)
+                                  .iter()
+                                  .rev()
+                                  .map(ref |p| pred(p))
+                                  .collect();
         tys.reverse();
         VecPerParamSpace::new(tys, selfs, fns)
     }
@@ -486,14 +498,14 @@ impl<T> VecPerParamSpace<T> {
         // one would suffice.  i.e. change to use `move_iter`.
         let VecPerParamSpace { type_limit, self_limit, content } = self;
         let mut i = 0;
-        let (prefix, fn_vec) = content.partition(|_| {
+        let (prefix, fn_vec) = content.partition(ref |_| {
             let on_left = i < self_limit;
             i += 1;
             on_left
         });
 
         let mut i = 0;
-        let (type_vec, self_vec) = prefix.partition(|_| {
+        let (type_vec, self_vec) = prefix.partition(ref |_| {
             let on_left = i < type_limit;
             i += 1;
             on_left

--- a/src/librustc/middle/trans/asm.rs
+++ b/src/librustc/middle/trans/asm.rs
@@ -37,7 +37,7 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
     let temp_scope = fcx.push_custom_cleanup_scope();
 
     // Prepare the output operands
-    let outputs = ia.outputs.iter().map(|&(ref c, ref out)| {
+    let outputs = ia.outputs.iter().map(ref |&(ref c, ref out)| {
         constraints.push((*c).clone());
 
         let out_datum = unpack_datum!(bcx, expr::trans(bcx, &**out));
@@ -47,7 +47,7 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
     }).collect::<Vec<_>>();
 
     // Now the input operands
-    let inputs = ia.inputs.iter().map(|&(ref c, ref input)| {
+    let inputs = ia.inputs.iter().map(ref |&(ref c, ref input)| {
         constraints.push((*c).clone());
 
         let in_datum = unpack_datum!(bcx, expr::trans(bcx, &**input));
@@ -103,8 +103,8 @@ pub fn trans_inline_asm<'a>(bcx: &'a Block<'a>, ia: &ast::InlineAsm)
         ast::AsmIntel => llvm::AD_Intel
     };
 
-    let r = ia.asm.get().with_c_str(|a| {
-        constraints.as_slice().with_c_str(|c| {
+    let r = ia.asm.get().with_c_str(ref |a| {
+        constraints.as_slice().with_c_str(ref |c| {
             InlineAsmCall(bcx,
                           a,
                           c,

--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -30,7 +30,7 @@ pub fn terminate(cx: &Block, _: &str) {
 
 pub fn check_not_terminated(cx: &Block) {
     if cx.terminated.get() {
-        fail!("already terminated!");
+        fail!("block {} already terminated!", cx.to_str());
     }
 }
 
@@ -122,7 +122,9 @@ pub fn Invoke(cx: &Block,
     terminate(cx, "Invoke");
     debug!("Invoke({} with arguments ({}))",
            cx.val_to_string(fn_),
-           args.iter().map(|a| cx.val_to_string(*a)).collect::<Vec<String>>().connect(", "));
+           args.iter()
+               .map(ref |a| cx.val_to_string(*a))
+               .collect::<Vec<String>>().connect(", "));
     B(cx).invoke(fn_, args, then, catch, attributes)
 }
 

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -395,7 +395,7 @@ pub fn trans_unboxing_shim(bcx: &Block,
     bcx = trans_call_inner(bcx,
                            None,
                            function_type,
-                           |bcx, _| {
+                           ref |bcx, _| {
                                Callee {
                                    bcx: bcx,
                                    data: Fn(llshimmedfn),
@@ -647,7 +647,7 @@ pub fn trans_call<'a>(
     trans_call_inner(in_cx,
                      Some(common::expr_info(call_ex)),
                      expr_ty(in_cx, f),
-                     |cx, _| trans(cx, f),
+                     ref |cx, _| trans(cx, f),
                      args,
                      Some(dest)).bcx
 }
@@ -667,8 +667,11 @@ pub fn trans_method_call<'a>(
         bcx,
         Some(common::expr_info(call_ex)),
         monomorphize_type(bcx, method_ty),
-        |cx, arg_cleanup_scope| {
-            meth::trans_method_callee(cx, method_call, Some(rcvr), arg_cleanup_scope)
+        ref |cx, arg_cleanup_scope| {
+            meth::trans_method_callee(cx,
+                                      method_call,
+                                      Some(rcvr),
+                                      arg_cleanup_scope)
         },
         args,
         Some(dest)).bcx
@@ -688,7 +691,7 @@ pub fn trans_lang_call<'a>(
     callee::trans_call_inner(bcx,
                              None,
                              fty,
-                             |bcx, _| {
+                             ref |bcx, _| {
                                 trans_fn_ref_with_vtables_to_callee(bcx,
                                                                     did,
                                                                     0,
@@ -876,7 +879,7 @@ pub fn trans_call_inner<'a>(
 
         let mut llargs = Vec::new();
         let arg_tys = match args {
-            ArgExprs(a) => a.iter().map(|x| expr_ty(bcx, &**x)).collect(),
+            ArgExprs(a) => a.iter().map(ref |x| expr_ty(bcx, &**x)).collect(),
             _ => fail!("expected arg exprs.")
         };
         bcx = trans_args(bcx,
@@ -969,7 +972,7 @@ fn trans_args_under_call_abi<'a>(
             for i in range(0, field_types.len()) {
                 let arg_datum = tuple_lvalue_datum.get_element(
                     *field_types.get(i),
-                    |srcval| {
+                    ref |srcval| {
                         adt::trans_field_ptr(bcx, repr_ptr, srcval, 0, i)
                     });
                 let arg_datum = arg_datum.to_expr_datum();

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -538,7 +538,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
 
               expr::with_field_tys(tcx, ety, Some(e.id), |discr, field_tys| {
                   let (cs, inlineable) = vec::unzip(field_tys.iter().enumerate()
-                      .map(|(ix, &field_ty)| {
+                      .map(ref |(ix, &field_ty)| {
                       match fs.iter().find(|f| field_ty.ident.name == f.ident.node.name) {
                           Some(ref f) => const_expr(cx, &*f.expr, is_local),
                           None => {

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -309,14 +309,14 @@ pub fn trans_for<'a>(
                                                   false,
                                                   option_cleanup_scope_id,
                                                   (),
-                                                  |(), bcx, lloption| {
+                                                  ref |(), bcx, lloption| {
         let Result {
             bcx: bcx,
             val: _
         } = callee::trans_call_inner(bcx,
                                      Some(loop_info),
                                      method_type,
-                                     |bcx, arg_cleanup_scope| {
+                                     ref |bcx, arg_cleanup_scope| {
                                          meth::trans_method_callee(
                                              bcx,
                                              method_call,

--- a/src/librustc/middle/trans/datum.rs
+++ b/src/librustc/middle/trans/datum.rs
@@ -322,7 +322,7 @@ impl Datum<Rvalue> {
             ByValue => {
                 lvalue_scratch_datum(
                     bcx, self.ty, name, false, scope, self,
-                    |this, bcx, llval| this.store_to(bcx, llval))
+                    ref |this, bcx, llval| this.store_to(bcx, llval))
             }
         }
     }
@@ -386,8 +386,8 @@ impl Datum<Expr> {
          */
 
         self.match_kind(
-            |d| d,
-            |_| bcx.sess().bug("assert_lvalue given rvalue"))
+            ref |d| d,
+            ref |_| bcx.sess().bug("assert_lvalue given rvalue"))
     }
 
     pub fn assert_rvalue(self, bcx: &Block) -> Datum<Rvalue> {
@@ -396,8 +396,8 @@ impl Datum<Expr> {
          */
 
         self.match_kind(
-            |_| bcx.sess().bug("assert_rvalue given lvalue"),
-            |r| r)
+            ref |_| bcx.sess().bug("assert_rvalue given lvalue"),
+            ref |r| r)
     }
 
     pub fn store_to_dest<'a>(self,
@@ -425,8 +425,8 @@ impl Datum<Expr> {
          */
 
         self.match_kind(
-            |_| { /* Nothing to do, cleanup already arranged */ },
-            |r| {
+            ref |_| { /* Nothing to do, cleanup already arranged */ },
+            ref |r| {
                 let scope = cleanup::temporary_scope(bcx.tcx(), expr_id);
                 r.add_clean(bcx.fcx, scope);
             })
@@ -451,8 +451,8 @@ impl Datum<Expr> {
                                expr_id: ast::NodeId)
                                -> DatumBlock<'a, Lvalue> {
         self.match_kind(
-            |l| DatumBlock::new(bcx, l),
-            |r| {
+            ref |l| DatumBlock::new(bcx, l),
+            ref |r| {
                 let scope = cleanup::temporary_scope(bcx.tcx(), expr_id);
                 r.to_lvalue_datum_in_scope(bcx, name, scope)
             })
@@ -468,7 +468,7 @@ impl Datum<Expr> {
          */
 
         self.match_kind(
-            |l| {
+            ref |l| {
                 let mut bcx = bcx;
                 match l.appropriate_rvalue_mode(bcx.ccx()) {
                     ByRef => {
@@ -483,7 +483,7 @@ impl Datum<Expr> {
                     }
                 }
             },
-            |r| DatumBlock::new(bcx, r))
+            ref |r| DatumBlock::new(bcx, r))
     }
 
 }

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1265,8 +1265,10 @@ pub fn create_function_debug_context(cx: &CrateContext,
 
     let is_local_to_unit = is_node_local_to_unit(cx, fn_ast_id);
 
-    let fn_metadata = function_name.as_slice().with_c_str(|function_name| {
-                          linkage_name.as_slice().with_c_str(|linkage_name| {
+    let fn_metadata = function_name.as_slice()
+                                   .with_c_str(ref |function_name| {
+                          linkage_name.as_slice()
+                                      .with_c_str(ref |linkage_name| {
             unsafe {
                 llvm::LLVMDIBuilderCreateFunction(
                     DIB(cx),
@@ -1549,7 +1551,7 @@ fn declare_local(bcx: &Block,
         CapturedVariable => (0, DW_TAG_auto_variable)
     };
 
-    let (var_alloca, var_metadata) = name.get().with_c_str(|name| {
+    let (var_alloca, var_metadata) = name.get().with_c_str(ref |name| {
         match variable_access {
             DirectVariable { alloca } => (
                 alloca,
@@ -2352,7 +2354,9 @@ fn prepare_enum_metadata(cx: &CrateContext,
                                                                     codemap::DUMMY_SP);
                 let discriminant_name = get_enum_discriminant_name(cx, enum_def_id);
 
-                let discriminant_type_metadata = discriminant_name.get().with_c_str(|name| {
+                let discriminant_type_metadata =
+                        discriminant_name.get()
+                                         .with_c_str(ref |name| {
                     unsafe {
                         llvm::LLVMDIBuilderCreateEnumerationType(
                             DIB(cx),
@@ -3276,7 +3280,7 @@ fn populate_scope_map(cx: &CrateContext,
     // Push argument identifiers onto the stack so arguments integrate nicely
     // with variable shadowing.
     for &arg_pat in arg_pats.iter() {
-        pat_util::pat_bindings(def_map, &*arg_pat, |_, _, _, path1| {
+        pat_util::pat_bindings(def_map, &*arg_pat, ref |_, _, _, path1| {
             scope_stack.push(ScopeStackEntry { scope_metadata: fn_metadata,
                                                ident: Some(path1.node) });
         })

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -669,7 +669,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
         // Array for the arguments we will pass to the rust function.
         let mut llrust_args = Vec::new();
         let mut next_foreign_arg_counter: c_uint = 0;
-        let next_foreign_arg: |pad: bool| -> c_uint = |pad: bool| {
+        let next_foreign_arg: |pad: bool| -> c_uint = ref |pad: bool| {
             next_foreign_arg_counter += if pad {
                 2
             } else {

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -45,7 +45,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
            vtables.repr(ccx.tcx()),
            ref_id);
 
-    assert!(real_substs.types.all(|t| {
+    assert!(real_substs.types.all(ref |t| {
         !ty::type_needs_infer(*t) && !ty::type_has_params(*t)
     }));
 
@@ -84,7 +84,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
     let map_node = session::expect(
         ccx.sess(),
         ccx.tcx.map.find(fn_id.node),
-        || {
+        ref || {
             format!("while monomorphizing {:?}, couldn't find it in \
                      the item map (may have attempted to monomorphize \
                      an item defined in a different crate?)",
@@ -131,7 +131,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         mono_ty.hash(&mut state);
 
         hash = format!("h{}", state.result());
-        ccx.tcx.map.with_path(fn_id.node, |path| {
+        ccx.tcx.map.with_path(fn_id.node, ref |path| {
             exported_name(path, hash.as_slice())
         })
     };
@@ -140,7 +140,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
 
     // This shouldn't need to option dance.
     let mut hash_id = Some(hash_id);
-    let mk_lldecl = |abi: abi::Abi| {
+    let mk_lldecl = ref |abi: abi::Abi| {
         let lldecl = if abi != abi::Rust {
             foreign::decl_rust_fn_with_foreign_abi(ccx, mono_ty, s.as_slice())
         } else {
@@ -179,7 +179,9 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         ast_map::NodeVariant(v) => {
             let parent = ccx.tcx.map.get_parent(fn_id.node);
             let tvs = ty::enum_variants(ccx.tcx(), local_def(parent));
-            let this_tv = tvs.iter().find(|tv| { tv.id.node == fn_id.node}).unwrap();
+            let this_tv = tvs.iter()
+                             .find(ref |tv| tv.id.node == fn_id.node)
+                             .unwrap();
             let d = mk_lldecl(abi::Rust);
             set_inline_hint(d);
             match v.node.kind {

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -393,8 +393,11 @@ pub fn write_content<'a>(
                     let elem = unpack_datum!(bcx, expr::trans(bcx, &**element));
                     assert!(!ty::type_moves_by_default(bcx.tcx(), elem.ty));
 
-                    let bcx = iter_vec_loop(bcx, lldest, vt,
-                                  C_uint(bcx.ccx(), count), |set_bcx, lleltptr, _| {
+                    let bcx = iter_vec_loop(bcx,
+                                            lldest,
+                                            vt,
+                                            C_uint(bcx.ccx(), count),
+                                            ref |set_bcx, lleltptr, _| {
                         elem.shallow_copy_and_take(set_bcx, lleltptr)
                     });
 

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -1171,8 +1171,8 @@ pub fn ty_of_closure<AC:AstConv>(
     // that function type
     let rb = rscope::BindingRscope::new(id);
 
-    let input_tys = decl.inputs.iter().enumerate().map(|(i, a)| {
-        let expected_arg_ty = expected_sig.as_ref().and_then(|e| {
+    let input_tys = decl.inputs.iter().enumerate().map(ref |(i, a)| {
+        let expected_arg_ty = expected_sig.as_ref().and_then(ref |e| {
             // no guarantee that the correct number of expected args
             // were supplied
             if i < e.inputs.len() {

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -219,7 +219,7 @@ fn get_method_index(tcx: &ty::ctxt,
     // we find the trait the method came from, counting up the
     // methods from them.
     let mut method_count = 0;
-    ty::each_bound_trait_and_supertraits(tcx, &[subtrait], |bound_ref| {
+    ty::each_bound_trait_and_supertraits(tcx, &[subtrait], ref |bound_ref| {
         if bound_ref.def_id == trait_ref.def_id {
             false
         } else {
@@ -708,12 +708,14 @@ impl<'a> LookupContext<'a> {
         let tcx = self.tcx();
         let mut next_bound_idx = 0; // count only trait bounds
 
-        ty::each_bound_trait_and_supertraits(tcx, bounds, |bound_trait_ref| {
+        ty::each_bound_trait_and_supertraits(tcx,
+                                             bounds,
+                                             ref |bound_trait_ref| {
             let this_bound_idx = next_bound_idx;
             next_bound_idx += 1;
 
             let trait_items = ty::trait_items(tcx, bound_trait_ref.def_id);
-            match trait_items.iter().position(|ti| {
+            match trait_items.iter().position(ref |ti| {
                 match *ti {
                     ty::MethodTraitItem(ref m) => {
                         m.explicit_self != ty::StaticExplicitSelfCategory &&
@@ -786,7 +788,7 @@ impl<'a> LookupContext<'a> {
         debug!("push_candidates_from_impl: {} {}",
                token::get_name(self.m_name),
                impl_items.iter()
-                         .map(|&did| {
+                         .map(ref |&did| {
                              ty::impl_or_trait_item(self.tcx(),
                                                     did.def_id()).ident()
                          })
@@ -794,11 +796,11 @@ impl<'a> LookupContext<'a> {
                          .repr(self.tcx()));
 
         let method = match impl_items.iter()
-                                     .map(|&did| {
+                                     .map(ref |&did| {
                                          ty::impl_or_trait_item(self.tcx(),
                                                                 did.def_id())
                                      })
-                                     .find(|m| {
+                                     .find(ref |m| {
                                          m.ident().name == self.m_name
                                      }) {
             Some(ty::MethodTraitItem(method)) => method,
@@ -807,7 +809,7 @@ impl<'a> LookupContext<'a> {
 
         // determine the `self` of the impl with fresh
         // variables for each parameter:
-        let span = self.self_expr.map_or(self.span, |e| e.span);
+        let span = self.self_expr.map_or(self.span, ref |e| e.span);
         let vcx = self.fcx.vtable_context();
         let TypeAndSubsts {
             substs: impl_substs,
@@ -1269,7 +1271,7 @@ impl<'a> LookupContext<'a> {
             MethodObject(..) => {
                 // For annoying reasons, we've already handled the
                 // substitution of self for object calls.
-                let args = fn_sig.inputs.slice_from(1).iter().map(|t| {
+                let args = fn_sig.inputs.slice_from(1).iter().map(ref |t| {
                     t.subst(tcx, &all_substs)
                 });
                 Some(*fn_sig.inputs.get(0)).move_iter().chain(args).collect()

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -531,7 +531,7 @@ fn check_fn<'a>(ccx: &'a CrateCtxt<'a>,
             // to be do-block/for-loop confusion
             demand::suptype_with_fn(&fcx, tail_expr.span, false,
                 fcx.ret_ty, fcx.expr_ty(&**tail_expr),
-                |sp, e, a, s| {
+                ref |sp, e, a, s| {
                     fcx.report_mismatched_return_types(sp, e, a, s);
                 });
         }
@@ -804,7 +804,7 @@ fn check_impl_items_against_trait(ccx: &CrateCtxt,
                 // corresponding method definition in the trait.
                 let opt_trait_method_ty =
                     trait_items.iter()
-                               .find(|ti| {
+                               .find(ref |ti| {
                                    ti.ident().name == impl_item_ty.ident()
                                                                   .name
                                });
@@ -3534,7 +3534,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprTup(ref elts) => {
         let expected = expected.only_has_type();
-        let flds = expected.map_to_option(fcx, |sty| {
+        let flds = expected.map_to_option(fcx, ref |sty| {
             match *sty {
                 ty::ty_tup(ref flds) => Some((*flds).clone()),
                 _ => None
@@ -3543,7 +3543,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         let mut bot_field = false;
         let mut err_field = false;
 
-        let elt_ts = elts.iter().enumerate().map(|(i, e)| {
+        let elt_ts = elts.iter().enumerate().map(ref |(i, e)| {
             let opt_hint = match flds {
                 Some(ref fs) if i < fs.len() => ExpectHasType(*fs.get(i)),
                 _ => NoExpectation
@@ -4771,7 +4771,7 @@ pub fn check_bounds_are_used(ccx: &CrateCtxt,
     if tps.len() == 0u { return; }
     let mut tps_used = Vec::from_elem(tps.len(), false);
 
-    ty::walk_ty(ty, |t| {
+    ty::walk_ty(ty, ref |t| {
             match ty::get(t).sty {
                 ty::ty_param(ParamTy {idx, ..}) => {
                     debug!("Found use of ty param num {}", idx);

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -649,7 +649,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
     match ty::get(function_type).sty {
         ty::ty_closure(box ty::ClosureTy {
                 store: ty::RegionTraitStore(region, _), ..}) => {
-            freevars::with_freevars(tcx, expr.id, |freevars| {
+            freevars::with_freevars(tcx, expr.id, ref |freevars| {
                 if freevars.is_empty() {
                     // No free variables means that the environment
                     // will be NULL at runtime and hence the closure
@@ -666,7 +666,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
             });
         }
         ty::ty_unboxed_closure(_, region) => {
-            freevars::with_freevars(tcx, expr.id, |freevars| {
+            freevars::with_freevars(tcx, expr.id, ref |freevars| {
                 // No free variables means that there is no environment and
                 // hence the closure has static lifetime. Otherwise, the
                 // closure must not outlive the variables it closes over
@@ -1018,9 +1018,14 @@ fn constrain_regions_in_type_of_node(
     // is going to fail anyway, so just stop here and let typeck
     // report errors later on in the writeback phase.
     let ty0 = rcx.resolve_node_type(id);
-    let ty = ty::adjust_ty(tcx, origin.span(), id, ty0,
+    let ty = ty::adjust_ty(tcx,
+                           origin.span(),
+                           id,
+                           ty0,
                            rcx.fcx.inh.adjustments.borrow().find(&id),
-                           |method_call| rcx.resolve_method_type(method_call));
+                           ref |method_call| {
+                               rcx.resolve_method_type(method_call)
+                           });
     debug!("constrain_regions_in_type_of_node(\
             ty={}, ty0={}, id={}, minimum_lifetime={:?})",
            ty_to_string(tcx, ty), ty_to_string(tcx, ty0),

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -29,11 +29,11 @@ pub fn replace_late_bound_regions_in_fn_sig(
 
     let mut map = HashMap::new();
     let fn_sig = {
-        let mut f = ty_fold::RegionFolder::regions(tcx, |r| {
+        let mut f = ty_fold::RegionFolder::regions(tcx, ref |r| {
             debug!("region r={}", r.to_string());
             match r {
                 ty::ReLateBound(s, br) if s == fn_sig.binder_id => {
-                    *map.find_or_insert_with(br, |_| mapf(br))
+                    *map.find_or_insert_with(br, ref |_| mapf(br))
                 }
                 _ => r
             }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -129,7 +129,7 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
     ty::each_bound_trait_and_supertraits(tcx,
                                          type_param_bounds.trait_bounds
                                                           .as_slice(),
-                                         |trait_ref| {
+                                         ref |trait_ref| {
         // ...and here trait_ref is each bound that was declared on A,
         // expressed in terms of the type parameters.
 
@@ -142,7 +142,8 @@ fn lookup_vtables_for_param(vcx: &VtableContext,
 
         // Substitute the values of the type parameters that may
         // appear in the bound.
-        let trait_ref = substs.as_ref().map_or(trait_ref.clone(), |substs| {
+        let trait_ref = substs.as_ref()
+                              .map_or(trait_ref.clone(), ref |substs| {
             debug!("about to subst: {}, {}",
                    trait_ref.repr(tcx), substs.repr(tcx));
             trait_ref.subst(tcx, *substs)
@@ -283,7 +284,7 @@ fn lookup_vtable_from_bounds(vcx: &VtableContext,
 
     let mut n_bound = 0;
     let mut ret = None;
-    ty::each_bound_trait_and_supertraits(tcx, bounds, |bound_trait_ref| {
+    ty::each_bound_trait_and_supertraits(tcx, bounds, ref |bound_trait_ref| {
         debug!("checking bounds trait {}",
                bound_trait_ref.repr(vcx.tcx()));
 

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -599,7 +599,7 @@ pub fn convert_struct(ccx: &CrateCtxt,
 
     // Write the type of each of the members and check for duplicate fields.
     let mut seen_fields: HashMap<ast::Name, Span> = HashMap::new();
-    let field_tys = struct_def.fields.iter().map(|f| {
+    let field_tys = struct_def.fields.iter().map(ref |f| {
         let result = convert_field(ccx, &pty.generics, f, local_def(id));
 
         if result.name != special_idents::unnamed_field.name {
@@ -854,9 +854,9 @@ pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::Item) -> Rc<ty::TraitDef> {
             if !ty::try_add_builtin_trait(ccx.tcx, trait_def_id, &mut bounds) {
 
                 // FIXME(#5527) Could have same trait multiple times
-                if ty_trait_refs.iter().any(
-                    |other_trait| other_trait.def_id == trait_ref.def_id)
-                {
+                if ty_trait_refs.iter().any(ref |other_trait| {
+                    other_trait.def_id == trait_ref.def_id
+                }) {
                     // This means a trait inherited from the same
                     // supertrait more than once.
                     span_err!(tcx.sess, sp, E0127,

--- a/src/librustc/middle/typeck/infer/combine.rs
+++ b/src/librustc/middle/typeck/infer/combine.rs
@@ -319,8 +319,8 @@ pub fn expected_found<C:Combine,T>(
 
 pub fn eq_tys<C:Combine>(this: &C, a: ty::t, b: ty::t) -> ures {
     let suber = this.sub();
-    this.infcx().try(|| {
-        suber.tys(a, b).and_then(|_ok| suber.contratys(a, b)).to_ures()
+    this.infcx().try(ref || {
+        suber.tys(a, b).and_then(ref |_ok| suber.contratys(a, b)).to_ures()
     })
 }
 
@@ -330,10 +330,10 @@ pub fn eq_regions<C:Combine>(this: &C, a: ty::Region, b: ty::Region)
             a.repr(this.infcx().tcx),
             b.repr(this.infcx().tcx));
     let sub = this.sub();
-    indent(|| {
-        this.infcx().try(|| {
-            sub.regions(a, b).and_then(|_r| sub.contraregions(a, b))
-        }).or_else(|e| {
+    indent(ref || {
+        this.infcx().try(ref || {
+            sub.regions(a, b).and_then(ref |_r| sub.contraregions(a, b))
+        }).or_else(ref |e| {
             // substitute a better error, but use the regions
             // found in the original error
             match e {

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1198,7 +1198,7 @@ impl<'a> Rebuilder<'a> {
         let mut new_lts = Vec::new();
         if last_seg.lifetimes.len() == 0 {
             // traverse once to see if there's a need to insert lifetime
-            let need_insert = range(0, expected).any(|i| {
+            let need_insert = range(0, expected).any(ref |i| {
                 indexes.contains(&i)
             });
             if need_insert {

--- a/src/librustc/middle/typeck/infer/glb.rs
+++ b/src/librustc/middle/typeck/infer/glb.rs
@@ -153,7 +153,7 @@ impl<'f> Combine for Glb<'f> {
             fold_regions_in_sig(
                 self.get_ref().infcx.tcx,
                 &sig0,
-                |r| {
+                ref |r| {
                 generalize_region(self,
                                   mark,
                                   new_vars.as_slice(),

--- a/src/librustc/middle/typeck/infer/lub.rs
+++ b/src/librustc/middle/typeck/infer/lub.rs
@@ -137,8 +137,14 @@ impl<'f> Combine for Lub<'f> {
             fold_regions_in_sig(
                 self.get_ref().infcx.tcx,
                 &sig0,
-                |r| generalize_region(self, mark, new_vars.as_slice(),
-                                      sig0.binder_id, &a_map, r));
+                ref |r| {
+                    generalize_region(self,
+                                      mark,
+                                      new_vars.as_slice(),
+                                      sig0.binder_id,
+                                      &a_map,
+                                      r)
+                });
         return Ok(sig1);
 
         fn generalize_region(this: &Lub,
@@ -160,7 +166,7 @@ impl<'f> Combine for Lub<'f> {
             // Variables created during LUB computation which are
             // *related* to regions that pre-date the LUB computation
             // stay as they are.
-            if !tainted.iter().all(|r| is_var_in_set(new_vars, *r)) {
+            if !tainted.iter().all(ref |r| is_var_in_set(new_vars, *r)) {
                 debug!("generalize_region(r0={:?}): \
                         non-new-variables found in {:?}",
                        r0, tainted);
@@ -174,7 +180,7 @@ impl<'f> Combine for Lub<'f> {
             // bound region from A that we find it to be associated
             // with.
             for (a_br, a_r) in a_map.iter() {
-                if tainted.iter().any(|x| x == a_r) {
+                if tainted.iter().any(ref |x| x == a_r) {
                     debug!("generalize_region(r0={:?}): \
                             replacing with {:?}, tainted={:?}",
                            r0, *a_br, tainted);

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -295,8 +295,8 @@ pub fn common_supertype(cx: &InferCtxt,
         values: Types(expected_found(a_is_expected, a, b))
     };
 
-    let result =
-        cx.commit_if_ok(|| cx.lub(a_is_expected, trace.clone()).tys(a, b));
+    let result = cx.commit_if_ok(ref || cx.lub(a_is_expected, trace.clone())
+                   .tys(a, b));
     match result {
         Ok(t) => t,
         Err(ref err) => {
@@ -314,7 +314,7 @@ pub fn mk_subty(cx: &InferCtxt,
              -> ures {
     debug!("mk_subty({} <: {})", a.repr(cx.tcx), b.repr(cx.tcx));
     indent(|| {
-        cx.commit_if_ok(|| {
+        cx.commit_if_ok(ref || {
             let trace = TypeTrace {
                 origin: origin,
                 values: Types(expected_found(a_is_expected, a, b))
@@ -326,7 +326,7 @@ pub fn mk_subty(cx: &InferCtxt,
 
 pub fn can_mk_subty(cx: &InferCtxt, a: ty::t, b: ty::t) -> ures {
     debug!("can_mk_subty({} <: {})", a.repr(cx.tcx), b.repr(cx.tcx));
-    cx.probe(|| {
+    cx.probe(ref || {
         let trace = TypeTrace {
             origin: Misc(codemap::DUMMY_SP),
             values: Types(expected_found(true, a, b))
@@ -351,8 +351,7 @@ pub fn mk_eqty(cx: &InferCtxt,
                origin: TypeOrigin,
                a: ty::t,
                b: ty::t)
-            -> ures
-{
+               -> ures {
     debug!("mk_eqty({} <: {})", a.repr(cx.tcx), b.repr(cx.tcx));
     cx.commit_if_ok(|| {
         let trace = TypeTrace {
@@ -369,12 +368,11 @@ pub fn mk_sub_trait_refs(cx: &InferCtxt,
                          origin: TypeOrigin,
                          a: Rc<ty::TraitRef>,
                          b: Rc<ty::TraitRef>)
-    -> ures
-{
+                         -> ures {
     debug!("mk_sub_trait_refs({} <: {})",
            a.repr(cx.tcx), b.repr(cx.tcx));
-    indent(|| {
-        cx.commit_if_ok(|| {
+    indent(ref || {
+        cx.commit_if_ok(ref || {
             let trace = TypeTrace {
                 origin: origin,
                 values: TraitRefs(expected_found(a_is_expected, a.clone(), b.clone()))
@@ -402,8 +400,8 @@ pub fn mk_coercety(cx: &InferCtxt,
                    b: ty::t)
                 -> CoerceResult {
     debug!("mk_coercety({} -> {})", a.repr(cx.tcx), b.repr(cx.tcx));
-    indent(|| {
-        cx.commit_if_ok(|| {
+    indent(ref || {
+        cx.commit_if_ok(ref || {
             let trace = TypeTrace {
                 origin: origin,
                 values: Types(expected_found(a_is_expected, a, b))
@@ -420,7 +418,7 @@ pub fn resolve_type(cx: &InferCtxt,
                     modes: uint)
                     -> fres<ty::t> {
     let mut resolver = resolver(cx, modes, span);
-    cx.commit_unconditionally(|| resolver.resolve_type_chk(a))
+    cx.commit_unconditionally(ref || resolver.resolve_type_chk(a))
 }
 
 pub fn resolve_region(cx: &InferCtxt, r: ty::Region, modes: uint)
@@ -561,7 +559,7 @@ impl<'a> InferCtxt<'a> {
 
     /// Execute `f` and commit the bindings if successful
     pub fn commit_if_ok<T,E>(&self, f: || -> Result<T,E>) -> Result<T,E> {
-        self.commit_unconditionally(|| self.try(|| f()))
+        self.commit_unconditionally(ref || self.try(ref || f()))
     }
 
     /// Execute `f`, unroll bindings on failure

--- a/src/librustc/middle/typeck/infer/resolve.rs
+++ b/src/librustc/middle/typeck/infer/resolve.rs
@@ -128,7 +128,7 @@ impl<'a> ResolveState<'a> {
         // allow us to pass back errors in any useful way.
 
         assert!(self.v_seen.is_empty());
-        let rty = indent(|| self.resolve_type(typ) );
+        let rty = indent(ref || self.resolve_type(typ) );
         assert!(self.v_seen.is_empty());
         match self.err {
           None => {
@@ -142,11 +142,10 @@ impl<'a> ResolveState<'a> {
         }
     }
 
-    pub fn resolve_region_chk(&mut self,
-                              orig: ty::Region)
+    pub fn resolve_region_chk(&mut self, orig: ty::Region)
                               -> fres<ty::Region> {
         self.err = None;
-        let resolved = indent(|| self.resolve_region(orig) );
+        let resolved = indent(ref || self.resolve_region(orig) );
         match self.err {
           None => Ok(resolved),
           Some(e) => Err(e)

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -483,20 +483,20 @@ pub fn check_crate(tcx: &ty::ctxt,
         tcx: tcx
     };
 
-    time(time_passes, "type collecting", (), |_|
+    time(time_passes, "type collecting", (), ref |_|
         collect::collect_item_types(&ccx, krate));
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
     tcx.sess.abort_if_errors();
 
-    time(time_passes, "variance inference", (), |_|
+    time(time_passes, "variance inference", (), ref |_|
          variance::infer_variance(tcx, krate));
 
-    time(time_passes, "coherence checking", (), |_|
+    time(time_passes, "coherence checking", (), ref |_|
         coherence::check_coherence(&ccx, krate));
 
-    time(time_passes, "type checking", (), |_|
+    time(time_passes, "type checking", (), ref |_|
         check::check_item_types(&ccx, krate));
 
     check_for_entry_fn(&ccx);

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -76,7 +76,7 @@ fn verify(sess: &Session, items: &lang_items::LanguageItems) {
     if !needs_check { return }
 
     let mut missing = HashSet::new();
-    sess.cstore.iter_crate_data(|cnum, _| {
+    sess.cstore.iter_crate_data(ref |cnum, _| {
         for item in csearch::get_missing_lang_items(&sess.cstore, cnum).iter() {
             missing.insert(*item);
         }

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -464,7 +464,9 @@ impl Engine256 {
         }
 
         let self_state = &mut self.state;
-        self.buffer.standard_padding(8, |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.standard_padding(8, ref |input: &[u8]| {
+            self_state.process_block(input)
+        });
         write_u32_be(self.buffer.next(4), (self.length_bits >> 32) as u32 );
         write_u32_be(self.buffer.next(4), self.length_bits as u32);
         self_state.process_block(self.buffer.full_buffer());
@@ -656,7 +658,7 @@ mod bench {
     pub fn sha256_10(b: &mut Bencher) {
         let mut sh = Sha256::new();
         let bytes = [1u8, ..10];
-        b.iter(|| {
+        b.iter(ref || {
             sh.input(bytes);
         });
         b.bytes = bytes.len() as u64;
@@ -666,7 +668,7 @@ mod bench {
     pub fn sha256_1k(b: &mut Bencher) {
         let mut sh = Sha256::new();
         let bytes = [1u8, ..1024];
-        b.iter(|| {
+        b.iter(ref || {
             sh.input(bytes);
         });
         b.bytes = bytes.len() as u64;
@@ -676,7 +678,7 @@ mod bench {
     pub fn sha256_64k(b: &mut Bencher) {
         let mut sh = Sha256::new();
         let bytes = [1u8, ..65536];
-        b.iter(|| {
+        b.iter(ref || {
             sh.input(bytes);
         });
         b.bytes = bytes.len() as u64;

--- a/src/librustc_llvm/archive_ro.rs
+++ b/src/librustc_llvm/archive_ro.rs
@@ -44,7 +44,7 @@ impl ArchiveRO {
     pub fn read<'a>(&'a self, file: &str) -> Option<&'a [u8]> {
         unsafe {
             let mut size = 0 as libc::size_t;
-            let ptr = file.with_c_str(|file| {
+            let ptr = file.with_c_str(ref |file| {
                 ::LLVMRustArchiveReadSection(self.ptr, file, &mut size)
             });
             if ptr.is_null() {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -188,22 +188,22 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
 
                 if !rendered {
                     let mut s = String::new();
-                    let id = playground_krate.get().map(|krate| {
+                    let id = playground_krate.get().map(ref |krate| {
                         let idx = test_idx.get().unwrap();
                         let i = idx.get();
                         idx.set(i + 1);
 
-                        let test = origtext.lines().map(|l| {
+                        let test = origtext.lines().map(ref |l| {
                             stripped_filtered_line(l).unwrap_or(l)
                         }).collect::<Vec<&str>>().connect("\n");
-                        let krate = krate.as_ref().map(|s| s.as_slice());
+                        let krate = krate.as_ref().map(ref |s| s.as_slice());
                         let test = test::maketest(test.as_slice(), krate, false, false);
                         s.push_str(format!("<span id='rust-example-raw-{}' \
                                              class='rusttest'>{}</span>",
                                            i, Escape(test.as_slice())).as_slice());
                         format!("rust-example-rendered-{}", i)
                     });
-                    let id = id.as_ref().map(|a| a.as_slice());
+                    let id = id.as_ref().map(ref |a| a.as_slice());
                     s.push_str(highlight::highlight(text.as_slice(), None, id)
                                          .as_slice());
                     let output = s.to_c_str();

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -104,7 +104,7 @@ impl TocBuilder {
         loop {
             match self.chain.pop() {
                 Some(mut next) => {
-                    this.map(|e| next.children.entries.push(e));
+                    this.map(ref |e| next.children.entries.push(e));
                     if next.level < level {
                         // this is the parent we want, so return it to
                         // its rightful place.
@@ -115,7 +115,7 @@ impl TocBuilder {
                     }
                 }
                 None => {
-                    this.map(|e| self.top_level.entries.push(e));
+                    this.map(ref |e| self.top_level.entries.push(e));
                     return
                 }
             }

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -298,7 +298,7 @@ pub fn unindent(s: &str) -> String {
     let lines = s.lines_any().collect::<Vec<&str> >();
     let mut saw_first_line = false;
     let mut saw_second_line = false;
-    let min_indent = lines.iter().fold(uint::MAX, |min_indent, line| {
+    let min_indent = lines.iter().fold(uint::MAX, ref |min_indent, line| {
 
         // After we see the first non-whitespace line, look at
         // the line we have. If it is not whitespace, and therefore
@@ -324,7 +324,7 @@ pub fn unindent(s: &str) -> String {
         } else {
             saw_first_line = true;
             let mut spaces = 0;
-            line.chars().all(|char| {
+            line.chars().all(ref |char| {
                 // Only comparing against space because I wouldn't
                 // know what to do with mixed whitespace chars
                 if char == ' ' {

--- a/src/librustdoc/stability_summary.rs
+++ b/src/librustdoc/stability_summary.rs
@@ -145,15 +145,18 @@ fn summarize_item(item: &Item) -> (Counts, Option<ModuleSummary>) {
             let mut counts = item_counts;
             let mut submodules = Vec::new();
 
-            for (subcounts, submodule) in items.iter().filter(|i| visible(*i))
-                                                      .map(summarize_item) {
+            for (subcounts, submodule) in items.iter()
+                                               .filter(ref |i| visible(*i))
+                                               .map(summarize_item) {
                 counts = counts + subcounts;
-                submodule.map(|m| submodules.push(m));
+                submodule.map(ref |m| submodules.push(m));
             }
             submodules.sort();
 
             (counts, Some(ModuleSummary {
-                name: item.name.as_ref().map_or("".to_string(), |n| n.clone()),
+                name: item.name
+                          .as_ref()
+                          .map_or("".to_string(), ref |n| n.clone()),
                 counts: counts,
                 submodules: submodules,
             }))

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -74,7 +74,7 @@ impl<'a> RustdocVisitor<'a> {
                                               None);
         // attach the crate's exported macros to the top-level module:
         self.module.macros = krate.exported_macros.iter()
-            .map(|it| self.visit_macro(&**it)).collect();
+            .map(ref |it| self.visit_macro(&**it)).collect();
         self.module.is_crate = true;
     }
 
@@ -88,9 +88,9 @@ impl<'a> RustdocVisitor<'a> {
             name: item.ident,
             vis: item.vis,
             stab: self.stability(item.id),
-            attrs: item.attrs.iter().map(|x| *x).collect(),
+            attrs: item.attrs.iter().map(ref |x| *x).collect(),
             generics: generics.clone(),
-            fields: sd.fields.iter().map(|x| (*x).clone()).collect(),
+            fields: sd.fields.iter().map(ref |x| (*x).clone()).collect(),
             whence: item.span
         }
     }
@@ -130,7 +130,7 @@ impl<'a> RustdocVisitor<'a> {
             id: item.id,
             vis: item.vis,
             stab: self.stability(item.id),
-            attrs: item.attrs.iter().map(|x| *x).collect(),
+            attrs: item.attrs.iter().map(ref |x| *x).collect(),
             decl: fd.clone(),
             name: item.ident,
             whence: item.span,
@@ -163,10 +163,10 @@ impl<'a> RustdocVisitor<'a> {
         if item.vis != ast::Public {
             return om.view_items.push(item.clone());
         }
-        let please_inline = item.attrs.iter().any(|item| {
+        let please_inline = item.attrs.iter().any(ref |item| {
             match item.meta_item_list() {
                 Some(list) => {
-                    list.iter().any(|i| i.name().get() == "inline")
+                    list.iter().any(ref |i| i.name().get() == "inline")
                 }
                 None => false,
             }

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -530,7 +530,9 @@ mod tests {
             let ptr = input.as_ptr();
             let expected = ["zero", "one"];
             let mut it = expected.iter();
-            let result = from_c_multistring(ptr as *const libc::c_char, None, |c| {
+            let result = from_c_multistring(ptr as *const libc::c_char,
+                                            None,
+                                            ref |c| {
                 let cbytes = c.as_bytes_no_nul();
                 assert_eq!(cbytes, it.next().unwrap().as_bytes());
             });
@@ -694,7 +696,7 @@ mod tests {
         }
 
         let mut c_: Option<CString> = None;
-        foo(|c| {
+        foo(ref |c| {
             c_ = Some(c.clone());
             c.clone();
             // force a copy, reading the memory
@@ -735,7 +737,7 @@ mod bench {
         Mary had a little lamb, Little lamb";
 
     fn bench_to_string(b: &mut Bencher, s: &str) {
-        b.iter(|| {
+        b.iter(ref || {
             let c_str = s.to_c_str();
             check(s, c_str.as_ptr());
         })
@@ -757,7 +759,7 @@ mod bench {
     }
 
     fn bench_to_c_str_unchecked(b: &mut Bencher, s: &str) {
-        b.iter(|| {
+        b.iter(ref || {
             let c_str = unsafe { s.to_c_str_unchecked() };
             check(s, c_str.as_ptr())
         })
@@ -779,8 +781,8 @@ mod bench {
     }
 
     fn bench_with_c_str(b: &mut Bencher, s: &str) {
-        b.iter(|| {
-            s.with_c_str(|c_str_buf| check(s, c_str_buf))
+        b.iter(ref || {
+            s.with_c_str(ref |c_str_buf| check(s, c_str_buf))
         })
     }
 
@@ -800,9 +802,9 @@ mod bench {
     }
 
     fn bench_with_c_str_unchecked(b: &mut Bencher, s: &str) {
-        b.iter(|| {
+        b.iter(ref || {
             unsafe {
-                s.with_c_str_unchecked(|c_str_buf| check(s, c_str_buf))
+                s.with_c_str_unchecked(ref |c_str_buf| check(s, c_str_buf))
             }
         })
     }

--- a/src/librustrt/local_data.rs
+++ b/src/librustrt/local_data.rs
@@ -605,7 +605,7 @@ mod tests {
         static key: Key<uint> = &Key;
         let _clear = ClearKey(key);
         key.replace(None);
-        b.iter(|| {
+        b.iter(ref || {
             key.replace(None)
         });
     }
@@ -615,7 +615,7 @@ mod tests {
         static key: Key<uint> = &Key;
         let _clear = ClearKey(key);
         key.replace(Some(1u));
-        b.iter(|| {
+        b.iter(ref || {
             key.replace(Some(2))
         });
     }
@@ -625,7 +625,7 @@ mod tests {
         static key: Key<uint> = &Key;
         let _clear = ClearKey(key);
         key.replace(Some(0u));
-        b.iter(|| {
+        b.iter(ref || {
             let old = key.replace(None).unwrap();
             let new = old + 1;
             key.replace(Some(new))
@@ -639,7 +639,7 @@ mod tests {
         for (i, key) in keys.iter().enumerate() {
             key.replace(Some(i));
         }
-        b.iter(|| {
+        b.iter(ref || {
             let key: Key<uint> = &keys[99];
             key.replace(Some(42))
         });
@@ -652,7 +652,7 @@ mod tests {
         for (i, key) in keys.iter().enumerate() {
             key.replace(Some(i));
         }
-        b.iter(|| {
+        b.iter(ref || {
             let key: Key<uint> = &keys[999];
             key.replace(Some(42))
         });
@@ -664,7 +664,7 @@ mod tests {
         static key: Key<uint> = &Key;
         let _clear = ClearKey(key);
         key.replace(Some(42));
-        b.iter(|| {
+        b.iter(ref || {
             key.get()
         });
     }
@@ -676,7 +676,7 @@ mod tests {
         for (i, key) in keys.iter().enumerate() {
             key.replace(Some(i));
         }
-        b.iter(|| {
+        b.iter(ref || {
             let key: Key<uint> = &keys[99];
             key.get()
         });
@@ -689,7 +689,7 @@ mod tests {
         for (i, key) in keys.iter().enumerate() {
             key.replace(Some(i));
         }
-        b.iter(|| {
+        b.iter(ref || {
             let key: Key<uint> = &keys[999];
             key.get()
         });

--- a/src/librustrt/local_heap.rs
+++ b/src/librustrt/local_heap.rs
@@ -122,7 +122,7 @@ impl LocalHeap {
         //
         // In this pass, nothing gets freed, so it does not matter whether
         // we read the next field before or after the callback.
-        self.each_live_alloc(true, |_, alloc| {
+        self.each_live_alloc(true, ref |_, alloc| {
             n_total_boxes += 1;
             (*alloc).ref_count = RC_IMMORTAL;
         });
@@ -335,11 +335,11 @@ mod bench {
 
     #[bench]
     fn alloc_managed_small(b: &mut Bencher) {
-        b.iter(|| { box(GC) 10i });
+        b.iter(ref || { box(GC) 10i });
     }
 
     #[bench]
     fn alloc_managed_big(b: &mut Bencher) {
-        b.iter(|| { box(GC) ([10i, ..1000]) });
+        b.iter(ref || { box(GC) ([10i, ..1000]) });
     }
 }

--- a/src/librustuv/access.rs
+++ b/src/librustuv/access.rs
@@ -57,7 +57,7 @@ impl Access {
 
         if inner.held {
             let t: Box<Task> = Local::take();
-            t.deschedule(1, |task| {
+            t.deschedule(1, ref |task| {
                 inner.queue.push((task, token));
                 Ok(())
             });

--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -55,7 +55,7 @@ impl GetAddrInfoRequest {
             None => (None, null())
         };
 
-        let hint = hints.map(|hint| {
+        let hint = hints.map(ref |hint| {
             libc::addrinfo {
                 ai_flags: 0,
                 ai_family: hint.family as c_int,
@@ -67,7 +67,7 @@ impl GetAddrInfoRequest {
                 ai_next: mut_null(),
             }
         });
-        let hint_ptr = hint.as_ref().map_or(null(), |x| {
+        let hint_ptr = hint.as_ref().map_or(null(), ref |x| {
             x as *const libc::addrinfo
         });
         let mut req = Request::new(uvll::UV_GETADDRINFO);
@@ -81,7 +81,7 @@ impl GetAddrInfoRequest {
                 req.defuse(); // uv callback now owns this request
                 let mut cx = Ctx { slot: None, status: 0, addrinfo: None };
 
-                wait_until_woken_after(&mut cx.slot, loop_, || {
+                wait_until_woken_after(&mut cx.slot, loop_, ref || {
                     req.set_data(&mut cx);
                 });
 

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -181,7 +181,7 @@ pub trait UvHandle<T> {
             uvll::set_data_for_uv_handle(self.uv_handle(),
                                          ptr::mut_null::<()>());
 
-            wait_until_woken_after(&mut slot, &self.uv_loop(), || {
+            wait_until_woken_after(&mut slot, &self.uv_loop(), ref || {
                 uvll::set_data_for_uv_handle(self.uv_handle(), &mut slot);
             })
         }
@@ -248,7 +248,7 @@ fn wait_until_woken_after(slot: *mut Option<BlockedTask>,
         assert!((*slot).is_none());
         let task: Box<Task> = Local::take();
         loop_.modify_blockers(1);
-        task.deschedule(1, |task| {
+        task.deschedule(1, ref |task| {
             *slot = Some(task);
             f();
             Ok(())
@@ -259,7 +259,7 @@ fn wait_until_woken_after(slot: *mut Option<BlockedTask>,
 
 fn wakeup(slot: &mut Option<BlockedTask>) {
     assert!(slot.is_some());
-    let _ = slot.take_unwrap().wake().map(|t| t.reawaken());
+    let _ = slot.take_unwrap().wake().map(ref |t| t.reawaken());
 }
 
 pub struct Request {

--- a/src/librustuv/process.rs
+++ b/src/librustuv/process.rs
@@ -67,8 +67,8 @@ impl Process {
             }
         }
 
-        let ret = with_argv(cfg.program, cfg.args, |argv| {
-            with_env(cfg.env, |envp| {
+        let ret = with_argv(cfg.program, cfg.args, ref |argv| {
+            with_env(cfg.env, ref |envp| {
                 let mut flags = 0;
                 if cfg.uid.is_some() {
                     flags |= uvll::PROCESS_SETUID;

--- a/src/librustuv/stream.rs
+++ b/src/librustuv/stream.rs
@@ -182,7 +182,7 @@ impl StreamWatcher {
 
                 let loop_ = unsafe { uvll::get_loop_for_uv_handle(self.handle) };
                 wait_until_woken_after(&mut self.blocked_writer,
-                                       &Loop::wrap(loop_), || {
+                                       &Loop::wrap(loop_), ref || {
                     req.set_data(&mut wcx);
                 });
 

--- a/src/librustuv/timeout.rs
+++ b/src/librustuv/timeout.rs
@@ -239,7 +239,7 @@ impl ConnectCtx {
                     }
                     None => {}
                 }
-                wait_until_woken_after(&mut self.task, &io.loop_, || {
+                wait_until_woken_after(&mut self.task, &io.loop_, ref || {
                     let data = &self as *const _ as *mut ConnectCtx;
                     match self.timer {
                         Some(ref mut timer) => unsafe { timer.set_data(data) },

--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -97,7 +97,7 @@ impl RtioTimer for TimerWatcher {
         let _f = ForbidUnwind::new("timer");
 
         self.action = Some(WakeTask);
-        wait_until_woken_after(&mut self.blocker, &self.uv_loop(), || {
+        wait_until_woken_after(&mut self.blocker, &self.uv_loop(), ref || {
             self.start(timer_cb, msecs, 0);
         });
         self.stop();

--- a/src/libsemver/lib.rs
+++ b/src/libsemver/lib.rs
@@ -208,13 +208,13 @@ fn expect(ch: Option<char>, c: char) -> Option<()> {
 }
 
 fn parse_iter<T: Iterator<char>>(rdr: &mut T) -> Option<Version> {
-    let maybe_vers = take_num(rdr).and_then(|(major, ch)| {
+    let maybe_vers = take_num(rdr).and_then(ref |(major, ch)| {
         expect(ch, '.').and_then(|_| Some(major))
-    }).and_then(|major| {
+    }).and_then(ref |major| {
         take_num(rdr).and_then(|(minor, ch)| {
             expect(ch, '.').and_then(|_| Some((major, minor)))
         })
-    }).and_then(|(major, minor)| {
+    }).and_then(ref |(major, minor)| {
         take_num(rdr).and_then(|(patch, ch)| {
            Some((major, minor, patch, ch))
         })

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -367,7 +367,7 @@ mod tests {
     pub fn bench_to_base64(b: &mut Bencher) {
         let s = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム \
                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
-        b.iter(|| {
+        b.iter(ref || {
             s.as_bytes().to_base64(STANDARD);
         });
         b.bytes = s.len() as u64;
@@ -378,7 +378,7 @@ mod tests {
         let s = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム \
                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
         let sb = s.as_bytes().to_base64(STANDARD);
-        b.iter(|| {
+        b.iter(ref || {
             sb.as_slice().from_base64().unwrap();
         });
         b.bytes = sb.len() as u64;

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -200,7 +200,7 @@ mod tests {
     pub fn bench_to_hex(b: &mut Bencher) {
         let s = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム \
                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
-        b.iter(|| {
+        b.iter(ref || {
             s.as_bytes().to_hex();
         });
         b.bytes = s.len() as u64;
@@ -211,7 +211,7 @@ mod tests {
         let s = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム \
                  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン";
         let sb = s.as_bytes().to_hex();
-        b.iter(|| {
+        b.iter(ref || {
             sb.as_slice().from_hex().unwrap();
         });
         b.bytes = sb.len() as u64;

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1675,7 +1675,7 @@ impl<T: Iterator<char>> Parser<T> {
     }
 
     fn parse_ident(&mut self, ident: &str, value: JsonEvent) -> JsonEvent {
-        if ident.chars().all(|c| Some(c) == self.next_char()) {
+        if ident.chars().all(ref |c| Some(c) == self.next_char()) {
             self.bump();
             value
         } else {
@@ -1937,7 +1937,9 @@ impl ::Decoder<DecoderError> for Decoder {
             }
         };
         let idx = match names.iter()
-                             .position(|n| str::eq_slice(*n, name.as_slice())) {
+                             .position(ref |n| {
+                                 str::eq_slice(*n, name.as_slice())
+                             }) {
             Some(idx) => idx,
             None => return Err(UnknownVariantError(name))
         };
@@ -2420,14 +2422,14 @@ mod tests {
     fn test_write_enum() {
         let animal = Dog;
         assert_eq!(
-            with_str_writer(|writer| {
+            with_str_writer(ref |writer| {
                 let mut encoder = Encoder::new(writer);
                 animal.encode(&mut encoder).unwrap();
             }),
             "\"Dog\"".to_string()
         );
         assert_eq!(
-            with_str_writer(|writer| {
+            with_str_writer(ref |writer| {
                 let mut encoder = PrettyEncoder::new(writer);
                 animal.encode(&mut encoder).unwrap();
             }),
@@ -2436,14 +2438,14 @@ mod tests {
 
         let animal = Frog("Henry".to_string(), 349);
         assert_eq!(
-            with_str_writer(|writer| {
+            with_str_writer(ref |writer| {
                 let mut encoder = Encoder::new(writer);
                 animal.encode(&mut encoder).unwrap();
             }),
             "{\"variant\":\"Frog\",\"fields\":[\"Henry\",349]}".to_string()
         );
         assert_eq!(
-            with_str_writer(|writer| {
+            with_str_writer(ref |writer| {
                 let mut encoder = PrettyEncoder::new(writer);
                 animal.encode(&mut encoder).unwrap();
             }),
@@ -2459,14 +2461,14 @@ mod tests {
     #[test]
     fn test_write_some() {
         let value = Some("jodhpurs".to_string());
-        let s = with_str_writer(|writer| {
+        let s = with_str_writer(ref |writer| {
             let mut encoder = Encoder::new(writer);
             value.encode(&mut encoder).unwrap();
         });
         assert_eq!(s, "\"jodhpurs\"".to_string());
 
         let value = Some("jodhpurs".to_string());
-        let s = with_str_writer(|writer| {
+        let s = with_str_writer(ref |writer| {
             let mut encoder = PrettyEncoder::new(writer);
             value.encode(&mut encoder).unwrap();
         });
@@ -2476,13 +2478,13 @@ mod tests {
     #[test]
     fn test_write_none() {
         let value: Option<String> = None;
-        let s = with_str_writer(|writer| {
+        let s = with_str_writer(ref |writer| {
             let mut encoder = Encoder::new(writer);
             value.encode(&mut encoder).unwrap();
         });
         assert_eq!(s, "null".to_string());
 
-        let s = with_str_writer(|writer| {
+        let s = with_str_writer(ref |writer| {
             let mut encoder = Encoder::new(writer);
             value.encode(&mut encoder).unwrap();
         });
@@ -3326,7 +3328,7 @@ mod tests {
 
     #[bench]
     fn bench_streaming_small(b: &mut Bencher) {
-        b.iter( || {
+        b.iter(ref || {
             let mut parser = Parser::new(
                 r#"{
                     "a": 1.0,
@@ -3347,7 +3349,7 @@ mod tests {
     }
     #[bench]
     fn bench_small(b: &mut Bencher) {
-        b.iter( || {
+        b.iter(ref || {
             let _ = from_str(r#"{
                 "a": 1.0,
                 "b": [

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -580,9 +580,9 @@ pub trait EncoderHelpers<E> {
 
 impl<E, S:Encoder<E>> EncoderHelpers<E> for S {
     fn emit_from_vec<T>(&mut self, v: &[T], f: |&mut S, &T| -> Result<(), E>) -> Result<(), E> {
-        self.emit_seq(v.len(), |this| {
+        self.emit_seq(v.len(), ref |this| {
             for (i, e) in v.iter().enumerate() {
-                try!(this.emit_seq_elt(i, |this| {
+                try!(this.emit_seq_elt(i, ref |this| {
                     f(this, e)
                 }));
             }
@@ -597,10 +597,10 @@ pub trait DecoderHelpers<E> {
 
 impl<E, D:Decoder<E>> DecoderHelpers<E> for D {
     fn read_to_vec<T>(&mut self, f: |&mut D| -> Result<T, E>) -> Result<Vec<T>, E> {
-        self.read_seq(|this, len| {
+        self.read_seq(ref |this, len| {
             let mut v = Vec::with_capacity(len);
             for i in range(0, len) {
-                v.push(try!(this.read_seq_elt(i, |this| f(this))));
+                v.push(try!(this.read_seq_elt(i, ref |this| f(this))));
             }
             Ok(v)
         })

--- a/src/libstd/collections/hashmap.rs
+++ b/src/libstd/collections/hashmap.rs
@@ -2994,7 +2994,7 @@ mod bench {
     fn new_drop(b : &mut Bencher) {
         use super::HashMap;
 
-        b.iter(|| {
+        b.iter(ref || {
             let m : HashMap<int, int> = HashMap::new();
             assert_eq!(m.len(), 0);
         })
@@ -3004,7 +3004,7 @@ mod bench {
     fn new_insert_drop(b : &mut Bencher) {
         use super::HashMap;
 
-        b.iter(|| {
+        b.iter(ref || {
             let mut m = HashMap::new();
             m.insert(0i, 0i);
             assert_eq!(m.len(), 1);
@@ -3023,7 +3023,7 @@ mod bench {
 
         let mut k = 1001;
 
-        b.iter(|| {
+        b.iter(ref || {
             m.insert(k, k);
             k += 1;
         });
@@ -3039,7 +3039,7 @@ mod bench {
             m.insert(i, i);
         }
 
-        b.iter(|| {
+        b.iter(ref || {
             for i in range_inclusive(1i, 1000) {
                 m.contains_key(&i);
             }
@@ -3056,7 +3056,7 @@ mod bench {
             m.insert(i, i);
         }
 
-        b.iter(|| {
+        b.iter(ref || {
             for i in range_inclusive(1001i, 2000) {
                 m.contains_key(&i);
             }
@@ -3075,7 +3075,7 @@ mod bench {
 
         let mut k = 1i;
 
-        b.iter(|| {
+        b.iter(ref || {
             m.pop(&k);
             m.insert(k + 1000, k + 1000);
             k += 1;
@@ -3094,7 +3094,7 @@ mod bench {
 
         let mut k = 1i;
 
-        b.iter(|| {
+        b.iter(ref || {
             m.find(&(k + 400));
             m.find(&(k + 2000));
             m.pop(&k);

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -64,7 +64,7 @@ impl DynamicLibrary {
                         -> Result<DynamicLibrary, String> {
         unsafe {
             let mut filename = filename;
-            let maybe_library = dl::check_for_errors_in(|| {
+            let maybe_library = dl::check_for_errors_in(ref || {
                 match filename.take() {
                     Some(name) => dl::open_external(name),
                     None => dl::open_internal()

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -607,21 +607,21 @@ mod test {
 
     #[bench]
     fn bench_buffered_reader(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             BufferedReader::new(NullStream)
         });
     }
 
     #[bench]
     fn bench_buffered_writer(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             BufferedWriter::new(NullStream)
         });
     }
 
     #[bench]
     fn bench_buffered_stream(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             BufferedStream::new(NullStream);
         });
     }

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -516,7 +516,7 @@ mod bench {
 
             let data = Vec::from_fn($stride*100+$start_index, |i| i as u8);
             let mut sum = 0u64;
-            $b.iter(|| {
+            $b.iter(ref || {
                 let mut i = $start_index;
                 while i < data.len() {
                     sum += u64_from_be_bytes(data.as_slice(), i, $size);

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -631,7 +631,7 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 ///         let contents = try!(fs::readdir(dir));
 ///         for entry in contents.iter() {
 ///             if entry.is_dir() {
-///                 try!(visit_dirs(entry, |p| cb(p)));
+///                 try!(visit_dirs(entry, ref |p| cb(p)));
 ///             } else {
 ///                 cb(entry);
 ///             }
@@ -682,8 +682,11 @@ impl Iterator<Path> for Directories {
                 if path.is_dir() {
                     let result = readdir(&path)
                         .update_err("couldn't advance Directories iterator",
-                                    |e| format!("{}; path={}",
-                                                e, path.display()));
+                                    ref |e| {
+                                        format!("{}; path={}",
+                                                e,
+                                                path.display())
+                                    });
 
                     match result {
                         Ok(dirs) => { self.stack.push_all_move(dirs); }

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -550,7 +550,7 @@ mod test {
         let src: Vec<u8> = Vec::from_elem(len, 5);
 
         b.bytes = (times * len) as u64;
-        b.iter(|| {
+        b.iter(ref || {
             let mut wr = MemWriter::new();
             for _ in range(0, times) {
                 wr.write(src.as_slice()).unwrap();
@@ -558,7 +558,7 @@ mod test {
 
             let v = wr.unwrap();
             assert_eq!(v.len(), times * len);
-            assert!(v.iter().all(|x| *x == 5));
+            assert!(v.iter().all(ref |x| *x == 5));
         });
     }
 
@@ -604,7 +604,7 @@ mod test {
 
     #[bench]
     fn bench_mem_reader(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let buf = Vec::from_slice([5 as u8, ..100]);
             {
                 let mut rdr = MemReader::new(buf);
@@ -619,7 +619,7 @@ mod test {
 
     #[bench]
     fn bench_buf_writer(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let mut buf = [0 as u8, ..100];
             {
                 let mut wr = BufWriter::new(buf);
@@ -633,7 +633,7 @@ mod test {
 
     #[bench]
     fn bench_buf_reader(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             let buf = [5 as u8, ..100];
             {
                 let mut rdr = BufReader::new(buf);

--- a/src/libstd/io/signal.rs
+++ b/src/libstd/io/signal.rs
@@ -134,7 +134,7 @@ impl Listener {
         if self.handles.iter().any(|&(sig, _)| sig == signum) {
             return Ok(()); // self is already listening to signum, so succeed
         }
-        match LocalIo::maybe_raise(|io| {
+        match LocalIo::maybe_raise(ref |io| {
             io.signal(signum as int, box SignalCallback {
                 signum: signum,
                 tx: self.tx.clone(),

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -786,6 +786,6 @@ mod bench {
     #[bench]
     fn bench_pow_function(b: &mut Bencher) {
         let v = Vec::from_fn(1024u, |n| n);
-        b.iter(|| {v.iter().fold(0u, |old, new| num::pow(old, *new));});
+        b.iter(ref || {v.iter().fold(0u, |old, new| num::pow(old, *new));});
     }
 }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -479,7 +479,7 @@ pub fn float_to_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Float+
                 _ => unreachable!()
             } as u8);
 
-            int_to_str_bytes_common(exp, 10, sign, |c| buf.push(c));
+            int_to_str_bytes_common(exp, 10, sign, ref |c| buf.push(c));
         }
     }
 
@@ -824,31 +824,31 @@ mod bench {
         #[bench]
         fn to_str_bin(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<uint>().to_str_radix(2); })
+            b.iter(ref || { rng.gen::<uint>().to_str_radix(2); })
         }
 
         #[bench]
         fn to_str_oct(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<uint>().to_str_radix(8); })
+            b.iter(ref || { rng.gen::<uint>().to_str_radix(8); })
         }
 
         #[bench]
         fn to_str_dec(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<uint>().to_str_radix(10); })
+            b.iter(ref || { rng.gen::<uint>().to_str_radix(10); })
         }
 
         #[bench]
         fn to_str_hex(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<uint>().to_str_radix(16); })
+            b.iter(ref || { rng.gen::<uint>().to_str_radix(16); })
         }
 
         #[bench]
         fn to_str_base_36(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<uint>().to_str_radix(36); })
+            b.iter(ref || { rng.gen::<uint>().to_str_radix(36); })
         }
     }
 
@@ -860,31 +860,31 @@ mod bench {
         #[bench]
         fn to_str_bin(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<int>().to_str_radix(2); })
+            b.iter(ref || { rng.gen::<int>().to_str_radix(2); })
         }
 
         #[bench]
         fn to_str_oct(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<int>().to_str_radix(8); })
+            b.iter(ref || { rng.gen::<int>().to_str_radix(8); })
         }
 
         #[bench]
         fn to_str_dec(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<int>().to_str_radix(10); })
+            b.iter(ref || { rng.gen::<int>().to_str_radix(10); })
         }
 
         #[bench]
         fn to_str_hex(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<int>().to_str_radix(16); })
+            b.iter(ref || { rng.gen::<int>().to_str_radix(16); })
         }
 
         #[bench]
         fn to_str_base_36(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { rng.gen::<int>().to_str_radix(36); })
+            b.iter(ref || { rng.gen::<int>().to_str_radix(36); })
         }
     }
 
@@ -896,7 +896,7 @@ mod bench {
         #[bench]
         fn float_to_string(b: &mut Bencher) {
             let mut rng = weak_rng();
-            b.iter(|| { f64::to_string(rng.gen()); })
+            b.iter(ref || { f64::to_string(rng.gen()); })
         }
     }
 }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -282,7 +282,7 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
                        os::last_os_error());
             }
             let mut result = Vec::new();
-            ptr::array_each(environ, |e| {
+            ptr::array_each(environ, ref |e| {
                 let env_pair =
                     Vec::from_slice(CString::new(e, false).as_bytes_no_nul());
                 result.push(env_pair);

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -1258,7 +1258,7 @@ mod bench {
     #[bench]
     fn join_home_dir(b: &mut Bencher) {
         let posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.join("home");
         });
     }
@@ -1266,7 +1266,7 @@ mod bench {
     #[bench]
     fn join_abs_path_home_dir(b: &mut Bencher) {
         let posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.join("/home");
         });
     }
@@ -1274,7 +1274,7 @@ mod bench {
     #[bench]
     fn join_many_home_dir(b: &mut Bencher) {
         let posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.join_many(&["home"]);
         });
     }
@@ -1282,7 +1282,7 @@ mod bench {
     #[bench]
     fn join_many_abs_path_home_dir(b: &mut Bencher) {
         let posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.join_many(&["/home"]);
         });
     }
@@ -1290,7 +1290,7 @@ mod bench {
     #[bench]
     fn push_home_dir(b: &mut Bencher) {
         let mut posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.push("home");
         });
     }
@@ -1298,7 +1298,7 @@ mod bench {
     #[bench]
     fn push_abs_path_home_dir(b: &mut Bencher) {
         let mut posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.push("/home");
         });
     }
@@ -1306,7 +1306,7 @@ mod bench {
     #[bench]
     fn push_many_home_dir(b: &mut Bencher) {
         let mut posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.push_many(&["home"]);
         });
     }
@@ -1314,7 +1314,7 @@ mod bench {
     #[bench]
     fn push_many_abs_path_home_dir(b: &mut Bencher) {
         let mut posix_path = Path::new("/");
-        b.iter(|| {
+        b.iter(ref || {
             posix_path.push_many(&["/home"]);
         });
     }
@@ -1322,7 +1322,7 @@ mod bench {
     #[bench]
     fn ends_with_path_home_dir(b: &mut Bencher) {
         let posix_home_path = Path::new("/home");
-        b.iter(|| {
+        b.iter(ref || {
             posix_home_path.ends_with_path(&Path::new("home"));
         });
     }
@@ -1330,7 +1330,7 @@ mod bench {
     #[bench]
     fn ends_with_path_missmatch_jome_home(b: &mut Bencher) {
         let posix_home_path = Path::new("/home");
-        b.iter(|| {
+        b.iter(ref || {
             posix_home_path.ends_with_path(&Path::new("jome"));
         });
     }
@@ -1340,7 +1340,7 @@ mod bench {
         let path = Path::new("/home/1/2/3/4/5/6/7/8/9");
         let mut sub = path.clone();
         sub.pop();
-        b.iter(|| {
+        b.iter(ref || {
             path.is_ancestor_of(&sub);
         });
     }
@@ -1350,7 +1350,7 @@ mod bench {
         let path = Path::new("/a/b/c");
         let mut other = path.clone();
         other.pop();
-        b.iter(|| {
+        b.iter(ref || {
             path.path_relative_from(&other);
         });
     }
@@ -1361,7 +1361,7 @@ mod bench {
         let mut other = path.clone();
         other.pop();
         other.push("d");
-        b.iter(|| {
+        b.iter(ref || {
             path.path_relative_from(&other);
         });
     }
@@ -1371,7 +1371,7 @@ mod bench {
         let path = Path::new("/a/b");
         let mut other = path.clone();
         other.push("c");
-        b.iter(|| {
+        b.iter(ref || {
             path.path_relative_from(&other);
         });
     }

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1044,7 +1044,7 @@ fn parse_prefix<'a>(mut path: &'a str) -> Option<PathPrefix> {
 
     fn parse_two_comps<'a>(mut path: &'a str, f: |char| -> bool)
                        -> Option<(uint, uint)> {
-        let idx_a = match path.find(|x| f(x)) {
+        let idx_a = match path.find(ref |x| f(x)) {
             None => return None,
             Some(x) => x
         };

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -579,7 +579,7 @@ mod bench {
     #[bench]
     fn rand_xorshift(b: &mut Bencher) {
         let mut rng: XorShiftRng = OsRng::new().unwrap().gen();
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, RAND_BENCH_N) {
                 rng.gen::<uint>();
             }
@@ -590,7 +590,7 @@ mod bench {
     #[bench]
     fn rand_isaac(b: &mut Bencher) {
         let mut rng: IsaacRng = OsRng::new().unwrap().gen();
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, RAND_BENCH_N) {
                 rng.gen::<uint>();
             }
@@ -601,7 +601,7 @@ mod bench {
     #[bench]
     fn rand_isaac64(b: &mut Bencher) {
         let mut rng: Isaac64Rng = OsRng::new().unwrap().gen();
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, RAND_BENCH_N) {
                 rng.gen::<uint>();
             }
@@ -612,7 +612,7 @@ mod bench {
     #[bench]
     fn rand_std(b: &mut Bencher) {
         let mut rng = StdRng::new().unwrap();
-        b.iter(|| {
+        b.iter(ref || {
             for _ in range(0, RAND_BENCH_N) {
                 rng.gen::<uint>();
             }
@@ -624,7 +624,7 @@ mod bench {
     fn rand_shuffle_100(b: &mut Bencher) {
         let mut rng = weak_rng();
         let x : &mut[uint] = [1,..100];
-        b.iter(|| {
+        b.iter(ref || {
             rng.shuffle(x);
         })
     }

--- a/src/libsync/comm/oneshot.rs
+++ b/src/libsync/comm/oneshot.rs
@@ -138,7 +138,7 @@ impl<T: Send> Packet<T> {
         // like we're not empty, then immediately go through to `try_recv`.
         if self.state.load(atomic::SeqCst) == EMPTY {
             let t: Box<Task> = Local::take();
-            t.deschedule(1, |task| {
+            t.deschedule(1, ref |task| {
                 let n = unsafe { task.cast_to_uint() };
                 match self.state.compare_and_swap(EMPTY, n, atomic::SeqCst) {
                     // Nothing on the channel, we legitimately block

--- a/src/libsync/comm/select.rs
+++ b/src/libsync/comm/select.rs
@@ -182,7 +182,7 @@ impl Select {
             // sequentially until one fails. If one fails, then abort
             // immediately so we can go unblock on all the other receivers.
             let task: Box<Task> = Local::take();
-            task.deschedule(amt, |task| {
+            task.deschedule(amt, ref |task| {
                 // Prepare for the block
                 let (i, handle) = iter.next().unwrap();
                 match (*handle).packet.start_selection(task) {

--- a/src/libsync/comm/shared.rs
+++ b/src/libsync/comm/shared.rs
@@ -230,7 +230,7 @@ impl<T: Send> Packet<T> {
         }
 
         let task: Box<Task> = Local::take();
-        task.deschedule(1, |task| {
+        task.deschedule(1, ref |task| {
             self.decrement(task)
         });
 

--- a/src/libsync/comm/stream.rs
+++ b/src/libsync/comm/stream.rs
@@ -181,7 +181,7 @@ impl<T: Send> Packet<T> {
         // Welp, our channel has no data. Deschedule the current task and
         // initiate the blocking protocol.
         let task: Box<Task> = Local::take();
-        task.deschedule(1, |task| {
+        task.deschedule(1, ref |task| {
             self.decrement(task)
         });
 

--- a/src/libsync/comm/sync.rs
+++ b/src/libsync/comm/sync.rs
@@ -452,7 +452,7 @@ impl Queue {
             task: None,
             next: 0 as *mut Node,
         };
-        task.deschedule(1, |task| {
+        task.deschedule(1, ref |task| {
             node.task = Some(task);
             if self.tail.is_null() {
                 self.head = &mut node as *mut Node;

--- a/src/libsync/deque.rs
+++ b/src/libsync/deque.rs
@@ -170,7 +170,7 @@ impl<T: Send> BufferPool<T> {
     fn free(&self, buf: Box<Buffer<T>>) {
         unsafe {
             let mut pool = self.pool.lock();
-            match pool.iter().position(|v| v.size() > buf.size()) {
+            match pool.iter().position(ref |v| v.size() > buf.size()) {
                 Some(i) => pool.insert(i, buf),
                 None => pool.push(buf),
             }

--- a/src/libsync/mutex.rs
+++ b/src/libsync/mutex.rs
@@ -251,7 +251,7 @@ impl StaticMutex {
         // of lock stealing the lock, it's also possible for native/native
         // contention to hit this location, but as less common.
         let t: Box<Task> = Local::take();
-        t.deschedule(1, |task| {
+        t.deschedule(1, ref |task| {
             let task = unsafe { task.cast_to_uint() };
 
             // These accesses are protected by the respective native/green
@@ -336,7 +336,7 @@ impl StaticMutex {
         }
 
         let mut node = q::Node::new(0);
-        t.deschedule(1, |task| {
+        t.deschedule(1, ref |task| {
             unsafe {
                 node.data = task.cast_to_uint();
                 self.q.push(&mut node);

--- a/src/libsync/one.rs
+++ b/src/libsync/one.rs
@@ -130,9 +130,9 @@ mod test {
     fn smoke_once() {
         static mut o: Once = ONCE_INIT;
         let mut a = 0i;
-        unsafe { o.doit(|| a += 1); }
+        unsafe { o.doit(ref || a += 1); }
         assert_eq!(a, 1);
-        unsafe { o.doit(|| a += 1); }
+        unsafe { o.doit(ref || a += 1); }
         assert_eq!(a, 1);
     }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -531,7 +531,9 @@ impl<'a, O: IdVisitingOperation> Visitor<()> for IdVisitor<'a, O> {
                         id: NodeId,
                         _: ()) {
         self.operation.visit_id(id);
-        struct_def.ctor_id.map(|ctor_id| self.operation.visit_id(ctor_id));
+        struct_def.ctor_id.map(ref |ctor_id| {
+            self.operation.visit_id(ctor_id)
+        });
         visit::walk_struct_def(self, struct_def, ());
     }
 
@@ -614,18 +616,20 @@ pub fn walk_pat(pat: &Pat, it: |&Pat| -> bool) -> bool {
     match pat.node {
         PatIdent(_, _, Some(ref p)) => walk_pat(&**p, it),
         PatStruct(_, ref fields, _) => {
-            fields.iter().all(|field| walk_pat(&*field.pat, |p| it(p)))
+            fields.iter().all(ref |field| {
+                walk_pat(&*field.pat, ref |p| it(p))
+            })
         }
         PatEnum(_, Some(ref s)) | PatTup(ref s) => {
-            s.iter().all(|p| walk_pat(&**p, |p| it(p)))
+            s.iter().all(ref |p| walk_pat(&**p, ref |p| it(p)))
         }
         PatBox(ref s) | PatRegion(ref s) => {
             walk_pat(&**s, it)
         }
         PatVec(ref before, ref slice, ref after) => {
-            before.iter().all(|p| walk_pat(&**p, |p| it(p))) &&
-            slice.iter().all(|p| walk_pat(&**p, |p| it(p))) &&
-            after.iter().all(|p| walk_pat(&**p, |p| it(p)))
+            before.iter().all(ref |p| walk_pat(&**p, ref |p| it(p))) &&
+            slice.iter().all(ref |p| walk_pat(&**p, ref |p| it(p))) &&
+            after.iter().all(ref |p| walk_pat(&**p, ref |p| it(p)))
         }
         PatMac(_) => fail!("attempted to analyze unexpanded pattern"),
         PatWild(_) | PatLit(_) | PatRange(_, _) | PatIdent(_, _, _) |

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -317,7 +317,7 @@ pub fn test_cfg<AM: AttrMetaMethods, It: Iterator<AM>>
 
     // this would be much nicer as a chain of iterator adaptors, but
     // this doesn't work.
-    let some_cfg_matches = metas.fold(false, |matches, mi| {
+    let some_cfg_matches = metas.fold(false, ref |matches, mi| {
         debug!("testing name: {}", mi.name());
         let this_matches = if mi.check_name("cfg") { // it is a #[cfg()] attribute
             debug!("is cfg");
@@ -326,7 +326,7 @@ pub fn test_cfg<AM: AttrMetaMethods, It: Iterator<AM>>
             match mi.meta_item_list() {
                 Some(cfg_meta) => {
                     debug!("is cfg(...)");
-                    cfg_meta.iter().all(|cfg_mi| {
+                    cfg_meta.iter().all(ref |cfg_mi| {
                         debug!("cfg({}[...])", cfg_mi.name());
                         match cfg_mi.node {
                             ast::MetaList(ref s, ref not_cfgs)
@@ -334,7 +334,7 @@ pub fn test_cfg<AM: AttrMetaMethods, It: Iterator<AM>>
                                 debug!("not!");
                                 // inside #[cfg(not(...))], so these need to all
                                 // not match.
-                                !not_cfgs.iter().all(|mi| {
+                                !not_cfgs.iter().all(ref |mi| {
                                     debug!("cfg(not({}[...]))", mi.name());
                                     contains(cfg, *mi)
                                 })

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -39,7 +39,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
                 args: Vec::new(),
                 ret_ty: Self,
                 attributes: attrs,
-                combine_substructure: combine_substructure(|c, s, sub| {
+                combine_substructure: combine_substructure(ref |c, s, sub| {
                     cs_clone("Clone", c, s, sub)
                 }),
             }
@@ -49,15 +49,17 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn cs_clone(
-    name: &str,
-    cx: &mut ExtCtxt, trait_span: Span,
-    substr: &Substructure) -> Gc<Expr> {
+fn cs_clone(name: &str,
+            cx: &mut ExtCtxt,
+            trait_span: Span,
+            substr: &Substructure)
+            -> Gc<Expr> {
     let clone_ident = substr.method_ident;
     let ctor_ident;
     let all_fields;
-    let subcall = |field: &FieldInfo|
-        cx.expr_method_call(field.span, field.self_, clone_ident, Vec::new());
+    let subcall = ref |field: &FieldInfo| {
+        cx.expr_method_call(field.span, field.self_, clone_ident, Vec::new())
+    };
 
     match *substr.fields {
         Struct(ref af) => {
@@ -87,7 +89,7 @@ fn cs_clone(
         cx.expr_call_ident(trait_span, ctor_ident, subcalls)
     } else {
         // struct-like
-        let fields = all_fields.iter().map(|field| {
+        let fields = all_fields.iter().map(ref |field| {
             let ident = match field.name {
                 Some(i) => i,
                 None => {

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -25,14 +25,19 @@ pub fn expand_deriving_totaleq(cx: &mut ExtCtxt,
                                push: |Gc<Item>|) {
     fn cs_total_eq_assert(cx: &mut ExtCtxt, span: Span,
                           substr: &Substructure) -> Gc<Expr> {
-        cs_same_method(|cx, span, exprs| {
+        cs_same_method(ref |cx, span, exprs| {
             // create `a.<method>(); b.<method>(); c.<method>(); ...`
             // (where method is `assert_receiver_is_total_eq`)
-            let stmts = exprs.move_iter().map(|e| cx.stmt_expr(e)).collect();
+            let stmts = exprs.move_iter()
+                             .map(ref |e| cx.stmt_expr(e))
+                             .collect();
             let block = cx.block(span, stmts, None);
             cx.expr_block(block)
         },
-                       |cx, sp, _, _| cx.span_bug(sp, "non matching enums in deriving(Eq)?"),
+                       ref |cx, sp, _, _| {
+                           cx.span_bug(sp,
+                                       "non matching enums in deriving(Eq)?")
+                       },
                        cx,
                        span,
                        substr)
@@ -57,7 +62,7 @@ pub fn expand_deriving_totaleq(cx: &mut ExtCtxt,
                 args: vec!(),
                 ret_ty: nil_ty(),
                 attributes: attrs,
-                combine_substructure: combine_substructure(|a, b, c| {
+                combine_substructure: combine_substructure(ref |a, b, c| {
                     cs_total_eq_assert(a, b, c)
                 })
             }

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -40,7 +40,7 @@ pub fn expand_deriving_totalord(cx: &mut ExtCtxt,
                 args: vec!(borrowed_self()),
                 ret_ty: Literal(Path::new(vec!("std", "cmp", "Ordering"))),
                 attributes: attrs,
-                combine_substructure: combine_substructure(|a, b, c| {
+                combine_substructure: combine_substructure(ref |a, b, c| {
                     cs_cmp(a, b, c)
                 }),
             }
@@ -88,7 +88,7 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
         // foldr nests the if-elses correctly, leaving the first field
         // as the outermost one, and the last as the innermost.
         false,
-        |cx, span, old, new| {
+        ref |cx, span, old, new| {
             // let __test = new;
             // if __test == ::std::cmp::Equal {
             //    old
@@ -107,7 +107,7 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
             cx.expr_block(cx.block(span, vec!(assign), Some(if_)))
         },
         cx.expr_path(equals_path.clone()),
-        |cx, span, (self_args, tag_tuple), _non_self_args| {
+        ref |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
                 cx.span_bug(span, "not exactly 2 arguments in `deriving(TotalOrd)`")
             } else {

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -54,7 +54,7 @@ pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
                                           vec!(box Self,
                                                box Literal(Path::new_local("__E"))), true)),
                 attributes: Vec::new(),
-                combine_substructure: combine_substructure(|a, b, c| {
+                combine_substructure: combine_substructure(ref |a, b, c| {
                     decodable_substructure(a, b, c)
                 }),
             })
@@ -166,7 +166,7 @@ fn decode_static_fields(cx: &mut ExtCtxt,
             if fields.is_empty() {
                 cx.expr_ident(trait_span, outer_pat_ident)
             } else {
-                let fields = fields.iter().enumerate().map(|(i, &span)| {
+                let fields = fields.iter().enumerate().map(ref |(i, &span)| {
                     getarg(cx, span,
                            token::intern_and_get_ident(format!("_field{}",
                                                                i).as_slice()),
@@ -178,7 +178,9 @@ fn decode_static_fields(cx: &mut ExtCtxt,
         }
         Named(ref fields) => {
             // use the field's span to get nicer error messages.
-            let fields = fields.iter().enumerate().map(|(i, &(name, span))| {
+            let fields = fields.iter()
+                               .enumerate()
+                               .map(ref |(i, &(name, span))| {
                 let arg = getarg(cx, span, token::get_ident(name), i);
                 cx.field_imm(span, name, arg)
             }).collect();

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -54,7 +54,7 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
                 args: vec!(Ptr(box Literal(args), Borrowed(None, MutMutable))),
                 ret_ty: nil_ty(),
                 attributes: attrs,
-                combine_substructure: combine_substructure(|a, b, c| {
+                combine_substructure: combine_substructure(ref |a, b, c| {
                     hash_substructure(a, b, c)
                 })
             }
@@ -71,7 +71,7 @@ fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span,
         _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(Hash)`")
     };
     let hash_ident = substr.method_ident;
-    let call_hash = |span, thing_expr| {
+    let call_hash = ref |span, thing_expr| {
         let expr = cx.expr_method_call(span, thing_expr, hash_ident, vec!(state_expr));
         cx.stmt_expr(expr)
     };

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -68,9 +68,13 @@ pub fn expand_meta_deriving(cx: &mut ExtCtxt,
                     MetaNameValue(ref tname, _) |
                     MetaList(ref tname, _) |
                     MetaWord(ref tname) => {
-                        macro_rules! expand(($func:path) => ($func(cx, titem.span,
-                                                                   titem, item,
-                                                                   |i| push(i))));
+                        macro_rules! expand(($func:path) => ($func(cx,
+                                                                   titem.span,
+                                                                   titem,
+                                                                   item,
+                                                                   ref |i| {
+                                                                       push(i)
+                                                                   })));
                         match tname.get() {
                             "Clone" => expand!(clone::expand_deriving_clone),
 

--- a/src/libsyntax/ext/deriving/zero.rs
+++ b/src/libsyntax/ext/deriving/zero.rs
@@ -51,11 +51,11 @@ pub fn expand_deriving_zero(cx: &mut ExtCtxt,
                 ret_ty: Literal(Path::new(vec!("bool"))),
                 attributes: attrs,
                 combine_substructure: combine_substructure(|cx, span, substr| {
-                    cs_and(|cx, span, _, _| cx.span_bug(span,
-                                                        "Non-matching enum \
-                                                         variant in \
-                                                         deriving(Zero)"),
-                           cx, span, substr)
+                    cs_and(ref |cx, span, _, _| {
+                        cx.span_bug(span,
+                                    "Non-matching enum variant in \
+                                     deriving(Zero)")
+                    }, cx, span, substr)
                 })
             }
         )
@@ -71,7 +71,9 @@ fn zero_substructure(cx: &mut ExtCtxt, trait_span: Span,
         cx.ident_of("Zero"),
         cx.ident_of("zero")
     );
-    let zero_call = |span| cx.expr_call_global(span, zero_ident.clone(), Vec::new());
+    let zero_call = ref |span| {
+        cx.expr_call_global(span, zero_ident.clone(), Vec::new())
+    };
 
     return match *substr.fields {
         StaticStruct(_, ref summary) => {
@@ -80,12 +82,14 @@ fn zero_substructure(cx: &mut ExtCtxt, trait_span: Span,
                     if fields.is_empty() {
                         cx.expr_ident(trait_span, substr.type_ident)
                     } else {
-                        let exprs = fields.iter().map(|sp| zero_call(*sp)).collect();
+                        let exprs = fields.iter()
+                                          .map(ref |sp| zero_call(*sp))
+                                          .collect();
                         cx.expr_call_ident(trait_span, substr.type_ident, exprs)
                     }
                 }
                 Named(ref fields) => {
-                    let zero_fields = fields.iter().map(|&(ident, span)| {
+                    let zero_fields = fields.iter().map(ref |&(ident, span)| {
                         cx.field_imm(span, ident, zero_call(span))
                     }).collect();
                     cx.expr_struct_ident(trait_span, substr.type_ident, zero_fields)

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -735,8 +735,9 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt, sp: Span,
                 cx.verify_piece(&piece);
                 match cx.trans_piece(&piece) {
                     Some(piece) => {
-                        cx.trans_literal_string().map(|piece|
-                                                      cx.pieces.push(piece));
+                        cx.trans_literal_string().map(ref |piece| {
+                            cx.pieces.push(piece)
+                        });
                         cx.pieces.push(piece);
                     }
                     None => {}
@@ -754,7 +755,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt, sp: Span,
         }
         None => {}
     }
-    cx.trans_literal_string().map(|piece| cx.pieces.push(piece));
+    cx.trans_literal_string().map(ref |piece| cx.pieces.push(piece));
 
     // Make sure that all arguments were used and all arguments have types.
     for (i, ty) in cx.arg_types.iter().enumerate() {

--- a/src/libsyntax/parse/lexer/comments.rs
+++ b/src/libsyntax/parse/lexer/comments.rs
@@ -368,7 +368,7 @@ pub fn gather_comments_and_literals(span_diagnostic: &diagnostic::SpanHandler,
         //discard, and look ahead; we're working with internal state
         let TokenAndSpan {tok: tok, sp: sp} = rdr.peek();
         if token::is_lit(&tok) {
-            rdr.with_str_from(bstart, |s| {
+            rdr.with_str_from(bstart, ref |s| {
                 debug!("tok lit: {}", s);
                 literals.push(Literal {lit: s.to_string(), pos: sp.lo});
             })

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2501,7 +2501,7 @@ impl<'a> State<'a> {
             try!(self.pclose());
         }
 
-        opt_bounds.as_ref().map(|bounds| {
+        opt_bounds.as_ref().map(ref |bounds| {
             self.print_bounds(opt_region, bounds, true, false)
         });
 
@@ -2585,13 +2585,13 @@ impl<'a> State<'a> {
             ast::LitStr(ref st, style) => self.print_string(st.get(), style),
             ast::LitByte(byte) => {
                 let mut res = String::from_str("b'");
-                (byte as char).escape_default(|c| res.push_char(c));
+                (byte as char).escape_default(ref |c| res.push_char(c));
                 res.push_char('\'');
                 word(&mut self.s, res.as_slice())
             }
             ast::LitChar(ch) => {
                 let mut res = String::from_str("'");
-                ch.escape_default(|c| res.push_char(c));
+                ch.escape_default(ref |c| res.push_char(c));
                 res.push_char('\'');
                 word(&mut self.s, res.as_slice())
             }

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -820,14 +820,14 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn> ) -> io::IoR
             PadOnLeft | PadOnRight => t.desc.name.as_slice().len(),
         }
     }
-    match tests.iter().max_by(|t|len_if_padded(*t)) {
+    match tests.iter().max_by(ref |t| len_if_padded(*t)) {
         Some(t) => {
             let n = t.desc.name.as_slice();
             st.max_name_len = n.len();
         },
         None => {}
     }
-    try!(run_tests(opts, tests, |x| callback(&x, &mut st)));
+    try!(run_tests(opts, tests, ref |x| callback(&x, &mut st)));
     match opts.save_metrics {
         None => (),
         Some(ref pth) => {
@@ -1306,7 +1306,7 @@ impl Bencher {
 
         // Initial bench run to get ballpark figure.
         let mut n = 1_u64;
-        self.bench_n(n, |x| f(x));
+        self.bench_n(n, ref |x| f(x));
 
         // Try to estimate iter count for 1ms falling back to 1m
         // iterations if first run took < 1ns.
@@ -1328,7 +1328,7 @@ impl Bencher {
             let loop_start = precise_time_ns();
 
             for p in samples.mut_iter() {
-                self.bench_n(n, |x| f(x));
+                self.bench_n(n, ref |x| f(x));
                 *p = self.ns_per_iter() as f64;
             };
 
@@ -1336,7 +1336,7 @@ impl Bencher {
             let summ = stats::Summary::new(samples);
 
             for p in samples.mut_iter() {
-                self.bench_n(5 * n, |x| f(x));
+                self.bench_n(5 * n, ref |x| f(x));
                 *p = self.ns_per_iter() as f64;
             };
 

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -1058,7 +1058,7 @@ mod bench {
 
     #[bench]
     pub fn sum_three_items(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             [1e20f64, 1.5f64, -1e20f64].sum();
         })
     }
@@ -1067,7 +1067,7 @@ mod bench {
         let nums = [-1e30f64, 1e60, 1e30, 1.0, -1e60];
         let v = Vec::from_fn(500, |i| nums[i%5]);
 
-        b.iter(|| {
+        b.iter(ref || {
             v.as_slice().sum();
         })
     }

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -571,21 +571,21 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, String> {
           },
           'c' => {
             parse_type(s, pos, 'a', &mut *tm)
-                .and_then(|pos| parse_char(s, pos, ' '))
-                .and_then(|pos| parse_type(s, pos, 'b', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, ' '))
-                .and_then(|pos| parse_type(s, pos, 'e', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, ' '))
-                .and_then(|pos| parse_type(s, pos, 'T', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, ' '))
-                .and_then(|pos| parse_type(s, pos, 'Y', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ' '))
+                .and_then(ref |pos| parse_type(s, pos, 'b', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ' '))
+                .and_then(ref |pos| parse_type(s, pos, 'e', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ' '))
+                .and_then(ref |pos| parse_type(s, pos, 'T', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ' '))
+                .and_then(ref |pos| parse_type(s, pos, 'Y', &mut *tm))
           }
           'D' | 'x' => {
             parse_type(s, pos, 'm', &mut *tm)
-                .and_then(|pos| parse_char(s, pos, '/'))
-                .and_then(|pos| parse_type(s, pos, 'd', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, '/'))
-                .and_then(|pos| parse_type(s, pos, 'y', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, '/'))
+                .and_then(ref |pos| parse_type(s, pos, 'd', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, '/'))
+                .and_then(ref |pos| parse_type(s, pos, 'y', &mut *tm))
           }
           'd' => match match_digits_in_range(s, pos, 2u, false, 1_i32,
                                              31_i32) {
@@ -604,10 +604,10 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, String> {
           }
           'F' => {
             parse_type(s, pos, 'Y', &mut *tm)
-                .and_then(|pos| parse_char(s, pos, '-'))
-                .and_then(|pos| parse_type(s, pos, 'm', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, '-'))
-                .and_then(|pos| parse_type(s, pos, 'd', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, '-'))
+                .and_then(ref |pos| parse_type(s, pos, 'm', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, '-'))
+                .and_then(ref |pos| parse_type(s, pos, 'd', &mut *tm))
           }
           'H' => {
             match match_digits_in_range(s, pos, 2u, false, 0_i32, 23_i32) {
@@ -682,17 +682,17 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, String> {
           },
           'R' => {
             parse_type(s, pos, 'H', &mut *tm)
-                .and_then(|pos| parse_char(s, pos, ':'))
-                .and_then(|pos| parse_type(s, pos, 'M', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ':'))
+                .and_then(ref |pos| parse_type(s, pos, 'M', &mut *tm))
           }
           'r' => {
             parse_type(s, pos, 'I', &mut *tm)
-                .and_then(|pos| parse_char(s, pos, ':'))
-                .and_then(|pos| parse_type(s, pos, 'M', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, ':'))
-                .and_then(|pos| parse_type(s, pos, 'S', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, ' '))
-                .and_then(|pos| parse_type(s, pos, 'p', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ':'))
+                .and_then(ref |pos| parse_type(s, pos, 'M', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ':'))
+                .and_then(ref |pos| parse_type(s, pos, 'S', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ' '))
+                .and_then(ref |pos| parse_type(s, pos, 'p', &mut *tm))
           }
           'S' => {
             match match_digits_in_range(s, pos, 2u, false, 0_i32, 60_i32) {
@@ -707,10 +707,10 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, String> {
           //'s' {}
           'T' | 'X' => {
             parse_type(s, pos, 'H', &mut *tm)
-                .and_then(|pos| parse_char(s, pos, ':'))
-                .and_then(|pos| parse_type(s, pos, 'M', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, ':'))
-                .and_then(|pos| parse_type(s, pos, 'S', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ':'))
+                .and_then(ref |pos| parse_type(s, pos, 'M', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, ':'))
+                .and_then(ref |pos| parse_type(s, pos, 'S', &mut *tm))
           }
           't' => parse_char(s, pos, '\t'),
           'u' => {
@@ -725,10 +725,10 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, String> {
           }
           'v' => {
             parse_type(s, pos, 'e', &mut *tm)
-                .and_then(|pos|  parse_char(s, pos, '-'))
-                .and_then(|pos| parse_type(s, pos, 'b', &mut *tm))
-                .and_then(|pos| parse_char(s, pos, '-'))
-                .and_then(|pos| parse_type(s, pos, 'Y', &mut *tm))
+                .and_then(ref |pos|  parse_char(s, pos, '-'))
+                .and_then(ref |pos| parse_type(s, pos, 'b', &mut *tm))
+                .and_then(ref |pos| parse_char(s, pos, '-'))
+                .and_then(ref |pos| parse_type(s, pos, 'Y', &mut *tm))
           }
           //'W' {}
           'w' => {
@@ -1575,6 +1575,6 @@ mod tests {
 
     #[bench]
     fn bench_precise_time_ns(b: &mut Bencher) {
-        b.iter(|| precise_time_ns())
+        b.iter(ref || precise_time_ns())
     }
 }

--- a/src/libunicode/normalize.rs
+++ b/src/libunicode/normalize.rs
@@ -53,7 +53,7 @@ fn d(c: char, i: |char|, k: bool) {
     match bsearch_table(c, canonical_table) {
         Some(canon) => {
             for x in canon.iter() {
-                d(*x, |b| i(b), k);
+                d(*x, ref |b| i(b), k);
             }
             return;
         }
@@ -67,7 +67,7 @@ fn d(c: char, i: |char|, k: bool) {
     match bsearch_table(c, compatibility_table) {
         Some(compat) => {
             for x in compat.iter() {
-                d(*x, |b| i(b), k);
+                d(*x, ref |b| i(b), k);
             }
             return;
         }

--- a/src/liburl/lib.rs
+++ b/src/liburl/lib.rs
@@ -315,7 +315,7 @@ pub fn encode_form_urlencoded(m: &HashMap<String, Vec<String>>) -> String {
     }
 
     let mut first = true;
-    m.iter().fold(String::new(), |mut out, (key, values)| {
+    m.iter().fold(String::new(), ref |mut out, (key, values)| {
         let key = encode_plus(key);
 
         for value in values.iter() {

--- a/src/libuuid/lib.rs
+++ b/src/libuuid/lib.rs
@@ -843,7 +843,7 @@ mod bench {
 
     #[bench]
     pub fn create_uuids(b: &mut Bencher) {
-        b.iter(|| {
+        b.iter(ref || {
             Uuid::new_v4();
         })
     }
@@ -851,7 +851,7 @@ mod bench {
     #[bench]
     pub fn uuid_to_string(b: &mut Bencher) {
         let u = Uuid::new_v4();
-        b.iter(|| {
+        b.iter(ref || {
             u.to_string();
         })
     }
@@ -859,7 +859,7 @@ mod bench {
     #[bench]
     pub fn parse_str(b: &mut Bencher) {
         let s = "urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4";
-        b.iter(|| {
+        b.iter(ref || {
             Uuid::parse_string(s).unwrap();
         })
     }

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -25,19 +25,19 @@ fn timed(label: &str, f: ||) {
 fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
     println!(" Ascending integers:");
 
-    timed("insert", || {
+    timed("insert", ref || {
         for i in range(0u, n_keys) {
             map.insert(i, i + 1);
         }
     });
 
-    timed("search", || {
+    timed("search", ref || {
         for i in range(0u, n_keys) {
             assert_eq!(map.find(&i).unwrap(), &(i + 1));
         }
     });
 
-    timed("remove", || {
+    timed("remove", ref || {
         for i in range(0, n_keys) {
             assert!(map.remove(&i));
         }
@@ -47,19 +47,19 @@ fn ascending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
 fn descending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
     println!(" Descending integers:");
 
-    timed("insert", || {
+    timed("insert", ref || {
         for i in range(0, n_keys).rev() {
             map.insert(i, i + 1);
         }
     });
 
-    timed("search", || {
+    timed("search", ref || {
         for i in range(0, n_keys).rev() {
             assert_eq!(map.find(&i).unwrap(), &(i + 1));
         }
     });
 
-    timed("remove", || {
+    timed("remove", ref || {
         for i in range(0, n_keys) {
             assert!(map.remove(&i));
         }
@@ -67,19 +67,19 @@ fn descending<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint) {
 }
 
 fn vector<M: MutableMap<uint, uint>>(map: &mut M, n_keys: uint, dist: &[uint]) {
-    timed("insert", || {
+    timed("insert", ref || {
         for i in range(0u, n_keys) {
             map.insert(dist[i], i + 1);
         }
     });
 
-    timed("search", || {
+    timed("search", ref || {
         for i in range(0u, n_keys) {
             assert_eq!(map.find(&dist[i]).unwrap(), &(i + 1));
         }
     });
 
-    timed("remove", || {
+    timed("remove", ref || {
         for i in range(0u, n_keys) {
             assert!(map.remove(&dist[i]));
         }

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -49,7 +49,9 @@ fn maybe_run_test(argv: &[String], name: String, test: ||) {
     if os::getenv("RUST_BENCH").is_some() {
         run_test = true
     } else if argv.len() > 0 {
-        run_test = argv.iter().any(|x| x == &"all".to_string()) || argv.iter().any(|x| x == &name)
+        run_test = argv.iter()
+                       .any(ref |x| x == &"all".to_string()) ||
+                    argv.iter().any(ref |x| x == &name)
     }
 
     if !run_test {

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -147,7 +147,7 @@ fn rendezvous(nn: uint, set: Vec<Color>) {
 
     // these channels will allow us to talk to each creature by 'name'/index
     let mut to_creature: Vec<Sender<CreatureInfo>> =
-        set.iter().enumerate().map(|(ii, &col)| {
+        set.iter().enumerate().map(ref |(ii, &col)| {
             // create each creature as a listener with a port, and
             // give us a channel to talk to each
             let to_rendezvous = to_rendezvous.clone();
@@ -198,7 +198,7 @@ fn main() {
     } else {
         std::os::args().as_slice()
                        .get(1)
-                       .and_then(|arg| from_str(arg.as_slice()))
+                       .and_then(ref |arg| from_str(arg.as_slice()))
                        .unwrap_or(600)
     };
 

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -44,8 +44,8 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
 
    // sort by key, then by value
    fn sortKV(mut orig: Vec<(Vec<u8> ,f64)> ) -> Vec<(Vec<u8> ,f64)> {
-        orig.sort_by(|&(ref a, _), &(ref b, _)| a.cmp(b));
-        orig.sort_by(|&(_, a), &(_, b)| f64_cmp(b, a));
+        orig.sort_by(ref |&(ref a, _), &(ref b, _)| a.cmp(b));
+        orig.sort_by(ref |&(_, a), &(_, b)| f64_cmp(b, a));
         orig
    }
 
@@ -120,7 +120,7 @@ fn make_sequence_processor(sz: uint,
 
        carry = windows_with_carry(carry.append(line.as_slice()).as_slice(),
                                   sz,
-                                  |window| {
+                                  ref |window| {
          update_freq(&mut freqs, window);
          total += 1u;
       });
@@ -155,9 +155,12 @@ fn main() {
 
     // initialize each sequence sorter
     let sizes = vec!(1u,2,3,4,6,12,18);
-    let mut streams = Vec::from_fn(sizes.len(), |_| Some(channel::<String>()));
+    let mut streams = Vec::from_fn(sizes.len(),
+                                   ref |_| Some(channel::<String>()));
     let mut from_child = Vec::new();
-    let to_child  = sizes.iter().zip(streams.mut_iter()).map(|(sz, stream_ref)| {
+    let to_child = sizes.iter()
+                        .zip(streams.mut_iter())
+                        .map(ref |(sz, stream_ref)| {
         let sz = *sz;
         let stream = replace(stream_ref, None);
         let (to_parent_, from_child_) = stream.unwrap();

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -75,7 +75,7 @@ impl Code {
     }
 
     fn pack(string: &str) -> Code {
-        string.bytes().fold(Code(0u64), |a, b| a.push_char(b))
+        string.bytes().fold(Code(0u64), ref |a, b| a.push_char(b))
     }
 
     fn unpack(&self, frame: uint) -> String {
@@ -133,7 +133,7 @@ impl Table {
     fn new() -> Table {
         Table {
             count: 0,
-            items: Vec::from_fn(TABLE_SIZE, |_| None),
+            items: Vec::from_fn(TABLE_SIZE, ref |_| None),
         }
     }
 
@@ -278,8 +278,8 @@ fn print_occurrences(frequencies: &mut Table, occurrence: &'static str) {
 
 fn get_sequence<R: Buffer>(r: &mut R, key: &str) -> Vec<u8> {
     let mut res = Vec::new();
-    for l in r.lines().map(|l| l.ok().unwrap())
-        .skip_while(|l| key != l.as_slice().slice_to(key.len())).skip(1)
+    for l in r.lines().map(ref |l| l.ok().unwrap())
+        .skip_while(ref |l| key != l.as_slice().slice_to(key.len())).skip(1)
     {
         res.push_all(l.as_slice().trim().as_bytes());
     }
@@ -298,11 +298,11 @@ fn main() {
     };
     let input = Arc::new(input);
 
-    let nb_freqs: Vec<(uint, Future<Table>)> = range(1u, 3).map(|i| {
+    let nb_freqs: Vec<(uint, Future<Table>)> = range(1u, 3).map(ref |i| {
         let input = input.clone();
         (i, Future::spawn(proc() generate_frequencies(input.as_slice(), i)))
     }).collect();
-    let occ_freqs: Vec<Future<Table>> = OCCURRENCES.iter().map(|&occ| {
+    let occ_freqs: Vec<Future<Table>> = OCCURRENCES.iter().map(ref |&occ| {
         let input = input.clone();
         Future::spawn(proc() generate_frequencies(input.as_slice(), occ.len()))
     }).collect();

--- a/src/test/compile-fail/borrowck-assign-comp-idx.rs
+++ b/src/test/compile-fail/borrowck-assign-comp-idx.rs
@@ -34,14 +34,14 @@ fn b() {
 
     borrow(
         p.as_slice(),
-        || *p.get_mut(0) = 5); //~ ERROR cannot borrow `p` as mutable
+        ref || *p.get_mut(0) = 5); //~ ERROR cannot borrow `p` as mutable
 }
 
 fn c() {
     // Legal because the scope of the borrow does not include the
     // modification:
     let mut p = vec!(1);
-    borrow(p.as_slice(), ||{});
+    borrow(p.as_slice(), ref ||{});
     *p.get_mut(0) = 5;
 }
 

--- a/src/test/compile-fail/borrowck-autoref-3261.rs
+++ b/src/test/compile-fail/borrowck-autoref-3261.rs
@@ -22,7 +22,7 @@ impl X {
 fn main() {
     let mut x = X(Right(main));
     (&mut x).with(
-        |opt| { //~ ERROR cannot borrow `x` as mutable more than once at a time
+        ref |opt| { //~ ERROR cannot borrow `x` as mutable more than once at a time
             match opt {
                 &Right(ref f) => {
                     x = X(Left((0,0)));

--- a/src/test/compile-fail/borrowck-block-unint.rs
+++ b/src/test/compile-fail/borrowck-block-unint.rs
@@ -11,7 +11,7 @@
 fn force(f: ||) { f(); }
 fn main() {
     let x: int;
-    force(|| {  //~ ERROR capture of possibly uninitialized variable: `x`
+    force(ref || {  //~ ERROR capture of possibly uninitialized variable: `x`
         println!("{}", x);
     });
 }

--- a/src/test/compile-fail/borrowck-call-is-borrow-issue-12224.rs
+++ b/src/test/compile-fail/borrowck-call-is-borrow-issue-12224.rs
@@ -18,14 +18,14 @@ struct Test<'a> {
 }
 
 fn call(f: |Fn|) {
-    f(|| {
+    f(ref || {
     //~^ ERROR: closure requires unique access to `f` but it is already borrowed
-        f(|| {})
+        f(ref || {})
     });
 }
 
 fn test1() {
-    call(|a| {
+    call(ref |a| {
         a();
     });
 }
@@ -47,16 +47,16 @@ fn test5(f: &mut Test) {
 }
 
 fn test6() {
-    let f = || {};
-    (|| {
+    let f = ref || {};
+    (ref || {
         f();
     })();
 }
 
 fn test7() {
     fn foo(_: |g: |int|, b: int|) {}
-    let f = |g: |int|, b: int| {};
-    f(|a| { //~ ERROR: cannot borrow `f` as immutable because previous closure
+    let f = ref |g: |int|, b: int| {};
+    f(ref |a| { //~ ERROR: cannot borrow `f` as immutable because previous closure
         foo(f); //~ ERROR: cannot move out of captured outer variable
     }, 3);
 }

--- a/src/test/compile-fail/borrowck-closures-mut-and-imm.rs
+++ b/src/test/compile-fail/borrowck-closures-mut-and-imm.rs
@@ -22,37 +22,37 @@ fn set(x: &mut int) {
 
 fn a() {
     let mut x = 3i;
-    let c1 = || x = 4;
-    let c2 = || x * 5; //~ ERROR cannot borrow `x`
+    let c1 = ref || x = 4;
+    let c2 = ref || x * 5; //~ ERROR cannot borrow `x`
 }
 
 fn b() {
     let mut x = 3i;
-    let c1 = || set(&mut x);
-    let c2 = || get(&x); //~ ERROR cannot borrow `x`
+    let c1 = ref || set(&mut x);
+    let c2 = ref || get(&x); //~ ERROR cannot borrow `x`
 }
 
 fn c() {
     let mut x = 3i;
-    let c1 = || set(&mut x);
-    let c2 = || x * 5; //~ ERROR cannot borrow `x`
+    let c1 = ref || set(&mut x);
+    let c2 = ref || x * 5; //~ ERROR cannot borrow `x`
 }
 
 fn d() {
     let mut x = 3i;
-    let c2 = || x * 5;
+    let c2 = ref || x * 5;
     x = 5; //~ ERROR cannot assign
 }
 
 fn e() {
     let mut x = 3i;
-    let c1 = || get(&x);
+    let c1 = ref || get(&x);
     x = 5; //~ ERROR cannot assign
 }
 
 fn f() {
     let mut x = box 3i;
-    let c1 = || get(&*x);
+    let c1 = ref || get(&*x);
     *x = 5; //~ ERROR cannot assign
 }
 
@@ -62,7 +62,7 @@ fn g() {
     }
 
     let mut x = box Foo { f: box 3 };
-    let c1 = || get(&*x.f);
+    let c1 = ref || get(&*x.f);
     *x.f = 5; //~ ERROR cannot assign to `*x.f`
 }
 
@@ -72,8 +72,8 @@ fn h() {
     }
 
     let mut x = box Foo { f: box 3 };
-    let c1 = || get(&*x.f);
-    let c2 = || *x.f = 5; //~ ERROR cannot borrow `x` as mutable
+    let c1 = ref || get(&*x.f);
+    let c2 = ref || *x.f = 5; //~ ERROR cannot borrow `x` as mutable
 }
 
 fn main() {

--- a/src/test/compile-fail/borrowck-closures-mut-of-imm.rs
+++ b/src/test/compile-fail/borrowck-closures-mut-of-imm.rs
@@ -20,9 +20,9 @@ fn set(x: &mut int) {
 }
 
 fn a(x: &int) {
-    let c1 = || set(&mut *x);
+    let c1 = ref || set(&mut *x);
     //~^ ERROR cannot borrow
-    let c2 = || set(&mut *x);
+    let c2 = ref || set(&mut *x);
     //~^ ERROR closure requires unique access to `x`
     //~^^ ERROR cannot borrow
 }

--- a/src/test/compile-fail/borrowck-closures-two-mut.rs
+++ b/src/test/compile-fail/borrowck-closures-two-mut.rs
@@ -15,8 +15,8 @@
 
 fn a() {
     let mut x = 3i;
-    let c1 = || x = 4;
-    let c2 = || x = 5; //~ ERROR cannot borrow `x` as mutable more than once
+    let c1 = ref || x = 4;
+    let c2 = ref || x = 5; //~ ERROR cannot borrow `x` as mutable more than once
 }
 
 fn set(x: &mut int) {
@@ -25,20 +25,20 @@ fn set(x: &mut int) {
 
 fn b() {
     let mut x = 3i;
-    let c1 = || set(&mut x);
-    let c2 = || set(&mut x); //~ ERROR cannot borrow `x` as mutable more than once
+    let c1 = ref || set(&mut x);
+    let c2 = ref || set(&mut x); //~ ERROR cannot borrow `x` as mutable more than once
 }
 
 fn c() {
     let mut x = 3i;
-    let c1 = || x = 5;
-    let c2 = || set(&mut x); //~ ERROR cannot borrow `x` as mutable more than once
+    let c1 = ref || x = 5;
+    let c2 = ref || set(&mut x); //~ ERROR cannot borrow `x` as mutable more than once
 }
 
 fn d() {
     let mut x = 3i;
-    let c1 = || x = 5;
-    let c2 = || { let _y = || set(&mut x); }; // (nested closure)
+    let c1 = ref || x = 5;
+    let c2 = ref || { let _y = ref || set(&mut x); }; // (nested closure)
     //~^ ERROR cannot borrow `x` as mutable more than once
 }
 
@@ -48,8 +48,8 @@ fn g() {
     }
 
     let mut x = box Foo { f: box 3 };
-    let c1 = || set(&mut *x.f);
-    let c2 = || set(&mut *x.f);
+    let c1 = ref || set(&mut *x.f);
+    let c2 = ref || set(&mut *x.f);
     //~^ ERROR cannot borrow `x` as mutable more than once
 }
 

--- a/src/test/compile-fail/borrowck-closures-unique.rs
+++ b/src/test/compile-fail/borrowck-closures-unique.rs
@@ -23,27 +23,27 @@ fn set(x: &mut int) -> int {
 }
 
 fn a(x: &mut int) {
-    let c1 = || get(x);
-    let c2 = || get(x);
+    let c1 = ref || get(x);
+    let c2 = ref || get(x);
 }
 
 fn b(x: &mut int) {
-    let c1 = || get(x);
-    let c2 = || set(x); //~ ERROR closure requires unique access to `x`
+    let c1 = ref || get(x);
+    let c2 = ref || set(x); //~ ERROR closure requires unique access to `x`
 }
 
 fn c(x: &mut int) {
-    let c1 = || get(x);
-    let c2 = || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
+    let c1 = ref || get(x);
+    let c2 = ref || { get(x); set(x); }; //~ ERROR closure requires unique access to `x`
 }
 
 fn d(x: &mut int) {
-    let c1 = || set(x);
-    let c2 = || set(x); //~ ERROR closure requires unique access to `x`
+    let c1 = ref || set(x);
+    let c2 = ref || set(x); //~ ERROR closure requires unique access to `x`
 }
 
 fn e(x: &mut int) {
-    let c1: || = || x = fail!(); //~ ERROR closure cannot assign to immutable argument `x`
+    let c1: || = ref || x = fail!(); //~ ERROR closure cannot assign to immutable argument `x`
 }
 
 fn main() {

--- a/src/test/compile-fail/borrowck-closures-use-after-free.rs
+++ b/src/test/compile-fail/borrowck-closures-use-after-free.rs
@@ -25,7 +25,7 @@ impl Drop for Foo {
 
 fn main() {
   let mut ptr = box Foo { x: 0 };
-  let test = |foo: &Foo| {
+  let test = ref |foo: &Foo| {
     ptr = box Foo { x: ptr.x + 1 };
   };
   test(&*ptr); //~ ERROR cannot borrow `*ptr`

--- a/src/test/compile-fail/borrowck-insert-during-each.rs
+++ b/src/test/compile-fail/borrowck-insert-during-each.rs
@@ -25,7 +25,7 @@ impl Foo {
 
 fn bar(f: &mut Foo) {
   f.foo(
-        |a| { //~ ERROR closure requires unique access to `f`
+        ref |a| { //~ ERROR closure requires unique access to `f`
             f.n.insert(*a);
         })
 }

--- a/src/test/compile-fail/borrowck-loan-blocks-mut-uniq.rs
+++ b/src/test/compile-fail/borrowck-loan-blocks-mut-uniq.rs
@@ -15,7 +15,7 @@ fn borrow(v: &int, f: |x: &int|) {
 fn box_imm() {
     let mut v = box 3;
     borrow(&*v,
-           |w| { //~ ERROR cannot borrow `v` as mutable
+           ref |w| { //~ ERROR cannot borrow `v` as mutable
             v = box 4;
             assert_eq!(*v, 3);
             assert_eq!(*w, 4);

--- a/src/test/compile-fail/borrowck-loan-rcvr.rs
+++ b/src/test/compile-fail/borrowck-loan-rcvr.rs
@@ -31,7 +31,7 @@ fn a() {
     p.impurem();
 
     // But in this case we do not honor the loan:
-    p.blockm(|| { //~ ERROR cannot borrow `p` as mutable
+    p.blockm(ref || { //~ ERROR cannot borrow `p` as mutable
         p.x = 10;
     })
 }

--- a/src/test/compile-fail/borrowck-loan-vec-content.rs
+++ b/src/test/compile-fail/borrowck-loan-vec-content.rs
@@ -18,14 +18,14 @@ fn takes_imm_elt(_v: &int, f: ||) {
 
 fn has_mut_vec_and_does_not_try_to_change_it() {
     let mut v = vec!(1, 2, 3);
-    takes_imm_elt(v.get(0), || {})
+    takes_imm_elt(v.get(0), ref || {})
 }
 
 fn has_mut_vec_but_tries_to_change_it() {
     let mut v = vec!(1, 2, 3);
     takes_imm_elt(
         v.get(0),
-        || { //~ ERROR cannot borrow `v` as mutable
+        ref || { //~ ERROR cannot borrow `v` as mutable
             *v.get_mut(1) = 4;
         })
 }

--- a/src/test/compile-fail/borrowck-preserve-box-in-field.rs
+++ b/src/test/compile-fail/borrowck-preserve-box-in-field.rs
@@ -24,7 +24,7 @@ struct F { f: Box<int> }
 
 pub fn main() {
     let mut x = box(GC) F {f: box 3};
-    borrow(&*x.f, |b_x| {
+    borrow(&*x.f, ref |b_x| {
     //~^ ERROR cannot borrow `x` as mutable because `*x.f` is also borrowed as immutable
         assert_eq!(*b_x, 3);
         assert_eq!(&(*x.f) as *const int, &(*b_x) as *const int);

--- a/src/test/compile-fail/borrowck-preserve-box-in-uniq.rs
+++ b/src/test/compile-fail/borrowck-preserve-box-in-uniq.rs
@@ -24,7 +24,7 @@ struct F { f: Box<int> }
 
 pub fn main() {
     let mut x = box box(GC) F{f: box 3};
-    borrow(&*x.f, |b_x| {
+    borrow(&*x.f, ref |b_x| {
     //~^ ERROR cannot borrow `x` as mutable because `*x.f` is also borrowed as immutable
         assert_eq!(*b_x, 3);
         assert_eq!(&(*x.f) as *const int, &(*b_x) as *const int);

--- a/src/test/compile-fail/borrowck-preserve-box.rs
+++ b/src/test/compile-fail/borrowck-preserve-box.rs
@@ -22,7 +22,7 @@ fn borrow(x: &int, f: |x: &int|) {
 
 pub fn main() {
     let mut x = box(GC) 3;
-    borrow(&*x, |b_x| {
+    borrow(&*x, ref |b_x| {
     //~^ ERROR cannot borrow `x` as mutable because `*x` is also borrowed as immutable
         assert_eq!(*b_x, 3);
         assert_eq!(&(*x) as *const int, &(*b_x) as *const int);

--- a/src/test/compile-fail/borrowck-preserve-expl-deref.rs
+++ b/src/test/compile-fail/borrowck-preserve-expl-deref.rs
@@ -24,7 +24,7 @@ struct F { f: Box<int> }
 
 pub fn main() {
     let mut x = box(GC) F {f: box 3};
-    borrow(&*(*x).f, |b_x| {
+    borrow(&*(*x).f, ref |b_x| {
     //~^ ERROR cannot borrow `x` as mutable because `*x.f` is also borrowed as immutable
         assert_eq!(*b_x, 3);
         assert_eq!(&(*x.f) as *const int, &(*b_x) as *const int);

--- a/src/test/compile-fail/issue-11192.rs
+++ b/src/test/compile-fail/issue-11192.rs
@@ -20,7 +20,7 @@ impl Drop for Foo {
 
 fn main() {
     let mut ptr = box Foo { x: 0 };
-    let test = |foo: &Foo| {
+    let test = ref |foo: &Foo| {
         println!("access {}", foo.x);
         ptr = box Foo { x: ptr.x + 1 };
         println!("access {}", foo.x);

--- a/src/test/compile-fail/issue-11873.rs
+++ b/src/test/compile-fail/issue-11873.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     let mut v = vec!(1i);
-    let f = || v.push(2i);
+    let f = ref || v.push(2i);
     let _w = v; //~ ERROR: cannot move out of `v`
 
     f();

--- a/src/test/compile-fail/issue-16149.rs
+++ b/src/test/compile-fail/issue-16149.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test
+//
+// ICE's after emitting the right error.
+
 extern {
     static externalValue: int;
 }

--- a/src/test/compile-fail/issue-6801.rs
+++ b/src/test/compile-fail/issue-6801.rs
@@ -23,7 +23,7 @@ fn invoke(f: || -> uint) {
 
 fn main() {
       let x  : Box<uint>  = box 9;
-      let sq : || -> uint =  || { *x * *x };
+      let sq : || -> uint = ref || { *x * *x };
 
       twice(x); //~ ERROR: cannot move out of
       invoke(sq);

--- a/src/test/compile-fail/lint-unused-mut-variables.rs
+++ b/src/test/compile-fail/lint-unused-mut-variables.rs
@@ -35,7 +35,7 @@ fn main() {
       _ => {}
     }
 
-    let x = |mut y: int| 10i; //~ ERROR: variable does not need to be mutable
+    let x = ref |mut y: int| 10i; //~ ERROR: variable does not need to be mutable
     fn what(mut foo: int) {} //~ ERROR: variable does not need to be mutable
 
     // positive cases
@@ -44,7 +44,7 @@ fn main() {
     let mut a = Vec::new();
     a.push(3i);
     let mut a = Vec::new();
-    callback(|| {
+    callback(ref || {
         a.push(3i);
     });
     let (mut a, b) = (1i, 2i);
@@ -65,7 +65,7 @@ fn main() {
       _ => {}
     }
 
-    let x = |mut y: int| y = 32i;
+    let x = ref |mut y: int| y = 32i;
     fn nothing(mut foo: int) { foo = 37i; }
 
     // leading underscore should avoid the warning, just like the

--- a/src/test/compile-fail/regions-creating-enums.rs
+++ b/src/test/compile-fail/regions-creating-enums.rs
@@ -33,8 +33,8 @@ fn map_nums<'a,'b>(x: &ast, f: |uint| -> uint) -> &'a ast<'b> {
         return &num(f(x)); //~ ERROR borrowed value does not live long enough
       }
       add(x, y) => {
-        let m_x = map_nums(x, |z| f(z));
-        let m_y = map_nums(y, |z| f(z));
+        let m_x = map_nums(x, ref |z| f(z));
+        let m_y = map_nums(y, ref |z| f(z));
         return &add(m_x, m_y);  //~ ERROR borrowed value does not live long enough
       }
     }

--- a/src/test/compile-fail/regions-nested-fns-2.rs
+++ b/src/test/compile-fail/regions-nested-fns-2.rs
@@ -13,7 +13,7 @@ fn ignore(_f: <'z>|&'z int| -> &'z int) {}
 fn nested() {
     let y = 3;
     ignore(
-        |z| { //~ ERROR `y` does not live long enough
+        ref |z| { //~ ERROR `y` does not live long enough
             if false { &y } else { z }
         });
 }

--- a/src/test/run-pass/argument-passing.rs
+++ b/src/test/run-pass/argument-passing.rs
@@ -29,6 +29,6 @@ pub fn main() {
     assert_eq!(f1(&mut a, &mut b, c), 6);
     assert_eq!(a.x, 0);
     assert_eq!(b, 10);
-    assert_eq!(f2(a.x, |_| a.x = 50), 0);
+    assert_eq!(f2(a.x, ref |_| a.x = 50), 0);
     assert_eq!(a.x, 50);
 }

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -31,7 +31,7 @@ impl<A> iterable<A> for Vec<A> {
 
 fn length<A, T: iterable<A>>(x: T) -> uint {
     let mut len = 0;
-    x.iterate(|_y| {
+    x.iterate(ref |_y| {
         len += 1;
         true
     });
@@ -41,7 +41,7 @@ fn length<A, T: iterable<A>>(x: T) -> uint {
 pub fn main() {
     let x: Vec<int> = vec!(0,1,2,3);
     // Call a method
-    x.iterate(|y| { assert!(*x.get(*y as uint) == *y); true });
+    x.iterate(ref |y| { assert!(*x.get(*y as uint) == *y); true });
     // Call a parameterized function
     assert_eq!(length(x.clone()), x.len());
     // Call a parameterized function, with type arguments that require
@@ -51,7 +51,7 @@ pub fn main() {
     // Now try it with a type that *needs* to be borrowed
     let z = [0,1,2,3];
     // Call a method
-    z.iterate(|y| { assert!(z[*y as uint] == *y); true });
+    z.iterate(ref |y| { assert!(z[*y as uint] == *y); true });
     // Call a parameterized function
     assert_eq!(length::<int, &[int]>(z), z.len());
 }

--- a/src/test/run-pass/block-iter-1.rs
+++ b/src/test/run-pass/block-iter-1.rs
@@ -15,7 +15,7 @@ fn iter_vec<T>(v: Vec<T> , f: |&T|) { for x in v.iter() { f(x); } }
 pub fn main() {
     let v = vec!(1i, 2, 3, 4, 5, 6, 7);
     let mut odds = 0i;
-    iter_vec(v, |i| {
+    iter_vec(v, ref |i| {
         if *i % 2 == 1 {
             odds += 1;
         }

--- a/src/test/run-pass/block-iter-2.rs
+++ b/src/test/run-pass/block-iter-2.rs
@@ -15,8 +15,8 @@ fn iter_vec<T>(v: Vec<T> , f: |&T|) { for x in v.iter() { f(x); } }
 pub fn main() {
     let v = vec!(1i, 2, 3, 4, 5);
     let mut sum = 0;
-    iter_vec(v.clone(), |i| {
-        iter_vec(v.clone(), |j| {
+    iter_vec(v.clone(), ref |i| {
+        iter_vec(v.clone(), ref |j| {
             sum += *i * *j;
         });
     });

--- a/src/test/run-pass/foreach-nested.rs
+++ b/src/test/run-pass/foreach-nested.rs
@@ -14,8 +14,8 @@ fn two(it: |int|) { it(0); it(1); }
 pub fn main() {
     let mut a: Vec<int> = vec!(-1, -1, -1, -1);
     let mut p: int = 0;
-    two(|i| {
-        two(|j| { *a.get_mut(p as uint) = 10 * i + j; p += 1; })
+    two(ref |i| {
+        two(ref |j| { *a.get_mut(p as uint) = 10 * i + j; p += 1; })
     });
     assert_eq!(*a.get(0), 0);
     assert_eq!(*a.get(1), 1);

--- a/src/test/run-pass/foreach-put-structured.rs
+++ b/src/test/run-pass/foreach-put-structured.rs
@@ -19,7 +19,7 @@ fn pairs(it: |(int, int)|) {
 pub fn main() {
     let mut i: int = 10;
     let mut j: int = 0;
-    pairs(|p| {
+    pairs(ref |p| {
         let (_0, _1) = p;
         println!("{}", _0);
         println!("{}", _1);

--- a/src/test/run-pass/foreach-simple-outer-slot.rs
+++ b/src/test/run-pass/foreach-simple-outer-slot.rs
@@ -13,7 +13,11 @@
 
 pub fn main() {
     let mut sum: int = 0;
-    first_ten(|i| { println!("main"); println!("{}", i); sum = sum + i; });
+    first_ten(ref |i| {
+        println!("main");
+        println!("{}", i);
+        sum = sum + i;
+    });
     println!("sum");
     println!("{}", sum);
     assert_eq!(sum, 45);

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -187,16 +187,16 @@ fn test_format_args() {
     let mut buf = MemWriter::new();
     {
         let w = &mut buf as &mut io::Writer;
-        format_args!(|args| { write!(w, "{}", args); }, "{}", 1i);
-        format_args!(|args| { write!(w, "{}", args); }, "test");
-        format_args!(|args| { write!(w, "{}", args); }, "{test}", test=3i);
+        format_args!(ref |args| { write!(w, "{}", args); }, "{}", 1i);
+        format_args!(ref |args| { write!(w, "{}", args); }, "test");
+        format_args!(ref |args| { write!(w, "{}", args); }, "{test}", test=3i);
     }
     let s = str::from_utf8(buf.unwrap().as_slice()).unwrap().to_string();
     t!(s, "1test3");
 
     let s = format_args!(fmt::format, "hello {}", "world");
     t!(s, "hello world");
-    let s = format_args!(|args| {
+    let s = format_args!(ref |args| {
         format!("{}: {}", "args were", args)
     }, "hello {}", "world");
     t!(s, "args were: hello world");

--- a/src/test/run-pass/lambda-infer-unresolved.rs
+++ b/src/test/run-pass/lambda-infer-unresolved.rs
@@ -16,7 +16,7 @@ struct Refs { refs: Vec<int> , n: int }
 
 pub fn main() {
     let mut e = Refs{refs: vec!(), n: 0};
-    let _f: || = || println!("{}", e.n);
+    let _f: || = ref || println!("{}", e.n);
     let x: &[int] = e.refs.as_slice();
     assert_eq!(x.len(), 0);
 }

--- a/src/test/run-pass/regions-copy-closure.rs
+++ b/src/test/run-pass/regions-copy-closure.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let mut i = 3i;
     assert_eq!(i, 3);
     {
-        let cl = || i += 1;
+        let cl = ref || i += 1;
         let cl_box = box_it(cl);
         (cl_box.cl)();
     }

--- a/src/test/run-pass/static-impl.rs
+++ b/src/test/run-pass/static-impl.rs
@@ -62,11 +62,11 @@ pub fn main() {
     assert_eq!(("hi".to_string()).plus(), 200);
 
     assert_eq!((vec!(1i)).length_().str(), "1".to_string());
-    let vect = vec!(3i, 4).map_(|a| *a + 4);
+    let vect = vec!(3i, 4).map_(ref |a| *a + 4);
     assert_eq!(*vect.get(0), 7);
-    let vect = (vec!(3i, 4)).map_::<uint>(|a| *a as uint + 4u);
+    let vect = (vec!(3i, 4)).map_::<uint>(ref |a| *a as uint + 4u);
     assert_eq!(*vect.get(0), 7u);
     let mut x = 0u;
-    10u.multi(|_n| x += 2u );
+    10u.multi(ref |_n| x += 2u );
     assert_eq!(x, 20u);
 }


### PR DESCRIPTION
librustc: Require the `ref` keyword to get by-reference closure captures.

Because captured variables are now captured by value by default, this
breaks code like:

```
let mut a = 10;
[ 1i, 2, 3 ].iter().map(|x| a += *x);
```

Change this code to:

```
let mut a = 10;
[ 1i, 2, 3 ].iter().map(ref |x| a += *x);
```

As a simple change, you may wish to uniformly add the `ref` keyword to
all old boxed closures. This will guarantee that the semantics remain
the same.

Issue #12831.

[breaking-change]

r? @alexcrichton
