### PR TITLE
librustc: Fix a couple of cases in which unboxed closure typechecking

### DIFF
--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -563,7 +563,11 @@ pub fn trait_ref_for_unboxed_function<AC:AstConv,
                         .map(|input| {
                             ast_ty_to_ty(this, rscope, &*input.ty)
                         }).collect::<Vec<_>>();
-    let input_tuple = ty::mk_tup(this.tcx(), input_types);
+    let input_tuple = if input_types.len() == 0 {
+        ty::mk_nil()
+    } else {
+        ty::mk_tup(this.tcx(), input_types)
+    };
     let output_type = ast_ty_to_ty(this,
                                    rscope,
                                    &*unboxed_function.decl.output);

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2678,7 +2678,11 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
 
         // Tuple up the arguments and insert the resulting function type into
         // the `unboxed_closures` table.
-        fn_ty.sig.inputs = vec![ty::mk_tup(fcx.tcx(), fn_ty.sig.inputs)];
+        fn_ty.sig.inputs = if fn_ty.sig.inputs.len() == 0 {
+            vec![ty::mk_nil()]
+        } else {
+            vec![ty::mk_tup(fcx.tcx(), fn_ty.sig.inputs)]
+        };
 
         let kind = match kind {
             ast::FnUnboxedClosureKind => ty::FnUnboxedClosureKind,

--- a/src/test/run-pass/unboxed-closures-zero-args.rs
+++ b/src/test/run-pass/unboxed-closures-zero-args.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+fn main() {
+    let mut zero = |&mut:| {};
+    zero.call_mut(());
+}
+


### PR DESCRIPTION
code wasn't considering the zero-argument case.

Closes #16168.

r? @pnkfelix
