### PR TITLE
librustc: Resolve nested vtable parameters in overloaded calls.

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -201,7 +201,9 @@ impl param_substs {
 }
 
 fn param_substs_to_string(this: &param_substs, tcx: &ty::ctxt) -> String {
-    format!("param_substs({})", this.substs.repr(tcx))
+    format!("param_substs(substs={},vtables={})",
+            this.substs.repr(tcx),
+            this.vtables.repr(tcx))
 }
 
 impl Repr for param_substs {
@@ -859,8 +861,7 @@ pub fn find_vtable(tcx: &ty::ctxt,
     debug!("find_vtable(n_param={:?}, n_bound={}, ps={})",
            n_param, n_bound, ps.repr(tcx));
 
-    let param_bounds = ps.vtables.get(n_param.space,
-                                      n_param.index);
+    let param_bounds = ps.vtables.get(n_param.space, n_param.index);
     param_bounds.get(n_bound).clone()
 }
 

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -769,7 +769,8 @@ pub fn early_resolve_expr(ex: &ast::Expr, fcx: &FnCtxt, is_early: bool) {
       ast::ExprAssignOp(_, _, _) |
       ast::ExprIndex(_, _) |
       ast::ExprMethodCall(_, _, _) |
-      ast::ExprForLoop(..) => {
+      ast::ExprForLoop(..) |
+      ast::ExprCall(..) => {
         match fcx.inh.method_map.borrow().find(&MethodCall::expr(ex.id)) {
           Some(method) => {
               debug!("vtable resolution on parameter bounds for method call {}",

--- a/src/test/run-pass/overloaded-calls-param-vtables.rs
+++ b/src/test/run-pass/overloaded-calls-param-vtables.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that nested vtables work with overloaded calls.
+
+#![feature(overloaded_calls)]
+
+use std::ops::Fn;
+
+struct G;
+
+impl<'a, A: Add<int, int>> Fn<(A,), int> for G {
+    extern "rust-call" fn call(&self, (arg,): (A,)) -> int {
+        arg.add(&1)
+    }
+}
+
+fn main() {
+    // ICE trigger
+    G(1i);
+}
+


### PR DESCRIPTION
Closes #16508.

r? @nick29581
