### PR TITLE
Add support for trailing commas in more places

### DIFF
--- a/src/test/run-pass/trailing-comma.rs
+++ b/src/test/run-pass/trailing-comma.rs
@@ -8,9 +8,31 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn f(_: int,) {}
+fn f<T,>(_: T,) {}
+
+struct Foo<T,>;
+
+struct Bar;
+
+impl Bar {
+    fn f(_: int,) {}
+    fn g(self, _: int,) {}
+    fn h(self,) {}
+}
+
+enum Baz {
+    Qux(int,),
+}
 
 pub fn main() {
-    f(0i,);
+    f::<int,>(0i,);
     let (_, _,) = (1i, 1i,);
+
+    let x: Foo<int,> = Foo::<int,>;
+
+    Bar::f(0i,);
+    Bar.g(0i,);
+    Bar.h();
+
+    let x = Qux(1,);
 }


### PR DESCRIPTION
This lets the parser understand trailing commas in method calls, method definitions, enum variants, and type parameters.

Closes #14240.
Closes #15887.
