### PR TITLE
librustc: Use Typer's node_ty method instead of free function in ExprUseVisitor.

### DIFF
--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -234,7 +234,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                          decl: &ast::FnDecl,
                          body: &ast::Block) {
         for arg in decl.inputs.iter() {
-            let arg_ty = ty::node_id_to_type(self.tcx(), arg.pat.id);
+            let arg_ty = return_if_err!(self.typer.node_ty(arg.pat.id));
 
             let arg_cmt = self.mc.cat_rvalue(
                 arg.id,
@@ -414,7 +414,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
 
                 // Fetch the type of the value that the iteration yields to
                 // produce the pattern's categorized mutable type.
-                let pattern_type = ty::node_id_to_type(self.tcx(), pat.id);
+                let pattern_type = return_if_err!(self.typer.node_ty(pat.id));
                 let pat_cmt = self.mc.cat_rvalue(pat.id,
                                                  pat.span,
                                                  ty::ReScope(blk.id),
@@ -828,7 +828,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
                        pat.repr(tcx));
 
                 // pat_ty: the type of the binding being produced.
-                let pat_ty = ty::node_id_to_type(tcx, pat.id);
+                let pat_ty = return_if_err!(typer.node_ty(pat.id));
 
                 // Each match binding is effectively an assignment to the
                 // binding being produced.
@@ -971,7 +971,7 @@ impl<'d,'t,TYPER:mc::Typer> ExprUseVisitor<'d,'t,TYPER> {
         // Create the cmt for the variable being borrowed, from the
         // caller's perspective
         let var_id = upvar_def.def_id().node;
-        let var_ty = ty::node_id_to_type(self.tcx(), var_id);
+        let var_ty = try!(self.typer.node_ty(var_id));
         self.mc.cat_def(closure_id, closure_span, var_ty, upvar_def)
     }
 }

--- a/src/test/auxiliary/issue-16643.rs
+++ b/src/test/auxiliary/issue-16643.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+
+pub struct TreeBuilder<H>;
+
+impl<H> TreeBuilder<H> {
+    pub fn process_token(&mut self) {
+        match self {
+            _ => for _y in *self {}
+        }
+    }
+}
+
+impl<H> Iterator<H> for TreeBuilder<H> {
+    fn next(&mut self) -> Option<H> {
+        None
+    }
+}

--- a/src/test/run-pass/issue-16643.rs
+++ b/src/test/run-pass/issue-16643.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-16643.rs
+
+extern crate i = "issue-16643";
+
+pub fn main() {
+    i::TreeBuilder::<uint>.process_token();
+}


### PR DESCRIPTION
We shouldn't be making calls directly to `ty::node_id_to_type` since the typer may be bcx which also has to monomorphize the type.

Fixes #16643.
