### PR TITLE
rustdoc: Don't assume that a doc attribute was sugared: Fixes #15976

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -124,14 +124,7 @@ fn try_inline_def(cx: &core::DocContext,
 pub fn load_attrs(tcx: &ty::ctxt, did: ast::DefId) -> Vec<clean::Attribute> {
     let mut attrs = Vec::new();
     csearch::get_item_attrs(&tcx.sess.cstore, did, |v| {
-        attrs.extend(v.move_iter().map(|mut a| {
-            // FIXME this isn't quite always true, it's just true about 99% of
-            //       the time when dealing with documentation. For example,
-            //       this would treat doc comments of the form `#[doc = "foo"]`
-            //       incorrectly.
-            if a.name().get() == "doc" && a.value_str().is_some() {
-                a.node.is_sugared_doc = true;
-            }
+        attrs.extend(v.move_iter().map(|a| {
             a.clean()
         }));
     });


### PR DESCRIPTION
As of 8876ce44, `is_sugared_doc` is encoded in metadata, so there is no
need to assume that all `doc` attributes came from sugared comments.

Fixes #15976
