### PR TITLE
Adjust the error messages to match the pattern "expected foo, found bar"

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -200,7 +200,7 @@ impl<'a> Parser<'a> {
                 self.cur.next();
             }
             Some((_, other)) => {
-                self.err(format!("expected `{}` but found `{}`",
+                self.err(format!("expected `{}`, found `{}`",
                                  c,
                                  other).as_slice());
             }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -575,12 +575,12 @@ pub fn parse_def_id(buf: &[u8]) -> ast::DefId {
 
     let crate_num = match uint::parse_bytes(crate_part, 10u) {
        Some(cn) => cn as ast::CrateNum,
-       None => fail!("internal error: parse_def_id: crate number expected, but found {:?}",
+       None => fail!("internal error: parse_def_id: crate number expected, found {:?}",
                      crate_part)
     };
     let def_num = match uint::parse_bytes(def_part, 10u) {
        Some(dn) => dn as ast::NodeId,
-       None => fail!("internal error: parse_def_id: id expected, but found {:?}",
+       None => fail!("internal error: parse_def_id: id expected, found {:?}",
                      def_part)
     };
     ast::DefId { krate: crate_num, node: def_num }

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -122,7 +122,7 @@ impl<'a> Visitor<()> for EffectCheckVisitor<'a> {
                 // we need to create a new context, when we're
                 // - outside `unsafe` and found a `unsafe` block
                 //   (normal case)
-                // - inside `unsafe` but found an `unsafe` block
+                // - inside `unsafe`, found an `unsafe` block
                 //   created internally to the compiler
                 //
                 // The second case is necessary to ensure that the

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3603,17 +3603,17 @@ pub fn type_err_to_str(cx: &ctxt, err: &type_err) -> String {
     match *err {
         terr_mismatch => "types differ".to_string(),
         terr_fn_style_mismatch(values) => {
-            format!("expected {} fn but found {} fn",
+            format!("expected {} fn, found {} fn",
                     values.expected.to_string(),
                     values.found.to_string())
         }
         terr_abi_mismatch(values) => {
-            format!("expected {} fn but found {} fn",
+            format!("expected {} fn, found {} fn",
                     values.expected.to_string(),
                     values.found.to_string())
         }
         terr_onceness_mismatch(values) => {
-            format!("expected {} fn but found {} fn",
+            format!("expected {} fn, found {} fn",
                     values.expected.to_string(),
                     values.found.to_string())
         }
@@ -3630,20 +3630,20 @@ pub fn type_err_to_str(cx: &ctxt, err: &type_err) -> String {
         terr_ptr_mutability => "pointers differ in mutability".to_string(),
         terr_ref_mutability => "references differ in mutability".to_string(),
         terr_ty_param_size(values) => {
-            format!("expected a type with {} type params \
-                     but found one with {} type params",
+            format!("expected a type with {} type params, \
+                     found one with {} type params",
                     values.expected,
                     values.found)
         }
         terr_tuple_size(values) => {
-            format!("expected a tuple with {} elements \
-                     but found one with {} elements",
+            format!("expected a tuple with {} elements, \
+                     found one with {} elements",
                     values.expected,
                     values.found)
         }
         terr_record_size(values) => {
-            format!("expected a record with {} fields \
-                     but found one with {} fields",
+            format!("expected a record with {} fields, \
+                     found one with {} fields",
                     values.expected,
                     values.found)
         }
@@ -3651,7 +3651,7 @@ pub fn type_err_to_str(cx: &ctxt, err: &type_err) -> String {
             "record elements differ in mutability".to_string()
         }
         terr_record_fields(values) => {
-            format!("expected a record with field `{}` but found one \
+            format!("expected a record with field `{}`, found one \
                      with field `{}`",
                     token::get_ident(values.expected),
                     token::get_ident(values.found))
@@ -3670,57 +3670,57 @@ pub fn type_err_to_str(cx: &ctxt, err: &type_err) -> String {
         }
         terr_regions_insufficiently_polymorphic(br, _) => {
             format!("expected bound lifetime parameter {}, \
-                     but found concrete lifetime",
+                     found concrete lifetime",
                     bound_region_ptr_to_string(cx, br))
         }
         terr_regions_overly_polymorphic(br, _) => {
             format!("expected concrete lifetime, \
-                     but found bound lifetime parameter {}",
+                     found bound lifetime parameter {}",
                     bound_region_ptr_to_string(cx, br))
         }
         terr_trait_stores_differ(_, ref values) => {
-            format!("trait storage differs: expected `{}` but found `{}`",
+            format!("trait storage differs: expected `{}`, found `{}`",
                     trait_store_to_string(cx, (*values).expected),
                     trait_store_to_string(cx, (*values).found))
         }
         terr_sorts(values) => {
-            format!("expected {} but found {}",
+            format!("expected {}, found {}",
                     ty_sort_string(cx, values.expected),
                     ty_sort_string(cx, values.found))
         }
         terr_traits(values) => {
-            format!("expected trait `{}` but found trait `{}`",
+            format!("expected trait `{}`, found trait `{}`",
                     item_path_str(cx, values.expected),
                     item_path_str(cx, values.found))
         }
         terr_builtin_bounds(values) => {
             if values.expected.is_empty() {
-                format!("expected no bounds but found `{}`",
+                format!("expected no bounds, found `{}`",
                         values.found.user_string(cx))
             } else if values.found.is_empty() {
-                format!("expected bounds `{}` but found no bounds",
+                format!("expected bounds `{}`, found no bounds",
                         values.expected.user_string(cx))
             } else {
-                format!("expected bounds `{}` but found bounds `{}`",
+                format!("expected bounds `{}`, found bounds `{}`",
                         values.expected.user_string(cx),
                         values.found.user_string(cx))
             }
         }
         terr_integer_as_char => {
-            "expected an integral type but found `char`".to_string()
+            "expected an integral type, found `char`".to_string()
         }
         terr_int_mismatch(ref values) => {
-            format!("expected `{}` but found `{}`",
+            format!("expected `{}`, found `{}`",
                     values.expected.to_string(),
                     values.found.to_string())
         }
         terr_float_mismatch(ref values) => {
-            format!("expected `{}` but found `{}`",
+            format!("expected `{}`, found `{}`",
                     values.expected.to_string(),
                     values.found.to_string())
         }
         terr_variadic_mismatch(ref values) => {
-            format!("expected {} fn but found {} function",
+            format!("expected {} fn, found {} function",
                     if values.expected { "variadic" } else { "non-variadic" },
                     if values.found { "variadic" } else { "non-variadic" })
         }
@@ -4548,7 +4548,7 @@ pub fn eval_repeat_count<T: ExprTyProvider>(tcx: &T, count_expr: &ast::Expr) -> 
         const_eval::const_int(count) => if count < 0 {
             tcx.ty_ctxt().sess.span_err(count_expr.span,
                                         "expected positive integer for \
-                                         repeat count but found negative integer");
+                                         repeat count, found negative integer");
             return 0;
         } else {
             return count as uint
@@ -4557,38 +4557,38 @@ pub fn eval_repeat_count<T: ExprTyProvider>(tcx: &T, count_expr: &ast::Expr) -> 
         const_eval::const_float(count) => {
             tcx.ty_ctxt().sess.span_err(count_expr.span,
                                         "expected positive integer for \
-                                         repeat count but found float");
+                                         repeat count, found float");
             return count as uint;
         }
         const_eval::const_str(_) => {
             tcx.ty_ctxt().sess.span_err(count_expr.span,
                                         "expected positive integer for \
-                                         repeat count but found string");
+                                         repeat count, found string");
             return 0;
         }
         const_eval::const_bool(_) => {
             tcx.ty_ctxt().sess.span_err(count_expr.span,
                                         "expected positive integer for \
-                                         repeat count but found boolean");
+                                         repeat count, found boolean");
             return 0;
         }
         const_eval::const_binary(_) => {
             tcx.ty_ctxt().sess.span_err(count_expr.span,
                                         "expected positive integer for \
-                                         repeat count but found binary array");
+                                         repeat count, found binary array");
             return 0;
         }
         const_eval::const_nil => {
             tcx.ty_ctxt().sess.span_err(count_expr.span,
                                         "expected positive integer for \
-                                         repeat count but found ()");
+                                         repeat count, found ()");
             return 0;
         }
       },
       Err(..) => {
         tcx.ty_ctxt().sess.span_err(count_expr.span,
-                                    "expected constant integer for repeat count \
-                                     but found variable");
+                                    "expected constant integer for repeat count, \
+                                     found variable");
         return 0;
       }
     }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -191,7 +191,7 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
 
         if supplied_num_region_params != 0 || anon_regions.is_err() {
             span_err!(tcx.sess, path.span, E0107,
-                "wrong number of lifetime parameters: expected {} but found {}",
+                "wrong number of lifetime parameters: expected {}, found {}",
                 expected_num_region_params, supplied_num_region_params);
         }
 
@@ -216,7 +216,7 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
             "expected"
         };
         this.tcx().sess.span_fatal(path.span,
-            format!("wrong number of type arguments: {} {} but found {}",
+            format!("wrong number of type arguments: {} {}, found {}",
                     expected,
                     required_ty_param_count,
                     supplied_ty_param_count).as_slice());
@@ -227,7 +227,7 @@ fn ast_path_substs<AC:AstConv,RS:RegionScope>(
             "expected"
         };
         this.tcx().sess.span_fatal(path.span,
-            format!("wrong number of type arguments: {} {} but found {}",
+            format!("wrong number of type arguments: {} {}, found {}",
                     expected,
                     formal_ty_param_count,
                     supplied_ty_param_count).as_slice());

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -169,7 +169,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
                     fcx.infcx().type_error_message_str_with_expected(pat.span,
                                                        |expected, actual| {
                        expected.map_or("".to_string(), |e| {
-                        format!("mismatched types: expected `{}` but found {}",
+                        format!("mismatched types: expected `{}`, found {}",
                                 e, actual)
                         })},
                         Some(expected),
@@ -223,7 +223,7 @@ pub fn check_pat_variant(pcx: &pat_ctxt, pat: &ast::Pat, path: &ast::Path,
                                                |expected, actual| {
                                                expected.map_or("".to_string(),
                                                               |e| {
-                        format!("mismatched types: expected `{}` but found {}",
+                        format!("mismatched types: expected `{}`, found {}",
                                 e, actual)
                     })
                 },
@@ -395,7 +395,7 @@ pub fn check_struct_like_enum_variant_pat(pcx: &pat_ctxt,
         Some(&def::DefTy(..)) => {
             let name = pprust::path_to_string(path);
             span_err!(tcx.sess, span, E0028,
-                "mismatched types: expected `{}` but found `{}`",
+                "mismatched types: expected `{}`, found `{}`",
                 fcx.infcx().ty_to_string(expected), name);
         }
         _ => {
@@ -548,7 +548,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
                             expected.map_or("".to_string(),
                                             |e| {
                                 format!("mismatched types: expected \
-                                        `{}` but found {}", e, actual)
+                                        `{}`, found {}", e, actual)
                             })},
                             Some(expected),
                             "a structure pattern".to_string(),
@@ -607,8 +607,8 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
                                                                  |expected,
                                                                   actual| {
                         expected.map_or("".to_string(), |e| {
-                            format!("mismatched types: expected `{}` \
-                                     but found {}", e, actual)
+                            format!("mismatched types: expected `{}`, \
+                                     found {}", e, actual)
                         }
                     )},
                     Some(expected),
@@ -645,7 +645,7 @@ pub fn check_pat(pcx: &pat_ctxt, pat: &ast::Pat, expected: ty::t) {
                 |expected, actual| {
                     expected.map_or("".to_string(),
                                     |e| {
-                        format!("mismatched types: expected `{}` but found {}",
+                        format!("mismatched types: expected `{}`, found {}",
                                 e, actual)
                     })
                 },
@@ -763,7 +763,7 @@ fn check_pointer_pat(pcx: &pat_ctxt,
                 span,
                 |expected, actual| {
                     expected.map_or("".to_string(), |e| {
-                        format!("mismatched types: expected `{}` but found {}",
+                        format!("mismatched types: expected `{}`, found {}",
                                 e, actual)
                     })
                 },

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2313,7 +2313,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             ty::ty_closure(box ty::ClosureTy {sig: ref sig, ..}) => sig,
             _ => {
                 fcx.type_error_message(call_expr.span, |actual| {
-                    format!("expected function but found `{}`", actual)
+                    format!("expected function, found `{}`", actual)
                 }, fn_ty, None);
                 &error_fn_sig
             }
@@ -3811,7 +3811,7 @@ impl Repr for Expectation {
 pub fn require_uint(fcx: &FnCtxt, sp: Span, t: ty::t) {
     if !type_is_uint(fcx, sp, t) {
         fcx.type_error_message(sp, |actual| {
-            format!("mismatched types: expected `uint` type but found `{}`",
+            format!("mismatched types: expected `uint` type, found `{}`",
                     actual)
         }, t, None);
     }
@@ -3820,7 +3820,7 @@ pub fn require_uint(fcx: &FnCtxt, sp: Span, t: ty::t) {
 pub fn require_integral(fcx: &FnCtxt, sp: Span, t: ty::t) {
     if !type_is_integral(fcx, sp, t) {
         fcx.type_error_message(sp, |actual| {
-            format!("mismatched types: expected integral type but found `{}`",
+            format!("mismatched types: expected integral type, found `{}`",
                     actual)
         }, t, None);
     }
@@ -4336,28 +4336,28 @@ pub fn polytype_for_def(fcx: &FnCtxt,
       def::DefTy(_) |
       def::DefPrimTy(_) |
       def::DefTyParam(..)=> {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found type");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found type");
       }
       def::DefMod(..) | def::DefForeignMod(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found module");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found module");
       }
       def::DefUse(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found use");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found use");
       }
       def::DefRegion(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found region");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found region");
       }
       def::DefTyParamBinder(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found type parameter");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found type parameter");
       }
       def::DefLabel(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found label");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found label");
       }
       def::DefSelfTy(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found self ty");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found self ty");
       }
       def::DefMethod(..) => {
-        fcx.ccx.tcx.sess.span_bug(sp, "expected value but found method");
+        fcx.ccx.tcx.sess.span_bug(sp, "expected value, found method");
       }
     }
 }
@@ -4585,8 +4585,8 @@ pub fn instantiate_path(fcx: &FnCtxt,
                 } else if i == type_count {
                     span_err!(fcx.tcx().sess, typ.span, E0087,
                         "too many type parameters provided: \
-                         expected at most {} parameter(s) \
-                         but found {} parameter(s)",
+                         expected at most {} parameter(s), \
+                         found {} parameter(s)",
                          type_count, segment.types.len());
                     substs.types.truncate(space, 0);
                 }
@@ -4603,7 +4603,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
                 } else if i == region_count {
                     span_err!(fcx.tcx().sess, lifetime.span, E0088,
                         "too many lifetime parameters provided: \
-                         expected {} parameter(s) but found {} parameter(s)",
+                         expected {} parameter(s), found {} parameter(s)",
                         region_count,
                         segment.lifetimes.len());
                     substs.mut_regions().truncate(space, 0);
@@ -4652,7 +4652,7 @@ pub fn instantiate_path(fcx: &FnCtxt,
                 if desired.len() != required_len { "at least " } else { "" };
             span_err!(fcx.tcx().sess, span, E0089,
                 "too few type parameters provided: expected {}{} parameter(s) \
-                 but found {} parameter(s)",
+                , found {} parameter(s)",
                 qualifier, required_len, provided_len);
             substs.types.replace(space,
                                  Vec::from_elem(desired.len(), ty::mk_err()));
@@ -4705,8 +4705,8 @@ pub fn instantiate_path(fcx: &FnCtxt,
         // Otherwise, too few were provided. Report an error and then
         // use inference variables.
         span_err!(fcx.tcx().sess, span, E0090,
-            "too few lifetime parameters provided: expected {} parameter(s) \
-             but found {} parameter(s)",
+            "too few lifetime parameters provided: expected {} parameter(s), \
+             found {} parameter(s)",
             desired.len(), provided_len);
 
         substs.mut_regions().replace(

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -206,7 +206,7 @@ fn relate_trait_refs(vcx: &VtableContext,
                 !ty::trait_ref_contains_error(&r_exp_trait_ref)
             {
                 let tcx = vcx.tcx();
-                span_err!(tcx.sess, span, E0095, "expected {}, but found {} ({})",
+                span_err!(tcx.sess, span, E0095, "expected {}, found {} ({})",
                           ppaux::trait_ref_to_string(tcx, &r_exp_trait_ref),
                           ppaux::trait_ref_to_string(tcx, &r_act_trait_ref),
                           ty::type_err_to_str(tcx, err));

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -377,7 +377,7 @@ impl<'a> ErrorReporting for InferCtxt<'a> {
 
     fn values_str(&self, values: &ValuePairs) -> Option<String> {
         /*!
-         * Returns a string of the form "expected `{}` but found `{}`",
+         * Returns a string of the form "expected `{}`, found `{}`",
          * or None if this is a derived error.
          */
         match *values {
@@ -405,7 +405,7 @@ impl<'a> ErrorReporting for InferCtxt<'a> {
             return None;
         }
 
-        Some(format!("expected `{}` but found `{}`",
+        Some(format!("expected `{}`, found `{}`",
                      expected.user_string(self.tcx),
                      found.user_string(self.tcx)))
     }

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -799,7 +799,7 @@ impl<'a> InferCtxt<'a> {
             _ => {
                 // if I leave out : String, it infers &str and complains
                 |actual: String| {
-                    format!("mismatched types: expected `{}` but found `{}`",
+                    format!("mismatched types: expected `{}`, found `{}`",
                             self.ty_to_string(resolved_expected),
                             actual)
                 }

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -151,7 +151,7 @@ pub fn expand_asm(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     clobs.push(clob);
 
                     if OPTIONS.iter().any(|opt| s.equiv(opt)) {
-                        cx.span_warn(p.last_span, "expected a clobber, but found an option");
+                        cx.span_warn(p.last_span, "expected a clobber, found an option");
                     }
                 }
 

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -128,7 +128,7 @@ fn parse_args(ecx: &mut ExtCtxt, sp: Span, allow_method: bool,
                 }
                 _ => {
                     ecx.span_err(p.span,
-                                 format!("expected ident for named argument, but found `{}`",
+                                 format!("expected ident for named argument, found `{}`",
                                          p.this_token_to_string()).as_slice());
                     return (invocation, None);
                 }

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -92,7 +92,7 @@ impl<'a> ParserAttr for Parser<'a> {
             }
             _ => {
                 let token_str = self.this_token_to_string();
-                self.fatal(format!("expected `#` but found `{}`",
+                self.fatal(format!("expected `#`, found `{}`",
                                    token_str).as_slice());
             }
         };

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -413,7 +413,7 @@ impl<'a> Parser<'a> {
         } else {
             let token_str = Parser::token_to_string(t);
             let this_token_str = self.this_token_to_string();
-            self.fatal(format!("expected `{}` but found `{}`",
+            self.fatal(format!("expected `{}`, found `{}`",
                                token_str,
                                this_token_str).as_slice())
         }
@@ -447,11 +447,11 @@ impl<'a> Parser<'a> {
             let actual = self.this_token_to_string();
             self.fatal(
                 (if expected.len() != 1 {
-                    (format!("expected one of `{}` but found `{}`",
+                    (format!("expected one of `{}`, found `{}`",
                              expect,
                              actual))
                 } else {
-                    (format!("expected `{}` but found `{}`",
+                    (format!("expected `{}`, found `{}`",
                              expect,
                              actual))
                 }).as_slice()
@@ -1314,7 +1314,7 @@ impl<'a> Parser<'a> {
 
               _ => {
                   let token_str = p.this_token_to_string();
-                  p.fatal((format!("expected `;` or `{{` but found `{}`",
+                  p.fatal((format!("expected `;` or `{{`, found `{}`",
                                    token_str)).as_slice())
               }
             }
@@ -3375,7 +3375,7 @@ impl<'a> Parser<'a> {
                         ""
                     };
                     let tok_str = self.this_token_to_string();
-                    self.fatal(format!("expected {}`(` or `{{`, but found `{}`",
+                    self.fatal(format!("expected {}`(` or `{{`, found `{}`",
                                        ident_str,
                                        tok_str).as_slice())
                 }
@@ -3924,7 +3924,7 @@ impl<'a> Parser<'a> {
             },
             _ => {
                 let token_str = self.this_token_to_string();
-                self.fatal(format!("expected `self` but found `{}`",
+                self.fatal(format!("expected `self`, found `{}`",
                                    token_str).as_slice())
             }
         }
@@ -4455,7 +4455,7 @@ impl<'a> Parser<'a> {
         } else {
             let token_str = self.this_token_to_string();
             self.fatal(format!("expected `{}`, `(`, or `;` after struct \
-                                name but found `{}`", "{",
+                                name, found `{}`", "{",
                                token_str).as_slice())
         }
 
@@ -4486,7 +4486,7 @@ impl<'a> Parser<'a> {
                 let span = self.span;
                 let token_str = self.this_token_to_string();
                 self.span_fatal(span,
-                                format!("expected `,`, or `}}` but found `{}`",
+                                format!("expected `,`, or `}}`, found `{}`",
                                         token_str).as_slice())
             }
         }
@@ -4566,7 +4566,7 @@ impl<'a> Parser<'a> {
               }
               _ => {
                   let token_str = self.this_token_to_string();
-                  self.fatal(format!("expected item but found `{}`",
+                  self.fatal(format!("expected item, found `{}`",
                                      token_str).as_slice())
               }
             }
@@ -5107,7 +5107,7 @@ impl<'a> Parser<'a> {
             let span = self.span;
             let token_str = self.this_token_to_string();
             self.span_fatal(span,
-                            format!("expected `{}` or `fn` but found `{}`", "{",
+                            format!("expected `{}` or `fn`, found `{}`", "{",
                                     token_str).as_slice());
         }
 

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -184,7 +184,7 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
     // Check magic number
     let magic = try!(file.read_le_u16());
     if magic != 0x011A {
-        return Err(format!("invalid magic number: expected {:x} but found {:x}",
+        return Err(format!("invalid magic number: expected {:x}, found {:x}",
                            0x011Au, magic as uint));
     }
 

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -29,7 +29,7 @@ pub fn main() {
     unsafe {
         // comma in place of a colon
         asm!("add $2, $1; mov $1, $0" : "=r"(x) : "r"(x), "r"(8u) : "cc", "volatile");
-        //~^ WARNING expected a clobber, but found an option
+        //~^ WARNING expected a clobber, found an option
     }
     assert_eq!(x, 13);
 }

--- a/src/test/compile-fail/bad-bang-ann-3.rs
+++ b/src/test/compile-fail/bad-bang-ann-3.rs
@@ -12,7 +12,7 @@
 
 fn bad_bang(i: uint) -> ! {
     return 7u;
-    //~^ ERROR expected `!` but found `uint`
+    //~^ ERROR expected `!`, found `uint`
 }
 
 fn main() { bad_bang(5u); }

--- a/src/test/compile-fail/bad-bang-ann.rs
+++ b/src/test/compile-fail/bad-bang-ann.rs
@@ -12,7 +12,7 @@
 
 fn bad_bang(i: uint) -> ! {
     if i < 0u { } else { fail!(); }
-    //~^ ERROR expected `!` but found `()`
+    //~^ ERROR expected `!`, found `()`
 }
 
 fn main() { bad_bang(5u); }

--- a/src/test/compile-fail/bad-const-type.rs
+++ b/src/test/compile-fail/bad-const-type.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected `collections::string::String` but found `int`
+// error-pattern:expected `collections::string::String`, found `int`
 
 static i: String = 10i;
 fn main() { println!("{}", i); }

--- a/src/test/compile-fail/bang-tailexpr.rs
+++ b/src/test/compile-fail/bang-tailexpr.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn f() -> ! {
-    3i //~ ERROR expected `!` but found `int`
+    3i //~ ERROR expected `!`, found `int`
 }
 fn main() { }

--- a/src/test/compile-fail/block-must-not-have-result-do.rs
+++ b/src/test/compile-fail/block-must-not-have-result-do.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()` but found `bool`
+// error-pattern:mismatched types: expected `()`, found `bool`
 
 fn main() {
     loop {

--- a/src/test/compile-fail/block-must-not-have-result-res.rs
+++ b/src/test/compile-fail/block-must-not-have-result-res.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()` but found `bool`
+// error-pattern:mismatched types: expected `()`, found `bool`
 
 struct r;
 

--- a/src/test/compile-fail/block-must-not-have-result-while.rs
+++ b/src/test/compile-fail/block-must-not-have-result-while.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()` but found `bool`
+// error-pattern:mismatched types: expected `()`, found `bool`
 
 fn main() {
     while true {

--- a/src/test/compile-fail/closure-bounds-subtype.rs
+++ b/src/test/compile-fail/closure-bounds-subtype.rs
@@ -21,7 +21,7 @@ fn give_any(f: ||:) {
 
 fn give_owned(f: ||:Send) {
     take_any(f);
-    take_const_owned(f); //~ ERROR expected bounds `Send+Sync` but found bounds `Send`
+    take_const_owned(f); //~ ERROR expected bounds `Send+Sync`, found bounds `Send`
 }
 
 fn main() {}

--- a/src/test/compile-fail/column-offset-1-based.rs
+++ b/src/test/compile-fail/column-offset-1-based.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-# //~ ERROR 11:1: 11:2 error: expected `[` but found `<eof>`
+# //~ ERROR 11:1: 11:2 error: expected `[`, found `<eof>`

--- a/src/test/compile-fail/empty-impl-semicolon.rs
+++ b/src/test/compile-fail/empty-impl-semicolon.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-impl Foo; //~ ERROR expected `{` but found `;`
+impl Foo; //~ ERROR expected `{`, found `;`

--- a/src/test/compile-fail/explicit-self-lifetime-mismatch.rs
+++ b/src/test/compile-fail/explicit-self-lifetime-mismatch.rs
@@ -16,10 +16,10 @@ struct Foo<'a,'b> {
 impl<'a,'b> Foo<'a,'b> {
     // The number of errors is related to the way invariance works.
     fn bar(self: Foo<'b,'a>) {}
-    //~^ ERROR mismatched types: expected `Foo<'a,'b>` but found `Foo<'b,'a>`
-    //~^^ ERROR mismatched types: expected `Foo<'a,'b>` but found `Foo<'b,'a>`
-    //~^^^ ERROR mismatched types: expected `Foo<'b,'a>` but found `Foo<'a,'b>`
-    //~^^^^ ERROR mismatched types: expected `Foo<'b,'a>` but found `Foo<'a,'b>`
+    //~^ ERROR mismatched types: expected `Foo<'a,'b>`, found `Foo<'b,'a>`
+    //~^^ ERROR mismatched types: expected `Foo<'a,'b>`, found `Foo<'b,'a>`
+    //~^^^ ERROR mismatched types: expected `Foo<'b,'a>`, found `Foo<'a,'b>`
+    //~^^^^ ERROR mismatched types: expected `Foo<'b,'a>`, found `Foo<'a,'b>`
 }
 
 fn main() {}

--- a/src/test/compile-fail/extern-expected-fn-or-brace.rs
+++ b/src/test/compile-fail/extern-expected-fn-or-brace.rs
@@ -11,4 +11,4 @@
 // Verifies that the expected token errors for `extern crate` are
 // raised
 
-extern "C" mod foo; //~ERROR expected `{` or `fn` but found `mod`
+extern "C" mod foo; //~ERROR expected `{` or `fn`, found `mod`

--- a/src/test/compile-fail/extern-foreign-crate.rs
+++ b/src/test/compile-fail/extern-foreign-crate.rs
@@ -11,4 +11,4 @@
 // Verifies that the expected token errors for `extern crate` are
 // raised
 
-extern crate foo {} //~ERROR expected one of `=`, `;` but found `{`
+extern crate foo {} //~ERROR expected one of `=`, `;`, found `{`

--- a/src/test/compile-fail/fully-qualified-type-name2.rs
+++ b/src/test/compile-fail/fully-qualified-type-name2.rs
@@ -20,7 +20,7 @@ mod y {
 
 fn bar(x: x::foo) -> y::foo {
     return x;
-    //~^ ERROR mismatched types: expected `y::foo` but found `x::foo`
+    //~^ ERROR mismatched types: expected `y::foo`, found `x::foo`
 }
 
 fn main() {

--- a/src/test/compile-fail/fully-qualified-type-name3.rs
+++ b/src/test/compile-fail/fully-qualified-type-name3.rs
@@ -17,7 +17,7 @@ type T2 = int;
 
 fn bar(x: T1) -> T2 {
     return x;
-    //~^ ERROR mismatched types: expected `T2` but found `T1`
+    //~^ ERROR mismatched types: expected `T2`, found `T1`
 }
 
 fn main() {

--- a/src/test/compile-fail/generic-type-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-less-params-with-defaults.rs
@@ -15,5 +15,5 @@ struct Heap;
 struct Vec<T, A = Heap>;
 
 fn main() {
-    let _: Vec; //~ ERROR wrong number of type arguments: expected at least 1 but found 0
+    let _: Vec; //~ ERROR wrong number of type arguments: expected at least 1, found 0
 }

--- a/src/test/compile-fail/generic-type-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-more-params-with-defaults.rs
@@ -16,5 +16,5 @@ struct Vec<T, A = Heap>;
 
 fn main() {
     let _: Vec<int, Heap, bool>;
-    //~^ ERROR wrong number of type arguments: expected at most 2 but found 3
+    //~^ ERROR wrong number of type arguments: expected at most 2, found 3
 }

--- a/src/test/compile-fail/generic-type-params-name-repr.rs
+++ b/src/test/compile-fail/generic-type-params-name-repr.rs
@@ -21,23 +21,23 @@ struct HashMap<K, V, H = Hash<K>>;
 fn main() {
     // Ensure that the printed type doesn't include the default type params...
     let _: Foo<int> = ();
-    //~^ ERROR mismatched types: expected `Foo<int>` but found `()`
+    //~^ ERROR mismatched types: expected `Foo<int>`, found `()`
 
     // ...even when they're present, but the same types as the defaults.
     let _: Foo<int, B, C> = ();
-    //~^ ERROR mismatched types: expected `Foo<int>` but found `()`
+    //~^ ERROR mismatched types: expected `Foo<int>`, found `()`
 
     // Including cases where the default is using previous type params.
     let _: HashMap<String, int> = ();
-    //~^ ERROR mismatched types: expected `HashMap<collections::string::String,int>` but found `()`
+    //~^ ERROR mismatched types: expected `HashMap<collections::string::String,int>`, found `()`
     let _: HashMap<String, int, Hash<String>> = ();
-    //~^ ERROR mismatched types: expected `HashMap<collections::string::String,int>` but found `()`
+    //~^ ERROR mismatched types: expected `HashMap<collections::string::String,int>`, found `()`
 
     // But not when there's a different type in between.
     let _: Foo<A, int, C> = ();
-    //~^ ERROR mismatched types: expected `Foo<A,int>` but found `()`
+    //~^ ERROR mismatched types: expected `Foo<A,int>`, found `()`
 
     // And don't print <> at all when there's just defaults.
     let _: Foo<A, B, C> = ();
-    //~^ ERROR mismatched types: expected `Foo` but found `()`
+    //~^ ERROR mismatched types: expected `Foo`, found `()`
 }

--- a/src/test/compile-fail/if-branch-types.rs
+++ b/src/test/compile-fail/if-branch-types.rs
@@ -10,5 +10,5 @@
 
 fn main() {
     let x = if true { 10i } else { 10u };
-    //~^ ERROR if and else have incompatible types: expected `int` but found `uint`
+    //~^ ERROR if and else have incompatible types: expected `int`, found `uint`
 }

--- a/src/test/compile-fail/if-without-else-result.rs
+++ b/src/test/compile-fail/if-without-else-result.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()` but found `bool`
+// error-pattern:mismatched types: expected `()`, found `bool`
 
 extern crate debug;
 

--- a/src/test/compile-fail/inherit-struct4.rs
+++ b/src/test/compile-fail/inherit-struct4.rs
@@ -12,7 +12,7 @@
 #![feature(struct_inherit)]
 
 // With lifetime parameters.
-struct S5<'a> : S4 { //~ ERROR wrong number of lifetime parameters: expected 1 but found 0
+struct S5<'a> : S4 { //~ ERROR wrong number of lifetime parameters: expected 1, found 0
     f4: int,
 }
 

--- a/src/test/compile-fail/integer-literal-suffix-inference.rs
+++ b/src/test/compile-fail/integer-literal-suffix-inference.rs
@@ -39,62 +39,62 @@ fn main() {
     fn id_u64(n: u64) -> u64 { n }
 
     id_i8(a8); // ok
-    id_i8(a16); //~ ERROR mismatched types: expected `i8` but found `i16`
-    id_i8(a32); //~ ERROR mismatched types: expected `i8` but found `i32`
-    id_i8(a64); //~ ERROR mismatched types: expected `i8` but found `i64`
+    id_i8(a16); //~ ERROR mismatched types: expected `i8`, found `i16`
+    id_i8(a32); //~ ERROR mismatched types: expected `i8`, found `i32`
+    id_i8(a64); //~ ERROR mismatched types: expected `i8`, found `i64`
 
-    id_i16(a8); //~ ERROR mismatched types: expected `i16` but found `i8`
+    id_i16(a8); //~ ERROR mismatched types: expected `i16`, found `i8`
     id_i16(a16); // ok
-    id_i16(a32); //~ ERROR mismatched types: expected `i16` but found `i32`
-    id_i16(a64); //~ ERROR mismatched types: expected `i16` but found `i64`
+    id_i16(a32); //~ ERROR mismatched types: expected `i16`, found `i32`
+    id_i16(a64); //~ ERROR mismatched types: expected `i16`, found `i64`
 
-    id_i32(a8); //~ ERROR mismatched types: expected `i32` but found `i8`
-    id_i32(a16); //~ ERROR mismatched types: expected `i32` but found `i16`
+    id_i32(a8); //~ ERROR mismatched types: expected `i32`, found `i8`
+    id_i32(a16); //~ ERROR mismatched types: expected `i32`, found `i16`
     id_i32(a32); // ok
-    id_i32(a64); //~ ERROR mismatched types: expected `i32` but found `i64`
+    id_i32(a64); //~ ERROR mismatched types: expected `i32`, found `i64`
 
-    id_i64(a8); //~ ERROR mismatched types: expected `i64` but found `i8`
-    id_i64(a16); //~ ERROR mismatched types: expected `i64` but found `i16`
-    id_i64(a32); //~ ERROR mismatched types: expected `i64` but found `i32`
+    id_i64(a8); //~ ERROR mismatched types: expected `i64`, found `i8`
+    id_i64(a16); //~ ERROR mismatched types: expected `i64`, found `i16`
+    id_i64(a32); //~ ERROR mismatched types: expected `i64`, found `i32`
     id_i64(a64); // ok
 
     id_i8(c8); // ok
-    id_i8(c16); //~ ERROR mismatched types: expected `i8` but found `i16`
-    id_i8(c32); //~ ERROR mismatched types: expected `i8` but found `i32`
-    id_i8(c64); //~ ERROR mismatched types: expected `i8` but found `i64`
+    id_i8(c16); //~ ERROR mismatched types: expected `i8`, found `i16`
+    id_i8(c32); //~ ERROR mismatched types: expected `i8`, found `i32`
+    id_i8(c64); //~ ERROR mismatched types: expected `i8`, found `i64`
 
-    id_i16(c8); //~ ERROR mismatched types: expected `i16` but found `i8`
+    id_i16(c8); //~ ERROR mismatched types: expected `i16`, found `i8`
     id_i16(c16); // ok
-    id_i16(c32); //~ ERROR mismatched types: expected `i16` but found `i32`
-    id_i16(c64); //~ ERROR mismatched types: expected `i16` but found `i64`
+    id_i16(c32); //~ ERROR mismatched types: expected `i16`, found `i32`
+    id_i16(c64); //~ ERROR mismatched types: expected `i16`, found `i64`
 
-    id_i32(c8); //~ ERROR mismatched types: expected `i32` but found `i8`
-    id_i32(c16); //~ ERROR mismatched types: expected `i32` but found `i16`
+    id_i32(c8); //~ ERROR mismatched types: expected `i32`, found `i8`
+    id_i32(c16); //~ ERROR mismatched types: expected `i32`, found `i16`
     id_i32(c32); // ok
-    id_i32(c64); //~ ERROR mismatched types: expected `i32` but found `i64`
+    id_i32(c64); //~ ERROR mismatched types: expected `i32`, found `i64`
 
-    id_i64(a8); //~ ERROR mismatched types: expected `i64` but found `i8`
-    id_i64(a16); //~ ERROR mismatched types: expected `i64` but found `i16`
-    id_i64(a32); //~ ERROR mismatched types: expected `i64` but found `i32`
+    id_i64(a8); //~ ERROR mismatched types: expected `i64`, found `i8`
+    id_i64(a16); //~ ERROR mismatched types: expected `i64`, found `i16`
+    id_i64(a32); //~ ERROR mismatched types: expected `i64`, found `i32`
     id_i64(a64); // ok
 
     id_u8(b8); // ok
-    id_u8(b16); //~ ERROR mismatched types: expected `u8` but found `u16`
-    id_u8(b32); //~ ERROR mismatched types: expected `u8` but found `u32`
-    id_u8(b64); //~ ERROR mismatched types: expected `u8` but found `u64`
+    id_u8(b16); //~ ERROR mismatched types: expected `u8`, found `u16`
+    id_u8(b32); //~ ERROR mismatched types: expected `u8`, found `u32`
+    id_u8(b64); //~ ERROR mismatched types: expected `u8`, found `u64`
 
-    id_u16(b8); //~ ERROR mismatched types: expected `u16` but found `u8`
+    id_u16(b8); //~ ERROR mismatched types: expected `u16`, found `u8`
     id_u16(b16); // ok
-    id_u16(b32); //~ ERROR mismatched types: expected `u16` but found `u32`
-    id_u16(b64); //~ ERROR mismatched types: expected `u16` but found `u64`
+    id_u16(b32); //~ ERROR mismatched types: expected `u16`, found `u32`
+    id_u16(b64); //~ ERROR mismatched types: expected `u16`, found `u64`
 
-    id_u32(b8); //~ ERROR mismatched types: expected `u32` but found `u8`
-    id_u32(b16); //~ ERROR mismatched types: expected `u32` but found `u16`
+    id_u32(b8); //~ ERROR mismatched types: expected `u32`, found `u8`
+    id_u32(b16); //~ ERROR mismatched types: expected `u32`, found `u16`
     id_u32(b32); // ok
-    id_u32(b64); //~ ERROR mismatched types: expected `u32` but found `u64`
+    id_u32(b64); //~ ERROR mismatched types: expected `u32`, found `u64`
 
-    id_u64(b8); //~ ERROR mismatched types: expected `u64` but found `u8`
-    id_u64(b16); //~ ERROR mismatched types: expected `u64` but found `u16`
-    id_u64(b32); //~ ERROR mismatched types: expected `u64` but found `u32`
+    id_u64(b8); //~ ERROR mismatched types: expected `u64`, found `u8`
+    id_u64(b16); //~ ERROR mismatched types: expected `u64`, found `u16`
+    id_u64(b32); //~ ERROR mismatched types: expected `u64`, found `u32`
     id_u64(b64); // ok
 }

--- a/src/test/compile-fail/issue-10764.rs
+++ b/src/test/compile-fail/issue-10764.rs
@@ -12,4 +12,4 @@ fn f(_: extern "Rust" fn()) {}
 extern fn bar() {}
 
 fn main() { f(bar) }
-//~^ ERROR: expected `fn()` but found `extern "C" fn()`
+//~^ ERROR: expected `fn()`, found `extern "C" fn()`

--- a/src/test/compile-fail/issue-11319.rs
+++ b/src/test/compile-fail/issue-11319.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     match Some(10) {
-    //~^ ERROR match arms have incompatible types: expected `bool` but found `()`
+    //~^ ERROR match arms have incompatible types: expected `bool`, found `()`
         Some(5) => false,
         Some(2) => true,
         None    => (), //~ NOTE match arm with an incompatible type

--- a/src/test/compile-fail/issue-11515.rs
+++ b/src/test/compile-fail/issue-11515.rs
@@ -14,5 +14,5 @@ struct Test<'s> {
 
 fn main() {
     let test = box Test { func: proc() {} };
-    //~^ ERROR: expected `||` but found `proc()`
+    //~^ ERROR: expected `||`, found `proc()`
 }

--- a/src/test/compile-fail/issue-12997-2.rs
+++ b/src/test/compile-fail/issue-12997-2.rs
@@ -12,6 +12,6 @@
 
 //! Test that makes sure wrongly-typed bench functions are rejected
 
-// error-pattern:expected &-ptr but found int
+// error-pattern:expected &-ptr, found int
 #[bench]
 fn bar(x: int) { }

--- a/src/test/compile-fail/issue-13482.rs
+++ b/src/test/compile-fail/issue-13482.rs
@@ -12,7 +12,7 @@ fn main() {
   let x = [1,2];
   let y = match x {
     [] => None,
-//~^ ERROR expected `[<generic integer #1>, .. 2]` but found a fixed vector pattern of size 0
+//~^ ERROR expected `[<generic integer #1>, .. 2]`, found a fixed vector pattern of size 0
     [a,_] => Some(a)
   };
 }

--- a/src/test/compile-fail/issue-13599.rs
+++ b/src/test/compile-fail/issue-13599.rs
@@ -16,8 +16,8 @@ fn expect_proc(_: proc()) {}
 
 fn main() {
     expect_closure(proc() {});
-    //~^ ERROR mismatched types: expected `||` but found `proc()` (expected closure, found proc)
+    //~^ ERROR mismatched types: expected `||`, found `proc()` (expected closure, found proc)
 
     expect_proc(|| {});
-    //~^ ERROR mismatched types: expected `proc()` but found `||` (expected proc, found closure)
+    //~^ ERROR mismatched types: expected `proc()`, found `||` (expected proc, found closure)
 }

--- a/src/test/compile-fail/issue-14845.rs
+++ b/src/test/compile-fail/issue-14845.rs
@@ -16,9 +16,9 @@ struct X {
 fn main() {
     let x = X { a: [0] };
     let _f = &x.a as *mut u8;
-    //~^ ERROR mismatched types: expected `*mut u8` but found `&[u8, .. 1]`
+    //~^ ERROR mismatched types: expected `*mut u8`, found `&[u8, .. 1]`
 
     let local = [0u8];
     let _v = &local as *mut u8;
-    //~^ ERROR mismatched types: expected `*mut u8` but found `&[u8, .. 1]`
+    //~^ ERROR mismatched types: expected `*mut u8`, found `&[u8, .. 1]`
 }

--- a/src/test/compile-fail/issue-15094.rs
+++ b/src/test/compile-fail/issue-15094.rs
@@ -18,7 +18,7 @@ struct Shower<T> {
 
 impl<T: fmt::Show> ops::Fn<(), ()> for Shower<T> {
     fn call(&self, _args: ()) {
-//~^ ERROR `call` has an incompatible type for trait: expected "rust-call" fn but found "Rust" fn
+//~^ ERROR `call` has an incompatible type for trait: expected "rust-call" fn, found "Rust" fn
         println!("{}", self.x);
     }
 }

--- a/src/test/compile-fail/issue-16338.rs
+++ b/src/test/compile-fail/issue-16338.rs
@@ -12,6 +12,6 @@ use std::raw::Slice;
 
 fn main() {
     let Slice { data: data, len: len } = "foo";
-    //~^ ERROR mismatched types: expected `&'static str` but found a structure pattern
+    //~^ ERROR mismatched types: expected `&'static str`, found a structure pattern
 }
 

--- a/src/test/compile-fail/issue-16401.rs
+++ b/src/test/compile-fail/issue-16401.rs
@@ -13,7 +13,7 @@ use std::raw::Slice;
 fn main() {
     match () {
         Slice { data: data, len: len } => (),
-        //~^ ERROR mismatched types: expected `()` but found a structure pattern
+        //~^ ERROR mismatched types: expected `()`, found a structure pattern
         _ => unreachable!()
     }
 }

--- a/src/test/compile-fail/issue-1655.rs
+++ b/src/test/compile-fail/issue-1655.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected `[` but found `vec`
+// error-pattern:expected `[`, found `vec`
 mod blade_runner {
     #vec[doc(
         brief = "Blade Runner is probably the best movie ever",

--- a/src/test/compile-fail/issue-2951.rs
+++ b/src/test/compile-fail/issue-2951.rs
@@ -10,7 +10,7 @@
 
 fn foo<T, U>(x: T, y: U) {
     let mut xx = x;
-    xx = y; //~ ERROR expected `T` but found `U`
+    xx = y; //~ ERROR expected `T`, found `U`
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-3036.rs
+++ b/src/test/compile-fail/issue-3036.rs
@@ -13,4 +13,4 @@
 fn main()
 {
     let x = 3
-} //~ ERROR: expected `;` but found `}`
+} //~ ERROR: expected `;`, found `}`

--- a/src/test/compile-fail/issue-3477.rs
+++ b/src/test/compile-fail/issue-3477.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let _p: char = 100; //~ ERROR mismatched types: expected `char` but found
+    let _p: char = 100; //~ ERROR mismatched types: expected `char`, found
 }

--- a/src/test/compile-fail/issue-3680.rs
+++ b/src/test/compile-fail/issue-3680.rs
@@ -12,6 +12,6 @@ fn main() {
     match None {
         Err(_) => ()
         //~^ ERROR mismatched types: expected `core::option::Option<<generic #1>>`
-        //         but found `core::result::Result<<generic #2>,<generic #3>>`
+        //         , found `core::result::Result<<generic #2>,<generic #3>>`
     }
 }

--- a/src/test/compile-fail/issue-4517.rs
+++ b/src/test/compile-fail/issue-4517.rs
@@ -13,6 +13,6 @@ fn bar(int_param: int) {}
 fn main() {
     let foo: [u8, ..4] = [1u8, ..4u];
     bar(foo);
-    //~^ ERROR mismatched types: expected `int` but found `[u8, .. 4]`
-    //         (expected int but found vector)
+    //~^ ERROR mismatched types: expected `int`, found `[u8, .. 4]`
+    //         (expected int, found vector)
 }

--- a/src/test/compile-fail/issue-4968.rs
+++ b/src/test/compile-fail/issue-4968.rs
@@ -13,6 +13,6 @@
 static A: (int,int) = (4,2);
 fn main() {
     match 42 { A => () }
-    //~^ ERROR mismatched types: expected `<generic integer #0>` but found `(int,int)`
-    //         (expected integral variable but found tuple)
+    //~^ ERROR mismatched types: expected `<generic integer #0>`, found `(int,int)`
+    //         (expected integral variable, found tuple)
 }

--- a/src/test/compile-fail/issue-5100.rs
+++ b/src/test/compile-fail/issue-5100.rs
@@ -12,33 +12,33 @@ enum A { B, C }
 
 fn main() {
     match (true, false) {
-        B => (), //~ ERROR expected `(bool,bool)` but found an enum or structure pattern
+        B => (), //~ ERROR expected `(bool,bool)`, found an enum or structure pattern
         _ => ()
     }
 
     match (true, false) {
         (true, false, false) => ()
-        //~^ ERROR mismatched types: expected `(bool,bool)` but found tuple
-        //         (expected a tuple with 2 elements but found one with 3 elements)
+        //~^ ERROR mismatched types: expected `(bool,bool)`, found tuple
+        //         (expected a tuple with 2 elements, found one with 3 elements)
     }
 
     match (true, false) {
         box (true, false) => ()
-        //~^ ERROR mismatched types: expected `(bool,bool)` but found a box pattern
+        //~^ ERROR mismatched types: expected `(bool,bool)`, found a box pattern
     }
 
     match (true, false) {
         &(true, false) => ()
-        //~^ ERROR mismatched types: expected `(bool,bool)` but found an `&`-pointer pattern
+        //~^ ERROR mismatched types: expected `(bool,bool)`, found an `&`-pointer pattern
     }
 
 
-    let v = [('a', 'b')   //~ ERROR expected function but found `(char,char)`
+    let v = [('a', 'b')   //~ ERROR expected function, found `(char,char)`
              ('c', 'd'),
              ('e', 'f')];
 
     for &(x,y) in v.iter() {} // should be OK
 
     // Make sure none of the errors above were fatal
-    let x: char = true; //~ ERROR expected `char` but found `bool`
+    let x: char = true; //~ ERROR expected `char`, found `bool`
 }

--- a/src/test/compile-fail/issue-5358-1.rs
+++ b/src/test/compile-fail/issue-5358-1.rs
@@ -13,7 +13,7 @@ struct S(Either<uint, uint>);
 
 fn main() {
     match S(Left(5)) {
-        Right(_) => {}  //~ ERROR mismatched types: expected `S` but found `Either
+        Right(_) => {}  //~ ERROR mismatched types: expected `S`, found `Either
         _ => {}
     }
 }

--- a/src/test/compile-fail/issue-6610.rs
+++ b/src/test/compile-fail/issue-6610.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-trait Foo { fn a() } //~ ERROR expected `;` or `{` but found `}`
+trait Foo { fn a() } //~ ERROR expected `;` or `{`, found `}`
 
 fn main() {}

--- a/src/test/compile-fail/issue-7061.rs
+++ b/src/test/compile-fail/issue-7061.rs
@@ -15,7 +15,7 @@ struct BarStruct;
 
 impl<'a> BarStruct {
     fn foo(&'a mut self) -> Gc<BarStruct> { self }
-    //~^ ERROR: error: mismatched types: expected `Gc<BarStruct>` but found `&'a mut BarStruct
+    //~^ ERROR: error: mismatched types: expected `Gc<BarStruct>`, found `&'a mut BarStruct
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-7092.rs
+++ b/src/test/compile-fail/issue-7092.rs
@@ -14,7 +14,7 @@ enum Whatever {
 fn foo(x: Whatever) {
     match x {
         Some(field) => field.access(),
-        //~^ ERROR: mismatched types: expected `Whatever` but found
+        //~^ ERROR: mismatched types: expected `Whatever`, found
     }
 }
 

--- a/src/test/compile-fail/issue-8761.rs
+++ b/src/test/compile-fail/issue-8761.rs
@@ -10,9 +10,9 @@
 
 enum Foo {
     A = 1i64,
-    //~^ ERROR mismatched types: expected `int` but found `i64`
+    //~^ ERROR mismatched types: expected `int`, found `i64`
     B = 2u8
-    //~^ ERROR mismatched types: expected `int` but found `u8`
+    //~^ ERROR mismatched types: expected `int`, found `u8`
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue13359.rs
+++ b/src/test/compile-fail/issue13359.rs
@@ -14,8 +14,8 @@ fn bar(_s: u32) { }
 
 fn main() {
     foo(1*(1 as int));
-    //~^ ERROR: mismatched types: expected `i16` but found `int` (expected `i16` but found `int`)
+    //~^ ERROR: mismatched types: expected `i16`, found `int` (expected `i16`, found `int`)
 
     bar(1*(1 as uint));
-    //~^ ERROR: mismatched types: expected `u32` but found `uint` (expected `u32` but found `uint`)
+    //~^ ERROR: mismatched types: expected `u32`, found `uint` (expected `u32`, found `uint`)
 }

--- a/src/test/compile-fail/loop-does-not-diverge.rs
+++ b/src/test/compile-fail/loop-does-not-diverge.rs
@@ -14,7 +14,7 @@ fn forever() -> ! {
   loop {
     break;
   }
-  return 42i; //~ ERROR expected `!` but found `int`
+  return 42i; //~ ERROR expected `!`, found `int`
 }
 
 fn main() {

--- a/src/test/compile-fail/macro-bad-delimiter-ident.rs
+++ b/src/test/compile-fail/macro-bad-delimiter-ident.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    foo! bar < //~ ERROR expected `(` or `{`, but found `<`
+    foo! bar < //~ ERROR expected `(` or `{`, found `<`
 }

--- a/src/test/compile-fail/match-struct.rs
+++ b/src/test/compile-fail/match-struct.rs
@@ -14,7 +14,7 @@ enum E { C(int) }
 
 fn main() {
     match (S { a: 1 }) {
-        C(_) => (), //~ ERROR mismatched types: expected `S` but found `E`
+        C(_) => (), //~ ERROR mismatched types: expected `S`, found `E`
         _ => ()
     }
 }

--- a/src/test/compile-fail/match-vec-mismatch-2.rs
+++ b/src/test/compile-fail/match-vec-mismatch-2.rs
@@ -10,6 +10,6 @@
 
 fn main() {
     match () {
-        [()] => { } //~ ERROR mismatched types: expected `()` but found a vector pattern
+        [()] => { } //~ ERROR mismatched types: expected `()`, found a vector pattern
     }
 }

--- a/src/test/compile-fail/multitrait.rs
+++ b/src/test/compile-fail/multitrait.rs
@@ -12,7 +12,7 @@ struct S {
  y: int
 }
 
-impl Cmp, ToString for S { //~ ERROR: expected `{` but found `,`
+impl Cmp, ToString for S { //~ ERROR: expected `{`, found `,`
   fn eq(&&other: S) { false }
   fn to_string(&self) -> String { "hi".to_string() }
 }

--- a/src/test/compile-fail/mut-patterns.rs
+++ b/src/test/compile-fail/mut-patterns.rs
@@ -12,5 +12,5 @@
 
 pub fn main() {
     struct Foo { x: int }
-    let mut Foo { x: x } = Foo { x: 3 }; //~ ERROR: expected `;` but found `{`
+    let mut Foo { x: x } = Foo { x: 3 }; //~ ERROR: expected `;`, found `{`
 }

--- a/src/test/compile-fail/noexporttypeexe.rs
+++ b/src/test/compile-fail/noexporttypeexe.rs
@@ -18,5 +18,5 @@ fn main() {
     // because the def_id associated with the type was
     // not convertible to a path.
   let x: int = noexporttypelib::foo();
-    //~^ ERROR expected `int` but found `core::option::Option<int>`
+    //~^ ERROR expected `int`, found `core::option::Option<int>`
 }

--- a/src/test/compile-fail/non-constant-enum-for-vec-repeat.rs
+++ b/src/test/compile-fail/non-constant-enum-for-vec-repeat.rs
@@ -12,5 +12,5 @@ enum State { ST_NULL, ST_WHITESPACE }
 
 fn main() {
     [ST_NULL, ..(ST_WHITESPACE as uint)];
-    //~^ ERROR expected constant integer for repeat count but found variable
+    //~^ ERROR expected constant integer for repeat count, found variable
 }

--- a/src/test/compile-fail/non-constant-expr-for-vec-repeat.rs
+++ b/src/test/compile-fail/non-constant-expr-for-vec-repeat.rs
@@ -12,6 +12,6 @@
 
 fn main() {
     fn bar(n: uint) {
-        let _x = [0, ..n]; //~ ERROR expected constant integer for repeat count but found variable
+        let _x = [0, ..n]; //~ ERROR expected constant integer for repeat count, found variable
     }
 }

--- a/src/test/compile-fail/omitted-arg-in-item-fn.rs
+++ b/src/test/compile-fail/omitted-arg-in-item-fn.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo(x) { //~ ERROR expected `:` but found `)`
+fn foo(x) { //~ ERROR expected `:`, found `)`
 }

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -29,9 +29,9 @@ fn main() {
         _ => ()
     }
     match 'c' {
-        S { .. } => (),   //~ ERROR mismatched types: expected `char` but found a structure pattern
+        S { .. } => (),   //~ ERROR mismatched types: expected `char`, found a structure pattern
 
         _ => ()
     }
-    f(true);            //~ ERROR mismatched types: expected `char` but found `bool`
+    f(true);            //~ ERROR mismatched types: expected `char`, found `bool`
 }

--- a/src/test/compile-fail/pptypedef.rs
+++ b/src/test/compile-fail/pptypedef.rs
@@ -12,8 +12,8 @@ fn let_in<T>(x: T, f: |T|) {}
 
 fn main() {
     let_in(3u, |i| { assert!(i == 3i); });
-    //~^ ERROR expected `uint` but found `int`
+    //~^ ERROR expected `uint`, found `int`
 
     let_in(3i, |i| { assert!(i == 3u); });
-    //~^ ERROR expected `int` but found `uint`
+    //~^ ERROR expected `int`, found `uint`
 }

--- a/src/test/compile-fail/raw-str-unbalanced.rs
+++ b/src/test/compile-fail/raw-str-unbalanced.rs
@@ -10,5 +10,5 @@
 
 static s: &'static str =
     r#"
-      "## //~ ERROR expected `;` but found `#`
+      "## //~ ERROR expected `;`, found `#`
 ;

--- a/src/test/compile-fail/regions-bounds.rs
+++ b/src/test/compile-fail/regions-bounds.rs
@@ -16,12 +16,12 @@ struct an_enum<'a>(&'a int);
 struct a_class<'a> { x:&'a int }
 
 fn a_fn1<'a,'b>(e: an_enum<'a>) -> an_enum<'b> {
-    return e; //~ ERROR mismatched types: expected `an_enum<'b>` but found `an_enum<'a>`
+    return e; //~ ERROR mismatched types: expected `an_enum<'b>`, found `an_enum<'a>`
     //~^ ERROR cannot infer
 }
 
 fn a_fn3<'a,'b>(e: a_class<'a>) -> a_class<'b> {
-    return e; //~ ERROR mismatched types: expected `a_class<'b>` but found `a_class<'a>`
+    return e; //~ ERROR mismatched types: expected `a_class<'b>`, found `a_class<'a>`
     //~^ ERROR cannot infer
 }
 

--- a/src/test/compile-fail/regions-infer-paramd-indirect.rs
+++ b/src/test/compile-fail/regions-infer-paramd-indirect.rs
@@ -32,7 +32,7 @@ impl<'a> set_f<'a> for c<'a> {
     }
 
     fn set_f_bad(&self, b: Gc<b>) {
-        self.f = b; //~ ERROR mismatched types: expected `Gc<Gc<&'a int>>` but found `Gc<Gc<&int>>`
+        self.f = b; //~ ERROR mismatched types: expected `Gc<Gc<&'a int>>`, found `Gc<Gc<&int>>`
         //~^ ERROR cannot infer
     }
 }

--- a/src/test/compile-fail/regions-infer-paramd-method.rs
+++ b/src/test/compile-fail/regions-infer-paramd-method.rs
@@ -40,7 +40,7 @@ trait set_foo_foo {
 
 impl<'a> set_foo_foo for with_foo<'a> {
     fn set_foo(&mut self, f: @foo) {
-        self.f = f; //~ ERROR mismatched types: expected `@foo/&self` but found `@foo/&`
+        self.f = f; //~ ERROR mismatched types: expected `@foo/&self`, found `@foo/&`
     }
 }
 

--- a/src/test/compile-fail/regions-trait-3.rs
+++ b/src/test/compile-fail/regions-trait-3.rs
@@ -26,7 +26,7 @@ trait get_ctxt<'a> {
 }
 
 fn make_gc1(gc: @get_ctxt<'a>) -> @get_ctxt<'b>  {
-    return gc; //~ ERROR mismatched types: expected `@get_ctxt/&b` but found `@get_ctxt/&a`
+    return gc; //~ ERROR mismatched types: expected `@get_ctxt/&b`, found `@get_ctxt/&a`
 }
 
 struct Foo {

--- a/src/test/compile-fail/removed-syntax-closure-lifetime.rs
+++ b/src/test/compile-fail/removed-syntax-closure-lifetime.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type closure = Box<lt/fn()>; //~ ERROR expected `,` but found `/`
+type closure = Box<lt/fn()>; //~ ERROR expected `,`, found `/`

--- a/src/test/compile-fail/removed-syntax-const-item.rs
+++ b/src/test/compile-fail/removed-syntax-const-item.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-const i: int = 42; //~ ERROR expected item but found `const`
+const i: int = 42; //~ ERROR expected item, found `const`

--- a/src/test/compile-fail/removed-syntax-enum-newtype.rs
+++ b/src/test/compile-fail/removed-syntax-enum-newtype.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum e = int; //~ ERROR expected `{` but found `=`
+enum e = int; //~ ERROR expected `{`, found `=`

--- a/src/test/compile-fail/removed-syntax-field-let.rs
+++ b/src/test/compile-fail/removed-syntax-field-let.rs
@@ -11,5 +11,5 @@
 struct s {
     let foo: (),
     //~^  ERROR found `let` in ident position
-    //~^^ ERROR expected `:` but found `foo`
+    //~^^ ERROR expected `:`, found `foo`
 }

--- a/src/test/compile-fail/removed-syntax-field-semicolon.rs
+++ b/src/test/compile-fail/removed-syntax-field-semicolon.rs
@@ -10,5 +10,5 @@
 
 struct s {
     bar: ();
-    //~^ ERROR expected `,`, or `}` but found `;`
+    //~^ ERROR expected `,`, or `}`, found `;`
 }

--- a/src/test/compile-fail/removed-syntax-fixed-vec.rs
+++ b/src/test/compile-fail/removed-syntax-fixed-vec.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type v = [int * 3]; //~ ERROR expected `]` but found `*`
+type v = [int * 3]; //~ ERROR expected `]`, found `*`

--- a/src/test/compile-fail/removed-syntax-fn-pure.rs
+++ b/src/test/compile-fail/removed-syntax-fn-pure.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pure fn f() {} //~ ERROR expected item but found `pure`
+pure fn f() {} //~ ERROR expected item, found `pure`

--- a/src/test/compile-fail/removed-syntax-fn-sigil.rs
+++ b/src/test/compile-fail/removed-syntax-fn-sigil.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn f() {
-    let x: fn~() = || (); //~ ERROR expected `(` but found `~`
+    let x: fn~() = || (); //~ ERROR expected `(`, found `~`
 }

--- a/src/test/compile-fail/removed-syntax-larrow-init.rs
+++ b/src/test/compile-fail/removed-syntax-larrow-init.rs
@@ -11,5 +11,5 @@
 fn removed_moves() {
     let mut x = 0;
     let y <- x;
-    //~^ ERROR expected `;` but found `<-`
+    //~^ ERROR expected `;`, found `<-`
 }

--- a/src/test/compile-fail/removed-syntax-larrow-move.rs
+++ b/src/test/compile-fail/removed-syntax-larrow-move.rs
@@ -12,5 +12,5 @@ fn removed_moves() {
     let mut x = 0;
     let y = 0;
     y <- x;
-    //~^ ERROR expected one of `;`, `}` but found `<-`
+    //~^ ERROR expected one of `;`, `}`, found `<-`
 }

--- a/src/test/compile-fail/removed-syntax-mut-vec-expr.rs
+++ b/src/test/compile-fail/removed-syntax-mut-vec-expr.rs
@@ -11,5 +11,5 @@
 fn f() {
     let v = [mut 1, 2, 3, 4];
     //~^  ERROR found `mut` in ident position
-    //~^^ ERROR expected `]` but found `1`
+    //~^^ ERROR expected `]`, found `1`
 }

--- a/src/test/compile-fail/removed-syntax-mut-vec-ty.rs
+++ b/src/test/compile-fail/removed-syntax-mut-vec-ty.rs
@@ -10,4 +10,4 @@
 
 type v = [mut int];
     //~^  ERROR found `mut` in ident position
-    //~^^ ERROR expected `]` but found `int`
+    //~^^ ERROR expected `]`, found `int`

--- a/src/test/compile-fail/removed-syntax-ptr-lifetime.rs
+++ b/src/test/compile-fail/removed-syntax-ptr-lifetime.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-type bptr = &lifetime/int; //~ ERROR expected `;` but found `/`
+type bptr = &lifetime/int; //~ ERROR expected `;`, found `/`

--- a/src/test/compile-fail/removed-syntax-uniq-mut-expr.rs
+++ b/src/test/compile-fail/removed-syntax-uniq-mut-expr.rs
@@ -11,5 +11,5 @@
 fn f() {
     let a_box = box mut 42;
     //~^  ERROR found `mut` in ident position
-    //~^^ ERROR expected `;` but found `42`
+    //~^^ ERROR expected `;`, found `42`
 }

--- a/src/test/compile-fail/removed-syntax-uniq-mut-ty.rs
+++ b/src/test/compile-fail/removed-syntax-uniq-mut-ty.rs
@@ -10,4 +10,4 @@
 
 type mut_box = Box<mut int>;
     //~^  ERROR found `mut` in ident position
-    //~^^ ERROR expected `,` but found `int`
+    //~^^ ERROR expected `,`, found `int`

--- a/src/test/compile-fail/removed-syntax-with-1.rs
+++ b/src/test/compile-fail/removed-syntax-with-1.rs
@@ -16,5 +16,5 @@ fn removed_with() {
 
     let a = S { foo: (), bar: () };
     let b = S { foo: () with a };
-    //~^ ERROR expected one of `,`, `}` but found `with`
+    //~^ ERROR expected one of `,`, `}`, found `with`
 }

--- a/src/test/compile-fail/removed-syntax-with-2.rs
+++ b/src/test/compile-fail/removed-syntax-with-2.rs
@@ -16,5 +16,5 @@ fn removed_with() {
 
     let a = S { foo: (), bar: () };
     let b = S { foo: (), with a };
-    //~^ ERROR expected `:` but found `a`
+    //~^ ERROR expected `:`, found `a`
 }

--- a/src/test/compile-fail/repeat_count.rs
+++ b/src/test/compile-fail/repeat_count.rs
@@ -12,17 +12,17 @@
 
 fn main() {
     let n = 1;
-    let a = [0, ..n]; //~ ERROR expected constant integer for repeat count but found variable
-    let b = [0, ..()]; //~ ERROR expected positive integer for repeat count but found ()
-    //~^ ERROR: expected `uint` but found `()`
-    let c = [0, ..true]; //~ ERROR expected positive integer for repeat count but found boolean
-    //~^ ERROR: expected `uint` but found `bool`
-    let d = [0, ..0.5]; //~ ERROR expected positive integer for repeat count but found float
-    //~^ ERROR: expected `uint` but found `<generic float #0>`
-    let e = [0, .."foo"]; //~ ERROR expected positive integer for repeat count but found string
-    //~^ ERROR: expected `uint` but found `&'static str`
+    let a = [0, ..n]; //~ ERROR expected constant integer for repeat count, found variable
+    let b = [0, ..()]; //~ ERROR expected positive integer for repeat count, found ()
+    //~^ ERROR: expected `uint`, found `()`
+    let c = [0, ..true]; //~ ERROR expected positive integer for repeat count, found boolean
+    //~^ ERROR: expected `uint`, found `bool`
+    let d = [0, ..0.5]; //~ ERROR expected positive integer for repeat count, found float
+    //~^ ERROR: expected `uint`, found `<generic float #0>`
+    let e = [0, .."foo"]; //~ ERROR expected positive integer for repeat count, found string
+    //~^ ERROR: expected `uint`, found `&'static str`
     let f = [0, ..-4];
-    //~^ ERROR expected positive integer for repeat count but found negative integer
+    //~^ ERROR expected positive integer for repeat count, found negative integer
     let f = [0u, ..-1];
-    //~^ ERROR expected positive integer for repeat count but found negative integer
+    //~^ ERROR expected positive integer for repeat count, found negative integer
 }

--- a/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
+++ b/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
@@ -13,7 +13,7 @@ struct Foo<T,U>(T);
 fn main() {
     match Foo(1.1) {
         1 => {}
-        //~^ ERROR expected `Foo<<generic float #0>,<generic #2>>` but found `<generic integer #0>`
+        //~^ ERROR expected `Foo<<generic float #0>,<generic #2>>`, found `<generic integer #0>`
     }
 
 }

--- a/src/test/compile-fail/struct-base-wrong-type.rs
+++ b/src/test/compile-fail/struct-base-wrong-type.rs
@@ -12,11 +12,11 @@ struct Foo { a: int, b: int }
 struct Bar { x: int }
 
 static bar: Bar = Bar { x: 5 };
-static foo: Foo = Foo { a: 2, ..bar }; //~ ERROR mismatched types: expected `Foo` but found `Bar`
+static foo: Foo = Foo { a: 2, ..bar }; //~ ERROR mismatched types: expected `Foo`, found `Bar`
 static foo_i: Foo = Foo { a: 2, ..4 }; //~ ERROR mismatched types: expected `Foo`
 
 fn main() {
     let b = Bar { x: 5 };
-    let f = Foo { a: 2, ..b }; //~ ERROR mismatched types: expected `Foo` but found `Bar`
+    let f = Foo { a: 2, ..b }; //~ ERROR mismatched types: expected `Foo`, found `Bar`
     let f_i = Foo { a: 2, ..4 }; //~ ERROR mismatched types: expected `Foo`
 }

--- a/src/test/compile-fail/structure-constructor-type-mismatch.rs
+++ b/src/test/compile-fail/structure-constructor-type-mismatch.rs
@@ -24,25 +24,25 @@ type PairF<U> = Pair<f32,U>;
 
 fn main() {
     let pt = PointF {
-        //~^ ERROR expected f32 but found int
+        //~^ ERROR expected f32, found int
         x: 1i,
         y: 2i,
     };
 
     let pt2 = Point::<f32> {
-        //~^ ERROR expected f32 but found int
+        //~^ ERROR expected f32, found int
         x: 3i,
         y: 4i,
     };
 
     let pair = PairF {
-        //~^ ERROR expected f32 but found int
+        //~^ ERROR expected f32, found int
         x: 5i,
         y: 6i,
     };
 
     let pair2 = PairF::<int> {
-        //~^ ERROR expected f32 but found int
+        //~^ ERROR expected f32, found int
         x: 7i,
         y: 8i,
     };

--- a/src/test/compile-fail/suppressed-error.rs
+++ b/src/test/compile-fail/suppressed-error.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    let (x, y) = (); //~ ERROR expected `()` but found tuple (types differ)
+    let (x, y) = (); //~ ERROR expected `()`, found tuple (types differ)
     return x;
 }

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `char` but found
+// error-pattern:mismatched types: expected `char`, found
 // Issue #876
 
 #![no_implicit_prelude]

--- a/src/test/compile-fail/terr-in-field.rs
+++ b/src/test/compile-fail/terr-in-field.rs
@@ -20,7 +20,7 @@ struct bar {
 
 fn want_foo(f: foo) {}
 fn have_bar(b: bar) {
-    want_foo(b); //~ ERROR (expected struct foo but found struct bar)
+    want_foo(b); //~ ERROR (expected struct foo, found struct bar)
 }
 
 fn main() {}

--- a/src/test/compile-fail/terr-sorts.rs
+++ b/src/test/compile-fail/terr-sorts.rs
@@ -20,7 +20,7 @@ type bar = Gc<foo>;
 
 fn want_foo(f: foo) {}
 fn have_bar(b: bar) {
-    want_foo(b); //~ ERROR (expected struct foo but found Gc-ptr)
+    want_foo(b); //~ ERROR (expected struct foo, found Gc-ptr)
 }
 
 fn main() {}

--- a/src/test/compile-fail/trait-coercion-generic-bad.rs
+++ b/src/test/compile-fail/trait-coercion-generic-bad.rs
@@ -25,7 +25,7 @@ impl Trait<&'static str> for Struct {
 
 fn main() {
     let s: Box<Trait<int>> = box Struct { person: "Fred" };
-    //~^ ERROR expected Trait<int>, but found Trait<&'static str>
-    //~^^ ERROR expected Trait<int>, but found Trait<&'static str>
+    //~^ ERROR expected Trait<int>, found Trait<&'static str>
+    //~^^ ERROR expected Trait<int>, found Trait<&'static str>
     s.f(1);
 }

--- a/src/test/compile-fail/trait-impl-method-mismatch.rs
+++ b/src/test/compile-fail/trait-impl-method-mismatch.rs
@@ -18,7 +18,7 @@ trait Mumbo {
 impl Mumbo for uint {
     // Cannot have a larger effect than the trait:
     unsafe fn jumbo(&self, x: Gc<uint>) { *self + *x; }
-    //~^ ERROR expected normal fn but found unsafe fn
+    //~^ ERROR expected normal fn, found unsafe fn
 }
 
 fn main() {}

--- a/src/test/compile-fail/tuple-arity-mismatch.rs
+++ b/src/test/compile-fail/tuple-arity-mismatch.rs
@@ -14,5 +14,5 @@ fn first((value, _): (int, f64)) -> int { value }
 
 fn main() {
     let y = first ((1,2,3));
-    //~^ ERROR expected a tuple with 2 elements but found one with 3 elements
+    //~^ ERROR expected a tuple with 2 elements, found one with 3 elements
 }

--- a/src/test/compile-fail/tutorial-suffix-inference-test.rs
+++ b/src/test/compile-fail/tutorial-suffix-inference-test.rs
@@ -17,9 +17,9 @@ fn main() {
 
     identity_u8(x);  // after this, `x` is assumed to have type `u8`
     identity_u16(x);
-    //~^ ERROR mismatched types: expected `u16` but found `u8`
+    //~^ ERROR mismatched types: expected `u16`, found `u8`
     identity_u16(y);
-    //~^ ERROR mismatched types: expected `u16` but found `i32`
+    //~^ ERROR mismatched types: expected `u16`, found `i32`
 
     let a = 3i;
 
@@ -27,6 +27,6 @@ fn main() {
 
     identity_i(a); // ok
     identity_u16(a);
-    //~^ ERROR mismatched types: expected `u16` but found `int`
+    //~^ ERROR mismatched types: expected `u16`, found `int`
 
 }

--- a/src/test/compile-fail/type-parameter-names.rs
+++ b/src/test/compile-fail/type-parameter-names.rs
@@ -11,6 +11,6 @@
 // Test that we print out the names of type parameters correctly in
 // our error messages.
 
-fn foo<Foo, Bar>(x: Foo) -> Bar { x } //~ ERROR expected `Bar` but found `Foo`
+fn foo<Foo, Bar>(x: Foo) -> Bar { x } //~ ERROR expected `Bar`, found `Foo`
 
 fn main() {}

--- a/src/test/compile-fail/type-params-in-different-spaces-2.rs
+++ b/src/test/compile-fail/type-params-in-different-spaces-2.rs
@@ -15,12 +15,12 @@ trait Tr<T> {
 // these compile as if Self: Tr<U>, even tho only Self: Tr<Self or T>
 trait A:    Tr<Self> {
     fn test<U>(u: U) -> Self {
-        Tr::op(u)   //~ ERROR expected Tr<U>, but found Tr<Self>
+        Tr::op(u)   //~ ERROR expected Tr<U>, found Tr<Self>
     }
 }
 trait B<T>: Tr<T> {
     fn test<U>(u: U) -> Self {
-        Tr::op(u)   //~ ERROR expected Tr<U>, but found Tr<T>
+        Tr::op(u)   //~ ERROR expected Tr<U>, found Tr<T>
     }
 }
 

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_1.rs
@@ -17,5 +17,5 @@ struct Foo<'a, T> {
 
 pub fn main() {
     let c: Foo<_, _> = Foo { r: &5u };
-    //~^ ERROR wrong number of type arguments: expected 1 but found 2
+    //~^ ERROR wrong number of type arguments: expected 1, found 2
 }

--- a/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_lifetime_2.rs
@@ -17,5 +17,5 @@ struct Foo<'a, T> {
 
 pub fn main() {
     let c: Foo<_, uint> = Foo { r: &5 };
-    //~^ ERROR wrong number of type arguments: expected 1 but found 2
+    //~^ ERROR wrong number of type arguments: expected 1, found 2
 }

--- a/src/test/compile-fail/typeck_type_placeholder_mismatch.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_mismatch.rs
@@ -19,11 +19,11 @@ pub fn main() {
 
 fn test1() {
     let x: Foo<_> = Bar::<uint>;
-    //~^ ERROR mismatched types: expected `Foo<<generic #0>>` but found `Bar<uint>`
+    //~^ ERROR mismatched types: expected `Foo<<generic #0>>`, found `Bar<uint>`
     let y: Foo<uint> = x;
 }
 
 fn test2() {
     let x: Foo<_> = Bar::<uint>;
-    //~^ ERROR mismatched types: expected `Foo<<generic #0>>` but found `Bar<uint>`
+    //~^ ERROR mismatched types: expected `Foo<<generic #0>>`, found `Bar<uint>`
 }

--- a/src/test/compile-fail/unsized.rs
+++ b/src/test/compile-fail/unsized.rs
@@ -10,7 +10,7 @@
 
 // Test syntax checks for `type` keyword.
 
-struct S1 for type; //~ ERROR expected `{`, `(`, or `;` after struct name but found `for`
+struct S1 for type; //~ ERROR expected `{`, `(`, or `;` after struct name, found `for`
 
 pub fn main() {
 }

--- a/src/test/compile-fail/variadic-ffi.rs
+++ b/src/test/compile-fail/variadic-ffi.rs
@@ -25,13 +25,13 @@ fn main() {
 
         let x: unsafe extern "C" fn(f: int, x: u8) = foo;
         //~^ ERROR: mismatched types: expected `unsafe extern "C" fn(int, u8)`
-        //          but found `unsafe extern "C" fn(int, u8, ...)`
-        //          (expected non-variadic fn but found variadic function)
+        //         , found `unsafe extern "C" fn(int, u8, ...)`
+        //          (expected non-variadic fn, found variadic function)
 
         let y: unsafe extern "C" fn(f: int, x: u8, ...) = bar;
         //~^ ERROR: mismatched types: expected `unsafe extern "C" fn(int, u8, ...)`
-        //          but found `extern "C" extern fn(int, u8)`
-        //          (expected variadic fn but found non-variadic function)
+        //         , found `extern "C" extern fn(int, u8)`
+        //          (expected variadic fn, found non-variadic function)
 
         foo(1, 2, 3f32); //~ ERROR: can't pass an f32 to variadic function, cast to c_double
         foo(1, 2, true); //~ ERROR: can't pass bool to variadic function, cast to c_int

--- a/src/test/compile-fail/wrong-mul-method-signature.rs
+++ b/src/test/compile-fail/wrong-mul-method-signature.rs
@@ -20,7 +20,7 @@ struct Vec1 {
 // Expecting ref in input signature
 impl Mul<f64, Vec1> for Vec1 {
     fn mul(&self, s: f64) -> Vec1 {
-    //~^ ERROR: method `mul` has an incompatible type for trait: expected &-ptr but found f64
+    //~^ ERROR: method `mul` has an incompatible type for trait: expected &-ptr, found f64
         Vec1 {
             x: self.x * s
         }
@@ -35,7 +35,7 @@ struct Vec2 {
 // Wrong type parameter ordering
 impl Mul<Vec2, f64> for Vec2 {
     fn mul(&self, s: f64) -> Vec2 {
-    //~^ ERROR: method `mul` has an incompatible type for trait: expected &-ptr but found f64
+    //~^ ERROR: method `mul` has an incompatible type for trait: expected &-ptr, found f64
         Vec2 {
             x: self.x * s,
             y: self.y * s
@@ -52,7 +52,7 @@ struct Vec3 {
 // Unexpected return type
 impl Mul<f64, i32> for Vec3 {
     fn mul(&self, s: &f64) -> f64 {
-    //~^ ERROR: method `mul` has an incompatible type for trait: expected i32 but found f64
+    //~^ ERROR: method `mul` has an incompatible type for trait: expected i32, found f64
         *s
     }
 }

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -65,6 +65,6 @@ fn main() {
 
         // positive test so that this test will be updated when the
         // compiler changes.
-        assert!(err.as_slice().contains("expected item but found"))
+        assert!(err.as_slice().contains("expected item, found"))
     }
 }

--- a/src/test/run-pass/issue-2804.rs
+++ b/src/test/run-pass/issue-2804.rs
@@ -50,7 +50,7 @@ fn add_interface(_store: int, managed_ip: String, data: json::Json) -> (String, 
             (label, bool_value(false))
         }
         _ => {
-            println!("Expected dict for {} interfaces but found {:?}", managed_ip, data);
+            println!("Expected dict for {} interfaces, found {:?}", managed_ip, data);
             ("gnos:missing-interface".to_string(), bool_value(true))
         }
     }
@@ -68,7 +68,7 @@ fn add_interfaces(store: int, managed_ip: String, device: HashMap<String, json::
         }
         _ =>
         {
-            println!("Expected list for {} interfaces but found {:?}", managed_ip,
+            println!("Expected list for {} interfaces, found {:?}", managed_ip,
                    device.get(&"interfaces".to_string()));
             Vec::new()
         }


### PR DESCRIPTION
Closes #8492.

I did not find this suggestion in the [guidelines](https://github.com/rust-lang/rust-guidelines) but it's mentioned in the [old style guide](https://github.com/rust-lang/rust/wiki/Note-style-guide/73c864a10a8e231e2a6630e5a3461f1d3022a20a).
