### PR TITLE
Make variable mutable to allow mutable reference

### DIFF
--- a/src/doc/guide-pointers.md
+++ b/src/doc/guide-pointers.md
@@ -332,7 +332,7 @@ let z = &x;
 Mutable ones, however, are not:
 
 ```{rust,ignore}
-let x = 5i;
+let mut x = 5i;
 let y = &mut x;
 let z = &mut x; // error: cannot borrow `x` as mutable more than once at a time
 ```


### PR DESCRIPTION
This appears to be a minor typo. This example implies that x is mutable otherwise the compiler would error on the line before the comment implies.

Please let me know if I'm missing something - I'd love to learn what I got wrong!
