### PR TITLE
stabilize core::{option, result}

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -47,7 +47,7 @@ pub fn run(lib_path: &str,
     match cmd.spawn() {
         Ok(mut process) => {
             for input in input.iter() {
-                process.stdin.get_mut_ref().write(input.as_bytes()).unwrap();
+                process.stdin.as_mut().unwrap().write(input.as_bytes()).unwrap();
             }
             let ProcessOutput { status, output, error } =
                 process.wait_with_output().unwrap();
@@ -79,7 +79,7 @@ pub fn run_background(lib_path: &str,
     match cmd.spawn() {
         Ok(mut process) => {
             for input in input.iter() {
-                process.stdin.get_mut_ref().write(input.as_bytes()).unwrap();
+                process.stdin.as_mut().unwrap().write(input.as_bytes()).unwrap();
             }
 
             Some(process)

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1526,7 +1526,7 @@ fn compile_cc_with_clang_and_save_bitcode(config: &Config, _props: &TestProps,
     let testcc = testfile.with_extension("cc");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
-        prog: config.clang_path.get_ref().as_str().unwrap().to_string(),
+        prog: config.clang_path.as_ref().unwrap().as_str().unwrap().to_string(),
         args: vec!("-c".to_string(),
                    "-emit-llvm".to_string(),
                    "-o".to_string(),
@@ -1542,7 +1542,7 @@ fn extract_function_from_bitcode(config: &Config, _props: &TestProps,
     let bitcodefile = output_base_name(config, testfile).with_extension("bc");
     let bitcodefile = append_suffix_to_stem(&bitcodefile, suffix);
     let extracted_bc = append_suffix_to_stem(&bitcodefile, "extract");
-    let prog = config.llvm_bin_path.get_ref().join("llvm-extract");
+    let prog = config.llvm_bin_path.as_ref().unwrap().join("llvm-extract");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
         prog: prog.as_str().unwrap().to_string(),
@@ -1559,7 +1559,7 @@ fn disassemble_extract(config: &Config, _props: &TestProps,
     let bitcodefile = append_suffix_to_stem(&bitcodefile, suffix);
     let extracted_bc = append_suffix_to_stem(&bitcodefile, "extract");
     let extracted_ll = extracted_bc.with_extension("ll");
-    let prog = config.llvm_bin_path.get_ref().join("llvm-dis");
+    let prog = config.llvm_bin_path.as_ref().unwrap().join("llvm-dis");
     let proc_args = ProcArgs {
         // FIXME (#9639): This needs to handle non-utf8 paths
         prog: prog.as_str().unwrap().to_string(),

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -476,7 +476,7 @@ impl<T> TypedArena<T> {
     /// Grows the arena.
     #[inline(never)]
     fn grow(&self) {
-        let chunk = self.first.borrow_mut().take_unwrap();
+        let chunk = self.first.borrow_mut().take().unwrap();
         let new_capacity = chunk.capacity.checked_mul(&2).unwrap();
         let chunk = TypedArenaChunk::<T>::new(Some(chunk), new_capacity);
         self.ptr.set(chunk.start() as *const T);
@@ -489,13 +489,13 @@ impl<T> TypedArena<T> {
 impl<T> Drop for TypedArena<T> {
     fn drop(&mut self) {
         // Determine how much was filled.
-        let start = self.first.borrow().get_ref().start() as uint;
+        let start = self.first.borrow().as_ref().unwrap().start() as uint;
         let end = self.ptr.get() as uint;
         let diff = (end - start) / mem::size_of::<T>();
 
         // Pass that to the `destroy` method.
         unsafe {
-            self.first.borrow_mut().get_mut_ref().destroy(diff)
+            self.first.borrow_mut().as_mut().unwrap().destroy(diff)
         }
     }
 }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -630,7 +630,7 @@ impl<'a, A> MutItems<'a, A> {
                     None => return self.list.push_front_node(ins_node),
                     Some(prev) => prev,
                 };
-                let node_own = prev_node.next.take_unwrap();
+                let node_own = prev_node.next.take().unwrap();
                 ins_node.next = link_with_prev(node_own, Rawlink::some(&mut *ins_node));
                 prev_node.next = link_with_prev(ins_node, Rawlink::some(prev_node));
                 self.list.length += 1;

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -309,7 +309,7 @@ impl<'a, T> Iterator<&'a T> for Items<'a, T> {
         }
         let raw_index = raw_index(self.lo, self.elts.len(), self.index);
         self.index += 1;
-        Some(self.elts[raw_index].get_ref())
+        Some(self.elts[raw_index].as_ref().unwrap())
     }
 
     #[inline]
@@ -327,7 +327,7 @@ impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
         }
         self.rindex -= 1;
         let raw_index = raw_index(self.lo, self.elts.len(), self.rindex);
-        Some(self.elts[raw_index].get_ref())
+        Some(self.elts[raw_index].as_ref().unwrap())
     }
 }
 
@@ -343,7 +343,7 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
             None
         } else {
             let raw_index = raw_index(self.lo, self.elts.len(), self.index + j);
-            Some(self.elts[raw_index].get_ref())
+            Some(self.elts[raw_index].as_ref().unwrap())
         }
     }
 }

--- a/src/libcollections/treemap.rs
+++ b/src/libcollections/treemap.rs
@@ -1447,7 +1447,7 @@ impl<K: Ord, V> TreeNode<K, V> {
 // Remove left horizontal link by rotating right
 fn skew<K: Ord, V>(node: &mut Box<TreeNode<K, V>>) {
     if node.left.as_ref().map_or(false, |x| x.level == node.level) {
-        let mut save = node.left.take_unwrap();
+        let mut save = node.left.take().unwrap();
         swap(&mut node.left, &mut save.right); // save.right now None
         swap(node, &mut save);
         node.right = Some(save);
@@ -1459,7 +1459,7 @@ fn skew<K: Ord, V>(node: &mut Box<TreeNode<K, V>>) {
 fn split<K: Ord, V>(node: &mut Box<TreeNode<K, V>>) {
     if node.right.as_ref().map_or(false,
       |x| x.right.as_ref().map_or(false, |y| y.level == node.level)) {
-        let mut save = node.right.take_unwrap();
+        let mut save = node.right.take().unwrap();
         swap(&mut node.right, &mut save.left); // save.left now None
         save.level += 1;
         swap(node, &mut save);
@@ -1563,7 +1563,7 @@ fn remove<K: Ord, V>(node: &mut Option<Box<TreeNode<K, V>>>,
           Equal => {
             if save.left.is_some() {
                 if save.right.is_some() {
-                    let mut left = save.left.take_unwrap();
+                    let mut left = save.left.take().unwrap();
                     if left.right.is_some() {
                         heir_swap(save, &mut left.right);
                     } else {
@@ -1573,13 +1573,13 @@ fn remove<K: Ord, V>(node: &mut Option<Box<TreeNode<K, V>>>,
                     save.left = Some(left);
                     (remove(&mut save.left, key), true)
                 } else {
-                    let new = save.left.take_unwrap();
+                    let new = save.left.take().unwrap();
                     let box TreeNode{value, ..} = replace(save, new);
-                    *save = save.left.take_unwrap();
+                    *save = save.left.take().unwrap();
                     (Some(value), true)
                 }
             } else if save.right.is_some() {
-                let new = save.right.take_unwrap();
+                let new = save.right.take().unwrap();
                 let box TreeNode{value, ..} = replace(save, new);
                 (Some(value), true)
             } else {

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -99,7 +99,7 @@
 //!             // Take a reference to the inside of cache cell
 //!             let mut cache = self.span_tree_cache.borrow_mut();
 //!             if cache.is_some() {
-//!                 return cache.get_ref().clone();
+//!                 return cache.as_ref().unwrap().clone();
 //!             }
 //!
 //!             let span_tree = self.calc_span_tree();

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2191,7 +2191,12 @@ pub fn iterate<'a, T: Clone>(f: |T|: 'a -> T, seed: T) -> Iterate<'a, T> {
         if *first {
             *first = false;
         } else {
-            val.mutate(|x| (*f)(x));
+            match val.take() {
+                Some(x) => {
+                    *val = Some((*f)(x))
+                }
+                None => {}
+            }
         }
         val.clone()
     })

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -141,6 +141,8 @@
 //! }
 //! ```
 
+#![stable]
+
 use cmp::{PartialEq, Eq, Ord};
 use default::Default;
 use slice::Slice;
@@ -155,6 +157,7 @@ use slice;
 
 /// The `Option` type.
 #[deriving(Clone, PartialEq, PartialOrd, Eq, Ord, Show)]
+#[stable]
 pub enum Option<T> {
     /// No value
     None,
@@ -173,6 +176,7 @@ impl<T> Option<T> {
 
     /// Returns `true` if the option is a `Some` value
     #[inline]
+    #[stable]
     pub fn is_some(&self) -> bool {
         match *self {
             Some(_) => true,
@@ -182,6 +186,7 @@ impl<T> Option<T> {
 
     /// Returns `true` if the option is a `None` value
     #[inline]
+    #[stable]
     pub fn is_none(&self) -> bool {
         !self.is_some()
     }
@@ -207,18 +212,21 @@ impl<T> Option<T> {
     /// println!("still can print num_as_str: {}", num_as_str);
     /// ```
     #[inline]
+    #[stable]
     pub fn as_ref<'r>(&'r self) -> Option<&'r T> {
         match *self { Some(ref x) => Some(x), None => None }
     }
 
     /// Convert from `Option<T>` to `Option<&mut T>`
     #[inline]
+    #[unstable = "waiting for mut conventions"]
     pub fn as_mut<'r>(&'r mut self) -> Option<&'r mut T> {
         match *self { Some(ref mut x) => Some(x), None => None }
     }
 
     /// Convert from `Option<T>` to `&mut [T]` (without copying)
     #[inline]
+    #[unstable = "waiting for mut conventions"]
     pub fn as_mut_slice<'r>(&'r mut self) -> &'r mut [T] {
         match *self {
             Some(ref mut x) => {
@@ -243,6 +251,7 @@ impl<T> Option<T> {
     /// Fails if the value is a `None` with a custom failure message provided by
     /// `msg`.
     #[inline]
+    #[unstable = "waiting for conventions"]
     pub fn expect(self, msg: &str) -> T {
         match self {
             Some(val) => val,
@@ -262,6 +271,7 @@ impl<T> Option<T> {
     /// Instead, prefer to use pattern matching and handle the `None`
     /// case explicitly.
     #[inline]
+    #[unstable = "waiting for conventions"]
     pub fn unwrap(self) -> T {
         match self {
             Some(val) => val,
@@ -271,6 +281,7 @@ impl<T> Option<T> {
 
     /// Returns the contained value or a default.
     #[inline]
+    #[unstable = "waiting for conventions"]
     pub fn unwrap_or(self, def: T) -> T {
         match self {
             Some(x) => x,
@@ -280,6 +291,7 @@ impl<T> Option<T> {
 
     /// Returns the contained value or computes it from a closure.
     #[inline]
+    #[unstable = "waiting for conventions"]
     pub fn unwrap_or_else(self, f: || -> T) -> T {
         match self {
             Some(x) => x,
@@ -303,18 +315,30 @@ impl<T> Option<T> {
     /// let num_as_int: Option<uint> = num_as_str.map(|n| n.len());
     /// ```
     #[inline]
+    #[unstable = "waiting for unboxed closures"]
     pub fn map<U>(self, f: |T| -> U) -> Option<U> {
         match self { Some(x) => Some(f(x)), None => None }
     }
 
     /// Applies a function to the contained value or returns a default.
     #[inline]
+    #[unstable = "waiting for unboxed closures"]
     pub fn map_or<U>(self, def: U, f: |T| -> U) -> U {
         match self { None => def, Some(t) => f(t) }
     }
 
+    /// Applies a function to the contained value or computes a default.
+    #[inline]
+    #[unstable = "waiting for unboxed closures"]
+    pub fn map_or_else<U>(self, def: || -> U, f: |T| -> U) -> U {
+        match self { None => def(), Some(t) => f(t) }
+    }
+
+    /// Deprecated.
+    ///
     /// Applies a function to the contained value or does nothing.
     /// Returns true if the contained value was mutated.
+    #[deprecated = "removed due to lack of use"]
     pub fn mutate(&mut self, f: |T| -> T) -> bool {
         if self.is_some() {
             *self = Some(f(self.take_unwrap()));
@@ -322,8 +346,11 @@ impl<T> Option<T> {
         } else { false }
     }
 
+    /// Deprecated.
+    ///
     /// Applies a function to the contained value or sets it to a default.
     /// Returns true if the contained value was mutated, or false if set to the default.
+    #[deprecated = "removed due to lack of use"]
     pub fn mutate_or_set(&mut self, def: T, f: |T| -> T) -> bool {
         if self.is_some() {
             *self = Some(f(self.take_unwrap()));
@@ -340,18 +367,21 @@ impl<T> Option<T> {
 
     /// Returns an iterator over the possibly contained value.
     #[inline]
+    #[unstable = "waiting for iterator conventions"]
     pub fn iter<'r>(&'r self) -> Item<&'r T> {
         Item{opt: self.as_ref()}
     }
 
     /// Returns a mutable iterator over the possibly contained value.
     #[inline]
+    #[unstable = "waiting for iterator conventions"]
     pub fn mut_iter<'r>(&'r mut self) -> Item<&'r mut T> {
         Item{opt: self.as_mut()}
     }
 
     /// Returns a consuming iterator over the possibly contained value.
     #[inline]
+    #[unstable = "waiting for iterator conventions"]
     pub fn move_iter(self) -> Item<T> {
         Item{opt: self}
     }
@@ -362,6 +392,7 @@ impl<T> Option<T> {
 
     /// Returns `None` if the option is `None`, otherwise returns `optb`.
     #[inline]
+    #[stable]
     pub fn and<U>(self, optb: Option<U>) -> Option<U> {
         match self {
             Some(_) => optb,
@@ -372,6 +403,7 @@ impl<T> Option<T> {
     /// Returns `None` if the option is `None`, otherwise calls `f` with the
     /// wrapped value and returns the result.
     #[inline]
+    #[unstable = "waiting for unboxed closures"]
     pub fn and_then<U>(self, f: |T| -> Option<U>) -> Option<U> {
         match self {
             Some(x) => f(x),
@@ -381,6 +413,7 @@ impl<T> Option<T> {
 
     /// Returns the option if it contains a value, otherwise returns `optb`.
     #[inline]
+    #[stable]
     pub fn or(self, optb: Option<T>) -> Option<T> {
         match self {
             Some(_) => self,
@@ -391,6 +424,7 @@ impl<T> Option<T> {
     /// Returns the option if it contains a value, otherwise calls `f` and
     /// returns the result.
     #[inline]
+    #[unstable = "waiting for unboxed closures"]
     pub fn or_else(self, f: || -> Option<T>) -> Option<T> {
         match self {
             Some(_) => self,
@@ -404,12 +438,16 @@ impl<T> Option<T> {
 
     /// Takes the value out of the option, leaving a `None` in its place.
     #[inline]
+    #[stable]
     pub fn take(&mut self) -> Option<T> {
         mem::replace(self, None)
     }
 
+    /// Deprecated.
+    ///
     /// Filters an optional value using a given function.
     #[inline(always)]
+    #[deprecated = "removed due to lack of use"]
     pub fn filtered(self, f: |t: &T| -> bool) -> Option<T> {
         match self {
             Some(x) => if f(&x) { Some(x) } else { None },
@@ -417,8 +455,11 @@ impl<T> Option<T> {
         }
     }
 
+    /// Deprecated.
+    ///
     /// Applies a function zero or more times until the result is `None`.
     #[inline]
+    #[deprecated = "removed due to lack of use"]
     pub fn while_some(self, f: |v: T| -> Option<T>) {
         let mut opt = self;
         loop {
@@ -433,6 +474,8 @@ impl<T> Option<T> {
     // Common special cases
     /////////////////////////////////////////////////////////////////////////
 
+    /// Deprecated: use `take().unwrap()` instead.
+    ///
     /// The option dance. Moves a value out of an option type and returns it,
     /// replacing the original with `None`.
     ///
@@ -440,6 +483,7 @@ impl<T> Option<T> {
     ///
     /// Fails if the value equals `None`.
     #[inline]
+    #[deprecated = "use take().unwrap() instead"]
     pub fn take_unwrap(&mut self) -> T {
         match self.take() {
             Some(x) => x,
@@ -447,6 +491,8 @@ impl<T> Option<T> {
         }
     }
 
+    /// Deprecated: use `as_ref().unwrap()` instead.
+    ///
     /// Gets an immutable reference to the value inside an option.
     ///
     /// # Failure
@@ -460,6 +506,7 @@ impl<T> Option<T> {
     /// Instead, prefer to use pattern matching and handle the `None`
     /// case explicitly.
     #[inline]
+    #[deprecated = "use .as_ref().unwrap() instead"]
     pub fn get_ref<'a>(&'a self) -> &'a T {
         match *self {
             Some(ref x) => x,
@@ -467,6 +514,8 @@ impl<T> Option<T> {
         }
     }
 
+    /// Deprecated: use `as_mut().unwrap()` instead.
+    ///
     /// Gets a mutable reference to the value inside an option.
     ///
     /// # Failure
@@ -480,6 +529,7 @@ impl<T> Option<T> {
     /// Instead, prefer to use pattern matching and handle the `None`
     /// case explicitly.
     #[inline]
+    #[deprecated = "use .as_mut().unwrap() instead"]
     pub fn get_mut_ref<'a>(&'a mut self) -> &'a mut T {
         match *self {
             Some(ref mut x) => x,
@@ -512,6 +562,7 @@ impl<T: Default> Option<T> {
     /// assert_eq!(0i, bad_year);
     /// ```
     #[inline]
+    #[unstable = "waiting for conventions"]
     pub fn unwrap_or_default(self) -> T {
         match self {
             Some(x) => x,
@@ -527,6 +578,7 @@ impl<T: Default> Option<T> {
 impl<T> Slice<T> for Option<T> {
     /// Convert from `Option<T>` to `&[T]` (without copying)
     #[inline]
+    #[stable]
     fn as_slice<'a>(&'a self) -> &'a [T] {
         match *self {
             Some(ref x) => slice::ref_slice(x),
@@ -552,6 +604,7 @@ impl<T> Default for Option<T> {
 /// The `Item` iterator is returned by the `iter`, `mut_iter` and `move_iter`
 /// methods on `Option`.
 #[deriving(Clone)]
+#[unstable = "waiting for iterator conventions"]
 pub struct Item<A> {
     opt: Option<A>
 }
@@ -584,54 +637,62 @@ impl<A> ExactSize<A> for Item<A> {}
 // Free functions
 /////////////////////////////////////////////////////////////////////////////
 
-/// Takes each element in the `Iterator`: if it is `None`, no further
-/// elements are taken, and the `None` is returned. Should no `None` occur, a
-/// vector containing the values of each `Option` is returned.
-///
-/// Here is an example which increments every integer in a vector,
-/// checking for overflow:
-///
-/// ```rust
-/// use std::option;
-/// use std::uint;
-///
-/// let v = vec!(1u, 2u);
-/// let res: Option<Vec<uint>> = option::collect(v.iter().map(|x: &uint|
-///     if *x == uint::MAX { None }
-///     else { Some(x + 1) }
-/// ));
-/// assert!(res == Some(vec!(2u, 3u)));
-/// ```
+/// Deprecated: use `Iterator::collect` instead.
 #[inline]
-pub fn collect<T, Iter: Iterator<Option<T>>, V: FromIterator<T>>(iter: Iter) -> Option<V> {
-    // FIXME(#11084): This could be replaced with Iterator::scan when this
-    // performance bug is closed.
+#[deprecated = "use Iterator::collect instead"]
+pub fn collect<T, Iter: Iterator<Option<T>>, V: FromIterator<T>>(mut iter: Iter) -> Option<V> {
+    iter.collect()
+}
 
-    struct Adapter<Iter> {
-        iter: Iter,
-        found_none: bool,
-    }
+impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
+    /// Takes each element in the `Iterator`: if it is `None`, no further
+    /// elements are taken, and the `None` is returned. Should no `None` occur, a
+    /// container with the values of each `Option` is returned.
+    ///
+    /// Here is an example which increments every integer in a vector,
+    /// checking for overflow:
+    ///
+    /// ```rust
+    /// use std::uint;
+    ///
+    /// let v = vec!(1u, 2u);
+    /// let res: Option<Vec<uint>> = v.iter().map(|x: &uint|
+    ///     if *x == uint::MAX { None }
+    ///     else { Some(x + 1) }
+    /// ).collect();
+    /// assert!(res == Some(vec!(2u, 3u)));
+    /// ```
+    #[inline]
+    fn from_iter<I: Iterator<Option<A>>>(iter: I) -> Option<V> {
+        // FIXME(#11084): This could be replaced with Iterator::scan when this
+        // performance bug is closed.
 
-    impl<T, Iter: Iterator<Option<T>>> Iterator<T> for Adapter<Iter> {
-        #[inline]
-        fn next(&mut self) -> Option<T> {
-            match self.iter.next() {
-                Some(Some(value)) => Some(value),
-                Some(None) => {
-                    self.found_none = true;
-                    None
+        struct Adapter<Iter> {
+            iter: Iter,
+            found_none: bool,
+        }
+
+        impl<T, Iter: Iterator<Option<T>>> Iterator<T> for Adapter<Iter> {
+            #[inline]
+            fn next(&mut self) -> Option<T> {
+                match self.iter.next() {
+                    Some(Some(value)) => Some(value),
+                    Some(None) => {
+                        self.found_none = true;
+                        None
+                    }
+                    None => None,
                 }
-                None => None,
             }
         }
-    }
 
-    let mut adapter = Adapter { iter: iter, found_none: false };
-    let v: V = FromIterator::from_iter(adapter.by_ref());
+        let mut adapter = Adapter { iter: iter, found_none: false };
+        let v: V = FromIterator::from_iter(adapter.by_ref());
 
-    if adapter.found_none {
-        None
-    } else {
-        Some(v)
+        if adapter.found_none {
+            None
+        } else {
+            Some(v)
+        }
     }
 }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -341,7 +341,7 @@ impl<T> Option<T> {
     #[deprecated = "removed due to lack of use"]
     pub fn mutate(&mut self, f: |T| -> T) -> bool {
         if self.is_some() {
-            *self = Some(f(self.take_unwrap()));
+            *self = Some(f(self.take().unwrap()));
             true
         } else { false }
     }
@@ -353,7 +353,7 @@ impl<T> Option<T> {
     #[deprecated = "removed due to lack of use"]
     pub fn mutate_or_set(&mut self, def: T, f: |T| -> T) -> bool {
         if self.is_some() {
-            *self = Some(f(self.take_unwrap()));
+            *self = Some(f(self.take().unwrap()));
             true
         } else {
             *self = Some(def);

--- a/src/libcoretest/option.rs
+++ b/src/libcoretest/option.rs
@@ -73,7 +73,7 @@ fn test_option_dance() {
     let mut y = Some(5i);
     let mut y2 = 0;
     for _x in x.iter() {
-        y2 = y.take_unwrap();
+        y2 = y.take().unwrap();
     }
     assert_eq!(y2, 5);
     assert!(y.is_none());
@@ -82,8 +82,8 @@ fn test_option_dance() {
 #[test] #[should_fail]
 fn test_option_too_much_dance() {
     let mut y = Some(marker::NoCopy);
-    let _y2 = y.take_unwrap();
-    let _y3 = y.take_unwrap();
+    let _y2 = y.take().unwrap();
+    let _y3 = y.take().unwrap();
 }
 
 #[test]

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -106,7 +106,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> Paths {
     let mut root = os::getcwd();
     let pat_root = Path::new(pattern).root_path();
     if pat_root.is_some() {
-        if check_windows_verbatim(pat_root.get_ref()) {
+        if check_windows_verbatim(pat_root.as_ref().unwrap()) {
             // FIXME: How do we want to handle verbatim paths? I'm inclined to return nothing,
             // since we can't very well find all UNC shares with a 1-letter server name.
             return Paths {
@@ -116,7 +116,7 @@ pub fn glob_with(pattern: &str, options: MatchOptions) -> Paths {
                 todo: Vec::new(),
             };
         }
-        root.push(pat_root.get_ref());
+        root.push(pat_root.as_ref().unwrap());
     }
 
     let root_len = pat_root.map_or(0u, |p| p.as_vec().len());

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -305,7 +305,7 @@ pub fn start(argc: int, argv: *const *const u8,
     let mut main = Some(main);
     let mut ret = None;
     simple::task().run(|| {
-        ret = Some(run(event_loop_factory, main.take_unwrap()));
+        ret = Some(run(event_loop_factory, main.take().unwrap()));
     }).destroy();
     // unsafe is ok b/c we're sure that the runtime is gone
     unsafe { rt::cleanup() }

--- a/src/libnative/io/timer_unix.rs
+++ b/src/libnative/io/timer_unix.rs
@@ -119,7 +119,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
         let mut timer = match active.shift() {
             Some(timer) => timer, None => return
         };
-        let mut cb = timer.cb.take_unwrap();
+        let mut cb = timer.cb.take().unwrap();
         cb.call();
         if timer.repeat {
             timer.cb = Some(cb);

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -139,7 +139,7 @@ pub fn start(argc: int, argv: *const *const u8, main: proc()) -> int {
         unsafe {
             rt::stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);
         }
-        exit_code = Some(run(main.take_unwrap()));
+        exit_code = Some(run(main.take().unwrap()));
     }).destroy());
     unsafe { rt::cleanup(); }
     // If the exit code wasn't set, then the task block must have failed.

--- a/src/libnative/task.rs
+++ b/src/libnative/task.rs
@@ -92,7 +92,7 @@ pub fn spawn_opts(opts: TaskOpts, f: proc():Send) {
         let mut f = Some(f);
         let mut task = task;
         task.put_runtime(ops);
-        drop(task.run(|| { f.take_unwrap()() }).destroy());
+        drop(task.run(|| { f.take().unwrap()() }).destroy());
         drop(token);
     })
 }

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -223,7 +223,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     let mut addl_plugins = Some(addl_plugins);
     let Plugins { macros, registrars }
         = time(time_passes, "plugin loading", (), |_|
-               plugin::load::load_plugins(sess, &krate, addl_plugins.take_unwrap()));
+               plugin::load::load_plugins(sess, &krate, addl_plugins.take().unwrap()));
 
     let mut registry = Registry::new(&krate);
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -207,7 +207,7 @@ pub struct Context<'a> {
 macro_rules! run_lints ( ($cx:expr, $f:ident, $($args:expr),*) => ({
     // Move the vector of passes out of `$cx` so that we can
     // iterate over it mutably while passing `$cx` to the methods.
-    let mut passes = $cx.lints.passes.take_unwrap();
+    let mut passes = $cx.lints.passes.take().unwrap();
     for obj in passes.mut_iter() {
         obj.$f($cx, $($args),*);
     }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -166,7 +166,7 @@ impl<'a> Drop for StatRecorder<'a> {
             let end = time::precise_time_ns();
             let elapsed = ((end - self.start) / 1_000_000) as uint;
             let iend = self.ccx.stats.n_llvm_insns.get();
-            self.ccx.stats.fn_stats.borrow_mut().push((self.name.take_unwrap(),
+            self.ccx.stats.fn_stats.borrow_mut().push((self.name.take().unwrap(),
                                                        elapsed,
                                                        iend - self.istart));
             self.ccx.stats.n_fns.set(self.ccx.stats.n_fns.get() + 1);

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -147,7 +147,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
             decl_internal_rust_fn(ccx, mono_ty, s.as_slice())
         };
 
-        ccx.monomorphized.borrow_mut().insert(hash_id.take_unwrap(), lldecl);
+        ccx.monomorphized.borrow_mut().insert(hash_id.take().unwrap(), lldecl);
         lldecl
     };
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -108,7 +108,7 @@ fn try_inline_def(cx: &core::DocContext,
         _ => return None,
     };
     let fqn = csearch::get_item_path(tcx, did);
-    cx.inlined.borrow_mut().get_mut_ref().insert(did);
+    cx.inlined.borrow_mut().as_mut().unwrap().insert(did);
     ret.push(clean::Item {
         source: clean::Span::empty(),
         name: Some(fqn.last().unwrap().to_string()),
@@ -142,7 +142,7 @@ pub fn record_extern_fqn(cx: &core::DocContext,
         core::Typed(ref tcx) => {
             let fqn = csearch::get_item_path(tcx, did);
             let fqn = fqn.move_iter().map(|i| i.to_string()).collect();
-            cx.external_paths.borrow_mut().get_mut_ref().insert(did, (fqn, kind));
+            cx.external_paths.borrow_mut().as_mut().unwrap().insert(did, (fqn, kind));
         }
         core::NotTyped(..) => {}
     }
@@ -278,7 +278,7 @@ fn build_impls(cx: &core::DocContext,
 fn build_impl(cx: &core::DocContext,
               tcx: &ty::ctxt,
               did: ast::DefId) -> Option<clean::Item> {
-    if !cx.inlined.borrow_mut().get_mut_ref().insert(did) {
+    if !cx.inlined.borrow_mut().as_mut().unwrap().insert(did) {
         return None
     }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -468,7 +468,7 @@ impl Clean<TyParam> for ast::TyParam {
 
 impl Clean<TyParam> for ty::TypeParameterDef {
     fn clean(&self) -> TyParam {
-        get_cx().external_typarams.borrow_mut().get_mut_ref()
+        get_cx().external_typarams.borrow_mut().as_mut().unwrap()
                 .insert(self.def_id, self.ident.clean());
         TyParam {
             name: self.ident.clean(),
@@ -541,8 +541,8 @@ impl Clean<TyParamBound> for ty::BuiltinBound {
         };
         let fqn = csearch::get_item_path(tcx, did);
         let fqn = fqn.move_iter().map(|i| i.to_string()).collect();
-        cx.external_paths.borrow_mut().get_mut_ref().insert(did,
-                                                            (fqn, TypeTrait));
+        cx.external_paths.borrow_mut().as_mut().unwrap().insert(did,
+                                                                (fqn, TypeTrait));
         TraitBound(ResolvedPath {
             path: path,
             typarams: None,
@@ -563,7 +563,7 @@ impl Clean<TyParamBound> for ty::TraitRef {
                      .collect::<Vec<String>>();
         let path = external_path(fqn.last().unwrap().as_slice(),
                                  &self.substs);
-        cx.external_paths.borrow_mut().get_mut_ref().insert(self.def_id,
+        cx.external_paths.borrow_mut().as_mut().unwrap().insert(self.def_id,
                                                             (fqn, TypeTrait));
         TraitBound(ResolvedPath {
             path: path,
@@ -1294,7 +1294,7 @@ impl Clean<Type> for ty::t {
                 };
                 let path = external_path(fqn.last().unwrap().to_string().as_slice(),
                                          substs);
-                get_cx().external_paths.borrow_mut().get_mut_ref()
+                get_cx().external_paths.borrow_mut().as_mut().unwrap()
                                        .insert(did, (fqn, kind));
                 ResolvedPath {
                     path: path,
@@ -2086,7 +2086,7 @@ fn register_def(cx: &core::DocContext, def: def::Def) -> ast::DefId {
     match kind {
         TypeTrait => {
             let t = inline::build_external_trait(tcx, did);
-            cx.external_traits.borrow_mut().get_mut_ref().insert(did, t);
+            cx.external_traits.borrow_mut().as_mut().unwrap().insert(did, t);
         }
         _ => {}
     }
@@ -2153,7 +2153,7 @@ fn lang_struct(did: Option<ast::DefId>, t: ty::t, name: &str,
     let fqn: Vec<String> = fqn.move_iter().map(|i| {
         i.to_string()
     }).collect();
-    get_cx().external_paths.borrow_mut().get_mut_ref()
+    get_cx().external_paths.borrow_mut().as_mut().unwrap()
                            .insert(did, (fqn, TypeStruct));
     ResolvedPath {
         typarams: None,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -297,7 +297,7 @@ pub fn run(mut krate: clean::Crate, external_html: &ExternalHtml, dst: Path) -> 
     let public_items = public_items.unwrap_or(NodeSet::new());
     let paths: HashMap<ast::DefId, (Vec<String>, ItemType)> =
       analysis.as_ref().map(|a| {
-        let paths = a.external_paths.borrow_mut().take_unwrap();
+        let paths = a.external_paths.borrow_mut().take().unwrap();
         paths.move_iter().map(|(k, (v, t))| {
             (k, (v, match t {
                 clean::TypeStruct => item_type::Struct,
@@ -325,13 +325,13 @@ pub fn run(mut krate: clean::Crate, external_html: &ExternalHtml, dst: Path) -> 
         public_items: public_items,
         orphan_methods: Vec::new(),
         traits: analysis.as_ref().map(|a| {
-            a.external_traits.borrow_mut().take_unwrap()
+            a.external_traits.borrow_mut().take().unwrap()
         }).unwrap_or(HashMap::new()),
         typarams: analysis.as_ref().map(|a| {
-            a.external_typarams.borrow_mut().take_unwrap()
+            a.external_typarams.borrow_mut().take().unwrap()
         }).unwrap_or(HashMap::new()),
         inlined: analysis.as_ref().map(|a| {
-            a.inlined.borrow_mut().take_unwrap()
+            a.inlined.borrow_mut().take().unwrap()
         }).unwrap_or(HashSet::new()),
     };
     cache.stack.push(krate.name.clone());
@@ -805,7 +805,7 @@ impl DocFolder for Cache {
                         v.push(Implementor {
                             def_id: item.def_id,
                             generics: i.generics.clone(),
-                            trait_: i.trait_.get_ref().clone(),
+                            trait_: i.trait_.as_ref().unwrap().clone(),
                             for_: i.for_.clone(),
                             stability: item.stability.clone(),
                         });
@@ -878,7 +878,7 @@ impl DocFolder for Cache {
 
         // Keep track of the fully qualified path for this item.
         let pushed = if item.name.is_some() {
-            let n = item.name.get_ref();
+            let n = item.name.as_ref().unwrap();
             if n.len() > 0 {
                 self.stack.push(n.to_string());
                 true
@@ -1125,7 +1125,7 @@ impl Context {
                 if title.len() > 0 {
                     title.push_str("::");
                 }
-                title.push_str(it.name.get_ref().as_slice());
+                title.push_str(it.name.as_ref().unwrap().as_slice());
             }
             title.push_str(" - Rust");
             let tyname = shortty(it).to_static_str();
@@ -1191,10 +1191,10 @@ impl Context {
             // modules are special because they add a namespace. We also need to
             // recurse into the items of the module as well.
             clean::ModuleItem(..) => {
-                let name = item.name.get_ref().to_string();
+                let name = item.name.as_ref().unwrap().to_string();
                 let mut item = Some(item);
                 self.recurse(name, |this| {
-                    let item = item.take_unwrap();
+                    let item = item.take().unwrap();
                     let dst = this.dst.join("index.html");
                     let dst = try!(File::create(&dst));
                     try!(render(dst, this, &item, false));
@@ -1398,7 +1398,7 @@ fn item_path(item: &clean::Item) -> String {
 fn full_path(cx: &Context, item: &clean::Item) -> String {
     let mut s = cx.current.connect("::");
     s.push_str("::");
-    s.push_str(item.name.get_ref().as_slice());
+    s.push_str(item.name.as_ref().unwrap().as_slice());
     return s
 }
 
@@ -1809,7 +1809,7 @@ fn item_enum(w: &mut fmt::Formatter, it: &clean::Item,
         try!(write!(w, " {{\n"));
         for v in e.variants.iter() {
             try!(write!(w, "    "));
-            let name = v.name.get_ref().as_slice();
+            let name = v.name.as_ref().unwrap().as_slice();
             match v.inner {
                 clean::VariantItem(ref var) => {
                     match var.kind {
@@ -2098,7 +2098,7 @@ impl<'a> fmt::Show for Sidebar<'a> {
             try!(write!(w, "<div class='block {}'><h2>{}</h2>", short, longty));
             for item in items.iter() {
                 let curty = shortty(cur).to_static_str();
-                let class = if cur.name.get_ref() == item &&
+                let class = if cur.name.as_ref().unwrap() == item &&
                                short == curty { "current" } else { "" };
                 try!(write!(w, "<a class='{ty} {class}' href='{href}{path}'>\
                                 {name}</a>",

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -385,7 +385,7 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
 
     // Process all of the crate attributes, extracting plugin metadata along
     // with the passes which we are supposed to run.
-    match krate.module.get_ref().doc_list() {
+    match krate.module.as_ref().unwrap().doc_list() {
         Some(nested) => {
             for inner in nested.iter() {
                 match *inner {

--- a/src/librustrt/task.rs
+++ b/src/librustrt/task.rs
@@ -384,7 +384,7 @@ impl Task {
         //      function, and I would be saddened if more usage of the function
         //      crops up.
         unsafe {
-            let imp = self.imp.take_unwrap();
+            let imp = self.imp.take().unwrap();
             let vtable = mem::transmute::<_, &raw::TraitObject>(&imp).vtable;
             match imp.wrap().downcast::<T>() {
                 Ok(t) => Some(t),
@@ -407,7 +407,7 @@ impl Task {
     pub fn spawn_sibling(mut self: Box<Task>,
                          opts: TaskOpts,
                          f: proc(): Send) {
-        let ops = self.imp.take_unwrap();
+        let ops = self.imp.take().unwrap();
         ops.spawn_sibling(self, opts, f)
     }
 
@@ -417,7 +417,7 @@ impl Task {
     pub fn deschedule(mut self: Box<Task>,
                       amt: uint,
                       f: |BlockedTask| -> ::core::result::Result<(), BlockedTask>) {
-        let ops = self.imp.take_unwrap();
+        let ops = self.imp.take().unwrap();
         ops.deschedule(amt, self, f)
     }
 
@@ -425,7 +425,7 @@ impl Task {
     /// current task can accept a change in scheduling. This function can only
     /// be called on tasks that were previously blocked in `deschedule`.
     pub fn reawaken(mut self: Box<Task>) {
-        let ops = self.imp.take_unwrap();
+        let ops = self.imp.take().unwrap();
         ops.reawaken(self);
     }
 
@@ -433,14 +433,14 @@ impl Task {
     /// eventually return, but possibly not immediately. This is used as an
     /// opportunity to allow other tasks a chance to run.
     pub fn yield_now(mut self: Box<Task>) {
-        let ops = self.imp.take_unwrap();
+        let ops = self.imp.take().unwrap();
         ops.yield_now(self);
     }
 
     /// Similar to `yield_now`, except that this function may immediately return
     /// without yielding (depending on what the runtime decides to do).
     pub fn maybe_yield(mut self: Box<Task>) {
-        let ops = self.imp.take_unwrap();
+        let ops = self.imp.take().unwrap();
         ops.maybe_yield(self);
     }
 
@@ -448,20 +448,20 @@ impl Task {
     /// stored in the task's runtime. This factory may not always be available,
     /// which is why the return type is `Option`
     pub fn local_io<'a>(&'a mut self) -> Option<LocalIo<'a>> {
-        self.imp.get_mut_ref().local_io()
+        self.imp.as_mut().unwrap().local_io()
     }
 
     /// Returns the stack bounds for this task in (lo, hi) format. The stack
     /// bounds may not be known for all tasks, so the return value may be
     /// `None`.
     pub fn stack_bounds(&self) -> (uint, uint) {
-        self.imp.get_ref().stack_bounds()
+        self.imp.as_ref().unwrap().stack_bounds()
     }
 
     /// Returns whether it is legal for this task to block the OS thread that it
     /// is running on.
     pub fn can_block(&self) -> bool {
-        self.imp.get_ref().can_block()
+        self.imp.as_ref().unwrap().can_block()
     }
 
     /// Consume this task, flagging it as a candidate for destruction.

--- a/src/librustrt/thread.rs
+++ b/src/librustrt/thread.rs
@@ -128,7 +128,7 @@ impl<T: Send> Thread<T> {
         unsafe { imp::join(self.native) };
         self.joined = true;
         assert!(self.packet.is_some());
-        self.packet.take_unwrap()
+        self.packet.take().unwrap()
     }
 }
 

--- a/src/librustuv/addrinfo.rs
+++ b/src/librustuv/addrinfo.rs
@@ -86,7 +86,7 @@ impl GetAddrInfoRequest {
                 });
 
                 match cx.status {
-                    0 => Ok(accum_addrinfo(cx.addrinfo.get_ref())),
+                    0 => Ok(accum_addrinfo(cx.addrinfo.as_ref().unwrap())),
                     n => Err(UvError(n))
                 }
             }

--- a/src/librustuv/async.rs
+++ b/src/librustuv/async.rs
@@ -136,7 +136,7 @@ mod test_remote {
                 // once
                 let MyCallback(ref mut s) = *self;
                 if s.is_some() {
-                    s.take_unwrap().send(1);
+                    s.take().unwrap().send(1);
                 }
             }
         }

--- a/src/librustuv/lib.rs
+++ b/src/librustuv/lib.rs
@@ -259,7 +259,7 @@ fn wait_until_woken_after(slot: *mut Option<BlockedTask>,
 
 fn wakeup(slot: &mut Option<BlockedTask>) {
     assert!(slot.is_some());
-    let _ = slot.take_unwrap().wake().map(|t| t.reawaken());
+    let _ = slot.take().unwrap().wake().map(|t| t.reawaken());
 }
 
 pub struct Request {

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -596,7 +596,7 @@ impl rtio::RtioUdpSocket for UdpWatcher {
                 wait_until_woken_after(&mut cx.task, &loop_, || {
                     unsafe { uvll::set_data_for_uv_handle(handle, &mut cx) }
                 });
-                match cx.result.take_unwrap() {
+                match cx.result.take().unwrap() {
                     (n, _) if n < 0 =>
                         Err(uv_error_to_io_error(UvError(n as c_int))),
                     (n, addr) => Ok((n as uint, addr.unwrap()))
@@ -657,7 +657,7 @@ impl rtio::RtioUdpSocket for UdpWatcher {
         // here.
         let data = if guard.can_timeout {Some(Vec::from_slice(buf))} else {None};
         let uv_buf = if guard.can_timeout {
-            slice_to_uv_buf(data.get_ref().as_slice())
+            slice_to_uv_buf(data.as_ref().unwrap().as_slice())
         } else {
             slice_to_uv_buf(buf)
         };

--- a/src/librustuv/process.rs
+++ b/src/librustuv/process.rs
@@ -297,7 +297,7 @@ impl rtio::RtioProcess for Process {
             self.timer = Some(timer);
         }
 
-        let timer = self.timer.get_mut_ref();
+        let timer = self.timer.as_mut().unwrap();
         timer.stop();
         timer.start(timer_cb, ms, 0);
         self.timeout_state = TimeoutPending;

--- a/src/librustuv/stream.rs
+++ b/src/librustuv/stream.rs
@@ -161,7 +161,7 @@ impl StreamWatcher {
         // bytes.
         let data = if may_timeout {Some(Vec::from_slice(buf))} else {None};
         let uv_buf = if may_timeout {
-            slice_to_uv_buf(data.get_ref().as_slice())
+            slice_to_uv_buf(data.as_ref().unwrap().as_slice())
         } else {
             slice_to_uv_buf(buf)
         };

--- a/src/librustuv/timeout.rs
+++ b/src/librustuv/timeout.rs
@@ -140,7 +140,7 @@ impl<T: Send> AccessTimeout<T> {
             self.timer = Some(timer);
         }
 
-        let timer = self.timer.get_mut_ref();
+        let timer = self.timer.as_mut().unwrap();
         unsafe {
             let cx = uvll::get_data_for_uv_handle(timer.handle);
             let cx = cx as *mut TimerContext;

--- a/src/librustuv/timer.rs
+++ b/src/librustuv/timer.rs
@@ -132,9 +132,9 @@ extern fn timer_cb(handle: *mut uvll::uv_timer_t) {
     let _f = ForbidSwitch::new("timer callback can't switch");
     let timer: &mut TimerWatcher = unsafe { UvHandle::from_uv_handle(&handle) };
 
-    match timer.action.take_unwrap() {
+    match timer.action.take().unwrap() {
         WakeTask => {
-            let task = timer.blocker.take_unwrap();
+            let task = timer.blocker.take().unwrap();
             let _ = task.wake().map(|t| t.reawaken());
         }
         CallOnce(mut cb) => { cb.call() }

--- a/src/librustuv/uvio.rs
+++ b/src/librustuv/uvio.rs
@@ -66,7 +66,7 @@ impl Drop for UvEventLoop {
         // Lastly, after we've closed the pool of handles we pump the event loop
         // one last time to run any closing callbacks to make sure the loop
         // shuts down cleanly.
-        let handle = self.uvio.handle_pool.get_ref().handle();
+        let handle = self.uvio.handle_pool.as_ref().unwrap().handle();
         drop(self.uvio.handle_pool.take());
         self.run();
 
@@ -132,7 +132,7 @@ impl UvIoFactory {
         // It's understood by the homing code that the "local id" is just the
         // pointer of the local I/O factory cast to a uint.
         let id: uint = unsafe { mem::transmute_copy(&self) };
-        HomeHandle::new(id, &mut **self.handle_pool.get_mut_ref())
+        HomeHandle::new(id, &mut **self.handle_pool.as_mut().unwrap())
     }
 }
 

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -182,7 +182,7 @@ impl<W: Writer> BufferedWriter<W> {
     pub fn unwrap(mut self) -> W {
         // FIXME(#12628): is failing the right thing to do if flushing fails?
         self.flush_buf().unwrap();
-        self.inner.take_unwrap()
+        self.inner.take().unwrap()
     }
 }
 

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -54,7 +54,7 @@ use collections::HashMap;
 ///     Err(e) => fail!("failed to execute child: {}", e),
 /// };
 ///
-/// let contents = child.stdout.get_mut_ref().read_to_end();
+/// let contents = child.stdout.as_mut().unwrap().read_to_end();
 /// assert!(child.wait().unwrap().success());
 /// ```
 pub struct Process {
@@ -95,7 +95,7 @@ pub type EnvMap = HashMap<CString, CString>;
 ///   Err(e) => fail!("failed to execute process: {}", e),
 /// };
 ///
-/// let output = process.stdout.get_mut_ref().read_to_end();
+/// let output = process.stdout.as_mut().unwrap().read_to_end();
 /// ```
 #[deriving(Clone)]
 pub struct Command {

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -70,7 +70,7 @@ impl TempDir {
     /// temporary directory is prevented.
     pub fn unwrap(self) -> Path {
         let mut tmpdir = self;
-        tmpdir.path.take_unwrap()
+        tmpdir.path.take().unwrap()
     }
 
     /// Access the wrapped `std::path::Path` to the temporary directory.

--- a/src/libsync/comm/oneshot.rs
+++ b/src/libsync/comm/oneshot.rs
@@ -107,7 +107,7 @@ impl<T: Send> Packet<T> {
             // Couldn't send the data, the port hung up first. Return the data
             // back up the stack.
             DISCONNECTED => {
-                Err(self.data.take_unwrap())
+                Err(self.data.take().unwrap())
             }
 
             // Not possible, these are one-use channels
@@ -244,7 +244,7 @@ impl<T: Send> Packet<T> {
             // There's data on the channel, so make sure we destroy it promptly.
             // This is why not using an arc is a little difficult (need the box
             // to stay valid while we take the data).
-            DATA => { self.data.take_unwrap(); }
+            DATA => { self.data.take().unwrap(); }
 
             // We're the only ones that can block on this port
             _ => unreachable!()

--- a/src/libsync/comm/sync.rs
+++ b/src/libsync/comm/sync.rs
@@ -347,7 +347,7 @@ impl<T: Send> Packet<T> {
         let waiter = match mem::replace(&mut state.blocker, NoneBlocked) {
             NoneBlocked => None,
             BlockedSender(task) => {
-                *state.canceled.take_unwrap() = true;
+                *state.canceled.take().unwrap() = true;
                 Some(task)
             }
             BlockedReceiver(..) => unreachable!(),
@@ -434,7 +434,7 @@ impl<T> Buffer<T> {
         let start = self.start;
         self.size -= 1;
         self.start = (self.start + 1) % self.buf.len();
-        self.buf.get_mut(start).take_unwrap()
+        self.buf.get_mut(start).take().unwrap()
     }
 
     fn size(&self) -> uint { self.size }
@@ -481,7 +481,7 @@ impl Queue {
         }
         unsafe {
             (*node).next = 0 as *mut Node;
-            Some((*node).task.take_unwrap())
+            Some((*node).task.take().unwrap())
         }
     }
 }

--- a/src/libsync/mpsc_queue.rs
+++ b/src/libsync/mpsc_queue.rs
@@ -122,7 +122,7 @@ impl<T: Send> Queue<T> {
                 *self.tail.get() = next;
                 assert!((*tail).value.is_none());
                 assert!((*next).value.is_some());
-                let ret = (*next).value.take_unwrap();
+                let ret = (*next).value.take().unwrap();
                 let _: Box<Node<T>> = mem::transmute(tail);
                 return Data(ret);
             }

--- a/src/libsync/raw.rs
+++ b/src/libsync/raw.rs
@@ -259,7 +259,7 @@ impl<'a> Condvar<'a> {
             // signaller already sent -- I mean 'unconditionally' in contrast
             // with acquire().)
             (|| {
-                let _ = wait_end.take_unwrap().recv();
+                let _ = wait_end.take().unwrap().recv();
             }).finally(|| {
                 // Reacquire the condvar.
                 match self.order {
@@ -318,7 +318,7 @@ impl<'a> Condvar<'a> {
                               condvar_id,
                               "cond.signal_on()",
                               || {
-                queue.take_unwrap().broadcast()
+                queue.take().unwrap().broadcast()
             })
         }
     }

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -245,7 +245,7 @@ impl<'a> Iterator<&'a str> for Graphemes<'a> {
             // looking up each character twice.
             cat = match self.cat {
                 None => gr::grapheme_category(ch),
-                _ => self.cat.take_unwrap()
+                _ => self.cat.take().unwrap()
             };
 
             if match cat {
@@ -345,7 +345,7 @@ impl<'a> DoubleEndedIterator<&'a str> for Graphemes<'a> {
             // cached category, if any
             cat = match self.catb {
                 None => gr::grapheme_category(ch),
-                _ => self.catb.take_unwrap()
+                _ => self.catb.take().unwrap()
             };
 
             // a matching state machine that runs *backwards* across an input string

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -52,8 +52,8 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
     // Send/Receive lots of messages.
     for j in range(0u, count) {
         //println!("task %?, iter %?", i, j);
-        let num_chan2 = num_chan.take_unwrap();
-        let num_port2 = num_port.take_unwrap();
+        let num_chan2 = num_chan.take().unwrap();
+        let num_port2 = num_port.take().unwrap();
         send(&num_chan2, i * j);
         num_chan = Some(num_chan2);
         let _n = recv(&num_port2);

--- a/src/test/bench/msgsend-ring-rw-arcs.rs
+++ b/src/test/bench/msgsend-ring-rw-arcs.rs
@@ -52,8 +52,8 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
     // Send/Receive lots of messages.
     for j in range(0u, count) {
         //println!("task %?, iter %?", i, j);
-        let num_chan2 = num_chan.take_unwrap();
-        let num_port2 = num_port.take_unwrap();
+        let num_chan2 = num_chan.take().unwrap();
+        let num_port2 = num_port.take().unwrap();
         send(&num_chan2, i * j);
         num_chan = Some(num_chan2);
         let _n = recv(&num_port2);


### PR DESCRIPTION
Per API meeting

  https://github.com/rust-lang/meeting-minutes/blob/master/Meeting-API-review-2014-08-13.md
# Changes to `core::option`

Most of the module is marked as stable or unstable; most of the unstable items are awaiting resolution of conventions issues.

However, a few methods have been deprecated, either due to lack of use or redundancy:
- `take_unwrap`, `get_ref` and `get_mut_ref` (redundant, and we prefer for this functionality to go through an explicit .unwrap)
- `filtered` and `while`
- `mutate` and `mutate_or_set`
- `collect`: this functionality is being moved to a new `FromIterator` impl.
# Changes to `core::result`

Most of the module is marked as stable or unstable; most of the unstable items are awaiting resolution of conventions issues.
- `collect`: this functionality is being moved to a new `FromIterator` impl.
- `fold_` is deprecated due to lack of use
- Several methods found in `core::option` are added here, including `iter`, `as_slice`, and variants.

Due to deprecations, this is a:

[breaking-change]
