### PR TITLE
std: Use concat! and stringify! to simplify the most common assert! case

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -96,7 +96,7 @@ macro_rules! fail(
 macro_rules! assert(
     ($cond:expr) => (
         if !$cond {
-            fail!("assertion failed: {:s}", stringify!($cond))
+            fail!(concat!("assertion failed: ", stringify!($cond)))
         }
     );
     ($cond:expr, $($arg:expr),+) => (


### PR DESCRIPTION
With no custom message, we should just use concat! + stringify! for
`assert!(expr)` to avoid the string formatting code path.

Inspired by issue #16625
