### PR TITLE
add #[experimental] as_string/as_vec functions

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -16,6 +16,7 @@ use alloc::heap::{allocate, reallocate, deallocate};
 use core::cmp::max;
 use core::default::Default;
 use core::fmt;
+use core::kinds;
 use core::mem;
 use core::num;
 use core::ptr;
@@ -749,7 +750,6 @@ impl<T> Vec<T> {
             MoveItems { allocation: ptr, cap: cap, iter: iter }
         }
     }
-
 
     /// Sets the length of a vector.
     ///
@@ -1692,6 +1692,39 @@ pub fn unzip<T, U, V: Iterator<(T, U)>>(mut iter: V) -> (Vec<T>, Vec<U>) {
     (ts, us)
 }
 
+/// Wrapper type providing a `&Vec<T>` reference via `Deref`.
+#[experimental]
+pub struct AsVec<'a, T> {
+    x: Vec<T>,
+    l: kinds::marker::ContravariantLifetime<'a>
+}
+
+impl<'a, T> Deref<Vec<T>> for AsVec<'a, T> {
+    fn deref<'b>(&'b self) -> &'b Vec<T> {
+        &self.x
+    }
+}
+
+// Prevent the inner `Vec<T>` from attempting to deallocate memory.
+#[unsafe_destructor]
+impl<'a, T> Drop for AsVec<'a, T> {
+    fn drop(&mut self) {
+        self.x.len = 0;
+        self.x.cap = 0;
+    }
+}
+
+/// Convert a slice to a wrapper type providing a `&Vec<T>` reference.
+#[experimental]
+pub fn as_vec<'a, T>(x: &'a [T]) -> AsVec<'a, T> {
+    unsafe {
+        AsVec {
+            x: Vec::from_raw_parts(x.len(), x.len(), x.as_ptr() as *mut T),
+            l: kinds::marker::ContravariantLifetime::<'a>
+        }
+    }
+}
+
 /// Unsafe vector operations.
 pub mod raw {
     use super::Vec;
@@ -1717,9 +1750,37 @@ mod tests {
     use std::prelude::*;
     use std::mem::size_of;
     use test::Bencher;
-    use super::{unzip, raw, Vec};
+    use super::{as_vec, unzip, raw, Vec};
 
     use MutableSeq;
+
+    struct DropCounter<'a> {
+        count: &'a mut int
+    }
+
+    #[unsafe_destructor]
+    impl<'a> Drop for DropCounter<'a> {
+        fn drop(&mut self) {
+            *self.count += 1;
+        }
+    }
+
+    #[test]
+    fn test_as_vec() {
+        let xs = &[1u8, 2u8, 3u8];
+        assert_eq!(xs, as_vec(xs).as_slice());
+    }
+
+    #[test]
+    fn test_as_vec_dtor() {
+        let (mut count_x, mut count_y) = (0, 0);
+        {
+            let xs = &[DropCounter { count: &mut count_x }, DropCounter { count: &mut count_y }];
+            assert_eq!(as_vec(xs).len(), 2);
+        }
+        assert_eq!(count_x, 1);
+        assert_eq!(count_y, 1);
+    }
 
     #[test]
     fn test_small_vec_struct() {
@@ -1731,17 +1792,6 @@ mod tests {
         struct TwoVec<T> {
             x: Vec<T>,
             y: Vec<T>
-        }
-
-        struct DropCounter<'a> {
-            count: &'a mut int
-        }
-
-        #[unsafe_destructor]
-        impl<'a> Drop for DropCounter<'a> {
-            fn drop(&mut self) {
-                *self.count += 1;
-            }
         }
 
         let (mut count_x, mut count_y) = (0, 0);


### PR DESCRIPTION
This provides a way to pass `&[T]` to functions taking `&U` where `U` is
a `Vec<T>`. It can be seen as an alternative to the `Equiv` trait, as it
handles all of the common cases well, without requiring a new trait and
new equiv methods. Methods like `find_with` on TreeMap taking a closure
with an equivalent `Ord` implementation are still useful.

Closes #14549
