### PR TITLE
librustc: Don't ICE with type when name only contain underscores.

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -768,9 +768,13 @@ impl LintPass for NonCamelCaseTypes {
             let s = token::get_ident(ident);
 
             if !is_camel_case(ident) {
-                cx.span_lint(NON_CAMEL_CASE_TYPES, span,
-                    format!("{} `{}` should have a camel case name such as `{}`",
-                            sort, s, to_camel_case(s.get())).as_slice());
+                let c = to_camel_case(s.get());
+                let m = if c.is_empty() {
+                    format!("{} `{}` should have a camel case name such as `CamelCase`", sort, s)
+                } else {
+                    format!("{} `{}` should have a camel case name such as `{}`", sort, s, c)
+                };
+                cx.span_lint(NON_CAMEL_CASE_TYPES, span, m.as_slice());
             }
         }
 

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -754,7 +754,7 @@ impl LintPass for NonCamelCaseTypes {
 
             // start with a non-lowercase letter rather than non-uppercase
             // ones (some scripts don't have a concept of upper/lowercase)
-            !ident.char_at(0).is_lowercase() && !ident.contains_char('_')
+            ident.len() > 0 && !ident.char_at(0).is_lowercase() && !ident.contains_char('_')
         }
 
         fn to_camel_case(s: &str) -> String {

--- a/src/test/compile-fail/lint-non-camel-case-types.rs
+++ b/src/test/compile-fail/lint-non-camel-case-types.rs
@@ -37,6 +37,6 @@ struct foo7 {
     bar: int,
 }
 
-type __ = int; //~ ERROR type `__` should have a camel case name such as ``
+type __ = int; //~ ERROR type `__` should have a camel case name such as `CamelCase`
 
 fn main() { }

--- a/src/test/compile-fail/lint-non-camel-case-types.rs
+++ b/src/test/compile-fail/lint-non-camel-case-types.rs
@@ -37,4 +37,6 @@ struct foo7 {
     bar: int,
 }
 
+type __ = int; //~ ERROR type `__` should have a camel case name such as ``
+
 fn main() { }


### PR DESCRIPTION
Fix for type identifiers with only underscores (two or more), I assume they doesn't count as camel case.

``` rust
type __ = int;

fn main() {
}
```

```
error: internal compiler error: unexpected failure
note: the compiler hit an unexpected failure path. this is a bug.
note: we would appreciate a bug report: http://doc.rust-lang.org/complement-bugreport.html
note: run with `RUST_BACKTRACE=1` for a backtrace
task 'rustc' failed at 'index out of bounds: the len is 0 but the index is 0', /home/rustbuild/src/rust-buildbot/slave/nightly-linux/build/src/librustc/lib.rs:1

stack backtrace:
   1: 0xb603f5d0 - rt::backtrace::imp::write::ha55f265f6626471dmxr
   2: 0xb6042620 - failure::on_fail::h4d2c6d42b67e94803Sr
   3: 0xb640a180 - unwind::begin_unwind_inner::h484879fa7cc3611fZhe
   4: 0xb6409e50 - unwind::begin_unwind_fmt::hd14e5c64bc9006capfe
   5: 0xb6409df0 - rust_begin_unwind
   6: 0xb6454580 - failure::begin_unwind::h9ab1fc5753bd08f3YDk
   7: 0xb6458cb0 - failure::fail_bounds_check::h88167bad36865909aCk
   8: 0xb6f685d0 - lint::builtin::NonCamelCaseTypes.LintPass::check_item::check_case::he854eeffd105cb0f40E
   9: 0xb6f68050 - lint::builtin::NonCamelCaseTypes.LintPass::check_item::hc35b45d248e41cd43XE
  10: 0xb6f7b760 - lint::context::Context<'a>.Visitor<(*>::visit_item::closure.139262
  11: 0xb6f79510 - lint::context::Context<'a>::with_lint_attrs::hb9efe321fa321ce6spG
  12: 0xb6f81d30 - lint::context::Context<'a>.Visitor<(*>::visit_mod::he4593c831936b308ZMG
  13: 0xb6f8f2f0 - lint::context::check_crate::closure.139319
  14: 0xb6f79510 - lint::context::Context<'a>::with_lint_attrs::hb9efe321fa321ce6spG
  15: 0xb6efda70 - lint::context::check_crate::ha9e64328726b9579q1G
  16: 0xb6efda20 - driver::driver::phase_3_run_analysis_passes::closure.136263
  17: 0xb659d640 - util::common::time::h2837683151147173214
  18: 0xb6e7d130 - driver::driver::phase_3_run_analysis_passes::h7079eff53afc4de3Jfz
  19: 0xb6e783f0 - driver::driver::compile_input::h0ec84a550e24779cP1y
  20: 0xb6f26250 - driver::run_compiler::h7e7c01ecbfd0ad87JzC
  21: 0xb6f26150 - driver::main_args::closure.137215
  22: 0xb6f380d0 - task::TaskBuilder<S>::try_future::closure.138376
  23: 0xb6f37ec0 - task::TaskBuilder<S>::spawn_internal::closure.138353
  24: 0xb774bdd0 - task::spawn_opts::closure.8325
  25: 0xb6409c10 - unwind::try::try_fn::h91f00772748cf73eD8d
  26: 0xb6468ae0 - rust_try_inner
  27: 0xb6468aa0 - rust_try
  28: 0xb6407880 - unwind::try::h78a4fc0e85c326aef6d
  29: 0xb6407640 - task::Task::run::hb6f2d9484116e3d8xcd
  30: 0xb774bba0 - task::spawn_opts::closure.8271
  31: 0xb6409350 - thread::thread_start::h8c02fef9f651da5cjBd
  32: 0xb5ed3fc0 - start_thread
  33: 0xb62e8a32 - __clone
  34:        0x0 - <unknown>
```
