### PR TITLE
librustc: Properly tag upvars in proc's to stop misleading unused_mut warnings.

### DIFF
--- a/src/librustc/middle/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc/middle/borrowck/gather_loans/restrictions.rs
@@ -70,18 +70,19 @@ impl<'a> RestrictionsContext<'a> {
             mc::cat_arg(local_id) => {
                 // R-Variable, locally declared
                 let lp = Rc::new(LpVar(local_id));
-                SafeIf(lp.clone(), vec!(lp))
+                SafeIf(lp.clone(), vec![lp])
             }
 
             mc::cat_upvar(upvar_id, _) => {
                 // R-Variable, captured into closure
                 let lp = Rc::new(LpUpvar(upvar_id));
-                SafeIf(lp.clone(), vec!(lp))
+                SafeIf(lp.clone(), vec![lp])
             }
 
-            mc::cat_copied_upvar(..) => {
-                // FIXME(#2152) allow mutation of upvars
-                Safe
+            mc::cat_copied_upvar(mc::CopiedUpvar { upvar_id, .. }) => {
+                // R-Variable, copied/moved into closure
+                let lp = Rc::new(LpVar(upvar_id));
+                SafeIf(lp.clone(), vec![lp])
             }
 
             mc::cat_downcast(cmt_base) => {

--- a/src/test/run-pass/issue-16671.rs
+++ b/src/test/run-pass/issue-16671.rs
@@ -8,12 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() {
-    let x = 1i;
-    proc() { x = 2; };
-    //~^ ERROR: cannot assign to immutable captured outer variable in a proc `x`
+#![forbid(warnings)]
 
-    let s = std::io::stdin();
-    proc() { s.lines(); };
-    //~^ ERROR: cannot borrow immutable captured outer variable in a proc `s` as mutable
+// Pretty printing tests complain about `use std::predule::*`
+#![allow(unused_imports)]
+
+// A var moved into a proc, that has a mutable loan path should
+// not trigger a misleading unused_mut warning.
+
+pub fn main() {
+    let mut stdin = std::io::stdin();
+    spawn(proc() {
+        let _ = stdin.lines();
+    });
 }


### PR DESCRIPTION
Fixes #16671.
