### PR TITLE
Fix a potential overflow in `core::str::Searcher::new`

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -562,7 +562,9 @@ enum Searcher {
 impl Searcher {
     fn new(haystack: &[u8], needle: &[u8]) -> Searcher {
         // FIXME: Tune this.
-        if needle.len() + 20 > haystack.len() {
+        // This checks whether mathematically (that is, not constrained by
+        // wrap-around of uint) `haystack.len() - 20 < needle.len()`.
+        if haystack.len() < 20 || haystack.len() - 20 < needle.len() {
             Naive(NaiveSearcher::new())
         } else {
             let searcher = TwoWaySearcher::new(needle);


### PR DESCRIPTION
The overflow is mitigated by checking a sufficient condition for the less
relation.

Given the term `A - B < C` (`A`, `B` and `C` fixed size unsigned integers) one
can check whether it holds, by evaluating `A < C || A - B < C`.
