### PR TITLE
Add syntax extensions for lowercasing/uppercasing strings (Fixes #16607)

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -582,6 +582,34 @@ pub mod builtin {
     #[macro_export]
     macro_rules! stringify( ($t:tt) => ({ /* compiler built-in */ }) )
 
+    /// A macro which converts its argument to a lowercase string at compile time
+    /// Useful for lowercasing stringified idents in macros
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let lower1 = to_lower!(stringify!(FooBar))
+    /// let lower2 = to_lower!("FooBar")
+    /// assert_eq!(lower1, "foobar");
+    /// assert_eq!(lower2, "foobar");
+    /// ```
+    #[macro_export]
+    macro_rules! to_lower( ($t:tt) => ({ /* compiler built-in */ }) )
+
+    /// A macro which converts its argument to an uppercase string at compile time
+    /// Useful for lowercasing stringified idents in macros
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let upper1 = to_upper!(stringify!(FooBar))
+    /// let upper2 = to_upper!("FooBar")
+    /// assert_eq!(upper1, "FOOBAR");
+    /// assert_eq!(upper2, "FOOBAR");
+    /// ```
+    #[macro_export]
+    macro_rules! to_upper( ($t:tt) => ({ /* compiler built-in */ }) )
+
     /// Includes a utf8-encoded file as a string.
     ///
     /// This macro will yield an expression of type `&'static str` which is the

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -401,6 +401,12 @@ fn initial_syntax_expander_table() -> SyntaxEnv {
     syntax_expanders.insert(intern("stringify"),
                             builtin_normal_expander(
                                     ext::source_util::expand_stringify));
+    syntax_expanders.insert(intern("to_lower"),
+                            builtin_normal_expander(
+                                    ext::source_util::expand_lower));
+    syntax_expanders.insert(intern("to_upper"),
+                            builtin_normal_expander(
+                                    ext::source_util::expand_upper));
     syntax_expanders.insert(intern("include"),
                             builtin_normal_expander(
                                     ext::source_util::expand_include));


### PR DESCRIPTION
Testcase:

```
 #![feature(macro_rules)]
macro_rules! identify (
  ($i: ident) => {
    let $i = to_lower!(stringify!($i));
  }
)

fn main() {
    println!("{}", to_lower!("FooBar"))
    println!("{}", to_lower!(stringify!(FooBar)))
    println!("{}", to_upper!("FooBar"))
    println!("{}", to_upper!(stringify!(FooBar)))
    identify!(FooBar);
    println!("{}",FooBar)
}
```
