### PR TITLE
Added support for extern crate ... as ...;

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -891,9 +891,8 @@ There are several kinds of view item:
 ##### Extern crate declarations
 
 ~~~~ {.ebnf .gram}
-extern_crate_decl : "extern" "crate" ident [ '(' link_attrs ')' ] ? [ '=' string_lit ] ? ;
-link_attrs : link_attr [ ',' link_attrs ] + ;
-link_attr : ident '=' literal ;
+extern_crate_decl : "extern" "crate" crate_name
+crate_name: ident | ( string_lit as ident )
 ~~~~
 
 An _`extern crate` declaration_ specifies a dependency on an external crate.
@@ -913,11 +912,9 @@ Four examples of `extern crate` declarations:
 ~~~~ {.ignore}
 extern crate pcre;
 
-extern crate std; // equivalent to: extern crate std = "std";
+extern crate std; // equivalent to: extern crate std as std;
 
-extern crate ruststd = "std"; // linking to 'std' under another name
-
-extern crate foo = "some/where/rust-foo#foo:1.0"; // a full crate ID for external tools
+extern crate "std" as ruststd; // linking to 'std' under another name
 ~~~~
 
 ##### Use declarations

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4825,7 +4825,8 @@ impl<'a> Parser<'a> {
     /// # Example
     ///
     /// extern crate url;
-    /// extern crate foo = "bar";
+    /// extern crate foo = "bar"; //deprecated
+    /// extern crate "bar" as foo;
     fn parse_item_extern_crate(&mut self,
                                 lo: BytePos,
                                 visibility: Visibility,
@@ -4836,6 +4837,8 @@ impl<'a> Parser<'a> {
             token::IDENT(..) => {
                 let the_ident = self.parse_ident();
                 self.expect_one_of(&[], &[token::EQ, token::SEMI]);
+                // NOTE - #16689 change this to a warning once
+                //        the 'as' support is in stage0
                 let path = if self.token == token::EQ {
                     self.bump();
                     Some(self.parse_str())
@@ -4843,7 +4846,14 @@ impl<'a> Parser<'a> {
 
                 self.expect(&token::SEMI);
                 (path, the_ident)
-            }
+            },
+            token::LIT_STR(..) | token::LIT_STR_RAW(..) => {
+                let path = self.parse_str();
+                self.expect_keyword(keywords::As);
+                let the_ident = self.parse_ident();
+                self.expect(&token::SEMI);
+                (Some(path), the_ident)
+            },
             _ => {
                 let span = self.span;
                 let token_str = self.this_token_to_string();

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2375,13 +2375,13 @@ impl<'a> State<'a> {
         match item.node {
             ast::ViewItemExternCrate(id, ref optional_path, _) => {
                 try!(self.head("extern crate"));
-                try!(self.print_ident(id));
                 for &(ref p, style) in optional_path.iter() {
-                    try!(space(&mut self.s));
-                    try!(word(&mut self.s, "="));
-                    try!(space(&mut self.s));
                     try!(self.print_string(p.get(), style));
+                    try!(space(&mut self.s));
+                    try!(word(&mut self.s, "as"));
+                    try!(space(&mut self.s));
                 }
+                try!(self.print_ident(id));
             }
 
             ast::ViewItemUse(ref vp) => {

--- a/src/test/auxiliary/crateresolve4b-1.rs
+++ b/src/test/auxiliary/crateresolve4b-1.rs
@@ -13,6 +13,6 @@
 #![crate_id="crateresolve4b#0.1"]
 #![crate_type = "lib"]
 
-extern crate crateresolve4a = "crateresolve4a#0.2";
+extern crate "crateresolve4a#0.2" as crateresolve4a;
 
 pub fn f() -> int { crateresolve4a::g() }

--- a/src/test/auxiliary/crateresolve4b-2.rs
+++ b/src/test/auxiliary/crateresolve4b-2.rs
@@ -13,6 +13,6 @@
 #![crate_id="crateresolve4b#0.2"]
 #![crate_type = "lib"]
 
-extern crate crateresolve4a = "crateresolve4a#0.1";
+extern crate "crateresolve4a#0.1" as crateresolve4a;
 
 pub fn g() -> int { crateresolve4a::f() }

--- a/src/test/auxiliary/issue-12133-dylib2.rs
+++ b/src/test/auxiliary/issue-12133-dylib2.rs
@@ -12,6 +12,6 @@
 
 #![crate_type = "dylib"]
 
-extern crate a = "issue-12133-rlib";
-extern crate b = "issue-12133-dylib";
+extern crate "issue-12133-rlib" as a;
+extern crate "issue-12133-dylib" as b;
 

--- a/src/test/auxiliary/issue-13560-3.rs
+++ b/src/test/auxiliary/issue-13560-3.rs
@@ -13,6 +13,6 @@
 #![crate_type = "rlib"]
 #![feature(phase)]
 
-#[phase(plugin)] extern crate t1 = "issue-13560-1";
-#[phase(plugin, link)] extern crate t2 = "issue-13560-2";
+#[phase(plugin)] extern crate "issue-13560-1" as t1;
+#[phase(plugin, link)] extern crate "issue-13560-2" as t2;
 

--- a/src/test/auxiliary/issue-13620-2.rs
+++ b/src/test/auxiliary/issue-13620-2.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate crate1 = "issue-13620-1";
+extern crate "issue-13620-1" as crate1;
 
 pub static FOO2: crate1::Foo = crate1::FOO;

--- a/src/test/auxiliary/issue-13872-2.rs
+++ b/src/test/auxiliary/issue-13872-2.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate foo = "issue-13872-1";
+extern crate "issue-13872-1" as foo;
 
 pub use foo::B;

--- a/src/test/auxiliary/issue-13872-3.rs
+++ b/src/test/auxiliary/issue-13872-3.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate bar = "issue-13872-2";
+extern crate "issue-13872-2" as bar;
 
 use bar::B;
 

--- a/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
+++ b/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
@@ -14,7 +14,7 @@
 #![crate_type = "dylib"]
 #![feature(plugin_registrar, quote, globs)]
 
-extern crate other = "syntax-extension-with-dll-deps-1";
+extern crate "syntax-extension-with-dll-deps-1" as other;
 extern crate syntax;
 extern crate rustc;
 

--- a/src/test/auxiliary/trait_default_method_xc_aux_2.rs
+++ b/src/test/auxiliary/trait_default_method_xc_aux_2.rs
@@ -10,7 +10,7 @@
 
 // aux-build:trait_default_method_xc_aux.rs
 
-extern crate aux = "trait_default_method_xc_aux";
+extern crate "trait_default_method_xc_aux" as aux;
 use aux::A;
 
 pub struct a_struct { pub x: int }

--- a/src/test/compile-fail/bad-crate-id.rs
+++ b/src/test/compile-fail/bad-crate-id.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate foo = ""; //~ ERROR: crate name must not be empty
+extern crate "" as foo; //~ ERROR: crate name must not be empty
 
 fn main() {}

--- a/src/test/compile-fail/bad-crate-id2.rs
+++ b/src/test/compile-fail/bad-crate-id2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate bar = "#a"; //~ ERROR: invalid character `#` in crate name: `#a`
+extern crate "#a" as bar; //~ ERROR: invalid character `#` in crate name: `#a`
 
 fn main() {}
 

--- a/src/test/compile-fail/issue-11680.rs
+++ b/src/test/compile-fail/issue-11680.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-11680.rs
 
-extern crate other = "issue-11680";
+extern crate "issue-11680" as other;
 
 fn main() {
     let _b = other::Bar(1);

--- a/src/test/compile-fail/issue-12612.rs
+++ b/src/test/compile-fail/issue-12612.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-12612-1.rs
 
-extern crate foo = "issue-12612-1";
+extern crate "issue-12612-1" as foo;
 
 use foo::bar;
 

--- a/src/test/compile-fail/privacy-struct-variant.rs
+++ b/src/test/compile-fail/privacy-struct-variant.rs
@@ -12,7 +12,7 @@
 
 #![feature(struct_variant)]
 
-extern crate other = "privacy-struct-variant";
+extern crate "privacy-struct-variant" as other;
 
 mod a {
     pub enum Foo {

--- a/src/test/compile-fail/privacy5.rs
+++ b/src/test/compile-fail/privacy5.rs
@@ -11,7 +11,7 @@
 // aux-build:privacy-tuple-struct.rs
 // ignore-fast
 
-extern crate other = "privacy-tuple-struct";
+extern crate "privacy-tuple-struct" as other;
 
 mod a {
     pub struct A(());

--- a/src/test/compile-fail/struct-field-privacy.rs
+++ b/src/test/compile-fail/struct-field-privacy.rs
@@ -10,7 +10,7 @@
 
 // aux-build:struct-field-privacy.rs
 
-extern crate xc = "struct-field-privacy";
+extern crate "struct-field-privacy" as xc;
 
 struct A {
     a: int,

--- a/src/test/compile-fail/unreachable-variant.rs
+++ b/src/test/compile-fail/unreachable-variant.rs
@@ -10,7 +10,7 @@
 
 // aux-build:unreachable-variant.rs
 
-extern crate other = "unreachable-variant";
+extern crate "unreachable-variant" as other;
 
 fn main() {
     let _x = other::super_sekrit::baz; //~ ERROR is private

--- a/src/test/compile-fail/use-meta-mismatch.rs
+++ b/src/test/compile-fail/use-meta-mismatch.rs
@@ -10,6 +10,6 @@
 
 // error-pattern:can't find crate for `extra`
 
-extern crate extra = "fake-crate";
+extern crate "fake-crate" as extra;
 
 fn main() { }

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -16,4 +16,4 @@
 #![no_std]
 
 extern crate core;
-extern crate other = "weak-lang-items";
+extern crate "weak-lang-items" as other;

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -2,8 +2,8 @@
 #![no_std]
 #![feature(globs)]
 #[phase(plugin, link)]
-extern crate std = "std";
-extern crate rt = "native";
+extern crate "std" as std;
+extern crate "native" as rt;
 #[prelude_import]
 use std::prelude::*;
 // Copyright 2014 The Rust Project Developers. See the COPYRIGHT

--- a/src/test/pretty/raw-str-nonexpr.rs
+++ b/src/test/pretty/raw-str-nonexpr.rs
@@ -13,6 +13,6 @@
 #![feature(asm)]
 
 #[cfg = r#"just parse this"#]
-extern crate blah = r##"blah"##;
+extern crate r##"blah"## as blah;
 
 fn main() { unsafe { asm!(r###"blah"###); } }

--- a/src/test/run-pass-fulldeps/issue-13560.rs
+++ b/src/test/run-pass-fulldeps/issue-13560.rs
@@ -16,7 +16,7 @@
 // Regression test for issue #13560, the test itself is all in the dependent
 // libraries. The fail which previously failed to compile is the one numbered 3.
 
-extern crate t2 = "issue-13560-2";
-extern crate t3 = "issue-13560-3";
+extern crate "issue-13560-2" as t2;
+extern crate "issue-13560-3" as t3;
 
 fn main() {}

--- a/src/test/run-pass-fulldeps/syntax-extension-with-dll-deps.rs
+++ b/src/test/run-pass-fulldeps/syntax-extension-with-dll-deps.rs
@@ -15,7 +15,7 @@
 #![feature(phase)]
 
 #[phase(plugin)]
-extern crate extension = "syntax-extension-with-dll-deps-2";
+extern crate "syntax-extension-with-dll-deps-2" as extension;
 
 fn main() {
     foo!();

--- a/src/test/run-pass/extern-foreign-crate.rs
+++ b/src/test/run-pass/extern-foreign-crate.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate mystd = "std";
+extern crate "std" as mystd;
 
 pub fn main() {}

--- a/src/test/run-pass/issue-10028.rs
+++ b/src/test/run-pass/issue-10028.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-10028.rs
 
-extern crate issue10028 = "issue-10028";
+extern crate "issue-10028" as issue10028;
 
 use issue10028::ZeroLengthThingWithDestructor;
 

--- a/src/test/run-pass/issue-11224.rs
+++ b/src/test/run-pass/issue-11224.rs
@@ -10,6 +10,6 @@
 
 // aux-build:issue-11224.rs
 
-extern crate unused = "issue-11224";
+extern crate "issue-11224" as unused;
 
 pub fn main() {}

--- a/src/test/run-pass/issue-11225-1.rs
+++ b/src/test/run-pass/issue-11225-1.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-11225-1.rs
 
-extern crate foo = "issue-11225-1";
+extern crate "issue-11225-1" as foo;
 
 pub fn main() {
     foo::foo(1i);

--- a/src/test/run-pass/issue-11225-2.rs
+++ b/src/test/run-pass/issue-11225-2.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-11225-2.rs
 
-extern crate foo = "issue-11225-2";
+extern crate "issue-11225-2" as foo;
 
 pub fn main() {
     foo::foo(1i);

--- a/src/test/run-pass/issue-11508.rs
+++ b/src/test/run-pass/issue-11508.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-11508.rs
 
-extern crate rand = "issue-11508";
+extern crate "issue-11508" as rand;
 
 use rand::{Closed01, random};
 

--- a/src/test/run-pass/issue-11529.rs
+++ b/src/test/run-pass/issue-11529.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-11529.rs
 
-extern crate a = "issue-11529";
+extern crate "issue-11529" as a;
 
 fn main() {
     let one = 1;

--- a/src/test/run-pass/issue-12133-1.rs
+++ b/src/test/run-pass/issue-12133-1.rs
@@ -11,7 +11,7 @@
 // aux-build:issue-12133-rlib.rs
 // aux-build:issue-12133-dylib.rs
 
-extern crate a = "issue-12133-rlib";
-extern crate b = "issue-12133-dylib";
+extern crate "issue-12133-rlib" as a;
+extern crate "issue-12133-dylib" as b;
 
 fn main() {}

--- a/src/test/run-pass/issue-12133-2.rs
+++ b/src/test/run-pass/issue-12133-2.rs
@@ -12,7 +12,7 @@
 // aux-build:issue-12133-dylib.rs
 // no-prefer-dynamic
 
-extern crate a = "issue-12133-rlib";
-extern crate b = "issue-12133-dylib";
+extern crate "issue-12133-rlib" as a;
+extern crate "issue-12133-dylib" as b;
 
 fn main() {}

--- a/src/test/run-pass/issue-12133-3.rs
+++ b/src/test/run-pass/issue-12133-3.rs
@@ -12,6 +12,6 @@
 // aux-build:issue-12133-dylib.rs
 // aux-build:issue-12133-dylib2.rs
 
-extern crate other = "issue-12133-dylib2";
+extern crate "issue-12133-dylib2" as other;
 
 fn main() {}

--- a/src/test/run-pass/issue-12612.rs
+++ b/src/test/run-pass/issue-12612.rs
@@ -11,8 +11,8 @@
 // aux-build:issue-12612-1.rs
 // aux-build:issue-12612-2.rs
 
-extern crate foo = "issue-12612-1";
-extern crate bar = "issue-12612-2";
+extern crate "issue-12612-1" as foo;
+extern crate "issue-12612-2" as bar;
 
 mod test {
     use bar::baz;

--- a/src/test/run-pass/issue-13620.rs
+++ b/src/test/run-pass/issue-13620.rs
@@ -11,7 +11,7 @@
 // aux-build:issue-13620-1.rs
 // aux-build:issue-13620-2.rs
 
-extern crate crate2 = "issue-13620-2";
+extern crate "issue-13620-2" as crate2;
 
 fn main() {
     (crate2::FOO2.foo)();

--- a/src/test/run-pass/issue-13872.rs
+++ b/src/test/run-pass/issue-13872.rs
@@ -12,7 +12,7 @@
 // aux-build:issue-13872-2.rs
 // aux-build:issue-13872-3.rs
 
-extern crate other = "issue-13872-3";
+extern crate "issue-13872-3" as other;
 
 fn main() {
     other::foo();

--- a/src/test/run-pass/issue-14330.rs
+++ b/src/test/run-pass/issue-14330.rs
@@ -10,6 +10,6 @@
 
 #![feature(phase)]
 
-#[phase(plugin, link)] extern crate std2 = "std";
+#[phase(plugin, link)] extern crate "std" as std2;
 
 fn main() {}

--- a/src/test/run-pass/issue-14421.rs
+++ b/src/test/run-pass/issue-14421.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-14421.rs
 
-extern crate bug_lib = "issue-14421";
+extern crate "issue-14421" as bug_lib;
 
 use bug_lib::B;
 use bug_lib::make;

--- a/src/test/run-pass/issue-14422.rs
+++ b/src/test/run-pass/issue-14422.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-14422.rs
 
-extern crate bug_lib = "issue-14422";
+extern crate "issue-14422" as bug_lib;
 
 use bug_lib::B;
 use bug_lib::make;

--- a/src/test/run-pass/issue-4545.rs
+++ b/src/test/run-pass/issue-4545.rs
@@ -10,5 +10,5 @@
 
 // aux-build:issue-4545.rs
 
-extern crate somelib = "issue-4545";
+extern crate "issue-4545" as somelib;
 pub fn main() { somelib::mk::<int>(); }

--- a/src/test/run-pass/issue-5518.rs
+++ b/src/test/run-pass/issue-5518.rs
@@ -10,6 +10,6 @@
 
 // aux-build:issue-5518.rs
 
-extern crate other = "issue-5518";
+extern crate "issue-5518" as other;
 
 fn main() {}

--- a/src/test/run-pass/issue-5521.rs
+++ b/src/test/run-pass/issue-5521.rs
@@ -11,7 +11,7 @@
 // aux-build:issue-5521.rs
 
 
-extern crate foo = "issue-5521";
+extern crate "issue-5521" as foo;
 
 fn bar(a: foo::map) {
     if false {

--- a/src/test/run-pass/issue-7178.rs
+++ b/src/test/run-pass/issue-7178.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-7178.rs
 
-extern crate cross_crate_self = "issue-7178";
+extern crate "issue-7178" as cross_crate_self;
 
 pub fn main() {
     let _ = cross_crate_self::Foo::new(&1i);

--- a/src/test/run-pass/issue-7899.rs
+++ b/src/test/run-pass/issue-7899.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-7899.rs
 
-extern crate testcrate = "issue-7899";
+extern crate "issue-7899" as testcrate;
 
 fn main() {
     let f = testcrate::V2(1.0f32, 2.0f32);

--- a/src/test/run-pass/issue-8044.rs
+++ b/src/test/run-pass/issue-8044.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-8044.rs
 
-extern crate minimal = "issue-8044";
+extern crate "issue-8044" as minimal;
 use minimal::{BTree, leaf};
 
 pub fn main() {

--- a/src/test/run-pass/issue-8259.rs
+++ b/src/test/run-pass/issue-8259.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-8259.rs
 
-extern crate other = "issue-8259";
+extern crate "issue-8259" as other;
 static a: other::Foo<'static> = other::A;
 
 pub fn main() {}

--- a/src/test/run-pass/issue-9906.rs
+++ b/src/test/run-pass/issue-9906.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-9906.rs
 
-extern crate testmod = "issue-9906";
+extern crate "issue-9906" as testmod;
 
 pub fn main() {
     testmod::foo();

--- a/src/test/run-pass/issue-9968.rs
+++ b/src/test/run-pass/issue-9968.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-9968.rs
 
-extern crate lib = "issue-9968";
+extern crate "issue-9968" as lib;
 
 use lib::{Trait, Struct};
 

--- a/src/test/run-pass/lang-item-public.rs
+++ b/src/test/run-pass/lang-item-public.rs
@@ -14,7 +14,7 @@
 
 #![no_std]
 
-extern crate lang_lib = "lang-item-public";
+extern crate "lang-item-public" as lang_lib;
 
 #[cfg(target_os = "linux")]
 #[link(name = "c")]

--- a/src/test/run-pass/linkage-visibility.rs
+++ b/src/test/run-pass/linkage-visibility.rs
@@ -12,7 +12,7 @@
 // ignore-android: FIXME(#10379)
 // ignore-windows: std::dynamic_lib does not work on Windows well
 
-extern crate foo = "linkage-visibility";
+extern crate "linkage-visibility" as foo;
 
 pub fn main() {
     foo::test();

--- a/src/test/run-pass/linkage1.rs
+++ b/src/test/run-pass/linkage1.rs
@@ -15,7 +15,7 @@
 
 #![feature(linkage)]
 
-extern crate other = "linkage1";
+extern crate "linkage1" as other;
 
 extern {
     #[linkage = "extern_weak"]

--- a/src/test/run-pass/priv-impl-prim-ty.rs
+++ b/src/test/run-pass/priv-impl-prim-ty.rs
@@ -10,7 +10,7 @@
 
 // aux-build:priv-impl-prim-ty.rs
 
-extern crate bar = "priv-impl-prim-ty";
+extern crate "priv-impl-prim-ty" as bar;
 
 pub fn main() {
     bar::frob(1i);

--- a/src/test/run-pass/reexport-should-still-link.rs
+++ b/src/test/run-pass/reexport-should-still-link.rs
@@ -10,7 +10,7 @@
 
 // aux-build:reexport-should-still-link.rs
 
-extern crate foo = "reexport-should-still-link";
+extern crate "reexport-should-still-link" as foo;
 
 pub fn main() {
     foo::bar();

--- a/src/test/run-pass/static-fn-inline-xc.rs
+++ b/src/test/run-pass/static-fn-inline-xc.rs
@@ -10,7 +10,7 @@
 
 // aux-build:static_fn_inline_xc_aux.rs
 
-extern crate mycore = "static_fn_inline_xc_aux";
+extern crate "static_fn_inline_xc_aux" as mycore;
 
 use mycore::num;
 

--- a/src/test/run-pass/static-fn-trait-xc.rs
+++ b/src/test/run-pass/static-fn-trait-xc.rs
@@ -10,7 +10,7 @@
 
 // aux-build:static_fn_trait_xc_aux.rs
 
-extern crate mycore = "static_fn_trait_xc_aux";
+extern crate "static_fn_trait_xc_aux" as mycore;
 
 use mycore::num;
 

--- a/src/test/run-pass/static-function-pointer-xc.rs
+++ b/src/test/run-pass/static-function-pointer-xc.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:static-function-pointer-aux.rs
-extern crate aux = "static-function-pointer-aux";
+extern crate "static-function-pointer-aux" as aux;
 
 fn f(x: int) -> int { x }
 

--- a/src/test/run-pass/trait-default-method-xc-2.rs
+++ b/src/test/run-pass/trait-default-method-xc-2.rs
@@ -12,8 +12,8 @@
 // aux-build:trait_default_method_xc_aux_2.rs
 
 
-extern crate aux = "trait_default_method_xc_aux";
-extern crate aux2 = "trait_default_method_xc_aux_2";
+extern crate "trait_default_method_xc_aux" as aux;
+extern crate "trait_default_method_xc_aux_2" as aux2;
 use aux::A;
 use aux2::{a_struct, welp};
 

--- a/src/test/run-pass/trait-default-method-xc.rs
+++ b/src/test/run-pass/trait-default-method-xc.rs
@@ -10,7 +10,7 @@
 
 // aux-build:trait_default_method_xc_aux.rs
 
-extern crate aux = "trait_default_method_xc_aux";
+extern crate "trait_default_method_xc_aux" as aux;
 use aux::{A, TestEquality, Something};
 use aux::B;
 

--- a/src/test/run-pass/trait-inheritance-auto-xc-2.rs
+++ b/src/test/run-pass/trait-inheritance-auto-xc-2.rs
@@ -10,7 +10,7 @@
 
 // aux-build:trait_inheritance_auto_xc_2_aux.rs
 
-extern crate aux = "trait_inheritance_auto_xc_2_aux";
+extern crate "trait_inheritance_auto_xc_2_aux" as aux;
 
 // aux defines impls of Foo, Bar and Baz for A
 use aux::{Foo, Bar, Baz, A};

--- a/src/test/run-pass/trait-inheritance-auto-xc.rs
+++ b/src/test/run-pass/trait-inheritance-auto-xc.rs
@@ -10,7 +10,7 @@
 
 // aux-build:trait_inheritance_auto_xc_aux.rs
 
-extern crate aux = "trait_inheritance_auto_xc_aux";
+extern crate "trait_inheritance_auto_xc_aux" as aux;
 
 use aux::{Foo, Bar, Baz, Quux};
 

--- a/src/test/run-pass/trait-inheritance-cross-trait-call-xc.rs
+++ b/src/test/run-pass/trait-inheritance-cross-trait-call-xc.rs
@@ -10,7 +10,7 @@
 
 // aux-build:trait_inheritance_cross_trait_call_xc_aux.rs
 
-extern crate aux = "trait_inheritance_cross_trait_call_xc_aux";
+extern crate "trait_inheritance_cross_trait_call_xc_aux" as aux;
 
 use aux::Foo;
 

--- a/src/test/run-pass/typeid-intrinsic.rs
+++ b/src/test/run-pass/typeid-intrinsic.rs
@@ -11,8 +11,8 @@
 // aux-build:typeid-intrinsic.rs
 // aux-build:typeid-intrinsic2.rs
 
-extern crate other1 = "typeid-intrinsic";
-extern crate other2 = "typeid-intrinsic2";
+extern crate "typeid-intrinsic" as other1;
+extern crate "typeid-intrinsic2" as other2;
 
 use std::hash;
 use std::intrinsics;

--- a/src/test/run-pass/use-crate-name-alias.rs
+++ b/src/test/run-pass/use-crate-name-alias.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 // Issue #1706
-extern crate stdlib = "std";
+extern crate "std" as stdlib;
 
 pub fn main() {}

--- a/src/test/run-pass/use.rs
+++ b/src/test/run-pass/use.rs
@@ -14,7 +14,7 @@
 
 #![no_std]
 extern crate std;
-extern crate zed = "std";
+extern crate "std" as zed;
 
 
 use std::str;

--- a/src/test/run-pass/weak-lang-item.rs
+++ b/src/test/run-pass/weak-lang-item.rs
@@ -10,7 +10,7 @@
 
 // aux-build:weak-lang-items.rs
 
-extern crate other = "weak-lang-items";
+extern crate "weak-lang-items" as other;
 
 use std::task;
 

--- a/src/test/run-pass/xcrate-address-insignificant.rs
+++ b/src/test/run-pass/xcrate-address-insignificant.rs
@@ -10,7 +10,7 @@
 
 // aux-build:xcrate_address_insignificant.rs
 
-extern crate foo = "xcrate_address_insignificant";
+extern crate "xcrate_address_insignificant" as foo;
 
 pub fn main() {
     assert_eq!(foo::foo::<f64>(), foo::bar());

--- a/src/test/run-pass/xcrate-trait-lifetime-param.rs
+++ b/src/test/run-pass/xcrate-trait-lifetime-param.rs
@@ -10,7 +10,7 @@
 
 // aux-build:xcrate-trait-lifetime-param.rs
 
-extern crate other = "xcrate-trait-lifetime-param";
+extern crate "xcrate-trait-lifetime-param" as other;
 
 struct Reader<'a> {
     b : &'a [u8]


### PR DESCRIPTION
For review. Not sure about the link_attrs stuff. Will work on converting all the tests.

extern crate "foobar" as foo;
extern crate foobar as foo;

Implements remaining part of RFC #47.
Addresses issue #16461.

Removed link_attrs from rust.md, they don't appear to be supported by
the parser.
