### PR TITLE
librustc: When checking static method calls to unboxed closures, look at

### DIFF
--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -263,7 +263,7 @@ impl<'a> Rcx<'a> {
 
 impl<'fcx> mc::Typer for Rcx<'fcx> {
     fn tcx<'a>(&'a self) -> &'a ty::ctxt {
-        self.fcx.tcx()
+        self.fcx.ccx.tcx
     }
 
     fn node_ty(&self, id: ast::NodeId) -> mc::McResult<ty::t> {

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -774,7 +774,8 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
           Some(method) => {
               debug!("vtable resolution on parameter bounds for method call {}",
                      ex.repr(fcx.tcx()));
-              let type_param_defs = ty::method_call_type_param_defs(cx.tcx, method.origin);
+              let type_param_defs =
+                  ty::method_call_type_param_defs(fcx, method.origin);
               let substs = fcx.method_ty_substs(ex.id);
               let vcx = fcx.vtable_context();
               let vtbls = lookup_vtables(&vcx, ex.span,

--- a/src/test/compile-fail/unboxed-closures-static-call-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closures-static-call-wrong-trait.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+fn main() {
+    let mut_ = |&mut: x| x;
+    mut_.call_once((0i, )); //~ ERROR type `closure` does not implement
+}
+

--- a/src/test/run-pass/unboxed-closures-static-call-fn-once.rs
+++ b/src/test/run-pass/unboxed-closures-static-call-fn-once.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+fn main() {
+    let onetime = |: x| x;
+    onetime.call_once((0i,));
+}
+


### PR DESCRIPTION
the right trait and take the method name into account.

Closes #16599.

r? @huonw
