### PR TITLE
Log linker stderr and stdout.

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1305,6 +1305,8 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
                 sess.note(str::from_utf8(output.as_slice()).unwrap());
                 sess.abort_if_errors();
             }
+            debug!("linker stderr:\n{}", str::from_utf8_owned(prog.error).unwrap());
+            debug!("linker stdout:\n{}", str::from_utf8_owned(prog.output).unwrap());
         },
         Err(e) => {
             sess.err(format!("could not exec the linker `{}`: {}",


### PR DESCRIPTION
Shows linker spew even when linking succeeds.  This is occasionally useful in order to see verbose linker output.
