### PR TITLE
Fix LLVM version in configure

### DIFF
--- a/configure
+++ b/configure
@@ -635,7 +635,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[2-5]*)
+        (3.[2-6]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)


### PR DESCRIPTION
Upstream LLVM from VCS already has version 3.6,
configure fixed appropriately to allow building with it
