### PR TITLE
Middle-clicking on search results should not load the link on the same page

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -391,14 +391,16 @@
             var hoverTimeout, $results = $('.search-results .result');
 
             $results.on('click', function(e) {
+                var dst = $(this).find('a')[0];
                 if (e.which == 1) {
-                    var dst = $(this).find('a')[0];
                     if (window.location.pathname == dst.pathname) {
                         $('#search').addClass('hidden');
                         $('#main').removeClass('hidden');
                     }
                     document.location.href = dst.href;
-                }
+                } else if (e.which == 2 && e.target.tagName.toLowerCase() != "a"){
+                    window.open(dst.href);
+                }            
             }).on('mouseover', function() {
                 var $el = $(this);
                 clearTimeout(hoverTimeout);

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -390,13 +390,15 @@
         function initSearchNav() {
             var hoverTimeout, $results = $('.search-results .result');
 
-            $results.on('click', function() {
-                var dst = $(this).find('a')[0];
-                if (window.location.pathname == dst.pathname) {
-                    $('#search').addClass('hidden');
-                    $('#main').removeClass('hidden');
+            $results.on('click', function(e) {
+                if (e.which == 1) {
+                    var dst = $(this).find('a')[0];
+                    if (window.location.pathname == dst.pathname) {
+                        $('#search').addClass('hidden');
+                        $('#main').removeClass('hidden');
+                    }
+                    document.location.href = dst.href;
                 }
-                document.location.href = dst.href;
             }).on('mouseover', function() {
                 var $el = $(this);
                 clearTimeout(hoverTimeout);


### PR DESCRIPTION
Middle clicking is usually used for opening a link in a new tab in most browsers. It's an easy way to navigate without losing your current page.

When using rustdoc's search, I'd like to be able to middle-click on search results so that I can open multiple results in new tabs. However, currently the `onclick` listener captures middle clicks too, so link opens in two places — in a new tab, and on the same page.

This partially fixes it. It would be better if the anchor tag on a result spanned the entire result path+name, and not just the name -- while normal clicking still works due to the event handler, middle clicking is broken if you click on something other than the result name (not the path). I don't mind doing it that way, but it seems like there was a reason behind having the `a` tag only cover the name. ([Code pointer](https://github.com/rust-lang/rust/blob/be6c7cf882bacc9da96df5304679af678390d5b0/src/librustdoc/html/static/main.js#L464) in case I need it in the future)
