### PR TITLE
make priorityqueue's from_iter use heapify

### DIFF
--- a/src/libcollections/priority_queue.rs
+++ b/src/libcollections/priority_queue.rs
@@ -527,10 +527,9 @@ impl<'a, T> Iterator<&'a T> for Items<'a, T> {
 }
 
 impl<T: Ord> FromIterator<T> for PriorityQueue<T> {
-    fn from_iter<Iter: Iterator<T>>(iter: Iter) -> PriorityQueue<T> {
-        let mut q = PriorityQueue::new();
-        q.extend(iter);
-        q
+    fn from_iter<Iter: Iterator<T>>(mut iter: Iter) -> PriorityQueue<T> {
+        let vec: Vec<T> = iter.collect();
+        PriorityQueue::from_vec(vec)
     }
 }
 


### PR DESCRIPTION
Heapify is O(n), extend as currently implemented is O(nlogn). No brainer.

Currently investigating whether extend can just be implemented as a local heapify.
