### PR TITLE
Improve the diagnostics for mistakes in for loops

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2168,12 +2168,13 @@ fn lookup_method_for_for_loop(fcx: &FnCtxt,
         }
     };
 
+    let expr_type = fcx.expr_ty(&*iterator_expr);
     let method = method::lookup_in_trait(fcx,
                                          iterator_expr.span,
                                          Some(&*iterator_expr),
                                          token::intern("next"),
                                          trait_did,
-                                         fcx.expr_ty(&*iterator_expr),
+                                         expr_type,
                                          [],
                                          DontAutoderefReceiver,
                                          IgnoreStaticMethods);
@@ -2184,8 +2185,9 @@ fn lookup_method_for_for_loop(fcx: &FnCtxt,
         Some(ref method) => method.ty,
         None => {
             fcx.tcx().sess.span_err(iterator_expr.span,
-                                    "`for` loop expression does not \
-                                     implement the `Iterator` trait");
+                                    format!("`for` loop expression has type `{}` which does \
+                                             not implement the `Iterator` trait",
+                                            fcx.infcx().ty_to_string(expr_type)).as_slice());
             ty::mk_err()
         }
     };

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2184,10 +2184,15 @@ fn lookup_method_for_for_loop(fcx: &FnCtxt,
     let method_type = match method {
         Some(ref method) => method.ty,
         None => {
-            fcx.tcx().sess.span_err(iterator_expr.span,
-                                    format!("`for` loop expression has type `{}` which does \
-                                             not implement the `Iterator` trait",
-                                            fcx.infcx().ty_to_string(expr_type)).as_slice());
+            let true_expr_type = fcx.infcx().resolve_type_vars_if_possible(expr_type);
+
+            if !ty::type_is_error(true_expr_type) {
+                let ty_string = fcx.infcx().ty_to_string(true_expr_type);
+                fcx.tcx().sess.span_err(iterator_expr.span,
+                                        format!("`for` loop expression has type `{}` which does \
+                                                 not implement the `Iterator` trait",
+                                                ty_string).as_slice());
+            }
             ty::mk_err()
         }
     };

--- a/src/test/compile-fail/for-loop-bogosity.rs
+++ b/src/test/compile-fail/for-loop-bogosity.rs
@@ -24,8 +24,7 @@ pub fn main() {
         x: 1,
         y: 2,
     };
-    for x in bogus {    //~ ERROR does not implement the `Iterator` trait
+    for x in bogus { //~ ERROR has type `MyStruct` which does not implement the `Iterator` trait
         drop(x);
     }
 }
-

--- a/src/test/compile-fail/for-loop-type-error.rs
+++ b/src/test/compile-fail/for-loop-type-error.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let x = () + (); //~ ERROR binary operation
+
+    // this shouldn't have a flow-on error:
+    for _ in x {}
+}


### PR DESCRIPTION
- print the type of `x` in `for ... in x` in the "does not implement Iterator" message
- avoid printing that message if `x` has a type error
