### PR TITLE
Move dynamic_lib out of std.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -49,10 +49,10 @@
 # automatically generated for all stage/host/target combinations.
 ################################################################################
 
-TARGET_CRATES := libc std green rustuv native flate arena glob term semver \
-                 uuid serialize sync getopts collections num test time rand \
-                 url log regex graphviz core rbml rlibc alloc debug rustrt \
-                 unicode
+TARGET_CRATES := libc std dynamic_lib green rustuv native flate arena glob \
+                 term semver uuid serialize sync getopts collections num test \
+                 time rand url log regex graphviz core rbml rlibc alloc debug \
+                 rustrt unicode
 HOST_CRATES := syntax rustc rustdoc fourcc hexfloat regex_macros fmt_macros \
 	       rustc_llvm rustc_back
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
@@ -66,17 +66,18 @@ DEPS_debug := std
 DEPS_rustrt := alloc core libc collections native:rustrt_native
 DEPS_std := core libc rand alloc collections rustrt sync unicode \
 	native:rust_builtin native:backtrace
+DEPS_dynamic_lib := std debug
 DEPS_graphviz := std
 DEPS_green := std native:context_switch
 DEPS_rustuv := std native:uv native:uv_support
 DEPS_native := std
 DEPS_syntax := std term serialize log fmt_macros debug
 DEPS_rustc := syntax flate arena serialize getopts rbml \
-              time log graphviz debug rustc_llvm rustc_back
+              time log graphviz debug rustc_llvm rustc_back dynamic_lib
 DEPS_rustc_llvm := native:rustllvm libc std
 DEPS_rustc_back := std syntax rustc_llvm flate log libc
 DEPS_rustdoc := rustc native:hoedown serialize getopts \
-                test time debug
+                test time debug dynamic_lib
 DEPS_flate := std native:miniz
 DEPS_arena := std
 DEPS_graphviz := std
@@ -101,7 +102,7 @@ DEPS_regex := std
 DEPS_regex_macros = rustc syntax std regex
 DEPS_fmt_macros = std
 
-TOOL_DEPS_compiletest := test green rustuv getopts
+TOOL_DEPS_compiletest := test green rustuv getopts dynamic_lib
 TOOL_DEPS_rustdoc := rustdoc native
 TOOL_DEPS_rustc := rustc native
 TOOL_SOURCE_compiletest := $(S)src/compiletest/compiletest.rs

--- a/src/README.md
+++ b/src/README.md
@@ -17,6 +17,7 @@ Source layout:
 | `libarena/`         | The arena (a fast but limited) memory allocator           |
 | `libbacktrace/`     | The libbacktrace library                                  |
 | `libcollections/`   | A collection of useful data structures and containers     |
+| `libdynamic_lib/`   | A wrapper over the platform's dynamic library facilities  |
 | `libflate/`         | Simple compression library                                |
 | `libfmt_macros/`    | Macro support for format strings                          |
 | `libfourcc/`        | Data format identifier library                            |

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate dynamic_lib;
+
 use std::io::process::{ProcessExit, Command, Process, ProcessOutput};
-use std::dynamic_lib::DynamicLibrary;
+use self::dynamic_lib::DynamicLibrary;
 
 fn add_target_env(cmd: &mut Command, lib_path: &str, aux_path: Option<&str>) {
     // Need to be sure to put both the lib_path and the aux path in the dylib

--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -39,6 +39,7 @@ li {list-style-type: none; }
 
 * [The `arena` allocation library](arena/index.html)
 * [The `collections` library](collections/index.html)
+* [The `dynamic_lib` library](dynamic_lib/index.html)
 * [The `flate` compression library](flate/index.html)
 * [The `fourcc` four-character code library](fourcc/index.html)
 * [The `getopts` argument parsing library](getopts/index.html)

--- a/src/libdynamic_lib/lib.rs
+++ b/src/libdynamic_lib/lib.rs
@@ -8,31 +8,35 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-/*!
+//! Dynamic library facilities.
+//!
+//! A simple wrapper over the platform's dynamic library facilities.
 
-Dynamic library facilities.
-
-A simple wrapper over the platform's dynamic library facilities
-
-*/
+#![crate_name = "dynamic_lib"]
+#![crate_type = "rlib"]
+#![crate_type = "dylib"]
+#![license = "MIT/ASL2"]
+#![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
+       html_root_url = "http://doc.rust-lang.org/master/")]
 
 #![experimental]
 #![allow(missing_doc)]
 
-use clone::Clone;
-use collections::MutableSeq;
-use c_str::ToCStr;
-use iter::Iterator;
-use mem;
-use ops::*;
-use option::*;
-use os;
-use path::{Path,GenericPath};
-use result::*;
-use slice::{Slice,ImmutableSlice};
-use str;
-use string::String;
-use vec::Vec;
+extern crate libc;
+extern crate debug;
+
+use std::clone::Clone;
+use std::collections::MutableSeq;
+use std::c_str::ToCStr;
+use std::iter::Iterator;
+use std::mem;
+use std::os;
+use std::path::{Path,GenericPath};
+use std::slice::{Slice,ImmutableSlice};
+use std::str;
+use std::string::String;
+use std::vec::Vec;
 
 pub struct DynamicLibrary { handle: *mut u8 }
 
@@ -156,10 +160,9 @@ impl DynamicLibrary {
 
 #[cfg(test, not(target_os = "ios"))]
 mod test {
-    use super::*;
-    use prelude::*;
     use libc;
-    use mem;
+    use super::DynamicLibrary;
+    use std::mem;
 
     #[test]
     #[ignore(cfg(windows))] // FIXME #8818
@@ -213,11 +216,10 @@ mod test {
 #[cfg(target_os = "dragonfly")]
 pub mod dl {
 
-    use c_str::{CString, ToCStr};
+    use std::c_str::{CString, ToCStr};
     use libc;
-    use ptr;
-    use result::*;
-    use string::String;
+    use std::ptr;
+    use std::string::String;
 
     pub unsafe fn open_external<T: ToCStr>(filename: T) -> *mut u8 {
         filename.with_c_str(|raw_name| {
@@ -230,7 +232,7 @@ pub mod dl {
     }
 
     pub fn check_for_errors_in<T>(f: || -> T) -> Result<T, String> {
-        use rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
+        use std::rt::mutex::{StaticNativeMutex, NATIVE_MUTEX_INIT};
         static mut lock: StaticNativeMutex = NATIVE_MUTEX_INIT;
         unsafe {
             // dlerror isn't thread safe, so we need to lock around this entire
@@ -280,16 +282,16 @@ pub mod dl {
 
 #[cfg(target_os = "windows")]
 pub mod dl {
-    use c_str::ToCStr;
-    use iter::Iterator;
-    use libc;
-    use os;
-    use ptr;
-    use result::{Ok, Err, Result};
-    use str::StrSlice;
-    use str;
-    use string::String;
-    use vec::Vec;
+    use std::c_str::ToCStr;
+    use std::iter::Iterator;
+    use std::libc;
+    use std::os;
+    use std::ptr;
+    use std::result::{Ok, Err, Result};
+    use std::str::StrSlice;
+    use std::str;
+    use std::string::String;
+    use std::vec::Vec;
 
     pub unsafe fn open_external<T: ToCStr>(filename: T) -> *mut u8 {
         // Windows expects Unicode data

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -47,6 +47,7 @@ extern crate rustc_back = "rustc_back";
 extern crate serialize;
 extern crate rbml;
 extern crate time;
+extern crate dynamic_lib;
 #[phase(plugin, link)] extern crate log;
 #[phase(plugin, link)] extern crate syntax;
 

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -10,10 +10,10 @@
 
 #![allow(non_camel_case_types)]
 
+use dynamic_lib::DynamicLibrary;
 use std::cell::RefCell;
 use std::os;
 use std::io::fs;
-use std::dynamic_lib::DynamicLibrary;
 use std::collections::HashSet;
 
 use util::fs as myfs;

--- a/src/librustc/plugin/load.rs
+++ b/src/librustc/plugin/load.rs
@@ -13,10 +13,10 @@
 use driver::session::Session;
 use metadata::creader::PluginMetadataReader;
 use plugin::registry::Registry;
+use dynamic_lib::DynamicLibrary;
 
 use std::mem;
 use std::os;
-use std::dynamic_lib::DynamicLibrary;
 use syntax::ast;
 use syntax::attr;
 use syntax::visit;

--- a/src/librustc/plugin/mod.rs
+++ b/src/librustc/plugin/mod.rs
@@ -57,6 +57,8 @@
  * for examples of syntax extension plugins.
  */
 
+extern crate dynamic_lib;
+
 pub use self::registry::Registry;
 
 pub mod registry;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -25,6 +25,7 @@ extern crate serialize;
 extern crate syntax;
 extern crate testing = "test";
 extern crate time;
+extern crate dynamic_lib;
 #[phase(plugin, link)] extern crate log;
 
 use std::io;

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -10,7 +10,7 @@
 
 use clean;
 
-use std::dynamic_lib as dl;
+use dynamic_lib as dl;
 use serialize::json;
 use std::mem;
 use std::string::String;

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -10,15 +10,14 @@
 
 use std::cell::RefCell;
 use std::char;
-use std::dynamic_lib::DynamicLibrary;
 use std::gc::GC;
 use std::io::{Command, TempDir};
 use std::io;
 use std::os;
 use std::str;
 use std::string::String;
-
 use std::collections::{HashSet, HashMap};
+
 use testing;
 use rustc::back::link;
 use rustc::driver::config;
@@ -36,6 +35,7 @@ use fold::DocFolder;
 use html::markdown;
 use passes;
 use visit_ast::RustdocVisitor;
+use dynamic_lib::DynamicLibrary;
 
 pub fn run(input: &str,
            cfgs: Vec<String>,

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -258,7 +258,6 @@ pub mod sync;
 /* Runtime and platform support */
 
 pub mod c_vec;
-pub mod dynamic_lib;
 pub mod os;
 pub mod io;
 pub mod path;

--- a/src/test/auxiliary/linkage-visibility.rs
+++ b/src/test/auxiliary/linkage-visibility.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::dynamic_lib::DynamicLibrary;
+extern crate dynamic_lib;
+
+use dynamic_lib::DynamicLibrary;
 
 #[no_mangle]
 pub fn foo() { bar(); }

--- a/src/test/run-make/extern-fn-reachable/main.rs
+++ b/src/test/run-make/extern-fn-reachable/main.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::dynamic_lib::DynamicLibrary;
+extern crate dynamic_lib;
+
+use dynamic_lib::DynamicLibrary;
 use std::os;
 
 pub fn main() {

--- a/src/test/run-pass/linkage-visibility.rs
+++ b/src/test/run-pass/linkage-visibility.rs
@@ -10,7 +10,7 @@
 
 // aux-build:linkage-visibility.rs
 // ignore-android: FIXME(#10379)
-// ignore-windows: std::dynamic_lib does not work on Windows well
+// ignore-windows: dynamic_lib does not work on Windows well
 
 extern crate foo = "linkage-visibility";
 


### PR DESCRIPTION
A first step in fixing #8157. 

We might want to move `dynamic_lib` to a crate in rust-lang org, this is a first step towards that. Does it make sense to do it this way?
